### PR TITLE
fix(sync): exponential backoff for offline peers in daemon tick

### DIFF
--- a/codemem/sync/sync_pass.py
+++ b/codemem/sync/sync_pass.py
@@ -323,7 +323,6 @@ _CONNECTIVITY_ERROR_PATTERNS = (
     "timed out",
     "name or service not known",
     "nodename nor servname provided",
-    "all addresses failed",
     "errno 65",
     "errno 61",
     "errno 60",

--- a/codemem/sync/sync_pass.py
+++ b/codemem/sync/sync_pass.py
@@ -315,6 +315,95 @@ def sync_once(
     return {"ok": False, "error": error, "address_errors": address_errors}
 
 
+# Connectivity errors that indicate a peer is offline (not a protocol/auth issue).
+_CONNECTIVITY_ERROR_PATTERNS = (
+    "no route to host",
+    "connection refused",
+    "network is unreachable",
+    "timed out",
+    "name or service not known",
+    "nodename nor servname provided",
+    "all addresses failed",
+    "errno 65",
+    "errno 61",
+    "errno 60",
+    "errno 111",
+)
+
+# After consecutive connectivity failures, back off: 2min, 4min, 8min, ..., max 30min.
+_PEER_BACKOFF_BASE_S = 120
+_PEER_BACKOFF_MAX_S = 1800
+
+
+def _is_connectivity_error(error: str | None) -> bool:
+    """Return True if the error string indicates a network connectivity failure."""
+    if not error:
+        return False
+    lower = error.lower()
+    return any(pattern in lower for pattern in _CONNECTIVITY_ERROR_PATTERNS)
+
+
+def _consecutive_connectivity_failures(
+    store: MemoryStore, peer_device_id: str, limit: int = 10
+) -> int:
+    """Count the number of consecutive recent failures that are connectivity errors."""
+    rows = store.conn.execute(
+        """
+        SELECT ok, error FROM sync_attempts
+        WHERE peer_device_id = ?
+        ORDER BY started_at DESC
+        LIMIT ?
+        """,
+        (peer_device_id, limit),
+    ).fetchall()
+    count = 0
+    for row in rows:
+        if row["ok"]:
+            break
+        if _is_connectivity_error(row["error"]):
+            count += 1
+        else:
+            break
+    return count
+
+
+def _peer_backoff_seconds(consecutive_failures: int) -> int:
+    """Calculate backoff duration based on consecutive connectivity failures."""
+    if consecutive_failures <= 1:
+        return 0
+    exponent = min(consecutive_failures - 1, 8)
+    return min(_PEER_BACKOFF_BASE_S * (2 ** (exponent - 1)), _PEER_BACKOFF_MAX_S)
+
+
+def _should_skip_offline_peer(store: MemoryStore, peer_device_id: str) -> bool:
+    """Return True if we should skip this peer due to repeated connectivity failures."""
+    failures = _consecutive_connectivity_failures(store, peer_device_id)
+    if failures < 2:
+        return False
+    backoff_s = _peer_backoff_seconds(failures)
+    if backoff_s <= 0:
+        return False
+    # Check when the last attempt was.
+    row = store.conn.execute(
+        """
+        SELECT started_at FROM sync_attempts
+        WHERE peer_device_id = ?
+        ORDER BY started_at DESC
+        LIMIT 1
+        """,
+        (peer_device_id,),
+    ).fetchone()
+    if not row or not row["started_at"]:
+        return False
+    try:
+        last_attempt = dt.datetime.fromisoformat(row["started_at"])
+        now = dt.datetime.now(dt.UTC)
+        elapsed = (now - last_attempt).total_seconds()
+        return elapsed < backoff_s
+    except (ValueError, TypeError):
+        return False
+
+
 def sync_daemon_tick(store: MemoryStore) -> list[dict[str, Any]]:
     sync_pass_preflight(store)
     rows = store.conn.execute("SELECT peer_device_id FROM sync_peers").fetchall()
@@ -322,5 +411,8 @@ def sync_daemon_tick(store: MemoryStore) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     for row in rows:
         peer_device_id = str(row["peer_device_id"])
+        if _should_skip_offline_peer(store, peer_device_id):
+            results.append({"ok": False, "skipped": True, "reason": "peer offline (backoff)"})
+            continue
         results.append(run_sync_pass(store, peer_device_id, mdns_entries=mdns_entries))
     return results

--- a/tests/test_sync_daemon.py
+++ b/tests/test_sync_daemon.py
@@ -851,3 +851,20 @@ def test_sync_daemon_tick_uses_run_sync_pass(monkeypatch, tmp_path: Path) -> Non
         assert set(called) == {"peer-1", "peer-2"}
     finally:
         store.close()
+
+
+def test_is_connectivity_error_ignores_generic_address_failure_prefix() -> None:
+    error = (
+        "all addresses failed | "
+        "http://a1.local: peer status failed (401: unauthorized:unknown_peer)"
+    )
+    assert sync_pass._is_connectivity_error(error) is False
+
+
+def test_is_connectivity_error_matches_connectivity_detail_in_address_summary() -> None:
+    error = (
+        "all addresses failed | "
+        "http://a1.local: peer status failed (503: unavailable) || "
+        "http://a2.local: [Errno 61] Connection refused"
+    )
+    assert sync_pass._is_connectivity_error(error) is True


### PR DESCRIPTION
## Description

The sync daemon attempts to sync with all peers every tick (~2min), even when peers are clearly offline. This generates thousands of redundant sync_attempts rows and noisy error logs. In one observed case, 14,598 attempts accumulated against an offline peer.

Now the daemon detects consecutive connectivity failures per peer and applies exponential backoff before retrying.

## Type of Change

- [x] Bug fix (fixes an issue)

## What Changed

Added to `sync_pass.py`:
- `_is_connectivity_error()` — detects network errors (No route to host, Connection refused, timed out, etc.) vs protocol/auth errors
- `_consecutive_connectivity_failures()` — counts recent consecutive connectivity failures from sync_attempts
- `_peer_backoff_seconds()` — exponential backoff: 2min after 2 failures, 4min after 3, up to 30min max
- `_should_skip_offline_peer()` — checks if backoff window is still active
- `sync_daemon_tick()` — now skips peers in backoff, returns `{skipped: true}` for them

**Important:** Manual sync (`codemem sync once`, viewer Sync Now button) is unaffected and always attempts regardless of backoff state. Backoff only applies to the automatic daemon tick cycle.

When a peer comes back online, the next attempt after the backoff window expires will succeed, resetting the consecutive failure count and restoring normal sync frequency.

## Testing

- [x] Tests pass locally (406 passed)
- [x] Manually verified: peer was offline since Feb 16, confirmed sync works when online
- [x] ruff check passes

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced