### PR TITLE
feat(observability): add claude integration health command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ uv tool install --upgrade codemem
 
 Claude MCP launch uses `uvx`; first startup may be slower because `uvx` can fetch/install tooling on demand.
 
-Claude hook ingestion also auto-falls back to `uvx codemem==<plugin-version> ingest-claude-hook` when a local `codemem` binary is unavailable.
+Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks`) and auto-falls back to `codemem ingest-claude-hook` / `uvx codemem==<plugin-version> ingest-claude-hook` when the local server path is unavailable.
 
-Claude hook events are ingested through `codemem ingest-claude-hook` and share the same raw-event queue pipeline used by OpenCode.
+Claude hook events share the same raw-event queue pipeline used by OpenCode.
 
 > Migrating from `opencode-mem`? See [docs/rename-migration.md](docs/rename-migration.md).
 

--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -52,6 +52,7 @@ from .commands.memory_cmds import (
 )
 from .commands.opencode_integration_cmds import install_mcp_cmd, install_plugin_cmd
 from .commands.raw_events_cmds import (
+    claude_integration_status_cmd,
     enqueue_raw_event_cmd,
     flush_raw_events_cmd,
     raw_events_gate_cmd,
@@ -578,6 +579,27 @@ def raw_events_status(
     store = _store(db_path)
     try:
         raw_events_status_cmd(store, limit=limit)
+    finally:
+        store.close()
+
+
+@app.command("claude-integration-status")
+def claude_integration_status(
+    db_path: str = typer.Option(None, help="Path to SQLite database"),
+    limit: int = typer.Option(100, help="Max pending streams to inspect"),
+) -> None:
+    """Show Claude hook queue/flush health signals in one report."""
+
+    cfg = load_config()
+    store = _store(db_path)
+    try:
+        claude_integration_status_cmd(
+            store,
+            limit=limit,
+            observer_runtime=cfg.observer_runtime,
+            claude_command=cfg.claude_command,
+            sweeper_interval_s=cfg.raw_events_sweeper_interval_s,
+        )
     finally:
         store.close()
 

--- a/codemem/commands/raw_events_cmds.py
+++ b/codemem/commands/raw_events_cmds.py
@@ -177,6 +177,83 @@ def raw_events_status_cmd(store: MemoryStore, *, limit: int) -> None:
         )
 
 
+def claude_integration_status_cmd(
+    store: MemoryStore,
+    *,
+    limit: int,
+    observer_runtime: str,
+    claude_command: list[str],
+    sweeper_interval_s: int,
+) -> None:
+    claude_items = store.raw_event_backlog(limit=limit, source="claude")
+
+    pending_events = 0
+    running_streams = 0
+    errored_streams = 0
+    queue_claimed = 0
+    queue_failed = 0
+    stream_summaries: list[dict[str, Any]] = []
+
+    for item in claude_items:
+        stream_id = str(item.get("stream_id") or item.get("opencode_session_id") or "")
+        if not stream_id:
+            continue
+        pending = int(item.get("pending") or 0)
+        pending_events += pending
+        legacy_counts = store.raw_event_batch_status_counts(stream_id, source="claude")
+        queue_counts = store.raw_event_queue_status_counts(stream_id, source="claude")
+        is_running = (
+            int(legacy_counts.get("running", 0) or 0) > 0
+            or int(queue_counts.get("claimed", 0) or 0) > 0
+        )
+        is_error = (
+            int(legacy_counts.get("error", 0) or 0) > 0
+            or int(queue_counts.get("failed", 0) or 0) > 0
+        )
+        if is_running:
+            running_streams += 1
+        if is_error:
+            errored_streams += 1
+        queue_claimed += int(queue_counts.get("claimed", 0) or 0)
+        queue_failed += int(queue_counts.get("failed", 0) or 0)
+        stream_summaries.append(
+            {
+                "stream_id": stream_id,
+                "pending": pending,
+                "batch_running": int(legacy_counts.get("running", 0) or 0),
+                "batch_error": int(legacy_counts.get("error", 0) or 0),
+                "queue_claimed": int(queue_counts.get("claimed", 0) or 0),
+                "queue_failed": int(queue_counts.get("failed", 0) or 0),
+                "project": item.get("project") or "",
+            }
+        )
+
+    top_streams = sorted(stream_summaries, key=lambda entry: int(entry["pending"]), reverse=True)[
+        :5
+    ]
+
+    health = "green"
+    if errored_streams > 0 or queue_failed > 0:
+        health = "red"
+    elif pending_events > 0 or running_streams > 0:
+        health = "yellow"
+
+    payload = {
+        "health": health,
+        "observer_runtime": observer_runtime,
+        "claude_command": claude_command,
+        "raw_events_sweeper_interval_s": sweeper_interval_s,
+        "claude_streams": len(claude_items),
+        "pending_events": pending_events,
+        "running_streams": running_streams,
+        "errored_streams": errored_streams,
+        "queue_claimed": queue_claimed,
+        "queue_failed": queue_failed,
+        "top_streams": top_streams,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
 def raw_events_retry_cmd(
     store: MemoryStore,
     *,

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -704,8 +704,13 @@ class MemoryStore:
     def purge_raw_events(self, max_age_ms: int) -> int:
         return store_raw_events.purge_raw_events(self.conn, max_age_ms)
 
-    def raw_event_backlog(self, *, limit: int = 25) -> list[dict[str, Any]]:
-        return store_raw_events.raw_event_backlog(self.conn, limit=limit)
+    def raw_event_backlog(
+        self,
+        *,
+        limit: int = 25,
+        source: str | None = None,
+    ) -> list[dict[str, Any]]:
+        return store_raw_events.raw_event_backlog(self.conn, limit=limit, source=source)
 
     def raw_event_backlog_totals(self) -> dict[str, int]:
         return store_raw_events.raw_event_backlog_totals(self.conn)

--- a/codemem/store/raw_events.py
+++ b/codemem/store/raw_events.py
@@ -878,9 +878,13 @@ def purge_raw_events(conn: sqlite3.Connection, max_age_ms: int) -> int:
     return purge_raw_events_before(conn, cutoff)
 
 
-def raw_event_backlog(conn: sqlite3.Connection, *, limit: int = 25) -> list[dict[str, Any]]:
-    rows = conn.execute(
-        """
+def raw_event_backlog(
+    conn: sqlite3.Connection,
+    *,
+    limit: int = 25,
+    source: str | None = None,
+) -> list[dict[str, Any]]:
+    base_query = """
         WITH max_events AS (
             SELECT source, stream_id, MAX(event_seq) AS max_seq
             FROM raw_events
@@ -902,9 +906,17 @@ def raw_event_backlog(conn: sqlite3.Connection, *, limit: int = 25) -> list[dict
         WHERE e.max_seq > s.last_flushed_event_seq
         ORDER BY s.last_seen_ts_wall_ms DESC
         LIMIT ?
-        """,
-        (limit,),
-    ).fetchall()
+    """
+    if source is None:
+        rows = conn.execute(base_query, (limit,)).fetchall()
+    else:
+        rows = conn.execute(
+            base_query.replace(
+                "WHERE e.max_seq > s.last_flushed_event_seq",
+                "WHERE e.max_seq > s.last_flushed_event_seq AND s.source = ?",
+            ),
+            (source, limit),
+        ).fetchall()
     return [dict(row) for row in rows]
 
 

--- a/codemem/viewer_routes/raw_events.py
+++ b/codemem/viewer_routes/raw_events.py
@@ -186,6 +186,12 @@ def _handle_post_claude_hooks(
             logger.debug("raw event flusher error", exc_info=exc)
         handler._send_json({"inserted": int(inserted), "skipped": 0})
         return True
+    except Exception as exc:  # pragma: no cover
+        response: dict[str, Any] = {"error": "internal server error"}
+        if os.environ.get("CODEMEM_VIEWER_DEBUG") == "1":
+            response["detail"] = str(exc)
+        handler._send_json(response, status=500)
+        return True
     finally:
         store.close()
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,7 +242,7 @@ The OpenCode adapter streams each captured event to the viewer API (`captureEven
 
 When stream delivery is unavailable, the adapter can enqueue raw events through the CLI fallback path (`enqueue-raw-event`) so events still enter durable queue processing.
 
-Claude hook ingestion writes directly to raw-event queue storage and flushes on configured lifecycle boundaries.
+Claude hook ingestion is enqueue-first (`POST /api/claude-hooks`) with CLI fallback and does not flush by default.
 
 ### OpenCode session finalization triggers
 - `session.idle` — finalizes current local buffer
@@ -260,8 +260,8 @@ Claude hook ingestion writes directly to raw-event queue storage and flushes on 
 - Once events are accepted by the viewer/store queue, flush workers handle retries
 
 ### Claude hook flush boundaries
-- `Stop` and `SessionEnd` trigger immediate flush attempts by default
-- `CODEMEM_CLAUDE_HOOK_FLUSH=0` disables immediate boundary flush attempts
+- `CODEMEM_CLAUDE_HOOK_FLUSH=1` enables immediate `SessionEnd` boundary flush attempts
+- `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` extends immediate flush to `Stop` when boundary flush is enabled
 
 ## Design tradeoffs
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -62,7 +62,7 @@ Ingest one Claude hook payload from stdin (this is what the installed hook scrip
 printf '%s\n' '{"hook_event_name":"SessionStart","session_id":"sess-1","cwd":"/tmp/demo"}' | codemem ingest-claude-hook
 ```
 
-By default, Claude hooks are enqueue-only. Set `CODEMEM_CLAUDE_HOOK_FLUSH=1` to enable immediate flush on `SessionEnd`, and set `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` to also flush on `Stop`.
+By default, Claude hooks are enqueue-only on the HTTP path. In CLI fallback mode (`codemem ingest-claude-hook` / `uvx`), `SessionEnd` flush is enabled by default to preserve progress when no viewer sweeper is available. Set `CODEMEM_CLAUDE_HOOK_FLUSH=0` to force enqueue-only in fallback mode as well, and set `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` to include `Stop`.
 
 The packaged template currently registers these hook events in `plugins/claude/hooks/hooks.json`:
 - `SessionStart`
@@ -82,7 +82,7 @@ After restarting OpenCode or the viewer, run this quick check when behavior look
 2. Check backend stats and recent writes (`codemem stats`, `codemem recent`).
 3. Verify runner mode and source (`CODEMEM_RUNNER`, `CODEMEM_RUNNER_FROM`) match your install strategy.
 4. Confirm injection controls are what you expect (`CODEMEM_INJECT_CONTEXT`, `CODEMEM_INJECT_LIMIT`, `CODEMEM_INJECT_TOKEN_BUDGET`).
-5. If stream mode is enabled, check backlog health (`codemem raw-events-status`).
+5. If stream mode is enabled, check backlog health (`codemem raw-events-status`) and Claude-specific health (`codemem claude-integration-status`).
 
 If needed, restart viewer + plugin flow:
 
@@ -235,10 +235,14 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Customize the viewer host/port printed on startup. |
 | `CODEMEM_VIEWER_AUTO` | Set to `0`/`false`/`off` to disable auto-start (default on). |
 | `CODEMEM_VIEWER_AUTO_STOP` | Set to `0`/`false`/`off` to keep the viewer running after OpenCode exits (default on). |
-| `CODEMEM_PLUGIN_LOG` | Path for the plugin log file (set `1`/`true`/`yes` to enable; defaults to off). |
+| `CODEMEM_PLUGIN_LOG` | Path for the plugin log file (set `1`/`true`/`yes` for `~/.codemem/plugin.log`; Claude hook failures are logged to this path by default). |
 | `CODEMEM_PLUGIN_LOG_PATH` | Explicit log file path for Claude hook script logging (overrides `CODEMEM_PLUGIN_LOG` for that script). |
 | `CODEMEM_CLAUDE_HOOK_HTTP_CONNECT_TIMEOUT_S` | Claude hook HTTP enqueue connect timeout in seconds (default `1`). |
 | `CODEMEM_CLAUDE_HOOK_HTTP_MAX_TIME_S` | Claude hook HTTP enqueue total timeout in seconds (default `2`). |
+| `CODEMEM_CLAUDE_HOOK_LOCK_DIR` | Claude hook fallback lock directory path (default `~/.codemem/claude-hook-ingest.lock`). |
+| `CODEMEM_CLAUDE_HOOK_LOCK_TTL_S` | Reclaim stale Claude hook fallback lock after this many seconds (default `300`). |
+| `CODEMEM_CLAUDE_HOOK_LOCK_GRACE_S` | Grace period before treating lock metadata gaps as stale (default `2`). |
+| `CODEMEM_CLAUDE_HOOK_SPOOL_DIR` | Claude hook durable spool directory for all-fail fallback payloads (default `~/.codemem/claude-hook-spool`). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |
 | `CODEMEM_BACKEND_UPDATE_POLICY` | Backend update behavior on compatibility mismatch: `notify` (default), `auto`, or `off`. |

--- a/plugins/claude/scripts/ingest-hook.sh
+++ b/plugins/claude/scripts/ingest-hook.sh
@@ -44,12 +44,344 @@ case "${CODEMEM_PLUGIN_IGNORE:-}" in
 esac
 
 LOCK_DIR="${CODEMEM_CLAUDE_HOOK_LOCK_DIR:-$HOME/.codemem/claude-hook-ingest.lock}"
+LOCK_TTL_S="${CODEMEM_CLAUDE_HOOK_LOCK_TTL_S:-300}"
+LOCK_GRACE_S="${CODEMEM_CLAUDE_HOOK_LOCK_GRACE_S:-2}"
+SPOOL_DIR="${CODEMEM_CLAUDE_HOOK_SPOOL_DIR:-$HOME/.codemem/claude-hook-spool}"
+LOCK_OWNER_TOKEN=""
+STALE_CHECK_PID=""
+STALE_CHECK_TS=""
+STALE_CHECK_OWNER=""
+case "${LOCK_TTL_S}" in
+  ''|*[!0-9]*) LOCK_TTL_S=300 ;;
+esac
+case "${LOCK_GRACE_S}" in
+  ''|*[!0-9]*) LOCK_GRACE_S=2 ;;
+esac
+
+normalize_payload_ts() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return
+  fi
+  payload="$(printf '%s' "${payload}" | python3 -c '
+import datetime as dt
+import json
+import sys
+
+raw = sys.stdin.read()
+try:
+    obj = json.loads(raw)
+except Exception:
+    sys.stdout.write(raw)
+    raise SystemExit(0)
+
+if isinstance(obj, dict):
+    ts = obj.get("ts")
+    if not isinstance(ts, str) or not ts.strip():
+        timestamp = obj.get("timestamp")
+        if isinstance(timestamp, str) and timestamp.strip():
+            obj["ts"] = timestamp
+        else:
+            obj["ts"] = dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+sys.stdout.write(json.dumps(obj, separators=(",", ":"), ensure_ascii=False))
+' 2>/dev/null || printf '%s' "${payload}")"
+}
+
+spool_payload() {
+  spool_payload_text="$1"
+  mkdir -p "${SPOOL_DIR}" >/dev/null 2>&1 || true
+  spool_tmp="$(mktemp "${SPOOL_DIR}/.hook-tmp-XXXXXX" 2>/dev/null || true)"
+  if [ -z "${spool_tmp}" ]; then
+    log_line "codemem ingest-claude-hook failed to allocate spool temp file"
+    return 1
+  fi
+  if ! printf '%s' "${spool_payload_text}" >"${spool_tmp}" 2>/dev/null; then
+    rm -f "${spool_tmp}" >/dev/null 2>&1 || true
+    log_line "codemem ingest-claude-hook failed to spool payload"
+    return 1
+  fi
+  spool_file="${SPOOL_DIR}/hook-$(date +%s)-$$-${RANDOM}.json"
+  if mv "${spool_tmp}" "${spool_file}" >/dev/null 2>&1; then
+    log_line "codemem ingest-claude-hook spooled payload: ${spool_file}"
+    return 0
+  fi
+  rm -f "${spool_tmp}" >/dev/null 2>&1 || true
+  log_line "codemem ingest-claude-hook failed to spool payload"
+  return 1
+}
+
+enqueue_via_http_payload() {
+  enqueue_payload="$1"
+  if ! command -v curl >/dev/null 2>&1; then
+    return 1
+  fi
+
+  response_file="$(mktemp "${TMPDIR:-/tmp}/codemem-claude-hook-http.XXXXXX" 2>/dev/null || true)"
+  if [ -z "${response_file}" ]; then
+    return 1
+  fi
+
+  status_code="$(
+    printf '%s' "${enqueue_payload}" | \
+      curl -sS \
+        --connect-timeout "${HTTP_CONNECT_TIMEOUT_S}" \
+        --max-time "${HTTP_MAX_TIME_S}" \
+        -H 'Content-Type: application/json' \
+        --data-binary @- \
+        -o "${response_file}" \
+        -w '%{http_code}' \
+        "${CLAUDE_HOOK_URL}" 2>/dev/null
+  )"
+
+  case "${status_code}" in
+    2*)
+      if grep -Eq '"inserted"[[:space:]]*:[[:space:]]*[0-9]+' "${response_file}" && \
+         grep -Eq '"skipped"[[:space:]]*:[[:space:]]*[0-9]+' "${response_file}"; then
+        rm -f "${response_file}" >/dev/null 2>&1 || true
+        return 0
+      fi
+      if grep -Eq '"skipped"[[:space:]]*:[[:space:]]*[1-9][0-9]*' "${response_file}"; then
+        log_line "codemem ingest-claude-hook HTTP accepted but skipped payload"
+      else
+        log_line "codemem ingest-claude-hook HTTP accepted with unexpected response body"
+      fi
+      rm -f "${response_file}" >/dev/null 2>&1 || true
+      return 1
+      ;;
+  esac
+
+  rm -f "${response_file}" >/dev/null 2>&1 || true
+  return 1
+}
+
+enqueue_via_http() {
+  enqueue_via_http_payload "${payload}"
+}
+
+is_truthy() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|on) return 0 ;;
+  esac
+  return 1
+}
+
+should_force_boundary_flush() {
+  if ! is_truthy "${CODEMEM_CLAUDE_HOOK_FLUSH:-0}"; then
+    return 1
+  fi
+  case "${payload}" in
+    *'"hook_event_name":"SessionEnd"'*) return 0 ;;
+    *'"hook_event_name":"Stop"'*)
+      if is_truthy "${CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP:-0}"; then
+        return 0
+      fi
+      ;;
+  esac
+  return 1
+}
+
+run_cli_ingest_payload() {
+  cli_payload="$1"
+  have_backend=0
+
+  if command -v codemem >/dev/null 2>&1; then
+    have_backend=1
+    if printf '%s' "${cli_payload}" | CODEMEM_PLUGIN_IGNORE=1 CODEMEM_CLAUDE_HOOK_FLUSH="${CODEMEM_CLAUDE_HOOK_FLUSH:-1}" codemem ingest-claude-hook >/dev/null 2>&1; then
+      return 0
+    fi
+    log_line "codemem ingest-claude-hook failed via codemem binary"
+  fi
+
+  if command -v uvx >/dev/null 2>&1; then
+    have_backend=1
+    if printf '%s' "${cli_payload}" | CODEMEM_PLUGIN_IGNORE=1 CODEMEM_CLAUDE_HOOK_FLUSH="${CODEMEM_CLAUDE_HOOK_FLUSH:-1}" uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook >/dev/null 2>&1; then
+      return 0
+    fi
+    log_line "codemem ingest-claude-hook failed via uvx"
+  fi
+
+  if [ "${have_backend}" -eq 0 ]; then
+    log_line "codemem ingest-claude-hook skipped: codemem and uvx not found"
+  else
+    log_line "codemem ingest-claude-hook failed: all fallback attempts failed"
+  fi
+  return 1
+}
+
+run_cli_ingest() {
+  run_cli_ingest_payload "${payload}"
+}
+
+drain_spool() {
+  mkdir -p "${SPOOL_DIR}" >/dev/null 2>&1 || true
+  for queued_file in "${SPOOL_DIR}"/*.json; do
+    if [ ! -e "${queued_file}" ]; then
+      continue
+    fi
+    if ! queued_payload="$(cat "${queued_file}" 2>/dev/null)"; then
+      log_line "codemem ingest-claude-hook failed reading spooled payload: ${queued_file}"
+      continue
+    fi
+    if [ -z "${queued_payload}" ]; then
+      if [ ! -s "${queued_file}" ]; then
+        rm -f "${queued_file}" >/dev/null 2>&1 || true
+      fi
+      continue
+    fi
+    if enqueue_via_http_payload "${queued_payload}" || run_cli_ingest_payload "${queued_payload}"; then
+      rm -f "${queued_file}" >/dev/null 2>&1 || true
+      continue
+    fi
+    log_line "codemem ingest-claude-hook failed processing spooled payload: ${queued_file}"
+    continue
+  done
+}
+
+recover_stale_tmp_spool() {
+  mkdir -p "${SPOOL_DIR}" >/dev/null 2>&1 || true
+  now_epoch="$(date +%s)"
+  for tmp_file in "${SPOOL_DIR}"/.hook-tmp-*; do
+    if [ ! -e "${tmp_file}" ]; then
+      continue
+    fi
+    tmp_mtime="$(stat -f %m "${tmp_file}" 2>/dev/null || stat -c %Y "${tmp_file}" 2>/dev/null || printf '%s' "${now_epoch}")"
+    age="$((now_epoch - tmp_mtime))"
+    if [ "${age}" -le "${LOCK_TTL_S}" ]; then
+      continue
+    fi
+    recovered="${SPOOL_DIR}/hook-recovered-$(date +%s)-$$-${RANDOM}.json"
+    if mv "${tmp_file}" "${recovered}" >/dev/null 2>&1; then
+      log_line "codemem ingest-claude-hook recovered stale temp spool payload: ${recovered}"
+    fi
+  done
+}
+
+lock_is_stale() {
+  lock_pid=""
+  lock_ts=""
+  lock_owner=""
+  now_epoch="$(date +%s)"
+  lock_mtime="$(stat -f %m "${LOCK_DIR}" 2>/dev/null || stat -c %Y "${LOCK_DIR}" 2>/dev/null || printf '%s' "${now_epoch}")"
+
+  if [ -f "${LOCK_DIR}/pid" ]; then
+    lock_pid="$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)"
+  fi
+  if [ -f "${LOCK_DIR}/ts" ]; then
+    lock_ts="$(cat "${LOCK_DIR}/ts" 2>/dev/null || true)"
+  fi
+  if [ -f "${LOCK_DIR}/owner" ]; then
+    lock_owner="$(cat "${LOCK_DIR}/owner" 2>/dev/null || true)"
+  fi
+
+  case "${lock_ts}" in
+    ''|*[!0-9]*) lock_ts="" ;;
+  esac
+
+  STALE_CHECK_PID="${lock_pid}"
+  STALE_CHECK_TS="${lock_ts}"
+  STALE_CHECK_OWNER="${lock_owner}"
+
+  if [ -n "${lock_pid}" ]; then
+    if kill -0 "${lock_pid}" >/dev/null 2>&1; then
+      lock_cmd="$(ps -p "${lock_pid}" -o command= 2>/dev/null || true)"
+      if printf '%s' "${lock_cmd}" | grep -q "ingest-hook.sh"; then
+        if [ -n "${lock_ts}" ]; then
+          age="$((now_epoch - lock_ts))"
+          if [ "${age}" -gt "${LOCK_TTL_S}" ]; then
+            return 0
+          fi
+        fi
+        return 1
+      fi
+      if [ -n "${lock_ts}" ]; then
+        age="$((now_epoch - lock_ts))"
+        if [ "${age}" -gt "${LOCK_TTL_S}" ]; then
+          return 0
+        fi
+      fi
+      return 1
+    fi
+    return 0
+  fi
+
+  if [ -n "${lock_ts}" ]; then
+    age="$((now_epoch - lock_ts))"
+    if [ "${age}" -gt "${LOCK_GRACE_S}" ]; then
+      return 0
+    fi
+    return 1
+  fi
+
+  age="$((now_epoch - lock_mtime))"
+  if [ "${age}" -gt "${LOCK_GRACE_S}" ]; then
+    return 0
+  fi
+  return 1
+}
+
+write_lock_metadata() {
+  LOCK_OWNER_TOKEN="$$-$(date +%s)-${RANDOM}"
+  if ! date +%s >"${LOCK_DIR}/ts" 2>/dev/null; then
+    LOCK_OWNER_TOKEN=""
+    return 1
+  fi
+  if ! printf '%s\n' "$$" >"${LOCK_DIR}/pid" 2>/dev/null; then
+    LOCK_OWNER_TOKEN=""
+    return 1
+  fi
+  if ! printf '%s\n' "${LOCK_OWNER_TOKEN}" >"${LOCK_DIR}/owner" 2>/dev/null; then
+    LOCK_OWNER_TOKEN=""
+    return 1
+  fi
+  return 0
+}
+
+cleanup_lock_dir() {
+  rm -f "${LOCK_DIR}/pid" "${LOCK_DIR}/ts" "${LOCK_DIR}/owner" >/dev/null 2>&1 || true
+  rmdir "${LOCK_DIR}" >/dev/null 2>&1 || true
+}
+
+cleanup_lock_dir_if_unchanged() {
+  current_pid=""
+  current_ts=""
+  current_owner=""
+  if [ -f "${LOCK_DIR}/pid" ]; then
+    current_pid="$(cat "${LOCK_DIR}/pid" 2>/dev/null || true)"
+  fi
+  if [ -f "${LOCK_DIR}/ts" ]; then
+    current_ts="$(cat "${LOCK_DIR}/ts" 2>/dev/null || true)"
+  fi
+  if [ -f "${LOCK_DIR}/owner" ]; then
+    current_owner="$(cat "${LOCK_DIR}/owner" 2>/dev/null || true)"
+  fi
+
+  if [ "${current_pid}" = "${STALE_CHECK_PID}" ] && \
+     [ "${current_ts}" = "${STALE_CHECK_TS}" ] && \
+     [ "${current_owner}" = "${STALE_CHECK_OWNER}" ]; then
+    cleanup_lock_dir
+    return 0
+  fi
+  return 1
+}
+
 acquire_lock() {
   mkdir -p "$(dirname "${LOCK_DIR}")" >/dev/null 2>&1 || true
   attempts=100
   while [ "${attempts}" -gt 0 ]; do
     if mkdir "${LOCK_DIR}" >/dev/null 2>&1; then
-      return 0
+      if write_lock_metadata; then
+        return 0
+      fi
+      cleanup_lock_dir
+      attempts=$((attempts - 1))
+      sleep 0.05
+      continue
+    fi
+    if lock_is_stale; then
+      cleanup_lock_dir_if_unchanged || true
+      attempts=$((attempts - 1))
+      sleep 0.05
+      continue
     fi
     attempts=$((attempts - 1))
     sleep 0.05
@@ -58,54 +390,52 @@ acquire_lock() {
 }
 
 release_lock() {
-  rmdir "${LOCK_DIR}" >/dev/null 2>&1 || true
+  if [ -z "${LOCK_OWNER_TOKEN}" ]; then
+    return
+  fi
+  current_owner="$(cat "${LOCK_DIR}/owner" 2>/dev/null || true)"
+  if [ "${current_owner}" = "${LOCK_OWNER_TOKEN}" ]; then
+    cleanup_lock_dir
+  fi
 }
 
+normalize_payload_ts
+
+if enqueue_via_http; then
+  if should_force_boundary_flush; then
+    run_cli_ingest || true
+  fi
+  exit 0
+fi
+
 if ! acquire_lock; then
-  log_line "codemem ingest-claude-hook skipped: lock busy"
+  log_line "codemem ingest-claude-hook lock busy; trying unlocked fallback"
+  if ! run_cli_ingest; then
+    if ! spool_payload "${payload}"; then
+      log_line "codemem ingest-claude-hook failed: fallback and spool failed"
+      exit 1
+    fi
+  fi
   exit 0
 fi
 trap 'release_lock' EXIT
 
-enqueue_via_http() {
-  if ! command -v curl >/dev/null 2>&1; then
-    return 1
-  fi
-  status_code="$(
-    printf '%s' "${payload}" | \
-      curl -sS \
-        --connect-timeout "${HTTP_CONNECT_TIMEOUT_S}" \
-        --max-time "${HTTP_MAX_TIME_S}" \
-        -H 'Content-Type: application/json' \
-        --data-binary @- \
-        -o /dev/null \
-        -w '%{http_code}' \
-        "${CLAUDE_HOOK_URL}" 2>/dev/null
-  )"
-  case "${status_code}" in
-    2*) return 0 ;;
-  esac
-  return 1
-}
+recover_stale_tmp_spool
+
+drain_spool
 
 if enqueue_via_http; then
-  exit 0
-fi
-
-if command -v codemem >/dev/null 2>&1; then
-  if ! printf '%s' "${payload}" | CODEMEM_PLUGIN_IGNORE=1 codemem ingest-claude-hook >/dev/null 2>&1; then
-    log_line "codemem ingest-claude-hook failed via codemem binary"
+  if should_force_boundary_flush; then
+    run_cli_ingest || true
   fi
   exit 0
 fi
 
-if command -v uvx >/dev/null 2>&1; then
-  if ! printf '%s' "${payload}" | CODEMEM_PLUGIN_IGNORE=1 uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook >/dev/null 2>&1; then
-    log_line "codemem ingest-claude-hook failed via uvx"
+if ! run_cli_ingest; then
+  if ! spool_payload "${payload}"; then
+    log_line "codemem ingest-claude-hook failed: fallback and spool failed"
+    exit 1
   fi
-  exit 0
 fi
-
-log_line "codemem ingest-claude-hook skipped: codemem and uvx not found"
 
 exit 0

--- a/tests/test_claude_integration_cmds.py
+++ b/tests/test_claude_integration_cmds.py
@@ -288,12 +288,38 @@ def test_claude_hook_script_has_version_pinned_uvx_fallback() -> None:
     assert 'CLAUDE_HOOK_URL="http://${VIEWER_HOST}:${VIEWER_PORT}/api/claude-hooks"' in hook_script
     assert "curl -sS" in hook_script
     assert 'uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook' in hook_script
-    assert "CODEMEM_PLUGIN_IGNORE=1 codemem ingest-claude-hook" in hook_script
-    assert 'CODEMEM_PLUGIN_IGNORE=1 uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook' in hook_script
+    assert (
+        "CODEMEM_PLUGIN_IGNORE=1 "
+        'CODEMEM_CLAUDE_HOOK_FLUSH="${CODEMEM_CLAUDE_HOOK_FLUSH:-1}" '
+        "codemem ingest-claude-hook"
+    ) in hook_script
+    assert (
+        "CODEMEM_PLUGIN_IGNORE=1 "
+        'CODEMEM_CLAUDE_HOOK_FLUSH="${CODEMEM_CLAUDE_HOOK_FLUSH:-1}" '
+        'uvx "${UVX_PACKAGE_SPEC}" ingest-claude-hook'
+    ) in hook_script
     assert (
         'LOCK_DIR="${CODEMEM_CLAUDE_HOOK_LOCK_DIR:-$HOME/.codemem/claude-hook-ingest.lock}"'
         in hook_script
     )
+    assert 'LOCK_TTL_S="${CODEMEM_CLAUDE_HOOK_LOCK_TTL_S:-300}"' in hook_script
+    assert 'LOCK_GRACE_S="${CODEMEM_CLAUDE_HOOK_LOCK_GRACE_S:-2}"' in hook_script
+    assert (
+        'SPOOL_DIR="${CODEMEM_CLAUDE_HOOK_SPOOL_DIR:-$HOME/.codemem/claude-hook-spool}"'
+        in hook_script
+    )
+    assert 'mktemp "${SPOOL_DIR}/.hook-tmp-XXXXXX"' in hook_script
+    assert "normalize_payload_ts()" in hook_script
+    assert 'timestamp = obj.get("timestamp")' in hook_script
+    assert "should_force_boundary_flush()" in hook_script
+    assert "spool_payload()" in hook_script
+    assert "drain_spool()" in hook_script
+    assert "cleanup_lock_dir()" in hook_script
+    assert "lock_is_stale()" in hook_script
+    assert "lock busy; trying unlocked fallback" in hook_script
+    assert "fallback and spool failed" in hook_script
+    assert "all fallback attempts failed" in hook_script
+    assert "should_force_boundary_flush; then" in hook_script
     assert "CODEMEM_HOOK_ALLOW_UVX" not in hook_script
 
 

--- a/tests/test_claude_integration_status_cmd.py
+++ b/tests/test_claude_integration_status_cmd.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+
+from codemem.commands.raw_events_cmds import claude_integration_status_cmd
+
+
+class _FakeStore:
+    def __init__(self, items: list[dict[str, object]]) -> None:
+        self._items = items
+
+    def raw_event_backlog(
+        self,
+        *,
+        limit: int = 25,
+        source: str | None = None,
+    ) -> list[dict[str, object]]:
+        items = self._items
+        if source is not None:
+            items = [item for item in items if item.get("source") == source]
+        return items[:limit]
+
+    def raw_event_batch_status_counts(self, stream_id: str, *, source: str) -> dict[str, int]:
+        _ = source
+        if stream_id == "sess-fail":
+            return {"started": 0, "running": 0, "error": 1, "completed": 0}
+        return {"started": 0, "running": 0, "error": 0, "completed": 0}
+
+    def raw_event_queue_status_counts(self, stream_id: str, *, source: str) -> dict[str, int]:
+        _ = source
+        if stream_id == "sess-run":
+            return {"pending": 0, "claimed": 1, "failed": 0, "completed": 0}
+        if stream_id == "sess-fail":
+            return {"pending": 0, "claimed": 0, "failed": 1, "completed": 0}
+        return {"pending": 0, "claimed": 0, "failed": 0, "completed": 0}
+
+
+def test_claude_integration_status_cmd_reports_red_on_failed_streams(capsys) -> None:
+    store = _FakeStore(
+        [
+            {"source": "claude", "stream_id": "sess-run", "pending": 3, "project": "alpha"},
+            {"source": "claude", "stream_id": "sess-fail", "pending": 4, "project": "alpha"},
+            {"source": "opencode", "stream_id": "sess-oc", "pending": 9, "project": "beta"},
+        ]
+    )
+
+    claude_integration_status_cmd(
+        store,  # type: ignore[arg-type]
+        limit=100,
+        observer_runtime="claude_sidecar",
+        claude_command=["claude"],
+        sweeper_interval_s=30,
+    )
+
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["health"] == "red"
+    assert payload["claude_streams"] == 2
+    assert payload["pending_events"] == 7
+    assert payload["running_streams"] == 1
+    assert payload["errored_streams"] == 1
+    assert payload["queue_failed"] == 1
+    assert payload["observer_runtime"] == "claude_sidecar"
+
+
+def test_claude_integration_status_cmd_reports_green_when_idle(capsys) -> None:
+    store = _FakeStore([])
+
+    claude_integration_status_cmd(
+        store,  # type: ignore[arg-type]
+        limit=100,
+        observer_runtime="api_http",
+        claude_command=["claude"],
+        sweeper_interval_s=30,
+    )
+
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["health"] == "green"
+    assert payload["claude_streams"] == 0
+    assert payload["pending_events"] == 0
+
+
+def test_claude_integration_status_cmd_limits_claude_streams_only(capsys) -> None:
+    store = _FakeStore(
+        [
+            {"source": "opencode", "stream_id": "sess-oc", "pending": 99, "project": "beta"},
+            {"source": "claude", "stream_id": "sess-cld", "pending": 2, "project": "alpha"},
+        ]
+    )
+
+    claude_integration_status_cmd(
+        store,  # type: ignore[arg-type]
+        limit=1,
+        observer_runtime="api_http",
+        claude_command=["claude"],
+        sweeper_interval_s=30,
+    )
+
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["claude_streams"] == 1
+    assert payload["pending_events"] == 2

--- a/tests/test_viewer_routes_raw_events.py
+++ b/tests/test_viewer_routes_raw_events.py
@@ -365,6 +365,54 @@ def test_handle_post_claude_hooks_skips_unmappable_payload() -> None:
     assert flusher.noted == []
 
 
+def test_handle_post_claude_hooks_store_error_returns_500() -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "sess-cld-3",
+        "prompt": "run tests",
+    }
+    body = json.dumps(payload).encode("utf-8")
+    handler = DummyHandler(body=body, content_length=len(body))
+    flusher = DummyFlusher()
+
+    class FailingStore(DummyStore):
+        def record_raw_event(
+            self,
+            *,
+            opencode_session_id: str,
+            source: str,
+            event_id: str,
+            event_type: str,
+            payload: dict[str, Any],
+            ts_wall_ms: int | None = None,
+            ts_mono_ms: float | None = None,
+        ) -> bool:
+            _ = (
+                opencode_session_id,
+                source,
+                event_id,
+                event_type,
+                payload,
+                ts_wall_ms,
+                ts_mono_ms,
+            )
+            raise RuntimeError("db write failed")
+
+    store = FailingStore()
+    handled = raw_events.handle_post(
+        handler,
+        path="/api/claude-hooks",
+        store_factory=lambda _db_path: store,
+        default_db_path="/tmp/mem.sqlite",
+        flusher=flusher,
+        strip_private_obj=lambda value: value,
+    )
+
+    assert handled is True
+    assert handler.status == 500
+    assert handler.response == {"error": "internal server error"}
+
+
 def test_handle_get_raw_events_status_returns_items_and_totals() -> None:
     class StatusStore(DummyStore):
         def raw_event_backlog(self, *, limit: int = 25) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Description
Add an operator-facing `claude-integration-status` command and complete Claude hook reliability hardening for lock recovery, spool durability, and fallback behavior.

This adds clearer health signals for queue/flush state and reduces silent-loss risk in degraded environments with bounded lock handling, stale lock recovery, durable spooling, and safer fallback processing.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation run:
- bash -n plugins/claude/scripts/ingest-hook.sh
- uv run ruff check codemem tests
- uv run pytest tests/test_claude_integration_cmds.py tests/test_claude_hooks.py tests/test_viewer_routes_raw_events.py tests/test_claude_integration_status_cmd.py

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced