### PR TITLE
Add sync guardrail tests and ignore coverage artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 *.pid
 .DS_Store
 .pytest_cache/
+.coverage
+coverage.xml
 *.egg-info/
 .eggs/
 build/

--- a/tests/test_sync_service_cmds.py
+++ b/tests/test_sync_service_cmds.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import typer
+
 from codemem.commands import sync_service_cmds
 
 
@@ -41,3 +43,84 @@ def test_install_autostart_quiet_linux_returns_true_when_commands_succeed(
     )
 
     assert sync_service_cmds.install_autostart_quiet(user=True) is True
+
+
+def test_install_autostart_quiet_linux_returns_false_when_subprocess_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(sync_service_cmds.sys, "platform", "linux")
+    monkeypatch.setattr(sync_service_cmds.Path, "home", lambda: tmp_path)
+
+    def _missing_bin(*_args, **_kwargs):
+        raise OSError("systemctl missing")
+
+    monkeypatch.setattr(sync_service_cmds.subprocess, "run", _missing_bin)
+
+    assert sync_service_cmds.install_autostart_quiet(user=True) is False
+
+
+def test_sync_service_start_cmd_falls_back_when_service_action_reports_success(
+    capsys, monkeypatch
+) -> None:
+    cfg = type(
+        "Cfg",
+        (),
+        {
+            "sync_enabled": True,
+            "sync_host": "127.0.0.1",
+            "sync_port": 7337,
+            "sync_interval_s": 30,
+        },
+    )()
+    statuses = iter(
+        [
+            type(
+                "S",
+                (),
+                {"running": False, "mechanism": "service", "detail": "inactive", "pid": None},
+            )(),
+            type(
+                "S",
+                (),
+                {"running": False, "mechanism": "none", "detail": "unsupported", "pid": None},
+            )(),
+        ]
+    )
+    monkeypatch.setattr(sync_service_cmds, "run_service_action_quiet", lambda *_a, **_k: True)
+
+    sync_service_cmds.sync_service_start_cmd(
+        load_config=lambda: cfg,
+        effective_status=lambda *_a, **_k: next(statuses),
+        spawn_daemon=lambda **_k: 4242,
+        user=True,
+        system=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "Started sync daemon (pid 4242)" in out
+
+
+def test_sync_service_stop_cmd_reports_already_stopped_when_service_fails(
+    capsys, monkeypatch
+) -> None:
+    cfg = type("Cfg", (), {"sync_host": "127.0.0.1", "sync_port": 7337})()
+
+    def _raise_exit(*_args, **_kwargs):
+        raise typer.Exit(code=1)
+
+    monkeypatch.setattr(sync_service_cmds, "run_service_action", _raise_exit)
+
+    sync_service_cmds.sync_service_stop_cmd(
+        load_config=lambda: cfg,
+        effective_status=lambda *_a, **_k: type(
+            "S", (), {"running": False, "mechanism": "service", "detail": "inactive", "pid": None}
+        )(),
+        stop_pidfile_with_reason=lambda: type(
+            "R", (), {"stopped": False, "reason": "pid_not_running", "pid": 123}
+        )(),
+        user=True,
+        system=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "Sync already stopped" in out


### PR DESCRIPTION
## Summary
- Add sync-service tests for failure-truthfulness paths:
  - autostart returns false when subprocess tooling is missing (`OSError`)
  - start command falls back to pidfile daemon when service restart reports success but daemon is not running
  - stop command reports "already stopped" when service stop fails and runtime is inactive
- Add sync-runtime test ensuring stale pidfile is cleared when PID is no longer running (`pid_not_running`).
- Add `.coverage` and `coverage.xml` to `.gitignore` to keep local coverage artifacts out of commits.

## Why
- `codemem-ugs` calls for guardrail coverage around autostart/stop truthfulness and PID safety.
- Ignoring coverage outputs removes recurring accidental-untracked noise during test-heavy sessions.

## Validation
- `uv run pytest tests/test_sync_service_cmds.py tests/test_sync_runtime.py`
- `uv run ruff check tests/test_sync_service_cmds.py tests/test_sync_runtime.py`
- CodeReviewer: PASS
- gordon-ramsay: PASS