### PR TITLE
refactor(raw-events): tighten route and flush ownership boundaries

### DIFF
--- a/codemem/viewer.py
+++ b/codemem/viewer.py
@@ -6,7 +6,7 @@ import socket
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 from . import viewer_assets, viewer_raw_events
 from .config import load_config  # noqa: F401
@@ -113,16 +113,6 @@ class ViewerHandler(BaseHTTPRequestHandler):
             if viewer_routes_stats.handle_get(self, store, parsed.path, parsed.query):
                 return
             if viewer_routes_raw_events.handle_get(self, store, parsed.path, parsed.query):
-                return
-            if parsed.path == "/api/raw-events/status":
-                params = parse_qs(parsed.query)
-                limit = int(params.get("limit", ["25"])[0])
-                self._send_json(
-                    {
-                        "items": store.raw_event_backlog(limit=limit),
-                        "totals": store.raw_event_backlog_totals(),
-                    }
-                )
                 return
             if viewer_routes_memory.handle_get(self, store, parsed.path, parsed.query):
                 return

--- a/codemem/viewer_raw_events.py
+++ b/codemem/viewer_raw_events.py
@@ -8,7 +8,7 @@ import threading
 import time
 
 from .db import DEFAULT_DB_PATH
-from .raw_event_flush import flush_raw_events  # noqa: F401
+from .raw_event_flush import flush_raw_events
 from .store import MemoryStore
 
 logger = logging.getLogger(__name__)
@@ -61,9 +61,7 @@ class RawEventAutoFlusher:
         try:
             store = MemoryStore(os.environ.get("CODEMEM_DB") or DEFAULT_DB_PATH)
             try:
-                from . import viewer as _viewer
-
-                _viewer.flush_raw_events(
+                flush_raw_events(
                     store,
                     opencode_session_id=opencode_session_id,
                     cwd=None,
@@ -150,9 +148,7 @@ class RawEventSweeper:
             )
             for opencode_session_id in session_ids:
                 try:
-                    from . import viewer as _viewer
-
-                    _viewer.flush_raw_events(
+                    flush_raw_events(
                         store,
                         opencode_session_id=opencode_session_id,
                         cwd=None,

--- a/tests/test_raw_event_sweeper.py
+++ b/tests/test_raw_event_sweeper.py
@@ -49,7 +49,7 @@ def test_raw_event_sweeper_flushes_idle_sessions(monkeypatch, tmp_path: Path) ->
         store.close()
 
     sweeper = RawEventSweeper()
-    with patch("codemem.viewer.flush_raw_events") as flush:
+    with patch("codemem.viewer_raw_events.flush_raw_events") as flush:
         sweeper.tick()
         flush.assert_called_once()
 


### PR DESCRIPTION
## Description
Reduce raw-event ownership ambiguity by consolidating route responsibilities and isolating flush execution failures from ingest success.

This PR:
- moves `/api/raw-events/status` handling into `viewer_routes/raw_events.py`
- removes `viewer` module indirection from `viewer_raw_events.py` (direct `flush_raw_events` call)
- hardens ingest request boundaries (`Content-Length` validation)
- prevents flusher failures from turning successful ingest writes into 500 responses
- adds route/sweeper conformance tests for the new ownership boundaries

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `uv run pytest tests/test_viewer_routes_raw_events.py tests/test_raw_event_sweeper.py tests/test_viewer_raw_events.py`
- `uv run ruff check codemem/viewer_routes/raw_events.py codemem/viewer.py codemem/viewer_raw_events.py tests/test_viewer_routes_raw_events.py tests/test_raw_event_sweeper.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
