### PR TITLE
feat(worker): drain persisted queue during idle sweeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,6 @@ When OpenCode starts, the plugin loads and:
 | `CODEMEM_OBSERVER_MODEL` | Override observer model (default `gpt-5.1-codex-mini` or `claude-4.5-haiku`). |
 | `CODEMEM_OBSERVER_API_KEY` | API key for observer model (optional). |
 | `CODEMEM_OBSERVER_MAX_CHARS` | Max observer prompt characters (default `12000`). |
-| `CODEMEM_ENABLE_CLI_INGEST` | Set to `1` to allow the plugin to spawn `codemem ingest` (legacy path). Default is stream-only. |
 | `CODEMEM_RAW_EVENTS_AUTO_FLUSH` | Set to `1` to enable viewer-side debounced flushing of streamed raw events (default off). |
 | `CODEMEM_RAW_EVENTS_DEBOUNCE_MS` | Debounce delay before auto-flush per session (default `60000`). |
 | `CODEMEM_RAW_EVENTS_SWEEPER` | Set to `1` to enable periodic sweeper flush for idle sessions (default off). |
@@ -454,7 +453,6 @@ If you want maximum reliability ("stream now, flush later"), run stream-only and
 Important: stream-only requires the viewer to be running and reachable. If the plugin cannot POST to the viewer, it will log an error and events may be dropped.
 
 ```bash
-export CODEMEM_ENABLE_CLI_INGEST=0
 export CODEMEM_RAW_EVENTS_AUTO_FLUSH=1
 export CODEMEM_RAW_EVENTS_DEBOUNCE_MS=60000
 export CODEMEM_RAW_EVENTS_SWEEPER=1

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -616,6 +616,9 @@ class MemoryStore:
             limit=limit,
         )
 
+    def raw_event_sessions_with_pending_queue(self, *, limit: int = 25) -> list[str]:
+        return store_raw_events.raw_event_sessions_with_pending_queue(self.conn, limit=limit)
+
     def purge_raw_events_before(self, cutoff_ts_wall_ms: int) -> int:
         return store_raw_events.purge_raw_events_before(self.conn, cutoff_ts_wall_ms)
 

--- a/codemem/store/raw_events.py
+++ b/codemem/store/raw_events.py
@@ -676,6 +676,24 @@ def raw_event_sessions_pending_idle_flush(
     return [str(row["opencode_session_id"]) for row in rows if row["opencode_session_id"]]
 
 
+def raw_event_sessions_with_pending_queue(
+    conn: sqlite3.Connection,
+    *,
+    limit: int = 25,
+) -> list[str]:
+    rows = conn.execute(
+        """
+        SELECT DISTINCT b.opencode_session_id
+        FROM raw_event_flush_batches b
+        WHERE b.status IN ('pending', 'failed', 'started', 'error')
+        ORDER BY b.updated_at ASC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    return [str(row["opencode_session_id"]) for row in rows if row["opencode_session_id"]]
+
+
 def purge_raw_events_before(conn: sqlite3.Connection, cutoff_ts_wall_ms: int) -> int:
     cutoff_iso = dt.datetime.fromtimestamp(cutoff_ts_wall_ms / 1000.0, tz=dt.UTC).isoformat()
     conn.execute(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,8 +2,8 @@
 
 ## Overview
 - **CLI (`codemem`)** runs ingestion, MCP server, viewer, and export/import.
-- **Plugin** captures OpenCode events and posts them to `codemem ingest`.
-- **Ingest pipeline** builds transcript from events, calls the observer, and writes memories.
+- **Plugin** captures OpenCode events and streams raw events to the viewer HTTP API.
+- **Ingest pipeline** flushes queued raw events, builds transcript, calls the observer, and writes memories.
 - **Observer** returns typed observations and a session summary.
 - **Store** persists sessions, memories, and artifacts in SQLite.
 - **Viewer** serves a static HTML dashboard backed by JSON APIs.
@@ -11,8 +11,8 @@
 
 ## Data flow
 1. Plugin collects events during an OpenCode session (user prompts, assistant messages, tool calls).
-2. Plugin flushes events to `codemem ingest` based on adaptive strategy.
-3. Ingest builds transcript from user_prompt/assistant_message events.
+2. Plugin streams raw events to `/api/raw-events` on the viewer.
+3. Python-side flush workers drain queued raw events and run ingest/observer.
 4. Observer creates observations + summary from transcript and tool events.
 5. Store writes artifacts (transcript, pre/post context), observations, and session summary.
 6. Viewer and MCP server read from SQLite.

--- a/tests/test_raw_event_sweeper.py
+++ b/tests/test_raw_event_sweeper.py
@@ -165,3 +165,116 @@ def test_raw_event_sweeper_prioritizes_persisted_queue(monkeypatch, tmp_path: Pa
     kwargs = flush.call_args.kwargs
     assert kwargs["opencode_session_id"] == "sess-queued"
     assert kwargs["max_events"] == 7
+
+
+def test_raw_event_sweeper_skips_stale_queue_sessions_without_backlog(
+    monkeypatch, tmp_path: Path
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    monkeypatch.setenv("CODEMEM_RAW_EVENTS_SWEEPER", "1")
+    monkeypatch.setenv("CODEMEM_RAW_EVENTS_SWEEPER_IDLE_MS", "999999999")
+    monkeypatch.setenv("CODEMEM_RAW_EVENTS_SWEEPER_LIMIT", "1")
+    monkeypatch.setenv("CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS", "7")
+
+    store = MemoryStore(db_path)
+    try:
+        now_ms = int(time.time() * 1000)
+
+        store.record_raw_event(
+            opencode_session_id="sess-stale",
+            event_id="evt-stale-0",
+            event_type="user_prompt",
+            payload={"type": "user_prompt", "prompt_text": "stale"},
+            ts_wall_ms=now_ms,
+            ts_mono_ms=1.0,
+        )
+        store.update_raw_event_session_meta(
+            opencode_session_id="sess-stale",
+            cwd=str(tmp_path),
+            project="test-project",
+            started_at="2026-01-01T00:00:00Z",
+            last_seen_ts_wall_ms=now_ms,
+        )
+        store.update_raw_event_flush_state("sess-stale", 0)
+
+        store.record_raw_event(
+            opencode_session_id="sess-real",
+            event_id="evt-real-0",
+            event_type="user_prompt",
+            payload={"type": "user_prompt", "prompt_text": "real"},
+            ts_wall_ms=now_ms + 1,
+            ts_mono_ms=2.0,
+        )
+        store.record_raw_event(
+            opencode_session_id="sess-real",
+            event_id="evt-real-1",
+            event_type="tool.execute.after",
+            payload={"type": "tool.execute.after", "tool": "read", "args": {"filePath": "x"}},
+            ts_wall_ms=now_ms + 2,
+            ts_mono_ms=3.0,
+        )
+        store.update_raw_event_session_meta(
+            opencode_session_id="sess-real",
+            cwd=str(tmp_path),
+            project="test-project",
+            started_at="2026-01-01T00:00:00Z",
+            last_seen_ts_wall_ms=now_ms,
+        )
+
+        store.conn.execute(
+            """
+            INSERT INTO raw_event_flush_batches(
+                opencode_session_id,
+                start_event_seq,
+                end_event_seq,
+                extractor_version,
+                status,
+                created_at,
+                updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "sess-stale",
+                0,
+                0,
+                "raw_events_v1",
+                "pending",
+                "2026-01-01T00:00:00+00:00",
+                "2026-01-01T00:00:00+00:00",
+            ),
+        )
+        store.conn.execute(
+            """
+            INSERT INTO raw_event_flush_batches(
+                opencode_session_id,
+                start_event_seq,
+                end_event_seq,
+                extractor_version,
+                status,
+                created_at,
+                updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "sess-real",
+                0,
+                1,
+                "raw_events_v1",
+                "pending",
+                "2026-01-01T00:00:01+00:00",
+                "2026-01-01T00:00:01+00:00",
+            ),
+        )
+        store.conn.commit()
+    finally:
+        store.close()
+
+    sweeper = RawEventSweeper()
+    with patch("codemem.viewer_raw_events.flush_raw_events") as flush:
+        sweeper.tick()
+
+    flush.assert_called_once()
+    kwargs = flush.call_args.kwargs
+    assert kwargs["opencode_session_id"] == "sess-real"
+    assert kwargs["max_events"] == 7


### PR DESCRIPTION
## Description
Implement queue-first idle worker behavior so idle sweeps consume persisted queue sessions before idle-discovery candidates.

This adds resumable, bounded processing by passing a configurable max-event chunk size to flush calls during sweeper ticks.

What changed:
- Added persisted queue session selector in store layer
- Updated idle sweeper to:
  - recover stuck batches first
  - drain persisted pending/failed queue sessions first
  - then process idle-discovery sessions (skipping already drained sessions)
  - use `CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS` for bounded chunk progress
- Added tests for queue-first sweep behavior and chunked flush checkpoint resume

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `uv run pytest tests/test_raw_event_sweeper.py tests/test_raw_event_flush.py tests/test_raw_event_queue_states.py`
- `uv run ruff check codemem/viewer_raw_events.py codemem/store/raw_events.py codemem/store/_store.py tests/test_raw_event_sweeper.py tests/test_raw_event_flush.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
