### PR TITLE
fix(db): backfill identity columns for existing databases

### DIFF
--- a/codemem/db.py
+++ b/codemem/db.py
@@ -470,6 +470,22 @@ def _raw_event_identity_needs_rebuild(conn: sqlite3.Connection) -> bool:
     )
 
 
+def _raw_event_identity_needs_data_migration(conn: sqlite3.Connection) -> bool:
+    required_columns = {
+        "raw_events": {"source", "stream_id"},
+        "raw_event_sessions": {"source", "stream_id"},
+        "raw_event_flush_batches": {"source", "stream_id"},
+        "opencode_sessions": {"source", "stream_id"},
+    }
+    for table, columns in required_columns.items():
+        if not _table_exists(conn, table):
+            continue
+        existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+        if not columns.issubset(existing):
+            return True
+    return _raw_event_identity_needs_rebuild(conn)
+
+
 def _assert_no_raw_event_identity_collisions(conn: sqlite3.Connection) -> None:
     checks = [
         (
@@ -1026,11 +1042,12 @@ def _ensure_memory_identity_schema(conn: sqlite3.Connection) -> None:
 
 def initialize_schema(conn: sqlite3.Connection) -> None:
     current_version = _schema_user_version(conn)
+    raw_event_identity_migrate = _raw_event_identity_needs_data_migration(conn)
     if current_version < 1:
         _initialize_schema_v1(conn)
         current_version = 1
     _ensure_memory_identity_schema(conn)
-    _ensure_raw_event_identity_schema(conn, migrate_data=current_version < SCHEMA_VERSION)
+    _ensure_raw_event_identity_schema(conn, migrate_data=raw_event_identity_migrate)
     if current_version < SCHEMA_VERSION:
         conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
     _ensure_vector_schema(conn)

--- a/codemem/db.py
+++ b/codemem/db.py
@@ -15,7 +15,7 @@ LEGACY_DEFAULT_DB_PATHS = (
     Path.home() / ".codemem.sqlite",
     Path.home() / ".opencode-mem.sqlite",
 )
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 def _sidecar_paths(path: Path) -> list[Path]:
@@ -984,11 +984,52 @@ def _ensure_raw_event_reliability_schema(conn: sqlite3.Connection) -> None:
     _ensure_column(conn, "raw_event_flush_batches", "attempt_count", "INTEGER NOT NULL DEFAULT 0")
 
 
+def _ensure_memory_identity_schema(conn: sqlite3.Connection) -> None:
+    if not _table_exists(conn, "memory_items"):
+        return
+    _ensure_column(conn, "memory_items", "subtitle", "TEXT")
+    _ensure_column(conn, "memory_items", "facts", "TEXT")
+    _ensure_column(conn, "memory_items", "narrative", "TEXT")
+    _ensure_column(conn, "memory_items", "concepts", "TEXT")
+    _ensure_column(conn, "memory_items", "files_read", "TEXT")
+    _ensure_column(conn, "memory_items", "files_modified", "TEXT")
+    _ensure_column(conn, "memory_items", "prompt_number", "INTEGER")
+    _ensure_column(conn, "memory_items", "user_prompt_id", "INTEGER")
+    _ensure_column(conn, "memory_items", "import_key", "TEXT")
+    _ensure_column(conn, "memory_items", "deleted_at", "TEXT")
+    _ensure_column(conn, "memory_items", "rev", "INTEGER")
+    _ensure_column(conn, "memory_items", "actor_id", "TEXT")
+    _ensure_column(conn, "memory_items", "actor_display_name", "TEXT")
+    _ensure_column(conn, "memory_items", "visibility", "TEXT")
+    _ensure_column(conn, "memory_items", "workspace_id", "TEXT")
+    _ensure_column(conn, "memory_items", "workspace_kind", "TEXT")
+    _ensure_column(conn, "memory_items", "origin_device_id", "TEXT")
+    _ensure_column(conn, "memory_items", "origin_source", "TEXT")
+    _ensure_column(conn, "memory_items", "trust_state", "TEXT")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_import_key ON memory_items(import_key)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_user_prompt_id ON memory_items(user_prompt_id)"
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_memory_items_actor_id ON memory_items(actor_id)")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_visibility ON memory_items(visibility)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_workspace_id ON memory_items(workspace_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_items_workspace_kind ON memory_items(workspace_kind)"
+    )
+
+
 def initialize_schema(conn: sqlite3.Connection) -> None:
     current_version = _schema_user_version(conn)
     if current_version < 1:
         _initialize_schema_v1(conn)
         current_version = 1
+    _ensure_memory_identity_schema(conn)
     _ensure_raw_event_identity_schema(conn, migrate_data=current_version < SCHEMA_VERSION)
     if current_version < SCHEMA_VERSION:
         conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -86,6 +86,78 @@ def test_initialize_schema_skips_reinit_but_keeps_kind_normalization(
     assert kind == "decision"
 
 
+def test_initialize_schema_upgrades_existing_v3_db_with_identity_columns(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CODEMEM_EMBEDDING_DISABLED", "1")
+    conn = db.connect(tmp_path / "mem.sqlite")
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                cwd TEXT,
+                project TEXT,
+                git_remote TEXT,
+                git_branch TEXT,
+                user TEXT,
+                tool_version TEXT,
+                metadata_json TEXT,
+                import_key TEXT
+            );
+
+            CREATE TABLE memory_items (
+                id INTEGER PRIMARY KEY,
+                session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                kind TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body_text TEXT NOT NULL,
+                confidence REAL DEFAULT 0.5,
+                tags_text TEXT DEFAULT '',
+                active INTEGER DEFAULT 1,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                metadata_json TEXT
+            );
+
+            CREATE TABLE raw_event_flush_batches (
+                id INTEGER PRIMARY KEY,
+                opencode_session_id TEXT,
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE user_prompts (
+                id INTEGER PRIMARY KEY,
+                session_id INTEGER,
+                project TEXT,
+                prompt_text TEXT,
+                created_at TEXT
+            );
+            """
+        )
+        conn.execute("PRAGMA user_version = 3")
+        conn.commit()
+
+        db.initialize_schema(conn)
+
+        actor_column = conn.execute(
+            "SELECT name FROM pragma_table_info('memory_items') WHERE name = 'actor_id'"
+        ).fetchone()
+        visibility_column = conn.execute(
+            "SELECT name FROM pragma_table_info('memory_items') WHERE name = 'visibility'"
+        ).fetchone()
+        row = conn.execute("PRAGMA user_version").fetchone()
+    finally:
+        conn.close()
+
+    assert actor_column is not None
+    assert visibility_column is not None
+    assert row is not None
+    assert int(row[0]) == db.SCHEMA_VERSION
+
+
 def test_initialize_schema_backfills_raw_event_identity_without_reinit(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -415,3 +415,102 @@ def test_initialize_schema_fails_fast_on_identity_collisions(monkeypatch, tmp_pa
             assert "collision" in str(exc).lower()
     finally:
         conn.close()
+
+
+def test_initialize_schema_skips_raw_event_backfill_for_already_migrated_v4(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CODEMEM_EMBEDDING_DISABLED", "1")
+    conn = db.connect(tmp_path / "v4.sqlite")
+    try:
+        conn.execute("PRAGMA user_version = 4")
+        conn.executescript(
+            """
+            CREATE TABLE raw_events (
+                id INTEGER PRIMARY KEY,
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL DEFAULT '',
+                opencode_session_id TEXT NOT NULL,
+                event_id TEXT,
+                event_seq INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                ts_wall_ms INTEGER,
+                ts_mono_ms REAL,
+                payload_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(source, stream_id, event_seq),
+                UNIQUE(source, stream_id, event_id)
+            );
+
+            CREATE TABLE raw_event_sessions (
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL,
+                opencode_session_id TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (source, stream_id)
+            );
+
+            CREATE TABLE raw_event_flush_batches (
+                id INTEGER PRIMARY KEY,
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL,
+                opencode_session_id TEXT NOT NULL,
+                start_event_seq INTEGER NOT NULL,
+                end_event_seq INTEGER NOT NULL,
+                extractor_version TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                UNIQUE(source, stream_id, start_event_seq, end_event_seq, extractor_version)
+            );
+
+            CREATE TABLE opencode_sessions (
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL,
+                opencode_session_id TEXT NOT NULL,
+                session_id INTEGER,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (source, stream_id)
+            );
+
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                started_at TEXT NOT NULL,
+                user TEXT,
+                tool_version TEXT
+            );
+
+            CREATE TABLE memory_items (
+                id INTEGER PRIMARY KEY,
+                session_id INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body_text TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                user_prompt_id INTEGER
+            );
+
+            CREATE TABLE user_prompts (
+                id INTEGER PRIMARY KEY
+            );
+            """
+        )
+        conn.commit()
+
+        monkeypatch.setattr(
+            db,
+            "_backfill_raw_event_identity_columns",
+            lambda _conn: (_ for _ in ()).throw(
+                AssertionError("raw-event backfill should not rerun")
+            ),
+        )
+
+        db.initialize_schema(conn)
+
+        row = conn.execute("PRAGMA user_version").fetchone()
+        assert row is not None
+        assert int(row[0]) == db.SCHEMA_VERSION
+    finally:
+        conn.close()


### PR DESCRIPTION
## Description
Backfill identity-related columns for existing databases at startup so older local databases can adopt the new provenance and visibility model without throwing missing-column errors. This makes the identity-aware stack safe for upgrades instead of only for fresh databases.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `uv run pytest tests/test_db_schema.py`
- `uv run ruff check codemem/db.py tests/test_db_schema.py`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
