### PR TITLE
fix(observer): support configurable Claude command for sidecar runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Observer runtime/auth in `0.16`:
 - Runtime options: `api_http` and `claude_sidecar`.
 - `api_http` defaults to `gpt-5.1-codex-mini` (OpenAI path) unless you set `observer_model`.
 - `claude_sidecar` defaults to `claude-4.5-haiku`; if the selected `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's CLI default model.
+- `claude_sidecar` command is configurable with `claude_command` (`CODEMEM_CLAUDE_COMMAND`) as a JSON argv array.
+  - Config file example: `"claude_command": ["wrapper", "claude", "--"]`
+  - Env var example: `CODEMEM_CLAUDE_COMMAND='["wrapper","claude","--"]'`
 - Auth sources: `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` must be a JSON string array (argv), not a space-separated string.
   - Config file example: `"observer_auth_command": ["iap-auth", "--audience", "example"]`

--- a/codemem/config.py
+++ b/codemem/config.py
@@ -11,6 +11,7 @@ DEFAULT_CONFIG_PATH = Path("~/.config/codemem/config.json").expanduser()
 DEFAULT_CONFIG_PATH_JSONC = Path("~/.config/codemem/config.jsonc").expanduser()
 
 CONFIG_ENV_OVERRIDES = {
+    "claude_command": "CODEMEM_CLAUDE_COMMAND",
     "observer_provider": "CODEMEM_OBSERVER_PROVIDER",
     "observer_model": "CODEMEM_OBSERVER_MODEL",
     "observer_runtime": "CODEMEM_OBSERVER_RUNTIME",
@@ -185,6 +186,7 @@ class OpencodeMemConfig:
     use_opencode_run: bool = False
     opencode_model: str = "openai/gpt-5.1-codex-mini"
     opencode_agent: str | None = None
+    claude_command: list[str] = field(default_factory=lambda: ["claude"])
     observer_provider: str | None = None
     observer_model: str | None = None
     observer_api_key: str | None = None
@@ -336,6 +338,21 @@ def _coerce_command(value: object, *, key: str) -> list[str] | None:
     return None
 
 
+def _coerce_claude_command(value: object) -> list[str] | None:
+    parsed = _coerce_command(value, key="claude_command")
+    if parsed is None:
+        return None
+    normalized = [item.strip() for item in parsed]
+    if any(not item for item in normalized):
+        warnings.warn(
+            f"Invalid command list for claude_command: {value!r}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
+    return normalized
+
+
 def _coerce_str_map(value: object, *, key: str) -> dict[str, str] | None:
     if value is None:
         return None
@@ -428,6 +445,11 @@ def _apply_dict(cfg: OpencodeMemConfig, data: dict[str, Any]) -> OpencodeMemConf
             if parsed is not None:
                 setattr(cfg, key, parsed)
             continue
+        if key == "claude_command":
+            parsed = _coerce_claude_command(value)
+            if parsed is not None:
+                setattr(cfg, key, parsed)
+            continue
         if key == "observer_headers":
             parsed = _coerce_str_map(value, key=key)
             if parsed is not None:
@@ -448,6 +470,9 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
     cfg.use_opencode_run = _parse_bool(os.getenv("CODEMEM_USE_OPENCODE_RUN"), cfg.use_opencode_run)
     cfg.opencode_model = os.getenv("CODEMEM_OPENCODE_MODEL", cfg.opencode_model)
     cfg.opencode_agent = os.getenv("CODEMEM_OPENCODE_AGENT", cfg.opencode_agent)
+    parsed_claude_command = _coerce_claude_command(os.getenv("CODEMEM_CLAUDE_COMMAND"))
+    if parsed_claude_command is not None:
+        cfg.claude_command = parsed_claude_command
     cfg.observer_provider = os.getenv("CODEMEM_OBSERVER_PROVIDER", cfg.observer_provider)
     cfg.observer_model = os.getenv("CODEMEM_OBSERVER_MODEL", cfg.observer_model)
     cfg.observer_api_key = os.getenv("CODEMEM_OBSERVER_API_KEY", cfg.observer_api_key)

--- a/codemem/observer.py
+++ b/codemem/observer.py
@@ -157,6 +157,13 @@ class ObserverClient:
         model = cfg.observer_model or ""
         self._configured_model = model.strip() or None
         self._sidecar_model = self._configured_model or DEFAULT_ANTHROPIC_MODEL
+        self._claude_command = []
+        for part in cfg.claude_command or []:
+            token = str(part).strip()
+            if token:
+                self._claude_command.append(token)
+        if not self._claude_command:
+            self._claude_command = ["claude"]
         custom_providers = _list_custom_providers()
 
         if provider and provider not in {"openai", "anthropic"} | custom_providers:
@@ -337,7 +344,7 @@ class ObserverClient:
 
     def _claude_sidecar_cmd(self, prompt: str, *, use_model: bool) -> list[str]:
         cmd = [
-            "claude",
+            *self._claude_command,
             "-p",
             "--output-format",
             "json",
@@ -372,8 +379,10 @@ class ObserverClient:
                 env=env,
             )
         except FileNotFoundError:
-            logger.warning("observer claude_sidecar unavailable: claude command not found")
-            return None, "claude command not found"
+            logger.warning(
+                "observer claude_sidecar unavailable: configured claude command not found"
+            )
+            return None, "configured claude command not found"
         except subprocess.TimeoutExpired:
             logger.warning(
                 "observer claude_sidecar timed out", extra={"timeout_s": _CLAUDE_SIDECAR_TIMEOUT_S}

--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -58,6 +58,20 @@ def _as_command_argv(value: Any) -> list[str] | None:
     return list(value)
 
 
+def _as_executable_argv(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return None
+        token = item.strip()
+        if not token:
+            return None
+        normalized.append(token)
+    return normalized
+
+
 def handle_get(
     handler: _ViewerHandler,
     *,
@@ -112,6 +126,7 @@ def handle_post(
         return True
 
     allowed_keys = {
+        "claude_command",
         "observer_provider",
         "observer_model",
         "observer_runtime",
@@ -159,6 +174,16 @@ def handle_post(
                 )
                 return True
             config_data[key] = provider
+            continue
+        if key == "claude_command":
+            argv = _as_executable_argv(value)
+            if argv is None:
+                handler._send_json({"error": "claude_command must be string array"}, status=400)
+                return True
+            if argv:
+                config_data[key] = argv
+            else:
+                config_data.pop(key, None)
             continue
         if key == "observer_model":
             if not isinstance(value, str):

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1550,6 +1550,17 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   }
   function configuredValueForKey(config, key) {
     switch (key) {
+      case "claude_command": {
+        const value = config?.claude_command;
+        if (!Array.isArray(value)) return [];
+        const normalized = [];
+        value.forEach((item) => {
+          if (typeof item !== "string") return;
+          const token = item.trim();
+          if (token) normalized.push(token);
+        });
+        return normalized;
+      }
       case "observer_provider":
       case "observer_model":
       case "observer_auth_file":
@@ -1686,6 +1697,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     state.configDefaults = defaults;
     state.configPath = payload.path || "";
     const observerProvider = $select("observerProvider");
+    const claudeCommand = document.getElementById("claudeCommand");
     const observerModel = $input("observerModel");
     const observerRuntime = $select("observerRuntime");
     const observerAuthSource = $select("observerAuthSource");
@@ -1709,6 +1721,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const settingsEffective = $("settingsEffective");
     const observerProviderValue = asInputString(effectiveOrConfigured(config, effective, "observer_provider"));
     setProviderOptions(observerProvider, providers, observerProviderValue);
+    if (claudeCommand) {
+      const value = effectiveOrConfigured(config, effective, "claude_command");
+      const argv = Array.isArray(value) ? value.filter((item) => typeof item === "string") : [];
+      claudeCommand.value = argv.length ? JSON.stringify(argv, null, 2) : "";
+    }
     const observerModelValue = asInputString(effectiveOrConfigured(config, effective, "observer_model"));
     if (observerModel) observerModel.value = observerModelValue;
     if (observerRuntime) observerRuntime.value = asInputString(effectiveOrConfigured(config, effective, "observer_runtime")) || "api_http";
@@ -1773,14 +1790,21 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const settingsStatus = $("settingsStatus");
     if (settingsStatus) settingsStatus.textContent = "Ready";
   }
-  function parseCommandArgv(raw) {
+  function parseCommandArgv(raw, options) {
     const text = raw.trim();
     if (!text) return [];
     const parsed = JSON.parse(text);
     if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
-      throw new Error("observer auth command must be a JSON string array");
+      throw new Error(`${options.label} must be a JSON string array`);
     }
-    return parsed;
+    if (!options.normalize && !options.requireNonEmpty) {
+      return parsed;
+    }
+    const values = options.normalize ? parsed.map((item) => item.trim()) : parsed;
+    if (options.requireNonEmpty && values.some((item) => item.trim() === "")) {
+      throw new Error(`${options.label} cannot contain empty command tokens`);
+    }
+    return values;
   }
   function parseObserverHeaders(raw) {
     const text = raw.trim();
@@ -1799,11 +1823,17 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     return headers;
   }
   function collectSettingsPayload() {
+    const claudeCommandInput = document.getElementById("claudeCommand")?.value || "";
     const authCommandInput = document.getElementById("observerAuthCommand")?.value || "";
     const observerHeadersInput = document.getElementById("observerHeaders")?.value || "";
     const authCacheTtlInput = ($input("observerAuthCacheTtlS")?.value || "").trim();
     const sweeperIntervalInput = ($input("rawEventsSweeperIntervalS")?.value || "").trim();
-    const authCommand = parseCommandArgv(authCommandInput);
+    const claudeCommand = parseCommandArgv(claudeCommandInput, {
+      label: "claude command",
+      normalize: true,
+      requireNonEmpty: true
+    });
+    const authCommand = parseCommandArgv(authCommandInput, { label: "observer auth command" });
     const headers = parseObserverHeaders(observerHeadersInput);
     const authCacheTtl = authCacheTtlInput === "" ? "" : Number(authCacheTtlInput);
     const sweeperIntervalNum = Number(sweeperIntervalInput);
@@ -1815,6 +1845,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       throw new Error("raw-event sweeper interval must be a positive number");
     }
     return {
+      claude_command: claudeCommand,
       observer_provider: normalizeTextValue($select("observerProvider")?.value || ""),
       observer_model: normalizeTextValue($input("observerModel")?.value || ""),
       observer_runtime: normalizeTextValue($select("observerRuntime")?.value || "api_http") || "api_http",
@@ -1945,6 +1976,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       if (e.key === "Escape" && settingsOpen) closeSettings(startPolling2, refreshCallback);
     });
     const inputs = [
+      "claudeCommand",
       "observerProvider",
       "observerModel",
       "observerRuntime",

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1087,6 +1087,11 @@
                 <div class="small">Run observer calls through local Claude runtime auth.</div>
               </div>
               <div class="field">
+                <label for="claudeCommand">Claude command (JSON argv)</label>
+                <textarea id="claudeCommand" rows="2" placeholder='["claude"]'></textarea>
+                <div class="small">Used by `claude_sidecar` runtime. Example wrapper: `["wrapper", "claude", "--"]`.</div>
+              </div>
+              <div class="field">
                 <label for="observerMaxChars">Observer max chars</label>
                 <input id="observerMaxChars" type="number" min="1" />
                 <div class="small" id="observerMaxCharsHint"></div>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,6 +173,7 @@ The observer turns raw session transcripts into typed, structured memories. It's
 - The observer still uses one pipeline (extract -> prompt -> parse -> persist); runtime/auth choices are adapter inputs, not a separate path.
 - Supported runtime values are `api_http` and `claude_sidecar`.
 - `claude_sidecar` executes observer prompts through local Claude runtime auth and bypasses provider API-key client initialization.
+- `claude_sidecar` command launch is configurable with `claude_command` / `CODEMEM_CLAUDE_COMMAND` (JSON argv; default `["claude"]`).
 - Runtime defaults: `api_http` uses `gpt-5.1-codex-mini`; `claude_sidecar` uses `claude-4.5-haiku` unless explicitly overridden.
 - If a configured `observer_model` is not available in Claude CLI, codemem retries once with Claude's default model.
 - Supported auth sources are `auto`, `env`, `file`, `command`, `none`.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -89,6 +89,7 @@ Observer execution in `0.16` supports both API and Claude runtime paths.
 
 - Runtime values: `api_http`, `claude_sidecar`.
 - `claude_sidecar` runs observer calls via local Claude runtime auth (no `ANTHROPIC_API_KEY` required).
+- `claude_sidecar` uses `claude_command` (or `CODEMEM_CLAUDE_COMMAND`) as argv prefix for launching Claude CLI. Default: `["claude"]`.
 - Default models:
   - `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
   - `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.
@@ -225,6 +226,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_OBSERVER_PROVIDER` | Force `openai`, `anthropic`, or a custom provider key (optional). |
 | `CODEMEM_OBSERVER_MODEL` | Override observer model (default `gpt-5.1-codex-mini` or `claude-4.5-haiku`). |
 | `CODEMEM_OBSERVER_API_KEY` | API key for observer model (optional). |
+| `CODEMEM_CLAUDE_COMMAND` | JSON argv array for Claude CLI invocation used by `claude_sidecar` (default `["claude"]`). |
 | `CODEMEM_OBSERVER_RUNTIME` | Observer runtime mode (`api_http` or `claude_sidecar`). |
 | `CODEMEM_OBSERVER_AUTH_SOURCE` | Observer auth source (`auto`, `env`, `file`, `command`, `none`). |
 | `CODEMEM_OBSERVER_AUTH_FILE` | Path to token file used when auth source is `file`. |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -15,7 +15,7 @@
 - Open via the Settings button in the header.
 - Shows effective values (configured or default) to avoid blank/ambiguous fields.
 - Persists only changed settings on save (unchanged effective defaults are not rewritten to config).
-- Observer/runtime settings include `observer_runtime`, `observer_provider`, `observer_model`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, and `observer_headers`.
+- Observer/runtime settings include `claude_command`, `observer_runtime`, `observer_provider`, `observer_model`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, and `observer_headers`.
 - Sync settings can also be updated here (`sync_enabled`, `sync_host`, `sync_port`, `sync_interval_s`, `sync_mdns`).
 - Environment variables still override file values.
 - Config file supports JSON and JSONC (`~/.config/codemem/config.json` or `~/.config/codemem/config.jsonc`).
@@ -24,6 +24,8 @@
 
 - Runtime choices are `api_http` and `claude_sidecar`.
 - `claude_sidecar` runs observer calls through the local Claude runtime (subscription/session auth) and does not require `ANTHROPIC_API_KEY`.
+- `claude_command` controls how `claude_sidecar` invokes Claude CLI (default `["claude"]`).
+  - Wrapper example: `"claude_command": ["wrapper", "claude", "--"]`
 - Default model selection:
   - `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
   - `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -143,9 +143,11 @@ def test_load_config_warns_and_uses_defaults_on_invalid_json(tmp_path: Path) -> 
 def test_get_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CODEMEM_OBSERVER_PROVIDER", "anthropic")
     monkeypatch.setenv("CODEMEM_OBSERVER_MODEL", "claude-4.5-haiku")
+    monkeypatch.setenv("CODEMEM_CLAUDE_COMMAND", '["wrapper", "claude", "--"]')
     overrides = get_env_overrides()
     assert overrides["observer_provider"] == "anthropic"
     assert overrides["observer_model"] == "claude-4.5-haiku"
+    assert overrides["claude_command"] == '["wrapper", "claude", "--"]'
 
 
 def test_load_config_invalid_int_env_does_not_crash_and_warns(
@@ -382,3 +384,49 @@ def test_load_config_reads_raw_events_sweeper_interval_from_env(
     cfg = load_config(config_path)
 
     assert cfg.raw_events_sweeper_interval_s == 75
+
+
+def test_load_config_parses_claude_command_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_CLAUDE_COMMAND", '["wrapper", "claude", "--"]')
+
+    cfg = load_config(config_path)
+
+    assert cfg.claude_command == ["wrapper", "claude", "--"]
+
+
+def test_load_config_reads_claude_command_from_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"claude_command": ["wrapper", "claude", "--"]}\n')
+
+    cfg = load_config(config_path)
+
+    assert cfg.claude_command == ["wrapper", "claude", "--"]
+
+
+def test_load_config_rejects_invalid_claude_command_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_CLAUDE_COMMAND", "wrapper claude --")
+
+    with pytest.warns(RuntimeWarning, match="claude_command"):
+        cfg = load_config(config_path)
+
+    assert cfg.claude_command == ["claude"]
+
+
+def test_load_config_rejects_claude_command_with_empty_tokens(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"claude_command": ["wrapper", " ", "--"]}\n')
+
+    with pytest.warns(RuntimeWarning, match="claude_command"):
+        cfg = load_config(config_path)
+
+    assert cfg.claude_command == ["claude"]

--- a/tests/test_observer_auth.py
+++ b/tests/test_observer_auth.py
@@ -451,6 +451,70 @@ def test_observer_runtime_claude_sidecar_uses_sidecar_call() -> None:
     assert DEFAULT_ANTHROPIC_MODEL in called_cmd
 
 
+def test_observer_runtime_claude_sidecar_uses_custom_claude_command() -> None:
+    cfg = OpencodeMemConfig(
+        observer_runtime="claude_sidecar",
+        claude_command=["wrapper", "claude", "--"],
+    )
+    run_mock = Mock(
+        return_value=subprocess.CompletedProcess(
+            args=["wrapper", "claude", "--"],
+            returncode=0,
+            stdout=_claude_sidecar_payload(result="hello from wrapped sidecar"),
+            stderr="",
+        )
+    )
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch("codemem.observer.subprocess.run", run_mock),
+    ):
+        from codemem.observer import ObserverClient
+
+        client = ObserverClient()
+        output = client._call("hello")
+
+    assert output == "hello from wrapped sidecar"
+    called_cmd = run_mock.call_args.args[0]
+    assert called_cmd[:7] == [
+        "wrapper",
+        "claude",
+        "--",
+        "-p",
+        "--output-format",
+        "json",
+        "--permission-mode",
+    ]
+
+
+def test_observer_runtime_claude_sidecar_empty_claude_command_falls_back_to_default() -> None:
+    cfg = OpencodeMemConfig(
+        observer_runtime="claude_sidecar",
+        claude_command=[],
+    )
+    run_mock = Mock(
+        return_value=subprocess.CompletedProcess(
+            args=["claude"],
+            returncode=0,
+            stdout=_claude_sidecar_payload(result="hello from fallback command"),
+            stderr="",
+        )
+    )
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch("codemem.observer.subprocess.run", run_mock),
+    ):
+        from codemem.observer import ObserverClient
+
+        client = ObserverClient()
+        output = client._call("hello")
+
+    assert output == "hello from fallback command"
+    called_cmd = run_mock.call_args.args[0]
+    assert called_cmd[0] == "claude"
+
+
 def test_observer_runtime_claude_sidecar_retries_without_model_on_model_error() -> None:
     cfg = OpencodeMemConfig(
         observer_runtime="claude_sidecar",

--- a/tests/test_viewer_routes_config.py
+++ b/tests/test_viewer_routes_config.py
@@ -33,6 +33,7 @@ def test_config_route_accepts_observer_auth_fields(
 
     handler = DummyHandler(
         {
+            "claude_command": ["wrapper", "claude", "--"],
             "observer_provider": "openai",
             "observer_runtime": "api_http",
             "observer_auth_source": "command",
@@ -53,6 +54,7 @@ def test_config_route_accepts_observer_auth_fields(
     assert handled is True
     assert handler.status == 200
     saved = read_config_file(config_path)
+    assert saved["claude_command"] == ["wrapper", "claude", "--"]
     assert saved["observer_auth_source"] == "command"
     assert saved["observer_auth_command"] == ["iap-auth"]
     assert saved["observer_auth_timeout_ms"] == 2000
@@ -111,6 +113,67 @@ def test_config_route_rejects_invalid_observer_auth_command(
     assert handled is True
     assert handler.status == 400
     assert handler.response == {"error": "observer_auth_command must be string array"}
+
+
+def test_config_route_rejects_invalid_claude_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler({"claude_command": "wrapper claude"})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "claude_command must be string array"}
+
+
+def test_config_route_rejects_claude_command_with_empty_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler({"claude_command": ["wrapper", " ", "--"]})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "claude_command must be string array"}
+
+
+def test_config_route_clears_claude_command_with_empty_array(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"claude_command": ["wrapper", "claude", "--"]}\n')
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler({"claude_command": []})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    saved = read_config_file(config_path)
+    assert "claude_command" not in saved
 
 
 def test_config_route_rejects_invalid_observer_headers(

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -59,6 +59,17 @@ function inferObserverModel(runtime: string, provider: string, configuredModel: 
 
 function configuredValueForKey(config: any, key: string): unknown {
   switch (key) {
+    case 'claude_command': {
+      const value = config?.claude_command;
+      if (!Array.isArray(value)) return [];
+      const normalized: string[] = [];
+      value.forEach((item) => {
+        if (typeof item !== 'string') return;
+        const token = item.trim();
+        if (token) normalized.push(token);
+      });
+      return normalized;
+    }
     case 'observer_provider':
     case 'observer_model':
     case 'observer_auth_file':
@@ -220,6 +231,7 @@ export function renderConfigModal(payload: any) {
   state.configPath = payload.path || '';
 
   const observerProvider = $select('observerProvider');
+  const claudeCommand = document.getElementById('claudeCommand') as HTMLTextAreaElement | null;
   const observerModel = $input('observerModel');
   const observerRuntime = $select('observerRuntime');
   const observerAuthSource = $select('observerAuthSource');
@@ -244,6 +256,11 @@ export function renderConfigModal(payload: any) {
 
   const observerProviderValue = asInputString(effectiveOrConfigured(config, effective, 'observer_provider'));
   setProviderOptions(observerProvider, providers, observerProviderValue);
+  if (claudeCommand) {
+    const value = effectiveOrConfigured(config, effective, 'claude_command');
+    const argv = Array.isArray(value) ? value.filter((item) => typeof item === 'string') : [];
+    claudeCommand.value = argv.length ? JSON.stringify(argv, null, 2) : '';
+  }
 
   const observerModelValue = asInputString(effectiveOrConfigured(config, effective, 'observer_model'));
   if (observerModel) observerModel.value = observerModelValue;
@@ -315,14 +332,21 @@ export function renderConfigModal(payload: any) {
   if (settingsStatus) settingsStatus.textContent = 'Ready';
 }
 
-function parseCommandArgv(raw: string): string[] {
+function parseCommandArgv(raw: string, options: { label: string; normalize?: boolean; requireNonEmpty?: boolean }): string[] {
   const text = raw.trim();
   if (!text) return [];
   const parsed = JSON.parse(text);
   if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== 'string')) {
-    throw new Error('observer auth command must be a JSON string array');
+    throw new Error(`${options.label} must be a JSON string array`);
   }
-  return parsed;
+  if (!options.normalize && !options.requireNonEmpty) {
+    return parsed;
+  }
+  const values = options.normalize ? parsed.map((item) => item.trim()) : parsed;
+  if (options.requireNonEmpty && values.some((item) => item.trim() === '')) {
+    throw new Error(`${options.label} cannot contain empty command tokens`);
+  }
+  return values;
 }
 
 function parseObserverHeaders(raw: string): Record<string, string> {
@@ -343,11 +367,17 @@ function parseObserverHeaders(raw: string): Record<string, string> {
 }
 
 function collectSettingsPayload(): Record<string, unknown> {
+  const claudeCommandInput = (document.getElementById('claudeCommand') as HTMLTextAreaElement | null)?.value || '';
   const authCommandInput = (document.getElementById('observerAuthCommand') as HTMLTextAreaElement | null)?.value || '';
   const observerHeadersInput = (document.getElementById('observerHeaders') as HTMLTextAreaElement | null)?.value || '';
   const authCacheTtlInput = ($input('observerAuthCacheTtlS')?.value || '').trim();
   const sweeperIntervalInput = ($input('rawEventsSweeperIntervalS')?.value || '').trim();
-  const authCommand = parseCommandArgv(authCommandInput);
+  const claudeCommand = parseCommandArgv(claudeCommandInput, {
+    label: 'claude command',
+    normalize: true,
+    requireNonEmpty: true,
+  });
+  const authCommand = parseCommandArgv(authCommandInput, { label: 'observer auth command' });
   const headers = parseObserverHeaders(observerHeadersInput);
   const authCacheTtl = authCacheTtlInput === '' ? '' : Number(authCacheTtlInput);
   const sweeperIntervalNum = Number(sweeperIntervalInput);
@@ -361,6 +391,7 @@ function collectSettingsPayload(): Record<string, unknown> {
   }
 
   return {
+    claude_command: claudeCommand,
     observer_provider: normalizeTextValue($select('observerProvider')?.value || ''),
     observer_model: normalizeTextValue($input('observerModel')?.value || ''),
     observer_runtime: normalizeTextValue($select('observerRuntime')?.value || 'api_http') || 'api_http',
@@ -505,6 +536,7 @@ export function initSettings(stopPolling: () => void, startPolling: () => void, 
 
   // Mark dirty on any input change
   const inputs = [
+    'claudeCommand',
     'observerProvider',
     'observerModel',
     'observerRuntime',


### PR DESCRIPTION
## Description
- Add configurable Claude CLI argv for `claude_sidecar` runtime via `claude_command` and `CODEMEM_CLAUDE_COMMAND` (JSON array only).
- Wire the setting through config loading, `/api/config` validation, settings UI, and observer sidecar command construction so wrapper-based launches are supported.
- Harden validation to reject empty/whitespace command tokens and keep default behavior as `["claude"]` when unset.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `bun run check && bun run build` (in `viewer_ui/`)
- `uv run ruff check codemem/config.py codemem/observer.py codemem/viewer_routes/config.py tests/test_config.py tests/test_observer_auth.py tests/test_viewer_routes_config.py`
- `uv run pytest tests/test_config.py tests/test_observer_auth.py tests/test_viewer_routes_config.py`
- `uv run pytest`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
