### PR TITLE
feat(sync): claim peers as part of your identity

### DIFF
--- a/codemem/db.py
+++ b/codemem/db.py
@@ -15,7 +15,7 @@ LEGACY_DEFAULT_DB_PATHS = (
     Path.home() / ".codemem.sqlite",
     Path.home() / ".opencode-mem.sqlite",
 )
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 
 def _sidecar_paths(path: Path) -> list[Path]:
@@ -325,6 +325,7 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
             pinned_fingerprint TEXT,
             public_key TEXT,
             addresses_json TEXT,
+            claimed_local_actor INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL,
             last_seen_at TEXT,
             last_sync_at TEXT,
@@ -392,6 +393,7 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
     _ensure_column(conn, "sync_peers", "public_key", "TEXT")
     _ensure_column(conn, "sync_peers", "projects_include_json", "TEXT")
     _ensure_column(conn, "sync_peers", "projects_exclude_json", "TEXT")
+    _ensure_column(conn, "sync_peers", "claimed_local_actor", "INTEGER NOT NULL DEFAULT 0")
     _ensure_column(conn, "raw_event_sessions", "project", "TEXT")
     _ensure_column(conn, "raw_event_sessions", "started_at", "TEXT")
     _ensure_column(conn, "raw_event_sessions", "last_seen_ts_wall_ms", "INTEGER")
@@ -1040,6 +1042,15 @@ def _ensure_memory_identity_schema(conn: sqlite3.Connection) -> None:
     )
 
 
+def _ensure_sync_peer_schema(conn: sqlite3.Connection) -> None:
+    if not _table_exists(conn, "sync_peers"):
+        return
+    _ensure_column(conn, "sync_peers", "public_key", "TEXT")
+    _ensure_column(conn, "sync_peers", "projects_include_json", "TEXT")
+    _ensure_column(conn, "sync_peers", "projects_exclude_json", "TEXT")
+    _ensure_column(conn, "sync_peers", "claimed_local_actor", "INTEGER NOT NULL DEFAULT 0")
+
+
 def initialize_schema(conn: sqlite3.Connection) -> None:
     current_version = _schema_user_version(conn)
     raw_event_identity_migrate = _raw_event_identity_needs_data_migration(conn)
@@ -1047,6 +1058,7 @@ def initialize_schema(conn: sqlite3.Connection) -> None:
         _initialize_schema_v1(conn)
         current_version = 1
     _ensure_memory_identity_schema(conn)
+    _ensure_sync_peer_schema(conn)
     _ensure_raw_event_identity_schema(conn, migrate_data=raw_event_identity_migrate)
     if current_version < SCHEMA_VERSION:
         conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -264,6 +264,30 @@ class MemoryStore:
             )
         self.conn.commit()
 
+    def same_actor_peer_ids(self) -> list[str]:
+        rows = self.conn.execute(
+            "SELECT peer_device_id FROM sync_peers WHERE claimed_local_actor = 1 ORDER BY peer_device_id"
+        ).fetchall()
+        return [str(row["peer_device_id"]) for row in rows if row["peer_device_id"]]
+
+    def claimed_same_actor_legacy_actor_ids(self) -> list[str]:
+        return [f"legacy-sync:{peer_id}" for peer_id in self.same_actor_peer_ids()]
+
+    def memory_owned_by_self(self, item: dict[str, Any] | MemoryResult) -> bool:
+        claimed_peers = set(self.same_actor_peer_ids())
+        legacy_actor_ids = set(self.claimed_same_actor_legacy_actor_ids())
+        if isinstance(item, MemoryResult):
+            actor_id = self._clean_optional_str(item.metadata.get("actor_id"))
+            origin_device_id = self._clean_optional_str(item.metadata.get("origin_device_id"))
+        else:
+            actor_id = self._clean_optional_str(item.get("actor_id"))
+            origin_device_id = self._clean_optional_str(item.get("origin_device_id"))
+        if actor_id == self.actor_id:
+            return True
+        if origin_device_id and origin_device_id in claimed_peers:
+            return True
+        return bool(actor_id and actor_id in legacy_actor_ids)
+
     def _effective_sync_project_filters(
         self, *, peer_device_id: str | None = None
     ) -> tuple[list[str], list[str]]:

--- a/codemem/store/replication.py
+++ b/codemem/store/replication.py
@@ -92,6 +92,16 @@ def _sync_visibility_allowed(payload: dict[str, Any] | None) -> bool:
     return visibility == "shared"
 
 
+def _peer_claimed_local_actor(store: MemoryStore, peer_device_id: str | None) -> bool:
+    if not peer_device_id:
+        return False
+    row = store.conn.execute(
+        "SELECT claimed_local_actor FROM sync_peers WHERE peer_device_id = ?",
+        (peer_device_id,),
+    ).fetchone()
+    return bool(row and row["claimed_local_actor"])
+
+
 def count_replication_ops_missing_project(store: MemoryStore) -> int:
     """Count memory_item replication ops whose payload lacks a usable project.
 
@@ -170,7 +180,9 @@ def filter_replication_ops_for_sync_with_status(
             project = None
             payload = op.get("payload")
             if isinstance(payload, dict):
-                if not _sync_visibility_allowed(payload):
+                if not _sync_visibility_allowed(payload) and not _peer_claimed_local_actor(
+                    store, peer_device_id
+                ):
                     skipped_count += 1
                     if first_skipped is None:
                         first_skipped = {

--- a/codemem/store/search.py
+++ b/codemem/store/search.py
@@ -106,15 +106,34 @@ def _actor_id_for(item: MemoryResult | dict[str, Any]) -> str | None:
     return str(actor_id) if actor_id else None
 
 
+def _ownership_scope_clause(store: MemoryStore, scope: str | None) -> tuple[str | None, list[Any]]:
+    normalized = str(scope or "").strip().lower()
+    if normalized not in {"mine", "theirs"}:
+        return None, []
+    claimed_peer_ids = store.same_actor_peer_ids()
+    legacy_actor_ids = store.claimed_same_actor_legacy_actor_ids()
+    owned_parts = ["memory_items.actor_id = ?"]
+    params: list[Any] = [store.actor_id]
+    if claimed_peer_ids:
+        placeholders = ", ".join("?" for _ in claimed_peer_ids)
+        owned_parts.append(f"memory_items.origin_device_id IN ({placeholders})")
+        params.extend(claimed_peer_ids)
+    if legacy_actor_ids:
+        placeholders = ", ".join("?" for _ in legacy_actor_ids)
+        owned_parts.append(f"memory_items.actor_id IN ({placeholders})")
+        params.extend(legacy_actor_ids)
+    owned_clause = "(" + " OR ".join(owned_parts) + ")"
+    if normalized == "mine":
+        return owned_clause, params
+    return f"NOT {owned_clause}", params
+
+
 def _personal_bias(
     store: MemoryStore | None, item: MemoryResult | dict[str, Any], filters: dict[str, Any] | None
 ) -> float:
     if store is None or not _personal_first_enabled(filters):
         return 0.0
-    actor_id = _actor_id_for(item)
-    if not actor_id or actor_id != store.actor_id:
-        return 0.0
-    return PERSONAL_FIRST_BONUS
+    return PERSONAL_FIRST_BONUS if store.memory_owned_by_self(item) else 0.0
 
 
 def _add_multi_value_filter(
@@ -153,6 +172,12 @@ def _extend_memory_filter_clauses(
     if filters.get("since"):
         where_clauses.append("memory_items.created_at >= ?")
         params.append(filters["since"])
+    ownership_clause, ownership_params = _ownership_scope_clause(
+        store, filters.get("ownership_scope")
+    )
+    if ownership_clause:
+        where_clauses.append(ownership_clause)
+        params.extend(ownership_params)
 
     _add_multi_value_filter(
         where_clauses,

--- a/codemem/sync/discovery.py
+++ b/codemem/sync/discovery.py
@@ -152,6 +152,23 @@ def set_peer_project_filter(
     conn.commit()
 
 
+def set_peer_local_actor_claim(
+    conn: sqlite3.Connection,
+    peer_device_id: str,
+    *,
+    claimed_local_actor: bool,
+) -> None:
+    conn.execute(
+        """
+        UPDATE sync_peers
+        SET claimed_local_actor = ?
+        WHERE peer_device_id = ?
+        """,
+        (1 if claimed_local_actor else 0, peer_device_id),
+    )
+    conn.commit()
+
+
 def record_sync_attempt(
     conn: sqlite3.Connection,
     peer_device_id: str,

--- a/codemem/viewer.py
+++ b/codemem/viewer.py
@@ -129,6 +129,7 @@ class ViewerHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         strict_paths = {
             "/api/sync/peers/rename",
+            "/api/sync/peers/identity",
             "/api/sync/peers/scope",
             "/api/sync/actions/sync-now",
             "/api/sync/run",

--- a/codemem/viewer_routes/memory.py
+++ b/codemem/viewer_routes/memory.py
@@ -62,6 +62,11 @@ def _attach_session_fields(store: MemoryStore, items: list[dict[str, Any]]) -> N
         item.setdefault("cwd", fields.get("cwd") or "")
 
 
+def _attach_ownership_fields(store: MemoryStore, items: list[dict[str, Any]]) -> None:
+    for item in items:
+        item["owned_by_self"] = store.memory_owned_by_self(item)
+
+
 def _apply_scope_filter(
     store: MemoryStore, filters: dict[str, Any] | None, scope: str | None
 ) -> tuple[dict[str, Any], bool]:
@@ -70,9 +75,9 @@ def _apply_scope_filter(
         return {}, False
     scoped = dict(filters or {})
     if normalized == "mine":
-        scoped["include_actor_ids"] = [store.actor_id]
+        scoped["ownership_scope"] = "mine"
     elif normalized == "theirs":
-        scoped["exclude_actor_ids"] = [store.actor_id]
+        scoped["ownership_scope"] = "theirs"
     elif normalized == "shared":
         scoped["include_visibility"] = ["shared"]
     return scoped, True
@@ -140,6 +145,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
         if has_more:
             items = items[:limit]
         _attach_session_fields(store, items)
+        _attach_ownership_fields(store, items)
         handler._send_json(
             {
                 "items": items,
@@ -175,6 +181,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
         if has_more:
             items = items[:limit]
         _attach_session_fields(store, items)
+        _attach_ownership_fields(store, items)
         handler._send_json(
             {
                 "items": items,
@@ -294,6 +301,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
             return True
         items = store.recent(limit=limit, filters=scoped_filters)
         _attach_session_fields(store, items)
+        _attach_ownership_fields(store, items)
         handler._send_json({"items": items})
         return True
 

--- a/codemem/viewer_routes/sync.py
+++ b/codemem/viewer_routes/sync.py
@@ -9,7 +9,12 @@ from urllib.parse import parse_qs
 
 from ..net import pick_advertise_host, pick_advertise_hosts
 from ..store import MemoryStore
-from ..sync.discovery import load_peer_addresses, normalize_address, set_peer_project_filter
+from ..sync.discovery import (
+    load_peer_addresses,
+    normalize_address,
+    set_peer_local_actor_claim,
+    set_peer_project_filter,
+)
 from ..sync.sync_pass import sync_once
 from ..sync_identity import ensure_device_identity, load_public_key
 from ..sync_runtime import SyncRuntimeStatus, effective_status
@@ -185,7 +190,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
             """
             SELECT peer_device_id, name, pinned_fingerprint, addresses_json,
                    last_seen_at, last_sync_at, last_error,
-                   projects_include_json, projects_exclude_json
+                   projects_include_json, projects_exclude_json, claimed_local_actor
             FROM sync_peers
             ORDER BY name, peer_device_id
             """
@@ -215,6 +220,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                 "last_sync_at": row["last_sync_at"],
                 "last_error": row["last_error"] if include_diagnostics else None,
                 "has_error": bool(row["last_error"]),
+                "claimed_local_actor": bool(row["claimed_local_actor"]),
                 "project_scope": {
                     "include": override_include,
                     "exclude": override_exclude,
@@ -298,7 +304,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
             """
             SELECT peer_device_id, name, pinned_fingerprint, addresses_json,
                    last_seen_at, last_sync_at, last_error,
-                   projects_include_json, projects_exclude_json
+                   projects_include_json, projects_exclude_json, claimed_local_actor
             FROM sync_peers
             ORDER BY name, peer_device_id
             """
@@ -328,6 +334,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                     "last_sync_at": row["last_sync_at"],
                     "last_error": row["last_error"] if include_diagnostics else None,
                     "has_error": bool(row["last_error"]),
+                    "claimed_local_actor": bool(row["claimed_local_actor"]),
                     "project_scope": {
                         "include": override_include,
                         "exclude": override_exclude,
@@ -517,6 +524,30 @@ def handle_post(
                 },
             }
         )
+        return True
+
+    if path == "/api/sync/peers/identity":
+        if payload is None:
+            handler._send_json({"error": "invalid json"}, status=400)
+            return True
+        peer_device_id = payload.get("peer_device_id")
+        if not isinstance(peer_device_id, str) or not peer_device_id.strip():
+            handler._send_json({"error": "peer_device_id required"}, status=400)
+            return True
+        row = store.conn.execute(
+            "SELECT 1 FROM sync_peers WHERE peer_device_id = ?",
+            (peer_device_id.strip(),),
+        ).fetchone()
+        if row is None:
+            handler._send_json({"error": "peer not found"}, status=404)
+            return True
+        claimed_local_actor = bool(payload.get("claimed_local_actor"))
+        set_peer_local_actor_claim(
+            store.conn,
+            peer_device_id.strip(),
+            claimed_local_actor=claimed_local_actor,
+        )
+        handler._send_json({"ok": True, "claimed_local_actor": claimed_local_actor})
         return True
 
     if path == "/api/sync/actions/sync-now":

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -101,7 +101,7 @@
   const SYNC_PAIRING_KEY = "codemem-sync-pairing";
   const SYNC_REDACT_KEY = "codemem-sync-redact";
   const FEED_FILTERS = ["all", "observations", "summaries"];
-  const FEED_SCOPES = ["all", "mine", "theirs", "shared"];
+  const FEED_SCOPES = ["all", "mine", "theirs"];
   const state = {
     /* Tab */
     activeTab: "feed",
@@ -276,6 +276,20 @@
     if (!resp.ok) {
       throw new Error(payload?.error || text || "request failed");
     }
+    return payload;
+  }
+  async function updatePeerIdentity(peerDeviceId, claimedLocalActor) {
+    const resp = await fetch("/api/sync/peers/identity", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        peer_device_id: peerDeviceId,
+        claimed_local_actor: claimedLocalActor
+      })
+    });
+    const text = await resp.text();
+    const payload = text ? JSON.parse(text) : {};
+    if (!resp.ok) throw new Error(payload?.error || text || "request failed");
     return payload;
   }
   async function loadProjects$1() {
@@ -458,16 +472,17 @@
   let loadMoreInFlight = false;
   let feedScrollHandlerBound = false;
   let feedProjectGeneration = 0;
+  let lastFeedScope = "all";
   function feedScopeLabel(scope) {
     if (scope === "mine") return " · mine";
     if (scope === "theirs") return " · theirs";
-    if (scope === "shared") return " · shared";
     return "";
   }
   function provenanceChip(label, variant = "") {
     return el("span", `provenance-chip ${variant}`.trim(), label);
   }
   function authorLabel(item) {
+    if (item?.owned_by_self === true) return "You";
     const actorId = String(item.actor_id || "").trim();
     const actorName = String(item.actor_display_name || "").trim();
     if (actorId && actorId === state.lastStatsPayload?.identity?.actor_id) return "You";
@@ -475,6 +490,7 @@
   }
   function resetPagination(project) {
     lastFeedProject = project;
+    lastFeedScope = state.feedScopeFilter;
     feedProjectGeneration += 1;
     observationOffset = 0;
     summaryOffset = 0;
@@ -513,11 +529,6 @@
     return Array.from(byKey.values()).sort((a, b) => {
       return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
     });
-  }
-  function mergeRefreshFeedItems(currentItems, firstPageItems) {
-    const firstPageKeys = new Set(firstPageItems.map(itemKey));
-    const olderItems = currentItems.filter((item) => !firstPageKeys.has(itemKey(item)));
-    return mergeFeedItems(olderItems, firstPageItems);
   }
   function getSummaryObject(item) {
     const preferredKeys = ["request", "outcome", "plan", "completed", "learned", "investigated", "next", "next_steps", "notes"];
@@ -968,7 +979,8 @@
   }
   async function loadFeedData() {
     const project = state.currentProject || "";
-    if (project !== lastFeedProject) {
+    const scopeChanged = state.feedScopeFilter !== lastFeedScope;
+    if (project !== lastFeedProject || scopeChanged) {
       resetPagination(project);
       renderProjectSwitchLoadingState();
     }
@@ -989,7 +1001,7 @@
     const firstPageFeedItems = [...summaryItems, ...filtered].sort((a, b) => {
       return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
     });
-    const feedItems = mergeRefreshFeedItems(state.lastFeedItems, firstPageFeedItems);
+    const feedItems = firstPageFeedItems;
     const newCount = countNewItems(feedItems, state.lastFeedItems);
     if (newCount) {
       const seen = new Set(state.lastFeedItems.map(itemKey));
@@ -999,11 +1011,12 @@
     }
     state.pendingFeedItems = null;
     state.lastFeedItems = feedItems;
-    state.lastFeedFilteredCount = Math.max(state.lastFeedFilteredCount, filteredCount);
+    state.lastFeedFilteredCount = filteredCount;
     summaryHasMore = pageHasMore(summaries, summaryItems.length, summariesLimit);
     observationHasMore = pageHasMore(observations, observationItems.length, observationsLimit);
-    summaryOffset = Math.max(summaryOffset, pageNextOffset(summaries, summaryItems.length));
-    observationOffset = Math.max(observationOffset, pageNextOffset(observations, observationItems.length));
+    summaryOffset = pageNextOffset(summaries, summaryItems.length);
+    observationOffset = pageNextOffset(observations, observationItems.length);
+    lastFeedScope = state.feedScopeFilter;
     updateFeedView();
   }
   function buildHealthCard({ label, value, detail, icon, className, title }) {
@@ -1340,6 +1353,15 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   function parseScopeList(value) {
     return value.split(",").map((item) => item.trim()).filter(Boolean);
   }
+  function renderScopeChips(values, emptyLabel) {
+    const wrap = el("div", "peer-scope-chips");
+    if (!values.length) {
+      wrap.appendChild(el("span", "peer-scope-chip empty", emptyLabel));
+      return wrap;
+    }
+    values.forEach((value) => wrap.appendChild(el("span", "peer-scope-chip", value)));
+    return wrap;
+  }
   function renderActionList(container, actions) {
     if (!container) return;
     container.textContent = "";
@@ -1486,6 +1508,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never",
         lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : "Ping: never"
       ].join(" · "));
+      const identityMeta = el(
+        "div",
+        "peer-meta",
+        peer.claimed_local_actor ? "Belongs to your identity" : "Different or unknown identity"
+      );
       const scope = peer.project_scope || {};
       const includeList = Array.isArray(scope.include) ? scope.include : [];
       const excludeList = Array.isArray(scope.exclude) ? scope.exclude : [];
@@ -1493,6 +1520,24 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       const effectiveExclude = Array.isArray(scope.effective_exclude) ? scope.effective_exclude : [];
       const inheritsGlobal = Boolean(scope.inherits_global);
       const scopePanel = el("div", "peer-scope");
+      const identityRow = el("div", "peer-scope-summary");
+      const identityCheckbox = el("input", "cm-checkbox");
+      identityCheckbox.type = "checkbox";
+      identityCheckbox.checked = Boolean(peer.claimed_local_actor);
+      const identityLabel = document.createElement("label");
+      identityLabel.append(identityCheckbox, document.createTextNode(" Belongs to my identity"));
+      identityRow.appendChild(identityLabel);
+      identityCheckbox.addEventListener("change", async () => {
+        identityCheckbox.disabled = true;
+        try {
+          await updatePeerIdentity(peerId, identityCheckbox.checked);
+          await loadSyncData();
+        } catch {
+          identityCheckbox.checked = !identityCheckbox.checked;
+        } finally {
+          identityCheckbox.disabled = false;
+        }
+      });
       const scopeSummary = el(
         "div",
         "peer-scope-summary",
@@ -1502,6 +1547,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         "div",
         "peer-scope-effective",
         `Effective scope · include: ${effectiveInclude.join(", ") || "all"} · exclude: ${effectiveExclude.join(", ") || "none"}`
+      );
+      const chipRow = el("div", "peer-scope-row");
+      chipRow.append(
+        renderScopeChips(includeList, "All projects"),
+        renderScopeChips(excludeList, "No exclusions")
       );
       const includeInput = el("input", "peer-scope-input");
       includeInput.placeholder = "project-a, project-b";
@@ -1541,7 +1591,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         }
       });
       scopeActions.append(saveScopeBtn, inheritBtn);
-      scopePanel.append(scopeSummary, effectiveSummary, inputRow, scopeActions);
+      scopePanel.append(identityRow, identityMeta, scopeSummary, effectiveSummary, chipRow, inputRow, scopeActions);
       titleRow.append(name, actions);
       card.append(titleRow, addressLabel, meta, scopePanel);
       syncPeers.appendChild(card);

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -530,6 +530,11 @@
       return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
     });
   }
+  function mergeRefreshFeedItems(currentItems, firstPageItems) {
+    const firstPageKeys = new Set(firstPageItems.map(itemKey));
+    const olderItems = currentItems.filter((item) => !firstPageKeys.has(itemKey(item)));
+    return mergeFeedItems(olderItems, firstPageItems);
+  }
   function getSummaryObject(item) {
     const preferredKeys = ["request", "outcome", "plan", "completed", "learned", "investigated", "next", "next_steps", "notes"];
     const looksLikeSummary = (v) => {
@@ -1001,7 +1006,7 @@
     const firstPageFeedItems = [...summaryItems, ...filtered].sort((a, b) => {
       return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
     });
-    const feedItems = firstPageFeedItems;
+    const feedItems = mergeRefreshFeedItems(state.lastFeedItems, firstPageFeedItems);
     const newCount = countNewItems(feedItems, state.lastFeedItems);
     if (newCount) {
       const seen = new Set(state.lastFeedItems.map(itemKey));
@@ -1011,11 +1016,11 @@
     }
     state.pendingFeedItems = null;
     state.lastFeedItems = feedItems;
-    state.lastFeedFilteredCount = filteredCount;
+    state.lastFeedFilteredCount = Math.max(state.lastFeedFilteredCount, filteredCount);
     summaryHasMore = pageHasMore(summaries, summaryItems.length, summariesLimit);
     observationHasMore = pageHasMore(observations, observationItems.length, observationsLimit);
-    summaryOffset = pageNextOffset(summaries, summaryItems.length);
-    observationOffset = pageNextOffset(observations, observationItems.length);
+    summaryOffset = Math.max(summaryOffset, pageNextOffset(summaries, summaryItems.length));
+    observationOffset = Math.max(observationOffset, pageNextOffset(observations, observationItems.length));
     lastFeedScope = state.feedScopeFilter;
     updateFeedView();
   }

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -888,6 +888,9 @@
       .peer-scope { display: grid; gap: var(--sp-2); padding-top: var(--sp-2); border-top: 1px solid var(--border); }
       .peer-scope-summary, .peer-scope-effective { font-size: 12px; color: var(--text-secondary); }
       .peer-scope-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-2); }
+      .peer-scope-chips { display: flex; flex-wrap: wrap; gap: 6px; min-height: 32px; align-items: flex-start; padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); }
+      .peer-scope-chip { display: inline-flex; align-items: center; padding: 4px 8px; border-radius: var(--radius-pill); background: rgba(43, 122, 176, 0.12); color: var(--accent); font-size: 12px; }
+      .peer-scope-chip.empty { background: transparent; color: var(--text-tertiary); border: 1px dashed var(--border); }
       .peer-scope-input { width: 100%; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--text-primary); padding: 8px 10px; font: inherit; }
       .peer-scope-actions { display: flex; gap: var(--sp-2); }
       .peer-actions { display: flex; gap: 6px; }
@@ -1375,10 +1378,9 @@
         <div class="feed-controls-right">
           <input class="feed-search" id="feedSearch" placeholder="Search title, body, tags…" />
           <div class="feed-toggle" id="feedScopeToggle">
-            <button class="toggle-button" data-filter="all">All visible</button>
+            <button class="toggle-button" data-filter="all">All</button>
             <button class="toggle-button" data-filter="mine">Mine</button>
             <button class="toggle-button" data-filter="theirs">Theirs</button>
-            <button class="toggle-button" data-filter="shared">Shared</button>
           </div>
           <div class="feed-toggle" id="feedTypeToggle">
             <button class="toggle-button" data-filter="all">All</button>

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -29,6 +29,9 @@ def test_initialize_schema_sets_user_version(monkeypatch, tmp_path: Path) -> Non
         visibility_column = conn.execute(
             "SELECT name FROM pragma_table_info('memory_items') WHERE name = 'visibility'"
         ).fetchone()
+        claimed_local_actor_column = conn.execute(
+            "SELECT name FROM pragma_table_info('sync_peers') WHERE name = 'claimed_local_actor'"
+        ).fetchone()
         workspace_column = conn.execute(
             "SELECT name FROM pragma_table_info('memory_items') WHERE name = 'workspace_id'"
         ).fetchone()
@@ -43,6 +46,7 @@ def test_initialize_schema_sets_user_version(monkeypatch, tmp_path: Path) -> Non
     assert attempt_column is not None
     assert actor_column is not None
     assert visibility_column is not None
+    assert claimed_local_actor_column is not None
     assert workspace_column is not None
 
 
@@ -154,6 +158,86 @@ def test_initialize_schema_upgrades_existing_v3_db_with_identity_columns(
 
     assert actor_column is not None
     assert visibility_column is not None
+    assert row is not None
+    assert int(row[0]) == db.SCHEMA_VERSION
+
+
+def test_initialize_schema_upgrades_existing_v4_db_with_peer_claim_column(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CODEMEM_EMBEDDING_DISABLED", "1")
+    conn = db.connect(tmp_path / "mem.sqlite")
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sync_peers (
+                peer_device_id TEXT PRIMARY KEY,
+                name TEXT,
+                pinned_fingerprint TEXT,
+                public_key TEXT,
+                addresses_json TEXT,
+                created_at TEXT NOT NULL,
+                last_seen_at TEXT,
+                last_sync_at TEXT,
+                last_error TEXT
+            );
+
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                cwd TEXT,
+                project TEXT,
+                git_remote TEXT,
+                git_branch TEXT,
+                user TEXT,
+                tool_version TEXT,
+                metadata_json TEXT,
+                import_key TEXT
+            );
+
+            CREATE TABLE memory_items (
+                id INTEGER PRIMARY KEY,
+                session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                kind TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body_text TEXT NOT NULL,
+                confidence REAL DEFAULT 0.5,
+                tags_text TEXT DEFAULT '',
+                active INTEGER DEFAULT 1,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                metadata_json TEXT
+            );
+
+            CREATE TABLE user_prompts (
+                id INTEGER PRIMARY KEY,
+                session_id INTEGER,
+                project TEXT,
+                prompt_text TEXT,
+                created_at TEXT
+            );
+
+            CREATE TABLE raw_event_flush_batches (
+                id INTEGER PRIMARY KEY,
+                opencode_session_id TEXT,
+                created_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute("PRAGMA user_version = 4")
+        conn.commit()
+
+        db.initialize_schema(conn)
+
+        claimed_column = conn.execute(
+            "SELECT name FROM pragma_table_info('sync_peers') WHERE name = 'claimed_local_actor'"
+        ).fetchone()
+        row = conn.execute("PRAGMA user_version").fetchone()
+    finally:
+        conn.close()
+
+    assert claimed_column is not None
     assert row is not None
     assert int(row[0]) == db.SCHEMA_VERSION
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -608,6 +608,34 @@ def test_shared_memories_replicate(tmp_path: Path) -> None:
         store.close()
 
 
+def test_private_memories_replicate_to_claimed_same_actor_peer(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-self", "[]", 1, "2026-01-24T00:00:00Z"),
+        )
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        store.remember(session_id, kind="note", title="Private", body_text="Body")
+        ops, _ = store.load_replication_ops_since(None, limit=10)
+
+        filtered, _cursor, skipped = store.filter_replication_ops_for_sync_with_status(
+            ops, peer_device_id="peer-self"
+        )
+
+        assert len(filtered) == 1
+        assert skipped is None
+    finally:
+        store.close()
+
+
 def test_replication_delete_wins_over_older_upsert(tmp_path: Path) -> None:
     store_a = MemoryStore(tmp_path / "a.sqlite")
     store_b = MemoryStore(tmp_path / "b.sqlite")

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -184,6 +184,77 @@ def test_sync_peer_scope_update_endpoint_updates_override(tmp_path: Path, monkey
     finally:
         conn.close()
 
+
+def test_sync_peers_endpoint_exposes_local_actor_claim(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-1", "[]", 1, "2026-01-24T00:00:00Z"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/api/sync/peers")
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["items"][0]["claimed_local_actor"] is True
+    finally:
+        server.shutdown()
+
+
+def test_sync_peer_identity_endpoint_updates_claim(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/peers/identity",
+            body=json.dumps({"peer_device_id": "peer-1", "claimed_local_actor": True}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["claimed_local_actor"] is True
+    finally:
+        server.shutdown()
+
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT claimed_local_actor FROM sync_peers WHERE peer_device_id = ?",
+            ("peer-1",),
+        ).fetchone()
+        assert row is not None
+        assert int(row["claimed_local_actor"]) == 1
+    finally:
+        conn.close()
+
     server, port = _start_server(db_path)
     try:
         conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)

--- a/tests/test_viewer_routes_memory.py
+++ b/tests/test_viewer_routes_memory.py
@@ -173,3 +173,71 @@ def test_observations_endpoint_rejects_invalid_scope(tmp_path: Path) -> None:
         assert handler.response == {"error": "invalid_scope"}
     finally:
         store.close()
+
+
+def test_observations_claimed_peer_counts_as_mine(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-self", "[]", 1, "2026-01-24T00:00:00Z"),
+        )
+        session = store.start_session(
+            cwd="/tmp/work",
+            git_remote=None,
+            git_branch="main",
+            user="tester",
+            tool_version="test",
+            project="proj",
+        )
+        claimed_id = store.remember(
+            session,
+            kind="bugfix",
+            title="Claimed peer memory",
+            body_text="From my other computer",
+            metadata={
+                "actor_id": "legacy-sync:peer-self",
+                "actor_display_name": "Legacy synced peer",
+                "origin_device_id": "peer-self",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "legacy_unknown",
+            },
+        )
+        other_id = store.remember(
+            session,
+            kind="bugfix",
+            title="Other memory",
+            body_text="From teammate",
+            metadata={
+                "actor_id": "legacy-sync:peer-other",
+                "actor_display_name": "Legacy synced peer",
+                "origin_device_id": "peer-other",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "legacy_unknown",
+            },
+        )
+        store.end_session(session)
+
+        mine_handler = DummyHandler()
+        handled = memory.handle_get(mine_handler, store, "/api/observations", "scope=mine")
+        assert handled is True
+        assert mine_handler.status == 200
+        assert mine_handler.response is not None
+        assert [item["id"] for item in mine_handler.response["items"]] == [claimed_id]
+        assert mine_handler.response["items"][0]["owned_by_self"] is True
+
+        theirs_handler = DummyHandler()
+        handled = memory.handle_get(theirs_handler, store, "/api/observations", "scope=theirs")
+        assert handled is True
+        assert theirs_handler.status == 200
+        assert theirs_handler.response is not None
+        assert [item["id"] for item in theirs_handler.response["items"]] == [other_id]
+        assert theirs_handler.response["items"][0]["owned_by_self"] is False
+    finally:
+        store.close()

--- a/viewer_ui/src/lib/api.ts
+++ b/viewer_ui/src/lib/api.ts
@@ -117,6 +117,21 @@ export async function updatePeerScope(
   return payload;
 }
 
+export async function updatePeerIdentity(peerDeviceId: string, claimedLocalActor: boolean): Promise<any> {
+  const resp = await fetch('/api/sync/peers/identity', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      peer_device_id: peerDeviceId,
+      claimed_local_actor: claimedLocalActor,
+    }),
+  });
+  const text = await resp.text();
+  const payload = text ? JSON.parse(text) : {};
+  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  return payload;
+}
+
 export async function loadProjects(): Promise<string[]> {
   const payload = await fetchJson('/api/projects');
   return payload.projects || [];

--- a/viewer_ui/src/lib/state.ts
+++ b/viewer_ui/src/lib/state.ts
@@ -13,7 +13,7 @@ const SYNC_REDACT_KEY = 'codemem-sync-redact';
 
 export const FEED_FILTERS = ['all', 'observations', 'summaries'] as const;
 export type FeedFilter = (typeof FEED_FILTERS)[number];
-export const FEED_SCOPES = ['all', 'mine', 'theirs', 'shared'] as const;
+export const FEED_SCOPES = ['all', 'mine', 'theirs'] as const;
 export type FeedScope = (typeof FEED_SCOPES)[number];
 
 /* ── Mutable application state ─────────────────────────────── */

--- a/viewer_ui/src/tabs/feed.ts
+++ b/viewer_ui/src/tabs/feed.ts
@@ -82,11 +82,11 @@ let summaryHasMore = true;
 let loadMoreInFlight = false;
 let feedScrollHandlerBound = false;
 let feedProjectGeneration = 0;
+let lastFeedScope = 'all';
 
 function feedScopeLabel(scope: string): string {
   if (scope === 'mine') return ' · mine';
   if (scope === 'theirs') return ' · theirs';
-  if (scope === 'shared') return ' · shared';
   return '';
 }
 
@@ -95,6 +95,7 @@ function provenanceChip(label: string, variant = ''): HTMLElement {
 }
 
 function authorLabel(item: any): string {
+  if (item?.owned_by_self === true) return 'You';
   const actorId = String(item.actor_id || '').trim();
   const actorName = String(item.actor_display_name || '').trim();
   if (actorId && actorId === state.lastStatsPayload?.identity?.actor_id) return 'You';
@@ -103,6 +104,7 @@ function authorLabel(item: any): string {
 
 function resetPagination(project: string) {
   lastFeedProject = project;
+  lastFeedScope = state.feedScopeFilter;
   feedProjectGeneration += 1;
   observationOffset = 0;
   summaryOffset = 0;
@@ -695,7 +697,8 @@ export function updateFeedView(force = false) {
 
 export async function loadFeedData() {
   const project = state.currentProject || '';
-  if (project !== lastFeedProject) {
+  const scopeChanged = state.feedScopeFilter !== lastFeedScope;
+  if (project !== lastFeedProject || scopeChanged) {
     resetPagination(project);
     renderProjectSwitchLoadingState();
   }
@@ -720,7 +723,7 @@ export async function loadFeedData() {
   const firstPageFeedItems = [...summaryItems, ...filtered].sort((a, b) => {
     return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
   });
-  const feedItems = mergeRefreshFeedItems(state.lastFeedItems, firstPageFeedItems);
+  const feedItems = firstPageFeedItems;
 
   const newCount = countNewItems(feedItems, state.lastFeedItems);
   if (newCount) {
@@ -732,10 +735,11 @@ export async function loadFeedData() {
 
   state.pendingFeedItems = null;
   state.lastFeedItems = feedItems;
-  state.lastFeedFilteredCount = Math.max(state.lastFeedFilteredCount, filteredCount);
+  state.lastFeedFilteredCount = filteredCount;
   summaryHasMore = pageHasMore(summaries, summaryItems.length, summariesLimit);
   observationHasMore = pageHasMore(observations, observationItems.length, observationsLimit);
-  summaryOffset = Math.max(summaryOffset, pageNextOffset(summaries, summaryItems.length));
-  observationOffset = Math.max(observationOffset, pageNextOffset(observations, observationItems.length));
+  summaryOffset = pageNextOffset(summaries, summaryItems.length);
+  observationOffset = pageNextOffset(observations, observationItems.length);
+  lastFeedScope = state.feedScopeFilter;
   updateFeedView();
 }

--- a/viewer_ui/src/tabs/feed.ts
+++ b/viewer_ui/src/tabs/feed.ts
@@ -723,7 +723,7 @@ export async function loadFeedData() {
   const firstPageFeedItems = [...summaryItems, ...filtered].sort((a, b) => {
     return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
   });
-  const feedItems = firstPageFeedItems;
+  const feedItems = mergeRefreshFeedItems(state.lastFeedItems, firstPageFeedItems);
 
   const newCount = countNewItems(feedItems, state.lastFeedItems);
   if (newCount) {
@@ -735,11 +735,11 @@ export async function loadFeedData() {
 
   state.pendingFeedItems = null;
   state.lastFeedItems = feedItems;
-  state.lastFeedFilteredCount = filteredCount;
+  state.lastFeedFilteredCount = Math.max(state.lastFeedFilteredCount, filteredCount);
   summaryHasMore = pageHasMore(summaries, summaryItems.length, summariesLimit);
   observationHasMore = pageHasMore(observations, observationItems.length, observationsLimit);
-  summaryOffset = pageNextOffset(summaries, summaryItems.length);
-  observationOffset = pageNextOffset(observations, observationItems.length);
+  summaryOffset = Math.max(summaryOffset, pageNextOffset(summaries, summaryItems.length));
+  observationOffset = Math.max(observationOffset, pageNextOffset(observations, observationItems.length));
   lastFeedScope = state.feedScopeFilter;
   updateFeedView();
 }

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -44,6 +44,16 @@ function parseScopeList(value: string): string[] {
     .filter(Boolean);
 }
 
+function renderScopeChips(values: string[], emptyLabel: string): HTMLElement {
+  const wrap = el('div', 'peer-scope-chips');
+  if (!values.length) {
+    wrap.appendChild(el('span', 'peer-scope-chip empty', emptyLabel));
+    return wrap;
+  }
+  values.forEach((value) => wrap.appendChild(el('span', 'peer-scope-chip', value)));
+  return wrap;
+}
+
 function renderActionList(container: HTMLElement | null, actions: Array<{ label: string; command: string }>) {
   if (!container) return;
   container.textContent = '';
@@ -216,6 +226,11 @@ export function renderSyncPeers() {
       lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : 'Sync: never',
       lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : 'Ping: never',
     ].join(' · '));
+    const identityMeta = el(
+      'div',
+      'peer-meta',
+      peer.claimed_local_actor ? 'Belongs to your identity' : 'Different or unknown identity',
+    );
 
     const scope = peer.project_scope || {};
     const includeList = Array.isArray(scope.include) ? scope.include : [];
@@ -224,6 +239,24 @@ export function renderSyncPeers() {
     const effectiveExclude = Array.isArray(scope.effective_exclude) ? scope.effective_exclude : [];
     const inheritsGlobal = Boolean(scope.inherits_global);
     const scopePanel = el('div', 'peer-scope');
+    const identityRow = el('div', 'peer-scope-summary');
+    const identityCheckbox = el('input', 'cm-checkbox') as HTMLInputElement;
+    identityCheckbox.type = 'checkbox';
+    identityCheckbox.checked = Boolean(peer.claimed_local_actor);
+    const identityLabel = document.createElement('label');
+    identityLabel.append(identityCheckbox, document.createTextNode(' Belongs to my identity'));
+    identityRow.appendChild(identityLabel);
+    identityCheckbox.addEventListener('change', async () => {
+      identityCheckbox.disabled = true;
+      try {
+        await api.updatePeerIdentity(peerId, identityCheckbox.checked);
+        await loadSyncData();
+      } catch {
+        identityCheckbox.checked = !identityCheckbox.checked;
+      } finally {
+        identityCheckbox.disabled = false;
+      }
+    });
     const scopeSummary = el(
       'div',
       'peer-scope-summary',
@@ -235,6 +268,11 @@ export function renderSyncPeers() {
       'div',
       'peer-scope-effective',
       `Effective scope · include: ${effectiveInclude.join(', ') || 'all'} · exclude: ${effectiveExclude.join(', ') || 'none'}`,
+    );
+    const chipRow = el('div', 'peer-scope-row');
+    chipRow.append(
+      renderScopeChips(includeList, 'All projects'),
+      renderScopeChips(excludeList, 'No exclusions'),
     );
     const includeInput = el('input', 'peer-scope-input') as HTMLInputElement;
     includeInput.placeholder = 'project-a, project-b';
@@ -274,7 +312,7 @@ export function renderSyncPeers() {
       }
     });
     scopeActions.append(saveScopeBtn, inheritBtn);
-    scopePanel.append(scopeSummary, effectiveSummary, inputRow, scopeActions);
+    scopePanel.append(identityRow, identityMeta, scopeSummary, effectiveSummary, chipRow, inputRow, scopeActions);
 
     titleRow.append(name, actions);
     card.append(titleRow, addressLabel, meta, scopePanel);


### PR DESCRIPTION
## Description
Allow peers to be claimed as part of the local identity so another laptop or legacy device can count as `Mine` without a full actor editor. This gives the MVP a cheap same-identity path for personal memories and private sync across a user's own machines.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `uv run pytest tests/test_viewer_routes_memory.py tests/test_store.py`
- `bun run check`
- `bun run build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
