### PR TITLE
docs: add install matrix, embedding packaging, and user migration decisions

### DIFF
--- a/docs/plans/2026-03-15-embedding-packaging.md
+++ b/docs/plans/2026-03-15-embedding-packaging.md
@@ -1,0 +1,268 @@
+# Embedding Model Packaging
+
+**Status:** Decision
+**Date:** 2026-03-15
+
+## Model Selection
+
+| Property | Value |
+|---|---|
+| Model | `BAAI/bge-small-en-v1.5` |
+| Dimensions | 384 |
+| Max tokens | 512 |
+| License | MIT |
+| Parameters | 33.4M |
+
+Same model as the Python runtime (via `fastembed`). Both runtimes produce identical 384-dim vectors, so they can share a `memory_vectors` table without reindexing.
+
+The `@huggingface/transformers` library uses the community-maintained ONNX conversion at `Xenova/bge-small-en-v1.5`, which provides multiple quantization variants:
+
+| Variant | File | Size | Notes |
+|---|---|---|---|
+| fp32 | `model.onnx` | 133 MB | Full precision, matches fastembed output exactly |
+| fp16 | `model_fp16.onnx` | 67 MB | Half precision, negligible quality loss |
+| int8 (quantized) | `model_quantized.onnx` | 34 MB | Default for transformers.js, good quality/size tradeoff |
+| q4 | `model_q4.onnx` | 61 MB | 4-bit quantization |
+
+**Decision: Use `model_quantized.onnx` (int8, 34 MB).** This is what `@huggingface/transformers` downloads by default with `dtype: 'q8'`. The quality difference vs fp32 is negligible for codemem's use case (memory search, not benchmark-competitive retrieval). The 4x size reduction matters for first-run download.
+
+The vectors produced by int8 quantized inference will differ slightly from fastembed's fp32 vectors. This is acceptable — search quality is comparable, and each runtime embeds consistently with itself. Cross-runtime vector mixing is already handled by the DB coexistence contract (both runtimes populate the same `memory_vectors` table; stale vectors are detected via `backfill_vectors`).
+
+## Version Pinning
+
+Pin to an exact HuggingFace commit hash to prevent silent model drift.
+
+```typescript
+const MODEL_ID = 'Xenova/bge-small-en-v1.5';
+const MODEL_REVISION = 'ea104dacec62c0de699686887e3f920caeb4f3e3';
+
+const extractor = await pipeline('feature-extraction', MODEL_ID, {
+  revision: MODEL_REVISION,
+  dtype: 'q8',
+});
+```
+
+The `revision` parameter is passed through to HuggingFace Hub API calls. It locks to a specific commit, preventing upstream changes from altering model behavior or file layout.
+
+**Upstream model (BAAI) revision:** `5c38ec7c405ec4b44b94cc5a9bb96e735b38267a` (last modified 2024-02-22). The Xenova conversion is derived from this. If BAAI publishes a new version, we'd need to verify the Xenova conversion is updated and re-pin.
+
+**Update process:** Bump `MODEL_REVISION` in source, run the embedding test suite to verify vector output hasn't regressed, and release a new version. No automatic updates.
+
+## Cache Strategy
+
+### Where models live
+
+`@huggingface/transformers` in Node.js caches downloaded models to the filesystem. The default location is `~/.cache/huggingface/transformers/` — the library uses a `FileCache` implementation that stores blobs keyed by URL.
+
+We override the cache directory to keep all codemem data colocated:
+
+```typescript
+import { env } from '@huggingface/transformers';
+
+env.cacheDir = path.join(codememDataDir, 'models');
+// e.g., ~/.codemem/models/
+```
+
+This keeps the model cache next to the SQLite DB and avoids polluting the global HuggingFace cache (which may be cleaned by other tools).
+
+### Cache structure
+
+The library stores files as:
+```
+~/.codemem/models/
+  Xenova/bge-small-en-v1.5/
+    onnx/model_quantized.onnx   (34 MB)
+    tokenizer.json               (~700 KB)
+    tokenizer_config.json
+    config.json
+```
+
+Total cached size: ~35 MB.
+
+### Cache invalidation
+
+No automatic invalidation. The pinned revision ensures the same files are always fetched. Cache is invalidated only when:
+1. User deletes `~/.codemem/models/` manually
+2. We bump `MODEL_REVISION` in a new release (new revision → new cache key → re-download)
+
+## First-Run Experience
+
+### What happens
+
+1. User runs a command that needs embeddings (e.g., `codemem embed`, or the viewer+sync process computes vectors for new memories)
+2. The embedding worker thread is lazy-started (per runtime topology decision)
+3. Worker calls `pipeline('feature-extraction', MODEL_ID, { revision, dtype })` 
+4. `@huggingface/transformers` checks the local cache
+5. **Cache miss (first run):** downloads ~35 MB from HuggingFace Hub
+6. Model loads into onnxruntime session (~1-3s on modern hardware)
+7. First embedding is computed
+
+### Latency budget (first run)
+
+| Phase | Estimate |
+|---|---|
+| Download (35 MB, broadband) | 3-10s |
+| Download (35 MB, slow connection) | 30-60s |
+| ONNX session initialization | 1-3s |
+| First inference (warm-up) | 50-200ms |
+| **Total (broadband)** | **5-15s** |
+
+### Progress indication
+
+`@huggingface/transformers` accepts a `progress_callback` option:
+
+```typescript
+const extractor = await pipeline('feature-extraction', MODEL_ID, {
+  revision: MODEL_REVISION,
+  dtype: 'q8',
+  progress_callback: (progress) => {
+    // progress.status: 'download' | 'progress' | 'done'
+    // progress.file: filename being downloaded
+    // progress.progress: 0-100 percentage
+    // progress.loaded / progress.total: bytes
+  },
+});
+```
+
+The worker thread forwards progress events to the main process via `postMessage`. The main process can:
+- Log to stderr for CLI commands (`Downloading embedding model... 45%`)
+- Emit via the viewer HTTP API for UI display
+- Suppress entirely for MCP (MCP doesn't compute embeddings)
+
+### Offline behavior (no internet on first run)
+
+If the model is not cached and there's no internet:
+- `@huggingface/transformers` throws a fetch error
+- The embedding worker catches it and reports failure to the main process
+- codemem continues operating without embeddings (same as Python: `get_embedding_client()` returns `None` on failure)
+- Semantic search falls back to FTS or returns empty results
+- Next run with internet will retry the download
+
+The `local_files_only: true` option can be used to skip network attempts entirely (useful for air-gapped environments where models are pre-seeded).
+
+## Bundle vs Download
+
+### Option A: Download on demand (chosen)
+
+Model files are downloaded from HuggingFace Hub on first use and cached locally.
+
+**Pros:**
+- npm package stays small (~2-5 MB without model weights)
+- Users who disable embeddings (`CODEMEM_EMBEDDING_DISABLED=1`) never download the model
+- Model updates don't require a new npm release
+- Standard pattern for ML-in-JS tools
+
+**Cons:**
+- First-run requires internet access
+- Download adds 5-15s latency on first use
+- HuggingFace Hub availability is a dependency
+
+### Option B: Bundle in npm package
+
+Ship `model_quantized.onnx` + tokenizer files inside the npm package.
+
+**Pros:**
+- Works offline immediately
+- No first-run download delay
+- No HuggingFace Hub dependency
+
+**Cons:**
+- npm package balloons from ~2 MB to ~37 MB
+- Every `npm install` downloads 37 MB even if embeddings are disabled
+- npm has a 2 GB package size limit but discourages large packages (registry bandwidth costs)
+- Model updates require a new npm release
+- Users who already have the model cached download it again in the package
+
+### Option C: Separate `@codemem/model-bge-small` package
+
+Ship the model as a separate optional dependency.
+
+**Pros:**
+- Main package stays small
+- Opt-in: only installed when embeddings are wanted
+- Works offline once installed
+
+**Cons:**
+- Extra package to manage and version
+- Users must know to install it
+- npm registry still carries the bandwidth cost
+- Complicates the install story
+
+**Decision: Option A (download on demand).** This matches the Python runtime's behavior (fastembed downloads models on first use) and keeps the package small. The 5-15s first-run delay is a one-time cost with clear progress indication.
+
+### Pre-seeding for offline environments
+
+For air-gapped or CI environments, document a pre-seed command:
+
+```bash
+codemem model download    # downloads model to ~/.codemem/models/
+```
+
+This runs the pipeline initialization once, populating the cache. Subsequent runs work offline with `local_files_only: true` (auto-detected when cache is warm).
+
+## Per-Platform Packaging
+
+### ONNX models are platform-neutral
+
+The `model_quantized.onnx` file is a serialized computation graph. It runs identically on macOS, Linux, and Windows. No per-platform model variants needed.
+
+### onnxruntime-node is platform-specific
+
+`onnxruntime-node` ships native binaries per platform+arch. npm handles this via `optionalDependencies` with platform-specific packages:
+
+```
+@onnxruntime/node-darwin-arm64
+@onnxruntime/node-darwin-x64
+@onnxruntime/node-linux-arm64
+@onnxruntime/node-linux-x64
+@onnxruntime/node-win32-x64
+```
+
+npm's `os`/`cpu` fields in each sub-package ensure only the relevant binary is installed. No action needed from codemem — this is handled by the onnxruntime-node package itself.
+
+### Platform matrix
+
+| Platform | ONNX model | onnxruntime binary | Status |
+|---|---|---|---|
+| macOS arm64 (Apple Silicon) | Same | `darwin-arm64` | Primary target |
+| macOS x64 | Same | `darwin-x64` | Supported |
+| Linux x64 | Same | `linux-x64` | Supported (CI, servers) |
+| Linux arm64 | Same | `linux-arm64` | Supported |
+| Windows x64 | Same | `win32-x64` | Supported |
+
+### GPU acceleration
+
+Not in scope. codemem's embedding workload (short text chunks, batch sizes <100) doesn't benefit meaningfully from GPU acceleration. CPU inference at 10-50ms per item is fast enough. The onnxruntime CPU backend is the default and requires no additional setup.
+
+## Compatibility with Python
+
+### Can both runtimes share cached model files?
+
+No, and they shouldn't try.
+
+| Aspect | Python (fastembed) | TS (@huggingface/transformers) |
+|---|---|---|
+| Cache location | `~/.cache/fastembed/` | `~/.codemem/models/` |
+| Model format | ONNX (fastembed's own download) | ONNX (from HuggingFace Hub) |
+| Quantization | fastembed default (varies) | int8 (`model_quantized.onnx`) |
+| File layout | fastembed-specific directory structure | HuggingFace Hub cache structure |
+
+The cache formats are incompatible. Each runtime manages its own model download and cache independently. This is fine — the 35 MB duplication is negligible, and coupling cache formats across runtimes would be fragile.
+
+### Can both runtimes share computed vectors?
+
+Yes. Both runtimes write to the same `memory_vectors` table (per the DB coexistence contract). Vectors are 384-dim floats regardless of runtime. The slight numerical differences between fp32 (fastembed) and int8-quantized (TS) inference don't affect search quality — cosine similarity rankings are stable across these precision levels.
+
+If a user switches runtimes, stale vectors from the old runtime remain valid. The `backfill_vectors` process detects memories without vectors and computes them, but it doesn't re-embed memories that already have vectors.
+
+## Open Risks
+
+1. **HuggingFace Hub availability.** First-run depends on HuggingFace Hub being reachable. Mitigation: clear error message, retry logic, and `codemem model download` for pre-seeding. The Xenova repo has been stable for 2+ years.
+
+2. **Xenova repo maintenance.** The `Xenova/bge-small-en-v1.5` conversion is community-maintained. If it disappears, we'd need to host our own ONNX conversion or switch to the BAAI repo's ONNX (which lacks quantized variants). Mitigation: pinned revision means cached copies keep working indefinitely.
+
+3. **onnxruntime-node binary compatibility.** New Node.js major versions or OS updates could break onnxruntime-node. Mitigation: pin onnxruntime-node version, test across supported platforms in CI.
+
+4. **int8 vs fp32 vector drift.** If a user's DB has a mix of fp32 (Python) and int8 (TS) vectors, search results may be slightly inconsistent. Mitigation: this is a known acceptable tradeoff (documented above). A future `codemem embed --recompute` command could normalize all vectors to a single precision.
+
+5. **Model size growth.** If we later need a larger/better model (e.g., `bge-base-en-v1.5` at 768-dim), the download grows to ~130 MB and the vector table size doubles. This is a future concern, not a current blocker — model selection is a one-way door for existing vector data.

--- a/docs/plans/2026-03-15-install-matrix.md
+++ b/docs/plans/2026-03-15-install-matrix.md
@@ -1,0 +1,237 @@
+# Native Install & Package Matrix
+
+**Status:** Decision
+**Date:** 2026-03-15
+
+Context: codemem's npm package ships three native dependencies. This document maps
+what each package requires per platform, what users need installed, and what breaks.
+
+## Platform Support Matrix
+
+| Platform | better-sqlite3 | sqlite-vec | onnxruntime-node |
+|---|---|---|---|
+| macOS arm64 | ⚠️ Compile from source¹ | ✅ Prebuild (.dylib) | ✅ Prebuild |
+| macOS x64 | ✅ Prebuild available | ✅ Prebuild (.dylib) | ✅ Prebuild |
+| Linux x64 | ✅ Prebuild available | ✅ Prebuild (.so) | ✅ Prebuild |
+| Linux arm64 | ⚠️ Compile from source¹ | ✅ Prebuild (.so) | ✅ Prebuild |
+| Windows x64 | ✅ Prebuild available | ✅ Prebuild (.dll) | ✅ Prebuild |
+
+¹ No prebuild for Node 24 + arm64 confirmed in spike. better-sqlite3 publishes
+prebuilds via `prebuild-install` (143 release assets for v12.8.0 covering many
+Node × platform combos), but coverage for newer Node versions on arm64 lags.
+Prebuilds for Node 20/22 on arm64 are typically available. **This is the primary
+install friction point.**
+
+### How each package ships native code
+
+| Package | Native strategy | Build system | Fallback |
+|---|---|---|---|
+| better-sqlite3 | `prebuild-install`, falls back to `node-gyp rebuild` | node-gyp (C++ addon, compiles SQLite amalgamation) | Source compilation |
+| sqlite-vec | `optionalDependencies` per-platform packages | None — prebuilt binaries only | Fatal error if platform unsupported |
+| onnxruntime-node | Single package, postinstall downloads platform binary | N-API addon, prebuilt | Fatal error if platform unsupported |
+
+### sqlite-vec platform packages
+
+The `sqlite-vec` npm package uses the `optionalDependencies` pattern with
+platform-specific sub-packages:
+
+- `sqlite-vec-darwin-arm64`
+- `sqlite-vec-darwin-x64`
+- `sqlite-vec-linux-arm64`
+- `sqlite-vec-linux-x64`
+- `sqlite-vec-windows-x64`
+
+Each sub-package declares `os` and `cpu` fields so npm only installs the
+matching one. No compilation step.
+
+## SQLite Version Compatibility
+
+**better-sqlite3 bundles its own SQLite** (currently v3.51.3) compiled from the
+amalgamation source. It does NOT use a system SQLite.
+
+**sqlite-vec does not conflict.** The sqlite-vec .dylib/.so is loaded via
+`db.loadExtension()`, which loads the shared library into the running SQLite
+instance managed by better-sqlite3. The extension hooks into the host's SQLite
+API — it doesn't bundle or link its own SQLite. No version conflict, no symbol
+collision.
+
+The only requirement is that the host SQLite version supports the extension's
+required APIs. sqlite-vec uses virtual tables and standard extension entry
+points, which have been stable since SQLite 3.9.0 (2015). better-sqlite3's
+bundled 3.51.3 is well above this.
+
+## Install Size Budget
+
+| Package | Unpacked size | Notes |
+|---|---|---|
+| better-sqlite3 | ~10 MB | Includes SQLite amalgamation source + prebuilt .node |
+| sqlite-vec (per-platform) | ~160 KB | Only the matching platform package is installed |
+| onnxruntime-node | **~220 MB** | Ships all platform binaries in one package |
+| **Total (with onnxruntime)** | **~230 MB** | Dominated by onnxruntime |
+| **Total (without onnxruntime)** | **~10 MB** | Core functionality only |
+
+onnxruntime-node is 95% of the install weight. This is the strongest argument
+for making it optional (see §Optional Dependencies below).
+
+## Build Tool Requirements
+
+### When prebuilds are available (most users)
+
+No build tools required. `npm install` downloads prebuilt binaries for all three
+packages.
+
+### When better-sqlite3 must compile from source
+
+This applies to: Node 24 on arm64 (macOS and Linux), and any future
+Node version before prebuilds are published.
+
+| Platform | Required tools |
+|---|---|
+| macOS arm64 | Xcode Command Line Tools (`xcode-select --install`) — provides clang++, make, python3 |
+| Linux arm64 | `build-essential` (gcc/g++, make), `python3` |
+| Linux x64 | `build-essential`, `python3` (only if prebuild missing) |
+
+node-gyp requires: Python 3, a C++ compiler supporting C++20, and make.
+These are standard on developer machines but **not** on minimal CI images or
+Docker containers. The install script (`prebuild-install || node-gyp rebuild`)
+handles the fallback automatically.
+
+### Mitigation: ship our own prebuilds
+
+If Node 24 arm64 becomes a common target before upstream publishes prebuilds:
+1. Fork/rebuild with `prebuild` targeting Node 24 arm64
+2. Host prebuilds on GitHub Releases
+3. Configure `prebuild-install --download` to check our mirror first
+
+This is a contingency, not a first step.
+
+## CI Matrix
+
+### Minimum test matrix
+
+| Runner | Node | Arch | Purpose |
+|---|---|---|---|
+| `macos-14` (M1) | 22 | arm64 | Primary dev platform, prebuild test |
+| `macos-14` (M1) | 24 | arm64 | Source compilation test |
+| `ubuntu-24.04` | 22 | x64 | Standard Linux, prebuild test |
+| `ubuntu-24.04` | 24 | x64 | Latest Node on Linux |
+| `ubuntu-24.04-arm` | 22 | arm64 | Linux arm64 prebuild test |
+
+### Extended matrix (lower priority)
+
+| Runner | Node | Arch | Purpose |
+|---|---|---|---|
+| `macos-13` | 22 | x64 | Intel Mac support |
+| `windows-latest` | 22 | x64 | Windows baseline (if we support it) |
+| `ubuntu-24.04-arm` | 24 | arm64 | Linux arm64 source compilation |
+
+### What each CI job validates
+
+1. `npm install` succeeds (prebuilds download or compilation works)
+2. `better-sqlite3` opens a database and runs queries
+3. `sqlite-vec` extension loads via `db.loadExtension()`
+4. `onnxruntime-node` loads a model and produces embeddings (optional dep jobs only)
+5. Cross-process WAL concurrency (two Node processes hitting the same DB)
+
+## Optional Dependencies Strategy
+
+### Recommendation: Ship two packages
+
+**`optionalDependencies` does NOT reduce default install size** — npm still
+installs optional dependencies unless the user explicitly passes
+`--omit=optional`. Instead, split into two packages:
+
+- **`codemem`** — core package, no onnxruntime (~10 MB). FTS search works, semantic search is unavailable.
+- **`codemem-embeddings`** (or `@codemem/embeddings`) — adds `onnxruntime-node` + `@huggingface/transformers` (~220 MB). Enables semantic search.
+
+Users install what they need:
+```bash
+npm install codemem                    # Core only (~10 MB)
+npm install codemem codemem-embeddings # Full with semantic search (~230 MB)
+```
+
+The core package detects `codemem-embeddings` at runtime via dynamic import:
+
+```typescript
+let onnxruntime: typeof import('onnxruntime-node') | null = null;
+try {
+  onnxruntime = await import('onnxruntime-node');
+} catch {
+  // Embeddings unavailable — semantic search falls back to FTS
+}
+```
+
+This is a real reduction in install size for the common case, unlike
+`optionalDependencies` which is a no-op for default `npm install`.
+
+#### Runtime detection
+
+```typescript
+let onnxruntime: typeof import('onnxruntime-node') | null = null;
+try {
+  onnxruntime = await import('onnxruntime-node');
+} catch {
+  // Embeddings unavailable — semantic search falls back to FTS
+}
+```
+
+#### User-facing behavior
+
+| onnxruntime installed? | Embedding commands | Semantic search | FTS search |
+|---|---|---|---|
+| Yes | Work normally | Available | Available |
+| No | Error with install instructions | Unavailable (graceful) | Available |
+
+The CLI should detect the missing optional dep and print:
+```
+Embeddings require onnxruntime-node. Install it with:
+  npm install onnxruntime-node
+```
+
+#### Install instructions in README
+
+```bash
+# Core install (~10 MB)
+npm install codemem
+
+# With embedding support (~230 MB)
+npm install codemem onnxruntime-node
+```
+
+## Open Risks
+
+### 1. better-sqlite3 prebuild lag on new Node versions
+**Risk:** Every major Node release has a window where prebuilds aren't published
+yet for all platforms. Users on bleeding-edge Node hit a compilation requirement.
+**Mitigation:** Pin `engines` to Node versions with confirmed prebuilds. Document
+build tool requirements clearly. Consider self-hosting prebuilds if the window
+is long.
+
+### 2. onnxruntime-node postinstall fragility
+**Risk:** onnxruntime-node's `postinstall` script downloads binaries at install
+time. This fails behind corporate proxies, in air-gapped environments, or when
+Microsoft's CDN is down.
+**Mitigation:** Being an optional dependency limits blast radius. Document proxy
+configuration (`global-agent` is already a dep of onnxruntime-node). Consider
+bundling the model file separately from the runtime.
+
+### 3. sqlite-vec alpha stability
+**Risk:** sqlite-vec is `0.1.7-alpha.2`. API surface or binary format could
+change. The npm package structure (optionalDependencies pattern) is good, but
+the extension itself is pre-1.0.
+**Mitigation:** Pin to a specific version. Test extension loading in CI. Be
+prepared to vendor the .dylib/.so if the npm package becomes unmaintained.
+
+### 4. glibc minimum on Linux
+**Risk:** Prebuilt binaries (sqlite-vec, onnxruntime-node, better-sqlite3
+prebuilds) are compiled against a specific glibc version. Old distros
+(CentOS 7, Amazon Linux 2) may not have a new enough glibc.
+**Mitigation:** Document minimum Linux versions. Test on Ubuntu 22.04+ which
+covers the vast majority of Node.js deployments.
+
+### 5. Total install weight with onnxruntime + model files
+**Risk:** onnxruntime-node is 220 MB. Embedding models (e.g., all-MiniLM-L6-v2
+ONNX) add another 20-80 MB. Total install weight for a user wanting embeddings
+could hit 300+ MB.
+**Mitigation:** Optional dependency strategy keeps the default install at ~10 MB.
+Model files should be downloaded on first use, not at install time.

--- a/docs/plans/2026-03-15-runtime-topology-decision.md
+++ b/docs/plans/2026-03-15-runtime-topology-decision.md
@@ -157,8 +157,18 @@ const syncTick = async () => {
   }
 };
 
-setInterval(syncTick, config.syncIntervalMs);
+// Use setTimeout chain (not setInterval) to prevent overlapping ticks.
+// setInterval would start a new tick before the previous one finishes
+// if a sync pass exceeds the interval (slow peer/network), creating
+// concurrent sync passes against the same store.
+const scheduleNext = () => setTimeout(async () => {
+  await syncTick();
+  scheduleNext();
+}, config.syncIntervalMs);
+scheduleNext();
 ```
+
+**Important:** Do NOT use `setInterval` with async tick functions — it does not await the returned promise, so overlapping ticks can occur. The `setTimeout` chain matches the Python daemon's serialized loop (`while ...: _run_tick_once()`).
 
 The sync daemon also hosts HTTP routes for peer-to-peer sync API (push/pull). These are served by the same HTTP server as the viewer — they're just additional route handlers under `/api/sync/`.
 

--- a/docs/plans/2026-03-15-user-migration-compatibility.md
+++ b/docs/plans/2026-03-15-user-migration-compatibility.md
@@ -1,0 +1,292 @@
+# User Migration Compatibility: Python → npm
+
+## Status
+
+Decision
+
+## Context
+
+codemem currently ships as a Python package (`pip install codemem` / `uvx codemem`). The TypeScript port will ship as an npm package. During transition, users may have both installed. This document defines how the npm version interoperates with existing Python installations and how users upgrade.
+
+Current Python version: `0.19.0`. Plugin pinned backend: `codemem==0.19.0`.
+
+## Config Compatibility
+
+### Path and format: identical
+
+The npm version MUST read `~/.config/codemem/config.json` (and `.jsonc`) using the same resolution logic:
+
+1. `CODEMEM_CONFIG` env var (if set)
+2. `~/.config/codemem/config.json` (if exists)
+3. `~/.config/codemem/config.jsonc` (if exists)
+4. Default to `~/.config/codemem/config.json`
+
+The npm version MUST support JSONC (comments, trailing commas) — the Python version already does via `_strip_json_comments` / `_strip_trailing_commas`.
+
+### Field compatibility
+
+All config keys from `OpencodeMemConfig` (see `codemem/config.py`) MUST be recognized by the npm version. The npm version MAY add new keys but MUST NOT remove or rename existing ones.
+
+**Environment variable overrides:** The npm version MUST honor the same `CODEMEM_*` env vars with the same semantics (see `CONFIG_ENV_OVERRIDES` and `_apply_env` in `config.py`). Env vars override file config.
+
+**Python-only fields the npm version can ignore (but must not reject):**
+
+- `runner`, `runner_from`, `use_opencode_run` — these control `uvx`/`uv run` dispatch, irrelevant to npm
+- `opencode_model`, `opencode_agent` — OpenCode-specific runner config
+
+**New npm-only fields:** Any new config keys MUST use a distinct namespace or be additive. The Python version ignores unknown keys (it only processes keys matching `OpencodeMemConfig` attributes), so coexistence is safe.
+
+### Config writes
+
+Both runtimes write config via the viewer Settings UI. The npm version MUST use the same `json.dumps(data, indent=2)` equivalent format. Writes are whole-file replacements — no merge conflicts possible since only one process writes at a time (user-initiated saves).
+
+## Database Compatibility
+
+Reference: [DB Coexistence Contract](2026-03-15-db-coexistence-contract.md)
+
+### Schema reuse: yes, with constraints
+
+The npm version opens `~/.codemem/mem.sqlite` (or `CODEMEM_DB`) directly. No migration step is needed for read/write access.
+
+**Phase 2 rules apply:**
+
+- Python owns DDL (schema changes). The npm version validates schema on connect but does NOT run `CREATE TABLE`, `ALTER TABLE`, or modify triggers.
+- npm reads `PRAGMA user_version` and checks against `MIN_COMPATIBLE_SCHEMA`. If too old, it exits with: `"Database schema version {v} is too old. Run the Python codemem CLI to upgrade."`
+- npm sets identical connection pragmas: `journal_mode=WAL`, `busy_timeout=5000`, `foreign_keys=ON`, `synchronous=NORMAL`.
+
+### sqlite-vec
+
+Both runtimes must load sqlite-vec. The npm version uses `sqlite-vec` from npm (`@anthropic-ai/sqlite-vec` or equivalent). Both MUST pin the same sqlite-vec version — verify via `SELECT vec_version()` on startup.
+
+### Pre-migration backup
+
+On first npm access to the database, the npm version creates a one-time backup:
+```
+~/.codemem/backups/mem.sqlite.pre-ts-{ISO_DATE}
+```
+Controlled by a marker file `~/.codemem/.ts-first-access`.
+
+### FTS5 triggers
+
+FTS triggers fire at the SQLite engine level regardless of which runtime issued the DML. The npm version MUST NOT use `INSERT OR REPLACE` on `memory_items` — use `INSERT ... ON CONFLICT DO UPDATE` instead (see DB coexistence contract for rationale).
+
+## Plugin Runner Transition
+
+### Current plugin architecture
+
+The OpenCode plugin (`.opencode/plugin/codemem.js`) resolves a CLI backend via:
+
+1. `CODEMEM_RUNNER` env var → uses that runner (`uvx`, `uv`, or custom)
+2. Dev mode detection → if `pyproject.toml` contains `name = "codemem"`, uses `uv run`
+3. Default → `uvx codemem==0.19.0` (pinned to `PINNED_BACKEND_VERSION`)
+
+The plugin shells out to the resolved runner for: `codemem ingest`, `codemem mcp`, `codemem pack`, `codemem serve`, `codemem stats`, `codemem recent`, `codemem enqueue-raw-event`, `codemem version`.
+
+### PATH resolution during coexistence
+
+If both Python (`uvx codemem`) and npm (`npx codemem`) are installed:
+
+- **`uvx` path:** Always resolves to the Python version. The plugin's default runner is `uvx`, so existing installs continue using Python.
+- **`npx` / global npm path:** Resolves to the npm version. A bare `codemem` on PATH depends on which was installed last / which is earlier in PATH.
+- **No conflict by default:** The plugin explicitly uses `uvx` dispatch, not bare `codemem`. Users on the Python plugin will not accidentally pick up the npm version.
+
+### Plugin migration strategy
+
+The plugin itself is the natural migration point. When the npm version ships:
+
+1. **New plugin version** updates `buildRunnerArgs` and `runCli` to handle `npx` dispatch correctly (currently only `uvx`/`uv` are wired — `npx` would produce `npx stats` instead of `npx codemem stats`). This plugin update MUST ship before users set `CODEMEM_RUNNER=npx`.
+2. **`CODEMEM_RUNNER=npx`** serves as the opt-in during transition, but only after the plugin runner wiring is updated.
+3. **`CODEMEM_RUNNER=uvx`** remains supported for users who want to stay on Python.
+4. A future plugin release (after Python deprecation) removes `uvx` support and defaults to npm.
+
+### Detection logic (recommended)
+
+The plugin should detect which backend is available:
+
+```javascript
+async function detectBackend() {
+  // 1. Explicit env var wins
+  if (process.env.CODEMEM_RUNNER) return process.env.CODEMEM_RUNNER;
+
+  // 2. Dev mode (pyproject.toml present)
+  if (isDevMode(cwd)) return "uv";
+
+  // 3. Try npm first (preferred after transition)
+  try {
+    const result = await exec(["npx", "codemem", "version"]);
+    if (result.exitCode === 0) return "npx";
+  } catch {}
+
+  // 4. Fall back to uvx
+  return "uvx";
+}
+```
+
+This is deferred to the plugin release that ships npm support. The current plugin does not need changes until then.
+
+### Claude Code plugin
+
+The Claude Code marketplace plugin uses `uvx codemem==<version> mcp` for MCP server launch and `codemem ingest-claude-hook` / `codemem claude-hook-inject` for hook ingestion. The same runner transition strategy applies — update the hook scripts to resolve `npx codemem` when available.
+
+## Upgrade Path
+
+### Step-by-step: uvx → npm
+
+```bash
+# 1. Verify current install works
+uvx codemem stats
+
+# 2. Install npm version
+npm install -g codemem
+# or: use npx codemem (no global install needed)
+
+# 3. Verify npm version reads existing data
+npx codemem stats
+# Should show the same memory counts as step 1
+
+# 4. Switch the plugin runner (if using OpenCode)
+# PREREQUISITE: The plugin's command builder must be updated to support
+# npx dispatch first (currently .opencode/plugin/codemem.js only handles
+# uvx/uv runner args). Do NOT set CODEMEM_RUNNER=npx until a plugin
+# release that wires npx command building is published.
+# When ready:
+# export CODEMEM_RUNNER=npx
+
+# 5. Restart OpenCode / Claude Code
+
+# 6. Verify plugin uses npm backend
+# Check plugin log (~/.codemem/plugin.log) for runner info
+
+# 7. (Optional) Uninstall Python version
+uv tool uninstall codemem
+# or: pip uninstall codemem
+```
+
+### Verification checklist
+
+After switching to npm:
+
+- [ ] `npx codemem stats` shows expected memory counts
+- [ ] `npx codemem search "recent work"` returns results
+- [ ] `npx codemem serve` launches the viewer
+- [ ] Plugin injects context on new sessions (check toast message)
+- [ ] MCP tools (`mem-status`, `mem-recent`, `mem-stats`) work
+
+### Rollback
+
+If the npm version has issues:
+
+```bash
+# Revert runner
+unset CODEMEM_RUNNER  # or set CODEMEM_RUNNER=uvx
+
+# Restart OpenCode / Claude Code
+# Python backend resumes immediately — same DB, same config
+```
+
+## Breaking Changes
+
+### Intentional differences (npm vs Python)
+
+| Area | Python | npm | Impact |
+|------|--------|-----|--------|
+| Runtime prerequisite | Python 3.11+ / uv | Node 22+ | Different install chain |
+| Runner dispatch | `uvx codemem==X.Y.Z` | `npx codemem` or global | Plugin config change |
+| Extension loading | `sqlite_vec.load(conn)` | `sqliteVec.load(db)` | Transparent to users |
+| Observer runtime | `claude_sidecar` option uses Python subprocess | TBD — may drop `claude_sidecar` | Users on `claude_sidecar` must switch to `api_http` |
+
+### CLI command parity
+
+The npm version MUST support all CLI commands from the Python version at launch:
+
+- `stats`, `recent`, `search`, `embed`, `serve`, `pack`, `mcp`, `version`
+- `ingest`, `enqueue-raw-event`, `raw-events-status`
+- `export-memories`, `import-memories`
+- `sync` subcommands
+- `install-mcp`, `install-plugin`
+- `db prune-memories`
+
+Any command not ported at launch MUST print a clear message: `"This command is not yet available in the npm version. Use uvx codemem <command> instead."`
+
+### Config key changes: none
+
+No config keys are renamed or removed. The npm version adds keys only.
+
+### Default value changes: none planned
+
+All defaults match the Python version. If any must change, document in release notes with migration instructions.
+
+## Version Parity
+
+### Recommendation: start fresh at 1.0.0
+
+The npm package should start at `1.0.0`, not `0.19.x`. Rationale:
+
+1. **Clean semver signal.** `1.0.0` communicates "stable, ready for production" to npm users who have no context on the Python version history.
+2. **Avoid confusion.** If the npm package is `0.19.0`, users may think it's the same release as the Python `0.19.0` — but the codebases will diverge immediately.
+3. **Independent versioning.** The two packages have different release cadences once the port ships. Coupled version numbers create false expectations.
+
+The npm `1.0.0` release notes should state: "Port of Python codemem 0.19.x. Full database and config compatibility."
+
+### Plugin version pinning
+
+The OpenCode plugin pins `PINNED_BACKEND_VERSION` to a specific backend version. During transition, this pin must specify which runtime:
+
+```javascript
+const PINNED_BACKEND_VERSION = "1.0.0";          // npm version
+const PINNED_PYTHON_BACKEND_VERSION = "0.19.0";  // fallback
+```
+
+## Deprecation Strategy
+
+### Timeline
+
+1. **T+0:** npm `1.0.0` ships. Python `0.19.x` continues to work. Plugin defaults to `uvx` runner.
+2. **T+2 weeks:** Plugin update defaults to `npx` runner (with `uvx` fallback). Release notes announce Python deprecation timeline.
+3. **T+1 month:** Publish Python `0.20.0` — a thin deprecation release (see below).
+4. **T+3 months:** Remove Python package from active support. PyPI package remains installable but unmaintained.
+
+### Deprecation release (Python 0.20.0)
+
+Publish a final Python version that:
+
+1. **Prints a deprecation notice on every CLI invocation:**
+   ```
+   ⚠️  codemem has moved to npm. Install with: npm install -g codemem
+       This Python version (0.20.0) will not receive further updates.
+       Your data and config will work unchanged with the npm version.
+   ```
+2. **Still works normally** — all commands function. The notice is informational, not blocking.
+3. **Adds `CODEMEM_SUPPRESS_DEPRECATION=1`** env var to silence the notice (for CI, scripts).
+
+This approach is better than publishing a broken/stub package — users who depend on the Python version for automation should not be broken by the deprecation notice.
+
+### PyPI package metadata
+
+Update the Python package's PyPI description and README to redirect:
+
+```
+⚠️ This package has been superseded by the npm version.
+Install: npm install -g codemem
+Docs: https://github.com/kunickiaj/codemem
+```
+
+### Communication channels
+
+- GitHub release notes for both the npm `1.0.0` and Python `0.20.0` releases
+- README.md update (this repo) — update Quick Start to show npm install path
+- OpenCode plugin marketplace description update
+
+## Open Questions
+
+1. **npm package name.** Is `codemem` available on npm? If not, use `@kunickiaj/codemem` or similar scoped name. This affects all `npx` commands in this document.
+
+2. **Node version floor.** Node 22+ for `node:sqlite`? Or Node 18+ with `better-sqlite3`? This affects the install prerequisites section. (See DB coexistence contract, open question 5.)
+
+3. **`claude_sidecar` observer runtime.** The Python version supports shelling out to `claude` CLI for observation. Does the npm version support this, or do we drop it and require `api_http`? Affects users who rely on Claude CLI for observer inference.
+
+4. **Sync daemon.** The Python version has `codemem sync daemon` which runs as a long-lived process. Does the npm version reimplement this, or defer it? Sync is a significant surface area.
+
+5. **Viewer embedding.** The Python viewer is embedded in `codemem/viewer.py` as inline HTML. The npm version likely serves static files differently. Is the viewer ported in the initial npm release, or deferred?
+
+6. **Plugin ecosystem.** Both OpenCode (`.opencode/plugin/`) and Claude Code (`.Claude/plugin/`) plugins exist. Do both get updated simultaneously, or is one prioritized?


### PR DESCRIPTION
## Description

Three design documents for the TypeScript migration, completing the gating decisions needed before the scaffold bead (codemem-a71):

**1. Native Install & Package Matrix (codemem-5uq)**
- Platform support matrix for macOS/Linux arm64/x64
- better-sqlite3 may need source compilation (no Node 24 arm64 prebuild yet)
- onnxruntime-node is 220MB unpacked — recommends `optionalDependencies`
- sqlite-vec ships per-platform optional sub-packages (~160KB each)
- CI needs 5 runners minimum (Node 22/24 × macOS arm64 / Linux x64 / Linux arm64)

**2. Embedding Model Packaging (codemem-qla)**
- Pin to `BAAI/bge-small-en-v1.5` int8 quantized via exact HuggingFace commit hash
- Cache at `~/.codemem/models/` (colocated with DB)
- Download on demand (not bundled in npm package)
- First-run: 5-15s download with progress callback, graceful offline degradation
- Python/TS caches are separate (incompatible formats) but shared vector table

**3. User Migration Compatibility (codemem-ouu)**
- Config paths reused identically (`~/.config/codemem/config.json`)
- Database reuse via DB coexistence contract (Phase 2: Python DDL, npm DML-only)
- Plugin transition: `CODEMEM_RUNNER=npx` opt-in, future default flip
- npm version starts at 1.0.0 (clean semver break from Python 0.19.x)
- Python 0.20.0 prints deprecation notice, 3-month sunset

## Type of Change

- [x] 📚 Documentation (docs-only change)

## Testing

- [x] Self-review completed

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced

Closes: codemem-5uq, codemem-qla, codemem-ouu