### PR TITLE
chore(beads): switch codemem to embedded dolt mode

### DIFF
--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,4 +1,7 @@
 {
-  "database": "beads.db",
-  "jsonl_export": "issues.jsonl"
+  "database": "dolt",
+  "jsonl_export": "issues.jsonl",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "beads_codemem"
 }


### PR DESCRIPTION
## Description
Switch codemem beads metadata from Dolt server mode to embedded mode so local Beads commands no longer require a running Dolt SQL server on 127.0.0.1:3307.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
