### PR TITLE
chore: release 0.9.17

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,28 @@ will be published.
 
 If you are about to run commands, prefer `uv run ...` (no manual venv activation needed).
 
+## Releases (reproducible process)
+
+This repo uses PR-only `main` with required CI checks.
+
+Release checklist:
+
+1. Create a release branch + PR (no direct pushes to `main`)
+2. Update version:
+   - `pyproject.toml`
+   - `opencode_mem/__init__.py`
+3. Regenerate lockfiles/artifacts and commit the results:
+   - Python: run `uv sync` and commit `uv.lock`
+   - Viewer UI bundle: in `viewer_ui/`, run:
+     - `bun install`
+     - `bun run build`
+     - commit updated `opencode_mem/viewer_static/app.js`
+4. Ensure JS installs use the public npm registry (avoid private registries/mirrors)
+   - Keep `.opencode/.npmrc` with `registry=https://registry.npmjs.org/`
+5. Wait for CI to pass, then squash-merge the PR
+6. Tag the merge commit as `vX.Y.Z` and push the tag
+   - The `Release` workflow triggers on `v*` tags and publishes the GitHub Release artifacts.
+
 ## Stack (what this repo uses)
 
 - Python: >=3.11,<3.15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Release checklist:
    - `pyproject.toml`
    - `opencode_mem/__init__.py`
 3. Regenerate lockfiles/artifacts and commit the results:
-   - Python: run `uv sync` and commit `uv.lock`
+   - Python: run `uv sync` and commit `uv.lock` (the lockfile includes the local package version)
    - Viewer UI bundle: in `viewer_ui/`, run:
      - `bun install`
      - `bun run build`

--- a/opencode_mem/__init__.py
+++ b/opencode_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.9.16"
+__version__ = "0.9.17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = [
 
 [project]
 name = "opencode-mem"
-version = "0.9.16"
+version = "0.9.17"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "opencode-mem"
-version = "0.9.16"
+version = "0.9.17"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Summary\n- Bump version to 0.9.17\n- Regenerate uv.lock for the new version\n- Document the reproducible release process in AGENTS.md\n\n## Notes\n- CI should pass with the viewer bundle committed on main.