### PR TITLE
feat: add built-in coordinator discovery service

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -78,6 +78,11 @@ from .commands.sync_cmds import (
     sync_status_cmd,
     sync_uninstall_cmd,
 )
+from .commands.sync_coordinator_cmds import (
+    coordinator_enroll_device_cmd,
+    coordinator_group_create_cmd,
+    coordinator_serve_cmd,
+)
 from .commands.sync_service_cmds import install_autostart_quiet as _install_autostart_quiet
 from .commands.sync_service_cmds import run_service_action as _run_service_action
 from .commands.sync_service_cmds import run_service_action_quiet as _run_service_action_quiet
@@ -110,10 +115,12 @@ from .viewer import DEFAULT_VIEWER_HOST, DEFAULT_VIEWER_PORT
 app = typer.Typer(help="codemem: persistent memory for OpenCode CLI")
 sync_app = typer.Typer(help="Sync codemem between devices")
 sync_peers_app = typer.Typer(help="Manage sync peers")
+sync_coordinator_app = typer.Typer(help="Run or manage coordinator-backed discovery")
 serve_app = typer.Typer(help="Run or manage the viewer", invoke_without_command=True)
 db_app = typer.Typer(help="Database maintenance")
 app.add_typer(sync_app, name="sync")
 sync_app.add_typer(sync_peers_app, name="peers")
+sync_app.add_typer(sync_coordinator_app, name="coordinator")
 app.add_typer(serve_app, name="serve")
 app.add_typer(db_app, name="db")
 
@@ -1123,6 +1130,46 @@ def sync_daemon(
         host=host,
         port=port,
         interval_s=interval_s,
+    )
+
+
+@sync_coordinator_app.command("serve")
+def sync_coordinator_serve(
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+    host: str = typer.Option("127.0.0.1", help="Host to bind coordinator server"),
+    port: int = typer.Option(7347, help="Port to bind coordinator server"),
+) -> None:
+    """Run the built-in coordinator discovery service."""
+    coordinator_serve_cmd(db_path=db_path, host=host, port=port)
+
+
+@sync_coordinator_app.command("group-create")
+def sync_coordinator_group_create(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    name: str | None = typer.Option(None, help="Optional display name"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """Create a coordinator group."""
+    coordinator_group_create_cmd(group_id=group_id, name=name, db_path=db_path)
+
+
+@sync_coordinator_app.command("enroll-device")
+def sync_coordinator_enroll_device(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    device_id: str = typer.Argument(..., help="Device ID to enroll"),
+    fingerprint: str = typer.Option(..., help="Pinned fingerprint for the device"),
+    public_key_file: str = typer.Option(..., help="Path to the device public key file"),
+    name: str | None = typer.Option(None, help="Optional display name"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """Enroll a device into a coordinator group."""
+    coordinator_enroll_device_cmd(
+        group_id=group_id,
+        device_id=device_id,
+        fingerprint=fingerprint,
+        public_key_file=public_key_file,
+        name=name,
+        db_path=db_path,
     )
 
 

--- a/codemem/commands/sync_coordinator_cmds.py
+++ b/codemem/commands/sync_coordinator_cmds.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from http.server import HTTPServer
+from pathlib import Path
+
+from rich import print
+
+from ..coordinator_api import build_coordinator_handler
+from ..coordinator_store import DEFAULT_COORDINATOR_DB_PATH, CoordinatorStore
+
+
+def coordinator_serve_cmd(*, db_path: str | None, host: str, port: int) -> None:
+    resolved_db = Path(db_path or DEFAULT_COORDINATOR_DB_PATH).expanduser()
+    store = CoordinatorStore(resolved_db)
+    store.close()
+    handler = build_coordinator_handler(resolved_db)
+    server = HTTPServer((host, port), handler)
+    print(f"[green]Coordinator listening[/green] {host}:{port}")
+    print(f"- DB: {resolved_db}")
+    server.serve_forever()
+
+
+def coordinator_group_create_cmd(*, group_id: str, name: str | None, db_path: str | None) -> None:
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        store.create_group(group_id, display_name=name)
+    finally:
+        store.close()
+    print(f"[green]Created coordinator group[/green] {group_id}")
+
+
+def coordinator_enroll_device_cmd(
+    *,
+    group_id: str,
+    device_id: str,
+    fingerprint: str,
+    public_key_file: str,
+    name: str | None,
+    db_path: str | None,
+) -> None:
+    public_key = Path(public_key_file).expanduser().read_text().strip()
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        store.create_group(group_id)
+        store.enroll_device(
+            group_id,
+            device_id=device_id,
+            fingerprint=fingerprint,
+            public_key=public_key,
+            display_name=name,
+        )
+    finally:
+        store.close()
+    print(f"[green]Enrolled device[/green] {device_id} -> {group_id}")

--- a/codemem/config.py
+++ b/codemem/config.py
@@ -38,6 +38,10 @@ CONFIG_ENV_OVERRIDES = {
     "sync_mdns": "CODEMEM_SYNC_MDNS",
     "sync_key_store": "CODEMEM_SYNC_KEY_STORE",
     "sync_advertise": "CODEMEM_SYNC_ADVERTISE",
+    "sync_coordinator_url": "CODEMEM_SYNC_COORDINATOR_URL",
+    "sync_coordinator_group": "CODEMEM_SYNC_COORDINATOR_GROUP",
+    "sync_coordinator_timeout_s": "CODEMEM_SYNC_COORDINATOR_TIMEOUT_S",
+    "sync_coordinator_presence_ttl_s": "CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S",
     "sync_projects_include": "CODEMEM_SYNC_PROJECTS_INCLUDE",
     "sync_projects_exclude": "CODEMEM_SYNC_PROJECTS_EXCLUDE",
     "raw_events_sweeper_interval_s": "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
@@ -227,6 +231,10 @@ class OpencodeMemConfig:
     sync_key_store: str = "file"
 
     sync_advertise: str = "auto"
+    sync_coordinator_url: str | None = None
+    sync_coordinator_group: str | None = None
+    sync_coordinator_timeout_s: int = 3
+    sync_coordinator_presence_ttl_s: int = 180
 
     raw_events_sweeper_interval_s: int = 30
 
@@ -425,6 +433,8 @@ def _apply_dict(cfg: OpencodeMemConfig, data: dict[str, Any]) -> OpencodeMemConf
             "plugin_cmd_timeout_ms",
             "sync_port",
             "sync_interval_s",
+            "sync_coordinator_timeout_s",
+            "sync_coordinator_presence_ttl_s",
             "raw_events_sweeper_interval_s",
         }:
             setattr(cfg, key, _parse_int(value, getattr(cfg, key), key=key))
@@ -581,6 +591,20 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
     cfg.sync_mdns = _parse_bool(os.getenv("CODEMEM_SYNC_MDNS"), cfg.sync_mdns)
     cfg.sync_key_store = os.getenv("CODEMEM_SYNC_KEY_STORE", cfg.sync_key_store)
     cfg.sync_advertise = os.getenv("CODEMEM_SYNC_ADVERTISE", cfg.sync_advertise)
+    cfg.sync_coordinator_url = os.getenv("CODEMEM_SYNC_COORDINATOR_URL", cfg.sync_coordinator_url)
+    cfg.sync_coordinator_group = os.getenv(
+        "CODEMEM_SYNC_COORDINATOR_GROUP", cfg.sync_coordinator_group
+    )
+    cfg.sync_coordinator_timeout_s = _parse_int(
+        os.getenv("CODEMEM_SYNC_COORDINATOR_TIMEOUT_S"),
+        cfg.sync_coordinator_timeout_s,
+        key="sync_coordinator_timeout_s",
+    )
+    cfg.sync_coordinator_presence_ttl_s = _parse_int(
+        os.getenv("CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S"),
+        cfg.sync_coordinator_presence_ttl_s,
+        key="sync_coordinator_presence_ttl_s",
+    )
 
     include = _coerce_str_list(
         os.getenv("CODEMEM_SYNC_PROJECTS_INCLUDE"), key="sync_projects_include"

--- a/codemem/coordinator_api.py
+++ b/codemem/coordinator_api.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from .coordinator_store import DEFAULT_COORDINATOR_DB_PATH, CoordinatorStore
+from .sync_auth import DEFAULT_TIME_WINDOW_S, verify_signature
+
+MAX_COORDINATOR_BODY_BYTES = 64 * 1024
+
+
+def _send_json(handler: BaseHTTPRequestHandler, payload: dict[str, Any], status: int = 200) -> None:
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json; charset=utf-8")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def _path_with_query(path: str) -> str:
+    parsed = urlparse(path)
+    return f"{parsed.path}?{parsed.query}" if parsed.query else parsed.path
+
+
+def _read_body(handler: BaseHTTPRequestHandler) -> bytes:
+    length = int(handler.headers.get("Content-Length", "0") or 0)
+    if length > MAX_COORDINATOR_BODY_BYTES:
+        raise ValueError("body_too_large")
+    return handler.rfile.read(length) if length > 0 else b""
+
+
+def _parse_json_body(raw: bytes) -> dict[str, Any] | None:
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _record_nonce(store: CoordinatorStore, *, device_id: str, nonce: str, created_at: str) -> bool:
+    try:
+        store.conn.execute(
+            "INSERT INTO request_nonces(device_id, nonce, created_at) VALUES (?, ?, ?)",
+            (device_id, nonce, created_at),
+        )
+        store.conn.commit()
+        return True
+    except Exception:
+        return False
+
+
+def _cleanup_nonces(store: CoordinatorStore, *, cutoff: str) -> None:
+    store.conn.execute("DELETE FROM request_nonces WHERE created_at < ?", (cutoff,))
+    store.conn.commit()
+
+
+def _authorize_request(
+    store: CoordinatorStore,
+    handler: BaseHTTPRequestHandler,
+    *,
+    group_id: str,
+    body: bytes,
+) -> tuple[bool, str, dict[str, Any] | None]:
+    device_id = handler.headers.get("X-Opencode-Device")
+    signature = handler.headers.get("X-Opencode-Signature")
+    timestamp = handler.headers.get("X-Opencode-Timestamp")
+    nonce = handler.headers.get("X-Opencode-Nonce")
+    if not device_id or not signature or not timestamp or not nonce:
+        return False, "missing_headers", None
+    enrollment = store.get_enrollment(group_id=group_id, device_id=device_id)
+    if enrollment is None:
+        return False, "unknown_device", None
+    try:
+        ok = verify_signature(
+            method=handler.command,
+            path_with_query=_path_with_query(handler.path),
+            body_bytes=body,
+            timestamp=timestamp,
+            nonce=nonce,
+            signature=signature,
+            public_key=str(enrollment["public_key"]),
+            device_id=device_id,
+        )
+    except Exception:
+        return False, "signature_verification_error", None
+    if not ok:
+        return False, "invalid_signature", None
+    created_at = dt.datetime.now(dt.UTC).isoformat()
+    if not _record_nonce(store, device_id=device_id, nonce=nonce, created_at=created_at):
+        return False, "nonce_replay", None
+    cutoff = (dt.datetime.now(dt.UTC) - dt.timedelta(seconds=DEFAULT_TIME_WINDOW_S * 2)).isoformat()
+    _cleanup_nonces(store, cutoff=cutoff)
+    return True, "ok", enrollment
+
+
+def build_coordinator_handler(db_path: Path | None = None):
+    resolved_db = Path(db_path or DEFAULT_COORDINATOR_DB_PATH).expanduser()
+
+    class CoordinatorHandler(BaseHTTPRequestHandler):
+        def _store(self) -> CoordinatorStore:
+            return CoordinatorStore(resolved_db)
+
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != "/v1/presence":
+                _send_json(self, {"error": "not_found"}, status=404)
+                return
+            store = self._store()
+            try:
+                try:
+                    raw = _read_body(self)
+                except ValueError as exc:
+                    if str(exc) == "body_too_large":
+                        _send_json(self, {"error": "body_too_large"}, status=413)
+                        return
+                    raise
+                data = _parse_json_body(raw)
+                if data is None:
+                    _send_json(self, {"error": "invalid_json"}, status=400)
+                    return
+                group_id = str(data.get("group_id") or "").strip()
+                if not group_id:
+                    _send_json(self, {"error": "group_id_required"}, status=400)
+                    return
+                ok, reason, enrollment = _authorize_request(
+                    store, self, group_id=group_id, body=raw
+                )
+                if not ok or enrollment is None:
+                    _send_json(self, {"error": reason}, status=401)
+                    return
+                if data.get("fingerprint") and str(data.get("fingerprint")) != str(
+                    enrollment["fingerprint"]
+                ):
+                    _send_json(self, {"error": "fingerprint_mismatch"}, status=401)
+                    return
+                raw_addresses = data.get("addresses") or []
+                if not isinstance(raw_addresses, list) or not all(
+                    isinstance(item, str) for item in raw_addresses
+                ):
+                    _send_json(self, {"error": "addresses_must_be_list_of_strings"}, status=400)
+                    return
+                try:
+                    ttl_s = max(1, int(data.get("ttl_s") or 180))
+                except (TypeError, ValueError):
+                    _send_json(self, {"error": "ttl_s_must_be_int"}, status=400)
+                    return
+                response = store.upsert_presence(
+                    group_id=group_id,
+                    device_id=str(enrollment["device_id"]),
+                    addresses=raw_addresses,
+                    ttl_s=ttl_s,
+                    capabilities=data.get("capabilities")
+                    if isinstance(data.get("capabilities"), dict)
+                    else None,
+                )
+                _send_json(self, {"ok": True, **response})
+            finally:
+                store.close()
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != "/v1/peers":
+                _send_json(self, {"error": "not_found"}, status=404)
+                return
+            params = parse_qs(parsed.query)
+            group_id = str(params.get("group_id", [""])[0] or "").strip()
+            if not group_id:
+                _send_json(self, {"error": "group_id_required"}, status=400)
+                return
+            store = self._store()
+            try:
+                ok, reason, enrollment = _authorize_request(
+                    store, self, group_id=group_id, body=b""
+                )
+                if not ok or enrollment is None:
+                    _send_json(self, {"error": reason}, status=401)
+                    return
+                items = store.list_group_peers(
+                    group_id=group_id,
+                    requesting_device_id=str(enrollment["device_id"]),
+                )
+                _send_json(self, {"items": items})
+            finally:
+                store.close()
+
+    return CoordinatorHandler

--- a/codemem/coordinator_store.py
+++ b/codemem/coordinator_store.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from .sync.discovery import merge_addresses
+
+DEFAULT_COORDINATOR_DB_PATH = Path.home() / ".codemem" / "coordinator.sqlite"
+
+
+def connect(path: Path | str | None = None) -> sqlite3.Connection:
+    db_path = Path(path or DEFAULT_COORDINATOR_DB_PATH).expanduser()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    initialize_schema(conn)
+    return conn
+
+
+def initialize_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS groups (
+            group_id TEXT PRIMARY KEY,
+            display_name TEXT,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS enrolled_devices (
+            group_id TEXT NOT NULL,
+            device_id TEXT NOT NULL,
+            public_key TEXT NOT NULL,
+            fingerprint TEXT NOT NULL,
+            display_name TEXT,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (group_id, device_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS presence_records (
+            group_id TEXT NOT NULL,
+            device_id TEXT NOT NULL,
+            addresses_json TEXT NOT NULL,
+            last_seen_at TEXT NOT NULL,
+            expires_at TEXT NOT NULL,
+            capabilities_json TEXT NOT NULL DEFAULT '{}',
+            PRIMARY KEY (group_id, device_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS request_nonces (
+            device_id TEXT NOT NULL,
+            nonce TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (device_id, nonce)
+        )
+        """
+    )
+    conn.commit()
+
+
+class CoordinatorStore:
+    def __init__(self, path: Path | str | None = None) -> None:
+        self.path = Path(path or DEFAULT_COORDINATOR_DB_PATH).expanduser()
+        self.conn = connect(self.path)
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def create_group(self, group_id: str, *, display_name: str | None = None) -> None:
+        now = dt.datetime.now(dt.UTC).isoformat()
+        self.conn.execute(
+            "INSERT OR IGNORE INTO groups(group_id, display_name, created_at) VALUES (?, ?, ?)",
+            (group_id, display_name, now),
+        )
+        self.conn.commit()
+
+    def enroll_device(
+        self,
+        group_id: str,
+        *,
+        device_id: str,
+        fingerprint: str,
+        public_key: str,
+        display_name: str | None = None,
+    ) -> None:
+        now = dt.datetime.now(dt.UTC).isoformat()
+        self.conn.execute(
+            """
+            INSERT INTO enrolled_devices(
+                group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+            ) VALUES (?, ?, ?, ?, ?, 1, ?)
+            ON CONFLICT(group_id, device_id) DO UPDATE SET
+                public_key = excluded.public_key,
+                fingerprint = excluded.fingerprint,
+                display_name = excluded.display_name,
+                enabled = 1
+            """,
+            (group_id, device_id, public_key, fingerprint, display_name, now),
+        )
+        self.conn.commit()
+
+    def get_enrollment(self, *, group_id: str, device_id: str) -> dict[str, Any] | None:
+        row = self.conn.execute(
+            """
+            SELECT device_id, public_key, fingerprint, display_name
+            FROM enrolled_devices
+            WHERE group_id = ? AND device_id = ? AND enabled = 1
+            """,
+            (group_id, device_id),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def upsert_presence(
+        self,
+        *,
+        group_id: str,
+        device_id: str,
+        addresses: list[str],
+        ttl_s: int,
+        capabilities: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        now = dt.datetime.now(dt.UTC)
+        expires_at = (now + dt.timedelta(seconds=ttl_s)).isoformat()
+        normalized = merge_addresses([], addresses)
+        self.conn.execute(
+            """
+            INSERT INTO presence_records(group_id, device_id, addresses_json, last_seen_at, expires_at, capabilities_json)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(group_id, device_id) DO UPDATE SET
+                addresses_json = excluded.addresses_json,
+                last_seen_at = excluded.last_seen_at,
+                expires_at = excluded.expires_at,
+                capabilities_json = excluded.capabilities_json
+            """,
+            (
+                group_id,
+                device_id,
+                json.dumps(normalized, ensure_ascii=False),
+                now.isoformat(),
+                expires_at,
+                json.dumps(capabilities or {}, ensure_ascii=False),
+            ),
+        )
+        self.conn.commit()
+        return {
+            "group_id": group_id,
+            "device_id": device_id,
+            "addresses": normalized,
+            "expires_at": expires_at,
+        }
+
+    def list_group_peers(self, *, group_id: str, requesting_device_id: str) -> list[dict[str, Any]]:
+        now = dt.datetime.now(dt.UTC)
+        rows = self.conn.execute(
+            """
+            SELECT enrolled_devices.device_id, enrolled_devices.fingerprint, enrolled_devices.display_name,
+                   presence_records.addresses_json, presence_records.last_seen_at, presence_records.expires_at,
+                   presence_records.capabilities_json
+            FROM enrolled_devices
+            LEFT JOIN presence_records
+              ON presence_records.group_id = enrolled_devices.group_id
+             AND presence_records.device_id = enrolled_devices.device_id
+            WHERE enrolled_devices.group_id = ?
+              AND enrolled_devices.enabled = 1
+              AND enrolled_devices.device_id != ?
+            ORDER BY enrolled_devices.device_id ASC
+            """,
+            (group_id, requesting_device_id),
+        ).fetchall()
+        items: list[dict[str, Any]] = []
+        for row in rows:
+            expires_raw = str(row["expires_at"] or "").strip()
+            stale = True
+            if expires_raw:
+                try:
+                    expires_at = dt.datetime.fromisoformat(expires_raw.replace("Z", "+00:00"))
+                    if expires_at.tzinfo is None:
+                        expires_at = expires_at.replace(tzinfo=dt.UTC)
+                    stale = expires_at <= now
+                except ValueError:
+                    stale = True
+            addresses = (
+                [] if stale else merge_addresses([], json.loads(row["addresses_json"] or "[]"))
+            )
+            items.append(
+                {
+                    "device_id": row["device_id"],
+                    "fingerprint": row["fingerprint"],
+                    "display_name": row["display_name"],
+                    "addresses": addresses,
+                    "last_seen_at": row["last_seen_at"],
+                    "expires_at": row["expires_at"],
+                    "stale": stale,
+                    "capabilities": json.loads(row["capabilities_json"] or "{}"),
+                }
+            )
+        return items

--- a/codemem/sync/coordinator.py
+++ b/codemem/sync/coordinator.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode, urlparse
+
+from ..config import OpencodeMemConfig, load_config
+from ..net import pick_advertise_hosts
+from ..store import MemoryStore
+from ..sync_auth import build_auth_headers
+from ..sync_identity import ensure_device_identity, load_public_key
+from . import discovery, http_client
+
+
+def coordinator_enabled(config: OpencodeMemConfig | None = None) -> bool:
+    cfg = config or load_config()
+    return bool(
+        str(cfg.sync_coordinator_url or "").strip()
+        and str(cfg.sync_coordinator_group or "").strip()
+    )
+
+
+def _coordinator_base_url(config: OpencodeMemConfig) -> str:
+    return http_client.build_base_url(str(config.sync_coordinator_url or "").strip())
+
+
+def _keys_dir() -> Path | None:
+    value = os.environ.get("CODEMEM_KEYS_DIR")
+    return Path(value).expanduser() if value else None
+
+
+def _advertised_sync_addresses(config: OpencodeMemConfig) -> list[str]:
+    addresses: list[str] = []
+    for host in pick_advertise_hosts(config.sync_advertise):
+        host_value = host.strip()
+        if not host_value:
+            continue
+        parsed = urlparse(host_value)
+        if parsed.scheme:
+            addresses.append(http_client.build_base_url(host_value))
+            continue
+        addresses.append(http_client.build_base_url(f"http://{host_value}:{config.sync_port}"))
+    return discovery.merge_addresses([], addresses)
+
+
+def register_presence(
+    store: MemoryStore, *, config: OpencodeMemConfig | None = None
+) -> dict[str, Any] | None:
+    cfg = config or load_config()
+    if not coordinator_enabled(cfg):
+        return None
+    keys_dir = _keys_dir()
+    device_id, fingerprint = ensure_device_identity(store.conn, keys_dir=keys_dir)
+    public_key = load_public_key(keys_dir)
+    if not public_key:
+        raise RuntimeError("public key missing")
+    base_url = _coordinator_base_url(cfg)
+    if not base_url:
+        raise RuntimeError("coordinator url missing")
+    payload = {
+        "group_id": str(cfg.sync_coordinator_group or "").strip(),
+        "fingerprint": fingerprint,
+        "public_key": public_key,
+        "addresses": _advertised_sync_addresses(cfg),
+        "ttl_s": max(1, int(cfg.sync_coordinator_presence_ttl_s)),
+    }
+    body_bytes = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    url = f"{base_url}/v1/presence"
+    headers = build_auth_headers(
+        device_id=device_id,
+        method="POST",
+        url=url,
+        body_bytes=body_bytes,
+        keys_dir=keys_dir,
+    )
+    status, response = http_client.request_json(
+        "POST",
+        url,
+        headers=headers,
+        body=payload,
+        body_bytes=body_bytes,
+        timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
+    )
+    if status != 200 or not isinstance(response, dict):
+        detail = response.get("error") if isinstance(response, dict) else None
+        raise RuntimeError(f"coordinator presence failed ({status}: {detail or 'unknown'})")
+    return response
+
+
+def lookup_peers(
+    store: MemoryStore, *, config: OpencodeMemConfig | None = None
+) -> list[dict[str, Any]]:
+    cfg = config or load_config()
+    if not coordinator_enabled(cfg):
+        return []
+    keys_dir = _keys_dir()
+    device_id, _fingerprint = ensure_device_identity(store.conn, keys_dir=keys_dir)
+    base_url = _coordinator_base_url(cfg)
+    if not base_url:
+        return []
+    query = urlencode({"group_id": str(cfg.sync_coordinator_group or "").strip()})
+    url = f"{base_url}/v1/peers?{query}"
+    headers = build_auth_headers(
+        device_id=device_id,
+        method="GET",
+        url=url,
+        body_bytes=b"",
+        keys_dir=keys_dir,
+    )
+    status, response = http_client.request_json(
+        "GET",
+        url,
+        headers=headers,
+        timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
+    )
+    if status != 200 or not isinstance(response, dict):
+        detail = response.get("error") if isinstance(response, dict) else None
+        raise RuntimeError(f"coordinator lookup failed ({status}: {detail or 'unknown'})")
+    items = response.get("items")
+    if not isinstance(items, list):
+        return []
+    return [item for item in items if isinstance(item, dict)]
+
+
+def refresh_peer_address_cache(
+    store: MemoryStore, *, config: OpencodeMemConfig | None = None
+) -> dict[str, int]:
+    cfg = config or load_config()
+    if not coordinator_enabled(cfg):
+        return {"updated_peers": 0, "ignored_peers": 0}
+    register_presence(store, config=cfg)
+    items = lookup_peers(store, config=cfg)
+    updated = 0
+    ignored = 0
+    now = dt.datetime.now(dt.UTC)
+    for item in items:
+        peer_device_id = str(item.get("device_id") or "").strip()
+        if not peer_device_id:
+            ignored += 1
+            continue
+        row = store.conn.execute(
+            "SELECT pinned_fingerprint FROM sync_peers WHERE peer_device_id = ?",
+            (peer_device_id,),
+        ).fetchone()
+        if row is None:
+            ignored += 1
+            continue
+        expected_fingerprint = str(row["pinned_fingerprint"] or "").strip()
+        fingerprint = str(item.get("fingerprint") or "").strip()
+        if not expected_fingerprint or expected_fingerprint != fingerprint:
+            ignored += 1
+            continue
+        expires_at = str(item.get("expires_at") or "").strip()
+        if expires_at:
+            try:
+                expires = dt.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+                if expires.tzinfo is None:
+                    expires = expires.replace(tzinfo=dt.UTC)
+                if expires <= now:
+                    ignored += 1
+                    continue
+            except ValueError:
+                pass
+        addresses = item.get("addresses")
+        if not isinstance(addresses, list):
+            ignored += 1
+            continue
+        normalized = [str(address) for address in addresses if isinstance(address, str)]
+        if not normalized:
+            ignored += 1
+            continue
+        merged = discovery.merge_addresses(
+            normalized,
+            discovery.load_peer_addresses(store.conn, peer_device_id),
+        )
+        store.conn.execute(
+            "UPDATE sync_peers SET addresses_json = ?, last_seen_at = ? WHERE peer_device_id = ?",
+            (json.dumps(merged, ensure_ascii=False), now.isoformat(), peer_device_id),
+        )
+        store.conn.commit()
+        updated += 1
+    return {"updated_peers": updated, "ignored_peers": ignored}

--- a/codemem/sync/sync_pass.py
+++ b/codemem/sync/sync_pass.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import json
 import os
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlencode
@@ -11,7 +12,7 @@ from ..store import MemoryStore, ReplicationOp
 from ..sync_api import MAX_SYNC_BODY_BYTES
 from ..sync_auth import build_auth_headers
 from ..sync_identity import ensure_device_identity
-from . import discovery, http_client, replication
+from . import coordinator, discovery, http_client, replication
 
 
 def _backfill_derived_fields_for_applied_ops(
@@ -106,6 +107,8 @@ def run_sync_pass(
     mdns_entries: list[dict[str, Any]] | None = None,
     limit: int = 200,
 ) -> dict[str, Any]:
+    with suppress(Exception):
+        coordinator.refresh_peer_address_cache(store)
     if mdns_entries is None:
         mdns_entries = discovery.discover_peers_via_mdns() if discovery.mdns_enabled() else []
     stored = discovery.load_peer_addresses(store.conn, peer_device_id)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,6 +164,47 @@ def test_load_config_invalid_int_env_does_not_crash_and_warns(
     assert cfg.sync_port == 7337
 
 
+def test_load_config_reads_sync_coordinator_fields_from_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "sync_coordinator_url": "https://coord.example",
+                "sync_coordinator_group": "team-alpha",
+                "sync_coordinator_timeout_s": 5,
+                "sync_coordinator_presence_ttl_s": 240,
+            }
+        )
+        + "\n"
+    )
+
+    cfg = load_config(config_path)
+
+    assert cfg.sync_coordinator_url == "https://coord.example"
+    assert cfg.sync_coordinator_group == "team-alpha"
+    assert cfg.sync_coordinator_timeout_s == 5
+    assert cfg.sync_coordinator_presence_ttl_s == 240
+
+
+def test_load_config_reads_sync_coordinator_fields_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_URL", "https://coord.example")
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_GROUP", "team-alpha")
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_TIMEOUT_S", "6")
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S", "300")
+
+    cfg = load_config(config_path)
+
+    assert cfg.sync_coordinator_url == "https://coord.example"
+    assert cfg.sync_coordinator_group == "team-alpha"
+    assert cfg.sync_coordinator_timeout_s == 6
+    assert cfg.sync_coordinator_presence_ttl_s == 300
+
+
 def test_load_config_invalid_config_value_does_not_crash_and_warns(tmp_path: Path) -> None:
     config_path = tmp_path / "config.json"
     config_path.write_text('{"sync_port": "abc"}\n')

--- a/tests/test_coordinator_api.py
+++ b/tests/test_coordinator_api.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import http.client
+import json
+import threading
+from http.server import HTTPServer
+from pathlib import Path
+
+from codemem import db
+from codemem.coordinator_api import build_coordinator_handler
+from codemem.coordinator_store import CoordinatorStore
+from codemem.sync_auth import build_auth_headers
+from codemem.sync_identity import ensure_device_identity, fingerprint_public_key, load_public_key
+
+
+def _start_server(db_path: Path) -> tuple[HTTPServer, int]:
+    handler = build_coordinator_handler(db_path)
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
+
+
+def _seed_identity(db_path: Path, keys_dir: Path) -> tuple[str, str, str]:
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        device_id, _ = ensure_device_identity(conn, keys_dir=keys_dir)
+    finally:
+        conn.close()
+    public_key = load_public_key(keys_dir)
+    assert public_key
+    fingerprint = fingerprint_public_key(public_key)
+    return device_id, public_key, fingerprint
+
+
+def test_coordinator_presence_and_peers_flow(tmp_path: Path) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    client_db = tmp_path / "client.sqlite"
+    peer_db = tmp_path / "peer.sqlite"
+    client_keys = tmp_path / "client-keys"
+    peer_keys = tmp_path / "peer-keys"
+
+    client_device_id, client_public_key, client_fingerprint = _seed_identity(client_db, client_keys)
+    peer_device_id, peer_public_key, peer_fingerprint = _seed_identity(peer_db, peer_keys)
+
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha", display_name="Team Alpha")
+        store.enroll_device(
+            "team-alpha",
+            device_id=client_device_id,
+            fingerprint=client_fingerprint,
+            public_key=client_public_key,
+            display_name="client",
+        )
+        store.enroll_device(
+            "team-alpha",
+            device_id=peer_device_id,
+            fingerprint=peer_fingerprint,
+            public_key=peer_public_key,
+            display_name="peer",
+        )
+        store.upsert_presence(
+            group_id="team-alpha",
+            device_id=peer_device_id,
+            addresses=["http://127.0.0.1:7337"],
+            ttl_s=180,
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    try:
+        presence_body = {
+            "group_id": "team-alpha",
+            "fingerprint": client_fingerprint,
+            "public_key": client_public_key,
+            "addresses": ["http://192.0.2.10:7337"],
+            "ttl_s": 180,
+        }
+        presence_url = f"http://127.0.0.1:{port}/v1/presence"
+        presence_headers = build_auth_headers(
+            device_id=client_device_id,
+            method="POST",
+            url=presence_url,
+            body_bytes=json.dumps(presence_body, ensure_ascii=False).encode("utf-8"),
+            keys_dir=client_keys,
+        )
+        presence_headers["Content-Type"] = "application/json"
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST", "/v1/presence", body=json.dumps(presence_body), headers=presence_headers
+        )
+        resp = conn.getresponse()
+        presence_payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert presence_payload["addresses"] == ["http://192.0.2.10:7337"]
+
+        peers_url = f"http://127.0.0.1:{port}/v1/peers?group_id=team-alpha"
+        peers_headers = build_auth_headers(
+            device_id=client_device_id,
+            method="GET",
+            url=peers_url,
+            body_bytes=b"",
+            keys_dir=client_keys,
+        )
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/v1/peers?group_id=team-alpha", headers=peers_headers)
+        resp = conn.getresponse()
+        peers_payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert len(peers_payload["items"]) == 1
+        assert peers_payload["items"][0]["device_id"] == peer_device_id
+        assert peers_payload["items"][0]["addresses"] == ["http://127.0.0.1:7337"]
+        assert peers_payload["items"][0]["stale"] is False
+    finally:
+        server.shutdown()
+
+
+def test_coordinator_presence_rejects_non_numeric_ttl(tmp_path: Path) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    client_db = tmp_path / "client.sqlite"
+    client_keys = tmp_path / "client-keys"
+    client_device_id, client_public_key, client_fingerprint = _seed_identity(client_db, client_keys)
+
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha")
+        store.enroll_device(
+            "team-alpha",
+            device_id=client_device_id,
+            fingerprint=client_fingerprint,
+            public_key=client_public_key,
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    try:
+        body = {
+            "group_id": "team-alpha",
+            "fingerprint": client_fingerprint,
+            "public_key": client_public_key,
+            "addresses": ["http://192.0.2.10:7337"],
+            "ttl_s": "abc",
+        }
+        url = f"http://127.0.0.1:{port}/v1/presence"
+        headers = build_auth_headers(
+            device_id=client_device_id,
+            method="POST",
+            url=url,
+            body_bytes=json.dumps(body, ensure_ascii=False).encode("utf-8"),
+            keys_dir=client_keys,
+        )
+        headers["Content-Type"] = "application/json"
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("POST", "/v1/presence", body=json.dumps(body), headers=headers)
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 400
+        assert payload["error"] == "ttl_s_must_be_int"
+    finally:
+        server.shutdown()
+
+
+def test_coordinator_presence_rejects_non_list_addresses(tmp_path: Path) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    client_db = tmp_path / "client.sqlite"
+    client_keys = tmp_path / "client-keys"
+    client_device_id, client_public_key, client_fingerprint = _seed_identity(client_db, client_keys)
+
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha")
+        store.enroll_device(
+            "team-alpha",
+            device_id=client_device_id,
+            fingerprint=client_fingerprint,
+            public_key=client_public_key,
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    try:
+        body = {
+            "group_id": "team-alpha",
+            "fingerprint": client_fingerprint,
+            "public_key": client_public_key,
+            "addresses": "http://192.0.2.10:7337",
+            "ttl_s": 180,
+        }
+        url = f"http://127.0.0.1:{port}/v1/presence"
+        headers = build_auth_headers(
+            device_id=client_device_id,
+            method="POST",
+            url=url,
+            body_bytes=json.dumps(body, ensure_ascii=False).encode("utf-8"),
+            keys_dir=client_keys,
+        )
+        headers["Content-Type"] = "application/json"
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("POST", "/v1/presence", body=json.dumps(body), headers=headers)
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 400
+        assert payload["error"] == "addresses_must_be_list_of_strings"
+    finally:
+        server.shutdown()
+
+
+def test_coordinator_presence_rejects_large_body(tmp_path: Path) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    client_db = tmp_path / "client.sqlite"
+    client_keys = tmp_path / "client-keys"
+    client_device_id, _client_public_key, _client_fingerprint = _seed_identity(
+        client_db, client_keys
+    )
+
+    server, port = _start_server(coordinator_db)
+    try:
+        body = b"{" + b"a" * 70000 + b"}"
+        url = f"http://127.0.0.1:{port}/v1/presence"
+        headers = build_auth_headers(
+            device_id=client_device_id,
+            method="POST",
+            url=url,
+            body_bytes=body,
+            keys_dir=client_keys,
+        )
+        headers["Content-Type"] = "application/json"
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("POST", "/v1/presence", body=body, headers=headers)
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 413
+        assert payload["error"] == "body_too_large"
+    finally:
+        server.shutdown()

--- a/tests/test_sync_coordinator.py
+++ b/tests/test_sync_coordinator.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import threading
+from http.server import HTTPServer
+from pathlib import Path
+
+from codemem.config import OpencodeMemConfig
+from codemem.store import MemoryStore
+from codemem.sync import coordinator
+from codemem.sync.sync_pass import run_sync_pass
+from codemem.sync_api import build_sync_handler
+from codemem.sync_identity import ensure_device_identity, fingerprint_public_key, load_public_key
+
+
+def _start_server(db_path: Path) -> tuple[HTTPServer, int]:
+    handler = build_sync_handler(db_path)
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
+
+
+def test_refresh_peer_address_cache_updates_matching_peer(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))
+    store = MemoryStore(db_path)
+    try:
+        ensure_device_identity(store.conn, keys_dir=keys_dir)
+        actor = store.create_actor(display_name="Teammate")
+        store.conn.execute(
+            """
+            INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, actor_id, addresses_json, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "peer-1",
+                "fp-peer-1",
+                "ssh-ed25519 AAAApeer",
+                actor["actor_id"],
+                json.dumps(["http://stale.local:7337"]),
+                "2026-01-24T00:00:00Z",
+            ),
+        )
+        store.conn.commit()
+
+        def fake_request_json(method: str, url: str, **_kwargs):
+            if method == "POST" and url.endswith("/v1/presence"):
+                return 200, {
+                    "ok": True,
+                    "addresses": ["http://127.0.0.1:7337"],
+                    "expires_at": "2099-01-01T00:00:00Z",
+                }
+            if method == "GET" and "/v1/peers?" in url:
+                return 200, {
+                    "items": [
+                        {
+                            "device_id": "peer-1",
+                            "fingerprint": "fp-peer-1",
+                            "addresses": ["http://127.0.0.1:7337"],
+                            "last_seen_at": "2099-01-01T00:00:00Z",
+                            "expires_at": "2099-01-01T00:03:00Z",
+                            "stale": False,
+                        }
+                    ]
+                }
+            raise AssertionError(f"unexpected {method} {url}")
+
+        monkeypatch.setattr("codemem.sync.coordinator.http_client.request_json", fake_request_json)
+
+        result = coordinator.refresh_peer_address_cache(
+            store,
+            config=OpencodeMemConfig(
+                sync_coordinator_url="https://coord.example",
+                sync_coordinator_group="team-alpha",
+                sync_coordinator_timeout_s=3,
+                sync_coordinator_presence_ttl_s=180,
+                sync_advertise="127.0.0.1",
+                sync_port=7337,
+            ),
+        )
+
+        addresses = store.conn.execute(
+            "SELECT addresses_json FROM sync_peers WHERE peer_device_id = ?",
+            ("peer-1",),
+        ).fetchone()
+
+        assert result == {"updated_peers": 1, "ignored_peers": 0}
+        assert addresses is not None
+        assert json.loads(addresses["addresses_json"]) == [
+            "http://127.0.0.1:7337",
+            "http://stale.local:7337",
+        ]
+    finally:
+        store.close()
+
+
+def test_refresh_peer_address_cache_ignores_fingerprint_mismatch(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))
+    store = MemoryStore(db_path)
+    try:
+        ensure_device_identity(store.conn, keys_dir=keys_dir)
+        actor = store.create_actor(display_name="Teammate")
+        store.conn.execute(
+            """
+            INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, actor_id, addresses_json, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "peer-1",
+                "expected-fingerprint",
+                "ssh-ed25519 AAAApeer",
+                actor["actor_id"],
+                json.dumps(["http://stale.local:7337"]),
+                "2026-01-24T00:00:00Z",
+            ),
+        )
+        store.conn.commit()
+
+        def fake_request_json(method: str, url: str, **_kwargs):
+            if method == "POST":
+                return 200, {"ok": True, "addresses": [], "expires_at": "2099-01-01T00:00:00Z"}
+            return 200, {
+                "items": [
+                    {
+                        "device_id": "peer-1",
+                        "fingerprint": "wrong-fingerprint",
+                        "addresses": ["http://127.0.0.1:7337"],
+                        "expires_at": "2099-01-01T00:03:00Z",
+                    }
+                ]
+            }
+
+        monkeypatch.setattr("codemem.sync.coordinator.http_client.request_json", fake_request_json)
+
+        result = coordinator.refresh_peer_address_cache(
+            store,
+            config=OpencodeMemConfig(
+                sync_coordinator_url="https://coord.example",
+                sync_coordinator_group="team-alpha",
+                sync_coordinator_timeout_s=3,
+                sync_coordinator_presence_ttl_s=180,
+                sync_advertise="127.0.0.1",
+                sync_port=7337,
+            ),
+        )
+
+        addresses = store.conn.execute(
+            "SELECT addresses_json FROM sync_peers WHERE peer_device_id = ?",
+            ("peer-1",),
+        ).fetchone()
+
+        assert result == {"updated_peers": 0, "ignored_peers": 1}
+        assert addresses is not None
+        assert json.loads(addresses["addresses_json"]) == ["http://stale.local:7337"]
+    finally:
+        store.close()
+
+
+def test_refresh_peer_address_cache_ignores_expired_presence(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))
+    store = MemoryStore(db_path)
+    try:
+        ensure_device_identity(store.conn, keys_dir=keys_dir)
+        actor = store.create_actor(display_name="Teammate")
+        store.conn.execute(
+            """
+            INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, actor_id, addresses_json, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "peer-1",
+                "fp-peer-1",
+                "ssh-ed25519 AAAApeer",
+                actor["actor_id"],
+                json.dumps(["http://stale.local:7337"]),
+                "2026-01-24T00:00:00Z",
+            ),
+        )
+        store.conn.commit()
+
+        def fake_request_json(method: str, url: str, **_kwargs):
+            if method == "POST":
+                return 200, {"ok": True, "addresses": [], "expires_at": "2099-01-01T00:00:00Z"}
+            return 200, {
+                "items": [
+                    {
+                        "device_id": "peer-1",
+                        "fingerprint": "fp-peer-1",
+                        "addresses": ["http://127.0.0.1:7337"],
+                        "expires_at": "2000-01-01T00:00:00Z",
+                    }
+                ]
+            }
+
+        monkeypatch.setattr("codemem.sync.coordinator.http_client.request_json", fake_request_json)
+
+        result = coordinator.refresh_peer_address_cache(
+            store,
+            config=OpencodeMemConfig(
+                sync_coordinator_url="https://coord.example",
+                sync_coordinator_group="team-alpha",
+                sync_coordinator_timeout_s=3,
+                sync_coordinator_presence_ttl_s=180,
+                sync_advertise="127.0.0.1",
+                sync_port=7337,
+            ),
+        )
+
+        addresses = store.conn.execute(
+            "SELECT addresses_json FROM sync_peers WHERE peer_device_id = ?",
+            ("peer-1",),
+        ).fetchone()
+
+        assert result == {"updated_peers": 0, "ignored_peers": 1}
+        assert addresses is not None
+        assert json.loads(addresses["addresses_json"]) == ["http://stale.local:7337"]
+    finally:
+        store.close()
+
+
+def test_run_sync_pass_uses_coordinator_refreshed_addresses(tmp_path: Path, monkeypatch) -> None:
+    local_db = tmp_path / "local.sqlite"
+    remote_db = tmp_path / "remote.sqlite"
+    local_keys = tmp_path / "local-keys"
+    remote_keys = tmp_path / "remote-keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(local_keys))
+
+    remote_store = MemoryStore(remote_db)
+    try:
+        remote_device_id, _ = ensure_device_identity(remote_store.conn, keys_dir=remote_keys)
+        remote_store.device_id = remote_device_id
+        remote_public_key = load_public_key(remote_keys)
+        assert remote_public_key
+        remote_fingerprint = fingerprint_public_key(remote_public_key)
+        remote_session = remote_store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        remote_store.remember(
+            remote_session, kind="note", title="Remote", body_text="From coordinator peer"
+        )
+    finally:
+        remote_store.close()
+
+    server, port = _start_server(remote_db)
+    local_store = MemoryStore(local_db)
+    try:
+        local_device_id, _ = ensure_device_identity(local_store.conn, keys_dir=local_keys)
+        local_public_key = load_public_key(local_keys)
+        assert local_public_key
+        local_fingerprint = fingerprint_public_key(local_public_key)
+        local_store.conn.execute(
+            """
+            INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                remote_device_id,
+                remote_fingerprint,
+                remote_public_key,
+                json.dumps([]),
+                dt.datetime.now(dt.UTC).isoformat(),
+            ),
+        )
+        local_store.conn.commit()
+        remote_conn = MemoryStore(remote_db)
+        try:
+            remote_conn.conn.execute(
+                """
+                INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    local_device_id,
+                    local_fingerprint,
+                    local_public_key,
+                    json.dumps([]),
+                    dt.datetime.now(dt.UTC).isoformat(),
+                ),
+            )
+            remote_conn.conn.commit()
+        finally:
+            remote_conn.close()
+
+        def fake_refresh(store: MemoryStore) -> dict[str, int]:
+            store.conn.execute(
+                "UPDATE sync_peers SET addresses_json = ? WHERE peer_device_id = ?",
+                (json.dumps([f"http://127.0.0.1:{port}"]), remote_device_id),
+            )
+            store.conn.commit()
+            return {"updated_peers": 1, "ignored_peers": 0}
+
+        monkeypatch.setattr(
+            "codemem.sync.sync_pass.coordinator.refresh_peer_address_cache", fake_refresh
+        )
+
+        result = run_sync_pass(local_store, remote_device_id, mdns_entries=[])
+        imported = local_store.conn.execute(
+            "SELECT COUNT(1) AS total FROM memory_items WHERE title = ?",
+            ("Remote",),
+        ).fetchone()
+
+        assert result["ok"] is True
+        assert imported is not None
+        assert int(imported["total"] or 0) == 1
+    finally:
+        local_store.close()
+        server.shutdown()
+
+
+def test_run_sync_pass_falls_back_when_coordinator_refresh_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    local_db = tmp_path / "local.sqlite"
+    remote_db = tmp_path / "remote.sqlite"
+    local_keys = tmp_path / "local-keys"
+    remote_keys = tmp_path / "remote-keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(local_keys))
+
+    remote_store = MemoryStore(remote_db)
+    try:
+        remote_device_id, _ = ensure_device_identity(remote_store.conn, keys_dir=remote_keys)
+        remote_store.device_id = remote_device_id
+        remote_public_key = load_public_key(remote_keys)
+        assert remote_public_key
+        remote_fingerprint = fingerprint_public_key(remote_public_key)
+        remote_session = remote_store.start_session(
+            cwd=str(tmp_path),
+            git_remote=None,
+            git_branch=None,
+            user="tester",
+            tool_version="test",
+            project="codemem",
+        )
+        remote_store.remember(
+            remote_session, kind="note", title="Remote", body_text="From cached peer"
+        )
+    finally:
+        remote_store.close()
+
+    server, port = _start_server(remote_db)
+    local_store = MemoryStore(local_db)
+    try:
+        local_device_id, _ = ensure_device_identity(local_store.conn, keys_dir=local_keys)
+        local_public_key = load_public_key(local_keys)
+        assert local_public_key
+        local_fingerprint = fingerprint_public_key(local_public_key)
+        local_store.conn.execute(
+            """
+            INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                remote_device_id,
+                remote_fingerprint,
+                remote_public_key,
+                json.dumps([f"http://127.0.0.1:{port}"]),
+                dt.datetime.now(dt.UTC).isoformat(),
+            ),
+        )
+        local_store.conn.commit()
+        remote_conn = MemoryStore(remote_db)
+        try:
+            remote_conn.conn.execute(
+                """
+                INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    local_device_id,
+                    local_fingerprint,
+                    local_public_key,
+                    json.dumps([]),
+                    dt.datetime.now(dt.UTC).isoformat(),
+                ),
+            )
+            remote_conn.conn.commit()
+        finally:
+            remote_conn.close()
+
+        def fake_refresh(_store: MemoryStore) -> dict[str, int]:
+            raise RuntimeError("unauthorized")
+
+        monkeypatch.setattr(
+            "codemem.sync.sync_pass.coordinator.refresh_peer_address_cache", fake_refresh
+        )
+
+        result = run_sync_pass(local_store, remote_device_id, mdns_entries=[])
+        imported = local_store.conn.execute(
+            "SELECT COUNT(1) AS total FROM memory_items WHERE title = ?",
+            ("Remote",),
+        ).fetchone()
+
+        assert result["ok"] is True
+        assert imported is not None
+        assert int(imported["total"] or 0) == 1
+    finally:
+        local_store.close()
+        server.shutdown()


### PR DESCRIPTION
## Description
- add a first-party coordinator service to `codemem` for coordinator-backed cross-network discovery
- add coordinator config, presence registration, peer lookup, and direct-sync cache refresh integration
- add CLI commands plus Python tests for the self-hosted coordinator path

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_config.py tests/test_sync_coordinator.py tests/test_coordinator_api.py tests/test_sync_protocol.py tests/test_sync_daemon.py`
- `uv run ruff check codemem/config.py codemem/coordinator_store.py codemem/coordinator_api.py codemem/commands/sync_coordinator_cmds.py codemem/cli_app.py codemem/sync/coordinator.py codemem/sync/sync_pass.py tests/test_config.py tests/test_sync_coordinator.py tests/test_coordinator_api.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced