### PR TITLE
fix: stats command crashes when sqlite-vec is disabled

### DIFF
--- a/codemem/store/usage.py
+++ b/codemem/store/usage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -219,8 +220,11 @@ def stats(store: MemoryStore) -> dict[str, Any]:
     db_path = str(store.db_path)
     size_bytes = Path(db_path).stat().st_size if Path(db_path).exists() else 0
 
-    vector_rows = store.conn.execute("SELECT COUNT(*) FROM memory_vectors").fetchone()
-    vector_count = vector_rows[0] if vector_rows else 0
+    try:
+        vector_rows = store.conn.execute("SELECT COUNT(*) FROM memory_vectors").fetchone()
+        vector_count = vector_rows[0] if vector_rows else 0
+    except sqlite3.OperationalError:
+        vector_count = 0
     vector_coverage = 0.0
     if active_memories:
         vector_coverage = min(1.0, float(vector_count) / float(active_memories))


### PR DESCRIPTION
## Description

`codemem stats` crashes with `OperationalError: no such module: vec0` when `CODEMEM_EMBEDDING_DISABLED=1` is set because `store/usage.py` queries the `memory_vectors` virtual table unconditionally.

Wrap the vector count query in try/except so stats works without embeddings. Returns `vector_count: 0` when the table can't be queried.

## Type of Change
- [ ] 🚀 Feature
- [x] 🐛 Bug fix
- [ ] 📚 Documentation
- [ ] 🔧 Maintenance

## Testing
- [x] `uv run pytest tests/test_store.py` — all pass
- [x] `uv run ruff check codemem/store/usage.py` — passes

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced