### PR TITLE
sync: add accept-time per-peer project filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,28 @@ Notes:
 - Filtering is reversible: excluded projects are skipped without advancing cursors, so toggling
   filters later will allow previously filtered ops to sync.
 
+#### Per-peer overrides (recommended for coworker sync)
+
+Global filters apply to all peers by default. When accepting a pairing payload, you can set a
+per-peer override so one peer only syncs shared work projects while your other devices still sync
+everything.
+
+Example:
+
+```bash
+# Accept a peer and only sync specific projects with them
+opencode-mem sync pair --accept '<payload>' --include shared-repo-1,shared-repo-2
+
+# Accept a peer and exclude a project
+opencode-mem sync pair --accept '<payload>' --exclude private-repo
+
+# Clear per-peer override (inherit global defaults)
+opencode-mem sync pair --accept '<payload>' --default
+
+# Force per-peer override to sync all projects with this peer
+opencode-mem sync pair --accept '<payload>' --all
+```
+
 ## Semantic recall
 
 Semantic recall stores vector embeddings for memory items using sqlite-vec and fastembed. Embeddings are written when memories are created; use `opencode-mem embed` to backfill existing memories.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -50,6 +50,11 @@
 2. Or run `opencode-mem sync pair` and copy the payload.
 3. On the other device, run `opencode-mem sync pair --accept '<payload>'`.
 
+Optional (recommended for coworker sync): set a per-peer project filter at accept time:
+
+- `opencode-mem sync pair --accept '<payload>' --include shared-repo-1,shared-repo-2`
+- `opencode-mem sync pair --accept '<payload>' --exclude private-repo`
+
 ### One-off sync
 
 - `opencode-mem sync once` syncs all peers once.

--- a/opencode_mem/cli.py
+++ b/opencode_mem/cli.py
@@ -83,6 +83,7 @@ from .sync_daemon import run_sync_daemon, run_sync_pass, sync_pass_preflight
 from .sync_discovery import (
     discover_peers_via_mdns,
     mdns_enabled,
+    set_peer_project_filter,
     update_peer_addresses,
 )
 from .sync_identity import ensure_device_identity, fingerprint_public_key, load_public_key
@@ -693,6 +694,24 @@ def sync_pair(
     accept: str | None = typer.Option(None, help="Accept pairing payload (JSON)"),
     name: str | None = typer.Option(None, help="Label for the peer"),
     address: str | None = typer.Option(None, help="Override peer address (host:port)"),
+    include: str | None = typer.Option(
+        None,
+        help="Comma-separated project basenames to sync with this peer (accept only)",
+    ),
+    exclude: str | None = typer.Option(
+        None,
+        help="Comma-separated project basenames to exclude for this peer (accept only)",
+    ),
+    all_projects: bool = typer.Option(
+        False,
+        "--all",
+        help="Override peer project filter to sync all projects with this peer (accept only)",
+    ),
+    default_projects: bool = typer.Option(
+        False,
+        "--default",
+        help="Clear peer project filter override and inherit global defaults (accept only)",
+    ),
     db_path: str = typer.Option(None, help="Path to SQLite database"),
 ) -> None:
     """Print pairing payload or accept a peer payload."""
@@ -702,12 +721,17 @@ def sync_pair(
         load_public_key=load_public_key,
         fingerprint_public_key=fingerprint_public_key,
         update_peer_addresses=update_peer_addresses,
+        set_peer_project_filter=set_peer_project_filter,
         pick_advertise_hosts=pick_advertise_hosts,
         pick_advertise_host=pick_advertise_host,
         load_config=load_config,
         accept=accept,
         name=name,
         address=address,
+        include=include,
+        exclude=exclude,
+        all_projects=all_projects,
+        default_projects=default_projects,
         db_path=db_path,
     )
 

--- a/opencode_mem/sync_discovery.py
+++ b/opencode_mem/sync_discovery.py
@@ -125,6 +125,33 @@ def update_peer_addresses(
     return merged
 
 
+def set_peer_project_filter(
+    conn: sqlite3.Connection,
+    peer_device_id: str,
+    *,
+    include: list[str] | None,
+    exclude: list[str] | None,
+) -> None:
+    """Set per-peer project filters.
+
+    - include/exclude as lists store a per-peer override (including empty lists).
+    - include=None and exclude=None clears the override (both columns NULL), inheriting global config.
+    """
+
+    include_json = None if include is None else db.to_json(include)
+    exclude_json = None if exclude is None else db.to_json(exclude)
+    conn.execute(
+        """
+        UPDATE sync_peers
+        SET projects_include_json = ?,
+            projects_exclude_json = ?
+        WHERE peer_device_id = ?
+        """,
+        (include_json, exclude_json, peer_device_id),
+    )
+    conn.commit()
+
+
 def record_sync_attempt(
     conn: sqlite3.Connection,
     peer_device_id: str,


### PR DESCRIPTION
## Description
Added per-peer project filtering for sync, allowing users to specify which projects to include or exclude when pairing with specific peers. This is particularly useful for coworker sync scenarios where you want to share only specific repositories while keeping others private.

New CLI options for `opencode-mem sync pair --accept`:
- `--include` - Specify comma-separated projects to sync with this peer
- `--exclude` - Specify comma-separated projects to exclude from sync with this peer
- `--all` - Override to sync all projects with this peer
- `--default` - Clear per-peer override to inherit global defaults

Updated documentation in README.md and user-guide.md with examples of the new functionality.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced