### PR TITLE
chore: release 0.9.18

### DIFF
--- a/opencode_mem/__init__.py
+++ b/opencode_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.9.17"
+__version__ = "0.9.18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = [
 
 [project]
 name = "opencode-mem"
-version = "0.9.17"
+version = "0.9.18"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "opencode-mem"
-version = "0.9.17"
+version = "0.9.18"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Release 0.9.18

Bugfix release addressing project name resolution issues across the ingestion and sync pipelines.

### Changes included (already merged to main)
- **fix(ingest)**: Plugin `flushEvents` now sends project name instead of full filesystem path; ingest pipeline respects `OPENCODE_MEM_PROJECT` env var (#19)
- **fix(sync)**: Replicated memories now propagate project to sessions on target machines, fixing N/A project display (#20)

### This PR
- Bumps version to 0.9.18 in `pyproject.toml` and `opencode_mem/__init__.py`
- Regenerates `uv.lock`