### PR TITLE
feat: wire raw event sweeper into serve command

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { resolveDbPath } from "@codemem/core";
+import { ObserverClient, RawEventSweeper, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 
@@ -11,7 +11,7 @@ export const serveCommand = new Command("serve")
 	.option("--port <port>", "bind port", "38888")
 	.action(async (opts: { db?: string; host: string; port: string }) => {
 		// Dynamic import to avoid loading hono/server deps for non-serve commands
-		const { createApp, closeStore } = await import("@codemem/viewer-server");
+		const { createApp, closeStore, getStore } = await import("@codemem/viewer-server");
 		const { serve } = await import("@hono/node-server");
 
 		const dbPath = resolveDbPath(opts.db);
@@ -20,18 +20,37 @@ export const serveCommand = new Command("serve")
 		const port = Number.parseInt(opts.port, 10);
 		const app = createApp();
 
+		// Start the raw event sweeper — shares the same store as the viewer
+		const observer = new ObserverClient();
+		const sweeper = new RawEventSweeper(getStore(), { observer });
+		sweeper.start();
+
 		const server = serve({ fetch: app.fetch, hostname: opts.host, port }, (info) => {
 			p.intro("codemem viewer");
 			p.log.success(`Listening on http://${info.address}:${info.port}`);
 			p.log.info(`Database: ${dbPath}`);
+			p.log.step("Raw event sweeper started");
 		});
 
-		const shutdown = () => {
+		const shutdown = async () => {
 			p.outro("shutting down");
-			closeStore();
-			server.close();
-			process.exit(0);
+			// Stop sweeper first and wait for any in-flight tick to drain.
+			await sweeper.stop();
+			// Close HTTP server, wait for in-flight requests to drain
+			server.close(() => {
+				closeStore();
+				process.exit(0);
+			});
+			// Force exit after 5s if graceful shutdown stalls
+			setTimeout(() => {
+				closeStore();
+				process.exit(1);
+			}, 5000).unref();
 		};
-		process.on("SIGINT", shutdown);
-		process.on("SIGTERM", shutdown);
+		process.on("SIGINT", () => {
+			void shutdown();
+		});
+		process.on("SIGTERM", () => {
+			void shutdown();
+		});
 	});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,6 +113,9 @@ export {
 	stripTrailingCommas,
 } from "./observer-config.js";
 export { buildMemoryPack, estimateTokens } from "./pack.js";
+export type { FlushRawEventsOptions } from "./raw-event-flush.js";
+export { buildSessionContext, flushRawEvents } from "./raw-event-flush.js";
+export { RawEventSweeper } from "./raw-event-sweeper.js";
 export type { StoreHandle } from "./search.js";
 export {
 	expandQuery,

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -303,7 +303,13 @@ export async function ingest(
 		const response = await options.observer.observe(system, user);
 
 		if (!response.raw) {
-			// Surface the failure — silent memory loss is unacceptable
+			// Raw-event flushes must be lossless: if the observer returns no output,
+			// fail the flush so we do NOT advance last_flushed_event_seq.
+			if (sessionContext?.flusher === "raw_events") {
+				throw new Error("observer failed during raw-event flush");
+			}
+
+			// Surface the failure for normal ingest paths.
 			const status = options.observer.getStatus();
 			console.warn(
 				`[codemem] Observer returned no output (provider=${response.provider}, model=${response.model}` +

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -1,0 +1,251 @@
+/**
+ * Raw event flush orchestration — bridge between the sweeper and the ingest pipeline.
+ *
+ * Ports the core flush logic from codemem/raw_event_flush.py.
+ *
+ * Reads unflushed raw events for a session, creates a batch record,
+ * builds an IngestPayload, runs it through the ingest pipeline,
+ * and updates flush state on success (or records failure details).
+ */
+
+import { type IngestOptions, ingest } from "./ingest-pipeline.js";
+import type { IngestPayload, SessionContext } from "./ingest-types.js";
+import { ObserverAuthError } from "./observer-client.js";
+import type { MemoryStore } from "./store.js";
+
+const EXTRACTOR_VERSION = "raw_events_v1";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncateErrorMessage(message: string, limit = 280): string {
+	const text = message.replace(/\s+/g, " ").trim();
+	if (text.length <= limit) return text;
+	return `${text.slice(0, limit - 3).trimEnd()}...`;
+}
+
+function providerDisplayName(provider: string | null | undefined): string {
+	const normalized = (provider ?? "").trim().toLowerCase();
+	if (normalized === "openai") return "OpenAI";
+	if (normalized === "anthropic") return "Anthropic";
+	if (normalized) return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+	return "Observer";
+}
+
+function summarizeFlushFailure(exc: Error, provider: string | null | undefined): string {
+	const providerTitle = providerDisplayName(provider);
+	const rawMessage = String(exc.message ?? "")
+		.trim()
+		.toLowerCase();
+
+	if (exc instanceof ObserverAuthError) {
+		return `${providerTitle} authentication failed. Refresh credentials and retry.`;
+	}
+	if (exc.name === "TimeoutError" || rawMessage.includes("timeout")) {
+		return `${providerTitle} request timed out during raw-event processing.`;
+	}
+	if (rawMessage === "observer failed during raw-event flush") {
+		return `${providerTitle} returned no usable output for raw-event processing.`;
+	}
+	if (/parse|xml|json/i.test(rawMessage)) {
+		return `${providerTitle} response could not be processed.`;
+	}
+	return `${providerTitle} processing failed during raw-event ingestion.`;
+}
+
+// ---------------------------------------------------------------------------
+// Session context builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build session context from raw events — extracts prompt count, tool count,
+ * duration, files modified/read, and first user prompt.
+ *
+ * Port of build_session_context() from raw_event_flush.py.
+ */
+export function buildSessionContext(events: Record<string, unknown>[]): SessionContext {
+	let promptCount = 0;
+	let toolCount = 0;
+
+	for (const e of events) {
+		if (e.type === "user_prompt") promptCount++;
+		if (e.type === "tool.execute.after") toolCount++;
+	}
+
+	const tsValues: number[] = [];
+	for (const e of events) {
+		const ts = e.timestamp_wall_ms;
+		if (ts == null) continue;
+		const num = Number(ts);
+		if (!Number.isFinite(num)) continue;
+		tsValues.push(num);
+	}
+	let durationMs = 0;
+	if (tsValues.length > 0) {
+		durationMs = Math.max(0, Math.max(...tsValues) - Math.min(...tsValues));
+	}
+
+	const filesModified = new Set<string>();
+	const filesRead = new Set<string>();
+	for (const e of events) {
+		if (e.type !== "tool.execute.after") continue;
+		const tool = String(e.tool ?? "").toLowerCase();
+		const args = e.args;
+		if (args == null || typeof args !== "object") continue;
+		const filePath =
+			(args as Record<string, unknown>).filePath ?? (args as Record<string, unknown>).path;
+		if (typeof filePath !== "string" || !filePath) continue;
+		if (tool === "write" || tool === "edit") filesModified.add(filePath);
+		if (tool === "read") filesRead.add(filePath);
+	}
+
+	let firstPrompt: string | undefined;
+	for (const e of events) {
+		if (e.type !== "user_prompt") continue;
+		const text = e.prompt_text;
+		if (typeof text === "string" && text.trim()) {
+			firstPrompt = text.trim();
+			break;
+		}
+	}
+
+	return {
+		firstPrompt,
+		promptCount,
+		toolCount,
+		durationMs,
+		filesModified: [...filesModified].sort(),
+		filesRead: [...filesRead].sort(),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Main flush function
+// ---------------------------------------------------------------------------
+
+export interface FlushRawEventsOptions {
+	opencodeSessionId: string;
+	source?: string;
+	cwd?: string | null;
+	project?: string | null;
+	startedAt?: string | null;
+	maxEvents?: number | null;
+}
+
+/**
+ * Flush raw events for a single session through the ingest pipeline.
+ *
+ * 1. Reads unflushed raw events from the store
+ * 2. Creates/claims a flush batch for idempotency
+ * 3. Builds session context and IngestPayload
+ * 4. Calls ingest()
+ * 5. Updates flush state on success; records failure details on error
+ *
+ * Port of flush_raw_events() from raw_event_flush.py.
+ */
+export async function flushRawEvents(
+	store: MemoryStore,
+	ingestOpts: IngestOptions,
+	opts: FlushRawEventsOptions,
+): Promise<{ flushed: number; updatedState: number }> {
+	let { source = "opencode", cwd, project, startedAt } = opts;
+	const { opencodeSessionId, maxEvents } = opts;
+
+	source = (source ?? "").trim().toLowerCase() || "opencode";
+
+	// Resolve session metadata for missing fields
+	const meta = store.rawEventSessionMeta(opencodeSessionId, source);
+	if (cwd == null) cwd = (meta.cwd as string) ?? process.cwd();
+	if (project == null) project = (meta.project as string) ?? null;
+	if (startedAt == null) startedAt = (meta.started_at as string) ?? null;
+
+	// Read unflushed events
+	const lastFlushed = store.rawEventFlushState(opencodeSessionId, source);
+	const events = store.rawEventsSinceBySeq(opencodeSessionId, source, lastFlushed, maxEvents);
+	if (events.length === 0) {
+		return { flushed: 0, updatedState: 0 };
+	}
+
+	// Extract event sequence range
+	const eventSeqs: number[] = [];
+	for (const e of events) {
+		const seq = e.event_seq;
+		if (seq == null) continue;
+		const num = Number(seq);
+		if (Number.isFinite(num)) eventSeqs.push(num);
+	}
+	if (eventSeqs.length === 0) {
+		return { flushed: 0, updatedState: 0 };
+	}
+
+	const startEventSeq = Math.min(...eventSeqs);
+	const lastEventSeq = Math.max(...eventSeqs);
+	if (lastEventSeq < startEventSeq) {
+		return { flushed: 0, updatedState: 0 };
+	}
+
+	// Get or create flush batch (idempotency guard)
+	const { batchId, status } = store.getOrCreateRawEventFlushBatch(
+		opencodeSessionId,
+		source,
+		startEventSeq,
+		lastEventSeq,
+		EXTRACTOR_VERSION,
+	);
+
+	// If already completed, just advance flush state
+	if (status === "completed") {
+		store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
+		return { flushed: 0, updatedState: 1 };
+	}
+
+	// Claim the batch (atomic lock)
+	if (!store.claimRawEventFlushBatch(batchId)) {
+		return { flushed: 0, updatedState: 0 };
+	}
+
+	// Build session context
+	const sessionContext: SessionContext = buildSessionContext(events);
+	sessionContext.opencodeSessionId = opencodeSessionId;
+	sessionContext.source = source;
+	sessionContext.streamId = opencodeSessionId;
+	sessionContext.flusher = "raw_events";
+	sessionContext.flushBatch = {
+		batch_id: batchId,
+		start_event_seq: startEventSeq,
+		end_event_seq: lastEventSeq,
+	};
+
+	// Build ingest payload
+	const payload: IngestPayload = {
+		cwd: cwd ?? undefined,
+		project: project ?? undefined,
+		startedAt: startedAt ?? new Date().toISOString(),
+		events,
+		sessionContext,
+	};
+
+	// Run ingest pipeline
+	try {
+		await ingest(payload, store, ingestOpts);
+	} catch (exc) {
+		// Record failure details on the batch
+		const err = exc instanceof Error ? exc : new Error(String(exc));
+		const provider = ingestOpts.observer?.getStatus?.()?.provider as string | undefined;
+		const message = truncateErrorMessage(summarizeFlushFailure(err, provider));
+		store.recordRawEventFlushBatchFailure(batchId, {
+			message,
+			errorType: err instanceof ObserverAuthError ? "ObserverAuthError" : err.name,
+			observerProvider: provider ?? null,
+			observerModel: (ingestOpts.observer?.getStatus?.()?.model as string) ?? null,
+			observerRuntime: null,
+		});
+		throw exc;
+	}
+
+	// Success — mark batch completed and advance flush state
+	store.updateRawEventFlushBatchStatus(batchId, "completed");
+	store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
+	return { flushed: events.length, updatedState: 1 };
+}

--- a/packages/core/src/raw-event-sweeper.ts
+++ b/packages/core/src/raw-event-sweeper.ts
@@ -1,0 +1,322 @@
+/**
+ * RawEventSweeper — periodically processes raw events into memories.
+ *
+ * Ports codemem/viewer_raw_events.py RawEventSweeper class.
+ *
+ * Uses setInterval (Node single-threaded) instead of Python threads.
+ * The sweeper takes a shared MemoryStore and an IngestOptions provider.
+ *
+ * Each tick():
+ * 1. Check if enabled
+ * 2. Check auth backoff
+ * 3. Purge old events (if retention configured)
+ * 4. Mark stuck batches as error
+ * 5. Flush sessions with pending queue entries
+ * 6. Flush idle sessions with unflushed events
+ * 7. Handle auth errors by setting backoff
+ */
+
+import type { IngestOptions } from "./ingest-pipeline.js";
+import { ObserverAuthError } from "./observer-client.js";
+import { flushRawEvents } from "./raw-event-flush.js";
+import type { MemoryStore } from "./store.js";
+
+/** Back off for 5 minutes after an auth error (seconds). */
+const AUTH_BACKOFF_S = 300;
+
+// ---------------------------------------------------------------------------
+// Env helpers — read config from env vars matching Python exactly
+// ---------------------------------------------------------------------------
+
+function envInt(name: string, fallback: number): number {
+	const value = process.env[name];
+	if (value == null) return fallback;
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function envBoolDisabled(name: string): boolean {
+	const value = (process.env[name] ?? "1").trim().toLowerCase();
+	return value === "0" || value === "false" || value === "off";
+}
+
+// ---------------------------------------------------------------------------
+// RawEventSweeper
+// ---------------------------------------------------------------------------
+
+export class RawEventSweeper {
+	private store: MemoryStore;
+	private ingestOpts: IngestOptions;
+	private active = false;
+	private running = false; // reentrancy guard — prevents overlapping ticks
+	private currentTick: Promise<void> | null = null;
+	private wakeHandle: ReturnType<typeof setTimeout> | null = null;
+	private loopHandle: ReturnType<typeof setTimeout> | null = null;
+	private authBackoffUntil = 0; // epoch seconds
+	private authErrorLogged = false;
+
+	constructor(store: MemoryStore, ingestOpts: IngestOptions) {
+		this.store = store;
+		this.ingestOpts = ingestOpts;
+	}
+
+	// -----------------------------------------------------------------------
+	// Config readers (from env vars, matching Python)
+	// -----------------------------------------------------------------------
+
+	private enabled(): boolean {
+		return !envBoolDisabled("CODEMEM_RAW_EVENTS_SWEEPER");
+	}
+
+	private intervalMs(): number {
+		return Math.max(1000, envInt("CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS", 30_000));
+	}
+
+	private idleMs(): number {
+		return envInt("CODEMEM_RAW_EVENTS_SWEEPER_IDLE_MS", 120_000);
+	}
+
+	private limit(): number {
+		return envInt("CODEMEM_RAW_EVENTS_SWEEPER_LIMIT", 25);
+	}
+
+	private workerMaxEvents(): number | null {
+		const parsed = envInt("CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS", 250);
+		return parsed <= 0 ? null : parsed;
+	}
+
+	private retentionMs(): number {
+		return envInt("CODEMEM_RAW_EVENTS_RETENTION_MS", 0);
+	}
+
+	private stuckBatchMs(): number {
+		return envInt("CODEMEM_RAW_EVENTS_STUCK_BATCH_MS", 300_000);
+	}
+
+	// -----------------------------------------------------------------------
+	// Auth backoff
+	// -----------------------------------------------------------------------
+
+	private handleAuthError(exc: ObserverAuthError): void {
+		this.authBackoffUntil = Date.now() / 1000 + AUTH_BACKOFF_S;
+		if (!this.authErrorLogged) {
+			this.authErrorLogged = true;
+			const msg =
+				`codemem: observer auth error — backing off for ${AUTH_BACKOFF_S}s. ` +
+				`Refresh your provider credentials or update observer_provider in settings. ` +
+				`(${exc.message})`;
+			console.error(msg);
+		}
+	}
+
+	/**
+	 * Reset the auth backoff and wake the worker.
+	 * Call this after credentials are refreshed.
+	 */
+	resetAuthBackoff(): void {
+		this.authBackoffUntil = 0;
+		this.authErrorLogged = false;
+		this.wake();
+	}
+
+	/**
+	 * Return the current auth backoff status.
+	 */
+	authBackoffStatus(): { active: boolean; remainingS: number } {
+		const now = Date.now() / 1000;
+		const remaining = Math.max(0, Math.round(this.authBackoffUntil - now));
+		return { active: remaining > 0, remainingS: remaining };
+	}
+
+	// -----------------------------------------------------------------------
+	// Lifecycle
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Start the sweeper loop.
+	 * Uses a self-scheduling async loop (sleep → tick → sleep) to prevent
+	 * overlapping ticks. This mirrors the Python threading pattern where
+	 * the thread sleeps, runs tick() synchronously, then sleeps again.
+	 * No-op if sweeper is disabled or already running.
+	 */
+	start(): void {
+		if (!this.enabled()) return;
+		if (this.active) return;
+		this.active = true;
+		this.scheduleNext();
+	}
+
+	/**
+	 * Stop the sweeper. Cancels the next scheduled tick and waits for any
+	 * in-progress tick to finish before returning.
+	 */
+	async stop(): Promise<void> {
+		this.active = false;
+		if (this.loopHandle != null) {
+			clearTimeout(this.loopHandle);
+			this.loopHandle = null;
+		}
+		if (this.wakeHandle != null) {
+			clearTimeout(this.wakeHandle);
+			this.wakeHandle = null;
+		}
+		if (this.currentTick != null) {
+			await this.currentTick;
+		}
+	}
+
+	/**
+	 * Notify the sweeper that config changed.
+	 * Schedules an extra tick after a short delay.
+	 */
+	notifyConfigChanged(): void {
+		this.wake();
+	}
+
+	/** Schedule the next tick after the configured interval. */
+	private scheduleNext(): void {
+		if (!this.active) return;
+		this.loopHandle = setTimeout(async () => {
+			this.loopHandle = null;
+			await this.runTick();
+			this.scheduleNext();
+		}, this.intervalMs());
+		if (typeof this.loopHandle === "object" && "unref" in this.loopHandle) {
+			this.loopHandle.unref();
+		}
+	}
+
+	/** Execute a tick with reentrancy protection. */
+	private async runTick(): Promise<void> {
+		if (this.running) return;
+		this.running = true;
+		this.currentTick = (async () => {
+			try {
+				await this.tick();
+			} catch (err) {
+				console.error("codemem: sweeper tick failed unexpectedly:", err);
+			} finally {
+				this.running = false;
+				this.currentTick = null;
+			}
+		})();
+		await this.currentTick;
+	}
+
+	private wake(): void {
+		if (!this.active) return;
+		// Schedule a near-immediate extra tick (with reentrancy guard)
+		if (this.wakeHandle != null) {
+			clearTimeout(this.wakeHandle);
+		}
+		this.wakeHandle = setTimeout(async () => {
+			this.wakeHandle = null;
+			await this.runTick();
+		}, 100);
+		if (typeof this.wakeHandle === "object" && "unref" in this.wakeHandle) {
+			this.wakeHandle.unref();
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Tick — one sweep cycle
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Execute one sweep cycle. Public for testing.
+	 *
+	 * 1. Check enabled / auth backoff
+	 * 2. Purge old events
+	 * 3. Mark stuck batches
+	 * 4. Flush pending queue sessions
+	 * 5. Flush idle sessions
+	 */
+	async tick(): Promise<void> {
+		if (!this.enabled()) return;
+
+		// Skip while backing off from auth error
+		const now = Date.now() / 1000;
+		if (now < this.authBackoffUntil) return;
+
+		// Backoff expired — reset so next auth error gets logged again
+		if (this.authErrorLogged) {
+			this.authErrorLogged = false;
+		}
+
+		const nowMs = Date.now();
+		const idleBefore = nowMs - this.idleMs();
+
+		// Purge old events if retention configured
+		const retentionMs = this.retentionMs();
+		if (retentionMs > 0) {
+			this.store.purgeRawEvents(retentionMs);
+		}
+
+		// Mark stuck batches as error
+		const stuckMs = this.stuckBatchMs();
+		if (stuckMs > 0) {
+			const cutoff = new Date(nowMs - stuckMs).toISOString();
+			this.store.markStuckRawEventBatchesAsError(cutoff, 100);
+		}
+
+		const maxEvents = this.workerMaxEvents();
+		const sessionLimit = this.limit();
+		const drained = new Set<string>();
+
+		// Phase 1: Flush sessions with pending queue entries
+		const queueSessions = this.store.rawEventSessionsWithPendingQueue(sessionLimit);
+		for (const item of queueSessions) {
+			const { source, streamId } = item;
+			if (!streamId) continue;
+
+			try {
+				await flushRawEvents(this.store, this.ingestOpts, {
+					opencodeSessionId: streamId,
+					source,
+					cwd: null,
+					project: null,
+					startedAt: null,
+					maxEvents,
+				});
+				drained.add(`${source}:${streamId}`);
+			} catch (exc) {
+				if (exc instanceof ObserverAuthError) {
+					this.handleAuthError(exc);
+					return; // Stop all flush work during auth backoff
+				}
+				console.error(
+					`codemem: raw event queue worker flush failed for ${streamId}:`,
+					exc instanceof Error ? exc.message : exc,
+				);
+			}
+		}
+
+		// Phase 2: Flush idle sessions with unflushed events
+		const idleSessions = this.store.rawEventSessionsPendingIdleFlush(idleBefore, sessionLimit);
+		for (const item of idleSessions) {
+			const { source, streamId } = item;
+			if (!streamId) continue;
+			if (drained.has(`${source}:${streamId}`)) continue;
+
+			try {
+				await flushRawEvents(this.store, this.ingestOpts, {
+					opencodeSessionId: streamId,
+					source,
+					cwd: null,
+					project: null,
+					startedAt: null,
+					maxEvents,
+				});
+			} catch (exc) {
+				if (exc instanceof ObserverAuthError) {
+					this.handleAuthError(exc);
+					return; // Stop all flush work during auth backoff
+				}
+				console.error(
+					`codemem: raw event sweeper flush failed for ${streamId}:`,
+					exc instanceof Error ? exc.message : exc,
+				);
+			}
+		}
+	}
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -559,6 +559,390 @@ export class MemoryStore {
 	}
 
 	// -----------------------------------------------------------------------
+	// Raw event helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Normalize source/streamId to match Python's _normalize_stream_identity().
+	 * Trims whitespace, lowercases source, defaults to "opencode".
+	 */
+	private normalizeStreamIdentity(source: string, streamId: string): [string, string] {
+		const s = source.trim().toLowerCase() || "opencode";
+		const sid = streamId.trim();
+		if (!sid) throw new Error("stream_id is required");
+		return [s, sid];
+	}
+
+	// -----------------------------------------------------------------------
+	// Raw event query methods (ports from codemem/store/raw_events.py)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Find sessions that have unflushed events and have been idle long enough.
+	 * Port of raw_event_sessions_pending_idle_flush().
+	 */
+	rawEventSessionsPendingIdleFlush(
+		idleBeforeTsWallMs: number,
+		limit = 25,
+	): { source: string; streamId: string }[] {
+		const rows = this.db
+			.prepare(
+				`WITH max_events AS (
+            SELECT source, stream_id, MAX(event_seq) AS max_seq
+            FROM raw_events
+            GROUP BY source, stream_id
+        )
+        SELECT s.source, s.stream_id
+        FROM raw_event_sessions s
+        JOIN max_events e ON e.source = s.source AND e.stream_id = s.stream_id
+        WHERE s.last_seen_ts_wall_ms IS NOT NULL
+          AND s.last_seen_ts_wall_ms <= ?
+          AND e.max_seq > s.last_flushed_event_seq
+        ORDER BY s.last_seen_ts_wall_ms ASC
+        LIMIT ?`,
+			)
+			.all(idleBeforeTsWallMs, limit) as { source: string | null; stream_id: string | null }[];
+
+		return rows
+			.filter((row) => row.stream_id)
+			.map((row) => ({
+				source: String(row.source ?? "opencode"),
+				streamId: String(row.stream_id ?? ""),
+			}));
+	}
+
+	/**
+	 * Find sessions that have pending/failed flush batches with unflushed events.
+	 * Port of raw_event_sessions_with_pending_queue().
+	 */
+	rawEventSessionsWithPendingQueue(limit = 25): { source: string; streamId: string }[] {
+		const rows = this.db
+			.prepare(
+				`WITH pending_batches AS (
+            SELECT b.source, b.stream_id, MIN(b.updated_at) AS oldest_pending_update
+            FROM raw_event_flush_batches b
+            WHERE b.status IN ('pending', 'failed', 'started', 'error')
+            GROUP BY b.source, b.stream_id
+        ),
+        max_events AS (
+            SELECT source, stream_id, MAX(event_seq) AS max_seq
+            FROM raw_events
+            GROUP BY source, stream_id
+        )
+        SELECT b.source, b.stream_id
+        FROM pending_batches b
+        JOIN max_events e ON e.source = b.source AND e.stream_id = b.stream_id
+        LEFT JOIN raw_event_sessions s ON s.source = b.source AND s.stream_id = b.stream_id
+        WHERE e.max_seq > COALESCE(s.last_flushed_event_seq, -1)
+        ORDER BY b.oldest_pending_update ASC
+        LIMIT ?`,
+			)
+			.all(limit) as { source: string | null; stream_id: string | null }[];
+
+		return rows
+			.filter((row) => row.stream_id)
+			.map((row) => ({
+				source: String(row.source ?? "opencode"),
+				streamId: String(row.stream_id ?? ""),
+			}));
+	}
+
+	/**
+	 * Delete raw events older than max_age_ms. Returns count of deleted raw_events rows.
+	 * Port of purge_raw_events() + purge_raw_events_before().
+	 */
+	purgeRawEvents(maxAgeMs: number): number {
+		if (maxAgeMs <= 0) return 0;
+		const nowMs = Date.now();
+		const cutoffTsWallMs = nowMs - maxAgeMs;
+		const cutoffIso = new Date(cutoffTsWallMs).toISOString();
+
+		return this.db.transaction(() => {
+			this.db.prepare("DELETE FROM raw_event_ingest_samples WHERE created_at < ?").run(cutoffIso);
+			const result = this.db
+				.prepare("DELETE FROM raw_events WHERE ts_wall_ms IS NOT NULL AND ts_wall_ms < ?")
+				.run(cutoffTsWallMs);
+			return result.changes;
+		})();
+	}
+
+	/**
+	 * Mark stuck flush batches (started/running/pending/claimed) as failed.
+	 * Port of mark_stuck_raw_event_batches_as_error().
+	 */
+	markStuckRawEventBatchesAsError(olderThanIso: string, limit = 100): number {
+		const now = new Date().toISOString();
+		const result = this.db
+			.prepare(
+				`WITH candidates AS (
+            SELECT id
+            FROM raw_event_flush_batches
+            WHERE status IN ('started', 'running', ?, ?) AND updated_at < ?
+            ORDER BY updated_at
+            LIMIT ?
+        )
+        UPDATE raw_event_flush_batches
+        SET status = ?,
+            updated_at = ?,
+            error_message = 'Flush retry timed out.',
+            error_type = 'RawEventBatchStuck',
+            observer_provider = NULL,
+            observer_model = NULL,
+            observer_runtime = NULL
+        WHERE id IN (SELECT id FROM candidates)`,
+			)
+			.run(
+				"pending", // RAW_EVENT_QUEUE_PENDING
+				"claimed", // RAW_EVENT_QUEUE_CLAIMED
+				olderThanIso,
+				limit,
+				"failed", // RAW_EVENT_QUEUE_FAILED
+				now,
+			);
+
+		return result.changes;
+	}
+
+	// -----------------------------------------------------------------------
+	// Raw event per-session methods (ports for flush pipeline)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Get session metadata (cwd, project, started_at, etc.) for a raw event stream.
+	 * Port of raw_event_session_meta().
+	 */
+	rawEventSessionMeta(opencodeSessionId: string, source = "opencode"): Record<string, unknown> {
+		const [s, sid] = this.normalizeStreamIdentity(source, opencodeSessionId);
+		const row = this.db
+			.prepare(
+				`SELECT cwd, project, started_at, last_seen_ts_wall_ms, last_flushed_event_seq
+				 FROM raw_event_sessions
+				 WHERE source = ? AND stream_id = ?`,
+			)
+			.get(s, sid) as Record<string, unknown> | undefined;
+		if (!row) return {};
+		return {
+			cwd: row.cwd,
+			project: row.project,
+			started_at: row.started_at,
+			last_seen_ts_wall_ms: row.last_seen_ts_wall_ms,
+			last_flushed_event_seq: row.last_flushed_event_seq,
+		};
+	}
+
+	/**
+	 * Get the last flushed event_seq for a session. Returns -1 if no state.
+	 * Port of raw_event_flush_state().
+	 */
+	rawEventFlushState(opencodeSessionId: string, source = "opencode"): number {
+		const [s, sid] = this.normalizeStreamIdentity(source, opencodeSessionId);
+		const row = this.db
+			.prepare(
+				"SELECT last_flushed_event_seq FROM raw_event_sessions WHERE source = ? AND stream_id = ?",
+			)
+			.get(s, sid) as { last_flushed_event_seq: number } | undefined;
+		if (!row) return -1;
+		return Number(row.last_flushed_event_seq);
+	}
+
+	/**
+	 * Get raw events after a given event_seq, ordered by event_seq ASC.
+	 * Returns enriched event objects with type, timestamps, event_seq, event_id.
+	 * Port of raw_events_since_by_seq().
+	 */
+	rawEventsSinceBySeq(
+		opencodeSessionId: string,
+		source = "opencode",
+		afterEventSeq = -1,
+		limit?: number | null,
+	): Record<string, unknown>[] {
+		const [s, sid] = this.normalizeStreamIdentity(source, opencodeSessionId);
+		const limitClause = limit != null && limit > 0 ? "LIMIT ?" : "";
+		const params: unknown[] = [s, sid, afterEventSeq];
+		if (limit != null && limit > 0) params.push(limit);
+
+		const rows = this.db
+			.prepare(
+				`SELECT event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, event_id
+				 FROM raw_events
+				 WHERE source = ? AND stream_id = ? AND event_seq > ?
+				 ORDER BY event_seq ASC
+				 ${limitClause}`,
+			)
+			.all(...params) as {
+			event_seq: number;
+			event_type: string;
+			ts_wall_ms: number | null;
+			ts_mono_ms: number | null;
+			payload_json: string | null;
+			event_id: string | null;
+		}[];
+
+		return rows.map((row) => {
+			const payload = fromJson(row.payload_json) as Record<string, unknown>;
+			// Use || (not ??) to match Python's `or` semantics — empty string falls through
+			payload.type = payload.type || row.event_type;
+			payload.timestamp_wall_ms = row.ts_wall_ms;
+			payload.timestamp_mono_ms = row.ts_mono_ms;
+			payload.event_seq = row.event_seq;
+			payload.event_id = row.event_id;
+			return payload;
+		});
+	}
+
+	/**
+	 * Get or create a flush batch record. Returns [batchId, status].
+	 * Port of get_or_create_raw_event_flush_batch().
+	 */
+	getOrCreateRawEventFlushBatch(
+		opencodeSessionId: string,
+		source: string,
+		startEventSeq: number,
+		endEventSeq: number,
+		extractorVersion: string,
+	): { batchId: number; status: string } {
+		const [s, sid] = this.normalizeStreamIdentity(source, opencodeSessionId);
+		const now = new Date().toISOString();
+
+		// Atomic UPSERT to avoid SELECT+INSERT races. We intentionally do NOT
+		// heartbeat claimed/running batches: their updated_at stays unchanged so
+		// stuck-batch recovery can still age them out.
+		const row = this.db
+			.prepare(
+				`INSERT INTO raw_event_flush_batches(
+					source, stream_id, opencode_session_id,
+					start_event_seq, end_event_seq, extractor_version,
+					status, created_at, updated_at
+				)
+				VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+				ON CONFLICT(source, stream_id, start_event_seq, end_event_seq, extractor_version)
+				DO UPDATE SET
+					updated_at = CASE
+						WHEN raw_event_flush_batches.status IN ('claimed', 'running')
+						THEN raw_event_flush_batches.updated_at
+						ELSE excluded.updated_at
+					END
+				RETURNING id, status`,
+			)
+			.get(s, sid, sid, startEventSeq, endEventSeq, extractorVersion, now, now) as
+			| { id: number; status: string }
+			| undefined;
+
+		if (!row) throw new Error("Failed to create flush batch");
+		// Canonicalize legacy DB statuses to match Python's _RAW_EVENT_QUEUE_DB_TO_CANONICAL
+		const rawStatus = String(row.status);
+		const canonicalStatus =
+			rawStatus === "started"
+				? "pending"
+				: rawStatus === "running"
+					? "claimed"
+					: rawStatus === "error"
+						? "failed"
+						: rawStatus;
+		return { batchId: Number(row.id), status: canonicalStatus };
+	}
+
+	/**
+	 * Attempt to claim a flush batch for processing.
+	 * Returns true if successfully claimed, false if already claimed/completed.
+	 * Port of claim_raw_event_flush_batch().
+	 */
+	claimRawEventFlushBatch(batchId: number): boolean {
+		const now = new Date().toISOString();
+		const row = this.db
+			.prepare(
+				`UPDATE raw_event_flush_batches
+				 SET status = 'claimed', updated_at = ?, attempt_count = attempt_count + 1
+				 WHERE id = ? AND status IN ('pending', 'failed', 'started', 'error')
+				 RETURNING id`,
+			)
+			.get(now, batchId) as { id: number } | undefined;
+		return row != null;
+	}
+
+	/**
+	 * Update the status of a flush batch.
+	 * Port of update_raw_event_flush_batch_status().
+	 */
+	updateRawEventFlushBatchStatus(batchId: number, status: string): void {
+		const now = new Date().toISOString();
+		this.db
+			.prepare(
+				`UPDATE raw_event_flush_batches
+				 SET status = ?,
+				     updated_at = ?,
+				     error_message = CASE WHEN ? = 'failed' THEN error_message ELSE NULL END,
+				     error_type = CASE WHEN ? = 'failed' THEN error_type ELSE NULL END,
+				     observer_provider = CASE WHEN ? = 'failed' THEN observer_provider ELSE NULL END,
+				     observer_model = CASE WHEN ? = 'failed' THEN observer_model ELSE NULL END,
+				     observer_runtime = CASE WHEN ? = 'failed' THEN observer_runtime ELSE NULL END
+				 WHERE id = ?`,
+			)
+			.run(status, now, status, status, status, status, status, batchId);
+	}
+
+	/**
+	 * Record a flush batch failure with error details.
+	 * Port of record_raw_event_flush_batch_failure().
+	 */
+	recordRawEventFlushBatchFailure(
+		batchId: number,
+		opts: {
+			message: string;
+			errorType: string;
+			observerProvider?: string | null;
+			observerModel?: string | null;
+			observerRuntime?: string | null;
+		},
+	): void {
+		const now = new Date().toISOString();
+		this.db
+			.prepare(
+				`UPDATE raw_event_flush_batches
+				 SET status = 'failed',
+				     updated_at = ?,
+				     error_message = ?,
+				     error_type = ?,
+				     observer_provider = ?,
+				     observer_model = ?,
+				     observer_runtime = ?
+				 WHERE id = ?`,
+			)
+			.run(
+				now,
+				opts.message,
+				opts.errorType,
+				opts.observerProvider ?? null,
+				opts.observerModel ?? null,
+				opts.observerRuntime ?? null,
+				batchId,
+			);
+	}
+
+	/**
+	 * Update the last flushed event_seq for a session.
+	 * Port of update_raw_event_flush_state().
+	 */
+	updateRawEventFlushState(
+		opencodeSessionId: string,
+		lastFlushed: number,
+		source = "opencode",
+	): void {
+		const [s, sid] = this.normalizeStreamIdentity(source, opencodeSessionId);
+		const now = new Date().toISOString();
+		this.db
+			.prepare(
+				`INSERT INTO raw_event_sessions(opencode_session_id, source, stream_id, last_flushed_event_seq, updated_at)
+				 VALUES (?, ?, ?, ?, ?)
+				 ON CONFLICT(source, stream_id) DO UPDATE SET
+				     opencode_session_id = excluded.opencode_session_id,
+				     last_flushed_event_seq = excluded.last_flushed_event_seq,
+				     updated_at = excluded.updated_at`,
+			)
+			.run(sid, s, sid, lastFlushed, now);
+	}
+
+	// -----------------------------------------------------------------------
 	// close
 	// -----------------------------------------------------------------------
 

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -26,7 +26,8 @@ export { VERSION };
 /** Shared store instance — SQLite WAL mode handles concurrent reads safely. */
 let sharedStore: MemoryStore | null = null;
 
-function defaultGetStore(): MemoryStore {
+/** Get (or create) the shared store instance. Exported so the sweeper can share it. */
+export function getStore(): MemoryStore {
 	if (!sharedStore) {
 		sharedStore = new MemoryStore(resolveDbPath());
 	}
@@ -43,7 +44,7 @@ export function closeStore(): void {
  * Create the Hono app with all viewer routes.
  * Exported for testing — pass a custom store factory to inject test DBs.
  */
-export function createApp(getStore: () => MemoryStore = defaultGetStore) {
+export function createApp(storeFactory: () => MemoryStore = getStore) {
 	const app = new Hono();
 
 	// CORS / origin guard
@@ -51,12 +52,12 @@ export function createApp(getStore: () => MemoryStore = defaultGetStore) {
 	app.use("*", originGuard());
 
 	// API routes
-	app.route("/", statsRoutes(getStore));
-	app.route("/", memoryRoutes(getStore));
+	app.route("/", statsRoutes(storeFactory));
+	app.route("/", memoryRoutes(storeFactory));
 	app.route("/", observerStatusRoutes());
 	app.route("/", configRoutes());
-	app.route("/", rawEventsRoutes(getStore));
-	app.route("/", syncRoutes(getStore));
+	app.route("/", rawEventsRoutes(storeFactory));
+	app.route("/", syncRoutes(storeFactory));
 
 	// Static assets — serve viewer_static/ under /assets/*
 	const staticRoot =

--- a/packages/viewer-server/vite.config.ts
+++ b/packages/viewer-server/vite.config.ts
@@ -4,6 +4,12 @@ import { defineConfig } from "vitest/config";
 // Library mode — SSR/Node target.
 // Externalizes @codemem/core, hono, and node: built-ins.
 export default defineConfig({
+	resolve: {
+		alias: {
+			"@codemem/core": resolve(import.meta.dirname, "../core/src/index.ts"),
+		},
+		conditions: ["source"],
+	},
 	build: {
 		lib: {
 			entry: resolve(import.meta.dirname, "src/index.ts"),


### PR DESCRIPTION
## Description

Port the raw event sweeper and flush orchestration from Python, closing the biggest gap to deprecating the Python backend. Previously, `codemem serve` (TS) only started the HTTP server — raw events accumulated but were never processed into memories.

### What's added

**`packages/core/src/raw-event-flush.ts`** — Flush orchestration
- `flushRawEvents()` — reads unflushed events for a session, creates/claims a flush batch, builds an `IngestPayload`, calls the existing `ingest()` pipeline, records success/failure
- `buildSessionContext()` — extracts session metadata (prompt count, tool count, duration, files) from raw events
- Error categorization with provider-aware messages matching Python

**`packages/core/src/raw-event-sweeper.ts`** — Background sweeper
- `RawEventSweeper` class using `setInterval` (Node equivalent of Python's threading)
- `tick()` — one sweep cycle: purge old events → mark stuck batches → flush pending queue sessions → flush idle sessions
- Auth error backoff (300s window, logs once, clears on reset)
- All 7 env vars respected with defaults matching Python exactly
- `start()`/`stop()` lifecycle, `notifyConfigChanged()` triggers extra tick
- Interval handles `.unref()`'d to not block process exit

**`packages/core/src/store.ts`** — 12 new methods
- 4 query methods: `rawEventSessionsPendingIdleFlush`, `rawEventSessionsWithPendingQueue`, `purgeRawEvents`, `markStuckRawEventBatchesAsError`
- 8 flush pipeline methods: `rawEventSessionMeta`, `rawEventFlushState`, `rawEventsSinceBySeq`, `getOrCreateRawEventFlushBatch`, `claimRawEventFlushBatch`, `updateRawEventFlushBatchStatus`, `recordRawEventFlushBatchFailure`, `updateRawEventFlushState`

**Wiring**
- `packages/cli/src/commands/serve.ts` — creates `ObserverClient` + `RawEventSweeper`, starts on server boot, stops on shutdown
- `packages/viewer-server/src/index.ts` — exports `getStore()` so CLI can share the store instance with the sweeper

### SQL correctness
The 4 query methods have SQL identical to the Python originals in `codemem/store/raw_events.py`. Targeted review recommended.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 380/380)
- [ ] Added/updated tests for changes (tests planned as follow-up)
- [x] Manually verified changes work as expected (build passes, serve command starts sweeper)

## Checklist

- [x] Code follows project style (`biome check` passes with pre-existing warnings only)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced