### PR TITLE
fix(raw-events): redact CLI fallback payloads and harden max-events parsing

### DIFF
--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -343,6 +343,14 @@ const asFiniteNonNegativeInt = (value) => {
   return Math.trunc(value);
 };
 
+const parsePositiveInt = (value, fallback) => {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+};
+
 export const buildInjectionToastMessage = (metrics) => {
   const items = asFiniteNonNegativeInt(metrics?.items);
   const packTokens = asFiniteNonNegativeInt(metrics?.pack_tokens);
@@ -400,10 +408,7 @@ export const OpencodeMemPlugin = async ({
   worktree,
 }) => {
   const events = [];
-  const maxEvents = Number.parseInt(
-    process.env.CODEMEM_PLUGIN_MAX_EVENTS || "200",
-    10
-  );
+  const maxEvents = parsePositiveInt(process.env.CODEMEM_PLUGIN_MAX_EVENTS, 200);
   const maxChars = Number.parseInt(
     process.env.CODEMEM_PLUGIN_MAX_EVENT_CHARS || "8000",
     10
@@ -1809,4 +1814,5 @@ export const __testUtils = {
   selectRawEventId,
   buildRawEventEnvelope,
   trimEventQueue,
+  parsePositiveInt,
 };

--- a/.opencode/tests/plugin-adapter.test.js
+++ b/.opencode/tests/plugin-adapter.test.js
@@ -156,6 +156,13 @@ describe("opencode adapter event mapping", () => {
     expect(envelope.event_id).toBe("stable-raw-id");
   });
 
+  test("parsePositiveInt falls back for invalid values", () => {
+    expect(__testUtils.parsePositiveInt("200", 10)).toBe(200);
+    expect(__testUtils.parsePositiveInt("0", 10)).toBe(10);
+    expect(__testUtils.parsePositiveInt("-5", 10)).toBe(10);
+    expect(__testUtils.parsePositiveInt("NaN", 10)).toBe(10);
+  });
+
   test("trimEventQueue drops enqueued events first", () => {
     const events = [
       { _raw_event_id: "a", _raw_enqueued: false },

--- a/codemem/commands/raw_events_cmds.py
+++ b/codemem/commands/raw_events_cmds.py
@@ -7,6 +7,7 @@ from typing import Any
 import typer
 from rich import print
 
+from codemem.ingest_sanitize import _strip_private
 from codemem.store import MemoryStore
 
 
@@ -54,6 +55,16 @@ def _coerce_optional_float(payload: dict[str, Any], key: str) -> float | None:
         raise ValueError(f"{key} must be number") from exc
 
 
+def _strip_private_obj(value: Any) -> Any:
+    if isinstance(value, str):
+        return _strip_private(value)
+    if isinstance(value, list):
+        return [_strip_private_obj(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _strip_private_obj(item) for key, item in value.items()}
+    return value
+
+
 def enqueue_raw_event_cmd(store: MemoryStore) -> None:
     """Read one raw event from stdin and enqueue it."""
 
@@ -95,6 +106,8 @@ def enqueue_raw_event_cmd(store: MemoryStore) -> None:
         started_at = _coerce_optional_str(payload, "started_at")
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
+
+    event_payload = _strip_private_obj(event_payload)
 
     inserted = store.record_raw_event(
         opencode_session_id=opencode_session_id,

--- a/tests/test_raw_events_enqueue_cmd.py
+++ b/tests/test_raw_events_enqueue_cmd.py
@@ -141,3 +141,36 @@ def test_enqueue_raw_event_cmd_keeps_last_seen_timestamp_monotonic(tmp_path: Pat
         assert meta["last_seen_ts_wall_ms"] == 200
     finally:
         store.close()
+
+
+def test_enqueue_raw_event_cmd_strips_private_tags_from_payload(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    payload = {
+        "opencode_session_id": "sess-redact",
+        "event_id": "evt-redact-1",
+        "event_type": "assistant_message",
+        "payload": {
+            "assistant_text": "before <private>secret-token</private> after",
+            "nested": {
+                "note": "x<private>hidden</private>y",
+            },
+        },
+    }
+
+    result = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(payload),
+    )
+
+    assert result.exit_code == 0
+    store = MemoryStore(db_path)
+    try:
+        events = store.raw_events_since(opencode_session_id="sess-redact", after_event_seq=-1)
+        assert len(events) == 1
+        stored_event = json.dumps(events[0], sort_keys=True)
+        assert "<private>" not in stored_event
+        assert "secret-token" not in stored_event
+        assert "hidden" not in stored_event
+    finally:
+        store.close()


### PR DESCRIPTION
## Description
Brings fallback queue behavior in line with HTTP ingest privacy semantics by sanitizing queued payloads before persistence, and hardens plugin max-event parsing so invalid values do not disable queue bounds unexpectedly.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run pytest tests/test_raw_events_enqueue_cmd.py`
- `uv run ruff check codemem/commands/raw_events_cmds.py tests/test_raw_events_enqueue_cmd.py`
- `bun test ./.opencode/tests/plugin-adapter.test.js`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
