### PR TITLE
fix(sync): keep offline peers informational in health UI

### DIFF
--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -700,7 +700,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const reductionPercent = parsePercentValue(reductionLabel);
     const tagCoverage = Number(dbStats.tags_coverage || 0);
     const syncState = String(syncStatus.daemon_state || "unknown");
-    const syncStateLabel = titleCase(syncState);
+    const syncStateLabel = syncState === "offline-peers" ? "Offline peers" : titleCase(syncState);
     const peerCount = Array.isArray(lastSyncPeers) ? lastSyncPeers.length : 0;
     const syncDisabled = syncState === "disabled" || syncStatus.enabled === false;
     const syncNoPeers = !syncDisabled && peerCount === 0;
@@ -837,7 +837,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         label: "Then run doctor to see root cause details.",
         command: "uv run codemem sync doctor"
       });
-    } else if (!syncDisabled && !syncNoPeers && syncLooksStale) {
+    } else if (!syncDisabled && !syncNoPeers && syncState === "offline-peers") ;
+    else if (!syncDisabled && !syncNoPeers && syncLooksStale) {
       recommendations.push({
         label: "Sync is stale. Run one immediate sync pass.",
         command: "uv run codemem sync once"
@@ -885,7 +886,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const pending = Number(status.pending || 0);
     const daemonDetail = String(status.daemon_detail || "");
     const daemonState = String(status.daemon_state || "unknown");
-    const daemonStateLabel = titleCase(daemonState);
+    const daemonStateLabel = daemonState === "offline-peers" ? "Offline peers" : titleCase(daemonState);
     const syncDisabled = daemonState === "disabled" || status.enabled === false;
     const peerCount = Object.keys(peers).length;
     const syncNoPeers = !syncDisabled && peerCount === 0;
@@ -895,6 +896,9 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         `Peers: ${peerCount}`,
         lastSync ? `Last sync: ${formatAgeShort(secondsSince(lastSync))} ago` : "Last sync: never"
       ];
+      if (daemonState === "offline-peers") {
+        parts.push("All peers are currently offline; sync will resume automatically");
+      }
       if (daemonDetail && daemonState === "stopped") {
         parts.push(`Detail: ${daemonDetail}`);
       }
@@ -972,6 +976,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     }
     const actions = [];
     if (syncNoPeers) ;
+    else if (daemonState === "offline-peers") ;
     else if (daemonState === "stopped") {
       actions.push({
         label: "Sync daemon is stopped. Start it.",

--- a/viewer_ui/src/app.ts
+++ b/viewer_ui/src/app.ts
@@ -866,7 +866,7 @@ function renderHealthOverview() {
   const reductionPercent = parsePercentValue(reductionLabel);
   const tagCoverage = Number(dbStats.tags_coverage || 0);
   const syncState = String(syncStatus.daemon_state || 'unknown');
-  const syncStateLabel = titleCase(syncState);
+  const syncStateLabel = syncState === 'offline-peers' ? 'Offline peers' : titleCase(syncState);
   const peerCount = Array.isArray(lastSyncPeers) ? lastSyncPeers.length : 0;
   const syncDisabled = syncState === 'disabled' || syncStatus.enabled === false;
   const syncNoPeers = !syncDisabled && peerCount === 0;
@@ -1018,6 +1018,8 @@ function renderHealthOverview() {
       label: 'Then run doctor to see root cause details.',
       command: 'uv run codemem sync doctor',
     });
+  } else if (!syncDisabled && !syncNoPeers && syncState === 'offline-peers') {
+    // Informational state: peers are currently offline.
   } else if (!syncDisabled && !syncNoPeers && syncLooksStale) {
     recommendations.push({
       label: 'Sync is stale. Run one immediate sync pass.',
@@ -1071,7 +1073,7 @@ function renderSyncStatus(status: any) {
   const pending = Number(status.pending || 0);
   const daemonDetail = String(status.daemon_detail || '');
   const daemonState = String(status.daemon_state || 'unknown');
-  const daemonStateLabel = titleCase(daemonState);
+  const daemonStateLabel = daemonState === 'offline-peers' ? 'Offline peers' : titleCase(daemonState);
   const syncDisabled = daemonState === 'disabled' || status.enabled === false;
   const peerCount = Object.keys(peers).length;
   const syncNoPeers = !syncDisabled && peerCount === 0;
@@ -1088,6 +1090,9 @@ function renderSyncStatus(status: any) {
               ? `Last sync: ${formatAgeShort(secondsSince(lastSync))} ago`
               : 'Last sync: never',
           ];
+    if (daemonState === 'offline-peers') {
+      parts.push('All peers are currently offline; sync will resume automatically');
+    }
     if (daemonDetail && daemonState === 'stopped') {
       parts.push(`Detail: ${daemonDetail}`);
     }
@@ -1179,6 +1184,8 @@ function renderSyncStatus(status: any) {
   const actions: Array<{ label: string; command: string }> = [];
   if (syncNoPeers) {
     // No remediation needed when no peers are configured.
+  } else if (daemonState === 'offline-peers') {
+    // Informational state: no manual remediation needed.
   } else if (daemonState === 'stopped') {
     actions.push({
       label: 'Sync daemon is stopped. Start it.',


### PR DESCRIPTION
## Description
Adjust sync health classification so peers being offline does not surface as an unhealthy daemon error.
This adds an informational `offline-peers` state, updates viewer health messaging/actions to avoid restart guidance for offline-only cases, and adds regression coverage for offline/degraded/error scenarios.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran:
- `uv run pytest tests/test_sync_viewer_api.py` (23 passed)

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced