### PR TITLE
fix(sync): claim orphan legacy devices from the viewer

### DIFF
--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -314,6 +314,77 @@ class MemoryStore:
             return
         self._reconcile_claimed_same_actor_legacy_memories()
 
+    def claimable_legacy_device_ids(self) -> list[dict[str, Any]]:
+        rows = self.conn.execute(
+            """
+            SELECT origin_device_id, COUNT(*) AS memory_count, MAX(created_at) AS last_seen_at
+            FROM memory_items
+            WHERE origin_device_id IS NOT NULL
+              AND origin_device_id != ''
+              AND origin_device_id != 'unknown'
+              AND (
+                    actor_id LIKE 'legacy-sync:%'
+                 OR actor_display_name = 'Legacy synced peer'
+                 OR workspace_id = 'shared:legacy'
+                 OR workspace_kind = 'shared'
+                 OR trust_state = 'legacy_unknown'
+              )
+              AND origin_device_id != ?
+              AND origin_device_id NOT IN (
+                    SELECT peer_device_id FROM sync_peers WHERE peer_device_id IS NOT NULL
+              )
+            GROUP BY origin_device_id
+            ORDER BY last_seen_at DESC, origin_device_id ASC
+            """,
+            (self.device_id,),
+        ).fetchall()
+        return [
+            {
+                "origin_device_id": str(row["origin_device_id"]),
+                "memory_count": int(row["memory_count"] or 0),
+                "last_seen_at": row["last_seen_at"],
+            }
+            for row in rows
+            if row["origin_device_id"]
+        ]
+
+    def claim_legacy_device_id_as_self(self, origin_device_id: str) -> int:
+        device_id = self._clean_optional_str(origin_device_id)
+        if not device_id or device_id in {"unknown", self.device_id}:
+            return 0
+        personal_workspace_id = self._default_workspace_id(
+            actor_id=self.actor_id,
+            workspace_kind="personal",
+        )
+        cursor = self.conn.execute(
+            """
+            UPDATE memory_items
+            SET actor_id = ?,
+                actor_display_name = ?,
+                visibility = 'private',
+                workspace_id = ?,
+                workspace_kind = 'personal',
+                trust_state = 'trusted'
+            WHERE origin_device_id = ?
+              AND (
+                    actor_id LIKE 'legacy-sync:%'
+                 OR actor_display_name = 'Legacy synced peer'
+                 OR workspace_id = 'shared:legacy'
+                 OR workspace_kind = 'shared'
+                 OR trust_state = 'legacy_unknown'
+              )
+            """,
+            (
+                self.actor_id,
+                self.actor_display_name,
+                personal_workspace_id,
+                device_id,
+            ),
+        )
+        if self.conn.in_transaction:
+            self.conn.commit()
+        return int(cursor.rowcount or 0)
+
     def same_actor_peer_ids(self) -> list[str]:
         rows = self.conn.execute(
             "SELECT peer_device_id FROM sync_peers WHERE claimed_local_actor = 1 ORDER BY peer_device_id"

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -366,6 +366,9 @@ class MemoryStore:
                 workspace_kind = 'personal',
                 trust_state = 'trusted'
             WHERE origin_device_id = ?
+              AND origin_device_id NOT IN (
+                    SELECT peer_device_id FROM sync_peers WHERE peer_device_id IS NOT NULL
+              )
               AND (
                     actor_id LIKE 'legacy-sync:%'
                  OR actor_display_name = 'Legacy synced peer'

--- a/codemem/viewer.py
+++ b/codemem/viewer.py
@@ -131,6 +131,7 @@ class ViewerHandler(BaseHTTPRequestHandler):
             "/api/sync/peers/rename",
             "/api/sync/peers/identity",
             "/api/sync/peers/scope",
+            "/api/sync/legacy-devices/claim",
             "/api/sync/actions/sync-now",
             "/api/sync/run",
         }

--- a/codemem/viewer_routes/sync.py
+++ b/codemem/viewer_routes/sync.py
@@ -248,6 +248,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
             item["status"] = _attempt_status(item)
             item["address"] = _attempt_address(item)
             attempts_items.append(item)
+        legacy_devices = store.claimable_legacy_device_ids()
 
         if daemon_state_value == "ok":
             peer_states = {
@@ -288,7 +289,8 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                 **status_payload,
                 "status": status_block,
                 "peers": peers_items,
-                "attempts": attempts_items,
+                "attempts": attempts_items[:5],
+                "legacy_devices": legacy_devices,
             }
         )
         return True
@@ -550,6 +552,27 @@ def handle_post(
         if claimed_local_actor:
             store.reconcile_claimed_same_actor_legacy_memories(peer_device_id.strip())
         handler._send_json({"ok": True, "claimed_local_actor": claimed_local_actor})
+        return True
+
+    if path == "/api/sync/legacy-devices/claim":
+        if payload is None:
+            handler._send_json({"error": "invalid json"}, status=400)
+            return True
+        origin_device_id = payload.get("origin_device_id")
+        if not isinstance(origin_device_id, str) or not origin_device_id.strip():
+            handler._send_json({"error": "origin_device_id required"}, status=400)
+            return True
+        updated = store.claim_legacy_device_id_as_self(origin_device_id.strip())
+        if updated <= 0:
+            handler._send_json({"error": "legacy device not found"}, status=404)
+            return True
+        handler._send_json(
+            {
+                "ok": True,
+                "origin_device_id": origin_device_id.strip(),
+                "updated": updated,
+            }
+        )
         return True
 
     if path == "/api/sync/actions/sync-now":

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -131,6 +131,7 @@
     lastSyncStatus: null,
     lastSyncPeers: [],
     lastSyncAttempts: [],
+    lastSyncLegacyDevices: [],
     pairingPayloadRaw: null,
     pairingCommandRaw: "",
     /* Config */
@@ -286,6 +287,17 @@
         peer_device_id: peerDeviceId,
         claimed_local_actor: claimedLocalActor
       })
+    });
+    const text = await resp.text();
+    const payload = text ? JSON.parse(text) : {};
+    if (!resp.ok) throw new Error(payload?.error || text || "request failed");
+    return payload;
+  }
+  async function claimLegacyDeviceIdentity(originDeviceId) {
+    const resp = await fetch("/api/sync/legacy-devices/claim", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ origin_device_id: originDeviceId })
     });
     const text = await resp.text();
     const payload = text ? JSON.parse(text) : {};
@@ -1635,13 +1647,45 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       syncPeers.appendChild(card);
     });
   }
+  function renderLegacyDeviceClaims() {
+    const panel = document.getElementById("syncLegacyClaims");
+    const select = document.getElementById("syncLegacyDeviceSelect");
+    const button = document.getElementById("syncLegacyClaimButton");
+    const meta = document.getElementById("syncLegacyClaimsMeta");
+    if (!panel || !select || !button || !meta) return;
+    const devices = Array.isArray(state.lastSyncLegacyDevices) ? state.lastSyncLegacyDevices : [];
+    select.textContent = "";
+    meta.textContent = "";
+    if (!devices.length) {
+      panel.hidden = true;
+      return;
+    }
+    panel.hidden = false;
+    devices.forEach((device, index) => {
+      const option = document.createElement("option");
+      const deviceId = String(device.origin_device_id || "").trim();
+      if (!deviceId) return;
+      const count = Number(device.memory_count || 0);
+      const lastSeen = String(device.last_seen_at || "").trim();
+      option.value = deviceId;
+      option.textContent = count > 0 ? `${deviceId} (${count} memories)` : deviceId;
+      if (index === 0) option.selected = true;
+      select.appendChild(option);
+      if (!meta.textContent && lastSeen) {
+        meta.textContent = `Detected from older synced memories. Latest memory: ${formatTimestamp(lastSeen)}`;
+      }
+    });
+    if (!meta.textContent) {
+      meta.textContent = "Detected from older synced memories that are not attached to a current peer.";
+    }
+  }
   function renderSyncAttempts() {
     const syncAttempts = document.getElementById("syncAttempts");
     if (!syncAttempts) return;
     syncAttempts.textContent = "";
     const attempts = state.lastSyncAttempts;
     if (!Array.isArray(attempts) || !attempts.length) return;
-    attempts.forEach((attempt) => {
+    attempts.slice(0, 5).forEach((attempt) => {
       const line = el("div", "diag-line");
       const left = el("div", "left");
       left.append(
@@ -1689,8 +1733,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       if (statusPayload) state.lastSyncStatus = statusPayload;
       state.lastSyncPeers = payload.peers || [];
       state.lastSyncAttempts = payload.attempts || [];
+      state.lastSyncLegacyDevices = payload.legacy_devices || [];
       renderSyncStatus();
       renderSyncPeers();
+      renderLegacyDeviceClaims();
       renderSyncAttempts();
       renderHealthOverview();
     } catch {
@@ -1711,6 +1757,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const syncPairingToggle = document.getElementById("syncPairingToggle");
     const syncNowButton = document.getElementById("syncNowButton");
     const syncRedact = document.getElementById("syncRedact");
+    const syncLegacyClaimButton = document.getElementById("syncLegacyClaimButton");
+    const syncLegacyDeviceSelect = document.getElementById("syncLegacyDeviceSelect");
     const pairingCopy = document.getElementById("pairingCopy");
     const syncPairing = document.getElementById("syncPairing");
     if (syncPairing) syncPairing.hidden = !state.syncPairingOpen;
@@ -1735,6 +1783,23 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       renderSyncPeers();
       renderSyncAttempts();
       renderPairing();
+    });
+    syncLegacyClaimButton?.addEventListener("click", async () => {
+      const originDeviceId = String(syncLegacyDeviceSelect?.value || "").trim();
+      if (!originDeviceId || !syncLegacyClaimButton) return;
+      syncLegacyClaimButton.disabled = true;
+      const originalText = syncLegacyClaimButton.textContent || "Claim as mine";
+      syncLegacyClaimButton.textContent = "Claiming...";
+      try {
+        await claimLegacyDeviceIdentity(originDeviceId);
+        await loadSyncData();
+      } catch {
+        syncLegacyClaimButton.textContent = "Retry claim";
+        syncLegacyClaimButton.disabled = false;
+        return;
+      }
+      syncLegacyClaimButton.textContent = originalText;
+      syncLegacyClaimButton.disabled = false;
     });
     syncNowButton?.addEventListener("click", async () => {
       if (!syncNowButton) return;

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -899,6 +899,52 @@
       .peer-actions { display: flex; gap: 6px; }
       .peer-actions button { border: 1px solid var(--border); background: transparent; border-radius: var(--radius-pill); padding: 5px 10px; font-family: var(--font-sans); font-size: 12px; cursor: pointer; color: var(--text-secondary); }
       .peer-actions button:hover { border-color: var(--border-hover); background: var(--surface-2); }
+      .sync-legacy-claim-row { margin-top: 12px; gap: 12px; align-items: center; flex-wrap: wrap; }
+      .sync-legacy-select {
+        min-width: 320px;
+        max-width: 100%;
+        flex: 1 1 320px;
+        padding: 8px 12px;
+        border-radius: var(--radius-md);
+        border: 1px solid var(--border);
+        background: var(--input-bg);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 13px;
+        cursor: pointer;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+      }
+      .sync-legacy-select:hover { border-color: var(--border-hover); }
+      .sync-legacy-select:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--focus-ring);
+      }
+      .sync-legacy-button {
+        border: 1px solid var(--control-border);
+        background: var(--control-bg);
+        color: var(--control-text);
+        border-radius: var(--radius-pill);
+        padding: 8px 14px;
+        font-family: var(--font-sans);
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+      }
+      .sync-legacy-button:hover {
+        background: var(--control-hover-bg);
+        border-color: var(--control-hover-border);
+      }
+      .sync-legacy-button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .sync-legacy-button:disabled {
+        opacity: 0.7;
+        cursor: default;
+        transform: none;
+      }
       .peer-meta { font-size: 13px; color: var(--text-tertiary); }
       .peer-addresses { font-family: var(--font-mono); font-size: 12px; color: var(--text-secondary); opacity: 0.7; }
       .attempts-list { margin-top: var(--sp-3); display: grid; gap: 6px; font-size: 13px; color: var(--text-tertiary); }
@@ -1450,16 +1496,25 @@
         <div class="peer-list" id="syncPeers"></div>
       </div>
 
-      <div class="card" style="animation-delay: 0.1s">
-        <h2>Recent sync attempts</h2>
-        <div class="attempts-list" id="syncAttempts"></div>
+      <div class="card" id="syncLegacyClaims" style="animation-delay: 0.08s" hidden>
+        <h2>Claim old device as mine</h2>
+        <div class="peer-meta" id="syncLegacyClaimsMeta"></div>
+        <div class="peer-actions sync-legacy-claim-row">
+          <select class="sync-legacy-select" id="syncLegacyDeviceSelect"></select>
+          <button class="sync-legacy-button" id="syncLegacyClaimButton">Claim as mine</button>
+        </div>
       </div>
 
-      <div class="section-meta" style="text-align:right;">
+      <div class="section-meta" style="text-align:right; margin-bottom:12px;">
         <label class="small" style="display:inline-flex;align-items:center;gap:8px;">
           <input id="syncRedact" type="checkbox" checked />
           Redact sensitive details
         </label>
+      </div>
+
+      <div class="card" style="animation-delay: 0.1s">
+        <h2>Recent sync attempts</h2>
+        <div class="attempts-list" id="syncAttempts"></div>
       </div>
     </div>
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -108,7 +108,7 @@ Judged query JSONL format:
 - `filters` is optional and uses the same retrieval filter shape as normal search commands.
 - Supported retrieval filters include `project`, `kind`, `include_actor_ids`, `exclude_actor_ids`, `include_workspace_ids`, `exclude_workspace_ids`, `include_workspace_kinds`, `exclude_workspace_kinds`, and `personal_first`.
 
-## Sync (Phase 2)
+## Sync
 
 ### Enable + run
 
@@ -126,6 +126,11 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 
 - `codemem sync pair --accept '<payload>' --include shared-repo-1,shared-repo-2`
 - `codemem sync pair --accept '<payload>' --exclude private-repo`
+
+### Claim your own devices
+
+- In the Sync panel, use `Belongs to me` for currently paired machines that should count as your identity.
+- If a machine is replaced or re-paired, use `Claim old device as mine` to reconnect older synced history to you.
 
 ### One-off sync
 
@@ -155,6 +160,9 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 
 ## Retrieval scope
 - New memories default to private visibility and stay local unless written as shared.
-- The feed supports `All visible`, `Mine`, and `Shared` scopes without splitting memories into separate databases.
+- The feed supports `All`, `Mine`, and `Theirs` scopes without splitting memories into separate databases.
 - Shared memories are the only ones eligible for peer-to-peer sync; project and per-peer sync filters still narrow where shared memories flow.
-- Trust labels are informational in MVP: `trusted` is the normal case, while `legacy_unknown` marks older synced memories whose provenance had to be backfilled conservatively.
+
+## Viewer sync panel
+- `Redact sensitive details` lives above Recent sync attempts so it is easier to find before you inspect peer addresses and attempt history.
+- Recent sync attempts intentionally show only the latest few rows in the viewer; use CLI diagnostics for deeper history if needed.

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -370,6 +370,145 @@ def test_sync_peer_identity_endpoint_reconciles_legacy_claimed_memories(
         store.close()
 
 
+def test_sync_status_exposes_claimable_legacy_device_ids(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    _monkeypatch_sync_enabled(monkeypatch)
+    store = MemoryStore(db_path)
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        store.remember(
+            session_id,
+            kind="note",
+            title="Legacy orphan",
+            body_text="From an old machine",
+            metadata={
+                "actor_id": "legacy-sync:peer-old",
+                "actor_display_name": "Legacy synced peer",
+                "origin_device_id": "peer-old",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "legacy_unknown",
+            },
+        )
+        store.remember(
+            session_id,
+            kind="note",
+            title="Known peer",
+            body_text="Still a current peer",
+            metadata={
+                "actor_id": "legacy-sync:peer-1",
+                "actor_display_name": "Legacy synced peer",
+                "origin_device_id": "peer-1",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "legacy_unknown",
+            },
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/api/sync/status")
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["legacy_devices"] == [
+            {
+                "origin_device_id": "peer-old",
+                "memory_count": 1,
+                "last_seen_at": payload["legacy_devices"][0]["last_seen_at"],
+            }
+        ]
+    finally:
+        server.shutdown()
+
+
+def test_sync_legacy_device_claim_endpoint_reconciles_memories(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(
+            session_id,
+            kind="note",
+            title="Legacy orphan",
+            body_text="From my old machine",
+            metadata={
+                "actor_id": "legacy-sync:peer-old",
+                "actor_display_name": "Legacy synced peer",
+                "origin_device_id": "peer-old",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "legacy_unknown",
+            },
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/legacy-devices/claim",
+            body=json.dumps({"origin_device_id": "peer-old"}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["origin_device_id"] == "peer-old"
+        assert payload["updated"] == 1
+    finally:
+        server.shutdown()
+
+    store = MemoryStore(db_path)
+    try:
+        row = store.conn.execute(
+            "SELECT actor_id, visibility, workspace_id, workspace_kind, trust_state FROM memory_items WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["actor_id"] == store.actor_id
+        assert row["visibility"] == "private"
+        assert row["workspace_id"] == f"personal:{store.actor_id}"
+        assert row["workspace_kind"] == "personal"
+        assert row["trust_state"] == "trusted"
+    finally:
+        store.close()
+
+
 def test_sync_status_endpoint_includes_diagnostics_when_requested(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -509,6 +509,79 @@ def test_sync_legacy_device_claim_endpoint_reconciles_memories(tmp_path: Path, m
         store.close()
 
 
+def test_sync_legacy_device_claim_endpoint_rejects_current_peer_ids(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(
+            session_id,
+            kind="note",
+            title="Current peer memory",
+            body_text="Should stay shared",
+            metadata={
+                "actor_id": "legacy-sync:peer-1",
+                "actor_display_name": "Legacy synced peer",
+                "origin_device_id": "peer-1",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "legacy_unknown",
+            },
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/legacy-devices/claim",
+            body=json.dumps({"origin_device_id": "peer-1"}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 404
+        assert payload["error"] == "legacy device not found"
+    finally:
+        server.shutdown()
+
+    store = MemoryStore(db_path)
+    try:
+        row = store.conn.execute(
+            "SELECT actor_id, visibility, workspace_id, workspace_kind, trust_state FROM memory_items WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["actor_id"] == "legacy-sync:peer-1"
+        assert row["visibility"] == "shared"
+        assert row["workspace_id"] == "shared:legacy"
+        assert row["workspace_kind"] == "shared"
+        assert row["trust_state"] == "legacy_unknown"
+    finally:
+        store.close()
+
+
 def test_sync_status_endpoint_includes_diagnostics_when_requested(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/viewer_ui/src/lib/api.ts
+++ b/viewer_ui/src/lib/api.ts
@@ -132,6 +132,18 @@ export async function updatePeerIdentity(peerDeviceId: string, claimedLocalActor
   return payload;
 }
 
+export async function claimLegacyDeviceIdentity(originDeviceId: string): Promise<any> {
+  const resp = await fetch('/api/sync/legacy-devices/claim', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ origin_device_id: originDeviceId }),
+  });
+  const text = await resp.text();
+  const payload = text ? JSON.parse(text) : {};
+  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  return payload;
+}
+
 export async function loadProjects(): Promise<string[]> {
   const payload = await fetchJson('/api/projects');
   return payload.projects || [];

--- a/viewer_ui/src/lib/state.ts
+++ b/viewer_ui/src/lib/state.ts
@@ -52,6 +52,7 @@ export const state = {
   lastSyncStatus: null as any,
   lastSyncPeers: [] as any[],
   lastSyncAttempts: [] as any[],
+  lastSyncLegacyDevices: [] as any[],
   pairingPayloadRaw: null as any,
   pairingCommandRaw: '',
 

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -357,6 +357,41 @@ export function renderSyncPeers() {
   });
 }
 
+export function renderLegacyDeviceClaims() {
+  const panel = document.getElementById('syncLegacyClaims');
+  const select = document.getElementById('syncLegacyDeviceSelect') as HTMLSelectElement | null;
+  const button = document.getElementById('syncLegacyClaimButton') as HTMLButtonElement | null;
+  const meta = document.getElementById('syncLegacyClaimsMeta');
+  if (!panel || !select || !button || !meta) return;
+
+  const devices = Array.isArray(state.lastSyncLegacyDevices) ? state.lastSyncLegacyDevices : [];
+  select.textContent = '';
+  meta.textContent = '';
+  if (!devices.length) {
+    (panel as any).hidden = true;
+    return;
+  }
+
+  (panel as any).hidden = false;
+  devices.forEach((device, index) => {
+    const option = document.createElement('option');
+    const deviceId = String(device.origin_device_id || '').trim();
+    if (!deviceId) return;
+    const count = Number(device.memory_count || 0);
+    const lastSeen = String(device.last_seen_at || '').trim();
+    option.value = deviceId;
+    option.textContent = count > 0 ? `${deviceId} (${count} memories)` : deviceId;
+    if (index === 0) option.selected = true;
+    select.appendChild(option);
+    if (!meta.textContent && lastSeen) {
+      meta.textContent = `Detected from older synced memories. Latest memory: ${formatTimestamp(lastSeen)}`;
+    }
+  });
+  if (!meta.textContent) {
+    meta.textContent = 'Detected from older synced memories that are not attached to a current peer.';
+  }
+}
+
 /* ── Attempts renderer ───────────────────────────────────── */
 
 export function renderSyncAttempts() {
@@ -366,7 +401,7 @@ export function renderSyncAttempts() {
   const attempts = state.lastSyncAttempts;
   if (!Array.isArray(attempts) || !attempts.length) return;
 
-  attempts.forEach((attempt) => {
+  attempts.slice(0, 5).forEach((attempt) => {
     const line = el('div', 'diag-line');
     const left = el('div', 'left');
     left.append(
@@ -422,8 +457,10 @@ export async function loadSyncData() {
     if (statusPayload) state.lastSyncStatus = statusPayload;
     state.lastSyncPeers = payload.peers || [];
     state.lastSyncAttempts = payload.attempts || [];
+    state.lastSyncLegacyDevices = payload.legacy_devices || [];
     renderSyncStatus();
     renderSyncPeers();
+    renderLegacyDeviceClaims();
     renderSyncAttempts();
     // Re-render health indicators since they consume sync state (health dot, etc.)
     renderHealthOverview();
@@ -449,6 +486,8 @@ export function initSyncTab(refreshCallback: () => void) {
   const syncPairingToggle = document.getElementById('syncPairingToggle') as HTMLButtonElement | null;
   const syncNowButton = document.getElementById('syncNowButton') as HTMLButtonElement | null;
   const syncRedact = document.getElementById('syncRedact') as HTMLInputElement | null;
+  const syncLegacyClaimButton = document.getElementById('syncLegacyClaimButton') as HTMLButtonElement | null;
+  const syncLegacyDeviceSelect = document.getElementById('syncLegacyDeviceSelect') as HTMLSelectElement | null;
   const pairingCopy = document.getElementById('pairingCopy') as HTMLButtonElement | null;
   const syncPairing = document.getElementById('syncPairing');
 
@@ -477,6 +516,24 @@ export function initSyncTab(refreshCallback: () => void) {
     renderSyncPeers();
     renderSyncAttempts();
     renderPairing();
+  });
+
+  syncLegacyClaimButton?.addEventListener('click', async () => {
+    const originDeviceId = String(syncLegacyDeviceSelect?.value || '').trim();
+    if (!originDeviceId || !syncLegacyClaimButton) return;
+    syncLegacyClaimButton.disabled = true;
+    const originalText = syncLegacyClaimButton.textContent || 'Claim as mine';
+    syncLegacyClaimButton.textContent = 'Claiming...';
+    try {
+      await api.claimLegacyDeviceIdentity(originDeviceId);
+      await loadSyncData();
+    } catch {
+      syncLegacyClaimButton.textContent = 'Retry claim';
+      syncLegacyClaimButton.disabled = false;
+      return;
+    }
+    syncLegacyClaimButton.textContent = originalText;
+    syncLegacyClaimButton.disabled = false;
   });
 
   syncNowButton?.addEventListener('click', async () => {


### PR DESCRIPTION
## Description
Add a small sync-viewer follow-up that lets users reclaim older orphaned device ids from detected legacy synced memories, so personal history stays attached to the local identity even after device ids change. This also polishes the Sync tab by improving the claim control styling, moving the redaction toggle above recent attempts, trimming the attempts list, and updating the user guide to match the current behavior.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:
- `uv run pytest tests/test_sync_viewer_api.py::test_sync_status_exposes_claimable_legacy_device_ids tests/test_sync_viewer_api.py::test_sync_legacy_device_claim_endpoint_reconciles_memories tests/test_sync_viewer_api.py::test_sync_peer_identity_endpoint_reconciles_legacy_claimed_memories tests/test_store.py::test_claimed_peer_legacy_memories_are_reconciled_to_local_actor`
- `uv run ruff check codemem/store/_store.py codemem/viewer.py codemem/viewer_routes/sync.py tests/test_sync_viewer_api.py tests/test_store.py`
- `bun run check && bun run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
