### PR TITLE
feat(reliability): add raw-events baseline metrics gate

### DIFF
--- a/codemem/commands/raw_events_cmds.py
+++ b/codemem/commands/raw_events_cmds.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typer
 from rich import print
 
 from codemem.store import MemoryStore
@@ -73,3 +74,71 @@ def raw_events_retry_cmd(
             max_events=None,
         )
         print(f"Retried batch {batch['id']} -> flushed {result['flushed']} events")
+
+
+def raw_events_gate_cmd(
+    store: MemoryStore,
+    *,
+    min_flush_success_rate: float,
+    max_dropped_event_rate: float,
+    min_session_boundary_accuracy: float,
+    max_retry_depth: int,
+    min_events: int,
+    min_batches: int,
+    min_sessions: int,
+    window_hours: float,
+) -> None:
+    """Validate reliability baseline thresholds and fail on violation."""
+
+    metrics = store.raw_event_reliability_metrics(window_hours=window_hours)
+    rates = metrics.get("rates", {})
+    flush_success_rate = float(rates.get("flush_success_rate", 1.0) or 0.0)
+    dropped_event_rate = float(rates.get("dropped_event_rate", 0.0) or 0.0)
+    session_boundary_accuracy = float(rates.get("session_boundary_accuracy", 1.0) or 0.0)
+    retry_depth_max = int(metrics.get("retry_depth_max", 0) or 0)
+    counts = metrics.get("counts", {})
+    processed_events = int(
+        (counts.get("inserted_events", 0) or 0) + (counts.get("dropped_events", 0) or 0)
+    )
+    total_batches = int(counts.get("terminal_batches", 0) or 0)
+    sessions_with_events = int(counts.get("sessions_with_events", 0) or 0)
+
+    failures: list[str] = []
+    if processed_events < min_events:
+        failures.append(f"eligible_events={processed_events} < min {min_events}")
+    if total_batches < min_batches:
+        failures.append(f"terminal_batches={total_batches} < min {min_batches}")
+    if sessions_with_events < min_sessions:
+        failures.append(f"sessions_with_events={sessions_with_events} < min {min_sessions}")
+    if flush_success_rate < min_flush_success_rate:
+        failures.append(
+            f"flush_success_rate={flush_success_rate:.4f} < min {min_flush_success_rate:.4f}"
+        )
+    if dropped_event_rate > max_dropped_event_rate:
+        failures.append(
+            f"dropped_event_rate={dropped_event_rate:.4f} > max {max_dropped_event_rate:.4f}"
+        )
+    if session_boundary_accuracy < min_session_boundary_accuracy:
+        failures.append(
+            f"session_boundary_accuracy={session_boundary_accuracy:.4f} < min {min_session_boundary_accuracy:.4f}"
+        )
+    if retry_depth_max > max_retry_depth:
+        failures.append(f"retry_depth_max={retry_depth_max} > max {max_retry_depth}")
+
+    print(
+        "reliability gate: "
+        f"flush_success_rate={flush_success_rate:.4f}, "
+        f"dropped_event_rate={dropped_event_rate:.4f}, "
+        f"session_boundary_accuracy={session_boundary_accuracy:.4f}, "
+        f"retry_depth_max={retry_depth_max}, "
+        f"eligible_events={processed_events}, "
+        f"terminal_batches={total_batches}, "
+        f"sessions_with_events={sessions_with_events}, "
+        f"window_hours={window_hours:.2f}"
+    )
+    if failures:
+        print("[red]reliability gate failed[/red]")
+        for failure in failures:
+            print(f"- {failure}")
+        raise typer.Exit(code=1)
+    print("[green]reliability gate passed[/green]")

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -643,6 +643,13 @@ class MemoryStore:
             limit=limit,
         )
 
+    def raw_event_reliability_metrics(self, *, window_hours: float | None = None) -> dict[str, Any]:
+        if window_hours is None:
+            return store_raw_events.raw_event_reliability_metrics(self.conn)
+        return store_raw_events.raw_event_reliability_metrics_windowed(
+            self.conn, window_hours=window_hours
+        )
+
     def mark_stuck_raw_event_batches_as_error(
         self,
         *,

--- a/codemem/store/usage.py
+++ b/codemem/store/usage.py
@@ -270,4 +270,5 @@ def stats(store: MemoryStore) -> dict[str, Any]:
             "raw_events": raw_events,
         },
         "usage": usage,
+        "reliability": store.raw_event_reliability_metrics(),
     }

--- a/tests/test_raw_events_gate.py
+++ b/tests/test_raw_events_gate.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from codemem.cli import app
+from codemem.store import MemoryStore
+
+runner = CliRunner()
+
+
+def _seed_reliability_fixture(store: MemoryStore) -> None:
+    now = dt.datetime.now(dt.UTC).isoformat()
+    store.conn.execute(
+        """
+        INSERT INTO raw_event_sessions(opencode_session_id, project, started_at, updated_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        ("sess-a", "proj-a", now, now),
+    )
+    store.conn.execute(
+        """
+        INSERT INTO raw_event_sessions(opencode_session_id, project, started_at, updated_at)
+        VALUES (?, ?, ?, ?)
+        """,
+        ("sess-b", "proj-b", None, now),
+    )
+    store.conn.execute(
+        """
+        INSERT INTO raw_events(
+            opencode_session_id,
+            event_id,
+            event_seq,
+            event_type,
+            ts_wall_ms,
+            ts_mono_ms,
+            payload_json,
+            created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("sess-a", "evt-a-1", 0, "user_prompt", 1, 1.0, "{}", now),
+    )
+    store.conn.execute(
+        """
+        INSERT INTO raw_events(
+            opencode_session_id,
+            event_id,
+            event_seq,
+            event_type,
+            ts_wall_ms,
+            ts_mono_ms,
+            payload_json,
+            created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("sess-b", "evt-b-1", 0, "user_prompt", 2, 2.0, "{}", now),
+    )
+
+    store.conn.execute(
+        """
+        INSERT INTO raw_event_ingest_stats(
+            id,
+            inserted_events,
+            skipped_events,
+            skipped_invalid,
+            skipped_duplicate,
+            skipped_conflict,
+            updated_at
+        )
+        VALUES (1, 90, 10, 10, 0, 0, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            inserted_events = excluded.inserted_events,
+            skipped_events = excluded.skipped_events,
+            skipped_invalid = excluded.skipped_invalid,
+            skipped_duplicate = excluded.skipped_duplicate,
+            skipped_conflict = excluded.skipped_conflict,
+            updated_at = excluded.updated_at
+        """,
+        (now,),
+    )
+    store.conn.execute(
+        """
+        INSERT INTO raw_event_ingest_samples(
+            created_at,
+            inserted_events,
+            skipped_invalid,
+            skipped_duplicate,
+            skipped_conflict
+        )
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (now, 90, 10, 0, 0),
+    )
+    for i in range(9):
+        store.conn.execute(
+            """
+            INSERT INTO raw_event_flush_batches(
+                opencode_session_id,
+                start_event_seq,
+                end_event_seq,
+                extractor_version,
+                status,
+                created_at,
+                updated_at,
+                attempt_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("sess-a", i, i, "v1", "completed", now, now, 1),
+        )
+    store.conn.execute(
+        """
+        INSERT INTO raw_event_flush_batches(
+            opencode_session_id,
+            start_event_seq,
+            end_event_seq,
+            extractor_version,
+            status,
+            created_at,
+            updated_at,
+            attempt_count
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("sess-a", 10, 10, "v1", "error", now, now, 2),
+    )
+    store.conn.commit()
+
+
+def test_raw_event_reliability_metrics_formula_values(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        _seed_reliability_fixture(store)
+        metrics = store.raw_event_reliability_metrics(window_hours=24)
+    finally:
+        store.close()
+
+    assert metrics["rates"]["flush_success_rate"] == 0.9
+    assert metrics["rates"]["dropped_event_rate"] == 0.1
+    assert metrics["rates"]["session_boundary_accuracy"] == 0.5
+    assert metrics["retry_depth_max"] == 1
+
+
+def test_store_stats_includes_reliability_block(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        _seed_reliability_fixture(store)
+        payload = store.stats()
+    finally:
+        store.close()
+
+    assert "reliability" in payload
+    assert "formulas" in payload["reliability"]
+
+
+def test_raw_events_gate_exits_nonzero_on_threshold_violation(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    try:
+        _seed_reliability_fixture(store)
+    finally:
+        store.close()
+
+    result = runner.invoke(
+        app,
+        [
+            "raw-events-gate",
+            "--db-path",
+            str(db_path),
+            "--min-flush-success-rate",
+            "0.95",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "reliability gate failed" in result.stdout
+
+
+def test_raw_events_gate_passes_on_empty_database(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    store.close()
+
+    result = runner.invoke(app, ["raw-events-gate", "--db-path", str(db_path)])
+
+    assert result.exit_code == 1
+    assert "eligible_events=0 < min 1" in result.stdout
+
+
+def test_raw_events_gate_can_allow_empty_sample_when_requested(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    store.close()
+
+    result = runner.invoke(
+        app,
+        [
+            "raw-events-gate",
+            "--db-path",
+            str(db_path),
+            "--min-events",
+            "0",
+            "--min-batches",
+            "0",
+            "--min-sessions",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "reliability gate passed" in result.stdout
+
+
+def test_duplicate_replay_does_not_increase_dropped_rate(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        assert (
+            store.record_raw_event(
+                opencode_session_id="sess",
+                event_id="evt-1",
+                event_type="user_prompt",
+                payload={"type": "user_prompt", "prompt_text": "hello"},
+                ts_wall_ms=1,
+                ts_mono_ms=1.0,
+            )
+            is True
+        )
+        assert (
+            store.record_raw_event(
+                opencode_session_id="sess",
+                event_id="evt-1",
+                event_type="user_prompt",
+                payload={"type": "user_prompt", "prompt_text": "hello"},
+                ts_wall_ms=2,
+                ts_mono_ms=2.0,
+            )
+            is False
+        )
+        metrics = store.raw_event_reliability_metrics()
+    finally:
+        store.close()
+
+    assert metrics["counts"]["inserted_events"] == 1
+    assert metrics["counts"]["skipped_duplicate"] == 1
+    assert metrics["counts"]["dropped_events"] == 0
+    assert metrics["rates"]["dropped_event_rate"] == 0.0
+
+
+def test_raw_events_gate_rejects_invalid_threshold_args(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    store.close()
+
+    result = runner.invoke(
+        app,
+        ["raw-events-gate", "--db-path", str(db_path), "--min-flush-success-rate", "1.5"],
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid value" in result.stderr


### PR DESCRIPTION
## Description
Add a baseline reliability gate for raw-event ingestion and flush behavior with explicit formulas and threshold enforcement.

This PR adds:
- persisted reliability counters with reasoned skip buckets
- rolling-window reliability calculations for gate checks
- a new CLI command: `codemem raw-events-gate`
- schema updates for ingest samples and flush attempt counts
- tests for formulas, threshold failures, anti-gaming behavior, and CLI validation

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `uv run pytest tests/test_raw_events_gate.py tests/test_db_schema.py tests/test_raw_event_flush.py tests/test_raw_event_retry.py`
- `uv run ruff check codemem/db.py codemem/store/raw_events.py codemem/store/_store.py codemem/store/usage.py codemem/commands/raw_events_cmds.py codemem/cli_app.py tests/test_raw_events_gate.py tests/test_db_schema.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
