### PR TITLE
fix(parity): assert item/ordered IDs in pack and filter fixtures

### DIFF
--- a/tests/parity/fixtures/pack_memory_layer.json
+++ b/tests/parity/fixtures/pack_memory_layer.json
@@ -13,10 +13,10 @@
     "has_pack_text": true,
     "has_metrics": true,
     "item_ids": [
-      13,
       1,
       4,
       8,
+      5,
       10
     ]
   }

--- a/tests/parity/generate_fixtures.py
+++ b/tests/parity/generate_fixtures.py
@@ -825,18 +825,20 @@ def main() -> None:
         store, memory_ids, session_ids = build_seed_database(db_path)
 
         print("Generating fixtures...")
+        # Read-only fixtures first (against clean seed)
         generate_search_fixtures(store, memory_ids)
         generate_timeline_fixture(store)
         generate_recent_fixtures(store)
         generate_get_fixtures(store, memory_ids)
         generate_explain_fixture(store)
-        generate_remember_fixture(store, session_ids)
-        generate_forget_fixture(store, memory_ids, session_ids)
         generate_recent_by_kinds_fixture(store)
         generate_stats_fixture(store)
-        generate_update_visibility_fixture(store, memory_ids)
         generate_pack_fixture(store)
         generate_multi_filter_fixtures(store)
+        # Mutating fixtures last (these modify the seed DB)
+        generate_remember_fixture(store, session_ids)
+        generate_forget_fixture(store, memory_ids, session_ids)
+        generate_update_visibility_fixture(store, memory_ids)
 
         store.close()
 

--- a/tests/parity/test_parity.py
+++ b/tests/parity/test_parity.py
@@ -354,9 +354,12 @@ class TestPack:
         expected = fixture["expected_output"]
         assert pack["context"] == expected["context"]
         assert expected["has_items"] is True
-        assert len(pack.get("items", [])) >= expected["item_count_gte"]
+        items = pack.get("items", [])
+        assert len(items) >= expected["item_count_gte"]
         assert bool(pack.get("pack_text")) == expected["has_pack_text"]
         assert bool(pack.get("metrics")) == expected["has_metrics"]
+        actual_ids = [it["id"] for it in items if "id" in it]
+        assert actual_ids == expected["item_ids"]
 
 
 # ---------------------------------------------------------------------------
@@ -374,6 +377,7 @@ class TestMultiFilter:
         assert len(results) == expected["count"]
         if results:
             assert all(r.kind == "discovery" for r in results)
+        assert [r.id for r in results] == expected["ordered_ids"]
 
     def test_recent_kind_change_filter(self, seed_store: MemoryStore) -> None:
         fixture = _load_fixture("recent_kind_change_filter")
@@ -384,3 +388,4 @@ class TestMultiFilter:
         assert len(results) == expected["count"]
         if results:
             assert all(r.get("kind") == "change" for r in results)
+        assert [r["id"] for r in results] == expected["ordered_ids"]


### PR DESCRIPTION
## Description

Add missing ID assertions for pack, visibility+kind search, and kind-only recent parity tests — all three were flagged in PR #240 review. The tests now assert `item_ids` and `ordered_ids` from the golden fixtures, catching selection and ordering regressions.

Also reorder fixture generation so read-only fixtures run against the clean seed before mutating fixtures (remember, forget, update_visibility) modify the database. This fixes a bug where pack fixture captured IDs from a mutated state that didn't match the test's fresh seed.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] No new warnings introduced

Addresses: PR #240 review feedback