### PR TITLE
feat(store): add explainability payload assembly for retrieval

### DIFF
--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -1348,6 +1348,24 @@ class MemoryStore:
             filters=filters,
         )
 
+    def explain(
+        self,
+        *,
+        query: str | None = None,
+        ids: Sequence[Any] | None = None,
+        limit: int = 10,
+        filters: dict[str, Any] | None = None,
+        include_pack_context: bool = False,
+    ) -> dict[str, Any]:
+        return store_search.explain(
+            self,
+            query=query,
+            ids=ids,
+            limit=limit,
+            filters=filters,
+            include_pack_context=include_pack_context,
+        )
+
     def _expand_query(self, query: str) -> str:
         return store_search._expand_query(query)
 

--- a/codemem/store/search.py
+++ b/codemem/store/search.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
     from ._store import MemoryStore
 
 
+SQLITE_INT64_MIN = -(2**63)
+SQLITE_INT64_MAX = (2**63) - 1
+
+
 def search_index(
     store: MemoryStore,
     query: str,
@@ -82,6 +86,181 @@ def timeline(
     return timeline_items
 
 
+def explain(
+    store: MemoryStore,
+    *,
+    query: str | None = None,
+    ids: Sequence[Any] | None = None,
+    limit: int = 10,
+    filters: dict[str, Any] | None = None,
+    include_pack_context: bool = False,
+) -> dict[str, Any]:
+    filters = dict(filters or {})
+    normalized_query = (query or "").strip()
+    ordered_ids, invalid_ids = _dedupe_ordered_ids(ids or [])
+    errors: list[dict[str, Any]] = []
+    if invalid_ids:
+        errors.append(
+            {
+                "code": "INVALID_ARGUMENT",
+                "field": "ids",
+                "message": "some ids are not valid integers",
+                "ids": invalid_ids,
+            }
+        )
+
+    if not normalized_query and not ordered_ids:
+        errors.append(
+            {
+                "code": "INVALID_ARGUMENT",
+                "field": "query",
+                "message": "at least one of query or ids is required",
+            }
+        )
+        return {
+            "items": [],
+            "missing_ids": [],
+            "errors": errors,
+            "metadata": {
+                "query": None,
+                "project": filters.get("project"),
+                "requested_ids_count": len(ordered_ids),
+                "returned_items_count": 0,
+                "include_pack_context": include_pack_context,
+            },
+        }
+
+    query_results: list[MemoryResult] = []
+    if normalized_query:
+        query_results = search(
+            store,
+            normalized_query,
+            limit=max(1, int(limit)),
+            filters=filters or None,
+            log_usage=False,
+        )
+
+    query_rank = {item.id: index for index, item in enumerate(query_results, start=1)}
+    id_rows, missing_not_found, missing_project_mismatch = _load_items_by_ids_for_explain(
+        store,
+        ordered_ids,
+        filters,
+    )
+    id_by_id = {
+        int(item["id"]): MemoryResult(
+            id=int(item["id"]),
+            kind=str(item["kind"]),
+            title=str(item["title"]),
+            body_text=str(item["body_text"]),
+            confidence=float(item.get("confidence") or 0.0),
+            created_at=str(item["created_at"]),
+            updated_at=str(item["updated_at"]),
+            tags_text=str(item.get("tags_text") or ""),
+            score=float(item.get("score") or 0.0),
+            session_id=int(item["session_id"]),
+            metadata=(
+                item["metadata_json"]
+                if isinstance(item.get("metadata_json"), dict)
+                else db.from_json(item.get("metadata_json"))
+            ),
+        )
+        for item in id_rows
+    }
+
+    ordered_items: list[tuple[MemoryResult, str, int | None]] = []
+    selected_ids: set[int] = set()
+    explicit_id_set = set(ordered_ids)
+    for item in query_results:
+        selected_ids.add(item.id)
+        source = "query+id_lookup" if item.id in explicit_id_set else "query"
+        ordered_items.append((item, source, query_rank.get(item.id)))
+    for memory_id in ordered_ids:
+        if memory_id in selected_ids:
+            continue
+        item = id_by_id.get(memory_id)
+        if item is None:
+            continue
+        ordered_items.append((item, "id_lookup", None))
+        selected_ids.add(memory_id)
+
+    session_projects = _load_session_projects(
+        store,
+        {item.session_id for item, _, _ in ordered_items},
+    )
+    query_tokens = _tokenize_query(normalized_query, store.STOPWORDS) if normalized_query else []
+    reference_now = dt.datetime.now(dt.UTC)
+
+    items_payload = [
+        _explain_item(
+            store,
+            item=item,
+            source=source,
+            rank=rank,
+            query_tokens=query_tokens,
+            project_filter=filters.get("project"),
+            project_value=session_projects.get(item.session_id),
+            include_pack_context=include_pack_context,
+            reference_now=reference_now,
+        )
+        for item, source, rank in ordered_items
+    ]
+
+    missing_not_found_set = set(missing_not_found)
+    missing_project_mismatch_set = set(missing_project_mismatch)
+    missing_ids = [
+        memory_id
+        for memory_id in ordered_ids
+        if memory_id in missing_not_found_set or memory_id in missing_project_mismatch_set
+    ]
+    if missing_not_found:
+        errors.append(
+            {
+                "code": "NOT_FOUND",
+                "field": "ids",
+                "message": "some requested ids were not found",
+                "ids": missing_not_found,
+            }
+        )
+    if missing_project_mismatch:
+        errors.append(
+            {
+                "code": "PROJECT_MISMATCH",
+                "field": "project",
+                "message": "some requested ids are outside the requested project scope",
+                "ids": missing_project_mismatch,
+            }
+        )
+
+    tokens_read = sum(
+        store.estimate_tokens(f"{item.title} {item.body_text}") for item, _, _ in ordered_items
+    )
+    store.record_usage(
+        "search_explain",
+        tokens_read=tokens_read,
+        metadata={
+            "query_present": bool(normalized_query),
+            "requested_ids": len(ordered_ids),
+            "returned_items": len(items_payload),
+            "missing_ids": len(missing_ids),
+            "project": filters.get("project"),
+            "include_pack_context": include_pack_context,
+        },
+    )
+
+    return {
+        "items": items_payload,
+        "missing_ids": missing_ids,
+        "errors": errors,
+        "metadata": {
+            "query": normalized_query or None,
+            "project": filters.get("project"),
+            "requested_ids_count": len(ordered_ids),
+            "returned_items_count": len(items_payload),
+            "include_pack_context": include_pack_context,
+        },
+    }
+
+
 def _expand_query(query: str) -> str:
     tokens = re.findall(r"[A-Za-z0-9_]+", query)
     tokens = [token for token in tokens if token.lower() not in {"or", "and", "not"}]
@@ -90,6 +269,174 @@ def _expand_query(query: str) -> str:
     if len(tokens) == 1:
         return tokens[0]
     return " OR ".join(tokens)
+
+
+def _dedupe_ordered_ids(ids: Sequence[Any]) -> tuple[list[int], list[str]]:
+    deduped: list[int] = []
+    seen: set[int] = set()
+    invalid: list[str] = []
+    for raw_id in ids:
+        if isinstance(raw_id, bool):
+            invalid.append(str(raw_id))
+            continue
+        if isinstance(raw_id, float):
+            invalid.append(str(raw_id))
+            continue
+        try:
+            memory_id = int(raw_id)
+        except (TypeError, ValueError, OverflowError):
+            invalid.append(str(raw_id))
+            continue
+        if not isinstance(raw_id, int) and not (isinstance(raw_id, str) and raw_id.isdigit()):
+            invalid.append(str(raw_id))
+            continue
+        if memory_id < SQLITE_INT64_MIN or memory_id > SQLITE_INT64_MAX:
+            invalid.append(str(raw_id))
+            continue
+        if memory_id <= 0:
+            invalid.append(str(raw_id))
+            continue
+        if memory_id in seen:
+            continue
+        seen.add(memory_id)
+        deduped.append(memory_id)
+    return deduped, invalid
+
+
+def _load_items_by_ids_for_explain(
+    store: MemoryStore,
+    ids: list[int],
+    filters: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[int], list[int]]:
+    if not ids:
+        return [], [], []
+    placeholders = ",".join("?" for _ in ids)
+    rows = store.conn.execute(
+        f"""
+        SELECT memory_items.*
+        FROM memory_items
+        WHERE memory_items.active = 1
+          AND memory_items.id IN ({placeholders})
+        """,
+        ids,
+    ).fetchall()
+    all_rows = db.rows_to_dicts(rows)
+    all_found_ids = {int(item["id"]) for item in all_rows}
+
+    if not filters.get("project"):
+        return all_rows, [memory_id for memory_id in ids if memory_id not in all_found_ids], []
+
+    scoped_params: list[Any] = list(ids)
+    project_clause, project_params = store._project_clause(str(filters["project"]))
+    if not project_clause:
+        return all_rows, [memory_id for memory_id in ids if memory_id not in all_found_ids], []
+    scoped_params.extend(project_params)
+    scoped_rows = store.conn.execute(
+        f"""
+        SELECT memory_items.*
+        FROM memory_items
+        JOIN sessions ON sessions.id = memory_items.session_id
+        WHERE memory_items.active = 1
+          AND memory_items.id IN ({placeholders})
+          AND {project_clause}
+        """,
+        scoped_params,
+    ).fetchall()
+    scoped = db.rows_to_dicts(scoped_rows)
+    scoped_ids = {int(item["id"]) for item in scoped}
+
+    missing_not_found = [memory_id for memory_id in ids if memory_id not in all_found_ids]
+    missing_project_mismatch = [
+        memory_id for memory_id in ids if memory_id in all_found_ids and memory_id not in scoped_ids
+    ]
+    return scoped, missing_not_found, missing_project_mismatch
+
+
+def _load_session_projects(store: MemoryStore, session_ids: set[int]) -> dict[int, str | None]:
+    if not session_ids:
+        return {}
+    ordered_ids = sorted(session_ids)
+    placeholders = ",".join("?" for _ in ordered_ids)
+    rows = store.conn.execute(
+        f"SELECT id, project FROM sessions WHERE id IN ({placeholders})",
+        ordered_ids,
+    ).fetchall()
+    return {int(row["id"]): row["project"] for row in rows}
+
+
+def _project_matches_filter(
+    store: MemoryStore,
+    project_filter: str | None,
+    item_project: str | None,
+) -> bool:
+    if not project_filter:
+        return True
+    if not item_project:
+        return False
+    normalized_filter = project_filter.strip().replace("\\", "/")
+    if not normalized_filter:
+        return True
+    if "/" in normalized_filter:
+        filter_value = store._project_basename(normalized_filter)
+    else:
+        filter_value = normalized_filter
+    normalized_project = item_project.replace("\\", "/")
+    return normalized_project == filter_value or normalized_project.endswith(f"/{filter_value}")
+
+
+def _explain_item(
+    store: MemoryStore,
+    *,
+    item: MemoryResult,
+    source: str,
+    rank: int | None,
+    query_tokens: list[str],
+    project_filter: str | None,
+    project_value: str | None,
+    include_pack_context: bool,
+    reference_now: dt.datetime,
+) -> dict[str, Any]:
+    text = f"{item.title} {item.body_text} {item.tags_text}".lower()
+    matched_terms = [token for token in query_tokens if token in text]
+    base_score: float | None = item.score if source in {"query", "query+id_lookup"} else None
+    recency_component = _recency_score(item.created_at, now=reference_now)
+    kind_component = _kind_bonus(item.kind)
+    total_score: float | None = None
+    if base_score is not None:
+        total_score = (base_score * 1.5) + recency_component + kind_component
+
+    return {
+        "id": item.id,
+        "kind": item.kind,
+        "title": item.title,
+        "created_at": item.created_at,
+        "project": project_value,
+        "retrieval": {
+            "source": source,
+            "rank": rank,
+        },
+        "score": {
+            "total": total_score,
+            "components": {
+                "base": base_score,
+                "recency": recency_component,
+                "kind_bonus": kind_component,
+                "semantic_boost": None,
+            },
+        },
+        "matches": {
+            "query_terms": matched_terms,
+            "project_match": _project_matches_filter(store, project_filter, project_value),
+        },
+        "pack_context": (
+            {
+                "included": None,
+                "section": None,
+            }
+            if include_pack_context
+            else None
+        ),
+    }
 
 
 def _query_looks_like_tasks(query: str) -> bool:
@@ -207,11 +554,12 @@ def _parse_created_at(value: str) -> dt.datetime | None:
     return parsed
 
 
-def _recency_score(created_at: str) -> float:
+def _recency_score(created_at: str, *, now: dt.datetime | None = None) -> float:
     parsed = _parse_created_at(created_at)
     if not parsed:
         return 0.0
-    days_ago = (dt.datetime.now(dt.UTC) - parsed).days
+    reference_now = now or dt.datetime.now(dt.UTC)
+    days_ago = (reference_now - parsed).days
     return 1.0 / (1.0 + (days_ago / 7.0))
 
 
@@ -395,9 +743,14 @@ def _rerank_results(
         recent_results = _filter_recent_results(results, recency_days)
         if recent_results:
             results = cast(list[MemoryResult], list(recent_results))
+    reference_now = dt.datetime.now(dt.UTC)
 
     def score(item: MemoryResult) -> float:
-        return (item.score * 1.5) + _recency_score(item.created_at) + _kind_bonus(item.kind)
+        return (
+            (item.score * 1.5)
+            + _recency_score(item.created_at, now=reference_now)
+            + _kind_bonus(item.kind)
+        )
 
     ordered = sorted(results, key=score, reverse=True)
     return ordered[:limit]
@@ -414,12 +767,13 @@ def _rerank_results_hybrid(
         recent_results = _filter_recent_results(results, recency_days)
         if recent_results:
             results = cast(list[MemoryResult], list(recent_results))
+    reference_now = dt.datetime.now(dt.UTC)
 
     def score(item: MemoryResult) -> float:
         semantic_boost = 0.35 if item.id in semantic_ids else 0.0
         return (
             (item.score * 1.2)
-            + (_recency_score(item.created_at) * 0.8)
+            + (_recency_score(item.created_at, now=reference_now) * 0.8)
             + _kind_bonus(item.kind)
             + semantic_boost
         )
@@ -716,7 +1070,7 @@ def search(
         JOIN memory_items ON memory_items.id = memory_fts.rowid
         {join_clause}
         WHERE {where}
-        ORDER BY (score * 1.5 + recency) DESC
+        ORDER BY (score * 1.5 + recency) DESC, memory_items.created_at DESC, memory_items.id DESC
         LIMIT ?
     """
     params.append(limit)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2405,6 +2405,172 @@ def test_search_finds_by_tag_only(tmp_path: Path) -> None:
     assert any(result.id == memory_id for result in results)
 
 
+def test_explain_requires_query_or_ids(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+
+    payload = store.explain()
+
+    assert payload["items"] == []
+    assert payload["missing_ids"] == []
+    assert payload["errors"][0]["code"] == "INVALID_ARGUMENT"
+    assert payload["metadata"]["returned_items_count"] == 0
+
+
+def test_explain_reports_invalid_ids_without_crashing(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    memory_id = store.remember(session, kind="note", title="Alpha", body_text="Alpha body")
+    store.end_session(session)
+
+    payload = store.explain(
+        query="alpha",
+        ids=[memory_id, True, 1.9, "2.4", "bad", None],
+    )
+
+    assert [item["id"] for item in payload["items"]] == [memory_id]
+    invalid_error = next(error for error in payload["errors"] if error["field"] == "ids")
+    assert invalid_error["code"] == "INVALID_ARGUMENT"
+    assert invalid_error["ids"] == ["True", "1.9", "2.4", "bad", "None"]
+
+
+def test_explain_invalid_ids_without_query_returns_structured_errors(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+
+    payload = store.explain(ids=["bad"], query=None)
+
+    assert payload["items"] == []
+    assert payload["missing_ids"] == []
+    assert {error["field"] for error in payload["errors"]} == {"ids", "query"}
+
+
+def test_search_stable_tiebreaker_prefers_newer_id_on_equal_scores(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    first_id = store.remember(session, kind="note", title="alpha", body_text="alpha")
+    second_id = store.remember(session, kind="note", title="alpha", body_text="alpha")
+    store.end_session(session)
+
+    fixed_created_at = "2026-01-01T00:00:00+00:00"
+    store.conn.execute(
+        "UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id IN (?, ?)",
+        (fixed_created_at, fixed_created_at, first_id, second_id),
+    )
+    store.conn.commit()
+
+    results = store.search("alpha", limit=2)
+
+    assert [item.id for item in results] == [second_id, first_id]
+
+
+def test_explain_ids_reports_missing_and_project_mismatch(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session_a = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    memory_a = store.remember(session_a, kind="note", title="A", body_text="A body")
+    store.end_session(session_a)
+
+    session_b = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-b",
+    )
+    memory_b = store.remember(session_b, kind="note", title="B", body_text="B body")
+    store.end_session(session_b)
+
+    payload = store.explain(
+        ids=[memory_a, memory_b, 999999],
+        filters={"project": "project-a"},
+    )
+
+    assert [item["id"] for item in payload["items"]] == [memory_a]
+    assert payload["missing_ids"] == [memory_b, 999999]
+    codes = {error["code"] for error in payload["errors"]}
+    assert codes == {"NOT_FOUND", "PROJECT_MISMATCH"}
+    assert payload["items"][0]["matches"]["project_match"] is True
+    assert payload["metadata"]["requested_ids_count"] == 3
+    assert payload["metadata"]["returned_items_count"] == 1
+
+
+def test_explain_combines_query_and_ids_with_sources(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    memory_query = store.remember(
+        session,
+        kind="decision",
+        title="Cache tuning decision",
+        body_text="Picked cache tuning strategy",
+    )
+    memory_id_only = store.remember(
+        session,
+        kind="note",
+        title="Follow-up",
+        body_text="Review benchmark numbers",
+    )
+    store.end_session(session)
+
+    payload = store.explain(
+        query="cache tuning",
+        ids=[memory_query, memory_id_only],
+        filters={"project": "/tmp/project-a"},
+    )
+
+    assert [item["id"] for item in payload["items"]] == [memory_query, memory_id_only]
+    assert payload["items"][0]["retrieval"] == {"source": "query+id_lookup", "rank": 1}
+    assert payload["items"][1]["retrieval"] == {"source": "id_lookup", "rank": None}
+    assert payload["items"][0]["score"]["components"]["base"] is not None
+    assert payload["items"][1]["score"]["components"]["base"] is None
+    assert payload["items"][0]["matches"]["query_terms"] == ["cache", "tuning"]
+    assert payload["items"][0]["pack_context"] is None
+
+
+def test_explain_include_pack_context_returns_deterministic_shape(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    memory_id = store.remember(session, kind="note", title="Alpha", body_text="Alpha body")
+    store.end_session(session)
+
+    payload = store.explain(ids=[memory_id], include_pack_context=True)
+
+    assert payload["items"][0]["pack_context"] == {"included": None, "section": None}
+
+
 def test_merge_ranked_results_shadow_logs_without_changing_baseline(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Description
- Add `MemoryStore.explain(...)` and store-side explainability assembly for retrieval rationale.
- Support query + explicit id workflows in one envelope with deterministic ordering, per-item retrieval source/rank, score components, project match, and optional `pack_context` placeholder shape.
- Return structured non-fatal errors for invalid ids, not-found ids, and project-scope mismatches.
- Harden id parsing (reject bool/float/non-digit/non-positive/out-of-range ids) and add stable FTS tie-break ordering for equal-score queries.
- Add focused tests for explain envelope behavior, invalid id handling, and deterministic tie-break ordering.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `uv run pytest tests/test_store.py -k "explain or stable_tiebreaker"`
- `uv run pytest tests/test_store.py -k "merge_ranked_results or search_index_and_timeline"`
- `uv run ruff check codemem/store/search.py codemem/store/_store.py tests/test_store.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced