### PR TITLE
feat: add actor registry and merge foundations

### DIFF
--- a/codemem/db.py
+++ b/codemem/db.py
@@ -15,7 +15,7 @@ LEGACY_DEFAULT_DB_PATHS = (
     Path.home() / ".codemem.sqlite",
     Path.home() / ".opencode-mem.sqlite",
 )
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 
 def _sidecar_paths(path: Path) -> list[Path]:
@@ -1042,6 +1042,27 @@ def _ensure_memory_identity_schema(conn: sqlite3.Connection) -> None:
     )
 
 
+def _ensure_actor_registry_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS actors (
+            actor_id TEXT PRIMARY KEY,
+            display_name TEXT NOT NULL,
+            is_local INTEGER NOT NULL DEFAULT 0,
+            status TEXT NOT NULL DEFAULT 'active',
+            merged_into_actor_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_actors_is_local ON actors(is_local)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_actors_status ON actors(status)")
+    if _table_exists(conn, "sync_peers"):
+        _ensure_column(conn, "sync_peers", "actor_id", "TEXT")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_sync_peers_actor_id ON sync_peers(actor_id)")
+
+
 def _ensure_sync_peer_schema(conn: sqlite3.Connection) -> None:
     if not _table_exists(conn, "sync_peers"):
         return
@@ -1049,6 +1070,8 @@ def _ensure_sync_peer_schema(conn: sqlite3.Connection) -> None:
     _ensure_column(conn, "sync_peers", "projects_include_json", "TEXT")
     _ensure_column(conn, "sync_peers", "projects_exclude_json", "TEXT")
     _ensure_column(conn, "sync_peers", "claimed_local_actor", "INTEGER NOT NULL DEFAULT 0")
+    _ensure_column(conn, "sync_peers", "actor_id", "TEXT")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_sync_peers_actor_id ON sync_peers(actor_id)")
 
 
 def _ensure_artifact_storage_schema(conn: sqlite3.Connection) -> None:
@@ -1065,6 +1088,7 @@ def initialize_schema(conn: sqlite3.Connection) -> None:
         _initialize_schema_v1(conn)
         current_version = 1
     _ensure_memory_identity_schema(conn)
+    _ensure_actor_registry_schema(conn)
     _ensure_sync_peer_schema(conn)
     _ensure_artifact_storage_schema(conn)
     _ensure_raw_event_identity_schema(conn, migrate_data=raw_event_identity_migrate)

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -34,6 +34,8 @@ class MemoryStore:
     SEMANTIC_CANDIDATE_LIMIT = 200
     ARTIFACT_COMPRESSION_MIN_BYTES = 4096
     ARTIFACT_COMPRESSION_ENCODING = "zlib+utf8"
+    LEGACY_SYNC_ACTOR_DISPLAY_NAME = "Legacy synced peer"
+    LEGACY_SHARED_WORKSPACE_ID = "shared:legacy"
     STOPWORDS = {
         "a",
         "an",
@@ -114,6 +116,8 @@ class MemoryStore:
         self._sync_projects_exclude = [
             p.strip() for p in cfg.sync_projects_exclude if p and p.strip()
         ]
+        self._ensure_local_actor_record()
+        self._sync_peer_actor_compatibility_state()
         self._backfill_identity_provenance()
         self._reconcile_claimed_same_actor_legacy_memories()
 
@@ -142,6 +146,344 @@ class MemoryStore:
         if workspace_kind == "shared":
             return "shared:default"
         return f"personal:{actor_id}"
+
+    def _upsert_actor_record(
+        self,
+        *,
+        actor_id: str,
+        display_name: str,
+        is_local: bool,
+    ) -> None:
+        now = dt.datetime.now(dt.UTC).isoformat()
+        if is_local:
+            self.conn.execute("UPDATE actors SET is_local = 0 WHERE actor_id != ?", (actor_id,))
+            self.conn.execute(
+                """
+                INSERT INTO actors(
+                    actor_id,
+                    display_name,
+                    is_local,
+                    status,
+                    merged_into_actor_id,
+                    created_at,
+                    updated_at
+                )
+                VALUES (?, ?, 1, 'active', NULL, ?, ?)
+                ON CONFLICT(actor_id) DO UPDATE SET
+                    display_name = excluded.display_name,
+                    is_local = 1,
+                    status = 'active',
+                    merged_into_actor_id = NULL,
+                    updated_at = excluded.updated_at
+                """,
+                (actor_id, display_name, now, now),
+            )
+            return
+        self.conn.execute(
+            """
+            INSERT INTO actors(
+                actor_id,
+                display_name,
+                is_local,
+                status,
+                merged_into_actor_id,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, 0, 'active', NULL, ?, ?)
+            ON CONFLICT(actor_id) DO UPDATE SET
+                display_name = excluded.display_name,
+                updated_at = excluded.updated_at
+            """,
+            (actor_id, display_name, now, now),
+        )
+
+    def _ensure_local_actor_record(self) -> None:
+        self._upsert_actor_record(
+            actor_id=self.actor_id,
+            display_name=self.actor_display_name,
+            is_local=True,
+        )
+        if self.conn.in_transaction:
+            self.conn.commit()
+
+    def _sync_peer_actor_compatibility_state(self) -> None:
+        self.conn.execute(
+            """
+            UPDATE sync_peers
+            SET actor_id = ?
+            WHERE claimed_local_actor = 1
+              AND (actor_id IS NULL OR TRIM(actor_id) = '')
+            """,
+            (self.actor_id,),
+        )
+        self.conn.execute(
+            "UPDATE sync_peers SET claimed_local_actor = 1 WHERE actor_id = ?",
+            (self.actor_id,),
+        )
+        self.conn.execute(
+            """
+            UPDATE sync_peers
+            SET claimed_local_actor = 0
+            WHERE actor_id IS NOT NULL
+              AND TRIM(actor_id) != ''
+              AND actor_id != ?
+            """,
+            (self.actor_id,),
+        )
+        if self.conn.in_transaction:
+            self.conn.commit()
+
+    def get_actor(self, actor_id: str) -> dict[str, Any] | None:
+        cleaned = self._clean_optional_str(actor_id)
+        if not cleaned:
+            return None
+        row = self.conn.execute(
+            """
+            SELECT actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+            FROM actors
+            WHERE actor_id = ?
+            """,
+            (cleaned,),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "actor_id": str(row["actor_id"]),
+            "display_name": str(row["display_name"]),
+            "is_local": bool(row["is_local"]),
+            "status": str(row["status"]),
+            "merged_into_actor_id": row["merged_into_actor_id"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def resolve_actor(self, actor_id: str) -> dict[str, Any] | None:
+        cleaned_actor_id = self._clean_optional_str(actor_id)
+        if not cleaned_actor_id:
+            return None
+        seen: set[str] = set()
+        current_actor_id = cleaned_actor_id
+        while current_actor_id and current_actor_id not in seen:
+            seen.add(current_actor_id)
+            actor = self.get_actor(current_actor_id)
+            if actor is None:
+                return None
+            merged_into_actor_id = self._clean_optional_str(actor.get("merged_into_actor_id"))
+            if actor["status"] != "merged" or not merged_into_actor_id:
+                return actor
+            current_actor_id = merged_into_actor_id
+        raise ValueError("actor merge redirect cycle")
+
+    def list_actors(self, *, include_merged: bool = False) -> list[dict[str, Any]]:
+        where = "" if include_merged else "WHERE status = 'active'"
+        rows = self.conn.execute(
+            f"""
+            SELECT actor_id, display_name, is_local, status, merged_into_actor_id, created_at, updated_at
+            FROM actors
+            {where}
+            ORDER BY is_local DESC, display_name COLLATE NOCASE ASC, actor_id ASC
+            """
+        ).fetchall()
+        return [
+            {
+                "actor_id": str(row["actor_id"]),
+                "display_name": str(row["display_name"]),
+                "is_local": bool(row["is_local"]),
+                "status": str(row["status"]),
+                "merged_into_actor_id": row["merged_into_actor_id"],
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+            }
+            for row in rows
+        ]
+
+    def create_actor(self, *, display_name: str, actor_id: str | None = None) -> dict[str, Any]:
+        cleaned_name = self._clean_optional_str(display_name)
+        if not cleaned_name:
+            raise ValueError("display_name required")
+        cleaned_actor_id = self._clean_optional_str(actor_id)
+        if cleaned_actor_id == self.actor_id:
+            self._ensure_local_actor_record()
+            actor = self.get_actor(self.actor_id)
+            if actor is None:
+                raise ValueError("local actor missing")
+            return actor
+        if cleaned_actor_id is None:
+            cleaned_actor_id = f"actor:{uuid4()}"
+        self._upsert_actor_record(
+            actor_id=cleaned_actor_id,
+            display_name=cleaned_name,
+            is_local=False,
+        )
+        if self.conn.in_transaction:
+            self.conn.commit()
+        actor = self.get_actor(cleaned_actor_id)
+        if actor is None:
+            raise ValueError("actor create failed")
+        return actor
+
+    def rename_actor(self, actor_id: str, *, display_name: str) -> dict[str, Any]:
+        cleaned_actor_id = self._clean_optional_str(actor_id)
+        cleaned_name = self._clean_optional_str(display_name)
+        if not cleaned_actor_id:
+            raise ValueError("actor_id required")
+        if not cleaned_name:
+            raise ValueError("display_name required")
+        actor = self.get_actor(cleaned_actor_id)
+        if actor is None:
+            raise LookupError("actor not found")
+        if actor["is_local"]:
+            raise ValueError("local actor rename not supported")
+        if actor["status"] != "active":
+            raise ValueError("merged actor rename not supported")
+        self._upsert_actor_record(
+            actor_id=cleaned_actor_id,
+            display_name=cleaned_name,
+            is_local=bool(actor["is_local"]),
+        )
+        if self.conn.in_transaction:
+            self.conn.commit()
+        renamed = self.get_actor(cleaned_actor_id)
+        if renamed is None:
+            raise LookupError("actor not found")
+        return renamed
+
+    def peer_actor_assignment(self, peer_device_id: str) -> dict[str, Any] | None:
+        cleaned_peer_id = self._clean_optional_str(peer_device_id)
+        if not cleaned_peer_id:
+            return None
+        row = self.conn.execute(
+            """
+            SELECT p.peer_device_id, p.actor_id, p.claimed_local_actor, a.display_name AS actor_display_name
+            FROM sync_peers AS p
+            LEFT JOIN actors AS a ON a.actor_id = p.actor_id
+            WHERE p.peer_device_id = ?
+            """,
+            (cleaned_peer_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        actor_id = self._clean_optional_str(row["actor_id"])
+        return {
+            "peer_device_id": str(row["peer_device_id"]),
+            "actor_id": actor_id,
+            "actor_display_name": row["actor_display_name"],
+            "claimed_local_actor": bool(row["claimed_local_actor"]),
+        }
+
+    def assigned_actor_for_peer(self, peer_device_id: str) -> dict[str, Any] | None:
+        assignment = self.peer_actor_assignment(peer_device_id)
+        actor_id = self._clean_optional_str(assignment.get("actor_id")) if assignment else None
+        if not actor_id:
+            return None
+        return self.resolve_actor(actor_id)
+
+    def assign_peer_actor(self, peer_device_id: str, *, actor_id: str | None) -> dict[str, Any]:
+        cleaned_peer_id = self._clean_optional_str(peer_device_id)
+        if not cleaned_peer_id:
+            raise ValueError("peer_device_id required")
+        row = self.conn.execute(
+            "SELECT 1 FROM sync_peers WHERE peer_device_id = ?",
+            (cleaned_peer_id,),
+        ).fetchone()
+        if row is None:
+            raise LookupError("peer not found")
+        cleaned_actor_id = self._clean_optional_str(actor_id)
+        claimed_local_actor = False
+        if cleaned_actor_id is not None:
+            actor = self.resolve_actor(cleaned_actor_id)
+            if actor is None:
+                raise LookupError("actor not found")
+            cleaned_actor_id = str(actor["actor_id"])
+            claimed_local_actor = cleaned_actor_id == self.actor_id
+        self.conn.execute(
+            """
+            UPDATE sync_peers
+            SET actor_id = ?,
+                claimed_local_actor = ?
+            WHERE peer_device_id = ?
+            """,
+            (cleaned_actor_id, 1 if claimed_local_actor else 0, cleaned_peer_id),
+        )
+        if self.conn.in_transaction:
+            self.conn.commit()
+        if cleaned_actor_id is not None:
+            self.reconcile_peer_actor_legacy_memories(cleaned_peer_id)
+        assignment = self.peer_actor_assignment(cleaned_peer_id)
+        if assignment is None:
+            raise LookupError("peer not found")
+        return assignment
+
+    def merge_actor(self, *, primary_actor_id: str, secondary_actor_id: str) -> dict[str, Any]:
+        cleaned_primary_actor_id = self._clean_optional_str(primary_actor_id)
+        cleaned_secondary_actor_id = self._clean_optional_str(secondary_actor_id)
+        if not cleaned_primary_actor_id:
+            raise ValueError("primary_actor_id required")
+        if not cleaned_secondary_actor_id:
+            raise ValueError("secondary_actor_id required")
+        if cleaned_primary_actor_id == cleaned_secondary_actor_id:
+            raise ValueError("cannot merge actor into itself")
+
+        primary_actor = self.resolve_actor(cleaned_primary_actor_id)
+        secondary_actor = self.get_actor(cleaned_secondary_actor_id)
+        if primary_actor is None:
+            raise LookupError("primary actor not found")
+        if secondary_actor is None:
+            raise LookupError("secondary actor not found")
+        if secondary_actor["is_local"]:
+            raise ValueError("local actor cannot be merged into another actor")
+        if secondary_actor["status"] != "active":
+            raise ValueError("secondary actor already merged")
+
+        resolved_primary_actor_id = str(primary_actor["actor_id"])
+        if resolved_primary_actor_id == cleaned_secondary_actor_id:
+            raise ValueError("secondary actor already redirects to primary actor")
+
+        now = self._now_iso()
+        claimed_local_actor = 1 if resolved_primary_actor_id == self.actor_id else 0
+        peer_update = self.conn.execute(
+            """
+            UPDATE sync_peers
+            SET actor_id = ?,
+                claimed_local_actor = ?
+            WHERE actor_id = ?
+            """,
+            (resolved_primary_actor_id, claimed_local_actor, cleaned_secondary_actor_id),
+        )
+        self.conn.execute(
+            """
+            UPDATE actors
+            SET status = 'merged',
+                merged_into_actor_id = ?,
+                updated_at = ?
+            WHERE actor_id = ?
+            """,
+            (resolved_primary_actor_id, now, cleaned_secondary_actor_id),
+        )
+        if self.conn.in_transaction:
+            self.conn.commit()
+
+        reassigned_peer_count = int(peer_update.rowcount or 0)
+        if reassigned_peer_count:
+            rows = self.conn.execute(
+                "SELECT peer_device_id FROM sync_peers WHERE actor_id = ? ORDER BY peer_device_id",
+                (resolved_primary_actor_id,),
+            ).fetchall()
+            for row in rows:
+                peer_device_id = self._clean_optional_str(row["peer_device_id"])
+                if peer_device_id:
+                    self.reconcile_peer_actor_legacy_memories(peer_device_id)
+
+        primary = self.get_actor(resolved_primary_actor_id)
+        secondary = self.get_actor(cleaned_secondary_actor_id)
+        if primary is None or secondary is None:
+            raise LookupError("actor not found")
+        return {
+            "primary_actor": primary,
+            "secondary_actor": secondary,
+            "reassigned_peer_count": reassigned_peer_count,
+        }
 
     def _resolve_memory_provenance(
         self, metadata: dict[str, Any] | None = None
@@ -201,18 +543,56 @@ class MemoryStore:
         if is_local:
             return self._resolve_memory_provenance(metadata)
         origin_device_id = clock_device_id or "unknown"
+        assigned_actor = self.assigned_actor_for_peer(origin_device_id)
+        if assigned_actor is not None:
+            assigned_actor_id = str(assigned_actor["actor_id"])
+            assigned_display_name = str(assigned_actor["display_name"])
+            if assigned_actor_id == self.actor_id:
+                return {
+                    "actor_id": self.actor_id,
+                    "actor_display_name": self.actor_display_name,
+                    "visibility": "private",
+                    "workspace_id": self._default_workspace_id(
+                        actor_id=self.actor_id,
+                        workspace_kind="personal",
+                    ),
+                    "workspace_kind": "personal",
+                    "origin_device_id": origin_device_id,
+                    "origin_source": self._clean_optional_str(metadata.get("origin_source"))
+                    or source
+                    or "sync",
+                    "trust_state": self._clean_optional_str(metadata.get("trust_state"))
+                    or "trusted",
+                }
+            return {
+                "actor_id": assigned_actor_id,
+                "actor_display_name": assigned_display_name,
+                "visibility": self._clean_optional_str(metadata.get("visibility")) or "shared",
+                "workspace_id": self._clean_optional_str(metadata.get("workspace_id"))
+                or self._default_workspace_id(
+                    actor_id=assigned_actor_id,
+                    workspace_kind="shared",
+                ),
+                "workspace_kind": "shared",
+                "origin_device_id": origin_device_id,
+                "origin_source": self._clean_optional_str(metadata.get("origin_source"))
+                or source
+                or "sync",
+                "trust_state": self._clean_optional_str(metadata.get("trust_state")) or "trusted",
+            }
         actor_id = (
             self._clean_optional_str(metadata.get("actor_id")) or f"legacy-sync:{origin_device_id}"
         )
         actor_display_name = (
-            self._clean_optional_str(metadata.get("actor_display_name")) or "Legacy synced peer"
+            self._clean_optional_str(metadata.get("actor_display_name"))
+            or self.LEGACY_SYNC_ACTOR_DISPLAY_NAME
         )
         return {
             "actor_id": actor_id,
             "actor_display_name": actor_display_name,
             "visibility": self._clean_optional_str(metadata.get("visibility")) or "shared",
             "workspace_id": self._clean_optional_str(metadata.get("workspace_id"))
-            or "shared:legacy",
+            or self.LEGACY_SHARED_WORKSPACE_ID,
             "workspace_kind": self._clean_optional_str(metadata.get("workspace_kind")) or "shared",
             "origin_device_id": origin_device_id,
             "origin_source": self._clean_optional_str(metadata.get("origin_source"))
@@ -289,22 +669,95 @@ class MemoryStore:
                 trust_state = 'trusted'
             WHERE origin_device_id IN ({placeholders})
               AND (
-                    actor_id LIKE 'legacy-sync:%'
-                 OR actor_display_name = 'Legacy synced peer'
-                 OR workspace_id = 'shared:legacy'
-                 OR workspace_kind = 'shared'
-                 OR trust_state = 'legacy_unknown'
-              )
+                    (
+                        actor_id IS NULL
+                     OR TRIM(actor_id) = ''
+                     OR actor_id LIKE 'legacy-sync:%'
+                     OR actor_id = ?
+                    )
+                AND (
+                        actor_id IS NULL
+                     OR TRIM(actor_id) = ''
+                     OR actor_id LIKE 'legacy-sync:%'
+                     OR actor_display_name = ?
+                     OR workspace_id = ?
+                     OR trust_state = 'legacy_unknown'
+                    )
+                )
             """,
             [
                 self.actor_id,
                 self.actor_display_name,
                 personal_workspace_id,
                 *claimed_peers,
+                self.actor_id,
+                self.LEGACY_SYNC_ACTOR_DISPLAY_NAME,
+                self.LEGACY_SHARED_WORKSPACE_ID,
             ],
         )
         if self.conn.in_transaction:
             self.conn.commit()
+
+    def reconcile_peer_actor_legacy_memories(self, peer_device_id: str) -> int:
+        assignment = self.peer_actor_assignment(peer_device_id)
+        actor_id = self._clean_optional_str(assignment.get("actor_id")) if assignment else None
+        if not assignment or not actor_id:
+            return 0
+        actor = self.get_actor(actor_id)
+        if actor is None:
+            return 0
+        cleaned_peer_id = str(assignment["peer_device_id"])
+        if actor_id == self.actor_id:
+            self.reconcile_claimed_same_actor_legacy_memories(cleaned_peer_id)
+            row = self.conn.execute(
+                "SELECT COUNT(1) AS total FROM memory_items WHERE origin_device_id = ? AND actor_id = ?",
+                (cleaned_peer_id, self.actor_id),
+            ).fetchone()
+            return int(row["total"] or 0) if row else 0
+        cursor = self.conn.execute(
+            """
+            UPDATE memory_items
+            SET actor_id = ?,
+                actor_display_name = ?,
+                visibility = CASE WHEN visibility = 'shared' THEN visibility ELSE 'shared' END,
+                workspace_id = CASE
+                    WHEN workspace_id IS NULL OR TRIM(workspace_id) = '' OR workspace_id = ? THEN ?
+                    ELSE workspace_id
+                END,
+                workspace_kind = CASE WHEN workspace_kind = 'shared' THEN workspace_kind ELSE 'shared' END,
+                trust_state = 'trusted'
+            WHERE origin_device_id = ?
+              AND (
+                    (
+                        actor_id IS NULL
+                     OR TRIM(actor_id) = ''
+                     OR actor_id LIKE 'legacy-sync:%'
+                     OR actor_id = ?
+                    )
+                AND (
+                        actor_id IS NULL
+                     OR TRIM(actor_id) = ''
+                     OR actor_id LIKE 'legacy-sync:%'
+                     OR actor_display_name = ?
+                     OR workspace_id = ?
+                     OR trust_state = 'legacy_unknown'
+                    )
+              )
+            """,
+            (
+                actor_id,
+                str(actor["display_name"]),
+                self.LEGACY_SHARED_WORKSPACE_ID,
+                self._default_workspace_id(actor_id=actor_id, workspace_kind="shared"),
+                cleaned_peer_id,
+                actor_id,
+                self.LEGACY_SYNC_ACTOR_DISPLAY_NAME,
+                self.LEGACY_SHARED_WORKSPACE_ID,
+            ),
+        )
+        if self.conn.in_transaction:
+            self.conn.commit()
+        return int(cursor.rowcount or 0)
 
     def reconcile_claimed_same_actor_legacy_memories(self, peer_device_id: str) -> None:
         peer_id = self._clean_optional_str(peer_device_id)
@@ -327,12 +780,20 @@ class MemoryStore:
               AND origin_device_id != ''
               AND origin_device_id != 'unknown'
               AND (
-                    actor_id LIKE 'legacy-sync:%'
-                 OR actor_display_name = 'Legacy synced peer'
-                 OR workspace_id = 'shared:legacy'
-                 OR workspace_kind = 'shared'
-                 OR trust_state = 'legacy_unknown'
-              )
+                    (
+                        actor_id IS NULL
+                     OR TRIM(actor_id) = ''
+                     OR actor_id LIKE 'legacy-sync:%'
+                    )
+                AND (
+                        actor_id IS NULL
+                     OR TRIM(actor_id) = ''
+                     OR actor_id LIKE 'legacy-sync:%'
+                     OR actor_display_name = ?
+                     OR workspace_id = ?
+                     OR trust_state = 'legacy_unknown'
+                    )
+                )
               AND origin_device_id != ?
               AND origin_device_id NOT IN (
                     SELECT peer_device_id FROM sync_peers WHERE peer_device_id IS NOT NULL
@@ -340,7 +801,7 @@ class MemoryStore:
             GROUP BY origin_device_id
             ORDER BY last_seen_at DESC, origin_device_id ASC
             """,
-            (self.device_id,),
+            (self.LEGACY_SYNC_ACTOR_DISPLAY_NAME, self.LEGACY_SHARED_WORKSPACE_ID, self.device_id),
         ).fetchall()
         return [
             {
@@ -374,18 +835,30 @@ class MemoryStore:
                     SELECT peer_device_id FROM sync_peers WHERE peer_device_id IS NOT NULL
               )
               AND (
-                    actor_id LIKE 'legacy-sync:%'
-                 OR actor_display_name = 'Legacy synced peer'
-                 OR workspace_id = 'shared:legacy'
-                 OR workspace_kind = 'shared'
-                 OR trust_state = 'legacy_unknown'
-              )
+                    (
+                        actor_id IS NULL
+                     OR TRIM(actor_id) = ''
+                     OR actor_id LIKE 'legacy-sync:%'
+                     OR actor_id = ?
+                    )
+                AND (
+                        actor_id IS NULL
+                     OR TRIM(actor_id) = ''
+                     OR actor_id LIKE 'legacy-sync:%'
+                     OR actor_display_name = ?
+                     OR workspace_id = ?
+                     OR trust_state = 'legacy_unknown'
+                    )
+                )
             """,
             (
                 self.actor_id,
                 self.actor_display_name,
                 personal_workspace_id,
                 device_id,
+                self.actor_id,
+                self.LEGACY_SYNC_ACTOR_DISPLAY_NAME,
+                self.LEGACY_SHARED_WORKSPACE_ID,
             ),
         )
         if self.conn.in_transaction:
@@ -394,7 +867,13 @@ class MemoryStore:
 
     def same_actor_peer_ids(self) -> list[str]:
         rows = self.conn.execute(
-            "SELECT peer_device_id FROM sync_peers WHERE claimed_local_actor = 1 ORDER BY peer_device_id"
+            """
+            SELECT peer_device_id
+            FROM sync_peers
+            WHERE claimed_local_actor = 1 OR actor_id = ?
+            ORDER BY peer_device_id
+            """,
+            (self.actor_id,),
         ).fetchall()
         return [str(row["peer_device_id"]) for row in rows if row["peer_device_id"]]
 
@@ -1633,6 +2112,68 @@ class MemoryStore:
         self.conn.commit()
         self._record_memory_item_op(memory_id, "delete")
 
+    def update_memory_visibility(self, memory_id: int, *, visibility: str) -> dict[str, Any]:
+        cleaned_visibility = self._clean_optional_str(visibility)
+        if cleaned_visibility not in {"private", "shared"}:
+            raise ValueError("visibility must be private or shared")
+        row = self.conn.execute(
+            "SELECT * FROM memory_items WHERE id = ? AND active = 1",
+            (memory_id,),
+        ).fetchone()
+        if row is None:
+            raise LookupError("memory not found")
+        row_data = dict(row)
+        if not self.memory_owned_by_self(row_data):
+            raise PermissionError("memory not owned by self")
+        actor_id = self._clean_optional_str(row_data.get("actor_id")) or self.actor_id
+        workspace_kind = "shared" if cleaned_visibility == "shared" else "personal"
+        current_workspace_id = self._clean_optional_str(row_data.get("workspace_id"))
+        if (
+            cleaned_visibility == "shared"
+            and current_workspace_id
+            and current_workspace_id.startswith("shared:")
+        ):
+            workspace_id = current_workspace_id
+        else:
+            workspace_id = self._default_workspace_id(
+                actor_id=actor_id,
+                workspace_kind=workspace_kind,
+            )
+        metadata = self._normalize_metadata(row_data.get("metadata_json"))
+        metadata["visibility"] = cleaned_visibility
+        metadata["workspace_kind"] = workspace_kind
+        metadata["workspace_id"] = workspace_id
+        metadata["clock_device_id"] = self.device_id
+        now = self._now_iso()
+        rev = int(row_data.get("rev") or 0) + 1
+        self.conn.execute(
+            """
+            UPDATE memory_items
+            SET visibility = ?,
+                workspace_kind = ?,
+                workspace_id = ?,
+                updated_at = ?,
+                metadata_json = ?,
+                rev = ?
+            WHERE id = ?
+            """,
+            (
+                cleaned_visibility,
+                workspace_kind,
+                workspace_id,
+                now,
+                db.to_json(metadata),
+                rev,
+                memory_id,
+            ),
+        )
+        self.conn.commit()
+        self._record_memory_item_op(memory_id, "upsert")
+        updated = self.get(memory_id)
+        if updated is None:
+            raise LookupError("memory not found")
+        return updated
+
     def get(self, memory_id: int) -> dict[str, Any] | None:
         row = self.conn.execute(
             "SELECT * FROM memory_items WHERE id = ?",
@@ -1938,6 +2479,21 @@ class MemoryStore:
         log_usage: bool = True,
     ) -> list[MemoryResult]:
         return store_search.search(self, query, limit=limit, filters=filters, log_usage=log_usage)
+
+    def search_with_diagnostics(
+        self,
+        query: str,
+        limit: int = 10,
+        filters: dict[str, Any] | None = None,
+        log_usage: bool = True,
+    ) -> tuple[list[MemoryResult], dict[str, Any]]:
+        return store_search.search_with_diagnostics(
+            self,
+            query,
+            limit=limit,
+            filters=filters,
+            log_usage=log_usage,
+        )
 
     def build_memory_pack(
         self,

--- a/codemem/store/replication.py
+++ b/codemem/store/replication.py
@@ -82,9 +82,18 @@ def _sync_visibility_allowed(payload: dict[str, Any] | None) -> bool:
     if not isinstance(payload, dict):
         return False
     visibility = str(payload.get("visibility") or "").strip().lower()
+    metadata_value = payload.get("metadata_json")
+    metadata = cast(dict[str, Any], metadata_value) if isinstance(metadata_value, dict) else {}
+    metadata_visibility = str(metadata.get("visibility") or "").strip().lower()
+    if not visibility and metadata_visibility:
+        visibility = metadata_visibility
     if not visibility:
         workspace_kind = str(payload.get("workspace_kind") or "").strip().lower()
         workspace_id = str(payload.get("workspace_id") or "").strip().lower()
+        if not workspace_kind:
+            workspace_kind = str(metadata.get("workspace_kind") or "").strip().lower()
+        if not workspace_id:
+            workspace_id = str(metadata.get("workspace_id") or "").strip().lower()
         if workspace_kind == "shared" or workspace_id.startswith("shared:"):
             visibility = "shared"
         else:
@@ -1173,7 +1182,9 @@ def apply_replication_ops(
             if not _sync_project_allowed(store, project, peer_device_id=source_device_id):
                 skipped += 1
                 continue
-            if not _sync_visibility_allowed(payload if isinstance(payload, dict) else None):
+            if not _sync_visibility_allowed(
+                payload if isinstance(payload, dict) else None
+            ) and not _peer_claimed_local_actor(store, source_device_id):
                 skipped += 1
                 continue
             if op_type == "upsert":

--- a/codemem/viewer.py
+++ b/codemem/viewer.py
@@ -128,6 +128,10 @@ class ViewerHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
         parsed = urlparse(self.path)
         strict_paths = {
+            "/api/memories/visibility",
+            "/api/sync/actors",
+            "/api/sync/actors/merge",
+            "/api/sync/actors/rename",
             "/api/sync/peers/rename",
             "/api/sync/peers/identity",
             "/api/sync/peers/scope",
@@ -147,6 +151,8 @@ class ViewerHandler(BaseHTTPRequestHandler):
             store = MemoryStore(os.environ.get("CODEMEM_DB") or DEFAULT_DB_PATH)
             try:
                 if viewer_routes_sync.handle_post(self, store, parsed.path, payload):
+                    return
+                if viewer_routes_memory.handle_post(self, store, parsed.path, payload):
                     return
             finally:
                 store.close()

--- a/codemem/viewer_routes/memory.py
+++ b/codemem/viewer_routes/memory.py
@@ -330,3 +330,40 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
         return True
 
     return False
+
+
+def handle_post(
+    handler: _ViewerHandler, store: MemoryStore, path: str, payload: dict[str, Any] | None
+) -> bool:
+    if path != "/api/memories/visibility":
+        return False
+    if payload is None:
+        handler._send_json({"error": "invalid json"}, status=400)
+        return True
+    memory_id = payload.get("memory_id")
+    visibility = payload.get("visibility")
+    try:
+        resolved_memory_id = int(memory_id)
+    except (TypeError, ValueError):
+        handler._send_json({"error": "memory_id must be int"}, status=400)
+        return True
+    if not isinstance(visibility, str) or visibility.strip() not in {"private", "shared"}:
+        handler._send_json({"error": "visibility must be private or shared"}, status=400)
+        return True
+    try:
+        item = store.update_memory_visibility(
+            resolved_memory_id,
+            visibility=visibility.strip(),
+        )
+    except ValueError as exc:
+        handler._send_json({"error": str(exc)}, status=400)
+        return True
+    except LookupError:
+        handler._send_json({"error": "memory not found"}, status=404)
+        return True
+    except PermissionError:
+        handler._send_json({"error": "memory not owned by self"}, status=403)
+        return True
+    item["owned_by_self"] = store.memory_owned_by_self(item)
+    handler._send_json({"item": item})
+    return True

--- a/codemem/viewer_routes/sync.py
+++ b/codemem/viewer_routes/sync.py
@@ -12,7 +12,6 @@ from ..store import MemoryStore
 from ..sync.discovery import (
     load_peer_addresses,
     normalize_address,
-    set_peer_local_actor_claim,
     set_peer_project_filter,
 )
 from ..sync.sync_pass import sync_once
@@ -188,10 +187,12 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
         # Compatibility: older UI expects status/peers/attempts keys.
         peers_rows = store.conn.execute(
             """
-            SELECT peer_device_id, name, pinned_fingerprint, addresses_json,
-                   last_seen_at, last_sync_at, last_error,
-                   projects_include_json, projects_exclude_json, claimed_local_actor
-            FROM sync_peers
+            SELECT p.peer_device_id, p.name, p.pinned_fingerprint, p.addresses_json,
+                   p.last_seen_at, p.last_sync_at, p.last_error,
+                   p.projects_include_json, p.projects_exclude_json, p.claimed_local_actor,
+                   p.actor_id, a.display_name AS actor_display_name
+            FROM sync_peers AS p
+            LEFT JOIN actors AS a ON a.actor_id = p.actor_id
             ORDER BY name, peer_device_id
             """
         ).fetchall()
@@ -221,6 +222,8 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                 "last_error": row["last_error"] if include_diagnostics else None,
                 "has_error": bool(row["last_error"]),
                 "claimed_local_actor": bool(row["claimed_local_actor"]),
+                "actor_id": row["actor_id"],
+                "actor_display_name": row["actor_display_name"],
                 "project_scope": {
                     "include": override_include,
                     "exclude": override_exclude,
@@ -304,10 +307,12 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
         }
         rows = store.conn.execute(
             """
-            SELECT peer_device_id, name, pinned_fingerprint, addresses_json,
-                   last_seen_at, last_sync_at, last_error,
-                   projects_include_json, projects_exclude_json, claimed_local_actor
-            FROM sync_peers
+            SELECT p.peer_device_id, p.name, p.pinned_fingerprint, p.addresses_json,
+                   p.last_seen_at, p.last_sync_at, p.last_error,
+                   p.projects_include_json, p.projects_exclude_json, p.claimed_local_actor,
+                   p.actor_id, a.display_name AS actor_display_name
+            FROM sync_peers AS p
+            LEFT JOIN actors AS a ON a.actor_id = p.actor_id
             ORDER BY name, peer_device_id
             """
         ).fetchall()
@@ -337,6 +342,8 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                     "last_error": row["last_error"] if include_diagnostics else None,
                     "has_error": bool(row["last_error"]),
                     "claimed_local_actor": bool(row["claimed_local_actor"]),
+                    "actor_id": row["actor_id"],
+                    "actor_display_name": row["actor_display_name"],
                     "project_scope": {
                         "include": override_include,
                         "exclude": override_exclude,
@@ -348,6 +355,12 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                 }
             )
         handler._send_json({"items": peers, "redacted": not include_diagnostics})
+        return True
+
+    if path == "/api/sync/actors":
+        params = parse_qs(query)
+        include_merged = params.get("includeMerged", ["0"])[0] in {"1", "true", "yes"}
+        handler._send_json({"items": store.list_actors(include_merged=include_merged)})
         return True
 
     if path == "/api/sync/attempts":
@@ -431,6 +444,75 @@ def handle_post(
     if path == "/api/sync/run":
         # Compatibility endpoint for the bundled web UI.
         path = "/api/sync/actions/sync-now"
+
+    if path == "/api/sync/actors":
+        if payload is None:
+            handler._send_json({"error": "invalid json"}, status=400)
+            return True
+        display_name = payload.get("display_name")
+        actor_id = payload.get("actor_id")
+        if not isinstance(display_name, str) or not display_name.strip():
+            handler._send_json({"error": "display_name required"}, status=400)
+            return True
+        if actor_id is not None and not isinstance(actor_id, str):
+            handler._send_json({"error": "actor_id must be string or null"}, status=400)
+            return True
+        try:
+            actor = store.create_actor(display_name=display_name, actor_id=actor_id)
+        except ValueError as exc:
+            handler._send_json({"error": str(exc)}, status=400)
+            return True
+        handler._send_json(actor, status=201)
+        return True
+
+    if path == "/api/sync/actors/rename":
+        if payload is None:
+            handler._send_json({"error": "invalid json"}, status=400)
+            return True
+        actor_id = payload.get("actor_id")
+        display_name = payload.get("display_name")
+        if not isinstance(actor_id, str) or not actor_id.strip():
+            handler._send_json({"error": "actor_id required"}, status=400)
+            return True
+        if not isinstance(display_name, str) or not display_name.strip():
+            handler._send_json({"error": "display_name required"}, status=400)
+            return True
+        try:
+            actor = store.rename_actor(actor_id.strip(), display_name=display_name)
+        except ValueError as exc:
+            handler._send_json({"error": str(exc)}, status=400)
+            return True
+        except LookupError:
+            handler._send_json({"error": "actor not found"}, status=404)
+            return True
+        handler._send_json(actor)
+        return True
+
+    if path == "/api/sync/actors/merge":
+        if payload is None:
+            handler._send_json({"error": "invalid json"}, status=400)
+            return True
+        primary_actor_id = payload.get("primary_actor_id")
+        secondary_actor_id = payload.get("secondary_actor_id")
+        if not isinstance(primary_actor_id, str) or not primary_actor_id.strip():
+            handler._send_json({"error": "primary_actor_id required"}, status=400)
+            return True
+        if not isinstance(secondary_actor_id, str) or not secondary_actor_id.strip():
+            handler._send_json({"error": "secondary_actor_id required"}, status=400)
+            return True
+        try:
+            result = store.merge_actor(
+                primary_actor_id=primary_actor_id,
+                secondary_actor_id=secondary_actor_id,
+            )
+        except ValueError as exc:
+            handler._send_json({"error": str(exc)}, status=400)
+            return True
+        except LookupError as exc:
+            handler._send_json({"error": str(exc)}, status=404)
+            return True
+        handler._send_json(result)
+        return True
 
     if path == "/api/sync/peers/rename":
         if payload is None:
@@ -543,15 +625,36 @@ def handle_post(
         if row is None:
             handler._send_json({"error": "peer not found"}, status=404)
             return True
-        claimed_local_actor = bool(payload.get("claimed_local_actor"))
-        set_peer_local_actor_claim(
-            store.conn,
-            peer_device_id.strip(),
-            claimed_local_actor=claimed_local_actor,
-        )
-        if claimed_local_actor:
-            store.reconcile_claimed_same_actor_legacy_memories(peer_device_id.strip())
-        handler._send_json({"ok": True, "claimed_local_actor": claimed_local_actor})
+        raw_actor_id = payload.get("actor_id") if "actor_id" in payload else None
+        if "actor_id" in payload and raw_actor_id is not None and not isinstance(raw_actor_id, str):
+            handler._send_json({"error": "actor_id must be string or null"}, status=400)
+            return True
+        if "actor_id" in payload and "claimed_local_actor" in payload:
+            handler._send_json(
+                {"error": "provide actor_id or claimed_local_actor, not both"},
+                status=400,
+            )
+            return True
+        if (
+            "actor_id" not in payload
+            and "claimed_local_actor" in payload
+            and not isinstance(payload.get("claimed_local_actor"), bool)
+        ):
+            handler._send_json({"error": "claimed_local_actor must be boolean"}, status=400)
+            return True
+        actor_id = raw_actor_id if "actor_id" in payload else None
+        if "actor_id" not in payload:
+            actor_id = store.actor_id if bool(payload.get("claimed_local_actor")) else None
+        try:
+            assignment = store.assign_peer_actor(peer_device_id.strip(), actor_id=actor_id)
+        except LookupError as exc:
+            status = 404 if str(exc) in {"peer not found", "actor not found"} else 400
+            handler._send_json({"error": str(exc)}, status=status)
+            return True
+        except ValueError as exc:
+            handler._send_json({"error": str(exc)}, status=400)
+            return True
+        handler._send_json({"ok": True, **assignment})
         return True
 
     if path == "/api/sync/legacy-devices/claim":

--- a/docs/plans/2026-03-12-actor-registry-peer-assignment-contract.md
+++ b/docs/plans/2026-03-12-actor-registry-peer-assignment-contract.md
@@ -1,0 +1,324 @@
+# Actor Registry and Peer-Assignment Contract
+
+**Bead:** `codemem-ix6.1`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Problem
+
+The shipped identity-aware sync MVP introduced actor-aware provenance, personal/shared workspace boundaries,
+and a lightweight `claimed_local_actor` peer override.
+
+That override is useful, but it is still a stopgap:
+
+- it models "this peer belongs to me" as a boolean instead of an explicit actor relationship
+- it cannot map multiple peers to one stable actor record
+- it does not provide a real home for teammate actors
+- it makes legacy-history collapse feel like a special case instead of part of the actor model
+- it leaves future per-actor sharing, review, and retrieval features without a durable identity layer
+
+We need a first-class actor registry and peer-assignment contract that extends the shipped MVP without dragging in
+accounts, org directories, or hosted identity machinery.
+
+## Goals
+
+- Replace the one-off same-identity peer claim with explicit actor records and peer-to-actor assignments.
+- Allow multiple sync peers to resolve to one logical actor.
+- Preserve current local-first behavior for single-user installs.
+- Define how legacy synced histories get upgraded when a peer is assigned to an actor.
+- Lock the minimum UI and API contract needed for follow-on implementation.
+
+## Non-goals
+
+- No account system, login flow, org membership, or SSO.
+- No cryptographic actor identity separate from the existing peer/device trust model.
+- No generic per-memory actor editing workflow in this slice.
+- No trust-policy engine or actor-based sync ACLs.
+- No requirement to rewrite every historical memory row immediately when an actor changes.
+
+## Current baseline
+
+Today the repo already has these behaviors:
+
+- a local actor profile, with `actor_id` defaulting to `local:<device_id>` when not configured
+- memory provenance fields (`actor_id`, `actor_display_name`, `visibility`, `workspace_id`, `workspace_kind`, `origin_device_id`, `trust_state`)
+- private memories syncing only to peers marked `claimed_local_actor`
+- legacy backfill that synthesizes actor IDs such as `legacy-sync:<origin_device_id>`
+- a viewer/Sync panel flow for `Belongs to me` and `Claim old device as mine`
+
+This contract must preserve those outcomes while giving them a cleaner identity model.
+
+## Core decisions
+
+### 1) Actor identity remains lightweight and opaque
+
+`actor_id` stays an opaque stable string, not a username or account handle.
+
+Rules:
+
+- existing local actor IDs remain valid; do not force a migration away from `local:<device_id>` immediately
+- explicit actor records may use any stable opaque ID shape, but new managed actors should prefer a durable
+  actor-oriented namespace such as `actor:<opaque-id>` rather than encoding transport device IDs
+- display labels belong in `actor_display_name`, not in `actor_id`
+
+This keeps backward compatibility while allowing the product to stop pretending device identity is the same thing as
+actor identity.
+
+### 2) Add a first-class actor registry
+
+The system should store explicit actor records rather than only inferring actors from memory rows.
+
+Minimum actor record fields for the first pass:
+
+- `actor_id` - stable primary identifier
+- `display_name` - human-readable label
+- `is_local` - whether this record is the current installation's actor
+- `status` - `active|merged` to support safe collapse flows without hard deletes
+- `merged_into_actor_id` - nullable redirect target when an actor has been merged into another
+- `created_at`
+- `updated_at`
+
+Notes:
+
+- exactly one actor record may be `is_local=1` per local database
+- local config remains the source of truth for the current actor profile in the short term; the actor table mirrors it so
+  the UI and assignment logic have a uniform model
+- non-local actors are lightweight labels plus stable IDs, not authenticated user accounts
+
+### 3) Peer assignment is many peers to one actor
+
+Each sync peer may map to zero or one actor.
+
+Rules:
+
+- one actor may have many peers assigned to it
+- a peer may have at most one active actor assignment at a time
+- unmapped peers remain valid and continue using current legacy/fallback provenance behavior
+- the local machine does not need a `sync_peers` row for its own actor record
+
+Implementation preference:
+
+- store the current assignment directly on `sync_peers.actor_id` rather than introducing an extra join table for MVP
+
+That shape is enough for:
+
+- multiple devices belonging to one person
+- multiple teammate devices resolving to one teammate actor
+- a simple UI that answers "which peers belong to which actor?"
+
+### 4) `claimed_local_actor` becomes compatibility state, not the long-term model
+
+The shipped boolean override should migrate into explicit actor assignment instead of surviving as the primary concept.
+
+Contract:
+
+- assigning a peer to the local actor is the new semantic equivalent of `claimed_local_actor = 1`
+- during migration, existing `claimed_local_actor = 1` peers should automatically map to the local actor
+- follow-on implementation may keep the boolean column temporarily for compatibility, but it should be derived from or
+  kept in sync with the explicit assignment
+- new product surfaces should talk about actor assignment, not about a standalone same-identity flag
+
+### 5) Actor assignment affects both future provenance and legacy upgrade behavior
+
+Assigning a peer to an actor has two distinct effects.
+
+#### Future inbound behavior
+
+When an inbound payload from a peer lacks explicit actor fields, the assigned actor becomes the fallback author identity
+for provenance resolution.
+
+This replaces device-only fallback with actor-aware fallback when the operator has already told us who that peer is.
+
+#### Existing legacy-history behavior
+
+When a peer is assigned to an actor, historical rows from that peer become eligible for backfill if their current
+provenance is still synthetic or legacy-derived.
+
+Rows are eligible for reassignment when their provenance still looks incomplete, for example:
+
+- `actor_id` matches `legacy-sync:*`
+- `actor_display_name` is the legacy placeholder label
+- `workspace_id` or `workspace_kind` still reflects legacy shared fallback
+- `trust_state = legacy_unknown`
+
+Do not rewrite rows that already carry explicit non-legacy actor provenance from a newer peer.
+
+### 6) Same-person assignment remains the only case that widens private sync
+
+The current system allows `visibility=private` memories to sync to peers marked `claimed_local_actor`.
+
+That behavior should survive, but only for peers assigned to the local actor.
+
+Rules:
+
+- peers assigned to the local actor are treated as the same-person continuity path
+- those peers may continue receiving private/personal memories
+- peers assigned to any non-local actor remain shared-only recipients
+- actor assignment to a teammate must not silently widen private-memory replication
+
+This keeps the useful "my machines act like one person" behavior without turning actor assignment into a privacy footgun.
+
+### 7) Legacy backfill differs for local vs non-local actor assignment
+
+When upgrading historical rows from an assigned peer, the target actor determines the safe rewrite behavior.
+
+#### If the peer is assigned to the local actor
+
+Backfilled rows should become equivalent to current personal memory defaults:
+
+- `actor_id = <local actor_id>`
+- `actor_display_name = <local actor_display_name>`
+- `visibility = private`
+- `workspace_kind = personal`
+- `workspace_id = personal:<local actor_id>`
+- `trust_state = trusted`
+
+This preserves the meaning of the existing `Belongs to me` and `Claim old device as mine` flows.
+
+#### If the peer is assigned to a non-local actor
+
+Backfilled rows should become explicit shared provenance for that actor:
+
+- `actor_id = <assigned actor_id>`
+- `actor_display_name = <assigned display_name>`
+- `visibility = shared` unless the row already has explicit non-legacy visibility metadata
+- `workspace_kind = shared`
+- `workspace_id = shared:default` unless a better explicit shared workspace already exists
+- `trust_state = trusted`
+
+Rationale:
+
+- the operator has provided explicit actor identity, so the old `legacy_unknown` placeholder is no longer the best model
+- we still keep the scope conservative by treating teammate-origin history as shared, not personal
+
+## Merge and collapse semantics
+
+The first pass needs a practical collapse story, not a grand unified identity engine.
+
+### Primary collapse mechanism: many peers, one actor
+
+The main way to collapse legacy history is to assign multiple peers to the same actor.
+
+That alone solves the most important product problem:
+
+- several old devices can resolve to one person
+- retrieval can treat them as one contributor
+- ownership and shared/private defaults stop depending on device sprawl
+
+### Actor merge behavior
+
+The first managed "merge actor" workflow may stay intentionally narrow.
+
+Minimum contract:
+
+- choose a primary actor and a secondary actor
+- move peer assignments from secondary to primary
+- future fallback provenance resolves to the primary actor
+- mark the secondary actor as `merged` with `merged_into_actor_id = <primary>`
+- hide merged actors from normal picker UIs
+
+Deferred for later unless clearly needed:
+
+- eagerly rewriting every historical row that already references the secondary explicit actor ID
+- multi-step actor split/undo workflows
+- full audit-log UI for actor merges
+
+This keeps the merge story safe and explainable while avoiding a large historical-rewrite feature in the first pass.
+
+## UI contract
+
+The first actor-management UI should stay close to the existing Sync panel mental model.
+
+Minimum supported actions:
+
+- create actor
+- rename actor
+- assign peer to actor
+- unassign peer from actor
+- assign peer to local actor (replacement for `Belongs to me`)
+- claim old device history as local actor
+- optionally merge one actor into another if the implementation can explain the effect clearly
+
+Minimum information shown:
+
+- actor display name
+- whether the actor is local or non-local
+- which peers are assigned to the actor
+- whether a peer is unassigned
+- a short explanation of what assignment changes affect:
+  - future provenance fallback
+  - legacy history upgrade
+  - private sync only when assigned to the local actor
+
+Non-goals for the first UI pass:
+
+- editing every actor field manually
+- project/workspace policy editing inside the actor editor
+- actor avatars, invitations, or presence
+- exposing merged actors as first-class active rows
+
+## API contract
+
+The first implementation should support a minimal management API surface.
+
+Recommended operations:
+
+- list actors
+- create actor
+- rename actor
+- list peers with assigned actor IDs
+- assign or unassign a peer's actor
+- trigger legacy-history reconciliation for an assigned peer when needed
+
+Recommended payload shape requirements:
+
+- peer list responses should include both `peer_device_id` and `actor_id`
+- actor list responses should include enough metadata for selection and badges (`actor_id`, `display_name`,
+  `is_local`, `status`, `merged_into_actor_id`)
+- assignment updates should be explicit writes, not implicit side effects hidden behind unrelated peer-update endpoints
+
+The first pass does not need a public CLI for full actor management if the viewer API/UI lands first, but the backend
+contract should not preclude a later CLI.
+
+## Migration plan
+
+### Existing local actor
+
+- create or mirror an actor record for the configured local actor on startup or migration
+- preserve the current configured `actor_id` and `actor_display_name`
+
+### Existing `claimed_local_actor` peers
+
+- migrate each claimed peer to `sync_peers.actor_id = <local actor_id>`
+- keep `claimed_local_actor` in sync during the transition period if the column remains
+
+### Existing unclaimed peers
+
+- leave them unassigned
+- keep current fallback behavior until the operator assigns them
+
+### Existing legacy memories
+
+- do not perform a global rewrite during schema migration alone
+- only upgrade eligible legacy rows when the relevant peer or legacy device is explicitly claimed or assigned
+- keep already explicit actor provenance intact
+
+This avoids surprise mass rewrites while still making assignment immediately useful.
+
+## Open implementation questions
+
+- Should the local actor config remain authoritative forever, or should the actor table eventually become canonical?
+- Do we need a dedicated "retired/merged actors" view, or is hiding them from normal pickers enough?
+- Should peer unassignment preserve a last-known actor reference for audit/debugging, or is clearing `sync_peers.actor_id`
+  sufficient in MVP?
+- Do we need a one-shot "reconcile all assigned peers" maintenance action, or are per-peer updates enough?
+
+## Acceptance criteria
+
+This contract is successful when:
+
+1. The actor registry model is explicit enough for persistence and UI implementation.
+2. Multiple peers can map to one actor without relying on boolean same-identity flags.
+3. Migration from `claimed_local_actor` is defined and backward compatible.
+4. Legacy-history collapse rules are clear for both same-person and teammate assignments.
+5. The first implementation can ship without inventing accounts, orgs, or trust-policy machinery.

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -32,6 +32,12 @@ def test_initialize_schema_sets_user_version(monkeypatch, tmp_path: Path) -> Non
         claimed_local_actor_column = conn.execute(
             "SELECT name FROM pragma_table_info('sync_peers') WHERE name = 'claimed_local_actor'"
         ).fetchone()
+        peer_actor_column = conn.execute(
+            "SELECT name FROM pragma_table_info('sync_peers') WHERE name = 'actor_id'"
+        ).fetchone()
+        actors_table = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'actors'"
+        ).fetchone()
         workspace_column = conn.execute(
             "SELECT name FROM pragma_table_info('memory_items') WHERE name = 'workspace_id'"
         ).fetchone()
@@ -53,6 +59,8 @@ def test_initialize_schema_sets_user_version(monkeypatch, tmp_path: Path) -> Non
     assert actor_column is not None
     assert visibility_column is not None
     assert claimed_local_actor_column is not None
+    assert peer_actor_column is not None
+    assert actors_table is not None
     assert workspace_column is not None
     assert artifact_encoding_column is not None
     assert artifact_blob_column is not None
@@ -170,7 +178,7 @@ def test_initialize_schema_upgrades_existing_v3_db_with_identity_columns(
     assert int(row[0]) == db.SCHEMA_VERSION
 
 
-def test_initialize_schema_upgrades_existing_v4_db_with_peer_claim_column(
+def test_initialize_schema_upgrades_existing_v4_db_with_actor_registry_columns(
     monkeypatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("CODEMEM_EMBEDDING_DISABLED", "1")
@@ -241,11 +249,19 @@ def test_initialize_schema_upgrades_existing_v4_db_with_peer_claim_column(
         claimed_column = conn.execute(
             "SELECT name FROM pragma_table_info('sync_peers') WHERE name = 'claimed_local_actor'"
         ).fetchone()
+        actor_column = conn.execute(
+            "SELECT name FROM pragma_table_info('sync_peers') WHERE name = 'actor_id'"
+        ).fetchone()
+        actors_table = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'actors'"
+        ).fetchone()
         row = conn.execute("PRAGMA user_version").fetchone()
     finally:
         conn.close()
 
     assert claimed_column is not None
+    assert actor_column is not None
+    assert actors_table is not None
     assert row is not None
     assert int(row[0]) == db.SCHEMA_VERSION
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -793,6 +793,282 @@ def test_claimed_peer_legacy_memories_are_reconciled_to_local_actor(tmp_path: Pa
         store.close()
 
 
+def test_store_bootstrap_creates_local_actor_and_migrates_claimed_peer_assignment(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-self", "[]", 1, "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+    finally:
+        store.close()
+
+    store = MemoryStore(db_path)
+    try:
+        actor_row = store.conn.execute(
+            "SELECT actor_id, display_name, is_local, status FROM actors WHERE actor_id = ?",
+            (store.actor_id,),
+        ).fetchone()
+        peer_row = store.conn.execute(
+            "SELECT actor_id, claimed_local_actor FROM sync_peers WHERE peer_device_id = ?",
+            ("peer-self",),
+        ).fetchone()
+
+        assert actor_row is not None
+        assert actor_row["actor_id"] == store.actor_id
+        assert actor_row["display_name"] == store.actor_display_name
+        assert actor_row["is_local"] == 1
+        assert actor_row["status"] == "active"
+        assert peer_row is not None
+        assert peer_row["actor_id"] == store.actor_id
+        assert int(peer_row["claimed_local_actor"] or 0) == 1
+    finally:
+        store.close()
+
+
+def test_assign_peer_actor_persists_non_local_assignment(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+
+        actor = store.create_actor(display_name="Teammate")
+        assignment = store.assign_peer_actor("peer-1", actor_id=actor["actor_id"])
+
+        row = store.conn.execute(
+            "SELECT actor_id, claimed_local_actor FROM sync_peers WHERE peer_device_id = ?",
+            ("peer-1",),
+        ).fetchone()
+
+        assert assignment["actor_id"] == actor["actor_id"]
+        assert assignment["actor_display_name"] == "Teammate"
+        assert assignment["claimed_local_actor"] is False
+        assert row is not None
+        assert row["actor_id"] == actor["actor_id"]
+        assert int(row["claimed_local_actor"] or 0) == 0
+    finally:
+        store.close()
+
+
+def test_assigned_peer_legacy_memories_are_reconciled_to_assigned_actor(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+        actor = store.create_actor(display_name="Teammate")
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(
+            session_id,
+            kind="note",
+            title="Legacy teammate memory",
+            body_text="Shared from a teammate",
+            metadata={
+                "actor_id": "legacy-sync:peer-1",
+                "actor_display_name": "Legacy synced peer",
+                "origin_device_id": "peer-1",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "legacy_unknown",
+            },
+        )
+
+        assignment = store.assign_peer_actor("peer-1", actor_id=actor["actor_id"])
+
+        row = store.conn.execute(
+            "SELECT actor_id, actor_display_name, visibility, workspace_id, workspace_kind, trust_state FROM memory_items WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+
+        assert assignment["actor_id"] == actor["actor_id"]
+        assert row is not None
+        assert row["actor_id"] == actor["actor_id"]
+        assert row["actor_display_name"] == "Teammate"
+        assert row["visibility"] == "shared"
+        assert row["workspace_id"] == "shared:default"
+        assert row["workspace_kind"] == "shared"
+        assert row["trust_state"] == "trusted"
+    finally:
+        store.close()
+
+
+def test_claimable_legacy_device_ids_excludes_explicit_shared_actor_rows(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        store.remember(
+            session_id,
+            kind="note",
+            title="Explicit teammate shared memory",
+            body_text="Already resolved to a named actor",
+            metadata={
+                "actor_id": "actor:teammate",
+                "actor_display_name": "Teammate",
+                "origin_device_id": "peer-1",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:default",
+                "workspace_kind": "shared",
+                "trust_state": "trusted",
+            },
+        )
+
+        assert store.claimable_legacy_device_ids() == []
+    finally:
+        store.close()
+
+
+def test_assign_peer_actor_does_not_rewrite_explicit_non_legacy_actor_rows(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+        actor = store.create_actor(display_name="Teammate")
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(
+            session_id,
+            kind="note",
+            title="Explicit actor row",
+            body_text="Should stay attached to its explicit actor",
+            metadata={
+                "actor_id": "actor:already-known",
+                "actor_display_name": "Already Known",
+                "origin_device_id": "peer-1",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:legacy",
+                "workspace_kind": "shared",
+                "trust_state": "trusted",
+            },
+        )
+
+        store.assign_peer_actor("peer-1", actor_id=actor["actor_id"])
+
+        row = store.conn.execute(
+            "SELECT actor_id, actor_display_name, visibility, workspace_id, workspace_kind, trust_state FROM memory_items WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+
+        assert row is not None
+        assert row["actor_id"] == "actor:already-known"
+        assert row["actor_display_name"] == "Already Known"
+        assert row["workspace_id"] == "shared:legacy"
+        assert row["trust_state"] == "trusted"
+    finally:
+        store.close()
+
+
+def test_merge_actor_reassigns_peers_and_marks_secondary_merged(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        primary = store.create_actor(display_name="Primary")
+        secondary = store.create_actor(display_name="Secondary")
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, actor_id, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-1", "[]", secondary["actor_id"], "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+
+        result = store.merge_actor(
+            primary_actor_id=primary["actor_id"],
+            secondary_actor_id=secondary["actor_id"],
+        )
+
+        peer_row = store.conn.execute(
+            "SELECT actor_id, claimed_local_actor FROM sync_peers WHERE peer_device_id = ?",
+            ("peer-1",),
+        ).fetchone()
+        merged_actor = store.get_actor(secondary["actor_id"])
+        actors = store.list_actors()
+
+        assert result["reassigned_peer_count"] == 1
+        assert peer_row is not None
+        assert peer_row["actor_id"] == primary["actor_id"]
+        assert int(peer_row["claimed_local_actor"] or 0) == 0
+        assert merged_actor is not None
+        assert merged_actor["status"] == "merged"
+        assert merged_actor["merged_into_actor_id"] == primary["actor_id"]
+        assert all(actor["actor_id"] != secondary["actor_id"] for actor in actors)
+    finally:
+        store.close()
+
+
+def test_assign_peer_actor_resolves_merged_actor_to_primary(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        primary = store.create_actor(display_name="Primary")
+        secondary = store.create_actor(display_name="Secondary")
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+        store.merge_actor(
+            primary_actor_id=primary["actor_id"],
+            secondary_actor_id=secondary["actor_id"],
+        )
+
+        assignment = store.assign_peer_actor("peer-1", actor_id=secondary["actor_id"])
+
+        assert assignment["actor_id"] == primary["actor_id"]
+        assert assignment["actor_display_name"] == "Primary"
+    finally:
+        store.close()
+
+
+def test_merge_actor_rejects_merging_local_actor_into_another(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        teammate = store.create_actor(display_name="Teammate")
+
+        try:
+            store.merge_actor(
+                primary_actor_id=teammate["actor_id"],
+                secondary_actor_id=store.actor_id,
+            )
+        except ValueError as exc:
+            assert str(exc) == "local actor cannot be merged into another actor"
+        else:
+            raise AssertionError("expected ValueError")
+    finally:
+        store.close()
+
+
 def test_replication_delete_wins_over_older_upsert(tmp_path: Path) -> None:
     store_a = MemoryStore(tmp_path / "a.sqlite")
     store_b = MemoryStore(tmp_path / "b.sqlite")
@@ -2697,6 +2973,272 @@ def test_apply_replication_ops_does_not_link_prompt_by_raw_numeric_id(tmp_path: 
     ).fetchone()
     assert row is not None
     assert row["user_prompt_id"] is None
+
+
+def test_apply_replication_ops_uses_assigned_actor_for_legacy_peer_fallback(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+        actor = store.create_actor(display_name="Teammate")
+        store.assign_peer_actor("peer-1", actor_id=actor["actor_id"])
+
+        op: ReplicationOp = {
+            "op_id": "op-assigned-fallback",
+            "entity_type": "memory_item",
+            "entity_id": "export:memory:assigned-fallback",
+            "op_type": "upsert",
+            "payload": {
+                "session_id": 1,
+                "project": "project-a",
+                "kind": "discovery",
+                "title": "Assigned actor fallback",
+                "body_text": "body",
+                "confidence": 0.7,
+                "tags_text": "",
+                "active": 1,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "metadata_json": {},
+                "subtitle": None,
+                "facts": [],
+                "narrative": "body",
+                "concepts": [],
+                "files_read": [],
+                "files_modified": [],
+                "prompt_number": 1,
+                "import_key": "export:memory:assigned-fallback",
+                "deleted_at": None,
+                "rev": 1,
+            },
+            "clock": {
+                "rev": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "device_id": "peer-1",
+            },
+            "device_id": "peer-1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+
+        result = store.apply_replication_ops([op], source_device_id="peer-1")
+
+        row = store.conn.execute(
+            "SELECT actor_id, actor_display_name, visibility, workspace_id, workspace_kind, trust_state FROM memory_items WHERE import_key = ?",
+            ("export:memory:assigned-fallback",),
+        ).fetchone()
+
+        assert result["inserted"] == 1
+        assert row is not None
+        assert row["actor_id"] == actor["actor_id"]
+        assert row["actor_display_name"] == "Teammate"
+        assert row["visibility"] == "shared"
+        assert row["workspace_id"] == "shared:default"
+        assert row["workspace_kind"] == "shared"
+        assert row["trust_state"] == "trusted"
+    finally:
+        store.close()
+
+
+def test_apply_replication_ops_accepts_private_memory_from_local_actor_peer(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-self", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+        store.assign_peer_actor("peer-self", actor_id=store.actor_id)
+
+        op: ReplicationOp = {
+            "op_id": "op-private-local-actor",
+            "entity_type": "memory_item",
+            "entity_id": "export:memory:private-local-actor",
+            "op_type": "upsert",
+            "payload": {
+                "session_id": 1,
+                "project": "project-a",
+                "kind": "note",
+                "title": "Private from my other machine",
+                "body_text": "body",
+                "confidence": 0.7,
+                "tags_text": "",
+                "active": 1,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "metadata_json": {},
+                "subtitle": None,
+                "facts": [],
+                "narrative": "body",
+                "concepts": [],
+                "files_read": [],
+                "files_modified": [],
+                "prompt_number": 1,
+                "visibility": "private",
+                "import_key": "export:memory:private-local-actor",
+                "deleted_at": None,
+                "rev": 1,
+            },
+            "clock": {
+                "rev": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "device_id": "peer-self",
+            },
+            "device_id": "peer-self",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+
+        result = store.apply_replication_ops([op], source_device_id="peer-self")
+
+        row = store.conn.execute(
+            "SELECT actor_id, visibility, workspace_id, workspace_kind FROM memory_items WHERE import_key = ?",
+            ("export:memory:private-local-actor",),
+        ).fetchone()
+
+        assert result["inserted"] == 1
+        assert row is not None
+        assert row["actor_id"] == store.actor_id
+        assert row["visibility"] == "private"
+        assert row["workspace_id"] == f"personal:{store.actor_id}"
+        assert row["workspace_kind"] == "personal"
+    finally:
+        store.close()
+
+
+def test_apply_replication_ops_rejects_metadata_only_private_memory_from_non_local_peer(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+
+        op: ReplicationOp = {
+            "op_id": "op-metadata-private-nonlocal",
+            "entity_type": "memory_item",
+            "entity_id": "export:memory:metadata-private-nonlocal",
+            "op_type": "upsert",
+            "payload": {
+                "session_id": 1,
+                "project": "project-a",
+                "kind": "note",
+                "title": "Should be rejected",
+                "body_text": "body",
+                "confidence": 0.7,
+                "tags_text": "",
+                "active": 1,
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "metadata_json": {"visibility": "private", "workspace_kind": "personal"},
+                "subtitle": None,
+                "facts": [],
+                "narrative": "body",
+                "concepts": [],
+                "files_read": [],
+                "files_modified": [],
+                "prompt_number": 1,
+                "import_key": "export:memory:metadata-private-nonlocal",
+                "deleted_at": None,
+                "rev": 1,
+            },
+            "clock": {
+                "rev": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "device_id": "peer-1",
+            },
+            "device_id": "peer-1",
+            "created_at": "2026-01-01T00:00:00+00:00",
+        }
+
+        result = store.apply_replication_ops([op], source_device_id="peer-1")
+        row = store.conn.execute(
+            "SELECT 1 FROM memory_items WHERE import_key = ?",
+            ("export:memory:metadata-private-nonlocal",),
+        ).fetchone()
+
+        assert result["skipped"] >= 1
+        assert row is None
+    finally:
+        store.close()
+
+
+def test_update_memory_visibility_updates_workspace_and_records_replication(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(session_id, kind="note", title="Alpha", body_text="Body")
+
+        updated = store.update_memory_visibility(memory_id, visibility="shared")
+
+        row = store.conn.execute(
+            "SELECT visibility, workspace_kind, workspace_id, rev FROM memory_items WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+        op_row = store.conn.execute(
+            "SELECT op_type FROM replication_ops WHERE entity_type = 'memory_item' AND entity_id = ? ORDER BY created_at DESC LIMIT 1",
+            (updated["import_key"],),
+        ).fetchone()
+
+        assert updated["visibility"] == "shared"
+        assert row is not None
+        assert row["visibility"] == "shared"
+        assert row["workspace_kind"] == "shared"
+        assert row["workspace_id"] == "shared:default"
+        assert int(row["rev"] or 0) >= 2
+        assert op_row is not None
+        assert op_row["op_type"] == "upsert"
+    finally:
+        store.close()
+
+
+def test_update_memory_visibility_rejects_memory_not_owned_by_self(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(
+            session_id,
+            kind="note",
+            title="Teammate note",
+            body_text="Body",
+            metadata={
+                "actor_id": "actor:teammate",
+                "actor_display_name": "Teammate",
+                "origin_device_id": "peer-1",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:default",
+                "workspace_kind": "shared",
+                "trust_state": "trusted",
+            },
+        )
+
+        try:
+            store.update_memory_visibility(memory_id, visibility="private")
+        except PermissionError:
+            pass
+        else:
+            raise AssertionError("expected PermissionError")
+    finally:
+        store.close()
 
 
 def test_record_replication_op_backfills_missing_prompt_import_key(tmp_path: Path) -> None:

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -208,6 +208,131 @@ def test_sync_peers_endpoint_exposes_local_actor_claim(tmp_path: Path, monkeypat
         payload = json.loads(resp.read().decode("utf-8"))
         assert resp.status == 200
         assert payload["items"][0]["claimed_local_actor"] is True
+        assert payload["items"][0]["actor_id"] is not None
+    finally:
+        server.shutdown()
+
+
+def test_sync_actors_endpoint_lists_local_and_created_actors(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        local_actor_id = store.actor_id
+        teammate = store.create_actor(display_name="Teammate")
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/api/sync/actors")
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        actor_ids = {item["actor_id"] for item in payload["items"]}
+        assert local_actor_id in actor_ids
+        assert teammate["actor_id"] in actor_ids
+    finally:
+        server.shutdown()
+
+
+def test_sync_actors_create_endpoint_creates_actor(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/actors",
+            body=json.dumps({"display_name": "Teammate"}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 201
+        assert payload["display_name"] == "Teammate"
+        assert str(payload["actor_id"]).startswith("actor:")
+    finally:
+        server.shutdown()
+
+
+def test_sync_actors_rename_endpoint_renames_non_local_actor(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        actor = store.create_actor(display_name="Teammate")
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/actors/rename",
+            body=json.dumps({"actor_id": actor["actor_id"], "display_name": "Teammate Prime"}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["display_name"] == "Teammate Prime"
+    finally:
+        server.shutdown()
+
+
+def test_sync_actors_merge_endpoint_reassigns_secondary_actor_peers(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        primary = store.create_actor(display_name="Primary")
+        secondary = store.create_actor(display_name="Secondary")
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, actor_id, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-1", "[]", secondary["actor_id"], "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/actors/merge",
+            body=json.dumps(
+                {
+                    "primary_actor_id": primary["actor_id"],
+                    "secondary_actor_id": secondary["actor_id"],
+                }
+            ),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["reassigned_peer_count"] == 1
+        assert payload["secondary_actor"]["status"] == "merged"
+        assert payload["secondary_actor"]["merged_into_actor_id"] == primary["actor_id"]
     finally:
         server.shutdown()
 
@@ -242,17 +367,19 @@ def test_sync_peer_identity_endpoint_updates_claim(tmp_path: Path, monkeypatch) 
         payload = json.loads(resp.read().decode("utf-8"))
         assert resp.status == 200
         assert payload["claimed_local_actor"] is True
+        assert payload["actor_id"] is not None
     finally:
         server.shutdown()
 
     conn = db.connect(db_path)
     try:
         row = conn.execute(
-            "SELECT claimed_local_actor FROM sync_peers WHERE peer_device_id = ?",
+            "SELECT claimed_local_actor, actor_id FROM sync_peers WHERE peer_device_id = ?",
             ("peer-1",),
         ).fetchone()
         assert row is not None
         assert int(row["claimed_local_actor"]) == 1
+        assert row["actor_id"] is not None
     finally:
         conn.close()
 
@@ -294,6 +421,134 @@ def test_sync_peer_identity_endpoint_updates_claim(tmp_path: Path, monkeypatch) 
         assert json.loads(row["projects_exclude_json"]) == ["secret"]
     finally:
         conn.close()
+
+
+def test_sync_peer_identity_endpoint_updates_explicit_actor_assignment(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+        actor = store.create_actor(display_name="Teammate")
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/peers/identity",
+            body=json.dumps({"peer_device_id": "peer-1", "actor_id": actor["actor_id"]}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["actor_id"] == actor["actor_id"]
+        assert payload["actor_display_name"] == "Teammate"
+        assert payload["claimed_local_actor"] is False
+    finally:
+        server.shutdown()
+
+    conn = db.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT actor_id, claimed_local_actor FROM sync_peers WHERE peer_device_id = ?",
+            ("peer-1",),
+        ).fetchone()
+        assert row is not None
+        assert row["actor_id"] == actor["actor_id"]
+        assert int(row["claimed_local_actor"] or 0) == 0
+    finally:
+        conn.close()
+
+
+def test_sync_peer_identity_endpoint_rejects_conflicting_assignment_fields(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        store.conn.commit()
+        actor = store.create_actor(display_name="Teammate")
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/peers/identity",
+            body=json.dumps(
+                {
+                    "peer_device_id": "peer-1",
+                    "actor_id": actor["actor_id"],
+                    "claimed_local_actor": True,
+                }
+            ),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 400
+        assert payload["error"] == "provide actor_id or claimed_local_actor, not both"
+    finally:
+        server.shutdown()
+
+
+def test_sync_peer_identity_endpoint_rejects_non_boolean_claim_flag(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/sync/peers/identity",
+            body=json.dumps({"peer_device_id": "peer-1", "claimed_local_actor": "false"}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 400
+        assert payload["error"] == "claimed_local_actor must be boolean"
+    finally:
+        server.shutdown()
 
 
 def test_sync_peer_identity_endpoint_reconciles_legacy_claimed_memories(
@@ -368,6 +623,98 @@ def test_sync_peer_identity_endpoint_reconciles_legacy_claimed_memories(
         assert row["trust_state"] == "trusted"
     finally:
         store.close()
+
+
+def test_memory_visibility_endpoint_updates_owned_memory(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(session_id, kind="note", title="Owned note", body_text="Body")
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/memories/visibility",
+            body=json.dumps({"memory_id": memory_id, "visibility": "shared"}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["item"]["visibility"] == "shared"
+        assert payload["item"]["workspace_kind"] == "shared"
+    finally:
+        server.shutdown()
+
+
+def test_memory_visibility_endpoint_rejects_memory_not_owned_by_self(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    store = MemoryStore(db_path)
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(
+            session_id,
+            kind="note",
+            title="Teammate note",
+            body_text="Body",
+            metadata={
+                "actor_id": "actor:teammate",
+                "actor_display_name": "Teammate",
+                "origin_device_id": "peer-1",
+                "origin_source": "sync",
+                "visibility": "shared",
+                "workspace_id": "shared:default",
+                "workspace_kind": "shared",
+                "trust_state": "trusted",
+            },
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/api/memories/visibility",
+            body=json.dumps({"memory_id": memory_id, "visibility": "private"}),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1:38888",
+            },
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 403
+        assert payload["error"] == "memory not owned by self"
+    finally:
+        server.shutdown()
 
 
 def test_sync_status_exposes_claimable_legacy_device_ids(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Description
- add actor registry persistence and peer-to-actor assignment storage
- implement merge redirects, peer reassignment, and legacy provenance reconciliation hooks
- expose backend sync and memory APIs needed by follow-on UI work

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_db_schema.py tests/test_store.py tests/test_sync_viewer_api.py`
- `uv run ruff check codemem/db.py codemem/store/_store.py codemem/store/replication.py codemem/viewer.py codemem/viewer_routes/memory.py codemem/viewer_routes/sync.py tests/test_db_schema.py tests/test_store.py tests/test_sync_viewer_api.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced