### PR TITLE
feat: add coordinator onboarding status surface

### DIFF
--- a/codemem/sync/coordinator.py
+++ b/codemem/sync/coordinator.py
@@ -17,20 +17,23 @@ from . import discovery, http_client
 
 def coordinator_enabled(config: OpencodeMemConfig | None = None) -> bool:
     cfg = config or load_config()
-    return bool(str(cfg.sync_coordinator_url or "").strip() and _coordinator_groups(cfg))
+    return bool(
+        str(getattr(cfg, "sync_coordinator_url", "") or "").strip() and _coordinator_groups(cfg)
+    )
 
 
 def _coordinator_groups(config: OpencodeMemConfig) -> list[str]:
-    if config.sync_coordinator_groups:
-        return [
-            str(group).strip() for group in config.sync_coordinator_groups if str(group).strip()
-        ]
-    group = str(config.sync_coordinator_group or "").strip()
+    groups_value = getattr(config, "sync_coordinator_groups", []) or []
+    if groups_value:
+        return [str(group).strip() for group in groups_value if str(group).strip()]
+    group = str(getattr(config, "sync_coordinator_group", "") or "").strip()
     return [group] if group else []
 
 
 def _coordinator_base_url(config: OpencodeMemConfig) -> str:
-    return http_client.build_base_url(str(config.sync_coordinator_url or "").strip())
+    return http_client.build_base_url(
+        str(getattr(config, "sync_coordinator_url", "") or "").strip()
+    )
 
 
 def _keys_dir() -> Path | None:
@@ -40,7 +43,7 @@ def _keys_dir() -> Path | None:
 
 def _advertised_sync_addresses(config: OpencodeMemConfig) -> list[str]:
     addresses: list[str] = []
-    for host in pick_advertise_hosts(config.sync_advertise):
+    for host in pick_advertise_hosts(getattr(config, "sync_advertise", "auto")):
         host_value = host.strip()
         if not host_value:
             continue
@@ -48,7 +51,9 @@ def _advertised_sync_addresses(config: OpencodeMemConfig) -> list[str]:
         if parsed.scheme:
             addresses.append(http_client.build_base_url(host_value))
             continue
-        addresses.append(http_client.build_base_url(f"http://{host_value}:{config.sync_port}"))
+        addresses.append(
+            http_client.build_base_url(f"http://{host_value}:{getattr(config, 'sync_port', 7337)}")
+        )
     return discovery.merge_addresses([], addresses)
 
 
@@ -71,7 +76,7 @@ def register_presence(
         "fingerprint": fingerprint,
         "public_key": public_key,
         "addresses": _advertised_sync_addresses(cfg),
-        "ttl_s": max(1, int(cfg.sync_coordinator_presence_ttl_s)),
+        "ttl_s": max(1, int(getattr(cfg, "sync_coordinator_presence_ttl_s", 180))),
     }
     responses: list[dict[str, Any]] = []
     for group_id in groups:
@@ -91,7 +96,7 @@ def register_presence(
             headers=headers,
             body=group_payload,
             body_bytes=body_bytes,
-            timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
+            timeout_s=max(1.0, float(getattr(cfg, "sync_coordinator_timeout_s", 3))),
         )
         if status != 200 or not isinstance(response, dict):
             detail = response.get("error") if isinstance(response, dict) else None
@@ -126,7 +131,7 @@ def lookup_peers(
             "GET",
             url,
             headers=headers,
-            timeout_s=max(1.0, float(cfg.sync_coordinator_timeout_s)),
+            timeout_s=max(1.0, float(getattr(cfg, "sync_coordinator_timeout_s", 3))),
         )
         if status != 200 or not isinstance(response, dict):
             detail = response.get("error") if isinstance(response, dict) else None
@@ -222,3 +227,60 @@ def refresh_peer_address_cache(
         store.conn.commit()
         updated += 1
     return {"updated_peers": updated, "ignored_peers": ignored}
+
+
+def status_snapshot(
+    store: MemoryStore, *, config: OpencodeMemConfig | None = None
+) -> dict[str, Any]:
+    cfg = config or load_config()
+    groups = _coordinator_groups(cfg)
+    if not coordinator_enabled(cfg):
+        return {
+            "enabled": False,
+            "configured": False,
+            "groups": groups,
+            "paired_peer_count": int(
+                store.conn.execute("SELECT COUNT(1) AS total FROM sync_peers").fetchone()["total"]
+                or 0
+            ),
+        }
+
+    paired_peer_count = int(
+        store.conn.execute("SELECT COUNT(1) AS total FROM sync_peers").fetchone()["total"] or 0
+    )
+    snapshot: dict[str, Any] = {
+        "enabled": True,
+        "configured": True,
+        "coordinator_url": str(getattr(cfg, "sync_coordinator_url", "") or "").strip(),
+        "groups": groups,
+        "paired_peer_count": paired_peer_count,
+        "presence_status": "unknown",
+        "presence_error": None,
+        "advertised_addresses": [],
+        "fresh_peer_count": 0,
+        "stale_peer_count": 0,
+        "discovered_peer_count": 0,
+    }
+    try:
+        registration = register_presence(store, config=cfg) or {}
+        snapshot["presence_status"] = "posted"
+        responses = registration.get("responses") if isinstance(registration, dict) else []
+        if isinstance(responses, list) and responses:
+            first = responses[0]
+            if isinstance(first, dict):
+                snapshot["advertised_addresses"] = first.get("addresses") or []
+    except Exception as exc:
+        message = str(exc)
+        snapshot["presence_status"] = "error"
+        snapshot["presence_error"] = message
+        if "unknown_device" in message:
+            snapshot["presence_status"] = "not_enrolled"
+
+    try:
+        peers = lookup_peers(store, config=cfg)
+        snapshot["discovered_peer_count"] = len(peers)
+        snapshot["fresh_peer_count"] = sum(1 for item in peers if not bool(item.get("stale")))
+        snapshot["stale_peer_count"] = sum(1 for item in peers if bool(item.get("stale")))
+    except Exception as exc:
+        snapshot["lookup_error"] = str(exc)
+    return snapshot

--- a/codemem/viewer_routes/sync.py
+++ b/codemem/viewer_routes/sync.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qs
 
 from ..net import pick_advertise_host, pick_advertise_hosts
 from ..store import MemoryStore
+from ..sync import coordinator
 from ..sync.discovery import (
     load_peer_addresses,
     normalize_address,
@@ -254,6 +255,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
             attempts_items.append(item)
         legacy_devices = store.claimable_legacy_device_ids()
         sharing_review = store.sharing_review_summary(project=project)
+        coordinator_status = coordinator.status_snapshot(store, config=config)
 
         if daemon_state_value == "ok":
             peer_states = {
@@ -297,6 +299,7 @@ def handle_get(handler: _ViewerHandler, store: MemoryStore, path: str, query: st
                 "attempts": attempts_items[:5],
                 "legacy_devices": legacy_devices,
                 "sharing_review": sharing_review,
+                "coordinator": coordinator_status,
             }
         )
         return True

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -132,6 +132,7 @@
     lastSyncActors: [],
     lastSyncPeers: [],
     lastSyncSharingReview: [],
+    lastSyncCoordinator: null,
     lastSyncAttempts: [],
     lastSyncLegacyDevices: [],
     pairingPayloadRaw: null,
@@ -2000,6 +2001,43 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       list.appendChild(row);
     });
   }
+  function renderSyncCoordinatorOverview() {
+    const panel = document.getElementById("syncCoordinatorOverview");
+    const meta = document.getElementById("syncCoordinatorMeta");
+    const list = document.getElementById("syncCoordinatorList");
+    const actions = document.getElementById("syncCoordinatorActions");
+    if (!panel || !meta || !list || !actions) return;
+    list.textContent = "";
+    const coordinator = state.lastSyncCoordinator;
+    if (!coordinator || !coordinator.configured) {
+      panel.hidden = true;
+      return;
+    }
+    panel.hidden = false;
+    meta.textContent = `${String(coordinator.coordinator_url || "")} · groups: ${(coordinator.groups || []).join(", ") || "none"}`;
+    const rows = [
+      ["Enrollment", coordinator.presence_status === "posted" ? "Enrolled and posting presence" : coordinator.presence_status === "not_enrolled" ? "Not enrolled in coordinator" : "Coordinator error"],
+      ["Paired peers", String(coordinator.paired_peer_count || 0)],
+      ["Fresh discovered peers", String(coordinator.fresh_peer_count || 0)],
+      ["Stale discovered peers", String(coordinator.stale_peer_count || 0)],
+      ["Advertised addresses", Array.isArray(coordinator.advertised_addresses) && coordinator.advertised_addresses.length ? coordinator.advertised_addresses.join(" · ") : "None"]
+    ];
+    rows.forEach(([label, value]) => {
+      const row = el("div", "peer-meta", `${label}: ${value}`);
+      list.appendChild(row);
+    });
+    const actionItems = [];
+    if (coordinator.presence_status === "not_enrolled") {
+      actionItems.push({ label: "This device is not enrolled in the coordinator group.", command: "Use invite import or remote admin enrollment for this device" });
+    }
+    if (!Number(coordinator.paired_peer_count || 0)) {
+      actionItems.push({ label: "No trusted sync peers are paired yet.", command: "uv run codemem sync pair --payload-only" });
+    }
+    if (!Number(coordinator.fresh_peer_count || 0)) {
+      actionItems.push({ label: "No fresh peers were discovered from the coordinator.", command: "uv run codemem sync once" });
+    }
+    renderActionList(actions, actionItems);
+  }
   function renderLegacyDeviceClaims() {
     const panel = document.getElementById("syncLegacyClaims");
     const select = document.getElementById("syncLegacyDeviceSelect");
@@ -2094,9 +2132,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       state.lastSyncActors = Array.isArray(actorsPayload?.items) ? actorsPayload.items : [];
       state.lastSyncPeers = payload.peers || [];
       state.lastSyncSharingReview = payload.sharing_review || [];
+      state.lastSyncCoordinator = payload.coordinator || null;
       state.lastSyncAttempts = payload.attempts || [];
       state.lastSyncLegacyDevices = payload.legacy_devices || [];
       renderSyncStatus();
+      renderSyncCoordinatorOverview();
       renderSyncActors();
       renderSyncSharingReview();
       renderSyncPeers();

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1568,6 +1568,13 @@
         <div class="actor-list" id="syncActorsList"></div>
       </div>
 
+      <div class="card" id="syncCoordinatorOverview" style="animation-delay: 0.045s" hidden>
+        <h2>Coordinator onboarding</h2>
+        <div class="section-meta" id="syncCoordinatorMeta"></div>
+        <div class="actor-list" id="syncCoordinatorList"></div>
+        <div class="sync-actions" id="syncCoordinatorActions" hidden></div>
+      </div>
+
       <div class="card" style="animation-delay: 0.05s">
         <h2>Peers</h2>
         <div class="peer-list" id="syncPeers"></div>

--- a/tests/test_sync_viewer_api.py
+++ b/tests/test_sync_viewer_api.py
@@ -150,6 +150,47 @@ def test_sync_status_endpoint_includes_sharing_review_for_teammate_peer(
         server.shutdown()
 
 
+def test_sync_status_endpoint_includes_coordinator_status(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "mem.sqlite"
+    monkeypatch.setenv("CODEMEM_DB", str(db_path))
+    _monkeypatch_sync_enabled(monkeypatch)
+    monkeypatch.setattr(
+        "codemem.viewer_routes.sync.coordinator.status_snapshot",
+        lambda store, config=None: {
+            "configured": True,
+            "coordinator_url": "https://coord.example",
+            "groups": ["team-alpha"],
+            "presence_status": "posted",
+            "paired_peer_count": 1,
+            "fresh_peer_count": 1,
+            "stale_peer_count": 0,
+            "advertised_addresses": ["http://192.0.2.10:7337"],
+        },
+    )
+    conn = db.connect(db_path)
+    try:
+        db.initialize_schema(conn)
+        conn.execute(
+            "INSERT INTO sync_peers(peer_device_id, addresses_json, created_at) VALUES (?, ?, ?)",
+            ("peer-1", "[]", "2026-01-24T00:00:00Z"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    server, port = _start_server(db_path)
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request("GET", "/api/sync/status")
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["coordinator"]["configured"] is True
+        assert payload["coordinator"]["fresh_peer_count"] == 1
+    finally:
+        server.shutdown()
+
+
 def test_sync_status_sharing_review_matches_project_basename(tmp_path: Path, monkeypatch) -> None:
     db_path = tmp_path / "mem.sqlite"
     monkeypatch.setenv("CODEMEM_DB", str(db_path))

--- a/viewer_ui/src/lib/state.ts
+++ b/viewer_ui/src/lib/state.ts
@@ -53,6 +53,7 @@ export const state = {
   lastSyncActors: [] as any[],
   lastSyncPeers: [] as any[],
   lastSyncSharingReview: [] as any[],
+  lastSyncCoordinator: null as any,
   lastSyncAttempts: [] as any[],
   lastSyncLegacyDevices: [] as any[],
   pairingPayloadRaw: null as any,

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -598,6 +598,44 @@ export function renderSyncSharingReview() {
   });
 }
 
+export function renderSyncCoordinatorOverview() {
+  const panel = document.getElementById('syncCoordinatorOverview');
+  const meta = document.getElementById('syncCoordinatorMeta');
+  const list = document.getElementById('syncCoordinatorList');
+  const actions = document.getElementById('syncCoordinatorActions');
+  if (!panel || !meta || !list || !actions) return;
+  list.textContent = '';
+  const coordinator = state.lastSyncCoordinator;
+  if (!coordinator || !coordinator.configured) {
+    (panel as any).hidden = true;
+    return;
+  }
+  (panel as any).hidden = false;
+  meta.textContent = `${String(coordinator.coordinator_url || '')} · groups: ${(coordinator.groups || []).join(', ') || 'none'}`;
+  const rows = [
+    ['Enrollment', coordinator.presence_status === 'posted' ? 'Enrolled and posting presence' : coordinator.presence_status === 'not_enrolled' ? 'Not enrolled in coordinator' : 'Coordinator error'],
+    ['Paired peers', String(coordinator.paired_peer_count || 0)],
+    ['Fresh discovered peers', String(coordinator.fresh_peer_count || 0)],
+    ['Stale discovered peers', String(coordinator.stale_peer_count || 0)],
+    ['Advertised addresses', Array.isArray(coordinator.advertised_addresses) && coordinator.advertised_addresses.length ? coordinator.advertised_addresses.join(' · ') : 'None'],
+  ];
+  rows.forEach(([label, value]) => {
+    const row = el('div', 'peer-meta', `${label}: ${value}`);
+    list.appendChild(row);
+  });
+  const actionItems: Array<{ label: string; command: string }> = [];
+  if (coordinator.presence_status === 'not_enrolled') {
+    actionItems.push({ label: 'This device is not enrolled in the coordinator group.', command: 'Use invite import or remote admin enrollment for this device' });
+  }
+  if (!Number(coordinator.paired_peer_count || 0)) {
+    actionItems.push({ label: 'No trusted sync peers are paired yet.', command: 'uv run codemem sync pair --payload-only' });
+  }
+  if (!Number(coordinator.fresh_peer_count || 0)) {
+    actionItems.push({ label: 'No fresh peers were discovered from the coordinator.', command: 'uv run codemem sync once' });
+  }
+  renderActionList(actions, actionItems);
+}
+
 export function renderLegacyDeviceClaims() {
   const panel = document.getElementById('syncLegacyClaims');
   const select = document.getElementById('syncLegacyDeviceSelect') as HTMLSelectElement | null;
@@ -706,9 +744,11 @@ export async function loadSyncData() {
     state.lastSyncActors = Array.isArray(actorsPayload?.items) ? actorsPayload.items : [];
     state.lastSyncPeers = payload.peers || [];
     state.lastSyncSharingReview = payload.sharing_review || [];
+    state.lastSyncCoordinator = payload.coordinator || null;
     state.lastSyncAttempts = payload.attempts || [];
     state.lastSyncLegacyDevices = payload.legacy_devices || [];
     renderSyncStatus();
+    renderSyncCoordinatorOverview();
     renderSyncActors();
     renderSyncSharingReview();
     renderSyncPeers();


### PR DESCRIPTION
## Description
- add a Sync-tab coordinator onboarding status surface
- show whether coordinator discovery is configured, posting presence, discovering fresh peers, and paired with trusted devices
- provide action hints that reduce setup guesswork

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `uv run pytest tests/test_coordinator_api.py tests/test_sync_cli.py tests/test_sync_viewer_api.py`
- `bun run check`
- `bun run build`
- `uv run ruff check codemem/sync/coordinator.py codemem/viewer_routes/sync.py viewer_ui/src/lib/state.ts viewer_ui/src/tabs/sync.ts tests/test_sync_viewer_api.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced