### PR TITLE
feat: rename CLI to codemem, add tsx dev script, adopt clack for output

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
     "format": "pnpm exec biome check --write packages/",
     "typecheck": "pnpm exec tsc --build",
     "check": "pnpm run typecheck && pnpm run lint && pnpm run test",
-    "codemem-ts": "node packages/cli/dist/index.js"
+    "codemem": "tsx --conditions source packages/cli/src/index.ts"
   },
   "dependencies": {
     "@opencode-ai/plugin": "1.2.27"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",
+    "tsx": "^4.21.0",
     "typescript": "^5.8.2",
     "vite": "^8.0.0",
     "vitest": "^3.1.4"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"type": "module",
 	"bin": {
-		"codemem-ts": "./dist/index.js"
+		"codemem": "./dist/index.js"
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
@@ -12,15 +12,18 @@
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {
+		"@clack/prompts": "^1.1.0",
 		"@codemem/core": "workspace:*",
 		"@codemem/mcp-server": "workspace:*",
 		"@codemem/viewer-server": "workspace:*",
 		"@hono/node-server": "^1.14.3",
-		"chalk": "^5.6.2",
-		"commander": "^14.0.3"
+		"commander": "^14.0.3",
+		"omelette": "^0.4.17"
 	},
 	"devDependencies": {
 		"@types/node": "^25.5.0",
+		"@types/omelette": "^0.4.5",
+		"tsx": "^4.21.0",
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
 
 export const mcpCommand = new Command("mcp")
+	.configureHelp(helpStyle)
 	.description("Start the MCP stdio server")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.action(async (opts: { db?: string }) => {

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -1,8 +1,10 @@
+import * as p from "@clack/prompts";
 import { MemoryStore, resolveDbPath } from "@codemem/core";
-import chalk from "chalk";
 import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
 
 export const packCommand = new Command("pack")
+	.configureHelp(helpStyle)
 	.description("Build a context-aware memory pack")
 	.argument("<context>", "context string to search for")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
@@ -22,30 +24,28 @@ export const packCommand = new Command("pack")
 					return;
 				}
 
-				console.log(chalk.bold(`Memory pack for "${context}"\n`));
+				p.intro(`Memory pack for "${context}"`);
 
 				if (result.items.length === 0) {
-					console.log(chalk.dim("No relevant memories found."));
+					p.log.warn("No relevant memories found.");
+					p.outro("done");
 					return;
 				}
 
 				const m = result.metrics;
-				console.log(
-					chalk.dim(
-						`  ${m.total_items} items, ~${m.pack_tokens} tokens` +
-							(m.fallback_used ? " (fallback)" : "") +
-							` [fts:${m.sources.fts} sem:${m.sources.semantic} fuzzy:${m.sources.fuzzy}]`,
-					),
+				p.log.info(
+					`${m.total_items} items, ~${m.pack_tokens} tokens` +
+						(m.fallback_used ? " (fallback)" : "") +
+						`  [fts:${m.sources.fts} sem:${m.sources.semantic} fuzzy:${m.sources.fuzzy}]`,
 				);
-				console.log();
 
 				for (const item of result.items) {
-					const kind = chalk.dim(`(${item.kind})`);
-					console.log(`  ${chalk.cyan(`#${item.id}`)} ${kind} ${item.title}`);
+					p.log.step(`#${item.id}  ${item.kind}  ${item.title}`);
 				}
 
-				console.log(chalk.dim("\n--- pack_text ---\n"));
-				console.log(result.pack_text);
+				p.note(result.pack_text, "pack_text");
+
+				p.outro("done");
 			} finally {
 				store.close();
 			}

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,8 +1,10 @@
+import * as p from "@clack/prompts";
 import { MemoryStore, resolveDbPath } from "@codemem/core";
-import chalk from "chalk";
 import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
 
 export const searchCommand = new Command("search")
+	.configureHelp(helpStyle)
 	.description("Search memories by query")
 	.argument("<query>", "search query")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
@@ -22,24 +24,24 @@ export const searchCommand = new Command("search")
 			}
 
 			if (results.length === 0) {
-				console.log(chalk.dim("No results found."));
+				p.log.warn("No results found.");
 				return;
 			}
 
-			console.log(chalk.bold(`${results.length} result(s) for "${query}"\n`));
+			p.intro(`${results.length} result(s) for "${query}"`);
+
 			for (const item of results) {
 				const score = item.score.toFixed(3);
-				const kind = chalk.dim(`(${item.kind})`);
 				const age = timeSince(item.created_at);
-				console.log(
-					`  ${chalk.cyan(`#${item.id}`)} ${kind} ${item.title} ${chalk.dim(`[${score}] ${age}`)}`,
+				const preview =
+					item.body_text.length > 120 ? `${item.body_text.slice(0, 120)}…` : item.body_text;
+
+				p.log.message(
+					[`#${item.id}  ${item.kind}  ${age}  [${score}]`, item.title, preview].join("\n"),
 				);
-				if (item.body_text.length > 120) {
-					console.log(`    ${chalk.dim(item.body_text.slice(0, 120))}…`);
-				} else {
-					console.log(`    ${chalk.dim(item.body_text)}`);
-				}
 			}
+
+			p.outro("done");
 		} finally {
 			store.close();
 		}

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,7 +1,10 @@
+import * as p from "@clack/prompts";
 import { resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
 
 export const serveCommand = new Command("serve")
+	.configureHelp(helpStyle)
 	.description("Start the viewer server")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--host <host>", "bind host", "127.0.0.1")
@@ -18,12 +21,13 @@ export const serveCommand = new Command("serve")
 		const app = createApp();
 
 		const server = serve({ fetch: app.fetch, hostname: opts.host, port }, (info) => {
-			console.log(`codemem viewer listening on http://${info.address}:${info.port}`);
-			console.log(`  database: ${dbPath}`);
+			p.intro("codemem viewer");
+			p.log.success(`Listening on http://${info.address}:${info.port}`);
+			p.log.info(`Database: ${dbPath}`);
 		});
 
 		const shutdown = () => {
-			console.log("\nShutting down...");
+			p.outro("shutting down");
 			closeStore();
 			server.close();
 			process.exit(0);

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -1,8 +1,10 @@
+import * as p from "@clack/prompts";
 import { MemoryStore, resolveDbPath } from "@codemem/core";
-import chalk from "chalk";
 import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
 
 export const statsCommand = new Command("stats")
+	.configureHelp(helpStyle)
 	.description("Show database statistics")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--json", "output as JSON")
@@ -16,15 +18,23 @@ export const statsCommand = new Command("stats")
 			}
 
 			const db = result.database;
-			const sizeKb = Math.round(db.size_bytes / 1024);
-			console.log(chalk.bold("codemem stats (TS backend)\n"));
-			console.log(`  Database:  ${chalk.cyan(db.path)}`);
-			console.log(`  Size:      ${sizeKb.toLocaleString()} KB`);
-			console.log(`  Sessions:  ${db.sessions}`);
-			console.log(`  Memories:  ${db.active_memory_items} active / ${db.memory_items} total`);
-			console.log(`  Artifacts: ${db.artifacts}`);
-			console.log(`  Vectors:   ${db.vector_rows}`);
-			console.log(`  Raw events: ${db.raw_events}`);
+			const sizeMb = (db.size_bytes / 1_048_576).toFixed(1);
+
+			p.intro("codemem stats");
+
+			p.log.info([`Path:        ${db.path}`, `Size:        ${sizeMb} MB`].join("\n"));
+
+			p.log.success(
+				[
+					`Sessions:    ${db.sessions.toLocaleString()}`,
+					`Memories:    ${db.active_memory_items.toLocaleString()} active / ${db.memory_items.toLocaleString()} total`,
+					`Artifacts:   ${db.artifacts.toLocaleString()}`,
+					`Vectors:     ${db.vector_rows.toLocaleString()}`,
+					`Raw events:  ${db.raw_events.toLocaleString()}`,
+				].join("\n"),
+			);
+
+			p.outro("done");
 		} finally {
 			store.close();
 		}

--- a/packages/cli/src/help-style.ts
+++ b/packages/cli/src/help-style.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared Commander help style configuration.
+ *
+ * Applied to every Command instance so subcommand --help
+ * output gets the same colors as the root.
+ */
+
+import { styleText } from "node:util";
+import type { HelpConfiguration } from "commander";
+
+export const helpStyle: HelpConfiguration = {
+	styleTitle: (str) => styleText("bold", str),
+	styleCommandText: (str) => styleText("cyan", str),
+	styleCommandDescription: (str) => str,
+	styleDescriptionText: (str) => styleText("dim", str),
+	styleOptionText: (str) => styleText("green", str),
+	styleOptionTerm: (str) => styleText("green", str),
+	styleSubcommandText: (str) => styleText("cyan", str),
+	styleArgumentText: (str) => styleText("yellow", str),
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,23 +3,49 @@
 /**
  * @codemem/cli — CLI entry point.
  *
- * Prototype commands for validating the TS store port:
- *   codemem-ts stats   → database statistics
- *   codemem-ts search  → FTS5 memory search
- *   codemem-ts pack    → context-aware memory pack
+ * Commands:
+ *   codemem stats   → database statistics
+ *   codemem search  → FTS5 memory search
+ *   codemem pack    → context-aware memory pack
+ *   codemem serve   → viewer server
+ *   codemem mcp     → MCP stdio server
  */
 
 import { VERSION } from "@codemem/core";
 import { Command } from "commander";
+import omelette from "omelette";
 import { mcpCommand } from "./commands/mcp.js";
 import { packCommand } from "./commands/pack.js";
 import { searchCommand } from "./commands/search.js";
 import { serveCommand } from "./commands/serve.js";
 import { statsCommand } from "./commands/stats.js";
+import { helpStyle } from "./help-style.js";
+
+// Shell completion (bash/zsh/fish)
+const completion = omelette("codemem <command>");
+completion.on("command", ({ reply }) => {
+	reply(["stats", "search", "pack", "serve", "mcp", "help", "--help", "--version"]);
+});
+completion.init();
+
+// `codemem --setup-completion` installs shell completion
+if (process.argv.includes("--setup-completion")) {
+	completion.setupShellInitFile();
+	process.exit(0);
+}
+// `codemem --cleanup-completion` removes it
+if (process.argv.includes("--cleanup-completion")) {
+	completion.cleanupShellInitFile();
+	process.exit(0);
+}
 
 const program = new Command();
 
-program.name("codemem-ts").description("codemem TypeScript backend CLI").version(VERSION);
+program
+	.name("codemem")
+	.description("codemem — persistent memory for AI coding agents")
+	.version(VERSION)
+	.configureHelp(helpStyle);
 
 program.addCommand(serveCommand);
 program.addCommand(mcpCommand);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"source": "./src/index.ts",
 			"import": "./dist/index.js",
 			"types": "./dist/index.d.ts"
 		}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"source": "./src/index.ts",
 			"import": "./dist/index.js",
 			"types": "./dist/index.d.ts"
 		}

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"exports": {
 		".": {
+			"source": "./src/index.ts",
 			"import": "./dist/index.js",
 			"types": "./dist/index.d.ts"
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,18 +27,24 @@ importers:
       '@biomejs/biome':
         specifier: ^2.0.6
         version: 2.4.7
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.8.2
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)
+        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
       vitest:
         specifier: ^3.1.4
-        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@codemem/core':
         specifier: workspace:*
         version: link:../core
@@ -51,25 +57,31 @@ importers:
       '@hono/node-server':
         specifier: ^1.14.3
         version: 1.19.11(hono@4.12.8)
-      chalk:
-        specifier: ^5.6.2
-        version: 5.6.2
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      omelette:
+        specifier: ^0.4.17
+        version: 0.4.17
     devDependencies:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      '@types/omelette':
+        specifier: ^0.4.5
+        version: 0.4.5
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)
+        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/core:
     dependencies:
@@ -88,10 +100,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)
+        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/mcp-server:
     dependencies:
@@ -113,10 +125,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)
+        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)
+        version: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/viewer-server:
     dependencies:
@@ -144,10 +156,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.0(@types/node@22.19.15)(esbuild@0.27.4)
+        version: 8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)
+        version: 3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)
 
 packages:
 
@@ -203,6 +215,12 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@clack/core@1.1.0':
+    resolution: {integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==}
+
+  '@clack/prompts@1.1.0':
+    resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -642,6 +660,9 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
+  '@types/omelette@0.4.5':
+    resolution: {integrity: sha512-zUCJpVRwfMcZfkxSCGp73mgd3/xesvPz5tQJIORlfP/zkYEyp9KUfF7IP3RRjyZR3DwxkPs96/IFf70GmYZYHQ==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -729,10 +750,6 @@ packages:
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -916,6 +933,9 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -1112,6 +1132,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  omelette@0.4.17:
+    resolution: {integrity: sha512-UlU69G6Bhu0XFjw3tjFZ0qyiMUjAOR+rdzblA1nLQ8xiqFtxOVlkhM39BlgTpLFx9fxkm6rnxNNRsS5GxE/yww==}
+    engines: {node: '>=0.8.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -1189,6 +1213,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rolldown@1.0.0-rc.9:
     resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1257,6 +1284,9 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1345,6 +1375,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -1551,6 +1586,15 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.7':
     optional: true
+
+  '@clack/core@1.1.0':
+    dependencies:
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.1.0':
+    dependencies:
+      '@clack/core': 1.1.0
+      sisteransi: 1.0.5
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -1842,6 +1886,8 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/omelette@0.4.5': {}
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1850,21 +1896,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1967,8 +2013,6 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
-
-  chalk@5.6.2: {}
 
   check-error@2.1.3: {}
 
@@ -2170,6 +2214,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   github-from-package@0.0.0: {}
 
   gopd@1.2.0: {}
@@ -2305,6 +2353,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  omelette@0.4.17: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -2387,6 +2437,8 @@ snapshots:
       util-deprecate: 1.0.2
 
   require-from-string@2.0.2: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   rolldown@1.0.0-rc.9:
     dependencies:
@@ -2527,6 +2579,8 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
+  sisteransi@1.0.5: {}
+
   source-map-js@1.2.1: {}
 
   sqlite-vec-darwin-arm64@0.1.7-alpha.2:
@@ -2603,6 +2657,13 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -2625,13 +2686,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@22.19.15)(lightningcss@1.32.0):
+  vite-node@3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2646,13 +2707,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0):
+  vite-node@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2667,7 +2728,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0):
+  vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2679,8 +2740,9 @@ snapshots:
       '@types/node': 22.19.15
       fsevents: 2.3.3
       lightningcss: 1.32.0
+      tsx: 4.21.0
 
-  vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0):
+  vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2692,8 +2754,9 @@ snapshots:
       '@types/node': 25.5.0
       fsevents: 2.3.3
       lightningcss: 1.32.0
+      tsx: 4.21.0
 
-  vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4):
+  vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -2705,8 +2768,9 @@ snapshots:
       '@types/node': 22.19.15
       esbuild: 0.27.4
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4):
+  vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -2718,12 +2782,13 @@ snapshots:
       '@types/node': 25.5.0
       esbuild: 0.27.4
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@22.19.15)(lightningcss@1.32.0):
+  vitest@3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2741,8 +2806,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)
-      vite-node: 3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.15)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
@@ -2760,11 +2825,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0):
+  vitest@3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2782,8 +2847,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)
-      vite-node: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0


### PR DESCRIPTION
## Description

Improve CLI developer experience with three changes:

1. **Rename `codemem-ts` → `codemem`** — bin name in package.json and Commander program name updated
2. **Add tsx-based dev script** — `pnpm codemem <cmd>` runs from source with no build step needed (replaces `pnpm build && node packages/cli/dist/index.js <cmd>`)
3. **Replace chalk with @clack/prompts** — all command output (stats, search, pack, serve) uses clack's structured log/intro/outro/note components for styled, consistent terminal output. Drops chalk dependency.

### Before (chalk + console.log)
```
codemem stats (TS backend)
  Database:  /path/to/db
  Size:      2,092,444 KB
```

### After (@clack/prompts)
```
┌  codemem stats
│
●  Path:        /path/to/db
│  Size:        2044.0 MB
│
◆  Sessions:    6,838
│  Memories:    7,179 active / 7,671 total
│  Artifacts:   76,871
│  Vectors:     8,833
│  Raw events:  109,349
│
└  done
```

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 379/380, 1 known failure in viewer-server fixed in #277)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected (`pnpm codemem stats`, `pnpm codemem search`, built CLI)

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced