### PR TITLE
feat: restore Python search/filter knobs in TS

### DIFF
--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -8,6 +8,11 @@
 import { projectClause } from "./project.js";
 import type { MemoryFilters } from "./types.js";
 
+export interface OwnershipFilterContext {
+	actorId: string;
+	deviceId: string;
+}
+
 export interface FilterResult {
 	clauses: string[];
 	params: unknown[];
@@ -18,10 +23,42 @@ export interface FilterResult {
  * Normalize a filter value that may be a single string or an array of strings
  * into a clean, non-empty array of trimmed strings.
  */
-function normalizeStringArray(value: string | string[] | undefined | null): string[] {
+export function normalizeFilterStrings(value: string | string[] | undefined | null): string[] {
 	if (value == null) return [];
 	const items = Array.isArray(value) ? value : [value];
-	return items.map((s) => String(s).trim()).filter((s) => s.length > 0);
+	const seen = new Set<string>();
+	const normalized: string[] = [];
+	for (const item of items) {
+		const candidate = String(item).trim();
+		if (!candidate || seen.has(candidate)) continue;
+		seen.add(candidate);
+		normalized.push(candidate);
+	}
+	return normalized;
+}
+
+export function normalizeWorkspaceKinds(value: string | string[] | undefined | null): string[] {
+	return normalizeFilterStrings(value)
+		.map((raw) => raw.toLowerCase())
+		.filter(
+			(raw, idx, arr) => (raw === "personal" || raw === "shared") && arr.indexOf(raw) === idx,
+		);
+}
+
+export function normalizeVisibilityValues(value: string | string[] | undefined | null): string[] {
+	return normalizeFilterStrings(value)
+		.map((raw) => raw.toLowerCase())
+		.filter((raw, idx, arr) => (raw === "private" || raw === "shared") && arr.indexOf(raw) === idx);
+}
+
+export function normalizeTrustStates(value: string | string[] | undefined | null): string[] {
+	return normalizeFilterStrings(value)
+		.map((raw) => raw.toLowerCase())
+		.filter(
+			(raw, idx, arr) =>
+				(raw === "trusted" || raw === "legacy_unknown" || raw === "unreviewed") &&
+				arr.indexOf(raw) === idx,
+		);
 }
 
 /**
@@ -55,6 +92,13 @@ function addMultiValueFilter(
  * similar base conditions — this function only appends filter-specific clauses.
  */
 export function buildFilterClauses(filters: MemoryFilters | undefined | null): FilterResult {
+	return buildFilterClausesWithContext(filters);
+}
+
+export function buildFilterClausesWithContext(
+	filters: MemoryFilters | undefined | null,
+	ownership?: OwnershipFilterContext,
+): FilterResult {
 	const result: FilterResult = { clauses: [], params: [], joinSessions: false };
 	if (!filters) return result;
 
@@ -64,6 +108,27 @@ export function buildFilterClauses(filters: MemoryFilters | undefined | null): F
 	if (filters.kind) {
 		clauses.push("memory_items.kind = ?");
 		params.push(filters.kind);
+	}
+	if (filters.session_id) {
+		clauses.push("memory_items.session_id = ?");
+		params.push(filters.session_id);
+	}
+	if (filters.since) {
+		clauses.push("memory_items.created_at >= ?");
+		params.push(filters.since);
+	}
+
+	const ownershipScope = String(filters.ownership_scope ?? "")
+		.trim()
+		.toLowerCase();
+	if (ownership && (ownershipScope === "mine" || ownershipScope === "theirs")) {
+		const ownedClause = "(memory_items.actor_id = ? OR memory_items.origin_device_id = ?)";
+		if (ownershipScope === "mine") {
+			clauses.push(ownedClause);
+		} else {
+			clauses.push(`NOT ${ownedClause}`);
+		}
+		params.push(ownership.actorId, ownership.deviceId);
 	}
 
 	// Project scoping — requires sessions JOIN
@@ -81,8 +146,8 @@ export function buildFilterClauses(filters: MemoryFilters | undefined | null): F
 		clauses,
 		params,
 		"memory_items.visibility",
-		normalizeStringArray(filters.include_visibility),
-		normalizeStringArray(filters.exclude_visibility),
+		normalizeVisibilityValues(filters.include_visibility ?? filters.visibility),
+		normalizeVisibilityValues(filters.exclude_visibility),
 	);
 
 	// Workspace IDs
@@ -90,8 +155,8 @@ export function buildFilterClauses(filters: MemoryFilters | undefined | null): F
 		clauses,
 		params,
 		"memory_items.workspace_id",
-		normalizeStringArray(filters.include_workspace_ids),
-		normalizeStringArray(filters.exclude_workspace_ids),
+		normalizeFilterStrings(filters.include_workspace_ids),
+		normalizeFilterStrings(filters.exclude_workspace_ids),
 	);
 
 	// Workspace kinds
@@ -99,8 +164,8 @@ export function buildFilterClauses(filters: MemoryFilters | undefined | null): F
 		clauses,
 		params,
 		"memory_items.workspace_kind",
-		normalizeStringArray(filters.include_workspace_kinds),
-		normalizeStringArray(filters.exclude_workspace_kinds),
+		normalizeWorkspaceKinds(filters.include_workspace_kinds),
+		normalizeWorkspaceKinds(filters.exclude_workspace_kinds),
 	);
 
 	// Actor IDs
@@ -108,8 +173,8 @@ export function buildFilterClauses(filters: MemoryFilters | undefined | null): F
 		clauses,
 		params,
 		"memory_items.actor_id",
-		normalizeStringArray(filters.include_actor_ids),
-		normalizeStringArray(filters.exclude_actor_ids),
+		normalizeFilterStrings(filters.include_actor_ids),
+		normalizeFilterStrings(filters.exclude_actor_ids),
 	);
 
 	// Trust states
@@ -117,8 +182,8 @@ export function buildFilterClauses(filters: MemoryFilters | undefined | null): F
 		clauses,
 		params,
 		"memory_items.trust_state",
-		normalizeStringArray(filters.include_trust_states),
-		normalizeStringArray(filters.exclude_trust_states),
+		normalizeTrustStates(filters.include_trust_states),
+		normalizeTrustStates(filters.exclude_trust_states),
 	);
 
 	return result;

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -127,6 +127,19 @@ describe("kindBonus", () => {
 // ---------------------------------------------------------------------------
 
 describe("rerankResults", () => {
+	const mockStore = {
+		db: {} as never,
+		actorId: "local:test-device",
+		deviceId: "test-device",
+		get: () => null,
+		recent: () => [],
+		recentByKinds: () => [],
+		memoryOwnedBySelf: (item: MemoryResult | Record<string, unknown>) => {
+			const metadata = (item as MemoryResult).metadata as Record<string, unknown> | undefined;
+			return metadata?.actor_id === "local:test-device";
+		},
+	};
+
 	function makeResult(overrides: Partial<MemoryResult>): MemoryResult {
 		return {
 			id: 1,
@@ -150,7 +163,7 @@ describe("rerankResults", () => {
 			makeResult({ id: 2, score: 2.0 }),
 			makeResult({ id: 3, score: 1.0 }),
 		];
-		const reranked = rerankResults(results, 2);
+		const reranked = rerankResults(mockStore, results, 2);
 		expect(reranked).toHaveLength(2);
 	});
 
@@ -159,13 +172,29 @@ describe("rerankResults", () => {
 			makeResult({ id: 1, score: 1.0, kind: "exploration" }),
 			makeResult({ id: 2, score: 3.0, kind: "decision" }),
 		];
-		const reranked = rerankResults(results, 10);
+		const reranked = rerankResults(mockStore, results, 10);
 		expect(reranked[0]?.id).toBe(2);
 		expect(reranked[1]?.id).toBe(1);
 	});
 
+	it("applies personal_first and trust_bias adjustments", () => {
+		const results = [
+			makeResult({ id: 1, score: 1.0, metadata: { actor_id: "local:test-device" } }),
+			makeResult({
+				id: 2,
+				score: 1.0,
+				metadata: { visibility: "shared", workspace_kind: "shared", trust_state: "unreviewed" },
+			}),
+		];
+		const reranked = rerankResults(mockStore, results, 10, {
+			personal_first: true,
+			trust_bias: "soft",
+		});
+		expect(reranked[0]?.id).toBe(1);
+	});
+
 	it("returns empty array for empty input", () => {
-		expect(rerankResults([], 10)).toEqual([]);
+		expect(rerankResults(mockStore, [], 10)).toEqual([]);
 	});
 });
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -10,7 +10,12 @@
  */
 
 import { fromJson } from "./db.js";
-import { buildFilterClauses } from "./filters.js";
+import {
+	buildFilterClausesWithContext,
+	normalizeFilterStrings,
+	normalizeVisibilityValues,
+	normalizeWorkspaceKinds,
+} from "./filters.js";
 import { parsePositiveMemoryId } from "./integers.js";
 import { projectMatchesFilter } from "./project.js";
 import type {
@@ -32,7 +37,10 @@ import type {
 /** Structural type for the store parameter (avoids circular import). */
 export interface StoreHandle {
 	readonly db: import("better-sqlite3").Database;
+	readonly actorId: string;
+	readonly deviceId: string;
 	get(memoryId: number): MemoryItemResponse | null;
+	memoryOwnedBySelf(item: MemoryItem | MemoryResult | Record<string, unknown>): boolean;
 	recent(limit?: number, filters?: MemoryFilters | null, offset?: number): MemoryItemResponse[];
 	recentByKinds(
 		kinds: string[],
@@ -59,6 +67,19 @@ const MEMORY_KIND_BONUS: Record<string, number> = {
 	exploration: 0.1,
 	entities: 0.05,
 };
+
+const PERSONAL_FIRST_BONUS = 0.45;
+const TRUST_BIAS_LEGACY_UNKNOWN_PENALTY = 0.18;
+const TRUST_BIAS_UNREVIEWED_PENALTY = 0.12;
+const WIDEN_SHARED_DEFAULT_MIN_PERSONAL_RESULTS = 3;
+const WIDEN_SHARED_DEFAULT_MIN_PERSONAL_SCORE = 0.0;
+const WIDEN_SHARED_MAX_SHARED_RESULTS = 2;
+const PERSONAL_QUERY_PATTERNS = [
+	/\bwhat did i\b/i,
+	/\bmy notes\b/i,
+	/\bmy last session\b/i,
+	/\bmy machine\b/i,
+];
 
 /** FTS5 operators that must be stripped from user queries. */
 const FTS5_OPERATORS = new Set(["or", "and", "not", "near", "phrase"]);
@@ -117,6 +138,131 @@ export function kindBonus(kind: string | null): number {
 	return MEMORY_KIND_BONUS[kind.trim().toLowerCase()] ?? 0.0;
 }
 
+function personalFirstEnabled(filters: MemoryFilters | undefined): boolean {
+	if (!filters || filters.personal_first === undefined) return true;
+	const value = filters.personal_first;
+	if (typeof value === "string") {
+		const lowered = value.trim().toLowerCase();
+		if (["0", "false", "no", "off"].includes(lowered)) return false;
+		if (["1", "true", "yes", "on"].includes(lowered)) return true;
+	}
+	return Boolean(value);
+}
+
+function trustBiasMode(filters: MemoryFilters | undefined): "off" | "soft" {
+	const value = String(filters?.trust_bias ?? "off")
+		.trim()
+		.toLowerCase();
+	return value === "soft" ? "soft" : "off";
+}
+
+function widenSharedWhenWeakEnabled(filters: MemoryFilters | undefined): boolean {
+	if (!filters || filters.widen_shared_when_weak === undefined) return false;
+	const value = filters.widen_shared_when_weak;
+	if (typeof value === "string") {
+		const lowered = value.trim().toLowerCase();
+		if (["0", "false", "no", "off"].includes(lowered)) return false;
+		if (["1", "true", "yes", "on"].includes(lowered)) return true;
+	}
+	return Boolean(value);
+}
+
+function widenSharedMinPersonalResults(filters: MemoryFilters | undefined): number {
+	const value = filters?.widen_shared_min_personal_results;
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return WIDEN_SHARED_DEFAULT_MIN_PERSONAL_RESULTS;
+	}
+	return Math.max(1, Math.trunc(value));
+}
+
+function widenSharedMinPersonalScore(filters: MemoryFilters | undefined): number {
+	const value = filters?.widen_shared_min_personal_score;
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return WIDEN_SHARED_DEFAULT_MIN_PERSONAL_SCORE;
+	}
+	return Math.max(0, value);
+}
+
+function queryBlocksSharedWidening(query: string): boolean {
+	return PERSONAL_QUERY_PATTERNS.some((pattern) => pattern.test(query));
+}
+
+function filtersBlockSharedWidening(filters: MemoryFilters | undefined): boolean {
+	if (!filters) return false;
+	const ownershipScope = String(filters.ownership_scope ?? "")
+		.trim()
+		.toLowerCase();
+	if (ownershipScope === "mine" || ownershipScope === "theirs") return true;
+	const includeVisibility = normalizeVisibilityValues(
+		filters.include_visibility ?? filters.visibility,
+	);
+	const excludeVisibility = normalizeVisibilityValues(filters.exclude_visibility);
+	const includeWorkspaceIds = normalizeFilterStrings(filters.include_workspace_ids);
+	const excludeWorkspaceIds = normalizeFilterStrings(filters.exclude_workspace_ids);
+	const includeWorkspaceKinds = normalizeWorkspaceKinds(filters.include_workspace_kinds);
+	const excludeWorkspaceKinds = normalizeWorkspaceKinds(filters.exclude_workspace_kinds);
+	if (includeVisibility.length || includeWorkspaceIds.length || includeWorkspaceKinds.length)
+		return true;
+	if (excludeVisibility.includes("private") || excludeVisibility.includes("shared")) return true;
+	if (excludeWorkspaceKinds.includes("shared") || excludeWorkspaceKinds.includes("personal")) {
+		return true;
+	}
+	return excludeWorkspaceIds.some(
+		(value) => value.startsWith("personal:") || value.startsWith("shared:"),
+	);
+}
+
+function sharedWideningFilters(filters: MemoryFilters | undefined): MemoryFilters {
+	return {
+		...(filters ?? {}),
+		visibility: undefined,
+		ownership_scope: undefined,
+		include_visibility: ["shared"],
+		include_workspace_kinds: ["shared"],
+		personal_first: false,
+		widen_shared_when_weak: false,
+	};
+}
+
+function markWideningMetadata(items: MemoryResult[]): MemoryResult[] {
+	return items.map((item) => ({
+		...item,
+		metadata: { ...(item.metadata ?? {}), widened_from_shared: true },
+	}));
+}
+
+function personalBias(
+	store: StoreHandle,
+	item: MemoryResult,
+	filters: MemoryFilters | undefined,
+): number {
+	if (!personalFirstEnabled(filters)) return 0.0;
+	return store.memoryOwnedBySelf(item) ? PERSONAL_FIRST_BONUS : 0.0;
+}
+
+function sharedTrustPenalty(
+	store: StoreHandle,
+	item: MemoryResult,
+	filters: MemoryFilters | undefined,
+): number {
+	if (trustBiasMode(filters) !== "soft") return 0.0;
+	if (store.memoryOwnedBySelf(item)) return 0.0;
+	const metadata = item.metadata ?? {};
+	const visibility = String(metadata.visibility ?? "")
+		.trim()
+		.toLowerCase();
+	const workspaceKind = String(metadata.workspace_kind ?? "")
+		.trim()
+		.toLowerCase();
+	if (visibility !== "shared" && workspaceKind !== "shared") return 0.0;
+	const trustState = String(metadata.trust_state ?? "trusted")
+		.trim()
+		.toLowerCase();
+	if (trustState === "legacy_unknown") return TRUST_BIAS_LEGACY_UNKNOWN_PENALTY;
+	if (trustState === "unreviewed") return TRUST_BIAS_UNREVIEWED_PENALTY;
+	return 0.0;
+}
+
 // ---------------------------------------------------------------------------
 // rerankResults
 // ---------------------------------------------------------------------------
@@ -127,13 +273,22 @@ export function kindBonus(kind: string | null): number {
  * Simplified version: does not apply personal_bias or trust_penalty
  * (those require actor resolution, deferred to a follow-up).
  */
-export function rerankResults(results: MemoryResult[], limit: number): MemoryResult[] {
+export function rerankResults(
+	store: StoreHandle,
+	results: MemoryResult[],
+	limit: number,
+	filters?: MemoryFilters,
+): MemoryResult[] {
 	const referenceNow = new Date();
 
 	const scored = results.map((item) => ({
 		item,
 		combinedScore:
-			item.score * 1.5 + recencyScore(item.created_at, referenceNow) + kindBonus(item.kind),
+			item.score * 1.5 +
+			recencyScore(item.created_at, referenceNow) +
+			kindBonus(item.kind) +
+			personalBias(store, item, filters) -
+			sharedTrustPenalty(store, item, filters),
 	}));
 
 	scored.sort((a, b) => b.combinedScore - a.combinedScore);
@@ -158,6 +313,48 @@ export function search(
 	limit = 10,
 	filters?: MemoryFilters,
 ): MemoryResult[] {
+	const primary = searchOnce(store, query, limit, filters);
+	if (
+		!widenSharedWhenWeakEnabled(filters) ||
+		!query ||
+		queryBlocksSharedWidening(query) ||
+		filtersBlockSharedWidening(filters)
+	) {
+		return primary;
+	}
+
+	const personalResults = primary.filter((item) => store.memoryOwnedBySelf(item));
+	const strongestPersonalScore = personalResults[0]?.score ?? -Infinity;
+	const personalStrongEnough =
+		personalResults.length >= widenSharedMinPersonalResults(filters) &&
+		strongestPersonalScore >= widenSharedMinPersonalScore(filters);
+	if (personalStrongEnough) return primary;
+
+	const shared = markWideningMetadata(
+		searchOnce(
+			store,
+			query,
+			WIDEN_SHARED_MAX_SHARED_RESULTS,
+			sharedWideningFilters(filters),
+		).filter((item) => !store.memoryOwnedBySelf(item)),
+	);
+	const seen = new Set(primary.map((item) => item.id));
+	const combined = [...primary];
+	for (const item of shared) {
+		if (seen.has(item.id)) continue;
+		seen.add(item.id);
+		combined.push(item);
+		if (combined.length >= Math.max(1, Math.trunc(limit))) break;
+	}
+	return combined;
+}
+
+function searchOnce(
+	store: StoreHandle,
+	query: string,
+	limit = 10,
+	filters?: MemoryFilters,
+): MemoryResult[] {
 	const effectiveLimit = Math.max(1, Math.trunc(limit));
 	const expanded = expandQuery(query);
 	if (!expanded) return [];
@@ -169,7 +366,10 @@ export function search(
 	const params: unknown[] = [expanded];
 	const whereClauses = ["memory_items.active = 1", "memory_fts MATCH ?"];
 
-	const filterResult = buildFilterClauses(filters);
+	const filterResult = buildFilterClausesWithContext(filters, {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+	});
 	whereClauses.push(...filterResult.clauses);
 	params.push(...filterResult.params);
 
@@ -225,7 +425,7 @@ export function search(
 		};
 	});
 
-	return rerankResults(results, effectiveLimit);
+	return rerankResults(store, results, effectiveLimit, filters);
 }
 
 // ---------------------------------------------------------------------------
@@ -295,7 +495,10 @@ function timelineAround(
 		return [];
 	}
 
-	const filterResult = buildFilterClauses(filters);
+	const filterResult = buildFilterClausesWithContext(filters, {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+	});
 	const whereParts = ["memory_items.active = 1", ...filterResult.clauses];
 	const baseParams = [...filterResult.params];
 
@@ -470,7 +673,10 @@ function loadItemsByIdsForExplain(
 	let projectScopedIds = new Set(allFoundIds);
 	if (filters.project) {
 		const projectFiltersOnly: MemoryFilters = { project: filters.project };
-		const projectFilterResult = buildFilterClauses(projectFiltersOnly);
+		const projectFilterResult = buildFilterClausesWithContext(projectFiltersOnly, {
+			actorId: store.actorId,
+			deviceId: store.deviceId,
+		});
 		if (projectFilterResult.clauses.length > 0) {
 			const projectJoin = projectFilterResult.joinSessions
 				? "JOIN sessions ON sessions.id = memory_items.session_id"
@@ -489,7 +695,10 @@ function loadItemsByIdsForExplain(
 		}
 	}
 
-	const filterResult = buildFilterClauses(filters);
+	const filterResult = buildFilterClausesWithContext(filters, {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+	});
 	const joinClause = filterResult.joinSessions
 		? "JOIN sessions ON sessions.id = memory_items.session_id"
 		: "";

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connect } from "./db.js";
-import { buildFilterClauses } from "./filters.js";
+import { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 
@@ -477,6 +477,22 @@ describe("buildFilterClauses", () => {
 		expect(result.params).toEqual(["private", "shared"]);
 	});
 
+	it("normalizes visibility/workspace/trust values like Python", () => {
+		const result = buildFilterClauses({
+			visibility: [" Shared ", "INVALID", "private"],
+			include_workspace_kinds: ["PERSONAL", "nope", "shared"],
+			include_trust_states: ["Unreviewed", "bogus", "trusted"],
+		});
+		expect(result.params).toEqual([
+			"shared",
+			"private",
+			"personal",
+			"shared",
+			"unreviewed",
+			"trusted",
+		]);
+	});
+
 	it("builds exclude_actor_ids filter", () => {
 		const result = buildFilterClauses({ exclude_actor_ids: ["actor:123"] });
 		expect(result.clauses).toHaveLength(1);
@@ -492,5 +508,16 @@ describe("buildFilterClauses", () => {
 		});
 		expect(result.clauses).toHaveLength(3);
 		expect(result.params).toEqual(["feature", "shared", "personal"]);
+	});
+
+	it("builds ownership_scope mine clause with actor/device context", () => {
+		const result = buildFilterClausesWithContext(
+			{ ownership_scope: "mine" },
+			{ actorId: "local:device-1", deviceId: "device-1" },
+		);
+		expect(result.clauses).toEqual([
+			"(memory_items.actor_id = ? OR memory_items.origin_device_id = ?)",
+		]);
+		expect(result.params).toEqual(["local:device-1", "device-1"]);
 	});
 });

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -315,7 +315,7 @@ export class MemoryStore {
 	 * Simplified: check actor_id first, then origin_device_id.
 	 * Peer claim/legacy checks deferred until sync parity is needed.
 	 */
-	memoryOwnedBySelf(item: MemoryItem | Record<string, unknown>): boolean {
+	memoryOwnedBySelf(item: MemoryItem | MemoryResult | Record<string, unknown>): boolean {
 		const rec = item as Record<string, unknown>;
 		const itemActorId = cleanStr(rec.actor_id);
 		if (itemActorId === this.actorId) return true;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -446,8 +446,11 @@ export interface MemoryResult {
 
 export interface MemoryFilters {
 	kind?: string;
+	session_id?: number;
+	since?: string;
 	/** Project scope — matches sessions.project. Triggers session JOIN. */
 	project?: string;
+	visibility?: string | string[];
 	include_visibility?: string[];
 	exclude_visibility?: string[];
 	include_workspace_ids?: string[];
@@ -458,4 +461,10 @@ export interface MemoryFilters {
 	exclude_actor_ids?: string[];
 	include_trust_states?: string[];
 	exclude_trust_states?: string[];
+	ownership_scope?: "mine" | "theirs" | string;
+	personal_first?: boolean | string;
+	trust_bias?: "off" | "soft" | string;
+	widen_shared_when_weak?: boolean | string;
+	widen_shared_min_personal_results?: number;
+	widen_shared_min_personal_score?: number;
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -45,6 +45,7 @@ const MEMORY_KINDS: Record<string, string> = {
 const filterSchema = {
 	kind: z.string().optional().describe("Filter by memory kind"),
 	project: z.string().optional().describe("Filter by project scope (matches sessions.project)"),
+	visibility: z.array(z.string()).optional(),
 	include_visibility: z.array(z.string()).optional(),
 	exclude_visibility: z.array(z.string()).optional(),
 	include_workspace_ids: z.array(z.string()).optional(),
@@ -55,6 +56,12 @@ const filterSchema = {
 	exclude_actor_ids: z.array(z.string()).optional(),
 	include_trust_states: z.array(z.string()).optional(),
 	exclude_trust_states: z.array(z.string()).optional(),
+	ownership_scope: z.string().optional(),
+	personal_first: z.union([z.boolean(), z.string()]).optional(),
+	trust_bias: z.string().optional(),
+	widen_shared_when_weak: z.union([z.boolean(), z.string()]).optional(),
+	widen_shared_min_personal_results: z.number().int().optional(),
+	widen_shared_min_personal_score: z.number().optional(),
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp-server/src/project-scope.test.ts
+++ b/packages/mcp-server/src/project-scope.test.ts
@@ -29,6 +29,31 @@ describe("project-scope helpers", () => {
 		});
 	});
 
+	it("passes through advanced search knobs", async () => {
+		const { buildFilters } = await import("./project-scope.js");
+		expect(
+			buildFilters(
+				{
+					personal_first: false,
+					trust_bias: "soft",
+					widen_shared_when_weak: true,
+					widen_shared_min_personal_results: 2,
+					widen_shared_min_personal_score: 0.3,
+					ownership_scope: "mine",
+				},
+				"repo-name",
+			),
+		).toEqual({
+			personal_first: false,
+			project: "repo-name",
+			trust_bias: "soft",
+			widen_shared_when_weak: true,
+			widen_shared_min_personal_results: 2,
+			widen_shared_min_personal_score: 0.3,
+			ownership_scope: "mine",
+		});
+	});
+
 	it("falls back to default project when env or request project is blank", async () => {
 		process.env.CODEMEM_PROJECT = "   ";
 		const { buildFilters, resolveDefaultProject } = await import("./project-scope.js");

--- a/packages/mcp-server/src/project-scope.ts
+++ b/packages/mcp-server/src/project-scope.ts
@@ -21,6 +21,7 @@ export function buildFilters(
 
 	for (const key of [
 		"kind",
+		"visibility",
 		"include_visibility",
 		"exclude_visibility",
 		"include_workspace_ids",
@@ -31,6 +32,12 @@ export function buildFilters(
 		"exclude_actor_ids",
 		"include_trust_states",
 		"exclude_trust_states",
+		"ownership_scope",
+		"personal_first",
+		"trust_bias",
+		"widen_shared_when_weak",
+		"widen_shared_min_personal_results",
+		"widen_shared_min_personal_score",
 	] as const) {
 		const val = raw[key];
 		if (val !== undefined && val !== null) {


### PR DESCRIPTION
## Description

Restore the missing Python search/filter knobs and normalization semantics in the TypeScript backend.

### Added filter surface parity
- `visibility`
- `session_id`
- `since`
- `ownership_scope`
- `personal_first`
- `trust_bias`
- `widen_shared_when_weak`
- `widen_shared_min_personal_results`
- `widen_shared_min_personal_score`

### Filter normalization parity
- visibility values are now lowercased and whitelisted (`private`, `shared`)
- workspace kinds are now lowercased and whitelisted (`personal`, `shared`)
- trust states are now lowercased and whitelisted (`trusted`, `legacy_unknown`, `unreviewed`)
- duplicate/empty filter values are collapsed like Python

### Search behavior parity
- `ownership_scope=mine|theirs` now adds actor/device ownership SQL clauses
- `personal_first` now adds personal-result bias during reranking
- `trust_bias=soft` now applies penalties to unreviewed / legacy_unknown shared memories
- `widen_shared_when_weak` now performs a second shared-only pass when personal results are weak and appends widened shared results with provenance metadata

### MCP parity
- MCP filter schema now exposes the missing Python search knobs
- `project-scope.ts` now forwards those knobs into `MemoryFilters`

### Tests
- `packages/core/src/store.test.ts`
  - normalization coverage
  - ownership_scope clause coverage
- `packages/core/src/search.test.ts`
  - rerank adjustments for personal/trust bias
- `packages/mcp-server/src/project-scope.test.ts`
  - advanced filter passthrough coverage

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 404/404)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (`pnpm clean && pnpm build`, `pnpm lint` with only existing unrelated warnings)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced