### PR TITLE
Add timeline and explain methods

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,12 +21,15 @@ export {
 	toJson,
 } from "./db.js";
 export { buildFilterClauses } from "./filters.js";
+export type { StoreHandle } from "./search.js";
 export {
 	expandQuery,
+	explain,
 	kindBonus,
 	recencyScore,
 	rerankResults,
 	search,
+	timeline,
 } from "./search.js";
 
 export { MemoryStore } from "./store.js";

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -270,3 +270,261 @@ describe("MemoryStore.search", () => {
 		expect(typeof result.metadata).toBe("object");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Integration tests: MemoryStore.timeline
+// ---------------------------------------------------------------------------
+
+describe("MemoryStore.timeline", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-timeline-test-"));
+		dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	/** Seed memories with controlled timestamps so ordering is deterministic. */
+	function seedTimeline() {
+		const sessionId = insertTestSession(store.db);
+		const baseTime = new Date("2025-01-01T00:00:00Z").getTime();
+		const ids: number[] = [];
+
+		// Insert 7 memories with 1-hour spacing in the same session
+		const titles = [
+			"First setup",
+			"Added models",
+			"Database schema",
+			"API endpoints",
+			"Authentication",
+			"Testing suite",
+			"Deployment config",
+		];
+		for (let i = 0; i < titles.length; i++) {
+			const ts = new Date(baseTime + i * 3_600_000).toISOString();
+			// Insert directly to control timestamps; FTS trigger auto-populates memory_fts
+			const info = store.db
+				.prepare(
+					`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+					 tags_text, active, created_at, updated_at, metadata_json, rev)
+					 VALUES (?, 'feature', ?, 'body text', 0.5, '', 1, ?, ?, '{}', 1)`,
+				)
+				.run(sessionId, titles[i], ts, ts);
+			ids.push(Number(info.lastInsertRowid));
+		}
+		return { sessionId, ids };
+	}
+
+	it("finds anchor by query and returns neighbors", () => {
+		seedTimeline();
+		const results = store.timeline("Database");
+		expect(results.length).toBeGreaterThan(0);
+		// Should find "Database schema" as anchor and include neighbors
+		const titles = results.map((r) => r.title);
+		expect(titles).toContain("Database schema");
+	});
+
+	it("finds anchor by memoryId", () => {
+		const { ids } = seedTimeline();
+		// Use the 4th memory (API endpoints) as anchor
+		const anchorId = ids[3] as number;
+		const results = store.timeline(null, anchorId, 2, 2);
+		expect(results.length).toBeGreaterThan(0);
+		// Should contain the anchor
+		const resultIds = results.map((r) => r.id);
+		expect(resultIds).toContain(anchorId);
+		// With depth 2 before + anchor + depth 2 after = up to 5
+		expect(results.length).toBeLessThanOrEqual(5);
+	});
+
+	it("returns empty for no match", () => {
+		seedTimeline();
+		const results = store.timeline("xyznonexistent");
+		expect(results).toEqual([]);
+	});
+
+	it("stays within same session", () => {
+		const { ids } = seedTimeline();
+		// Create a memory in a different session
+		const session2 = insertTestSession(store.db);
+		store.remember(session2, "feature", "Unrelated item", "Different session entirely");
+
+		// Use memoryId to anchor on a known session
+		const anchorId = ids[3] as number;
+		const results = store.timeline(null, anchorId, 3, 3);
+		expect(results.length).toBeGreaterThan(1);
+		// All results should share the same session_id
+		const sessionIds = new Set(results.map((r) => r.session_id));
+		expect(sessionIds.size).toBe(1);
+	});
+
+	it("parses metadata_json on each result", () => {
+		seedTimeline();
+		const results = store.timeline("Database");
+		expect(results.length).toBeGreaterThan(0);
+		for (const r of results) {
+			// metadata_json should be parsed into an object, not a raw string
+			expect(typeof r.metadata_json).toBe("object");
+		}
+	});
+
+	it("returns empty when memoryId does not exist", () => {
+		seedTimeline();
+		const results = store.timeline(null, 99999);
+		expect(results).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: MemoryStore.explain
+// ---------------------------------------------------------------------------
+
+describe("MemoryStore.explain", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-explain-test-"));
+		dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function seedMemories() {
+		const sessionId = insertTestSession(store.db);
+		const id1 = store.remember(
+			sessionId,
+			"discovery",
+			"Database migration guide",
+			"How to run migrations",
+		);
+		const id2 = store.remember(
+			sessionId,
+			"feature",
+			"Authentication system",
+			"JWT tokens and refresh flow",
+		);
+		const id3 = store.remember(
+			sessionId,
+			"bugfix",
+			"Database connection fix",
+			"Fixed connection leak",
+		);
+		return { sessionId, id1, id2, id3 };
+	}
+
+	it("returns scored items for query", () => {
+		seedMemories();
+		const result = store.explain("database") as Record<string, unknown>;
+		const items = result.items as Record<string, unknown>[];
+		expect(items.length).toBeGreaterThan(0);
+		expect(result.errors).toEqual([]);
+
+		// Each item should have the explain payload shape
+		for (const item of items) {
+			expect(item).toHaveProperty("id");
+			expect(item).toHaveProperty("kind");
+			expect(item).toHaveProperty("title");
+			expect(item).toHaveProperty("retrieval");
+			expect(item).toHaveProperty("score");
+
+			const retrieval = item.retrieval as Record<string, unknown>;
+			expect(retrieval.source).toBe("query");
+			expect(typeof retrieval.rank).toBe("number");
+
+			const score = item.score as Record<string, unknown>;
+			expect(typeof score.total).toBe("number");
+			expect(score.total as number).toBeGreaterThanOrEqual(0);
+
+			const components = score.components as Record<string, unknown>;
+			expect(typeof components.base).toBe("number");
+			expect(typeof components.recency).toBe("number");
+			expect(typeof components.kind_bonus).toBe("number");
+		}
+	});
+
+	it("returns items by id lookup", () => {
+		const { id1, id2 } = seedMemories();
+		const result = store.explain(null, [id1, id2]) as Record<string, unknown>;
+		const items = result.items as Record<string, unknown>[];
+		expect(items).toHaveLength(2);
+
+		for (const item of items) {
+			const retrieval = item.retrieval as Record<string, unknown>;
+			expect(retrieval.source).toBe("id_lookup");
+			expect(retrieval.rank).toBeNull();
+
+			// id_lookup items have null base score and null total
+			const score = item.score as Record<string, unknown>;
+			expect(score.total).toBeNull();
+			expect((score.components as Record<string, unknown>).base).toBeNull();
+		}
+	});
+
+	it("merges query and id results", () => {
+		const { id1, id2 } = seedMemories();
+		// id1 is "Database migration guide" — should match the query
+		// id2 is "Authentication system" — should only appear via id_lookup
+		const result = store.explain("database", [id1, id2]) as Record<string, unknown>;
+		const items = result.items as Record<string, unknown>[];
+		expect(items.length).toBeGreaterThanOrEqual(2);
+
+		const sources = items.map((i) => (i.retrieval as Record<string, unknown>).source);
+		// id1 should appear as query+id_lookup (found by both query and id)
+		expect(sources).toContain("query+id_lookup");
+		// id2 should appear as id_lookup (not matched by "database" query)
+		expect(sources).toContain("id_lookup");
+
+		// No duplicates
+		const ids = items.map((i) => i.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it("reports missing ids", () => {
+		seedMemories();
+		const result = store.explain(null, [99999, 88888]) as Record<string, unknown>;
+		const missingIds = result.missing_ids as number[];
+		expect(missingIds).toContain(99999);
+		expect(missingIds).toContain(88888);
+
+		const errors = result.errors as Record<string, unknown>[];
+		const notFoundError = errors.find((e) => e.code === "NOT_FOUND");
+		expect(notFoundError).toBeDefined();
+	});
+
+	it("returns error when neither query nor ids provided", () => {
+		seedMemories();
+		const result = store.explain() as Record<string, unknown>;
+		expect(result.items).toEqual([]);
+		const errors = result.errors as Record<string, unknown>[];
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toHaveProperty("code", "INVALID_ARGUMENT");
+	});
+
+	it("returns expected metadata shape", () => {
+		seedMemories();
+		const result = store.explain("database") as Record<string, unknown>;
+		const metadata = result.metadata as Record<string, unknown>;
+		expect(metadata).toHaveProperty("query", "database");
+		expect(metadata).toHaveProperty("requested_ids_count", 0);
+		expect(typeof metadata.returned_items_count).toBe("number");
+	});
+});

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -2,10 +2,11 @@
  * FTS5 full-text search for memory items.
  *
  * Port of codemem/store/search.py — focused subset:
- * expandQuery, search, recencyScore, kindBonus, rerankResults.
+ * expandQuery, search, recencyScore, kindBonus, rerankResults,
+ * timeline, explain.
  *
  * NOT ported: semantic/vector search, shared widening, personal_bias,
- * trust_penalty, working_set boosting, shadow logging.
+ * trust_penalty, working_set boosting, shadow logging, pack context.
  */
 
 import { fromJson } from "./db.js";
@@ -18,8 +19,9 @@ import type { MemoryFilters, MemoryResult } from "./types.js";
 // ---------------------------------------------------------------------------
 
 /** Structural type for the store parameter (avoids circular import). */
-interface StoreHandle {
+export interface StoreHandle {
 	readonly db: import("better-sqlite3").Database;
+	get(memoryId: number): Record<string, unknown> | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -206,4 +208,417 @@ export function search(
 	});
 
 	return rerankResults(results, effectiveLimit);
+}
+
+// ---------------------------------------------------------------------------
+// timeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a chronological window of memories around an anchor.
+ *
+ * Port of Python's timeline() + _timeline_around() from search.py.
+ * Finds an anchor by memoryId or query, then fetches neighbors in the
+ * same session ordered by created_at.
+ *
+ * NOT ported: usage tracking (record_usage), _attach_prompt_links.
+ */
+export function timeline(
+	store: StoreHandle,
+	query?: string | null,
+	memoryId?: number | null,
+	depthBefore = 3,
+	depthAfter = 3,
+	filters?: MemoryFilters | null,
+): Record<string, unknown>[] {
+	// Find anchor: prefer explicit memoryId, fall back to search
+	let anchor: Record<string, unknown> | null = null;
+	if (memoryId != null) {
+		anchor = store.get(memoryId);
+	}
+	if (anchor == null && query) {
+		const matches = search(store, query, 1, filters ?? undefined);
+		if (matches.length > 0) {
+			// Convert MemoryResult to dict-like shape for consistency
+			const m = matches[0] as MemoryResult;
+			anchor = {
+				id: m.id,
+				session_id: m.session_id,
+				created_at: m.created_at,
+			};
+		}
+	}
+	if (anchor == null) {
+		return [];
+	}
+
+	return timelineAround(store, anchor, depthBefore, depthAfter, filters);
+}
+
+/**
+ * Internal: fetch memories before/after an anchor within the same session.
+ *
+ * Port of Python's _timeline_around().
+ */
+function timelineAround(
+	store: StoreHandle,
+	anchor: Record<string, unknown>,
+	depthBefore: number,
+	depthAfter: number,
+	filters?: MemoryFilters | null,
+): Record<string, unknown>[] {
+	const anchorId = anchor.id as number | undefined;
+	const anchorCreatedAt = anchor.created_at as string | undefined;
+	const anchorSessionId = anchor.session_id as number | undefined;
+
+	if (!anchorId || !anchorCreatedAt) {
+		return [];
+	}
+
+	const filterResult = buildFilterClauses(filters);
+	const whereParts = ["memory_items.active = 1", ...filterResult.clauses];
+	const baseParams = [...filterResult.params];
+
+	if (anchorSessionId) {
+		whereParts.push("memory_items.session_id = ?");
+		baseParams.push(anchorSessionId);
+	}
+
+	const whereClause = whereParts.join(" AND ");
+	const joinClause = filterResult.joinSessions
+		? "JOIN sessions ON sessions.id = memory_items.session_id"
+		: "";
+
+	// Before: older memories, descending (we'll reverse later)
+	const beforeRows = store.db
+		.prepare(
+			`SELECT memory_items.*
+			 FROM memory_items
+			 ${joinClause}
+			 WHERE ${whereClause} AND memory_items.created_at < ?
+			 ORDER BY memory_items.created_at DESC
+			 LIMIT ?`,
+		)
+		.all(...baseParams, anchorCreatedAt, depthBefore) as Record<string, unknown>[];
+
+	// After: newer memories, ascending
+	const afterRows = store.db
+		.prepare(
+			`SELECT memory_items.*
+			 FROM memory_items
+			 ${joinClause}
+			 WHERE ${whereClause} AND memory_items.created_at > ?
+			 ORDER BY memory_items.created_at ASC
+			 LIMIT ?`,
+		)
+		.all(...baseParams, anchorCreatedAt, depthAfter) as Record<string, unknown>[];
+
+	// Re-fetch anchor row to get full columns (anchor from search may be partial)
+	const anchorRow = store.db
+		.prepare("SELECT * FROM memory_items WHERE id = ? AND active = 1")
+		.get(anchorId) as Record<string, unknown> | undefined;
+
+	// Combine: reversed(before) + anchor + after
+	const rows: Record<string, unknown>[] = [...beforeRows.reverse()];
+	if (anchorRow) {
+		rows.push(anchorRow);
+	}
+	rows.push(...afterRows);
+
+	// Parse metadata_json and add linked_prompt stub on each row.
+	// linked_prompt is set by Python's _attach_prompt_links — not yet ported,
+	// but the field must exist for MCP response shape stability.
+	return rows.map((row) => ({
+		...row,
+		metadata_json: fromJson(row.metadata_json as string | null),
+		linked_prompt: null,
+	}));
+}
+
+// ---------------------------------------------------------------------------
+// explain
+// ---------------------------------------------------------------------------
+
+/**
+ * Deduplicate an array of IDs, preserving order. Returns valid int IDs
+ * and a list of values that could not be parsed as integers.
+ */
+function dedupeOrderedIds(ids: unknown[]): { ordered: number[]; invalid: string[] } {
+	const seen = new Set<number>();
+	const ordered: number[] = [];
+	const invalid: string[] = [];
+
+	for (const rawId of ids) {
+		// Reject booleans and floats explicitly (matches Python behavior)
+		if (typeof rawId === "boolean" || (typeof rawId === "number" && !Number.isInteger(rawId))) {
+			invalid.push(String(rawId));
+			continue;
+		}
+		const parsed = Number(rawId);
+		if (!Number.isInteger(parsed) || parsed <= 0) {
+			invalid.push(String(rawId));
+			continue;
+		}
+		if (seen.has(parsed)) continue;
+		seen.add(parsed);
+		ordered.push(parsed);
+	}
+
+	return { ordered, invalid };
+}
+
+/**
+ * Build an explain payload for a single memory item.
+ *
+ * Port of Python's _explain_item() — simplified: no personal_bias,
+ * no project matching, no pack context, no semantic_boost.
+ */
+function explainItem(
+	item: MemoryResult,
+	source: string,
+	rank: number | null,
+	queryTokens: string[],
+	referenceNow: Date,
+): Record<string, unknown> {
+	const text = `${item.title} ${item.body_text} ${item.tags_text}`.toLowerCase();
+	const matchedTerms = queryTokens.filter((token) => text.includes(token));
+
+	const baseScore: number | null =
+		source === "query" || source === "query+id_lookup" ? item.score : null;
+	const recencyComponent = recencyScore(item.created_at, referenceNow);
+	const kindComponent = kindBonus(item.kind);
+
+	let totalScore: number | null = null;
+	if (baseScore != null) {
+		totalScore = baseScore * 1.5 + recencyComponent + kindComponent;
+	}
+
+	return {
+		id: item.id,
+		kind: item.kind,
+		title: item.title,
+		created_at: item.created_at,
+		project: null, // TODO: port project lookup via session
+		retrieval: {
+			source,
+			rank,
+		},
+		score: {
+			total: totalScore,
+			components: {
+				base: baseScore,
+				recency: recencyComponent,
+				kind_bonus: kindComponent,
+				personal_bias: 0.0,
+				semantic_boost: null,
+			},
+		},
+		matches: {
+			query_terms: matchedTerms,
+			project_match: null, // TODO: port _project_matches_filter
+		},
+		pack_context: null, // TODO: port include_pack_context
+	};
+}
+
+/**
+ * Check whether a row matches the given filters (client-side enforcement).
+ * Used for ID-based lookups in explain() to enforce the same scope as query results.
+ */
+function rowMatchesFilters(row: Record<string, unknown>, filters: MemoryFilters): boolean {
+	if (filters.kind && row.kind !== filters.kind) return false;
+	if (filters.include_visibility?.length) {
+		if (!filters.include_visibility.includes(row.visibility as string)) return false;
+	}
+	if (filters.exclude_visibility?.length) {
+		if (row.visibility != null && filters.exclude_visibility.includes(row.visibility as string))
+			return false;
+	}
+	if (filters.include_actor_ids?.length) {
+		if (!filters.include_actor_ids.includes(row.actor_id as string)) return false;
+	}
+	if (filters.exclude_actor_ids?.length) {
+		if (row.actor_id != null && filters.exclude_actor_ids.includes(row.actor_id as string))
+			return false;
+	}
+	if (filters.include_workspace_kinds?.length) {
+		if (!filters.include_workspace_kinds.includes(row.workspace_kind as string)) return false;
+	}
+	if (filters.exclude_workspace_kinds?.length) {
+		if (
+			row.workspace_kind != null &&
+			filters.exclude_workspace_kinds.includes(row.workspace_kind as string)
+		)
+			return false;
+	}
+	if (filters.include_trust_states?.length) {
+		if (!filters.include_trust_states.includes(row.trust_state as string)) return false;
+	}
+	if (filters.exclude_trust_states?.length) {
+		if (row.trust_state != null && filters.exclude_trust_states.includes(row.trust_state as string))
+			return false;
+	}
+	return true;
+}
+
+/**
+ * Explain search results with scoring breakdown.
+ *
+ * Port of Python's explain() from search.py. Accepts a query and/or
+ * explicit IDs, merges results, and returns a detailed scoring payload
+ * for each item.
+ *
+ * NOT ported: usage tracking, project mismatch checks, pack context,
+ * _attach_prompt_links, personal_bias, semantic_boost.
+ */
+export function explain(
+	store: StoreHandle,
+	query?: string | null,
+	ids?: unknown[] | null,
+	limit = 10,
+	filters?: MemoryFilters | null,
+): Record<string, unknown> {
+	const normalizedQuery = (query ?? "").trim();
+	const { ordered: orderedIds, invalid: invalidIds } = dedupeOrderedIds(ids ?? []);
+
+	const errors: Record<string, unknown>[] = [];
+	if (invalidIds.length > 0) {
+		errors.push({
+			code: "INVALID_ARGUMENT",
+			field: "ids",
+			message: "some ids are not valid integers",
+			ids: invalidIds,
+		});
+	}
+
+	// Require at least one of query or ids
+	if (!normalizedQuery && orderedIds.length === 0) {
+		errors.push({
+			code: "INVALID_ARGUMENT",
+			field: "query",
+			message: "at least one of query or ids is required",
+		});
+		return {
+			items: [],
+			missing_ids: [],
+			errors,
+			metadata: {
+				query: null,
+				requested_ids_count: orderedIds.length,
+				returned_items_count: 0,
+			},
+		};
+	}
+
+	// Query-based results
+	let queryResults: MemoryResult[] = [];
+	if (normalizedQuery) {
+		queryResults = search(
+			store,
+			normalizedQuery,
+			Math.max(1, Math.trunc(limit)),
+			filters ?? undefined,
+		);
+	}
+
+	// Build rank map for query results
+	const queryRank = new Map<number, number>();
+	for (let i = 0; i < queryResults.length; i++) {
+		queryRank.set((queryResults[i] as MemoryResult).id, i + 1);
+	}
+
+	// Load items by explicit IDs, enforcing the same filters as query-based results.
+	const idLookup = new Map<number, MemoryResult>();
+	const missingNotFound: number[] = [];
+	const missingFilterMismatch: number[] = [];
+	for (const memId of orderedIds) {
+		const row = store.get(memId);
+		if (!row || (row.active as number) === 0) {
+			missingNotFound.push(memId);
+			continue;
+		}
+		// Check that the row passes the same filters applied to query results.
+		if (filters && !rowMatchesFilters(row, filters)) {
+			missingFilterMismatch.push(memId);
+			continue;
+		}
+		idLookup.set(memId, {
+			id: row.id as number,
+			kind: row.kind as string,
+			title: row.title as string,
+			body_text: row.body_text as string,
+			confidence: (row.confidence as number) ?? 0,
+			created_at: row.created_at as string,
+			updated_at: row.updated_at as string,
+			tags_text: (row.tags_text as string) ?? "",
+			score: 0,
+			session_id: row.session_id as number,
+			metadata:
+				typeof row.metadata_json === "object" && row.metadata_json != null
+					? (row.metadata_json as Record<string, unknown>)
+					: fromJson(row.metadata_json as string | null),
+		});
+	}
+
+	// Merge: query results first, then id-lookup results not already seen
+	const explicitIdSet = new Set(orderedIds);
+	const selectedIds = new Set<number>();
+	const orderedItems: Array<{ item: MemoryResult; source: string; rank: number | null }> = [];
+
+	for (const item of queryResults) {
+		selectedIds.add(item.id);
+		const source = explicitIdSet.has(item.id) ? "query+id_lookup" : "query";
+		orderedItems.push({ item, source, rank: queryRank.get(item.id) ?? null });
+	}
+
+	for (const memId of orderedIds) {
+		if (selectedIds.has(memId)) continue;
+		const item = idLookup.get(memId);
+		if (!item) continue;
+		orderedItems.push({ item, source: "id_lookup", rank: null });
+		selectedIds.add(memId);
+	}
+
+	// Tokenize query for term matching
+	const queryTokens = normalizedQuery
+		? (normalizedQuery.match(/[A-Za-z0-9_]+/g) ?? []).map((t) => t.toLowerCase())
+		: [];
+
+	const referenceNow = new Date();
+	const itemsPayload = orderedItems.map(({ item, source, rank }) =>
+		explainItem(item, source, rank, queryTokens, referenceNow),
+	);
+
+	// Collect all missing IDs (requested but not returned)
+	const missingIds = orderedIds.filter((id) => !selectedIds.has(id));
+
+	if (missingNotFound.length > 0) {
+		errors.push({
+			code: "NOT_FOUND",
+			field: "ids",
+			message: "some requested ids were not found",
+			ids: missingNotFound,
+		});
+	}
+	if (missingFilterMismatch.length > 0) {
+		errors.push({
+			code: "FILTER_MISMATCH",
+			field: "filters",
+			message: "some requested ids do not match the provided filters",
+			ids: missingFilterMismatch,
+		});
+	}
+
+	return {
+		items: itemsPayload,
+		missing_ids: missingIds,
+		errors,
+		metadata: {
+			query: normalizedQuery || null,
+			project: null, // TODO: port project filter
+			requested_ids_count: orderedIds.length,
+			returned_items_count: itemsPayload.length,
+			include_pack_context: false,
+		},
+	};
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -8,8 +8,8 @@
  * Methods ported: get, remember, forget, recent, recentByKinds, stats,
  * updateMemoryVisibility, close.
  *
- * NOT ported yet: search, timeline, explain, pack, usage tracking, vectors,
- * provenance resolution, memory_owned_by_self check.
+ * NOT ported yet: pack, usage tracking, vectors, provenance resolution,
+ * memory_owned_by_self check.
  */
 
 import { randomUUID } from "node:crypto";
@@ -25,7 +25,7 @@ import {
 	toJson,
 } from "./db.js";
 import { buildFilterClauses } from "./filters.js";
-import { search as searchFn } from "./search.js";
+import { explain as explainFn, search as searchFn, timeline as timelineFn } from "./search.js";
 import type { MemoryFilters, MemoryItem, MemoryResult } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -384,6 +384,45 @@ export class MemoryStore {
 	 */
 	search(query: string, limit = 10, filters?: MemoryFilters): MemoryResult[] {
 		return searchFn(this, query, limit, filters);
+	}
+
+	// -----------------------------------------------------------------------
+	// timeline
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Return a chronological window of memories around an anchor.
+	 *
+	 * Finds an anchor by memoryId or query, then fetches neighbors
+	 * in the same session. Delegates to search.ts.
+	 */
+	timeline(
+		query?: string | null,
+		memoryId?: number | null,
+		depthBefore = 3,
+		depthAfter = 3,
+		filters?: MemoryFilters | null,
+	): Record<string, unknown>[] {
+		return timelineFn(this, query, memoryId, depthBefore, depthAfter, filters);
+	}
+
+	// -----------------------------------------------------------------------
+	// explain
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Explain search results with scoring breakdown.
+	 *
+	 * Returns detailed scoring components for each result, merging
+	 * query-based and ID-based lookups. Delegates to search.ts.
+	 */
+	explain(
+		query?: string | null,
+		ids?: unknown[] | null,
+		limit = 10,
+		filters?: MemoryFilters | null,
+	): Record<string, unknown> {
+		return explainFn(this, query, ids, limit, filters);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Description

Ports timeline and explain methods from Python (`codemem/store/search.py`) to TypeScript, completing the query-side store methods needed for parity.

**`timeline()`** — finds an anchor memory by ID or query, then returns same-session neighbors in chronological order:
- Supports `depthBefore`/`depthAfter` for controlling window size
- Filters via `buildFilterClauses()` 
- Scoped to same session as anchor

**`explain()`** — merges query-based search results with explicit ID lookups, providing scoring breakdown:
- Retrieval source tracking: "query", "id_lookup", or "query+id_lookup"
- Score components: BM25 base, recency, kind bonus
- Missing ID reporting with error details
- Validates at least one of query or ids is provided

**Supporting:**
- `dedupeOrderedIds()` — validates and deduplicates ID arrays
- `StoreHandle` interface extended with `get()` method
- 11 new tests (6 timeline, 5 explain)

**Not ported:** build_memory_pack (next PR), usage tracking, prompt links, project mismatch checks.

Part of: codemem-egb

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — typecheck + lint + 98 tests)
- [x] Added/updated tests for changes (11 new tests)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`biome check` passes clean)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced