### PR TITLE
fix(release): use Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Publish @kunickiaj/codemem


### PR DESCRIPTION
## Description
Update npm release job to run on Node 24 for npm Trusted Publishing compatibility.

The npm Trusted Publishing docs require npm CLI >= 11.5.1 and Node >= 22.14. The release workflow used Node 20, which caused npm publish to fail with `ENEEDAUTH` even with OIDC/trusted publisher configured.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Manually verified changes work as expected

Validation:
- Confirmed failing run used Node 20 and npm trusted publishing docs require Node >= 22.14.

## Checklist
- [x] Self-review completed
- [x] No new warnings introduced