### PR TITLE
fix(claude-hooks): default to enqueue-only and guard recursion

### DIFF
--- a/codemem/commands/claude_integration_cmds.py
+++ b/codemem/commands/claude_integration_cmds.py
@@ -106,7 +106,7 @@ def _queue_adapter_event(hook_payload: dict[str, Any], *, store: Any) -> tuple[s
 def _should_flush(hook_event_name: str) -> bool:
     if hook_event_name not in {"Stop", "SessionEnd"}:
         return False
-    if not _env_truthy("CODEMEM_CLAUDE_HOOK_FLUSH", True):
+    if not _env_truthy("CODEMEM_CLAUDE_HOOK_FLUSH", False):
         return False
     if hook_event_name == "SessionEnd":
         return True

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -273,7 +273,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_RAW_EVENTS_SWEEPER_LIMIT` | Max idle sessions to flush per sweeper tick (default `25`). |
 | `CODEMEM_RAW_EVENTS_STUCK_BATCH_MS` | Mark flush batches older than this many ms as error (default `300000`). |
 | `CODEMEM_RAW_EVENTS_RETENTION_MS` | If >0, delete raw events older than this many ms (default `0`, keep forever). |
-| `CODEMEM_CLAUDE_HOOK_FLUSH` | Set to `0` to disable immediate hook flush attempts (default on). |
+| `CODEMEM_CLAUDE_HOOK_FLUSH` | Set to `1` to enable immediate hook flush attempts for `SessionEnd` (default off; enqueue-only). |
 | `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP` | Set to `1` to flush on Claude `Stop` hooks in addition to `SessionEnd` (default off). |
 
 ## Compatibility guidance behavior

--- a/plugins/claude/scripts/ingest-hook.sh
+++ b/plugins/claude/scripts/ingest-hook.sh
@@ -32,21 +32,47 @@ if [ -z "${payload}" ]; then
   exit 0
 fi
 
-if command -v codemem >/dev/null 2>&1; then
-  (
-    if ! printf '%s' "${payload}" | codemem ingest-claude-hook >/dev/null 2>&1; then
-      log_line "codemem ingest-claude-hook failed via codemem binary"
+case "${CODEMEM_PLUGIN_IGNORE:-}" in
+  "1"|"true"|"yes"|"on")
+    exit 0
+    ;;
+esac
+
+LOCK_DIR="${CODEMEM_CLAUDE_HOOK_LOCK_DIR:-$HOME/.codemem/claude-hook-ingest.lock}"
+acquire_lock() {
+  mkdir -p "$(dirname "${LOCK_DIR}")" >/dev/null 2>&1 || true
+  attempts=100
+  while [ "${attempts}" -gt 0 ]; do
+    if mkdir "${LOCK_DIR}" >/dev/null 2>&1; then
+      return 0
     fi
-  ) &
+    attempts=$((attempts - 1))
+    sleep 0.05
+  done
+  return 1
+}
+
+release_lock() {
+  rmdir "${LOCK_DIR}" >/dev/null 2>&1 || true
+}
+
+if ! acquire_lock; then
+  log_line "codemem ingest-claude-hook skipped: lock busy"
+  exit 0
+fi
+trap 'release_lock' EXIT
+
+if command -v codemem >/dev/null 2>&1; then
+  if ! printf '%s' "${payload}" | CODEMEM_PLUGIN_IGNORE=1 codemem ingest-claude-hook >/dev/null 2>&1; then
+    log_line "codemem ingest-claude-hook failed via codemem binary"
+  fi
   exit 0
 fi
 
 if command -v uvx >/dev/null 2>&1; then
-  (
-    if ! printf '%s' "${payload}" | uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook >/dev/null 2>&1; then
-      log_line "codemem ingest-claude-hook failed via uvx"
-    fi
-  ) &
+  if ! printf '%s' "${payload}" | CODEMEM_PLUGIN_IGNORE=1 uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook >/dev/null 2>&1; then
+    log_line "codemem ingest-claude-hook failed via uvx"
+  fi
   exit 0
 fi
 

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -72,7 +72,7 @@ def test_ingest_claude_hook_cmd_processes_stop_hook_without_default_flush() -> N
     assert called["count"] == 1
 
 
-def test_ingest_claude_hook_cmd_flushes_session_end_by_default() -> None:
+def test_ingest_claude_hook_cmd_does_not_flush_session_end_by_default() -> None:
     payload = {
         "hook_event_name": "SessionEnd",
         "session_id": "sess-1",
@@ -101,6 +101,44 @@ def test_ingest_claude_hook_cmd_flushes_session_end_by_default() -> None:
 
     with (
         patch("sys.stdin", io.StringIO(json.dumps(payload))),
+        patch("codemem.commands.claude_integration_cmds.MemoryStore", _FakeStore),
+        patch("codemem.commands.claude_integration_cmds.flush_raw_events", _fake_flush),
+    ):
+        ingest_claude_hook_cmd()
+
+    assert called["count"] == 1
+
+
+def test_ingest_claude_hook_cmd_flushes_session_end_when_enabled() -> None:
+    payload = {
+        "hook_event_name": "SessionEnd",
+        "session_id": "sess-1",
+        "stop_reason": "end_turn",
+    }
+    called = {"count": 0}
+
+    class _FakeStore:
+        def __init__(self, _: object) -> None:
+            pass
+
+        def record_raw_event(self, **kwargs: object) -> bool:
+            called["count"] += 1
+            assert kwargs["event_type"] == "claude.hook"
+            return True
+
+        def update_raw_event_session_meta(self, **_: object) -> None:
+            return None
+
+        def close(self) -> None:
+            return None
+
+    def _fake_flush(*_: object, **__: object) -> dict[str, int]:
+        called["count"] += 1
+        return {"flushed": 1, "updated_state": 1}
+
+    with (
+        patch("sys.stdin", io.StringIO(json.dumps(payload))),
+        patch.dict("os.environ", {"CODEMEM_CLAUDE_HOOK_FLUSH": "1"}, clear=False),
         patch("codemem.commands.claude_integration_cmds.MemoryStore", _FakeStore),
         patch("codemem.commands.claude_integration_cmds.flush_raw_events", _fake_flush),
     ):
@@ -138,7 +176,14 @@ def test_ingest_claude_hook_cmd_flushes_stop_hook_when_assistant_text_missing() 
 
     with (
         patch("sys.stdin", io.StringIO(json.dumps(payload))),
-        patch.dict("os.environ", {"CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP": "1"}, clear=False),
+        patch.dict(
+            "os.environ",
+            {
+                "CODEMEM_CLAUDE_HOOK_FLUSH": "1",
+                "CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP": "1",
+            },
+            clear=False,
+        ),
         patch("codemem.commands.claude_integration_cmds.MemoryStore", _FakeStore),
         patch("codemem.commands.claude_integration_cmds.flush_raw_events", _fake_flush),
     ):
@@ -241,6 +286,12 @@ def test_claude_hook_script_has_version_pinned_uvx_fallback() -> None:
     assert 'UVX_PACKAGE_SPEC="codemem"' in hook_script
     assert 'UVX_PACKAGE_SPEC="codemem==${PLUGIN_VERSION}"' in hook_script
     assert 'uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook' in hook_script
+    assert "CODEMEM_PLUGIN_IGNORE=1 codemem ingest-claude-hook" in hook_script
+    assert 'CODEMEM_PLUGIN_IGNORE=1 uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook' in hook_script
+    assert (
+        'LOCK_DIR="${CODEMEM_CLAUDE_HOOK_LOCK_DIR:-$HOME/.codemem/claude-hook-ingest.lock}"'
+        in hook_script
+    )
     assert "CODEMEM_HOOK_ALLOW_UVX" not in hook_script
 
 


### PR DESCRIPTION
## Description
Stabilize Claude hook ingestion by switching the default to enqueue-only behavior and adding recursion/fan-out guards in the hook script.

This prevents hook-triggered flush storms by default, respects CODEMEM_PLUGIN_IGNORE for internal subprocesses, and adds lock-based fallback coordination while keeping the codemem/uvx fallback path version-pinned.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation run:
- uv run ruff check codemem tests
- uv run pytest tests/test_claude_integration_cmds.py

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced