### PR TITLE
feat(observer): add configurable auth adapters and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,15 @@ Common overrides:
 | `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
 
 The viewer includes a Settings modal for observer provider/model plus runtime/auth fields.
-Observer auth sources in `0.16` are API-style (`env`, `file`, `command`) and support
-templated headers like `Authorization: Bearer ${auth.token}` for gateway flows.
+
+Observer runtime/auth in `0.16`:
+
+- Runtime options: `api_http` and `claude_sidecar` (reserved; currently not implemented, so it falls back to `api_http` with a warning).
+- Auth sources: `auto`, `env`, `file`, `command`, `none`.
+- `observer_auth_command` must be a JSON string array (argv), not a space-separated string.
+  - Config file example: `"observer_auth_command": ["iap-auth", "--audience", "example"]`
+  - Env var example: `CODEMEM_OBSERVER_AUTH_COMMAND='["iap-auth","--audience","example"]'`
+- Header templates support `${auth.token}`, `${auth.type}`, and `${auth.source}` (for example `Authorization: Bearer ${auth.token}`).
 
 ## Export and import
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ The viewer includes a grouped Settings modal (`Observer`, `Queue`, `Sync`) for o
 Observer runtime/auth in `0.16`:
 
 - Runtime options: `api_http` and `claude_sidecar`.
-- `claude_sidecar` runs observer calls through local Claude runtime auth; if an explicit `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's default model.
+- `api_http` defaults to `gpt-5.1-codex-mini` (OpenAI path) unless you set `observer_model`.
+- `claude_sidecar` defaults to `claude-4.5-haiku`; if the selected `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's CLI default model.
 - Auth sources: `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` must be a JSON string array (argv), not a space-separated string.
   - Config file example: `"observer_auth_command": ["iap-auth", "--audience", "example"]`

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Common overrides:
 | `CODEMEM_INJECT_CONTEXT` | `0` to disable automatic context injection |
 | `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
 
-The viewer includes a Settings modal for observer provider, model, and max chars.
+The viewer includes a Settings modal for observer provider/model plus runtime/auth fields.
+Observer auth sources in `0.16` are API-style (`env`, `file`, `command`) and support
+templated headers like `Authorization: Bearer ${auth.token}` for gateway flows.
 
 ## Export and import
 

--- a/README.md
+++ b/README.md
@@ -123,16 +123,18 @@ Common overrides:
 | `CODEMEM_INJECT_CONTEXT` | `0` to disable automatic context injection |
 | `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
 
-The viewer includes a Settings modal for observer provider/model plus runtime/auth fields.
+The viewer includes a grouped Settings modal (`Observer`, `Queue`, `Sync`) for observer controls, queue cadence, and sync defaults.
 
 Observer runtime/auth in `0.16`:
 
-- Runtime options: `api_http` and `claude_sidecar` (reserved; currently not implemented, so it falls back to `api_http` with a warning).
+- Runtime options: `api_http` and `claude_sidecar`.
+- `claude_sidecar` runs observer calls through local Claude runtime auth; if an explicit `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's default model.
 - Auth sources: `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` must be a JSON string array (argv), not a space-separated string.
   - Config file example: `"observer_auth_command": ["iap-auth", "--audience", "example"]`
   - Env var example: `CODEMEM_OBSERVER_AUTH_COMMAND='["iap-auth","--audience","example"]'`
 - Header templates support `${auth.token}`, `${auth.type}`, and `${auth.source}` (for example `Authorization: Bearer ${auth.token}`).
+- Queue cadence is configurable with `raw_events_sweeper_interval_s` (seconds) in Settings/config.
 
 ## Export and import
 

--- a/codemem/commands/claude_integration_cmds.py
+++ b/codemem/commands/claude_integration_cmds.py
@@ -106,7 +106,11 @@ def _queue_adapter_event(hook_payload: dict[str, Any], *, store: Any) -> tuple[s
 def _should_flush(hook_event_name: str) -> bool:
     if hook_event_name not in {"Stop", "SessionEnd"}:
         return False
-    return _env_truthy("CODEMEM_CLAUDE_HOOK_FLUSH", True)
+    if not _env_truthy("CODEMEM_CLAUDE_HOOK_FLUSH", True):
+        return False
+    if hook_event_name == "SessionEnd":
+        return True
+    return _env_truthy("CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP", False)
 
 
 def ingest_claude_hook_cmd() -> None:

--- a/codemem/config.py
+++ b/codemem/config.py
@@ -36,6 +36,7 @@ CONFIG_ENV_OVERRIDES = {
     "sync_advertise": "CODEMEM_SYNC_ADVERTISE",
     "sync_projects_include": "CODEMEM_SYNC_PROJECTS_INCLUDE",
     "sync_projects_exclude": "CODEMEM_SYNC_PROJECTS_EXCLUDE",
+    "raw_events_sweeper_interval_s": "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
 }
 
 
@@ -219,6 +220,8 @@ class OpencodeMemConfig:
 
     sync_advertise: str = "auto"
 
+    raw_events_sweeper_interval_s: int = 30
+
     # Basename-based project filters for syncing memory_items.
     # When include is non-empty, only those projects will sync.
     # Exclude always takes precedence.
@@ -399,6 +402,7 @@ def _apply_dict(cfg: OpencodeMemConfig, data: dict[str, Any]) -> OpencodeMemConf
             "plugin_cmd_timeout_ms",
             "sync_port",
             "sync_interval_s",
+            "raw_events_sweeper_interval_s",
         }:
             setattr(cfg, key, _parse_int(value, getattr(cfg, key), key=key))
             continue
@@ -534,6 +538,11 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
     cfg.sync_port = _parse_int(os.getenv("CODEMEM_SYNC_PORT"), cfg.sync_port, key="sync_port")
     cfg.sync_interval_s = _parse_int(
         os.getenv("CODEMEM_SYNC_INTERVAL_S"), cfg.sync_interval_s, key="sync_interval_s"
+    )
+    cfg.raw_events_sweeper_interval_s = _parse_int(
+        os.getenv("CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S"),
+        cfg.raw_events_sweeper_interval_s,
+        key="raw_events_sweeper_interval_s",
     )
     cfg.sync_mdns = _parse_bool(os.getenv("CODEMEM_SYNC_MDNS"), cfg.sync_mdns)
     cfg.sync_key_store = os.getenv("CODEMEM_SYNC_KEY_STORE", cfg.sync_key_store)

--- a/codemem/config.py
+++ b/codemem/config.py
@@ -13,6 +13,13 @@ DEFAULT_CONFIG_PATH_JSONC = Path("~/.config/codemem/config.jsonc").expanduser()
 CONFIG_ENV_OVERRIDES = {
     "observer_provider": "CODEMEM_OBSERVER_PROVIDER",
     "observer_model": "CODEMEM_OBSERVER_MODEL",
+    "observer_runtime": "CODEMEM_OBSERVER_RUNTIME",
+    "observer_auth_source": "CODEMEM_OBSERVER_AUTH_SOURCE",
+    "observer_auth_file": "CODEMEM_OBSERVER_AUTH_FILE",
+    "observer_auth_command": "CODEMEM_OBSERVER_AUTH_COMMAND",
+    "observer_auth_timeout_ms": "CODEMEM_OBSERVER_AUTH_TIMEOUT_MS",
+    "observer_auth_cache_ttl_s": "CODEMEM_OBSERVER_AUTH_CACHE_TTL_S",
+    "observer_headers": "CODEMEM_OBSERVER_HEADERS",
     "observer_max_chars": "CODEMEM_OBSERVER_MAX_CHARS",
     "pack_observation_limit": "CODEMEM_PACK_OBSERVATION_LIMIT",
     "pack_session_limit": "CODEMEM_PACK_SESSION_LIMIT",
@@ -180,6 +187,13 @@ class OpencodeMemConfig:
     observer_provider: str | None = None
     observer_model: str | None = None
     observer_api_key: str | None = None
+    observer_runtime: str = "api_http"
+    observer_auth_source: str = "auto"
+    observer_auth_file: str | None = None
+    observer_auth_command: list[str] = field(default_factory=list)
+    observer_auth_timeout_ms: int = 1500
+    observer_auth_cache_ttl_s: int = 300
+    observer_headers: dict[str, str] = field(default_factory=dict)
     observer_max_chars: int = 12000
     observer_max_tokens: int = 4000
     summary_max_chars: int = 6000
@@ -288,6 +302,69 @@ def _coerce_str_list(value: object, *, key: str) -> list[str] | None:
     return None
 
 
+def _coerce_command(value: object, *, key: str) -> list[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        if any(not isinstance(item, str) for item in value):
+            warnings.warn(
+                f"Invalid command list for {key}: {value!r}", RuntimeWarning, stacklevel=2
+            )
+            return None
+        return list(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            warnings.warn(
+                f"Invalid command list for {key}: {value!r}", RuntimeWarning, stacklevel=2
+            )
+            return None
+        if not isinstance(parsed, list) or any(not isinstance(item, str) for item in parsed):
+            warnings.warn(
+                f"Invalid command list for {key}: {value!r}", RuntimeWarning, stacklevel=2
+            )
+            return None
+        return list(parsed)
+    warnings.warn(f"Invalid command for {key}: {value!r}", RuntimeWarning, stacklevel=2)
+    return None
+
+
+def _coerce_str_map(value: object, *, key: str) -> dict[str, str] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return {}
+        try:
+            value = json.loads(text)
+        except Exception:
+            warnings.warn(f"Invalid object for {key}: {value!r}", RuntimeWarning, stacklevel=2)
+            return None
+    if not isinstance(value, dict):
+        warnings.warn(f"Invalid object for {key}: {value!r}", RuntimeWarning, stacklevel=2)
+        return None
+    parsed: dict[str, str] = {}
+    for map_key, map_value in value.items():
+        if not isinstance(map_key, str) or not isinstance(map_value, str):
+            warnings.warn(
+                f"Invalid header entry for {key}: {map_key!r}", RuntimeWarning, stacklevel=2
+            )
+            return None
+        key_str = map_key.strip()
+        if not key_str:
+            warnings.warn(
+                f"Invalid header key for {key}: {map_key!r}", RuntimeWarning, stacklevel=2
+            )
+            return None
+        parsed[key_str] = map_value
+    return parsed
+
+
 def load_config(path: Path | None = None) -> OpencodeMemConfig:
     cfg = OpencodeMemConfig()
     config_path = get_config_path(path)
@@ -311,6 +388,8 @@ def _apply_dict(cfg: OpencodeMemConfig, data: dict[str, Any]) -> OpencodeMemConf
         if not hasattr(cfg, key):
             continue
         if key in {
+            "observer_auth_timeout_ms",
+            "observer_auth_cache_ttl_s",
             "observer_max_chars",
             "observer_max_tokens",
             "summary_max_chars",
@@ -340,6 +419,16 @@ def _apply_dict(cfg: OpencodeMemConfig, data: dict[str, Any]) -> OpencodeMemConf
         }:
             setattr(cfg, key, _coerce_bool(value, getattr(cfg, key), key=key))
             continue
+        if key == "observer_auth_command":
+            parsed = _coerce_command(value, key=key)
+            if parsed is not None:
+                setattr(cfg, key, parsed)
+            continue
+        if key == "observer_headers":
+            parsed = _coerce_str_map(value, key=key)
+            if parsed is not None:
+                setattr(cfg, key, parsed)
+            continue
         if key in {"sync_projects_include", "sync_projects_exclude"}:
             parsed = _coerce_str_list(value, key=key)
             if parsed is not None:
@@ -358,6 +447,31 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
     cfg.observer_provider = os.getenv("CODEMEM_OBSERVER_PROVIDER", cfg.observer_provider)
     cfg.observer_model = os.getenv("CODEMEM_OBSERVER_MODEL", cfg.observer_model)
     cfg.observer_api_key = os.getenv("CODEMEM_OBSERVER_API_KEY", cfg.observer_api_key)
+    cfg.observer_runtime = os.getenv("CODEMEM_OBSERVER_RUNTIME", cfg.observer_runtime)
+    cfg.observer_auth_source = os.getenv("CODEMEM_OBSERVER_AUTH_SOURCE", cfg.observer_auth_source)
+    cfg.observer_auth_file = os.getenv("CODEMEM_OBSERVER_AUTH_FILE", cfg.observer_auth_file)
+    parsed_auth_command = _coerce_command(
+        os.getenv("CODEMEM_OBSERVER_AUTH_COMMAND"),
+        key="observer_auth_command",
+    )
+    if parsed_auth_command is not None:
+        cfg.observer_auth_command = parsed_auth_command
+    parsed_headers = _coerce_str_map(
+        os.getenv("CODEMEM_OBSERVER_HEADERS"),
+        key="observer_headers",
+    )
+    if parsed_headers is not None:
+        cfg.observer_headers = parsed_headers
+    cfg.observer_auth_timeout_ms = _parse_int(
+        os.getenv("CODEMEM_OBSERVER_AUTH_TIMEOUT_MS"),
+        cfg.observer_auth_timeout_ms,
+        key="observer_auth_timeout_ms",
+    )
+    cfg.observer_auth_cache_ttl_s = _parse_int(
+        os.getenv("CODEMEM_OBSERVER_AUTH_CACHE_TTL_S"),
+        cfg.observer_auth_cache_ttl_s,
+        key="observer_auth_cache_ttl_s",
+    )
     cfg.observer_max_chars = _parse_int(
         os.getenv("CODEMEM_OBSERVER_MAX_CHARS"),
         cfg.observer_max_chars,

--- a/codemem/observer.py
+++ b/codemem/observer.py
@@ -156,6 +156,7 @@ class ObserverClient:
         provider = (cfg.observer_provider or "").lower()
         model = cfg.observer_model or ""
         self._configured_model = model.strip() or None
+        self._sidecar_model = self._configured_model or DEFAULT_ANTHROPIC_MODEL
         custom_providers = _list_custom_providers()
 
         if provider and provider not in {"openai", "anthropic"} | custom_providers:
@@ -198,6 +199,8 @@ class ObserverClient:
             self.model = DEFAULT_OPENAI_MODEL
         else:
             self.model = _resolve_custom_provider_default_model(resolved_provider) or ""
+        if self.runtime == "claude_sidecar":
+            self.model = self._sidecar_model
         self.api_key = cfg.observer_api_key or os.getenv("CODEMEM_OBSERVER_API_KEY")
         self.max_chars = cfg.observer_max_chars
         self.max_tokens = cfg.observer_max_tokens
@@ -341,8 +344,8 @@ class ObserverClient:
             "--permission-mode",
             "bypassPermissions",
         ]
-        if use_model and self._configured_model:
-            cmd.extend(["--model", self._configured_model])
+        if use_model and self._sidecar_model:
+            cmd.extend(["--model", self._sidecar_model])
         cmd.append(prompt)
         return cmd
 
@@ -397,10 +400,10 @@ class ObserverClient:
 
     def _call_claude_sidecar(self, prompt: str) -> str | None:
         output, error = self._invoke_claude_sidecar(prompt, use_model=True)
-        if error and self._configured_model and _is_claude_sidecar_model_error(error):
+        if error and self._sidecar_model and _is_claude_sidecar_model_error(error):
             logger.warning(
                 "observer claude_sidecar model unsupported; retrying with default model",
-                extra={"model": self._configured_model},
+                extra={"model": self._sidecar_model},
             )
             output, error = self._invoke_claude_sidecar(prompt, use_model=False)
         if error:

--- a/codemem/observer.py
+++ b/codemem/observer.py
@@ -51,9 +51,11 @@ _build_codex_headers = _observer_auth._build_codex_headers
 _extract_oauth_access = _observer_auth._extract_oauth_access
 _extract_oauth_account_id = _observer_auth._extract_oauth_account_id
 _extract_oauth_expires = _observer_auth._extract_oauth_expires
-_get_iap_token = _observer_auth._get_iap_token
 _get_opencode_auth_path = _observer_auth._get_opencode_auth_path
 _now_ms = _observer_auth._now_ms
+ObserverAuthAdapter = _observer_auth.ObserverAuthAdapter
+ObserverAuthMaterial = _observer_auth.ObserverAuthMaterial
+_render_observer_headers = _observer_auth._render_observer_headers
 _redact_text = _observer_codex._redact_text
 _resolve_oauth_provider = _observer_auth._resolve_oauth_provider
 
@@ -126,9 +128,24 @@ class ObserverClient:
             resolved_provider = "openai"
 
         self.provider = resolved_provider
+        self._configured_provider = provider or None
         self.use_opencode_run = cfg.use_opencode_run
+        runtime = (cfg.observer_runtime or "api_http").strip().lower()
+        if runtime == "claude_sidecar":
+            logger.warning("observer runtime claude_sidecar is not implemented yet; using api_http")
+            runtime = "api_http"
+        self.runtime = runtime if runtime in {"api_http"} else "api_http"
         self.opencode_model = cfg.opencode_model
         self.opencode_agent = cfg.opencode_agent
+        self.observer_headers = dict(cfg.observer_headers or {})
+        self.auth_adapter = ObserverAuthAdapter(
+            source=cfg.observer_auth_source,
+            file_path=cfg.observer_auth_file,
+            command=tuple(cfg.observer_auth_command or []),
+            timeout_ms=max(100, int(cfg.observer_auth_timeout_ms or 1500)),
+            cache_ttl_s=max(0, int(cfg.observer_auth_cache_ttl_s or 300)),
+        )
+        self.auth = ObserverAuthMaterial(token=None, auth_type="none", source="none")
         if model:
             self.model = model
         elif resolved_provider == "anthropic":
@@ -143,73 +160,106 @@ class ObserverClient:
         self.client: object | None = None
         self.codex_access: str | None = None
         self.codex_account_id: str | None = None
+
+        self._init_provider_client(force_refresh=False)
+
+    def _init_provider_client(self, *, force_refresh: bool) -> None:
+        self.client = None
+        self.codex_access = None
+        self.codex_account_id = None
+
         oauth_cache = _load_opencode_oauth_cache()
         oauth_access = None
         oauth_expires = None
         oauth_provider = None
-        if resolved_provider in {"openai", "anthropic"}:
-            oauth_provider = _resolve_oauth_provider(provider or None, self.model)
+        if self.provider in {"openai", "anthropic"}:
+            oauth_provider = _resolve_oauth_provider(self._configured_provider, self.model)
             oauth_access = _extract_oauth_access(oauth_cache, oauth_provider)
             oauth_expires = _extract_oauth_expires(oauth_cache, oauth_provider)
-            if oauth_access and (oauth_expires is None or oauth_expires > _now_ms()):
-                self.codex_access = oauth_access
-                self.codex_account_id = _extract_oauth_account_id(oauth_cache, oauth_provider)
+            if oauth_access and oauth_expires is not None and oauth_expires <= _now_ms():
+                oauth_access = None
         if self.use_opencode_run:
             logger.info("observer auth: using opencode run")
             return
-        if resolved_provider not in {"openai", "anthropic"}:
-            provider_config = _get_opencode_provider_config(resolved_provider)
+
+        if self.provider not in {"openai", "anthropic"}:
+            provider_config = _get_opencode_provider_config(self.provider)
             base_url, model_id, headers = _resolve_custom_provider_model(
-                resolved_provider,
+                self.provider,
                 self.model,
             )
             if not base_url or not model_id:
                 logger.warning("observer auth: missing custom provider config")
                 return
             api_key = _get_provider_api_key(provider_config) or self.api_key
+            merged_headers = dict(headers)
+            merged_headers.update(self.observer_headers)
+            self.auth = self.auth_adapter.resolve(
+                explicit_token=api_key,
+                env_tokens=(os.getenv("CODEMEM_OBSERVER_API_KEY") or "",),
+                force_refresh=force_refresh,
+            )
+            rendered_headers = _render_observer_headers(merged_headers, self.auth)
             try:
                 from openai import OpenAI  # type: ignore
 
                 self.client = OpenAI(
-                    api_key=api_key or "unused",
+                    api_key=self.auth.token or "unused",
                     base_url=base_url,
-                    default_headers=headers or None,
+                    default_headers=rendered_headers or None,
                 )
                 self.model = model_id
             except Exception as exc:  # pragma: no cover
                 logger.exception("observer auth: custom provider client init failed", exc_info=exc)
                 self.client = None
-        elif resolved_provider == "anthropic":
-            if not self.api_key:
-                self.api_key = os.getenv("ANTHROPIC_API_KEY") or oauth_access
-            if not self.api_key:
+        elif self.provider == "anthropic":
+            self.auth = self.auth_adapter.resolve(
+                explicit_token=self.api_key,
+                env_tokens=(os.getenv("ANTHROPIC_API_KEY") or "",),
+                oauth_token=oauth_access,
+                force_refresh=force_refresh,
+            )
+            if not self.auth.token:
                 logger.warning("observer auth: missing anthropic api key")
                 return
             try:
                 import anthropic  # type: ignore
 
-                self.client = anthropic.Anthropic(api_key=self.api_key)
+                self.client = anthropic.Anthropic(api_key=self.auth.token)
             except Exception as exc:  # pragma: no cover
                 logger.exception("observer auth: anthropic client init failed", exc_info=exc)
                 self.client = None
         else:
-            if not self.api_key:
-                self.api_key = (
-                    os.getenv("OPENCODE_API_KEY")
-                    or os.getenv("OPENAI_API_KEY")
-                    or os.getenv("CODEX_API_KEY")
-                    or oauth_access
+            self.auth = self.auth_adapter.resolve(
+                explicit_token=self.api_key,
+                env_tokens=(
+                    os.getenv("OPENCODE_API_KEY") or "",
+                    os.getenv("OPENAI_API_KEY") or "",
+                    os.getenv("CODEX_API_KEY") or "",
+                ),
+                oauth_token=oauth_access,
+                force_refresh=force_refresh,
+            )
+            if self.auth.source == "oauth" and oauth_access:
+                self.codex_access = oauth_access
+                self.codex_account_id = _extract_oauth_account_id(
+                    oauth_cache, oauth_provider or "openai"
                 )
-            if not self.api_key:
+            if not self.auth.token:
                 logger.warning("observer auth: missing openai api key")
                 return
             try:
                 from openai import OpenAI  # type: ignore
 
-                self.client = OpenAI(api_key=self.api_key)
+                self.client = OpenAI(api_key=self.auth.token)
             except Exception as exc:  # pragma: no cover
                 logger.exception("observer auth: openai client init failed", exc_info=exc)
                 self.client = None
+
+    def _refresh_provider_client(self) -> bool:
+        self.auth_adapter.invalidate_cache()
+        self._init_provider_client(force_refresh=True)
+        return self.client is not None or bool(self.codex_access)
 
     def observe(self, context: ObserverContext) -> ObserverResponse:
         prompt = build_observer_prompt(context)
@@ -222,6 +272,20 @@ class ObserverClient:
     def _call(self, prompt: str) -> str | None:
         if self.use_opencode_run:
             return self._call_opencode_run(prompt)
+        try:
+            return self._call_once(prompt)
+        except ObserverAuthError as exc:
+            logger.warning(
+                "observer auth error: %s (provider=%s, model=%s)",
+                exc,
+                self.provider,
+                self.model,
+            )
+            if not self._refresh_provider_client():
+                raise
+            return self._call_once(prompt)
+
+    def _call_once(self, prompt: str) -> str | None:
         if self.codex_access:
             return self._call_codex(prompt)
         if not self.client:
@@ -236,7 +300,6 @@ class ObserverClient:
                     max_tokens_to_sample=self.max_tokens,
                 )
                 return resp.completion
-            # OpenAI and custom providers use OpenAI-compatible APIs
             resp = self.client.chat.completions.create(  # type: ignore[union-attr]
                 model=self.model,
                 messages=[
@@ -249,12 +312,6 @@ class ObserverClient:
             return resp.choices[0].message.content
         except Exception as exc:  # pragma: no cover
             if _is_auth_error(exc):
-                logger.warning(
-                    "observer auth error: %s (provider=%s, model=%s)",
-                    exc,
-                    self.provider,
-                    self.model,
-                )
                 raise ObserverAuthError(str(exc)) from exc
             logger.exception(
                 "observer call failed",
@@ -303,6 +360,13 @@ class ObserverClient:
             logger.warning("observer auth: missing codex access token")
             return None
         headers = _build_codex_headers(self.codex_access, self.codex_account_id)
+        if self.observer_headers:
+            codex_auth = ObserverAuthMaterial(
+                token=self.codex_access,
+                auth_type="bearer",
+                source=self.auth.source,
+            )
+            headers.update(_render_observer_headers(self.observer_headers, codex_auth))
         payload = _build_codex_payload(self.model, prompt, self.max_tokens)
         endpoint = _resolve_codex_endpoint()
 

--- a/codemem/observer.py
+++ b/codemem/observer.py
@@ -22,6 +22,8 @@ DEFAULT_CODEX_ENDPOINT = _observer_codex.DEFAULT_CODEX_ENDPOINT
 
 logger = logging.getLogger(__name__)
 
+_CLAUDE_SIDECAR_TIMEOUT_S = 45
+
 
 class ObserverAuthError(Exception):
     """Raised when the observer encounters an authentication/authorization failure.
@@ -44,6 +46,47 @@ def _is_auth_error(exc: Exception) -> bool:
     # HTTP status code check for generic cases
     status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
     return isinstance(status, int) and status in (401, 403)
+
+
+def _extract_claude_result_payload(output: str) -> dict[str, Any] | None:
+    if not output:
+        return None
+    for line in reversed(output.splitlines()):
+        text = line.strip()
+        if not text:
+            continue
+        try:
+            payload = json.loads(text)
+        except Exception:
+            continue
+        if isinstance(payload, dict) and payload.get("type") == "result":
+            return payload
+    return None
+
+
+def _is_claude_sidecar_model_error(message: str) -> bool:
+    lowered = message.lower()
+    return (
+        "issue with the selected model" in lowered
+        or "run --model to pick a different model" in lowered
+        or "model" in lowered
+        and "may not exist" in lowered
+    )
+
+
+def _is_claude_sidecar_auth_error(message: str) -> bool:
+    lowered = message.lower()
+    checks = (
+        "not logged in",
+        "login",
+        "authentication",
+        "unauthorized",
+        "permission denied",
+        "api key",
+        "anthropic_api_key",
+        "setup-token",
+    )
+    return any(token in lowered for token in checks)
 
 
 _REDACT_PATTERNS = _observer_codex._REDACT_PATTERNS
@@ -112,6 +155,7 @@ class ObserverClient:
         cfg = load_config()
         provider = (cfg.observer_provider or "").lower()
         model = cfg.observer_model or ""
+        self._configured_model = model.strip() or None
         custom_providers = _list_custom_providers()
 
         if provider and provider not in {"openai", "anthropic"} | custom_providers:
@@ -130,11 +174,11 @@ class ObserverClient:
         self.provider = resolved_provider
         self._configured_provider = provider or None
         self.use_opencode_run = cfg.use_opencode_run
-        runtime = (cfg.observer_runtime or "api_http").strip().lower()
-        if runtime == "claude_sidecar":
-            logger.warning("observer runtime claude_sidecar is not implemented yet; using api_http")
+        runtime_raw = cfg.observer_runtime
+        runtime = runtime_raw.strip().lower() if isinstance(runtime_raw, str) else "api_http"
+        if runtime not in {"api_http", "claude_sidecar"}:
             runtime = "api_http"
-        self.runtime = runtime if runtime in {"api_http"} else "api_http"
+        self.runtime = runtime
         self.opencode_model = cfg.opencode_model
         self.opencode_agent = cfg.opencode_agent
         self.observer_headers = dict(cfg.observer_headers or {})
@@ -161,7 +205,8 @@ class ObserverClient:
         self.codex_access: str | None = None
         self.codex_account_id: str | None = None
 
-        self._init_provider_client(force_refresh=False)
+        if self.runtime == "api_http":
+            self._init_provider_client(force_refresh=False)
 
     def _init_provider_client(self, *, force_refresh: bool) -> None:
         self.client = None
@@ -272,6 +317,8 @@ class ObserverClient:
     def _call(self, prompt: str) -> str | None:
         if self.use_opencode_run:
             return self._call_opencode_run(prompt)
+        if self.runtime == "claude_sidecar":
+            return self._call_claude_sidecar(prompt)
         try:
             return self._call_once(prompt)
         except ObserverAuthError as exc:
@@ -284,6 +331,84 @@ class ObserverClient:
             if not self._refresh_provider_client():
                 raise
             return self._call_once(prompt)
+
+    def _claude_sidecar_cmd(self, prompt: str, *, use_model: bool) -> list[str]:
+        cmd = [
+            "claude",
+            "-p",
+            "--output-format",
+            "json",
+            "--permission-mode",
+            "bypassPermissions",
+        ]
+        if use_model and self._configured_model:
+            cmd.extend(["--model", self._configured_model])
+        cmd.append(prompt)
+        return cmd
+
+    def _invoke_claude_sidecar(
+        self, prompt: str, *, use_model: bool
+    ) -> tuple[str | None, str | None]:
+        cmd = self._claude_sidecar_cmd(prompt, use_model=use_model)
+        env = dict(os.environ)
+        env.update(
+            {
+                "CODEMEM_PLUGIN_IGNORE": "1",
+                "CODEMEM_VIEWER": "0",
+                "CODEMEM_VIEWER_AUTO": "0",
+                "CODEMEM_VIEWER_AUTO_STOP": "0",
+            }
+        )
+        try:
+            result = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_CLAUDE_SIDECAR_TIMEOUT_S,
+                env=env,
+            )
+        except FileNotFoundError:
+            logger.warning("observer claude_sidecar unavailable: claude command not found")
+            return None, "claude command not found"
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "observer claude_sidecar timed out", extra={"timeout_s": _CLAUDE_SIDECAR_TIMEOUT_S}
+            )
+            return None, "claude sidecar call timed out"
+        except Exception as exc:  # pragma: no cover
+            logger.exception("observer claude_sidecar call failed", exc_info=exc)
+            return None, str(exc)
+
+        payload = _extract_claude_result_payload(result.stdout)
+        if payload is not None:
+            message = str(payload.get("result") or "").strip()
+            is_error = bool(payload.get("is_error"))
+            if is_error:
+                return None, message or "claude sidecar returned an error"
+            return (message or None), None
+
+        if result.returncode != 0:
+            message = (result.stderr or "").strip() or (result.stdout or "").strip()
+            return None, message or f"claude sidecar exited with code {result.returncode}"
+
+        text = (result.stdout or "").strip()
+        return (text or None), None
+
+    def _call_claude_sidecar(self, prompt: str) -> str | None:
+        output, error = self._invoke_claude_sidecar(prompt, use_model=True)
+        if error and self._configured_model and _is_claude_sidecar_model_error(error):
+            logger.warning(
+                "observer claude_sidecar model unsupported; retrying with default model",
+                extra={"model": self._configured_model},
+            )
+            output, error = self._invoke_claude_sidecar(prompt, use_model=False)
+        if error:
+            if _is_claude_sidecar_auth_error(error):
+                raise ObserverAuthError(error)
+            logger.warning("observer claude_sidecar call failed: %s", error)
+            return None
+        return output
 
     def _call_once(self, prompt: str) -> str | None:
         if self.codex_access:

--- a/codemem/observer.py
+++ b/codemem/observer.py
@@ -417,8 +417,12 @@ class ObserverClient:
         if self.codex_access:
             return self._call_codex(prompt)
         if not self.client:
-            logger.warning("observer auth: missing client and codex token")
-            return None
+            self._refresh_provider_client()
+            if self.codex_access:
+                return self._call_codex(prompt)
+            if not self.client:
+                logger.warning("observer auth: missing client and codex token")
+                return None
         try:
             if self.provider == "anthropic":
                 resp = self.client.completions.create(  # type: ignore[union-attr]

--- a/codemem/observer_auth.py
+++ b/codemem/observer_auth.py
@@ -218,7 +218,7 @@ class ObserverAuthAdapter:
 
         token = None
         token_source = "none"
-        if source in {"auto", "env"}:
+        if source == "auto":
             if explicit_token:
                 token = explicit_token
                 token_source = "explicit"
@@ -229,6 +229,10 @@ class ObserverAuthAdapter:
             if not token and oauth_token and source == "auto":
                 token = oauth_token
                 token_source = "oauth"
+        elif source == "env":
+            token = next((value for value in env_tokens if value), None)
+            if token:
+                token_source = "env"
 
         if source in {"auto", "file"} and not token:
             token = _read_auth_file(self.file_path)

--- a/codemem/observer_auth.py
+++ b/codemem/observer_auth.py
@@ -5,7 +5,9 @@ import logging
 import os
 import platform
 import re
+import subprocess
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +19,9 @@ _REDACT_PATTERNS = (
     re.compile(r"sk-[A-Za-z0-9]{10,}"),
     re.compile(r"Bearer\s+[A-Za-z0-9._-]{10,}"),
 )
+_AUTH_TOKEN_TEMPLATE = re.compile(r"\$\{auth\.token\}")
+_AUTH_TYPE_TEMPLATE = re.compile(r"\$\{auth\.type\}")
+_AUTH_SOURCE_TEMPLATE = re.compile(r"\$\{auth\.source\}")
 
 
 def _get_iap_token() -> str | None:
@@ -109,3 +114,167 @@ def _redact_text(text: str, limit: int = 400) -> str:
     if len(redacted) > limit:
         return f"{redacted[:limit]}…"
     return redacted
+
+
+def _normalize_auth_source(value: str | None) -> str:
+    normalized = (value or "").strip().lower()
+    if normalized in {"", "auto", "env", "file", "command", "none"}:
+        return normalized or "auto"
+    return "auto"
+
+
+def _run_auth_command(command: tuple[str, ...], timeout_ms: int) -> str | None:
+    if not command:
+        return None
+    timeout_s = max(0.1, timeout_ms / 1000.0)
+    try:
+        result = subprocess.run(
+            list(command),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        logger.warning(
+            "observer auth command timed out",
+            extra={"command": command[0], "timeout_ms": timeout_ms},
+            exc_info=exc,
+        )
+        return None
+    except Exception as exc:
+        logger.warning(
+            "observer auth command failed",
+            extra={"command": command[0]},
+            exc_info=exc,
+        )
+        return None
+
+    if result.returncode != 0:
+        logger.warning(
+            "observer auth command returned non-zero",
+            extra={
+                "command": command[0],
+                "returncode": result.returncode,
+                "stderr": _redact_text((result.stderr or "").strip()),
+            },
+        )
+        return None
+
+    token = (result.stdout or "").strip()
+    return token or None
+
+
+def _read_auth_file(file_path: str | None) -> str | None:
+    if not file_path:
+        return None
+    path = Path(os.path.expanduser(os.path.expandvars(file_path))).resolve()
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        token = path.read_text().strip()
+    except Exception as exc:
+        logger.warning("observer auth file read failed", extra={"path": str(path)}, exc_info=exc)
+        return None
+    return token or None
+
+
+@dataclass(frozen=True)
+class ObserverAuthMaterial:
+    token: str | None
+    auth_type: str = "none"
+    source: str = "none"
+
+
+@dataclass
+class ObserverAuthAdapter:
+    source: str = "auto"
+    file_path: str | None = None
+    command: tuple[str, ...] = ()
+    timeout_ms: int = 1500
+    cache_ttl_s: int = 300
+    _cached: ObserverAuthMaterial = field(
+        default_factory=lambda: ObserverAuthMaterial(token=None, auth_type="none", source="none")
+    )
+    _cached_at_monotonic_s: float = 0.0
+
+    def resolve(
+        self,
+        *,
+        explicit_token: str | None = None,
+        env_tokens: tuple[str, ...] = (),
+        oauth_token: str | None = None,
+        force_refresh: bool = False,
+    ) -> ObserverAuthMaterial:
+        source = _normalize_auth_source(self.source)
+
+        if source == "none":
+            return ObserverAuthMaterial(token=None, auth_type="none", source="none")
+
+        if not force_refresh and source in {"command", "file"} and self.cache_ttl_s > 0:
+            age_s = time.monotonic() - self._cached_at_monotonic_s
+            if self._cached_at_monotonic_s > 0 and age_s <= self.cache_ttl_s:
+                return self._cached
+
+        token = None
+        token_source = "none"
+        if source in {"auto", "env"}:
+            if explicit_token:
+                token = explicit_token
+                token_source = "explicit"
+            if not token:
+                token = next((value for value in env_tokens if value), None)
+                if token:
+                    token_source = "env"
+            if not token and oauth_token and source == "auto":
+                token = oauth_token
+                token_source = "oauth"
+
+        if source in {"auto", "file"} and not token:
+            token = _read_auth_file(self.file_path)
+            if token:
+                token_source = "file"
+
+        if source in {"auto", "command"} and not token:
+            token = _run_auth_command(self.command, self.timeout_ms)
+            if token:
+                token_source = "command"
+
+        resolved = (
+            ObserverAuthMaterial(token=token, auth_type="bearer", source=token_source)
+            if token
+            else ObserverAuthMaterial(token=None, auth_type="none", source="none")
+        )
+
+        should_cache = source in {"command", "file"}
+        if should_cache and resolved.token:
+            self._cached = resolved
+            self._cached_at_monotonic_s = time.monotonic()
+        elif should_cache:
+            self.invalidate_cache()
+        return resolved
+
+    def invalidate_cache(self) -> None:
+        self._cached = ObserverAuthMaterial(token=None, auth_type="none", source="none")
+        self._cached_at_monotonic_s = 0.0
+
+
+def _render_observer_headers(
+    headers: dict[str, str],
+    auth: ObserverAuthMaterial,
+) -> dict[str, str]:
+    rendered: dict[str, str] = {}
+    token = auth.token or ""
+    for key, value in headers.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            continue
+        candidate = _AUTH_TOKEN_TEMPLATE.sub(token, value)
+        candidate = _AUTH_TYPE_TEMPLATE.sub(auth.auth_type, candidate)
+        candidate = _AUTH_SOURCE_TEMPLATE.sub(auth.source, candidate)
+        if "${auth.token}" in value and not token:
+            continue
+        cleaned = candidate.strip()
+        if not cleaned:
+            continue
+        rendered[key] = cleaned
+    return rendered

--- a/codemem/viewer_raw_events.py
+++ b/codemem/viewer_raw_events.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 
+from .config import load_config
 from .db import DEFAULT_DB_PATH
 from .observer import ObserverAuthError
 from .raw_event_flush import flush_raw_events
@@ -104,11 +105,14 @@ class RawEventSweeper:
         return value not in {"0", "false", "off"}
 
     def interval_ms(self) -> int:
-        value = os.environ.get("CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS", "30000")
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return 30000
+        env_value = os.environ.get("CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS")
+        if env_value is not None:
+            try:
+                return int(env_value)
+            except (TypeError, ValueError):
+                return 30000
+        interval_s = load_config().raw_events_sweeper_interval_s
+        return max(1000, int(interval_s) * 1000)
 
     def idle_ms(self) -> int:
         value = os.environ.get("CODEMEM_RAW_EVENTS_SWEEPER_IDLE_MS", "120000")

--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -129,6 +129,7 @@ def handle_post(
         "sync_port",
         "sync_interval_s",
         "sync_mdns",
+        "raw_events_sweeper_interval_s",
     }
     allowed_providers = set(load_provider_options())
 
@@ -284,6 +285,15 @@ def handle_post(
             parsed = _as_positive_int(value, key=key)
             if parsed is None:
                 handler._send_json({"error": f"{key} must be int"}, status=400)
+                return True
+            config_data[key] = parsed
+            continue
+        if key == "raw_events_sweeper_interval_s":
+            parsed = _as_positive_int(value, key=key)
+            if parsed is None:
+                handler._send_json(
+                    {"error": "raw_events_sweeper_interval_s must be int"}, status=400
+                )
                 return True
             config_data[key] = parsed
             continue

--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import asdict
 from typing import Any, Protocol
 
@@ -21,11 +22,47 @@ class _ViewerHandler(Protocol):
     def _send_json(self, payload: dict[str, Any], status: int = 200) -> None: ...
 
 
+_RUNTIMES = {"api_http", "claude_sidecar"}
+_AUTH_SOURCES = {"auto", "env", "file", "command", "none"}
+
+
+def _as_positive_int(value: Any, *, key: str, allow_zero: bool = False) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if allow_zero:
+        return parsed if parsed >= 0 else None
+    return parsed if parsed > 0 else None
+
+
+def _as_string_map(value: Any) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    parsed: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            return None
+        stripped = key.strip()
+        if not stripped:
+            return None
+        parsed[stripped] = item
+    return parsed
+
+
+def _as_command_argv(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    if any(not isinstance(item, str) for item in value):
+        return None
+    return list(value)
+
+
 def handle_get(
     handler: _ViewerHandler,
     *,
     path: str,
-    load_provider_options: callable,
+    load_provider_options: Callable[[], list[str]],
 ) -> bool:
     if path != "/api/config":
         return False
@@ -54,7 +91,7 @@ def handle_post(
     handler: _ViewerHandler,
     *,
     path: str,
-    load_provider_options: callable,
+    load_provider_options: Callable[[], list[str]],
 ) -> bool:
     if path != "/api/config":
         return False
@@ -77,6 +114,13 @@ def handle_post(
     allowed_keys = {
         "observer_provider",
         "observer_model",
+        "observer_runtime",
+        "observer_auth_source",
+        "observer_auth_file",
+        "observer_auth_command",
+        "observer_auth_timeout_ms",
+        "observer_auth_cache_ttl_s",
+        "observer_headers",
         "observer_max_chars",
         "pack_observation_limit",
         "pack_session_limit",
@@ -125,27 +169,100 @@ def handle_post(
                 continue
             config_data[key] = model_value
             continue
+        if key == "observer_runtime":
+            if not isinstance(value, str):
+                handler._send_json({"error": "observer_runtime must be string"}, status=400)
+                return True
+            runtime = value.strip().lower()
+            if runtime not in _RUNTIMES:
+                handler._send_json(
+                    {"error": "observer_runtime must be one of: api_http, claude_sidecar"},
+                    status=400,
+                )
+                return True
+            config_data[key] = runtime
+            continue
+        if key == "observer_auth_source":
+            if not isinstance(value, str):
+                handler._send_json({"error": "observer_auth_source must be string"}, status=400)
+                return True
+            source = value.strip().lower()
+            if source not in _AUTH_SOURCES:
+                handler._send_json(
+                    {
+                        "error": "observer_auth_source must be one of: auto, env, file, command, none"
+                    },
+                    status=400,
+                )
+                return True
+            config_data[key] = source
+            continue
+        if key == "observer_auth_file":
+            if not isinstance(value, str):
+                handler._send_json({"error": "observer_auth_file must be string"}, status=400)
+                return True
+            file_path = value.strip()
+            if not file_path:
+                config_data.pop(key, None)
+                continue
+            config_data[key] = file_path
+            continue
+        if key == "observer_auth_command":
+            argv = _as_command_argv(value)
+            if argv is None:
+                handler._send_json(
+                    {"error": "observer_auth_command must be string array"}, status=400
+                )
+                return True
+            if argv:
+                config_data[key] = argv
+            else:
+                config_data.pop(key, None)
+            continue
+        if key == "observer_headers":
+            headers = _as_string_map(value)
+            if headers is None:
+                handler._send_json(
+                    {"error": "observer_headers must be object of string values"}, status=400
+                )
+                return True
+            if headers:
+                config_data[key] = headers
+            else:
+                config_data.pop(key, None)
+            continue
+        if key == "observer_auth_timeout_ms":
+            timeout_ms = _as_positive_int(value, key=key)
+            if timeout_ms is None:
+                handler._send_json(
+                    {"error": "observer_auth_timeout_ms must be positive int"}, status=400
+                )
+                return True
+            config_data[key] = timeout_ms
+            continue
+        if key == "observer_auth_cache_ttl_s":
+            ttl_s = _as_positive_int(value, key=key, allow_zero=True)
+            if ttl_s is None:
+                handler._send_json(
+                    {"error": "observer_auth_cache_ttl_s must be non-negative int"},
+                    status=400,
+                )
+                return True
+            config_data[key] = ttl_s
+            continue
         if key == "observer_max_chars":
-            try:
-                value = int(value)
-            except (TypeError, ValueError):
+            parsed = _as_positive_int(value, key=key)
+            if parsed is None:
                 handler._send_json({"error": "observer_max_chars must be int"}, status=400)
                 return True
-            if value <= 0:
-                handler._send_json({"error": "observer_max_chars must be positive"}, status=400)
-                return True
-            config_data[key] = value
+            config_data[key] = parsed
             continue
         if key in {"pack_observation_limit", "pack_session_limit"}:
-            try:
-                value = int(value)
-            except (TypeError, ValueError):
+            parsed = _as_positive_int(value, key=key)
+            if parsed is None:
                 handler._send_json({"error": f"{key} must be int"}, status=400)
                 return True
-            if value <= 0:
-                handler._send_json({"error": f"{key} must be positive"}, status=400)
-                return True
-            config_data[key] = value
+            config_data[key] = parsed
             continue
         if key in {"sync_enabled", "sync_mdns"}:
             if not isinstance(value, bool):
@@ -164,15 +281,11 @@ def handle_post(
             config_data[key] = host_value
             continue
         if key in {"sync_port", "sync_interval_s"}:
-            try:
-                value = int(value)
-            except (TypeError, ValueError):
+            parsed = _as_positive_int(value, key=key)
+            if parsed is None:
                 handler._send_json({"error": f"{key} must be int"}, status=400)
                 return True
-            if value <= 0:
-                handler._send_json({"error": f"{key} must be positive"}, status=400)
-                return True
-            config_data[key] = value
+            config_data[key] = parsed
             continue
 
     try:

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1711,11 +1711,12 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       const authCommand = parseCommandArgv(authCommandInput);
       const headers = parseObserverHeaders(observerHeadersInput);
       const authCacheTtl = authCacheTtlInput === "" ? "" : Number(authCacheTtlInput);
-      const sweeperInterval = sweeperIntervalInput === "" ? "" : Number(sweeperIntervalInput);
+      const sweeperIntervalNum = Number(sweeperIntervalInput);
+      const sweeperInterval = sweeperIntervalInput === "" ? "" : sweeperIntervalNum;
       if (authCacheTtlInput !== "" && !Number.isFinite(authCacheTtl)) {
         throw new Error("observer auth cache ttl must be a number");
       }
-      if (sweeperIntervalInput !== "" && (!Number.isFinite(sweeperInterval) || sweeperInterval <= 0)) {
+      if (sweeperIntervalInput !== "" && (!Number.isFinite(sweeperIntervalNum) || sweeperIntervalNum <= 0)) {
         throw new Error("raw-event sweeper interval must be a positive number");
       }
       await saveConfig({

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1507,6 +1507,39 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   let settingsOpen = false;
   let previouslyFocused = null;
   let settingsActiveTab = "observer";
+  function hasOwn(obj, key) {
+    return typeof obj === "object" && obj !== null && Object.prototype.hasOwnProperty.call(obj, key);
+  }
+  function configuredOrEffective(config, effective, key) {
+    if (hasOwn(config, key)) return config[key];
+    if (hasOwn(effective, key)) return effective[key];
+    return void 0;
+  }
+  function asInputString(value) {
+    if (value === void 0 || value === null) return "";
+    return String(value);
+  }
+  function toProviderList(value) {
+    if (!Array.isArray(value)) return [];
+    return value.filter((item) => typeof item === "string" && item.trim().length > 0);
+  }
+  function setProviderOptions(selectEl, providers, currentValue) {
+    if (!selectEl) return;
+    const values = new Set(providers);
+    if (currentValue) values.add(currentValue);
+    selectEl.innerHTML = "";
+    const autoOption = document.createElement("option");
+    autoOption.value = "";
+    autoOption.textContent = "auto (default)";
+    selectEl.append(autoOption);
+    Array.from(values).sort((a, b) => a.localeCompare(b)).forEach((provider) => {
+      const option = document.createElement("option");
+      option.value = provider;
+      option.textContent = provider;
+      selectEl.append(option);
+    });
+    selectEl.value = currentValue;
+  }
   function getFocusableNodes(container) {
     if (!container) return [];
     const selector = [
@@ -1549,6 +1582,9 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (!payload || typeof payload !== "object") return;
     const defaults = payload.defaults || {};
     const config = payload.config || {};
+    const effective = payload.effective || {};
+    const envOverrides = payload.env_overrides && typeof payload.env_overrides === "object" ? payload.env_overrides : {};
+    const providers = toProviderList(payload.providers);
     state.configDefaults = defaults;
     state.configPath = payload.path || "";
     const observerProvider = $select("observerProvider");
@@ -1570,48 +1606,60 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const syncInterval = $input("syncInterval");
     const syncMdns = $input("syncMdns");
     const settingsPath = $("settingsPath");
+    const observerModelHint = $("observerModelHint");
     const observerMaxCharsHint = $("observerMaxCharsHint");
     const settingsEffective = $("settingsEffective");
-    if (observerProvider) observerProvider.value = config.observer_provider || "";
-    if (observerModel) observerModel.value = config.observer_model || "";
-    if (observerRuntime) observerRuntime.value = config.observer_runtime || "api_http";
-    if (observerAuthSource) observerAuthSource.value = config.observer_auth_source || "auto";
-    if (observerAuthFile) observerAuthFile.value = config.observer_auth_file || "";
+    const observerProviderValue = asInputString(configuredOrEffective(config, effective, "observer_provider"));
+    setProviderOptions(observerProvider, providers, observerProviderValue);
+    const observerModelValue = asInputString(configuredOrEffective(config, effective, "observer_model"));
+    if (observerModel) observerModel.value = observerModelValue;
+    if (observerRuntime) observerRuntime.value = asInputString(configuredOrEffective(config, effective, "observer_runtime")) || "api_http";
+    if (observerAuthSource) observerAuthSource.value = asInputString(configuredOrEffective(config, effective, "observer_auth_source")) || "auto";
+    if (observerAuthFile) observerAuthFile.value = asInputString(configuredOrEffective(config, effective, "observer_auth_file"));
     if (observerAuthCommand) {
-      const argv = Array.isArray(config.observer_auth_command) ? config.observer_auth_command : [];
-      observerAuthCommand.value = argv.length ? JSON.stringify(argv, null, 2) : "";
+      const argv = configuredOrEffective(config, effective, "observer_auth_command");
+      const command = Array.isArray(argv) ? argv : [];
+      const commandStrings = command.filter((item) => typeof item === "string");
+      observerAuthCommand.value = commandStrings.length ? JSON.stringify(commandStrings, null, 2) : "";
     }
     if (observerAuthTimeoutMs) {
-      const timeoutMs = config.observer_auth_timeout_ms;
-      observerAuthTimeoutMs.value = timeoutMs === void 0 || timeoutMs === null ? "" : String(timeoutMs);
+      observerAuthTimeoutMs.value = asInputString(configuredOrEffective(config, effective, "observer_auth_timeout_ms"));
     }
     if (observerAuthCacheTtlS) {
-      const cacheTtl = config.observer_auth_cache_ttl_s;
-      observerAuthCacheTtlS.value = cacheTtl === void 0 || cacheTtl === null ? "" : String(cacheTtl);
+      observerAuthCacheTtlS.value = asInputString(configuredOrEffective(config, effective, "observer_auth_cache_ttl_s"));
     }
     if (observerHeaders) {
-      const headers = config.observer_headers && typeof config.observer_headers === "object" ? config.observer_headers : {};
+      const headerValue = configuredOrEffective(config, effective, "observer_headers");
+      const headers = headerValue && typeof headerValue === "object" ? headerValue : {};
       observerHeaders.value = Object.keys(headers).length ? JSON.stringify(headers, null, 2) : "";
     }
-    if (observerMaxChars) observerMaxChars.value = config.observer_max_chars || "";
-    if (packObservationLimit) packObservationLimit.value = config.pack_observation_limit || "";
-    if (packSessionLimit) packSessionLimit.value = config.pack_session_limit || "";
+    if (observerMaxChars) observerMaxChars.value = asInputString(configuredOrEffective(config, effective, "observer_max_chars"));
+    if (packObservationLimit) packObservationLimit.value = asInputString(configuredOrEffective(config, effective, "pack_observation_limit"));
+    if (packSessionLimit) packSessionLimit.value = asInputString(configuredOrEffective(config, effective, "pack_session_limit"));
     if (rawEventsSweeperIntervalS) {
-      const intervalS = config.raw_events_sweeper_interval_s;
-      rawEventsSweeperIntervalS.value = intervalS === void 0 || intervalS === null ? "" : String(intervalS);
+      rawEventsSweeperIntervalS.value = asInputString(configuredOrEffective(config, effective, "raw_events_sweeper_interval_s"));
     }
-    if (syncEnabled) syncEnabled.checked = Boolean(config.sync_enabled);
-    if (syncHost) syncHost.value = config.sync_host || "";
-    if (syncPort) syncPort.value = config.sync_port || "";
-    if (syncInterval) syncInterval.value = config.sync_interval_s || "";
-    if (syncMdns) syncMdns.checked = Boolean(config.sync_mdns);
+    if (syncEnabled) syncEnabled.checked = Boolean(configuredOrEffective(config, effective, "sync_enabled"));
+    if (syncHost) syncHost.value = asInputString(configuredOrEffective(config, effective, "sync_host"));
+    if (syncPort) syncPort.value = asInputString(configuredOrEffective(config, effective, "sync_port"));
+    if (syncInterval) syncInterval.value = asInputString(configuredOrEffective(config, effective, "sync_interval_s"));
+    if (syncMdns) syncMdns.checked = Boolean(configuredOrEffective(config, effective, "sync_mdns"));
     if (settingsPath) settingsPath.textContent = state.configPath ? `Config path: ${state.configPath}` : "Config path: n/a";
+    if (observerModelHint) {
+      const source = hasOwn(config, "observer_model") ? "Configured" : "Default";
+      const effectiveModel = observerModelValue || "n/a";
+      observerModelHint.textContent = `${source} model: ${effectiveModel}`;
+    }
     if (observerMaxCharsHint) {
       const def = defaults?.observer_max_chars || "";
       observerMaxCharsHint.textContent = def ? `Default: ${def}` : "";
     }
     if (settingsEffective) {
-      settingsEffective.textContent = payload.env_overrides ? "Effective config differs (env overrides active)" : "";
+      settingsEffective.textContent = Object.keys(envOverrides).length > 0 ? "Effective config differs (env overrides active)" : "";
+    }
+    const overrides = $("settingsOverrides");
+    if (overrides) {
+      overrides.hidden = Object.keys(envOverrides).length === 0;
     }
     updateAuthSourceVisibility();
     setSettingsTab(settingsActiveTab);
@@ -1754,8 +1802,6 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     try {
       const payload = await loadConfig();
       renderConfigModal(payload);
-      const overrides = $("settingsOverrides");
-      if (overrides) overrides.hidden = !payload?.config?.has_env_overrides;
     } catch {
     }
   }

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1506,6 +1506,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   }
   let settingsOpen = false;
   let previouslyFocused = null;
+  let settingsActiveTab = "observer";
   function getFocusableNodes(container) {
     if (!container) return [];
     const selector = [
@@ -1562,6 +1563,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const observerMaxChars = $input("observerMaxChars");
     const packObservationLimit = $input("packObservationLimit");
     const packSessionLimit = $input("packSessionLimit");
+    const rawEventsSweeperIntervalS = $input("rawEventsSweeperIntervalS");
     const syncEnabled = $input("syncEnabled");
     const syncHost = $input("syncHost");
     const syncPort = $input("syncPort");
@@ -1579,8 +1581,14 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       const argv = Array.isArray(config.observer_auth_command) ? config.observer_auth_command : [];
       observerAuthCommand.value = argv.length ? JSON.stringify(argv, null, 2) : "";
     }
-    if (observerAuthTimeoutMs) observerAuthTimeoutMs.value = config.observer_auth_timeout_ms || "";
-    if (observerAuthCacheTtlS) observerAuthCacheTtlS.value = config.observer_auth_cache_ttl_s || "";
+    if (observerAuthTimeoutMs) {
+      const timeoutMs = config.observer_auth_timeout_ms;
+      observerAuthTimeoutMs.value = timeoutMs === void 0 || timeoutMs === null ? "" : String(timeoutMs);
+    }
+    if (observerAuthCacheTtlS) {
+      const cacheTtl = config.observer_auth_cache_ttl_s;
+      observerAuthCacheTtlS.value = cacheTtl === void 0 || cacheTtl === null ? "" : String(cacheTtl);
+    }
     if (observerHeaders) {
       const headers = config.observer_headers && typeof config.observer_headers === "object" ? config.observer_headers : {};
       observerHeaders.value = Object.keys(headers).length ? JSON.stringify(headers, null, 2) : "";
@@ -1588,6 +1596,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (observerMaxChars) observerMaxChars.value = config.observer_max_chars || "";
     if (packObservationLimit) packObservationLimit.value = config.pack_observation_limit || "";
     if (packSessionLimit) packSessionLimit.value = config.pack_session_limit || "";
+    if (rawEventsSweeperIntervalS) {
+      const intervalS = config.raw_events_sweeper_interval_s;
+      rawEventsSweeperIntervalS.value = intervalS === void 0 || intervalS === null ? "" : String(intervalS);
+    }
     if (syncEnabled) syncEnabled.checked = Boolean(config.sync_enabled);
     if (syncHost) syncHost.value = config.sync_host || "";
     if (syncPort) syncPort.value = config.sync_port || "";
@@ -1602,6 +1614,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       settingsEffective.textContent = payload.env_overrides ? "Effective config differs (env overrides active)" : "";
     }
     updateAuthSourceVisibility();
+    setSettingsTab(settingsActiveTab);
     setDirty(false);
     const settingsStatus = $("settingsStatus");
     if (settingsStatus) settingsStatus.textContent = "Ready";
@@ -1639,6 +1652,22 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (fileField) fileField.hidden = source !== "file";
     if (commandField) commandField.hidden = source !== "command";
     if (commandNote) commandNote.hidden = source !== "command";
+  }
+  function setSettingsTab(tab) {
+    const next = ["observer", "queue", "sync"].includes(tab) ? tab : "observer";
+    settingsActiveTab = next;
+    document.querySelectorAll("[data-settings-tab]").forEach((node) => {
+      const button = node;
+      const active = button.dataset.settingsTab === next;
+      button.classList.toggle("active", active);
+      button.setAttribute("aria-selected", active ? "true" : "false");
+    });
+    document.querySelectorAll("[data-settings-panel]").forEach((node) => {
+      const panel = node;
+      const active = panel.dataset.settingsPanel === next;
+      panel.classList.toggle("active", active);
+      panel.hidden = !active;
+    });
   }
   function setDirty(dirty) {
     state.settingsDirty = dirty;
@@ -1678,11 +1707,16 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       const authCommandInput = document.getElementById("observerAuthCommand")?.value || "";
       const observerHeadersInput = document.getElementById("observerHeaders")?.value || "";
       const authCacheTtlInput = ($input("observerAuthCacheTtlS")?.value || "").trim();
+      const sweeperIntervalInput = ($input("rawEventsSweeperIntervalS")?.value || "").trim();
       const authCommand = parseCommandArgv(authCommandInput);
       const headers = parseObserverHeaders(observerHeadersInput);
       const authCacheTtl = authCacheTtlInput === "" ? "" : Number(authCacheTtlInput);
+      const sweeperInterval = sweeperIntervalInput === "" ? "" : Number(sweeperIntervalInput);
       if (authCacheTtlInput !== "" && !Number.isFinite(authCacheTtl)) {
         throw new Error("observer auth cache ttl must be a number");
+      }
+      if (sweeperIntervalInput !== "" && (!Number.isFinite(sweeperInterval) || sweeperInterval <= 0)) {
+        throw new Error("raw-event sweeper interval must be a positive number");
       }
       await saveConfig({
         observer_provider: $select("observerProvider")?.value || "",
@@ -1697,6 +1731,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         observer_max_chars: Number($input("observerMaxChars")?.value || 0) || "",
         pack_observation_limit: Number($input("packObservationLimit")?.value || 0) || "",
         pack_session_limit: Number($input("packSessionLimit")?.value || 0) || "",
+        raw_events_sweeper_interval_s: sweeperInterval,
         sync_enabled: $input("syncEnabled")?.checked || false,
         sync_host: $input("syncHost")?.value || "",
         sync_port: Number($input("syncPort")?.value || 0) || "",
@@ -1753,6 +1788,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       "observerMaxChars",
       "packObservationLimit",
       "packSessionLimit",
+      "rawEventsSweeperIntervalS",
       "syncEnabled",
       "syncHost",
       "syncPort",
@@ -1766,6 +1802,12 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       input.addEventListener("change", () => setDirty(true));
     });
     $select("observerAuthSource")?.addEventListener("change", () => updateAuthSourceVisibility());
+    document.querySelectorAll("[data-settings-tab]").forEach((node) => {
+      node.addEventListener("click", () => {
+        const tab = node.dataset.settingsTab || "observer";
+        setSettingsTab(tab);
+      });
+    });
   }
   let lastAnnouncedRefreshState = null;
   function setRefreshStatus(rs, detail) {

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1552,6 +1552,13 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     state.configPath = payload.path || "";
     const observerProvider = $select("observerProvider");
     const observerModel = $input("observerModel");
+    const observerRuntime = $select("observerRuntime");
+    const observerAuthSource = $select("observerAuthSource");
+    const observerAuthFile = $input("observerAuthFile");
+    const observerAuthCommand = document.getElementById("observerAuthCommand");
+    const observerAuthTimeoutMs = $input("observerAuthTimeoutMs");
+    const observerAuthCacheTtlS = $input("observerAuthCacheTtlS");
+    const observerHeaders = document.getElementById("observerHeaders");
     const observerMaxChars = $input("observerMaxChars");
     const packObservationLimit = $input("packObservationLimit");
     const packSessionLimit = $input("packSessionLimit");
@@ -1565,6 +1572,19 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const settingsEffective = $("settingsEffective");
     if (observerProvider) observerProvider.value = config.observer_provider || "";
     if (observerModel) observerModel.value = config.observer_model || "";
+    if (observerRuntime) observerRuntime.value = config.observer_runtime || "api_http";
+    if (observerAuthSource) observerAuthSource.value = config.observer_auth_source || "auto";
+    if (observerAuthFile) observerAuthFile.value = config.observer_auth_file || "";
+    if (observerAuthCommand) {
+      const argv = Array.isArray(config.observer_auth_command) ? config.observer_auth_command : [];
+      observerAuthCommand.value = argv.length ? JSON.stringify(argv, null, 2) : "";
+    }
+    if (observerAuthTimeoutMs) observerAuthTimeoutMs.value = config.observer_auth_timeout_ms || "";
+    if (observerAuthCacheTtlS) observerAuthCacheTtlS.value = config.observer_auth_cache_ttl_s || "";
+    if (observerHeaders) {
+      const headers = config.observer_headers && typeof config.observer_headers === "object" ? config.observer_headers : {};
+      observerHeaders.value = Object.keys(headers).length ? JSON.stringify(headers, null, 2) : "";
+    }
     if (observerMaxChars) observerMaxChars.value = config.observer_max_chars || "";
     if (packObservationLimit) packObservationLimit.value = config.pack_observation_limit || "";
     if (packSessionLimit) packSessionLimit.value = config.pack_session_limit || "";
@@ -1581,9 +1601,44 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (settingsEffective) {
       settingsEffective.textContent = payload.env_overrides ? "Effective config differs (env overrides active)" : "";
     }
+    updateAuthSourceVisibility();
     setDirty(false);
     const settingsStatus = $("settingsStatus");
     if (settingsStatus) settingsStatus.textContent = "Ready";
+  }
+  function parseCommandArgv(raw) {
+    const text = raw.trim();
+    if (!text) return [];
+    const parsed = JSON.parse(text);
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+      throw new Error("observer auth command must be a JSON string array");
+    }
+    return parsed;
+  }
+  function parseObserverHeaders(raw) {
+    const text = raw.trim();
+    if (!text) return {};
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("observer headers must be a JSON object");
+    }
+    const headers = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof key !== "string" || !key.trim() || typeof value !== "string") {
+        throw new Error("observer headers must map string keys to string values");
+      }
+      headers[key.trim()] = value;
+    }
+    return headers;
+  }
+  function updateAuthSourceVisibility() {
+    const source = $select("observerAuthSource")?.value || "auto";
+    const fileField = document.getElementById("observerAuthFileField");
+    const commandField = document.getElementById("observerAuthCommandField");
+    const commandNote = document.getElementById("observerAuthCommandNote");
+    if (fileField) fileField.hidden = source !== "file";
+    if (commandField) commandField.hidden = source !== "command";
+    if (commandNote) commandNote.hidden = source !== "command";
   }
   function setDirty(dirty) {
     state.settingsDirty = dirty;
@@ -1620,9 +1675,25 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     saveBtn.disabled = true;
     status.textContent = "Saving...";
     try {
+      const authCommandInput = document.getElementById("observerAuthCommand")?.value || "";
+      const observerHeadersInput = document.getElementById("observerHeaders")?.value || "";
+      const authCacheTtlInput = ($input("observerAuthCacheTtlS")?.value || "").trim();
+      const authCommand = parseCommandArgv(authCommandInput);
+      const headers = parseObserverHeaders(observerHeadersInput);
+      const authCacheTtl = authCacheTtlInput === "" ? "" : Number(authCacheTtlInput);
+      if (authCacheTtlInput !== "" && !Number.isFinite(authCacheTtl)) {
+        throw new Error("observer auth cache ttl must be a number");
+      }
       await saveConfig({
         observer_provider: $select("observerProvider")?.value || "",
         observer_model: $input("observerModel")?.value || "",
+        observer_runtime: $select("observerRuntime")?.value || "api_http",
+        observer_auth_source: $select("observerAuthSource")?.value || "auto",
+        observer_auth_file: $input("observerAuthFile")?.value || "",
+        observer_auth_command: authCommand,
+        observer_auth_timeout_ms: Number($input("observerAuthTimeoutMs")?.value || 0) || "",
+        observer_auth_cache_ttl_s: authCacheTtl,
+        observer_headers: headers,
         observer_max_chars: Number($input("observerMaxChars")?.value || 0) || "",
         pack_observation_limit: Number($input("packObservationLimit")?.value || 0) || "",
         pack_session_limit: Number($input("packSessionLimit")?.value || 0) || "",
@@ -1635,8 +1706,9 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       status.textContent = "Saved";
       setDirty(false);
       closeSettings(startPolling2, refreshCallback);
-    } catch {
-      status.textContent = "Save failed";
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown error";
+      status.textContent = `Save failed: ${message}`;
     } finally {
       saveBtn.disabled = !state.settingsDirty;
     }
@@ -1668,13 +1740,32 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       trapModalFocus(e);
       if (e.key === "Escape" && settingsOpen) closeSettings(startPolling2, refreshCallback);
     });
-    const inputs = ["observerProvider", "observerModel", "observerMaxChars", "packObservationLimit", "packSessionLimit", "syncEnabled", "syncHost", "syncPort", "syncInterval", "syncMdns"];
+    const inputs = [
+      "observerProvider",
+      "observerModel",
+      "observerRuntime",
+      "observerAuthSource",
+      "observerAuthFile",
+      "observerAuthCommand",
+      "observerAuthTimeoutMs",
+      "observerAuthCacheTtlS",
+      "observerHeaders",
+      "observerMaxChars",
+      "packObservationLimit",
+      "packSessionLimit",
+      "syncEnabled",
+      "syncHost",
+      "syncPort",
+      "syncInterval",
+      "syncMdns"
+    ];
     inputs.forEach((id) => {
       const input = document.getElementById(id);
       if (!input) return;
       input.addEventListener("input", () => setDirty(true));
       input.addEventListener("change", () => setDirty(true));
     });
+    $select("observerAuthSource")?.addEventListener("change", () => updateAuthSourceVisibility());
   }
   let lastAnnouncedRefreshState = null;
   function setRefreshStatus(rs, detail) {

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -908,7 +908,8 @@
       .modal-footer { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); flex-shrink: 0; padding-top: var(--sp-2); border-top: 1px solid var(--border); }
 
       .field { display: flex; flex-direction: column; gap: 6px; font-size: 13px; }
-      .field input, .field select { padding: var(--sp-2) var(--sp-3); border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--input-bg); font-family: var(--font-sans); font-size: 13px; color: var(--text-primary); }
+      .field input, .field select, .field textarea { padding: var(--sp-2) var(--sp-3); border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--input-bg); font-family: var(--font-sans); font-size: 13px; color: var(--text-primary); }
+      .field textarea { resize: vertical; min-height: 84px; }
       .settings-save {
         border: 1px solid var(--control-border);
         background: var(--control-bg);
@@ -1030,6 +1031,51 @@
             <label for="observerModel">Observer model</label>
             <input id="observerModel" placeholder="leave empty for default" />
             <div class="small">Override the observer model.</div>
+          </div>
+          <div class="field">
+            <label for="observerRuntime">Observer runtime</label>
+            <select id="observerRuntime">
+              <option value="api_http">api_http (default)</option>
+              <option value="claude_sidecar">claude_sidecar (reserved)</option>
+            </select>
+            <div class="small">`claude_sidecar` is reserved for a follow-up runtime bridge.</div>
+          </div>
+          <div class="field">
+            <label for="observerAuthSource">Observer auth source</label>
+            <select id="observerAuthSource">
+              <option value="auto">auto (default)</option>
+              <option value="env">env</option>
+              <option value="file">file</option>
+              <option value="command">command</option>
+              <option value="none">none</option>
+            </select>
+            <div class="small">Choose how observer credentials are resolved.</div>
+          </div>
+          <div class="field" id="observerAuthFileField" hidden>
+            <label for="observerAuthFile">Observer auth file</label>
+            <input id="observerAuthFile" placeholder="~/.codemem/work-token.txt" />
+            <div class="small">Read token from this file when auth source is `file`.</div>
+          </div>
+          <div class="field" id="observerAuthCommandField" hidden>
+            <label for="observerAuthCommand">Observer auth command</label>
+            <textarea id="observerAuthCommand" rows="3" placeholder='["iap-auth", "--audience", "gateway"]'></textarea>
+            <div class="small">Command stdout is used as the token when source is `command` (argv only; no shell).</div>
+          </div>
+          <div class="small" id="observerAuthCommandNote" hidden>
+            Command format: JSON string array, e.g. `["iap-auth", "--audience", "gateway"]`.
+          </div>
+          <div class="field">
+            <label for="observerAuthTimeoutMs">Observer auth timeout (ms)</label>
+            <input id="observerAuthTimeoutMs" type="number" min="1" />
+          </div>
+          <div class="field">
+            <label for="observerAuthCacheTtlS">Observer auth cache TTL (s)</label>
+            <input id="observerAuthCacheTtlS" type="number" min="0" />
+          </div>
+          <div class="field">
+            <label for="observerHeaders">Observer headers (JSON object)</label>
+            <textarea id="observerHeaders" rows="4" placeholder='{"Authorization":"Bearer ${auth.token}"}'></textarea>
+            <div class="small">Template variables: `${auth.token}`, `${auth.type}`, `${auth.source}`.</div>
           </div>
           <div class="field">
             <label for="observerMaxChars">Observer max chars</label>

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -907,6 +907,42 @@
       .modal-body { display: flex; flex-direction: column; gap: var(--sp-3); flex: 1; min-height: 0; overflow-y: auto; padding-right: 6px; }
       .modal-footer { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); flex-shrink: 0; padding-top: var(--sp-2); border-top: 1px solid var(--border); }
 
+      .settings-tabs { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 6px; }
+      .settings-tab {
+        border: 1px solid var(--border);
+        background: var(--surface-0);
+        color: var(--text-secondary);
+        border-radius: var(--radius-sm);
+        padding: 7px 10px;
+        font-family: var(--font-sans);
+        font-size: 12px;
+        cursor: pointer;
+      }
+      .settings-tab:hover { border-color: var(--border-hover); }
+      .settings-tab.active {
+        border-color: var(--accent-border);
+        color: var(--accent-strong);
+        background: var(--accent-subtle);
+      }
+      .settings-panel { display: none; flex-direction: column; gap: var(--sp-3); }
+      .settings-panel.active { display: flex; }
+      .settings-group {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sp-2);
+        padding: var(--sp-3);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-0);
+      }
+      .settings-group-title {
+        margin: 0;
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--text-tertiary);
+      }
+
       .field { display: flex; flex-direction: column; gap: 6px; font-size: 13px; }
       .field input, .field select, .field textarea { padding: var(--sp-2) var(--sp-3); border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--input-bg); font-family: var(--font-sans); font-size: 13px; color: var(--text-primary); }
       .field textarea { resize: vertical; min-height: 84px; }
@@ -1022,82 +1058,117 @@
         </div>
         <div class="modal-body">
           <div class="small" id="settingsDescription">Update observer and sync defaults for this viewer.</div>
-          <div class="field">
-            <label for="observerProvider">Observer provider</label>
-            <select id="observerProvider"><option value="">auto (default)</option></select>
-            <div class="small">Leave blank to use defaults.</div>
+          <div class="settings-tabs" role="tablist" aria-label="Settings sections">
+            <button class="settings-tab active" id="settingsTabObserver" data-settings-tab="observer" role="tab" aria-selected="true">Observer</button>
+            <button class="settings-tab" id="settingsTabQueue" data-settings-tab="queue" role="tab" aria-selected="false">Queue</button>
+            <button class="settings-tab" id="settingsTabSync" data-settings-tab="sync" role="tab" aria-selected="false">Sync</button>
           </div>
-          <div class="field">
-            <label for="observerModel">Observer model</label>
-            <input id="observerModel" placeholder="leave empty for default" />
-            <div class="small">Override the observer model.</div>
+
+          <div class="settings-panel active" id="settingsPanelObserver" data-settings-panel="observer">
+            <div class="settings-group">
+              <h3 class="settings-group-title">Model Runtime</h3>
+              <div class="field">
+                <label for="observerProvider">Observer provider</label>
+                <select id="observerProvider"><option value="">auto (default)</option></select>
+                <div class="small">Leave blank to use defaults.</div>
+              </div>
+              <div class="field">
+                <label for="observerModel">Observer model</label>
+                <input id="observerModel" placeholder="leave empty for default" />
+                <div class="small">Override the observer model.</div>
+              </div>
+              <div class="field">
+                <label for="observerRuntime">Observer runtime</label>
+                <select id="observerRuntime">
+                  <option value="api_http">api_http (default)</option>
+                  <option value="claude_sidecar">claude_sidecar</option>
+                </select>
+                <div class="small">Run observer calls through local Claude runtime auth.</div>
+              </div>
+              <div class="field">
+                <label for="observerMaxChars">Observer max chars</label>
+                <input id="observerMaxChars" type="number" min="1" />
+                <div class="small" id="observerMaxCharsHint"></div>
+              </div>
+            </div>
+
+            <div class="settings-group">
+              <h3 class="settings-group-title">Auth Adapter</h3>
+              <div class="field">
+                <label for="observerAuthSource">Observer auth source</label>
+                <select id="observerAuthSource">
+                  <option value="auto">auto (default)</option>
+                  <option value="env">env</option>
+                  <option value="file">file</option>
+                  <option value="command">command</option>
+                  <option value="none">none</option>
+                </select>
+                <div class="small">Choose how observer credentials are resolved.</div>
+              </div>
+              <div class="field" id="observerAuthFileField" hidden>
+                <label for="observerAuthFile">Observer auth file</label>
+                <input id="observerAuthFile" placeholder="~/.codemem/work-token.txt" />
+                <div class="small">Read token from this file when auth source is `file`.</div>
+              </div>
+              <div class="field" id="observerAuthCommandField" hidden>
+                <label for="observerAuthCommand">Observer auth command</label>
+                <textarea id="observerAuthCommand" rows="3" placeholder='["iap-auth", "--audience", "gateway"]'></textarea>
+                <div class="small">Command stdout is used as the token when source is `command` (argv only; no shell).</div>
+              </div>
+              <div class="small" id="observerAuthCommandNote" hidden>
+                Command format: JSON string array, e.g. `["iap-auth", "--audience", "gateway"]`.
+              </div>
+              <div class="field">
+                <label for="observerAuthTimeoutMs">Observer auth timeout (ms)</label>
+                <input id="observerAuthTimeoutMs" type="number" min="1" />
+              </div>
+              <div class="field">
+                <label for="observerAuthCacheTtlS">Observer auth cache TTL (s)</label>
+                <input id="observerAuthCacheTtlS" type="number" min="0" />
+              </div>
+              <div class="field">
+                <label for="observerHeaders">Observer headers (JSON object)</label>
+                <textarea id="observerHeaders" rows="4" placeholder='{"Authorization":"Bearer ${auth.token}"}'></textarea>
+                <div class="small">Template variables: `${auth.token}`, `${auth.type}`, `${auth.source}`.</div>
+              </div>
+            </div>
           </div>
-          <div class="field">
-            <label for="observerRuntime">Observer runtime</label>
-            <select id="observerRuntime">
-              <option value="api_http">api_http (default)</option>
-              <option value="claude_sidecar">claude_sidecar (reserved)</option>
-            </select>
-            <div class="small">`claude_sidecar` is reserved for a follow-up runtime bridge.</div>
+
+          <div class="settings-panel" id="settingsPanelQueue" data-settings-panel="queue">
+            <div class="settings-group">
+              <h3 class="settings-group-title">Processing Cadence</h3>
+              <div class="field">
+                <label for="rawEventsSweeperIntervalS">Raw-event sweeper interval (seconds)</label>
+                <input id="rawEventsSweeperIntervalS" type="number" min="1" />
+                <div class="small">How often background flush checks pending raw events.</div>
+              </div>
+            </div>
+            <div class="settings-group">
+              <h3 class="settings-group-title">Pack Defaults</h3>
+              <div class="field">
+                <label for="packObservationLimit">Pack observation limit</label>
+                <input id="packObservationLimit" type="number" min="1" />
+                <div class="small">Default number of observations to include in a pack.</div>
+              </div>
+              <div class="field">
+                <label for="packSessionLimit">Pack session limit</label>
+                <input id="packSessionLimit" type="number" min="1" />
+                <div class="small">Default number of session summaries to include in a pack.</div>
+              </div>
+            </div>
           </div>
-          <div class="field">
-            <label for="observerAuthSource">Observer auth source</label>
-            <select id="observerAuthSource">
-              <option value="auto">auto (default)</option>
-              <option value="env">env</option>
-              <option value="file">file</option>
-              <option value="command">command</option>
-              <option value="none">none</option>
-            </select>
-            <div class="small">Choose how observer credentials are resolved.</div>
+
+          <div class="settings-panel" id="settingsPanelSync" data-settings-panel="sync">
+            <div class="settings-group">
+              <h3 class="settings-group-title">Peer Sync</h3>
+              <div class="field"><label for="syncEnabled">Sync enabled</label><input id="syncEnabled" type="checkbox" /></div>
+              <div class="field"><label for="syncHost">Sync host</label><input id="syncHost" placeholder="127.0.0.1" /></div>
+              <div class="field"><label for="syncPort">Sync port</label><input id="syncPort" type="number" min="1" /></div>
+              <div class="field"><label for="syncInterval">Sync interval (seconds)</label><input id="syncInterval" type="number" min="10" /></div>
+              <div class="field"><label for="syncMdns">mDNS discovery</label><input id="syncMdns" type="checkbox" /></div>
+            </div>
           </div>
-          <div class="field" id="observerAuthFileField" hidden>
-            <label for="observerAuthFile">Observer auth file</label>
-            <input id="observerAuthFile" placeholder="~/.codemem/work-token.txt" />
-            <div class="small">Read token from this file when auth source is `file`.</div>
-          </div>
-          <div class="field" id="observerAuthCommandField" hidden>
-            <label for="observerAuthCommand">Observer auth command</label>
-            <textarea id="observerAuthCommand" rows="3" placeholder='["iap-auth", "--audience", "gateway"]'></textarea>
-            <div class="small">Command stdout is used as the token when source is `command` (argv only; no shell).</div>
-          </div>
-          <div class="small" id="observerAuthCommandNote" hidden>
-            Command format: JSON string array, e.g. `["iap-auth", "--audience", "gateway"]`.
-          </div>
-          <div class="field">
-            <label for="observerAuthTimeoutMs">Observer auth timeout (ms)</label>
-            <input id="observerAuthTimeoutMs" type="number" min="1" />
-          </div>
-          <div class="field">
-            <label for="observerAuthCacheTtlS">Observer auth cache TTL (s)</label>
-            <input id="observerAuthCacheTtlS" type="number" min="0" />
-          </div>
-          <div class="field">
-            <label for="observerHeaders">Observer headers (JSON object)</label>
-            <textarea id="observerHeaders" rows="4" placeholder='{"Authorization":"Bearer ${auth.token}"}'></textarea>
-            <div class="small">Template variables: `${auth.token}`, `${auth.type}`, `${auth.source}`.</div>
-          </div>
-          <div class="field">
-            <label for="observerMaxChars">Observer max chars</label>
-            <input id="observerMaxChars" type="number" min="1" />
-            <div class="small" id="observerMaxCharsHint"></div>
-          </div>
-          <div class="field">
-            <label for="packObservationLimit">Pack observation limit</label>
-            <input id="packObservationLimit" type="number" min="1" />
-            <div class="small">Default number of observations to include in a pack.</div>
-          </div>
-          <div class="field">
-            <label for="packSessionLimit">Pack session limit</label>
-            <input id="packSessionLimit" type="number" min="1" />
-            <div class="small">Default number of session summaries to include in a pack.</div>
-          </div>
-          <div class="field"><label>Sync settings</label><div class="small">Configure peer sync.</div></div>
-          <div class="field"><label for="syncEnabled">Sync enabled</label><input id="syncEnabled" type="checkbox" /></div>
-          <div class="field"><label for="syncHost">Sync host</label><input id="syncHost" placeholder="127.0.0.1" /></div>
-          <div class="field"><label for="syncPort">Sync port</label><input id="syncPort" type="number" min="1" /></div>
-          <div class="field"><label for="syncInterval">Sync interval (seconds)</label><input id="syncInterval" type="number" min="10" /></div>
-          <div class="field"><label for="syncMdns">mDNS discovery</label><input id="syncMdns" type="checkbox" /></div>
+
           <div class="small mono" id="settingsPath"></div>
           <div class="small" id="settingsEffective"></div>
           <div class="settings-note" id="settingsOverrides">Environment variables override file settings.</div>

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1070,12 +1070,13 @@
               <div class="field">
                 <label for="observerProvider">Observer provider</label>
                 <select id="observerProvider"><option value="">auto (default)</option></select>
-                <div class="small">Leave blank to use defaults.</div>
+                <div class="small">`auto` uses provider defaults for the selected runtime.</div>
               </div>
               <div class="field">
                 <label for="observerModel">Observer model</label>
                 <input id="observerModel" placeholder="leave empty for default" />
                 <div class="small">Default: `gpt-5.1-codex-mini` for `api_http`; `claude-4.5-haiku` for `claude_sidecar`.</div>
+                <div class="small" id="observerModelHint"></div>
               </div>
               <div class="field">
                 <label for="observerRuntime">Observer runtime</label>

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1075,7 +1075,7 @@
               <div class="field">
                 <label for="observerModel">Observer model</label>
                 <input id="observerModel" placeholder="leave empty for default" />
-                <div class="small">Override the observer model.</div>
+                <div class="small">Default: `gpt-5.1-codex-mini` for `api_http`; `claude-4.5-haiku` for `claude_sidecar`.</div>
               </div>
               <div class="field">
                 <label for="observerRuntime">Observer runtime</label>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,7 +172,8 @@ The observer turns raw session transcripts into typed, structured memories. It's
 
 - The observer still uses one pipeline (extract -> prompt -> parse -> persist); runtime/auth choices are adapter inputs, not a separate path.
 - Supported runtime values are `api_http` and `claude_sidecar`.
-- `claude_sidecar` is currently reserved/not implemented; runtime selection falls back to `api_http` with a warning.
+- `claude_sidecar` executes observer prompts through local Claude runtime auth and bypasses provider API-key client initialization.
+- If a configured `observer_model` is not available in Claude CLI, codemem retries once with Claude's default model.
 - Supported auth sources are `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` is argv data and must be a JSON string array when passed via env (`CODEMEM_OBSERVER_AUTH_COMMAND`).
 - Header templating supports `${auth.token}`, `${auth.type}`, `${auth.source}`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,6 +173,7 @@ The observer turns raw session transcripts into typed, structured memories. It's
 - The observer still uses one pipeline (extract -> prompt -> parse -> persist); runtime/auth choices are adapter inputs, not a separate path.
 - Supported runtime values are `api_http` and `claude_sidecar`.
 - `claude_sidecar` executes observer prompts through local Claude runtime auth and bypasses provider API-key client initialization.
+- Runtime defaults: `api_http` uses `gpt-5.1-codex-mini`; `claude_sidecar` uses `claude-4.5-haiku` unless explicitly overridden.
 - If a configured `observer_model` is not available in Claude CLI, codemem retries once with Claude's default model.
 - Supported auth sources are `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` is argv data and must be a JSON string array when passed via env (`CODEMEM_OBSERVER_AUTH_COMMAND`).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,6 +168,17 @@ PL->>OC: append codemem context to system prompt
 
 The observer turns raw session transcripts into typed, structured memories. It's the quality gate — everything that ends up in the store passes through here.
 
+### Runtime and auth adapter (0.16)
+
+- The observer still uses one pipeline (extract -> prompt -> parse -> persist); runtime/auth choices are adapter inputs, not a separate path.
+- Supported runtime values are `api_http` and `claude_sidecar`.
+- `claude_sidecar` is currently reserved/not implemented; runtime selection falls back to `api_http` with a warning.
+- Supported auth sources are `auto`, `env`, `file`, `command`, `none`.
+- `observer_auth_command` is argv data and must be a JSON string array when passed via env (`CODEMEM_OBSERVER_AUTH_COMMAND`).
+- Header templating supports `${auth.token}`, `${auth.type}`, `${auth.source}`.
+- `file`/`command` auth resolution caches successful tokens for TTL and does not cache failures.
+- Custom provider auth does not implicitly consume OpenCode/IAP env fallback tokens.
+
 ### Memory taxonomy
 
 Observations use a fixed set of kinds defined in `codemem/memory_kinds.py`:

--- a/docs/plans/2026-03-03-observer-auth-adapter-and-runtime-plan.md
+++ b/docs/plans/2026-03-03-observer-auth-adapter-and-runtime-plan.md
@@ -1,0 +1,152 @@
+# Observer Auth Adapter and Runtime Plan
+
+**Bead:** codemem-afm.12  
+**Status:** Design  
+**Date:** 2026-03-03
+
+## Problem
+
+Observer execution is currently tied to API-key-style auth assumptions and partial OpenCode-specific behavior. This creates gaps for:
+
+- standalone Claude environments where Pro/Max subscription auth is available via host runtime, not API keys
+- enterprise gateway environments that require short-lived tokens (for example, IAP) refreshed by a local command or wrapper
+- future host runtimes (Codex, Cursor, ChatGPT subscription contexts) with different auth storage and refresh models
+
+At the same time, we do **not** want a second observer pipeline.
+
+## Goal
+
+Add a flexible observer provider/auth adapter layer under the existing observer pipeline, with first-class support for command-based token retrieval, and make it configurable in both:
+
+- config file (`~/.config/codemem/config.json`)
+- settings UI (viewer `/api/config` + settings panel)
+
+## Non-goals (for 0.16)
+
+- No full Claude sidecar runtime implementation in this bead
+- No full Pro/Max observer-runtime bridge in this bead
+- No breaking change to existing API key workflows
+
+## Design
+
+### 1) Keep one observer pipeline
+
+Do not change ingest/parse/persist flow. Only introduce adapter seams at provider/auth resolution.
+
+Current flow remains:
+
+1. Build `ObserverContext`
+2. Build prompt
+3. Execute observer call
+4. Parse XML
+5. Persist observations/summary/usage
+
+### 2) Introduce adapter interfaces (minimal)
+
+Add lightweight interfaces in observer modules:
+
+- `ObserverProviderAdapter`: resolves request target/options (`base_url`, model, provider headers)
+- `ObserverAuthAdapter`: resolves auth material for each request (`none|api_key|bearer`) with optional cache/refresh
+
+This keeps provider/auth pluggable without changing parser or storage logic.
+
+### 3) Auth source model (0.16 scope)
+
+Add supported auth sources:
+
+- `env` (existing behavior, explicit vars)
+- `file` (read token from a local file path)
+- `command` (execute command and use stdout as token)
+
+`command` is first-class, not shell interpolation in header strings.
+
+### 4) Header templating
+
+Allow templated headers with adapter variables:
+
+- `${auth.token}`
+- `${auth.type}`
+
+Example:
+
+```json
+{
+  "observer_auth": {
+    "source": "command",
+    "command": ["iap-auth"],
+    "timeout_ms": 1500,
+    "cache_ttl_s": 300
+  },
+  "observer_headers": {
+    "Authorization": "Bearer ${auth.token}"
+  }
+}
+```
+
+### 5) Config surface (required)
+
+Add config keys:
+
+- `observer_runtime` (`api_http` default; `claude_sidecar` reserved)
+- `observer_auth_source` (`env|file|command|none`)
+- `observer_auth_file` (path)
+- `observer_auth_command` (array of args)
+- `observer_auth_timeout_ms` (int)
+- `observer_auth_cache_ttl_s` (int)
+- `observer_headers` (map string->string template)
+
+Keep existing keys intact (`observer_provider`, `observer_model`, `observer_api_key`, etc.) for compatibility.
+
+### 6) Settings UI surface (required)
+
+Expose and persist these fields in settings UI and `/api/config` validation:
+
+- runtime selector
+- auth source selector
+- file path input (when `file`)
+- command input (when `command`)
+- timeout / ttl numeric inputs
+- header template editor (key/value rows)
+
+Validation must reject unsafe/malformed config (for example, non-array command payload).
+
+### 7) Security and reliability
+
+- Never log raw tokens
+- Strip trailing newline from command output
+- Direct exec (argv list), no shell interpolation
+- Timeout command execution
+- On 401/403: one forced refresh attempt, then fail with clear auth error
+- Cache token by source config hash and TTL
+
+## Future extension (post-0.16)
+
+Implement `claude_sidecar` runtime adapter using same `ObserverContext` request contract, with host-runtime auth (Pro/Max) and session reuse.
+
+This is additive and does not fork the observer pipeline.
+
+## Acceptance criteria
+
+1. Existing API key flows continue working unchanged.
+2. Observer can authenticate via `command` token source and templated `Authorization` header.
+3. Config file accepts new observer auth/runtime fields with validation.
+4. Settings UI can view/edit/save these fields.
+5. Tests cover config parsing, command auth, token cache/refresh, and settings API validation.
+6. Docs explicitly state current auth support and 0.16 limitations (Pro/Max runtime bridge deferred).
+
+## Bead breakdown
+
+- `codemem-afm.12`: observer auth/runtime adapter architecture and 0.16 delivery gate
+- `codemem-afm.13`: implement auth adapters (`env|file|command`) + header templating + retry/refresh behavior
+- `codemem-afm.14`: config + settings API + viewer settings UI integration
+- `codemem-afm.15`: docs + validation matrix for standalone Claude/work gateway before release tag
+
+## Validation matrix for release gate
+
+Run before tagging `v0.16.0`:
+
+- local OpenCode + API key
+- local standalone Claude + API key path
+- work gateway + command token source (`iap-auth` style)
+
+All must pass observer flush and produce persisted observations.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -87,9 +87,11 @@ Provider/model selection can be overridden with `CODEMEM_OBSERVER_PROVIDER` and
 
 Observer execution in `0.16` uses API-style auth paths.
 
+- Runtime values: `api_http`, `claude_sidecar`.
+- `claude_sidecar` is reserved/not implemented yet; codemem logs a warning and runs through `api_http`.
+- Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
 - Supported: API keys and gateway tokens codemem can read directly.
-- Supported token sources: `env`, `file`, `command`.
-- Not yet supported: direct Pro/Max subscription observer runtime bridge.
+- Custom provider path does not implicitly fall back to OpenCode/IAP env tokens; use provider key, `CODEMEM_OBSERVER_API_KEY`, `file`, or `command`.
 
 For command-refreshed gateway auth, configure a command token source plus templated headers:
 
@@ -98,7 +100,7 @@ For command-refreshed gateway auth, configure a command token source plus templa
   "observer_provider": "your-gateway-provider",
   "observer_runtime": "api_http",
   "observer_auth_source": "command",
-  "observer_auth_command": ["iap-auth"],
+  "observer_auth_command": ["iap-auth", "--audience", "example"],
   "observer_auth_timeout_ms": 1500,
   "observer_auth_cache_ttl_s": 300,
   "observer_headers": {
@@ -107,13 +109,21 @@ For command-refreshed gateway auth, configure a command token source plus templa
 }
 ```
 
+`observer_auth_command` is direct argv execution (no shell interpolation).
+
+- Config key type: JSON string array (`["cmd", "arg1", "arg2"]`).
+- Env var `CODEMEM_OBSERVER_AUTH_COMMAND` must also be a JSON string array (for example `'["iap-auth","--audience","example"]'`), not a space-separated command string.
+
 Header template variables:
 
 - `${auth.token}`
 - `${auth.type}`
 - `${auth.source}`
 
-`observer_auth_command` runs as direct argv execution (no shell interpolation).
+Command/file token cache behavior:
+
+- Successful token resolutions are cached for `observer_auth_cache_ttl_s`.
+- Failed token resolutions are not cached.
 
 ## Stream-only mode (advanced)
 
@@ -211,7 +221,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_OBSERVER_PROVIDER` | Force `openai`, `anthropic`, or a custom provider key (optional). |
 | `CODEMEM_OBSERVER_MODEL` | Override observer model (default `gpt-5.1-codex-mini` or `claude-4.5-haiku`). |
 | `CODEMEM_OBSERVER_API_KEY` | API key for observer model (optional). |
-| `CODEMEM_OBSERVER_RUNTIME` | Observer runtime mode (`api_http`, `claude_sidecar`; sidecar reserved for follow-up). |
+| `CODEMEM_OBSERVER_RUNTIME` | Observer runtime mode (`api_http`, `claude_sidecar`; `claude_sidecar` is reserved/not implemented yet). |
 | `CODEMEM_OBSERVER_AUTH_SOURCE` | Observer auth source (`auto`, `env`, `file`, `command`, `none`). |
 | `CODEMEM_OBSERVER_AUTH_FILE` | Path to token file used when auth source is `file`. |
 | `CODEMEM_OBSERVER_AUTH_COMMAND` | Command argv as a JSON string array used when auth source is `command`. |

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -83,6 +83,38 @@ slash commands in the OpenCode chat input.
 Provider/model selection can be overridden with `CODEMEM_OBSERVER_PROVIDER` and
 `CODEMEM_OBSERVER_MODEL`. Custom providers are loaded from OpenCode config.
 
+### Observer auth modes (0.16)
+
+Observer execution in `0.16` uses API-style auth paths.
+
+- Supported: API keys and gateway tokens codemem can read directly.
+- Supported token sources: `env`, `file`, `command`.
+- Not yet supported: direct Pro/Max subscription observer runtime bridge.
+
+For command-refreshed gateway auth, configure a command token source plus templated headers:
+
+```json
+{
+  "observer_provider": "your-gateway-provider",
+  "observer_runtime": "api_http",
+  "observer_auth_source": "command",
+  "observer_auth_command": ["iap-auth"],
+  "observer_auth_timeout_ms": 1500,
+  "observer_auth_cache_ttl_s": 300,
+  "observer_headers": {
+    "Authorization": "Bearer ${auth.token}"
+  }
+}
+```
+
+Header template variables:
+
+- `${auth.token}`
+- `${auth.type}`
+- `${auth.source}`
+
+`observer_auth_command` runs as direct argv execution (no shell interpolation).
+
 ## Stream-only mode (advanced)
 
 Stream contract:
@@ -179,6 +211,13 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_OBSERVER_PROVIDER` | Force `openai`, `anthropic`, or a custom provider key (optional). |
 | `CODEMEM_OBSERVER_MODEL` | Override observer model (default `gpt-5.1-codex-mini` or `claude-4.5-haiku`). |
 | `CODEMEM_OBSERVER_API_KEY` | API key for observer model (optional). |
+| `CODEMEM_OBSERVER_RUNTIME` | Observer runtime mode (`api_http`, `claude_sidecar`; sidecar reserved for follow-up). |
+| `CODEMEM_OBSERVER_AUTH_SOURCE` | Observer auth source (`auto`, `env`, `file`, `command`, `none`). |
+| `CODEMEM_OBSERVER_AUTH_FILE` | Path to token file used when auth source is `file`. |
+| `CODEMEM_OBSERVER_AUTH_COMMAND` | Command argv as a JSON string array used when auth source is `command`. |
+| `CODEMEM_OBSERVER_AUTH_TIMEOUT_MS` | Command auth timeout in milliseconds (default `1500`). |
+| `CODEMEM_OBSERVER_AUTH_CACHE_TTL_S` | Cache TTL for command/file auth resolution in seconds (default `300`). |
+| `CODEMEM_OBSERVER_HEADERS` | JSON object of templated observer headers, e.g. `{"Authorization":"Bearer ${auth.token}"}`. |
 | `CODEMEM_OBSERVER_MAX_CHARS` | Max observer prompt characters (default `12000`). |
 | `CODEMEM_RAW_EVENTS_BACKOFF_MS` | Backoff window after stream failure before retrying stream POSTs (default `10000`). |
 | `CODEMEM_RAW_EVENTS_STATUS_CHECK_MS` | Minimum interval between stream availability preflight checks (default `30000`). |

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -89,6 +89,9 @@ Observer execution in `0.16` supports both API and Claude runtime paths.
 
 - Runtime values: `api_http`, `claude_sidecar`.
 - `claude_sidecar` runs observer calls via local Claude runtime auth (no `ANTHROPIC_API_KEY` required).
+- Default models:
+  - `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
+  - `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.
 - If `observer_model` is unsupported in Claude CLI, codemem retries once without `--model`.
 - Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
 - Supported: API keys and gateway tokens codemem can read directly.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -36,7 +36,7 @@ Ingest one Claude hook payload from stdin (this is what the installed hook scrip
 printf '%s\n' '{"hook_event_name":"SessionStart","session_id":"sess-1","cwd":"/tmp/demo"}' | codemem ingest-claude-hook
 ```
 
-By default, `Stop` and `SessionEnd` trigger an immediate queue flush attempt. Set `CODEMEM_CLAUDE_HOOK_FLUSH=0` to disable that behavior.
+By default, `SessionEnd` triggers an immediate queue flush attempt. Set `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` to also flush on `Stop`, or `CODEMEM_CLAUDE_HOOK_FLUSH=0` to disable hook-triggered flushes entirely.
 
 The packaged template currently registers these hook events in `plugins/claude/hooks/hooks.json`:
 - `SessionStart`
@@ -85,10 +85,11 @@ Provider/model selection can be overridden with `CODEMEM_OBSERVER_PROVIDER` and
 
 ### Observer auth modes (0.16)
 
-Observer execution in `0.16` uses API-style auth paths.
+Observer execution in `0.16` supports both API and Claude runtime paths.
 
 - Runtime values: `api_http`, `claude_sidecar`.
-- `claude_sidecar` is reserved/not implemented yet; codemem logs a warning and runs through `api_http`.
+- `claude_sidecar` runs observer calls via local Claude runtime auth (no `ANTHROPIC_API_KEY` required).
+- If `observer_model` is unsupported in Claude CLI, codemem retries once without `--model`.
 - Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
 - Supported: API keys and gateway tokens codemem can read directly.
 - Custom provider path does not implicitly fall back to OpenCode/IAP env tokens; use provider key, `CODEMEM_OBSERVER_API_KEY`, `file`, or `command`.
@@ -221,7 +222,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_OBSERVER_PROVIDER` | Force `openai`, `anthropic`, or a custom provider key (optional). |
 | `CODEMEM_OBSERVER_MODEL` | Override observer model (default `gpt-5.1-codex-mini` or `claude-4.5-haiku`). |
 | `CODEMEM_OBSERVER_API_KEY` | API key for observer model (optional). |
-| `CODEMEM_OBSERVER_RUNTIME` | Observer runtime mode (`api_http`, `claude_sidecar`; `claude_sidecar` is reserved/not implemented yet). |
+| `CODEMEM_OBSERVER_RUNTIME` | Observer runtime mode (`api_http` or `claude_sidecar`). |
 | `CODEMEM_OBSERVER_AUTH_SOURCE` | Observer auth source (`auto`, `env`, `file`, `command`, `none`). |
 | `CODEMEM_OBSERVER_AUTH_FILE` | Path to token file used when auth source is `file`. |
 | `CODEMEM_OBSERVER_AUTH_COMMAND` | Command argv as a JSON string array used when auth source is `command`. |
@@ -234,13 +235,15 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_RAW_EVENTS_HARD_MAX` | Hard upper bound for in-memory plugin queue under sustained failure pressure (default `2000`). |
 | `CODEMEM_RAW_EVENTS_AUTO_FLUSH` | Set to `1` to enable viewer-side debounced flush of streamed raw events (default off). |
 | `CODEMEM_RAW_EVENTS_DEBOUNCE_MS` | Debounce delay before auto-flush per session (default `60000`). |
-| `CODEMEM_RAW_EVENTS_SWEEPER` | Set to `1` to enable periodic sweeper flush for idle sessions (default off). |
+| `CODEMEM_RAW_EVENTS_SWEEPER` | Set to `1` to enable periodic sweeper flush for idle sessions (default on). |
 | `CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS` | Sweeper tick interval (default `30000`). |
+| `CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S` | Config/env interval in seconds used by Settings UI (default `30`; overridden by `CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS` when set). |
 | `CODEMEM_RAW_EVENTS_SWEEPER_IDLE_MS` | Consider session idle if no events since this many ms (default `120000`). |
 | `CODEMEM_RAW_EVENTS_SWEEPER_LIMIT` | Max idle sessions to flush per sweeper tick (default `25`). |
 | `CODEMEM_RAW_EVENTS_STUCK_BATCH_MS` | Mark flush batches older than this many ms as error (default `300000`). |
 | `CODEMEM_RAW_EVENTS_RETENTION_MS` | If >0, delete raw events older than this many ms (default `0`, keep forever). |
-| `CODEMEM_CLAUDE_HOOK_FLUSH` | Set to `0` to disable immediate flush attempts on Claude `Stop`/`SessionEnd` hooks (default on). |
+| `CODEMEM_CLAUDE_HOOK_FLUSH` | Set to `0` to disable immediate hook flush attempts (default on). |
+| `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP` | Set to `1` to flush on Claude `Stop` hooks in addition to `SessionEnd` (default off). |
 | `CODEMEM_HOOK_ALLOW_UVX` | Set to `1` to allow Claude hook script fallback to `uvx --from codemem` when `codemem` binary is not found (default off). |
 
 ## Compatibility guidance behavior

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -21,12 +21,15 @@
 ## Observer auth configuration
 
 - Runtime choices are `api_http` and `claude_sidecar`.
-- `claude_sidecar` is currently reserved/not implemented; codemem logs a warning and uses `api_http`.
+- `claude_sidecar` runs observer calls through the local Claude runtime (subscription/session auth) and does not require `ANTHROPIC_API_KEY`.
+- If a configured `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's default model.
 - Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` is argv and must be a JSON string array, not a space-separated string.
   - Config file form: `"observer_auth_command": ["iap-auth", "--audience", "example"]`
   - Env var form (`CODEMEM_OBSERVER_AUTH_COMMAND`): `'["iap-auth","--audience","example"]'`
 - Header templates can use `${auth.token}`, `${auth.type}`, and `${auth.source}`.
+- Settings are grouped into `Observer`, `Queue`, and `Sync` sections to reduce modal clutter.
+- Queue settings include `raw_events_sweeper_interval_s` (seconds), which controls background pending-event drain cadence.
 
 Example command-token gateway config:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -13,10 +13,34 @@
 
 ## Settings modal
 - Open via the Settings button in the header.
-- Writes `observer_provider`, `observer_model`, `observer_max_chars`, `pack_observation_limit`, and `pack_session_limit`.
+- Writes observer runtime/auth settings (`observer_runtime`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, `observer_headers`) plus `observer_provider`, `observer_model`, `observer_max_chars`, `pack_observation_limit`, and `pack_session_limit`.
 - Sync settings can also be updated here (`sync_enabled`, `sync_host`, `sync_port`, `sync_interval_s`, `sync_mdns`).
 - Environment variables still override file values.
 - Config file supports JSON and JSONC (`~/.config/codemem/config.json` or `~/.config/codemem/config.jsonc`).
+
+## Observer auth configuration
+
+- `0.16` observer flow supports API key/gateway token auth sources: `env`, `file`, `command`.
+- Pro/Max subscription runtime bridging for observer calls is a follow-up item.
+
+Example command-token gateway config:
+
+```json
+{
+  "observer_provider": "your-gateway-provider",
+  "observer_auth_source": "command",
+  "observer_auth_command": ["iap-auth"],
+  "observer_headers": {
+    "Authorization": "Bearer ${auth.token}"
+  }
+}
+```
+
+Header template variables:
+
+- `${auth.token}`
+- `${auth.type}`
+- `${auth.source}`
 
 ## Memory persistence
 - A session is created per ingest payload.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -20,18 +20,27 @@
 
 ## Observer auth configuration
 
-- `0.16` observer flow supports API key/gateway token auth sources: `env`, `file`, `command`.
-- Pro/Max subscription runtime bridging for observer calls is a follow-up item.
+- Runtime choices are `api_http` and `claude_sidecar`.
+- `claude_sidecar` is currently reserved/not implemented; codemem logs a warning and uses `api_http`.
+- Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
+- `observer_auth_command` is argv and must be a JSON string array, not a space-separated string.
+  - Config file form: `"observer_auth_command": ["iap-auth", "--audience", "example"]`
+  - Env var form (`CODEMEM_OBSERVER_AUTH_COMMAND`): `'["iap-auth","--audience","example"]'`
+- Header templates can use `${auth.token}`, `${auth.type}`, and `${auth.source}`.
 
 Example command-token gateway config:
 
 ```json
 {
   "observer_provider": "your-gateway-provider",
+  "observer_runtime": "api_http",
   "observer_auth_source": "command",
-  "observer_auth_command": ["iap-auth"],
+  "observer_auth_command": ["iap-auth", "--audience", "example"],
+  "observer_auth_timeout_ms": 1500,
+  "observer_auth_cache_ttl_s": 300,
   "observer_headers": {
-    "Authorization": "Bearer ${auth.token}"
+    "Authorization": "Bearer ${auth.token}",
+    "X-Auth-Source": "${auth.source}"
   }
 }
 ```
@@ -41,6 +50,11 @@ Header template variables:
 - `${auth.token}`
 - `${auth.type}`
 - `${auth.source}`
+
+Command/file token caching notes:
+
+- Successful `file`/`command` token resolutions are cached for `observer_auth_cache_ttl_s`.
+- Failed `file`/`command` resolutions are not cached (codemem clears stale cache and retries on the next call).
 
 ## Memory persistence
 - A session is created per ingest payload.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -22,6 +22,9 @@
 
 - Runtime choices are `api_http` and `claude_sidecar`.
 - `claude_sidecar` runs observer calls through the local Claude runtime (subscription/session auth) and does not require `ANTHROPIC_API_KEY`.
+- Default model selection:
+  - `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
+  - `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.
 - If a configured `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's default model.
 - Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` is argv and must be a JSON string array, not a space-separated string.

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -35,11 +35,48 @@ def test_ingest_claude_hook_cmd_skips_pre_tool_use_hook() -> None:
     assert called["count"] == 0
 
 
-def test_ingest_claude_hook_cmd_processes_stop_hook() -> None:
+def test_ingest_claude_hook_cmd_processes_stop_hook_without_default_flush() -> None:
     payload = {
         "hook_event_name": "Stop",
         "session_id": "sess-1",
         "last_assistant_message": "Done",
+    }
+    called = {"count": 0}
+
+    class _FakeStore:
+        def __init__(self, _: object) -> None:
+            pass
+
+        def record_raw_event(self, **kwargs: object) -> bool:
+            called["count"] += 1
+            assert kwargs["event_type"] == "claude.hook"
+            return True
+
+        def update_raw_event_session_meta(self, **_: object) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    def _fake_flush(*_: object, **__: object) -> dict[str, int]:
+        called["count"] += 1
+        return {"flushed": 1, "updated_state": 1}
+
+    with (
+        patch("sys.stdin", io.StringIO(json.dumps(payload))),
+        patch("codemem.commands.claude_integration_cmds.MemoryStore", _FakeStore),
+        patch("codemem.commands.claude_integration_cmds.flush_raw_events", _fake_flush),
+    ):
+        ingest_claude_hook_cmd()
+
+    assert called["count"] == 1
+
+
+def test_ingest_claude_hook_cmd_flushes_session_end_by_default() -> None:
+    payload = {
+        "hook_event_name": "SessionEnd",
+        "session_id": "sess-1",
+        "stop_reason": "end_turn",
     }
     called = {"count": 0}
 
@@ -101,6 +138,7 @@ def test_ingest_claude_hook_cmd_flushes_stop_hook_when_assistant_text_missing() 
 
     with (
         patch("sys.stdin", io.StringIO(json.dumps(payload))),
+        patch.dict("os.environ", {"CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP": "1"}, clear=False),
         patch("codemem.commands.claude_integration_cmds.MemoryStore", _FakeStore),
         patch("codemem.commands.claude_integration_cmds.flush_raw_events", _fake_flush),
     ):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -271,3 +271,92 @@ def test_load_config_clamps_hybrid_shadow_sample_rate(
     cfg = load_config(config_path)
 
     assert cfg.hybrid_retrieval_shadow_sample_rate == 1.0
+
+
+def test_load_config_reads_observer_auth_fields(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "observer_runtime": "api_http",
+                "observer_auth_source": "command",
+                "observer_auth_file": "~/.codemem/token.txt",
+                "observer_auth_command": ["iap-auth", "--audience", "gateway"],
+                "observer_auth_timeout_ms": 2500,
+                "observer_auth_cache_ttl_s": 120,
+                "observer_headers": {
+                    "Authorization": "Bearer ${auth.token}",
+                    "X-Auth-Source": "${auth.source}",
+                },
+            }
+        )
+    )
+
+    cfg = load_config(config_path)
+
+    assert cfg.observer_runtime == "api_http"
+    assert cfg.observer_auth_source == "command"
+    assert cfg.observer_auth_file == "~/.codemem/token.txt"
+    assert cfg.observer_auth_command == ["iap-auth", "--audience", "gateway"]
+    assert cfg.observer_auth_timeout_ms == 2500
+    assert cfg.observer_auth_cache_ttl_s == 120
+    assert cfg.observer_headers["Authorization"] == "Bearer ${auth.token}"
+
+
+def test_load_config_parses_observer_auth_command_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv(
+        "CODEMEM_OBSERVER_AUTH_COMMAND",
+        '["iap-auth", "--audience", "gateway"]',
+    )
+
+    cfg = load_config(config_path)
+
+    assert cfg.observer_auth_command == ["iap-auth", "--audience", "gateway"]
+
+
+def test_load_config_rejects_non_json_observer_auth_command_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_OBSERVER_AUTH_COMMAND", "iap-auth --audience gateway")
+
+    with pytest.warns(RuntimeWarning, match="observer_auth_command"):
+        cfg = load_config(config_path)
+
+    assert cfg.observer_auth_command == []
+
+
+def test_load_config_parses_observer_headers_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv(
+        "CODEMEM_OBSERVER_HEADERS",
+        '{"Authorization":"Bearer ${auth.token}","X-Auth-Source":"${auth.source}"}',
+    )
+
+    cfg = load_config(config_path)
+
+    assert cfg.observer_headers == {
+        "Authorization": "Bearer ${auth.token}",
+        "X-Auth-Source": "${auth.source}",
+    }
+
+
+def test_load_config_invalid_observer_headers_warns_and_uses_default(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"observer_headers": {"Authorization": 1}}\n')
+
+    with pytest.warns(RuntimeWarning, match="observer_headers"):
+        cfg = load_config(config_path)
+
+    assert cfg.observer_headers == {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -360,3 +360,25 @@ def test_load_config_invalid_observer_headers_warns_and_uses_default(tmp_path: P
         cfg = load_config(config_path)
 
     assert cfg.observer_headers == {}
+
+
+def test_load_config_reads_raw_events_sweeper_interval_from_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"raw_events_sweeper_interval_s": 90}\n')
+
+    cfg = load_config(config_path)
+
+    assert cfg.raw_events_sweeper_interval_s == 90
+
+
+def test_load_config_reads_raw_events_sweeper_interval_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S", "75")
+
+    cfg = load_config(config_path)
+
+    assert cfg.raw_events_sweeper_interval_s == 75

--- a/tests/test_observer_auth.py
+++ b/tests/test_observer_auth.py
@@ -319,6 +319,24 @@ def test_auth_adapter_command_source_does_not_cache_failed_resolution(
     assert len(calls) == 2
 
 
+def test_auth_adapter_env_source_uses_environment_tokens_only() -> None:
+    adapter = ObserverAuthAdapter(source="env")
+
+    resolved = adapter.resolve(explicit_token="config-token", env_tokens=("env-token",))
+
+    assert resolved.token == "env-token"
+    assert resolved.source == "env"
+
+
+def test_auth_adapter_env_source_ignores_explicit_token_when_env_missing() -> None:
+    adapter = ObserverAuthAdapter(source="env")
+
+    resolved = adapter.resolve(explicit_token="config-token", env_tokens=())
+
+    assert resolved.token is None
+    assert resolved.source == "none"
+
+
 def test_custom_provider_none_auth_source_does_not_use_api_key() -> None:
     cfg = OpencodeMemConfig(
         observer_provider="gateway",
@@ -347,6 +365,47 @@ def test_custom_provider_none_auth_source_does_not_use_api_key() -> None:
     assert client.client.kwargs["api_key"] == "unused"
     assert client.auth.token is None
     assert client.auth.source == "none"
+
+
+def test_observer_retries_auth_resolution_when_client_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = OpencodeMemConfig(
+        observer_provider="openai",
+        observer_auth_source="command",
+        observer_auth_command=["iap-auth"],
+    )
+    tokens = iter([None, "token-2"])
+
+    def fake_run(_cmd: tuple[str, ...], _timeout_ms: int) -> str | None:
+        return next(tokens)
+
+    class OpenAIWithChatStub:
+        def __init__(self, **_kwargs: object) -> None:
+            self.kwargs = _kwargs
+
+            class _Completions:
+                def create(self, **_payload: object) -> object:
+                    return SimpleNamespace(
+                        choices=[SimpleNamespace(message=SimpleNamespace(content="observer-ok"))]
+                    )
+
+            self.chat = SimpleNamespace(completions=_Completions())
+
+    monkeypatch.setattr("codemem.observer_auth._run_auth_command", fake_run)
+    openai_module = SimpleNamespace(OpenAI=OpenAIWithChatStub)
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch.dict(sys.modules, {"openai": openai_module}),
+    ):
+        from codemem.observer import ObserverClient
+
+        client = ObserverClient()
+        assert client.client is None
+        output = client._call("hello")
+
+    assert output == "observer-ok"
 
 
 def _claude_sidecar_payload(*, result: str, is_error: bool = False) -> str:

--- a/tests/test_observer_auth.py
+++ b/tests/test_observer_auth.py
@@ -16,6 +16,11 @@ from codemem.observer import (
     _load_opencode_oauth_cache,
     _resolve_oauth_provider,
 )
+from codemem.observer_auth import (
+    ObserverAuthAdapter,
+    ObserverAuthMaterial,
+    _render_observer_headers,
+)
 
 
 class OpenAIStub:
@@ -239,3 +244,150 @@ def test_opencode_run_enabled_when_no_auth(monkeypatch: pytest.MonkeyPatch) -> N
         client = ObserverClient()
         assert client.use_opencode_run is True
         assert client.client is None
+
+
+def test_auth_adapter_command_source_caches_until_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = ObserverAuthAdapter(
+        source="command",
+        command=("iap-auth",),
+        timeout_ms=1000,
+        cache_ttl_s=300,
+    )
+    calls: list[int] = []
+
+    def fake_run(_cmd: tuple[str, ...], _timeout_ms: int) -> str:
+        calls.append(1)
+        return "token-a"
+
+    monkeypatch.setattr("codemem.observer_auth._run_auth_command", fake_run)
+
+    first = adapter.resolve()
+    second = adapter.resolve()
+
+    assert first.token == "token-a"
+    assert second.token == "token-a"
+    assert len(calls) == 1
+
+
+def test_auth_adapter_command_force_refresh_bypasses_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = ObserverAuthAdapter(
+        source="command",
+        command=("iap-auth",),
+        timeout_ms=1000,
+        cache_ttl_s=300,
+    )
+    tokens = iter(["token-a", "token-b"])
+
+    def fake_run(_cmd: tuple[str, ...], _timeout_ms: int) -> str:
+        return next(tokens)
+
+    monkeypatch.setattr("codemem.observer_auth._run_auth_command", fake_run)
+
+    first = adapter.resolve()
+    second = adapter.resolve(force_refresh=True)
+
+    assert first.token == "token-a"
+    assert second.token == "token-b"
+
+
+def test_auth_adapter_command_source_does_not_cache_failed_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = ObserverAuthAdapter(
+        source="command",
+        command=("iap-auth",),
+        timeout_ms=1000,
+        cache_ttl_s=300,
+    )
+    calls: list[int] = []
+    tokens = iter([None, "token-b"])
+
+    def fake_run(_cmd: tuple[str, ...], _timeout_ms: int) -> str | None:
+        calls.append(1)
+        return next(tokens)
+
+    monkeypatch.setattr("codemem.observer_auth._run_auth_command", fake_run)
+
+    first = adapter.resolve()
+    second = adapter.resolve()
+
+    assert first.token is None
+    assert second.token == "token-b"
+    assert len(calls) == 2
+
+
+def test_custom_provider_none_auth_source_does_not_use_api_key() -> None:
+    cfg = OpencodeMemConfig(
+        observer_provider="gateway",
+        observer_model="gateway-model",
+        observer_api_key="should-not-be-used",
+        observer_auth_source="none",
+    )
+    openai_module = SimpleNamespace(OpenAI=OpenAIStub)
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch("codemem.observer._list_custom_providers", return_value={"gateway"}),
+        patch("codemem.observer._get_opencode_provider_config", return_value={}),
+        patch(
+            "codemem.observer._resolve_custom_provider_model",
+            return_value=("https://gateway.example/v1", "gateway-model", {}),
+        ),
+        patch("codemem.observer._get_provider_api_key", return_value=None),
+        patch.dict(sys.modules, {"openai": openai_module}),
+    ):
+        from codemem.observer import ObserverClient
+
+        client = ObserverClient()
+
+    assert isinstance(client.client, OpenAIStub)
+    assert client.client.kwargs["api_key"] == "unused"
+    assert client.auth.token is None
+    assert client.auth.source == "none"
+
+
+def test_observer_runtime_claude_sidecar_falls_back_to_api_http() -> None:
+    cfg = OpencodeMemConfig(
+        observer_provider="openai",
+        observer_api_key="stub-key",
+        observer_runtime="claude_sidecar",
+    )
+    openai_module = SimpleNamespace(OpenAI=OpenAIStub)
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch.dict(sys.modules, {"openai": openai_module}),
+    ):
+        from codemem.observer import ObserverClient
+
+        client = ObserverClient()
+
+    assert client.runtime == "api_http"
+
+
+def test_render_observer_headers_injects_auth_token() -> None:
+    auth = ObserverAuthMaterial(token="secret-token", auth_type="bearer", source="command")
+    headers = _render_observer_headers(
+        {
+            "Authorization": "Bearer ${auth.token}",
+            "X-Auth-Source": "${auth.source}",
+        },
+        auth,
+    )
+
+    assert headers["Authorization"] == "Bearer secret-token"
+    assert headers["X-Auth-Source"] == "command"
+
+
+def test_render_observer_headers_skips_token_placeholder_when_missing() -> None:
+    auth = ObserverAuthMaterial(token=None, auth_type="none", source="none")
+    headers = _render_observer_headers(
+        {
+            "Authorization": "Bearer ${auth.token}",
+            "X-Mode": "${auth.type}",
+        },
+        auth,
+    )
+
+    assert "Authorization" not in headers
+    assert headers["X-Mode"] == "none"

--- a/tests/test_observer_auth.py
+++ b/tests/test_observer_auth.py
@@ -9,6 +9,7 @@ import pytest
 
 from codemem.config import OpencodeMemConfig
 from codemem.observer import (
+    DEFAULT_ANTHROPIC_MODEL,
     ObserverAuthError,
     _build_codex_headers,
     _extract_oauth_account_id,
@@ -387,6 +388,8 @@ def test_observer_runtime_claude_sidecar_uses_sidecar_call() -> None:
     assert run_mock.call_count == 1
     called_cmd = run_mock.call_args.args[0]
     assert called_cmd[:4] == ["claude", "-p", "--output-format", "json"]
+    assert "--model" in called_cmd
+    assert DEFAULT_ANTHROPIC_MODEL in called_cmd
 
 
 def test_observer_runtime_claude_sidecar_retries_without_model_on_model_error() -> None:

--- a/tests/test_observer_auth.py
+++ b/tests/test_observer_auth.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -8,6 +9,7 @@ import pytest
 
 from codemem.config import OpencodeMemConfig
 from codemem.observer import (
+    ObserverAuthError,
     _build_codex_headers,
     _extract_oauth_account_id,
     _extract_oauth_expires,
@@ -346,12 +348,118 @@ def test_custom_provider_none_auth_source_does_not_use_api_key() -> None:
     assert client.auth.source == "none"
 
 
-def test_observer_runtime_claude_sidecar_falls_back_to_api_http() -> None:
+def _claude_sidecar_payload(*, result: str, is_error: bool = False) -> str:
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": is_error,
+            "result": result,
+        }
+    )
+
+
+def test_observer_runtime_claude_sidecar_uses_sidecar_call() -> None:
     cfg = OpencodeMemConfig(
-        observer_provider="openai",
-        observer_api_key="stub-key",
         observer_runtime="claude_sidecar",
     )
+    run_mock = Mock(
+        return_value=subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout=_claude_sidecar_payload(result="hello from sidecar"),
+            stderr="",
+        )
+    )
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch("codemem.observer.subprocess.run", run_mock),
+    ):
+        from codemem.observer import ObserverClient
+
+        client = ObserverClient()
+        output = client._call("hello")
+
+    assert client.runtime == "claude_sidecar"
+    assert client.client is None
+    assert output == "hello from sidecar"
+    assert run_mock.call_count == 1
+    called_cmd = run_mock.call_args.args[0]
+    assert called_cmd[:4] == ["claude", "-p", "--output-format", "json"]
+
+
+def test_observer_runtime_claude_sidecar_retries_without_model_on_model_error() -> None:
+    cfg = OpencodeMemConfig(
+        observer_runtime="claude_sidecar",
+        observer_model="claude-4.5-haiku",
+    )
+    run_mock = Mock(
+        side_effect=[
+            subprocess.CompletedProcess(
+                args=["claude"],
+                returncode=0,
+                stdout=_claude_sidecar_payload(
+                    result=(
+                        "There's an issue with the selected model (claude-4.5-haiku). "
+                        "Run --model to pick a different model."
+                    ),
+                    is_error=True,
+                ),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["claude"],
+                returncode=0,
+                stdout=_claude_sidecar_payload(result="hello from fallback"),
+                stderr="",
+            ),
+        ]
+    )
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch("codemem.observer.subprocess.run", run_mock),
+    ):
+        from codemem.observer import ObserverClient
+
+        client = ObserverClient()
+        output = client._call("hello")
+
+    assert output == "hello from fallback"
+    assert run_mock.call_count == 2
+    first_cmd = run_mock.call_args_list[0].args[0]
+    second_cmd = run_mock.call_args_list[1].args[0]
+    assert "--model" in first_cmd
+    assert "claude-4.5-haiku" in first_cmd
+    assert "--model" not in second_cmd
+
+
+def test_observer_runtime_claude_sidecar_raises_auth_error() -> None:
+    cfg = OpencodeMemConfig(observer_runtime="claude_sidecar")
+    run_mock = Mock(
+        return_value=subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout=_claude_sidecar_payload(result="Please login first.", is_error=True),
+            stderr="",
+        )
+    )
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch("codemem.observer.subprocess.run", run_mock),
+    ):
+        from codemem.observer import ObserverClient
+
+        client = ObserverClient()
+        with pytest.raises(ObserverAuthError):
+            client._call("hello")
+
+
+def test_observer_runtime_non_string_falls_back_to_api_http() -> None:
+    cfg = OpencodeMemConfig(observer_provider="openai", observer_api_key="stub-key")
+    cfg.observer_runtime = 1  # type: ignore[assignment]
     openai_module = SimpleNamespace(OpenAI=OpenAIStub)
     with (
         patch("codemem.observer.load_config", return_value=cfg),

--- a/tests/test_viewer_raw_events.py
+++ b/tests/test_viewer_raw_events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from codemem import viewer, viewer_raw_events
+from codemem.config import OpencodeMemConfig
 
 
 def test_viewer_raw_events_reexports() -> None:
@@ -9,3 +10,26 @@ def test_viewer_raw_events_reexports() -> None:
     assert viewer.RAW_EVENT_FLUSHER is viewer_raw_events.RAW_EVENT_FLUSHER
     assert viewer.RAW_EVENT_SWEEPER is viewer_raw_events.RAW_EVENT_SWEEPER
     assert viewer.flush_raw_events is viewer_raw_events.flush_raw_events
+
+
+def test_raw_event_sweeper_interval_uses_config_when_env_unset(
+    monkeypatch,
+) -> None:
+    sweeper = viewer_raw_events.RawEventSweeper()
+    cfg = OpencodeMemConfig(raw_events_sweeper_interval_s=42)
+    monkeypatch.delenv("CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS", raising=False)
+    monkeypatch.setattr(viewer_raw_events, "load_config", lambda: cfg)
+
+    assert sweeper.interval_ms() == 42000
+
+
+def test_raw_event_sweeper_interval_prefers_env_ms(monkeypatch) -> None:
+    sweeper = viewer_raw_events.RawEventSweeper()
+    monkeypatch.setenv("CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS", "5000")
+    monkeypatch.setattr(
+        viewer_raw_events,
+        "load_config",
+        lambda: OpencodeMemConfig(raw_events_sweeper_interval_s=42),
+    )
+
+    assert sweeper.interval_ms() == 5000

--- a/tests/test_viewer_routes_config.py
+++ b/tests/test_viewer_routes_config.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codemem.config import read_config_file
+from codemem.viewer_routes import config as viewer_config
+
+
+class DummyHandler:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.headers = {"Content-Length": str(len(body))}
+        self.rfile = io.BytesIO(body)
+        self.response: dict[str, Any] | None = None
+        self.status: int | None = None
+
+    def _send_json(self, payload: dict[str, Any], status: int = 200) -> None:
+        self.response = payload
+        self.status = status
+
+
+def test_config_route_accepts_observer_auth_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler(
+        {
+            "observer_provider": "openai",
+            "observer_runtime": "api_http",
+            "observer_auth_source": "command",
+            "observer_auth_command": ["iap-auth"],
+            "observer_auth_timeout_ms": 2000,
+            "observer_auth_cache_ttl_s": 60,
+            "observer_headers": {"Authorization": "Bearer ${auth.token}"},
+        }
+    )
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    saved = read_config_file(config_path)
+    assert saved["observer_auth_source"] == "command"
+    assert saved["observer_auth_command"] == ["iap-auth"]
+    assert saved["observer_auth_timeout_ms"] == 2000
+    assert saved["observer_auth_cache_ttl_s"] == 60
+    assert saved["observer_headers"] == {"Authorization": "Bearer ${auth.token}"}
+
+
+def test_config_route_preserves_observer_auth_command_exactly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    command = ["iap-auth", "--audience", " gateway ", ""]
+    handler = DummyHandler(
+        {
+            "observer_auth_source": "command",
+            "observer_auth_command": command,
+        }
+    )
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    saved = read_config_file(config_path)
+    assert saved["observer_auth_command"] == command
+
+
+def test_config_route_rejects_invalid_observer_auth_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler(
+        {
+            "observer_auth_source": "command",
+            "observer_auth_command": "iap-auth",
+        }
+    )
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "observer_auth_command must be string array"}
+
+
+def test_config_route_rejects_invalid_observer_headers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler(
+        {
+            "observer_headers": {"Authorization": 123},
+        }
+    )
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "observer_headers must be object of string values"}

--- a/tests/test_viewer_routes_config.py
+++ b/tests/test_viewer_routes_config.py
@@ -40,6 +40,7 @@ def test_config_route_accepts_observer_auth_fields(
             "observer_auth_timeout_ms": 2000,
             "observer_auth_cache_ttl_s": 60,
             "observer_headers": {"Authorization": "Bearer ${auth.token}"},
+            "raw_events_sweeper_interval_s": 45,
         }
     )
 
@@ -57,6 +58,7 @@ def test_config_route_accepts_observer_auth_fields(
     assert saved["observer_auth_timeout_ms"] == 2000
     assert saved["observer_auth_cache_ttl_s"] == 60
     assert saved["observer_headers"] == {"Authorization": "Bearer ${auth.token}"}
+    assert saved["raw_events_sweeper_interval_s"] == 45
 
 
 def test_config_route_preserves_observer_auth_command_exactly(
@@ -133,3 +135,23 @@ def test_config_route_rejects_invalid_observer_headers(
     assert handled is True
     assert handler.status == 400
     assert handler.response == {"error": "observer_headers must be object of string values"}
+
+
+def test_config_route_rejects_invalid_raw_events_sweeper_interval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler({"raw_events_sweeper_interval_s": 0})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "raw_events_sweeper_interval_s must be int"}

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -236,11 +236,12 @@ export async function saveSettings(startPolling: () => void, refreshCallback: ()
     const authCommand = parseCommandArgv(authCommandInput);
     const headers = parseObserverHeaders(observerHeadersInput);
     const authCacheTtl = authCacheTtlInput === '' ? '' : Number(authCacheTtlInput);
-    const sweeperInterval = sweeperIntervalInput === '' ? '' : Number(sweeperIntervalInput);
+    const sweeperIntervalNum = Number(sweeperIntervalInput);
+    const sweeperInterval = sweeperIntervalInput === '' ? '' : sweeperIntervalNum;
     if (authCacheTtlInput !== '' && !Number.isFinite(authCacheTtl)) {
       throw new Error('observer auth cache ttl must be a number');
     }
-    if (sweeperIntervalInput !== '' && (!Number.isFinite(sweeperInterval) || sweeperInterval <= 0)) {
+    if (sweeperIntervalInput !== '' && (!Number.isFinite(sweeperIntervalNum) || sweeperIntervalNum <= 0)) {
       throw new Error('raw-event sweeper interval must be a positive number');
     }
 

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -6,6 +6,7 @@ import * as api from '../lib/api';
 
 let settingsOpen = false;
 let previouslyFocused: HTMLElement | null = null;
+let settingsActiveTab = 'observer';
 
 function getFocusableNodes(container: HTMLElement | null): HTMLElement[] {
   if (!container) return [];
@@ -69,6 +70,7 @@ export function renderConfigModal(payload: any) {
   const observerMaxChars = $input('observerMaxChars');
   const packObservationLimit = $input('packObservationLimit');
   const packSessionLimit = $input('packSessionLimit');
+  const rawEventsSweeperIntervalS = $input('rawEventsSweeperIntervalS');
   const syncEnabled = $input('syncEnabled');
   const syncHost = $input('syncHost');
   const syncPort = $input('syncPort');
@@ -87,8 +89,14 @@ export function renderConfigModal(payload: any) {
     const argv = Array.isArray(config.observer_auth_command) ? config.observer_auth_command : [];
     observerAuthCommand.value = argv.length ? JSON.stringify(argv, null, 2) : '';
   }
-  if (observerAuthTimeoutMs) observerAuthTimeoutMs.value = config.observer_auth_timeout_ms || '';
-  if (observerAuthCacheTtlS) observerAuthCacheTtlS.value = config.observer_auth_cache_ttl_s || '';
+  if (observerAuthTimeoutMs) {
+    const timeoutMs = config.observer_auth_timeout_ms;
+    observerAuthTimeoutMs.value = timeoutMs === undefined || timeoutMs === null ? '' : String(timeoutMs);
+  }
+  if (observerAuthCacheTtlS) {
+    const cacheTtl = config.observer_auth_cache_ttl_s;
+    observerAuthCacheTtlS.value = cacheTtl === undefined || cacheTtl === null ? '' : String(cacheTtl);
+  }
   if (observerHeaders) {
     const headers = config.observer_headers && typeof config.observer_headers === 'object'
       ? config.observer_headers
@@ -98,6 +106,10 @@ export function renderConfigModal(payload: any) {
   if (observerMaxChars) observerMaxChars.value = config.observer_max_chars || '';
   if (packObservationLimit) packObservationLimit.value = config.pack_observation_limit || '';
   if (packSessionLimit) packSessionLimit.value = config.pack_session_limit || '';
+  if (rawEventsSweeperIntervalS) {
+    const intervalS = config.raw_events_sweeper_interval_s;
+    rawEventsSweeperIntervalS.value = intervalS === undefined || intervalS === null ? '' : String(intervalS);
+  }
   if (syncEnabled) syncEnabled.checked = Boolean(config.sync_enabled);
   if (syncHost) syncHost.value = config.sync_host || '';
   if (syncPort) syncPort.value = config.sync_port || '';
@@ -114,6 +126,7 @@ export function renderConfigModal(payload: any) {
   }
 
   updateAuthSourceVisibility();
+  setSettingsTab(settingsActiveTab);
 
   setDirty(false);
   const settingsStatus = $('settingsStatus');
@@ -155,6 +168,23 @@ function updateAuthSourceVisibility() {
   if (fileField) fileField.hidden = source !== 'file';
   if (commandField) commandField.hidden = source !== 'command';
   if (commandNote) commandNote.hidden = source !== 'command';
+}
+
+function setSettingsTab(tab: string) {
+  const next = ['observer', 'queue', 'sync'].includes(tab) ? tab : 'observer';
+  settingsActiveTab = next;
+  document.querySelectorAll('[data-settings-tab]').forEach((node) => {
+    const button = node as HTMLButtonElement;
+    const active = button.dataset.settingsTab === next;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-selected', active ? 'true' : 'false');
+  });
+  document.querySelectorAll('[data-settings-panel]').forEach((node) => {
+    const panel = node as HTMLElement;
+    const active = panel.dataset.settingsPanel === next;
+    panel.classList.toggle('active', active);
+    panel.hidden = !active;
+  });
 }
 
 function setDirty(dirty: boolean) {
@@ -202,11 +232,16 @@ export async function saveSettings(startPolling: () => void, refreshCallback: ()
     const authCommandInput = (document.getElementById('observerAuthCommand') as HTMLTextAreaElement | null)?.value || '';
     const observerHeadersInput = (document.getElementById('observerHeaders') as HTMLTextAreaElement | null)?.value || '';
     const authCacheTtlInput = ($input('observerAuthCacheTtlS')?.value || '').trim();
+    const sweeperIntervalInput = ($input('rawEventsSweeperIntervalS')?.value || '').trim();
     const authCommand = parseCommandArgv(authCommandInput);
     const headers = parseObserverHeaders(observerHeadersInput);
     const authCacheTtl = authCacheTtlInput === '' ? '' : Number(authCacheTtlInput);
+    const sweeperInterval = sweeperIntervalInput === '' ? '' : Number(sweeperIntervalInput);
     if (authCacheTtlInput !== '' && !Number.isFinite(authCacheTtl)) {
       throw new Error('observer auth cache ttl must be a number');
+    }
+    if (sweeperIntervalInput !== '' && (!Number.isFinite(sweeperInterval) || sweeperInterval <= 0)) {
+      throw new Error('raw-event sweeper interval must be a positive number');
     }
 
     await api.saveConfig({
@@ -222,6 +257,7 @@ export async function saveSettings(startPolling: () => void, refreshCallback: ()
       observer_max_chars: Number($input('observerMaxChars')?.value || 0) || '',
       pack_observation_limit: Number($input('packObservationLimit')?.value || 0) || '',
       pack_session_limit: Number($input('packSessionLimit')?.value || 0) || '',
+      raw_events_sweeper_interval_s: sweeperInterval,
       sync_enabled: $input('syncEnabled')?.checked || false,
       sync_host: $input('syncHost')?.value || '',
       sync_port: Number($input('syncPort')?.value || 0) || '',
@@ -281,6 +317,7 @@ export function initSettings(stopPolling: () => void, startPolling: () => void, 
     'observerMaxChars',
     'packObservationLimit',
     'packSessionLimit',
+    'rawEventsSweeperIntervalS',
     'syncEnabled',
     'syncHost',
     'syncPort',
@@ -295,4 +332,10 @@ export function initSettings(stopPolling: () => void, startPolling: () => void, 
   });
 
   $select('observerAuthSource')?.addEventListener('change', () => updateAuthSourceVisibility());
+  document.querySelectorAll('[data-settings-tab]').forEach((node) => {
+    node.addEventListener('click', () => {
+      const tab = (node as HTMLElement).dataset.settingsTab || 'observer';
+      setSettingsTab(tab);
+    });
+  });
 }

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -8,6 +8,53 @@ let settingsOpen = false;
 let previouslyFocused: HTMLElement | null = null;
 let settingsActiveTab = 'observer';
 
+function hasOwn(obj: unknown, key: string): boolean {
+  return typeof obj === 'object' && obj !== null && Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+function configuredOrEffective(config: any, effective: any, key: string): any {
+  if (hasOwn(config, key)) return config[key];
+  if (hasOwn(effective, key)) return effective[key];
+  return undefined;
+}
+
+function asInputString(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  return String(value);
+}
+
+function toProviderList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function setProviderOptions(
+  selectEl: HTMLSelectElement | null,
+  providers: string[],
+  currentValue: string,
+) {
+  if (!selectEl) return;
+  const values = new Set(providers);
+  if (currentValue) values.add(currentValue);
+
+  selectEl.innerHTML = '';
+  const autoOption = document.createElement('option');
+  autoOption.value = '';
+  autoOption.textContent = 'auto (default)';
+  selectEl.append(autoOption);
+
+  Array.from(values)
+    .sort((a, b) => a.localeCompare(b))
+    .forEach((provider) => {
+      const option = document.createElement('option');
+      option.value = provider;
+      option.textContent = provider;
+      selectEl.append(option);
+    });
+
+  selectEl.value = currentValue;
+}
+
 function getFocusableNodes(container: HTMLElement | null): HTMLElement[] {
   if (!container) return [];
   const selector = [
@@ -55,6 +102,11 @@ export function renderConfigModal(payload: any) {
   if (!payload || typeof payload !== 'object') return;
   const defaults = payload.defaults || {};
   const config = payload.config || {};
+  const effective = payload.effective || {};
+  const envOverrides = payload.env_overrides && typeof payload.env_overrides === 'object'
+    ? payload.env_overrides
+    : {};
+  const providers = toProviderList(payload.providers);
   state.configDefaults = defaults;
   state.configPath = payload.path || '';
 
@@ -77,52 +129,65 @@ export function renderConfigModal(payload: any) {
   const syncInterval = $input('syncInterval');
   const syncMdns = $input('syncMdns');
   const settingsPath = $('settingsPath');
+  const observerModelHint = $('observerModelHint');
   const observerMaxCharsHint = $('observerMaxCharsHint');
   const settingsEffective = $('settingsEffective');
 
-  if (observerProvider) observerProvider.value = config.observer_provider || '';
-  if (observerModel) observerModel.value = config.observer_model || '';
-  if (observerRuntime) observerRuntime.value = config.observer_runtime || 'api_http';
-  if (observerAuthSource) observerAuthSource.value = config.observer_auth_source || 'auto';
-  if (observerAuthFile) observerAuthFile.value = config.observer_auth_file || '';
+  const observerProviderValue = asInputString(configuredOrEffective(config, effective, 'observer_provider'));
+  setProviderOptions(observerProvider, providers, observerProviderValue);
+
+  const observerModelValue = asInputString(configuredOrEffective(config, effective, 'observer_model'));
+  if (observerModel) observerModel.value = observerModelValue;
+  if (observerRuntime) observerRuntime.value = asInputString(configuredOrEffective(config, effective, 'observer_runtime')) || 'api_http';
+  if (observerAuthSource) observerAuthSource.value = asInputString(configuredOrEffective(config, effective, 'observer_auth_source')) || 'auto';
+  if (observerAuthFile) observerAuthFile.value = asInputString(configuredOrEffective(config, effective, 'observer_auth_file'));
   if (observerAuthCommand) {
-    const argv = Array.isArray(config.observer_auth_command) ? config.observer_auth_command : [];
-    observerAuthCommand.value = argv.length ? JSON.stringify(argv, null, 2) : '';
+    const argv = configuredOrEffective(config, effective, 'observer_auth_command');
+    const command = Array.isArray(argv) ? argv : [];
+    const commandStrings = command.filter((item) => typeof item === 'string');
+    observerAuthCommand.value = commandStrings.length ? JSON.stringify(commandStrings, null, 2) : '';
   }
   if (observerAuthTimeoutMs) {
-    const timeoutMs = config.observer_auth_timeout_ms;
-    observerAuthTimeoutMs.value = timeoutMs === undefined || timeoutMs === null ? '' : String(timeoutMs);
+    observerAuthTimeoutMs.value = asInputString(configuredOrEffective(config, effective, 'observer_auth_timeout_ms'));
   }
   if (observerAuthCacheTtlS) {
-    const cacheTtl = config.observer_auth_cache_ttl_s;
-    observerAuthCacheTtlS.value = cacheTtl === undefined || cacheTtl === null ? '' : String(cacheTtl);
+    observerAuthCacheTtlS.value = asInputString(configuredOrEffective(config, effective, 'observer_auth_cache_ttl_s'));
   }
   if (observerHeaders) {
-    const headers = config.observer_headers && typeof config.observer_headers === 'object'
-      ? config.observer_headers
-      : {};
+    const headerValue = configuredOrEffective(config, effective, 'observer_headers');
+    const headers = headerValue && typeof headerValue === 'object' ? headerValue : {};
     observerHeaders.value = Object.keys(headers).length ? JSON.stringify(headers, null, 2) : '';
   }
-  if (observerMaxChars) observerMaxChars.value = config.observer_max_chars || '';
-  if (packObservationLimit) packObservationLimit.value = config.pack_observation_limit || '';
-  if (packSessionLimit) packSessionLimit.value = config.pack_session_limit || '';
+  if (observerMaxChars) observerMaxChars.value = asInputString(configuredOrEffective(config, effective, 'observer_max_chars'));
+  if (packObservationLimit) packObservationLimit.value = asInputString(configuredOrEffective(config, effective, 'pack_observation_limit'));
+  if (packSessionLimit) packSessionLimit.value = asInputString(configuredOrEffective(config, effective, 'pack_session_limit'));
   if (rawEventsSweeperIntervalS) {
-    const intervalS = config.raw_events_sweeper_interval_s;
-    rawEventsSweeperIntervalS.value = intervalS === undefined || intervalS === null ? '' : String(intervalS);
+    rawEventsSweeperIntervalS.value = asInputString(configuredOrEffective(config, effective, 'raw_events_sweeper_interval_s'));
   }
-  if (syncEnabled) syncEnabled.checked = Boolean(config.sync_enabled);
-  if (syncHost) syncHost.value = config.sync_host || '';
-  if (syncPort) syncPort.value = config.sync_port || '';
-  if (syncInterval) syncInterval.value = config.sync_interval_s || '';
-  if (syncMdns) syncMdns.checked = Boolean(config.sync_mdns);
+  if (syncEnabled) syncEnabled.checked = Boolean(configuredOrEffective(config, effective, 'sync_enabled'));
+  if (syncHost) syncHost.value = asInputString(configuredOrEffective(config, effective, 'sync_host'));
+  if (syncPort) syncPort.value = asInputString(configuredOrEffective(config, effective, 'sync_port'));
+  if (syncInterval) syncInterval.value = asInputString(configuredOrEffective(config, effective, 'sync_interval_s'));
+  if (syncMdns) syncMdns.checked = Boolean(configuredOrEffective(config, effective, 'sync_mdns'));
 
   if (settingsPath) settingsPath.textContent = state.configPath ? `Config path: ${state.configPath}` : 'Config path: n/a';
+  if (observerModelHint) {
+    const source = hasOwn(config, 'observer_model') ? 'Configured' : 'Default';
+    const effectiveModel = observerModelValue || 'n/a';
+    observerModelHint.textContent = `${source} model: ${effectiveModel}`;
+  }
   if (observerMaxCharsHint) {
     const def = defaults?.observer_max_chars || '';
     observerMaxCharsHint.textContent = def ? `Default: ${def}` : '';
   }
   if (settingsEffective) {
-    settingsEffective.textContent = payload.env_overrides ? 'Effective config differs (env overrides active)' : '';
+    settingsEffective.textContent = Object.keys(envOverrides).length > 0
+      ? 'Effective config differs (env overrides active)'
+      : '';
+  }
+  const overrides = $('settingsOverrides');
+  if (overrides) {
+    (overrides as any).hidden = Object.keys(envOverrides).length === 0;
   }
 
   updateAuthSourceVisibility();
@@ -281,8 +346,6 @@ export async function loadConfigData() {
   try {
     const payload = await api.loadConfig();
     renderConfigModal(payload);
-    const overrides = $('settingsOverrides');
-    if (overrides) (overrides as any).hidden = !payload?.config?.has_env_overrides;
   } catch {}
 }
 

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -59,6 +59,13 @@ export function renderConfigModal(payload: any) {
 
   const observerProvider = $select('observerProvider');
   const observerModel = $input('observerModel');
+  const observerRuntime = $select('observerRuntime');
+  const observerAuthSource = $select('observerAuthSource');
+  const observerAuthFile = $input('observerAuthFile');
+  const observerAuthCommand = document.getElementById('observerAuthCommand') as HTMLTextAreaElement | null;
+  const observerAuthTimeoutMs = $input('observerAuthTimeoutMs');
+  const observerAuthCacheTtlS = $input('observerAuthCacheTtlS');
+  const observerHeaders = document.getElementById('observerHeaders') as HTMLTextAreaElement | null;
   const observerMaxChars = $input('observerMaxChars');
   const packObservationLimit = $input('packObservationLimit');
   const packSessionLimit = $input('packSessionLimit');
@@ -73,6 +80,21 @@ export function renderConfigModal(payload: any) {
 
   if (observerProvider) observerProvider.value = config.observer_provider || '';
   if (observerModel) observerModel.value = config.observer_model || '';
+  if (observerRuntime) observerRuntime.value = config.observer_runtime || 'api_http';
+  if (observerAuthSource) observerAuthSource.value = config.observer_auth_source || 'auto';
+  if (observerAuthFile) observerAuthFile.value = config.observer_auth_file || '';
+  if (observerAuthCommand) {
+    const argv = Array.isArray(config.observer_auth_command) ? config.observer_auth_command : [];
+    observerAuthCommand.value = argv.length ? JSON.stringify(argv, null, 2) : '';
+  }
+  if (observerAuthTimeoutMs) observerAuthTimeoutMs.value = config.observer_auth_timeout_ms || '';
+  if (observerAuthCacheTtlS) observerAuthCacheTtlS.value = config.observer_auth_cache_ttl_s || '';
+  if (observerHeaders) {
+    const headers = config.observer_headers && typeof config.observer_headers === 'object'
+      ? config.observer_headers
+      : {};
+    observerHeaders.value = Object.keys(headers).length ? JSON.stringify(headers, null, 2) : '';
+  }
   if (observerMaxChars) observerMaxChars.value = config.observer_max_chars || '';
   if (packObservationLimit) packObservationLimit.value = config.pack_observation_limit || '';
   if (packSessionLimit) packSessionLimit.value = config.pack_session_limit || '';
@@ -91,9 +113,48 @@ export function renderConfigModal(payload: any) {
     settingsEffective.textContent = payload.env_overrides ? 'Effective config differs (env overrides active)' : '';
   }
 
+  updateAuthSourceVisibility();
+
   setDirty(false);
   const settingsStatus = $('settingsStatus');
   if (settingsStatus) settingsStatus.textContent = 'Ready';
+}
+
+function parseCommandArgv(raw: string): string[] {
+  const text = raw.trim();
+  if (!text) return [];
+  const parsed = JSON.parse(text);
+  if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== 'string')) {
+    throw new Error('observer auth command must be a JSON string array');
+  }
+  return parsed;
+}
+
+function parseObserverHeaders(raw: string): Record<string, string> {
+  const text = raw.trim();
+  if (!text) return {};
+  const parsed = JSON.parse(text);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('observer headers must be a JSON object');
+  }
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof key !== 'string' || !key.trim() || typeof value !== 'string') {
+      throw new Error('observer headers must map string keys to string values');
+    }
+    headers[key.trim()] = value;
+  }
+  return headers;
+}
+
+function updateAuthSourceVisibility() {
+  const source = $select('observerAuthSource')?.value || 'auto';
+  const fileField = document.getElementById('observerAuthFileField');
+  const commandField = document.getElementById('observerAuthCommandField');
+  const commandNote = document.getElementById('observerAuthCommandNote');
+  if (fileField) fileField.hidden = source !== 'file';
+  if (commandField) commandField.hidden = source !== 'command';
+  if (commandNote) commandNote.hidden = source !== 'command';
 }
 
 function setDirty(dirty: boolean) {
@@ -138,9 +199,26 @@ export async function saveSettings(startPolling: () => void, refreshCallback: ()
   status.textContent = 'Saving...';
 
   try {
+    const authCommandInput = (document.getElementById('observerAuthCommand') as HTMLTextAreaElement | null)?.value || '';
+    const observerHeadersInput = (document.getElementById('observerHeaders') as HTMLTextAreaElement | null)?.value || '';
+    const authCacheTtlInput = ($input('observerAuthCacheTtlS')?.value || '').trim();
+    const authCommand = parseCommandArgv(authCommandInput);
+    const headers = parseObserverHeaders(observerHeadersInput);
+    const authCacheTtl = authCacheTtlInput === '' ? '' : Number(authCacheTtlInput);
+    if (authCacheTtlInput !== '' && !Number.isFinite(authCacheTtl)) {
+      throw new Error('observer auth cache ttl must be a number');
+    }
+
     await api.saveConfig({
       observer_provider: $select('observerProvider')?.value || '',
       observer_model: $input('observerModel')?.value || '',
+      observer_runtime: $select('observerRuntime')?.value || 'api_http',
+      observer_auth_source: $select('observerAuthSource')?.value || 'auto',
+      observer_auth_file: $input('observerAuthFile')?.value || '',
+      observer_auth_command: authCommand,
+      observer_auth_timeout_ms: Number($input('observerAuthTimeoutMs')?.value || 0) || '',
+      observer_auth_cache_ttl_s: authCacheTtl,
+      observer_headers: headers,
       observer_max_chars: Number($input('observerMaxChars')?.value || 0) || '',
       pack_observation_limit: Number($input('packObservationLimit')?.value || 0) || '',
       pack_session_limit: Number($input('packSessionLimit')?.value || 0) || '',
@@ -153,8 +231,9 @@ export async function saveSettings(startPolling: () => void, refreshCallback: ()
     status.textContent = 'Saved';
     setDirty(false);
     closeSettings(startPolling, refreshCallback);
-  } catch {
-    status.textContent = 'Save failed';
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    status.textContent = `Save failed: ${message}`;
   } finally {
     saveBtn.disabled = !state.settingsDirty;
   }
@@ -189,11 +268,31 @@ export function initSettings(stopPolling: () => void, startPolling: () => void, 
   });
 
   // Mark dirty on any input change
-  const inputs = ['observerProvider', 'observerModel', 'observerMaxChars', 'packObservationLimit', 'packSessionLimit', 'syncEnabled', 'syncHost', 'syncPort', 'syncInterval', 'syncMdns'];
+  const inputs = [
+    'observerProvider',
+    'observerModel',
+    'observerRuntime',
+    'observerAuthSource',
+    'observerAuthFile',
+    'observerAuthCommand',
+    'observerAuthTimeoutMs',
+    'observerAuthCacheTtlS',
+    'observerHeaders',
+    'observerMaxChars',
+    'packObservationLimit',
+    'packSessionLimit',
+    'syncEnabled',
+    'syncHost',
+    'syncPort',
+    'syncInterval',
+    'syncMdns',
+  ];
   inputs.forEach((id) => {
     const input = document.getElementById(id);
     if (!input) return;
     input.addEventListener('input', () => setDirty(true));
     input.addEventListener('change', () => setDirty(true));
   });
+
+  $select('observerAuthSource')?.addEventListener('change', () => updateAuthSourceVisibility());
 }


### PR DESCRIPTION
## Description
- Add observer auth/runtime adapter behavior for 0.16 without forking the observer pipeline.
- Support strict command/file/env/none auth source configuration in config + settings UI, including header templating for gateway flows.
- Document current runtime limitation (`claude_sidecar` reserved with `api_http` fallback) and auth expectations.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run ruff check codemem/config.py codemem/observer.py codemem/observer_auth.py codemem/viewer_routes/config.py tests/test_observer_auth.py tests/test_config.py tests/test_viewer_routes_config.py`
- `uv run pytest tests/test_observer_auth.py tests/test_config.py tests/test_viewer_routes_config.py`
- `uv run pytest`
- `bun run build` (in `viewer_ui/`)

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
