### PR TITLE
test: add pack and multi-filter parity fixtures

### DIFF
--- a/tests/parity/fixtures/pack_memory_layer.json
+++ b/tests/parity/fixtures/pack_memory_layer.json
@@ -1,0 +1,23 @@
+{
+  "method": "build_memory_pack",
+  "description": "Pack assembly for 'memory layer coding' — exercises search, dedup, section formatting",
+  "seed_db": "seed_v1",
+  "input": {
+    "context": "memory layer coding",
+    "limit": 5
+  },
+  "expected_output": {
+    "context": "memory layer coding",
+    "has_items": true,
+    "item_count_gte": 1,
+    "has_pack_text": true,
+    "has_metrics": true,
+    "item_ids": [
+      13,
+      1,
+      4,
+      8,
+      10
+    ]
+  }
+}

--- a/tests/parity/fixtures/recent_kind_change_filter.json
+++ b/tests/parity/fixtures/recent_kind_change_filter.json
@@ -1,0 +1,19 @@
+{
+  "method": "recent",
+  "description": "Recent with kind=change filter",
+  "seed_db": "seed_v1",
+  "input": {
+    "limit": 10,
+    "filters": {
+      "kind": "change"
+    }
+  },
+  "expected_output": {
+    "count": 2,
+    "all_change": true,
+    "ordered_ids": [
+      9,
+      2
+    ]
+  }
+}

--- a/tests/parity/fixtures/search_visibility_kind_filter.json
+++ b/tests/parity/fixtures/search_visibility_kind_filter.json
@@ -1,0 +1,22 @@
+{
+  "method": "search",
+  "description": "Search with include_visibility=shared AND kind=discovery filters combined",
+  "seed_db": "seed_v1",
+  "input": {
+    "query": "memory",
+    "limit": 10,
+    "filters": {
+      "kind": "discovery",
+      "include_visibility": [
+        "shared"
+      ]
+    }
+  },
+  "expected_output": {
+    "count": 1,
+    "all_discovery": true,
+    "ordered_ids": [
+      1
+    ]
+  }
+}

--- a/tests/parity/generate_fixtures.py
+++ b/tests/parity/generate_fixtures.py
@@ -753,6 +753,67 @@ def generate_update_visibility_fixture(store: MemoryStore, memory_ids: list[int]
     )
 
 
+def generate_pack_fixture(store: MemoryStore) -> None:
+    """Capture build_memory_pack behavior."""
+    pack = store.build_memory_pack("memory layer coding", limit=5, log_usage=False)
+    _write_fixture(
+        "pack_memory_layer",
+        {
+            "method": "build_memory_pack",
+            "description": "Pack assembly for 'memory layer coding' — exercises search, dedup, section formatting",
+            "seed_db": SEED_VERSION,
+            "input": {"context": "memory layer coding", "limit": 5},
+            "expected_output": {
+                "context": pack["context"],
+                "has_items": len(pack.get("items", [])) > 0,
+                "item_count_gte": 1,
+                "has_pack_text": bool(pack.get("pack_text")),
+                "has_metrics": bool(pack.get("metrics")),
+                "item_ids": [it["id"] for it in pack.get("items", []) if "id" in it],
+            },
+        },
+    )
+
+
+def generate_multi_filter_fixtures(store: MemoryStore) -> None:
+    """Capture search/recent with multiple filters combined."""
+    # visibility + kind filter
+    filters_vk: dict[str, Any] = {"kind": "discovery", "include_visibility": ["shared"]}
+    results_vk = list(store.search("memory", limit=10, filters=filters_vk))
+    _write_fixture(
+        "search_visibility_kind_filter",
+        {
+            "method": "search",
+            "description": "Search with include_visibility=shared AND kind=discovery filters combined",
+            "seed_db": SEED_VERSION,
+            "input": {"query": "memory", "limit": 10, "filters": filters_vk},
+            "expected_output": {
+                "count": len(results_vk),
+                "all_discovery": all(r.kind == "discovery" for r in results_vk),
+                "ordered_ids": [r.id for r in results_vk],
+            },
+        },
+    )
+
+    # recent with kind filter
+    filters_rk: dict[str, Any] = {"kind": "change"}
+    recent_vk = store.recent(limit=10, filters=filters_rk)
+    _write_fixture(
+        "recent_kind_change_filter",
+        {
+            "method": "recent",
+            "description": "Recent with kind=change filter",
+            "seed_db": SEED_VERSION,
+            "input": {"limit": 10, "filters": filters_rk},
+            "expected_output": {
+                "count": len(recent_vk),
+                "all_change": all(r.get("kind") == "change" for r in recent_vk),
+                "ordered_ids": [r["id"] for r in recent_vk],
+            },
+        },
+    )
+
+
 def main() -> None:
     import tempfile
 
@@ -774,6 +835,8 @@ def main() -> None:
         generate_recent_by_kinds_fixture(store)
         generate_stats_fixture(store)
         generate_update_visibility_fixture(store, memory_ids)
+        generate_pack_fixture(store)
+        generate_multi_filter_fixtures(store)
 
         store.close()
 

--- a/tests/parity/test_parity.py
+++ b/tests/parity/test_parity.py
@@ -338,3 +338,49 @@ class TestUpdateVisibility:
         updated = seed_store.update_memory_visibility(target_id, visibility=inp["visibility"])
         assert updated.get("visibility") == expected["after_visibility"]
         assert updated.get("workspace_kind") == expected["after_workspace_kind"]
+
+
+# ---------------------------------------------------------------------------
+# Pack tests
+# ---------------------------------------------------------------------------
+
+
+class TestPack:
+    def test_pack_memory_layer(self, seed_store: MemoryStore) -> None:
+        fixture = _load_fixture("pack_memory_layer")
+        inp = fixture["input"]
+        pack = seed_store.build_memory_pack(inp["context"], limit=inp["limit"], log_usage=False)
+
+        expected = fixture["expected_output"]
+        assert pack["context"] == expected["context"]
+        assert expected["has_items"] is True
+        assert len(pack.get("items", [])) >= expected["item_count_gte"]
+        assert bool(pack.get("pack_text")) == expected["has_pack_text"]
+        assert bool(pack.get("metrics")) == expected["has_metrics"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-filter tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiFilter:
+    def test_search_visibility_kind_filter(self, seed_store: MemoryStore) -> None:
+        fixture = _load_fixture("search_visibility_kind_filter")
+        inp = fixture["input"]
+        results = list(seed_store.search(inp["query"], limit=inp["limit"], filters=inp["filters"]))
+
+        expected = fixture["expected_output"]
+        assert len(results) == expected["count"]
+        if results:
+            assert all(r.kind == "discovery" for r in results)
+
+    def test_recent_kind_change_filter(self, seed_store: MemoryStore) -> None:
+        fixture = _load_fixture("recent_kind_change_filter")
+        inp = fixture["input"]
+        results = seed_store.recent(limit=inp["limit"], filters=inp["filters"])
+
+        expected = fixture["expected_output"]
+        assert len(results) == expected["count"]
+        if results:
+            assert all(r.get("kind") == "change" for r in results)


### PR DESCRIPTION
## Description

Add golden fixtures for `build_memory_pack()` and combined filter searches (visibility+kind, kind-only recent) to the parity corpus. These cover the pack assembly path (search, dedup, section formatting, token budgeting) and multi-filter SQL generation — both identified as critical gaps in the gordon-ramsay code review.

16 total parity fixtures now covering the store's public surface.

## Type of Change

- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] No new warnings introduced

Closes: codemem-k631