### PR TITLE
feat: add remote coordinator admin flow

### DIFF
--- a/codemem/config.py
+++ b/codemem/config.py
@@ -42,6 +42,7 @@ CONFIG_ENV_OVERRIDES = {
     "sync_coordinator_group": "CODEMEM_SYNC_COORDINATOR_GROUP",
     "sync_coordinator_timeout_s": "CODEMEM_SYNC_COORDINATOR_TIMEOUT_S",
     "sync_coordinator_presence_ttl_s": "CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S",
+    "sync_coordinator_admin_secret": "CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET",
     "sync_projects_include": "CODEMEM_SYNC_PROJECTS_INCLUDE",
     "sync_projects_exclude": "CODEMEM_SYNC_PROJECTS_EXCLUDE",
     "raw_events_sweeper_interval_s": "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
@@ -235,6 +236,7 @@ class OpencodeMemConfig:
     sync_coordinator_group: str | None = None
     sync_coordinator_timeout_s: int = 3
     sync_coordinator_presence_ttl_s: int = 180
+    sync_coordinator_admin_secret: str | None = None
 
     raw_events_sweeper_interval_s: int = 30
 
@@ -604,6 +606,9 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
         os.getenv("CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S"),
         cfg.sync_coordinator_presence_ttl_s,
         key="sync_coordinator_presence_ttl_s",
+    )
+    cfg.sync_coordinator_admin_secret = os.getenv(
+        "CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET", cfg.sync_coordinator_admin_secret
     )
 
     include = _coerce_str_list(

--- a/codemem/coordinator_api.py
+++ b/codemem/coordinator_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import os
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,7 @@ from .coordinator_store import DEFAULT_COORDINATOR_DB_PATH, CoordinatorStore
 from .sync_auth import DEFAULT_TIME_WINDOW_S, verify_signature
 
 MAX_COORDINATOR_BODY_BYTES = 64 * 1024
+ADMIN_HEADER = "X-Codemem-Coordinator-Admin"
 
 
 def _send_json(handler: BaseHTTPRequestHandler, payload: dict[str, Any], status: int = 200) -> None:
@@ -42,6 +44,24 @@ def _parse_json_body(raw: bytes) -> dict[str, Any] | None:
     except json.JSONDecodeError:
         return None
     return data if isinstance(data, dict) else None
+
+
+def _admin_secret() -> str | None:
+    value = os.environ.get("CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET")
+    cleaned = str(value or "").strip()
+    return cleaned or None
+
+
+def _authorize_admin_request(handler: BaseHTTPRequestHandler) -> tuple[bool, str]:
+    expected = _admin_secret()
+    if not expected:
+        return False, "admin_not_configured"
+    provided = str(handler.headers.get(ADMIN_HEADER) or "").strip()
+    if not provided:
+        return False, "missing_admin_header"
+    if provided != expected:
+        return False, "invalid_admin_secret"
+    return True, "ok"
 
 
 def _record_nonce(store: CoordinatorStore, *, device_id: str, nonce: str, created_at: str) -> bool:
@@ -109,6 +129,8 @@ def build_coordinator_handler(db_path: Path | None = None):
 
         def do_POST(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)
+            if parsed.path.startswith("/v1/admin/devices"):
+                return self._handle_admin_post(parsed.path)
             if parsed.path != "/v1/presence":
                 _send_json(self, {"error": "not_found"}, status=404)
                 return
@@ -166,6 +188,8 @@ def build_coordinator_handler(db_path: Path | None = None):
 
         def do_GET(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)
+            if parsed.path == "/v1/admin/devices":
+                return self._handle_admin_list(parsed.query)
             if parsed.path != "/v1/peers":
                 _send_json(self, {"error": "not_found"}, status=404)
                 return
@@ -189,5 +213,108 @@ def build_coordinator_handler(db_path: Path | None = None):
                 _send_json(self, {"items": items})
             finally:
                 store.close()
+
+        def _handle_admin_list(self, query: str) -> None:
+            ok, reason = _authorize_admin_request(self)
+            if not ok:
+                _send_json(self, {"error": reason}, status=401)
+                return
+            params = parse_qs(query)
+            group_id = str(params.get("group_id", [""])[0] or "").strip()
+            include_disabled = str(
+                params.get("include_disabled", ["0"])[0] or ""
+            ).strip().lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+            if not group_id:
+                _send_json(self, {"error": "group_id_required"}, status=400)
+                return
+            store = self._store()
+            try:
+                _send_json(
+                    self,
+                    {
+                        "items": store.list_enrolled_devices(
+                            group_id=group_id,
+                            include_disabled=include_disabled,
+                        )
+                    },
+                )
+            finally:
+                store.close()
+
+        def _handle_admin_post(self, path: str) -> None:
+            ok, reason = _authorize_admin_request(self)
+            if not ok:
+                _send_json(self, {"error": reason}, status=401)
+                return
+            try:
+                raw = _read_body(self)
+            except ValueError as exc:
+                if str(exc) == "body_too_large":
+                    _send_json(self, {"error": "body_too_large"}, status=413)
+                    return
+                raise
+            data = _parse_json_body(raw)
+            if data is None:
+                _send_json(self, {"error": "invalid_json"}, status=400)
+                return
+            group_id = str(data.get("group_id") or "").strip()
+            device_id = str(data.get("device_id") or "").strip()
+            if path == "/v1/admin/devices":
+                fingerprint = str(data.get("fingerprint") or "").strip()
+                public_key = str(data.get("public_key") or "").strip()
+                display_name = str(data.get("display_name") or "").strip() or None
+                if not group_id or not device_id or not fingerprint or not public_key:
+                    _send_json(
+                        self,
+                        {"error": "group_id_device_id_fingerprint_public_key_required"},
+                        status=400,
+                    )
+                    return
+                store = self._store()
+                try:
+                    store.create_group(group_id)
+                    store.enroll_device(
+                        group_id,
+                        device_id=device_id,
+                        fingerprint=fingerprint,
+                        public_key=public_key,
+                        display_name=display_name,
+                    )
+                finally:
+                    store.close()
+                _send_json(self, {"ok": True})
+                return
+            if not group_id or not device_id:
+                _send_json(self, {"error": "group_id_and_device_id_required"}, status=400)
+                return
+            store = self._store()
+            try:
+                if path == "/v1/admin/devices/rename":
+                    display_name = str(data.get("display_name") or "").strip()
+                    if not display_name:
+                        _send_json(self, {"error": "display_name_required"}, status=400)
+                        return
+                    ok = store.rename_device(
+                        group_id=group_id, device_id=device_id, display_name=display_name
+                    )
+                elif path == "/v1/admin/devices/disable":
+                    ok = store.set_device_enabled(
+                        group_id=group_id, device_id=device_id, enabled=False
+                    )
+                elif path == "/v1/admin/devices/remove":
+                    ok = store.remove_device(group_id=group_id, device_id=device_id)
+                else:
+                    _send_json(self, {"error": "not_found"}, status=404)
+                    return
+            finally:
+                store.close()
+            if not ok:
+                _send_json(self, {"error": "device_not_found"}, status=404)
+                return
+            _send_json(self, {"ok": True})
 
     return CoordinatorHandler

--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -318,12 +318,21 @@ def handle_get(
     except ValueError:
         handler._send_json({"error": "config file could not be read"}, status=500)
         return True
-    effective = asdict(load_config(config_path))
+    redacted_keys = {"sync_coordinator_admin_secret"}
+    config_data = {key: value for key, value in config_data.items() if key not in redacted_keys}
+    effective = {
+        key: value
+        for key, value in asdict(load_config(config_path)).items()
+        if key not in redacted_keys
+    }
+    defaults = {
+        key: value for key, value in asdict(OpencodeMemConfig()).items() if key not in redacted_keys
+    }
     handler._send_json(
         {
             "path": str(config_path),
             "config": config_data,
-            "defaults": asdict(OpencodeMemConfig()),
+            "defaults": defaults,
             "effective": effective,
             "env_overrides": get_env_overrides(),
             "providers": load_provider_options(),

--- a/docs/plans/2026-03-13-remote-coordinator-admin-access-control.md
+++ b/docs/plans/2026-03-13-remote-coordinator-admin-access-control.md
@@ -1,0 +1,150 @@
+# Remote Coordinator Admin Access Control
+
+**Bead:** `codemem-y4m`  
+**Status:** Design  
+**Date:** 2026-03-13
+
+## Problem
+
+Coordinator-backed discovery now has two distinct classes of operation:
+
+- device participation operations
+  - register presence
+  - look up peers
+- coordinator administration operations
+  - enroll devices
+  - list enrolled devices
+  - rename device display names
+  - disable or remove devices
+
+The first class can reasonably use device-key auth. The second class must not.
+
+If remote mutation endpoints are exposed without a separate admin capability, any enrolled device could potentially
+reconfigure or remove peers it does not own.
+
+## Goal
+
+Define a staged remote admin model that keeps the coordinator MVP safe enough to extend without pretending we already have
+full identity, RBAC, or delegated admin.
+
+## Non-goals
+
+- No account system or SSO.
+- No full multi-role permission model.
+- No hosted codemem identity service.
+- No conflation of discovery groups with memory-sharing policy.
+
+## Recommended staged model
+
+### Stage 0: local built-in coordinator admin
+
+Applies only to the built-in coordinator running against a local SQLite DB.
+
+Admin boundary:
+
+- OS/filesystem access
+
+Implication:
+
+- local CLI management commands are acceptable without extra auth because whoever can run them already controls the local
+  coordinator DB.
+
+### Stage 1: remote admin via explicit operator secret
+
+For remote coordinators (including Cloudflare/self-hosted HTTP deployments), the first safe admin model should be a
+simple operator-managed admin secret.
+
+Recommended shape:
+
+- one coordinator-wide admin secret, or one per group if we want narrower blast radius
+- sent via dedicated admin header (for example `X-Codemem-Coordinator-Admin`)
+- used only for remote admin endpoints
+
+This is intentionally boring.
+
+Why this is the right first stage:
+
+- easy for self-hosters to understand
+- straightforward to implement across Python and Worker runtimes
+- clearly separates device participation auth from admin auth
+- avoids overloading device keys with admin power
+
+### Stage 2: explicit admin identities/keys
+
+Later, if the operator-secret model proves too coarse, move to a stronger admin model:
+
+- `group_admins` or equivalent store
+- admin public keys or signed admin requests
+- possibly multiple admins per group
+
+But that should come after Stage 1 is working, not before.
+
+### Stage 3: optional self-service device actions
+
+Possible later extension:
+
+- allow a device to update only its own non-sensitive metadata
+- maybe allow self-remove
+
+Not allowed in Stage 1:
+
+- one device mutating other devices
+- open self-enrollment based only on group name
+
+## Operation classes
+
+### Device-key auth operations
+
+These remain authenticated by the enrolled device's existing sync keypair:
+
+- `POST /v1/presence`
+- `GET /v1/peers`
+
+These are participation operations, not admin operations.
+
+### Admin-secret operations
+
+These should require explicit remote admin capability:
+
+- list enrolled devices
+- enroll a new device
+- rename a device display name
+- disable a device
+- remove a device
+
+## API boundary recommendation
+
+Keep device and admin surfaces separate.
+
+Suggested split:
+
+- `/v1/presence`
+- `/v1/peers`
+- `/v1/admin/devices`
+- `/v1/admin/devices/<device_id>`
+
+This makes it harder to accidentally apply the wrong auth rule to the wrong endpoint.
+
+## Config surface for Stage 1
+
+If/when remote admin ships, the operator would configure something like:
+
+- `sync_coordinator_admin_secret`
+
+This should be treated as a sensitive local config value and never surfaced casually in UI copy.
+
+## Built-in coordinator implication
+
+The local built-in coordinator can still use direct CLI commands against its SQLite DB without implementing the remote
+admin secret flow.
+
+That means we can safely ship local management commands now while remote admin remains blocked on this design.
+
+## Acceptance criteria
+
+This design is successful when:
+
+1. Device participation auth and remote admin auth are clearly separated.
+2. Stage 1 recommends a pragmatic remote admin model that is simple and safe enough to ship.
+3. The design explains why local built-in coordinator admin is a different case.
+4. Future evolution toward stronger admin identity is possible without blocking Stage 1.

--- a/tests/test_coordinator_api.py
+++ b/tests/test_coordinator_api.py
@@ -238,3 +238,119 @@ def test_coordinator_presence_rejects_large_body(tmp_path: Path) -> None:
         assert payload["error"] == "body_too_large"
     finally:
         server.shutdown()
+
+
+def test_admin_endpoints_require_admin_secret(tmp_path: Path, monkeypatch) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET", "topsecret")
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha")
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/v1/admin/devices?group_id=team-alpha")
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 401
+        assert payload["error"] == "missing_admin_header"
+    finally:
+        server.shutdown()
+
+
+def test_admin_device_management_flow(tmp_path: Path, monkeypatch) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET", "topsecret")
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha")
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    headers = {"X-Codemem-Coordinator-Admin": "topsecret", "Content-Type": "application/json"}
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        body = json.dumps(
+            {
+                "group_id": "team-alpha",
+                "device_id": "device-1",
+                "fingerprint": "fp-1",
+                "public_key": "ssh-ed25519 AAAAtest example@test",
+                "display_name": "laptop",
+            }
+        )
+        conn.request("POST", "/v1/admin/devices", body=body, headers=headers)
+        resp = conn.getresponse()
+        assert resp.status == 200
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "GET",
+            "/v1/admin/devices?group_id=team-alpha",
+            headers={"X-Codemem-Coordinator-Admin": "topsecret"},
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["items"][0]["display_name"] == "laptop"
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/v1/admin/devices/rename",
+            body=json.dumps(
+                {"group_id": "team-alpha", "device_id": "device-1", "display_name": "work-laptop"}
+            ),
+            headers=headers,
+        )
+        resp = conn.getresponse()
+        assert resp.status == 200
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/v1/admin/devices/disable",
+            body=json.dumps({"group_id": "team-alpha", "device_id": "device-1"}),
+            headers=headers,
+        )
+        resp = conn.getresponse()
+        assert resp.status == 200
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "GET",
+            "/v1/admin/devices?group_id=team-alpha&include_disabled=1",
+            headers={"X-Codemem-Coordinator-Admin": "topsecret"},
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["items"][0]["display_name"] == "work-laptop"
+        assert payload["items"][0]["enabled"] == 0
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/v1/admin/devices/remove",
+            body=json.dumps({"group_id": "team-alpha", "device_id": "device-1"}),
+            headers=headers,
+        )
+        resp = conn.getresponse()
+        assert resp.status == 200
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "GET",
+            "/v1/admin/devices?group_id=team-alpha&include_disabled=1",
+            headers={"X-Codemem-Coordinator-Admin": "topsecret"},
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["items"] == []
+    finally:
+        server.shutdown()


### PR DESCRIPTION
## Description
- add remote coordinator admin endpoints for list/enroll/rename/disable/remove under a separate admin-secret model
- wire the existing `codemem sync coordinator ...` commands to target remote coordinators when `--remote-url` is provided
- add and document the remote coordinator admin access-control design note

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_coordinator_api.py tests/test_sync_cli.py tests/test_config.py`
- `uv run ruff check codemem/config.py codemem/coordinator_api.py codemem/coordinator_store.py codemem/commands/sync_coordinator_cmds.py codemem/cli_app.py tests/test_coordinator_api.py tests/test_sync_cli.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced