### PR TITLE
feat: add skeleton loading states to Sync tab

### DIFF
--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1527,6 +1527,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       updateFeedView(true);
     }
   }
+  function hideSkeleton(id) {
+    const skeleton = document.getElementById(id);
+    if (skeleton) skeleton.remove();
+  }
   let adminSetupExpanded = false;
   function setAdminSetupExpanded(v) {
     adminSetupExpanded = v;
@@ -1682,6 +1686,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const syncMeta = document.getElementById("syncMeta");
     const syncActions = document.getElementById("syncActions");
     if (!syncStatusGrid) return;
+    hideSkeleton("syncDiagSkeleton");
     syncStatusGrid.textContent = "";
     const status = state.lastSyncStatus;
     if (!status) {
@@ -1998,6 +2003,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const joinPanel = document.getElementById("syncJoinPanel");
     const joinRequests = document.getElementById("syncJoinRequests");
     if (!meta || !setupPanel || !list || !actions) return;
+    hideSkeleton("syncTeamSkeleton");
     ensureInvitePanelInAdminSection();
     ensureJoinPanelInSetupSection();
     list.textContent = "";
@@ -2271,6 +2277,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const actorList = document.getElementById("syncActorsList");
     const actorMeta = document.getElementById("syncActorsMeta");
     if (!actorList) return;
+    hideSkeleton("syncActorsSkeleton");
     actorList.textContent = "";
     const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
     if (actorMeta) {
@@ -2398,6 +2405,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
   function renderSyncPeers() {
     const syncPeers = document.getElementById("syncPeers");
     if (!syncPeers) return;
+    hideSkeleton("syncPeersSkeleton");
     syncPeers.textContent = "";
     const peers = state.lastSyncPeers;
     if (!Array.isArray(peers) || !peers.length) {
@@ -2702,6 +2710,10 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
           actorMeta.textContent = "Actor controls are temporarily unavailable. Peer status and sync health still loaded.";
       }
     } catch {
+      hideSkeleton("syncTeamSkeleton");
+      hideSkeleton("syncActorsSkeleton");
+      hideSkeleton("syncPeersSkeleton");
+      hideSkeleton("syncDiagSkeleton");
       const syncMeta = document.getElementById("syncMeta");
       if (syncMeta) syncMeta.textContent = "Sync unavailable";
     }

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -928,6 +928,30 @@
       .peer-actions button { border: 1px solid var(--border); background: transparent; border-radius: var(--radius-pill); padding: 5px 10px; font-family: var(--font-sans); font-size: 12px; cursor: pointer; color: var(--text-secondary); }
       .peer-actions button:hover { border-color: var(--border-hover); background: var(--surface-2); }
       .peer-scope-editor-wrap { display: grid; gap: var(--sp-2); }
+      @keyframes sync-shimmer {
+        0% { background-position: -200px 0; }
+        100% { background-position: 200px 0; }
+      }
+      .sync-skeleton { padding: 16px 0; }
+      .sync-skeleton-line {
+        height: 12px;
+        border-radius: 6px;
+        background: linear-gradient(90deg, var(--border) 25%, var(--surface-2) 50%, var(--border) 75%);
+        background-size: 400px 100%;
+        animation: sync-shimmer 1.5s ease-in-out infinite;
+        margin: 8px 0;
+      }
+      .sync-skeleton-line.short { width: 40%; }
+      .sync-skeleton-line.medium { width: 65%; }
+      .sync-skeleton-line.long { width: 85%; }
+      .sync-skeleton-block {
+        height: 56px;
+        border-radius: 8px;
+        background: linear-gradient(90deg, var(--border) 25%, var(--surface-2) 50%, var(--border) 75%);
+        background-size: 400px 100%;
+        animation: sync-shimmer 1.5s ease-in-out infinite;
+        margin: 8px 0;
+      }
       .sync-empty-state {
         padding: 20px;
         text-align: center;
@@ -1627,6 +1651,11 @@
           </div>
         </div>
         <div class="section-meta" id="syncTeamMeta"></div>
+        <div class="sync-skeleton" id="syncTeamSkeleton">
+          <div class="sync-skeleton-line medium"></div>
+          <div class="sync-skeleton-block"></div>
+          <div class="sync-skeleton-line short"></div>
+        </div>
         <div id="syncSetupPanel">
           <div id="syncJoinSection">
             <h3 class="settings-group-title">Join a team</h3>
@@ -1674,9 +1703,17 @@
           <button class="settings-button" id="syncActorCreateButton">Create actor</button>
         </div>
         <div class="actor-list" id="syncActorsList"></div>
+        <div class="sync-skeleton" id="syncActorsSkeleton">
+          <div class="sync-skeleton-line long"></div>
+          <div class="sync-skeleton-line medium"></div>
+        </div>
 
         <h3 class="settings-group-title" style="margin-top: 20px">Devices</h3>
         <div class="peer-list" id="syncPeers"></div>
+        <div class="sync-skeleton" id="syncPeersSkeleton">
+          <div class="sync-skeleton-block"></div>
+          <div class="sync-skeleton-block"></div>
+        </div>
 
         <div id="syncSharingReview" hidden>
           <h3 class="settings-group-title" style="margin-top: 20px">What teammates will receive</h3>
@@ -1707,6 +1744,11 @@
           </div>
         </div>
         <div class="section-meta" id="syncMeta">Loading sync status…</div>
+        <div class="sync-skeleton" id="syncDiagSkeleton">
+          <div class="sync-skeleton-line long"></div>
+          <div class="sync-skeleton-line medium"></div>
+          <div class="sync-skeleton-line short"></div>
+        </div>
         <div class="sync-actions" id="syncActions"></div>
         <div class="grid-2" id="syncStatusGrid"></div>
 

--- a/viewer_ui/src/tabs/sync/diagnostics.ts
+++ b/viewer_ui/src/tabs/sync/diagnostics.ts
@@ -9,7 +9,7 @@ import {
   isSyncRedactionEnabled,
   setSyncRedactionEnabled,
 } from '../../lib/state';
-import { redactAddress, renderActionList } from './helpers';
+import { redactAddress, renderActionList, hideSkeleton } from './helpers';
 
 /* ── Import render functions needed for redact toggle ────── */
 // These are set by the index module to avoid circular imports.
@@ -25,6 +25,7 @@ export function renderSyncStatus() {
   const syncMeta = document.getElementById('syncMeta');
   const syncActions = document.getElementById('syncActions');
   if (!syncStatusGrid) return;
+  hideSkeleton('syncDiagSkeleton');
   syncStatusGrid.textContent = '';
 
   const status = state.lastSyncStatus;

--- a/viewer_ui/src/tabs/sync/helpers.ts
+++ b/viewer_ui/src/tabs/sync/helpers.ts
@@ -3,6 +3,13 @@
 import { el, copyToClipboard } from '../../lib/dom';
 import { state } from '../../lib/state';
 
+/* ── Skeleton helpers ────────────────────────────────────── */
+
+export function hideSkeleton(id: string): void {
+  const skeleton = document.getElementById(id);
+  if (skeleton) skeleton.remove();
+}
+
 /* ── Module-level UI state ───────────────────────────────── */
 
 export let adminSetupExpanded = false;

--- a/viewer_ui/src/tabs/sync/index.ts
+++ b/viewer_ui/src/tabs/sync/index.ts
@@ -7,6 +7,7 @@ import { renderHealthOverview } from '../health';
 import { renderSyncStatus, renderSyncAttempts, renderPairing, initDiagnosticsEvents, setRenderSyncPeers } from './diagnostics';
 import { renderTeamSync, renderSyncSharingReview, initTeamSyncEvents, setLoadSyncData as setTeamSyncLoadData } from './team-sync';
 import { renderSyncActors, renderSyncPeers, renderLegacyDeviceClaims, initPeopleEvents, setLoadSyncData as setPeopleLoadData } from './people';
+import { hideSkeleton } from './helpers';
 
 /* ── Re-exports consumed by app.ts ───────────────────────── */
 
@@ -51,6 +52,11 @@ export async function loadSyncData() {
           'Actor controls are temporarily unavailable. Peer status and sync health still loaded.';
     }
   } catch {
+    // Clear all skeletons so the error state is visible, not masked by loading placeholders
+    hideSkeleton('syncTeamSkeleton');
+    hideSkeleton('syncActorsSkeleton');
+    hideSkeleton('syncPeersSkeleton');
+    hideSkeleton('syncDiagSkeleton');
     const syncMeta = document.getElementById('syncMeta');
     if (syncMeta) syncMeta.textContent = 'Sync unavailable';
   }

--- a/viewer_ui/src/tabs/sync/people.ts
+++ b/viewer_ui/src/tabs/sync/people.ts
@@ -17,6 +17,7 @@ import {
   actorMergeNote,
   createChipEditor,
   openPeerScopeEditors,
+  hideSkeleton,
 } from './helpers';
 
 /* ── loadSyncData callback (set by index module) ─────────── */
@@ -32,6 +33,7 @@ export function renderSyncActors() {
   const actorList = document.getElementById('syncActorsList');
   const actorMeta = document.getElementById('syncActorsMeta');
   if (!actorList) return;
+  hideSkeleton('syncActorsSkeleton');
   actorList.textContent = '';
 
   const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
@@ -175,6 +177,7 @@ export function renderSyncActors() {
 export function renderSyncPeers() {
   const syncPeers = document.getElementById('syncPeers');
   if (!syncPeers) return;
+  hideSkeleton('syncPeersSkeleton');
   syncPeers.textContent = '';
   const peers = state.lastSyncPeers;
   if (!Array.isArray(peers) || !peers.length) {

--- a/viewer_ui/src/tabs/sync/team-sync.ts
+++ b/viewer_ui/src/tabs/sync/team-sync.ts
@@ -10,6 +10,7 @@ import {
   setAdminSetupExpanded,
   teamInvitePanelOpen,
   setTeamInvitePanelOpen,
+  hideSkeleton,
 } from './helpers';
 
 /* ── DOM placement helpers ───────────────────────────────── */
@@ -105,6 +106,7 @@ export function renderTeamSync() {
   const joinPanel = document.getElementById('syncJoinPanel');
   const joinRequests = document.getElementById('syncJoinRequests');
   if (!meta || !setupPanel || !list || !actions) return;
+  hideSkeleton('syncTeamSkeleton');
   // Move panels back to their home sections BEFORE clearing, so they survive the wipe
   ensureInvitePanelInAdminSection();
   ensureJoinPanelInSetupSection();


### PR DESCRIPTION
## Description

Complete the **loading-states** skill from the frontend-orchestrator sequence. Add shimmer-animated skeleton placeholders that show during the initial data fetch and get removed once real data renders.

### Skeleton locations
- **Team sync card**: status line + block + short line
- **People card**: actor skeleton lines + device skeleton blocks  
- **Diagnostics card**: three status skeleton lines

### Implementation
- CSS `@keyframes sync-shimmer` creates a left-to-right gradient sweep
- `.sync-skeleton-line` (short/medium/long variants) and `.sync-skeleton-block` for different content shapes
- `hideSkeleton(id)` helper removes the skeleton element from the DOM (not just hidden) on first render, so it never flashes back on refresh cycles
- Each render function (`renderTeamSync`, `renderSyncActors`, `renderSyncPeers`, `renderSyncStatus`) calls `hideSkeleton` at entry

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Manually verified changes work as expected
- `bun run check` — TypeScript passes
- `bun run build` — bundle built
- `uv run ruff check codemem tests` — all pass
- `uv run pytest tests/test_sync_viewer_api.py` — all pass

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced