### PR TITLE
Port plugin ingest pipeline to TypeScript

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,50 @@ export {
 	toJson,
 } from "./db.js";
 export { buildFilterClauses } from "./filters.js";
+// Ingest pipeline
+export {
+	budgetToolEvents,
+	eventToToolEvent,
+	extractAdapterEvent,
+	extractToolEvents,
+	isInternalMemoryTool,
+	LOW_SIGNAL_TOOLS,
+	normalizeToolName,
+	projectAdapterToolEvent,
+} from "./ingest-events.js";
+export { isLowSignalObservation, normalizeObservation } from "./ingest-filters.js";
+export type { IngestOptions } from "./ingest-pipeline.js";
+export { cleanOrphanSessions, ingest, main as ingestMain } from "./ingest-pipeline.js";
+export { buildObserverPrompt } from "./ingest-prompts.js";
+export {
+	isSensitiveFieldName,
+	sanitizePayload,
+	sanitizeToolOutput,
+	stripPrivate,
+	stripPrivateObj,
+} from "./ingest-sanitize.js";
+export {
+	buildTranscript,
+	deriveRequest,
+	extractAssistantMessages,
+	extractAssistantUsage,
+	extractPrompts,
+	firstSentence,
+	isTrivialRequest,
+	normalizeAdapterEvents,
+	normalizeRequestText,
+	TRIVIAL_REQUESTS,
+} from "./ingest-transcript.js";
+export type {
+	IngestPayload,
+	ObserverContext,
+	ParsedObservation,
+	ParsedOutput,
+	ParsedSummary,
+	SessionContext,
+	ToolEvent,
+} from "./ingest-types.js";
+export { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
 export type { ObserverAuthMaterial } from "./observer-auth.js";
 export {
 	buildCodexHeaders,

--- a/packages/core/src/ingest-events.ts
+++ b/packages/core/src/ingest-events.ts
@@ -1,0 +1,311 @@
+/**
+ * Event extraction and budgeting for the ingest pipeline.
+ *
+ * Ports codemem/ingest/events.py + codemem/ingest_tool_events.py —
+ * converts raw plugin events into ToolEvent structs, filters low-signal
+ * tools, deduplicates, and budgets the list to fit observer token limits.
+ */
+
+import { sanitizePayload, sanitizeToolOutput } from "./ingest-sanitize.js";
+import type { ToolEvent } from "./ingest-types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Tools whose output is too noisy / low-signal to send to the observer.
+ * Matches Python's LOW_SIGNAL_TOOLS set.
+ */
+export const LOW_SIGNAL_TOOLS = new Set([
+	"tui",
+	"shell",
+	"cmd",
+	"task",
+	"slashcommand",
+	"skill",
+	"todowrite",
+	"askuserquestion",
+]);
+
+// ---------------------------------------------------------------------------
+// Tool name helpers
+// ---------------------------------------------------------------------------
+
+/** Return true for codemem's own MCP tools (avoids feedback loops). */
+export function isInternalMemoryTool(tool: string): boolean {
+	return tool.startsWith("codemem_memory_");
+}
+
+/** Extract a clean, lowercase tool name from a raw event. */
+export function normalizeToolName(event: Record<string, unknown>): string {
+	let tool = String(event.tool ?? event.type ?? "tool").toLowerCase();
+	if (tool.includes(".")) tool = tool.split(".").pop() ?? tool;
+	if (tool.includes(":")) tool = tool.split(":").pop() ?? tool;
+	return tool;
+}
+
+// ---------------------------------------------------------------------------
+// Output compaction
+// ---------------------------------------------------------------------------
+
+function compactReadOutput(text: string, maxLines = 80, maxChars = 2000): string {
+	if (!text) return "";
+	const allLines = text.split("\n");
+	let lines = allLines;
+	if (lines.length > maxLines) {
+		lines = [...lines.slice(0, maxLines), `... (+${allLines.length - maxLines} more lines)`];
+	}
+	let compacted = lines.join("\n");
+	if (maxChars > 0 && compacted.length > maxChars) {
+		compacted = `${compacted.slice(0, maxChars)}\n... (truncated)`;
+	}
+	return compacted;
+}
+
+function compactListOutput(text: string): string {
+	return compactReadOutput(text, 120, 2400);
+}
+
+// ---------------------------------------------------------------------------
+// Event → ToolEvent conversion
+// ---------------------------------------------------------------------------
+
+/** Convert a single raw event to a ToolEvent, or null if it should be skipped. */
+export function eventToToolEvent(
+	event: Record<string, unknown>,
+	maxChars: number,
+	lowSignalTools: Set<string> = LOW_SIGNAL_TOOLS,
+): ToolEvent | null {
+	if (event.type !== "tool.execute.after") return null;
+
+	const tool = normalizeToolName(event);
+	if (isInternalMemoryTool(tool)) return null;
+	if (lowSignalTools.has(tool)) return null;
+
+	const rawArgs = event.args;
+	const args =
+		rawArgs != null && typeof rawArgs === "object" && !Array.isArray(rawArgs)
+			? (rawArgs as Record<string, unknown>)
+			: {};
+
+	let result = sanitizeToolOutput(tool, event.result, maxChars);
+	if (tool === "read" && typeof result === "string") result = compactReadOutput(result);
+	if (tool === "bash" && typeof result === "string") result = compactReadOutput(result);
+	if ((tool === "glob" || tool === "grep") && typeof result === "string") {
+		result = compactListOutput(result);
+	}
+
+	const error = sanitizePayload(event.error, maxChars);
+
+	return {
+		toolName: tool,
+		toolInput: sanitizePayload(args, maxChars),
+		toolOutput: result,
+		toolError: error,
+		timestamp: typeof event.timestamp === "string" ? event.timestamp : null,
+		cwd:
+			(typeof event.cwd === "string" ? event.cwd : null) ??
+			(typeof args.cwd === "string" ? args.cwd : null),
+	};
+}
+
+/** Filter and convert all events to ToolEvents. */
+export function extractToolEvents(
+	events: Record<string, unknown>[],
+	maxChars: number,
+): ToolEvent[] {
+	const result: ToolEvent[] = [];
+	for (const event of events) {
+		const te = eventToToolEvent(event, maxChars);
+		if (te) result.push(te);
+	}
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter event extraction (schema v1.0)
+// ---------------------------------------------------------------------------
+
+/** Extract validated _adapter event, or null if not a valid v1.0 adapter. */
+export function extractAdapterEvent(
+	event: Record<string, unknown>,
+): Record<string, unknown> | null {
+	const adapter = event._adapter;
+	if (adapter == null || typeof adapter !== "object" || Array.isArray(adapter)) return null;
+	const a = adapter as Record<string, unknown>;
+
+	if (a.schema_version !== "1.0") return null;
+	if (typeof a.source !== "string" || !a.source.trim()) return null;
+	if (typeof a.session_id !== "string" || !a.session_id.trim()) return null;
+	if (typeof a.event_id !== "string" || !a.event_id.trim()) return null;
+
+	const eventType = a.event_type;
+	if (typeof eventType !== "string") return null;
+	const validTypes = new Set([
+		"prompt",
+		"assistant",
+		"tool_call",
+		"tool_result",
+		"session_start",
+		"session_end",
+		"error",
+	]);
+	if (!validTypes.has(eventType)) return null;
+
+	if (a.payload == null || typeof a.payload !== "object") return null;
+	if (typeof a.ts !== "string" || !a.ts.trim()) return null;
+
+	// Validate timestamp parses
+	try {
+		const d = new Date(a.ts as string);
+		if (Number.isNaN(d.getTime())) return null;
+	} catch {
+		return null;
+	}
+
+	return a;
+}
+
+/** Project an adapter tool_result into the flat event format expected by eventToToolEvent. */
+export function projectAdapterToolEvent(
+	adapter: Record<string, unknown>,
+	event: Record<string, unknown>,
+): Record<string, unknown> | null {
+	const eventType = String(adapter.event_type ?? "");
+	const payload = adapter.payload as Record<string, unknown> | undefined;
+	if (!payload || typeof payload !== "object") return null;
+	if (eventType !== "tool_result") return null;
+
+	let toolInput = payload.tool_input;
+	if (toolInput == null || typeof toolInput !== "object") toolInput = {};
+
+	let toolError = payload.tool_error ?? null;
+	if (toolError == null && payload.status === "error") toolError = payload.error ?? null;
+
+	let toolOutput = payload.tool_output ?? null;
+	if (toolOutput == null && "output" in payload) toolOutput = payload.output ?? null;
+
+	return {
+		type: "tool.execute.after",
+		tool: payload.tool_name,
+		args: toolInput,
+		result: toolOutput,
+		error: toolError,
+		timestamp: adapter.ts,
+		cwd: event.cwd,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tool event budgeting
+// ---------------------------------------------------------------------------
+
+function toolEventSignature(event: ToolEvent): string {
+	if (event.toolName === "bash" && event.toolInput != null && typeof event.toolInput === "object") {
+		const input = event.toolInput as Record<string, unknown>;
+		const cmd = String(input.command ?? "")
+			.trim()
+			.toLowerCase();
+		if ((cmd === "git status" || cmd === "git diff") && !event.toolError) {
+			return `bash:${cmd}`;
+		}
+	}
+	const parts: string[] = [event.toolName];
+	try {
+		parts.push(JSON.stringify(event.toolInput));
+	} catch {
+		parts.push(String(event.toolInput));
+	}
+	if (event.toolError) parts.push(String(event.toolError).slice(0, 200));
+	if (typeof event.toolOutput === "string" && event.toolOutput) {
+		parts.push(event.toolOutput.slice(0, 200));
+	}
+	return parts.join("|");
+}
+
+function toolEventImportance(event: ToolEvent): number {
+	let score = 0;
+	if (event.toolError) score += 100;
+	const tool = (event.toolName || "").toLowerCase();
+	if (tool === "edit" || tool === "write") score += 50;
+	else if (tool === "bash") score += 30;
+	else if (tool === "read") score += 20;
+	else score += 10;
+	return score;
+}
+
+function estimateEventSize(event: ToolEvent): number {
+	try {
+		return JSON.stringify(event).length;
+	} catch {
+		return String(event).length;
+	}
+}
+
+/**
+ * Deduplicate, rank, and trim tool events to fit within budget.
+ *
+ * 1. Deduplicates (keeping last occurrence).
+ * 2. If over maxEvents, keeps the most important ones.
+ * 3. If over maxTotalChars, keeps the most important that fit.
+ */
+export function budgetToolEvents(
+	toolEvents: ToolEvent[],
+	maxTotalChars: number,
+	maxEvents: number,
+): ToolEvent[] {
+	if (!toolEvents.length || maxTotalChars <= 0 || maxEvents <= 0) return [];
+
+	// Deduplicate, preferring last occurrence
+	const seen = new Set<string>();
+	const deduped: ToolEvent[] = [];
+	for (let i = toolEvents.length - 1; i >= 0; i--) {
+		const evt = toolEvents[i];
+		if (!evt) continue;
+		const sig = toolEventSignature(evt);
+		if (seen.has(sig)) continue;
+		seen.add(sig);
+		deduped.push(evt);
+	}
+	deduped.reverse();
+
+	// Trim to maxEvents by importance
+	let result = deduped;
+	if (result.length > maxEvents) {
+		const indexed = result.map((e, i) => ({ event: e, idx: i }));
+		indexed.sort((a, b) => {
+			const impDiff = toolEventImportance(b.event) - toolEventImportance(a.event);
+			if (impDiff !== 0) return impDiff;
+			return a.idx - b.idx; // prefer earlier for same importance
+		});
+		const keepIdxs = new Set(indexed.slice(0, maxEvents).map((x) => x.idx));
+		result = result.filter((_, i) => keepIdxs.has(i));
+	}
+
+	// Check total size
+	const totalSize = result.reduce((sum, e) => sum + estimateEventSize(e), 0);
+	if (totalSize <= maxTotalChars) return result;
+
+	// Budget by size — pick most important that fit
+	const indexed = result.map((e, i) => ({ event: e, idx: i }));
+	indexed.sort((a, b) => {
+		const impDiff = toolEventImportance(b.event) - toolEventImportance(a.event);
+		if (impDiff !== 0) return impDiff;
+		return a.idx - b.idx;
+	});
+
+	const kept: { event: ToolEvent; idx: number }[] = [];
+	let runningTotal = 0;
+	for (const item of indexed) {
+		const size = estimateEventSize(item.event);
+		if (runningTotal + size > maxTotalChars && kept.length > 0) continue;
+		kept.push(item);
+		runningTotal += size;
+		if (runningTotal >= maxTotalChars) break;
+	}
+
+	// Restore original order
+	kept.sort((a, b) => a.idx - b.idx);
+	return kept.map((x) => x.event);
+}

--- a/packages/core/src/ingest-filters.ts
+++ b/packages/core/src/ingest-filters.ts
@@ -1,0 +1,54 @@
+/**
+ * Low-signal observation filtering for the ingest pipeline.
+ *
+ * Ports the relevant parts of codemem/summarizer.py — detects observations
+ * that are too generic or noisy to store as memories.
+ */
+
+// ---------------------------------------------------------------------------
+// Patterns that indicate low-signal content
+// ---------------------------------------------------------------------------
+
+/**
+ * Observation-level patterns that indicate content too generic to store.
+ * Empty by default — trust the observer LLM. Only patterns that consistently
+ * get through observer guidance are added here.
+ */
+const LOW_SIGNAL_OBSERVATION_PATTERNS: RegExp[] = [
+	/\bno\s+code\s+changes?\s+(?:were|was)\s+(?:recorded|made)\b/i,
+	/\bno\s+code\s+was\s+modified\b/i,
+	/\bno\s+new\s+(?:code|configuration|config|documentation)(?:\s+or\s+(?:code|configuration|config|documentation))?\s+(?:was|were)\s+(?:shipped|delivered)\b/i,
+	/\bno\s+new\s+deliverables?\b/i,
+	/\bno\s+definitive\s+(?:code\s+rewrite|feature\s+delivery)(?:\s+or\s+(?:code\s+rewrite|feature\s+delivery))?\s+(?:occurred|happened)\b/i,
+	/\bonly\s+file\s+inspection\s+occurred\b/i,
+	/\bonly\s+produced\s+(?:an?\s+)?understanding\b/i,
+	/\bconsisted\s+entirely\s+of\s+capturing\b/i,
+	/\bno\s+fully\s+resolved\s+deliverable\b/i,
+	/\beffort\s+focused\s+on\s+clarifying\b/i,
+	/\bno\s+code\s*,?\s+configuration\s*,?\s+or\s+documentation\s+changes?\s+(?:were|was)\s+made\b/i,
+	/\bwork\s+consisted\s+entirely\s+of\s+capturing\s+the\s+current\s+state\b/i,
+	/\bprimary\s+user\s+request\s+details\s+were\s+absent\b/i,
+];
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Normalize observation text: strip leading bullets/markers, collapse whitespace. */
+export function normalizeObservation(text: string): string {
+	let cleaned = text.trim().replace(/^[\s\-\u2022\u2514\u203a>$]+/, "");
+	cleaned = cleaned.replace(/\s+/g, " ").trim();
+	return cleaned;
+}
+
+/**
+ * Return true if the observation text is too generic / low-signal to store.
+ *
+ * Checks against known patterns of empty or self-referential content that
+ * the observer LLM sometimes generates.
+ */
+export function isLowSignalObservation(text: string): boolean {
+	const normalized = normalizeObservation(text);
+	if (!normalized) return true;
+	return LOW_SIGNAL_OBSERVATION_PATTERNS.some((p) => p.test(normalized));
+}

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -1,0 +1,655 @@
+/**
+ * Tests for the ingest pipeline stages.
+ *
+ * Tests individual stages (not the full pipeline, which requires an LLM mock).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import {
+	budgetToolEvents,
+	extractToolEvents,
+	isInternalMemoryTool,
+	normalizeToolName,
+} from "./ingest-events.js";
+import { isLowSignalObservation, normalizeObservation } from "./ingest-filters.js";
+import { type IngestOptions, ingest } from "./ingest-pipeline.js";
+import { stripPrivate } from "./ingest-sanitize.js";
+import {
+	buildTranscript,
+	deriveRequest,
+	firstSentence,
+	isTrivialRequest,
+	normalizeRequestText,
+} from "./ingest-transcript.js";
+import type { IngestPayload, ParsedSummary, ToolEvent } from "./ingest-types.js";
+import { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema } from "./test-utils.js";
+
+// ---------------------------------------------------------------------------
+// ingest-events
+// ---------------------------------------------------------------------------
+
+describe("ingest-events", () => {
+	describe("normalizeToolName", () => {
+		it("extracts last segment from dotted names", () => {
+			expect(normalizeToolName({ tool: "tool.execute.after" })).toBe("after");
+		});
+
+		it("extracts last segment from colon-separated names", () => {
+			expect(normalizeToolName({ tool: "mcp:read" })).toBe("read");
+		});
+
+		it("lowercases tool names", () => {
+			expect(normalizeToolName({ tool: "BASH" })).toBe("bash");
+		});
+
+		it("falls back to type if tool is missing", () => {
+			expect(normalizeToolName({ type: "tool.execute.after" })).toBe("after");
+		});
+	});
+
+	describe("isInternalMemoryTool", () => {
+		it("detects codemem memory tools", () => {
+			expect(isInternalMemoryTool("codemem_memory_search")).toBe(true);
+			expect(isInternalMemoryTool("codemem_memory_pack")).toBe(true);
+		});
+
+		it("does not flag non-memory tools", () => {
+			expect(isInternalMemoryTool("bash")).toBe(false);
+			expect(isInternalMemoryTool("read")).toBe(false);
+		});
+	});
+
+	describe("extractToolEvents", () => {
+		it("filters out low-signal tools", () => {
+			const events = [
+				{ type: "tool.execute.after", tool: "bash", args: {}, result: "ok" },
+				{ type: "tool.execute.after", tool: "tui", args: {}, result: "ok" },
+				{ type: "tool.execute.after", tool: "edit", args: {}, result: "ok" },
+			];
+			const result = extractToolEvents(events, 2000);
+			const tools = result.map((e) => e.toolName);
+			expect(tools).toContain("bash");
+			expect(tools).toContain("edit");
+			expect(tools).not.toContain("tui");
+		});
+
+		it("skips non tool.execute.after events", () => {
+			const events = [
+				{ type: "user_prompt", prompt_text: "hello" },
+				{ type: "tool.execute.after", tool: "bash", args: {}, result: "ok" },
+			];
+			const result = extractToolEvents(events, 2000);
+			expect(result).toHaveLength(1);
+			expect(result[0]?.toolName).toBe("bash");
+		});
+
+		it("skips codemem memory tools", () => {
+			const events = [
+				{
+					type: "tool.execute.after",
+					tool: "codemem_memory_search",
+					args: {},
+					result: "memories",
+				},
+			];
+			const result = extractToolEvents(events, 2000);
+			expect(result).toHaveLength(0);
+		});
+	});
+
+	describe("budgetToolEvents", () => {
+		function makeEvent(name: string, size = 100): ToolEvent {
+			return {
+				toolName: name,
+				toolInput: "x".repeat(size),
+				toolOutput: null,
+				toolError: null,
+				timestamp: null,
+				cwd: null,
+			};
+		}
+
+		it("returns empty array for empty input", () => {
+			expect(budgetToolEvents([], 5000, 10)).toEqual([]);
+		});
+
+		it("returns empty for zero budget", () => {
+			expect(budgetToolEvents([makeEvent("bash")], 0, 10)).toEqual([]);
+		});
+
+		it("respects maxEvents limit", () => {
+			const events = [makeEvent("a"), makeEvent("b"), makeEvent("c"), makeEvent("d")];
+			const result = budgetToolEvents(events, 100_000, 2);
+			expect(result.length).toBeLessThanOrEqual(2);
+		});
+
+		it("deduplicates identical events", () => {
+			const e1 = makeEvent("bash");
+			const e2 = { ...e1 }; // same signature
+			const result = budgetToolEvents([e1, e2], 100_000, 10);
+			expect(result).toHaveLength(1);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ingest-transcript
+// ---------------------------------------------------------------------------
+
+describe("ingest-transcript", () => {
+	describe("buildTranscript", () => {
+		it("produces chronological text from prompts and messages", () => {
+			const events = [
+				{ type: "user_prompt", prompt_text: "Fix the bug" },
+				{ type: "assistant_message", assistant_text: "I found the issue" },
+				{ type: "user_prompt", prompt_text: "Ship it" },
+			];
+			const transcript = buildTranscript(events);
+			expect(transcript).toContain("User: Fix the bug");
+			expect(transcript).toContain("Assistant: I found the issue");
+			expect(transcript).toContain("User: Ship it");
+			// Check order
+			const fixIdx = transcript.indexOf("Fix the bug");
+			const foundIdx = transcript.indexOf("I found the issue");
+			const shipIdx = transcript.indexOf("Ship it");
+			expect(fixIdx).toBeLessThan(foundIdx);
+			expect(foundIdx).toBeLessThan(shipIdx);
+		});
+
+		it("strips private content", () => {
+			const events = [
+				{ type: "user_prompt", prompt_text: "Hello <private>secret</private> world" },
+			];
+			const transcript = buildTranscript(events);
+			expect(transcript).not.toContain("secret");
+			expect(transcript).toContain("Hello");
+			expect(transcript).toContain("world");
+		});
+
+		it("skips events with empty text", () => {
+			const events = [
+				{ type: "user_prompt", prompt_text: "" },
+				{ type: "assistant_message", assistant_text: "   " },
+				{ type: "user_prompt", prompt_text: "Real prompt" },
+			];
+			const transcript = buildTranscript(events);
+			expect(transcript).toBe("User: Real prompt");
+		});
+	});
+
+	describe("isTrivialRequest", () => {
+		it("detects trivial inputs", () => {
+			expect(isTrivialRequest("yes")).toBe(true);
+			expect(isTrivialRequest("ok")).toBe(true);
+			expect(isTrivialRequest("LGTM")).toBe(true);
+			expect(isTrivialRequest("  approved  ")).toBe(true);
+			expect(isTrivialRequest("")).toBe(true);
+			expect(isTrivialRequest(null)).toBe(true);
+		});
+
+		it("does not flag real requests", () => {
+			expect(isTrivialRequest("Fix the authentication bug")).toBe(false);
+			expect(isTrivialRequest("Add a new endpoint for /api/users")).toBe(false);
+		});
+	});
+
+	describe("normalizeRequestText", () => {
+		it("trims, lowercases, and strips quotes", () => {
+			expect(normalizeRequestText('  "Hello World"  ')).toBe("hello world");
+		});
+
+		it("handles null/empty", () => {
+			expect(normalizeRequestText(null)).toBe("");
+			expect(normalizeRequestText("")).toBe("");
+		});
+	});
+
+	describe("firstSentence", () => {
+		it("extracts first sentence", () => {
+			expect(firstSentence("Fixed the bug. Then deployed.")).toBe("Fixed the bug.");
+		});
+
+		it("strips markdown prefixes", () => {
+			expect(firstSentence("## Overview\nThis is the content.")).toBe(
+				"Overview This is the content.",
+			);
+		});
+	});
+
+	describe("deriveRequest", () => {
+		it("derives from completed field first", () => {
+			const summary: ParsedSummary = {
+				request: "",
+				investigated: "Looked at stuff.",
+				learned: "Learned things.",
+				completed: "Fixed the auth bug. Then cleaned up.",
+				nextSteps: "Deploy.",
+				notes: "",
+				filesRead: [],
+				filesModified: [],
+			};
+			expect(deriveRequest(summary)).toBe("Fixed the auth bug.");
+		});
+
+		it("falls through to next non-empty field", () => {
+			const summary: ParsedSummary = {
+				request: "",
+				investigated: "",
+				learned: "Learned the system uses JWT. Tokens expire.",
+				completed: "",
+				nextSteps: "",
+				notes: "",
+				filesRead: [],
+				filesModified: [],
+			};
+			expect(deriveRequest(summary)).toBe("Learned the system uses JWT.");
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ingest-xml-parser
+// ---------------------------------------------------------------------------
+
+describe("ingest-xml-parser", () => {
+	describe("parseObserverResponse", () => {
+		it("extracts observations and summary", () => {
+			const xml = `
+<observation>
+  <type>bugfix</type>
+  <title>Fixed auth timeout</title>
+  <narrative>The session handler had a race condition.</narrative>
+  <facts><fact>Race in session handler</fact></facts>
+  <concepts><concept>problem-solution</concept></concepts>
+  <files_read><file>src/auth.ts</file></files_read>
+  <files_modified><file>src/auth.ts</file></files_modified>
+</observation>
+
+<summary>
+  <request>Fix the auth bug</request>
+  <investigated>Examined session handler</investigated>
+  <learned>Race condition in event loop</learned>
+  <completed>Fixed the timeout</completed>
+  <next_steps>Add tests</next_steps>
+  <notes>Consider retry logic</notes>
+  <files_read><file>src/auth.ts</file></files_read>
+  <files_modified><file>src/auth.ts</file></files_modified>
+</summary>`;
+
+			const result = parseObserverResponse(xml);
+			expect(result.observations).toHaveLength(1);
+			expect(result.observations[0]?.kind).toBe("bugfix");
+			expect(result.observations[0]?.title).toBe("Fixed auth timeout");
+			expect(result.observations[0]?.narrative).toContain("race condition");
+			expect(result.observations[0]?.facts).toEqual(["Race in session handler"]);
+			expect(result.observations[0]?.concepts).toEqual(["problem-solution"]);
+			expect(result.observations[0]?.filesRead).toEqual(["src/auth.ts"]);
+
+			expect(result.summary).not.toBeNull();
+			expect(result.summary?.request).toBe("Fix the auth bug");
+			expect(result.summary?.completed).toBe("Fixed the timeout");
+			expect(result.skipSummaryReason).toBeNull();
+		});
+
+		it("handles skip_summary", () => {
+			const xml = '<skip_summary reason="low-signal"/>';
+			const result = parseObserverResponse(xml);
+			expect(result.observations).toHaveLength(0);
+			expect(result.summary).toBeNull();
+			expect(result.skipSummaryReason).toBe("low-signal");
+		});
+
+		it("handles empty/malformed XML gracefully", () => {
+			const result = parseObserverResponse("");
+			expect(result.observations).toHaveLength(0);
+			expect(result.summary).toBeNull();
+		});
+
+		it("strips code fences", () => {
+			const xml =
+				"```xml\n<observation><type>change</type><title>Test</title><narrative>Narrative</narrative></observation>\n```";
+			const result = parseObserverResponse(xml);
+			expect(result.observations).toHaveLength(1);
+			expect(result.observations[0]?.title).toBe("Test");
+		});
+
+		it("extracts multiple observations", () => {
+			const xml = `
+<observation><type>feature</type><title>First</title><narrative>N1</narrative></observation>
+<observation><type>bugfix</type><title>Second</title><narrative>N2</narrative></observation>`;
+			const result = parseObserverResponse(xml);
+			expect(result.observations).toHaveLength(2);
+			expect(result.observations[0]?.title).toBe("First");
+			expect(result.observations[1]?.title).toBe("Second");
+		});
+	});
+
+	describe("hasMeaningfulObservation", () => {
+		it("returns true when observations have title or narrative", () => {
+			expect(
+				hasMeaningfulObservation([
+					{
+						kind: "change",
+						title: "Something",
+						narrative: "",
+						subtitle: null,
+						facts: [],
+						concepts: [],
+						filesRead: [],
+						filesModified: [],
+					},
+				]),
+			).toBe(true);
+		});
+
+		it("returns false for empty observations", () => {
+			expect(hasMeaningfulObservation([])).toBe(false);
+		});
+
+		it("returns false when all observations lack title and narrative", () => {
+			expect(
+				hasMeaningfulObservation([
+					{
+						kind: "change",
+						title: "",
+						narrative: "",
+						subtitle: null,
+						facts: [],
+						concepts: [],
+						filesRead: [],
+						filesModified: [],
+					},
+				]),
+			).toBe(false);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ingest-filters
+// ---------------------------------------------------------------------------
+
+describe("ingest-filters", () => {
+	describe("isLowSignalObservation", () => {
+		it("detects low-signal patterns", () => {
+			expect(isLowSignalObservation("No code changes were recorded")).toBe(true);
+			expect(isLowSignalObservation("No new deliverables")).toBe(true);
+			expect(isLowSignalObservation("Only file inspection occurred")).toBe(true);
+		});
+
+		it("allows real observations through", () => {
+			expect(isLowSignalObservation("Fixed race condition in session handler")).toBe(false);
+			expect(isLowSignalObservation("Added OAuth2 PKCE flow to authentication")).toBe(false);
+		});
+
+		it("treats empty text as low-signal", () => {
+			expect(isLowSignalObservation("")).toBe(true);
+			expect(isLowSignalObservation("   ")).toBe(true);
+		});
+	});
+
+	describe("normalizeObservation", () => {
+		it("strips leading bullets and whitespace", () => {
+			expect(normalizeObservation("  - Some observation")).toBe("Some observation");
+			expect(normalizeObservation("• Bullet point")).toBe("Bullet point");
+		});
+
+		it("collapses whitespace", () => {
+			expect(normalizeObservation("  multiple   spaces  ")).toBe("multiple spaces");
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ingest-sanitize
+// ---------------------------------------------------------------------------
+
+describe("ingest-sanitize", () => {
+	describe("stripPrivate", () => {
+		it("removes private blocks", () => {
+			expect(stripPrivate("hello <private>secret</private> world")).toBe("hello  world");
+		});
+
+		it("handles orphaned opening tags", () => {
+			expect(stripPrivate("before <private>after")).toBe("before ");
+		});
+
+		it("handles empty input", () => {
+			expect(stripPrivate("")).toBe("");
+		});
+
+		it("is case-insensitive", () => {
+			expect(stripPrivate("a <PRIVATE>b</PRIVATE> c")).toBe("a  c");
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ingest() integration (mocked observer)
+// ---------------------------------------------------------------------------
+
+describe("ingest() integration", () => {
+	let tmpDir: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-ingest-test-"));
+		const dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	const mockObserver = {
+		observe: async () => ({
+			raw: `<observation>
+				<type>discovery</type>
+				<title>Found the auth bug</title>
+				<narrative>The timeout was caused by a race condition</narrative>
+				<facts><fact>Race in session handler</fact></facts>
+				<concepts><concept>concurrency</concept></concepts>
+				<files_read><file>src/auth.ts</file></files_read>
+				<files_modified></files_modified>
+			</observation>
+			<summary>
+				<request>Fix auth timeout</request>
+				<investigated>Session handling code</investigated>
+				<learned>Race condition in handler</learned>
+				<completed>Fixed the timeout</completed>
+				<next_steps>Add retry logic</next_steps>
+				<notes></notes>
+			</summary>`,
+			parsed: null,
+			provider: "test",
+			model: "test-model",
+		}),
+		getStatus: () => ({
+			provider: "test",
+			model: "test-model",
+			runtime: "test",
+			auth: { source: "none", type: "none", hasToken: false },
+		}),
+	};
+
+	function buildPayload(overrides?: Partial<IngestPayload>): IngestPayload {
+		return {
+			cwd: "/tmp/test-project",
+			events: [
+				{
+					type: "user_prompt",
+					prompt_text: "Fix the auth timeout bug",
+					prompt_number: 1,
+					timestamp: new Date().toISOString(),
+				},
+				{
+					type: "tool.execute.after",
+					tool: "bash",
+					args: { command: "grep -r timeout" },
+					result: "src/auth.ts:42: setTimeout(...)",
+					timestamp: new Date().toISOString(),
+				},
+				{
+					type: "assistant_message",
+					assistant_text: "I found the issue - there's a race condition in the session handler.",
+					timestamp: new Date().toISOString(),
+				},
+			],
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-1",
+				promptCount: 1,
+				toolCount: 1,
+				durationMs: 5000,
+			},
+			...overrides,
+		};
+	}
+
+	it("creates memories from observer response", async () => {
+		const payload = buildPayload();
+		await ingest(payload, store, { observer: mockObserver } as unknown as IngestOptions);
+
+		const memories = store.recent(10);
+		expect(memories.length).toBeGreaterThan(0);
+
+		// Should have at least one observation memory
+		const obs = memories.find((m) => m.title === "Found the auth bug");
+		expect(obs).toBeDefined();
+		expect(obs?.kind).toBe("discovery");
+		expect(obs?.body_text).toContain("race condition");
+
+		// Session should be ended
+		const session = store.db
+			.prepare("SELECT * FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as Record<string, unknown>;
+		expect(session.ended_at).not.toBeNull();
+	});
+
+	it("handles observer returning null gracefully", async () => {
+		const nullObserver = {
+			observe: async () => ({
+				raw: null as string | null,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload();
+		// Should not throw
+		await ingest(payload, store, { observer: nullObserver } as unknown as IngestOptions);
+
+		// No memories created
+		const memories = store.recent(10);
+		expect(memories).toHaveLength(0);
+
+		// Session should still be ended
+		const session = store.db
+			.prepare("SELECT * FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as Record<string, unknown>;
+		expect(session.ended_at).not.toBeNull();
+	});
+
+	it("skips trivial requests", async () => {
+		let observerCalled = false;
+		const trackingObserver = {
+			observe: async () => {
+				observerCalled = true;
+				return { raw: null as string | null, parsed: null, provider: "test", model: "test" };
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			events: [{ type: "user_prompt", prompt_text: "yes", timestamp: new Date().toISOString() }],
+		});
+
+		await ingest(payload, store, { observer: trackingObserver } as unknown as IngestOptions);
+
+		expect(observerCalled).toBe(false);
+
+		// Session should still be ended
+		const session = store.db
+			.prepare("SELECT * FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as Record<string, unknown>;
+		expect(session.ended_at).not.toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// cleanOrphanSessions
+// ---------------------------------------------------------------------------
+
+describe("cleanOrphanSessions", () => {
+	let tmpDir: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-orphan-test-"));
+		const dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("closes stale sessions", async () => {
+		// Dynamically import to get the function
+		const { cleanOrphanSessions } = await import("./ingest-pipeline.js");
+
+		// Insert an old session with no ended_at
+		store.db
+			.prepare("INSERT INTO sessions (started_at, cwd) VALUES (?, ?)")
+			.run("2020-01-01T00:00:00Z", "/tmp");
+
+		const cleaned = cleanOrphanSessions(store, 1);
+		expect(cleaned).toBe(1);
+
+		// Verify it was ended
+		const session = store.db.prepare("SELECT * FROM sessions WHERE id = 1").get() as Record<
+			string,
+			unknown
+		>;
+		expect(session.ended_at).not.toBeNull();
+	});
+
+	it("does not close recent sessions", async () => {
+		const { cleanOrphanSessions } = await import("./ingest-pipeline.js");
+
+		// Insert a recent session with no ended_at
+		store.db
+			.prepare("INSERT INTO sessions (started_at, cwd) VALUES (?, ?)")
+			.run(new Date().toISOString(), "/tmp");
+
+		const cleaned = cleanOrphanSessions(store, 1);
+		expect(cleaned).toBe(0);
+	});
+});

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -1,0 +1,496 @@
+/**
+ * Main ingest pipeline — processes raw coding session events, calls the
+ * observer LLM, and stores extracted memories.
+ *
+ * Ports the `ingest()` function from codemem/plugin_ingest.py.
+ *
+ * Pipeline stages:
+ * 1. Extract session context, events, cwd
+ * 2. Create/find session in store
+ * 3. Extract prompts, tool events, assistant messages
+ * 4. Build transcript
+ * 5. Budget tool events
+ * 6. Build observer context + prompt
+ * 7. Call observer LLM via ObserverClient.observe()
+ * 8. Parse XML response
+ * 9. Filter low-signal observations
+ * 10. Persist observations as memories
+ * 11. Persist session summary
+ * 12. End session
+ */
+
+import { toJson } from "./db.js";
+import {
+	budgetToolEvents,
+	eventToToolEvent,
+	extractAdapterEvent,
+	extractToolEvents,
+	projectAdapterToolEvent,
+} from "./ingest-events.js";
+import { isLowSignalObservation } from "./ingest-filters.js";
+import { buildObserverPrompt } from "./ingest-prompts.js";
+import {
+	buildTranscript,
+	deriveRequest,
+	extractAssistantMessages,
+	extractAssistantUsage,
+	extractPrompts,
+	firstSentence,
+	isTrivialRequest,
+	normalizeAdapterEvents,
+} from "./ingest-transcript.js";
+import type {
+	IngestPayload,
+	ObserverContext,
+	ParsedSummary,
+	SessionContext,
+	ToolEvent,
+} from "./ingest-types.js";
+import { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
+import type { ObserverClient } from "./observer-client.js";
+import type { MemoryStore } from "./store.js";
+
+// ---------------------------------------------------------------------------
+// Allowed memory kinds (matches Python)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_KINDS = new Set([
+	"bugfix",
+	"feature",
+	"refactor",
+	"change",
+	"discovery",
+	"decision",
+	"exploration",
+]);
+
+// ---------------------------------------------------------------------------
+// Path normalization
+// ---------------------------------------------------------------------------
+
+function normalizePath(path: string, repoRoot: string | null): string {
+	if (!path) return "";
+	const cleaned = path.trim();
+	if (!repoRoot) return cleaned;
+	const root = repoRoot.replace(/\/+$/, "");
+	if (cleaned === root) return ".";
+	if (cleaned.startsWith(`${root}/`)) return cleaned.slice(root.length + 1);
+	return cleaned;
+}
+
+function normalizePaths(paths: string[], repoRoot: string | null): string[] {
+	return paths.map((p) => normalizePath(p, repoRoot)).filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Summary body formatting
+// ---------------------------------------------------------------------------
+
+function summaryBody(summary: ParsedSummary): string {
+	const sections: [string, string][] = [
+		["Request", summary.request],
+		["Completed", summary.completed],
+		["Learned", summary.learned],
+		["Investigated", summary.investigated],
+		["Next steps", summary.nextSteps],
+		["Notes", summary.notes],
+	];
+	return sections
+		.filter(([, value]) => value)
+		.map(([label, value]) => `## ${label}\n${value}`)
+		.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Event normalization (adapter projection)
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert raw events with adapter envelopes into normalized flat events.
+ * Handles both tool events (via adapter projection) and transcript events
+ * (via normalizeAdapterEvents).
+ */
+function normalizeEventsForToolExtraction(
+	events: Record<string, unknown>[],
+	maxChars: number,
+): ToolEvent[] {
+	const toolEvents: ToolEvent[] = [];
+	for (const event of events) {
+		const adapter = extractAdapterEvent(event);
+		if (adapter) {
+			// Skip tool_call events (only tool_result matters)
+			if (adapter.event_type === "tool_call") continue;
+			const projected = projectAdapterToolEvent(adapter, event);
+			if (projected) {
+				const te = eventToToolEvent(projected, maxChars);
+				if (te) {
+					toolEvents.push(te);
+					continue;
+				}
+			}
+		}
+		// Direct (non-adapter) events
+		const directEvents = extractToolEvents([event], maxChars);
+		toolEvents.push(...directEvents);
+	}
+	return toolEvents;
+}
+
+// ---------------------------------------------------------------------------
+// Main pipeline
+// ---------------------------------------------------------------------------
+
+export interface IngestOptions {
+	/** Observer LLM client. */
+	observer: ObserverClient;
+	/** Maximum chars per tool event payload (from config). Default 12000. */
+	maxChars?: number;
+	/** Maximum chars for observer total budget. Default 12000. */
+	observerMaxChars?: number;
+	/** Whether to store summaries. Default true. */
+	storeSummary?: boolean;
+	/** Whether to store typed observations. Default true. */
+	storeTyped?: boolean;
+}
+
+/**
+ * Process a batch of raw coding session events through the full ingest pipeline.
+ *
+ * Extracts prompts, tool events, and assistant messages from the payload,
+ * builds a transcript, calls the observer LLM, parses the response,
+ * filters low-signal content, and persists observations + summary.
+ */
+export async function ingest(
+	payload: IngestPayload,
+	store: MemoryStore,
+	options: IngestOptions,
+): Promise<void> {
+	const cwd = payload.cwd ?? process.cwd();
+	const events = payload.events ?? [];
+	if (!Array.isArray(events) || events.length === 0) return;
+
+	const sessionContext = payload.sessionContext ?? {};
+	const storeSummary = options.storeSummary ?? true;
+	const storeTyped = options.storeTyped ?? true;
+	const maxChars = options.maxChars ?? 12_000;
+	const observerMaxChars = options.observerMaxChars ?? 12_000;
+
+	// ------------------------------------------------------------------
+	// Session creation — use store.db directly (matching MCP server pattern)
+	// ------------------------------------------------------------------
+	const now = new Date().toISOString();
+	const project = payload.project ?? null;
+
+	const sessionInfo = store.db
+		.prepare(
+			`INSERT INTO sessions (started_at, cwd, project, user, tool_version, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			now,
+			cwd,
+			project,
+			process.env.USER ?? "unknown",
+			"plugin-ts",
+			toJson({
+				source: "plugin",
+				event_count: events.length,
+				started_at: payload.startedAt,
+				session_context: sessionContext,
+			}),
+		);
+	const sessionId = Number(sessionInfo.lastInsertRowid);
+
+	try {
+		// ------------------------------------------------------------------
+		// Extract data from events
+		// ------------------------------------------------------------------
+		const normalizedEvents = normalizeAdapterEvents(events);
+		const prompts = extractPrompts(normalizedEvents);
+		const promptNumber =
+			prompts.length > 0 ? (prompts[prompts.length - 1]?.promptNumber ?? prompts.length) : null;
+
+		// Tool events — handle adapter projection
+		let toolEvents = normalizeEventsForToolExtraction(events, maxChars);
+
+		// Budget tool events
+		const toolBudget = Math.max(2000, Math.min(8000, observerMaxChars - 5000));
+		toolEvents = budgetToolEvents(toolEvents, toolBudget, 30);
+
+		// Assistant messages
+		const assistantMessages = extractAssistantMessages(normalizedEvents);
+		const assistantUsageEvents = extractAssistantUsage(normalizedEvents);
+		const lastAssistantMessage = assistantMessages.at(-1) ?? null;
+
+		// Latest prompt
+		const latestPrompt =
+			sessionContext.firstPrompt ??
+			(prompts.length > 0 ? prompts[prompts.length - 1]?.promptText : null) ??
+			null;
+
+		// ------------------------------------------------------------------
+		// Should we process?
+		// ------------------------------------------------------------------
+		let shouldProcess =
+			toolEvents.length > 0 ||
+			Boolean(latestPrompt) ||
+			(storeSummary && Boolean(lastAssistantMessage));
+
+		if (
+			latestPrompt &&
+			isTrivialRequest(latestPrompt) &&
+			toolEvents.length === 0 &&
+			!lastAssistantMessage
+		) {
+			shouldProcess = false;
+		}
+
+		if (!shouldProcess) {
+			endSession(store, sessionId, events.length, sessionContext);
+			return;
+		}
+
+		// ------------------------------------------------------------------
+		// Build transcript
+		// ------------------------------------------------------------------
+		const transcript = buildTranscript(normalizedEvents);
+
+		// ------------------------------------------------------------------
+		// Build observer prompt
+		// ------------------------------------------------------------------
+		const sessionSummaryParts: string[] = [];
+		if ((sessionContext.promptCount ?? 0) > 1) {
+			sessionSummaryParts.push(`Session had ${sessionContext.promptCount} prompts`);
+		}
+		if ((sessionContext.toolCount ?? 0) > 0) {
+			sessionSummaryParts.push(`${sessionContext.toolCount} tool executions`);
+		}
+		if ((sessionContext.durationMs ?? 0) > 0) {
+			const durationMin = (sessionContext.durationMs ?? 0) / 60000;
+			sessionSummaryParts.push(`~${durationMin.toFixed(1)} minutes of work`);
+		}
+		if (sessionContext.filesModified?.length) {
+			sessionSummaryParts.push(`Modified: ${sessionContext.filesModified.slice(0, 5).join(", ")}`);
+		}
+		if (sessionContext.filesRead?.length) {
+			sessionSummaryParts.push(`Read: ${sessionContext.filesRead.slice(0, 5).join(", ")}`);
+		}
+		const sessionInfoText = sessionSummaryParts.join("; ");
+
+		let observerPrompt = latestPrompt ?? "";
+		if (sessionInfoText) {
+			observerPrompt = observerPrompt
+				? `${observerPrompt}\n\n[Session context: ${sessionInfoText}]`
+				: `[Session context: ${sessionInfoText}]`;
+		}
+
+		const observerContext: ObserverContext = {
+			project,
+			userPrompt: observerPrompt,
+			promptNumber,
+			toolEvents,
+			lastAssistantMessage: storeSummary ? lastAssistantMessage : null,
+			includeSummary: storeSummary,
+			diffSummary: "",
+			recentFiles: "",
+		};
+
+		const { system, user } = buildObserverPrompt(observerContext);
+
+		// ------------------------------------------------------------------
+		// Call observer LLM
+		// ------------------------------------------------------------------
+		const response = await options.observer.observe(system, user);
+
+		if (!response.raw) {
+			// Surface the failure — silent memory loss is unacceptable
+			const status = options.observer.getStatus();
+			console.warn(
+				`[codemem] Observer returned no output (provider=${response.provider}, model=${response.model}` +
+					`${status.lastError ? `, error=${status.lastError}` : ""}). No memories will be created for this session.`,
+			);
+			endSession(store, sessionId, events.length, sessionContext);
+			return;
+		}
+
+		// ------------------------------------------------------------------
+		// Parse response
+		// ------------------------------------------------------------------
+		const parsed = parseObserverResponse(response.raw);
+
+		// ------------------------------------------------------------------
+		// Filter and persist observations
+		// ------------------------------------------------------------------
+		if (storeTyped && hasMeaningfulObservation(parsed.observations)) {
+			for (const obs of parsed.observations) {
+				const kind = obs.kind.trim().toLowerCase();
+				if (!ALLOWED_KINDS.has(kind)) continue;
+				if (!obs.title && !obs.narrative) continue;
+				if (isLowSignalObservation(obs.title) || isLowSignalObservation(obs.narrative)) {
+					continue;
+				}
+
+				const filesRead = normalizePaths(obs.filesRead, cwd);
+				const filesModified = normalizePaths(obs.filesModified, cwd);
+
+				// Build body text from narrative
+				const bodyParts: string[] = [];
+				if (obs.narrative) bodyParts.push(obs.narrative);
+				if (obs.facts.length > 0) {
+					bodyParts.push(obs.facts.map((f) => `- ${f}`).join("\n"));
+				}
+				const bodyText = bodyParts.join("\n\n");
+
+				store.remember(sessionId, kind, obs.title || obs.narrative, bodyText, 0.5, undefined, {
+					subtitle: obs.subtitle,
+					facts: obs.facts,
+					concepts: obs.concepts,
+					files_read: filesRead,
+					files_modified: filesModified,
+					prompt_number: promptNumber,
+					source: "observer",
+				});
+			}
+		}
+
+		// ------------------------------------------------------------------
+		// Persist session summary
+		// ------------------------------------------------------------------
+		if (storeSummary && parsed.summary && !parsed.skipSummaryReason) {
+			const summary = parsed.summary;
+			if (
+				summary.request ||
+				summary.investigated ||
+				summary.learned ||
+				summary.completed ||
+				summary.nextSteps ||
+				summary.notes
+			) {
+				summary.filesRead = normalizePaths(summary.filesRead, cwd);
+				summary.filesModified = normalizePaths(summary.filesModified, cwd);
+
+				// Derive meaningful request if trivial
+				let request = summary.request;
+				if (isTrivialRequest(request)) {
+					const derived = deriveRequest(summary);
+					if (derived) request = derived;
+				}
+
+				const body = summaryBody(summary);
+				if (body && !isLowSignalObservation(firstSentence(body))) {
+					store.remember(sessionId, "change", request || "Session summary", body, 0.3, undefined, {
+						is_summary: true,
+						prompt_number: promptNumber,
+						files_read: summary.filesRead,
+						files_modified: summary.filesModified,
+						source: "observer_summary",
+					});
+				}
+			}
+		}
+
+		// ------------------------------------------------------------------
+		// Record observer usage
+		// ------------------------------------------------------------------
+		const usageTokenTotal = assistantUsageEvents.reduce((sum, e) => sum + (e.total_tokens ?? 0), 0);
+		store.db
+			.prepare(
+				`INSERT INTO usage_events (session_id, event, tokens_read, tokens_written, created_at, metadata_json)
+				 VALUES (?, ?, ?, ?, ?, ?)`,
+			)
+			.run(
+				sessionId,
+				"observer_call",
+				response.raw.length,
+				transcript.length,
+				new Date().toISOString(),
+				toJson({
+					project,
+					observation_count: parsed.observations.length,
+					has_summary: parsed.summary != null,
+					provider: response.provider,
+					model: response.model,
+					session_usage_tokens: usageTokenTotal,
+				}),
+			);
+
+		// ------------------------------------------------------------------
+		// End session
+		// ------------------------------------------------------------------
+		endSession(store, sessionId, events.length, sessionContext);
+	} catch (err) {
+		// End session even on error
+		try {
+			endSession(store, sessionId, events.length, sessionContext);
+		} catch {
+			// ignore cleanup errors
+		}
+		throw err;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session lifecycle helpers
+// ---------------------------------------------------------------------------
+
+function endSession(
+	store: MemoryStore,
+	sessionId: number,
+	eventCount: number,
+	sessionContext: SessionContext,
+): void {
+	store.db.prepare("UPDATE sessions SET ended_at = ?, metadata_json = ? WHERE id = ?").run(
+		new Date().toISOString(),
+		toJson({
+			post: {},
+			source: "plugin",
+			event_count: eventCount,
+			session_context: sessionContext,
+		}),
+		sessionId,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Orphan session cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Close orphan sessions (started but never ended) older than maxAgeHours.
+ * Returns the number of sessions closed.
+ */
+export function cleanOrphanSessions(store: MemoryStore, maxAgeHours = 24): number {
+	const cutoff = new Date(Date.now() - maxAgeHours * 3600_000).toISOString();
+	const result = store.db
+		.prepare("UPDATE sessions SET ended_at = ? WHERE ended_at IS NULL AND started_at < ?")
+		.run(cutoff, cutoff);
+	return result.changes;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a JSON payload from stdin and run the ingest pipeline.
+ *
+ * This is the TypeScript equivalent of `codemem ingest` — receives events
+ * from the plugin and processes them through the observer LLM.
+ */
+export async function main(store: MemoryStore, observer: ObserverClient): Promise<void> {
+	const chunks: string[] = [];
+	for await (const chunk of process.stdin) {
+		chunks.push(String(chunk));
+	}
+	const raw = chunks.join("");
+	if (!raw.trim()) return;
+
+	let payload: IngestPayload;
+	try {
+		payload = JSON.parse(raw) as IngestPayload;
+	} catch (err) {
+		throw new Error(`codemem: invalid payload: ${err}`);
+	}
+
+	await ingest(payload, store, { observer });
+}

--- a/packages/core/src/ingest-prompts.ts
+++ b/packages/core/src/ingest-prompts.ts
@@ -1,0 +1,232 @@
+/**
+ * Observer prompt construction for the ingest pipeline.
+ *
+ * Ports codemem/observer_prompts.py — builds the system + user prompt
+ * sent to the observer LLM that extracts memories from session transcripts.
+ */
+
+import type { ObserverContext, ToolEvent } from "./ingest-types.js";
+
+// ---------------------------------------------------------------------------
+// Constants — prompt fragments matching Python's observer_prompts.py
+// ---------------------------------------------------------------------------
+
+const OBSERVATION_TYPES = "bugfix, feature, refactor, change, discovery, decision, exploration";
+
+const SYSTEM_IDENTITY =
+	"You are a memory observer creating searchable records of development work " +
+	"FOR FUTURE SESSIONS. Record what was BUILT/FIXED/DEPLOYED/CONFIGURED/LEARNED, " +
+	"not what you (the observer) are doing. These memories help developers " +
+	"recall past work, decisions, learnings, and investigations.";
+
+const RECORDING_FOCUS = `Focus on deliverables, capabilities, AND learnings:
+- What the system NOW DOES differently (new capabilities)
+- What shipped to users/production (features, fixes, configs, docs)
+- What was LEARNED through debugging, investigation, or testing
+- How systems work and why they behave the way they do
+- Changes in technical domains (auth, data, UI, infra, DevOps)
+
+Use outcome-focused verbs: implemented, fixed, deployed, configured, migrated, optimized, added, refactored, discovered, learned, debugged.
+Only describe actions that are clearly supported by the observed context.
+Never invent file changes, API behavior, or code edits that are not explicitly present in the session evidence.`;
+
+const SKIP_GUIDANCE = `Skip routine operations WITHOUT learnings:
+- Empty status checks or listings (unless revealing important state)
+- Package installations with no errors or insights
+- Simple file reads with no discoveries
+- Repetitive operations already documented with no new findings
+If nothing meaningful happened AND nothing was learned:
+- Output no <observation> blocks
+- Output <skip_summary reason="low-signal"/> instead of a <summary> block.`;
+
+const NARRATIVE_GUIDANCE = `Create narratives that tell the complete story:
+- Context: What was the problem or goal? What prompted this work?
+- Investigation: What was examined? What was discovered?
+- Learning: How does it work? Why does it exist? Any gotchas?
+- Implementation: What was changed? What does the code do now?
+- Impact: What's better? What does the system do differently?
+- Next steps: What remains? What should future sessions know?
+
+Aim for ~120-400 words per significant work item.
+Prefer fewer, higher-signal observations over many small ones.
+Include specific details when present: file paths, function names, configuration values.`;
+
+const OUTPUT_GUIDANCE =
+	"Output only XML. Do not include commentary outside XML.\n\n" +
+	"ALWAYS emit at least one <observation> block for any meaningful work. " +
+	"Observations are the PRIMARY output - they capture what was built, fixed, learned, or decided. " +
+	"Also emit a <summary> block to track session progress.\n\n" +
+	"Prefer fewer, more comprehensive observations over many small ones.";
+
+const OBSERVATION_SCHEMA = `<observation>
+  <type>[ ${OBSERVATION_TYPES} ]</type>
+  <title>[Short outcome-focused title - what was achieved or learned]</title>
+  <subtitle>[One sentence explanation of the outcome (max 24 words)]</subtitle>
+  <facts>
+    <fact>[Specific, self-contained statement with concrete details]</fact>
+  </facts>
+  <narrative>[
+    Full context: What was done, how it works, why it matters.
+    Aim for 100-500 words.
+  ]</narrative>
+  <concepts>
+    <concept>[how-it-works, why-it-exists, what-changed, problem-solution, gotcha, pattern, trade-off]</concept>
+  </concepts>
+  <files_read>
+    <file>[full path from project root]</file>
+  </files_read>
+  <files_modified>
+    <file>[full path from project root]</file>
+  </files_modified>
+</observation>`;
+
+const SUMMARY_SCHEMA = `<summary>
+  <request>[What did the user request?]</request>
+  <investigated>[What was explored or examined?]</investigated>
+  <learned>[What was learned about how things work?]</learned>
+  <completed>[What work was done? What shipped?]</completed>
+  <next_steps>[What are the logical next steps?]</next_steps>
+  <notes>[Additional context, insights, or warnings.]</notes>
+  <files_read>
+    <file>[path]</file>
+  </files_read>
+  <files_modified>
+    <file>[path]</file>
+  </files_modified>
+</summary>
+
+If nothing meaningful happened, emit <skip_summary reason="low-signal"/> and do not emit <summary>.
+Otherwise, write a summary that explains the current state of the PRIMARY work.
+
+Only summarize what is evidenced in the session context. Do not infer or fabricate
+file edits, behaviors, or outcomes that are not explicitly observed.
+
+Keep summaries concise (aim for ~150-450 words total across all fields).`;
+
+// ---------------------------------------------------------------------------
+// XML escaping
+// ---------------------------------------------------------------------------
+
+function escapeXml(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&apos;");
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatJson(value: unknown): string {
+	if (value == null) return "";
+	if (typeof value === "string") return value;
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch {
+		return String(value);
+	}
+}
+
+function formatToolEvent(event: ToolEvent): string {
+	const parts = ["<observed_from_primary_session>"];
+	parts.push(`  <what_happened>${escapeXml(event.toolName)}</what_happened>`);
+	if (event.timestamp) {
+		parts.push(`  <occurred_at>${escapeXml(event.timestamp)}</occurred_at>`);
+	}
+	if (event.cwd) {
+		parts.push(`  <working_directory>${escapeXml(event.cwd)}</working_directory>`);
+	}
+	const params = escapeXml(formatJson(event.toolInput));
+	const outcome = escapeXml(formatJson(event.toolOutput));
+	const error = escapeXml(formatJson(event.toolError));
+	if (params) parts.push(`  <parameters>${params}</parameters>`);
+	if (outcome) parts.push(`  <outcome>${outcome}</outcome>`);
+	if (error) parts.push(`  <error>${error}</error>`);
+	parts.push("</observed_from_primary_session>");
+	return parts.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the observer prompt from session context.
+ *
+ * Returns `{ system, user }` — the system prompt contains identity + schema,
+ * the user prompt contains the observed session context.
+ *
+ * The Python version concatenates everything into one prompt string passed as
+ * the user message. We split system/user for cleaner API mapping, but the
+ * content is equivalent.
+ */
+export function buildObserverPrompt(context: ObserverContext): {
+	system: string;
+	user: string;
+} {
+	// System prompt: identity + guidance + schemas
+	const systemBlocks: string[] = [
+		SYSTEM_IDENTITY,
+		"",
+		RECORDING_FOCUS,
+		"",
+		SKIP_GUIDANCE,
+		"",
+		NARRATIVE_GUIDANCE,
+		"",
+		OUTPUT_GUIDANCE,
+		"",
+		"Observation XML schema:",
+		OBSERVATION_SCHEMA,
+	];
+	if (context.includeSummary) {
+		systemBlocks.push("", "Summary XML schema:", SUMMARY_SCHEMA);
+	}
+	const system = systemBlocks.join("\n\n").trim();
+
+	// User prompt: observed session context
+	const userBlocks: string[] = ["Observed session context:"];
+
+	if (context.userPrompt) {
+		const promptBlock = ["<observed_from_primary_session>"];
+		promptBlock.push(`  <user_request>${escapeXml(context.userPrompt)}</user_request>`);
+		if (context.promptNumber != null) {
+			promptBlock.push(`  <prompt_number>${context.promptNumber}</prompt_number>`);
+		}
+		if (context.project) {
+			promptBlock.push(`  <project>${escapeXml(context.project)}</project>`);
+		}
+		promptBlock.push("</observed_from_primary_session>");
+		userBlocks.push(promptBlock.join("\n"));
+	}
+
+	if (context.diffSummary) {
+		userBlocks.push(
+			`<observed_from_primary_session>\n  <diff_summary>${escapeXml(context.diffSummary)}</diff_summary>\n</observed_from_primary_session>`,
+		);
+	}
+
+	if (context.recentFiles) {
+		userBlocks.push(
+			`<observed_from_primary_session>\n  <recent_files>${escapeXml(context.recentFiles)}</recent_files>\n</observed_from_primary_session>`,
+		);
+	}
+
+	for (const event of context.toolEvents) {
+		userBlocks.push(formatToolEvent(event));
+	}
+
+	if (context.includeSummary && context.lastAssistantMessage) {
+		userBlocks.push("Summary context:");
+		userBlocks.push(
+			`<summary_context>\n  <assistant_response>${escapeXml(context.lastAssistantMessage)}</assistant_response>\n</summary_context>`,
+		);
+	}
+
+	const user = userBlocks.join("\n\n").trim();
+
+	return { system, user };
+}

--- a/packages/core/src/ingest-sanitize.ts
+++ b/packages/core/src/ingest-sanitize.ts
@@ -1,0 +1,132 @@
+/**
+ * Text sanitization for the ingest pipeline.
+ *
+ * Ports codemem/ingest_sanitize.py — strips <private> blocks and redacts
+ * sensitive field names from payloads before they reach the observer LLM.
+ */
+
+// ---------------------------------------------------------------------------
+// Private content stripping
+// ---------------------------------------------------------------------------
+
+const PRIVATE_BLOCK_RE = /<private>.*?<\/private>/gis;
+const PRIVATE_OPEN_RE = /<private>/gi;
+const PRIVATE_CLOSE_RE = /<\/private>/gi;
+
+/**
+ * Remove `<private>…</private>` blocks from text.
+ *
+ * Handles matched pairs, orphaned opening tags (truncates at the tag),
+ * and stray closing tags (removed).
+ */
+export function stripPrivate(text: string): string {
+	if (!text) return "";
+	// Remove matched pairs
+	let redacted = text.replace(PRIVATE_BLOCK_RE, "");
+	// Orphaned opening tag — truncate everything after it
+	const openMatch = PRIVATE_OPEN_RE.exec(redacted);
+	if (openMatch) {
+		redacted = redacted.slice(0, openMatch.index);
+	}
+	// Stray closing tags
+	redacted = redacted.replace(PRIVATE_CLOSE_RE, "");
+	return redacted;
+}
+
+// ---------------------------------------------------------------------------
+// Sensitive field detection
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_FIELD_RE =
+	/(?:^|_|-)(?:token|secret|password|passwd|api[_-]?key|authorization|private[_-]?key|cookie)(?:$|_|-)/i;
+
+const REDACTED_VALUE = "[REDACTED]";
+
+export function isSensitiveFieldName(fieldName: string): boolean {
+	const normalized = fieldName.trim().toLowerCase();
+	if (!normalized) return false;
+	return SENSITIVE_FIELD_RE.test(normalized);
+}
+
+// ---------------------------------------------------------------------------
+// Deep sanitization
+// ---------------------------------------------------------------------------
+
+export function stripPrivateObj(value: unknown): unknown {
+	if (typeof value === "string") return stripPrivate(value);
+	if (Array.isArray(value)) return value.map(stripPrivateObj);
+	if (value != null && typeof value === "object") {
+		const result: Record<string, unknown> = {};
+		for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+			if (isSensitiveFieldName(key)) {
+				result[key] = REDACTED_VALUE;
+			} else {
+				result[key] = stripPrivateObj(item);
+			}
+		}
+		return result;
+	}
+	return value;
+}
+
+// ---------------------------------------------------------------------------
+// Payload sanitization (truncation + private stripping)
+// ---------------------------------------------------------------------------
+
+function truncateText(text: string, maxChars: number): string {
+	if (maxChars <= 0) return "";
+	if (text.length <= maxChars) return text;
+	return `${text.slice(0, maxChars)}... (truncated)`;
+}
+
+export function sanitizePayload(value: unknown, maxChars: number): unknown {
+	if (value == null) return null;
+	if (typeof value === "string") {
+		return truncateText(stripPrivate(value), maxChars);
+	}
+	const cleaned = stripPrivateObj(value);
+	try {
+		const serialized = JSON.stringify(cleaned);
+		if (maxChars > 0 && serialized.length > maxChars) {
+			return truncateText(serialized, maxChars);
+		}
+	} catch {
+		const asStr = String(cleaned);
+		if (maxChars > 0 && asStr.length > maxChars) {
+			return truncateText(asStr, maxChars);
+		}
+	}
+	return cleaned;
+}
+
+// ---------------------------------------------------------------------------
+// Low-signal output detection
+// ---------------------------------------------------------------------------
+
+const LOW_SIGNAL_OUTPUTS = new Set([
+	"wrote file successfully.",
+	"wrote file successfully",
+	"file written successfully.",
+	"read file successfully.",
+	"read file successfully",
+	"<file>",
+	"<image>",
+]);
+
+function isLowSignalOutput(output: string): boolean {
+	if (!output) return true;
+	const lines = output
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean);
+	if (lines.length === 0) return true;
+	return lines.every((line) => LOW_SIGNAL_OUTPUTS.has(line.toLowerCase()));
+}
+
+export function sanitizeToolOutput(_tool: string, output: unknown, maxChars: number): unknown {
+	if (output == null) return null;
+	const sanitized = sanitizePayload(output, maxChars);
+	const text = String(sanitized ?? "");
+	if (isLowSignalOutput(text)) return "";
+	return sanitized;
+}

--- a/packages/core/src/ingest-transcript.ts
+++ b/packages/core/src/ingest-transcript.ts
@@ -1,0 +1,205 @@
+/**
+ * Transcript building and request analysis for the ingest pipeline.
+ *
+ * Ports codemem/ingest/transcript.py + relevant extraction functions
+ * from codemem/plugin_ingest.py.
+ */
+
+import { stripPrivate } from "./ingest-sanitize.js";
+import type { ParsedSummary } from "./ingest-types.js";
+
+// ---------------------------------------------------------------------------
+// Trivial request detection
+// ---------------------------------------------------------------------------
+
+export const TRIVIAL_REQUESTS = new Set([
+	"yes",
+	"y",
+	"ok",
+	"okay",
+	"approved",
+	"approve",
+	"looks good",
+	"lgtm",
+	"ship it",
+	"sounds good",
+	"sure",
+	"go ahead",
+	"proceed",
+]);
+
+/** Normalize request text for comparison: trim, strip quotes, collapse whitespace, lowercase. */
+export function normalizeRequestText(text: string | null): string {
+	if (!text) return "";
+	let cleaned = text
+		.trim()
+		.replace(/^["']+|["']+$/g, "")
+		.trim();
+	cleaned = cleaned.replace(/\s+/g, " ");
+	return cleaned.toLowerCase();
+}
+
+/** Check whether the text is a trivial approval/acknowledgement. */
+export function isTrivialRequest(text: string | null): boolean {
+	const normalized = normalizeRequestText(text);
+	if (!normalized) return true;
+	return TRIVIAL_REQUESTS.has(normalized);
+}
+
+// ---------------------------------------------------------------------------
+// Sentence extraction
+// ---------------------------------------------------------------------------
+
+/** Extract the first sentence from text (strip markdown prefixes). */
+export function firstSentence(text: string): string {
+	let cleaned = text
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean)
+		.join(" ");
+	cleaned = cleaned.replace(/^[#*\-\d.\s]+/, "");
+	const parts = cleaned.split(/(?<=[.!?])\s+/);
+	return (parts[0] ?? cleaned).trim();
+}
+
+/** Derive a meaningful request from summary fields when the original is trivial. */
+export function deriveRequest(summary: ParsedSummary): string {
+	const candidates = [
+		summary.completed,
+		summary.learned,
+		summary.investigated,
+		summary.nextSteps,
+		summary.notes,
+	];
+	for (const candidate of candidates) {
+		if (candidate) return firstSentence(candidate);
+	}
+	return "";
+}
+
+// ---------------------------------------------------------------------------
+// Transcript building
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a chronological transcript from user prompts and assistant messages.
+ * Strips private content before including text.
+ */
+export function buildTranscript(events: Record<string, unknown>[]): string {
+	const parts: string[] = [];
+	for (const event of events) {
+		const eventType = event.type;
+		if (eventType === "user_prompt") {
+			const promptText = stripPrivate(String(event.prompt_text ?? "")).trim();
+			if (promptText) parts.push(`User: ${promptText}`);
+		} else if (eventType === "assistant_message") {
+			const assistantText = stripPrivate(String(event.assistant_text ?? "")).trim();
+			if (assistantText) parts.push(`Assistant: ${assistantText}`);
+		}
+	}
+	return parts.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Extraction helpers
+// ---------------------------------------------------------------------------
+
+/** Extract assistant text messages from raw events. */
+export function extractAssistantMessages(events: Record<string, unknown>[]): string[] {
+	const messages: string[] = [];
+	for (const event of events) {
+		if (event.type !== "assistant_message") continue;
+		const text = String(event.assistant_text ?? "").trim();
+		if (text) messages.push(text);
+	}
+	return messages;
+}
+
+/** Extract token usage events from assistant_usage events. */
+export function extractAssistantUsage(events: Record<string, unknown>[]): Record<string, number>[] {
+	const usageEvents: Record<string, number>[] = [];
+	for (const event of events) {
+		if (event.type !== "assistant_usage") continue;
+		const usage = event.usage;
+		if (usage == null || typeof usage !== "object") continue;
+		const u = usage as Record<string, unknown>;
+		const inputTokens = Number(u.input_tokens ?? 0) || 0;
+		const outputTokens = Number(u.output_tokens ?? 0) || 0;
+		const cacheCreation = Number(u.cache_creation_input_tokens ?? 0) || 0;
+		const cacheRead = Number(u.cache_read_input_tokens ?? 0) || 0;
+		const total = inputTokens + outputTokens + cacheCreation;
+		if (total <= 0) continue;
+		usageEvents.push({
+			input_tokens: inputTokens,
+			output_tokens: outputTokens,
+			cache_creation_input_tokens: cacheCreation,
+			cache_read_input_tokens: cacheRead,
+			total_tokens: total,
+		});
+	}
+	return usageEvents;
+}
+
+/** Extract user prompts with prompt numbers from raw events. */
+export function extractPrompts(
+	events: Record<string, unknown>[],
+): { promptText: string; promptNumber: number | null; timestamp: string | null }[] {
+	const prompts: { promptText: string; promptNumber: number | null; timestamp: string | null }[] =
+		[];
+	for (const event of events) {
+		if (event.type !== "user_prompt") continue;
+		const promptText = String(event.prompt_text ?? "").trim();
+		if (!promptText) continue;
+		prompts.push({
+			promptText,
+			promptNumber: typeof event.prompt_number === "number" ? event.prompt_number : null,
+			timestamp: typeof event.timestamp === "string" ? event.timestamp : null,
+		});
+	}
+	return prompts;
+}
+
+/**
+ * Project adapter events into the flat event format used by transcript building.
+ *
+ * Adapter events use the `_adapter` envelope (schema v1.0). This function
+ * converts prompt and assistant adapter events into the standard
+ * `user_prompt` / `assistant_message` shapes so buildTranscript can
+ * process them uniformly.
+ */
+export function normalizeAdapterEvents(
+	events: Record<string, unknown>[],
+): Record<string, unknown>[] {
+	return events.map((event) => {
+		const adapter = event._adapter;
+		if (adapter == null || typeof adapter !== "object" || Array.isArray(adapter)) return event;
+		const a = adapter as Record<string, unknown>;
+		if (a.schema_version !== "1.0") return event;
+
+		const payload = a.payload;
+		if (payload == null || typeof payload !== "object") return event;
+		const p = payload as Record<string, unknown>;
+
+		const eventType = String(a.event_type ?? "");
+		if (eventType === "prompt") {
+			const text = String(p.text ?? "").trim();
+			if (!text) return event;
+			return {
+				type: "user_prompt",
+				prompt_text: text,
+				prompt_number: p.prompt_number ?? null,
+				timestamp: a.ts ?? null,
+			};
+		}
+		if (eventType === "assistant") {
+			const text = String(p.text ?? "").trim();
+			if (!text) return event;
+			return {
+				type: "assistant_message",
+				assistant_text: text,
+				timestamp: a.ts ?? null,
+			};
+		}
+		return event;
+	});
+}

--- a/packages/core/src/ingest-types.ts
+++ b/packages/core/src/ingest-types.ts
@@ -1,0 +1,92 @@
+/**
+ * Types for the ingest pipeline.
+ *
+ * Mirrors the Python dataclasses from codemem/observer_prompts.py and
+ * codemem/xml_parser.py.
+ */
+
+// ---------------------------------------------------------------------------
+// Tool events (input to observer)
+// ---------------------------------------------------------------------------
+
+export interface ToolEvent {
+	toolName: string;
+	toolInput: unknown;
+	toolOutput: unknown;
+	toolError: unknown;
+	timestamp: string | null;
+	cwd: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Observer context (assembled before calling observer LLM)
+// ---------------------------------------------------------------------------
+
+export interface ObserverContext {
+	project: string | null;
+	userPrompt: string;
+	promptNumber: number | null;
+	toolEvents: ToolEvent[];
+	lastAssistantMessage: string | null;
+	includeSummary: boolean;
+	diffSummary: string;
+	recentFiles: string;
+}
+
+// ---------------------------------------------------------------------------
+// Parsed observer output (XML response)
+// ---------------------------------------------------------------------------
+
+export interface ParsedObservation {
+	kind: string;
+	title: string;
+	narrative: string;
+	subtitle: string | null;
+	facts: string[];
+	concepts: string[];
+	filesRead: string[];
+	filesModified: string[];
+}
+
+export interface ParsedSummary {
+	request: string;
+	investigated: string;
+	learned: string;
+	completed: string;
+	nextSteps: string;
+	notes: string;
+	filesRead: string[];
+	filesModified: string[];
+}
+
+export interface ParsedOutput {
+	observations: ParsedObservation[];
+	summary: ParsedSummary | null;
+	skipSummaryReason: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Ingest payload (received from stdin)
+// ---------------------------------------------------------------------------
+
+export interface SessionContext {
+	flushBatch?: Record<string, unknown>;
+	firstPrompt?: string;
+	promptCount?: number;
+	toolCount?: number;
+	durationMs?: number;
+	filesModified?: string[];
+	filesRead?: string[];
+	source?: string;
+	streamId?: string;
+	opencodeSessionId?: string;
+	flusher?: string;
+}
+
+export interface IngestPayload {
+	cwd?: string;
+	events?: Record<string, unknown>[];
+	project?: string;
+	startedAt?: string;
+	sessionContext?: SessionContext;
+}

--- a/packages/core/src/ingest-xml-parser.ts
+++ b/packages/core/src/ingest-xml-parser.ts
@@ -1,0 +1,145 @@
+/**
+ * XML response parser for the observer LLM output.
+ *
+ * Ports codemem/xml_parser.py — uses regex-based parsing to extract
+ * observations and session summaries from the observer's XML response.
+ *
+ * The observer output is structured XML, not arbitrary HTML, so regex
+ * is sufficient (no DOM parser needed).
+ */
+
+import type { ParsedObservation, ParsedOutput, ParsedSummary } from "./ingest-types.js";
+
+// ---------------------------------------------------------------------------
+// Regex patterns
+// ---------------------------------------------------------------------------
+
+// Match <observation> with optional attributes (LLMs sometimes add kind="...")
+const OBSERVATION_BLOCK_RE = /<observation[^>]*>.*?<\/observation>/gs;
+const SUMMARY_BLOCK_RE = /<summary[^>]*>.*?<\/summary>/gs;
+const SKIP_SUMMARY_RE = /<skip_summary(?:\s+reason="(?<reason>[^"]+)")?\s*\/>/i;
+const CODE_FENCE_RE = /```(?:xml)?/gi;
+
+// ---------------------------------------------------------------------------
+// Text extraction helpers
+// ---------------------------------------------------------------------------
+
+/** Remove code fences and trim whitespace. */
+function cleanXmlText(text: string): string {
+	return text.replace(CODE_FENCE_RE, "").trim();
+}
+
+/** Extract text content from within a single XML tag. Returns empty string if not found. */
+function extractTagText(xml: string, tag: string): string {
+	const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, "i");
+	const match = re.exec(xml);
+	if (!match?.[1]) return "";
+	return match[1].trim();
+}
+
+/** Extract text content of repeated child elements within a parent tag. */
+function extractChildTexts(xml: string, parentTag: string, childTag: string): string[] {
+	const parentRe = new RegExp(`<${parentTag}[^>]*>([\\s\\S]*?)</${parentTag}>`, "i");
+	const parentMatch = parentRe.exec(xml);
+	if (!parentMatch?.[1]) return [];
+
+	const childRe = new RegExp(`<${childTag}[^>]*>([\\s\\S]*?)</${childTag}>`, "gi");
+	const items: string[] = [];
+	for (
+		let match = childRe.exec(parentMatch[1]);
+		match !== null;
+		match = childRe.exec(parentMatch[1])
+	) {
+		const text = match[1]?.trim();
+		if (text) items.push(text);
+	}
+	return items;
+}
+
+// ---------------------------------------------------------------------------
+// Block parsers
+// ---------------------------------------------------------------------------
+
+function parseObservationBlock(block: string): ParsedObservation | null {
+	// Minimal validation — must have at least a type or title
+	const kind = extractTagText(block, "type");
+	const title = extractTagText(block, "title");
+	if (!kind && !title) return null;
+
+	return {
+		kind,
+		title,
+		narrative: extractTagText(block, "narrative"),
+		subtitle: extractTagText(block, "subtitle") || null,
+		facts: extractChildTexts(block, "facts", "fact"),
+		concepts: extractChildTexts(block, "concepts", "concept"),
+		filesRead: extractChildTexts(block, "files_read", "file"),
+		filesModified: extractChildTexts(block, "files_modified", "file"),
+	};
+}
+
+function parseSummaryBlock(block: string): ParsedSummary | null {
+	const request = extractTagText(block, "request");
+	const investigated = extractTagText(block, "investigated");
+	const learned = extractTagText(block, "learned");
+	const completed = extractTagText(block, "completed");
+	const nextSteps = extractTagText(block, "next_steps");
+	const notes = extractTagText(block, "notes");
+
+	// At least one field must be populated
+	if (!request && !investigated && !learned && !completed && !nextSteps && !notes) {
+		return null;
+	}
+
+	return {
+		request,
+		investigated,
+		learned,
+		completed,
+		nextSteps,
+		notes,
+		filesRead: extractChildTexts(block, "files_read", "file"),
+		filesModified: extractChildTexts(block, "files_modified", "file"),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the observer LLM's XML response into structured data.
+ *
+ * Extracts all `<observation>` blocks and the last `<summary>` block.
+ * Handles missing/empty tags gracefully.
+ */
+export function parseObserverResponse(raw: string): ParsedOutput {
+	const cleaned = cleanXmlText(raw);
+
+	// Extract observations
+	const observations: ParsedObservation[] = [];
+	const obsBlocks = cleaned.match(OBSERVATION_BLOCK_RE) ?? [];
+	for (const block of obsBlocks) {
+		const parsed = parseObservationBlock(block);
+		if (parsed) observations.push(parsed);
+	}
+
+	// Extract summary (use last block if multiple)
+	let summary: ParsedSummary | null = null;
+	const summaryBlocks = cleaned.match(SUMMARY_BLOCK_RE) ?? [];
+	const lastSummaryBlock = summaryBlocks.at(-1);
+	if (lastSummaryBlock) {
+		summary = parseSummaryBlock(lastSummaryBlock);
+	}
+
+	// Check for skip_summary
+	const skipMatch = SKIP_SUMMARY_RE.exec(cleaned);
+	const skipReason = skipMatch?.groups?.reason ?? null;
+
+	return { observations, summary, skipSummaryReason: skipReason };
+}
+
+/** Return true if at least one observation has a title or narrative. */
+export function hasMeaningfulObservation(observations: ParsedObservation[]): boolean {
+	return observations.some((obs) => obs.title || obs.narrative);
+}

--- a/packages/core/src/observer-auth.ts
+++ b/packages/core/src/observer-auth.ts
@@ -148,10 +148,11 @@ export function buildCodexHeaders(
 export function runAuthCommand(command: string[], timeoutMs: number): string | null {
 	const cmd = command[0];
 	if (!cmd) return null;
-	const timeoutS = Math.max(100, timeoutMs);
+	// execFileSync timeout is in milliseconds
+	const effectiveTimeoutMs = Math.max(100, timeoutMs);
 	try {
 		const stdout = execFileSync(cmd, command.slice(1), {
-			timeout: timeoutS,
+			timeout: effectiveTimeoutMs,
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "pipe"],
 		});


### PR DESCRIPTION
## Description

Ports the full plugin ingest pipeline from Python (`codemem/plugin_ingest.py` + `codemem/ingest/*.py` + `codemem/xml_parser.py` + `codemem/summarizer.py` — ~2000 lines total) to TypeScript. This is the core pipeline that turns raw coding session events into stored memories.

### Pipeline stages:
1. **Receive** — JSON payload with events, cwd, session_context
2. **Extract** — user prompts, assistant messages, tool events (with adapter v1.0 support)
3. **Budget** — deduplicate and trim tool events to token budget
4. **Transcript** — build chronological text from prompts + assistant messages
5. **Prompt** — construct system/user prompts for the observer LLM
6. **Observe** — call LLM via ObserverClient.observe()
7. **Parse** — regex-based XML parsing of observations + session summary
8. **Filter** — reject low-signal observations (13 noise patterns)
9. **Persist** — store observations as memories, session summary, usage tracking

### New modules (8 files, ~1800 lines):
- `ingest-types.ts` — ToolEvent, ObserverContext, ParsedOutput, SessionContext, IngestPayload
- `ingest-events.ts` — tool event extraction, adapter projection, budgeting, LOW_SIGNAL_TOOLS
- `ingest-transcript.ts` — transcript building, prompt/message/usage extraction
- `ingest-xml-parser.ts` — regex XML parser for observer response
- `ingest-prompts.ts` — system/user prompt construction for observer LLM
- `ingest-filters.ts` — low-signal observation detection
- `ingest-sanitize.ts` — private content stripping, payload sanitization
- `ingest-pipeline.ts` — main `ingest()` orchestrator + `main()` stdin entry point

41 new tests covering all pipeline stages. 209 total.

Closes: codemem-9hl

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run check` — 209 tests)
- [x] 41 new tests covering event extraction, transcript building, XML parsing, low-signal detection, sanitization
- [x] Pipeline stages tested individually (full integration requires LLM)

## Checklist

- [x] Code follows project style (`biome check` — remaining warnings are intentional `${auth.*}` template patterns)
- [x] Self-review completed
- [x] No new errors introduced