### PR TITLE
chore(beads): ignore local Dolt runtime artifacts

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -39,6 +39,13 @@ beads.right.meta.json
 sync_base.jsonl
 export-state/
 
+# Dolt runtime artifacts (local only)
+dolt/
+dolt-access.lock
+sql-server.pid
+sql-server.log
+*.corrupt.backup/
+
 # NOTE: Do NOT add negation patterns (e.g., !issues.jsonl) here.
 # They would override fork protection in .git/info/exclude, allowing
 # contributors to accidentally commit upstream issue databases.


### PR DESCRIPTION
## Description
Add ignore rules for local Dolt runtime artifacts in `.beads/.gitignore` so lock files, local Dolt directories, and corruption backup folders do not appear as untracked changes.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
