### PR TITLE
feat: add coordinator invite generation flow

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -79,6 +79,7 @@ from .commands.sync_cmds import (
     sync_uninstall_cmd,
 )
 from .commands.sync_coordinator_cmds import (
+    coordinator_create_invite_cmd,
     coordinator_disable_device_cmd,
     coordinator_enroll_device_cmd,
     coordinator_group_create_cmd,
@@ -1232,6 +1233,32 @@ def sync_coordinator_remove_device(
         group_id=group_id,
         device_id=device_id,
         db_path=db_path,
+    )
+
+
+@sync_coordinator_app.command("create-invite")
+def sync_coordinator_create_invite(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    coordinator_url: str = typer.Option(
+        None, help="Coordinator URL embedded in the invite payload"
+    ),
+    policy: str = typer.Option("auto_admit", help="Invite policy: auto_admit or approval_required"),
+    ttl_hours: int = typer.Option(24, help="Invite lifetime in hours"),
+    created_by: str = typer.Option(None, help="Optional creator label"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+    remote_url: str = typer.Option(None, help="Remote coordinator base URL"),
+    admin_secret: str = typer.Option(None, help="Remote coordinator admin secret"),
+) -> None:
+    """Create a team-scoped coordinator invite."""
+    coordinator_create_invite_cmd(
+        group_id=group_id,
+        coordinator_url=coordinator_url,
+        policy=policy,
+        ttl_hours=ttl_hours,
+        created_by=created_by,
+        db_path=db_path,
+        remote_url=remote_url,
+        admin_secret=admin_secret,
     )
 
 

--- a/codemem/commands/sync_coordinator_cmds.py
+++ b/codemem/commands/sync_coordinator_cmds.py
@@ -5,8 +5,13 @@ from pathlib import Path
 
 from rich import print
 
+from ..config import load_config
 from ..coordinator_api import build_coordinator_handler
+from ..coordinator_invites import InvitePayload, encode_invite_payload, invite_link
 from ..coordinator_store import DEFAULT_COORDINATOR_DB_PATH, CoordinatorStore
+from ..sync import http_client
+
+VALID_INVITE_POLICIES = {"auto_admit", "approval_required"}
 
 
 def coordinator_serve_cmd(*, db_path: str | None, host: str, port: int) -> None:
@@ -122,3 +127,109 @@ def coordinator_remove_device_cmd(
     if not removed:
         raise SystemExit(f"Device not found in {group_id}: {device_id}")
     print(f"[green]Removed device[/green] {device_id}")
+
+
+def _resolve_remote_target(
+    remote_url: str | None, admin_secret: str | None
+) -> tuple[str | None, str | None]:
+    config = load_config()
+    resolved_url = (remote_url or "").strip() or None
+    resolved_secret = (
+        (admin_secret or config.sync_coordinator_admin_secret or "").strip()
+        if resolved_url
+        else None
+    )
+    return resolved_url, resolved_secret
+
+
+def _remote_admin_headers(admin_secret: str) -> dict[str, str]:
+    return {"X-Codemem-Coordinator-Admin": admin_secret}
+
+
+def _remote_request(
+    method: str,
+    url: str,
+    *,
+    admin_secret: str,
+    body: dict | None = None,
+) -> dict | None:
+    status, payload = http_client.request_json(
+        method,
+        url,
+        headers=_remote_admin_headers(admin_secret),
+        body=body,
+        timeout_s=3.0,
+    )
+    if not (200 <= status < 300):
+        detail = payload.get("error") if isinstance(payload, dict) else None
+        raise SystemExit(f"Remote coordinator request failed ({status}): {detail or 'unknown'}")
+    return payload
+
+
+def coordinator_create_invite_cmd(
+    *,
+    group_id: str,
+    coordinator_url: str | None,
+    policy: str,
+    ttl_hours: int,
+    created_by: str | None,
+    db_path: str | None,
+    remote_url: str | None,
+    admin_secret: str | None,
+) -> None:
+    if policy not in VALID_INVITE_POLICIES:
+        raise SystemExit(
+            f"Invalid policy: {policy!r}. Must be one of: {', '.join(sorted(VALID_INVITE_POLICIES))}"
+        )
+    expires_at = __import__("datetime").datetime.now(__import__("datetime").UTC) + __import__(
+        "datetime"
+    ).timedelta(hours=ttl_hours)
+    expires_value = expires_at.isoformat()
+    resolved_remote_url, resolved_admin_secret = _resolve_remote_target(remote_url, admin_secret)
+    if resolved_remote_url:
+        if not resolved_admin_secret:
+            raise SystemExit("Remote coordinator admin secret required")
+        payload = _remote_request(
+            "POST",
+            f"{resolved_remote_url.rstrip('/')}/v1/admin/invites",
+            admin_secret=resolved_admin_secret,
+            body={
+                "group_id": group_id,
+                "policy": policy,
+                "expires_at": expires_value,
+                "created_by": created_by,
+                "coordinator_url": coordinator_url or resolved_remote_url,
+            },
+        )
+        print(f"[green]Invite created[/green] {group_id}")
+        print(f"- import: {payload.get('encoded')}")
+        print(f"- link: {payload.get('link')}")
+        return
+
+    store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+    try:
+        group = store.get_group(group_id)
+        if group is None:
+            raise SystemExit(f"Group not found: {group_id}")
+        invite = store.create_invite(
+            group_id=group_id,
+            policy=policy,
+            expires_at=expires_value,
+            created_by=created_by,
+        )
+    finally:
+        store.close()
+    payload: InvitePayload = {
+        "v": 1,
+        "kind": "coordinator_team_invite",
+        "coordinator_url": (coordinator_url or "").strip(),
+        "group_id": group_id,
+        "policy": policy,
+        "token": str(invite.get("token") or ""),
+        "expires_at": expires_value,
+        "team_name": invite.get("team_name_snapshot"),
+    }
+    encoded = encode_invite_payload(payload)
+    print(f"[green]Invite created[/green] {group_id}")
+    print(f"- import: {encoded}")
+    print(f"- link: {invite_link(encoded)}")

--- a/codemem/coordinator_api.py
+++ b/codemem/coordinator_api.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
+from .coordinator_invites import InvitePayload, encode_invite_payload, invite_link
 from .coordinator_store import DEFAULT_COORDINATOR_DB_PATH, CoordinatorStore
 from .sync_auth import DEFAULT_TIME_WINDOW_S, verify_signature
 
@@ -131,6 +132,8 @@ def build_coordinator_handler(db_path: Path | None = None):
             parsed = urlparse(self.path)
             if parsed.path.startswith("/v1/admin/devices"):
                 return self._handle_admin_post(parsed.path)
+            if parsed.path == "/v1/admin/invites":
+                return self._handle_admin_post(parsed.path)
             if parsed.path != "/v1/presence":
                 _send_json(self, {"error": "not_found"}, status=404)
                 return
@@ -190,6 +193,8 @@ def build_coordinator_handler(db_path: Path | None = None):
             parsed = urlparse(self.path)
             if parsed.path == "/v1/admin/devices":
                 return self._handle_admin_list(parsed.query)
+            if parsed.path == "/v1/admin/invites":
+                return self._handle_admin_list_invites(parsed.query)
             if parsed.path != "/v1/peers":
                 _send_json(self, {"error": "not_found"}, status=404)
                 return
@@ -245,6 +250,31 @@ def build_coordinator_handler(db_path: Path | None = None):
             finally:
                 store.close()
 
+        def _handle_admin_list_invites(self, query: str) -> None:
+            ok, reason = _authorize_admin_request(self)
+            if not ok:
+                _send_json(self, {"error": reason}, status=401)
+                return
+            params = parse_qs(query)
+            group_id = str(params.get("group_id", [""])[0] or "").strip()
+            if not group_id:
+                _send_json(self, {"error": "group_id_required"}, status=400)
+                return
+            store = self._store()
+            try:
+                rows = store.conn.execute(
+                    """
+                    SELECT invite_id, group_id, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+                    FROM coordinator_invites
+                    WHERE group_id = ?
+                    ORDER BY created_at DESC
+                    """,
+                    (group_id,),
+                ).fetchall()
+                _send_json(self, {"items": [dict(row) for row in rows]})
+            finally:
+                store.close()
+
         def _handle_admin_post(self, path: str) -> None:
             ok, reason = _authorize_admin_request(self)
             if not ok:
@@ -287,6 +317,57 @@ def build_coordinator_handler(db_path: Path | None = None):
                 finally:
                     store.close()
                 _send_json(self, {"ok": True})
+                return
+            if path == "/v1/admin/invites":
+                policy = str(data.get("policy") or "auto_admit").strip()
+                expires_at = str(data.get("expires_at") or "").strip()
+                created_by = str(data.get("created_by") or "").strip() or None
+                if (
+                    not group_id
+                    or policy not in {"auto_admit", "approval_required"}
+                    or not expires_at
+                ):
+                    _send_json(
+                        self,
+                        {"error": "group_id_policy_and_expires_at_required"},
+                        status=400,
+                    )
+                    return
+                store = self._store()
+                try:
+                    group = store.get_group(group_id)
+                    if group is None:
+                        _send_json(self, {"error": "group_not_found"}, status=404)
+                        return
+                    invite = store.create_invite(
+                        group_id=group_id,
+                        policy=policy,
+                        expires_at=expires_at,
+                        created_by=created_by,
+                    )
+                finally:
+                    store.close()
+                payload: InvitePayload = {
+                    "v": 1,
+                    "kind": "coordinator_team_invite",
+                    "coordinator_url": str(data.get("coordinator_url") or "").strip(),
+                    "group_id": group_id,
+                    "policy": policy,
+                    "token": str(invite.get("token") or ""),
+                    "expires_at": expires_at,
+                    "team_name": invite.get("team_name_snapshot"),
+                }
+                encoded = encode_invite_payload(payload)
+                _send_json(
+                    self,
+                    {
+                        "ok": True,
+                        "invite": {k: v for k, v in invite.items() if k != "token"},
+                        "payload": payload,
+                        "encoded": encoded,
+                        "link": invite_link(encoded),
+                    },
+                )
                 return
             if not group_id or not device_id:
                 _send_json(self, {"error": "group_id_and_device_id_required"}, status=400)

--- a/codemem/coordinator_invites.py
+++ b/codemem/coordinator_invites.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import TypedDict
+from urllib.parse import quote
+
+
+class InvitePayload(TypedDict):
+    v: int
+    kind: str
+    coordinator_url: str
+    group_id: str
+    policy: str
+    token: str
+    expires_at: str
+    team_name: str | None
+
+
+def encode_invite_payload(payload: InvitePayload) -> str:
+    raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decode_invite_payload(value: str) -> InvitePayload:
+    padding = "=" * (-len(value) % 4)
+    data = json.loads(base64.urlsafe_b64decode(value + padding).decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("invalid invite payload")
+    return data  # type: ignore[return-value]
+
+
+def invite_link(encoded_payload: str) -> str:
+    return f"codemem://join?invite={quote(encoded_payload)}"

--- a/codemem/coordinator_store.py
+++ b/codemem/coordinator_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import secrets
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -67,6 +68,21 @@ def initialize_schema(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordinator_invites (
+            invite_id TEXT PRIMARY KEY,
+            group_id TEXT NOT NULL,
+            token TEXT NOT NULL UNIQUE,
+            policy TEXT NOT NULL,
+            expires_at TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            created_by TEXT,
+            team_name_snapshot TEXT,
+            revoked_at TEXT
+        )
+        """
+    )
     conn.commit()
 
 
@@ -85,6 +101,13 @@ class CoordinatorStore:
             (group_id, display_name, now),
         )
         self.conn.commit()
+
+    def get_group(self, group_id: str) -> dict[str, Any] | None:
+        row = self.conn.execute(
+            "SELECT group_id, display_name, created_at FROM groups WHERE group_id = ?",
+            (group_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
 
     def enroll_device(
         self,
@@ -173,6 +196,45 @@ class CoordinatorStore:
         )
         self.conn.commit()
         return int(result.rowcount or 0) > 0
+
+    def create_invite(
+        self,
+        *,
+        group_id: str,
+        policy: str,
+        expires_at: str,
+        created_by: str | None = None,
+    ) -> dict[str, Any]:
+        now = dt.datetime.now(dt.UTC).isoformat()
+        invite_id = secrets.token_urlsafe(12)
+        token = secrets.token_urlsafe(24)
+        group = self.get_group(group_id)
+        self.conn.execute(
+            """
+            INSERT INTO coordinator_invites(
+                invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+            """,
+            (
+                invite_id,
+                group_id,
+                token,
+                policy,
+                expires_at,
+                now,
+                created_by,
+                (group or {}).get("display_name"),
+            ),
+        )
+        self.conn.commit()
+        row = self.conn.execute(
+            """
+            SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+            FROM coordinator_invites WHERE invite_id = ?
+            """,
+            (invite_id,),
+        ).fetchone()
+        return dict(row) if row is not None else {}
 
     def upsert_presence(
         self,

--- a/tests/test_coordinator_api.py
+++ b/tests/test_coordinator_api.py
@@ -354,3 +354,38 @@ def test_admin_device_management_flow(tmp_path: Path, monkeypatch) -> None:
         assert payload["items"] == []
     finally:
         server.shutdown()
+
+
+def test_admin_invite_generation_flow(tmp_path: Path, monkeypatch) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET", "topsecret")
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha", display_name="Team Alpha")
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    headers = {"X-Codemem-Coordinator-Admin": "topsecret", "Content-Type": "application/json"}
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        body = json.dumps(
+            {
+                "group_id": "team-alpha",
+                "policy": "auto_admit",
+                "expires_at": "2026-03-15T00:00:00Z",
+                "created_by": "admin",
+                "coordinator_url": f"http://127.0.0.1:{port}",
+            }
+        )
+        conn.request("POST", "/v1/admin/invites", body=body, headers=headers)
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["ok"] is True
+        assert payload["payload"]["group_id"] == "team-alpha"
+        assert payload["payload"]["policy"] == "auto_admit"
+        assert payload["encoded"]
+        assert payload["link"].startswith("codemem://join?invite=")
+    finally:
+        server.shutdown()

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -354,6 +354,43 @@ def test_sync_coordinator_management_commands(tmp_path: Path) -> None:
     assert "No enrolled devices" in result.stdout
 
 
+def test_sync_coordinator_create_invite_local(tmp_path: Path) -> None:
+    db_path = tmp_path / "coordinator.sqlite"
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "group-create",
+            "team-alpha",
+            "--name",
+            "Team Alpha",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "create-invite",
+            "team-alpha",
+            "--coordinator-url",
+            "https://coord.example",
+            "--ttl-hours",
+            "24",
+            "--db-path",
+            str(db_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Invite created" in result.stdout
+    assert "codemem://join?invite=" in result.stdout
+
+
 def test_serve_start_defaults_to_background(monkeypatch) -> None:
     calls: list[dict[str, object]] = []
 


### PR DESCRIPTION
## Description
- add coordinator invite storage and payload encoding
- add admin API and CLI flow to generate team-scoped invites with policy and expiry
- output both import strings and link forms for the same invite artifact

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_coordinator_api.py tests/test_sync_cli.py`
- `uv run ruff check codemem/coordinator_invites.py codemem/coordinator_store.py codemem/coordinator_api.py codemem/commands/sync_coordinator_cmds.py codemem/cli_app.py tests/test_coordinator_api.py tests/test_sync_cli.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced