### PR TITLE
refactor(claude-hooks): route hook ingest through local HTTP enqueue

### DIFF
--- a/codemem/claude_hooks.py
+++ b/codemem/claude_hooks.py
@@ -54,6 +54,13 @@ def _coerce_session_id(payload: dict[str, Any]) -> str | None:
     return value or None
 
 
+def _iso_to_wall_ms(value: str) -> int:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return int(parsed.timestamp() * 1000)
+
+
 def map_claude_hook_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
     hook_event = str(payload.get("hook_event_name") or "").strip()
     if hook_event not in MAPPABLE_CLAUDE_HOOK_EVENTS:
@@ -209,4 +216,39 @@ def build_ingest_payload_from_hook(hook_payload: dict[str, Any]) -> dict[str, An
             "stream_id": session_id,
             "opencode_session_id": session_id,
         },
+    }
+
+
+def build_raw_event_envelope_from_hook(hook_payload: dict[str, Any]) -> dict[str, Any] | None:
+    adapter_event = map_claude_hook_payload(hook_payload)
+    if adapter_event is None:
+        return None
+
+    session_id = str(adapter_event.get("session_id") or "").strip()
+    if not session_id:
+        return None
+
+    ts = str(adapter_event.get("ts") or "").strip()
+    if not ts:
+        return None
+
+    source = str(adapter_event.get("source") or "claude")
+    hook_event_name = str(hook_payload.get("hook_event_name") or "")
+    cwd = hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None
+    project = hook_payload.get("project") if isinstance(hook_payload.get("project"), str) else None
+
+    return {
+        "opencode_session_id": session_id,
+        "source": source,
+        "event_id": str(adapter_event.get("event_id") or ""),
+        "event_type": "claude.hook",
+        "payload": {
+            "type": "claude.hook",
+            "timestamp": ts,
+            "_adapter": adapter_event,
+        },
+        "ts_wall_ms": _iso_to_wall_ms(ts),
+        "cwd": cwd,
+        "project": project,
+        "started_at": ts if hook_event_name == "SessionStart" else None,
     }

--- a/codemem/commands/claude_integration_cmds.py
+++ b/codemem/commands/claude_integration_cmds.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import datetime as dt
 import json
 import os
 import sys
 from typing import Any
 
-from codemem.claude_hooks import MAPPABLE_CLAUDE_HOOK_EVENTS, map_claude_hook_payload
+from codemem.claude_hooks import MAPPABLE_CLAUDE_HOOK_EVENTS, build_raw_event_envelope_from_hook
 from codemem.db import DEFAULT_DB_PATH
 from codemem.ingest_sanitize import _strip_private
 from codemem.raw_event_flush import flush_raw_events
@@ -42,18 +41,6 @@ def _hook_stream_id(hook_payload: dict[str, Any]) -> str | None:
     )
 
 
-def _iso_to_wall_ms(ts: str | None) -> int:
-    if isinstance(ts, str) and ts.strip():
-        try:
-            parsed = dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            if parsed.tzinfo is None:
-                parsed = parsed.replace(tzinfo=dt.UTC)
-            return int(parsed.timestamp() * 1000)
-        except ValueError:
-            pass
-    return int(dt.datetime.now(dt.UTC).timestamp() * 1000)
-
-
 def _strip_private_obj(value: Any) -> Any:
     if isinstance(value, str):
         return _strip_private(value)
@@ -65,40 +52,30 @@ def _strip_private_obj(value: Any) -> Any:
 
 
 def _queue_adapter_event(hook_payload: dict[str, Any], *, store: Any) -> tuple[str, bool] | None:
-    adapter_event = map_claude_hook_payload(hook_payload)
-    if adapter_event is None:
+    envelope = build_raw_event_envelope_from_hook(hook_payload)
+    if envelope is None:
         return None
-    source = str(adapter_event.get("source") or "claude")
-    session_id = str(adapter_event.get("session_id") or "").strip()
-    if not session_id:
-        return None
-    stream_id = _adapter_stream_id(
-        session_id=session_id,
-    )
-    ts = str(adapter_event.get("ts") or "")
-    payload = {
-        "type": "claude.hook",
-        "timestamp": ts,
-        "_adapter": adapter_event,
-    }
-    payload = _strip_private_obj(payload)
+
+    stream_id = _adapter_stream_id(session_id=str(envelope["opencode_session_id"]))
+    source = str(envelope.get("source") or "claude")
+    payload = _strip_private_obj(envelope["payload"])
     inserted = store.record_raw_event(
         opencode_session_id=stream_id,
         source=source,
-        event_id=str(adapter_event.get("event_id") or ""),
+        event_id=str(envelope.get("event_id") or ""),
         event_type="claude.hook",
         payload=payload,
-        ts_wall_ms=_iso_to_wall_ms(ts),
+        ts_wall_ms=int(envelope.get("ts_wall_ms") or 0),
     )
     store.update_raw_event_session_meta(
         opencode_session_id=stream_id,
         source=source,
-        cwd=hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None,
-        project=hook_payload.get("project")
-        if isinstance(hook_payload.get("project"), str)
+        cwd=envelope.get("cwd") if isinstance(envelope.get("cwd"), str) else None,
+        project=envelope.get("project") if isinstance(envelope.get("project"), str) else None,
+        started_at=envelope.get("started_at")
+        if isinstance(envelope.get("started_at"), str)
         else None,
-        started_at=ts if str(hook_payload.get("hook_event_name") or "") == "SessionStart" else None,
-        last_seen_ts_wall_ms=_iso_to_wall_ms(ts),
+        last_seen_ts_wall_ms=int(envelope.get("ts_wall_ms") or 0),
     )
     return stream_id, inserted
 

--- a/codemem/viewer_routes/raw_events.py
+++ b/codemem/viewer_routes/raw_events.py
@@ -8,6 +8,8 @@ from collections.abc import Callable
 from typing import Any, Protocol
 from urllib.parse import parse_qs
 
+from codemem.claude_hooks import build_raw_event_envelope_from_hook
+
 
 def _safe_int_env(name: str, default: int) -> int:
     value = os.getenv(name)
@@ -45,10 +47,23 @@ class _Store(Protocol):
         self, *, opencode_session_id: str, events: list[dict[str, Any]]
     ) -> dict: ...
 
+    def record_raw_event(
+        self,
+        *,
+        opencode_session_id: str,
+        source: str,
+        event_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        ts_wall_ms: int | None = None,
+        ts_mono_ms: float | None = None,
+    ) -> bool: ...
+
     def update_raw_event_session_meta(
         self,
         *,
         opencode_session_id: str,
+        source: str = "opencode",
         cwd: str | None,
         project: str | None,
         started_at: str | None,
@@ -86,6 +101,95 @@ def handle_get(handler: Any, store: Any, path: str, query: str) -> bool:
     return True
 
 
+def _read_payload_object(handler: _ViewerHandler) -> dict[str, Any] | None:
+    try:
+        length = int(handler.headers.get("Content-Length", "0") or 0)
+    except (TypeError, ValueError):
+        handler._send_json({"error": "invalid content-length"}, status=400)
+        return None
+    if length < 0:
+        handler._send_json({"error": "invalid content-length"}, status=400)
+        return None
+    if length > MAX_RAW_EVENTS_BODY_BYTES:
+        handler._send_json(
+            {
+                "error": "payload too large",
+                "max_bytes": MAX_RAW_EVENTS_BODY_BYTES,
+            },
+            status=413,
+        )
+        return None
+    raw = handler.rfile.read(length).decode("utf-8") if length else ""
+    try:
+        payload = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        handler._send_json({"error": "invalid json"}, status=400)
+        return None
+    if not isinstance(payload, dict):
+        handler._send_json({"error": "payload must be an object"}, status=400)
+        return None
+    return payload
+
+
+def _handle_post_claude_hooks(
+    handler: _ViewerHandler,
+    *,
+    store_factory: Callable[[str], _Store],
+    default_db_path: str,
+    flusher: _RawEventFlusher,
+    strip_private_obj: Callable[[Any], Any],
+) -> bool:
+    payload = _read_payload_object(handler)
+    if payload is None:
+        return True
+
+    envelope = build_raw_event_envelope_from_hook(payload)
+    if envelope is None:
+        handler._send_json({"inserted": 0, "skipped": 1})
+        return True
+
+    try:
+        store: _Store = store_factory(os.environ.get("CODEMEM_DB") or default_db_path)
+    except Exception as exc:  # pragma: no cover
+        response: dict[str, Any] = {"error": "internal server error"}
+        if os.environ.get("CODEMEM_VIEWER_DEBUG") == "1":
+            response["detail"] = str(exc)
+        handler._send_json(response, status=500)
+        return True
+
+    try:
+        opencode_session_id = str(envelope["opencode_session_id"])
+        source = str(envelope.get("source") or "claude")
+        payload_obj = strip_private_obj(envelope["payload"])
+        inserted = store.record_raw_event(
+            opencode_session_id=opencode_session_id,
+            source=source,
+            event_id=str(envelope["event_id"]),
+            event_type="claude.hook",
+            payload=payload_obj,
+            ts_wall_ms=int(envelope["ts_wall_ms"]),
+        )
+        store.update_raw_event_session_meta(
+            opencode_session_id=opencode_session_id,
+            source=source,
+            cwd=envelope.get("cwd") if isinstance(envelope.get("cwd"), str) else None,
+            project=envelope.get("project") if isinstance(envelope.get("project"), str) else None,
+            started_at=envelope.get("started_at")
+            if isinstance(envelope.get("started_at"), str)
+            else None,
+            last_seen_ts_wall_ms=int(envelope["ts_wall_ms"]),
+        )
+        try:
+            flusher.note_activity(opencode_session_id, source=source)
+        except Exception as exc:  # pragma: no cover
+            logger.warning("raw event flusher note_activity failed", extra={"source": source})
+            logger.debug("raw event flusher error", exc_info=exc)
+        handler._send_json({"inserted": int(inserted), "skipped": 0})
+        return True
+    finally:
+        store.close()
+
+
 def handle_post(
     handler: _ViewerHandler,
     *,
@@ -95,34 +199,19 @@ def handle_post(
     flusher: _RawEventFlusher,
     strip_private_obj: Callable[[Any], Any],
 ) -> bool:
+    if path == "/api/claude-hooks":
+        return _handle_post_claude_hooks(
+            handler,
+            store_factory=store_factory,
+            default_db_path=default_db_path,
+            flusher=flusher,
+            strip_private_obj=strip_private_obj,
+        )
     if path != "/api/raw-events":
         return False
 
-    try:
-        length = int(handler.headers.get("Content-Length", "0") or 0)
-    except (TypeError, ValueError):
-        handler._send_json({"error": "invalid content-length"}, status=400)
-        return True
-    if length < 0:
-        handler._send_json({"error": "invalid content-length"}, status=400)
-        return True
-    if length > MAX_RAW_EVENTS_BODY_BYTES:
-        handler._send_json(
-            {
-                "error": "payload too large",
-                "max_bytes": MAX_RAW_EVENTS_BODY_BYTES,
-            },
-            status=413,
-        )
-        return True
-    raw = handler.rfile.read(length).decode("utf-8") if length else ""
-    try:
-        payload = json.loads(raw) if raw else {}
-    except json.JSONDecodeError:
-        handler._send_json({"error": "invalid json"}, status=400)
-        return True
-    if not isinstance(payload, dict):
-        handler._send_json({"error": "payload must be an object"}, status=400)
+    payload = _read_payload_object(handler)
+    if payload is None:
         return True
 
     try:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ codemem has five main pieces: **adapters** that capture shell/runtime activity, 
 
 | Component | What it does | Key files |
 |-----------|-------------|-----------|
-| Adapters | Capture OpenCode/Claude events and enqueue raw events for ingest | `.opencode/plugin/codemem.js`, `codemem/commands/claude_integration_cmds.py`, `codemem/claude_hooks.py` |
+| Adapters | Capture OpenCode/Claude events and enqueue raw events for ingest | `.opencode/plugin/codemem.js`, `plugins/claude/scripts/ingest-hook.sh`, `codemem/commands/claude_integration_cmds.py`, `codemem/claude_hooks.py` |
 | Ingest pipeline | Extracts tool events, builds transcripts, runs the observer | `codemem/plugin_ingest.py`, `codemem/ingest/` |
 | Observer | Produces typed observations and session summaries from transcripts | `codemem/observer_prompts.py`, `codemem/xml_parser.py` |
 | Store | SQLite persistence for sessions, memories, artifacts, embeddings | `codemem/store/`, `codemem/db.py` |
@@ -21,7 +21,8 @@ flowchart LR
     OC["OpenCode"] -->|tool/message events| OCA["OpenCode adapter"]
     OCA -->|POST /api/raw-events| VW["Viewer API"]
     OCA -->|fallback: enqueue-raw-event CLI| DB
-    CH["Claude hooks"] -->|ingest-claude-hook| DB
+    CH["Claude hooks"] -->|POST /api/claude-hooks| VW
+    CH -->|fallback: ingest-claude-hook CLI| DB
     VW --> DB["SQLite"]
     DB -->|flush batch claimed| IN["Ingest pipeline"]
     IN --> OB["Observer"]
@@ -33,7 +34,7 @@ flowchart LR
 
 1. Adapters capture tool/conversation lifecycle events and normalize them into raw events with optional `_adapter` envelopes.
 2. OpenCode streams raw events to the viewer ingest API (`POST /api/raw-events`) with preflight checks (`GET /api/raw-events/status`) and can fall back to CLI queue enqueue when stream writes fail.
-3. Claude hook ingestion writes to the same durable raw-event queue family through `codemem ingest-claude-hook`.
+3. Claude hook ingestion posts to `POST /api/claude-hooks` first and falls back to `codemem ingest-claude-hook` (or pinned `uvx`) when the local viewer API is unavailable.
 4. The viewer/store persists raw events and queues durable flush batches.
 5. Idle and sweeper workers claim batches and run them through ingest.
 6. Ingest builds a transcript from user prompts and assistant messages, then hands it to the observer.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -46,7 +46,7 @@ uv tool install --upgrade codemem
 
 Claude MCP launch uses `uvx`; startup can be slower on first run because it may install dependencies on demand.
 
-Claude hook ingestion uses the same version-pinned fallback when local `codemem` is not available:
+Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks` to the local codemem server) with a version-pinned CLI fallback when the server path is unavailable:
 
 - `uvx codemem==<plugin-version> ingest-claude-hook`
 
@@ -62,7 +62,7 @@ Ingest one Claude hook payload from stdin (this is what the installed hook scrip
 printf '%s\n' '{"hook_event_name":"SessionStart","session_id":"sess-1","cwd":"/tmp/demo"}' | codemem ingest-claude-hook
 ```
 
-By default, `SessionEnd` triggers an immediate queue flush attempt. Set `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` to also flush on `Stop`, or `CODEMEM_CLAUDE_HOOK_FLUSH=0` to disable hook-triggered flushes entirely.
+By default, Claude hooks are enqueue-only. Set `CODEMEM_CLAUDE_HOOK_FLUSH=1` to enable immediate flush on `SessionEnd`, and set `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` to also flush on `Stop`.
 
 The packaged template currently registers these hook events in `plugins/claude/hooks/hooks.json`:
 - `SessionStart`
@@ -237,6 +237,8 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_VIEWER_AUTO_STOP` | Set to `0`/`false`/`off` to keep the viewer running after OpenCode exits (default on). |
 | `CODEMEM_PLUGIN_LOG` | Path for the plugin log file (set `1`/`true`/`yes` to enable; defaults to off). |
 | `CODEMEM_PLUGIN_LOG_PATH` | Explicit log file path for Claude hook script logging (overrides `CODEMEM_PLUGIN_LOG` for that script). |
+| `CODEMEM_CLAUDE_HOOK_HTTP_CONNECT_TIMEOUT_S` | Claude hook HTTP enqueue connect timeout in seconds (default `1`). |
+| `CODEMEM_CLAUDE_HOOK_HTTP_MAX_TIME_S` | Claude hook HTTP enqueue total timeout in seconds (default `2`). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |
 | `CODEMEM_BACKEND_UPDATE_POLICY` | Backend update behavior on compatibility mismatch: `notify` (default), `auto`, or `off`. |

--- a/plugins/claude/scripts/ingest-hook.sh
+++ b/plugins/claude/scripts/ingest-hook.sh
@@ -14,6 +14,11 @@ if [ -z "${PLUGIN_ROOT}" ]; then
 fi
 PLUGIN_MANIFEST="${PLUGIN_ROOT}/.claude-plugin/plugin.json"
 UVX_PACKAGE_SPEC="codemem"
+VIEWER_HOST="${CODEMEM_VIEWER_HOST:-127.0.0.1}"
+VIEWER_PORT="${CODEMEM_VIEWER_PORT:-38888}"
+CLAUDE_HOOK_URL="http://${VIEWER_HOST}:${VIEWER_PORT}/api/claude-hooks"
+HTTP_CONNECT_TIMEOUT_S="${CODEMEM_CLAUDE_HOOK_HTTP_CONNECT_TIMEOUT_S:-1}"
+HTTP_MAX_TIME_S="${CODEMEM_CLAUDE_HOOK_HTTP_MAX_TIME_S:-2}"
 
 if [ -f "${PLUGIN_MANIFEST}" ]; then
   PLUGIN_VERSION="$(sed -n 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${PLUGIN_MANIFEST}" | sed -n '1p')"
@@ -61,6 +66,31 @@ if ! acquire_lock; then
   exit 0
 fi
 trap 'release_lock' EXIT
+
+enqueue_via_http() {
+  if ! command -v curl >/dev/null 2>&1; then
+    return 1
+  fi
+  status_code="$(
+    printf '%s' "${payload}" | \
+      curl -sS \
+        --connect-timeout "${HTTP_CONNECT_TIMEOUT_S}" \
+        --max-time "${HTTP_MAX_TIME_S}" \
+        -H 'Content-Type: application/json' \
+        --data-binary @- \
+        -o /dev/null \
+        -w '%{http_code}' \
+        "${CLAUDE_HOOK_URL}" 2>/dev/null
+  )"
+  case "${status_code}" in
+    2*) return 0 ;;
+  esac
+  return 1
+}
+
+if enqueue_via_http; then
+  exit 0
+fi
 
 if command -v codemem >/dev/null 2>&1; then
   if ! printf '%s' "${payload}" | CODEMEM_PLUGIN_IGNORE=1 codemem ingest-claude-hook >/dev/null 2>&1; then

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from codemem.claude_hooks import build_ingest_payload_from_hook, map_claude_hook_payload
+from codemem.claude_hooks import (
+    build_ingest_payload_from_hook,
+    build_raw_event_envelope_from_hook,
+    map_claude_hook_payload,
+)
 
 
 def test_map_user_prompt_submit_to_prompt_event() -> None:
@@ -160,3 +164,24 @@ def test_map_claude_hook_payload_missing_ts_generates_distinct_event_ids(
     assert second is not None
     assert first["ts"] != second["ts"]
     assert first["event_id"] != second["event_id"]
+
+
+def test_build_raw_event_envelope_from_hook_includes_queue_fields() -> None:
+    payload = {
+        "hook_event_name": "SessionStart",
+        "session_id": "sess-enqueue",
+        "source": "startup",
+        "cwd": "/tmp/repo",
+        "project": "codemem",
+        "ts": "2026-03-04T01:00:00Z",
+    }
+
+    envelope = build_raw_event_envelope_from_hook(payload)
+
+    assert envelope is not None
+    assert envelope["opencode_session_id"] == "sess-enqueue"
+    assert envelope["source"] == "claude"
+    assert envelope["event_type"] == "claude.hook"
+    assert envelope["started_at"] == "2026-03-04T01:00:00Z"
+    assert envelope["payload"]["_adapter"]["event_type"] == "session_start"
+    assert envelope["ts_wall_ms"] == 1772586000000

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -285,6 +285,8 @@ def test_claude_hook_script_has_version_pinned_uvx_fallback() -> None:
 
     assert 'UVX_PACKAGE_SPEC="codemem"' in hook_script
     assert 'UVX_PACKAGE_SPEC="codemem==${PLUGIN_VERSION}"' in hook_script
+    assert 'CLAUDE_HOOK_URL="http://${VIEWER_HOST}:${VIEWER_PORT}/api/claude-hooks"' in hook_script
+    assert "curl -sS" in hook_script
     assert 'uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook' in hook_script
     assert "CODEMEM_PLUGIN_IGNORE=1 codemem ingest-claude-hook" in hook_script
     assert 'CODEMEM_PLUGIN_IGNORE=1 uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook' in hook_script

--- a/tests/test_viewer_routes_raw_events.py
+++ b/tests/test_viewer_routes_raw_events.py
@@ -33,6 +33,7 @@ class DummyStore:
         self.conn: Any = None
         self.closed = False
         self.recorded_batches: list[tuple[str, list[dict[str, Any]]]] = []
+        self.recorded_events: list[dict[str, Any]] = []
         self.meta_updates: list[dict[str, Any]] = []
 
     def raw_event_backlog_totals(self) -> dict[str, int]:
@@ -48,10 +49,35 @@ class DummyStore:
         self.recorded_batches.append((opencode_session_id, events))
         return {"inserted": len(events)}
 
+    def record_raw_event(
+        self,
+        *,
+        opencode_session_id: str,
+        source: str,
+        event_id: str,
+        event_type: str,
+        payload: dict[str, Any],
+        ts_wall_ms: int | None = None,
+        ts_mono_ms: float | None = None,
+    ) -> bool:
+        self.recorded_events.append(
+            {
+                "opencode_session_id": opencode_session_id,
+                "source": source,
+                "event_id": event_id,
+                "event_type": event_type,
+                "payload": payload,
+                "ts_wall_ms": ts_wall_ms,
+                "ts_mono_ms": ts_mono_ms,
+            }
+        )
+        return True
+
     def update_raw_event_session_meta(
         self,
         *,
         opencode_session_id: str,
+        source: str = "opencode",
         cwd: str | None,
         project: str | None,
         started_at: str | None,
@@ -60,6 +86,7 @@ class DummyStore:
         self.meta_updates.append(
             {
                 "opencode_session_id": opencode_session_id,
+                "source": source,
                 "cwd": cwd,
                 "project": project,
                 "started_at": started_at,
@@ -277,6 +304,65 @@ def test_handle_post_flusher_failure_does_not_fail_ingest() -> None:
     assert handled is True
     assert handler.status == 200
     assert handler.response == {"inserted": 1, "received": 1}
+
+
+def test_handle_post_claude_hooks_enqueues_mapped_event() -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "sess-cld-1",
+        "prompt": "run tests",
+        "cwd": "/tmp/repo",
+    }
+    body = json.dumps(payload).encode("utf-8")
+    handler = DummyHandler(body=body, content_length=len(body))
+    flusher = DummyFlusher()
+    store = DummyStore()
+
+    handled = raw_events.handle_post(
+        handler,
+        path="/api/claude-hooks",
+        store_factory=lambda _db_path: store,
+        default_db_path="/tmp/mem.sqlite",
+        flusher=flusher,
+        strip_private_obj=lambda value: value,
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert handler.response == {"inserted": 1, "skipped": 0}
+    assert len(store.recorded_events) == 1
+    event = store.recorded_events[0]
+    assert event["source"] == "claude"
+    assert event["event_type"] == "claude.hook"
+    assert event["payload"]["_adapter"]["event_type"] == "prompt"
+    assert store.meta_updates[0]["source"] == "claude"
+    assert flusher.noted == ["sess-cld-1"]
+
+
+def test_handle_post_claude_hooks_skips_unmappable_payload() -> None:
+    payload = {
+        "hook_event_name": "NotMapped",
+        "session_id": "sess-cld-2",
+    }
+    body = json.dumps(payload).encode("utf-8")
+    handler = DummyHandler(body=body, content_length=len(body))
+    flusher = DummyFlusher()
+    store = DummyStore()
+
+    handled = raw_events.handle_post(
+        handler,
+        path="/api/claude-hooks",
+        store_factory=lambda _db_path: store,
+        default_db_path="/tmp/mem.sqlite",
+        flusher=flusher,
+        strip_private_obj=lambda value: value,
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert handler.response == {"inserted": 0, "skipped": 1}
+    assert store.recorded_events == []
+    assert flusher.noted == []
 
 
 def test_handle_get_raw_events_status_returns_items_and_totals() -> None:


### PR DESCRIPTION
## Description
Route Claude hook ingestion through the local viewer HTTP queue first (`POST /api/claude-hooks`) and fall back to CLI ingest only when the server path is unavailable.

This unifies Claude ingest with the OpenCode queue model, keeps hook handling fast/non-blocking, and preserves durable fallback behavior while improving mapping/coverage for Claude hook envelopes.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation run:
- uv run ruff check codemem tests
- uv run pytest tests/test_claude_hooks.py tests/test_claude_integration_cmds.py tests/test_viewer_routes_raw_events.py

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced