### PR TITLE
Add edge case tests for store port (12 new tests)

### DIFF
--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -144,6 +144,26 @@ describe("buildMemoryPack", () => {
 		expect(pack.context).toBe("my test context");
 	});
 
+	it("with tokenBudget=0 skips budget enforcement (treats as no budget)", () => {
+		store.remember(sessionId, "discovery", "Found database issue", "The DB was slow", 0.8);
+		store.remember(sessionId, "bugfix", "Fixed database query", "Optimized the join", 0.9);
+
+		// tokenBudget=0 — the code checks `tokenBudget > 0`, so 0 means no budgeting
+		const pack = buildMemoryPack(store, "database", 10, 0);
+		const metrics = pack.metrics as Record<string, unknown>;
+
+		// Should still return a valid structure
+		expect(metrics).toHaveProperty("total_items");
+		expect(metrics).toHaveProperty("pack_tokens");
+		expect(metrics).toHaveProperty("fallback_used");
+		expect(typeof metrics.total_items).toBe("number");
+		expect(typeof metrics.pack_tokens).toBe("number");
+
+		// Items should be present (budget not enforced since 0 > 0 is false)
+		expect((pack.items as unknown[]).length).toBeGreaterThanOrEqual(1);
+		expect(pack.pack_text).toBeTruthy();
+	});
+
 	it("pack items have expected fields", () => {
 		store.remember(sessionId, "bugfix", "Fix crash", "Null pointer fix", 0.9, ["crash", "fix"]);
 

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -39,6 +39,20 @@ describe("expandQuery", () => {
 		expect(expandQuery("AND OR NOT")).toBe("");
 	});
 
+	it("strips NEAR operator", () => {
+		expect(expandQuery("NEAR database")).toBe("database");
+		expect(expandQuery("near tables")).toBe("tables");
+	});
+
+	it("strips PHRASE operator", () => {
+		expect(expandQuery("phrase match test")).toBe("match OR test");
+		expect(expandQuery("PHRASE only")).toBe("only");
+	});
+
+	it("returns empty when query is only NEAR/PHRASE operators", () => {
+		expect(expandQuery("NEAR PHRASE")).toBe("");
+	});
+
 	it("handles special characters by extracting alphanumeric tokens", () => {
 		expect(expandQuery("hello-world")).toBe("hello OR world");
 		expect(expandQuery("foo_bar")).toBe("foo_bar");
@@ -250,6 +264,54 @@ describe("MemoryStore.search", () => {
 		}
 	});
 
+	it("returns empty array when query becomes empty after operator filtering", () => {
+		seedMemories();
+		const results = store.search("AND OR NOT");
+		expect(results).toEqual([]);
+	});
+
+	it("filters by multiple criteria combined (kind + visibility)", () => {
+		const sessionId = insertTestSession(store.db);
+		// Insert memories with different kinds and visibility
+		const ts = new Date().toISOString();
+		store.db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'bugfix', 'Database bugfix shared', 'Shared fix for DB', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, ts, ts);
+		store.db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'bugfix', 'Database bugfix private', 'Private fix for DB', 0.5, '', 1, ?, ?, '{}', 1, 'private')`,
+			)
+			.run(sessionId, ts, ts);
+		store.db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'feature', 'Database feature shared', 'Shared feature for DB', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, ts, ts);
+
+		const results = store.search("database", 10, {
+			kind: "bugfix",
+			include_visibility: ["shared"],
+		});
+		expect(results.length).toBeGreaterThan(0);
+		for (const r of results) {
+			expect(r.kind).toBe("bugfix");
+			// visibility is on metadata, but the filter should have applied
+		}
+		// The shared bugfix should be found, the private bugfix and feature should not
+		const titles = results.map((r) => r.title);
+		expect(titles).toContain("Database bugfix shared");
+		expect(titles).not.toContain("Database bugfix private");
+		expect(titles).not.toContain("Database feature shared");
+	});
+
 	it("returns MemoryResult objects with expected shape", () => {
 		seedMemories();
 		const results = store.search("authentication");
@@ -382,6 +444,36 @@ describe("MemoryStore.timeline", () => {
 		seedTimeline();
 		const results = store.timeline(null, 99999);
 		expect(results).toEqual([]);
+	});
+
+	it("with depthBefore=0 returns only anchor + after items", () => {
+		const { ids } = seedTimeline();
+		// Anchor on the 4th memory (index 3 = "API endpoints")
+		const anchorId = ids[3] as number;
+		const results = store.timeline(null, anchorId, 0, 2);
+		expect(results.length).toBeGreaterThan(0);
+		const resultIds = results.map((r) => r.id);
+		expect(resultIds).toContain(anchorId);
+		// Should not have any items before the anchor
+		const anchorIdx = resultIds.indexOf(anchorId);
+		expect(anchorIdx).toBe(0);
+		// Should have at most 2 items after anchor
+		expect(results.length).toBeLessThanOrEqual(3); // anchor + 2 after
+	});
+
+	it("with depthAfter=0 returns only before items + anchor", () => {
+		const { ids } = seedTimeline();
+		// Anchor on the 4th memory (index 3 = "API endpoints")
+		const anchorId = ids[3] as number;
+		const results = store.timeline(null, anchorId, 2, 0);
+		expect(results.length).toBeGreaterThan(0);
+		const resultIds = results.map((r) => r.id);
+		expect(resultIds).toContain(anchorId);
+		// Should have at most 2 items before anchor
+		const anchorIdx = resultIds.indexOf(anchorId);
+		expect(anchorIdx).toBeLessThanOrEqual(2);
+		// Anchor should be last (nothing after it)
+		expect(resultIds[resultIds.length - 1]).toBe(anchorId);
 	});
 });
 
@@ -526,5 +618,53 @@ describe("MemoryStore.explain", () => {
 		expect(metadata).toHaveProperty("query", "database");
 		expect(metadata).toHaveProperty("requested_ids_count", 0);
 		expect(typeof metadata.returned_items_count).toBe("number");
+	});
+
+	it("rejects booleans and floats in ids (dedupeOrderedIds)", () => {
+		const { id1 } = seedMemories();
+		// Pass booleans, a float, and one valid int
+		const result = store.explain(null, [true, false, 3.14, id1]) as Record<string, unknown>;
+		const items = result.items as Record<string, unknown>[];
+		// Only the valid integer id should produce an item
+		expect(items).toHaveLength(1);
+		expect(items[0]?.id).toBe(id1);
+		// The invalid values should be reported
+		const errors = result.errors as Record<string, unknown>[];
+		const invalidArgError = errors.find((e) => e.code === "INVALID_ARGUMENT");
+		expect(invalidArgError).toBeDefined();
+		const invalidIds = invalidArgError?.ids as string[];
+		expect(invalidIds).toContain("true");
+		expect(invalidIds).toContain("false");
+		expect(invalidIds).toContain("3.14");
+	});
+
+	it("excludes id-lookup memories that fail workspace_id filter (rowMatchesFilters)", () => {
+		const sessionId = insertTestSession(store.db);
+		// Insert a memory with a specific workspace_id
+		const ts = new Date().toISOString();
+		store.db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, workspace_id)
+				 VALUES (?, 'discovery', 'WS memory', 'workspace body', 0.5, '', 1, ?, ?, '{}', 1, 'ws:team-alpha')`,
+			)
+			.run(sessionId, ts, ts);
+		const memId = Number(
+			(store.db.prepare("SELECT last_insert_rowid() as id").get() as { id: number }).id,
+		);
+
+		// Explain with include_workspace_ids filter that doesn't match
+		const result = store.explain(null, [memId], 10, {
+			include_workspace_ids: ["ws:team-beta"],
+		}) as Record<string, unknown>;
+
+		const items = result.items as Record<string, unknown>[];
+		expect(items).toHaveLength(0);
+
+		// Should report as filter mismatch
+		const errors = result.errors as Record<string, unknown>[];
+		const mismatch = errors.find((e) => e.code === "FILTER_MISMATCH");
+		expect(mismatch).toBeDefined();
+		expect((mismatch?.ids as number[]) ?? []).toContain(memId);
 	});
 });

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -111,6 +111,29 @@ describe("MemoryStore", () => {
 			);
 		});
 
+		it("succeeds with empty title", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "", "Body with empty title");
+			expect(memId).toBeGreaterThan(0);
+
+			const row = store.get(memId);
+			expect(row).not.toBeNull();
+			expect(row?.title).toBe("");
+			expect(row?.body_text).toBe("Body with empty title");
+		});
+
+		it("rejects invalid kind with descriptive error including valid kinds", () => {
+			const sessionId = insertTestSession(store.db);
+			try {
+				store.remember(sessionId, "made_up_kind", "Title", "Body");
+				expect.unreachable("should have thrown");
+			} catch (e) {
+				const msg = (e as Error).message;
+				expect(msg).toMatch(/Invalid memory kind/);
+				expect(msg).toContain("made_up_kind");
+			}
+		});
+
 		it("sets clock_device_id in metadata", () => {
 			const sessionId = insertTestSession(store.db);
 			const memId = store.remember(sessionId, "discovery", "Title", "Body");


### PR DESCRIPTION
## Description

Adds 12 edge case tests identified during the holistic store port review, covering gaps in search, timeline, explain, store, and pack test coverage.

**search.test.ts (9 new tests):**
- `expandQuery` strips NEAR and PHRASE operators
- `expandQuery` returns empty when only operators remain
- `store.search("AND OR NOT")` returns `[]`
- Search with multiple combined filters (kind + visibility)
- Timeline with `depthBefore=0` (anchor + after only)
- Timeline with `depthAfter=0` (before + anchor only)
- `dedupeOrderedIds` rejects booleans and floats
- Explain with `include_workspace_ids` filter enforced on ID lookups

**store.test.ts (2 new tests):**
- `remember` with empty title succeeds (NOT NULL allows empty strings)
- Invalid kind error message includes the kind name

**pack.test.ts (1 new test):**
- `tokenBudget=0` documents current behavior (items pass through)

120 tests total (up from 108).

Closes: codemem-5jh1

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — 120 tests)
- [x] All new tests exercise previously untested edge cases

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced