### PR TITLE
Fix coexistence contract violations and data semantics

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,8 +13,6 @@
 	},
 	"dependencies": {
 		"@codemem/core": "workspace:*",
-		"@codemem/mcp-server": "workspace:*",
-		"@codemem/viewer-server": "workspace:*",
 		"chalk": "^5.6.2",
 		"commander": "^14.0.3"
 	},

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -1,17 +1,17 @@
-import { MemoryStore } from "@codemem/core";
+import { MemoryStore, resolveDbPath } from "@codemem/core";
 import chalk from "chalk";
 import { Command } from "commander";
 
 export const packCommand = new Command("pack")
 	.description("Build a context-aware memory pack")
 	.argument("<context>", "context string to search for")
-	.option("--db <path>", "database path")
+	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("-n, --limit <n>", "max items", "10")
 	.option("--budget <tokens>", "token budget")
 	.option("--json", "output as JSON")
 	.action(
 		(context: string, opts: { db?: string; limit: string; budget?: string; json?: boolean }) => {
-			const store = new MemoryStore(opts.db);
+			const store = new MemoryStore(resolveDbPath(opts.db));
 			try {
 				const limit = Number.parseInt(opts.limit, 10) || 10;
 				const budget = opts.budget ? Number.parseInt(opts.budget, 10) : undefined;

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,16 +1,16 @@
-import { MemoryStore } from "@codemem/core";
+import { MemoryStore, resolveDbPath } from "@codemem/core";
 import chalk from "chalk";
 import { Command } from "commander";
 
 export const searchCommand = new Command("search")
 	.description("Search memories by query")
 	.argument("<query>", "search query")
-	.option("--db <path>", "database path")
+	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("-n, --limit <n>", "max results", "10")
 	.option("--kind <kind>", "filter by memory kind")
 	.option("--json", "output as JSON")
 	.action((query: string, opts: { db?: string; limit: string; kind?: string; json?: boolean }) => {
-		const store = new MemoryStore(opts.db);
+		const store = new MemoryStore(resolveDbPath(opts.db));
 		try {
 			const limit = Number.parseInt(opts.limit, 10) || 10;
 			const filters = opts.kind ? { kind: opts.kind } : undefined;

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -1,13 +1,13 @@
-import { MemoryStore } from "@codemem/core";
+import { MemoryStore, resolveDbPath } from "@codemem/core";
 import chalk from "chalk";
 import { Command } from "commander";
 
 export const statsCommand = new Command("stats")
 	.description("Show database statistics")
-	.option("--db <path>", "database path")
+	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--json", "output as JSON")
 	.action((opts: { db?: string; json?: boolean }) => {
-		const store = new MemoryStore(opts.db);
+		const store = new MemoryStore(resolveDbPath(opts.db));
 		try {
 			const result = store.stats();
 			if (opts.json) {

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -2,9 +2,9 @@ import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-	// CLI uses tsc for build (not Vite library mode — CLI entry points with
-	// program.parse() get tree-shaken away by Rolldown). Vite config retained
-	// for vitest integration only.
+	// CLI uses Vite SSR mode for build (--ssr flag in package.json build script).
+	// Library mode tree-shakes program.parse() away. This lib config is retained
+	// for vitest integration; actual build uses SSR via the CLI flag.
 	build: {
 		lib: {
 			entry: resolve(import.meta.dirname, "src/index.ts"),

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -139,19 +139,34 @@ describe("assertSchemaReady", () => {
 		expect(() => assertSchemaReady(db)).toThrow(/not initialized/);
 	});
 
-	it("passes for the current schema version", () => {
+	it("passes for the current schema version with required tables", () => {
 		db.pragma(`user_version = ${SCHEMA_VERSION}`);
+		// Create the required tables
+		db.exec("CREATE TABLE memory_items (id INTEGER PRIMARY KEY)");
+		db.exec("CREATE TABLE sessions (id INTEGER PRIMARY KEY)");
+		db.exec("CREATE TABLE artifacts (id INTEGER PRIMARY KEY)");
+		db.exec("CREATE TABLE raw_events (id INTEGER PRIMARY KEY)");
 		expect(() => assertSchemaReady(db)).not.toThrow();
 	});
 
 	it("throws for a stale schema version", () => {
 		db.pragma("user_version = 3");
-		expect(() => assertSchemaReady(db)).toThrow(/older than expected/);
+		expect(() => assertSchemaReady(db)).toThrow(/older than minimum compatible/);
 	});
 
-	it("throws for a schema version newer than supported", () => {
+	it("warns but continues for a newer schema version", () => {
 		db.pragma(`user_version = ${SCHEMA_VERSION + 1}`);
-		expect(() => assertSchemaReady(db)).toThrow(/newer than this TS runtime/);
+		// Create required tables — newer version should warn, not throw
+		db.exec("CREATE TABLE memory_items (id INTEGER PRIMARY KEY)");
+		db.exec("CREATE TABLE sessions (id INTEGER PRIMARY KEY)");
+		db.exec("CREATE TABLE artifacts (id INTEGER PRIMARY KEY)");
+		db.exec("CREATE TABLE raw_events (id INTEGER PRIMARY KEY)");
+		expect(() => assertSchemaReady(db)).not.toThrow();
+	});
+
+	it("throws when required tables are missing", () => {
+		db.pragma(`user_version = ${SCHEMA_VERSION}`);
+		expect(() => assertSchemaReady(db)).toThrow(/Required tables missing/);
 	});
 });
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -16,11 +16,33 @@ import * as sqliteVec from "sqlite-vec";
 // Re-export the Database type for consumers
 export type { DatabaseType as Database };
 
-/** Current schema version — must match Python's SCHEMA_VERSION in db.py. */
+/** Current schema version this TS runtime was built against. */
 export const SCHEMA_VERSION = 6;
+
+/**
+ * Minimum schema version the TS runtime can operate with.
+ * Per the coexistence contract (docs/plans/2026-03-15-db-coexistence-contract.md),
+ * TS must tolerate additive newer schemas. It only hard-fails if the schema is
+ * too old to have the tables/columns it needs.
+ */
+export const MIN_COMPATIBLE_SCHEMA = 6;
+
+/** Required tables the TS runtime needs to function. */
+const REQUIRED_TABLES = ["memory_items", "sessions", "artifacts", "raw_events"] as const;
 
 /** Default database path — matches Python's DEFAULT_DB_PATH. */
 export const DEFAULT_DB_PATH = join(homedir(), ".codemem", "mem.sqlite");
+
+/**
+ * Resolve the database path from explicit arg → CODEMEM_DB env → default.
+ * All TS entry points should use this instead of hardcoding fallback logic.
+ */
+export function resolveDbPath(explicit?: string): string {
+	if (explicit) return explicit;
+	const envPath = process.env.CODEMEM_DB;
+	if (envPath) return envPath;
+	return DEFAULT_DB_PATH;
+}
 
 /**
  * Open a better-sqlite3 connection with the standard codemem pragmas.
@@ -89,10 +111,17 @@ export function getSchemaVersion(db: DatabaseType): number {
 }
 
 /**
- * Verify that the database schema is initialized and at the expected version.
+ * Verify the database schema is initialized and compatible.
  *
- * Throws if the schema version is 0 (uninitialized) or ahead of what this
- * TS runtime understands. During Phase 1, Python must initialize the DB first.
+ * Per the coexistence contract: TS tolerates additive newer schemas (Python may
+ * have run migrations that add tables/columns the TS runtime doesn't know about).
+ * TS only hard-fails if:
+ *   - Schema is uninitialized (version 0)
+ *   - Schema is too old (below MIN_COMPATIBLE_SCHEMA)
+ *   - Required tables are missing
+ *
+ * Warns (but continues) if schema is newer than SCHEMA_VERSION — the additive
+ * changes are assumed safe per the coexistence contract.
  */
 export function assertSchemaReady(db: DatabaseType): void {
 	const version = getSchemaVersion(db);
@@ -103,16 +132,25 @@ export function assertSchemaReady(db: DatabaseType): void {
 				"Run: uv run codemem stats",
 		);
 	}
-	if (version < SCHEMA_VERSION) {
+	if (version < MIN_COMPATIBLE_SCHEMA) {
 		throw new Error(
-			`Database schema version ${version} is older than expected (${SCHEMA_VERSION}). ` +
+			`Database schema version ${version} is older than minimum compatible (${MIN_COMPATIBLE_SCHEMA}). ` +
 				"Run the Python runtime to complete migrations: uv run codemem stats",
 		);
 	}
 	if (version > SCHEMA_VERSION) {
+		console.warn(
+			`Database schema version ${version} is newer than this TS runtime (${SCHEMA_VERSION}). ` +
+				"Running in compatibility mode — additive schema changes are tolerated.",
+		);
+	}
+
+	// Validate required tables exist (catches corrupt or partially migrated DBs)
+	const missing = REQUIRED_TABLES.filter((t) => !tableExists(db, t));
+	if (missing.length > 0) {
 		throw new Error(
-			`Database schema version ${version} is newer than this TS runtime supports (${SCHEMA_VERSION}). ` +
-				"Update the TS backend to match the Python schema version.",
+			`Required tables missing: ${missing.join(", ")}. ` +
+				"The database may be corrupt or from an incompatible version.",
 		);
 	}
 }

--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -65,6 +65,13 @@ export function buildFilterClauses(filters: MemoryFilters | undefined | null): F
 		params.push(filters.kind);
 	}
 
+	// Project scoping — requires sessions JOIN
+	if (filters.project) {
+		clauses.push("sessions.project = ?");
+		params.push(filters.project);
+		result.joinSessions = true;
+	}
+
 	// Visibility
 	addMultiValueFilter(
 		clauses,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,8 @@ export {
 	getSchemaVersion,
 	isEmbeddingDisabled,
 	loadSqliteVec,
+	MIN_COMPATIBLE_SCHEMA,
+	resolveDbPath,
 	SCHEMA_VERSION,
 	tableExists,
 	toJson,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -128,11 +128,9 @@ export class MemoryStore {
 	/**
 	 * Create a new memory item. Returns the new memory ID.
 	 *
-	 * Validates and normalizes the kind. Sets clock_device_id and
-	 * origin_device_id for replication tracing.
-	 *
-	 * NOT ported yet: full provenance resolution, vector storage,
-	 * flush_batch dedup (tracked for follow-up).
+	 * Validates and normalizes the kind. Resolves provenance fields (actor_id,
+	 * visibility, workspace_id, trust_state) matching Python's
+	 * _resolve_memory_provenance logic.
 	 */
 	remember(
 		sessionId: number,
@@ -152,13 +150,18 @@ export class MemoryStore {
 		const importKey = (metaPayload.import_key as string) || randomUUID();
 		metaPayload.import_key = importKey;
 
+		// Resolve provenance fields — mirrors Python's _resolve_memory_provenance
+		const provenance = this.resolveProvenance(metaPayload);
+
 		const info = this.db
 			.prepare(
 				`INSERT INTO memory_items(
 					session_id, kind, title, body_text, confidence, tags_text,
 					active, created_at, updated_at, metadata_json,
-					origin_device_id, deleted_at, rev, import_key
-				) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, NULL, 1, ?)`,
+					actor_id, actor_display_name, visibility, workspace_id,
+					workspace_kind, origin_device_id, origin_source, trust_state,
+					deleted_at, rev, import_key
+				) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 1, ?)`,
 			)
 			.run(
 				sessionId,
@@ -170,11 +173,90 @@ export class MemoryStore {
 				now,
 				now,
 				toJson(metaPayload),
-				this.deviceId,
+				provenance.actor_id,
+				provenance.actor_display_name,
+				provenance.visibility,
+				provenance.workspace_id,
+				provenance.workspace_kind,
+				provenance.origin_device_id,
+				provenance.origin_source,
+				provenance.trust_state,
 				importKey,
 			);
 
 		return Number(info.lastInsertRowid);
+	}
+
+	// -----------------------------------------------------------------------
+	// provenance resolution
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Resolve provenance fields for a new memory, matching Python's
+	 * _resolve_memory_provenance. Uses metadata overrides when present,
+	 * falls back to store-level defaults.
+	 */
+	private resolveProvenance(metadata: Record<string, unknown>): {
+		actor_id: string | null;
+		actor_display_name: string | null;
+		visibility: string;
+		workspace_id: string;
+		workspace_kind: string;
+		origin_device_id: string;
+		origin_source: string | null;
+		trust_state: string;
+	} {
+		const clean = (v: unknown): string | null => {
+			if (v == null) return null;
+			const s = String(v).trim();
+			return s.length > 0 ? s : null;
+		};
+
+		const actorId = clean(metadata.actor_id) ?? this.deviceId;
+		const actorDisplayName = clean(metadata.actor_display_name) ?? null;
+
+		const explicitWorkspaceKind = clean(metadata.workspace_kind);
+		const explicitWorkspaceId = clean(metadata.workspace_id);
+
+		// Visibility defaults to "shared" (matches Python behavior)
+		let visibility = clean(metadata.visibility);
+		if (!visibility || (visibility !== "private" && visibility !== "shared")) {
+			if (explicitWorkspaceKind === "shared" || explicitWorkspaceId?.startsWith("shared:")) {
+				visibility = "shared";
+			} else {
+				visibility = "shared";
+			}
+		}
+
+		// Workspace kind derives from visibility
+		let workspaceKind = explicitWorkspaceKind ?? "shared";
+		if (workspaceKind !== "personal" && workspaceKind !== "shared") {
+			workspaceKind = visibility === "shared" ? "shared" : "personal";
+		} else if (visibility === "shared") {
+			workspaceKind = "shared";
+		} else if (visibility === "private") {
+			workspaceKind = "personal";
+		}
+
+		// Workspace ID with fallback
+		const workspaceId =
+			explicitWorkspaceId ??
+			(workspaceKind === "personal" ? `personal:${actorId}` : `shared:${actorId}`);
+
+		const originDeviceId = clean(metadata.origin_device_id) ?? this.deviceId;
+		const originSource = clean(metadata.origin_source) ?? clean(metadata.source) ?? null;
+		const trustState = clean(metadata.trust_state) ?? "trusted";
+
+		return {
+			actor_id: actorId,
+			actor_display_name: actorDisplayName,
+			visibility,
+			workspace_id: workspaceId,
+			workspace_kind: workspaceKind,
+			origin_device_id: originDeviceId,
+			origin_source: originSource,
+			trust_state: trustState,
+		};
 	}
 
 	// -----------------------------------------------------------------------

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -421,6 +421,8 @@ export interface MemoryResult {
 
 export interface MemoryFilters {
 	kind?: string;
+	/** Project scope — matches sessions.project. Triggers session JOIN. */
+	project?: string;
 	include_visibility?: string[];
 	exclude_visibility?: string[];
 	include_workspace_ids?: string[];

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -10,10 +10,10 @@
  */
 
 import {
-	DEFAULT_DB_PATH,
 	type MemoryFilters,
 	type MemoryItemResponse,
 	MemoryStore,
+	resolveDbPath,
 	toJson,
 	VERSION,
 } from "@codemem/core";
@@ -41,6 +41,7 @@ const MEMORY_KINDS: Record<string, string> = {
 
 const filterSchema = {
 	kind: z.string().optional().describe("Filter by memory kind"),
+	project: z.string().optional().describe("Filter by project scope (matches sessions.project)"),
 	include_visibility: z.array(z.string()).optional(),
 	exclude_visibility: z.array(z.string()).optional(),
 	include_workspace_ids: z.array(z.string()).optional(),
@@ -57,11 +58,26 @@ const filterSchema = {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Default project scope — resolved from CODEMEM_PROJECT env var or cwd.
+ * Matches Python's `default_project = os.environ.get("CODEMEM_PROJECT") or resolve_project(os.getcwd())`.
+ */
+const defaultProject = process.env.CODEMEM_PROJECT || null;
+
 /** Build a MemoryFilters object from raw tool params, dropping undefined keys. */
 function buildFilters(raw: Record<string, unknown>): MemoryFilters | undefined {
 	const filters: MemoryFilters = {};
 	let hasAny = false;
+
+	// Apply default project scope if not explicitly provided
+	const resolvedProject = (raw.project as string | undefined) ?? defaultProject;
+	if (resolvedProject) {
+		filters.project = resolvedProject;
+		hasAny = true;
+	}
+
 	for (const key of Object.keys(filterSchema)) {
+		if (key === "project") continue; // handled above
 		const val = raw[key];
 		if (val !== undefined && val !== null) {
 			(filters as Record<string, unknown>)[key] = val;
@@ -131,7 +147,7 @@ function getMany(store: MemoryStore, ids: number[]): MemoryItemResponse[] {
 // ---------------------------------------------------------------------------
 
 async function main() {
-	const dbPath = process.env.CODEMEM_DB ?? DEFAULT_DB_PATH;
+	const dbPath = resolveDbPath();
 	const store = new MemoryStore(dbPath);
 
 	const server = new McpServer({ name: "codemem", version: VERSION });
@@ -239,7 +255,7 @@ async function main() {
 		"Explain search results with detailed scoring breakdown.",
 		{
 			query: z.string().optional().describe("Search query"),
-			ids: z.array(z.number().int()).optional().describe("Specific memory IDs to explain"),
+			ids: z.array(z.number().int()).max(200).optional().describe("Specific memory IDs to explain"),
 			limit: z.number().int().min(1).max(50).default(10).describe("Max results"),
 			include_pack_context: z.boolean().default(false).describe("Include formatted pack context"),
 			...filterSchema,
@@ -262,7 +278,10 @@ async function main() {
 		"memory_expand",
 		"Fetch memories by ID with surrounding timeline context.",
 		{
-			ids: z.array(z.union([z.number(), z.string()])).describe("Memory IDs to expand"),
+			ids: z
+				.array(z.union([z.number(), z.string()]))
+				.max(200)
+				.describe("Memory IDs to expand"),
 			depth_before: z.number().int().min(0).default(3).describe("Timeline items before"),
 			depth_after: z.number().int().min(0).default(3).describe("Timeline items after"),
 			include_observations: z.boolean().default(false).describe("Include full observation details"),
@@ -375,7 +394,7 @@ async function main() {
 		"memory_get_observations",
 		"Fetch multiple memory items by their IDs.",
 		{
-			ids: z.array(z.number().int()).describe("Memory IDs to fetch"),
+			ids: z.array(z.number().int()).max(200).describe("Memory IDs to fetch"),
 		},
 		async (args) => {
 			try {
@@ -437,7 +456,9 @@ async function main() {
 		"memory_remember",
 		"Create a new memory. Use for milestones, decisions, and notable facts.",
 		{
-			kind: z.string().describe(`Memory kind: ${Object.keys(MEMORY_KINDS).join(", ")}`),
+			kind: z
+				.enum(["discovery", "change", "feature", "bugfix", "refactor", "decision", "exploration"])
+				.describe("Memory kind"),
 			title: z.string().describe("Short title"),
 			body: z.string().describe("Body text (high-signal content)"),
 			confidence: z.number().min(0).max(1).default(0.5).describe("Confidence 0-1"),
@@ -445,30 +466,41 @@ async function main() {
 		},
 		async (args) => {
 			try {
-				// Create a transient session for MCP-originated memories.
+				// Create a transient session + memory in a transaction for atomicity.
 				// TS store doesn't have startSession/endSession yet, so
-				// we insert the session row directly.
-				const now = nowIso();
-				const user = process.env.USER ?? "unknown";
-				const cwd = process.cwd();
-				const project = args.project ?? process.env.CODEMEM_PROJECT ?? null;
+				// we insert the session row directly. Wrapped in transaction to
+				// prevent orphaned sessions if remember() fails.
+				const result = store.db.transaction(() => {
+					const now = nowIso();
+					const user = process.env.USER ?? "unknown";
+					const cwd = process.cwd();
+					const project = args.project ?? process.env.CODEMEM_PROJECT ?? null;
 
-				const sessionInfo = store.db
-					.prepare(
-						`INSERT INTO sessions(started_at, ended_at, cwd, project, user, tool_version, metadata_json)
-						 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-					)
-					.run(now, now, cwd, project, user, "mcp-ts", toJson({ mcp: true }));
-				const sessionId = Number(sessionInfo.lastInsertRowid);
+					const sessionInfo = store.db
+						.prepare(
+							`INSERT INTO sessions(started_at, ended_at, cwd, project, user, tool_version, metadata_json)
+							 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+						)
+						.run(now, now, cwd, project, user, "mcp-ts", toJson({ mcp: true }));
+					const sessionId = Number(sessionInfo.lastInsertRowid);
 
-				const memId = store.remember(sessionId, args.kind, args.title, args.body, args.confidence);
+					const memId = store.remember(
+						sessionId,
+						args.kind,
+						args.title,
+						args.body,
+						args.confidence,
+					);
 
-				// End the session
-				store.db
-					.prepare("UPDATE sessions SET ended_at = ?, metadata_json = ? WHERE id = ?")
-					.run(nowIso(), toJson({ mcp: true }), sessionId);
+					// End the session
+					store.db
+						.prepare("UPDATE sessions SET ended_at = ?, metadata_json = ? WHERE id = ?")
+						.run(nowIso(), toJson({ mcp: true }), sessionId);
 
-				return jsonContent({ id: memId });
+					return memId;
+				})();
+
+				return jsonContent({ id: result });
 			} catch (err) {
 				return errorContent(err instanceof Error ? err.message : String(err));
 			}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,12 +42,6 @@ importers:
       '@codemem/core':
         specifier: workspace:*
         version: link:../core
-      '@codemem/mcp-server':
-        specifier: workspace:*
-        version: link:../mcp-server
-      '@codemem/viewer-server':
-        specifier: workspace:*
-        version: link:../viewer-server
       chalk:
         specifier: ^5.6.2
         version: 5.6.2


### PR DESCRIPTION
## Description

Addresses critical review findings across the TS store port — coexistence contract violations, missing data semantics, and security hardening.

### Schema compatibility (db.ts)
- **`MIN_COMPATIBLE_SCHEMA`** — TS now tolerates additive newer schemas per the coexistence contract. Warns on newer versions instead of crashing.
- **Required table validation** — checks `memory_items`, `sessions`, `artifacts`, `raw_events` exist instead of relying on exact version match.

### Provenance resolution (store.ts)
- **`remember()` now writes all provenance fields**: `actor_id`, `actor_display_name`, `visibility`, `workspace_id`, `workspace_kind`, `origin_device_id`, `origin_source`, `trust_state`
- New `resolveProvenance()` matches Python's `_resolve_memory_provenance` — visibility defaults, workspace kind derivation, trust state defaults.

### Project scoping (filters.ts, types.ts)
- Added `project` to `MemoryFilters` with automatic sessions JOIN
- MCP server resolves `CODEMEM_PROJECT` env var as default project scope

### DB path resolution (db.ts)
- New `resolveDbPath(explicit?)` centralizes: explicit arg → `CODEMEM_DB` env → default
- Both CLI and MCP server use it consistently

### MCP hardening (mcp-server/index.ts)
- `kind` uses zod enum — validates at MCP layer before store
- ID arrays capped at `max(200)` — DoS prevention
- `memory_remember` wrapped in SQLite transaction — no orphaned sessions
- Project filter wired through with `CODEMEM_PROJECT` default

### CLI cleanup
- Removed phantom deps on `@codemem/mcp-server`, `@codemem/viewer-server`
- Fixed misleading vite.config.ts comment

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — 121 tests, +1 new)
- [x] Updated schema compatibility tests for new behavior
- [x] Manually verified CLI + MCP against real DB

## Checklist

- [x] Code follows project style (`biome check` passes clean)
- [x] Self-review completed
- [x] Addresses coexistence contract (docs/plans/2026-03-15-db-coexistence-contract.md)
- [x] No new warnings introduced