### PR TITLE
fix(plugin): start viewer on init and tighten migration guide

### DIFF
--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -777,6 +777,7 @@ export const OpencodeMemPlugin = async ({
 
   await log("info", "codemem plugin initialized", { cwd, version });
   await logLine(`plugin initialized cwd=${cwd} version=${version}`);
+  startViewer();
   await verifyCliCompatibility();
 
   const truncate = (value) => {

--- a/docs/rename-migration.md
+++ b/docs/rename-migration.md
@@ -34,10 +34,75 @@ New:
 }
 ```
 
+### End-user cutover checklist (opencode-mem -> codemem)
+
+1. Back up the legacy DB file:
+
+```bash
+cp ~/.opencode-mem.sqlite ~/.opencode-mem.sqlite.bak
+```
+
+2. Update OpenCode plugin config to `@kunickiaj/codemem`.
+3. Update OpenCode MCP command to `codemem` (if configured):
+
+```json
+{
+  "mcp": {
+    "codemem": {
+      "type": "local",
+      "command": ["codemem", "mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+
+4. Migrate runtime config file (if present):
+
+```bash
+mkdir -p ~/.config/codemem
+cp ~/.config/opencode-mem/config.json ~/.config/codemem/config.json
+```
+
+5. Restart OpenCode.
+6. Verify codemem health:
+
+```bash
+codemem stats
+codemem raw-events-status
+```
+
+7. Confirm migrated default DB exists:
+
+```bash
+ls ~/.codemem/mem.sqlite
+```
+
+8. Remove legacy tool only after successful verification:
+
+```bash
+uv tool uninstall opencode-mem
+```
+
+Expected DB behavior:
+- First codemem run migrates `~/.opencode-mem.sqlite` to `~/.codemem/mem.sqlite`.
+- Migration includes SQLite sidecars (`-wal`, `-shm`).
+- If the new default DB already exists, legacy DB is left untouched.
+- If migration is skipped because a new DB already exists, move/copy legacy DB manually.
+
 ### Runtime/CLI migration
 
 - Prefer published package installs (`codemem`) over git-based `uvx --from git+...`.
 - If runtime is older than supported minimum, plugin warns and provides upgrade command.
+- Keep `opencode-mem` installed until one successful codemem run is confirmed, then uninstall it.
+- Remove `runner_from` from `~/.config/codemem/config.json` for normal installed behavior.
+
+### Dev machine behavior
+
+- Inside the codemem repo, OpenCode auto-loads `.opencode/plugin/codemem.js` (dev mode).
+- Outside the repo, OpenCode uses configured plugin package (`@kunickiaj/codemem`).
+- For realistic migration validation on a dev machine, run at least one session outside the repo.
+- Viewer auto-start now occurs on plugin initialization and is idempotent.
 
 ## Release communication template
 
@@ -57,3 +122,4 @@ CodeMem rename update:
 - Release notes include migration snippet
 - Fallback paths documented and tested
 - Transition window end date announced before alias removal
+- Migration checklist includes backup, verification, and legacy uninstall order


### PR DESCRIPTION
## Description
- Start the viewer during plugin initialization (idempotent), so codemem is available immediately after OpenCode launch without manual `codemem serve`.
- Keep existing guards (`viewer_enabled`, `viewer_auto`, `viewerStarted`) so this does not spawn duplicate viewer processes.
- Update migration docs with cutover details discovered during real migration testing.

## Migration doc updates
- Add MCP command migration (`opencode-mem mcp` -> `codemem mcp`).
- Add runtime config migration (`~/.config/opencode-mem/config.json` -> `~/.config/codemem/config.json`).
- Document DB auto-migration behavior and skip case when `~/.codemem/mem.sqlite` already exists.
- Clarify `runner_from` guidance for dev vs installed behavior.

## Testing
- `uv run pytest tests/test_viewer_routes_raw_events.py`
- Manual verification: viewer now starts automatically after plugin initialization.