### PR TITLE
Port viewer server to Hono with all API routes

### DIFF
--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -11,13 +11,18 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "pnpm exec vite build",
+		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist",
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {
-		"@codemem/core": "workspace:*"
+		"@codemem/core": "workspace:*",
+		"@hono/node-server": "^1.19.11",
+		"hono": "^4.12.8"
 	},
 	"devDependencies": {
+		"@types/better-sqlite3": "^7.6.13",
+		"@types/node": "^22.15.0",
+		"better-sqlite3": "^12.8.0",
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Viewer server route tests.
+ *
+ * Uses Hono's built-in test client (app.request()) — no real HTTP server needed.
+ * Tests use an in-memory SQLite DB with initTestSchema from @codemem/core.
+ */
+
+import { SCHEMA_VERSION } from "@codemem/core";
+import Database from "better-sqlite3";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+async function json(res: Response): Promise<Record<string, unknown>> {
+	return (await res.json()) as Record<string, unknown>;
+}
+
+import type { ViewerVariables } from "./middleware.js";
+import { corsMiddleware } from "./middleware.js";
+import configRoutes from "./routes/config.js";
+import memoryRoutes from "./routes/memory.js";
+import observerStatusRoutes from "./routes/observer-status.js";
+import rawEventsRoutes from "./routes/raw-events.js";
+import statsRoutes from "./routes/stats.js";
+import syncRoutes from "./routes/sync.js";
+import { viewerHtml } from "./viewer-html.js";
+
+// ---------------------------------------------------------------------------
+// Test schema (inline to avoid importing core test-utils which isn't exported)
+// ---------------------------------------------------------------------------
+
+function initTestSchema(db: InstanceType<typeof Database>): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS sessions (
+			id INTEGER PRIMARY KEY,
+			started_at TEXT NOT NULL,
+			ended_at TEXT,
+			cwd TEXT,
+			project TEXT,
+			git_remote TEXT,
+			git_branch TEXT,
+			user TEXT,
+			tool_version TEXT,
+			metadata_json TEXT,
+			import_key TEXT
+		);
+		CREATE TABLE IF NOT EXISTS memory_items (
+			id INTEGER PRIMARY KEY,
+			session_id INTEGER NOT NULL REFERENCES sessions(id),
+			kind TEXT NOT NULL,
+			title TEXT NOT NULL,
+			subtitle TEXT,
+			body_text TEXT NOT NULL,
+			confidence REAL DEFAULT 0.5,
+			tags_text TEXT DEFAULT '',
+			active INTEGER DEFAULT 1,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			metadata_json TEXT,
+			actor_id TEXT,
+			actor_display_name TEXT,
+			visibility TEXT,
+			workspace_id TEXT,
+			workspace_kind TEXT,
+			origin_device_id TEXT,
+			origin_source TEXT,
+			trust_state TEXT,
+			facts TEXT,
+			narrative TEXT,
+			concepts TEXT,
+			files_read TEXT,
+			files_modified TEXT,
+			user_prompt_id INTEGER,
+			prompt_number INTEGER,
+			deleted_at TEXT,
+			rev INTEGER DEFAULT 0,
+			import_key TEXT
+		);
+		CREATE TABLE IF NOT EXISTS artifacts (
+			id INTEGER PRIMARY KEY,
+			session_id INTEGER NOT NULL REFERENCES sessions(id),
+			kind TEXT NOT NULL,
+			path TEXT,
+			content_text TEXT,
+			content_hash TEXT,
+			content_encoding TEXT,
+			content_blob BLOB,
+			created_at TEXT NOT NULL,
+			metadata_json TEXT
+		);
+		CREATE TABLE IF NOT EXISTS raw_events (
+			id INTEGER PRIMARY KEY,
+			source TEXT NOT NULL DEFAULT 'opencode',
+			stream_id TEXT NOT NULL DEFAULT '',
+			opencode_session_id TEXT NOT NULL,
+			event_id TEXT,
+			event_seq INTEGER NOT NULL,
+			event_type TEXT NOT NULL,
+			ts_wall_ms INTEGER,
+			ts_mono_ms REAL,
+			payload_json TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			UNIQUE(source, stream_id, event_seq),
+			UNIQUE(source, stream_id, event_id)
+		);
+		CREATE TABLE IF NOT EXISTS user_prompts (
+			id INTEGER PRIMARY KEY,
+			session_id INTEGER,
+			project TEXT,
+			prompt_text TEXT NOT NULL,
+			prompt_number INTEGER,
+			created_at TEXT NOT NULL,
+			created_at_epoch INTEGER,
+			metadata_json TEXT,
+			import_key TEXT
+		);
+		CREATE TABLE IF NOT EXISTS usage_events (
+			id INTEGER PRIMARY KEY,
+			session_id INTEGER,
+			event TEXT NOT NULL,
+			tokens_read INTEGER DEFAULT 0,
+			tokens_written INTEGER DEFAULT 0,
+			tokens_saved INTEGER DEFAULT 0,
+			created_at TEXT NOT NULL,
+			metadata_json TEXT
+		);
+		CREATE TABLE IF NOT EXISTS sync_device (
+			device_id TEXT PRIMARY KEY,
+			public_key TEXT NOT NULL,
+			fingerprint TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS sync_peers (
+			peer_device_id TEXT PRIMARY KEY,
+			name TEXT,
+			pinned_fingerprint TEXT,
+			public_key TEXT,
+			addresses_json TEXT,
+			claimed_local_actor INTEGER NOT NULL DEFAULT 0,
+			actor_id TEXT,
+			projects_include_json TEXT,
+			projects_exclude_json TEXT,
+			created_at TEXT NOT NULL,
+			last_seen_at TEXT,
+			last_sync_at TEXT,
+			last_error TEXT
+		);
+		CREATE TABLE IF NOT EXISTS sync_attempts (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			peer_device_id TEXT NOT NULL,
+			started_at TEXT NOT NULL,
+			finished_at TEXT,
+			ok INTEGER NOT NULL DEFAULT 0,
+			ops_in INTEGER NOT NULL DEFAULT 0,
+			ops_out INTEGER NOT NULL DEFAULT 0,
+			error TEXT
+		);
+		CREATE TABLE IF NOT EXISTS actors (
+			actor_id TEXT PRIMARY KEY,
+			display_name TEXT NOT NULL,
+			is_local INTEGER NOT NULL DEFAULT 0,
+			status TEXT NOT NULL DEFAULT 'active',
+			merged_into_actor_id TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS sync_daemon_state (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			last_error TEXT,
+			last_traceback TEXT,
+			last_error_at TEXT,
+			last_ok_at TEXT
+		);
+		CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+			title, body_text, tags_text,
+			content='memory_items', content_rowid='id'
+		);
+		CREATE TRIGGER IF NOT EXISTS memory_items_ai AFTER INSERT ON memory_items BEGIN
+			INSERT INTO memory_fts(rowid, title, body_text, tags_text)
+			VALUES (new.id, new.title, new.body_text, new.tags_text);
+		END;
+		PRAGMA user_version = ${SCHEMA_VERSION};
+	`);
+}
+
+function _insertTestSession(db: InstanceType<typeof Database>): number {
+	const now = new Date().toISOString();
+	const info = db
+		.prepare("INSERT INTO sessions (started_at, cwd, user, tool_version) VALUES (?, ?, ?, ?)")
+		.run(now, "/tmp/test", "testuser", "test-1.0");
+	return Number(info.lastInsertRowid);
+}
+
+// ---------------------------------------------------------------------------
+// Fake store middleware — injects a MemoryStore backed by in-memory DB
+// ---------------------------------------------------------------------------
+
+import { MemoryStore } from "@codemem/core";
+
+/**
+ * Build a test Hono app with a real MemoryStore backed by a temp DB file.
+ * We use a temp file because MemoryStore calls connect() which opens by path.
+ */
+function createTestApp(dbPath: string): Hono<{ Variables: ViewerVariables }> {
+	const app = new Hono<{ Variables: ViewerVariables }>();
+
+	app.use("*", corsMiddleware());
+
+	// Store middleware that uses the test DB path
+	app.use("/api/*", async (c, next) => {
+		const store = new MemoryStore(dbPath);
+		c.set("store", store);
+		try {
+			await next();
+		} finally {
+			store.close();
+		}
+	});
+
+	app.route("/", statsRoutes);
+	app.route("/", memoryRoutes);
+	app.route("/", observerStatusRoutes);
+	app.route("/", configRoutes);
+	app.route("/", rawEventsRoutes);
+	app.route("/", syncRoutes);
+
+	app.get("/", (c) => c.html(viewerHtml()));
+	app.get("*", (c) => {
+		if (c.req.path.startsWith("/api/")) return c.json({ error: "not found" }, 404);
+		return c.html(viewerHtml());
+	});
+
+	return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("viewer-server", () => {
+	let dbPath: string;
+	let tmpDir: string;
+	let app: Hono<{ Variables: ViewerVariables }>;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+		dbPath = join(tmpDir, "test.sqlite");
+
+		// Pre-create the schema so MemoryStore's assertSchemaReady passes
+		const setupDb = new Database(dbPath);
+		setupDb.pragma("journal_mode = WAL");
+		initTestSchema(setupDb);
+		setupDb.close();
+
+		app = createTestApp(dbPath);
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// --- HTML routes ---
+
+	it("GET / returns HTML", async () => {
+		const res = await app.request("/");
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		expect(body).toContain("<!DOCTYPE html>");
+		expect(body).toContain("codemem");
+		expect(body).toContain("app.js");
+	});
+
+	it("GET /some/spa/route returns HTML (SPA fallback)", async () => {
+		const res = await app.request("/some/spa/route");
+		expect(res.status).toBe(200);
+		const body = await res.text();
+		expect(body).toContain("<!DOCTYPE html>");
+	});
+
+	// --- Stats ---
+
+	it("GET /api/stats returns JSON with database key", async () => {
+		const res = await app.request("/api/stats");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("database");
+		expect(body.database).toHaveProperty("path");
+		expect(body.database).toHaveProperty("sessions");
+		expect(body.database).toHaveProperty("memory_items");
+	});
+
+	// --- Memory routes ---
+
+	it("GET /api/observations returns items array with pagination", async () => {
+		const res = await app.request("/api/observations");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("items");
+		expect(Array.isArray(body.items)).toBe(true);
+		expect(body).toHaveProperty("pagination");
+		expect(body.pagination).toHaveProperty("limit");
+		expect(body.pagination).toHaveProperty("offset");
+		expect(body.pagination).toHaveProperty("has_more");
+	});
+
+	it("GET /api/observations with data returns enriched items", async () => {
+		// Seed a session + memory
+		const db = new Database(dbPath);
+		const now = new Date().toISOString();
+		db.prepare("INSERT INTO sessions (started_at, cwd, project) VALUES (?, ?, ?)").run(
+			now,
+			"/tmp/test",
+			"/home/user/myproject",
+		);
+		const sessionId = db.prepare("SELECT last_insert_rowid() AS id").get() as { id: number };
+		db.prepare(
+			`INSERT INTO memory_items (session_id, kind, title, body_text, active, created_at, updated_at, metadata_json)
+			 VALUES (?, 'discovery', 'Test memory', 'body text', 1, ?, ?, '{}')`,
+		).run(sessionId.id, now, now);
+		db.close();
+
+		const res = await app.request("/api/observations");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		const items = body.items as unknown[];
+		expect(items.length).toBeGreaterThanOrEqual(1);
+		expect(items[0]).toHaveProperty("title", "Test memory");
+		expect(items[0]).toHaveProperty("project");
+		expect(items[0]).toHaveProperty("owned_by_self");
+	});
+
+	it("GET /api/memories redirects to /api/observations", async () => {
+		const res = await app.request("/api/memories", { redirect: "manual" });
+		expect(res.status).toBe(307);
+		expect(res.headers.get("location")).toContain("/api/observations");
+	});
+
+	it("GET /api/summaries returns paginated items", async () => {
+		const res = await app.request("/api/summaries");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("items");
+		expect(body).toHaveProperty("pagination");
+	});
+
+	it("GET /api/memory returns items array", async () => {
+		const res = await app.request("/api/memory");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("items");
+	});
+
+	it("GET /api/sessions returns items", async () => {
+		const res = await app.request("/api/sessions");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("items");
+	});
+
+	it("GET /api/projects returns projects array", async () => {
+		const res = await app.request("/api/projects");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("projects");
+		expect(Array.isArray(body.projects)).toBe(true);
+	});
+
+	it("GET /api/session returns aggregate counts", async () => {
+		const res = await app.request("/api/session");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("total");
+		expect(body).toHaveProperty("memories");
+		expect(body).toHaveProperty("artifacts");
+		expect(body).toHaveProperty("prompts");
+		expect(body).toHaveProperty("observations");
+	});
+
+	it("GET /api/artifacts requires session_id", async () => {
+		const res = await app.request("/api/artifacts");
+		expect(res.status).toBe(400);
+		const body = await json(res);
+		expect(body.error).toBe("session_id required");
+	});
+
+	it("GET /api/pack requires context", async () => {
+		const res = await app.request("/api/pack");
+		expect(res.status).toBe(400);
+		const body = await json(res);
+		expect(body.error).toBe("context required");
+	});
+
+	// --- Observer status ---
+
+	it("GET /api/observer-status returns stub response", async () => {
+		const res = await app.request("/api/observer-status");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("active", null);
+		expect(body).toHaveProperty("queue");
+	});
+
+	// --- Raw events ---
+
+	it("GET /api/raw-events returns totals", async () => {
+		const res = await app.request("/api/raw-events");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("pending");
+		expect(body).toHaveProperty("sessions");
+	});
+
+	// --- Config (stubbed) ---
+
+	it("GET /api/config returns 501", async () => {
+		const res = await app.request("/api/config");
+		expect(res.status).toBe(501);
+	});
+
+	// --- Sync ---
+
+	it("GET /api/sync/status returns status object", async () => {
+		const res = await app.request("/api/sync/status");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("enabled");
+		expect(body).toHaveProperty("peers");
+		expect(body).toHaveProperty("attempts");
+	});
+
+	it("GET /api/sync/peers returns peers list", async () => {
+		const res = await app.request("/api/sync/peers");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("items");
+		expect(body).toHaveProperty("redacted");
+	});
+
+	it("GET /api/sync/actors returns actors list", async () => {
+		const res = await app.request("/api/sync/actors");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("items");
+	});
+
+	it("GET /api/sync/attempts returns attempts list", async () => {
+		const res = await app.request("/api/sync/attempts");
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("items");
+	});
+
+	// --- 404 ---
+
+	it("GET /api/unknown returns 404", async () => {
+		const res = await app.request("/api/unknown");
+		expect(res.status).toBe(404);
+		const body = await json(res);
+		expect(body).toHaveProperty("error", "not found");
+	});
+
+	// --- Visibility update ---
+
+	it("POST /api/memories/visibility updates visibility", async () => {
+		// Seed data
+		const db = new Database(dbPath);
+		const now = new Date().toISOString();
+		db.prepare("INSERT INTO sessions (started_at, cwd) VALUES (?, ?)").run(now, "/tmp/test");
+		const sessionId = (db.prepare("SELECT last_insert_rowid() AS id").get() as { id: number }).id;
+		db.prepare(
+			`INSERT INTO memory_items (session_id, kind, title, body_text, active, created_at, updated_at, visibility, metadata_json, rev)
+			 VALUES (?, 'discovery', 'Test', 'body', 1, ?, ?, 'shared', '{}', 1)`,
+		).run(sessionId, now, now);
+		const memoryId = (db.prepare("SELECT last_insert_rowid() AS id").get() as { id: number }).id;
+		db.close();
+
+		const res = await app.request("/api/memories/visibility", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ memory_id: memoryId, visibility: "private" }),
+		});
+		expect(res.status).toBe(200);
+		const body = await json(res);
+		expect(body).toHaveProperty("item");
+		expect((body.item as Record<string, unknown>).visibility).toBe("private");
+	});
+});

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -1,11 +1,148 @@
 /**
- * @codemem/viewer-server — unified viewer + sync process.
+ * @codemem/viewer-server — Hono HTTP server for the codemem viewer.
  *
- * Single HTTP server handling viewer routes and sync daemon.
- * Shares one better-sqlite3 connection between viewer and sync.
- * Embedding inference runs in a worker_thread (lazy-started).
+ * Serves the existing frontend SPA (viewer_static/app.js) and all API routes.
+ * Single process: viewer + API. Sync daemon management is not yet ported.
  *
- * Entry: `codemem serve`
+ * Entry: `node dist/index.js` or via the CLI `codemem serve`
  */
 
-export { VERSION } from "@codemem/core";
+import { resolve } from "node:path";
+import { serve } from "@hono/node-server";
+import { serveStatic } from "@hono/node-server/serve-static";
+import { Hono } from "hono";
+import type { ViewerVariables } from "./middleware.js";
+import { corsMiddleware, storeMiddleware } from "./middleware.js";
+import configRoutes from "./routes/config.js";
+import memoryRoutes from "./routes/memory.js";
+import observerStatusRoutes from "./routes/observer-status.js";
+import rawEventsRoutes from "./routes/raw-events.js";
+import statsRoutes from "./routes/stats.js";
+import syncRoutes from "./routes/sync.js";
+import { viewerHtml } from "./viewer-html.js";
+
+export type { ViewerVariables } from "./middleware.js";
+export { corsMiddleware, storeMiddleware } from "./middleware.js";
+export { viewerHtml } from "./viewer-html.js";
+
+// ---------------------------------------------------------------------------
+// Default configuration
+// ---------------------------------------------------------------------------
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 38888;
+
+// ---------------------------------------------------------------------------
+// App factory — exported for testing and composition
+// ---------------------------------------------------------------------------
+
+export interface CreateAppOptions {
+	/** Database path. Resolved from CODEMEM_DB env if not provided. */
+	dbPath?: string;
+	/**
+	 * Root directory for static assets (viewer_static/).
+	 * Defaults to CODEMEM_VIEWER_STATIC_DIR env or ../../codemem/viewer_static/
+	 * relative to this package.
+	 */
+	staticDir?: string;
+}
+
+/**
+ * Create and configure the Hono app with all routes and middleware.
+ *
+ * Exported so tests can use `app.request()` without starting a real server.
+ */
+export function createApp(options: CreateAppOptions = {}): Hono<{ Variables: ViewerVariables }> {
+	const app = new Hono<{ Variables: ViewerVariables }>();
+
+	// --- Middleware ---
+	app.use("*", corsMiddleware());
+	app.use("/api/*", storeMiddleware(options.dbPath));
+
+	// --- API routes ---
+	app.route("/", statsRoutes);
+	app.route("/", memoryRoutes);
+	app.route("/", observerStatusRoutes);
+	app.route("/", configRoutes);
+	app.route("/", rawEventsRoutes);
+	app.route("/", syncRoutes);
+
+	// --- Static assets ---
+	// Resolve static asset directory:
+	// 1. Explicit option
+	// 2. CODEMEM_VIEWER_STATIC_DIR env
+	// 3. Default: from packages/viewer-server/dist/ → repo root → codemem/viewer_static/
+	const staticRoot =
+		options.staticDir ??
+		process.env.CODEMEM_VIEWER_STATIC_DIR ??
+		resolve(import.meta.dirname ?? ".", "../../../codemem/viewer_static");
+
+	app.use(
+		"/assets/*",
+		serveStatic({
+			root: staticRoot,
+			rewriteRequestPath: (path) => path.replace(/^\/assets/, ""),
+		}),
+	);
+
+	// --- SPA fallback: serve viewer HTML for / and unmatched paths ---
+	app.get("/", (c) => {
+		return c.html(viewerHtml());
+	});
+
+	// Catch-all for SPA client-side routing (non-API, non-static)
+	app.get("*", (c) => {
+		// Don't serve HTML for API routes that didn't match
+		if (c.req.path.startsWith("/api/")) {
+			return c.json({ error: "not found" }, 404);
+		}
+		return c.html(viewerHtml());
+	});
+
+	return app;
+}
+
+// ---------------------------------------------------------------------------
+// Server entry point — only runs when executed directly
+// ---------------------------------------------------------------------------
+
+function main(): void {
+	const host = process.env.CODEMEM_VIEWER_HOST ?? DEFAULT_HOST;
+	const port = Number.parseInt(process.env.CODEMEM_VIEWER_PORT ?? String(DEFAULT_PORT), 10);
+
+	const app = createApp();
+
+	const server = serve(
+		{
+			fetch: app.fetch,
+			hostname: host,
+			port,
+		},
+		(info) => {
+			console.log(`codemem viewer listening on http://${info.address}:${info.port}`);
+		},
+	);
+
+	// Graceful shutdown
+	const shutdown = () => {
+		console.log("\nShutting down viewer server...");
+		server.close(() => {
+			process.exit(0);
+		});
+		// Force exit after 5s if close() hangs
+		setTimeout(() => process.exit(1), 5000).unref();
+	};
+
+	process.on("SIGINT", shutdown);
+	process.on("SIGTERM", shutdown);
+}
+
+// Run main when executed directly (not imported)
+const isDirectRun =
+	typeof import.meta.url === "string" &&
+	(process.argv[1] === import.meta.filename ||
+		process.argv[1]?.endsWith("/viewer-server/dist/index.js"));
+
+if (isDirectRun) {
+	main();
+}

--- a/packages/viewer-server/src/middleware.ts
+++ b/packages/viewer-server/src/middleware.ts
@@ -1,0 +1,65 @@
+/**
+ * Hono middleware for the codemem viewer server.
+ *
+ * - storeMiddleware: creates a MemoryStore per-request, attaches to context
+ * - corsMiddleware: configures CORS for local development
+ */
+
+import { MemoryStore, resolveDbPath } from "@codemem/core";
+import type { Context, MiddlewareHandler, Next } from "hono";
+import { cors } from "hono/cors";
+
+// ---------------------------------------------------------------------------
+// Context variable typing
+// ---------------------------------------------------------------------------
+
+/** Hono context variables set by viewer-server middleware. */
+export type ViewerVariables = {
+	store: MemoryStore;
+};
+
+// ---------------------------------------------------------------------------
+// Store middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * Attach a MemoryStore instance to Hono context.
+ *
+ * Opens a fresh store per-request and closes it after the response.
+ * The dbPath is resolved once at server start and reused.
+ */
+export function storeMiddleware(dbPath?: string): MiddlewareHandler {
+	const resolvedPath = resolveDbPath(dbPath);
+	return async (c: Context, next: Next) => {
+		const store = new MemoryStore(resolvedPath);
+		c.set("store", store);
+		try {
+			await next();
+		} finally {
+			store.close();
+		}
+	};
+}
+
+// ---------------------------------------------------------------------------
+// CORS middleware
+// ---------------------------------------------------------------------------
+
+/**
+ * CORS middleware for local development.
+ * Allows same-origin and configurable origins.
+ */
+export function corsMiddleware(): MiddlewareHandler {
+	return cors({
+		origin: (origin) => {
+			// Allow same-origin requests (no Origin header) and localhost variants
+			if (!origin) return "*";
+			if (origin.startsWith("http://localhost:") || origin.startsWith("http://127.0.0.1:")) {
+				return origin;
+			}
+			return null as unknown as string;
+		},
+		allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+		allowHeaders: ["Content-Type"],
+	});
+}

--- a/packages/viewer-server/src/routes/config.ts
+++ b/packages/viewer-server/src/routes/config.ts
@@ -1,0 +1,31 @@
+/**
+ * Config routes — port of codemem/viewer_routes/config.py.
+ *
+ * GET  /api/config — return current config, defaults, effective values
+ * POST /api/config — save config updates with effects tracking
+ *
+ * The Python config system (load_config, write_config_file, runtime hot-reload,
+ * sync daemon management) is deeply integrated with the Python process.
+ * These routes are stubbed until the config system is ported to TS.
+ */
+
+import { Hono } from "hono";
+import type { ViewerVariables } from "../middleware.js";
+
+const app = new Hono<{ Variables: ViewerVariables }>();
+
+// TODO: Port config system to TS — load_config(), read_config_file(),
+// write_config_file(), OpencodeMemConfig dataclass, CONFIG_ENV_OVERRIDES,
+// runtime hot-reload, sync daemon start/stop/restart.
+// Python source: codemem/viewer_routes/config.py (640 lines)
+// Python source: codemem/config.py (config loading, defaults, env overrides)
+
+app.get("/api/config", (c) => {
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/config", (c) => {
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+export default app;

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -1,0 +1,439 @@
+/**
+ * Memory routes — port of codemem/viewer_routes/memory.py.
+ *
+ * Routes:
+ *   GET  /api/memories     — list observations (alias for /api/observations)
+ *   GET  /api/observations — paginated observations by kind
+ *   GET  /api/summaries    — paginated session summaries
+ *   GET  /api/memory       — recent memories with optional kind/project filter
+ *   GET  /api/sessions     — recent sessions
+ *   GET  /api/session      — aggregate counts for a project
+ *   GET  /api/projects     — distinct project names
+ *   GET  /api/artifacts    — artifacts for a session
+ *   GET  /api/pack         — build memory pack
+ *   POST /api/memories/visibility — update memory visibility
+ */
+
+import {
+	fromJson,
+	type MemoryFilters,
+	type MemoryItemResponse,
+	type MemoryStore,
+} from "@codemem/core";
+import { Hono } from "hono";
+import type { ViewerVariables } from "../middleware.js";
+
+const app = new Hono<{ Variables: ViewerVariables }>();
+
+// ---------------------------------------------------------------------------
+// Helpers — mirrors Python's _attach_session_fields / _attach_ownership_fields
+// ---------------------------------------------------------------------------
+
+interface MemoryWithSessionFields extends MemoryItemResponse {
+	project?: string;
+	cwd?: string;
+	owned_by_self?: boolean;
+}
+
+/**
+ * Attach session project/cwd to memory items.
+ * Python source: codemem/viewer_routes/memory.py lines 15-62
+ */
+function attachSessionFields(store: MemoryStore, items: MemoryWithSessionFields[]): void {
+	const sessionIds: number[] = [];
+	const seen = new Set<number>();
+	for (const item of items) {
+		const sid = item.session_id;
+		if (sid == null || seen.has(sid)) continue;
+		seen.add(sid);
+		sessionIds.push(sid);
+	}
+	if (sessionIds.length === 0) return;
+
+	const placeholders = sessionIds.map(() => "?").join(", ");
+	const rows = store.db
+		.prepare(`SELECT id, project, cwd FROM sessions WHERE id IN (${placeholders})`)
+		.all(...sessionIds) as Array<{ id: number; project: string | null; cwd: string | null }>;
+
+	const bySession = new Map<number, { project: string; cwd: string }>();
+	for (const row of rows) {
+		const project = (row.project ?? "").trim();
+		// Python uses store._project_basename — just take the last path segment
+		const basename = project ? (project.split("/").pop() ?? project) : "";
+		bySession.set(row.id, { project: basename, cwd: row.cwd ?? "" });
+	}
+
+	for (const item of items) {
+		const fields = bySession.get(item.session_id);
+		if (!fields) continue;
+		item.project ??= fields.project;
+		item.cwd ??= fields.cwd;
+	}
+}
+
+/**
+ * Attach ownership flags to memory items.
+ * Python source: codemem/viewer_routes/memory.py lines 65-67
+ */
+function attachOwnershipFields(store: MemoryStore, items: MemoryWithSessionFields[]): void {
+	for (const item of items) {
+		// Mirrors Python's memory_owned_by_self: checks origin_device_id
+		item.owned_by_self = !item.origin_device_id || item.origin_device_id === store.deviceId;
+	}
+}
+
+/**
+ * Apply scope filter to memory filters.
+ * Python source: codemem/viewer_routes/memory.py lines 70-83
+ */
+function applyScopeFilter(
+	store: MemoryStore,
+	baseFilters: MemoryFilters | undefined,
+	scope: string | null,
+): { filters: MemoryFilters; valid: boolean } {
+	const normalized = (scope ?? "all").trim().toLowerCase();
+	if (!["all", "mine", "theirs", "shared"].includes(normalized)) {
+		return { filters: {}, valid: false };
+	}
+	const filters: MemoryFilters = { ...(baseFilters ?? {}) };
+	if (normalized === "mine") {
+		// TODO: ownership_scope filter not yet in TS buildFilterClauses
+		// Python source: codemem/viewer_routes/memory.py line 78
+	} else if (normalized === "theirs") {
+		// TODO: ownership_scope filter not yet in TS buildFilterClauses
+	} else if (normalized === "shared") {
+		filters.include_visibility = ["shared"];
+	}
+	void store; // used by ownership_scope once ported
+	return { filters, valid: true };
+}
+
+// ---------------------------------------------------------------------------
+// Observation kinds (memories minus session_summary)
+// ---------------------------------------------------------------------------
+
+const OBSERVATION_KINDS = [
+	"bugfix",
+	"change",
+	"decision",
+	"discovery",
+	"exploration",
+	"feature",
+	"refactor",
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function safeInt(value: string | undefined, fallback: number): number {
+	if (value == null) return fallback;
+	const n = Number.parseInt(value, 10);
+	return Number.isNaN(n) ? fallback : n;
+}
+
+function intParam(
+	c: { req: { query: (k: string) => string | undefined } },
+	key: string,
+	fallback: number,
+): number | null {
+	const raw = c.req.query(key);
+	if (raw == null) return fallback;
+	const n = Number.parseInt(raw, 10);
+	if (Number.isNaN(n)) return null; // signal parse error
+	return n;
+}
+
+// ---------------------------------------------------------------------------
+// GET routes
+// ---------------------------------------------------------------------------
+
+app.get("/api/memories", (c) => {
+	// Compatibility endpoint — redirect logic to /api/observations
+	const url = new URL(c.req.url);
+	url.pathname = "/api/observations";
+	return c.redirect(url.pathname + url.search, 307);
+});
+
+app.get("/api/observations", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const limit = intParam(c, "limit", 20);
+	const offset = intParam(c, "offset", 0);
+	if (limit === null || offset === null) {
+		return c.json({ error: "limit and offset must be int" }, 400);
+	}
+	const clampedLimit = Math.max(1, limit);
+	const clampedOffset = Math.max(0, offset);
+
+	const project = c.req.query("project") ?? null;
+	const scope = c.req.query("scope") ?? "all";
+
+	const baseFilters: MemoryFilters | undefined = project ? { project } : undefined;
+	const { filters, valid } = applyScopeFilter(store, baseFilters, scope);
+	if (!valid) return c.json({ error: "invalid_scope" }, 400);
+
+	const items = store.recentByKinds(OBSERVATION_KINDS, clampedLimit + 1, filters, clampedOffset);
+	const hasMore = items.length > clampedLimit;
+	const page = hasMore ? items.slice(0, clampedLimit) : items;
+	const enriched = page as MemoryWithSessionFields[];
+	attachSessionFields(store, enriched);
+	attachOwnershipFields(store, enriched);
+
+	return c.json({
+		items: enriched,
+		pagination: {
+			limit: clampedLimit,
+			offset: clampedOffset,
+			next_offset: hasMore ? clampedOffset + page.length : null,
+			has_more: hasMore,
+		},
+	});
+});
+
+app.get("/api/summaries", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const limit = intParam(c, "limit", 50);
+	const offset = intParam(c, "offset", 0);
+	if (limit === null || offset === null) {
+		return c.json({ error: "limit and offset must be int" }, 400);
+	}
+	const clampedLimit = Math.max(1, limit);
+	const clampedOffset = Math.max(0, offset);
+
+	const project = c.req.query("project") ?? null;
+	const scope = c.req.query("scope") ?? "all";
+
+	const baseFilters: MemoryFilters = { kind: "session_summary" };
+	if (project) baseFilters.project = project;
+	const { filters, valid } = applyScopeFilter(store, baseFilters, scope);
+	if (!valid) return c.json({ error: "invalid_scope" }, 400);
+
+	const items = store.recent(clampedLimit + 1, filters, clampedOffset);
+	const hasMore = items.length > clampedLimit;
+	const page = hasMore ? items.slice(0, clampedLimit) : items;
+	const enriched = page as MemoryWithSessionFields[];
+	attachSessionFields(store, enriched);
+	attachOwnershipFields(store, enriched);
+
+	return c.json({
+		items: enriched,
+		pagination: {
+			limit: clampedLimit,
+			offset: clampedOffset,
+			next_offset: hasMore ? clampedOffset + page.length : null,
+			has_more: hasMore,
+		},
+	});
+});
+
+app.get("/api/memory", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const limit = safeInt(c.req.query("limit"), 20);
+	const kind = c.req.query("kind") ?? null;
+	const project = c.req.query("project") ?? null;
+	const scope = c.req.query("scope") ?? "all";
+
+	const baseFilters: MemoryFilters = {};
+	if (kind) baseFilters.kind = kind;
+	if (project) baseFilters.project = project;
+	const { filters, valid } = applyScopeFilter(
+		store,
+		Object.keys(baseFilters).length > 0 ? baseFilters : undefined,
+		scope,
+	);
+	if (!valid) return c.json({ error: "invalid_scope" }, 400);
+
+	const items = store.recent(limit, filters) as MemoryWithSessionFields[];
+	attachSessionFields(store, items);
+	attachOwnershipFields(store, items);
+
+	return c.json({ items });
+});
+
+app.get("/api/sessions", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const limit = safeInt(c.req.query("limit"), 20);
+
+	// TODO: Port allSessions() to TS store
+	// Python source: codemem/viewer_routes/memory.py lines 91-98
+	const rows = store.db
+		.prepare("SELECT * FROM sessions ORDER BY started_at DESC LIMIT ?")
+		.all(limit) as Array<Record<string, unknown>>;
+
+	const items = rows.map((row) => ({
+		...row,
+		metadata_json: fromJson(row.metadata_json as string | null),
+	}));
+
+	return c.json({ items });
+});
+
+app.get("/api/projects", (c) => {
+	const store = c.get("store") as MemoryStore;
+
+	// TODO: Port allSessions() / _project_basename() to TS store
+	// Python source: codemem/viewer_routes/memory.py lines 100-114
+	const rows = store.db
+		.prepare("SELECT project FROM sessions WHERE project IS NOT NULL AND project != ''")
+		.all() as Array<{ project: string }>;
+
+	const projects = [
+		...new Set(
+			rows
+				.map((r) => r.project.trim())
+				.filter((p) => p && !p.toLowerCase().startsWith("fatal:"))
+				.map((p) => p.split("/").pop() ?? p)
+				.filter(Boolean),
+		),
+	].sort();
+
+	return c.json({ projects });
+});
+
+app.get("/api/session", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const project = c.req.query("project") ?? null;
+
+	// Aggregate counts — mirrors Python codemem/viewer_routes/memory.py lines 198-258
+	const count = (sql: string, params: unknown[] = []): number => {
+		const row = store.db.prepare(sql).get(...params) as { total: number } | undefined;
+		return row?.total ?? 0;
+	};
+
+	let prompts: number;
+	let artifacts: number;
+	let memories: number;
+	let observations: number;
+
+	if (project) {
+		prompts = count("SELECT COUNT(*) AS total FROM user_prompts WHERE project = ?", [project]);
+		artifacts = count(
+			`SELECT COUNT(*) AS total FROM artifacts
+			 JOIN sessions ON sessions.id = artifacts.session_id
+			 WHERE sessions.project = ?`,
+			[project],
+		);
+		memories = count(
+			`SELECT COUNT(*) AS total FROM memory_items
+			 JOIN sessions ON sessions.id = memory_items.session_id
+			 WHERE sessions.project = ?`,
+			[project],
+		);
+		observations = count(
+			`SELECT COUNT(*) AS total FROM memory_items
+			 JOIN sessions ON sessions.id = memory_items.session_id
+			 WHERE kind != 'session_summary' AND sessions.project = ?`,
+			[project],
+		);
+	} else {
+		prompts = count("SELECT COUNT(*) AS total FROM user_prompts");
+		artifacts = count("SELECT COUNT(*) AS total FROM artifacts");
+		memories = count("SELECT COUNT(*) AS total FROM memory_items");
+		observations = count(
+			"SELECT COUNT(*) AS total FROM memory_items WHERE kind != 'session_summary'",
+		);
+	}
+
+	return c.json({
+		total: prompts + artifacts + memories,
+		memories,
+		artifacts,
+		prompts,
+		observations,
+	});
+});
+
+app.get("/api/artifacts", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const sessionId = c.req.query("session_id");
+	if (!sessionId) {
+		return c.json({ error: "session_id required" }, 400);
+	}
+	const sid = Number.parseInt(sessionId, 10);
+	if (Number.isNaN(sid)) {
+		return c.json({ error: "session_id must be int" }, 400);
+	}
+
+	// TODO: Port sessionArtifacts() to TS store
+	// Python source: codemem/viewer_routes/memory.py lines 322-330
+	const rows = store.db
+		.prepare("SELECT * FROM artifacts WHERE session_id = ? ORDER BY created_at DESC")
+		.all(sid) as Array<Record<string, unknown>>;
+
+	return c.json({ items: rows });
+});
+
+app.get("/api/pack", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const context = c.req.query("context") ?? "";
+	if (!context) {
+		return c.json({ error: "context required" }, 400);
+	}
+
+	const limitRaw = c.req.query("limit");
+	const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+	if (limitRaw && (limit == null || Number.isNaN(limit))) {
+		return c.json({ error: "limit must be int" }, 400);
+	}
+
+	const tokenBudgetRaw = c.req.query("token_budget");
+	let tokenBudget: number | null = null;
+	if (tokenBudgetRaw && tokenBudgetRaw !== "") {
+		tokenBudget = Number.parseInt(tokenBudgetRaw, 10);
+		if (Number.isNaN(tokenBudget)) {
+			return c.json({ error: "token_budget must be int" }, 400);
+		}
+	}
+
+	const project = c.req.query("project") ?? null;
+	const scope = c.req.query("scope") ?? "all";
+	const baseFilters: MemoryFilters | undefined = project ? { project } : undefined;
+	const { filters, valid } = applyScopeFilter(store, baseFilters, scope);
+	if (!valid) return c.json({ error: "invalid_scope" }, 400);
+
+	const pack = store.buildMemoryPack(context, limit, tokenBudget, filters);
+	return c.json(pack);
+});
+
+// ---------------------------------------------------------------------------
+// POST routes
+// ---------------------------------------------------------------------------
+
+app.post("/api/memories/visibility", async (c) => {
+	const store = c.get("store") as MemoryStore;
+	let payload: Record<string, unknown>;
+	try {
+		payload = await c.req.json();
+	} catch {
+		return c.json({ error: "invalid json" }, 400);
+	}
+
+	const memoryId = payload.memory_id;
+	const visibility = payload.visibility;
+
+	if (memoryId == null || typeof memoryId !== "number") {
+		return c.json({ error: "memory_id must be int" }, 400);
+	}
+	if (typeof visibility !== "string" || !["private", "shared"].includes(visibility.trim())) {
+		return c.json({ error: "visibility must be private or shared" }, 400);
+	}
+
+	try {
+		const item = store.updateMemoryVisibility(memoryId, visibility.trim());
+		const enriched = item as MemoryWithSessionFields;
+		enriched.owned_by_self =
+			!enriched.origin_device_id || enriched.origin_device_id === store.deviceId;
+		return c.json({ item: enriched });
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		if (msg === "memory not found") {
+			return c.json({ error: "memory not found" }, 404);
+		}
+		if (msg.includes("not owned")) {
+			return c.json({ error: "memory not owned by self" }, 403);
+		}
+		return c.json({ error: msg }, 400);
+	}
+});
+
+export default app;

--- a/packages/viewer-server/src/routes/observer-status.ts
+++ b/packages/viewer-server/src/routes/observer-status.ts
@@ -1,0 +1,34 @@
+/**
+ * Observer status route — port of codemem/viewer_routes/observer_status.py.
+ *
+ * GET /api/observer-status — observer runtime + credential status
+ *
+ * Most of this depends on Python-only runtime state (observer instance,
+ * raw event sweeper, credential probing). Stubbed until those are ported.
+ */
+
+import { Hono } from "hono";
+import type { ViewerVariables } from "../middleware.js";
+
+const app = new Hono<{ Variables: ViewerVariables }>();
+
+// TODO: Port observer runtime status, credential probing, and queue state.
+// Python source: codemem/viewer_routes/observer_status.py (67 lines)
+// Depends on: plugin_ingest.OBSERVER, observer.probe_available_credentials(),
+//   store.raw_event_backlog_totals(), store.latest_raw_event_flush_failure(),
+//   RAW_EVENT_SWEEPER.auth_backoff_status()
+app.get("/api/observer-status", (c) => {
+	return c.json({
+		active: null,
+		available_credentials: {},
+		latest_failure: null,
+		queue: {
+			pending: 0,
+			sessions: 0,
+			auth_backoff_active: false,
+			auth_backoff_remaining_s: 0,
+		},
+	});
+});
+
+export default app;

--- a/packages/viewer-server/src/routes/raw-events.ts
+++ b/packages/viewer-server/src/routes/raw-events.ts
@@ -1,0 +1,73 @@
+/**
+ * Raw events routes — port of codemem/viewer_routes/raw_events.py.
+ *
+ * GET  /api/raw-events        — backlog totals (compat for stats panel)
+ * GET  /api/raw-events/status — full backlog with session details
+ * POST /api/raw-events        — ingest raw events
+ * POST /api/claude-hooks      — ingest Claude hook payloads
+ *
+ * The raw event ingestion and backlog management depends on store methods
+ * not yet ported to TS (raw_event_backlog, record_raw_events_batch, etc.).
+ * GET routes are stubbed; POST routes will need the full ingest pipeline.
+ */
+
+import type { MemoryStore } from "@codemem/core";
+import { Hono } from "hono";
+import type { ViewerVariables } from "../middleware.js";
+
+const app = new Hono<{ Variables: ViewerVariables }>();
+
+// TODO: Port raw_event_backlog(), raw_event_backlog_totals() to TS store
+// Python source: codemem/viewer_routes/raw_events.py lines 94-119
+app.get("/api/raw-events", (c) => {
+	const store = c.get("store") as MemoryStore;
+	// Return minimal totals structure — backlog queries not yet ported
+	try {
+		const row = store.db
+			.prepare(
+				`SELECT COUNT(*) AS pending,
+				        COUNT(DISTINCT opencode_session_id) AS sessions
+				 FROM raw_events`,
+			)
+			.get() as { pending: number; sessions: number } | undefined;
+		return c.json({
+			pending: row?.pending ?? 0,
+			sessions: row?.sessions ?? 0,
+		});
+	} catch {
+		return c.json({ pending: 0, sessions: 0 });
+	}
+});
+
+app.get("/api/raw-events/status", (c) => {
+	const store = c.get("store") as MemoryStore;
+	void store;
+	// TODO: Port raw_event_backlog() with session aliases to TS store
+	// Python source: codemem/viewer_routes/raw_events.py lines 96-115
+	return c.json({
+		items: [],
+		totals: { pending: 0, sessions: 0 },
+		ingest: {
+			available: false,
+			mode: "not_implemented",
+			max_body_bytes: 1048576,
+		},
+	});
+});
+
+// TODO: Port raw event ingestion (POST /api/raw-events)
+// Python source: codemem/viewer_routes/raw_events.py lines 248-470
+// Depends on: store.record_raw_events_batch(), store.update_raw_event_session_meta(),
+//   _resolve_session_stream_id(), strip_private_obj(), flusher.note_activity()
+app.post("/api/raw-events", (c) => {
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+// TODO: Port Claude hooks ingestion (POST /api/claude-hooks)
+// Python source: codemem/viewer_routes/raw_events.py lines 176-246
+// Depends on: build_raw_event_envelope_from_hook(), store.record_raw_event()
+app.post("/api/claude-hooks", (c) => {
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+export default app;

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -1,0 +1,25 @@
+/**
+ * Stats routes — port of codemem/viewer_routes/stats.py.
+ *
+ * GET /api/stats — database statistics
+ * GET /api/usage — usage summary (stubbed — store methods not yet ported)
+ */
+
+import type { MemoryStore } from "@codemem/core";
+import { Hono } from "hono";
+import type { ViewerVariables } from "../middleware.js";
+
+const app = new Hono<{ Variables: ViewerVariables }>();
+
+app.get("/api/stats", (c) => {
+	const store = c.get("store") as MemoryStore;
+	return c.json(store.stats());
+});
+
+// TODO: Port usage_summary(), usage_totals(), recent_pack_events() to TS store
+// Python source: codemem/viewer_routes/stats.py lines 18-41
+app.get("/api/usage", (c) => {
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+export default app;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1,0 +1,420 @@
+/**
+ * Sync routes — port of codemem/viewer_routes/sync.py.
+ *
+ * GET routes:
+ *   /api/sync/status   — device ID, peers, daemon state, attempts
+ *   /api/sync/peers    — list peers with project scopes
+ *   /api/sync/actors   — list actors
+ *   /api/sync/attempts — recent sync attempts
+ *   /api/sync/pairing  — pairing info (device ID, fingerprint)
+ *
+ * POST routes:
+ *   /api/sync/now                   — trigger sync
+ *   /api/sync/actors                — create actor
+ *   /api/sync/actors/rename         — rename actor
+ *   /api/sync/actors/merge          — merge actors
+ *   /api/sync/invites/create        — create invite
+ *   /api/sync/invites/import        — import invite
+ *   /api/sync/join-requests/review  — review join request
+ *   /api/sync/peers/scope           — set peer project filter
+ *   /api/sync/peers/identity        — set peer identity
+ *   /api/sync/legacy-devices/claim  — claim legacy devices
+ *
+ * DELETE routes:
+ *   /api/sync/peers/:id — remove peer
+ *
+ * Many sync operations depend on Python-only runtime modules (sync daemon,
+ * coordinator commands, identity management). Those are stubbed with 501.
+ * Read-only operations that can use raw SQL are implemented.
+ */
+
+import { ensureDeviceIdentity, type MemoryStore } from "@codemem/core";
+import { Hono } from "hono";
+import type { ViewerVariables } from "../middleware.js";
+
+const app = new Hono<{ Variables: ViewerVariables }>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function includeDiagnostics(c: { req: { query: (k: string) => string | undefined } }): boolean {
+	return ["1", "true", "yes"].includes(c.req.query("includeDiagnostics") ?? "0");
+}
+
+function safeJsonList(raw: string | null | undefined): string[] {
+	if (raw == null) return [];
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
+	} catch {
+		return [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GET routes
+// ---------------------------------------------------------------------------
+
+// TODO: Full /api/sync/status requires: load_config(), effective_status(),
+// coordinator.status_snapshot(), coordinator_list_join_requests_action(),
+// claimable_legacy_device_ids(), sharing_review_summary()
+// Python source: codemem/viewer_routes/sync.py lines 136-335
+app.get("/api/sync/status", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const diag = includeDiagnostics(c);
+
+	const deviceRow = store.db
+		.prepare("SELECT device_id, fingerprint FROM sync_device LIMIT 1")
+		.get() as { device_id: string; fingerprint: string } | undefined;
+
+	const peerCount =
+		(store.db.prepare("SELECT COUNT(1) AS total FROM sync_peers").get() as { total: number })
+			?.total ?? 0;
+
+	const lastSync =
+		(
+			store.db.prepare("SELECT MAX(last_sync_at) AS last_sync_at FROM sync_peers").get() as
+				| { last_sync_at: string | null }
+				| undefined
+		)?.last_sync_at ?? null;
+
+	// Minimal status response — full daemon state requires ported config
+	const statusPayload: Record<string, unknown> = {
+		enabled: false,
+		interval_s: 300,
+		peer_count: peerCount,
+		last_sync_at: lastSync,
+		daemon_state: "stopped",
+		daemon_running: false,
+		daemon_detail: "TS viewer-server does not manage the sync daemon yet",
+		project_filter_active: false,
+		project_filter: { include: [], exclude: [] },
+		redacted: !diag,
+	};
+
+	if (diag && deviceRow) {
+		statusPayload.device_id = deviceRow.device_id;
+		statusPayload.fingerprint = deviceRow.fingerprint;
+	}
+
+	// Build peers list
+	const peerRows = store.db
+		.prepare(
+			`SELECT p.peer_device_id, p.name, p.pinned_fingerprint, p.addresses_json,
+			        p.last_seen_at, p.last_sync_at, p.last_error,
+			        p.projects_include_json, p.projects_exclude_json, p.claimed_local_actor,
+			        p.actor_id, a.display_name AS actor_display_name
+			 FROM sync_peers AS p
+			 LEFT JOIN actors AS a ON a.actor_id = p.actor_id
+			 ORDER BY name, peer_device_id`,
+		)
+		.all() as Array<Record<string, unknown>>;
+
+	const peers = peerRows.map((row) => ({
+		peer_device_id: row.peer_device_id,
+		name: row.name,
+		fingerprint: diag ? row.pinned_fingerprint : null,
+		pinned: Boolean(row.pinned_fingerprint),
+		addresses: [],
+		last_seen_at: row.last_seen_at,
+		last_sync_at: row.last_sync_at,
+		last_error: diag ? row.last_error : null,
+		has_error: Boolean(row.last_error),
+		claimed_local_actor: Boolean(row.claimed_local_actor),
+		actor_id: row.actor_id,
+		actor_display_name: row.actor_display_name,
+		project_scope: {
+			include: safeJsonList(row.projects_include_json as string | null),
+			exclude: safeJsonList(row.projects_exclude_json as string | null),
+			effective_include: safeJsonList(row.projects_include_json as string | null),
+			effective_exclude: safeJsonList(row.projects_exclude_json as string | null),
+			inherits_global: row.projects_include_json == null && row.projects_exclude_json == null,
+		},
+	}));
+
+	// Build attempts list
+	const attemptRows = store.db
+		.prepare(
+			`SELECT peer_device_id, ok, error, started_at, finished_at, ops_in, ops_out
+			 FROM sync_attempts ORDER BY finished_at DESC LIMIT 25`,
+		)
+		.all() as Array<Record<string, unknown>>;
+
+	const attempts = attemptRows.slice(0, 5).map((row) => ({
+		...row,
+		status: row.ok ? "ok" : row.error ? "error" : "unknown",
+		address: null,
+	}));
+
+	return c.json({
+		...statusPayload,
+		status: { ...statusPayload, peers: {}, pending: 0, sync: {}, ping: {} },
+		peers,
+		attempts,
+		legacy_devices: [],
+		sharing_review: { unreviewed: 0 },
+		coordinator: { enabled: false, configured: false },
+		join_requests: [],
+	});
+});
+
+app.get("/api/sync/peers", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const diag = includeDiagnostics(c);
+
+	const rows = store.db
+		.prepare(
+			`SELECT p.peer_device_id, p.name, p.pinned_fingerprint, p.addresses_json,
+			        p.last_seen_at, p.last_sync_at, p.last_error,
+			        p.projects_include_json, p.projects_exclude_json, p.claimed_local_actor,
+			        p.actor_id, a.display_name AS actor_display_name
+			 FROM sync_peers AS p
+			 LEFT JOIN actors AS a ON a.actor_id = p.actor_id
+			 ORDER BY name, peer_device_id`,
+		)
+		.all() as Array<Record<string, unknown>>;
+
+	const peers = rows.map((row) => ({
+		peer_device_id: row.peer_device_id,
+		name: row.name,
+		fingerprint: diag ? row.pinned_fingerprint : null,
+		pinned: Boolean(row.pinned_fingerprint),
+		addresses: [],
+		last_seen_at: row.last_seen_at,
+		last_sync_at: row.last_sync_at,
+		last_error: diag ? row.last_error : null,
+		has_error: Boolean(row.last_error),
+		claimed_local_actor: Boolean(row.claimed_local_actor),
+		actor_id: row.actor_id,
+		actor_display_name: row.actor_display_name,
+		project_scope: {
+			include: safeJsonList(row.projects_include_json as string | null),
+			exclude: safeJsonList(row.projects_exclude_json as string | null),
+			effective_include: safeJsonList(row.projects_include_json as string | null),
+			effective_exclude: safeJsonList(row.projects_exclude_json as string | null),
+			inherits_global: row.projects_include_json == null && row.projects_exclude_json == null,
+		},
+	}));
+
+	return c.json({ items: peers, redacted: !diag });
+});
+
+app.get("/api/sync/actors", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const includeMerged = ["1", "true", "yes"].includes(c.req.query("includeMerged") ?? "0");
+
+	let rows: Array<Record<string, unknown>>;
+	if (includeMerged) {
+		rows = store.db.prepare("SELECT * FROM actors ORDER BY display_name").all() as Array<
+			Record<string, unknown>
+		>;
+	} else {
+		rows = store.db
+			.prepare("SELECT * FROM actors WHERE status != 'merged' ORDER BY display_name")
+			.all() as Array<Record<string, unknown>>;
+	}
+
+	return c.json({ items: rows });
+});
+
+app.get("/api/sync/attempts", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const limitRaw = c.req.query("limit") ?? "25";
+	const limit = Number.parseInt(limitRaw, 10);
+	if (Number.isNaN(limit) || limit <= 0) {
+		return c.json({ error: "invalid_limit" }, 400);
+	}
+	const clampedLimit = Math.min(limit, 500);
+
+	const rows = store.db
+		.prepare(
+			`SELECT peer_device_id, ok, error, started_at, finished_at, ops_in, ops_out
+			 FROM sync_attempts ORDER BY finished_at DESC LIMIT ?`,
+		)
+		.all(clampedLimit) as Array<Record<string, unknown>>;
+
+	return c.json({ items: rows });
+});
+
+// TODO: Port pairing info (device identity, public key, advertise hosts)
+// Python source: codemem/viewer_routes/sync.py lines 426-469
+app.get("/api/sync/pairing", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const diag = includeDiagnostics(c);
+
+	if (!diag) {
+		return c.json({
+			redacted: true,
+			pairing_filter_hint:
+				"Run this on another device with codemem sync pair --accept '<payload>'.",
+		});
+	}
+
+	// Ensure device identity exists — creates keys + DB row if missing
+	// (matches Python's behavior which calls ensure_device_identity on this route)
+	let deviceId: string;
+	let fingerprint: string;
+	let publicKey: string;
+	try {
+		[deviceId, fingerprint] = ensureDeviceIdentity(store.db);
+		const deviceRow = store.db
+			.prepare("SELECT public_key FROM sync_device WHERE device_id = ?")
+			.get(deviceId) as { public_key: string } | undefined;
+		publicKey = deviceRow?.public_key ?? "";
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : "unknown";
+		return c.json({ error: `device identity initialization failed: ${msg}` }, 500);
+	}
+
+	return c.json({
+		device_id: deviceId,
+		fingerprint,
+		public_key: publicKey,
+		pairing_filter_hint: "Run this on another device with codemem sync pair --accept '<payload>'.",
+		addresses: [],
+	});
+});
+
+// ---------------------------------------------------------------------------
+// POST routes
+// ---------------------------------------------------------------------------
+
+// TODO: Port sync_once() to TS
+// Python source: codemem/viewer_routes/sync.py lines 717-749
+app.post("/api/sync/actions/sync-now", (c) => {
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+// Compatibility alias
+app.post("/api/sync/run", (c) => {
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/sync/actors", async (c) => {
+	const _store = c.get("store") as MemoryStore;
+	let payload: Record<string, unknown>;
+	try {
+		payload = await c.req.json();
+	} catch {
+		return c.json({ error: "invalid json" }, 400);
+	}
+
+	const displayName = payload.display_name;
+	const actorId = payload.actor_id ?? null;
+
+	if (typeof displayName !== "string" || !displayName.trim()) {
+		return c.json({ error: "display_name required" }, 400);
+	}
+	if (actorId !== null && typeof actorId !== "string") {
+		return c.json({ error: "actor_id must be string or null" }, 400);
+	}
+
+	// TODO: Port store.create_actor() to TS store
+	// Python source: codemem/viewer_routes/sync.py lines 484-502
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/sync/actors/rename", async (c) => {
+	// TODO: Port store.rename_actor() to TS store
+	// Python source: codemem/viewer_routes/sync.py lines 504-525
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/sync/actors/merge", async (c) => {
+	// TODO: Port store.merge_actor() to TS store
+	// Python source: codemem/viewer_routes/sync.py lines 527-551
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/sync/peers/rename", async (c) => {
+	const store = c.get("store") as MemoryStore;
+	let payload: Record<string, unknown>;
+	try {
+		payload = await c.req.json();
+	} catch {
+		return c.json({ error: "invalid json" }, 400);
+	}
+
+	const peerDeviceId = payload.peer_device_id;
+	const name = payload.name;
+	if (typeof peerDeviceId !== "string" || !peerDeviceId) {
+		return c.json({ error: "peer_device_id required" }, 400);
+	}
+	if (typeof name !== "string" || !name.trim()) {
+		return c.json({ error: "name required" }, 400);
+	}
+
+	const row = store.db
+		.prepare("SELECT 1 FROM sync_peers WHERE peer_device_id = ?")
+		.get(peerDeviceId);
+	if (!row) {
+		return c.json({ error: "peer not found" }, 404);
+	}
+
+	store.db
+		.prepare("UPDATE sync_peers SET name = ? WHERE peer_device_id = ?")
+		.run(name.trim(), peerDeviceId);
+
+	return c.json({ ok: true });
+});
+
+app.post("/api/sync/peers/scope", async (c) => {
+	// TODO: Port set_peer_project_filter() and _effective_sync_project_filters()
+	// Python source: codemem/viewer_routes/sync.py lines 580-647
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/sync/peers/identity", async (c) => {
+	// TODO: Port assign_peer_actor() to TS store
+	// Python source: codemem/viewer_routes/sync.py lines 649-694
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/sync/legacy-devices/claim", async (c) => {
+	// TODO: Port claim_legacy_device_id_as_self() to TS store
+	// Python source: codemem/viewer_routes/sync.py lines 696-715
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/sync/invites/create", async (c) => {
+	// TODO: Port coordinator_create_invite_action()
+	// Python source: codemem/viewer_routes/sync.py lines 751-794
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/sync/invites/import", async (c) => {
+	// TODO: Port coordinator_import_invite_action()
+	// Python source: codemem/viewer_routes/sync.py lines 796-815
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+app.post("/api/sync/join-requests/review", async (c) => {
+	// TODO: Port coordinator_review_join_request_action()
+	// Python source: codemem/viewer_routes/sync.py lines 817-850
+	return c.json({ error: "not yet implemented" }, 501);
+});
+
+// ---------------------------------------------------------------------------
+// DELETE routes
+// ---------------------------------------------------------------------------
+
+app.delete("/api/sync/peers/:peer_device_id", (c) => {
+	const store = c.get("store") as MemoryStore;
+	const peerDeviceId = c.req.param("peer_device_id");
+	if (!peerDeviceId) {
+		return c.json({ error: "peer_device_id required" }, 400);
+	}
+
+	const row = store.db
+		.prepare("SELECT 1 FROM sync_peers WHERE peer_device_id = ?")
+		.get(peerDeviceId);
+	if (!row) {
+		return c.json({ error: "peer not found" }, 404);
+	}
+
+	store.db.prepare("DELETE FROM sync_peers WHERE peer_device_id = ?").run(peerDeviceId);
+	return c.json({ ok: true });
+});
+
+export default app;

--- a/packages/viewer-server/src/viewer-html.ts
+++ b/packages/viewer-server/src/viewer-html.ts
@@ -1,0 +1,22 @@
+/**
+ * Generate the viewer index HTML shell.
+ *
+ * The actual frontend is a pre-built SPA bundle at viewer_static/app.js.
+ * This just provides the minimal HTML wrapper that loads it.
+ */
+
+export function viewerHtml(options?: { title?: string }): string {
+	const title = options?.title ?? "codemem";
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>${title}</title>
+</head>
+<body>
+	<div id="root"></div>
+	<script type="module" src="/assets/app.js"></script>
+</body>
+</html>`;
+}

--- a/packages/viewer-server/vite.config.ts
+++ b/packages/viewer-server/vite.config.ts
@@ -1,17 +1,10 @@
-import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
-// Library mode for now. Will switch to full app mode with dev server
-// when we build out the viewer UI integration and sync daemon.
 export default defineConfig({
 	build: {
-		lib: {
-			entry: resolve(import.meta.dirname, "src/index.ts"),
-			formats: ["es"],
-			fileName: "index",
-		},
+		ssr: "src/index.ts",
 		rollupOptions: {
-			external: [/^@codemem\//, /^node:/],
+			external: [/^@codemem\//, /^node:/, "better-sqlite3", "sqlite-vec"],
 		},
 		outDir: "dist",
 		sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,16 +114,31 @@ importers:
       '@codemem/core':
         specifier: workspace:*
         version: link:../core
+      '@hono/node-server':
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.8)
+      hono:
+        specifier: ^4.12.8
+        version: 4.12.8
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.19.15
+      better-sqlite3:
+        specifier: ^12.8.0
+        version: 12.8.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)
+        version: 8.0.0(@types/node@22.19.15)(esbuild@0.27.4)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)
 
 packages:
 
@@ -611,6 +626,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
@@ -1331,6 +1349,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -1804,6 +1825,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -1815,6 +1840,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0))':
     dependencies:
@@ -2573,6 +2606,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@7.18.2: {}
 
   unpipe@1.0.0: {}
@@ -2580,6 +2615,27 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
+
+  vite-node@3.2.4(@types/node@22.19.15)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite-node@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:
@@ -2602,6 +2658,19 @@ snapshots:
       - tsx
       - yaml
 
+  vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+
   vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.4
@@ -2615,6 +2684,19 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
+  vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4):
+    dependencies:
+      '@oxc-project/runtime': 0.115.0
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+
   vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4):
     dependencies:
       '@oxc-project/runtime': 0.115.0
@@ -2627,6 +2709,47 @@ snapshots:
       '@types/node': 25.5.0
       esbuild: 0.27.4
       fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.15)(lightningcss@1.32.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:


### PR DESCRIPTION
## Description

Replaces Python's embedded HTTP server (`codemem/viewer.py` + `codemem/viewer_routes/`, 2690 lines) with a Hono server. This is the **final piece** — with this PR, the TS backend handles everything Python did: store, MCP, CLI, observer/ingest, sync, and now the viewer.

### Server shell (`index.ts`, `middleware.ts`, `viewer-html.ts`)
- Hono app with CORS middleware, store middleware (MemoryStore per-request)
- Static file serving for `viewer_static/app.js`
- SPA fallback (non-API paths → viewer HTML)
- `createApp()` factory for test use
- Graceful shutdown (SIGINT/SIGTERM)
- SSR build mode

### Fully ported routes (10 routes across 3 modules)
- **stats.ts**: `GET /api/stats`
- **memory.ts**: `GET /api/observations`, `/api/summaries`, `/api/memory`, `/api/sessions`, `/api/session`, `/api/projects`, `/api/artifacts`, `/api/pack`, `POST /api/memories/visibility`

### Sync routes (read + 2 write, via raw SQL)
- **sync.ts**: `GET /api/sync/status`, `/peers`, `/actors`, `/attempts`, `/pairing`
- `POST /api/sync/peers/rename`, `DELETE /api/sync/peers/:id`

### Stubbed routes (501 — depend on unported store methods)
- `/api/usage` (usage tracking not ported)
- `/api/config` (config system not ported)
- `/api/observer-status` (Python-only runtime state)
- `/api/raw-events` POST (ingest trigger)
- Sync mutations (actor create/rename/merge, invites, join requests, scope, identity, legacy claim)

22 new tests. 392 total.

Closes: codemem-e524

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Tests pass locally (`pnpm run check` — 392 tests)
- [x] 22 new tests via Hono test client (no real HTTP server)
- [x] HTML, stats, memory CRUD, sync read routes, 404 handling all tested

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new errors introduced