### PR TITLE
Add plugin compatibility tests and stricter version checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,9 @@ jobs:
       - name: Install codemem runtime dependencies
         run: uv sync --python 3.14
 
+      - name: Run plugin compatibility unit tests
+        run: bun test ./.opencode/plugin/compat.test.js
+
       - name: Pack and install npm package locally
         run: |
           test "$(npm config get registry)" = "https://registry.npmjs.org/"
@@ -192,10 +195,12 @@ jobs:
         run: |
           CODEMEM_RUNNER=uv \
           CODEMEM_RUNNER_FROM="${GITHUB_WORKSPACE}" \
+          CODEMEM_MIN_VERSION=999.0.0 \
           CODEMEM_VIEWER=0 \
           CODEMEM_INJECT_CONTEXT=0 \
           bun --cwd .tmp/plugin-smoke -e "
             import pluginFactory from '@kunickiaj/codemem';
+            const toastMessages = [];
             if (typeof pluginFactory !== 'function') {
               throw new Error('default export must be a function');
             }
@@ -205,7 +210,11 @@ jobs:
               worktree: process.cwd(),
               client: {
                 app: { log: async () => {} },
-                tui: { showToast: async () => {} },
+                tui: {
+                  showToast: async ({ body }) => {
+                    toastMessages.push(String(body?.message || ''));
+                  },
+                },
               },
             });
             if (!plugin || typeof plugin !== 'object') {
@@ -221,4 +230,10 @@ jobs:
                 properties: { tool: 'read', args: { filePath: 'README.md' } },
               },
             });
+            const sawCompatibilityWarning = toastMessages.some((msg) =>
+              msg.includes('older than required')
+            );
+            if (!sawCompatibilityWarning) {
+              throw new Error('expected compatibility warning toast from version probe');
+            }
           "

--- a/.opencode/plugin/compat.js
+++ b/.opencode/plugin/compat.js
@@ -1,0 +1,50 @@
+export const parseSemver = (value) => {
+  const match = String(value || "").trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+};
+
+export const isVersionAtLeast = (currentVersion, minVersion) => {
+  const current = parseSemver(currentVersion);
+  const minimum = parseSemver(minVersion);
+  if (!current || !minimum) return false;
+  for (let i = 0; i < 3; i += 1) {
+    if (current[i] > minimum[i]) return true;
+    if (current[i] < minimum[i]) return false;
+  }
+  return true;
+};
+
+export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
+  const normalizedRunner = String(runner || "").trim();
+  const normalizedFrom = String(runnerFrom || "").trim();
+
+  if (normalizedRunner === "uv") {
+    return {
+      mode: "uv-dev",
+      action: "In your codemem repo, pull latest changes and run `uv sync`, then restart OpenCode.",
+      note: "detected dev repo mode",
+    };
+  }
+
+  if (normalizedRunner === "uvx") {
+    if (normalizedFrom.startsWith("git+") || normalizedFrom.includes(".git")) {
+      return {
+        mode: "uvx-git",
+        action: `Update CODEMEM_RUNNER_FROM to a newer git ref/source (current: ${normalizedFrom || "<unset>"}), then restart OpenCode.`,
+        note: "detected uvx git mode",
+      };
+    }
+    return {
+      mode: "uvx-custom",
+      action: `Update CODEMEM_RUNNER_FROM to a newer source (current: ${normalizedFrom || "<unset>"}), then restart OpenCode.`,
+      note: "detected uvx custom source mode",
+    };
+  }
+
+  return {
+    mode: "generic",
+    action: "Run `uv tool install --upgrade codemem`, then restart OpenCode.",
+    note: "fallback guidance",
+  };
+};

--- a/.opencode/plugin/compat.test.js
+++ b/.opencode/plugin/compat.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { isVersionAtLeast, parseSemver, resolveUpgradeGuidance } from "./compat.js";
+
+describe("parseSemver", () => {
+  test("parses x.y.z versions", () => {
+    expect(parseSemver("0.10.2")).toEqual([0, 10, 2]);
+  });
+
+  test("returns null for unparseable values", () => {
+    expect(parseSemver("v-next")).toBeNull();
+    expect(parseSemver("")).toBeNull();
+  });
+});
+
+describe("isVersionAtLeast", () => {
+  test("compares semantic versions", () => {
+    expect(isVersionAtLeast("0.10.2", "0.10.2")).toBe(true);
+    expect(isVersionAtLeast("0.10.3", "0.10.2")).toBe(true);
+    expect(isVersionAtLeast("0.9.9", "0.10.2")).toBe(false);
+  });
+
+  test("treats unparseable versions as incompatible", () => {
+    expect(isVersionAtLeast("v-next", "0.10.2")).toBe(false);
+    expect(isVersionAtLeast("0.10.2", "v-next")).toBe(false);
+  });
+});
+
+describe("resolveUpgradeGuidance", () => {
+  test("returns uv-dev guidance", () => {
+    const guidance = resolveUpgradeGuidance({
+      runner: "uv",
+      runnerFrom: "/tmp/codemem",
+    });
+    expect(guidance.mode).toBe("uv-dev");
+    expect(guidance.action).toContain("uv sync");
+  });
+
+  test("returns uvx-git guidance", () => {
+    const guidance = resolveUpgradeGuidance({
+      runner: "uvx",
+      runnerFrom: "git+https://github.com/kunickiaj/codemem.git",
+    });
+    expect(guidance.mode).toBe("uvx-git");
+    expect(guidance.action).toContain("CODEMEM_RUNNER_FROM");
+  });
+
+  test("returns uvx-custom guidance", () => {
+    const guidance = resolveUpgradeGuidance({
+      runner: "uvx",
+      runnerFrom: "./local/dist",
+    });
+    expect(guidance.mode).toBe("uvx-custom");
+  });
+
+  test("returns generic fallback guidance", () => {
+    const guidance = resolveUpgradeGuidance({
+      runner: "node",
+      runnerFrom: "",
+    });
+    expect(guidance.mode).toBe("generic");
+    expect(guidance.action).toContain("uv tool install --upgrade codemem");
+  });
+});

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -76,6 +76,7 @@ codemem raw-events-retry <opencode_session_id>
 | `CODEMEM_VIEWER_AUTO_STOP` | Set to `0`/`false`/`off` to keep the viewer running after OpenCode exits (default on). |
 | `CODEMEM_PLUGIN_LOG` | Path for the plugin log file (set `1`/`true`/`yes` to enable; defaults to off). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
+| `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |
 | `CODEMEM_CODEX_ENDPOINT` | Override Codex OAuth endpoint. |
 | `CODEMEM_PLUGIN_DEBUG` | Set to `1`, `true`, or `yes` to log plugin lifecycle events. |
 | `CODEMEM_PLUGIN_IGNORE` | Skip all plugin behavior for this process. |
@@ -99,3 +100,14 @@ codemem raw-events-retry <opencode_session_id>
 | `CODEMEM_RAW_EVENTS_SWEEPER_LIMIT` | Max idle sessions to flush per sweeper tick (default `25`). |
 | `CODEMEM_RAW_EVENTS_STUCK_BATCH_MS` | Mark flush batches older than this many ms as error (default `300000`). |
 | `CODEMEM_RAW_EVENTS_RETENTION_MS` | If >0, delete raw events older than this many ms (default `0`, keep forever). |
+
+## Compatibility guidance behavior
+
+When the plugin detects CLI/runtime version mismatch, it shows guidance based on runner mode:
+
+- `CODEMEM_RUNNER=uv`: pull latest in your repo, run `uv sync`, restart OpenCode
+- `CODEMEM_RUNNER=uvx` with git source: update `CODEMEM_RUNNER_FROM` to newer ref/source, restart OpenCode
+- `CODEMEM_RUNNER=uvx` with custom source: update `CODEMEM_RUNNER_FROM`, restart OpenCode
+- other/unknown runner: run `uv tool install --upgrade codemem`, restart OpenCode
+
+Compatibility checks are warning-only and do not block plugin startup.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "index.js",
     "README.md",
     "LICENSE",
-    ".opencode/plugin/codemem.js"
+    ".opencode/plugin/codemem.js",
+    ".opencode/plugin/compat.js"
   ],
   "dependencies": {
     "@opencode-ai/plugin": "1.1.61"


### PR DESCRIPTION
## Summary
- Extract plugin compatibility helpers into `.opencode/plugin/compat.js` for focused testing (`parseSemver`, `isVersionAtLeast`, `resolveUpgradeGuidance`).
- Add Bun unit tests in `.opencode/plugin/compat.test.js` for semver parsing, version comparisons, and runner-mode guidance behavior.
- Harden compatibility behavior: use strict semver parsing, treat unparseable versions as incompatible, and run `codemem version` instead of unsupported `--version`.
- Strengthen CI plugin smoke to assert compatibility warning behavior by forcing a min-version mismatch and verifying toast emission.

## Why
- `codemem-8vz` needs deterministic, test-backed mismatch detection and guidance behavior to prevent plugin-first upgrade regressions.
- Previous checks were too permissive and could silently pass ambiguous version outputs.

## Validation
- `bun test ./.opencode/plugin/compat.test.js`
- Local plugin smoke initialization with `CODEMEM_RUNNER=uv` and forced mismatch (`CODEMEM_MIN_VERSION=999.0.0`) confirms warning path.
- `CodeReviewer`: PASS
- `gordon-ramsay`: PASS after tightening compatibility and smoke assertions.