### PR TITLE
fix: expand db paths and restore config-backed actor identity parity

### DIFF
--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Database } from "./db.js";
@@ -11,6 +11,7 @@ import {
 	isEmbeddingDisabled,
 	loadSqliteVec,
 	migrateLegacyDbPath,
+	resolveDbPath,
 	SCHEMA_VERSION,
 	tableExists,
 	toJson,
@@ -58,6 +59,10 @@ describe("connect", () => {
 		const nested = join(tmpDir, "deep", "nested", "dir", "test.sqlite");
 		db = connect(nested);
 		expect(db.pragma("journal_mode", { simple: true })).toBe("wal");
+	});
+
+	it("expands ~/ paths like Python", () => {
+		expect(resolveDbPath("~/codemem-test.sqlite")).toBe(join(homedir(), "codemem-test.sqlite"));
 	});
 });
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -19,6 +19,7 @@ import { dirname, join } from "node:path";
 import type { Database as DatabaseType } from "better-sqlite3";
 import Database from "better-sqlite3";
 import * as sqliteVec from "sqlite-vec";
+import { expandUserPath } from "./observer-config.js";
 
 // Re-export the Database type for consumers
 export type { DatabaseType as Database };
@@ -55,9 +56,9 @@ export const DEFAULT_DB_PATH = join(homedir(), ".codemem", "mem.sqlite");
  * All TS entry points should use this instead of hardcoding fallback logic.
  */
 export function resolveDbPath(explicit?: string): string {
-	if (explicit) return explicit;
+	if (explicit) return expandUserPath(explicit);
 	const envPath = process.env.CODEMEM_DB;
-	if (envPath) return envPath;
+	if (envPath) return expandUserPath(envPath);
 	return DEFAULT_DB_PATH;
 }
 

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -133,6 +133,54 @@ export function loadOpenCodeConfig(): Record<string, unknown> {
 	}
 }
 
+/** Expand `~/...` paths like Python's `Path(...).expanduser()`. */
+export function expandUserPath(value: string): string {
+	return value.startsWith("~/") ? join(homedir(), value.slice(2)) : value;
+}
+
+/** Resolve codemem config path with CODEMEM_CONFIG override. */
+export function getCodememConfigPath(): string {
+	const envPath = process.env.CODEMEM_CONFIG?.trim();
+	if (envPath) return expandUserPath(envPath);
+	const configDir = join(homedir(), ".config", "codemem");
+	const candidates = [join(configDir, "config.json"), join(configDir, "config.jsonc")];
+	return candidates.find((p) => existsSync(p)) ?? join(configDir, "config.json");
+}
+
+/** Read codemem config file with the same JSON/JSONC behavior as Python. */
+export function readCodememConfigFile(): Record<string, unknown> {
+	const configPath = getCodememConfigPath();
+	if (!existsSync(configPath)) return {};
+
+	let text: string;
+	try {
+		text = readFileSync(configPath, "utf-8");
+	} catch {
+		return {};
+	}
+
+	if (!text.trim()) return {};
+
+	try {
+		const parsed = JSON.parse(text) as unknown;
+		return parsed != null && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: {};
+	} catch {
+		// fall through to JSONC
+	}
+
+	try {
+		const cleaned = stripTrailingCommas(stripJsonComments(text));
+		const parsed = JSON.parse(cleaned) as unknown;
+		return parsed != null && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: {};
+	} catch {
+		return {};
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Provider helpers
 // ---------------------------------------------------------------------------

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -18,9 +18,18 @@ describe("MemoryStore", () => {
 	let tmpDir: string;
 	let dbPath: string;
 	let store: MemoryStore;
+	let prevCodememConfig: string | undefined;
+	let prevActorId: string | undefined;
+	let prevActorDisplayName: string | undefined;
 
 	beforeEach(() => {
+		prevCodememConfig = process.env.CODEMEM_CONFIG;
+		prevActorId = process.env.CODEMEM_ACTOR_ID;
+		prevActorDisplayName = process.env.CODEMEM_ACTOR_DISPLAY_NAME;
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-store-test-"));
+		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
+		delete process.env.CODEMEM_ACTOR_ID;
+		delete process.env.CODEMEM_ACTOR_DISPLAY_NAME;
 		dbPath = join(tmpDir, "test.sqlite");
 		// Pre-create the schema so MemoryStore constructor's assertSchemaReady passes
 		const setupDb = connect(dbPath);
@@ -32,6 +41,12 @@ describe("MemoryStore", () => {
 
 	afterEach(() => {
 		store?.close();
+		if (prevCodememConfig === undefined) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevCodememConfig;
+		if (prevActorId === undefined) delete process.env.CODEMEM_ACTOR_ID;
+		else process.env.CODEMEM_ACTOR_ID = prevActorId;
+		if (prevActorDisplayName === undefined) delete process.env.CODEMEM_ACTOR_DISPLAY_NAME;
+		else process.env.CODEMEM_ACTOR_DISPLAY_NAME = prevActorDisplayName;
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -60,6 +75,37 @@ describe("MemoryStore", () => {
 	// -- remember -----------------------------------------------------------
 
 	describe("remember", () => {
+		it("defaults deviceId to stable 'local' when sync_device is empty", () => {
+			expect(store.deviceId).toBe("local");
+			expect(store.actorId).toBe("local:local");
+		});
+
+		it("loads actor identity defaults from codemem config file", () => {
+			store.close();
+			writeFileSync(
+				process.env.CODEMEM_CONFIG as string,
+				JSON.stringify({ actor_id: "actor:config", actor_display_name: "Config User" }),
+			);
+			store = new MemoryStore(dbPath);
+
+			expect(store.actorId).toBe("actor:config");
+			expect(store.actorDisplayName).toBe("Config User");
+		});
+
+		it("lets env overrides win over config-backed actor identity", () => {
+			store.close();
+			writeFileSync(
+				process.env.CODEMEM_CONFIG as string,
+				JSON.stringify({ actor_id: "actor:config", actor_display_name: "Config User" }),
+			);
+			process.env.CODEMEM_ACTOR_ID = "actor:env";
+			process.env.CODEMEM_ACTOR_DISPLAY_NAME = "Env User";
+			store = new MemoryStore(dbPath);
+
+			expect(store.actorId).toBe("actor:env");
+			expect(store.actorDisplayName).toBe("Env User");
+		});
+
 		it("inserts a memory item and returns the ID", () => {
 			const sessionId = insertTestSession(store.db);
 			const memId = store.remember(sessionId, "feature", "My Feature", "Feature body", 0.8);

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -12,7 +12,7 @@
  * memory_owned_by_self check.
  */
 
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { statSync } from "node:fs";
 import type { Database } from "./db.js";
 import {
@@ -22,10 +22,12 @@ import {
 	DEFAULT_DB_PATH,
 	fromJson,
 	loadSqliteVec,
+	resolveDbPath,
 	tableExists,
 	toJson,
 } from "./db.js";
 import { buildFilterClauses } from "./filters.js";
+import { readCodememConfigFile } from "./observer-config.js";
 import { buildMemoryPack } from "./pack.js";
 import { explain as explainFn, search as searchFn, timeline as timelineFn } from "./search.js";
 import type {
@@ -101,9 +103,9 @@ export class MemoryStore {
 	readonly actorDisplayName: string;
 
 	constructor(dbPath: string = DEFAULT_DB_PATH) {
-		this.dbPath = dbPath;
-		backupOnFirstAccess(dbPath);
-		this.db = connect(dbPath);
+		this.dbPath = resolveDbPath(dbPath);
+		backupOnFirstAccess(this.dbPath);
+		this.db = connect(this.dbPath);
 		try {
 			loadSqliteVec(this.db);
 			assertSchemaReady(this.db);
@@ -112,9 +114,8 @@ export class MemoryStore {
 			throw err;
 		}
 
-		// Resolve device ID: env var → sync_device table → random UUID fallback.
-		// Python reads from sync_device; randomUUID would break ownership checks
-		// (every request gets a different ID, so nothing is "owned by self").
+		// Resolve device ID: env var → sync_device table → stable "local" fallback.
+		// Python uses exactly this order and fallback.
 		const envDeviceId = process.env.CODEMEM_DEVICE_ID?.trim();
 		if (envDeviceId) {
 			this.deviceId = envDeviceId;
@@ -127,20 +128,19 @@ export class MemoryStore {
 					| undefined;
 				dbDeviceId = row?.device_id;
 			} catch {
-				// Table doesn't exist — fall through to UUID
+				// Table doesn't exist — fall through to stable default
 			}
-			this.deviceId =
-				dbDeviceId ??
-				`fallback:${createHash("sha256").update(this.dbPath).digest("hex").slice(0, 32)}`;
+			this.deviceId = dbDeviceId ?? "local";
 		}
 
-		// Resolve actor identity — matches Python's _resolve_actor_id / _resolve_actor_display_name.
-		// Python: actor_id = config.actor_id OR f"local:{device_id}"
-		// Python: actor_display_name = config.actor_display_name OR $USER OR actor_id
-		const configActorId = process.env.CODEMEM_ACTOR_ID?.trim();
+		// Resolve actor identity — matches Python load_config() precedence:
+		// config file, then env override, then local fallbacks.
+		const config = readCodememConfigFile();
+		const configActorId = process.env.CODEMEM_ACTOR_ID?.trim() || cleanStr(config.actor_id) || null;
 		this.actorId = configActorId || `local:${this.deviceId}`;
 
-		const configDisplayName = process.env.CODEMEM_ACTOR_DISPLAY_NAME?.trim();
+		const configDisplayName =
+			process.env.CODEMEM_ACTOR_DISPLAY_NAME?.trim() || cleanStr(config.actor_display_name) || null;
 		this.actorDisplayName =
 			configDisplayName || process.env.USER?.trim() || process.env.USERNAME?.trim() || this.actorId;
 	}


### PR DESCRIPTION
## Description

Fix two Python→TypeScript parity bugs identified in the hardening audit.

### 1. Expand `~/...` DB paths like Python

TypeScript previously treated `~/...` literally in `resolveDbPath()`, which could make TS open a different database than Python for the same `CODEMEM_DB` or `--db` value. Python uses `Path(...).expanduser()`.

What changed:
- added `expandUserPath()` in `packages/core/src/observer-config.ts`
- `packages/core/src/db.ts` now expands explicit and env-provided DB paths in `resolveDbPath()`
- `MemoryStore` normalizes the constructor path through `resolveDbPath()` before backup/connect

### 2. Restore config-backed actor identity precedence

TypeScript previously resolved `actorId` / `actorDisplayName` from env only, while Python uses codemem config file values first and then env overrides.

What changed:
- added `getCodememConfigPath()` and `readCodememConfigFile()` in `packages/core/src/observer-config.ts`
- `packages/core/src/store.ts` now resolves actor identity with Python-compatible precedence:
  - `CODEMEM_ACTOR_ID` / `CODEMEM_ACTOR_DISPLAY_NAME`
  - config file `actor_id` / `actor_display_name`
  - Python fallback logic (`local:${device_id}`, `$USER` / `$USERNAME` / `actor_id`)
- `deviceId` fallback now matches Python exactly: env → `sync_device.device_id` → `"local"`

### Tests
- `packages/core/src/db.test.ts`: `~/...` path expansion coverage
- `packages/core/src/store.test.ts`: stable `local` fallback, config-driven actor identity, env-overrides-config parity

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 397/397)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (`pnpm clean && pnpm build`)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced