### PR TITLE
feat(pack): add deterministic pack delta metadata

### DIFF
--- a/codemem/store/packs.py
+++ b/codemem/store/packs.py
@@ -597,7 +597,10 @@ def build_memory_pack(
             section_blocks.append(f"## {title}\n")
     pack_text = "\n\n".join(section_blocks)
     pack_tokens = store.estimate_tokens(pack_text)
-    current_pack_ids = _dedupe_int_ids([_item_id(item) for item in final_items])
+    emitted_items: list[MemoryResult | dict[str, Any]] = []
+    for _title, section_items in sections:
+        emitted_items.extend(section_items)
+    current_pack_ids = _dedupe_int_ids([_item_id(item) for item in emitted_items])
     previous_pack_ids, previous_pack_tokens = _pack_delta_baseline(
         store,
         project=(filters or {}).get("project"),

--- a/codemem/store/usage.py
+++ b/codemem/store/usage.py
@@ -162,7 +162,7 @@ def recent_pack_events(
             LEFT JOIN sessions ON sessions.id = usage_events.session_id
             WHERE event = 'pack'
               AND ({session_clause} OR {meta_clause})
-            ORDER BY usage_events.created_at DESC
+            ORDER BY usage_events.created_at DESC, usage_events.id DESC
             LIMIT ?
             """,
             (*session_params, *meta_params, limit),
@@ -174,7 +174,7 @@ def recent_pack_events(
                    created_at, metadata_json
             FROM usage_events
             WHERE event = 'pack'
-            ORDER BY created_at DESC
+            ORDER BY created_at DESC, id DESC
             LIMIT ?
             """,
             (limit,),

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3065,6 +3065,175 @@ def test_pack_reports_avoided_work_metrics(tmp_path: Path) -> None:
     assert metrics.get("avoided_work_known_items") == 1
 
 
+def test_pack_delta_defaults_without_prior_pack(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd=str(tmp_path),
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    store.remember(session, kind="note", title="Alpha", body_text="alpha")
+    store.end_session(session)
+
+    pack = store.build_memory_pack("alpha", limit=1)
+    metrics = pack.get("metrics") or {}
+
+    assert isinstance(metrics.get("pack_item_ids"), list)
+    assert metrics.get("pack_delta_available") is False
+    assert metrics.get("added_ids") == []
+    assert metrics.get("removed_ids") == []
+    assert metrics.get("retained_ids") == []
+    assert metrics.get("pack_token_delta") == 0
+
+
+def test_pack_delta_legacy_prior_without_pack_item_ids_is_unavailable(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd=str(tmp_path),
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    store.remember(session, kind="note", title="Alpha", body_text="alpha")
+    store.record_usage(
+        "pack",
+        session_id=session,
+        tokens_read=111,
+        metadata={"pack_tokens": 111},
+    )
+    store.end_session(session)
+
+    pack = store.build_memory_pack("alpha", limit=1)
+    metrics = pack.get("metrics") or {}
+
+    assert metrics.get("pack_delta_available") is False
+    assert metrics.get("added_ids") == []
+    assert metrics.get("removed_ids") == []
+    assert metrics.get("retained_ids") == []
+    assert metrics.get("pack_token_delta") == 0
+
+
+def test_pack_delta_invalid_prior_pack_item_ids_is_unavailable(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd=str(tmp_path),
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    store.remember(session, kind="note", title="Alpha", body_text="alpha")
+    store.record_usage(
+        "pack",
+        session_id=session,
+        tokens_read=111,
+        metadata={"pack_tokens": 111, "pack_item_ids": "bad"},
+    )
+    store.end_session(session)
+
+    pack = store.build_memory_pack("alpha", limit=1)
+    metrics = pack.get("metrics") or {}
+
+    assert metrics.get("pack_delta_available") is False
+    assert metrics.get("added_ids") == []
+    assert metrics.get("removed_ids") == []
+    assert metrics.get("retained_ids") == []
+    assert metrics.get("pack_token_delta") == 0
+
+
+def test_pack_delta_for_changed_consecutive_packs(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd=str(tmp_path),
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    alpha_id = store.remember(session, kind="note", title="Alpha", body_text="alpha")
+    beta_id = store.remember(session, kind="note", title="Beta", body_text="beta")
+    store.end_session(session)
+
+    first_pack = store.build_memory_pack("alpha", limit=1)
+    second_pack = store.build_memory_pack("beta", limit=1)
+    first_metrics = first_pack.get("metrics") or {}
+    second_metrics = second_pack.get("metrics") or {}
+
+    assert first_metrics.get("pack_item_ids") == [alpha_id]
+    assert second_metrics.get("pack_item_ids") == [beta_id]
+    assert second_metrics.get("pack_delta_available") is True
+    assert second_metrics.get("added_ids") == [beta_id]
+    assert second_metrics.get("removed_ids") == [alpha_id]
+    assert second_metrics.get("retained_ids") == []
+    assert second_metrics.get("pack_token_delta") == (
+        int(second_metrics.get("pack_tokens") or 0) - int(first_metrics.get("pack_tokens") or 0)
+    )
+
+
+def test_pack_delta_for_unchanged_consecutive_packs(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd=str(tmp_path),
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    alpha_id = store.remember(session, kind="note", title="Alpha", body_text="alpha")
+    store.end_session(session)
+
+    _first_pack = store.build_memory_pack("alpha", limit=1)
+    second_pack = store.build_memory_pack("alpha", limit=1)
+    second_metrics = second_pack.get("metrics") or {}
+
+    assert second_metrics.get("pack_item_ids") == [alpha_id]
+    assert second_metrics.get("pack_delta_available") is True
+    assert second_metrics.get("added_ids") == []
+    assert second_metrics.get("removed_ids") == []
+    assert second_metrics.get("retained_ids") == [alpha_id]
+    assert second_metrics.get("pack_token_delta") == 0
+
+
+def test_recent_pack_events_stable_tiebreaker_by_id(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd=str(tmp_path),
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    store.record_usage("pack", session_id=session, tokens_read=10, metadata={"marker": "a"})
+    store.record_usage("pack", session_id=session, tokens_read=20, metadata={"marker": "b"})
+    store.end_session(session)
+
+    row_ids = [
+        int(row["id"])
+        for row in store.conn.execute(
+            "SELECT id FROM usage_events WHERE event = 'pack' ORDER BY id ASC"
+        ).fetchall()
+    ]
+    assert len(row_ids) == 2
+    tied_created_at = "2026-03-01T00:00:00+00:00"
+    store.conn.execute(
+        "UPDATE usage_events SET created_at = ? WHERE id IN (?, ?)",
+        (tied_created_at, row_ids[0], row_ids[1]),
+    )
+    store.conn.commit()
+
+    rows = store.recent_pack_events(limit=2)
+    assert [int(row["id"]) for row in rows] == [row_ids[1], row_ids[0]]
+
+
 def test_viewer_accepts_raw_events(monkeypatch, tmp_path: Path) -> None:
     db_path = tmp_path / "mem.sqlite"
     monkeypatch.setenv("CODEMEM_DB", str(db_path))


### PR DESCRIPTION
## Description
- Add deterministic pack-delta metadata to `build_memory_pack` metrics so consecutive pack runs can report what changed.
- Emit `pack_item_ids`, `added_ids`, `removed_ids`, `retained_ids`, `pack_token_delta`, and `pack_delta_available` with safe fallback when prior baseline metadata is missing or malformed.
- Make prior baseline selection deterministic by ordering recent pack events with `created_at DESC, id DESC`.
- Add regression tests for first-pack fallback, legacy/malformed baseline metadata, changed/unchanged pack deltas, and recent-pack tie-break ordering.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `uv run pytest tests/test_store.py -k "pack_delta or recent_pack_events_stable_tiebreaker"`
- `uv run pytest tests/test_store.py -k "pack_ or recent_pack_events_project_filter"`
- `uv run ruff check codemem/store/packs.py codemem/store/usage.py tests/test_store.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced