### PR TITLE
Add database connection layer with better-sqlite3 + sqlite-vec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,13 @@ viewer_ui/node_modules/
 viewer_ui/.vite/
 codemem/viewer_static/app.js.map
 
+# Agent skills (project-local installs, regenerate with: npx skills add)
+# Ignores canonical .agents/skills/, per-agent symlink dirs, and lockfile
+.agents/skills/
+.*/skills/
+/skills/
+/skills-lock.json
+
 # TypeScript build artifacts
 packages/*/dist/
 *.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "codemem"
   ],
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild", "@biomejs/biome"]
+    "onlyBuiltDependencies": ["esbuild", "@biomejs/biome", "better-sqlite3"]
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,8 +14,13 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
+		"@types/better-sqlite3": "^7.6.13",
 		"tsup": "catalog:",
 		"typescript": "catalog:",
 		"vitest": "catalog:"
+	},
+	"dependencies": {
+		"better-sqlite3": "^12.8.0",
+		"sqlite-vec": "0.1.7-alpha.2"
 	}
 }

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -1,0 +1,247 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "./db.js";
+import {
+	assertSchemaReady,
+	connect,
+	fromJson,
+	getSchemaVersion,
+	isEmbeddingDisabled,
+	loadSqliteVec,
+	SCHEMA_VERSION,
+	tableExists,
+	toJson,
+} from "./db.js";
+
+describe("connect", () => {
+	let tmpDir: string;
+	let db: Database;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+	});
+
+	afterEach(() => {
+		db?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("opens a database with WAL mode", () => {
+		db = connect(join(tmpDir, "test.sqlite"));
+		const mode = db.pragma("journal_mode", { simple: true }) as string;
+		expect(mode.toLowerCase()).toBe("wal");
+	});
+
+	it("sets busy_timeout to 5000ms", () => {
+		db = connect(join(tmpDir, "test.sqlite"));
+		const timeout = db.pragma("busy_timeout", { simple: true });
+		expect(timeout).toBe(5000);
+	});
+
+	it("enables foreign keys", () => {
+		db = connect(join(tmpDir, "test.sqlite"));
+		const fk = db.pragma("foreign_keys", { simple: true });
+		expect(fk).toBe(1);
+	});
+
+	it("sets synchronous to NORMAL", () => {
+		db = connect(join(tmpDir, "test.sqlite"));
+		const sync = db.pragma("synchronous", { simple: true });
+		// NORMAL = 1
+		expect(sync).toBe(1);
+	});
+
+	it("creates parent directories if they don't exist", () => {
+		const nested = join(tmpDir, "deep", "nested", "dir", "test.sqlite");
+		db = connect(nested);
+		expect(db.pragma("journal_mode", { simple: true })).toBe("wal");
+	});
+});
+
+describe("loadSqliteVec", () => {
+	let tmpDir: string;
+	let db: Database;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+		db = connect(join(tmpDir, "test.sqlite"));
+	});
+
+	afterEach(() => {
+		db?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("loads the sqlite-vec extension", () => {
+		loadSqliteVec(db);
+		const row = db.prepare("SELECT vec_version() AS v").get() as { v: string };
+		expect(row.v).toMatch(/^v?\d+\.\d+/);
+	});
+
+	it("skips loading when embeddings are disabled", () => {
+		const orig = process.env.CODEMEM_EMBEDDING_DISABLED;
+		try {
+			process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+			// Should not throw, and vec_version should not be available
+			loadSqliteVec(db);
+			expect(() => db.prepare("SELECT vec_version()").get()).toThrow();
+		} finally {
+			if (orig === undefined) {
+				delete process.env.CODEMEM_EMBEDDING_DISABLED;
+			} else {
+				process.env.CODEMEM_EMBEDDING_DISABLED = orig;
+			}
+		}
+	});
+});
+
+describe("getSchemaVersion", () => {
+	let tmpDir: string;
+	let db: Database;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+		db = connect(join(tmpDir, "test.sqlite"));
+	});
+
+	afterEach(() => {
+		db?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns 0 for a fresh database", () => {
+		expect(getSchemaVersion(db)).toBe(0);
+	});
+
+	it("returns the version after it is set", () => {
+		db.pragma(`user_version = ${SCHEMA_VERSION}`);
+		expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+	});
+});
+
+describe("assertSchemaReady", () => {
+	let tmpDir: string;
+	let db: Database;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+		db = connect(join(tmpDir, "test.sqlite"));
+	});
+
+	afterEach(() => {
+		db?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("throws for uninitialized schema (version 0)", () => {
+		expect(() => assertSchemaReady(db)).toThrow(/not initialized/);
+	});
+
+	it("passes for the current schema version", () => {
+		db.pragma(`user_version = ${SCHEMA_VERSION}`);
+		expect(() => assertSchemaReady(db)).not.toThrow();
+	});
+
+	it("throws for a stale schema version", () => {
+		db.pragma("user_version = 3");
+		expect(() => assertSchemaReady(db)).toThrow(/older than expected/);
+	});
+
+	it("throws for a schema version newer than supported", () => {
+		db.pragma(`user_version = ${SCHEMA_VERSION + 1}`);
+		expect(() => assertSchemaReady(db)).toThrow(/newer than this TS runtime/);
+	});
+});
+
+describe("tableExists", () => {
+	let tmpDir: string;
+	let db: Database;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+		db = connect(join(tmpDir, "test.sqlite"));
+	});
+
+	afterEach(() => {
+		db?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns false for a non-existent table", () => {
+		expect(tableExists(db, "nonexistent")).toBe(false);
+	});
+
+	it("returns true for an existing table", () => {
+		db.exec("CREATE TABLE test_table (id INTEGER PRIMARY KEY)");
+		expect(tableExists(db, "test_table")).toBe(true);
+	});
+});
+
+describe("JSON helpers", () => {
+	it("fromJson returns {} for null/empty", () => {
+		expect(fromJson(null)).toEqual({});
+		expect(fromJson(undefined)).toEqual({});
+		expect(fromJson("")).toEqual({});
+	});
+
+	it("fromJson parses valid JSON", () => {
+		expect(fromJson('{"key": "value"}')).toEqual({ key: "value" });
+	});
+
+	it("fromJson returns {} for invalid JSON", () => {
+		expect(fromJson("not json")).toEqual({});
+	});
+
+	it("toJson serializes to JSON string", () => {
+		expect(toJson({ key: "value" })).toBe('{"key":"value"}');
+	});
+
+	it("toJson returns {} for null/undefined", () => {
+		expect(toJson(null)).toBe("{}");
+		expect(toJson(undefined)).toBe("{}");
+	});
+});
+
+describe("isEmbeddingDisabled", () => {
+	const envKey = "CODEMEM_EMBEDDING_DISABLED";
+	let orig: string | undefined;
+
+	beforeEach(() => {
+		orig = process.env[envKey];
+		delete process.env[envKey];
+	});
+
+	afterEach(() => {
+		if (orig === undefined) {
+			delete process.env[envKey];
+		} else {
+			process.env[envKey] = orig;
+		}
+	});
+
+	it("returns false when env var is unset", () => {
+		expect(isEmbeddingDisabled()).toBe(false);
+	});
+
+	it('returns true for "1"', () => {
+		process.env[envKey] = "1";
+		expect(isEmbeddingDisabled()).toBe(true);
+	});
+
+	it('returns true for "true" (case-insensitive)', () => {
+		process.env[envKey] = "TRUE";
+		expect(isEmbeddingDisabled()).toBe(true);
+	});
+
+	it('returns true for "yes"', () => {
+		process.env[envKey] = "yes";
+		expect(isEmbeddingDisabled()).toBe(true);
+	});
+
+	it('returns false for "0"', () => {
+		process.env[envKey] = "0";
+		expect(isEmbeddingDisabled()).toBe(false);
+	});
+});

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,0 +1,142 @@
+/**
+ * Database connection and schema initialization for the codemem TS backend.
+ *
+ * Mirrors codemem/db.py — same pragmas, same WAL mode, same sqlite-vec loading.
+ * During Phase 1 of the migration, Python owns DDL (schema migrations).
+ * The TS runtime validates the schema version but does NOT run migrations.
+ */
+
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { Database as DatabaseType } from "better-sqlite3";
+import Database from "better-sqlite3";
+import * as sqliteVec from "sqlite-vec";
+
+// Re-export the Database type for consumers
+export type { DatabaseType as Database };
+
+/** Current schema version — must match Python's SCHEMA_VERSION in db.py. */
+export const SCHEMA_VERSION = 6;
+
+/** Default database path — matches Python's DEFAULT_DB_PATH. */
+export const DEFAULT_DB_PATH = join(homedir(), ".codemem", "mem.sqlite");
+
+/**
+ * Open a better-sqlite3 connection with the standard codemem pragmas.
+ *
+ * Creates parent directories if they don't exist (matches Python's connect()).
+ * Sets WAL mode, busy timeout, foreign keys, and loads sqlite-vec.
+ * Does NOT initialize or migrate the schema — during Phase 1, Python owns DDL.
+ *
+ * Note: Legacy path migration (~/.codemem.sqlite → ~/.codemem/mem.sqlite)
+ * is handled by the Python runtime. In Phase 1, Python must run first.
+ */
+export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
+	mkdirSync(dirname(dbPath), { recursive: true });
+	const db = new Database(dbPath);
+
+	// Match Python's connect() pragmas exactly
+	db.pragma("foreign_keys = ON");
+	db.pragma("busy_timeout = 5000");
+
+	const journalMode = db.pragma("journal_mode = WAL", { simple: true }) as string;
+	if (journalMode.toLowerCase() !== "wal") {
+		console.warn(
+			`Failed to enable WAL mode (got ${journalMode}). Concurrent access may not work correctly.`,
+		);
+	}
+
+	db.pragma("synchronous = NORMAL");
+
+	return db;
+}
+
+/**
+ * Load the sqlite-vec extension into an open database connection.
+ *
+ * Call this after connect() when vector operations are needed.
+ * Skipped when CODEMEM_EMBEDDING_DISABLED=1.
+ */
+export function loadSqliteVec(db: DatabaseType): void {
+	if (isEmbeddingDisabled()) {
+		return;
+	}
+
+	sqliteVec.load(db);
+
+	const row = db.prepare("SELECT vec_version() AS v").get() as { v: string } | undefined;
+	if (!row?.v) {
+		throw new Error("sqlite-vec loaded but version check failed");
+	}
+}
+
+/** Check if embeddings are disabled via environment variable. */
+export function isEmbeddingDisabled(): boolean {
+	const val = process.env.CODEMEM_EMBEDDING_DISABLED?.toLowerCase();
+	return val === "1" || val === "true" || val === "yes";
+}
+
+/**
+ * Read the schema user_version from the database.
+ *
+ * During Phase 1, the TS runtime uses this to verify the schema is initialized
+ * (by Python) before operating. It does NOT set or bump the version.
+ */
+export function getSchemaVersion(db: DatabaseType): number {
+	const row = db.pragma("user_version", { simple: true });
+	return typeof row === "number" ? row : 0;
+}
+
+/**
+ * Verify that the database schema is initialized and at the expected version.
+ *
+ * Throws if the schema version is 0 (uninitialized) or ahead of what this
+ * TS runtime understands. During Phase 1, Python must initialize the DB first.
+ */
+export function assertSchemaReady(db: DatabaseType): void {
+	const version = getSchemaVersion(db);
+	if (version === 0) {
+		throw new Error(
+			"Database schema is not initialized. " +
+				"During Phase 1, the Python runtime must initialize the database first. " +
+				"Run: uv run codemem stats",
+		);
+	}
+	if (version < SCHEMA_VERSION) {
+		throw new Error(
+			`Database schema version ${version} is older than expected (${SCHEMA_VERSION}). ` +
+				"Run the Python runtime to complete migrations: uv run codemem stats",
+		);
+	}
+	if (version > SCHEMA_VERSION) {
+		throw new Error(
+			`Database schema version ${version} is newer than this TS runtime supports (${SCHEMA_VERSION}). ` +
+				"Update the TS backend to match the Python schema version.",
+		);
+	}
+}
+
+/** Check if a table exists in the database. */
+export function tableExists(db: DatabaseType, table: string): boolean {
+	const row = db
+		.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+		.get(table);
+	return row !== undefined;
+}
+
+/** Safely parse a JSON string, returning {} on failure. */
+export function fromJson(text: string | null | undefined): Record<string, unknown> {
+	if (!text) return {};
+	try {
+		return JSON.parse(text) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
+}
+
+/** Serialize a value to JSON, defaulting null/undefined to "{}". */
+export function toJson(data: unknown): string {
+	if (data == null) return "{}";
+	return JSON.stringify(data);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,3 +6,43 @@
  */
 
 export const VERSION = "0.0.1";
+
+export type { Database } from "./db.js";
+export {
+	assertSchemaReady,
+	connect,
+	DEFAULT_DB_PATH,
+	fromJson,
+	getSchemaVersion,
+	isEmbeddingDisabled,
+	loadSqliteVec,
+	SCHEMA_VERSION,
+	tableExists,
+	toJson,
+} from "./db.js";
+
+export type {
+	Actor,
+	Artifact,
+	MemoryFilters,
+	MemoryItem,
+	MemoryResult,
+	OpenCodeSession,
+	RawEvent,
+	RawEventFlushBatch,
+	RawEventIngestSample,
+	RawEventIngestStats,
+	RawEventSession,
+	ReplicationClock,
+	ReplicationCursor,
+	ReplicationOp,
+	Session,
+	SessionSummary,
+	SyncAttempt,
+	SyncDaemonState,
+	SyncDevice,
+	SyncNonce,
+	SyncPeer,
+	UsageEvent,
+	UserPrompt,
+} from "./types.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,323 @@
+/**
+ * TypeScript type definitions for the codemem database schema.
+ *
+ * These match the Python schema defined in codemem/db.py and the
+ * data structures in codemem/store/types.py.
+ */
+
+// ---------------------------------------------------------------------------
+// Core entities
+// ---------------------------------------------------------------------------
+
+export interface Session {
+	id: number;
+	started_at: string;
+	ended_at: string | null;
+	cwd: string | null;
+	project: string | null;
+	git_remote: string | null;
+	git_branch: string | null;
+	user: string | null;
+	tool_version: string | null;
+	metadata_json: string | null;
+	import_key: string | null;
+}
+
+export interface MemoryItem {
+	id: number;
+	session_id: number;
+	kind: string;
+	title: string;
+	subtitle: string | null;
+	body_text: string;
+	confidence: number;
+	tags_text: string;
+	active: number; // 0 or 1
+	created_at: string;
+	updated_at: string;
+	metadata_json: string | null;
+	// Identity / multi-actor fields
+	actor_id: string | null;
+	actor_display_name: string | null;
+	visibility: string | null;
+	workspace_id: string | null;
+	workspace_kind: string | null;
+	origin_device_id: string | null;
+	origin_source: string | null;
+	trust_state: string | null;
+	// Structured content fields
+	facts: string | null;
+	narrative: string | null;
+	concepts: string | null;
+	files_read: string | null;
+	files_modified: string | null;
+	// Linkage
+	user_prompt_id: number | null;
+	prompt_number: number | null;
+	import_key: string | null;
+	// Soft delete + replication
+	deleted_at: string | null;
+	rev: number;
+}
+
+export interface Artifact {
+	id: number;
+	session_id: number;
+	kind: string;
+	path: string | null;
+	content_text: string | null;
+	content_hash: string | null;
+	content_encoding: string | null;
+	content_blob: Buffer | null;
+	created_at: string;
+	metadata_json: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Usage tracking
+// ---------------------------------------------------------------------------
+
+export interface UsageEvent {
+	id: number;
+	session_id: number | null;
+	event: string;
+	tokens_read: number;
+	tokens_written: number;
+	tokens_saved: number;
+	created_at: string;
+	metadata_json: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Raw event pipeline
+// ---------------------------------------------------------------------------
+
+export interface RawEvent {
+	id: number;
+	source: string;
+	stream_id: string;
+	opencode_session_id: string;
+	event_id: string | null;
+	event_seq: number;
+	event_type: string;
+	/** Wall-clock timestamp in ms. SQLite INTEGER. */
+	ts_wall_ms: number | null;
+	/** Monotonic timestamp in ms. SQLite REAL (may have fractional part). */
+	ts_mono_ms: number | null;
+	payload_json: string;
+	created_at: string;
+}
+
+export interface RawEventSession {
+	source: string;
+	stream_id: string;
+	opencode_session_id: string;
+	cwd: string | null;
+	project: string | null;
+	started_at: string | null;
+	last_seen_ts_wall_ms: number | null;
+	last_received_event_seq: number;
+	last_flushed_event_seq: number;
+	updated_at: string;
+}
+
+export interface RawEventFlushBatch {
+	id: number;
+	source: string;
+	stream_id: string;
+	opencode_session_id: string;
+	start_event_seq: number;
+	end_event_seq: number;
+	extractor_version: string;
+	status: string;
+	error_message: string | null;
+	error_type: string | null;
+	observer_provider: string | null;
+	observer_model: string | null;
+	observer_runtime: string | null;
+	attempt_count: number;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface UserPrompt {
+	id: number;
+	session_id: number | null;
+	project: string | null;
+	prompt_text: string;
+	prompt_number: number | null;
+	created_at: string;
+	created_at_epoch: number;
+	metadata_json: string | null;
+	import_key: string | null;
+}
+
+export interface SessionSummary {
+	id: number;
+	session_id: number | null;
+	project: string | null;
+	request: string | null;
+	investigated: string | null;
+	learned: string | null;
+	completed: string | null;
+	next_steps: string | null;
+	notes: string | null;
+	files_read: string | null;
+	files_edited: string | null;
+	prompt_number: number | null;
+	created_at: string;
+	created_at_epoch: number;
+	metadata_json: string | null;
+	import_key: string | null;
+}
+
+export interface OpenCodeSession {
+	source: string;
+	stream_id: string;
+	opencode_session_id: string;
+	session_id: number | null;
+	created_at: string;
+}
+
+export interface RawEventIngestStats {
+	id: number; // always 1 (single-row table)
+	inserted_events: number;
+	skipped_events: number;
+	skipped_invalid: number;
+	skipped_duplicate: number;
+	skipped_conflict: number;
+	updated_at: string;
+}
+
+export interface RawEventIngestSample {
+	id: number;
+	created_at: string;
+	inserted_events: number;
+	skipped_invalid: number;
+	skipped_duplicate: number;
+	skipped_conflict: number;
+}
+
+// ---------------------------------------------------------------------------
+// Sync / replication
+// ---------------------------------------------------------------------------
+
+export interface ReplicationOp {
+	op_id: string;
+	entity_type: string;
+	entity_id: string;
+	op_type: string;
+	payload_json: string | null;
+	clock_rev: number;
+	clock_updated_at: string;
+	clock_device_id: string;
+	device_id: string;
+	created_at: string;
+}
+
+export interface ReplicationClock {
+	rev: number;
+	updated_at: string;
+	device_id: string;
+}
+
+export interface ReplicationCursor {
+	peer_device_id: string;
+	last_applied_cursor: string | null;
+	last_acked_cursor: string | null;
+	updated_at: string;
+}
+
+export interface SyncPeer {
+	peer_device_id: string;
+	name: string | null;
+	pinned_fingerprint: string | null;
+	public_key: string | null;
+	addresses_json: string | null;
+	claimed_local_actor: number;
+	actor_id: string | null;
+	projects_include_json: string | null;
+	projects_exclude_json: string | null;
+	created_at: string;
+	last_seen_at: string | null;
+	last_sync_at: string | null;
+	last_error: string | null;
+}
+
+export interface SyncNonce {
+	nonce: string;
+	device_id: string;
+	created_at: string;
+}
+
+export interface SyncDevice {
+	device_id: string;
+	public_key: string;
+	fingerprint: string;
+	created_at: string;
+}
+
+export interface SyncDaemonState {
+	id: number; // always 1 (single-row table)
+	last_error: string | null;
+	last_traceback: string | null;
+	last_error_at: string | null;
+	last_ok_at: string | null;
+}
+
+export interface SyncAttempt {
+	id: number;
+	peer_device_id: string;
+	started_at: string;
+	finished_at: string | null;
+	ok: number;
+	ops_in: number;
+	ops_out: number;
+	error: string | null;
+}
+
+export interface Actor {
+	actor_id: string;
+	display_name: string;
+	is_local: number;
+	status: string;
+	merged_into_actor_id: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Search result (returned by store.search())
+// ---------------------------------------------------------------------------
+
+export interface MemoryResult {
+	id: number;
+	kind: string;
+	title: string;
+	body_text: string;
+	confidence: number;
+	created_at: string;
+	updated_at: string;
+	tags_text: string;
+	score: number;
+	session_id: number;
+	metadata: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Filter types (used by search, recent, etc.)
+// ---------------------------------------------------------------------------
+
+export interface MemoryFilters {
+	kind?: string;
+	include_visibility?: string[];
+	exclude_visibility?: string[];
+	include_workspace_ids?: string[];
+	exclude_workspace_ids?: string[];
+	include_workspace_kinds?: string[];
+	exclude_workspace_kinds?: string[];
+	include_actor_ids?: string[];
+	exclude_actor_ids?: string[];
+	include_trust_states?: string[];
+	exclude_trust_states?: string[];
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,7 +3,12 @@ import { defineConfig } from "tsup";
 export default defineConfig({
 	entry: ["src/index.ts"],
 	format: ["esm"],
-	dts: true,
+	dts: {
+		compilerOptions: {
+			composite: false,
+		},
+	},
 	clean: true,
 	sourcemap: true,
+	external: ["better-sqlite3", "sqlite-vec"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.4
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.5.0)
 
   packages/cli:
     dependencies:
@@ -57,10 +57,20 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.5.0)
 
   packages/core:
+    dependencies:
+      better-sqlite3:
+        specifier: ^12.8.0
+        version: 12.8.0
+      sqlite-vec:
+        specifier: 0.1.7-alpha.2
+        version: 0.1.7-alpha.2
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
@@ -69,7 +79,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.5.0)
 
   packages/mcp-server:
     dependencies:
@@ -85,7 +95,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.5.0)
 
   packages/viewer-server:
     dependencies:
@@ -101,7 +111,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4
+        version: 3.2.4(@types/node@25.5.0)
 
 packages:
 
@@ -458,6 +468,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -466,6 +479,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -508,6 +524,22 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  better-sqlite3@12.8.0:
+    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -530,6 +562,9 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -550,9 +585,24 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -564,6 +614,10 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -578,13 +632,31 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -610,6 +682,16 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
@@ -624,9 +706,19 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -671,6 +763,23 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -684,8 +793,22 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -695,11 +818,46 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  sqlite-vec-darwin-arm64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-raIATOqFYkeCHhb/t3r7W7Cf2lVYdf4J3ogJ6GFc8PQEgHCPEsi+bYnm2JT84MzLfTlSTIdxr4/NKv+zF7oLPw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  sqlite-vec-darwin-x64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-jeZEELsQjjRsVojsvU5iKxOvkaVuE+JYC8Y4Ma8U45aAERrDYmqZoHvgSG7cg1PXL3bMlumFTAmHynf1y4pOzA==}
+    cpu: [x64]
+    os: [darwin]
+
+  sqlite-vec-linux-arm64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-6Spj4Nfi7tG13jsUG+W7jnT0bCTWbyPImu2M8nWp20fNrd1SZ4g3CSlDAK8GBdavX7wRlbBHCZ+BDa++rbDewA==}
+    cpu: [arm64]
+    os: [linux]
+
+  sqlite-vec-linux-x64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-IcgrbHaDccTVhXDf8Orwdc2+hgDLAFORl6OBUhcvlmwswwBP1hqBTSEhovClG4NItwTOBNgpwOoQ7Qp3VDPWLg==}
+    cpu: [x64]
+    os: [linux]
+
+  sqlite-vec-windows-x64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-TRP6hTjAcwvQ6xpCZvjP00pdlda8J38ArFy1lMYhtQWXiIBmWnhMaMbq4kaeCYwvTTddfidatRS+TJrwIKB/oQ==}
+    cpu: [x64]
+    os: [win32]
+
+  sqlite-vec@0.1.7-alpha.2:
+    resolution: {integrity: sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -708,6 +866,13 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -764,6 +929,9 @@ packages:
       typescript:
         optional: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -771,6 +939,12 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -849,6 +1023,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   zod@4.1.8:
     resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
@@ -1064,6 +1241,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1073,6 +1254,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1081,13 +1266,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1)':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1
+      vite: 7.3.1(@types/node@25.5.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1121,6 +1306,28 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  base64-js@1.5.1: {}
+
+  better-sqlite3@12.8.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bundle-require@5.1.0(esbuild@0.27.4):
     dependencies:
       esbuild: 0.27.4
@@ -1142,6 +1349,8 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chownr@1.1.4: {}
+
   commander@4.1.1: {}
 
   confbox@0.1.8: {}
@@ -1152,7 +1361,19 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
+
+  detect-libc@2.1.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   es-module-lexer@1.7.0: {}
 
@@ -1189,11 +1410,15 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  file-uri-to-path@1.0.0: {}
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -1201,8 +1426,18 @@ snapshots:
       mlly: 1.8.1
       rollup: 4.59.0
 
+  fs-constants@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  github-from-package@0.0.0: {}
+
+  ieee754@1.2.1: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   joycon@3.1.1: {}
 
@@ -1219,6 +1454,12 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mimic-response@3.1.0: {}
+
+  minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.1:
     dependencies:
@@ -1237,7 +1478,17 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
   object-assign@4.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   pathe@2.0.3: {}
 
@@ -1266,6 +1517,39 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -1302,15 +1586,56 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
+  semver@7.7.4: {}
+
   siginfo@2.0.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
 
+  sqlite-vec-darwin-arm64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-darwin-x64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-linux-arm64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-linux-x64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-windows-x64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec@0.1.7-alpha.2:
+    optionalDependencies:
+      sqlite-vec-darwin-arm64: 0.1.7-alpha.2
+      sqlite-vec-darwin-x64: 0.1.7-alpha.2
+      sqlite-vec-linux-arm64: 0.1.7-alpha.2
+      sqlite-vec-linux-x64: 0.1.7-alpha.2
+      sqlite-vec-windows-x64: 0.1.7-alpha.2
+
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-json-comments@2.0.1: {}
 
   strip-literal@3.1.0:
     dependencies:
@@ -1325,6 +1650,21 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   thenify-all@1.6.0:
     dependencies:
@@ -1381,17 +1721,25 @@ snapshots:
       - tsx
       - yaml
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
 
-  vite-node@3.2.4:
+  undici-types@7.18.2: {}
+
+  util-deprecate@1.0.2: {}
+
+  vite-node@3.2.4(@types/node@25.5.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1
+      vite: 7.3.1(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -1406,7 +1754,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1:
+  vite@7.3.1(@types/node@25.5.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1415,13 +1763,14 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.5.0
       fsevents: 2.3.3
 
-  vitest@3.2.4:
+  vitest@3.2.4(@types/node@25.5.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1)
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1439,9 +1788,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1
-      vite-node: 3.2.4
+      vite: 7.3.1(@types/node@25.5.0)
+      vite-node: 3.2.4(@types/node@25.5.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -1460,5 +1811,7 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrappy@1.0.2: {}
 
   zod@4.1.8: {}


### PR DESCRIPTION
## Description

Foundation for the TS store port (codemem-egb). Adds the database connection layer and complete schema type definitions to `@codemem/core`.

**`db.ts`** — Connection + utilities:
- `connect()` with WAL/busy_timeout/FK pragmas (matches Python exactly)
- `loadSqliteVec()` respects `CODEMEM_EMBEDDING_DISABLED`
- `assertSchemaReady()` validates Python has initialized schema to version 6 (strict — rejects stale versions)
- `fromJson()`/`toJson()` helpers

**`types.ts`** — TypeScript interfaces for all 25 database tables:
- Core: Session, MemoryItem, Artifact
- Raw event pipeline: RawEvent, RawEventSession, RawEventFlushBatch, OpenCodeSession, RawEventIngestStats/Sample
- Sync: ReplicationOp, SyncPeer, SyncDevice, SyncNonce, SyncDaemonState, SyncAttempt, Actor
- Query types: MemoryResult, MemoryFilters

Native deps (`better-sqlite3`, `sqlite-vec`) externalized from tsup bundle.

Part of: codemem-egb

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — typecheck + lint + test)
- [x] Added/updated tests for changes (25 tests: connection pragmas, sqlite-vec loading, schema version checks, isEmbeddingDisabled, JSON helpers, table existence)
- [x] Manually verified changes work as expected
- [x] Python tests unaffected

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced