### PR TITLE
Feat/opencode oauth observer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 .eggs/
 build/
 dist/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -269,10 +269,10 @@ When OpenCode starts, the plugin loads and:
 
 The ingest pipeline uses an observer agent to emit XML observations and summaries. Summaries are generated on session end by default; use `<skip_summary/>` in observer output to skip. The defaults are:
 
-- **OpenAI**: `gpt-5.1-codex-mini` (uses `OPENCODE_MEM_OBSERVER_API_KEY`, or `OPENCODE_API_KEY` / `OPENAI_API_KEY`).
-- **Anthropic**: `claude-4.5-haiku` (set `OPENCODE_MEM_OBSERVER_PROVIDER=anthropic` and provide `OPENCODE_MEM_OBSERVER_API_KEY` or `ANTHROPIC_API_KEY`).
+- **OpenAI**: `gpt-5.1-codex-mini` (uses `OPENCODE_MEM_OBSERVER_API_KEY`, or `OPENCODE_API_KEY` / `OPENAI_API_KEY`; falls back to OpenCode OAuth cache at `~/.local/share/opencode/auth.json` when API keys are absent).
+- **Anthropic**: `claude-4.5-haiku` (set `OPENCODE_MEM_OBSERVER_PROVIDER=anthropic` and provide `OPENCODE_MEM_OBSERVER_API_KEY` or `ANTHROPIC_API_KEY`; falls back to OpenCode OAuth cache when API keys are absent).
 
-Override the model with `OPENCODE_MEM_OBSERVER_MODEL` or use `OPENCODE_MEM_USE_OPENCODE_RUN=1` with `OPENCODE_MEM_OPENCODE_MODEL` for OAuth-backed runs.
+Observer provider is selected from `OPENCODE_MEM_OBSERVER_PROVIDER` when set, otherwise inferred from the model (`claude*` → Anthropic, otherwise OpenAI). Override the model with `OPENCODE_MEM_OBSERVER_MODEL`, or use `OPENCODE_MEM_USE_OPENCODE_RUN=1` with `OPENCODE_MEM_OPENCODE_MODEL` as a fallback for OAuth-backed runs.
 
 ## Running OpenCode with the plugin
 

--- a/docs/plans/2026-01-15-opencode-oauth-observer.md
+++ b/docs/plans/2026-01-15-opencode-oauth-observer.md
@@ -1,0 +1,285 @@
+# OpenCode OAuth Observer Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Auto-detect OpenCode OAuth cache for observer calls when API keys are absent, while preserving `opencode run` as an emergency fallback.
+
+**Architecture:** Add a small OAuth cache loader that reads `~/.local/share/opencode/auth.json` on demand. Provider selection follows explicit config first, then model inference, then existing defaults. Use cached access tokens for OpenAI/Anthropic client init when API keys are missing; keep devaigateway IAP flow unchanged. Preserve `opencode run` when explicitly enabled and no direct auth is available.
+
+**Tech Stack:** Python 3.11+, OpenAI/Anthropic SDKs, pytest, ruff.
+
+### Task 1: Add OAuth cache loader
+
+**Files:**
+- Modify: `opencode_mem/observer.py`
+- Test: `tests/test_observer_auth.py`
+
+**Step 1: Write the failing test**
+
+```python
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from opencode_mem.observer import _load_opencode_oauth_cache
+
+
+def test_loads_openai_oauth_cache(tmp_path: Path) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "openai": {
+                    "type": "oauth",
+                    "access": "oa-access",
+                    "refresh": "oa-refresh",
+                    "expires": 9999999999999,
+                }
+            }
+        )
+    )
+    with patch("opencode_mem.observer._get_opencode_auth_path", return_value=auth_path):
+        data = _load_opencode_oauth_cache()
+    assert data["openai"]["access"] == "oa-access"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_observer_auth.py::test_loads_openai_oauth_cache -q`
+Expected: FAIL with `ImportError` or missing symbol.
+
+**Step 3: Write minimal implementation**
+
+```python
+from typing import Any
+
+
+def _get_opencode_auth_path() -> Path:
+    return Path.home() / ".local" / "share" / "opencode" / "auth.json"
+
+
+def _load_opencode_oauth_cache() -> dict[str, Any]:
+    path = _get_opencode_auth_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_observer_auth.py::test_loads_openai_oauth_cache -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add opencode_mem/observer.py tests/test_observer_auth.py
+git commit -m "feat: load opencode oauth cache for observer"
+```
+
+### Task 2: Provider selection rules
+
+**Files:**
+- Modify: `opencode_mem/observer.py`
+- Test: `tests/test_observer_auth.py`
+
+**Step 1: Write the failing test**
+
+```python
+from opencode_mem.observer import _resolve_oauth_provider
+
+
+def test_provider_resolves_from_model() -> None:
+    assert _resolve_oauth_provider(None, "claude-4.5-haiku") == "anthropic"
+    assert _resolve_oauth_provider(None, "gpt-5.1-codex-mini") == "openai"
+
+
+def test_provider_respects_config_override() -> None:
+    assert _resolve_oauth_provider("anthropic", "gpt-5.1-codex-mini") == "anthropic"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_observer_auth.py::test_provider_resolves_from_model -q`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+
+def _resolve_oauth_provider(configured: str | None, model: str) -> str:
+    if configured:
+        return configured.lower()
+    if model.lower().startswith("claude"):
+        return "anthropic"
+    return "openai"
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_observer_auth.py::test_provider_resolves_from_model -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add opencode_mem/observer.py tests/test_observer_auth.py
+git commit -m "feat: infer oauth provider for observer"
+```
+
+### Task 3: Use OAuth tokens for client init
+
+**Files:**
+- Modify: `opencode_mem/observer.py`
+- Test: `tests/test_observer_auth.py`
+
+**Step 1: Write the failing test**
+
+```python
+from unittest.mock import patch
+
+
+def test_openai_client_uses_oauth_token(tmp_path: Path) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "openai": {
+                    "type": "oauth",
+                    "access": "oa-access",
+                    "refresh": "oa-refresh",
+                    "expires": 9999999999999,
+                }
+            }
+        )
+    )
+    with patch("opencode_mem.observer._get_opencode_auth_path", return_value=auth_path):
+        with patch("opencode_mem.observer.OpenAI") as mock_openai:
+            from opencode_mem.observer import ObserverClient
+
+            client = ObserverClient()
+            assert client.client is not None
+            mock_openai.assert_called_once()
+            _, kwargs = mock_openai.call_args
+            assert kwargs["api_key"] == "oa-access"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_observer_auth.py::test_openai_client_uses_oauth_token -q`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+from typing import Optional
+
+
+def _extract_oauth_access(cache: dict[str, Any], provider: str) -> Optional[str]:
+    entry = cache.get(provider, {})
+    access = entry.get("access") if isinstance(entry, dict) else None
+    return access if isinstance(access, str) and access else None
+```
+
+Use the access token for `OpenAI(api_key=...)` or `anthropic.Anthropic(api_key=...)` when API key is missing.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_observer_auth.py::test_openai_client_uses_oauth_token -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add opencode_mem/observer.py tests/test_observer_auth.py
+git commit -m "feat: prefer oauth cache tokens for observer clients"
+```
+
+### Task 4: Preserve `opencode run` fallback
+
+**Files:**
+- Modify: `opencode_mem/observer.py`
+- Test: `tests/test_observer_auth.py`
+
+**Step 1: Write the failing test**
+
+```python
+from unittest.mock import patch
+
+
+def test_opencode_run_fallback_when_no_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_MEM_OBSERVER_API_KEY", raising=False)
+    with patch("opencode_mem.observer._load_opencode_oauth_cache", return_value={}):
+        from opencode_mem.config import OpencodeMemConfig
+        from opencode_mem.observer import ObserverClient
+
+        with patch("opencode_mem.observer.load_config", return_value=OpencodeMemConfig(use_opencode_run=True)):
+            client = ObserverClient()
+            assert client.use_opencode_run is True
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_observer_auth.py::test_opencode_run_fallback_when_no_auth -q`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+Keep `use_opencode_run` behavior intact, but only return early once OAuth cache is considered.
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_observer_auth.py::test_opencode_run_fallback_when_no_auth -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add opencode_mem/observer.py tests/test_observer_auth.py
+git commit -m "test: ensure opencode run remains fallback"
+```
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Update configuration docs**
+
+Add notes:
+- Observer auto-detects OpenCode OAuth cache at `~/.local/share/opencode/auth.json` when API keys are absent.
+- Provider chosen from `observer_provider` or inferred from model.
+- `OPENCODE_MEM_USE_OPENCODE_RUN` remains optional fallback.
+
+**Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document observer oauth cache usage"
+```
+
+### Task 6: Final verification
+
+Run:
+- `uv run pytest`
+- `uv run ruff check opencode_mem tests`
+- `uv run ruff format --check opencode_mem tests`
+
+Expected: All pass.
+
+### Execution Handoff
+
+Plan complete and saved to `docs/plans/2026-01-15-opencode-oauth-observer.md`. Two execution options:
+
+1. **Subagent-Driven (this session)** — dispatch a fresh subagent per task, review between tasks, fast iteration
+2. **Parallel Session (separate)** — open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/opencode_mem/observer.py
+++ b/opencode_mem/observer.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from .config import load_config
 from .observer_prompts import ObserverContext, build_observer_prompt
@@ -12,6 +14,9 @@ from .xml_parser import ParsedOutput, parse_observer_output
 
 DEFAULT_OPENAI_MODEL = "gpt-5.1-codex-mini"
 DEFAULT_ANTHROPIC_MODEL = "claude-4.5-haiku"
+
+
+logger = logging.getLogger(__name__)
 
 
 def _get_iap_token() -> str | None:
@@ -26,8 +31,43 @@ def _load_opencode_config() -> dict:
         return {}
     try:
         return json.loads(config_path.read_text())
-    except Exception:
+    except Exception as exc:
+        logger.warning("opencode config load failed", exc_info=exc)
         return {}
+
+
+def _get_opencode_auth_path() -> Path:
+    return Path.home() / ".local" / "share" / "opencode" / "auth.json"
+
+
+def _load_opencode_oauth_cache() -> dict[str, Any]:
+    path = _get_opencode_auth_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except Exception as exc:
+        logger.warning("opencode auth cache load failed", exc_info=exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _resolve_oauth_provider(configured: str | None, model: str) -> str:
+    if configured:
+        return configured.lower()
+    if model.lower().startswith("claude"):
+        return "anthropic"
+    return "openai"
+
+
+def _extract_oauth_access(cache: dict[str, Any], provider: str) -> str | None:
+    entry = cache.get(provider)
+    if not isinstance(entry, dict):
+        return None
+    access = entry.get("access")
+    if isinstance(access, str) and access:
+        return access
+    return None
 
 
 def _resolve_devaigateway_model(model_name: str) -> tuple[str, str]:
@@ -91,6 +131,9 @@ class ObserverClient:
         self.max_chars = cfg.observer_max_chars
         self.max_tokens = cfg.observer_max_tokens
         self.client: object | None = None
+        oauth_cache = _load_opencode_oauth_cache()
+        oauth_provider = _resolve_oauth_provider(self.provider, self.model)
+        oauth_access = _extract_oauth_access(oauth_cache, oauth_provider)
         if self.use_opencode_run:
             return
         if provider == "devaigateway":
@@ -112,7 +155,7 @@ class ObserverClient:
                 self.client = None
         elif provider == "anthropic":
             if not self.api_key:
-                self.api_key = os.getenv("ANTHROPIC_API_KEY")
+                self.api_key = os.getenv("ANTHROPIC_API_KEY") or oauth_access
             if not self.api_key:
                 return
             try:
@@ -127,6 +170,7 @@ class ObserverClient:
                     os.getenv("OPENCODE_API_KEY")
                     or os.getenv("OPENAI_API_KEY")
                     or os.getenv("CODEX_API_KEY")
+                    or oauth_access
                 )
             if not self.api_key:
                 return

--- a/opencode_mem/observer_prompts.py
+++ b/opencode_mem/observer_prompts.py
@@ -78,13 +78,13 @@ OBSERVATION_SCHEMA = f"""
       - discovery: learning about existing system, debugging insights
       - decision: architectural/design choice with rationale
       - exploration: attempted approach that was tried but NOT shipped
-    
+
     IMPORTANT: Use 'exploration' when:
       - Multiple approaches were tried for the same problem
       - An implementation was attempted but then replaced or reverted
       - Something was tested/experimented with but not kept
       - The attempt provides useful "why we didn't do X" context
-    
+
     Exploration memories are valuable! They prevent repeating failed approaches.
     Include what was tried AND why it didn't work out.
   -->

--- a/opencode_mem/viewer.py
+++ b/opencode_mem/viewer.py
@@ -804,8 +804,8 @@ VIEWER_HTML = """<!doctype html>
       function setTheme(theme) {
         document.documentElement.setAttribute("data-theme", theme);
         localStorage.setItem("opencode-mem-theme", theme);
-        themeToggle.innerHTML = theme === "dark" 
-          ? '<i data-lucide="sun"></i>' 
+        themeToggle.innerHTML = theme === "dark"
+          ? '<i data-lucide="sun"></i>'
           : '<i data-lucide="moon"></i>';
         themeToggle.title = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
         if (typeof lucide !== "undefined") lucide.createIcons();

--- a/tests/test_observer_auth.py
+++ b/tests/test_observer_auth.py
@@ -1,0 +1,177 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from opencode_mem.config import OpencodeMemConfig
+from opencode_mem.observer import _load_opencode_oauth_cache, _resolve_oauth_provider
+
+
+class OpenAIStub:
+    def __init__(self, **_kwargs: object) -> None:
+        self.kwargs = _kwargs
+
+
+def test_loads_openai_oauth_cache(tmp_path: Path) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "openai": {
+                    "type": "oauth",
+                    "access": "oa-access",
+                    "refresh": "oa-refresh",
+                    "expires": 9999999999999,
+                }
+            }
+        )
+    )
+    with patch("opencode_mem.observer._get_opencode_auth_path", return_value=auth_path):
+        data = _load_opencode_oauth_cache()
+    assert data["openai"]["access"] == "oa-access"
+
+
+def test_provider_resolves_from_model() -> None:
+    assert _resolve_oauth_provider(None, "claude-4.5-haiku") == "anthropic"
+    assert _resolve_oauth_provider(None, "gpt-5.1-codex-mini") == "openai"
+
+
+def test_provider_respects_config_override() -> None:
+    assert _resolve_oauth_provider("anthropic", "gpt-5.1-codex-mini") == "anthropic"
+
+
+def test_oauth_provider_uses_model_when_config_missing() -> None:
+    assert _resolve_oauth_provider(None, "claude-4.5-haiku") == "anthropic"
+    assert _resolve_oauth_provider(None, "gpt-5.1-codex-mini") == "openai"
+
+
+def test_oauth_provider_prefers_runtime_provider() -> None:
+    assert _resolve_oauth_provider("anthropic", "gpt-5.1-codex-mini") == "anthropic"
+    assert _resolve_oauth_provider("openai", "claude-4.5-haiku") == "openai"
+
+
+def test_openai_client_uses_oauth_token_when_api_key_missing(tmp_path: Path) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "openai": {
+                    "type": "oauth",
+                    "access": "oa-access",
+                    "refresh": "oa-refresh",
+                    "expires": 9999999999999,
+                }
+            }
+        )
+    )
+    cfg = OpencodeMemConfig(observer_api_key=None, observer_provider="openai")
+    openai_module = SimpleNamespace(OpenAI=OpenAIStub)
+    with (
+        patch("opencode_mem.observer.load_config", return_value=cfg),
+        patch("opencode_mem.observer._get_opencode_auth_path", return_value=auth_path),
+        patch.dict("os.environ", {}, clear=True),
+        patch.dict(sys.modules, {"openai": openai_module}),
+    ):
+        from opencode_mem.observer import ObserverClient
+
+        client = ObserverClient()
+        assert client.client is not None
+        assert isinstance(client.client, OpenAIStub)
+        assert client.client.kwargs["api_key"] == "oa-access"
+
+
+def test_anthropic_client_uses_oauth_token_when_api_key_missing(tmp_path: Path) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "anthropic": {
+                    "type": "oauth",
+                    "access": "anthropic-access",
+                    "refresh": "anthropic-refresh",
+                    "expires": 9999999999999,
+                }
+            }
+        )
+    )
+    anthropic_module = SimpleNamespace(Anthropic=Mock())
+    cfg = OpencodeMemConfig(observer_api_key=None, observer_provider="anthropic")
+    with (
+        patch("opencode_mem.observer.load_config", return_value=cfg),
+        patch("opencode_mem.observer._get_opencode_auth_path", return_value=auth_path),
+        patch.dict("os.environ", {}, clear=True),
+        patch.dict(sys.modules, {"anthropic": anthropic_module}),
+    ):
+        from opencode_mem.observer import ObserverClient
+
+        client = ObserverClient()
+        assert client.client is not None
+        anthropic_module.Anthropic.assert_called_once_with(api_key="anthropic-access")
+
+
+def test_oauth_skips_when_api_key_present(tmp_path: Path) -> None:
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(
+        json.dumps(
+            {
+                "openai": {
+                    "type": "oauth",
+                    "access": "oa-access",
+                    "refresh": "oa-refresh",
+                    "expires": 9999999999999,
+                }
+            }
+        )
+    )
+    cfg = OpencodeMemConfig(observer_api_key="cfg-key", observer_provider="openai")
+    openai_module = SimpleNamespace(OpenAI=OpenAIStub)
+    with (
+        patch("opencode_mem.observer.load_config", return_value=cfg),
+        patch("opencode_mem.observer._get_opencode_auth_path", return_value=auth_path),
+        patch.dict("os.environ", {}, clear=True),
+        patch.dict(sys.modules, {"openai": openai_module}),
+    ):
+        from opencode_mem.observer import ObserverClient
+
+        client = ObserverClient()
+        assert client.client is not None
+        assert isinstance(client.client, OpenAIStub)
+        assert client.client.kwargs["api_key"] == "cfg-key"
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"openai": {"access": "token"}}, "token"),
+        ({"openai": {"access": ""}}, None),
+        ({"openai": {"access": None}}, None),
+        ({"openai": "oops"}, None),
+        ({}, None),
+    ],
+)
+def test_extract_oauth_access(payload: dict, expected: str | None) -> None:
+    from opencode_mem.observer import _extract_oauth_access
+
+    assert _extract_oauth_access(payload, "openai") == expected
+
+
+def test_opencode_run_enabled_when_no_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENCODE_MEM_OBSERVER_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with (
+        patch("opencode_mem.observer._load_opencode_oauth_cache", return_value={}),
+        patch(
+            "opencode_mem.observer.load_config",
+            return_value=OpencodeMemConfig(use_opencode_run=True),
+        ),
+    ):
+        from opencode_mem.observer import ObserverClient
+
+        client = ObserverClient()
+        assert client.use_opencode_run is True
+        assert client.client is None

--- a/uv.lock
+++ b/uv.lock
@@ -968,7 +968,7 @@ wheels = [
 
 [[package]]
 name = "opencode-mem"
-version = "0.3.1"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Description
Implement a more efficient way to reuse oauth creds for observer llm call.s

## Type of Change
<!-- Mark the relevant option(s) with an "x" -->

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
<!-- Describe how you tested these changes -->

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
<!-- Mark completed items with an "x" -->

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ x Documentation updated (if needed)
- [x] No new warnings introduced
