### PR TITLE
feat: add coordinator settings to the UI

### DIFF
--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -45,7 +45,17 @@ _HOT_RELOAD_KEYS = {
     "raw_events_sweeper_interval_s",
 }
 _LIVE_APPLY_KEYS = {"pack_observation_limit", "pack_session_limit"}
-_SYNC_ACTION_KEYS = {"sync_enabled", "sync_host", "sync_port", "sync_interval_s", "sync_mdns"}
+_SYNC_ACTION_KEYS = {
+    "sync_enabled",
+    "sync_host",
+    "sync_port",
+    "sync_interval_s",
+    "sync_mdns",
+    "sync_coordinator_url",
+    "sync_coordinator_group",
+    "sync_coordinator_timeout_s",
+    "sync_coordinator_presence_ttl_s",
+}
 
 
 def _config_value_changed(before: dict[str, Any], after: dict[str, Any], key: str) -> bool:
@@ -241,10 +251,17 @@ def _build_effects(
 
 
 def _as_positive_int(value: Any, *, key: str, allow_zero: bool = False) -> int | None:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError):
+    if isinstance(value, bool):
         return None
+    if isinstance(value, float):
+        if not value.is_integer():
+            return None
+        parsed = int(value)
+    else:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
     if allow_zero:
         return parsed if parsed >= 0 else None
     return parsed if parsed > 0 else None
@@ -359,6 +376,10 @@ def handle_post(
         "sync_port",
         "sync_interval_s",
         "sync_mdns",
+        "sync_coordinator_url",
+        "sync_coordinator_group",
+        "sync_coordinator_timeout_s",
+        "sync_coordinator_presence_ttl_s",
         "raw_events_sweeper_interval_s",
     )
     allowed_providers = set(load_provider_options())
@@ -545,7 +566,22 @@ def handle_post(
                 continue
             config_data[key] = host_value
             continue
-        if key in {"sync_port", "sync_interval_s"}:
+        if key in {"sync_coordinator_url", "sync_coordinator_group"}:
+            if not isinstance(value, str):
+                handler._send_json({"error": f"{key} must be string"}, status=400)
+                return True
+            string_value = value.strip()
+            if not string_value:
+                config_data.pop(key, None)
+                continue
+            config_data[key] = string_value
+            continue
+        if key in {
+            "sync_port",
+            "sync_interval_s",
+            "sync_coordinator_timeout_s",
+            "sync_coordinator_presence_ttl_s",
+        }:
             parsed = _as_positive_int(value, key=key)
             if parsed is None:
                 handler._send_json({"error": f"{key} must be int"}, status=400)

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -2247,7 +2247,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     syncHost: "sync_host",
     syncPort: "sync_port",
     syncInterval: "sync_interval_s",
-    syncMdns: "sync_mdns"
+    syncMdns: "sync_mdns",
+    syncCoordinatorUrl: "sync_coordinator_url",
+    syncCoordinatorGroup: "sync_coordinator_group",
+    syncCoordinatorTimeout: "sync_coordinator_timeout_s",
+    syncCoordinatorPresenceTtl: "sync_coordinator_presence_ttl_s"
   };
   function loadAdvancedPreference() {
     try {
@@ -2316,6 +2320,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       case "observer_model":
       case "observer_auth_file":
       case "sync_host":
+      case "sync_coordinator_url":
+      case "sync_coordinator_group":
         return normalizeTextValue(asInputString(config?.[key]));
       case "observer_runtime":
         return normalizeTextValue(asInputString(config?.observer_runtime));
@@ -2347,6 +2353,12 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         if (!hasOwn(config, key)) return "";
         const parsed = Number(config[key]);
         return Number.isFinite(parsed) && parsed !== 0 ? parsed : "";
+      }
+      case "sync_coordinator_timeout_s":
+      case "sync_coordinator_presence_ttl_s": {
+        if (!hasOwn(config, key)) return "";
+        const parsed = Number(config[key]);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : "";
       }
       case "observer_auth_cache_ttl_s": {
         if (!hasOwn(config, key)) return "";
@@ -2604,6 +2616,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const syncPort = $input("syncPort");
     const syncInterval = $input("syncInterval");
     const syncMdns = $input("syncMdns");
+    const syncCoordinatorUrl = $input("syncCoordinatorUrl");
+    const syncCoordinatorGroup = $input("syncCoordinatorGroup");
+    const syncCoordinatorTimeout = $input("syncCoordinatorTimeout");
+    const syncCoordinatorPresenceTtl = $input("syncCoordinatorPresenceTtl");
     const settingsPath = $("settingsPath");
     const observerModelHint = $("observerModelHint");
     const observerMaxCharsHint = $("observerMaxCharsHint");
@@ -2654,6 +2670,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (syncPort) syncPort.value = asInputString(effectiveOrConfigured(config, effective, "sync_port"));
     if (syncInterval) syncInterval.value = asInputString(effectiveOrConfigured(config, effective, "sync_interval_s"));
     if (syncMdns) syncMdns.checked = Boolean(effectiveOrConfigured(config, effective, "sync_mdns"));
+    if (syncCoordinatorUrl) syncCoordinatorUrl.value = asInputString(effectiveOrConfigured(config, effective, "sync_coordinator_url"));
+    if (syncCoordinatorGroup) syncCoordinatorGroup.value = asInputString(effectiveOrConfigured(config, effective, "sync_coordinator_group"));
+    if (syncCoordinatorTimeout) syncCoordinatorTimeout.value = asInputString(effectiveOrConfigured(config, effective, "sync_coordinator_timeout_s"));
+    if (syncCoordinatorPresenceTtl) syncCoordinatorPresenceTtl.value = asInputString(effectiveOrConfigured(config, effective, "sync_coordinator_presence_ttl_s"));
     if (settingsPath) settingsPath.textContent = state.configPath ? `Config path: ${state.configPath}` : "Config path: n/a";
     if (observerModelHint) renderObserverModelHint();
     if (observerMaxCharsHint) {
@@ -2788,7 +2808,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       sync_host: normalizeTextValue($input("syncHost")?.value || ""),
       sync_port: Number($input("syncPort")?.value || 0) || "",
       sync_interval_s: Number($input("syncInterval")?.value || 0) || "",
-      sync_mdns: $input("syncMdns")?.checked || false
+      sync_mdns: $input("syncMdns")?.checked || false,
+      sync_coordinator_url: normalizeTextValue($input("syncCoordinatorUrl")?.value || ""),
+      sync_coordinator_group: normalizeTextValue($input("syncCoordinatorGroup")?.value || ""),
+      sync_coordinator_timeout_s: Number($input("syncCoordinatorTimeout")?.value || 0) || "",
+      sync_coordinator_presence_ttl_s: Number($input("syncCoordinatorPresenceTtl")?.value || 0) || ""
     };
   }
   function updateAuthSourceVisibility() {
@@ -2927,7 +2951,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       "syncHost",
       "syncPort",
       "syncInterval",
-      "syncMdns"
+      "syncMdns",
+      "syncCoordinatorUrl",
+      "syncCoordinatorGroup",
+      "syncCoordinatorTimeout",
+      "syncCoordinatorPresenceTtl"
     ];
     inputs.forEach((id) => {
       const input = document.getElementById(id);

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1455,6 +1455,24 @@
               <div class="field settings-advanced" hidden><label for="syncHost">Sync host</label><input id="syncHost" placeholder="127.0.0.1" /></div>
               <div class="field settings-advanced" hidden><label for="syncPort">Sync port</label><input id="syncPort" type="number" min="1" /></div>
               <div class="field field-checkbox settings-advanced" hidden><input class="cm-checkbox" id="syncMdns" type="checkbox" /><label for="syncMdns">Enable mDNS discovery</label></div>
+              <div class="field">
+                <label for="syncCoordinatorUrl">Coordinator URL</label>
+                <input id="syncCoordinatorUrl" placeholder="https://coord.example.workers.dev" />
+                <div class="small">Optional self-hosted/operator-run discovery service. Direct peer-to-peer sync remains the data path.</div>
+              </div>
+              <div class="field">
+                <label for="syncCoordinatorGroup">Coordinator group</label>
+                <input id="syncCoordinatorGroup" placeholder="nerdworld" />
+                <div class="small">Discovery namespace for peers using the same coordinator.</div>
+              </div>
+              <div class="field settings-advanced" hidden>
+                <label for="syncCoordinatorTimeout">Coordinator timeout (seconds)</label>
+                <input id="syncCoordinatorTimeout" type="number" min="1" />
+              </div>
+              <div class="field settings-advanced" hidden>
+                <label for="syncCoordinatorPresenceTtl">Presence TTL (seconds)</label>
+                <input id="syncCoordinatorPresenceTtl" type="number" min="1" />
+              </div>
             </div>
           </div>
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -163,6 +163,7 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 
 - Use coordinator-backed discovery when peers are reachable but their addresses change frequently or mDNS does not work across network boundaries such as VPNs.
 - Set `sync_coordinator_url` and `sync_coordinator_group` to enable it.
+- The Settings UI exposes coordinator URL, group, timeout, and presence TTL fields under the Sync tab.
 - The coordinator is self-hosted/operator-run and only helps peers discover fresh addresses; direct peer-to-peer sync remains the data path.
 - See [docs/coordinator-discovery.md](coordinator-discovery.md) for setup, config, and current limitations.
 

--- a/tests/test_viewer_routes_config.py
+++ b/tests/test_viewer_routes_config.py
@@ -67,6 +67,77 @@ def test_config_route_accepts_observer_auth_fields(
     assert saved["raw_events_sweeper_interval_s"] == 45
 
 
+def test_config_route_accepts_sync_coordinator_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler(
+        {
+            "sync_coordinator_url": "https://coord.example.workers.dev",
+            "sync_coordinator_group": "nerdworld",
+            "sync_coordinator_timeout_s": 5,
+            "sync_coordinator_presence_ttl_s": 240,
+        }
+    )
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 200
+    saved = read_config_file(config_path)
+    assert saved["sync_coordinator_url"] == "https://coord.example.workers.dev"
+    assert saved["sync_coordinator_group"] == "nerdworld"
+    assert saved["sync_coordinator_timeout_s"] == 5
+    assert saved["sync_coordinator_presence_ttl_s"] == 240
+
+
+def test_config_route_rejects_invalid_sync_coordinator_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler({"sync_coordinator_timeout_s": "abc"})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "sync_coordinator_timeout_s must be int"}
+
+
+def test_config_route_rejects_fractional_sync_coordinator_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+
+    handler = DummyHandler({"sync_coordinator_timeout_s": 1.9})
+
+    handled = viewer_config.handle_post(
+        handler,
+        path="/api/config",
+        load_provider_options=lambda: ["openai", "anthropic"],
+    )
+
+    assert handled is True
+    assert handler.status == 400
+    assert handler.response == {"error": "sync_coordinator_timeout_s must be int"}
+
+
 def test_config_route_preserves_observer_auth_command_exactly(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -39,6 +39,10 @@ const INPUT_TO_CONFIG_KEY: Record<string, string> = {
   syncPort: 'sync_port',
   syncInterval: 'sync_interval_s',
   syncMdns: 'sync_mdns',
+  syncCoordinatorUrl: 'sync_coordinator_url',
+  syncCoordinatorGroup: 'sync_coordinator_group',
+  syncCoordinatorTimeout: 'sync_coordinator_timeout_s',
+  syncCoordinatorPresenceTtl: 'sync_coordinator_presence_ttl_s',
 };
 
 function loadAdvancedPreference(): boolean {
@@ -116,6 +120,8 @@ function configuredValueForKey(config: any, key: string): unknown {
     case 'observer_model':
     case 'observer_auth_file':
     case 'sync_host':
+    case 'sync_coordinator_url':
+    case 'sync_coordinator_group':
       return normalizeTextValue(asInputString(config?.[key]));
     case 'observer_runtime':
       return normalizeTextValue(asInputString(config?.observer_runtime));
@@ -147,6 +153,12 @@ function configuredValueForKey(config: any, key: string): unknown {
       if (!hasOwn(config, key)) return '';
       const parsed = Number(config[key]);
       return Number.isFinite(parsed) && parsed !== 0 ? parsed : '';
+    }
+    case 'sync_coordinator_timeout_s':
+    case 'sync_coordinator_presence_ttl_s': {
+      if (!hasOwn(config, key)) return '';
+      const parsed = Number(config[key]);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : '';
     }
     case 'observer_auth_cache_ttl_s': {
       if (!hasOwn(config, key)) return '';
@@ -453,6 +465,10 @@ export function renderConfigModal(payload: any) {
   const syncPort = $input('syncPort');
   const syncInterval = $input('syncInterval');
   const syncMdns = $input('syncMdns');
+  const syncCoordinatorUrl = $input('syncCoordinatorUrl');
+  const syncCoordinatorGroup = $input('syncCoordinatorGroup');
+  const syncCoordinatorTimeout = $input('syncCoordinatorTimeout');
+  const syncCoordinatorPresenceTtl = $input('syncCoordinatorPresenceTtl');
   const settingsPath = $('settingsPath');
   const observerModelHint = $('observerModelHint');
   const observerMaxCharsHint = $('observerMaxCharsHint');
@@ -505,6 +521,10 @@ export function renderConfigModal(payload: any) {
   if (syncPort) syncPort.value = asInputString(effectiveOrConfigured(config, effective, 'sync_port'));
   if (syncInterval) syncInterval.value = asInputString(effectiveOrConfigured(config, effective, 'sync_interval_s'));
   if (syncMdns) syncMdns.checked = Boolean(effectiveOrConfigured(config, effective, 'sync_mdns'));
+  if (syncCoordinatorUrl) syncCoordinatorUrl.value = asInputString(effectiveOrConfigured(config, effective, 'sync_coordinator_url'));
+  if (syncCoordinatorGroup) syncCoordinatorGroup.value = asInputString(effectiveOrConfigured(config, effective, 'sync_coordinator_group'));
+  if (syncCoordinatorTimeout) syncCoordinatorTimeout.value = asInputString(effectiveOrConfigured(config, effective, 'sync_coordinator_timeout_s'));
+  if (syncCoordinatorPresenceTtl) syncCoordinatorPresenceTtl.value = asInputString(effectiveOrConfigured(config, effective, 'sync_coordinator_presence_ttl_s'));
 
   if (settingsPath) settingsPath.textContent = state.configPath ? `Config path: ${state.configPath}` : 'Config path: n/a';
   if (observerModelHint) renderObserverModelHint();
@@ -657,6 +677,10 @@ function collectSettingsPayload(options: { allowUntouchedParseErrors?: boolean }
     sync_port: Number($input('syncPort')?.value || 0) || '',
     sync_interval_s: Number($input('syncInterval')?.value || 0) || '',
     sync_mdns: $input('syncMdns')?.checked || false,
+    sync_coordinator_url: normalizeTextValue($input('syncCoordinatorUrl')?.value || ''),
+    sync_coordinator_group: normalizeTextValue($input('syncCoordinatorGroup')?.value || ''),
+    sync_coordinator_timeout_s: Number($input('syncCoordinatorTimeout')?.value || 0) || '',
+    sync_coordinator_presence_ttl_s: Number($input('syncCoordinatorPresenceTtl')?.value || 0) || '',
   };
 }
 
@@ -810,6 +834,10 @@ export function initSettings(stopPolling: () => void, startPolling: () => void, 
     'syncPort',
     'syncInterval',
     'syncMdns',
+    'syncCoordinatorUrl',
+    'syncCoordinatorGroup',
+    'syncCoordinatorTimeout',
+    'syncCoordinatorPresenceTtl',
   ];
   inputs.forEach((id) => {
     const input = document.getElementById(id);


### PR DESCRIPTION
## Description
- add coordinator discovery settings to the viewer settings UI
- persist coordinator URL, group, timeout, and presence TTL through the config API
- document the settings flow in the user guide

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_viewer_routes_config.py`
- `uv run ruff check codemem/viewer_routes/config.py tests/test_viewer_routes_config.py`
- `bun run check`
- `bun run build`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced