### PR TITLE
fix(viewer): harden settings dialog accessibility

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1013,13 +1013,14 @@
 
     <!-- ── Settings modal ──────────────────────────────────── -->
     <div class="modal-backdrop" id="settingsBackdrop" hidden></div>
-    <div class="modal" id="settingsModal" hidden role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
+    <div class="modal" id="settingsModal" hidden role="dialog" aria-modal="true" aria-labelledby="settingsTitle" aria-describedby="settingsDescription" tabindex="-1">
       <div class="modal-card">
         <div class="modal-header">
           <h2 id="settingsTitle">Observer settings</h2>
-          <button class="modal-close" id="settingsClose">close</button>
+          <button class="modal-close" id="settingsClose" aria-label="Close settings">close</button>
         </div>
         <div class="modal-body">
+          <div class="small" id="settingsDescription">Update observer and sync defaults for this viewer.</div>
           <div class="field">
             <label for="observerProvider">Observer provider</label>
             <select id="observerProvider"><option value="">auto (default)</option></select>


### PR DESCRIPTION
## Description

Implements keyboard accessibility improvements for the settings modal, including focus trapping and proper focus management. When the modal opens, focus moves to the first focusable element, Tab navigation is constrained within the modal, and focus returns to the previously focused element when closed. Also adds ARIA attributes for better screen reader support.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced