### PR TITLE
fix(plugin): pin backend launcher versions across OpenCode and Claude

### DIFF
--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -13,6 +13,8 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
+const PINNED_BACKEND_VERSION = "0.16.0";
+const DEFAULT_UVX_SOURCE = `codemem==${PINNED_BACKEND_VERSION}`;
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>
@@ -401,6 +403,19 @@ const detectRunner = ({ cwd, envRunner }) => {
   return "uvx";
 };
 
+const buildRunnerArgs = ({ runner, runnerFrom, runnerFromExplicit }) => {
+  if (runner === "uvx") {
+    if (runnerFromExplicit) {
+      return ["--from", runnerFrom, "codemem"];
+    }
+    return [runnerFrom || "codemem"];
+  }
+  if (runner === "uv") {
+    return ["run", "--directory", runnerFrom, "codemem"];
+  }
+  return [];
+};
+
 export const OpencodeMemPlugin = async ({
   project,
   client,
@@ -443,26 +458,15 @@ export const OpencodeMemPlugin = async ({
   // Determine runner mode:
   // - If CODEMEM_RUNNER is set, use that
   // - If we're in a directory with pyproject.toml containing codemem, use "uv" (dev mode)
-  // - Otherwise, use "uvx" with SSH git URL (installed mode)
+  // - Otherwise, use "uvx" with a package source pinned to plugin version
   const runner = detectRunner({
     cwd,
     envRunner: process.env.CODEMEM_RUNNER,
   });
-  const defaultRunnerFrom = runner === "uvx"
-    ? "git+https://github.com/kunickiaj/codemem.git"
-    : cwd;
+  const runnerFromExplicit = Boolean(String(process.env.CODEMEM_RUNNER_FROM || "").trim());
+  const defaultRunnerFrom = runner === "uvx" ? DEFAULT_UVX_SOURCE : cwd;
   const runnerFrom = process.env.CODEMEM_RUNNER_FROM || defaultRunnerFrom;
-  const buildRunnerArgs = () => {
-    if (runner === "uvx") {
-      return ["--from", runnerFrom, "codemem"];
-    }
-    if (runner === "uv") {
-      return ["run", "--directory", runnerFrom, "codemem"];
-    }
-    // For other runners (e.g., direct 'codemem' binary), no extra args
-    return [];
-  };
-  const runnerArgs = buildRunnerArgs();
+  const runnerArgs = buildRunnerArgs({ runner, runnerFrom, runnerFromExplicit });
   const viewerEnabled = envNotDisabled(process.env.CODEMEM_VIEWER || "1");
   const viewerAutoStart = envNotDisabled(
     process.env.CODEMEM_VIEWER_AUTO || "1"
@@ -1805,6 +1809,9 @@ export const OpencodeMemPlugin = async ({
 
 export default OpencodeMemPlugin;
 export const __testUtils = {
+  PINNED_BACKEND_VERSION,
+  DEFAULT_UVX_SOURCE,
+  buildRunnerArgs,
   appendWorkingSetFileArgs,
   extractApplyPatchPaths,
   mapOpencodeEventTypeToAdapterType,

--- a/.opencode/tests/plugin-adapter.test.js
+++ b/.opencode/tests/plugin-adapter.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import { __testUtils } from "../plugin/codemem.js";
 
@@ -216,5 +218,36 @@ describe("opencode adapter event mapping", () => {
 
     expect(events.length).toBe(2);
     expect(dropped).toBe("a");
+  });
+
+  test("buildRunnerArgs defaults uvx to pinned backend source", () => {
+    const args = __testUtils.buildRunnerArgs({
+      runner: "uvx",
+      runnerFrom: __testUtils.DEFAULT_UVX_SOURCE,
+      runnerFromExplicit: false,
+    });
+
+    expect(args).toEqual([`codemem==${__testUtils.PINNED_BACKEND_VERSION}`]);
+  });
+
+  test("buildRunnerArgs keeps explicit uvx source behavior", () => {
+    const args = __testUtils.buildRunnerArgs({
+      runner: "uvx",
+      runnerFrom: "git+https://github.com/kunickiaj/codemem.git",
+      runnerFromExplicit: true,
+    });
+
+    expect(args).toEqual([
+      "--from",
+      "git+https://github.com/kunickiaj/codemem.git",
+      "codemem",
+    ]);
+  });
+
+  test("pinned backend version matches package version", () => {
+    const packageJsonPath = resolve(import.meta.dir, "..", "..", "package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+
+    expect(__testUtils.PINNED_BACKEND_VERSION).toBe(packageJson.version);
   });
 });

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ uv tool install --upgrade codemem
 }
 ```
 
+By default, the OpenCode plugin resolves backend CLI calls from a `uvx` source pinned to the plugin version, so plugin and backend stay aligned unless you override `CODEMEM_RUNNER` / `CODEMEM_RUNNER_FROM`.
+
 3. Restart OpenCode, then verify:
 
 ```bash
@@ -64,7 +66,7 @@ In [Claude Code](https://claude.ai/code), add the codemem marketplace source and
 
 The Claude plugin starts MCP with:
 
-- `uvx codemem mcp`
+- `uvx codemem==<plugin-version> mcp`
 
 We still recommend installing/upgrading the CLI for local hook ingestion and manual `codemem` commands:
 
@@ -73,6 +75,8 @@ uv tool install --upgrade codemem
 ```
 
 Claude MCP launch uses `uvx`; first startup may be slower because `uvx` can fetch/install tooling on demand.
+
+Claude hook ingestion also auto-falls back to `uvx codemem==<plugin-version> ingest-claude-hook` when a local `codemem` binary is unavailable.
 
 Claude hook events are ingested through `codemem ingest-claude-hook` and share the same raw-event queue pipeline used by OpenCode.
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -36,7 +36,7 @@ mise use -g uv@latest
 
 The plugin starts MCP with:
 
-- `uvx codemem mcp`
+- `uvx codemem==<plugin-version> mcp`
 
 We still recommend installing the CLI explicitly for local hook ingestion and manual `codemem` usage:
 
@@ -45,6 +45,10 @@ uv tool install --upgrade codemem
 ```
 
 Claude MCP launch uses `uvx`; startup can be slower on first run because it may install dependencies on demand.
+
+Claude hook ingestion uses the same version-pinned fallback when local `codemem` is not available:
+
+- `uvx codemem==<plugin-version> ingest-claude-hook`
 
 You can update an existing marketplace install with:
 
@@ -226,7 +230,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | Env var | Description |
 | --- | --- |
 | `CODEMEM_RUNNER` | Override auto-detected runner: `uv` (dev mode), `uvx` (installed mode), or direct binary path. |
-| `CODEMEM_RUNNER_FROM` | Override source location: directory path for `uv run --directory`, or git URL/path for `uvx --from`. |
+| `CODEMEM_RUNNER_FROM` | Override source location: directory path for `uv run --directory`, or package/git/path source for `uvx --from` (default OpenCode source is pinned to plugin version). |
 | `CODEMEM_VIEWER` | Set to `0`, `false`, or `off` to disable the viewer entirely. |
 | `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Customize the viewer host/port printed on startup. |
 | `CODEMEM_VIEWER_AUTO` | Set to `0`/`false`/`off` to disable auto-start (default on). |
@@ -271,13 +275,13 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_RAW_EVENTS_RETENTION_MS` | If >0, delete raw events older than this many ms (default `0`, keep forever). |
 | `CODEMEM_CLAUDE_HOOK_FLUSH` | Set to `0` to disable immediate hook flush attempts (default on). |
 | `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP` | Set to `1` to flush on Claude `Stop` hooks in addition to `SessionEnd` (default off). |
-| `CODEMEM_HOOK_ALLOW_UVX` | Set to `1` to allow Claude hook script fallback to `uvx --from codemem` when `codemem` binary is not found (default off). |
 
 ## Compatibility guidance behavior
 
 When the plugin detects CLI/runtime version mismatch, it shows guidance based on runner mode:
 
 - `CODEMEM_RUNNER=uv`: pull latest in your repo, run `uv sync`, restart OpenCode
+- `CODEMEM_RUNNER=uvx` with package source: update `CODEMEM_RUNNER_FROM` (or update plugin package version), restart OpenCode
 - `CODEMEM_RUNNER=uvx` with git source: update `CODEMEM_RUNNER_FROM` to newer ref/source, restart OpenCode
 - `CODEMEM_RUNNER=uvx` with custom source: update `CODEMEM_RUNNER_FROM`, restart OpenCode
 - other/unknown runner: run `uv tool install --upgrade codemem`, restart OpenCode

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -11,7 +11,7 @@
     "codemem": {
       "command": "uvx",
       "args": [
-        "codemem",
+        "codemem==0.16.0",
         "mcp"
       ]
     }

--- a/plugins/claude/scripts/ingest-hook.sh
+++ b/plugins/claude/scripts/ingest-hook.sh
@@ -7,7 +7,20 @@ case "${LOG_PATH_ENV}" in
   "1"|"true"|"yes") LOG_PATH="$HOME/.codemem/plugin.log" ;;
   *) LOG_PATH="${LOG_PATH_ENV}" ;;
 esac
-ALLOW_UVX="${CODEMEM_HOOK_ALLOW_UVX:-0}"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [ -z "${PLUGIN_ROOT}" ]; then
+  SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+  PLUGIN_ROOT="$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)"
+fi
+PLUGIN_MANIFEST="${PLUGIN_ROOT}/.claude-plugin/plugin.json"
+UVX_PACKAGE_SPEC="codemem"
+
+if [ -f "${PLUGIN_MANIFEST}" ]; then
+  PLUGIN_VERSION="$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${PLUGIN_MANIFEST}" | sed -n '1p')"
+  if [ -n "${PLUGIN_VERSION}" ]; then
+    UVX_PACKAGE_SPEC="codemem==${PLUGIN_VERSION}"
+  fi
+fi
 
 log_line() {
   mkdir -p "$(dirname "${LOG_PATH}")" >/dev/null 2>&1 || true
@@ -28,19 +41,15 @@ if command -v codemem >/dev/null 2>&1; then
   exit 0
 fi
 
-if [ "${ALLOW_UVX}" = "1" ] && command -v uvx >/dev/null 2>&1; then
+if command -v uvx >/dev/null 2>&1; then
   (
-    if ! printf '%s' "${payload}" | uvx --from codemem codemem ingest-claude-hook >/dev/null 2>&1; then
+    if ! printf '%s' "${payload}" | uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook >/dev/null 2>&1; then
       log_line "codemem ingest-claude-hook failed via uvx"
     fi
   ) &
   exit 0
 fi
 
-if [ "${ALLOW_UVX}" = "1" ]; then
-  log_line "codemem ingest-claude-hook skipped: codemem and uvx not found"
-else
-  log_line "codemem ingest-claude-hook skipped: codemem binary not found"
-fi
+log_line "codemem ingest-claude-hook skipped: codemem and uvx not found"
 
 exit 0

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -211,7 +211,7 @@ def test_claude_plugin_manifest_version_matches_package_version() -> None:
     mcp_servers = plugin_manifest["mcpServers"]
     codemem_mcp = mcp_servers["codemem"]
     assert codemem_mcp["command"] == "uvx"
-    assert codemem_mcp["args"] == ["codemem", "mcp"]
+    assert codemem_mcp["args"] == [f"codemem=={__version__}", "mcp"]
 
 
 def test_marketplace_manifest_points_to_codemem_plugin() -> None:
@@ -231,6 +231,17 @@ def test_marketplace_manifest_points_to_codemem_plugin() -> None:
 
     resolved_plugin_path = repo_root / codemem_plugin["source"]
     assert resolved_plugin_path.exists()
+
+
+def test_claude_hook_script_has_version_pinned_uvx_fallback() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    hook_script_path = repo_root / "plugins" / "claude" / "scripts" / "ingest-hook.sh"
+    hook_script = hook_script_path.read_text()
+
+    assert 'UVX_PACKAGE_SPEC="codemem"' in hook_script
+    assert 'UVX_PACKAGE_SPEC="codemem==${PLUGIN_VERSION}"' in hook_script
+    assert 'uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook' in hook_script
+    assert "CODEMEM_HOOK_ALLOW_UVX" not in hook_script
 
 
 def test_adapter_stream_id_uses_source_and_session_only() -> None:


### PR DESCRIPTION
## Description
- Pin OpenCode plugin uvx backend source to the plugin version by default so frontend/backend stay aligned unless runner overrides are explicitly configured.
- Pin Claude marketplace MCP launcher to plugin version and make Claude hook ingestion auto-fallback to version-pinned uvx without manual opt-in.
- Update docs and tests to make uv/uvx requirements and version-pinned launcher behavior explicit.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `bun test ./.opencode/tests/*.test.js`
- `uv run pytest tests/test_claude_integration_cmds.py`
- `uv run pytest`
- `uv run ruff check tests/test_claude_integration_cmds.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
