### PR TITLE
sync: add per-peer project filter overrides

### DIFF
--- a/opencode_mem/commands/sync_cmds.py
+++ b/opencode_mem/commands/sync_cmds.py
@@ -512,7 +512,7 @@ def sync_doctor_cmd(
                     device_id=store.device_id,
                 )
                 _allowed, _next, blocked = store.filter_replication_ops_for_sync_with_status(
-                    outbound_ops
+                    outbound_ops, peer_device_id=peer_device_id
                 )
                 if blocked is not None:
                     blocked_outbound[peer_device_id] = blocked

--- a/opencode_mem/db.py
+++ b/opencode_mem/db.py
@@ -325,6 +325,8 @@ def initialize_schema(conn: sqlite3.Connection) -> None:
     _ensure_column(conn, "session_summaries", "import_key", "TEXT")
     _ensure_column(conn, "raw_event_sessions", "cwd", "TEXT")
     _ensure_column(conn, "sync_peers", "public_key", "TEXT")
+    _ensure_column(conn, "sync_peers", "projects_include_json", "TEXT")
+    _ensure_column(conn, "sync_peers", "projects_exclude_json", "TEXT")
     _ensure_column(conn, "raw_event_sessions", "project", "TEXT")
     _ensure_column(conn, "raw_event_sessions", "started_at", "TEXT")
     _ensure_column(conn, "raw_event_sessions", "last_seen_ts_wall_ms", "INTEGER")

--- a/opencode_mem/sync_api.py
+++ b/opencode_mem/sync_api.py
@@ -167,6 +167,7 @@ def build_sync_handler(db_path: Path | None = None):
                     if not _authorize_request(store, self, b""):
                         self._unauthorized()
                         return
+                    peer_device_id = str(self.headers.get("X-Opencode-Device") or "")
                     params = parse_qs(parsed.query)
                     cursor = params.get("since", [None])[0]
                     limit_value = params.get("limit", ["200"])[0]
@@ -180,7 +181,8 @@ def build_sync_handler(db_path: Path | None = None):
                         device_id=store.device_id,
                     )
                     ops, next_cursor, blocked = store.filter_replication_ops_for_sync_with_status(
-                        ops
+                        ops,
+                        peer_device_id=peer_device_id or None,
                     )
                     payload: dict[str, Any] = {"ops": ops, "next_cursor": next_cursor}
                     if blocked is not None and not ops:

--- a/opencode_mem/sync_daemon.py
+++ b/opencode_mem/sync_daemon.py
@@ -283,7 +283,9 @@ def sync_once(
                 limit=limit,
                 device_id=device_id,
             )
-            outbound_ops, outbound_cursor = store.filter_replication_ops_for_sync(outbound_ops)
+            outbound_ops, outbound_cursor = store.filter_replication_ops_for_sync(
+                outbound_ops, peer_device_id=peer_device_id
+            )
             post_url = f"{base_url}/v1/ops"
             if outbound_ops:
                 batches = _chunk_ops_by_size(outbound_ops, max_bytes=MAX_SYNC_BODY_BYTES)


### PR DESCRIPTION
## Description
Added per-peer project filtering for sync operations. This enhancement allows for more granular control over which projects are synced with specific peers, overriding the global sync project filters when needed.

## Type of Change
- [x] 🚀 Feature (new functionality)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced