### PR TITLE
fix(viewer): handle port conflicts and stale pid recovery

### DIFF
--- a/codemem/commands/viewer_cmds.py
+++ b/codemem/commands/viewer_cmds.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import os
 import signal
 import subprocess
@@ -64,10 +65,10 @@ def _port_open(host: str, port: int) -> bool:
             return False
 
 
-def _pid_for_port(port: int) -> int | None:
+def _pid_for_port(host: str, port: int) -> int | None:
     try:
         result = subprocess.run(
-            ["lsof", "-ti", f"tcp:{port}"],
+            ["lsof", "-nP", "-ti", f"TCP@{host}:{port}"],
             capture_output=True,
             text=True,
             check=False,
@@ -106,7 +107,8 @@ def serve(
 
     if stop or restart:
         pid = _read_pid(pid_path)
-        port_pid = _pid_for_port(port) if _port_open(host, port) else None
+        listening = _port_open(host, port)
+        port_pid = _pid_for_port(host, port)
         if pid is not None and port_pid is not None and pid != port_pid:
             print(
                 f"[yellow]Viewer PID file mismatch (file {pid}, port {port_pid}); using port pid[/yellow]"
@@ -115,15 +117,16 @@ def serve(
         if pid is None and port_pid is not None:
             pid = port_pid
             print(f"[yellow]Found viewer pid {pid} by port scan[/yellow]")
+        port_bound_by_pid = pid is not None and port_pid is not None and pid == port_pid
         if pid is None:
-            if _port_open(host, port):
+            if listening:
                 print("[yellow]Viewer is running but no PID file was found[/yellow]")
             else:
                 print("[yellow]No background viewer found[/yellow]")
         elif not _pid_running(pid):
             _clear_pid(pid_path)
             print("[yellow]Removed stale viewer PID file[/yellow]")
-        elif not _port_open(host, port):
+        elif not listening and not port_bound_by_pid:
             _clear_pid(pid_path)
             print("[yellow]Removed stale viewer PID file (port not listening)[/yellow]")
         else:
@@ -177,5 +180,18 @@ def serve(
     if _port_open(host, port):
         print(f"[yellow]Viewer already running at http://{host}:{port}[/yellow]")
         return
-    print(f"[green]Viewer running at http://{host}:{port}[/green]")
-    start_viewer(host=host, port=port, background=False)
+    print(f"[green]Starting viewer at http://{host}:{port}[/green]")
+    try:
+        start_viewer(host=host, port=port, background=False)
+    except OSError as exc:
+        if exc.errno == errno.EADDRINUSE:
+            in_use_pid = _pid_for_port(host, port)
+            if in_use_pid is not None:
+                print(
+                    f"[yellow]Port {port} is already in use by pid {in_use_pid}; "
+                    "viewer may already be running[/yellow]"
+                )
+            else:
+                print(f"[yellow]Port {port} is already in use[/yellow]")
+            return
+        raise

--- a/tests/test_viewer_cmds_pid.py
+++ b/tests/test_viewer_cmds_pid.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 from types import SimpleNamespace
 from typing import Any
 
@@ -36,3 +37,74 @@ def test_serve_background_ignores_stale_pid_file(monkeypatch: Any) -> None:
 
     assert calls["cleared"] == 1
     assert calls["popen"] == 1
+
+
+def test_serve_stop_uses_port_pid_when_port_probe_fails(monkeypatch: Any) -> None:
+    from codemem.commands import viewer_cmds
+
+    calls: dict[str, Any] = {"kill": 0, "cleared": 0, "running_checks": 0}
+
+    monkeypatch.setattr(viewer_cmds, "_read_pid", lambda *_: None)
+    monkeypatch.setattr(viewer_cmds, "_port_open", lambda *_: False)
+    monkeypatch.setattr(viewer_cmds, "_pid_for_port", lambda *_: 321)
+
+    def fake_pid_running(*_args: Any, **_kwargs: Any) -> bool:
+        calls["running_checks"] += 1
+        return calls["running_checks"] == 1
+
+    monkeypatch.setattr(viewer_cmds, "_pid_running", fake_pid_running)
+    monkeypatch.setattr(
+        viewer_cmds, "_clear_pid", lambda *_: calls.__setitem__("cleared", calls["cleared"] + 1)
+    )
+    monkeypatch.setattr(viewer_cmds.time, "sleep", lambda *_: None)
+
+    def fake_kill(pid: int, _sig: int) -> None:
+        assert pid == 321
+        calls["kill"] += 1
+
+    monkeypatch.setattr(viewer_cmds.os, "kill", fake_kill)
+
+    viewer_cmds.serve(
+        db_path=None,
+        host="127.0.0.1",
+        port=38888,
+        background=False,
+        stop=True,
+        restart=False,
+    )
+
+    assert calls["kill"] == 1
+    assert calls["cleared"] == 1
+
+
+def test_serve_foreground_handles_eaddrinuse(monkeypatch: Any) -> None:
+    from codemem.commands import viewer_cmds
+
+    calls: dict[str, int] = {"start": 0, "port_pid": 0}
+
+    monkeypatch.setattr(viewer_cmds, "_port_open", lambda *_: False)
+
+    def fake_pid_for_port(*_args: Any, **_kwargs: Any) -> int | None:
+        calls["port_pid"] += 1
+        if calls["port_pid"] == 1:
+            return None
+        return 456
+
+    monkeypatch.setattr(viewer_cmds, "_pid_for_port", fake_pid_for_port)
+
+    def fake_start_viewer(*_args: Any, **_kwargs: Any) -> None:
+        calls["start"] += 1
+        raise OSError(errno.EADDRINUSE, "Address already in use")
+
+    monkeypatch.setattr(viewer_cmds, "start_viewer", fake_start_viewer)
+
+    viewer_cmds.serve(
+        db_path=None,
+        host="127.0.0.1",
+        port=38888,
+        background=False,
+        stop=False,
+        restart=False,
+    )
+
+    assert calls["start"] == 1


### PR DESCRIPTION
## Description
This fixes viewer process lifecycle handling so local daemon operations are deterministic and do not mislead users when the port is already occupied.

- Stop/restart now resolves PID by port scan even when connect probes fail, so `serve --stop` can terminate orphan/stuck listeners.
- Foreground `serve` now handles `EADDRINUSE` gracefully (no traceback), and reports clear "port already in use" messaging.
- Added regression tests for stale PID recovery, stop-by-port-PID fallback, and `EADDRINUSE` foreground handling.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run pytest tests/test_viewer_cmds_pid.py -q`
- `uv run pytest`
- `uv run codemem serve --background && uv run codemem serve --stop`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced