### PR TITLE
fix: restore Python-compatible project scoping in TS MCP and search

### DIFF
--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -47,7 +47,7 @@ export const statsCommand = new Command("stats")
 			);
 
 			if (result.usage.events.length > 0) {
-				const lines = result.usage.events.map((e) => {
+				const lines = result.usage.events.map((e: (typeof result.usage.events)[number]) => {
 					const parts = [`${e.event}: ${e.count.toLocaleString()}`];
 					if (e.tokens_read > 0) parts.push(`read ${fmtTokens(e.tokens_read)} tokens`);
 					if (e.tokens_saved > 0) parts.push(`est. saved ${fmtTokens(e.tokens_saved)} tokens`);

--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -5,6 +5,7 @@
  * Builds WHERE clause fragments and parameter arrays from a MemoryFilters object.
  */
 
+import { projectClause } from "./project.js";
 import type { MemoryFilters } from "./types.js";
 
 export interface FilterResult {
@@ -67,9 +68,12 @@ export function buildFilterClauses(filters: MemoryFilters | undefined | null): F
 
 	// Project scoping — requires sessions JOIN
 	if (filters.project) {
-		clauses.push("sessions.project = ?");
-		params.push(filters.project);
-		result.joinSessions = true;
+		const { clause, params: projectParams } = projectClause(filters.project);
+		if (clause) {
+			clauses.push(clause);
+			params.push(...projectParams);
+			result.joinSessions = true;
+		}
 	}
 
 	// Visibility

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,6 +113,13 @@ export {
 	stripTrailingCommas,
 } from "./observer-config.js";
 export { buildMemoryPack, estimateTokens } from "./pack.js";
+export {
+	projectBasename,
+	projectClause,
+	projectColumnClause,
+	projectMatchesFilter,
+	resolveProject,
+} from "./project.js";
 export type { FlushRawEventsOptions } from "./raw-event-flush.js";
 export { buildSessionContext, flushRawEvents } from "./raw-event-flush.js";
 export { RawEventSweeper } from "./raw-event-sweeper.js";

--- a/packages/core/src/project.test.ts
+++ b/packages/core/src/project.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { projectBasename, projectClause, projectMatchesFilter, resolveProject } from "./project.js";
+
+describe("project helpers", () => {
+	let tmpDir: string | null = null;
+
+	afterEach(() => {
+		if (tmpDir) {
+			rmSync(tmpDir, { recursive: true, force: true });
+			tmpDir = null;
+		}
+	});
+
+	it("uses basename-aware SQL matching for project filters", () => {
+		expect(projectClause("/Users/adam/workspace/codemem")).toEqual({
+			clause: "(sessions.project = ? OR sessions.project LIKE ? OR sessions.project LIKE ?)",
+			params: ["codemem", "%/codemem", "%\\codemem"],
+		});
+	});
+
+	it("matches exact and suffix project paths like Python", () => {
+		expect(projectMatchesFilter("codemem", "codemem")).toBe(true);
+		expect(projectMatchesFilter("/Users/adam/workspace/codemem", "codemem")).toBe(true);
+		expect(projectMatchesFilter("codemem", "workspace/codemem")).toBe(true);
+		expect(projectMatchesFilter("codemem", "workspace/other")).toBe(false);
+		expect(projectMatchesFilter("codemem", null)).toBe(false);
+	});
+
+	it("resolves git repo basename as project", () => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-project-test-"));
+		const repoRoot = join(tmpDir, "my-repo");
+		const nested = join(repoRoot, "packages", "core");
+		mkdirSync(join(repoRoot, ".git"), { recursive: true });
+		mkdirSync(nested, { recursive: true });
+
+		expect(resolveProject(nested)).toBe("my-repo");
+	});
+
+	it("resolves main repo basename for git worktrees", () => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-project-test-"));
+		const mainRepo = join(tmpDir, "main-repo");
+		const worktree = join(tmpDir, "feature-worktree");
+		mkdirSync(join(mainRepo, ".git", "worktrees", "feature-worktree"), { recursive: true });
+		mkdirSync(worktree, { recursive: true });
+		writeFileSync(
+			join(worktree, ".git"),
+			`gitdir: ${join(mainRepo, ".git", "worktrees", "feature-worktree")}`,
+		);
+
+		expect(resolveProject(worktree)).toBe("main-repo");
+	});
+
+	it("honors explicit override before cwd resolution", () => {
+		expect(resolveProject("/tmp/anything", " custom-project ")).toBe("custom-project");
+	});
+
+	it("returns cwd basename when no git repo exists", () => {
+		expect(projectBasename("/tmp/foo/bar")).toBe("bar");
+		expect(resolveProject("/tmp/foo/bar")).toBe("bar");
+	});
+});

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1,0 +1,86 @@
+import { existsSync, lstatSync, readFileSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+
+export function projectBasename(value: string): string {
+	const normalized = value.replaceAll("\\", "/").replace(/\/+$/, "");
+	if (!normalized) return "";
+	const parts = normalized.split("/");
+	return parts[parts.length - 1] ?? "";
+}
+
+export function projectColumnClause(
+	columnExpr: string,
+	project: string,
+): { clause: string; params: string[] } {
+	const trimmed = project.trim();
+	if (!trimmed) return { clause: "", params: [] };
+	const value = /[\\/]/.test(trimmed) ? projectBasename(trimmed) : trimmed;
+	if (!value) return { clause: "", params: [] };
+	return {
+		clause: `(${columnExpr} = ? OR ${columnExpr} LIKE ? OR ${columnExpr} LIKE ?)`,
+		params: [value, `%/${value}`, `%\\${value}`],
+	};
+}
+
+export function projectClause(project: string): { clause: string; params: string[] } {
+	return projectColumnClause("sessions.project", project);
+}
+
+export function projectMatchesFilter(
+	projectFilter: string | null | undefined,
+	itemProject: string | null | undefined,
+): boolean {
+	if (!projectFilter) return true;
+	if (!itemProject) return false;
+	const normalizedFilter = projectFilter.trim().replaceAll("\\", "/");
+	if (!normalizedFilter) return true;
+	const filterValue = normalizedFilter.includes("/")
+		? projectBasename(normalizedFilter)
+		: normalizedFilter;
+	const normalizedProject = itemProject.replaceAll("\\", "/");
+	return normalizedProject === filterValue || normalizedProject.endsWith(`/${filterValue}`);
+}
+
+function findGitAnchor(startCwd: string): string | null {
+	let current = resolve(startCwd);
+	while (true) {
+		const gitPath = resolve(current, ".git");
+		if (existsSync(gitPath)) {
+			try {
+				if (lstatSync(gitPath).isDirectory()) {
+					return current;
+				}
+				const text = readFileSync(gitPath, "utf8").trim();
+				if (text.startsWith("gitdir:")) {
+					const gitdir = resolve(current, text.slice("gitdir:".length).trim()).replaceAll(
+						"\\",
+						"/",
+					);
+					const worktreeMarker = "/.git/worktrees/";
+					const worktreeIndex = gitdir.indexOf(worktreeMarker);
+					if (worktreeIndex >= 0) {
+						return gitdir.slice(0, worktreeIndex);
+					}
+				}
+				return current;
+			} catch {
+				return current;
+			}
+		}
+		const parent = dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+}
+
+export function resolveProject(cwd: string, override?: string | null): string | null {
+	if (override != null) {
+		const trimmed = override.trim();
+		return trimmed || null;
+	}
+	const gitAnchor = findGitAnchor(cwd);
+	if (gitAnchor) {
+		return basename(gitAnchor);
+	}
+	return basename(resolve(cwd));
+}

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -264,6 +264,33 @@ describe("MemoryStore.search", () => {
 		}
 	});
 
+	it("matches project filters by basename and suffix like Python", () => {
+		const now = new Date().toISOString();
+		const matchingSessionId = Number(
+			store.db
+				.prepare(
+					`INSERT INTO sessions (started_at, cwd, user, tool_version, project)
+					 VALUES (?, ?, ?, ?, ?)`,
+				)
+				.run(now, "/tmp/codemem", "testuser", "test-1.0", "workspace/codemem").lastInsertRowid,
+		);
+		const otherSessionId = Number(
+			store.db
+				.prepare(
+					`INSERT INTO sessions (started_at, cwd, user, tool_version, project)
+					 VALUES (?, ?, ?, ?, ?)`,
+				)
+				.run(now, "/tmp/other", "testuser", "test-1.0", "workspace/other").lastInsertRowid,
+		);
+
+		store.remember(matchingSessionId, "discovery", "Database guide", "database details");
+		store.remember(otherSessionId, "discovery", "Database elsewhere", "database details");
+
+		const results = store.search("database", 10, { project: "/Users/adam/workspace/codemem" });
+		expect(results).toHaveLength(1);
+		expect(results[0]?.session_id).toBe(matchingSessionId);
+	});
+
 	it("returns empty array when query becomes empty after operator filtering", () => {
 		seedMemories();
 		const results = store.search("AND OR NOT");
@@ -650,5 +677,59 @@ describe("MemoryStore.explain", () => {
 		const mismatch = result.errors.find((e) => e.code === "FILTER_MISMATCH");
 		expect(mismatch).toBeDefined();
 		expect(mismatch?.ids ?? []).toContain(memId);
+	});
+
+	it("reports PROJECT_MISMATCH for ids outside requested project scope", () => {
+		const now = new Date().toISOString();
+		const matchingSessionId = Number(
+			store.db
+				.prepare(
+					`INSERT INTO sessions (started_at, cwd, user, tool_version, project)
+					 VALUES (?, ?, ?, ?, ?)`,
+				)
+				.run(now, "/tmp/codemem", "testuser", "test-1.0", "codemem").lastInsertRowid,
+		);
+		const otherSessionId = Number(
+			store.db
+				.prepare(
+					`INSERT INTO sessions (started_at, cwd, user, tool_version, project)
+					 VALUES (?, ?, ?, ?, ?)`,
+				)
+				.run(now, "/tmp/other", "testuser", "test-1.0", "workspace/other").lastInsertRowid,
+		);
+		const matchingId = store.remember(
+			matchingSessionId,
+			"discovery",
+			"In scope",
+			"project scoped memory",
+		);
+		const otherId = store.remember(
+			otherSessionId,
+			"discovery",
+			"Out of scope",
+			"project scoped memory",
+		);
+
+		const result = store.explain(null, [matchingId, otherId], 10, {
+			project: "/Users/adam/workspace/codemem",
+		});
+
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]?.id).toBe(matchingId);
+		expect(result.metadata.project).toBe("/Users/adam/workspace/codemem");
+		expect(result.items[0]?.project).toBe("codemem");
+		expect(result.items[0]?.matches.project_match).toBe(true);
+
+		const mismatch = result.errors.find((e) => e.code === "PROJECT_MISMATCH");
+		expect(mismatch).toBeDefined();
+		expect(mismatch?.ids ?? []).toContain(otherId);
+		expect(result.missing_ids).toContain(otherId);
+	});
+
+	it("treats whitespace-only project filters as no project scope", () => {
+		const { id1, id2 } = seedMemories();
+		const result = store.explain(null, [id1, id2], 10, { project: "   " });
+		expect(result.items).toHaveLength(2);
+		expect(result.errors.find((e) => e.code === "PROJECT_MISMATCH")).toBeUndefined();
 	});
 });

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -11,6 +11,7 @@
 
 import { fromJson } from "./db.js";
 import { buildFilterClauses } from "./filters.js";
+import { projectMatchesFilter } from "./project.js";
 import type {
 	ExplainError,
 	ExplainItem,
@@ -394,6 +395,8 @@ function explainItem(
 	source: string,
 	rank: number | null,
 	queryTokens: string[],
+	projectFilter: string | null | undefined,
+	projectValue: string | null | undefined,
 	referenceNow: Date,
 ): ExplainItem {
 	const text = `${item.title} ${item.body_text} ${item.tags_text}`.toLowerCase();
@@ -414,7 +417,7 @@ function explainItem(
 		kind: item.kind,
 		title: item.title,
 		created_at: item.created_at,
-		project: null, // TODO: port project lookup via session
+		project: projectValue ?? null,
 		retrieval: {
 			source,
 			rank,
@@ -431,60 +434,115 @@ function explainItem(
 		},
 		matches: {
 			query_terms: matchedTerms,
-			project_match: null, // TODO: port _project_matches_filter
+			project_match: projectMatchesFilter(projectFilter, projectValue),
 		},
 		pack_context: null, // TODO: port include_pack_context
 	};
 }
 
-/**
- * Check whether a row matches the given filters (client-side enforcement).
- * Used for ID-based lookups in explain() to enforce the same scope as query results.
- */
-function rowMatchesFilters(row: MemoryItemResponse, filters: MemoryFilters): boolean {
-	if (filters.kind && row.kind !== filters.kind) return false;
-	if (filters.include_visibility?.length) {
-		if (!filters.include_visibility.includes(row.visibility as string)) return false;
+function loadItemsByIdsForExplain(
+	store: StoreHandle,
+	ids: number[],
+	filters: MemoryFilters,
+): {
+	items: MemoryResult[];
+	missingNotFound: number[];
+	missingProjectMismatch: number[];
+	missingFilterMismatch: number[];
+} {
+	if (ids.length === 0) {
+		return {
+			items: [],
+			missingNotFound: [],
+			missingProjectMismatch: [],
+			missingFilterMismatch: [],
+		};
 	}
-	if (filters.exclude_visibility?.length) {
-		if (row.visibility != null && filters.exclude_visibility.includes(row.visibility as string))
-			return false;
-	}
-	if (filters.include_actor_ids?.length) {
-		if (!filters.include_actor_ids.includes(row.actor_id as string)) return false;
-	}
-	if (filters.exclude_actor_ids?.length) {
-		if (row.actor_id != null && filters.exclude_actor_ids.includes(row.actor_id as string))
-			return false;
-	}
-	if (filters.include_workspace_ids?.length) {
-		if (!filters.include_workspace_ids.includes(row.workspace_id as string)) return false;
-	}
-	if (filters.exclude_workspace_ids?.length) {
-		if (
-			row.workspace_id != null &&
-			filters.exclude_workspace_ids.includes(row.workspace_id as string)
+
+	const placeholders = ids.map(() => "?").join(", ");
+	const allRows = store.db
+		.prepare(
+			`SELECT memory_items.*
+		 FROM memory_items
+		 WHERE memory_items.active = 1
+		   AND memory_items.id IN (${placeholders})`,
 		)
-			return false;
+		.all(...ids) as MemoryItem[];
+	const allFoundIds = new Set(allRows.map((item) => item.id));
+
+	let projectScopedRows = allRows;
+	let projectScopedIds = new Set(allFoundIds);
+	if (filters.project) {
+		const projectFiltersOnly: MemoryFilters = { project: filters.project };
+		const projectFilterResult = buildFilterClauses(projectFiltersOnly);
+		if (projectFilterResult.clauses.length > 0) {
+			const projectJoin = projectFilterResult.joinSessions
+				? "JOIN sessions ON sessions.id = memory_items.session_id"
+				: "";
+			projectScopedRows = store.db
+				.prepare(
+					`SELECT memory_items.*
+				 FROM memory_items
+				 ${projectJoin}
+				 WHERE memory_items.active = 1
+				   AND memory_items.id IN (${placeholders})
+				   AND ${projectFilterResult.clauses.join(" AND ")}`,
+				)
+				.all(...ids, ...projectFilterResult.params) as MemoryItem[];
+			projectScopedIds = new Set(projectScopedRows.map((item) => item.id));
+		}
 	}
-	if (filters.include_workspace_kinds?.length) {
-		if (!filters.include_workspace_kinds.includes(row.workspace_kind as string)) return false;
-	}
-	if (filters.exclude_workspace_kinds?.length) {
-		if (
-			row.workspace_kind != null &&
-			filters.exclude_workspace_kinds.includes(row.workspace_kind as string)
+
+	const filterResult = buildFilterClauses(filters);
+	const joinClause = filterResult.joinSessions
+		? "JOIN sessions ON sessions.id = memory_items.session_id"
+		: "";
+	const scopedRows = store.db
+		.prepare(
+			`SELECT memory_items.*
+		 FROM memory_items
+		 ${joinClause}
+		 WHERE ${["memory_items.active = 1", `memory_items.id IN (${placeholders})`, ...filterResult.clauses].join(" AND ")}`,
 		)
-			return false;
-	}
-	if (filters.include_trust_states?.length) {
-		if (!filters.include_trust_states.includes(row.trust_state as string)) return false;
-	}
-	if (filters.exclude_trust_states?.length) {
-		if (row.trust_state != null && filters.exclude_trust_states.includes(row.trust_state as string))
-			return false;
-	}
-	return true;
+		.all(...ids, ...filterResult.params) as MemoryItem[];
+	const scopedIds = new Set(scopedRows.map((item) => item.id));
+
+	const missingNotFound = ids.filter((memoryId) => !allFoundIds.has(memoryId));
+	const missingProjectMismatch = ids.filter(
+		(memoryId) => allFoundIds.has(memoryId) && !projectScopedIds.has(memoryId),
+	);
+	const missingFilterMismatch = ids.filter(
+		(memoryId) => projectScopedIds.has(memoryId) && !scopedIds.has(memoryId),
+	);
+
+	const items = scopedRows.map((row) => ({
+		id: row.id,
+		kind: row.kind,
+		title: row.title,
+		body_text: row.body_text,
+		confidence: row.confidence ?? 0,
+		created_at: row.created_at,
+		updated_at: row.updated_at,
+		tags_text: row.tags_text ?? "",
+		score: 0,
+		session_id: row.session_id,
+		metadata: fromJson(row.metadata_json),
+	}));
+
+	return { items, missingNotFound, missingProjectMismatch, missingFilterMismatch };
+}
+
+function loadSessionProjects(
+	store: StoreHandle,
+	sessionIds: Set<number>,
+): Map<number, string | null> {
+	if (sessionIds.size === 0) return new Map();
+	const orderedIds = [...sessionIds].sort((a, b) => a - b);
+	const placeholders = orderedIds.map(() => "?").join(", ");
+	const rows = store.db
+		.prepare(`SELECT id, project FROM sessions WHERE id IN (${placeholders})`)
+		.all(...orderedIds) as { id: number; project: string | null }[];
+	return new Map(rows.map((row) => [row.id, row.project]));
 }
 
 /**
@@ -555,35 +613,13 @@ export function explain(
 		queryRank.set((queryResults[i] as MemoryResult).id, i + 1);
 	}
 
-	// Load items by explicit IDs, enforcing the same filters as query-based results.
-	const idLookup = new Map<number, MemoryResult>();
-	const missingNotFound: number[] = [];
-	const missingFilterMismatch: number[] = [];
-	for (const memId of orderedIds) {
-		const row = store.get(memId);
-		if (!row || (row.active as number) === 0) {
-			missingNotFound.push(memId);
-			continue;
-		}
-		// Check that the row passes the same filters applied to query results.
-		if (filters && !rowMatchesFilters(row, filters)) {
-			missingFilterMismatch.push(memId);
-			continue;
-		}
-		idLookup.set(memId, {
-			id: row.id,
-			kind: row.kind,
-			title: row.title,
-			body_text: row.body_text,
-			confidence: row.confidence ?? 0,
-			created_at: row.created_at,
-			updated_at: row.updated_at,
-			tags_text: row.tags_text ?? "",
-			score: 0,
-			session_id: row.session_id,
-			metadata: row.metadata_json,
-		});
-	}
+	const {
+		items: idRows,
+		missingNotFound,
+		missingProjectMismatch,
+		missingFilterMismatch,
+	} = loadItemsByIdsForExplain(store, orderedIds, filters ?? {});
+	const idLookup = new Map(idRows.map((item) => [item.id, item]));
 
 	// Merge: query results first, then id-lookup results not already seen
 	const explicitIdSet = new Set(orderedIds);
@@ -609,9 +645,21 @@ export function explain(
 		? (normalizedQuery.match(/[A-Za-z0-9_]+/g) ?? []).map((t) => t.toLowerCase())
 		: [];
 
+	const sessionProjects = loadSessionProjects(
+		store,
+		new Set(orderedItems.map(({ item }) => item.session_id).filter((sessionId) => sessionId > 0)),
+	);
 	const referenceNow = new Date();
 	const itemsPayload = orderedItems.map(({ item, source, rank }) =>
-		explainItem(item, source, rank, queryTokens, referenceNow),
+		explainItem(
+			item,
+			source,
+			rank,
+			queryTokens,
+			filters?.project ?? null,
+			sessionProjects.get(item.session_id) ?? null,
+			referenceNow,
+		),
 	);
 
 	// Collect all missing IDs (requested but not returned)
@@ -623,6 +671,14 @@ export function explain(
 			field: "ids",
 			message: "some requested ids were not found",
 			ids: missingNotFound,
+		});
+	}
+	if (missingProjectMismatch.length > 0) {
+		errors.push({
+			code: "PROJECT_MISMATCH",
+			field: "project",
+			message: "some requested ids are outside the requested project scope",
+			ids: missingProjectMismatch,
 		});
 	}
 	if (missingFilterMismatch.length > 0) {
@@ -640,7 +696,7 @@ export function explain(
 		errors,
 		metadata: {
 			query: normalizedQuery || null,
-			project: null, // TODO: port project filter
+			project: filters?.project ?? null,
 			requested_ids_count: orderedIds.length,
 			returned_items_count: itemsPayload.length,
 			include_pack_context: false,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -369,7 +369,7 @@ export interface ExplainItem {
 	};
 	matches: {
 		query_terms: string[];
-		project_match: string | null;
+		project_match: boolean | null;
 	};
 	pack_context: string | null;
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -10,9 +10,10 @@
  */
 
 import {
-	type MemoryFilters,
 	type MemoryItemResponse,
+	type MemoryResult,
 	MemoryStore,
+	projectClause,
 	resolveDbPath,
 	toJson,
 	VERSION,
@@ -20,6 +21,7 @@ import {
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { buildFilters, resolveDefaultProject } from "./project-scope.js";
 
 // ---------------------------------------------------------------------------
 // Static data
@@ -58,34 +60,7 @@ const filterSchema = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Default project scope — resolved from CODEMEM_PROJECT env var or cwd.
- * Matches Python's `default_project = os.environ.get("CODEMEM_PROJECT") or resolve_project(os.getcwd())`.
- */
-const defaultProject = process.env.CODEMEM_PROJECT || null;
-
-/** Build a MemoryFilters object from raw tool params, dropping undefined keys. */
-function buildFilters(raw: Record<string, unknown>): MemoryFilters | undefined {
-	const filters: MemoryFilters = {};
-	let hasAny = false;
-
-	// Apply default project scope if not explicitly provided
-	const resolvedProject = (raw.project as string | undefined) ?? defaultProject;
-	if (resolvedProject) {
-		filters.project = resolvedProject;
-		hasAny = true;
-	}
-
-	for (const key of Object.keys(filterSchema)) {
-		if (key === "project") continue; // handled above
-		const val = raw[key];
-		if (val !== undefined && val !== null) {
-			(filters as Record<string, unknown>)[key] = val;
-			hasAny = true;
-		}
-	}
-	return hasAny ? filters : undefined;
-}
+const defaultProject = resolveDefaultProject();
 
 /** Wrap a JSON result into the MCP text content envelope. */
 function jsonContent(data: unknown) {
@@ -168,7 +143,7 @@ async function main() {
 				const filters = buildFilters(args);
 				const items = store.search(args.query, args.limit, filters);
 				return jsonContent({
-					items: items.map((m) => ({
+					items: items.map((m: MemoryResult) => ({
 						id: m.id,
 						title: m.title,
 						kind: m.kind,
@@ -201,7 +176,7 @@ async function main() {
 				const filters = buildFilters(args);
 				const items = store.search(args.query, args.limit, filters);
 				return jsonContent({
-					items: items.map((m) => ({
+					items: items.map((m: MemoryResult) => ({
 						id: m.id,
 						kind: m.kind,
 						title: m.title,
@@ -285,10 +260,15 @@ async function main() {
 			depth_before: z.number().int().min(0).default(3).describe("Timeline items before"),
 			depth_after: z.number().int().min(0).default(3).describe("Timeline items after"),
 			include_observations: z.boolean().default(false).describe("Include full observation details"),
-			project: z.string().optional().describe("Project scope (not yet implemented in TS)"),
+			project: z.string().optional().describe("Project scope filter"),
 		},
 		async (args) => {
 			try {
+				const resolvedProject = args.project?.trim() || defaultProject || null;
+				const filters = resolvedProject ? { project: resolvedProject } : undefined;
+				const { clause: projectFilterClause, params: projectFilterParams } = resolvedProject
+					? projectClause(resolvedProject)
+					: { clause: "", params: [] as string[] };
 				const [orderedIds, invalidIds] = dedupeOrderedIds(args.ids);
 				const errors: Array<Record<string, unknown>> = [];
 
@@ -302,9 +282,11 @@ async function main() {
 				}
 
 				const missingNotFound: number[] = [];
+				const missingProjectMismatch: number[] = [];
 				const anchors: MemoryItemResponse[] = [];
 				const timelineItems: MemoryItemResponse[] = [];
 				const timelineSeen = new Set<number>();
+				const sessionScopeMatches = new Map<number, boolean>();
 
 				for (const memoryId of orderedIds) {
 					const item = store.get(memoryId);
@@ -313,9 +295,32 @@ async function main() {
 						continue;
 					}
 
+					const sessionId = item.session_id;
+					if (resolvedProject && projectFilterClause && sessionId > 0) {
+						if (!sessionScopeMatches.has(sessionId)) {
+							const row = store.db
+								.prepare(`SELECT 1 FROM sessions WHERE id = ? AND ${projectFilterClause}`)
+								.get(sessionId, ...projectFilterParams);
+							sessionScopeMatches.set(sessionId, row != null);
+						}
+						if (!sessionScopeMatches.get(sessionId)) {
+							missingProjectMismatch.push(memoryId);
+							continue;
+						}
+					} else if (resolvedProject && projectFilterClause && sessionId <= 0) {
+						missingProjectMismatch.push(memoryId);
+						continue;
+					}
+
 					anchors.push(item);
 
-					const expanded = store.timeline(null, memoryId, args.depth_before, args.depth_after);
+					const expanded = store.timeline(
+						null,
+						memoryId,
+						args.depth_before,
+						args.depth_after,
+						filters,
+					);
 					for (const expandedItem of expanded) {
 						const expandedId = expandedItem.id;
 						if (expandedId <= 0 || timelineSeen.has(expandedId)) continue;
@@ -330,6 +335,14 @@ async function main() {
 						field: "ids",
 						message: "some requested ids were not found",
 						ids: missingNotFound,
+					});
+				}
+				if (missingProjectMismatch.length > 0) {
+					errors.push({
+						code: "PROJECT_MISMATCH",
+						field: "project",
+						message: "some requested ids are outside the requested project scope",
+						ids: missingProjectMismatch,
 					});
 				}
 
@@ -351,10 +364,13 @@ async function main() {
 					anchors,
 					timeline: timelineItems,
 					observations,
-					missing_ids: missingNotFound,
+					missing_ids: orderedIds.filter(
+						(memoryId) =>
+							missingNotFound.includes(memoryId) || missingProjectMismatch.includes(memoryId),
+					),
 					errors,
 					metadata: {
-						project: args.project ?? null,
+						project: resolvedProject,
 						requested_ids_count: orderedIds.length,
 						returned_anchor_count: anchors.length,
 						timeline_count: timelineItems.length,

--- a/packages/mcp-server/src/project-scope.test.ts
+++ b/packages/mcp-server/src/project-scope.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("project-scope helpers", () => {
+	afterEach(() => {
+		delete process.env.CODEMEM_PROJECT;
+		vi.resetModules();
+		vi.unstubAllGlobals();
+	});
+
+	it("prefers CODEMEM_PROJECT when set", async () => {
+		process.env.CODEMEM_PROJECT = "forced-project";
+		const { resolveDefaultProject } = await import("./project-scope.js");
+		expect(resolveDefaultProject()).toBe("forced-project");
+	});
+
+	it("buildFilters applies the default project when project is omitted", async () => {
+		const { buildFilters } = await import("./project-scope.js");
+		expect(buildFilters({ kind: "decision" }, "repo-name")).toEqual({
+			kind: "decision",
+			project: "repo-name",
+		});
+	});
+
+	it("buildFilters respects an explicit project override", async () => {
+		const { buildFilters } = await import("./project-scope.js");
+		expect(buildFilters({ project: "manual", kind: "change" }, "repo-name")).toEqual({
+			kind: "change",
+			project: "manual",
+		});
+	});
+
+	it("falls back to default project when env or request project is blank", async () => {
+		process.env.CODEMEM_PROJECT = "   ";
+		const { buildFilters, resolveDefaultProject } = await import("./project-scope.js");
+		expect(resolveDefaultProject()).toBe("codemem");
+		expect(buildFilters({ project: "   ", kind: "change" }, "repo-name")).toEqual({
+			kind: "change",
+			project: "repo-name",
+		});
+	});
+});

--- a/packages/mcp-server/src/project-scope.ts
+++ b/packages/mcp-server/src/project-scope.ts
@@ -1,0 +1,43 @@
+import { type MemoryFilters, resolveProject } from "@codemem/core";
+
+export function resolveDefaultProject(): string | null {
+	const project = process.env.CODEMEM_PROJECT?.trim();
+	return project || resolveProject(process.cwd());
+}
+
+export function buildFilters(
+	raw: Record<string, unknown>,
+	defaultProject = resolveDefaultProject(),
+): MemoryFilters | undefined {
+	const filters: MemoryFilters = {};
+	let hasAny = false;
+
+	const explicitProject = typeof raw.project === "string" ? raw.project.trim() : undefined;
+	const resolvedProject = explicitProject || defaultProject || undefined;
+	if (resolvedProject) {
+		filters.project = resolvedProject;
+		hasAny = true;
+	}
+
+	for (const key of [
+		"kind",
+		"include_visibility",
+		"exclude_visibility",
+		"include_workspace_ids",
+		"exclude_workspace_ids",
+		"include_workspace_kinds",
+		"exclude_workspace_kinds",
+		"include_actor_ids",
+		"exclude_actor_ids",
+		"include_trust_states",
+		"exclude_trust_states",
+	] as const) {
+		const val = raw[key];
+		if (val !== undefined && val !== null) {
+			(filters as Record<string, unknown>)[key] = val;
+			hasAny = true;
+		}
+	}
+
+	return hasAny ? filters : undefined;
+}

--- a/packages/mcp-server/vite.config.ts
+++ b/packages/mcp-server/vite.config.ts
@@ -1,6 +1,13 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			"@codemem/core": resolve(import.meta.dirname, "../core/src/index.ts"),
+		},
+		conditions: ["source"],
+	},
 	build: {
 		lib: {
 			entry: "src/index.ts",


### PR DESCRIPTION
## Description

Restore Python-compatible project scoping semantics across the TypeScript core and MCP server.

### What was wrong before
- TS only used exact `sessions.project = ?` matching, while Python accepts basename/suffix matches via `_project_clause()`
- MCP default project scope only honored `CODEMEM_PROJECT`; it did not fall back to cwd/git-root-derived project like Python
- `explain(ids=...)` did not enforce project scope for explicit IDs and could silently widen across projects
- `memory_expand` ignored project enforcement entirely in TS

### What changed

**Shared project helpers (`packages/core/src/project.ts`)**
- `resolveProject()` — matches Python's `resolve_project(cwd, override)` behavior
- `projectClause()` / `projectColumnClause()` — basename-aware SQL clauses
- `projectMatchesFilter()` — Python-compatible exact/suffix project matching

**Core search / explain**
- `buildFilterClauses()` now uses Python-style project clauses instead of exact equality
- `explain()` now enforces project scope for explicit IDs, returning `PROJECT_MISMATCH` where appropriate
- explain payload now includes session project + `matches.project_match`

**MCP server**
- default project now resolves from `CODEMEM_PROJECT` or cwd/git-root, matching Python
- blank env/project values fall back like Python's falsey `or`
- `memory_expand` now enforces project scope and returns `PROJECT_MISMATCH`

**Tests**
- new project helper tests
- new MCP project-scope tests
- new search/explain parity tests for basename/suffix matching and project mismatch handling

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 393/393)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (`pnpm build` clean)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced