### PR TITLE
fix(claude): avoid event id collisions when hook timestamps are absent

### DIFF
--- a/codemem/claude_hooks.py
+++ b/codemem/claude_hooks.py
@@ -163,10 +163,12 @@ def map_claude_hook_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
     if unknown:
         meta["hook_fields"] = unknown
 
+    event_id_ts_seed = normalized_raw_ts or ts
+
     event_id = _stable_event_id(
         session_id,
         hook_event,
-        str(normalized_raw_ts or ""),
+        event_id_ts_seed,
         tool_use_id,
         hashlib.sha256(
             json.dumps(event_payload, sort_keys=True, default=str).encode("utf-8")

--- a/codemem/commands/claude_integration_cmds.py
+++ b/codemem/commands/claude_integration_cmds.py
@@ -38,6 +38,18 @@ def _adapter_stream_id(*, source: str, session_id: str, cwd: str | None) -> str:
     return f"{source}:{session_id}"
 
 
+def _hook_stream_id(hook_payload: dict[str, Any]) -> str | None:
+    session_id = str(hook_payload.get("session_id") or "").strip()
+    if not session_id:
+        return None
+    source = str(hook_payload.get("source") or "claude").strip() or "claude"
+    return _adapter_stream_id(
+        source=source,
+        session_id=session_id,
+        cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
+    )
+
+
 def _iso_to_wall_ms(ts: str | None) -> int:
     if isinstance(ts, str) and ts.strip():
         try:
@@ -235,14 +247,31 @@ def ingest_claude_hook_cmd() -> None:
     hook_event_name = str(hook_payload.get("hook_event_name") or "").strip()
     if hook_event_name not in ALLOWED_HOOK_EVENTS:
         return
+    should_flush = _should_flush(hook_event_name)
     db_path = os.environ.get("CODEMEM_DB") or DEFAULT_DB_PATH
     store = MemoryStore(db_path)
     try:
         queued = _queue_adapter_event(hook_payload, store=store)
         if queued is None:
+            if should_flush:
+                stream_id = _hook_stream_id(hook_payload)
+                if not stream_id:
+                    return
+                flush_raw_events(
+                    store,
+                    opencode_session_id=stream_id,
+                    cwd=hook_payload.get("cwd")
+                    if isinstance(hook_payload.get("cwd"), str)
+                    else None,
+                    project=hook_payload.get("project")
+                    if isinstance(hook_payload.get("project"), str)
+                    else None,
+                    started_at=None,
+                    max_events=None,
+                )
             return
         stream_id, _ = queued
-        if not _should_flush(hook_event_name):
+        if not should_flush:
             return
         flush_raw_events(
             store,

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -132,3 +132,29 @@ def test_map_claude_hook_payload_marks_generated_timestamp_when_missing() -> Non
     assert mapped is not None
     assert mapped["meta"]["ts_normalized"] == "generated"
     assert mapped["event_id"].startswith("cld_evt_")
+
+
+def test_map_claude_hook_payload_missing_ts_generates_distinct_event_ids(
+    monkeypatch,
+) -> None:
+    payload = {
+        "hook_event_name": "SessionStart",
+        "session_id": "sess-repeat",
+        "source": "startup",
+    }
+    generated = iter(
+        [
+            "2026-03-02T20:00:00.000000Z",
+            "2026-03-02T20:00:00.000001Z",
+        ]
+    )
+
+    monkeypatch.setattr("codemem.claude_hooks._now_iso", lambda: next(generated))
+
+    first = map_claude_hook_payload(payload)
+    second = map_claude_hook_payload(payload)
+
+    assert first is not None
+    assert second is not None
+    assert first["ts"] != second["ts"]
+    assert first["event_id"] != second["event_id"]

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -141,6 +141,43 @@ def test_ingest_claude_hook_cmd_processes_stop_hook() -> None:
     assert called["count"] == 2
 
 
+def test_ingest_claude_hook_cmd_flushes_stop_hook_when_assistant_text_missing() -> None:
+    payload = {
+        "hook_event_name": "Stop",
+        "session_id": "sess-1",
+    }
+    called = {"record": 0, "flush": 0}
+
+    class _FakeStore:
+        def __init__(self, _: object) -> None:
+            pass
+
+        def record_raw_event(self, **_: object) -> bool:
+            called["record"] += 1
+            return True
+
+        def update_raw_event_session_meta(self, **_: object) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    def _fake_flush(*_: object, **kwargs: object) -> dict[str, int]:
+        called["flush"] += 1
+        assert kwargs["opencode_session_id"] == "claude:sess-1"
+        return {"flushed": 0, "updated_state": 0}
+
+    with (
+        patch("sys.stdin", io.StringIO(json.dumps(payload))),
+        patch("codemem.commands.claude_integration_cmds.MemoryStore", _FakeStore),
+        patch("codemem.commands.claude_integration_cmds.flush_raw_events", _fake_flush),
+    ):
+        ingest_claude_hook_cmd()
+
+    assert called["record"] == 0
+    assert called["flush"] == 1
+
+
 def test_ingest_claude_hook_cmd_noops_on_invalid_json() -> None:
     called = {"count": 0}
 


### PR DESCRIPTION
## Description
Fixes Claude adapter event ID collision risk when hook payloads omit timestamps by seeding deterministic IDs with the effective generated timestamp. Adds regression coverage to ensure repeated missing-ts payloads do not dedupe into one raw event.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run pytest tests/test_claude_hooks.py tests/test_claude_integration_cmds.py`
- `uv run ruff check codemem/claude_hooks.py tests/test_claude_hooks.py`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
