### PR TITLE
feat(store): persist actor provenance and workspace scope

### DIFF
--- a/codemem/config.py
+++ b/codemem/config.py
@@ -11,6 +11,8 @@ DEFAULT_CONFIG_PATH = Path("~/.config/codemem/config.json").expanduser()
 DEFAULT_CONFIG_PATH_JSONC = Path("~/.config/codemem/config.jsonc").expanduser()
 
 CONFIG_ENV_OVERRIDES = {
+    "actor_id": "CODEMEM_ACTOR_ID",
+    "actor_display_name": "CODEMEM_ACTOR_DISPLAY_NAME",
     "claude_command": "CODEMEM_CLAUDE_COMMAND",
     "observer_provider": "CODEMEM_OBSERVER_PROVIDER",
     "observer_model": "CODEMEM_OBSERVER_MODEL",
@@ -187,6 +189,8 @@ class OpencodeMemConfig:
     use_opencode_run: bool = False
     opencode_model: str = "openai/gpt-5.1-codex-mini"
     opencode_agent: str | None = None
+    actor_id: str | None = None
+    actor_display_name: str | None = None
     claude_command: list[str] = field(default_factory=lambda: ["claude"])
     observer_provider: str | None = None
     observer_model: str | None = None
@@ -472,6 +476,8 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
     cfg.use_opencode_run = _parse_bool(os.getenv("CODEMEM_USE_OPENCODE_RUN"), cfg.use_opencode_run)
     cfg.opencode_model = os.getenv("CODEMEM_OPENCODE_MODEL", cfg.opencode_model)
     cfg.opencode_agent = os.getenv("CODEMEM_OPENCODE_AGENT", cfg.opencode_agent)
+    cfg.actor_id = os.getenv("CODEMEM_ACTOR_ID", cfg.actor_id)
+    cfg.actor_display_name = os.getenv("CODEMEM_ACTOR_DISPLAY_NAME", cfg.actor_display_name)
     parsed_claude_command = _coerce_claude_command(os.getenv("CODEMEM_CLAUDE_COMMAND"))
     if parsed_claude_command is not None:
         cfg.claude_command = parsed_claude_command

--- a/codemem/db.py
+++ b/codemem/db.py
@@ -148,6 +148,13 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             metadata_json TEXT,
+            actor_id TEXT,
+            actor_display_name TEXT,
+            workspace_id TEXT,
+            workspace_kind TEXT,
+            origin_device_id TEXT,
+            origin_source TEXT,
+            trust_state TEXT,
             user_prompt_id INTEGER,
             deleted_at TEXT,
             rev INTEGER DEFAULT 0,
@@ -370,6 +377,13 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
     _ensure_column(conn, "memory_items", "import_key", "TEXT")
     _ensure_column(conn, "memory_items", "deleted_at", "TEXT")
     _ensure_column(conn, "memory_items", "rev", "INTEGER")
+    _ensure_column(conn, "memory_items", "actor_id", "TEXT")
+    _ensure_column(conn, "memory_items", "actor_display_name", "TEXT")
+    _ensure_column(conn, "memory_items", "workspace_id", "TEXT")
+    _ensure_column(conn, "memory_items", "workspace_kind", "TEXT")
+    _ensure_column(conn, "memory_items", "origin_device_id", "TEXT")
+    _ensure_column(conn, "memory_items", "origin_source", "TEXT")
+    _ensure_column(conn, "memory_items", "trust_state", "TEXT")
     _ensure_column(conn, "user_prompts", "import_key", "TEXT")
     _ensure_column(conn, "session_summaries", "import_key", "TEXT")
     _ensure_column(conn, "raw_event_sessions", "cwd", "TEXT")
@@ -387,6 +401,10 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_memory_items_user_prompt_id ON memory_items(user_prompt_id)"
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_memory_items_actor_id ON memory_items(actor_id)")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_workspace_id ON memory_items(workspace_id)"
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_session_summaries_import_key ON session_summaries(import_key)"

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -98,6 +98,8 @@ class MemoryStore:
             self.device_id = str(row["device_id"]) if row else "local"
 
         cfg = load_config()
+        self.actor_id = self._resolve_actor_id(cfg.actor_id)
+        self.actor_display_name = self._resolve_actor_display_name(cfg.actor_display_name)
         self._pack_exact_dedupe_enabled = bool(cfg.pack_exact_dedupe_enabled)
         self._hybrid_retrieval_enabled = bool(cfg.hybrid_retrieval_enabled)
         self._hybrid_retrieval_shadow_log = bool(cfg.hybrid_retrieval_shadow_log)
@@ -108,6 +110,140 @@ class MemoryStore:
         self._sync_projects_exclude = [
             p.strip() for p in cfg.sync_projects_exclude if p and p.strip()
         ]
+        self._backfill_identity_provenance()
+
+    def _resolve_actor_id(self, configured_actor_id: str | None) -> str:
+        value = str(configured_actor_id or "").strip()
+        if value:
+            return value
+        device_id = str(self.device_id or "").strip() or "local"
+        return f"local:{device_id}"
+
+    def _resolve_actor_display_name(self, configured_display_name: str | None) -> str:
+        value = str(configured_display_name or "").strip()
+        if value:
+            return value
+        user = str(os.getenv("USER") or os.getenv("USERNAME") or "").strip()
+        return user or self.actor_id
+
+    @staticmethod
+    def _clean_optional_str(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        cleaned = value.strip()
+        return cleaned or None
+
+    def _default_workspace_id(self, *, actor_id: str, workspace_kind: str) -> str:
+        if workspace_kind == "shared":
+            return "shared:default"
+        return f"personal:{actor_id}"
+
+    def _resolve_memory_provenance(
+        self, metadata: dict[str, Any] | None = None
+    ) -> dict[str, str | None]:
+        metadata = dict(metadata or {})
+        actor_id = self._clean_optional_str(metadata.get("actor_id")) or self.actor_id
+        actor_display_name = (
+            self._clean_optional_str(metadata.get("actor_display_name")) or self.actor_display_name
+        )
+        workspace_kind = self._clean_optional_str(metadata.get("workspace_kind")) or "personal"
+        if workspace_kind not in {"personal", "shared"}:
+            workspace_kind = "personal"
+        workspace_id = self._clean_optional_str(
+            metadata.get("workspace_id")
+        ) or self._default_workspace_id(
+            actor_id=actor_id,
+            workspace_kind=workspace_kind,
+        )
+        origin_device_id = (
+            self._clean_optional_str(metadata.get("origin_device_id")) or self.device_id
+        )
+        origin_source = self._clean_optional_str(
+            metadata.get("origin_source")
+        ) or self._clean_optional_str(metadata.get("source"))
+        trust_state = self._clean_optional_str(metadata.get("trust_state")) or "trusted"
+        return {
+            "actor_id": actor_id,
+            "actor_display_name": actor_display_name,
+            "workspace_id": workspace_id,
+            "workspace_kind": workspace_kind,
+            "origin_device_id": origin_device_id,
+            "origin_source": origin_source,
+            "trust_state": trust_state,
+        }
+
+    def _derive_legacy_row_provenance(self, row: dict[str, Any]) -> dict[str, str | None]:
+        metadata = self._normalize_metadata(row.get("metadata_json"))
+        source = self._clean_optional_str(metadata.get("source"))
+        clock_device_id = self._clean_optional_str(metadata.get("clock_device_id"))
+        is_sync = source == "sync"
+        is_local = not is_sync and clock_device_id in {None, "local", self.device_id}
+        if is_local:
+            return self._resolve_memory_provenance(metadata)
+        origin_device_id = clock_device_id or "unknown"
+        actor_id = (
+            self._clean_optional_str(metadata.get("actor_id")) or f"legacy-sync:{origin_device_id}"
+        )
+        actor_display_name = (
+            self._clean_optional_str(metadata.get("actor_display_name")) or "Legacy synced peer"
+        )
+        return {
+            "actor_id": actor_id,
+            "actor_display_name": actor_display_name,
+            "workspace_id": self._clean_optional_str(metadata.get("workspace_id"))
+            or "shared:legacy",
+            "workspace_kind": self._clean_optional_str(metadata.get("workspace_kind")) or "shared",
+            "origin_device_id": origin_device_id,
+            "origin_source": self._clean_optional_str(metadata.get("origin_source"))
+            or source
+            or "sync",
+            "trust_state": self._clean_optional_str(metadata.get("trust_state"))
+            or "legacy_unknown",
+        }
+
+    def _backfill_identity_provenance(self) -> None:
+        rows = self.conn.execute(
+            """
+            SELECT id, metadata_json, actor_id, actor_display_name, workspace_id, workspace_kind,
+                   origin_device_id, origin_source, trust_state
+            FROM memory_items
+            WHERE actor_id IS NULL
+               OR actor_display_name IS NULL
+               OR workspace_id IS NULL
+               OR workspace_kind IS NULL
+               OR origin_device_id IS NULL
+               OR trust_state IS NULL
+            """
+        ).fetchall()
+        if not rows:
+            return
+        for row in rows:
+            row_data = dict(row)
+            provenance = self._derive_legacy_row_provenance(row_data)
+            self.conn.execute(
+                """
+                UPDATE memory_items
+                SET actor_id = COALESCE(actor_id, ?),
+                    actor_display_name = COALESCE(actor_display_name, ?),
+                    workspace_id = COALESCE(workspace_id, ?),
+                    workspace_kind = COALESCE(workspace_kind, ?),
+                    origin_device_id = COALESCE(origin_device_id, ?),
+                    origin_source = COALESCE(origin_source, ?),
+                    trust_state = COALESCE(trust_state, ?)
+                WHERE id = ?
+                """,
+                (
+                    provenance["actor_id"],
+                    provenance["actor_display_name"],
+                    provenance["workspace_id"],
+                    provenance["workspace_kind"],
+                    provenance["origin_device_id"],
+                    provenance["origin_source"],
+                    provenance["trust_state"],
+                    int(row_data["id"]),
+                ),
+            )
+        self.conn.commit()
 
     def _effective_sync_project_filters(
         self, *, peer_device_id: str | None = None
@@ -855,6 +991,7 @@ class MemoryStore:
         tags_text = " ".join(sorted(set(tags or [])))
         metadata_payload = dict(metadata or {})
         metadata_payload.setdefault("clock_device_id", self.device_id)
+        provenance = self._resolve_memory_provenance(metadata_payload)
         import_key = metadata_payload.get("import_key") or None
         if not import_key:
             import_key = str(uuid4())
@@ -883,12 +1020,19 @@ class MemoryStore:
                 created_at,
                 updated_at,
                 metadata_json,
+                actor_id,
+                actor_display_name,
+                workspace_id,
+                workspace_kind,
+                origin_device_id,
+                origin_source,
+                trust_state,
                 user_prompt_id,
                 deleted_at,
                 rev,
                 import_key
             )
-            VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id,
@@ -900,6 +1044,13 @@ class MemoryStore:
                 created_at,
                 created_at,
                 db.to_json(metadata_payload),
+                provenance["actor_id"],
+                provenance["actor_display_name"],
+                provenance["workspace_id"],
+                provenance["workspace_kind"],
+                provenance["origin_device_id"],
+                provenance["origin_source"],
+                provenance["trust_state"],
                 user_prompt_id,
                 None,
                 1,
@@ -945,6 +1096,7 @@ class MemoryStore:
         )
         metadata_payload = dict(metadata or {})
         metadata_payload.setdefault("clock_device_id", self.device_id)
+        provenance = self._resolve_memory_provenance(metadata_payload)
         if metadata_payload.get("flush_batch"):
             meta_text = db.to_json(metadata_payload)
             row = self.conn.execute(
@@ -989,6 +1141,13 @@ class MemoryStore:
                 created_at,
                 updated_at,
                 metadata_json,
+                actor_id,
+                actor_display_name,
+                workspace_id,
+                workspace_kind,
+                origin_device_id,
+                origin_source,
+                trust_state,
                 subtitle,
                 facts,
                 narrative,
@@ -1001,7 +1160,7 @@ class MemoryStore:
                 rev,
                 import_key
             )
-            VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id,
@@ -1013,6 +1172,13 @@ class MemoryStore:
                 created_at,
                 created_at,
                 db.to_json(metadata_payload),
+                provenance["actor_id"],
+                provenance["actor_display_name"],
+                provenance["workspace_id"],
+                provenance["workspace_kind"],
+                provenance["origin_device_id"],
+                provenance["origin_source"],
+                provenance["trust_state"],
                 subtitle,
                 db.to_json(facts or []),
                 narrative,

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -23,6 +23,12 @@ def test_initialize_schema_sets_user_version(monkeypatch, tmp_path: Path) -> Non
         attempt_column = conn.execute(
             "SELECT name FROM pragma_table_info('raw_event_flush_batches') WHERE name = 'attempt_count'"
         ).fetchone()
+        actor_column = conn.execute(
+            "SELECT name FROM pragma_table_info('memory_items') WHERE name = 'actor_id'"
+        ).fetchone()
+        workspace_column = conn.execute(
+            "SELECT name FROM pragma_table_info('memory_items') WHERE name = 'workspace_id'"
+        ).fetchone()
     finally:
         conn.close()
 
@@ -32,6 +38,8 @@ def test_initialize_schema_sets_user_version(monkeypatch, tmp_path: Path) -> Non
     assert ingest_samples_table is not None
     assert ingest_reason_column is not None
     assert attempt_column is not None
+    assert actor_column is not None
+    assert workspace_column is not None
 
 
 def test_initialize_schema_skips_reinit_but_keeps_kind_normalization(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -317,6 +317,141 @@ def test_replication_ops_idempotent(tmp_path: Path) -> None:
         store_b.close()
 
 
+def test_remember_persists_default_actor_and_personal_workspace(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(session_id, kind="note", title="Alpha", body_text="Body")
+
+        row = store.conn.execute(
+            """
+            SELECT actor_id, actor_display_name, workspace_id, workspace_kind,
+                   origin_device_id, trust_state
+            FROM memory_items
+            WHERE id = ?
+            """,
+            (memory_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["actor_id"] == store.actor_id
+        assert row["actor_display_name"] == store.actor_display_name
+        assert row["workspace_id"] == f"personal:{store.actor_id}"
+        assert row["workspace_kind"] == "personal"
+        assert row["origin_device_id"] == store.device_id
+        assert row["trust_state"] == "trusted"
+    finally:
+        store.close()
+
+
+def test_store_backfills_legacy_local_memories_to_personal_workspace(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        store.conn.execute(
+            """
+            INSERT INTO memory_items(
+                session_id, kind, title, body_text, created_at, updated_at, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                "note",
+                "Legacy",
+                "Legacy body",
+                "2026-03-08T00:00:00Z",
+                "2026-03-08T00:00:00Z",
+                db.to_json({"clock_device_id": store.device_id}),
+            ),
+        )
+        store.conn.commit()
+    finally:
+        store.close()
+
+    reopened = MemoryStore(db_path)
+    try:
+        row = reopened.conn.execute(
+            "SELECT actor_id, workspace_id, workspace_kind, trust_state FROM memory_items WHERE title = ?",
+            ("Legacy",),
+        ).fetchone()
+        assert row is not None
+        assert row["actor_id"] == reopened.actor_id
+        assert row["workspace_id"] == f"personal:{reopened.actor_id}"
+        assert row["workspace_kind"] == "personal"
+        assert row["trust_state"] == "trusted"
+    finally:
+        reopened.close()
+
+
+def test_store_backfills_legacy_synced_memories_to_shared_workspace(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        store.conn.execute(
+            """
+            INSERT INTO memory_items(
+                session_id, kind, title, body_text, created_at, updated_at, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                "note",
+                "Synced",
+                "From remote",
+                "2026-03-08T00:00:00Z",
+                "2026-03-08T00:00:00Z",
+                db.to_json({"clock_device_id": "peer-123", "source": "sync"}),
+            ),
+        )
+        store.conn.commit()
+    finally:
+        store.close()
+
+    reopened = MemoryStore(db_path)
+    try:
+        row = reopened.conn.execute(
+            """
+            SELECT actor_id, actor_display_name, workspace_id, workspace_kind,
+                   origin_device_id, origin_source, trust_state
+            FROM memory_items
+            WHERE title = ?
+            """,
+            ("Synced",),
+        ).fetchone()
+        assert row is not None
+        assert row["actor_id"] == "legacy-sync:peer-123"
+        assert row["actor_display_name"] == "Legacy synced peer"
+        assert row["workspace_id"] == "shared:legacy"
+        assert row["workspace_kind"] == "shared"
+        assert row["origin_device_id"] == "peer-123"
+        assert row["origin_source"] == "sync"
+        assert row["trust_state"] == "legacy_unknown"
+    finally:
+        reopened.close()
+
+
 def test_replication_delete_wins_over_older_upsert(tmp_path: Path) -> None:
     store_a = MemoryStore(tmp_path / "a.sqlite")
     store_b = MemoryStore(tmp_path / "b.sqlite")


### PR DESCRIPTION
## Description
Persist actor provenance and workspace scope on stored memories so identity-aware sync and retrieval have durable fields to work with. This establishes the storage-layer foundation for distinguishing local, remote, and shared memories without relying on inferred legacy state.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `uv run pytest tests/test_store.py`
- `uv run pytest tests/test_viewer_routes_memory.py`
- `uv run ruff check codemem tests`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
