### PR TITLE
perf: reduce unnecessary sync polling and re-renders

### DIFF
--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -2699,6 +2699,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       syncLegacyClaimButton.disabled = false;
     });
   }
+  let lastSyncHash = "";
   async function loadSyncData() {
     try {
       const payload = await loadSyncStatus(true, state.currentProject || "");
@@ -2709,6 +2710,9 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       } catch {
         actorLoadError = true;
       }
+      const hash = JSON.stringify([payload, actorsPayload]);
+      if (hash === lastSyncHash) return;
+      lastSyncHash = hash;
       const statusPayload = payload.status && typeof payload.status === "object" ? payload.status : null;
       if (statusPayload) state.lastSyncStatus = statusPayload;
       state.lastSyncActors = Array.isArray(actorsPayload?.items) ? actorsPayload.items : [];
@@ -3624,7 +3628,12 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     state.currentProject = $select("projectFilter")?.value || "";
     refresh();
   });
+  let refreshDebounceTimer = null;
   async function refresh() {
+    if (refreshDebounceTimer) clearTimeout(refreshDebounceTimer);
+    refreshDebounceTimer = setTimeout(() => doRefresh(), 80);
+  }
+  async function doRefresh() {
     if (state.refreshInFlight) {
       state.refreshQueued = true;
       return;
@@ -3634,11 +3643,13 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       setRefreshStatus("refreshing");
       const promises = [
         loadHealthData(),
-        loadConfigData(),
-        loadSyncData()
+        loadConfigData()
       ];
       if (state.activeTab === "feed") {
         promises.push(loadFeedData());
+      }
+      if (state.activeTab === "sync" || state.activeTab === "health") {
+        promises.push(loadSyncData());
       }
       if (state.syncPairingOpen) {
         promises.push(loadPairingData());
@@ -3651,7 +3662,7 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
       state.refreshInFlight = false;
       if (state.refreshQueued) {
         state.refreshQueued = false;
-        refresh();
+        doRefresh();
       }
     }
   }

--- a/viewer_ui/src/app.ts
+++ b/viewer_ui/src/app.ts
@@ -73,7 +73,7 @@ function switchTab(tab: TabId) {
   // Toggle tab panels
   TAB_IDS.forEach((id) => {
     const panel = $(`tab-${id}`);
-    if (panel) (panel as any).hidden = id !== tab;
+    if (panel) panel.hidden = id !== tab;
   });
 
   // Toggle tab buttons
@@ -132,7 +132,15 @@ $select('projectFilter')?.addEventListener('change', () => {
 
 /* ── Main refresh ────────────────────────────────────────── */
 
+let refreshDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
 async function refresh() {
+  // Debounce rapid calls (tab switch + hash change + visibility)
+  if (refreshDebounceTimer) clearTimeout(refreshDebounceTimer);
+  refreshDebounceTimer = setTimeout(() => doRefresh(), 80);
+}
+
+async function doRefresh() {
   if (state.refreshInFlight) { state.refreshQueued = true; return; }
   state.refreshInFlight = true;
 
@@ -143,12 +151,15 @@ async function refresh() {
     const promises: Promise<any>[] = [
       loadHealthData(),
       loadConfigData(),
-      loadSyncData(),
     ];
 
     // Load tab-specific data
     if (state.activeTab === 'feed') {
       promises.push(loadFeedData());
+    }
+    // Sync data is needed by both Sync tab and Health tab (health cards derive sync state)
+    if (state.activeTab === 'sync' || state.activeTab === 'health') {
+      promises.push(loadSyncData());
     }
 
     // Load pairing if open
@@ -164,7 +175,7 @@ async function refresh() {
     state.refreshInFlight = false;
     if (state.refreshQueued) {
       state.refreshQueued = false;
-      refresh();
+      doRefresh();
     }
   }
 }

--- a/viewer_ui/src/tabs/sync/index.ts
+++ b/viewer_ui/src/tabs/sync/index.ts
@@ -16,6 +16,8 @@ export { renderSyncPeers } from './people';
 
 /* ── Data loading ────────────────────────────────────────── */
 
+let lastSyncHash = '';
+
 export async function loadSyncData() {
   try {
     const payload = await api.loadSyncStatus(true, state.currentProject || '');
@@ -26,6 +28,12 @@ export async function loadSyncData() {
     } catch {
       actorLoadError = true;
     }
+
+    // Skip re-render if data hasn't changed since last poll
+    const hash = JSON.stringify([payload, actorsPayload]);
+    if (hash === lastSyncHash) return;
+    lastSyncHash = hash;
+
     const statusPayload =
       payload.status && typeof payload.status === 'object' ? payload.status : null;
     if (statusPayload) state.lastSyncStatus = statusPayload;


### PR DESCRIPTION
## Description

Apply the **performance-optimization** skill from the frontend-orchestrator sequence. Three changes:

### 1. Tab-scoped sync loading
`loadSyncData()` was called on every 5-second poll regardless of which tab was active. Now only loads when the Sync tab is visible. Health data (for the header dot) still loads unconditionally.

### 2. Refresh debounce
`refresh()` now debounces with 80ms delay. Rapid triggers (tab switch → hash change → visibility change during a single user action) coalesce into one API call instead of firing back-to-back.

### 3. Skip unchanged re-renders
`loadSyncData()` now hashes the API response and skips all DOM re-renders when data hasn't changed since the last poll. This eliminates unnecessary DOM thrashing during steady-state polling.

### Also
- Removed stray `as any` cast in `switchTab`

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing
- [x] `bun run check` — TypeScript passes
- [x] `bun run build` — bundle built
- [x] `uv run ruff check codemem tests` — all pass
- [x] `uv run pytest tests/test_sync_viewer_api.py` — all pass

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced