### PR TITLE
Port coordinator store and invites to TypeScript

### DIFF
--- a/packages/core/src/address-utils.ts
+++ b/packages/core/src/address-utils.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared address normalization utilities for the sync system.
+ *
+ * Used by both coordinator-store and sync-discovery to ensure
+ * consistent address handling across the sync pipeline.
+ */
+
+/**
+ * Normalize an address to a consistent URL form.
+ *
+ * Uses the built-in URL constructor for consistent normalization:
+ * lowercases host, strips default ports (80/443), trims trailing slashes.
+ * Returns empty string for invalid/empty input.
+ */
+export function normalizeAddress(address: string): string {
+	const value = address.trim();
+	if (!value) return "";
+
+	const withScheme = value.includes("://") ? value : `http://${value}`;
+
+	try {
+		const url = new URL(withScheme);
+		if (!url.hostname) return "";
+		if (url.port && (Number(url.port) <= 0 || Number(url.port) > 65535)) return "";
+		return url.origin + url.pathname.replace(/\/+$/, "");
+	} catch {
+		return "";
+	}
+}
+
+/**
+ * Produce a dedup key for an address (strips http scheme for comparison).
+ */
+export function addressDedupeKey(address: string): string {
+	if (!address) return "";
+	try {
+		const url = new URL(address);
+		const host = url.hostname.toLowerCase();
+		if (host && url.port) return `${host}:${url.port}`;
+		if (host) return host;
+	} catch {
+		// Not parseable
+	}
+	return address;
+}
+
+/**
+ * Merge two address lists, normalizing and deduplicating.
+ * Existing addresses come first, then new candidates.
+ */
+export function mergeAddresses(existing: string[], candidates: string[]): string[] {
+	const normalized: string[] = [];
+	const seen = new Set<string>();
+	for (const address of [...existing, ...candidates]) {
+		const cleaned = normalizeAddress(address);
+		const key = addressDedupeKey(cleaned);
+		if (!cleaned || seen.has(key)) continue;
+		seen.add(key);
+		normalized.push(cleaned);
+	}
+	return normalized;
+}

--- a/packages/core/src/coordinator-invites.test.ts
+++ b/packages/core/src/coordinator-invites.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+	decodeInvitePayload,
+	encodeInvitePayload,
+	extractInvitePayload,
+	type InvitePayload,
+	inviteLink,
+} from "./coordinator-invites.js";
+
+const SAMPLE_PAYLOAD: InvitePayload = {
+	v: 1,
+	kind: "invite",
+	coordinator_url: "https://coordinator.example.com",
+	group_id: "grp-abc123",
+	policy: "auto_approve",
+	token: "tok-xyz",
+	expires_at: "2026-12-31T23:59:59Z",
+	team_name: "My Team",
+};
+
+describe("coordinator-invites", () => {
+	describe("encode/decode round-trip", () => {
+		it("round-trips a full payload", () => {
+			const encoded = encodeInvitePayload(SAMPLE_PAYLOAD);
+			expect(typeof encoded).toBe("string");
+			expect(encoded.length).toBeGreaterThan(0);
+			// No padding characters
+			expect(encoded).not.toContain("=");
+
+			const decoded = decodeInvitePayload(encoded);
+			expect(decoded).toEqual(SAMPLE_PAYLOAD);
+		});
+
+		it("round-trips a payload with null team_name", () => {
+			const payload: InvitePayload = { ...SAMPLE_PAYLOAD, team_name: null };
+			const decoded = decodeInvitePayload(encodeInvitePayload(payload));
+			expect(decoded.team_name).toBeNull();
+		});
+	});
+
+	describe("decodeInvitePayload", () => {
+		it("throws on non-object payload", () => {
+			// Encode a string literal as base64url
+			const encoded = Buffer.from('"just a string"').toString("base64url").replace(/=+$/, "");
+			expect(() => decodeInvitePayload(encoded)).toThrow("invalid invite payload");
+		});
+	});
+
+	describe("inviteLink", () => {
+		it("produces a codemem:// link", () => {
+			const encoded = encodeInvitePayload(SAMPLE_PAYLOAD);
+			const link = inviteLink(encoded);
+			expect(link).toMatch(/^codemem:\/\/join\?invite=/);
+			expect(link).toContain(encodeURIComponent(encoded));
+		});
+	});
+
+	describe("extractInvitePayload", () => {
+		it("extracts from a codemem:// link", () => {
+			const encoded = encodeInvitePayload(SAMPLE_PAYLOAD);
+			const link = inviteLink(encoded);
+			const extracted = extractInvitePayload(link);
+			expect(extracted).toBe(encoded);
+		});
+
+		it("returns raw value if not a codemem:// link", () => {
+			const raw = "some-base64url-value";
+			expect(extractInvitePayload(raw)).toBe(raw);
+		});
+
+		it("trims whitespace", () => {
+			const raw = "  some-value  ";
+			expect(extractInvitePayload(raw)).toBe("some-value");
+		});
+
+		it("throws if codemem:// link has no invite param", () => {
+			expect(() => extractInvitePayload("codemem://join?other=foo")).toThrow(
+				"invite payload missing from link",
+			);
+		});
+
+		it("full round-trip: encode → link → extract → decode", () => {
+			const encoded = encodeInvitePayload(SAMPLE_PAYLOAD);
+			const link = inviteLink(encoded);
+			const extracted = extractInvitePayload(link);
+			const decoded = decodeInvitePayload(extracted);
+			expect(decoded).toEqual(SAMPLE_PAYLOAD);
+		});
+	});
+});

--- a/packages/core/src/coordinator-invites.ts
+++ b/packages/core/src/coordinator-invites.ts
@@ -1,0 +1,60 @@
+/**
+ * Invite link encoding/decoding for the coordinator join flow.
+ *
+ * Ported from codemem/coordinator_invites.py.
+ */
+
+export interface InvitePayload {
+	v: number;
+	kind: string;
+	coordinator_url: string;
+	group_id: string;
+	policy: string;
+	token: string;
+	expires_at: string;
+	team_name: string | null;
+}
+
+/** Encode an invite payload as a compact base64url string (no padding). */
+export function encodeInvitePayload(payload: InvitePayload): string {
+	const json = JSON.stringify(payload);
+	const bytes = new TextEncoder().encode(json);
+	const base64 = Buffer.from(bytes).toString("base64url");
+	// base64url from Buffer already omits padding — strip defensively
+	return base64.replace(/=+$/, "");
+}
+
+/** Decode a base64url invite payload string back to an InvitePayload. */
+export function decodeInvitePayload(value: string): InvitePayload {
+	// Re-add padding that was stripped
+	const padded = value + "=".repeat((4 - (value.length % 4)) % 4);
+	const json = Buffer.from(padded, "base64url").toString("utf-8");
+	const data: unknown = JSON.parse(json);
+	if (typeof data !== "object" || data === null) {
+		throw new Error("invalid invite payload");
+	}
+	return data as InvitePayload;
+}
+
+/** Build a `codemem://join?invite=...` link from an encoded payload. */
+export function inviteLink(encodedPayload: string): string {
+	return `codemem://join?invite=${encodeURIComponent(encodedPayload)}`;
+}
+
+/**
+ * Extract the raw encoded payload from either a `codemem://` link or a raw value.
+ *
+ * Throws if a `codemem://` link is provided but has no `invite` query parameter.
+ */
+export function extractInvitePayload(value: string): string {
+	const raw = value.trim();
+	if (raw.startsWith("codemem://")) {
+		const url = new URL(raw);
+		const invite = url.searchParams.get("invite") ?? "";
+		if (!invite) {
+			throw new Error("invite payload missing from link");
+		}
+		return invite;
+	}
+	return raw;
+}

--- a/packages/core/src/coordinator-store.test.ts
+++ b/packages/core/src/coordinator-store.test.ts
@@ -1,0 +1,409 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CoordinatorStore } from "./coordinator-store.js";
+
+describe("CoordinatorStore", () => {
+	let tmpDir: string;
+	let store: CoordinatorStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "coord-test-"));
+		store = new CoordinatorStore(join(tmpDir, "coordinator.sqlite"));
+	});
+
+	afterEach(() => {
+		store.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// -- Schema -------------------------------------------------------------
+
+	describe("schema", () => {
+		it("creates all expected tables", () => {
+			const tables = store.db
+				.prepare(
+					"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+				)
+				.all() as { name: string }[];
+			const names = tables.map((t) => t.name).sort();
+			expect(names).toEqual([
+				"coordinator_invites",
+				"coordinator_join_requests",
+				"enrolled_devices",
+				"groups",
+				"presence_records",
+				"request_nonces",
+			]);
+		});
+	});
+
+	// -- Groups -------------------------------------------------------------
+
+	describe("groups", () => {
+		it("creates and retrieves a group", () => {
+			store.createGroup("g1", "Team Alpha");
+			const group = store.getGroup("g1");
+			expect(group).not.toBeNull();
+			expect(group?.group_id).toBe("g1");
+			expect(group?.display_name).toBe("Team Alpha");
+			expect(group?.created_at).toBeTruthy();
+		});
+
+		it("returns null for missing group", () => {
+			expect(store.getGroup("nope")).toBeNull();
+		});
+
+		it("INSERT OR IGNORE on duplicate group_id", () => {
+			store.createGroup("g1", "Original");
+			store.createGroup("g1", "Changed");
+			expect(store.getGroup("g1")?.display_name).toBe("Original");
+		});
+
+		it("lists groups", () => {
+			store.createGroup("g1");
+			store.createGroup("g2", "Second");
+			const groups = store.listGroups();
+			expect(groups).toHaveLength(2);
+		});
+	});
+
+	// -- Devices ------------------------------------------------------------
+
+	describe("devices", () => {
+		beforeEach(() => {
+			store.createGroup("g1");
+		});
+
+		it("enrolls and retrieves a device", () => {
+			store.enrollDevice("g1", {
+				deviceId: "d1",
+				fingerprint: "fp1",
+				publicKey: "pk1",
+				displayName: "Laptop",
+			});
+			const enrollment = store.getEnrollment("g1", "d1");
+			expect(enrollment).not.toBeNull();
+			expect(enrollment?.device_id).toBe("d1");
+			expect(enrollment?.display_name).toBe("Laptop");
+		});
+
+		it("returns null for missing enrollment", () => {
+			expect(store.getEnrollment("g1", "missing")).toBeNull();
+		});
+
+		it("upserts on re-enroll", () => {
+			store.enrollDevice("g1", {
+				deviceId: "d1",
+				fingerprint: "fp1",
+				publicKey: "pk1",
+				displayName: "Old",
+			});
+			store.enrollDevice("g1", {
+				deviceId: "d1",
+				fingerprint: "fp2",
+				publicKey: "pk2",
+				displayName: "New",
+			});
+			const enrollment = store.getEnrollment("g1", "d1");
+			expect(enrollment?.fingerprint).toBe("fp2");
+			expect(enrollment?.display_name).toBe("New");
+		});
+
+		it("lists enrolled devices", () => {
+			store.enrollDevice("g1", {
+				deviceId: "d1",
+				fingerprint: "fp1",
+				publicKey: "pk1",
+			});
+			store.enrollDevice("g1", {
+				deviceId: "d2",
+				fingerprint: "fp2",
+				publicKey: "pk2",
+			});
+			expect(store.listEnrolledDevices("g1")).toHaveLength(2);
+		});
+
+		it("renames a device", () => {
+			store.enrollDevice("g1", {
+				deviceId: "d1",
+				fingerprint: "fp1",
+				publicKey: "pk1",
+			});
+			expect(store.renameDevice("g1", "d1", "Desktop")).toBe(true);
+			expect(store.getEnrollment("g1", "d1")?.display_name).toBe("Desktop");
+		});
+
+		it("disables and re-enables a device", () => {
+			store.enrollDevice("g1", {
+				deviceId: "d1",
+				fingerprint: "fp1",
+				publicKey: "pk1",
+			});
+			store.setDeviceEnabled("g1", "d1", false);
+			// Disabled device not returned by default
+			expect(store.listEnrolledDevices("g1")).toHaveLength(0);
+			// But shows up with includeDisabled
+			expect(store.listEnrolledDevices("g1", true)).toHaveLength(1);
+			// Re-enable
+			store.setDeviceEnabled("g1", "d1", true);
+			expect(store.listEnrolledDevices("g1")).toHaveLength(1);
+		});
+
+		it("removes a device and its presence", () => {
+			store.enrollDevice("g1", {
+				deviceId: "d1",
+				fingerprint: "fp1",
+				publicKey: "pk1",
+			});
+			store.upsertPresence({
+				groupId: "g1",
+				deviceId: "d1",
+				addresses: ["http://localhost:9000"],
+				ttlS: 300,
+			});
+			expect(store.removeDevice("g1", "d1")).toBe(true);
+			expect(store.getEnrollment("g1", "d1")).toBeNull();
+			// Verify presence was also cleaned up
+			const presence = store.db
+				.prepare("SELECT * FROM presence_records WHERE group_id = ? AND device_id = ?")
+				.get("g1", "d1");
+			expect(presence).toBeUndefined();
+		});
+
+		it("returns false when removing a non-existent device", () => {
+			expect(store.removeDevice("g1", "ghost")).toBe(false);
+		});
+	});
+
+	// -- Presence -----------------------------------------------------------
+
+	describe("presence", () => {
+		beforeEach(() => {
+			store.createGroup("g1");
+			store.enrollDevice("g1", {
+				deviceId: "d1",
+				fingerprint: "fp1",
+				publicKey: "pk1",
+			});
+			store.enrollDevice("g1", {
+				deviceId: "d2",
+				fingerprint: "fp2",
+				publicKey: "pk2",
+			});
+		});
+
+		it("upserts presence and returns normalized data", () => {
+			const result = store.upsertPresence({
+				groupId: "g1",
+				deviceId: "d1",
+				addresses: ["http://localhost:9000"],
+				ttlS: 300,
+			});
+			expect(result.group_id).toBe("g1");
+			expect(result.device_id).toBe("d1");
+			expect(result.addresses).toEqual(["http://localhost:9000"]);
+			expect(result.expires_at).toBeTruthy();
+		});
+
+		it("lists group peers excluding requesting device", () => {
+			store.upsertPresence({
+				groupId: "g1",
+				deviceId: "d1",
+				addresses: ["http://localhost:9000"],
+				ttlS: 300,
+			});
+			store.upsertPresence({
+				groupId: "g1",
+				deviceId: "d2",
+				addresses: ["http://localhost:9001"],
+				ttlS: 300,
+			});
+			// d1 asks for peers — should only see d2
+			const peers = store.listGroupPeers("g1", "d1");
+			expect(peers).toHaveLength(1);
+			expect(peers[0].device_id).toBe("d2");
+			expect(peers[0].stale).toBe(false);
+			expect(peers[0].addresses).toEqual(["http://localhost:9001"]);
+		});
+
+		it("marks stale presence with empty addresses", () => {
+			// Set presence with 0 TTL so it expires immediately
+			store.upsertPresence({
+				groupId: "g1",
+				deviceId: "d2",
+				addresses: ["http://localhost:9001"],
+				ttlS: 0,
+			});
+			const peers = store.listGroupPeers("g1", "d1");
+			expect(peers).toHaveLength(1);
+			expect(peers[0].stale).toBe(true);
+			expect(peers[0].addresses).toEqual([]);
+		});
+
+		it("shows enrolled peers with no presence record", () => {
+			// d2 never reported presence
+			const peers = store.listGroupPeers("g1", "d1");
+			expect(peers).toHaveLength(1);
+			expect(peers[0].device_id).toBe("d2");
+			expect(peers[0].stale).toBe(true);
+			expect(peers[0].addresses).toEqual([]);
+		});
+	});
+
+	// -- Invites ------------------------------------------------------------
+
+	describe("invites", () => {
+		beforeEach(() => {
+			store.createGroup("g1", "Team Alpha");
+		});
+
+		it("creates an invite and retrieves by token", () => {
+			const invite = store.createInvite({
+				groupId: "g1",
+				policy: "auto_approve",
+				expiresAt: "2099-01-01T00:00:00Z",
+				createdBy: "admin",
+			});
+			expect(invite.invite_id).toBeTruthy();
+			expect(invite.group_id).toBe("g1");
+			expect(invite.policy).toBe("auto_approve");
+			expect(invite.team_name_snapshot).toBe("Team Alpha");
+
+			const byToken = store.getInviteByToken(invite.token as string);
+			expect(byToken).not.toBeNull();
+			expect(byToken?.invite_id).toBe(invite.invite_id);
+		});
+
+		it("returns null for unknown token", () => {
+			expect(store.getInviteByToken("nonexistent")).toBeNull();
+		});
+
+		it("lists invites for a group", () => {
+			store.createInvite({
+				groupId: "g1",
+				policy: "auto_approve",
+				expiresAt: "2099-01-01T00:00:00Z",
+			});
+			store.createInvite({
+				groupId: "g1",
+				policy: "manual_review",
+				expiresAt: "2099-06-01T00:00:00Z",
+			});
+			expect(store.listInvites("g1")).toHaveLength(2);
+		});
+	});
+
+	// -- Join requests ------------------------------------------------------
+
+	describe("join requests", () => {
+		let inviteToken: string;
+
+		beforeEach(() => {
+			store.createGroup("g1");
+			const invite = store.createInvite({
+				groupId: "g1",
+				policy: "manual_review",
+				expiresAt: "2099-01-01T00:00:00Z",
+			});
+			inviteToken = invite.token as string;
+		});
+
+		it("creates a join request in pending status", () => {
+			const req = store.createJoinRequest({
+				groupId: "g1",
+				deviceId: "d-new",
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				displayName: "New Device",
+				token: inviteToken,
+			});
+			expect(req.request_id).toBeTruthy();
+			expect(req.status).toBe("pending");
+			expect(req.device_id).toBe("d-new");
+		});
+
+		it("lists pending join requests", () => {
+			store.createJoinRequest({
+				groupId: "g1",
+				deviceId: "d1",
+				publicKey: "pk1",
+				fingerprint: "fp1",
+				token: inviteToken,
+			});
+			store.createJoinRequest({
+				groupId: "g1",
+				deviceId: "d2",
+				publicKey: "pk2",
+				fingerprint: "fp2",
+				token: inviteToken,
+			});
+			const pending = store.listJoinRequests("g1");
+			expect(pending).toHaveLength(2);
+		});
+
+		it("approves a join request and enrolls the device", () => {
+			const req = store.createJoinRequest({
+				groupId: "g1",
+				deviceId: "d-new",
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				displayName: "New Device",
+				token: inviteToken,
+			});
+			const reviewed = store.reviewJoinRequest({
+				requestId: req.request_id as string,
+				approved: true,
+				reviewedBy: "admin",
+			});
+			expect(reviewed).not.toBeNull();
+			expect(reviewed?.status).toBe("approved");
+			expect(reviewed?.reviewed_by).toBe("admin");
+
+			// Device should now be enrolled
+			const enrollment = store.getEnrollment("g1", "d-new");
+			expect(enrollment).not.toBeNull();
+			expect(enrollment?.fingerprint).toBe("fp-new");
+		});
+
+		it("denies a join request without enrolling", () => {
+			const req = store.createJoinRequest({
+				groupId: "g1",
+				deviceId: "d-new",
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				token: inviteToken,
+			});
+			const reviewed = store.reviewJoinRequest({
+				requestId: req.request_id as string,
+				approved: false,
+			});
+			expect(reviewed?.status).toBe("denied");
+			expect(store.getEnrollment("g1", "d-new")).toBeNull();
+		});
+
+		it("returns null for missing request_id", () => {
+			expect(store.reviewJoinRequest({ requestId: "nope", approved: true })).toBeNull();
+		});
+
+		it("returns _no_transition for already-reviewed request", () => {
+			const req = store.createJoinRequest({
+				groupId: "g1",
+				deviceId: "d-new",
+				publicKey: "pk-new",
+				fingerprint: "fp-new",
+				token: inviteToken,
+			});
+			store.reviewJoinRequest({
+				requestId: req.request_id as string,
+				approved: true,
+			});
+			const again = store.reviewJoinRequest({
+				requestId: req.request_id as string,
+				approved: false,
+			});
+			expect(again?._no_transition).toBe(true);
+		});
+	});
+});

--- a/packages/core/src/coordinator-store.ts
+++ b/packages/core/src/coordinator-store.ts
@@ -1,0 +1,495 @@
+/**
+ * CoordinatorStore — SQLite-backed state for the coordinator relay server.
+ *
+ * The coordinator is a cloud relay that manages group membership, device
+ * enrollment, presence, invites, and join requests for sync between devices.
+ *
+ * This store uses its OWN database (separate from the main codemem DB) and
+ * owns its own schema — the TS side creates tables directly.
+ *
+ * Ported from codemem/coordinator_store.py.
+ */
+
+import { randomBytes } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { Database as DatabaseType } from "better-sqlite3";
+import Database from "better-sqlite3";
+import { mergeAddresses } from "./address-utils.js";
+
+export const DEFAULT_COORDINATOR_DB_PATH = join(homedir(), ".codemem", "coordinator.sqlite");
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nowISO(): string {
+	return new Date().toISOString();
+}
+
+function tokenUrlSafe(bytes: number): string {
+	return randomBytes(bytes).toString("base64url").replace(/=+$/, "");
+}
+
+function rowToRecord(row: unknown): Record<string, unknown> {
+	if (row == null) return {};
+	// better-sqlite3 returns plain objects when using .get()/.all()
+	return row as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+function initializeSchema(db: DatabaseType): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS groups (
+			group_id TEXT PRIMARY KEY,
+			display_name TEXT,
+			created_at TEXT NOT NULL
+		);
+
+		CREATE TABLE IF NOT EXISTS enrolled_devices (
+			group_id TEXT NOT NULL,
+			device_id TEXT NOT NULL,
+			public_key TEXT NOT NULL,
+			fingerprint TEXT NOT NULL,
+			display_name TEXT,
+			enabled INTEGER NOT NULL DEFAULT 1,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (group_id, device_id)
+		);
+
+		CREATE TABLE IF NOT EXISTS presence_records (
+			group_id TEXT NOT NULL,
+			device_id TEXT NOT NULL,
+			addresses_json TEXT NOT NULL,
+			last_seen_at TEXT NOT NULL,
+			expires_at TEXT NOT NULL,
+			capabilities_json TEXT NOT NULL DEFAULT '{}',
+			PRIMARY KEY (group_id, device_id)
+		);
+
+		CREATE TABLE IF NOT EXISTS request_nonces (
+			device_id TEXT NOT NULL,
+			nonce TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (device_id, nonce)
+		);
+
+		CREATE TABLE IF NOT EXISTS coordinator_invites (
+			invite_id TEXT PRIMARY KEY,
+			group_id TEXT NOT NULL,
+			token TEXT NOT NULL UNIQUE,
+			policy TEXT NOT NULL,
+			expires_at TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			created_by TEXT,
+			team_name_snapshot TEXT,
+			revoked_at TEXT
+		);
+
+		CREATE TABLE IF NOT EXISTS coordinator_join_requests (
+			request_id TEXT PRIMARY KEY,
+			group_id TEXT NOT NULL,
+			device_id TEXT NOT NULL,
+			public_key TEXT NOT NULL,
+			fingerprint TEXT NOT NULL,
+			display_name TEXT,
+			token TEXT NOT NULL,
+			status TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			reviewed_at TEXT,
+			reviewed_by TEXT
+		);
+	`);
+}
+
+// ---------------------------------------------------------------------------
+// Connection
+// ---------------------------------------------------------------------------
+
+export function connectCoordinator(path?: string): DatabaseType {
+	const dbPath = path ?? DEFAULT_COORDINATOR_DB_PATH;
+	mkdirSync(dirname(dbPath), { recursive: true });
+	const db = new Database(dbPath);
+	db.pragma("foreign_keys = ON");
+	db.pragma("busy_timeout = 5000");
+	db.pragma("journal_mode = WAL");
+	db.pragma("synchronous = NORMAL");
+	initializeSchema(db);
+	return db;
+}
+
+// ---------------------------------------------------------------------------
+// CoordinatorStore
+// ---------------------------------------------------------------------------
+
+export class CoordinatorStore {
+	readonly path: string;
+	readonly db: DatabaseType;
+
+	constructor(path?: string) {
+		this.path = path ?? DEFAULT_COORDINATOR_DB_PATH;
+		this.db = connectCoordinator(this.path);
+	}
+
+	close(): void {
+		this.db.close();
+	}
+
+	// -- Groups -------------------------------------------------------------
+
+	createGroup(groupId: string, displayName?: string | null): void {
+		this.db
+			.prepare("INSERT OR IGNORE INTO groups(group_id, display_name, created_at) VALUES (?, ?, ?)")
+			.run(groupId, displayName ?? null, nowISO());
+	}
+
+	getGroup(groupId: string): Record<string, unknown> | null {
+		const row = this.db
+			.prepare("SELECT group_id, display_name, created_at FROM groups WHERE group_id = ?")
+			.get(groupId);
+		return row ? rowToRecord(row) : null;
+	}
+
+	listGroups(): Record<string, unknown>[] {
+		return this.db
+			.prepare("SELECT group_id, display_name, created_at FROM groups ORDER BY created_at ASC")
+			.all()
+			.map(rowToRecord);
+	}
+
+	// -- Devices ------------------------------------------------------------
+
+	enrollDevice(
+		groupId: string,
+		opts: {
+			deviceId: string;
+			fingerprint: string;
+			publicKey: string;
+			displayName?: string | null;
+		},
+	): void {
+		this.db
+			.prepare(
+				`INSERT INTO enrolled_devices(
+					group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+				) VALUES (?, ?, ?, ?, ?, 1, ?)
+				ON CONFLICT(group_id, device_id) DO UPDATE SET
+					public_key = excluded.public_key,
+					fingerprint = excluded.fingerprint,
+					display_name = excluded.display_name,
+					enabled = 1`,
+			)
+			.run(
+				groupId,
+				opts.deviceId,
+				opts.publicKey,
+				opts.fingerprint,
+				opts.displayName ?? null,
+				nowISO(),
+			);
+	}
+
+	listEnrolledDevices(groupId: string, includeDisabled = false): Record<string, unknown>[] {
+		const where = includeDisabled ? "" : "AND enabled = 1";
+		return this.db
+			.prepare(
+				`SELECT group_id, device_id, fingerprint, display_name, enabled, created_at
+				 FROM enrolled_devices
+				 WHERE group_id = ? ${where}
+				 ORDER BY created_at ASC, device_id ASC`,
+			)
+			.all(groupId)
+			.map(rowToRecord);
+	}
+
+	getEnrollment(groupId: string, deviceId: string): Record<string, unknown> | null {
+		const row = this.db
+			.prepare(
+				`SELECT device_id, public_key, fingerprint, display_name
+				 FROM enrolled_devices
+				 WHERE group_id = ? AND device_id = ? AND enabled = 1`,
+			)
+			.get(groupId, deviceId);
+		return row ? rowToRecord(row) : null;
+	}
+
+	renameDevice(groupId: string, deviceId: string, displayName: string): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE enrolled_devices SET display_name = ?
+				 WHERE group_id = ? AND device_id = ?`,
+			)
+			.run(displayName, groupId, deviceId);
+		return result.changes > 0;
+	}
+
+	setDeviceEnabled(groupId: string, deviceId: string, enabled: boolean): boolean {
+		const result = this.db
+			.prepare(
+				`UPDATE enrolled_devices SET enabled = ?
+				 WHERE group_id = ? AND device_id = ?`,
+			)
+			.run(enabled ? 1 : 0, groupId, deviceId);
+		return result.changes > 0;
+	}
+
+	removeDevice(groupId: string, deviceId: string): boolean {
+		this.db
+			.prepare("DELETE FROM presence_records WHERE group_id = ? AND device_id = ?")
+			.run(groupId, deviceId);
+		const result = this.db
+			.prepare("DELETE FROM enrolled_devices WHERE group_id = ? AND device_id = ?")
+			.run(groupId, deviceId);
+		return result.changes > 0;
+	}
+
+	// -- Invites ------------------------------------------------------------
+
+	createInvite(opts: {
+		groupId: string;
+		policy: string;
+		expiresAt: string;
+		createdBy?: string | null;
+	}): Record<string, unknown> {
+		const now = nowISO();
+		const inviteId = tokenUrlSafe(12);
+		const token = tokenUrlSafe(24);
+		const group = this.getGroup(opts.groupId);
+
+		this.db
+			.prepare(
+				`INSERT INTO coordinator_invites(
+					invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+			)
+			.run(
+				inviteId,
+				opts.groupId,
+				token,
+				opts.policy,
+				opts.expiresAt,
+				now,
+				opts.createdBy ?? null,
+				(group?.display_name as string) ?? null,
+			);
+
+		const row = this.db
+			.prepare(
+				`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+				 FROM coordinator_invites WHERE invite_id = ?`,
+			)
+			.get(inviteId);
+		return row ? rowToRecord(row) : {};
+	}
+
+	getInviteByToken(token: string): Record<string, unknown> | null {
+		const row = this.db
+			.prepare(
+				`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+				 FROM coordinator_invites
+				 WHERE token = ?
+				   AND revoked_at IS NULL
+				   AND expires_at > ?`,
+			)
+			.get(token, new Date().toISOString());
+		return row ? rowToRecord(row) : null;
+	}
+
+	listInvites(groupId: string): Record<string, unknown>[] {
+		return this.db
+			.prepare(
+				`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+				 FROM coordinator_invites WHERE group_id = ?
+				 ORDER BY created_at ASC`,
+			)
+			.all(groupId)
+			.map(rowToRecord);
+	}
+
+	// -- Join requests ------------------------------------------------------
+
+	createJoinRequest(opts: {
+		groupId: string;
+		deviceId: string;
+		publicKey: string;
+		fingerprint: string;
+		displayName?: string | null;
+		token: string;
+	}): Record<string, unknown> {
+		const now = nowISO();
+		const requestId = tokenUrlSafe(12);
+
+		this.db
+			.prepare(
+				`INSERT INTO coordinator_join_requests(
+					request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+				) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL, NULL)`,
+			)
+			.run(
+				requestId,
+				opts.groupId,
+				opts.deviceId,
+				opts.publicKey,
+				opts.fingerprint,
+				opts.displayName ?? null,
+				opts.token,
+				now,
+			);
+
+		const row = this.db
+			.prepare(
+				`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+				 FROM coordinator_join_requests WHERE request_id = ?`,
+			)
+			.get(requestId);
+		return row ? rowToRecord(row) : {};
+	}
+
+	listJoinRequests(groupId: string, status = "pending"): Record<string, unknown>[] {
+		return this.db
+			.prepare(
+				`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+				 FROM coordinator_join_requests
+				 WHERE group_id = ? AND status = ?
+				 ORDER BY created_at ASC, device_id ASC`,
+			)
+			.all(groupId, status)
+			.map(rowToRecord);
+	}
+
+	reviewJoinRequest(opts: {
+		requestId: string;
+		approved: boolean;
+		reviewedBy?: string | null;
+	}): (Record<string, unknown> & { _no_transition?: boolean }) | null {
+		const row = this.db
+			.prepare(
+				`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status
+				 FROM coordinator_join_requests WHERE request_id = ?`,
+			)
+			.get(opts.requestId) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+
+		if (row.status !== "pending") {
+			return { ...rowToRecord(row), _no_transition: true };
+		}
+
+		// Wrap enroll + status update in a transaction for atomicity
+		return this.db.transaction(() => {
+			const reviewedAt = nowISO();
+			const nextStatus = opts.approved ? "approved" : "denied";
+
+			if (opts.approved) {
+				this.enrollDevice(row.group_id as string, {
+					deviceId: row.device_id as string,
+					fingerprint: row.fingerprint as string,
+					publicKey: row.public_key as string,
+					displayName: ((row.display_name as string) ?? "").trim() || null,
+				});
+			}
+
+			this.db
+				.prepare(
+					`UPDATE coordinator_join_requests
+					 SET status = ?, reviewed_at = ?, reviewed_by = ?
+					 WHERE request_id = ?`,
+				)
+				.run(nextStatus, reviewedAt, opts.reviewedBy ?? null, opts.requestId);
+
+			const updated = this.db
+				.prepare(
+					`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+					 FROM coordinator_join_requests WHERE request_id = ?`,
+				)
+				.get(opts.requestId);
+			return updated ? rowToRecord(updated) : null;
+		})();
+	}
+
+	// -- Presence -----------------------------------------------------------
+
+	upsertPresence(opts: {
+		groupId: string;
+		deviceId: string;
+		addresses: string[];
+		ttlS: number;
+		capabilities?: Record<string, unknown> | null;
+	}): Record<string, unknown> {
+		const now = new Date();
+		const expiresAt = new Date(now.getTime() + opts.ttlS * 1000).toISOString();
+		const normalized = mergeAddresses([], opts.addresses);
+
+		this.db
+			.prepare(
+				`INSERT INTO presence_records(group_id, device_id, addresses_json, last_seen_at, expires_at, capabilities_json)
+				 VALUES (?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(group_id, device_id) DO UPDATE SET
+					addresses_json = excluded.addresses_json,
+					last_seen_at = excluded.last_seen_at,
+					expires_at = excluded.expires_at,
+					capabilities_json = excluded.capabilities_json`,
+			)
+			.run(
+				opts.groupId,
+				opts.deviceId,
+				JSON.stringify(normalized),
+				now.toISOString(),
+				expiresAt,
+				JSON.stringify(opts.capabilities ?? {}),
+			);
+
+		return {
+			group_id: opts.groupId,
+			device_id: opts.deviceId,
+			addresses: normalized,
+			expires_at: expiresAt,
+		};
+	}
+
+	listGroupPeers(groupId: string, requestingDeviceId: string): Record<string, unknown>[] {
+		const now = new Date();
+		const rows = this.db
+			.prepare(
+				`SELECT enrolled_devices.device_id, enrolled_devices.fingerprint, enrolled_devices.display_name,
+						presence_records.addresses_json, presence_records.last_seen_at, presence_records.expires_at,
+						presence_records.capabilities_json
+				 FROM enrolled_devices
+				 LEFT JOIN presence_records
+				   ON presence_records.group_id = enrolled_devices.group_id
+				  AND presence_records.device_id = enrolled_devices.device_id
+				 WHERE enrolled_devices.group_id = ?
+				   AND enrolled_devices.enabled = 1
+				   AND enrolled_devices.device_id != ?
+				 ORDER BY enrolled_devices.device_id ASC`,
+			)
+			.all(groupId, requestingDeviceId) as Record<string, unknown>[];
+
+		return rows.map((row) => {
+			const expiresRaw = String(row.expires_at ?? "").trim();
+			let stale = true;
+			if (expiresRaw) {
+				const expiresAt = new Date(expiresRaw);
+				// Invalid Date has NaN time — treat as stale
+				stale = Number.isNaN(expiresAt.getTime()) || expiresAt <= now;
+			}
+			const addresses = stale
+				? []
+				: mergeAddresses([], JSON.parse((row.addresses_json as string) || "[]") as string[]);
+
+			return {
+				device_id: row.device_id,
+				fingerprint: row.fingerprint,
+				display_name: row.display_name,
+				addresses,
+				last_seen_at: row.last_seen_at,
+				expires_at: row.expires_at,
+				stale,
+				capabilities: JSON.parse((row.capabilities_json as string) || "{}"),
+			};
+		});
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,20 @@
 
 export const VERSION = "0.0.1";
 
+export { addressDedupeKey, mergeAddresses, normalizeAddress } from "./address-utils.js";
 export * as Api from "./api-types.js";
+export type { InvitePayload } from "./coordinator-invites.js";
+export {
+	decodeInvitePayload,
+	encodeInvitePayload,
+	extractInvitePayload,
+	inviteLink,
+} from "./coordinator-invites.js";
+export {
+	CoordinatorStore,
+	connectCoordinator,
+	DEFAULT_COORDINATOR_DB_PATH,
+} from "./coordinator-store.js";
 export type { Database } from "./db.js";
 export {
 	assertSchemaReady,


### PR DESCRIPTION
## Description

Ports the coordinator store and invites from Python to TypeScript. The coordinator is the cloud relay for device-to-device sync.

### `coordinator-store.ts` (~430 lines)
Own SQLite database at `~/.codemem/coordinator.sqlite` (separate from main codemem DB). Schema created by TS (not Python — coordinator is a standalone service).

**Tables:** groups, enrolled_devices, presence_records, request_nonces, coordinator_invites, join_requests

**Methods:**
- Groups: createGroup, getGroup, listGroups
- Devices: enrollDevice, listEnrolledDevices, getEnrollment, renameDevice, setDeviceEnabled, removeDevice
- Presence: upsertPresence, listGroupPeers (stale detection, excludes self device)
- Invites: createInvite, getInviteByToken, listInvites
- Join requests: createJoinRequest, listJoinRequests, reviewJoinRequest (auto-enrolls on approve)

### `coordinator-invites.ts` (~63 lines)
- Invite payload encode/decode (base64url, no padding)
- `codemem://join?invite=...` link format
- Extract from link or raw encoded value

36 new tests. 307 total.

Part of: codemem-2b8

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Tests pass locally (`pnpm run check` — 307 tests)
- [x] 26 coordinator store tests, 10 invite tests

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new errors introduced