### PR TITLE
fix: tighten integer parsing and query validation to match Python

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,7 @@ export type {
 	ToolEvent,
 } from "./ingest-types.js";
 export { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
+export { parsePositiveMemoryId, parseStrictInteger } from "./integers.js";
 export type { ObserverAuthMaterial } from "./observer-auth.js";
 export {
 	buildCodexHeaders,

--- a/packages/core/src/integers.ts
+++ b/packages/core/src/integers.ts
@@ -1,0 +1,44 @@
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
+
+/**
+ * Parse a strict integer string like Python's int(), but reject partial strings
+ * like "10abc" that parseInt() would silently truncate.
+ */
+export function parseStrictInteger(value: string | undefined): number | null {
+	if (value == null) return null;
+	const trimmed = value.trim();
+	if (!/^[+-]?\d+$/.test(trimmed)) return null;
+	try {
+		const parsed = BigInt(trimmed);
+		if (parsed < MIN_SAFE_BIGINT || parsed > MAX_SAFE_BIGINT) return null;
+		return Number(parsed);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Parse a positive memory ID matching Python's stricter semantics:
+ * - allow integer numbers
+ * - allow digit-only strings
+ * - reject bools, floats, scientific notation, whitespacey strings, unsafe ints
+ */
+export function parsePositiveMemoryId(value: unknown): number | null {
+	if (typeof value === "boolean") return null;
+	if (typeof value === "number") {
+		if (!Number.isInteger(value) || !Number.isSafeInteger(value) || value <= 0) return null;
+		return value;
+	}
+	if (typeof value === "string") {
+		if (!/^\d+$/.test(value)) return null;
+		try {
+			const parsed = BigInt(value);
+			if (parsed <= 0n || parsed > MAX_SAFE_BIGINT) return null;
+			return Number(parsed);
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -651,6 +651,26 @@ describe("MemoryStore.explain", () => {
 		expect(invalidIds).toContain("3.14");
 	});
 
+	it("rejects non-digit strings, scientific notation, and unsafe ints in ids", () => {
+		const { id1 } = seedMemories();
+		const result = store.explain(null, [
+			"1e2",
+			"1.0",
+			" 7 ",
+			`${Number.MAX_SAFE_INTEGER + 1}`,
+			id1,
+		]);
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]?.id).toBe(id1);
+		const invalidArgError = result.errors.find((e) => e.code === "INVALID_ARGUMENT");
+		expect(invalidArgError).toBeDefined();
+		const invalidIds = invalidArgError?.ids as (string | number)[];
+		expect(invalidIds).toContain("1e2");
+		expect(invalidIds).toContain("1.0");
+		expect(invalidIds).toContain(" 7 ");
+		expect(invalidIds).toContain(`${Number.MAX_SAFE_INTEGER + 1}`);
+	});
+
 	it("excludes id-lookup memories that fail workspace_id filter (rowMatchesFilters)", () => {
 		const sessionId = insertTestSession(store.db);
 		// Insert a memory with a specific workspace_id

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -11,6 +11,7 @@
 
 import { fromJson } from "./db.js";
 import { buildFilterClauses } from "./filters.js";
+import { parsePositiveMemoryId } from "./integers.js";
 import { projectMatchesFilter } from "./project.js";
 import type {
 	ExplainError,
@@ -366,13 +367,8 @@ export function dedupeOrderedIds(ids: unknown[]): { ordered: number[]; invalid: 
 	const invalid: string[] = [];
 
 	for (const rawId of ids) {
-		// Reject booleans and floats explicitly (matches Python behavior)
-		if (typeof rawId === "boolean" || (typeof rawId === "number" && !Number.isInteger(rawId))) {
-			invalid.push(String(rawId));
-			continue;
-		}
-		const parsed = Number(rawId);
-		if (!Number.isInteger(parsed) || parsed <= 0) {
+		const parsed = parsePositiveMemoryId(rawId);
+		if (parsed == null) {
 			invalid.push(String(rawId));
 			continue;
 		}

--- a/packages/viewer-server/src/helpers.test.ts
+++ b/packages/viewer-server/src/helpers.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { queryInt } from "./helpers.js";
+
+describe("queryInt", () => {
+	it("parses full integer strings", () => {
+		expect(queryInt("10", 25)).toBe(10);
+		expect(queryInt("  -7  ", 25)).toBe(-7);
+	});
+
+	it("rejects partial or non-integer strings", () => {
+		expect(queryInt("10abc", 25)).toBe(25);
+		expect(queryInt("1.0", 25)).toBe(25);
+		expect(queryInt("1e2", 25)).toBe(25);
+		expect(queryInt("", 25)).toBe(25);
+	});
+});

--- a/packages/viewer-server/src/helpers.ts
+++ b/packages/viewer-server/src/helpers.ts
@@ -1,3 +1,5 @@
+import { parseStrictInteger } from "@codemem/core";
+
 /**
  * Shared helpers for viewer-server routes.
  */
@@ -23,8 +25,8 @@ export function safeJsonList(raw: string | null | undefined): string[] {
  */
 export function queryInt(value: string | undefined, defaultValue: number): number {
 	if (value == null) return defaultValue;
-	const parsed = Number.parseInt(value, 10);
-	return Number.isNaN(parsed) ? defaultValue : parsed;
+	const parsed = parseStrictInteger(value);
+	return parsed == null ? defaultValue : parsed;
 }
 
 /**

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -5,7 +5,7 @@
  */
 
 import type { MemoryStore } from "@codemem/core";
-import { fromJson } from "@codemem/core";
+import { fromJson, parsePositiveMemoryId, parseStrictInteger } from "@codemem/core";
 import { Hono } from "hono";
 import { queryInt } from "../helpers.js";
 
@@ -225,8 +225,8 @@ export function memoryRoutes(getStore: StoreFactory) {
 			const tokenBudgetStr = c.req.query("token_budget");
 			let tokenBudget: number | undefined;
 			if (tokenBudgetStr) {
-				tokenBudget = Number.parseInt(tokenBudgetStr, 10);
-				if (Number.isNaN(tokenBudget)) {
+				tokenBudget = parseStrictInteger(tokenBudgetStr) ?? undefined;
+				if (tokenBudget === undefined) {
 					return c.json({ error: "token_budget must be int" }, 400);
 				}
 			}
@@ -263,8 +263,8 @@ export function memoryRoutes(getStore: StoreFactory) {
 			if (!sessionIdStr) {
 				return c.json({ error: "session_id required" }, 400);
 			}
-			const sessionId = Number.parseInt(sessionIdStr, 10);
-			if (Number.isNaN(sessionId)) {
+			const sessionId = parseStrictInteger(sessionIdStr);
+			if (sessionId == null) {
 				return c.json({ error: "session_id must be int" }, 400);
 			}
 			const rows = store.db
@@ -278,8 +278,8 @@ export function memoryRoutes(getStore: StoreFactory) {
 	app.post("/api/memories/visibility", async (c) => {
 		const store = getStore();
 		const body = await c.req.json<Record<string, unknown>>();
-		const memoryId = Number(body.memory_id);
-		if (Number.isNaN(memoryId)) {
+		const memoryId = parsePositiveMemoryId(body.memory_id);
+		if (memoryId == null) {
 			return c.json({ error: "memory_id must be int" }, 400);
 		}
 		const visibility = String(body.visibility ?? "").trim();


### PR DESCRIPTION
## Description

Tighten integer parsing semantics so the TS backend stops accepting inputs that Python rejects.

### What was wrong before

**ID parsing (`dedupeOrderedIds`)**
TypeScript used `Number(rawId)`, which incorrectly accepted values that Python rejects:
- `"1e2"`
- `"1.0"`
- `" 7 "`
- unsafe integers beyond `Number.MAX_SAFE_INTEGER`

**Query param parsing (`queryInt`)**
TypeScript used `parseInt()`, which silently truncated partial strings like:
- `"10abc"` → `10`

Python route code uses `int(...)`, which rejects partial junk.

### What changed
- Added `packages/core/src/integers.ts`
  - `parseStrictInteger()` for full-string integer parsing
  - `parsePositiveMemoryId()` for Python-compatible ID parsing
- `packages/core/src/search.ts`
  - `dedupeOrderedIds()` now uses `parsePositiveMemoryId()`
- `packages/viewer-server/src/helpers.ts`
  - `queryInt()` now uses `parseStrictInteger()` instead of `parseInt()`
- `packages/viewer-server/src/routes/memory.ts`
  - tightened `token_budget`, `session_id`, and `memory_id` parsing
- exported strict parsers from `@codemem/core`

### Tests
- `packages/core/src/search.test.ts`
  - added coverage for `1e2`, `1.0`, ` 7 `, and unsafe integer IDs
- `packages/viewer-server/src/helpers.test.ts`
  - added strict query parsing coverage (`10abc` rejected, full ints accepted)

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 400/400)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (`pnpm clean && pnpm build`, `pnpm lint` with only existing unrelated warnings)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced