### PR TITLE
Isolate sync key paths in tests to prevent local key pollution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sync_keys_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))


### PR DESCRIPTION
## Summary
- add an autouse pytest fixture that forces `CODEMEM_KEYS_DIR` to a per-test temp path
- prevent sync CLI/identity tests that monkeypatch fake key generation from writing placeholder keys into `~/.config/codemem/keys`
- keep test behavior unchanged while hardening local-machine safety for contributors

## Why
Local test runs can exercise sync key setup paths. Several tests intentionally monkeypatch key generation with placeholder content (`private-key`/`public-key`), so missing key-path isolation can pollute real user keys. This PR isolates key paths globally for tests.

## Type
- [x] 🐛 Bug fix
- [x] 🧪 Testing

## Validation
- `uv run pytest tests/test_sync_cli.py tests/test_sync_identity.py tests/test_sync_viewer_api.py`
- `uv run ruff check tests/conftest.py tests/test_sync_cli.py tests/test_sync_viewer_api.py tests/test_sync_identity.py`

## Notes
- base branch: `main`
- this is the first PR in a stack; PR #79 builds on this isolation change