### PR TITLE
feat(viewer): add feed infinite scroll with paginated APIs

### DIFF
--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -1225,7 +1225,7 @@ class MemoryStore:
         return results
 
     def recent(
-        self, limit: int = 10, filters: dict[str, Any] | None = None
+        self, limit: int = 10, filters: dict[str, Any] | None = None, offset: int = 0
     ) -> list[dict[str, Any]]:
         filters = filters or {}
         params: list[Any] = []
@@ -1245,8 +1245,11 @@ class MemoryStore:
         if join_sessions:
             from_clause = "memory_items JOIN sessions ON sessions.id = memory_items.session_id"
         rows = self.conn.execute(
-            f"SELECT memory_items.* FROM {from_clause} WHERE {where_clause} ORDER BY created_at DESC LIMIT ?",
-            (*params, limit),
+            (
+                f"SELECT memory_items.* FROM {from_clause} "
+                f"WHERE {where_clause} ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            ),
+            (*params, limit, max(offset, 0)),
         ).fetchall()
         results = db.rows_to_dicts(rows)
         for item in results:
@@ -1260,6 +1263,7 @@ class MemoryStore:
             tokens_read=tokens_read,
             metadata={
                 "limit": limit,
+                "offset": offset,
                 "results": len(results),
                 "kind": filters.get("kind"),
                 "project": filters.get("project"),
@@ -1272,6 +1276,7 @@ class MemoryStore:
         kinds: Iterable[str],
         limit: int = 10,
         filters: dict[str, Any] | None = None,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         filters = filters or {}
         kinds_list = [str(kind) for kind in kinds if kind]
@@ -1294,8 +1299,11 @@ class MemoryStore:
         if join_sessions:
             from_clause = "memory_items JOIN sessions ON sessions.id = memory_items.session_id"
         rows = self.conn.execute(
-            f"SELECT memory_items.* FROM {from_clause} WHERE {where_clause} ORDER BY created_at DESC LIMIT ?",
-            (*params, limit),
+            (
+                f"SELECT memory_items.* FROM {from_clause} "
+                f"WHERE {where_clause} ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            ),
+            (*params, limit, max(offset, 0)),
         ).fetchall()
         results = db.rows_to_dicts(rows)
         for item in results:
@@ -1309,6 +1317,7 @@ class MemoryStore:
             tokens_read=tokens_read,
             metadata={
                 "limit": limit,
+                "offset": offset,
                 "results": len(results),
                 "kinds": kinds_list,
                 "project": filters.get("project"),

--- a/tests/test_viewer_routes_memory.py
+++ b/tests/test_viewer_routes_memory.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from codemem.store import MemoryStore
+from codemem.viewer_routes import memory
+
+
+class DummyHandler:
+    def __init__(self) -> None:
+        self.response: dict[str, Any] | None = None
+        self.status: int | None = None
+
+    def _send_json(self, payload: dict[str, Any], status: int = 200) -> None:
+        self.response = payload
+        self.status = status
+
+
+def _seed_items(store: MemoryStore, *, kind: str, count: int) -> None:
+    row = store.conn.execute(
+        """
+        INSERT INTO sessions(started_at, cwd, project, user, tool_version)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        ("2026-01-01T00:00:00Z", "/tmp/work", "proj", "tester", "test"),
+    )
+    session_id = int(row.lastrowid or 0)
+    for index in range(count):
+        timestamp = f"2026-01-01T00:00:{index:02d}Z"
+        store.conn.execute(
+            """
+            INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (session_id, kind, f"{kind}-{index}", f"body-{index}", timestamp, timestamp),
+        )
+    store.conn.commit()
+
+
+def test_observations_endpoint_supports_offset_pagination(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        _seed_items(store, kind="bugfix", count=5)
+        handler = DummyHandler()
+
+        handled = memory.handle_get(handler, store, "/api/observations", "limit=2&offset=0")
+
+        assert handled is True
+        assert handler.status == 200
+        assert handler.response is not None
+        assert len(handler.response["items"]) == 2
+        assert handler.response["pagination"] == {
+            "limit": 2,
+            "offset": 0,
+            "next_offset": 2,
+            "has_more": True,
+        }
+
+        next_handler = DummyHandler()
+        handled = memory.handle_get(next_handler, store, "/api/observations", "limit=2&offset=4")
+
+        assert handled is True
+        assert next_handler.status == 200
+        assert next_handler.response is not None
+        assert len(next_handler.response["items"]) == 1
+        assert next_handler.response["pagination"] == {
+            "limit": 2,
+            "offset": 4,
+            "next_offset": None,
+            "has_more": False,
+        }
+    finally:
+        store.close()
+
+
+def test_summaries_endpoint_supports_offset_pagination(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        _seed_items(store, kind="session_summary", count=3)
+        handler = DummyHandler()
+
+        handled = memory.handle_get(handler, store, "/api/summaries", "limit=2&offset=0")
+
+        assert handled is True
+        assert handler.status == 200
+        assert handler.response is not None
+        assert len(handler.response["items"]) == 2
+        assert handler.response["pagination"] == {
+            "limit": 2,
+            "offset": 0,
+            "next_offset": 2,
+            "has_more": True,
+        }
+    finally:
+        store.close()
+
+
+def test_observations_endpoint_rejects_invalid_pagination_params(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        handler = DummyHandler()
+
+        handled = memory.handle_get(handler, store, "/api/observations", "limit=abc&offset=0")
+
+        assert handled is True
+        assert handler.status == 400
+        assert handler.response == {"error": "limit and offset must be int"}
+    finally:
+        store.close()

--- a/viewer_ui/src/lib/api.ts
+++ b/viewer_ui/src/lib/api.ts
@@ -23,11 +23,35 @@ export async function loadRawEvents(project: string): Promise<any> {
 }
 
 export async function loadMemories(project: string): Promise<any> {
-  return fetchJson(`/api/memories?project=${encodeURIComponent(project)}`);
+  return loadMemoriesPage(project);
+}
+
+function buildProjectParams(project: string, limit?: number, offset?: number): string {
+  const params = new URLSearchParams();
+  params.set('project', project || '');
+  if (typeof limit === 'number') params.set('limit', String(limit));
+  if (typeof offset === 'number') params.set('offset', String(offset));
+  return params.toString();
+}
+
+export async function loadMemoriesPage(
+  project: string,
+  options?: { limit?: number; offset?: number },
+): Promise<any> {
+  const query = buildProjectParams(project, options?.limit, options?.offset);
+  return fetchJson(`/api/memories?${query}`);
 }
 
 export async function loadSummaries(project: string): Promise<any> {
-  return fetchJson(`/api/summaries?project=${encodeURIComponent(project)}`);
+  return loadSummariesPage(project);
+}
+
+export async function loadSummariesPage(
+  project: string,
+  options?: { limit?: number; offset?: number },
+): Promise<any> {
+  const query = buildProjectParams(project, options?.limit, options?.offset);
+  return fetchJson(`/api/summaries?${query}`);
 }
 
 export async function loadConfig(): Promise<any> {

--- a/viewer_ui/src/tabs/feed.ts
+++ b/viewer_ui/src/tabs/feed.ts
@@ -70,6 +70,57 @@ function itemKey(item: any): string {
 
 type ItemViewMode = 'summary' | 'facts' | 'narrative';
 
+const OBSERVATION_PAGE_SIZE = 20;
+const SUMMARY_PAGE_SIZE = 50;
+const FEED_SCROLL_THRESHOLD_PX = 560;
+
+let lastFeedProject = '';
+let observationOffset = 0;
+let summaryOffset = 0;
+let observationHasMore = true;
+let summaryHasMore = true;
+let loadMoreInFlight = false;
+let feedScrollHandlerBound = false;
+
+function resetPagination(project: string) {
+  lastFeedProject = project;
+  observationOffset = 0;
+  summaryOffset = 0;
+  observationHasMore = true;
+  summaryHasMore = true;
+}
+
+function isNearFeedBottom(): boolean {
+  const root = document.documentElement;
+  const height = Math.max(root.scrollHeight, document.body.scrollHeight);
+  return window.innerHeight + window.scrollY >= height - FEED_SCROLL_THRESHOLD_PX;
+}
+
+function pageHasMore(payload: any, count: number, limit: number): boolean {
+  const value = payload?.pagination?.has_more;
+  if (typeof value === 'boolean') return value;
+  return count >= limit;
+}
+
+function pageNextOffset(payload: any, count: number): number {
+  const value = payload?.pagination?.next_offset;
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
+  return count;
+}
+
+function hasMorePages(): boolean {
+  return observationHasMore || summaryHasMore;
+}
+
+function mergeFeedItems(currentItems: any[], incomingItems: any[]): any[] {
+  const byKey = new Map<string, any>();
+  currentItems.forEach((item) => byKey.set(itemKey(item), item));
+  incomingItems.forEach((item) => byKey.set(itemKey(item), item));
+  return Array.from(byKey.values()).sort((a, b) => {
+    return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
+  });
+}
+
 /* ── Summary object extraction ───────────────────────────── */
 
 function getSummaryObject(item: any): Record<string, any> | null {
@@ -359,6 +410,59 @@ function countNewItems(nextItems: any[], currentItems: any[]): number {
   return nextItems.filter((i) => !seen.has(itemKey(i))).length;
 }
 
+async function loadMoreFeedPage() {
+  if (loadMoreInFlight || !hasMorePages()) return;
+  loadMoreInFlight = true;
+  try {
+    const [observations, summaries] = await Promise.all([
+      observationHasMore
+        ? api.loadMemoriesPage(state.currentProject, {
+            limit: OBSERVATION_PAGE_SIZE,
+            offset: observationOffset,
+          })
+        : Promise.resolve({ items: [], pagination: { has_more: false, next_offset: observationOffset } }),
+      summaryHasMore
+        ? api.loadSummariesPage(state.currentProject, {
+            limit: SUMMARY_PAGE_SIZE,
+            offset: summaryOffset,
+          })
+        : Promise.resolve({ items: [], pagination: { has_more: false, next_offset: summaryOffset } }),
+    ]);
+
+    const summaryItems = summaries.items || [];
+    const observationItems = observations.items || [];
+    const filtered = observationItems.filter((i: any) => !isLowSignalObservation(i));
+    state.lastFeedFilteredCount += observationItems.length - filtered.length;
+
+    summaryHasMore = pageHasMore(summaries, summaryItems.length, SUMMARY_PAGE_SIZE);
+    observationHasMore = pageHasMore(observations, observationItems.length, OBSERVATION_PAGE_SIZE);
+    summaryOffset = pageNextOffset(summaries, summaryOffset + summaryItems.length);
+    observationOffset = pageNextOffset(observations, observationOffset + observationItems.length);
+
+    const incoming = [...summaryItems, ...filtered];
+    const feedItems = mergeFeedItems(state.lastFeedItems, incoming);
+    const newCount = countNewItems(feedItems, state.lastFeedItems);
+    if (newCount) {
+      const seen = new Set(state.lastFeedItems.map(itemKey));
+      feedItems.forEach((item: any) => {
+        if (!seen.has(itemKey(item))) state.newItemKeys.add(itemKey(item));
+      });
+    }
+
+    state.lastFeedItems = feedItems;
+    updateFeedView();
+  } finally {
+    loadMoreInFlight = false;
+  }
+}
+
+function maybeLoadMoreFeedPage() {
+  if (state.activeTab !== 'feed') return;
+  if (!hasMorePages()) return;
+  if (!isNearFeedBottom()) return;
+  void loadMoreFeedPage();
+}
+
 /* ── Public API ──────────────────────────────────────────── */
 
 export function initFeedTab() {
@@ -379,6 +483,13 @@ export function initFeedTab() {
     state.feedQuery = feedSearch.value || '';
     updateFeedView();
   });
+
+  if (!feedScrollHandlerBound) {
+    window.addEventListener('scroll', () => {
+      maybeLoadMoreFeedPage();
+    }, { passive: true });
+    feedScrollHandlerBound = true;
+  }
 }
 
 export function updateFeedTypeToggle() {
@@ -407,7 +518,8 @@ export function updateFeedView() {
   if (feedMeta) {
     const filteredLabel = !state.feedQuery.trim() && state.lastFeedFilteredCount ? ` · ${state.lastFeedFilteredCount} observations filtered` : '';
     const queryLabel = state.feedQuery.trim() ? ` · matching "${state.feedQuery.trim()}"` : '';
-    feedMeta.textContent = `${visible.length} items${filterLabel}${queryLabel}${filteredLabel}`;
+    const moreLabel = hasMorePages() ? ' · scroll for more' : '';
+    feedMeta.textContent = `${visible.length} items${filterLabel}${queryLabel}${filteredLabel}${moreLabel}`;
   }
 
   if (changed) {
@@ -421,12 +533,21 @@ export function updateFeedView() {
   }
 
   window.scrollTo({ top: scrollY });
+  maybeLoadMoreFeedPage();
 }
 
 export async function loadFeedData() {
+  const project = state.currentProject || '';
+  if (project !== lastFeedProject) {
+    resetPagination(project);
+  }
+
+  const observationsLimit = Math.max(OBSERVATION_PAGE_SIZE, observationOffset || OBSERVATION_PAGE_SIZE);
+  const summariesLimit = Math.max(SUMMARY_PAGE_SIZE, summaryOffset || SUMMARY_PAGE_SIZE);
+
   const [observations, summaries] = await Promise.all([
-    api.loadMemories(state.currentProject),
-    api.loadSummaries(state.currentProject),
+    api.loadMemoriesPage(project, { limit: observationsLimit, offset: 0 }),
+    api.loadSummariesPage(project, { limit: summariesLimit, offset: 0 }),
   ]);
 
   const summaryItems = summaries.items || [];
@@ -448,5 +569,9 @@ export async function loadFeedData() {
   state.pendingFeedItems = null;
   state.lastFeedItems = feedItems;
   state.lastFeedFilteredCount = filteredCount;
+  summaryHasMore = pageHasMore(summaries, summaryItems.length, summariesLimit);
+  observationHasMore = pageHasMore(observations, observationItems.length, observationsLimit);
+  summaryOffset = pageNextOffset(summaries, summaryItems.length);
+  observationOffset = pageNextOffset(observations, observationItems.length);
   updateFeedView();
 }


### PR DESCRIPTION
## Description
Add offset-based pagination for `/api/observations` and `/api/summaries`, then wire the feed tab to progressively load additional pages as the user scrolls. This removes the fixed ~70-item ceiling and keeps feed browsing responsive for larger history.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced