### PR TITLE
Add hybrid retrieval flag plumbing (default off)

### DIFF
--- a/codemem/config.py
+++ b/codemem/config.py
@@ -15,6 +15,7 @@ CONFIG_ENV_OVERRIDES = {
     "observer_max_chars": "CODEMEM_OBSERVER_MAX_CHARS",
     "pack_observation_limit": "CODEMEM_PACK_OBSERVATION_LIMIT",
     "pack_session_limit": "CODEMEM_PACK_SESSION_LIMIT",
+    "hybrid_retrieval_enabled": "CODEMEM_HYBRID_RETRIEVAL_ENABLED",
     "sync_enabled": "CODEMEM_SYNC_ENABLED",
     "sync_host": "CODEMEM_SYNC_HOST",
     "sync_port": "CODEMEM_SYNC_PORT",
@@ -79,6 +80,7 @@ class OpencodeMemConfig:
     summary_max_chars: int = 6000
     pack_observation_limit: int = 50
     pack_session_limit: int = 10
+    hybrid_retrieval_enabled: bool = False
     viewer_auto: bool = True
     viewer_auto_stop: bool = True
     viewer_enabled: bool = True
@@ -182,6 +184,7 @@ def _apply_dict(cfg: OpencodeMemConfig, data: dict[str, Any]) -> OpencodeMemConf
             continue
         if key in {
             "use_opencode_run",
+            "hybrid_retrieval_enabled",
             "viewer_auto",
             "viewer_auto_stop",
             "viewer_enabled",
@@ -230,6 +233,9 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
         os.getenv("CODEMEM_PACK_SESSION_LIMIT"),
         cfg.pack_session_limit,
         key="pack_session_limit",
+    )
+    cfg.hybrid_retrieval_enabled = _parse_bool(
+        os.getenv("CODEMEM_HYBRID_RETRIEVAL_ENABLED"), cfg.hybrid_retrieval_enabled
     )
     cfg.viewer_auto = _parse_bool(os.getenv("CODEMEM_VIEWER_AUTO"), cfg.viewer_auto)
     cfg.viewer_auto_stop = _parse_bool(os.getenv("CODEMEM_VIEWER_AUTO_STOP"), cfg.viewer_auto_stop)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,3 +47,49 @@ def test_load_config_invalid_config_value_does_not_crash_and_warns(tmp_path: Pat
     with pytest.warns(RuntimeWarning, match="sync_port"):
         cfg = load_config(config_path)
     assert cfg.sync_port == 7337
+
+
+def test_load_config_reads_hybrid_retrieval_enabled_from_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"hybrid_retrieval_enabled": true}\n')
+
+    cfg = load_config(config_path)
+
+    assert cfg.hybrid_retrieval_enabled is True
+
+
+def test_load_config_reads_hybrid_retrieval_enabled_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_HYBRID_RETRIEVAL_ENABLED", "1")
+
+    cfg = load_config(config_path)
+
+    assert cfg.hybrid_retrieval_enabled is True
+
+
+def test_load_config_hybrid_retrieval_env_overrides_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"hybrid_retrieval_enabled": true}\n')
+    monkeypatch.setenv("CODEMEM_HYBRID_RETRIEVAL_ENABLED", "0")
+
+    cfg = load_config(config_path)
+
+    assert cfg.hybrid_retrieval_enabled is False
+
+
+def test_load_config_hybrid_retrieval_invalid_env_uses_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_HYBRID_RETRIEVAL_ENABLED", "maybe")
+
+    cfg = load_config(config_path)
+
+    assert cfg.hybrid_retrieval_enabled is False


### PR DESCRIPTION
## Summary
- Add `hybrid_retrieval_enabled` to runtime config plumbing with default `false`.
- Support config-file and environment override via `CODEMEM_HYBRID_RETRIEVAL_ENABLED`.
- Add config tests for file load, env load, env-over-file precedence, and invalid env fallback behavior.

## Why
- This is the safe first step for `codemem-c6p`: enable controlled rollout plumbing before any ranking logic changes.
- Keeping default-off guarantees current retrieval behavior remains unchanged.

## Validation
- `uv run pytest tests/test_config.py`
- `uv run ruff check codemem/config.py tests/test_config.py`
- CodeReviewer: PASS
- gordon-ramsay: PASS (scope-limited review)

## Notes
- This PR intentionally does not change scoring behavior yet; it only adds the feature-flag control surface.