### PR TITLE
feat(queue): add canonical durable claim-state model

### DIFF
--- a/codemem/commands/raw_events_cmds.py
+++ b/codemem/commands/raw_events_cmds.py
@@ -38,11 +38,13 @@ def raw_events_status_cmd(store: MemoryStore, *, limit: int) -> None:
         print("No pending raw events")
         return
     for item in items:
-        counts = store.raw_event_batch_status_counts(item["opencode_session_id"])
+        legacy_counts = store.raw_event_batch_status_counts(item["opencode_session_id"])
+        queue_counts = store.raw_event_queue_status_counts(item["opencode_session_id"])
         print(
             f"- {item['opencode_session_id']} pending={item['pending']} "
             f"max_seq={item['max_seq']} last_flushed={item['last_flushed_event_seq']} "
-            f"batches=started:{counts['started']} running:{counts['running']} error:{counts['error']} completed:{counts['completed']} "
+            f"batches=started:{legacy_counts['started']} running:{legacy_counts['running']} error:{legacy_counts['error']} completed:{legacy_counts['completed']} "
+            f"queue=pending:{queue_counts['pending']} claimed:{queue_counts['claimed']} failed:{queue_counts['failed']} done:{queue_counts['completed']} "
             f"project={item.get('project') or ''}"
         )
 

--- a/codemem/raw_event_flush.py
+++ b/codemem/raw_event_flush.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from .plugin_ingest import ingest
 from .store import MemoryStore
+from .store.raw_events import RAW_EVENT_QUEUE_FAILED
 
 EXTRACTOR_VERSION = "raw_events_v1"
 
@@ -152,7 +153,7 @@ def flush_raw_events(
     try:
         ingest(payload)
     except Exception:
-        store.update_raw_event_flush_batch_status(batch_id, "error")
+        store.update_raw_event_flush_batch_status(batch_id, RAW_EVENT_QUEUE_FAILED)
         raise
     store.update_raw_event_flush_batch_status(batch_id, "completed")
     store.update_raw_event_flush_state(opencode_session_id, last_event_seq)

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -631,6 +631,9 @@ class MemoryStore:
     def raw_event_batch_status_counts(self, opencode_session_id: str) -> dict[str, int]:
         return store_raw_events.raw_event_batch_status_counts(self.conn, opencode_session_id)
 
+    def raw_event_queue_status_counts(self, opencode_session_id: str) -> dict[str, int]:
+        return store_raw_events.raw_event_queue_status_counts(self.conn, opencode_session_id)
+
     def claim_raw_event_flush_batch(self, batch_id: int) -> bool:
         return store_raw_events.claim_raw_event_flush_batch(self.conn, batch_id)
 

--- a/tests/test_raw_event_flush.py
+++ b/tests/test_raw_event_flush.py
@@ -215,4 +215,4 @@ def test_flush_raw_events_marks_batch_error_when_observer_fails(tmp_path: Path) 
         ("sess", EXTRACTOR_VERSION),
     ).fetchone()
     assert row is not None
-    assert row["status"] == "error"
+    assert row["status"] == "failed"

--- a/tests/test_raw_event_queue_states.py
+++ b/tests/test_raw_event_queue_states.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+from codemem.store import MemoryStore
+
+
+def test_raw_event_queue_status_counts_maps_legacy_states(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        now = dt.datetime.now(dt.UTC).isoformat()
+        rows = [
+            ("started", 0),
+            ("running", 1),
+            ("completed", 2),
+            ("error", 3),
+        ]
+        for status, seq in rows:
+            store.conn.execute(
+                """
+                INSERT INTO raw_event_flush_batches(
+                    opencode_session_id,
+                    start_event_seq,
+                    end_event_seq,
+                    extractor_version,
+                    status,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("sess", seq, seq, "v1", status, now, now),
+            )
+        store.conn.commit()
+
+        counts = store.raw_event_queue_status_counts("sess")
+    finally:
+        store.close()
+
+    assert counts == {"pending": 1, "claimed": 1, "completed": 1, "failed": 1}
+
+
+def test_raw_event_batch_status_counts_handles_canonical_states(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        now = dt.datetime.now(dt.UTC).isoformat()
+        rows = [
+            ("pending", 0),
+            ("claimed", 1),
+            ("completed", 2),
+            ("failed", 3),
+        ]
+        for status, seq in rows:
+            store.conn.execute(
+                """
+                INSERT INTO raw_event_flush_batches(
+                    opencode_session_id,
+                    start_event_seq,
+                    end_event_seq,
+                    extractor_version,
+                    status,
+                    created_at,
+                    updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("sess", seq, seq, "v1", status, now, now),
+            )
+        store.conn.commit()
+
+        legacy_counts = store.raw_event_batch_status_counts("sess")
+        canonical_counts = store.raw_event_queue_status_counts("sess")
+    finally:
+        store.close()
+
+    assert legacy_counts == {"started": 1, "running": 1, "completed": 1, "error": 1}
+    assert canonical_counts == {"pending": 1, "claimed": 1, "completed": 1, "failed": 1}
+
+
+def test_raw_event_flush_batch_claim_is_single_owner(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        batch_id, _status = store.get_or_create_raw_event_flush_batch(
+            opencode_session_id="sess",
+            start_event_seq=0,
+            end_event_seq=1,
+            extractor_version="v1",
+        )
+
+        first_claim = store.claim_raw_event_flush_batch(batch_id)
+        second_claim = store.claim_raw_event_flush_batch(batch_id)
+
+        row = store.conn.execute(
+            "SELECT status, attempt_count FROM raw_event_flush_batches WHERE id = ?",
+            (batch_id,),
+        ).fetchone()
+    finally:
+        store.close()
+
+    assert first_claim is True
+    assert second_claim is False
+    assert row is not None
+    assert row["status"] == "claimed"
+    assert int(row["attempt_count"]) == 1
+
+
+def test_raw_event_failed_batch_is_recoverable_by_reclaim(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        batch_id, _status = store.get_or_create_raw_event_flush_batch(
+            opencode_session_id="sess",
+            start_event_seq=5,
+            end_event_seq=6,
+            extractor_version="v1",
+        )
+        assert store.claim_raw_event_flush_batch(batch_id) is True
+        store.update_raw_event_flush_batch_status(batch_id, "error")
+
+        reclaimed = store.claim_raw_event_flush_batch(batch_id)
+        row = store.conn.execute(
+            "SELECT status, attempt_count FROM raw_event_flush_batches WHERE id = ?",
+            (batch_id,),
+        ).fetchone()
+    finally:
+        store.close()
+
+    assert reclaimed is True
+    assert row is not None
+    assert row["status"] == "claimed"
+    assert int(row["attempt_count"]) == 2
+
+
+def test_raw_event_failed_canonical_batch_is_recoverable_by_reclaim(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        now = dt.datetime.now(dt.UTC).isoformat()
+        store.conn.execute(
+            """
+            INSERT INTO raw_event_flush_batches(
+                opencode_session_id,
+                start_event_seq,
+                end_event_seq,
+                extractor_version,
+                status,
+                created_at,
+                updated_at,
+                attempt_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("sess", 10, 11, "v1", "failed", now, now, 1),
+        )
+        batch_id = int(store.conn.execute("SELECT id FROM raw_event_flush_batches").fetchone()[0])
+        store.conn.commit()
+
+        reclaimed = store.claim_raw_event_flush_batch(batch_id)
+        row = store.conn.execute(
+            "SELECT status, attempt_count FROM raw_event_flush_batches WHERE id = ?",
+            (batch_id,),
+        ).fetchone()
+    finally:
+        store.close()
+
+    assert reclaimed is True
+    assert row is not None
+    assert row["status"] == "claimed"
+    assert int(row["attempt_count"]) == 2

--- a/tests/test_raw_event_stuck_batches.py
+++ b/tests/test_raw_event_stuck_batches.py
@@ -54,5 +54,5 @@ def test_mark_stuck_raw_event_batches_as_error(tmp_path: Path) -> None:
             "SELECT start_event_seq, status FROM raw_event_flush_batches ORDER BY start_event_seq"
         ).fetchall()
     }
-    assert statuses[0] == "error"
+    assert statuses[0] == "failed"
     assert statuses[2] == "started"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2021,7 +2021,7 @@ def test_get_or_create_raw_event_flush_batch_is_idempotent(tmp_path: Path) -> No
         end_event_seq=2,
         extractor_version="v1",
     )
-    assert status == "started"
+    assert status == "pending"
     batch_id2, status2 = store.get_or_create_raw_event_flush_batch(
         opencode_session_id="sess",
         start_event_seq=0,
@@ -2029,7 +2029,7 @@ def test_get_or_create_raw_event_flush_batch_is_idempotent(tmp_path: Path) -> No
         extractor_version="v1",
     )
     assert batch_id2 == batch_id
-    assert status2 == "started"
+    assert status2 == "pending"
 
 
 def test_raw_event_backlog(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description
Add a canonical durable queue state model for raw-event batch processing while preserving compatibility for legacy status values.

This PR introduces canonical states:
- `pending`
- `claimed`
- `completed`
- `failed`

Compatibility behavior:
- mixed legacy and canonical status rows are supported for claims, counts, and retries
- legacy-facing status outputs remain stable where expected

Additional reliability updates:
- flush failure writes canonical `failed`
- reclaim paths support both legacy and canonical failed states
- queue status reporting includes canonical counts alongside legacy-compatible batch summaries

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `uv run pytest tests/test_raw_event_queue_states.py tests/test_raw_event_flush.py tests/test_raw_event_retry.py tests/test_raw_event_stuck_batches.py tests/test_raw_events_gate.py`
- `uv run ruff check codemem/store/raw_events.py codemem/store/_store.py codemem/commands/raw_events_cmds.py codemem/raw_event_flush.py tests/test_raw_event_queue_states.py tests/test_raw_event_stuck_batches.py tests/test_raw_event_flush.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
