### PR TITLE
docs(plugin): document valid opencode plugin key format

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,18 @@ Restart OpenCode and the MCP tools will be available to the model.
 
 Add `@kunickiaj/codemem` to your OpenCode plugin config, then restart OpenCode.
 
-**Git fallback one-liner** (requires SSH access to the repo):
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@kunickiaj/codemem"]
+}
+```
+
+Notes:
+- The key is `plugin` (singular). `plugins` is rejected as an unknown key.
+- To pin a specific plugin release, use `"@kunickiaj/codemem@0.9.20"`.
+
+**Git fallback one-liner** (advanced):
 
 ```bash
 uvx --from git+ssh://git@github.com/kunickiaj/codemem.git codemem install-plugin


### PR DESCRIPTION
## Description
Document the verified OpenCode npm plugin config format in README. The docs now use `plugin` (singular), note that `plugins` is invalid, and show version-pin syntax for `@kunickiaj/codemem`.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Manual verification:
- OpenCode accepts `plugin: ["@kunickiaj/codemem"]` in `opencode.jsonc`
- OpenCode rejects `plugins` as an unknown key
- OpenCode resolves pinned plugin form `@kunickiaj/codemem@0.9.20`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
