### PR TITLE
feat: add coordinator invite import flow

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -83,6 +83,7 @@ from .commands.sync_coordinator_cmds import (
     coordinator_disable_device_cmd,
     coordinator_enroll_device_cmd,
     coordinator_group_create_cmd,
+    coordinator_import_invite_cmd,
     coordinator_list_devices_cmd,
     coordinator_remove_device_cmd,
     coordinator_rename_device_cmd,
@@ -1259,6 +1260,22 @@ def sync_coordinator_create_invite(
         db_path=db_path,
         remote_url=remote_url,
         admin_secret=admin_secret,
+    )
+
+
+@sync_coordinator_app.command("import-invite")
+def sync_coordinator_import_invite(
+    invite_value: str = typer.Argument(..., help="Invite payload or codemem://join link"),
+    db_path: str = typer.Option(None, help="Path to local codemem DB"),
+    keys_dir: str = typer.Option(None, help="Path to local codemem keys directory"),
+    config_path: str = typer.Option(None, help="Path to config file to update"),
+) -> None:
+    """Import a coordinator team invite."""
+    coordinator_import_invite_cmd(
+        invite_value=invite_value,
+        db_path=db_path,
+        keys_dir=keys_dir,
+        config_path=config_path,
     )
 
 

--- a/codemem/commands/sync_coordinator_cmds.py
+++ b/codemem/commands/sync_coordinator_cmds.py
@@ -5,11 +5,19 @@ from pathlib import Path
 
 from rich import print
 
-from ..config import load_config
+from .. import db
+from ..config import get_config_path, load_config, read_config_file, write_config_file
 from ..coordinator_api import build_coordinator_handler
-from ..coordinator_invites import InvitePayload, encode_invite_payload, invite_link
+from ..coordinator_invites import (
+    InvitePayload,
+    decode_invite_payload,
+    encode_invite_payload,
+    extract_invite_payload,
+    invite_link,
+)
 from ..coordinator_store import DEFAULT_COORDINATOR_DB_PATH, CoordinatorStore
 from ..sync import http_client
+from ..sync_identity import ensure_device_identity, load_public_key
 
 VALID_INVITE_POLICIES = {"auto_admit", "approval_required"}
 
@@ -233,3 +241,57 @@ def coordinator_create_invite_cmd(
     print(f"[green]Invite created[/green] {group_id}")
     print(f"- import: {encoded}")
     print(f"- link: {invite_link(encoded)}")
+
+
+def coordinator_import_invite_cmd(
+    *,
+    invite_value: str,
+    db_path: str | None,
+    keys_dir: str | None,
+    config_path: str | None,
+) -> None:
+    payload: InvitePayload = decode_invite_payload(extract_invite_payload(invite_value))
+    resolved_db_path = (
+        Path(db_path).expanduser() if db_path else Path.home() / ".codemem" / "mem.sqlite"
+    )
+    resolved_keys_dir = Path(keys_dir).expanduser() if keys_dir else None
+    resolved_config_path = get_config_path(Path(config_path).expanduser() if config_path else None)
+
+    conn = db.connect(resolved_db_path)
+    try:
+        db.initialize_schema(conn)
+        device_id, fingerprint = ensure_device_identity(conn, keys_dir=resolved_keys_dir)
+    finally:
+        conn.close()
+    public_key = load_public_key(resolved_keys_dir)
+    if not public_key:
+        raise SystemExit("public key missing")
+
+    resolved_config = load_config(resolved_config_path)
+    display_name = resolved_config.actor_display_name or device_id
+
+    status, response = http_client.request_json(
+        "POST",
+        f"{str(payload['coordinator_url']).rstrip('/')}/v1/join",
+        body={
+            "token": str(payload["token"]),
+            "device_id": device_id,
+            "public_key": public_key,
+            "fingerprint": fingerprint,
+            "display_name": display_name,
+        },
+        timeout_s=3.0,
+    )
+    if not (200 <= status < 300):
+        detail = response.get("error") if isinstance(response, dict) else None
+        raise SystemExit(f"Invite import failed ({status}): {detail or 'unknown'}")
+    response_data = response if isinstance(response, dict) else {}
+
+    config_data = read_config_file(resolved_config_path)
+    config_data["sync_coordinator_url"] = str(payload["coordinator_url"])
+    config_data["sync_coordinator_group"] = str(payload["group_id"])
+    write_config_file(config_data, resolved_config_path)
+
+    print(f"[green]Invite imported[/green] {payload['group_id']}")
+    print(f"- coordinator: {payload['coordinator_url']}")
+    print(f"- status: {response_data.get('status')}")

--- a/codemem/coordinator_api.py
+++ b/codemem/coordinator_api.py
@@ -134,6 +134,8 @@ def build_coordinator_handler(db_path: Path | None = None):
                 return self._handle_admin_post(parsed.path)
             if parsed.path == "/v1/admin/invites":
                 return self._handle_admin_post(parsed.path)
+            if parsed.path == "/v1/join":
+                return self._handle_join()
             if parsed.path != "/v1/presence":
                 _send_json(self, {"error": "not_found"}, status=404)
                 return
@@ -397,5 +399,102 @@ def build_coordinator_handler(db_path: Path | None = None):
                 _send_json(self, {"error": "device_not_found"}, status=404)
                 return
             _send_json(self, {"ok": True})
+
+        def _handle_join(self) -> None:
+            try:
+                raw = _read_body(self)
+            except ValueError as exc:
+                if str(exc) == "body_too_large":
+                    _send_json(self, {"error": "body_too_large"}, status=413)
+                    return
+                raise
+            data = _parse_json_body(raw)
+            if data is None:
+                _send_json(self, {"error": "invalid_json"}, status=400)
+                return
+            token = str(data.get("token") or "").strip()
+            device_id = str(data.get("device_id") or "").strip()
+            fingerprint = str(data.get("fingerprint") or "").strip()
+            public_key = str(data.get("public_key") or "").strip()
+            display_name = str(data.get("display_name") or "").strip() or None
+            if not token or not device_id or not fingerprint or not public_key:
+                _send_json(
+                    self, {"error": "token_device_id_fingerprint_public_key_required"}, status=400
+                )
+                return
+            store = self._store()
+            try:
+                invite = store.get_invite_by_token(token=token)
+                if invite is None:
+                    _send_json(self, {"error": "invalid_token"}, status=404)
+                    return
+                if invite.get("revoked_at"):
+                    _send_json(self, {"error": "revoked_token"}, status=400)
+                    return
+                expires_at = str(invite.get("expires_at") or "")
+                if expires_at and dt.datetime.fromisoformat(
+                    expires_at.replace("Z", "+00:00")
+                ) <= dt.datetime.now(dt.UTC):
+                    _send_json(self, {"error": "expired_token"}, status=400)
+                    return
+                existing = store.get_enrollment(
+                    group_id=str(invite["group_id"]), device_id=device_id
+                )
+                if existing is not None:
+                    _send_json(
+                        self,
+                        {
+                            "ok": True,
+                            "status": "already_enrolled",
+                            "group_id": invite["group_id"],
+                            "policy": invite["policy"],
+                        },
+                    )
+                    return
+                if invite["policy"] not in {"auto_admit", "approval_required"}:
+                    _send_json(
+                        self,
+                        {"error": f"unknown invite policy: {invite['policy']}"},
+                        status=400,
+                    )
+                    return
+                if invite["policy"] == "approval_required":
+                    request = store.create_join_request(
+                        group_id=str(invite["group_id"]),
+                        device_id=device_id,
+                        public_key=public_key,
+                        fingerprint=fingerprint,
+                        display_name=display_name,
+                        token=token,
+                    )
+                    _send_json(
+                        self,
+                        {
+                            "ok": True,
+                            "status": "pending",
+                            "group_id": invite["group_id"],
+                            "policy": invite["policy"],
+                            "request_id": request.get("request_id"),
+                        },
+                    )
+                    return
+                store.enroll_device(
+                    str(invite["group_id"]),
+                    device_id=device_id,
+                    fingerprint=fingerprint,
+                    public_key=public_key,
+                    display_name=display_name,
+                )
+                _send_json(
+                    self,
+                    {
+                        "ok": True,
+                        "status": "enrolled",
+                        "group_id": invite["group_id"],
+                        "policy": invite["policy"],
+                    },
+                )
+            finally:
+                store.close()
 
     return CoordinatorHandler

--- a/codemem/coordinator_invites.py
+++ b/codemem/coordinator_invites.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from typing import TypedDict
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote, urlparse
 
 
 class InvitePayload(TypedDict):
@@ -32,3 +32,14 @@ def decode_invite_payload(value: str) -> InvitePayload:
 
 def invite_link(encoded_payload: str) -> str:
     return f"codemem://join?invite={quote(encoded_payload)}"
+
+
+def extract_invite_payload(value: str) -> str:
+    raw = value.strip()
+    if raw.startswith("codemem://"):
+        parsed = urlparse(raw)
+        invite = parse_qs(parsed.query).get("invite", [""])[0]
+        if not invite:
+            raise ValueError("invite payload missing from link")
+        return invite
+    return raw

--- a/codemem/coordinator_store.py
+++ b/codemem/coordinator_store.py
@@ -83,6 +83,23 @@ def initialize_schema(conn: sqlite3.Connection) -> None:
         )
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordinator_join_requests (
+            request_id TEXT PRIMARY KEY,
+            group_id TEXT NOT NULL,
+            device_id TEXT NOT NULL,
+            public_key TEXT NOT NULL,
+            fingerprint TEXT NOT NULL,
+            display_name TEXT,
+            token TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            reviewed_at TEXT,
+            reviewed_by TEXT
+        )
+        """
+    )
     conn.commit()
 
 
@@ -233,6 +250,47 @@ class CoordinatorStore:
             FROM coordinator_invites WHERE invite_id = ?
             """,
             (invite_id,),
+        ).fetchone()
+        return dict(row) if row is not None else {}
+
+    def get_invite_by_token(self, *, token: str) -> dict[str, Any] | None:
+        row = self.conn.execute(
+            """
+            SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+            FROM coordinator_invites
+            WHERE token = ?
+            """,
+            (token,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def create_join_request(
+        self,
+        *,
+        group_id: str,
+        device_id: str,
+        public_key: str,
+        fingerprint: str,
+        display_name: str | None,
+        token: str,
+    ) -> dict[str, Any]:
+        now = dt.datetime.now(dt.UTC).isoformat()
+        request_id = secrets.token_urlsafe(12)
+        self.conn.execute(
+            """
+            INSERT INTO coordinator_join_requests(
+                request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL, NULL)
+            """,
+            (request_id, group_id, device_id, public_key, fingerprint, display_name, token, now),
+        )
+        self.conn.commit()
+        row = self.conn.execute(
+            """
+            SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+            FROM coordinator_join_requests WHERE request_id = ?
+            """,
+            (request_id,),
         ).fetchone()
         return dict(row) if row is not None else {}
 

--- a/codemem/db.py
+++ b/codemem/db.py
@@ -1106,7 +1106,12 @@ def _ensure_column(conn: sqlite3.Connection, table: str, column: str, column_typ
     existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
     if column in existing:
         return
-    conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {column_type}")
+    try:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {column_type}")
+    except sqlite3.OperationalError as exc:
+        if "duplicate column name" in str(exc):
+            return
+        raise
 
 
 def _cleanup_orphan_prompt_links(conn: sqlite3.Connection) -> None:

--- a/tests/test_coordinator_api.py
+++ b/tests/test_coordinator_api.py
@@ -389,3 +389,59 @@ def test_admin_invite_generation_flow(tmp_path: Path, monkeypatch) -> None:
         assert payload["link"].startswith("codemem://join?invite=")
     finally:
         server.shutdown()
+
+
+def test_join_endpoint_auto_admit_and_pending(tmp_path: Path, monkeypatch) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET", "topsecret")
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha", display_name="Team Alpha")
+        invite_auto = store.create_invite(
+            group_id="team-alpha",
+            policy="auto_admit",
+            expires_at="2099-01-01T00:00:00Z",
+        )
+        invite_pending = store.create_invite(
+            group_id="team-alpha",
+            policy="approval_required",
+            expires_at="2099-01-01T00:00:00Z",
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        body = json.dumps(
+            {
+                "token": invite_auto["token"],
+                "device_id": "device-auto",
+                "public_key": "ssh-ed25519 AAAAtest auto@test",
+                "fingerprint": "fp-auto",
+                "display_name": "auto-device",
+            }
+        )
+        conn.request("POST", "/v1/join", body=body, headers={"Content-Type": "application/json"})
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["status"] == "enrolled"
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        body = json.dumps(
+            {
+                "token": invite_pending["token"],
+                "device_id": "device-pending",
+                "public_key": "ssh-ed25519 AAAAtest pending@test",
+                "fingerprint": "fp-pending",
+                "display_name": "pending-device",
+            }
+        )
+        conn.request("POST", "/v1/join", body=body, headers={"Content-Type": "application/json"})
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["status"] == "pending"
+    finally:
+        server.shutdown()

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -10,6 +10,8 @@ from typer.testing import CliRunner
 from codemem import db, sync_identity
 from codemem.cli import app
 from codemem.coordinator_api import build_coordinator_handler
+from codemem.coordinator_invites import encode_invite_payload
+from codemem.coordinator_store import CoordinatorStore
 
 runner = CliRunner()
 
@@ -389,6 +391,70 @@ def test_sync_coordinator_create_invite_local(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert "Invite created" in result.stdout
     assert "codemem://join?invite=" in result.stdout
+
+
+def test_sync_coordinator_import_invite_local(tmp_path: Path) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    keys_dir = tmp_path / "keys"
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}\n")
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        sync_identity.ensure_device_identity(conn, keys_dir=keys_dir)
+    finally:
+        conn.close()
+
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha", display_name="Team Alpha")
+        invite = store.create_invite(
+            group_id="team-alpha",
+            policy="auto_admit",
+            expires_at="2099-01-01T00:00:00Z",
+        )
+    finally:
+        store.close()
+    payload = {
+        "v": 1,
+        "kind": "coordinator_team_invite",
+        "coordinator_url": "http://127.0.0.1:1",
+        "group_id": "team-alpha",
+        "policy": "auto_admit",
+        "token": invite["token"],
+        "expires_at": "2099-01-01T00:00:00Z",
+        "team_name": "Team Alpha",
+    }
+
+    server = HTTPServer(("127.0.0.1", 0), build_coordinator_handler(coordinator_db))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        payload["coordinator_url"] = f"http://127.0.0.1:{server.server_address[1]}"
+        encoded = encode_invite_payload(payload)  # type: ignore[arg-type]
+        result = runner.invoke(
+            app,
+            [
+                "sync",
+                "coordinator",
+                "import-invite",
+                encoded,
+                "--db-path",
+                str(db_path),
+                "--keys-dir",
+                str(keys_dir),
+                "--config-path",
+                str(config_path),
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Invite imported" in result.stdout
+        assert "status: enrolled" in result.stdout
+        saved = json.loads(config_path.read_text())
+        assert saved["sync_coordinator_group"] == "team-alpha"
+    finally:
+        server.shutdown()
 
 
 def test_serve_start_defaults_to_background(monkeypatch) -> None:


### PR DESCRIPTION
## Description
- add teammate invite import flow for team-scoped coordinator invites
- support paste/import strings and codemem:// link forms using the same payload
- configure coordinator target/group automatically and redeem auto-admit joins through the coordinator API

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_coordinator_api.py tests/test_sync_cli.py`
- `uv run ruff check codemem/coordinator_invites.py codemem/coordinator_store.py codemem/coordinator_api.py codemem/commands/sync_coordinator_cmds.py codemem/cli_app.py tests/test_coordinator_api.py tests/test_sync_cli.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced