### PR TITLE
Port sync replication protocol and HTTP client to TypeScript

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,6 +127,8 @@ export {
 	signRequest,
 	verifySignature,
 } from "./sync-auth.js";
+export type { RequestJsonOptions } from "./sync-http-client.js";
+export { buildBaseUrl, requestJson } from "./sync-http-client.js";
 export type { EnsureDeviceIdentityOptions } from "./sync-identity.js";
 export {
 	ensureDeviceIdentity,
@@ -139,6 +141,12 @@ export {
 	storePrivateKeyKeychain,
 	validateExistingKeypair,
 } from "./sync-identity.js";
+export {
+	chunkOpsBySize,
+	extractReplicationOps,
+	getReplicationCursor,
+	setReplicationCursor,
+} from "./sync-replication.js";
 
 export type {
 	Actor,

--- a/packages/core/src/sync-http-client.test.ts
+++ b/packages/core/src/sync-http-client.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildBaseUrl, requestJson } from "./sync-http-client.js";
+
+// ---------------------------------------------------------------------------
+// buildBaseUrl
+// ---------------------------------------------------------------------------
+
+describe("buildBaseUrl", () => {
+	it("adds http:// when no scheme is present", () => {
+		expect(buildBaseUrl("192.168.1.1:8080")).toBe("http://192.168.1.1:8080");
+	});
+
+	it("preserves https:// scheme", () => {
+		expect(buildBaseUrl("https://peer.example.com")).toBe("https://peer.example.com");
+	});
+
+	it("preserves http:// scheme", () => {
+		expect(buildBaseUrl("http://localhost:3000")).toBe("http://localhost:3000");
+	});
+
+	it("trims whitespace and trailing slashes", () => {
+		expect(buildBaseUrl("  http://host:9000///  ")).toBe("http://host:9000");
+	});
+
+	it("returns empty string for empty/blank input", () => {
+		expect(buildBaseUrl("")).toBe("");
+		expect(buildBaseUrl("   ")).toBe("");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// requestJson (mocked fetch)
+// ---------------------------------------------------------------------------
+
+describe("requestJson", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("returns parsed JSON on success", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			status: 200,
+			text: () => Promise.resolve(JSON.stringify({ ok: true, count: 5 })),
+		});
+
+		const [status, body] = await requestJson("POST", "http://localhost:8080/push", {
+			body: { ops: [] },
+		});
+
+		expect(status).toBe(200);
+		expect(body).toEqual({ ok: true, count: 5 });
+
+		const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+		expect(call[0]).toBe("http://localhost:8080/push");
+		expect(call[1].method).toBe("POST");
+		expect(call[1].headers["Content-Type"]).toBe("application/json");
+	});
+
+	it("returns null body for empty response", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			status: 204,
+			text: () => Promise.resolve(""),
+		});
+
+		const [status, body] = await requestJson("GET", "http://localhost:8080/status");
+		expect(status).toBe(204);
+		expect(body).toBeNull();
+	});
+
+	it("handles non-JSON response gracefully", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			status: 502,
+			text: () => Promise.resolve("<html>Bad Gateway</html>"),
+		});
+
+		const [status, body] = await requestJson("GET", "http://localhost:8080/health");
+		expect(status).toBe(502);
+		expect(body).not.toBeNull();
+		expect(body?.error).toMatch(/^non_json_response:/);
+		expect(body?.error).toContain("Bad Gateway");
+	});
+
+	it("handles unexpected JSON type (array)", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			status: 200,
+			text: () => Promise.resolve("[1, 2, 3]"),
+		});
+
+		const [status, body] = await requestJson("GET", "http://localhost:8080/list");
+		expect(status).toBe(200);
+		expect(body).toEqual({ error: "unexpected_json_type: array" });
+	});
+
+	it("sets Accept header and omits Content-Type for bodyless requests", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			status: 200,
+			text: () => Promise.resolve("{}"),
+		});
+
+		await requestJson("GET", "http://localhost:8080/info");
+		const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+		expect(call[1].headers.Accept).toBe("application/json");
+		expect(call[1].headers["Content-Type"]).toBeUndefined();
+	});
+
+	it("passes custom headers", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			status: 200,
+			text: () => Promise.resolve("{}"),
+		});
+
+		await requestJson("GET", "http://localhost:8080/auth", {
+			headers: { Authorization: "Bearer tok" },
+		});
+
+		const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+		expect(call[1].headers.Authorization).toBe("Bearer tok");
+	});
+});

--- a/packages/core/src/sync-http-client.ts
+++ b/packages/core/src/sync-http-client.ts
@@ -1,0 +1,93 @@
+/**
+ * Sync HTTP client: JSON request helper using Node.js built-in fetch.
+ *
+ * Async counterpart to the synchronous Python http.client implementation.
+ * Ported from codemem/sync/http_client.py.
+ */
+
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a peer address into a base URL.
+ *
+ * Adds `http://` when no scheme is present, trims whitespace and trailing slashes.
+ */
+export function buildBaseUrl(address: string): string {
+	const trimmed = address.trim().replace(/\/+$/, "");
+	if (!trimmed) return "";
+	// Check for an existing scheme (e.g. http://, https://)
+	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
+	return `http://${trimmed}`;
+}
+
+// ---------------------------------------------------------------------------
+// JSON request
+// ---------------------------------------------------------------------------
+
+export interface RequestJsonOptions {
+	headers?: Record<string, string>;
+	body?: Record<string, unknown>;
+	bodyBytes?: Uint8Array;
+	timeoutS?: number;
+}
+
+/**
+ * Send an HTTP request and parse the JSON response.
+ *
+ * Returns `[statusCode, parsedBody]`. The body is null when the response
+ * has no content. Non-JSON responses are returned as `{ error: "non_json_response: ..." }`.
+ */
+export async function requestJson(
+	method: string,
+	url: string,
+	options: RequestJsonOptions = {},
+): Promise<[status: number, body: Record<string, unknown> | null]> {
+	const { headers, body, timeoutS = 3 } = options;
+	let { bodyBytes } = options;
+
+	if (bodyBytes == null && body != null) {
+		bodyBytes = new TextEncoder().encode(JSON.stringify(body));
+	}
+
+	const requestHeaders: Record<string, string> = {
+		Accept: "application/json",
+	};
+	if (bodyBytes != null) {
+		requestHeaders["Content-Type"] = "application/json";
+		requestHeaders["Content-Length"] = String(bodyBytes.byteLength);
+	}
+	if (headers) {
+		Object.assign(requestHeaders, headers);
+	}
+
+	const response = await fetch(url, {
+		method,
+		headers: requestHeaders,
+		body: bodyBytes ?? null,
+		signal: AbortSignal.timeout(timeoutS * 1000),
+	});
+
+	const raw = await response.text();
+	if (!raw) return [response.status, null];
+
+	let payload: unknown;
+	try {
+		payload = JSON.parse(raw);
+	} catch {
+		const snippet = raw.slice(0, 240).trim();
+		return [
+			response.status,
+			{ error: snippet ? `non_json_response: ${snippet}` : "non_json_response" },
+		];
+	}
+
+	if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
+		return [response.status, payload as Record<string, unknown>];
+	}
+	return [
+		response.status,
+		{ error: `unexpected_json_type: ${Array.isArray(payload) ? "array" : typeof payload}` },
+	];
+}

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1,0 +1,137 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	chunkOpsBySize,
+	extractReplicationOps,
+	getReplicationCursor,
+	setReplicationCursor,
+} from "./sync-replication.js";
+import { initTestSchema } from "./test-utils.js";
+import type { ReplicationOp } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOp(id: string, payloadSize = 10): ReplicationOp {
+	return {
+		op_id: id,
+		entity_type: "memory",
+		entity_id: `ent-${id}`,
+		op_type: "upsert",
+		payload_json: "x".repeat(payloadSize),
+		clock_rev: 1,
+		clock_updated_at: "2026-01-01T00:00:00Z",
+		clock_device_id: "dev-a",
+		device_id: "dev-a",
+		created_at: "2026-01-01T00:00:00Z",
+	};
+}
+
+// ---------------------------------------------------------------------------
+// chunkOpsBySize
+// ---------------------------------------------------------------------------
+
+describe("chunkOpsBySize", () => {
+	it("returns a single batch when all ops fit", () => {
+		const ops = [makeOp("1"), makeOp("2")];
+		const batches = chunkOpsBySize(ops, 100_000);
+		expect(batches).toHaveLength(1);
+		expect(batches[0]).toHaveLength(2);
+	});
+
+	it("splits into multiple batches when ops exceed limit", () => {
+		const ops = [makeOp("1", 200), makeOp("2", 200), makeOp("3", 200)];
+		// Choose a limit that fits ~1-2 ops but not all 3
+		const singleSize = new TextEncoder().encode(JSON.stringify({ ops: [ops[0]] })).byteLength;
+		const batches = chunkOpsBySize(ops, singleSize * 2);
+		expect(batches.length).toBeGreaterThan(1);
+		// All ops should be present across batches
+		const allOps = batches.flat();
+		expect(allOps).toHaveLength(3);
+	});
+
+	it("throws when a single op exceeds the limit", () => {
+		const ops = [makeOp("big", 10_000)];
+		expect(() => chunkOpsBySize(ops, 100)).toThrow("single op exceeds size limit");
+	});
+
+	it("returns empty array for empty input", () => {
+		expect(chunkOpsBySize([], 1000)).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Cursor operations (require DB)
+// ---------------------------------------------------------------------------
+
+describe("replication cursors", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("returns [null, null] for unknown peer", () => {
+		const [applied, acked] = getReplicationCursor(db, "unknown-peer");
+		expect(applied).toBeNull();
+		expect(acked).toBeNull();
+	});
+
+	it("round-trips cursor values after set", () => {
+		setReplicationCursor(db, "peer-1", {
+			lastApplied: "cursor-a",
+			lastAcked: "cursor-b",
+		});
+		const [applied, acked] = getReplicationCursor(db, "peer-1");
+		expect(applied).toBe("cursor-a");
+		expect(acked).toBe("cursor-b");
+	});
+
+	it("updates only the specified cursor field via COALESCE", () => {
+		setReplicationCursor(db, "peer-2", { lastApplied: "v1" });
+		setReplicationCursor(db, "peer-2", { lastAcked: "ack-1" });
+
+		const [applied, acked] = getReplicationCursor(db, "peer-2");
+		expect(applied).toBe("v1"); // preserved via COALESCE
+		expect(acked).toBe("ack-1");
+	});
+
+	it("overwrites cursor on subsequent set", () => {
+		setReplicationCursor(db, "peer-3", { lastApplied: "old" });
+		setReplicationCursor(db, "peer-3", { lastApplied: "new" });
+		const [applied] = getReplicationCursor(db, "peer-3");
+		expect(applied).toBe("new");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// extractReplicationOps
+// ---------------------------------------------------------------------------
+
+describe("extractReplicationOps", () => {
+	it("extracts ops from a valid payload", () => {
+		const ops = [makeOp("1"), makeOp("2")];
+		const result = extractReplicationOps({ ops });
+		expect(result).toEqual(ops);
+	});
+
+	it("returns empty array for non-object payload", () => {
+		expect(extractReplicationOps("not-an-object")).toEqual([]);
+		expect(extractReplicationOps(null)).toEqual([]);
+		expect(extractReplicationOps(42)).toEqual([]);
+	});
+
+	it("returns empty array when ops is missing", () => {
+		expect(extractReplicationOps({ other: "data" })).toEqual([]);
+	});
+
+	it("returns empty array when ops is not an array", () => {
+		expect(extractReplicationOps({ ops: "not-array" })).toEqual([]);
+	});
+});

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -1,0 +1,151 @@
+/**
+ * Sync replication: cursor tracking, op chunking, and payload extraction.
+ *
+ * Keeps replication functions decoupled from MemoryStore by accepting
+ * a raw Database handle. Ported from codemem/sync/replication.py.
+ */
+
+import type { Database } from "./db.js";
+import type { ReplicationOp } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Op chunking
+// ---------------------------------------------------------------------------
+
+/**
+ * Split replication ops into batches that fit within a byte-size limit.
+ *
+ * Each batch is serialized as `{"ops": [...]}` and must not exceed maxBytes
+ * when UTF-8 encoded. Throws if a single op exceeds the limit.
+ */
+export function chunkOpsBySize(ops: ReplicationOp[], maxBytes: number): ReplicationOp[][] {
+	const encoder = new TextEncoder();
+	// Overhead: {"ops":[]} = 9 bytes, comma between elements = 1 byte
+	const WRAPPER_OVERHEAD = 9;
+	const COMMA_OVERHEAD = 1;
+
+	const batches: ReplicationOp[][] = [];
+	let current: ReplicationOp[] = [];
+	let currentBytes = WRAPPER_OVERHEAD;
+
+	for (const op of ops) {
+		const opBytes = encoder.encode(JSON.stringify(op)).byteLength;
+		const addedBytes = current.length === 0 ? opBytes : opBytes + COMMA_OVERHEAD;
+
+		if (currentBytes + addedBytes <= maxBytes) {
+			current.push(op);
+			currentBytes += addedBytes;
+			continue;
+		}
+		if (current.length === 0) {
+			throw new Error("single op exceeds size limit");
+		}
+		batches.push(current);
+		current = [op];
+		currentBytes = WRAPPER_OVERHEAD + opBytes;
+		if (currentBytes > maxBytes) {
+			throw new Error("single op exceeds size limit");
+		}
+	}
+	if (current.length > 0) {
+		batches.push(current);
+	}
+	return batches;
+}
+
+// ---------------------------------------------------------------------------
+// Cursor read/write
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the replication cursor for a peer device.
+ *
+ * Returns `[lastApplied, lastAcked]` — both null when no cursor exists.
+ */
+export function getReplicationCursor(
+	db: Database,
+	peerDeviceId: string,
+): [lastApplied: string | null, lastAcked: string | null] {
+	const row = db
+		.prepare(
+			`SELECT last_applied_cursor, last_acked_cursor
+			 FROM replication_cursors
+			 WHERE peer_device_id = ?`,
+		)
+		.get(peerDeviceId) as
+		| { last_applied_cursor: string | null; last_acked_cursor: string | null }
+		| undefined;
+
+	if (!row) return [null, null];
+	return [row.last_applied_cursor, row.last_acked_cursor];
+}
+
+/**
+ * Insert or update the replication cursor for a peer device.
+ *
+ * Uses COALESCE on update so callers can set only one of the two cursors
+ * without clobbering the other.
+ */
+export function setReplicationCursor(
+	db: Database,
+	peerDeviceId: string,
+	options: { lastApplied?: string | null; lastAcked?: string | null } = {},
+): void {
+	const now = new Date().toISOString();
+	const lastApplied = options.lastApplied ?? null;
+	const lastAcked = options.lastAcked ?? null;
+
+	// Atomic UPSERT — avoids TOCTOU race with concurrent sync workers
+	db.prepare(
+		`INSERT INTO replication_cursors(peer_device_id, last_applied_cursor, last_acked_cursor, updated_at)
+		 VALUES (?, ?, ?, ?)
+		 ON CONFLICT(peer_device_id) DO UPDATE SET
+			last_applied_cursor = COALESCE(excluded.last_applied_cursor, last_applied_cursor),
+			last_acked_cursor = COALESCE(excluded.last_acked_cursor, last_acked_cursor),
+			updated_at = excluded.updated_at`,
+	).run(peerDeviceId, lastApplied, lastAcked, now);
+}
+
+// ---------------------------------------------------------------------------
+// Payload extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract replication ops from a parsed JSON payload.
+ *
+ * Returns an empty array if the payload is not an object or lacks an `ops` array.
+ */
+/** Required fields for a valid replication op. */
+const REQUIRED_OP_FIELDS = [
+	"op_id",
+	"entity_type",
+	"entity_id",
+	"op_type",
+	"clock_rev",
+	"clock_updated_at",
+	"clock_device_id",
+	"device_id",
+	"created_at",
+] as const;
+
+/**
+ * Extract and validate replication ops from a parsed JSON payload.
+ *
+ * Returns an empty array if the payload is not an object or lacks an `ops` array.
+ * Silently filters out ops missing required fields to prevent garbage data
+ * from entering the replication pipeline.
+ */
+export function extractReplicationOps(payload: unknown): ReplicationOp[] {
+	if (typeof payload !== "object" || payload === null) return [];
+	const obj = payload as Record<string, unknown>;
+	const ops = obj.ops;
+	if (!Array.isArray(ops)) return [];
+
+	return ops.filter((op): op is ReplicationOp => {
+		if (typeof op !== "object" || op === null) return false;
+		const record = op as Record<string, unknown>;
+		return REQUIRED_OP_FIELDS.every(
+			(field) => record[field] !== undefined && record[field] !== null,
+		);
+	});
+}

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -118,6 +118,13 @@ export function initTestSchema(db: Database): void {
 			created_at TEXT NOT NULL
 		);
 
+		CREATE TABLE IF NOT EXISTS replication_cursors (
+			peer_device_id TEXT PRIMARY KEY,
+			last_applied_cursor TEXT,
+			last_acked_cursor TEXT,
+			updated_at TEXT NOT NULL
+		);
+
 		-- FTS5 full-text index on memory_items
 		CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
 			title, body_text, tags_text,


### PR DESCRIPTION
## Description

Ports the sync replication protocol and HTTP client from Python to TypeScript.

### `sync-replication.ts` (~120 lines)
- **`chunkOpsBySize(ops, maxBytes)`** — splits replication ops into byte-limited batches (throws on oversized single op)
- **`getReplicationCursor(db, peerDeviceId)`** — reads cursor from `replication_cursors` table
- **`setReplicationCursor(db, peerDeviceId, options)`** — UPSERT with COALESCE for partial cursor updates
- **`extractReplicationOps(payload)`** — safe extraction from unknown payload

### `sync-http-client.ts` (~95 lines)
- **`buildBaseUrl(address)`** — normalizes peer addresses (adds `http://`, trims whitespace/slashes)
- **`requestJson(method, url, options?)`** — async `fetch()` with `AbortSignal.timeout()`, JSON parsing, graceful non-JSON handling. Returns `[status, body]` tuple.

Both modules use `Database` type directly (decoupled from MemoryStore).

23 new tests. 272 total.

Part of: codemem-2b8

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Tests pass locally (`pnpm run check` — 272 tests)
- [x] Replication: chunk batching, cursor round-trips, COALESCE updates, safe extraction
- [x] HTTP: URL normalization, mocked fetch (success, empty, non-JSON, header passthrough)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new errors introduced