### PR TITLE
Add build_memory_pack for context-aware memory retrieval

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
 	toJson,
 } from "./db.js";
 export { buildFilterClauses } from "./filters.js";
+export { buildMemoryPack, estimateTokens } from "./pack.js";
 export type { StoreHandle } from "./search.js";
 export {
 	expandQuery,

--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -1,0 +1,163 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import { buildMemoryPack, estimateTokens } from "./pack.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+
+// ---------------------------------------------------------------------------
+// Unit tests: estimateTokens
+// ---------------------------------------------------------------------------
+
+describe("estimateTokens", () => {
+	it("estimates roughly 4 chars per token", () => {
+		expect(estimateTokens("abcd")).toBe(1);
+		expect(estimateTokens("abcdefgh")).toBe(2);
+		expect(estimateTokens("a")).toBe(1); // ceil(1/4) = 1
+	});
+
+	it("returns 0 for empty string", () => {
+		expect(estimateTokens("")).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: buildMemoryPack
+// ---------------------------------------------------------------------------
+
+describe("buildMemoryPack", () => {
+	let tmpDir: string;
+	let store: MemoryStore;
+	let sessionId: number;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-pack-"));
+		const dbPath = join(tmpDir, "test.db");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		store = new MemoryStore(dbPath);
+		sessionId = insertTestSession(store.db);
+	});
+
+	afterEach(() => {
+		store.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns items and pack_text for matching context", () => {
+		store.remember(sessionId, "discovery", "Found database issue", "The DB was slow", 0.8);
+		store.remember(sessionId, "bugfix", "Fixed database query", "Optimized the join", 0.9);
+
+		const pack = buildMemoryPack(store, "database");
+
+		expect((pack.items as unknown[]).length).toBeGreaterThanOrEqual(1);
+		expect(pack.pack_text).toBeTruthy();
+		expect(typeof pack.pack_text).toBe("string");
+		expect((pack.item_ids as number[]).length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("falls back to recent when no search results", () => {
+		store.remember(sessionId, "feature", "Add login page", "Built the login UI", 0.7);
+
+		const pack = buildMemoryPack(store, "zzz_nomatch_zzz");
+		const metrics = pack.metrics as Record<string, unknown>;
+
+		expect(metrics.fallback_used).toBe(true);
+		expect((pack.items as unknown[]).length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("respects token budget by truncating items", () => {
+		// Insert several items with substantial text
+		for (let i = 0; i < 10; i++) {
+			store.remember(
+				sessionId,
+				"discovery",
+				`Discovery item ${i} about testing`,
+				`This is a long body text for item ${i} that should consume tokens in the budget calculation`,
+				0.5,
+			);
+		}
+
+		// Very small budget — should get fewer items than unlimited
+		const smallPack = buildMemoryPack(store, "testing", 10, 20);
+		const fullPack = buildMemoryPack(store, "testing", 10, null);
+
+		const smallItems = smallPack.items as unknown[];
+		const fullItems = fullPack.items as unknown[];
+
+		expect(smallItems.length).toBeLessThanOrEqual(fullItems.length);
+	});
+
+	it("formats sections correctly", () => {
+		store.remember(sessionId, "decision", "Use PostgreSQL", "Decided on PG for prod", 0.9);
+		store.remember(sessionId, "discovery", "Found Redis cache", "Redis speeds up lookups", 0.7);
+
+		const pack = buildMemoryPack(store, "PostgreSQL Redis");
+		const text = pack.pack_text as string;
+
+		// Should have section headers
+		expect(text).toContain("## Timeline");
+		// Items should appear with [id] (kind) format
+		expect(text).toMatch(/\[\d+\]/);
+		expect(text).toMatch(/\((decision|discovery)\)/);
+	});
+
+	it("metrics has expected shape", () => {
+		store.remember(sessionId, "feature", "Add search", "FTS5 search feature", 0.8);
+
+		const pack = buildMemoryPack(store, "search");
+		const metrics = pack.metrics as Record<string, unknown>;
+
+		expect(metrics).toHaveProperty("total_items");
+		expect(metrics).toHaveProperty("pack_tokens");
+		expect(metrics).toHaveProperty("fallback_used");
+		expect(metrics).toHaveProperty("sources");
+		expect(typeof metrics.total_items).toBe("number");
+		expect(typeof metrics.pack_tokens).toBe("number");
+		expect(typeof metrics.fallback_used).toBe("boolean");
+
+		const sources = metrics.sources as Record<string, number>;
+		expect(sources).toHaveProperty("fts");
+		expect(sources).toHaveProperty("semantic");
+		expect(sources).toHaveProperty("fuzzy");
+		expect(sources.semantic).toBe(0);
+		expect(sources.fuzzy).toBe(0);
+	});
+
+	it("returns empty pack for empty database", () => {
+		const pack = buildMemoryPack(store, "anything");
+
+		expect((pack.items as unknown[]).length).toBe(0);
+		expect(pack.pack_text).toBe("");
+		expect((pack.item_ids as number[]).length).toBe(0);
+
+		const metrics = pack.metrics as Record<string, unknown>;
+		expect(metrics.total_items).toBe(0);
+		expect(metrics.fallback_used).toBe(true);
+	});
+
+	it("includes context in the result", () => {
+		const pack = buildMemoryPack(store, "my test context");
+		expect(pack.context).toBe("my test context");
+	});
+
+	it("pack items have expected fields", () => {
+		store.remember(sessionId, "bugfix", "Fix crash", "Null pointer fix", 0.9, ["crash", "fix"]);
+
+		const pack = buildMemoryPack(store, "crash");
+		const items = pack.items as Array<Record<string, unknown>>;
+
+		expect(items.length).toBeGreaterThanOrEqual(1);
+		const item = items[0] as Record<string, unknown>;
+		expect(item).toHaveProperty("id");
+		expect(item).toHaveProperty("kind");
+		expect(item).toHaveProperty("title");
+		expect(item).toHaveProperty("body");
+		expect(item).toHaveProperty("confidence");
+		expect(item).toHaveProperty("tags");
+		expect(item).toHaveProperty("metadata");
+	});
+});

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -1,0 +1,210 @@
+/**
+ * Memory pack builder — simplified port of codemem/store/packs.py.
+ *
+ * Builds a formatted "memory pack" from search results, organized into
+ * sections (summary, timeline, observations) with token budgeting.
+ *
+ * NOT ported: semantic search, fuzzy search, task/recall mode detection,
+ * _merge_ranked_results, exact dedup, pack delta tracking.
+ */
+
+import type { StoreHandle } from "./search.js";
+import { search } from "./search.js";
+import type { MemoryFilters, MemoryResult } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Observation kind priority — higher-signal kinds sort first. */
+const OBSERVATION_KIND_PRIORITY: Record<string, number> = {
+	decision: 0,
+	feature: 1,
+	bugfix: 2,
+	refactor: 3,
+	change: 4,
+	discovery: 5,
+	exploration: 6,
+	note: 7,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Rough token estimate: ~4 chars per token (matches Python heuristic). */
+export function estimateTokens(text: string): number {
+	return Math.ceil(text.length / 4);
+}
+
+/** Format a single memory item as a pack line. */
+function formatItem(item: MemoryResult): string {
+	const parts = [`[${item.id}]`, `(${item.kind})`, item.title];
+	if (item.body_text) {
+		parts.push("-", item.body_text);
+	}
+	return parts.join(" ");
+}
+
+/** Build a formatted section with header and items. */
+function formatSection(header: string, items: MemoryResult[]): string {
+	if (items.length === 0) return "";
+	const lines = [`## ${header}`, ...items.map(formatItem)];
+	return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Pack item shape (what goes into items array)
+// ---------------------------------------------------------------------------
+
+interface PackItem {
+	id: number;
+	kind: string;
+	title: string;
+	body: string;
+	confidence: number;
+	tags: string;
+	metadata: Record<string, unknown>;
+}
+
+function toPackItem(result: MemoryResult): PackItem {
+	return {
+		id: result.id,
+		kind: result.kind,
+		title: result.title,
+		body: result.body_text,
+		confidence: result.confidence,
+		tags: result.tags_text,
+		metadata: result.metadata,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// buildMemoryPack
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a memory pack: a formatted, categorized summary of memories
+ * matching a given context string.
+ *
+ * Flow:
+ * 1. Search for memories matching `context`
+ * 2. Separate into summary / timeline / observations sections
+ * 3. Fall back to recent() if search returns nothing
+ * 4. Apply token budget (truncate items if budget exceeded)
+ * 5. Format sections into pack_text
+ */
+export function buildMemoryPack(
+	store: StoreHandle,
+	context: string,
+	limit = 10,
+	tokenBudget: number | null = null,
+	filters?: MemoryFilters,
+): Record<string, unknown> {
+	const effectiveLimit = Math.max(1, Math.trunc(limit));
+	let fallbackUsed = false;
+	let ftsCount = 0;
+
+	// Step 1: search for matching memories
+	let results = search(store, context, effectiveLimit, filters);
+	ftsCount = results.length;
+
+	// Step 3: fall back to recent if no search results
+	if (results.length === 0) {
+		fallbackUsed = true;
+		const recentRows = store.recent(effectiveLimit, filters ?? null);
+		results = recentRows.map((row) => ({
+			id: row.id as number,
+			kind: row.kind as string,
+			title: row.title as string,
+			body_text: row.body_text as string,
+			confidence: (row.confidence as number) ?? 0,
+			created_at: row.created_at as string,
+			updated_at: row.updated_at as string,
+			tags_text: (row.tags_text as string) ?? "",
+			score: 0,
+			session_id: row.session_id as number,
+			metadata:
+				typeof row.metadata_json === "object" && row.metadata_json != null
+					? (row.metadata_json as Record<string, unknown>)
+					: {},
+		}));
+	}
+
+	// Step 2: categorize results
+	const summaryItems = results.filter((r) => r.kind === "session_summary").slice(0, 1);
+	const timelineItems = results.filter((r) => r.kind !== "session_summary").slice(0, 3);
+	const observationItems = [...results]
+		.filter((r) => r.kind !== "session_summary")
+		.sort((a, b) => {
+			const pa = OBSERVATION_KIND_PRIORITY[a.kind] ?? 99;
+			const pb = OBSERVATION_KIND_PRIORITY[b.kind] ?? 99;
+			return pa - pb;
+		});
+
+	// Step 4: apply token budget
+	let budgetedSummary = summaryItems;
+	let budgetedTimeline = timelineItems;
+	let budgetedObservations = observationItems;
+
+	if (tokenBudget != null && tokenBudget > 0) {
+		let tokensUsed = 0;
+
+		budgetedSummary = [];
+		for (const item of summaryItems) {
+			const cost = estimateTokens(formatItem(item));
+			if (tokensUsed + cost > tokenBudget) break;
+			tokensUsed += cost;
+			budgetedSummary.push(item);
+		}
+
+		budgetedTimeline = [];
+		for (const item of timelineItems) {
+			const cost = estimateTokens(formatItem(item));
+			if (tokensUsed + cost > tokenBudget) break;
+			tokensUsed += cost;
+			budgetedTimeline.push(item);
+		}
+
+		budgetedObservations = [];
+		for (const item of observationItems) {
+			const cost = estimateTokens(formatItem(item));
+			if (tokensUsed + cost > tokenBudget) break;
+			tokensUsed += cost;
+			budgetedObservations.push(item);
+		}
+	}
+
+	// Step 5: format sections
+	const sections = [
+		formatSection("Summary", budgetedSummary),
+		formatSection("Timeline", budgetedTimeline),
+		formatSection("Observations", budgetedObservations),
+	].filter((s) => s.length > 0);
+
+	const packText = sections.join("\n\n");
+
+	// Collect all unique items across sections
+	const seenIds = new Set<number>();
+	const allItems: PackItem[] = [];
+	const allItemIds: number[] = [];
+	for (const item of [...budgetedSummary, ...budgetedTimeline, ...budgetedObservations]) {
+		if (seenIds.has(item.id)) continue;
+		seenIds.add(item.id);
+		allItems.push(toPackItem(item));
+		allItemIds.push(item.id);
+	}
+
+	return {
+		context,
+		items: allItems,
+		item_ids: allItemIds,
+		pack_text: packText,
+		metrics: {
+			total_items: allItems.length,
+			pack_tokens: estimateTokens(packText),
+			fallback_used: fallbackUsed,
+			sources: { fts: ftsCount, semantic: 0, fuzzy: 0 },
+		},
+	};
+}

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -22,6 +22,17 @@ import type { MemoryFilters, MemoryResult } from "./types.js";
 export interface StoreHandle {
 	readonly db: import("better-sqlite3").Database;
 	get(memoryId: number): Record<string, unknown> | null;
+	recent(
+		limit?: number,
+		filters?: MemoryFilters | null,
+		offset?: number,
+	): Record<string, unknown>[];
+	recentByKinds(
+		kinds: string[],
+		limit?: number,
+		filters?: MemoryFilters | null,
+		offset?: number,
+	): Record<string, unknown>[];
 }
 
 // ---------------------------------------------------------------------------
@@ -439,6 +450,16 @@ function rowMatchesFilters(row: Record<string, unknown>, filters: MemoryFilters)
 	}
 	if (filters.exclude_actor_ids?.length) {
 		if (row.actor_id != null && filters.exclude_actor_ids.includes(row.actor_id as string))
+			return false;
+	}
+	if (filters.include_workspace_ids?.length) {
+		if (!filters.include_workspace_ids.includes(row.workspace_id as string)) return false;
+	}
+	if (filters.exclude_workspace_ids?.length) {
+		if (
+			row.workspace_id != null &&
+			filters.exclude_workspace_ids.includes(row.workspace_id as string)
+		)
 			return false;
 	}
 	if (filters.include_workspace_kinds?.length) {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -25,6 +25,7 @@ import {
 	toJson,
 } from "./db.js";
 import { buildFilterClauses } from "./filters.js";
+import { buildMemoryPack } from "./pack.js";
 import { explain as explainFn, search as searchFn, timeline as timelineFn } from "./search.js";
 import type { MemoryFilters, MemoryItem, MemoryResult } from "./types.js";
 
@@ -423,6 +424,25 @@ export class MemoryStore {
 		filters?: MemoryFilters | null,
 	): Record<string, unknown> {
 		return explainFn(this, query, ids, limit, filters);
+	}
+
+	// -----------------------------------------------------------------------
+	// buildMemoryPack
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Build a formatted memory pack from search results.
+	 *
+	 * Categorizes memories into summary/timeline/observations sections,
+	 * with optional token budgeting. Delegates to pack.ts.
+	 */
+	buildMemoryPack(
+		context: string,
+		limit?: number,
+		tokenBudget?: number | null,
+		filters?: MemoryFilters,
+	): Record<string, unknown> {
+		return buildMemoryPack(this, context, limit, tokenBudget ?? null, filters);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Description

Ports the core flow of Python's `build_memory_pack` (`codemem/store/packs.py`) to TypeScript, completing the store port for bead codemem-egb.

**How it works:**
1. Searches for memories matching `context` via FTS5
2. Falls back to `store.recent()` if no search results
3. Categorizes results into sections: Summary, Timeline, Observations
4. Sorts observations by kind priority (decision > feature > bugfix > ...)
5. Deduplicates across sections
6. Formats `pack_text` with section headers
7. Enforces optional `tokenBudget` (stops adding items when exceeded)
8. Returns structured payload with items, pack_text, and metrics

**New files:**
- `pack.ts` — `buildMemoryPack()`, `estimateTokens()` (~160 lines)
- `pack.test.ts` — 10 tests covering search, fallback, budget, formatting, metrics, empty DB

**Modified:**
- `search.ts` — `StoreHandle` extended with `recent()` and `recentByKinds()`
- `store.ts` — Added `buildMemoryPack()` method
- `index.ts` — New exports

**Simplified from Python (deferred):** semantic search, fuzzy fallback, task/recall mode detection, merge ranking, exact dedup, pack delta tracking.

Closes: codemem-73bj
Part of: codemem-egb

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — typecheck + lint + 108 tests)
- [x] Added/updated tests for changes (10 new tests)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`biome check` passes clean)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced