### PR TITLE
Add hybrid evaluation command with precision/recall deltas

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -30,6 +30,7 @@ from .commands.maintenance_cmds import (
     backfill_discovery_tokens_cmd,
     backfill_tags_cmd,
     embed_cmd,
+    hybrid_eval_cmd,
     ingest_cmd,
     init_db_cmd,
     mcp_cmd,
@@ -629,6 +630,39 @@ def pack_benchmark(
         project=project,
         all_projects=all_projects,
         json_out=json_out,
+    )
+
+
+@app.command("hybrid-eval")
+def hybrid_eval(
+    judged_queries_path: Path = typer.Argument(
+        ...,
+        exists=True,
+        dir_okay=False,
+        file_okay=True,
+        readable=True,
+        resolve_path=True,
+        help="Path to judged query JSONL file",
+    ),
+    limit: int = typer.Option(8, help="Top-k results to evaluate"),
+    db_path: str = typer.Option(None, help="Path to SQLite database"),
+    json_out: Path | None = typer.Option(None, help="Optional JSON output file"),
+    min_delta_precision: float | None = typer.Option(
+        None, help="Fail if precision delta is below this threshold"
+    ),
+    min_delta_recall: float | None = typer.Option(
+        None, help="Fail if recall delta is below this threshold"
+    ),
+) -> None:
+    """Evaluate baseline vs hybrid retrieval precision/recall deltas."""
+    hybrid_eval_cmd(
+        store_from_path=_store,
+        db_path=db_path,
+        judged_queries_path=judged_queries_path,
+        limit=limit,
+        json_out=json_out,
+        min_delta_precision=min_delta_precision,
+        min_delta_recall=min_delta_recall,
     )
 
 

--- a/codemem/hybrid_eval.py
+++ b/codemem/hybrid_eval.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+import statistics
+from collections.abc import Sequence
+from typing import Any, TypedDict
+
+from .store import MemoryStore
+
+
+class JudgedQuery(TypedDict):
+    query: str
+    relevant_ids: list[int]
+    filters: dict[str, Any] | None
+
+
+def read_judged_queries(text: str) -> list[JudgedQuery]:
+    rows: list[JudgedQuery] = []
+    for line in (text or "").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        payload = json.loads(stripped)
+        query = str(payload.get("query") or "").strip()
+        if not query:
+            raise ValueError("each judged query must include non-empty 'query'")
+        relevant_ids_raw = payload.get("relevant_ids") or []
+        relevant_ids = [int(item) for item in relevant_ids_raw]
+        filters = payload.get("filters")
+        if filters is not None and not isinstance(filters, dict):
+            raise ValueError("'filters' must be an object when provided")
+        rows.append(
+            {
+                "query": query,
+                "relevant_ids": relevant_ids,
+                "filters": filters,
+            }
+        )
+    if not rows:
+        raise ValueError("no judged queries found; provide at least one JSONL row")
+    return rows
+
+
+def _precision_recall(
+    result_ids: Sequence[int], relevant_ids: set[int]
+) -> tuple[float, float, int]:
+    if not result_ids:
+        return 0.0, 0.0, 0
+    hits = sum(1 for memory_id in result_ids if memory_id in relevant_ids)
+    precision = float(hits) / float(len(result_ids))
+    recall = float(hits) / float(len(relevant_ids)) if relevant_ids else 0.0
+    return precision, recall, hits
+
+
+def run_hybrid_eval(
+    store: MemoryStore,
+    *,
+    judged_queries: list[JudgedQuery],
+    limit: int,
+) -> dict[str, Any]:
+    previous_hybrid_enabled = bool(store._hybrid_retrieval_enabled)
+    previous_shadow_log = bool(store._hybrid_retrieval_shadow_log)
+    per_query: list[dict[str, Any]] = []
+    baseline_precision: list[float] = []
+    baseline_recall: list[float] = []
+    hybrid_precision: list[float] = []
+    hybrid_recall: list[float] = []
+
+    try:
+        store._hybrid_retrieval_shadow_log = False
+        for row in judged_queries:
+            query = row["query"]
+            filters = row.get("filters")
+            relevant = set(int(item) for item in row["relevant_ids"])
+
+            store._hybrid_retrieval_enabled = False
+            baseline_pack = store.build_memory_pack(
+                context=query,
+                limit=limit,
+                token_budget=None,
+                filters=filters,
+                log_usage=False,
+            )
+            baseline_ids = [
+                int(item["id"])
+                for item in baseline_pack.get("items") or []
+                if isinstance(item, dict) and item.get("id") is not None
+            ]
+            b_precision, b_recall, b_hits = _precision_recall(baseline_ids, relevant)
+
+            store._hybrid_retrieval_enabled = True
+            hybrid_pack = store.build_memory_pack(
+                context=query,
+                limit=limit,
+                token_budget=None,
+                filters=filters,
+                log_usage=False,
+            )
+            hybrid_ids = [
+                int(item["id"])
+                for item in hybrid_pack.get("items") or []
+                if isinstance(item, dict) and item.get("id") is not None
+            ]
+            h_precision, h_recall, h_hits = _precision_recall(hybrid_ids, relevant)
+
+            baseline_precision.append(b_precision)
+            baseline_recall.append(b_recall)
+            hybrid_precision.append(h_precision)
+            hybrid_recall.append(h_recall)
+            per_query.append(
+                {
+                    "query": query,
+                    "relevant_count": len(relevant),
+                    "baseline": {
+                        "precision": b_precision,
+                        "recall": b_recall,
+                        "hits": b_hits,
+                        "ids": baseline_ids,
+                    },
+                    "hybrid": {
+                        "precision": h_precision,
+                        "recall": h_recall,
+                        "hits": h_hits,
+                        "ids": hybrid_ids,
+                    },
+                    "delta": {
+                        "precision": h_precision - b_precision,
+                        "recall": h_recall - b_recall,
+                    },
+                }
+            )
+    finally:
+        store._hybrid_retrieval_enabled = previous_hybrid_enabled
+        store._hybrid_retrieval_shadow_log = previous_shadow_log
+
+    def _avg(values: list[float]) -> float:
+        return float(statistics.mean(values)) if values else 0.0
+
+    summary = {
+        "queries": len(per_query),
+        "limit": int(limit),
+        "baseline": {
+            "precision": _avg(baseline_precision),
+            "recall": _avg(baseline_recall),
+        },
+        "hybrid": {
+            "precision": _avg(hybrid_precision),
+            "recall": _avg(hybrid_recall),
+        },
+    }
+    summary["delta"] = {
+        "precision": summary["hybrid"]["precision"] - summary["baseline"]["precision"],
+        "recall": summary["hybrid"]["recall"] - summary["baseline"]["recall"],
+    }
+    return {
+        "summary": summary,
+        "results": per_query,
+    }
+
+
+def format_hybrid_eval_report(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary") or {}
+    baseline = summary.get("baseline") or {}
+    hybrid = summary.get("hybrid") or {}
+    delta = summary.get("delta") or {}
+    lines = [
+        f"queries: {summary.get('queries', 0)} limit={summary.get('limit', 0)}",
+        f"baseline: precision@k={baseline.get('precision', 0.0):.3f} recall@k={baseline.get('recall', 0.0):.3f}",
+        f"hybrid: precision@k={hybrid.get('precision', 0.0):.3f} recall@k={hybrid.get('recall', 0.0):.3f}",
+        f"delta: precision={delta.get('precision', 0.0):+.3f} recall={delta.get('recall', 0.0):+.3f}",
+    ]
+    return "\n".join(lines)
+
+
+def to_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,6 +36,25 @@
 - Backfill existing memories with: `codemem embed --dry-run` then `codemem embed`.
 - If sqlite-vec fails to load, semantic recall is skipped and keyword search remains.
 
+## Hybrid retrieval evaluation
+
+- Evaluate baseline vs hybrid retrieval with judged queries:
+  - `codemem hybrid-eval /path/to/judged.jsonl --limit 8`
+- Use threshold gates for rollout decisions:
+  - `codemem hybrid-eval /path/to/judged.jsonl --min-delta-precision 0.01 --min-delta-recall 0.01`
+- Save machine-readable output:
+  - `codemem hybrid-eval /path/to/judged.jsonl --json-out .tmp/hybrid-eval.json`
+
+Judged query JSONL format:
+
+```json
+{"query":"sync diagnostics","relevant_ids":[123,456],"filters":{"project":"codemem"}}
+{"query":"viewer autostart","relevant_ids":[789]}
+```
+
+- `relevant_ids` are memory item IDs expected in top-k.
+- `filters` is optional and uses the same project/kind filter shape as normal search commands.
+
 ## Sync (Phase 2)
 
 ### Enable + run

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -18,6 +18,7 @@ def test_root_help_shows_db_namespace() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "db" in result.stdout
+    assert "hybrid-eval" in result.stdout
 
 
 def test_db_help_shows_prune_commands() -> None:

--- a/tests/test_hybrid_eval.py
+++ b/tests/test_hybrid_eval.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+
+from codemem.commands.maintenance_cmds import hybrid_eval_cmd
+from codemem.hybrid_eval import read_judged_queries, run_hybrid_eval
+
+
+def test_read_judged_queries_parses_jsonl() -> None:
+    rows = read_judged_queries(
+        """
+        # comment
+        {"query": "alpha", "relevant_ids": [1, 2], "filters": {"project": "p"}}
+        {"query": "beta", "relevant_ids": [3]}
+        """
+    )
+    assert len(rows) == 2
+    assert rows[0]["query"] == "alpha"
+    assert rows[0]["relevant_ids"] == [1, 2]
+    assert rows[0]["filters"] == {"project": "p"}
+
+
+def test_read_judged_queries_requires_query() -> None:
+    with pytest.raises(ValueError):
+        read_judged_queries('{"relevant_ids": [1]}')
+
+
+def test_run_hybrid_eval_computes_delta_and_restores_flags() -> None:
+    class FakeStore:
+        def __init__(self) -> None:
+            self._hybrid_retrieval_enabled = False
+            self._hybrid_retrieval_shadow_log = True
+
+        def build_memory_pack(
+            self, context, limit=8, token_budget=None, filters=None, log_usage=True
+        ):
+            if self._hybrid_retrieval_enabled:
+                return {"items": [{"id": 1}, {"id": 7}]}
+            return {"items": [{"id": 7}, {"id": 8}]}
+
+    store = FakeStore()
+    payload = run_hybrid_eval(
+        store=store,  # type: ignore[arg-type]
+        judged_queries=[{"query": "alpha", "relevant_ids": [1], "filters": None}],
+        limit=2,
+    )
+    assert payload["summary"]["baseline"]["precision"] == 0.0
+    assert payload["summary"]["hybrid"]["precision"] == 0.5
+    assert payload["summary"]["delta"]["precision"] == 0.5
+    assert payload["summary"]["delta"]["recall"] == 1.0
+    assert store._hybrid_retrieval_enabled is False
+    assert store._hybrid_retrieval_shadow_log is True
+
+
+def test_read_judged_queries_requires_nonempty_dataset() -> None:
+    with pytest.raises(ValueError, match="no judged queries"):
+        read_judged_queries("# only comments\n\n")
+
+
+def test_hybrid_eval_cmd_fails_when_threshold_not_met(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    class FakeStore:
+        def __init__(self) -> None:
+            self._hybrid_retrieval_enabled = False
+            self._hybrid_retrieval_shadow_log = True
+
+        def build_memory_pack(
+            self, context, limit=8, token_budget=None, filters=None, log_usage=True
+        ):
+            if self._hybrid_retrieval_enabled:
+                return {"items": [{"id": 1}, {"id": 7}]}
+            return {"items": [{"id": 7}, {"id": 8}]}
+
+        def close(self) -> None:
+            return
+
+    judged_path = tmp_path / "judged.jsonl"
+    judged_path.write_text('{"query": "alpha", "relevant_ids": [1]}\n')
+
+    with pytest.raises(typer.Exit) as exc:
+        hybrid_eval_cmd(
+            store_from_path=lambda _db: FakeStore(),
+            db_path=None,
+            judged_queries_path=judged_path,
+            limit=2,
+            json_out=None,
+            min_delta_precision=0.75,
+            min_delta_recall=None,
+        )
+    assert exc.value.exit_code == 1
+    assert "threshold failed" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Add `codemem hybrid-eval` command to compare baseline vs hybrid retrieval on a judged JSONL query set.
- Implement evaluator in `codemem/hybrid_eval.py` that runs both modes through `build_memory_pack`, computes precision@k/recall@k per query, and reports aggregate deltas.
- Add threshold gates (`--min-delta-precision`, `--min-delta-recall`) with explicit failure diagnostics and non-zero exit for CI/local rollout checks.
- Add tests for judged-query parsing, empty dataset rejection, delta math, flag restoration, threshold failures, and root CLI help visibility.
- Document hybrid evaluation workflow and judged query JSONL format in `docs/user-guide.md`.

## Why
- `codemem-c6p` requires measurable evidence before deciding default rollout.
- This adds a reproducible, scriptable decision loop instead of ad-hoc manual checks.

## Validation
- `uv run pytest tests/test_hybrid_eval.py tests/test_cli_help.py`
- `uv run ruff check codemem/hybrid_eval.py codemem/commands/maintenance_cmds.py codemem/cli_app.py tests/test_hybrid_eval.py tests/test_cli_help.py`
- CodeReviewer: PASS
- gordon-ramsay: PASS after switching to feature-flag-controlled pack evaluation and adding threshold diagnostics.