### PR TITLE
feat: implement migration safety contract for shared SQLite DB

### DIFF
--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -142,11 +142,20 @@ describe("assertSchemaReady", () => {
 
 	it("passes for the current schema version with required tables", () => {
 		db.pragma(`user_version = ${SCHEMA_VERSION}`);
-		// Create the required tables
-		db.exec("CREATE TABLE memory_items (id INTEGER PRIMARY KEY)");
+		// Create all required tables + FTS5 index
+		db.exec(
+			"CREATE TABLE memory_items (id INTEGER PRIMARY KEY, title TEXT, body_text TEXT, tags_text TEXT)",
+		);
 		db.exec("CREATE TABLE sessions (id INTEGER PRIMARY KEY)");
 		db.exec("CREATE TABLE artifacts (id INTEGER PRIMARY KEY)");
 		db.exec("CREATE TABLE raw_events (id INTEGER PRIMARY KEY)");
+		db.exec(
+			"CREATE TABLE raw_event_sessions (source TEXT, stream_id TEXT, PRIMARY KEY (source, stream_id))",
+		);
+		db.exec("CREATE TABLE usage_events (id INTEGER PRIMARY KEY)");
+		db.exec(
+			"CREATE VIRTUAL TABLE memory_fts USING fts5(title, body_text, tags_text, content='memory_items', content_rowid='id')",
+		);
 		expect(() => assertSchemaReady(db)).not.toThrow();
 	});
 
@@ -157,11 +166,20 @@ describe("assertSchemaReady", () => {
 
 	it("warns but continues for a newer schema version", () => {
 		db.pragma(`user_version = ${SCHEMA_VERSION + 1}`);
-		// Create required tables — newer version should warn, not throw
-		db.exec("CREATE TABLE memory_items (id INTEGER PRIMARY KEY)");
+		// Create all required tables + FTS5 index
+		db.exec(
+			"CREATE TABLE memory_items (id INTEGER PRIMARY KEY, title TEXT, body_text TEXT, tags_text TEXT)",
+		);
 		db.exec("CREATE TABLE sessions (id INTEGER PRIMARY KEY)");
 		db.exec("CREATE TABLE artifacts (id INTEGER PRIMARY KEY)");
 		db.exec("CREATE TABLE raw_events (id INTEGER PRIMARY KEY)");
+		db.exec(
+			"CREATE TABLE raw_event_sessions (source TEXT, stream_id TEXT, PRIMARY KEY (source, stream_id))",
+		);
+		db.exec("CREATE TABLE usage_events (id INTEGER PRIMARY KEY)");
+		db.exec(
+			"CREATE VIRTUAL TABLE memory_fts USING fts5(title, body_text, tags_text, content='memory_items', content_rowid='id')",
+		);
 		expect(() => assertSchemaReady(db)).not.toThrow();
 	});
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -6,7 +6,14 @@
  * The TS runtime validates the schema version but does NOT run migrations.
  */
 
-import { copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "node:fs";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { Database as DatabaseType } from "better-sqlite3";
@@ -28,7 +35,17 @@ export const SCHEMA_VERSION = 6;
 export const MIN_COMPATIBLE_SCHEMA = 6;
 
 /** Required tables the TS runtime needs to function. */
-const REQUIRED_TABLES = ["memory_items", "sessions", "artifacts", "raw_events"] as const;
+const REQUIRED_TABLES = [
+	"memory_items",
+	"sessions",
+	"artifacts",
+	"raw_events",
+	"raw_event_sessions",
+	"usage_events",
+] as const;
+
+/** Marker file written after the first successful TS access to a DB. */
+const TS_MARKER = ".codemem-ts-accessed";
 
 /** Default database path — matches Python's DEFAULT_DB_PATH. */
 export const DEFAULT_DB_PATH = join(homedir(), ".codemem", "mem.sqlite");
@@ -167,6 +184,43 @@ export function getSchemaVersion(db: DatabaseType): number {
 }
 
 /**
+ * Create a timestamped backup of the database on first TS access.
+ *
+ * The backup file is named `mem.sqlite.pre-ts-YYYYMMDDTHHMMSS.bak` and placed
+ * next to the original. A marker file prevents repeated backups. This ensures
+ * users can recover if the TS runtime introduces bugs that corrupt the DB
+ * during the migration period.
+ */
+export function backupOnFirstAccess(dbPath: string): void {
+	const markerPath = join(dirname(dbPath), TS_MARKER);
+	if (existsSync(markerPath)) return;
+	if (!existsSync(dbPath)) return; // Fresh DB, nothing to back up
+
+	const ts = new Date().toISOString().replace(/[:.]/g, "").slice(0, 15);
+	const backupPath = `${dbPath}.pre-ts-${ts}.bak`;
+	try {
+		copyFileSync(dbPath, backupPath);
+		// Also back up WAL/SHM if present (they contain uncommitted data)
+		const walPath = `${dbPath}-wal`;
+		const shmPath = `${dbPath}-shm`;
+		if (existsSync(walPath)) copyFileSync(walPath, `${backupPath}-wal`);
+		if (existsSync(shmPath)) copyFileSync(shmPath, `${backupPath}-shm`);
+		console.error(`[codemem] First TS access — backed up database to ${backupPath}`);
+	} catch (err) {
+		console.error(`[codemem] Warning: failed to create backup at ${backupPath}:`, err);
+		// Continue — backup failure shouldn't prevent operation
+	}
+
+	// Write marker so we don't back up again
+	try {
+		mkdirSync(dirname(markerPath), { recursive: true });
+		writeFileSync(markerPath, new Date().toISOString(), "utf-8");
+	} catch {
+		// Non-fatal — worst case we back up again next time
+	}
+}
+
+/**
  * Verify the database schema is initialized and compatible.
  *
  * Per the coexistence contract: TS tolerates additive newer schemas (Python may
@@ -175,6 +229,7 @@ export function getSchemaVersion(db: DatabaseType): number {
  *   - Schema is uninitialized (version 0)
  *   - Schema is too old (below MIN_COMPATIBLE_SCHEMA)
  *   - Required tables are missing
+ *   - FTS5 index is missing (needed for search)
  *
  * Warns (but continues) if schema is newer than SCHEMA_VERSION — the additive
  * changes are assumed safe per the coexistence contract.
@@ -184,8 +239,7 @@ export function assertSchemaReady(db: DatabaseType): void {
 	if (version === 0) {
 		throw new Error(
 			"Database schema is not initialized. " +
-				"During Phase 1, the Python runtime must initialize the database first. " +
-				"Run: uv run codemem stats",
+				"Run the Python runtime to initialize: uv run codemem stats",
 		);
 	}
 	if (version < MIN_COMPATIBLE_SCHEMA) {
@@ -207,6 +261,14 @@ export function assertSchemaReady(db: DatabaseType): void {
 		throw new Error(
 			`Required tables missing: ${missing.join(", ")}. ` +
 				"The database may be corrupt or from an incompatible version.",
+		);
+	}
+
+	// FTS5 index is required for search
+	if (!tableExists(db, "memory_fts")) {
+		throw new Error(
+			"FTS5 index (memory_fts) is missing. " +
+				"Run the Python runtime to rebuild: uv run codemem stats",
 		);
 	}
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export {
 export type { Database } from "./db.js";
 export {
 	assertSchemaReady,
+	backupOnFirstAccess,
 	connect,
 	DEFAULT_DB_PATH,
 	fromJson,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -17,6 +17,7 @@ import { statSync } from "node:fs";
 import type { Database } from "./db.js";
 import {
 	assertSchemaReady,
+	backupOnFirstAccess,
 	connect,
 	DEFAULT_DB_PATH,
 	fromJson,
@@ -101,6 +102,7 @@ export class MemoryStore {
 
 	constructor(dbPath: string = DEFAULT_DB_PATH) {
 		this.dbPath = dbPath;
+		backupOnFirstAccess(dbPath);
 		this.db = connect(dbPath);
 		try {
 			loadSqliteVec(this.db);

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -105,6 +105,55 @@ export function initTestSchema(db: Database): void {
 			UNIQUE(source, stream_id, event_id)
 		);
 
+		CREATE TABLE IF NOT EXISTS raw_event_sessions (
+			source TEXT NOT NULL DEFAULT 'opencode',
+			stream_id TEXT NOT NULL DEFAULT '',
+			opencode_session_id TEXT,
+			cwd TEXT,
+			project TEXT,
+			started_at TEXT,
+			last_seen_ts_wall_ms INTEGER,
+			last_received_event_seq INTEGER NOT NULL DEFAULT -1,
+			last_flushed_event_seq INTEGER NOT NULL DEFAULT -1,
+			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+			updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+			PRIMARY KEY (source, stream_id)
+		);
+
+		CREATE TABLE IF NOT EXISTS raw_event_flush_batches (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			source TEXT NOT NULL,
+			stream_id TEXT NOT NULL,
+			opencode_session_id TEXT,
+			start_event_seq INTEGER NOT NULL,
+			end_event_seq INTEGER NOT NULL,
+			extractor_version TEXT,
+			status TEXT NOT NULL DEFAULT 'pending',
+			error_message TEXT,
+			error_category TEXT,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL,
+			UNIQUE(source, stream_id, start_event_seq, end_event_seq, extractor_version)
+		);
+
+		CREATE TABLE IF NOT EXISTS raw_event_ingest_samples (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			source TEXT NOT NULL,
+			stream_id TEXT NOT NULL,
+			event_type TEXT,
+			created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+		);
+
+		CREATE TABLE IF NOT EXISTS raw_event_ingest_totals (
+			source TEXT NOT NULL,
+			stream_id TEXT NOT NULL,
+			total_events INTEGER NOT NULL DEFAULT 0,
+			total_bytes INTEGER NOT NULL DEFAULT 0,
+			last_event_type TEXT,
+			updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+			PRIMARY KEY (source, stream_id)
+		);
+
 		CREATE TABLE IF NOT EXISTS sync_device (
 			device_id TEXT PRIMARY KEY,
 			public_key TEXT NOT NULL,


### PR DESCRIPTION
## Description

Implement the migration safety contract for TS access to the shared SQLite database, ensuring users can safely transition from Python to TypeScript without data loss risk.

### Backup on first TS access
- `backupOnFirstAccess()` creates a timestamped copy (`mem.sqlite.pre-ts-YYYYMMDDTHHMMSS.bak`) before the TS runtime writes to the DB
- Also backs up WAL/SHM files if present (contain uncommitted data)
- Marker file (`.codemem-ts-accessed`) prevents repeated backups
- Non-fatal — backup failure logs a warning but doesn't block operation

### Stronger schema validation
- `REQUIRED_TABLES` expanded: added `raw_event_sessions` and `usage_events`
- Added FTS5 index check — `memory_fts` must exist for search to work
- Clearer error messages pointing to Python runtime for initialization

### Test schema alignment
- `initTestSchema()` now creates `raw_event_sessions`, `raw_event_flush_batches`, `raw_event_ingest_samples`, and `raw_event_ingest_totals` tables
- `db.test.ts` schema validation tests updated to include all required tables + FTS5 index

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 393/393)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (`pnpm build` clean)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced