### PR TITLE
fix: invite creation requires coordinator URL and documents admin secret

### DIFF
--- a/codemem/commands/sync_coordinator_cmds.py
+++ b/codemem/commands/sync_coordinator_cmds.py
@@ -197,7 +197,11 @@ def coordinator_create_invite_action(
     resolved_remote_url, resolved_admin_secret = _resolve_remote_target(remote_url, admin_secret)
     if resolved_remote_url:
         if not resolved_admin_secret:
-            raise SystemExit("Remote coordinator admin secret required")
+            raise SystemExit(
+                "Admin secret required to create invites via the coordinator API. "
+                "Set sync_coordinator_admin_secret in config or "
+                "CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET env var on this device."
+            )
         payload = _remote_request(
             "POST",
             f"{resolved_remote_url.rstrip('/')}/v1/admin/invites",
@@ -219,6 +223,14 @@ def coordinator_create_invite_action(
             "mode": "remote",
         }
 
+    resolved_coordinator_url = (coordinator_url or "").strip()
+    if not resolved_coordinator_url:
+        cfg = load_config()
+        resolved_coordinator_url = str(getattr(cfg, "sync_coordinator_url", "") or "").strip()
+    if not resolved_coordinator_url:
+        raise SystemExit(
+            "Coordinator URL required. Pass --coordinator-url or set sync_coordinator_url in config."
+        )
     store = CoordinatorStore(db_path or DEFAULT_COORDINATOR_DB_PATH)
     try:
         group = store.get_group(group_id)
@@ -235,12 +247,12 @@ def coordinator_create_invite_action(
     payload: InvitePayload = {
         "v": 1,
         "kind": "coordinator_team_invite",
-        "coordinator_url": (coordinator_url or "").strip(),
+        "coordinator_url": resolved_coordinator_url,
         "group_id": group_id,
         "policy": policy,
         "token": str(invite.get("token") or ""),
         "expires_at": expires_value,
-        "team_name": invite.get("team_name_snapshot"),
+        "team_name": invite.get("team_name_snapshot") or group_id,
     }
     encoded = encode_invite_payload(payload)
     return {
@@ -303,12 +315,18 @@ def coordinator_import_invite_action(
     if not public_key:
         raise SystemExit("public key missing")
 
+    coordinator_url = str(payload.get("coordinator_url") or "").strip()
+    if not coordinator_url:
+        raise SystemExit(
+            "Invite is missing a coordinator URL. Ask the team admin for a new invite."
+        )
+
     resolved_config = load_config(resolved_config_path)
     display_name = resolved_config.actor_display_name or device_id
 
     status, response = http_client.request_json(
         "POST",
-        f"{str(payload['coordinator_url']).rstrip('/')}/v1/join",
+        f"{coordinator_url.rstrip('/')}/v1/join",
         body={
             "token": str(payload["token"]),
             "device_id": device_id,
@@ -324,7 +342,7 @@ def coordinator_import_invite_action(
     response_data = response if isinstance(response, dict) else {}
 
     config_data = read_config_file(resolved_config_path)
-    config_data["sync_coordinator_url"] = str(payload["coordinator_url"])
+    config_data["sync_coordinator_url"] = coordinator_url
     config_data["sync_coordinator_group"] = str(payload["group_id"])
     write_config_file(config_data, resolved_config_path)
 
@@ -360,7 +378,10 @@ def coordinator_list_join_requests_action(
     resolved_remote_url, resolved_admin_secret = _resolve_remote_target(remote_url, admin_secret)
     if resolved_remote_url:
         if not resolved_admin_secret:
-            raise SystemExit("Remote coordinator admin secret required")
+            raise SystemExit(
+                "Admin secret required. Set sync_coordinator_admin_secret in config "
+                "or CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET env var."
+            )
         payload = _remote_request(
             "GET",
             f"{resolved_remote_url.rstrip('/')}/v1/admin/join-requests?group_id={quote(group_id, safe='')}",
@@ -408,7 +429,10 @@ def coordinator_review_join_request_action(
     resolved_remote_url, resolved_admin_secret = _resolve_remote_target(remote_url, admin_secret)
     if resolved_remote_url:
         if not resolved_admin_secret:
-            raise SystemExit("Remote coordinator admin secret required")
+            raise SystemExit(
+                "Admin secret required. Set sync_coordinator_admin_secret in config "
+                "or CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET env var."
+            )
         endpoint = "/v1/admin/join-requests/approve" if approve else "/v1/admin/join-requests/deny"
         payload = _remote_request(
             "POST",

--- a/docs/coordinator-deployment.md
+++ b/docs/coordinator-deployment.md
@@ -12,11 +12,17 @@ pip install codemem
 # Create a coordinator group
 codemem sync coordinator group-create my-team --db-path ~/.codemem/coordinator.sqlite
 
+# Set an admin secret (required for creating invites via the API)
+set -x CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET (python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+
 # Start the coordinator
 codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
 ```
 
 The coordinator is now listening on port 7347. Devices on the same network can connect using this machine's IP address.
+
+**Important:** Save the admin secret — you'll need it in your client config to create invites from the UI or API. The
+coordinator rejects admin operations (invite creation, join request review) without it.
 
 ## CLI reference
 
@@ -136,6 +142,21 @@ production use.
 
 Once the coordinator is reachable, teammates configure their codemem client:
 
+**Admin's machine** (the device running the coordinator):
+
+```json
+{
+  "sync_enabled": true,
+  "sync_coordinator_url": "https://coord.example.com",
+  "sync_coordinator_group": "my-team",
+  "sync_coordinator_admin_secret": "<the secret you generated above>"
+}
+```
+
+The admin secret lets you create invites and review join requests from the viewer UI or API. Only the admin needs this.
+
+**Teammate devices:**
+
 ```json
 {
   "sync_enabled": true,
@@ -152,6 +173,9 @@ set -x CODEMEM_SYNC_COORDINATOR_GROUP "my-team"
 ```
 
 Or through the viewer UI: Settings → Device Sync → Coordinator URL / Group.
+
+**Note:** Teammates who join via an invite link don't need to configure anything manually — the invite import
+auto-configures `sync_coordinator_url` and `sync_coordinator_group`.
 
 ## Onboarding teammates
 


### PR DESCRIPTION
## Description

Fix several dogfooding blockers discovered during first coordinator deployment:

### Bugs fixed
- **Empty coordinator URL in invites**: CLI invite creation produced `"coordinator_url": ""` because nothing fell back to config. Now reads `sync_coordinator_url` from config, raises a clear error if still missing.
- **Import crashes on empty URL**: `coordinator_import_invite_action` would hit `"/v1/join"` with no host. Now validates the invite's `coordinator_url` first with an actionable error: "Invite is missing a coordinator URL. Ask the team admin for a new invite."
- **Null team_name**: `team_name` in invite payloads was always `null`. Now defaults to `group_id`.

### Error messages improved
- Admin secret errors now explain exactly how to configure: "Set sync_coordinator_admin_secret in config or CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET env var."

### Documentation updated
- **Quick start**: Added admin secret generation step (`secrets.token_urlsafe(32)`)
- **Client configuration**: Split into Admin vs Teammate sections; admin config includes `sync_coordinator_admin_secret`
- **Note**: Invite import auto-configures URL and group — teammates don't need manual config

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Manually verified changes work as expected
- `uv run pytest tests/test_sync_cli.py tests/test_sync_viewer_api.py tests/test_coordinator_api.py` — all pass

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced