### PR TITLE
Support JSONC config files for codemem

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -16,6 +16,7 @@
 - Writes `observer_provider`, `observer_model`, `observer_max_chars`, `pack_observation_limit`, and `pack_session_limit`.
 - Sync settings can also be updated here (`sync_enabled`, `sync_host`, `sync_port`, `sync_interval_s`, `sync_mdns`).
 - Environment variables still override file values.
+- Config file supports JSON and JSONC (`~/.config/codemem/config.json` or `~/.config/codemem/config.jsonc`).
 
 ## Memory persistence
 - A session is created per ingest payload.


### PR DESCRIPTION
## Summary
- Add JSONC-aware config parsing in `codemem/config.py` for both `read_config_file` and `load_config`.
- Support `//` and `/* ... */` comments plus trailing commas while preserving strict JSON compatibility.
- Add config path fallback logic to prefer `~/.config/codemem/config.jsonc` when `config.json` is absent (while still preferring `config.json` when both exist).
- Emit a runtime warning when config parsing fails in `load_config` and defaults/env overrides are used.
- Add comprehensive tests for JSONC parsing, string safety (`//` in strings), precedence, invalid/unterminated comment handling, and warning behavior.
- Update docs to state that both `config.json` and `config.jsonc` are supported.

## Why
- `codemem-0uu` requested JSONC support so users can keep comments/trailing commas in managed configs without breaking runtime config loading.

## Validation
- `uv run pytest tests/test_config.py`
- `uv run ruff check codemem/config.py tests/test_config.py`
- CodeReviewer + gordon-ramsay reviews completed; addressed blockers (silent parse fallback and unterminated block comments).