### PR TITLE
feat(settings): hot-reload viewer config and auto-apply sync changes

### DIFF
--- a/codemem/plugin_ingest.py
+++ b/codemem/plugin_ingest.py
@@ -118,6 +118,12 @@ def _get_config() -> Any:
     return CONFIG
 
 
+def invalidate_runtime_state() -> None:
+    global CONFIG, OBSERVER
+    CONFIG = None
+    OBSERVER = None
+
+
 def _normalize_tool_name(event: dict[str, Any]) -> str:
     return _normalize_tool_name_impl(event)
 

--- a/codemem/viewer_raw_events.py
+++ b/codemem/viewer_raw_events.py
@@ -97,6 +97,7 @@ class RawEventSweeper:
     def __init__(self) -> None:
         self._thread: threading.Thread | None = None
         self._stop = threading.Event()
+        self._wake = threading.Event()
         self._auth_backoff_until: float = 0.0  # epoch ms; skip flushes until this time
         self._auth_error_logged: bool = False
 
@@ -277,9 +278,23 @@ class RawEventSweeper:
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
+    def notify_config_changed(self) -> None:
+        self._wake.set()
+
+    def reset_auth_backoff(self) -> None:
+        self._auth_backoff_until = 0.0
+        self._auth_error_logged = False
+        self._wake.set()
+
     def _run(self) -> None:
-        interval_ms = max(1000, self.interval_ms())
-        while not self._stop.wait(interval_ms / 1000.0):
+        while not self._stop.is_set():
+            interval_ms = max(1000, self.interval_ms())
+            woke = self._wake.wait(interval_ms / 1000.0)
+            self._wake.clear()
+            if self._stop.is_set():
+                break
+            if woke:
+                continue
             self.tick()
 
 

--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -5,7 +5,9 @@ from collections.abc import Callable
 from dataclasses import asdict
 from typing import Any, Protocol
 
+from ..commands.sync_service_cmds import run_service_action_quiet
 from ..config import (
+    CONFIG_ENV_OVERRIDES,
     OpencodeMemConfig,
     get_config_path,
     get_env_overrides,
@@ -13,6 +15,9 @@ from ..config import (
     read_config_file,
     write_config_file,
 )
+from ..plugin_ingest import invalidate_runtime_state
+from ..sync_runtime import effective_status, spawn_daemon, stop_pidfile_with_reason
+from ..viewer_raw_events import RAW_EVENT_SWEEPER
 
 
 class _ViewerHandler(Protocol):
@@ -24,6 +29,215 @@ class _ViewerHandler(Protocol):
 
 _RUNTIMES = {"api_http", "claude_sidecar"}
 _AUTH_SOURCES = {"auto", "env", "file", "command", "none"}
+_HOT_RELOAD_KEYS = {
+    "claude_command",
+    "observer_base_url",
+    "observer_provider",
+    "observer_model",
+    "observer_runtime",
+    "observer_auth_source",
+    "observer_auth_file",
+    "observer_auth_command",
+    "observer_auth_timeout_ms",
+    "observer_auth_cache_ttl_s",
+    "observer_headers",
+    "observer_max_chars",
+    "raw_events_sweeper_interval_s",
+}
+_LIVE_APPLY_KEYS = {"pack_observation_limit", "pack_session_limit"}
+_SYNC_ACTION_KEYS = {"sync_enabled", "sync_host", "sync_port", "sync_interval_s", "sync_mdns"}
+
+
+def _config_value_changed(before: dict[str, Any], after: dict[str, Any], key: str) -> bool:
+    return before.get(key) != after.get(key)
+
+
+def _effective_value_changed(before: dict[str, Any], after: dict[str, Any], key: str) -> bool:
+    return before.get(key) != after.get(key)
+
+
+def _manual_action(kind: str, command: str, *, label: str, reason: str) -> dict[str, str]:
+    return {
+        "kind": kind,
+        "command": command,
+        "label": label,
+        "reason": reason,
+    }
+
+
+def _build_warning(key: str) -> str:
+    env_var = CONFIG_ENV_OVERRIDES.get(key, "environment")
+    return f"{key} is currently controlled by {env_var}; saved config will not take effect until that override is removed."
+
+
+def _determine_sync_action(
+    *,
+    changed_keys: set[str],
+    before_effective: dict[str, Any],
+    after_effective: dict[str, Any],
+) -> tuple[str | None, str | None]:
+    sync_keys = changed_keys & _SYNC_ACTION_KEYS
+    if not sync_keys:
+        return None, None
+    before_enabled = bool(before_effective.get("sync_enabled"))
+    after_enabled = bool(after_effective.get("sync_enabled"))
+    if "sync_enabled" in sync_keys and not after_enabled:
+        return "stop", "sync was disabled"
+    if "sync_enabled" in sync_keys and after_enabled and not before_enabled:
+        return "start", "sync was enabled"
+    if after_enabled and sync_keys - {"sync_enabled"}:
+        return "restart", "sync runtime settings changed"
+    if not after_enabled and sync_keys - {"sync_enabled"}:
+        return None, "sync settings saved and will apply next time sync starts"
+    return None, None
+
+
+def _sync_start(*, host: str, port: int, interval_s: int) -> tuple[bool, str | None]:
+    if run_service_action_quiet("start", user=True, system=False):
+        status = effective_status(host, port)
+        if status.running:
+            return True, f"sync daemon started ({status.mechanism})"
+    status = effective_status(host, port)
+    if status.running:
+        return True, f"sync daemon already running ({status.mechanism})"
+    try:
+        spawn_daemon(host=host, port=port, interval_s=interval_s, db_path=None)
+    except OSError as exc:
+        return False, f"failed to start sync daemon: {exc}"
+    status = effective_status(host, port)
+    if status.running:
+        return True, f"sync daemon started ({status.mechanism})"
+    return False, "sync daemon start did not result in a running process"
+
+
+def _sync_stop(*, host: str, port: int) -> tuple[bool, str | None]:
+    if run_service_action_quiet("stop", user=True, system=False):
+        status = effective_status(host, port)
+        if not status.running:
+            return True, "sync daemon stopped"
+    result = stop_pidfile_with_reason()
+    if result.stopped or result.reason in {"pidfile_missing", "pid_not_running"}:
+        return True, "sync daemon stopped"
+    status = effective_status(host, port)
+    if not status.running:
+        return True, "sync daemon already stopped"
+    return False, f"failed to stop sync daemon ({result.reason})"
+
+
+def _sync_restart(*, host: str, port: int, interval_s: int) -> tuple[bool, str | None]:
+    if run_service_action_quiet("restart", user=True, system=False):
+        status = effective_status(host, port)
+        if status.running:
+            return True, f"sync daemon restarted ({status.mechanism})"
+    stopped, stop_message = _sync_stop(host=host, port=port)
+    if not stopped:
+        return False, stop_message
+    started, start_message = _sync_start(host=host, port=port, interval_s=interval_s)
+    if not started:
+        return False, start_message
+    return True, start_message or "sync daemon restarted"
+
+
+def _apply_sync_runtime_action(action: str, *, effective_config: dict[str, Any]) -> dict[str, Any]:
+    host = str(effective_config.get("sync_host") or OpencodeMemConfig().sync_host)
+    port = int(effective_config.get("sync_port") or OpencodeMemConfig().sync_port)
+    interval_s = int(effective_config.get("sync_interval_s") or OpencodeMemConfig().sync_interval_s)
+    if action == "start":
+        ok, message = _sync_start(host=host, port=port, interval_s=interval_s)
+    elif action == "stop":
+        ok, message = _sync_stop(host=host, port=port)
+    elif action == "restart":
+        ok, message = _sync_restart(host=host, port=port, interval_s=interval_s)
+    else:
+        return {"attempted": False, "ok": None, "message": None, "manual_action": None}
+    manual_action = None
+    if not ok:
+        manual_action = _manual_action(
+            "sync",
+            f"uv run codemem sync {action}",
+            label=f"Run `codemem sync {action}`",
+            reason=message or f"sync {action} failed",
+        )
+    return {
+        "attempted": True,
+        "ok": ok,
+        "message": message,
+        "manual_action": manual_action,
+    }
+
+
+def _apply_runtime_updates(changed_keys: set[str]) -> list[str]:
+    applied: list[str] = []
+    hot_reload_keys = changed_keys & _HOT_RELOAD_KEYS
+    if hot_reload_keys:
+        invalidate_runtime_state()
+        RAW_EVENT_SWEEPER.reset_auth_backoff()
+        applied.extend(sorted(hot_reload_keys - {"raw_events_sweeper_interval_s"}))
+    if "raw_events_sweeper_interval_s" in hot_reload_keys:
+        RAW_EVENT_SWEEPER.notify_config_changed()
+        applied.append("raw_events_sweeper_interval_s")
+    return applied
+
+
+def _build_effects(
+    *,
+    saved_changed_keys: set[str],
+    effective_changed_keys: set[str],
+    before_effective: dict[str, Any],
+    after_effective: dict[str, Any],
+    env_overrides: dict[str, str],
+) -> dict[str, Any]:
+    ignored_by_env = sorted(
+        key
+        for key in saved_changed_keys
+        if key not in effective_changed_keys and key in env_overrides
+    )
+    warnings = [_build_warning(key) for key in ignored_by_env]
+    hot_reloaded_keys = sorted(effective_changed_keys & _HOT_RELOAD_KEYS)
+    live_applied_keys = sorted(effective_changed_keys & _LIVE_APPLY_KEYS)
+    restart_required_keys: list[str] = []
+    sync_action, sync_reason = _determine_sync_action(
+        changed_keys=effective_changed_keys,
+        before_effective=before_effective,
+        after_effective=after_effective,
+    )
+    sync_effect: dict[str, Any] = {
+        "affected_keys": sorted(effective_changed_keys & _SYNC_ACTION_KEYS),
+        "action": sync_action,
+        "reason": sync_reason,
+        "attempted": False,
+        "ok": None,
+        "message": sync_reason,
+        "manual_action": None,
+    }
+    if sync_action is not None:
+        sync_effect.update(
+            _apply_sync_runtime_action(sync_action, effective_config=after_effective)
+        )
+    manual_actions: list[dict[str, str]] = []
+    manual_action = sync_effect.get("manual_action")
+    if isinstance(manual_action, dict):
+        manual_actions.append(manual_action)
+    if restart_required_keys:
+        manual_actions.append(
+            _manual_action(
+                "viewer_restart",
+                "uv run codemem serve --restart",
+                label="Restart codemem viewer",
+                reason="some settings still require a viewer restart",
+            )
+        )
+    return {
+        "saved_keys": sorted(saved_changed_keys),
+        "effective_keys": sorted(effective_changed_keys),
+        "hot_reloaded_keys": hot_reloaded_keys,
+        "live_applied_keys": live_applied_keys,
+        "restart_required_keys": restart_required_keys,
+        "ignored_by_env_keys": ignored_by_env,
+        "warnings": warnings,
+        "sync": sync_effect,
+        "manual_actions": manual_actions,
+    }
 
 
 def _as_positive_int(value: Any, *, key: str, allow_zero: bool = False) -> int | None:
@@ -155,6 +369,8 @@ def handle_post(
     except ValueError:
         handler._send_json({"error": "config file could not be read"}, status=500)
         return True
+    original_config_data = dict(config_data)
+    before_effective = asdict(load_config(config_path))
 
     for key in allowed_keys:
         if key not in updates:
@@ -351,5 +567,29 @@ def handle_post(
     except OSError:
         handler._send_json({"error": "failed to write config"}, status=500)
         return True
-    handler._send_json({"path": str(config_path), "config": config_data})
+    after_effective = asdict(load_config(config_path))
+    saved_changed_keys = {
+        key for key in allowed_keys if _config_value_changed(original_config_data, config_data, key)
+    }
+    effective_changed_keys = {
+        key
+        for key in allowed_keys
+        if _effective_value_changed(before_effective, after_effective, key)
+    }
+    _apply_runtime_updates(effective_changed_keys)
+    effects = _build_effects(
+        saved_changed_keys=saved_changed_keys,
+        effective_changed_keys=effective_changed_keys,
+        before_effective=before_effective,
+        after_effective=after_effective,
+        env_overrides=get_env_overrides(),
+    )
+    handler._send_json(
+        {
+            "path": str(config_path),
+            "config": config_data,
+            "effective": after_effective,
+            "effects": effects,
+        }
+    )
     return True

--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -116,7 +116,7 @@ def _sync_stop(*, host: str, port: int) -> tuple[bool, str | None]:
         if not status.running:
             return True, "sync daemon stopped"
     result = stop_pidfile_with_reason()
-    if result.stopped or result.reason in {"pidfile_missing", "pid_not_running"}:
+    if result.stopped:
         return True, "sync daemon stopped"
     status = effective_status(host, port)
     if not status.running:

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -134,6 +134,7 @@
     configDefaults: {},
     configPath: "",
     settingsDirty: false,
+    noticeTimer: null,
     /* Sync UI toggles */
     syncDiagnosticsOpen: false,
     syncPairingOpen: false
@@ -225,10 +226,19 @@
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload)
     });
-    if (!resp.ok) {
-      const msg = await resp.text();
-      throw new Error(msg);
+    const text = await resp.text();
+    let parsed = null;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+      }
     }
+    if (!resp.ok) {
+      const message = parsed && typeof parsed.error === "string" ? parsed.error : text || "request failed";
+      throw new Error(message);
+    }
+    return parsed;
   }
   async function loadSyncStatus(includeDiagnostics) {
     const param = "?includeDiagnostics=1";
@@ -1815,6 +1825,78 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   function isSettingsOpen() {
     return settingsOpen;
   }
+  function hideGlobalNotice() {
+    const notice = $("globalNotice");
+    if (!notice) return;
+    hide(notice);
+    notice.textContent = "";
+    notice.classList.remove("success", "warning");
+    if (state.noticeTimer) {
+      clearTimeout(state.noticeTimer);
+      state.noticeTimer = null;
+    }
+  }
+  function showGlobalNotice(message, type = "success") {
+    const notice = $("globalNotice");
+    if (!notice || !message) return;
+    notice.textContent = message;
+    notice.classList.remove("success", "warning");
+    notice.classList.add(type === "warning" ? "warning" : "success");
+    show(notice);
+    if (state.noticeTimer) clearTimeout(state.noticeTimer);
+    state.noticeTimer = setTimeout(() => {
+      hideGlobalNotice();
+    }, 12e3);
+  }
+  function formatSettingsKey(key) {
+    return String(key || "").replace(/_/g, " ");
+  }
+  function joinPhrases(values) {
+    const items = values.filter((value) => typeof value === "string" && value.trim());
+    if (items.length === 0) return "";
+    if (items.length === 1) return items[0];
+    if (items.length === 2) return `${items[0]} and ${items[1]}`;
+    return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+  }
+  function buildSettingsNotice(payload) {
+    const effects = payload?.effects && typeof payload.effects === "object" ? payload.effects : {};
+    const hotReloaded = Array.isArray(effects.hot_reloaded_keys) ? effects.hot_reloaded_keys.map(formatSettingsKey) : [];
+    const liveApplied = Array.isArray(effects.live_applied_keys) ? effects.live_applied_keys.map(formatSettingsKey) : [];
+    const restartRequired = Array.isArray(effects.restart_required_keys) ? effects.restart_required_keys.map(formatSettingsKey) : [];
+    const warnings = Array.isArray(effects.warnings) ? effects.warnings.filter(
+      (value) => typeof value === "string" && value.trim().length > 0
+    ) : [];
+    const manualActions = Array.isArray(effects.manual_actions) ? effects.manual_actions : [];
+    const sync = effects.sync && typeof effects.sync === "object" ? effects.sync : {};
+    const lines = [];
+    if (hotReloaded.length) {
+      lines.push(`Applied now: ${joinPhrases(hotReloaded)}.`);
+    }
+    if (liveApplied.length) {
+      lines.push(`Live settings updated: ${joinPhrases(liveApplied)}.`);
+    }
+    if (sync.attempted && typeof sync.message === "string" && sync.message) {
+      lines.push(`Sync: ${sync.message}.`);
+    } else if (Array.isArray(sync.affected_keys) && sync.affected_keys.length && typeof sync.reason === "string" && sync.reason) {
+      lines.push(`Sync: ${sync.reason}.`);
+    }
+    if (restartRequired.length) {
+      lines.push(`Manual restart required: ${joinPhrases(restartRequired)}.`);
+    }
+    warnings.forEach((warning) => {
+      lines.push(warning);
+    });
+    manualActions.forEach((action) => {
+      if (action && typeof action.command === "string" && action.command.trim()) {
+        lines.push(`If needed: ${action.command}.`);
+      }
+    });
+    if (!lines.length) {
+      lines.push("Saved.");
+    }
+    const hasWarning = restartRequired.length > 0 || warnings.length > 0 || sync.ok === false;
+    return { message: lines.join(" "), type: hasWarning ? "warning" : "success" };
+  }
   function renderConfigModal(payload) {
     if (!payload || typeof payload !== "object") return;
     const defaults = payload.defaults || {};
@@ -2109,10 +2191,12 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         closeSettings(startPolling2, refreshCallback);
         return;
       }
-      await saveConfig(changed);
+      const result = await saveConfig(changed);
+      const notice = buildSettingsNotice(result);
       status.textContent = "Saved";
       setDirty(false);
       closeSettings(startPolling2, refreshCallback);
+      showGlobalNotice(notice.message, notice.type);
     } catch (error) {
       const message = error instanceof Error ? error.message : "unknown error";
       status.textContent = `Save failed: ${message}`;

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -906,6 +906,25 @@
       .modal-close { border: none; background: transparent; color: var(--text-tertiary); cursor: pointer; font-size: 12px; font-family: var(--font-sans); }
       .modal-body { display: flex; flex-direction: column; gap: var(--sp-3); flex: 1; min-height: 0; overflow-y: auto; padding-right: 6px; }
       .modal-footer { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); flex-shrink: 0; padding-top: var(--sp-2); border-top: 1px solid var(--border); }
+      .app-notice {
+        margin: var(--sp-3) var(--sp-5) 0;
+        padding: var(--sp-3) var(--sp-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-1);
+        color: var(--text-secondary);
+        box-shadow: var(--shadow-sm);
+      }
+      .app-notice.success {
+        border-color: rgba(26, 107, 86, 0.24);
+        background: rgba(26, 107, 86, 0.08);
+        color: var(--accent);
+      }
+      .app-notice.warning {
+        border-color: rgba(212, 100, 46, 0.28);
+        background: rgba(212, 100, 46, 0.1);
+        color: var(--accent-warm);
+      }
 
       .settings-tabs { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 6px; }
       .settings-tab {
@@ -1150,6 +1169,7 @@
       <button class="tab-btn" id="tabBtn-health">Health</button>
       <button class="tab-btn" id="tabBtn-sync">Sync</button>
     </nav>
+    <div class="app-notice" id="globalNotice" hidden aria-live="polite"></div>
 
     <!-- ── Settings modal ──────────────────────────────────── -->
     <div class="modal-backdrop" id="settingsBackdrop" hidden></div>

--- a/tests/test_viewer_raw_events.py
+++ b/tests/test_viewer_raw_events.py
@@ -33,3 +33,23 @@ def test_raw_event_sweeper_interval_prefers_env_ms(monkeypatch) -> None:
     )
 
     assert sweeper.interval_ms() == 5000
+
+
+def test_raw_event_sweeper_config_change_wakes_worker() -> None:
+    sweeper = viewer_raw_events.RawEventSweeper()
+
+    assert sweeper._wake.is_set() is False
+    sweeper.notify_config_changed()
+    assert sweeper._wake.is_set() is True
+
+
+def test_raw_event_sweeper_reset_auth_backoff_clears_state() -> None:
+    sweeper = viewer_raw_events.RawEventSweeper()
+    sweeper._auth_backoff_until = 123.0
+    sweeper._auth_error_logged = True
+
+    sweeper.reset_auth_backoff()
+
+    assert sweeper._auth_backoff_until == 0.0
+    assert sweeper._auth_error_logged is False
+    assert sweeper._wake.is_set() is True

--- a/tests/test_viewer_routes_config.py
+++ b/tests/test_viewer_routes_config.py
@@ -53,6 +53,10 @@ def test_config_route_accepts_observer_auth_fields(
 
     assert handled is True
     assert handler.status == 200
+    assert handler.response is not None
+    effects = handler.response["effects"]
+    assert "observer_auth_source" in effects["hot_reloaded_keys"]
+    assert effects["sync"]["action"] is None
     saved = read_config_file(config_path)
     assert saved["claude_command"] == ["wrapper", "claude", "--"]
     assert saved["observer_auth_source"] == "command"
@@ -298,3 +302,239 @@ def test_config_route_rejects_invalid_raw_events_sweeper_interval(
     assert handled is True
     assert handler.status == 400
     assert handler.response == {"error": "raw_events_sweeper_interval_s must be int"}
+
+
+def test_config_route_hot_reloads_runtime_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    invalidated: list[str] = []
+    notified: list[str] = []
+    reset_calls: list[str] = []
+    monkeypatch.setattr(
+        viewer_config, "invalidate_runtime_state", lambda: invalidated.append("runtime")
+    )
+    monkeypatch.setattr(
+        viewer_config.RAW_EVENT_SWEEPER,
+        "notify_config_changed",
+        lambda: notified.append("sweeper"),
+    )
+    monkeypatch.setattr(
+        viewer_config.RAW_EVENT_SWEEPER,
+        "reset_auth_backoff",
+        lambda: reset_calls.append("reset"),
+    )
+
+    handler = DummyHandler(
+        {
+            "observer_runtime": "claude_sidecar",
+            "raw_events_sweeper_interval_s": 15,
+            "pack_observation_limit": 25,
+        }
+    )
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert invalidated == ["runtime"]
+    assert notified == ["sweeper"]
+    assert reset_calls == ["reset"]
+    assert handler.response is not None
+    effects = handler.response["effects"]
+    assert sorted(effects["hot_reloaded_keys"]) == [
+        "observer_runtime",
+        "raw_events_sweeper_interval_s",
+    ]
+    assert effects["live_applied_keys"] == ["pack_observation_limit"]
+
+
+def test_config_route_warns_when_env_override_blocks_effective_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_OBSERVER_RUNTIME", "api_http")
+    invalidated: list[str] = []
+    monkeypatch.setattr(
+        viewer_config, "invalidate_runtime_state", lambda: invalidated.append("runtime")
+    )
+
+    handler = DummyHandler({"observer_runtime": "claude_sidecar"})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert invalidated == []
+    assert handler.response is not None
+    effects = handler.response["effects"]
+    assert effects["hot_reloaded_keys"] == []
+    assert effects["ignored_by_env_keys"] == ["observer_runtime"]
+    assert effects["warnings"]
+
+
+def test_config_route_auto_starts_sync_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"sync_enabled": false, "sync_interval_s": 60}\n')
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    applied: list[str] = []
+
+    def _apply(action: str, *, effective_config: dict[str, Any]) -> dict[str, Any]:
+        applied.append(action)
+        return {
+            "attempted": True,
+            "ok": True,
+            "message": f"sync {action} ok",
+            "manual_action": None,
+        }
+
+    monkeypatch.setattr(viewer_config, "_apply_sync_runtime_action", _apply)
+
+    handler = DummyHandler({"sync_enabled": True})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert applied == ["start"]
+    assert handler.response is not None
+    sync_effect = handler.response["effects"]["sync"]
+    assert sync_effect["action"] == "start"
+    assert sync_effect["ok"] is True
+
+
+def test_config_route_auto_stops_sync_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"sync_enabled": true, "sync_interval_s": 60}\n')
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    applied: list[str] = []
+
+    def _apply(action: str, *, effective_config: dict[str, Any]) -> dict[str, Any]:
+        applied.append(action)
+        return {
+            "attempted": True,
+            "ok": True,
+            "message": f"sync {action} ok",
+            "manual_action": None,
+        }
+
+    monkeypatch.setattr(viewer_config, "_apply_sync_runtime_action", _apply)
+
+    handler = DummyHandler({"sync_enabled": False})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert applied == ["stop"]
+    assert handler.response is not None
+    sync_effect = handler.response["effects"]["sync"]
+    assert sync_effect["action"] == "stop"
+    assert sync_effect["ok"] is True
+
+
+def test_config_route_auto_restarts_sync_when_runtime_settings_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"sync_enabled": true, "sync_interval_s": 60}\n')
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    applied: list[str] = []
+
+    def _apply(action: str, *, effective_config: dict[str, Any]) -> dict[str, Any]:
+        applied.append(action)
+        return {
+            "attempted": True,
+            "ok": True,
+            "message": f"sync {action} ok",
+            "manual_action": None,
+        }
+
+    monkeypatch.setattr(viewer_config, "_apply_sync_runtime_action", _apply)
+
+    handler = DummyHandler({"sync_interval_s": 90})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert applied == ["restart"]
+    assert handler.response is not None
+    sync_effect = handler.response["effects"]["sync"]
+    assert sync_effect["action"] == "restart"
+    assert sync_effect["ok"] is True
+
+
+def test_config_route_reports_manual_sync_action_when_auto_apply_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"sync_enabled": true, "sync_interval_s": 60}\n')
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    monkeypatch.setattr(
+        viewer_config,
+        "_apply_sync_runtime_action",
+        lambda action, *, effective_config: {
+            "attempted": True,
+            "ok": False,
+            "message": "sync restart failed",
+            "manual_action": {
+                "kind": "sync",
+                "command": "uv run codemem sync restart",
+                "label": "Run `codemem sync restart`",
+                "reason": "sync restart failed",
+            },
+        },
+    )
+
+    handler = DummyHandler({"sync_interval_s": 90})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    assert handler.response is not None
+    sync_effect = handler.response["effects"]["sync"]
+    assert sync_effect["action"] == "restart"
+    assert sync_effect["ok"] is False
+    assert handler.response["effects"]["manual_actions"] == [
+        {
+            "kind": "sync",
+            "command": "uv run codemem sync restart",
+            "label": "Run `codemem sync restart`",
+            "reason": "sync restart failed",
+        }
+    ]

--- a/tests/test_viewer_routes_config.py
+++ b/tests/test_viewer_routes_config.py
@@ -538,3 +538,24 @@ def test_config_route_reports_manual_sync_action_when_auto_apply_fails(
             "reason": "sync restart failed",
         }
     ]
+
+
+def test_sync_stop_does_not_report_success_when_pidfile_missing_but_daemon_still_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(viewer_config, "run_service_action_quiet", lambda *args, **kwargs: False)
+    monkeypatch.setattr(
+        viewer_config,
+        "stop_pidfile_with_reason",
+        lambda: type("Result", (), {"stopped": False, "reason": "pidfile_missing"})(),
+    )
+    monkeypatch.setattr(
+        viewer_config,
+        "effective_status",
+        lambda host, port: type("Status", (), {"running": True, "mechanism": "port"})(),
+    )
+
+    ok, message = viewer_config._sync_stop(host="127.0.0.1", port=7337)
+
+    assert ok is False
+    assert message == "failed to stop sync daemon (pidfile_missing)"

--- a/viewer_ui/src/lib/api.ts
+++ b/viewer_ui/src/lib/api.ts
@@ -64,10 +64,18 @@ export async function saveConfig(payload: any): Promise<void> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  if (!resp.ok) {
-    const msg = await resp.text();
-    throw new Error(msg);
+  const text = await resp.text();
+  let parsed: any = null;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {}
   }
+  if (!resp.ok) {
+    const message = parsed && typeof parsed.error === 'string' ? parsed.error : text || 'request failed';
+    throw new Error(message);
+  }
+  return parsed;
 }
 
 export async function loadSyncStatus(includeDiagnostics: boolean): Promise<any> {

--- a/viewer_ui/src/lib/state.ts
+++ b/viewer_ui/src/lib/state.ts
@@ -55,6 +55,7 @@ export const state = {
   configDefaults: {} as Record<string, any>,
   configPath: '',
   settingsDirty: false,
+  noticeTimer: null as ReturnType<typeof setTimeout> | null,
 
   /* Sync UI toggles */
   syncDiagnosticsOpen: false,

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -358,6 +358,93 @@ export function isSettingsOpen(): boolean {
   return settingsOpen;
 }
 
+function hideGlobalNotice() {
+  const notice = $('globalNotice');
+  if (!notice) return;
+  hide(notice);
+  notice.textContent = '';
+  notice.classList.remove('success', 'warning');
+  if (state.noticeTimer) {
+    clearTimeout(state.noticeTimer);
+    state.noticeTimer = null;
+  }
+}
+
+function showGlobalNotice(message: string, type: 'success' | 'warning' = 'success') {
+  const notice = $('globalNotice');
+  if (!notice || !message) return;
+  notice.textContent = message;
+  notice.classList.remove('success', 'warning');
+  notice.classList.add(type === 'warning' ? 'warning' : 'success');
+  show(notice);
+  if (state.noticeTimer) clearTimeout(state.noticeTimer);
+  state.noticeTimer = setTimeout(() => {
+    hideGlobalNotice();
+  }, 12_000);
+}
+
+function formatSettingsKey(key: string): string {
+  return String(key || '').replace(/_/g, ' ');
+}
+
+function joinPhrases(values: string[]): string {
+  const items = values.filter((value) => typeof value === 'string' && value.trim());
+  if (items.length === 0) return '';
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+}
+
+function buildSettingsNotice(payload: any): { message: string; type: 'success' | 'warning' } {
+  const effects = payload?.effects && typeof payload.effects === 'object' ? payload.effects : {};
+  const hotReloaded = Array.isArray(effects.hot_reloaded_keys)
+    ? effects.hot_reloaded_keys.map(formatSettingsKey)
+    : [];
+  const liveApplied = Array.isArray(effects.live_applied_keys)
+    ? effects.live_applied_keys.map(formatSettingsKey)
+    : [];
+  const restartRequired = Array.isArray(effects.restart_required_keys)
+    ? effects.restart_required_keys.map(formatSettingsKey)
+    : [];
+  const warnings = Array.isArray(effects.warnings)
+    ? effects.warnings.filter(
+        (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0,
+      )
+    : [];
+  const manualActions = Array.isArray(effects.manual_actions) ? effects.manual_actions : [];
+  const sync = effects.sync && typeof effects.sync === 'object' ? effects.sync : {};
+  const lines: string[] = [];
+
+  if (hotReloaded.length) {
+    lines.push(`Applied now: ${joinPhrases(hotReloaded)}.`);
+  }
+  if (liveApplied.length) {
+    lines.push(`Live settings updated: ${joinPhrases(liveApplied)}.`);
+  }
+  if (sync.attempted && typeof sync.message === 'string' && sync.message) {
+    lines.push(`Sync: ${sync.message}.`);
+  } else if (Array.isArray(sync.affected_keys) && sync.affected_keys.length && typeof sync.reason === 'string' && sync.reason) {
+    lines.push(`Sync: ${sync.reason}.`);
+  }
+  if (restartRequired.length) {
+    lines.push(`Manual restart required: ${joinPhrases(restartRequired)}.`);
+  }
+  warnings.forEach((warning) => {
+    lines.push(warning);
+  });
+  manualActions.forEach((action) => {
+    if (action && typeof action.command === 'string' && action.command.trim()) {
+      lines.push(`If needed: ${action.command}.`);
+    }
+  });
+  if (!lines.length) {
+    lines.push('Saved.');
+  }
+
+  const hasWarning = restartRequired.length > 0 || warnings.length > 0 || sync.ok === false;
+  return { message: lines.join(' '), type: hasWarning ? 'warning' : 'success' };
+}
+
 export function renderConfigModal(payload: any) {
   if (!payload || typeof payload !== 'object') return;
   const defaults = payload.defaults || {};
@@ -685,10 +772,12 @@ export async function saveSettings(startPolling: () => void, refreshCallback: ()
       return;
     }
 
-    await api.saveConfig(changed);
+    const result = await api.saveConfig(changed);
+    const notice = buildSettingsNotice(result);
     status.textContent = 'Saved';
     setDirty(false);
     closeSettings(startPolling, refreshCallback);
+    showGlobalNotice(notice.message, notice.type);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'unknown error';
     status.textContent = `Save failed: ${message}`;


### PR DESCRIPTION
## Description
Improve the viewer settings UX so observer/runtime changes apply without restarting `codemem serve`, sync lifecycle changes are auto-applied when safe, and saves report exactly what changed, what applied immediately, and what still needs attention.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced