### PR TITLE
feat: add multi-group coordinator discovery

### DIFF
--- a/codemem/config.py
+++ b/codemem/config.py
@@ -40,6 +40,7 @@ CONFIG_ENV_OVERRIDES = {
     "sync_advertise": "CODEMEM_SYNC_ADVERTISE",
     "sync_coordinator_url": "CODEMEM_SYNC_COORDINATOR_URL",
     "sync_coordinator_group": "CODEMEM_SYNC_COORDINATOR_GROUP",
+    "sync_coordinator_groups": "CODEMEM_SYNC_COORDINATOR_GROUPS",
     "sync_coordinator_timeout_s": "CODEMEM_SYNC_COORDINATOR_TIMEOUT_S",
     "sync_coordinator_presence_ttl_s": "CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S",
     "sync_coordinator_admin_secret": "CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET",
@@ -234,6 +235,7 @@ class OpencodeMemConfig:
     sync_advertise: str = "auto"
     sync_coordinator_url: str | None = None
     sync_coordinator_group: str | None = None
+    sync_coordinator_groups: list[str] = field(default_factory=list)
     sync_coordinator_timeout_s: int = 3
     sync_coordinator_presence_ttl_s: int = 180
     sync_coordinator_admin_secret: str | None = None
@@ -473,7 +475,7 @@ def _apply_dict(cfg: OpencodeMemConfig, data: dict[str, Any]) -> OpencodeMemConf
             if parsed is not None:
                 setattr(cfg, key, parsed)
             continue
-        if key in {"sync_projects_include", "sync_projects_exclude"}:
+        if key in {"sync_projects_include", "sync_projects_exclude", "sync_coordinator_groups"}:
             parsed = _coerce_str_list(value, key=key)
             if parsed is not None:
                 setattr(cfg, key, parsed)
@@ -597,6 +599,11 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
     cfg.sync_coordinator_group = os.getenv(
         "CODEMEM_SYNC_COORDINATOR_GROUP", cfg.sync_coordinator_group
     )
+    coordinator_groups = _coerce_str_list(
+        os.getenv("CODEMEM_SYNC_COORDINATOR_GROUPS"), key="sync_coordinator_groups"
+    )
+    if coordinator_groups is not None:
+        cfg.sync_coordinator_groups = coordinator_groups
     cfg.sync_coordinator_timeout_s = _parse_int(
         os.getenv("CODEMEM_SYNC_COORDINATOR_TIMEOUT_S"),
         cfg.sync_coordinator_timeout_s,
@@ -621,4 +628,10 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
     )
     if exclude is not None:
         cfg.sync_projects_exclude = exclude
+
+    if cfg.sync_coordinator_groups:
+        if not cfg.sync_coordinator_group:
+            cfg.sync_coordinator_group = cfg.sync_coordinator_groups[0]
+    elif cfg.sync_coordinator_group:
+        cfg.sync_coordinator_groups = [cfg.sync_coordinator_group]
     return cfg

--- a/codemem/sync/coordinator.py
+++ b/codemem/sync/coordinator.py
@@ -17,10 +17,16 @@ from . import discovery, http_client
 
 def coordinator_enabled(config: OpencodeMemConfig | None = None) -> bool:
     cfg = config or load_config()
-    return bool(
-        str(cfg.sync_coordinator_url or "").strip()
-        and str(cfg.sync_coordinator_group or "").strip()
-    )
+    return bool(str(cfg.sync_coordinator_url or "").strip() and _coordinator_groups(cfg))
+
+
+def _coordinator_groups(config: OpencodeMemConfig) -> list[str]:
+    if config.sync_coordinator_groups:
+        return [
+            str(group).strip() for group in config.sync_coordinator_groups if str(group).strip()
+        ]
+    group = str(config.sync_coordinator_group or "").strip()
+    return [group] if group else []
 
 
 def _coordinator_base_url(config: OpencodeMemConfig) -> str:
@@ -60,34 +66,38 @@ def register_presence(
     base_url = _coordinator_base_url(cfg)
     if not base_url:
         raise RuntimeError("coordinator url missing")
+    groups = _coordinator_groups(cfg)
     payload = {
-        "group_id": str(cfg.sync_coordinator_group or "").strip(),
         "fingerprint": fingerprint,
         "public_key": public_key,
         "addresses": _advertised_sync_addresses(cfg),
         "ttl_s": max(1, int(cfg.sync_coordinator_presence_ttl_s)),
     }
-    body_bytes = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-    url = f"{base_url}/v1/presence"
-    headers = build_auth_headers(
-        device_id=device_id,
-        method="POST",
-        url=url,
-        body_bytes=body_bytes,
-        keys_dir=keys_dir,
-    )
-    status, response = http_client.request_json(
-        "POST",
-        url,
-        headers=headers,
-        body=payload,
-        body_bytes=body_bytes,
-        timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
-    )
-    if status != 200 or not isinstance(response, dict):
-        detail = response.get("error") if isinstance(response, dict) else None
-        raise RuntimeError(f"coordinator presence failed ({status}: {detail or 'unknown'})")
-    return response
+    responses: list[dict[str, Any]] = []
+    for group_id in groups:
+        group_payload = {**payload, "group_id": group_id}
+        body_bytes = json.dumps(group_payload, ensure_ascii=False).encode("utf-8")
+        url = f"{base_url}/v1/presence"
+        headers = build_auth_headers(
+            device_id=device_id,
+            method="POST",
+            url=url,
+            body_bytes=body_bytes,
+            keys_dir=keys_dir,
+        )
+        status, response = http_client.request_json(
+            "POST",
+            url,
+            headers=headers,
+            body=group_payload,
+            body_bytes=body_bytes,
+            timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
+        )
+        if status != 200 or not isinstance(response, dict):
+            detail = response.get("error") if isinstance(response, dict) else None
+            raise RuntimeError(f"coordinator presence failed ({status}: {detail or 'unknown'})")
+        responses.append(response)
+    return {"groups": groups, "responses": responses}
 
 
 def lookup_peers(
@@ -101,28 +111,57 @@ def lookup_peers(
     base_url = _coordinator_base_url(cfg)
     if not base_url:
         return []
-    query = urlencode({"group_id": str(cfg.sync_coordinator_group or "").strip()})
-    url = f"{base_url}/v1/peers?{query}"
-    headers = build_auth_headers(
-        device_id=device_id,
-        method="GET",
-        url=url,
-        body_bytes=b"",
-        keys_dir=keys_dir,
-    )
-    status, response = http_client.request_json(
-        "GET",
-        url,
-        headers=headers,
-        timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
-    )
-    if status != 200 or not isinstance(response, dict):
-        detail = response.get("error") if isinstance(response, dict) else None
-        raise RuntimeError(f"coordinator lookup failed ({status}: {detail or 'unknown'})")
-    items = response.get("items")
-    if not isinstance(items, list):
-        return []
-    return [item for item in items if isinstance(item, dict)]
+    merged: dict[tuple[str, str], dict[str, Any]] = {}
+    for group_id in _coordinator_groups(cfg):
+        query = urlencode({"group_id": group_id})
+        url = f"{base_url}/v1/peers?{query}"
+        headers = build_auth_headers(
+            device_id=device_id,
+            method="GET",
+            url=url,
+            body_bytes=b"",
+            keys_dir=keys_dir,
+        )
+        status, response = http_client.request_json(
+            "GET",
+            url,
+            headers=headers,
+            timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
+        )
+        if status != 200 or not isinstance(response, dict):
+            detail = response.get("error") if isinstance(response, dict) else None
+            raise RuntimeError(f"coordinator lookup failed ({status}: {detail or 'unknown'})")
+        items = response.get("items")
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            key = (
+                str(item.get("device_id") or "").strip(),
+                str(item.get("fingerprint") or "").strip(),
+            )
+            if not key[0]:
+                continue
+            existing = merged.get(key)
+            if existing is None:
+                merged[key] = {
+                    **item,
+                    "addresses": discovery.merge_addresses([], item.get("addresses") or []),
+                    "groups": [group_id],
+                }
+                continue
+            existing["addresses"] = discovery.merge_addresses(
+                existing.get("addresses") or [], item.get("addresses") or []
+            )
+            existing["groups"] = discovery.merge_addresses(existing.get("groups") or [], [group_id])
+            existing["stale"] = bool(existing.get("stale", True) and item.get("stale", True))
+            if item.get("last_seen_at") and str(item.get("last_seen_at")) > str(
+                existing.get("last_seen_at") or ""
+            ):
+                existing["last_seen_at"] = item.get("last_seen_at")
+                existing["expires_at"] = item.get("expires_at")
+    return list(merged.values())
 
 
 def refresh_peer_address_cache(

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -19,10 +19,10 @@ the network boundary you care about (for example VPNs).
 
 ## Config
 
-Set both of these to enable coordinator-backed discovery:
+Set these to enable coordinator-backed discovery:
 
 - `sync_coordinator_url`
-- `sync_coordinator_group`
+- either `sync_coordinator_group` or `sync_coordinator_groups`
 
 Optional knobs:
 
@@ -35,6 +35,7 @@ Environment variable equivalents:
 
 - `CODEMEM_SYNC_COORDINATOR_URL`
 - `CODEMEM_SYNC_COORDINATOR_GROUP`
+- `CODEMEM_SYNC_COORDINATOR_GROUPS`
 - `CODEMEM_SYNC_COORDINATOR_TIMEOUT_S`
 - `CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S`
 
@@ -50,6 +51,22 @@ Example config:
   "sync_advertise": "tailscale"
 }
 ```
+
+Multi-group config is also supported:
+
+```json
+{
+  "sync_coordinator_url": "https://coord.example.workers.dev",
+  "sync_coordinator_groups": ["team-alpha", "lab"]
+}
+```
+
+Backward compatibility:
+
+- `sync_coordinator_group` still works
+- when only the legacy single-group field is set, codemem treats it as a one-item `sync_coordinator_groups`
+- when `sync_coordinator_groups` is set, the first entry becomes the legacy single-group value for compatibility with
+  older surfaces
 
 ## Built-in coordinator service
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,6 +186,24 @@ def test_load_config_reads_sync_coordinator_fields_from_file(tmp_path: Path) -> 
     assert cfg.sync_coordinator_presence_ttl_s == 240
 
 
+def test_load_config_reads_sync_coordinator_groups_from_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "sync_coordinator_url": "https://coord.example",
+                "sync_coordinator_groups": ["team-alpha", "lab"],
+            }
+        )
+        + "\n"
+    )
+
+    cfg = load_config(config_path)
+
+    assert cfg.sync_coordinator_groups == ["team-alpha", "lab"]
+    assert cfg.sync_coordinator_group == "team-alpha"
+
+
 def test_load_config_reads_sync_coordinator_fields_from_env(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -203,6 +221,21 @@ def test_load_config_reads_sync_coordinator_fields_from_env(
     assert cfg.sync_coordinator_group == "team-alpha"
     assert cfg.sync_coordinator_timeout_s == 6
     assert cfg.sync_coordinator_presence_ttl_s == 300
+
+
+def test_load_config_reads_sync_coordinator_groups_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_URL", "https://coord.example")
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_GROUPS", "team-alpha,lab")
+
+    cfg = load_config(config_path)
+
+    assert cfg.sync_coordinator_groups == ["team-alpha", "lab"]
+    assert cfg.sync_coordinator_group == "team-alpha"
 
 
 def test_load_config_invalid_config_value_does_not_crash_and_warns(tmp_path: Path) -> None:

--- a/tests/test_sync_coordinator.py
+++ b/tests/test_sync_coordinator.py
@@ -97,6 +97,130 @@ def test_refresh_peer_address_cache_updates_matching_peer(tmp_path: Path, monkey
         store.close()
 
 
+def test_register_presence_posts_only_configured_groups(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))
+    store = MemoryStore(db_path)
+    calls: list[str] = []
+    try:
+        ensure_device_identity(store.conn, keys_dir=keys_dir)
+
+        def fake_request_json(method: str, url: str, *, body=None, **_kwargs):
+            calls.append(str((body or {}).get("group_id") or ""))
+            return 200, {"ok": True}
+
+        monkeypatch.setattr("codemem.sync.coordinator.http_client.request_json", fake_request_json)
+
+        coordinator.register_presence(
+            store,
+            config=OpencodeMemConfig(
+                sync_coordinator_url="https://coord.example",
+                sync_coordinator_group="legacy-only",
+                sync_coordinator_groups=["team-alpha", "lab"],
+                sync_coordinator_timeout_s=3,
+                sync_coordinator_presence_ttl_s=180,
+                sync_advertise="127.0.0.1",
+                sync_port=7337,
+            ),
+        )
+
+        assert calls == ["team-alpha", "lab"]
+    finally:
+        store.close()
+
+
+def test_register_presence_posts_to_each_configured_group(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))
+    store = MemoryStore(db_path)
+    calls: list[dict[str, str]] = []
+    try:
+        ensure_device_identity(store.conn, keys_dir=keys_dir)
+
+        def fake_request_json(method: str, url: str, *, body=None, **_kwargs):
+            calls.append({"method": method, "group_id": str((body or {}).get("group_id") or "")})
+            return 200, {"ok": True, "group_id": (body or {}).get("group_id")}
+
+        monkeypatch.setattr("codemem.sync.coordinator.http_client.request_json", fake_request_json)
+
+        coordinator.register_presence(
+            store,
+            config=OpencodeMemConfig(
+                sync_coordinator_url="https://coord.example",
+                sync_coordinator_groups=["team-alpha", "lab"],
+                sync_coordinator_timeout_s=3,
+                sync_coordinator_presence_ttl_s=180,
+                sync_advertise="127.0.0.1",
+                sync_port=7337,
+            ),
+        )
+
+        assert calls == [
+            {"method": "POST", "group_id": "team-alpha"},
+            {"method": "POST", "group_id": "lab"},
+        ]
+    finally:
+        store.close()
+
+
+def test_lookup_peers_merges_results_from_multiple_groups(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))
+    store = MemoryStore(db_path)
+    try:
+        ensure_device_identity(store.conn, keys_dir=keys_dir)
+
+        def fake_request_json(method: str, url: str, **_kwargs):
+            if method == "GET" and "group_id=team-alpha" in url:
+                return 200, {
+                    "items": [
+                        {
+                            "device_id": "peer-1",
+                            "fingerprint": "fp-peer-1",
+                            "addresses": ["http://10.0.0.2:7337"],
+                            "last_seen_at": "2026-03-13T10:00:00Z",
+                            "expires_at": "2026-03-13T10:03:00Z",
+                            "stale": False,
+                        }
+                    ]
+                }
+            if method == "GET" and "group_id=lab" in url:
+                return 200, {
+                    "items": [
+                        {
+                            "device_id": "peer-1",
+                            "fingerprint": "fp-peer-1",
+                            "addresses": ["http://100.64.0.5:7337"],
+                            "last_seen_at": "2026-03-13T11:00:00Z",
+                            "expires_at": "2026-03-13T11:03:00Z",
+                            "stale": False,
+                        }
+                    ]
+                }
+            raise AssertionError(url)
+
+        monkeypatch.setattr("codemem.sync.coordinator.http_client.request_json", fake_request_json)
+
+        items = coordinator.lookup_peers(
+            store,
+            config=OpencodeMemConfig(
+                sync_coordinator_url="https://coord.example",
+                sync_coordinator_groups=["team-alpha", "lab"],
+                sync_coordinator_timeout_s=3,
+            ),
+        )
+
+        assert len(items) == 1
+        assert items[0]["groups"] == ["team-alpha", "lab"]
+        assert items[0]["addresses"] == ["http://10.0.0.2:7337", "http://100.64.0.5:7337"]
+        assert items[0]["last_seen_at"] == "2026-03-13T11:00:00Z"
+    finally:
+        store.close()
+
+
 def test_refresh_peer_address_cache_ignores_fingerprint_mismatch(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Description
- add true multi-group coordinator discovery membership with backward-compatible config parsing
- register presence per group and merge peer lookup results across configured groups
- document the migration story from legacy single-group config to the multi-group model

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_config.py tests/test_sync_coordinator.py`
- `uv run ruff check codemem/config.py codemem/sync/coordinator.py tests/test_config.py tests/test_sync_coordinator.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced