### PR TITLE
fix: refresh coordinator presence and dedupe addresses

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -1214,7 +1214,11 @@ def sync_coordinator_disable_device(
     db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
 ) -> None:
     """Disable an enrolled device without deleting its record."""
-    coordinator_disable_device_cmd(group_id=group_id, device_id=device_id, db_path=db_path)
+    coordinator_disable_device_cmd(
+        group_id=group_id,
+        device_id=device_id,
+        db_path=db_path,
+    )
 
 
 @sync_coordinator_app.command("remove-device")
@@ -1224,7 +1228,11 @@ def sync_coordinator_remove_device(
     db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
 ) -> None:
     """Remove an enrolled device and its cached presence record."""
-    coordinator_remove_device_cmd(group_id=group_id, device_id=device_id, db_path=db_path)
+    coordinator_remove_device_cmd(
+        group_id=group_id,
+        device_id=device_id,
+        db_path=db_path,
+    )
 
 
 def sync_service_status(

--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -79,8 +79,12 @@ from .commands.sync_cmds import (
     sync_uninstall_cmd,
 )
 from .commands.sync_coordinator_cmds import (
+    coordinator_disable_device_cmd,
     coordinator_enroll_device_cmd,
     coordinator_group_create_cmd,
+    coordinator_list_devices_cmd,
+    coordinator_remove_device_cmd,
+    coordinator_rename_device_cmd,
     coordinator_serve_cmd,
 )
 from .commands.sync_service_cmds import install_autostart_quiet as _install_autostart_quiet
@@ -1171,6 +1175,56 @@ def sync_coordinator_enroll_device(
         name=name,
         db_path=db_path,
     )
+
+
+@sync_coordinator_app.command("list-devices")
+def sync_coordinator_list_devices(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    include_disabled: bool = typer.Option(False, help="Include disabled devices"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """List enrolled devices in a coordinator group."""
+    coordinator_list_devices_cmd(
+        group_id=group_id,
+        include_disabled=include_disabled,
+        db_path=db_path,
+    )
+
+
+@sync_coordinator_app.command("rename-device")
+def sync_coordinator_rename_device(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    device_id: str = typer.Argument(..., help="Device ID to rename"),
+    name: str = typer.Option(..., help="New display name"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """Rename an enrolled device display name."""
+    coordinator_rename_device_cmd(
+        group_id=group_id,
+        device_id=device_id,
+        name=name,
+        db_path=db_path,
+    )
+
+
+@sync_coordinator_app.command("disable-device")
+def sync_coordinator_disable_device(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    device_id: str = typer.Argument(..., help="Device ID to disable"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """Disable an enrolled device without deleting its record."""
+    coordinator_disable_device_cmd(group_id=group_id, device_id=device_id, db_path=db_path)
+
+
+@sync_coordinator_app.command("remove-device")
+def sync_coordinator_remove_device(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    device_id: str = typer.Argument(..., help="Device ID to remove"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+) -> None:
+    """Remove an enrolled device and its cached presence record."""
+    coordinator_remove_device_cmd(group_id=group_id, device_id=device_id, db_path=db_path)
 
 
 def sync_service_status(

--- a/codemem/commands/sync_coordinator_cmds.py
+++ b/codemem/commands/sync_coordinator_cmds.py
@@ -52,3 +52,56 @@ def coordinator_enroll_device_cmd(
     finally:
         store.close()
     print(f"[green]Enrolled device[/green] {device_id} -> {group_id}")
+
+
+def coordinator_list_devices_cmd(
+    *, group_id: str, include_disabled: bool, db_path: str | None
+) -> None:
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        rows = store.list_enrolled_devices(group_id=group_id, include_disabled=include_disabled)
+    finally:
+        store.close()
+    if not rows:
+        print(f"[yellow]No enrolled devices[/yellow] for {group_id}")
+        return
+    print(f"[bold]Enrolled devices[/bold] for {group_id}")
+    for row in rows:
+        state = "enabled" if row.get("enabled") else "disabled"
+        display_name = row.get("display_name") or row.get("device_id")
+        print(f"- {display_name} ({state}) ({row.get('device_id')})")
+
+
+def coordinator_rename_device_cmd(
+    *, group_id: str, device_id: str, name: str, db_path: str | None
+) -> None:
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        updated = store.rename_device(group_id=group_id, device_id=device_id, display_name=name)
+    finally:
+        store.close()
+    if not updated:
+        raise SystemExit(f"Device not found in {group_id}: {device_id}")
+    print(f"[green]Renamed device[/green] {device_id} -> {name}")
+
+
+def coordinator_disable_device_cmd(*, group_id: str, device_id: str, db_path: str | None) -> None:
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        updated = store.set_device_enabled(group_id=group_id, device_id=device_id, enabled=False)
+    finally:
+        store.close()
+    if not updated:
+        raise SystemExit(f"Device not found in {group_id}: {device_id}")
+    print(f"[green]Disabled device[/green] {device_id}")
+
+
+def coordinator_remove_device_cmd(*, group_id: str, device_id: str, db_path: str | None) -> None:
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        removed = store.remove_device(group_id=group_id, device_id=device_id)
+    finally:
+        store.close()
+    if not removed:
+        raise SystemExit(f"Device not found in {group_id}: {device_id}")
+    print(f"[green]Removed device[/green] {device_id}")

--- a/codemem/commands/sync_coordinator_cmds.py
+++ b/codemem/commands/sync_coordinator_cmds.py
@@ -55,7 +55,10 @@ def coordinator_enroll_device_cmd(
 
 
 def coordinator_list_devices_cmd(
-    *, group_id: str, include_disabled: bool, db_path: str | None
+    *,
+    group_id: str,
+    include_disabled: bool,
+    db_path: str | None,
 ) -> None:
     store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
     try:
@@ -73,7 +76,11 @@ def coordinator_list_devices_cmd(
 
 
 def coordinator_rename_device_cmd(
-    *, group_id: str, device_id: str, name: str, db_path: str | None
+    *,
+    group_id: str,
+    device_id: str,
+    name: str,
+    db_path: str | None,
 ) -> None:
     store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
     try:
@@ -85,7 +92,12 @@ def coordinator_rename_device_cmd(
     print(f"[green]Renamed device[/green] {device_id} -> {name}")
 
 
-def coordinator_disable_device_cmd(*, group_id: str, device_id: str, db_path: str | None) -> None:
+def coordinator_disable_device_cmd(
+    *,
+    group_id: str,
+    device_id: str,
+    db_path: str | None,
+) -> None:
     store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
     try:
         updated = store.set_device_enabled(group_id=group_id, device_id=device_id, enabled=False)
@@ -96,7 +108,12 @@ def coordinator_disable_device_cmd(*, group_id: str, device_id: str, db_path: st
     print(f"[green]Disabled device[/green] {device_id}")
 
 
-def coordinator_remove_device_cmd(*, group_id: str, device_id: str, db_path: str | None) -> None:
+def coordinator_remove_device_cmd(
+    *,
+    group_id: str,
+    device_id: str,
+    db_path: str | None,
+) -> None:
     store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
     try:
         removed = store.remove_device(group_id=group_id, device_id=device_id)

--- a/codemem/config.py
+++ b/codemem/config.py
@@ -42,6 +42,7 @@ CONFIG_ENV_OVERRIDES = {
     "sync_coordinator_group": "CODEMEM_SYNC_COORDINATOR_GROUP",
     "sync_coordinator_timeout_s": "CODEMEM_SYNC_COORDINATOR_TIMEOUT_S",
     "sync_coordinator_presence_ttl_s": "CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S",
+    "sync_coordinator_admin_secret": "CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET",
     "sync_projects_include": "CODEMEM_SYNC_PROJECTS_INCLUDE",
     "sync_projects_exclude": "CODEMEM_SYNC_PROJECTS_EXCLUDE",
     "raw_events_sweeper_interval_s": "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
@@ -235,6 +236,7 @@ class OpencodeMemConfig:
     sync_coordinator_group: str | None = None
     sync_coordinator_timeout_s: int = 3
     sync_coordinator_presence_ttl_s: int = 180
+    sync_coordinator_admin_secret: str | None = None
 
     raw_events_sweeper_interval_s: int = 30
 
@@ -604,6 +606,9 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
         os.getenv("CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S"),
         cfg.sync_coordinator_presence_ttl_s,
         key="sync_coordinator_presence_ttl_s",
+    )
+    cfg.sync_coordinator_admin_secret = os.getenv(
+        "CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET", cfg.sync_coordinator_admin_secret
     )
 
     include = _coerce_str_list(

--- a/codemem/config.py
+++ b/codemem/config.py
@@ -40,6 +40,7 @@ CONFIG_ENV_OVERRIDES = {
     "sync_advertise": "CODEMEM_SYNC_ADVERTISE",
     "sync_coordinator_url": "CODEMEM_SYNC_COORDINATOR_URL",
     "sync_coordinator_group": "CODEMEM_SYNC_COORDINATOR_GROUP",
+    "sync_coordinator_groups": "CODEMEM_SYNC_COORDINATOR_GROUPS",
     "sync_coordinator_timeout_s": "CODEMEM_SYNC_COORDINATOR_TIMEOUT_S",
     "sync_coordinator_presence_ttl_s": "CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S",
     "sync_coordinator_admin_secret": "CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET",
@@ -234,6 +235,7 @@ class OpencodeMemConfig:
     sync_advertise: str = "auto"
     sync_coordinator_url: str | None = None
     sync_coordinator_group: str | None = None
+    sync_coordinator_groups: list[str] = field(default_factory=list)
     sync_coordinator_timeout_s: int = 3
     sync_coordinator_presence_ttl_s: int = 180
     sync_coordinator_admin_secret: str | None = None
@@ -473,7 +475,7 @@ def _apply_dict(cfg: OpencodeMemConfig, data: dict[str, Any]) -> OpencodeMemConf
             if parsed is not None:
                 setattr(cfg, key, parsed)
             continue
-        if key in {"sync_projects_include", "sync_projects_exclude"}:
+        if key in {"sync_projects_include", "sync_projects_exclude", "sync_coordinator_groups"}:
             parsed = _coerce_str_list(value, key=key)
             if parsed is not None:
                 setattr(cfg, key, parsed)
@@ -597,6 +599,11 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
     cfg.sync_coordinator_group = os.getenv(
         "CODEMEM_SYNC_COORDINATOR_GROUP", cfg.sync_coordinator_group
     )
+    coordinator_groups = _coerce_str_list(
+        os.getenv("CODEMEM_SYNC_COORDINATOR_GROUPS"), key="sync_coordinator_groups"
+    )
+    if coordinator_groups is not None:
+        cfg.sync_coordinator_groups = coordinator_groups
     cfg.sync_coordinator_timeout_s = _parse_int(
         os.getenv("CODEMEM_SYNC_COORDINATOR_TIMEOUT_S"),
         cfg.sync_coordinator_timeout_s,
@@ -621,4 +628,10 @@ def _apply_env(cfg: OpencodeMemConfig) -> OpencodeMemConfig:
     )
     if exclude is not None:
         cfg.sync_projects_exclude = exclude
+
+    if cfg.sync_coordinator_groups:
+        if not cfg.sync_coordinator_group:
+            cfg.sync_coordinator_group = cfg.sync_coordinator_groups[0]
+    elif cfg.sync_coordinator_group:
+        cfg.sync_coordinator_groups = [cfg.sync_coordinator_group]
     return cfg

--- a/codemem/coordinator_api.py
+++ b/codemem/coordinator_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import os
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,7 @@ from .coordinator_store import DEFAULT_COORDINATOR_DB_PATH, CoordinatorStore
 from .sync_auth import DEFAULT_TIME_WINDOW_S, verify_signature
 
 MAX_COORDINATOR_BODY_BYTES = 64 * 1024
+ADMIN_HEADER = "X-Codemem-Coordinator-Admin"
 
 
 def _send_json(handler: BaseHTTPRequestHandler, payload: dict[str, Any], status: int = 200) -> None:
@@ -42,6 +44,24 @@ def _parse_json_body(raw: bytes) -> dict[str, Any] | None:
     except json.JSONDecodeError:
         return None
     return data if isinstance(data, dict) else None
+
+
+def _admin_secret() -> str | None:
+    value = os.environ.get("CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET")
+    cleaned = str(value or "").strip()
+    return cleaned or None
+
+
+def _authorize_admin_request(handler: BaseHTTPRequestHandler) -> tuple[bool, str]:
+    expected = _admin_secret()
+    if not expected:
+        return False, "admin_not_configured"
+    provided = str(handler.headers.get(ADMIN_HEADER) or "").strip()
+    if not provided:
+        return False, "missing_admin_header"
+    if provided != expected:
+        return False, "invalid_admin_secret"
+    return True, "ok"
 
 
 def _record_nonce(store: CoordinatorStore, *, device_id: str, nonce: str, created_at: str) -> bool:
@@ -109,6 +129,8 @@ def build_coordinator_handler(db_path: Path | None = None):
 
         def do_POST(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)
+            if parsed.path.startswith("/v1/admin/devices"):
+                return self._handle_admin_post(parsed.path)
             if parsed.path != "/v1/presence":
                 _send_json(self, {"error": "not_found"}, status=404)
                 return
@@ -166,6 +188,8 @@ def build_coordinator_handler(db_path: Path | None = None):
 
         def do_GET(self) -> None:  # noqa: N802
             parsed = urlparse(self.path)
+            if parsed.path == "/v1/admin/devices":
+                return self._handle_admin_list(parsed.query)
             if parsed.path != "/v1/peers":
                 _send_json(self, {"error": "not_found"}, status=404)
                 return
@@ -189,5 +213,108 @@ def build_coordinator_handler(db_path: Path | None = None):
                 _send_json(self, {"items": items})
             finally:
                 store.close()
+
+        def _handle_admin_list(self, query: str) -> None:
+            ok, reason = _authorize_admin_request(self)
+            if not ok:
+                _send_json(self, {"error": reason}, status=401)
+                return
+            params = parse_qs(query)
+            group_id = str(params.get("group_id", [""])[0] or "").strip()
+            include_disabled = str(
+                params.get("include_disabled", ["0"])[0] or ""
+            ).strip().lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+            if not group_id:
+                _send_json(self, {"error": "group_id_required"}, status=400)
+                return
+            store = self._store()
+            try:
+                _send_json(
+                    self,
+                    {
+                        "items": store.list_enrolled_devices(
+                            group_id=group_id,
+                            include_disabled=include_disabled,
+                        )
+                    },
+                )
+            finally:
+                store.close()
+
+        def _handle_admin_post(self, path: str) -> None:
+            ok, reason = _authorize_admin_request(self)
+            if not ok:
+                _send_json(self, {"error": reason}, status=401)
+                return
+            try:
+                raw = _read_body(self)
+            except ValueError as exc:
+                if str(exc) == "body_too_large":
+                    _send_json(self, {"error": "body_too_large"}, status=413)
+                    return
+                raise
+            data = _parse_json_body(raw)
+            if data is None:
+                _send_json(self, {"error": "invalid_json"}, status=400)
+                return
+            group_id = str(data.get("group_id") or "").strip()
+            device_id = str(data.get("device_id") or "").strip()
+            if path == "/v1/admin/devices":
+                fingerprint = str(data.get("fingerprint") or "").strip()
+                public_key = str(data.get("public_key") or "").strip()
+                display_name = str(data.get("display_name") or "").strip() or None
+                if not group_id or not device_id or not fingerprint or not public_key:
+                    _send_json(
+                        self,
+                        {"error": "group_id_device_id_fingerprint_public_key_required"},
+                        status=400,
+                    )
+                    return
+                store = self._store()
+                try:
+                    store.create_group(group_id)
+                    store.enroll_device(
+                        group_id,
+                        device_id=device_id,
+                        fingerprint=fingerprint,
+                        public_key=public_key,
+                        display_name=display_name,
+                    )
+                finally:
+                    store.close()
+                _send_json(self, {"ok": True})
+                return
+            if not group_id or not device_id:
+                _send_json(self, {"error": "group_id_and_device_id_required"}, status=400)
+                return
+            store = self._store()
+            try:
+                if path == "/v1/admin/devices/rename":
+                    display_name = str(data.get("display_name") or "").strip()
+                    if not display_name:
+                        _send_json(self, {"error": "display_name_required"}, status=400)
+                        return
+                    ok = store.rename_device(
+                        group_id=group_id, device_id=device_id, display_name=display_name
+                    )
+                elif path == "/v1/admin/devices/disable":
+                    ok = store.set_device_enabled(
+                        group_id=group_id, device_id=device_id, enabled=False
+                    )
+                elif path == "/v1/admin/devices/remove":
+                    ok = store.remove_device(group_id=group_id, device_id=device_id)
+                else:
+                    _send_json(self, {"error": "not_found"}, status=404)
+                    return
+            finally:
+                store.close()
+            if not ok:
+                _send_json(self, {"error": "device_not_found"}, status=404)
+                return
+            _send_json(self, {"ok": True})
 
     return CoordinatorHandler

--- a/codemem/coordinator_store.py
+++ b/codemem/coordinator_store.py
@@ -111,6 +111,22 @@ class CoordinatorStore:
         )
         self.conn.commit()
 
+    def list_enrolled_devices(
+        self, *, group_id: str, include_disabled: bool = False
+    ) -> list[dict[str, Any]]:
+        where = "" if include_disabled else "AND enabled = 1"
+        rows = self.conn.execute(
+            f"""
+            SELECT group_id, device_id, fingerprint, display_name, enabled, created_at
+            FROM enrolled_devices
+            WHERE group_id = ?
+            {where}
+            ORDER BY created_at ASC, device_id ASC
+            """,
+            (group_id,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
     def get_enrollment(self, *, group_id: str, device_id: str) -> dict[str, Any] | None:
         row = self.conn.execute(
             """
@@ -121,6 +137,42 @@ class CoordinatorStore:
             (group_id, device_id),
         ).fetchone()
         return dict(row) if row is not None else None
+
+    def rename_device(self, *, group_id: str, device_id: str, display_name: str) -> bool:
+        result = self.conn.execute(
+            """
+            UPDATE enrolled_devices
+            SET display_name = ?
+            WHERE group_id = ? AND device_id = ?
+            """,
+            (display_name, group_id, device_id),
+        )
+        self.conn.commit()
+        return int(result.rowcount or 0) > 0
+
+    def set_device_enabled(self, *, group_id: str, device_id: str, enabled: bool) -> bool:
+        result = self.conn.execute(
+            """
+            UPDATE enrolled_devices
+            SET enabled = ?
+            WHERE group_id = ? AND device_id = ?
+            """,
+            (1 if enabled else 0, group_id, device_id),
+        )
+        self.conn.commit()
+        return int(result.rowcount or 0) > 0
+
+    def remove_device(self, *, group_id: str, device_id: str) -> bool:
+        self.conn.execute(
+            "DELETE FROM presence_records WHERE group_id = ? AND device_id = ?",
+            (group_id, device_id),
+        )
+        result = self.conn.execute(
+            "DELETE FROM enrolled_devices WHERE group_id = ? AND device_id = ?",
+            (group_id, device_id),
+        )
+        self.conn.commit()
+        return int(result.rowcount or 0) > 0
 
     def upsert_presence(
         self,

--- a/codemem/sync/coordinator.py
+++ b/codemem/sync/coordinator.py
@@ -17,10 +17,16 @@ from . import discovery, http_client
 
 def coordinator_enabled(config: OpencodeMemConfig | None = None) -> bool:
     cfg = config or load_config()
-    return bool(
-        str(cfg.sync_coordinator_url or "").strip()
-        and str(cfg.sync_coordinator_group or "").strip()
-    )
+    return bool(str(cfg.sync_coordinator_url or "").strip() and _coordinator_groups(cfg))
+
+
+def _coordinator_groups(config: OpencodeMemConfig) -> list[str]:
+    if config.sync_coordinator_groups:
+        return [
+            str(group).strip() for group in config.sync_coordinator_groups if str(group).strip()
+        ]
+    group = str(config.sync_coordinator_group or "").strip()
+    return [group] if group else []
 
 
 def _coordinator_base_url(config: OpencodeMemConfig) -> str:
@@ -60,34 +66,38 @@ def register_presence(
     base_url = _coordinator_base_url(cfg)
     if not base_url:
         raise RuntimeError("coordinator url missing")
+    groups = _coordinator_groups(cfg)
     payload = {
-        "group_id": str(cfg.sync_coordinator_group or "").strip(),
         "fingerprint": fingerprint,
         "public_key": public_key,
         "addresses": _advertised_sync_addresses(cfg),
         "ttl_s": max(1, int(cfg.sync_coordinator_presence_ttl_s)),
     }
-    body_bytes = json.dumps(payload, ensure_ascii=False).encode("utf-8")
-    url = f"{base_url}/v1/presence"
-    headers = build_auth_headers(
-        device_id=device_id,
-        method="POST",
-        url=url,
-        body_bytes=body_bytes,
-        keys_dir=keys_dir,
-    )
-    status, response = http_client.request_json(
-        "POST",
-        url,
-        headers=headers,
-        body=payload,
-        body_bytes=body_bytes,
-        timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
-    )
-    if status != 200 or not isinstance(response, dict):
-        detail = response.get("error") if isinstance(response, dict) else None
-        raise RuntimeError(f"coordinator presence failed ({status}: {detail or 'unknown'})")
-    return response
+    responses: list[dict[str, Any]] = []
+    for group_id in groups:
+        group_payload = {**payload, "group_id": group_id}
+        body_bytes = json.dumps(group_payload, ensure_ascii=False).encode("utf-8")
+        url = f"{base_url}/v1/presence"
+        headers = build_auth_headers(
+            device_id=device_id,
+            method="POST",
+            url=url,
+            body_bytes=body_bytes,
+            keys_dir=keys_dir,
+        )
+        status, response = http_client.request_json(
+            "POST",
+            url,
+            headers=headers,
+            body=group_payload,
+            body_bytes=body_bytes,
+            timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
+        )
+        if status != 200 or not isinstance(response, dict):
+            detail = response.get("error") if isinstance(response, dict) else None
+            raise RuntimeError(f"coordinator presence failed ({status}: {detail or 'unknown'})")
+        responses.append(response)
+    return {"groups": groups, "responses": responses}
 
 
 def lookup_peers(
@@ -101,28 +111,57 @@ def lookup_peers(
     base_url = _coordinator_base_url(cfg)
     if not base_url:
         return []
-    query = urlencode({"group_id": str(cfg.sync_coordinator_group or "").strip()})
-    url = f"{base_url}/v1/peers?{query}"
-    headers = build_auth_headers(
-        device_id=device_id,
-        method="GET",
-        url=url,
-        body_bytes=b"",
-        keys_dir=keys_dir,
-    )
-    status, response = http_client.request_json(
-        "GET",
-        url,
-        headers=headers,
-        timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
-    )
-    if status != 200 or not isinstance(response, dict):
-        detail = response.get("error") if isinstance(response, dict) else None
-        raise RuntimeError(f"coordinator lookup failed ({status}: {detail or 'unknown'})")
-    items = response.get("items")
-    if not isinstance(items, list):
-        return []
-    return [item for item in items if isinstance(item, dict)]
+    merged: dict[tuple[str, str], dict[str, Any]] = {}
+    for group_id in _coordinator_groups(cfg):
+        query = urlencode({"group_id": group_id})
+        url = f"{base_url}/v1/peers?{query}"
+        headers = build_auth_headers(
+            device_id=device_id,
+            method="GET",
+            url=url,
+            body_bytes=b"",
+            keys_dir=keys_dir,
+        )
+        status, response = http_client.request_json(
+            "GET",
+            url,
+            headers=headers,
+            timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
+        )
+        if status != 200 or not isinstance(response, dict):
+            detail = response.get("error") if isinstance(response, dict) else None
+            raise RuntimeError(f"coordinator lookup failed ({status}: {detail or 'unknown'})")
+        items = response.get("items")
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            key = (
+                str(item.get("device_id") or "").strip(),
+                str(item.get("fingerprint") or "").strip(),
+            )
+            if not key[0]:
+                continue
+            existing = merged.get(key)
+            if existing is None:
+                merged[key] = {
+                    **item,
+                    "addresses": discovery.merge_addresses([], item.get("addresses") or []),
+                    "groups": [group_id],
+                }
+                continue
+            existing["addresses"] = discovery.merge_addresses(
+                existing.get("addresses") or [], item.get("addresses") or []
+            )
+            existing["groups"] = discovery.merge_addresses(existing.get("groups") or [], [group_id])
+            existing["stale"] = bool(existing.get("stale", True) and item.get("stale", True))
+            if item.get("last_seen_at") and str(item.get("last_seen_at")) > str(
+                existing.get("last_seen_at") or ""
+            ):
+                existing["last_seen_at"] = item.get("last_seen_at")
+                existing["expires_at"] = item.get("expires_at")
+    return list(merged.values())
 
 
 def refresh_peer_address_cache(

--- a/codemem/sync/daemon.py
+++ b/codemem/sync/daemon.py
@@ -50,19 +50,24 @@ def run_sync_daemon(
             store.close()
         zeroconf = advertise_mdns(device_id=device_id, port=port)
     stop = stop_event or threading.Event()
-    try:
-        while not stop.wait(interval_s):
-            store = MemoryStore(db_path or db.DEFAULT_DB_PATH)
+
+    def _run_tick_once() -> None:
+        store = MemoryStore(db_path or db.DEFAULT_DB_PATH)
+        try:
             try:
-                try:
-                    sync_pass.sync_daemon_tick(store)
-                    store.set_sync_daemon_ok()
-                except Exception as exc:
-                    tb = traceback.format_exc()
-                    store.set_sync_daemon_error(str(exc), tb)
-                    _append_sync_daemon_log(tb)
-            finally:
-                store.close()
+                sync_pass.sync_daemon_tick(store)
+                store.set_sync_daemon_ok()
+            except Exception as exc:
+                tb = traceback.format_exc()
+                store.set_sync_daemon_error(str(exc), tb)
+                _append_sync_daemon_log(tb)
+        finally:
+            store.close()
+
+    try:
+        _run_tick_once()
+        while not stop.wait(interval_s):
+            _run_tick_once()
     finally:
         server.shutdown()
         if zeroconf is not None:

--- a/codemem/sync/discovery.py
+++ b/codemem/sync/discovery.py
@@ -33,7 +33,22 @@ def normalize_address(address: str) -> str:
         path = parsed.path.rstrip("/")
         scheme = parsed.scheme.lower()
         return f"{scheme}://{netloc}{path}"
+    parsed = urlparse(f"//{value}")
+    host = (parsed.hostname or "").lower()
+    if host and parsed.port:
+        return f"{host}:{parsed.port}"
     return value.rstrip("/")
+
+
+def _address_dedupe_key(address: str) -> str:
+    cleaned = normalize_address(address)
+    if not cleaned:
+        return ""
+    parsed = urlparse(cleaned)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme in {"", "http"} and host and parsed.port and not parsed.path:
+        return f"{host}:{parsed.port}"
+    return cleaned
 
 
 def merge_addresses(existing: list[str], candidates: list[str]) -> list[str]:
@@ -41,9 +56,10 @@ def merge_addresses(existing: list[str], candidates: list[str]) -> list[str]:
     seen: set[str] = set()
     for address in existing + candidates:
         cleaned = normalize_address(address)
-        if not cleaned or cleaned in seen:
+        dedupe_key = _address_dedupe_key(cleaned)
+        if not cleaned or dedupe_key in seen:
             continue
-        seen.add(cleaned)
+        seen.add(dedupe_key)
         normalized.append(cleaned)
     return normalized
 

--- a/codemem/sync/sync_pass.py
+++ b/codemem/sync/sync_pass.py
@@ -408,6 +408,8 @@ def _should_skip_offline_peer(store: MemoryStore, peer_device_id: str) -> bool:
 
 def sync_daemon_tick(store: MemoryStore) -> list[dict[str, Any]]:
     sync_pass_preflight(store)
+    with suppress(Exception):
+        coordinator.refresh_peer_address_cache(store)
     rows = store.conn.execute("SELECT peer_device_id FROM sync_peers").fetchall()
     mdns_entries = discovery.discover_peers_via_mdns() if discovery.mdns_enabled() else []
     results: list[dict[str, Any]] = []

--- a/codemem/viewer_routes/config.py
+++ b/codemem/viewer_routes/config.py
@@ -318,12 +318,21 @@ def handle_get(
     except ValueError:
         handler._send_json({"error": "config file could not be read"}, status=500)
         return True
-    effective = asdict(load_config(config_path))
+    redacted_keys = {"sync_coordinator_admin_secret"}
+    config_data = {key: value for key, value in config_data.items() if key not in redacted_keys}
+    effective = {
+        key: value
+        for key, value in asdict(load_config(config_path)).items()
+        if key not in redacted_keys
+    }
+    defaults = {
+        key: value for key, value in asdict(OpencodeMemConfig()).items() if key not in redacted_keys
+    }
     handler._send_json(
         {
             "path": str(config_path),
             "config": config_data,
-            "defaults": asdict(OpencodeMemConfig()),
+            "defaults": defaults,
             "effective": effective,
             "env_overrides": get_env_overrides(),
             "providers": load_provider_options(),

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -96,6 +96,25 @@ If the coordinator is unavailable, codemem falls back to cached addresses and mD
 - enrollment is explicit per device/group
 - there is no username/password or codemem-operated account layer in this model
 
+## Remote admin flow
+
+Built-in local coordinator management commands operate directly on the local SQLite store.
+
+For remote coordinators, the first admin model uses a separate operator-managed admin secret. Remote management commands
+reuse the same `codemem sync coordinator ...` verbs, but target a remote coordinator when you pass `--remote-url` and
+an admin secret (or configure `sync_coordinator_admin_secret`).
+
+Examples:
+
+```fish
+codemem sync coordinator list-devices nerdworld --remote-url "https://coord.codemem.sh"
+codemem sync coordinator enroll-device nerdworld <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/device.key.pub --remote-url "https://coord.codemem.sh"
+codemem sync coordinator rename-device nerdworld <device-id> --name "work-laptop" --remote-url "https://coord.codemem.sh"
+```
+
+Device participation auth still uses the enrolled device keypair for `presence` and `peers` endpoints; the admin secret
+is only for remote mutation/listing endpoints.
+
 ## Cloudflare Worker reference deployment
 
 The design targets a runtime-agnostic HTTP contract, but a Cloudflare Worker is the canonical low-cost reference

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -60,11 +60,18 @@ Basic flow:
 ```fish
 codemem sync coordinator group-create team-alpha --db-path ~/.codemem/coordinator.sqlite
 codemem sync coordinator enroll-device team-alpha <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/id_ed25519.pub --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator list-devices team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator rename-device team-alpha <device-id> --name "work-laptop" --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator disable-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator remove-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
 codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
 ```
 
 This keeps the primary deployment path inside the main `codemem` artifact and reuses the existing Python signature
 verification code directly.
+
+These management commands operate on the built-in local coordinator store only. Remote coordinator admin flows require a
+separate access-control model before they should be exposed over HTTP.
 
 ## How discovery works
 

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -19,10 +19,10 @@ the network boundary you care about (for example VPNs).
 
 ## Config
 
-Set both of these to enable coordinator-backed discovery:
+Set these to enable coordinator-backed discovery:
 
 - `sync_coordinator_url`
-- `sync_coordinator_group`
+- either `sync_coordinator_group` or `sync_coordinator_groups`
 
 Optional knobs:
 
@@ -35,6 +35,7 @@ Environment variable equivalents:
 
 - `CODEMEM_SYNC_COORDINATOR_URL`
 - `CODEMEM_SYNC_COORDINATOR_GROUP`
+- `CODEMEM_SYNC_COORDINATOR_GROUPS`
 - `CODEMEM_SYNC_COORDINATOR_TIMEOUT_S`
 - `CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S`
 
@@ -50,6 +51,22 @@ Example config:
   "sync_advertise": "tailscale"
 }
 ```
+
+Multi-group config is also supported:
+
+```json
+{
+  "sync_coordinator_url": "https://coord.example.workers.dev",
+  "sync_coordinator_groups": ["team-alpha", "lab"]
+}
+```
+
+Backward compatibility:
+
+- `sync_coordinator_group` still works
+- when only the legacy single-group field is set, codemem treats it as a one-item `sync_coordinator_groups`
+- when `sync_coordinator_groups` is set, the first entry becomes the legacy single-group value for compatibility with
+  older surfaces
 
 ## Built-in coordinator service
 

--- a/docs/plans/2026-03-12-cloudflare-bootstrap-script-design.md
+++ b/docs/plans/2026-03-12-cloudflare-bootstrap-script-design.md
@@ -1,0 +1,157 @@
+# Cloudflare Coordinator Bootstrap Script Design
+
+**Bead:** `codemem-iw3`  
+**Status:** Design  
+**Date:** 2026-03-12
+
+## Goal
+
+Provide a user-friendly bootstrap flow for the Cloudflare coordinator example that is:
+
+- easy to run manually
+- pleasant and guided when interactive
+- fully scriptable for automation
+
+## Recommended shape
+
+Implement this as a standalone Python helper in:
+
+- `examples/cloudflare-coordinator/bootstrap.py`
+
+Do **not** bake it into the main `codemem` CLI yet.
+
+## Why script-first
+
+- Cloudflare bootstrap is deployment-specific, not core product behavior
+- it depends on operator workflow and external tooling like `wrangler`
+- the built-in coordinator service belongs in the main CLI; Cloudflare bootstrap does not need to yet
+
+## Dependency choice
+
+Recommended stack:
+
+- `Typer` for command/flag handling
+- `rich` for formatted output
+- `questionary` for interactive prompts
+
+Fallback if we want fewer dependencies:
+
+- `Typer` + `rich.prompt`
+
+Recommendation:
+
+- start with `Typer` + `rich` + `questionary`
+
+This gives us a nice interactive experience without sacrificing scriptability.
+
+## Modes
+
+### Interactive mode (default)
+
+Running without enough flags should walk the operator through setup.
+
+The script should:
+
+1. detect local codemem identity (`device_id`, fingerprint, public key)
+2. check that `wrangler` is installed and authenticated
+3. ask for the coordinator group name
+4. create the D1 database if needed
+5. create or patch `wrangler.toml`
+6. apply the schema
+7. optionally deploy the Worker
+8. show or confirm the resulting Worker URL
+9. apply or print the D1 enrollment SQL for the local device
+10. optionally write or print a config snippet for `config.json`
+11. optionally run the existing smoke check
+
+### Scriptable mode
+
+All required inputs must be passable as flags.
+
+Recommended flags:
+
+- `--group`
+- `--worker-url`
+- `--db-path`
+- `--keys-dir`
+- `--config-path`
+- `--create-d1`
+- `--apply-schema`
+- `--deploy`
+- `--enroll-local`
+- `--print-sql`
+- `--print-config`
+- `--run-smoke-check`
+- `--dry-run`
+- `--non-interactive`
+- `--format text|json`
+
+Behavior:
+
+- no prompts when `--non-interactive` is set
+- machine-readable output when `--format json` is requested
+- non-zero exit on validation or smoke-check failure
+
+## First implementation scope
+
+The first version should automate most of the operator workflow once `wrangler login` is already complete.
+
+It should:
+
+- read local identity information from the codemem DB and key store
+- verify `wrangler` is available
+- create D1 and apply schema when requested
+- write or patch `wrangler.toml` from the example when requested
+- deploy the Worker when requested
+- generate and optionally apply enrollment SQL for the local device
+- generate optional config snippets pointing codemem at the Worker
+- optionally run the existing smoke-check script
+
+It should **not** try to:
+
+- mutate D1 directly unless we explicitly decide to shell out to `wrangler`
+- enroll multiple devices in one run
+- become a generic Cloudflare deployment framework
+
+`--dry-run` should remain available so operators can see exactly what would be executed before the script mutates any
+Cloudflare resources.
+
+## Output design
+
+Interactive mode should present:
+
+- detected identity summary
+- generated SQL block
+- generated config snippet
+- next-step checklist
+
+Scriptable mode should be able to emit JSON like:
+
+```json
+{
+  "group": "team-alpha",
+  "device_id": "...",
+  "fingerprint": "SHA256:...",
+  "public_key_file": "...",
+  "enrollment_sql": "...",
+  "config_snippet": {
+    "sync_coordinator_url": "https://...",
+    "sync_coordinator_group": "team-alpha"
+  }
+}
+```
+
+## Nice-to-have follow-ons
+
+- optional shell-out helpers for `wrangler d1 execute`
+- optional Terraform example for Worker + D1 infra
+- multi-device enrollment bundle generation
+
+## Acceptance criteria
+
+This design is successful when:
+
+1. The bootstrap flow is clearly script-first, not main-CLI-first.
+2. Interactive and non-interactive modes are both defined.
+3. Dependency choices are pragmatic and lightweight.
+4. The first implementation scope stays focused on local device bootstrap and verification.

--- a/docs/plans/2026-03-13-remote-coordinator-admin-access-control.md
+++ b/docs/plans/2026-03-13-remote-coordinator-admin-access-control.md
@@ -1,0 +1,150 @@
+# Remote Coordinator Admin Access Control
+
+**Bead:** `codemem-y4m`  
+**Status:** Design  
+**Date:** 2026-03-13
+
+## Problem
+
+Coordinator-backed discovery now has two distinct classes of operation:
+
+- device participation operations
+  - register presence
+  - look up peers
+- coordinator administration operations
+  - enroll devices
+  - list enrolled devices
+  - rename device display names
+  - disable or remove devices
+
+The first class can reasonably use device-key auth. The second class must not.
+
+If remote mutation endpoints are exposed without a separate admin capability, any enrolled device could potentially
+reconfigure or remove peers it does not own.
+
+## Goal
+
+Define a staged remote admin model that keeps the coordinator MVP safe enough to extend without pretending we already have
+full identity, RBAC, or delegated admin.
+
+## Non-goals
+
+- No account system or SSO.
+- No full multi-role permission model.
+- No hosted codemem identity service.
+- No conflation of discovery groups with memory-sharing policy.
+
+## Recommended staged model
+
+### Stage 0: local built-in coordinator admin
+
+Applies only to the built-in coordinator running against a local SQLite DB.
+
+Admin boundary:
+
+- OS/filesystem access
+
+Implication:
+
+- local CLI management commands are acceptable without extra auth because whoever can run them already controls the local
+  coordinator DB.
+
+### Stage 1: remote admin via explicit operator secret
+
+For remote coordinators (including Cloudflare/self-hosted HTTP deployments), the first safe admin model should be a
+simple operator-managed admin secret.
+
+Recommended shape:
+
+- one coordinator-wide admin secret, or one per group if we want narrower blast radius
+- sent via dedicated admin header (for example `X-Codemem-Coordinator-Admin`)
+- used only for remote admin endpoints
+
+This is intentionally boring.
+
+Why this is the right first stage:
+
+- easy for self-hosters to understand
+- straightforward to implement across Python and Worker runtimes
+- clearly separates device participation auth from admin auth
+- avoids overloading device keys with admin power
+
+### Stage 2: explicit admin identities/keys
+
+Later, if the operator-secret model proves too coarse, move to a stronger admin model:
+
+- `group_admins` or equivalent store
+- admin public keys or signed admin requests
+- possibly multiple admins per group
+
+But that should come after Stage 1 is working, not before.
+
+### Stage 3: optional self-service device actions
+
+Possible later extension:
+
+- allow a device to update only its own non-sensitive metadata
+- maybe allow self-remove
+
+Not allowed in Stage 1:
+
+- one device mutating other devices
+- open self-enrollment based only on group name
+
+## Operation classes
+
+### Device-key auth operations
+
+These remain authenticated by the enrolled device's existing sync keypair:
+
+- `POST /v1/presence`
+- `GET /v1/peers`
+
+These are participation operations, not admin operations.
+
+### Admin-secret operations
+
+These should require explicit remote admin capability:
+
+- list enrolled devices
+- enroll a new device
+- rename a device display name
+- disable a device
+- remove a device
+
+## API boundary recommendation
+
+Keep device and admin surfaces separate.
+
+Suggested split:
+
+- `/v1/presence`
+- `/v1/peers`
+- `/v1/admin/devices`
+- `/v1/admin/devices/<device_id>`
+
+This makes it harder to accidentally apply the wrong auth rule to the wrong endpoint.
+
+## Config surface for Stage 1
+
+If/when remote admin ships, the operator would configure something like:
+
+- `sync_coordinator_admin_secret`
+
+This should be treated as a sensitive local config value and never surfaced casually in UI copy.
+
+## Built-in coordinator implication
+
+The local built-in coordinator can still use direct CLI commands against its SQLite DB without implementing the remote
+admin secret flow.
+
+That means we can safely ship local management commands now while remote admin remains blocked on this design.
+
+## Acceptance criteria
+
+This design is successful when:
+
+1. Device participation auth and remote admin auth are clearly separated.
+2. Stage 1 recommends a pragmatic remote admin model that is simple and safe enough to ship.
+3. The design explains why local built-in coordinator admin is a different case.
+4. Future evolution toward stronger admin identity is possible without blocking Stage 1.

--- a/examples/cloudflare-coordinator/.gitignore
+++ b/examples/cloudflare-coordinator/.gitignore
@@ -1,0 +1,2 @@
+.wrangler/
+wrangler.toml

--- a/examples/cloudflare-coordinator/README.md
+++ b/examples/cloudflare-coordinator/README.md
@@ -15,18 +15,88 @@ It is not a relay, queue, or central memory store.
 - `src/index.mjs` - Worker implementation
 - `schema.sql` - D1 schema
 - `wrangler.toml.example` - example Wrangler config
+- `bootstrap.py` - guided bootstrap helper for local device enrollment
 - `smoke_check.py` - live smoke-check script for deployed endpoints
 
-## Create the D1 database
+## First-time setup
+
+### 1. Install and authenticate Wrangler
+
+```fish
+npm install -g wrangler
+wrangler login
+```
+
+### 2. Create the D1 database
 
 ```fish
 wrangler d1 create codemem-coordinator
-wrangler d1 execute codemem-coordinator --file examples/cloudflare-coordinator/schema.sql
 ```
 
-Copy the returned D1 database ID into `wrangler.toml.example` or your real `wrangler.toml`.
+Copy the returned D1 database ID into a real `wrangler.toml` created from `wrangler.toml.example`.
+
+### 3. Create a real `wrangler.toml`
+
+```fish
+cp examples/cloudflare-coordinator/wrangler.toml.example examples/cloudflare-coordinator/wrangler.toml
+```
+
+Then edit `examples/cloudflare-coordinator/wrangler.toml` and replace:
+
+- `REPLACE_WITH_D1_DATABASE_ID`
+
+with the actual D1 database ID from step 2.
+
+### 4. Apply the schema
+
+```fish
+wrangler d1 execute codemem-coordinator --remote --file examples/cloudflare-coordinator/schema.sql
+```
+
+### 5. Deploy the Worker
+
+```fish
+wrangler deploy
+```
+
+Wrangler prints the deployed Worker URL, for example:
+
+- `https://codemem-coordinator.<your-subdomain>.workers.dev`
+
+That URL becomes your `sync_coordinator_url`.
 
 ## Bootstrap enrollment
+
+The easiest path is the bootstrap helper:
+
+```fish
+uv run python examples/cloudflare-coordinator/bootstrap.py
+```
+
+It will:
+
+- detect your local codemem device identity
+- create or reuse the named D1 database when requested
+- write `wrangler.toml` once it knows the D1 database id
+- apply schema and enrollment SQL remotely when requested
+- generate D1 enrollment SQL for the selected group
+- print a config snippet for `sync_coordinator_url` and `sync_coordinator_group`
+- optionally run the smoke check
+
+The script automates most of the flow once `wrangler login` is already complete, but the manual steps below are still
+useful if you want to inspect or repair the setup by hand.
+
+For automation, use non-interactive JSON output:
+
+```fish
+uv run python examples/cloudflare-coordinator/bootstrap.py \
+  --group team-alpha \
+  --worker-url "https://your-worker.example.workers.dev" \
+  --non-interactive \
+  --format json
+```
+
+If you want to follow the manual path, the details are below.
 
 The first slice assumes explicit operator enrollment.
 
@@ -49,10 +119,10 @@ VALUES (
 );
 ```
 
-## Deploy
+Apply manual enrollment against the remote D1 database:
 
 ```fish
-wrangler deploy
+wrangler d1 execute codemem-coordinator --remote --command "<paste generated SQL here>"
 ```
 
 ## Configure codemem

--- a/examples/cloudflare-coordinator/bootstrap.py
+++ b/examples/cloudflare-coordinator/bootstrap.py
@@ -1,0 +1,494 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Confirm, Prompt
+from rich.syntax import Syntax
+
+from codemem import db
+from codemem.sync_identity import ensure_device_identity, fingerprint_public_key, load_public_key
+
+app = typer.Typer(add_completion=False, help="Bootstrap the Cloudflare coordinator example")
+console = Console()
+WRANGLER_TOML_TEMPLATE = Path(__file__).with_name("wrangler.toml.example")
+SCHEMA_SQL_PATH = Path(__file__).with_name("schema.sql")
+DRY_RUN_DATABASE_ID = "00000000-0000-0000-0000-000000000000"
+
+
+class CommandFailure(RuntimeError):
+    def __init__(self, command: list[str], *, stdout: str = "", stderr: str = "") -> None:
+        self.command = command
+        self.stdout = stdout
+        self.stderr = stderr
+        detail = "\n".join(part for part in [stdout, stderr] if part).strip()
+        super().__init__(detail or f"command failed: {' '.join(command)}")
+
+
+def _load_local_identity(db_path: Path, keys_dir: Path | None) -> dict[str, str]:
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        device_id, fingerprint = ensure_device_identity(conn, keys_dir=keys_dir)
+    finally:
+        conn.close()
+    public_key = load_public_key(keys_dir)
+    if not public_key:
+        raise typer.BadParameter("public key missing")
+    return {
+        "device_id": device_id,
+        "fingerprint": fingerprint or fingerprint_public_key(public_key),
+        "public_key": public_key.strip(),
+    }
+
+
+def _sql_escape(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def build_enrollment_sql(
+    *,
+    group: str,
+    device_id: str,
+    fingerprint: str,
+    public_key: str,
+    device_name: str,
+) -> str:
+    return (
+        "INSERT INTO groups(group_id, display_name, created_at)\n"
+        f"VALUES ('{_sql_escape(group)}', '{_sql_escape(group)}', CURRENT_TIMESTAMP)\n"
+        "ON CONFLICT(group_id) DO NOTHING;\n\n"
+        "INSERT INTO enrolled_devices(group_id, device_id, public_key, fingerprint, display_name, created_at)\n"
+        "VALUES (\n"
+        f"  '{_sql_escape(group)}',\n"
+        f"  '{_sql_escape(device_id)}',\n"
+        f"  '{_sql_escape(public_key)}',\n"
+        f"  '{_sql_escape(fingerprint)}',\n"
+        f"  '{_sql_escape(device_name)}',\n"
+        "  CURRENT_TIMESTAMP\n"
+        ");"
+    )
+
+
+def build_config_snippet(*, worker_url: str, group: str) -> dict[str, str]:
+    return {
+        "sync_coordinator_url": worker_url.rstrip("/"),
+        "sync_coordinator_group": group,
+    }
+
+
+def build_wrangle_commands(*, database_name: str) -> list[str]:
+    return [
+        f"wrangler d1 create {database_name}",
+        f"wrangler d1 execute {database_name} --file {SCHEMA_SQL_PATH.as_posix()}",
+    ]
+
+
+def parse_d1_create_output(output: str) -> str | None:
+    patterns = [
+        re.compile(r"database_id\s*=\s*([0-9a-f-]{16,})", re.IGNORECASE),
+        re.compile(r"database id[:\s]+([0-9a-f-]{16,})", re.IGNORECASE),
+        re.compile(r'"uuid"\s*:\s*"([0-9a-f-]{16,})"', re.IGNORECASE),
+        re.compile(
+            r"\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b", re.IGNORECASE
+        ),
+    ]
+    for pattern in patterns:
+        match = pattern.search(output)
+        if match:
+            return match.group(1)
+    return None
+
+
+def parse_worker_url_output(output: str) -> str | None:
+    match = re.search(r"https://[a-z0-9.-]+\.workers\.dev", output, re.IGNORECASE)
+    return match.group(0) if match else None
+
+
+def render_wrangler_toml(*, database_id: str) -> str:
+    template = WRANGLER_TOML_TEMPLATE.read_text()
+    return template.replace("REPLACE_WITH_D1_DATABASE_ID", database_id)
+
+
+def write_wrangler_toml(*, wrangler_toml: Path, database_id: str) -> None:
+    wrangler_toml.parent.mkdir(parents=True, exist_ok=True)
+    wrangler_toml.write_text(render_wrangler_toml(database_id=database_id))
+
+
+def read_database_id_from_wrangler_toml(wrangler_toml: Path) -> str | None:
+    if not wrangler_toml.exists():
+        return None
+    return parse_d1_create_output(wrangler_toml.read_text())
+
+
+def parse_d1_list_output(output: str) -> list[dict[str, str]]:
+    text = output.strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, list):
+        results: list[dict[str, str]] = []
+        for item in parsed:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name") or item.get("database_name") or "").strip()
+            uuid = str(item.get("uuid") or item.get("database_id") or "").strip()
+            if name and uuid:
+                results.append({"name": name, "uuid": uuid})
+        return results
+    results = []
+    for line in text.splitlines():
+        match = re.search(
+            r"(?P<name>[A-Za-z0-9._-]+).*?(?P<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+            line,
+            re.IGNORECASE,
+        )
+        if match:
+            results.append({"name": match.group("name"), "uuid": match.group("uuid")})
+    return results
+
+
+def list_d1_databases(*, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = ["wrangler", "d1", "list", "--json"]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    output = "\n".join(part for part in [result.stdout, result.stderr] if part)
+    return {"command": command, "databases": parse_d1_list_output(output), "output": output}
+
+
+def find_existing_database_id(
+    *, database_name: str, dry_run: bool, cwd: Path
+) -> tuple[str | None, dict[str, Any] | None]:
+    listing = list_d1_databases(dry_run=dry_run, cwd=cwd)
+    for item in listing["databases"]:
+        if str(item.get("name") or "").strip() == database_name:
+            return str(item.get("uuid") or "").strip() or None, listing
+    return None, listing
+
+
+def run_command(
+    command: list[str],
+    *,
+    dry_run: bool,
+    cwd: Path,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    if dry_run:
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+    try:
+        return subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            capture_output=capture_output,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise typer.BadParameter(f"missing required command: {command[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise CommandFailure(command, stdout=exc.stdout or "", stderr=exc.stderr or "") from exc
+
+
+def ensure_wrangler_ready(*, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = ["wrangler", "whoami"]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    return {"command": command, "stdout": result.stdout, "stderr": result.stderr}
+
+
+def create_d1_database(*, database_name: str, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = ["wrangler", "d1", "create", database_name]
+    reused_existing = False
+    list_result = None
+    if dry_run:
+        return {
+            "command": command,
+            "database_id": DRY_RUN_DATABASE_ID,
+            "output": "",
+            "reused_existing": False,
+            "list_result": None,
+        }
+    try:
+        result = run_command(command, dry_run=dry_run, cwd=cwd)
+        output = "\n".join(part for part in [result.stdout, result.stderr] if part)
+        database_id = parse_d1_create_output(output)
+    except CommandFailure as exc:
+        output = str(exc)
+        if "already exists" not in output.lower():
+            raise
+        database_id, list_result = find_existing_database_id(
+            database_name=database_name,
+            dry_run=dry_run,
+            cwd=cwd,
+        )
+        if not database_id:
+            raise typer.BadParameter(
+                f"D1 database '{database_name}' already exists but its database id could not be discovered automatically. Run 'wrangler d1 list' and rerun the script with that id."
+            ) from exc
+        reused_existing = True
+    return {
+        "command": command,
+        "database_id": database_id,
+        "output": output,
+        "reused_existing": reused_existing,
+        "list_result": list_result,
+    }
+
+
+def apply_schema(*, database_name: str, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = [
+        "wrangler",
+        "d1",
+        "execute",
+        database_name,
+        "--remote",
+        "--file",
+        str(SCHEMA_SQL_PATH),
+    ]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    return {"command": command, "stdout": result.stdout, "stderr": result.stderr}
+
+
+def deploy_worker(*, dry_run: bool, cwd: Path) -> dict[str, Any]:
+    command = ["wrangler", "deploy"]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    output = "\n".join(part for part in [result.stdout, result.stderr] if part)
+    return {"command": command, "worker_url": parse_worker_url_output(output), "output": output}
+
+
+def apply_enrollment_sql(
+    *, database_name: str, sql: str, dry_run: bool, cwd: Path
+) -> dict[str, Any]:
+    command = ["wrangler", "d1", "execute", database_name, "--remote", "--command", sql]
+    result = run_command(command, dry_run=dry_run, cwd=cwd)
+    return {"command": command, "stdout": result.stdout, "stderr": result.stderr}
+
+
+def _run_smoke_check(*, db_path: Path, worker_url: str, group: str, keys_dir: Path | None) -> int:
+    command = [
+        "uv",
+        "run",
+        "python",
+        "examples/cloudflare-coordinator/smoke_check.py",
+        "--db",
+        str(db_path),
+        "--url",
+        worker_url,
+        "--group",
+        group,
+    ]
+    if keys_dir is not None:
+        command.extend(["--keys-dir", str(keys_dir)])
+    result = subprocess.run(command, check=False)
+    return int(result.returncode)
+
+
+@app.command()
+def main(
+    db_path: Path = typer.Option(
+        Path("~/.codemem/mem.sqlite").expanduser(), help="Path to local codemem DB"
+    ),
+    group: str | None = typer.Option(None, help="Coordinator group ID"),
+    worker_url: str | None = typer.Option(None, help="Deployed Worker URL"),
+    keys_dir: Path | None = typer.Option(None, help="Optional CODEMEM_KEYS_DIR override"),
+    device_name: str | None = typer.Option(None, help="Optional display name for enrolled device"),
+    database_name: str = typer.Option(
+        "codemem-coordinator", help="Suggested Cloudflare D1 database name"
+    ),
+    wrangler_toml: Path = typer.Option(
+        Path(__file__).with_name("wrangler.toml"),
+        help="Path to generated wrangler.toml",
+    ),
+    create_d1: bool = typer.Option(False, help="Create the D1 database with wrangler"),
+    apply_schema_sql: bool = typer.Option(
+        False, "--apply-schema", help="Apply schema.sql with wrangler"
+    ),
+    deploy: bool = typer.Option(False, help="Deploy the Worker with wrangler"),
+    enroll_local: bool = typer.Option(False, help="Apply generated enrollment SQL with wrangler"),
+    dry_run: bool = typer.Option(False, help="Print commands without executing them"),
+    non_interactive: bool = typer.Option(
+        False, "--non-interactive", help="Disable prompts and require all needed values via flags"
+    ),
+    format: str = typer.Option("text", help="Output format: text or json"),
+    print_sql: bool = typer.Option(True, help="Include bootstrap SQL in the output"),
+    print_config: bool = typer.Option(True, help="Include config snippet in the output"),
+    run_smoke_check: bool = typer.Option(
+        False, help="Run smoke_check.py after printing bootstrap info"
+    ),
+) -> None:
+    if format not in {"text", "json"}:
+        raise typer.BadParameter("format must be 'text' or 'json'")
+    resolved_db_path = db_path.expanduser()
+    resolved_keys_dir = keys_dir.expanduser() if keys_dir is not None else None
+    resolved_wrangler_toml = wrangler_toml.expanduser()
+    script_dir = Path(__file__).resolve().parent
+    identity = _load_local_identity(resolved_db_path, resolved_keys_dir)
+
+    if not non_interactive:
+        create_d1 = create_d1 or Confirm.ask("Create the D1 database with wrangler?", default=True)
+        apply_schema_sql = apply_schema_sql or Confirm.ask(
+            "Apply schema.sql with wrangler?", default=True
+        )
+        deploy = deploy or Confirm.ask("Deploy the Worker with wrangler?", default=True)
+        enroll_local = enroll_local or Confirm.ask(
+            "Apply enrollment SQL with wrangler?", default=True
+        )
+
+    if not group:
+        if non_interactive:
+            raise typer.BadParameter("--group is required in non-interactive mode")
+        group = Prompt.ask("Coordinator group", default="team-alpha")
+    if not device_name:
+        if non_interactive:
+            device_name = identity["device_id"]
+        else:
+            device_name = Prompt.ask("Device display name", default=identity["device_id"])
+
+    needs_wrangler = create_d1 or apply_schema_sql or deploy or enroll_local
+    try:
+        wrangler_ready = (
+            ensure_wrangler_ready(dry_run=dry_run, cwd=script_dir) if needs_wrangler else None
+        )
+    except CommandFailure as exc:
+        raise typer.BadParameter(
+            f"wrangler is not ready. Run 'wrangler login' first.\n\n{exc}"
+        ) from exc
+
+    database_id = read_database_id_from_wrangler_toml(resolved_wrangler_toml)
+    d1_create = None
+    if create_d1:
+        d1_create = create_d1_database(database_name=database_name, dry_run=dry_run, cwd=script_dir)
+        database_id = d1_create.get("database_id") or database_id
+    elif not database_id and needs_wrangler:
+        database_id, list_result = find_existing_database_id(
+            database_name=database_name,
+            dry_run=dry_run,
+            cwd=script_dir,
+        )
+        if list_result is not None:
+            d1_create = {
+                "command": ["wrangler", "d1", "list", "--json"],
+                "database_id": database_id,
+                "output": list_result.get("output", ""),
+                "reused_existing": bool(database_id),
+                "list_result": list_result,
+            }
+    if not database_id and not non_interactive:
+        database_id = Prompt.ask("Cloudflare D1 database id", default="") or None
+    if dry_run and not database_id and needs_wrangler:
+        database_id = DRY_RUN_DATABASE_ID
+    if needs_wrangler and not database_id:
+        raise typer.BadParameter(
+            f"No D1 database id is configured for '{database_name}'. Create it first or provide its id."
+        )
+    if database_id:
+        if not dry_run:
+            write_wrangler_toml(wrangler_toml=resolved_wrangler_toml, database_id=database_id)
+    elif not dry_run and resolved_wrangler_toml.exists():
+        console.print(f"[yellow]Keeping existing {resolved_wrangler_toml}[/yellow]")
+
+    try:
+        schema_result = (
+            apply_schema(database_name=database_name, dry_run=dry_run, cwd=script_dir)
+            if apply_schema_sql
+            else None
+        )
+        deploy_result = deploy_worker(dry_run=dry_run, cwd=script_dir) if deploy else None
+    except CommandFailure as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    if not worker_url:
+        worker_url = (deploy_result or {}).get("worker_url") if deploy_result else None
+    if not worker_url:
+        if non_interactive:
+            raise typer.BadParameter("--worker-url is required unless --deploy discovers it")
+        worker_url = Prompt.ask("Worker URL", default="https://your-worker.example.workers.dev")
+
+    sql = build_enrollment_sql(
+        group=group,
+        device_id=identity["device_id"],
+        fingerprint=identity["fingerprint"],
+        public_key=identity["public_key"],
+        device_name=device_name,
+    )
+    config_snippet = build_config_snippet(worker_url=worker_url, group=group)
+    try:
+        enrollment_result = (
+            apply_enrollment_sql(
+                database_name=database_name,
+                sql=sql,
+                dry_run=dry_run,
+                cwd=script_dir,
+            )
+            if enroll_local
+            else None
+        )
+    except CommandFailure as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    payload = {
+        "group": group,
+        "device_id": identity["device_id"],
+        "fingerprint": identity["fingerprint"],
+        "device_name": device_name,
+        "public_key": identity["public_key"],
+        "wrangler_ready": wrangler_ready,
+        "database_id": database_id,
+        "wrangler_toml": str(resolved_wrangler_toml),
+        "needs_wrangler": needs_wrangler,
+        "wrangler_commands": build_wrangle_commands(database_name=database_name),
+        "d1_create": d1_create,
+        "schema_apply": schema_result,
+        "deploy": deploy_result,
+        "enroll_local": enrollment_result,
+        "enrollment_sql": sql if print_sql else None,
+        "config_snippet": config_snippet if print_config else None,
+        "dry_run": dry_run,
+    }
+
+    if format == "json":
+        console.print_json(data=payload)
+    else:
+        console.print(Panel.fit("Cloudflare coordinator bootstrap", style="cyan"))
+        console.print(f"[bold]Device ID:[/bold] {identity['device_id']}")
+        console.print(f"[bold]Fingerprint:[/bold] {identity['fingerprint']}")
+        console.print(f"[bold]Group:[/bold] {group}")
+        console.print(f"[bold]Worker URL:[/bold] {worker_url}")
+        if database_id:
+            console.print(f"[bold]D1 database id:[/bold] {database_id}")
+        console.print(f"[bold]wrangler.toml:[/bold] {resolved_wrangler_toml}")
+        console.print("\n[bold]Wrangler setup commands[/bold]")
+        for command in payload["wrangler_commands"]:
+            console.print(f"- {command}")
+        if print_sql:
+            console.print("\n[bold]Enrollment SQL[/bold]")
+            console.print(Syntax(sql, "sql", word_wrap=True))
+        if print_config:
+            console.print("\n[bold]Config snippet[/bold]")
+            console.print(Syntax(json.dumps(config_snippet, indent=2), "json", word_wrap=True))
+        console.print("\n[bold]Next steps[/bold]")
+        console.print("1. Confirm wrangler commands succeeded")
+        console.print("2. Add the config snippet to your codemem config")
+        console.print("3. Run the smoke check")
+
+    should_run_smoke = run_smoke_check
+    if not non_interactive and not should_run_smoke:
+        should_run_smoke = Confirm.ask("Run smoke check now?", default=False)
+    if should_run_smoke:
+        exit_code = _run_smoke_check(
+            db_path=resolved_db_path,
+            worker_url=worker_url,
+            group=group,
+            keys_dir=resolved_keys_dir,
+        )
+        if exit_code != 0:
+            raise typer.Exit(code=exit_code)
+
+
+if __name__ == "__main__":
+    app()

--- a/examples/cloudflare-coordinator/bootstrap.py
+++ b/examples/cloudflare-coordinator/bootstrap.py
@@ -13,6 +13,7 @@ from rich.prompt import Confirm, Prompt
 from rich.syntax import Syntax
 
 from codemem import db
+from codemem.config import get_config_path, read_config_file, write_config_file
 from codemem.sync_identity import ensure_device_identity, fingerprint_public_key, load_public_key
 
 app = typer.Typer(add_completion=False, help="Bootstrap the Cloudflare coordinator example")
@@ -81,6 +82,17 @@ def build_config_snippet(*, worker_url: str, group: str) -> dict[str, str]:
         "sync_coordinator_url": worker_url.rstrip("/"),
         "sync_coordinator_group": group,
     }
+
+
+def write_config_snippet(
+    *, config_path: Path, snippet: dict[str, str], dry_run: bool
+) -> dict[str, Any]:
+    if dry_run:
+        return {"path": str(config_path), "written": False, "dry_run": True}
+    data = read_config_file(config_path)
+    data.update(snippet)
+    write_config_file(data, config_path)
+    return {"path": str(config_path), "written": True, "dry_run": False}
 
 
 def build_wrangle_commands(*, database_name: str) -> list[str]:
@@ -161,7 +173,12 @@ def list_d1_databases(*, dry_run: bool, cwd: Path) -> dict[str, Any]:
     command = ["wrangler", "d1", "list", "--json"]
     result = run_command(command, dry_run=dry_run, cwd=cwd)
     output = "\n".join(part for part in [result.stdout, result.stderr] if part)
-    return {"command": command, "databases": parse_d1_list_output(output), "output": output}
+    return {
+        "command": command,
+        "databases": parse_d1_list_output(output),
+        "output": output,
+        "dry_run": dry_run,
+    }
 
 
 def find_existing_database_id(
@@ -214,6 +231,7 @@ def create_d1_database(*, database_name: str, dry_run: bool, cwd: Path) -> dict[
             "output": "",
             "reused_existing": False,
             "list_result": None,
+            "dry_run": True,
         }
     try:
         result = run_command(command, dry_run=dry_run, cwd=cwd)
@@ -239,6 +257,7 @@ def create_d1_database(*, database_name: str, dry_run: bool, cwd: Path) -> dict[
         "output": output,
         "reused_existing": reused_existing,
         "list_result": list_result,
+        "dry_run": dry_run,
     }
 
 
@@ -253,14 +272,24 @@ def apply_schema(*, database_name: str, dry_run: bool, cwd: Path) -> dict[str, A
         str(SCHEMA_SQL_PATH),
     ]
     result = run_command(command, dry_run=dry_run, cwd=cwd)
-    return {"command": command, "stdout": result.stdout, "stderr": result.stderr}
+    return {
+        "command": command,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "dry_run": dry_run,
+    }
 
 
 def deploy_worker(*, dry_run: bool, cwd: Path) -> dict[str, Any]:
     command = ["wrangler", "deploy"]
     result = run_command(command, dry_run=dry_run, cwd=cwd)
     output = "\n".join(part for part in [result.stdout, result.stderr] if part)
-    return {"command": command, "worker_url": parse_worker_url_output(output), "output": output}
+    return {
+        "command": command,
+        "worker_url": parse_worker_url_output(output),
+        "output": output,
+        "dry_run": dry_run,
+    }
 
 
 def apply_enrollment_sql(
@@ -268,10 +297,17 @@ def apply_enrollment_sql(
 ) -> dict[str, Any]:
     command = ["wrangler", "d1", "execute", database_name, "--remote", "--command", sql]
     result = run_command(command, dry_run=dry_run, cwd=cwd)
-    return {"command": command, "stdout": result.stdout, "stderr": result.stderr}
+    return {
+        "command": command,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+        "dry_run": dry_run,
+    }
 
 
-def _run_smoke_check(*, db_path: Path, worker_url: str, group: str, keys_dir: Path | None) -> int:
+def _run_smoke_check(
+    *, db_path: Path, worker_url: str, group: str, keys_dir: Path | None
+) -> tuple[int, str, str]:
     command = [
         "uv",
         "run",
@@ -286,8 +322,31 @@ def _run_smoke_check(*, db_path: Path, worker_url: str, group: str, keys_dir: Pa
     ]
     if keys_dir is not None:
         command.extend(["--keys-dir", str(keys_dir)])
-    result = subprocess.run(command, check=False)
-    return int(result.returncode)
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    return int(result.returncode), (result.stdout or ""), (result.stderr or "")
+
+
+def _smoke_check_guidance(stderr_text: str) -> str | None:
+    text = stderr_text.strip()
+    lowered = text.lower()
+    if "error code: 1010" in lowered:
+        return (
+            "Cloudflare blocked the request before it reached the coordinator. Check Browser Integrity Check or WAF rules "
+            "for the Worker hostname/custom domain."
+        )
+    if "unknown_device" in lowered:
+        return "The device is not enrolled in the coordinator group yet. Apply the enrollment SQL remotely and retry."
+    if "invalid_admin_secret" in lowered:
+        return "The configured remote admin secret is wrong for this coordinator."
+    return None
+
+
+def _step_status(selected: bool, *, result: dict[str, Any] | None = None) -> dict[str, Any]:
+    if not selected:
+        return {"status": "skipped"}
+    if result is None:
+        return {"status": "failed"}
+    return {"status": "dry_run" if result.get("dry_run") else "executed", **result}
 
 
 @app.command()
@@ -306,6 +365,7 @@ def main(
         Path(__file__).with_name("wrangler.toml"),
         help="Path to generated wrangler.toml",
     ),
+    config_path: Path | None = typer.Option(None, help="Path to codemem config file to update"),
     create_d1: bool = typer.Option(False, help="Create the D1 database with wrangler"),
     apply_schema_sql: bool = typer.Option(
         False, "--apply-schema", help="Apply schema.sql with wrangler"
@@ -319,6 +379,7 @@ def main(
     format: str = typer.Option("text", help="Output format: text or json"),
     print_sql: bool = typer.Option(True, help="Include bootstrap SQL in the output"),
     print_config: bool = typer.Option(True, help="Include config snippet in the output"),
+    write_config: bool = typer.Option(False, help="Write coordinator config into config.json"),
     run_smoke_check: bool = typer.Option(
         False, help="Run smoke_check.py after printing bootstrap info"
     ),
@@ -328,6 +389,9 @@ def main(
     resolved_db_path = db_path.expanduser()
     resolved_keys_dir = keys_dir.expanduser() if keys_dir is not None else None
     resolved_wrangler_toml = wrangler_toml.expanduser()
+    resolved_config_path = get_config_path(
+        config_path.expanduser() if config_path is not None else None
+    )
     script_dir = Path(__file__).resolve().parent
     identity = _load_local_identity(resolved_db_path, resolved_keys_dir)
 
@@ -350,6 +414,11 @@ def main(
             device_name = identity["device_id"]
         else:
             device_name = Prompt.ask("Device display name", default=identity["device_id"])
+    if not non_interactive:
+        write_config = write_config or Confirm.ask(
+            f"Write coordinator settings to {resolved_config_path}?",
+            default=True,
+        )
 
     needs_wrangler = create_d1 or apply_schema_sql or deploy or enroll_local
     try:
@@ -411,13 +480,22 @@ def main(
         worker_url = Prompt.ask("Worker URL", default="https://your-worker.example.workers.dev")
 
     sql = build_enrollment_sql(
-        group=group,
+        group=str(group),
         device_id=identity["device_id"],
         fingerprint=identity["fingerprint"],
         public_key=identity["public_key"],
-        device_name=device_name,
+        device_name=str(device_name),
     )
-    config_snippet = build_config_snippet(worker_url=worker_url, group=group)
+    config_snippet = build_config_snippet(worker_url=str(worker_url), group=str(group))
+    config_write_result = (
+        write_config_snippet(
+            config_path=resolved_config_path,
+            snippet=config_snippet,
+            dry_run=dry_run,
+        )
+        if write_config
+        else None
+    )
     try:
         enrollment_result = (
             apply_enrollment_sql(
@@ -440,20 +518,34 @@ def main(
         "wrangler_ready": wrangler_ready,
         "database_id": database_id,
         "wrangler_toml": str(resolved_wrangler_toml),
+        "config_path": str(resolved_config_path),
         "needs_wrangler": needs_wrangler,
         "wrangler_commands": build_wrangle_commands(database_name=database_name),
         "d1_create": d1_create,
         "schema_apply": schema_result,
         "deploy": deploy_result,
         "enroll_local": enrollment_result,
+        "config_write": config_write_result,
         "enrollment_sql": sql if print_sql else None,
         "config_snippet": config_snippet if print_config else None,
         "dry_run": dry_run,
+        "steps": {
+            "wrangler_ready": _step_status(needs_wrangler, result=wrangler_ready),
+            "create_d1": _step_status(create_d1, result=d1_create),
+            "apply_schema": _step_status(apply_schema_sql, result=schema_result),
+            "deploy": _step_status(deploy, result=deploy_result),
+            "enroll_local": _step_status(enroll_local, result=enrollment_result),
+            "write_config": _step_status(write_config, result=config_write_result),
+        },
     }
 
-    if format == "json":
+    should_run_smoke = run_smoke_check
+    if not non_interactive and not should_run_smoke:
+        should_run_smoke = Confirm.ask("Run smoke check now?", default=False)
+
+    if format == "json" and not should_run_smoke:
         console.print_json(data=payload)
-    else:
+    elif format != "json":
         console.print(Panel.fit("Cloudflare coordinator bootstrap", style="cyan"))
         console.print(f"[bold]Device ID:[/bold] {identity['device_id']}")
         console.print(f"[bold]Fingerprint:[/bold] {identity['fingerprint']}")
@@ -462,6 +554,10 @@ def main(
         if database_id:
             console.print(f"[bold]D1 database id:[/bold] {database_id}")
         console.print(f"[bold]wrangler.toml:[/bold] {resolved_wrangler_toml}")
+        console.print(f"[bold]config.json:[/bold] {resolved_config_path}")
+        console.print("\n[bold]Step status[/bold]")
+        for name, item in payload["steps"].items():
+            console.print(f"- {name}: {item['status']}")
         console.print("\n[bold]Wrangler setup commands[/bold]")
         for command in payload["wrangler_commands"]:
             console.print(f"- {command}")
@@ -472,20 +568,38 @@ def main(
             console.print("\n[bold]Config snippet[/bold]")
             console.print(Syntax(json.dumps(config_snippet, indent=2), "json", word_wrap=True))
         console.print("\n[bold]Next steps[/bold]")
-        console.print("1. Confirm wrangler commands succeeded")
-        console.print("2. Add the config snippet to your codemem config")
-        console.print("3. Run the smoke check")
+        console.print("1. Review any failed step above")
+        console.print("2. If config was not written, add the config snippet manually")
+        console.print("3. Run the smoke check if remote steps succeeded")
 
-    should_run_smoke = run_smoke_check
-    if not non_interactive and not should_run_smoke:
-        should_run_smoke = Confirm.ask("Run smoke check now?", default=False)
     if should_run_smoke:
-        exit_code = _run_smoke_check(
+        exit_code, stdout_text, stderr_text = _run_smoke_check(
             db_path=resolved_db_path,
-            worker_url=worker_url,
-            group=group,
+            worker_url=str(worker_url),
+            group=str(group),
             keys_dir=resolved_keys_dir,
         )
+        payload["steps"]["smoke_check"] = {
+            "status": "executed" if exit_code == 0 else "failed",
+            "exit_code": exit_code,
+            "stdout": stdout_text,
+            "stderr": stderr_text,
+            "guidance": _smoke_check_guidance(stderr_text),
+        }
+        if format == "json":
+            console.print_json(data=payload)
+            if exit_code != 0:
+                raise typer.Exit(code=exit_code)
+            return
+        if stdout_text.strip():
+            console.print("\n[bold]Smoke check output[/bold]")
+            console.print(stdout_text.rstrip())
+        if stderr_text.strip():
+            console.print("\n[bold red]Smoke check error[/bold red]")
+            console.print(stderr_text.rstrip())
+        guidance = _smoke_check_guidance(stderr_text)
+        if guidance:
+            console.print(f"\n[yellow]{guidance}[/yellow]")
         if exit_code != 0:
             raise typer.Exit(code=exit_code)
 

--- a/examples/cloudflare-coordinator/smoke_check.py
+++ b/examples/cloudflare-coordinator/smoke_check.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from urllib import request
+from urllib import error, request
 
 from codemem import db
 from codemem.sync_auth import build_auth_headers
@@ -17,8 +17,12 @@ def _json_request(
     if body is not None:
         body_bytes = json.dumps(body, ensure_ascii=False).encode("utf-8")
     req = request.Request(url, data=body_bytes, headers=headers, method=method)
-    with request.urlopen(req, timeout=5) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+    try:
+        with request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"{method} {url} failed with HTTP {exc.code}: {detail}") from exc
 
 
 def main() -> None:

--- a/tests/test_cloudflare_bootstrap.py
+++ b/tests/test_cloudflare_bootstrap.py
@@ -23,6 +23,7 @@ def _load_bootstrap_module():
 def test_cloudflare_bootstrap_script_outputs_json(tmp_path: Path) -> None:
     db_path = tmp_path / "mem.sqlite"
     keys_dir = tmp_path / "keys"
+    config_path = tmp_path / "config.json"
     conn = db.connect(db_path)
     try:
         db.initialize_schema(conn)
@@ -44,8 +45,11 @@ def test_cloudflare_bootstrap_script_outputs_json(tmp_path: Path) -> None:
             "nerdworld",
             "--worker-url",
             "https://coord.example.workers.dev",
+            "--config-path",
+            str(config_path),
             "--device-name",
             "laptop",
+            "--write-config",
             "--non-interactive",
             "--format",
             "json",
@@ -60,8 +64,12 @@ def test_cloudflare_bootstrap_script_outputs_json(tmp_path: Path) -> None:
     assert payload["group"] == "nerdworld"
     assert payload["device_id"] == device_id
     assert payload["fingerprint"] == fingerprint
+    assert payload["steps"]["write_config"]["status"] == "executed"
     assert payload["config_snippet"]["sync_coordinator_group"] == "nerdworld"
     assert payload["config_snippet"]["sync_coordinator_url"] == "https://coord.example.workers.dev"
+    saved = json.loads(config_path.read_text())
+    assert saved["sync_coordinator_group"] == "nerdworld"
+    assert saved["sync_coordinator_url"] == "https://coord.example.workers.dev"
     assert "INSERT INTO groups" in payload["enrollment_sql"]
     assert any("wrangler d1 create" in command for command in payload["wrangler_commands"])
 
@@ -69,6 +77,7 @@ def test_cloudflare_bootstrap_script_outputs_json(tmp_path: Path) -> None:
 def test_cloudflare_bootstrap_script_supports_full_dry_run_flow(tmp_path: Path) -> None:
     db_path = tmp_path / "mem.sqlite"
     keys_dir = tmp_path / "keys"
+    config_path = tmp_path / "config.json"
     conn = db.connect(db_path)
     try:
         db.initialize_schema(conn)
@@ -90,12 +99,15 @@ def test_cloudflare_bootstrap_script_supports_full_dry_run_flow(tmp_path: Path) 
             "nerdworld",
             "--worker-url",
             "https://coord.example.workers.dev",
+            "--config-path",
+            str(config_path),
             "--device-name",
             "laptop",
             "--create-d1",
             "--apply-schema",
             "--deploy",
             "--enroll-local",
+            "--write-config",
             "--dry-run",
             "--non-interactive",
             "--format",
@@ -118,6 +130,7 @@ def test_cloudflare_bootstrap_script_supports_full_dry_run_flow(tmp_path: Path) 
     assert payload["enroll_local"]["command"][:3] == ["wrangler", "d1", "execute"]
     assert "--remote" in payload["schema_apply"]["command"]
     assert "--remote" in payload["enroll_local"]["command"]
+    assert payload["steps"]["write_config"]["status"] == "dry_run"
 
 
 def test_create_d1_database_reuses_existing_database_id() -> None:
@@ -144,3 +157,12 @@ def test_create_d1_database_reuses_existing_database_id() -> None:
 
     assert result["database_id"] == "784d138d-ab3c-4f5c-9464-cf45c5b69af3"
     assert result["reused_existing"] is True
+
+
+def test_smoke_check_guidance_handles_cloudflare_1010() -> None:
+    module = _load_bootstrap_module()
+    guidance = module._smoke_check_guidance(
+        "POST https://coord.example.workers.dev/v1/presence failed with HTTP 403: error code: 1010"
+    )
+    assert guidance is not None
+    assert "Browser Integrity Check" in guidance

--- a/tests/test_cloudflare_bootstrap.py
+++ b/tests/test_cloudflare_bootstrap.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+from codemem import db
+from codemem.sync_identity import ensure_device_identity
+
+
+def _load_bootstrap_module():
+    path = (
+        Path(__file__).resolve().parents[1] / "examples" / "cloudflare-coordinator" / "bootstrap.py"
+    )
+    spec = importlib.util.spec_from_file_location("cloudflare_bootstrap", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cloudflare_bootstrap_script_outputs_json(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        device_id, fingerprint = ensure_device_identity(conn, keys_dir=keys_dir)
+    finally:
+        conn.close()
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "examples/cloudflare-coordinator/bootstrap.py",
+            "--db-path",
+            str(db_path),
+            "--keys-dir",
+            str(keys_dir),
+            "--group",
+            "nerdworld",
+            "--worker-url",
+            "https://coord.example.workers.dev",
+            "--device-name",
+            "laptop",
+            "--non-interactive",
+            "--format",
+            "json",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["group"] == "nerdworld"
+    assert payload["device_id"] == device_id
+    assert payload["fingerprint"] == fingerprint
+    assert payload["config_snippet"]["sync_coordinator_group"] == "nerdworld"
+    assert payload["config_snippet"]["sync_coordinator_url"] == "https://coord.example.workers.dev"
+    assert "INSERT INTO groups" in payload["enrollment_sql"]
+    assert any("wrangler d1 create" in command for command in payload["wrangler_commands"])
+
+
+def test_cloudflare_bootstrap_script_supports_full_dry_run_flow(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        device_id, _fingerprint = ensure_device_identity(conn, keys_dir=keys_dir)
+    finally:
+        conn.close()
+
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "python",
+            "examples/cloudflare-coordinator/bootstrap.py",
+            "--db-path",
+            str(db_path),
+            "--keys-dir",
+            str(keys_dir),
+            "--group",
+            "nerdworld",
+            "--worker-url",
+            "https://coord.example.workers.dev",
+            "--device-name",
+            "laptop",
+            "--create-d1",
+            "--apply-schema",
+            "--deploy",
+            "--enroll-local",
+            "--dry-run",
+            "--non-interactive",
+            "--format",
+            "json",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload["device_id"] == device_id
+    assert payload["dry_run"] is True
+    assert payload["needs_wrangler"] is True
+    assert payload["wrangler_ready"]["command"] == ["wrangler", "whoami"]
+    assert payload["d1_create"]["command"][:3] == ["wrangler", "d1", "create"]
+    assert payload["schema_apply"]["command"][:3] == ["wrangler", "d1", "execute"]
+    assert payload["deploy"]["command"] == ["wrangler", "deploy"]
+    assert payload["enroll_local"]["command"][:3] == ["wrangler", "d1", "execute"]
+    assert "--remote" in payload["schema_apply"]["command"]
+    assert "--remote" in payload["enroll_local"]["command"]
+
+
+def test_create_d1_database_reuses_existing_database_id() -> None:
+    module = _load_bootstrap_module()
+
+    def fake_run_command(command, *, dry_run, cwd, capture_output=True):
+        if command[:3] == ["wrangler", "d1", "create"]:
+            raise module.CommandFailure(command, stderr="A database with that name already exists")
+        if command[:4] == ["wrangler", "d1", "list", "--json"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout='[{"name": "codemem-coordinator", "uuid": "784d138d-ab3c-4f5c-9464-cf45c5b69af3"}]',
+                stderr="",
+            )
+        raise AssertionError(command)
+
+    module.__dict__["run_command"] = fake_run_command
+    result = module.create_d1_database(
+        database_name="codemem-coordinator",
+        dry_run=False,
+        cwd=Path("."),
+    )
+
+    assert result["database_id"] == "784d138d-ab3c-4f5c-9464-cf45c5b69af3"
+    assert result["reused_existing"] is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,6 +186,24 @@ def test_load_config_reads_sync_coordinator_fields_from_file(tmp_path: Path) -> 
     assert cfg.sync_coordinator_presence_ttl_s == 240
 
 
+def test_load_config_reads_sync_coordinator_groups_from_file(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "sync_coordinator_url": "https://coord.example",
+                "sync_coordinator_groups": ["team-alpha", "lab"],
+            }
+        )
+        + "\n"
+    )
+
+    cfg = load_config(config_path)
+
+    assert cfg.sync_coordinator_groups == ["team-alpha", "lab"]
+    assert cfg.sync_coordinator_group == "team-alpha"
+
+
 def test_load_config_reads_sync_coordinator_fields_from_env(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -203,6 +221,21 @@ def test_load_config_reads_sync_coordinator_fields_from_env(
     assert cfg.sync_coordinator_group == "team-alpha"
     assert cfg.sync_coordinator_timeout_s == 6
     assert cfg.sync_coordinator_presence_ttl_s == 300
+
+
+def test_load_config_reads_sync_coordinator_groups_from_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    monkeypatch.setenv("CODEMEM_CONFIG", str(config_path))
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_URL", "https://coord.example")
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_GROUPS", "team-alpha,lab")
+
+    cfg = load_config(config_path)
+
+    assert cfg.sync_coordinator_groups == ["team-alpha", "lab"]
+    assert cfg.sync_coordinator_group == "team-alpha"
 
 
 def test_load_config_invalid_config_value_does_not_crash_and_warns(tmp_path: Path) -> None:

--- a/tests/test_coordinator_api.py
+++ b/tests/test_coordinator_api.py
@@ -238,3 +238,119 @@ def test_coordinator_presence_rejects_large_body(tmp_path: Path) -> None:
         assert payload["error"] == "body_too_large"
     finally:
         server.shutdown()
+
+
+def test_admin_endpoints_require_admin_secret(tmp_path: Path, monkeypatch) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET", "topsecret")
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha")
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/v1/admin/devices?group_id=team-alpha")
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 401
+        assert payload["error"] == "missing_admin_header"
+    finally:
+        server.shutdown()
+
+
+def test_admin_device_management_flow(tmp_path: Path, monkeypatch) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET", "topsecret")
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha")
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    headers = {"X-Codemem-Coordinator-Admin": "topsecret", "Content-Type": "application/json"}
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        body = json.dumps(
+            {
+                "group_id": "team-alpha",
+                "device_id": "device-1",
+                "fingerprint": "fp-1",
+                "public_key": "ssh-ed25519 AAAAtest example@test",
+                "display_name": "laptop",
+            }
+        )
+        conn.request("POST", "/v1/admin/devices", body=body, headers=headers)
+        resp = conn.getresponse()
+        assert resp.status == 200
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "GET",
+            "/v1/admin/devices?group_id=team-alpha",
+            headers={"X-Codemem-Coordinator-Admin": "topsecret"},
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["items"][0]["display_name"] == "laptop"
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/v1/admin/devices/rename",
+            body=json.dumps(
+                {"group_id": "team-alpha", "device_id": "device-1", "display_name": "work-laptop"}
+            ),
+            headers=headers,
+        )
+        resp = conn.getresponse()
+        assert resp.status == 200
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/v1/admin/devices/disable",
+            body=json.dumps({"group_id": "team-alpha", "device_id": "device-1"}),
+            headers=headers,
+        )
+        resp = conn.getresponse()
+        assert resp.status == 200
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "GET",
+            "/v1/admin/devices?group_id=team-alpha&include_disabled=1",
+            headers={"X-Codemem-Coordinator-Admin": "topsecret"},
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["items"][0]["display_name"] == "work-laptop"
+        assert payload["items"][0]["enabled"] == 0
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/v1/admin/devices/remove",
+            body=json.dumps({"group_id": "team-alpha", "device_id": "device-1"}),
+            headers=headers,
+        )
+        resp = conn.getresponse()
+        assert resp.status == 200
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "GET",
+            "/v1/admin/devices?group_id=team-alpha&include_disabled=1",
+            headers={"X-Codemem-Coordinator-Admin": "topsecret"},
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["items"] == []
+    finally:
+        server.shutdown()

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -761,7 +761,7 @@ def test_sync_once_updates_addresses_from_mdns(monkeypatch, tmp_path: Path) -> N
         ).fetchone()
         assert row is not None
         addresses = json.loads(row["addresses_json"])
-        assert "192.168.1.22:7337" in addresses
+        assert "http://192.168.1.22:7337" in addresses
     finally:
         conn.close()
 

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -1,5 +1,7 @@
 import json
 import os
+import threading
+from http.server import HTTPServer
 from pathlib import Path
 
 import typer
@@ -7,8 +9,17 @@ from typer.testing import CliRunner
 
 from codemem import db, sync_identity
 from codemem.cli import app
+from codemem.coordinator_api import build_coordinator_handler
 
 runner = CliRunner()
+
+
+def _start_coordinator_server(db_path: Path) -> tuple[HTTPServer, int]:
+    handler = build_coordinator_handler(db_path)
+    server = HTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
 
 
 def _write_fake_keys(private_key_path: Path, public_key_path: Path) -> None:

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -216,6 +216,133 @@ def test_serve_restart_subcommand_matches_legacy_flag(monkeypatch) -> None:
     ]
 
 
+def test_sync_coordinator_management_commands(tmp_path: Path) -> None:
+    db_path = tmp_path / "coordinator.sqlite"
+    public_key_file = tmp_path / "device.key.pub"
+    public_key_file.write_text("ssh-ed25519 AAAAtest example@test\n")
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "group-create",
+            "team-alpha",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "enroll-device",
+            "team-alpha",
+            "device-1",
+            "--fingerprint",
+            "fp-1",
+            "--public-key-file",
+            str(public_key_file),
+            "--name",
+            "laptop",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "list-devices",
+            "team-alpha",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "laptop (enabled) (device-1)" in result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "rename-device",
+            "team-alpha",
+            "device-1",
+            "--name",
+            "work-laptop",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "disable-device",
+            "team-alpha",
+            "device-1",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "list-devices",
+            "team-alpha",
+            "--include-disabled",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "work-laptop (disabled) (device-1)" in result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "remove-device",
+            "team-alpha",
+            "device-1",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "list-devices",
+            "team-alpha",
+            "--include-disabled",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "No enrolled devices" in result.stdout
+
+
 def test_serve_start_defaults_to_background(monkeypatch) -> None:
     calls: list[dict[str, object]] = []
 

--- a/tests/test_sync_coordinator.py
+++ b/tests/test_sync_coordinator.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from codemem.config import OpencodeMemConfig
 from codemem.store import MemoryStore
-from codemem.sync import coordinator
+from codemem.sync import coordinator, discovery
 from codemem.sync.sync_pass import run_sync_pass
 from codemem.sync_api import build_sync_handler
 from codemem.sync_identity import ensure_device_identity, fingerprint_public_key, load_public_key
@@ -95,6 +95,14 @@ def test_refresh_peer_address_cache_updates_matching_peer(tmp_path: Path, monkey
         ]
     finally:
         store.close()
+
+
+def test_normalize_address_canonicalizes_bare_host_port() -> None:
+    assert discovery.normalize_address("192.168.42.123:7337") == "192.168.42.123:7337"
+    assert discovery.normalize_address("http://192.168.42.123:7337") == "http://192.168.42.123:7337"
+    assert discovery.merge_addresses([], ["192.168.42.123:7337", "http://192.168.42.123:7337"]) == [
+        "192.168.42.123:7337"
+    ]
 
 
 def test_register_presence_posts_only_configured_groups(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_sync_coordinator.py
+++ b/tests/test_sync_coordinator.py
@@ -97,6 +97,130 @@ def test_refresh_peer_address_cache_updates_matching_peer(tmp_path: Path, monkey
         store.close()
 
 
+def test_register_presence_posts_only_configured_groups(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))
+    store = MemoryStore(db_path)
+    calls: list[str] = []
+    try:
+        ensure_device_identity(store.conn, keys_dir=keys_dir)
+
+        def fake_request_json(method: str, url: str, *, body=None, **_kwargs):
+            calls.append(str((body or {}).get("group_id") or ""))
+            return 200, {"ok": True}
+
+        monkeypatch.setattr("codemem.sync.coordinator.http_client.request_json", fake_request_json)
+
+        coordinator.register_presence(
+            store,
+            config=OpencodeMemConfig(
+                sync_coordinator_url="https://coord.example",
+                sync_coordinator_group="legacy-only",
+                sync_coordinator_groups=["team-alpha", "lab"],
+                sync_coordinator_timeout_s=3,
+                sync_coordinator_presence_ttl_s=180,
+                sync_advertise="127.0.0.1",
+                sync_port=7337,
+            ),
+        )
+
+        assert calls == ["team-alpha", "lab"]
+    finally:
+        store.close()
+
+
+def test_register_presence_posts_to_each_configured_group(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))
+    store = MemoryStore(db_path)
+    calls: list[dict[str, str]] = []
+    try:
+        ensure_device_identity(store.conn, keys_dir=keys_dir)
+
+        def fake_request_json(method: str, url: str, *, body=None, **_kwargs):
+            calls.append({"method": method, "group_id": str((body or {}).get("group_id") or "")})
+            return 200, {"ok": True, "group_id": (body or {}).get("group_id")}
+
+        monkeypatch.setattr("codemem.sync.coordinator.http_client.request_json", fake_request_json)
+
+        coordinator.register_presence(
+            store,
+            config=OpencodeMemConfig(
+                sync_coordinator_url="https://coord.example",
+                sync_coordinator_groups=["team-alpha", "lab"],
+                sync_coordinator_timeout_s=3,
+                sync_coordinator_presence_ttl_s=180,
+                sync_advertise="127.0.0.1",
+                sync_port=7337,
+            ),
+        )
+
+        assert calls == [
+            {"method": "POST", "group_id": "team-alpha"},
+            {"method": "POST", "group_id": "lab"},
+        ]
+    finally:
+        store.close()
+
+
+def test_lookup_peers_merges_results_from_multiple_groups(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    monkeypatch.setenv("CODEMEM_KEYS_DIR", str(keys_dir))
+    store = MemoryStore(db_path)
+    try:
+        ensure_device_identity(store.conn, keys_dir=keys_dir)
+
+        def fake_request_json(method: str, url: str, **_kwargs):
+            if method == "GET" and "group_id=team-alpha" in url:
+                return 200, {
+                    "items": [
+                        {
+                            "device_id": "peer-1",
+                            "fingerprint": "fp-peer-1",
+                            "addresses": ["http://10.0.0.2:7337"],
+                            "last_seen_at": "2026-03-13T10:00:00Z",
+                            "expires_at": "2026-03-13T10:03:00Z",
+                            "stale": False,
+                        }
+                    ]
+                }
+            if method == "GET" and "group_id=lab" in url:
+                return 200, {
+                    "items": [
+                        {
+                            "device_id": "peer-1",
+                            "fingerprint": "fp-peer-1",
+                            "addresses": ["http://100.64.0.5:7337"],
+                            "last_seen_at": "2026-03-13T11:00:00Z",
+                            "expires_at": "2026-03-13T11:03:00Z",
+                            "stale": False,
+                        }
+                    ]
+                }
+            raise AssertionError(url)
+
+        monkeypatch.setattr("codemem.sync.coordinator.http_client.request_json", fake_request_json)
+
+        items = coordinator.lookup_peers(
+            store,
+            config=OpencodeMemConfig(
+                sync_coordinator_url="https://coord.example",
+                sync_coordinator_groups=["team-alpha", "lab"],
+                sync_coordinator_timeout_s=3,
+            ),
+        )
+
+        assert len(items) == 1
+        assert items[0]["groups"] == ["team-alpha", "lab"]
+        assert items[0]["addresses"] == ["http://10.0.0.2:7337", "http://100.64.0.5:7337"]
+        assert items[0]["last_seen_at"] == "2026-03-13T11:00:00Z"
+    finally:
+        store.close()
+
+
 def test_refresh_peer_address_cache_ignores_fingerprint_mismatch(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_sync_daemon.py
+++ b/tests/test_sync_daemon.py
@@ -860,6 +860,26 @@ def test_sync_daemon_tick_uses_run_sync_pass(monkeypatch, tmp_path: Path) -> Non
         store.close()
 
 
+def test_sync_daemon_tick_refreshes_coordinator_presence_without_peers(
+    monkeypatch, tmp_path: Path
+) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    calls: list[str] = []
+    try:
+        monkeypatch.setattr(sync_pass.discovery, "mdns_enabled", lambda: False)
+        monkeypatch.setattr(
+            "codemem.sync.sync_pass.coordinator.refresh_peer_address_cache",
+            lambda _store: calls.append("refresh") or {"updated_peers": 0, "ignored_peers": 0},
+        )
+
+        result = sync_pass.sync_daemon_tick(store)
+
+        assert calls == ["refresh"]
+        assert result == []
+    finally:
+        store.close()
+
+
 def test_is_connectivity_error_ignores_generic_address_failure_prefix() -> None:
     error = (
         "all addresses failed | "


### PR DESCRIPTION
## Description
- refresh coordinator presence independently of peer sync passes by running presence/cache refresh during daemon ticks and on daemon startup
- canonicalize bare `host:port` addresses to the same form as `http://host:port` before merge/dedup
- add focused tests for coordinator visibility without peers and address canonicalization

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_sync_daemon.py tests/test_sync_coordinator.py`
- `uv run ruff check codemem/sync/daemon.py codemem/sync/discovery.py codemem/sync/sync_pass.py tests/test_sync_daemon.py tests/test_sync_coordinator.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced