### PR TITLE
add adapter-neutral session aliases in API envelopes

### DIFF
--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -265,6 +265,8 @@ const buildRawEventEnvelope = ({
   nowMono,
   nextEventId,
 }) => ({
+  session_stream_id: sessionID,
+  session_id: sessionID,
   opencode_session_id: sessionID,
   event_id: selectRawEventId({ payload, nextEventId }),
   event_type: type,

--- a/.opencode/tests/plugin-adapter.test.js
+++ b/.opencode/tests/plugin-adapter.test.js
@@ -138,6 +138,8 @@ describe("opencode adapter event mapping", () => {
     });
 
     expect(envelope.event_id).toBe("generated-id");
+    expect(envelope.session_stream_id).toBe("sess-5");
+    expect(envelope.session_id).toBe("sess-5");
     expect(envelope.opencode_session_id).toBe("sess-5");
     expect(envelope.event_type).toBe("assistant_message");
   });

--- a/codemem/claude_hooks.py
+++ b/codemem/claude_hooks.py
@@ -410,6 +410,8 @@ def build_ingest_payload_from_hook(hook_payload: dict[str, Any]) -> dict[str, An
         "session_context": {
             "source": "claude",
             "stream_id": session_id,
+            "session_stream_id": session_id,
+            "session_id": session_id,
             "opencode_session_id": session_id,
         },
     }
@@ -434,6 +436,8 @@ def build_raw_event_envelope_from_hook(hook_payload: dict[str, Any]) -> dict[str
     project = _resolve_hook_project(cwd=cwd, payload_project=hook_payload.get("project"))
 
     return {
+        "session_stream_id": session_id,
+        "session_id": session_id,
         "opencode_session_id": session_id,
         "source": source,
         "event_id": str(adapter_event.get("event_id") or ""),

--- a/codemem/viewer_routes/raw_events.py
+++ b/codemem/viewer_routes/raw_events.py
@@ -31,6 +31,18 @@ SESSION_ID_KEYS = (
 )
 
 
+def _with_session_aliases(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for item in items:
+        stream_id = str(item.get("stream_id") or item.get("opencode_session_id") or "")
+        entry = dict(item)
+        if stream_id:
+            entry["session_stream_id"] = stream_id
+            entry["session_id"] = stream_id
+        normalized.append(entry)
+    return normalized
+
+
 class _ViewerHandler(Protocol):
     headers: Any
     rfile: Any
@@ -91,7 +103,7 @@ def handle_get(handler: Any, store: Any, path: str, query: str) -> bool:
             return True
         handler._send_json(
             {
-                "items": store.raw_event_backlog(limit=limit),
+                "items": _with_session_aliases(store.raw_event_backlog(limit=limit)),
                 "totals": store.raw_event_backlog_totals(),
                 "ingest": {
                     "available": True,

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -74,6 +74,8 @@ def test_build_ingest_payload_wraps_adapter_event() -> None:
     assert ingest_payload is not None
     assert ingest_payload["session_context"]["source"] == "claude"
     assert ingest_payload["session_context"]["stream_id"] == "sess-xyz"
+    assert ingest_payload["session_context"]["session_stream_id"] == "sess-xyz"
+    assert ingest_payload["session_context"]["session_id"] == "sess-xyz"
     assert ingest_payload["session_context"]["opencode_session_id"] == "sess-xyz"
     event = ingest_payload["events"][0]
     assert event["_adapter"]["event_type"] == "session_start"
@@ -179,6 +181,8 @@ def test_build_raw_event_envelope_from_hook_includes_queue_fields() -> None:
     envelope = build_raw_event_envelope_from_hook(payload)
 
     assert envelope is not None
+    assert envelope["session_stream_id"] == "sess-enqueue"
+    assert envelope["session_id"] == "sess-enqueue"
     assert envelope["opencode_session_id"] == "sess-enqueue"
     assert envelope["source"] == "claude"
     assert envelope["event_type"] == "claude.hook"

--- a/tests/test_viewer_routes_raw_events.py
+++ b/tests/test_viewer_routes_raw_events.py
@@ -490,7 +490,14 @@ def test_handle_get_raw_events_status_returns_items_and_totals() -> None:
     assert handled is True
     assert handler.status == 200
     assert handler.response == {
-        "items": [{"opencode_session_id": "sess", "pending": 7}],
+        "items": [
+            {
+                "opencode_session_id": "sess",
+                "session_stream_id": "sess",
+                "session_id": "sess",
+                "pending": 7,
+            }
+        ],
         "totals": {"sessions": 1, "pending": 7},
         "ingest": {
             "available": True,


### PR DESCRIPTION
## Description
Adds adapter-neutral session aliases (`session_stream_id` and `session_id`) in user-facing raw-event/API envelopes while preserving legacy `opencode_session_id`. This normalizes response payloads and producer envelopes without breaking existing integrations.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced