### PR TITLE
chore(release): bump version to 0.16.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.16.1"
+    "version": "0.16.2"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -13,7 +13,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.16.1";
+const PINNED_BACKEND_VERSION = "0.16.2";
 const DEFAULT_UVX_SOURCE = `codemem==${PINNED_BACKEND_VERSION}`;
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();

--- a/codemem/__init__.py
+++ b/codemem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.16.1"
+__version__ = "0.16.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kunickiaj/codemem",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "CodeMem plugin for OpenCode",
   "type": "module",
   "main": "index.js",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "author": {
     "name": "Adam Kunicki"
   },
@@ -11,7 +11,7 @@
     "codemem": {
       "command": "uvx",
       "args": [
-        "codemem==0.16.1",
+        "codemem==0.16.2",
         "mcp"
       ]
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = [
 
 [project]
 name = "codemem"
-version = "0.16.1"
+version = "0.16.2"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "codemem"
-version = "0.16.1"
+version = "0.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Description
Bump release version metadata to `0.16.2` across Python package, npm package, and plugin manifests using the release helper so shipped artifacts stay aligned.

Also refresh `uv.lock` for the new local package version before cutting the release stack merge.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `uv run python scripts/release_version.py set 0.16.2`
- `uv run python scripts/release_version.py check`
- `uv sync`
- `bun install && bun run build` (in `viewer_ui/`)
- `uv run ruff check codemem tests`
- `uv run pytest`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced