### PR TITLE
Prepare 0.11.1 release

### DIFF
--- a/codemem/__init__.py
+++ b/codemem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.11.0"
+__version__ = "0.11.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kunickiaj/codemem",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "CodeMem plugin for OpenCode",
   "type": "module",
   "main": "index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ include = [
 
 [project]
 name = "codemem"
-version = "0.11.0"
+version = "0.11.1"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "codemem"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Summary
- Bump package version from `0.11.0` to `0.11.1` in both `pyproject.toml` and `codemem/__init__.py`.
- Regenerate `uv.lock` so the editable package version matches the release version.

## Validation
- `uv sync`
- `bun install` and `bun run build` in `viewer_ui/`
- `HOME=/tmp/codemem-release-home env -u CODEMEM_CONFIG -u CODEMEM_HYBRID_RETRIEVAL_ENABLED -u CODEMEM_HYBRID_RETRIEVAL_SHADOW_LOG -u CODEMEM_HYBRID_RETRIEVAL_SHADOW_SAMPLE_RATE uv run pytest`
- `uv run ruff check codemem tests`