### PR TITLE
ci: add TypeScript build, test, and lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,75 @@ jobs:
       - name: Run ruff format check
         run: uv run ruff format --check codemem tests
 
+  ts-build:
+    name: TypeScript Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build (Vite + tsc declarations)
+        run: pnpm run build
+
+  ts-test:
+    name: TypeScript Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Run vitest
+        run: pnpm run test
+
+  ts-lint:
+    name: TypeScript Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Biome check
+        run: pnpm run lint
+
   plugin-smoke:
     name: Plugin Smoke (npm install + load)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "bugs": {
     "url": "https://github.com/kunickiaj/codemem/issues"
   },
+  "packageManager": "pnpm@10.26.1",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Description

Add three new CI jobs for the TypeScript workspace packages alongside the existing Python jobs:

- **ts-build**: Runs `pnpm build` (Vite library builds for all packages + `tsc --build` for declaration emit)
- **ts-test**: Runs `pnpm test` (vitest — 380 tests across 19 files)
- **ts-lint**: Runs `pnpm lint` (biome check)

All three use Node 22, pnpm with frozen lockfile, and dependency caching. Existing Python jobs (test matrix, lint, plugin-smoke, provider-loop) are unchanged.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced