### PR TITLE
fix(viewer): harden origin checks and request limits

### DIFF
--- a/opencode_mem/viewer_http.py
+++ b/opencode_mem/viewer_http.py
@@ -10,20 +10,24 @@ _ALLOWED_ORIGIN_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 
 def _is_allowed_loopback_origin_url(url: str) -> bool:
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
     if parsed.scheme != "http":
         return False
     if parsed.username is not None or parsed.password is not None:
         return False
-    if parsed.hostname not in _ALLOWED_ORIGIN_HOSTS:
-        return False
-    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
-        return False
     try:
+        hostname = parsed.hostname
         _ = parsed.port
     except ValueError:
         return False
-    return True
+    if hostname not in _ALLOWED_ORIGIN_HOSTS:
+        return False
+    return (
+        parsed.path in ("", "/") and not parsed.params and not parsed.query and not parsed.fragment
+    )
 
 
 def _is_unsafe_missing_origin(handler: BaseHTTPRequestHandler) -> bool:

--- a/tests/test_viewer_http.py
+++ b/tests/test_viewer_http.py
@@ -106,6 +106,7 @@ def test_reject_cross_origin_blocks_spoofed_loopback_origins() -> None:
         "http://127.0.0.1.evil.test",
         "http://localhost.evil.test",
         "http://127.0.0.1@evil.test",
+        "http://[::1",
         "http://[::1]:bad",
         "http://127.0.0.1/path",
     ]

--- a/tests/test_viewer_routes_raw_events.py
+++ b/tests/test_viewer_routes_raw_events.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+from opencode_mem.viewer_routes import raw_events
+
+
+class DummyHandler:
+    def __init__(self, body: bytes, content_length: int) -> None:
+        self.headers = {"Content-Length": str(content_length)}
+        self.rfile = io.BytesIO(body)
+        self.response: dict[str, Any] | None = None
+        self.status: int | None = None
+
+    def _send_json(self, payload: dict[str, Any], status: int = 200) -> None:
+        self.response = payload
+        self.status = status
+
+
+class DummyFlusher:
+    def __init__(self) -> None:
+        self.noted: list[str] = []
+
+    def note_activity(self, opencode_session_id: str) -> None:
+        self.noted.append(opencode_session_id)
+
+
+class DummyStore:
+    def __init__(self) -> None:
+        self.conn: Any = None
+        self.closed = False
+        self.recorded_batches: list[tuple[str, list[dict[str, Any]]]] = []
+        self.meta_updates: list[dict[str, Any]] = []
+
+    def raw_event_backlog_totals(self) -> dict[str, int]:
+        return {}
+
+    def record_raw_events_batch(
+        self, *, opencode_session_id: str, events: list[dict[str, Any]]
+    ) -> dict[str, int]:
+        self.recorded_batches.append((opencode_session_id, events))
+        return {"inserted": len(events)}
+
+    def update_raw_event_session_meta(
+        self,
+        *,
+        opencode_session_id: str,
+        cwd: str | None,
+        project: str | None,
+        started_at: str | None,
+        last_seen_ts_wall_ms: int | None,
+    ) -> None:
+        self.meta_updates.append(
+            {
+                "opencode_session_id": opencode_session_id,
+                "cwd": cwd,
+                "project": project,
+                "started_at": started_at,
+                "last_seen_ts_wall_ms": last_seen_ts_wall_ms,
+            }
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_handle_post_rejects_oversized_payload(monkeypatch) -> None:
+    payload = {
+        "opencode_session_id": "sess-1",
+        "event_type": "tool.execute.after",
+        "payload": {"tool": "read"},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    handler = DummyHandler(body=body, content_length=len(body))
+    flusher = DummyFlusher()
+    store = DummyStore()
+    store_factory_called = False
+
+    def store_factory(_db_path: str) -> DummyStore:
+        nonlocal store_factory_called
+        store_factory_called = True
+        return store
+
+    monkeypatch.setattr(raw_events, "MAX_RAW_EVENTS_BODY_BYTES", len(body) - 1)
+
+    handled = raw_events.handle_post(
+        handler,
+        path="/api/raw-events",
+        store_factory=store_factory,
+        default_db_path="/tmp/mem.sqlite",
+        flusher=flusher,
+        strip_private_obj=lambda value: value,
+    )
+
+    assert handled is True
+    assert handler.status == 413
+    assert handler.response == {
+        "error": "payload too large",
+        "max_bytes": len(body) - 1,
+    }
+    assert store_factory_called is False
+    assert store.closed is False
+    assert flusher.noted == []
+
+
+def test_handle_post_accepts_payload_within_size_limit(monkeypatch) -> None:
+    payload = {
+        "opencode_session_id": "sess-1",
+        "event_type": "tool.execute.after",
+        "payload": {"tool": "read"},
+        "ts_wall_ms": 123,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    handler = DummyHandler(body=body, content_length=len(body))
+    flusher = DummyFlusher()
+    store = DummyStore()
+
+    def store_factory(_db_path: str) -> DummyStore:
+        return store
+
+    monkeypatch.setattr(raw_events, "MAX_RAW_EVENTS_BODY_BYTES", len(body))
+
+    handled = raw_events.handle_post(
+        handler,
+        path="/api/raw-events",
+        store_factory=store_factory,
+        default_db_path="/tmp/mem.sqlite",
+        flusher=flusher,
+        strip_private_obj=lambda value: value,
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert handler.response == {"inserted": 1, "received": 1}
+    assert store.recorded_batches[0][0] == "sess-1"
+    assert store.recorded_batches[0][1][0]["event_type"] == "tool.execute.after"
+    assert store.meta_updates[0]["last_seen_ts_wall_ms"] == 123
+    assert store.closed is True
+    assert flusher.noted == ["sess-1"]


### PR DESCRIPTION
## Summary
- replace prefix-based Origin checks with strict parsed loopback origin validation
- require explicit Origin on mutating sync POST/DELETE routes while preserving safe non-browser raw-events ingestion
- add request-size limit for raw-events and validate sync attempts limit parsing

## Validation
- uv run pytest tests/test_viewer_http.py tests/test_sync_viewer_api.py tests/test_viewer_routes_raw_events.py tests/test_store.py::test_viewer_accepts_raw_events

Refs: opencode-mem-a7n, opencode-mem-3rt, opencode-mem-5ej, opencode-mem-juh