### PR TITLE
feat: stats parity with Python — tags, vector coverage, usage section

### DIFF
--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -3,6 +3,17 @@ import { MemoryStore, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 
+function fmtPct(n: number): string {
+	return `${Math.round(n * 100)}%`;
+}
+
+function fmtTokens(n: number): string {
+	if (n >= 1_000_000_000) return `~${(n / 1_000_000_000).toFixed(1)}B`;
+	if (n >= 1_000_000) return `~${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `~${(n / 1_000).toFixed(0)}K`;
+	return `${n}`;
+}
+
 export const statsCommand = new Command("stats")
 	.configureHelp(helpStyle)
 	.description("Show database statistics")
@@ -28,11 +39,29 @@ export const statsCommand = new Command("stats")
 				[
 					`Sessions:    ${db.sessions.toLocaleString()}`,
 					`Memories:    ${db.active_memory_items.toLocaleString()} active / ${db.memory_items.toLocaleString()} total`,
+					`Tags:        ${db.tags_filled.toLocaleString()} filled (${fmtPct(db.tags_coverage)} of active)`,
 					`Artifacts:   ${db.artifacts.toLocaleString()}`,
-					`Vectors:     ${db.vector_rows.toLocaleString()}`,
+					`Vectors:     ${db.vector_rows.toLocaleString()} (${fmtPct(db.vector_coverage)} coverage)`,
 					`Raw events:  ${db.raw_events.toLocaleString()}`,
 				].join("\n"),
 			);
+
+			if (result.usage.events.length > 0) {
+				const lines = result.usage.events.map((e) => {
+					const parts = [`${e.event}: ${e.count.toLocaleString()}`];
+					if (e.tokens_read > 0) parts.push(`read ${fmtTokens(e.tokens_read)} tokens`);
+					if (e.tokens_saved > 0) parts.push(`est. saved ${fmtTokens(e.tokens_saved)} tokens`);
+					return `  ${parts.join(", ")}`;
+				});
+
+				const t = result.usage.totals;
+				lines.push("");
+				lines.push(
+					`  Total: ${t.events.toLocaleString()} events, read ${fmtTokens(t.tokens_read)} tokens, est. saved ${fmtTokens(t.tokens_saved)} tokens`,
+				);
+
+				p.log.step(`Usage\n${lines.join("\n")}`);
+			}
 
 			p.outro("done");
 		} finally {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -401,6 +401,12 @@ export class MemoryStore {
 		if (tableExists(this.db, "memory_vectors")) {
 			vectorCount = count("SELECT COUNT(*) AS c FROM memory_vectors");
 		}
+		const vectorCoverage = activeMemories > 0 ? Math.min(1, vectorCount / activeMemories) : 0;
+
+		const tagsFilled = count(
+			"SELECT COUNT(*) AS c FROM memory_items WHERE active = 1 AND TRIM(tags_text) != ''",
+		);
+		const tagsCoverage = activeMemories > 0 ? Math.min(1, tagsFilled / activeMemories) : 0;
 
 		let sizeBytes = 0;
 		try {
@@ -409,7 +415,42 @@ export class MemoryStore {
 			// File may not exist yet or be inaccessible
 		}
 
+		// Usage stats
+		const usageRows = this.db
+			.prepare(
+				`SELECT event, COUNT(*) AS count,
+				        SUM(tokens_read) AS tokens_read,
+				        SUM(tokens_written) AS tokens_written,
+				        SUM(COALESCE(tokens_saved, 0)) AS tokens_saved
+				 FROM usage_events
+				 GROUP BY event
+				 ORDER BY count DESC`,
+			)
+			.all() as {
+			event: string;
+			count: number;
+			tokens_read: number | null;
+			tokens_written: number | null;
+			tokens_saved: number | null;
+		}[];
+
+		const usageEvents = usageRows.map((r) => ({
+			event: r.event,
+			count: r.count,
+			tokens_read: r.tokens_read ?? 0,
+			tokens_written: r.tokens_written ?? 0,
+			tokens_saved: r.tokens_saved ?? 0,
+		}));
+
+		const totalEvents = usageEvents.reduce((s, e) => s + e.count, 0);
+		const totalTokensRead = usageEvents.reduce((s, e) => s + e.tokens_read, 0);
+		const totalTokensWritten = usageEvents.reduce((s, e) => s + e.tokens_written, 0);
+		const totalTokensSaved = usageEvents.reduce((s, e) => s + e.tokens_saved, 0);
+
 		return {
+			identity: {
+				device_id: this.deviceId,
+			},
 			database: {
 				path: this.dbPath,
 				size_bytes: sizeBytes,
@@ -418,7 +459,19 @@ export class MemoryStore {
 				active_memory_items: activeMemories,
 				artifacts,
 				vector_rows: vectorCount,
+				vector_coverage: vectorCoverage,
+				tags_filled: tagsFilled,
+				tags_coverage: tagsCoverage,
 				raw_events: rawEvents,
+			},
+			usage: {
+				events: usageEvents,
+				totals: {
+					events: totalEvents,
+					tokens_read: totalTokensRead,
+					tokens_written: totalTokensWritten,
+					tokens_saved: totalTokensSaved,
+				},
 			},
 		};
 	}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -307,7 +307,18 @@ export interface TimelineItemResponse extends MemoryItemResponse {
 }
 
 /** Stats response from store.stats() */
+export interface UsageEventRow {
+	event: string;
+	count: number;
+	tokens_read: number;
+	tokens_written: number;
+	tokens_saved: number;
+}
+
 export interface StoreStats {
+	identity: {
+		device_id: string;
+	};
 	database: {
 		path: string;
 		size_bytes: number;
@@ -316,7 +327,19 @@ export interface StoreStats {
 		active_memory_items: number;
 		artifacts: number;
 		vector_rows: number;
+		vector_coverage: number;
+		tags_filled: number;
+		tags_coverage: number;
 		raw_events: number;
+	};
+	usage: {
+		events: UsageEventRow[];
+		totals: {
+			events: number;
+			tokens_read: number;
+			tokens_written: number;
+			tokens_saved: number;
+		};
 	};
 }
 


### PR DESCRIPTION
## Description

Bring the TS `stats` command to full parity with the Python implementation. Previously missing:

- **Tags**: `tags_filled` count and `tags_coverage` percentage of active memories
- **Vector coverage**: percentage of active memories with embeddings
- **Usage section**: full event-type breakdown with token read/saved counts and totals

### Before (TS)
```
┌  codemem stats
│
●  Path:        /path/to/db
│  Size:        2044.0 MB
│
◆  Sessions:    6,838
│  Memories:    7,179 active / 7,671 total
│  Artifacts:   76,871
│  Vectors:     8,833
│  Raw events:  109,349
│
└  done
```

### After (TS — matches Python)
```
┌  codemem stats
│
●  Path:        /path/to/db
│  Size:        2051.6 MB
│
◆  Sessions:    6,862
│  Memories:    7,246 active / 7,738 total
│  Tags:        5,951 filled (82% of active)
│  Artifacts:   77,064
│  Vectors:     9,042 (100% coverage)
│  Raw events:  110,018
│
◇  Usage
│    pack: 76,125, read ~684.3M tokens, est. saved ~1.1B tokens
│    recent: 71,365, read ~798.6M tokens
│    ...
│    Total: 238,197 events, read ~1.9B tokens, est. saved ~1.1B tokens
│
└  done
```

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 380/380)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced