### PR TITLE
chore(release): reset to v0.10.0 and fix package artifacts

### DIFF
--- a/codemem/__init__.py
+++ b/codemem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.10.1"
+__version__ = "0.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kunickiaj/codemem",
-  "version": "0.9.20",
+  "version": "0.10.0",
   "description": "CodeMem plugin for OpenCode",
   "type": "module",
   "main": "index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ packages = ["codemem"]
 
 [tool.hatch.build.targets.wheel.force-include]
 ".opencode/plugin/codemem.js" = "codemem/.opencode/plugin/codemem.js"
-"codemem/viewer_static" = "codemem/viewer_static"
 
 [tool.hatch.build.targets.sdist]
 include = [
@@ -17,7 +16,7 @@ include = [
 
 [project]
 name = "codemem"
-version = "0.10.1"
+version = "0.10.0"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "codemem"
-version = "0.10.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Description
Reset release version back to 0.10.0 and fix packaging issues that blocked publishing.

Changes:
- set Python package version to 0.10.0 in pyproject.toml and codemem/__init__.py
- set npm package version to 0.10.0 in package.json
- remove duplicate wheel force-include for codemem/viewer_static to prevent duplicate ZIP entries
- refresh uv.lock for version reset

## Testing
Local validation completed:
- uv sync
- bun install --cwd viewer_ui
- bun run --cwd viewer_ui build
- uv build (wheel built successfully)
- wheel duplicate check: 0 duplicate entries
- uv run pytest
- uv run ruff check codemem tests
- uv run ruff format --check codemem tests
