### PR TITLE
docs: rewrite README and architecture for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,35 +2,29 @@
 
 [![CI](https://github.com/kunickiaj/codemem/actions/workflows/ci.yml/badge.svg)](https://github.com/kunickiaj/codemem/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/kunickiaj/codemem/branch/main/graph/badge.svg)](https://codecov.io/gh/kunickiaj/codemem) [![Release](https://img.shields.io/github/v/release/kunickiaj/codemem)](https://github.com/kunickiaj/codemem/releases)
 
-A lightweight persistent-memory companion for OpenCode. Captures terminal sessions (and tool calls) as memories, serves a viewer, and exposes an OpenCode plugin that records tool usage automatically.
+Persistent memory for [OpenCode](https://opencode.ai). codemem captures what you work on across sessions, retrieves relevant context using hybrid search, and injects it into future prompts automatically.
 
-## Why codemem
-
-- Persistent cross-session memory for coding agents, stored locally in SQLite
-- Built-in viewer for memory feed, session history, and observer tuning
-- Peer-to-peer sync so your memory graph can travel across machines without a central service
-- OpenCode-native plugin + MCP tools for low-friction usage in daily workflows
-
-## What it looks like
+- **Local-first** — everything lives in SQLite on your machine
+- **Hybrid retrieval** — FTS5 BM25 lexical search + sqlite-vec semantic search, merged and re-ranked
+- **Automatic injection** — the OpenCode plugin injects context into every prompt, no manual steps
+- **Built-in viewer** — browse memories, sessions, and observer output in a local web UI
+- **Peer-to-peer sync** — replicate memories across machines without a central service
 
 | Light | Dark |
 |-------|------|
 | ![codemem viewer – light theme](docs/images/codemem-light.png) | ![codemem viewer – dark theme](docs/images/codemem-dark.png) |
 
-## Prerequisites
+## Quick start
 
-- Python 3.11+
-- [uv](https://docs.astral.sh/uv/) (recommended) or pip
+**Prerequisites:** Python 3.11+ and [uv](https://docs.astral.sh/uv/)
 
-## Get started in 60 seconds
-
-1) Install the CLI:
+1. Install the CLI and plugin:
 
 ```bash
 uv tool install --upgrade codemem
 ```
 
-2) Add the plugin in OpenCode config (`~/.config/opencode/opencode.jsonc`):
+2. Add the plugin to your OpenCode config (`~/.config/opencode/opencode.jsonc`):
 
 ```json
 {
@@ -39,30 +33,131 @@ uv tool install --upgrade codemem
 }
 ```
 
-3) Restart OpenCode, then verify:
+3. Restart OpenCode, then verify:
 
 ```bash
 codemem stats
 codemem raw-events-status
 ```
 
-If you are migrating from `opencode-mem`, use the step-by-step checklist in
-`docs/rename-migration.md`.
+That's it. The plugin captures activity, builds memories, and injects context from here on.
 
-## Alternative install paths
+> Migrating from `opencode-mem`? See [docs/rename-migration.md](docs/rename-migration.md).
 
-SSH access is only needed for git-based fallback installs.
+## How it works
 
-### For local development
+The plugin hooks into OpenCode's event system. It captures tool calls and conversation messages, flushes them through an observer pipeline that produces typed memories, and injects relevant context back into future prompts.
+
+```mermaid
+sequenceDiagram
+participant OC as OpenCode
+participant PL as codemem plugin
+participant ST as MemoryStore
+participant DB as SQLite
+
+OC->>PL: tool.execute.after events
+OC->>PL: experimental.chat.system.transform
+PL->>ST: build_memory_pack with shaped query
+ST->>DB: FTS5 BM25 lexical search
+ST->>DB: sqlite vec semantic search
+ST->>ST: merge rerank and section assembly
+ST-->>PL: pack text
+PL->>OC: inject codemem context
+```
+
+**Retrieval** combines two strategies: keyword search via SQLite FTS5 with BM25 scoring and semantic similarity via sqlite-vec embeddings. In the pack-building path, results from both are merged, deduplicated, and re-ranked using recency and memory-kind boosts.
+
+**Injection** happens automatically. The plugin builds a query from the current session context (first prompt, latest prompt, project, recently modified files), calls `build_memory_pack`, and appends the result to the system prompt via `experimental.chat.system.transform`.
+
+**Memories** are typed — `bugfix`, `feature`, `refactor`, `change`, `discovery`, `decision`, `exploration` — with structured fields like `facts`, `concepts`, `files_read`, and `files_modified` that improve retrieval relevance. Low-signal events are filtered at multiple layers before persistence.
+
+For architecture details, see [docs/architecture.md](docs/architecture.md).
+
+## CLI
+
+| Command | Description |
+|---------|-------------|
+| `codemem stats` | Database statistics |
+| `codemem recent` | Recent memories |
+| `codemem search <query>` | Search memories |
+| `codemem embed` | Backfill semantic embeddings |
+| `codemem serve` | Launch the web viewer |
+| `codemem db prune-memories` | Deactivate low-signal memories (`--dry-run` to preview) |
+| `codemem export-memories` | Export memories by project |
+| `codemem import-memories` | Import memories (idempotent) |
+| `codemem sync` | Peer-to-peer sync commands |
+
+Run `codemem --help` for the full list.
+
+## MCP tools
+
+To give the LLM direct access to memory tools (search, timeline, pack, remember, forget):
 
 ```bash
-# Create virtual environment and install with dependencies
+codemem install-mcp
+```
+
+This updates your OpenCode config to register the MCP server. Restart OpenCode to activate.
+
+## Configuration
+
+Config file: `~/.config/codemem/config.json` (override with `CODEMEM_CONFIG`). Environment variables take precedence over file settings.
+
+Common overrides:
+
+| Variable | Purpose |
+|----------|---------|
+| `CODEMEM_DB` | SQLite database path |
+| `CODEMEM_INJECT_CONTEXT` | `0` to disable automatic context injection |
+| `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
+
+The viewer includes a Settings modal for observer provider, model, and max chars.
+
+## Export and import
+
+Share project knowledge with teammates or back up memories across machines.
+
+```bash
+# Export current project
+codemem export-memories project.json
+
+# Import on another machine (idempotent, safe to re-run)
+codemem import-memories project.json --remap-project ~/workspace/myproject
+
+# Import from claude-mem
+codemem import-from-claude-mem ~/.claude-mem/claude-mem.db
+```
+
+See `codemem export-memories --help` and `codemem import-memories --help` for full options.
+
+## Peer-to-peer sync
+
+Replicate memories across devices without a central server.
+
+```bash
+codemem sync enable        # generate device keys
+codemem sync pair          # generate pairing payload
+codemem sync daemon        # start sync daemon
+codemem sync install       # autostart on macOS + Linux
+```
+
+Project filters, per-peer overrides, and config keys are documented in [docs/user-guide.md](docs/user-guide.md).
+
+## Semantic recall
+
+Embeddings are stored in sqlite-vec and written automatically when memories are created. Use `codemem embed` to backfill existing memories. If sqlite-vec cannot load, keyword search still works.
+
+> **aarch64 Linux note:** The PyPI wheels currently ship a 32-bit `vec0.so` on aarch64. See [docs/user-guide.md](docs/user-guide.md) for the workaround.
+
+## Alternative install methods
+
+<details>
+<summary>Local development, uvx, git install</summary>
+
+### Local development
+
+```bash
 uv sync
-
-# Run commands via the venv
-.venv/bin/codemem --help
-
-# Or activate the venv first
 source .venv/bin/activate  # bash/zsh
 source .venv/bin/activate.fish  # fish
 codemem --help
@@ -70,324 +165,32 @@ codemem --help
 
 ### Via uvx (no install)
 
-Run directly without installing:
-
 ```bash
-# Run latest
 uvx --from git+ssh://git@github.com/kunickiaj/codemem.git codemem stats
-
-# Run specific version
-uvx --from git+ssh://git@github.com/kunickiaj/codemem.git@v0.9.17 codemem stats
-
-# Run from local clone
-uvx --from . codemem stats
 ```
 
 ### Install from GitHub
 
 ```bash
-# Install latest
 uv pip install git+ssh://git@github.com/kunickiaj/codemem.git
-
-# Install specific version
-uv pip install git+ssh://git@github.com/kunickiaj/codemem.git@v0.9.17
 ```
 
-### Configuration
-
-Optionally point the SQLite store somewhere else:
-
-```bash
-export CODEMEM_DB=~/.codemem/mem.sqlite
-```
-
-## CLI commands
-
-- `codemem init-db` – initialize the database.
-- `codemem stats` / `codemem recent` / `codemem search` – inspect stored memories.
-- `codemem embed` – backfill semantic embeddings for existing memories.
-- `codemem db prune-memories` – deactivate low-signal memories (use `--dry-run` to preview).
-- `codemem serve` – launch the web viewer (the plugin also auto-starts it).
-- `codemem export-memories` / `codemem import-memories` – export and import memories by project for sharing or backup.
-- `codemem sync` – enable peer sync, pair devices, and run the sync daemon.
-
-## Runtime hook behavior (plugin)
-
-- The plugin captures tool activity via `tool.execute.after` and conversation messages from event payloads.
-- Flush boundaries are event-driven: `session.idle`, `session.created`, `/new` prompt, and `session.error`.
-- Force-flush triggers fire on heavy sessions: `>=50` tools, `>=15` prompts, or `>=10m` session duration.
-- Raw events are delivered to the viewer ingest API (`/api/raw-events`).
-
-For usage and troubleshooting details, see `docs/user-guide.md` and `docs/plugin-reference.md`.
-
-### Sync project filters
-
-By default, sync replicates all projects. You can restrict which projects a device will apply by
-project basename (folder name).
-
-Config keys (in `~/.config/codemem/config.json`):
-
-```json
-{
-  "sync_projects_include": ["codemem"],
-  "sync_projects_exclude": ["work-repo"]
-}
-```
-
-Notes:
-- If `sync_projects_include` is non-empty, only those projects sync.
-- `sync_projects_exclude` always wins.
-- Filtering is reversible: excluded projects are skipped without advancing cursors, so toggling
-  filters later will allow previously filtered ops to sync.
-
-#### Per-peer overrides (recommended for coworker sync)
-
-Global filters apply to all peers by default. When accepting a pairing payload, you can set a
-per-peer override so one peer only syncs shared work projects while your other devices still sync
-everything.
-
-Example:
-
-```bash
-# Accept a peer and only sync specific projects with them
-codemem sync pair --accept '<payload>' --include shared-repo-1,shared-repo-2
-
-# Accept a peer and exclude a project
-codemem sync pair --accept '<payload>' --exclude private-repo
-
-# Clear per-peer override (inherit global defaults)
-codemem sync pair --accept '<payload>' --default
-
-# Force per-peer override to sync all projects with this peer
-codemem sync pair --accept '<payload>' --all
-```
-
-## Semantic recall
-
-Semantic recall stores vector embeddings for memory items using sqlite-vec and fastembed. Embeddings are written when memories are created; use `codemem embed` to backfill existing memories.
-
-Notes:
-- Requires a Python SQLite build that supports extension loading (sqlite-vec).
-- If sqlite-vec cannot load, semantic recall is skipped and keyword search still works.
-
-### sqlite-vec on aarch64 (Linux)
-
-The PyPI wheels for sqlite-vec currently ship a 32-bit `vec0.so` on aarch64, which fails to load in 64-bit Python with `ELFCLASS32`. Use the aarch64 release build instead:
-
-```bash
-# Download the aarch64 loadable extension (0.1.7a2)
-curl -L -o /tmp/sqlite-vec-0.1.7a2-linux-aarch64.tar.gz \
-  https://github.com/asg017/sqlite-vec/releases/download/v0.1.7-alpha.2/sqlite-vec-0.1.7-alpha.2-loadable-linux-aarch64.tar.gz
-
-# Extract and replace the bundled vec0.so inside the venv
-tar -xzf /tmp/sqlite-vec-0.1.7a2-linux-aarch64.tar.gz -C /tmp
-cp /tmp/vec0.so .venv/lib/python*/site-packages/sqlite_vec/vec0.so
-```
-
-This keeps sqlite-vec installed but swaps in a 64-bit aarch64 loadable, unblocking vector search and imports on Debian 13 arm64.
-
-## Exporting and importing memories
-
-Share your project knowledge with teammates or back up memories to transfer between machines.
-
-### Export memories
-
-```bash
-# Export all memories for current project
-codemem export-memories myproject.json
-
-# Export a specific project
-codemem export-memories myproject.json --project /path/to/myproject
-
-# Export all projects
-codemem export-memories all.json --all-projects
-
-# Export including deactivated memories
-codemem export-memories myproject.json --project myproject --include-inactive
-
-# Export to stdout and compress
-codemem export-memories - --project myproject | gzip > myproject.json.gz
-
-# Export memories from a specific date
-codemem export-memories recent.json --project myproject --since 2025-01-01
-```
-
-### Import memories
-
-Imports are idempotent. You can safely re-run the same import file to pick up
-new entries without duplicating existing data.
-
-```bash
-# Preview what will be imported (dry run)
-codemem import-memories myproject.json --dry-run
-
-# Import memories
-codemem import-memories myproject.json
-
-# Import with project remapping (teammate has different paths)
-codemem import-memories myproject.json --remap-project /Users/teammate/workspace/myproject
-
-# Import from compressed file
-gunzip -c myproject.json.gz | codemem import-memories -
-```
-
-### Import from claude-mem
-
-Use the claude-mem SQLite database directly (not the JSON export).
-Imports are idempotent, so re-running is safe.
-
-```bash
-codemem import-from-claude-mem ~/.claude-mem/claude-mem.db
-```
-
-### Use case: sharing knowledge with teammates
-
-When a teammate joins your project:
-
-```bash
-# You: export your project memories
-codemem export-memories project-knowledge.json --project myproject
-
-# Share the file (Slack, email, git, etc.)
-
-# Teammate: import into their codemem
-codemem import-memories project-knowledge.json --remap-project ~/workspace/myproject
-```
-
-Now their LLM has access to all your discoveries, patterns, and decisions about the codebase.
-
-## Contributing
-
-Contributor setup, tests, linting, and release workflow live in `CONTRIBUTING.md`.
-
-## Configuration
-
-Configuration is stored in `~/.config/codemem/config.json` (override with `CODEMEM_CONFIG`). Environment variables always take precedence.
-
-### Sync quickstart (Phase 2)
-
-```bash
-# Enable sync (generates device keys)
-codemem sync enable
-
-# Start daemon (foreground)
-codemem sync daemon
-```
-
-Pair on device A (CLI or viewer UI QR):
-
-```bash
-codemem sync pair
-```
-
-Copy the payload to device B:
-
-```bash
-codemem sync pair --accept '<payload>'
-```
-
-Status and one-off sync:
-
-```bash
-codemem sync status
-codemem sync once
-```
-
-Autostart (macOS + Linux):
-
-```bash
-codemem sync install
-```
-
-Relevant config keys (override with env vars):
-
-- `sync_enabled` / `CODEMEM_SYNC_ENABLED`
-- `sync_host` / `CODEMEM_SYNC_HOST`
-- `sync_port` / `CODEMEM_SYNC_PORT`
-- `sync_interval_s` / `CODEMEM_SYNC_INTERVAL_S`
-- `sync_mdns` / `CODEMEM_SYNC_MDNS`
-- `sync_key_store` / `CODEMEM_SYNC_KEY_STORE` ("file" or "keychain")
-
-Note: macOS keychain storage uses the `security` CLI and may expose the key via process arguments. Keep `sync_key_store=file` if that’s a concern.
-
-The viewer includes a Settings modal for the observer provider, model, and max chars. Changes write to the config file; environment variables still override those values.
-
-## Docs
-
-- `docs/architecture.md` covers the data flow and components.
-- `docs/user-guide.md` covers viewer usage and troubleshooting.
-- `docs/plugin-reference.md` covers plugin behavior, env vars, and stream reliability knobs.
-- `docs/rename-migration.md` covers migration from `opencode-mem` to `codemem`.
-- `CONTRIBUTING.md` covers contributor setup, testing, and release workflow.
-
-## OpenCode MCP setup
-
-To let the LLM call memory tools (search/timeline/pack), run:
-
-```bash
-codemem install-mcp
-```
-
-This writes/updates your global OpenCode config at `~/.config/opencode/opencode.json`. The MCP entry looks like:
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "codemem": {
-      "type": "local",
-      "command": ["uvx", "codemem", "mcp"],
-      "enabled": true
-    }
-  }
-}
-```
-
-Restart OpenCode and the MCP tools will be available to the model.
-
-## Plugin mode
-
-### Installation
-
-**Recommended (npm package):**
-
-Add `@kunickiaj/codemem` to your OpenCode plugin config, then restart OpenCode.
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@kunickiaj/codemem"]
-}
-```
-
-Notes:
-- The key is `plugin` (singular). `plugins` is rejected as an unknown key.
-- To pin a specific plugin release, use `"@kunickiaj/codemem@0.9.20"`.
-
-**Git fallback one-liner** (advanced):
+### Plugin from git (advanced)
 
 ```bash
 uvx --from git+ssh://git@github.com/kunickiaj/codemem.git codemem install-plugin
 ```
 
-That's it! Restart OpenCode and the plugin is active.
+### Plugin for development
 
-**For development** (working on codemem):
+Start OpenCode inside the codemem repo directory — the plugin auto-loads from `.opencode/plugin/`.
 
-Just start OpenCode inside the repo directory — the plugin auto-loads from `.opencode/plugin/`.
+</details>
 
-### How it works
+## Documentation
 
-When OpenCode starts, the plugin loads and:
-
-1. **Auto-detects mode**:
-   - If in the `codemem` repo → uses `uv run` (dev mode, picks up changes)
-   - Otherwise → uses `uvx --from git+https://...` (installed mode; configurable via `CODEMEM_RUNNER_FROM`)
-
-2. Tracks every tool invocation (`tool.execute.after`)
-3. Flushes captured events on session boundaries (`session.idle`, `session.created`, `/new`, `session.error`)
-4. Auto-starts the viewer by default (set `CODEMEM_VIEWER_AUTO=0` to disable)
-5. Injects a memory pack into the system prompt (disable with `CODEMEM_INJECT_CONTEXT=0`)
-6. Checks backend CLI compatibility at startup and shows update guidance (`CODEMEM_BACKEND_UPDATE_POLICY=auto` enables best-effort auto-update)
-
-Observer/settings panel and advanced plugin controls are documented in `docs/plugin-reference.md`.
+- [Architecture](docs/architecture.md) — data flow, retrieval, observer pipeline, design tradeoffs
+- [User guide](docs/user-guide.md) — viewer usage, sync setup, troubleshooting
+- [Plugin reference](docs/plugin-reference.md) — plugin behavior, env vars, stream reliability
+- [Migration guide](docs/rename-migration.md) — migrating from `opencode-mem`
+- [Contributing](CONTRIBUTING.md) — development setup, tests, linting, releases

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,71 +1,250 @@
 # Architecture
 
-## Overview
-- **CLI (`codemem`)** runs ingestion, MCP server, viewer, and export/import.
-- **Plugin** captures OpenCode events and streams raw events to the viewer HTTP API.
-- **Ingest pipeline** flushes queued raw events, builds transcript, calls the observer, and writes memories.
-- **Observer** returns typed observations and a session summary.
-- **Store** persists sessions, memories, and artifacts in SQLite.
-- **Viewer** serves a static HTML dashboard backed by JSON APIs.
-- **MCP server** exposes memory tools to OpenCode.
+codemem has five main pieces: a **plugin** that captures OpenCode activity, an **ingest pipeline** that turns raw events into typed memories, a **store** backed by SQLite, a **retrieval system** that combines keyword and semantic search, and a **viewer** for browsing everything.
+
+## Components
+
+| Component | What it does | Key files |
+|-----------|-------------|-----------|
+| Plugin | Captures OpenCode events, streams them to the viewer API | `.opencode/plugin/codemem.js` |
+| Ingest pipeline | Extracts tool events, builds transcripts, runs the observer | `codemem/plugin_ingest.py`, `codemem/ingest/` |
+| Observer | Produces typed observations and session summaries from transcripts | `codemem/observer_prompts.py`, `codemem/xml_parser.py` |
+| Store | SQLite persistence for sessions, memories, artifacts, embeddings | `codemem/store/`, `codemem/db.py` |
+| Viewer | Local web UI + JSON APIs for stats, sessions, and memory items | `codemem/viewer.py`, `codemem/viewer_routes/` |
+| MCP server | Exposes memory tools (search, timeline, pack, remember, forget) to OpenCode | `codemem/mcp_server.py` |
+| CLI | Ties everything together: ingest, serve, search, export/import, sync | `codemem/cli_app.py` |
 
 ## Data flow
-1. Plugin collects events during an OpenCode session (user prompts, assistant messages, tool calls).
-2. Plugin preflights raw-event ingest availability (`GET /api/raw-events/status`) and streams events (`POST /api/raw-events`).
-3. Viewer/store persist raw events and queue durable flush batches.
-4. Idle/sweeper workers claim and flush queued batches into ingest.
-5. Ingest builds transcript from user_prompt/assistant_message events.
-6. Observer creates observations + summary from transcript and tool events.
-7. Store writes artifacts (transcript, pre/post context), observations, and session summary.
-8. Viewer and MCP server read from SQLite.
 
-## Plugin Flush Strategy
-The plugin uses an adaptive flush strategy optimized for OpenCode's multi-session environment:
+```mermaid
+flowchart LR
+    OC["OpenCode"] -->|tool.execute.after\nmessage events| PL["Plugin"]
+    PL -->|POST /api/raw-events| VW["Viewer API"]
+    VW --> DB["SQLite"]
+    DB -->|flush batch claimed| IN["Ingest pipeline"]
+    IN --> OB["Observer"]
+    OB -->|typed observations\nsession summary| IN
+    IN -->|memories, artifacts| DB
+    DB -->|search, pack| MCP["MCP server"]
+    DB --> VW
+```
 
-### Event-based flush triggers
-- `session.idle`: flushes current buffered events
-- `session.created`: flushes current buffered events before switching session
-- `/new` boundary (detected from captured user prompt text): flushes current buffered events before switching context
-- `session.error`: immediate flush attempt
+1. The plugin captures tool calls and conversation messages during an OpenCode session.
+2. It streams raw events to the viewer's ingest API (`POST /api/raw-events`) with preflight health checks (`GET /api/raw-events/status`).
+3. The viewer/store persists raw events and queues durable flush batches.
+4. Idle and sweeper workers claim batches and run them through ingest.
+5. Ingest builds a transcript from user prompts and assistant messages, then hands it to the observer.
+6. The observer returns typed observations and an optional session summary as XML.
+7. Ingest writes artifacts (transcript, context snapshots), observations, and summaries to SQLite.
+8. The viewer, MCP server, and CLI all read from the same SQLite database.
 
-### Threshold-based Force Flush (immediate)
-- 50+ tool executions OR 15+ prompts
-- 10+ minutes continuous work
+## Retrieval
 
-### Stream reliability and failure semantics
-- Plugin stream health preflight: `GET /api/raw-events/status`
-- Event ingest path: `POST /api/raw-events`
-- Stream failures are handled in-plugin with a backoff window (`CODEMEM_RAW_EVENTS_BACKOFF_MS`) and periodic preflight checks (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`).
-- Once batches are accepted by the viewer/store queue, flush workers own retries (`codemem raw-events-retry`, sweeper/idle flush).
+Retrieval has two search backends and a merge/re-rank layer that combines them for pack construction.
 
-## Sessions and memory persistence
-- A **session** is created per ingest payload (one plugin flush).
-- Memory items persist when the observer returns meaningful content.
-- Low‑signal observations are filtered before writing to SQLite.
-- Transcripts are built from captured user_prompt and assistant_message events.
+### Lexical search (FTS5 + BM25)
 
-## Export/Import
-- **Export:** Serialize sessions, memory_items, session_summaries, user_prompts to versioned JSON
-- **Import:** Restore memories with optional project path remapping for team sharing
-- Use cases: knowledge transfer, backup/restore, team onboarding
+The `memory_fts` virtual table is an FTS5 index over `title`, `body_text`, and `tags_text` from `memory_items`. It's kept in sync automatically via SQLite triggers on insert, update, and delete.
 
-## Configuration
-- File config lives at `~/.config/codemem/config.json`.
-- Environment variables override file settings.
-- Viewer settings modal edits only observer provider/model/max chars.
+Search queries go through `_expand_query` (OR-joined tokens) and are scored with `-bm25(memory_fts, 1.0, 1.0, 0.25)`. Results are ordered by a weighted combination of BM25 score and recency in the SQL query itself:
 
-## Viewer
-- Implemented in `codemem/viewer.py` as an embedded HTML page.
-- Serves JSON APIs for stats, sessions, memory items, and config.
-- Viewer stats cards are sourced from `/api/stats`, `/api/usage`, and `/api/raw-events`.
-- Restart required to pick up HTML changes.
+```sql
+ORDER BY (score * 1.5 + recency) DESC
+```
+
+where `recency = 1.0 / (1.0 + (days_ago / 7.0))`.
+
+This is the baseline search path used by `codemem search`, MCP `memory_search`, and as input to pack construction.
+
+### Semantic search (sqlite-vec)
+
+When embeddings are available, `memory_vectors` (a `vec0` virtual table from sqlite-vec) stores 384-dimensional float vectors keyed by `memory_id`. Vectors are written automatically when memories are created, or backfilled with `codemem embed`.
+
+Semantic search embeds the query text, then runs a nearest-neighbor lookup against `memory_vectors`. Distance is converted to a similarity score: `1.0 / (1.0 + distance)`.
+
+If sqlite-vec can't load (e.g., missing native extension), semantic search is silently skipped and keyword search still works.
+
+### Hybrid merge and re-rank (pack path)
+
+In the pack-building path — CLI `pack`/`inject`, MCP `memory_pack`, and plugin injection — results from both backends are merged and re-ranked. This happens in `_merge_ranked_results` (`codemem/store/search.py`):
+
+1. Run FTS5 search to get lexical candidates.
+2. Run semantic search to get vector candidates.
+3. Merge candidates, deduplicating by memory ID.
+4. Re-rank the merged set using a composite score.
+
+The re-ranking formula in hybrid mode (`_rerank_results_hybrid`):
+
+```
+score = (fts_score * 1.2) + (recency * 0.8) + kind_bonus + semantic_boost
+
+where:
+  fts_score    = -bm25(memory_fts, 1.0, 1.0, 0.25)
+  recency      = 1.0 / (1.0 + days_ago / 7.0)
+  kind_bonus   = 0.25 (session_summary), 0.2 (decision), 0.15 (note),
+                 0.1 (observation), 0.05 (entities), 0.0 (others)
+  semantic_boost = 0.35 if the memory ID was returned by vector search, else 0.0
+```
+
+In baseline mode (hybrid disabled), the formula is slightly different: `fts_score * 1.5 + recency + kind_bonus` with no semantic boost.
+
+**Scope note:** Hybrid merge/re-rank only runs in the pack-building path. Direct search endpoints (`codemem search`, MCP `memory_search`) use FTS5 scoring with recency weighting but don't merge semantic results.
+
+```mermaid
+flowchart TD
+    Q["Context query"] --> L["FTS5 lexical search with BM25 scoring"]
+    Q --> S["sqlite-vec semantic nearest neighbor search"]
+    L --> M["Merge and deduplicate candidates"]
+    S --> M
+    M --> R["Re-rank: fts score + recency + kind bonus + semantic boost"]
+    R --> P["Assemble pack sections: Summary, Timeline, Observations"]
+    P --> B["Apply item limit and token budget trimming"]
+    B --> OUT["Pack text for injection"]
+```
 
 ## Context injection
-- The plugin injects a memory pack into the system prompt using OpenCode hook APIs.
-- Injection is per session and bounded by a configurable token budget.
-- Reuse savings compare observer discovery tokens to pack read size.
 
-## Semantic recall
-- Embeddings are stored in the `memory_vectors` sqlite-vec table.
-- Vectors are written when memories are created, or via `codemem embed` for backfill.
-- Pack/inject can merge keyword and semantic results when embeddings are available.
+The plugin injects a memory pack into the system prompt on every turn. This is the primary way codemem delivers value — it happens automatically, no manual steps required.
+
+### How the query is built
+
+The plugin constructs a search query from the current session's working set (`resolveInjectQuery` in the plugin):
+
+- **First prompt** — captures the session's original intent (most stable signal)
+- **Latest prompt** — adds current focus (skipped if identical to first prompt or trivially short)
+- **Project name** — scopes results to the active project
+- **Recently modified files** — last 5 filenames from `tool.execute.after` events with `edit`/`write` tools
+
+These are concatenated into a single query string, capped at 500 characters.
+
+### How the pack is built
+
+`build_memory_pack` (`codemem/store/packs.py`) assembles three sections:
+
+1. **Summary** — the most recent `session_summary` matching the query (or the latest one if none match)
+2. **Timeline** — recent memories from search results, ordered by relevance
+3. **Observations** — typed memories (`decision`, `feature`, `bugfix`, `refactor`, `change`, `discovery`, `exploration`, `note`) sorted by tag overlap with the query, then recency, then kind priority
+
+Items are deduplicated across sections. If the query looks like a task lookup ("todo", "pending", "what's next") or a recall query ("what did we do", "last time"), the pack uses specialized retrieval paths that prioritize relevant kinds and recency.
+
+### Limits
+
+- **Item limit** (`limit`, default from `pack_observation_limit` config, typically 50) — caps total memory items considered
+- **Token budget** (`token_budget`) — when set, sections are trimmed once the running token count exceeds the budget; earlier sections (Summary, Timeline) get priority
+
+In plugin mode, these can be overridden via `CODEMEM_INJECT_LIMIT` and `CODEMEM_INJECT_TOKEN_BUDGET`.
+
+### Injection hook
+
+The plugin uses `experimental.chat.system.transform` to append the pack text to the system prompt. It caches the pack per session and re-fetches when the query changes (i.e., when prompts or file activity shift context). A toast notification shows injection stats on first inject per session.
+
+```mermaid
+sequenceDiagram
+participant OC as OpenCode
+participant PL as codemem plugin
+participant CLI as codemem pack
+participant ST as MemoryStore
+participant DB as SQLite
+
+OC->>PL: tool.execute.after events
+PL->>PL: update session context
+OC->>PL: experimental.chat.system.transform
+PL->>PL: build injection query from working set
+PL->>CLI: codemem pack with query, limit, token budget
+CLI->>ST: build_memory_pack
+ST->>DB: FTS5 BM25 lexical search
+ST->>DB: sqlite-vec semantic search
+ST->>ST: merge, rerank, assemble sections
+ST-->>CLI: pack text and metrics
+CLI-->>PL: JSON result
+PL->>OC: append codemem context to system prompt
+```
+
+## Observer pipeline
+
+The observer turns raw session transcripts into typed, structured memories. It's the quality gate — everything that ends up in the store passes through here.
+
+### Memory taxonomy
+
+Observations use a fixed set of kinds defined in `codemem/memory_kinds.py`:
+
+| Kind | When to use | Example |
+|------|------------|---------|
+| `decision` | A tradeoff was made or an approach chosen | "Switched to async cache to avoid lock contention" |
+| `discovery` | Something new was learned about the codebase or domain | "The billing service uses event sourcing internally" |
+| `bugfix` | A bug was identified and fixed | "Fixed retry loop that caused duplicate webhook delivery" |
+| `feature` | New functionality was added | "Added CSV export to the reports page" |
+| `refactor` | Code was restructured without changing behavior | "Extracted auth middleware into shared package" |
+| `change` | A general code change that doesn't fit the above | "Updated CI config to run tests in parallel" |
+| `exploration` | Something was tried but not shipped (preserves "why not") | "Tried Redis for session store, reverted due to complexity" |
+| `note` | Small useful facts worth remembering | "The staging DB password rotates weekly" |
+| `observation` | General observations from session activity | "Test suite takes 4 minutes on this repo" |
+| `session_summary` | Auto-generated session summary | (produced by the observer, not typically created manually) |
+| `entities` | Notable services, components, or domains mentioned | (auto-extracted) |
+
+### Low-signal filtering
+
+Noise control happens at three layers:
+
+1. **Event extraction** (`codemem/ingest/events.py`) — Low-signal tool types (`tui`, `shell`, `task`, `slashcommand`, `skill`, `todowrite`, `askuserquestion`) are dropped before they reach the observer. Internal codemem memory tools (anything starting with `codemem_memory_`) are also excluded to prevent feedback loops.
+
+2. **Observer prompt guidance** (`codemem/observer_prompts.py`) — The observer prompt instructs the LLM to skip routine/noise-only work and focus on meaningful changes, decisions, and discoveries.
+
+3. **Post-observer text filtering** (`codemem/summarizer.py`) — `is_low_signal_observation` applies regex patterns to catch formulaic low-value outputs that the observer sometimes produces despite guidance (e.g., "no code changes were recorded", "only file inspection occurred").
+
+### Structured fields
+
+Each observation is persisted with structured metadata that improves retrieval:
+
+- **`facts`** — discrete factual statements extracted from the observation
+- **`concepts`** — domain concepts and technical terms mentioned
+- **`files_read`** / **`files_modified`** — file paths involved in the work
+- **`narrative`** — the full observation text
+- **`tags_text`** — auto-derived from kind, concepts, and file paths (`codemem/store/tags.py`); used in FTS5 indexing
+
+These fields feed into tag derivation, which directly influences FTS5 recall and pack section ordering (tag overlap with the query boosts observation ranking).
+
+```mermaid
+flowchart TD
+A["Raw OpenCode events"] --> B["Extract relevant events"]
+B --> C["Filter low signal tools and internal memory calls"]
+C --> D["Build transcript and bounded tool context"]
+D --> E["Run observer prompt"]
+E --> F["Parse XML: typed observations and optional summary"]
+F --> G["Apply low signal text checks"]
+G --> H["Persist memory items with structured fields"]
+G --> I["Persist session summary"]
+H --> J["Write to memory_fts and memory_vectors"]
+```
+
+## Plugin flush strategy
+
+The plugin buffers events in memory and flushes them to the viewer API on session boundaries.
+
+### Event-based triggers
+- `session.idle` — flushes current buffer
+- `session.created` — flushes before switching to a new session
+- `/new` command — detected from user prompt text, flushes before context switch
+- `session.error` — immediate flush
+
+### Threshold-based force flush
+- 50+ tool executions OR 15+ prompts
+- 10+ minutes of continuous work
+
+### Stream reliability
+- Preflight check: `GET /api/raw-events/status` with periodic re-checks (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`)
+- Backoff on failure: configurable via `CODEMEM_RAW_EVENTS_BACKOFF_MS`
+- Once batches are accepted by the viewer/store queue, flush workers handle retries
+
+## Design tradeoffs
+
+codemem is built for **episodic memory** — remembering what happened across coding sessions: what was tried, changed, decided, and learned. It's good at:
+
+- Recalling past decisions and their rationale
+- Surfacing relevant context from previous sessions automatically
+- Tracking what was explored but not shipped (and why)
+- Low-friction integration that works without changing how you use OpenCode
+
+It's **not** a structural code intelligence engine. It doesn't build symbol graphs, parse ASTs, or maintain a full map of your codebase structure. If you need "find all callers of this function" or "show me the dependency graph for this module", that's a different tool.
+
+The bet is that for day-to-day coding with an LLM, session-level episodic memory (what you worked on, what you decided, what you learned) is the highest-value context to inject — and that it should happen automatically without any manual bookkeeping.


### PR DESCRIPTION
## Description

Rewrite README.md and docs/architecture.md to give users, contributors, and search engines a clear picture of what codemem does and how it works.

**README.md** — full restructure:
- Scannable value prop and feature bullets above the fold
- Quick start (3 steps) right after screenshots
- Compact Mermaid sequence diagram showing the injection flow
- CLI commands as a table instead of a bullet list
- Advanced install paths collapsed in a `<details>` block
- Docs index at the bottom instead of scattered throughout
- Removed redundant/duplicated sections (plugin mode, config, sync details) that belong in dedicated docs

**docs/architecture.md** — rewritten as narrative prose:
- Component overview table with key file references
- Data flow section with Mermaid diagram
- Retrieval section covering FTS5/BM25 lexical search, sqlite-vec semantic search, and hybrid merge/re-rank with the actual scoring formula from code
- Context injection section: query construction, pack assembly (Summary/Timeline/Observations), limits, and the plugin hook lifecycle
- Observer pipeline: memory taxonomy table, three-layer low-signal filtering, structured fields
- Plugin flush strategy (triggers + thresholds + reliability)
- Design tradeoffs section contrasting episodic memory vs structural code intelligence

All claims verified against current implementation. No unimplemented features described. Hybrid merge/re-rank correctly scoped to pack-building path only.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Manually verified changes work as expected
- [x] Mermaid diagrams validated in mermaid.live
- [ ] Tests pass locally (`pytest`) — docs-only, no code changes
- [ ] Added/updated tests for changes — N/A

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass) — docs-only
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced