### PR TITLE
chore(release): prepare v0.10.1

### DIFF
--- a/codemem/__init__.py
+++ b/codemem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = [
 
 [project]
 name = "codemem"
-version = "0.10.0"
+version = "0.10.1"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "codemem"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Description
Prepare the `v0.10.1` release as a stacked follow-up to npm Trusted Publishing setup.

Changes:
- Bump package version to `0.10.1` in `pyproject.toml`.
- Bump runtime version to `0.10.1` in `codemem/__init__.py`.
- Refresh `uv.lock` to capture the local package version update.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv sync`
- `uv run pytest`
- `uv run ruff check codemem tests`
- `uv run ruff format --check codemem tests`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced