### PR TITLE
docs(agents): require PR template completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,17 @@ This repo does not have a separate JS build step (no Vite/Next/etc). The UI is e
   - `codemem/viewer.py` (UI kind lists)
   - `tests/test_e2e_pipeline.py` coverage around documented types
 
+## PR Hygiene (Required)
+
+- Always use `.github/PULL_REQUEST_TEMPLATE.md` for every PR.
+- Replace all template placeholder text before requesting review.
+- Complete all checklist sections accurately:
+  - Type of Change
+  - Testing
+  - Checklist
+- Apply this to every PR in a stack (base PR and each follow-up PR).
+- Keep PR titles/bodies and commit messages free of private inspiration references or other non-public context.
+
 ## Releases
 - Bump versions:
   - `pyproject.toml` (semver)


### PR DESCRIPTION
## Description
Add explicit agent workflow rules requiring pull request bodies to be fully completed from the repository PR template for every PR, including stacked follow-ups.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
