### PR TITLE
docs: record Python coordinator as canonical deployment target

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1457,7 +1457,7 @@
               <div class="field field-checkbox settings-advanced" hidden><input class="cm-checkbox" id="syncMdns" type="checkbox" /><label for="syncMdns">Enable mDNS discovery</label></div>
               <div class="field">
                 <label for="syncCoordinatorUrl">Coordinator URL</label>
-                <input id="syncCoordinatorUrl" placeholder="https://coord.example.workers.dev" />
+                <input id="syncCoordinatorUrl" placeholder="https://coord.example.com" />
                 <div class="small">Optional self-hosted/operator-run discovery service. Direct peer-to-peer sync remains the data path.</div>
               </div>
               <div class="field">

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -44,7 +44,7 @@ Example config:
 ```json
 {
   "sync_enabled": true,
-  "sync_coordinator_url": "https://coord.example.workers.dev",
+  "sync_coordinator_url": "https://coord.example.com",
   "sync_coordinator_group": "team-alpha",
   "sync_coordinator_timeout_s": 3,
   "sync_coordinator_presence_ttl_s": 180,
@@ -56,7 +56,7 @@ Multi-group config is also supported:
 
 ```json
 {
-  "sync_coordinator_url": "https://coord.example.workers.dev",
+  "sync_coordinator_url": "https://coord.example.com",
   "sync_coordinator_groups": ["team-alpha", "lab"]
 }
 ```
@@ -135,16 +135,28 @@ codemem sync coordinator rename-device nerdworld <device-id> --name "work-laptop
 Device participation auth still uses the enrolled device keypair for `presence` and `peers` endpoints; the admin secret
 is only for remote mutation/listing endpoints.
 
+## Canonical deployment target
+
+The built-in Python coordinator (`codemem sync coordinator serve`) is the canonical deployment target for ongoing
+product development and dogfooding.
+
+Recommended deployment patterns:
+
+- **Native**: run `codemem sync coordinator serve` on a reachable machine (VPS, homelab, always-on workstation)
+- **Container**: run via Docker/Podman with the coordinator SQLite volume mounted
+- **Exposure**: use Tailscale Funnel or Cloudflare Tunnel to make the coordinator reachable from outside a local network
+
+This keeps the deployment path inside the main `codemem` artifact, avoids a separate JS runtime dependency, and ensures
+new coordinator features (invites, join requests, admin flows) are immediately available without porting.
+
 ## Cloudflare Worker reference deployment
 
-The design targets a runtime-agnostic HTTP contract, but a Cloudflare Worker is the canonical low-cost reference
-deployment.
+A Cloudflare Worker reference implementation exists in `examples/cloudflare-coordinator/`. It implements the same HTTP
+contract against D1, but is secondary to the Python coordinator for ongoing feature development.
 
-That means the coordinator API should be simple enough to implement anywhere, but the first example deployment is
-expected to be a Worker-backed service at a stable address.
-
-The Cloudflare Worker remains an optional alternate reference deployment. Its scaffold lives in a follow-up PR in this
-stack, not in this docs-only change.
+Use the Cloudflare Worker path when you specifically want a serverless/edge deployment and are comfortable with the
+feature lag — new coordinator capabilities (invite/join flows, admin endpoints) land in the Python coordinator first and
+may not be ported to the Worker immediately.
 
 ## Current limitations
 

--- a/examples/cloudflare-coordinator/README.md
+++ b/examples/cloudflare-coordinator/README.md
@@ -1,6 +1,8 @@
 # Cloudflare Worker reference coordinator
 
-This is the canonical low-cost reference deployment for the coordinator-backed discovery contract.
+This is a secondary reference deployment for the coordinator-backed discovery contract. The canonical deployment target
+is the built-in Python coordinator (`codemem sync coordinator serve`). See `docs/coordinator-discovery.md` for the
+recommended deployment path.
 
 It is intentionally narrow:
 


### PR DESCRIPTION
## Description
Record the architecture decision that the built-in Python coordinator is the canonical deployment target for ongoing development and dogfooding, and the Cloudflare Worker is a secondary reference implementation.

- Update `docs/coordinator-discovery.md` with a new "Canonical deployment target" section documenting recommended deployment patterns (native, container, Tailscale Funnel / Cloudflare Tunnel)
- Update Cloudflare Worker section and README to reflect secondary status
- Update example coordinator URLs from workers.dev to generic domain

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Docs-only change; no behavior changes.

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced