### PR TITLE
feat(cli): add db rename-project command

### DIFF
--- a/opencode_mem/cli_app.py
+++ b/opencode_mem/cli_app.py
@@ -19,7 +19,12 @@ from .commands.common import (
     resolve_project_for_cli,
     write_config_or_exit,
 )
-from .commands.db_cmds import normalize_projects_cmd, prune_memories_cmd, prune_observations_cmd
+from .commands.db_cmds import (
+    normalize_projects_cmd,
+    prune_memories_cmd,
+    prune_observations_cmd,
+    rename_project_cmd,
+)
 from .commands.import_export_cmds import export_memories_cmd, import_memories_cmd
 from .commands.maintenance_cmds import (
     backfill_discovery_tokens_cmd,
@@ -1022,6 +1027,24 @@ def db_normalize_projects(
     """
 
     normalize_projects_cmd(store_from_path=_store, db_path=db_path, apply=apply)
+
+
+@db_app.command("rename-project")
+def db_rename_project(
+    old_name: str = typer.Argument(help="Current project name to rename"),
+    new_name: str = typer.Argument(help="New project name"),
+    db_path: str = typer.Option(None, help="Path to opencode-mem SQLite database"),
+    apply: bool = typer.Option(False, help="Apply changes (default is dry-run)"),
+) -> None:
+    """Rename a project across all sessions and related tables.
+
+    Matches both exact project names and path-like values whose basename
+    matches OLD_NAME (e.g. "/Users/.../product-context" matches "product-context").
+    """
+
+    rename_project_cmd(
+        store_from_path=_store, db_path=db_path, old_name=old_name, new_name=new_name, apply=apply
+    )
 
 
 @app.command()

--- a/opencode_mem/commands/db_cmds.py
+++ b/opencode_mem/commands/db_cmds.py
@@ -54,3 +54,24 @@ def normalize_projects_cmd(*, store_from_path, db_path: str | None, apply: bool)
         print("- Rewritten paths:")
         for source in sorted(mapping):
             print(f"  - {source} -> {mapping[source]}")
+
+
+def rename_project_cmd(
+    *, store_from_path, db_path: str | None, old_name: str, new_name: str, apply: bool
+) -> None:
+    """Rename a project across sessions, raw_event_sessions, and usage_events."""
+
+    store = store_from_path(db_path)
+    try:
+        result = store.rename_project(old_name, new_name, dry_run=not apply)
+    finally:
+        store.close()
+    action = "Will rename" if result.get("dry_run") else "Renamed"
+    print(
+        f"[bold]{action}[/bold] [cyan]{result.get('old_name')}[/cyan] → [green]{result.get('new_name')}[/green]"
+    )
+    print(f"- Sessions: {result.get('sessions_to_update')}")
+    print(f"- Raw event sessions: {result.get('raw_event_sessions_to_update')}")
+    print(f"- Usage events: {result.get('usage_events_to_update')}")
+    if result.get("dry_run"):
+        print("\n[dim]Pass --apply to execute.[/dim]")

--- a/opencode_mem/commands/db_cmds.py
+++ b/opencode_mem/commands/db_cmds.py
@@ -66,6 +66,12 @@ def rename_project_cmd(
         result = store.rename_project(old_name, new_name, dry_run=not apply)
     finally:
         store.close()
+
+    error = result.get("error")
+    if error:
+        print(f"[red]Error:[/red] {error}")
+        raise SystemExit(2)
+
     action = "Will rename" if result.get("dry_run") else "Renamed"
     print(
         f"[bold]{action}[/bold] [cyan]{result.get('old_name')}[/cyan] → [green]{result.get('new_name')}[/green]"

--- a/opencode_mem/store/_store.py
+++ b/opencode_mem/store/_store.py
@@ -1282,6 +1282,11 @@ class MemoryStore:
     def normalize_projects(self, *, dry_run: bool = True) -> dict[str, Any]:
         return store_maintenance.normalize_projects(self, dry_run=dry_run)
 
+    def rename_project(
+        self, old_name: str, new_name: str, *, dry_run: bool = True
+    ) -> dict[str, Any]:
+        return store_maintenance.rename_project(self, old_name, new_name, dry_run=dry_run)
+
     def _query_looks_like_tasks(self, query: str) -> bool:
         return store_search._query_looks_like_tasks(query)
 


### PR DESCRIPTION
## Summary
- Adds `opencode-mem db rename-project OLD_NAME NEW_NAME [--apply]` CLI command
- Renames project identifiers across `sessions`, `raw_event_sessions`, and `usage_events`
- Matches both exact names and path-like values whose basename matches (e.g. `product-context` also matches `/Users/.../product-context`)
- Defaults to dry-run for safety

## Motivation
Git worktrees produce project names derived from the worktree directory (e.g. `product-context`, `main`) instead of the parent repo name (`greenroom`). This command provides a clean way to fix misattributed project values after the fact.

## Usage
```bash
# Preview what would change
opencode-mem db rename-project product-context greenroom

# Apply the rename
opencode-mem db rename-project product-context greenroom --apply
```

## Changes
- `opencode_mem/store/maintenance.py` — `rename_project()` function
- `opencode_mem/store/_store.py` — forwarding method
- `opencode_mem/commands/db_cmds.py` — `rename_project_cmd()` with rich output
- `opencode_mem/cli_app.py` — wired as `db rename-project`