### PR TITLE
fix: refresh coordinator presence outside peer sync passes

### DIFF
--- a/codemem/sync/daemon.py
+++ b/codemem/sync/daemon.py
@@ -50,19 +50,25 @@ def run_sync_daemon(
             store.close()
         zeroconf = advertise_mdns(device_id=device_id, port=port)
     stop = stop_event or threading.Event()
-    try:
-        while not stop.wait(interval_s):
-            store = MemoryStore(db_path or db.DEFAULT_DB_PATH)
+
+    def _run_tick_once() -> None:
+        store = MemoryStore(db_path or db.DEFAULT_DB_PATH)
+        try:
             try:
-                try:
-                    sync_pass.sync_daemon_tick(store)
-                    store.set_sync_daemon_ok()
-                except Exception as exc:
-                    tb = traceback.format_exc()
-                    store.set_sync_daemon_error(str(exc), tb)
-                    _append_sync_daemon_log(tb)
-            finally:
-                store.close()
+                sync_pass.sync_daemon_tick(store)
+                store.set_sync_daemon_ok()
+            except Exception as exc:
+                tb = traceback.format_exc()
+                store.set_sync_daemon_error(str(exc), tb)
+                _append_sync_daemon_log(tb)
+        finally:
+            store.close()
+
+    try:
+        if not stop.is_set():
+            _run_tick_once()
+        while not stop.wait(interval_s):
+            _run_tick_once()
     finally:
         server.shutdown()
         if zeroconf is not None:

--- a/codemem/sync/sync_pass.py
+++ b/codemem/sync/sync_pass.py
@@ -408,6 +408,8 @@ def _should_skip_offline_peer(store: MemoryStore, peer_device_id: str) -> bool:
 
 def sync_daemon_tick(store: MemoryStore) -> list[dict[str, Any]]:
     sync_pass_preflight(store)
+    with suppress(Exception):
+        coordinator.refresh_peer_address_cache(store)
     rows = store.conn.execute("SELECT peer_device_id FROM sync_peers").fetchall()
     mdns_entries = discovery.discover_peers_via_mdns() if discovery.mdns_enabled() else []
     results: list[dict[str, Any]] = []

--- a/tests/test_sync_daemon.py
+++ b/tests/test_sync_daemon.py
@@ -9,6 +9,7 @@ import pytest
 
 from codemem import db
 from codemem.store import MemoryStore, ReplicationOp
+from codemem.sync import daemon as sync_daemon
 from codemem.sync import http_client, replication, sync_pass
 from codemem.sync.discovery import update_peer_addresses
 from codemem.sync_api import build_sync_handler
@@ -858,6 +859,46 @@ def test_sync_daemon_tick_uses_run_sync_pass(monkeypatch, tmp_path: Path) -> Non
         assert set(called) == {"peer-1", "peer-2"}
     finally:
         store.close()
+
+
+def test_sync_daemon_tick_refreshes_coordinator_presence_without_peers(
+    monkeypatch, tmp_path: Path
+) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    calls: list[str] = []
+    try:
+        monkeypatch.setattr(sync_pass.discovery, "mdns_enabled", lambda: False)
+        monkeypatch.setattr(
+            "codemem.sync.sync_pass.coordinator.refresh_peer_address_cache",
+            lambda _store: calls.append("refresh") or {"updated_peers": 0, "ignored_peers": 0},
+        )
+
+        result = sync_pass.sync_daemon_tick(store)
+
+        assert calls == ["refresh"]
+        assert result == []
+    finally:
+        store.close()
+
+
+def test_run_sync_daemon_skips_startup_tick_when_already_stopped(
+    monkeypatch, tmp_path: Path
+) -> None:
+    stop = threading.Event()
+    stop.set()
+    calls: list[str] = []
+
+    monkeypatch.setattr(sync_pass, "sync_daemon_tick", lambda store: calls.append("tick") or [])
+
+    sync_daemon.run_sync_daemon(
+        host="127.0.0.1",
+        port=7337,
+        interval_s=1,
+        db_path=tmp_path / "mem.sqlite",
+        stop_event=stop,
+    )
+
+    assert calls == []
 
 
 def test_is_connectivity_error_ignores_generic_address_failure_prefix() -> None:


### PR DESCRIPTION
## Description
- refresh coordinator presence/cache once per daemon tick even when no peer sync pass runs
- run one startup daemon tick so enrolled devices become visible sooner instead of waiting for peer-driven sync activity
- add focused tests for the no-peers-yet case that previously left coordinator entries stale or absent

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_sync_daemon.py tests/test_sync_coordinator.py`
- `uv run ruff check codemem/sync/daemon.py codemem/sync/sync_pass.py tests/test_sync_daemon.py tests/test_sync_coordinator.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced