### PR TITLE
Add MemoryStore class with CRUD operations and filter builder

### DIFF
--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -1,0 +1,114 @@
+/**
+ * Filter builder for memory_items queries.
+ *
+ * Mirrors Python's _extend_memory_filter_clauses in codemem/store/search.py.
+ * Builds WHERE clause fragments and parameter arrays from a MemoryFilters object.
+ */
+
+import type { MemoryFilters } from "./types.js";
+
+export interface FilterResult {
+	clauses: string[];
+	params: unknown[];
+	joinSessions: boolean;
+}
+
+/**
+ * Normalize a filter value that may be a single string or an array of strings
+ * into a clean, non-empty array of trimmed strings.
+ */
+function normalizeStringArray(value: string | string[] | undefined | null): string[] {
+	if (value == null) return [];
+	const items = Array.isArray(value) ? value : [value];
+	return items.map((s) => String(s).trim()).filter((s) => s.length > 0);
+}
+
+/**
+ * Add IN / NOT IN clauses for a multi-value filter column.
+ * Mirrors Python's _add_multi_value_filter.
+ */
+function addMultiValueFilter(
+	clauses: string[],
+	params: unknown[],
+	column: string,
+	includeValues: string[],
+	excludeValues: string[],
+): void {
+	if (includeValues.length > 0) {
+		const placeholders = includeValues.map(() => "?").join(", ");
+		clauses.push(`${column} IN (${placeholders})`);
+		params.push(...includeValues);
+	}
+	if (excludeValues.length > 0) {
+		const placeholders = excludeValues.map(() => "?").join(", ");
+		clauses.push(`(${column} IS NULL OR ${column} NOT IN (${placeholders}))`);
+		params.push(...excludeValues);
+	}
+}
+
+/**
+ * Build WHERE clause fragments from a MemoryFilters object.
+ *
+ * Returns clauses, params, and whether the sessions table must be joined.
+ * The caller is responsible for prepending `memory_items.active = 1` or
+ * similar base conditions — this function only appends filter-specific clauses.
+ */
+export function buildFilterClauses(filters: MemoryFilters | undefined | null): FilterResult {
+	const result: FilterResult = { clauses: [], params: [], joinSessions: false };
+	if (!filters) return result;
+
+	const { clauses, params } = result;
+
+	// Single kind filter
+	if (filters.kind) {
+		clauses.push("memory_items.kind = ?");
+		params.push(filters.kind);
+	}
+
+	// Visibility
+	addMultiValueFilter(
+		clauses,
+		params,
+		"memory_items.visibility",
+		normalizeStringArray(filters.include_visibility),
+		normalizeStringArray(filters.exclude_visibility),
+	);
+
+	// Workspace IDs
+	addMultiValueFilter(
+		clauses,
+		params,
+		"memory_items.workspace_id",
+		normalizeStringArray(filters.include_workspace_ids),
+		normalizeStringArray(filters.exclude_workspace_ids),
+	);
+
+	// Workspace kinds
+	addMultiValueFilter(
+		clauses,
+		params,
+		"memory_items.workspace_kind",
+		normalizeStringArray(filters.include_workspace_kinds),
+		normalizeStringArray(filters.exclude_workspace_kinds),
+	);
+
+	// Actor IDs
+	addMultiValueFilter(
+		clauses,
+		params,
+		"memory_items.actor_id",
+		normalizeStringArray(filters.include_actor_ids),
+		normalizeStringArray(filters.exclude_actor_ids),
+	);
+
+	// Trust states
+	addMultiValueFilter(
+		clauses,
+		params,
+		"memory_items.trust_state",
+		normalizeStringArray(filters.include_trust_states),
+		normalizeStringArray(filters.exclude_trust_states),
+	);
+
+	return result;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,9 @@ export {
 	tableExists,
 	toJson,
 } from "./db.js";
+export { buildFilterClauses } from "./filters.js";
 
+export { MemoryStore } from "./store.js";
 export type {
 	Actor,
 	Artifact,

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1,0 +1,432 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import { buildFilterClauses } from "./filters.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+
+// ---------------------------------------------------------------------------
+// Helper: create a MemoryStore backed by a temp DB with test schema.
+// We can't use the MemoryStore constructor directly because it calls
+// assertSchemaReady which requires the schema to already exist. Instead,
+// we pre-initialize the schema, then construct the store.
+// ---------------------------------------------------------------------------
+
+describe("MemoryStore", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-store-test-"));
+		dbPath = join(tmpDir, "test.sqlite");
+		// Pre-create the schema so MemoryStore constructor's assertSchemaReady passes
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		// Now open via MemoryStore
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// -- get ----------------------------------------------------------------
+
+	describe("get", () => {
+		it("returns null for non-existent memory", () => {
+			expect(store.get(9999)).toBeNull();
+		});
+
+		it("returns a memory item with parsed metadata", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Test title", "Test body");
+
+			const result = store.get(memId);
+			expect(result).not.toBeNull();
+			expect(result?.id).toBe(memId);
+			expect(result?.kind).toBe("discovery");
+			expect(result?.title).toBe("Test title");
+			expect(result?.body_text).toBe("Test body");
+			// metadata_json should be parsed into an object
+			expect(typeof result?.metadata_json).toBe("object");
+		});
+	});
+
+	// -- remember -----------------------------------------------------------
+
+	describe("remember", () => {
+		it("inserts a memory item and returns the ID", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "feature", "My Feature", "Feature body", 0.8);
+
+			expect(memId).toBeGreaterThan(0);
+
+			const row = store.get(memId);
+			expect(row).not.toBeNull();
+			expect(row?.kind).toBe("feature");
+			expect(row?.title).toBe("My Feature");
+			expect(row?.body_text).toBe("Feature body");
+			expect(row?.confidence).toBe(0.8);
+			expect(row?.active).toBe(1);
+			expect(row?.rev).toBe(1);
+			expect(row?.deleted_at).toBeNull();
+		});
+
+		it("generates an import_key when not provided", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+
+			const row = store.get(memId);
+			expect(row?.import_key).toBeTruthy();
+			expect(typeof row?.import_key).toBe("string");
+		});
+
+		it("preserves provided import_key in metadata", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body", 0.5, undefined, {
+				import_key: "custom-key-123",
+			});
+
+			const row = store.get(memId);
+			expect(row?.import_key).toBe("custom-key-123");
+		});
+
+		it("validates and normalizes memory kind", () => {
+			const sessionId = insertTestSession(store.db);
+			// Accepts valid kind
+			const memId = store.remember(sessionId, "  Discovery  ", "Title", "Body");
+			const row = store.get(memId);
+			expect(row?.kind).toBe("discovery");
+		});
+
+		it("rejects invalid memory kind", () => {
+			const sessionId = insertTestSession(store.db);
+			expect(() => store.remember(sessionId, "yolo", "Title", "Body")).toThrow(
+				/Invalid memory kind/,
+			);
+		});
+
+		it("sets clock_device_id in metadata", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+			const row = store.get(memId);
+			const meta = row?.metadata_json as Record<string, unknown>;
+			expect(meta.clock_device_id).toBe(store.deviceId);
+		});
+
+		it("sets origin_device_id", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+			const row = store.get(memId);
+			expect(row?.origin_device_id).toBe(store.deviceId);
+		});
+
+		it("sorts and deduplicates tags", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "T", "B", 0.5, [
+				"beta",
+				"alpha",
+				"beta",
+			]);
+
+			const row = store.get(memId);
+			expect(row?.tags_text).toBe("alpha beta");
+		});
+	});
+
+	// -- forget --------------------------------------------------------------
+
+	describe("forget", () => {
+		it("soft-deletes an existing memory", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "To Delete", "Body");
+
+			store.forget(memId);
+
+			const row = store.get(memId);
+			expect(row).not.toBeNull();
+			expect(row?.active).toBe(0);
+			expect(row?.deleted_at).toBeTruthy();
+			expect(row?.rev).toBe(2); // was 1, bumped to 2
+		});
+
+		it("updates metadata_json with clock_device_id", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "To Delete", "Body");
+			store.forget(memId);
+
+			const row = store.get(memId);
+			const meta = row?.metadata_json as Record<string, unknown>;
+			expect(meta.clock_device_id).toBe(store.deviceId);
+		});
+
+		it("is a no-op for non-existent memory", () => {
+			// Should not throw
+			store.forget(99999);
+		});
+	});
+
+	// -- recent --------------------------------------------------------------
+
+	describe("recent", () => {
+		it("returns active memories ordered by created_at DESC", () => {
+			const sessionId = insertTestSession(store.db);
+			// Insert with explicit timestamps to guarantee ordering
+			const base = "2026-01-01T00:00:0";
+			for (const [i, kind] of (["discovery", "feature", "bugfix"] as const).entries()) {
+				store.db
+					.prepare(
+						`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+					tags_text, active, created_at, updated_at, metadata_json, rev)
+					VALUES (?, ?, ?, ?, 0.5, '', 1, ?, ?, '{}', 1)`,
+					)
+					.run(sessionId, kind, `Item ${i}`, `Body ${i}`, `${base}${i}Z`, `${base}${i}Z`);
+			}
+
+			const results = store.recent(10);
+			expect(results).toHaveLength(3);
+			// Newest first (bugfix at :02, feature at :01, discovery at :00)
+			expect(results[0]?.kind).toBe("bugfix");
+			expect(results[2]?.kind).toBe("discovery");
+		});
+
+		it("excludes soft-deleted memories", () => {
+			const sessionId = insertTestSession(store.db);
+			const id1 = store.remember(sessionId, "discovery", "Keep", "Body");
+			const id2 = store.remember(sessionId, "discovery", "Delete", "Body");
+			store.forget(id2);
+
+			const results = store.recent(10);
+			expect(results).toHaveLength(1);
+			expect(results[0].id).toBe(id1);
+		});
+
+		it("respects limit and offset", () => {
+			const sessionId = insertTestSession(store.db);
+			for (let i = 0; i < 5; i++) {
+				store.remember(sessionId, "discovery", `Item ${i}`, `Body ${i}`);
+			}
+
+			const page1 = store.recent(2, null, 0);
+			const page2 = store.recent(2, null, 2);
+			expect(page1).toHaveLength(2);
+			expect(page2).toHaveLength(2);
+			expect(page1[0].id).not.toBe(page2[0].id);
+		});
+
+		it("filters by kind", () => {
+			const sessionId = insertTestSession(store.db);
+			store.remember(sessionId, "discovery", "D1", "Body");
+			store.remember(sessionId, "feature", "F1", "Body");
+			store.remember(sessionId, "discovery", "D2", "Body");
+
+			const results = store.recent(10, { kind: "discovery" });
+			expect(results).toHaveLength(2);
+			for (const r of results) {
+				expect(r.kind).toBe("discovery");
+			}
+		});
+	});
+
+	// -- recentByKinds -------------------------------------------------------
+
+	describe("recentByKinds", () => {
+		it("filters by multiple kinds", () => {
+			const sessionId = insertTestSession(store.db);
+			store.remember(sessionId, "discovery", "D1", "Body");
+			store.remember(sessionId, "feature", "F1", "Body");
+			store.remember(sessionId, "bugfix", "B1", "Body");
+			store.remember(sessionId, "refactor", "R1", "Body");
+
+			const results = store.recentByKinds(["discovery", "bugfix"]);
+			expect(results).toHaveLength(2);
+			const kinds = results.map((r) => r.kind);
+			expect(kinds).toContain("discovery");
+			expect(kinds).toContain("bugfix");
+		});
+
+		it("returns empty array for empty kinds list", () => {
+			const results = store.recentByKinds([]);
+			expect(results).toEqual([]);
+		});
+	});
+
+	// -- stats ---------------------------------------------------------------
+
+	describe("stats", () => {
+		it("returns a structured stats object", () => {
+			const sessionId = insertTestSession(store.db);
+			store.remember(sessionId, "discovery", "Title", "Body");
+
+			const result = store.stats();
+			expect(result.database).toBeDefined();
+
+			const dbStats = result.database as Record<string, unknown>;
+			expect(dbStats.path).toBe(dbPath);
+			expect(dbStats.size_bytes).toBeGreaterThan(0);
+			expect(dbStats.sessions).toBe(1);
+			expect(dbStats.memory_items).toBe(1);
+			expect(dbStats.active_memory_items).toBe(1);
+			expect(dbStats.artifacts).toBe(0);
+			expect(dbStats.raw_events).toBe(0);
+		});
+
+		it("counts inactive memories in total but not active", () => {
+			const sessionId = insertTestSession(store.db);
+			const _id1 = store.remember(sessionId, "discovery", "Active", "Body");
+			const id2 = store.remember(sessionId, "discovery", "Deleted", "Body");
+			store.forget(id2);
+
+			const result = store.stats();
+			const dbStats = result.database as Record<string, unknown>;
+			expect(dbStats.memory_items).toBe(2);
+			expect(dbStats.active_memory_items).toBe(1);
+		});
+	});
+
+	// -- updateMemoryVisibility ----------------------------------------------
+
+	describe("updateMemoryVisibility", () => {
+		it("updates visibility to private with device-scoped workspace_id", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+
+			const updated = store.updateMemoryVisibility(memId, "private");
+			expect(updated.visibility).toBe("private");
+			expect(updated.workspace_kind).toBe("personal");
+			expect(updated.workspace_id).toBe(`personal:${store.deviceId}`);
+		});
+
+		it("updates metadata_json with clock_device_id on visibility change", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+
+			const updated = store.updateMemoryVisibility(memId, "shared");
+			const meta = updated.metadata_json as Record<string, unknown>;
+			expect(meta.clock_device_id).toBe(store.deviceId);
+			expect(meta.visibility).toBe("shared");
+		});
+
+		it("updates visibility to shared", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+
+			const updated = store.updateMemoryVisibility(memId, "shared");
+			expect(updated.visibility).toBe("shared");
+			expect(updated.workspace_kind).toBe("shared");
+		});
+
+		it("bumps rev on visibility change", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+
+			const original = store.get(memId);
+			const updated = store.updateMemoryVisibility(memId, "private");
+			expect(updated.rev).toBe((original?.rev as number) + 1);
+		});
+
+		it("throws for invalid visibility", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+
+			expect(() => store.updateMemoryVisibility(memId, "invalid")).toThrow(
+				/visibility must be private or shared/,
+			);
+		});
+
+		it("throws for non-existent memory", () => {
+			expect(() => store.updateMemoryVisibility(99999, "shared")).toThrow(/memory not found/);
+		});
+
+		it("throws for inactive memory", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+			store.forget(memId);
+
+			expect(() => store.updateMemoryVisibility(memId, "shared")).toThrow(/memory not found/);
+		});
+
+		it("throws for memory owned by another device", () => {
+			const sessionId = insertTestSession(store.db);
+			// Insert a memory with a different origin_device_id
+			store.db
+				.prepare(
+					`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+					tags_text, active, created_at, updated_at, metadata_json,
+					origin_device_id, rev)
+					VALUES (?, 'discovery', 'Foreign', 'Body', 0.5, '', 1, ?, ?, '{}', 'other-device', 1)`,
+				)
+				.run(sessionId, new Date().toISOString(), new Date().toISOString());
+			const foreignId = Number(
+				(store.db.prepare("SELECT last_insert_rowid() as id").get() as { id: number }).id,
+			);
+
+			expect(() => store.updateMemoryVisibility(foreignId, "private")).toThrow(
+				/not owned by this device/,
+			);
+		});
+	});
+
+	// -- close ---------------------------------------------------------------
+
+	describe("close", () => {
+		it("closes the database connection", () => {
+			const sessionId = insertTestSession(store.db);
+			store.remember(sessionId, "discovery", "Title", "Body");
+			store.close();
+
+			// After close, operations should throw
+			expect(() => store.get(1)).toThrow();
+			// Prevent afterEach from double-closing
+			store = undefined as unknown as MemoryStore;
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildFilterClauses (unit tests)
+// ---------------------------------------------------------------------------
+
+describe("buildFilterClauses", () => {
+	it("returns empty for null/undefined filters", () => {
+		const result = buildFilterClauses(null);
+		expect(result.clauses).toEqual([]);
+		expect(result.params).toEqual([]);
+		expect(result.joinSessions).toBe(false);
+	});
+
+	it("builds kind filter", () => {
+		const result = buildFilterClauses({ kind: "discovery" });
+		expect(result.clauses).toEqual(["memory_items.kind = ?"]);
+		expect(result.params).toEqual(["discovery"]);
+	});
+
+	it("builds include_visibility filter", () => {
+		const result = buildFilterClauses({ include_visibility: ["private", "shared"] });
+		expect(result.clauses).toHaveLength(1);
+		expect(result.clauses[0]).toContain("IN");
+		expect(result.params).toEqual(["private", "shared"]);
+	});
+
+	it("builds exclude_actor_ids filter", () => {
+		const result = buildFilterClauses({ exclude_actor_ids: ["actor:123"] });
+		expect(result.clauses).toHaveLength(1);
+		expect(result.clauses[0]).toContain("NOT IN");
+		expect(result.params).toEqual(["actor:123"]);
+	});
+
+	it("combines multiple filters", () => {
+		const result = buildFilterClauses({
+			kind: "feature",
+			include_visibility: ["shared"],
+			exclude_workspace_kinds: ["personal"],
+		});
+		expect(result.clauses).toHaveLength(3);
+		expect(result.params).toEqual(["feature", "shared", "personal"]);
+	});
+});

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,0 +1,382 @@
+/**
+ * MemoryStore — TypeScript port of codemem/store/_store.py (Phase 1 CRUD).
+ *
+ * During Phase 1, Python owns DDL/schema. This TS runtime reads and writes data
+ * but does NOT create or migrate tables. The assertSchemaReady() call verifies
+ * the schema was initialized by Python before any operations.
+ *
+ * Methods ported: get, remember, forget, recent, recentByKinds, stats,
+ * updateMemoryVisibility, close.
+ *
+ * NOT ported yet: search, timeline, explain, pack, usage tracking, vectors,
+ * provenance resolution, memory_owned_by_self check.
+ */
+
+import { randomUUID } from "node:crypto";
+import { statSync } from "node:fs";
+import type { Database } from "./db.js";
+import {
+	assertSchemaReady,
+	connect,
+	DEFAULT_DB_PATH,
+	fromJson,
+	loadSqliteVec,
+	tableExists,
+	toJson,
+} from "./db.js";
+import { buildFilterClauses } from "./filters.js";
+import type { MemoryFilters, MemoryItem } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Memory kind validation (mirrors codemem/memory_kinds.py)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_MEMORY_KINDS = new Set([
+	"discovery",
+	"change",
+	"feature",
+	"bugfix",
+	"refactor",
+	"decision",
+	"exploration",
+]);
+
+/** Normalize and validate a memory kind. Throws on invalid kinds. */
+function validateMemoryKind(kind: string): string {
+	const normalized = kind.trim().toLowerCase();
+	if (!ALLOWED_MEMORY_KINDS.has(normalized)) {
+		throw new Error(
+			`Invalid memory kind "${kind}". Allowed: ${[...ALLOWED_MEMORY_KINDS].join(", ")}`,
+		);
+	}
+	return normalized;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** ISO 8601 timestamp in UTC. */
+function nowIso(): string {
+	return new Date().toISOString();
+}
+
+/**
+ * Parse a row's metadata_json string into a plain object.
+ * Mutates the row in place and returns it for convenience.
+ */
+function parseMetadata(row: Record<string, unknown>): Record<string, unknown> {
+	row.metadata_json = fromJson(row.metadata_json as string | null | undefined);
+	return row;
+}
+
+// ---------------------------------------------------------------------------
+// MemoryStore
+// ---------------------------------------------------------------------------
+
+export class MemoryStore {
+	readonly db: Database;
+	readonly dbPath: string;
+	readonly deviceId: string;
+
+	constructor(dbPath: string = DEFAULT_DB_PATH) {
+		this.dbPath = dbPath;
+		this.db = connect(dbPath);
+		loadSqliteVec(this.db);
+		assertSchemaReady(this.db);
+
+		const envDeviceId = process.env.CODEMEM_DEVICE_ID?.trim();
+		this.deviceId = envDeviceId || randomUUID();
+	}
+
+	// -----------------------------------------------------------------------
+	// get
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Fetch a single memory item by ID.
+	 * Returns null if not found (does not filter by active status).
+	 */
+	get(memoryId: number): Record<string, unknown> | null {
+		const row = this.db.prepare("SELECT * FROM memory_items WHERE id = ?").get(memoryId) as
+			| MemoryItem
+			| undefined;
+		if (!row) return null;
+		return parseMetadata({ ...row });
+	}
+
+	// -----------------------------------------------------------------------
+	// remember
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Create a new memory item. Returns the new memory ID.
+	 *
+	 * Validates and normalizes the kind. Sets clock_device_id and
+	 * origin_device_id for replication tracing.
+	 *
+	 * NOT ported yet: full provenance resolution, vector storage,
+	 * flush_batch dedup (tracked for follow-up).
+	 */
+	remember(
+		sessionId: number,
+		kind: string,
+		title: string,
+		bodyText: string,
+		confidence = 0.5,
+		tags?: string[],
+		metadata?: Record<string, unknown>,
+	): number {
+		const validKind = validateMemoryKind(kind);
+		const now = nowIso();
+		const tagsText = tags ? [...new Set(tags)].sort().join(" ") : "";
+		const metaPayload = { ...(metadata ?? {}) };
+
+		metaPayload.clock_device_id ??= this.deviceId;
+		const importKey = (metaPayload.import_key as string) || randomUUID();
+		metaPayload.import_key = importKey;
+
+		const info = this.db
+			.prepare(
+				`INSERT INTO memory_items(
+					session_id, kind, title, body_text, confidence, tags_text,
+					active, created_at, updated_at, metadata_json,
+					origin_device_id, deleted_at, rev, import_key
+				) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, NULL, 1, ?)`,
+			)
+			.run(
+				sessionId,
+				validKind,
+				title,
+				bodyText,
+				confidence,
+				tagsText,
+				now,
+				now,
+				toJson(metaPayload),
+				this.deviceId,
+				importKey,
+			);
+
+		return Number(info.lastInsertRowid);
+	}
+
+	// -----------------------------------------------------------------------
+	// forget
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Soft-delete a memory item (set active = 0, record deleted_at).
+	 * Updates metadata_json with clock_device_id for replication tracing.
+	 * No-op if the memory doesn't exist.
+	 */
+	forget(memoryId: number): void {
+		const row = this.db
+			.prepare("SELECT rev, metadata_json FROM memory_items WHERE id = ?")
+			.get(memoryId) as { rev: number; metadata_json: string | null } | undefined;
+		if (!row) return;
+
+		const meta = fromJson(row.metadata_json);
+		meta.clock_device_id = this.deviceId;
+
+		const now = nowIso();
+		const rev = (row.rev ?? 0) + 1;
+
+		this.db
+			.prepare(
+				`UPDATE memory_items
+				 SET active = 0, deleted_at = ?, updated_at = ?, metadata_json = ?, rev = ?
+				 WHERE id = ?`,
+			)
+			.run(now, now, toJson(meta), rev, memoryId);
+	}
+
+	// -----------------------------------------------------------------------
+	// recent
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Return recent active memories, newest first.
+	 * Supports optional filters via buildFilterClauses.
+	 */
+	recent(limit = 10, filters?: MemoryFilters | null, offset = 0): Record<string, unknown>[] {
+		const baseClauses = ["memory_items.active = 1"];
+		const filterResult = buildFilterClauses(filters);
+		const allClauses = [...baseClauses, ...filterResult.clauses];
+		const where = allClauses.join(" AND ");
+
+		// Note: joinSessions is set by the project filter (not yet ported).
+		// Once project filtering lands, it will trigger the sessions JOIN.
+		const from = filterResult.joinSessions
+			? "memory_items JOIN sessions ON sessions.id = memory_items.session_id"
+			: "memory_items";
+
+		const rows = this.db
+			.prepare(
+				`SELECT memory_items.* FROM ${from}
+				 WHERE ${where}
+				 ORDER BY created_at DESC
+				 LIMIT ? OFFSET ?`,
+			)
+			.all(...filterResult.params, limit, Math.max(offset, 0)) as Record<string, unknown>[];
+
+		return rows.map((row) => parseMetadata({ ...row }));
+	}
+
+	// -----------------------------------------------------------------------
+	// recentByKinds
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Return recent active memories filtered to specific kinds, newest first.
+	 */
+	recentByKinds(
+		kinds: string[],
+		limit = 10,
+		filters?: MemoryFilters | null,
+		offset = 0,
+	): Record<string, unknown>[] {
+		const kindsList = kinds.filter((k) => k.length > 0);
+		if (kindsList.length === 0) return [];
+
+		const kindPlaceholders = kindsList.map(() => "?").join(", ");
+		const baseClauses = ["memory_items.active = 1", `memory_items.kind IN (${kindPlaceholders})`];
+		const filterResult = buildFilterClauses(filters);
+		const allClauses = [...baseClauses, ...filterResult.clauses];
+		const where = allClauses.join(" AND ");
+
+		const from = filterResult.joinSessions
+			? "memory_items JOIN sessions ON sessions.id = memory_items.session_id"
+			: "memory_items";
+
+		const params = [...kindsList, ...filterResult.params, limit, Math.max(offset, 0)];
+
+		const rows = this.db
+			.prepare(
+				`SELECT memory_items.* FROM ${from}
+				 WHERE ${where}
+				 ORDER BY created_at DESC
+				 LIMIT ? OFFSET ?`,
+			)
+			.all(...params) as Record<string, unknown>[];
+
+		return rows.map((row) => parseMetadata({ ...row }));
+	}
+
+	// -----------------------------------------------------------------------
+	// stats
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Return database statistics matching the Python stats() output shape.
+	 */
+	stats(): Record<string, unknown> {
+		const count = (sql: string): number => {
+			const row = this.db.prepare(sql).get() as { c: number } | undefined;
+			return row?.c ?? 0;
+		};
+
+		const totalMemories = count("SELECT COUNT(*) AS c FROM memory_items");
+		const activeMemories = count("SELECT COUNT(*) AS c FROM memory_items WHERE active = 1");
+		const sessions = count("SELECT COUNT(*) AS c FROM sessions");
+		const artifacts = count("SELECT COUNT(*) AS c FROM artifacts");
+		const rawEvents = count("SELECT COUNT(*) AS c FROM raw_events");
+
+		let vectorCount = 0;
+		if (tableExists(this.db, "memory_vectors")) {
+			vectorCount = count("SELECT COUNT(*) AS c FROM memory_vectors");
+		}
+
+		let sizeBytes = 0;
+		try {
+			sizeBytes = statSync(this.dbPath).size;
+		} catch {
+			// File may not exist yet or be inaccessible
+		}
+
+		return {
+			database: {
+				path: this.dbPath,
+				size_bytes: sizeBytes,
+				sessions,
+				memory_items: totalMemories,
+				active_memory_items: activeMemories,
+				artifacts,
+				vector_rows: vectorCount,
+				raw_events: rawEvents,
+			},
+		};
+	}
+
+	// -----------------------------------------------------------------------
+	// updateMemoryVisibility
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Update the visibility of an active memory item.
+	 * Throws if visibility is invalid, memory not found, memory is inactive,
+	 * or memory is not owned by this device/actor.
+	 */
+	updateMemoryVisibility(memoryId: number, visibility: string): Record<string, unknown> {
+		const cleaned = visibility.trim();
+		if (cleaned !== "private" && cleaned !== "shared") {
+			throw new Error("visibility must be private or shared");
+		}
+
+		const row = this.db
+			.prepare("SELECT * FROM memory_items WHERE id = ? AND active = 1")
+			.get(memoryId) as MemoryItem | undefined;
+		if (!row) {
+			throw new Error("memory not found");
+		}
+
+		// Ownership check: only the originating device/actor can change visibility.
+		// Matches Python's memory_owned_by_self() — checks origin_device_id.
+		// When actor resolution is fully ported, this should also check actor_id.
+		if (row.origin_device_id && row.origin_device_id !== this.deviceId) {
+			throw new Error("memory not owned by this device");
+		}
+
+		const workspaceKind = cleaned === "shared" ? "shared" : "personal";
+		const workspaceId =
+			cleaned === "shared" && row.workspace_id?.startsWith("shared:")
+				? row.workspace_id
+				: workspaceKind === "personal"
+					? `personal:${this.deviceId}`
+					: "shared:default";
+
+		// Update metadata with visibility change + clock stamp
+		const meta = fromJson(row.metadata_json);
+		meta.visibility = cleaned;
+		meta.workspace_kind = workspaceKind;
+		meta.workspace_id = workspaceId;
+		meta.clock_device_id = this.deviceId;
+
+		const now = nowIso();
+		const rev = (row.rev ?? 0) + 1;
+
+		this.db
+			.prepare(
+				`UPDATE memory_items
+				 SET visibility = ?, workspace_kind = ?, workspace_id = ?,
+				     updated_at = ?, metadata_json = ?, rev = ?
+				 WHERE id = ?`,
+			)
+			.run(cleaned, workspaceKind, workspaceId, now, toJson(meta), rev, memoryId);
+
+		const updated = this.get(memoryId);
+		if (!updated) {
+			throw new Error("memory not found after update");
+		}
+		return updated;
+	}
+
+	// -----------------------------------------------------------------------
+	// close
+	// -----------------------------------------------------------------------
+
+	/** Close the database connection. */
+	close(): void {
+		this.db.close();
+	}
+}

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -1,0 +1,125 @@
+/**
+ * Test utilities for the codemem TS backend.
+ *
+ * During Phase 1, Python owns DDL. For tests, we create a minimal schema
+ * that matches the Python-created tables so the TS store can operate
+ * against an in-memory or temp-file database.
+ */
+
+import type { Database } from "./db.js";
+import { SCHEMA_VERSION } from "./db.js";
+
+/**
+ * Create the minimal schema needed for MemoryStore tests.
+ *
+ * This mirrors the Python DDL from codemem/db.py but only includes
+ * the tables needed for the CRUD methods under test. Sets user_version
+ * to SCHEMA_VERSION so assertSchemaReady() passes.
+ */
+export function initTestSchema(db: Database): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS sessions (
+			id INTEGER PRIMARY KEY,
+			started_at TEXT NOT NULL,
+			ended_at TEXT,
+			cwd TEXT,
+			project TEXT,
+			git_remote TEXT,
+			git_branch TEXT,
+			user TEXT,
+			tool_version TEXT,
+			metadata_json TEXT,
+			import_key TEXT
+		);
+
+		CREATE TABLE IF NOT EXISTS memory_items (
+			id INTEGER PRIMARY KEY,
+			session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+			kind TEXT NOT NULL,
+			title TEXT NOT NULL,
+			subtitle TEXT,
+			body_text TEXT NOT NULL,
+			confidence REAL DEFAULT 0.5,
+			tags_text TEXT DEFAULT '',
+			active INTEGER DEFAULT 1,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			metadata_json TEXT,
+			actor_id TEXT,
+			actor_display_name TEXT,
+			visibility TEXT,
+			workspace_id TEXT,
+			workspace_kind TEXT,
+			origin_device_id TEXT,
+			origin_source TEXT,
+			trust_state TEXT,
+			facts TEXT,
+			narrative TEXT,
+			concepts TEXT,
+			files_read TEXT,
+			files_modified TEXT,
+			user_prompt_id INTEGER,
+			prompt_number INTEGER,
+			deleted_at TEXT,
+			rev INTEGER DEFAULT 0,
+			import_key TEXT
+		);
+
+		CREATE TABLE IF NOT EXISTS artifacts (
+			id INTEGER PRIMARY KEY,
+			session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+			kind TEXT NOT NULL,
+			path TEXT,
+			content_text TEXT,
+			content_hash TEXT,
+			content_encoding TEXT,
+			content_blob BLOB,
+			created_at TEXT NOT NULL,
+			metadata_json TEXT
+		);
+
+		CREATE TABLE IF NOT EXISTS usage_events (
+			id INTEGER PRIMARY KEY,
+			session_id INTEGER REFERENCES sessions(id) ON DELETE SET NULL,
+			event TEXT NOT NULL,
+			tokens_read INTEGER DEFAULT 0,
+			tokens_written INTEGER DEFAULT 0,
+			tokens_saved INTEGER DEFAULT 0,
+			created_at TEXT NOT NULL,
+			metadata_json TEXT
+		);
+
+		CREATE TABLE IF NOT EXISTS raw_events (
+			id INTEGER PRIMARY KEY,
+			source TEXT NOT NULL DEFAULT 'opencode',
+			stream_id TEXT NOT NULL DEFAULT '',
+			opencode_session_id TEXT NOT NULL,
+			event_id TEXT,
+			event_seq INTEGER NOT NULL,
+			event_type TEXT NOT NULL,
+			ts_wall_ms INTEGER,
+			ts_mono_ms REAL,
+			payload_json TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			UNIQUE(source, stream_id, event_seq),
+			UNIQUE(source, stream_id, event_id)
+		);
+
+		PRAGMA user_version = ${SCHEMA_VERSION};
+	`);
+}
+
+/**
+ * Insert a minimal session row and return its ID.
+ * Useful for tests that need a valid session_id for memory_items FK.
+ */
+export function insertTestSession(db: Database): number {
+	const now = new Date().toISOString();
+	const info = db
+		.prepare(
+			`INSERT INTO sessions (started_at, cwd, user, tool_version)
+			 VALUES (?, ?, ?, ?)`,
+		)
+		.run(now, "/tmp/test", "testuser", "test-1.0");
+	return Number(info.lastInsertRowid);
+}


### PR DESCRIPTION
## Description

Ports the core MemoryStore CRUD methods from Python (`codemem/store/_store.py`) to TypeScript. This is the main data access layer for the TS backend.

**New files:**
- `store.ts` — `MemoryStore` class with 8 methods:
  - `get(memoryId)` — fetch by ID, parse metadata_json
  - `remember(sessionId, kind, title, bodyText, ...)` — insert with auto-generated import_key, sorted/deduped tags
  - `forget(memoryId)` — soft-delete (active=0, deleted_at, rev bump)
  - `recent(limit?, filters?, offset?)` — active memories newest-first
  - `recentByKinds(kinds, limit?, ...)` — same with kind IN clause
  - `stats()` — counts for memories, sessions, artifacts, raw_events, vectors, DB size
  - `updateMemoryVisibility(memoryId, visibility)` — validate + update visibility/workspace fields
  - `close()` — close DB connection
- `filters.ts` — `buildFilterClauses()` for composing WHERE fragments (kind, visibility, workspace, actor, trust_state include/exclude filters)
- `test-utils.ts` — `initTestSchema()` + `insertTestSession()` helpers for tests
- `store.test.ts` — 28 tests covering all methods + filter builder

**Not ported (follow-up PRs):** search (FTS5), explain, timeline, pack, usage tracking, vector storage, provenance resolution.

Part of: codemem-egb

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — typecheck + lint + 54 tests)
- [x] Added/updated tests for changes (28 new tests)
- [x] Manually verified changes work as expected
- [x] Python tests unaffected

## Checklist

- [x] Code follows project style (`biome check` passes clean)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced