### PR TITLE
fix(release): ship v0.14.1 project-filter hotfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,9 +230,13 @@ jobs:
                 properties: { tool: 'read', args: { filePath: 'README.md' } },
               },
             });
-            const sawCompatibilityWarning = toastMessages.some((msg) =>
-              msg.includes('older than required')
-            );
+            const hasCompatibilityWarning = () =>
+              toastMessages.some((msg) => msg.includes('older than required'));
+            const waitUntil = Date.now() + 5000;
+            while (!hasCompatibilityWarning() && Date.now() < waitUntil) {
+              await new Promise((resolve) => setTimeout(resolve, 50));
+            }
+            const sawCompatibilityWarning = hasCompatibilityWarning();
             if (!sawCompatibilityWarning) {
               throw new Error('expected compatibility warning toast from version probe');
             }

--- a/.opencode/lib/compat.js
+++ b/.opencode/lib/compat.js
@@ -31,13 +31,13 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
     if (normalizedFrom.startsWith("git+") || normalizedFrom.includes(".git")) {
       return {
         mode: "uvx-git",
-        action: `Update CODEMEM_RUNNER_FROM to a newer git ref/source (current: ${normalizedFrom || "<unset>"}), then restart OpenCode.`,
+        action: "Update CODEMEM_RUNNER_FROM to a newer git ref/source, then restart OpenCode.",
         note: "detected uvx git mode",
       };
     }
     return {
       mode: "uvx-custom",
-      action: `Update CODEMEM_RUNNER_FROM to a newer source (current: ${normalizedFrom || "<unset>"}), then restart OpenCode.`,
+      action: "Update CODEMEM_RUNNER_FROM to a newer source, then restart OpenCode.",
       note: "detected uvx custom source mode",
     };
   }
@@ -46,5 +46,92 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
     mode: "generic",
     action: "Run `uv tool install --upgrade codemem`, then restart OpenCode.",
     note: "fallback guidance",
+  };
+};
+
+export const parseBackendUpdatePolicy = (value) => {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return "notify";
+  if (["notify", "auto", "off"].includes(normalized)) {
+    return normalized;
+  }
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return "auto";
+  }
+  if (["0", "false", "no"].includes(normalized)) {
+    return "off";
+  }
+  return "notify";
+};
+
+const isPinnedGitSource = (runnerFrom) => {
+  const source = String(runnerFrom || "").trim();
+  if (!source) return false;
+  if (!(source.startsWith("git+") || source.includes(".git"))) {
+    return false;
+  }
+  const withoutQuery = source.replace(/[?#].*$/, "");
+  if (withoutQuery.includes(".git@")) {
+    return true;
+  }
+  if (!withoutQuery.startsWith("git+")) {
+    return false;
+  }
+  const urlValue = withoutQuery.slice(4);
+  try {
+    const parsed = new URL(urlValue);
+    const path = String(parsed.pathname || "");
+    if (path.includes(".git@")) {
+      return true;
+    }
+    return /@[^/]+$/.test(path);
+  } catch {
+    return /@[^/]+$/.test(withoutQuery);
+  }
+};
+
+export const resolveAutoUpdatePlan = ({ runner, runnerFrom }) => {
+  const normalizedRunner = String(runner || "").trim();
+  const source = String(runnerFrom || "").trim();
+
+  if (normalizedRunner === "uv") {
+    return {
+      allowed: false,
+      reason: "dev-runner",
+      command: null,
+      commandText: null,
+    };
+  }
+
+  if (normalizedRunner === "uvx") {
+    if (!source) {
+      return {
+        allowed: false,
+        reason: "missing-source",
+        command: null,
+        commandText: null,
+      };
+    }
+    if (isPinnedGitSource(source)) {
+      return {
+        allowed: false,
+        reason: "pinned-source",
+        command: null,
+        commandText: null,
+      };
+    }
+    return {
+      allowed: true,
+      reason: null,
+      command: ["uvx", "--refresh", "--from", source, "codemem", "version"],
+      commandText: "uvx --refresh --from <source> codemem version",
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: null,
+    command: ["uv", "tool", "install", "--upgrade", "codemem"],
+    commandText: "uv tool install --upgrade codemem",
   };
 };

--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -2,7 +2,13 @@ import { appendFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { tool } from "@opencode-ai/plugin";
 
-import { isVersionAtLeast, parseSemver, resolveUpgradeGuidance } from "../lib/compat.js";
+import {
+  isVersionAtLeast,
+  parseBackendUpdatePolicy,
+  parseSemver,
+  resolveAutoUpdatePlan,
+  resolveUpgradeGuidance,
+} from "../lib/compat.js";
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
@@ -170,6 +176,9 @@ export const OpencodeMemPlugin = async ({
   const commandTimeout = Number.parseInt(
     process.env.CODEMEM_PLUGIN_CMD_TIMEOUT || "20000",
     10
+  );
+  const backendUpdatePolicy = parseBackendUpdatePolicy(
+    process.env.CODEMEM_BACKEND_UPDATE_POLICY || "notify"
   );
 
   const parseNumber = (value, fallback) => {
@@ -548,9 +557,9 @@ export const OpencodeMemPlugin = async ({
     });
   };
 
-  const runCli = async (args) => {
+  const runCommand = async (cmd) => {
     const proc = Bun.spawn({
-      cmd: [runner, ...runnerArgs, ...args],
+      cmd,
       cwd,
       env: process.env,
       stdout: "pipe",
@@ -582,6 +591,27 @@ export const OpencodeMemPlugin = async ({
     return result;
   };
 
+  const runCli = async (args) => runCommand([runner, ...runnerArgs, ...args]);
+
+  const showToast = async (message, variant = "warning") => {
+    if (backendUpdatePolicy === "off") {
+      return;
+    }
+    if (!client.tui?.showToast) {
+      return;
+    }
+    try {
+      await client.tui.showToast({
+        body: {
+          message,
+          variant,
+        },
+      });
+    } catch (toastErr) {
+      // best-effort only
+    }
+  };
+
   const verifyCliCompatibility = async () => {
     const minVersion = process.env.CODEMEM_MIN_VERSION || "0.9.20";
     const versionResult = await runCli(["version"]);
@@ -606,21 +636,13 @@ export const OpencodeMemPlugin = async ({
         currentVersion,
         minVersion,
         runner,
-        runnerFrom,
+        runnerFromSet: Boolean(String(runnerFrom || "").trim()),
         upgradeMode: guidance.mode,
       });
-      if (client.tui?.showToast) {
-        try {
-          await client.tui.showToast({
-            body: {
-              message: `codemem compatibility check could not parse versions (cli='${currentVersion || "unknown"}', required='${minVersion}'). Suggested action: ${guidance.action}`,
-              variant: "warning",
-            },
-          });
-        } catch (toastErr) {
-          // best-effort only
-        }
-      }
+      await showToast(
+        `codemem compatibility check could not parse versions (cli='${currentVersion || "unknown"}', required='${minVersion}'). Suggested action: ${guidance.action}`,
+        "warning"
+      );
       return;
     }
 
@@ -634,25 +656,61 @@ export const OpencodeMemPlugin = async ({
       currentVersion,
       minVersion,
       runner,
-      runnerFrom,
+      runnerFromSet: Boolean(String(runnerFrom || "").trim()),
       upgradeMode: guidance.mode,
       upgradeAction: guidance.action,
     });
     await logLine(
       `compat.version_mismatch current=${currentVersion} required=${minVersion} mode=${guidance.mode} note=${redactLog(guidance.note)}`
     );
-    if (client.tui?.showToast) {
-      try {
-        await client.tui.showToast({
-          body: {
-            message: `${message}. Suggested action: ${guidance.action}`,
-            variant: "warning",
-          },
-        });
-      } catch (toastErr) {
-        // best-effort only
+
+    const autoPlan = resolveAutoUpdatePlan({ runner, runnerFrom });
+    if (backendUpdatePolicy === "auto") {
+      if (autoPlan.allowed && Array.isArray(autoPlan.command) && autoPlan.command.length > 0) {
+        const commandText = autoPlan.commandText || autoPlan.command.join(" ");
+        await logLine(`compat.auto_update_start cmd=${redactLog(commandText)}`);
+        const updateResult = await runCommand(autoPlan.command);
+        await logLine(
+          `compat.auto_update_result exit=${updateResult?.exitCode ?? "unknown"} stderr=${redactLog(
+            (updateResult?.stderr || "").trim()
+          )}`
+        );
+
+        const refreshedResult = await runCli(["version"]);
+        const refreshedVersion = (refreshedResult?.stdout || "").trim();
+        if (
+          updateResult?.exitCode === 0
+          && refreshedResult?.exitCode === 0
+          && isVersionAtLeast(refreshedVersion, minVersion)
+        ) {
+          await logLine(
+            `compat.auto_update_success before=${currentVersion} after=${refreshedVersion}`
+          );
+          await showToast(
+            `Updated codemem backend from ${currentVersion || "unknown"} to ${refreshedVersion}.`,
+            "success"
+          );
+          return;
+        }
+
+        await showToast(
+          `${message}. Auto-update did not resolve it. Suggested action: ${guidance.action}`,
+          "warning"
+        );
+        return;
       }
+
+      await logLine(
+        `compat.auto_update_skipped reason=${autoPlan.reason || "not-eligible"}`
+      );
+      await showToast(
+        `${message}. Auto-update skipped (${autoPlan.reason || "not eligible"}). Suggested action: ${guidance.action}`,
+        "warning"
+      );
+      return;
     }
+
+    await showToast(`${message}. Suggested action: ${guidance.action}`, "warning");
   };
 
   const resolveInjectQuery = () => {
@@ -803,7 +861,11 @@ export const OpencodeMemPlugin = async ({
   await log("info", "codemem plugin initialized", { cwd, version });
   await logLine(`plugin initialized cwd=${cwd} version=${version}`);
   startViewer();
-  await verifyCliCompatibility();
+  void verifyCliCompatibility().catch(async (err) => {
+    await logLine(
+      `compat.version_check_error message=${String(err?.message || err || "unknown")}`
+    );
+  });
 
   const truncate = (value) => {
     if (value === undefined || value === null) {

--- a/README.md
+++ b/README.md
@@ -382,11 +382,12 @@ When OpenCode starts, the plugin loads and:
 
 1. **Auto-detects mode**:
    - If in the `codemem` repo → uses `uv run` (dev mode, picks up changes)
-   - Otherwise → uses `uvx --from git+ssh://...` (installed mode)
+   - Otherwise → uses `uvx --from git+https://...` (installed mode; configurable via `CODEMEM_RUNNER_FROM`)
 
 2. Tracks every tool invocation (`tool.execute.after`)
 3. Flushes captured events on session boundaries (`session.idle`, `session.created`, `/new`, `session.error`)
 4. Auto-starts the viewer by default (set `CODEMEM_VIEWER_AUTO=0` to disable)
 5. Injects a memory pack into the system prompt (disable with `CODEMEM_INJECT_CONTEXT=0`)
+6. Checks backend CLI compatibility at startup and shows update guidance (`CODEMEM_BACKEND_UPDATE_POLICY=auto` enables best-effort auto-update)
 
 Observer/settings panel and advanced plugin controls are documented in `docs/plugin-reference.md`.

--- a/codemem/__init__.py
+++ b/codemem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.14.0"
+__version__ = "0.14.1"

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -108,6 +108,7 @@ When ingesting plugin payloads, CodeMem stores a normalized project label instea
 | `CODEMEM_PLUGIN_LOG` | Path for the plugin log file (set `1`/`true`/`yes` to enable; defaults to off). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |
+| `CODEMEM_BACKEND_UPDATE_POLICY` | Backend update behavior on compatibility mismatch: `notify` (default), `auto`, or `off`. |
 | `CODEMEM_CODEX_ENDPOINT` | Override Codex OAuth endpoint. |
 | `CODEMEM_PLUGIN_DEBUG` | Set to `1`, `true`, or `yes` to log plugin lifecycle events. |
 | `CODEMEM_PLUGIN_IGNORE` | Skip all plugin behavior for this process. |
@@ -141,4 +142,12 @@ When the plugin detects CLI/runtime version mismatch, it shows guidance based on
 - `CODEMEM_RUNNER=uvx` with custom source: update `CODEMEM_RUNNER_FROM`, restart OpenCode
 - other/unknown runner: run `uv tool install --upgrade codemem`, restart OpenCode
 
-Compatibility checks are warning-only and do not block plugin startup.
+Update policy:
+
+- `CODEMEM_BACKEND_UPDATE_POLICY=notify` (default): show warning toast with suggested action
+- `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible runners, then warn if still outdated
+  - skipped in `uv` dev mode
+  - skipped when `CODEMEM_RUNNER_FROM` is pinned to a git ref (for example `...git@vX.Y.Z`)
+- `CODEMEM_BACKEND_UPDATE_POLICY=off`: no compatibility toast (logging still records mismatch)
+
+Compatibility checks do not block plugin startup.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -18,6 +18,12 @@ CodeMem uses one shared semantic version stream across npm and PyPI artifacts.
 The OpenCode plugin performs a runtime CLI version check and warns if the local CLI is below
 `CODEMEM_MIN_VERSION` (default `0.9.20`).
 
+The compatibility reaction is controlled by `CODEMEM_BACKEND_UPDATE_POLICY`:
+
+- `notify` (default): warn with an upgrade hint
+- `auto`: attempt a best-effort update for eligible runners, then re-check (skips dev runner mode and pinned git refs)
+- `off`: suppress compatibility toasts
+
 Override for testing:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kunickiaj/codemem",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "CodeMem plugin for OpenCode",
   "type": "module",
   "main": "index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,18 @@ packages = ["codemem"]
 
 [tool.hatch.build.targets.wheel.force-include]
 ".opencode/plugin/codemem.js" = "codemem/.opencode/plugin/codemem.js"
+".opencode/lib/compat.js" = "codemem/.opencode/lib/compat.js"
 
 [tool.hatch.build.targets.sdist]
 include = [
   "codemem/",
   ".opencode/plugin/codemem.js",
+  ".opencode/lib/compat.js",
 ]
 
 [project]
 name = "codemem"
-version = "0.14.0"
+version = "0.14.1"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "codemem"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },

--- a/viewer_ui/src/tabs/feed.ts
+++ b/viewer_ui/src/tabs/feed.ts
@@ -90,6 +90,13 @@ function resetPagination(project: string) {
   summaryOffset = 0;
   observationHasMore = true;
   summaryHasMore = true;
+  state.lastFeedItems = [];
+  state.pendingFeedItems = null;
+  state.lastFeedFilteredCount = 0;
+  state.lastFeedSignature = '';
+  state.newItemKeys.clear();
+  state.itemViewState.clear();
+  state.itemExpandState.clear();
 }
 
 function isNearFeedBottom(): boolean {
@@ -207,6 +214,66 @@ function clampClass(mode: ItemViewMode): string[] {
   return mode === 'summary' ? ['clamp', 'clamp-3'] : ['clamp', 'clamp-5'];
 }
 
+function isSafeHref(value: string): boolean {
+  const href = String(value || '').trim();
+  if (!href) return false;
+  if (href.startsWith('#') || href.startsWith('/')) return true;
+  const lower = href.toLowerCase();
+  return lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('mailto:');
+}
+
+function sanitizeHtml(html: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = String(html || '');
+  const allowedTags = new Set(['p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'blockquote', 'a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr']);
+
+  template.content.querySelectorAll('script, iframe, object, embed, link, style').forEach((node) => {
+    node.remove();
+  });
+
+  template.content.querySelectorAll('*').forEach((node) => {
+    const tag = node.tagName.toLowerCase();
+    if (!allowedTags.has(tag)) {
+      node.replaceWith(document.createTextNode(node.textContent || ''));
+      return;
+    }
+
+    const allowedAttrs = tag === 'a' ? new Set(['href', 'title']) : new Set<string>();
+    for (const attr of Array.from(node.attributes)) {
+      const name = attr.name.toLowerCase();
+      if (!allowedAttrs.has(name)) {
+        node.removeAttribute(attr.name);
+      }
+    }
+
+    if (tag === 'a') {
+      const href = node.getAttribute('href') || '';
+      if (!isSafeHref(href)) {
+        node.removeAttribute('href');
+      } else {
+        node.setAttribute('rel', 'noopener noreferrer');
+        node.setAttribute('target', '_blank');
+      }
+    }
+  });
+
+  return template.innerHTML;
+}
+
+function renderMarkdownSafe(value: string): string {
+  const source = String(value || '');
+  try {
+    const rawHtml = (globalThis as any).marked.parse(source);
+    return sanitizeHtml(rawHtml);
+  } catch {
+    const escaped = source
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    return escaped;
+  }
+}
+
 /* ── Rendering functions ─────────────────────────────────── */
 
 function renderSummaryObject(summary: Record<string, any>): HTMLElement | null {
@@ -222,7 +289,7 @@ function renderSummaryObject(summary: Record<string, any>): HTMLElement | null {
     const row = el('div', 'summary-section');
     const label = el('div', 'summary-section-label', toTitleLabel(key));
     const value = el('div', 'summary-section-content');
-    try { value.innerHTML = (globalThis as any).marked.parse(content); } catch { value.textContent = content; }
+    value.innerHTML = renderMarkdownSafe(content);
     row.append(label, value);
     container.appendChild(row);
   });
@@ -243,7 +310,7 @@ function renderNarrative(narrative: string): HTMLElement | null {
   const content = String(narrative || '').trim();
   if (!content) return null;
   const body = el('div', 'feed-body');
-  try { body.innerHTML = (globalThis as any).marked.parse(content); } catch { body.textContent = content; }
+  body.innerHTML = renderMarkdownSafe(content);
   return body;
 }
 
@@ -410,7 +477,7 @@ function filterByQuery(items: any[]): any[] {
 
 function computeSignature(items: any[]): string {
   const parts = items.map((i) => `${itemSignature(i)}:${i.kind || ''}:${i.created_at_utc || i.created_at || ''}`);
-  return `${state.feedTypeFilter}|${state.currentProject}|${parts.join('|')}`;
+  return `${state.feedTypeFilter}|${state.currentProject}|${normalize(state.feedQuery)}|${parts.join('|')}`;
 }
 
 function countNewItems(nextItems: any[], currentItems: any[]): number {
@@ -477,6 +544,18 @@ function maybeLoadMoreFeedPage() {
   if (!hasMorePages()) return;
   if (!isNearFeedBottom()) return;
   void loadMoreFeedPage();
+}
+
+function renderProjectSwitchLoadingState() {
+  const feedList = document.getElementById('feedList');
+  const feedMeta = document.getElementById('feedMeta');
+  if (feedList) {
+    feedList.textContent = '';
+    feedList.appendChild(el('div', 'small', 'Loading selected project...'));
+  }
+  if (feedMeta) {
+    feedMeta.textContent = 'Loading selected project...';
+  }
 }
 
 /* ── Public API ──────────────────────────────────────────── */
@@ -556,6 +635,7 @@ export async function loadFeedData() {
   const project = state.currentProject || '';
   if (project !== lastFeedProject) {
     resetPagination(project);
+    renderProjectSwitchLoadingState();
   }
   const requestGeneration = feedProjectGeneration;
 


### PR DESCRIPTION
## Description
Fixes a viewer regression where selecting a project updated feed counters but could leave stale items visible. This hotfix also adds safer backend drift handling in the OpenCode plugin (`notify` by default, `auto`/`off` options), improves compatibility update guidance, and aligns release artifacts to `0.14.1` across npm/Python.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `uv run pytest tests/test_viewer_routes_memory.py tests/test_contracts.py`
- `uv run ruff check codemem tests`
- `bun test ./.opencode/tests/compat.test.js`
- `bun run check` (in `viewer_ui/`)
- `bun run build` (in `viewer_ui/`)

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced