### PR TITLE
fix(sync): include VPN interfaces in pairing discovery

### DIFF
--- a/opencode_mem/net.py
+++ b/opencode_mem/net.py
@@ -3,6 +3,108 @@ from __future__ import annotations
 import socket
 import subprocess
 
+_ALLOWED_INTERFACE_PREFIXES = (
+    "en",
+    "eth",
+    "wl",
+    "wlan",
+    "wifi",
+    "utun",
+    "tun",
+    "tap",
+    "wg",
+    "ppp",
+    "tailscale",
+)
+
+_BLOCKED_INTERFACE_PREFIXES = (
+    "lo",
+    "docker",
+    "veth",
+    "br-",
+    "bridge",
+    "awdl",
+    "llw",
+    "anpi",
+    "gif",
+    "stf",
+)
+
+
+def _interface_name_allowed(name: str) -> bool:
+    lowered = name.strip().lower()
+    if not lowered:
+        return False
+    if lowered.startswith(_BLOCKED_INTERFACE_PREFIXES):
+        return False
+    return lowered.startswith(_ALLOWED_INTERFACE_PREFIXES)
+
+
+def _parse_ifconfig_ipv4(output: str) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    current: str | None = None
+    for raw in output.splitlines():
+        line = raw.rstrip()
+        if not line:
+            continue
+        if line[0] not in {" ", "\t"}:
+            current = line.split(":", 1)[0].strip()
+            continue
+        if not current:
+            continue
+        parts = line.strip().split()
+        if len(parts) < 2 or parts[0] != "inet":
+            continue
+        pairs.append((current, parts[1]))
+    return pairs
+
+
+def _parse_ip_addr_ipv4(output: str) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    for raw in output.splitlines():
+        parts = raw.split()
+        if len(parts) < 4:
+            continue
+        try:
+            index = parts.index("inet")
+        except ValueError:
+            continue
+        if index + 1 >= len(parts):
+            continue
+        pairs.append((parts[1], parts[index + 1].split("/", 1)[0]))
+    return pairs
+
+
+def _interface_ipv4_candidates() -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def _add(name: str, value: str) -> None:
+        if not _interface_name_allowed(name):
+            return
+        cleaned = value.strip()
+        if not cleaned or cleaned.startswith("127.") or cleaned == "0.0.0.0":
+            return
+        if cleaned in seen:
+            return
+        seen.add(cleaned)
+        candidates.append(cleaned)
+
+    commands = (
+        (("ifconfig",), _parse_ifconfig_ipv4),
+        (("ip", "-4", "-o", "addr", "show"), _parse_ip_addr_ipv4),
+    )
+    for command, parser in commands:
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, check=False)
+        except FileNotFoundError:
+            continue
+        if result.returncode != 0:
+            continue
+        for iface, ip in parser(result.stdout):
+            _add(iface, ip)
+    return candidates
+
 
 def _tailscale_ipv4() -> str | None:
     try:
@@ -60,6 +162,9 @@ def _local_ipv4_candidates() -> list[str]:
                 _add(addr)
     except Exception:
         pass
+
+    for ip in _interface_ipv4_candidates():
+        _add(ip)
 
     return candidates
 

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import subprocess
+
+from opencode_mem import net
+
+
+def test_interface_ipv4_candidates_include_utun_and_filter_low_signal_interfaces(
+    monkeypatch,
+) -> None:
+    ifconfig_output = """
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+    inet 127.0.0.1 netmask 0xff000000
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+    inet 192.168.1.20 netmask 0xffffff00 broadcast 192.168.1.255
+utun4: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 1380
+    inet 10.11.12.13 --> 10.11.12.13 netmask 0xffffffff
+awdl0: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1484
+    inet 169.254.12.99 netmask 0xffff0000 broadcast 169.254.255.255
+docker0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST> mtu 1500
+    inet 172.17.0.1 netmask 255.255.0.0 broadcast 172.17.255.255
+""".strip()
+
+    def _fake_run(command, capture_output, text, check):
+        if tuple(command) == ("ifconfig",):
+            return subprocess.CompletedProcess(command, 0, stdout=ifconfig_output, stderr="")
+        raise FileNotFoundError
+
+    monkeypatch.setattr(net.subprocess, "run", _fake_run)
+
+    assert net._interface_ipv4_candidates() == ["192.168.1.20", "10.11.12.13"]
+
+
+def test_pick_advertise_hosts_auto_keeps_lan_first_then_tailscale(monkeypatch) -> None:
+    monkeypatch.setattr(net, "_local_ipv4_candidates", lambda: ["192.168.1.20", "10.11.12.13"])
+    monkeypatch.setattr(net, "_tailscale_ipv4", lambda: "100.99.10.1")
+
+    assert net.pick_advertise_hosts("auto") == ["192.168.1.20", "10.11.12.13", "100.99.10.1"]
+
+
+def test_pick_advertise_hosts_tailscale_mode_prioritizes_tailscale(monkeypatch) -> None:
+    monkeypatch.setattr(net, "_local_ipv4_candidates", lambda: ["192.168.1.20", "100.99.10.1"])
+    monkeypatch.setattr(net, "_tailscale_ipv4", lambda: "100.99.10.1")
+
+    assert net.pick_advertise_hosts("tailscale") == ["100.99.10.1", "192.168.1.20"]


### PR DESCRIPTION
## Summary
- include VPN adapters (utun*, tun*, tap*, wg*, ppp*) in pairing address discovery
- preserve existing LAN and Tailscale behavior while filtering unsuitable interfaces
- add focused net discovery tests for interface selection and ordering

## Validation
- uv run pytest tests/test_net.py

Refs: opencode-mem-qr1