### PR TITLE
chore(beads): ignore dolt monitor lockfile

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -33,6 +33,7 @@ dolt-server.lock
 dolt-server.port
 dolt-server.activity
 dolt-monitor.pid
+dolt-monitor.pid.lock
 
 # Backup data (auto-exported JSONL, local-only)
 backup/


### PR DESCRIPTION
## Description
Remove the tracked `.beads/dolt-monitor.pid.lock` runtime artifact and ignore that lockfile going forward so local beads monitor state does not keep showing up as stray repo noise. This keeps ephemeral local process files out of normal feature PRs.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:
- Confirmed `.beads/dolt-monitor.pid.lock` was tracked
- Confirmed `.beads/.gitignore` previously ignored `dolt-monitor.pid` but not `dolt-monitor.pid.lock`
- Confirmed only the lockfile removal and ignore-rule update are included

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
