### PR TITLE
fix(sync): improve failure handling and ingest safety

### DIFF
--- a/opencode_mem/ingest/events.py
+++ b/opencode_mem/ingest/events.py
@@ -56,7 +56,8 @@ def event_to_tool_event(
         return None
     if tool in low_signal_tools:
         return None
-    args = event.get("args") or {}
+    raw_args = event.get("args")
+    args = raw_args if isinstance(raw_args, dict) else {}
     result = _sanitize_tool_output(tool, event.get("result"), max_chars)
     if tool == "read" and isinstance(result, str):
         result = _compact_read_output(result)

--- a/opencode_mem/sync_api.py
+++ b/opencode_mem/sync_api.py
@@ -65,13 +65,15 @@ def _path_with_query(path: str) -> str:
     return parsed.path
 
 
-def _authorize_request(store: MemoryStore, handler: BaseHTTPRequestHandler, body: bytes) -> bool:
+def _authorize_request(
+    store: MemoryStore, handler: BaseHTTPRequestHandler, body: bytes
+) -> tuple[bool, str]:
     device_id = handler.headers.get("X-Opencode-Device")
     signature = handler.headers.get("X-Opencode-Signature")
     timestamp = handler.headers.get("X-Opencode-Timestamp")
     nonce = handler.headers.get("X-Opencode-Nonce")
     if not device_id or not signature or not timestamp or not nonce:
-        return False
+        return False, "missing_headers"
     row = store.conn.execute(
         """
         SELECT pinned_fingerprint, public_key
@@ -81,13 +83,13 @@ def _authorize_request(store: MemoryStore, handler: BaseHTTPRequestHandler, body
         (device_id,),
     ).fetchone()
     if row is None:
-        return False
+        return False, "unknown_peer"
     pinned_fingerprint = row["pinned_fingerprint"]
     public_key = row["public_key"]
     if not pinned_fingerprint or not public_key:
-        return False
+        return False, "peer_record_incomplete"
     if fingerprint_public_key(public_key) != pinned_fingerprint:
-        return False
+        return False, "fingerprint_mismatch"
     try:
         ok = verify_signature(
             method=handler.command,
@@ -100,16 +102,16 @@ def _authorize_request(store: MemoryStore, handler: BaseHTTPRequestHandler, body
             device_id=device_id,
         )
     except Exception:
-        return False
+        return False, "signature_verification_error"
     if not ok:
-        return False
+        return False, "invalid_signature"
     now = dt.datetime.now(dt.UTC)
     created_at = now.isoformat()
     if not record_nonce(store.conn, device_id=device_id, nonce=nonce, created_at=created_at):
-        return False
+        return False, "nonce_replay"
     cutoff = (now - dt.timedelta(seconds=DEFAULT_TIME_WINDOW_S * 2)).isoformat()
     cleanup_nonces(store.conn, cutoff=cutoff)
-    return True
+    return True, "ok"
 
 
 def build_sync_handler(db_path: Path | None = None):
@@ -123,16 +125,17 @@ def build_sync_handler(db_path: Path | None = None):
         def _store(self) -> MemoryStore:
             return MemoryStore(resolved_db)
 
-        def _unauthorized(self) -> None:
-            _send_json(self, {"error": "unauthorized"}, status=401)
+        def _unauthorized(self, reason: str) -> None:
+            _send_json(self, {"error": "unauthorized", "reason": reason}, status=401)
 
         def do_GET(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)
             if parsed.path == "/v1/status":
                 store = self._store()
                 try:
-                    if not _authorize_request(store, self, b""):
-                        self._unauthorized()
+                    authorized, reason = _authorize_request(store, self, b"")
+                    if not authorized:
+                        self._unauthorized(reason)
                         return
                     device_row = store.conn.execute(
                         "SELECT device_id, public_key, fingerprint FROM sync_device LIMIT 1"
@@ -164,8 +167,9 @@ def build_sync_handler(db_path: Path | None = None):
             if parsed.path == "/v1/ops":
                 store = self._store()
                 try:
-                    if not _authorize_request(store, self, b""):
-                        self._unauthorized()
+                    authorized, reason = _authorize_request(store, self, b"")
+                    if not authorized:
+                        self._unauthorized(reason)
                         return
                     peer_device_id = str(self.headers.get("X-Opencode-Device") or "")
                     params = parse_qs(parsed.query)
@@ -188,6 +192,8 @@ def build_sync_handler(db_path: Path | None = None):
                     if skipped is not None:
                         payload["skipped"] = skipped.get("skipped_count", 0)
                     _send_json(self, payload)
+                except Exception:
+                    _send_json(self, {"error": "internal_error"}, status=500)
                 finally:
                     store.close()
                 return
@@ -206,8 +212,9 @@ def build_sync_handler(db_path: Path | None = None):
                 except ValueError:
                     _send_json(self, {"error": "payload_too_large"}, status=413)
                     return
-                if not _authorize_request(store, self, raw):
-                    self._unauthorized()
+                authorized, reason = _authorize_request(store, self, raw)
+                if not authorized:
+                    self._unauthorized(reason)
                     return
                 source_device_id = str(self.headers.get("X-Opencode-Device") or "")
                 data = _parse_json_body(raw)

--- a/opencode_mem/viewer_http.py
+++ b/opencode_mem/viewer_http.py
@@ -10,20 +10,24 @@ _ALLOWED_ORIGIN_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 
 def _is_allowed_loopback_origin_url(url: str) -> bool:
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
     if parsed.scheme != "http":
         return False
     if parsed.username is not None or parsed.password is not None:
         return False
-    if parsed.hostname not in _ALLOWED_ORIGIN_HOSTS:
-        return False
-    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
-        return False
     try:
+        hostname = parsed.hostname
         _ = parsed.port
     except ValueError:
         return False
-    return True
+    if hostname not in _ALLOWED_ORIGIN_HOSTS:
+        return False
+    return (
+        parsed.path in ("", "/") and not parsed.params and not parsed.query and not parsed.fragment
+    )
 
 
 def _is_unsafe_missing_origin(handler: BaseHTTPRequestHandler) -> bool:

--- a/tests/test_ingest_events.py
+++ b/tests/test_ingest_events.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from opencode_mem.ingest.events import event_to_tool_event
+
+
+def test_event_to_tool_event_handles_non_dict_args() -> None:
+    event = {
+        "type": "tool.execute.after",
+        "tool": "bash",
+        "args": ["not", "a", "dict"],
+        "result": "ok",
+    }
+    tool_event = event_to_tool_event(event, max_chars=200)
+    assert tool_event is not None
+    assert tool_event.cwd is None
+    assert tool_event.tool_input == {}
+
+
+def test_event_to_tool_event_uses_cwd_from_dict_args() -> None:
+    event = {
+        "type": "tool.execute.after",
+        "tool": "bash",
+        "args": {"cwd": "/tmp/work"},
+        "result": "ok",
+    }
+    tool_event = event_to_tool_event(event, max_chars=200)
+    assert tool_event is not None
+    assert tool_event.cwd == "/tmp/work"

--- a/tests/test_sync_http_client.py
+++ b/tests/test_sync_http_client.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from opencode_mem.sync import http_client
+
+
+class _ConnRequestFails:
+    def __init__(self, *args, **kwargs) -> None:
+        self.closed = False
+
+    def request(self, method, path, body=None, headers=None) -> None:
+        raise RuntimeError("boom")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _ConnReadFails:
+    def __init__(self, *args, **kwargs) -> None:
+        self.closed = False
+
+    def request(self, method, path, body=None, headers=None) -> None:
+        return
+
+    def getresponse(self):
+        return _RespReadFails()
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RespReadFails:
+    status = 200
+
+    def read(self) -> bytes:
+        raise RuntimeError("read failed")
+
+
+def test_request_json_closes_connection_when_request_raises(monkeypatch) -> None:
+    conn = _ConnRequestFails()
+    monkeypatch.setattr(http_client, "HTTPConnection", lambda *a, **k: conn)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        http_client.request_json("GET", "http://127.0.0.1:7337/v1/status")
+
+    assert conn.closed is True
+
+
+def test_request_json_closes_connection_when_response_read_raises(monkeypatch) -> None:
+    conn = _ConnReadFails()
+    monkeypatch.setattr(http_client, "HTTPConnection", lambda *a, **k: conn)
+
+    with pytest.raises(RuntimeError, match="read failed"):
+        http_client.request_json("GET", "http://127.0.0.1:7337/v1/status")
+
+    assert conn.closed is True

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -448,7 +448,7 @@ def test_sync_pairing_payload(tmp_path: Path, monkeypatch) -> None:
         server.shutdown()
 
 
-def test_sync_attempts_rejects_invalid_limit(tmp_path: Path, monkeypatch) -> None:
+def test_sync_attempts_rejects_invalid_limit_query(tmp_path: Path, monkeypatch) -> None:
     db_path = tmp_path / "mem.sqlite"
     monkeypatch.setenv("OPENCODE_MEM_DB", str(db_path))
     conn = db.connect(db_path)
@@ -477,7 +477,7 @@ def test_sync_attempts_rejects_invalid_limit(tmp_path: Path, monkeypatch) -> Non
         server.shutdown()
 
 
-def test_sync_attempts_clamps_large_limit(tmp_path: Path, monkeypatch) -> None:
+def test_sync_attempts_clamps_large_limit_query(tmp_path: Path, monkeypatch) -> None:
     db_path = tmp_path / "mem.sqlite"
     monkeypatch.setenv("OPENCODE_MEM_DB", str(db_path))
     conn = db.connect(db_path)

--- a/tests/test_viewer_http.py
+++ b/tests/test_viewer_http.py
@@ -106,6 +106,7 @@ def test_reject_cross_origin_blocks_spoofed_loopback_origins() -> None:
         "http://127.0.0.1.evil.test",
         "http://localhost.evil.test",
         "http://127.0.0.1@evil.test",
+        "http://[::1",
         "http://[::1]:bad",
         "http://127.0.0.1/path",
     ]

--- a/tests/test_viewer_routes_raw_events.py
+++ b/tests/test_viewer_routes_raw_events.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+from opencode_mem.viewer_routes import raw_events
+
+
+class DummyHandler:
+    def __init__(self, body: bytes, content_length: int) -> None:
+        self.headers = {"Content-Length": str(content_length)}
+        self.rfile = io.BytesIO(body)
+        self.response: dict[str, Any] | None = None
+        self.status: int | None = None
+
+    def _send_json(self, payload: dict[str, Any], status: int = 200) -> None:
+        self.response = payload
+        self.status = status
+
+
+class DummyFlusher:
+    def __init__(self) -> None:
+        self.noted: list[str] = []
+
+    def note_activity(self, opencode_session_id: str) -> None:
+        self.noted.append(opencode_session_id)
+
+
+class DummyStore:
+    def __init__(self) -> None:
+        self.conn: Any = None
+        self.closed = False
+        self.recorded_batches: list[tuple[str, list[dict[str, Any]]]] = []
+        self.meta_updates: list[dict[str, Any]] = []
+
+    def raw_event_backlog_totals(self) -> dict[str, int]:
+        return {}
+
+    def record_raw_events_batch(
+        self, *, opencode_session_id: str, events: list[dict[str, Any]]
+    ) -> dict[str, int]:
+        self.recorded_batches.append((opencode_session_id, events))
+        return {"inserted": len(events)}
+
+    def update_raw_event_session_meta(
+        self,
+        *,
+        opencode_session_id: str,
+        cwd: str | None,
+        project: str | None,
+        started_at: str | None,
+        last_seen_ts_wall_ms: int | None,
+    ) -> None:
+        self.meta_updates.append(
+            {
+                "opencode_session_id": opencode_session_id,
+                "cwd": cwd,
+                "project": project,
+                "started_at": started_at,
+                "last_seen_ts_wall_ms": last_seen_ts_wall_ms,
+            }
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_handle_post_rejects_oversized_payload(monkeypatch) -> None:
+    payload = {
+        "opencode_session_id": "sess-1",
+        "event_type": "tool.execute.after",
+        "payload": {"tool": "read"},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    handler = DummyHandler(body=body, content_length=len(body))
+    flusher = DummyFlusher()
+    store = DummyStore()
+    store_factory_called = False
+
+    def store_factory(_db_path: str) -> DummyStore:
+        nonlocal store_factory_called
+        store_factory_called = True
+        return store
+
+    monkeypatch.setattr(raw_events, "MAX_RAW_EVENTS_BODY_BYTES", len(body) - 1)
+
+    handled = raw_events.handle_post(
+        handler,
+        path="/api/raw-events",
+        store_factory=store_factory,
+        default_db_path="/tmp/mem.sqlite",
+        flusher=flusher,
+        strip_private_obj=lambda value: value,
+    )
+
+    assert handled is True
+    assert handler.status == 413
+    assert handler.response == {
+        "error": "payload too large",
+        "max_bytes": len(body) - 1,
+    }
+    assert store_factory_called is False
+    assert store.closed is False
+    assert flusher.noted == []
+
+
+def test_handle_post_accepts_payload_within_size_limit(monkeypatch) -> None:
+    payload = {
+        "opencode_session_id": "sess-1",
+        "event_type": "tool.execute.after",
+        "payload": {"tool": "read"},
+        "ts_wall_ms": 123,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    handler = DummyHandler(body=body, content_length=len(body))
+    flusher = DummyFlusher()
+    store = DummyStore()
+
+    def store_factory(_db_path: str) -> DummyStore:
+        return store
+
+    monkeypatch.setattr(raw_events, "MAX_RAW_EVENTS_BODY_BYTES", len(body))
+
+    handled = raw_events.handle_post(
+        handler,
+        path="/api/raw-events",
+        store_factory=store_factory,
+        default_db_path="/tmp/mem.sqlite",
+        flusher=flusher,
+        strip_private_obj=lambda value: value,
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert handler.response == {"inserted": 1, "received": 1}
+    assert store.recorded_batches[0][0] == "sess-1"
+    assert store.recorded_batches[0][1][0]["event_type"] == "tool.execute.after"
+    assert store.meta_updates[0]["last_seen_ts_wall_ms"] == 123
+    assert store.closed is True
+    assert flusher.noted == ["sess-1"]


### PR DESCRIPTION
## Summary
- guarantee sync HTTP client connections close on both success and exception paths
- harden ingest tool-event args handling for malformed payloads
- return consistent internal_error JSON envelope for unexpected GET /v1/ops failures

## Validation
- uv run pytest tests/test_sync_http_client.py tests/test_ingest_events.py tests/test_sync_api.py tests/test_sync_api_security.py tests/test_ingest_tool_events.py

Refs: opencode-mem-azy, opencode-mem-agv, opencode-mem-3qz