### PR TITLE
feat(viewer): show effective settings defaults without config churn

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Common overrides:
 | `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
 
 The viewer includes a grouped Settings modal (`Observer`, `Queue`, `Sync`) for observer controls, queue cadence, and sync defaults.
+- Settings show effective values (configured or default) and only persist changed fields on save.
 
 Observer runtime/auth in `0.16`:
 

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1507,12 +1507,16 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   let settingsOpen = false;
   let previouslyFocused = null;
   let settingsActiveTab = "observer";
+  let settingsBaseline = {};
+  let settingsEnvOverrides = {};
+  const DEFAULT_OPENAI_MODEL = "gpt-5.1-codex-mini";
+  const DEFAULT_ANTHROPIC_MODEL = "claude-4.5-haiku";
   function hasOwn(obj, key) {
     return typeof obj === "object" && obj !== null && Object.prototype.hasOwnProperty.call(obj, key);
   }
-  function configuredOrEffective(config, effective, key) {
-    if (hasOwn(config, key)) return config[key];
+  function effectiveOrConfigured(config, effective, key) {
     if (hasOwn(effective, key)) return effective[key];
+    if (hasOwn(config, key)) return config[key];
     return void 0;
   }
   function asInputString(value) {
@@ -1522,6 +1526,37 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   function toProviderList(value) {
     if (!Array.isArray(value)) return [];
     return value.filter((item) => typeof item === "string" && item.trim().length > 0);
+  }
+  function isEqualValue(left, right) {
+    if (left === right) return true;
+    return JSON.stringify(left) === JSON.stringify(right);
+  }
+  function normalizeTextValue(value) {
+    const trimmed = value.trim();
+    return trimmed === "" ? "" : trimmed;
+  }
+  function inferObserverModel(runtime, provider, configuredModel) {
+    if (configuredModel) return { model: configuredModel, source: "Configured" };
+    if (runtime === "claude_sidecar") {
+      return { model: DEFAULT_ANTHROPIC_MODEL, source: "Default (claude_sidecar)" };
+    }
+    if (provider === "anthropic") {
+      return { model: DEFAULT_ANTHROPIC_MODEL, source: "Default (anthropic)" };
+    }
+    if (provider && provider !== "openai") {
+      return { model: "provider default", source: "Default (provider)" };
+    }
+    return { model: DEFAULT_OPENAI_MODEL, source: "Default (openai)" };
+  }
+  function renderObserverModelHint() {
+    const hint = $("observerModelHint");
+    if (!hint) return;
+    const runtime = ($select("observerRuntime")?.value || "api_http").trim();
+    const provider = ($select("observerProvider")?.value || "").trim();
+    const configuredModel = normalizeTextValue($input("observerModel")?.value || "");
+    const inferred = inferObserverModel(runtime, provider, configuredModel);
+    const source = hasOwn(settingsEnvOverrides, "observer_model") ? "Env override" : inferred.source;
+    hint.textContent = `${source}: ${inferred.model}`;
   }
   function setProviderOptions(selectEl, providers, currentValue) {
     if (!selectEl) return;
@@ -1584,6 +1619,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const config = payload.config || {};
     const effective = payload.effective || {};
     const envOverrides = payload.env_overrides && typeof payload.env_overrides === "object" ? payload.env_overrides : {};
+    settingsEnvOverrides = envOverrides;
     const providers = toProviderList(payload.providers);
     state.configDefaults = defaults;
     state.configPath = payload.path || "";
@@ -1609,47 +1645,49 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const observerModelHint = $("observerModelHint");
     const observerMaxCharsHint = $("observerMaxCharsHint");
     const settingsEffective = $("settingsEffective");
-    const observerProviderValue = asInputString(configuredOrEffective(config, effective, "observer_provider"));
+    const observerProviderValue = asInputString(effectiveOrConfigured(config, effective, "observer_provider"));
     setProviderOptions(observerProvider, providers, observerProviderValue);
-    const observerModelValue = asInputString(configuredOrEffective(config, effective, "observer_model"));
+    const observerModelValue = asInputString(effectiveOrConfigured(config, effective, "observer_model"));
     if (observerModel) observerModel.value = observerModelValue;
-    if (observerRuntime) observerRuntime.value = asInputString(configuredOrEffective(config, effective, "observer_runtime")) || "api_http";
-    if (observerAuthSource) observerAuthSource.value = asInputString(configuredOrEffective(config, effective, "observer_auth_source")) || "auto";
-    if (observerAuthFile) observerAuthFile.value = asInputString(configuredOrEffective(config, effective, "observer_auth_file"));
+    if (observerRuntime) observerRuntime.value = asInputString(effectiveOrConfigured(config, effective, "observer_runtime")) || "api_http";
+    if (observerAuthSource) observerAuthSource.value = asInputString(effectiveOrConfigured(config, effective, "observer_auth_source")) || "auto";
+    if (observerAuthFile) observerAuthFile.value = asInputString(effectiveOrConfigured(config, effective, "observer_auth_file"));
     if (observerAuthCommand) {
-      const argv = configuredOrEffective(config, effective, "observer_auth_command");
+      const argv = effectiveOrConfigured(config, effective, "observer_auth_command");
       const command = Array.isArray(argv) ? argv : [];
       const commandStrings = command.filter((item) => typeof item === "string");
       observerAuthCommand.value = commandStrings.length ? JSON.stringify(commandStrings, null, 2) : "";
     }
     if (observerAuthTimeoutMs) {
-      observerAuthTimeoutMs.value = asInputString(configuredOrEffective(config, effective, "observer_auth_timeout_ms"));
+      observerAuthTimeoutMs.value = asInputString(effectiveOrConfigured(config, effective, "observer_auth_timeout_ms"));
     }
     if (observerAuthCacheTtlS) {
-      observerAuthCacheTtlS.value = asInputString(configuredOrEffective(config, effective, "observer_auth_cache_ttl_s"));
+      observerAuthCacheTtlS.value = asInputString(effectiveOrConfigured(config, effective, "observer_auth_cache_ttl_s"));
     }
     if (observerHeaders) {
-      const headerValue = configuredOrEffective(config, effective, "observer_headers");
+      const headerValue = effectiveOrConfigured(config, effective, "observer_headers");
       const headers = headerValue && typeof headerValue === "object" ? headerValue : {};
-      observerHeaders.value = Object.keys(headers).length ? JSON.stringify(headers, null, 2) : "";
+      const normalized = {};
+      Object.entries(headers).forEach(([key, value]) => {
+        if (typeof key === "string" && key.trim() && typeof value === "string") {
+          normalized[key] = value;
+        }
+      });
+      observerHeaders.value = Object.keys(normalized).length ? JSON.stringify(normalized, null, 2) : "";
     }
-    if (observerMaxChars) observerMaxChars.value = asInputString(configuredOrEffective(config, effective, "observer_max_chars"));
-    if (packObservationLimit) packObservationLimit.value = asInputString(configuredOrEffective(config, effective, "pack_observation_limit"));
-    if (packSessionLimit) packSessionLimit.value = asInputString(configuredOrEffective(config, effective, "pack_session_limit"));
+    if (observerMaxChars) observerMaxChars.value = asInputString(effectiveOrConfigured(config, effective, "observer_max_chars"));
+    if (packObservationLimit) packObservationLimit.value = asInputString(effectiveOrConfigured(config, effective, "pack_observation_limit"));
+    if (packSessionLimit) packSessionLimit.value = asInputString(effectiveOrConfigured(config, effective, "pack_session_limit"));
     if (rawEventsSweeperIntervalS) {
-      rawEventsSweeperIntervalS.value = asInputString(configuredOrEffective(config, effective, "raw_events_sweeper_interval_s"));
+      rawEventsSweeperIntervalS.value = asInputString(effectiveOrConfigured(config, effective, "raw_events_sweeper_interval_s"));
     }
-    if (syncEnabled) syncEnabled.checked = Boolean(configuredOrEffective(config, effective, "sync_enabled"));
-    if (syncHost) syncHost.value = asInputString(configuredOrEffective(config, effective, "sync_host"));
-    if (syncPort) syncPort.value = asInputString(configuredOrEffective(config, effective, "sync_port"));
-    if (syncInterval) syncInterval.value = asInputString(configuredOrEffective(config, effective, "sync_interval_s"));
-    if (syncMdns) syncMdns.checked = Boolean(configuredOrEffective(config, effective, "sync_mdns"));
+    if (syncEnabled) syncEnabled.checked = Boolean(effectiveOrConfigured(config, effective, "sync_enabled"));
+    if (syncHost) syncHost.value = asInputString(effectiveOrConfigured(config, effective, "sync_host"));
+    if (syncPort) syncPort.value = asInputString(effectiveOrConfigured(config, effective, "sync_port"));
+    if (syncInterval) syncInterval.value = asInputString(effectiveOrConfigured(config, effective, "sync_interval_s"));
+    if (syncMdns) syncMdns.checked = Boolean(effectiveOrConfigured(config, effective, "sync_mdns"));
     if (settingsPath) settingsPath.textContent = state.configPath ? `Config path: ${state.configPath}` : "Config path: n/a";
-    if (observerModelHint) {
-      const source = hasOwn(config, "observer_model") ? "Configured" : "Default";
-      const effectiveModel = observerModelValue || "n/a";
-      observerModelHint.textContent = `${source} model: ${effectiveModel}`;
-    }
+    if (observerModelHint) renderObserverModelHint();
     if (observerMaxCharsHint) {
       const def = defaults?.observer_max_chars || "";
       observerMaxCharsHint.textContent = def ? `Default: ${def}` : "";
@@ -1663,6 +1701,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     }
     updateAuthSourceVisibility();
     setSettingsTab(settingsActiveTab);
+    try {
+      settingsBaseline = collectSettingsPayload();
+    } catch {
+      settingsBaseline = {};
+    }
     setDirty(false);
     const settingsStatus = $("settingsStatus");
     if (settingsStatus) settingsStatus.textContent = "Ready";
@@ -1691,6 +1734,43 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       headers[key.trim()] = value;
     }
     return headers;
+  }
+  function collectSettingsPayload() {
+    const authCommandInput = document.getElementById("observerAuthCommand")?.value || "";
+    const observerHeadersInput = document.getElementById("observerHeaders")?.value || "";
+    const authCacheTtlInput = ($input("observerAuthCacheTtlS")?.value || "").trim();
+    const sweeperIntervalInput = ($input("rawEventsSweeperIntervalS")?.value || "").trim();
+    const authCommand = parseCommandArgv(authCommandInput);
+    const headers = parseObserverHeaders(observerHeadersInput);
+    const authCacheTtl = authCacheTtlInput === "" ? "" : Number(authCacheTtlInput);
+    const sweeperIntervalNum = Number(sweeperIntervalInput);
+    const sweeperInterval = sweeperIntervalInput === "" ? "" : sweeperIntervalNum;
+    if (authCacheTtlInput !== "" && !Number.isFinite(authCacheTtl)) {
+      throw new Error("observer auth cache ttl must be a number");
+    }
+    if (sweeperIntervalInput !== "" && (!Number.isFinite(sweeperIntervalNum) || sweeperIntervalNum <= 0)) {
+      throw new Error("raw-event sweeper interval must be a positive number");
+    }
+    return {
+      observer_provider: normalizeTextValue($select("observerProvider")?.value || ""),
+      observer_model: normalizeTextValue($input("observerModel")?.value || ""),
+      observer_runtime: normalizeTextValue($select("observerRuntime")?.value || "api_http") || "api_http",
+      observer_auth_source: normalizeTextValue($select("observerAuthSource")?.value || "auto") || "auto",
+      observer_auth_file: normalizeTextValue($input("observerAuthFile")?.value || ""),
+      observer_auth_command: authCommand,
+      observer_auth_timeout_ms: Number($input("observerAuthTimeoutMs")?.value || 0) || "",
+      observer_auth_cache_ttl_s: authCacheTtl,
+      observer_headers: headers,
+      observer_max_chars: Number($input("observerMaxChars")?.value || 0) || "",
+      pack_observation_limit: Number($input("packObservationLimit")?.value || 0) || "",
+      pack_session_limit: Number($input("packSessionLimit")?.value || 0) || "",
+      raw_events_sweeper_interval_s: sweeperInterval,
+      sync_enabled: $input("syncEnabled")?.checked || false,
+      sync_host: normalizeTextValue($input("syncHost")?.value || ""),
+      sync_port: Number($input("syncPort")?.value || 0) || "",
+      sync_interval_s: Number($input("syncInterval")?.value || 0) || "",
+      sync_mdns: $input("syncMdns")?.checked || false
+    };
   }
   function updateAuthSourceVisibility() {
     const source = $select("observerAuthSource")?.value || "auto";
@@ -1752,41 +1832,20 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     saveBtn.disabled = true;
     status.textContent = "Saving...";
     try {
-      const authCommandInput = document.getElementById("observerAuthCommand")?.value || "";
-      const observerHeadersInput = document.getElementById("observerHeaders")?.value || "";
-      const authCacheTtlInput = ($input("observerAuthCacheTtlS")?.value || "").trim();
-      const sweeperIntervalInput = ($input("rawEventsSweeperIntervalS")?.value || "").trim();
-      const authCommand = parseCommandArgv(authCommandInput);
-      const headers = parseObserverHeaders(observerHeadersInput);
-      const authCacheTtl = authCacheTtlInput === "" ? "" : Number(authCacheTtlInput);
-      const sweeperIntervalNum = Number(sweeperIntervalInput);
-      const sweeperInterval = sweeperIntervalInput === "" ? "" : sweeperIntervalNum;
-      if (authCacheTtlInput !== "" && !Number.isFinite(authCacheTtl)) {
-        throw new Error("observer auth cache ttl must be a number");
-      }
-      if (sweeperIntervalInput !== "" && (!Number.isFinite(sweeperIntervalNum) || sweeperIntervalNum <= 0)) {
-        throw new Error("raw-event sweeper interval must be a positive number");
-      }
-      await saveConfig({
-        observer_provider: $select("observerProvider")?.value || "",
-        observer_model: $input("observerModel")?.value || "",
-        observer_runtime: $select("observerRuntime")?.value || "api_http",
-        observer_auth_source: $select("observerAuthSource")?.value || "auto",
-        observer_auth_file: $input("observerAuthFile")?.value || "",
-        observer_auth_command: authCommand,
-        observer_auth_timeout_ms: Number($input("observerAuthTimeoutMs")?.value || 0) || "",
-        observer_auth_cache_ttl_s: authCacheTtl,
-        observer_headers: headers,
-        observer_max_chars: Number($input("observerMaxChars")?.value || 0) || "",
-        pack_observation_limit: Number($input("packObservationLimit")?.value || 0) || "",
-        pack_session_limit: Number($input("packSessionLimit")?.value || 0) || "",
-        raw_events_sweeper_interval_s: sweeperInterval,
-        sync_enabled: $input("syncEnabled")?.checked || false,
-        sync_host: $input("syncHost")?.value || "",
-        sync_port: Number($input("syncPort")?.value || 0) || "",
-        sync_interval_s: Number($input("syncInterval")?.value || 0) || "",
-        sync_mdns: $input("syncMdns")?.checked || false
+      const current = collectSettingsPayload();
+      const changed = {};
+      Object.entries(current).forEach(([key, value]) => {
+        if (!isEqualValue(value, settingsBaseline[key])) {
+          changed[key] = value;
+        }
       });
+      if (Object.keys(changed).length === 0) {
+        status.textContent = "No changes";
+        setDirty(false);
+        closeSettings(startPolling2, refreshCallback);
+        return;
+      }
+      await saveConfig(changed);
       status.textContent = "Saved";
       setDirty(false);
       closeSettings(startPolling2, refreshCallback);
@@ -1849,6 +1908,9 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       input.addEventListener("change", () => setDirty(true));
     });
     $select("observerAuthSource")?.addEventListener("change", () => updateAuthSourceVisibility());
+    $select("observerProvider")?.addEventListener("change", () => renderObserverModelHint());
+    $select("observerRuntime")?.addEventListener("change", () => renderObserverModelHint());
+    $input("observerModel")?.addEventListener("input", () => renderObserverModelHint());
     document.querySelectorAll("[data-settings-tab]").forEach((node) => {
       node.addEventListener("click", () => {
         const tab = node.dataset.settingsTab || "observer";

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1548,6 +1548,65 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     }
     return { model: DEFAULT_OPENAI_MODEL, source: "Default (openai)" };
   }
+  function configuredValueForKey(config, key) {
+    switch (key) {
+      case "observer_provider":
+      case "observer_model":
+      case "observer_auth_file":
+      case "sync_host":
+        return normalizeTextValue(asInputString(config?.[key]));
+      case "observer_runtime":
+        return normalizeTextValue(asInputString(config?.observer_runtime));
+      case "observer_auth_source":
+        return normalizeTextValue(asInputString(config?.observer_auth_source));
+      case "observer_auth_command": {
+        const value = config?.observer_auth_command;
+        if (!Array.isArray(value)) return [];
+        return value.filter((item) => typeof item === "string");
+      }
+      case "observer_headers": {
+        const value = config?.observer_headers;
+        if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+        const headers = {};
+        Object.entries(value).forEach(([header, headerValue]) => {
+          if (typeof header === "string" && header.trim() && typeof headerValue === "string") {
+            headers[header.trim()] = headerValue;
+          }
+        });
+        return headers;
+      }
+      case "observer_auth_timeout_ms":
+      case "observer_max_chars":
+      case "pack_observation_limit":
+      case "pack_session_limit":
+      case "raw_events_sweeper_interval_s":
+      case "sync_port":
+      case "sync_interval_s": {
+        if (!hasOwn(config, key)) return "";
+        const parsed = Number(config[key]);
+        return Number.isFinite(parsed) && parsed !== 0 ? parsed : "";
+      }
+      case "observer_auth_cache_ttl_s": {
+        if (!hasOwn(config, key)) return "";
+        const parsed = Number(config[key]);
+        return Number.isFinite(parsed) ? parsed : "";
+      }
+      case "sync_enabled":
+      case "sync_mdns":
+        return Boolean(config?.[key]);
+      default:
+        return hasOwn(config, key) ? config[key] : "";
+    }
+  }
+  function mergeOverrideBaseline(baseline, config, envOverrides) {
+    const next = { ...baseline };
+    Object.keys(envOverrides).forEach((key) => {
+      if (hasOwn(next, key)) {
+        next[key] = configuredValueForKey(config, key);
+      }
+    });
+    return next;
+  }
   function renderObserverModelHint() {
     const hint = $("observerModelHint");
     if (!hint) return;
@@ -1555,7 +1614,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const provider = ($select("observerProvider")?.value || "").trim();
     const configuredModel = normalizeTextValue($input("observerModel")?.value || "");
     const inferred = inferObserverModel(runtime, provider, configuredModel);
-    const source = hasOwn(settingsEnvOverrides, "observer_model") ? "Env override" : inferred.source;
+    const overrideActive = ["observer_model", "observer_provider", "observer_runtime"].some(
+      (key) => hasOwn(settingsEnvOverrides, key)
+    );
+    const source = overrideActive ? "Env override" : inferred.source;
     hint.textContent = `${source}: ${inferred.model}`;
   }
   function setProviderOptions(selectEl, providers, currentValue) {
@@ -1702,7 +1764,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     updateAuthSourceVisibility();
     setSettingsTab(settingsActiveTab);
     try {
-      settingsBaseline = collectSettingsPayload();
+      const baseline = collectSettingsPayload();
+      settingsBaseline = mergeOverrideBaseline(baseline, config, envOverrides);
     } catch {
       settingsBaseline = {};
     }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -13,7 +13,9 @@
 
 ## Settings modal
 - Open via the Settings button in the header.
-- Writes observer runtime/auth settings (`observer_runtime`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, `observer_headers`) plus `observer_provider`, `observer_model`, `observer_max_chars`, `pack_observation_limit`, and `pack_session_limit`.
+- Shows effective values (configured or default) to avoid blank/ambiguous fields.
+- Persists only changed settings on save (unchanged effective defaults are not rewritten to config).
+- Observer/runtime settings include `observer_runtime`, `observer_provider`, `observer_model`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, and `observer_headers`.
 - Sync settings can also be updated here (`sync_enabled`, `sync_host`, `sync_port`, `sync_interval_s`, `sync_mdns`).
 - Environment variables still override file values.
 - Config file supports JSON and JSONC (`~/.config/codemem/config.json` or `~/.config/codemem/config.jsonc`).

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -7,14 +7,19 @@ import * as api from '../lib/api';
 let settingsOpen = false;
 let previouslyFocused: HTMLElement | null = null;
 let settingsActiveTab = 'observer';
+let settingsBaseline: Record<string, unknown> = {};
+let settingsEnvOverrides: Record<string, unknown> = {};
+
+const DEFAULT_OPENAI_MODEL = 'gpt-5.1-codex-mini';
+const DEFAULT_ANTHROPIC_MODEL = 'claude-4.5-haiku';
 
 function hasOwn(obj: unknown, key: string): boolean {
   return typeof obj === 'object' && obj !== null && Object.prototype.hasOwnProperty.call(obj, key);
 }
 
-function configuredOrEffective(config: any, effective: any, key: string): any {
-  if (hasOwn(config, key)) return config[key];
+function effectiveOrConfigured(config: any, effective: any, key: string): any {
   if (hasOwn(effective, key)) return effective[key];
+  if (hasOwn(config, key)) return config[key];
   return undefined;
 }
 
@@ -26,6 +31,41 @@ function asInputString(value: unknown): string {
 function toProviderList(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+}
+
+function isEqualValue(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function normalizeTextValue(value: string): string {
+  const trimmed = value.trim();
+  return trimmed === '' ? '' : trimmed;
+}
+
+function inferObserverModel(runtime: string, provider: string, configuredModel: string): { model: string; source: string } {
+  if (configuredModel) return { model: configuredModel, source: 'Configured' };
+  if (runtime === 'claude_sidecar') {
+    return { model: DEFAULT_ANTHROPIC_MODEL, source: 'Default (claude_sidecar)' };
+  }
+  if (provider === 'anthropic') {
+    return { model: DEFAULT_ANTHROPIC_MODEL, source: 'Default (anthropic)' };
+  }
+  if (provider && provider !== 'openai') {
+    return { model: 'provider default', source: 'Default (provider)' };
+  }
+  return { model: DEFAULT_OPENAI_MODEL, source: 'Default (openai)' };
+}
+
+function renderObserverModelHint() {
+  const hint = $('observerModelHint');
+  if (!hint) return;
+  const runtime = ($select('observerRuntime')?.value || 'api_http').trim();
+  const provider = ($select('observerProvider')?.value || '').trim();
+  const configuredModel = normalizeTextValue($input('observerModel')?.value || '');
+  const inferred = inferObserverModel(runtime, provider, configuredModel);
+  const source = hasOwn(settingsEnvOverrides, 'observer_model') ? 'Env override' : inferred.source;
+  hint.textContent = `${source}: ${inferred.model}`;
 }
 
 function setProviderOptions(
@@ -106,6 +146,7 @@ export function renderConfigModal(payload: any) {
   const envOverrides = payload.env_overrides && typeof payload.env_overrides === 'object'
     ? payload.env_overrides
     : {};
+  settingsEnvOverrides = envOverrides;
   const providers = toProviderList(payload.providers);
   state.configDefaults = defaults;
   state.configPath = payload.path || '';
@@ -133,49 +174,51 @@ export function renderConfigModal(payload: any) {
   const observerMaxCharsHint = $('observerMaxCharsHint');
   const settingsEffective = $('settingsEffective');
 
-  const observerProviderValue = asInputString(configuredOrEffective(config, effective, 'observer_provider'));
+  const observerProviderValue = asInputString(effectiveOrConfigured(config, effective, 'observer_provider'));
   setProviderOptions(observerProvider, providers, observerProviderValue);
 
-  const observerModelValue = asInputString(configuredOrEffective(config, effective, 'observer_model'));
+  const observerModelValue = asInputString(effectiveOrConfigured(config, effective, 'observer_model'));
   if (observerModel) observerModel.value = observerModelValue;
-  if (observerRuntime) observerRuntime.value = asInputString(configuredOrEffective(config, effective, 'observer_runtime')) || 'api_http';
-  if (observerAuthSource) observerAuthSource.value = asInputString(configuredOrEffective(config, effective, 'observer_auth_source')) || 'auto';
-  if (observerAuthFile) observerAuthFile.value = asInputString(configuredOrEffective(config, effective, 'observer_auth_file'));
+  if (observerRuntime) observerRuntime.value = asInputString(effectiveOrConfigured(config, effective, 'observer_runtime')) || 'api_http';
+  if (observerAuthSource) observerAuthSource.value = asInputString(effectiveOrConfigured(config, effective, 'observer_auth_source')) || 'auto';
+  if (observerAuthFile) observerAuthFile.value = asInputString(effectiveOrConfigured(config, effective, 'observer_auth_file'));
   if (observerAuthCommand) {
-    const argv = configuredOrEffective(config, effective, 'observer_auth_command');
+    const argv = effectiveOrConfigured(config, effective, 'observer_auth_command');
     const command = Array.isArray(argv) ? argv : [];
     const commandStrings = command.filter((item) => typeof item === 'string');
     observerAuthCommand.value = commandStrings.length ? JSON.stringify(commandStrings, null, 2) : '';
   }
   if (observerAuthTimeoutMs) {
-    observerAuthTimeoutMs.value = asInputString(configuredOrEffective(config, effective, 'observer_auth_timeout_ms'));
+    observerAuthTimeoutMs.value = asInputString(effectiveOrConfigured(config, effective, 'observer_auth_timeout_ms'));
   }
   if (observerAuthCacheTtlS) {
-    observerAuthCacheTtlS.value = asInputString(configuredOrEffective(config, effective, 'observer_auth_cache_ttl_s'));
+    observerAuthCacheTtlS.value = asInputString(effectiveOrConfigured(config, effective, 'observer_auth_cache_ttl_s'));
   }
   if (observerHeaders) {
-    const headerValue = configuredOrEffective(config, effective, 'observer_headers');
+    const headerValue = effectiveOrConfigured(config, effective, 'observer_headers');
     const headers = headerValue && typeof headerValue === 'object' ? headerValue : {};
-    observerHeaders.value = Object.keys(headers).length ? JSON.stringify(headers, null, 2) : '';
+    const normalized: Record<string, string> = {};
+    Object.entries(headers as Record<string, unknown>).forEach(([key, value]) => {
+      if (typeof key === 'string' && key.trim() && typeof value === 'string') {
+        normalized[key] = value;
+      }
+    });
+    observerHeaders.value = Object.keys(normalized).length ? JSON.stringify(normalized, null, 2) : '';
   }
-  if (observerMaxChars) observerMaxChars.value = asInputString(configuredOrEffective(config, effective, 'observer_max_chars'));
-  if (packObservationLimit) packObservationLimit.value = asInputString(configuredOrEffective(config, effective, 'pack_observation_limit'));
-  if (packSessionLimit) packSessionLimit.value = asInputString(configuredOrEffective(config, effective, 'pack_session_limit'));
+  if (observerMaxChars) observerMaxChars.value = asInputString(effectiveOrConfigured(config, effective, 'observer_max_chars'));
+  if (packObservationLimit) packObservationLimit.value = asInputString(effectiveOrConfigured(config, effective, 'pack_observation_limit'));
+  if (packSessionLimit) packSessionLimit.value = asInputString(effectiveOrConfigured(config, effective, 'pack_session_limit'));
   if (rawEventsSweeperIntervalS) {
-    rawEventsSweeperIntervalS.value = asInputString(configuredOrEffective(config, effective, 'raw_events_sweeper_interval_s'));
+    rawEventsSweeperIntervalS.value = asInputString(effectiveOrConfigured(config, effective, 'raw_events_sweeper_interval_s'));
   }
-  if (syncEnabled) syncEnabled.checked = Boolean(configuredOrEffective(config, effective, 'sync_enabled'));
-  if (syncHost) syncHost.value = asInputString(configuredOrEffective(config, effective, 'sync_host'));
-  if (syncPort) syncPort.value = asInputString(configuredOrEffective(config, effective, 'sync_port'));
-  if (syncInterval) syncInterval.value = asInputString(configuredOrEffective(config, effective, 'sync_interval_s'));
-  if (syncMdns) syncMdns.checked = Boolean(configuredOrEffective(config, effective, 'sync_mdns'));
+  if (syncEnabled) syncEnabled.checked = Boolean(effectiveOrConfigured(config, effective, 'sync_enabled'));
+  if (syncHost) syncHost.value = asInputString(effectiveOrConfigured(config, effective, 'sync_host'));
+  if (syncPort) syncPort.value = asInputString(effectiveOrConfigured(config, effective, 'sync_port'));
+  if (syncInterval) syncInterval.value = asInputString(effectiveOrConfigured(config, effective, 'sync_interval_s'));
+  if (syncMdns) syncMdns.checked = Boolean(effectiveOrConfigured(config, effective, 'sync_mdns'));
 
   if (settingsPath) settingsPath.textContent = state.configPath ? `Config path: ${state.configPath}` : 'Config path: n/a';
-  if (observerModelHint) {
-    const source = hasOwn(config, 'observer_model') ? 'Configured' : 'Default';
-    const effectiveModel = observerModelValue || 'n/a';
-    observerModelHint.textContent = `${source} model: ${effectiveModel}`;
-  }
+  if (observerModelHint) renderObserverModelHint();
   if (observerMaxCharsHint) {
     const def = defaults?.observer_max_chars || '';
     observerMaxCharsHint.textContent = def ? `Default: ${def}` : '';
@@ -192,6 +235,11 @@ export function renderConfigModal(payload: any) {
 
   updateAuthSourceVisibility();
   setSettingsTab(settingsActiveTab);
+  try {
+    settingsBaseline = collectSettingsPayload();
+  } catch {
+    settingsBaseline = {};
+  }
 
   setDirty(false);
   const settingsStatus = $('settingsStatus');
@@ -223,6 +271,46 @@ function parseObserverHeaders(raw: string): Record<string, string> {
     headers[key.trim()] = value;
   }
   return headers;
+}
+
+function collectSettingsPayload(): Record<string, unknown> {
+  const authCommandInput = (document.getElementById('observerAuthCommand') as HTMLTextAreaElement | null)?.value || '';
+  const observerHeadersInput = (document.getElementById('observerHeaders') as HTMLTextAreaElement | null)?.value || '';
+  const authCacheTtlInput = ($input('observerAuthCacheTtlS')?.value || '').trim();
+  const sweeperIntervalInput = ($input('rawEventsSweeperIntervalS')?.value || '').trim();
+  const authCommand = parseCommandArgv(authCommandInput);
+  const headers = parseObserverHeaders(observerHeadersInput);
+  const authCacheTtl = authCacheTtlInput === '' ? '' : Number(authCacheTtlInput);
+  const sweeperIntervalNum = Number(sweeperIntervalInput);
+  const sweeperInterval = sweeperIntervalInput === '' ? '' : sweeperIntervalNum;
+
+  if (authCacheTtlInput !== '' && !Number.isFinite(authCacheTtl)) {
+    throw new Error('observer auth cache ttl must be a number');
+  }
+  if (sweeperIntervalInput !== '' && (!Number.isFinite(sweeperIntervalNum) || sweeperIntervalNum <= 0)) {
+    throw new Error('raw-event sweeper interval must be a positive number');
+  }
+
+  return {
+    observer_provider: normalizeTextValue($select('observerProvider')?.value || ''),
+    observer_model: normalizeTextValue($input('observerModel')?.value || ''),
+    observer_runtime: normalizeTextValue($select('observerRuntime')?.value || 'api_http') || 'api_http',
+    observer_auth_source: normalizeTextValue($select('observerAuthSource')?.value || 'auto') || 'auto',
+    observer_auth_file: normalizeTextValue($input('observerAuthFile')?.value || ''),
+    observer_auth_command: authCommand,
+    observer_auth_timeout_ms: Number($input('observerAuthTimeoutMs')?.value || 0) || '',
+    observer_auth_cache_ttl_s: authCacheTtl,
+    observer_headers: headers,
+    observer_max_chars: Number($input('observerMaxChars')?.value || 0) || '',
+    pack_observation_limit: Number($input('packObservationLimit')?.value || 0) || '',
+    pack_session_limit: Number($input('packSessionLimit')?.value || 0) || '',
+    raw_events_sweeper_interval_s: sweeperInterval,
+    sync_enabled: $input('syncEnabled')?.checked || false,
+    sync_host: normalizeTextValue($input('syncHost')?.value || ''),
+    sync_port: Number($input('syncPort')?.value || 0) || '',
+    sync_interval_s: Number($input('syncInterval')?.value || 0) || '',
+    sync_mdns: $input('syncMdns')?.checked || false,
+  };
 }
 
 function updateAuthSourceVisibility() {
@@ -294,42 +382,21 @@ export async function saveSettings(startPolling: () => void, refreshCallback: ()
   status.textContent = 'Saving...';
 
   try {
-    const authCommandInput = (document.getElementById('observerAuthCommand') as HTMLTextAreaElement | null)?.value || '';
-    const observerHeadersInput = (document.getElementById('observerHeaders') as HTMLTextAreaElement | null)?.value || '';
-    const authCacheTtlInput = ($input('observerAuthCacheTtlS')?.value || '').trim();
-    const sweeperIntervalInput = ($input('rawEventsSweeperIntervalS')?.value || '').trim();
-    const authCommand = parseCommandArgv(authCommandInput);
-    const headers = parseObserverHeaders(observerHeadersInput);
-    const authCacheTtl = authCacheTtlInput === '' ? '' : Number(authCacheTtlInput);
-    const sweeperIntervalNum = Number(sweeperIntervalInput);
-    const sweeperInterval = sweeperIntervalInput === '' ? '' : sweeperIntervalNum;
-    if (authCacheTtlInput !== '' && !Number.isFinite(authCacheTtl)) {
-      throw new Error('observer auth cache ttl must be a number');
-    }
-    if (sweeperIntervalInput !== '' && (!Number.isFinite(sweeperIntervalNum) || sweeperIntervalNum <= 0)) {
-      throw new Error('raw-event sweeper interval must be a positive number');
+    const current = collectSettingsPayload();
+    const changed: Record<string, unknown> = {};
+    Object.entries(current).forEach(([key, value]) => {
+      if (!isEqualValue(value, settingsBaseline[key])) {
+        changed[key] = value;
+      }
+    });
+    if (Object.keys(changed).length === 0) {
+      status.textContent = 'No changes';
+      setDirty(false);
+      closeSettings(startPolling, refreshCallback);
+      return;
     }
 
-    await api.saveConfig({
-      observer_provider: $select('observerProvider')?.value || '',
-      observer_model: $input('observerModel')?.value || '',
-      observer_runtime: $select('observerRuntime')?.value || 'api_http',
-      observer_auth_source: $select('observerAuthSource')?.value || 'auto',
-      observer_auth_file: $input('observerAuthFile')?.value || '',
-      observer_auth_command: authCommand,
-      observer_auth_timeout_ms: Number($input('observerAuthTimeoutMs')?.value || 0) || '',
-      observer_auth_cache_ttl_s: authCacheTtl,
-      observer_headers: headers,
-      observer_max_chars: Number($input('observerMaxChars')?.value || 0) || '',
-      pack_observation_limit: Number($input('packObservationLimit')?.value || 0) || '',
-      pack_session_limit: Number($input('packSessionLimit')?.value || 0) || '',
-      raw_events_sweeper_interval_s: sweeperInterval,
-      sync_enabled: $input('syncEnabled')?.checked || false,
-      sync_host: $input('syncHost')?.value || '',
-      sync_port: Number($input('syncPort')?.value || 0) || '',
-      sync_interval_s: Number($input('syncInterval')?.value || 0) || '',
-      sync_mdns: $input('syncMdns')?.checked || false,
-    });
+    await api.saveConfig(changed);
     status.textContent = 'Saved';
     setDirty(false);
     closeSettings(startPolling, refreshCallback);
@@ -396,6 +463,9 @@ export function initSettings(stopPolling: () => void, startPolling: () => void, 
   });
 
   $select('observerAuthSource')?.addEventListener('change', () => updateAuthSourceVisibility());
+  $select('observerProvider')?.addEventListener('change', () => renderObserverModelHint());
+  $select('observerRuntime')?.addEventListener('change', () => renderObserverModelHint());
+  $input('observerModel')?.addEventListener('input', () => renderObserverModelHint());
   document.querySelectorAll('[data-settings-tab]').forEach((node) => {
     node.addEventListener('click', () => {
       const tab = (node as HTMLElement).dataset.settingsTab || 'observer';

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -57,6 +57,71 @@ function inferObserverModel(runtime: string, provider: string, configuredModel: 
   return { model: DEFAULT_OPENAI_MODEL, source: 'Default (openai)' };
 }
 
+function configuredValueForKey(config: any, key: string): unknown {
+  switch (key) {
+    case 'observer_provider':
+    case 'observer_model':
+    case 'observer_auth_file':
+    case 'sync_host':
+      return normalizeTextValue(asInputString(config?.[key]));
+    case 'observer_runtime':
+      return normalizeTextValue(asInputString(config?.observer_runtime));
+    case 'observer_auth_source':
+      return normalizeTextValue(asInputString(config?.observer_auth_source));
+    case 'observer_auth_command': {
+      const value = config?.observer_auth_command;
+      if (!Array.isArray(value)) return [];
+      return value.filter((item) => typeof item === 'string');
+    }
+    case 'observer_headers': {
+      const value = config?.observer_headers;
+      if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+      const headers: Record<string, string> = {};
+      Object.entries(value as Record<string, unknown>).forEach(([header, headerValue]) => {
+        if (typeof header === 'string' && header.trim() && typeof headerValue === 'string') {
+          headers[header.trim()] = headerValue;
+        }
+      });
+      return headers;
+    }
+    case 'observer_auth_timeout_ms':
+    case 'observer_max_chars':
+    case 'pack_observation_limit':
+    case 'pack_session_limit':
+    case 'raw_events_sweeper_interval_s':
+    case 'sync_port':
+    case 'sync_interval_s': {
+      if (!hasOwn(config, key)) return '';
+      const parsed = Number(config[key]);
+      return Number.isFinite(parsed) && parsed !== 0 ? parsed : '';
+    }
+    case 'observer_auth_cache_ttl_s': {
+      if (!hasOwn(config, key)) return '';
+      const parsed = Number(config[key]);
+      return Number.isFinite(parsed) ? parsed : '';
+    }
+    case 'sync_enabled':
+    case 'sync_mdns':
+      return Boolean(config?.[key]);
+    default:
+      return hasOwn(config, key) ? config[key] : '';
+  }
+}
+
+function mergeOverrideBaseline(
+  baseline: Record<string, unknown>,
+  config: any,
+  envOverrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const next = { ...baseline };
+  Object.keys(envOverrides).forEach((key) => {
+    if (hasOwn(next, key)) {
+      next[key] = configuredValueForKey(config, key);
+    }
+  });
+  return next;
+}
+
 function renderObserverModelHint() {
   const hint = $('observerModelHint');
   if (!hint) return;
@@ -64,7 +129,10 @@ function renderObserverModelHint() {
   const provider = ($select('observerProvider')?.value || '').trim();
   const configuredModel = normalizeTextValue($input('observerModel')?.value || '');
   const inferred = inferObserverModel(runtime, provider, configuredModel);
-  const source = hasOwn(settingsEnvOverrides, 'observer_model') ? 'Env override' : inferred.source;
+  const overrideActive = ['observer_model', 'observer_provider', 'observer_runtime'].some(
+    (key) => hasOwn(settingsEnvOverrides, key),
+  );
+  const source = overrideActive ? 'Env override' : inferred.source;
   hint.textContent = `${source}: ${inferred.model}`;
 }
 
@@ -236,7 +304,8 @@ export function renderConfigModal(payload: any) {
   updateAuthSourceVisibility();
   setSettingsTab(settingsActiveTab);
   try {
-    settingsBaseline = collectSettingsPayload();
+    const baseline = collectSettingsPayload();
+    settingsBaseline = mergeOverrideBaseline(baseline, config, envOverrides);
   } catch {
     settingsBaseline = {};
   }


### PR DESCRIPTION
## Description
- Render Settings fields from effective values (including env overrides) so the UI is not blank or misleading when defaults/overrides are active.
- Persist only changed fields on save, preventing open/save churn that writes untouched defaults back to config.
- Improve observer model clarity with contextual hinting by runtime/provider and document the effective-value behavior.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `bun run check` (in `viewer_ui/`)
- `bun run build` (in `viewer_ui/`)
- `uv run pytest`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
