### PR TITLE
Port sync identity module to TypeScript

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,18 @@ export {
 	timeline,
 } from "./search.js";
 export { MemoryStore } from "./store.js";
+export type { EnsureDeviceIdentityOptions } from "./sync-identity.js";
+export {
+	ensureDeviceIdentity,
+	fingerprintPublicKey,
+	generateKeypair,
+	loadPrivateKey,
+	loadPrivateKeyKeychain,
+	loadPublicKey,
+	resolveKeyPaths,
+	storePrivateKeyKeychain,
+	validateExistingKeypair,
+} from "./sync-identity.js";
 
 export type {
 	Actor,

--- a/packages/core/src/sync-identity.test.ts
+++ b/packages/core/src/sync-identity.test.ts
@@ -1,0 +1,219 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import {
+	ensureDeviceIdentity,
+	fingerprintPublicKey,
+	generateKeypair,
+	loadPrivateKey,
+	loadPublicKey,
+	resolveKeyPaths,
+	validateExistingKeypair,
+} from "./sync-identity.js";
+import { initTestSchema } from "./test-utils.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sshKeygenAvailable(): boolean {
+	try {
+		execFileSync("which", ["ssh-keygen"], { stdio: "pipe" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+const HAS_SSH_KEYGEN = sshKeygenAvailable();
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("sync-identity", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-sync-id-test-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// -- fingerprintPublicKey -----------------------------------------------
+
+	describe("fingerprintPublicKey", () => {
+		it("produces consistent SHA-256 hex", () => {
+			const key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey test@host";
+			const fp1 = fingerprintPublicKey(key);
+			const fp2 = fingerprintPublicKey(key);
+			expect(fp1).toBe(fp2);
+			expect(fp1).toMatch(/^[0-9a-f]{64}$/);
+		});
+
+		it("different keys produce different fingerprints", () => {
+			const fp1 = fingerprintPublicKey("key-a");
+			const fp2 = fingerprintPublicKey("key-b");
+			expect(fp1).not.toBe(fp2);
+		});
+	});
+
+	// -- resolveKeyPaths ----------------------------------------------------
+
+	describe("resolveKeyPaths", () => {
+		it("returns correct paths for custom dir", () => {
+			const [priv, pub] = resolveKeyPaths("/tmp/mykeys");
+			expect(priv).toBe("/tmp/mykeys/device.key");
+			expect(pub).toBe("/tmp/mykeys/device.key.pub");
+		});
+
+		it("uses default dir when none provided", () => {
+			const [priv, pub] = resolveKeyPaths();
+			expect(priv).toContain("device.key");
+			expect(pub).toContain("device.key.pub");
+			expect(priv).toContain(".config/codemem/keys");
+		});
+	});
+
+	// -- generateKeypair ----------------------------------------------------
+
+	describe("generateKeypair", () => {
+		it.skipIf(!HAS_SSH_KEYGEN)("creates key files on disk", () => {
+			const keysDir = join(tmpDir, "keys");
+			const [privPath, pubPath] = resolveKeyPaths(keysDir);
+			generateKeypair(privPath, pubPath);
+
+			const privContent = readFileSync(privPath, "utf-8");
+			const pubContent = readFileSync(pubPath, "utf-8");
+			expect(privContent).toContain("PRIVATE KEY");
+			expect(pubContent).toMatch(/^ssh-ed25519 /);
+		});
+
+		it.skipIf(!HAS_SSH_KEYGEN)("is idempotent when keys exist", () => {
+			const keysDir = join(tmpDir, "keys");
+			const [privPath, pubPath] = resolveKeyPaths(keysDir);
+			generateKeypair(privPath, pubPath);
+			const pub1 = readFileSync(pubPath, "utf-8");
+			// Second call should not regenerate
+			generateKeypair(privPath, pubPath);
+			const pub2 = readFileSync(pubPath, "utf-8");
+			expect(pub1).toBe(pub2);
+		});
+	});
+
+	// -- validateExistingKeypair --------------------------------------------
+
+	describe("validateExistingKeypair", () => {
+		it("returns false when files do not exist", () => {
+			expect(validateExistingKeypair("/no/such/priv", "/no/such/pub")).toBe(false);
+		});
+
+		it.skipIf(!HAS_SSH_KEYGEN)("returns true for valid generated keypair", () => {
+			const keysDir = join(tmpDir, "keys");
+			const [privPath, pubPath] = resolveKeyPaths(keysDir);
+			generateKeypair(privPath, pubPath);
+			expect(validateExistingKeypair(privPath, pubPath)).toBe(true);
+		});
+
+		it("returns false for invalid public key content", () => {
+			const keysDir = join(tmpDir, "keys-invalid");
+			const [privPath, pubPath] = resolveKeyPaths(keysDir);
+			mkdirSync(keysDir, { recursive: true });
+			writeFileSync(privPath, "fake-private-key\n");
+			writeFileSync(pubPath, "not-a-valid-key\n");
+			expect(validateExistingKeypair(privPath, pubPath)).toBe(false);
+		});
+	});
+
+	// -- loadPublicKey / loadPrivateKey --------------------------------------
+
+	describe("loadPublicKey", () => {
+		it("returns null when file does not exist", () => {
+			expect(loadPublicKey(join(tmpDir, "nope"))).toBeNull();
+		});
+
+		it.skipIf(!HAS_SSH_KEYGEN)("reads generated public key", () => {
+			const keysDir = join(tmpDir, "keys");
+			const [privPath, pubPath] = resolveKeyPaths(keysDir);
+			generateKeypair(privPath, pubPath);
+			const key = loadPublicKey(keysDir);
+			expect(key).toMatch(/^ssh-ed25519 /);
+		});
+	});
+
+	describe("loadPrivateKey", () => {
+		it("returns null when file does not exist", () => {
+			expect(loadPrivateKey(join(tmpDir, "nope"))).toBeNull();
+		});
+
+		it.skipIf(!HAS_SSH_KEYGEN)("reads generated private key", () => {
+			const keysDir = join(tmpDir, "keys");
+			const [privPath, pubPath] = resolveKeyPaths(keysDir);
+			generateKeypair(privPath, pubPath);
+			const key = loadPrivateKey(keysDir);
+			expect(key).not.toBeNull();
+			expect(key?.toString("utf-8")).toContain("PRIVATE KEY");
+		});
+	});
+
+	// -- ensureDeviceIdentity -----------------------------------------------
+
+	describe("ensureDeviceIdentity", () => {
+		function makeDb() {
+			const dbPath = join(tmpDir, `test-${Date.now()}.sqlite`);
+			const db = connect(dbPath);
+			initTestSchema(db);
+			return db;
+		}
+
+		it.skipIf(!HAS_SSH_KEYGEN)("creates new device in fresh DB", () => {
+			const db = makeDb();
+			const keysDir = join(tmpDir, "keys-new");
+			try {
+				const [deviceId, fingerprint] = ensureDeviceIdentity(db, { keysDir });
+				expect(deviceId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+				expect(fingerprint).toMatch(/^[0-9a-f]{64}$/);
+
+				// Verify DB row
+				const row = db.prepare("SELECT device_id, fingerprint FROM sync_device LIMIT 1").get() as {
+					device_id: string;
+					fingerprint: string;
+				};
+				expect(row.device_id).toBe(deviceId);
+				expect(row.fingerprint).toBe(fingerprint);
+			} finally {
+				db.close();
+			}
+		});
+
+		it.skipIf(!HAS_SSH_KEYGEN)("returns existing device on second call", () => {
+			const db = makeDb();
+			const keysDir = join(tmpDir, "keys-existing");
+			try {
+				const [id1, fp1] = ensureDeviceIdentity(db, { keysDir });
+				const [id2, fp2] = ensureDeviceIdentity(db, { keysDir });
+				expect(id2).toBe(id1);
+				expect(fp2).toBe(fp1);
+			} finally {
+				db.close();
+			}
+		});
+
+		it.skipIf(!HAS_SSH_KEYGEN)("uses provided deviceId", () => {
+			const db = makeDb();
+			const keysDir = join(tmpDir, "keys-custom-id");
+			const customId = "custom-device-id-123";
+			try {
+				const [deviceId] = ensureDeviceIdentity(db, { keysDir, deviceId: customId });
+				expect(deviceId).toBe(customId);
+			} finally {
+				db.close();
+			}
+		});
+	});
+});

--- a/packages/core/src/sync-identity.ts
+++ b/packages/core/src/sync-identity.ts
@@ -1,0 +1,359 @@
+/**
+ * Device identity management for the codemem sync system.
+ *
+ * Handles Ed25519 keypair generation, fingerprinting, and optional
+ * keychain storage. Ported from codemem/sync_identity.py.
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { Database } from "./db.js";
+import { connect as connectDb, resolveDbPath } from "./db.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_KEYS_DIR = join(homedir(), ".config", "codemem", "keys");
+const PRIVATE_KEY_NAME = "device.key";
+const PUBLIC_KEY_NAME = "device.key.pub";
+const KEYCHAIN_SERVICE = "codemem-sync";
+
+// ---------------------------------------------------------------------------
+// Fingerprint
+// ---------------------------------------------------------------------------
+
+/** SHA-256 hex digest of a public key string. */
+export function fingerprintPublicKey(publicKey: string): string {
+	return createHash("sha256").update(publicKey, "utf-8").digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Key store mode
+// ---------------------------------------------------------------------------
+
+function keyStoreMode(): "file" | "keychain" {
+	const env = process.env.CODEMEM_SYNC_KEY_STORE?.toLowerCase();
+	if (env === "keychain") return "keychain";
+	return "file";
+}
+
+// ---------------------------------------------------------------------------
+// CLI availability helpers
+// ---------------------------------------------------------------------------
+
+function cliAvailable(cmd: string): boolean {
+	try {
+		execFileSync("which", [cmd], { stdio: "pipe" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function sshKeygenAvailable(): boolean {
+	return cliAvailable("ssh-keygen");
+}
+
+// ---------------------------------------------------------------------------
+// Keychain storage (platform-specific)
+// ---------------------------------------------------------------------------
+
+function warnKeychainLimitations(): void {
+	if (process.platform !== "darwin") return;
+	if (keyStoreMode() !== "keychain") return;
+	if (process.env.CODEMEM_SYNC_KEYCHAIN_WARN === "0") return;
+	console.warn(
+		"[codemem] keychain storage on macOS uses the `security` CLI and may expose the key in process arguments.",
+	);
+}
+
+/** Store a private key in the OS keychain. Returns true on success. */
+export function storePrivateKeyKeychain(privateKey: Buffer, deviceId: string): boolean {
+	if (process.platform === "linux") {
+		if (!cliAvailable("secret-tool")) return false;
+		try {
+			execFileSync(
+				"secret-tool",
+				["store", "--label", "codemem sync key", "service", KEYCHAIN_SERVICE, "account", deviceId],
+				{ input: privateKey, stdio: ["pipe", "pipe", "pipe"] },
+			);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+	if (process.platform === "darwin") {
+		if (!cliAvailable("security")) return false;
+		try {
+			execFileSync(
+				"security",
+				[
+					"add-generic-password",
+					"-a",
+					deviceId,
+					"-s",
+					KEYCHAIN_SERVICE,
+					"-w",
+					privateKey.toString("utf-8"),
+					"-U",
+				],
+				{ stdio: ["pipe", "pipe", "pipe"] },
+			);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+	return false;
+}
+
+/** Load a private key from the OS keychain. Returns null if unavailable. */
+export function loadPrivateKeyKeychain(deviceId: string): Buffer | null {
+	if (process.platform === "linux") {
+		if (!cliAvailable("secret-tool")) return null;
+		try {
+			const out = execFileSync(
+				"secret-tool",
+				["lookup", "service", KEYCHAIN_SERVICE, "account", deviceId],
+				{ stdio: ["pipe", "pipe", "pipe"] },
+			);
+			return Buffer.from(out);
+		} catch {
+			return null;
+		}
+	}
+	if (process.platform === "darwin") {
+		if (!cliAvailable("security")) return null;
+		try {
+			const out = execFileSync(
+				"security",
+				["find-generic-password", "-a", deviceId, "-s", KEYCHAIN_SERVICE, "-w"],
+				{ stdio: ["pipe", "pipe", "pipe"] },
+			);
+			return Buffer.from(out);
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Key path resolution
+// ---------------------------------------------------------------------------
+
+/** Resolve private and public key file paths. */
+export function resolveKeyPaths(keysDir?: string): [string, string] {
+	const dir = keysDir ?? DEFAULT_KEYS_DIR;
+	return [join(dir, PRIVATE_KEY_NAME), join(dir, PUBLIC_KEY_NAME)];
+}
+
+// ---------------------------------------------------------------------------
+// Key file I/O
+// ---------------------------------------------------------------------------
+
+/** Read the public key from disk. Returns null if missing or empty. */
+export function loadPublicKey(keysDir?: string): string | null {
+	const [, publicPath] = resolveKeyPaths(keysDir);
+	if (!existsSync(publicPath)) return null;
+	const content = readFileSync(publicPath, "utf-8").trim();
+	return content || null;
+}
+
+/** Read the private key from disk (with keychain fallback). Returns null if unavailable. */
+export function loadPrivateKey(keysDir?: string, dbPath?: string): Buffer | null {
+	if (keyStoreMode() === "keychain") {
+		const deviceId = loadDeviceId(dbPath);
+		if (deviceId) {
+			const keychainValue = loadPrivateKeyKeychain(deviceId);
+			if (keychainValue) return keychainValue;
+		}
+	}
+	const [privatePath] = resolveKeyPaths(keysDir);
+	if (!existsSync(privatePath)) return null;
+	return readFileSync(privatePath);
+}
+
+/** Load device_id from the database (for keychain lookups). */
+function loadDeviceId(dbPath?: string): string | null {
+	const path = resolveDbPath(dbPath);
+	if (!existsSync(path)) return null;
+	const conn = connectDb(path);
+	try {
+		const row = conn.prepare("SELECT device_id FROM sync_device LIMIT 1").get() as
+			| { device_id: string }
+			| undefined;
+		return row?.device_id ?? null;
+	} finally {
+		conn.close();
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Key generation & validation
+// ---------------------------------------------------------------------------
+
+function publicKeyLooksValid(publicKey: string): boolean {
+	const value = publicKey.trim();
+	return (
+		value.startsWith("ssh-ed25519 ") || value.startsWith("ssh-rsa ") || value.startsWith("ecdsa-")
+	);
+}
+
+function backupInvalidKeyFile(path: string, stamp: string): void {
+	if (!existsSync(path)) return;
+	const backupPath = path.replace(/([^/]+)$/, `$1.invalid-${stamp}`);
+	renameSync(path, backupPath);
+}
+
+/** Generate an Ed25519 keypair using ssh-keygen. */
+export function generateKeypair(privatePath: string, publicPath: string): void {
+	mkdirSync(dirname(privatePath), { recursive: true });
+	if (existsSync(privatePath) && existsSync(publicPath)) return;
+	if (!sshKeygenAvailable()) {
+		throw new Error("ssh-keygen not available for key generation");
+	}
+
+	if (existsSync(privatePath) && !existsSync(publicPath)) {
+		// Private key exists but public is missing — derive public from private
+		try {
+			const result = execFileSync("ssh-keygen", ["-y", "-f", privatePath], {
+				encoding: "utf-8",
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+			const derivedKey = (result ?? "").trim();
+			if (derivedKey && publicKeyLooksValid(derivedKey)) {
+				writeFileSync(publicPath, `${derivedKey}\n`, { mode: 0o644 });
+				return;
+			}
+		} catch {
+			// Derivation failed — fall through to full regeneration with backup
+		}
+		// Back up the orphaned private key before regenerating
+		const stamp = new Date().toISOString().replace(/[:.]/g, "");
+		renameSync(privatePath, `${privatePath}.orphan-${stamp}`);
+	}
+
+	execFileSync("ssh-keygen", ["-t", "ed25519", "-N", "", "-f", privatePath, "-q"], {
+		stdio: ["pipe", "pipe", "pipe"],
+	});
+	chmodSync(privatePath, 0o600);
+	if (!existsSync(publicPath)) {
+		throw new Error("public key generation failed");
+	}
+}
+
+/** Validate that an existing keypair is consistent. */
+export function validateExistingKeypair(privatePath: string, publicPath: string): boolean {
+	if (!existsSync(privatePath) || !existsSync(publicPath)) return false;
+	const publicKey = readFileSync(publicPath, "utf-8").trim();
+	if (!publicKey || !publicKeyLooksValid(publicKey)) return false;
+	if (!sshKeygenAvailable()) return true;
+	try {
+		const derived = execFileSync("ssh-keygen", ["-y", "-f", privatePath], {
+			stdio: ["pipe", "pipe", "pipe"],
+			encoding: "utf-8",
+		}).trim();
+		if (!derived || !publicKeyLooksValid(derived)) return false;
+		// Auto-fix mismatched public key file
+		if (derived !== publicKey) {
+			writeFileSync(publicPath, `${derived}\n`, "utf-8");
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Main entry: ensure device identity
+// ---------------------------------------------------------------------------
+
+export interface EnsureDeviceIdentityOptions {
+	keysDir?: string;
+	deviceId?: string;
+}
+
+/**
+ * Ensure this device has a keypair and a row in the sync_device table.
+ *
+ * Returns [deviceId, fingerprint]. Creates keys and DB row if missing,
+ * validates and repairs if existing.
+ */
+export function ensureDeviceIdentity(
+	db: Database,
+	options?: EnsureDeviceIdentityOptions,
+): [string, string] {
+	const keysDir = options?.keysDir ?? DEFAULT_KEYS_DIR;
+	const [privatePath, publicPath] = resolveKeyPaths(keysDir);
+	warnKeychainLimitations();
+
+	// Check for existing device row
+	const row = db
+		.prepare("SELECT device_id, public_key, fingerprint FROM sync_device LIMIT 1")
+		.get() as { device_id: string; public_key: string; fingerprint: string } | undefined;
+	const existingDeviceId = row?.device_id ?? "";
+	const existingPublicKey = row?.public_key ?? "";
+	const existingFingerprint = row?.fingerprint ?? "";
+
+	// Validate or regenerate keys
+	let keysReady = existsSync(privatePath) && existsSync(publicPath);
+	if (keysReady && !validateExistingKeypair(privatePath, publicPath)) {
+		const stamp = new Date()
+			.toISOString()
+			.replace(/[-:T.Z]/g, "")
+			.slice(0, 20);
+		backupInvalidKeyFile(privatePath, stamp);
+		backupInvalidKeyFile(publicPath, stamp);
+		keysReady = false;
+	}
+	if (!keysReady) {
+		generateKeypair(privatePath, publicPath);
+	}
+
+	const publicKey = readFileSync(publicPath, "utf-8").trim();
+	if (!publicKey) {
+		throw new Error("public key missing");
+	}
+	const fingerprint = fingerprintPublicKey(publicKey);
+	const now = new Date().toISOString();
+
+	// Update existing device row if keys changed
+	if (existingDeviceId) {
+		if (existingPublicKey !== publicKey || existingFingerprint !== fingerprint) {
+			db.prepare("UPDATE sync_device SET public_key = ?, fingerprint = ? WHERE device_id = ?").run(
+				publicKey,
+				fingerprint,
+				existingDeviceId,
+			);
+		}
+		if (keyStoreMode() === "keychain") {
+			// Read key from file directly — don't go through loadPrivateKey
+			// which would resolve device ID from the default DB
+			const privateKey = existsSync(privatePath)
+				? readFileSync(privatePath)
+				: loadPrivateKeyKeychain(existingDeviceId);
+			if (privateKey) {
+				storePrivateKeyKeychain(privateKey, existingDeviceId);
+			}
+		}
+		return [existingDeviceId, fingerprint];
+	}
+
+	// Insert new device row
+	const resolvedDeviceId = options?.deviceId ?? randomUUID();
+	db.prepare(
+		"INSERT INTO sync_device(device_id, public_key, fingerprint, created_at) VALUES (?, ?, ?, ?)",
+	).run(resolvedDeviceId, publicKey, fingerprint, now);
+	if (keyStoreMode() === "keychain") {
+		const privateKey = existsSync(privatePath) ? readFileSync(privatePath) : null;
+		if (privateKey) {
+			storePrivateKeyKeychain(privateKey, resolvedDeviceId);
+		}
+	}
+	return [resolvedDeviceId, fingerprint];
+}

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -105,6 +105,13 @@ export function initTestSchema(db: Database): void {
 			UNIQUE(source, stream_id, event_id)
 		);
 
+		CREATE TABLE IF NOT EXISTS sync_device (
+			device_id TEXT PRIMARY KEY,
+			public_key TEXT NOT NULL,
+			fingerprint TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		);
+
 		-- FTS5 full-text index on memory_items
 		CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
 			title, body_text, tags_text,


### PR DESCRIPTION
## Description

Ports the sync identity module from Python (`codemem/sync_identity.py`, 295 lines) to TypeScript. This is the device key management layer for the sync system.

**Capabilities:**
- **Ed25519 keypair generation** via `ssh-keygen` (no native deps)
- **SHA-256 fingerprinting** of public keys via Node crypto
- **sync_device table management** — create or update device identity row
- **Platform keychain storage** — macOS (`security` CLI), Linux (`secret-tool`), with file fallback
- **Key validation** — verifies key pair consistency, auto-repairs mismatched public keys, backs up invalid keys

**Key functions:**
- `ensureDeviceIdentity(db, options?)` — main entry: generates keys if missing, creates/updates DB row, returns `[deviceId, fingerprint]`
- `fingerprintPublicKey()`, `loadPublicKey()`, `loadPrivateKey()`, `resolveKeyPaths()`
- `generateKeypair()`, `validateExistingKeypair()`
- `storePrivateKeyKeychain()`, `loadPrivateKeyKeychain()`

**Test schema:** Added `sync_device` table to `initTestSchema()` for test DB setup.

16 new tests. 238 total.

Part of: codemem-2b8

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Tests pass locally (`pnpm run check` — 238 tests)
- [x] 16 new tests covering fingerprinting, key generation, validation, identity lifecycle

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced