### PR TITLE
ci: run pull_request workflow for stacked PR targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+
   workflow_call:
 
 jobs:


### PR DESCRIPTION
## Description
Ensure CI runs for stacked PRs whose base branch is not `main`.

This updates workflow triggers so the `CI` workflow runs on all `pull_request` events, not only PRs targeting `main`.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Manual verification:
- Confirmed `.github/workflows/ci.yml` no longer restricts `pull_request` to `branches: [main]`.
- This allows CI checks to run for upstack PRs in Graphite stacks.

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
