### PR TITLE
feat(adapters): persist opencode and claude events through durable raw queue

### DIFF
--- a/.claude/plugin/codemem/.claude-plugin/plugin.json
+++ b/.claude/plugin/codemem/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "codemem",
+  "description": "codemem hook-first ingestion for Claude Code",
+  "version": "0.1.0",
+  "hooks": "./hooks/hooks.json"
+}

--- a/.claude/plugin/codemem/hooks/hooks.json
+++ b/.claude/plugin/codemem/hooks/hooks.json
@@ -1,0 +1,65 @@
+{
+  "description": "codemem hook-first Claude integration",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ingest-hook.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ingest-hook.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ingest-hook.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ingest-hook.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ingest-hook.sh"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ingest-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/plugin/codemem/scripts/ingest-hook.sh
+++ b/.claude/plugin/codemem/scripts/ingest-hook.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -u
+
+LOG_PATH_ENV="${CODEMEM_PLUGIN_LOG_PATH:-${CODEMEM_PLUGIN_LOG:-}}"
+case "${LOG_PATH_ENV}" in
+  ""|"0"|"false"|"off") LOG_PATH="$HOME/.codemem/plugin.log" ;;
+  "1"|"true"|"yes") LOG_PATH="$HOME/.codemem/plugin.log" ;;
+  *) LOG_PATH="${LOG_PATH_ENV}" ;;
+esac
+ALLOW_UVX="${CODEMEM_HOOK_ALLOW_UVX:-0}"
+
+log_line() {
+  mkdir -p "$(dirname "${LOG_PATH}")" >/dev/null 2>&1 || true
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >>"${LOG_PATH}" 2>/dev/null || true
+}
+
+payload="$(cat)"
+if [ -z "${payload}" ]; then
+  exit 0
+fi
+
+if command -v codemem >/dev/null 2>&1; then
+  (
+    if ! printf '%s' "${payload}" | codemem ingest-claude-hook >/dev/null 2>&1; then
+      log_line "codemem ingest-claude-hook failed via codemem binary"
+    fi
+  ) &
+  exit 0
+fi
+
+if [ "${ALLOW_UVX}" = "1" ] && command -v uvx >/dev/null 2>&1; then
+  (
+    if ! printf '%s' "${payload}" | uvx --from codemem codemem ingest-claude-hook >/dev/null 2>&1; then
+      log_line "codemem ingest-claude-hook failed via uvx"
+    fi
+  ) &
+  exit 0
+fi
+
+if [ "${ALLOW_UVX}" = "1" ]; then
+  log_line "codemem ingest-claude-hook skipped: codemem and uvx not found"
+else
+  log_line "codemem ingest-claude-hook skipped: codemem binary not found"
+fi
+
+exit 0

--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -1,5 +1,6 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
+import { createHash } from "node:crypto";
 import { tool } from "@opencode-ai/plugin";
 
 import {
@@ -111,6 +112,215 @@ const appendWorkingSetFileArgs = (args, workingSetFiles) => {
     args.push("--working-set-file", normalized.slice(0, 400));
   }
   return args;
+};
+
+const mapOpencodeEventTypeToAdapterType = (eventType) => {
+  if (eventType === "user_prompt") {
+    return "prompt";
+  }
+  if (eventType === "assistant_message") {
+    return "assistant";
+  }
+  if (eventType === "tool.execute.after") {
+    return "tool_result";
+  }
+  return null;
+};
+
+const buildOpencodeAdapterPayload = (event) => {
+  const eventType = event?.type;
+  if (eventType === "user_prompt") {
+    const text = String(event?.prompt_text || "").trim();
+    if (!text) {
+      return null;
+    }
+    return {
+      text,
+      prompt_number:
+        typeof event?.prompt_number === "number" ? event.prompt_number : null,
+    };
+  }
+
+  if (eventType === "assistant_message") {
+    const text = String(event?.assistant_text || "").trim();
+    if (!text) {
+      return null;
+    }
+    return { text };
+  }
+
+  if (eventType === "tool.execute.after") {
+    const toolName = String(event?.tool || "unknown");
+    return {
+      tool_name: toolName,
+      status: event?.error ? "error" : "ok",
+      tool_input: event?.args || {},
+      tool_output: event?.result ?? null,
+      error: event?.error ?? null,
+    };
+  }
+
+  return null;
+};
+
+const stableStringify = (value) => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const keys = Object.keys(value).sort();
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+    .join(",")}}`;
+};
+
+const stableDigest = (value) =>
+  createHash("sha256").update(stableStringify(value)).digest("hex").slice(0, 20);
+
+const sanitizeIdPart = (value, fallback, maxChars) => {
+  const normalized = String(value || "")
+    .replace(/[^A-Za-z0-9._:-]/g, "_")
+    .slice(0, maxChars);
+  return normalized || fallback;
+};
+
+const buildAdapterEventId = ({ sessionID, eventType, event, payload, ts }) => {
+  const safeSessionID = sanitizeIdPart(sessionID, "unknown", 48);
+  const safeType = sanitizeIdPart(eventType, "event", 24);
+  const rawTimestamp =
+    typeof event?.timestamp === "string" && event.timestamp.trim()
+      ? event.timestamp.trim()
+      : ts;
+  const digest = stableDigest({
+    session_id: String(sessionID || ""),
+    event_type: String(eventType || ""),
+    raw_event_type: String(event?.type || ""),
+    timestamp: rawTimestamp,
+    payload,
+  });
+  return `oc:${safeSessionID}:${safeType}:${digest}`.slice(0, 128);
+};
+
+const buildOpencodeAdapterEvent = ({ sessionID, event }) => {
+  if (!sessionID || !event || typeof event !== "object") {
+    return null;
+  }
+  const adapterType = mapOpencodeEventTypeToAdapterType(event.type);
+  if (!adapterType) {
+    return null;
+  }
+  const payload = buildOpencodeAdapterPayload(event);
+  if (!payload) {
+    return null;
+  }
+  const ts = typeof event.timestamp === "string" ? event.timestamp : new Date().toISOString();
+  return {
+    schema_version: "1.0",
+    source: "opencode",
+    session_id: String(sessionID),
+    event_id: buildAdapterEventId({
+      sessionID,
+      eventType: adapterType,
+      event,
+      payload,
+      ts,
+    }),
+    event_type: adapterType,
+    ts,
+    ordering_confidence: "low",
+    payload,
+    meta: {
+      original_event_type: String(event.type || "unknown"),
+    },
+  };
+};
+
+const resolveProjectName = (project) =>
+  project?.name ||
+  (project?.root
+    ? String(project.root).split(/[/\\]/).filter(Boolean).pop()
+    : null) ||
+  null;
+
+const selectRawEventId = ({ payload, nextEventId }) => {
+  const fromPayload =
+    payload &&
+    typeof payload === "object" &&
+    payload._raw_event_id;
+  return String(fromPayload || nextEventId());
+};
+
+const buildRawEventEnvelope = ({
+  sessionID,
+  type,
+  payload,
+  cwd,
+  project,
+  startedAt,
+  nowMs,
+  nowMono,
+  nextEventId,
+}) => ({
+  opencode_session_id: sessionID,
+  event_id: selectRawEventId({ payload, nextEventId }),
+  event_type: type,
+  ts_wall_ms: nowMs,
+  ts_mono_ms: nowMono,
+  payload,
+  cwd,
+  project,
+  started_at: startedAt,
+});
+
+const trimEventQueue = ({ events, maxEvents, hardMaxEvents, onUnsentPressure, onForcedDrop }) => {
+  if (!Number.isFinite(maxEvents) || maxEvents <= 0) {
+    return;
+  }
+  while (events.length > maxEvents) {
+    const droppableIndex = events.findIndex(
+      (queued) => queued && typeof queued === "object" && queued._raw_enqueued
+    );
+    if (droppableIndex >= 0) {
+      events.splice(droppableIndex, 1);
+      continue;
+    }
+    if (typeof onUnsentPressure === "function") {
+      onUnsentPressure(events.length, maxEvents);
+    }
+    if (
+      Number.isFinite(hardMaxEvents) &&
+      hardMaxEvents > 0 &&
+      events.length > hardMaxEvents
+    ) {
+      const dropped = events.shift();
+      if (typeof onForcedDrop === "function") {
+        onForcedDrop(dropped, events.length, hardMaxEvents);
+      }
+      continue;
+    }
+    break;
+  }
+};
+
+const attachAdapterEvent = ({ sessionID, event }) => {
+  if (!event || typeof event !== "object") {
+    return event;
+  }
+  let adapterEvent = null;
+  try {
+    adapterEvent = buildOpencodeAdapterEvent({ sessionID, event });
+  } catch (err) {
+    return event;
+  }
+  if (!adapterEvent) {
+    return event;
+  }
+  return {
+    ...event,
+    _adapter: adapterEvent,
+  };
 };
 
 const asNonNegativeCount = (value) => {
@@ -280,6 +490,7 @@ export const OpencodeMemPlugin = async ({
   const injectedSessions = new Map();
   const injectionToastShown = new Set();
   let sessionStartedAt = null;
+  let activeSessionID = null;
   let viewerStarted = false;
   let promptCounter = 0;
   let lastPromptText = null;
@@ -304,8 +515,13 @@ export const OpencodeMemPlugin = async ({
     process.env.CODEMEM_RAW_EVENTS_STATUS_CHECK_MS || "30000",
     30000
   );
+  const rawEventsHardMax = parseNumber(
+    process.env.CODEMEM_RAW_EVENTS_HARD_MAX || "2000",
+    2000
+  );
   let streamUnavailableUntil = 0;
   let streamErrorNoted = false;
+  let fallbackFailureNoted = false;
   let lastStatusCheckAt = 0;
   let lastStatusAvailable = true;
   const nextEventId = () => {
@@ -313,6 +529,18 @@ export const OpencodeMemPlugin = async ({
       return crypto.randomUUID();
     }
     return `${Date.now()}-${Math.random()}`;
+  };
+
+  const queueRawEventViaCli = async (body) => {
+    const result = await runCli(["enqueue-raw-event"], {
+      stdinText: JSON.stringify(body),
+    });
+    if (result?.exitCode !== 0) {
+      throw new Error(
+        `enqueue-raw-event failed (${result?.exitCode ?? "unknown"})`
+      );
+    }
+    return true;
   };
 
   const lastToastAtBySession = new Map();
@@ -327,12 +555,72 @@ export const OpencodeMemPlugin = async ({
   };
 
   const emitRawEvent = async ({ sessionID, type, payload }) => {
-    if (!rawEventsEnabled || !sessionID || !type) {
-      return;
+    if (!rawEventsEnabled) {
+      return true;
+    }
+    if (!sessionID || !type) {
+      return false;
     }
     const now = Date.now();
+    const body = buildRawEventEnvelope({
+      sessionID,
+      type,
+      payload,
+      cwd,
+      project: resolveProjectName(project),
+      startedAt: sessionStartedAt,
+      nowMs: now,
+      nowMono:
+        typeof performance !== "undefined" && performance.now
+          ? performance.now()
+          : null,
+      nextEventId,
+    });
+
     if (now < streamUnavailableUntil) {
-      return;
+      try {
+        await queueRawEventViaCli(body);
+        fallbackFailureNoted = false;
+        if (payload && typeof payload === "object") {
+          payload._raw_enqueued = true;
+        }
+        return true;
+      } catch (fallbackErr) {
+        await logLine(
+          `raw_events.fallback.error sessionID=${sessionID} type=${type} err=${String(
+            fallbackErr
+          ).slice(0, 200)}`
+        );
+        if (!fallbackFailureNoted) {
+          fallbackFailureNoted = true;
+          try {
+            await client.app.log({
+              service: "codemem",
+              level: "error",
+              message: "codemem fallback enqueue failed during stream backoff",
+              extra: {
+                sessionID,
+                backoffMs: rawEventsBackoffMs,
+              },
+            });
+          } catch (logErr) {
+            // best-effort logging only
+          }
+          if (client.tui?.showToast && shouldToast(sessionID)) {
+            try {
+              await client.tui.showToast({
+                body: {
+                  message: "codemem: fallback enqueue failed while stream is down",
+                  variant: "error",
+                },
+              });
+            } catch (toastErr) {
+              // best-effort only
+            }
+          }
+        }
+        return false;
+      }
     }
     try {
       if (now - lastStatusCheckAt >= Math.max(1000, rawEventsStatusCheckMs)) {
@@ -348,20 +636,6 @@ export const OpencodeMemPlugin = async ({
         throw new Error("raw-events ingest unavailable");
       }
 
-      const body = {
-        opencode_session_id: sessionID,
-        event_id: nextEventId(),
-        event_type: type,
-        ts_wall_ms: Date.now(),
-        ts_mono_ms:
-          typeof performance !== "undefined" && performance.now
-            ? performance.now()
-            : null,
-        payload,
-        cwd,
-        project: project?.name || (project?.root ? String(project.root).split(/[/\\]/).filter(Boolean).pop() : null) || null,
-        started_at: sessionStartedAt,
-      };
       const postResp = await fetch(rawEventsUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -372,48 +646,110 @@ export const OpencodeMemPlugin = async ({
       }
       streamUnavailableUntil = 0;
       streamErrorNoted = false;
+      fallbackFailureNoted = false;
       lastStatusAvailable = true;
+      if (payload && typeof payload === "object") {
+        payload._raw_enqueued = true;
+      }
+      return true;
     } catch (err) {
       streamUnavailableUntil = Date.now() + Math.max(1000, rawEventsBackoffMs);
       await logLine(`raw_events.error sessionID=${sessionID} type=${type} err=${String(err).slice(0, 200)}`);
-      await client.app.log({
-        service: "codemem",
-        level: "error",
-        message: "Failed to stream raw events to codemem viewer",
-        extra: {
-          sessionID,
-          type,
-          viewerHost,
-          viewerPort,
-          error: String(err),
-        },
-      });
-
-      if (!streamErrorNoted) {
-        streamErrorNoted = true;
+      try {
         await client.app.log({
           service: "codemem",
           level: "error",
-          message: "codemem stream unavailable; no fallback available",
+          message: "Failed to stream raw events to codemem viewer",
           extra: {
             sessionID,
-            backoffMs: rawEventsBackoffMs,
+            type,
+            viewerHost,
+            viewerPort,
+            error: String(err),
           },
         });
+      } catch (logErr) {
+        // best-effort logging only
+      }
+
+      let fallbackOk = false;
+      try {
+        await queueRawEventViaCli(body);
+        fallbackOk = true;
+      } catch (fallbackErr) {
+        await logLine(
+          `raw_events.fallback.error sessionID=${sessionID} type=${type} err=${String(
+            fallbackErr
+          ).slice(0, 200)}`
+        );
+      }
+
+      if (fallbackOk) {
+        fallbackFailureNoted = false;
+        if (payload && typeof payload === "object") {
+          payload._raw_enqueued = true;
+        }
+        if (!streamErrorNoted) {
+          streamErrorNoted = true;
+          try {
+            await client.app.log({
+              service: "codemem",
+              level: "warn",
+              message: "codemem stream unavailable; queued raw event via CLI fallback",
+              extra: {
+                sessionID,
+                backoffMs: rawEventsBackoffMs,
+              },
+            });
+          } catch (logErr) {
+            // best-effort logging only
+          }
+        }
+        if (client.tui?.showToast && shouldToast(sessionID)) {
+          try {
+            await client.tui.showToast({
+              body: {
+                message: "codemem: viewer stream unavailable; queue fallback active",
+                variant: "warning",
+              },
+            });
+          } catch (toastErr) {
+            // best-effort only
+          }
+        }
+        return true;
+      }
+
+      if (!streamErrorNoted) {
+        streamErrorNoted = true;
+        try {
+          await client.app.log({
+            service: "codemem",
+            level: "error",
+            message: "codemem stream unavailable; fallback enqueue failed",
+            extra: {
+              sessionID,
+              backoffMs: rawEventsBackoffMs,
+            },
+          });
+        } catch (logErr) {
+          // best-effort logging only
+        }
       }
 
       if (client.tui?.showToast && shouldToast(sessionID)) {
         try {
-          await client.tui.showToast({
-            body: {
-              message: `codemem: stream unavailable (${viewerHost}:${viewerPort}); no fallback`,
-              variant: "error",
-            },
-          });
+            await client.tui.showToast({
+              body: {
+                message: `codemem: stream unavailable (${viewerHost}:${viewerPort}); fallback failed`,
+                variant: "error",
+              },
+            });
         } catch (toastErr) {
           // best-effort only
         }
       }
+      return false;
     }
   };
 
@@ -641,14 +977,39 @@ export const OpencodeMemPlugin = async ({
     });
   };
 
-  const runCommand = async (cmd) => {
+  const runCommand = async (cmd, options = {}) => {
+    const { stdinText = null } = options;
     const proc = Bun.spawn({
       cmd,
       cwd,
       env: process.env,
+      stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",
     });
+    let stdinFailure = null;
+    if (typeof stdinText === "string") {
+      try {
+        proc.stdin.write(stdinText);
+      } catch (stdinErr) {
+        stdinFailure = `stdin write failed: ${String(stdinErr)}`;
+      }
+    }
+    try {
+      proc.stdin.end();
+    } catch (stdinErr) {
+      if (!stdinFailure) {
+        stdinFailure = `stdin close failed: ${String(stdinErr)}`;
+      }
+    }
+    if (stdinFailure) {
+      try {
+        proc.kill();
+      } catch (killErr) {
+        // ignore
+      }
+      return { exitCode: 1, stdout: "", stderr: stdinFailure };
+    }
     const resultPromise = Promise.all([
       proc.exited,
       new Response(proc.stdout).text(),
@@ -675,7 +1036,8 @@ export const OpencodeMemPlugin = async ({
     return result;
   };
 
-  const runCli = async (args) => runCommand([runner, ...runnerArgs, ...args]);
+  const runCli = async (args, options = {}) =>
+    runCommand([runner, ...runnerArgs, ...args], options);
 
   const showToast = async (message, variant = "warning") => {
     if (backendUpdatePolicy === "off") {
@@ -840,11 +1202,7 @@ export const OpencodeMemPlugin = async ({
     }
 
     // Project name for scoping
-    const projectName =
-      project?.name ||
-      (project?.root
-        ? String(project.root).split(/[/\\]/).filter(Boolean).pop()
-        : null);
+    const projectName = resolveProjectName(project);
     if (projectName) {
       parts.push(projectName);
     }
@@ -1010,18 +1368,54 @@ export const OpencodeMemPlugin = async ({
 
   const recordEvent = (event) => {
     events.push(event);
-    if (
-      Number.isFinite(maxEvents) &&
-      maxEvents > 0 &&
-      events.length > maxEvents
-    ) {
-      events.splice(0, events.length - maxEvents);
-    }
+    trimEventQueue({
+      events,
+      maxEvents,
+      hardMaxEvents: Math.max(maxEvents, rawEventsHardMax),
+      onUnsentPressure: (queuedCount, cap) => {
+        void logLine(`queue.pressure unsent_preserved queued=${queuedCount} max_events=${cap}`);
+      },
+      onForcedDrop: (dropped, queuedCount, hardCap) => {
+        void logLine(
+          `queue.drop hard_cap event_id=${dropped?._raw_event_id || "unknown"} queued=${queuedCount} hard_max=${hardCap}`
+        );
+      },
+    });
   };
 
   const captureEvent = (sessionID, event) => {
-    recordEvent(event);
-    void emitRawEvent({ sessionID, type: event?.type || "unknown", payload: event });
+    const normalizedSessionID =
+      typeof sessionID === "string" && sessionID.trim() ? sessionID.trim() : null;
+    if (normalizedSessionID) {
+      activeSessionID = normalizedSessionID;
+    }
+    const effectiveSessionID = normalizedSessionID || activeSessionID;
+    const resolvedSessionID =
+      effectiveSessionID || `missing:${Date.now()}:${String(nextEventId()).slice(0, 8)}`;
+    if (!effectiveSessionID) {
+      activeSessionID = resolvedSessionID;
+      void logLine(`capture.fallback_session_id ${resolvedSessionID}`);
+    }
+    const adapterAnnotatedEvent = attachAdapterEvent({
+      sessionID: resolvedSessionID,
+      event,
+    });
+    const rawEventId =
+      adapterAnnotatedEvent?._adapter?.event_id ||
+      (adapterAnnotatedEvent && adapterAnnotatedEvent._raw_event_id) ||
+      nextEventId();
+    const queuedEvent = {
+      ...adapterAnnotatedEvent,
+      _raw_event_id: rawEventId,
+      _raw_session_id: resolvedSessionID,
+      _raw_retry_count: 0,
+    };
+    recordEvent(queuedEvent);
+    void emitRawEvent({
+      sessionID: resolvedSessionID,
+      type: queuedEvent?.type || "unknown",
+      payload: queuedEvent,
+    });
   };
 
   const flushEvents = async () => {
@@ -1030,15 +1424,52 @@ export const OpencodeMemPlugin = async ({
       return;
     }
 
+    const batch = events.splice(0, events.length);
+    if (!batch.length) {
+      await logLine("flush.skip empty");
+      return;
+    }
+
+    const failed = [];
+    for (const queuedEvent of batch) {
+      if (queuedEvent && typeof queuedEvent === "object" && queuedEvent._raw_enqueued) {
+        continue;
+      }
+      const queuedSessionID =
+        queuedEvent?._raw_session_id ||
+        queuedEvent?.properties?.sessionID ||
+        null;
+      const ok = await emitRawEvent({
+        sessionID: queuedSessionID,
+        type: queuedEvent?.type || "unknown",
+        payload: queuedEvent,
+      });
+      if (!ok) {
+        const currentRetry =
+          typeof queuedEvent?._raw_retry_count === "number" && Number.isFinite(queuedEvent._raw_retry_count)
+            ? queuedEvent._raw_retry_count
+            : 0;
+        const nextRetry = currentRetry + 1;
+        failed.push({
+          ...queuedEvent,
+          _raw_retry_count: nextRetry,
+        });
+      }
+    }
+    if (failed.length) {
+      events.unshift(...failed);
+      await logLine(`flush.retry_deferred count=${failed.length}`);
+      return;
+    }
+
     // Calculate session duration
     const durationMs = sessionContext.startTime
       ? Date.now() - sessionContext.startTime
       : 0;
     await logLine(
-      `flush.stream_only finalize count=${events.length} tools=${sessionContext.toolCount} prompts=${sessionContext.promptCount} duration=${Math.round(durationMs / 1000)}s`
+      `flush.stream_only finalize count=${batch.length} tools=${sessionContext.toolCount} prompts=${sessionContext.promptCount} duration=${Math.round(durationMs / 1000)}s`
     );
-    await logLine(`flush.ok count=${events.length}`);
-    events.length = 0;
+    await logLine(`flush.ok count=${batch.length}`);
     sessionStartedAt = null;
     resetSessionContext();
   };
@@ -1260,6 +1691,7 @@ export const OpencodeMemPlugin = async ({
         if (events.length) {
           await flushEvents();
         }
+        activeSessionID = sessionID || null;
         sessionStartedAt = new Date().toISOString();
         promptCounter = 0;
         lastPromptText = null;
@@ -1268,6 +1700,7 @@ export const OpencodeMemPlugin = async ({
         startViewer();
       }
       if (eventType === "session.deleted") {
+        activeSessionID = null;
         await stopViewer();
       }
     },
@@ -1366,4 +1799,14 @@ export const OpencodeMemPlugin = async ({
 };
 
 export default OpencodeMemPlugin;
-export const __testUtils = { appendWorkingSetFileArgs, extractApplyPatchPaths };
+export const __testUtils = {
+  appendWorkingSetFileArgs,
+  extractApplyPatchPaths,
+  mapOpencodeEventTypeToAdapterType,
+  buildOpencodeAdapterPayload,
+  buildOpencodeAdapterEvent,
+  attachAdapterEvent,
+  selectRawEventId,
+  buildRawEventEnvelope,
+  trimEventQueue,
+};

--- a/.opencode/tests/plugin-adapter.test.js
+++ b/.opencode/tests/plugin-adapter.test.js
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+
+import { __testUtils } from "../plugin/codemem.js";
+
+describe("opencode adapter event mapping", () => {
+  test("maps user_prompt to prompt adapter envelope", () => {
+    const event = {
+      type: "user_prompt",
+      prompt_text: "Summarize the latest changes",
+      prompt_number: 2,
+      timestamp: "2026-03-02T20:00:00Z",
+    };
+
+    const mapped = __testUtils.buildOpencodeAdapterEvent({
+      sessionID: "sess-1",
+      event,
+    });
+
+    expect(mapped).not.toBeNull();
+    expect(mapped?.source).toBe("opencode");
+    expect(mapped?.event_type).toBe("prompt");
+    expect(mapped?.payload).toEqual({
+      text: "Summarize the latest changes",
+      prompt_number: 2,
+    });
+  });
+
+  test("maps tool.execute.after to tool_result with error status", () => {
+    const event = {
+      type: "tool.execute.after",
+      tool: "bash",
+      args: { command: "uv run pytest" },
+      result: "failed",
+      error: "1 test failed",
+      timestamp: "2026-03-02T20:00:01Z",
+    };
+
+    const mapped = __testUtils.buildOpencodeAdapterEvent({
+      sessionID: "sess-2",
+      event,
+    });
+
+    expect(mapped).not.toBeNull();
+    expect(mapped?.event_type).toBe("tool_result");
+    expect(mapped?.payload?.tool_name).toBe("bash");
+    expect(mapped?.payload?.status).toBe("error");
+  });
+
+  test("attachAdapterEvent keeps unknown event unchanged", () => {
+    const unknown = { type: "assistant_usage", usage: { input_tokens: 12 } };
+    const attached = __testUtils.attachAdapterEvent({
+      sessionID: "sess-3",
+      event: unknown,
+    });
+
+    expect(attached).toEqual(unknown);
+    expect(attached).not.toHaveProperty("_adapter");
+  });
+
+  test("attachAdapterEvent annotates mapped events", () => {
+    const event = {
+      type: "assistant_message",
+      assistant_text: "Done.",
+      timestamp: "2026-03-02T20:00:02Z",
+    };
+
+    const attached = __testUtils.attachAdapterEvent({
+      sessionID: "sess-4",
+      event,
+    });
+
+    expect(attached).toHaveProperty("_adapter");
+    expect(attached._adapter.event_type).toBe("assistant");
+    expect(attached._adapter.payload.text).toBe("Done.");
+  });
+
+  test("builds deterministic adapter event ids with explicit timestamp", () => {
+    const event = {
+      type: "assistant_message",
+      assistant_text: "Deterministic",
+      timestamp: "2026-03-02T20:00:05Z",
+    };
+
+    const first = __testUtils.buildOpencodeAdapterEvent({
+      sessionID: "sess-det",
+      event,
+    });
+    const second = __testUtils.buildOpencodeAdapterEvent({
+      sessionID: "sess-det",
+      event,
+    });
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first?.event_id).toBe(second?.event_id);
+  });
+
+  test("keeps adapter event ids within schema length", () => {
+    const longSession = "sess-" + "x".repeat(500);
+    const event = {
+      type: "user_prompt",
+      prompt_text: "Validate id length",
+      timestamp: "2026-03-02T20:00:00Z",
+    };
+    const mapped = __testUtils.buildOpencodeAdapterEvent({
+      sessionID: longSession,
+      event,
+    });
+
+    expect(mapped).not.toBeNull();
+    expect(mapped?.event_id.length).toBeLessThanOrEqual(128);
+  });
+
+  test("selectRawEventId prefers existing payload id", () => {
+    const selected = __testUtils.selectRawEventId({
+      payload: { _raw_event_id: "stable-id-1" },
+      nextEventId: () => "generated-id",
+    });
+
+    expect(selected).toBe("stable-id-1");
+  });
+
+  test("buildRawEventEnvelope uses generated id when raw id is absent", () => {
+    const envelope = __testUtils.buildRawEventEnvelope({
+      sessionID: "sess-5",
+      type: "assistant_message",
+      payload: {
+        _adapter: { event_id: "adapter-stable-id" },
+      },
+      cwd: "/tmp/worktree",
+      project: "codemem",
+      startedAt: "2026-03-02T20:00:00Z",
+      nowMs: 12345,
+      nowMono: 678.9,
+      nextEventId: () => "generated-id",
+    });
+
+    expect(envelope.event_id).toBe("generated-id");
+    expect(envelope.opencode_session_id).toBe("sess-5");
+    expect(envelope.event_type).toBe("assistant_message");
+  });
+
+  test("buildRawEventEnvelope reuses payload _raw_event_id when present", () => {
+    const envelope = __testUtils.buildRawEventEnvelope({
+      sessionID: "sess-5",
+      type: "assistant_message",
+      payload: { _raw_event_id: "stable-raw-id" },
+      cwd: "/tmp/worktree",
+      project: "codemem",
+      startedAt: "2026-03-02T20:00:00Z",
+      nowMs: 12345,
+      nowMono: 678.9,
+      nextEventId: () => "generated-id",
+    });
+
+    expect(envelope.event_id).toBe("stable-raw-id");
+  });
+
+  test("trimEventQueue drops enqueued events first", () => {
+    const events = [
+      { _raw_event_id: "a", _raw_enqueued: false },
+      { _raw_event_id: "b", _raw_enqueued: true },
+    ];
+
+    __testUtils.trimEventQueue({
+      events,
+      maxEvents: 1,
+    });
+
+    expect(events.length).toBe(1);
+    expect(events[0]._raw_event_id).toBe("a");
+  });
+
+  test("trimEventQueue preserves unsent events under pressure", () => {
+    const events = [
+      { _raw_event_id: "a", _raw_enqueued: false },
+      { _raw_event_id: "b", _raw_enqueued: false },
+    ];
+    let pressured = false;
+
+    __testUtils.trimEventQueue({
+      events,
+      maxEvents: 1,
+      onUnsentPressure: () => {
+        pressured = true;
+      },
+    });
+
+    expect(events.length).toBe(2);
+    expect(pressured).toBe(true);
+  });
+
+  test("trimEventQueue enforces hard cap for unsent pressure", () => {
+    const events = [
+      { _raw_event_id: "a", _raw_enqueued: false },
+      { _raw_event_id: "b", _raw_enqueued: false },
+      { _raw_event_id: "c", _raw_enqueued: false },
+    ];
+    let dropped = null;
+
+    __testUtils.trimEventQueue({
+      events,
+      maxEvents: 1,
+      hardMaxEvents: 2,
+      onForcedDrop: (event) => {
+        dropped = event?._raw_event_id || null;
+      },
+    });
+
+    expect(events.length).toBe(2);
+    expect(dropped).toBe("a");
+  });
+});

--- a/codemem/claude_hooks.py
+++ b/codemem/claude_hooks.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+MAPPABLE_CLAUDE_HOOK_EVENTS = {
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "Stop",
+    "SessionEnd",
+}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_iso_ts(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.isoformat().replace("+00:00", "Z")
+
+
+def _stable_event_id(*parts: str) -> str:
+    joined = "|".join(parts)
+    digest = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:24]
+    return f"cld_evt_{digest}"
+
+
+def _extract_meta(payload: dict[str, Any], consumed_keys: set[str]) -> dict[str, Any]:
+    unknown = {k: v for k, v in payload.items() if k not in consumed_keys}
+    return unknown
+
+
+def _coerce_session_id(payload: dict[str, Any]) -> str | None:
+    raw = payload.get("session_id")
+    if not isinstance(raw, str):
+        return None
+    value = raw.strip()
+    return value or None
+
+
+def map_claude_hook_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    hook_event = str(payload.get("hook_event_name") or "").strip()
+    if hook_event not in MAPPABLE_CLAUDE_HOOK_EVENTS:
+        return None
+
+    session_id = _coerce_session_id(payload)
+    if not session_id:
+        return None
+
+    raw_ts = payload.get("ts") or payload.get("timestamp")
+    normalized_raw_ts = _normalize_iso_ts(raw_ts)
+    ts = normalized_raw_ts or _now_iso()
+    tool_use_id = str(payload.get("tool_use_id") or "").strip()
+    event_type: str
+    event_payload: dict[str, Any]
+    consumed: set[str] = {
+        "hook_event_name",
+        "session_id",
+        "cwd",
+        "ts",
+        "timestamp",
+        "transcript_path",
+        "permission_mode",
+        "tool_use_id",
+    }
+
+    if hook_event == "SessionStart":
+        event_type = "session_start"
+        event_payload = {"source": payload.get("source")}
+        consumed.add("source")
+    elif hook_event == "UserPromptSubmit":
+        text = str(payload.get("prompt") or "").strip()
+        if not text:
+            return None
+        event_type = "prompt"
+        event_payload = {"text": text}
+        consumed.add("prompt")
+    elif hook_event == "PreToolUse":
+        tool_name = str(payload.get("tool_name") or "").strip()
+        if not tool_name:
+            return None
+        tool_input = payload.get("tool_input")
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        event_type = "tool_call"
+        event_payload = {
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+        }
+        consumed.update({"tool_name", "tool_input"})
+    elif hook_event == "PostToolUse":
+        tool_name = str(payload.get("tool_name") or "").strip()
+        if not tool_name:
+            return None
+        tool_input = payload.get("tool_input")
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        tool_response = payload.get("tool_response")
+        event_type = "tool_result"
+        event_payload = {
+            "tool_name": tool_name,
+            "status": "ok",
+            "tool_input": tool_input,
+            "tool_output": tool_response,
+            "tool_error": None,
+        }
+        consumed.update({"tool_name", "tool_input", "tool_response"})
+    elif hook_event == "PostToolUseFailure":
+        tool_name = str(payload.get("tool_name") or "").strip()
+        if not tool_name:
+            return None
+        tool_input = payload.get("tool_input")
+        if not isinstance(tool_input, dict):
+            tool_input = {}
+        error = payload.get("error")
+        event_type = "tool_result"
+        event_payload = {
+            "tool_name": tool_name,
+            "status": "error",
+            "tool_input": tool_input,
+            "tool_output": None,
+            "error": error,
+        }
+        consumed.update({"tool_name", "tool_input", "error", "is_interrupt"})
+    elif hook_event == "Stop":
+        assistant_text = str(payload.get("last_assistant_message") or "").strip()
+        if not assistant_text:
+            return None
+        event_type = "assistant"
+        event_payload = {"text": assistant_text}
+        consumed.update({"stop_hook_active", "last_assistant_message"})
+    else:
+        event_type = "session_end"
+        event_payload = {"reason": payload.get("reason")}
+        consumed.add("reason")
+
+    meta: dict[str, Any] = {
+        "hook_event_name": hook_event,
+        "ordering_confidence": "low",
+    }
+    if tool_use_id:
+        meta["tool_use_id"] = tool_use_id
+    if normalized_raw_ts is None:
+        meta["ts_normalized"] = "generated"
+
+    unknown = _extract_meta(payload, consumed)
+    if unknown:
+        meta["hook_fields"] = unknown
+
+    event_id = _stable_event_id(
+        session_id,
+        hook_event,
+        str(normalized_raw_ts or ""),
+        tool_use_id,
+        hashlib.sha256(
+            json.dumps(event_payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest(),
+    )
+
+    return {
+        "schema_version": "1.0",
+        "source": "claude",
+        "session_id": session_id,
+        "event_id": event_id,
+        "event_type": event_type,
+        "ts": ts,
+        "ordering_confidence": "low",
+        "cwd": payload.get("cwd"),
+        "payload": event_payload,
+        "meta": meta,
+    }
+
+
+def build_ingest_payload_from_hook(hook_payload: dict[str, Any]) -> dict[str, Any] | None:
+    adapter_event = map_claude_hook_payload(hook_payload)
+    if adapter_event is None:
+        return None
+
+    session_id = str(adapter_event["session_id"])
+    return {
+        "cwd": hook_payload.get("cwd"),
+        "events": [
+            {
+                "type": "claude.hook",
+                "timestamp": adapter_event["ts"],
+                "_adapter": adapter_event,
+            }
+        ],
+        "session_context": {
+            "opencode_session_id": f"claude:{session_id}",
+        },
+    }

--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -10,6 +10,10 @@ import typer
 from rich import print
 
 from . import __version__, db
+from .commands.claude_integration_cmds import (
+    ingest_claude_hook_cmd,
+    install_claude_integration_cmd,
+)
 from .commands.common import (
     compact_lines,
     compact_list,
@@ -51,6 +55,7 @@ from .commands.memory_cmds import (
 )
 from .commands.opencode_integration_cmds import install_mcp_cmd, install_plugin_cmd
 from .commands.raw_events_cmds import (
+    enqueue_raw_event_cmd,
     flush_raw_events_cmd,
     raw_events_gate_cmd,
     raw_events_retry_cmd,
@@ -551,6 +556,19 @@ def flush_raw_events(
         store.close()
 
 
+@app.command("enqueue-raw-event")
+def enqueue_raw_event(
+    db_path: str = typer.Option(None, help="Path to SQLite database"),
+) -> None:
+    """Enqueue one raw event from stdin into the durable queue."""
+
+    store = _store(db_path)
+    try:
+        enqueue_raw_event_cmd(store)
+    finally:
+        store.close()
+
+
 @app.command("raw-events-status")
 def raw_events_status(
     db_path: str = typer.Option(None, help="Path to SQLite database"),
@@ -688,6 +706,13 @@ def mcp() -> None:
 def ingest() -> None:
     """Ingest plugin events from stdin."""
     ingest_cmd()
+
+
+@app.command("ingest-claude-hook")
+def ingest_claude_hook() -> None:
+    """Ingest one Claude hook payload from stdin."""
+
+    ingest_claude_hook_cmd()
 
 
 @app.command()
@@ -1174,6 +1199,17 @@ def install_mcp(
 ) -> None:
     """Install the codemem MCP entry into OpenCode's config."""
     install_mcp_cmd(force=force)
+
+
+@app.command("install-claude-integration")
+def install_claude_integration(
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Overwrite existing Claude plugin files"
+    ),
+) -> None:
+    """Install codemem Claude plugin + hook scaffolding in the current project."""
+
+    install_claude_integration_cmd(force=force)
 
 
 def main() -> None:

--- a/codemem/commands/claude_integration_cmds.py
+++ b/codemem/commands/claude_integration_cmds.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich import print
+
+from codemem.claude_hooks import MAPPABLE_CLAUDE_HOOK_EVENTS, map_claude_hook_payload
+from codemem.db import DEFAULT_DB_PATH
+from codemem.raw_event_flush import flush_raw_events
+from codemem.store import MemoryStore
+
+ALLOWED_HOOK_EVENTS = frozenset(
+    hook_event for hook_event in MAPPABLE_CLAUDE_HOOK_EVENTS if hook_event != "PreToolUse"
+)
+
+
+def _env_truthy(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _adapter_stream_id(*, source: str, session_id: str, cwd: str | None) -> str:
+    _ = cwd
+    return f"{source}:{session_id}"
+
+
+def _iso_to_wall_ms(ts: str | None) -> int:
+    if isinstance(ts, str) and ts.strip():
+        try:
+            parsed = dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=dt.UTC)
+            return int(parsed.timestamp() * 1000)
+        except ValueError:
+            pass
+    return int(dt.datetime.now(dt.UTC).timestamp() * 1000)
+
+
+def _queue_adapter_event(hook_payload: dict[str, Any], *, store: Any) -> tuple[str, bool] | None:
+    adapter_event = map_claude_hook_payload(hook_payload)
+    if adapter_event is None:
+        return None
+    source = str(adapter_event.get("source") or "claude")
+    session_id = str(adapter_event.get("session_id") or "").strip()
+    if not session_id:
+        return None
+    stream_id = _adapter_stream_id(
+        source=source,
+        session_id=session_id,
+        cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
+    )
+    ts = str(adapter_event.get("ts") or "")
+    payload = {
+        "type": "claude.hook",
+        "timestamp": ts,
+        "_adapter": adapter_event,
+    }
+    inserted = store.record_raw_event(
+        opencode_session_id=stream_id,
+        event_id=str(adapter_event.get("event_id") or ""),
+        event_type="claude.hook",
+        payload=payload,
+        ts_wall_ms=_iso_to_wall_ms(ts),
+    )
+    store.update_raw_event_session_meta(
+        opencode_session_id=stream_id,
+        cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
+        project=hook_payload.get("project")
+        if isinstance(hook_payload.get("project"), str)
+        else None,
+        started_at=ts if str(hook_payload.get("hook_event_name") or "") == "SessionStart" else None,
+        last_seen_ts_wall_ms=_iso_to_wall_ms(ts),
+    )
+    return stream_id, inserted
+
+
+def _should_flush(hook_event_name: str) -> bool:
+    if hook_event_name not in {"Stop", "SessionEnd"}:
+        return False
+    return _env_truthy("CODEMEM_CLAUDE_HOOK_FLUSH", True)
+
+
+def _strip_json_comments(text: str) -> str:
+    lines: list[str] = []
+    for line in text.splitlines():
+        result: list[str] = []
+        in_string = False
+        escape_next = False
+        i = 0
+        while i < len(line):
+            char = line[i]
+            if escape_next:
+                result.append(char)
+                escape_next = False
+                i += 1
+                continue
+            if char == "\\" and in_string:
+                result.append(char)
+                escape_next = True
+                i += 1
+                continue
+            if char == '"':
+                in_string = not in_string
+                result.append(char)
+                i += 1
+                continue
+            if not in_string and char == "/" and i + 1 < len(line) and line[i + 1] == "/":
+                break
+            result.append(char)
+            i += 1
+        lines.append("".join(result))
+    return "\n".join(lines)
+
+
+def _load_json_or_empty(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    raw = path.read_text()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        parsed = json.loads(_strip_json_comments(raw))
+    if isinstance(parsed, dict):
+        return parsed
+    raise ValueError("settings file root must be a JSON object")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        backup = path.with_suffix(path.suffix + ".bak")
+        backup.write_text(path.read_text())
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+
+
+def _resolve_claude_plugin_source() -> Path:
+    cli_dir = Path(__file__).resolve().parents[1]
+    packaged = cli_dir / ".claude" / "plugin" / "codemem"
+    if packaged.exists():
+        return packaged
+
+    repo_copy = cli_dir.parent / ".claude" / "plugin" / "codemem"
+    if repo_copy.exists():
+        return repo_copy
+
+    raise FileNotFoundError("Claude plugin template not found in package or repository")
+
+
+def _merge_enabled_plugins(settings: dict[str, Any], plugin_ref: str) -> dict[str, Any]:
+    merged = dict(settings)
+    raw_enabled = merged.get("enabledPlugins")
+    enabled: list[str] = []
+    if isinstance(raw_enabled, list):
+        enabled = [str(item) for item in raw_enabled if isinstance(item, str)]
+    if plugin_ref not in enabled:
+        enabled.append(plugin_ref)
+    merged["enabledPlugins"] = enabled
+    return merged
+
+
+def _build_install_report(
+    *, plugin_dir: Path, settings_path: Path, plugin_ref: str
+) -> dict[str, str]:
+    return {
+        "plugin_dir": str(plugin_dir),
+        "settings_path": str(settings_path),
+        "enabled_plugin": plugin_ref,
+        "hook_entrypoint": "codemem ingest-claude-hook",
+    }
+
+
+def install_claude_integration_cmd(*, force: bool, cwd: Path | None = None) -> dict[str, str]:
+    root = cwd or Path.cwd()
+    plugin_source = _resolve_claude_plugin_source()
+    plugin_dir = root / ".claude" / "plugins" / "codemem"
+    plugin_ref = "./plugins/codemem"
+    settings_path = root / ".claude" / "settings.json"
+
+    if plugin_dir.exists() and not force:
+        print(f"[yellow]Claude plugin already exists at {plugin_dir}[/yellow]")
+        print("[dim]Use --force to overwrite plugin template files[/dim]")
+    else:
+        shutil.copytree(plugin_source, plugin_dir, dirs_exist_ok=True)
+        script_path = plugin_dir / "scripts" / "ingest-hook.sh"
+        if script_path.exists():
+            script_path.chmod(script_path.stat().st_mode | 0o111)
+
+    try:
+        settings = _load_json_or_empty(settings_path)
+    except Exception as exc:
+        print(f"[red]Error: Failed to parse {settings_path}: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    settings = _merge_enabled_plugins(settings, plugin_ref)
+    try:
+        _write_json(settings_path, settings)
+    except Exception as exc:
+        print(f"[red]Error: Failed to write {settings_path}: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    report = _build_install_report(
+        plugin_dir=plugin_dir,
+        settings_path=settings_path,
+        plugin_ref=plugin_ref,
+    )
+    print(f"[green]✓ Claude integration installed in {root / '.claude'}[/green]")
+    print(json.dumps(report, indent=2))
+    return report
+
+
+def ingest_claude_hook_cmd() -> None:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return
+    try:
+        hook_payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return
+    if not isinstance(hook_payload, dict):
+        return
+    hook_event_name = str(hook_payload.get("hook_event_name") or "").strip()
+    if hook_event_name not in ALLOWED_HOOK_EVENTS:
+        return
+    db_path = os.environ.get("CODEMEM_DB") or DEFAULT_DB_PATH
+    store = MemoryStore(db_path)
+    try:
+        queued = _queue_adapter_event(hook_payload, store=store)
+        if queued is None:
+            return
+        stream_id, _ = queued
+        if not _should_flush(hook_event_name):
+            return
+        flush_raw_events(
+            store,
+            opencode_session_id=stream_id,
+            cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
+            project=hook_payload.get("project")
+            if isinstance(hook_payload.get("project"), str)
+            else None,
+            started_at=None,
+            max_events=None,
+        )
+    finally:
+        store.close()

--- a/codemem/commands/raw_events_cmds.py
+++ b/codemem/commands/raw_events_cmds.py
@@ -1,9 +1,117 @@
 from __future__ import annotations
 
+import json
+import sys
+from typing import Any
+
 import typer
 from rich import print
 
 from codemem.store import MemoryStore
+
+
+def _coerce_optional_str(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be string")
+    text = value.strip()
+    return text or None
+
+
+def _require_non_empty_str(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be string")
+    text = value.strip()
+    if not text:
+        raise ValueError(f"{key} required")
+    return text
+
+
+def _coerce_optional_int(payload: dict[str, Any], key: str) -> int | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key} must be int")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{key} must be int") from exc
+
+
+def _coerce_optional_float(payload: dict[str, Any], key: str) -> float | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (float, int)):
+        raise ValueError(f"{key} must be number")
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{key} must be number") from exc
+
+
+def enqueue_raw_event_cmd(store: MemoryStore) -> None:
+    """Read one raw event from stdin and enqueue it."""
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        raise typer.BadParameter("stdin payload required")
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter("stdin must be valid JSON object") from exc
+    if not isinstance(payload, dict):
+        raise typer.BadParameter("payload must be an object")
+
+    try:
+        opencode_session_id = _require_non_empty_str(payload, "opencode_session_id")
+        event_type = _require_non_empty_str(payload, "event_type")
+        event_payload = payload.get("payload")
+        if event_payload is None:
+            event_payload = {}
+        if not isinstance(event_payload, dict):
+            raise ValueError("payload must be an object")
+
+        event_id_value = payload.get("event_id")
+        if event_id_value is None:
+            event_id_value = event_payload.get("_raw_event_id")
+        if event_id_value is None:
+            raise ValueError("event_id required")
+        if not isinstance(event_id_value, str):
+            raise ValueError("event_id must be string")
+        event_id = event_id_value.strip()
+        if not event_id:
+            raise ValueError("event_id required")
+
+        ts_wall_ms = _coerce_optional_int(payload, "ts_wall_ms")
+        ts_mono_ms = _coerce_optional_float(payload, "ts_mono_ms")
+        cwd = _coerce_optional_str(payload, "cwd")
+        project = _coerce_optional_str(payload, "project")
+        started_at = _coerce_optional_str(payload, "started_at")
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    inserted = store.record_raw_event(
+        opencode_session_id=opencode_session_id,
+        event_id=event_id,
+        event_type=event_type,
+        payload=event_payload,
+        ts_wall_ms=ts_wall_ms,
+        ts_mono_ms=ts_mono_ms,
+    )
+    store.update_raw_event_session_meta(
+        opencode_session_id=opencode_session_id,
+        cwd=cwd,
+        project=project,
+        started_at=started_at,
+        last_seen_ts_wall_ms=ts_wall_ms,
+    )
+    print(json.dumps({"inserted": int(inserted)}))
 
 
 def flush_raw_events_cmd(

--- a/codemem/store/raw_events.py
+++ b/codemem/store/raw_events.py
@@ -558,7 +558,12 @@ def update_raw_event_session_meta(
             cwd = COALESCE(excluded.cwd, raw_event_sessions.cwd),
             project = COALESCE(excluded.project, raw_event_sessions.project),
             started_at = COALESCE(excluded.started_at, raw_event_sessions.started_at),
-            last_seen_ts_wall_ms = COALESCE(excluded.last_seen_ts_wall_ms, raw_event_sessions.last_seen_ts_wall_ms),
+            last_seen_ts_wall_ms = CASE
+                WHEN excluded.last_seen_ts_wall_ms IS NULL THEN raw_event_sessions.last_seen_ts_wall_ms
+                WHEN raw_event_sessions.last_seen_ts_wall_ms IS NULL THEN excluded.last_seen_ts_wall_ms
+                WHEN excluded.last_seen_ts_wall_ms > raw_event_sessions.last_seen_ts_wall_ms THEN excluded.last_seen_ts_wall_ms
+                ELSE raw_event_sessions.last_seen_ts_wall_ms
+            END,
             updated_at = excluded.updated_at
         """,
         (opencode_session_id, cwd, project, started_at, last_seen_ts_wall_ms, now),

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from codemem.claude_hooks import build_ingest_payload_from_hook, map_claude_hook_payload
+
+
+def test_map_user_prompt_submit_to_prompt_event() -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "sess-123",
+        "prompt": "Run tests",
+        "cwd": "/tmp/repo",
+        "custom_field": "keep-me",
+    }
+
+    event = map_claude_hook_payload(payload)
+
+    assert event is not None
+    assert event["source"] == "claude"
+    assert event["event_type"] == "prompt"
+    assert event["payload"]["text"] == "Run tests"
+    assert event["meta"]["hook_event_name"] == "UserPromptSubmit"
+    assert event["meta"]["hook_fields"]["custom_field"] == "keep-me"
+
+
+def test_map_pre_tool_use_to_tool_call_event() -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "session_id": "sess-abc",
+        "tool_use_id": "toolu_1",
+        "tool_name": "Bash",
+        "tool_input": {"command": "uv run pytest"},
+    }
+
+    event = map_claude_hook_payload(payload)
+
+    assert event is not None
+    assert event["event_type"] == "tool_call"
+    assert event["payload"]["tool_name"] == "Bash"
+    assert event["payload"]["tool_input"] == {"command": "uv run pytest"}
+    assert event["meta"]["tool_use_id"] == "toolu_1"
+
+
+def test_map_post_tool_use_failure_to_tool_result_error() -> None:
+    payload = {
+        "hook_event_name": "PostToolUseFailure",
+        "session_id": "sess-abc",
+        "tool_name": "Bash",
+        "tool_input": {"command": "uv run pytest"},
+        "error": {"message": "1 failed"},
+    }
+
+    event = map_claude_hook_payload(payload)
+
+    assert event is not None
+    assert event["event_type"] == "tool_result"
+    assert event["payload"]["status"] == "error"
+    assert event["payload"]["error"] == {"message": "1 failed"}
+
+
+def test_build_ingest_payload_wraps_adapter_event() -> None:
+    payload = {
+        "hook_event_name": "SessionStart",
+        "session_id": "sess-xyz",
+        "source": "startup",
+        "cwd": "/tmp/repo",
+    }
+
+    ingest_payload = build_ingest_payload_from_hook(payload)
+
+    assert ingest_payload is not None
+    assert ingest_payload["session_context"]["opencode_session_id"] == "claude:sess-xyz"
+    event = ingest_payload["events"][0]
+    assert event["_adapter"]["event_type"] == "session_start"
+
+
+def test_map_post_tool_use_to_tool_result_ok() -> None:
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "session_id": "sess-abc",
+        "tool_name": "Bash",
+        "tool_input": {"command": "uv run pytest"},
+        "tool_response": {"exit_code": 0},
+    }
+
+    event = map_claude_hook_payload(payload)
+
+    assert event is not None
+    assert event["event_type"] == "tool_result"
+    assert event["payload"]["status"] == "ok"
+    assert event["payload"]["tool_output"] == {"exit_code": 0}
+
+
+def test_map_session_end_to_session_end_event() -> None:
+    payload = {
+        "hook_event_name": "SessionEnd",
+        "session_id": "sess-end",
+        "reason": "user_exit",
+    }
+
+    event = map_claude_hook_payload(payload)
+
+    assert event is not None
+    assert event["event_type"] == "session_end"
+    assert event["payload"]["reason"] == "user_exit"
+
+
+def test_map_claude_hook_payload_event_id_is_stable_with_explicit_timestamp() -> None:
+    payload = {
+        "hook_event_name": "SessionStart",
+        "session_id": "sess-stable",
+        "source": "startup",
+        "ts": "2026-03-02T20:00:00Z",
+    }
+
+    first = map_claude_hook_payload(payload)
+    second = map_claude_hook_payload(payload)
+
+    assert first is not None
+    assert second is not None
+    assert first["event_id"] == second["event_id"]
+
+
+def test_map_claude_hook_payload_marks_generated_timestamp_when_missing() -> None:
+    payload = {
+        "hook_event_name": "SessionStart",
+        "session_id": "sess-stable-no-ts",
+        "source": "startup",
+    }
+
+    mapped = map_claude_hook_payload(payload)
+
+    assert mapped is not None
+    assert mapped["meta"]["ts_normalized"] == "generated"
+    assert mapped["event_id"].startswith("cld_evt_")

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from codemem.commands.claude_integration_cmds import (
+    ALLOWED_HOOK_EVENTS,
+    _adapter_stream_id,
+    _build_install_report,
+    _load_json_or_empty,
+    _merge_enabled_plugins,
+    _queue_adapter_event,
+    ingest_claude_hook_cmd,
+    install_claude_integration_cmd,
+)
+
+
+def test_merge_enabled_plugins_preserves_existing_entries() -> None:
+    settings = {
+        "enabledPlugins": ["./plugins/existing"],
+        "other": {"x": 1},
+    }
+
+    merged = _merge_enabled_plugins(settings, "./plugins/codemem")
+
+    assert merged["enabledPlugins"] == ["./plugins/existing", "./plugins/codemem"]
+    assert merged["other"] == {"x": 1}
+
+
+def test_build_install_report_shape() -> None:
+    report = _build_install_report(
+        plugin_dir=Path("/tmp/.claude/plugins/codemem"),
+        settings_path=Path("/tmp/.claude/settings.json"),
+        plugin_ref="./plugins/codemem",
+    )
+
+    assert set(report.keys()) == {
+        "plugin_dir",
+        "settings_path",
+        "enabled_plugin",
+        "hook_entrypoint",
+    }
+    assert report["enabled_plugin"] == "./plugins/codemem"
+
+
+def test_install_claude_integration_writes_plugin_and_settings(monkeypatch, tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    (source / ".claude-plugin").mkdir(parents=True)
+    (source / "hooks").mkdir(parents=True)
+    (source / "scripts").mkdir(parents=True)
+    (source / ".claude-plugin" / "plugin.json").write_text('{"name":"codemem"}\n')
+    (source / "hooks" / "hooks.json").write_text('{"hooks":{}}\n')
+    (source / "scripts" / "ingest-hook.sh").write_text("#!/usr/bin/env bash\n")
+
+    monkeypatch.setattr(
+        "codemem.commands.claude_integration_cmds._resolve_claude_plugin_source",
+        lambda: source,
+    )
+
+    report = install_claude_integration_cmd(force=False, cwd=tmp_path)
+
+    assert report["enabled_plugin"] == "./plugins/codemem"
+    installed_plugin = (
+        tmp_path / ".claude" / "plugins" / "codemem" / ".claude-plugin" / "plugin.json"
+    )
+    settings_path = tmp_path / ".claude" / "settings.json"
+    assert installed_plugin.exists()
+    assert settings_path.exists()
+    assert "./plugins/codemem" in settings_path.read_text()
+
+
+def test_load_json_or_empty_rejects_non_object(tmp_path: Path) -> None:
+    path = tmp_path / "settings.json"
+    path.write_text("[]\n")
+
+    try:
+        _load_json_or_empty(path)
+    except ValueError as exc:
+        assert "JSON object" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for non-object JSON")
+
+
+def test_ingest_claude_hook_cmd_skips_pre_tool_use_hook() -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "session_id": "sess-1",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo hi"},
+    }
+    called = {"count": 0}
+
+    def _fake_ingest(_: object) -> None:
+        called["count"] += 1
+
+    with (
+        patch("sys.stdin", io.StringIO(json.dumps(payload))),
+        patch("codemem.commands.claude_integration_cmds.MemoryStore", side_effect=AssertionError),
+    ):
+        ingest_claude_hook_cmd()
+
+    assert called["count"] == 0
+
+
+def test_ingest_claude_hook_cmd_processes_stop_hook() -> None:
+    payload = {
+        "hook_event_name": "Stop",
+        "session_id": "sess-1",
+        "last_assistant_message": "Done",
+    }
+    called = {"count": 0}
+
+    class _FakeStore:
+        def __init__(self, _: object) -> None:
+            pass
+
+        def record_raw_event(self, **kwargs: object) -> bool:
+            called["count"] += 1
+            assert kwargs["event_type"] == "claude.hook"
+            return True
+
+        def update_raw_event_session_meta(self, **_: object) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    def _fake_flush(*_: object, **__: object) -> dict[str, int]:
+        called["count"] += 1
+        return {"flushed": 1, "updated_state": 1}
+
+    with (
+        patch("sys.stdin", io.StringIO(json.dumps(payload))),
+        patch("codemem.commands.claude_integration_cmds.MemoryStore", _FakeStore),
+        patch("codemem.commands.claude_integration_cmds.flush_raw_events", _fake_flush),
+    ):
+        ingest_claude_hook_cmd()
+
+    assert called["count"] == 2
+
+
+def test_ingest_claude_hook_cmd_noops_on_invalid_json() -> None:
+    called = {"count": 0}
+
+    with (
+        patch("sys.stdin", io.StringIO("{not-json")),
+        patch("codemem.commands.claude_integration_cmds.MemoryStore", side_effect=AssertionError),
+    ):
+        ingest_claude_hook_cmd()
+
+    assert called["count"] == 0
+
+
+def test_ingest_claude_hook_cmd_noops_on_non_object_payload() -> None:
+    called = {"count": 0}
+
+    with (
+        patch("sys.stdin", io.StringIO("[]")),
+        patch("codemem.commands.claude_integration_cmds.MemoryStore", side_effect=AssertionError),
+    ):
+        ingest_claude_hook_cmd()
+
+    assert called["count"] == 0
+
+
+def test_ingest_claude_hook_cmd_skips_unmappable_hook() -> None:
+    called = {"count": 0}
+    payload = {
+        "hook_event_name": "NotMapped",
+        "session_id": "sess-1",
+    }
+
+    def _fake_ingest(_: object) -> None:
+        called["count"] += 1
+
+    with (
+        patch("sys.stdin", io.StringIO(json.dumps(payload))),
+        patch("codemem.commands.claude_integration_cmds.MemoryStore", side_effect=AssertionError),
+    ):
+        ingest_claude_hook_cmd()
+
+    assert called["count"] == 0
+
+
+def test_hooks_template_matches_allowlist_events() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    hooks_path = repo_root / ".claude" / "plugin" / "codemem" / "hooks" / "hooks.json"
+    hooks_payload = json.loads(hooks_path.read_text())
+
+    assert set(hooks_payload["hooks"].keys()) == ALLOWED_HOOK_EVENTS
+
+
+def test_adapter_stream_id_uses_source_and_session_only() -> None:
+    stream_id = _adapter_stream_id(source="claude", session_id="sess-1", cwd="/tmp/worktree-a")
+    assert stream_id == "claude:sess-1"
+
+
+def test_queue_adapter_event_writes_claude_hook_payload() -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "sess-queue",
+        "prompt": "hello",
+        "cwd": "/tmp/worktree-a",
+    }
+
+    calls: dict[str, object] = {}
+
+    class _FakeStore:
+        def record_raw_event(self, **kwargs: object) -> bool:
+            calls["record"] = kwargs
+            return True
+
+        def update_raw_event_session_meta(self, **kwargs: object) -> None:
+            calls["meta"] = kwargs
+
+    queued = _queue_adapter_event(payload, store=_FakeStore())
+
+    assert queued is not None
+    stream_id, inserted = queued
+    assert inserted is True
+    assert stream_id == "claude:sess-queue"
+    record = calls["record"]
+    assert isinstance(record, dict)
+    assert record["event_type"] == "claude.hook"

--- a/tests/test_raw_events_enqueue_cmd.py
+++ b/tests/test_raw_events_enqueue_cmd.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from codemem.cli import app
+from codemem.store import MemoryStore
+
+runner = CliRunner()
+
+
+def test_enqueue_raw_event_cmd_writes_event_and_meta(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    payload = {
+        "opencode_session_id": "sess-cli",
+        "event_id": "evt-1",
+        "event_type": "assistant_message",
+        "payload": {"type": "assistant_message", "assistant_text": "done"},
+        "ts_wall_ms": 123,
+        "ts_mono_ms": 4.5,
+        "cwd": "/tmp/wt",
+        "project": "codemem",
+        "started_at": "2026-03-02T20:00:00Z",
+    }
+
+    result = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(payload),
+    )
+
+    assert result.exit_code == 0
+    store = MemoryStore(db_path)
+    try:
+        events = store.raw_events_since(opencode_session_id="sess-cli", after_event_seq=-1)
+        assert len(events) == 1
+        assert events[0]["event_id"] == "evt-1"
+        meta = store.raw_event_session_meta("sess-cli")
+        assert meta["cwd"] == "/tmp/wt"
+        assert meta["project"] == "codemem"
+        assert meta["started_at"] == "2026-03-02T20:00:00Z"
+        assert meta["last_seen_ts_wall_ms"] == 123
+    finally:
+        store.close()
+
+
+def test_enqueue_raw_event_cmd_rejects_empty_stdin(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    result = runner.invoke(app, ["enqueue-raw-event", "--db-path", str(db_path)], input="\n")
+
+    assert result.exit_code != 0
+    assert "stdin payload required" in result.output
+    store = MemoryStore(db_path)
+    try:
+        events = store.raw_events_since(opencode_session_id="sess-empty", after_event_seq=-1)
+        assert events == []
+    finally:
+        store.close()
+
+
+def test_enqueue_raw_event_cmd_uses_payload_raw_event_id_when_event_id_missing(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    payload = {
+        "opencode_session_id": "sess-cli",
+        "event_type": "user_prompt",
+        "payload": {"_raw_event_id": "stable-raw-id", "type": "user_prompt"},
+    }
+
+    result = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(payload),
+    )
+
+    assert result.exit_code == 0
+    store = MemoryStore(db_path)
+    try:
+        events = store.raw_events_since(opencode_session_id="sess-cli", after_event_seq=-1)
+        assert len(events) == 1
+        assert events[0]["event_id"] == "stable-raw-id"
+    finally:
+        store.close()
+
+
+def test_enqueue_raw_event_cmd_rejects_invalid_payload(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    payload = {
+        "opencode_session_id": "sess-cli",
+        "event_id": "evt-1",
+        "event_type": "assistant_message",
+        "payload": "not-an-object",
+    }
+
+    result = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(payload),
+    )
+
+    assert result.exit_code != 0
+    assert "payload must be an object" in result.output
+
+
+def test_enqueue_raw_event_cmd_keeps_last_seen_timestamp_monotonic(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    first = {
+        "opencode_session_id": "sess-cli",
+        "event_id": "evt-1",
+        "event_type": "assistant_message",
+        "payload": {},
+        "ts_wall_ms": 200,
+    }
+    second = {
+        "opencode_session_id": "sess-cli",
+        "event_id": "evt-2",
+        "event_type": "assistant_message",
+        "payload": {},
+        "ts_wall_ms": 100,
+    }
+
+    first_result = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(first),
+    )
+    second_result = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(second),
+    )
+
+    assert first_result.exit_code == 0
+    assert second_result.exit_code == 0
+    store = MemoryStore(db_path)
+    try:
+        meta = store.raw_event_session_meta("sess-cli")
+        assert meta["last_seen_ts_wall_ms"] == 200
+    finally:
+        store.close()


### PR DESCRIPTION
## Description
Adds durable raw-event queue parity across adapters by introducing queue-backed fallback paths and CLI enqueue support, then wiring Claude hook ingestion through the same raw-event pipeline family used by OpenCode. Includes queue/session metadata safeguards and adapter-focused regression tests.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run pytest tests/test_raw_events_enqueue_cmd.py tests/test_claude_hooks.py tests/test_claude_integration_cmds.py`
- `uv run ruff check codemem/cli_app.py codemem/commands/raw_events_cmds.py codemem/store/raw_events.py codemem/claude_hooks.py codemem/commands/claude_integration_cmds.py tests/test_raw_events_enqueue_cmd.py tests/test_claude_hooks.py tests/test_claude_integration_cmds.py`
- `bun test ./.opencode/tests/plugin-adapter.test.js`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
