### PR TITLE
feat(mcp): add memory_expand tool for id-based context expansion

### DIFF
--- a/codemem/mcp_server.py
+++ b/codemem/mcp_server.py
@@ -20,6 +20,9 @@ from .memory_kinds import ALLOWED_MEMORY_KINDS, validate_memory_kind
 from .store import MemoryStore
 from .utils import resolve_project
 
+SQLITE_INT64_MIN = -(2**63)
+SQLITE_INT64_MAX = (2**63) - 1
+
 
 def build_store(*, check_same_thread: bool = True) -> MemoryStore:
     db_path = os.environ.get("CODEMEM_DB", str(DEFAULT_DB_PATH))
@@ -55,6 +58,45 @@ def build_server() -> FastMCP:
 
     def with_store(handler):
         return handler(get_store())
+
+    def _dedupe_ordered_ids(ids: list[Any]) -> tuple[list[int], list[str]]:
+        deduped: list[int] = []
+        seen: set[int] = set()
+        invalid: list[str] = []
+        for raw_id in ids:
+            if isinstance(raw_id, (bool, float)):
+                invalid.append(str(raw_id))
+                continue
+            try:
+                memory_id = int(raw_id)
+            except (TypeError, ValueError, OverflowError):
+                invalid.append(str(raw_id))
+                continue
+            if not isinstance(raw_id, int) and not (isinstance(raw_id, str) and raw_id.isdigit()):
+                invalid.append(str(raw_id))
+                continue
+            if memory_id < SQLITE_INT64_MIN or memory_id > SQLITE_INT64_MAX:
+                invalid.append(str(raw_id))
+                continue
+            if memory_id <= 0:
+                invalid.append(str(raw_id))
+                continue
+            if memory_id in seen:
+                continue
+            deduped.append(memory_id)
+            seen.add(memory_id)
+        return deduped, invalid
+
+    def _project_matches_scope(scope_project: str, item_project: str | None) -> bool:
+        if item_project is None:
+            return False
+        scope_value = scope_project.strip().replace("\\", "/")
+        if not scope_value:
+            return True
+        if "/" in scope_value:
+            scope_value = Path(scope_value).name
+        normalized_item = item_project.replace("\\", "/")
+        return normalized_item == scope_value or normalized_item.endswith(f"/{scope_value}")
 
     @mcp.tool()
     def memory_search_index(
@@ -96,6 +138,135 @@ def build_server() -> FastMCP:
                 filters=filters or None,
             )
             return {"items": items}
+
+        return with_store(handler)
+
+    @mcp.tool()
+    def memory_expand(
+        ids: list[Any],
+        depth_before: int = 3,
+        depth_after: int = 3,
+        include_observations: bool = False,
+        project: str | None = None,
+    ) -> dict[str, Any]:
+        def handler(store: MemoryStore) -> dict[str, Any]:
+            resolved_project = project or default_project
+            filters = {"project": resolved_project} if resolved_project else None
+            ordered_ids, invalid_ids = _dedupe_ordered_ids(ids)
+
+            errors: list[dict[str, Any]] = []
+            if invalid_ids:
+                errors.append(
+                    {
+                        "code": "INVALID_ARGUMENT",
+                        "field": "ids",
+                        "message": "some ids are not valid integers",
+                        "ids": invalid_ids,
+                    }
+                )
+
+            missing_not_found: list[int] = []
+            missing_project_mismatch: list[int] = []
+            anchors: list[dict[str, Any]] = []
+            timeline_items: list[dict[str, Any]] = []
+            timeline_seen: set[int] = set()
+
+            session_projects: dict[int, str | None] = {}
+
+            for memory_id in ordered_ids:
+                item = store.get(memory_id)
+                if not item or not item.get("active", 1):
+                    missing_not_found.append(memory_id)
+                    continue
+
+                session_id = int(item.get("session_id") or 0)
+                item_project = session_projects.get(session_id)
+                if session_id and session_id not in session_projects:
+                    row = store.conn.execute(
+                        "SELECT project FROM sessions WHERE id = ?",
+                        (session_id,),
+                    ).fetchone()
+                    item_project = row["project"] if row else None
+                    session_projects[session_id] = item_project
+
+                if resolved_project and not _project_matches_scope(resolved_project, item_project):
+                    missing_project_mismatch.append(memory_id)
+                    continue
+
+                anchors.append(item)
+                expanded = store.timeline(
+                    memory_id=memory_id,
+                    depth_before=depth_before,
+                    depth_after=depth_after,
+                    filters=filters,
+                )
+                for expanded_item in expanded:
+                    expanded_id = int(expanded_item.get("id") or 0)
+                    if expanded_id <= 0 or expanded_id in timeline_seen:
+                        continue
+                    timeline_seen.add(expanded_id)
+                    timeline_items.append(expanded_item)
+
+            if missing_not_found:
+                errors.append(
+                    {
+                        "code": "NOT_FOUND",
+                        "field": "ids",
+                        "message": "some requested ids were not found",
+                        "ids": missing_not_found,
+                    }
+                )
+            if missing_project_mismatch:
+                errors.append(
+                    {
+                        "code": "PROJECT_MISMATCH",
+                        "field": "project",
+                        "message": "some requested ids are outside the requested project scope",
+                        "ids": missing_project_mismatch,
+                    }
+                )
+
+            missing_not_found_set = set(missing_not_found)
+            missing_project_mismatch_set = set(missing_project_mismatch)
+            missing_ids = [
+                memory_id
+                for memory_id in ordered_ids
+                if memory_id in missing_not_found_set or memory_id in missing_project_mismatch_set
+            ]
+
+            observations: list[dict[str, Any]] = []
+            if include_observations:
+                observation_ids: list[int] = []
+                observation_seen: set[int] = set()
+                for item in anchors + timeline_items:
+                    item_id = int(item.get("id") or 0)
+                    if item_id <= 0 or item_id in observation_seen:
+                        continue
+                    observation_seen.add(item_id)
+                    observation_ids.append(item_id)
+                observations_by_id = {
+                    int(item.get("id") or 0): item for item in store.get_many(observation_ids)
+                }
+                observations = [
+                    observations_by_id[item_id]
+                    for item_id in observation_ids
+                    if item_id in observations_by_id
+                ]
+
+            return {
+                "anchors": anchors,
+                "timeline": timeline_items,
+                "observations": observations,
+                "missing_ids": missing_ids,
+                "errors": errors,
+                "metadata": {
+                    "project": resolved_project,
+                    "requested_ids_count": len(ordered_ids),
+                    "returned_anchor_count": len(anchors),
+                    "timeline_count": len(timeline_items),
+                    "include_observations": include_observations,
+                },
+            }
 
         return with_store(handler)
 

--- a/tests/test_mcp_expand.py
+++ b/tests/test_mcp_expand.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from codemem.mcp_server import build_server
+from codemem.store import MemoryStore
+
+
+def _call_tool(server: Any, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    _content, structured = asyncio.run(server.call_tool(name, arguments))
+    assert isinstance(structured, dict)
+    return structured
+
+
+def _seed_two_projects(db_path: Path) -> tuple[int, int, int]:
+    store = MemoryStore(db_path)
+    session_a = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    memory_a1 = store.remember(session_a, kind="note", title="A1", body_text="A1 body")
+    memory_a2 = store.remember(session_a, kind="note", title="A2", body_text="A2 body")
+    store.end_session(session_a)
+
+    session_b = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-b",
+    )
+    memory_b1 = store.remember(session_b, kind="note", title="B1", body_text="B1 body")
+    store.end_session(session_b)
+    store.close()
+    return memory_a1, memory_a2, memory_b1
+
+
+def test_memory_expand_tool_is_registered(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CODEMEM_DB", str(tmp_path / "mem.sqlite"))
+    server = build_server()
+    tools = asyncio.run(server.list_tools())
+
+    names = {tool.name for tool in tools}
+    assert "memory_expand" in names
+
+
+def test_memory_expand_dedupes_ids_and_keeps_input_order(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    memory_a1, memory_a2, _memory_b1 = _seed_two_projects(db_path)
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+
+    server = build_server()
+    payload = _call_tool(
+        server,
+        "memory_expand",
+        {
+            "ids": [memory_a2, memory_a1, memory_a2],
+            "project": "/tmp/project-a",
+        },
+    )
+
+    assert [item["id"] for item in payload["anchors"]] == [memory_a2, memory_a1]
+    assert payload["missing_ids"] == []
+    assert payload["observations"] == []
+    assert payload["errors"] == []
+
+
+def test_memory_expand_reports_invalid_missing_and_project_mismatch(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    memory_a1, _memory_a2, memory_b1 = _seed_two_projects(db_path)
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+
+    server = build_server()
+    payload = _call_tool(
+        server,
+        "memory_expand",
+        {
+            "ids": [memory_a1, memory_b1, 999999, "bad", True],
+            "project": "/tmp/project-a",
+            "include_observations": True,
+        },
+    )
+
+    assert [item["id"] for item in payload["anchors"]] == [memory_a1]
+    assert payload["missing_ids"] == [memory_b1, 999999]
+    assert payload["observations"][0]["id"] == memory_a1
+    assert all("id" in item and "session_id" in item for item in payload["timeline"])
+    assert all("id" in item and "body_text" in item for item in payload["observations"])
+    errors_by_code = {error["code"]: error for error in payload["errors"]}
+    assert set(errors_by_code) == {"INVALID_ARGUMENT", "NOT_FOUND", "PROJECT_MISMATCH"}
+    assert errors_by_code["INVALID_ARGUMENT"]["ids"] == ["bad", "True"]
+    assert errors_by_code["NOT_FOUND"]["ids"] == [999999]
+    assert errors_by_code["PROJECT_MISMATCH"]["ids"] == [memory_b1]
+
+
+def test_memory_expand_uses_default_project_scope_when_project_omitted(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    memory_a1, _memory_a2, memory_b1 = _seed_two_projects(db_path)
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    monkeypatch.setenv("CODEMEM_PROJECT", "/tmp/project-a")
+
+    server = build_server()
+    payload = _call_tool(server, "memory_expand", {"ids": [memory_a1, memory_b1]})
+
+    assert [item["id"] for item in payload["anchors"]] == [memory_a1]
+    assert payload["missing_ids"] == [memory_b1]
+    assert {error["code"] for error in payload["errors"]} == {"PROJECT_MISMATCH"}
+    assert payload["metadata"]["project"] == "/tmp/project-a"
+    assert payload["metadata"]["requested_ids_count"] == 2
+    assert payload["metadata"]["returned_anchor_count"] == 1


### PR DESCRIPTION
## Description
- Add MCP tool `memory_expand` to expand explicit memory IDs into anchor + timeline context in one call.
- Support deduped ordered IDs, default project scoping, optional observation payload expansion, and structured non-fatal error reporting for invalid/not-found/project-mismatch IDs.
- Add focused MCP tests for registration, dedupe/order behavior, mixed error handling, and default project fallback semantics.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `uv run pytest tests/test_mcp_expand.py`
- `uv run pytest tests/test_store.py -k "search_index_and_timeline or prompt_memory_linkage_forward_reverse_and_timeline"`
- `uv run ruff check codemem/mcp_server.py tests/test_mcp_expand.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced