### PR TITLE
refactor: typography consistency pass for Sync tab

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -491,6 +491,7 @@
         font-size: 16px;
         color: var(--accent-cool);
         line-height: 1.2;
+        font-feature-settings: 'tnum' 1;
       }
 
       .stat .label {
@@ -902,7 +903,7 @@
       .peer-list { display: grid; gap: var(--sp-3); }
       .peer-card { border: 1px solid var(--border); border-radius: var(--radius-lg); padding: var(--sp-4); background: var(--surface-1); display: grid; gap: var(--sp-2); }
       .peer-title { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); flex-wrap: wrap; }
-      .peer-title strong { font-size: 15px; }
+      .peer-title strong { font-size: 14px; font-weight: 600; }
       .actor-list { display: grid; gap: var(--sp-3); margin-top: var(--sp-3); }
       .actor-row { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: var(--sp-3); background: var(--surface-1); }
       .actor-details { min-width: 0; display: grid; gap: 6px; }
@@ -1048,6 +1049,7 @@
       .sync-team-metrics {
         font-size: 13px;
         color: var(--text-secondary);
+        font-feature-settings: 'tnum' 1;
       }
       .sync-legacy-claim-row { margin-top: 12px; gap: 12px; align-items: center; flex-wrap: wrap; }
       .sync-legacy-select {


### PR DESCRIPTION
## Description

Apply the **typography-system** skill from the frontend-orchestrator sequence. Minor consistency fixes:

- **Peer name size**: 15px → 14px. Was an orphan between body (14px) and heading (16px) scales, now aligns with body.
- **Tabular numbers**: Added `font-feature-settings: 'tnum' 1` to stat grid values and team metrics. Numbers now maintain consistent widths during polling updates instead of shifting layout.

The existing type scale (11/12/13/14/16/18px) follows a roughly major-second progression and is already well-structured. No scale redesign needed.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing
- [x] `bun run check` — TypeScript passes
- [x] `bun run build` — bundle built
- [x] `uv run pytest tests/test_sync_viewer_api.py` — all pass

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced