### PR TITLE
feat: add local coordinator management commands

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -1214,7 +1214,11 @@ def sync_coordinator_disable_device(
     db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
 ) -> None:
     """Disable an enrolled device without deleting its record."""
-    coordinator_disable_device_cmd(group_id=group_id, device_id=device_id, db_path=db_path)
+    coordinator_disable_device_cmd(
+        group_id=group_id,
+        device_id=device_id,
+        db_path=db_path,
+    )
 
 
 @sync_coordinator_app.command("remove-device")
@@ -1224,7 +1228,11 @@ def sync_coordinator_remove_device(
     db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
 ) -> None:
     """Remove an enrolled device and its cached presence record."""
-    coordinator_remove_device_cmd(group_id=group_id, device_id=device_id, db_path=db_path)
+    coordinator_remove_device_cmd(
+        group_id=group_id,
+        device_id=device_id,
+        db_path=db_path,
+    )
 
 
 def sync_service_status(

--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -79,8 +79,12 @@ from .commands.sync_cmds import (
     sync_uninstall_cmd,
 )
 from .commands.sync_coordinator_cmds import (
+    coordinator_disable_device_cmd,
     coordinator_enroll_device_cmd,
     coordinator_group_create_cmd,
+    coordinator_list_devices_cmd,
+    coordinator_remove_device_cmd,
+    coordinator_rename_device_cmd,
     coordinator_serve_cmd,
 )
 from .commands.sync_service_cmds import install_autostart_quiet as _install_autostart_quiet
@@ -1171,6 +1175,56 @@ def sync_coordinator_enroll_device(
         name=name,
         db_path=db_path,
     )
+
+
+@sync_coordinator_app.command("list-devices")
+def sync_coordinator_list_devices(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    include_disabled: bool = typer.Option(False, help="Include disabled devices"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """List enrolled devices in a coordinator group."""
+    coordinator_list_devices_cmd(
+        group_id=group_id,
+        include_disabled=include_disabled,
+        db_path=db_path,
+    )
+
+
+@sync_coordinator_app.command("rename-device")
+def sync_coordinator_rename_device(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    device_id: str = typer.Argument(..., help="Device ID to rename"),
+    name: str = typer.Option(..., help="New display name"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """Rename an enrolled device display name."""
+    coordinator_rename_device_cmd(
+        group_id=group_id,
+        device_id=device_id,
+        name=name,
+        db_path=db_path,
+    )
+
+
+@sync_coordinator_app.command("disable-device")
+def sync_coordinator_disable_device(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    device_id: str = typer.Argument(..., help="Device ID to disable"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """Disable an enrolled device without deleting its record."""
+    coordinator_disable_device_cmd(group_id=group_id, device_id=device_id, db_path=db_path)
+
+
+@sync_coordinator_app.command("remove-device")
+def sync_coordinator_remove_device(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    device_id: str = typer.Argument(..., help="Device ID to remove"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """Remove an enrolled device and its cached presence record."""
+    coordinator_remove_device_cmd(group_id=group_id, device_id=device_id, db_path=db_path)
 
 
 def sync_service_status(

--- a/codemem/commands/sync_coordinator_cmds.py
+++ b/codemem/commands/sync_coordinator_cmds.py
@@ -52,3 +52,56 @@ def coordinator_enroll_device_cmd(
     finally:
         store.close()
     print(f"[green]Enrolled device[/green] {device_id} -> {group_id}")
+
+
+def coordinator_list_devices_cmd(
+    *, group_id: str, include_disabled: bool, db_path: str | None
+) -> None:
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        rows = store.list_enrolled_devices(group_id=group_id, include_disabled=include_disabled)
+    finally:
+        store.close()
+    if not rows:
+        print(f"[yellow]No enrolled devices[/yellow] for {group_id}")
+        return
+    print(f"[bold]Enrolled devices[/bold] for {group_id}")
+    for row in rows:
+        state = "enabled" if row.get("enabled") else "disabled"
+        display_name = row.get("display_name") or row.get("device_id")
+        print(f"- {display_name} ({state}) ({row.get('device_id')})")
+
+
+def coordinator_rename_device_cmd(
+    *, group_id: str, device_id: str, name: str, db_path: str | None
+) -> None:
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        updated = store.rename_device(group_id=group_id, device_id=device_id, display_name=name)
+    finally:
+        store.close()
+    if not updated:
+        raise SystemExit(f"Device not found in {group_id}: {device_id}")
+    print(f"[green]Renamed device[/green] {device_id} -> {name}")
+
+
+def coordinator_disable_device_cmd(*, group_id: str, device_id: str, db_path: str | None) -> None:
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        updated = store.set_device_enabled(group_id=group_id, device_id=device_id, enabled=False)
+    finally:
+        store.close()
+    if not updated:
+        raise SystemExit(f"Device not found in {group_id}: {device_id}")
+    print(f"[green]Disabled device[/green] {device_id}")
+
+
+def coordinator_remove_device_cmd(*, group_id: str, device_id: str, db_path: str | None) -> None:
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        removed = store.remove_device(group_id=group_id, device_id=device_id)
+    finally:
+        store.close()
+    if not removed:
+        raise SystemExit(f"Device not found in {group_id}: {device_id}")
+    print(f"[green]Removed device[/green] {device_id}")

--- a/codemem/commands/sync_coordinator_cmds.py
+++ b/codemem/commands/sync_coordinator_cmds.py
@@ -55,7 +55,10 @@ def coordinator_enroll_device_cmd(
 
 
 def coordinator_list_devices_cmd(
-    *, group_id: str, include_disabled: bool, db_path: str | None
+    *,
+    group_id: str,
+    include_disabled: bool,
+    db_path: str | None,
 ) -> None:
     store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
     try:
@@ -73,7 +76,11 @@ def coordinator_list_devices_cmd(
 
 
 def coordinator_rename_device_cmd(
-    *, group_id: str, device_id: str, name: str, db_path: str | None
+    *,
+    group_id: str,
+    device_id: str,
+    name: str,
+    db_path: str | None,
 ) -> None:
     store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
     try:
@@ -85,7 +92,12 @@ def coordinator_rename_device_cmd(
     print(f"[green]Renamed device[/green] {device_id} -> {name}")
 
 
-def coordinator_disable_device_cmd(*, group_id: str, device_id: str, db_path: str | None) -> None:
+def coordinator_disable_device_cmd(
+    *,
+    group_id: str,
+    device_id: str,
+    db_path: str | None,
+) -> None:
     store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
     try:
         updated = store.set_device_enabled(group_id=group_id, device_id=device_id, enabled=False)
@@ -96,7 +108,12 @@ def coordinator_disable_device_cmd(*, group_id: str, device_id: str, db_path: st
     print(f"[green]Disabled device[/green] {device_id}")
 
 
-def coordinator_remove_device_cmd(*, group_id: str, device_id: str, db_path: str | None) -> None:
+def coordinator_remove_device_cmd(
+    *,
+    group_id: str,
+    device_id: str,
+    db_path: str | None,
+) -> None:
     store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
     try:
         removed = store.remove_device(group_id=group_id, device_id=device_id)

--- a/codemem/coordinator_store.py
+++ b/codemem/coordinator_store.py
@@ -111,6 +111,22 @@ class CoordinatorStore:
         )
         self.conn.commit()
 
+    def list_enrolled_devices(
+        self, *, group_id: str, include_disabled: bool = False
+    ) -> list[dict[str, Any]]:
+        where = "" if include_disabled else "AND enabled = 1"
+        rows = self.conn.execute(
+            f"""
+            SELECT group_id, device_id, fingerprint, display_name, enabled, created_at
+            FROM enrolled_devices
+            WHERE group_id = ?
+            {where}
+            ORDER BY created_at ASC, device_id ASC
+            """,
+            (group_id,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
     def get_enrollment(self, *, group_id: str, device_id: str) -> dict[str, Any] | None:
         row = self.conn.execute(
             """
@@ -121,6 +137,42 @@ class CoordinatorStore:
             (group_id, device_id),
         ).fetchone()
         return dict(row) if row is not None else None
+
+    def rename_device(self, *, group_id: str, device_id: str, display_name: str) -> bool:
+        result = self.conn.execute(
+            """
+            UPDATE enrolled_devices
+            SET display_name = ?
+            WHERE group_id = ? AND device_id = ?
+            """,
+            (display_name, group_id, device_id),
+        )
+        self.conn.commit()
+        return int(result.rowcount or 0) > 0
+
+    def set_device_enabled(self, *, group_id: str, device_id: str, enabled: bool) -> bool:
+        result = self.conn.execute(
+            """
+            UPDATE enrolled_devices
+            SET enabled = ?
+            WHERE group_id = ? AND device_id = ?
+            """,
+            (1 if enabled else 0, group_id, device_id),
+        )
+        self.conn.commit()
+        return int(result.rowcount or 0) > 0
+
+    def remove_device(self, *, group_id: str, device_id: str) -> bool:
+        self.conn.execute(
+            "DELETE FROM presence_records WHERE group_id = ? AND device_id = ?",
+            (group_id, device_id),
+        )
+        result = self.conn.execute(
+            "DELETE FROM enrolled_devices WHERE group_id = ? AND device_id = ?",
+            (group_id, device_id),
+        )
+        self.conn.commit()
+        return int(result.rowcount or 0) > 0
 
     def upsert_presence(
         self,

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -96,6 +96,25 @@ If the coordinator is unavailable, codemem falls back to cached addresses and mD
 - enrollment is explicit per device/group
 - there is no username/password or codemem-operated account layer in this model
 
+## Remote admin flow
+
+Built-in local coordinator management commands operate directly on the local SQLite store.
+
+For remote coordinators, the first admin model uses a separate operator-managed admin secret. Remote management commands
+reuse the same `codemem sync coordinator ...` verbs, but target a remote coordinator when you pass `--remote-url` and
+an admin secret (or configure `sync_coordinator_admin_secret`).
+
+Examples:
+
+```fish
+codemem sync coordinator list-devices nerdworld --remote-url "https://coord.codemem.sh"
+codemem sync coordinator enroll-device nerdworld <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/device.key.pub --remote-url "https://coord.codemem.sh"
+codemem sync coordinator rename-device nerdworld <device-id> --name "work-laptop" --remote-url "https://coord.codemem.sh"
+```
+
+Device participation auth still uses the enrolled device keypair for `presence` and `peers` endpoints; the admin secret
+is only for remote mutation/listing endpoints.
+
 ## Cloudflare Worker reference deployment
 
 The design targets a runtime-agnostic HTTP contract, but a Cloudflare Worker is the canonical low-cost reference

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -60,11 +60,18 @@ Basic flow:
 ```fish
 codemem sync coordinator group-create team-alpha --db-path ~/.codemem/coordinator.sqlite
 codemem sync coordinator enroll-device team-alpha <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/id_ed25519.pub --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator list-devices team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator rename-device team-alpha <device-id> --name "work-laptop" --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator disable-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator remove-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
 codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
 ```
 
 This keeps the primary deployment path inside the main `codemem` artifact and reuses the existing Python signature
 verification code directly.
+
+These management commands operate on the built-in local coordinator store only. Remote coordinator admin flows require a
+separate access-control model before they should be exposed over HTTP.
 
 ## How discovery works
 

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -1,5 +1,7 @@
 import json
 import os
+import threading
+from http.server import HTTPServer
 from pathlib import Path
 
 import typer
@@ -7,8 +9,17 @@ from typer.testing import CliRunner
 
 from codemem import db, sync_identity
 from codemem.cli import app
+from codemem.coordinator_api import build_coordinator_handler
 
 runner = CliRunner()
+
+
+def _start_coordinator_server(db_path: Path) -> tuple[HTTPServer, int]:
+    handler = build_coordinator_handler(db_path)
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
 
 
 def _write_fake_keys(private_key_path: Path, public_key_path: Path) -> None:

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -216,6 +216,133 @@ def test_serve_restart_subcommand_matches_legacy_flag(monkeypatch) -> None:
     ]
 
 
+def test_sync_coordinator_management_commands(tmp_path: Path) -> None:
+    db_path = tmp_path / "coordinator.sqlite"
+    public_key_file = tmp_path / "device.key.pub"
+    public_key_file.write_text("ssh-ed25519 AAAAtest example@test\n")
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "group-create",
+            "team-alpha",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "enroll-device",
+            "team-alpha",
+            "device-1",
+            "--fingerprint",
+            "fp-1",
+            "--public-key-file",
+            str(public_key_file),
+            "--name",
+            "laptop",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "list-devices",
+            "team-alpha",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "laptop (enabled) (device-1)" in result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "rename-device",
+            "team-alpha",
+            "device-1",
+            "--name",
+            "work-laptop",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "disable-device",
+            "team-alpha",
+            "device-1",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "list-devices",
+            "team-alpha",
+            "--include-disabled",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "work-laptop (disabled) (device-1)" in result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "remove-device",
+            "team-alpha",
+            "device-1",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "list-devices",
+            "team-alpha",
+            "--include-disabled",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "No enrolled devices" in result.stdout
+
+
 def test_serve_start_defaults_to_background(monkeypatch) -> None:
     calls: list[dict[str, object]] = []
 


### PR DESCRIPTION
## Description
- add built-in coordinator management commands for listing, renaming, disabling, and removing enrolled devices
- extend the local coordinator store with those management operations
- document the local-only management flow in the coordinator discovery guide

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_sync_cli.py`
- `uv run ruff check codemem/coordinator_store.py codemem/commands/sync_coordinator_cmds.py codemem/cli_app.py tests/test_sync_cli.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced