### PR TITLE
Fix constructor DB leak and add fromJson parse warning

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -130,7 +130,8 @@ export function fromJson(text: string | null | undefined): Record<string, unknow
 	if (!text) return {};
 	try {
 		return JSON.parse(text) as Record<string, unknown>;
-	} catch {
+	} catch (err) {
+		console.warn("fromJson: failed to parse metadata_json", err);
 		return {};
 	}
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -84,8 +84,13 @@ export class MemoryStore {
 	constructor(dbPath: string = DEFAULT_DB_PATH) {
 		this.dbPath = dbPath;
 		this.db = connect(dbPath);
-		loadSqliteVec(this.db);
-		assertSchemaReady(this.db);
+		try {
+			loadSqliteVec(this.db);
+			assertSchemaReady(this.db);
+		} catch (err) {
+			this.db.close();
+			throw err;
+		}
 
 		const envDeviceId = process.env.CODEMEM_DEVICE_ID?.trim();
 		this.deviceId = envDeviceId || randomUUID();


### PR DESCRIPTION
## Description

Two quick fixes from holistic store port review:

1. **MemoryStore constructor DB leak** — If `loadSqliteVec()` or `assertSchemaReady()` throws after `connect()` opens the DB, the connection was leaked. Now wrapped in try/catch that closes the DB before re-throwing. Prevents WAL file accumulation and lock contention in test runners and short-lived processes.

2. **fromJson parse warning** — `fromJson()` silently returned `{}` on JSON parse failure. Now logs `console.warn` with the error for debugging corrupt `metadata_json` values.

Closes: codemem-4ivp, codemem-jepw

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — 108 tests)
- [x] Existing tests cover both changes (constructor failure path via assertSchemaReady, fromJson invalid JSON test now shows warning in stderr)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced