### PR TITLE
fix(sync): verify pidfile target before stopping daemon

### DIFF
--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -571,6 +571,7 @@ def test_sync_service_status_uses_pid(monkeypatch) -> None:
     )
     monkeypatch.setattr("codemem.sync_runtime._read_pid", lambda p: 123)
     monkeypatch.setattr("codemem.sync_runtime._pid_running", lambda pid: True)
+    monkeypatch.setattr("codemem.sync_runtime._pid_is_sync_daemon", lambda pid: True)
     monkeypatch.setattr(
         "codemem.cli_app.load_config",
         lambda: type(

--- a/tests/test_sync_runtime.py
+++ b/tests/test_sync_runtime.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import signal
+from pathlib import Path
+
+from codemem import sync_runtime
+
+
+def test_stop_pidfile_does_not_kill_unrelated_process(monkeypatch, tmp_path: Path) -> None:
+    pid_path = tmp_path / "sync.pid"
+    pid_path.write_text("123\n")
+    monkeypatch.setenv("CODEMEM_SYNC_PID", str(pid_path))
+    monkeypatch.setattr(sync_runtime, "_pid_running", lambda pid: True)
+    monkeypatch.setattr(sync_runtime, "_pid_is_sync_daemon", lambda pid: False)
+
+    def _unexpected_kill(pid: int, sig: int) -> None:
+        raise AssertionError("stop_pidfile should not signal unrelated processes")
+
+    monkeypatch.setattr(sync_runtime.os, "kill", _unexpected_kill)
+
+    assert sync_runtime.stop_pidfile() is False
+    assert not pid_path.exists()
+
+
+def test_stop_pidfile_kills_verified_sync_daemon(monkeypatch, tmp_path: Path) -> None:
+    pid_path = tmp_path / "sync.pid"
+    pid_path.write_text("456\n")
+    monkeypatch.setenv("CODEMEM_SYNC_PID", str(pid_path))
+    monkeypatch.setattr(sync_runtime, "_pid_is_sync_daemon", lambda pid: True)
+
+    checks = iter([True, False])
+    monkeypatch.setattr(sync_runtime, "_pid_running", lambda pid: next(checks, False))
+    monkeypatch.setattr(sync_runtime.time, "sleep", lambda _n: None)
+
+    sent: list[tuple[int, int]] = []
+    monkeypatch.setattr(sync_runtime.os, "kill", lambda pid, sig: sent.append((pid, sig)))
+
+    assert sync_runtime.stop_pidfile() is True
+    assert sent == [(456, signal.SIGTERM)]
+    assert not pid_path.exists()
+
+
+def test_effective_status_ignores_pidfile_for_non_sync_process(monkeypatch, tmp_path: Path) -> None:
+    pid_path = tmp_path / "sync.pid"
+    pid_path.write_text("321\n")
+    monkeypatch.setenv("CODEMEM_SYNC_PID", str(pid_path))
+    monkeypatch.setattr(sync_runtime.sys, "platform", "win32")
+    monkeypatch.setattr(sync_runtime, "_port_open", lambda host, port: False)
+    monkeypatch.setattr(sync_runtime, "_pid_running", lambda pid: True)
+    monkeypatch.setattr(sync_runtime, "_pid_is_sync_daemon", lambda pid: False)
+
+    status = sync_runtime.effective_status("127.0.0.1", 7337)
+
+    assert status.running is False
+    assert status.mechanism == "none"
+    assert status.detail == "unsupported"
+
+
+def test_pid_command_missing_ps_returns_none(monkeypatch) -> None:
+    def _missing_ps(*_args, **_kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(sync_runtime.subprocess, "run", _missing_ps)
+
+    assert sync_runtime._pid_command(123) is None


### PR DESCRIPTION
## Description
Harden pidfile-based sync daemon detection and shutdown so reused/stale PID files do not target unrelated processes. The runtime now verifies process identity before reporting/running pidfile actions and safely handles systems where `ps` is unavailable.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `uv run pytest --cov=codemem --cov-report=xml --cov-report=term`
- `uv run pytest tests/test_sync_runtime.py tests/test_sync_cli.py -k "sync_runtime or sync_stop_falls_back_to_pid or sync_disable_stops_pid_when_no_service"`
- `uv run ruff check codemem/sync_runtime.py tests/test_sync_runtime.py tests/test_sync_cli.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
