### PR TITLE
fix(ingest): normalize Windows-style project labels deterministically

### DIFF
--- a/codemem/plugin_ingest.py
+++ b/codemem/plugin_ingest.py
@@ -5,7 +5,7 @@ import os
 import sys
 from collections.abc import Iterable
 from dataclasses import asdict
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 from . import db
@@ -271,6 +271,11 @@ def _normalize_project_label(value: Any) -> str | None:
     if not text:
         return None
     if "/" in text or "\\" in text:
+        looks_like_windows_path = "\\" in text or (
+            len(text) >= 2 and text[1] == ":" and text[0].isalpha()
+        )
+        if looks_like_windows_path:
+            return PureWindowsPath(text).name or None
         return Path(text).name or None
     return text
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -84,6 +84,17 @@ Failure semantics:
 - Availability checks are rate-limited (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`).
 - Accepted raw-event batches are retried by viewer/store queue workers (`codemem raw-events-retry`).
 
+## Project label normalization
+
+When ingesting plugin payloads, CodeMem stores a normalized project label instead of a full path.
+
+- Path-like labels are reduced to the basename (for example, `/Users/adam/workspace/codemem` -> `codemem`).
+- Windows-style paths are normalized with Windows path rules on every OS runtime.
+  - `C:\Users\adam\workspace\codemem` -> `codemem`
+  - `D:/dev/client-demo` -> `client-demo`
+  - `\\server\share\team\project-x` -> `project-x`
+- `CODEMEM_PROJECT` still has highest precedence and is normalized the same way.
+
 ## Environment hints
 
 | Env var | Description |

--- a/tests/test_plugin_ingest.py
+++ b/tests/test_plugin_ingest.py
@@ -11,6 +11,7 @@ from codemem.plugin_ingest import (
     _budget_tool_events,
     _build_transcript,
     _event_to_tool_event,
+    _normalize_project_label,
     _resolve_ingest_project,
     ingest,
 )
@@ -210,6 +211,21 @@ def test_resolve_ingest_project_ignores_non_string_payload_values() -> None:
             pre_project="/Users/adam/.local/share/opencode/worktree/abc123/crisp-canyon",
         )
     assert project == "codemem"
+
+
+def test_normalize_project_label_uses_windows_path_rules_for_backslashes() -> None:
+    value = r"C:\Users\adam\workspace\codemem"
+    assert _normalize_project_label(value) == "codemem"
+
+
+def test_normalize_project_label_uses_windows_path_rules_for_drive_prefix_with_slashes() -> None:
+    value = "D:/dev/client-demo"
+    assert _normalize_project_label(value) == "client-demo"
+
+
+def test_normalize_project_label_uses_windows_path_rules_for_unc_paths() -> None:
+    value = r"\\server\share\team\project-x"
+    assert _normalize_project_label(value) == "project-x"
 
 
 def test_ingest_with_tool_events_does_not_crash(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description
Normalize Windows-style project path labels in plugin ingest using Windows path semantics on all runtimes, so cross-platform payloads resolve to stable basenames. Also documents the expected normalization behavior.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced