### PR TITLE
fix(viewer): remove violet theme variant before 0.12

### DIFF
--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -183,15 +183,9 @@
     }
   });
   function resolveTheme(themeId) {
-    const aliases = {
-      "light-warm": "light",
-      "dark-nocturne": "dark-aurora",
-      "dark-violet": "dark-aurora"
-    };
-    const normalized = aliases[themeId] || themeId;
-    const exact = THEME_OPTIONS.find((theme) => theme.id === normalized);
+    const exact = THEME_OPTIONS.find((theme) => theme.id === themeId);
     if (exact) return exact;
-    const fallback = normalized.startsWith("dark") ? "dark" : "light";
+    const fallback = themeId.startsWith("dark") ? "dark" : "light";
     return THEME_OPTIONS.find((theme) => theme.id === fallback) || THEME_OPTIONS[0];
   }
   function getTheme() {

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -100,7 +100,6 @@
   const THEME_OPTIONS = [
     { id: "light", label: "Light (Classic)", mode: "light" },
     { id: "dark", label: "Dark (Classic)", mode: "dark" },
-    { id: "dark-violet", label: "Dark (Violet)", mode: "dark" },
     { id: "dark-aurora", label: "Dark (Aurora)", mode: "dark" }
   ];
   let feedTypeFilter = "all";
@@ -186,7 +185,8 @@
   function resolveTheme(themeId) {
     const aliases = {
       "light-warm": "light",
-      "dark-nocturne": "dark-violet"
+      "dark-nocturne": "dark-aurora",
+      "dark-violet": "dark-aurora"
     };
     const normalized = aliases[themeId] || themeId;
     const exact = THEME_OPTIONS.find((theme) => theme.id === normalized);

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -14,19 +14,11 @@
           if (!rawTheme) {
             return;
           }
-          var normalizedTheme = rawTheme;
-          if (rawTheme === 'light-warm') {
-            normalizedTheme = 'light';
-          } else if (rawTheme === 'dark-nocturne') {
-            normalizedTheme = 'dark-aurora';
-          } else if (rawTheme === 'dark-violet') {
-            normalizedTheme = 'dark-aurora';
-          }
-          var mode = normalizedTheme.indexOf('dark') === 0 ? 'dark' : 'light';
+          var mode = rawTheme.indexOf('dark') === 0 ? 'dark' : 'light';
           document.documentElement.setAttribute('data-theme', mode);
           document.documentElement.setAttribute('data-color-mode', mode);
-          if (normalizedTheme !== mode) {
-            document.documentElement.setAttribute('data-theme-variant', normalizedTheme);
+          if (rawTheme !== mode) {
+            document.documentElement.setAttribute('data-theme-variant', rawTheme);
           }
         } catch (_error) {
           // Ignore localStorage access errors before app init.

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -18,7 +18,9 @@
           if (rawTheme === 'light-warm') {
             normalizedTheme = 'light';
           } else if (rawTheme === 'dark-nocturne') {
-            normalizedTheme = 'dark-violet';
+            normalizedTheme = 'dark-aurora';
+          } else if (rawTheme === 'dark-violet') {
+            normalizedTheme = 'dark-aurora';
           }
           var mode = normalizedTheme.indexOf('dark') === 0 ? 'dark' : 'light';
           document.documentElement.setAttribute('data-theme', mode);
@@ -173,41 +175,6 @@
         --body-base-mid: #1f1e1d;
         --body-base-end: #242322;
         --dot-color: rgba(255, 255, 255, 0.04);
-      }
-      [data-theme-variant="dark-violet"] {
-        --bg: #0b0f1f;
-        --ink: #f7f3ff;
-        --text: #f7f3ff;
-        --muted: #cdc7ee;
-        --card: #2a315f;
-        --accent: #9d8cff;
-        --accent-2: #cf9aff;
-        --accent-3: #d4c3ff;
-        --border: #50588e;
-        --control-text: #e0beff;
-        --control-hover-text: #f2deff;
-        --toggle-active-bg: rgba(224, 190, 255, 0.28);
-        --toggle-active-text: #f2e7ff;
-        --toggle-hover-bg: rgba(224, 190, 255, 0.2);
-        --toggle-hover-text: #f7efff;
-        --feed-hover-bg: var(--item-bg);
-        --feed-hover-border: #f070ff;
-        --feed-hover-border-left: #f070ff;
-        --placeholder-text: #efe8ff;
-        --status-attention: #ff9e7a;
-        --focus-ring: rgba(157, 140, 255, 0.3);
-        --header-bg: rgba(20, 26, 52, 0.9);
-        --input-bg: rgba(48, 58, 107, 0.95);
-        --item-bg: rgba(57, 68, 122, 0.95);
-        --item-hover-bg: rgba(69, 80, 143, 0.97);
-        --stat-bg: #3a457f;
-        --body-grad-1: rgba(157, 140, 255, 0.2);
-        --body-grad-2: rgba(207, 154, 255, 0.16);
-        --body-grad-3: rgba(113, 226, 255, 0.1);
-        --body-base-start: #090c1a;
-        --body-base-mid: #101733;
-        --body-base-end: #171f45;
-        --dot-color: rgba(224, 217, 255, 0.05);
       }
       [data-theme-variant="dark-aurora"] {
         --bg: #0d1420;

--- a/viewer_ui/src/app.ts
+++ b/viewer_ui/src/app.ts
@@ -228,15 +228,9 @@ function isUserInteracting() {
 
 
 function resolveTheme(themeId: string): ThemeOption {
-  const aliases: Record<string, string> = {
-    'light-warm': 'light',
-    'dark-nocturne': 'dark-aurora',
-    'dark-violet': 'dark-aurora',
-  };
-  const normalized = aliases[themeId] || themeId;
-  const exact = THEME_OPTIONS.find((theme) => theme.id === normalized);
+  const exact = THEME_OPTIONS.find((theme) => theme.id === themeId);
   if (exact) return exact;
-  const fallback = normalized.startsWith('dark') ? 'dark' : 'light';
+  const fallback = themeId.startsWith('dark') ? 'dark' : 'light';
   return THEME_OPTIONS.find((theme) => theme.id === fallback) || THEME_OPTIONS[0];
 }
 

--- a/viewer_ui/src/app.ts
+++ b/viewer_ui/src/app.ts
@@ -114,7 +114,6 @@ type ThemeOption = {
 const THEME_OPTIONS: ThemeOption[] = [
   { id: 'light', label: 'Light (Classic)', mode: 'light' },
   { id: 'dark', label: 'Dark (Classic)', mode: 'dark' },
-  { id: 'dark-violet', label: 'Dark (Violet)', mode: 'dark' },
   { id: 'dark-aurora', label: 'Dark (Aurora)', mode: 'dark' },
 ];
 let feedTypeFilter = 'all';
@@ -231,7 +230,8 @@ function isUserInteracting() {
 function resolveTheme(themeId: string): ThemeOption {
   const aliases: Record<string, string> = {
     'light-warm': 'light',
-    'dark-nocturne': 'dark-violet',
+    'dark-nocturne': 'dark-aurora',
+    'dark-violet': 'dark-aurora',
   };
   const normalized = aliases[themeId] || themeId;
   const exact = THEME_OPTIONS.find((theme) => theme.id === normalized);


### PR DESCRIPTION
## Description
Remove the `Dark (Violet)` viewer theme variant ahead of the 0.12 release and keep dark theme choices focused on Classic and Aurora.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
