### PR TITLE
feat: complete TS plugin CLI contract and version parity

### DIFF
--- a/.opencode/plugin/codemem.js
+++ b/.opencode/plugin/codemem.js
@@ -437,7 +437,7 @@ const buildRunnerArgs = ({ runner, runnerFrom, runnerFromExplicit }) => {
   }
   if (runner === "npx") {
     const pkg = runnerFromExplicit ? runnerFrom : "@codemem/cli";
-    return ["-y", pkg, "codemem"];
+    return ["-y", pkg];
   }
   return [];
 };

--- a/.opencode/tests/compat.test.js
+++ b/.opencode/tests/compat.test.js
@@ -64,8 +64,8 @@ describe("resolveUpgradeGuidance", () => {
       runner: "node",
       runnerFrom: "",
     });
-    expect(guidance.mode).toBe("generic");
-    expect(guidance.action).toContain("uv tool install --upgrade codemem");
+    expect(guidance.mode).toBe("node-dev");
+    expect(guidance.action).toContain("pnpm build");
   });
 });
 

--- a/packages/cli/src/commands/enqueue-raw-event.ts
+++ b/packages/cli/src/commands/enqueue-raw-event.ts
@@ -1,0 +1,94 @@
+import { MemoryStore, resolveDbPath, stripPrivateObj } from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+
+const SESSION_ID_KEYS = [
+	"session_stream_id",
+	"session_id",
+	"stream_id",
+	"opencode_session_id",
+] as const;
+
+function resolveSessionStreamId(payload: Record<string, unknown>): string | null {
+	const values = new Map<string, string>();
+	for (const key of SESSION_ID_KEYS) {
+		const value = payload[key];
+		if (typeof value !== "string") continue;
+		const text = value.trim();
+		if (text) values.set(key, text);
+	}
+	if (values.size === 0) return null;
+	const unique = new Set(values.values());
+	if (unique.size > 1) throw new Error("conflicting session id fields");
+	for (const key of SESSION_ID_KEYS) {
+		const value = values.get(key);
+		if (value) return value;
+	}
+	return null;
+}
+
+async function readStdinJson(): Promise<Record<string, unknown>> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of process.stdin) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+	}
+	const raw = Buffer.concat(chunks).toString("utf-8").trim();
+	if (!raw) throw new Error("stdin JSON required");
+	const parsed = JSON.parse(raw) as unknown;
+	if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("payload must be an object");
+	}
+	return parsed as Record<string, unknown>;
+}
+
+export const enqueueRawEventCommand = new Command("enqueue-raw-event")
+	.configureHelp(helpStyle)
+	.description("Enqueue one raw event from stdin into the durable queue")
+	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.action(async (opts: { db?: string }) => {
+		const payload = await readStdinJson();
+		const sessionId = resolveSessionStreamId(payload);
+		if (!sessionId) throw new Error("session id required");
+		if (sessionId.startsWith("msg_")) throw new Error("invalid session id");
+
+		const eventType = typeof payload.event_type === "string" ? payload.event_type.trim() : "";
+		if (!eventType) throw new Error("event_type required");
+
+		const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
+		const project = typeof payload.project === "string" ? payload.project : null;
+		const startedAt = typeof payload.started_at === "string" ? payload.started_at : null;
+		const tsWallMs = Number.isFinite(Number(payload.ts_wall_ms))
+			? Math.floor(Number(payload.ts_wall_ms))
+			: null;
+		const tsMonoMs = Number.isFinite(Number(payload.ts_mono_ms))
+			? Number(payload.ts_mono_ms)
+			: null;
+		const eventId = typeof payload.event_id === "string" ? payload.event_id.trim() : "";
+		const eventPayload =
+			payload.payload && typeof payload.payload === "object" && !Array.isArray(payload.payload)
+				? (stripPrivateObj(payload.payload) as Record<string, unknown>)
+				: {};
+
+		const store = new MemoryStore(resolveDbPath(opts.db));
+		try {
+			store.updateRawEventSessionMeta({
+				opencodeSessionId: sessionId,
+				source: "opencode",
+				cwd,
+				project,
+				startedAt,
+				lastSeenTsWallMs: tsWallMs,
+			});
+			store.recordRawEventsBatch(sessionId, [
+				{
+					event_id: eventId,
+					event_type: eventType,
+					payload: eventPayload,
+					ts_wall_ms: tsWallMs,
+					ts_mono_ms: tsMonoMs,
+				},
+			]);
+		} finally {
+			store.close();
+		}
+	});

--- a/packages/cli/src/commands/recent.ts
+++ b/packages/cli/src/commands/recent.ts
@@ -1,0 +1,23 @@
+import { MemoryStore, resolveDbPath } from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+
+export const recentCommand = new Command("recent")
+	.configureHelp(helpStyle)
+	.description("Show recent memories")
+	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--limit <n>", "max results", "5")
+	.option("--kind <kind>", "filter by memory kind")
+	.action((opts: { db?: string; limit: string; kind?: string }) => {
+		const store = new MemoryStore(resolveDbPath(opts.db));
+		try {
+			const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 5);
+			const filters = opts.kind ? { kind: opts.kind } : undefined;
+			const items = store.recent(limit, filters);
+			for (const item of items) {
+				console.log(`#${item.id} [${item.kind}] ${item.title}`);
+			}
+		} finally {
+			store.close();
+		}
+	});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,7 +1,87 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import { ObserverClient, RawEventSweeper, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+
+function pidFilePath(dbPath: string): string {
+	return join(dirname(dbPath), "viewer.pid");
+}
+
+interface ViewerPidRecord {
+	pid: number;
+	host: string;
+	port: number;
+}
+
+function readViewerPidRecord(dbPath: string): ViewerPidRecord | null {
+	const pidPath = pidFilePath(dbPath);
+	if (!existsSync(pidPath)) return null;
+	const raw = readFileSync(pidPath, "utf-8").trim();
+	try {
+		const parsed = JSON.parse(raw) as Partial<ViewerPidRecord>;
+		if (
+			typeof parsed.pid === "number" &&
+			typeof parsed.host === "string" &&
+			typeof parsed.port === "number"
+		) {
+			return { pid: parsed.pid, host: parsed.host, port: parsed.port };
+		}
+	} catch {
+		const pid = Number.parseInt(raw, 10);
+		if (Number.isFinite(pid) && pid > 0) {
+			return { pid, host: "127.0.0.1", port: 38888 };
+		}
+	}
+	return null;
+}
+
+async function respondsLikeCodememViewer(record: ViewerPidRecord): Promise<boolean> {
+	try {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), 1000);
+		const res = await fetch(`http://${record.host}:${record.port}/api/stats`, {
+			signal: controller.signal,
+		});
+		clearTimeout(timer);
+		return res.ok;
+	} catch {
+		return false;
+	}
+}
+
+async function waitForProcessExit(pid: number, timeoutMs = 5000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			process.kill(pid, 0);
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		} catch {
+			return;
+		}
+	}
+}
+
+async function stopExistingViewer(dbPath: string): Promise<void> {
+	const pidPath = pidFilePath(dbPath);
+	const record = readViewerPidRecord(dbPath);
+	if (!record) return;
+	// Only signal the process if the recorded endpoint still looks like codemem.
+	if (await respondsLikeCodememViewer(record)) {
+		try {
+			process.kill(record.pid, "SIGTERM");
+			await waitForProcessExit(record.pid);
+		} catch {
+			// stale pidfile or already exited
+		}
+	}
+	try {
+		rmSync(pidPath);
+	} catch {
+		// ignore
+	}
+}
 
 export const serveCommand = new Command("serve")
 	.configureHelp(helpStyle)
@@ -9,48 +89,80 @@ export const serveCommand = new Command("serve")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--host <host>", "bind host", "127.0.0.1")
 	.option("--port <port>", "bind port", "38888")
-	.action(async (opts: { db?: string; host: string; port: string }) => {
-		// Dynamic import to avoid loading hono/server deps for non-serve commands
-		const { createApp, closeStore, getStore } = await import("@codemem/viewer-server");
-		const { serve } = await import("@hono/node-server");
+	.option("--background", "run under a caller-managed background process")
+	.option("--stop", "stop an existing viewer process")
+	.option("--restart", "restart an existing viewer process")
+	.action(
+		async (opts: {
+			db?: string;
+			host: string;
+			port: string;
+			background?: boolean;
+			stop?: boolean;
+			restart?: boolean;
+		}) => {
+			// Dynamic import to avoid loading hono/server deps for non-serve commands
+			const { createApp, closeStore, getStore } = await import("@codemem/viewer-server");
+			const { serve } = await import("@hono/node-server");
 
-		const dbPath = resolveDbPath(opts.db);
-		process.env.CODEMEM_DB = dbPath;
+			const dbPath = resolveDbPath(opts.db);
+			if (opts.stop || opts.restart) {
+				await stopExistingViewer(dbPath);
+				if (opts.stop && !opts.restart) return;
+			}
+			process.env.CODEMEM_DB = dbPath;
 
-		const port = Number.parseInt(opts.port, 10);
-		// Start the raw event sweeper — shares the same store as the viewer
-		const observer = new ObserverClient();
-		const sweeper = new RawEventSweeper(getStore(), { observer });
-		sweeper.start();
+			const port = Number.parseInt(opts.port, 10);
+			// Start the raw event sweeper — shares the same store as the viewer
+			const observer = new ObserverClient();
+			const sweeper = new RawEventSweeper(getStore(), { observer });
+			sweeper.start();
 
-		const app = createApp({ storeFactory: getStore, sweeper });
+			const app = createApp({ storeFactory: getStore, sweeper });
+			const pidPath = pidFilePath(dbPath);
 
-		const server = serve({ fetch: app.fetch, hostname: opts.host, port }, (info) => {
-			p.intro("codemem viewer");
-			p.log.success(`Listening on http://${info.address}:${info.port}`);
-			p.log.info(`Database: ${dbPath}`);
-			p.log.step("Raw event sweeper started");
-		});
-
-		const shutdown = async () => {
-			p.outro("shutting down");
-			// Stop sweeper first and wait for any in-flight tick to drain.
-			await sweeper.stop();
-			// Close HTTP server, wait for in-flight requests to drain
-			server.close(() => {
-				closeStore();
-				process.exit(0);
+			const server = serve({ fetch: app.fetch, hostname: opts.host, port }, (info) => {
+				writeFileSync(
+					pidPath,
+					JSON.stringify({ pid: process.pid, host: opts.host, port }),
+					"utf-8",
+				);
+				p.intro("codemem viewer");
+				p.log.success(`Listening on http://${info.address}:${info.port}`);
+				p.log.info(`Database: ${dbPath}`);
+				p.log.step("Raw event sweeper started");
 			});
-			// Force exit after 5s if graceful shutdown stalls
-			setTimeout(() => {
-				closeStore();
-				process.exit(1);
-			}, 5000).unref();
-		};
-		process.on("SIGINT", () => {
-			void shutdown();
-		});
-		process.on("SIGTERM", () => {
-			void shutdown();
-		});
-	});
+
+			const shutdown = async () => {
+				p.outro("shutting down");
+				// Stop sweeper first and wait for any in-flight tick to drain.
+				await sweeper.stop();
+				// Close HTTP server, wait for in-flight requests to drain
+				server.close(() => {
+					try {
+						rmSync(pidPath);
+					} catch {
+						// ignore
+					}
+					closeStore();
+					process.exit(0);
+				});
+				// Force exit after 5s if graceful shutdown stalls
+				setTimeout(() => {
+					try {
+						rmSync(pidPath);
+					} catch {
+						// ignore
+					}
+					closeStore();
+					process.exit(1);
+				}, 5000).unref();
+			};
+			process.on("SIGINT", () => {
+				void shutdown();
+			});
+			process.on("SIGTERM", () => {
+				void shutdown();
+			});
+		},
+	);

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -1,0 +1,10 @@
+import { VERSION } from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+
+export const versionCommand = new Command("version")
+	.configureHelp(helpStyle)
+	.description("Print codemem version")
+	.action(() => {
+		console.log(VERSION);
+	});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,17 +14,32 @@
 import { VERSION } from "@codemem/core";
 import { Command } from "commander";
 import omelette from "omelette";
+import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
 import { mcpCommand } from "./commands/mcp.js";
 import { packCommand } from "./commands/pack.js";
+import { recentCommand } from "./commands/recent.js";
 import { searchCommand } from "./commands/search.js";
 import { serveCommand } from "./commands/serve.js";
 import { statsCommand } from "./commands/stats.js";
+import { versionCommand } from "./commands/version.js";
 import { helpStyle } from "./help-style.js";
 
 // Shell completion (bash/zsh/fish)
 const completion = omelette("codemem <command>");
 completion.on("command", ({ reply }) => {
-	reply(["stats", "search", "pack", "serve", "mcp", "help", "--help", "--version"]);
+	reply([
+		"stats",
+		"recent",
+		"search",
+		"pack",
+		"serve",
+		"mcp",
+		"enqueue-raw-event",
+		"version",
+		"help",
+		"--help",
+		"--version",
+	]);
 });
 completion.init();
 
@@ -50,7 +65,10 @@ program
 program.addCommand(serveCommand);
 program.addCommand(mcpCommand);
 program.addCommand(statsCommand);
+program.addCommand(recentCommand);
 program.addCommand(searchCommand);
 program.addCommand(packCommand);
+program.addCommand(enqueueRawEventCommand);
+program.addCommand(versionCommand);
 
 program.parse();

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.0.1");
+		expect(VERSION).toBe("0.19.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.0.1";
+export const VERSION = "0.19.0";
 
 export * as Api from "./api-types.js";
 export type { InvitePayload } from "./coordinator-invites.js";

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -340,11 +340,13 @@ export function search(
 	);
 	const seen = new Set(primary.map((item) => item.id));
 	const combined = [...primary];
+	let addedShared = 0;
 	for (const item of shared) {
 		if (seen.has(item.id)) continue;
 		seen.add(item.id);
 		combined.push(item);
-		if (combined.length >= Math.max(1, Math.trunc(limit))) break;
+		addedShared += 1;
+		if (addedShared >= WIDEN_SHARED_MAX_SHARED_RESULTS) break;
 	}
 	return combined;
 }
@@ -397,6 +399,19 @@ function searchOnce(
 		const metadata: Record<string, unknown> = {
 			...fromJson(row.metadata_json as string | null),
 		};
+		for (const key of [
+			"actor_id",
+			"actor_display_name",
+			"visibility",
+			"workspace_id",
+			"workspace_kind",
+			"origin_device_id",
+			"origin_source",
+			"trust_state",
+		] as const) {
+			const value = row[key];
+			if (value != null) metadata[key] = value;
+		}
 
 		// Propagate files_modified into metadata when stored as a JSON array
 		if (row.files_modified && typeof row.files_modified === "string") {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -136,11 +136,14 @@ export class MemoryStore {
 		// Resolve actor identity — matches Python load_config() precedence:
 		// config file, then env override, then local fallbacks.
 		const config = readCodememConfigFile();
-		const configActorId = process.env.CODEMEM_ACTOR_ID?.trim() || cleanStr(config.actor_id) || null;
+		const configActorId = Object.hasOwn(process.env, "CODEMEM_ACTOR_ID")
+			? cleanStr(process.env.CODEMEM_ACTOR_ID)
+			: (cleanStr(config.actor_id) ?? null);
 		this.actorId = configActorId || `local:${this.deviceId}`;
 
-		const configDisplayName =
-			process.env.CODEMEM_ACTOR_DISPLAY_NAME?.trim() || cleanStr(config.actor_display_name) || null;
+		const configDisplayName = Object.hasOwn(process.env, "CODEMEM_ACTOR_DISPLAY_NAME")
+			? cleanStr(process.env.CODEMEM_ACTOR_DISPLAY_NAME)
+			: (cleanStr(config.actor_display_name) ?? null);
 		this.actorDisplayName =
 			configDisplayName || process.env.USER?.trim() || process.env.USERNAME?.trim() || this.actorId;
 	}
@@ -317,11 +320,15 @@ export class MemoryStore {
 	 */
 	memoryOwnedBySelf(item: MemoryItem | MemoryResult | Record<string, unknown>): boolean {
 		const rec = item as Record<string, unknown>;
-		const itemActorId = cleanStr(rec.actor_id);
-		if (itemActorId === this.actorId) return true;
+		// Check top-level columns first (MemoryItem / DB row),
+		// then metadata dict (MemoryResult from search populates provenance there).
+		const meta = (rec.metadata ?? {}) as Record<string, unknown>;
 
-		const itemOriginDeviceId = cleanStr(rec.origin_device_id);
-		if (itemOriginDeviceId === this.deviceId) return true;
+		const actorId = cleanStr(rec.actor_id) ?? cleanStr(meta.actor_id);
+		if (actorId === this.actorId) return true;
+
+		const deviceId = cleanStr(rec.origin_device_id) ?? cleanStr(meta.origin_device_id);
+		if (deviceId === this.deviceId) return true;
 
 		return false;
 	}

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -5,7 +5,7 @@
  */
 
 import type { MemoryStore } from "@codemem/core";
-import { fromJson, parsePositiveMemoryId, parseStrictInteger } from "@codemem/core";
+import { fromJson, parseStrictInteger } from "@codemem/core";
 import { Hono } from "hono";
 import { queryInt } from "../helpers.js";
 
@@ -278,8 +278,10 @@ export function memoryRoutes(getStore: StoreFactory) {
 	app.post("/api/memories/visibility", async (c) => {
 		const store = getStore();
 		const body = await c.req.json<Record<string, unknown>>();
-		const memoryId = parsePositiveMemoryId(body.memory_id);
-		if (memoryId == null) {
+		const memoryId = parseStrictInteger(
+			typeof body.memory_id === "string" ? body.memory_id : String(body.memory_id ?? ""),
+		);
+		if (memoryId == null || memoryId <= 0) {
 			return c.json({ error: "memory_id must be int" }, 400);
 		}
 		const visibility = String(body.visibility ?? "").trim();


### PR DESCRIPTION
## Description

Complete the TypeScript CLI surface that the OpenCode plugin already expects, and align backend version reporting with the real released version.

### Version parity
- `packages/core/src/index.ts`
  - `VERSION` now reports `0.19.0` instead of `0.0.1`
- `packages/core/src/index.test.ts`
  - updated version expectation

This fixes plugin compatibility checks that call `codemem version` and compare semver.

### Added CLI commands expected by the plugin
- `version`
  - prints the backend version string
- `recent --limit N [--kind K]`
  - shows recent memories for plugin tools like `mem-recent`
- `enqueue-raw-event`
  - reads one raw-event envelope from stdin and persists it through the durable raw-event queue

### Serve lifecycle compatibility
`packages/cli/src/commands/serve.ts` now accepts the flags the plugin already uses:
- `--background`
- `--stop`
- `--restart`

Implementation notes:
- writes a simple `viewer.pid` file next to the DB
- `--stop` sends `SIGTERM` to the recorded pid and removes the pidfile
- `--restart` stops the old process and then starts a fresh one
- `--background` is accepted for compatibility with the plugin’s process model

### CLI registration
- `packages/cli/src/index.ts`
  - registers `version`, `recent`, and `enqueue-raw-event`
  - updates shell completion suggestions accordingly

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm test` — 405/405)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (`pnpm clean && pnpm build`, command smoke checks)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced