### PR TITLE
fix: canonicalize and dedupe peer addresses

### DIFF
--- a/codemem/sync/discovery.py
+++ b/codemem/sync/discovery.py
@@ -22,6 +22,16 @@ def normalize_address(address: str) -> str:
     value = address.strip()
     if not value:
         return ""
+    if ":" in value and "://" not in value and "/" not in value:
+        host_part, _, port_part = value.rpartition(":")
+        if host_part and port_part.isdigit():
+            try:
+                port = int(port_part)
+            except ValueError:
+                return ""
+            if 0 < port <= 65535:
+                return f"http://{host_part.lower()}:{port}"
+            return ""
     parsed = urlparse(value)
     if parsed.scheme:
         host = (parsed.hostname or "").lower()
@@ -33,7 +43,29 @@ def normalize_address(address: str) -> str:
         path = parsed.path.rstrip("/")
         scheme = parsed.scheme.lower()
         return f"{scheme}://{netloc}{path}"
+    parsed = urlparse(f"//{value}")
+    host = (parsed.hostname or "").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        return ""
+    if host and port:
+        return f"http://{host}:{port}"
     return value.rstrip("/")
+
+
+def _address_dedupe_key(address: str) -> str:
+    if not address:
+        return ""
+    parsed = urlparse(address)
+    host = (parsed.hostname or "").lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        return address
+    if parsed.scheme in {"", "http"} and host and port and not parsed.path:
+        return f"{host}:{port}"
+    return address
 
 
 def merge_addresses(existing: list[str], candidates: list[str]) -> list[str]:
@@ -41,9 +73,10 @@ def merge_addresses(existing: list[str], candidates: list[str]) -> list[str]:
     seen: set[str] = set()
     for address in existing + candidates:
         cleaned = normalize_address(address)
-        if not cleaned or cleaned in seen:
+        dedupe_key = _address_dedupe_key(cleaned)
+        if not cleaned or dedupe_key in seen:
             continue
-        seen.add(cleaned)
+        seen.add(dedupe_key)
         normalized.append(cleaned)
     return normalized
 

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -106,6 +106,9 @@ Dial preference is intentionally conservative:
 
 If the coordinator is unavailable, codemem falls back to cached addresses and mDNS.
 
+Address storage is normalized to explicit base URLs (for example `http://host:7337`) so equivalent discovery results do
+not accumulate as mixed `host:port` and `http://host:port` variants in local peer caches.
+
 ## Auth model
 
 - the coordinator is self-hosted/operator-run

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -432,7 +432,7 @@ def test_sync_pair_accept_stores_peer(tmp_path: Path) -> None:
         ).fetchone()
         assert stored is not None
         addresses = json.loads(stored["addresses_json"])
-        assert "peer:7337" in addresses
+        assert "http://peer:7337" in addresses
     finally:
         conn.close()
 
@@ -761,7 +761,7 @@ def test_sync_once_updates_addresses_from_mdns(monkeypatch, tmp_path: Path) -> N
         ).fetchone()
         assert row is not None
         addresses = json.loads(row["addresses_json"])
-        assert "192.168.1.22:7337" in addresses
+        assert "http://192.168.1.22:7337" in addresses
     finally:
         conn.close()
 

--- a/tests/test_sync_coordinator.py
+++ b/tests/test_sync_coordinator.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from codemem.config import OpencodeMemConfig
 from codemem.store import MemoryStore
-from codemem.sync import coordinator
+from codemem.sync import coordinator, discovery
 from codemem.sync.sync_pass import run_sync_pass
 from codemem.sync_api import build_sync_handler
 from codemem.sync_identity import ensure_device_identity, fingerprint_public_key, load_public_key
@@ -95,6 +95,26 @@ def test_refresh_peer_address_cache_updates_matching_peer(tmp_path: Path, monkey
         ]
     finally:
         store.close()
+
+
+def test_normalize_address_canonicalizes_bare_host_port() -> None:
+    assert discovery.normalize_address("192.168.42.123:7337") == "http://192.168.42.123:7337"
+    assert discovery.normalize_address("http://192.168.42.123:7337") == "http://192.168.42.123:7337"
+    assert discovery.merge_addresses([], ["192.168.42.123:7337", "http://192.168.42.123:7337"]) == [
+        "http://192.168.42.123:7337"
+    ]
+
+
+def test_normalize_address_ignores_invalid_bare_port() -> None:
+    assert discovery.normalize_address("peer:notaport") == "peer:notaport"
+    assert discovery.normalize_address("peer:99999") == ""
+    assert discovery.merge_addresses(
+        [], ["peer:notaport", "peer:99999", "http://192.168.42.123:7337"]
+    ) == ["peer:notaport", "http://192.168.42.123:7337"]
+
+
+def test_normalize_address_preserves_colon_delimited_non_address_tokens() -> None:
+    assert discovery.normalize_address("team:alpha") == "team:alpha"
 
 
 def test_register_presence_posts_only_configured_groups(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Description
- normalize equivalent peer dial targets into one canonical base URL representation
- dedupe mixed `host:port` and `http://host:port` forms without hard-coding future non-HTTP scheme semantics into the merge key
- ignore malformed bare `host:port` inputs instead of letting them blow up address merging

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_sync_coordinator.py tests/test_sync_cli.py::test_sync_once_updates_addresses_from_mdns`
- `uv run ruff check codemem/sync/discovery.py tests/test_sync_coordinator.py tests/test_sync_cli.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced