### PR TITLE
feat: add pending approval workflow for coordinator joins

### DIFF
--- a/codemem/cli_app.py
+++ b/codemem/cli_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import subprocess
@@ -85,8 +86,10 @@ from .commands.sync_coordinator_cmds import (
     coordinator_group_create_cmd,
     coordinator_import_invite_cmd,
     coordinator_list_devices_cmd,
+    coordinator_list_join_requests_cmd,
     coordinator_remove_device_cmd,
     coordinator_rename_device_cmd,
+    coordinator_review_join_request_cmd,
     coordinator_serve_cmd,
 )
 from .commands.sync_service_cmds import install_autostart_quiet as _install_autostart_quiet
@@ -914,10 +917,8 @@ def dev(
         )
     finally:
         if watcher is not None:
-            try:
+            with contextlib.suppress(Exception):
                 watcher.terminate()
-            except Exception:
-                return
 
 
 @sync_app.command("enable")
@@ -1276,6 +1277,60 @@ def sync_coordinator_import_invite(
         db_path=db_path,
         keys_dir=keys_dir,
         config_path=config_path,
+    )
+
+
+@sync_coordinator_app.command("list-join-requests")
+def sync_coordinator_list_join_requests(
+    group_id: str = typer.Argument(..., help="Coordinator group identifier"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+    remote_url: str = typer.Option(None, help="Remote coordinator base URL"),
+    admin_secret: str = typer.Option(None, help="Remote coordinator admin secret"),
+) -> None:
+    """List pending coordinator join requests."""
+    coordinator_list_join_requests_cmd(
+        group_id=group_id,
+        db_path=db_path,
+        remote_url=remote_url,
+        admin_secret=admin_secret,
+    )
+
+
+@sync_coordinator_app.command("approve-join-request")
+def sync_coordinator_approve_join_request(
+    request_id: str = typer.Argument(..., help="Coordinator join request id"),
+    reviewed_by: str = typer.Option(None, help="Optional reviewer label"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+    remote_url: str = typer.Option(None, help="Remote coordinator base URL"),
+    admin_secret: str = typer.Option(None, help="Remote coordinator admin secret"),
+) -> None:
+    """Approve a pending coordinator join request."""
+    coordinator_review_join_request_cmd(
+        request_id=request_id,
+        approve=True,
+        reviewed_by=reviewed_by,
+        db_path=db_path,
+        remote_url=remote_url,
+        admin_secret=admin_secret,
+    )
+
+
+@sync_coordinator_app.command("deny-join-request")
+def sync_coordinator_deny_join_request(
+    request_id: str = typer.Argument(..., help="Coordinator join request id"),
+    reviewed_by: str = typer.Option(None, help="Optional reviewer label"),
+    db_path: str = typer.Option(None, help="Path to coordinator SQLite database"),
+    remote_url: str = typer.Option(None, help="Remote coordinator base URL"),
+    admin_secret: str = typer.Option(None, help="Remote coordinator admin secret"),
+) -> None:
+    """Deny a pending coordinator join request."""
+    coordinator_review_join_request_cmd(
+        request_id=request_id,
+        approve=False,
+        reviewed_by=reviewed_by,
+        db_path=db_path,
+        remote_url=remote_url,
+        admin_secret=admin_secret,
     )
 
 

--- a/codemem/commands/sync_coordinator_cmds.py
+++ b/codemem/commands/sync_coordinator_cmds.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from http.server import HTTPServer
 from pathlib import Path
+from urllib.parse import quote
 
 from rich import print
 
@@ -295,3 +296,68 @@ def coordinator_import_invite_cmd(
     print(f"[green]Invite imported[/green] {payload['group_id']}")
     print(f"- coordinator: {payload['coordinator_url']}")
     print(f"- status: {response_data.get('status')}")
+
+
+def coordinator_list_join_requests_cmd(
+    *, group_id: str, db_path: str | None, remote_url: str | None, admin_secret: str | None
+) -> None:
+    resolved_remote_url, resolved_admin_secret = _resolve_remote_target(remote_url, admin_secret)
+    if resolved_remote_url:
+        if not resolved_admin_secret:
+            raise SystemExit("Remote coordinator admin secret required")
+        payload = _remote_request(
+            "GET",
+            f"{resolved_remote_url.rstrip('/')}/v1/admin/join-requests?group_id={quote(group_id, safe='')}",
+            admin_secret=resolved_admin_secret,
+        )
+        rows = payload.get("items") if isinstance(payload, dict) else []
+    else:
+        store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+        try:
+            rows = store.list_join_requests(group_id=group_id)
+        finally:
+            store.close()
+    if not rows:
+        print(f"[yellow]No pending join requests[/yellow] for {group_id}")
+        return
+    print(f"[bold]Pending join requests[/bold] for {group_id}")
+    for row in rows:
+        display_name = row.get("display_name") or row.get("device_id")
+        print(f"- {display_name} ({row.get('device_id')}) request_id={row.get('request_id')}")
+
+
+def coordinator_review_join_request_cmd(
+    *,
+    request_id: str,
+    approve: bool,
+    reviewed_by: str | None,
+    db_path: str | None,
+    remote_url: str | None,
+    admin_secret: str | None,
+) -> None:
+    resolved_remote_url, resolved_admin_secret = _resolve_remote_target(remote_url, admin_secret)
+    if resolved_remote_url:
+        if not resolved_admin_secret:
+            raise SystemExit("Remote coordinator admin secret required")
+        endpoint = "/v1/admin/join-requests/approve" if approve else "/v1/admin/join-requests/deny"
+        payload = _remote_request(
+            "POST",
+            f"{resolved_remote_url.rstrip('/')}{endpoint}",
+            admin_secret=resolved_admin_secret,
+            body={"request_id": request_id, "reviewed_by": reviewed_by},
+        )
+        request = payload.get("request") if isinstance(payload, dict) else None
+    else:
+        store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
+        try:
+            request = store.review_join_request(
+                request_id=request_id,
+                approved=approve,
+                reviewed_by=reviewed_by,
+            )
+        finally:
+            store.close()
+    if not request:
+        raise SystemExit(f"Join request not found: {request_id}")
+    action = "Approved" if approve else "Denied"
+    print(f"[green]{action} join request[/green] {request_id}")

--- a/codemem/coordinator_api.py
+++ b/codemem/coordinator_api.py
@@ -134,6 +134,8 @@ def build_coordinator_handler(db_path: Path | None = None):
                 return self._handle_admin_post(parsed.path)
             if parsed.path == "/v1/admin/invites":
                 return self._handle_admin_post(parsed.path)
+            if parsed.path.startswith("/v1/admin/join-requests"):
+                return self._handle_admin_post(parsed.path)
             if parsed.path == "/v1/join":
                 return self._handle_join()
             if parsed.path != "/v1/presence":
@@ -197,6 +199,8 @@ def build_coordinator_handler(db_path: Path | None = None):
                 return self._handle_admin_list(parsed.query)
             if parsed.path == "/v1/admin/invites":
                 return self._handle_admin_list_invites(parsed.query)
+            if parsed.path == "/v1/admin/join-requests":
+                return self._handle_admin_list_join_requests(parsed.query)
             if parsed.path != "/v1/peers":
                 _send_json(self, {"error": "not_found"}, status=404)
                 return
@@ -274,6 +278,22 @@ def build_coordinator_handler(db_path: Path | None = None):
                     (group_id,),
                 ).fetchall()
                 _send_json(self, {"items": [dict(row) for row in rows]})
+            finally:
+                store.close()
+
+        def _handle_admin_list_join_requests(self, query: str) -> None:
+            ok, reason = _authorize_admin_request(self)
+            if not ok:
+                _send_json(self, {"error": reason}, status=401)
+                return
+            params = parse_qs(query)
+            group_id = str(params.get("group_id", [""])[0] or "").strip()
+            if not group_id:
+                _send_json(self, {"error": "group_id_required"}, status=400)
+                return
+            store = self._store()
+            try:
+                _send_json(self, {"items": store.list_join_requests(group_id=group_id)})
             finally:
                 store.close()
 
@@ -370,6 +390,36 @@ def build_coordinator_handler(db_path: Path | None = None):
                         "link": invite_link(encoded),
                     },
                 )
+                return
+            if path in {"/v1/admin/join-requests/approve", "/v1/admin/join-requests/deny"}:
+                request_id = str(data.get("request_id") or "").strip()
+                reviewed_by = str(data.get("reviewed_by") or "").strip() or None
+                if not request_id:
+                    _send_json(self, {"error": "request_id_required"}, status=400)
+                    return
+                store = self._store()
+                try:
+                    request = store.review_join_request(
+                        request_id=request_id,
+                        approved=path.endswith("/approve"),
+                        reviewed_by=reviewed_by,
+                    )
+                finally:
+                    store.close()
+                if request is None:
+                    _send_json(self, {"error": "request_not_found"}, status=404)
+                    return
+                if request.get("_no_transition"):
+                    _send_json(
+                        self,
+                        {
+                            "error": "request_not_pending",
+                            "status": request.get("status"),
+                        },
+                        status=409,
+                    )
+                    return
+                _send_json(self, {"ok": True, "request": request})
                 return
             if not group_id or not device_id:
                 _send_json(self, {"error": "group_id_and_device_id_required"}, status=400)

--- a/codemem/coordinator_store.py
+++ b/codemem/coordinator_store.py
@@ -294,6 +294,68 @@ class CoordinatorStore:
         ).fetchone()
         return dict(row) if row is not None else {}
 
+    def list_join_requests(self, *, group_id: str, status: str = "pending") -> list[dict[str, Any]]:
+        rows = self.conn.execute(
+            """
+            SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+            FROM coordinator_join_requests
+            WHERE group_id = ? AND status = ?
+            ORDER BY created_at ASC, device_id ASC
+            """,
+            (group_id, status),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def review_join_request(
+        self,
+        *,
+        request_id: str,
+        approved: bool,
+        reviewed_by: str | None = None,
+    ) -> dict[str, Any] | None:
+        row = self.conn.execute(
+            """
+            SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status
+            FROM coordinator_join_requests
+            WHERE request_id = ?
+            """,
+            (request_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        data = dict(row)
+        if data.get("status") != "pending":
+            data["_no_transition"] = True
+            return data
+        reviewed_at = dt.datetime.now(dt.UTC).isoformat()
+        next_status = "approved" if approved else "denied"
+        if approved:
+            self.enroll_device(
+                str(data["group_id"]),
+                device_id=str(data["device_id"]),
+                fingerprint=str(data["fingerprint"]),
+                public_key=str(data["public_key"]),
+                display_name=(str(data.get("display_name") or "").strip() or None),
+            )
+        self.conn.execute(
+            """
+            UPDATE coordinator_join_requests
+            SET status = ?, reviewed_at = ?, reviewed_by = ?
+            WHERE request_id = ?
+            """,
+            (next_status, reviewed_at, reviewed_by, request_id),
+        )
+        self.conn.commit()
+        updated = self.conn.execute(
+            """
+            SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+            FROM coordinator_join_requests
+            WHERE request_id = ?
+            """,
+            (request_id,),
+        ).fetchone()
+        return dict(updated) if updated is not None else None
+
     def upsert_presence(
         self,
         *,

--- a/tests/test_coordinator_api.py
+++ b/tests/test_coordinator_api.py
@@ -445,3 +445,54 @@ def test_join_endpoint_auto_admit_and_pending(tmp_path: Path, monkeypatch) -> No
         assert payload["status"] == "pending"
     finally:
         server.shutdown()
+
+
+def test_admin_can_list_and_approve_pending_join_request(tmp_path: Path, monkeypatch) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    monkeypatch.setenv("CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET", "topsecret")
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha", display_name="Team Alpha")
+        invite = store.create_invite(
+            group_id="team-alpha",
+            policy="approval_required",
+            expires_at="2099-01-01T00:00:00Z",
+        )
+        request = store.create_join_request(
+            group_id="team-alpha",
+            device_id="device-pending",
+            public_key="ssh-ed25519 AAAAtest pending@test",
+            fingerprint="fp-pending",
+            display_name="pending-device",
+            token=invite["token"],
+        )
+    finally:
+        store.close()
+
+    server, port = _start_server(coordinator_db)
+    headers = {"X-Codemem-Coordinator-Admin": "topsecret", "Content-Type": "application/json"}
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "GET",
+            "/v1/admin/join-requests?group_id=team-alpha",
+            headers={"X-Codemem-Coordinator-Admin": "topsecret"},
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["items"][0]["request_id"] == request["request_id"]
+
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+        conn.request(
+            "POST",
+            "/v1/admin/join-requests/approve",
+            body=json.dumps({"request_id": request["request_id"], "reviewed_by": "admin"}),
+            headers=headers,
+        )
+        resp = conn.getresponse()
+        payload = json.loads(resp.read().decode("utf-8"))
+        assert resp.status == 200
+        assert payload["request"]["status"] == "approved"
+    finally:
+        server.shutdown()

--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -457,6 +457,56 @@ def test_sync_coordinator_import_invite_local(tmp_path: Path) -> None:
         server.shutdown()
 
 
+def test_sync_coordinator_join_request_management_local(tmp_path: Path) -> None:
+    coordinator_db = tmp_path / "coordinator.sqlite"
+    store = CoordinatorStore(coordinator_db)
+    try:
+        store.create_group("team-alpha", display_name="Team Alpha")
+        invite = store.create_invite(
+            group_id="team-alpha",
+            policy="approval_required",
+            expires_at="2099-01-01T00:00:00Z",
+        )
+        request = store.create_join_request(
+            group_id="team-alpha",
+            device_id="device-pending",
+            public_key="ssh-ed25519 AAAAtest pending@test",
+            fingerprint="fp-pending",
+            display_name="pending-device",
+            token=invite["token"],
+        )
+    finally:
+        store.close()
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "list-join-requests",
+            "team-alpha",
+            "--db-path",
+            str(coordinator_db),
+        ],
+    )
+    assert result.exit_code == 0
+    assert request["request_id"] in result.stdout
+
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            "coordinator",
+            "approve-join-request",
+            request["request_id"],
+            "--db-path",
+            str(coordinator_db),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Approved join request" in result.stdout
+
+
 def test_serve_start_defaults_to_background(monkeypatch) -> None:
     calls: list[dict[str, object]] = []
 


### PR DESCRIPTION
## Description
- add pending join request records for approval-required invites
- add admin API and CLI flows to list, approve, and deny coordinator join requests
- keep teammate import flow aware of pending state instead of silently failing

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `uv run pytest tests/test_coordinator_api.py tests/test_sync_cli.py tests/test_sync_viewer_api.py`
- `bun run check`
- `bun run build`
- `uv run ruff check codemem/coordinator_invites.py codemem/coordinator_store.py codemem/coordinator_api.py codemem/commands/sync_coordinator_cmds.py codemem/cli_app.py codemem/sync/coordinator.py codemem/viewer_routes/sync.py tests/test_coordinator_api.py tests/test_sync_cli.py tests/test_sync_viewer_api.py`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced