### PR TITLE
refactor(raw-events): canonicalize source/stream identity and harden migration

### DIFF
--- a/codemem/claude_hooks.py
+++ b/codemem/claude_hooks.py
@@ -205,6 +205,8 @@ def build_ingest_payload_from_hook(hook_payload: dict[str, Any]) -> dict[str, An
             }
         ],
         "session_context": {
-            "opencode_session_id": f"claude:{session_id}",
+            "source": "claude",
+            "stream_id": session_id,
+            "opencode_session_id": session_id,
         },
     }

--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -533,8 +533,9 @@ def backfill_discovery_tokens(
 
 @app.command("flush-raw-events")
 def flush_raw_events(
-    opencode_session_id: str = typer.Argument(..., help="OpenCode session id"),
+    stream_id: str = typer.Argument(..., help="Stream id"),
     db_path: str = typer.Option(None, help="Path to SQLite database"),
+    source: str = typer.Option("opencode", help="Adapter source for the stream"),
     cwd: str | None = typer.Option(None, help="Working directory for capture context"),
     project: str | None = typer.Option(None, help="Project identifier"),
     started_at: str | None = typer.Option(None, help="ISO timestamp for session start"),
@@ -546,7 +547,8 @@ def flush_raw_events(
     try:
         flush_raw_events_cmd(
             store,
-            opencode_session_id=opencode_session_id,
+            opencode_session_id=stream_id,
+            source=source,
             cwd=cwd,
             project=project,
             started_at=started_at,
@@ -585,15 +587,21 @@ def raw_events_status(
 
 @app.command("raw-events-retry")
 def raw_events_retry(
-    opencode_session_id: str = typer.Argument(..., help="OpenCode session id"),
+    stream_id: str = typer.Argument(..., help="Stream id"),
     db_path: str = typer.Option(None, help="Path to SQLite database"),
+    source: str = typer.Option("opencode", help="Adapter source for the stream"),
     limit: int = typer.Option(5, help="Max error batches to retry"),
 ) -> None:
     """Retry error raw-event flush batches for a session."""
 
     store = _store(db_path)
     try:
-        raw_events_retry_cmd(store, opencode_session_id=opencode_session_id, limit=limit)
+        raw_events_retry_cmd(
+            store,
+            opencode_session_id=stream_id,
+            source=source,
+            limit=limit,
+        )
     finally:
         store.close()
 

--- a/codemem/commands/claude_integration_cmds.py
+++ b/codemem/commands/claude_integration_cmds.py
@@ -34,9 +34,8 @@ def _env_truthy(name: str, default: bool) -> bool:
     return default
 
 
-def _adapter_stream_id(*, source: str, session_id: str, cwd: str | None) -> str:
-    _ = cwd
-    return f"{source}:{session_id}"
+def _adapter_stream_id(*, session_id: str) -> str:
+    return session_id
 
 
 def _hook_stream_id(hook_payload: dict[str, Any]) -> str | None:
@@ -44,9 +43,7 @@ def _hook_stream_id(hook_payload: dict[str, Any]) -> str | None:
     if not session_id:
         return None
     return _adapter_stream_id(
-        source="claude",
         session_id=session_id,
-        cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
     )
 
 
@@ -81,9 +78,7 @@ def _queue_adapter_event(hook_payload: dict[str, Any], *, store: Any) -> tuple[s
     if not session_id:
         return None
     stream_id = _adapter_stream_id(
-        source=source,
         session_id=session_id,
-        cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
     )
     ts = str(adapter_event.get("ts") or "")
     payload = {
@@ -94,6 +89,7 @@ def _queue_adapter_event(hook_payload: dict[str, Any], *, store: Any) -> tuple[s
     payload = _strip_private_obj(payload)
     inserted = store.record_raw_event(
         opencode_session_id=stream_id,
+        source=source,
         event_id=str(adapter_event.get("event_id") or ""),
         event_type="claude.hook",
         payload=payload,
@@ -101,6 +97,7 @@ def _queue_adapter_event(hook_payload: dict[str, Any], *, store: Any) -> tuple[s
     )
     store.update_raw_event_session_meta(
         opencode_session_id=stream_id,
+        source=source,
         cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
         project=hook_payload.get("project")
         if isinstance(hook_payload.get("project"), str)
@@ -271,6 +268,7 @@ def ingest_claude_hook_cmd() -> None:
                 flush_raw_events(
                     store,
                     opencode_session_id=stream_id,
+                    source="claude",
                     cwd=hook_payload.get("cwd")
                     if isinstance(hook_payload.get("cwd"), str)
                     else None,
@@ -287,6 +285,7 @@ def ingest_claude_hook_cmd() -> None:
         flush_raw_events(
             store,
             opencode_session_id=stream_id,
+            source="claude",
             cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
             project=hook_payload.get("project")
             if isinstance(hook_payload.get("project"), str)

--- a/codemem/commands/raw_events_cmds.py
+++ b/codemem/commands/raw_events_cmds.py
@@ -81,6 +81,7 @@ def enqueue_raw_event_cmd(store: MemoryStore) -> None:
 
     try:
         opencode_session_id = _require_non_empty_str(payload, "opencode_session_id")
+        source = _coerce_optional_str(payload, "source") or "opencode"
         event_type = _require_non_empty_str(payload, "event_type")
         event_payload = payload.get("payload")
         if event_payload is None:
@@ -111,6 +112,7 @@ def enqueue_raw_event_cmd(store: MemoryStore) -> None:
 
     inserted = store.record_raw_event(
         opencode_session_id=opencode_session_id,
+        source=source,
         event_id=event_id,
         event_type=event_type,
         payload=event_payload,
@@ -119,6 +121,7 @@ def enqueue_raw_event_cmd(store: MemoryStore) -> None:
     )
     store.update_raw_event_session_meta(
         opencode_session_id=opencode_session_id,
+        source=source,
         cwd=cwd,
         project=project,
         started_at=started_at,
@@ -131,6 +134,7 @@ def flush_raw_events_cmd(
     store: MemoryStore,
     *,
     opencode_session_id: str,
+    source: str,
     cwd: str | None,
     project: str | None,
     started_at: str | None,
@@ -143,6 +147,7 @@ def flush_raw_events_cmd(
     result = flush(
         store,
         opencode_session_id=opencode_session_id,
+        source=source,
         cwd=cwd,
         project=project,
         started_at=started_at,
@@ -159,10 +164,12 @@ def raw_events_status_cmd(store: MemoryStore, *, limit: int) -> None:
         print("No pending raw events")
         return
     for item in items:
-        legacy_counts = store.raw_event_batch_status_counts(item["opencode_session_id"])
-        queue_counts = store.raw_event_queue_status_counts(item["opencode_session_id"])
+        source = str(item.get("source") or "opencode")
+        stream_id = str(item.get("stream_id") or item["opencode_session_id"])
+        legacy_counts = store.raw_event_batch_status_counts(stream_id, source=source)
+        queue_counts = store.raw_event_queue_status_counts(stream_id, source=source)
         print(
-            f"- {item['opencode_session_id']} pending={item['pending']} "
+            f"- {source}:{stream_id} pending={item['pending']} "
             f"max_seq={item['max_seq']} last_flushed={item['last_flushed_event_seq']} "
             f"batches=started:{legacy_counts['started']} running:{legacy_counts['running']} error:{legacy_counts['error']} completed:{legacy_counts['completed']} "
             f"queue=pending:{queue_counts['pending']} claimed:{queue_counts['claimed']} failed:{queue_counts['failed']} done:{queue_counts['completed']} "
@@ -174,23 +181,25 @@ def raw_events_retry_cmd(
     store: MemoryStore,
     *,
     opencode_session_id: str,
+    source: str,
     limit: int,
 ) -> None:
     """Retry error raw-event flush batches for a session."""
 
     from codemem.raw_event_flush import flush_raw_events as flush
 
-    errors = store.raw_event_error_batches(opencode_session_id, limit=limit)
+    errors = store.raw_event_error_batches(opencode_session_id, source=source, limit=limit)
     if not errors:
         print("No error batches")
         return
     for batch in errors:
         # Re-run extraction by forcing last_flushed back to the batch start-1.
         start_seq = int(batch["start_event_seq"])
-        store.update_raw_event_flush_state(opencode_session_id, start_seq - 1)
+        store.update_raw_event_flush_state(opencode_session_id, start_seq - 1, source=source)
         result = flush(
             store,
             opencode_session_id=opencode_session_id,
+            source=source,
             cwd=None,
             project=None,
             started_at=None,

--- a/codemem/db.py
+++ b/codemem/db.py
@@ -15,7 +15,7 @@ LEGACY_DEFAULT_DB_PATHS = (
     Path.home() / ".codemem.sqlite",
     Path.home() / ".opencode-mem.sqlite",
 )
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 
 def _sidecar_paths(path: Path) -> list[Path]:
@@ -196,6 +196,8 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
 
         CREATE TABLE IF NOT EXISTS raw_events (
             id INTEGER PRIMARY KEY,
+            source TEXT NOT NULL DEFAULT 'opencode',
+            stream_id TEXT NOT NULL DEFAULT '',
             opencode_session_id TEXT NOT NULL,
             event_id TEXT,
             event_seq INTEGER NOT NULL,
@@ -204,31 +206,40 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
             ts_mono_ms REAL,
             payload_json TEXT NOT NULL,
             created_at TEXT NOT NULL,
-            UNIQUE(opencode_session_id, event_seq)
+            UNIQUE(source, stream_id, event_seq),
+            UNIQUE(source, stream_id, event_id)
         );
         CREATE INDEX IF NOT EXISTS idx_raw_events_session_seq ON raw_events(opencode_session_id, event_seq);
         CREATE INDEX IF NOT EXISTS idx_raw_events_created_at ON raw_events(created_at DESC);
 
         CREATE TABLE IF NOT EXISTS raw_event_sessions (
-            opencode_session_id TEXT PRIMARY KEY,
+            source TEXT NOT NULL DEFAULT 'opencode',
+            stream_id TEXT NOT NULL DEFAULT '',
+            opencode_session_id TEXT NOT NULL,
             cwd TEXT,
             project TEXT,
             started_at TEXT,
             last_seen_ts_wall_ms INTEGER,
             last_received_event_seq INTEGER NOT NULL DEFAULT -1,
             last_flushed_event_seq INTEGER NOT NULL DEFAULT -1,
-            updated_at TEXT NOT NULL
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (source, stream_id)
         );
 
         CREATE TABLE IF NOT EXISTS opencode_sessions (
-            opencode_session_id TEXT PRIMARY KEY,
+            source TEXT NOT NULL DEFAULT 'opencode',
+            stream_id TEXT NOT NULL DEFAULT '',
+            opencode_session_id TEXT NOT NULL,
             session_id INTEGER REFERENCES sessions(id) ON DELETE CASCADE,
-            created_at TEXT NOT NULL
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (source, stream_id)
         );
         CREATE INDEX IF NOT EXISTS idx_opencode_sessions_session_id ON opencode_sessions(session_id);
 
         CREATE TABLE IF NOT EXISTS raw_event_flush_batches (
             id INTEGER PRIMARY KEY,
+            source TEXT NOT NULL DEFAULT 'opencode',
+            stream_id TEXT NOT NULL DEFAULT '',
             opencode_session_id TEXT NOT NULL,
             start_event_seq INTEGER NOT NULL,
             end_event_seq INTEGER NOT NULL,
@@ -236,7 +247,7 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
             status TEXT NOT NULL,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
-            UNIQUE(opencode_session_id, start_event_seq, end_event_seq, extractor_version)
+            UNIQUE(source, stream_id, start_event_seq, end_event_seq, extractor_version)
         );
         CREATE INDEX IF NOT EXISTS idx_raw_event_flush_batches_session ON raw_event_flush_batches(opencode_session_id, created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_raw_event_flush_batches_status ON raw_event_flush_batches(status, updated_at DESC);
@@ -369,10 +380,6 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
     _ensure_column(conn, "raw_event_sessions", "started_at", "TEXT")
     _ensure_column(conn, "raw_event_sessions", "last_seen_ts_wall_ms", "INTEGER")
     _ensure_column(conn, "raw_event_sessions", "last_received_event_seq", "INTEGER")
-    _ensure_column(conn, "raw_events", "event_id", "TEXT")
-    conn.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_raw_events_event_id ON raw_events(opencode_session_id, event_id)"
-    )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_sessions_import_key ON sessions(import_key)")
     conn.execute(
@@ -387,6 +394,498 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_user_prompts_import_key ON user_prompts(import_key)"
     )
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def _table_pk_columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    pk_rows = [row for row in rows if int(row[5] or 0) > 0]
+    pk_rows.sort(key=lambda row: int(row[5]))
+    return [str(row[1]) for row in pk_rows]
+
+
+def _table_create_sql(conn: sqlite3.Connection, table: str) -> str:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    if row is None or row[0] is None:
+        return ""
+    return " ".join(str(row[0]).lower().split())
+
+
+def _raw_event_identity_needs_rebuild(conn: sqlite3.Connection) -> bool:
+    if not _table_exists(conn, "raw_event_sessions") or not _table_exists(
+        conn, "opencode_sessions"
+    ):
+        return False
+    if _table_pk_columns(conn, "raw_event_sessions") != [
+        "source",
+        "stream_id",
+    ]:
+        return True
+    if _table_pk_columns(conn, "opencode_sessions") != ["source", "stream_id"]:
+        return True
+
+    raw_events_sql = _table_create_sql(conn, "raw_events")
+    if "unique(source, stream_id, event_seq)" not in raw_events_sql:
+        return True
+    if "unique(source, stream_id, event_id)" not in raw_events_sql:
+        return True
+
+    batches_sql = _table_create_sql(conn, "raw_event_flush_batches")
+    return (
+        "unique(source, stream_id, start_event_seq, end_event_seq, extractor_version)"
+        not in batches_sql
+    )
+
+
+def _assert_no_raw_event_identity_collisions(conn: sqlite3.Connection) -> None:
+    checks = [
+        (
+            "raw_events(source, stream_id, event_seq)",
+            """
+            SELECT source, stream_id, event_seq
+            FROM raw_events
+            GROUP BY source, stream_id, event_seq
+            HAVING COUNT(*) > 1
+            LIMIT 1
+            """,
+        ),
+        (
+            "raw_events(source, stream_id, event_id)",
+            """
+            SELECT source, stream_id, event_id
+            FROM raw_events
+            WHERE event_id IS NOT NULL
+            GROUP BY source, stream_id, event_id
+            HAVING COUNT(*) > 1
+            LIMIT 1
+            """,
+        ),
+        (
+            "raw_event_sessions(source, stream_id)",
+            """
+            SELECT source, stream_id
+            FROM raw_event_sessions
+            GROUP BY source, stream_id
+            HAVING COUNT(*) > 1
+            LIMIT 1
+            """,
+        ),
+        (
+            "raw_event_flush_batches(source, stream_id, start_event_seq, end_event_seq, extractor_version)",
+            """
+            SELECT source, stream_id, start_event_seq, end_event_seq, extractor_version
+            FROM raw_event_flush_batches
+            GROUP BY source, stream_id, start_event_seq, end_event_seq, extractor_version
+            HAVING COUNT(*) > 1
+            LIMIT 1
+            """,
+        ),
+        (
+            "opencode_sessions(source, stream_id)",
+            """
+            SELECT source, stream_id
+            FROM opencode_sessions
+            GROUP BY source, stream_id
+            HAVING COUNT(*) > 1
+            LIMIT 1
+            """,
+        ),
+    ]
+    for label, sql in checks:
+        row = conn.execute(sql).fetchone()
+        if row is not None:
+            raise RuntimeError(f"Raw-event identity migration collision detected in {label}")
+
+
+def _rebuild_raw_event_identity_tables(conn: sqlite3.Connection) -> None:
+    _assert_no_raw_event_identity_collisions(conn)
+
+    before_counts = {
+        "raw_events": int(conn.execute("SELECT COUNT(*) FROM raw_events").fetchone()[0]),
+        "raw_event_sessions": int(
+            conn.execute("SELECT COUNT(*) FROM raw_event_sessions").fetchone()[0]
+        ),
+        "raw_event_flush_batches": int(
+            conn.execute("SELECT COUNT(*) FROM raw_event_flush_batches").fetchone()[0]
+        ),
+        "opencode_sessions": int(
+            conn.execute("SELECT COUNT(*) FROM opencode_sessions").fetchone()[0]
+        ),
+    }
+
+    batch_columns = {
+        row[1] for row in conn.execute("PRAGMA table_info(raw_event_flush_batches)").fetchall()
+    }
+    batch_attempt_expr = "COALESCE(attempt_count, 0)" if "attempt_count" in batch_columns else "0"
+
+    conn.executescript(
+        """
+        CREATE TABLE raw_events_v2 (
+            id INTEGER PRIMARY KEY,
+            source TEXT NOT NULL DEFAULT 'opencode',
+            stream_id TEXT NOT NULL,
+            opencode_session_id TEXT NOT NULL,
+            event_id TEXT,
+            event_seq INTEGER NOT NULL,
+            event_type TEXT NOT NULL,
+            ts_wall_ms INTEGER,
+            ts_mono_ms REAL,
+            payload_json TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            UNIQUE(source, stream_id, event_seq),
+            UNIQUE(source, stream_id, event_id)
+        );
+
+        CREATE TABLE raw_event_sessions_v2 (
+            source TEXT NOT NULL DEFAULT 'opencode',
+            stream_id TEXT NOT NULL,
+            opencode_session_id TEXT NOT NULL,
+            cwd TEXT,
+            project TEXT,
+            started_at TEXT,
+            last_seen_ts_wall_ms INTEGER,
+            last_received_event_seq INTEGER NOT NULL DEFAULT -1,
+            last_flushed_event_seq INTEGER NOT NULL DEFAULT -1,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (source, stream_id)
+        );
+
+        CREATE TABLE raw_event_flush_batches_v2 (
+            id INTEGER PRIMARY KEY,
+            source TEXT NOT NULL DEFAULT 'opencode',
+            stream_id TEXT NOT NULL,
+            opencode_session_id TEXT NOT NULL,
+            start_event_seq INTEGER NOT NULL,
+            end_event_seq INTEGER NOT NULL,
+            extractor_version TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(source, stream_id, start_event_seq, end_event_seq, extractor_version)
+        );
+
+        CREATE TABLE opencode_sessions_v2 (
+            source TEXT NOT NULL DEFAULT 'opencode',
+            stream_id TEXT NOT NULL,
+            opencode_session_id TEXT NOT NULL,
+            session_id INTEGER REFERENCES sessions(id) ON DELETE CASCADE,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (source, stream_id)
+        );
+        """
+    )
+
+    conn.execute(
+        """
+        INSERT INTO raw_events_v2(
+            id,
+            source,
+            stream_id,
+            opencode_session_id,
+            event_id,
+            event_seq,
+            event_type,
+            ts_wall_ms,
+            ts_mono_ms,
+            payload_json,
+            created_at
+        )
+        SELECT
+            id,
+            source,
+            stream_id,
+            stream_id,
+            event_id,
+            event_seq,
+            event_type,
+            ts_wall_ms,
+            ts_mono_ms,
+            payload_json,
+            created_at
+        FROM raw_events
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO raw_event_sessions_v2(
+            source,
+            stream_id,
+            opencode_session_id,
+            cwd,
+            project,
+            started_at,
+            last_seen_ts_wall_ms,
+            last_received_event_seq,
+            last_flushed_event_seq,
+            updated_at
+        )
+        SELECT
+            source,
+            stream_id,
+            stream_id,
+            cwd,
+            project,
+            started_at,
+            last_seen_ts_wall_ms,
+            last_received_event_seq,
+            last_flushed_event_seq,
+            updated_at
+        FROM raw_event_sessions
+        """
+    )
+    conn.execute(
+        f"""
+        INSERT INTO raw_event_flush_batches_v2(
+            id,
+            source,
+            stream_id,
+            opencode_session_id,
+            start_event_seq,
+            end_event_seq,
+            extractor_version,
+            status,
+            created_at,
+            updated_at,
+            attempt_count
+        )
+        SELECT
+            id,
+            source,
+            stream_id,
+            stream_id,
+            start_event_seq,
+            end_event_seq,
+            extractor_version,
+            status,
+            created_at,
+            updated_at,
+            {batch_attempt_expr}
+        FROM raw_event_flush_batches
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO opencode_sessions_v2(
+            source,
+            stream_id,
+            opencode_session_id,
+            session_id,
+            created_at
+        )
+        SELECT
+            os.source,
+            os.stream_id,
+            os.stream_id,
+            CASE
+                WHEN os.session_id IS NULL THEN NULL
+                WHEN EXISTS(SELECT 1 FROM sessions s WHERE s.id = os.session_id) THEN os.session_id
+                ELSE NULL
+            END,
+            os.created_at
+        FROM opencode_sessions os
+        """
+    )
+
+    after_counts = {
+        "raw_events": int(conn.execute("SELECT COUNT(*) FROM raw_events_v2").fetchone()[0]),
+        "raw_event_sessions": int(
+            conn.execute("SELECT COUNT(*) FROM raw_event_sessions_v2").fetchone()[0]
+        ),
+        "raw_event_flush_batches": int(
+            conn.execute("SELECT COUNT(*) FROM raw_event_flush_batches_v2").fetchone()[0]
+        ),
+        "opencode_sessions": int(
+            conn.execute("SELECT COUNT(*) FROM opencode_sessions_v2").fetchone()[0]
+        ),
+    }
+    if before_counts != after_counts:
+        raise RuntimeError(
+            "Raw-event identity migration row-count mismatch; aborting rebuild "
+            f"(before={before_counts}, after={after_counts})"
+        )
+
+    conn.executescript(
+        """
+        DROP TABLE raw_events;
+        ALTER TABLE raw_events_v2 RENAME TO raw_events;
+
+        DROP TABLE raw_event_sessions;
+        ALTER TABLE raw_event_sessions_v2 RENAME TO raw_event_sessions;
+
+        DROP TABLE raw_event_flush_batches;
+        ALTER TABLE raw_event_flush_batches_v2 RENAME TO raw_event_flush_batches;
+
+        DROP TABLE opencode_sessions;
+        ALTER TABLE opencode_sessions_v2 RENAME TO opencode_sessions;
+        """
+    )
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_events_session_seq ON raw_events(opencode_session_id, event_seq)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_events_created_at ON raw_events(created_at DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_events_event_id ON raw_events(opencode_session_id, event_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_events_source_stream_event_id ON raw_events(source, stream_id, event_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_events_source_stream_seq ON raw_events(source, stream_id, event_seq)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_event_sessions_source_stream ON raw_event_sessions(source, stream_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_event_sessions_legacy_session ON raw_event_sessions(opencode_session_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_event_flush_batches_session ON raw_event_flush_batches(opencode_session_id, created_at DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_event_flush_batches_source_stream ON raw_event_flush_batches(source, stream_id, created_at DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_raw_event_flush_batches_status ON raw_event_flush_batches(status, updated_at DESC)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_opencode_sessions_session_id ON opencode_sessions(session_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_opencode_sessions_source_stream ON opencode_sessions(source, stream_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_opencode_sessions_legacy_session ON opencode_sessions(opencode_session_id)"
+    )
+
+
+def _ensure_raw_event_identity_schema(conn: sqlite3.Connection, *, migrate_data: bool) -> None:
+    if _table_exists(conn, "raw_event_sessions"):
+        _ensure_column(conn, "raw_event_sessions", "source", "TEXT NOT NULL DEFAULT 'opencode'")
+        _ensure_column(conn, "raw_event_sessions", "stream_id", "TEXT NOT NULL DEFAULT ''")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_raw_event_sessions_source_stream ON raw_event_sessions(source, stream_id)"
+        )
+
+    if _table_exists(conn, "raw_events"):
+        _ensure_column(conn, "raw_events", "event_id", "TEXT")
+        _ensure_column(conn, "raw_events", "source", "TEXT NOT NULL DEFAULT 'opencode'")
+        _ensure_column(conn, "raw_events", "stream_id", "TEXT NOT NULL DEFAULT ''")
+        _ensure_column(conn, "raw_events", "ts_wall_ms", "INTEGER")
+        _ensure_column(conn, "raw_events", "ts_mono_ms", "REAL")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_raw_events_event_id ON raw_events(opencode_session_id, event_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_raw_events_source_stream_event_id ON raw_events(source, stream_id, event_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_raw_events_source_stream_seq ON raw_events(source, stream_id, event_seq)"
+        )
+
+    if _table_exists(conn, "raw_event_flush_batches"):
+        _ensure_column(
+            conn, "raw_event_flush_batches", "source", "TEXT NOT NULL DEFAULT 'opencode'"
+        )
+        _ensure_column(conn, "raw_event_flush_batches", "stream_id", "TEXT NOT NULL DEFAULT ''")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_raw_event_flush_batches_source_stream ON raw_event_flush_batches(source, stream_id, created_at DESC)"
+        )
+
+    if _table_exists(conn, "opencode_sessions"):
+        _ensure_column(conn, "opencode_sessions", "source", "TEXT NOT NULL DEFAULT 'opencode'")
+        _ensure_column(conn, "opencode_sessions", "stream_id", "TEXT NOT NULL DEFAULT ''")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_opencode_sessions_source_stream ON opencode_sessions(source, stream_id)"
+        )
+
+    if not migrate_data:
+        return
+    _backfill_raw_event_identity_columns(conn)
+    if _raw_event_identity_needs_rebuild(conn):
+        _rebuild_raw_event_identity_tables(conn)
+
+
+def _backfill_raw_event_identity_columns(conn: sqlite3.Connection) -> None:
+    known_prefixes = {"opencode", "claude", "cursor", "codex"}
+
+    def _normalize_legacy_identity(key: str, source: str, stream_id: str) -> tuple[str, str]:
+        source_norm = source.strip().lower() or "opencode"
+        stream_norm = stream_id.strip()
+        if stream_norm:
+            if ":" in stream_norm:
+                prefix, remainder = stream_norm.split(":", 1)
+                prefix = prefix.strip().lower()
+                remainder = remainder.strip()
+                if (
+                    prefix in known_prefixes
+                    and remainder
+                    and (source_norm == "opencode" or source_norm == prefix)
+                ):
+                    return prefix, remainder
+            return source_norm, stream_norm
+
+        key_norm = key.strip()
+        if not key_norm:
+            return source_norm, key_norm
+        if ":" in key_norm:
+            prefix, remainder = key_norm.split(":", 1)
+            prefix = prefix.strip().lower()
+            remainder = remainder.strip()
+            if (
+                prefix in known_prefixes
+                and remainder
+                and (source_norm == "opencode" or source_norm == prefix)
+            ):
+                return prefix, remainder
+        return source_norm, key_norm
+
+    targets = [
+        ("raw_events", "opencode_session_id"),
+        ("raw_event_sessions", "opencode_session_id"),
+        ("raw_event_flush_batches", "opencode_session_id"),
+        ("opencode_sessions", "opencode_session_id"),
+    ]
+    for table, key_col in targets:
+        columns = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+        if key_col not in columns or "source" not in columns or "stream_id" not in columns:
+            continue
+        rows = conn.execute(
+            f"SELECT rowid AS _rid, {key_col}, source, stream_id FROM {table}"
+        ).fetchall()
+        updates: list[tuple[str, str, int]] = []
+        for row in rows:
+            key = str(row[key_col] or "").strip()
+            if not key:
+                continue
+            current_source = str(row["source"] or "").strip().lower() or "opencode"
+            current_stream = str(row["stream_id"] or "").strip()
+            source, stream_id = _normalize_legacy_identity(
+                key=key,
+                source=current_source,
+                stream_id=current_stream,
+            )
+            if current_source == source and current_stream == stream_id:
+                continue
+            updates.append((source, stream_id, int(row["_rid"])))
+        if updates:
+            conn.executemany(
+                f"UPDATE {table} SET source = ?, stream_id = ? WHERE rowid = ?",
+                updates,
+            )
 
 
 def _schema_user_version(conn: sqlite3.Connection) -> int:
@@ -463,8 +962,12 @@ def _ensure_raw_event_reliability_schema(conn: sqlite3.Connection) -> None:
 
 
 def initialize_schema(conn: sqlite3.Connection) -> None:
-    if _schema_user_version(conn) < SCHEMA_VERSION:
+    current_version = _schema_user_version(conn)
+    if current_version < 1:
         _initialize_schema_v1(conn)
+        current_version = 1
+    _ensure_raw_event_identity_schema(conn, migrate_data=current_version < SCHEMA_VERSION)
+    if current_version < SCHEMA_VERSION:
         conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     _ensure_vector_schema(conn)
     _ensure_raw_event_reliability_schema(conn)

--- a/codemem/plugin_ingest.py
+++ b/codemem/plugin_ingest.py
@@ -478,10 +478,15 @@ def ingest(payload: dict[str, Any]) -> None:
     store = MemoryStore(Path(db_path) if db_path else db.DEFAULT_DB_PATH)
     try:
         started_at = payload.get("started_at")
-        opencode_session_id = session_context.get("opencode_session_id")
-        if isinstance(opencode_session_id, str) and opencode_session_id.strip():
-            session_id = store.get_or_create_opencode_session(
-                opencode_session_id=opencode_session_id,
+        source = str(session_context.get("source") or "opencode").strip().lower() or "opencode"
+        stream_id_raw = session_context.get("stream_id") or session_context.get(
+            "opencode_session_id"
+        )
+        stream_id = str(stream_id_raw or "").strip()
+        if stream_id:
+            session_id = store.get_or_create_stream_session(
+                source=source,
+                stream_id=stream_id,
                 cwd=cwd,
                 project=project,
                 metadata={
@@ -613,11 +618,12 @@ def ingest(payload: dict[str, Any]) -> None:
             discovery_tokens = store.estimate_tokens(discovery_text)
 
         discovery_group = None
-        if isinstance(opencode_session_id, str) and opencode_session_id.strip():
+        if stream_id:
+            stream_key = stream_id if source == "opencode" else f"{source}:{stream_id}"
             if prompt_number is not None:
-                discovery_group = f"{opencode_session_id.strip()}:p{prompt_number}"
+                discovery_group = f"{stream_key}:p{prompt_number}"
             else:
-                discovery_group = f"{opencode_session_id.strip()}:unknown"
+                discovery_group = f"{stream_key}:unknown"
         elif prompt_number is not None:
             discovery_group = f"session:{session_id}:p{prompt_number}"
 

--- a/codemem/raw_event_flush.py
+++ b/codemem/raw_event_flush.py
@@ -68,6 +68,7 @@ def flush_raw_events(
     store: MemoryStore,
     *,
     opencode_session_id: str,
+    source: str = "opencode",
     cwd: str | None,
     project: str | None,
     started_at: str | None,
@@ -89,7 +90,8 @@ def flush_raw_events(
         except (TypeError, ValueError):
             return None
 
-    meta = store.raw_event_session_meta(opencode_session_id)
+    source = source.strip().lower() or "opencode"
+    meta = store.raw_event_session_meta(opencode_session_id, source=source)
     if cwd is None:
         cwd = meta.get("cwd") or os.getcwd()
     if project is None:
@@ -97,9 +99,10 @@ def flush_raw_events(
     if started_at is None:
         started_at = meta.get("started_at")
 
-    last_flushed = store.raw_event_flush_state(opencode_session_id)
+    last_flushed = store.raw_event_flush_state(opencode_session_id, source=source)
     events = store.raw_events_since_by_seq(
         opencode_session_id=opencode_session_id,
+        source=source,
         after_event_seq=last_flushed,
         limit=max_events,
     )
@@ -118,18 +121,21 @@ def flush_raw_events(
 
     batch_id, status = store.get_or_create_raw_event_flush_batch(
         opencode_session_id=opencode_session_id,
+        source=source,
         start_event_seq=start_event_seq,
         end_event_seq=last_event_seq,
         extractor_version=EXTRACTOR_VERSION,
     )
     if status == "completed":
-        store.update_raw_event_flush_state(opencode_session_id, last_event_seq)
+        store.update_raw_event_flush_state(opencode_session_id, last_event_seq, source=source)
         return {"flushed": 0, "updated_state": 1}
 
     if not store.claim_raw_event_flush_batch(batch_id):
         return {"flushed": 0, "updated_state": 0}
     session_context = build_session_context(events)
     session_context["opencode_session_id"] = opencode_session_id
+    session_context["source"] = source
+    session_context["stream_id"] = opencode_session_id
     session_context["start_event_seq"] = start_event_seq
     session_context["end_event_seq"] = last_event_seq
     session_context["flusher"] = "raw_events"
@@ -153,5 +159,5 @@ def flush_raw_events(
         store.update_raw_event_flush_batch_status(batch_id, RAW_EVENT_QUEUE_FAILED)
         raise
     store.update_raw_event_flush_batch_status(batch_id, "completed")
-    store.update_raw_event_flush_state(opencode_session_id, last_event_seq)
+    store.update_raw_event_flush_state(opencode_session_id, last_event_seq, source=source)
     return {"flushed": len(events), "updated_state": 1}

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -485,9 +485,31 @@ class MemoryStore:
         project: str | None,
         metadata: dict[str, Any] | None = None,
     ) -> int:
+        return self.get_or_create_stream_session(
+            source="opencode",
+            stream_id=opencode_session_id,
+            cwd=cwd,
+            project=project,
+            metadata=metadata,
+        )
+
+    def get_or_create_stream_session(
+        self,
+        *,
+        source: str,
+        stream_id: str,
+        cwd: str,
+        project: str | None,
+        metadata: dict[str, Any] | None = None,
+    ) -> int:
+        source_norm = source.strip().lower() or "opencode"
+        stream_norm = stream_id.strip()
+        if not stream_norm:
+            raise ValueError("stream_id is required")
+
         row = self.conn.execute(
-            "SELECT session_id FROM opencode_sessions WHERE opencode_session_id = ?",
-            (opencode_session_id,),
+            "SELECT session_id FROM opencode_sessions WHERE source = ? AND stream_id = ?",
+            (source_norm, stream_norm),
         ).fetchone()
         if row is not None and row["session_id"] is not None:
             return int(row["session_id"])
@@ -504,11 +526,13 @@ class MemoryStore:
         created_at = dt.datetime.now(dt.UTC).isoformat()
         self.conn.execute(
             """
-            INSERT INTO opencode_sessions(opencode_session_id, session_id, created_at)
-            VALUES (?, ?, ?)
-            ON CONFLICT(opencode_session_id) DO UPDATE SET session_id = excluded.session_id
+            INSERT INTO opencode_sessions(opencode_session_id, source, stream_id, session_id, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(source, stream_id) DO UPDATE SET
+                opencode_session_id = excluded.opencode_session_id,
+                session_id = excluded.session_id
             """,
-            (opencode_session_id, session_id, created_at),
+            (stream_norm, source_norm, stream_norm, session_id, created_at),
         )
         self.conn.commit()
         return session_id
@@ -517,6 +541,7 @@ class MemoryStore:
         self,
         *,
         opencode_session_id: str,
+        source: str = "opencode",
         start_event_seq: int,
         end_event_seq: int,
         extractor_version: str,
@@ -524,6 +549,7 @@ class MemoryStore:
         return store_raw_events.get_or_create_raw_event_flush_batch(
             self.conn,
             opencode_session_id=opencode_session_id,
+            source=source,
             start_event_seq=start_event_seq,
             end_event_seq=end_event_seq,
             extractor_version=extractor_version,
@@ -536,6 +562,7 @@ class MemoryStore:
         self,
         *,
         opencode_session_id: str,
+        source: str = "opencode",
         event_id: str,
         event_type: str,
         payload: dict[str, Any],
@@ -545,6 +572,7 @@ class MemoryStore:
         return store_raw_events.record_raw_event(
             self.conn,
             opencode_session_id=opencode_session_id,
+            source=source,
             event_id=event_id,
             event_type=event_type,
             payload=payload,
@@ -556,21 +584,28 @@ class MemoryStore:
         self,
         *,
         opencode_session_id: str,
+        source: str = "opencode",
         events: list[dict[str, Any]],
     ) -> dict[str, int]:
         return store_raw_events.record_raw_events_batch(
             self.conn,
             opencode_session_id=opencode_session_id,
+            source=source,
             events=events,
         )
 
-    def raw_event_flush_state(self, opencode_session_id: str) -> int:
-        return store_raw_events.raw_event_flush_state(self.conn, opencode_session_id)
+    def raw_event_flush_state(self, opencode_session_id: str, *, source: str = "opencode") -> int:
+        return store_raw_events.raw_event_flush_state(
+            self.conn,
+            opencode_session_id,
+            source=source,
+        )
 
     def update_raw_event_session_meta(
         self,
         *,
         opencode_session_id: str,
+        source: str = "opencode",
         cwd: str | None = None,
         project: str | None = None,
         started_at: str | None = None,
@@ -579,31 +614,55 @@ class MemoryStore:
         store_raw_events.update_raw_event_session_meta(
             self.conn,
             opencode_session_id=opencode_session_id,
+            source=source,
             cwd=cwd,
             project=project,
             started_at=started_at,
             last_seen_ts_wall_ms=last_seen_ts_wall_ms,
         )
 
-    def raw_event_session_meta(self, opencode_session_id: str) -> dict[str, Any]:
-        return store_raw_events.raw_event_session_meta(self.conn, opencode_session_id)
+    def raw_event_session_meta(
+        self, opencode_session_id: str, *, source: str = "opencode"
+    ) -> dict[str, Any]:
+        return store_raw_events.raw_event_session_meta(
+            self.conn,
+            opencode_session_id,
+            source=source,
+        )
 
-    def update_raw_event_flush_state(self, opencode_session_id: str, last_flushed: int) -> None:
-        store_raw_events.update_raw_event_flush_state(self.conn, opencode_session_id, last_flushed)
+    def update_raw_event_flush_state(
+        self,
+        opencode_session_id: str,
+        last_flushed: int,
+        *,
+        source: str = "opencode",
+    ) -> None:
+        store_raw_events.update_raw_event_flush_state(
+            self.conn,
+            opencode_session_id,
+            last_flushed,
+            source=source,
+        )
 
-    def max_raw_event_seq(self, opencode_session_id: str) -> int:
-        return store_raw_events.max_raw_event_seq(self.conn, opencode_session_id)
+    def max_raw_event_seq(self, opencode_session_id: str, *, source: str = "opencode") -> int:
+        return store_raw_events.max_raw_event_seq(
+            self.conn,
+            opencode_session_id,
+            source=source,
+        )
 
     def raw_events_since(
         self,
         *,
         opencode_session_id: str,
+        source: str = "opencode",
         after_event_seq: int,
         limit: int | None = None,
     ) -> list[dict[str, Any]]:
         return store_raw_events.raw_events_since(
             self.conn,
             opencode_session_id=opencode_session_id,
+            source=source,
             after_event_seq=after_event_seq,
             limit=limit,
         )
@@ -612,12 +671,14 @@ class MemoryStore:
         self,
         *,
         opencode_session_id: str,
+        source: str = "opencode",
         after_event_seq: int,
         limit: int | None = None,
     ) -> list[dict[str, Any]]:
         return store_raw_events.raw_events_since_by_seq(
             self.conn,
             opencode_session_id=opencode_session_id,
+            source=source,
             after_event_seq=after_event_seq,
             limit=limit,
         )
@@ -627,14 +688,14 @@ class MemoryStore:
         *,
         idle_before_ts_wall_ms: int,
         limit: int = 25,
-    ) -> list[str]:
+    ) -> list[dict[str, str]]:
         return store_raw_events.raw_event_sessions_pending_idle_flush(
             self.conn,
             idle_before_ts_wall_ms=idle_before_ts_wall_ms,
             limit=limit,
         )
 
-    def raw_event_sessions_with_pending_queue(self, *, limit: int = 25) -> list[str]:
+    def raw_event_sessions_with_pending_queue(self, *, limit: int = 25) -> list[dict[str, str]]:
         return store_raw_events.raw_event_sessions_with_pending_queue(self.conn, limit=limit)
 
     def purge_raw_events_before(self, cutoff_ts_wall_ms: int) -> int:
@@ -649,21 +710,44 @@ class MemoryStore:
     def raw_event_backlog_totals(self) -> dict[str, int]:
         return store_raw_events.raw_event_backlog_totals(self.conn)
 
-    def raw_event_batch_status_counts(self, opencode_session_id: str) -> dict[str, int]:
-        return store_raw_events.raw_event_batch_status_counts(self.conn, opencode_session_id)
+    def raw_event_batch_status_counts(
+        self,
+        opencode_session_id: str,
+        *,
+        source: str = "opencode",
+    ) -> dict[str, int]:
+        return store_raw_events.raw_event_batch_status_counts(
+            self.conn,
+            opencode_session_id,
+            source=source,
+        )
 
-    def raw_event_queue_status_counts(self, opencode_session_id: str) -> dict[str, int]:
-        return store_raw_events.raw_event_queue_status_counts(self.conn, opencode_session_id)
+    def raw_event_queue_status_counts(
+        self,
+        opencode_session_id: str,
+        *,
+        source: str = "opencode",
+    ) -> dict[str, int]:
+        return store_raw_events.raw_event_queue_status_counts(
+            self.conn,
+            opencode_session_id,
+            source=source,
+        )
 
     def claim_raw_event_flush_batch(self, batch_id: int) -> bool:
         return store_raw_events.claim_raw_event_flush_batch(self.conn, batch_id)
 
     def raw_event_error_batches(
-        self, opencode_session_id: str, limit: int = 10
+        self,
+        opencode_session_id: str,
+        *,
+        source: str = "opencode",
+        limit: int = 10,
     ) -> list[dict[str, Any]]:
         return store_raw_events.raw_event_error_batches(
             self.conn,
             opencode_session_id,
+            source=source,
             limit=limit,
         )
 

--- a/codemem/store/maintenance.py
+++ b/codemem/store/maintenance.py
@@ -29,7 +29,9 @@ def _safe_json_list(value: str | None) -> list[str]:
     return items
 
 
-def _session_discovery_tokens_from_raw_events(store: MemoryStore, opencode_session_id: str) -> int:
+def _session_discovery_tokens_from_raw_events(
+    store: MemoryStore, *, source: str, stream_id: str
+) -> int:
     row = store.conn.execute(
         """
         SELECT
@@ -45,11 +47,12 @@ def _session_discovery_tokens_from_raw_events(store: MemoryStore, opencode_sessi
                 0
             ) AS total_tokens
         FROM raw_events
-        WHERE opencode_session_id = ?
+        WHERE source = ?
+          AND stream_id = ?
           AND event_type = 'assistant_usage'
           AND json_valid(payload_json) = 1
         """,
-        (opencode_session_id,),
+        (source, stream_id),
     ).fetchone()
     if row is None:
         return 0
@@ -57,7 +60,7 @@ def _session_discovery_tokens_from_raw_events(store: MemoryStore, opencode_sessi
 
 
 def _session_discovery_tokens_by_prompt(
-    store: MemoryStore, opencode_session_id: str
+    store: MemoryStore, *, source: str, stream_id: str
 ) -> dict[int, int]:
     rows = store.conn.execute(
         """
@@ -75,13 +78,14 @@ def _session_discovery_tokens_by_prompt(
                 0
             ) AS total_tokens
         FROM raw_events
-        WHERE opencode_session_id = ?
+        WHERE source = ?
+          AND stream_id = ?
           AND event_type = 'assistant_usage'
           AND json_valid(payload_json) = 1
           AND json_extract(payload_json, '$.prompt_number') IS NOT NULL
         GROUP BY CAST(json_extract(payload_json, '$.prompt_number') AS INTEGER)
         """,
-        (opencode_session_id,),
+        (source, stream_id),
     ).fetchall()
     totals: dict[int, int] = {}
     for row in rows:
@@ -178,7 +182,11 @@ def backfill_discovery_tokens(store: MemoryStore, *, limit_sessions: int = 50) -
 
     target_rows = store.conn.execute(
         """
-        SELECT DISTINCT s.id AS session_id, os.opencode_session_id AS opencode_session_id
+        SELECT DISTINCT
+            s.id AS session_id,
+            os.source AS source,
+            os.stream_id AS stream_id,
+            os.opencode_session_id AS opencode_session_id
         FROM sessions s
         JOIN opencode_sessions os ON os.session_id = s.id
         JOIN memory_items mi ON mi.session_id = s.id
@@ -196,8 +204,9 @@ def backfill_discovery_tokens(store: MemoryStore, *, limit_sessions: int = 50) -
     updated = 0
     for row in target_rows:
         session_id = int(row["session_id"])
-        opencode_session_id = str(row["opencode_session_id"] or "").strip()
-        if not opencode_session_id:
+        source = str(row["source"] or "").strip().lower() or "opencode"
+        stream_id = str(row["stream_id"] or "").strip()
+        if not stream_id:
             continue
 
         items = store.conn.execute(
@@ -229,14 +238,18 @@ def backfill_discovery_tokens(store: MemoryStore, *, limit_sessions: int = 50) -
         if not grouped:
             continue
 
-        by_prompt = _session_discovery_tokens_by_prompt(store, opencode_session_id)
-        session_tokens = _session_discovery_tokens_from_raw_events(store, opencode_session_id)
+        by_prompt = _session_discovery_tokens_by_prompt(store, source=source, stream_id=stream_id)
+        session_tokens = _session_discovery_tokens_from_raw_events(
+            store,
+            source=source,
+            stream_id=stream_id,
+        )
         source_label = "usage" if session_tokens > 0 else "estimate"
         if session_tokens <= 0:
             session_tokens = _session_discovery_tokens_from_transcript(store, session_id)
 
         group_tokens: dict[int | None, int] = {}
-        keys = sorted(grouped.keys(), key=lambda k: (-1 if k is None else k))
+        keys = sorted(grouped.keys(), key=lambda k: -1 if k is None else k)
         if by_prompt:
             assigned = 0
             for key in keys:
@@ -269,11 +282,9 @@ def backfill_discovery_tokens(store: MemoryStore, *, limit_sessions: int = 50) -
                     group_tokens[key] = max(0, int(total))
 
         now = store._now_iso()
+        stream_key = stream_id if source == "opencode" else f"{source}:{stream_id}"
         for key, group_items in grouped.items():
-            if key is None:
-                group_id = f"{opencode_session_id}:unknown"
-            else:
-                group_id = f"{opencode_session_id}:p{key}"
+            group_id = f"{stream_key}:unknown" if key is None else f"{stream_key}:p{key}"
             tokens_value = group_tokens.get(key)
             tokens = int(tokens_value) if isinstance(tokens_value, int) else 0
             for memory_id, meta in group_items:
@@ -481,7 +492,7 @@ def normalize_projects(store: MemoryStore, *, dry_run: bool = True) -> dict[str,
         "SELECT id, cwd, project FROM sessions ORDER BY started_at DESC"
     ).fetchall()
     raw_rows = store.conn.execute(
-        "SELECT opencode_session_id, cwd, project FROM raw_event_sessions"
+        "SELECT source, stream_id, cwd, project FROM raw_event_sessions"
     ).fetchall()
     usage_rows = store.conn.execute(
         "SELECT id, metadata_json FROM usage_events WHERE event = 'pack'"
@@ -513,9 +524,12 @@ def normalize_projects(store: MemoryStore, *, dry_run: bool = True) -> dict[str,
         if new_value is not None and new_value != proj:
             session_updates.append((new_value, session_id))
 
-    raw_updates: list[tuple[str | None, str]] = []
+    raw_updates: list[tuple[str | None, str, str]] = []
     for row in raw_rows:
-        opencode_session_id = str(row["opencode_session_id"])
+        source = str(row["source"] or "").strip().lower() or "opencode"
+        stream_id = str(row["stream_id"] or "").strip()
+        if not stream_id:
+            continue
         cwd = row["cwd"]
         project = row["project"]
         if not project or not isinstance(project, str):
@@ -533,7 +547,7 @@ def normalize_projects(store: MemoryStore, *, dry_run: bool = True) -> dict[str,
                 new_value = base
                 rewritten_paths.setdefault(proj, base)
         if new_value is not None and new_value != proj:
-            raw_updates.append((new_value, opencode_session_id))
+            raw_updates.append((new_value, source, stream_id))
 
     usage_updates: list[tuple[str, int]] = []
     for row in usage_rows:
@@ -572,10 +586,10 @@ def normalize_projects(store: MemoryStore, *, dry_run: bool = True) -> dict[str,
             "UPDATE sessions SET project = ? WHERE id = ?",
             (project, session_id),
         )
-    for project, opencode_session_id in raw_updates:
+    for project, source, stream_id in raw_updates:
         store.conn.execute(
-            "UPDATE raw_event_sessions SET project = ? WHERE opencode_session_id = ?",
-            (project, opencode_session_id),
+            "UPDATE raw_event_sessions SET project = ? WHERE source = ? AND stream_id = ?",
+            (project, source, stream_id),
         )
     for metadata_json, usage_id in usage_updates:
         store.conn.execute(
@@ -626,7 +640,7 @@ def rename_project(
 
     raw_rows = store.conn.execute(
         """
-        SELECT opencode_session_id, project FROM raw_event_sessions
+        SELECT source, stream_id, project FROM raw_event_sessions
         WHERE project = ?
            OR project LIKE ? ESCAPE '!'
            OR project LIKE ? ESCAPE '!'
@@ -668,8 +682,12 @@ def rename_project(
             )
         for row in raw_rows:
             store.conn.execute(
-                "UPDATE raw_event_sessions SET project = ? WHERE opencode_session_id = ?",
-                (new_basename, str(row["opencode_session_id"])),
+                "UPDATE raw_event_sessions SET project = ? WHERE source = ? AND stream_id = ?",
+                (
+                    new_basename,
+                    str(row["source"] or "").strip().lower() or "opencode",
+                    str(row["stream_id"] or "").strip(),
+                ),
             )
         for metadata_json, usage_id in usage_updates:
             store.conn.execute(

--- a/codemem/store/raw_events.py
+++ b/codemem/store/raw_events.py
@@ -24,6 +24,14 @@ _RAW_EVENT_QUEUE_DB_TO_CANONICAL = {
 }
 
 
+def _normalize_stream_identity(*, source: str, stream_id: str) -> tuple[str, str]:
+    source_norm = source.strip().lower() or "opencode"
+    stream_norm = stream_id.strip()
+    if not stream_norm:
+        raise ValueError("stream_id is required")
+    return source_norm, stream_norm
+
+
 def _update_raw_event_ingest_stats(
     conn: sqlite3.Connection,
     *,
@@ -82,14 +90,21 @@ def get_or_create_raw_event_flush_batch(
     conn: sqlite3.Connection,
     *,
     opencode_session_id: str,
+    source: str = "opencode",
     start_event_seq: int,
     end_event_seq: int,
     extractor_version: str,
 ) -> tuple[int, str]:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     now = dt.datetime.now(dt.UTC).isoformat()
     cur = conn.execute(
         """
         INSERT INTO raw_event_flush_batches(
+            source,
+            stream_id,
             opencode_session_id,
             start_event_seq,
             end_event_seq,
@@ -98,13 +113,15 @@ def get_or_create_raw_event_flush_batch(
             created_at,
             updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(opencode_session_id, start_event_seq, end_event_seq, extractor_version)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(source, stream_id, start_event_seq, end_event_seq, extractor_version)
         DO UPDATE SET updated_at = excluded.updated_at
         RETURNING id, status
         """,
         (
-            opencode_session_id,
+            source,
+            stream_id,
+            stream_id,
             start_event_seq,
             end_event_seq,
             extractor_version,
@@ -136,6 +153,7 @@ def record_raw_event(
     conn: sqlite3.Connection,
     *,
     opencode_session_id: str,
+    source: str = "opencode",
     event_id: str,
     event_type: str,
     payload: dict[str, Any],
@@ -148,11 +166,15 @@ def record_raw_event(
         raise ValueError("event_id is required")
     if not event_type.strip():
         raise ValueError("event_type is required")
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
 
     # Server-assigned sequencing. This avoids event_seq collisions when the plugin reloads.
     cur = conn.execute(
-        "SELECT 1 FROM raw_events WHERE opencode_session_id = ? AND event_id = ?",
-        (opencode_session_id, event_id),
+        "SELECT 1 FROM raw_events WHERE source = ? AND stream_id = ? AND event_id = ?",
+        (source, stream_id, event_id),
     ).fetchone()
     if cur is not None:
         _update_raw_event_ingest_stats(
@@ -166,17 +188,17 @@ def record_raw_event(
         return False
 
     existing = conn.execute(
-        "SELECT 1 FROM raw_event_sessions WHERE opencode_session_id = ?",
-        (opencode_session_id,),
+        "SELECT 1 FROM raw_event_sessions WHERE source = ? AND stream_id = ?",
+        (source, stream_id),
     ).fetchone()
     if existing is None:
         now = dt.datetime.now(dt.UTC).isoformat()
         conn.execute(
             """
-            INSERT INTO raw_event_sessions(opencode_session_id, updated_at)
-            VALUES (?, ?)
+            INSERT INTO raw_event_sessions(opencode_session_id, source, stream_id, updated_at)
+            VALUES (?, ?, ?, ?)
             """,
-            (opencode_session_id, now),
+            (stream_id, source, stream_id, now),
         )
 
     row = conn.execute(
@@ -184,10 +206,10 @@ def record_raw_event(
         UPDATE raw_event_sessions
         SET last_received_event_seq = last_received_event_seq + 1,
             updated_at = ?
-        WHERE opencode_session_id = ?
+        WHERE source = ? AND stream_id = ?
         RETURNING last_received_event_seq
         """,
-        (dt.datetime.now(dt.UTC).isoformat(), opencode_session_id),
+        (dt.datetime.now(dt.UTC).isoformat(), source, stream_id),
     ).fetchone()
     if row is None:
         raise RuntimeError("Failed to allocate raw event seq")
@@ -197,6 +219,8 @@ def record_raw_event(
     conn.execute(
         """
         INSERT INTO raw_events(
+            source,
+            stream_id,
             opencode_session_id,
             event_id,
             event_seq,
@@ -206,10 +230,12 @@ def record_raw_event(
             payload_json,
             created_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
-            opencode_session_id,
+            source,
+            stream_id,
+            stream_id,
             event_id,
             event_seq,
             event_type,
@@ -234,10 +260,15 @@ def record_raw_events_batch(
     conn: sqlite3.Connection,
     *,
     opencode_session_id: str,
+    source: str = "opencode",
     events: list[dict[str, Any]],
 ) -> dict[str, int]:
     if not opencode_session_id.strip():
         raise ValueError("opencode_session_id is required")
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     inserted = 0
     skipped_invalid = 0
     skipped_duplicate = 0
@@ -245,13 +276,13 @@ def record_raw_events_batch(
     now = dt.datetime.now(dt.UTC).isoformat()
     with conn:
         existing = conn.execute(
-            "SELECT 1 FROM raw_event_sessions WHERE opencode_session_id = ?",
-            (opencode_session_id,),
+            "SELECT 1 FROM raw_event_sessions WHERE source = ? AND stream_id = ?",
+            (source, stream_id),
         ).fetchone()
         if existing is None:
             conn.execute(
-                "INSERT INTO raw_event_sessions(opencode_session_id, updated_at) VALUES (?, ?)",
-                (opencode_session_id, now),
+                "INSERT INTO raw_event_sessions(opencode_session_id, source, stream_id, updated_at) VALUES (?, ?, ?, ?)",
+                (stream_id, source, stream_id, now),
             )
 
         normalized: list[dict[str, Any]] = []
@@ -298,8 +329,8 @@ def record_raw_events_batch(
             chunk = normalized[i : i + chunk_size]
             placeholders = ",".join("?" for _ in chunk)
             rows = conn.execute(
-                f"SELECT event_id FROM raw_events WHERE opencode_session_id = ? AND event_id IN ({placeholders})",
-                [opencode_session_id, *[e["event_id"] for e in chunk]],
+                f"SELECT event_id FROM raw_events WHERE source = ? AND stream_id = ? AND event_id IN ({placeholders})",
+                [source, stream_id, *[e["event_id"] for e in chunk]],
             ).fetchall()
             for row in rows:
                 existing_ids.add(str(row["event_id"]))
@@ -322,10 +353,10 @@ def record_raw_events_batch(
             UPDATE raw_event_sessions
             SET last_received_event_seq = last_received_event_seq + ?,
                 updated_at = ?
-            WHERE opencode_session_id = ?
+            WHERE source = ? AND stream_id = ?
             RETURNING last_received_event_seq
             """,
-            (len(new_events), now, opencode_session_id),
+            (len(new_events), now, source, stream_id),
         ).fetchone()
         if row is None:
             raise RuntimeError("Failed to allocate raw event seq")
@@ -337,6 +368,8 @@ def record_raw_events_batch(
                 conn.execute(
                     """
                     INSERT INTO raw_events(
+                        source,
+                        stream_id,
                         opencode_session_id,
                         event_id,
                         event_seq,
@@ -346,10 +379,12 @@ def record_raw_events_batch(
                         payload_json,
                         created_at
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
-                        opencode_session_id,
+                        source,
+                        stream_id,
+                        stream_id,
                         event["event_id"],
                         start_seq + offset,
                         event["event_type"],
@@ -452,14 +487,14 @@ def raw_event_reliability_metrics_windowed(
 
     boundary_query = """
         WITH has_events AS (
-            SELECT DISTINCT opencode_session_id
+            SELECT DISTINCT source, stream_id
             FROM raw_events
         )
         SELECT
             COUNT(1) AS sessions_with_events,
             SUM(CASE WHEN COALESCE(s.started_at, '') != '' THEN 1 ELSE 0 END) AS sessions_with_started_at
         FROM has_events e
-        LEFT JOIN raw_event_sessions s ON s.opencode_session_id = e.opencode_session_id
+        LEFT JOIN raw_event_sessions s ON s.source = e.source AND s.stream_id = e.stream_id
     """
     if cutoff_iso is None:
         boundary_counts = conn.execute(boundary_query).fetchone()
@@ -467,7 +502,7 @@ def raw_event_reliability_metrics_windowed(
         boundary_counts = conn.execute(
             """
             WITH has_events AS (
-                SELECT DISTINCT opencode_session_id
+                SELECT DISTINCT source, stream_id
                 FROM raw_events
                 WHERE created_at >= ?
             )
@@ -475,7 +510,7 @@ def raw_event_reliability_metrics_windowed(
                 COUNT(1) AS sessions_with_events,
                 SUM(CASE WHEN COALESCE(s.started_at, '') != '' THEN 1 ELSE 0 END) AS sessions_with_started_at
             FROM has_events e
-            LEFT JOIN raw_event_sessions s ON s.opencode_session_id = e.opencode_session_id
+            LEFT JOIN raw_event_sessions s ON s.source = e.source AND s.stream_id = e.stream_id
             """,
             (cutoff_iso,),
         ).fetchone()
@@ -523,10 +558,19 @@ def raw_event_reliability_metrics_windowed(
     }
 
 
-def raw_event_flush_state(conn: sqlite3.Connection, opencode_session_id: str) -> int:
+def raw_event_flush_state(
+    conn: sqlite3.Connection,
+    opencode_session_id: str,
+    *,
+    source: str = "opencode",
+) -> int:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     row = conn.execute(
-        "SELECT last_flushed_event_seq FROM raw_event_sessions WHERE opencode_session_id = ?",
-        (opencode_session_id,),
+        "SELECT last_flushed_event_seq FROM raw_event_sessions WHERE source = ? AND stream_id = ?",
+        (source, stream_id),
     ).fetchone()
     if row is None:
         return -1
@@ -537,24 +581,32 @@ def update_raw_event_session_meta(
     conn: sqlite3.Connection,
     *,
     opencode_session_id: str,
+    source: str = "opencode",
     cwd: str | None = None,
     project: str | None = None,
     started_at: str | None = None,
     last_seen_ts_wall_ms: int | None = None,
 ) -> None:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     now = dt.datetime.now(dt.UTC).isoformat()
     conn.execute(
         """
         INSERT INTO raw_event_sessions(
             opencode_session_id,
+            source,
+            stream_id,
             cwd,
             project,
             started_at,
             last_seen_ts_wall_ms,
             updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?)
-        ON CONFLICT(opencode_session_id) DO UPDATE SET
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(source, stream_id) DO UPDATE SET
+            opencode_session_id = excluded.opencode_session_id,
             cwd = COALESCE(excluded.cwd, raw_event_sessions.cwd),
             project = COALESCE(excluded.project, raw_event_sessions.project),
             started_at = COALESCE(excluded.started_at, raw_event_sessions.started_at),
@@ -566,19 +618,37 @@ def update_raw_event_session_meta(
             END,
             updated_at = excluded.updated_at
         """,
-        (opencode_session_id, cwd, project, started_at, last_seen_ts_wall_ms, now),
+        (
+            stream_id,
+            source,
+            stream_id,
+            cwd,
+            project,
+            started_at,
+            last_seen_ts_wall_ms,
+            now,
+        ),
     )
     conn.commit()
 
 
-def raw_event_session_meta(conn: sqlite3.Connection, opencode_session_id: str) -> dict[str, Any]:
+def raw_event_session_meta(
+    conn: sqlite3.Connection,
+    opencode_session_id: str,
+    *,
+    source: str = "opencode",
+) -> dict[str, Any]:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     row = conn.execute(
         """
         SELECT cwd, project, started_at, last_seen_ts_wall_ms, last_flushed_event_seq
         FROM raw_event_sessions
-        WHERE opencode_session_id = ?
+        WHERE source = ? AND stream_id = ?
         """,
-        (opencode_session_id,),
+        (source, stream_id),
     ).fetchone()
     if row is None:
         return {}
@@ -592,26 +662,44 @@ def raw_event_session_meta(conn: sqlite3.Connection, opencode_session_id: str) -
 
 
 def update_raw_event_flush_state(
-    conn: sqlite3.Connection, opencode_session_id: str, last_flushed: int
+    conn: sqlite3.Connection,
+    opencode_session_id: str,
+    last_flushed: int,
+    *,
+    source: str = "opencode",
 ) -> None:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     now = dt.datetime.now(dt.UTC).isoformat()
     conn.execute(
         """
-        INSERT INTO raw_event_sessions(opencode_session_id, last_flushed_event_seq, updated_at)
-        VALUES (?, ?, ?)
-        ON CONFLICT(opencode_session_id) DO UPDATE SET
+        INSERT INTO raw_event_sessions(opencode_session_id, source, stream_id, last_flushed_event_seq, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(source, stream_id) DO UPDATE SET
+            opencode_session_id = excluded.opencode_session_id,
             last_flushed_event_seq = excluded.last_flushed_event_seq,
             updated_at = excluded.updated_at
         """,
-        (opencode_session_id, last_flushed, now),
+        (stream_id, source, stream_id, last_flushed, now),
     )
     conn.commit()
 
 
-def max_raw_event_seq(conn: sqlite3.Connection, opencode_session_id: str) -> int:
+def max_raw_event_seq(
+    conn: sqlite3.Connection,
+    opencode_session_id: str,
+    *,
+    source: str = "opencode",
+) -> int:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     row = conn.execute(
-        "SELECT MAX(event_seq) AS max_seq FROM raw_events WHERE opencode_session_id = ?",
-        (opencode_session_id,),
+        "SELECT MAX(event_seq) AS max_seq FROM raw_events WHERE source = ? AND stream_id = ?",
+        (source, stream_id),
     ).fetchone()
     if row is None:
         return -1
@@ -623,18 +711,23 @@ def raw_events_since(
     conn: sqlite3.Connection,
     *,
     opencode_session_id: str,
+    source: str = "opencode",
     after_event_seq: int,
     limit: int | None = None,
 ) -> list[dict[str, Any]]:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     limit_clause = "LIMIT ?" if limit else ""
-    params: list[Any] = [opencode_session_id, after_event_seq]
+    params: list[Any] = [source, stream_id, after_event_seq]
     if limit:
         params.append(limit)
     rows = conn.execute(
         f"""
         SELECT event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, event_id
         FROM raw_events
-        WHERE opencode_session_id = ? AND event_seq > ?
+        WHERE source = ? AND stream_id = ? AND event_seq > ?
         ORDER BY (ts_mono_ms IS NULL) ASC, ts_mono_ms ASC, event_seq ASC
         {limit_clause}
         """,
@@ -658,18 +751,23 @@ def raw_events_since_by_seq(
     conn: sqlite3.Connection,
     *,
     opencode_session_id: str,
+    source: str = "opencode",
     after_event_seq: int,
     limit: int | None = None,
 ) -> list[dict[str, Any]]:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     limit_clause = "LIMIT ?" if limit else ""
-    params: list[Any] = [opencode_session_id, after_event_seq]
+    params: list[Any] = [source, stream_id, after_event_seq]
     if limit:
         params.append(limit)
     rows = conn.execute(
         f"""
         SELECT event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, event_id
         FROM raw_events
-        WHERE opencode_session_id = ? AND event_seq > ?
+        WHERE source = ? AND stream_id = ? AND event_seq > ?
         ORDER BY event_seq ASC
         {limit_clause}
         """,
@@ -694,17 +792,17 @@ def raw_event_sessions_pending_idle_flush(
     *,
     idle_before_ts_wall_ms: int,
     limit: int = 25,
-) -> list[str]:
+) -> list[dict[str, str]]:
     rows = conn.execute(
         """
         WITH max_events AS (
-            SELECT opencode_session_id, MAX(event_seq) AS max_seq
+            SELECT source, stream_id, MAX(event_seq) AS max_seq
             FROM raw_events
-            GROUP BY opencode_session_id
+            GROUP BY source, stream_id
         )
-        SELECT s.opencode_session_id
+        SELECT s.source, s.stream_id
         FROM raw_event_sessions s
-        JOIN max_events e ON e.opencode_session_id = s.opencode_session_id
+        JOIN max_events e ON e.source = s.source AND e.stream_id = s.stream_id
         WHERE s.last_seen_ts_wall_ms IS NOT NULL
           AND s.last_seen_ts_wall_ms <= ?
           AND e.max_seq > s.last_flushed_event_seq
@@ -713,40 +811,49 @@ def raw_event_sessions_pending_idle_flush(
         """,
         (idle_before_ts_wall_ms, limit),
     ).fetchall()
-    return [str(row["opencode_session_id"]) for row in rows if row["opencode_session_id"]]
+    return [
+        {"source": str(row["source"] or "opencode"), "stream_id": str(row["stream_id"] or "")}
+        for row in rows
+        if row["stream_id"]
+    ]
 
 
 def raw_event_sessions_with_pending_queue(
     conn: sqlite3.Connection,
     *,
     limit: int = 25,
-) -> list[str]:
+) -> list[dict[str, str]]:
     rows = conn.execute(
         """
         WITH pending_batches AS (
             SELECT
-              b.opencode_session_id,
+              b.source,
+              b.stream_id,
               MIN(b.updated_at) AS oldest_pending_update
             FROM raw_event_flush_batches b
             WHERE b.status IN ('pending', 'failed', 'started', 'error')
-            GROUP BY b.opencode_session_id
+            GROUP BY b.source, b.stream_id
         ),
         max_events AS (
-            SELECT opencode_session_id, MAX(event_seq) AS max_seq
+            SELECT source, stream_id, MAX(event_seq) AS max_seq
             FROM raw_events
-            GROUP BY opencode_session_id
+            GROUP BY source, stream_id
         )
-        SELECT b.opencode_session_id
+        SELECT b.source, b.stream_id
         FROM pending_batches b
-        JOIN max_events e ON e.opencode_session_id = b.opencode_session_id
-        LEFT JOIN raw_event_sessions s ON s.opencode_session_id = b.opencode_session_id
+        JOIN max_events e ON e.source = b.source AND e.stream_id = b.stream_id
+        LEFT JOIN raw_event_sessions s ON s.source = b.source AND s.stream_id = b.stream_id
         WHERE e.max_seq > COALESCE(s.last_flushed_event_seq, -1)
         ORDER BY b.oldest_pending_update ASC
         LIMIT ?
         """,
         (limit,),
     ).fetchall()
-    return [str(row["opencode_session_id"]) for row in rows if row["opencode_session_id"]]
+    return [
+        {"source": str(row["source"] or "opencode"), "stream_id": str(row["stream_id"] or "")}
+        for row in rows
+        if row["stream_id"]
+    ]
 
 
 def purge_raw_events_before(conn: sqlite3.Connection, cutoff_ts_wall_ms: int) -> int:
@@ -775,12 +882,14 @@ def raw_event_backlog(conn: sqlite3.Connection, *, limit: int = 25) -> list[dict
     rows = conn.execute(
         """
         WITH max_events AS (
-            SELECT opencode_session_id, MAX(event_seq) AS max_seq
+            SELECT source, stream_id, MAX(event_seq) AS max_seq
             FROM raw_events
-            GROUP BY opencode_session_id
+            GROUP BY source, stream_id
         )
         SELECT
           s.opencode_session_id,
+          s.source,
+          s.stream_id,
           s.project,
           s.cwd,
           s.started_at,
@@ -789,7 +898,7 @@ def raw_event_backlog(conn: sqlite3.Connection, *, limit: int = 25) -> list[dict
           e.max_seq,
           (e.max_seq - s.last_flushed_event_seq) AS pending
         FROM raw_event_sessions s
-        JOIN max_events e ON e.opencode_session_id = s.opencode_session_id
+        JOIN max_events e ON e.source = s.source AND e.stream_id = s.stream_id
         WHERE e.max_seq > s.last_flushed_event_seq
         ORDER BY s.last_seen_ts_wall_ms DESC
         LIMIT ?
@@ -803,15 +912,15 @@ def raw_event_backlog_totals(conn: sqlite3.Connection) -> dict[str, int]:
     row = conn.execute(
         """
         WITH max_events AS (
-            SELECT opencode_session_id, MAX(event_seq) AS max_seq
+            SELECT source, stream_id, MAX(event_seq) AS max_seq
             FROM raw_events
-            GROUP BY opencode_session_id
+            GROUP BY source, stream_id
         )
         SELECT
           COUNT(1) AS sessions,
           SUM(e.max_seq - s.last_flushed_event_seq) AS pending
         FROM raw_event_sessions s
-        JOIN max_events e ON e.opencode_session_id = s.opencode_session_id
+        JOIN max_events e ON e.source = s.source AND e.stream_id = s.stream_id
         WHERE e.max_seq > s.last_flushed_event_seq
         """
     ).fetchone()
@@ -823,16 +932,23 @@ def raw_event_backlog_totals(conn: sqlite3.Connection) -> dict[str, int]:
 
 
 def raw_event_batch_status_counts(
-    conn: sqlite3.Connection, opencode_session_id: str
+    conn: sqlite3.Connection,
+    opencode_session_id: str,
+    *,
+    source: str = "opencode",
 ) -> dict[str, int]:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     rows = conn.execute(
         """
         SELECT status, COUNT(*) AS n
         FROM raw_event_flush_batches
-        WHERE opencode_session_id = ?
+        WHERE source = ? AND stream_id = ?
         GROUP BY status
         """,
-        (opencode_session_id,),
+        (source, stream_id),
     ).fetchall()
     counts = {"started": 0, "running": 0, "completed": 0, "error": 0}
     for row in rows:
@@ -850,16 +966,23 @@ def raw_event_batch_status_counts(
 
 
 def raw_event_queue_status_counts(
-    conn: sqlite3.Connection, opencode_session_id: str
+    conn: sqlite3.Connection,
+    opencode_session_id: str,
+    *,
+    source: str = "opencode",
 ) -> dict[str, int]:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     rows = conn.execute(
         """
         SELECT status, COUNT(*) AS n
         FROM raw_event_flush_batches
-        WHERE opencode_session_id = ?
+        WHERE source = ? AND stream_id = ?
         GROUP BY status
         """,
-        (opencode_session_id,),
+        (source, stream_id),
     ).fetchall()
     counts = {
         RAW_EVENT_QUEUE_PENDING: 0,
@@ -898,17 +1021,25 @@ def claim_raw_event_flush_batch(conn: sqlite3.Connection, batch_id: int) -> bool
 
 
 def raw_event_error_batches(
-    conn: sqlite3.Connection, opencode_session_id: str, limit: int = 10
+    conn: sqlite3.Connection,
+    opencode_session_id: str,
+    *,
+    source: str = "opencode",
+    limit: int = 10,
 ) -> list[dict[str, Any]]:
+    source, stream_id = _normalize_stream_identity(
+        source=source,
+        stream_id=opencode_session_id,
+    )
     rows = conn.execute(
         """
         SELECT id, start_event_seq, end_event_seq, extractor_version, status, updated_at
         FROM raw_event_flush_batches
-        WHERE opencode_session_id = ? AND status IN ('error', ?)
+        WHERE source = ? AND stream_id = ? AND status IN ('error', ?)
         ORDER BY updated_at DESC
         LIMIT ?
         """,
-        (opencode_session_id, RAW_EVENT_QUEUE_FAILED, limit),
+        (source, stream_id, RAW_EVENT_QUEUE_FAILED, limit),
     ).fetchall()
     items: list[dict[str, Any]] = []
     for row in rows:

--- a/codemem/viewer_raw_events.py
+++ b/codemem/viewer_raw_events.py
@@ -21,8 +21,8 @@ _AUTH_BACKOFF_S = 300
 class RawEventAutoFlusher:
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._timers: dict[str, threading.Timer] = {}
-        self._flushing: set[str] = set()
+        self._timers: dict[tuple[str, str], threading.Timer] = {}
+        self._flushing: set[tuple[str, str]] = set()
 
     def enabled(self) -> bool:
         return os.environ.get("CODEMEM_RAW_EVENTS_AUTO_FLUSH") == "1"
@@ -34,32 +34,40 @@ class RawEventAutoFlusher:
         except (TypeError, ValueError):
             return 60000
 
-    def note_activity(self, opencode_session_id: str) -> None:
+    def note_activity(self, opencode_session_id: str, *, source: str = "opencode") -> None:
         if not opencode_session_id:
             return
         if not self.enabled():
             return
+        source_norm = source.strip().lower() or "opencode"
+        key = (source_norm, opencode_session_id)
         delay_ms = self.debounce_ms()
         if delay_ms <= 0:
-            self.flush_now(opencode_session_id)
+            self.flush_now(opencode_session_id, source=source_norm)
             return
         with self._lock:
-            existing = self._timers.pop(opencode_session_id, None)
+            existing = self._timers.pop(key, None)
             if existing:
                 existing.cancel()
-            timer = threading.Timer(delay_ms / 1000.0, self.flush_now, args=(opencode_session_id,))
+            timer = threading.Timer(
+                delay_ms / 1000.0,
+                self.flush_now,
+                kwargs={"opencode_session_id": opencode_session_id, "source": source_norm},
+            )
             timer.daemon = True
-            self._timers[opencode_session_id] = timer
+            self._timers[key] = timer
             timer.start()
 
-    def flush_now(self, opencode_session_id: str) -> None:
+    def flush_now(self, opencode_session_id: str, *, source: str = "opencode") -> None:
         if not opencode_session_id:
             return
+        source_norm = source.strip().lower() or "opencode"
+        key = (source_norm, opencode_session_id)
         with self._lock:
-            if opencode_session_id in self._flushing:
+            if key in self._flushing:
                 return
-            self._flushing.add(opencode_session_id)
-            timer = self._timers.pop(opencode_session_id, None)
+            self._flushing.add(key)
+            timer = self._timers.pop(key, None)
         if timer:
             timer.cancel()
         try:
@@ -68,6 +76,7 @@ class RawEventAutoFlusher:
                 flush_raw_events(
                     store,
                     opencode_session_id=opencode_session_id,
+                    source=source_norm,
                     cwd=None,
                     project=None,
                     started_at=None,
@@ -77,7 +86,7 @@ class RawEventAutoFlusher:
                 store.close()
         finally:
             with self._lock:
-                self._flushing.discard(opencode_session_id)
+                self._flushing.discard(key)
 
 
 RAW_EVENT_FLUSHER = RawEventAutoFlusher()
@@ -181,19 +190,24 @@ class RawEventSweeper:
                 )
 
             max_events = self.worker_max_events()
-            drained: set[str] = set()
+            drained: set[tuple[str, str]] = set()
             queue_session_ids = store.raw_event_sessions_with_pending_queue(limit=self.limit())
-            for opencode_session_id in queue_session_ids:
+            for item in queue_session_ids:
+                source = str(item.get("source") or "opencode")
+                opencode_session_id = str(item.get("stream_id") or "")
+                if not opencode_session_id:
+                    continue
                 try:
                     flush_raw_events(
                         store,
                         opencode_session_id=opencode_session_id,
+                        source=source,
                         cwd=None,
                         project=None,
                         started_at=None,
                         max_events=max_events,
                     )
-                    drained.add(opencode_session_id)
+                    drained.add((source, opencode_session_id))
                 except ObserverAuthError as exc:
                     self._handle_auth_error(exc)
                     return  # Stop all flush work during auth backoff.
@@ -215,13 +229,18 @@ class RawEventSweeper:
                 idle_before_ts_wall_ms=idle_before,
                 limit=self.limit(),
             )
-            for opencode_session_id in session_ids:
-                if opencode_session_id in drained:
+            for item in session_ids:
+                source = str(item.get("source") or "opencode")
+                opencode_session_id = str(item.get("stream_id") or "")
+                if not opencode_session_id:
+                    continue
+                if (source, opencode_session_id) in drained:
                     continue
                 try:
                     flush_raw_events(
                         store,
                         opencode_session_id=opencode_session_id,
+                        source=source,
                         cwd=None,
                         project=None,
                         started_at=None,

--- a/codemem/viewer_routes/raw_events.py
+++ b/codemem/viewer_routes/raw_events.py
@@ -31,7 +31,7 @@ class _ViewerHandler(Protocol):
 
 
 class _RawEventFlusher(Protocol):
-    def note_activity(self, opencode_session_id: str) -> None: ...
+    def note_activity(self, opencode_session_id: str, *, source: str = "opencode") -> None: ...
 
 
 class _Store(Protocol):
@@ -297,7 +297,7 @@ def handle_post(
                 last_seen_ts_wall_ms=last_seen_by_session.get(meta_session_id),
             )
             try:
-                flusher.note_activity(meta_session_id)
+                flusher.note_activity(meta_session_id, source="opencode")
             except Exception as exc:  # pragma: no cover
                 logger.warning(
                     "raw event flusher note_activity failed",

--- a/docs/plans/2026-03-03-adapter-session-identity-decoupling.md
+++ b/docs/plans/2026-03-03-adapter-session-identity-decoupling.md
@@ -1,0 +1,251 @@
+# Decouple Adapter Session Identity from OpenCode Stream Semantics
+
+**Bead:** codemem-afm.9
+**Status:** Design
+**Date:** 2026-03-03
+
+## Problem
+
+The raw-event queue and flush pipeline use `opencode_session_id` as the universal session key across all adapter sources. Claude sessions are stored with a synthetic `"claude:{uuid}"` value in that column — a prefix hack that conflates adapter source with session identity.
+
+This causes:
+
+- **Naming lies**: every function signature, column name, and variable says "opencode" when it means "any adapter stream"
+- **Implicit source encoding**: the `"claude:"` prefix is the only way to distinguish adapter sources, requiring string parsing instead of a queryable column
+- **Inconsistent convention**: OpenCode sessions use bare `"ses_*"` IDs with no prefix; Claude sessions are prefixed — no reason for the asymmetry when source is known
+
+## Design
+
+### Core change
+
+1. Add explicit `source TEXT NOT NULL` and native `stream_id` identity across raw-event tables.
+2. Use compound identity `(source, stream_id)` for all queue, flush, and stream-session operations.
+3. Strip `"claude:"` prefix from existing Claude stream IDs during migration; store native UUID in `stream_id` and adapter in `source`.
+4. Keep compatibility aliases for legacy `opencode_session_id` CLI/API inputs during transition.
+5. Defer broad naming cleanup (column/table/function rename) to a second pass in `codemem-afm.11`.
+
+### Rollout strategy
+
+#### Phase 1 (this bead): identity decoupling with compatibility
+
+- Introduce `source + stream_id` as canonical identity.
+- Preserve runtime compatibility for legacy call sites and CLI arguments.
+- Keep user-facing behavior stable while eliminating prefix-based source encoding.
+
+#### Phase 2 (follow-up): naming cleanup
+
+- Rename `opencode_session_id` references to adapter-neutral names in schema/code/docs.
+- Rename `opencode_sessions` table to `stream_sessions` where it is operationally safe.
+- Drop legacy compatibility aliases after one release window.
+
+### Naming convention
+
+| Adapter  | `source`    | `stream_id`              |
+|----------|-------------|--------------------------|
+| OpenCode | `opencode`  | `ses_abc123`             |
+| Claude   | `claude`    | `b0be3bdc-d292-4e17-...` |
+| Cursor   | `cursor`    | (whatever native ID)     |
+| Codex    | `codex`     | (whatever native ID)     |
+
+The `stream_id` is always the adapter's native session identifier. No prefixing.
+
+### Schema migration
+
+SQLite supports `RENAME COLUMN`, but this migration changes identity constraints and ON CONFLICT behavior.
+To avoid partial constraint drift, recreate all identity tables and copy data in one transaction.
+
+**Table recreation (identity + constraint updates):**
+
+```sql
+-- raw_events: compound stream identity and uniqueness
+CREATE TABLE raw_events_new (
+    id INTEGER PRIMARY KEY,
+    source TEXT NOT NULL DEFAULT 'opencode',
+    stream_id TEXT NOT NULL,
+    event_id TEXT,
+    event_seq INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    ts_wall_ms INTEGER,
+    ts_mono_ms REAL,
+    payload_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE(source, stream_id, event_seq),
+    UNIQUE(source, stream_id, event_id)
+);
+
+INSERT INTO raw_events_new
+SELECT
+    id,
+    CASE WHEN opencode_session_id LIKE 'claude:%' THEN 'claude' ELSE 'opencode' END,
+    CASE WHEN opencode_session_id LIKE 'claude:%' THEN SUBSTR(opencode_session_id, 8) ELSE opencode_session_id END,
+    event_id, event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at
+FROM raw_events;
+
+DROP TABLE raw_events;
+ALTER TABLE raw_events_new RENAME TO raw_events;
+CREATE INDEX idx_raw_events_source_stream_seq ON raw_events(source, stream_id, event_seq);
+
+-- raw_event_sessions: (source, stream_id) compound PK
+CREATE TABLE raw_event_sessions_new (
+    source TEXT NOT NULL DEFAULT 'opencode',
+    stream_id TEXT NOT NULL,
+    cwd TEXT,
+    project TEXT,
+    started_at TEXT,
+    last_seen_ts_wall_ms INTEGER,
+    last_received_event_seq INTEGER NOT NULL DEFAULT -1,
+    last_flushed_event_seq INTEGER NOT NULL DEFAULT -1,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (source, stream_id)
+);
+
+INSERT INTO raw_event_sessions_new
+    SELECT
+        CASE WHEN opencode_session_id LIKE 'claude:%' THEN 'claude' ELSE 'opencode' END,
+        CASE WHEN opencode_session_id LIKE 'claude:%' THEN SUBSTR(opencode_session_id, 8) ELSE opencode_session_id END,
+        cwd, project, started_at, last_seen_ts_wall_ms,
+        last_received_event_seq, last_flushed_event_seq, updated_at
+    FROM raw_event_sessions;
+
+DROP TABLE raw_event_sessions;
+ALTER TABLE raw_event_sessions_new RENAME TO raw_event_sessions;
+
+-- raw_event_flush_batches: compound stream identity
+CREATE TABLE raw_event_flush_batches_new (
+    id INTEGER PRIMARY KEY,
+    source TEXT NOT NULL DEFAULT 'opencode',
+    stream_id TEXT NOT NULL,
+    start_event_seq INTEGER NOT NULL,
+    end_event_seq INTEGER NOT NULL,
+    extractor_version TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(source, stream_id, start_event_seq, end_event_seq, extractor_version)
+);
+
+INSERT INTO raw_event_flush_batches_new
+SELECT
+    id,
+    CASE WHEN opencode_session_id LIKE 'claude:%' THEN 'claude' ELSE 'opencode' END,
+    CASE WHEN opencode_session_id LIKE 'claude:%' THEN SUBSTR(opencode_session_id, 8) ELSE opencode_session_id END,
+    start_event_seq, end_event_seq, extractor_version, status, created_at, updated_at, COALESCE(attempt_count, 0)
+FROM raw_event_flush_batches;
+
+DROP TABLE raw_event_flush_batches;
+ALTER TABLE raw_event_flush_batches_new RENAME TO raw_event_flush_batches;
+CREATE INDEX idx_raw_event_flush_batches_source_stream
+    ON raw_event_flush_batches(source, stream_id, created_at DESC);
+
+-- opencode_sessions → stream_sessions
+CREATE TABLE stream_sessions (
+    source TEXT NOT NULL DEFAULT 'opencode',
+    stream_id TEXT NOT NULL,
+    session_id INTEGER REFERENCES sessions(id) ON DELETE CASCADE,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (source, stream_id)
+);
+
+INSERT INTO stream_sessions
+    SELECT
+        CASE WHEN opencode_session_id LIKE 'claude:%' THEN 'claude' ELSE 'opencode' END,
+        CASE WHEN opencode_session_id LIKE 'claude:%' THEN SUBSTR(opencode_session_id, 8) ELSE opencode_session_id END,
+        session_id, created_at
+    FROM opencode_sessions;
+
+DROP TABLE opencode_sessions;
+CREATE INDEX idx_stream_sessions_session_id ON stream_sessions(session_id);
+```
+
+### API / function signature changes
+
+`flush_raw_events` becomes:
+
+```python
+def flush_raw_events(
+    store: MemoryStore,
+    *,
+    source: str,
+    stream_id: str,
+    cwd: str | None,
+    project: str | None,
+    started_at: str | None,
+    max_events: int | None = None,
+) -> dict[str, int]:
+```
+
+Callers pass `source` explicitly:
+
+- **OpenCode adapter** (viewer API / CLI fallback): `source="opencode"`
+- **Claude hooks** (`claude_integration_cmds.py`): `source="claude"`
+- **CLI `flush-raw-events`**: accepts `--source` flag, defaults to `"opencode"`; legacy `opencode_session_id` args remain accepted as aliases.
+- **Sweeper / idle worker**: reads `source` from `raw_event_sessions` row
+
+The `_adapter_stream_id` function in `claude_integration_cmds.py` stops prepending the source:
+
+```python
+# Before
+def _adapter_stream_id(*, source: str, session_id: str, cwd: str | None) -> str:
+    return f"{source}:{session_id}"
+
+# After — just returns the native ID
+def _adapter_stream_id(*, source: str, session_id: str, cwd: str | None) -> str:
+    return session_id
+```
+
+Session context passed into `ingest()`:
+
+```python
+session_context["source"] = source
+session_context["stream_id"] = stream_id
+```
+
+Store methods (`get_or_create_opencode_session`, `record_raw_event`, etc.) take `(source, stream_id)` as canonical identity. Legacy wrappers can map old signatures during Phase 1.
+
+### Code rename scope
+
+~230 references to `opencode_session_id` across:
+
+- `codemem/store/raw_events.py` — bulk of store operations
+- `codemem/store/_store.py` — MemoryStore facade methods
+- `codemem/store/maintenance.py` — discovery tokens, project backfill
+- `codemem/raw_event_flush.py` — flush orchestration
+- `codemem/plugin_ingest.py` — ingest entry point, session creation
+- `codemem/commands/claude_integration_cmds.py` — Claude hook adapter
+- `codemem/cli_app.py` — CLI commands
+- `codemem/viewer_raw_events.py` — viewer API
+- `tests/` — test fixtures and assertions
+
+Do not do a global mechanical rename in Phase 1. First add canonical `(source, stream_id)` paths and compatibility adapters, then rename in Phase 2.
+
+## Scope boundaries
+
+**In scope:**
+- Canonical `(source, stream_id)` identity across raw-event tables and store APIs
+- Table recreation for identity/constraint updates (`raw_events`, `raw_event_sessions`, `raw_event_flush_batches`, mapping table)
+- Claude prefix stripping + data migration
+- Function signatures: `flush_raw_events`, store methods, ingest (with compatibility aliases)
+- Index/unique recreation with compound keys
+
+**Out of scope (separate beads):**
+- Observer isolation / UUID bleed fix — codemem-afm.10
+- Observer provider resolution decoupling — codemem-afm.10
+- Full CLI/docs naming cleanup (`raw-events-status`, args/help text) — codemem-afm.11
+- Viewer API response format changes — follow-up
+- `_adapter` envelope format — already has `source` field, untouched
+
+## Migration risk
+
+- **Data loss**: low if migration runs in one transaction with copy-then-swap table recreation.
+- **Rollback**: require pre-migration DB backup and schema gate; rollback is restore-from-backup.
+- **Concurrent access**: migration must run with viewer/sweeper stopped to avoid mid-copy writes.
+- **Constraint drift**: avoided by recreating tables instead of partial ALTER + index patching.
+
+## Required migration tests
+
+1. **Cross-source uniqueness**: same `event_id` and `event_seq` can exist for different sources without collision.
+2. **Batch uniqueness**: `(source, stream_id, start_event_seq, end_event_seq, extractor_version)` conflict behavior matches pre-migration semantics.
+3. **Prefix migration**: `claude:{uuid}` rows migrate to `(source='claude', stream_id='{uuid}')` in all identity tables.
+4. **Legacy compatibility**: old CLI/API input names still function and map to canonical `(source, stream_id)`.
+5. **Mixed-source flush**: OpenCode and Claude streams flush independently with no identity bleed.

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -68,7 +68,9 @@ def test_build_ingest_payload_wraps_adapter_event() -> None:
     ingest_payload = build_ingest_payload_from_hook(payload)
 
     assert ingest_payload is not None
-    assert ingest_payload["session_context"]["opencode_session_id"] == "claude:sess-xyz"
+    assert ingest_payload["session_context"]["source"] == "claude"
+    assert ingest_payload["session_context"]["stream_id"] == "sess-xyz"
+    assert ingest_payload["session_context"]["opencode_session_id"] == "sess-xyz"
     event = ingest_payload["events"][0]
     assert event["_adapter"]["event_type"] == "session_start"
 

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -165,7 +165,7 @@ def test_ingest_claude_hook_cmd_flushes_stop_hook_when_assistant_text_missing() 
 
     def _fake_flush(*_: object, **kwargs: object) -> dict[str, int]:
         called["flush"] += 1
-        assert kwargs["opencode_session_id"] == "claude:sess-1"
+        assert kwargs["opencode_session_id"] == "sess-1"
         return {"flushed": 0, "updated_state": 0}
 
     with (
@@ -231,8 +231,8 @@ def test_hooks_template_matches_allowlist_events() -> None:
 
 
 def test_adapter_stream_id_uses_source_and_session_only() -> None:
-    stream_id = _adapter_stream_id(source="claude", session_id="sess-1", cwd="/tmp/worktree-a")
-    assert stream_id == "claude:sess-1"
+    stream_id = _adapter_stream_id(session_id="sess-1")
+    assert stream_id == "sess-1"
 
 
 def test_queue_adapter_event_writes_claude_hook_payload() -> None:
@@ -258,7 +258,7 @@ def test_queue_adapter_event_writes_claude_hook_payload() -> None:
     assert queued is not None
     stream_id, inserted = queued
     assert inserted is True
-    assert stream_id == "claude:sess-queue"
+    assert stream_id == "sess-queue"
     record = calls["record"]
     assert isinstance(record, dict)
     assert record["event_type"] == "claude.hook"

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -72,3 +72,262 @@ def test_initialize_schema_skips_reinit_but_keeps_kind_normalization(
         conn.close()
 
     assert kind == "decision"
+
+
+def test_initialize_schema_backfills_raw_event_identity_without_reinit(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CODEMEM_EMBEDDING_DISABLED", "1")
+    conn = db.connect(tmp_path / "legacy.sqlite")
+    try:
+        conn.execute("PRAGMA user_version = 1")
+        conn.executescript(
+            """
+            CREATE TABLE raw_events (
+                id INTEGER PRIMARY KEY,
+                opencode_session_id TEXT NOT NULL,
+                event_seq INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(opencode_session_id, event_seq)
+            );
+
+            CREATE TABLE raw_event_sessions (
+                opencode_session_id TEXT PRIMARY KEY,
+                cwd TEXT,
+                project TEXT,
+                started_at TEXT,
+                last_seen_ts_wall_ms INTEGER,
+                last_received_event_seq INTEGER NOT NULL DEFAULT -1,
+                last_flushed_event_seq INTEGER NOT NULL DEFAULT -1,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE raw_event_flush_batches (
+                id INTEGER PRIMARY KEY,
+                opencode_session_id TEXT NOT NULL,
+                start_event_seq INTEGER NOT NULL,
+                end_event_seq INTEGER NOT NULL,
+                extractor_version TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE(opencode_session_id, start_event_seq, end_event_seq, extractor_version)
+            );
+
+            CREATE TABLE opencode_sessions (
+                opencode_session_id TEXT PRIMARY KEY,
+                session_id INTEGER,
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                cwd TEXT,
+                git_remote TEXT,
+                git_branch TEXT,
+                user TEXT,
+                tool_version TEXT,
+                metadata_json TEXT,
+                project TEXT,
+                import_key TEXT
+            );
+
+            CREATE TABLE memory_items (
+                id INTEGER PRIMARY KEY,
+                session_id INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body_text TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                user_prompt_id INTEGER
+            );
+
+            CREATE TABLE user_prompts (
+                id INTEGER PRIMARY KEY
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO raw_events(opencode_session_id, event_seq, event_type, payload_json, created_at) VALUES (?, ?, ?, ?, ?)",
+            ("claude:sess-legacy", 1, "prompt", "{}", "2026-01-01T00:00:00Z"),
+        )
+        conn.execute(
+            "INSERT INTO raw_event_sessions(opencode_session_id, updated_at) VALUES (?, ?)",
+            ("claude:sess-legacy", "2026-01-01T00:00:00Z"),
+        )
+        conn.execute(
+            "INSERT INTO raw_event_flush_batches(opencode_session_id, start_event_seq, end_event_seq, extractor_version, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "claude:sess-legacy",
+                1,
+                1,
+                "v1",
+                "pending",
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:00:00Z",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO sessions(id, started_at, cwd, user, tool_version) VALUES (?, ?, ?, ?, ?)",
+            (1, "2026-01-01T00:00:00Z", "/tmp", "tester", "test"),
+        )
+        conn.execute(
+            "INSERT INTO opencode_sessions(opencode_session_id, session_id, created_at) VALUES (?, ?, ?)",
+            ("claude:sess-legacy", 1, "2026-01-01T00:00:00Z"),
+        )
+        conn.commit()
+
+        def _unexpected_reinit(_conn):
+            raise AssertionError(
+                "initialize_schema should not rerun full migration at current version"
+            )
+
+        monkeypatch.setattr(db, "_initialize_schema_v1", _unexpected_reinit)
+        db.initialize_schema(conn)
+
+        for table in (
+            "raw_events",
+            "raw_event_sessions",
+            "raw_event_flush_batches",
+            "opencode_sessions",
+        ):
+            columns = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+            assert "source" in columns
+            assert "stream_id" in columns
+        assert [
+            row[1]
+            for row in conn.execute("PRAGMA table_info(raw_event_sessions)").fetchall()
+            if row[5]
+        ] == [
+            "source",
+            "stream_id",
+        ]
+        assert [
+            row[1]
+            for row in conn.execute("PRAGMA table_info(opencode_sessions)").fetchall()
+            if row[5]
+        ] == [
+            "source",
+            "stream_id",
+        ]
+
+        row = conn.execute(
+            "SELECT source, stream_id, opencode_session_id FROM raw_event_sessions WHERE source = ? AND stream_id = ?",
+            ("claude", "sess-legacy"),
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "claude"
+        assert row[1] == "sess-legacy"
+        assert row[2] == "sess-legacy"
+    finally:
+        conn.close()
+
+
+def test_initialize_schema_fails_fast_on_identity_collisions(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CODEMEM_EMBEDDING_DISABLED", "1")
+    conn = db.connect(tmp_path / "legacy-collision.sqlite")
+    try:
+        conn.execute("PRAGMA user_version = 1")
+        conn.executescript(
+            """
+            CREATE TABLE raw_events (
+                id INTEGER PRIMARY KEY,
+                opencode_session_id TEXT NOT NULL,
+                event_id TEXT,
+                event_seq INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                ts_wall_ms INTEGER,
+                ts_mono_ms REAL,
+                payload_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(opencode_session_id, event_seq)
+            );
+
+            CREATE TABLE raw_event_sessions (
+                opencode_session_id TEXT PRIMARY KEY,
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL DEFAULT '',
+                cwd TEXT,
+                project TEXT,
+                started_at TEXT,
+                last_seen_ts_wall_ms INTEGER,
+                last_received_event_seq INTEGER NOT NULL DEFAULT -1,
+                last_flushed_event_seq INTEGER NOT NULL DEFAULT -1,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE raw_event_flush_batches (
+                id INTEGER PRIMARY KEY,
+                opencode_session_id TEXT NOT NULL,
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL DEFAULT '',
+                start_event_seq INTEGER NOT NULL,
+                end_event_seq INTEGER NOT NULL,
+                extractor_version TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                UNIQUE(opencode_session_id, start_event_seq, end_event_seq, extractor_version)
+            );
+
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                cwd TEXT,
+                git_remote TEXT,
+                git_branch TEXT,
+                user TEXT,
+                tool_version TEXT,
+                metadata_json TEXT,
+                project TEXT,
+                import_key TEXT
+            );
+
+            CREATE TABLE opencode_sessions (
+                opencode_session_id TEXT PRIMARY KEY,
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL DEFAULT '',
+                session_id INTEGER,
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE memory_items (
+                id INTEGER PRIMARY KEY,
+                session_id INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body_text TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                user_prompt_id INTEGER
+            );
+
+            CREATE TABLE user_prompts (
+                id INTEGER PRIMARY KEY
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO raw_event_sessions(opencode_session_id, updated_at) VALUES (?, ?)",
+            ("sess-collide", "2026-01-01T00:00:00Z"),
+        )
+        conn.execute(
+            "INSERT INTO raw_event_sessions(opencode_session_id, updated_at) VALUES (?, ?)",
+            ("opencode:sess-collide", "2026-01-01T00:00:00Z"),
+        )
+        conn.commit()
+
+        try:
+            db.initialize_schema(conn)
+            raise AssertionError("expected initialize_schema to fail on identity collision")
+        except RuntimeError as exc:
+            assert "collision" in str(exc).lower()
+    finally:
+        conn.close()

--- a/tests/test_plugin_ingest_characterization.py
+++ b/tests/test_plugin_ingest_characterization.py
@@ -18,6 +18,9 @@ class FakeStore:
     def get_or_create_opencode_session(self, *_args: Any, **_kwargs: Any) -> int:
         return 1
 
+    def get_or_create_stream_session(self, *_args: Any, **_kwargs: Any) -> int:
+        return 1
+
     def start_session(self, *_args: Any, **_kwargs: Any) -> int:
         return 1
 
@@ -216,3 +219,36 @@ def test_ingest_early_exit_on_trivial_request(monkeypatch: Any) -> None:
     assert not plugin_ingest.build_artifact_bundle.called
     assert store.ended
     assert store.closed
+
+
+def test_ingest_discovery_group_uses_unprefixed_opencode_stream(monkeypatch: Any) -> None:
+    store = FakeStore()
+    captured: dict[str, Any] = {}
+
+    def fake_persist_observations(*_args: Any, **kwargs: Any) -> None:
+        captured["discovery_group"] = kwargs.get("discovery_group")
+
+    _set_common_patches(monkeypatch, store)
+    monkeypatch.setattr(plugin_ingest, "build_artifact_bundle", lambda *_: [])
+    monkeypatch.setattr(plugin_ingest, "_persist_observations_impl", fake_persist_observations)
+    monkeypatch.setattr(
+        plugin_ingest, "OBSERVER", SimpleNamespace(observe=lambda _ctx: _make_response())
+    )
+
+    payload = {
+        "cwd": "/tmp",
+        "project": "demo",
+        "started_at": "2026-01-28T00:00:00Z",
+        "session_context": {"source": "opencode", "stream_id": "sess-1"},
+        "events": [
+            {
+                "type": "user_prompt",
+                "prompt_text": "Please implement the feature",
+                "prompt_number": 2,
+            }
+        ],
+    }
+
+    plugin_ingest.ingest(payload)
+
+    assert captured["discovery_group"] == "sess-1:p2"

--- a/tests/test_raw_event_queue_states.py
+++ b/tests/test_raw_event_queue_states.py
@@ -20,6 +20,8 @@ def test_raw_event_queue_status_counts_maps_legacy_states(tmp_path: Path) -> Non
             store.conn.execute(
                 """
                 INSERT INTO raw_event_flush_batches(
+                    source,
+                    stream_id,
                     opencode_session_id,
                     start_event_seq,
                     end_event_seq,
@@ -27,9 +29,9 @@ def test_raw_event_queue_status_counts_maps_legacy_states(tmp_path: Path) -> Non
                     status,
                     created_at,
                     updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                ("sess", seq, seq, "v1", status, now, now),
+                ("opencode", "sess", "sess", seq, seq, "v1", status, now, now),
             )
         store.conn.commit()
 
@@ -54,6 +56,8 @@ def test_raw_event_batch_status_counts_handles_canonical_states(tmp_path: Path) 
             store.conn.execute(
                 """
                 INSERT INTO raw_event_flush_batches(
+                    source,
+                    stream_id,
                     opencode_session_id,
                     start_event_seq,
                     end_event_seq,
@@ -61,9 +65,9 @@ def test_raw_event_batch_status_counts_handles_canonical_states(tmp_path: Path) 
                     status,
                     created_at,
                     updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                ("sess", seq, seq, "v1", status, now, now),
+                ("opencode", "sess", "sess", seq, seq, "v1", status, now, now),
             )
         store.conn.commit()
 
@@ -136,6 +140,8 @@ def test_raw_event_failed_canonical_batch_is_recoverable_by_reclaim(tmp_path: Pa
         store.conn.execute(
             """
             INSERT INTO raw_event_flush_batches(
+                source,
+                stream_id,
                 opencode_session_id,
                 start_event_seq,
                 end_event_seq,
@@ -144,9 +150,9 @@ def test_raw_event_failed_canonical_batch_is_recoverable_by_reclaim(tmp_path: Pa
                 created_at,
                 updated_at,
                 attempt_count
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            ("sess", 10, 11, "v1", "failed", now, now, 1),
+            ("opencode", "sess", "sess", 10, 11, "v1", "failed", now, now, 1),
         )
         batch_id = int(store.conn.execute("SELECT id FROM raw_event_flush_batches").fetchone()[0])
         store.conn.commit()

--- a/tests/test_raw_event_sweeper.py
+++ b/tests/test_raw_event_sweeper.py
@@ -225,6 +225,8 @@ def test_raw_event_sweeper_skips_stale_queue_sessions_without_backlog(
         store.conn.execute(
             """
             INSERT INTO raw_event_flush_batches(
+                source,
+                stream_id,
                 opencode_session_id,
                 start_event_seq,
                 end_event_seq,
@@ -232,9 +234,11 @@ def test_raw_event_sweeper_skips_stale_queue_sessions_without_backlog(
                 status,
                 created_at,
                 updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
+                "opencode",
+                "sess-stale",
                 "sess-stale",
                 0,
                 0,
@@ -247,6 +251,8 @@ def test_raw_event_sweeper_skips_stale_queue_sessions_without_backlog(
         store.conn.execute(
             """
             INSERT INTO raw_event_flush_batches(
+                source,
+                stream_id,
                 opencode_session_id,
                 start_event_seq,
                 end_event_seq,
@@ -254,9 +260,11 @@ def test_raw_event_sweeper_skips_stale_queue_sessions_without_backlog(
                 status,
                 created_at,
                 updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
+                "opencode",
+                "sess-real",
                 "sess-real",
                 0,
                 1,

--- a/tests/test_raw_events_enqueue_cmd.py
+++ b/tests/test_raw_events_enqueue_cmd.py
@@ -42,6 +42,13 @@ def test_enqueue_raw_event_cmd_writes_event_and_meta(tmp_path: Path) -> None:
         assert meta["project"] == "codemem"
         assert meta["started_at"] == "2026-03-02T20:00:00Z"
         assert meta["last_seen_ts_wall_ms"] == 123
+        identity = store.conn.execute(
+            "SELECT source, stream_id FROM raw_event_sessions WHERE opencode_session_id = ?",
+            ("sess-cli",),
+        ).fetchone()
+        assert identity is not None
+        assert identity["source"] == "opencode"
+        assert identity["stream_id"] == "sess-cli"
     finally:
         store.close()
 
@@ -172,5 +179,95 @@ def test_enqueue_raw_event_cmd_strips_private_tags_from_payload(tmp_path: Path) 
         assert "<private>" not in stored_event
         assert "secret-token" not in stored_event
         assert "hidden" not in stored_event
+    finally:
+        store.close()
+
+
+def test_enqueue_raw_event_cmd_tracks_source_and_stream_identity_columns(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    stream_id = "4d297237-0bcd-4f1c-9f4e-c8b934c6fab8"
+    payload = {
+        "opencode_session_id": stream_id,
+        "source": "claude",
+        "event_id": "evt-claude-1",
+        "event_type": "user_prompt",
+        "payload": {"type": "user_prompt", "prompt_text": "Claude identity test"},
+    }
+
+    result = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(payload),
+    )
+
+    assert result.exit_code == 0
+    store = MemoryStore(db_path)
+    try:
+        session_row = store.conn.execute(
+            "SELECT source, stream_id FROM raw_event_sessions WHERE opencode_session_id = ?",
+            (stream_id,),
+        ).fetchone()
+        assert session_row is not None
+        assert session_row["source"] == "claude"
+        assert session_row["stream_id"] == stream_id
+
+        event_row = store.conn.execute(
+            "SELECT source, stream_id FROM raw_events WHERE opencode_session_id = ?",
+            (stream_id,),
+        ).fetchone()
+        assert event_row is not None
+        assert event_row["source"] == "claude"
+        assert event_row["stream_id"] == stream_id
+    finally:
+        store.close()
+
+
+def test_enqueue_raw_event_cmd_allows_same_stream_id_across_sources(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    stream_id = "shared-stream"
+    payload_opencode = {
+        "opencode_session_id": stream_id,
+        "source": "opencode",
+        "event_id": "evt-shared",
+        "event_type": "user_prompt",
+        "payload": {"type": "user_prompt", "prompt_text": "OpenCode"},
+    }
+    payload_claude = {
+        "opencode_session_id": stream_id,
+        "source": "claude",
+        "event_id": "evt-shared",
+        "event_type": "user_prompt",
+        "payload": {"type": "user_prompt", "prompt_text": "Claude"},
+    }
+
+    first = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(payload_opencode),
+    )
+    second = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(payload_claude),
+    )
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+
+    store = MemoryStore(db_path)
+    try:
+        rows = store.conn.execute(
+            """
+            SELECT source, stream_id, event_id
+            FROM raw_events
+            WHERE stream_id = ? AND event_id = ?
+            ORDER BY source ASC
+            """,
+            (stream_id, "evt-shared"),
+        ).fetchall()
+        assert [dict(row) for row in rows] == [
+            {"source": "claude", "stream_id": stream_id, "event_id": "evt-shared"},
+            {"source": "opencode", "stream_id": stream_id, "event_id": "evt-shared"},
+        ]
     finally:
         store.close()

--- a/tests/test_raw_events_gate.py
+++ b/tests/test_raw_events_gate.py
@@ -15,21 +15,23 @@ def _seed_reliability_fixture(store: MemoryStore) -> None:
     now = dt.datetime.now(dt.UTC).isoformat()
     store.conn.execute(
         """
-        INSERT INTO raw_event_sessions(opencode_session_id, project, started_at, updated_at)
-        VALUES (?, ?, ?, ?)
+        INSERT INTO raw_event_sessions(source, stream_id, opencode_session_id, project, started_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
         """,
-        ("sess-a", "proj-a", now, now),
+        ("opencode", "sess-a", "sess-a", "proj-a", now, now),
     )
     store.conn.execute(
         """
-        INSERT INTO raw_event_sessions(opencode_session_id, project, started_at, updated_at)
-        VALUES (?, ?, ?, ?)
+        INSERT INTO raw_event_sessions(source, stream_id, opencode_session_id, project, started_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
         """,
-        ("sess-b", "proj-b", None, now),
+        ("opencode", "sess-b", "sess-b", "proj-b", None, now),
     )
     store.conn.execute(
         """
         INSERT INTO raw_events(
+            source,
+            stream_id,
             opencode_session_id,
             event_id,
             event_seq,
@@ -39,13 +41,15 @@ def _seed_reliability_fixture(store: MemoryStore) -> None:
             payload_json,
             created_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        ("sess-a", "evt-a-1", 0, "user_prompt", 1, 1.0, "{}", now),
+        ("opencode", "sess-a", "sess-a", "evt-a-1", 0, "user_prompt", 1, 1.0, "{}", now),
     )
     store.conn.execute(
         """
         INSERT INTO raw_events(
+            source,
+            stream_id,
             opencode_session_id,
             event_id,
             event_seq,
@@ -55,9 +59,9 @@ def _seed_reliability_fixture(store: MemoryStore) -> None:
             payload_json,
             created_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        ("sess-b", "evt-b-1", 0, "user_prompt", 2, 2.0, "{}", now),
+        ("opencode", "sess-b", "sess-b", "evt-b-1", 0, "user_prompt", 2, 2.0, "{}", now),
     )
 
     store.conn.execute(
@@ -99,6 +103,8 @@ def _seed_reliability_fixture(store: MemoryStore) -> None:
         store.conn.execute(
             """
             INSERT INTO raw_event_flush_batches(
+                source,
+                stream_id,
                 opencode_session_id,
                 start_event_seq,
                 end_event_seq,
@@ -107,13 +113,15 @@ def _seed_reliability_fixture(store: MemoryStore) -> None:
                 created_at,
                 updated_at,
                 attempt_count
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            ("sess-a", i, i, "v1", "completed", now, now, 1),
+            ("opencode", "sess-a", "sess-a", i, i, "v1", "completed", now, now, 1),
         )
     store.conn.execute(
         """
         INSERT INTO raw_event_flush_batches(
+            source,
+            stream_id,
             opencode_session_id,
             start_event_seq,
             end_event_seq,
@@ -122,9 +130,9 @@ def _seed_reliability_fixture(store: MemoryStore) -> None:
             created_at,
             updated_at,
             attempt_count
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        ("sess-a", 10, 10, "v1", "error", now, now, 2),
+        ("opencode", "sess-a", "sess-a", 10, 10, "v1", "error", now, now, 2),
     )
     store.conn.commit()
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1433,6 +1433,82 @@ def test_backfill_discovery_tokens_uses_existing_when_no_artifacts(tmp_path: Pat
     assert meta_a["discovery_source"] == "fallback"
 
 
+def test_backfill_discovery_tokens_scopes_raw_events_by_source_and_stream(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    shared_stream = "shared-stream"
+    open_session = store.get_or_create_stream_session(
+        source="opencode",
+        stream_id=shared_stream,
+        cwd="/tmp",
+        project="/tmp/project-a",
+    )
+    claude_session = store.get_or_create_stream_session(
+        source="claude",
+        stream_id=shared_stream,
+        cwd="/tmp",
+        project="/tmp/project-a",
+    )
+
+    store.remember(
+        open_session,
+        kind="feature",
+        title="OpenCode",
+        body_text="OpenCode body",
+        metadata={"source": "observer"},
+    )
+    store.remember(
+        claude_session,
+        kind="feature",
+        title="Claude",
+        body_text="Claude body",
+        metadata={"source": "observer"},
+    )
+
+    store.record_raw_events_batch(
+        opencode_session_id=shared_stream,
+        source="opencode",
+        events=[
+            {
+                "event_id": "open-usage",
+                "event_type": "assistant_usage",
+                "payload": {"usage": {"input_tokens": 10, "output_tokens": 2}},
+            }
+        ],
+    )
+    store.record_raw_events_batch(
+        opencode_session_id=shared_stream,
+        source="claude",
+        events=[
+            {
+                "event_id": "claude-usage",
+                "event_type": "assistant_usage",
+                "payload": {"usage": {"input_tokens": 20, "output_tokens": 5}},
+            }
+        ],
+    )
+
+    updated = store.backfill_discovery_tokens(limit_sessions=10)
+    assert updated == 2
+
+    open_meta = json.loads(
+        store.conn.execute(
+            "SELECT metadata_json FROM memory_items WHERE session_id = ? ORDER BY id DESC LIMIT 1",
+            (open_session,),
+        ).fetchone()["metadata_json"]
+    )
+    claude_meta = json.loads(
+        store.conn.execute(
+            "SELECT metadata_json FROM memory_items WHERE session_id = ? ORDER BY id DESC LIMIT 1",
+            (claude_session,),
+        ).fetchone()["metadata_json"]
+    )
+
+    assert open_meta["discovery_tokens"] == 12
+    assert claude_meta["discovery_tokens"] == 25
+    assert open_meta["discovery_group"] == "shared-stream:unknown"
+    assert claude_meta["discovery_group"] == "claude:shared-stream:unknown"
+
+
 def test_deactivate_low_signal_observations(tmp_path: Path) -> None:
     """Test the deactivation mechanism works - with empty patterns, nothing is deactivated."""
     store = MemoryStore(tmp_path / "mem.sqlite")
@@ -1608,13 +1684,47 @@ def test_rename_project_updates_sessions_raw_event_sessions_and_usage_events(
         # raw_event_sessions: path-like project
         store.conn.execute(
             """
-            INSERT INTO raw_event_sessions(opencode_session_id, cwd, project, started_at, updated_at)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO raw_event_sessions(
+                source,
+                stream_id,
+                opencode_session_id,
+                cwd,
+                project,
+                started_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
             (
+                "opencode",
+                "ses_test",
                 "ses_test",
                 "/tmp/greenroom/wt/product-context",
                 "/tmp/greenroom/wt/product-context",
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:00:00Z",
+            ),
+        )
+        # Same stream_id across a different source should not be updated.
+        store.conn.execute(
+            """
+            INSERT INTO raw_event_sessions(
+                source,
+                stream_id,
+                opencode_session_id,
+                cwd,
+                project,
+                started_at,
+                updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "claude",
+                "ses_test",
+                "ses_test",
+                "/tmp/claude",
+                "claude-project",
                 "2026-01-01T00:00:00Z",
                 "2026-01-01T00:00:00Z",
             ),
@@ -1645,11 +1755,18 @@ def test_rename_project_updates_sessions_raw_event_sessions_and_usage_events(
         assert [r["project"] for r in rows] == ["greenroom", "greenroom"]
 
         row = store.conn.execute(
-            "SELECT project FROM raw_event_sessions WHERE opencode_session_id = ?",
-            ("ses_test",),
+            "SELECT project FROM raw_event_sessions WHERE source = ? AND stream_id = ?",
+            ("opencode", "ses_test"),
         ).fetchone()
         assert row is not None
         assert row["project"] == "greenroom"
+
+        other = store.conn.execute(
+            "SELECT project FROM raw_event_sessions WHERE source = ? AND stream_id = ?",
+            ("claude", "ses_test"),
+        ).fetchone()
+        assert other is not None
+        assert other["project"] == "claude-project"
 
         row = store.conn.execute(
             "SELECT metadata_json FROM usage_events WHERE event = 'search_index' LIMIT 1"
@@ -3758,7 +3875,8 @@ def test_viewer_multi_session_updates_meta_and_notes_activity(monkeypatch, tmp_p
     noted: list[str] = []
 
     class DummyFlusher:
-        def note_activity(self, opencode_session_id: str) -> None:
+        def note_activity(self, opencode_session_id: str, *, source: str = "opencode") -> None:
+            _ = source
             noted.append(opencode_session_id)
 
     monkeypatch.setattr(viewer_module, "RAW_EVENT_FLUSHER", DummyFlusher())

--- a/tests/test_viewer_routes_raw_events.py
+++ b/tests/test_viewer_routes_raw_events.py
@@ -23,7 +23,8 @@ class DummyFlusher:
     def __init__(self) -> None:
         self.noted: list[str] = []
 
-    def note_activity(self, opencode_session_id: str) -> None:
+    def note_activity(self, opencode_session_id: str, *, source: str = "opencode") -> None:
+        _ = source
         self.noted.append(opencode_session_id)
 
 
@@ -259,8 +260,9 @@ def test_handle_post_flusher_failure_does_not_fail_ingest() -> None:
     store = DummyStore()
 
     class FailingFlusher:
-        def note_activity(self, opencode_session_id: str) -> None:
+        def note_activity(self, opencode_session_id: str, *, source: str = "opencode") -> None:
             _ = opencode_session_id
+            _ = source
             raise RuntimeError("flush failed")
 
     handled = raw_events.handle_post(


### PR DESCRIPTION
## Description
This PR implements AFM.9 session identity decoupling by making raw-event identity canonical as `(source, stream_id)` and hardening migration behavior for older local databases.

- Canonicalized adapter/session handling across raw-event enqueue, flush, retry, sweeper, and Claude integration paths.
- Added schema hardening/migration logic for identity columns and PK/unique constraints, including fail-fast collision checks and row-count safety checks.
- Updated viewer/raw-events plumbing to be source-aware where needed and aligned direct SQL fixtures/tests to canonical identity semantics.
- Added/updated tests covering migration compatibility, identity constraints, enqueue behavior, viewer routing, and reliability fixtures.
- Included implementation plan update: `docs/plans/2026-03-03-adapter-session-identity-decoupling.md`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run ruff check codemem tests`
- `uv run pytest tests/test_db_schema.py tests/test_raw_events_enqueue_cmd.py tests/test_raw_events_gate.py -q`
- `uv run pytest`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced