### PR TITLE
fix: WCAG accessibility audit fixes for Sync tab

### DIFF
--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -1880,15 +1880,19 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     const pairingCopy = document.getElementById("pairingCopy");
     const syncPairing = document.getElementById("syncPairing");
     if (syncPairing) syncPairing.hidden = !state.syncPairingOpen;
-    if (syncPairingToggle)
+    if (syncPairingToggle) {
       syncPairingToggle.textContent = state.syncPairingOpen ? "Hide pairing" : "Show pairing";
+      syncPairingToggle.setAttribute("aria-expanded", String(state.syncPairingOpen));
+    }
     if (syncRedact) syncRedact.checked = isSyncRedactionEnabled();
     syncPairingToggle?.addEventListener("click", () => {
       const next = !state.syncPairingOpen;
       setSyncPairingOpen(next);
       if (syncPairing) syncPairing.hidden = !next;
-      if (syncPairingToggle)
+      if (syncPairingToggle) {
         syncPairingToggle.textContent = next ? "Hide pairing" : "Show pairing";
+        syncPairingToggle.setAttribute("aria-expanded", String(next));
+      }
       if (next) {
         const pairingPayloadEl = document.getElementById("pairingPayload");
         const pairingHint = document.getElementById("pairingHint");
@@ -2204,6 +2208,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       if (!syncInvitePanel) return;
       setAdminSetupExpanded(!adminSetupExpanded);
       syncInvitePanel.hidden = !adminSetupExpanded;
+      syncToggleAdmin.setAttribute("aria-expanded", String(adminSetupExpanded));
       syncToggleAdmin.textContent = adminSetupExpanded ? "Hide team setup" : "Set up a new team instead…";
     });
     syncCreateInviteButton?.addEventListener("click", async () => {
@@ -2443,9 +2448,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       if (peerId) name.title = peerId;
       const peerStatus = peer.status || {};
       const online = peerStatus.sync_status === "ok" || peerStatus.ping_status === "ok";
-      const badge = el("span", "badge", online ? "Online" : "Offline");
-      badge.style.background = online ? "rgba(31, 111, 92, 0.12)" : "rgba(230, 126, 77, 0.15)";
-      badge.style.color = online ? "var(--accent)" : "var(--accent-warm)";
+      const badge = el("span", `badge ${online ? "badge-online" : "badge-offline"}`, online ? "Online" : "Offline");
       name.append(" ", badge);
       const actions = el("div", "peer-actions");
       const primaryAddress = pickPrimaryAddress(peer.addresses);
@@ -2584,12 +2587,14 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       scopeActions.append(saveScopeBtn, inheritBtn);
       editorWrap.append(inputRow, scopeActions);
       toggleScopeBtn.textContent = scopeEditorOpen ? "Hide scope editor" : "Edit scope";
+      toggleScopeBtn.setAttribute("aria-expanded", String(scopeEditorOpen));
       toggleScopeBtn.addEventListener("click", () => {
         const isCollapsed = editorWrap.classList.contains("collapsed");
         editorWrap.classList.toggle("collapsed", !isCollapsed);
         editorWrap.inert = !isCollapsed;
         if (!isCollapsed) openPeerScopeEditors.delete(peerId);
         else openPeerScopeEditors.add(peerId);
+        toggleScopeBtn.setAttribute("aria-expanded", String(isCollapsed));
         toggleScopeBtn.textContent = isCollapsed ? "Hide scope editor" : "Edit scope";
       });
       scopePanel.append(identityRow, identityMeta, actorRow, actorHint, scopeSummary, effectiveSummary, editorWrap);

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -839,6 +839,8 @@
         font-size: 12px;
         font-weight: 600;
       }
+      .badge-online { background: rgba(26, 107, 86, 0.12); color: var(--accent); }
+      .badge-offline { background: rgba(182, 75, 47, 0.15); color: var(--accent-warm); }
 
       .pill {
         display: inline-block;
@@ -1679,7 +1681,7 @@
           </div>
         </div>
         <div class="section-meta" id="syncTeamMeta"></div>
-        <div class="sync-skeleton" id="syncTeamSkeleton">
+        <div class="sync-skeleton" id="syncTeamSkeleton" role="status" aria-label="Loading team sync">
           <div class="sync-skeleton-line medium"></div>
           <div class="sync-skeleton-block"></div>
           <div class="sync-skeleton-line short"></div>
@@ -1689,17 +1691,20 @@
             <h3 class="settings-group-title">Join a team</h3>
             <div class="section-meta">Have an invite? Paste it here.</div>
             <div class="actor-create-row" id="syncJoinPanel">
+              <label for="syncJoinInvite" class="sr-only">Team invite</label>
               <textarea class="feed-search" id="syncJoinInvite" placeholder="Paste team invite or codemem:// link"></textarea>
               <button class="settings-button" id="syncJoinButton">Join team</button>
             </div>
           </div>
           <div id="syncAdminSection">
-            <button class="sync-toggle-admin" id="syncToggleAdmin">Set up a new team instead…</button>
+            <button class="sync-toggle-admin" id="syncToggleAdmin" aria-expanded="false" aria-controls="syncInvitePanel">Set up a new team instead…</button>
             <div id="syncInvitePanel" hidden>
               <h3 class="settings-group-title" style="margin-top:12px">Create a team</h3>
               <div class="section-meta">Generate an invite to share with teammates.</div>
               <div class="actor-create-row">
+                <label for="syncInviteGroup" class="sr-only">Team name</label>
                 <input class="peer-scope-input" id="syncInviteGroup" placeholder="Team name (e.g. my-team)" />
+                <label for="syncInvitePolicy" class="sr-only">Join policy</label>
                 <select class="sync-actor-select" id="syncInvitePolicy">
                   <option value="auto_admit">Auto-admit</option>
                   <option value="approval_required">Approval required</option>
@@ -1711,11 +1716,12 @@
                 </div>
                 <button class="settings-button" id="syncCreateInviteButton">Create invite</button>
               </div>
-              <textarea class="feed-search" id="syncInviteOutput" placeholder="Invite will appear here" hidden></textarea>
+              <label for="syncInviteOutput" class="sr-only">Generated invite</label>
+              <textarea class="feed-search" id="syncInviteOutput" placeholder="Invite will appear here" readonly hidden></textarea>
             </div>
           </div>
         </div>
-        <div class="actor-list" id="syncTeamStatus"></div>
+        <div class="actor-list" id="syncTeamStatus" aria-live="polite"></div>
         <div class="actor-list" id="syncJoinRequests"></div>
         <div class="sync-actions" id="syncTeamActions" hidden></div>
       </div>
@@ -1727,18 +1733,19 @@
         <h3 class="settings-group-title">Actors</h3>
         <div class="section-meta" id="syncActorsMeta">Create and rename actors here. Assign each device below.</div>
         <div class="actor-create-row">
+          <label for="syncActorCreateInput" class="sr-only">Actor name</label>
           <input class="peer-scope-input" id="syncActorCreateInput" placeholder="Create a named actor" />
           <button class="settings-button" id="syncActorCreateButton">Create actor</button>
         </div>
         <div class="actor-list" id="syncActorsList"></div>
-        <div class="sync-skeleton" id="syncActorsSkeleton">
+        <div class="sync-skeleton" id="syncActorsSkeleton" role="status" aria-label="Loading actors">
           <div class="sync-skeleton-line long"></div>
           <div class="sync-skeleton-line medium"></div>
         </div>
 
         <h3 class="settings-group-title" style="margin-top: 20px">Devices</h3>
         <div class="peer-list" id="syncPeers"></div>
-        <div class="sync-skeleton" id="syncPeersSkeleton">
+        <div class="sync-skeleton" id="syncPeersSkeleton" role="status" aria-label="Loading devices">
           <div class="sync-skeleton-block"></div>
           <div class="sync-skeleton-block"></div>
         </div>
@@ -1753,6 +1760,7 @@
           <h3 class="settings-group-title" style="margin-top: 20px">Legacy device history</h3>
           <div class="peer-meta" id="syncLegacyClaimsMeta"></div>
           <div class="peer-actions sync-legacy-claim-row">
+            <label for="syncLegacyDeviceSelect" class="sr-only">Legacy device</label>
             <select class="sync-legacy-select" id="syncLegacyDeviceSelect"></select>
             <button class="sync-legacy-button" id="syncLegacyClaimButton">Attach device history</button>
           </div>
@@ -1772,7 +1780,7 @@
           </div>
         </div>
         <div class="section-meta" id="syncMeta">Loading sync status…</div>
-        <div class="sync-skeleton" id="syncDiagSkeleton">
+        <div class="sync-skeleton" id="syncDiagSkeleton" role="status" aria-label="Loading diagnostics">
           <div class="sync-skeleton-line long"></div>
           <div class="sync-skeleton-line medium"></div>
           <div class="sync-skeleton-line short"></div>

--- a/viewer_ui/src/tabs/sync/diagnostics.ts
+++ b/viewer_ui/src/tabs/sync/diagnostics.ts
@@ -239,16 +239,20 @@ export function initDiagnosticsEvents(refreshCallback: () => void) {
 
   // Apply initial toggle states
   if (syncPairing) syncPairing.hidden = !state.syncPairingOpen;
-  if (syncPairingToggle)
+  if (syncPairingToggle) {
     syncPairingToggle.textContent = state.syncPairingOpen ? 'Hide pairing' : 'Show pairing';
+    syncPairingToggle.setAttribute('aria-expanded', String(state.syncPairingOpen));
+  }
   if (syncRedact) syncRedact.checked = isSyncRedactionEnabled();
 
   syncPairingToggle?.addEventListener('click', () => {
     const next = !state.syncPairingOpen;
     setSyncPairingOpen(next);
     if (syncPairing) syncPairing.hidden = !next;
-    if (syncPairingToggle)
+    if (syncPairingToggle) {
       syncPairingToggle.textContent = next ? 'Hide pairing' : 'Show pairing';
+      syncPairingToggle.setAttribute('aria-expanded', String(next));
+    }
     if (next) {
       const pairingPayloadEl = document.getElementById('pairingPayload');
       const pairingHint = document.getElementById('pairingHint');

--- a/viewer_ui/src/tabs/sync/people.ts
+++ b/viewer_ui/src/tabs/sync/people.ts
@@ -201,9 +201,7 @@ export function renderSyncPeers() {
 
     const peerStatus = peer.status || {};
     const online = peerStatus.sync_status === 'ok' || peerStatus.ping_status === 'ok';
-    const badge = el('span', 'badge', online ? 'Online' : 'Offline');
-    badge.style.background = online ? 'rgba(31, 111, 92, 0.12)' : 'rgba(230, 126, 77, 0.15)';
-    badge.style.color = online ? 'var(--accent)' : 'var(--accent-warm)';
+    const badge = el('span', `badge ${online ? 'badge-online' : 'badge-offline'}`, online ? 'Online' : 'Offline');
     name.append(' ', badge);
 
     const actions = el('div', 'peer-actions');
@@ -355,12 +353,14 @@ export function renderSyncPeers() {
     scopeActions.append(saveScopeBtn, inheritBtn);
     editorWrap.append(inputRow, scopeActions);
     toggleScopeBtn.textContent = scopeEditorOpen ? 'Hide scope editor' : 'Edit scope';
+    toggleScopeBtn.setAttribute('aria-expanded', String(scopeEditorOpen));
     toggleScopeBtn.addEventListener('click', () => {
       const isCollapsed = editorWrap.classList.contains('collapsed');
       editorWrap.classList.toggle('collapsed', !isCollapsed);
       editorWrap.inert = !isCollapsed;
       if (!isCollapsed) openPeerScopeEditors.delete(peerId);
       else openPeerScopeEditors.add(peerId);
+      toggleScopeBtn.setAttribute('aria-expanded', String(isCollapsed));
       toggleScopeBtn.textContent = isCollapsed ? 'Hide scope editor' : 'Edit scope';
     });
     scopePanel.append(identityRow, identityMeta, actorRow, actorHint, scopeSummary, effectiveSummary, editorWrap);

--- a/viewer_ui/src/tabs/sync/team-sync.ts
+++ b/viewer_ui/src/tabs/sync/team-sync.ts
@@ -312,6 +312,7 @@ export function initTeamSyncEvents(
     if (!syncInvitePanel) return;
     setAdminSetupExpanded(!adminSetupExpanded);
     syncInvitePanel.hidden = !adminSetupExpanded;
+    syncToggleAdmin.setAttribute('aria-expanded', String(adminSetupExpanded));
     syncToggleAdmin.textContent = adminSetupExpanded
       ? 'Hide team setup'
       : 'Set up a new team instead\u2026';


### PR DESCRIPTION
## Description

Systematic WCAG audit of the Sync tab applying the **accessibility-excellence** skill from the frontend-orchestrator sequence.

### Findings and fixes

| # | WCAG | Issue | Fix |
|---|------|-------|-----|
| 1 | A (1.3.1) | 6 form inputs missing explicit `<label>` — relied on placeholder only | Added `<label class="sr-only">` for each: team name, invite textarea, policy select, actor name, legacy device select, invite output |
| 2 | A (4.1.2) | Admin setup toggle missing `aria-expanded` | Added `aria-expanded` + `aria-controls="syncInvitePanel"` |
| 3 | A (4.1.2) | Scope editor toggle missing `aria-expanded` | Added `aria-expanded` toggled on click |
| 4 | A (4.1.2) | Pairing toggle missing `aria-expanded` | Added `aria-expanded` toggled on click |
| 5 | A (4.1.3) | Skeleton loading regions not announced | Added `role="status"` + `aria-label` to each skeleton |
| 6 | A (4.1.3) | Team sync status changes not announced | Added `aria-live="polite"` to status container |
| 7 | AA (1.4.3) | Online/offline badge colors via inline `style` | Replaced with semantic CSS classes `.badge-online` / `.badge-offline` |
| 8 | Best practice | Invite output textarea editable | Added `readonly` attribute |

### Not changed (already compliant)
- Focus indicators on selects: existing `box-shadow` focus rings are valid replacements for `outline: none`
- `prefers-reduced-motion`: already kills all animations/transitions
- Global notice `aria-live="polite"`: already in place
- Chip editor remove buttons: already have `aria-label`

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Manually verified changes work as expected
- `bun run check` — TypeScript passes
- `bun run build` — bundle built
- `uv run ruff check codemem tests` — all pass
- `uv run pytest tests/test_sync_viewer_api.py` — all pass

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced