### PR TITLE
feat: improve shared retrieval widening and trust ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ codemem sync daemon        # start sync daemon
 codemem sync install       # autostart on macOS + Linux
 ```
 
-The viewer now includes actor management for mapping multiple peers to one logical person, plus owned-memory visibility controls so shared versus private scope can be changed explicitly instead of relying on metadata conventions.
+The viewer now includes actor management for mapping multiple peers to one logical person, plus owned-memory visibility controls so project-filtered memories share by default while `Only me` stays a per-memory local override.
 
 Project filters, peer-to-actor assignment, visibility controls, and config keys are documented in [docs/user-guide.md](docs/user-guide.md).
 

--- a/codemem/mcp_server.py
+++ b/codemem/mcp_server.py
@@ -67,11 +67,17 @@ def build_server() -> FastMCP:
         exclude_actor_ids: list[str] | None = None,
         include_visibility: list[str] | None = None,
         exclude_visibility: list[str] | None = None,
+        include_trust_states: list[str] | None = None,
+        exclude_trust_states: list[str] | None = None,
         include_workspace_ids: list[str] | None = None,
         exclude_workspace_ids: list[str] | None = None,
         include_workspace_kinds: list[str] | None = None,
         exclude_workspace_kinds: list[str] | None = None,
         personal_first: bool | None = None,
+        trust_bias: str | None = None,
+        widen_shared_when_weak: bool | None = None,
+        widen_shared_min_personal_results: int | None = None,
+        widen_shared_min_personal_score: float | None = None,
     ) -> dict[str, Any]:
         filters: dict[str, Any] = {}
         if kind:
@@ -87,6 +93,10 @@ def build_server() -> FastMCP:
             filters["include_visibility"] = include_visibility
         if exclude_visibility:
             filters["exclude_visibility"] = exclude_visibility
+        if include_trust_states:
+            filters["include_trust_states"] = include_trust_states
+        if exclude_trust_states:
+            filters["exclude_trust_states"] = exclude_trust_states
         if include_workspace_ids:
             filters["include_workspace_ids"] = include_workspace_ids
         if exclude_workspace_ids:
@@ -97,6 +107,14 @@ def build_server() -> FastMCP:
             filters["exclude_workspace_kinds"] = exclude_workspace_kinds
         if personal_first is not None:
             filters["personal_first"] = personal_first
+        if trust_bias is not None:
+            filters["trust_bias"] = trust_bias
+        if widen_shared_when_weak is not None:
+            filters["widen_shared_when_weak"] = widen_shared_when_weak
+        if widen_shared_min_personal_results is not None:
+            filters["widen_shared_min_personal_results"] = widen_shared_min_personal_results
+        if widen_shared_min_personal_score is not None:
+            filters["widen_shared_min_personal_score"] = widen_shared_min_personal_score
         return filters
 
     def _dedupe_ordered_ids(ids: list[Any]) -> tuple[list[int], list[str]]:
@@ -137,11 +155,17 @@ def build_server() -> FastMCP:
         exclude_actor_ids: list[str] | None = None,
         include_visibility: list[str] | None = None,
         exclude_visibility: list[str] | None = None,
+        include_trust_states: list[str] | None = None,
+        exclude_trust_states: list[str] | None = None,
         include_workspace_ids: list[str] | None = None,
         exclude_workspace_ids: list[str] | None = None,
         include_workspace_kinds: list[str] | None = None,
         exclude_workspace_kinds: list[str] | None = None,
         personal_first: bool | None = None,
+        trust_bias: str | None = None,
+        widen_shared_when_weak: bool | None = None,
+        widen_shared_min_personal_results: int | None = None,
+        widen_shared_min_personal_score: float | None = None,
     ) -> dict[str, Any]:
         def handler(store: MemoryStore) -> dict[str, Any]:
             filters = build_filters(
@@ -151,14 +175,39 @@ def build_server() -> FastMCP:
                 exclude_actor_ids=exclude_actor_ids,
                 include_visibility=include_visibility,
                 exclude_visibility=exclude_visibility,
+                include_trust_states=include_trust_states,
+                exclude_trust_states=exclude_trust_states,
                 include_workspace_ids=include_workspace_ids,
                 exclude_workspace_ids=exclude_workspace_ids,
                 include_workspace_kinds=include_workspace_kinds,
                 exclude_workspace_kinds=exclude_workspace_kinds,
                 personal_first=personal_first,
+                trust_bias=trust_bias,
+                widen_shared_when_weak=widen_shared_when_weak,
+                widen_shared_min_personal_results=widen_shared_min_personal_results,
+                widen_shared_min_personal_score=widen_shared_min_personal_score,
             )
-            items = store.search_index(query, limit=limit, filters=filters or None)
-            return {"items": items}
+            items, widening = store.search_with_diagnostics(
+                query,
+                limit=limit,
+                filters=filters or None,
+                log_usage=False,
+            )
+            return {
+                "items": [
+                    {
+                        "id": item.id,
+                        "kind": item.kind,
+                        "title": item.title,
+                        "score": item.score,
+                        "created_at": item.created_at,
+                        "session_id": item.session_id,
+                        "metadata": item.metadata,
+                    }
+                    for item in items
+                ],
+                "widening": widening,
+            }
 
         return with_store(handler)
 
@@ -359,11 +408,17 @@ def build_server() -> FastMCP:
         exclude_actor_ids: list[str] | None = None,
         include_visibility: list[str] | None = None,
         exclude_visibility: list[str] | None = None,
+        include_trust_states: list[str] | None = None,
+        exclude_trust_states: list[str] | None = None,
         include_workspace_ids: list[str] | None = None,
         exclude_workspace_ids: list[str] | None = None,
         include_workspace_kinds: list[str] | None = None,
         exclude_workspace_kinds: list[str] | None = None,
         personal_first: bool | None = None,
+        trust_bias: str | None = None,
+        widen_shared_when_weak: bool | None = None,
+        widen_shared_min_personal_results: int | None = None,
+        widen_shared_min_personal_score: float | None = None,
     ) -> dict[str, Any]:
         def handler(store: MemoryStore) -> dict[str, Any]:
             filters = build_filters(
@@ -373,13 +428,21 @@ def build_server() -> FastMCP:
                 exclude_actor_ids=exclude_actor_ids,
                 include_visibility=include_visibility,
                 exclude_visibility=exclude_visibility,
+                include_trust_states=include_trust_states,
+                exclude_trust_states=exclude_trust_states,
                 include_workspace_ids=include_workspace_ids,
                 exclude_workspace_ids=exclude_workspace_ids,
                 include_workspace_kinds=include_workspace_kinds,
                 exclude_workspace_kinds=exclude_workspace_kinds,
                 personal_first=personal_first,
+                trust_bias=trust_bias,
+                widen_shared_when_weak=widen_shared_when_weak,
+                widen_shared_min_personal_results=widen_shared_min_personal_results,
+                widen_shared_min_personal_score=widen_shared_min_personal_score,
             )
-            matches = store.search(query, limit=limit, filters=filters or None)
+            matches, widening = store.search_with_diagnostics(
+                query, limit=limit, filters=filters or None
+            )
             return {
                 "items": [
                     {
@@ -393,7 +456,8 @@ def build_server() -> FastMCP:
                         "metadata": m.metadata,
                     }
                     for m in matches
-                ]
+                ],
+                "widening": widening,
             }
 
         return with_store(handler)
@@ -491,11 +555,17 @@ def build_server() -> FastMCP:
         exclude_actor_ids: list[str] | None = None,
         include_visibility: list[str] | None = None,
         exclude_visibility: list[str] | None = None,
+        include_trust_states: list[str] | None = None,
+        exclude_trust_states: list[str] | None = None,
         include_workspace_ids: list[str] | None = None,
         exclude_workspace_ids: list[str] | None = None,
         include_workspace_kinds: list[str] | None = None,
         exclude_workspace_kinds: list[str] | None = None,
         personal_first: bool | None = None,
+        trust_bias: str | None = None,
+        widen_shared_when_weak: bool | None = None,
+        widen_shared_min_personal_results: int | None = None,
+        widen_shared_min_personal_score: float | None = None,
     ) -> dict[str, Any]:
         def handler(store: MemoryStore) -> dict[str, Any]:
             filters = build_filters(
@@ -504,11 +574,17 @@ def build_server() -> FastMCP:
                 exclude_actor_ids=exclude_actor_ids,
                 include_visibility=include_visibility,
                 exclude_visibility=exclude_visibility,
+                include_trust_states=include_trust_states,
+                exclude_trust_states=exclude_trust_states,
                 include_workspace_ids=include_workspace_ids,
                 exclude_workspace_ids=exclude_workspace_ids,
                 include_workspace_kinds=include_workspace_kinds,
                 exclude_workspace_kinds=exclude_workspace_kinds,
                 personal_first=personal_first,
+                trust_bias=trust_bias,
+                widen_shared_when_weak=widen_shared_when_weak,
+                widen_shared_min_personal_results=widen_shared_min_personal_results,
+                widen_shared_min_personal_score=widen_shared_min_personal_score,
             )
             config = load_config()
             return store.build_memory_pack(

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -119,6 +119,7 @@ class MemoryStore:
         self._ensure_local_actor_record()
         self._sync_peer_actor_compatibility_state()
         self._backfill_identity_provenance()
+        self._migrate_project_first_sharing_defaults()
         self._reconcile_claimed_same_actor_legacy_memories()
 
     def _resolve_actor_id(self, configured_actor_id: str | None) -> str:
@@ -502,10 +503,10 @@ class MemoryStore:
             ):
                 visibility = "shared"
             else:
-                visibility = "private"
+                visibility = "shared"
         if visibility not in {"private", "shared"}:
-            visibility = "private"
-        workspace_kind = explicit_workspace_kind or "personal"
+            visibility = "shared"
+        workspace_kind = explicit_workspace_kind or "shared"
         if workspace_kind not in {"personal", "shared"}:
             workspace_kind = "shared" if visibility == "shared" else "personal"
         elif visibility == "shared":
@@ -648,6 +649,51 @@ class MemoryStore:
                 ),
             )
         self.conn.commit()
+
+    def _migrate_project_first_sharing_defaults(self) -> None:
+        rows = self.conn.execute(
+            """
+            SELECT id, metadata_json, rev
+            FROM memory_items
+            WHERE active = 1
+              AND actor_id = ?
+              AND visibility = 'private'
+              AND workspace_kind = 'personal'
+            ORDER BY id ASC
+            """,
+            (self.actor_id,),
+        ).fetchall()
+        migrated_ids: list[int] = []
+        for row in rows:
+            metadata = self._normalize_metadata(row["metadata_json"])
+            if "visibility" in metadata:
+                continue
+            now = self._now_iso()
+            rev = int(row["rev"] or 0) + 1
+            memory_id = int(row["id"])
+            self.conn.execute(
+                """
+                UPDATE memory_items
+                SET visibility = 'shared',
+                    workspace_kind = 'shared',
+                    workspace_id = ?,
+                    updated_at = ?,
+                    rev = ?
+                WHERE id = ?
+                """,
+                (
+                    self._default_workspace_id(actor_id=self.actor_id, workspace_kind="shared"),
+                    now,
+                    rev,
+                    memory_id,
+                ),
+            )
+            migrated_ids.append(memory_id)
+        if not migrated_ids:
+            return
+        self.conn.commit()
+        for memory_id in migrated_ids:
+            self._record_memory_item_op(memory_id, "upsert")
 
     def _reconcile_claimed_same_actor_legacy_memories(self) -> None:
         claimed_peers = self.same_actor_peer_ids()

--- a/codemem/store/packs.py
+++ b/codemem/store/packs.py
@@ -600,6 +600,9 @@ def build_memory_pack(
         }
         for m in final_items
     ]
+    widened_shared_items = sum(
+        1 for item in formatted if bool((item.get("metadata") or {}).get("widened_from_shared"))
+    )
 
     section_blocks = []
     section_unique_ids: set[int] = set()
@@ -736,6 +739,8 @@ def build_memory_pack(
         else True,
         "semantic_candidates": semantic_candidates,
         "semantic_hits": semantic_hits,
+        "widening_applied": widened_shared_items > 0,
+        "widened_shared_items": widened_shared_items,
         "exact_dedupe_enabled": exact_dedupe_enabled,
         "exact_duplicates_collapsed": returned_duplicates_collapsed,
         "exact_candidates_total": returned_candidates_total,

--- a/codemem/store/search.py
+++ b/codemem/store/search.py
@@ -19,6 +19,17 @@ if TYPE_CHECKING:
 SQLITE_INT64_MIN = -(2**63)
 SQLITE_INT64_MAX = (2**63) - 1
 PERSONAL_FIRST_BONUS = 0.45
+TRUST_BIAS_LEGACY_UNKNOWN_PENALTY = 0.18
+TRUST_BIAS_UNREVIEWED_PENALTY = 0.12
+WIDEN_SHARED_DEFAULT_MIN_PERSONAL_RESULTS = 3
+WIDEN_SHARED_DEFAULT_MIN_PERSONAL_SCORE = 0.0
+WIDEN_SHARED_MAX_SHARED_RESULTS = 2
+PERSONAL_QUERY_PATTERNS = (
+    re.compile(r"\bwhat did i\b", re.IGNORECASE),
+    re.compile(r"\bmy notes\b", re.IGNORECASE),
+    re.compile(r"\bmy last session\b", re.IGNORECASE),
+    re.compile(r"\bmy machine\b", re.IGNORECASE),
+)
 
 
 def _normalize_filter_strings(value: Any) -> list[str]:
@@ -60,6 +71,15 @@ def _normalize_visibility_values(value: Any) -> list[str]:
     return normalized
 
 
+def _normalize_trust_states(value: Any) -> list[str]:
+    normalized: list[str] = []
+    for raw in _normalize_filter_strings(value):
+        lowered = raw.lower()
+        if lowered in {"trusted", "legacy_unknown", "unreviewed"} and lowered not in normalized:
+            normalized.append(lowered)
+    return normalized
+
+
 def _personal_first_enabled(filters: dict[str, Any] | None) -> bool:
     if not filters or "personal_first" not in filters:
         return True
@@ -71,6 +91,141 @@ def _personal_first_enabled(filters: dict[str, Any] | None) -> bool:
         if lowered in {"1", "true", "yes", "on"}:
             return True
     return bool(value)
+
+
+def _trust_bias_mode(filters: dict[str, Any] | None) -> str:
+    if not filters:
+        return "off"
+    value = str(filters.get("trust_bias") or "off").strip().lower()
+    return value if value in {"off", "soft"} else "off"
+
+
+def _widen_shared_when_weak_enabled(filters: dict[str, Any] | None) -> bool:
+    if not filters or "widen_shared_when_weak" not in filters:
+        return False
+    value = filters.get("widen_shared_when_weak")
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+    return bool(value)
+
+
+def _widen_shared_min_personal_results(filters: dict[str, Any] | None) -> int:
+    if not filters:
+        return WIDEN_SHARED_DEFAULT_MIN_PERSONAL_RESULTS
+    try:
+        parsed = int(
+            filters.get(
+                "widen_shared_min_personal_results", WIDEN_SHARED_DEFAULT_MIN_PERSONAL_RESULTS
+            )
+        )
+    except (TypeError, ValueError):
+        return WIDEN_SHARED_DEFAULT_MIN_PERSONAL_RESULTS
+    return max(1, parsed)
+
+
+def _widen_shared_min_personal_score(filters: dict[str, Any] | None) -> float:
+    if not filters:
+        return WIDEN_SHARED_DEFAULT_MIN_PERSONAL_SCORE
+    try:
+        parsed = float(
+            filters.get("widen_shared_min_personal_score", WIDEN_SHARED_DEFAULT_MIN_PERSONAL_SCORE)
+        )
+    except (TypeError, ValueError):
+        return WIDEN_SHARED_DEFAULT_MIN_PERSONAL_SCORE
+    return max(0.0, parsed)
+
+
+def _query_blocks_shared_widening(query: str) -> bool:
+    return any(pattern.search(query) for pattern in PERSONAL_QUERY_PATTERNS)
+
+
+def _filters_block_shared_widening(filters: dict[str, Any] | None) -> bool:
+    filters = filters or {}
+    ownership_scope = str(filters.get("ownership_scope") or "").strip().lower()
+    if ownership_scope in {"mine", "theirs"}:
+        return True
+    include_visibility = _normalize_visibility_values(
+        filters.get("include_visibility") or filters.get("visibility")
+    )
+    exclude_visibility = _normalize_visibility_values(filters.get("exclude_visibility"))
+    include_workspace_ids = _normalize_filter_strings(filters.get("include_workspace_ids"))
+    exclude_workspace_ids = _normalize_filter_strings(filters.get("exclude_workspace_ids"))
+    include_workspace_kinds = _normalize_workspace_kinds(filters.get("include_workspace_kinds"))
+    exclude_workspace_kinds = _normalize_workspace_kinds(filters.get("exclude_workspace_kinds"))
+    if include_visibility or include_workspace_ids or include_workspace_kinds:
+        return True
+    if "private" in exclude_visibility or "shared" in exclude_visibility:
+        return True
+    if "shared" in exclude_workspace_kinds or "personal" in exclude_workspace_kinds:
+        return True
+    return any(
+        value.startswith("personal:") or value.startswith("shared:")
+        for value in exclude_workspace_ids
+    )
+
+
+def _mark_widening_metadata(
+    items: Sequence[MemoryResult], *, widened_from_shared: bool
+) -> list[MemoryResult]:
+    marked: list[MemoryResult] = []
+    for item in items:
+        metadata = dict(item.metadata or {})
+        metadata["widened_from_shared"] = widened_from_shared
+        item.metadata = metadata
+        marked.append(item)
+    return marked
+
+
+def _shared_widening_filters(filters: dict[str, Any] | None) -> dict[str, Any]:
+    widened = dict(filters or {})
+    widened.pop("visibility", None)
+    widened.pop("ownership_scope", None)
+    widened["include_visibility"] = ["shared"]
+    widened["include_workspace_kinds"] = ["shared"]
+    widened["personal_first"] = False
+    widened["widen_shared_when_weak"] = False
+    return widened
+
+
+def _search_usage_metadata(
+    filters: dict[str, Any],
+    *,
+    limit: int,
+    results: Sequence[MemoryResult],
+    working_set_paths: list[str],
+    widening: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "limit": limit,
+        "results": len(results),
+        "kind": filters.get("kind"),
+        "project": filters.get("project"),
+        "working_set_paths": len(working_set_paths),
+        "personal_first": _personal_first_enabled(filters),
+        "include_visibility": _normalize_visibility_values(
+            filters.get("include_visibility") or filters.get("visibility")
+        ),
+        "exclude_visibility": _normalize_visibility_values(filters.get("exclude_visibility")),
+        "include_actor_ids": _normalize_filter_strings(filters.get("include_actor_ids")),
+        "exclude_actor_ids": _normalize_filter_strings(filters.get("exclude_actor_ids")),
+        "include_workspace_ids": _normalize_filter_strings(filters.get("include_workspace_ids")),
+        "exclude_workspace_ids": _normalize_filter_strings(filters.get("exclude_workspace_ids")),
+        "include_workspace_kinds": _normalize_workspace_kinds(
+            filters.get("include_workspace_kinds")
+        ),
+        "exclude_workspace_kinds": _normalize_workspace_kinds(
+            filters.get("exclude_workspace_kinds")
+        ),
+        "include_trust_states": _normalize_trust_states(filters.get("include_trust_states")),
+        "exclude_trust_states": _normalize_trust_states(filters.get("exclude_trust_states")),
+        "trust_bias": _trust_bias_mode(filters),
+        "widen_shared_when_weak": _widen_shared_when_weak_enabled(filters),
+        **widening,
+    }
 
 
 def _metadata_with_provenance(raw_metadata: Any, row: Any) -> dict[str, Any]:
@@ -134,6 +289,30 @@ def _personal_bias(
     if store is None or not _personal_first_enabled(filters):
         return 0.0
     return PERSONAL_FIRST_BONUS if store.memory_owned_by_self(item) else 0.0
+
+
+def _shared_trust_penalty(
+    store: MemoryStore | None, item: MemoryResult | dict[str, Any], filters: dict[str, Any] | None
+) -> float:
+    if store is None or _trust_bias_mode(filters) != "soft":
+        return 0.0
+    if store.memory_owned_by_self(item):
+        return 0.0
+    metadata = (
+        item.metadata
+        if isinstance(item, MemoryResult)
+        else _coerce_metadata_dict(item.get("metadata_json"))
+    )
+    visibility = str(metadata.get("visibility") or "").strip().lower()
+    workspace_kind = str(metadata.get("workspace_kind") or "").strip().lower()
+    if visibility != "shared" and workspace_kind != "shared":
+        return 0.0
+    trust_state = str(metadata.get("trust_state") or "trusted").strip().lower()
+    if trust_state == "legacy_unknown":
+        return TRUST_BIAS_LEGACY_UNKNOWN_PENALTY
+    if trust_state == "unreviewed":
+        return TRUST_BIAS_UNREVIEWED_PENALTY
+    return 0.0
 
 
 def _add_multi_value_filter(
@@ -208,6 +387,13 @@ def _extend_memory_filter_clauses(
         column="memory_items.workspace_kind",
         include_values=_normalize_workspace_kinds(filters.get("include_workspace_kinds")),
         exclude_values=_normalize_workspace_kinds(filters.get("exclude_workspace_kinds")),
+    )
+    _add_multi_value_filter(
+        where_clauses,
+        params,
+        column="memory_items.trust_state",
+        include_values=_normalize_trust_states(filters.get("include_trust_states")),
+        exclude_values=_normalize_trust_states(filters.get("exclude_trust_states")),
     )
 
     if filters.get("project"):
@@ -983,6 +1169,7 @@ def _rerank_results(
             + _recency_score(item.created_at, now=reference_now)
             + _kind_bonus(item.kind)
             + _personal_bias(store, item, filters)
+            - _shared_trust_penalty(store, item, filters)
         )
 
     ordered = sorted(results, key=score, reverse=True)
@@ -1011,6 +1198,7 @@ def _rerank_results_hybrid(
             + (_recency_score(item.created_at, now=reference_now) * 0.8)
             + _kind_bonus(item.kind)
             + _personal_bias(store, item, filters)
+            - _shared_trust_penalty(store, item, filters)
             + semantic_boost
         )
 
@@ -1364,6 +1552,9 @@ def _rerank_with_working_set(
     results: list[MemoryResult],
     base_scores: dict[int, float],
     working_set_paths: list[str],
+    *,
+    store: MemoryStore | None = None,
+    filters: dict[str, Any] | None = None,
 ) -> list[MemoryResult]:
     if not results or not working_set_paths:
         return list(results)
@@ -1371,7 +1562,17 @@ def _rerank_with_working_set(
     for item in results:
         boost = _working_set_overlap_boost(item, working_set_paths)
         base_score = float(base_scores.get(item.id, item.score))
-        scored.append((base_score + boost, boost, item.created_at, item.id, item))
+        personal_bias = _personal_bias(store, item, filters)
+        trust_penalty = _shared_trust_penalty(store, item, filters)
+        scored.append(
+            (
+                base_score + boost + personal_bias - trust_penalty,
+                boost,
+                item.created_at,
+                item.id,
+                item,
+            )
+        )
     scored.sort(key=lambda entry: (entry[0], entry[1], entry[2], entry[3]), reverse=True)
     return [entry[4] for entry in scored]
 
@@ -1385,12 +1586,11 @@ def _coerce_metadata_dict(raw_metadata: Any) -> dict[str, Any]:
     return {}
 
 
-def search(
+def _search_once(
     store: MemoryStore,
     query: str,
     limit: int = 10,
     filters: dict[str, Any] | None = None,
-    log_usage: bool = True,
 ) -> list[MemoryResult]:
     filters = filters or {}
     effective_limit = max(1, int(limit))
@@ -1453,10 +1653,72 @@ def search(
         base_scores[int(row["id"])] = base_score
 
     if working_set_paths:
-        results = _rerank_with_working_set(results, base_scores, working_set_paths)
+        results = _rerank_with_working_set(
+            results,
+            base_scores,
+            working_set_paths,
+            store=store,
+            filters=filters,
+        )
         results = results[:effective_limit]
     else:
         results = _rerank_results(results, limit=effective_limit, store=store, filters=filters)
+
+    return results
+
+
+def search_with_diagnostics(
+    store: MemoryStore,
+    query: str,
+    limit: int = 10,
+    filters: dict[str, Any] | None = None,
+    log_usage: bool = True,
+) -> tuple[list[MemoryResult], dict[str, Any]]:
+    filters = filters or {}
+    working_set_paths = _normalize_working_set_paths(filters.get("working_set_paths"))
+    primary_results = _search_once(store, query, limit=limit, filters=filters)
+    strong_result_threshold = _widen_shared_min_personal_score(filters)
+    strong_personal_results = [
+        item for item in primary_results if float(item.score) >= strong_result_threshold
+    ]
+    widening = {
+        "widening_applied": False,
+        "personal_result_count": len(primary_results),
+        "shared_result_count": 0,
+        "strong_personal_result_count": len(strong_personal_results),
+    }
+    results = _mark_widening_metadata(primary_results, widened_from_shared=False)
+
+    should_widen = (
+        _widen_shared_when_weak_enabled(filters)
+        and not _filters_block_shared_widening(filters)
+        and not _query_blocks_shared_widening(query)
+        and len(strong_personal_results) < _widen_shared_min_personal_results(filters)
+    )
+    if should_widen:
+        shared_results = _search_once(
+            store,
+            query,
+            limit=max(limit, WIDEN_SHARED_MAX_SHARED_RESULTS),
+            filters=_shared_widening_filters(filters),
+        )
+        seen_ids = {item.id for item in results}
+        widened_shared_results: list[MemoryResult] = []
+        for item in shared_results:
+            if item.id in seen_ids:
+                continue
+            seen_ids.add(item.id)
+            widened_shared_results.append(item)
+            if len(widened_shared_results) >= WIDEN_SHARED_MAX_SHARED_RESULTS:
+                break
+        if widened_shared_results:
+            widening["widening_applied"] = True
+            widening["shared_result_count"] = len(widened_shared_results)
+            results = results + _mark_widening_metadata(
+                widened_shared_results,
+                widened_from_shared=True,
+            )
+            results = results[: max(1, int(limit)) + WIDEN_SHARED_MAX_SHARED_RESULTS]
 
     if log_usage:
         tokens_read = sum(
@@ -1465,33 +1727,29 @@ def search(
         store.record_usage(
             "search",
             tokens_read=tokens_read,
-            metadata={
-                "limit": limit,
-                "results": len(results),
-                "kind": filters.get("kind"),
-                "project": filters.get("project"),
-                "working_set_paths": len(working_set_paths),
-                "personal_first": _personal_first_enabled(filters),
-                "include_visibility": _normalize_visibility_values(
-                    filters.get("include_visibility") or filters.get("visibility")
-                ),
-                "exclude_visibility": _normalize_visibility_values(
-                    filters.get("exclude_visibility")
-                ),
-                "include_actor_ids": _normalize_filter_strings(filters.get("include_actor_ids")),
-                "exclude_actor_ids": _normalize_filter_strings(filters.get("exclude_actor_ids")),
-                "include_workspace_ids": _normalize_filter_strings(
-                    filters.get("include_workspace_ids")
-                ),
-                "exclude_workspace_ids": _normalize_filter_strings(
-                    filters.get("exclude_workspace_ids")
-                ),
-                "include_workspace_kinds": _normalize_workspace_kinds(
-                    filters.get("include_workspace_kinds")
-                ),
-                "exclude_workspace_kinds": _normalize_workspace_kinds(
-                    filters.get("exclude_workspace_kinds")
-                ),
-            },
+            metadata=_search_usage_metadata(
+                filters,
+                limit=limit,
+                results=results,
+                working_set_paths=working_set_paths,
+                widening=widening,
+            ),
         )
+    return results, widening
+
+
+def search(
+    store: MemoryStore,
+    query: str,
+    limit: int = 10,
+    filters: dict[str, Any] | None = None,
+    log_usage: bool = True,
+) -> list[MemoryResult]:
+    results, _widening = search_with_diagnostics(
+        store,
+        query,
+        limit=limit,
+        filters=filters,
+        log_usage=log_usage,
+    )
     return results

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -626,6 +626,10 @@
     const olderItems = currentItems.filter((item) => !firstPageKeys.has(itemKey(item)));
     return mergeFeedItems(olderItems, firstPageItems);
   }
+  function replaceFeedItem(updatedItem) {
+    const key = itemKey(updatedItem);
+    state.lastFeedItems = state.lastFeedItems.map((item) => itemKey(item) === key ? updatedItem : item);
+  }
   function getSummaryObject(item) {
     const preferredKeys = ["request", "outcome", "plan", "completed", "learned", "investigated", "next", "next_steps", "notes"];
     const looksLikeSummary = (v) => {
@@ -923,34 +927,34 @@
         option.selected = optionData.value === visibility;
         visibilitySelect.appendChild(option);
       });
-      const visibilityButton = el("button", "settings-button", "Save visibility");
       visibilitySelect.setAttribute("aria-label", `Visibility for ${String(item.title || "memory")}`);
       const visibilityNote = el(
         "div",
         "feed-visibility-note",
-        visibility === "shared" ? "Shared memories can sync to trusted peers and stay in shared scope." : "Private memories stay local unless the peer is assigned to your local actor."
+        visibility === "shared" ? "This memory can sync to peers allowed by your project filters." : "This memory stays local unless the peer is assigned to your local actor."
       );
       visibilitySelect.addEventListener("change", () => {
-        visibilityNote.textContent = visibilitySelect.value === "shared" ? "Shared memories can sync to trusted peers and stay in shared scope." : "Private memories stay local unless the peer is assigned to your local actor.";
+        visibilityNote.textContent = visibilitySelect.value === "shared" ? "This memory can sync to peers allowed by your project filters." : "This memory stays local unless the peer is assigned to your local actor.";
       });
-      visibilityButton.addEventListener("click", async () => {
-        visibilityButton.disabled = true;
+      visibilitySelect.addEventListener("change", async () => {
+        const previousVisibility = visibility;
         visibilitySelect.disabled = true;
-        visibilityButton.textContent = "Saving...";
         try {
-          await updateMemoryVisibility(memoryId, visibilitySelect.value);
+          const payload = await updateMemoryVisibility(memoryId, visibilitySelect.value);
+          if (payload?.item) {
+            replaceFeedItem(payload.item);
+            updateFeedView(true);
+          }
           showGlobalNotice(visibilitySelect.value === "shared" ? "Memory will now sync as shared context." : "Memory is private again.");
-          await loadFeedData();
         } catch (error) {
+          visibilitySelect.value = previousVisibility;
+          visibilityNote.textContent = previousVisibility === "shared" ? "This memory can sync to peers allowed by your project filters." : "This memory stays local unless the peer is assigned to your local actor.";
           showGlobalNotice(error instanceof Error ? error.message : "Failed to save visibility.", "warning");
-          visibilityButton.textContent = "Retry save";
         } finally {
-          visibilityButton.disabled = false;
           visibilitySelect.disabled = false;
-          if (visibilityButton.textContent === "Saving...") visibilityButton.textContent = "Save visibility";
         }
       });
-      visibilityControls.append(visibilitySelect, visibilityButton, visibilityNote);
+      visibilityControls.append(visibilitySelect, visibilityNote);
       footerLeft.appendChild(visibilityControls);
     }
     footer.append(footerLeft, footerRight);
@@ -1515,7 +1519,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (actor?.is_local) {
       return "Local actor assignment keeps this peer in your same-person continuity path, including private sync.";
     }
-    return "Only memories marked shared sync to this actor. Existing private memories stay local until you change their visibility in the feed.";
+    return "This actor receives memories from allowed projects by default. Use Only me on a memory when it should stay local.";
   }
   function buildActorOptions(selectedActorId) {
     const options = [];
@@ -1848,7 +1852,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     actorList.textContent = "";
     const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
     if (actorMeta) {
-      actorMeta.textContent = actors.length ? "Create, rename, and merge actors here. Assign each peer below. Non-local actors only receive memories marked shared." : "No named actors yet. Create one here, then assign peers below.";
+      actorMeta.textContent = actors.length ? "Create, rename, and merge actors here. Assign each peer below. Non-local actors receive memories from allowed projects unless you mark them Only me." : "No named actors yet. Create one here, then assign peers below.";
     }
     actors.forEach((actor) => {
       const row = el("div", "actor-row");

--- a/docs/plans/2026-03-12-adaptive-widening-personal-to-shared-retrieval.md
+++ b/docs/plans/2026-03-12-adaptive-widening-personal-to-shared-retrieval.md
@@ -1,0 +1,235 @@
+# Adaptive Widening from Personal to Shared Retrieval
+
+**Bead:** `codemem-qth`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Problem
+
+Identity-aware retrieval now has the right default instinct: stay personal-first.
+
+That improves relevance, but it also creates a new failure mode. Some questions are genuinely about work the
+current actor has not touched directly, even though trusted shared memories exist. Right now the only safe answer is
+to widen explicitly. That is predictable, but it is also brittle:
+
+- callers need to know in advance when personal-only retrieval will be too narrow
+- weak or empty result sets can look like "codemem knows nothing" even when shared context exists
+- blindly blending personal and shared results would fix recall at the cost of noisy attribution and trust
+
+We need a narrow, explicit widening design that helps weak personal queries without making shared teammate memory feel
+like ambient background radiation.
+
+## Goals
+
+- Keep personal-first retrieval as the default behavior.
+- Define when widening is allowed to trigger automatically.
+- Keep widened shared results visibly distinct from personal results.
+- Preserve explicit caller control over whether widening is allowed.
+- Define an evaluation plan before rollout.
+
+## Non-goals
+
+- No hidden default blend of personal and shared results for all queries.
+- No trust-state weighting in this slice.
+- No teammate-specific routing heuristics or social graph logic.
+- No changes to sync scope or replication policy.
+- No automatic widening for clearly private/personal questions.
+
+## Current baseline
+
+The current search layer already supports the right raw ingredients:
+
+- personal-first bias via `PERSONAL_FIRST_BONUS`
+- ownership filters (`mine|theirs`)
+- explicit visibility and workspace filters
+- actor/workspace include/exclude filters
+
+The missing piece is a contract for controlled second-pass widening when a personal-first search is weak.
+
+## Proposed retrieval model
+
+### Phase 1: personal-first primary pass
+
+The first pass remains unchanged:
+
+- personal-first bias enabled
+- no automatic inclusion of extra shared-only candidates beyond what current filters already allow
+- current ranking remains optimized for personal relevance
+
+This preserves existing single-user behavior and keeps the baseline understandable.
+
+### Phase 2: optional widening pass
+
+If the caller explicitly enables widening, codemem may run a second retrieval pass against shared scope when the first
+pass is weak.
+
+Recommended API shape:
+
+- `widen_shared_when_weak: bool = False`
+- optional `widen_shared_min_personal_results`
+- optional `widen_shared_min_personal_score`
+
+Default policy:
+
+- disabled unless the caller opts in
+
+That means the first implementation is still explicit, but callers like memory-pack generation can choose to use it.
+
+## Weak-result trigger rules
+
+The widening trigger should be conservative.
+
+Recommended first-pass trigger:
+
+Widen only when all of the following are true:
+
+1. `widen_shared_when_weak = True`
+2. the caller did not already request explicit shared-only or explicit workspace filters that make widening redundant
+3. the personal-first pass returns fewer than `N` strong results
+4. the query is not obviously personal/private in wording or filters
+
+Recommended initial thresholds:
+
+- `N = 3` results
+- strong result = score above a configurable floor derived from current search score normalization
+
+Implementation note:
+
+- start with count-based gating plus a low score floor rather than a fancy confidence model
+
+That is easier to reason about and easier to evaluate.
+
+## Queries that should not auto-widen
+
+Do not widen for:
+
+- queries explicitly filtered to `mine`
+- queries explicitly filtered to personal/private visibility or personal workspace only
+- queries whose wording strongly signals personal/private intent, for example:
+  - "what did I decide"
+  - "my notes"
+  - "my last session"
+  - "my machine"
+
+The first implementation can keep this language guardrail extremely simple:
+
+- only block widening for a short denylist of obvious first-person patterns
+- do not attempt full intent classification
+
+## Shared-pass constraints
+
+When widening triggers, the second pass should search only within shared scope.
+
+Recommended constraints:
+
+- `include_visibility = ["shared"]`
+- optionally `include_workspace_kinds = ["shared"]`
+- preserve explicit include/exclude actor and workspace filters from the caller
+- disable personal-first bias in the widened pass
+
+This ensures the second pass is truly additive rather than just rerunning the same search with slightly different rank
+weights.
+
+## Result blending contract
+
+Do not fully interleave personal and widened shared results by score alone.
+
+Recommended first implementation:
+
+- keep personal-pass results first
+- append at most `M` widened shared results after them
+- mark widened results with an explanation flag
+
+Recommended initial limit:
+
+- `M = 2`
+
+This gives the user a visible "here are a couple shared leads" escape hatch without turning the full result set into a
+mixed pile.
+
+## Output labeling
+
+Widened shared results must be labeled in the response surface.
+
+Recommended response fields:
+
+- per-result: `widened_from_shared: true|false`
+- aggregate metadata:
+  - `widening_applied: true|false`
+  - `personal_result_count`
+  - `shared_result_count`
+
+UI and prompt-pack callers can then render this clearly instead of pretending the results all came from the same pass.
+
+Recommended copy style for product surfaces:
+
+- "Added shared context because personal results were weak."
+
+Short, factual, not mystical.
+
+## Ranking inside the widened shared pass
+
+Use the existing retrieval/rerank logic inside the widened pass with two constraints:
+
+- no personal-first bonus
+- no trust-state weighting yet
+
+This keeps the shared pass consistent with the current search stack while avoiding premature ranking complexity.
+
+## Telemetry and evaluation plan
+
+Before broad rollout, capture enough telemetry to answer whether widening helps or just adds noise.
+
+Minimum telemetry:
+
+- whether widening was enabled by the caller
+- whether widening triggered
+- personal result count before widening
+- widened shared result count
+- top shared result scores
+- actor IDs of widened results
+
+Evaluation questions:
+
+- how often do personal-first queries fall below the trigger threshold?
+- how often would widening have added shared results?
+- do widened results cluster around a few actors or projects?
+- do widened shared additions correlate with better downstream pack usefulness or obvious noise?
+
+For the first implementation, offline inspection plus targeted dogfooding is enough. No need for a giant analytics
+program.
+
+## Rollout plan
+
+1. Add opt-in widening flags to the relevant retrieval API surfaces.
+2. Instrument widening decisions and result counts.
+3. Enable it first for pack-building or other high-context callers that can explain the added shared context.
+4. Review real examples before enabling in broader search surfaces.
+
+## Failure modes to avoid
+
+The first implementation must not:
+
+- widen silently for all queries
+- insert many shared results ahead of strong personal results
+- widen when the caller explicitly asked for `mine`
+- widen private/personal scoped queries
+- hide whether widened results came from shared scope
+
+## Out of scope for the first implementation
+
+- trust-aware result weighting
+- actor affinity or teammate-priority ranking
+- automatic widening based on long conversational state
+- project-specific widening heuristics beyond explicit filters already present
+- UI affordances for per-result "why was this widened" deep inspection
+
+## Acceptance criteria
+
+This design is successful when:
+
+1. The trigger conditions for widening are explicit and conservative.
+2. The widened pass is constrained to shared scope and preserves caller filters.
+3. Blending rules keep personal results primary and shared results visibly secondary.
+4. Telemetry/evaluation requirements are defined before rollout.
+5. Failure modes and out-of-scope behaviors are explicit enough to prevent a noisy first implementation.

--- a/docs/plans/2026-03-12-optional-relay-coordinator-mode.md
+++ b/docs/plans/2026-03-12-optional-relay-coordinator-mode.md
@@ -1,0 +1,240 @@
+# Optional Relay / Coordinator Mode for Identity-Aware Shared Sync
+
+**Bead:** `codemem-6pe`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Problem
+
+Peer-to-peer sync is the right default for codemem: local-first, simple, no hosted dependency.
+
+But once shared memory spans more teammates and more networks, pure peer-to-peer runs into practical friction:
+
+- peers may not be mutually reachable because of NAT, VPN, sleep, or firewall realities
+- updates can arrive only when specific devices are online together
+- pairing scales awkwardly as the number of peers grows
+- the product may need a more reliable shared-memory transport without becoming a mandatory cloud SaaS
+
+We need a design for an optional relay/coordinator mode that improves reachability and fan-out while preserving the
+local-first, no-central-service-required shape of codemem.
+
+## Goals
+
+- Keep pure peer-to-peer sync as the default and always-supported mode.
+- Define an optional relay/coordinator that improves reliability for shared sync.
+- Reuse the existing provenance and replication model as much as possible.
+- Preserve end-user control over whether relay mode is enabled.
+- Avoid inventing hosted accounts or a mandatory identity provider.
+
+## Non-goals
+
+- No mandatory always-online codemem cloud.
+- No server-side semantic search or server-authoritative memory store in the first relay design.
+- No enterprise auth/SSO/RBAC system.
+- No replacement of device pairing with email/login identity.
+- No assumption that relay mode and peer-to-peer mode are mutually exclusive.
+
+## Recommended architecture stance
+
+Use a **coordinator-plus-relay** model, not a server-authoritative database.
+
+Recommended responsibilities for the optional service:
+
+- rendezvous / reachability coordination for enrolled devices
+- authenticated message relay for replication payloads when direct peer dial is unavailable
+- optional durable queueing of encrypted replication envelopes for temporarily offline peers
+
+What the relay should **not** own in the first version:
+
+- canonical memory state
+- actor registry truth
+- search index or retrieval ranking
+- policy decisions about visibility beyond transport enforcement
+
+This keeps the relay as a transport helper, not a new product center of gravity.
+
+## Core design decisions
+
+### 1) Local databases stay authoritative
+
+Each device still owns its local SQLite store.
+
+Replication semantics remain the same:
+
+- devices emit replication ops
+- devices apply replication ops locally
+- clocks/conflict rules remain device-side
+
+The relay forwards or temporarily stores envelopes; it does not become the source of truth for memory contents.
+
+### 2) Relay enrollment is device-based, not account-based
+
+The current sync stack already has device identity material:
+
+- device IDs
+- public keys
+- fingerprints
+- pairing payloads
+
+The first relay mode should extend that instead of inventing user accounts.
+
+Recommended enrollment model:
+
+- a relay instance has its own public endpoint and server identity
+- a device enrolls by explicitly trusting that relay and registering its device public key
+- relay membership is scoped to a shared sync group or workspace, not to a global codemem account
+
+This keeps the auth story aligned with existing pair/trust mechanics.
+
+### 3) Relay transport should preserve end-to-end provenance and, ideally, encryption
+
+Relay mode should carry the same replication payloads and provenance fields used by peer-to-peer sync.
+
+Preferred stance:
+
+- the relay can inspect routing metadata
+- the relay should not need to understand memory semantics beyond delivery metadata
+- if feasible, payload bodies stay encrypted end-to-end between member devices
+
+If the first implementation cannot achieve full body encryption immediately, that limitation should be explicit and not
+misrepresented as zero-knowledge magic.
+
+### 4) Relay groups map to intentional shared-sync scopes
+
+The relay should not be a global inbox for every device everywhere.
+
+Recommended unit of coordination:
+
+- a relay-backed sync group representing a bounded shared collaboration context
+
+That group may later align with a shared workspace, but the first design should keep the transport group distinct from
+memory workspace semantics.
+
+Reason:
+
+- one relay group may transport multiple shared scopes
+- memory visibility/workspace remains an item-level concern
+- transport enrollment and retrieval scope should not collapse into one overloaded object too early
+
+## Relay responsibilities
+
+Minimum relay responsibilities:
+
+1. authenticate enrolled devices
+2. accept replication envelopes from a sender
+3. route envelopes to intended peers or group members
+4. queue envelopes temporarily for offline recipients
+5. expose delivery status/health information back to devices
+
+Optional but reasonable later responsibilities:
+
+- membership roster distribution
+- push notifications / wake-up hints
+- relay-side anti-abuse rate limits
+
+Not a responsibility in the first version:
+
+- query answering
+- pack building
+- server-side merge resolution
+
+## Auth and key story
+
+### Relay identity
+
+Each relay has a pinned identity, ideally comparable to the current peer fingerprint trust model.
+
+Devices should explicitly trust a relay rather than silently accepting any host claiming to be one.
+
+### Device authentication to relay
+
+Recommended first pass:
+
+- device signs a challenge or request with its existing sync private key
+- relay verifies enrollment against the registered public key for that device
+
+This avoids bolting on passwords or tokens as the primary auth model.
+
+### Group membership
+
+Recommended first pass:
+
+- one enrolled device can invite another by exchanging a relay-group join payload
+- join flow remains operator-driven and explicit, similar in spirit to current pairing
+
+This keeps the product consistent: codemem still works by explicit trust relationships, just with a different transport.
+
+## Coexistence with pure peer-to-peer
+
+Relay mode should be additive, not a forked product.
+
+Recommended coexistence rules:
+
+- direct peer-to-peer remains enabled when configured and reachable
+- relay mode is an additional transport path when direct dial fails or is unavailable
+- the replication payload schema stays shared across both transports
+- one device may use direct transport with some peers and relay transport for others
+
+This avoids a painful either/or migration and keeps local setups simple.
+
+## Delivery and conflict model
+
+Do not invent a new merge system for relay mode.
+
+Use the current replication clock model unchanged:
+
+- relay forwards envelopes
+- recipients apply the same clock/conflict resolution rules they already use
+
+If relay queueing introduces duplicate delivery, idempotency must rely on the existing replication op identity rules.
+
+## Failure modes and boundaries
+
+### Relay offline
+
+- direct peer-to-peer should still work when available
+- relay-backed queued delivery pauses but local capture continues
+
+### Device offline
+
+- relay may queue envelopes up to a bounded retention window
+- devices reconcile on reconnect using the normal replication cursor model
+
+### Relay compromise
+
+Design assumption:
+
+- relay compromise must not imply server-authoritative deletion or mutation of local memory
+- if payload encryption is not end-to-end in the first version, document clearly that the relay can inspect transported
+  payload bodies
+
+### Membership mistakes
+
+- removing a device from a relay group should stop new deliveries
+- it should not be expected to retroactively erase already-synced memories from local peers
+
+That is a visibility/data-lifecycle problem, not a transport trick.
+
+## Rollout recommendation
+
+1. Keep peer-to-peer as the only shipping mode until relay design is explicitly chosen.
+2. Build relay support behind an opt-in transport configuration.
+3. Start with coordinator-assisted delivery for sync ops, not server-side storage/search.
+4. Add offline queueing only if direct relay forwarding is not enough.
+
+## Out of scope for the first implementation
+
+- hosted multi-tenant codemem accounts
+- central search over team memory
+- server-side pack generation
+- cross-group policy inheritance
+- full audit/compliance system
+
+## Acceptance criteria
+
+This design is successful when:
+
+1. Relay responsibilities are clearly bounded to coordination/transport.
+2. The auth and key story builds on existing device trust rather than introducing a mandatory account system.
+3. Coexistence rules with pure peer-to-peer sync are explicit.
+4. Failure modes and local-first boundaries are named clearly enough to guide implementation.

--- a/docs/plans/2026-03-12-project-first-sharing-private-override.md
+++ b/docs/plans/2026-03-12-project-first-sharing-private-override.md
@@ -1,0 +1,109 @@
+# Project-First Sharing with Private Per-Memory Override
+
+**Bead:** `codemem-71t`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Problem
+
+Identity-aware sync introduced explicit memory visibility controls, but the current behavior made `visibility`
+the primary sync gate for non-local peers. In practice that means new teammate peers receive nothing unless memories are
+individually marked shared.
+
+That is a poor fit for the existing product model because codemem already has global and per-peer project include/exclude
+filters. Users reasonably expect those project filters to define the default sync set, with `private` acting as an
+escape hatch for exceptions.
+
+## Goal
+
+Restore project-first sharing semantics for non-local peers:
+
+- project include/exclude filters define the default eligible sync set
+- `private` is the explicit do-not-share override
+- same-person peers assigned to the local actor continue to receive private memories
+
+## Non-goals
+
+- No silent widening beyond the projects already allowed for a peer
+- No actor-specific sharing policy beyond local-actor continuity versus non-local actor sharing
+- No bulk onboarding wizard in this slice
+- No new visibility enum or full sharing-policy engine
+
+## Proposed model
+
+### Local actor defaults
+
+For local actor-authored memories, default visibility becomes effectively shared.
+
+That means:
+
+- newly created local memories are eligible for sync to non-local peers when project filters allow them
+- users mark a memory `private` only when they want to keep it off the shared path
+
+### Non-local peers
+
+For peers assigned to a non-local actor, outbound sync should allow a memory when all of the following are true:
+
+1. the memory's project passes the effective include/exclude filters for that peer
+2. the memory is not explicitly marked `private`
+
+### Local-actor peers
+
+For peers assigned to the local actor, existing same-person continuity remains unchanged:
+
+- private memories continue to sync
+- project filters still narrow what is sent if configured
+
+## Storage contract
+
+We do not need a new visibility enum for this fix.
+
+Instead:
+
+- `private` continues to mean explicit do-not-share for non-local peers
+- `shared` continues to mean shareable
+- local memories that were previously defaulted to `private` only because the old model required it should be migrated to
+  `shared`
+
+## Migration rules
+
+Migrate local-actor memories from old implicit-private defaults to shared when all of the following are true:
+
+- `actor_id` matches the local actor
+- current row visibility is `private`
+- current workspace is personal
+- metadata does not explicitly set `visibility`
+
+Migration behavior:
+
+- set row visibility to `shared`
+- set workspace kind to `shared`
+- set workspace ID to `shared:default`
+- do not treat rows with explicit `metadata_json.visibility = private` as migration candidates
+
+This preserves real private overrides while reclassifying old default-private rows into the model users expected.
+
+## UI and docs contract
+
+- Feed visibility controls should keep the current simple language (`Only me` / `Share with peers`)
+- Sync UI copy should explain that non-local peers receive memories from allowed projects unless those memories are set to
+  `Only me`
+- Docs should stop claiming that new memories default private
+
+## Tests required
+
+- default local memories replicate to non-local peers when project filters allow them
+- explicit private memories do not replicate to non-local peers
+- explicit private memories still replicate to local-actor peers
+- migrated legacy default-private local memories become shareable without needing per-memory edits
+- project filters still exclude memories even when their visibility is shared/default-shareable
+
+## Acceptance criteria
+
+This work is successful when:
+
+1. project filters once again define the default shared sync set for non-local peers
+2. `private` acts as a per-memory override instead of the default non-local behavior
+3. same-person continuity for local-actor peers remains intact
+4. legacy default-private local memories are migrated safely
+5. docs and UI copy reflect the restored model clearly

--- a/docs/plans/2026-03-12-trust-aware-review-and-retrieval-follow-on.md
+++ b/docs/plans/2026-03-12-trust-aware-review-and-retrieval-follow-on.md
@@ -1,0 +1,196 @@
+# Trust-Aware Review and Retrieval Follow-on
+
+**Bead:** `codemem-2av`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Problem
+
+`trust_state` exists today, but it is mostly inert. That was the right MVP choice.
+
+Now that identity-aware provenance and explicit shared/private controls exist, the next question is not
+"should trust_state become auth policy?" It absolutely should not. The real question is simpler:
+
+- what is the minimum useful review and retrieval behavior that makes provenance quality visible
+- without hiding shared context by default
+- and without turning trust_state into a permission engine
+
+## Goal
+
+Define the first narrow behavior change for `trust_state` across retrieval and review surfaces.
+
+The first follow-on slice should:
+
+- make provenance quality visible in product surfaces
+- make trust state queryable and filterable where useful
+- optionally apply a small ranking preference against lower-confidence shared memories
+- avoid any sync allow/deny semantics
+
+## Non-goals
+
+- No auth or access-control behavior.
+- No blocking sync based on trust state.
+- No mandatory manual review queue before shared memories are usable.
+- No cryptographic verification model.
+- No actor-specific trust policies in this slice.
+
+## Current baseline
+
+Today:
+
+- `trusted` is the default for normal local and explicit-provenance synced memories
+- `legacy_unknown` marks backfilled provenance from older sync history
+- `unreviewed` exists as a reserved enum but is not yet operationally meaningful
+
+The viewer can surface trust badges, but retrieval does not yet use trust state beyond plain display.
+
+## Recommended first follow-on behavior
+
+### 1) Review behavior: make trust visible, not blocking
+
+The first review improvement should be a lightweight provenance review surface, not a moderation system.
+
+Recommended behavior:
+
+- show trust state clearly on shared memories in the viewer/feed
+- allow users to filter for low-confidence shared memories (`legacy_unknown`, later `unreviewed`)
+- add a minimal action to mark a memory as reviewed/trusted when the product eventually exposes item editing beyond
+  visibility controls
+
+This is enough to make the field useful without pretending codemem has a human review workflow platform.
+
+### 2) Retrieval behavior: soft penalty only for lower-confidence shared results
+
+The first retrieval behavior should be intentionally mild.
+
+Recommended rule:
+
+- do not penalize or alter local/private memories based on trust state
+- apply at most a small ranking penalty to shared memories with `trust_state in {legacy_unknown, unreviewed}`
+- never remove these memories from results solely because of trust state unless the caller explicitly filters them out
+
+This keeps trust-state behavior as a ranking refinement rather than a hidden censorship layer.
+
+## Proposed states and transitions
+
+### `trusted`
+
+Meaning:
+
+- provenance is explicit enough to treat the memory as ordinary first-class context
+
+Transitions in first follow-on slice:
+
+- default for normal local/shared writes
+- destination state when a user explicitly reviews a lower-confidence shared memory
+
+### `legacy_unknown`
+
+Meaning:
+
+- provenance was synthesized from legacy sync history
+
+Transitions in first follow-on slice:
+
+- set automatically by legacy backfill paths
+- may transition to `trusted` when the operator resolves provenance confidence through explicit review or actor cleanup
+
+### `unreviewed`
+
+Meaning:
+
+- provenance is explicit enough to be useful, but the memory has not yet been reviewed in a future shared-review flow
+
+First-slice recommendation:
+
+- do not mass-assign `unreviewed` yet
+- reserve it for future product surfaces that create or import shared memories needing review semantics
+
+This avoids inventing a noisy state transition just to feel busy.
+
+## Product surfaces for the first slice
+
+### Viewer/feed
+
+Add the minimum useful trust-aware UI:
+
+- visible trust badge for non-`trusted` shared memories
+- optional feed/search filter for low-confidence trust states
+- simple explanatory copy for `legacy_unknown`
+
+Recommended copy:
+
+- `legacy provenance`
+- `shared provenance not fully confirmed`
+
+Short and human. No compliance theater.
+
+### Search and pack APIs
+
+Add optional trust filters:
+
+- `include_trust_states`
+- `exclude_trust_states`
+
+And optionally a caller-controlled ranking flag:
+
+- `trust_bias: off|soft`
+
+Default recommendation:
+
+- `off` for direct search surfaces until evaluated
+- `soft` may be reasonable later for pack-building or widened shared retrieval, but only after examples are reviewed
+
+## Ranking guidance
+
+If trust-aware ranking is enabled, keep it small.
+
+Recommended first-pass weights:
+
+- `trusted`: no change
+- `legacy_unknown`: small penalty
+- `unreviewed`: same or slightly smaller penalty than `legacy_unknown`
+
+The penalty should be weaker than personal-first bias and weaker than obvious lexical/semantic relevance. The goal is
+"prefer cleaner provenance when results are otherwise similar," not "bury anything imperfect."
+
+## Evaluation plan
+
+Before enabling trust-aware ranking by default, inspect real examples for:
+
+- whether `legacy_unknown` results actually look noisier than `trusted` shared results
+- whether the penalty hides useful historical context too aggressively
+- whether users reach for explicit trust filters in the viewer
+
+Minimum telemetry:
+
+- trust-state distribution in result sets
+- when a trust filter was used
+- when a ranking penalty changed top-N ordering
+
+## Failure modes to avoid
+
+Do not:
+
+- turn `trust_state` into an implicit access-control gate
+- hide `legacy_unknown` results by default
+- apply trust penalties to the local actor's own memories
+- overload `unreviewed` before a real review workflow exists
+- mix trust semantics with sync authorization
+
+## Out of scope for this slice
+
+- per-actor trust policies
+- reviewer identities or audit logs
+- sync quarantine queues
+- cryptographic attestation
+- automatic promotion from `legacy_unknown` based on weak heuristics alone
+
+## Acceptance criteria
+
+This design is successful when:
+
+1. The minimum useful trust-aware behavior is defined without becoming auth policy.
+2. Review behavior and ranking behavior are clearly separated.
+3. The states, transitions, and product surfaces are explicit.
+4. The first implementation remains conservative and reversible.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -140,7 +140,8 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 - Assign each paired peer below to `Unassigned actor`, your local actor, or a named actor.
 - Assigning a peer changes how older synced memories from that peer are attributed.
 - Assigning a peer to a non-local actor keeps that peer's history shared; assigning it to your local actor keeps it personal/private.
-- Non-local actors do not receive your private memories. If you add a new teammate peer and want existing context to sync, mark the relevant memories as shared from the feed.
+- Non-local actors receive memories from projects allowed by their include/exclude filters by default.
+- Use `Only me` on a memory when it should stay local and not sync to non-local actors.
 
 ### One-off sync
 
@@ -169,11 +170,11 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 - Sync errors: `codemem sync status` shows the last error per peer.
 
 ## Retrieval scope
-- New memories default to private visibility and stay local unless written as shared.
-- Owned feed items now expose a visibility control so you can explicitly switch a memory between `Private memory` and `Shared memory`.
-- Switching a memory to shared moves it into shared workspace scope; switching it back to private restores personal workspace scope.
+- New memories default to the shared path for projects allowed by sync filters.
+- Owned feed items expose a visibility control so you can explicitly switch a memory between `Only me` and `Share with peers`.
+- Choosing `Only me` keeps the memory local and restores personal workspace scope; choosing `Share with peers` keeps it eligible for allowed-project sync and shared workspace scope.
 - The feed supports `All`, `Mine`, and `Theirs` scopes without splitting memories into separate databases.
-- Shared memories are the only ones eligible for peer-to-peer sync; project and per-peer sync filters still narrow where shared memories flow.
+- For non-local peers, project and per-peer sync filters define the default eligible sync set, and `Only me` acts as a per-memory override.
 
 ## Viewer sync panel
 - The `Actors` section gives actor creation/rename one home, while peer cards keep assignment close to the peer being changed.

--- a/tests/test_mcp_search_filters.py
+++ b/tests/test_mcp_search_filters.py
@@ -25,7 +25,13 @@ def _seed_actor_scoped_memories(db_path: Path) -> tuple[str, int, int]:
         tool_version="test",
         project="/tmp/project-a",
     )
-    personal_id = store.remember(session, kind="note", title="Alpha", body_text="Local alpha")
+    personal_id = store.remember(
+        session,
+        kind="note",
+        title="Alpha",
+        body_text="Local alpha",
+        metadata={"visibility": "private"},
+    )
     shared_id = store.remember(
         session,
         kind="note",
@@ -93,3 +99,155 @@ def test_memory_pack_supports_workspace_filters(tmp_path: Path, monkeypatch) -> 
 
     assert [item["id"] for item in payload["items"]] == [shared_id]
     assert payload["items"][0]["metadata"]["workspace_kind"] == "shared"
+
+
+def test_memory_search_reports_widened_shared_results(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    _actor_id, personal_id, shared_id = _seed_actor_scoped_memories(db_path)
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+
+    server = build_server()
+    payload = _call_tool(
+        server,
+        "memory_search",
+        {
+            "query": "alpha",
+            "project": "/tmp/project-a",
+            "limit": 1,
+            "widen_shared_when_weak": True,
+        },
+    )
+
+    assert [item["id"] for item in payload["items"]] == [personal_id, shared_id]
+    assert payload["items"][0]["metadata"]["widened_from_shared"] is False
+    assert payload["items"][1]["metadata"]["widened_from_shared"] is True
+    assert payload["widening"]["widening_applied"] is True
+
+
+def test_memory_search_supports_trust_filters_and_bias(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    trusted_id = store.remember(
+        session,
+        kind="note",
+        title="Shared auth flow",
+        body_text="Trusted shared details",
+        metadata={
+            "actor_id": "actor:trusted",
+            "actor_display_name": "Trusted teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+            "trust_state": "trusted",
+        },
+    )
+    legacy_id = store.remember(
+        session,
+        kind="note",
+        title="Shared auth flow",
+        body_text="Legacy shared details",
+        metadata={
+            "actor_id": "actor:legacy",
+            "actor_display_name": "Legacy teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+            "trust_state": "legacy_unknown",
+        },
+    )
+    store.end_session(session)
+    store.conn.execute(
+        "UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?",
+        ("2026-01-01T00:00:00+00:00", "2026-01-01T00:00:00+00:00", trusted_id),
+    )
+    store.conn.execute(
+        "UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?",
+        ("2026-01-02T00:00:00+00:00", "2026-01-02T00:00:00+00:00", legacy_id),
+    )
+    store.conn.commit()
+    store.close()
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+
+    server = build_server()
+    filtered = _call_tool(
+        server,
+        "memory_search",
+        {
+            "query": "shared auth flow",
+            "project": "/tmp/project-a",
+            "include_trust_states": ["legacy_unknown"],
+            "personal_first": False,
+        },
+    )
+    ranked = _call_tool(
+        server,
+        "memory_search",
+        {
+            "query": "shared auth flow",
+            "project": "/tmp/project-a",
+            "personal_first": False,
+            "trust_bias": "soft",
+        },
+    )
+
+    assert [item["id"] for item in filtered["items"]] == [legacy_id]
+    assert [item["id"] for item in ranked["items"]] == [trusted_id, legacy_id]
+
+
+def test_memory_pack_reports_widened_shared_items(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    personal_id = store.remember(session, kind="note", title="Alpha", body_text="Local alpha")
+    personal_id_2 = store.remember(
+        session, kind="note", title="Alpha", body_text="Second local alpha"
+    )
+    shared_id = store.remember(
+        session,
+        kind="note",
+        title="Alpha",
+        body_text="Shared alpha",
+        metadata={
+            "actor_id": "actor:teammate",
+            "actor_display_name": "Teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+        },
+    )
+    store.end_session(session)
+    store.close()
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+
+    server = build_server()
+    payload = _call_tool(
+        server,
+        "memory_pack",
+        {
+            "context": "alpha",
+            "project": "/tmp/project-a",
+            "limit": 2,
+            "widen_shared_when_weak": True,
+        },
+    )
+
+    returned_ids = {item["id"] for item in payload["items"]}
+    assert personal_id in returned_ids or personal_id_2 in returned_ids
+    assert shared_id in returned_ids
+    assert payload["metrics"]["widening_applied"] is True
+    assert payload["metrics"]["widened_shared_items"] >= 1

--- a/tests/test_retrieval_shared_scope.py
+++ b/tests/test_retrieval_shared_scope.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codemem.store import MemoryStore
+
+
+def test_search_widens_into_shared_results_when_personal_results_are_weak(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    personal_id = store.remember(session, kind="note", title="Alpha", body_text="Local alpha")
+    shared_id = store.remember(
+        session,
+        kind="note",
+        title="Alpha",
+        body_text="Shared alpha",
+        metadata={
+            "actor_id": "actor:teammate",
+            "actor_display_name": "Teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+        },
+    )
+    store.end_session(session)
+
+    results, widening = store.search_with_diagnostics(
+        "alpha",
+        limit=1,
+        filters={"project": "/tmp/project-a", "widen_shared_when_weak": True},
+    )
+
+    assert [item.id for item in results] == [personal_id, shared_id]
+    assert results[0].metadata["widened_from_shared"] is False
+    assert results[1].metadata["widened_from_shared"] is True
+    assert widening["widening_applied"] is True
+    assert widening["personal_result_count"] == 1
+    assert widening["shared_result_count"] == 1
+
+
+def test_search_does_not_widen_for_explicitly_personal_query(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    personal_id = store.remember(session, kind="note", title="My notes", body_text="Local alpha")
+    store.remember(
+        session,
+        kind="note",
+        title="My notes",
+        body_text="Shared alpha",
+        metadata={
+            "actor_id": "actor:teammate",
+            "actor_display_name": "Teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+        },
+    )
+    store.end_session(session)
+
+    results, widening = store.search_with_diagnostics(
+        "my notes",
+        limit=1,
+        filters={"project": "/tmp/project-a", "widen_shared_when_weak": True},
+    )
+
+    assert [item.id for item in results] == [personal_id]
+    assert widening["widening_applied"] is False
+
+
+def test_search_soft_trust_bias_prefers_trusted_shared_memory(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    trusted_id = store.remember(
+        session,
+        kind="note",
+        title="Shared auth flow",
+        body_text="Trusted shared details",
+        metadata={
+            "actor_id": "actor:trusted",
+            "actor_display_name": "Trusted teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+            "trust_state": "trusted",
+        },
+    )
+    legacy_id = store.remember(
+        session,
+        kind="note",
+        title="Shared auth flow",
+        body_text="Legacy shared details",
+        metadata={
+            "actor_id": "actor:legacy",
+            "actor_display_name": "Legacy teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+            "trust_state": "legacy_unknown",
+        },
+    )
+    store.end_session(session)
+    store.conn.execute(
+        "UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?",
+        ("2026-01-01T00:00:00+00:00", "2026-01-01T00:00:00+00:00", trusted_id),
+    )
+    store.conn.execute(
+        "UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?",
+        ("2026-01-02T00:00:00+00:00", "2026-01-02T00:00:00+00:00", legacy_id),
+    )
+    store.conn.commit()
+
+    baseline = store.search(
+        "shared auth flow",
+        limit=2,
+        filters={"project": "/tmp/project-a", "personal_first": False, "trust_bias": "off"},
+    )
+    trust_biased = store.search(
+        "shared auth flow",
+        limit=2,
+        filters={"project": "/tmp/project-a", "personal_first": False, "trust_bias": "soft"},
+    )
+
+    assert [item.id for item in baseline] == [legacy_id, trusted_id]
+    assert [item.id for item in trust_biased] == [trusted_id, legacy_id]
+
+
+def test_search_soft_trust_bias_does_not_penalize_local_actor_memory(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    local_id = store.remember(
+        session,
+        kind="note",
+        title="Auth summary",
+        body_text="Local memory",
+        metadata={"trust_state": "legacy_unknown"},
+    )
+    shared_id = store.remember(
+        session,
+        kind="note",
+        title="Auth summary",
+        body_text="Trusted teammate memory",
+        metadata={
+            "actor_id": "actor:trusted",
+            "actor_display_name": "Trusted teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+            "trust_state": "trusted",
+        },
+    )
+    store.end_session(session)
+
+    results = store.search(
+        "auth summary",
+        limit=2,
+        filters={"project": "/tmp/project-a", "trust_bias": "soft"},
+    )
+
+    assert [item.id for item in results] == [local_id, shared_id]
+
+
+def test_search_soft_trust_bias_applies_with_working_set_hint(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    session = store.start_session(
+        cwd="/tmp",
+        git_remote=None,
+        git_branch="main",
+        user="tester",
+        tool_version="test",
+        project="/tmp/project-a",
+    )
+    trusted_id = store.remember_observation(
+        session,
+        kind="note",
+        title="Auth service",
+        narrative="Trusted details",
+        files_modified=["src/auth/service.py"],
+        metadata={
+            "actor_id": "actor:trusted",
+            "actor_display_name": "Trusted teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+            "trust_state": "trusted",
+        },
+    )
+    legacy_id = store.remember_observation(
+        session,
+        kind="note",
+        title="Auth service",
+        narrative="Legacy details",
+        files_modified=["src/auth/service.py"],
+        metadata={
+            "actor_id": "actor:legacy",
+            "actor_display_name": "Legacy teammate",
+            "workspace_id": "shared:team-alpha",
+            "workspace_kind": "shared",
+            "visibility": "shared",
+            "trust_state": "legacy_unknown",
+        },
+    )
+    store.end_session(session)
+    store.conn.execute(
+        "UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?",
+        ("2026-01-01T00:00:00+00:00", "2026-01-01T00:00:00+00:00", trusted_id),
+    )
+    store.conn.execute(
+        "UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?",
+        ("2026-01-02T00:00:00+00:00", "2026-01-02T00:00:00+00:00", legacy_id),
+    )
+    store.conn.commit()
+
+    results = store.search(
+        "auth service",
+        limit=2,
+        filters={
+            "project": "/tmp/project-a",
+            "personal_first": False,
+            "trust_bias": "soft",
+            "working_set_paths": ["src/auth/service.py"],
+        },
+    )
+
+    assert [item.id for item in results] == [trusted_id, legacy_id]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -525,7 +525,7 @@ def test_apply_replication_ops_preserves_actor_and_workspace_provenance(tmp_path
         store_b.close()
 
 
-def test_remember_persists_default_actor_and_personal_workspace(tmp_path: Path) -> None:
+def test_remember_persists_default_actor_and_shared_workspace(tmp_path: Path) -> None:
     store = MemoryStore(tmp_path / "mem.sqlite")
     try:
         session_id = store.start_session(
@@ -550,16 +550,16 @@ def test_remember_persists_default_actor_and_personal_workspace(tmp_path: Path) 
         assert row is not None
         assert row["actor_id"] == store.actor_id
         assert row["actor_display_name"] == store.actor_display_name
-        assert row["visibility"] == "private"
-        assert row["workspace_id"] == f"personal:{store.actor_id}"
-        assert row["workspace_kind"] == "personal"
+        assert row["visibility"] == "shared"
+        assert row["workspace_id"] == "shared:default"
+        assert row["workspace_kind"] == "shared"
         assert row["origin_device_id"] == store.device_id
         assert row["trust_state"] == "trusted"
     finally:
         store.close()
 
 
-def test_store_backfills_legacy_local_memories_to_personal_workspace(tmp_path: Path) -> None:
+def test_store_backfills_legacy_local_memories_to_shared_workspace(tmp_path: Path) -> None:
     db_path = tmp_path / "mem.sqlite"
     store = MemoryStore(db_path)
     try:
@@ -599,9 +599,9 @@ def test_store_backfills_legacy_local_memories_to_personal_workspace(tmp_path: P
         ).fetchone()
         assert row is not None
         assert row["actor_id"] == reopened.actor_id
-        assert row["visibility"] == "private"
-        assert row["workspace_id"] == f"personal:{reopened.actor_id}"
-        assert row["workspace_kind"] == "personal"
+        assert row["visibility"] == "shared"
+        assert row["workspace_id"] == "shared:default"
+        assert row["workspace_kind"] == "shared"
         assert row["trust_state"] == "trusted"
     finally:
         reopened.close()
@@ -674,7 +674,13 @@ def test_private_memories_do_not_replicate(tmp_path: Path) -> None:
             tool_version="test",
             project="codemem",
         )
-        store.remember(session_id, kind="note", title="Private", body_text="Body")
+        store.remember(
+            session_id,
+            kind="note",
+            title="Private",
+            body_text="Body",
+            metadata={"visibility": "private"},
+        )
         ops, _ = store.load_replication_ops_since(None, limit=10)
 
         filtered, _cursor, skipped = store.filter_replication_ops_for_sync_with_status(ops)
@@ -684,6 +690,75 @@ def test_private_memories_do_not_replicate(tmp_path: Path) -> None:
         assert skipped["reason"] == "visibility_filter"
     finally:
         store.close()
+
+
+def test_default_project_memories_replicate_to_non_local_peers(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        store.remember(session_id, kind="note", title="Default shared", body_text="Body")
+        ops, _ = store.load_replication_ops_since(None, limit=10)
+
+        filtered, _cursor, skipped = store.filter_replication_ops_for_sync_with_status(
+            ops, peer_device_id="peer-other"
+        )
+
+        assert len(filtered) == 1
+        assert skipped is None
+        assert filtered[0]["payload"] is not None
+        assert filtered[0]["payload"]["visibility"] == "shared"
+    finally:
+        store.close()
+
+
+def test_store_migrates_legacy_implicit_private_local_memories_to_shared(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    store = MemoryStore(db_path)
+    try:
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        memory_id = store.remember(
+            session_id, kind="note", title="Legacy default", body_text="Body"
+        )
+        store.conn.execute(
+            "UPDATE memory_items SET visibility = 'private', workspace_kind = 'personal', workspace_id = ? WHERE id = ?",
+            (f"personal:{store.actor_id}", memory_id),
+        )
+        store.conn.commit()
+    finally:
+        store.close()
+
+    reopened = MemoryStore(db_path)
+    try:
+        row = reopened.conn.execute(
+            "SELECT visibility, workspace_kind, workspace_id FROM memory_items WHERE id = ?",
+            (memory_id,),
+        ).fetchone()
+        ops, _ = reopened.load_replication_ops_since(None, limit=20)
+        filtered, _cursor, _skipped = reopened.filter_replication_ops_for_sync_with_status(
+            ops, peer_device_id="peer-other"
+        )
+
+        assert row is not None
+        assert row["visibility"] == "shared"
+        assert row["workspace_kind"] == "shared"
+        assert row["workspace_id"] == "shared:default"
+        assert any(op.get("entity_type") == "memory_item" for op in filtered)
+    finally:
+        reopened.close()
 
 
 def test_shared_memories_replicate(tmp_path: Path) -> None:
@@ -3946,6 +4021,7 @@ def test_search_filters_by_actor_and_workspace(tmp_path: Path) -> None:
         kind="note",
         title="Shared parser",
         body_text="Local parser note",
+        metadata={"visibility": "private"},
     )
     shared_id = store.remember(
         session,
@@ -4161,7 +4237,13 @@ def test_pack_filters_by_workspace_and_includes_provenance_metadata(tmp_path: Pa
         tool_version="test",
         project="/tmp/project-a",
     )
-    store.remember(session, kind="note", title="Alpha", body_text="Local alpha note")
+    store.remember(
+        session,
+        kind="note",
+        title="Alpha",
+        body_text="Local alpha note",
+        metadata={"visibility": "private"},
+    )
     shared_id = store.remember(
         session,
         kind="note",

--- a/tests/test_viewer_routes_memory.py
+++ b/tests/test_viewer_routes_memory.py
@@ -121,7 +121,13 @@ def test_observations_endpoint_supports_scope_filter(tmp_path: Path) -> None:
             tool_version="test",
             project="proj",
         )
-        mine_id = store.remember(session, kind="bugfix", title="Mine", body_text="Local note")
+        mine_id = store.remember(
+            session,
+            kind="bugfix",
+            title="Mine",
+            body_text="Local note",
+            metadata={"visibility": "private"},
+        )
         shared_id = store.remember(
             session,
             kind="bugfix",

--- a/viewer_ui/src/tabs/feed.ts
+++ b/viewer_ui/src/tabs/feed.ts
@@ -163,6 +163,11 @@ function mergeRefreshFeedItems(currentItems: any[], firstPageItems: any[]): any[
   return mergeFeedItems(olderItems, firstPageItems);
 }
 
+function replaceFeedItem(updatedItem: any) {
+  const key = itemKey(updatedItem);
+  state.lastFeedItems = state.lastFeedItems.map((item) => (itemKey(item) === key ? updatedItem : item));
+}
+
 /* ── Summary object extraction ───────────────────────────── */
 
 function getSummaryObject(item: any): Record<string, any> | null {
@@ -516,38 +521,40 @@ function renderFeedItem(item: any): HTMLElement {
       option.selected = optionData.value === visibility;
       visibilitySelect.appendChild(option);
     });
-    const visibilityButton = el('button', 'settings-button', 'Save visibility') as HTMLButtonElement;
     visibilitySelect.setAttribute('aria-label', `Visibility for ${String(item.title || 'memory')}`);
     const visibilityNote = el(
       'div',
       'feed-visibility-note',
       visibility === 'shared'
-        ? 'Shared memories can sync to trusted peers and stay in shared scope.'
-        : 'Private memories stay local unless the peer is assigned to your local actor.',
+        ? 'This memory can sync to peers allowed by your project filters.'
+        : 'This memory stays local unless the peer is assigned to your local actor.',
     );
     visibilitySelect.addEventListener('change', () => {
       visibilityNote.textContent = visibilitySelect.value === 'shared'
-        ? 'Shared memories can sync to trusted peers and stay in shared scope.'
-        : 'Private memories stay local unless the peer is assigned to your local actor.';
+        ? 'This memory can sync to peers allowed by your project filters.'
+        : 'This memory stays local unless the peer is assigned to your local actor.';
     });
-    visibilityButton.addEventListener('click', async () => {
-      visibilityButton.disabled = true;
+    visibilitySelect.addEventListener('change', async () => {
+      const previousVisibility = visibility;
       visibilitySelect.disabled = true;
-      visibilityButton.textContent = 'Saving...';
       try {
-        await api.updateMemoryVisibility(memoryId, visibilitySelect.value as 'private' | 'shared');
+        const payload = await api.updateMemoryVisibility(memoryId, visibilitySelect.value as 'private' | 'shared');
+        if (payload?.item) {
+          replaceFeedItem(payload.item);
+          updateFeedView(true);
+        }
         showGlobalNotice(visibilitySelect.value === 'shared' ? 'Memory will now sync as shared context.' : 'Memory is private again.');
-        await loadFeedData();
       } catch (error) {
+        visibilitySelect.value = previousVisibility;
+        visibilityNote.textContent = previousVisibility === 'shared'
+          ? 'This memory can sync to peers allowed by your project filters.'
+          : 'This memory stays local unless the peer is assigned to your local actor.';
         showGlobalNotice(error instanceof Error ? error.message : 'Failed to save visibility.', 'warning');
-        visibilityButton.textContent = 'Retry save';
       } finally {
-        visibilityButton.disabled = false;
         visibilitySelect.disabled = false;
-        if (visibilityButton.textContent === 'Saving...') visibilityButton.textContent = 'Save visibility';
       }
     });
-    visibilityControls.append(visibilitySelect, visibilityButton, visibilityNote);
+    visibilityControls.append(visibilitySelect, visibilityNote);
     footerLeft.appendChild(visibilityControls);
   }
   footer.append(footerLeft, footerRight);

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -64,7 +64,7 @@ function assignmentNote(actorId: string): string {
   if (actor?.is_local) {
     return 'Local actor assignment keeps this peer in your same-person continuity path, including private sync.';
   }
-  return 'Only memories marked shared sync to this actor. Existing private memories stay local until you change their visibility in the feed.';
+  return 'This actor receives memories from allowed projects by default. Use Only me on a memory when it should stay local.';
 }
 
 function buildActorOptions(selectedActorId: string): HTMLOptionElement[] {
@@ -442,7 +442,7 @@ export function renderSyncActors() {
   const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
   if (actorMeta) {
     actorMeta.textContent = actors.length
-      ? 'Create, rename, and merge actors here. Assign each peer below. Non-local actors only receive memories marked shared.'
+      ? 'Create, rename, and merge actors here. Assign each peer below. Non-local actors receive memories from allowed projects unless you mark them Only me.'
       : 'No named actors yet. Create one here, then assign peers below.';
   }
 


### PR DESCRIPTION
## Description
- implement opt-in widening from personal-first retrieval into shared context when results are weak
- add trust-state filters and soft ranking penalties for lower-confidence shared memories only
- restore project-first sharing semantics before release so allowed-project memories share by default and `Only me` remains the explicit per-memory override
- document the retrieval and sharing follow-ons and expose widening/trust diagnostics through MCP search and pack surfaces

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_store.py tests/test_sync_viewer_api.py tests/test_sync_protocol.py tests/test_mcp_search_filters.py tests/test_retrieval_shared_scope.py`
- `uv run ruff check codemem/store/_store.py codemem/store/search.py codemem/store/packs.py codemem/mcp_server.py tests/test_store.py tests/test_sync_viewer_api.py tests/test_sync_protocol.py tests/test_mcp_search_filters.py tests/test_retrieval_shared_scope.py`
- `bun run check`
- `bun run build`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced