### PR TITLE
fix(claude-plugin): use uvx MCP launcher for marketplace installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Persistent memory for [OpenCode](https://opencode.ai) and [Claude Code](https://
 
 **Prerequisites:** Python 3.11+ and [uv](https://docs.astral.sh/uv/)
 
+If `uv` is not installed yet:
+
+```bash
+# Homebrew
+brew install uv
+
+# mise
+mise use -g uv@latest
+```
+
 1. Install the CLI and plugin:
 
 ```bash
@@ -51,6 +61,18 @@ In [Claude Code](https://claude.ai/code), add the codemem marketplace source and
 /plugin marketplace add kunickiaj/codemem
 /plugin install codemem
 ```
+
+The Claude plugin starts MCP with:
+
+- `uvx codemem mcp`
+
+We still recommend installing/upgrading the CLI for local hook ingestion and manual `codemem` commands:
+
+```bash
+uv tool install --upgrade codemem
+```
+
+Claude MCP launch uses `uvx`; first startup may be slower because `uvx` can fetch/install tooling on demand.
 
 Claude hook events are ingested through `codemem ingest-claude-hook` and share the same raw-event queue pipeline used by OpenCode.
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -24,6 +24,28 @@ In Claude Code, add the marketplace and install the plugin:
 /plugin install codemem
 ```
 
+Prerequisite: `uvx` must be available (provided by `uv`). If needed:
+
+```bash
+# Homebrew
+brew install uv
+
+# mise
+mise use -g uv@latest
+```
+
+The plugin starts MCP with:
+
+- `uvx codemem mcp`
+
+We still recommend installing the CLI explicitly for local hook ingestion and manual `codemem` usage:
+
+```bash
+uv tool install --upgrade codemem
+```
+
+Claude MCP launch uses `uvx`; startup can be slower on first run because it may install dependencies on demand.
+
 You can update an existing marketplace install with:
 
 ```text

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -9,8 +9,9 @@
   "license": "MIT",
   "mcpServers": {
     "codemem": {
-      "command": "codemem",
+      "command": "uvx",
       "args": [
+        "codemem",
         "mcp"
       ]
     }

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -209,8 +209,9 @@ def test_claude_plugin_manifest_version_matches_package_version() -> None:
     assert plugin_manifest["description"].startswith("Persistent memory for Claude Code")
     assert "hooks" not in plugin_manifest
     mcp_servers = plugin_manifest["mcpServers"]
-    assert mcp_servers["codemem"]["command"] == "codemem"
-    assert mcp_servers["codemem"]["args"] == ["mcp"]
+    codemem_mcp = mcp_servers["codemem"]
+    assert codemem_mcp["command"] == "uvx"
+    assert codemem_mcp["args"] == ["codemem", "mcp"]
 
 
 def test_marketplace_manifest_points_to_codemem_plugin() -> None:


### PR DESCRIPTION
## Description
- Fix Claude marketplace bootstrap by making MCP launch use `uvx --from codemem codemem mcp` directly, so installs do not require a preinstalled `codemem` binary.
- Update README and plugin reference docs to clearly state that `uv`/`uvx` is required, including Homebrew and mise install examples.
- Update plugin manifest tests to lock expected MCP launcher behavior.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `uv run ruff check tests/test_claude_integration_cmds.py`
- `uv run pytest tests/test_claude_integration_cmds.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
