### PR TITLE
fix(test): prevent flaky CLI test when request_id starts with dash

### DIFF
--- a/tests/test_sync_cli.py
+++ b/tests/test_sync_cli.py
@@ -498,9 +498,10 @@ def test_sync_coordinator_join_request_management_local(tmp_path: Path) -> None:
             "sync",
             "coordinator",
             "approve-join-request",
-            request["request_id"],
             "--db-path",
             str(coordinator_db),
+            "--",
+            request["request_id"],
         ],
     )
     assert result.exit_code == 0, f"approve-join-request failed: {result.output}"


### PR DESCRIPTION
## Description

Fix flaky test `test_sync_coordinator_join_request_management_local` that failed intermittently on Python 3.13 CI.

Root cause: `secrets.token_urlsafe(12)` can produce request IDs starting with `-`, which Typer/Click interprets as an option flag (`No such option: -U`). The fix moves `--db-path` before the positional argument and adds a `--` separator so the request_id is never parsed as an option.

Verified with 10 consecutive runs locally.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Verified 10 consecutive runs with no flakes

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] No new warnings introduced