### PR TITLE
chore(release): prepare 0.18.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.17.0"
+    "version": "0.18.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -13,7 +13,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.17.0";
+const PINNED_BACKEND_VERSION = "0.18.0";
 const DEFAULT_UVX_SOURCE = `codemem==${PINNED_BACKEND_VERSION}`;
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();

--- a/codemem/__init__.py
+++ b/codemem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.17.0"
+__version__ = "0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kunickiaj/codemem",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "CodeMem plugin for OpenCode",
   "type": "module",
   "main": "index.js",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": {
     "name": "Adam Kunicki"
   },
@@ -11,7 +11,7 @@
     "codemem": {
       "command": "uvx",
       "args": [
-        "codemem==0.17.0",
+        "codemem==0.18.0",
         "mcp"
       ]
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = [
 
 [project]
 name = "codemem"
-version = "0.17.0"
+version = "0.18.0"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "codemem"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Description
Prepare the `0.18.0` release after the identity-aware sync and shared-memory MVP work landed on `main`. This PR aligns all managed version fields, refreshes the Python lockfile, and ensures release artifacts are ready for tagging once the release branch is merged.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation:
- `uv run python scripts/release_version.py set 0.18.0`
- `uv sync`
- `bun install && bun run build` (in `viewer_ui/`)
- `uv run python scripts/release_version.py check`
- `uv run pytest`
- `uv run ruff check codemem tests`
- `uv run ruff format --check codemem tests`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced