### PR TITLE
feat(sync): propagate provenance and add peer scope controls

### DIFF
--- a/codemem/store/replication.py
+++ b/codemem/store/replication.py
@@ -529,6 +529,7 @@ def _memory_item_clock(store: MemoryStore, row: dict[str, Any]) -> tuple[int, st
 
 def _memory_item_payload(store: MemoryStore, row: dict[str, Any]) -> dict[str, Any]:
     metadata = store._normalize_metadata(row.get("metadata_json"))
+    legacy_provenance = store._derive_legacy_row_provenance(row)
     session_id = row.get("session_id")
     project = None
     session_import_key = None
@@ -575,6 +576,14 @@ def _memory_item_payload(store: MemoryStore, row: dict[str, Any]) -> dict[str, A
         "created_at": row.get("created_at"),
         "updated_at": row.get("updated_at"),
         "metadata_json": metadata,
+        "actor_id": row.get("actor_id") or legacy_provenance["actor_id"],
+        "actor_display_name": row.get("actor_display_name")
+        or legacy_provenance["actor_display_name"],
+        "workspace_id": row.get("workspace_id") or legacy_provenance["workspace_id"],
+        "workspace_kind": row.get("workspace_kind") or legacy_provenance["workspace_kind"],
+        "origin_device_id": row.get("origin_device_id") or legacy_provenance["origin_device_id"],
+        "origin_source": row.get("origin_source") or legacy_provenance["origin_source"],
+        "trust_state": row.get("trust_state") or legacy_provenance["trust_state"],
         "subtitle": row.get("subtitle"),
         "facts": row.get("facts"),
         "narrative": row.get("narrative"),
@@ -1182,6 +1191,31 @@ def _apply_memory_item_upsert(store: MemoryStore, op: ReplicationOp) -> str:
     metadata_json = db.to_json(metadata)
     created_at = str(payload.get("created_at") or clock.get("updated_at") or "")
     updated_at = str(payload.get("updated_at") or clock.get("updated_at") or "")
+    fallback_provenance = store._derive_legacy_row_provenance({"metadata_json": metadata})
+    actor_id = store._clean_optional_str(payload.get("actor_id")) or fallback_provenance["actor_id"]
+    actor_display_name = (
+        store._clean_optional_str(payload.get("actor_display_name"))
+        or fallback_provenance["actor_display_name"]
+    )
+    workspace_id = (
+        store._clean_optional_str(payload.get("workspace_id"))
+        or fallback_provenance["workspace_id"]
+    )
+    workspace_kind = (
+        store._clean_optional_str(payload.get("workspace_kind"))
+        or fallback_provenance["workspace_kind"]
+    )
+    origin_device_id = (
+        store._clean_optional_str(payload.get("origin_device_id"))
+        or fallback_provenance["origin_device_id"]
+    )
+    origin_source = (
+        store._clean_optional_str(payload.get("origin_source"))
+        or fallback_provenance["origin_source"]
+    )
+    trust_state = (
+        store._clean_optional_str(payload.get("trust_state")) or fallback_provenance["trust_state"]
+    )
     project_value = payload.get("project")
     project = project_value if isinstance(project_value, str) and project_value.strip() else None
     session_id_value: int | None
@@ -1221,6 +1255,13 @@ def _apply_memory_item_upsert(store: MemoryStore, op: ReplicationOp) -> str:
         created_at,
         updated_at,
         metadata_json,
+        actor_id,
+        actor_display_name,
+        workspace_id,
+        workspace_kind,
+        origin_device_id,
+        origin_source,
+        trust_state,
         payload.get("subtitle"),
         _json_text(payload.get("facts")),
         payload.get("narrative"),
@@ -1247,6 +1288,13 @@ def _apply_memory_item_upsert(store: MemoryStore, op: ReplicationOp) -> str:
                 created_at,
                 updated_at,
                 metadata_json,
+                actor_id,
+                actor_display_name,
+                workspace_id,
+                workspace_kind,
+                origin_device_id,
+                origin_source,
+                trust_state,
                 subtitle,
                 facts,
                 narrative,
@@ -1259,7 +1307,7 @@ def _apply_memory_item_upsert(store: MemoryStore, op: ReplicationOp) -> str:
                 deleted_at,
                 rev
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             values,
         )
@@ -1277,6 +1325,13 @@ def _apply_memory_item_upsert(store: MemoryStore, op: ReplicationOp) -> str:
             created_at = ?,
             updated_at = ?,
             metadata_json = ?,
+            actor_id = ?,
+            actor_display_name = ?,
+            workspace_id = ?,
+            workspace_kind = ?,
+            origin_device_id = ?,
+            origin_source = ?,
+            trust_state = ?,
             subtitle = ?,
             facts = ?,
             narrative = ?,

--- a/codemem/viewer.py
+++ b/codemem/viewer.py
@@ -129,6 +129,7 @@ class ViewerHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         strict_paths = {
             "/api/sync/peers/rename",
+            "/api/sync/peers/scope",
             "/api/sync/actions/sync-now",
             "/api/sync/run",
         }

--- a/codemem/viewer_routes/sync.py
+++ b/codemem/viewer_routes/sync.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs
 
 from ..net import pick_advertise_host, pick_advertise_hosts
 from ..store import MemoryStore
-from ..sync.discovery import load_peer_addresses, normalize_address
+from ..sync.discovery import load_peer_addresses, normalize_address, set_peer_project_filter
 from ..sync.sync_pass import sync_once
 from ..sync_identity import ensure_device_identity, load_public_key
 from ..sync_runtime import SyncRuntimeStatus, effective_status
@@ -184,13 +184,22 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
         peers_rows = store.conn.execute(
             """
             SELECT peer_device_id, name, pinned_fingerprint, addresses_json,
-                   last_seen_at, last_sync_at, last_error
+                   last_seen_at, last_sync_at, last_error,
+                   projects_include_json, projects_exclude_json
             FROM sync_peers
             ORDER BY name, peer_device_id
             """
         ).fetchall()
         peers_items: list[dict[str, Any]] = []
         for row in peers_rows:
+            override_include_raw = row["projects_include_json"]
+            override_exclude_raw = row["projects_exclude_json"]
+            override_include = store._safe_json_list(override_include_raw)
+            override_exclude = store._safe_json_list(override_exclude_raw)
+            inherits_global = override_include_raw is None and override_exclude_raw is None
+            effective_include, effective_exclude = store._effective_sync_project_filters(
+                peer_device_id=str(row["peer_device_id"])
+            )
             addresses = (
                 load_peer_addresses(store.conn, row["peer_device_id"])
                 if include_diagnostics
@@ -206,6 +215,13 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                 "last_sync_at": row["last_sync_at"],
                 "last_error": row["last_error"] if include_diagnostics else None,
                 "has_error": bool(row["last_error"]),
+                "project_scope": {
+                    "include": override_include,
+                    "exclude": override_exclude,
+                    "effective_include": effective_include,
+                    "effective_exclude": effective_exclude,
+                    "inherits_global": inherits_global,
+                },
             }
             peer_item["status"] = _peer_status(peer_item)
             peers_items.append(peer_item)
@@ -281,13 +297,21 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
         rows = store.conn.execute(
             """
             SELECT peer_device_id, name, pinned_fingerprint, addresses_json,
-                   last_seen_at, last_sync_at, last_error
+                   last_seen_at, last_sync_at, last_error,
+                   projects_include_json, projects_exclude_json
             FROM sync_peers
             ORDER BY name, peer_device_id
             """
         ).fetchall()
         peers = []
         for row in rows:
+            override_include_raw = row["projects_include_json"]
+            override_exclude_raw = row["projects_exclude_json"]
+            override_include = store._safe_json_list(override_include_raw)
+            override_exclude = store._safe_json_list(override_exclude_raw)
+            effective_include, effective_exclude = store._effective_sync_project_filters(
+                peer_device_id=str(row["peer_device_id"])
+            )
             addresses = (
                 load_peer_addresses(store.conn, row["peer_device_id"])
                 if include_diagnostics
@@ -304,6 +328,14 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                     "last_sync_at": row["last_sync_at"],
                     "last_error": row["last_error"] if include_diagnostics else None,
                     "has_error": bool(row["last_error"]),
+                    "project_scope": {
+                        "include": override_include,
+                        "exclude": override_exclude,
+                        "effective_include": effective_include,
+                        "effective_exclude": effective_exclude,
+                        "inherits_global": override_include_raw is None
+                        and override_exclude_raw is None,
+                    },
                 }
             )
         handler._send_json({"items": peers, "redacted": not include_diagnostics})
@@ -416,6 +448,75 @@ def handle_post(
         )
         store.conn.commit()
         handler._send_json({"ok": True})
+        return True
+
+    if path == "/api/sync/peers/scope":
+        if payload is None:
+            handler._send_json({"error": "invalid json"}, status=400)
+            return True
+        peer_device_id = payload.get("peer_device_id")
+        if not isinstance(peer_device_id, str) or not peer_device_id.strip():
+            handler._send_json({"error": "peer_device_id required"}, status=400)
+            return True
+        row = store.conn.execute(
+            "SELECT 1 FROM sync_peers WHERE peer_device_id = ?",
+            (peer_device_id.strip(),),
+        ).fetchone()
+        if row is None:
+            handler._send_json({"error": "peer not found"}, status=404)
+            return True
+        inherit_global = bool(payload.get("inherit_global"))
+
+        def _parse_scope_list(value: Any, *, field: str) -> list[str] | None:
+            if value is None:
+                return []
+            if not isinstance(value, list):
+                raise ValueError(field)
+            items: list[str] = []
+            for item in value:
+                if not isinstance(item, str):
+                    raise ValueError(field)
+                cleaned = item.strip()
+                if cleaned:
+                    items.append(cleaned)
+            return items
+
+        try:
+            include = (
+                None
+                if inherit_global
+                else _parse_scope_list(payload.get("include"), field="include")
+            )
+            exclude = (
+                None
+                if inherit_global
+                else _parse_scope_list(payload.get("exclude"), field="exclude")
+            )
+        except ValueError as exc:
+            handler._send_json({"error": f"invalid {exc.args[0]}"}, status=400)
+            return True
+
+        set_peer_project_filter(
+            store.conn,
+            peer_device_id.strip(),
+            include=include,
+            exclude=exclude,
+        )
+        effective_include, effective_exclude = store._effective_sync_project_filters(
+            peer_device_id=peer_device_id.strip()
+        )
+        handler._send_json(
+            {
+                "ok": True,
+                "project_scope": {
+                    "include": [] if include is None else include,
+                    "exclude": [] if exclude is None else exclude,
+                    "effective_include": effective_include,
+                    "effective_exclude": effective_exclude,
+                    "inherits_global": inherit_global,
+                },
+            }
+        )
         return True
 
     if path == "/api/sync/actions/sync-now":

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -247,6 +247,24 @@
   async function loadPairing() {
     return fetchJson("/api/sync/pairing?includeDiagnostics=1");
   }
+  async function updatePeerScope(peerDeviceId, include, exclude, inheritGlobal = false) {
+    const resp = await fetch("/api/sync/peers/scope", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        peer_device_id: peerDeviceId,
+        include,
+        exclude,
+        inherit_global: inheritGlobal
+      })
+    });
+    const text = await resp.text();
+    const payload = text ? JSON.parse(text) : {};
+    if (!resp.ok) {
+      throw new Error(payload?.error || text || "request failed");
+    }
+    return payload;
+  }
   async function loadProjects$1() {
     const payload = await fetchJson("/api/projects");
     return payload.projects || [];
@@ -1245,6 +1263,9 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const unique = Array.from(new Set(addresses.filter(Boolean)));
     return typeof unique[0] === "string" ? unique[0] : "";
   }
+  function parseScopeList(value) {
+    return value.split(",").map((item) => item.trim()).filter(Boolean);
+  }
   function renderActionList(container, actions) {
     if (!container) return;
     container.textContent = "";
@@ -1391,8 +1412,64 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never",
         lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : "Ping: never"
       ].join(" · "));
+      const scope = peer.project_scope || {};
+      const includeList = Array.isArray(scope.include) ? scope.include : [];
+      const excludeList = Array.isArray(scope.exclude) ? scope.exclude : [];
+      const effectiveInclude = Array.isArray(scope.effective_include) ? scope.effective_include : [];
+      const effectiveExclude = Array.isArray(scope.effective_exclude) ? scope.effective_exclude : [];
+      const inheritsGlobal = Boolean(scope.inherits_global);
+      const scopePanel = el("div", "peer-scope");
+      const scopeSummary = el(
+        "div",
+        "peer-scope-summary",
+        inheritsGlobal ? "Using global sync scope" : `Peer override · include: ${includeList.join(", ") || "all"} · exclude: ${excludeList.join(", ") || "none"}`
+      );
+      const effectiveSummary = el(
+        "div",
+        "peer-scope-effective",
+        `Effective scope · include: ${effectiveInclude.join(", ") || "all"} · exclude: ${effectiveExclude.join(", ") || "none"}`
+      );
+      const includeInput = el("input", "peer-scope-input");
+      includeInput.placeholder = "project-a, project-b";
+      includeInput.value = includeList.join(", ");
+      const excludeInput = el("input", "peer-scope-input");
+      excludeInput.placeholder = "private-repo";
+      excludeInput.value = excludeList.join(", ");
+      const inputRow = el("div", "peer-scope-row");
+      inputRow.append(includeInput, excludeInput);
+      const scopeActions = el("div", "peer-scope-actions");
+      const saveScopeBtn = el("button", "settings-button", "Save scope");
+      const inheritBtn = el("button", "settings-button", "Use global");
+      saveScopeBtn.addEventListener("click", async () => {
+        saveScopeBtn.disabled = true;
+        saveScopeBtn.textContent = "Saving...";
+        try {
+          await updatePeerScope(peerId, parseScopeList(includeInput.value), parseScopeList(excludeInput.value));
+          await loadSyncData();
+        } catch {
+          saveScopeBtn.textContent = "Retry save";
+        } finally {
+          saveScopeBtn.disabled = false;
+          if (saveScopeBtn.textContent === "Saving...") saveScopeBtn.textContent = "Save scope";
+        }
+      });
+      inheritBtn.addEventListener("click", async () => {
+        inheritBtn.disabled = true;
+        inheritBtn.textContent = "Resetting...";
+        try {
+          await updatePeerScope(peerId, null, null, true);
+          await loadSyncData();
+        } catch {
+          inheritBtn.textContent = "Retry reset";
+        } finally {
+          inheritBtn.disabled = false;
+          if (inheritBtn.textContent === "Resetting...") inheritBtn.textContent = "Use global";
+        }
+      });
+      scopeActions.append(saveScopeBtn, inheritBtn);
+      scopePanel.append(scopeSummary, effectiveSummary, inputRow, scopeActions);
       titleRow.append(name, actions);
-      card.append(titleRow, addressLabel, meta);
+      card.append(titleRow, addressLabel, meta, scopePanel);
       syncPeers.appendChild(card);
     });
   }

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -857,6 +857,11 @@
       .peer-card { border: 1px solid var(--border); border-radius: var(--radius-lg); padding: var(--sp-4); background: var(--surface-1); display: grid; gap: var(--sp-2); }
       .peer-title { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); }
       .peer-title strong { font-size: 15px; }
+      .peer-scope { display: grid; gap: var(--sp-2); padding-top: var(--sp-2); border-top: 1px solid var(--border); }
+      .peer-scope-summary, .peer-scope-effective { font-size: 12px; color: var(--text-secondary); }
+      .peer-scope-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-2); }
+      .peer-scope-input { width: 100%; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--text-primary); padding: 8px 10px; font: inherit; }
+      .peer-scope-actions { display: flex; gap: var(--sp-2); }
       .peer-actions { display: flex; gap: 6px; }
       .peer-actions button { border: 1px solid var(--border); background: transparent; border-radius: var(--radius-pill); padding: 5px 10px; font-family: var(--font-sans); font-size: 12px; cursor: pointer; color: var(--text-secondary); }
       .peer-actions button:hover { border-color: var(--border-hover); background: var(--surface-2); }

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -317,6 +317,85 @@ def test_replication_ops_idempotent(tmp_path: Path) -> None:
         store_b.close()
 
 
+def test_replication_payload_includes_actor_and_workspace_provenance(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        store.remember(
+            session_id,
+            kind="note",
+            title="Alpha",
+            body_text="Body",
+            metadata={"workspace_kind": "shared", "workspace_id": "shared:team-alpha"},
+        )
+        ops, _ = store.load_replication_ops_since(None, limit=10)
+        payload = ops[0]["payload"]
+        assert payload["actor_id"] == store.actor_id
+        assert payload["workspace_kind"] == "shared"
+        assert payload["workspace_id"] == "shared:team-alpha"
+        assert payload["origin_device_id"] == store.device_id
+    finally:
+        store.close()
+
+
+def test_apply_replication_ops_preserves_actor_and_workspace_provenance(tmp_path: Path) -> None:
+    store_a = MemoryStore(tmp_path / "a.sqlite")
+    store_b = MemoryStore(tmp_path / "b.sqlite")
+    try:
+        session_id = store_a.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        store_a.remember(
+            session_id,
+            kind="note",
+            title="Alpha",
+            body_text="Body",
+            metadata={
+                "actor_id": "actor:alice",
+                "actor_display_name": "Alice",
+                "workspace_id": "shared:team-alpha",
+                "workspace_kind": "shared",
+                "origin_source": "observer",
+                "trust_state": "trusted",
+            },
+        )
+        ops, _ = store_a.load_replication_ops_since(None, limit=10)
+
+        result = store_b.apply_replication_ops(ops)
+        assert result["inserted"] == 1
+        row = store_b.conn.execute(
+            """
+            SELECT actor_id, actor_display_name, workspace_id, workspace_kind,
+                   origin_source, trust_state
+            FROM memory_items
+            WHERE import_key = ?
+            """,
+            (ops[0]["entity_id"],),
+        ).fetchone()
+        assert row is not None
+        assert row["actor_id"] == "actor:alice"
+        assert row["actor_display_name"] == "Alice"
+        assert row["workspace_id"] == "shared:team-alpha"
+        assert row["workspace_kind"] == "shared"
+        assert row["origin_source"] == "observer"
+        assert row["trust_state"] == "trusted"
+    finally:
+        store_a.close()
+        store_b.close()
+
+
 def test_remember_persists_default_actor_and_personal_workspace(tmp_path: Path) -> None:
     store = MemoryStore(tmp_path / "mem.sqlite")
     try:

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -99,6 +99,128 @@ def test_sync_status_endpoint(tmp_path: Path, monkeypatch) -> None:
         server.shutdown()
 
 
+def test_sync_peers_endpoint_exposes_project_scope(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    monkeypatch.setattr(
+        "codemem.viewer.load_config",
+        lambda: type(
+            "Cfg",
+            (),
+            {
+                "sync_enabled": True,
+                "sync_host": "127.0.0.1",
+                "sync_port": 7337,
+                "sync_interval_s": 60,
+                "sync_projects_include": ["project-a"],
+                "sync_projects_exclude": ["private"],
+            },
+        )(),
+    )
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO sync_peers(peer_device_id, addresses_json, created_at, projects_include_json, projects_exclude_json)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "peer-1",
+                "[]",
+                "2026-01-24T00:00:00Z",
+                json.dumps(["project-b"]),
+                json.dumps(["secret"]),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/api/sync/peers?includeDiagnostics=1")
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        peer = payload["items"][0]
+        scope = peer["project_scope"]
+        assert scope["include"] == ["project-b"]
+        assert scope["exclude"] == ["secret"]
+        assert scope["effective_include"] == ["project-b"]
+        assert scope["effective_exclude"] == ["secret"]
+        assert scope["inherits_global"] is False
+    finally:
+        server.shutdown()
+
+
+def test_sync_peer_scope_update_endpoint_updates_override(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    monkeypatch.setattr(
+        "codemem.viewer.load_config",
+        lambda: type(
+            "Cfg",
+            (),
+            {
+                "sync_enabled": True,
+                "sync_host": "127.0.0.1",
+                "sync_port": 7337,
+                "sync_interval_s": 60,
+                "sync_projects_include": ["project-a"],
+                "sync_projects_exclude": [],
+            },
+        )(),
+    )
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/peers/scope",
+            body=json.dumps(
+                {
+                    "peer_device_id": "peer-1",
+                    "include": ["project-b"],
+                    "exclude": ["secret"],
+                    "inherit_global": False,
+                }
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["project_scope"]["effective_include"] == ["project-b"]
+        assert payload["project_scope"]["inherits_global"] is False
+    finally:
+        server.shutdown()
+
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT projects_include_json, projects_exclude_json FROM sync_peers WHERE peer_device_id = ?",
+            ("peer-1",),
+        ).fetchone()
+        assert row is not None
+        assert json.loads(row["projects_include_json"]) == ["project-b"]
+        assert json.loads(row["projects_exclude_json"]) == ["secret"]
+    finally:
+        conn.close()
+
+
 def test_sync_status_endpoint_includes_diagnostics_when_requested(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -198,7 +198,10 @@ def test_sync_peer_scope_update_endpoint_updates_override(tmp_path: Path, monkey
                     "inherit_global": False,
                 }
             ),
-            headers={"Content-Type": "application/json"},
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
         )
         resp = conn.getresponse()
         payload = json.loads(resp.read().decode("utf-8"))

--- a/viewer_ui/src/lib/api.ts
+++ b/viewer_ui/src/lib/api.ts
@@ -87,6 +87,30 @@ export async function loadPairing(): Promise<any> {
   return fetchJson('/api/sync/pairing?includeDiagnostics=1');
 }
 
+export async function updatePeerScope(
+  peerDeviceId: string,
+  include: string[] | null,
+  exclude: string[] | null,
+  inheritGlobal = false,
+): Promise<any> {
+  const resp = await fetch('/api/sync/peers/scope', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      peer_device_id: peerDeviceId,
+      include,
+      exclude,
+      inherit_global: inheritGlobal,
+    }),
+  });
+  const text = await resp.text();
+  const payload = text ? JSON.parse(text) : {};
+  if (!resp.ok) {
+    throw new Error(payload?.error || text || 'request failed');
+  }
+  return payload;
+}
+
 export async function loadProjects(): Promise<string[]> {
   const payload = await fetchJson('/api/projects');
   return payload.projects || [];

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -37,6 +37,13 @@ function pickPrimaryAddress(addresses: unknown): string {
   return typeof unique[0] === 'string' ? unique[0] : '';
 }
 
+function parseScopeList(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 function renderActionList(container: HTMLElement | null, actions: Array<{ label: string; command: string }>) {
   if (!container) return;
   container.textContent = '';
@@ -210,8 +217,67 @@ export function renderSyncPeers() {
       lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : 'Ping: never',
     ].join(' · '));
 
+    const scope = peer.project_scope || {};
+    const includeList = Array.isArray(scope.include) ? scope.include : [];
+    const excludeList = Array.isArray(scope.exclude) ? scope.exclude : [];
+    const effectiveInclude = Array.isArray(scope.effective_include) ? scope.effective_include : [];
+    const effectiveExclude = Array.isArray(scope.effective_exclude) ? scope.effective_exclude : [];
+    const inheritsGlobal = Boolean(scope.inherits_global);
+    const scopePanel = el('div', 'peer-scope');
+    const scopeSummary = el(
+      'div',
+      'peer-scope-summary',
+      inheritsGlobal
+        ? 'Using global sync scope'
+        : `Peer override · include: ${includeList.join(', ') || 'all'} · exclude: ${excludeList.join(', ') || 'none'}`,
+    );
+    const effectiveSummary = el(
+      'div',
+      'peer-scope-effective',
+      `Effective scope · include: ${effectiveInclude.join(', ') || 'all'} · exclude: ${effectiveExclude.join(', ') || 'none'}`,
+    );
+    const includeInput = el('input', 'peer-scope-input') as HTMLInputElement;
+    includeInput.placeholder = 'project-a, project-b';
+    includeInput.value = includeList.join(', ');
+    const excludeInput = el('input', 'peer-scope-input') as HTMLInputElement;
+    excludeInput.placeholder = 'private-repo';
+    excludeInput.value = excludeList.join(', ');
+    const inputRow = el('div', 'peer-scope-row');
+    inputRow.append(includeInput, excludeInput);
+    const scopeActions = el('div', 'peer-scope-actions');
+    const saveScopeBtn = el('button', 'settings-button', 'Save scope') as HTMLButtonElement;
+    const inheritBtn = el('button', 'settings-button', 'Use global') as HTMLButtonElement;
+    saveScopeBtn.addEventListener('click', async () => {
+      saveScopeBtn.disabled = true;
+      saveScopeBtn.textContent = 'Saving...';
+      try {
+        await api.updatePeerScope(peerId, parseScopeList(includeInput.value), parseScopeList(excludeInput.value));
+        await loadSyncData();
+      } catch {
+        saveScopeBtn.textContent = 'Retry save';
+      } finally {
+        saveScopeBtn.disabled = false;
+        if (saveScopeBtn.textContent === 'Saving...') saveScopeBtn.textContent = 'Save scope';
+      }
+    });
+    inheritBtn.addEventListener('click', async () => {
+      inheritBtn.disabled = true;
+      inheritBtn.textContent = 'Resetting...';
+      try {
+        await api.updatePeerScope(peerId, null, null, true);
+        await loadSyncData();
+      } catch {
+        inheritBtn.textContent = 'Retry reset';
+      } finally {
+        inheritBtn.disabled = false;
+        if (inheritBtn.textContent === 'Resetting...') inheritBtn.textContent = 'Use global';
+      }
+    });
+    scopeActions.append(saveScopeBtn, inheritBtn);
+    scopePanel.append(scopeSummary, effectiveSummary, inputRow, scopeActions);
+
     titleRow.append(name, actions);
-    card.append(titleRow, addressLabel, meta);
+    card.append(titleRow, addressLabel, meta, scopePanel);
     syncPeers.appendChild(card);
   });
 }


### PR DESCRIPTION
## Description
Propagate provenance fields through sync replication and add per-peer scope controls so sync behavior can be narrowed by project instead of applying one global rule. This makes the sync layer carry enough identity metadata for later personal/shared filtering.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `uv run pytest tests/test_sync_viewer_api.py`
- `uv run ruff check codemem/viewer.py tests/test_sync_viewer_api.py`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
