### PR TITLE
feat: port critical viewer-server replacement surfaces

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -18,12 +18,12 @@ export const serveCommand = new Command("serve")
 		process.env.CODEMEM_DB = dbPath;
 
 		const port = Number.parseInt(opts.port, 10);
-		const app = createApp();
-
 		// Start the raw event sweeper — shares the same store as the viewer
 		const observer = new ObserverClient();
 		const sweeper = new RawEventSweeper(getStore(), { observer });
 		sweeper.start();
+
+		const app = createApp({ storeFactory: getStore, sweeper });
 
 		const server = serve({ fetch: app.fetch, hostname: opts.host, port }, (info) => {
 			p.intro("codemem viewer");

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1048,6 +1048,379 @@ export class MemoryStore {
 	}
 
 	// -----------------------------------------------------------------------
+	// Raw event ingestion methods (ports for POST /api/raw-events)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Update ingest stats counters (sample + running totals).
+	 * Port of _update_raw_event_ingest_stats().
+	 */
+	private updateRawEventIngestStats(
+		inserted: number,
+		skippedInvalid: number,
+		skippedDuplicate: number,
+		skippedConflict: number,
+	): void {
+		const now = nowIso();
+		const skippedEvents = skippedInvalid + skippedDuplicate + skippedConflict;
+		this.db
+			.prepare(
+				`INSERT INTO raw_event_ingest_samples(
+					created_at, inserted_events, skipped_invalid, skipped_duplicate, skipped_conflict
+				) VALUES (?, ?, ?, ?, ?)`,
+			)
+			.run(now, inserted, skippedInvalid, skippedDuplicate, skippedConflict);
+		this.db
+			.prepare(
+				`INSERT INTO raw_event_ingest_stats(
+					id, inserted_events, skipped_events, skipped_invalid,
+					skipped_duplicate, skipped_conflict, updated_at
+				) VALUES (1, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT(id) DO UPDATE SET
+					inserted_events = inserted_events + excluded.inserted_events,
+					skipped_events = skipped_events + excluded.skipped_events,
+					skipped_invalid = skipped_invalid + excluded.skipped_invalid,
+					skipped_duplicate = skipped_duplicate + excluded.skipped_duplicate,
+					skipped_conflict = skipped_conflict + excluded.skipped_conflict,
+					updated_at = excluded.updated_at`,
+			)
+			.run(inserted, skippedEvents, skippedInvalid, skippedDuplicate, skippedConflict, now);
+	}
+
+	/**
+	 * Record a single raw event. Returns true if inserted, false if duplicate.
+	 * Port of record_raw_event().
+	 */
+	recordRawEvent(opts: {
+		opencodeSessionId: string;
+		source?: string;
+		eventId: string;
+		eventType: string;
+		payload: Record<string, unknown>;
+		tsWallMs?: number | null;
+		tsMonoMs?: number | null;
+	}): boolean {
+		if (!opts.opencodeSessionId.trim()) throw new Error("opencode_session_id is required");
+		if (!opts.eventId.trim()) throw new Error("event_id is required");
+		if (!opts.eventType.trim()) throw new Error("event_type is required");
+
+		const [source, streamId] = this.normalizeStreamIdentity(
+			opts.source ?? "opencode",
+			opts.opencodeSessionId,
+		);
+
+		// Check for duplicate
+		const existing = this.db
+			.prepare("SELECT 1 FROM raw_events WHERE source = ? AND stream_id = ? AND event_id = ?")
+			.get(source, streamId, opts.eventId);
+		if (existing != null) {
+			this.updateRawEventIngestStats(0, 0, 1, 0);
+			return false;
+		}
+
+		// Ensure session row exists
+		const sessionRow = this.db
+			.prepare("SELECT 1 FROM raw_event_sessions WHERE source = ? AND stream_id = ?")
+			.get(source, streamId);
+		if (sessionRow == null) {
+			const now = nowIso();
+			this.db
+				.prepare(
+					"INSERT INTO raw_event_sessions(opencode_session_id, source, stream_id, updated_at) VALUES (?, ?, ?, ?)",
+				)
+				.run(streamId, source, streamId, now);
+		}
+
+		// Allocate event_seq
+		const seqRow = this.db
+			.prepare(
+				`UPDATE raw_event_sessions
+				 SET last_received_event_seq = last_received_event_seq + 1, updated_at = ?
+				 WHERE source = ? AND stream_id = ?
+				 RETURNING last_received_event_seq`,
+			)
+			.get(nowIso(), source, streamId) as { last_received_event_seq: number } | undefined;
+		if (!seqRow) throw new Error("Failed to allocate raw event seq");
+		const eventSeq = Number(seqRow.last_received_event_seq);
+
+		const createdAt = nowIso();
+		this.db
+			.prepare(
+				`INSERT INTO raw_events(
+					source, stream_id, opencode_session_id, event_id, event_seq,
+					event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.run(
+				source,
+				streamId,
+				streamId,
+				opts.eventId,
+				eventSeq,
+				opts.eventType,
+				opts.tsWallMs ?? null,
+				opts.tsMonoMs ?? null,
+				toJson(opts.payload),
+				createdAt,
+			);
+		this.updateRawEventIngestStats(1, 0, 0, 0);
+		return true;
+	}
+
+	/**
+	 * Record a batch of raw events for a single session. Returns { inserted, skipped }.
+	 * Port of record_raw_events_batch().
+	 */
+	recordRawEventsBatch(
+		opencodeSessionId: string,
+		events: Record<string, unknown>[],
+	): { inserted: number; skipped: number } {
+		if (!opencodeSessionId.trim()) throw new Error("opencode_session_id is required");
+		const [source, streamId] = this.normalizeStreamIdentity("opencode", opencodeSessionId);
+
+		return this.db.transaction(() => {
+			const now = nowIso();
+
+			// Ensure session row exists
+			const sessionRow = this.db
+				.prepare("SELECT 1 FROM raw_event_sessions WHERE source = ? AND stream_id = ?")
+				.get(source, streamId);
+			if (sessionRow == null) {
+				this.db
+					.prepare(
+						"INSERT INTO raw_event_sessions(opencode_session_id, source, stream_id, updated_at) VALUES (?, ?, ?, ?)",
+					)
+					.run(streamId, source, streamId, now);
+			}
+
+			// Normalize and validate events
+			let skippedInvalid = 0;
+			let skippedDuplicate = 0;
+			let skippedConflict = 0;
+
+			interface NormalizedEvent {
+				eventId: string;
+				eventType: string;
+				payload: Record<string, unknown>;
+				tsWallMs: unknown;
+				tsMonoMs: unknown;
+			}
+			const normalized: NormalizedEvent[] = [];
+			const seenIds = new Set<string>();
+
+			for (const event of events) {
+				const eventId = String(event.event_id ?? "");
+				const eventType = String(event.event_type ?? "");
+				let payload = event.payload;
+				if (payload == null || typeof payload !== "object" || Array.isArray(payload)) {
+					payload = {};
+				}
+				const tsWallMs = event.ts_wall_ms;
+				const tsMonoMs = event.ts_mono_ms;
+
+				if (!eventId || !eventType) {
+					skippedInvalid++;
+					continue;
+				}
+				if (seenIds.has(eventId)) {
+					skippedDuplicate++;
+					continue;
+				}
+				seenIds.add(eventId);
+				normalized.push({
+					eventId,
+					eventType,
+					payload: payload as Record<string, unknown>,
+					tsWallMs,
+					tsMonoMs,
+				});
+			}
+
+			if (normalized.length === 0) {
+				this.updateRawEventIngestStats(0, skippedInvalid, skippedDuplicate, skippedConflict);
+				return { inserted: 0, skipped: skippedInvalid + skippedDuplicate + skippedConflict };
+			}
+
+			// Check for existing event_ids in chunks
+			const existingIds = new Set<string>();
+			const chunkSize = 500;
+			for (let i = 0; i < normalized.length; i += chunkSize) {
+				const chunk = normalized.slice(i, i + chunkSize);
+				const placeholders = chunk.map(() => "?").join(",");
+				const rows = this.db
+					.prepare(
+						`SELECT event_id FROM raw_events WHERE source = ? AND stream_id = ? AND event_id IN (${placeholders})`,
+					)
+					.all(source, streamId, ...chunk.map((e) => e.eventId)) as {
+					event_id: string;
+				}[];
+				for (const row of rows) {
+					existingIds.add(String(row.event_id));
+				}
+			}
+
+			const newEvents = normalized.filter((e) => !existingIds.has(e.eventId));
+			skippedDuplicate += normalized.length - newEvents.length;
+
+			if (newEvents.length === 0) {
+				this.updateRawEventIngestStats(0, skippedInvalid, skippedDuplicate, skippedConflict);
+				return { inserted: 0, skipped: skippedInvalid + skippedDuplicate + skippedConflict };
+			}
+
+			// Allocate seq range
+			const seqRow = this.db
+				.prepare(
+					`UPDATE raw_event_sessions
+					 SET last_received_event_seq = last_received_event_seq + ?, updated_at = ?
+					 WHERE source = ? AND stream_id = ?
+					 RETURNING last_received_event_seq`,
+				)
+				.get(newEvents.length, now, source, streamId) as
+				| { last_received_event_seq: number }
+				| undefined;
+			if (!seqRow) throw new Error("Failed to allocate raw event seq");
+			const endSeq = Number(seqRow.last_received_event_seq);
+			const startSeq = endSeq - newEvents.length + 1;
+
+			let inserted = 0;
+			const insertStmt = this.db.prepare(
+				`INSERT INTO raw_events(
+					source, stream_id, opencode_session_id, event_id, event_seq,
+					event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			);
+
+			for (let offset = 0; offset < newEvents.length; offset++) {
+				const event = newEvents[offset]!;
+				try {
+					insertStmt.run(
+						source,
+						streamId,
+						streamId,
+						event.eventId,
+						startSeq + offset,
+						event.eventType,
+						event.tsWallMs ?? null,
+						event.tsMonoMs ?? null,
+						toJson(event.payload),
+						now,
+					);
+					inserted++;
+				} catch (err: unknown) {
+					// SQLite UNIQUE constraint → skip conflict
+					if (err instanceof Error && err.message.includes("UNIQUE constraint")) {
+						skippedConflict++;
+					} else {
+						throw err;
+					}
+				}
+			}
+
+			this.updateRawEventIngestStats(inserted, skippedInvalid, skippedDuplicate, skippedConflict);
+			return { inserted, skipped: skippedInvalid + skippedDuplicate + skippedConflict };
+		})();
+	}
+
+	/**
+	 * UPSERT session metadata (cwd, project, started_at, last_seen_ts_wall_ms).
+	 * Port of update_raw_event_session_meta().
+	 */
+	updateRawEventSessionMeta(opts: {
+		opencodeSessionId: string;
+		source?: string;
+		cwd?: string | null;
+		project?: string | null;
+		startedAt?: string | null;
+		lastSeenTsWallMs?: number | null;
+	}): void {
+		const [source, streamId] = this.normalizeStreamIdentity(
+			opts.source ?? "opencode",
+			opts.opencodeSessionId,
+		);
+		const now = nowIso();
+		this.db
+			.prepare(
+				`INSERT INTO raw_event_sessions(
+					opencode_session_id, source, stream_id, cwd, project,
+					started_at, last_seen_ts_wall_ms, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				ON CONFLICT(source, stream_id) DO UPDATE SET
+					opencode_session_id = excluded.opencode_session_id,
+					cwd = COALESCE(excluded.cwd, raw_event_sessions.cwd),
+					project = COALESCE(excluded.project, raw_event_sessions.project),
+					started_at = COALESCE(excluded.started_at, raw_event_sessions.started_at),
+					last_seen_ts_wall_ms = CASE
+						WHEN excluded.last_seen_ts_wall_ms IS NULL THEN raw_event_sessions.last_seen_ts_wall_ms
+						WHEN raw_event_sessions.last_seen_ts_wall_ms IS NULL THEN excluded.last_seen_ts_wall_ms
+						WHEN excluded.last_seen_ts_wall_ms > raw_event_sessions.last_seen_ts_wall_ms THEN excluded.last_seen_ts_wall_ms
+						ELSE raw_event_sessions.last_seen_ts_wall_ms
+					END,
+					updated_at = excluded.updated_at`,
+			)
+			.run(
+				streamId,
+				source,
+				streamId,
+				opts.cwd ?? null,
+				opts.project ?? null,
+				opts.startedAt ?? null,
+				opts.lastSeenTsWallMs ?? null,
+				now,
+			);
+	}
+
+	/**
+	 * Get totals of pending (unflushed) raw events.
+	 * Port of raw_event_backlog_totals().
+	 */
+	rawEventBacklogTotals(): { pending: number; sessions: number } {
+		const row = this.db
+			.prepare(
+				`WITH max_events AS (
+					SELECT source, stream_id, MAX(event_seq) AS max_seq
+					FROM raw_events
+					GROUP BY source, stream_id
+				)
+				SELECT
+					COUNT(1) AS sessions,
+					SUM(e.max_seq - s.last_flushed_event_seq) AS pending
+				FROM raw_event_sessions s
+				JOIN max_events e ON e.source = s.source AND e.stream_id = s.stream_id
+				WHERE e.max_seq > s.last_flushed_event_seq`,
+			)
+			.get() as { sessions: number | null; pending: number | null } | undefined;
+		if (!row) return { sessions: 0, pending: 0 };
+		return {
+			sessions: Number(row.sessions ?? 0),
+			pending: Number(row.pending ?? 0),
+		};
+	}
+
+	/**
+	 * Get the latest failed flush batch, or null if none.
+	 * Port of latest_raw_event_flush_failure().
+	 */
+	latestRawEventFlushFailure(source?: string | null): Record<string, unknown> | null {
+		let query = `SELECT
+			id, source, stream_id, opencode_session_id,
+			start_event_seq, end_event_seq, extractor_version,
+			status, updated_at, attempt_count,
+			error_message, error_type,
+			observer_provider, observer_model, observer_runtime
+		FROM raw_event_flush_batches
+		WHERE status IN ('error', 'failed')`;
+		const params: unknown[] = [];
+		if (source != null) {
+			query += " AND source = ?";
+			params.push(source.trim().toLowerCase() || "opencode");
+		}
+		query += " ORDER BY updated_at DESC LIMIT 1";
+		const row = this.db.prepare(query).get(...params) as Record<string, unknown> | undefined;
+		if (!row) return null;
+		return { ...row, status: "error" };
+	}
+
+	// -----------------------------------------------------------------------
 	// close
 	// -----------------------------------------------------------------------
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -66,12 +66,14 @@ function createTestStore(): MemoryStore {
 function createTestApp() {
 	let store: MemoryStore | null = null;
 
-	const app = createApp(() => {
-		// Reuse the same store for the lifetime of the test
-		if (!store) {
-			store = createTestStore();
-		}
-		return store;
+	const app = createApp({
+		storeFactory: () => {
+			// Reuse the same store for the lifetime of the test
+			if (!store) {
+				store = createTestStore();
+			}
+			return store;
+		},
 	});
 
 	return {

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -10,7 +10,7 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { MemoryStore, resolveDbPath, VERSION } from "@codemem/core";
+import { MemoryStore, type RawEventSweeper, resolveDbPath, VERSION } from "@codemem/core";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { originGuard, preflightHandler } from "./middleware.js";
@@ -44,7 +44,14 @@ export function closeStore(): void {
  * Create the Hono app with all viewer routes.
  * Exported for testing — pass a custom store factory to inject test DBs.
  */
-export function createApp(storeFactory: () => MemoryStore = getStore) {
+export interface AppOptions {
+	storeFactory?: () => MemoryStore;
+	sweeper?: RawEventSweeper | null;
+}
+
+export function createApp(opts?: AppOptions) {
+	const storeFactory = opts?.storeFactory ?? getStore;
+	const sweeper = opts?.sweeper ?? null;
 	const app = new Hono();
 
 	// CORS / origin guard
@@ -54,7 +61,7 @@ export function createApp(storeFactory: () => MemoryStore = getStore) {
 	// API routes
 	app.route("/", statsRoutes(storeFactory));
 	app.route("/", memoryRoutes(storeFactory));
-	app.route("/", observerStatusRoutes());
+	app.route("/", observerStatusRoutes({ getStore: storeFactory, getSweeper: () => sweeper }));
 	app.route("/", configRoutes());
 	app.route("/", rawEventsRoutes(storeFactory));
 	app.route("/", syncRoutes(storeFactory));

--- a/packages/viewer-server/src/routes/config.ts
+++ b/packages/viewer-server/src/routes/config.ts
@@ -2,31 +2,109 @@
  * Config routes — GET /api/config, POST /api/config.
  *
  * Ports Python's viewer_routes/config.py.
- *
- * NOTE: Config persistence (read_config_file, write_config_file) and
- * runtime reloading are Python-side. This route returns stub data until
- * the config subsystem is ported to TS.
+ * GET returns actual config from disk + effective values + env overrides.
+ * POST is not yet fully ported — returns 501.
  */
 
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { stripJsonComments, stripTrailingCommas } from "@codemem/core";
 import { Hono } from "hono";
+
+/** Env var overrides matching Python's CONFIG_ENV_OVERRIDES. */
+const CONFIG_ENV_OVERRIDES: Record<string, string> = {
+	actor_id: "CODEMEM_ACTOR_ID",
+	actor_display_name: "CODEMEM_ACTOR_DISPLAY_NAME",
+	observer_base_url: "CODEMEM_OBSERVER_BASE_URL",
+	observer_provider: "CODEMEM_OBSERVER_PROVIDER",
+	observer_model: "CODEMEM_OBSERVER_MODEL",
+	observer_api_key: "CODEMEM_OBSERVER_API_KEY",
+	observer_runtime: "CODEMEM_OBSERVER_RUNTIME",
+	observer_auth_source: "CODEMEM_OBSERVER_AUTH_SOURCE",
+	observer_auth_file: "CODEMEM_OBSERVER_AUTH_FILE",
+	observer_max_chars: "CODEMEM_OBSERVER_MAX_CHARS",
+	sync_enabled: "CODEMEM_SYNC_ENABLED",
+	sync_host: "CODEMEM_SYNC_HOST",
+	sync_port: "CODEMEM_SYNC_PORT",
+	sync_interval_s: "CODEMEM_SYNC_INTERVAL_S",
+	sync_mdns: "CODEMEM_SYNC_MDNS",
+	raw_events_sweeper_interval_s: "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS",
+};
+
+/** Known provider names from OpenCode config. */
+function loadProviderOptions(): string[] {
+	// Simplified: return well-known providers.
+	// Python loads this from OpenCode's config.json — we can match
+	// that once the config subsystem is fully ported.
+	return ["openai", "anthropic", "google", "xai", "groq", "deepseek", "mistral", "together"];
+}
+
+function getConfigPath(): string {
+	const envPath = process.env.CODEMEM_CONFIG;
+	if (envPath) return envPath.replace(/^~/, homedir());
+	const configDir = join(homedir(), ".config", "codemem");
+	const candidates = [join(configDir, "config.json"), join(configDir, "config.jsonc")];
+	return candidates.find((p) => existsSync(p)) ?? join(configDir, "config.json");
+}
+
+function readConfigFile(configPath: string): Record<string, unknown> {
+	if (!existsSync(configPath)) return {};
+	try {
+		let text = readFileSync(configPath, "utf-8").trim();
+		if (!text) return {};
+		try {
+			return JSON.parse(text) as Record<string, unknown>;
+		} catch {
+			text = stripTrailingCommas(stripJsonComments(text));
+			return JSON.parse(text) as Record<string, unknown>;
+		}
+	} catch {
+		return {};
+	}
+}
+
+function getEnvOverrides(): Record<string, string> {
+	const overrides: Record<string, string> = {};
+	for (const [key, envVar] of Object.entries(CONFIG_ENV_OVERRIDES)) {
+		const val = process.env[envVar];
+		if (val != null && val !== "") {
+			overrides[key] = envVar;
+		}
+	}
+	return overrides;
+}
 
 export function configRoutes() {
 	const app = new Hono();
 
 	app.get("/api/config", (c) => {
-		// Stub: return minimal structure matching Python's response shape.
+		const configPath = getConfigPath();
+		const configData = readConfigFile(configPath);
+		const envOverrides = getEnvOverrides();
+
+		// Build effective values: config file + env overrides
+		const effective = { ...configData };
+		for (const [key, envVar] of Object.entries(CONFIG_ENV_OVERRIDES)) {
+			const val = process.env[envVar];
+			if (val != null && val !== "") {
+				effective[key] = val;
+			}
+		}
+
 		return c.json({
-			path: "",
-			config: {},
+			path: configPath,
+			config: configData,
 			defaults: {},
-			effective: {},
-			env_overrides: {},
-			providers: ["openai", "anthropic"],
+			effective,
+			env_overrides: envOverrides,
+			providers: loadProviderOptions(),
 		});
 	});
 
 	app.post("/api/config", async (c) => {
-		// Stub: config save not yet ported to TS.
+		// Config save not yet fully ported to TS.
+		// Python's implementation has 300+ lines of validation + runtime effects.
 		return c.json({ error: "config save not yet implemented in TS viewer" }, 501);
 	});
 

--- a/packages/viewer-server/src/routes/observer-status.ts
+++ b/packages/viewer-server/src/routes/observer-status.ts
@@ -3,29 +3,71 @@
  *
  * Ports Python's viewer_routes/observer_status.py.
  * Returns observer runtime info, credential availability, and queue status.
- *
- * NOTE: The Python observer runtime (probe_available_credentials, OBSERVER
- * singleton, RAW_EVENT_SWEEPER) is not yet available in TS. This route
- * returns stub data until those subsystems are ported.
  */
 
+import type { MemoryStore, RawEventSweeper } from "@codemem/core";
 import { Hono } from "hono";
 
-export function observerStatusRoutes() {
+type StoreFactory = () => MemoryStore;
+
+export interface ObserverStatusDeps {
+	getStore: StoreFactory;
+	getSweeper: () => RawEventSweeper | null;
+}
+
+function buildFailureImpact(
+	latestFailure: Record<string, unknown> | null,
+	queueTotals: { pending: number; sessions: number },
+	authBackoff: { active: boolean; remainingS: number },
+): string | null {
+	if (!latestFailure) return null;
+	if (authBackoff.active) {
+		return `Queue retries paused for ~${authBackoff.remainingS}s after an observer auth failure.`;
+	}
+	if (queueTotals.pending > 0) {
+		return `${queueTotals.pending} queued raw events across ${queueTotals.sessions} session(s) are waiting on a successful flush.`;
+	}
+	return "Failed flush batches are pending retry.";
+}
+
+export function observerStatusRoutes(deps?: ObserverStatusDeps) {
 	const app = new Hono();
 
 	app.get("/api/observer-status", (c) => {
-		// Stub: return minimal structure matching Python's response shape.
-		// Real implementation requires porting the observer runtime.
+		const store = deps?.getStore();
+		const sweeper = deps?.getSweeper();
+
+		// Stub fallback when store doesn't have the required methods (e.g. tests with mock store)
+		if (!store || typeof store.rawEventBacklogTotals !== "function") {
+			return c.json({
+				active: null,
+				available_credentials: {},
+				latest_failure: null,
+				queue: {
+					pending: 0,
+					sessions: 0,
+					auth_backoff_active: false,
+					auth_backoff_remaining_s: 0,
+				},
+			});
+		}
+
+		const queueTotals = store.rawEventBacklogTotals();
+		const authBackoff = sweeper?.authBackoffStatus() ?? { active: false, remainingS: 0 };
+		const latestFailure = store.latestRawEventFlushFailure();
+
+		const failureWithImpact = latestFailure
+			? { ...latestFailure, impact: buildFailureImpact(latestFailure, queueTotals, authBackoff) }
+			: null;
+
 		return c.json({
-			active: null,
-			available_credentials: {},
-			latest_failure: null,
+			active: null, // TODO: wire observer singleton status when available
+			available_credentials: {}, // TODO: port probe_available_credentials
+			latest_failure: failureWithImpact,
 			queue: {
-				pending: 0,
-				sessions: 0,
-				auth_backoff_active: false,
-				auth_backoff_remaining_s: 0,
+				...queueTotals,
+				auth_backoff_active: authBackoff.active,
+				auth_backoff_remaining_s: authBackoff.remainingS,
 			},
 		});
 	});

--- a/packages/viewer-server/src/routes/raw-events.ts
+++ b/packages/viewer-server/src/routes/raw-events.ts
@@ -1,15 +1,51 @@
 /**
- * Raw events routes — GET /api/raw-events, GET /api/raw-events/status.
+ * Raw events routes — GET & POST /api/raw-events, GET /api/raw-events/status.
  *
- * Ports Python's viewer_routes/raw_events.py (GET handlers only).
- * POST handlers for raw event ingestion are not yet ported.
+ * Ports Python's viewer_routes/raw_events.py.
  */
 
+import { createHash } from "node:crypto";
 import type { MemoryStore } from "@codemem/core";
+import { stripPrivateObj } from "@codemem/core";
 import { Hono } from "hono";
 import { queryInt } from "../helpers.js";
 
 type StoreFactory = () => MemoryStore;
+
+const MAX_RAW_EVENTS_BODY_BYTES =
+	Number.parseInt(process.env.CODEMEM_RAW_EVENTS_MAX_BODY_BYTES ?? "", 10) || 1048576;
+
+/** Keys to check (in priority order) when resolving a session stream id. */
+const SESSION_ID_KEYS = [
+	"session_stream_id",
+	"session_id",
+	"stream_id",
+	"opencode_session_id",
+] as const;
+
+/**
+ * Resolve a session stream id from a payload object.
+ * Checks multiple field aliases. Throws on conflicting values.
+ */
+function resolveSessionStreamId(payload: Record<string, unknown>): string | null {
+	const values = new Map<string, string>();
+	for (const key of SESSION_ID_KEYS) {
+		const value = payload[key];
+		if (value == null) continue;
+		if (typeof value !== "string") throw new Error(`${key} must be string`);
+		const text = value.trim();
+		if (text) values.set(key, text);
+	}
+	if (values.size === 0) return null;
+	const unique = new Set(values.values());
+	if (unique.size > 1) throw new Error("conflicting session id fields");
+	// Return the first matching key's value (preserves priority order)
+	for (const key of SESSION_ID_KEYS) {
+		const v = values.get(key);
+		if (v) return v;
+	}
+	return null;
+}
 
 export function rawEventsRoutes(getStore: StoreFactory) {
 	const app = new Hono();
@@ -17,66 +53,272 @@ export function rawEventsRoutes(getStore: StoreFactory) {
 	// GET /api/raw-events (compat endpoint for stats panel)
 	app.get("/api/raw-events", (c) => {
 		const store = getStore();
-		{
-			// Pending = events received but not yet flushed to the observer.
-			// Matches Python's raw_event_backlog calculation.
-			const row = store.db
-				.prepare(
-					`SELECT COALESCE(SUM(last_received_event_seq - last_flushed_event_seq), 0) AS pending,
-						COUNT(*) AS sessions
-					 FROM raw_event_sessions
-					 WHERE last_received_event_seq > last_flushed_event_seq`,
-				)
-				.get() as Record<string, unknown>;
-			return c.json({
-				pending: Number(row.pending ?? 0),
-				sessions: Number(row.sessions ?? 0),
-			});
-		}
+		const totals = store.rawEventBacklogTotals();
+		return c.json(totals);
 	});
 
 	// GET /api/raw-events/status
 	app.get("/api/raw-events/status", (c) => {
 		const store = getStore();
-		{
-			const limit = queryInt(c.req.query("limit"), 25);
-			const rows = store.db
-				.prepare(
-					`SELECT source, stream_id, opencode_session_id, cwd, project,
-						started_at, last_seen_ts_wall_ms,
-						last_received_event_seq, last_flushed_event_seq, updated_at
-					 FROM raw_event_sessions
-					 ORDER BY updated_at DESC
-					 LIMIT ?`,
-				)
-				.all(limit) as Record<string, unknown>[];
-			const items = rows.map((row) => {
-				const streamId = String(row.stream_id ?? row.opencode_session_id ?? "");
-				return {
-					...row,
-					session_stream_id: streamId,
-					session_id: streamId,
+		const limit = queryInt(c.req.query("limit"), 25);
+		const rows = store.db
+			.prepare(
+				`SELECT source, stream_id, opencode_session_id, cwd, project,
+					started_at, last_seen_ts_wall_ms,
+					last_received_event_seq, last_flushed_event_seq, updated_at
+				 FROM raw_event_sessions
+				 ORDER BY updated_at DESC
+				 LIMIT ?`,
+			)
+			.all(limit) as Record<string, unknown>[];
+		const items = rows.map((row) => {
+			const streamId = String(row.stream_id ?? row.opencode_session_id ?? "");
+			return {
+				...row,
+				session_stream_id: streamId,
+				session_id: streamId,
+			};
+		});
+		const totals = store.rawEventBacklogTotals();
+		return c.json({
+			items,
+			totals,
+			ingest: {
+				available: true,
+				mode: "stream_queue",
+				max_body_bytes: MAX_RAW_EVENTS_BODY_BYTES,
+			},
+		});
+	});
+
+	// POST /api/raw-events — ingest raw events from plugin
+	app.post("/api/raw-events", async (c) => {
+		// Enforce body size via Content-Length
+		const contentLength = Number.parseInt(c.req.header("content-length") ?? "0", 10);
+		if (Number.isNaN(contentLength) || contentLength < 0) {
+			return c.json({ error: "invalid content-length" }, 400);
+		}
+		if (contentLength > MAX_RAW_EVENTS_BODY_BYTES) {
+			return c.json({ error: "payload too large", max_bytes: MAX_RAW_EVENTS_BODY_BYTES }, 413);
+		}
+
+		// Parse JSON body
+		let payload: Record<string, unknown>;
+		try {
+			const raw = await c.req.text();
+			const parsed: unknown = raw ? JSON.parse(raw) : {};
+			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+				return c.json({ error: "payload must be an object" }, 400);
+			}
+			payload = parsed as Record<string, unknown>;
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+
+		const store = getStore();
+		try {
+			// Validate top-level string fields
+			const cwd = payload.cwd;
+			if (cwd != null && typeof cwd !== "string") {
+				return c.json({ error: "cwd must be string" }, 400);
+			}
+			const project = payload.project;
+			if (project != null && typeof project !== "string") {
+				return c.json({ error: "project must be string" }, 400);
+			}
+			const startedAt = payload.started_at;
+			if (startedAt != null && typeof startedAt !== "string") {
+				return c.json({ error: "started_at must be string" }, 400);
+			}
+
+			// Determine event list: batch (events array) or single-event payload
+			let items = payload.events;
+			if (items == null) {
+				items = [payload];
+			}
+			if (!Array.isArray(items)) {
+				return c.json({ error: "events must be a list" }, 400);
+			}
+
+			// Resolve default session id from top-level payload
+			let defaultSessionId: string;
+			try {
+				defaultSessionId = resolveSessionStreamId(payload) ?? "";
+			} catch (err) {
+				return c.json({ error: (err as Error).message }, 400);
+			}
+			if (defaultSessionId.startsWith("msg_")) {
+				return c.json({ error: "invalid session id" }, 400);
+			}
+
+			let inserted = 0;
+			const lastSeenBySession = new Map<string, number>();
+			const metaBySession = new Map<string, Record<string, string>>();
+			const sessionIds = new Set<string>();
+			const batchBySession = new Map<string, Record<string, unknown>[]>();
+
+			for (const item of items) {
+				if (item == null || typeof item !== "object" || Array.isArray(item)) {
+					return c.json({ error: "event must be an object" }, 400);
+				}
+				const itemObj = item as Record<string, unknown>;
+
+				let itemSessionId: string | null;
+				try {
+					itemSessionId = resolveSessionStreamId(itemObj);
+				} catch (err) {
+					return c.json({ error: (err as Error).message }, 400);
+				}
+				const opencodeSessionId = String(itemSessionId ?? defaultSessionId ?? "");
+				if (!opencodeSessionId) {
+					return c.json({ error: "session id required" }, 400);
+				}
+				if (opencodeSessionId.startsWith("msg_")) {
+					return c.json({ error: "invalid session id" }, 400);
+				}
+
+				let eventId = String(itemObj.event_id ?? "");
+				const eventType = String(itemObj.event_type ?? "");
+				if (!eventType) {
+					return c.json({ error: "event_type required" }, 400);
+				}
+
+				const eventSeqValue = itemObj.event_seq;
+				if (eventSeqValue != null) {
+					const parsed = Number(eventSeqValue);
+					if (!Number.isFinite(parsed) || parsed !== Math.floor(parsed)) {
+						return c.json({ error: "event_seq must be int" }, 400);
+					}
+				}
+
+				let tsWallMs = itemObj.ts_wall_ms;
+				if (tsWallMs != null) {
+					const parsed = Number(tsWallMs);
+					if (!Number.isFinite(parsed)) {
+						return c.json({ error: "ts_wall_ms must be int" }, 400);
+					}
+					tsWallMs = Math.floor(parsed);
+					const prev = lastSeenBySession.get(opencodeSessionId) ?? (tsWallMs as number);
+					lastSeenBySession.set(opencodeSessionId, Math.max(prev, tsWallMs as number));
+				}
+
+				let tsMonoMs = itemObj.ts_mono_ms;
+				if (tsMonoMs != null) {
+					const parsed = Number(tsMonoMs);
+					if (!Number.isFinite(parsed)) {
+						return c.json({ error: "ts_mono_ms must be number" }, 400);
+					}
+					tsMonoMs = parsed;
+				}
+
+				let eventPayload = itemObj.payload;
+				if (eventPayload == null) eventPayload = {};
+				if (typeof eventPayload !== "object" || Array.isArray(eventPayload)) {
+					return c.json({ error: "payload must be an object" }, 400);
+				}
+
+				// Per-item meta fields
+				const itemCwd = itemObj.cwd;
+				if (itemCwd != null && typeof itemCwd !== "string") {
+					return c.json({ error: "cwd must be string" }, 400);
+				}
+				const itemProject = itemObj.project;
+				if (itemProject != null && typeof itemProject !== "string") {
+					return c.json({ error: "project must be string" }, 400);
+				}
+				const itemStartedAt = itemObj.started_at;
+				if (itemStartedAt != null && typeof itemStartedAt !== "string") {
+					return c.json({ error: "started_at must be string" }, 400);
+				}
+
+				// Sanitize payload
+				eventPayload = stripPrivateObj(eventPayload) as Record<string, unknown>;
+
+				// Generate stable event_id for legacy senders
+				if (!eventId) {
+					if (eventSeqValue != null) {
+						const rawId = JSON.stringify(
+							{ s: eventSeqValue, t: eventType, p: eventPayload },
+							Object.keys({ s: eventSeqValue, t: eventType, p: eventPayload }).sort(),
+						);
+						const hash = createHash("sha256").update(rawId, "utf-8").digest("hex").slice(0, 16);
+						eventId = `legacy-seq-${eventSeqValue}-${hash}`;
+					} else {
+						const rawId = JSON.stringify(
+							{
+								m: tsMonoMs ?? null,
+								p: eventPayload,
+								t: eventType,
+								w: tsWallMs ?? null,
+							},
+							// sort_keys=True in Python → keys already alphabetical above
+						);
+						eventId = `legacy-${createHash("sha256").update(rawId, "utf-8").digest("hex").slice(0, 16)}`;
+					}
+				}
+
+				const eventEntry: Record<string, unknown> = {
+					event_id: eventId,
+					event_type: eventType,
+					payload: eventPayload,
+					ts_wall_ms: tsWallMs ?? null,
+					ts_mono_ms: tsMonoMs ?? null,
 				};
-			});
-			const totals = store.db
-				.prepare(
-					`SELECT COUNT(*) AS pending,
-						COUNT(DISTINCT opencode_session_id) AS sessions
-					 FROM raw_events`,
-				)
-				.get() as Record<string, unknown>;
-			return c.json({
-				items,
-				totals: {
-					pending: Number(totals.pending ?? 0),
-					sessions: Number(totals.sessions ?? 0),
-				},
-				ingest: {
-					available: false,
-					mode: "not_implemented",
-					reason: "POST /api/raw-events not yet ported to TS viewer-server",
-				},
-			});
+
+				sessionIds.add(opencodeSessionId);
+				const list = batchBySession.get(opencodeSessionId) ?? [];
+				list.push({ ...eventEntry });
+				batchBySession.set(opencodeSessionId, list);
+
+				if (itemCwd || itemProject || itemStartedAt) {
+					const perSession = metaBySession.get(opencodeSessionId) ?? {};
+					if (itemCwd) perSession.cwd = itemCwd as string;
+					if (itemProject) perSession.project = itemProject as string;
+					if (itemStartedAt) perSession.started_at = itemStartedAt as string;
+					metaBySession.set(opencodeSessionId, perSession);
+				}
+			}
+
+			// Insert events
+			if (sessionIds.size === 1) {
+				const singleSessionId = sessionIds.values().next().value as string;
+				const batch = batchBySession.get(singleSessionId) ?? [];
+				const result = store.recordRawEventsBatch(singleSessionId, batch);
+				inserted = result.inserted;
+			} else {
+				for (const [sid, sidEvents] of batchBySession) {
+					const result = store.recordRawEventsBatch(sid, sidEvents);
+					inserted += result.inserted;
+				}
+			}
+
+			// Update session metadata
+			for (const metaSessionId of sessionIds) {
+				const sessionMeta = metaBySession.get(metaSessionId) ?? {};
+				const applyRequestMeta = sessionIds.size === 1 || metaSessionId === defaultSessionId;
+				store.updateRawEventSessionMeta({
+					opencodeSessionId: metaSessionId,
+					cwd:
+						sessionMeta.cwd ?? (applyRequestMeta ? (cwd as string | undefined) : undefined) ?? null,
+					project:
+						sessionMeta.project ??
+						(applyRequestMeta ? (project as string | undefined) : undefined) ??
+						null,
+					startedAt:
+						sessionMeta.started_at ??
+						(applyRequestMeta ? (startedAt as string | undefined) : undefined) ??
+						null,
+					lastSeenTsWallMs: lastSeenBySession.get(metaSessionId) ?? null,
+				});
+			}
+
+			return c.json({ inserted, received: (items as unknown[]).length });
+		} catch (err) {
+			const response: Record<string, unknown> = { error: "internal server error" };
+			if (process.env.CODEMEM_VIEWER_DEBUG === "1") {
+				response.detail = (err as Error).message;
+			}
+			return c.json(response, 500);
 		}
 	});
 


### PR DESCRIPTION
## Description

Port the critical viewer-server surfaces needed to replace the Python backend for event ingestion, observer status, and config display.

### POST /api/raw-events
- Full port matching Python's `viewer_routes/raw_events.py`
- Session ID resolution from 4 field aliases with conflict detection
- Single-event and batch payload support
- Legacy event_id generation via SHA-256
- Per-event validation (event_type required, ts_wall_ms/ts_mono_ms numeric)
- Payload sanitization via `stripPrivateObj`

### Store methods (6 new)
- `recordRawEvent()` — single event insert with duplicate detection
- `recordRawEventsBatch()` — transactional batch insert with seq allocation
- `updateRawEventSessionMeta()` — UPSERT session metadata
- `rawEventBacklogTotals()` — pending event count
- `latestRawEventFlushFailure()` — latest failed flush batch
- `updateRawEventIngestStats()` — ingest sample tracking (private)

### Observer status (real data)
- Queue totals from `rawEventBacklogTotals()`
- Auth backoff state from sweeper
- Latest failure with impact message
- Graceful fallback for test environments

### Config GET (real data)
- Reads actual `~/.config/codemem/config.json{c}`
- Returns config, effective values (with env overrides), and env override map
- Provider list from known providers

### createApp signature change
- `createApp()` now accepts `{ storeFactory, sweeper }` options object
- Sweeper reference passed through to observer-status route
- Test helper updated to use new signature

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 393/393)
- [ ] Added/updated tests for changes (existing tests updated for new createApp signature)
- [x] Manually verified changes work as expected (`pnpm build` clean)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced