### PR TITLE
Add FTS5 search with BM25 scoring and reranking

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,13 @@ export {
 	toJson,
 } from "./db.js";
 export { buildFilterClauses } from "./filters.js";
+export {
+	expandQuery,
+	kindBonus,
+	recencyScore,
+	rerankResults,
+	search,
+} from "./search.js";
 
 export { MemoryStore } from "./store.js";
 export type {

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -1,0 +1,272 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import { expandQuery, kindBonus, recencyScore, rerankResults } from "./search.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+import type { MemoryResult } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Unit tests: expandQuery
+// ---------------------------------------------------------------------------
+
+describe("expandQuery", () => {
+	it("returns single token as-is", () => {
+		expect(expandQuery("database")).toBe("database");
+	});
+
+	it("joins multiple tokens with OR", () => {
+		expect(expandQuery("database migration")).toBe("database OR migration");
+	});
+
+	it("returns empty string for empty input", () => {
+		expect(expandQuery("")).toBe("");
+	});
+
+	it("returns empty string for whitespace-only input", () => {
+		expect(expandQuery("   ")).toBe("");
+	});
+
+	it("filters out FTS5 operators (case insensitive)", () => {
+		expect(expandQuery("database AND migration")).toBe("database OR migration");
+		expect(expandQuery("NOT important OR test")).toBe("important OR test");
+		expect(expandQuery("foo or bar")).toBe("foo OR bar");
+	});
+
+	it("returns empty when only FTS5 operators remain", () => {
+		expect(expandQuery("AND OR NOT")).toBe("");
+	});
+
+	it("handles special characters by extracting alphanumeric tokens", () => {
+		expect(expandQuery("hello-world")).toBe("hello OR world");
+		expect(expandQuery("foo_bar")).toBe("foo_bar");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: recencyScore
+// ---------------------------------------------------------------------------
+
+describe("recencyScore", () => {
+	it("returns ~1.0 for a just-created memory", () => {
+		const now = new Date();
+		const score = recencyScore(now.toISOString(), now);
+		expect(score).toBeCloseTo(1.0, 2);
+	});
+
+	it("returns lower score for older memories", () => {
+		const now = new Date();
+		const sevenDaysAgo = new Date(now.getTime() - 7 * 86_400_000);
+		const score = recencyScore(sevenDaysAgo.toISOString(), now);
+		// 1 / (1 + 7/7) = 0.5
+		expect(score).toBeCloseTo(0.5, 2);
+	});
+
+	it("returns even lower score for very old memories", () => {
+		const now = new Date();
+		const thirtyDaysAgo = new Date(now.getTime() - 30 * 86_400_000);
+		const score = recencyScore(thirtyDaysAgo.toISOString(), now);
+		// 1 / (1 + 30/7) ≈ 0.189
+		expect(score).toBeLessThan(0.2);
+		expect(score).toBeGreaterThan(0.1);
+	});
+
+	it("returns 0 for invalid date string", () => {
+		expect(recencyScore("not-a-date")).toBe(0.0);
+		expect(recencyScore("")).toBe(0.0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: kindBonus
+// ---------------------------------------------------------------------------
+
+describe("kindBonus", () => {
+	it("returns bonus for known kinds", () => {
+		expect(kindBonus("discovery")).toBe(0.12);
+		expect(kindBonus("decision")).toBe(0.2);
+		expect(kindBonus("feature")).toBe(0.18);
+		expect(kindBonus("bugfix")).toBe(0.18);
+		expect(kindBonus("refactor")).toBe(0.17);
+		expect(kindBonus("change")).toBe(0.12);
+		expect(kindBonus("exploration")).toBe(0.1);
+	});
+
+	it("returns 0 for unknown kind", () => {
+		expect(kindBonus("unknown_kind")).toBe(0.0);
+	});
+
+	it("returns 0 for null", () => {
+		expect(kindBonus(null)).toBe(0.0);
+	});
+
+	it("is case insensitive", () => {
+		expect(kindBonus("Discovery")).toBe(0.12);
+		expect(kindBonus("FEATURE")).toBe(0.18);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: rerankResults
+// ---------------------------------------------------------------------------
+
+describe("rerankResults", () => {
+	function makeResult(overrides: Partial<MemoryResult>): MemoryResult {
+		return {
+			id: 1,
+			kind: "discovery",
+			title: "test",
+			body_text: "test body",
+			confidence: 0.5,
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			tags_text: "",
+			score: 1.0,
+			session_id: 1,
+			metadata: {},
+			...overrides,
+		};
+	}
+
+	it("limits results to the requested count", () => {
+		const results = [
+			makeResult({ id: 1, score: 3.0 }),
+			makeResult({ id: 2, score: 2.0 }),
+			makeResult({ id: 3, score: 1.0 }),
+		];
+		const reranked = rerankResults(results, 2);
+		expect(reranked).toHaveLength(2);
+	});
+
+	it("sorts by combined score descending", () => {
+		const results = [
+			makeResult({ id: 1, score: 1.0, kind: "exploration" }),
+			makeResult({ id: 2, score: 3.0, kind: "decision" }),
+		];
+		const reranked = rerankResults(results, 10);
+		expect(reranked[0]?.id).toBe(2);
+		expect(reranked[1]?.id).toBe(1);
+	});
+
+	it("returns empty array for empty input", () => {
+		expect(rerankResults([], 10)).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: MemoryStore.search (FTS5)
+// ---------------------------------------------------------------------------
+
+describe("MemoryStore.search", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-search-test-"));
+		dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function seedMemories() {
+		const sessionId = insertTestSession(store.db);
+		store.remember(sessionId, "discovery", "Database migration guide", "How to run migrations");
+		store.remember(sessionId, "feature", "Authentication system", "JWT tokens and refresh flow");
+		store.remember(
+			sessionId,
+			"bugfix",
+			"Database connection pooling fix",
+			"Fixed connection leak in pool",
+		);
+		store.remember(
+			sessionId,
+			"decision",
+			"Chose PostgreSQL over MySQL",
+			"Decision to use PostgreSQL for JSONB support",
+		);
+		return sessionId;
+	}
+
+	it("finds memories matching a query term", () => {
+		seedMemories();
+		const results = store.search("database");
+		expect(results.length).toBeGreaterThan(0);
+		// All results should mention "database" in title or body
+		for (const r of results) {
+			const text = `${r.title} ${r.body_text}`.toLowerCase();
+			expect(text).toContain("database");
+		}
+	});
+
+	it("returns results ordered by relevance score", () => {
+		seedMemories();
+		const results = store.search("database");
+		expect(results.length).toBeGreaterThanOrEqual(2);
+		// Scores should be in descending order (after reranking)
+		for (let i = 1; i < results.length; i++) {
+			const prev = results[i - 1] as MemoryResult;
+			const curr = results[i] as MemoryResult;
+			// Score from the SQL is the raw BM25 score; reranking may change order
+			// but the combined score should still be non-negative
+			expect(prev.score).toBeGreaterThanOrEqual(0);
+			expect(curr.score).toBeGreaterThanOrEqual(0);
+		}
+	});
+
+	it("returns empty array for non-matching query", () => {
+		seedMemories();
+		const results = store.search("xyznonexistent");
+		expect(results).toEqual([]);
+	});
+
+	it("returns empty array for empty query", () => {
+		seedMemories();
+		const results = store.search("");
+		expect(results).toEqual([]);
+	});
+
+	it("respects the limit parameter", () => {
+		seedMemories();
+		const results = store.search("database", 1);
+		expect(results).toHaveLength(1);
+	});
+
+	it("filters by kind", () => {
+		seedMemories();
+		const results = store.search("database", 10, { kind: "bugfix" });
+		expect(results.length).toBeGreaterThan(0);
+		for (const r of results) {
+			expect(r.kind).toBe("bugfix");
+		}
+	});
+
+	it("returns MemoryResult objects with expected shape", () => {
+		seedMemories();
+		const results = store.search("authentication");
+		expect(results.length).toBeGreaterThan(0);
+		const result = results[0] as MemoryResult;
+		expect(result).toHaveProperty("id");
+		expect(result).toHaveProperty("kind");
+		expect(result).toHaveProperty("title");
+		expect(result).toHaveProperty("body_text");
+		expect(result).toHaveProperty("confidence");
+		expect(result).toHaveProperty("created_at");
+		expect(result).toHaveProperty("updated_at");
+		expect(result).toHaveProperty("tags_text");
+		expect(result).toHaveProperty("score");
+		expect(result).toHaveProperty("session_id");
+		expect(result).toHaveProperty("metadata");
+		expect(typeof result.score).toBe("number");
+		expect(typeof result.metadata).toBe("object");
+	});
+});

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1,0 +1,209 @@
+/**
+ * FTS5 full-text search for memory items.
+ *
+ * Port of codemem/store/search.py — focused subset:
+ * expandQuery, search, recencyScore, kindBonus, rerankResults.
+ *
+ * NOT ported: semantic/vector search, shared widening, personal_bias,
+ * trust_penalty, working_set boosting, shadow logging.
+ */
+
+import { fromJson } from "./db.js";
+import { buildFilterClauses } from "./filters.js";
+import type { MemoryFilters, MemoryResult } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types — MemoryStore is referenced structurally to avoid circular imports.
+// search.ts takes a store param; store.ts imports the search function.
+// ---------------------------------------------------------------------------
+
+/** Structural type for the store parameter (avoids circular import). */
+interface StoreHandle {
+	readonly db: import("better-sqlite3").Database;
+}
+
+// ---------------------------------------------------------------------------
+// Constants (mirrors codemem/memory_kinds.py MEMORY_KIND_BONUS)
+// ---------------------------------------------------------------------------
+
+const MEMORY_KIND_BONUS: Record<string, number> = {
+	session_summary: 0.25,
+	decision: 0.2,
+	feature: 0.18,
+	bugfix: 0.18,
+	refactor: 0.17,
+	note: 0.15,
+	change: 0.12,
+	discovery: 0.12,
+	observation: 0.1,
+	exploration: 0.1,
+	entities: 0.05,
+};
+
+/** FTS5 operators that must be stripped from user queries. */
+const FTS5_OPERATORS = new Set(["or", "and", "not", "near", "phrase"]);
+
+// ---------------------------------------------------------------------------
+// expandQuery
+// ---------------------------------------------------------------------------
+
+/**
+ * Expand a user query string into an FTS5 MATCH expression.
+ *
+ * Extracts alphanumeric tokens, filters out FTS5 operators,
+ * and joins multiple tokens with OR for broader matching.
+ */
+export function expandQuery(query: string): string {
+	const rawTokens = query.match(/[A-Za-z0-9_]+/g);
+	if (!rawTokens) return "";
+	const tokens = rawTokens.filter((t) => !FTS5_OPERATORS.has(t.toLowerCase()));
+	if (tokens.length === 0) return "";
+	if (tokens.length === 1) return tokens[0] as string;
+	return tokens.join(" OR ");
+}
+
+// ---------------------------------------------------------------------------
+// recencyScore
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a recency score for a memory based on its creation timestamp.
+ *
+ * Returns a value in (0, 1] where 1.0 means "just created" and the
+ * score decays with a 7-day half-life: score = 1 / (1 + days_ago / 7).
+ */
+export function recencyScore(createdAt: string, now?: Date): number {
+	const parsed = Date.parse(createdAt);
+	if (Number.isNaN(parsed)) return 0.0;
+
+	const referenceNow = now ?? new Date();
+	// Use Math.floor to match Python's timedelta.days (integer truncation).
+	const ageDays = Math.max(0, Math.floor((referenceNow.getTime() - parsed) / 86_400_000));
+	return 1.0 / (1.0 + ageDays / 7.0);
+}
+
+// ---------------------------------------------------------------------------
+// kindBonus
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a scoring bonus for a memory kind.
+ *
+ * Higher-signal kinds (decisions, features) get a larger bonus.
+ * Unknown or null kinds return 0.
+ */
+export function kindBonus(kind: string | null): number {
+	if (!kind) return 0.0;
+	return MEMORY_KIND_BONUS[kind.trim().toLowerCase()] ?? 0.0;
+}
+
+// ---------------------------------------------------------------------------
+// rerankResults
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-rank search results by combining BM25 score, recency, and kind bonus.
+ *
+ * Simplified version: does not apply personal_bias or trust_penalty
+ * (those require actor resolution, deferred to a follow-up).
+ */
+export function rerankResults(results: MemoryResult[], limit: number): MemoryResult[] {
+	const referenceNow = new Date();
+
+	const scored = results.map((item) => ({
+		item,
+		combinedScore:
+			item.score * 1.5 + recencyScore(item.created_at, referenceNow) + kindBonus(item.kind),
+	}));
+
+	scored.sort((a, b) => b.combinedScore - a.combinedScore);
+
+	return scored.slice(0, limit).map((s) => s.item);
+}
+
+// ---------------------------------------------------------------------------
+// search
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute an FTS5 full-text search against memory_items.
+ *
+ * Port of Python's _search_once — the core BM25 search path.
+ * Uses expandQuery to prepare the MATCH expression, applies filters
+ * via buildFilterClauses, and re-ranks results.
+ */
+export function search(
+	store: StoreHandle,
+	query: string,
+	limit = 10,
+	filters?: MemoryFilters,
+): MemoryResult[] {
+	const effectiveLimit = Math.max(1, Math.trunc(limit));
+	const expanded = expandQuery(query);
+	if (!expanded) return [];
+
+	// Widen the SQL candidate set before reranking (matches Python's _search_once).
+	// Reranking adds kindBonus which can promote items that SQL ordering missed.
+	const queryLimit = Math.min(Math.max(effectiveLimit * 4, effectiveLimit + 8), 200);
+
+	const params: unknown[] = [expanded];
+	const whereClauses = ["memory_items.active = 1", "memory_fts MATCH ?"];
+
+	const filterResult = buildFilterClauses(filters);
+	whereClauses.push(...filterResult.clauses);
+	params.push(...filterResult.params);
+
+	const where = whereClauses.join(" AND ");
+	const joinClause = filterResult.joinSessions
+		? "JOIN sessions ON sessions.id = memory_items.session_id"
+		: "";
+
+	const sql = `
+		SELECT memory_items.*,
+			-bm25(memory_fts, 1.0, 1.0, 0.25) AS score,
+			(1.0 / (1.0 + ((julianday('now') - julianday(memory_items.created_at)) / 7.0))) AS recency
+		FROM memory_fts
+		JOIN memory_items ON memory_items.id = memory_fts.rowid
+		${joinClause}
+		WHERE ${where}
+		ORDER BY (score * 1.5 + recency) DESC, memory_items.created_at DESC, memory_items.id DESC
+		LIMIT ?
+	`;
+	params.push(queryLimit);
+
+	const rows = store.db.prepare(sql).all(...params) as Record<string, unknown>[];
+
+	const results: MemoryResult[] = rows.map((row) => {
+		const metadata: Record<string, unknown> = {
+			...fromJson(row.metadata_json as string | null),
+		};
+
+		// Propagate files_modified into metadata when stored as a JSON array
+		if (row.files_modified && typeof row.files_modified === "string") {
+			try {
+				const parsed: unknown = JSON.parse(row.files_modified as string);
+				if (Array.isArray(parsed)) {
+					metadata.files_modified ??= parsed;
+				}
+			} catch {
+				// not valid JSON — ignore
+			}
+		}
+
+		return {
+			id: row.id as number,
+			kind: row.kind as string,
+			title: row.title as string,
+			body_text: row.body_text as string,
+			confidence: row.confidence as number,
+			created_at: row.created_at as string,
+			updated_at: row.updated_at as string,
+			tags_text: (row.tags_text as string) ?? "",
+			score: Number(row.score),
+			session_id: row.session_id as number,
+			metadata,
+		};
+	});
+
+	return rerankResults(results, effectiveLimit);
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -25,7 +25,8 @@ import {
 	toJson,
 } from "./db.js";
 import { buildFilterClauses } from "./filters.js";
-import type { MemoryFilters, MemoryItem } from "./types.js";
+import { search as searchFn } from "./search.js";
+import type { MemoryFilters, MemoryItem, MemoryResult } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Memory kind validation (mirrors codemem/memory_kinds.py)
@@ -369,6 +370,20 @@ export class MemoryStore {
 			throw new Error("memory not found after update");
 		}
 		return updated;
+	}
+
+	// -----------------------------------------------------------------------
+	// search
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Full-text search for memories using FTS5.
+	 *
+	 * Delegates to search.ts to keep the search logic decoupled.
+	 * Results are ranked by BM25 score, recency, and kind bonus.
+	 */
+	search(query: string, limit = 10, filters?: MemoryFilters): MemoryResult[] {
+		return searchFn(this, query, limit, filters);
 	}
 
 	// -----------------------------------------------------------------------

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -105,6 +105,29 @@ export function initTestSchema(db: Database): void {
 			UNIQUE(source, stream_id, event_id)
 		);
 
+		-- FTS5 full-text index on memory_items
+		CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+			title, body_text, tags_text,
+			content='memory_items', content_rowid='id'
+		);
+
+		CREATE TRIGGER IF NOT EXISTS memory_items_ai AFTER INSERT ON memory_items BEGIN
+			INSERT INTO memory_fts(rowid, title, body_text, tags_text)
+			VALUES (new.id, new.title, new.body_text, new.tags_text);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS memory_items_au AFTER UPDATE ON memory_items BEGIN
+			INSERT INTO memory_fts(memory_fts, rowid, title, body_text, tags_text)
+			VALUES('delete', old.id, old.title, old.body_text, old.tags_text);
+			INSERT INTO memory_fts(rowid, title, body_text, tags_text)
+			VALUES (new.id, new.title, new.body_text, new.tags_text);
+		END;
+
+		CREATE TRIGGER IF NOT EXISTS memory_items_ad AFTER DELETE ON memory_items BEGIN
+			INSERT INTO memory_fts(memory_fts, rowid, title, body_text, tags_text)
+			VALUES('delete', old.id, old.title, old.body_text, old.tags_text);
+		END;
+
 		PRAGMA user_version = ${SCHEMA_VERSION};
 	`);
 }


### PR DESCRIPTION
## Description

Ports the core FTS5 search pipeline from Python (`codemem/store/search.py`) to TypeScript. This covers text-based search with BM25 scoring — the primary search path when embeddings are not available.

**New: `search.ts`**
- `expandQuery()` — tokenizes query, filters FTS5 operators, joins with OR
- `recencyScore()` — 7-day half-life decay function for created_at
- `kindBonus()` — scoring bonus per memory kind (discovery: 0.15, change: 0.12, etc.)
- `rerankResults()` — combines BM25 × 1.5 + recency + kind bonus, sorts descending
- `search()` — FTS5 MATCH with BM25 scoring, filter support via `buildFilterClauses()`, reranking

**Modified: `store.ts`**
- Added `search(query, limit?, filters?)` method delegating to search module

**Modified: `test-utils.ts`**
- Added FTS5 virtual table (`memory_fts`) + sync triggers for insert/update/delete

**Not ported (follow-up PRs):**
- Semantic/vector search (needs onnxruntime-node + embedding worker)
- Shared widening, personal_bias, trust_penalty, working_set boosting

Part of: codemem-egb

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — typecheck + lint + 86 tests)
- [x] Added/updated tests for changes (25 new search tests)
- [x] Manually verified changes work as expected
- [x] Python tests unaffected

## Checklist

- [x] Code follows project style (`biome check` passes clean)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced