### PR TITLE
fix(ingest): resolve project name correctly from plugin and env var

### DIFF
--- a/.opencode/plugin/opencode-mem.js
+++ b/.opencode/plugin/opencode-mem.js
@@ -749,7 +749,7 @@ export const OpencodeMemPlugin = async ({
 
     const payload = {
       cwd,
-      project: project?.root || project?.name || null,
+      project: project?.name || (project?.root ? String(project.root).split(/[/\\]/).filter(Boolean).pop() : null) || null,
       started_at: sessionStartedAt || new Date().toISOString(),
       events: [...events],
       // Session context for comprehensive memories

--- a/opencode_mem/plugin_ingest.py
+++ b/opencode_mem/plugin_ingest.py
@@ -285,7 +285,14 @@ def ingest(payload: dict[str, Any]) -> None:
         capture_post=capture_post_context,
     )
     diff_summary = post.get("git_diff") or ""
-    project = payload.get("project") or pre.get("project")
+    env_project = os.environ.get("OPENCODE_MEM_PROJECT")
+    raw_project = env_project or payload.get("project") or pre.get("project")
+    # Normalize: if the value looks like a filesystem path, extract just the directory name.
+    # The plugin may send project.root (a full path) instead of project.name.
+    if raw_project and ("/" in raw_project or "\\" in raw_project):
+        project = Path(raw_project).name
+    else:
+        project = raw_project
     repo_root = pre.get("project") or None
     db_path = os.environ.get("OPENCODE_MEM_DB")
     store = MemoryStore(Path(db_path) if db_path else db.DEFAULT_DB_PATH)


### PR DESCRIPTION
## Summary
- Plugin's `flushEvents` was sending `project.root` (full filesystem path) instead of directory name, causing wrong project values (e.g. `product-context` instead of `greenroom`)
- Ingest pipeline ignored `OPENCODE_MEM_PROJECT` env var entirely — now checks it first, matching MCP server and CLI behavior
- Added path-to-basename normalization as a safety net for any remaining path leakage

## Changes
- `.opencode/plugin/opencode-mem.js` — `flushEvents` payload now uses same name-extraction logic as `emitRawEvent`
- `opencode_mem/plugin_ingest.py` — checks `OPENCODE_MEM_PROJECT` env var first, normalizes paths to basenames