### PR TITLE
Fix pidfile sync daemon detection for python launcher

### DIFF
--- a/codemem/sync_runtime.py
+++ b/codemem/sync_runtime.py
@@ -220,6 +220,17 @@ def _matches_sync_daemon_invocation(
         ):
             return True
 
+    if start + 3 < len(tokens):
+        binary_name = _normalized_binary_name(tokens[start]).removesuffix(".exe")
+        script_name = _normalized_binary_name(tokens[start + 1]).removesuffix(".exe")
+        if (
+            (binary_name == "py" or binary_name.startswith("python"))
+            and script_name in allowed_binaries
+            and lowered[start + 2] == "sync"
+            and lowered[start + 3] == "daemon"
+        ):
+            return True
+
     return False
 
 

--- a/tests/test_sync_runtime.py
+++ b/tests/test_sync_runtime.py
@@ -168,6 +168,9 @@ def test_is_sync_daemon_command_accepts_direct_and_wrapped_invocations() -> None
     )
     assert sync_runtime._is_sync_daemon_command("python -m codemem sync daemon")
     assert sync_runtime._is_sync_daemon_command(
+        "/opt/homebrew/bin/python3 /Users/adam/workspace/codemem/.venv/bin/codemem sync daemon --host 0.0.0.0 --port 7337"
+    )
+    assert sync_runtime._is_sync_daemon_command(
         "codemem sync daemon --db-path /home/o'connor/.codemem/mem.sqlite"
     )
 


### PR DESCRIPTION
## Summary
- extend sync daemon PID command detection to accept interpreter-launched CLI invocations
- specifically support process commands like `python .../.venv/bin/codemem sync daemon ...`
- prevent false `pid_unverified` results that block `sync disable/stop` from signaling a real codemem daemon

## Why
In dev/local environments, the daemon may run through the Python interpreter with the `codemem` entrypoint path. The previous matcher only accepted direct binary or `python -m ...` forms, causing false negatives and confusing stop/disable behavior.

## Type
- [x] 🐛 Bug fix
- [x] 🧪 Testing

## Validation
- `uv run pytest tests/test_sync_runtime.py -k "sync_daemon_command or stop_pidfile"`
- `uv run ruff check codemem/sync_runtime.py tests/test_sync_runtime.py`