### PR TITLE
chore(release): prepare 0.18.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.18.0"
+    "version": "0.18.1"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -13,7 +13,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.18.0";
+const PINNED_BACKEND_VERSION = "0.18.1";
 const DEFAULT_UVX_SOURCE = `codemem==${PINNED_BACKEND_VERSION}`;
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();

--- a/codemem/__init__.py
+++ b/codemem/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.18.0"
+__version__ = "0.18.1"

--- a/codemem/viewer_routes/memory.py
+++ b/codemem/viewer_routes/memory.py
@@ -199,38 +199,52 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
         params = parse_qs(query)
         project = params.get("project", [None])[0]
 
-        prompts = store.conn.execute(
-            "SELECT COUNT(*) AS total FROM user_prompts WHERE (? IS NULL OR project = ?)",
-            (project, project),
-        ).fetchone()["total"]
-        artifacts = store.conn.execute(
-            """
-            SELECT COUNT(*) AS total
-            FROM artifacts
-            JOIN sessions ON sessions.id = artifacts.session_id
-            WHERE (? IS NULL OR sessions.project = ?)
-            """,
-            (project, project),
-        ).fetchone()["total"]
-        memories = store.conn.execute(
-            """
-            SELECT COUNT(*) AS total
-            FROM memory_items
-            JOIN sessions ON sessions.id = memory_items.session_id
-            WHERE (? IS NULL OR sessions.project = ?)
-            """,
-            (project, project),
-        ).fetchone()["total"]
-        observations = store.conn.execute(
-            """
-            SELECT COUNT(*) AS total
-            FROM memory_items
-            JOIN sessions ON sessions.id = memory_items.session_id
-            WHERE kind != 'session_summary'
-              AND (? IS NULL OR sessions.project = ?)
-            """,
-            (project, project),
-        ).fetchone()["total"]
+        if project:
+            prompts = store.conn.execute(
+                "SELECT COUNT(*) AS total FROM user_prompts WHERE project = ?",
+                (project,),
+            ).fetchone()["total"]
+            artifacts = store.conn.execute(
+                """
+                SELECT COUNT(*) AS total
+                FROM artifacts
+                JOIN sessions ON sessions.id = artifacts.session_id
+                WHERE sessions.project = ?
+                """,
+                (project,),
+            ).fetchone()["total"]
+            memories = store.conn.execute(
+                """
+                SELECT COUNT(*) AS total
+                FROM memory_items
+                JOIN sessions ON sessions.id = memory_items.session_id
+                WHERE sessions.project = ?
+                """,
+                (project,),
+            ).fetchone()["total"]
+            observations = store.conn.execute(
+                """
+                SELECT COUNT(*) AS total
+                FROM memory_items
+                JOIN sessions ON sessions.id = memory_items.session_id
+                WHERE kind != 'session_summary'
+                  AND sessions.project = ?
+                """,
+                (project,),
+            ).fetchone()["total"]
+        else:
+            prompts = store.conn.execute("SELECT COUNT(*) AS total FROM user_prompts").fetchone()[
+                "total"
+            ]
+            artifacts = store.conn.execute("SELECT COUNT(*) AS total FROM artifacts").fetchone()[
+                "total"
+            ]
+            memories = store.conn.execute("SELECT COUNT(*) AS total FROM memory_items").fetchone()[
+                "total"
+            ]
+            observations = store.conn.execute(
+                "SELECT COUNT(*) AS total FROM memory_items WHERE kind != 'session_summary'"
+            ).fetchone()["total"]
         total = int(prompts or 0) + int(artifacts or 0) + int(memories or 0)
 
         handler._send_json(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kunickiaj/codemem",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "CodeMem plugin for OpenCode",
   "type": "module",
   "main": "index.js",

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "author": {
     "name": "Adam Kunicki"
   },
@@ -11,7 +11,7 @@
     "codemem": {
       "command": "uvx",
       "args": [
-        "codemem==0.18.0",
+        "codemem==0.18.1",
         "mcp"
       ]
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = [
 
 [project]
 name = "codemem"
-version = "0.18.0"
+version = "0.18.1"
 description = "Persistent memory layer for OpenCode CLI with MCP server and wrapper capture"
 authors = [{name = "OpenCode", email = "hello@opencode.dev"}]
 requires-python = ">=3.11,<3.15"

--- a/tests/test_viewer_routes_memory.py
+++ b/tests/test_viewer_routes_memory.py
@@ -241,3 +241,36 @@ def test_observations_claimed_peer_counts_as_mine(tmp_path: Path) -> None:
         assert theirs_handler.response["items"][0]["owned_by_self"] is False
     finally:
         store.close()
+
+
+def test_session_endpoint_reports_unfiltered_counts_without_project(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        session = store.start_session(
+            cwd="/tmp/work",
+            git_remote=None,
+            git_branch="main",
+            user="tester",
+            tool_version="test",
+            project="proj",
+        )
+        store.add_user_prompt(session, "proj", "Prompt")
+        store.add_artifact(session, kind="transcript", path=None, content_text="hello")
+        store.remember(session, kind="bugfix", title="Bug", body_text="Fix")
+        store.remember(session, kind="session_summary", title="Summary", body_text="Summary body")
+        store.end_session(session)
+
+        handler = DummyHandler()
+        handled = memory.handle_get(handler, store, "/api/session", "")
+
+        assert handled is True
+        assert handler.status == 200
+        assert handler.response == {
+            "total": 4,
+            "memories": 2,
+            "artifacts": 1,
+            "prompts": 1,
+            "observations": 1,
+        }
+    finally:
+        store.close()

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 
 [[package]]
 name = "codemem"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastembed" },


### PR DESCRIPTION
## Description
Prepare the `0.18.1` hotfix release for the viewer session-overview performance fix. This release keeps the patch tightly scoped to the user-visible viewer slowdown, aligns all managed version fields, refreshes release artifacts, and validates the full test/lint suite before tagging.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation:
- `uv run pytest`
- `uv run ruff check codemem tests`
- `uv run ruff format --check codemem tests`
- `uv run python scripts/release_version.py set 0.18.1`
- `uv sync`
- `bun run build` (in `viewer_ui/`)
- `uv run python scripts/release_version.py check`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced