### PR TITLE
fix(sync): harden pid command identity checks for daemon control

### DIFF
--- a/tests/test_sync_runtime.py
+++ b/tests/test_sync_runtime.py
@@ -19,7 +19,7 @@ def test_stop_pidfile_does_not_kill_unrelated_process(monkeypatch, tmp_path: Pat
     monkeypatch.setattr(sync_runtime.os, "kill", _unexpected_kill)
 
     assert sync_runtime.stop_pidfile() is False
-    assert not pid_path.exists()
+    assert pid_path.exists()
 
 
 def test_stop_pidfile_kills_verified_sync_daemon(monkeypatch, tmp_path: Path) -> None:
@@ -63,3 +63,35 @@ def test_pid_command_missing_ps_returns_none(monkeypatch) -> None:
     monkeypatch.setattr(sync_runtime.subprocess, "run", _missing_ps)
 
     assert sync_runtime._pid_command(123) is None
+
+
+def test_is_sync_daemon_command_accepts_direct_and_wrapped_invocations() -> None:
+    assert sync_runtime._is_sync_daemon_command("codemem sync daemon --host 0.0.0.0")
+    assert sync_runtime._is_sync_daemon_command("/opt/bin/codemem sync daemon --interval-s 120")
+    assert sync_runtime._is_sync_daemon_command("opencode-mem sync daemon --port 7337")
+    assert sync_runtime._is_sync_daemon_command(
+        "uv run --directory /repo codemem sync daemon --host 0.0.0.0"
+    )
+    assert sync_runtime._is_sync_daemon_command(
+        "uvx --from git+https://github.com/kunickiaj/codemem.git codemem sync daemon"
+    )
+    assert sync_runtime._is_sync_daemon_command("python -m codemem sync daemon")
+    assert sync_runtime._is_sync_daemon_command(
+        "codemem sync daemon --db-path /home/o'connor/.codemem/mem.sqlite"
+    )
+
+
+def test_is_sync_daemon_command_accepts_windows_and_configured_binary(monkeypatch) -> None:
+    assert sync_runtime._is_sync_daemon_command(r"C:\\Tools\\codemem.exe sync daemon")
+    monkeypatch.setenv("CODEMEM_SYNC_BIN", "/custom/bin/codemem-local")
+    assert sync_runtime._is_sync_daemon_command(
+        "/custom/bin/codemem-local sync daemon --interval-s 90"
+    )
+
+
+def test_is_sync_daemon_command_rejects_non_daemon_or_broad_matches() -> None:
+    assert not sync_runtime._is_sync_daemon_command("codemem sync status")
+    assert not sync_runtime._is_sync_daemon_command("python -m codemem sync status")
+    assert not sync_runtime._is_sync_daemon_command("sync-and-daemon-helper --sync --daemon")
+    assert not sync_runtime._is_sync_daemon_command("echo sync daemon")
+    assert not sync_runtime._is_sync_daemon_command("bash -lc 'echo codemem sync daemon'")


### PR DESCRIPTION
## Description
Harden sync daemon PID identity checks so `sync status/stop` only trust matching daemon command signatures instead of broad substring matching.

Changes:
- Replace loose `"sync" + "daemon"` matching with tokenized command checks.
- Accept known daemon invocations for:
  - `codemem sync daemon`
  - legacy `opencode-mem sync daemon`
  - `python -m codemem sync daemon`
  - configured custom binary from `CODEMEM_SYNC_BIN`
- Normalize binary names across POSIX and Windows-style command paths.
- Add regression tests for accepted wrappers/paths and rejected broad matches.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run pytest tests/test_sync_runtime.py tests/test_sync_cli.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced