### PR TITLE
feat(search): add contributor-aware retrieval filters

### DIFF
--- a/codemem/mcp_server.py
+++ b/codemem/mcp_server.py
@@ -59,6 +59,40 @@ def build_server() -> FastMCP:
     def with_store(handler):
         return handler(get_store())
 
+    def build_filters(
+        *,
+        kind: str | None = None,
+        project: str | None = None,
+        include_actor_ids: list[str] | None = None,
+        exclude_actor_ids: list[str] | None = None,
+        include_workspace_ids: list[str] | None = None,
+        exclude_workspace_ids: list[str] | None = None,
+        include_workspace_kinds: list[str] | None = None,
+        exclude_workspace_kinds: list[str] | None = None,
+        personal_first: bool | None = None,
+    ) -> dict[str, Any]:
+        filters: dict[str, Any] = {}
+        if kind:
+            filters["kind"] = kind
+        resolved_project = project or default_project
+        if resolved_project:
+            filters["project"] = resolved_project
+        if include_actor_ids:
+            filters["include_actor_ids"] = include_actor_ids
+        if exclude_actor_ids:
+            filters["exclude_actor_ids"] = exclude_actor_ids
+        if include_workspace_ids:
+            filters["include_workspace_ids"] = include_workspace_ids
+        if exclude_workspace_ids:
+            filters["exclude_workspace_ids"] = exclude_workspace_ids
+        if include_workspace_kinds:
+            filters["include_workspace_kinds"] = include_workspace_kinds
+        if exclude_workspace_kinds:
+            filters["exclude_workspace_kinds"] = exclude_workspace_kinds
+        if personal_first is not None:
+            filters["personal_first"] = personal_first
+        return filters
+
     def _dedupe_ordered_ids(ids: list[Any]) -> tuple[list[int], list[str]]:
         deduped: list[int] = []
         seen: set[int] = set()
@@ -93,14 +127,26 @@ def build_server() -> FastMCP:
         limit: int = 8,
         kind: str | None = None,
         project: str | None = None,
+        include_actor_ids: list[str] | None = None,
+        exclude_actor_ids: list[str] | None = None,
+        include_workspace_ids: list[str] | None = None,
+        exclude_workspace_ids: list[str] | None = None,
+        include_workspace_kinds: list[str] | None = None,
+        exclude_workspace_kinds: list[str] | None = None,
+        personal_first: bool | None = None,
     ) -> dict[str, Any]:
         def handler(store: MemoryStore) -> dict[str, Any]:
-            filters: dict[str, Any] = {}
-            if kind:
-                filters["kind"] = kind
-            resolved_project = project or default_project
-            if resolved_project:
-                filters["project"] = resolved_project
+            filters = build_filters(
+                kind=kind,
+                project=project,
+                include_actor_ids=include_actor_ids,
+                exclude_actor_ids=exclude_actor_ids,
+                include_workspace_ids=include_workspace_ids,
+                exclude_workspace_ids=exclude_workspace_ids,
+                include_workspace_kinds=include_workspace_kinds,
+                exclude_workspace_kinds=exclude_workspace_kinds,
+                personal_first=personal_first,
+            )
             items = store.search_index(query, limit=limit, filters=filters or None)
             return {"items": items}
 
@@ -113,12 +159,25 @@ def build_server() -> FastMCP:
         depth_before: int = 3,
         depth_after: int = 3,
         project: str | None = None,
+        include_actor_ids: list[str] | None = None,
+        exclude_actor_ids: list[str] | None = None,
+        include_workspace_ids: list[str] | None = None,
+        exclude_workspace_ids: list[str] | None = None,
+        include_workspace_kinds: list[str] | None = None,
+        exclude_workspace_kinds: list[str] | None = None,
+        personal_first: bool | None = None,
     ) -> dict[str, Any]:
         def handler(store: MemoryStore) -> dict[str, Any]:
-            filters: dict[str, Any] = {}
-            resolved_project = project or default_project
-            if resolved_project:
-                filters["project"] = resolved_project
+            filters = build_filters(
+                project=project,
+                include_actor_ids=include_actor_ids,
+                exclude_actor_ids=exclude_actor_ids,
+                include_workspace_ids=include_workspace_ids,
+                exclude_workspace_ids=exclude_workspace_ids,
+                include_workspace_kinds=include_workspace_kinds,
+                exclude_workspace_kinds=exclude_workspace_kinds,
+                personal_first=personal_first,
+            )
             items = store.timeline(
                 query=query,
                 memory_id=memory_id,
@@ -282,14 +341,26 @@ def build_server() -> FastMCP:
         limit: int = 5,
         kind: str | None = None,
         project: str | None = None,
+        include_actor_ids: list[str] | None = None,
+        exclude_actor_ids: list[str] | None = None,
+        include_workspace_ids: list[str] | None = None,
+        exclude_workspace_ids: list[str] | None = None,
+        include_workspace_kinds: list[str] | None = None,
+        exclude_workspace_kinds: list[str] | None = None,
+        personal_first: bool | None = None,
     ) -> dict[str, Any]:
         def handler(store: MemoryStore) -> dict[str, Any]:
-            filters: dict[str, Any] = {}
-            if kind:
-                filters["kind"] = kind
-            resolved_project = project or default_project
-            if resolved_project:
-                filters["project"] = resolved_project
+            filters = build_filters(
+                kind=kind,
+                project=project,
+                include_actor_ids=include_actor_ids,
+                exclude_actor_ids=exclude_actor_ids,
+                include_workspace_ids=include_workspace_ids,
+                exclude_workspace_ids=exclude_workspace_ids,
+                include_workspace_kinds=include_workspace_kinds,
+                exclude_workspace_kinds=exclude_workspace_kinds,
+                personal_first=personal_first,
+            )
             matches = store.search(query, limit=limit, filters=filters or None)
             return {
                 "items": [
@@ -316,15 +387,30 @@ def build_server() -> FastMCP:
         limit: int = 10,
         project: str | None = None,
         include_pack_context: bool = False,
+        include_actor_ids: list[str] | None = None,
+        exclude_actor_ids: list[str] | None = None,
+        include_workspace_ids: list[str] | None = None,
+        exclude_workspace_ids: list[str] | None = None,
+        include_workspace_kinds: list[str] | None = None,
+        exclude_workspace_kinds: list[str] | None = None,
+        personal_first: bool | None = None,
     ) -> dict[str, Any]:
         def handler(store: MemoryStore) -> dict[str, Any]:
-            resolved_project = project or default_project
-            filters = {"project": resolved_project} if resolved_project else None
+            filters = build_filters(
+                project=project,
+                include_actor_ids=include_actor_ids,
+                exclude_actor_ids=exclude_actor_ids,
+                include_workspace_ids=include_workspace_ids,
+                exclude_workspace_ids=exclude_workspace_ids,
+                include_workspace_kinds=include_workspace_kinds,
+                exclude_workspace_kinds=exclude_workspace_kinds,
+                personal_first=personal_first,
+            )
             return store.explain(
                 query=query,
                 ids=ids,
                 limit=limit,
-                filters=filters,
+                filters=filters or None,
                 include_pack_context=include_pack_context,
             )
 
@@ -342,15 +428,29 @@ def build_server() -> FastMCP:
 
     @mcp.tool()
     def memory_recent(
-        limit: int = 8, kind: str | None = None, project: str | None = None
+        limit: int = 8,
+        kind: str | None = None,
+        project: str | None = None,
+        include_actor_ids: list[str] | None = None,
+        exclude_actor_ids: list[str] | None = None,
+        include_workspace_ids: list[str] | None = None,
+        exclude_workspace_ids: list[str] | None = None,
+        include_workspace_kinds: list[str] | None = None,
+        exclude_workspace_kinds: list[str] | None = None,
+        personal_first: bool | None = None,
     ) -> dict[str, Any]:
         def handler(store: MemoryStore) -> dict[str, Any]:
-            filters: dict[str, Any] = {}
-            if kind:
-                filters["kind"] = kind
-            resolved_project = project or default_project
-            if resolved_project:
-                filters["project"] = resolved_project
+            filters = build_filters(
+                kind=kind,
+                project=project,
+                include_actor_ids=include_actor_ids,
+                exclude_actor_ids=exclude_actor_ids,
+                include_workspace_ids=include_workspace_ids,
+                exclude_workspace_ids=exclude_workspace_ids,
+                include_workspace_kinds=include_workspace_kinds,
+                exclude_workspace_kinds=exclude_workspace_kinds,
+                personal_first=personal_first,
+            )
             items = store.recent(limit=limit, filters=filters or None)
             return {"items": items}
 
@@ -358,16 +458,33 @@ def build_server() -> FastMCP:
 
     @mcp.tool()
     def memory_pack(
-        context: str, limit: int | None = None, project: str | None = None
+        context: str,
+        limit: int | None = None,
+        project: str | None = None,
+        include_actor_ids: list[str] | None = None,
+        exclude_actor_ids: list[str] | None = None,
+        include_workspace_ids: list[str] | None = None,
+        exclude_workspace_ids: list[str] | None = None,
+        include_workspace_kinds: list[str] | None = None,
+        exclude_workspace_kinds: list[str] | None = None,
+        personal_first: bool | None = None,
     ) -> dict[str, Any]:
         def handler(store: MemoryStore) -> dict[str, Any]:
-            resolved_project = project or default_project
-            filters = {"project": resolved_project} if resolved_project else None
+            filters = build_filters(
+                project=project,
+                include_actor_ids=include_actor_ids,
+                exclude_actor_ids=exclude_actor_ids,
+                include_workspace_ids=include_workspace_ids,
+                exclude_workspace_ids=exclude_workspace_ids,
+                include_workspace_kinds=include_workspace_kinds,
+                exclude_workspace_kinds=exclude_workspace_kinds,
+                personal_first=personal_first,
+            )
             config = load_config()
             return store.build_memory_pack(
                 context=context,
                 limit=limit or config.pack_observation_limit,
-                filters=filters,
+                filters=filters or None,
             )
 
         return with_store(handler)
@@ -431,7 +548,19 @@ def build_server() -> FastMCP:
                 "files_modified": "list<string>",
                 "prompt_number": "int",
             },
-            "filters": ["kind", "session_id", "since", "project"],
+            "filters": [
+                "kind",
+                "session_id",
+                "since",
+                "project",
+                "include_actor_ids",
+                "exclude_actor_ids",
+                "include_workspace_ids",
+                "exclude_workspace_ids",
+                "include_workspace_kinds",
+                "exclude_workspace_kinds",
+                "personal_first",
+            ],
         }
 
     @mcp.tool()

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -1485,17 +1485,13 @@ class MemoryStore:
     ) -> list[dict[str, Any]]:
         filters = filters or {}
         params: list[Any] = []
-        where = ["active = 1"]
-        join_sessions = False
-        if filters.get("kind"):
-            where.append("kind = ?")
-            params.append(filters["kind"])
-        if filters.get("project"):
-            clause, clause_params = self._project_clause(filters["project"])
-            if clause:
-                where.append(clause)
-                params.extend(clause_params)
-            join_sessions = True
+        where = ["memory_items.active = 1"]
+        join_sessions = store_search._extend_memory_filter_clauses(
+            self,
+            filters,
+            where_clauses=where,
+            params=params,
+        )
         where_clause = " AND ".join(where)
         from_clause = "memory_items"
         if join_sessions:
@@ -1523,6 +1519,7 @@ class MemoryStore:
                 "results": len(results),
                 "kind": filters.get("kind"),
                 "project": filters.get("project"),
+                "personal_first": store_search._personal_first_enabled(filters),
             },
         )
         return results
@@ -1540,16 +1537,15 @@ class MemoryStore:
             return []
         params: list[Any] = list(kinds_list)
         where = [
-            "active = 1",
-            "kind IN ({})".format(", ".join("?" for _ in kinds_list)),
+            "memory_items.active = 1",
+            "memory_items.kind IN ({})".format(", ".join("?" for _ in kinds_list)),
         ]
-        join_sessions = False
-        if filters.get("project"):
-            clause, clause_params = self._project_clause(filters["project"])
-            if clause:
-                where.append(clause)
-                params.extend(clause_params)
-            join_sessions = True
+        join_sessions = store_search._extend_memory_filter_clauses(
+            self,
+            filters,
+            where_clauses=where,
+            params=params,
+        )
         where_clause = " AND ".join(where)
         from_clause = "memory_items"
         if join_sessions:

--- a/codemem/store/packs.py
+++ b/codemem/store/packs.py
@@ -12,14 +12,29 @@ if TYPE_CHECKING:
 
 
 def _get_metadata(item: MemoryResult | dict[str, Any]) -> dict[str, Any]:
+    provenance_keys = (
+        "actor_id",
+        "actor_display_name",
+        "workspace_id",
+        "workspace_kind",
+        "origin_device_id",
+        "origin_source",
+        "trust_state",
+    )
     if not isinstance(item, dict):
-        return item.metadata or {}
-    metadata = item.get("metadata_json")
-    if isinstance(metadata, str):
-        return db.from_json(metadata)
-    if isinstance(metadata, dict):
-        return metadata
-    return {}
+        metadata = dict(item.metadata or {})
+    else:
+        metadata = item.get("metadata_json")
+        if isinstance(metadata, str):
+            metadata = db.from_json(metadata)
+        elif not isinstance(metadata, dict):
+            metadata = {}
+    metadata = dict(metadata)
+    for key in provenance_keys:
+        value = _item_value(item, key, None)
+        if value is not None:
+            metadata[key] = value
+    return metadata
 
 
 def _estimate_work_tokens(store: MemoryStore, item: MemoryResult | dict[str, Any]) -> int:
@@ -578,6 +593,7 @@ def build_memory_pack(
             "body": _item_body(m),
             "confidence": _item_confidence(m),
             "tags": _item_tags(m),
+            "metadata": _get_metadata(m),
             "support_count": 1 + len(duplicate_ids.get(_item_id(m) or -1, set())),
             "duplicate_ids": sorted(duplicate_ids.get(_item_id(m) or -1, set())),
         }

--- a/codemem/store/search.py
+++ b/codemem/store/search.py
@@ -18,6 +18,161 @@ if TYPE_CHECKING:
 
 SQLITE_INT64_MIN = -(2**63)
 SQLITE_INT64_MAX = (2**63) - 1
+PERSONAL_FIRST_BONUS = 0.45
+
+
+def _normalize_filter_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        candidate = value.strip()
+        return [candidate] if candidate else []
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in value:
+        if raw is None:
+            continue
+        candidate = str(raw).strip()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        normalized.append(candidate)
+    return normalized
+
+
+def _normalize_workspace_kinds(value: Any) -> list[str]:
+    normalized: list[str] = []
+    for raw in _normalize_filter_strings(value):
+        lowered = raw.lower()
+        if lowered in {"personal", "shared"} and lowered not in normalized:
+            normalized.append(lowered)
+    return normalized
+
+
+def _personal_first_enabled(filters: dict[str, Any] | None) -> bool:
+    if not filters or "personal_first" not in filters:
+        return True
+    value = filters.get("personal_first")
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+    return bool(value)
+
+
+def _metadata_with_provenance(raw_metadata: Any, row: Any) -> dict[str, Any]:
+    metadata = _coerce_metadata_dict(raw_metadata)
+    for key in (
+        "actor_id",
+        "actor_display_name",
+        "workspace_id",
+        "workspace_kind",
+        "origin_device_id",
+        "origin_source",
+        "trust_state",
+    ):
+        try:
+            value = row[key]
+        except (IndexError, KeyError, TypeError):
+            value = None
+        if value is not None:
+            metadata[key] = value
+    return metadata
+
+
+def _actor_id_for(item: MemoryResult | dict[str, Any]) -> str | None:
+    if isinstance(item, MemoryResult):
+        value = item.metadata.get("actor_id")
+        return str(value) if value else None
+    value = item.get("actor_id")
+    if value:
+        return str(value)
+    metadata = _coerce_metadata_dict(item.get("metadata_json") or item.get("metadata"))
+    actor_id = metadata.get("actor_id")
+    return str(actor_id) if actor_id else None
+
+
+def _personal_bias(
+    store: MemoryStore | None, item: MemoryResult | dict[str, Any], filters: dict[str, Any] | None
+) -> float:
+    if store is None or not _personal_first_enabled(filters):
+        return 0.0
+    actor_id = _actor_id_for(item)
+    if not actor_id or actor_id != store.actor_id:
+        return 0.0
+    return PERSONAL_FIRST_BONUS
+
+
+def _add_multi_value_filter(
+    where_clauses: list[str],
+    params: list[Any],
+    *,
+    column: str,
+    include_values: list[str],
+    exclude_values: list[str],
+) -> None:
+    if include_values:
+        placeholders = ", ".join("?" for _ in include_values)
+        where_clauses.append(f"{column} IN ({placeholders})")
+        params.extend(include_values)
+    if exclude_values:
+        placeholders = ", ".join("?" for _ in exclude_values)
+        where_clauses.append(f"({column} IS NULL OR {column} NOT IN ({placeholders}))")
+        params.extend(exclude_values)
+
+
+def _extend_memory_filter_clauses(
+    store: MemoryStore,
+    filters: dict[str, Any] | None,
+    *,
+    where_clauses: list[str],
+    params: list[Any],
+) -> bool:
+    filters = filters or {}
+    join_sessions = False
+    if filters.get("kind"):
+        where_clauses.append("memory_items.kind = ?")
+        params.append(filters["kind"])
+    if filters.get("session_id"):
+        where_clauses.append("memory_items.session_id = ?")
+        params.append(filters["session_id"])
+    if filters.get("since"):
+        where_clauses.append("memory_items.created_at >= ?")
+        params.append(filters["since"])
+
+    _add_multi_value_filter(
+        where_clauses,
+        params,
+        column="memory_items.actor_id",
+        include_values=_normalize_filter_strings(filters.get("include_actor_ids")),
+        exclude_values=_normalize_filter_strings(filters.get("exclude_actor_ids")),
+    )
+    _add_multi_value_filter(
+        where_clauses,
+        params,
+        column="memory_items.workspace_id",
+        include_values=_normalize_filter_strings(filters.get("include_workspace_ids")),
+        exclude_values=_normalize_filter_strings(filters.get("exclude_workspace_ids")),
+    )
+    _add_multi_value_filter(
+        where_clauses,
+        params,
+        column="memory_items.workspace_kind",
+        include_values=_normalize_workspace_kinds(filters.get("include_workspace_kinds")),
+        exclude_values=_normalize_workspace_kinds(filters.get("exclude_workspace_kinds")),
+    )
+
+    if filters.get("project"):
+        clause, clause_params = store._project_clause(filters["project"])
+        if clause:
+            where_clauses.append(clause)
+            params.extend(clause_params)
+            join_sessions = True
+    return join_sessions
 
 
 def search_index(
@@ -363,20 +518,12 @@ def _load_items_by_ids_for_explain(
 
     scoped_where_clauses = ["memory_items.active = 1", f"memory_items.id IN ({placeholders})"]
     scoped_params: list[Any] = list(ids)
-    join_sessions = False
-    if filters.get("kind"):
-        scoped_where_clauses.append("memory_items.kind = ?")
-        scoped_params.append(filters["kind"])
-    if filters.get("session_id"):
-        scoped_where_clauses.append("memory_items.session_id = ?")
-        scoped_params.append(filters["session_id"])
-    if filters.get("since"):
-        scoped_where_clauses.append("memory_items.created_at >= ?")
-        scoped_params.append(filters["since"])
-    if filters.get("project") and project_clause:
-        scoped_where_clauses.append(project_clause)
-        scoped_params.extend(project_params)
-        join_sessions = True
+    join_sessions = _extend_memory_filter_clauses(
+        store,
+        filters,
+        where_clauses=scoped_where_clauses,
+        params=scoped_params,
+    )
     scoped_join = "JOIN sessions ON sessions.id = memory_items.session_id" if join_sessions else ""
     scoped_rows = store.conn.execute(
         f"""
@@ -454,8 +601,9 @@ def _explain_item(
     recency_component = _recency_score(item.created_at, now=reference_now)
     kind_component = _kind_bonus(item.kind)
     total_score: float | None = None
+    personal_bias = _personal_bias(store, item, {"personal_first": True})
     if base_score is not None:
-        total_score = (base_score * 1.5) + recency_component + kind_component
+        total_score = (base_score * 1.5) + recency_component + kind_component + personal_bias
 
     return {
         "id": item.id,
@@ -473,6 +621,7 @@ def _explain_item(
                 "base": base_score,
                 "recency": recency_component,
                 "kind_bonus": kind_component,
+                "personal_bias": personal_bias,
                 "semantic_boost": None,
             },
         },
@@ -687,22 +836,12 @@ def _semantic_search(
     params: list[Any] = [query_embedding, limit]
     where_clauses = ["memory_items.active = 1"]
     join_sessions = False
-    if filters:
-        if filters.get("kind"):
-            where_clauses.append("memory_items.kind = ?")
-            params.append(filters["kind"])
-        if filters.get("session_id"):
-            where_clauses.append("memory_items.session_id = ?")
-            params.append(filters["session_id"])
-        if filters.get("since"):
-            where_clauses.append("memory_items.created_at >= ?")
-            params.append(filters["since"])
-        if filters.get("project"):
-            clause, clause_params = store._project_clause(filters["project"])
-            if clause:
-                where_clauses.append(clause)
-                params.extend(clause_params)
-            join_sessions = True
+    join_sessions = _extend_memory_filter_clauses(
+        store,
+        filters,
+        where_clauses=where_clauses,
+        params=params,
+    )
     where = " AND ".join(where_clauses)
     join_clause = "JOIN sessions ON sessions.id = memory_items.session_id" if join_sessions else ""
     sql = f"""
@@ -726,7 +865,7 @@ def _semantic_search(
                 "body_text": row["body_text"],
                 "confidence": row["confidence"],
                 "tags_text": row["tags_text"],
-                "metadata_json": row["metadata_json"],
+                "metadata_json": _metadata_with_provenance(row["metadata_json"], row),
                 "created_at": row["created_at"],
                 "updated_at": row["updated_at"],
                 "session_id": row["session_id"],
@@ -782,6 +921,9 @@ def _rerank_results(
     results: list[MemoryResult],
     limit: int,
     recency_days: int | None = None,
+    *,
+    store: MemoryStore | None = None,
+    filters: dict[str, Any] | None = None,
 ) -> list[MemoryResult]:
     if recency_days:
         recent_results = _filter_recent_results(results, recency_days)
@@ -794,6 +936,7 @@ def _rerank_results(
             (item.score * 1.5)
             + _recency_score(item.created_at, now=reference_now)
             + _kind_bonus(item.kind)
+            + _personal_bias(store, item, filters)
         )
 
     ordered = sorted(results, key=score, reverse=True)
@@ -806,6 +949,8 @@ def _rerank_results_hybrid(
     limit: int,
     semantic_ids: set[int],
     recency_days: int | None = None,
+    store: MemoryStore | None = None,
+    filters: dict[str, Any] | None = None,
 ) -> list[MemoryResult]:
     if recency_days:
         recent_results = _filter_recent_results(results, recency_days)
@@ -819,6 +964,7 @@ def _rerank_results_hybrid(
             (item.score * 1.2)
             + (_recency_score(item.created_at, now=reference_now) * 0.8)
             + _kind_bonus(item.kind)
+            + _personal_bias(store, item, filters)
             + semantic_boost
         )
 
@@ -943,7 +1089,13 @@ def _merge_ranked_results(
                 metadata=metadata,
             )
         )
-    baseline = _rerank_results(reranked, limit=limit, recency_days=store.RECALL_RECENCY_DAYS)
+    baseline = _rerank_results(
+        reranked,
+        limit=limit,
+        recency_days=store.RECALL_RECENCY_DAYS,
+        store=store,
+        filters=filters,
+    )
     should_shadow = store._hybrid_retrieval_shadow_log and _should_log_shadow(
         sample_rate=store._hybrid_retrieval_shadow_sample_rate
     )
@@ -954,6 +1106,8 @@ def _merge_ranked_results(
         limit=limit,
         semantic_ids=semantic_ids,
         recency_days=store.RECALL_RECENCY_DAYS,
+        store=store,
+        filters=filters,
     )
     if should_shadow:
         _log_shadow_comparison(
@@ -988,14 +1142,13 @@ def _timeline_around(
         return []
     filters = filters or {}
     params: list[Any] = []
-    join_sessions = False
     where_base = ["memory_items.active = 1"]
-    if filters.get("project"):
-        clause, clause_params = store._project_clause(filters["project"])
-        if clause:
-            where_base.append(clause)
-            params.extend(clause_params)
-        join_sessions = True
+    join_sessions = _extend_memory_filter_clauses(
+        store,
+        filters,
+        where_clauses=where_base,
+        params=params,
+    )
     if anchor_session_id:
         where_base.append("memory_items.session_id = ?")
         params.append(anchor_session_id)
@@ -1197,29 +1350,19 @@ def search(
     effective_limit = max(1, int(limit))
     working_set_paths = _normalize_working_set_paths(filters.get("working_set_paths"))
     query_limit = effective_limit
-    if working_set_paths:
+    if working_set_paths or _personal_first_enabled(filters):
         query_limit = max(effective_limit, min(max(effective_limit * 4, effective_limit + 8), 200))
     expanded_query = _expand_query(query)
     if not expanded_query:
         return []
     params: list[Any] = [expanded_query]
     where_clauses = ["memory_items.active = 1", "memory_fts MATCH ?"]
-    join_sessions = False
-    if filters.get("kind"):
-        where_clauses.append("memory_items.kind = ?")
-        params.append(filters["kind"])
-    if filters.get("session_id"):
-        where_clauses.append("memory_items.session_id = ?")
-        params.append(filters["session_id"])
-    if filters.get("since"):
-        where_clauses.append("memory_items.created_at >= ?")
-        params.append(filters["since"])
-    if filters.get("project"):
-        clause, clause_params = store._project_clause(filters["project"])
-        if clause:
-            where_clauses.append(clause)
-            params.extend(clause_params)
-        join_sessions = True
+    join_sessions = _extend_memory_filter_clauses(
+        store,
+        filters,
+        where_clauses=where_clauses,
+        params=params,
+    )
     where = " AND ".join(where_clauses)
     join_clause = "JOIN sessions ON sessions.id = memory_items.session_id" if join_sessions else ""
     sql = f"""
@@ -1237,32 +1380,37 @@ def search(
     results: list[MemoryResult] = []
     base_scores: dict[int, float] = {}
     for row in rows:
-        metadata = _coerce_metadata_dict(row["metadata_json"])
+        metadata = _metadata_with_provenance(row["metadata_json"], row)
         files_modified = db.from_json(row["files_modified"])
         if isinstance(files_modified, list):
             metadata = dict(metadata)
             metadata.setdefault("files_modified", files_modified)
-        base_score = (float(row["score"]) * 1.5) + float(row["recency"])
-        results.append(
-            MemoryResult(
-                id=row["id"],
-                kind=row["kind"],
-                title=row["title"],
-                body_text=row["body_text"],
-                confidence=row["confidence"],
-                created_at=row["created_at"],
-                updated_at=row["updated_at"],
-                tags_text=row["tags_text"],
-                score=float(row["score"]),
-                session_id=row["session_id"],
-                metadata=metadata,
-            )
+        result = MemoryResult(
+            id=row["id"],
+            kind=row["kind"],
+            title=row["title"],
+            body_text=row["body_text"],
+            confidence=row["confidence"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            tags_text=row["tags_text"],
+            score=float(row["score"]),
+            session_id=row["session_id"],
+            metadata=metadata,
         )
+        base_score = (
+            (float(row["score"]) * 1.5)
+            + float(row["recency"])
+            + _personal_bias(store, result, filters)
+        )
+        results.append(result)
         base_scores[int(row["id"])] = base_score
 
     if working_set_paths:
         results = _rerank_with_working_set(results, base_scores, working_set_paths)
         results = results[:effective_limit]
+    else:
+        results = _rerank_results(results, limit=effective_limit, store=store, filters=filters)
 
     if log_usage:
         tokens_read = sum(
@@ -1277,6 +1425,21 @@ def search(
                 "kind": filters.get("kind"),
                 "project": filters.get("project"),
                 "working_set_paths": len(working_set_paths),
+                "personal_first": _personal_first_enabled(filters),
+                "include_actor_ids": _normalize_filter_strings(filters.get("include_actor_ids")),
+                "exclude_actor_ids": _normalize_filter_strings(filters.get("exclude_actor_ids")),
+                "include_workspace_ids": _normalize_filter_strings(
+                    filters.get("include_workspace_ids")
+                ),
+                "exclude_workspace_ids": _normalize_filter_strings(
+                    filters.get("exclude_workspace_ids")
+                ),
+                "include_workspace_kinds": _normalize_workspace_kinds(
+                    filters.get("include_workspace_kinds")
+                ),
+                "exclude_workspace_kinds": _normalize_workspace_kinds(
+                    filters.get("exclude_workspace_kinds")
+                ),
             },
         )
     return results

--- a/codemem/store/search.py
+++ b/codemem/store/search.py
@@ -355,6 +355,7 @@ def explain(
             source=source,
             rank=rank,
             query_tokens=query_tokens,
+            filters=filters,
             project_filter=filters.get("project"),
             project_value=session_projects.get(item.session_id),
             include_pack_context=include_pack_context,
@@ -590,6 +591,7 @@ def _explain_item(
     source: str,
     rank: int | None,
     query_tokens: list[str],
+    filters: dict[str, Any],
     project_filter: str | None,
     project_value: str | None,
     include_pack_context: bool,
@@ -601,7 +603,7 @@ def _explain_item(
     recency_component = _recency_score(item.created_at, now=reference_now)
     kind_component = _kind_bonus(item.kind)
     total_score: float | None = None
-    personal_bias = _personal_bias(store, item, {"personal_first": True})
+    personal_bias = _personal_bias(store, item, filters)
     if base_score is not None:
         total_score = (base_score * 1.5) + recency_component + kind_component + personal_bias
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,6 +90,12 @@ where `recency = 1.0 / (1.0 + (days_ago / 7.0))`.
 
 This is the baseline search path used by `codemem search`, MCP `memory_search`, and as input to pack construction.
 
+Contributor-aware retrieval layers on top of this baseline without changing the storage model:
+
+- actor filters: `include_actor_ids` / `exclude_actor_ids`
+- workspace filters: `include_workspace_ids`, `exclude_workspace_ids`, `include_workspace_kinds`, `exclude_workspace_kinds`
+- `personal_first`: enabled by default, adding a ranking bonus for memories authored by the local actor
+
 ### Semantic search (sqlite-vec)
 
 When embeddings are available, `memory_vectors` (a `vec0` virtual table from sqlite-vec) stores 384-dimensional float vectors keyed by `memory_id`. Vectors are written automatically when memories are created, or backfilled with `codemem embed`.
@@ -123,7 +129,7 @@ where:
 
 In baseline mode (hybrid disabled), the formula is slightly different: `base_score * 1.5 + recency + kind_bonus` with no semantic boost.
 
-**Scope note:** Hybrid merge/re-rank only runs in the pack-building path. Direct search endpoints (`codemem search`, MCP `memory_search`) use FTS5 scoring with recency weighting but don't merge semantic results.
+**Scope note:** Hybrid merge/re-rank only runs in the pack-building path. Direct search endpoints (`codemem search`, MCP `memory_search`) use FTS5 scoring with recency weighting, actor/workspace filters, and personal-first ranking bias, but don't merge semantic results.
 
 ```mermaid
 flowchart TD

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -105,7 +105,8 @@ Judged query JSONL format:
 ```
 
 - `relevant_ids` are memory item IDs expected in top-k.
-- `filters` is optional and uses the same project/kind filter shape as normal search commands.
+- `filters` is optional and uses the same retrieval filter shape as normal search commands.
+- Supported retrieval filters include `project`, `kind`, `include_actor_ids`, `exclude_actor_ids`, `include_workspace_ids`, `exclude_workspace_ids`, `include_workspace_kinds`, `exclude_workspace_kinds`, and `personal_first`.
 
 ## Sync (Phase 2)
 

--- a/tests/test_mcp_explain.py
+++ b/tests/test_mcp_explain.py
@@ -193,3 +193,34 @@ def test_memory_explain_uses_default_project_scope_when_project_omitted(
     assert {error["code"] for error in payload["errors"]} == {"PROJECT_MISMATCH"}
     mismatch = next(error for error in payload["errors"] if error["code"] == "PROJECT_MISMATCH")
     assert mismatch["ids"] == [memory_b]
+
+
+def test_memory_explain_respects_personal_first_flag(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    memory_id = store.remember(session, kind="note", title="Alpha", body_text="Alpha body")
+    store.end_session(session)
+    store.close()
+
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    server = build_server()
+    payload = _call_tool(
+        server,
+        "memory_explain",
+        {
+            "ids": [memory_id],
+            "project": "/tmp/project-a",
+            "personal_first": False,
+        },
+    )
+
+    item = payload["items"][0]
+    assert item["score"]["components"]["personal_bias"] == 0

--- a/tests/test_mcp_search_filters.py
+++ b/tests/test_mcp_search_filters.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from codemem.mcp_server import build_server
+from codemem.store import MemoryStore
+
+
+def _call_tool(server: Any, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    _content, structured = asyncio.run(server.call_tool(name, arguments))
+    assert isinstance(structured, dict)
+    return structured
+
+
+def _seed_actor_scoped_memories(db_path: Path) -> tuple[str, int, int]:
+    store = MemoryStore(db_path)
+    actor_id = store.actor_id
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    personal_id = store.remember(session, kind="note", title="Alpha", body_text="Local alpha")
+    shared_id = store.remember(
+        session,
+        kind="note",
+        title="Alpha",
+        body_text="Shared alpha",
+        metadata={
+            "actor_id": "actor:teammate",
+            "actor_display_name": "Teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+        },
+    )
+    store.end_session(session)
+    store.close()
+    return actor_id, personal_id, shared_id
+
+
+def test_memory_search_supports_actor_and_workspace_filters(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    actor_id, personal_id, shared_id = _seed_actor_scoped_memories(db_path)
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+
+    server = build_server()
+    shared_only = _call_tool(
+        server,
+        "memory_search",
+        {
+            "query": "alpha",
+            "project": "/tmp/project-a",
+            "include_workspace_kinds": ["shared"],
+            "personal_first": False,
+        },
+    )
+    personal_only = _call_tool(
+        server,
+        "memory_search",
+        {
+            "query": "alpha",
+            "project": "/tmp/project-a",
+            "include_actor_ids": [actor_id],
+        },
+    )
+
+    assert [item["id"] for item in shared_only["items"]] == [shared_id]
+    assert shared_only["items"][0]["metadata"]["workspace_kind"] == "shared"
+    assert [item["id"] for item in personal_only["items"]] == [personal_id]
+
+
+def test_memory_pack_supports_workspace_filters(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    _actor_id, _personal_id, shared_id = _seed_actor_scoped_memories(db_path)
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+
+    server = build_server()
+    payload = _call_tool(
+        server,
+        "memory_pack",
+        {
+            "context": "alpha",
+            "project": "/tmp/project-a",
+            "include_workspace_kinds": ["shared"],
+            "personal_first": False,
+        },
+    )
+
+    assert [item["id"] for item in payload["items"]] == [shared_id]
+    assert payload["items"][0]["metadata"]["workspace_kind"] == "shared"

--- a/tests/test_pack_benchmark.py
+++ b/tests/test_pack_benchmark.py
@@ -63,12 +63,17 @@ def test_pack_benchmark_respects_project_filter(monkeypatch, tmp_path: Path) -> 
             for text in texts:
                 lowered = text.lower()
                 if "alpha" in lowered:
-                    vectors.append([1.0, 0.0])
+                    vector = [0.0] * 384
+                    vector[0] = 1.0
                 else:
-                    vectors.append([0.0, 1.0])
+                    vector = [0.0] * 384
+                    vector[1] = 1.0
+                vectors.append(vector)
             return vectors
 
     monkeypatch.setattr(store_module, "get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.semantic.get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.store.vectors.get_embedding_client", lambda: FakeEmbeddingClient())
 
     store = MemoryStore(tmp_path / "mem.sqlite")
     a = store.start_session(

--- a/tests/test_pack_filter_invariants.py
+++ b/tests/test_pack_filter_invariants.py
@@ -9,9 +9,13 @@ from codemem.store import MemoryStore
 def test_pack_project_filter_is_subset(monkeypatch, tmp_path: Path) -> None:
     class FakeEmbeddingClient:
         def embed(self, texts):
-            return [[1.0, 0.0] for _ in texts]
+            vector = [0.0] * 384
+            vector[0] = 1.0
+            return [list(vector) for _ in texts]
 
     monkeypatch.setattr(store_module, "get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.semantic.get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.store.vectors.get_embedding_client", lambda: FakeEmbeddingClient())
 
     store = MemoryStore(tmp_path / "mem.sqlite")
     a = store.start_session(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -337,6 +337,7 @@ def test_replication_payload_includes_actor_and_workspace_provenance(tmp_path: P
         )
         ops, _ = store.load_replication_ops_since(None, limit=10)
         payload = ops[0]["payload"]
+        assert payload is not None
         assert payload["actor_id"] == store.actor_id
         assert payload["workspace_kind"] == "shared"
         assert payload["workspace_id"] == "shared:team-alpha"
@@ -2494,12 +2495,17 @@ def test_pack_semantic_fallback(monkeypatch, tmp_path: Path) -> None:
             for text in texts:
                 lowered = text.lower()
                 if "alpha" in lowered or "alfa" in lowered:
-                    vectors.append([1.0, 0.0])
+                    vector = [0.0] * 384
+                    vector[0] = 1.0
                 else:
-                    vectors.append([0.0, 1.0])
+                    vector = [0.0] * 384
+                    vector[1] = 1.0
+                vectors.append(vector)
             return vectors
 
     monkeypatch.setattr(store_module, "get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.semantic.get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.store.vectors.get_embedding_client", lambda: FakeEmbeddingClient())
 
     store = MemoryStore(tmp_path / "mem.sqlite")
     session = store.start_session(
@@ -2526,12 +2532,17 @@ def test_semantic_search_respects_project_filter(monkeypatch, tmp_path: Path) ->
             for text in texts:
                 lowered = text.lower()
                 if "alpha" in lowered:
-                    vectors.append([1.0, 0.0])
+                    vector = [0.0] * 384
+                    vector[0] = 1.0
                 else:
-                    vectors.append([0.0, 1.0])
+                    vector = [0.0] * 384
+                    vector[1] = 1.0
+                vectors.append(vector)
             return vectors
 
     monkeypatch.setattr(store_module, "get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.semantic.get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.store.vectors.get_embedding_client", lambda: FakeEmbeddingClient())
 
     store = MemoryStore(tmp_path / "mem.sqlite")
     session_a = store.start_session(
@@ -2565,9 +2576,13 @@ def test_semantic_search_respects_project_filter(monkeypatch, tmp_path: Path) ->
 def test_semantic_search_respects_kind_filter(monkeypatch, tmp_path: Path) -> None:
     class FakeEmbeddingClient:
         def embed(self, texts):
-            return [[1.0, 0.0] for _ in texts]
+            vector = [0.0] * 384
+            vector[0] = 1.0
+            return [list(vector) for _ in texts]
 
     monkeypatch.setattr(store_module, "get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.semantic.get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.store.vectors.get_embedding_client", lambda: FakeEmbeddingClient())
 
     store = MemoryStore(tmp_path / "mem.sqlite")
     session = store.start_session(
@@ -2596,9 +2611,13 @@ def test_semantic_search_respects_kind_filter(monkeypatch, tmp_path: Path) -> No
 def test_semantic_search_respects_project_and_kind_filter(monkeypatch, tmp_path: Path) -> None:
     class FakeEmbeddingClient:
         def embed(self, texts):
-            return [[1.0, 0.0] for _ in texts]
+            vector = [0.0] * 384
+            vector[0] = 1.0
+            return [list(vector) for _ in texts]
 
     monkeypatch.setattr(store_module, "get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.semantic.get_embedding_client", lambda: FakeEmbeddingClient())
+    monkeypatch.setattr("codemem.store.vectors.get_embedding_client", lambda: FakeEmbeddingClient())
 
     store = MemoryStore(tmp_path / "mem.sqlite")
     a = store.start_session(
@@ -3065,6 +3084,148 @@ def test_search_working_set_large_limit_returns_requested_count(tmp_path: Path) 
     assert len(results) == 230
 
 
+def test_search_personal_first_prefers_local_actor_by_default(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    personal_id = store.remember(
+        session,
+        kind="note",
+        title="Parser cleanup",
+        body_text="Parser cleanup notes",
+    )
+    shared_id = store.remember(
+        session,
+        kind="note",
+        title="Parser cleanup",
+        body_text="Parser cleanup notes",
+        metadata={
+            "actor_id": "actor:teammate",
+            "actor_display_name": "Teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+        },
+    )
+    store.end_session(session)
+
+    preferred = store.search("parser cleanup", limit=2, filters={"project": "/tmp/project-a"})
+    baseline = store.search(
+        "parser cleanup",
+        limit=2,
+        filters={"project": "/tmp/project-a", "personal_first": False},
+    )
+
+    assert [item.id for item in preferred] == [personal_id, shared_id]
+    assert [item.id for item in baseline] == [shared_id, personal_id]
+    assert preferred[0].metadata["actor_id"] == store.actor_id
+    assert preferred[1].metadata["workspace_kind"] == "shared"
+
+
+def test_search_filters_by_actor_and_workspace(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    personal_id = store.remember(
+        session,
+        kind="note",
+        title="Shared parser",
+        body_text="Local parser note",
+    )
+    shared_id = store.remember(
+        session,
+        kind="note",
+        title="Shared parser",
+        body_text="Remote parser note",
+        metadata={
+            "actor_id": "actor:teammate",
+            "actor_display_name": "Teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+        },
+    )
+    store.end_session(session)
+
+    actor_filtered = store.search(
+        "shared parser",
+        limit=5,
+        filters={
+            "project": "/tmp/project-a",
+            "include_actor_ids": ["actor:teammate"],
+        },
+    )
+    shared_filtered = store.search(
+        "shared parser",
+        limit=5,
+        filters={
+            "project": "/tmp/project-a",
+            "include_workspace_kinds": ["shared"],
+        },
+    )
+    excluded = store.search(
+        "shared parser",
+        limit=5,
+        filters={
+            "project": "/tmp/project-a",
+            "exclude_workspace_ids": ["shared:team-alpha"],
+        },
+    )
+
+    assert [item.id for item in actor_filtered] == [shared_id]
+    assert [item.id for item in shared_filtered] == [shared_id]
+    assert [item.id for item in excluded] == [personal_id]
+
+
+def test_explain_reports_filter_mismatch_for_actor_filter(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    personal_id = store.remember(session, kind="note", title="Alpha", body_text="Alpha body")
+    shared_id = store.remember(
+        session,
+        kind="note",
+        title="Alpha",
+        body_text="Shared alpha body",
+        metadata={
+            "actor_id": "actor:teammate",
+            "actor_display_name": "Teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+        },
+    )
+    store.end_session(session)
+
+    payload = store.explain(
+        ids=[personal_id, shared_id],
+        filters={
+            "project": "/tmp/project-a",
+            "include_actor_ids": [store.actor_id],
+        },
+    )
+
+    assert [item["id"] for item in payload["items"]] == [personal_id]
+    assert payload["missing_ids"] == [shared_id]
+    errors_by_code = {error["code"]: error for error in payload["errors"]}
+    assert errors_by_code["FILTER_MISMATCH"]["ids"] == [shared_id]
+
+
 def test_explain_ids_reports_missing_and_project_mismatch(tmp_path: Path) -> None:
     store = MemoryStore(tmp_path / "mem.sqlite")
     session_a = store.start_session(
@@ -3184,6 +3345,46 @@ def test_explain_include_pack_context_returns_deterministic_shape(tmp_path: Path
     payload = store.explain(ids=[memory_id], include_pack_context=True)
 
     assert payload["items"][0]["pack_context"] == {"included": None, "section": None}
+
+
+def test_pack_filters_by_workspace_and_includes_provenance_metadata(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    store.remember(session, kind="note", title="Alpha", body_text="Local alpha note")
+    shared_id = store.remember(
+        session,
+        kind="note",
+        title="Alpha",
+        body_text="Shared alpha note",
+        metadata={
+            "actor_id": "actor:teammate",
+            "actor_display_name": "Teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+        },
+    )
+    store.end_session(session)
+
+    pack = store.build_memory_pack(
+        "alpha",
+        limit=5,
+        filters={
+            "project": "/tmp/project-a",
+            "include_workspace_kinds": ["shared"],
+            "personal_first": False,
+        },
+    )
+
+    assert [item["id"] for item in pack["items"]] == [shared_id]
+    assert pack["items"][0]["metadata"]["actor_id"] == "actor:teammate"
+    assert pack["items"][0]["metadata"]["workspace_kind"] == "shared"
 
 
 def test_merge_ranked_results_shadow_logs_without_changing_baseline(


### PR DESCRIPTION
## Description
Add contributor-aware retrieval filters and explain metadata so search, expand, and explain can bias toward the local actor while still exposing why results ranked the way they did. This keeps identity-aware retrieval aligned across interactive search and debugging workflows.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `uv run pytest tests/test_mcp_explain.py`
- `uv run ruff check codemem/store/search.py tests/test_mcp_explain.py`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
