### PR TITLE
accept session stream aliases on raw-event boundaries

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -575,7 +575,7 @@ def raw_events_status(
     db_path: str = typer.Option(None, help="Path to SQLite database"),
     limit: int = typer.Option(25, help="Max sessions to show"),
 ) -> None:
-    """Show pending raw-event backlog by OpenCode session."""
+    """Show pending raw-event backlog by source stream."""
 
     store = _store(db_path)
     try:
@@ -612,7 +612,7 @@ def raw_events_retry(
     source: str = typer.Option("opencode", help="Adapter source for the stream"),
     limit: int = typer.Option(5, help="Max error batches to retry"),
 ) -> None:
-    """Retry error raw-event flush batches for a session."""
+    """Retry error raw-event flush batches for a source stream."""
 
     store = _store(db_path)
     try:

--- a/codemem/commands/raw_events_cmds.py
+++ b/codemem/commands/raw_events_cmds.py
@@ -10,6 +10,13 @@ from rich import print
 from codemem.ingest_sanitize import _strip_private_obj
 from codemem.store import MemoryStore
 
+SESSION_ID_KEYS = (
+    "session_stream_id",
+    "session_id",
+    "stream_id",
+    "opencode_session_id",
+)
+
 
 def _coerce_optional_str(payload: dict[str, Any], key: str) -> str | None:
     value = payload.get(key)
@@ -55,6 +62,33 @@ def _coerce_optional_float(payload: dict[str, Any], key: str) -> float | None:
         raise ValueError(f"{key} must be number") from exc
 
 
+def _resolve_session_stream_id(payload: dict[str, Any], *, required: bool) -> str | None:
+    values: dict[str, str] = {}
+    for key in SESSION_ID_KEYS:
+        if key not in payload:
+            continue
+        value = payload.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise ValueError(f"{key} must be string")
+        text = value.strip()
+        if text:
+            values[key] = text
+
+    if values:
+        unique = set(values.values())
+        if len(unique) > 1:
+            raise ValueError("conflicting session id fields")
+        for key in SESSION_ID_KEYS:
+            if key in values:
+                return values[key]
+
+    if required:
+        raise ValueError("session id required")
+    return None
+
+
 def enqueue_raw_event_cmd(store: MemoryStore) -> None:
     """Read one raw event from stdin and enqueue it."""
 
@@ -70,7 +104,8 @@ def enqueue_raw_event_cmd(store: MemoryStore) -> None:
         raise typer.BadParameter("payload must be an object")
 
     try:
-        opencode_session_id = _require_non_empty_str(payload, "opencode_session_id")
+        opencode_session_id = _resolve_session_stream_id(payload, required=True)
+        assert opencode_session_id is not None
         source = _coerce_optional_str(payload, "source") or "opencode"
         event_type = _require_non_empty_str(payload, "event_type")
         event_payload = payload.get("payload")
@@ -147,7 +182,7 @@ def flush_raw_events_cmd(
 
 
 def raw_events_status_cmd(store: MemoryStore, *, limit: int) -> None:
-    """Show pending raw-event backlog by OpenCode session."""
+    """Show pending raw-event backlog by source stream."""
 
     items = store.raw_event_backlog(limit=limit)
     if not items:

--- a/codemem/viewer_routes/raw_events.py
+++ b/codemem/viewer_routes/raw_events.py
@@ -23,6 +23,12 @@ def _safe_int_env(name: str, default: int) -> int:
 
 MAX_RAW_EVENTS_BODY_BYTES = _safe_int_env("CODEMEM_RAW_EVENTS_MAX_BODY_BYTES", 1048576)
 logger = logging.getLogger(__name__)
+SESSION_ID_KEYS = (
+    "session_stream_id",
+    "session_id",
+    "stream_id",
+    "opencode_session_id",
+)
 
 
 class _ViewerHandler(Protocol):
@@ -129,6 +135,30 @@ def _read_payload_object(handler: _ViewerHandler) -> dict[str, Any] | None:
         handler._send_json({"error": "payload must be an object"}, status=400)
         return None
     return payload
+
+
+def _resolve_session_stream_id(payload: dict[str, Any]) -> str | None:
+    values: dict[str, str] = {}
+    for key in SESSION_ID_KEYS:
+        if key not in payload:
+            continue
+        value = payload.get(key)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise ValueError(f"{key} must be string")
+        text = value.strip()
+        if text:
+            values[key] = text
+
+    if values:
+        unique = set(values.values())
+        if len(unique) > 1:
+            raise ValueError("conflicting session id fields")
+        for key in SESSION_ID_KEYS:
+            if key in values:
+                return values[key]
+    return None
 
 
 def _handle_post_claude_hooks(
@@ -257,9 +287,13 @@ def handle_post(
             handler._send_json({"error": "events must be a list"}, status=400)
             return True
 
-        default_session_id = str(payload.get("opencode_session_id") or "")
+        try:
+            default_session_id = _resolve_session_stream_id(payload) or ""
+        except ValueError as exc:
+            handler._send_json({"error": str(exc)}, status=400)
+            return True
         if default_session_id.startswith("msg_"):
-            handler._send_json({"error": "invalid opencode_session_id"}, status=400)
+            handler._send_json({"error": "invalid session id"}, status=400)
             return True
 
         inserted = 0
@@ -272,12 +306,17 @@ def handle_post(
             if not isinstance(item, dict):
                 handler._send_json({"error": "event must be an object"}, status=400)
                 return True
-            opencode_session_id = str(item.get("opencode_session_id") or default_session_id or "")
+            try:
+                item_session_id = _resolve_session_stream_id(item)
+            except ValueError as exc:
+                handler._send_json({"error": str(exc)}, status=400)
+                return True
+            opencode_session_id = str(item_session_id or default_session_id or "")
             if not opencode_session_id:
-                handler._send_json({"error": "opencode_session_id required"}, status=400)
+                handler._send_json({"error": "session id required"}, status=400)
                 return True
             if opencode_session_id.startswith("msg_"):
-                handler._send_json({"error": "invalid opencode_session_id"}, status=400)
+                handler._send_json({"error": "invalid session id"}, status=400)
                 return True
             event_id = str(item.get("event_id") or "")
             event_type = str(item.get("event_type") or "")

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -202,10 +202,10 @@ To monitor backlog:
 codemem raw-events-status
 ```
 
-If `raw-events-status` shows `batches=error:N` (legacy label) or `queue=... failed:N` for a session, retry:
+If `raw-events-status` shows `batches=error:N` (legacy label) or `queue=... failed:N` for a stream, retry:
 
 ```bash
-codemem raw-events-retry <opencode_session_id>
+codemem raw-events-retry <session_stream_id>
 ```
 
 ## Hook lifecycle and flush boundaries

--- a/tests/test_raw_events_enqueue_cmd.py
+++ b/tests/test_raw_events_enqueue_cmd.py
@@ -53,6 +53,50 @@ def test_enqueue_raw_event_cmd_writes_event_and_meta(tmp_path: Path) -> None:
         store.close()
 
 
+def test_enqueue_raw_event_cmd_accepts_session_stream_id_alias(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    payload = {
+        "session_stream_id": "sess-stream-alias",
+        "event_id": "evt-1",
+        "event_type": "assistant_message",
+        "payload": {"type": "assistant_message", "assistant_text": "done"},
+    }
+
+    result = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(payload),
+    )
+
+    assert result.exit_code == 0
+    store = MemoryStore(db_path)
+    try:
+        events = store.raw_events_since(opencode_session_id="sess-stream-alias", after_event_seq=-1)
+        assert len(events) == 1
+    finally:
+        store.close()
+
+
+def test_enqueue_raw_event_cmd_rejects_conflicting_session_id_fields(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    payload = {
+        "session_stream_id": "sess-a",
+        "opencode_session_id": "sess-b",
+        "event_id": "evt-1",
+        "event_type": "assistant_message",
+        "payload": {"type": "assistant_message", "assistant_text": "done"},
+    }
+
+    result = runner.invoke(
+        app,
+        ["enqueue-raw-event", "--db-path", str(db_path)],
+        input=json.dumps(payload),
+    )
+
+    assert result.exit_code != 0
+    assert "conflicting session id fields" in result.output
+
+
 def test_enqueue_raw_event_cmd_rejects_empty_stdin(tmp_path: Path) -> None:
     db_path = tmp_path / "mem.sqlite"
     result = runner.invoke(app, ["enqueue-raw-event", "--db-path", str(db_path)], input="\n")

--- a/tests/test_viewer_routes_raw_events.py
+++ b/tests/test_viewer_routes_raw_events.py
@@ -174,6 +174,59 @@ def test_handle_post_accepts_payload_within_size_limit(monkeypatch) -> None:
     assert flusher.noted == ["sess-1"]
 
 
+def test_handle_post_accepts_session_stream_id_alias() -> None:
+    payload = {
+        "session_stream_id": "sess-alias",
+        "event_type": "tool.execute.after",
+        "payload": {"tool": "read"},
+        "ts_wall_ms": 123,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    handler = DummyHandler(body=body, content_length=len(body))
+    flusher = DummyFlusher()
+    store = DummyStore()
+
+    handled = raw_events.handle_post(
+        handler,
+        path="/api/raw-events",
+        store_factory=lambda _db_path: store,
+        default_db_path="/tmp/mem.sqlite",
+        flusher=flusher,
+        strip_private_obj=lambda value: value,
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert handler.response == {"inserted": 1, "received": 1}
+    assert store.recorded_batches[0][0] == "sess-alias"
+
+
+def test_handle_post_rejects_conflicting_session_id_fields() -> None:
+    payload = {
+        "session_stream_id": "sess-a",
+        "opencode_session_id": "sess-b",
+        "event_type": "tool.execute.after",
+        "payload": {"tool": "read"},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    handler = DummyHandler(body=body, content_length=len(body))
+    flusher = DummyFlusher()
+    store = DummyStore()
+
+    handled = raw_events.handle_post(
+        handler,
+        path="/api/raw-events",
+        store_factory=lambda _db_path: store,
+        default_db_path="/tmp/mem.sqlite",
+        flusher=flusher,
+        strip_private_obj=lambda value: value,
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "conflicting session id fields"}
+
+
 def test_handle_post_accepts_session_lifecycle_event_types() -> None:
     events = [
         {


### PR DESCRIPTION
## Description
Adds adapter-neutral session id aliases at raw-event ingestion boundaries. The raw-event CLI and viewer API now accept `session_stream_id`, `session_id`, and `stream_id` in addition to legacy `opencode_session_id`, with conflict validation and updated user-facing wording/docs.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced