### PR TITLE
fix(observer): unify Anthropic SDK path on Messages API and fix user-agent

### DIFF
--- a/codemem/observer.py
+++ b/codemem/observer.py
@@ -543,13 +543,15 @@ class ObserverClient:
                 return None
         try:
             if self.provider == "anthropic":
-                resp = self.client.completions.create(  # type: ignore[union-attr]
+                resp = self.client.messages.create(  # type: ignore[union-attr]
                     model=self.model,
-                    prompt=f"\nHuman: {prompt}\nAssistant:",
-                    temperature=0,
-                    max_tokens_to_sample=self.max_tokens,
+                    system="You are a memory observer.",
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=self.max_tokens,
                 )
-                return resp.completion
+                # Concatenate all text content blocks (Anthropic may split across multiple)
+                text_blocks = [b.text for b in resp.content if hasattr(b, "text")]
+                return "".join(text_blocks) if text_blocks else None
             resp = self.client.chat.completions.create(  # type: ignore[union-attr]
                 model=self.model,
                 messages=[

--- a/codemem/observer_anthropic.py
+++ b/codemem/observer_anthropic.py
@@ -4,11 +4,12 @@ import json
 import os
 from typing import Any
 
+from . import __version__
 from . import observer_auth as _observer_auth
 
 ANTHROPIC_MESSAGES_ENDPOINT = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_OAUTH_BETA = "oauth-2025-04-20"
-ANTHROPIC_OAUTH_USER_AGENT = "claude-cli/2.1.2 (external, cli)"
+ANTHROPIC_OAUTH_USER_AGENT = f"codemem/{__version__}"
 
 _ANTHROPIC_MODEL_ALIASES = {
     "claude-4.5-haiku": "claude-haiku-4-5",

--- a/tests/test_observer_provider_loop.py
+++ b/tests/test_observer_provider_loop.py
@@ -71,16 +71,16 @@ def _make_openai_backend(behavior: str, attempts: list[str]) -> SimpleNamespace:
 
 
 def _make_anthropic_backend(behavior: str, attempts: list[str]) -> SimpleNamespace:
-    class AnthropicCompletions:
+    class AnthropicMessages:
         def create(self, **_kwargs):
             attempts.append("attempt")
             if behavior == "raises":
                 raise RuntimeError("anthropic failed")
             if behavior == "malformed":
-                return SimpleNamespace()
-            return SimpleNamespace(completion="hello from adapter")
+                return SimpleNamespace(content=[])
+            return SimpleNamespace(content=[SimpleNamespace(text="hello from adapter")])
 
-    return SimpleNamespace(completions=AnthropicCompletions())
+    return SimpleNamespace(messages=AnthropicMessages())
 
 
 def _run_scenario(provider: str, scenario: Scenario) -> dict[str, object]:
@@ -102,7 +102,7 @@ def _run_scenario(provider: str, scenario: Scenario) -> dict[str, object]:
 
         class AnthropicStub:
             def __init__(self, **_kwargs: object) -> None:
-                self.completions = _make_anthropic_backend(scenario.behavior, attempts).completions
+                self.messages = _make_anthropic_backend(scenario.behavior, attempts).messages
 
         module_map = {"anthropic": SimpleNamespace(Anthropic=AnthropicStub)}
         cfg = OpencodeMemConfig(


### PR DESCRIPTION
## Description

Replace deprecated `completions.create` (doesn't support Claude 3+ models) with `messages.create` for the Anthropic SDK client path. Both the OAuth consumer path and the SDK path now use the same Messages API format.

Also fix hardcoded `claude-cli/2.1.2` user-agent in `observer_anthropic.py` to use `codemem/<version>` instead of impersonating another product.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] No new warnings introduced

Closes: codemem-a2mt, codemem-mh03