### PR TITLE
Add prototype CLI with stats, search, and pack commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:watch": "pnpm exec vitest",
     "lint": "pnpm exec biome check packages/",
     "format": "pnpm exec biome check --write packages/",
-    "typecheck": "pnpm exec tsc --build --noEmit",
+    "typecheck": "pnpm exec tsc --build",
     "check": "pnpm run typecheck && pnpm run lint && pnpm run test"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,15 +8,18 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "pnpm exec vite build",
+		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist",
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {
 		"@codemem/core": "workspace:*",
 		"@codemem/mcp-server": "workspace:*",
-		"@codemem/viewer-server": "workspace:*"
+		"@codemem/viewer-server": "workspace:*",
+		"chalk": "^5.6.2",
+		"commander": "^14.0.3"
 	},
 	"devDependencies": {
+		"@types/node": "^25.5.0",
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -1,0 +1,53 @@
+import { MemoryStore } from "@codemem/core";
+import chalk from "chalk";
+import { Command } from "commander";
+
+export const packCommand = new Command("pack")
+	.description("Build a context-aware memory pack")
+	.argument("<context>", "context string to search for")
+	.option("--db <path>", "database path")
+	.option("-n, --limit <n>", "max items", "10")
+	.option("--budget <tokens>", "token budget")
+	.option("--json", "output as JSON")
+	.action(
+		(context: string, opts: { db?: string; limit: string; budget?: string; json?: boolean }) => {
+			const store = new MemoryStore(opts.db);
+			try {
+				const limit = Number.parseInt(opts.limit, 10) || 10;
+				const budget = opts.budget ? Number.parseInt(opts.budget, 10) : undefined;
+				const result = store.buildMemoryPack(context, limit, budget);
+
+				if (opts.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+
+				console.log(chalk.bold(`Memory pack for "${context}"\n`));
+
+				if (result.items.length === 0) {
+					console.log(chalk.dim("No relevant memories found."));
+					return;
+				}
+
+				const m = result.metrics;
+				console.log(
+					chalk.dim(
+						`  ${m.total_items} items, ~${m.pack_tokens} tokens` +
+							(m.fallback_used ? " (fallback)" : "") +
+							` [fts:${m.sources.fts} sem:${m.sources.semantic} fuzzy:${m.sources.fuzzy}]`,
+					),
+				);
+				console.log();
+
+				for (const item of result.items) {
+					const kind = chalk.dim(`(${item.kind})`);
+					console.log(`  ${chalk.cyan(`#${item.id}`)} ${kind} ${item.title}`);
+				}
+
+				console.log(chalk.dim("\n--- pack_text ---\n"));
+				console.log(result.pack_text);
+			} finally {
+				store.close();
+			}
+		},
+	);

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,0 +1,56 @@
+import { MemoryStore } from "@codemem/core";
+import chalk from "chalk";
+import { Command } from "commander";
+
+export const searchCommand = new Command("search")
+	.description("Search memories by query")
+	.argument("<query>", "search query")
+	.option("--db <path>", "database path")
+	.option("-n, --limit <n>", "max results", "10")
+	.option("--kind <kind>", "filter by memory kind")
+	.option("--json", "output as JSON")
+	.action((query: string, opts: { db?: string; limit: string; kind?: string; json?: boolean }) => {
+		const store = new MemoryStore(opts.db);
+		try {
+			const limit = Number.parseInt(opts.limit, 10) || 10;
+			const filters = opts.kind ? { kind: opts.kind } : undefined;
+			const results = store.search(query, limit, filters);
+
+			if (opts.json) {
+				console.log(JSON.stringify(results, null, 2));
+				return;
+			}
+
+			if (results.length === 0) {
+				console.log(chalk.dim("No results found."));
+				return;
+			}
+
+			console.log(chalk.bold(`${results.length} result(s) for "${query}"\n`));
+			for (const item of results) {
+				const score = item.score.toFixed(3);
+				const kind = chalk.dim(`(${item.kind})`);
+				const age = timeSince(item.created_at);
+				console.log(
+					`  ${chalk.cyan(`#${item.id}`)} ${kind} ${item.title} ${chalk.dim(`[${score}] ${age}`)}`,
+				);
+				if (item.body_text.length > 120) {
+					console.log(`    ${chalk.dim(item.body_text.slice(0, 120))}…`);
+				} else {
+					console.log(`    ${chalk.dim(item.body_text)}`);
+				}
+			}
+		} finally {
+			store.close();
+		}
+	});
+
+function timeSince(isoDate: string): string {
+	const ms = Date.now() - new Date(isoDate).getTime();
+	const days = Math.floor(ms / 86_400_000);
+	if (days === 0) return "today";
+	if (days === 1) return "1d ago";
+	if (days < 30) return `${days}d ago`;
+	const months = Math.floor(days / 30);
+	return `${months}mo ago`;
+}

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -1,0 +1,31 @@
+import { MemoryStore } from "@codemem/core";
+import chalk from "chalk";
+import { Command } from "commander";
+
+export const statsCommand = new Command("stats")
+	.description("Show database statistics")
+	.option("--db <path>", "database path")
+	.option("--json", "output as JSON")
+	.action((opts: { db?: string; json?: boolean }) => {
+		const store = new MemoryStore(opts.db);
+		try {
+			const result = store.stats();
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			const db = result.database;
+			const sizeKb = Math.round(db.size_bytes / 1024);
+			console.log(chalk.bold("codemem stats (TS backend)\n"));
+			console.log(`  Database:  ${chalk.cyan(db.path)}`);
+			console.log(`  Size:      ${sizeKb.toLocaleString()} KB`);
+			console.log(`  Sessions:  ${db.sessions}`);
+			console.log(`  Memories:  ${db.active_memory_items} active / ${db.memory_items} total`);
+			console.log(`  Artifacts: ${db.artifacts}`);
+			console.log(`  Vectors:   ${db.vector_rows}`);
+			console.log(`  Raw events: ${db.raw_events}`);
+		} finally {
+			store.close();
+		}
+	});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,11 +1,29 @@
+#!/usr/bin/env node
+
 /**
  * @codemem/cli — CLI entry point.
  *
- * Dispatches to subcommands:
- *   codemem serve  → starts viewer+sync process (@codemem/viewer-server)
- *   codemem mcp    → starts MCP stdio server (@codemem/mcp-server)
- *   codemem stats  → one-shot CLI commands (@codemem/core)
- *   codemem embed  → one-shot embedding (inline, no worker thread)
+ * Prototype commands for validating the TS store port:
+ *   codemem-ts stats   → database statistics
+ *   codemem-ts search  → FTS5 memory search
+ *   codemem-ts pack    → context-aware memory pack
  */
 
-export { VERSION } from "@codemem/core";
+import { VERSION } from "@codemem/core";
+import { Command } from "commander";
+import { packCommand } from "./commands/pack.js";
+import { searchCommand } from "./commands/search.js";
+import { statsCommand } from "./commands/stats.js";
+
+const program = new Command();
+
+program
+	.name("codemem-ts")
+	.description("codemem TypeScript backend CLI (Phase 1 prototype)")
+	.version(VERSION);
+
+program.addCommand(statsCommand);
+program.addCommand(searchCommand);
+program.addCommand(packCommand);
+
+program.parse();

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -2,6 +2,9 @@ import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	// CLI uses tsc for build (not Vite library mode — CLI entry points with
+	// program.parse() get tree-shaken away by Rolldown). Vite config retained
+	// for vitest integration only.
 	build: {
 		lib: {
 			entry: resolve(import.meta.dirname, "src/index.ts"),
@@ -9,10 +12,7 @@ export default defineConfig({
 			fileName: "index",
 		},
 		rollupOptions: {
-			external: [/^@codemem\//, /^node:/],
-			output: {
-				banner: "#!/usr/bin/env node",
-			},
+			external: [/^@codemem\//, /^node:/, "commander", "chalk"],
 		},
 		outDir: "dist",
 		sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,16 @@ importers:
       '@codemem/viewer-server':
         specifier: workspace:*
         version: link:../viewer-server
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
     devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -644,12 +653,20 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1493,9 +1510,13 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk@5.6.2: {}
+
   check-error@2.1.3: {}
 
   chownr@1.1.4: {}
+
+  commander@14.0.3: {}
 
   debug@4.4.3:
     dependencies:


### PR DESCRIPTION
## Description

First consumer of `@codemem/core` — validates the store API works end-to-end against a real database.

**Commands:**
- `codemem-ts stats` — database statistics (path, size, session/memory/artifact/vector/raw_event counts)
- `codemem-ts search <query>` — FTS5 memory search with BM25 scoring, kind filter, formatted output
- `codemem-ts pack <context>` — context-aware memory retrieval with section formatting and metrics

All commands support `--db <path>` (custom database path) and `--json` (machine-readable output).

**Build approach:** Uses Vite SSR mode (`vite build --ssr`) for the CLI bundle — library mode tree-shakes away `program.parse()` side effects, but SSR mode preserves them. Externals: commander, chalk, @codemem/*.

**Also fixes:** Root `typecheck` script changed from `tsc --build --noEmit` to `tsc --build` for TS 5.9 compatibility with composite project references.

**Tested against real database:** stats shows 6922 active memories, search returns scored results, pack builds context packs with section formatting.

Closes: codemem-9jf

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — 120 tests)
- [x] Manually verified all 3 commands against real database (~7000 memories)
- [x] `--help` and `--json` flags work correctly
- [x] Python tests unaffected

## Checklist

- [x] Code follows project style (`biome check` passes clean)
- [x] Self-review completed
- [x] No new warnings introduced