### PR TITLE
fix: treat naive sync timestamps as UTC in viewer routes

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -270,5 +270,56 @@ describe("viewer-server", () => {
 				cleanup();
 			}
 		});
+
+		it("treats naive sync timestamps as UTC", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				const _warmup = await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db.exec(`
+					CREATE TABLE IF NOT EXISTS actors (
+						actor_id TEXT PRIMARY KEY,
+						display_name TEXT NOT NULL,
+						is_local INTEGER NOT NULL DEFAULT 0,
+						status TEXT NOT NULL DEFAULT 'active',
+						merged_into_actor_id TEXT,
+						created_at TEXT NOT NULL,
+						updated_at TEXT NOT NULL
+					);
+					CREATE TABLE IF NOT EXISTS sync_peers (
+						peer_device_id TEXT PRIMARY KEY,
+						name TEXT,
+						pinned_fingerprint TEXT,
+						addresses_json TEXT,
+						last_seen_at TEXT,
+						last_sync_at TEXT,
+						last_error TEXT,
+						projects_include_json TEXT,
+						projects_exclude_json TEXT,
+						claimed_local_actor INTEGER,
+						actor_id TEXT
+					)
+				`);
+				const now = new Date(Date.now() - 30_000).toISOString().replace(/\.\d{3}Z$/, "");
+				store.db
+					.prepare(
+						`INSERT INTO sync_peers (
+							peer_device_id, name, last_sync_at, claimed_local_actor, actor_id, created_at
+						) VALUES (?, ?, ?, 0, ?, ?)`,
+					)
+					.run("peer-1", "Peer One", now, "actor:peer-1", now);
+
+				const res = await app.request("/api/sync/status?diag=1");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					status: { peers: Record<string, Record<string, unknown>> };
+				};
+				expect(body.status.peers["peer-1"]?.peer_state).toBe("online");
+				expect(body.status.peers["peer-1"]?.sync_status).toBe("ok");
+			} finally {
+				cleanup();
+			}
+		});
 	});
 });

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -61,7 +61,9 @@ function mapPeerRow(row: Record<string, unknown>, showDiag: boolean): Record<str
 function isRecentIso(value: unknown, windowS = SYNC_STALE_AFTER_SECONDS): boolean {
 	const raw = String(value ?? "").trim();
 	if (!raw) return false;
-	const ts = new Date(raw.replace("Z", "+00:00"));
+	const normalized = raw.replace("Z", "+00:00");
+	const hasOffset = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(raw);
+	const ts = new Date(hasOffset ? normalized : `${normalized}+00:00`);
 	if (Number.isNaN(ts.getTime())) return false;
 	const ageS = (Date.now() - ts.getTime()) / 1000;
 	return ageS >= 0 && ageS <= windowS;


### PR DESCRIPTION
## Description

Fix sync freshness logic so naive ISO timestamps are interpreted as UTC, matching Python.

### What was wrong before
TypeScript used `new Date(raw.replace("Z", "+00:00"))`, which still lets naive timestamps be interpreted in the local timezone. Python explicitly treats naive timestamps as UTC in `viewer_routes/sync.py`.

That meant peer freshness could drift by server timezone and mark the same peer `online`/`stale` differently than Python.

### What changed
- `packages/viewer-server/src/routes/sync.ts`
  - detect whether the input already has an offset
  - if not, append `+00:00` before parsing
  - preserve existing handling for explicit `Z` / offset timestamps
- `packages/viewer-server/src/index.test.ts`
  - added a route-level test that inserts a peer with a naive recent timestamp and verifies `/api/sync/status` reports it as `online` / `ok`

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 405/405)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (`pnpm clean && pnpm build`)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced