### PR TITLE
Port sync discovery and daemon to TypeScript

### DIFF
--- a/packages/core/src/coordinator-store.ts
+++ b/packages/core/src/coordinator-store.ts
@@ -16,9 +16,65 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { Database as DatabaseType } from "better-sqlite3";
 import Database from "better-sqlite3";
-import { mergeAddresses } from "./address-utils.js";
 
 export const DEFAULT_COORDINATOR_DB_PATH = join(homedir(), ".codemem", "coordinator.sqlite");
+
+// ---------------------------------------------------------------------------
+// Address helpers (subset of sync/discovery.py, inlined to avoid circular deps)
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize an address using the URL constructor.
+ * Duplicated from sync-discovery.ts to avoid circular deps
+ * (coordinator-store loads before sync-discovery in the stack).
+ * TODO: extract to shared address-utils.ts module.
+ */
+function normalizeAddress(address: string): string {
+	const value = address.trim();
+	if (!value) return "";
+	const withScheme = value.includes("://") ? value : `http://${value}`;
+	try {
+		const url = new URL(withScheme);
+		if (!url.hostname) return "";
+		if (url.port && (Number(url.port) <= 0 || Number(url.port) > 65535)) return "";
+		return url.origin + url.pathname.replace(/\/+$/, "");
+	} catch {
+		return "";
+	}
+}
+
+function addressDedupeKey(address: string): string {
+	if (!address) return "";
+	try {
+		const parsed = new URL(address);
+		const host = parsed.hostname.toLowerCase();
+		if (
+			(parsed.protocol === "http:" || parsed.protocol === "") &&
+			host &&
+			parsed.port &&
+			parsed.pathname === "/"
+		) {
+			return `${host}:${parsed.port}`;
+		}
+	} catch {
+		// Not parseable
+	}
+	return address;
+}
+
+function mergeAddresses(existing: string[], candidates: string[]): string[] {
+	const normalized: string[] = [];
+	const seen = new Set<string>();
+	for (const address of [...existing, ...candidates]) {
+		const cleaned = normalizeAddress(address);
+		const key = addressDedupeKey(cleaned);
+		if (!cleaned || seen.has(key)) continue;
+		seen.add(key);
+		normalized.push(cleaned);
+	}
+	return normalized;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,6 @@
 
 export const VERSION = "0.0.1";
 
-export { addressDedupeKey, mergeAddresses, normalizeAddress } from "./address-utils.js";
 export * as Api from "./api-types.js";
 export type { InvitePayload } from "./coordinator-invites.js";
 export {
@@ -140,6 +139,31 @@ export {
 	signRequest,
 	verifySignature,
 } from "./sync-auth.js";
+export type { SyncDaemonOptions, SyncTickResult } from "./sync-daemon.js";
+export {
+	runSyncDaemon,
+	setSyncDaemonError,
+	setSyncDaemonOk,
+	syncDaemonTick,
+} from "./sync-daemon.js";
+export type { MdnsEntry } from "./sync-discovery.js";
+export {
+	addressDedupeKey,
+	advertiseMdns,
+	DEFAULT_SERVICE_TYPE,
+	discoverPeersViaMdns,
+	loadPeerAddresses,
+	mdnsAddressesForPeer,
+	mdnsEnabled,
+	mergeAddresses,
+	normalizeAddress,
+	recordPeerSuccess,
+	recordSyncAttempt,
+	selectDialAddresses,
+	setPeerLocalActorClaim,
+	setPeerProjectFilter,
+	updatePeerAddresses,
+} from "./sync-discovery.js";
 export type { RequestJsonOptions } from "./sync-http-client.js";
 export { buildBaseUrl, requestJson } from "./sync-http-client.js";
 export type { EnsureDeviceIdentityOptions } from "./sync-identity.js";

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -1,0 +1,158 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setSyncDaemonError, setSyncDaemonOk, syncDaemonTick } from "./sync-daemon.js";
+import { initTestSchema } from "./test-utils.js";
+
+// Mock sync-pass to avoid needing real keys/network
+vi.mock("./sync-pass.js", () => ({
+	syncPassPreflight: vi.fn(),
+	runSyncPass: vi.fn().mockResolvedValue({ ok: true, opsIn: 0, opsOut: 0, addressErrors: [] }),
+	shouldSkipOfflinePeer: vi.fn().mockReturnValue(false),
+}));
+
+// Mock discovery to avoid env var issues
+vi.mock("./sync-discovery.js", () => ({
+	mdnsEnabled: vi.fn().mockReturnValue(false),
+	discoverPeersViaMdns: vi.fn().mockReturnValue([]),
+	advertiseMdns: vi.fn().mockReturnValue({ close: vi.fn() }),
+}));
+
+// ---------------------------------------------------------------------------
+// syncDaemonTick
+// ---------------------------------------------------------------------------
+
+describe("syncDaemonTick", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("returns empty array when no peers exist", async () => {
+		const results = await syncDaemonTick(db);
+		expect(results).toEqual([]);
+	});
+
+	it("runs sync for each peer", async () => {
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "fp1", now);
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-2", "fp2", now);
+
+		const results = await syncDaemonTick(db);
+		expect(results).toHaveLength(2);
+		expect(results[0].ok).toBe(true);
+		expect(results[1].ok).toBe(true);
+	});
+
+	it("skips offline peers in backoff", async () => {
+		const { shouldSkipOfflinePeer } = await import("./sync-pass.js");
+		vi.mocked(shouldSkipOfflinePeer).mockReturnValue(true);
+
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "fp1", now);
+
+		const results = await syncDaemonTick(db);
+		expect(results).toHaveLength(1);
+		expect(results[0].skipped).toBe(true);
+		expect(results[0].reason).toContain("backoff");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Daemon state helpers
+// ---------------------------------------------------------------------------
+
+describe("setSyncDaemonOk", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("inserts daemon ok state", () => {
+		setSyncDaemonOk(db);
+		const row = db.prepare("SELECT * FROM sync_daemon_state WHERE id = 1").get() as Record<
+			string,
+			unknown
+		>;
+		expect(row).toBeTruthy();
+		expect(row.last_ok_at).toBeTruthy();
+	});
+
+	it("updates daemon ok state on subsequent calls", () => {
+		setSyncDaemonOk(db);
+		const first = (
+			db.prepare("SELECT last_ok_at FROM sync_daemon_state WHERE id = 1").get() as Record<
+				string,
+				unknown
+			>
+		).last_ok_at;
+
+		// Small delay to ensure different timestamp
+		setSyncDaemonOk(db);
+		const second = (
+			db.prepare("SELECT last_ok_at FROM sync_daemon_state WHERE id = 1").get() as Record<
+				string,
+				unknown
+			>
+		).last_ok_at;
+
+		// Both should be valid ISO timestamps
+		expect(typeof first).toBe("string");
+		expect(typeof second).toBe("string");
+	});
+});
+
+describe("setSyncDaemonError", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("records error and traceback", () => {
+		setSyncDaemonError(db, "something broke", "Error: something broke\n    at foo.ts:1");
+		const row = db.prepare("SELECT * FROM sync_daemon_state WHERE id = 1").get() as Record<
+			string,
+			unknown
+		>;
+		expect(row.last_error).toBe("something broke");
+		expect(row.last_traceback).toContain("foo.ts");
+		expect(row.last_error_at).toBeTruthy();
+	});
+
+	it("upserts on subsequent errors", () => {
+		setSyncDaemonError(db, "first error");
+		setSyncDaemonError(db, "second error");
+		const row = db.prepare("SELECT * FROM sync_daemon_state WHERE id = 1").get() as Record<
+			string,
+			unknown
+		>;
+		expect(row.last_error).toBe("second error");
+
+		// Should only have 1 row
+		const count = db.prepare("SELECT COUNT(*) as n FROM sync_daemon_state").get() as { n: number };
+		expect(count.n).toBe(1);
+	});
+});

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -1,0 +1,201 @@
+/**
+ * Sync daemon: periodic background sync with all configured peers.
+ *
+ * Uses AbortSignal for cancellation and setInterval for periodic ticks.
+ * Ported from codemem/sync/daemon.py — HTTP server portion is deferred
+ * to the viewer-server Hono routes.
+ */
+
+import type { Database } from "./db.js";
+import { connect as connectDb, resolveDbPath } from "./db.js";
+import { advertiseMdns, discoverPeersViaMdns, mdnsEnabled } from "./sync-discovery.js";
+import { ensureDeviceIdentity } from "./sync-identity.js";
+import { runSyncPass, shouldSkipOfflinePeer, syncPassPreflight } from "./sync-pass.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SyncDaemonOptions {
+	host?: string;
+	port?: number;
+	intervalS?: number;
+	dbPath?: string;
+	keysDir?: string;
+	signal?: AbortSignal;
+}
+
+export interface SyncTickResult {
+	ok: boolean;
+	skipped?: boolean;
+	reason?: string;
+	error?: string;
+	opsIn?: number;
+	opsOut?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Daemon state helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a successful daemon tick in sync_daemon_state.
+ */
+export function setSyncDaemonOk(db: Database): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO sync_daemon_state (id, last_ok_at)
+		 VALUES (1, ?)
+		 ON CONFLICT(id) DO UPDATE SET last_ok_at = excluded.last_ok_at`,
+	).run(now);
+}
+
+/**
+ * Record a daemon tick error in sync_daemon_state.
+ */
+export function setSyncDaemonError(db: Database, error: string, traceback?: string): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO sync_daemon_state (id, last_error, last_traceback, last_error_at)
+		 VALUES (1, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET
+		     last_error = excluded.last_error,
+		     last_traceback = excluded.last_traceback,
+		     last_error_at = excluded.last_error_at`,
+	).run(error, traceback ?? null, now);
+}
+
+// ---------------------------------------------------------------------------
+// Sync tick
+// ---------------------------------------------------------------------------
+
+/**
+ * Run one sync tick: iterate over all enabled peers and sync each.
+ *
+ * Returns per-peer results. Peers in backoff are skipped.
+ */
+export async function syncDaemonTick(db: Database, keysDir?: string): Promise<SyncTickResult[]> {
+	syncPassPreflight(db);
+
+	const mdnsEntries = mdnsEnabled() ? discoverPeersViaMdns() : [];
+	void mdnsEntries; // unused until mDNS is real
+
+	const rows = db.prepare("SELECT peer_device_id FROM sync_peers").all() as Array<{
+		peer_device_id: string;
+	}>;
+
+	const results: SyncTickResult[] = [];
+	for (const row of rows) {
+		const peerDeviceId = row.peer_device_id;
+
+		if (shouldSkipOfflinePeer(db, peerDeviceId)) {
+			results.push({ ok: false, skipped: true, reason: "peer offline (backoff)" });
+			continue;
+		}
+
+		const result = await runSyncPass(db, peerDeviceId, { keysDir });
+		results.push({
+			ok: result.ok,
+			error: result.error,
+			opsIn: result.opsIn,
+			opsOut: result.opsOut,
+		});
+	}
+
+	return results;
+}
+
+// ---------------------------------------------------------------------------
+// Daemon loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the sync daemon loop.
+ *
+ * 1. Ensures device identity
+ * 2. Starts mDNS advertising (if enabled)
+ * 3. Runs an initial sync tick
+ * 4. Sets up an interval timer for periodic sync
+ * 5. Waits for abort signal to stop
+ * 6. Cleans up on exit
+ */
+export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> {
+	const intervalS = options?.intervalS ?? 120;
+	const dbPath = resolveDbPath(options?.dbPath);
+	const keysDir = options?.keysDir;
+	const signal = options?.signal;
+
+	// Ensure device identity
+	const db = connectDb(dbPath);
+	let mdnsHandle: { close(): void } | null = null;
+	try {
+		const [deviceId] = ensureDeviceIdentity(db, { keysDir });
+
+		// Start mDNS advertising if enabled
+		if (mdnsEnabled() && options?.port) {
+			mdnsHandle = advertiseMdns(deviceId, options.port);
+		}
+	} finally {
+		db.close();
+	}
+
+	// Check cancellation before startup tick
+	if (signal?.aborted) {
+		mdnsHandle?.close();
+		return;
+	}
+
+	// Run initial tick
+	await runTickOnce(dbPath, keysDir);
+
+	// If aborted during initial tick, clean up
+	if (signal?.aborted) {
+		mdnsHandle?.close();
+		return;
+	}
+
+	// Set up periodic ticks — serialized to avoid overlapping sync passes
+	return new Promise<void>((resolve) => {
+		let tickRunning = false;
+		const timer = setInterval(() => {
+			if (tickRunning) return; // Skip if previous tick still running
+			tickRunning = true;
+			runTickOnce(dbPath, keysDir).finally(() => {
+				tickRunning = false;
+			});
+		}, intervalS * 1000);
+
+		const cleanup = () => {
+			clearInterval(timer);
+			mdnsHandle?.close();
+			resolve();
+		};
+
+		if (signal) {
+			if (signal.aborted) {
+				cleanup();
+				return;
+			}
+			signal.addEventListener("abort", cleanup, { once: true });
+		}
+	});
+}
+
+/**
+ * Run a single tick, opening and closing a DB connection.
+ *
+ * Errors are caught and recorded in sync_daemon_state.
+ */
+async function runTickOnce(dbPath: string, keysDir?: string): Promise<void> {
+	const db = connectDb(dbPath);
+	try {
+		await syncDaemonTick(db, keysDir);
+		setSyncDaemonOk(db);
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err);
+		const stack = err instanceof Error ? (err.stack ?? "") : "";
+		setSyncDaemonError(db, message, stack);
+	} finally {
+		db.close();
+	}
+}

--- a/packages/core/src/sync-discovery.test.ts
+++ b/packages/core/src/sync-discovery.test.ts
@@ -1,0 +1,333 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	addressDedupeKey,
+	loadPeerAddresses,
+	mdnsAddressesForPeer,
+	mdnsEnabled,
+	mergeAddresses,
+	normalizeAddress,
+	recordPeerSuccess,
+	recordSyncAttempt,
+	selectDialAddresses,
+	updatePeerAddresses,
+} from "./sync-discovery.js";
+import { initTestSchema } from "./test-utils.js";
+
+// ---------------------------------------------------------------------------
+// normalizeAddress
+// ---------------------------------------------------------------------------
+
+describe("normalizeAddress", () => {
+	it("normalizes host:port to http://host:port", () => {
+		expect(normalizeAddress("192.168.1.1:9090")).toBe("http://192.168.1.1:9090");
+	});
+
+	it("normalizes host:port with uppercase", () => {
+		expect(normalizeAddress("MyHost:8080")).toBe("http://myhost:8080");
+	});
+
+	it("preserves scheme and strips default port", () => {
+		// Default ports (443 for https, 80 for http) are stripped — semantically equivalent
+		expect(normalizeAddress("https://example.com:443/path/")).toBe("https://example.com/path");
+		expect(normalizeAddress("https://example.com:8443/path/")).toBe(
+			"https://example.com:8443/path",
+		);
+	});
+
+	it("strips trailing slashes and default port", () => {
+		expect(normalizeAddress("http://host:80/")).toBe("http://host");
+		expect(normalizeAddress("http://host:8080/")).toBe("http://host:8080");
+	});
+
+	it("returns empty for empty input", () => {
+		expect(normalizeAddress("")).toBe("");
+		expect(normalizeAddress("  ")).toBe("");
+	});
+
+	it("returns empty for invalid port", () => {
+		expect(normalizeAddress("host:99999")).toBe("");
+		expect(normalizeAddress("host:0")).toBe("");
+	});
+
+	it("handles http:// prefix without port", () => {
+		expect(normalizeAddress("http://example.com")).toBe("http://example.com");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// addressDedupeKey
+// ---------------------------------------------------------------------------
+
+describe("addressDedupeKey", () => {
+	it("strips http scheme for host:port", () => {
+		expect(addressDedupeKey("http://192.168.1.1:9090")).toBe("192.168.1.1:9090");
+	});
+
+	it("returns as-is for non-URL input", () => {
+		expect(addressDedupeKey("not-a-url")).toBe("not-a-url");
+	});
+
+	it("returns empty for empty input", () => {
+		expect(addressDedupeKey("")).toBe("");
+	});
+
+	it("returns full URL for addresses with paths", () => {
+		// Port 80 is default for http, so dedup key is just the host
+		expect(addressDedupeKey("http://host:80/path")).toBe("host");
+		// Non-default port preserves host:port
+		expect(addressDedupeKey("http://host:8080/path")).toBe("host:8080");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// mergeAddresses
+// ---------------------------------------------------------------------------
+
+describe("mergeAddresses", () => {
+	it("deduplicates addresses", () => {
+		const result = mergeAddresses(
+			["http://host:8080", "192.168.1.1:9090"],
+			["host:8080", "http://192.168.1.1:9090"],
+		);
+		expect(result).toEqual(["http://host:8080", "http://192.168.1.1:9090"]);
+	});
+
+	it("preserves order (existing first)", () => {
+		const result = mergeAddresses(["a.com:1"], ["b.com:2"]);
+		expect(result).toEqual(["http://a.com:1", "http://b.com:2"]);
+	});
+
+	it("filters out empty after normalization", () => {
+		const result = mergeAddresses(["", "  "], ["host:8080"]);
+		expect(result).toEqual(["http://host:8080"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// selectDialAddresses
+// ---------------------------------------------------------------------------
+
+describe("selectDialAddresses", () => {
+	it("returns stored when no mDNS", () => {
+		const result = selectDialAddresses({ stored: ["host:8080"], mdns: [] });
+		expect(result).toEqual(["http://host:8080"]);
+	});
+
+	it("puts mDNS first when available", () => {
+		const result = selectDialAddresses({
+			stored: ["stored:8080"],
+			mdns: ["mdns:9090"],
+		});
+		expect(result[0]).toBe("http://mdns:9090");
+		expect(result[1]).toBe("http://stored:8080");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// DB round-trip: loadPeerAddresses / updatePeerAddresses
+// ---------------------------------------------------------------------------
+
+describe("peer address storage", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("returns empty for unknown peer", () => {
+		expect(loadPeerAddresses(db, "unknown")).toEqual([]);
+	});
+
+	it("round-trips addresses through update/load", () => {
+		updatePeerAddresses(db, "peer-1", ["192.168.1.1:9090"], {
+			name: "test-peer",
+			pinnedFingerprint: "abc123",
+		});
+		const loaded = loadPeerAddresses(db, "peer-1");
+		expect(loaded).toEqual(["http://192.168.1.1:9090"]);
+	});
+
+	it("merges new addresses on subsequent updates", () => {
+		updatePeerAddresses(db, "peer-1", ["host1:8080"]);
+		updatePeerAddresses(db, "peer-1", ["host2:9090"]);
+		const loaded = loadPeerAddresses(db, "peer-1");
+		expect(loaded).toEqual(["http://host1:8080", "http://host2:9090"]);
+	});
+
+	it("deduplicates on merge", () => {
+		updatePeerAddresses(db, "peer-1", ["host:8080"]);
+		updatePeerAddresses(db, "peer-1", ["http://host:8080"]);
+		const loaded = loadPeerAddresses(db, "peer-1");
+		expect(loaded).toEqual(["http://host:8080"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// recordSyncAttempt
+// ---------------------------------------------------------------------------
+
+describe("recordSyncAttempt", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "fp", new Date().toISOString());
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("records a successful attempt and clears last_error", () => {
+		// Set an error first
+		db.prepare("UPDATE sync_peers SET last_error = ? WHERE peer_device_id = ?").run(
+			"old error",
+			"peer-1",
+		);
+		recordSyncAttempt(db, "peer-1", { ok: true, opsIn: 5, opsOut: 3 });
+
+		const attempt = db
+			.prepare("SELECT * FROM sync_attempts WHERE peer_device_id = ?")
+			.get("peer-1") as Record<string, unknown>;
+		expect(attempt.ok).toBe(1);
+		expect(attempt.ops_in).toBe(5);
+		expect(attempt.ops_out).toBe(3);
+
+		const peer = db
+			.prepare("SELECT last_error FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as Record<string, unknown>;
+		expect(peer.last_error).toBeNull();
+	});
+
+	it("records a failed attempt with error", () => {
+		recordSyncAttempt(db, "peer-1", { ok: false, error: "connection refused" });
+
+		const peer = db
+			.prepare("SELECT last_error FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as Record<string, unknown>;
+		expect(peer.last_error).toBe("connection refused");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// recordPeerSuccess
+// ---------------------------------------------------------------------------
+
+describe("recordPeerSuccess", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("promotes successful address to front", () => {
+		updatePeerAddresses(db, "peer-1", ["host1:8080", "host2:90"], {
+			pinnedFingerprint: "fp",
+		});
+		const ordered = recordPeerSuccess(db, "peer-1", "host2:90");
+		expect(ordered[0]).toBe("http://host2:90");
+		expect(ordered[1]).toBe("http://host1:8080");
+	});
+
+	it("handles null address gracefully", () => {
+		updatePeerAddresses(db, "peer-1", ["host1:8080"], {
+			pinnedFingerprint: "fp",
+		});
+		const ordered = recordPeerSuccess(db, "peer-1", null);
+		expect(ordered).toEqual(["http://host1:8080"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// mdnsEnabled
+// ---------------------------------------------------------------------------
+
+describe("mdnsEnabled", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("returns false when env var is not set", () => {
+		vi.stubEnv("CODEMEM_SYNC_MDNS", "");
+		expect(mdnsEnabled()).toBe(false);
+	});
+
+	it("returns true when env var is '1'", () => {
+		vi.stubEnv("CODEMEM_SYNC_MDNS", "1");
+		expect(mdnsEnabled()).toBe(true);
+	});
+
+	it("returns true when env var is 'true'", () => {
+		vi.stubEnv("CODEMEM_SYNC_MDNS", "true");
+		expect(mdnsEnabled()).toBe(true);
+	});
+
+	it("returns false for other values", () => {
+		vi.stubEnv("CODEMEM_SYNC_MDNS", "0");
+		expect(mdnsEnabled()).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// mdnsAddressesForPeer
+// ---------------------------------------------------------------------------
+
+describe("mdnsAddressesForPeer", () => {
+	it("extracts addresses matching peer device ID", () => {
+		const entries = [
+			{
+				host: "peer-host.local",
+				port: 9090,
+				properties: { device_id: "peer-1" },
+			},
+			{
+				host: "other-host.local",
+				port: 9091,
+				properties: { device_id: "peer-2" },
+			},
+		];
+		const addresses = mdnsAddressesForPeer("peer-1", entries);
+		expect(addresses).toEqual(["peer-host.local:9090"]);
+	});
+
+	it("returns empty for no matching peer", () => {
+		const entries = [
+			{
+				host: "host.local",
+				port: 9090,
+				properties: { device_id: "other" },
+			},
+		];
+		expect(mdnsAddressesForPeer("peer-1", entries)).toEqual([]);
+	});
+
+	it("skips entries without device_id property", () => {
+		const entries = [{ host: "host.local", port: 9090, properties: {} }];
+		expect(mdnsAddressesForPeer("peer-1", entries)).toEqual([]);
+	});
+
+	it("handles Uint8Array device_id", () => {
+		const entries = [
+			{
+				host: "host.local",
+				port: 9090,
+				properties: { device_id: new TextEncoder().encode("peer-1") },
+			},
+		];
+		expect(mdnsAddressesForPeer("peer-1", entries)).toEqual(["host.local:9090"]);
+	});
+});

--- a/packages/core/src/sync-discovery.ts
+++ b/packages/core/src/sync-discovery.ts
@@ -1,0 +1,275 @@
+/**
+ * Peer discovery and address management for the codemem sync system.
+ *
+ * Handles address normalization, deduplication, peer address storage,
+ * and mDNS stubs. Ported from codemem/sync/discovery.py.
+ */
+
+import { mergeAddresses, normalizeAddress } from "./address-utils.js";
+import type { Database } from "./db.js";
+
+// Re-export for consumers that import from sync-discovery
+export { addressDedupeKey, mergeAddresses, normalizeAddress } from "./address-utils.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_SERVICE_TYPE = "_codemem._tcp.local.";
+
+// ---------------------------------------------------------------------------
+// Address selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Select addresses to dial, preferring mDNS-discovered addresses.
+ *
+ * mDNS addresses come first, then stored addresses (deduplicated).
+ */
+export function selectDialAddresses(options: { stored: string[]; mdns: string[] }): string[] {
+	if (options.mdns.length === 0) {
+		return mergeAddresses(options.stored, []);
+	}
+	return mergeAddresses(options.mdns, options.stored);
+}
+
+// ---------------------------------------------------------------------------
+// Peer address storage (DB)
+// ---------------------------------------------------------------------------
+
+/**
+ * Load stored addresses for a peer from the sync_peers table.
+ */
+export function loadPeerAddresses(db: Database, peerDeviceId: string): string[] {
+	const row = db
+		.prepare("SELECT addresses_json FROM sync_peers WHERE peer_device_id = ?")
+		.get(peerDeviceId) as { addresses_json: string | null } | undefined;
+	if (!row?.addresses_json) return [];
+	try {
+		const raw = JSON.parse(row.addresses_json);
+		if (!Array.isArray(raw)) return [];
+		return raw.filter((item): item is string => typeof item === "string");
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Update stored addresses for a peer, merging with existing.
+ *
+ * Creates the sync_peers row if it doesn't exist (upsert).
+ * Returns the merged address list.
+ */
+export function updatePeerAddresses(
+	db: Database,
+	peerDeviceId: string,
+	addresses: string[],
+	options?: {
+		name?: string;
+		pinnedFingerprint?: string;
+		publicKey?: string;
+	},
+): string[] {
+	const merged = mergeAddresses(loadPeerAddresses(db, peerDeviceId), addresses);
+	const now = new Date().toISOString();
+	const addressesJson = JSON.stringify(merged);
+
+	// Atomic UPSERT — avoids TOCTOU race with concurrent sync workers
+	db.prepare(
+		`INSERT INTO sync_peers (
+			peer_device_id, name, pinned_fingerprint, public_key,
+			addresses_json, created_at, last_seen_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(peer_device_id) DO UPDATE SET
+			name = COALESCE(excluded.name, name),
+			pinned_fingerprint = COALESCE(excluded.pinned_fingerprint, pinned_fingerprint),
+			public_key = COALESCE(excluded.public_key, public_key),
+			addresses_json = excluded.addresses_json,
+			last_seen_at = excluded.last_seen_at`,
+	).run(
+		peerDeviceId,
+		options?.name ?? null,
+		options?.pinnedFingerprint ?? null,
+		options?.publicKey ?? null,
+		addressesJson,
+		now,
+		now,
+	);
+
+	return merged;
+}
+
+/**
+ * Record a sync attempt in the sync_attempts table and update peer status.
+ */
+export function recordSyncAttempt(
+	db: Database,
+	peerDeviceId: string,
+	options: {
+		ok: boolean;
+		opsIn?: number;
+		opsOut?: number;
+		error?: string;
+	},
+): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO sync_attempts (
+			peer_device_id, started_at, finished_at, ok, ops_in, ops_out, error
+		) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		peerDeviceId,
+		now,
+		now,
+		options.ok ? 1 : 0,
+		options.opsIn ?? 0,
+		options.opsOut ?? 0,
+		options.error ?? null,
+	);
+
+	if (options.ok) {
+		db.prepare(
+			"UPDATE sync_peers SET last_sync_at = ?, last_error = NULL WHERE peer_device_id = ?",
+		).run(now, peerDeviceId);
+	} else {
+		db.prepare("UPDATE sync_peers SET last_error = ? WHERE peer_device_id = ?").run(
+			options.error ?? null,
+			peerDeviceId,
+		);
+	}
+}
+
+/**
+ * Record a successful sync and promote the working address to the front.
+ *
+ * Returns the reordered address list.
+ */
+export function recordPeerSuccess(
+	db: Database,
+	peerDeviceId: string,
+	address: string | null,
+): string[] {
+	const addresses = loadPeerAddresses(db, peerDeviceId);
+	const normalized = normalizeAddress(address ?? "");
+	let ordered = addresses;
+	if (normalized) {
+		const remaining = addresses.filter((item) => normalizeAddress(item) !== normalized);
+		ordered = [normalized, ...remaining];
+		db.prepare(
+			`UPDATE sync_peers
+			 SET addresses_json = ?, last_sync_at = ?, last_error = NULL
+			 WHERE peer_device_id = ?`,
+		).run(JSON.stringify(ordered), new Date().toISOString(), peerDeviceId);
+	}
+	return ordered;
+}
+
+// ---------------------------------------------------------------------------
+// Project filters
+// ---------------------------------------------------------------------------
+
+/**
+ * Set per-peer project include/exclude filters.
+ *
+ * Pass null for both to clear the override (inherit global config).
+ */
+export function setPeerProjectFilter(
+	db: Database,
+	peerDeviceId: string,
+	options: {
+		include: string[] | null;
+		exclude: string[] | null;
+	},
+): void {
+	const includeJson = options.include === null ? null : JSON.stringify(options.include);
+	const excludeJson = options.exclude === null ? null : JSON.stringify(options.exclude);
+	db.prepare(
+		`UPDATE sync_peers
+		 SET projects_include_json = ?,
+		     projects_exclude_json = ?
+		 WHERE peer_device_id = ?`,
+	).run(includeJson, excludeJson, peerDeviceId);
+}
+
+/**
+ * Set the claimed_local_actor flag for a peer.
+ */
+export function setPeerLocalActorClaim(db: Database, peerDeviceId: string, claimed: boolean): void {
+	db.prepare("UPDATE sync_peers SET claimed_local_actor = ? WHERE peer_device_id = ?").run(
+		claimed ? 1 : 0,
+		peerDeviceId,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// mDNS stubs (Phase 1)
+// ---------------------------------------------------------------------------
+
+export interface MdnsEntry {
+	name?: string;
+	host?: string;
+	port?: number;
+	address?: Uint8Array | string;
+	properties?: Record<string, string | Uint8Array>;
+}
+
+/**
+ * Check if mDNS discovery is enabled via the CODEMEM_SYNC_MDNS env var.
+ */
+export function mdnsEnabled(): boolean {
+	const value = process.env.CODEMEM_SYNC_MDNS;
+	if (!value) return false;
+	return value === "1" || value.toLowerCase() === "true";
+}
+
+/**
+ * Advertise this device via mDNS.
+ *
+ * Phase 1 stub: logs the intent and returns a no-op closer.
+ * Real implementation will use dns-sd (macOS) or bonjour-service (Linux).
+ */
+export function advertiseMdns(_deviceId: string, _port: number): { close(): void } {
+	return { close() {} };
+}
+
+/**
+ * Discover peers via mDNS.
+ *
+ * Phase 1 stub: returns an empty array.
+ * Real implementation will use dns-sd (macOS) or bonjour-service (Linux).
+ */
+export function discoverPeersViaMdns(): MdnsEntry[] {
+	return [];
+}
+
+/**
+ * Extract addresses for a specific peer from mDNS discovery entries.
+ */
+export function mdnsAddressesForPeer(peerDeviceId: string, entries: MdnsEntry[]): string[] {
+	const addresses: string[] = [];
+	for (const entry of entries) {
+		const props = entry.properties ?? {};
+		let deviceId: string | Uint8Array | undefined =
+			props.device_id ??
+			((props as Record<string, unknown>).device_id as string | Uint8Array | undefined);
+		if (deviceId == null) continue;
+		if (deviceId instanceof Uint8Array) {
+			deviceId = new TextDecoder().decode(deviceId);
+		}
+		if (deviceId !== peerDeviceId) continue;
+
+		const port = entry.port ?? 0;
+		if (!port) continue;
+
+		// Prefer entry.address (resolved IP) over entry.host (service name).
+		// mDNS responses often carry a service-name host (e.g. _codemem._tcp.local)
+		// that isn't directly dialable, but include the usable IP in address.
+		const address = (entry as Record<string, unknown>).address as string | undefined;
+		const host = entry.host ?? "";
+		const dialHost = address && !address.includes(".local") ? address : host;
+		if (dialHost && !dialHost.includes("_tcp.local") && !dialHost.includes("_udp.local")) {
+			addresses.push(`${dialHost}:${port}`);
+		}
+	}
+	return addresses;
+}

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -168,16 +168,25 @@ describe("peerBackoffSeconds", () => {
 		expect(peerBackoffSeconds(1)).toBe(0);
 	});
 
-	it("returns base backoff for 2 failures", () => {
-		expect(peerBackoffSeconds(2)).toBe(120);
+	it("returns base backoff with jitter for 2 failures", () => {
+		// Base = 120s, jitter range = [60, 120)
+		const result = peerBackoffSeconds(2);
+		expect(result).toBeGreaterThanOrEqual(60);
+		expect(result).toBeLessThanOrEqual(120);
 	});
 
-	it("doubles for 3 failures", () => {
-		expect(peerBackoffSeconds(3)).toBe(240);
+	it("doubles base for 3 failures (with jitter)", () => {
+		// Base = 240s, jitter range = [120, 240)
+		const result = peerBackoffSeconds(3);
+		expect(result).toBeGreaterThanOrEqual(120);
+		expect(result).toBeLessThanOrEqual(240);
 	});
 
-	it("caps at max backoff", () => {
-		expect(peerBackoffSeconds(20)).toBe(1800);
+	it("caps at max backoff (with jitter)", () => {
+		// Max = 1800s, jitter range = [900, 1800)
+		const result = peerBackoffSeconds(20);
+		expect(result).toBeGreaterThanOrEqual(900);
+		expect(result).toBeLessThanOrEqual(1800);
 	});
 });
 

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -199,8 +199,9 @@ function loadLocalOpsSince(
 
 /**
  * Compute a cursor string from a timestamp and op_id.
+ * Currently unused — will be needed when real apply logic advances the cursor.
  */
-function computeCursor(createdAt: string, opId: string): string {
+export function computeCursor(createdAt: string, opId: string): string {
 	return `${createdAt}|${opId}`;
 }
 
@@ -213,11 +214,14 @@ function computeCursor(createdAt: string, opId: string): string {
  *
  * On 413 (too large), splits the batch in half and retries recursively.
  */
+const MAX_PUSH_SPLIT_DEPTH = 8;
+
 async function pushOps(
 	postUrl: string,
 	deviceId: string,
 	ops: ReplicationOp[],
 	keysDir?: string,
+	depth = 0,
 ): Promise<void> {
 	if (ops.length === 0) return;
 
@@ -242,11 +246,12 @@ async function pushOps(
 	if (
 		status === 413 &&
 		ops.length > 1 &&
+		depth < MAX_PUSH_SPLIT_DEPTH &&
 		(detail === "payload_too_large" || detail === "too_many_ops")
 	) {
 		const mid = Math.floor(ops.length / 2);
-		await pushOps(postUrl, deviceId, ops.slice(0, mid), keysDir);
-		await pushOps(postUrl, deviceId, ops.slice(mid), keysDir);
+		await pushOps(postUrl, deviceId, ops.slice(0, mid), keysDir, depth + 1);
+		await pushOps(postUrl, deviceId, ops.slice(mid), keysDir, depth + 1);
 		return;
 	}
 
@@ -511,11 +516,13 @@ export function consecutiveConnectivityFailures(
 	return count;
 }
 
-/** Calculate backoff duration based on consecutive connectivity failures. */
+/** Calculate backoff duration with jitter to avoid thundering herd. */
 export function peerBackoffSeconds(consecutiveFailures: number): number {
 	if (consecutiveFailures <= 1) return 0;
 	const exponent = Math.min(consecutiveFailures - 1, 8);
-	return Math.min(PEER_BACKOFF_BASE_S * 2 ** (exponent - 1), PEER_BACKOFF_MAX_S);
+	const base = Math.min(PEER_BACKOFF_BASE_S * 2 ** (exponent - 1), PEER_BACKOFF_MAX_S);
+	// Add 50% jitter: base * [0.5, 1.0)
+	return base * (0.5 + Math.random() * 0.5);
 }
 
 /** Check if a peer should be skipped due to repeated connectivity failures. */

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -165,6 +165,14 @@ export function initTestSchema(db: Database): void {
 			created_at TEXT NOT NULL
 		);
 
+		CREATE TABLE IF NOT EXISTS sync_daemon_state (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			last_error TEXT,
+			last_traceback TEXT,
+			last_error_at TEXT,
+			last_ok_at TEXT
+		);
+
 		-- FTS5 full-text index on memory_items
 		CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
 			title, body_text, tags_text,


### PR DESCRIPTION
## Description

Ports the sync discovery and daemon modules — the final pieces of the sync system.

### `sync-discovery.ts` (~310 lines)
- **Address management:** `normalizeAddress`, `addressDedupeKey`, `mergeAddresses`, `selectDialAddresses`
- **Peer address storage:** `loadPeerAddresses`, `updatePeerAddresses` (sync_peers table)
- **Sync tracking:** `recordSyncAttempt`, `recordPeerSuccess`, `setPeerProjectFilter`, `setPeerLocalActorClaim`
- **mDNS stubs:** `mdnsEnabled`, `advertiseMdns` (no-op closer), `discoverPeersViaMdns` (empty array), `mdnsAddressesForPeer` — actual mDNS deferred (needs dns-sd on macOS, bonjour-service on Linux)

### `sync-daemon.ts` (~170 lines)
- **`syncDaemonTick(db)`** — iterates enabled peers, skips offline (via backoff), runs sync pass per peer
- **`runSyncDaemon(options?)`** — full daemon loop with `AbortSignal` cancellation and `setInterval` ticks
- **State tracking:** `setSyncDaemonOk`, `setSyncDaemonError` → `sync_daemon_state` table

**Completes the sync layer port (codemem-2b8).** All sync modules now ported: identity, auth, replication, HTTP client, coordinator store, sync pass, discovery, daemon.

39 new tests. 370 total.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Tests pass locally (`pnpm run check` — 370 tests)
- [x] Address normalization, dedup, merge, DB round-trip
- [x] Daemon tick with no peers, state recording

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new errors introduced