### PR TITLE
Add hybrid shadow logging for retrieval comparisons

### DIFF
--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -98,6 +98,9 @@ class MemoryStore:
             self.device_id = str(row["device_id"]) if row else "local"
 
         cfg = load_config()
+        self._hybrid_retrieval_enabled = bool(cfg.hybrid_retrieval_enabled)
+        self._hybrid_retrieval_shadow_log = bool(cfg.hybrid_retrieval_shadow_log)
+        self._hybrid_retrieval_shadow_sample_rate = float(cfg.hybrid_retrieval_shadow_sample_rate)
         self._sync_projects_include = [
             p.strip() for p in cfg.sync_projects_include if p and p.strip()
         ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,3 +93,31 @@ def test_load_config_hybrid_retrieval_invalid_env_uses_default(
     cfg = load_config(config_path)
 
     assert cfg.hybrid_retrieval_enabled is False
+
+
+def test_load_config_reads_hybrid_shadow_settings(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"hybrid_retrieval_shadow_log": true, "hybrid_retrieval_shadow_sample_rate": 0.5}\n'
+    )
+    monkeypatch.setenv("CODEMEM_HYBRID_RETRIEVAL_SHADOW_LOG", "1")
+    monkeypatch.setenv("CODEMEM_HYBRID_RETRIEVAL_SHADOW_SAMPLE_RATE", "0.25")
+
+    cfg = load_config(config_path)
+
+    assert cfg.hybrid_retrieval_shadow_log is True
+    assert cfg.hybrid_retrieval_shadow_sample_rate == 0.25
+
+
+def test_load_config_clamps_hybrid_shadow_sample_rate(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_HYBRID_RETRIEVAL_SHADOW_SAMPLE_RATE", "5")
+
+    cfg = load_config(config_path)
+
+    assert cfg.hybrid_retrieval_shadow_sample_rate == 1.0


### PR DESCRIPTION
## Summary
- Add hybrid retrieval shadow-logging controls to config (`hybrid_retrieval_shadow_log`, `hybrid_retrieval_shadow_sample_rate`) with env overrides.
- Extend merge ranking to compute baseline vs hybrid orderings and emit `search_hybrid_shadow` usage events when shadow logging is enabled.
- Keep default behavior unchanged (`hybrid_retrieval_enabled=false`, shadow logging off).
- Add tests for config parsing/clamping and shadow logging behavior (including sample-rate-zero and no-hybrid-compute path).

## Why
- This enables side-by-side telemetry during normal work so we can decide if hybrid ranking should become default based on real usage data.
- Sampling controls let us collect enough signal without excessive event volume.

## Privacy and safety
- Shadow events log aggregate comparison metrics only (overlap/rank-shift indicators), not raw query text.
- Feature is opt-in and defaults off.

## Validation
- `uv run ruff check codemem/config.py codemem/store/_store.py codemem/store/search.py tests/test_config.py tests/test_store.py`
- `uv run pytest tests/test_config.py tests/test_store.py -k "hybrid_retrieval or merge_ranked_results_shadow or merge_ranked_results_can_activate_hybrid or skips_hybrid_compute"`
- CodeReviewer + gordon-ramsay reviews run; addressed actionable blockers in diff scope.