### PR TITLE
feat(cli): add serve start stop and restart commands

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -108,9 +108,11 @@ from .viewer import DEFAULT_VIEWER_HOST, DEFAULT_VIEWER_PORT
 app = typer.Typer(help="codemem: persistent memory for OpenCode CLI")
 sync_app = typer.Typer(help="Sync codemem between devices")
 sync_peers_app = typer.Typer(help="Manage sync peers")
+serve_app = typer.Typer(help="Run or manage the viewer", invoke_without_command=True)
 db_app = typer.Typer(help="Database maintenance")
 app.add_typer(sync_app, name="sync")
 sync_app.add_typer(sync_peers_app, name="peers")
+app.add_typer(serve_app, name="serve")
 app.add_typer(db_app, name="db")
 
 
@@ -783,8 +785,9 @@ def import_from_claude_mem(
         store.close()
 
 
-@app.command()
+@serve_app.callback(invoke_without_command=True)
 def serve(
+    ctx: typer.Context,
     db_path: str = typer.Option(None, help="Path to SQLite database"),
     host: str = typer.Option(DEFAULT_VIEWER_HOST, help="Host to bind viewer"),
     port: int = typer.Option(DEFAULT_VIEWER_PORT, help="Port to bind viewer"),
@@ -792,6 +795,8 @@ def serve(
     stop: bool = typer.Option(False, help="Stop background viewer"),
     restart: bool = typer.Option(False, help="Restart background viewer"),
 ) -> None:
+    if ctx.invoked_subcommand is not None:
+        return
     _serve(
         db_path=db_path,
         host=host,
@@ -799,6 +804,63 @@ def serve(
         background=background,
         stop=stop,
         restart=restart,
+    )
+
+
+@serve_app.command("start")
+def serve_start(
+    db_path: str = typer.Option(None, help="Path to SQLite database"),
+    host: str = typer.Option(DEFAULT_VIEWER_HOST, help="Host to bind viewer"),
+    port: int = typer.Option(DEFAULT_VIEWER_PORT, help="Port to bind viewer"),
+    background: bool = typer.Option(
+        True, "--background/--foreground", help="Run viewer in background"
+    ),
+) -> None:
+    """Start the viewer."""
+
+    _serve(
+        db_path=db_path,
+        host=host,
+        port=port,
+        background=background,
+        stop=False,
+        restart=False,
+    )
+
+
+@serve_app.command("stop")
+def serve_stop(
+    db_path: str = typer.Option(None, help="Path to SQLite database"),
+    host: str = typer.Option(DEFAULT_VIEWER_HOST, help="Host to bind viewer"),
+    port: int = typer.Option(DEFAULT_VIEWER_PORT, help="Port to bind viewer"),
+) -> None:
+    """Stop the background viewer."""
+
+    _serve(
+        db_path=db_path,
+        host=host,
+        port=port,
+        background=False,
+        stop=True,
+        restart=False,
+    )
+
+
+@serve_app.command("restart")
+def serve_restart(
+    db_path: str = typer.Option(None, help="Path to SQLite database"),
+    host: str = typer.Option(DEFAULT_VIEWER_HOST, help="Host to bind viewer"),
+    port: int = typer.Option(DEFAULT_VIEWER_PORT, help="Port to bind viewer"),
+) -> None:
+    """Restart the background viewer."""
+
+    _serve(
+        db_path=db_path,
+        host=host,
+        port=port,
+        background=False,
+        stop=False,
+        restart=True,
     )
 
 

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -21,6 +21,14 @@ def test_root_help_shows_db_namespace() -> None:
     assert "hybrid-eval" in result.stdout
 
 
+def test_serve_help_shows_management_subcommands() -> None:
+    result = runner.invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "start" in result.stdout
+    assert "stop" in result.stdout
+    assert "restart" in result.stdout
+
+
 def test_db_help_shows_prune_commands() -> None:
     result = runner.invoke(app, ["db", "--help"])
     assert result.exit_code == 0

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -194,6 +194,50 @@ def test_sync_disable_reports_no_pidfile_without_stop_instructions(
     assert "Stop the daemon to apply disable" not in result.stdout
 
 
+def test_serve_restart_subcommand_matches_legacy_flag(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_serve(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr("codemem.cli_app._serve", fake_serve)
+
+    result = runner.invoke(app, ["serve", "restart"])
+    assert result.exit_code == 0
+    assert calls == [
+        {
+            "db_path": None,
+            "host": "127.0.0.1",
+            "port": 38888,
+            "background": False,
+            "stop": False,
+            "restart": True,
+        }
+    ]
+
+
+def test_serve_start_defaults_to_background(monkeypatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_serve(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr("codemem.cli_app._serve", fake_serve)
+
+    result = runner.invoke(app, ["serve", "start"])
+    assert result.exit_code == 0
+    assert calls == [
+        {
+            "db_path": None,
+            "host": "127.0.0.1",
+            "port": 38888,
+            "background": True,
+            "stop": False,
+            "restart": False,
+        }
+    ]
+
+
 def test_sync_pair_accept_stores_peer(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     db_path = tmp_path / "mem.sqlite"


### PR DESCRIPTION
## Description
Add verb-style viewer management commands so `codemem serve` lines up better with the existing `codemem sync start|stop|restart` UX, while keeping the current flag-based `codemem serve --restart` behavior working for backward compatibility. This makes the CLI feel less inconsistent without breaking existing scripts.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation:
- `uv run pytest tests/test_cli_help.py tests/test_sync_cli.py`
- `uv run ruff check codemem/cli_app.py tests/test_cli_help.py tests/test_sync_cli.py`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced