### PR TITLE
feat(viewer): surface observer flush failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Observer runtime/auth in `0.16`:
 
 - Runtime options: `api_http` and `claude_sidecar`.
 - `api_http` defaults to `gpt-5.1-codex-mini` (OpenAI path) unless you set `observer_model`.
+- Anthropic direct API calls accept Anthropic model IDs/aliases. codemem maps the common Claude shorthand `claude-4.5-haiku` to Anthropic's direct API alias `claude-haiku-4-5`; you can also set a pinned snapshot like `claude-haiku-4-5-20251001` explicitly.
 - `claude_sidecar` defaults to `claude-4.5-haiku`; if the selected `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's CLI default model.
 - `claude_sidecar` command is configurable with `claude_command` (`CODEMEM_CLAUDE_COMMAND`) as a JSON argv array.
   - Config file example: `"claude_command": ["wrapper", "claude", "--"]`

--- a/codemem/db.py
+++ b/codemem/db.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
@@ -85,10 +86,8 @@ def _load_sqlite_vec(conn: sqlite3.Connection) -> None:
             )
         raise RuntimeError(message) from exc
     finally:
-        try:
+        with contextlib.suppress(AttributeError):
             conn.enable_load_extension(False)
-        except AttributeError:
-            return
 
 
 def connect(db_path: Path | str, check_same_thread: bool = True) -> sqlite3.Connection:
@@ -253,6 +252,11 @@ def _initialize_schema_v1(conn: sqlite3.Connection) -> None:
             end_event_seq INTEGER NOT NULL,
             extractor_version TEXT NOT NULL,
             status TEXT NOT NULL,
+            error_message TEXT,
+            error_type TEXT,
+            observer_provider TEXT,
+            observer_model TEXT,
+            observer_runtime TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             UNIQUE(source, stream_id, start_event_seq, end_event_seq, extractor_version)
@@ -574,6 +578,10 @@ def _rebuild_raw_event_identity_tables(conn: sqlite3.Connection) -> None:
     batch_columns = {
         row[1] for row in conn.execute("PRAGMA table_info(raw_event_flush_batches)").fetchall()
     }
+
+    def _batch_select_expr(column: str) -> str:
+        return column if column in batch_columns else f"NULL AS {column}"
+
     batch_attempt_expr = "COALESCE(attempt_count, 0)" if "attempt_count" in batch_columns else "0"
 
     # Clean up any leftover _v2 tables from a previously failed migration attempt.
@@ -629,6 +637,11 @@ def _rebuild_raw_event_identity_tables(conn: sqlite3.Connection) -> None:
             end_event_seq INTEGER NOT NULL,
             extractor_version TEXT NOT NULL,
             status TEXT NOT NULL,
+            error_message TEXT,
+            error_type TEXT,
+            observer_provider TEXT,
+            observer_model TEXT,
+            observer_runtime TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             attempt_count INTEGER NOT NULL DEFAULT 0,
@@ -715,6 +728,11 @@ def _rebuild_raw_event_identity_tables(conn: sqlite3.Connection) -> None:
             end_event_seq,
             extractor_version,
             status,
+            error_message,
+            error_type,
+            observer_provider,
+            observer_model,
+            observer_runtime,
             created_at,
             updated_at,
             attempt_count
@@ -728,6 +746,11 @@ def _rebuild_raw_event_identity_tables(conn: sqlite3.Connection) -> None:
             COALESCE(end_event_seq, 0),
             COALESCE(extractor_version, 'unknown'),
             COALESCE(status, 'unknown'),
+            {_batch_select_expr("error_message")},
+            {_batch_select_expr("error_type")},
+            {_batch_select_expr("observer_provider")},
+            {_batch_select_expr("observer_model")},
+            {_batch_select_expr("observer_runtime")},
             COALESCE(created_at, datetime('now')),
             COALESCE(updated_at, datetime('now')),
             {batch_attempt_expr}
@@ -1024,6 +1047,11 @@ def _ensure_raw_event_reliability_schema(conn: sqlite3.Connection) -> None:
     )
     _ensure_column(conn, "raw_event_ingest_stats", "skipped_conflict", "INTEGER NOT NULL DEFAULT 0")
     _ensure_column(conn, "raw_event_flush_batches", "attempt_count", "INTEGER NOT NULL DEFAULT 0")
+    _ensure_column(conn, "raw_event_flush_batches", "error_message", "TEXT")
+    _ensure_column(conn, "raw_event_flush_batches", "error_type", "TEXT")
+    _ensure_column(conn, "raw_event_flush_batches", "observer_provider", "TEXT")
+    _ensure_column(conn, "raw_event_flush_batches", "observer_model", "TEXT")
+    _ensure_column(conn, "raw_event_flush_batches", "observer_runtime", "TEXT")
 
 
 def _ensure_memory_identity_schema(conn: sqlite3.Connection) -> None:

--- a/codemem/observer.py
+++ b/codemem/observer.py
@@ -107,6 +107,7 @@ _resolve_oauth_provider = _observer_auth._resolve_oauth_provider
 
 _build_anthropic_headers = _observer_anthropic._build_anthropic_headers
 _build_anthropic_payload = _observer_anthropic._build_anthropic_payload
+_extract_anthropic_error_details = _observer_anthropic._extract_anthropic_error_details
 _parse_anthropic_stream = _observer_anthropic._parse_anthropic_stream
 _resolve_anthropic_endpoint = _observer_anthropic._resolve_anthropic_endpoint
 
@@ -229,6 +230,8 @@ class ObserverClient:
             cache_ttl_s=max(0, int(cfg.observer_auth_cache_ttl_s or 300)),
         )
         self.auth = ObserverAuthMaterial(token=None, auth_type="none", source="none")
+        self._last_error_code: str | None = None
+        self._last_error_message: str | None = None
         if model:
             self.model = model
         elif resolved_provider == "anthropic":
@@ -269,7 +272,7 @@ class ObserverClient:
             method = "sdk_client"
 
         token_present = bool(self.auth.token)
-        return {
+        status = {
             "provider": self.provider,
             "model": self.model,
             "runtime": self.runtime,
@@ -279,6 +282,23 @@ class ObserverClient:
                 "token_present": token_present,
             },
         }
+        if self._last_error_message:
+            status["last_error"] = {
+                "code": self._last_error_code or "observer_error",
+                "message": self._last_error_message,
+            }
+        return status
+
+    def _set_last_error(self, message: str, *, code: str | None = None) -> None:
+        text = message.strip()
+        if not text:
+            return
+        self._last_error_message = text
+        self._last_error_code = (code or "observer_error").strip() or "observer_error"
+
+    def _clear_last_error(self) -> None:
+        self._last_error_code = None
+        self._last_error_message = None
 
     def _init_provider_client(self, *, force_refresh: bool) -> None:
         self.client = None
@@ -392,6 +412,8 @@ class ObserverClient:
         if self.max_chars > 0 and len(prompt) > self.max_chars:
             prompt = prompt[: self.max_chars]
         raw = self._call(prompt)
+        if raw:
+            self._clear_last_error()
         parsed = parse_observer_output(raw or "")
         return ObserverResponse(raw=raw, parsed=parsed)
 
@@ -488,7 +510,16 @@ class ObserverClient:
             output, error = self._invoke_claude_sidecar(prompt, use_model=False)
         if error:
             if _is_claude_sidecar_auth_error(error):
+                self._set_last_error(
+                    "Claude authentication failed. Refresh credentials and retry.",
+                    code="auth_failed",
+                )
                 raise ObserverAuthError(error)
+            if _is_claude_sidecar_model_error(error):
+                self._set_last_error(
+                    f"Claude model is unavailable: {self._sidecar_model or self.model}.",
+                    code="invalid_model_id",
+                )
             logger.warning("observer claude_sidecar call failed: %s", error)
             return None
         return output
@@ -506,6 +537,9 @@ class ObserverClient:
                 return self._call_codex(prompt)
             if not self.client:
                 logger.warning("observer auth: missing client and codex token")
+                self._set_last_error(
+                    f"{self.provider.capitalize()} credentials are missing.", code="auth_missing"
+                )
                 return None
         try:
             if self.provider == "anthropic":
@@ -528,11 +562,19 @@ class ObserverClient:
             return resp.choices[0].message.content
         except Exception as exc:  # pragma: no cover
             if _is_auth_error(exc):
+                self._set_last_error(
+                    f"{self.provider.capitalize()} authentication failed. Refresh credentials and retry.",
+                    code="auth_failed",
+                )
                 raise ObserverAuthError(str(exc)) from exc
             logger.exception(
                 "observer call failed",
                 extra={"provider": self.provider, "model": self.model},
                 exc_info=exc,
+            )
+            self._set_last_error(
+                f"{self.provider.capitalize()} processing failed during observer inference.",
+                code="observer_call_failed",
             )
             return None
 
@@ -630,6 +672,10 @@ class ObserverClient:
                     if error_summary:
                         message = f"{message}: {error_summary}"
                     if response.status_code in (401, 403):
+                        self._set_last_error(
+                            "OpenAI authentication failed. Refresh credentials and retry.",
+                            code="auth_failed",
+                        )
                         raise ObserverAuthError(message)
                     logger.error(
                         message,
@@ -641,6 +687,10 @@ class ObserverClient:
                             "error": error_summary,
                             "request_id": request_id,
                         },
+                    )
+                    self._set_last_error(
+                        "OpenAI request failed during observer processing.",
+                        code="provider_request_failed",
                     )
                     return None
                 response.raise_for_status()
@@ -668,6 +718,10 @@ class ObserverClient:
                 request_url = None
 
             if status_code in (401, 403) or _is_auth_error(exc):
+                self._set_last_error(
+                    "OpenAI authentication failed. Refresh credentials and retry.",
+                    code="auth_failed",
+                )
                 raise ObserverAuthError(message) from exc
             logger.exception(
                 message,
@@ -682,6 +736,10 @@ class ObserverClient:
                     "exc_type": exc.__class__.__name__,
                 },
                 exc_info=exc,
+            )
+            self._set_last_error(
+                "OpenAI request failed during observer processing.",
+                code="provider_request_failed",
             )
             return None
 
@@ -732,7 +790,15 @@ class ObserverClient:
                     message = "observer anthropic oauth call failed"
                     if error_summary:
                         message = f"{message}: {error_summary}"
+                    details = _extract_anthropic_error_details(error_text)
                     if response.status_code in (401, 403):
+                        auth_message = (
+                            details["message"]
+                            if isinstance(details, dict)
+                            else "Anthropic authentication failed. Refresh credentials and retry."
+                        )
+                        auth_code = details["code"] if isinstance(details, dict) else "auth_failed"
+                        self._set_last_error(auth_message, code=auth_code)
                         raise ObserverAuthError(message)
                     logger.error(
                         message,
@@ -745,6 +811,13 @@ class ObserverClient:
                             "request_id": request_id,
                         },
                     )
+                    if isinstance(details, dict):
+                        self._set_last_error(details["message"], code=details["code"])
+                    else:
+                        self._set_last_error(
+                            "Anthropic request failed during observer processing.",
+                            code="provider_request_failed",
+                        )
                     return None
                 response.raise_for_status()
                 return _parse_anthropic_stream(response)
@@ -764,6 +837,7 @@ class ObserverClient:
             message = "observer anthropic oauth call failed"
             if error_summary:
                 message = f"{message}: {error_summary}"
+            details = _extract_anthropic_error_details(error_text)
 
             request_url = None
             try:
@@ -773,6 +847,13 @@ class ObserverClient:
                 request_url = None
 
             if status_code in (401, 403) or _is_auth_error(exc):
+                auth_message = (
+                    details["message"]
+                    if isinstance(details, dict)
+                    else "Anthropic authentication failed. Refresh credentials and retry."
+                )
+                auth_code = details["code"] if isinstance(details, dict) else "auth_failed"
+                self._set_last_error(auth_message, code=auth_code)
                 raise ObserverAuthError(message) from exc
             logger.exception(
                 message,
@@ -787,6 +868,13 @@ class ObserverClient:
                 },
                 exc_info=exc,
             )
+            if isinstance(details, dict):
+                self._set_last_error(details["message"], code=details["code"])
+            else:
+                self._set_last_error(
+                    "Anthropic request failed during observer processing.",
+                    code="provider_request_failed",
+                )
             return None
 
     def _extract_opencode_text(self, output: str) -> str:

--- a/codemem/observer_anthropic.py
+++ b/codemem/observer_anthropic.py
@@ -10,6 +10,17 @@ ANTHROPIC_MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_OAUTH_BETA = "oauth-2025-04-20"
 ANTHROPIC_OAUTH_USER_AGENT = "claude-cli/2.1.2 (external, cli)"
 
+_ANTHROPIC_MODEL_ALIASES = {
+    "claude-4.5-haiku": "claude-haiku-4-5",
+    "claude-4.5-sonnet": "claude-sonnet-4-5",
+    "claude-4.5-opus": "claude-opus-4-5",
+    "claude-4.6-sonnet": "claude-sonnet-4-6",
+    "claude-4.6-opus": "claude-opus-4-6",
+    "claude-4.1-opus": "claude-opus-4-1",
+    "claude-4.0-sonnet": "claude-sonnet-4-0",
+    "claude-4.0-opus": "claude-opus-4-0",
+}
+
 _redact_text = _observer_auth._redact_text
 
 
@@ -27,9 +38,44 @@ def _build_anthropic_headers(access_token: str) -> dict[str, str]:
     }
 
 
+def _normalize_anthropic_model(model: str) -> str:
+    normalized = model.strip()
+    if not normalized:
+        return normalized
+    return _ANTHROPIC_MODEL_ALIASES.get(normalized.lower(), normalized)
+
+
+def _extract_anthropic_error_details(error_text: str | None) -> dict[str, str] | None:
+    if not error_text:
+        return None
+    try:
+        payload = json.loads(error_text)
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    error_type = str(error.get("type") or "").strip().lower()
+    message = str(error.get("message") or "").strip()
+    if error_type == "not_found_error" and message.lower().startswith("model:"):
+        missing_model = message.split(":", 1)[1].strip()
+        return {
+            "code": "invalid_model_id",
+            "message": f"Anthropic model ID not found: {missing_model}.",
+        }
+    if error_type in {"authentication_error", "permission_error"}:
+        return {
+            "code": "auth_failed",
+            "message": "Anthropic authentication failed. Refresh credentials and retry.",
+        }
+    return None
+
+
 def _build_anthropic_payload(model: str, prompt: str, max_tokens: int) -> dict[str, Any]:
     return {
-        "model": model,
+        "model": _normalize_anthropic_model(model),
         "max_tokens": max_tokens,
         "stream": True,
         "messages": [

--- a/codemem/raw_event_flush.py
+++ b/codemem/raw_event_flush.py
@@ -1,14 +1,84 @@
 from __future__ import annotations
 
 import datetime as dt
+import logging
 import os
 from typing import Any
 
-from .plugin_ingest import ingest
+from . import plugin_ingest
+from .observer import ObserverAuthError
 from .store import MemoryStore
-from .store.raw_events import RAW_EVENT_QUEUE_FAILED
 
 EXTRACTOR_VERSION = "raw_events_v1"
+logger = logging.getLogger(__name__)
+ingest = plugin_ingest.ingest
+
+
+def _truncate_error_message(message: str, *, limit: int = 280) -> str:
+    text = " ".join(message.split())
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3].rstrip()}..."
+
+
+def _provider_display_name(provider: str | None) -> str:
+    normalized = (provider or "").strip().lower()
+    if normalized == "openai":
+        return "OpenAI"
+    if normalized == "anthropic":
+        return "Anthropic"
+    if normalized:
+        return normalized.capitalize()
+    return "Observer"
+
+
+def _summarize_flush_failure(exc: Exception, *, provider: str | None) -> str:
+    provider_title = _provider_display_name(provider)
+    raw_message = str(exc).strip().lower()
+    if isinstance(exc, ObserverAuthError):
+        return f"{provider_title} authentication failed. Refresh credentials and retry."
+    if isinstance(exc, TimeoutError):
+        return f"{provider_title} request timed out during raw-event processing."
+    if raw_message == "observer failed during raw-event flush":
+        return f"{provider_title} returned no usable output for raw-event processing."
+    if "parse" in raw_message or "xml" in raw_message or "json" in raw_message:
+        return f"{provider_title} response could not be processed."
+    return f"{provider_title} processing failed during raw-event ingestion."
+
+
+def _flush_failure_details(exc: Exception) -> dict[str, str | None]:
+    observer = plugin_ingest.OBSERVER
+    active = observer.get_status() if observer is not None else None
+    provider = (
+        str(active.get("provider") or "").strip() or None if isinstance(active, dict) else None
+    )
+    model = str(active.get("model") or "").strip() or None if isinstance(active, dict) else None
+    runtime = str(active.get("runtime") or "").strip() or None if isinstance(active, dict) else None
+    last_error = active.get("last_error") if isinstance(active, dict) else None
+    last_error_message = None
+    last_error_code = None
+    if isinstance(last_error, dict):
+        last_error_message = str(last_error.get("message") or "").strip() or None
+        last_error_code = str(last_error.get("code") or "").strip() or None
+    logger.warning(
+        "raw event flush failed",
+        extra={
+            "observer_provider": provider or "unknown",
+            "observer_model": model or "unknown",
+            "observer_runtime": runtime or "unknown",
+            "error_type": exc.__class__.__name__,
+        },
+        exc_info=exc,
+    )
+    return {
+        "message": _truncate_error_message(
+            last_error_message or _summarize_flush_failure(exc, provider=provider)
+        ),
+        "error_type": last_error_code or exc.__class__.__name__,
+        "observer_provider": provider,
+        "observer_model": model,
+        "observer_runtime": runtime,
+    }
 
 
 def build_session_context(events: list[dict[str, Any]]) -> dict[str, Any]:
@@ -155,8 +225,16 @@ def flush_raw_events(
     }
     try:
         ingest(payload)
-    except Exception:
-        store.update_raw_event_flush_batch_status(batch_id, RAW_EVENT_QUEUE_FAILED)
+    except Exception as exc:
+        details = _flush_failure_details(exc)
+        store.record_raw_event_flush_batch_failure(
+            batch_id,
+            message=str(details["message"] or exc.__class__.__name__),
+            error_type=str(details["error_type"] or exc.__class__.__name__),
+            observer_provider=details["observer_provider"],
+            observer_model=details["observer_model"],
+            observer_runtime=details["observer_runtime"],
+        )
         raise
     store.update_raw_event_flush_batch_status(batch_id, "completed")
     store.update_raw_event_flush_state(opencode_session_id, last_event_seq, source=source)

--- a/codemem/store/_store.py
+++ b/codemem/store/_store.py
@@ -1460,6 +1460,26 @@ class MemoryStore:
     def update_raw_event_flush_batch_status(self, batch_id: int, status: str) -> None:
         store_raw_events.update_raw_event_flush_batch_status(self.conn, batch_id, status)
 
+    def record_raw_event_flush_batch_failure(
+        self,
+        batch_id: int,
+        *,
+        message: str,
+        error_type: str,
+        observer_provider: str | None,
+        observer_model: str | None,
+        observer_runtime: str | None,
+    ) -> None:
+        store_raw_events.record_raw_event_flush_batch_failure(
+            self.conn,
+            batch_id,
+            message=message,
+            error_type=error_type,
+            observer_provider=observer_provider,
+            observer_model=observer_model,
+            observer_runtime=observer_runtime,
+        )
+
     def record_raw_event(
         self,
         *,
@@ -1657,6 +1677,9 @@ class MemoryStore:
             source=source,
             limit=limit,
         )
+
+    def latest_raw_event_flush_failure(self, *, source: str | None = None) -> dict[str, Any] | None:
+        return store_raw_events.latest_raw_event_flush_failure(self.conn, source=source)
 
     def raw_event_reliability_metrics(self, *, window_hours: float | None = None) -> dict[str, Any]:
         if window_hours is None:

--- a/codemem/store/raw_events.py
+++ b/codemem/store/raw_events.py
@@ -143,8 +143,68 @@ def update_raw_event_flush_batch_status(
 ) -> None:
     now = dt.datetime.now(dt.UTC).isoformat()
     conn.execute(
-        "UPDATE raw_event_flush_batches SET status = ?, updated_at = ? WHERE id = ?",
-        (status, now, batch_id),
+        (
+            "UPDATE raw_event_flush_batches "
+            "SET status = ?, updated_at = ?, "
+            "error_message = CASE WHEN ? = ? THEN error_message ELSE NULL END, "
+            "error_type = CASE WHEN ? = ? THEN error_type ELSE NULL END, "
+            "observer_provider = CASE WHEN ? = ? THEN observer_provider ELSE NULL END, "
+            "observer_model = CASE WHEN ? = ? THEN observer_model ELSE NULL END, "
+            "observer_runtime = CASE WHEN ? = ? THEN observer_runtime ELSE NULL END "
+            "WHERE id = ?"
+        ),
+        (
+            status,
+            now,
+            status,
+            RAW_EVENT_QUEUE_FAILED,
+            status,
+            RAW_EVENT_QUEUE_FAILED,
+            status,
+            RAW_EVENT_QUEUE_FAILED,
+            status,
+            RAW_EVENT_QUEUE_FAILED,
+            status,
+            RAW_EVENT_QUEUE_FAILED,
+            batch_id,
+        ),
+    )
+    conn.commit()
+
+
+def record_raw_event_flush_batch_failure(
+    conn: sqlite3.Connection,
+    batch_id: int,
+    *,
+    message: str,
+    error_type: str,
+    observer_provider: str | None,
+    observer_model: str | None,
+    observer_runtime: str | None,
+) -> None:
+    now = dt.datetime.now(dt.UTC).isoformat()
+    conn.execute(
+        """
+        UPDATE raw_event_flush_batches
+        SET status = ?,
+            updated_at = ?,
+            error_message = ?,
+            error_type = ?,
+            observer_provider = ?,
+            observer_model = ?,
+            observer_runtime = ?
+        WHERE id = ?
+        """,
+        (
+            RAW_EVENT_QUEUE_FAILED,
+            now,
+            message,
+            error_type,
+            observer_provider,
+            observer_model,
+            observer_runtime,
+            batch_id,
+        ),
     )
     conn.commit()
 
@@ -1045,7 +1105,19 @@ def raw_event_error_batches(
     )
     rows = conn.execute(
         """
-        SELECT id, start_event_seq, end_event_seq, extractor_version, status, updated_at
+        SELECT
+            id,
+            start_event_seq,
+            end_event_seq,
+            extractor_version,
+            status,
+            updated_at,
+            attempt_count,
+            error_message,
+            error_type,
+            observer_provider,
+            observer_model,
+            observer_runtime
         FROM raw_event_flush_batches
         WHERE source = ? AND stream_id = ? AND status IN ('error', ?)
         ORDER BY updated_at DESC
@@ -1059,6 +1131,42 @@ def raw_event_error_batches(
         item["status"] = "error"
         items.append(item)
     return items
+
+
+def latest_raw_event_flush_failure(
+    conn: sqlite3.Connection, *, source: str | None = None
+) -> dict[str, Any] | None:
+    query = """
+        SELECT
+            id,
+            source,
+            stream_id,
+            opencode_session_id,
+            start_event_seq,
+            end_event_seq,
+            extractor_version,
+            status,
+            updated_at,
+            attempt_count,
+            error_message,
+            error_type,
+            observer_provider,
+            observer_model,
+            observer_runtime
+        FROM raw_event_flush_batches
+        WHERE status IN ('error', ?)
+    """
+    params: list[Any] = [RAW_EVENT_QUEUE_FAILED]
+    if source is not None:
+        query += " AND source = ?"
+        params.append(source.strip().lower() or "opencode")
+    query += " ORDER BY updated_at DESC LIMIT 1"
+    row = conn.execute(query, tuple(params)).fetchone()
+    if row is None:
+        return None
+    item = dict(row)
+    item["status"] = "error"
+    return item
 
 
 def mark_stuck_raw_event_batches_as_error(
@@ -1078,7 +1186,13 @@ def mark_stuck_raw_event_batches_as_error(
             LIMIT ?
         )
         UPDATE raw_event_flush_batches
-        SET status = ?, updated_at = ?
+        SET status = ?,
+            updated_at = ?,
+            error_message = 'Flush retry timed out.',
+            error_type = 'RawEventBatchStuck',
+            observer_provider = NULL,
+            observer_model = NULL,
+            observer_runtime = NULL
         WHERE id IN (SELECT id FROM candidates)
         """,
         (

--- a/codemem/viewer.py
+++ b/codemem/viewer.py
@@ -103,7 +103,7 @@ class ViewerHandler(BaseHTTPRequestHandler):
                 return
             if viewer_routes_memory.handle_get(self, store, parsed.path, parsed.query):
                 return
-            if viewer_routes_observer_status.handle_get(self, parsed.path):
+            if viewer_routes_observer_status.handle_get(self, store, parsed.path):
                 return
             if viewer_routes_config.handle_get(
                 self,

--- a/codemem/viewer_raw_events.py
+++ b/codemem/viewer_raw_events.py
@@ -286,6 +286,14 @@ class RawEventSweeper:
         self._auth_error_logged = False
         self._wake.set()
 
+    def auth_backoff_status(self) -> dict[str, int | bool]:
+        now = time.time()
+        remaining = max(0, int(self._auth_backoff_until - now))
+        return {
+            "active": remaining > 0,
+            "remaining_s": remaining,
+        }
+
     def _run(self) -> None:
         while not self._stop.is_set():
             interval_ms = max(1000, self.interval_ms())

--- a/codemem/viewer_routes/observer_status.py
+++ b/codemem/viewer_routes/observer_status.py
@@ -4,13 +4,39 @@ from typing import Any, Protocol
 
 from .. import plugin_ingest as _plugin_ingest
 from ..observer import probe_available_credentials
+from ..viewer_raw_events import RAW_EVENT_SWEEPER
 
 
 class _ViewerHandler(Protocol):
     def _send_json(self, payload: dict[str, Any], status: int = 200) -> None: ...
 
 
-def handle_get(handler: _ViewerHandler, path: str) -> bool:
+class _Store(Protocol):
+    def raw_event_backlog_totals(self) -> dict[str, int]: ...
+
+    def latest_raw_event_flush_failure(
+        self, *, source: str | None = None
+    ) -> dict[str, Any] | None: ...
+
+
+def _build_failure_impact(
+    latest_failure: dict[str, Any] | None,
+    queue_totals: dict[str, int],
+    auth_backoff: dict[str, Any],
+) -> str | None:
+    if latest_failure is None:
+        return None
+    pending = int(queue_totals.get("pending") or 0)
+    sessions = int(queue_totals.get("sessions") or 0)
+    if bool(auth_backoff.get("active")):
+        remaining = int(auth_backoff.get("remaining_s") or 0)
+        return f"Queue retries paused for ~{remaining}s after an observer auth failure."
+    if pending > 0:
+        return f"{pending} queued raw events across {sessions} session(s) are waiting on a successful flush."
+    return "Failed flush batches are pending retry."
+
+
+def handle_get(handler: _ViewerHandler, store: _Store, path: str) -> bool:
     if path != "/api/observer-status":
         return False
 
@@ -19,11 +45,23 @@ def handle_get(handler: _ViewerHandler, path: str) -> bool:
     observer = _plugin_ingest.OBSERVER
     if observer is not None:
         active = observer.get_status()
+    latest_failure = store.latest_raw_event_flush_failure()
+    queue_totals = store.raw_event_backlog_totals()
+    auth_backoff = RAW_EVENT_SWEEPER.auth_backoff_status()
+    if latest_failure is not None:
+        latest_failure = dict(latest_failure)
+        latest_failure["impact"] = _build_failure_impact(latest_failure, queue_totals, auth_backoff)
 
     handler._send_json(
         {
             "active": active,
             "available_credentials": available,
+            "latest_failure": latest_failure,
+            "queue": {
+                **queue_totals,
+                "auth_backoff_active": bool(auth_backoff.get("active")),
+                "auth_backoff_remaining_s": int(auth_backoff.get("remaining_s") or 0),
+            },
         }
     )
     return True

--- a/codemem/viewer_static/app.js
+++ b/codemem/viewer_static/app.js
@@ -3484,6 +3484,12 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
     if (text) el2.textContent = text;
     return el2;
   }
+  function formatFailureTimestamp(value) {
+    if (typeof value !== "string" || !value.trim()) return "Unknown time";
+    const ts = new Date(value);
+    if (Number.isNaN(ts.getTime())) return value;
+    return ts.toLocaleString();
+  }
   function renderObserverStatusBanner(status) {
     const banner = $("observerStatusBanner");
     if (!banner) return;
@@ -3527,6 +3533,34 @@ Global: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : "";
         row.append(span);
       });
       banner.append(row);
+    }
+    const failure = status.latest_failure;
+    if (failure && typeof failure === "object") {
+      banner.append(createEl("div", "status-label", "Latest processing issue"));
+      const box = createEl("div", "status-issue");
+      const message = typeof failure.error_message === "string" && failure.error_message.trim() ? failure.error_message.trim() : "Raw-event processing failed.";
+      box.append(createEl("div", "status-issue-message", message));
+      const detailParts = [];
+      const provider = typeof failure.observer_provider === "string" ? failure.observer_provider.trim() : "";
+      const model = typeof failure.observer_model === "string" ? failure.observer_model.trim() : "";
+      const runtime = typeof failure.observer_runtime === "string" ? failure.observer_runtime.trim() : "";
+      if (provider || model || runtime) {
+        const flow = [provider || "observer", model ? `→ ${model}` : "", runtime ? `(${runtime})` : ""].filter(Boolean).join(" ").replace(/\s+/g, " ").trim();
+        if (flow) detailParts.push(flow);
+      }
+      const failedAt = formatFailureTimestamp(failure.updated_at);
+      if (failedAt) detailParts.push(`Last failure ${failedAt}`);
+      if (typeof failure.attempt_count === "number" && Number.isFinite(failure.attempt_count)) {
+        detailParts.push(`Attempts ${failure.attempt_count}`);
+      }
+      if (detailParts.length) {
+        box.append(createEl("div", "status-issue-meta", detailParts.join(" · ")));
+      }
+      const impact = typeof failure.impact === "string" ? failure.impact.trim() : "";
+      if (impact) {
+        box.append(createEl("div", "status-issue-impact", impact));
+      }
+      banner.append(box);
     }
     banner.hidden = false;
   }

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1241,6 +1241,25 @@
         align-items: center;
         gap: 4px;
       }
+      .observer-status-banner .status-issue {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 8px 10px;
+        border: 1px solid rgba(248, 113, 113, 0.32);
+        border-radius: var(--radius-sm);
+        background: rgba(248, 113, 113, 0.08);
+      }
+      .observer-status-banner .status-issue-message {
+        color: var(--text-primary);
+        font-weight: 500;
+      }
+      .observer-status-banner .status-issue-meta {
+        color: var(--text-secondary);
+      }
+      .observer-status-banner .status-issue-impact {
+        color: #fbbf24;
+      }
       .observer-status-banner .cred-ok { color: var(--semantic-success, #4ade80); }
       .observer-status-banner .cred-none { color: var(--text-tertiary); }
       .settings-group {

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -122,7 +122,7 @@ slash commands in the OpenCode chat input.
 ## Observer model defaults
 
 - OpenAI: `gpt-5.1-codex-mini`
-- Anthropic: `claude-4.5-haiku`
+- Anthropic: `claude-4.5-haiku` (mapped to Anthropic direct API alias `claude-haiku-4-5` when using `api_http`)
 
 Provider/model selection can be overridden with `CODEMEM_OBSERVER_PROVIDER` and
 `CODEMEM_OBSERVER_MODEL`. Custom providers are loaded from OpenCode config.
@@ -135,8 +135,9 @@ Observer execution in `0.16` supports both API and Claude runtime paths.
 - `claude_sidecar` runs observer calls via local Claude runtime auth (no `ANTHROPIC_API_KEY` required).
 - `claude_sidecar` uses `claude_command` (or `CODEMEM_CLAUDE_COMMAND`) as argv prefix for launching Claude CLI. Default: `["claude"]`.
 - Default models:
-  - `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
-  - `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.
+- `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
+- `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.
+- Anthropic direct API calls accept Anthropic model IDs/aliases; use `claude-haiku-4-5-20251001` if you need a pinned snapshot instead of the moving alias.
 - If `observer_model` is unsupported in Claude CLI, codemem retries once without `--model`.
 - Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
 - Supported: API keys and gateway tokens codemem can read directly.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -31,6 +31,7 @@
 - Default model selection:
   - `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
   - `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.
+- Anthropic direct API calls use Anthropic's direct model IDs. codemem translates the common shorthand `claude-4.5-haiku` to `claude-haiku-4-5`; if you want a fixed snapshot, set a versioned model like `claude-haiku-4-5-20251001` directly.
 - If a configured `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's default model.
 - Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` is argv and must be a JSON string array, not a space-separated string.

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 from codemem import db
@@ -618,7 +619,129 @@ def test_initialize_schema_skips_raw_event_backfill_for_already_migrated_v4(
         db.initialize_schema(conn)
 
         row = conn.execute("PRAGMA user_version").fetchone()
-        assert row is not None
-        assert int(row[0]) == db.SCHEMA_VERSION
     finally:
         conn.close()
+
+    assert row is not None
+    assert int(row[0]) == db.SCHEMA_VERSION
+
+
+def test_rebuild_raw_event_identity_tables_tolerates_missing_failure_columns(
+    tmp_path: Path,
+) -> None:
+    conn = sqlite3.connect(tmp_path / "mem.sqlite")
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id INTEGER PRIMARY KEY,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                cwd TEXT,
+                project TEXT,
+                git_remote TEXT,
+                git_branch TEXT,
+                user TEXT,
+                tool_version TEXT,
+                metadata_json TEXT,
+                import_key TEXT
+            );
+
+            CREATE TABLE raw_events (
+                id INTEGER PRIMARY KEY,
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL,
+                opencode_session_id TEXT NOT NULL,
+                event_id TEXT,
+                event_seq INTEGER NOT NULL,
+                event_type TEXT NOT NULL,
+                ts_wall_ms INTEGER,
+                ts_mono_ms REAL,
+                payload_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(source, stream_id, event_seq),
+                UNIQUE(source, stream_id, event_id)
+            );
+
+            CREATE TABLE raw_event_sessions (
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL,
+                opencode_session_id TEXT NOT NULL,
+                cwd TEXT,
+                project TEXT,
+                started_at TEXT,
+                last_seen_ts_wall_ms INTEGER,
+                last_received_event_seq INTEGER NOT NULL DEFAULT -1,
+                last_flushed_event_seq INTEGER NOT NULL DEFAULT -1,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (source, stream_id)
+            );
+
+            CREATE TABLE raw_event_flush_batches (
+                id INTEGER PRIMARY KEY,
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL,
+                opencode_session_id TEXT NOT NULL,
+                start_event_seq INTEGER NOT NULL,
+                end_event_seq INTEGER NOT NULL,
+                extractor_version TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                UNIQUE(source, stream_id, start_event_seq, end_event_seq, extractor_version)
+            );
+
+            CREATE TABLE opencode_sessions (
+                source TEXT NOT NULL DEFAULT 'opencode',
+                stream_id TEXT NOT NULL,
+                opencode_session_id TEXT NOT NULL,
+                session_id INTEGER REFERENCES sessions(id) ON DELETE CASCADE,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (source, stream_id)
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO raw_event_flush_batches(id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq, extractor_version, status, created_at, updated_at, attempt_count) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                1,
+                "opencode",
+                "sess-1",
+                "sess-1",
+                0,
+                2,
+                "v1",
+                "failed",
+                "2026-01-01T00:00:00Z",
+                "2026-01-01T00:00:00Z",
+                2,
+            ),
+        )
+        conn.commit()
+
+        db._rebuild_raw_event_identity_tables(conn)
+
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(raw_event_flush_batches)").fetchall()
+        }
+        row = conn.execute(
+            "SELECT error_message, error_type, observer_provider, observer_model, observer_runtime, attempt_count FROM raw_event_flush_batches WHERE id = 1"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert {
+        "error_message",
+        "error_type",
+        "observer_provider",
+        "observer_model",
+        "observer_runtime",
+    }.issubset(columns)
+    assert row is not None
+    assert row[0] is None
+    assert row[1] is None
+    assert row[2] is None
+    assert row[3] is None
+    assert row[4] is None
+    assert int(row[5]) == 2

--- a/tests/test_observer_anthropic.py
+++ b/tests/test_observer_anthropic.py
@@ -18,6 +18,8 @@ from codemem.observer_anthropic import (
     ANTHROPIC_OAUTH_USER_AGENT,
     _build_anthropic_headers,
     _build_anthropic_payload,
+    _extract_anthropic_error_details,
+    _normalize_anthropic_model,
     _parse_anthropic_stream,
     _resolve_anthropic_endpoint,
 )
@@ -33,15 +35,34 @@ def test_build_anthropic_headers_sets_bearer_auth() -> None:
     assert "x-api-key" not in headers
 
 
+def test_normalize_anthropic_model_maps_opencode_alias() -> None:
+    assert _normalize_anthropic_model("claude-4.5-haiku") == "claude-haiku-4-5"
+
+
 def test_build_anthropic_payload_structure() -> None:
     payload = _build_anthropic_payload("claude-4.5-haiku", "hello world", 1024)
-    assert payload["model"] == "claude-4.5-haiku"
+    assert payload["model"] == "claude-haiku-4-5"
     assert payload["max_tokens"] == 1024
     assert payload["stream"] is True
     assert payload["system"] == "You are a memory observer."
     assert len(payload["messages"]) == 1
     assert payload["messages"][0]["role"] == "user"
     assert payload["messages"][0]["content"] == "hello world"
+
+
+def test_build_anthropic_payload_preserves_direct_model_id() -> None:
+    payload = _build_anthropic_payload("claude-haiku-4-5-20251001", "hello world", 1024)
+    assert payload["model"] == "claude-haiku-4-5-20251001"
+
+
+def test_extract_anthropic_error_details_for_invalid_model() -> None:
+    details = _extract_anthropic_error_details(
+        '{"type":"error","error":{"type":"not_found_error","message":"model: claude-4.5-haiku"}}'
+    )
+    assert details == {
+        "code": "invalid_model_id",
+        "message": "Anthropic model ID not found: claude-4.5-haiku.",
+    }
 
 
 def test_resolve_anthropic_endpoint_default() -> None:
@@ -209,6 +230,7 @@ def test_anthropic_consumer_call_success(tmp_path: Path) -> None:
 
     stream_lines = _anthropic_sse_lines("observer result")
     fake_response = _FakeStreamResponse(stream_lines, status_code=200)
+    captured_json: dict[str, Any] = {}
 
     class FakeHTTPXClient:
         def __init__(self, **_kwargs: object) -> None:
@@ -223,6 +245,9 @@ def test_anthropic_consumer_call_success(tmp_path: Path) -> None:
         def stream(self, method: str, url: str, **kwargs: object):
             self._captured_url = url
             self._captured_headers = kwargs.get("headers", {})
+            payload = kwargs.get("json")
+            if isinstance(payload, dict):
+                captured_json.update(payload)
             return _StreamContextManager(fake_response)
 
     class _StreamContextManager:
@@ -240,6 +265,7 @@ def test_anthropic_consumer_call_success(tmp_path: Path) -> None:
         result = client._call("hello")
 
     assert result == "observer result"
+    assert captured_json["model"] == "claude-haiku-4-5"
 
 
 def test_anthropic_consumer_call_auth_error(tmp_path: Path) -> None:
@@ -277,6 +303,49 @@ def test_anthropic_consumer_call_auth_error(tmp_path: Path) -> None:
         pytest.raises(ObserverAuthError),
     ):
         client._call("hello")
+
+
+def test_anthropic_consumer_records_invalid_model_error_on_status(tmp_path: Path) -> None:
+    client = _make_anthropic_oauth_client(tmp_path)
+
+    fake_response = _FakeStreamResponse(
+        [],
+        status_code=404,
+        text='{"type":"error","error":{"type":"not_found_error","message":"model: claude-4.5-haiku"}}',
+    )
+
+    class FakeHTTPXClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object):
+            pass
+
+        def stream(self, method: str, url: str, **kwargs: object):
+            return _StreamContextManager(fake_response)
+
+    class _StreamContextManager:
+        def __init__(self, resp: object) -> None:
+            self._resp = resp
+
+        def __enter__(self):
+            return self._resp
+
+        def __exit__(self, *_args: object):
+            pass
+
+    httpx_module = SimpleNamespace(Client=FakeHTTPXClient)
+    with patch.dict(sys.modules, {"httpx": httpx_module}):
+        result = client._call("hello")
+
+    assert result is None
+    assert client.get_status()["last_error"] == {
+        "code": "invalid_model_id",
+        "message": "Anthropic model ID not found: claude-4.5-haiku.",
+    }
 
 
 def test_anthropic_consumer_sends_correct_headers(tmp_path: Path) -> None:

--- a/tests/test_raw_event_retry.py
+++ b/tests/test_raw_event_retry.py
@@ -49,6 +49,11 @@ def test_raw_event_retry_from_error_batch(tmp_path: Path) -> None:
         patch.dict("os.environ", {"CODEMEM_DB": str(tmp_path / "mem.sqlite")}),
     ):
         observer.observe.side_effect = RuntimeError("boom")
+        observer.get_status.return_value = {
+            "provider": "openai",
+            "model": "gpt-5.1-codex-mini",
+            "runtime": "api_http",
+        }
         pre.return_value = {"project": "test"}
         post.return_value = {"git_diff": "", "recent_files": ""}
 
@@ -64,6 +69,14 @@ def test_raw_event_retry_from_error_batch(tmp_path: Path) -> None:
         errors = store.raw_event_error_batches("sess-retry", limit=10)
         assert len(errors) == 1
         assert errors[0]["status"] == "error"
+        assert errors[0]["error_type"] == "RuntimeError"
+        assert errors[0]["error_message"] == "OpenAI processing failed during raw-event ingestion."
+
+        latest_failure = store.latest_raw_event_flush_failure()
+        assert latest_failure is not None
+        assert latest_failure["stream_id"] == "sess-retry"
+        assert latest_failure["observer_provider"] == "openai"
+        assert latest_failure["observer_runtime"] == "api_http"
 
         observer.observe.side_effect = None
         observer.observe.return_value = mock_response
@@ -78,3 +91,87 @@ def test_raw_event_retry_from_error_batch(tmp_path: Path) -> None:
         )
         assert result["flushed"] == 2
         assert store.raw_event_error_batches("sess-retry", limit=10) == []
+        assert store.latest_raw_event_flush_failure() is None
+
+
+def test_raw_event_retry_replaces_stale_failure_details_when_batch_gets_stuck(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    batch_id, _ = store.get_or_create_raw_event_flush_batch(
+        opencode_session_id="sess-stuck",
+        start_event_seq=0,
+        end_event_seq=1,
+        extractor_version="v1",
+    )
+    store.record_raw_event_flush_batch_failure(
+        batch_id,
+        message="Anthropic processing failed during raw-event ingestion.",
+        error_type="RuntimeError",
+        observer_provider="anthropic",
+        observer_model="claude-4.5-haiku",
+        observer_runtime="api_http",
+    )
+
+    claimed = store.claim_raw_event_flush_batch(batch_id)
+    assert claimed is True
+
+    changed = store.mark_stuck_raw_event_batches_as_error(
+        older_than_iso="9999-01-01T00:00:00+00:00",
+        limit=10,
+    )
+    assert changed == 1
+
+    latest_failure = store.latest_raw_event_flush_failure()
+    assert latest_failure is not None
+    assert latest_failure["error_type"] == "RawEventBatchStuck"
+    assert latest_failure["error_message"] == "Flush retry timed out."
+    assert latest_failure["observer_provider"] is None
+    assert latest_failure["observer_model"] is None
+    assert latest_failure["observer_runtime"] is None
+
+
+def test_raw_event_retry_uses_observer_last_error_details(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "mem.sqlite")
+    store.record_raw_event(
+        opencode_session_id="sess-invalid-model",
+        event_id="evt-0",
+        event_type="user_prompt",
+        payload={"type": "user_prompt", "prompt_text": "Hello"},
+        ts_wall_ms=100,
+        ts_mono_ms=1.0,
+    )
+
+    with (
+        patch("codemem.plugin_ingest.OBSERVER") as observer,
+        patch("codemem.plugin_ingest.capture_pre_context", return_value={"project": "test"}),
+        patch(
+            "codemem.plugin_ingest.capture_post_context",
+            return_value={"git_diff": "", "recent_files": ""},
+        ),
+        patch.dict("os.environ", {"CODEMEM_DB": str(tmp_path / "mem.sqlite")}),
+    ):
+        observer.observe.side_effect = RuntimeError("observer failed during raw-event flush")
+        observer.get_status.return_value = {
+            "provider": "anthropic",
+            "model": "claude-4.5-haiku",
+            "runtime": "api_http",
+            "last_error": {
+                "code": "invalid_model_id",
+                "message": "Anthropic model ID not found: claude-4.5-haiku.",
+            },
+        }
+
+        with contextlib.suppress(RuntimeError):
+            flush_raw_events(
+                store,
+                opencode_session_id="sess-invalid-model",
+                cwd=str(tmp_path),
+                project="test",
+                started_at="2026-01-01T00:00:00Z",
+            )
+
+    latest_failure = store.latest_raw_event_flush_failure()
+    assert latest_failure is not None
+    assert latest_failure["error_type"] == "invalid_model_id"
+    assert latest_failure["error_message"] == "Anthropic model ID not found: claude-4.5-haiku."

--- a/tests/test_viewer_routes_observer_status.py
+++ b/tests/test_viewer_routes_observer_status.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from codemem.viewer_routes import observer_status
+
+
+class DummyHandler:
+    def __init__(self) -> None:
+        self.response: dict[str, Any] | None = None
+        self.status: int | None = None
+
+    def _send_json(self, payload: dict[str, Any], status: int = 200) -> None:
+        self.response = payload
+        self.status = status
+
+
+class DummyStore:
+    def __init__(self, latest_failure: dict[str, Any] | None = None) -> None:
+        self._latest_failure = latest_failure
+
+    def raw_event_backlog_totals(self) -> dict[str, int]:
+        return {"sessions": 2, "pending": 14}
+
+    def latest_raw_event_flush_failure(self, *, source: str | None = None) -> dict[str, Any] | None:
+        _ = source
+        return self._latest_failure
+
+
+def test_handle_get_returns_latest_failure_details() -> None:
+    handler = DummyHandler()
+    store = DummyStore(
+        latest_failure={
+            "stream_id": "sess-1",
+            "status": "error",
+            "updated_at": "2026-03-15T20:00:00Z",
+            "attempt_count": 3,
+            "error_message": "observer anthropic oauth call failed",
+            "error_type": "RuntimeError",
+            "observer_provider": "anthropic",
+            "observer_model": "claude-4.5-haiku",
+            "observer_runtime": "api_http",
+        }
+    )
+
+    with (
+        patch.object(
+            observer_status,
+            "probe_available_credentials",
+            return_value={"anthropic": {"oauth": True}},
+        ),
+        patch.object(observer_status._plugin_ingest, "OBSERVER", None),
+        patch.object(
+            observer_status.RAW_EVENT_SWEEPER,
+            "auth_backoff_status",
+            return_value={"active": False, "remaining_s": 0},
+        ),
+    ):
+        handled = observer_status.handle_get(handler, store, "/api/observer-status")
+
+    assert handled is True
+    assert handler.status == 200
+    assert handler.response is not None
+    assert handler.response["queue"] == {
+        "sessions": 2,
+        "pending": 14,
+        "auth_backoff_active": False,
+        "auth_backoff_remaining_s": 0,
+    }
+    assert handler.response["latest_failure"]["observer_provider"] == "anthropic"
+    assert "waiting on a successful flush" in handler.response["latest_failure"]["impact"]
+
+
+def test_handle_get_reports_auth_backoff_impact() -> None:
+    handler = DummyHandler()
+    store = DummyStore(
+        latest_failure={
+            "stream_id": "sess-2",
+            "status": "error",
+            "updated_at": "2026-03-15T20:00:00Z",
+            "attempt_count": 1,
+            "error_message": "observer auth error",
+            "error_type": "ObserverAuthError",
+            "observer_provider": "anthropic",
+            "observer_model": "claude-4.5-haiku",
+            "observer_runtime": "api_http",
+        }
+    )
+
+    with (
+        patch.object(observer_status, "probe_available_credentials", return_value={}),
+        patch.object(observer_status._plugin_ingest, "OBSERVER", None),
+        patch.object(
+            observer_status.RAW_EVENT_SWEEPER,
+            "auth_backoff_status",
+            return_value={"active": True, "remaining_s": 287},
+        ),
+    ):
+        observer_status.handle_get(handler, store, "/api/observer-status")
+
+    assert handler.response is not None
+    assert handler.response["queue"]["auth_backoff_active"] is True
+    assert handler.response["queue"]["auth_backoff_remaining_s"] == 287
+    assert "paused for ~287s" in handler.response["latest_failure"]["impact"]

--- a/viewer_ui/src/tabs/settings.ts
+++ b/viewer_ui/src/tabs/settings.ts
@@ -818,6 +818,13 @@ function createEl(tag: string, className?: string, text?: string): HTMLElement {
   return el;
 }
 
+function formatFailureTimestamp(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) return 'Unknown time';
+  const ts = new Date(value);
+  if (Number.isNaN(ts.getTime())) return value;
+  return ts.toLocaleString();
+}
+
 function renderObserverStatusBanner(status: any) {
   const banner = $('observerStatusBanner');
   if (!banner) return;
@@ -866,6 +873,43 @@ function renderObserverStatusBanner(status: any) {
       row.append(span);
     });
     banner.append(row);
+  }
+
+  const failure = status.latest_failure;
+  if (failure && typeof failure === 'object') {
+    banner.append(createEl('div', 'status-label', 'Latest processing issue'));
+    const box = createEl('div', 'status-issue');
+    const message = typeof failure.error_message === 'string' && failure.error_message.trim()
+      ? failure.error_message.trim()
+      : 'Raw-event processing failed.';
+    box.append(createEl('div', 'status-issue-message', message));
+
+    const detailParts: string[] = [];
+    const provider = typeof failure.observer_provider === 'string' ? failure.observer_provider.trim() : '';
+    const model = typeof failure.observer_model === 'string' ? failure.observer_model.trim() : '';
+    const runtime = typeof failure.observer_runtime === 'string' ? failure.observer_runtime.trim() : '';
+    if (provider || model || runtime) {
+      const flow = [provider || 'observer', model ? `→ ${model}` : '', runtime ? `(${runtime})` : '']
+        .filter(Boolean)
+        .join(' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if (flow) detailParts.push(flow);
+    }
+    const failedAt = formatFailureTimestamp(failure.updated_at);
+    if (failedAt) detailParts.push(`Last failure ${failedAt}`);
+    if (typeof failure.attempt_count === 'number' && Number.isFinite(failure.attempt_count)) {
+      detailParts.push(`Attempts ${failure.attempt_count}`);
+    }
+    if (detailParts.length) {
+      box.append(createEl('div', 'status-issue-meta', detailParts.join(' · ')));
+    }
+
+    const impact = typeof failure.impact === 'string' ? failure.impact.trim() : '';
+    if (impact) {
+      box.append(createEl('div', 'status-issue-impact', impact));
+    }
+    banner.append(box);
   }
 
   banner.hidden = false;


### PR DESCRIPTION
## Description

This fixes two related observer issues:
- the viewer now surfaces the latest raw-event processing failure with queue impact so observer problems are visible instead of showing only backlog symptoms
- the Anthropic direct API path now maps the legacy Claude shorthand `claude-4.5-haiku` to Anthropic's supported direct API alias `claude-haiku-4-5`, which fixes the invalid model ID failure that caused raw-event flushes to stall

It also preserves known provider error details through the flush pipeline so the UI can show actionable messages like invalid model IDs instead of only a generic processing failure.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [ ] 🚀 Feature (new functionality)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- Targeted checks run locally:
  - `uv run pytest tests/test_raw_event_flush.py tests/test_observer_anthropic.py tests/test_raw_event_retry.py tests/test_observer_status.py tests/test_db_schema.py tests/test_viewer_routes_observer_status.py`
  - `uv run ruff check codemem tests`
  - `bun run check && bun run build` (in `viewer_ui/`)
- Manual verification:
  - reproduced the Anthropic direct API failure from viewer logs
  - confirmed the root cause was an invalid Anthropic model ID
  - confirmed using the correct Anthropic alias resolves the issue

## Checklist

- [x] Code follows project style (`ruff check` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced