### PR TITLE
Clarify runtime hook and sync reliability docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ export CODEMEM_DB=~/.codemem/mem.sqlite
 - `codemem export-memories` / `codemem import-memories` – export and import memories by project for sharing or backup.
 - `codemem sync` – enable peer sync, pair devices, and run the sync daemon.
 
+## Runtime hook behavior (plugin)
+
+- The plugin captures tool activity via `tool.execute.after` and conversation messages from event payloads.
+- Flush boundaries are event-driven: `session.idle`, `session.created`, `/new` prompt, and `session.error`.
+- Force-flush triggers fire on heavy sessions: `>=50` tools, `>=15` prompts, or `>=10m` session duration.
+- Raw events are delivered to the viewer ingest API (`/api/raw-events`).
+
+For usage and troubleshooting details, see `docs/user-guide.md` and `docs/plugin-reference.md`.
+
 ### Sync project filters
 
 By default, sync replicates all projects. You can restrict which projects a device will apply by

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,11 @@ The plugin uses an adaptive flush strategy optimized for OpenCode's multi-sessio
 - 50+ tool executions OR 15+ prompts
 - 10+ minutes continuous work
 
-**Note:** Streamed raw events are sent continuously; there is no plugin-side CLI fallback.
+### Stream reliability and failure semantics
+- Plugin stream health preflight: `GET /api/raw-events/status`
+- Event ingest path: `POST /api/raw-events`
+- Stream failures are handled in-plugin with a backoff window (`CODEMEM_RAW_EVENTS_BACKOFF_MS`) and periodic preflight checks (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`).
+- Once batches are accepted by the viewer/store queue, flush workers own retries (`codemem raw-events-retry`, sweeper/idle flush).
 
 ## Sessions and memory persistence
 - A **session** is created per ingest payload (one plugin flush).
@@ -53,6 +57,7 @@ The plugin uses an adaptive flush strategy optimized for OpenCode's multi-sessio
 ## Viewer
 - Implemented in `codemem/viewer.py` as an embedded HTML page.
 - Serves JSON APIs for stats, sessions, memory items, and config.
+- Viewer stats cards are sourced from `/api/stats`, `/api/usage`, and `/api/raw-events`.
 - Restart required to pick up HTML changes.
 
 ## Context injection

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -64,6 +64,26 @@ If `raw-events-status` shows `batches=error:N` (legacy label) or `queue=... fail
 codemem raw-events-retry <opencode_session_id>
 ```
 
+## Hook lifecycle and flush boundaries
+
+The plugin uses OpenCode event hooks and flushes on explicit lifecycle boundaries:
+
+- `tool.execute.after`: queue tool event; contributes to force-flush thresholds.
+- `session.idle`: immediate flush attempt.
+- `session.created`: flush previous session buffer before switching context.
+- `/new` prompt boundary: flush before session reset.
+- `session.error`: immediate flush attempt.
+
+Force-flush thresholds (immediate flush):
+- `>=50` tool events, or
+- `>=15` prompts, or
+- `>=10` minutes session duration.
+
+Failure semantics:
+- Stream POST failures are backoff-gated in plugin runtime (`CODEMEM_RAW_EVENTS_BACKOFF_MS`).
+- Availability checks are rate-limited (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`).
+- Accepted raw-event batches are retried by viewer/store queue workers (`codemem raw-events-retry`).
+
 ## Environment hints
 
 | Env var | Description |

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -36,7 +36,7 @@ Stream contract:
 - Preflight availability: `GET /api/raw-events/status`
 - Event streaming: `POST /api/raw-events`
 - Non-2xx and network failures are treated as stream failures.
-- There is no plugin-side CLI fallback path.
+- Raw events are delivered through the viewer ingest API.
 - Raw-event batches accepted by the viewer are retried by Python flush workers.
 
 Suggested settings:


### PR DESCRIPTION
## Summary
- document runtime hook flush boundaries and stream reliability behavior in user-facing terms
- clarify viewer/raw-events ingestion semantics and queue retry ownership
- remove history-specific fallback phrasing and keep docs aligned with shipped behavior

## Verification
- reviewed docs content against current endpoints and commands: /api/raw-events, /api/raw-events/status, codemem raw-events-retry, codemem sync doctor