### PR TITLE
feat(storage): add backward-compatible artifact compression

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -22,6 +22,7 @@ from .commands.common import (
     write_config_or_exit,
 )
 from .commands.db_cmds import (
+    compress_artifacts_cmd,
     normalize_projects_cmd,
     prune_memories_cmd,
     prune_observations_cmd,
@@ -1282,6 +1283,24 @@ def db_size_report(
     """Show SQLite file size and major storage consumers."""
 
     size_report_cmd(store_from_path=_store, db_path=db_path, limit=limit)
+
+
+@db_app.command("compress-artifacts")
+def db_compress_artifacts(
+    db_path: str = typer.Option(None, help="Path to codemem SQLite database"),
+    min_bytes: int = typer.Option(4096, min=1, help="Minimum artifact text size to compress"),
+    limit: int | None = typer.Option(None, min=1, help="Optional row limit"),
+    dry_run: bool = typer.Option(False, help="Preview without writing changes"),
+) -> None:
+    """Compress large stored artifact text payloads."""
+
+    compress_artifacts_cmd(
+        store_from_path=_store,
+        db_path=db_path,
+        min_bytes=min_bytes,
+        limit=limit,
+        dry_run=dry_run,
+    )
 
 
 @app.command()

--- a/codemem/commands/db_cmds.py
+++ b/codemem/commands/db_cmds.py
@@ -112,7 +112,7 @@ def size_report_cmd(*, store_from_path, db_path: str | None, limit: int) -> None
             print("\n[bold]Largest tables / indexes[/bold]")
             for item in objects:
                 print(
-                    f"- {item['name']} ({item['kind']}): {_format_bytes(item['bytes'])}"
+                    f"- {item['name']} ({item['kind']}): {_format_bytes(int(item['bytes']))}"
                     f" [{item['pages']:,} pages]"
                 )
 
@@ -123,6 +123,31 @@ def size_report_cmd(*, store_from_path, db_path: str | None, limit: int) -> None
                 print(f"- {name}: {count:,}")
     finally:
         store.close()
+
+
+def compress_artifacts_cmd(
+    *,
+    store_from_path,
+    db_path: str | None,
+    min_bytes: int,
+    limit: int | None,
+    dry_run: bool,
+) -> None:
+    """Compress large artifact text payloads."""
+
+    store = store_from_path(db_path)
+    try:
+        result = store.compress_artifacts(min_bytes=min_bytes, limit=limit, dry_run=dry_run)
+    finally:
+        store.close()
+
+    action = "Would compress" if dry_run else "Compressed"
+    print(
+        f"[bold]{action}[/bold] {result['compressed']} of {result['checked']} candidate artifacts"
+    )
+    print(f"- Raw bytes: {_format_bytes(result['raw_bytes'])}")
+    print(f"- Compressed bytes: {_format_bytes(result['compressed_bytes'])}")
+    print(f"- Saved bytes: {_format_bytes(result['saved_bytes'])}")
 
 
 def _format_bytes(num_bytes: int) -> str:

--- a/codemem/db.py
+++ b/codemem/db.py
@@ -1051,6 +1051,13 @@ def _ensure_sync_peer_schema(conn: sqlite3.Connection) -> None:
     _ensure_column(conn, "sync_peers", "claimed_local_actor", "INTEGER NOT NULL DEFAULT 0")
 
 
+def _ensure_artifact_storage_schema(conn: sqlite3.Connection) -> None:
+    if not _table_exists(conn, "artifacts"):
+        return
+    _ensure_column(conn, "artifacts", "content_encoding", "TEXT")
+    _ensure_column(conn, "artifacts", "content_blob", "BLOB")
+
+
 def initialize_schema(conn: sqlite3.Connection) -> None:
     current_version = _schema_user_version(conn)
     raw_event_identity_migrate = _raw_event_identity_needs_data_migration(conn)
@@ -1059,6 +1066,7 @@ def initialize_schema(conn: sqlite3.Connection) -> None:
         current_version = 1
     _ensure_memory_identity_schema(conn)
     _ensure_sync_peer_schema(conn)
+    _ensure_artifact_storage_schema(conn)
     _ensure_raw_event_identity_schema(conn, migrate_data=raw_event_identity_migrate)
     if current_version < SCHEMA_VERSION:
         conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -4,6 +4,8 @@ import datetime as dt
 import hashlib
 import math
 import os
+import sqlite3
+import zlib
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import Any
@@ -30,6 +32,8 @@ class MemoryStore:
     FUZZY_CANDIDATE_LIMIT = 200
     FUZZY_MIN_SCORE = 0.18
     SEMANTIC_CANDIDATE_LIMIT = 200
+    ARTIFACT_COMPRESSION_MIN_BYTES = 4096
+    ARTIFACT_COMPRESSION_ENCODING = "zlib+utf8"
     STOPWORDS = {
         "a",
         "an",
@@ -1109,6 +1113,9 @@ class MemoryStore:
     ) -> int:
         created_at = dt.datetime.now(dt.UTC).isoformat()
         content_hash = hashlib.sha256(content_text.encode("utf-8")).hexdigest()
+        content_text_value, content_encoding, content_blob = self._artifact_storage_payload(
+            content_text
+        )
         if metadata and metadata.get("flush_batch"):
             meta_text = db.to_json(metadata)
             row = self.conn.execute(
@@ -1123,17 +1130,29 @@ class MemoryStore:
                 return int(row["id"])
         cur = self.conn.execute(
             """
-            INSERT INTO artifacts(session_id, kind, path, content_text, content_hash, created_at, metadata_json)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
+            INSERT INTO artifacts(
                 session_id,
                 kind,
                 path,
                 content_text,
                 content_hash,
                 created_at,
+                metadata_json,
+                content_encoding,
+                content_blob
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                kind,
+                path,
+                content_text_value,
+                content_hash,
+                created_at,
                 db.to_json(metadata),
+                content_encoding,
+                content_blob,
             ),
         )
         self.conn.commit()
@@ -1951,20 +1970,111 @@ class MemoryStore:
         results = db.rows_to_dicts(rows)
         for item in results:
             item["metadata_json"] = db.from_json(item.get("metadata_json"))
+            item["content_text"] = self._artifact_text_from_row(item)
+            item.pop("content_blob", None)
         return results
 
     def latest_transcript(self, session_id: int) -> str | None:
         row = self.conn.execute(
             """
-            SELECT content_text FROM artifacts
+            SELECT content_text, content_encoding, content_blob FROM artifacts
             WHERE session_id = ? AND kind = 'transcript'
             ORDER BY id DESC LIMIT 1
             """,
             (session_id,),
         ).fetchone()
         if row:
-            return row["content_text"]
+            return self._artifact_text_from_row(row)
         return None
+
+    def compress_artifacts(
+        self,
+        *,
+        min_bytes: int | None = None,
+        limit: int | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, int]:
+        threshold = max(1, int(min_bytes or self.ARTIFACT_COMPRESSION_MIN_BYTES))
+        query = """
+            SELECT id, content_text
+            FROM artifacts
+            WHERE content_blob IS NULL
+              AND content_text IS NOT NULL
+              AND LENGTH(content_text) >= ?
+            ORDER BY id ASC
+        """
+        params: list[Any] = [threshold]
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(int(limit))
+        rows = self.conn.execute(query, params).fetchall()
+
+        checked = len(rows)
+        compressed = 0
+        raw_bytes = 0
+        compressed_bytes = 0
+        updates: list[tuple[None, str, bytes, int]] = []
+        for row in rows:
+            text = str(row["content_text"] or "")
+            raw = text.encode("utf-8")
+            blob = zlib.compress(raw, level=6)
+            if len(blob) >= len(raw):
+                continue
+            raw_bytes += len(raw)
+            compressed_bytes += len(blob)
+            compressed += 1
+            if not dry_run:
+                updates.append((None, self.ARTIFACT_COMPRESSION_ENCODING, blob, int(row["id"])))
+        if updates:
+            self.conn.executemany(
+                """
+                UPDATE artifacts
+                SET content_text = ?, content_encoding = ?, content_blob = ?
+                WHERE id = ?
+                """,
+                updates,
+            )
+            self.conn.commit()
+        return {
+            "checked": checked,
+            "compressed": compressed,
+            "raw_bytes": raw_bytes,
+            "compressed_bytes": compressed_bytes,
+            "saved_bytes": max(0, raw_bytes - compressed_bytes),
+            "dry_run": 1 if dry_run else 0,
+        }
+
+    def _artifact_storage_payload(
+        self, content_text: str
+    ) -> tuple[str | None, str | None, bytes | None]:
+        raw = content_text.encode("utf-8")
+        if len(raw) < self.ARTIFACT_COMPRESSION_MIN_BYTES:
+            return content_text, None, None
+        blob = zlib.compress(raw, level=6)
+        if len(blob) >= len(raw):
+            return content_text, None, None
+        return None, self.ARTIFACT_COMPRESSION_ENCODING, blob
+
+    def _artifact_text_from_row(self, row: sqlite3.Row | dict[str, Any]) -> str | None:
+        content_text = (
+            row["content_text"] if isinstance(row, sqlite3.Row) else row.get("content_text")
+        )
+        if content_text is not None:
+            return str(content_text)
+        content_encoding = (
+            row["content_encoding"] if isinstance(row, sqlite3.Row) else row.get("content_encoding")
+        )
+        content_blob = (
+            row["content_blob"] if isinstance(row, sqlite3.Row) else row.get("content_blob")
+        )
+        if not content_encoding or content_blob is None:
+            return None
+        if str(content_encoding) != self.ARTIFACT_COMPRESSION_ENCODING:
+            raise ValueError(f"Unsupported artifact content encoding: {content_encoding}")
+        try:
+            return zlib.decompress(bytes(content_blob)).decode("utf-8")
+        except (zlib.error, UnicodeDecodeError) as exc:
+            raise ValueError("Failed to decode compressed artifact content") from exc
 
     def replace_session_summary(self, session_id: int, summary: Summary) -> None:
         now = dt.datetime.now(dt.UTC).isoformat()

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -2000,7 +2000,7 @@ class MemoryStore:
             FROM artifacts
             WHERE content_blob IS NULL
               AND content_text IS NOT NULL
-              AND LENGTH(content_text) >= ?
+              AND LENGTH(CAST(content_text AS BLOB)) >= ?
             ORDER BY id ASC
         """
         params: list[Any] = [threshold]

--- a/codemem/store/maintenance.py
+++ b/codemem/store/maintenance.py
@@ -98,19 +98,7 @@ def _session_discovery_tokens_by_prompt(
 
 
 def _session_discovery_tokens_from_transcript(store: MemoryStore, session_id: int) -> int:
-    row = store.conn.execute(
-        """
-        SELECT content_text
-        FROM artifacts
-        WHERE session_id = ? AND kind = 'transcript'
-        ORDER BY id DESC
-        LIMIT 1
-        """,
-        (session_id,),
-    ).fetchone()
-    if row is None:
-        return 0
-    text = str(row["content_text"] or "")
+    text = store.latest_transcript(session_id) or ""
     if not text.strip():
         return 0
     return store.estimate_tokens(text)

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -35,6 +35,12 @@ def test_initialize_schema_sets_user_version(monkeypatch, tmp_path: Path) -> Non
         workspace_column = conn.execute(
             "SELECT name FROM pragma_table_info('memory_items') WHERE name = 'workspace_id'"
         ).fetchone()
+        artifact_encoding_column = conn.execute(
+            "SELECT name FROM pragma_table_info('artifacts') WHERE name = 'content_encoding'"
+        ).fetchone()
+        artifact_blob_column = conn.execute(
+            "SELECT name FROM pragma_table_info('artifacts') WHERE name = 'content_blob'"
+        ).fetchone()
     finally:
         conn.close()
 
@@ -48,6 +54,8 @@ def test_initialize_schema_sets_user_version(monkeypatch, tmp_path: Path) -> Non
     assert visibility_column is not None
     assert claimed_local_actor_column is not None
     assert workspace_column is not None
+    assert artifact_encoding_column is not None
+    assert artifact_blob_column is not None
 
 
 def test_initialize_schema_skips_reinit_but_keeps_kind_normalization(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -64,6 +64,74 @@ def test_recent_filters(tmp_path: Path) -> None:
     assert observations[0]["kind"] == "observation"
 
 
+def test_artifact_reads_transparently_decompress_large_content(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    text = "abc123\n" * 2000
+    artifact_id = store.add_artifact(session, kind="transcript", path=None, content_text=text)
+    row = store.conn.execute(
+        "SELECT content_text, content_encoding, content_blob FROM artifacts WHERE id = ?",
+        (artifact_id,),
+    ).fetchone()
+    assert row is not None
+    assert row["content_text"] is None
+    assert row["content_encoding"] == store.ARTIFACT_COMPRESSION_ENCODING
+    assert row["content_blob"] is not None
+
+    artifacts = store.session_artifacts(session)
+    assert artifacts[0]["content_text"] == text
+    assert store.latest_transcript(session) == text
+    store.close()
+
+
+def test_compress_artifacts_compresses_existing_rows(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    text = "legacy transcript\n" * 1000
+    store.conn.execute(
+        """
+        INSERT INTO artifacts(session_id, kind, path, content_text, content_hash, created_at, metadata_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            session,
+            "transcript",
+            None,
+            text,
+            "legacy-hash",
+            dt.datetime.now(dt.UTC).isoformat(),
+            db.to_json({}),
+        ),
+    )
+    store.conn.commit()
+
+    result = store.compress_artifacts(dry_run=False)
+    assert result["compressed"] >= 1
+    row = store.conn.execute(
+        "SELECT content_text, content_encoding, content_blob FROM artifacts ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert row["content_text"] is None
+    assert row["content_encoding"] == store.ARTIFACT_COMPRESSION_ENCODING
+    assert row["content_blob"] is not None
+    assert store.latest_transcript(session) == text
+    store.close()
+
+
 def test_rejects_invalid_memory_kind(tmp_path: Path) -> None:
     store = MemoryStore(tmp_path / "mem.sqlite")
     session = store.start_session(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -132,6 +132,46 @@ def test_compress_artifacts_compresses_existing_rows(tmp_path: Path) -> None:
     store.close()
 
 
+def test_compress_artifacts_uses_utf8_byte_length_threshold(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    text = "🙂" * 2000
+    store.conn.execute(
+        """
+        INSERT INTO artifacts(session_id, kind, path, content_text, content_hash, created_at, metadata_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            session,
+            "transcript",
+            None,
+            text,
+            "emoji-hash",
+            dt.datetime.now(dt.UTC).isoformat(),
+            db.to_json({}),
+        ),
+    )
+    store.conn.commit()
+
+    result = store.compress_artifacts(min_bytes=4096, dry_run=False)
+    assert result["compressed"] >= 1
+    row = store.conn.execute(
+        "SELECT content_text, content_encoding, content_blob FROM artifacts ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row is not None
+    assert row["content_text"] is None
+    assert row["content_encoding"] == store.ARTIFACT_COMPRESSION_ENCODING
+    assert row["content_blob"] is not None
+    store.close()
+
+
 def test_rejects_invalid_memory_kind(tmp_path: Path) -> None:
     store = MemoryStore(tmp_path / "mem.sqlite")
     session = store.start_session(


### PR DESCRIPTION
## Description
Add backward-compatible artifact compression for large stored text payloads so oversized transcripts, pre-context captures, and similar artifacts can be compressed without breaking existing viewer or maintenance reads. This keeps artifacts as the first storage-optimization target while avoiding the higher-risk raw-event JSON changes for now.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation:
- `uv run pytest tests/test_db_size_report.py tests/test_db_schema.py tests/test_store.py -k "size_report or artifact or compress_artifacts or schema_sets_user_version"`
- `uv run ruff check codemem/cli_app.py codemem/commands/db_cmds.py codemem/db.py codemem/store/_store.py codemem/store/maintenance.py tests/test_db_size_report.py tests/test_db_schema.py tests/test_store.py`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
