### PR TITLE
fix: schema migration crashes on retry when _v2 tables exist

### DIFF
--- a/codemem/db.py
+++ b/codemem/db.py
@@ -569,6 +569,18 @@ def _rebuild_raw_event_identity_tables(conn: sqlite3.Connection) -> None:
     }
     batch_attempt_expr = "COALESCE(attempt_count, 0)" if "attempt_count" in batch_columns else "0"
 
+    # Clean up any leftover _v2 tables from a previously failed migration attempt.
+    # executescript auto-commits, so a crash mid-migration leaves _v2 tables behind
+    # that block retry. These are always stale — the rename at the end is the commit point.
+    conn.executescript(
+        """
+        DROP TABLE IF EXISTS raw_events_v2;
+        DROP TABLE IF EXISTS raw_event_sessions_v2;
+        DROP TABLE IF EXISTS raw_event_flush_batches_v2;
+        DROP TABLE IF EXISTS opencode_sessions_v2;
+        """
+    )
+
     conn.executescript(
         """
         CREATE TABLE raw_events_v2 (


### PR DESCRIPTION
## Description

The raw-event identity rebuild migration uses `executescript` (which auto-commits after each statement) to create `_v2` staging tables, copy data, verify row counts, then rename. If any step crashes mid-migration, the `_v2` tables are left behind permanently, and the next startup fails with `OperationalError: table raw_events_v2 already exists` — making the DB unusable without manual SQL intervention.

**Fix:** Drop any leftover `_v2` tables at the start of the rebuild function. These are always stale — the rename at the end is the migration's commit point, so if `_v2` tables exist when the rebuild starts, a previous attempt failed and they should be discarded.

**Root cause:** `executescript` in Python's sqlite3 module auto-commits before execution and doesn't wrap the script in a transaction, so there's no atomicity guarantee across the multi-statement migration. A proper migration framework would prevent this class of bug (tracked in codemem-gga).

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing
- [x] `uv run pytest tests/test_store.py` — all pass
- [x] `uv run ruff check codemem/db.py` — passes

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced