### PR TITLE
Prepare 0.11.0 release

### DIFF
--- a/codemem/__init__.py
+++ b/codemem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.10.2"
+__version__ = "0.11.0"

--- a/codemem/sync_runtime.py
+++ b/codemem/sync_runtime.py
@@ -220,6 +220,17 @@ def _matches_sync_daemon_invocation(
         ):
             return True
 
+    if start + 3 < len(tokens):
+        binary_name = _normalized_binary_name(tokens[start]).removesuffix(".exe")
+        script_name = _normalized_binary_name(tokens[start + 1]).removesuffix(".exe")
+        if (
+            (binary_name == "py" or binary_name.startswith("python"))
+            and script_name in allowed_binaries
+            and lowered[start + 2] == "sync"
+            and lowered[start + 3] == "daemon"
+        ):
+            return True
+
     return False
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kunickiaj/codemem",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "CodeMem plugin for OpenCode",
   "type": "module",
   "main": "index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ include = [
 
 [project]
 name = "codemem"
-version = "0.10.2"
+version = "0.11.0"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/tests/test_sync_runtime.py
+++ b/tests/test_sync_runtime.py
@@ -168,6 +168,9 @@ def test_is_sync_daemon_command_accepts_direct_and_wrapped_invocations() -> None
     )
     assert sync_runtime._is_sync_daemon_command("python -m codemem sync daemon")
     assert sync_runtime._is_sync_daemon_command(
+        "/opt/homebrew/bin/python3 /Users/adam/workspace/codemem/.venv/bin/codemem sync daemon --host 0.0.0.0 --port 7337"
+    )
+    assert sync_runtime._is_sync_daemon_command(
         "codemem sync daemon --db-path /home/o'connor/.codemem/mem.sqlite"
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "codemem"
-version = "0.10.2"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Summary
- bump package version from `0.10.2` to `0.11.0` in both `pyproject.toml` and `codemem/__init__.py`
- refresh `uv.lock` so lock metadata matches the new local package version

## Validation
- `uv sync`
- `uv run ruff check codemem tests`
- `HOME="/tmp/codemem-test-home" uv run pytest`
- `bun install && bun run build` (in `viewer_ui/`)

## Release Highlights (manual notes to supplement auto-generated release notes)
- Glance-first Viewer health UX with weighted status and actionable copy-to-clipboard recovery commands
- Sync status clarity improvements (`disabled`, `stopped`, `error`, `ok`) with deterministic remediation guidance
- Sync UI refresh stability fix (avoid transient `ok -> unknown` flicker during polling)
- Test hardening to isolate sync key paths and prevent local key pollution during test runs
- Runtime hardening for invalid sync keypairs with safer recovery behavior and non-crashing sync-pass errors
- PID verification fix for interpreter-launched sync daemons (`python .../.venv/bin/codemem sync daemon ...`)

## Stack
- This PR is stacked on #80 (pidfile daemon detection fix) and should merge after #80.