### PR TITLE
chore(release): switch npm publish to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -139,6 +140,4 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Publish @kunickiaj/codemem
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Description
Switch npm publishing in the release workflow from token-based auth to npm Trusted Publishing (OIDC).

Changes:
- Add `id-token: write` permission to the `publish-npm` job.
- Remove `NODE_AUTH_TOKEN` dependency (`NPM_TOKEN` secret no longer required for npm publish).
- Publish with provenance metadata via `npm publish --access public --provenance`.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:
- Verified workflow structure aligns with npm Trusted Publisher setup for this repo/workflow.

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced