### PR TITLE
fix(sync): expose 401 reason codes for peer auth diagnostics

### DIFF
--- a/tests/test_sync_daemon.py
+++ b/tests/test_sync_daemon.py
@@ -478,6 +478,40 @@ def test_sync_once_succeeds_when_peer_skips_filtered_ops(monkeypatch, tmp_path: 
         store.close()
 
 
+def test_sync_once_includes_auth_reason_in_status_failure_detail(
+    monkeypatch, tmp_path: Path
+) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, addresses_json, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-1", "fp-peer", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+
+        monkeypatch.setattr(
+            "codemem.sync.sync_pass.ensure_device_identity",
+            lambda conn, keys_dir=None: ("dev-local", "fp-local"),
+        )
+        monkeypatch.setattr(
+            "codemem.sync.sync_pass.build_auth_headers",
+            lambda **kwargs: {},
+        )
+
+        def fake_request_json(method: str, url: str, **kwargs):
+            if url.endswith("/v1/status"):
+                return 401, {"error": "unauthorized", "reason": "unknown_peer"}
+            raise AssertionError(f"unexpected request: {method} {url}")
+
+        monkeypatch.setattr(http_client, "request_json", fake_request_json)
+
+        result = sync_pass.sync_once(store, "peer-1", ["127.0.0.1:7337"], limit=10)
+        assert result["ok"] is False
+        assert "unauthorized:unknown_peer" in str(result.get("error") or "")
+    finally:
+        store.close()
+
+
 def test_sync_once_advances_last_acked_when_outbound_filtered(monkeypatch, tmp_path: Path) -> None:
     store = MemoryStore(tmp_path / "mem.sqlite")
     try:


### PR DESCRIPTION
## Description
Make sync auth failures diagnosable by returning explicit 401 reason codes from sync API endpoints and carrying those reasons into sync pass error detail.

Changes:
- Sync API now returns `{ "error": "unauthorized", "reason": "<code>" }` for failed auth.
- `/v1/status`, `/v1/ops` (GET/POST) propagate `_authorize_request` reason codes.
- Sync pass error formatting now includes reason when present (`unauthorized:<reason>`), improving local diagnostics for peer push failures.
- Updated auth/security tests to assert explicit reason codes for representative failure paths.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run pytest tests/test_sync_runtime.py tests/test_sync_cli.py tests/test_sync_auth.py tests/test_sync_api_security.py tests/test_sync_daemon.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced