### PR TITLE
feat(pack): collapse exact duplicates in memory packs

### DIFF
--- a/codemem/config.py
+++ b/codemem/config.py
@@ -16,6 +16,7 @@ CONFIG_ENV_OVERRIDES = {
     "observer_max_chars": "CODEMEM_OBSERVER_MAX_CHARS",
     "pack_observation_limit": "CODEMEM_PACK_OBSERVATION_LIMIT",
     "pack_session_limit": "CODEMEM_PACK_SESSION_LIMIT",
+    "pack_exact_dedupe_enabled": "CODEMEM_PACK_EXACT_DEDUPE_ENABLED",
     "hybrid_retrieval_enabled": "CODEMEM_HYBRID_RETRIEVAL_ENABLED",
     "hybrid_retrieval_shadow_log": "CODEMEM_HYBRID_RETRIEVAL_SHADOW_LOG",
     "hybrid_retrieval_shadow_sample_rate": "CODEMEM_HYBRID_RETRIEVAL_SHADOW_SAMPLE_RATE",
@@ -184,6 +185,7 @@ class OpencodeMemConfig:
     summary_max_chars: int = 6000
     pack_observation_limit: int = 50
     pack_session_limit: int = 10
+    pack_exact_dedupe_enabled: bool = True
     hybrid_retrieval_enabled: bool = False
     hybrid_retrieval_shadow_log: bool = False
     hybrid_retrieval_shadow_sample_rate: float = 1.0
@@ -327,6 +329,7 @@ def _apply_dict(cfg: OpencodeMemConfig, data: dict[str, Any]) -> OpencodeMemConf
             continue
         if key in {
             "use_opencode_run",
+            "pack_exact_dedupe_enabled",
             "hybrid_retrieval_enabled",
             "hybrid_retrieval_shadow_log",
             "viewer_auto",
@@ -377,6 +380,10 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
         os.getenv("CODEMEM_PACK_SESSION_LIMIT"),
         cfg.pack_session_limit,
         key="pack_session_limit",
+    )
+    cfg.pack_exact_dedupe_enabled = _parse_bool(
+        os.getenv("CODEMEM_PACK_EXACT_DEDUPE_ENABLED"),
+        cfg.pack_exact_dedupe_enabled,
     )
     cfg.hybrid_retrieval_enabled = _parse_bool(
         os.getenv("CODEMEM_HYBRID_RETRIEVAL_ENABLED"), cfg.hybrid_retrieval_enabled

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -98,6 +98,7 @@ class MemoryStore:
             self.device_id = str(row["device_id"]) if row else "local"
 
         cfg = load_config()
+        self._pack_exact_dedupe_enabled = bool(cfg.pack_exact_dedupe_enabled)
         self._hybrid_retrieval_enabled = bool(cfg.hybrid_retrieval_enabled)
         self._hybrid_retrieval_shadow_log = bool(cfg.hybrid_retrieval_shadow_log)
         self._hybrid_retrieval_shadow_sample_rate = float(cfg.hybrid_retrieval_shadow_sample_rate)

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -922,6 +922,8 @@
     const totals = usagePayload.totals_filtered || usagePayload.totals || usagePayload.totals_global || stats.usage?.totals || {};
     const recentPacks = Array.isArray(usagePayload.recent_packs) ? usagePayload.recent_packs : [];
     const lastPackAt = recentPacks.length ? recentPacks[0]?.created_at : null;
+    const latestPackMeta = recentPacks.length ? recentPacks[0]?.metadata_json || {} : {};
+    const latestPackDeduped = Number(latestPackMeta?.exact_duplicates_collapsed || 0);
     const rawPending = Number(raw.pending || 0);
     const erroredBatches = Number(counts.errored_batches || 0);
     const flushSuccessRate = Number(rates.flush_success_rate ?? 1);
@@ -1014,7 +1016,7 @@
       healthDot.className = `health-dot ${statusClass}`;
       healthDot.title = statusLabel;
     }
-    const retrievalDetail = `${Number(totals.tokens_saved || 0).toLocaleString()} saved tokens`;
+    const retrievalDetail = `${Number(totals.tokens_saved || 0).toLocaleString()} saved tokens · ${latestPackDeduped.toLocaleString()} deduped in latest pack`;
     const pipelineDetail = rawPending > 0 ? "Queue is actively draining" : "Queue is clear";
     const syncDetail = syncDisabled ? "Sync disabled" : syncNoPeers ? "No peers configured" : syncOfflinePeers ? `${peerCount} peers offline · last sync ${formatAgeShort(syncAgeSeconds)} ago` : `${peerCount} peers · last sync ${formatAgeShort(syncAgeSeconds)} ago`;
     const freshnessDetail = `last pack ${formatAgeShort(packAgeSeconds)} ago`;
@@ -1114,10 +1116,13 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const packEvent = events.find((e) => e?.event === "pack") || null;
     const recentPacks = Array.isArray(usagePayload?.recent_packs) ? usagePayload.recent_packs : [];
     const latestPack = recentPacks.length ? recentPacks[0] : null;
+    const latestPackMeta = latestPack?.metadata_json || {};
     const lastPackAt = latestPack?.created_at || "";
     const packCount = Number(packEvent?.count || 0);
     const packTokens = Number(latestPack?.tokens_read || 0);
     const savedTokens = Number(latestPack?.tokens_saved || 0);
+    const dedupedCount = Number(latestPackMeta?.exact_duplicates_collapsed || 0);
+    const dedupeEnabled = !!latestPackMeta?.exact_dedupe_enabled;
     const reductionPercent = formatReductionPercent(savedTokens, packTokens);
     const packLine = packCount ? `${packCount} packs` : "No packs yet";
     const lastPackLine = lastPackAt ? `Last pack: ${formatTimestamp(lastPackAt)}` : "";
@@ -1126,6 +1131,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const items = [
       { label: "Last pack savings", value: latestPack ? `${savedTokens.toLocaleString()} (${reductionPercent})` : "n/a", icon: "trending-up" },
       { label: "Last pack size", value: latestPack ? packTokens.toLocaleString() : "n/a", icon: "package" },
+      { label: "Last pack deduped", value: latestPack ? dedupedCount.toLocaleString() : "n/a", icon: "copy-check" },
+      { label: "Exact dedupe", value: latestPack ? dedupeEnabled ? "On" : "Off" : "n/a", icon: "shield-check" },
       { label: "Packs", value: packCount || 0, icon: "archive" }
     ];
     items.forEach((item) => {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -214,6 +214,37 @@ def test_load_config_hybrid_retrieval_invalid_env_uses_default(
     assert cfg.hybrid_retrieval_enabled is False
 
 
+def test_load_config_pack_exact_dedupe_default_true(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+
+    cfg = load_config(config_path)
+
+    assert cfg.pack_exact_dedupe_enabled is True
+
+
+def test_load_config_reads_pack_exact_dedupe_from_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"pack_exact_dedupe_enabled": false}\n')
+
+    cfg = load_config(config_path)
+
+    assert cfg.pack_exact_dedupe_enabled is False
+
+
+def test_load_config_reads_pack_exact_dedupe_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_PACK_EXACT_DEDUPE_ENABLED", "0")
+
+    cfg = load_config(config_path)
+
+    assert cfg.pack_exact_dedupe_enabled is False
+
+
 def test_load_config_reads_hybrid_shadow_settings(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Description

Adds exact duplicate detection and removal functionality to memory pack building. When enabled (default), the system identifies memories with identical normalized titles and bodies, collapses duplicates into a single canonical item, and tracks support counts and duplicate IDs. Also introduces a compaction shadow system for testing deduplication strategies without affecting live data.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced