### PR TITLE
Add provider-loop scenario tests across adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,3 +237,30 @@ jobs:
               throw new Error('expected compatibility warning toast from version probe');
             }
           "
+
+  provider-loop:
+    name: Provider Loop (${{ matrix.provider }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: ["openai", "anthropic"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync --python 3.14
+
+      - name: Run provider-loop scenario suite
+        env:
+          CODEMEM_TEST_PROVIDER: ${{ matrix.provider }}
+        run: uv run pytest tests/test_observer_provider_loop.py -q -rA

--- a/tests/test_observer_provider_loop.py
+++ b/tests/test_observer_provider_loop.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from codemem.config import OpencodeMemConfig
+from codemem.observer import ObserverClient
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    behavior: str
+    expected_text: str | None
+    expected_status: str
+
+
+SCENARIOS = (
+    Scenario(
+        name="success",
+        behavior="success",
+        expected_text="hello from adapter",
+        expected_status="success",
+    ),
+    Scenario(
+        name="backend-error",
+        behavior="raises",
+        expected_text=None,
+        expected_status="failed",
+    ),
+    Scenario(
+        name="malformed-response",
+        behavior="malformed",
+        expected_text=None,
+        expected_status="failed",
+    ),
+)
+
+
+def _target_providers() -> list[str]:
+    selected = (os.getenv("CODEMEM_TEST_PROVIDER") or "").strip().lower()
+    if selected in {"openai", "anthropic"}:
+        return [selected]
+    return ["openai", "anthropic"]
+
+
+def _make_openai_backend(behavior: str, attempts: list[str]) -> SimpleNamespace:
+    class OpenAIChatCompletions:
+        def create(self, **_kwargs):
+            attempts.append("attempt")
+            if behavior == "raises":
+                raise RuntimeError("openai failed")
+            if behavior == "malformed":
+                return SimpleNamespace(choices=[])
+            message = SimpleNamespace(content="hello from adapter")
+            choice = SimpleNamespace(message=message)
+            return SimpleNamespace(choices=[choice])
+
+    return SimpleNamespace(chat=SimpleNamespace(completions=OpenAIChatCompletions()))
+
+
+def _make_anthropic_backend(behavior: str, attempts: list[str]) -> SimpleNamespace:
+    class AnthropicCompletions:
+        def create(self, **_kwargs):
+            attempts.append("attempt")
+            if behavior == "raises":
+                raise RuntimeError("anthropic failed")
+            if behavior == "malformed":
+                return SimpleNamespace()
+            return SimpleNamespace(completion="hello from adapter")
+
+    return SimpleNamespace(completions=AnthropicCompletions())
+
+
+def _run_scenario(provider: str, scenario: Scenario) -> dict[str, object]:
+    attempts: list[str] = []
+
+    if provider == "openai":
+
+        class OpenAIStub:
+            def __init__(self, **_kwargs: object) -> None:
+                self.chat = _make_openai_backend(scenario.behavior, attempts).chat
+
+        module_map = {"openai": SimpleNamespace(OpenAI=OpenAIStub)}
+        cfg = OpencodeMemConfig(
+            observer_provider="openai",
+            observer_api_key="stub-key",
+            observer_model="gpt-5.1-codex-mini",
+        )
+    else:
+
+        class AnthropicStub:
+            def __init__(self, **_kwargs: object) -> None:
+                self.completions = _make_anthropic_backend(scenario.behavior, attempts).completions
+
+        module_map = {"anthropic": SimpleNamespace(Anthropic=AnthropicStub)}
+        cfg = OpencodeMemConfig(
+            observer_provider="anthropic",
+            observer_api_key="stub-key",
+            observer_model="claude-4.5-haiku",
+        )
+
+    from unittest.mock import patch
+
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch.dict(sys.modules, module_map),
+    ):
+        client = ObserverClient()
+        output = client._call("hello")
+    status = "success" if output else "failed"
+    return {"output": output, "status": status, "attempts": len(attempts)}
+
+
+@pytest.mark.parametrize("provider", _target_providers())
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[s.name for s in SCENARIOS])
+def test_provider_loop_scenarios_match_expected(provider: str, scenario: Scenario) -> None:
+    result = _run_scenario(provider, scenario)
+    assert result["output"] == scenario.expected_text
+    assert result["status"] == scenario.expected_status
+    assert result["attempts"] == 1
+
+
+@pytest.mark.parametrize("scenario", SCENARIOS, ids=[s.name for s in SCENARIOS])
+def test_provider_loop_semantics_equivalent_across_adapters(scenario: Scenario) -> None:
+    openai_result = _run_scenario("openai", scenario)
+    anthropic_result = _run_scenario("anthropic", scenario)
+    assert openai_result["output"] == anthropic_result["output"]
+    assert openai_result["status"] == anthropic_result["status"]
+    assert openai_result["attempts"] == anthropic_result["attempts"]


### PR DESCRIPTION
## Summary
- Add `tests/test_observer_provider_loop.py` with a shared scenario suite that runs against both OpenAI and Anthropic adapter paths.
- Exercise real `ObserverClient()` initialization with provider-specific SDK stubs and validate equivalent status/attempt semantics for success, backend-error, and malformed-response scenarios.
- Add a dedicated CI matrix job `Provider Loop (openai|anthropic)` in `.github/workflows/ci.yml` for adapter-attributed pass/fail reporting.

## Why
- `codemem-94g` needs parity confidence across provider adapters, not just single-provider happy-path checks.
- This catches drift in provider loop behavior early and makes failures attributable per adapter in CI.

## Validation
- `uv run pytest tests/test_observer_provider_loop.py`
- `CODEMEM_TEST_PROVIDER=openai uv run pytest tests/test_observer_provider_loop.py -q -rA`
- `CODEMEM_TEST_PROVIDER=anthropic uv run pytest tests/test_observer_provider_loop.py -q -rA`
- `uv run ruff check tests/test_observer_provider_loop.py`
- workflow YAML parse validation
- CodeReviewer: PASS
- gordon-ramsay: PASS