### PR TITLE
refactor: add error handling and inline validation to Sync tab

### DIFF
--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1527,6 +1527,37 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       updateFeedView(true);
     }
   }
+  function shakeField(input) {
+    input.classList.add("sync-shake");
+    input.addEventListener("animationend", () => input.classList.remove("sync-shake"), { once: true });
+  }
+  function markFieldError(input, message) {
+    input.classList.add("sync-field-error");
+    const existing = input.parentElement?.querySelector(".sync-field-hint");
+    if (existing) existing.remove();
+    const hint = document.createElement("div");
+    hint.className = "sync-field-hint";
+    hint.textContent = message;
+    input.insertAdjacentElement("afterend", hint);
+    shakeField(input);
+    input.addEventListener("input", () => clearFieldError(input), { once: true });
+    return false;
+  }
+  function clearFieldError(input) {
+    input.classList.remove("sync-field-error");
+    const hint = input.parentElement?.querySelector(".sync-field-hint");
+    if (hint) hint.remove();
+  }
+  function friendlyError(error, fallback) {
+    if (error instanceof Error) {
+      const msg = error.message;
+      if (msg.includes("fetch") || msg.includes("network") || msg.includes("Failed to fetch")) {
+        return "Network error — check your connection and try again.";
+      }
+      return msg;
+    }
+    return fallback;
+  }
   let adminSetupExpanded = false;
   let teamInvitePanelOpen = false;
   const openPeerScopeEditors = /* @__PURE__ */ new Set();
@@ -1856,7 +1887,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
           showGlobalNotice(actorSelect.value ? "Device actor updated." : "Device actor cleared.");
           await loadSyncData();
         } catch (error) {
-          showGlobalNotice(error instanceof Error ? error.message : "Failed to update device actor.", "warning");
+          showGlobalNotice(friendlyError(error, "Failed to update device actor."), "warning");
           applyActorBtn.textContent = "Retry";
         } finally {
           actorSelect.disabled = false;
@@ -1893,7 +1924,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
           showGlobalNotice("Device sync scope saved.");
           await loadSyncData();
         } catch (error) {
-          showGlobalNotice(error instanceof Error ? error.message : "Failed to save device scope.", "warning");
+          showGlobalNotice(friendlyError(error, "Failed to save device scope."), "warning");
           saveScopeBtn.textContent = "Retry save";
         } finally {
           saveScopeBtn.disabled = false;
@@ -1908,7 +1939,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
           showGlobalNotice("Device sync scope reset to global defaults.");
           await loadSyncData();
         } catch (error) {
-          showGlobalNotice(error instanceof Error ? error.message : "Failed to reset device scope.", "warning");
+          showGlobalNotice(friendlyError(error, "Failed to reset device scope."), "warning");
           inheritBtn.textContent = "Retry reset";
         } finally {
           inheritBtn.disabled = false;
@@ -2041,7 +2072,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
             showGlobalNotice("Actor merged. Assigned devices moved to the selected actor.");
             await loadSyncData();
           } catch (error) {
-            showGlobalNotice(error instanceof Error ? error.message : "Failed to merge actor.", "warning");
+            showGlobalNotice(friendlyError(error, "Failed to merge actor."), "warning");
             mergeBtn.textContent = "Retry merge";
           } finally {
             mergeBtn.disabled = mergeTargets.length === 0;
@@ -2218,26 +2249,31 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         approveBtn.addEventListener("click", async () => {
           approveBtn.disabled = true;
           denyBtn.disabled = true;
+          approveBtn.textContent = "Approving…";
           try {
             await reviewJoinRequest(String(request.request_id || ""), "approve");
-            showGlobalNotice("Join request approved.");
+            showGlobalNotice(`Approved ${name}. They can now sync with the team.`);
             await loadSyncData();
           } catch (error) {
-            showGlobalNotice(error instanceof Error ? error.message : "Failed to approve join request.", "warning");
+            showGlobalNotice(friendlyError(error, "Failed to approve join request."), "warning");
+            approveBtn.textContent = "Retry";
           } finally {
             approveBtn.disabled = false;
             denyBtn.disabled = false;
           }
         });
         denyBtn.addEventListener("click", async () => {
+          if (!window.confirm(`Deny join request from ${name}? They will need a new invite to try again.`)) return;
           approveBtn.disabled = true;
           denyBtn.disabled = true;
+          denyBtn.textContent = "Denying…";
           try {
             await reviewJoinRequest(String(request.request_id || ""), "deny");
-            showGlobalNotice("Join request denied.");
+            showGlobalNotice(`Denied join request from ${name}.`);
             await loadSyncData();
           } catch (error) {
-            showGlobalNotice(error instanceof Error ? error.message : "Failed to deny join request.", "warning");
+            showGlobalNotice(friendlyError(error, "Failed to deny join request."), "warning");
+            denyBtn.textContent = "Retry deny";
           } finally {
             approveBtn.disabled = false;
             denyBtn.disabled = false;
@@ -2418,8 +2454,13 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       renderPairing();
     });
     syncActorCreateButton?.addEventListener("click", async () => {
-      const displayName = String(syncActorCreateInput?.value || "").trim();
-      if (!displayName || !syncActorCreateButton || !syncActorCreateInput) return;
+      if (!syncActorCreateButton || !syncActorCreateInput) return;
+      const displayName = String(syncActorCreateInput.value || "").trim();
+      if (!displayName) {
+        markFieldError(syncActorCreateInput, "Enter a name for the actor.");
+        return;
+      }
+      clearFieldError(syncActorCreateInput);
       syncActorCreateButton.disabled = true;
       syncActorCreateInput.disabled = true;
       syncActorCreateButton.textContent = "Creating...";
@@ -2429,8 +2470,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         syncActorCreateInput.value = "";
         await loadSyncData();
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : "Failed to create actor.", "warning");
-        syncActorCreateButton.textContent = "Retry create";
+        showGlobalNotice(friendlyError(error, "Failed to create actor."), "warning");
+        syncActorCreateButton.textContent = "Retry";
         syncActorCreateButton.disabled = false;
         syncActorCreateInput.disabled = false;
         return;
@@ -2447,22 +2488,36 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     });
     syncCreateInviteButton?.addEventListener("click", async () => {
       if (!syncCreateInviteButton || !syncInviteGroup || !syncInvitePolicy || !syncInviteTtl || !syncInviteOutput) return;
+      const groupName = syncInviteGroup.value.trim();
+      const ttlValue = Number(syncInviteTtl.value);
+      let valid = true;
+      if (!groupName) {
+        valid = markFieldError(syncInviteGroup, "Team name is required.");
+      } else {
+        clearFieldError(syncInviteGroup);
+      }
+      if (!ttlValue || ttlValue < 1) {
+        valid = markFieldError(syncInviteTtl, "Must be at least 1 hour.");
+      } else {
+        clearFieldError(syncInviteTtl);
+      }
+      if (!valid) return;
       syncCreateInviteButton.disabled = true;
-      syncCreateInviteButton.textContent = "Creating...";
+      syncCreateInviteButton.textContent = "Creating…";
       try {
         const result = await createCoordinatorInvite({
-          group_id: syncInviteGroup.value.trim(),
+          group_id: groupName,
           policy: syncInvitePolicy.value,
-          ttl_hours: Number(syncInviteTtl.value || 24) || 24
+          ttl_hours: ttlValue || 24
         });
         state.lastTeamInvite = result;
         syncInviteOutput.value = String(result.encoded || "");
         syncInviteOutput.hidden = false;
         syncInviteOutput.focus();
         syncInviteOutput.select();
-        showGlobalNotice("Invite created.");
+        showGlobalNotice("Invite created. Copy the text above and share it with your teammate.");
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : "Failed to create invite.", "warning");
+        showGlobalNotice(friendlyError(error, "Failed to create invite."), "warning");
       } finally {
         syncCreateInviteButton.disabled = false;
         syncCreateInviteButton.textContent = "Create invite";
@@ -2470,15 +2525,22 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     });
     syncJoinButton?.addEventListener("click", async () => {
       if (!syncJoinButton || !syncJoinInvite) return;
+      const inviteValue = syncJoinInvite.value.trim();
+      if (!inviteValue) {
+        markFieldError(syncJoinInvite, "Paste a team invite to join.");
+        return;
+      }
+      clearFieldError(syncJoinInvite);
       syncJoinButton.disabled = true;
-      syncJoinButton.textContent = "Joining...";
+      syncJoinButton.textContent = "Joining…";
       try {
-        const result = await importCoordinatorInvite(syncJoinInvite.value.trim());
+        const result = await importCoordinatorInvite(inviteValue);
         state.lastTeamJoin = result;
-        showGlobalNotice(result.status === "pending" ? "Join request submitted. Waiting for approval." : "Team invite imported.");
+        showGlobalNotice(result.status === "pending" ? "Join request submitted — waiting for admin approval." : "Joined team successfully.");
+        syncJoinInvite.value = "";
         await loadSyncData();
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : "Failed to import invite.", "warning");
+        showGlobalNotice(friendlyError(error, "Failed to import invite."), "warning");
       } finally {
         syncJoinButton.disabled = false;
         syncJoinButton.textContent = "Join team";
@@ -2496,8 +2558,8 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         showGlobalNotice("Old device history attached to your local actor.");
         await loadSyncData();
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : "Failed to attach old device history.", "warning");
-        syncLegacyClaimButton.textContent = "Retry claim";
+        showGlobalNotice(friendlyError(error, "Failed to attach old device history."), "warning");
+        syncLegacyClaimButton.textContent = "Retry";
         syncLegacyClaimButton.disabled = false;
         return;
       }
@@ -2512,7 +2574,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         await triggerSync();
         showGlobalNotice("Sync pass started.");
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : "Failed to start sync.", "warning");
+        showGlobalNotice(friendlyError(error, "Failed to start sync."), "warning");
       }
       syncNowButton.disabled = false;
       syncNowButton.textContent = "Sync now";

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -937,6 +937,25 @@
         border-radius: 8px;
         margin: 8px 0;
       }
+      .sync-field-error {
+        outline: 1.5px solid var(--red-text, #dc2626) !important;
+        outline-offset: -1px;
+      }
+      .sync-field-hint {
+        font-size: 0.78rem;
+        color: var(--red-text, #dc2626);
+        margin: 2px 0 0 2px;
+      }
+      @keyframes sync-shake {
+        0%, 100% { transform: translateX(0); }
+        20%, 60% { transform: translateX(-4px); }
+        40%, 80% { transform: translateX(4px); }
+      }
+      .sync-shake { animation: sync-shake 0.3s ease-in-out; }
+      .settings-button:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
       .sync-toggle-admin {
         background: none;
         border: none;

--- a/viewer_ui/src/tabs/sync.ts
+++ b/viewer_ui/src/tabs/sync.ts
@@ -14,6 +14,44 @@ import * as api from '../lib/api';
 import { showGlobalNotice } from '../lib/notice';
 import { renderHealthOverview } from './health';
 
+/* ── Validation helpers ───────────────────────────────────── */
+
+function shakeField(input: HTMLElement): void {
+  input.classList.add('sync-shake');
+  input.addEventListener('animationend', () => input.classList.remove('sync-shake'), { once: true });
+}
+
+function markFieldError(input: HTMLInputElement | HTMLTextAreaElement, message: string): boolean {
+  input.classList.add('sync-field-error');
+  // Remove existing hint if any
+  const existing = input.parentElement?.querySelector('.sync-field-hint');
+  if (existing) existing.remove();
+  const hint = document.createElement('div');
+  hint.className = 'sync-field-hint';
+  hint.textContent = message;
+  input.insertAdjacentElement('afterend', hint);
+  shakeField(input);
+  input.addEventListener('input', () => clearFieldError(input), { once: true });
+  return false;
+}
+
+function clearFieldError(input: HTMLInputElement | HTMLTextAreaElement): void {
+  input.classList.remove('sync-field-error');
+  const hint = input.parentElement?.querySelector('.sync-field-hint');
+  if (hint) hint.remove();
+}
+
+function friendlyError(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    const msg = error.message;
+    if (msg.includes('fetch') || msg.includes('network') || msg.includes('Failed to fetch')) {
+      return 'Network error — check your connection and try again.';
+    }
+    return msg;
+  }
+  return fallback;
+}
+
 const PAIRING_FILTER_HINT =
   "Run this on another device with codemem sync pair --accept '<payload>'. " +
   'On that accepting device, --include/--exclude only control what it sends to peers. ' +
@@ -404,7 +442,7 @@ export function renderSyncPeers() {
         showGlobalNotice(actorSelect.value ? 'Device actor updated.' : 'Device actor cleared.');
         await loadSyncData();
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : 'Failed to update device actor.', 'warning');
+        showGlobalNotice(friendlyError(error, 'Failed to update device actor.'), 'warning');
         applyActorBtn.textContent = 'Retry';
       } finally {
         actorSelect.disabled = false;
@@ -443,7 +481,7 @@ export function renderSyncPeers() {
         showGlobalNotice('Device sync scope saved.');
         await loadSyncData();
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : 'Failed to save device scope.', 'warning');
+        showGlobalNotice(friendlyError(error, 'Failed to save device scope.'), 'warning');
         saveScopeBtn.textContent = 'Retry save';
       } finally {
         saveScopeBtn.disabled = false;
@@ -458,7 +496,7 @@ export function renderSyncPeers() {
         showGlobalNotice('Device sync scope reset to global defaults.');
         await loadSyncData();
       } catch (error) {
-        showGlobalNotice(error instanceof Error ? error.message : 'Failed to reset device scope.', 'warning');
+        showGlobalNotice(friendlyError(error, 'Failed to reset device scope.'), 'warning');
         inheritBtn.textContent = 'Retry reset';
       } finally {
         inheritBtn.disabled = false;
@@ -603,7 +641,7 @@ export function renderSyncActors() {
           showGlobalNotice('Actor merged. Assigned devices moved to the selected actor.');
           await loadSyncData();
         } catch (error) {
-          showGlobalNotice(error instanceof Error ? error.message : 'Failed to merge actor.', 'warning');
+          showGlobalNotice(friendlyError(error, 'Failed to merge actor.'), 'warning');
           mergeBtn.textContent = 'Retry merge';
         } finally {
           mergeBtn.disabled = mergeTargets.length === 0;
@@ -794,26 +832,31 @@ export function renderTeamSync() {
       approveBtn.addEventListener('click', async () => {
         approveBtn.disabled = true;
         denyBtn.disabled = true;
+        approveBtn.textContent = 'Approving\u2026';
         try {
           await api.reviewJoinRequest(String(request.request_id || ''), 'approve');
-          showGlobalNotice('Join request approved.');
+          showGlobalNotice(`Approved ${name}. They can now sync with the team.`);
           await loadSyncData();
         } catch (error) {
-          showGlobalNotice(error instanceof Error ? error.message : 'Failed to approve join request.', 'warning');
+          showGlobalNotice(friendlyError(error, 'Failed to approve join request.'), 'warning');
+          approveBtn.textContent = 'Retry';
         } finally {
           approveBtn.disabled = false;
           denyBtn.disabled = false;
         }
       });
       denyBtn.addEventListener('click', async () => {
+        if (!window.confirm(`Deny join request from ${name}? They will need a new invite to try again.`)) return;
         approveBtn.disabled = true;
         denyBtn.disabled = true;
+        denyBtn.textContent = 'Denying\u2026';
         try {
           await api.reviewJoinRequest(String(request.request_id || ''), 'deny');
-          showGlobalNotice('Join request denied.');
+          showGlobalNotice(`Denied join request from ${name}.`);
           await loadSyncData();
         } catch (error) {
-          showGlobalNotice(error instanceof Error ? error.message : 'Failed to deny join request.', 'warning');
+          showGlobalNotice(friendlyError(error, 'Failed to deny join request.'), 'warning');
+          denyBtn.textContent = 'Retry deny';
         } finally {
           approveBtn.disabled = false;
           denyBtn.disabled = false;
@@ -1019,8 +1062,13 @@ export function initSyncTab(refreshCallback: () => void) {
   });
 
   syncActorCreateButton?.addEventListener('click', async () => {
-    const displayName = String(syncActorCreateInput?.value || '').trim();
-    if (!displayName || !syncActorCreateButton || !syncActorCreateInput) return;
+    if (!syncActorCreateButton || !syncActorCreateInput) return;
+    const displayName = String(syncActorCreateInput.value || '').trim();
+    if (!displayName) {
+      markFieldError(syncActorCreateInput, 'Enter a name for the actor.');
+      return;
+    }
+    clearFieldError(syncActorCreateInput);
     syncActorCreateButton.disabled = true;
     syncActorCreateInput.disabled = true;
     syncActorCreateButton.textContent = 'Creating...';
@@ -1030,8 +1078,8 @@ export function initSyncTab(refreshCallback: () => void) {
       syncActorCreateInput.value = '';
       await loadSyncData();
     } catch (error) {
-      showGlobalNotice(error instanceof Error ? error.message : 'Failed to create actor.', 'warning');
-      syncActorCreateButton.textContent = 'Retry create';
+      showGlobalNotice(friendlyError(error, 'Failed to create actor.'), 'warning');
+      syncActorCreateButton.textContent = 'Retry';
       syncActorCreateButton.disabled = false;
       syncActorCreateInput.disabled = false;
       return;
@@ -1050,22 +1098,37 @@ export function initSyncTab(refreshCallback: () => void) {
 
   syncCreateInviteButton?.addEventListener('click', async () => {
     if (!syncCreateInviteButton || !syncInviteGroup || !syncInvitePolicy || !syncInviteTtl || !syncInviteOutput) return;
+    // Inline validation
+    const groupName = syncInviteGroup.value.trim();
+    const ttlValue = Number(syncInviteTtl.value);
+    let valid = true;
+    if (!groupName) {
+      valid = markFieldError(syncInviteGroup, 'Team name is required.');
+    } else {
+      clearFieldError(syncInviteGroup);
+    }
+    if (!ttlValue || ttlValue < 1) {
+      valid = markFieldError(syncInviteTtl, 'Must be at least 1 hour.');
+    } else {
+      clearFieldError(syncInviteTtl);
+    }
+    if (!valid) return;
     syncCreateInviteButton.disabled = true;
-    syncCreateInviteButton.textContent = 'Creating...';
+    syncCreateInviteButton.textContent = 'Creating\u2026';
     try {
       const result = await api.createCoordinatorInvite({
-        group_id: syncInviteGroup.value.trim(),
+        group_id: groupName,
         policy: syncInvitePolicy.value as 'auto_admit' | 'approval_required',
-        ttl_hours: Number(syncInviteTtl.value || 24) || 24,
+        ttl_hours: ttlValue || 24,
       });
       state.lastTeamInvite = result;
       syncInviteOutput.value = String(result.encoded || '');
       (syncInviteOutput as any).hidden = false;
       syncInviteOutput.focus();
       syncInviteOutput.select();
-      showGlobalNotice('Invite created.');
+      showGlobalNotice('Invite created. Copy the text above and share it with your teammate.');
     } catch (error) {
-      showGlobalNotice(error instanceof Error ? error.message : 'Failed to create invite.', 'warning');
+      showGlobalNotice(friendlyError(error, 'Failed to create invite.'), 'warning');
     } finally {
       syncCreateInviteButton.disabled = false;
       syncCreateInviteButton.textContent = 'Create invite';
@@ -1074,15 +1137,22 @@ export function initSyncTab(refreshCallback: () => void) {
 
   syncJoinButton?.addEventListener('click', async () => {
     if (!syncJoinButton || !syncJoinInvite) return;
+    const inviteValue = syncJoinInvite.value.trim();
+    if (!inviteValue) {
+      markFieldError(syncJoinInvite, 'Paste a team invite to join.');
+      return;
+    }
+    clearFieldError(syncJoinInvite);
     syncJoinButton.disabled = true;
-    syncJoinButton.textContent = 'Joining...';
+    syncJoinButton.textContent = 'Joining\u2026';
     try {
-      const result = await api.importCoordinatorInvite(syncJoinInvite.value.trim());
+      const result = await api.importCoordinatorInvite(inviteValue);
       state.lastTeamJoin = result;
-      showGlobalNotice(result.status === 'pending' ? 'Join request submitted. Waiting for approval.' : 'Team invite imported.');
+      showGlobalNotice(result.status === 'pending' ? 'Join request submitted — waiting for admin approval.' : 'Joined team successfully.');
+      syncJoinInvite.value = '';
       await loadSyncData();
     } catch (error) {
-      showGlobalNotice(error instanceof Error ? error.message : 'Failed to import invite.', 'warning');
+      showGlobalNotice(friendlyError(error, 'Failed to import invite.'), 'warning');
     } finally {
       syncJoinButton.disabled = false;
       syncJoinButton.textContent = 'Join team';
@@ -1101,8 +1171,8 @@ export function initSyncTab(refreshCallback: () => void) {
       showGlobalNotice('Old device history attached to your local actor.');
       await loadSyncData();
     } catch (error) {
-      showGlobalNotice(error instanceof Error ? error.message : 'Failed to attach old device history.', 'warning');
-      syncLegacyClaimButton.textContent = 'Retry claim';
+      showGlobalNotice(friendlyError(error, 'Failed to attach old device history.'), 'warning');
+      syncLegacyClaimButton.textContent = 'Retry';
       syncLegacyClaimButton.disabled = false;
       return;
     }
@@ -1118,7 +1188,7 @@ export function initSyncTab(refreshCallback: () => void) {
       await api.triggerSync();
       showGlobalNotice('Sync pass started.');
     } catch (error) {
-      showGlobalNotice(error instanceof Error ? error.message : 'Failed to start sync.', 'warning');
+      showGlobalNotice(friendlyError(error, 'Failed to start sync.'), 'warning');
     }
     syncNowButton.disabled = false;
     syncNowButton.textContent = 'Sync now';


### PR DESCRIPTION
## Description

Apply the **error-handling-recovery** skill from the frontend-orchestrator sequence to the Sync tab.

### Inline validation
- **Create invite**: validates team name (required) and TTL (≥1 hour) before submitting. Invalid fields get a red outline, shake animation, and inline hint text. Errors auto-clear on next input.
- **Join team**: validates invite textarea is not empty before submitting.
- **Create actor**: validates name is not empty before submitting.

### Destructive action confirmation
- **Deny join request** now shows `window.confirm` with the device name and a note that they'll need a new invite.

### Contextual error messages
- All error paths use `friendlyError()` which detects network/fetch failures and returns "Network error — check your connection and try again." instead of raw exception text.
- Approve/deny success messages include the device name for clarity.
- Invite creation success message says "Copy the text above and share it with your teammate."
- Join success differentiates "waiting for admin approval" from immediate join.

### Async operation feedback
- Disabled buttons get `opacity: 0.55` and `cursor: not-allowed` via CSS.
- Failed operations show "Retry" as button text instead of generic labels.
- Invite input clears on successful join.

### CSS additions
- `.sync-field-error` — red outline on invalid fields
- `.sync-field-hint` — small red text below invalid fields
- `@keyframes sync-shake` — subtle shake animation (0.3s)
- `.settings-button:disabled` — opacity treatment

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Manually verified changes work as expected
- `bun run check` — TypeScript passes
- `bun run build` — bundle built
- `uv run ruff check codemem tests` — all pass
- `uv run pytest tests/test_sync_viewer_api.py` — all pass

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced