### PR TITLE
refactor: improve Sync tab onboarding UX with admin/teammate flow separation

### DIFF
--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1527,6 +1527,9 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       updateFeedView(true);
     }
   }
+  let adminSetupExpanded = false;
+  let teamInvitePanelOpen = false;
+  const openPeerScopeEditors = /* @__PURE__ */ new Set();
   function redactIpOctets(text) {
     return text.replace(/\b(\d{1,3}\.\d{1,3})\.\d{1,3}\.\d{1,3}\b/g, "$1.#.#");
   }
@@ -1663,6 +1666,25 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       container.appendChild(row);
     });
   }
+  function ensureInvitePanelInAdminSection() {
+    const invitePanel = document.getElementById("syncInvitePanel");
+    const adminSection = document.getElementById("syncAdminSection");
+    if (!invitePanel || !adminSection) return;
+    if (invitePanel.parentElement !== adminSection) adminSection.appendChild(invitePanel);
+  }
+  function ensureJoinPanelInSetupSection() {
+    const joinPanel = document.getElementById("syncJoinPanel");
+    const joinSection = document.getElementById("syncJoinSection");
+    if (!joinPanel || !joinSection) return;
+    if (joinPanel.parentElement !== joinSection) joinSection.appendChild(joinPanel);
+  }
+  function setInviteOutputVisibility() {
+    const syncInviteOutput = document.getElementById("syncInviteOutput");
+    if (!syncInviteOutput) return;
+    const encoded = String(state.lastTeamInvite?.encoded || "").trim();
+    syncInviteOutput.value = encoded;
+    syncInviteOutput.hidden = !encoded;
+  }
   function renderSyncStatus() {
     const syncStatusGrid = document.getElementById("syncStatusGrid");
     const syncMeta = document.getElementById("syncMeta");
@@ -1752,7 +1774,16 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (!syncPeers) return;
     syncPeers.textContent = "";
     const peers = state.lastSyncPeers;
-    if (!Array.isArray(peers) || !peers.length) return;
+    if (!Array.isArray(peers) || !peers.length) {
+      syncPeers.appendChild(
+        el(
+          "div",
+          "sync-empty-state",
+          "No devices paired yet. Use the pairing command in Diagnostics to connect another device."
+        )
+      );
+      return;
+    }
     peers.forEach((peer) => {
       const card = el("div", "peer-card");
       const titleRow = el("div", "peer-title");
@@ -1781,6 +1812,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         syncBtn.textContent = "Sync now";
       });
       actions.appendChild(syncBtn);
+      const toggleScopeBtn = el("button", null, "Edit scope");
+      actions.appendChild(toggleScopeBtn);
       const peerAddresses = Array.isArray(peer.addresses) ? Array.from(new Set(peer.addresses.filter(Boolean))) : [];
       const addressLine = peerAddresses.length ? peerAddresses.map((a) => isSyncRedactionEnabled() ? redactAddress(a) : a).join(" · ") : "No addresses";
       const addressLabel = el("div", "peer-addresses", addressLine);
@@ -1844,6 +1877,9 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       );
       const includeEditor = createChipEditor(includeList, "Add included project", "All projects");
       const excludeEditor = createChipEditor(excludeList, "Add excluded project", "No exclusions");
+      const editorWrap = el("div", "peer-scope-editor-wrap");
+      const scopeEditorOpen = openPeerScopeEditors.has(peerId);
+      editorWrap.hidden = !scopeEditorOpen;
       const inputRow = el("div", "peer-scope-row");
       inputRow.append(includeEditor.element, excludeEditor.element);
       const scopeActions = el("div", "peer-scope-actions");
@@ -1880,7 +1916,24 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         }
       });
       scopeActions.append(saveScopeBtn, inheritBtn);
-      scopePanel.append(identityRow, identityMeta, actorRow, actorHint, scopeSummary, effectiveSummary, inputRow, scopeActions);
+      editorWrap.append(inputRow, scopeActions);
+      toggleScopeBtn.textContent = scopeEditorOpen ? "Hide scope editor" : "Edit scope";
+      toggleScopeBtn.addEventListener("click", () => {
+        const nextHidden = !editorWrap.hidden;
+        editorWrap.hidden = nextHidden;
+        if (nextHidden) openPeerScopeEditors.delete(peerId);
+        else openPeerScopeEditors.add(peerId);
+        toggleScopeBtn.textContent = nextHidden ? "Edit scope" : "Hide scope editor";
+      });
+      scopePanel.append(
+        identityRow,
+        identityMeta,
+        actorRow,
+        actorHint,
+        scopeSummary,
+        effectiveSummary,
+        editorWrap
+      );
       titleRow.append(name, actions);
       card.append(titleRow, addressLabel, meta, scopePanel);
       syncPeers.appendChild(card);
@@ -1894,6 +1947,16 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
     if (actorMeta) {
       actorMeta.textContent = actors.length ? "Create, rename, and merge actors here. Assign each device below. Non-local actors receive memories from allowed projects unless you mark them Only me." : "No named actors yet. Create one here, then assign devices below.";
+    }
+    if (!actors.length) {
+      actorList.appendChild(
+        el(
+          "div",
+          "sync-empty-state",
+          "No actors yet. Create one to represent yourself or a teammate."
+        )
+      );
+      return;
     }
     actors.forEach((actor) => {
       const row = el("div", "actor-row");
@@ -2039,47 +2102,104 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     });
   }
   function renderTeamSync() {
-    const panel = document.getElementById("syncTeamCard");
     const meta = document.getElementById("syncTeamMeta");
+    const setupPanel = document.getElementById("syncSetupPanel");
     const list = document.getElementById("syncTeamStatus");
     const actions = document.getElementById("syncTeamActions");
     const invitePanel = document.getElementById("syncInvitePanel");
+    const toggleAdmin = document.getElementById("syncToggleAdmin");
     const joinPanel = document.getElementById("syncJoinPanel");
     const joinRequests = document.getElementById("syncJoinRequests");
-    if (!panel || !meta || !list || !actions) return;
+    if (!meta || !setupPanel || !list || !actions) return;
+    ensureInvitePanelInAdminSection();
+    ensureJoinPanelInSetupSection();
     list.textContent = "";
+    actions.textContent = "";
     if (joinRequests) joinRequests.textContent = "";
+    setInviteOutputVisibility();
     const coordinator = state.lastSyncCoordinator;
     const configured = Boolean(coordinator && coordinator.configured);
     meta.textContent = configured ? `Connected to ${String(coordinator.coordinator_url || "")} · group: ${(coordinator.groups || []).join(", ") || "none"}` : "Create a team invite or join an existing team to start syncing memories with teammates.";
-    if (invitePanel) invitePanel.hidden = false;
-    if (joinPanel) joinPanel.hidden = false;
     if (!configured) {
-      list.appendChild(el("div", "peer-meta", "Use Create invite if you are the team admin, or paste a team invite below to join."));
-      renderActionList(actions, []);
+      setupPanel.hidden = false;
+      list.hidden = true;
+      actions.hidden = true;
+      if (joinRequests) joinRequests.hidden = true;
+      if (invitePanel) invitePanel.hidden = !adminSetupExpanded;
+      if (toggleAdmin) {
+        toggleAdmin.textContent = adminSetupExpanded ? "Hide team setup" : "Set up a new team instead…";
+      }
       return;
     }
+    setupPanel.hidden = true;
+    list.hidden = false;
+    actions.hidden = false;
+    if (joinRequests) joinRequests.hidden = false;
     const presenceLabel = coordinator.presence_status === "posted" ? "Connected" : coordinator.presence_status === "not_enrolled" ? "Not connected — import an invite or ask your admin to enroll this device" : "Connection error";
-    const rows = [
-      ["Status", presenceLabel],
-      ["Paired devices", String(coordinator.paired_peer_count || 0)],
-      ["Discovered devices", String(coordinator.fresh_peer_count || 0)]
+    const statusRow = el("div", "sync-team-summary");
+    const statusLine = el("div", "sync-team-status-row");
+    const statusLabel = el("span", "sync-team-status-label", "Status");
+    const statusBadge = el(
+      "span",
+      `pill ${coordinator.presence_status === "posted" ? "pill-success" : coordinator.presence_status === "not_enrolled" ? "pill-warning" : "pill-error"}`,
+      presenceLabel
+    );
+    const metricParts = [
+      `Paired devices: ${Number(coordinator.paired_peer_count || 0)}`,
+      `Discovered: ${Number(coordinator.fresh_peer_count || 0)}`
     ];
     if (Number(coordinator.stale_peer_count || 0) > 0) {
-      rows.push(["Inactive devices", String(coordinator.stale_peer_count)]);
+      metricParts.push(`Inactive: ${Number(coordinator.stale_peer_count || 0)}`);
     }
-    rows.forEach(([label, value]) => {
-      const row = el("div", "peer-meta", `${label}: ${value}`);
-      list.appendChild(row);
+    statusLine.append(statusLabel, statusBadge);
+    statusRow.append(statusLine, el("div", "sync-team-metrics", metricParts.join(" · ")));
+    list.appendChild(statusRow);
+    const inviteToggleRow = el("div", "sync-action");
+    const inviteToggleText = el("div", "sync-action-text");
+    inviteToggleText.textContent = "Generate an invite to add another teammate to this team.";
+    const inviteToggleBtn = el("button", "settings-button", "Invite a teammate");
+    inviteToggleBtn.addEventListener("click", () => {
+      if (!invitePanel) return;
+      teamInvitePanelOpen = !teamInvitePanelOpen;
+      if (invitePanel.parentElement !== actions) actions.appendChild(invitePanel);
+      invitePanel.hidden = !teamInvitePanelOpen;
+      inviteToggleBtn.textContent = teamInvitePanelOpen ? "Hide invite form" : "Invite a teammate";
     });
-    const actionItems = [];
+    inviteToggleRow.append(inviteToggleText, inviteToggleBtn);
+    actions.appendChild(inviteToggleRow);
+    if (invitePanel) {
+      if (teamInvitePanelOpen) {
+        if (invitePanel.parentElement !== actions) actions.appendChild(invitePanel);
+        invitePanel.hidden = false;
+        inviteToggleBtn.textContent = "Hide invite form";
+      } else {
+        invitePanel.hidden = true;
+      }
+    }
     if (coordinator.presence_status === "not_enrolled") {
-      actionItems.push({ label: "This device is not connected to the team yet.", command: "Import a team invite or ask your admin to enroll this device" });
+      if (joinPanel) {
+        if (joinPanel.parentElement !== actions) actions.appendChild(joinPanel);
+        joinPanel.hidden = false;
+      }
+      const row = el("div", "sync-action");
+      const textWrap = el("div", "sync-action-text");
+      textWrap.textContent = "This device is not connected to the team yet.";
+      textWrap.appendChild(
+        el("span", "sync-action-command", "Import a team invite or ask your admin to enroll this device")
+      );
+      actions.appendChild(row);
+      row.appendChild(textWrap);
     }
     if (!Number(coordinator.paired_peer_count || 0) && coordinator.presence_status === "posted") {
-      actionItems.push({ label: "No devices are paired yet.", command: "uv run codemem sync pair --payload-only" });
+      const row = el("div", "sync-action");
+      const textWrap = el("div", "sync-action-text");
+      textWrap.textContent = "No devices are paired yet.";
+      textWrap.appendChild(el("span", "sync-action-command", "uv run codemem sync pair --payload-only"));
+      const btn = el("button", "settings-button sync-action-copy", "Copy");
+      btn.addEventListener("click", () => copyToClipboard("uv run codemem sync pair --payload-only", btn));
+      row.append(textWrap, btn);
+      actions.appendChild(row);
     }
-    renderActionList(actions, actionItems);
     const pending = Array.isArray(state.lastSyncJoinRequests) ? state.lastSyncJoinRequests : [];
     if (joinRequests && pending.length) {
       const title = el("div", "peer-meta", `${pending.length} pending join request${pending.length === 1 ? "" : "s"}`);
@@ -2127,6 +2247,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         row.append(details, rowActions);
         joinRequests.appendChild(row);
       });
+    } else if (joinRequests) {
+      joinRequests.hidden = true;
     }
   }
   function renderLegacyDeviceClaims() {
@@ -2264,6 +2386,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const syncInvitePolicy = document.getElementById("syncInvitePolicy");
     const syncInviteTtl = document.getElementById("syncInviteTtl");
     const syncInviteOutput = document.getElementById("syncInviteOutput");
+    const syncToggleAdmin = document.getElementById("syncToggleAdmin");
+    const syncInvitePanel = document.getElementById("syncInvitePanel");
     const syncJoinButton = document.getElementById("syncJoinButton");
     const syncJoinInvite = document.getElementById("syncJoinInvite");
     const syncLegacyClaimButton = document.getElementById("syncLegacyClaimButton");
@@ -2315,6 +2439,12 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       syncActorCreateButton.disabled = false;
       syncActorCreateInput.disabled = false;
     });
+    syncToggleAdmin?.addEventListener("click", () => {
+      if (!syncInvitePanel) return;
+      adminSetupExpanded = !adminSetupExpanded;
+      syncInvitePanel.hidden = !adminSetupExpanded;
+      syncToggleAdmin.textContent = adminSetupExpanded ? "Hide team setup" : "Set up a new team instead…";
+    });
     syncCreateInviteButton?.addEventListener("click", async () => {
       if (!syncCreateInviteButton || !syncInviteGroup || !syncInvitePolicy || !syncInviteTtl || !syncInviteOutput) return;
       syncCreateInviteButton.disabled = true;
@@ -2327,6 +2457,9 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         });
         state.lastTeamInvite = result;
         syncInviteOutput.value = String(result.encoded || "");
+        syncInviteOutput.hidden = false;
+        syncInviteOutput.focus();
+        syncInviteOutput.select();
         showGlobalNotice("Invite created.");
       } catch (error) {
         showGlobalNotice(error instanceof Error ? error.message : "Failed to create invite.", "warning");

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -850,6 +850,9 @@
         font-weight: 600;
       }
       .pill.alt { background: var(--accent-warm-subtle); color: var(--accent-warm); }
+      .pill-success { background: var(--green-bg, #16a34a22); color: var(--green-text, #16a34a); }
+      .pill-warning { background: var(--yellow-bg, #ca8a0422); color: var(--yellow-text, #ca8a04); }
+      .pill-error { background: var(--red-bg, #dc262622); color: var(--red-text, #dc2626); }
 
       .match {
         padding: 0 2px;
@@ -924,6 +927,67 @@
       .peer-actions { display: flex; gap: 6px; }
       .peer-actions button { border: 1px solid var(--border); background: transparent; border-radius: var(--radius-pill); padding: 5px 10px; font-family: var(--font-sans); font-size: 12px; cursor: pointer; color: var(--text-secondary); }
       .peer-actions button:hover { border-color: var(--border-hover); background: var(--surface-2); }
+      .peer-scope-editor-wrap { display: grid; gap: var(--sp-2); }
+      .sync-empty-state {
+        padding: 20px;
+        text-align: center;
+        color: var(--text-dim, var(--text-tertiary));
+        font-size: 0.9rem;
+        border: 1px dashed var(--border);
+        border-radius: 8px;
+        margin: 8px 0;
+      }
+      .sync-toggle-admin {
+        background: none;
+        border: none;
+        color: var(--text-dim, var(--text-tertiary));
+        padding: 4px 0;
+        cursor: pointer;
+        text-align: left;
+        margin-top: 16px;
+        font-size: 0.8rem;
+        text-decoration: underline;
+        text-decoration-style: dashed;
+        text-underline-offset: 3px;
+      }
+      .sync-toggle-admin:hover {
+        color: var(--accent);
+      }
+      .sync-ttl-group {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .sync-ttl-group label {
+        font-size: 0.8rem;
+        color: var(--text-dim, var(--text-tertiary));
+        white-space: nowrap;
+      }
+      .sync-team-summary {
+        display: grid;
+        gap: 8px;
+        padding: 12px 14px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        background: var(--surface-2);
+      }
+      .sync-team-status-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .sync-team-status-label {
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--text-tertiary);
+      }
+      .sync-team-metrics {
+        font-size: 13px;
+        color: var(--text-secondary);
+      }
       .sync-legacy-claim-row { margin-top: 12px; gap: 12px; align-items: center; flex-wrap: wrap; }
       .sync-legacy-select {
         min-width: 320px;
@@ -1544,19 +1608,36 @@
           </div>
         </div>
         <div class="section-meta" id="syncTeamMeta"></div>
-        <div class="actor-create-row" id="syncInvitePanel">
-          <input class="peer-scope-input" id="syncInviteGroup" placeholder="Team group" />
-          <select class="sync-actor-select" id="syncInvitePolicy">
-            <option value="auto_admit">Auto-admit</option>
-            <option value="approval_required">Approval required</option>
-          </select>
-          <input class="peer-scope-input" id="syncInviteTtl" type="number" min="1" value="24" placeholder="TTL hours" />
-          <button class="settings-button" id="syncCreateInviteButton">Create invite</button>
-        </div>
-        <textarea class="feed-search" id="syncInviteOutput" placeholder="Invite output appears here"></textarea>
-        <div class="actor-create-row" id="syncJoinPanel">
-          <textarea class="feed-search" id="syncJoinInvite" placeholder="Paste team invite or codemem:// link"></textarea>
-          <button class="settings-button" id="syncJoinButton">Join team</button>
+        <div id="syncSetupPanel">
+          <div id="syncJoinSection">
+            <h3 class="settings-group-title">Join a team</h3>
+            <div class="section-meta">Have an invite? Paste it here.</div>
+            <div class="actor-create-row" id="syncJoinPanel">
+              <textarea class="feed-search" id="syncJoinInvite" placeholder="Paste team invite or codemem:// link"></textarea>
+              <button class="settings-button" id="syncJoinButton">Join team</button>
+            </div>
+          </div>
+          <div id="syncAdminSection">
+            <button class="sync-toggle-admin" id="syncToggleAdmin">Set up a new team instead…</button>
+            <div id="syncInvitePanel" hidden>
+              <h3 class="settings-group-title" style="margin-top:12px">Create a team</h3>
+              <div class="section-meta">Generate an invite to share with teammates.</div>
+              <div class="actor-create-row">
+                <input class="peer-scope-input" id="syncInviteGroup" placeholder="Team name (e.g. my-team)" />
+                <select class="sync-actor-select" id="syncInvitePolicy">
+                  <option value="auto_admit">Auto-admit</option>
+                  <option value="approval_required">Approval required</option>
+                </select>
+                <div class="sync-ttl-group">
+                  <label for="syncInviteTtl">Expires in</label>
+                  <input class="peer-scope-input" id="syncInviteTtl" type="number" min="1" value="24" style="width:64px" />
+                  <label>hours</label>
+                </div>
+                <button class="settings-button" id="syncCreateInviteButton">Create invite</button>
+              </div>
+              <textarea class="feed-search" id="syncInviteOutput" placeholder="Invite will appear here" hidden></textarea>
+            </div>
+          </div>
         </div>
         <div class="actor-list" id="syncTeamStatus"></div>
         <div class="actor-list" id="syncJoinRequests"></div>

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -19,6 +19,10 @@ const PAIRING_FILTER_HINT =
   'On that accepting device, --include/--exclude only control what it sends to peers. ' +
   'This device does not yet enforce incoming project filters.';
 
+let adminSetupExpanded = false;
+let teamInvitePanelOpen = false;
+const openPeerScopeEditors = new Set<string>();
+
 /* ── Helpers ─────────────────────────────────────────────── */
 
 /** Redact the last two octets of IPv4 addresses while keeping the network prefix visible. */
@@ -176,6 +180,28 @@ function renderActionList(container: HTMLElement | null, actions: Array<{ label:
   });
 }
 
+function ensureInvitePanelInAdminSection() {
+  const invitePanel = document.getElementById('syncInvitePanel');
+  const adminSection = document.getElementById('syncAdminSection');
+  if (!invitePanel || !adminSection) return;
+  if (invitePanel.parentElement !== adminSection) adminSection.appendChild(invitePanel);
+}
+
+function ensureJoinPanelInSetupSection() {
+  const joinPanel = document.getElementById('syncJoinPanel');
+  const joinSection = document.getElementById('syncJoinSection');
+  if (!joinPanel || !joinSection) return;
+  if (joinPanel.parentElement !== joinSection) joinSection.appendChild(joinPanel);
+}
+
+function setInviteOutputVisibility() {
+  const syncInviteOutput = document.getElementById('syncInviteOutput') as HTMLTextAreaElement | null;
+  if (!syncInviteOutput) return;
+  const encoded = String(state.lastTeamInvite?.encoded || '').trim();
+  syncInviteOutput.value = encoded;
+  (syncInviteOutput as any).hidden = !encoded;
+}
+
 /* ── Sync status renderer ────────────────────────────────── */
 
 export function renderSyncStatus() {
@@ -289,7 +315,16 @@ export function renderSyncPeers() {
   if (!syncPeers) return;
   syncPeers.textContent = '';
   const peers = state.lastSyncPeers;
-  if (!Array.isArray(peers) || !peers.length) return;
+  if (!Array.isArray(peers) || !peers.length) {
+    syncPeers.appendChild(
+      el(
+        'div',
+        'sync-empty-state',
+        'No devices paired yet. Use the pairing command in Diagnostics to connect another device.',
+      ),
+    );
+    return;
+  }
 
   peers.forEach((peer) => {
     const card = el('div', 'peer-card');
@@ -318,6 +353,8 @@ export function renderSyncPeers() {
       syncBtn.textContent = 'Sync now';
     });
     actions.appendChild(syncBtn);
+    const toggleScopeBtn = el('button', null, 'Edit scope') as HTMLButtonElement;
+    actions.appendChild(toggleScopeBtn);
 
     const peerAddresses = Array.isArray(peer.addresses) ? Array.from(new Set(peer.addresses.filter(Boolean))) : [];
     const addressLine = peerAddresses.length
@@ -390,6 +427,9 @@ export function renderSyncPeers() {
     );
     const includeEditor = createChipEditor(includeList, 'Add included project', 'All projects');
     const excludeEditor = createChipEditor(excludeList, 'Add excluded project', 'No exclusions');
+    const editorWrap = el('div', 'peer-scope-editor-wrap');
+    const scopeEditorOpen = openPeerScopeEditors.has(peerId);
+    (editorWrap as any).hidden = !scopeEditorOpen;
     const inputRow = el('div', 'peer-scope-row');
     inputRow.append(includeEditor.element, excludeEditor.element);
     const scopeActions = el('div', 'peer-scope-actions');
@@ -426,7 +466,24 @@ export function renderSyncPeers() {
       }
     });
     scopeActions.append(saveScopeBtn, inheritBtn);
-    scopePanel.append(identityRow, identityMeta, actorRow, actorHint, scopeSummary, effectiveSummary, inputRow, scopeActions);
+    editorWrap.append(inputRow, scopeActions);
+    toggleScopeBtn.textContent = scopeEditorOpen ? 'Hide scope editor' : 'Edit scope';
+    toggleScopeBtn.addEventListener('click', () => {
+      const nextHidden = !(editorWrap as any).hidden;
+      (editorWrap as any).hidden = nextHidden;
+      if (nextHidden) openPeerScopeEditors.delete(peerId);
+      else openPeerScopeEditors.add(peerId);
+      toggleScopeBtn.textContent = nextHidden ? 'Edit scope' : 'Hide scope editor';
+    });
+    scopePanel.append(
+      identityRow,
+      identityMeta,
+      actorRow,
+      actorHint,
+      scopeSummary,
+      effectiveSummary,
+      editorWrap,
+    );
 
     titleRow.append(name, actions);
     card.append(titleRow, addressLabel, meta, scopePanel);
@@ -445,6 +502,17 @@ export function renderSyncActors() {
     actorMeta.textContent = actors.length
       ? 'Create, rename, and merge actors here. Assign each device below. Non-local actors receive memories from allowed projects unless you mark them Only me.'
       : 'No named actors yet. Create one here, then assign devices below.';
+  }
+
+  if (!actors.length) {
+    actorList.appendChild(
+      el(
+        'div',
+        'sync-empty-state',
+        'No actors yet. Create one to represent yourself or a teammate.',
+      ),
+    );
+    return;
   }
 
   actors.forEach((actor) => {
@@ -600,53 +668,113 @@ export function renderSyncSharingReview() {
 }
 
 export function renderTeamSync() {
-  const panel = document.getElementById('syncTeamCard');
   const meta = document.getElementById('syncTeamMeta');
+  const setupPanel = document.getElementById('syncSetupPanel');
   const list = document.getElementById('syncTeamStatus');
   const actions = document.getElementById('syncTeamActions');
   const invitePanel = document.getElementById('syncInvitePanel');
+  const toggleAdmin = document.getElementById('syncToggleAdmin') as HTMLButtonElement | null;
   const joinPanel = document.getElementById('syncJoinPanel');
   const joinRequests = document.getElementById('syncJoinRequests');
-  if (!panel || !meta || !list || !actions) return;
+  if (!meta || !setupPanel || !list || !actions) return;
+  // Move panels back to their home sections BEFORE clearing, so they survive the wipe
+  ensureInvitePanelInAdminSection();
+  ensureJoinPanelInSetupSection();
   list.textContent = '';
+  actions.textContent = '';
   if (joinRequests) joinRequests.textContent = '';
+  setInviteOutputVisibility();
   const coordinator = state.lastSyncCoordinator;
   const configured = Boolean(coordinator && coordinator.configured);
   meta.textContent = configured
     ? `Connected to ${String(coordinator.coordinator_url || '')} · group: ${(coordinator.groups || []).join(', ') || 'none'}`
     : 'Create a team invite or join an existing team to start syncing memories with teammates.';
-  if (invitePanel) (invitePanel as any).hidden = false;
-  if (joinPanel) (joinPanel as any).hidden = false;
   if (!configured) {
-    list.appendChild(el('div', 'peer-meta', 'Use Create invite if you are the team admin, or paste a team invite below to join.'));
-    renderActionList(actions, []);
+    (setupPanel as any).hidden = false;
+    (list as any).hidden = true;
+    (actions as any).hidden = true;
+    if (joinRequests) (joinRequests as any).hidden = true;
+    if (invitePanel) (invitePanel as any).hidden = !adminSetupExpanded;
+    if (toggleAdmin) {
+      toggleAdmin.textContent = adminSetupExpanded ? 'Hide team setup' : 'Set up a new team instead\u2026';
+    }
     return;
   }
+  (setupPanel as any).hidden = true;
+  (list as any).hidden = false;
+  (actions as any).hidden = false;
+  if (joinRequests) (joinRequests as any).hidden = false;
   const presenceLabel = coordinator.presence_status === 'posted'
     ? 'Connected'
     : coordinator.presence_status === 'not_enrolled'
       ? 'Not connected — import an invite or ask your admin to enroll this device'
       : 'Connection error';
-  const rows = [
-    ['Status', presenceLabel],
-    ['Paired devices', String(coordinator.paired_peer_count || 0)],
-    ['Discovered devices', String(coordinator.fresh_peer_count || 0)],
+  const statusRow = el('div', 'sync-team-summary');
+  const statusLine = el('div', 'sync-team-status-row');
+  const statusLabel = el('span', 'sync-team-status-label', 'Status');
+  const statusBadge = el(
+    'span',
+    `pill ${coordinator.presence_status === 'posted' ? 'pill-success' : coordinator.presence_status === 'not_enrolled' ? 'pill-warning' : 'pill-error'}`,
+    presenceLabel,
+  );
+  const metricParts = [
+    `Paired devices: ${Number(coordinator.paired_peer_count || 0)}`,
+    `Discovered: ${Number(coordinator.fresh_peer_count || 0)}`,
   ];
   if (Number(coordinator.stale_peer_count || 0) > 0) {
-    rows.push(['Inactive devices', String(coordinator.stale_peer_count)]);
+    metricParts.push(`Inactive: ${Number(coordinator.stale_peer_count || 0)}`);
   }
-  rows.forEach(([label, value]) => {
-    const row = el('div', 'peer-meta', `${label}: ${value}`);
-    list.appendChild(row);
+  statusLine.append(statusLabel, statusBadge);
+  statusRow.append(statusLine, el('div', 'sync-team-metrics', metricParts.join(' · ')));
+  list.appendChild(statusRow);
+
+  const inviteToggleRow = el('div', 'sync-action');
+  const inviteToggleText = el('div', 'sync-action-text');
+  inviteToggleText.textContent = 'Generate an invite to add another teammate to this team.';
+  const inviteToggleBtn = el('button', 'settings-button', 'Invite a teammate') as HTMLButtonElement;
+  inviteToggleBtn.addEventListener('click', () => {
+    if (!invitePanel) return;
+    teamInvitePanelOpen = !teamInvitePanelOpen;
+    if (invitePanel.parentElement !== actions) actions.appendChild(invitePanel);
+    (invitePanel as any).hidden = !teamInvitePanelOpen;
+    inviteToggleBtn.textContent = teamInvitePanelOpen ? 'Hide invite form' : 'Invite a teammate';
   });
-  const actionItems: Array<{ label: string; command: string }> = [];
+  inviteToggleRow.append(inviteToggleText, inviteToggleBtn);
+  actions.appendChild(inviteToggleRow);
+  if (invitePanel) {
+    if (teamInvitePanelOpen) {
+      if (invitePanel.parentElement !== actions) actions.appendChild(invitePanel);
+      (invitePanel as any).hidden = false;
+      inviteToggleBtn.textContent = 'Hide invite form';
+    } else {
+      (invitePanel as any).hidden = true;
+    }
+  }
+
   if (coordinator.presence_status === 'not_enrolled') {
-    actionItems.push({ label: 'This device is not connected to the team yet.', command: 'Import a team invite or ask your admin to enroll this device' });
+    if (joinPanel) {
+      if (joinPanel.parentElement !== actions) actions.appendChild(joinPanel);
+      (joinPanel as any).hidden = false;
+    }
+    const row = el('div', 'sync-action');
+    const textWrap = el('div', 'sync-action-text');
+    textWrap.textContent = 'This device is not connected to the team yet.';
+    textWrap.appendChild(
+      el('span', 'sync-action-command', 'Import a team invite or ask your admin to enroll this device'),
+    );
+    actions.appendChild(row);
+    row.appendChild(textWrap);
   }
   if (!Number(coordinator.paired_peer_count || 0) && coordinator.presence_status === 'posted') {
-    actionItems.push({ label: 'No devices are paired yet.', command: 'uv run codemem sync pair --payload-only' });
+    const row = el('div', 'sync-action');
+    const textWrap = el('div', 'sync-action-text');
+    textWrap.textContent = 'No devices are paired yet.';
+    textWrap.appendChild(el('span', 'sync-action-command', 'uv run codemem sync pair --payload-only'));
+    const btn = el('button', 'settings-button sync-action-copy', 'Copy') as HTMLButtonElement;
+    btn.addEventListener('click', () => copyToClipboard('uv run codemem sync pair --payload-only', btn));
+    row.append(textWrap, btn);
+    actions.appendChild(row);
   }
-  renderActionList(actions, actionItems);
 
   const pending = Array.isArray(state.lastSyncJoinRequests) ? state.lastSyncJoinRequests : [];
   if (joinRequests && pending.length) {
@@ -695,6 +823,8 @@ export function renderTeamSync() {
       row.append(details, rowActions);
       joinRequests.appendChild(row);
     });
+  } else if (joinRequests) {
+    (joinRequests as any).hidden = true;
   }
 }
 
@@ -852,6 +982,8 @@ export function initSyncTab(refreshCallback: () => void) {
   const syncInvitePolicy = document.getElementById('syncInvitePolicy') as HTMLSelectElement | null;
   const syncInviteTtl = document.getElementById('syncInviteTtl') as HTMLInputElement | null;
   const syncInviteOutput = document.getElementById('syncInviteOutput') as HTMLTextAreaElement | null;
+  const syncToggleAdmin = document.getElementById('syncToggleAdmin') as HTMLButtonElement | null;
+  const syncInvitePanel = document.getElementById('syncInvitePanel');
   const syncJoinButton = document.getElementById('syncJoinButton') as HTMLButtonElement | null;
   const syncJoinInvite = document.getElementById('syncJoinInvite') as HTMLTextAreaElement | null;
   const syncLegacyClaimButton = document.getElementById('syncLegacyClaimButton') as HTMLButtonElement | null;
@@ -909,6 +1041,13 @@ export function initSyncTab(refreshCallback: () => void) {
     syncActorCreateInput.disabled = false;
   });
 
+  syncToggleAdmin?.addEventListener('click', () => {
+    if (!syncInvitePanel) return;
+    adminSetupExpanded = !adminSetupExpanded;
+    (syncInvitePanel as any).hidden = !adminSetupExpanded;
+    syncToggleAdmin.textContent = adminSetupExpanded ? 'Hide team setup' : 'Set up a new team instead\u2026';
+  });
+
   syncCreateInviteButton?.addEventListener('click', async () => {
     if (!syncCreateInviteButton || !syncInviteGroup || !syncInvitePolicy || !syncInviteTtl || !syncInviteOutput) return;
     syncCreateInviteButton.disabled = true;
@@ -921,6 +1060,9 @@ export function initSyncTab(refreshCallback: () => void) {
       });
       state.lastTeamInvite = result;
       syncInviteOutput.value = String(result.encoded || '');
+      (syncInviteOutput as any).hidden = false;
+      syncInviteOutput.focus();
+      syncInviteOutput.select();
       showGlobalNotice('Invite created.');
     } catch (error) {
       showGlobalNotice(error instanceof Error ? error.message : 'Failed to create invite.', 'warning');


### PR DESCRIPTION
## Description

Improve Sync tab onboarding UX based on frontend-orchestrator maturity review. The tab was at Level 2 — structurally sound after the nm7 reorganization but confusing for first-time users.

### Changes

**Admin/teammate flow separation** (biggest dogfooding blocker)
- Teammate "Join a team" path is now prominent and visible by default
- Admin "Create a team" path collapsed behind a dashed-border toggle ("I'm setting up a new team")
- When coordinator is already configured, both setup paths hide and compact status appears
- Configured users get an "Invite a teammate" button that reveals the invite form inline

**Empty states**
- No actors: "No actors yet. Create one to represent yourself or a teammate."
- No devices: "No devices paired yet. Use the pairing command in Diagnostics to connect another device."
- Styled with dashed border and centered text (`.sync-empty-state`)

**Status visual weight**
- Connection status now uses pill badges: green "Connected", yellow "Not connected", red "Connection error"
- Paired/discovered device counts shown as compact secondary text

**Form UX improvements**
- Invite output textarea hidden until an invite is actually created
- Auto-selects invite text after creation for easy copy
- Better placeholder text ("Team name (e.g. my-team)")

**Device scope collapse**
- Per-device scope chip editors collapsed behind "Edit scope" toggle
- Actor assignment select stays visible (primary action)
- Reduces People card scroll depth with multiple devices

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `bun run check` — TypeScript passes
- `bun run build` — bundle built (153.76 kB)
- `uv run ruff check codemem tests` — all pass
- `uv run pytest tests/test_sync_viewer_api.py` — all pass

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced