### PR TITLE
feat(ingest): project adapter v1 envelopes into transcript and tool extraction

### DIFF
--- a/codemem/plugin_ingest.py
+++ b/codemem/plugin_ingest.py
@@ -5,6 +5,7 @@ import os
 import sys
 from collections.abc import Iterable
 from dataclasses import asdict
+from datetime import UTC, datetime
 from pathlib import Path, PureWindowsPath
 from typing import Any
 
@@ -21,9 +22,6 @@ from .ingest.events import (
 )
 from .ingest.events import (
     event_to_tool_event as _event_to_tool_event_impl,
-)
-from .ingest.events import (
-    extract_tool_events as _extract_tool_events_impl,
 )
 from .ingest.events import (
     is_internal_memory_tool as _is_internal_memory_tool_impl,
@@ -127,6 +125,13 @@ def _normalize_tool_name(event: dict[str, Any]) -> str:
 def _extract_assistant_messages(events: Iterable[dict[str, Any]]) -> list[str]:
     messages: list[str] = []
     for event in events:
+        adapter = _extract_adapter_event(event)
+        if adapter and adapter.get("event_type") == "assistant":
+            payload = adapter.get("payload")
+            text = str(payload.get("text") or "").strip() if isinstance(payload, dict) else ""
+            if text:
+                messages.append(text)
+                continue
         if event.get("type") != "assistant_message":
             continue
         text = str(event.get("assistant_text") or "").strip()
@@ -165,15 +170,32 @@ def _extract_assistant_usage(events: Iterable[dict[str, Any]]) -> list[dict[str,
 def _build_transcript(events: Iterable[dict[str, Any]]) -> str:
     """Build a transcript from user prompts and assistant messages in chronological order."""
 
-    return _build_transcript_impl(events, strip_private=_strip_private)
+    normalized_events = [_event_with_adapter_projection(event) for event in events]
+    return _build_transcript_impl(normalized_events, strip_private=_strip_private)
 
 
 def _event_to_tool_event(event: dict[str, Any], max_chars: int) -> ToolEvent | None:
+    adapter = _extract_adapter_event(event)
+    if adapter:
+        if adapter.get("event_type") == "tool_call":
+            return None
+        adapted = _project_adapter_tool_event(adapter, event=event)
+        if adapted is not None:
+            return _event_to_tool_event_impl(
+                adapted,
+                max_chars=max_chars,
+                low_signal_tools=LOW_SIGNAL_TOOLS,
+            )
     return _event_to_tool_event_impl(event, max_chars=max_chars, low_signal_tools=LOW_SIGNAL_TOOLS)
 
 
 def _extract_tool_events(events: Iterable[dict[str, Any]], max_chars: int) -> list[ToolEvent]:
-    return _extract_tool_events_impl(events, max_chars)
+    tool_events: list[ToolEvent] = []
+    for event in events:
+        tool_event = _event_to_tool_event(event, max_chars=max_chars)
+        if tool_event:
+            tool_events.append(tool_event)
+    return tool_events
 
 
 def _budget_tool_events(
@@ -247,6 +269,21 @@ def _normalize_paths(paths: list[str], repo_root: str | None) -> list[str]:
 def _extract_prompts(events: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     prompts: list[dict[str, Any]] = []
     for event in events:
+        adapter = _extract_adapter_event(event)
+        if adapter and adapter.get("event_type") == "prompt":
+            payload = adapter.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            prompt_text = str(payload.get("text") or "").strip()
+            if prompt_text:
+                prompts.append(
+                    {
+                        "prompt_text": prompt_text,
+                        "prompt_number": payload.get("prompt_number", event.get("prompt_number")),
+                        "timestamp": adapter.get("ts") or event.get("timestamp"),
+                    }
+                )
+                continue
         if event.get("type") != "user_prompt":
             continue
         prompt_text = str(event.get("prompt_text") or "").strip()
@@ -260,6 +297,112 @@ def _extract_prompts(events: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
             }
         )
     return prompts
+
+
+def _extract_adapter_event(event: dict[str, Any]) -> dict[str, Any] | None:
+    adapter = event.get("_adapter")
+    if not isinstance(adapter, dict):
+        return None
+    schema_version = adapter.get("schema_version")
+    if schema_version != "1.0":
+        return None
+    source = adapter.get("source")
+    if not isinstance(source, str) or not source.strip():
+        return None
+    session_id = adapter.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        return None
+    event_id = adapter.get("event_id")
+    if not isinstance(event_id, str) or not event_id.strip():
+        return None
+    event_type = adapter.get("event_type")
+    if not isinstance(event_type, str):
+        return None
+    if event_type not in {
+        "prompt",
+        "assistant",
+        "tool_call",
+        "tool_result",
+        "session_start",
+        "session_end",
+        "error",
+    }:
+        return None
+    payload = adapter.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    ts = adapter.get("ts")
+    if not isinstance(ts, str):
+        return None
+    text = ts.strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+    except ValueError:
+        return None
+    return adapter
+
+
+def _project_adapter_tool_event(
+    adapter: dict[str, Any], *, event: dict[str, Any]
+) -> dict[str, Any] | None:
+    event_type = str(adapter.get("event_type") or "")
+    payload = adapter.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    if event_type != "tool_result":
+        return None
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    tool_error = payload.get("tool_error")
+    if tool_error is None and payload.get("status") == "error":
+        tool_error = payload.get("error")
+    tool_output = payload.get("tool_output")
+    if tool_output is None and "output" in payload:
+        tool_output = payload.get("output")
+    return {
+        "type": "tool.execute.after",
+        "tool": payload.get("tool_name"),
+        "args": tool_input,
+        "result": tool_output,
+        "error": tool_error,
+        "timestamp": adapter.get("ts"),
+        "cwd": event.get("cwd"),
+    }
+
+
+def _event_with_adapter_projection(event: dict[str, Any]) -> dict[str, Any]:
+    adapter = _extract_adapter_event(event)
+    if not adapter:
+        return event
+    payload = adapter.get("payload")
+    if not isinstance(payload, dict):
+        return event
+    event_type = str(adapter.get("event_type") or "")
+    if event_type == "prompt":
+        text = str(payload.get("text") or "").strip()
+        if not text:
+            return event
+        return {
+            "type": "user_prompt",
+            "prompt_text": text,
+            "prompt_number": payload.get("prompt_number"),
+            "timestamp": adapter.get("ts"),
+        }
+    if event_type == "assistant":
+        text = str(payload.get("text") or "").strip()
+        if not text:
+            return event
+        return {
+            "type": "assistant_message",
+            "assistant_text": text,
+            "timestamp": adapter.get("ts"),
+        }
+    return event
 
 
 def _normalize_project_label(value: Any) -> str | None:

--- a/docs/plans/2026-03-02-multi-agent-adapter-architecture-design.md
+++ b/docs/plans/2026-03-02-multi-agent-adapter-architecture-design.md
@@ -1,0 +1,170 @@
+# Multi-Agent Adapter Architecture (OpenCode, Codex, Claude, Windsurf, Cursor)
+
+Related bead: `codemem-afm`
+
+## Goal
+
+Support multiple agent shells through a shared adapter contract, while keeping `codemem` core ingestion/retrieval logic shell-agnostic.
+
+Priority order:
+
+1. Preserve OpenCode behavior via adapter boundary.
+2. Add Claude Code CLI as first non-OpenCode adapter.
+3. Expand to other shells (Codex, Windsurf, Cursor) on the same contract.
+
+## Product alignment decisions
+
+- OpenCode is one adapter, not the system boundary.
+- Multi-adapter operation is expected (OpenCode + Claude enabled by default).
+- Project scoping is unified by normalized project label; shell identity stays in `source`.
+- Generic bash/zsh/fish shell-hook wrapper strategy is out of scope.
+
+## Adapter event schema v1 direction (`codemem-afm.1`)
+
+Canonical v1 event types:
+
+- `prompt`
+- `assistant`
+- `tool_call`
+- `tool_result`
+- `session_start`
+- `session_end`
+- `error`
+
+v1 scope is conversation and tool lifecycle only.
+
+Required envelope fields:
+
+- `schema_version`
+- `source`
+- `session_id`
+- `event_id`
+- `event_type`
+- `ts`
+- `payload`
+
+Ordering and identity:
+
+- `seq` should be emitted when available.
+- Missing `seq` is accepted for sources that cannot emit monotonic sequence yet, with `ordering_confidence=low`.
+- For sources without native IDs, generate deterministic `event_id` hashes.
+
+Safety:
+
+- Redaction policy is soft redact (`[REDACTED]`) while preserving payload shape.
+
+## OpenCode adapter boundary (`codemem-afm.2`)
+
+- Refactor current OpenCode event mapping into `OpenCode -> AdapterEventV1 -> ingest`.
+- Keep current flush/retry/backoff semantics unchanged.
+- Validate parity against current behavior using regression tests.
+
+## Claude adapter MVP (`codemem-afm.3`)
+
+Ingestion model:
+
+- Hook event stream is the MVP ingestion path.
+- Use official Claude hooks payloads as source-of-truth for event mapping.
+- Transcript fallback is out of scope for MVP (no fallback path shipped).
+- Hook payloads are enqueued through the shared raw-event queue path (same queue family used by OpenCode stream ingestion).
+
+Hook scope for MVP:
+
+- In scope hook events: `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PostToolUseFailure`, `Stop`, `SessionEnd`.
+- Out of scope in MVP: `PermissionRequest`, `Notification`, `SubagentStart`, `SubagentStop`, `TeammateIdle`, `TaskCompleted`, `ConfigChange`, `WorktreeCreate`, `WorktreeRemove`, `PreCompact`.
+- Deferred in template: `PreToolUse` (mapped in schema, but not emitted by default until tool-call persistence is enabled end-to-end).
+
+Exact Claude hook -> AdapterEventV1 mapping (MVP):
+
+- `SessionStart` -> `session_start`
+  - `payload.source` <- hook `source` (`startup|resume|clear|compact`)
+  - `meta.hook_event_name` <- `SessionStart`
+- `UserPromptSubmit` -> `prompt`
+  - `payload.text` <- hook `prompt`
+  - `meta.hook_event_name` <- `UserPromptSubmit`
+- `PreToolUse` -> `tool_call` (deferred in default template)
+  - `payload.tool_name` <- hook `tool_name`
+  - `payload.tool_input` <- hook `tool_input`
+  - `meta.tool_use_id` <- hook `tool_use_id` (when present)
+- `PostToolUse` -> `tool_result`
+  - `payload.tool_name` <- hook `tool_name`
+  - `payload.status` <- `ok`
+  - `payload.tool_output` <- hook `tool_response`/result payload (normalized string or object)
+  - `meta.tool_use_id` <- hook `tool_use_id` (when present)
+- `PostToolUseFailure` -> `tool_result`
+  - `payload.tool_name` <- hook `tool_name`
+  - `payload.status` <- `error`
+  - `payload.error` <- hook error/failure payload
+  - `meta.tool_use_id` <- hook `tool_use_id` (when present)
+- `Stop` -> `assistant`
+  - `payload.text` <- assistant response text available at stop time
+  - `meta.hook_event_name` <- `Stop`
+- `SessionEnd` -> `session_end`
+  - `payload.reason` <- hook `reason`
+  - `meta.hook_event_name` <- `SessionEnd`
+
+Ordering and identity notes for Claude hooks:
+
+- Use hook-provided sequence/order fields when present; otherwise compute deterministic `event_id` from `(session_id, hook_event_name, ts, tool_use_id?, content hash)`.
+- Set `ordering_confidence=high` when explicit ordering is present, else `ordering_confidence=low`.
+- Tool lifecycle correlation uses `meta.tool_use_id` when available.
+
+Activation and defaults:
+
+- Hybrid activation: explicit commands plus optional auto-detect.
+- Default for installed users: Claude adapter enabled and auto-detect enabled for known safe paths.
+- First-run summary with clear opt-out.
+
+Packaging:
+
+- Ship Claude integration via official plugin packaging and hooks configuration.
+- Keep hook scripts/pathing rooted in `${CLAUDE_PLUGIN_ROOT}`.
+
+Plugin packaging/install checklist (MVP):
+
+- `hooks/hooks.json` is packaged and registers only MVP in-scope events.
+- Hook commands resolve from `${CLAUDE_PLUGIN_ROOT}` (no absolute user-specific paths).
+- Installer enables plugin + hook config in one step and prints disable/uninstall commands.
+- Post-install validation confirms hooks load in Claude and emit JSON payloads to adapter ingress.
+
+Reliability checklist (MVP):
+
+- Hook handler failures are non-fatal to Claude sessions; adapter swallows and logs mapping/IO errors.
+- Raw payload ingestion preserves flush/retry/backoff semantics already used by OpenCode ingestion.
+- Idempotency/dedupe is enforced by deterministic `event_id` generation.
+- Redaction remains soft (`[REDACTED]`) and preserves payload shape.
+- Backpressure behavior is documented (bounded queue + retry path) before rollout.
+
+## Support matrix and rollout (`codemem-afm.4`)
+
+Support tiers:
+
+- `supported`
+- `partial`
+- `experimental`
+
+Rollout gates:
+
+1. Schema v1 stable.
+2. OpenCode adapter parity validated.
+3. Claude MVP validated.
+4. Add additional adapters with tiered support documentation.
+
+## Open questions to validate in implementation
+
+- Safe default auto-detect paths across environments.
+- Which optional metadata fields are stable enough for cross-shell normalization in v1.x.
+
+Reference docs:
+
+- `https://code.claude.com/docs/en/hooks`
+- `https://code.claude.com/docs/en/plugins-reference`
+
+Non-authoritative pattern references (optional):
+
+- `../claude-mem`
+
+## Draft schema artifacts
+
+- `docs/plans/adapter-event-v1.schema.json`
+- `docs/plans/adapter-event-v1.fixtures.json`

--- a/docs/plans/adapter-event-v1.fixtures.json
+++ b/docs/plans/adapter-event-v1.fixtures.json
@@ -1,0 +1,220 @@
+{
+  "schema": "adapter-event-v1",
+  "schema_version": "1.0",
+  "examples": [
+    {
+      "name": "opencode-prompt-high-ordering",
+      "event": {
+        "schema_version": "1.0",
+        "source": "opencode",
+        "session_id": "oc_20260302_0001",
+        "event_id": "oc_20260302_0001_prompt_0001",
+        "event_type": "prompt",
+        "ts": "2026-03-02T18:02:10Z",
+        "seq": 1,
+        "ordering_confidence": "high",
+        "project": "codemem",
+        "cwd": "/Users/adam/workspace/codemem",
+        "payload": {
+          "text": "Add a schema spec for adapter events."
+        },
+        "redacted": false,
+        "meta": {
+          "provider": "openai",
+          "model": "gpt-5.3-codex"
+        }
+      }
+    },
+    {
+      "name": "opencode-tool-result-redacted",
+      "event": {
+        "schema_version": "1.0",
+        "source": "opencode",
+        "session_id": "oc_20260302_0001",
+        "event_id": "oc_20260302_0001_tool_result_0002",
+        "event_type": "tool_result",
+        "ts": "2026-03-02T18:02:24Z",
+        "seq": 2,
+        "ordering_confidence": "high",
+        "project": "codemem",
+        "cwd": "/Users/adam/workspace/codemem",
+        "payload": {
+          "tool_name": "bash",
+          "status": "ok",
+          "output": "Authorization: [REDACTED]"
+        },
+        "redacted": true,
+        "meta": {
+          "redaction_matches": 1
+        }
+      }
+    },
+    {
+      "name": "claude-hook-session-start",
+      "event": {
+        "schema_version": "1.0",
+        "source": "claude",
+        "session_id": "cld_20260302_0099",
+        "event_id": "cld_evt_session_start_0001",
+        "event_type": "session_start",
+        "ts": "2026-03-02T18:09:58Z",
+        "seq": 1,
+        "ordering_confidence": "high",
+        "project": "codemem",
+        "cwd": "/Users/adam/workspace/codemem",
+        "payload": {
+          "source": "startup"
+        },
+        "redacted": false,
+        "meta": {
+          "hook_event_name": "SessionStart"
+        }
+      }
+    },
+    {
+      "name": "claude-hook-user-prompt-submit",
+      "event": {
+        "schema_version": "1.0",
+        "source": "claude",
+        "session_id": "cld_20260302_0099",
+        "event_id": "cld_evt_user_prompt_submit_0002",
+        "event_type": "prompt",
+        "ts": "2026-03-02T18:10:03Z",
+        "seq": 2,
+        "ordering_confidence": "high",
+        "project": "codemem",
+        "cwd": "/Users/adam/workspace/codemem",
+        "payload": {
+          "text": "Run the unit tests and fix any failures."
+        },
+        "redacted": false,
+        "meta": {
+          "hook_event_name": "UserPromptSubmit"
+        }
+      }
+    },
+    {
+      "name": "claude-structured-assistant-authoritative",
+      "event": {
+        "schema_version": "1.0",
+        "source": "claude",
+        "session_id": "cld_20260302_0099",
+        "event_id": "cld_evt_8f2b95a4",
+        "event_type": "assistant",
+        "ts": "2026-03-02T18:10:12Z",
+        "seq": 14,
+        "ordering_confidence": "high",
+        "project": "codemem",
+        "cwd": "/Users/adam/workspace/codemem",
+        "payload": {
+          "text": "Assistant response captured from Claude hook stream."
+        },
+        "redacted": false,
+        "meta": {
+          "hook_event_name": "Stop"
+        }
+      }
+    },
+    {
+      "name": "claude-hook-tool-call-pretooluse",
+      "event": {
+        "schema_version": "1.0",
+        "source": "claude",
+        "session_id": "cld_20260302_0099",
+        "event_id": "cld_evt_pretooluse_0015",
+        "event_type": "tool_call",
+        "ts": "2026-03-02T18:10:14Z",
+        "seq": 15,
+        "ordering_confidence": "high",
+        "project": "codemem",
+        "cwd": "/Users/adam/workspace/codemem",
+        "payload": {
+          "tool_name": "Bash",
+          "tool_input": {
+            "command": "uv run pytest tests/test_store.py"
+          }
+        },
+        "redacted": false,
+        "meta": {
+          "hook_event_name": "PreToolUse",
+          "tool_use_id": "toolu_01h4"
+        }
+      }
+    },
+    {
+      "name": "claude-hook-tool-result-posttoolusefailure",
+      "event": {
+        "schema_version": "1.0",
+        "source": "claude",
+        "session_id": "cld_20260302_0099",
+        "event_id": "cld_evt_posttoolusefailure_0016",
+        "event_type": "tool_result",
+        "ts": "2026-03-02T18:10:15Z",
+        "seq": 16,
+        "ordering_confidence": "high",
+        "project": "codemem",
+        "cwd": "/Users/adam/workspace/codemem",
+        "payload": {
+          "tool_name": "Bash",
+          "status": "error",
+          "error": "pytest failed: 1 test failed"
+        },
+        "redacted": false,
+        "meta": {
+          "hook_event_name": "PostToolUseFailure",
+          "tool_use_id": "toolu_01h4"
+        }
+      }
+    },
+    {
+      "name": "claude-hook-tool-result-posttooluse-success",
+      "event": {
+        "schema_version": "1.0",
+        "source": "claude",
+        "session_id": "cld_20260302_0099",
+        "event_id": "cld_evt_posttooluse_0017",
+        "event_type": "tool_result",
+        "ts": "2026-03-02T18:10:16Z",
+        "seq": 17,
+        "ordering_confidence": "high",
+        "project": "codemem",
+        "cwd": "/Users/adam/workspace/codemem",
+        "payload": {
+          "tool_name": "Bash",
+          "status": "ok",
+          "tool_output": {
+            "exit_code": 0,
+            "stdout": "1 passed"
+          }
+        },
+        "redacted": false,
+        "meta": {
+          "hook_event_name": "PostToolUse",
+          "tool_use_id": "toolu_01h5"
+        }
+      }
+    },
+    {
+      "name": "claude-session-end",
+      "event": {
+        "schema_version": "1.0",
+        "source": "claude",
+        "session_id": "cld_20260302_0099",
+        "event_id": "cld_evt_session_end_0020",
+        "event_type": "session_end",
+        "ts": "2026-03-02T18:11:02Z",
+        "seq": 20,
+        "ordering_confidence": "high",
+        "project": "codemem",
+        "cwd": "/Users/adam/workspace/codemem",
+        "payload": {
+          "reason": "prompt_input_exit"
+        },
+        "redacted": false,
+        "meta": {
+          "hook_event_name": "SessionEnd"
+        }
+      }
+    }
+  ]
+}

--- a/docs/plans/adapter-event-v1.schema.json
+++ b/docs/plans/adapter-event-v1.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "codemem://schemas/adapter-event-v1",
+  "title": "CodeMem Adapter Event V1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "source",
+    "session_id",
+    "event_id",
+    "event_type",
+    "ts",
+    "payload"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Adapter source key (for example: opencode, claude, codex, windsurf, cursor)."
+    },
+    "session_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "event_id": {
+      "type": "string",
+      "minLength": 8,
+      "maxLength": 128,
+      "pattern": "^[A-Za-z0-9._:-]+$",
+      "description": "Stable idempotency key at the adapter event level."
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "prompt",
+        "assistant",
+        "tool_call",
+        "tool_result",
+        "session_start",
+        "session_end",
+        "error"
+      ]
+    },
+    "ts": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "seq": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Monotonic sequence number within session when available."
+    },
+    "ordering_confidence": {
+      "type": "string",
+      "enum": [
+        "high",
+        "low"
+      ],
+      "description": "high when strict ordering is known; low when ordering is inferred."
+    },
+    "project": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "cwd": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "redacted": {
+      "type": "boolean",
+      "default": false,
+      "description": "True when payload text was masked with [REDACTED]."
+    },
+    "payload": {
+      "type": "object"
+    },
+    "meta": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Adapter-specific optional metadata."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "not": {
+          "required": [
+            "seq"
+          ]
+        }
+      },
+      "then": {
+        "required": [
+          "ordering_confidence"
+        ],
+        "properties": {
+          "ordering_confidence": {
+            "const": "low"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "event_type": {
+            "enum": [
+              "prompt",
+              "assistant"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "type": "object",
+            "required": [
+              "text"
+            ],
+            "properties": {
+              "text": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "event_type": {
+            "const": "tool_call"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "type": "object",
+            "required": [
+              "tool_name"
+            ],
+            "properties": {
+              "tool_name": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "event_type": {
+            "const": "tool_result"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "type": "object",
+            "required": [
+              "tool_name",
+              "status"
+            ],
+            "properties": {
+              "tool_name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "ok",
+                  "error"
+                ]
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "event_type": {
+            "const": "error"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "payload": {
+            "type": "object",
+            "required": [
+              "message"
+            ],
+            "properties": {
+              "message": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_plugin_ingest.py
+++ b/tests/test_plugin_ingest.py
@@ -11,6 +11,8 @@ from codemem.plugin_ingest import (
     _budget_tool_events,
     _build_transcript,
     _event_to_tool_event,
+    _extract_prompts,
+    _extract_tool_events,
     _normalize_project_label,
     _resolve_ingest_project,
     ingest,
@@ -84,6 +86,67 @@ def test_build_transcript_strips_private_blocks() -> None:
     assert "Hello" in transcript
 
 
+def test_build_transcript_uses_adapter_projection_for_prompt_and_assistant() -> None:
+    events = [
+        {
+            "type": "user_prompt",
+            "prompt_text": "",
+            "timestamp": "2026-01-14T19:00:00Z",
+            "_adapter": {
+                "schema_version": "1.0",
+                "source": "opencode",
+                "session_id": "sess-1",
+                "event_id": "sess-1:prompt:1",
+                "event_type": "prompt",
+                "ts": "2026-01-14T19:00:00Z",
+                "payload": {"text": "Adapter prompt"},
+            },
+        },
+        {
+            "type": "assistant_message",
+            "assistant_text": "",
+            "timestamp": "2026-01-14T19:00:01Z",
+            "_adapter": {
+                "schema_version": "1.0",
+                "source": "opencode",
+                "session_id": "sess-1",
+                "event_id": "sess-1:assistant:1",
+                "event_type": "assistant",
+                "ts": "2026-01-14T19:00:01Z",
+                "payload": {"text": "Adapter assistant"},
+            },
+        },
+    ]
+
+    transcript = _build_transcript(events)
+
+    assert "User: Adapter prompt" in transcript
+    assert "Assistant: Adapter assistant" in transcript
+
+
+def test_build_transcript_falls_back_when_adapter_assistant_text_empty() -> None:
+    events = [
+        {
+            "type": "assistant_message",
+            "assistant_text": "Legacy assistant response",
+            "timestamp": "2026-01-14T19:00:01Z",
+            "_adapter": {
+                "schema_version": "1.0",
+                "source": "opencode",
+                "session_id": "sess-1",
+                "event_id": "sess-1:assistant:1",
+                "event_type": "assistant",
+                "ts": "2026-01-14T19:00:01Z",
+                "payload": {"text": ""},
+            },
+        }
+    ]
+
+    transcript = _build_transcript(events)
+
+    assert "Assistant: Legacy assistant response" in transcript
+
+
 def test_build_transcript_empty_events() -> None:
     """Empty events should produce empty transcript."""
     assert _build_transcript([]) == ""
@@ -100,6 +163,124 @@ def test_build_transcript_no_messages() -> None:
         },
     ]
     assert _build_transcript(events) == ""
+
+
+def test_extract_prompts_prefers_adapter_payload_text() -> None:
+    events = [
+        {
+            "type": "user_prompt",
+            "prompt_text": "",
+            "timestamp": "2026-01-14T19:00:00Z",
+            "_adapter": {
+                "schema_version": "1.0",
+                "source": "opencode",
+                "session_id": "sess-1",
+                "event_id": "sess-1:prompt:1",
+                "event_type": "prompt",
+                "ts": "2026-01-14T19:00:00Z",
+                "payload": {"text": "Adapter-first prompt", "prompt_number": 3},
+            },
+        }
+    ]
+
+    prompts = _extract_prompts(events)
+    assert prompts == [
+        {
+            "prompt_text": "Adapter-first prompt",
+            "prompt_number": 3,
+            "timestamp": "2026-01-14T19:00:00Z",
+        }
+    ]
+
+
+def test_extract_prompts_falls_back_when_adapter_envelope_invalid() -> None:
+    events = [
+        {
+            "type": "user_prompt",
+            "prompt_text": "Legacy prompt fallback",
+            "prompt_number": 4,
+            "timestamp": "2026-01-14T19:00:00Z",
+            "_adapter": {
+                "schema_version": "0.9",
+                "source": "opencode",
+                "session_id": "sess-1",
+                "event_id": "sess-1:prompt:1",
+                "event_type": "prompt",
+                "ts": "2026-01-14T19:00:00Z",
+                "payload": {"text": "Adapter prompt should be ignored"},
+            },
+        }
+    ]
+
+    prompts = _extract_prompts(events)
+
+    assert prompts == [
+        {
+            "prompt_text": "Legacy prompt fallback",
+            "prompt_number": 4,
+            "timestamp": "2026-01-14T19:00:00Z",
+        }
+    ]
+
+
+def test_extract_prompts_falls_back_when_adapter_prompt_text_empty() -> None:
+    events = [
+        {
+            "type": "user_prompt",
+            "prompt_text": "Legacy prompt text",
+            "prompt_number": 5,
+            "timestamp": "2026-01-14T19:00:00Z",
+            "_adapter": {
+                "schema_version": "1.0",
+                "source": "opencode",
+                "session_id": "sess-1",
+                "event_id": "sess-1:prompt:1",
+                "event_type": "prompt",
+                "ts": "2026-01-14T19:00:00Z",
+                "payload": {"text": "   "},
+            },
+        }
+    ]
+
+    prompts = _extract_prompts(events)
+
+    assert prompts == [
+        {
+            "prompt_text": "Legacy prompt text",
+            "prompt_number": 5,
+            "timestamp": "2026-01-14T19:00:00Z",
+        }
+    ]
+
+
+def test_extract_prompts_uses_legacy_prompt_number_when_adapter_omits_it() -> None:
+    events = [
+        {
+            "type": "user_prompt",
+            "prompt_text": "Legacy prompt text",
+            "prompt_number": 7,
+            "timestamp": "2026-01-14T19:00:00Z",
+            "_adapter": {
+                "schema_version": "1.0",
+                "source": "opencode",
+                "session_id": "sess-1",
+                "event_id": "sess-1:prompt:1",
+                "event_type": "prompt",
+                "ts": "2026-01-14T19:00:00Z",
+                "payload": {"text": "Adapter prompt text"},
+            },
+        }
+    ]
+
+    prompts = _extract_prompts(events)
+
+    assert prompts == [
+        {
+            "prompt_text": "Adapter prompt text",
+            "prompt_number": 7,
+            "timestamp": "2026-01-14T19:00:00Z",
+        }
+    ]
 
 
 def test_tool_events_are_json_serializable() -> None:
@@ -127,6 +308,166 @@ def test_tool_events_are_json_serializable() -> None:
     assert len(parsed) == 2
     assert parsed[0]["tool_name"] == "bash"
     assert parsed[1]["tool_name"] == "read"
+
+
+def test_event_to_tool_event_supports_adapter_tool_result() -> None:
+    event = {
+        "type": "tool.execute.after",
+        "tool": "ignored",
+        "args": {},
+        "result": None,
+        "error": None,
+        "timestamp": "2026-01-14T19:00:03Z",
+        "_adapter": {
+            "schema_version": "1.0",
+            "source": "opencode",
+            "session_id": "sess-1",
+            "event_id": "sess-1:tool_result:1",
+            "event_type": "tool_result",
+            "ts": "2026-01-14T19:00:03Z",
+            "payload": {
+                "tool_name": "bash",
+                "status": "error",
+                "tool_input": {"command": "uv run pytest"},
+                "tool_output": "failed",
+                "error": "1 test failed",
+            },
+        },
+    }
+
+    tool_event = _event_to_tool_event(event, max_chars=5000)
+
+    assert tool_event is not None
+    assert tool_event.tool_name == "bash"
+    assert tool_event.tool_input == {"command": "uv run pytest"}
+    assert tool_event.tool_output == "failed"
+    assert tool_event.tool_error == "1 test failed"
+
+
+def test_event_to_tool_event_supports_adapter_tool_result_output_alias() -> None:
+    event = {
+        "type": "tool.execute.after",
+        "tool": "ignored",
+        "args": {},
+        "result": None,
+        "error": None,
+        "timestamp": "2026-01-14T19:00:03Z",
+        "_adapter": {
+            "schema_version": "1.0",
+            "source": "opencode",
+            "session_id": "sess-1",
+            "event_id": "sess-1:tool_result:1",
+            "event_type": "tool_result",
+            "ts": "2026-01-14T19:00:03Z",
+            "payload": {
+                "tool_name": "bash",
+                "status": "ok",
+                "tool_input": {"command": "echo hi"},
+                "output": "redacted output",
+            },
+        },
+    }
+
+    tool_event = _event_to_tool_event(event, max_chars=5000)
+
+    assert tool_event is not None
+    assert tool_event.tool_name == "bash"
+    assert tool_event.tool_input == {"command": "echo hi"}
+    assert tool_event.tool_output == "redacted output"
+    assert tool_event.tool_error is None
+
+
+def test_event_to_tool_event_ignores_adapter_tool_call() -> None:
+    event = {
+        "type": "tool.execute.after",
+        "tool": "ignored",
+        "args": {},
+        "result": None,
+        "error": None,
+        "timestamp": "2026-01-14T19:00:03Z",
+        "_adapter": {
+            "schema_version": "1.0",
+            "source": "claude",
+            "session_id": "sess-1",
+            "event_id": "sess-1:tool_call:1",
+            "event_type": "tool_call",
+            "ts": "2026-01-14T19:00:03Z",
+            "payload": {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo pretool"},
+            },
+        },
+    }
+
+    tool_event = _event_to_tool_event(event, max_chars=5000)
+
+    assert tool_event is None
+
+
+def test_event_to_tool_event_falls_back_when_adapter_envelope_invalid() -> None:
+    event = {
+        "type": "tool.execute.after",
+        "tool": "bash",
+        "args": {"command": "uv run pytest -q"},
+        "result": "legacy ok",
+        "error": None,
+        "timestamp": "2026-01-14T19:00:03Z",
+        "_adapter": {
+            "schema_version": "1.0",
+            "source": "",
+            "session_id": "sess-1",
+            "event_id": "sess-1:tool_result:1",
+            "event_type": "tool_result",
+            "ts": "2026-01-14T19:00:03Z",
+            "payload": {
+                "tool_name": "read",
+                "status": "ok",
+                "tool_input": {"filePath": "/tmp/x"},
+                "tool_output": "adapter should be ignored",
+            },
+        },
+    }
+
+    tool_event = _event_to_tool_event(event, max_chars=5000)
+
+    assert tool_event is not None
+    assert tool_event.tool_name == "bash"
+    assert tool_event.tool_input == {"command": "uv run pytest -q"}
+    assert tool_event.tool_output == "legacy ok"
+
+
+def test_extract_tool_events_uses_adapter_projection_before_legacy() -> None:
+    events = [
+        {
+            "type": "tool.execute.after",
+            "tool": "ignored",
+            "args": {"filePath": "/tmp/ignored"},
+            "result": None,
+            "error": None,
+            "timestamp": "2026-01-14T19:00:03Z",
+            "_adapter": {
+                "schema_version": "1.0",
+                "source": "opencode",
+                "session_id": "sess-1",
+                "event_id": "sess-1:tool_result:1",
+                "event_type": "tool_result",
+                "ts": "2026-01-14T19:00:03Z",
+                "payload": {
+                    "tool_name": "bash",
+                    "status": "ok",
+                    "tool_input": {"command": "echo adapter"},
+                    "tool_output": "adapter output",
+                },
+            },
+        }
+    ]
+
+    tool_events = _extract_tool_events(events, max_chars=5000)
+
+    assert len(tool_events) == 1
+    assert tool_events[0].tool_name == "bash"
+    assert tool_events[0].tool_input == {"command": "echo adapter"}
+    assert tool_events[0].tool_output == "adapter output"
 
 
 def test_resolve_ingest_project_prefers_env_override() -> None:


### PR DESCRIPTION
## Description
Introduces adapter-envelope projection in ingest so v1 adapter events participate in prompt/tool extraction without breaking legacy OpenCode event handling. Also adds adapter schema/fixtures and regression coverage for adapter prompt/tool mapping edge cases.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run pytest tests/test_plugin_ingest.py`
- `uv run ruff check codemem/plugin_ingest.py tests/test_plugin_ingest.py`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
