### PR TITLE
Add Hono viewer server shell with CORS and static serving

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lint": "pnpm exec biome check packages/",
     "format": "pnpm exec biome check --write packages/",
     "typecheck": "pnpm exec tsc --build",
-    "check": "pnpm run typecheck && pnpm run lint && pnpm run test"
+    "check": "pnpm run typecheck && pnpm run lint && pnpm run test",
+    "codemem-ts": "node packages/cli/dist/index.js"
   },
   "dependencies": {
     "@opencode-ai/plugin": "1.2.27"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,9 @@
 	},
 	"dependencies": {
 		"@codemem/core": "workspace:*",
+		"@codemem/mcp-server": "workspace:*",
+		"@codemem/viewer-server": "workspace:*",
+		"@hono/node-server": "^1.14.3",
 		"chalk": "^5.6.2",
 		"commander": "^14.0.3"
 	},

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,10 @@
+import { Command } from "commander";
+
+export const mcpCommand = new Command("mcp")
+	.description("Start the MCP stdio server")
+	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.action(async (opts: { db?: string }) => {
+		if (opts.db) process.env.CODEMEM_DB = opts.db;
+		// Dynamic import — MCP server is its own entry point
+		await import("@codemem/mcp-server");
+	});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,0 +1,33 @@
+import { resolveDbPath } from "@codemem/core";
+import { Command } from "commander";
+
+export const serveCommand = new Command("serve")
+	.description("Start the viewer server")
+	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--host <host>", "bind host", "127.0.0.1")
+	.option("--port <port>", "bind port", "38888")
+	.action(async (opts: { db?: string; host: string; port: string }) => {
+		// Dynamic import to avoid loading hono/server deps for non-serve commands
+		const { createApp, closeStore } = await import("@codemem/viewer-server");
+		const { serve } = await import("@hono/node-server");
+
+		const dbPath = resolveDbPath(opts.db);
+		process.env.CODEMEM_DB = dbPath;
+
+		const port = Number.parseInt(opts.port, 10);
+		const app = createApp();
+
+		const server = serve({ fetch: app.fetch, hostname: opts.host, port }, (info) => {
+			console.log(`codemem viewer listening on http://${info.address}:${info.port}`);
+			console.log(`  database: ${dbPath}`);
+		});
+
+		const shutdown = () => {
+			console.log("\nShutting down...");
+			closeStore();
+			server.close();
+			process.exit(0);
+		};
+		process.on("SIGINT", shutdown);
+		process.on("SIGTERM", shutdown);
+	});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,17 +11,18 @@
 
 import { VERSION } from "@codemem/core";
 import { Command } from "commander";
+import { mcpCommand } from "./commands/mcp.js";
 import { packCommand } from "./commands/pack.js";
 import { searchCommand } from "./commands/search.js";
+import { serveCommand } from "./commands/serve.js";
 import { statsCommand } from "./commands/stats.js";
 
 const program = new Command();
 
-program
-	.name("codemem-ts")
-	.description("codemem TypeScript backend CLI (Phase 1 prototype)")
-	.version(VERSION);
+program.name("codemem-ts").description("codemem TypeScript backend CLI").version(VERSION);
 
+program.addCommand(serveCommand);
+program.addCommand(mcpCommand);
 program.addCommand(statsCommand);
 program.addCommand(searchCommand);
 program.addCommand(packCommand);

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
 			fileName: "index",
 		},
 		rollupOptions: {
-			external: [/^@codemem\//, /^node:/, "commander", "chalk"],
+			external: [/^@codemem\//, /^@hono\//, /^node:/, "commander", "chalk", "hono"],
 		},
 		outDir: "dist",
 		sourcemap: true,

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -11,13 +11,18 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "pnpm exec vite build",
+		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist",
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {
-		"@codemem/core": "workspace:*"
+		"@codemem/core": "workspace:*",
+		"@hono/node-server": "^1.14.3",
+		"hono": "^4.7.10"
 	},
 	"devDependencies": {
+		"@types/better-sqlite3": "^7.6.13",
+		"@types/node": "^22.15.21",
+		"better-sqlite3": "^12.8.0",
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"

--- a/packages/viewer-server/src/helpers.ts
+++ b/packages/viewer-server/src/helpers.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared helpers for viewer-server routes.
+ */
+
+/**
+ * Parse a JSON string that should be an array of strings.
+ * Returns an empty array on null, invalid JSON, or non-array values.
+ * Mirrors Python's store._safe_json_list().
+ */
+export function safeJsonList(raw: string | null | undefined): string[] {
+	if (raw == null) return [];
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter((item): item is string => typeof item === "string");
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Parse a query parameter as an integer, returning the default on failure.
+ */
+export function queryInt(value: string | undefined, defaultValue: number): number {
+	if (value == null) return defaultValue;
+	const parsed = Number.parseInt(value, 10);
+	return Number.isNaN(parsed) ? defaultValue : parsed;
+}
+
+/**
+ * Parse a query parameter as a boolean flag.
+ * Recognizes "1", "true", "yes" as truthy.
+ */
+export function queryBool(value: string | undefined): boolean {
+	if (value == null) return false;
+	return value === "1" || value === "true" || value === "yes";
+}

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -8,4 +8,79 @@
  * Entry: `codemem serve`
  */
 
-export { VERSION } from "@codemem/core";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { MemoryStore, resolveDbPath, VERSION } from "@codemem/core";
+import { serveStatic } from "@hono/node-server/serve-static";
+import { Hono } from "hono";
+import { originGuard, preflightHandler } from "./middleware.js";
+import { configRoutes } from "./routes/config.js";
+import { memoryRoutes } from "./routes/memory.js";
+import { observerStatusRoutes } from "./routes/observer-status.js";
+import { rawEventsRoutes } from "./routes/raw-events.js";
+import { statsRoutes } from "./routes/stats.js";
+import { syncRoutes } from "./routes/sync.js";
+
+export { VERSION };
+
+/** Shared store instance — SQLite WAL mode handles concurrent reads safely. */
+let sharedStore: MemoryStore | null = null;
+
+function defaultGetStore(): MemoryStore {
+	if (!sharedStore) {
+		sharedStore = new MemoryStore(resolveDbPath());
+	}
+	return sharedStore;
+}
+
+/** Close the shared store (called on shutdown). */
+export function closeStore(): void {
+	sharedStore?.close();
+	sharedStore = null;
+}
+
+/**
+ * Create the Hono app with all viewer routes.
+ * Exported for testing — pass a custom store factory to inject test DBs.
+ */
+export function createApp(getStore: () => MemoryStore = defaultGetStore) {
+	const app = new Hono();
+
+	// CORS / origin guard
+	app.use("*", preflightHandler());
+	app.use("*", originGuard());
+
+	// API routes
+	app.route("/", statsRoutes(getStore));
+	app.route("/", memoryRoutes(getStore));
+	app.route("/", observerStatusRoutes());
+	app.route("/", configRoutes());
+	app.route("/", rawEventsRoutes(getStore));
+	app.route("/", syncRoutes(getStore));
+
+	// Static assets — serve viewer_static/ under /assets/*
+	const staticRoot =
+		process.env.CODEMEM_VIEWER_STATIC_DIR ??
+		join(import.meta.dirname ?? ".", "../../../codemem/viewer_static");
+
+	app.use(
+		"/assets/*",
+		serveStatic({
+			root: staticRoot,
+			rewriteRequestPath: (path) => path.replace(/^\/assets/, ""),
+		}),
+	);
+
+	// SPA — serve index.html for root and all client-side routes
+	const indexHtml = readFileSync(join(staticRoot, "index.html"), "utf-8");
+	app.get("*", (c) => {
+		if (c.req.path.startsWith("/api/")) {
+			return c.json({ error: "not found" }, 404);
+		}
+		return c.html(indexHtml);
+	});
+
+	return app;
+}
+
+// No auto-start — the CLI's `serve` command owns server startup.

--- a/packages/viewer-server/src/middleware.ts
+++ b/packages/viewer-server/src/middleware.ts
@@ -1,0 +1,95 @@
+/**
+ * CORS and cross-origin protection middleware.
+ *
+ * Ports Python's reject_cross_origin() logic from codemem/viewer_http.py.
+ * GETs are allowed from any origin (viewer is local-only).
+ * Mutations (POST/DELETE/PATCH/PUT) require an Origin header matching a
+ * loopback address, or are rejected with 403.
+ */
+
+import type { Context, Next } from "hono";
+import { createMiddleware } from "hono/factory";
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
+/**
+ * Check whether an Origin header value is a valid loopback URL.
+ * Mirrors Python's _is_allowed_loopback_origin_url().
+ */
+function isLoopbackOrigin(origin: string): boolean {
+	let url: URL;
+	try {
+		url = new URL(origin);
+	} catch {
+		return false;
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+	if (url.username || url.password) return false;
+	return LOOPBACK_HOSTS.has(url.hostname);
+}
+
+/** HTTP methods that mutate state and require origin validation. */
+const UNSAFE_METHODS = new Set(["POST", "DELETE", "PATCH", "PUT"]);
+
+/**
+ * Cross-origin protection middleware.
+ *
+ * - GET/HEAD/OPTIONS: allowed from any origin (viewer is local-only).
+ * - POST/DELETE/PATCH/PUT: Origin header must be present and match loopback.
+ *   Missing or non-loopback origins return 403.
+ *
+ * For same-origin requests (no Origin header) on safe methods, no
+ * Access-Control-Allow-Origin is set — the browser doesn't need it.
+ * For valid loopback origins, ACAO is echoed back.
+ */
+export function originGuard() {
+	return createMiddleware(async (c: Context, next: Next) => {
+		const origin = c.req.header("Origin");
+		const method = c.req.method;
+
+		if (UNSAFE_METHODS.has(method)) {
+			// Mutations MUST have a valid loopback origin
+			if (!origin) {
+				return c.json({ error: "forbidden" }, 403);
+			}
+			if (!isLoopbackOrigin(origin)) {
+				return c.json({ error: "forbidden" }, 403);
+			}
+			// Valid loopback origin — echo it for CORS
+			c.header("Access-Control-Allow-Origin", origin);
+			c.header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+			c.header("Access-Control-Allow-Headers", "Content-Type");
+		} else if (origin && isLoopbackOrigin(origin)) {
+			// Safe method with valid origin — echo for preflight
+			c.header("Access-Control-Allow-Origin", origin);
+			c.header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+			c.header("Access-Control-Allow-Headers", "Content-Type");
+		}
+		// No origin or non-loopback on safe method: no ACAO header set.
+		// Browser enforces same-origin; we don't set permissive headers.
+
+		await next();
+	});
+}
+
+/**
+ * Handle OPTIONS preflight requests.
+ * Returns 204 with appropriate CORS headers for loopback origins.
+ */
+export function preflightHandler() {
+	return createMiddleware(async (c: Context, next: Next) => {
+		if (c.req.method !== "OPTIONS") {
+			await next();
+			return;
+		}
+		const origin = c.req.header("Origin");
+		if (origin && isLoopbackOrigin(origin)) {
+			c.header("Access-Control-Allow-Origin", origin);
+			c.header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+			c.header("Access-Control-Allow-Headers", "Content-Type");
+			c.header("Access-Control-Max-Age", "86400");
+			return c.body(null, 204);
+		}
+		return c.body(null, 204);
+	});
+}

--- a/packages/viewer-server/src/routes/raw-events.ts
+++ b/packages/viewer-server/src/routes/raw-events.ts
@@ -18,11 +18,14 @@ export function rawEventsRoutes(getStore: StoreFactory) {
 	app.get("/api/raw-events", (c) => {
 		const store = getStore();
 		{
+			// Pending = events received but not yet flushed to the observer.
+			// Matches Python's raw_event_backlog calculation.
 			const row = store.db
 				.prepare(
-					`SELECT COUNT(*) AS pending,
-						COUNT(DISTINCT opencode_session_id) AS sessions
-					 FROM raw_events`,
+					`SELECT COALESCE(SUM(last_received_event_seq - last_flushed_event_seq), 0) AS pending,
+						COUNT(*) AS sessions
+					 FROM raw_event_sessions
+					 WHERE last_received_event_seq > last_flushed_event_seq`,
 				)
 				.get() as Record<string, unknown>;
 			return c.json({
@@ -69,9 +72,9 @@ export function rawEventsRoutes(getStore: StoreFactory) {
 					sessions: Number(totals.sessions ?? 0),
 				},
 				ingest: {
-					available: true,
-					mode: "stream_queue",
-					max_body_bytes: 1048576,
+					available: false,
+					mode: "not_implemented",
+					reason: "POST /api/raw-events not yet ported to TS viewer-server",
 				},
 			});
 		}

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -1,0 +1,87 @@
+/**
+ * Stats routes — GET /api/stats, GET /api/usage.
+ *
+ * Ports Python's viewer_routes/stats.py.
+ */
+
+import type { MemoryStore } from "@codemem/core";
+import { Hono } from "hono";
+
+/**
+ * Create stats routes. The store factory is called per-request to get a
+ * fresh connection (matching the Python viewer pattern).
+ */
+export function statsRoutes(getStore: () => MemoryStore) {
+	const app = new Hono();
+
+	app.get("/api/stats", (c) => {
+		const store = getStore();
+		return c.json(store.stats());
+	});
+
+	app.get("/api/usage", (c) => {
+		const store = getStore();
+		{
+			const projectFilter = c.req.query("project") || null;
+			const eventsGlobal = store.db
+				.prepare(
+					`SELECT event,
+						SUM(tokens_read) AS total_tokens_read,
+						SUM(tokens_written) AS total_tokens_written,
+						SUM(tokens_saved) AS total_tokens_saved,
+						COUNT(*) AS count
+					 FROM usage_events GROUP BY event ORDER BY event`,
+				)
+				.all() as Record<string, unknown>[];
+			const totalsGlobal = store.db
+				.prepare(
+					`SELECT COALESCE(SUM(tokens_read),0) AS tokens_read,
+						COALESCE(SUM(tokens_written),0) AS tokens_written,
+						COALESCE(SUM(tokens_saved),0) AS tokens_saved,
+						COUNT(*) AS count
+					 FROM usage_events`,
+				)
+				.get() as Record<string, unknown>;
+			let eventsFiltered: Record<string, unknown>[] | null = null;
+			let totalsFiltered: Record<string, unknown> | null = null;
+			if (projectFilter) {
+				eventsFiltered = store.db
+					.prepare(
+						`SELECT event,
+							SUM(tokens_read) AS total_tokens_read,
+							SUM(tokens_written) AS total_tokens_written,
+							SUM(tokens_saved) AS total_tokens_saved,
+							COUNT(*) AS count
+						 FROM usage_events
+						 JOIN sessions ON sessions.id = usage_events.session_id
+						 WHERE sessions.project = ?
+						 GROUP BY event ORDER BY event`,
+					)
+					.all(projectFilter) as Record<string, unknown>[];
+				totalsFiltered = store.db
+					.prepare(
+						`SELECT COALESCE(SUM(tokens_read),0) AS tokens_read,
+							COALESCE(SUM(tokens_written),0) AS tokens_written,
+							COALESCE(SUM(tokens_saved),0) AS tokens_saved,
+							COUNT(*) AS count
+						 FROM usage_events
+						 JOIN sessions ON sessions.id = usage_events.session_id
+						 WHERE sessions.project = ?`,
+					)
+					.get(projectFilter) as Record<string, unknown>;
+			}
+			return c.json({
+				project: projectFilter,
+				events: projectFilter ? eventsFiltered : eventsGlobal,
+				totals: projectFilter ? totalsFiltered : totalsGlobal,
+				events_global: eventsGlobal,
+				totals_global: totalsGlobal,
+				events_filtered: eventsFiltered,
+				totals_filtered: totalsFiltered,
+				recent_packs: [],
+			});
+		}
+	});
+
+	return app;
+}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -303,6 +303,11 @@ export function syncRoutes(getStore: StoreFactory) {
 					const [id, fp] = ensureDeviceIdentity(store.db);
 					deviceId = id;
 					fingerprint = fp;
+					// Read the newly created public key
+					const newRow = store.db
+						.prepare("SELECT public_key FROM sync_device WHERE device_id = ?")
+						.get(id) as { public_key: string } | undefined;
+					publicKey = newRow?.public_key ?? "";
 				} catch {
 					return c.json({ error: "device identity unavailable" }, 500);
 				}

--- a/packages/viewer-server/src/viewer-html.ts
+++ b/packages/viewer-server/src/viewer-html.ts
@@ -1,0 +1,21 @@
+/**
+ * Viewer HTML template.
+ *
+ * Returns the minimal HTML shell for the codemem viewer SPA.
+ * Title is hardcoded to avoid XSS from user-supplied parameters.
+ */
+
+export function viewerHtml(): string {
+	return `<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>codemem</title>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/assets/app.js"></script>
+</body>
+</html>`;
+}

--- a/packages/viewer-server/vite.config.ts
+++ b/packages/viewer-server/vite.config.ts
@@ -1,8 +1,8 @@
 import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
-// Library mode for now. Will switch to full app mode with dev server
-// when we build out the viewer UI integration and sync daemon.
+// Library mode — SSR/Node target.
+// Externalizes @codemem/core, hono, and node: built-ins.
 export default defineConfig({
 	build: {
 		lib: {
@@ -11,7 +11,7 @@ export default defineConfig({
 			fileName: "index",
 		},
 		rollupOptions: {
-			external: [/^@codemem\//, /^node:/],
+			external: [/^@codemem\//, /^node:/, /^hono/, /^better-sqlite3/],
 		},
 		outDir: "dist",
 		sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,15 @@ importers:
       '@codemem/core':
         specifier: workspace:*
         version: link:../core
+      '@codemem/mcp-server':
+        specifier: workspace:*
+        version: link:../mcp-server
+      '@codemem/viewer-server':
+        specifier: workspace:*
+        version: link:../viewer-server
+      '@hono/node-server':
+        specifier: ^1.14.3
+        version: 1.19.11(hono@4.12.8)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -114,16 +123,31 @@ importers:
       '@codemem/core':
         specifier: workspace:*
         version: link:../core
+      '@hono/node-server':
+        specifier: ^1.14.3
+        version: 1.19.11(hono@4.12.8)
+      hono:
+        specifier: ^4.7.10
+        version: 4.12.8
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^22.15.21
+        version: 22.19.15
+      better-sqlite3:
+        specifier: ^12.8.0
+        version: 12.8.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)
+        version: 8.0.0(@types/node@22.19.15)(esbuild@0.27.4)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)
 
 packages:
 
@@ -611,6 +635,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
@@ -1331,6 +1358,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -1804,6 +1834,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -1815,6 +1849,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0))':
     dependencies:
@@ -2573,6 +2615,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@7.18.2: {}
 
   unpipe@1.0.0: {}
@@ -2580,6 +2624,27 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
+
+  vite-node@3.2.4(@types/node@22.19.15)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite-node@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:
@@ -2602,6 +2667,19 @@ snapshots:
       - tsx
       - yaml
 
+  vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+
   vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.4
@@ -2615,6 +2693,19 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
+  vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4):
+    dependencies:
+      '@oxc-project/runtime': 0.115.0
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+
   vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4):
     dependencies:
       '@oxc-project/runtime': 0.115.0
@@ -2627,6 +2718,47 @@ snapshots:
       '@types/node': 25.5.0
       esbuild: 0.27.4
       fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.19.15)(lightningcss@1.32.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0):
     dependencies:


### PR DESCRIPTION
## Description

Server shell for the Hono-based viewer server with all review fixes baked in.

**Server shell:**
- `index.ts` — app factory with route mounting, static serving, SPA fallback
- `middleware.ts` — `originGuard()` rejects POST/DELETE without loopback Origin (ports Python's cross-origin rejection)
- `viewer-html.ts` — hardcoded `<title>codemem</title>` (no XSS vector)
- `helpers.ts` — `safeJsonList`, `queryInt`, `queryBool` shared utilities
- `routes/stats.ts` — `GET /api/stats` + `GET /api/usage`

**Package config:**
- SSR build mode (`vite build --ssr`)
- Dependencies: hono, @hono/node-server

Part of: codemem-e524

## Type of Change
- [x] 🚀 Feature (new functionality)

## Testing
- [x] Tests pass locally (`pnpm run check` — 380 tests)

## Checklist
- [x] Code follows project style
- [x] CORS ports Python's cross-origin rejection
- [x] No XSS vectors in HTML generation