### PR TITLE
fix(release): align npm trusted publishing with release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ github.ref_name }} \
-            --generate-notes \
-            --title "Release ${{ github.ref_name }}" \
-            dist/*
+          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            gh release upload "${{ github.ref_name }}" dist/* --clobber
+          else
+            gh release create "${{ github.ref_name }}" \
+              --generate-notes \
+              --title "Release ${{ github.ref_name }}" \
+              dist/*
+          fi
 
   publish-pypi:
     name: Publish to PyPI
@@ -126,6 +130,7 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    environment: release
     permissions:
       contents: read
       id-token: write
@@ -140,4 +145,6 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Publish @kunickiaj/codemem
+        env:
+          NODE_AUTH_TOKEN: ""
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Description
Fix release workflow alignment for npm Trusted Publishing.

Changes:
- Run `publish-npm` in `environment: release` to match npm trusted publisher settings.
- Keep OIDC permissions (`id-token: write`) for npm trusted publish.
- Make GitHub release step idempotent when release tag already exists (upload assets with `--clobber` instead of failing create).
- Clear `NODE_AUTH_TOKEN` in npm publish step to avoid fallback to stale token-based auth.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:
- Workflow YAML updated to match npm Trusted Publisher environment settings and release rerun behavior.

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced