### PR TITLE
feat: add teammate sharing review flow

### DIFF
--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -953,6 +953,76 @@ class MemoryStore:
     ) -> bool:
         return store_replication._sync_project_allowed(self, project, peer_device_id=peer_device_id)
 
+    def sharing_review_summary(self, *, project: str | None = None) -> list[dict[str, Any]]:
+        selected_project = self._clean_optional_str(project)
+        claimed_peers = self.same_actor_peer_ids()
+        legacy_actor_ids = self.claimed_same_actor_legacy_actor_ids()
+        ownership_clauses = ["memory_items.actor_id = ?"]
+        params: list[Any] = [self.actor_id]
+        if claimed_peers:
+            placeholders = ", ".join("?" for _ in claimed_peers)
+            ownership_clauses.append(f"memory_items.origin_device_id IN ({placeholders})")
+            params.extend(claimed_peers)
+        if legacy_actor_ids:
+            placeholders = ", ".join("?" for _ in legacy_actor_ids)
+            ownership_clauses.append(f"memory_items.actor_id IN ({placeholders})")
+            params.extend(legacy_actor_ids)
+        rows = self.conn.execute(
+            f"""
+            SELECT sync_peers.peer_device_id, sync_peers.name, sync_peers.actor_id,
+                   sessions.project AS project, memory_items.visibility AS visibility,
+                   COUNT(*) AS total
+            FROM sync_peers
+            JOIN memory_items ON memory_items.active = 1
+            JOIN sessions ON sessions.id = memory_items.session_id
+            WHERE sync_peers.actor_id IS NOT NULL
+              AND TRIM(sync_peers.actor_id) != ''
+              AND sync_peers.actor_id != ?
+              AND ({" OR ".join(ownership_clauses)})
+            GROUP BY sync_peers.peer_device_id, sync_peers.name, sync_peers.actor_id, sessions.project, memory_items.visibility
+            ORDER BY sync_peers.name, sync_peers.peer_device_id
+            """,
+            [self.actor_id, *params],
+        ).fetchall()
+        by_peer: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            peer_device_id = str(row["peer_device_id"])
+            actor = self.resolve_actor(str(row["actor_id"] or ""))
+            if actor is None or actor["is_local"]:
+                continue
+            project_name = self._clean_optional_str(row["project"])
+            if selected_project:
+                project_basename = self._project_basename(project_name) if project_name else ""
+                selected_basename = self._project_basename(selected_project)
+                if project_name != selected_project and project_basename != selected_basename:
+                    continue
+            if not self._sync_project_allowed(project_name, peer_device_id=peer_device_id):
+                continue
+            item = by_peer.setdefault(
+                peer_device_id,
+                {
+                    "peer_device_id": peer_device_id,
+                    "peer_name": self._clean_optional_str(row["name"]) or peer_device_id,
+                    "actor_id": actor["actor_id"],
+                    "actor_display_name": actor["display_name"],
+                    "project": selected_project,
+                    "scope_label": selected_project or "All allowed projects",
+                    "shareable_count": 0,
+                    "private_count": 0,
+                },
+            )
+            total = int(row["total"] or 0)
+            if str(row["visibility"] or "") == "private":
+                item["private_count"] += total
+            else:
+                item["shareable_count"] += total
+        results = list(by_peer.values())
+        for item in results:
+            item["total_count"] = item["shareable_count"] + item["private_count"]
+        return sorted(
+            results, key=lambda item: (str(item["peer_name"]).lower(), item["peer_device_id"])
+        )
+
     def count_replication_ops_missing_project(self) -> int:
         return store_replication.count_replication_ops_missing_project(self)
 

--- a/codemem/viewer_routes/sync.py
+++ b/codemem/viewer_routes/sync.py
@@ -128,6 +128,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
             "true",
             "yes",
         }
+        project = str(params.get("project", [""])[0] or "").strip() or None
         config = _viewer.load_config()
         device_row = store.conn.execute(
             "SELECT device_id, fingerprint FROM sync_device LIMIT 1"
@@ -252,6 +253,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
             item["address"] = _attempt_address(item)
             attempts_items.append(item)
         legacy_devices = store.claimable_legacy_device_ids()
+        sharing_review = store.sharing_review_summary(project=project)
 
         if daemon_state_value == "ok":
             peer_states = {
@@ -294,6 +296,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                 "peers": peers_items,
                 "attempts": attempts_items[:5],
                 "legacy_devices": legacy_devices,
+                "sharing_review": sharing_review,
             }
         )
         return True

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -131,6 +131,7 @@
     lastSyncStatus: null,
     lastSyncActors: [],
     lastSyncPeers: [],
+    lastSyncSharingReview: [],
     lastSyncAttempts: [],
     lastSyncLegacyDevices: [],
     pairingPayloadRaw: null,
@@ -266,9 +267,12 @@
     }
     return parsed;
   }
-  async function loadSyncStatus(includeDiagnostics) {
-    const param = "?includeDiagnostics=1";
-    return fetchJson(`/api/sync/status${param}`);
+  async function loadSyncStatus(includeDiagnostics, project = "") {
+    const params = new URLSearchParams();
+    params.set("includeDiagnostics", "1");
+    if (project) params.set("project", project);
+    const suffix = params.size ? `?${params.toString()}` : "";
+    return fetchJson(`/api/sync/status${suffix}`);
   }
   async function loadSyncActors() {
     return fetchJson("/api/sync/actors");
@@ -1953,6 +1957,49 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       actorList.appendChild(row);
     });
   }
+  function openFeedSharingReview() {
+    setFeedScopeFilter("mine");
+    state.feedQuery = "";
+    window.location.hash = "feed";
+  }
+  function renderSyncSharingReview() {
+    const panel = document.getElementById("syncSharingReview");
+    const meta = document.getElementById("syncSharingReviewMeta");
+    const list = document.getElementById("syncSharingReviewList");
+    if (!panel || !meta || !list) return;
+    list.textContent = "";
+    const items = Array.isArray(state.lastSyncSharingReview) ? state.lastSyncSharingReview : [];
+    if (!items.length) {
+      panel.hidden = true;
+      return;
+    }
+    panel.hidden = false;
+    const scopeLabel = state.currentProject ? `current project (${state.currentProject})` : "all allowed projects";
+    meta.textContent = `Teammate peers receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
+    items.forEach((item) => {
+      const row = el("div", "actor-row");
+      const details = el("div", "actor-details");
+      const title = el("div", "actor-title");
+      title.append(
+        el("strong", null, String(item.peer_name || item.peer_device_id || "Peer")),
+        el("span", "badge actor-badge", `actor: ${String(item.actor_display_name || item.actor_id || "unknown")}`)
+      );
+      const note = el(
+        "div",
+        "peer-meta",
+        `${Number(item.shareable_count || 0)} share by default · ${Number(item.private_count || 0)} marked Only me · ${String(item.scope_label || "All allowed projects")}`
+      );
+      details.append(title, note);
+      const actions = el("div", "actor-actions");
+      const reviewBtn = el("button", "settings-button", "Review my memories in Feed");
+      reviewBtn.addEventListener("click", () => {
+        openFeedSharingReview();
+      });
+      actions.appendChild(reviewBtn);
+      row.append(details, actions);
+      list.appendChild(row);
+    });
+  }
   function renderLegacyDeviceClaims() {
     const panel = document.getElementById("syncLegacyClaims");
     const select = document.getElementById("syncLegacyDeviceSelect");
@@ -2034,7 +2081,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   }
   async function loadSyncData() {
     try {
-      const payload = await loadSyncStatus(true);
+      const payload = await loadSyncStatus(true, state.currentProject || "");
       let actorsPayload = null;
       let actorLoadError = false;
       try {
@@ -2046,10 +2093,12 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       if (statusPayload) state.lastSyncStatus = statusPayload;
       state.lastSyncActors = Array.isArray(actorsPayload?.items) ? actorsPayload.items : [];
       state.lastSyncPeers = payload.peers || [];
+      state.lastSyncSharingReview = payload.sharing_review || [];
       state.lastSyncAttempts = payload.attempts || [];
       state.lastSyncLegacyDevices = payload.legacy_devices || [];
       renderSyncStatus();
       renderSyncActors();
+      renderSyncSharingReview();
       renderSyncPeers();
       renderLegacyDeviceClaims();
       renderSyncAttempts();

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1555,6 +1555,12 @@
         <div class="peer-list" id="syncPeers"></div>
       </div>
 
+      <div class="card" id="syncSharingReview" style="animation-delay: 0.06s" hidden>
+        <h2>Review what teammates will receive</h2>
+        <div class="section-meta" id="syncSharingReviewMeta"></div>
+        <div class="actor-list" id="syncSharingReviewList"></div>
+      </div>
+
       <div class="card" id="syncLegacyClaims" style="animation-delay: 0.08s" hidden>
         <h2>Attach old device history to local actor</h2>
         <div class="peer-meta" id="syncLegacyClaimsMeta"></div>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -142,6 +142,7 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 - Assigning a peer to a non-local actor keeps that peer's history shared; assigning it to your local actor keeps it personal/private.
 - Non-local actors receive memories from projects allowed by their include/exclude filters by default.
 - Use `Only me` on a memory when it should stay local and not sync to non-local actors.
+- The Sync panel also shows a teammate review card with per-peer counts for memories that will share by default versus memories marked `Only me`, plus a one-click jump into `My memories` in the Feed for review.
 
 ### One-off sync
 

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -100,6 +100,95 @@ def test_sync_status_endpoint(tmp_path: Path, monkeypatch) -> None:
         server.shutdown()
 
 
+def test_sync_status_endpoint_includes_sharing_review_for_teammate_peer(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    _monkeypatch_sync_enabled(monkeypatch)
+    store = MemoryStore(db_path)
+    try:
+        actor = store.create_actor(display_name="Teammate")
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, actor_id, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-1", "[]", actor["actor_id"], "2026-01-24T00:00:00Z"),
+        )
+        session_id = store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="project-a",
+        )
+        store.remember(session_id, kind="note", title="Shared", body_text="Shared body")
+        store.remember(
+            session_id,
+            kind="note",
+            title="Private",
+            body_text="Private body",
+            metadata={"visibility": "private"},
+        )
+        store.end_session(session_id)
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/api/sync/status?project=project-a")
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        review = payload["sharing_review"]
+        assert len(review) == 1
+        assert review[0]["peer_device_id"] == "peer-1"
+        assert review[0]["shareable_count"] == 1
+        assert review[0]["private_count"] == 1
+        assert review[0]["scope_label"] == "project-a"
+    finally:
+        server.shutdown()
+
+
+def test_sync_status_sharing_review_matches_project_basename(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    _monkeypatch_sync_enabled(monkeypatch)
+    store = MemoryStore(db_path)
+    try:
+        actor = store.create_actor(display_name="Teammate")
+        store.conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, actor_id, created_at) VALUES (?, ?, ?, ?)",
+            ("peer-1", "[]", actor["actor_id"], "2026-01-24T00:00:00Z"),
+        )
+        session_id = store.start_session(
+            cwd=str(tmp_path / "repo"),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project=str(tmp_path / "repo"),
+        )
+        store.remember(session_id, kind="note", title="Shared", body_text="Shared body")
+        store.end_session(session_id)
+    finally:
+        store.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/api/sync/status?project=repo")
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        review = payload["sharing_review"]
+        assert len(review) == 1
+        assert review[0]["shareable_count"] == 1
+        assert review[0]["scope_label"] == "repo"
+    finally:
+        server.shutdown()
+
+
 def test_sync_peers_endpoint_exposes_project_scope(tmp_path: Path, monkeypatch) -> None:
     db_path = tmp_path / "mem.sqlite"
     monkeypatch.setenv("CODEMEM_DB", str(db_path))

--- a/viewer_ui/src/lib/api.ts
+++ b/viewer_ui/src/lib/api.ts
@@ -96,9 +96,12 @@ export async function saveConfig(payload: any): Promise<void> {
   return parsed;
 }
 
-export async function loadSyncStatus(includeDiagnostics: boolean): Promise<any> {
-  const param = includeDiagnostics ? '?includeDiagnostics=1' : '';
-  return fetchJson(`/api/sync/status${param}`);
+export async function loadSyncStatus(includeDiagnostics: boolean, project = ''): Promise<any> {
+  const params = new URLSearchParams();
+  if (includeDiagnostics) params.set('includeDiagnostics', '1');
+  if (project) params.set('project', project);
+  const suffix = params.size ? `?${params.toString()}` : '';
+  return fetchJson(`/api/sync/status${suffix}`);
 }
 
 export async function loadSyncActors(): Promise<any> {

--- a/viewer_ui/src/lib/state.ts
+++ b/viewer_ui/src/lib/state.ts
@@ -52,6 +52,7 @@ export const state = {
   lastSyncStatus: null as any,
   lastSyncActors: [] as any[],
   lastSyncPeers: [] as any[],
+  lastSyncSharingReview: [] as any[],
   lastSyncAttempts: [] as any[],
   lastSyncLegacyDevices: [] as any[],
   pairingPayloadRaw: null as any,

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -5,6 +5,7 @@ import { formatAgeShort, formatTimestamp, secondsSince, titleCase } from '../lib
 import {
   state,
   isSyncPairingOpen,
+  setFeedScopeFilter,
   setSyncPairingOpen,
   isSyncRedactionEnabled,
   setSyncRedactionEnabled,
@@ -552,6 +553,51 @@ export function renderSyncActors() {
   });
 }
 
+function openFeedSharingReview() {
+  setFeedScopeFilter('mine');
+  state.feedQuery = '';
+  window.location.hash = 'feed';
+}
+
+export function renderSyncSharingReview() {
+  const panel = document.getElementById('syncSharingReview');
+  const meta = document.getElementById('syncSharingReviewMeta');
+  const list = document.getElementById('syncSharingReviewList');
+  if (!panel || !meta || !list) return;
+  list.textContent = '';
+  const items = Array.isArray(state.lastSyncSharingReview) ? state.lastSyncSharingReview : [];
+  if (!items.length) {
+    (panel as any).hidden = true;
+    return;
+  }
+  (panel as any).hidden = false;
+  const scopeLabel = state.currentProject ? `current project (${state.currentProject})` : 'all allowed projects';
+  meta.textContent = `Teammate peers receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
+  items.forEach((item) => {
+    const row = el('div', 'actor-row');
+    const details = el('div', 'actor-details');
+    const title = el('div', 'actor-title');
+    title.append(
+      el('strong', null, String(item.peer_name || item.peer_device_id || 'Peer')),
+      el('span', 'badge actor-badge', `actor: ${String(item.actor_display_name || item.actor_id || 'unknown')}`),
+    );
+    const note = el(
+      'div',
+      'peer-meta',
+      `${Number(item.shareable_count || 0)} share by default · ${Number(item.private_count || 0)} marked Only me · ${String(item.scope_label || 'All allowed projects')}`,
+    );
+    details.append(title, note);
+    const actions = el('div', 'actor-actions');
+    const reviewBtn = el('button', 'settings-button', 'Review my memories in Feed') as HTMLButtonElement;
+    reviewBtn.addEventListener('click', () => {
+      openFeedSharingReview();
+    });
+    actions.appendChild(reviewBtn);
+    row.append(details, actions);
+    list.appendChild(row);
+  });
+}
+
 export function renderLegacyDeviceClaims() {
   const panel = document.getElementById('syncLegacyClaims');
   const select = document.getElementById('syncLegacyDeviceSelect') as HTMLSelectElement | null;
@@ -647,7 +693,7 @@ export function renderPairing() {
 
 export async function loadSyncData() {
   try {
-    const payload = await api.loadSyncStatus(true);
+    const payload = await api.loadSyncStatus(true, state.currentProject || '');
     let actorsPayload: any = null;
     let actorLoadError = false;
     try {
@@ -659,10 +705,12 @@ export async function loadSyncData() {
     if (statusPayload) state.lastSyncStatus = statusPayload;
     state.lastSyncActors = Array.isArray(actorsPayload?.items) ? actorsPayload.items : [];
     state.lastSyncPeers = payload.peers || [];
+    state.lastSyncSharingReview = payload.sharing_review || [];
     state.lastSyncAttempts = payload.attempts || [];
     state.lastSyncLegacyDevices = payload.legacy_devices || [];
     renderSyncStatus();
     renderSyncActors();
+    renderSyncSharingReview();
     renderSyncPeers();
     renderLegacyDeviceClaims();
     renderSyncAttempts();


### PR DESCRIPTION
## Description
- add a Sync-tab review card that shows, per teammate peer, how many of your memories will share by default versus stay local as `Only me`
- scope the review summary to the current project when selected, and add a one-click jump into `My memories` in the Feed for review
- document the new onboarding/review flow in the user guide

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_sync_viewer_api.py`
- `uv run ruff check codemem/store/_store.py codemem/viewer_routes/sync.py tests/test_sync_viewer_api.py`
- `bun run check`
- `bun run build`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced