### PR TITLE
feat(viewer): surface provenance and scope context

### DIFF
--- a/codemem/store/usage.py
+++ b/codemem/store/usage.py
@@ -256,6 +256,10 @@ def stats(store: MemoryStore) -> dict[str, Any]:
     }
 
     return {
+        "identity": {
+            "actor_id": store.actor_id,
+            "actor_display_name": store.actor_display_name,
+        },
         "database": {
             "path": db_path,
             "size_bytes": size_bytes,

--- a/codemem/viewer_routes/memory.py
+++ b/codemem/viewer_routes/memory.py
@@ -66,11 +66,13 @@ def _apply_scope_filter(
     store: MemoryStore, filters: dict[str, Any] | None, scope: str | None
 ) -> tuple[dict[str, Any], bool]:
     normalized = str(scope or "all").strip().lower()
-    if normalized not in {"all", "mine", "shared"}:
+    if normalized not in {"all", "mine", "theirs", "shared"}:
         return {}, False
     scoped = dict(filters or {})
     if normalized == "mine":
         scoped["include_actor_ids"] = [store.actor_id]
+    elif normalized == "theirs":
+        scoped["exclude_actor_ids"] = [store.actor_id]
     elif normalized == "shared":
         scoped["include_visibility"] = ["shared"]
     return scoped, True

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -936,7 +936,7 @@
       btn.classList.toggle("active", value === state.feedScopeFilter);
     });
   }
-  function updateFeedView() {
+  function updateFeedView(force = false) {
     const feedList = document.getElementById("feedList");
     const feedMeta = document.getElementById("feedMeta");
     if (!feedList) return;
@@ -946,7 +946,7 @@
     const filterLabel = state.feedTypeFilter === "observations" ? " · observations" : state.feedTypeFilter === "summaries" ? " · session summaries" : "";
     const scopeLabel = feedScopeLabel(state.feedScopeFilter);
     const sig = computeSignature(visible);
-    const changed = sig !== state.lastFeedSignature;
+    const changed = force || sig !== state.lastFeedSignature;
     state.lastFeedSignature = sig;
     if (feedMeta) {
       const filteredLabel = !state.feedQuery.trim() && state.lastFeedFilteredCount ? ` · ${state.lastFeedFilteredCount} observations filtered` : "";
@@ -1306,6 +1306,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (typeof globalThis.lucide !== "undefined") globalThis.lucide.createIcons();
   }
   async function loadHealthData() {
+    const previousActorId = state.lastStatsPayload?.identity?.actor_id || null;
     const [statsPayload, usagePayload, sessionsPayload, rawEventsPayload] = await Promise.all([
       loadStats(),
       loadUsage(state.currentProject),
@@ -1315,9 +1316,13 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     state.lastStatsPayload = statsPayload || {};
     state.lastUsagePayload = usagePayload || {};
     state.lastRawEventsPayload = rawEventsPayload || {};
+    const nextActorId = state.lastStatsPayload?.identity?.actor_id || null;
     renderStats();
     renderSessionSummary();
     renderHealthOverview();
+    if (state.activeTab === "feed" && previousActorId !== nextActorId) {
+      updateFeedView(true);
+    }
   }
   function redactIpOctets(text) {
     return text.replace(/\b(\d{1,3}\.\d{1,3})\.\d{1,3}\.\d{1,3}\b/g, "$1.#.#");

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -101,7 +101,7 @@
   const SYNC_PAIRING_KEY = "codemem-sync-pairing";
   const SYNC_REDACT_KEY = "codemem-sync-redact";
   const FEED_FILTERS = ["all", "observations", "summaries"];
-  const FEED_SCOPES = ["all", "mine", "shared"];
+  const FEED_SCOPES = ["all", "mine", "theirs", "shared"];
   const state = {
     /* Tab */
     activeTab: "feed",
@@ -460,8 +460,18 @@
   let feedProjectGeneration = 0;
   function feedScopeLabel(scope) {
     if (scope === "mine") return " · mine";
+    if (scope === "theirs") return " · theirs";
     if (scope === "shared") return " · shared";
     return "";
+  }
+  function provenanceChip(label, variant = "") {
+    return el("span", `provenance-chip ${variant}`.trim(), label);
+  }
+  function authorLabel(item) {
+    const actorId = String(item.actor_id || "").trim();
+    const actorName = String(item.actor_display_name || "").trim();
+    if (actorId && actorId === state.lastStatsPayload?.identity?.actor_id) return "You";
+    return actorName || actorId || "Unknown author";
   }
   function resetPagination(project) {
     lastFeedProject = project;
@@ -756,13 +766,30 @@
     const tags = parseJsonArray(item.tags || []);
     const files = parseJsonArray(item.files || []);
     const project = item.project || "";
-    const actor = String(item.actor_display_name || item.actor_id || "").trim();
+    const actor = authorLabel(item);
     const visibility = String(item.visibility || metadata?.visibility || "private").trim();
-    const authorLabel = actor ? ` · Author: ${actor}` : "";
-    const visibilityLabel = visibility ? ` · Visibility: ${visibility}` : "";
+    const workspaceKind = String(item.workspace_kind || metadata?.workspace_kind || "").trim();
+    const originSource = String(item.origin_source || metadata?.origin_source || "").trim();
+    const originDeviceId = String(item.origin_device_id || metadata?.origin_device_id || "").trim();
+    const trustState = String(item.trust_state || metadata?.trust_state || "").trim();
     const tagContent = tags.length ? ` · ${tags.map((t) => formatTagLabel(t)).join(", ")}` : "";
     const fileContent = files.length ? ` · ${formatFileList(files)}` : "";
-    meta.textContent = `${project ? `Project: ${project}` : "Project: n/a"}${authorLabel}${visibilityLabel}${tagContent}${fileContent}`;
+    meta.textContent = `${project ? `Project: ${project}` : "Project: n/a"}${tagContent}${fileContent}`;
+    const provenance = el("div", "feed-provenance");
+    provenance.appendChild(
+      provenanceChip(actor, actor === "You" ? "mine" : "author")
+    );
+    provenance.appendChild(provenanceChip(visibility || "private", visibility || "private"));
+    if (workspaceKind && workspaceKind !== visibility) {
+      provenance.appendChild(provenanceChip(workspaceKind, "workspace"));
+    }
+    if (originSource) provenance.appendChild(provenanceChip(originSource, "source"));
+    if (originDeviceId && actor !== "You") {
+      provenance.appendChild(provenanceChip(originDeviceId, "device"));
+    }
+    if (trustState && trustState !== "trusted") {
+      provenance.appendChild(provenanceChip(trustState.replace(/_/g, " "), "trust"));
+    }
     const footer = el("div", "feed-footer");
     const footerLeft = el("div", "feed-footer-left");
     const filesWrap = el("div", "feed-files");
@@ -775,7 +802,7 @@
     if (filesWrap.childElementCount) footerLeft.appendChild(filesWrap);
     if (tagsWrap.childElementCount) footerLeft.appendChild(tagsWrap);
     footer.append(footerLeft, footerRight);
-    card.append(header, meta, bodyNode, footer);
+    card.append(header, provenance, meta, bodyNode, footer);
     return card;
   }
   function filterByType(items) {

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -691,6 +691,34 @@
         font-size: 12px;
       }
 
+      .feed-provenance {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+
+      .provenance-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 3px 8px;
+        border-radius: var(--radius-pill);
+        border: 1px solid var(--border);
+        background: var(--surface-2);
+        color: var(--text-tertiary);
+        font-size: 11px;
+        line-height: 1.2;
+        white-space: nowrap;
+      }
+      .provenance-chip.mine { background: var(--accent-subtle); color: var(--accent); border-color: rgba(43, 122, 176, 0.18); }
+      .provenance-chip.author { color: var(--text-secondary); }
+      .provenance-chip.private { background: rgba(140, 140, 140, 0.12); color: var(--text-secondary); }
+      .provenance-chip.shared { background: rgba(64, 125, 88, 0.12); color: #407d58; }
+      .provenance-chip.workspace { background: rgba(143, 173, 189, 0.12); color: #6b8fa3; }
+      .provenance-chip.source { background: rgba(94, 129, 172, 0.12); color: #5e81ac; }
+      .provenance-chip.device { background: rgba(128, 110, 74, 0.12); color: #806e4a; }
+      .provenance-chip.trust { background: rgba(202, 138, 4, 0.12); color: #a16207; }
+
       .feed-body {
         font-size: 13px;
         line-height: 1.55;
@@ -1349,6 +1377,7 @@
           <div class="feed-toggle" id="feedScopeToggle">
             <button class="toggle-button" data-filter="all">All visible</button>
             <button class="toggle-button" data-filter="mine">Mine</button>
+            <button class="toggle-button" data-filter="theirs">Theirs</button>
             <button class="toggle-button" data-filter="shared">Shared</button>
           </div>
           <div class="feed-toggle" id="feedTypeToggle">

--- a/tests/test_viewer_routes_memory.py
+++ b/tests/test_viewer_routes_memory.py
@@ -150,6 +150,13 @@ def test_observations_endpoint_supports_scope_filter(tmp_path: Path) -> None:
         assert shared_handler.status == 200
         assert shared_handler.response is not None
         assert [item["id"] for item in shared_handler.response["items"]] == [shared_id]
+
+        theirs_handler = DummyHandler()
+        handled = memory.handle_get(theirs_handler, store, "/api/observations", "scope=theirs")
+        assert handled is True
+        assert theirs_handler.status == 200
+        assert theirs_handler.response is not None
+        assert [item["id"] for item in theirs_handler.response["items"]] == [shared_id]
     finally:
         store.close()
 

--- a/viewer_ui/src/lib/state.ts
+++ b/viewer_ui/src/lib/state.ts
@@ -13,7 +13,7 @@ const SYNC_REDACT_KEY = 'codemem-sync-redact';
 
 export const FEED_FILTERS = ['all', 'observations', 'summaries'] as const;
 export type FeedFilter = (typeof FEED_FILTERS)[number];
-export const FEED_SCOPES = ['all', 'mine', 'shared'] as const;
+export const FEED_SCOPES = ['all', 'mine', 'theirs', 'shared'] as const;
 export type FeedScope = (typeof FEED_SCOPES)[number];
 
 /* ── Mutable application state ─────────────────────────────── */

--- a/viewer_ui/src/tabs/feed.ts
+++ b/viewer_ui/src/tabs/feed.ts
@@ -657,7 +657,7 @@ export function updateFeedScopeToggle() {
   });
 }
 
-export function updateFeedView() {
+export function updateFeedView(force = false) {
   const feedList = document.getElementById('feedList');
   const feedMeta = document.getElementById('feedMeta');
   if (!feedList) return;
@@ -669,7 +669,7 @@ export function updateFeedView() {
   const scopeLabel = feedScopeLabel(state.feedScopeFilter);
 
   const sig = computeSignature(visible);
-  const changed = sig !== state.lastFeedSignature;
+  const changed = force || sig !== state.lastFeedSignature;
   state.lastFeedSignature = sig;
 
   if (feedMeta) {

--- a/viewer_ui/src/tabs/feed.ts
+++ b/viewer_ui/src/tabs/feed.ts
@@ -85,8 +85,20 @@ let feedProjectGeneration = 0;
 
 function feedScopeLabel(scope: string): string {
   if (scope === 'mine') return ' · mine';
+  if (scope === 'theirs') return ' · theirs';
   if (scope === 'shared') return ' · shared';
   return '';
+}
+
+function provenanceChip(label: string, variant = ''): HTMLElement {
+  return el('span', `provenance-chip ${variant}`.trim(), label);
+}
+
+function authorLabel(item: any): string {
+  const actorId = String(item.actor_id || '').trim();
+  const actorName = String(item.actor_display_name || '').trim();
+  if (actorId && actorId === state.lastStatsPayload?.identity?.actor_id) return 'You';
+  return actorName || actorId || 'Unknown author';
 }
 
 function resetPagination(project: string) {
@@ -445,13 +457,31 @@ function renderFeedItem(item: any): HTMLElement {
   const tags = parseJsonArray(item.tags || []);
   const files = parseJsonArray(item.files || []);
   const project = item.project || '';
-  const actor = String(item.actor_display_name || item.actor_id || '').trim();
+  const actor = authorLabel(item);
   const visibility = String(item.visibility || metadata?.visibility || 'private').trim();
-  const authorLabel = actor ? ` · Author: ${actor}` : '';
-  const visibilityLabel = visibility ? ` · Visibility: ${visibility}` : '';
+  const workspaceKind = String(item.workspace_kind || metadata?.workspace_kind || '').trim();
+  const originSource = String(item.origin_source || metadata?.origin_source || '').trim();
+  const originDeviceId = String(item.origin_device_id || metadata?.origin_device_id || '').trim();
+  const trustState = String(item.trust_state || metadata?.trust_state || '').trim();
   const tagContent = tags.length ? ` · ${tags.map((t: any) => formatTagLabel(t)).join(', ')}` : '';
   const fileContent = files.length ? ` · ${formatFileList(files)}` : '';
-  meta.textContent = `${project ? `Project: ${project}` : 'Project: n/a'}${authorLabel}${visibilityLabel}${tagContent}${fileContent}`;
+  meta.textContent = `${project ? `Project: ${project}` : 'Project: n/a'}${tagContent}${fileContent}`;
+
+  const provenance = el('div', 'feed-provenance');
+  provenance.appendChild(
+    provenanceChip(actor, actor === 'You' ? 'mine' : 'author'),
+  );
+  provenance.appendChild(provenanceChip(visibility || 'private', visibility || 'private'));
+  if (workspaceKind && workspaceKind !== visibility) {
+    provenance.appendChild(provenanceChip(workspaceKind, 'workspace'));
+  }
+  if (originSource) provenance.appendChild(provenanceChip(originSource, 'source'));
+  if (originDeviceId && actor !== 'You') {
+    provenance.appendChild(provenanceChip(originDeviceId, 'device'));
+  }
+  if (trustState && trustState !== 'trusted') {
+    provenance.appendChild(provenanceChip(trustState.replace(/_/g, ' '), 'trust'));
+  }
 
   // Footer
   const footer = el('div', 'feed-footer');
@@ -464,7 +494,7 @@ function renderFeedItem(item: any): HTMLElement {
   if (tagsWrap.childElementCount) footerLeft.appendChild(tagsWrap);
   footer.append(footerLeft, footerRight);
 
-  card.append(header, meta, bodyNode, footer);
+  card.append(header, provenance, meta, bodyNode, footer);
   return card;
 }
 

--- a/viewer_ui/src/tabs/health.ts
+++ b/viewer_ui/src/tabs/health.ts
@@ -13,6 +13,7 @@ import {
 } from '../lib/format';
 import { state, isDetailsOpen, setDetailsOpen } from '../lib/state';
 import * as api from '../lib/api';
+import { updateFeedView } from './feed';
 
 type HealthAction = {
   label: string;
@@ -310,6 +311,7 @@ export function renderSessionSummary() {
 /* ── Data loading ────────────────────────────────────────── */
 
 export async function loadHealthData() {
+  const previousActorId = state.lastStatsPayload?.identity?.actor_id || null;
   const [statsPayload, usagePayload, sessionsPayload, rawEventsPayload] = await Promise.all([
     api.loadStats(),
     api.loadUsage(state.currentProject),
@@ -320,10 +322,14 @@ export async function loadHealthData() {
   state.lastStatsPayload = statsPayload || {};
   state.lastUsagePayload = usagePayload || {};
   state.lastRawEventsPayload = rawEventsPayload || {};
+  const nextActorId = state.lastStatsPayload?.identity?.actor_id || null;
 
   renderStats();
   renderSessionSummary();
   renderHealthOverview();
+  if (state.activeTab === 'feed' && previousActorId !== nextActorId) {
+    updateFeedView(true);
+  }
 }
 
 /* ── Init ────────────────────────────────────────────────── */


### PR DESCRIPTION
## Description
Surface provenance and ownership context in the viewer so users can tell whether a memory is theirs, another actor's, or shared. This makes the new sync/search identity model understandable in the UI instead of burying it in backend metadata.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `bun run check`
- `bun run build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
