### PR TITLE
Port sync auth module to TypeScript

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,21 @@ export {
 	timeline,
 } from "./search.js";
 export { MemoryStore } from "./store.js";
+export type {
+	BuildAuthHeadersOptions,
+	SignRequestOptions,
+	VerifySignatureOptions,
+} from "./sync-auth.js";
+export {
+	buildAuthHeaders,
+	buildCanonicalRequest,
+	cleanupNonces,
+	DEFAULT_TIME_WINDOW_S,
+	recordNonce,
+	SIGNATURE_VERSION,
+	signRequest,
+	verifySignature,
+} from "./sync-auth.js";
 export type { EnsureDeviceIdentityOptions } from "./sync-identity.js";
 export {
 	ensureDeviceIdentity,

--- a/packages/core/src/sync-auth.test.ts
+++ b/packages/core/src/sync-auth.test.ts
@@ -1,0 +1,291 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Database } from "./db.js";
+import { connect } from "./db.js";
+import {
+	buildCanonicalRequest,
+	cleanupNonces,
+	recordNonce,
+	signRequest,
+	verifySignature,
+} from "./sync-auth.js";
+import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
+import { initTestSchema } from "./test-utils.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sshKeygenAvailable(): boolean {
+	try {
+		execFileSync("which", ["ssh-keygen"], { stdio: "pipe" });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+const HAS_SSH_KEYGEN = sshKeygenAvailable();
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("sync-auth", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-sync-auth-test-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// -- buildCanonicalRequest ----------------------------------------------
+
+	describe("buildCanonicalRequest", () => {
+		it("produces deterministic output", () => {
+			const body = Buffer.from('{"hello":"world"}');
+			const r1 = buildCanonicalRequest("POST", "/api/sync", "1700000000", "abc123", body);
+			const r2 = buildCanonicalRequest("POST", "/api/sync", "1700000000", "abc123", body);
+			expect(r1.toString("utf-8")).toBe(r2.toString("utf-8"));
+		});
+
+		it("uppercases the method", () => {
+			const body = Buffer.from("");
+			const result = buildCanonicalRequest("get", "/path", "123", "nonce", body);
+			const lines = result.toString("utf-8").split("\n");
+			expect(lines[0]).toBe("GET");
+		});
+
+		it("includes all components in correct order", () => {
+			const body = Buffer.from("test-body");
+			const result = buildCanonicalRequest("PUT", "/a/b?q=1", "999", "n1", body);
+			const lines = result.toString("utf-8").split("\n");
+			expect(lines).toHaveLength(5);
+			expect(lines[0]).toBe("PUT");
+			expect(lines[1]).toBe("/a/b?q=1");
+			expect(lines[2]).toBe("999");
+			expect(lines[3]).toBe("n1");
+			// Line 4 is the SHA-256 hex digest of "test-body"
+			expect(lines[4]).toMatch(/^[0-9a-f]{64}$/);
+		});
+	});
+
+	// -- signRequest + verifySignature round-trip ----------------------------
+
+	describe("signRequest + verifySignature", () => {
+		function setupIdentity() {
+			const keysDir = join(tmpDir, "keys");
+			const dbPath = join(tmpDir, "test.sqlite");
+			const db = connect(dbPath);
+			initTestSchema(db);
+			const [deviceId] = ensureDeviceIdentity(db, { keysDir });
+			const publicKey = loadPublicKey(keysDir)!;
+			return { db, deviceId, publicKey, keysDir };
+		}
+
+		it.skipIf(!HAS_SSH_KEYGEN)("round-trips: sign then verify", () => {
+			const { db, deviceId, publicKey, keysDir } = setupIdentity();
+			try {
+				const body = Buffer.from('{"data":"test"}');
+				const url = "https://example.com/api/sync?page=1";
+				const ts = String(Math.floor(Date.now() / 1000));
+				const nonce = "test-nonce-abc";
+
+				const headers = signRequest({
+					method: "POST",
+					url,
+					bodyBytes: body,
+					keysDir,
+					timestamp: ts,
+					nonce,
+				});
+
+				expect(headers["X-Opencode-Timestamp"]).toBe(ts);
+				expect(headers["X-Opencode-Nonce"]).toBe(nonce);
+				expect(headers["X-Opencode-Signature"]).toMatch(/^v1:/);
+
+				const valid = verifySignature({
+					method: "POST",
+					pathWithQuery: "/api/sync?page=1",
+					bodyBytes: body,
+					timestamp: headers["X-Opencode-Timestamp"],
+					nonce: headers["X-Opencode-Nonce"],
+					signature: headers["X-Opencode-Signature"],
+					publicKey,
+					deviceId,
+				});
+				expect(valid).toBe(true);
+			} finally {
+				db.close();
+			}
+		});
+
+		it.skipIf(!HAS_SSH_KEYGEN)("rejects expired timestamp", () => {
+			const { db, deviceId, publicKey, keysDir } = setupIdentity();
+			try {
+				const body = Buffer.from("{}");
+				const oldTs = String(Math.floor(Date.now() / 1000) - 600);
+
+				const headers = signRequest({
+					method: "GET",
+					url: "https://example.com/api/test",
+					bodyBytes: body,
+					keysDir,
+					timestamp: oldTs,
+				});
+
+				const valid = verifySignature({
+					method: "GET",
+					pathWithQuery: "/api/test",
+					bodyBytes: body,
+					timestamp: headers["X-Opencode-Timestamp"],
+					nonce: headers["X-Opencode-Nonce"],
+					signature: headers["X-Opencode-Signature"],
+					publicKey,
+					deviceId,
+					timeWindowS: 300,
+				});
+				expect(valid).toBe(false);
+			} finally {
+				db.close();
+			}
+		});
+
+		it.skipIf(!HAS_SSH_KEYGEN)("rejects wrong signature version", () => {
+			const { db, deviceId, publicKey, keysDir } = setupIdentity();
+			try {
+				const body = Buffer.from("{}");
+				const ts = String(Math.floor(Date.now() / 1000));
+
+				const headers = signRequest({
+					method: "GET",
+					url: "https://example.com/api/test",
+					bodyBytes: body,
+					keysDir,
+					timestamp: ts,
+				});
+
+				// Replace version prefix
+				const tampered = headers["X-Opencode-Signature"].replace("v1:", "v99:");
+
+				const valid = verifySignature({
+					method: "GET",
+					pathWithQuery: "/api/test",
+					bodyBytes: body,
+					timestamp: headers["X-Opencode-Timestamp"],
+					nonce: headers["X-Opencode-Nonce"],
+					signature: tampered,
+					publicKey,
+					deviceId,
+				});
+				expect(valid).toBe(false);
+			} finally {
+				db.close();
+			}
+		});
+
+		it.skipIf(!HAS_SSH_KEYGEN)("rejects tampered body", () => {
+			const { db, deviceId, publicKey, keysDir } = setupIdentity();
+			try {
+				const body = Buffer.from('{"original":"data"}');
+				const ts = String(Math.floor(Date.now() / 1000));
+
+				const headers = signRequest({
+					method: "POST",
+					url: "https://example.com/api/sync",
+					bodyBytes: body,
+					keysDir,
+					timestamp: ts,
+				});
+
+				// Verify with different body
+				const valid = verifySignature({
+					method: "POST",
+					pathWithQuery: "/api/sync",
+					bodyBytes: Buffer.from('{"tampered":"data"}'),
+					timestamp: headers["X-Opencode-Timestamp"],
+					nonce: headers["X-Opencode-Nonce"],
+					signature: headers["X-Opencode-Signature"],
+					publicKey,
+					deviceId,
+				});
+				expect(valid).toBe(false);
+			} finally {
+				db.close();
+			}
+		});
+	});
+
+	// -- recordNonce --------------------------------------------------------
+
+	describe("recordNonce", () => {
+		function makeDb(): Database {
+			const dbPath = join(tmpDir, `nonce-${Date.now()}.sqlite`);
+			const db = connect(dbPath);
+			initTestSchema(db);
+			return db;
+		}
+
+		it("succeeds on first insert", () => {
+			const db = makeDb();
+			try {
+				const ok = recordNonce(db, "device-1", "nonce-abc", "2026-01-01T00:00:00Z");
+				expect(ok).toBe(true);
+			} finally {
+				db.close();
+			}
+		});
+
+		it("returns false on duplicate nonce for same device", () => {
+			const db = makeDb();
+			try {
+				recordNonce(db, "device-1", "nonce-dup", "2026-01-01T00:00:00Z");
+				const ok = recordNonce(db, "device-1", "nonce-dup", "2026-01-01T00:00:01Z");
+				expect(ok).toBe(false);
+			} finally {
+				db.close();
+			}
+		});
+
+		it("rejects same nonce even from different devices", () => {
+			// Nonce is the sole primary key — global replay protection
+			const db = makeDb();
+			try {
+				const ok1 = recordNonce(db, "device-1", "shared-nonce", "2026-01-01T00:00:00Z");
+				const ok2 = recordNonce(db, "device-2", "shared-nonce", "2026-01-01T00:00:00Z");
+				expect(ok1).toBe(true);
+				expect(ok2).toBe(false);
+			} finally {
+				db.close();
+			}
+		});
+	});
+
+	// -- cleanupNonces ------------------------------------------------------
+
+	describe("cleanupNonces", () => {
+		it("removes old entries and keeps recent ones", () => {
+			const dbPath = join(tmpDir, "cleanup.sqlite");
+			const db = connect(dbPath);
+			initTestSchema(db);
+			try {
+				recordNonce(db, "d1", "old-nonce", "2025-01-01T00:00:00Z");
+				recordNonce(db, "d1", "new-nonce", "2026-06-01T00:00:00Z");
+
+				cleanupNonces(db, "2026-01-01T00:00:00Z");
+
+				const rows = db.prepare("SELECT nonce FROM sync_nonces").all() as { nonce: string }[];
+				expect(rows).toHaveLength(1);
+				expect(rows[0].nonce).toBe("new-nonce");
+			} finally {
+				db.close();
+			}
+		});
+	});
+});

--- a/packages/core/src/sync-auth.ts
+++ b/packages/core/src/sync-auth.ts
@@ -1,0 +1,266 @@
+/**
+ * Sync authentication: request signing, verification, and nonce management.
+ *
+ * Uses ssh-keygen for Ed25519 signature operations (sign/verify) and
+ * SHA-256 canonical request hashing. Ported from codemem/sync_auth.py.
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Database } from "./db.js";
+import { loadPrivateKey, resolveKeyPaths } from "./sync-identity.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const SIGNATURE_VERSION = "v1";
+export const DEFAULT_TIME_WINDOW_S = 300;
+
+// ---------------------------------------------------------------------------
+// Canonical request
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a canonical request buffer for signing/verification.
+ *
+ * SHA-256 hashes the body, then joins method/path/timestamp/nonce/bodyHash
+ * with newlines and returns the UTF-8 encoded result.
+ */
+export function buildCanonicalRequest(
+	method: string,
+	pathWithQuery: string,
+	timestamp: string,
+	nonce: string,
+	bodyBytes: Buffer,
+): Buffer {
+	const bodyHash = createHash("sha256").update(bodyBytes).digest("hex");
+	const canonical = [method.toUpperCase(), pathWithQuery, timestamp, nonce, bodyHash].join("\n");
+	return Buffer.from(canonical, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Sign
+// ---------------------------------------------------------------------------
+
+export interface SignRequestOptions {
+	method: string;
+	url: string;
+	bodyBytes: Buffer;
+	keysDir?: string;
+	timestamp?: string;
+	nonce?: string;
+}
+
+/**
+ * Sign an HTTP request and return the auth headers.
+ *
+ * Uses ssh-keygen -Y sign with the device's Ed25519 private key.
+ * Returns X-Opencode-Timestamp, X-Opencode-Nonce, X-Opencode-Signature headers.
+ */
+export function signRequest(options: SignRequestOptions): Record<string, string> {
+	const ts = options.timestamp ?? String(Math.floor(Date.now() / 1000));
+	const nonceValue = options.nonce ?? randomBytes(16).toString("hex");
+
+	const parsed = new URL(options.url);
+	let path = parsed.pathname || "/";
+	if (parsed.search) {
+		path = `${path}${parsed.search}`;
+	}
+
+	const canonical = buildCanonicalRequest(options.method, path, ts, nonceValue, options.bodyBytes);
+
+	const [privateKeyPath] = resolveKeyPaths(options.keysDir);
+	let keyOverride: Buffer | null = null;
+	if (!existsSync(privateKeyPath)) {
+		const key = loadPrivateKey(options.keysDir);
+		if (!key) {
+			throw new Error("private key missing");
+		}
+		keyOverride = key;
+	}
+
+	const tmp = mkdtempSync(join(tmpdir(), "codemem-sign-"));
+	try {
+		const dataPath = join(tmp, "request");
+		writeFileSync(dataPath, canonical);
+
+		let signingKeyPath = privateKeyPath;
+		if (keyOverride !== null) {
+			const tempKey = join(tmp, "temp.key");
+			writeFileSync(tempKey, keyOverride);
+			chmodSync(tempKey, 0o600);
+			signingKeyPath = tempKey;
+		}
+
+		execFileSync(
+			"ssh-keygen",
+			["-Y", "sign", "-f", signingKeyPath, "-n", "codemem-sync", dataPath],
+			{ stdio: ["pipe", "pipe", "pipe"] },
+		);
+
+		const sigPath = `${dataPath}.sig`;
+		const signatureBytes = readFileSync(sigPath);
+		const signature = signatureBytes.toString("base64");
+
+		return {
+			"X-Opencode-Timestamp": ts,
+			"X-Opencode-Nonce": nonceValue,
+			"X-Opencode-Signature": `${SIGNATURE_VERSION}:${signature}`,
+		};
+	} finally {
+		rmSync(tmp, { recursive: true, force: true });
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+export interface VerifySignatureOptions {
+	method: string;
+	pathWithQuery: string;
+	bodyBytes: Buffer;
+	timestamp: string;
+	nonce: string;
+	signature: string;
+	publicKey: string;
+	deviceId: string;
+	timeWindowS?: number;
+}
+
+/**
+ * Verify a signed request.
+ *
+ * Checks timestamp freshness, signature version prefix, then delegates
+ * to ssh-keygen -Y verify with an allowed_signers file.
+ */
+export function verifySignature(options: VerifySignatureOptions): boolean {
+	const timeWindow = options.timeWindowS ?? DEFAULT_TIME_WINDOW_S;
+
+	// Parse and validate timestamp — reject non-numeric strings (matches Python's int())
+	if (!/^\d+$/.test(options.timestamp)) return false;
+	const tsInt = Number.parseInt(options.timestamp, 10);
+	if (Number.isNaN(tsInt)) return false;
+
+	const now = Math.floor(Date.now() / 1000);
+	if (Math.abs(now - tsInt) > timeWindow) return false;
+
+	// Validate signature version prefix
+	const prefix = `${SIGNATURE_VERSION}:`;
+	if (!options.signature.startsWith(prefix)) return false;
+
+	const encoded = options.signature.slice(prefix.length);
+	if (!encoded) return false;
+
+	let signatureBytes: Buffer;
+	try {
+		signatureBytes = Buffer.from(encoded, "base64");
+		// Verify it was valid base64 by round-tripping
+		if (signatureBytes.toString("base64") !== encoded) return false;
+	} catch {
+		return false;
+	}
+
+	const canonical = buildCanonicalRequest(
+		options.method,
+		options.pathWithQuery,
+		options.timestamp,
+		options.nonce,
+		options.bodyBytes,
+	);
+
+	const tmp = mkdtempSync(join(tmpdir(), "codemem-verify-"));
+	try {
+		const keyPath = join(tmp, "allowed_signers");
+		writeFileSync(keyPath, `${options.deviceId} ${options.publicKey}\n`);
+
+		const sigPath = join(tmp, "request.sig");
+		writeFileSync(sigPath, signatureBytes);
+
+		execFileSync(
+			"ssh-keygen",
+			["-Y", "verify", "-f", keyPath, "-I", options.deviceId, "-n", "codemem-sync", "-s", sigPath],
+			{ input: canonical, stdio: ["pipe", "pipe", "pipe"] },
+		);
+		// If execFileSync didn't throw, returncode is 0
+		return true;
+	} catch {
+		return false;
+	} finally {
+		rmSync(tmp, { recursive: true, force: true });
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth headers (convenience)
+// ---------------------------------------------------------------------------
+
+export interface BuildAuthHeadersOptions {
+	deviceId: string;
+	method: string;
+	url: string;
+	bodyBytes: Buffer;
+	keysDir?: string;
+	timestamp?: string;
+	nonce?: string;
+}
+
+/**
+ * Build full auth headers including device ID and request signature.
+ */
+export function buildAuthHeaders(options: BuildAuthHeadersOptions): Record<string, string> {
+	return {
+		"X-Opencode-Device": options.deviceId,
+		...signRequest({
+			method: options.method,
+			url: options.url,
+			bodyBytes: options.bodyBytes,
+			keysDir: options.keysDir,
+			timestamp: options.timestamp,
+			nonce: options.nonce,
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Nonce management
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a nonce to prevent replay attacks.
+ *
+ * Returns true on success, false if the nonce was already recorded
+ * (duplicate = potential replay).
+ */
+export function recordNonce(
+	db: Database,
+	deviceId: string,
+	nonce: string,
+	createdAt: string,
+): boolean {
+	try {
+		db.prepare("INSERT INTO sync_nonces(nonce, device_id, created_at) VALUES (?, ?, ?)").run(
+			nonce,
+			deviceId,
+			createdAt,
+		);
+		return true;
+	} catch (err: unknown) {
+		// SQLite UNIQUE constraint violation
+		if (err instanceof Error && err.message.includes("UNIQUE constraint failed")) {
+			return false;
+		}
+		throw err;
+	}
+}
+
+/**
+ * Remove nonces older than the given cutoff timestamp.
+ */
+export function cleanupNonces(db: Database, cutoff: string): void {
+	db.prepare("DELETE FROM sync_nonces WHERE created_at < ?").run(cutoff);
+}

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -112,6 +112,12 @@ export function initTestSchema(db: Database): void {
 			created_at TEXT NOT NULL
 		);
 
+		CREATE TABLE IF NOT EXISTS sync_nonces (
+			nonce TEXT PRIMARY KEY,
+			device_id TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		);
+
 		-- FTS5 full-text index on memory_items
 		CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
 			title, body_text, tags_text,


### PR DESCRIPTION
## Description

Ports the sync auth module from Python (`codemem/sync_auth.py`, 203 lines) to TypeScript. Handles Ed25519 request signing and verification for peer-to-peer sync authentication.

**Request signing:**
- Canonical request construction: `method\npath\ntimestamp\nnonce\nSHA256(body)`
- Ed25519 signing via `ssh-keygen -Y sign` (temp dir + cleanup)
- Auth headers: `X-Opencode-Device`, `X-Opencode-Timestamp`, `X-Opencode-Nonce`, `X-Opencode-Signature`

**Verification:**
- Timestamp window check (default 300s)
- Signature version prefix validation (`v1:`)
- `ssh-keygen -Y verify` with allowed_signers file

**Nonce management:**
- `recordNonce()` — INSERT with UNIQUE constraint (returns false on replay)
- `cleanupNonces()` — DELETE expired nonces by cutoff timestamp

11 new tests. 249 total.

Part of: codemem-2b8

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Tests pass locally (`pnpm run check` — 249 tests)
- [x] Round-trip sign + verify test
- [x] Rejection tests: expired timestamp, wrong version, tampered body
- [x] Nonce dedup + cleanup tests

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new errors introduced