### PR TITLE
chore: release 0.9.20

### DIFF
--- a/opencode_mem/__init__.py
+++ b/opencode_mem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.9.19"
+__version__ = "0.9.20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = [
 
 [project]
 name = "opencode-mem"
-version = "0.9.19"
+version = "0.9.20"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ wheels = [
 
 [[package]]
 name = "opencode-mem"
-version = "0.9.19"
+version = "0.9.20"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Summary
- bump package version to 0.9.20 in pyproject.toml and opencode_mem/__init__.py
- regenerate uv.lock with the release version metadata
- validate release branch with full tests and lint

## Validation
- uv sync
- uv run pytest
- uv run ruff check opencode_mem tests