### PR TITLE
docs: add coordinator discovery design and setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ The viewer now includes actor management for mapping multiple peers to one logic
 
 Project filters, peer-to-actor assignment, visibility controls, and config keys are documented in [docs/user-guide.md](docs/user-guide.md).
 
+For cross-network setups where peer addresses change frequently or mDNS does not cross VPN/network boundaries, codemem also supports optional coordinator-backed discovery with a self-hosted coordinator. The preferred deployment path is the built-in `codemem sync coordinator` service; see [docs/coordinator-discovery.md](docs/coordinator-discovery.md).
+
 ## Semantic recall
 
 Embeddings are stored in sqlite-vec and written automatically when memories are created. Use `codemem embed` to backfill existing memories. If sqlite-vec cannot load, keyword search still works.
@@ -256,6 +258,7 @@ Start OpenCode inside the codemem repo directory — the plugin auto-loads from 
 ## Documentation
 
 - [Architecture](docs/architecture.md) — data flow, retrieval, observer pipeline, design tradeoffs
+- [Coordinator-backed discovery](docs/coordinator-discovery.md) — self-hosted cross-network peer discovery
 - [User guide](docs/user-guide.md) — viewer usage, sync setup, troubleshooting
 - [Plugin reference](docs/plugin-reference.md) — plugin behavior, env vars, stream reliability
 - [Migration guide](docs/rename-migration.md) — migrating from `opencode-mem`

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -1,0 +1,110 @@
+# Coordinator-backed discovery
+
+Use coordinator-backed discovery when peers are usually reachable but their addresses change often or mDNS does not cross
+the network boundary you care about (for example VPNs).
+
+## What it does
+
+- gives devices a stable discovery/presence plane through a self-hosted coordinator
+- lets devices publish current dialable addresses
+- lets peers look up fresh addresses before direct sync
+- keeps direct peer-to-peer sync as the data path
+
+## What it does not do
+
+- it does not relay memory payloads
+- it does not queue offline sync data
+- it does not replace local SQLite as the source of truth
+- it is not a codemem-hosted public service
+
+## Config
+
+Set both of these to enable coordinator-backed discovery:
+
+- `sync_coordinator_url`
+- `sync_coordinator_group`
+
+Optional knobs:
+
+- `sync_coordinator_timeout_s` - request timeout for coordinator calls (default: `3`)
+- `sync_coordinator_presence_ttl_s` - advertised presence TTL in seconds (default: `180`)
+- `sync_mdns` - keep LAN mDNS discovery enabled or disable it independently
+- `sync_advertise` - controls which local addresses are published to peers and the coordinator
+
+Environment variable equivalents:
+
+- `CODEMEM_SYNC_COORDINATOR_URL`
+- `CODEMEM_SYNC_COORDINATOR_GROUP`
+- `CODEMEM_SYNC_COORDINATOR_TIMEOUT_S`
+- `CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S`
+
+Example config:
+
+```json
+{
+  "sync_enabled": true,
+  "sync_coordinator_url": "https://coord.example.workers.dev",
+  "sync_coordinator_group": "team-alpha",
+  "sync_coordinator_timeout_s": 3,
+  "sync_coordinator_presence_ttl_s": 180,
+  "sync_advertise": "tailscale"
+}
+```
+
+## Built-in coordinator service
+
+The preferred self-hosted deployment path is a first-party `codemem` coordinator service.
+
+Basic flow:
+
+```fish
+codemem sync coordinator group-create team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator enroll-device team-alpha <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/id_ed25519.pub --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
+```
+
+This keeps the primary deployment path inside the main `codemem` artifact and reuses the existing Python signature
+verification code directly.
+
+## How discovery works
+
+With coordinator-backed discovery enabled, codemem uses three sources of peer addresses:
+
+1. fresh coordinator presence records
+2. locally cached peer addresses in `sync_peers.addresses_json`
+3. mDNS-discovered addresses on LANs where mDNS works
+
+Dial preference is intentionally conservative:
+
+1. coordinator responses refresh the stored peer-address cache
+2. if mDNS returns addresses on the current LAN, codemem still tries those first
+3. otherwise codemem uses the stored address cache, which may have been refreshed by the coordinator
+
+If the coordinator is unavailable, codemem falls back to cached addresses and mDNS.
+
+## Auth model
+
+- the coordinator is self-hosted/operator-run
+- devices authenticate with their existing sync keypair
+- enrollment is explicit per device/group
+- there is no username/password or codemem-operated account layer in this model
+
+## Cloudflare Worker reference deployment
+
+The design targets a runtime-agnostic HTTP contract, but a Cloudflare Worker is the canonical low-cost reference
+deployment.
+
+That means the coordinator API should be simple enough to implement anywhere, but the first example deployment is
+expected to be a Worker-backed service at a stable address.
+
+The Cloudflare Worker remains an optional alternate reference deployment. Its scaffold lives in a follow-up PR in this
+stack, not in this docs-only change.
+
+## Current limitations
+
+- no relay/proxy transport yet
+- no offline buffered delivery yet
+- no central search or server-side memory store
+- no richer enrollment UX beyond explicit operator setup
+
+Those are deliberate non-goals for the coordinator MVP.

--- a/docs/plans/2026-03-12-actor-affinity-weighting-beyond-personal-first.md
+++ b/docs/plans/2026-03-12-actor-affinity-weighting-beyond-personal-first.md
@@ -1,0 +1,134 @@
+# Actor-Affinity Weighting Beyond Personal-First
+
+**Bead:** `codemem-831`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Problem
+
+codemem already has a personal-first retrieval bias. That means the current actor's own memories tend to rank above
+memories from other actors when all else is roughly equal.
+
+The open question is whether retrieval should go further and add a distinct actor-affinity weighting model beyond the
+current personal-first bonus.
+
+The intuition is reasonable:
+
+- your own memories often match your vocabulary, habits, and decision style better than teammates' memories
+- teammate memories may still be useful, but often as secondary context
+
+But this should be treated as a retrieval-quality hypothesis, not folded into trust semantics and not assumed correct
+without examples.
+
+## Goal
+
+Define whether there is a meaningful retrieval improvement available beyond the current personal-first bias, and if so,
+what the smallest safe next slice should be.
+
+## Non-goals
+
+- Do not overload `trust_state` with actor-affinity meaning.
+- Do not add hidden global teammate suppression.
+- Do not change sync or visibility policy.
+- Do not implement a full social graph or collaborator preference system.
+
+## Current baseline
+
+Today codemem already has:
+
+- `PERSONAL_FIRST_BONUS` in search ranking
+- actor/workspace include-exclude filters
+- adaptive widening from personal to shared retrieval when enabled
+- soft trust-aware penalties for lower-confidence shared memories
+
+That means any new actor-affinity work must answer a specific question:
+
+- what retrieval problem still exists after personal-first bias and adaptive widening?
+
+## Working hypothesis
+
+The likely residual issue is not "prefer my memories over everyone else's" in a blanket sense.
+It is narrower:
+
+- among shared results, some actors may consistently be more or less useful to a given user
+- current ranking may still bring in teammate context too early when lexical/semantic scores are close
+
+## Recommendation
+
+### Recommendation: do not add a second always-on actor bonus yet
+
+The first recommendation is conservative:
+
+- keep the current personal-first bonus as the main own-memory preference
+- do not add another unconditional ranking weight for the current actor yet
+- instead, instrument and evaluate whether real examples still show a useful gap
+
+Reason:
+
+- a second always-on own-actor boost may just duplicate current personal-first behavior
+- it could hide useful teammate context, especially once widening is active
+- we do not yet have evidence that a stronger own-actor preference improves outcomes instead of just feeling intuitively
+  correct
+
+## If a follow-on slice is justified later
+
+The first safe extension should be narrow.
+
+Recommended shape:
+
+- apply a very small additional actor-affinity weight only inside widened shared results, not on the full result set
+- keep the weight weaker than personal-first bias and weaker than strong lexical/semantic relevance
+- make it explicitly optional or shadow-only at first
+
+This treats actor affinity as a tie-breaker inside shared context, not as a new top-level ranking law.
+
+## Interaction with existing behavior
+
+### Personal-first bias
+
+- remains the primary own-memory preference
+- actor-affinity work should not replace it
+
+### Adaptive widening
+
+- if actor affinity is explored later, widened shared results are the right place to apply it first
+- this reduces the risk of suppressing teammate memories before widening is even needed
+
+### Trust weighting
+
+- stays separate
+- trust answers "how confident are we in provenance/review"
+- actor affinity answers "whose working style is more likely to match the current user"
+
+## Evaluation plan
+
+Before implementing any new ranking weight, gather examples from dogfooding.
+
+Minimum evaluation method:
+
+1. collect queries where current results feel too teammate-heavy even with personal-first enabled
+2. compare current ranking against a shadow-scored variant with a tiny actor-affinity tie-breaker
+3. review whether the change improves top-N usefulness without hiding important shared context
+
+Useful signals:
+
+- how often the current actor already dominates top results
+- how often teammate memories appear in top-N despite clearly weaker practical usefulness
+- whether the problem occurs mainly in widened shared results rather than baseline personal-first search
+
+## Success criteria for future implementation
+
+Only implement actor-affinity weighting if we can show that:
+
+1. current personal-first bias is not enough for a meaningful subset of queries
+2. the benefit is visible in real examples, not just intuition
+3. the weighting can remain smaller than semantic relevance and smaller than personal-first bias
+4. the behavior can be introduced in an optional or shadow-evaluated way first
+
+## Acceptance criteria
+
+This task is successful when:
+
+1. actor affinity is clearly separated from trust semantics
+2. the overlap with personal-first and adaptive widening is explicit
+3. the recommended next step is grounded in evaluation rather than intuition alone

--- a/docs/plans/2026-03-12-coordinator-backed-cross-network-discovery.md
+++ b/docs/plans/2026-03-12-coordinator-backed-cross-network-discovery.md
@@ -1,0 +1,384 @@
+# Coordinator-Backed Cross-Network Discovery
+
+**Bead:** `codemem-sw7`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Problem
+
+codemem's current sync model works best when peers have stable reachable addresses or can discover each other on the
+same LAN via mDNS. In practice, one of the main real-world failure modes is different:
+
+- peers are often reachable, but their addresses change frequently
+- peers go online and offline at different times
+- mDNS does not reliably cross VPN or broader network boundaries
+
+That means the immediate user pain is not primarily "we need a relay transport now." The main issue is durable,
+cross-network discovery and presence.
+
+## Goal
+
+Add an optional, self-hosted coordinator service that gives codemem devices a stable cross-network discovery plane.
+
+The first slice should:
+
+- let devices register current reachable addresses and liveness with a coordinator
+- let trusted devices look up current dial candidates for peers through that coordinator
+- keep direct peer-to-peer sync as the data path
+- remain runtime-agnostic, with a Cloudflare Worker reference deployment
+
+## Non-goals
+
+- No codemem-operated public service.
+- No server-authoritative memory store.
+- No relay/proxy transport in the first slice.
+- No offline message queue in the first slice.
+- No account system, email login, or SSO.
+
+## Architecture stance
+
+Use a **coordinator-only MVP** for discovery/presence, not a full coordinator-plus-relay implementation yet.
+
+### Why this cut
+
+- it directly addresses unstable addresses across VPN/network boundaries
+- it preserves codemem's current local-first direct-sync model
+- it avoids overbuilding transport infrastructure before it is actually needed
+- it keeps the door open for later relay and buffer support
+
+## Deployment model
+
+The coordinator is:
+
+- self-hosted or operator-run
+- reachable at a stable public or private address
+- defined by a small HTTP contract
+
+Reference deployment:
+
+- Cloudflare Worker is the canonical example because it is cheap and easy to operate
+
+But the protocol should stay runtime-agnostic so the same coordinator can also be implemented as any tiny HTTP service.
+
+## Trust and auth model
+
+### Device identity
+
+Reuse codemem's existing device trust model:
+
+- device IDs
+- public keys
+- fingerprints
+
+### Coordinator auth
+
+The first slice should assume **device-key auth only**:
+
+- devices sign coordinator requests with the same sync key material they already use
+- the coordinator stores an explicit allowlist or enrollment record for accepted device public keys
+- no passwords, user accounts, or codemem-hosted identity service
+
+### Enrollment
+
+Enrollment remains explicit and operator-controlled.
+
+The simplest first pass is:
+
+- an operator creates a coordinator group
+- devices are explicitly enrolled into that group with their public keys / fingerprints
+
+This can later be wrapped in a better UX, but the first version should optimize for clarity and safety.
+
+## Coordinator responsibilities
+
+The coordinator should do only four things in v1:
+
+1. authenticate enrolled devices
+2. accept presence/address registrations from those devices
+3. answer peer lookup requests for devices in the same group
+4. expose enough metadata to reason about freshness (`last_seen_at`, last registration)
+
+What it should **not** do in v1:
+
+- relay replication payloads
+- queue memory ops for offline devices
+- decide visibility or sync policy
+- store or inspect memory content
+- answer search queries
+
+## Coordinator data model
+
+Suggested logical records:
+
+### Group
+
+- `group_id`
+- `display_name` (optional)
+- `created_at`
+
+### Enrolled device
+
+- `group_id`
+- `device_id`
+- `public_key`
+- `fingerprint`
+- `display_name` (optional)
+- `enabled`
+- `created_at`
+
+### Presence record
+
+- `group_id`
+- `device_id`
+- `addresses` (normalized dial candidates)
+- `last_seen_at`
+- `expires_at`
+- optional capability flags reserved for later (`supports_relay`, `supports_queueing`)
+
+The first implementation can keep this very small. The main requirement is that presence expires automatically when a
+device stops refreshing.
+
+## HTTP contract
+
+Recommended minimal endpoints:
+
+### Auth headers
+
+Reuse the existing sync request signing model unchanged.
+
+Coordinator requests should carry:
+
+- `X-Opencode-Device`
+- `X-Opencode-Timestamp`
+- `X-Opencode-Nonce`
+- `X-Opencode-Signature`
+
+Verification should reuse the same canonical request format and device-key signature verification logic currently used by
+peer sync HTTP endpoints.
+
+### `POST /v1/presence`
+
+Used by a device to publish its current reachability.
+
+Request body:
+
+```json
+{
+  "group_id": "team-alpha",
+  "fingerprint": "SHA256:...",
+  "public_key": "ssh-ed25519 AAAA...",
+  "addresses": ["http://203.0.113.10:7337", "http://100.64.0.5:7337"],
+  "ttl_s": 180,
+  "display_name": "laptop",
+  "capabilities": {
+    "supports_relay": false,
+    "supports_queueing": false
+  }
+}
+```
+
+Behavior:
+
+- device identity (`device_id`, fingerprint)
+- group identifier
+- signed auth headers using existing device key material
+- list of current candidate addresses
+- optional metadata like display name / capabilities
+
+Response body:
+
+```json
+{
+  "ok": true,
+  "group_id": "team-alpha",
+  "device_id": "dev-123",
+  "addresses": ["http://203.0.113.10:7337", "http://100.64.0.5:7337"],
+  "expires_at": "2026-03-12T22:00:00Z"
+}
+```
+
+Notes:
+
+- the coordinator may normalize, deduplicate, or reorder addresses before storing them
+- `public_key` may be omitted after initial enrollment if the coordinator already has it on file, but including it in the
+  first contract keeps enrollment and registration easy to reason about
+
+- `ok`
+- normalized stored addresses
+- presence expiry timestamp
+
+### `GET /v1/peers`
+
+Used by a device to ask for current dial candidates for other devices in the same group.
+
+Query parameters:
+
+- `group_id`
+
+Response includes, per peer:
+
+```json
+{
+  "items": [
+    {
+      "device_id": "dev-456",
+      "fingerprint": "SHA256:...",
+      "addresses": ["http://198.51.100.10:7337"],
+      "last_seen_at": "2026-03-12T21:57:00Z",
+      "expires_at": "2026-03-12T22:00:00Z",
+      "stale": false,
+      "display_name": "workstation",
+      "capabilities": {
+        "supports_relay": false,
+        "supports_queueing": false
+      }
+    }
+  ]
+}
+```
+
+- `device_id`
+- `fingerprint`
+- `addresses`
+- `last_seen_at`
+- `stale` / freshness hint
+
+Optional later endpoint:
+
+### `GET /v1/peer/<device_id>`
+
+Useful if we want single-peer lookup instead of fetching the whole group roster each time.
+
+## Local codemem behavior
+
+### Discovery sources
+
+After this change, codemem should treat peer discovery as multi-source:
+
+1. coordinator presence records (cross-network source of truth)
+2. locally cached peer addresses (`sync_peers.addresses_json`)
+3. mDNS (LAN-only supplemental source)
+
+### Dial order
+
+Recommended first-pass dial order:
+
+1. fresh coordinator addresses
+2. cached known-good addresses
+3. mDNS-discovered addresses
+
+Direct sync stays the data path. The coordinator only helps codemem find where to dial.
+
+### Local persistence
+
+Keep writing discovered addresses back into `sync_peers.addresses_json` as a cache. The coordinator is not replacing the
+local peer table; it is becoming the cross-network source that refreshes it.
+
+Minimum local persistence expectations:
+
+- coordinator-returned addresses are merged into the existing local cache using the same normalization rules as mDNS and
+  remembered addresses
+- coordinator lookup must not create new peer trust entries implicitly; it only refreshes addresses for already-trusted
+  peers in the same group
+- the local cache remains usable when the coordinator is unavailable
+
+## Refresh / lifecycle behavior
+
+### Presence registration
+
+Devices should refresh coordinator presence on a lightweight cadence, for example:
+
+- at sync daemon startup
+- after local address changes are detected
+- periodically while sync is enabled
+
+### Expiration
+
+Presence records need TTL-based expiration so stale addresses disappear automatically.
+
+This avoids a coordinator becoming a graveyard of old laptop IPs.
+
+## Config and environment surface
+
+Recommended first-pass config fields:
+
+- `sync_coordinator_url: str | None = None`
+- `sync_coordinator_group: str | None = None`
+- `sync_coordinator_timeout_s: int = 3`
+- `sync_coordinator_presence_ttl_s: int = 180`
+
+Recommended environment variables:
+
+- `CODEMEM_SYNC_COORDINATOR_URL`
+- `CODEMEM_SYNC_COORDINATOR_GROUP`
+- `CODEMEM_SYNC_COORDINATOR_TIMEOUT_S`
+- `CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S`
+
+Enablement rule:
+
+- coordinator-backed discovery is enabled when both `sync_coordinator_url` and `sync_coordinator_group` are set
+- mDNS remains independently configurable via `sync_mdns`
+- `sync_advertise` remains the source for which local addresses get published to peers and the coordinator
+
+## Coexistence with later relay/buffer work
+
+The coordinator design should reserve room for future transport help without implementing it yet.
+
+Design constraints for v1:
+
+- capability flags should allow a later relay role to be advertised
+- group and device auth should be reusable if relay is added later
+- peer lookup responses may later include relay hints, but do not in v1
+
+This keeps the current work from blocking the future relay/buffer track.
+
+## Cloudflare Worker reference deployment
+
+The reference implementation should show:
+
+- a tiny HTTP API implementing the above contract
+- device-key request verification
+- simple persistence for group/device/presence data
+
+The first doc should stay explicit that Cloudflare Worker is just the canonical example, not the required runtime.
+
+## Failure modes
+
+### Coordinator unavailable
+
+- codemem falls back to cached addresses and mDNS
+- direct peer-to-peer may still work
+
+### Stale coordinator presence
+
+- peer lookup should surface freshness/expiry metadata
+- sync should still attempt direct dial only against non-expired candidates by default
+
+### Enrollment/auth mismatch
+
+- coordinator denies registration/lookup
+- codemem surfaces a clear configuration or trust error
+
+## Rollout recommendation
+
+1. Define the small coordinator HTTP contract.
+2. Add coordinator config to codemem.
+3. Implement coordinator-backed presence registration and lookup in the sync discovery path.
+4. Provide a Cloudflare Worker reference deployment.
+5. Document self-hosted setup and limits.
+
+## Follow-on work explicitly deferred
+
+- relay/proxy transport when direct dial fails
+- buffered/offline delivery
+- richer operator enrollment UX
+- public hosted service model
+
+## Acceptance criteria
+
+This design is successful when:
+
+1. The first slice clearly solves unstable cross-network discovery without requiring relay transport.
+2. The coordinator stays self-hosted, device-authenticated, and runtime-agnostic.
+3. Direct peer-to-peer sync remains the data path.
+4. The design leaves clean extension points for later relay/buffer work without forcing them into v1.

--- a/docs/plans/2026-03-12-relay-and-buffered-delivery-follow-on.md
+++ b/docs/plans/2026-03-12-relay-and-buffered-delivery-follow-on.md
@@ -1,0 +1,63 @@
+# Relay and Buffered Delivery Follow-on After Coordinator MVP
+
+**Bead:** `codemem-0wl`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Why this is deferred
+
+The coordinator MVP solves the immediate problem users are actually hitting today:
+
+- unstable peer addresses across VPN/network boundaries
+- weak or absent cross-network discovery beyond LAN mDNS
+
+Relay/proxy transport and offline buffering are still important, but they are not the first pain to solve.
+
+## Follow-on scope
+
+After coordinator-backed discovery ships, the next transport questions are:
+
+1. should the coordinator also proxy sync traffic when direct dial fails?
+2. should the coordinator buffer sync payloads briefly when peers are not online at the same time?
+
+Those should remain a separate track.
+
+## Design constraints inherited from the coordinator MVP
+
+The coordinator MVP should preserve these extension points for later work:
+
+- device-key auth remains the trust model
+- group membership remains explicit and reusable
+- capability flags can later advertise relay or queue support
+- local databases stay authoritative
+
+## Recommended next-step criteria
+
+Relay/proxy transport becomes justified when coordinator-backed discovery still leaves too many direct-dial failures even
+with fresh addresses.
+
+Buffered delivery becomes justified when:
+
+- peers are frequently not online at the same time
+- direct sync works when both peers are live, but operational usefulness suffers because updates wait too long
+
+## Future prototype boundaries
+
+When this track starts, the first relay/buffer slice should still avoid:
+
+- server-authoritative memory state
+- central retrieval/search
+- hosted account system
+- retroactive data deletion guarantees
+
+The likely first prototype should be:
+
+- optional relay transport for replication payload delivery only
+- short-lived queueing for offline recipients
+- explicit retention window and failure semantics
+
+## Success criteria for taking this on later
+
+- coordinator-backed discovery has shipped and been dogfooded
+- direct-dial failure patterns or offline gaps are well understood
+- we can name the specific user pain the relay/buffer layer is solving rather than building it preemptively

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -159,6 +159,13 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 
 - `codemem sync status` and `codemem sync start|stop|restart` for daemon control.
 
+### Coordinator-backed discovery
+
+- Use coordinator-backed discovery when peers are reachable but their addresses change frequently or mDNS does not work across network boundaries such as VPNs.
+- Set `sync_coordinator_url` and `sync_coordinator_group` to enable it.
+- The coordinator is self-hosted/operator-run and only helps peers discover fresh addresses; direct peer-to-peer sync remains the data path.
+- See [docs/coordinator-discovery.md](coordinator-discovery.md) for setup, config, and current limitations.
+
 ### Keychain (optional)
 
 - `sync_key_store=keychain` (or `CODEMEM_SYNC_KEY_STORE=keychain`) stores the private key in Secret Service (Linux) or Keychain (macOS).
@@ -180,6 +187,6 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 ## Viewer sync panel
 - The `Actors` section gives actor creation/rename one home, while peer cards keep assignment close to the peer being changed.
 - `Assigned actor` replaces the older `Belongs to me` language in the peer cards.
-- Feed cards you own include a `Save visibility` control so shared/private intent can be changed without editing raw metadata.
+- Feed cards you own include a visibility control so shared/private intent can be changed without editing raw metadata.
 - `Redact sensitive details` lives above Recent sync attempts so it is easier to find before you inspect peer addresses and attempt history.
 - Recent sync attempts intentionally show only the latest few rows in the viewer; use CLI diagnostics for deeper history if needed.


### PR DESCRIPTION
## Description
- document coordinator-backed discovery for self-hosters
- add the concrete coordinator design note, relay/buffer follow-on note, and actor-affinity evaluation note
- update README and user guide to reflect the built-in coordinator path and current limits

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- Documentation-only changes on top of the tested coordinator implementation stack

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced