### PR TITLE
feat(viewer): use chips for peer sync scope editing

### DIFF
--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -111,6 +111,7 @@ class MemoryStore:
             p.strip() for p in cfg.sync_projects_exclude if p and p.strip()
         ]
         self._backfill_identity_provenance()
+        self._reconcile_claimed_same_actor_legacy_memories()
 
     def _resolve_actor_id(self, configured_actor_id: str | None) -> str:
         value = str(configured_actor_id or "").strip()
@@ -263,6 +264,55 @@ class MemoryStore:
                 ),
             )
         self.conn.commit()
+
+    def _reconcile_claimed_same_actor_legacy_memories(self) -> None:
+        claimed_peers = self.same_actor_peer_ids()
+        if not claimed_peers:
+            return
+        personal_workspace_id = self._default_workspace_id(
+            actor_id=self.actor_id,
+            workspace_kind="personal",
+        )
+        placeholders = ",".join("?" for _ in claimed_peers)
+        self.conn.execute(
+            f"""
+            UPDATE memory_items
+            SET actor_id = ?,
+                actor_display_name = ?,
+                visibility = 'private',
+                workspace_id = ?,
+                workspace_kind = 'personal',
+                trust_state = 'trusted'
+            WHERE origin_device_id IN ({placeholders})
+              AND (
+                    actor_id LIKE 'legacy-sync:%'
+                 OR actor_display_name = 'Legacy synced peer'
+                 OR workspace_id = 'shared:legacy'
+                 OR workspace_kind = 'shared'
+                 OR trust_state = 'legacy_unknown'
+              )
+            """,
+            [
+                self.actor_id,
+                self.actor_display_name,
+                personal_workspace_id,
+                *claimed_peers,
+            ],
+        )
+        if self.conn.in_transaction:
+            self.conn.commit()
+
+    def reconcile_claimed_same_actor_legacy_memories(self, peer_device_id: str) -> None:
+        peer_id = self._clean_optional_str(peer_device_id)
+        if not peer_id:
+            return
+        row = self.conn.execute(
+            "SELECT claimed_local_actor FROM sync_peers WHERE peer_device_id = ?",
+            (peer_id,),
+        ).fetchone()
+        if not row or not row["claimed_local_actor"]:
+            return
+        self._reconcile_claimed_same_actor_legacy_memories()
 
     def same_actor_peer_ids(self) -> list[str]:
         rows = self.conn.execute(

--- a/codemem/viewer_routes/sync.py
+++ b/codemem/viewer_routes/sync.py
@@ -547,6 +547,8 @@ def handle_post(
             peer_device_id.strip(),
             claimed_local_actor=claimed_local_actor,
         )
+        if claimed_local_actor:
+            store.reconcile_claimed_same_actor_legacy_memories(peer_device_id.strip())
         handler._send_json({"ok": True, "claimed_local_actor": claimed_local_actor})
         return True
 

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1358,7 +1358,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   function parseScopeList(value) {
     return value.split(",").map((item) => item.trim()).filter(Boolean);
   }
-  function createChipEditor(initialValues, placeholder) {
+  function createChipEditor(initialValues, placeholder, emptyLabel) {
     let values = [...initialValues];
     const container = el("div", "peer-scope-editor");
     const chips = el("div", "peer-scope-chips");
@@ -1367,7 +1367,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const syncChips = () => {
       chips.textContent = "";
       if (!values.length) {
-        chips.appendChild(el("span", "peer-scope-chip empty", "None"));
+        chips.appendChild(el("span", "peer-scope-chip empty", emptyLabel));
         return;
       }
       values.forEach((value, index) => {
@@ -1595,8 +1595,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         "peer-scope-effective",
         `Effective scope · include: ${effectiveInclude.join(", ") || "all"} · exclude: ${effectiveExclude.join(", ") || "none"}`
       );
-      const includeEditor = createChipEditor(includeList, "Add included project");
-      const excludeEditor = createChipEditor(excludeList, "Add excluded project");
+      const includeEditor = createChipEditor(includeList, "Add included project", "All projects");
+      const excludeEditor = createChipEditor(excludeList, "Add excluded project", "No exclusions");
       const inputRow = el("div", "peer-scope-row");
       inputRow.append(includeEditor.element, excludeEditor.element);
       const scopeActions = el("div", "peer-scope-actions");

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1558,7 +1558,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       const identityMeta = el(
         "div",
         "peer-meta",
-        peer.claimed_local_actor ? "Belongs to your identity" : "Different or unknown identity"
+        peer.claimed_local_actor ? "Mine" : "Different or unknown"
       );
       const scope = peer.project_scope || {};
       const includeList = Array.isArray(scope.include) ? scope.include : [];
@@ -1572,7 +1572,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       identityCheckbox.type = "checkbox";
       identityCheckbox.checked = Boolean(peer.claimed_local_actor);
       const identityLabel = document.createElement("label");
-      identityLabel.append(identityCheckbox, document.createTextNode(" Belongs to my identity"));
+      identityLabel.append(identityCheckbox, document.createTextNode(" Belongs to me"));
       identityRow.appendChild(identityLabel);
       identityCheckbox.addEventListener("change", async () => {
         identityCheckbox.disabled = true;

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1358,14 +1358,56 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   function parseScopeList(value) {
     return value.split(",").map((item) => item.trim()).filter(Boolean);
   }
-  function renderScopeChips(values, emptyLabel) {
-    const wrap = el("div", "peer-scope-chips");
-    if (!values.length) {
-      wrap.appendChild(el("span", "peer-scope-chip empty", emptyLabel));
-      return wrap;
-    }
-    values.forEach((value) => wrap.appendChild(el("span", "peer-scope-chip", value)));
-    return wrap;
+  function createChipEditor(initialValues, placeholder) {
+    let values = [...initialValues];
+    const container = el("div", "peer-scope-editor");
+    const chips = el("div", "peer-scope-chips");
+    const input = el("input", "peer-scope-input");
+    input.placeholder = placeholder;
+    const syncChips = () => {
+      chips.textContent = "";
+      if (!values.length) {
+        chips.appendChild(el("span", "peer-scope-chip empty", "None"));
+        return;
+      }
+      values.forEach((value, index) => {
+        const chip = el("span", "peer-scope-chip");
+        const label = el("span", null, value);
+        const remove = el("button", "peer-scope-chip-remove", "x");
+        remove.type = "button";
+        remove.addEventListener("click", () => {
+          values = values.filter((_, currentIndex) => currentIndex !== index);
+          syncChips();
+        });
+        chip.append(label, remove);
+        chips.appendChild(chip);
+      });
+    };
+    const commitInput = () => {
+      const incoming = parseScopeList(input.value);
+      if (incoming.length) {
+        values = Array.from(/* @__PURE__ */ new Set([...values, ...incoming]));
+        input.value = "";
+        syncChips();
+      }
+    };
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === ",") {
+        event.preventDefault();
+        commitInput();
+      }
+      if (event.key === "Backspace" && !input.value && values.length) {
+        values = values.slice(0, -1);
+        syncChips();
+      }
+    });
+    input.addEventListener("blur", commitInput);
+    syncChips();
+    container.append(chips, input);
+    return {
+      element: container,
+      values: () => [...values]
+    };
   }
   function renderActionList(container, actions) {
     if (!container) return;
@@ -1553,19 +1595,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         "peer-scope-effective",
         `Effective scope · include: ${effectiveInclude.join(", ") || "all"} · exclude: ${effectiveExclude.join(", ") || "none"}`
       );
-      const chipRow = el("div", "peer-scope-row");
-      chipRow.append(
-        renderScopeChips(includeList, "All projects"),
-        renderScopeChips(excludeList, "No exclusions")
-      );
-      const includeInput = el("input", "peer-scope-input");
-      includeInput.placeholder = "project-a, project-b";
-      includeInput.value = includeList.join(", ");
-      const excludeInput = el("input", "peer-scope-input");
-      excludeInput.placeholder = "private-repo";
-      excludeInput.value = excludeList.join(", ");
+      const includeEditor = createChipEditor(includeList, "Add included project");
+      const excludeEditor = createChipEditor(excludeList, "Add excluded project");
       const inputRow = el("div", "peer-scope-row");
-      inputRow.append(includeInput, excludeInput);
+      inputRow.append(includeEditor.element, excludeEditor.element);
       const scopeActions = el("div", "peer-scope-actions");
       const saveScopeBtn = el("button", "settings-button", "Save scope");
       const inheritBtn = el("button", "settings-button", "Use global");
@@ -1573,7 +1606,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         saveScopeBtn.disabled = true;
         saveScopeBtn.textContent = "Saving...";
         try {
-          await updatePeerScope(peerId, parseScopeList(includeInput.value), parseScopeList(excludeInput.value));
+          await updatePeerScope(peerId, includeEditor.values(), excludeEditor.values());
           await loadSyncData();
         } catch {
           saveScopeBtn.textContent = "Retry save";
@@ -1596,7 +1629,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         }
       });
       scopeActions.append(saveScopeBtn, inheritBtn);
-      scopePanel.append(identityRow, identityMeta, scopeSummary, effectiveSummary, chipRow, inputRow, scopeActions);
+      scopePanel.append(identityRow, identityMeta, scopeSummary, effectiveSummary, inputRow, scopeActions);
       titleRow.append(name, actions);
       card.append(titleRow, addressLabel, meta, scopePanel);
       syncPeers.appendChild(card);

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -888,9 +888,12 @@
       .peer-scope { display: grid; gap: var(--sp-2); padding-top: var(--sp-2); border-top: 1px solid var(--border); }
       .peer-scope-summary, .peer-scope-effective { font-size: 12px; color: var(--text-secondary); }
       .peer-scope-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-2); }
+      .peer-scope-editor { display: grid; gap: 8px; }
       .peer-scope-chips { display: flex; flex-wrap: wrap; gap: 6px; min-height: 32px; align-items: flex-start; padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); }
-      .peer-scope-chip { display: inline-flex; align-items: center; padding: 4px 8px; border-radius: var(--radius-pill); background: rgba(43, 122, 176, 0.12); color: var(--accent); font-size: 12px; }
+      .peer-scope-chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; border-radius: var(--radius-pill); background: rgba(43, 122, 176, 0.12); color: var(--accent); font-size: 12px; }
       .peer-scope-chip.empty { background: transparent; color: var(--text-tertiary); border: 1px dashed var(--border); }
+      .peer-scope-chip-remove { border: none; background: transparent; color: inherit; cursor: pointer; padding: 0; font: inherit; opacity: 0.75; }
+      .peer-scope-chip-remove:hover { opacity: 1; }
       .peer-scope-input { width: 100%; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--text-primary); padding: 8px 10px; font: inherit; }
       .peer-scope-actions { display: flex; gap: var(--sp-2); }
       .peer-actions { display: flex; gap: 6px; }

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -636,6 +636,55 @@ def test_private_memories_replicate_to_claimed_same_actor_peer(tmp_path: Path) -
         store.close()
 
 
+def test_claimed_peer_legacy_memories_are_reconciled_to_local_actor(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-self", "[]", 1, "2026-01-24T00:00:00Z"),
+        )
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(
+            session_id,
+            kind="note",
+            title="Legacy",
+            body_text="From my old machine",
+            metadata={
+                "actor_id": "legacy-sync:peer-self",
+                "actor_display_name": "Legacy synced peer",
+                "origin_device_id": "peer-self",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "legacy_unknown",
+            },
+        )
+
+        store.reconcile_claimed_same_actor_legacy_memories("peer-self")
+
+        row = store.conn.execute(
+            "SELECT actor_id, actor_display_name, visibility, workspace_id, workspace_kind, trust_state FROM memory_items WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["actor_id"] == store.actor_id
+        assert row["actor_display_name"] == store.actor_display_name
+        assert row["visibility"] == "private"
+        assert row["workspace_id"] == f"personal:{store.actor_id}"
+        assert row["workspace_kind"] == "personal"
+        assert row["trust_state"] == "trusted"
+    finally:
+        store.close()
+
+
 def test_replication_delete_wins_over_older_upsert(tmp_path: Path) -> None:
     store_a = MemoryStore(tmp_path / "a.sqlite")
     store_b = MemoryStore(tmp_path / "b.sqlite")

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -6,6 +6,7 @@ from http.server import HTTPServer
 from pathlib import Path
 
 from codemem import db, sync_identity
+from codemem.store import MemoryStore
 from codemem.sync_identity import ensure_device_identity
 from codemem.sync_runtime import SyncRuntimeStatus
 from codemem.viewer import ViewerHandler
@@ -293,6 +294,80 @@ def test_sync_peer_identity_endpoint_updates_claim(tmp_path: Path, monkeypatch) 
         assert json.loads(row["projects_exclude_json"]) == ["secret"]
     finally:
         conn.close()
+
+
+def test_sync_peer_identity_endpoint_reconciles_legacy_claimed_memories(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(
+            session_id,
+            kind="note",
+            title="Legacy peer memory",
+            body_text="From my old machine",
+            metadata={
+                "actor_id": "legacy-sync:peer-1",
+                "actor_display_name": "Legacy synced peer",
+                "origin_device_id": "peer-1",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "legacy_unknown",
+            },
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/peers/identity",
+            body=json.dumps({"peer_device_id": "peer-1", "claimed_local_actor": True}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["claimed_local_actor"] is True
+    finally:
+        server.shutdown()
+
+    store = MemoryStore(db_path)
+    try:
+        row = store.conn.execute(
+            "SELECT actor_id, actor_display_name, visibility, workspace_id, workspace_kind, trust_state FROM memory_items WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["actor_id"] == store.actor_id
+        assert row["actor_display_name"] == store.actor_display_name
+        assert row["visibility"] == "private"
+        assert row["workspace_id"] == f"personal:{store.actor_id}"
+        assert row["workspace_kind"] == "personal"
+        assert row["trust_state"] == "trusted"
+    finally:
+        store.close()
 
 
 def test_sync_status_endpoint_includes_diagnostics_when_requested(

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -44,7 +44,7 @@ function parseScopeList(value: string): string[] {
     .filter(Boolean);
 }
 
-function createChipEditor(initialValues: string[], placeholder: string) {
+function createChipEditor(initialValues: string[], placeholder: string, emptyLabel: string) {
   let values = [...initialValues];
   const container = el('div', 'peer-scope-editor');
   const chips = el('div', 'peer-scope-chips');
@@ -54,7 +54,7 @@ function createChipEditor(initialValues: string[], placeholder: string) {
   const syncChips = () => {
     chips.textContent = '';
     if (!values.length) {
-      chips.appendChild(el('span', 'peer-scope-chip empty', 'None'));
+      chips.appendChild(el('span', 'peer-scope-chip empty', emptyLabel));
       return;
     }
     values.forEach((value, index) => {
@@ -315,8 +315,8 @@ export function renderSyncPeers() {
       'peer-scope-effective',
       `Effective scope · include: ${effectiveInclude.join(', ') || 'all'} · exclude: ${effectiveExclude.join(', ') || 'none'}`,
     );
-    const includeEditor = createChipEditor(includeList, 'Add included project');
-    const excludeEditor = createChipEditor(excludeList, 'Add excluded project');
+    const includeEditor = createChipEditor(includeList, 'Add included project', 'All projects');
+    const excludeEditor = createChipEditor(excludeList, 'Add excluded project', 'No exclusions');
     const inputRow = el('div', 'peer-scope-row');
     inputRow.append(includeEditor.element, excludeEditor.element);
     const scopeActions = el('div', 'peer-scope-actions');

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -44,14 +44,60 @@ function parseScopeList(value: string): string[] {
     .filter(Boolean);
 }
 
-function renderScopeChips(values: string[], emptyLabel: string): HTMLElement {
-  const wrap = el('div', 'peer-scope-chips');
-  if (!values.length) {
-    wrap.appendChild(el('span', 'peer-scope-chip empty', emptyLabel));
-    return wrap;
-  }
-  values.forEach((value) => wrap.appendChild(el('span', 'peer-scope-chip', value)));
-  return wrap;
+function createChipEditor(initialValues: string[], placeholder: string) {
+  let values = [...initialValues];
+  const container = el('div', 'peer-scope-editor');
+  const chips = el('div', 'peer-scope-chips');
+  const input = el('input', 'peer-scope-input') as HTMLInputElement;
+  input.placeholder = placeholder;
+
+  const syncChips = () => {
+    chips.textContent = '';
+    if (!values.length) {
+      chips.appendChild(el('span', 'peer-scope-chip empty', 'None'));
+      return;
+    }
+    values.forEach((value, index) => {
+      const chip = el('span', 'peer-scope-chip');
+      const label = el('span', null, value);
+      const remove = el('button', 'peer-scope-chip-remove', 'x') as HTMLButtonElement;
+      remove.type = 'button';
+      remove.addEventListener('click', () => {
+        values = values.filter((_, currentIndex) => currentIndex !== index);
+        syncChips();
+      });
+      chip.append(label, remove);
+      chips.appendChild(chip);
+    });
+  };
+
+  const commitInput = () => {
+    const incoming = parseScopeList(input.value);
+    if (incoming.length) {
+      values = Array.from(new Set([...values, ...incoming]));
+      input.value = '';
+      syncChips();
+    }
+  };
+
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      commitInput();
+    }
+    if (event.key === 'Backspace' && !input.value && values.length) {
+      values = values.slice(0, -1);
+      syncChips();
+    }
+  });
+  input.addEventListener('blur', commitInput);
+
+  syncChips();
+  container.append(chips, input);
+  return {
+    element: container,
+    values: () => [...values],
+  };
 }
 
 function renderActionList(container: HTMLElement | null, actions: Array<{ label: string; command: string }>) {
@@ -269,19 +315,10 @@ export function renderSyncPeers() {
       'peer-scope-effective',
       `Effective scope · include: ${effectiveInclude.join(', ') || 'all'} · exclude: ${effectiveExclude.join(', ') || 'none'}`,
     );
-    const chipRow = el('div', 'peer-scope-row');
-    chipRow.append(
-      renderScopeChips(includeList, 'All projects'),
-      renderScopeChips(excludeList, 'No exclusions'),
-    );
-    const includeInput = el('input', 'peer-scope-input') as HTMLInputElement;
-    includeInput.placeholder = 'project-a, project-b';
-    includeInput.value = includeList.join(', ');
-    const excludeInput = el('input', 'peer-scope-input') as HTMLInputElement;
-    excludeInput.placeholder = 'private-repo';
-    excludeInput.value = excludeList.join(', ');
+    const includeEditor = createChipEditor(includeList, 'Add included project');
+    const excludeEditor = createChipEditor(excludeList, 'Add excluded project');
     const inputRow = el('div', 'peer-scope-row');
-    inputRow.append(includeInput, excludeInput);
+    inputRow.append(includeEditor.element, excludeEditor.element);
     const scopeActions = el('div', 'peer-scope-actions');
     const saveScopeBtn = el('button', 'settings-button', 'Save scope') as HTMLButtonElement;
     const inheritBtn = el('button', 'settings-button', 'Use global') as HTMLButtonElement;
@@ -289,7 +326,7 @@ export function renderSyncPeers() {
       saveScopeBtn.disabled = true;
       saveScopeBtn.textContent = 'Saving...';
       try {
-        await api.updatePeerScope(peerId, parseScopeList(includeInput.value), parseScopeList(excludeInput.value));
+        await api.updatePeerScope(peerId, includeEditor.values(), excludeEditor.values());
         await loadSyncData();
       } catch {
         saveScopeBtn.textContent = 'Retry save';
@@ -312,7 +349,7 @@ export function renderSyncPeers() {
       }
     });
     scopeActions.append(saveScopeBtn, inheritBtn);
-    scopePanel.append(identityRow, identityMeta, scopeSummary, effectiveSummary, chipRow, inputRow, scopeActions);
+    scopePanel.append(identityRow, identityMeta, scopeSummary, effectiveSummary, inputRow, scopeActions);
 
     titleRow.append(name, actions);
     card.append(titleRow, addressLabel, meta, scopePanel);

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -275,7 +275,7 @@ export function renderSyncPeers() {
     const identityMeta = el(
       'div',
       'peer-meta',
-      peer.claimed_local_actor ? 'Belongs to your identity' : 'Different or unknown identity',
+      peer.claimed_local_actor ? 'Mine' : 'Different or unknown',
     );
 
     const scope = peer.project_scope || {};
@@ -290,7 +290,7 @@ export function renderSyncPeers() {
     identityCheckbox.type = 'checkbox';
     identityCheckbox.checked = Boolean(peer.claimed_local_actor);
     const identityLabel = document.createElement('label');
-    identityLabel.append(identityCheckbox, document.createTextNode(' Belongs to my identity'));
+    identityLabel.append(identityCheckbox, document.createTextNode(' Belongs to me'));
     identityRow.appendChild(identityLabel);
     identityCheckbox.addEventListener('change', async () => {
       identityCheckbox.disabled = true;


### PR DESCRIPTION
## Description
Replace comma-separated sync scope inputs with chip editors so include/exclude project rules are easier to read and edit without guessing delimiter syntax. This keeps the peer-scope UI aligned with the viewer's other identity-aware controls.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `bun run check`
- `bun run build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
