### PR TITLE
refactor: reorganize Sync tab into Team sync / People / Diagnostics

### DIFF
--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1554,11 +1554,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     return peers.filter((peer) => String(peer?.actor_id || "") === actorId).length;
   }
   function assignmentNote(actorId) {
-    if (!actorId) return "Unassigned peers keep legacy fallback attribution until you choose an actor.";
+    if (!actorId) return "Unassigned devices keep legacy fallback attribution until you choose an actor.";
     const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
     const actor = actors.find((item) => String(item?.actor_id || "") === actorId);
     if (actor?.is_local) {
-      return "Local actor assignment keeps this peer in your same-person continuity path, including private sync.";
+      return "Local actor assignment keeps this device in your same-person continuity path, including private sync.";
     }
     return "This actor receives memories from allowed projects by default. Use Only me on a memory when it should stay local.";
   }
@@ -1590,7 +1590,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (!targetActorId || !target) {
       return "Choose where this duplicate actor should collapse.";
     }
-    return `Merge into ${actorLabel(target)}. Assigned peers move now; existing memories already stamped with this actor keep their current provenance for now.`;
+    return `Merge into ${actorLabel(target)}. Assigned devices move now; existing memories keep their current provenance.`;
   }
   function createChipEditor(initialValues, placeholder, emptyLabel) {
     let values = [...initialValues];
@@ -1820,11 +1820,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         applyActorBtn.textContent = "Applying...";
         try {
           await assignPeerActor(peerId, actorSelect.value || null);
-          showGlobalNotice(actorSelect.value ? "Peer actor updated." : "Peer actor cleared.");
+          showGlobalNotice(actorSelect.value ? "Device actor updated." : "Device actor cleared.");
           await loadSyncData();
         } catch (error) {
-          showGlobalNotice(error instanceof Error ? error.message : "Failed to update peer actor.", "warning");
-          applyActorBtn.textContent = "Retry actor";
+          showGlobalNotice(error instanceof Error ? error.message : "Failed to update device actor.", "warning");
+          applyActorBtn.textContent = "Retry";
         } finally {
           actorSelect.disabled = false;
           applyActorBtn.disabled = false;
@@ -1835,7 +1835,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       const scopeSummary = el(
         "div",
         "peer-scope-summary",
-        inheritsGlobal ? "Using global sync scope" : `Peer override · include: ${includeList.join(", ") || "all"} · exclude: ${excludeList.join(", ") || "none"}`
+        inheritsGlobal ? "Using global sync scope" : `Device override · include: ${includeList.join(", ") || "all"} · exclude: ${excludeList.join(", ") || "none"}`
       );
       const effectiveSummary = el(
         "div",
@@ -1854,10 +1854,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         saveScopeBtn.textContent = "Saving...";
         try {
           await updatePeerScope(peerId, includeEditor.values(), excludeEditor.values());
-          showGlobalNotice("Peer sync scope saved.");
+          showGlobalNotice("Device sync scope saved.");
           await loadSyncData();
         } catch (error) {
-          showGlobalNotice(error instanceof Error ? error.message : "Failed to save peer scope.", "warning");
+          showGlobalNotice(error instanceof Error ? error.message : "Failed to save device scope.", "warning");
           saveScopeBtn.textContent = "Retry save";
         } finally {
           saveScopeBtn.disabled = false;
@@ -1869,10 +1869,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         inheritBtn.textContent = "Resetting...";
         try {
           await updatePeerScope(peerId, null, null, true);
-          showGlobalNotice("Peer sync scope reset to global defaults.");
+          showGlobalNotice("Device sync scope reset to global defaults.");
           await loadSyncData();
         } catch (error) {
-          showGlobalNotice(error instanceof Error ? error.message : "Failed to reset peer scope.", "warning");
+          showGlobalNotice(error instanceof Error ? error.message : "Failed to reset device scope.", "warning");
           inheritBtn.textContent = "Retry reset";
         } finally {
           inheritBtn.disabled = false;
@@ -1893,19 +1893,20 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     actorList.textContent = "";
     const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
     if (actorMeta) {
-      actorMeta.textContent = actors.length ? "Create, rename, and merge actors here. Assign each peer below. Non-local actors receive memories from allowed projects unless you mark them Only me." : "No named actors yet. Create one here, then assign peers below.";
+      actorMeta.textContent = actors.length ? "Create, rename, and merge actors here. Assign each device below. Non-local actors receive memories from allowed projects unless you mark them Only me." : "No named actors yet. Create one here, then assign devices below.";
     }
     actors.forEach((actor) => {
       const row = el("div", "actor-row");
       const details = el("div", "actor-details");
       const title = el("div", "actor-title");
       const name = el("strong", null, actorLabel(actor));
-      const badge = el("span", `badge actor-badge${actor.is_local ? " local" : ""}`, actor.is_local ? "Local" : `${assignedActorCount(String(actor.actor_id || ""))} peer${assignedActorCount(String(actor.actor_id || "")) === 1 ? "" : "s"}`);
+      const count = assignedActorCount(String(actor.actor_id || ""));
+      const badge = el("span", `badge actor-badge${actor.is_local ? " local" : ""}`, actor.is_local ? "Local" : `${count} device${count === 1 ? "" : "s"}`);
       title.append(name, badge);
       const note = el(
         "div",
         "peer-meta",
-        actor.is_local ? "Used for this device and same-person peers." : `${assignedActorCount(String(actor.actor_id || ""))} assigned peer${assignedActorCount(String(actor.actor_id || "")) === 1 ? "" : "s"}`
+        actor.is_local ? "Used for this device and same-person devices." : `${count} assigned device${count === 1 ? "" : "s"}`
       );
       details.append(title, note);
       const actions = el("div", "actor-actions");
@@ -1964,7 +1965,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         mergeBtn.addEventListener("click", async () => {
           if (!mergeSelect.value) return;
           const target = mergeTargets.find((candidate) => String(candidate.actor_id || "") === mergeSelect.value);
-          if (!window.confirm(`Merge ${actorLabel(actor)} into ${actorLabel(target)}? Assigned peers move now, but older memories keep their current stamped provenance for now.`)) {
+          if (!window.confirm(`Merge ${actorLabel(actor)} into ${actorLabel(target)}? Assigned devices move now, but older memories keep their current stamped provenance for now.`)) {
             return;
           }
           mergeBtn.disabled = true;
@@ -1974,7 +1975,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
           mergeBtn.textContent = "Merging...";
           try {
             await mergeActor(mergeSelect.value, actorId);
-            showGlobalNotice("Actor merged. Assigned peers were moved to the selected actor.");
+            showGlobalNotice("Actor merged. Assigned devices moved to the selected actor.");
             await loadSyncData();
           } catch (error) {
             showGlobalNotice(error instanceof Error ? error.message : "Failed to merge actor.", "warning");
@@ -2012,13 +2013,13 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     }
     panel.hidden = false;
     const scopeLabel = state.currentProject ? `current project (${state.currentProject})` : "all allowed projects";
-    meta.textContent = `Teammate peers receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
+    meta.textContent = `Teammates receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
     items.forEach((item) => {
       const row = el("div", "actor-row");
       const details = el("div", "actor-details");
       const title = el("div", "actor-title");
       title.append(
-        el("strong", null, String(item.peer_name || item.peer_device_id || "Peer")),
+        el("strong", null, String(item.peer_name || item.peer_device_id || "Device")),
         el("span", "badge actor-badge", `actor: ${String(item.actor_display_name || item.actor_id || "unknown")}`)
       );
       const note = el(
@@ -2037,11 +2038,11 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       list.appendChild(row);
     });
   }
-  function renderSyncCoordinatorOverview() {
-    const panel = document.getElementById("syncCoordinatorOverview");
-    const meta = document.getElementById("syncCoordinatorMeta");
-    const list = document.getElementById("syncCoordinatorList");
-    const actions = document.getElementById("syncCoordinatorActions");
+  function renderTeamSync() {
+    const panel = document.getElementById("syncTeamCard");
+    const meta = document.getElementById("syncTeamMeta");
+    const list = document.getElementById("syncTeamStatus");
+    const actions = document.getElementById("syncTeamActions");
     const invitePanel = document.getElementById("syncInvitePanel");
     const joinPanel = document.getElementById("syncJoinPanel");
     const joinRequests = document.getElementById("syncJoinRequests");
@@ -2049,36 +2050,34 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     list.textContent = "";
     if (joinRequests) joinRequests.textContent = "";
     const coordinator = state.lastSyncCoordinator;
-    panel.hidden = false;
     const configured = Boolean(coordinator && coordinator.configured);
-    meta.textContent = configured ? `${String(coordinator.coordinator_url || "")} · groups: ${(coordinator.groups || []).join(", ") || "none"}` : "Set up a team coordinator or join an invite to start coordinator-backed sync.";
+    meta.textContent = configured ? `Connected to ${String(coordinator.coordinator_url || "")} · group: ${(coordinator.groups || []).join(", ") || "none"}` : "Create a team invite or join an existing team to start syncing memories with teammates.";
     if (invitePanel) invitePanel.hidden = false;
     if (joinPanel) joinPanel.hidden = false;
     if (!configured) {
-      list.appendChild(el("div", "peer-meta", "Use Create team invite if you administer a team, or Join team if someone shared an invite with you."));
+      list.appendChild(el("div", "peer-meta", "Use Create invite if you are the team admin, or paste a team invite below to join."));
       renderActionList(actions, []);
       return;
     }
+    const presenceLabel = coordinator.presence_status === "posted" ? "Connected" : coordinator.presence_status === "not_enrolled" ? "Not connected — import an invite or ask your admin to enroll this device" : "Connection error";
     const rows = [
-      ["Enrollment", coordinator.presence_status === "posted" ? "Enrolled and posting presence" : coordinator.presence_status === "not_enrolled" ? "Not enrolled in coordinator" : "Coordinator error"],
-      ["Paired peers", String(coordinator.paired_peer_count || 0)],
-      ["Fresh discovered peers", String(coordinator.fresh_peer_count || 0)],
-      ["Stale discovered peers", String(coordinator.stale_peer_count || 0)],
-      ["Advertised addresses", Array.isArray(coordinator.advertised_addresses) && coordinator.advertised_addresses.length ? coordinator.advertised_addresses.join(" · ") : "None"]
+      ["Status", presenceLabel],
+      ["Paired devices", String(coordinator.paired_peer_count || 0)],
+      ["Discovered devices", String(coordinator.fresh_peer_count || 0)]
     ];
+    if (Number(coordinator.stale_peer_count || 0) > 0) {
+      rows.push(["Inactive devices", String(coordinator.stale_peer_count)]);
+    }
     rows.forEach(([label, value]) => {
       const row = el("div", "peer-meta", `${label}: ${value}`);
       list.appendChild(row);
     });
     const actionItems = [];
     if (coordinator.presence_status === "not_enrolled") {
-      actionItems.push({ label: "This device is not enrolled in the coordinator group.", command: "Use invite import or remote admin enrollment for this device" });
+      actionItems.push({ label: "This device is not connected to the team yet.", command: "Import a team invite or ask your admin to enroll this device" });
     }
-    if (!Number(coordinator.paired_peer_count || 0)) {
-      actionItems.push({ label: "No trusted sync peers are paired yet.", command: "uv run codemem sync pair --payload-only" });
-    }
-    if (!Number(coordinator.fresh_peer_count || 0)) {
-      actionItems.push({ label: "No fresh peers were discovered from the coordinator.", command: "uv run codemem sync once" });
+    if (!Number(coordinator.paired_peer_count || 0) && coordinator.presence_status === "posted") {
+      actionItems.push({ label: "No devices are paired yet.", command: "uv run codemem sync pair --payload-only" });
     }
     renderActionList(actions, actionItems);
     const pending = Array.isArray(state.lastSyncJoinRequests) ? state.lastSyncJoinRequests : [];
@@ -2159,7 +2158,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       }
     });
     if (!meta.textContent) {
-      meta.textContent = "Detected from older synced memories that are not attached to a current peer.";
+      meta.textContent = "Detected from older synced memories not yet attached to a current device.";
     }
   }
   function renderSyncAttempts() {
@@ -2229,7 +2228,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       state.lastSyncAttempts = payload.attempts || [];
       state.lastSyncLegacyDevices = payload.legacy_devices || [];
       renderSyncStatus();
-      renderSyncCoordinatorOverview();
+      renderTeamSync();
       renderSyncActors();
       renderSyncSharingReview();
       renderSyncPeers();

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1534,12 +1534,76 @@
 
     <!-- ── Tab: Sync ───────────────────────────────────────── -->
     <div class="tab-panel" id="tab-sync" hidden>
-      <div class="card">
+
+      <!-- 1. Team sync — primary, always visible -->
+      <div class="card" id="syncTeamCard">
         <div class="section-header">
-          <h2>Sync</h2>
+          <h2>Team sync</h2>
+          <div class="section-actions">
+            <button class="settings-button" id="syncNowButton">Sync now</button>
+          </div>
+        </div>
+        <div class="section-meta" id="syncTeamMeta"></div>
+        <div class="actor-create-row" id="syncInvitePanel">
+          <input class="peer-scope-input" id="syncInviteGroup" placeholder="Team group" />
+          <select class="sync-actor-select" id="syncInvitePolicy">
+            <option value="auto_admit">Auto-admit</option>
+            <option value="approval_required">Approval required</option>
+          </select>
+          <input class="peer-scope-input" id="syncInviteTtl" type="number" min="1" value="24" placeholder="TTL hours" />
+          <button class="settings-button" id="syncCreateInviteButton">Create invite</button>
+        </div>
+        <textarea class="feed-search" id="syncInviteOutput" placeholder="Invite output appears here"></textarea>
+        <div class="actor-create-row" id="syncJoinPanel">
+          <textarea class="feed-search" id="syncJoinInvite" placeholder="Paste team invite or codemem:// link"></textarea>
+          <button class="settings-button" id="syncJoinButton">Join team</button>
+        </div>
+        <div class="actor-list" id="syncTeamStatus"></div>
+        <div class="actor-list" id="syncJoinRequests"></div>
+        <div class="sync-actions" id="syncTeamActions" hidden></div>
+      </div>
+
+      <!-- 2. People — actors, devices, sharing, legacy claims -->
+      <div class="card" style="animation-delay: 0.04s">
+        <h2>People</h2>
+
+        <h3 class="settings-group-title">Actors</h3>
+        <div class="section-meta" id="syncActorsMeta">Create and rename actors here. Assign each device below.</div>
+        <div class="actor-create-row">
+          <input class="peer-scope-input" id="syncActorCreateInput" placeholder="Create a named actor" />
+          <button class="settings-button" id="syncActorCreateButton">Create actor</button>
+        </div>
+        <div class="actor-list" id="syncActorsList"></div>
+
+        <h3 class="settings-group-title" style="margin-top: 20px">Devices</h3>
+        <div class="peer-list" id="syncPeers"></div>
+
+        <div id="syncSharingReview" hidden>
+          <h3 class="settings-group-title" style="margin-top: 20px">What teammates will receive</h3>
+          <div class="section-meta" id="syncSharingReviewMeta"></div>
+          <div class="actor-list" id="syncSharingReviewList"></div>
+        </div>
+
+        <div id="syncLegacyClaims" hidden>
+          <h3 class="settings-group-title" style="margin-top: 20px">Legacy device history</h3>
+          <div class="peer-meta" id="syncLegacyClaimsMeta"></div>
+          <div class="peer-actions sync-legacy-claim-row">
+            <select class="sync-legacy-select" id="syncLegacyDeviceSelect"></select>
+            <button class="sync-legacy-button" id="syncLegacyClaimButton">Attach device history</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- 3. Diagnostics — status, pairing, attempts -->
+      <div class="card" style="animation-delay: 0.06s">
+        <div class="section-header">
+          <h2>Diagnostics</h2>
           <div class="section-actions">
             <button class="settings-button" id="syncPairingToggle">Show pairing</button>
-            <button class="settings-button" id="syncNowButton">Sync now</button>
+            <label class="small" style="display:inline-flex;align-items:center;gap:6px;">
+              <input id="syncRedact" type="checkbox" checked />
+              Redact
+            </label>
           </div>
         </div>
         <div class="section-meta" id="syncMeta">Loading sync status…</div>
@@ -1556,69 +1620,8 @@
           </div>
           <div class="peer-meta" id="pairingHint">Copy and run on the other device. Use --include/--exclude to control which projects sync.</div>
         </div>
-      </div>
 
-      <div class="card" style="animation-delay: 0.04s">
-        <h2>Actors</h2>
-        <div class="section-meta" id="syncActorsMeta">Create and rename actors here. Assign each peer below.</div>
-        <div class="actor-create-row">
-          <input class="peer-scope-input" id="syncActorCreateInput" placeholder="Create a named actor" />
-          <button class="settings-button" id="syncActorCreateButton">Create actor</button>
-        </div>
-        <div class="actor-list" id="syncActorsList"></div>
-      </div>
-
-      <div class="card" id="syncCoordinatorOverview" style="animation-delay: 0.045s" hidden>
-        <h2>Team sync</h2>
-        <div class="section-meta" id="syncCoordinatorMeta"></div>
-        <div class="actor-create-row" id="syncInvitePanel">
-          <input class="peer-scope-input" id="syncInviteGroup" placeholder="Team group" />
-          <select class="sync-actor-select" id="syncInvitePolicy">
-            <option value="auto_admit">Auto-admit</option>
-            <option value="approval_required">Approval required</option>
-          </select>
-          <input class="peer-scope-input" id="syncInviteTtl" type="number" min="1" value="24" placeholder="TTL hours" />
-          <button class="settings-button" id="syncCreateInviteButton">Create invite</button>
-        </div>
-        <textarea class="feed-search" id="syncInviteOutput" placeholder="Invite output appears here"></textarea>
-        <div class="actor-create-row" id="syncJoinPanel">
-          <textarea class="feed-search" id="syncJoinInvite" placeholder="Paste team invite or codemem:// link"></textarea>
-          <button class="settings-button" id="syncJoinButton">Join team</button>
-        </div>
-        <div class="actor-list" id="syncCoordinatorList"></div>
-        <div class="actor-list" id="syncJoinRequests"></div>
-        <div class="sync-actions" id="syncCoordinatorActions" hidden></div>
-      </div>
-
-      <div class="card" style="animation-delay: 0.05s">
-        <h2>Peers</h2>
-        <div class="peer-list" id="syncPeers"></div>
-      </div>
-
-      <div class="card" id="syncSharingReview" style="animation-delay: 0.06s" hidden>
-        <h2>Review what teammates will receive</h2>
-        <div class="section-meta" id="syncSharingReviewMeta"></div>
-        <div class="actor-list" id="syncSharingReviewList"></div>
-      </div>
-
-      <div class="card" id="syncLegacyClaims" style="animation-delay: 0.08s" hidden>
-        <h2>Attach old device history to local actor</h2>
-        <div class="peer-meta" id="syncLegacyClaimsMeta"></div>
-        <div class="peer-actions sync-legacy-claim-row">
-          <select class="sync-legacy-select" id="syncLegacyDeviceSelect"></select>
-          <button class="sync-legacy-button" id="syncLegacyClaimButton">Attach device history</button>
-        </div>
-      </div>
-
-      <div class="section-meta" style="text-align:right; margin-bottom:12px;">
-        <label class="small" style="display:inline-flex;align-items:center;gap:8px;">
-          <input id="syncRedact" type="checkbox" checked />
-          Redact sensitive details
-        </label>
-      </div>
-
-      <div class="card" style="animation-delay: 0.1s">
-        <h2>Recent sync attempts</h2>
+        <h3 class="settings-group-title" style="margin-top: 20px">Recent sync attempts</h3>
         <div class="attempts-list" id="syncAttempts"></div>
       </div>
     </div>

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -59,11 +59,11 @@ function assignedActorCount(actorId: string): number {
 }
 
 function assignmentNote(actorId: string): string {
-  if (!actorId) return 'Unassigned peers keep legacy fallback attribution until you choose an actor.';
+  if (!actorId) return 'Unassigned devices keep legacy fallback attribution until you choose an actor.';
   const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
   const actor = actors.find((item) => String(item?.actor_id || '') === actorId);
   if (actor?.is_local) {
-    return 'Local actor assignment keeps this peer in your same-person continuity path, including private sync.';
+    return 'Local actor assignment keeps this device in your same-person continuity path, including private sync.';
   }
   return 'This actor receives memories from allowed projects by default. Use Only me on a memory when it should stay local.';
 }
@@ -99,7 +99,7 @@ function actorMergeNote(targetActorId: string, secondaryActorId: string): string
   if (!targetActorId || !target) {
     return 'Choose where this duplicate actor should collapse.';
   }
-  return `Merge into ${actorLabel(target)}. Assigned peers move now; existing memories already stamped with this actor keep their current provenance for now.`;
+  return `Merge into ${actorLabel(target)}. Assigned devices move now; existing memories keep their current provenance.`;
 }
 
 function createChipEditor(initialValues: string[], placeholder: string, emptyLabel: string) {
@@ -282,7 +282,7 @@ export function renderSyncStatus() {
   renderActionList(syncActions, actions);
 }
 
-/* ── Peers renderer ──────────────────────────────────────── */
+/* ── Devices renderer ────────────────────────────────────── */
 
 export function renderSyncPeers() {
   const syncPeers = document.getElementById('syncPeers');
@@ -364,11 +364,11 @@ export function renderSyncPeers() {
       applyActorBtn.textContent = 'Applying...';
       try {
         await api.assignPeerActor(peerId, actorSelect.value || null);
-        showGlobalNotice(actorSelect.value ? 'Peer actor updated.' : 'Peer actor cleared.');
+        showGlobalNotice(actorSelect.value ? 'Device actor updated.' : 'Device actor cleared.');
         await loadSyncData();
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : 'Failed to update peer actor.', 'warning');
-        applyActorBtn.textContent = 'Retry actor';
+        showGlobalNotice(error instanceof Error ? error.message : 'Failed to update device actor.', 'warning');
+        applyActorBtn.textContent = 'Retry';
       } finally {
         actorSelect.disabled = false;
         applyActorBtn.disabled = false;
@@ -381,7 +381,7 @@ export function renderSyncPeers() {
       'peer-scope-summary',
       inheritsGlobal
         ? 'Using global sync scope'
-        : `Peer override · include: ${includeList.join(', ') || 'all'} · exclude: ${excludeList.join(', ') || 'none'}`,
+        : `Device override · include: ${includeList.join(', ') || 'all'} · exclude: ${excludeList.join(', ') || 'none'}`,
     );
     const effectiveSummary = el(
       'div',
@@ -400,10 +400,10 @@ export function renderSyncPeers() {
       saveScopeBtn.textContent = 'Saving...';
       try {
         await api.updatePeerScope(peerId, includeEditor.values(), excludeEditor.values());
-        showGlobalNotice('Peer sync scope saved.');
+        showGlobalNotice('Device sync scope saved.');
         await loadSyncData();
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : 'Failed to save peer scope.', 'warning');
+        showGlobalNotice(error instanceof Error ? error.message : 'Failed to save device scope.', 'warning');
         saveScopeBtn.textContent = 'Retry save';
       } finally {
         saveScopeBtn.disabled = false;
@@ -415,10 +415,10 @@ export function renderSyncPeers() {
       inheritBtn.textContent = 'Resetting...';
       try {
         await api.updatePeerScope(peerId, null, null, true);
-        showGlobalNotice('Peer sync scope reset to global defaults.');
+        showGlobalNotice('Device sync scope reset to global defaults.');
         await loadSyncData();
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : 'Failed to reset peer scope.', 'warning');
+        showGlobalNotice(error instanceof Error ? error.message : 'Failed to reset device scope.', 'warning');
         inheritBtn.textContent = 'Retry reset';
       } finally {
         inheritBtn.disabled = false;
@@ -443,8 +443,8 @@ export function renderSyncActors() {
   const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
   if (actorMeta) {
     actorMeta.textContent = actors.length
-      ? 'Create, rename, and merge actors here. Assign each peer below. Non-local actors receive memories from allowed projects unless you mark them Only me.'
-      : 'No named actors yet. Create one here, then assign peers below.';
+      ? 'Create, rename, and merge actors here. Assign each device below. Non-local actors receive memories from allowed projects unless you mark them Only me.'
+      : 'No named actors yet. Create one here, then assign devices below.';
   }
 
   actors.forEach((actor) => {
@@ -452,14 +452,15 @@ export function renderSyncActors() {
     const details = el('div', 'actor-details');
     const title = el('div', 'actor-title');
     const name = el('strong', null, actorLabel(actor));
-    const badge = el('span', `badge actor-badge${actor.is_local ? ' local' : ''}`, actor.is_local ? 'Local' : `${assignedActorCount(String(actor.actor_id || ''))} peer${assignedActorCount(String(actor.actor_id || '')) === 1 ? '' : 's'}`);
+    const count = assignedActorCount(String(actor.actor_id || ''));
+    const badge = el('span', `badge actor-badge${actor.is_local ? ' local' : ''}`, actor.is_local ? 'Local' : `${count} device${count === 1 ? '' : 's'}`);
     title.append(name, badge);
     const note = el(
       'div',
       'peer-meta',
       actor.is_local
-        ? 'Used for this device and same-person peers.'
-        : `${assignedActorCount(String(actor.actor_id || ''))} assigned peer${assignedActorCount(String(actor.actor_id || '')) === 1 ? '' : 's'}`,
+        ? 'Used for this device and same-person devices.'
+        : `${count} assigned device${count === 1 ? '' : 's'}`,
     );
     details.append(title, note);
 
@@ -521,7 +522,7 @@ export function renderSyncActors() {
       mergeBtn.addEventListener('click', async () => {
         if (!mergeSelect.value) return;
         const target = mergeTargets.find((candidate) => String(candidate.actor_id || '') === mergeSelect.value);
-        if (!window.confirm(`Merge ${actorLabel(actor)} into ${actorLabel(target)}? Assigned peers move now, but older memories keep their current stamped provenance for now.`)) {
+        if (!window.confirm(`Merge ${actorLabel(actor)} into ${actorLabel(target)}? Assigned devices move now, but older memories keep their current stamped provenance for now.`)) {
           return;
         }
         mergeBtn.disabled = true;
@@ -531,7 +532,7 @@ export function renderSyncActors() {
         mergeBtn.textContent = 'Merging...';
         try {
           await api.mergeActor(mergeSelect.value, actorId);
-          showGlobalNotice('Actor merged. Assigned peers were moved to the selected actor.');
+          showGlobalNotice('Actor merged. Assigned devices moved to the selected actor.');
           await loadSyncData();
         } catch (error) {
           showGlobalNotice(error instanceof Error ? error.message : 'Failed to merge actor.', 'warning');
@@ -572,13 +573,13 @@ export function renderSyncSharingReview() {
   }
   (panel as any).hidden = false;
   const scopeLabel = state.currentProject ? `current project (${state.currentProject})` : 'all allowed projects';
-  meta.textContent = `Teammate peers receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
+  meta.textContent = `Teammates receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
   items.forEach((item) => {
     const row = el('div', 'actor-row');
     const details = el('div', 'actor-details');
     const title = el('div', 'actor-title');
     title.append(
-      el('strong', null, String(item.peer_name || item.peer_device_id || 'Peer')),
+      el('strong', null, String(item.peer_name || item.peer_device_id || 'Device')),
       el('span', 'badge actor-badge', `actor: ${String(item.actor_display_name || item.actor_id || 'unknown')}`),
     );
     const note = el(
@@ -598,11 +599,11 @@ export function renderSyncSharingReview() {
   });
 }
 
-export function renderSyncCoordinatorOverview() {
-  const panel = document.getElementById('syncCoordinatorOverview');
-  const meta = document.getElementById('syncCoordinatorMeta');
-  const list = document.getElementById('syncCoordinatorList');
-  const actions = document.getElementById('syncCoordinatorActions');
+export function renderTeamSync() {
+  const panel = document.getElementById('syncTeamCard');
+  const meta = document.getElementById('syncTeamMeta');
+  const list = document.getElementById('syncTeamStatus');
+  const actions = document.getElementById('syncTeamActions');
   const invitePanel = document.getElementById('syncInvitePanel');
   const joinPanel = document.getElementById('syncJoinPanel');
   const joinRequests = document.getElementById('syncJoinRequests');
@@ -610,38 +611,40 @@ export function renderSyncCoordinatorOverview() {
   list.textContent = '';
   if (joinRequests) joinRequests.textContent = '';
   const coordinator = state.lastSyncCoordinator;
-  (panel as any).hidden = false;
   const configured = Boolean(coordinator && coordinator.configured);
   meta.textContent = configured
-    ? `${String(coordinator.coordinator_url || '')} · groups: ${(coordinator.groups || []).join(', ') || 'none'}`
-    : 'Set up a team coordinator or join an invite to start coordinator-backed sync.';
+    ? `Connected to ${String(coordinator.coordinator_url || '')} · group: ${(coordinator.groups || []).join(', ') || 'none'}`
+    : 'Create a team invite or join an existing team to start syncing memories with teammates.';
   if (invitePanel) (invitePanel as any).hidden = false;
   if (joinPanel) (joinPanel as any).hidden = false;
   if (!configured) {
-    list.appendChild(el('div', 'peer-meta', 'Use Create team invite if you administer a team, or Join team if someone shared an invite with you.'));
+    list.appendChild(el('div', 'peer-meta', 'Use Create invite if you are the team admin, or paste a team invite below to join.'));
     renderActionList(actions, []);
     return;
   }
+  const presenceLabel = coordinator.presence_status === 'posted'
+    ? 'Connected'
+    : coordinator.presence_status === 'not_enrolled'
+      ? 'Not connected — import an invite or ask your admin to enroll this device'
+      : 'Connection error';
   const rows = [
-    ['Enrollment', coordinator.presence_status === 'posted' ? 'Enrolled and posting presence' : coordinator.presence_status === 'not_enrolled' ? 'Not enrolled in coordinator' : 'Coordinator error'],
-    ['Paired peers', String(coordinator.paired_peer_count || 0)],
-    ['Fresh discovered peers', String(coordinator.fresh_peer_count || 0)],
-    ['Stale discovered peers', String(coordinator.stale_peer_count || 0)],
-    ['Advertised addresses', Array.isArray(coordinator.advertised_addresses) && coordinator.advertised_addresses.length ? coordinator.advertised_addresses.join(' · ') : 'None'],
+    ['Status', presenceLabel],
+    ['Paired devices', String(coordinator.paired_peer_count || 0)],
+    ['Discovered devices', String(coordinator.fresh_peer_count || 0)],
   ];
+  if (Number(coordinator.stale_peer_count || 0) > 0) {
+    rows.push(['Inactive devices', String(coordinator.stale_peer_count)]);
+  }
   rows.forEach(([label, value]) => {
     const row = el('div', 'peer-meta', `${label}: ${value}`);
     list.appendChild(row);
   });
   const actionItems: Array<{ label: string; command: string }> = [];
   if (coordinator.presence_status === 'not_enrolled') {
-    actionItems.push({ label: 'This device is not enrolled in the coordinator group.', command: 'Use invite import or remote admin enrollment for this device' });
+    actionItems.push({ label: 'This device is not connected to the team yet.', command: 'Import a team invite or ask your admin to enroll this device' });
   }
-  if (!Number(coordinator.paired_peer_count || 0)) {
-    actionItems.push({ label: 'No trusted sync peers are paired yet.', command: 'uv run codemem sync pair --payload-only' });
-  }
-  if (!Number(coordinator.fresh_peer_count || 0)) {
-    actionItems.push({ label: 'No fresh peers were discovered from the coordinator.', command: 'uv run codemem sync once' });
+  if (!Number(coordinator.paired_peer_count || 0) && coordinator.presence_status === 'posted') {
+    actionItems.push({ label: 'No devices are paired yet.', command: 'uv run codemem sync pair --payload-only' });
   }
   renderActionList(actions, actionItems);
 
@@ -726,7 +729,7 @@ export function renderLegacyDeviceClaims() {
     }
   });
   if (!meta.textContent) {
-    meta.textContent = 'Detected from older synced memories that are not attached to a current peer.';
+    meta.textContent = 'Detected from older synced memories not yet attached to a current device.';
   }
 }
 
@@ -808,7 +811,7 @@ export async function loadSyncData() {
     state.lastSyncAttempts = payload.attempts || [];
     state.lastSyncLegacyDevices = payload.legacy_devices || [];
     renderSyncStatus();
-    renderSyncCoordinatorOverview();
+    renderTeamSync();
     renderSyncActors();
     renderSyncSharingReview();
     renderSyncPeers();


### PR DESCRIPTION
## Description
Restructure the Sync tab from 7+ scattered cards into 3 clear information zones:

1. **Team sync** — primary, always visible at top — setup/join/invite/status
2. **People** — actors, devices, sharing review, legacy claims grouped together
3. **Diagnostics** — sync status grid, pairing, recent attempts, redaction toggle

Also cleans up product language throughout:
- "peers" → "devices" in user-facing copy
- Removes coordinator/enrollment jargon from primary UX
- Simplifies status labels (e.g. "Enrolled and posting presence" → "Connected")
- "Stale discovered peers" only shown when count > 0

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `bun run check` — TypeScript passes
- `bun run build` — bundle built
- `uv run pytest tests/test_sync_viewer_api.py tests/test_coordinator_api.py tests/test_sync_cli.py` — all pass
- `uv run ruff check codemem tests` — all pass

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced