### PR TITLE
perf(db): avoid repeated schema migration writes

### DIFF
--- a/codemem/store/replication.py
+++ b/codemem/store/replication.py
@@ -19,6 +19,13 @@ LEGACY_IMPORT_KEY_OLD_RE = re.compile(r"^legacy:memory_item:(\d+)$")
 LEGACY_IMPORT_KEY_NEW_RE = re.compile(r"^legacy:([^:]+):memory_item:(\d+)$")
 
 
+def _normalize_memory_kind(value: Any) -> str:
+    kind = str(value or "")
+    if kind.strip().lower() == "project":
+        return "decision"
+    return kind
+
+
 def _effective_sync_project_filters(
     store: MemoryStore, *, peer_device_id: str | None = None
 ) -> tuple[list[str], list[str]]:
@@ -1046,7 +1053,7 @@ def _apply_memory_item_upsert(store: MemoryStore, op: ReplicationOp) -> str:
     _ensure_session_for_replication(store, int(session_id), created_at, project=project)
     values = (
         int(session_id),
-        str(payload.get("kind") or ""),
+        _normalize_memory_kind(payload.get("kind")),
         str(payload.get("title") or ""),
         str(payload.get("body_text") or ""),
         float(payload.get("confidence") or 0.5),
@@ -1200,7 +1207,7 @@ def _apply_memory_item_delete(store: MemoryStore, op: ReplicationOp) -> str:
             """,
             (
                 int(session_id),
-                str(payload.get("kind") or ""),
+                _normalize_memory_kind(payload.get("kind")),
                 str(payload.get("title") or ""),
                 str(payload.get("body_text") or ""),
                 float(payload.get("confidence") or 0.5),

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codemem import db
+
+
+def test_initialize_schema_sets_user_version(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CODEMEM_EMBEDDING_DISABLED", "1")
+    conn = db.connect(tmp_path / "mem.sqlite")
+    try:
+        db.initialize_schema(conn)
+        row = conn.execute("PRAGMA user_version").fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert int(row[0]) == db.SCHEMA_VERSION
+
+
+def test_initialize_schema_skips_reinit_but_keeps_kind_normalization(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CODEMEM_EMBEDDING_DISABLED", "1")
+    conn = db.connect(tmp_path / "mem.sqlite")
+    try:
+        db.initialize_schema(conn)
+
+        conn.execute(
+            """
+            INSERT INTO sessions(started_at, cwd, project, user, tool_version)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            ("2026-01-01T00:00:00Z", "/tmp", "proj", "me", "test"),
+        )
+        session_id = int(conn.execute("SELECT id FROM sessions").fetchone()[0])
+        conn.execute(
+            """
+            INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (session_id, "project", "t", "b", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z"),
+        )
+        conn.commit()
+
+        def _unexpected_reinit(_conn):
+            raise AssertionError(
+                "initialize_schema should not rerun full migration at current version"
+            )
+
+        monkeypatch.setattr(db, "_initialize_schema_v1", _unexpected_reinit)
+        db.initialize_schema(conn)
+
+        kind = conn.execute("SELECT kind FROM memory_items LIMIT 1").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert kind == "decision"


### PR DESCRIPTION
## Description
Avoid repeated schema migration writes on every startup by gating one-time migration work behind `PRAGMA user_version`. This preserves the existing schema setup behavior while skipping unnecessary startup writes after initial migration.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `uv run pytest tests/test_db_schema.py tests/test_db_paths.py`
- `uv run ruff check codemem/db.py tests/test_db_schema.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
