### PR TITLE
fix Claude project inference when cwd is missing

### DIFF
--- a/codemem/claude_hooks.py
+++ b/codemem/claude_hooks.py
@@ -82,6 +82,8 @@ def _infer_project_from_cwd(cwd: str | None) -> str | None:
         path = Path(text).expanduser()
     except Exception:
         return None
+    if not path.is_absolute():
+        return None
     try:
         if not path.is_dir():
             return None
@@ -123,7 +125,7 @@ def _resolve_hook_project(*, cwd: str | None, payload_project: Any) -> str | Non
     return None
 
 
-def _infer_project_from_path_hint(path_hint: Any) -> str | None:
+def _infer_project_from_path_hint(path_hint: Any, *, cwd_hint: str | None = None) -> str | None:
     if not isinstance(path_hint, str):
         return None
     text = path_hint.strip()
@@ -133,6 +135,22 @@ def _infer_project_from_path_hint(path_hint: Any) -> str | None:
         candidate = Path(text).expanduser()
     except Exception:
         return None
+
+    if not candidate.is_absolute():
+        if not isinstance(cwd_hint, str) or not cwd_hint.strip():
+            return None
+        try:
+            base = Path(cwd_hint).expanduser()
+        except Exception:
+            return None
+        if not base.is_absolute():
+            return None
+        try:
+            if not base.is_dir():
+                return None
+        except OSError:
+            return None
+        candidate = base / candidate
 
     current = candidate if candidate.is_dir() else candidate.parent
     if not current:
@@ -147,14 +165,15 @@ def _infer_project_from_path_hint(path_hint: Any) -> str | None:
 
 
 def _resolve_hook_project_from_payload_paths(hook_payload: dict[str, Any]) -> str | None:
+    cwd_hint = hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None
     tool_input = hook_payload.get("tool_input")
     if isinstance(tool_input, dict):
         for key in ("filePath", "file_path", "path"):
-            project = _infer_project_from_path_hint(tool_input.get(key))
+            project = _infer_project_from_path_hint(tool_input.get(key), cwd_hint=cwd_hint)
             if project:
                 return project
 
-    project = _infer_project_from_path_hint(hook_payload.get("transcript_path"))
+    project = _infer_project_from_path_hint(hook_payload.get("transcript_path"), cwd_hint=cwd_hint)
     if project:
         return project
     return None
@@ -206,10 +225,24 @@ def _text_from_content(value: Any) -> str:
     return ""
 
 
-def _extract_from_transcript(transcript_path: Any) -> tuple[str | None, dict[str, int] | None]:
+def _extract_from_transcript(
+    transcript_path: Any, *, cwd_hint: str | None = None
+) -> tuple[str | None, dict[str, int] | None]:
     if not isinstance(transcript_path, str):
         return None, None
     path = Path(transcript_path).expanduser()
+    if not path.is_absolute():
+        if not isinstance(cwd_hint, str) or not cwd_hint.strip():
+            return None, None
+        base = Path(cwd_hint).expanduser()
+        if not base.is_absolute():
+            return None, None
+        try:
+            if not base.is_dir():
+                return None, None
+        except OSError:
+            return None, None
+        path = base / path
     if not path.exists() or not path.is_file():
         return None, None
 
@@ -364,7 +397,8 @@ def map_claude_hook_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
         usage = raw_usage
         if not assistant_text or usage is None:
             transcript_text, transcript_usage = _extract_from_transcript(
-                payload.get("transcript_path")
+                payload.get("transcript_path"),
+                cwd_hint=payload.get("cwd") if isinstance(payload.get("cwd"), str) else None,
             )
             if not assistant_text and transcript_text:
                 assistant_text = transcript_text

--- a/codemem/claude_hooks.py
+++ b/codemem/claude_hooks.py
@@ -123,6 +123,43 @@ def _resolve_hook_project(*, cwd: str | None, payload_project: Any) -> str | Non
     return None
 
 
+def _infer_project_from_path_hint(path_hint: Any) -> str | None:
+    if not isinstance(path_hint, str):
+        return None
+    text = path_hint.strip()
+    if not text:
+        return None
+    try:
+        candidate = Path(text).expanduser()
+    except Exception:
+        return None
+
+    current = candidate if candidate.is_dir() else candidate.parent
+    if not current:
+        return None
+
+    while not current.exists() and current.parent != current:
+        current = current.parent
+
+    if not current.exists():
+        return None
+    return _infer_project_from_cwd(str(current))
+
+
+def _resolve_hook_project_from_payload_paths(hook_payload: dict[str, Any]) -> str | None:
+    tool_input = hook_payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("filePath", "file_path", "path"):
+            project = _infer_project_from_path_hint(tool_input.get(key))
+            if project:
+                return project
+
+    project = _infer_project_from_path_hint(hook_payload.get("transcript_path"))
+    if project:
+        return project
+    return None
+
+
 def _iso_to_wall_ms(value: str) -> int:
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if parsed.tzinfo is None:
@@ -434,6 +471,8 @@ def build_raw_event_envelope_from_hook(hook_payload: dict[str, Any]) -> dict[str
     hook_event_name = str(hook_payload.get("hook_event_name") or "")
     cwd = hook_payload.get("cwd") if isinstance(hook_payload.get("cwd"), str) else None
     project = _resolve_hook_project(cwd=cwd, payload_project=hook_payload.get("project"))
+    if project is None:
+        project = _resolve_hook_project_from_payload_paths(hook_payload)
 
     return {
         "session_stream_id": session_id,

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -288,6 +288,56 @@ def test_build_raw_event_envelope_invalid_cwd_falls_back_to_payload_project(monk
     assert envelope["project"] == "payload-project"
 
 
+def test_build_raw_event_envelope_relative_cwd_falls_back_to_payload_project(
+    tmp_path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "codemem"
+    repo_root.mkdir()
+    (repo_root / ".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "sess-relative-cwd",
+        "prompt": "ship it",
+        "cwd": "codemem",
+        "project": "payload-project",
+        "ts": "2026-03-04T01:00:00Z",
+    }
+    monkeypatch.delenv("CODEMEM_PROJECT", raising=False)
+
+    envelope = build_raw_event_envelope_from_hook(payload)
+
+    assert envelope is not None
+    assert envelope["project"] == "payload-project"
+
+
+def test_build_raw_event_envelope_relative_cwd_and_relative_tool_path_fall_back_to_payload_project(
+    tmp_path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "codemem"
+    repo_root.mkdir()
+    (repo_root / ".git").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "session_id": "sess-relative-cwd-relative-tool-path",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": "src/feature.py"},
+        "tool_response": {"ok": True},
+        "cwd": "codemem",
+        "project": "payload-project",
+        "ts": "2026-03-04T01:00:00Z",
+    }
+    monkeypatch.delenv("CODEMEM_PROJECT", raising=False)
+
+    envelope = build_raw_event_envelope_from_hook(payload)
+
+    assert envelope is not None
+    assert envelope["project"] == "payload-project"
+
+
 def test_build_raw_event_envelope_infers_project_from_tool_input_path(
     tmp_path, monkeypatch
 ) -> None:
@@ -314,6 +364,80 @@ def test_build_raw_event_envelope_infers_project_from_tool_input_path(
     assert envelope["project"] == "greenroom"
 
 
+def test_build_raw_event_envelope_infers_project_from_relative_tool_input_path_with_cwd(
+    tmp_path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "greenroom"
+    repo_root.mkdir()
+    (repo_root / ".git").mkdir()
+    target_file = repo_root / "src" / "feature.py"
+    target_file.parent.mkdir()
+    target_file.write_text("print('ok')\n", encoding="utf-8")
+
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "session_id": "sess-relative-tool-path-project",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": "src/feature.py"},
+        "tool_response": {"ok": True},
+        "cwd": str(repo_root),
+        "ts": "2026-03-04T01:00:00Z",
+    }
+    monkeypatch.delenv("CODEMEM_PROJECT", raising=False)
+
+    envelope = build_raw_event_envelope_from_hook(payload)
+
+    assert envelope is not None
+    assert envelope["project"] == "greenroom"
+
+
+def test_build_raw_event_envelope_does_not_infer_project_from_relative_tool_input_path_without_cwd(
+    tmp_path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "greenroom"
+    repo_root.mkdir()
+    (repo_root / ".git").mkdir()
+    target_file = repo_root / "src" / "feature.py"
+    target_file.parent.mkdir()
+    target_file.write_text("print('ok')\n", encoding="utf-8")
+
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "session_id": "sess-relative-tool-path-no-cwd",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": "src/feature.py"},
+        "tool_response": {"ok": True},
+        "ts": "2026-03-04T01:00:00Z",
+    }
+    monkeypatch.delenv("CODEMEM_PROJECT", raising=False)
+    monkeypatch.chdir(repo_root)
+
+    envelope = build_raw_event_envelope_from_hook(payload)
+
+    assert envelope is not None
+    assert envelope["project"] is None
+
+
+def test_build_raw_event_envelope_does_not_infer_project_from_relative_tool_input_path_with_invalid_absolute_cwd(
+    monkeypatch,
+) -> None:
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "session_id": "sess-relative-tool-path-invalid-cwd",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": "src/feature.py"},
+        "tool_response": {"ok": True},
+        "cwd": "/tmp/does-not-exist/codemem",
+        "ts": "2026-03-04T01:00:00Z",
+    }
+    monkeypatch.delenv("CODEMEM_PROJECT", raising=False)
+
+    envelope = build_raw_event_envelope_from_hook(payload)
+
+    assert envelope is not None
+    assert envelope["project"] is None
+
+
 def test_map_stop_hook_uses_transcript_fallback_for_assistant_text(tmp_path) -> None:
     transcript_path = tmp_path / "transcript.jsonl"
     transcript_path.write_text(
@@ -332,6 +456,67 @@ def test_map_stop_hook_uses_transcript_fallback_for_assistant_text(tmp_path) -> 
     assert event is not None
     assert event["event_type"] == "assistant"
     assert event["payload"]["text"] == "assistant from transcript"
+
+
+def test_map_stop_hook_uses_relative_transcript_path_with_cwd(tmp_path) -> None:
+    repo_root = tmp_path / "greenroom"
+    repo_root.mkdir()
+    transcript_path = repo_root / "transcript.jsonl"
+    transcript_path.write_text(
+        '{"message":{"role":"assistant","content":"assistant from transcript"}}\n',
+        encoding="utf-8",
+    )
+
+    payload = {
+        "hook_event_name": "Stop",
+        "session_id": "sess-stop-relative-transcript",
+        "last_assistant_message": "",
+        "transcript_path": "transcript.jsonl",
+        "cwd": str(repo_root),
+    }
+
+    event = map_claude_hook_payload(payload)
+
+    assert event is not None
+    assert event["payload"]["text"] == "assistant from transcript"
+
+
+def test_map_stop_hook_does_not_use_relative_transcript_path_without_cwd(
+    tmp_path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "greenroom"
+    repo_root.mkdir()
+    transcript_path = repo_root / "transcript.jsonl"
+    transcript_path.write_text(
+        '{"message":{"role":"assistant","content":"assistant from transcript"}}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(repo_root)
+
+    payload = {
+        "hook_event_name": "Stop",
+        "session_id": "sess-stop-relative-transcript-no-cwd",
+        "last_assistant_message": "",
+        "transcript_path": "transcript.jsonl",
+    }
+
+    event = map_claude_hook_payload(payload)
+
+    assert event is None
+
+
+def test_map_stop_hook_does_not_use_relative_transcript_path_with_invalid_absolute_cwd() -> None:
+    payload = {
+        "hook_event_name": "Stop",
+        "session_id": "sess-stop-relative-transcript-invalid-cwd",
+        "last_assistant_message": "",
+        "transcript_path": "transcript.jsonl",
+        "cwd": "/tmp/does-not-exist/codemem",
+    }
+
+    event = map_claude_hook_payload(payload)
+
+    assert event is None
 
 
 def test_map_stop_hook_includes_usage_from_hook_payload() -> None:

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -288,6 +288,32 @@ def test_build_raw_event_envelope_invalid_cwd_falls_back_to_payload_project(monk
     assert envelope["project"] == "payload-project"
 
 
+def test_build_raw_event_envelope_infers_project_from_tool_input_path(
+    tmp_path, monkeypatch
+) -> None:
+    repo_root = tmp_path / "greenroom"
+    repo_root.mkdir()
+    (repo_root / ".git").mkdir()
+    target_file = repo_root / "src" / "feature.py"
+    target_file.parent.mkdir()
+    target_file.write_text("print('ok')\n", encoding="utf-8")
+
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "session_id": "sess-tool-path-project",
+        "tool_name": "Edit",
+        "tool_input": {"filePath": str(target_file)},
+        "tool_response": {"ok": True},
+        "ts": "2026-03-04T01:00:00Z",
+    }
+    monkeypatch.delenv("CODEMEM_PROJECT", raising=False)
+
+    envelope = build_raw_event_envelope_from_hook(payload)
+
+    assert envelope is not None
+    assert envelope["project"] == "greenroom"
+
+
 def test_map_stop_hook_uses_transcript_fallback_for_assistant_text(tmp_path) -> None:
     transcript_path = tmp_path / "transcript.jsonl"
     transcript_path.write_text(


### PR DESCRIPTION
## Description
Fixes missing Claude project labels when hook payloads do not include `cwd` or `project`. Raw-event envelope building now falls back to inferring project from path hints in hook payloads (`tool_input.filePath/file_path/path` and `transcript_path`) so Claude streams get project metadata more consistently.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced