### PR TITLE
feat(stream): define reliability contract and fallback semantics

### DIFF
--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -604,6 +604,20 @@ class MemoryStore:
             limit=limit,
         )
 
+    def raw_events_since_by_seq(
+        self,
+        *,
+        opencode_session_id: str,
+        after_event_seq: int,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
+        return store_raw_events.raw_events_since_by_seq(
+            self.conn,
+            opencode_session_id=opencode_session_id,
+            after_event_seq=after_event_seq,
+            limit=limit,
+        )
+
     def raw_event_sessions_pending_idle_flush(
         self,
         *,

--- a/codemem/viewer_routes/raw_events.py
+++ b/codemem/viewer_routes/raw_events.py
@@ -72,6 +72,11 @@ def handle_get(handler: Any, store: Any, path: str, query: str) -> bool:
             {
                 "items": store.raw_event_backlog(limit=limit),
                 "totals": store.raw_event_backlog_totals(),
+                "ingest": {
+                    "available": True,
+                    "mode": "stream_queue",
+                    "max_body_bytes": MAX_RAW_EVENTS_BODY_BYTES,
+                },
             }
         )
         return True

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -89,12 +89,19 @@ def test_viewer_api_contract_smoke(tmp_path, monkeypatch) -> None:
     for path in [
         "/api/session?project=",
         "/api/raw-events?project=",
+        "/api/raw-events/status?limit=5",
         "/api/memories?project=",
         "/api/summaries?project=",
         "/api/sync/status",
     ]:
         payload = _wait_for_http_json(base + path)
         assert isinstance(payload, dict)
+
+    raw_status = _wait_for_http_json(base + "/api/raw-events/status?limit=5")
+    assert isinstance(raw_status.get("items"), list)
+    assert isinstance(raw_status.get("totals"), dict)
+    assert isinstance(raw_status.get("ingest"), dict)
+    assert raw_status["ingest"].get("available") is True
 
     sync_status = _wait_for_http_json(base + "/api/sync/status")
     assert isinstance(sync_status, dict)

--- a/tests/test_viewer_routes_raw_events.py
+++ b/tests/test_viewer_routes_raw_events.py
@@ -300,6 +300,11 @@ def test_handle_get_raw_events_status_returns_items_and_totals() -> None:
     assert handler.response == {
         "items": [{"opencode_session_id": "sess", "pending": 7}],
         "totals": {"sessions": 1, "pending": 7},
+        "ingest": {
+            "available": True,
+            "mode": "stream_queue",
+            "max_body_bytes": raw_events.MAX_RAW_EVENTS_BODY_BYTES,
+        },
     }
 
 


### PR DESCRIPTION
## Description
Define and enforce a stream-only reliability contract with explicit fallback semantics and stronger ordering safety for chunked flush checkpoints.

This PR adds:
- explicit stream fallback helpers in plugin code (`auto`/`off` policy semantics)
- viewer raw-events status contract payload with ingest availability details
- docs alignment for actual flush triggers and fallback behavior
- flush ordering safety fix: chunked flush now reads by `event_seq` to prevent checkpoint skips on out-of-order timestamps
- contract tests for fallback helpers and route/status shape

## Type of Change
- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `node --check .opencode/plugin/codemem.js`
- `node --test tests/test_plugin_stream_contract.mjs`
- `uv run pytest tests/test_raw_event_flush.py tests/test_store.py::test_raw_events_since_orders_by_ts_mono tests/test_store.py::test_get_or_create_raw_event_flush_batch_is_idempotent tests/test_viewer_routes_raw_events.py tests/test_contracts.py`
- `uv run ruff check codemem/raw_event_flush.py codemem/store/_store.py codemem/store/raw_events.py codemem/viewer_routes/raw_events.py tests/test_raw_event_flush.py tests/test_store.py tests/test_viewer_routes_raw_events.py tests/test_contracts.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
