### PR TITLE
feat: add Cloudflare coordinator bootstrap helper

### DIFF
--- a/docs/plans/2026-03-12-cloudflare-bootstrap-script-design.md
+++ b/docs/plans/2026-03-12-cloudflare-bootstrap-script-design.md
@@ -1,0 +1,157 @@
+# Cloudflare Coordinator Bootstrap Script Design
+
+**Bead:** `codemem-iw3`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Goal
+
+Provide a user-friendly bootstrap flow for the Cloudflare coordinator example that is:
+
+- easy to run manually
+- pleasant and guided when interactive
+- fully scriptable for automation
+
+## Recommended shape
+
+Implement this as a standalone Python helper in:
+
+- `examples/cloudflare-coordinator/bootstrap.py`
+
+Do **not** bake it into the main `codemem` CLI yet.
+
+## Why script-first
+
+- Cloudflare bootstrap is deployment-specific, not core product behavior
+- it depends on operator workflow and external tooling like `wrangler`
+- the built-in coordinator service belongs in the main CLI; Cloudflare bootstrap does not need to yet
+
+## Dependency choice
+
+Recommended stack:
+
+- `Typer` for command/flag handling
+- `rich` for formatted output
+- `questionary` for interactive prompts
+
+Fallback if we want fewer dependencies:
+
+- `Typer` + `rich.prompt`
+
+Recommendation:
+
+- start with `Typer` + `rich` + `questionary`
+
+This gives us a nice interactive experience without sacrificing scriptability.
+
+## Modes
+
+### Interactive mode (default)
+
+Running without enough flags should walk the operator through setup.
+
+The script should:
+
+1. detect local codemem identity (`device_id`, fingerprint, public key)
+2. check that `wrangler` is installed and authenticated
+3. ask for the coordinator group name
+4. create the D1 database if needed
+5. create or patch `wrangler.toml`
+6. apply the schema
+7. optionally deploy the Worker
+8. show or confirm the resulting Worker URL
+9. apply or print the D1 enrollment SQL for the local device
+10. optionally write or print a config snippet for `config.json`
+11. optionally run the existing smoke check
+
+### Scriptable mode
+
+All required inputs must be passable as flags.
+
+Recommended flags:
+
+- `--group`
+- `--worker-url`
+- `--db-path`
+- `--keys-dir`
+- `--config-path`
+- `--create-d1`
+- `--apply-schema`
+- `--deploy`
+- `--enroll-local`
+- `--print-sql`
+- `--print-config`
+- `--run-smoke-check`
+- `--dry-run`
+- `--non-interactive`
+- `--format text|json`
+
+Behavior:
+
+- no prompts when `--non-interactive` is set
+- machine-readable output when `--format json` is requested
+- non-zero exit on validation or smoke-check failure
+
+## First implementation scope
+
+The first version should automate most of the operator workflow once `wrangler login` is already complete.
+
+It should:
+
+- read local identity information from the codemem DB and key store
+- verify `wrangler` is available
+- create D1 and apply schema when requested
+- write or patch `wrangler.toml` from the example when requested
+- deploy the Worker when requested
+- generate and optionally apply enrollment SQL for the local device
+- generate optional config snippets pointing codemem at the Worker
+- optionally run the existing smoke-check script
+
+It should **not** try to:
+
+- mutate D1 directly unless we explicitly decide to shell out to `wrangler`
+- enroll multiple devices in one run
+- become a generic Cloudflare deployment framework
+
+`--dry-run` should remain available so operators can see exactly what would be executed before the script mutates any
+Cloudflare resources.
+
+## Output design
+
+Interactive mode should present:
+
+- detected identity summary
+- generated SQL block
+- generated config snippet
+- next-step checklist
+
+Scriptable mode should be able to emit JSON like:
+
+```json
+{
+  "group": "team-alpha",
+  "device_id": "...",
+  "fingerprint": "SHA256:...",
+  "public_key_file": "...",
+  "enrollment_sql": "...",
+  "config_snippet": {
+    "sync_coordinator_url": "https://...",
+    "sync_coordinator_group": "team-alpha"
+  }
+}
+```
+
+## Nice-to-have follow-ons
+
+- optional shell-out helpers for `wrangler d1 execute`
+- optional Terraform example for Worker + D1 infra
+- multi-device enrollment bundle generation
+
+## Acceptance criteria
+
+This design is successful when:
+
+1. The bootstrap flow is clearly script-first, not main-CLI-first.
+2. Interactive and non-interactive modes are both defined.
+3. Dependency choices are pragmatic and lightweight.
+4. The first implementation scope stays focused on local device bootstrap and verification.

--- a/examples/cloudflare-coordinator/.gitignore
+++ b/examples/cloudflare-coordinator/.gitignore
@@ -1,0 +1,2 @@
+.wrangler/
+wrangler.toml

--- a/examples/cloudflare-coordinator/README.md
+++ b/examples/cloudflare-coordinator/README.md
@@ -15,18 +15,88 @@ It is not a relay, queue, or central memory store.
 - `src/index.mjs` - Worker implementation
 - `schema.sql` - D1 schema
 - `wrangler.toml.example` - example Wrangler config
+- `bootstrap.py` - guided bootstrap helper for local device enrollment
 - `smoke_check.py` - live smoke-check script for deployed endpoints
 
-## Create the D1 database
+## First-time setup
+
+### 1. Install and authenticate Wrangler
+
+```fish
+npm install -g wrangler
+wrangler login
+```
+
+### 2. Create the D1 database
 
 ```fish
 wrangler d1 create codemem-coordinator
-wrangler d1 execute codemem-coordinator --file examples/cloudflare-coordinator/schema.sql
 ```
 
-Copy the returned D1 database ID into `wrangler.toml.example` or your real `wrangler.toml`.
+Copy the returned D1 database ID into a real `wrangler.toml` created from `wrangler.toml.example`.
+
+### 3. Create a real `wrangler.toml`
+
+```fish
+cp examples/cloudflare-coordinator/wrangler.toml.example examples/cloudflare-coordinator/wrangler.toml
+```
+
+Then edit `examples/cloudflare-coordinator/wrangler.toml` and replace:
+
+- `REPLACE_WITH_D1_DATABASE_ID`
+
+with the actual D1 database ID from step 2.
+
+### 4. Apply the schema
+
+```fish
+wrangler d1 execute codemem-coordinator --remote --file examples/cloudflare-coordinator/schema.sql
+```
+
+### 5. Deploy the Worker
+
+```fish
+wrangler deploy
+```
+
+Wrangler prints the deployed Worker URL, for example:
+
+- `https://codemem-coordinator.<your-subdomain>.workers.dev`
+
+That URL becomes your `sync_coordinator_url`.
 
 ## Bootstrap enrollment
+
+The easiest path is the bootstrap helper:
+
+```fish
+uv run python examples/cloudflare-coordinator/bootstrap.py
+```
+
+It will:
+
+- detect your local codemem device identity
+- create or reuse the named D1 database when requested
+- write `wrangler.toml` once it knows the D1 database id
+- apply schema and enrollment SQL remotely when requested
+- generate D1 enrollment SQL for the selected group
+- print a config snippet for `sync_coordinator_url` and `sync_coordinator_group`
+- optionally run the smoke check
+
+The script automates most of the flow once `wrangler login` is already complete, but the manual steps below are still
+useful if you want to inspect or repair the setup by hand.
+
+For automation, use non-interactive JSON output:
+
+```fish
+uv run python examples/cloudflare-coordinator/bootstrap.py \
+  --group team-alpha \
+  --worker-url "https://your-worker.example.workers.dev" \
+  --non-interactive \
+  --format json
+```
+
+If you want to follow the manual path, the details are below.
 
 The first slice assumes explicit operator enrollment.
 
@@ -49,10 +119,10 @@ VALUES (
 );
 ```
 
-## Deploy
+Apply manual enrollment against the remote D1 database:
 
 ```fish
-wrangler deploy
+wrangler d1 execute codemem-coordinator --remote --command "<paste generated SQL here>"
 ```
 
 ## Configure codemem

--- a/examples/cloudflare-coordinator/bootstrap.py
+++ b/examples/cloudflare-coordinator/bootstrap.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Confirm, Prompt
+from rich.syntax import Syntax
+
+from codemem import db
+from codemem.sync_identity import ensure_device_identity, fingerprint_public_key, load_public_key
+
+app = typer.Typer(add_completion=False, help="Bootstrap the Cloudflare coordinator example")
+console = Console()
+WRANGLER_TOML_TEMPLATE = Path(__file__).with_name("wrangler.toml.example")
+SCHEMA_SQL_PATH = Path(__file__).with_name("schema.sql")
+DRY_RUN_DATABASE_ID = "00000000-0000-0000-0000-000000000000"
+
+
+class CommandFailure(RuntimeError):
+    def __init__(self, command: list[str], *, stdout: str = "", stderr: str = "") -> None:
+        self.command = command
+        self.stdout = stdout
+        self.stderr = stderr
+        detail = "\n".join(part for part in [stdout, stderr] if part).strip()
+        super().__init__(detail or f"command failed: {' '.join(command)}")
+
+
+def _load_local_identity(db_path: Path, keys_dir: Path | None) -> dict[str, str]:
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        device_id, fingerprint = ensure_device_identity(conn, keys_dir=keys_dir)
+    finally:
+        conn.close()
+    public_key = load_public_key(keys_dir)
+    if not public_key:
+        raise typer.BadParameter("public key missing")
+    return {
+        "device_id": device_id,
+        "fingerprint": fingerprint or fingerprint_public_key(public_key),
+        "public_key": public_key.strip(),
+    }
+
+
+def _sql_escape(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def build_enrollment_sql(
+    *,
+    group: str,
+    device_id: str,
+    fingerprint: str,
+    public_key: str,
+    device_name: str,
+) -> str:
+    return (
+        "INSERT INTO groups(group_id, display_name, created_at)\n"
+        f"VALUES ('{_sql_escape(group)}', '{_sql_escape(group)}', CURRENT_TIMESTAMP)\n"
+        "ON CONFLICT(group_id) DO NOTHING;\n\n"
+        "INSERT INTO enrolled_devices(group_id, device_id, public_key, fingerprint, display_name, created_at)\n"
+        "VALUES (\n"
+        f"  '{_sql_escape(group)}',\n"
+        f"  '{_sql_escape(device_id)}',\n"
+        f"  '{_sql_escape(public_key)}',\n"
+        f"  '{_sql_escape(fingerprint)}',\n"
+        f"  '{_sql_escape(device_name)}',\n"
+        "  CURRENT_TIMESTAMP\n"
+        ");"
+    )
+
+
+def build_config_snippet(*, worker_url: str, group: str) -> dict[str, str]:
+    return {
+        "sync_coordinator_url": worker_url.rstrip("/"),
+        "sync_coordinator_group": group,
+    }
+
+
+def build_wrangle_commands(*, database_name: str) -> list[str]:
+    return [
+        f"wrangler d1 create {database_name}",
+        f"wrangler d1 execute {database_name} --file {SCHEMA_SQL_PATH.as_posix()}",
+    ]
+
+
+def parse_d1_create_output(output: str) -> str | None:
+    patterns = [
+        re.compile(r"database_id\s*=\s*([0-9a-f-]{16,})", re.IGNORECASE),
+        re.compile(r"database id[:\s]+([0-9a-f-]{16,})", re.IGNORECASE),
+        re.compile(r'"uuid"\s*:\s*"([0-9a-f-]{16,})"', re.IGNORECASE),
+        re.compile(
+            r"\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b", re.IGNORECASE
+        ),
+    ]
+    for pattern in patterns:
+        match = pattern.search(output)
+        if match:
+            return match.group(1)
+    return None
+
+
+def parse_worker_url_output(output: str) -> str | None:
+    match = re.search(r"https://[a-z0-9.-]+\.workers\.dev", output, re.IGNORECASE)
+    return match.group(0) if match else None
+
+
+def render_wrangler_toml(*, database_id: str) -> str:
+    template = WRANGLER_TOML_TEMPLATE.read_text()
+    return template.replace("REPLACE_WITH_D1_DATABASE_ID", database_id)
+
+
+def write_wrangler_toml(*, wrangler_toml: Path, database_id: str) -> None:
+    wrangler_toml.parent.mkdir(parents=True, exist_ok=True)
+    wrangler_toml.write_text(render_wrangler_toml(database_id=database_id))
+
+
+def read_database_id_from_wrangler_toml(wrangler_toml: Path) -> str | None:
+    if not wrangler_toml.exists():
+        return None
+    return parse_d1_create_output(wrangler_toml.read_text())
+
+
+def parse_d1_list_output(output: str) -> list[dict[str, str]]:
+    text = output.strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, list):
+        results: list[dict[str, str]] = []
+        for item in parsed:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name") or item.get("database_name") or "").strip()
+            uuid = str(item.get("uuid") or item.get("database_id") or "").strip()
+            if name and uuid:
+                results.append({"name": name, "uuid": uuid})
+        return results
+    results = []
+    for line in text.splitlines():
+        match = re.search(
+            r"(?P<name>[A-Za-z0-9._-]+).*?(?P<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+            line,
+            re.IGNORECASE,
+        )
+        if match:
+            results.append({"name": match.group("name"), "uuid": match.group("uuid")})
+    return results
+
+
+def list_d1_databases(*, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = ["wrangler", "d1", "list", "--json"]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    output = "\n".join(part for part in [result.stdout, result.stderr] if part)
+    return {"command": command, "databases": parse_d1_list_output(output), "output": output}
+
+
+def find_existing_database_id(
+    *, database_name: str, dry_run: bool, cwd: Path
+) -> tuple[str | None, dict[str, Any] | None]:
+    listing = list_d1_databases(dry_run=dry_run, cwd=cwd)
+    for item in listing["databases"]:
+        if str(item.get("name") or "").strip() == database_name:
+            return str(item.get("uuid") or "").strip() or None, listing
+    return None, listing
+
+
+def run_command(
+    command: list[str],
+    *,
+    dry_run: bool,
+    cwd: Path,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    if dry_run:
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+    try:
+        return subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            capture_output=capture_output,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise typer.BadParameter(f"missing required command: {command[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise CommandFailure(command, stdout=exc.stdout or "", stderr=exc.stderr or "") from exc
+
+
+def ensure_wrangler_ready(*, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = ["wrangler", "whoami"]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    return {"command": command, "stdout": result.stdout, "stderr": result.stderr}
+
+
+def create_d1_database(*, database_name: str, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = ["wrangler", "d1", "create", database_name]
+    reused_existing = False
+    list_result = None
+    if dry_run:
+        return {
+            "command": command,
+            "database_id": DRY_RUN_DATABASE_ID,
+            "output": "",
+            "reused_existing": False,
+            "list_result": None,
+        }
+    try:
+        result = run_command(command, dry_run=dry_run, cwd=cwd)
+        output = "\n".join(part for part in [result.stdout, result.stderr] if part)
+        database_id = parse_d1_create_output(output)
+    except CommandFailure as exc:
+        output = str(exc)
+        if "already exists" not in output.lower():
+            raise
+        database_id, list_result = find_existing_database_id(
+            database_name=database_name,
+            dry_run=dry_run,
+            cwd=cwd,
+        )
+        if not database_id:
+            raise typer.BadParameter(
+                f"D1 database '{database_name}' already exists but its database id could not be discovered automatically. Run 'wrangler d1 list' and rerun the script with that id."
+            ) from exc
+        reused_existing = True
+    return {
+        "command": command,
+        "database_id": database_id,
+        "output": output,
+        "reused_existing": reused_existing,
+        "list_result": list_result,
+    }
+
+
+def apply_schema(*, database_name: str, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = [
+        "wrangler",
+        "d1",
+        "execute",
+        database_name,
+        "--remote",
+        "--file",
+        str(SCHEMA_SQL_PATH),
+    ]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    return {"command": command, "stdout": result.stdout, "stderr": result.stderr}
+
+
+def deploy_worker(*, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = ["wrangler", "deploy"]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    output = "\n".join(part for part in [result.stdout, result.stderr] if part)
+    return {"command": command, "worker_url": parse_worker_url_output(output), "output": output}
+
+
+def apply_enrollment_sql(
+    *, database_name: str, sql: str, dry_run: bool, cwd: Path
+) -> dict[str, Any]:
+    command = ["wrangler", "d1", "execute", database_name, "--remote", "--command", sql]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    return {"command": command, "stdout": result.stdout, "stderr": result.stderr}
+
+
+def _run_smoke_check(*, db_path: Path, worker_url: str, group: str, keys_dir: Path | None) -> int:
+    command = [
+        "uv",
+        "run",
+        "python",
+        "examples/cloudflare-coordinator/smoke_check.py",
+        "--db",
+        str(db_path),
+        "--url",
+        worker_url,
+        "--group",
+        group,
+    ]
+    if keys_dir is not None:
+        command.extend(["--keys-dir", str(keys_dir)])
+    result = subprocess.run(command, check=False)
+    return int(result.returncode)
+
+
+@app.command()
+def main(
+    db_path: Path = typer.Option(
+        Path("~/.codemem/mem.sqlite").expanduser(), help="Path to local codemem DB"
+    ),
+    group: str | None = typer.Option(None, help="Coordinator group ID"),
+    worker_url: str | None = typer.Option(None, help="Deployed Worker URL"),
+    keys_dir: Path | None = typer.Option(None, help="Optional CODEMEM_KEYS_DIR override"),
+    device_name: str | None = typer.Option(None, help="Optional display name for enrolled device"),
+    database_name: str = typer.Option(
+        "codemem-coordinator", help="Suggested Cloudflare D1 database name"
+    ),
+    wrangler_toml: Path = typer.Option(
+        Path(__file__).with_name("wrangler.toml"),
+        help="Path to generated wrangler.toml",
+    ),
+    create_d1: bool = typer.Option(False, help="Create the D1 database with wrangler"),
+    apply_schema_sql: bool = typer.Option(
+        False, "--apply-schema", help="Apply schema.sql with wrangler"
+    ),
+    deploy: bool = typer.Option(False, help="Deploy the Worker with wrangler"),
+    enroll_local: bool = typer.Option(False, help="Apply generated enrollment SQL with wrangler"),
+    dry_run: bool = typer.Option(False, help="Print commands without executing them"),
+    non_interactive: bool = typer.Option(
+        False, "--non-interactive", help="Disable prompts and require all needed values via flags"
+    ),
+    format: str = typer.Option("text", help="Output format: text or json"),
+    print_sql: bool = typer.Option(True, help="Include bootstrap SQL in the output"),
+    print_config: bool = typer.Option(True, help="Include config snippet in the output"),
+    run_smoke_check: bool = typer.Option(
+        False, help="Run smoke_check.py after printing bootstrap info"
+    ),
+) -> None:
+    if format not in {"text", "json"}:
+        raise typer.BadParameter("format must be 'text' or 'json'")
+    resolved_db_path = db_path.expanduser()
+    resolved_keys_dir = keys_dir.expanduser() if keys_dir is not None else None
+    resolved_wrangler_toml = wrangler_toml.expanduser()
+    script_dir = Path(__file__).resolve().parent
+    identity = _load_local_identity(resolved_db_path, resolved_keys_dir)
+
+    if not non_interactive:
+        create_d1 = create_d1 or Confirm.ask("Create the D1 database with wrangler?", default=True)
+        apply_schema_sql = apply_schema_sql or Confirm.ask(
+            "Apply schema.sql with wrangler?", default=True
+        )
+        deploy = deploy or Confirm.ask("Deploy the Worker with wrangler?", default=True)
+        enroll_local = enroll_local or Confirm.ask(
+            "Apply enrollment SQL with wrangler?", default=True
+        )
+
+    if not group:
+        if non_interactive:
+            raise typer.BadParameter("--group is required in non-interactive mode")
+        group = Prompt.ask("Coordinator group", default="team-alpha")
+    if not device_name:
+        if non_interactive:
+            device_name = identity["device_id"]
+        else:
+            device_name = Prompt.ask("Device display name", default=identity["device_id"])
+
+    needs_wrangler = create_d1 or apply_schema_sql or deploy or enroll_local
+    try:
+        wrangler_ready = (
+            ensure_wrangler_ready(dry_run=dry_run, cwd=script_dir) if needs_wrangler else None
+        )
+    except CommandFailure as exc:
+        raise typer.BadParameter(
+            f"wrangler is not ready. Run 'wrangler login' first.\n\n{exc}"
+        ) from exc
+
+    database_id = read_database_id_from_wrangler_toml(resolved_wrangler_toml)
+    d1_create = None
+    if create_d1:
+        d1_create = create_d1_database(database_name=database_name, dry_run=dry_run, cwd=script_dir)
+        database_id = d1_create.get("database_id") or database_id
+    elif not database_id and needs_wrangler:
+        database_id, list_result = find_existing_database_id(
+            database_name=database_name,
+            dry_run=dry_run,
+            cwd=script_dir,
+        )
+        if list_result is not None:
+            d1_create = {
+                "command": ["wrangler", "d1", "list", "--json"],
+                "database_id": database_id,
+                "output": list_result.get("output", ""),
+                "reused_existing": bool(database_id),
+                "list_result": list_result,
+            }
+    if not database_id and not non_interactive:
+        database_id = Prompt.ask("Cloudflare D1 database id", default="") or None
+    if dry_run and not database_id and needs_wrangler:
+        database_id = DRY_RUN_DATABASE_ID
+    if needs_wrangler and not database_id:
+        raise typer.BadParameter(
+            f"No D1 database id is configured for '{database_name}'. Create it first or provide its id."
+        )
+    if database_id:
+        if not dry_run:
+            write_wrangler_toml(wrangler_toml=resolved_wrangler_toml, database_id=database_id)
+    elif not dry_run and resolved_wrangler_toml.exists():
+        console.print(f"[yellow]Keeping existing {resolved_wrangler_toml}[/yellow]")
+
+    try:
+        schema_result = (
+            apply_schema(database_name=database_name, dry_run=dry_run, cwd=script_dir)
+            if apply_schema_sql
+            else None
+        )
+        deploy_result = deploy_worker(dry_run=dry_run, cwd=script_dir) if deploy else None
+    except CommandFailure as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    if not worker_url:
+        worker_url = (deploy_result or {}).get("worker_url") if deploy_result else None
+    if not worker_url:
+        if non_interactive:
+            raise typer.BadParameter("--worker-url is required unless --deploy discovers it")
+        worker_url = Prompt.ask("Worker URL", default="https://your-worker.example.workers.dev")
+
+    sql = build_enrollment_sql(
+        group=group,
+        device_id=identity["device_id"],
+        fingerprint=identity["fingerprint"],
+        public_key=identity["public_key"],
+        device_name=device_name,
+    )
+    config_snippet = build_config_snippet(worker_url=worker_url, group=group)
+    try:
+        enrollment_result = (
+            apply_enrollment_sql(
+                database_name=database_name,
+                sql=sql,
+                dry_run=dry_run,
+                cwd=script_dir,
+            )
+            if enroll_local
+            else None
+        )
+    except CommandFailure as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    payload = {
+        "group": group,
+        "device_id": identity["device_id"],
+        "fingerprint": identity["fingerprint"],
+        "device_name": device_name,
+        "public_key": identity["public_key"],
+        "wrangler_ready": wrangler_ready,
+        "database_id": database_id,
+        "wrangler_toml": str(resolved_wrangler_toml),
+        "needs_wrangler": needs_wrangler,
+        "wrangler_commands": build_wrangle_commands(database_name=database_name),
+        "d1_create": d1_create,
+        "schema_apply": schema_result,
+        "deploy": deploy_result,
+        "enroll_local": enrollment_result,
+        "enrollment_sql": sql if print_sql else None,
+        "config_snippet": config_snippet if print_config else None,
+        "dry_run": dry_run,
+    }
+
+    if format == "json":
+        console.print_json(data=payload)
+    else:
+        console.print(Panel.fit("Cloudflare coordinator bootstrap", style="cyan"))
+        console.print(f"[bold]Device ID:[/bold] {identity['device_id']}")
+        console.print(f"[bold]Fingerprint:[/bold] {identity['fingerprint']}")
+        console.print(f"[bold]Group:[/bold] {group}")
+        console.print(f"[bold]Worker URL:[/bold] {worker_url}")
+        if database_id:
+            console.print(f"[bold]D1 database id:[/bold] {database_id}")
+        console.print(f"[bold]wrangler.toml:[/bold] {resolved_wrangler_toml}")
+        console.print("\n[bold]Wrangler setup commands[/bold]")
+        for command in payload["wrangler_commands"]:
+            console.print(f"- {command}")
+        if print_sql:
+            console.print("\n[bold]Enrollment SQL[/bold]")
+            console.print(Syntax(sql, "sql", word_wrap=True))
+        if print_config:
+            console.print("\n[bold]Config snippet[/bold]")
+            console.print(Syntax(json.dumps(config_snippet, indent=2), "json", word_wrap=True))
+        console.print("\n[bold]Next steps[/bold]")
+        console.print("1. Confirm wrangler commands succeeded")
+        console.print("2. Add the config snippet to your codemem config")
+        console.print("3. Run the smoke check")
+
+    should_run_smoke = run_smoke_check
+    if not non_interactive and not should_run_smoke:
+        should_run_smoke = Confirm.ask("Run smoke check now?", default=False)
+    if should_run_smoke:
+        exit_code = _run_smoke_check(
+            db_path=resolved_db_path,
+            worker_url=worker_url,
+            group=group,
+            keys_dir=resolved_keys_dir,
+        )
+        if exit_code != 0:
+            raise typer.Exit(code=exit_code)
+
+
+if __name__ == "__main__":
+    app()

--- a/examples/cloudflare-coordinator/smoke_check.py
+++ b/examples/cloudflare-coordinator/smoke_check.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from urllib import request
+from urllib import error, request
 
 from codemem import db
 from codemem.sync_auth import build_auth_headers
@@ -17,8 +17,12 @@ def _json_request(
     if body is not None:
         body_bytes = json.dumps(body, ensure_ascii=False).encode("utf-8")
     req = request.Request(url, data=body_bytes, headers=headers, method=method)
-    with request.urlopen(req, timeout=5) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+    try:
+        with request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"{method} {url} failed with HTTP {exc.code}: {detail}") from exc
 
 
 def main() -> None:

--- a/tests/test_cloudflare_bootstrap.py
+++ b/tests/test_cloudflare_bootstrap.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+from codemem import db
+from codemem.sync_identity import ensure_device_identity
+
+
+def _load_bootstrap_module():
+    path = (
+        Path(__file__).resolve().parents[1] / "examples" / "cloudflare-coordinator" / "bootstrap.py"
+    )
+    spec = importlib.util.spec_from_file_location("cloudflare_bootstrap", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cloudflare_bootstrap_script_outputs_json(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        device_id, fingerprint = ensure_device_identity(conn, keys_dir=keys_dir)
+    finally:
+        conn.close()
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "examples/cloudflare-coordinator/bootstrap.py",
+            "--db-path",
+            str(db_path),
+            "--keys-dir",
+            str(keys_dir),
+            "--group",
+            "nerdworld",
+            "--worker-url",
+            "https://coord.example.workers.dev",
+            "--device-name",
+            "laptop",
+            "--non-interactive",
+            "--format",
+            "json",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["group"] == "nerdworld"
+    assert payload["device_id"] == device_id
+    assert payload["fingerprint"] == fingerprint
+    assert payload["config_snippet"]["sync_coordinator_group"] == "nerdworld"
+    assert payload["config_snippet"]["sync_coordinator_url"] == "https://coord.example.workers.dev"
+    assert "INSERT INTO groups" in payload["enrollment_sql"]
+    assert any("wrangler d1 create" in command for command in payload["wrangler_commands"])
+
+
+def test_cloudflare_bootstrap_script_supports_full_dry_run_flow(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        device_id, _fingerprint = ensure_device_identity(conn, keys_dir=keys_dir)
+    finally:
+        conn.close()
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "examples/cloudflare-coordinator/bootstrap.py",
+            "--db-path",
+            str(db_path),
+            "--keys-dir",
+            str(keys_dir),
+            "--group",
+            "nerdworld",
+            "--worker-url",
+            "https://coord.example.workers.dev",
+            "--device-name",
+            "laptop",
+            "--create-d1",
+            "--apply-schema",
+            "--deploy",
+            "--enroll-local",
+            "--dry-run",
+            "--non-interactive",
+            "--format",
+            "json",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["device_id"] == device_id
+    assert payload["dry_run"] is True
+    assert payload["needs_wrangler"] is True
+    assert payload["wrangler_ready"]["command"] == ["wrangler", "whoami"]
+    assert payload["d1_create"]["command"][:3] == ["wrangler", "d1", "create"]
+    assert payload["schema_apply"]["command"][:3] == ["wrangler", "d1", "execute"]
+    assert payload["deploy"]["command"] == ["wrangler", "deploy"]
+    assert payload["enroll_local"]["command"][:3] == ["wrangler", "d1", "execute"]
+    assert "--remote" in payload["schema_apply"]["command"]
+    assert "--remote" in payload["enroll_local"]["command"]
+
+
+def test_create_d1_database_reuses_existing_database_id() -> None:
+    module = _load_bootstrap_module()
+
+    def fake_run_command(command, *, dry_run, cwd, capture_output=True):
+        if command[:3] == ["wrangler", "d1", "create"]:
+            raise module.CommandFailure(command, stderr="A database with that name already exists")
+        if command[:4] == ["wrangler", "d1", "list", "--json"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout='[{"name": "codemem-coordinator", "uuid": "784d138d-ab3c-4f5c-9464-cf45c5b69af3"}]',
+                stderr="",
+            )
+        raise AssertionError(command)
+
+    module.__dict__["run_command"] = fake_run_command
+    result = module.create_d1_database(
+        database_name="codemem-coordinator",
+        dry_run=False,
+        cwd=Path("."),
+    )
+
+    assert result["database_id"] == "784d138d-ab3c-4f5c-9464-cf45c5b69af3"
+    assert result["reused_existing"] is True


### PR DESCRIPTION
## Description
- add a script-first bootstrap helper for the Cloudflare coordinator example
- support interactive and non-interactive bootstrap flows, including dry-run automation of D1/schema/deploy/enrollment steps
- document the stronger first-time setup flow and bootstrap script design note

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_cloudflare_bootstrap.py`
- `uv run ruff check examples/cloudflare-coordinator/bootstrap.py tests/test_cloudflare_bootstrap.py`
- `uv run python -m py_compile examples/cloudflare-coordinator/bootstrap.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced