### PR TITLE
fix(sync): prevent cross-device session id collisions

### DIFF
--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -357,9 +357,9 @@ class MemoryStore:
         return grouped_total + ungrouped_total
 
     def _ensure_session_for_replication(
-        self, session_id: int, started_at: str | None, *, project: str | None = None
-    ) -> None:
-        store_replication._ensure_session_for_replication(
+        self, session_id: int | None, started_at: str | None, *, project: str | None = None
+    ) -> int | None:
+        return store_replication._ensure_session_for_replication(
             self, session_id, started_at, project=project
         )
 


### PR DESCRIPTION
## Summary
- Prefer stable `session_import_key` in replicated memory payloads, deriving `opencode:<session-id>` when available and falling back to deterministic legacy keys.
- Resolve inbound replicated memories by `session_import_key` first so numeric `session_id` collisions across devices no longer reattach memories to the wrong local project/session.
- Keep numeric `session_id` handling as a legacy fallback and add regression tests covering outbound payloads and collision avoidance behavior.

## Validation
- `uv run pytest tests/test_store.py -k \"session_import_key or replication_ops_roundtrip or numeric_collisions\"`
- `uv run pytest tests/test_sync_daemon.py -k \"apply_replication_ops_allows_cross_device_legacy_entity_id\"`
- `uv run ruff check codemem/store/replication.py codemem/store/_store.py tests/test_store.py`