### PR TITLE
make observer custom providers codemem-config first

### DIFF
--- a/codemem/config.py
+++ b/codemem/config.py
@@ -14,6 +14,7 @@ CONFIG_ENV_OVERRIDES = {
     "claude_command": "CODEMEM_CLAUDE_COMMAND",
     "observer_provider": "CODEMEM_OBSERVER_PROVIDER",
     "observer_model": "CODEMEM_OBSERVER_MODEL",
+    "observer_base_url": "CODEMEM_OBSERVER_BASE_URL",
     "observer_runtime": "CODEMEM_OBSERVER_RUNTIME",
     "observer_auth_source": "CODEMEM_OBSERVER_AUTH_SOURCE",
     "observer_auth_file": "CODEMEM_OBSERVER_AUTH_FILE",
@@ -189,6 +190,7 @@ class OpencodeMemConfig:
     claude_command: list[str] = field(default_factory=lambda: ["claude"])
     observer_provider: str | None = None
     observer_model: str | None = None
+    observer_base_url: str | None = None
     observer_api_key: str | None = None
     observer_runtime: str = "api_http"
     observer_auth_source: str = "auto"
@@ -475,6 +477,7 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
         cfg.claude_command = parsed_claude_command
     cfg.observer_provider = os.getenv("CODEMEM_OBSERVER_PROVIDER", cfg.observer_provider)
     cfg.observer_model = os.getenv("CODEMEM_OBSERVER_MODEL", cfg.observer_model)
+    cfg.observer_base_url = os.getenv("CODEMEM_OBSERVER_BASE_URL", cfg.observer_base_url)
     cfg.observer_api_key = os.getenv("CODEMEM_OBSERVER_API_KEY", cfg.observer_api_key)
     cfg.observer_runtime = os.getenv("CODEMEM_OBSERVER_RUNTIME", cfg.observer_runtime)
     cfg.observer_auth_source = os.getenv("CODEMEM_OBSERVER_AUTH_SOURCE", cfg.observer_auth_source)

--- a/codemem/observer.py
+++ b/codemem/observer.py
@@ -164,10 +164,9 @@ class ObserverClient:
                 self._claude_command.append(token)
         if not self._claude_command:
             self._claude_command = ["claude"]
-        custom_providers = _list_custom_providers()
-
-        if provider and provider not in {"openai", "anthropic"} | custom_providers:
-            provider = ""
+        custom_providers = set(_list_custom_providers())
+        if provider and provider not in {"openai", "anthropic"}:
+            custom_providers.add(provider)
 
         resolved_provider = provider
         if not resolved_provider:
@@ -209,6 +208,10 @@ class ObserverClient:
         if self.runtime == "claude_sidecar":
             self.model = self._sidecar_model
         self.api_key = cfg.observer_api_key or os.getenv("CODEMEM_OBSERVER_API_KEY")
+        base_url = cfg.observer_base_url
+        self._custom_base_url = (
+            base_url.strip() if isinstance(base_url, str) and base_url.strip() else None
+        )
         self.max_chars = cfg.observer_max_chars
         self.max_tokens = cfg.observer_max_tokens
         self.client: object | None = None
@@ -243,6 +246,8 @@ class ObserverClient:
                 self.provider,
                 self.model,
             )
+            if not base_url and self._custom_base_url:
+                base_url = self._custom_base_url
             if not base_url or not model_id:
                 logger.warning("observer auth: missing custom provider config")
                 return

--- a/codemem/viewer.py
+++ b/codemem/viewer.py
@@ -8,7 +8,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from . import viewer_assets, viewer_raw_events
-from .config import load_config  # noqa: F401
+from .config import load_config
 from .db import DEFAULT_DB_PATH
 from .ingest_sanitize import _strip_private_obj
 from .observer import _load_opencode_config
@@ -43,6 +43,9 @@ def _load_provider_options() -> list[str]:
     providers: list[str] = []
     if isinstance(provider_config, dict):
         providers = [key for key in provider_config if isinstance(key, str) and key]
+    codemem_provider = (load_config().observer_provider or "").strip().lower()
+    if codemem_provider:
+        providers.append(codemem_provider)
     if not providers:
         return list(DEFAULT_PROVIDER_OPTIONS)
     combined = sorted(set(providers) | set(DEFAULT_PROVIDER_OPTIONS))

--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -125,11 +125,11 @@ def handle_post(
         handler._send_json({"error": "config must be an object"}, status=400)
         return True
 
-    allowed_keys = {
+    allowed_keys = (
         "claude_command",
+        "observer_base_url",
         "observer_provider",
         "observer_model",
-        "observer_base_url",
         "observer_runtime",
         "observer_auth_source",
         "observer_auth_file",
@@ -146,7 +146,7 @@ def handle_post(
         "sync_interval_s",
         "sync_mdns",
         "raw_events_sweeper_interval_s",
-    }
+    )
     allowed_providers = set(load_provider_options())
 
     config_path = get_config_path()
@@ -168,10 +168,16 @@ def handle_post(
                 handler._send_json({"error": "observer_provider must be string"}, status=400)
                 return True
             provider = value.strip().lower()
-            base_url_override = updates.get("observer_base_url")
-            provided_base_url = isinstance(base_url_override, str) and bool(
-                base_url_override.strip()
-            )
+            provided_base_url = False
+            if "observer_base_url" in updates:
+                base_url_override = updates.get("observer_base_url")
+                if base_url_override in (None, ""):
+                    provided_base_url = False
+                elif isinstance(base_url_override, str):
+                    provided_base_url = bool(base_url_override.strip())
+                else:
+                    handler._send_json({"error": "observer_base_url must be string"}, status=400)
+                    return True
             saved_base_url = config_data.get("observer_base_url")
             has_saved_base_url = isinstance(saved_base_url, str) and bool(saved_base_url.strip())
             if provider not in allowed_providers and not (provided_base_url or has_saved_base_url):

--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -129,6 +129,7 @@ def handle_post(
         "claude_command",
         "observer_provider",
         "observer_model",
+        "observer_base_url",
         "observer_runtime",
         "observer_auth_source",
         "observer_auth_file",
@@ -167,13 +168,29 @@ def handle_post(
                 handler._send_json({"error": "observer_provider must be string"}, status=400)
                 return True
             provider = value.strip().lower()
-            if provider not in allowed_providers:
+            base_url_override = updates.get("observer_base_url")
+            provided_base_url = isinstance(base_url_override, str) and bool(
+                base_url_override.strip()
+            )
+            saved_base_url = config_data.get("observer_base_url")
+            has_saved_base_url = isinstance(saved_base_url, str) and bool(saved_base_url.strip())
+            if provider not in allowed_providers and not (provided_base_url or has_saved_base_url):
                 handler._send_json(
                     {"error": "observer_provider must match a configured provider"},
                     status=400,
                 )
                 return True
             config_data[key] = provider
+            continue
+        if key == "observer_base_url":
+            if not isinstance(value, str):
+                handler._send_json({"error": "observer_base_url must be string"}, status=400)
+                return True
+            base_url = value.strip()
+            if not base_url:
+                config_data.pop(key, None)
+                continue
+            config_data[key] = base_url
             continue
         if key == "claude_command":
             argv = _as_executable_argv(value)

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -141,12 +141,14 @@ Observer execution in `0.16` supports both API and Claude runtime paths.
 - Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
 - Supported: API keys and gateway tokens codemem can read directly.
 - Custom provider path does not implicitly fall back to OpenCode/IAP env tokens; use provider key, `CODEMEM_OBSERVER_API_KEY`, `file`, or `command`.
+- For codemem-native custom providers, set `observer_base_url` (or `CODEMEM_OBSERVER_BASE_URL`) to avoid relying on OpenCode provider config.
 
 For command-refreshed gateway auth, configure a command token source plus templated headers:
 
 ```json
 {
   "observer_provider": "your-gateway-provider",
+  "observer_base_url": "https://gateway.example/v1",
   "observer_runtime": "api_http",
   "observer_auth_source": "command",
   "observer_auth_command": ["iap-auth", "--audience", "example"],

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -17,7 +17,7 @@
 - Persists only changed settings on save (unchanged effective defaults are not rewritten to config).
 - Uses task-oriented sections: `Connection`, `Processing`, and `Device Sync`.
 - Includes a `Show advanced controls` toggle for technical tuning fields (JSON headers, cache/timeout, network overrides, and pack limits).
-- Connection/auth settings map to `claude_command`, `observer_runtime`, `observer_provider`, `observer_model`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, and `observer_headers`.
+- Connection/auth settings map to `claude_command`, `observer_runtime`, `observer_provider`, `observer_model`, `observer_base_url`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, and `observer_headers`.
 - Sync settings can also be updated here (`sync_enabled`, `sync_host`, `sync_port`, `sync_interval_s`, `sync_mdns`).
 - Environment variables still override file values.
 - Config file supports JSON and JSONC (`~/.config/codemem/config.json` or `~/.config/codemem/config.jsonc`).
@@ -45,6 +45,7 @@ Example command-token gateway config:
 ```json
 {
   "observer_provider": "your-gateway-provider",
+  "observer_base_url": "https://gateway.example/v1",
   "observer_runtime": "api_http",
   "observer_auth_source": "command",
   "observer_auth_command": ["iap-auth", "--audience", "example"],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -143,10 +143,12 @@ def test_load_config_warns_and_uses_defaults_on_invalid_json(tmp_path: Path) -> 
 def test_get_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CODEMEM_OBSERVER_PROVIDER", "anthropic")
     monkeypatch.setenv("CODEMEM_OBSERVER_MODEL", "claude-4.5-haiku")
+    monkeypatch.setenv("CODEMEM_OBSERVER_BASE_URL", "https://gateway.example/v1")
     monkeypatch.setenv("CODEMEM_CLAUDE_COMMAND", '["wrapper", "claude", "--"]')
     overrides = get_env_overrides()
     assert overrides["observer_provider"] == "anthropic"
     assert overrides["observer_model"] == "claude-4.5-haiku"
+    assert overrides["observer_base_url"] == "https://gateway.example/v1"
     assert overrides["claude_command"] == '["wrapper", "claude", "--"]'
 
 
@@ -303,6 +305,19 @@ def test_load_config_reads_observer_auth_fields(tmp_path: Path) -> None:
     assert cfg.observer_auth_timeout_ms == 2500
     assert cfg.observer_auth_cache_ttl_s == 120
     assert cfg.observer_headers["Authorization"] == "Bearer ${auth.token}"
+
+
+def test_load_config_reads_observer_base_url_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_OBSERVER_BASE_URL", "https://gateway.example/v1")
+
+    cfg = load_config(config_path)
+
+    assert cfg.observer_base_url == "https://gateway.example/v1"
 
 
 def test_load_config_parses_observer_auth_command_from_env(

--- a/tests/test_observer_auth.py
+++ b/tests/test_observer_auth.py
@@ -367,6 +367,32 @@ def test_custom_provider_none_auth_source_does_not_use_api_key() -> None:
     assert client.auth.source == "none"
 
 
+def test_custom_provider_uses_codemem_base_url_without_opencode_provider_config() -> None:
+    cfg = OpencodeMemConfig(
+        observer_provider="gateway",
+        observer_model="gateway/gateway-model",
+        observer_base_url="https://gateway.example/v1",
+        observer_api_key="cfg-key",
+    )
+    openai_module = SimpleNamespace(OpenAI=OpenAIStub)
+    with (
+        patch("codemem.observer.load_config", return_value=cfg),
+        patch("codemem.observer._load_opencode_oauth_cache", return_value={}),
+        patch("codemem.observer._list_custom_providers", return_value=set()),
+        patch("codemem.observer._get_opencode_provider_config", return_value={}),
+        patch("codemem.observer._get_provider_api_key", return_value=None),
+        patch.dict(sys.modules, {"openai": openai_module}),
+    ):
+        from codemem.observer import ObserverClient
+
+        client = ObserverClient()
+
+    assert isinstance(client.client, OpenAIStub)
+    assert client.client.kwargs["base_url"] == "https://gateway.example/v1"
+    assert client.model == "gateway-model"
+    assert client.auth.token == "cfg-key"
+
+
 def test_observer_retries_auth_resolution_when_client_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_viewer_routes_config.py
+++ b/tests/test_viewer_routes_config.py
@@ -247,6 +247,39 @@ def test_config_route_rejects_unknown_provider_without_observer_base_url(
     assert handler.response == {"error": "observer_provider must match a configured provider"}
 
 
+def test_config_route_rejects_unknown_provider_when_base_url_cleared_in_same_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "observer_provider": "gateway",
+                "observer_base_url": "https://gateway.example/v1",
+            }
+        )
+        + "\n"
+    )
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler(
+        {
+            "observer_provider": "another-gateway",
+            "observer_base_url": "",
+        }
+    )
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "observer_provider must match a configured provider"}
+
+
 def test_config_route_rejects_invalid_raw_events_sweeper_interval(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_viewer_routes_config.py
+++ b/tests/test_viewer_routes_config.py
@@ -200,6 +200,53 @@ def test_config_route_rejects_invalid_observer_headers(
     assert handler.response == {"error": "observer_headers must be object of string values"}
 
 
+def test_config_route_accepts_custom_provider_with_observer_base_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler(
+        {
+            "observer_provider": "gateway",
+            "observer_base_url": "https://gateway.example/v1",
+        }
+    )
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    saved = read_config_file(config_path)
+    assert saved["observer_provider"] == "gateway"
+    assert saved["observer_base_url"] == "https://gateway.example/v1"
+
+
+def test_config_route_rejects_unknown_provider_without_observer_base_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler({"observer_provider": "gateway"})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "observer_provider must match a configured provider"}
+
+
 def test_config_route_rejects_invalid_raw_events_sweeper_interval(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Description
Makes custom observer providers codemem-config-first by adding `observer_base_url` / `CODEMEM_OBSERVER_BASE_URL` as a native configuration path, while keeping OpenCode provider config as fallback. Also updates viewer config validation/provider options and docs so custom providers can be configured without implicit dependency on OpenCode config files.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced