### PR TITLE
fix(claude): canonicalize boundary flush stream id to claude namespace

### DIFF
--- a/codemem/commands/claude_integration_cmds.py
+++ b/codemem/commands/claude_integration_cmds.py
@@ -42,9 +42,8 @@ def _hook_stream_id(hook_payload: dict[str, Any]) -> str | None:
     session_id = str(hook_payload.get("session_id") or "").strip()
     if not session_id:
         return None
-    source = str(hook_payload.get("source") or "claude").strip() or "claude"
     return _adapter_stream_id(
-        source=source,
+        source="claude",
         session_id=session_id,
         cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
     )

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -145,6 +145,7 @@ def test_ingest_claude_hook_cmd_flushes_stop_hook_when_assistant_text_missing() 
     payload = {
         "hook_event_name": "Stop",
         "session_id": "sess-1",
+        "source": "startup",
     }
     called = {"record": 0, "flush": 0}
 


### PR DESCRIPTION
## Description
Canonicalizes Claude boundary flush stream IDs to the `claude:<session_id>` namespace so fallback flushes target the same queue stream as enqueued hook events. Prevents end-of-session flush misses when raw hook `source` differs from adapter source.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run pytest tests/test_claude_integration_cmds.py tests/test_claude_hooks.py`
- `uv run ruff check codemem/commands/claude_integration_cmds.py tests/test_claude_integration_cmds.py`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
