### PR TITLE
feat: port config writes and sweeper runtime updates to TS

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,9 @@ export {
 export type { ObserverConfig, ObserverResponse, ObserverStatus } from "./observer-client.js";
 export { loadObserverConfig, ObserverAuthError, ObserverClient } from "./observer-client.js";
 export {
+	CODEMEM_CONFIG_ENV_OVERRIDES,
+	getCodememConfigPath,
+	getCodememEnvOverrides,
 	getOpenCodeProviderConfig,
 	getProviderApiKey,
 	getProviderBaseUrl,
@@ -124,12 +127,14 @@ export {
 	getProviderOptions,
 	listCustomProviders,
 	loadOpenCodeConfig,
+	readCodememConfigFile,
 	resolveCustomProviderDefaultModel,
 	resolveCustomProviderFromModel,
 	resolveCustomProviderModel,
 	resolvePlaceholder,
 	stripJsonComments,
 	stripTrailingCommas,
+	writeCodememConfigFile,
 } from "./observer-config.js";
 export { buildMemoryPack, estimateTokens } from "./pack.js";
 export {

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -6,9 +6,9 @@
  * environment variable / file placeholders in config values.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 // ---------------------------------------------------------------------------
 // JSONC helpers
@@ -138,6 +138,36 @@ export function expandUserPath(value: string): string {
 	return value.startsWith("~/") ? join(homedir(), value.slice(2)) : value;
 }
 
+/** Env var overrides matching Python's CONFIG_ENV_OVERRIDES. */
+export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
+	actor_id: "CODEMEM_ACTOR_ID",
+	actor_display_name: "CODEMEM_ACTOR_DISPLAY_NAME",
+	claude_command: "CODEMEM_CLAUDE_COMMAND",
+	observer_provider: "CODEMEM_OBSERVER_PROVIDER",
+	observer_model: "CODEMEM_OBSERVER_MODEL",
+	observer_base_url: "CODEMEM_OBSERVER_BASE_URL",
+	observer_runtime: "CODEMEM_OBSERVER_RUNTIME",
+	observer_auth_source: "CODEMEM_OBSERVER_AUTH_SOURCE",
+	observer_auth_file: "CODEMEM_OBSERVER_AUTH_FILE",
+	observer_auth_command: "CODEMEM_OBSERVER_AUTH_COMMAND",
+	observer_auth_timeout_ms: "CODEMEM_OBSERVER_AUTH_TIMEOUT_MS",
+	observer_auth_cache_ttl_s: "CODEMEM_OBSERVER_AUTH_CACHE_TTL_S",
+	observer_headers: "CODEMEM_OBSERVER_HEADERS",
+	observer_max_chars: "CODEMEM_OBSERVER_MAX_CHARS",
+	pack_observation_limit: "CODEMEM_PACK_OBSERVATION_LIMIT",
+	pack_session_limit: "CODEMEM_PACK_SESSION_LIMIT",
+	sync_enabled: "CODEMEM_SYNC_ENABLED",
+	sync_host: "CODEMEM_SYNC_HOST",
+	sync_port: "CODEMEM_SYNC_PORT",
+	sync_interval_s: "CODEMEM_SYNC_INTERVAL_S",
+	sync_mdns: "CODEMEM_SYNC_MDNS",
+	sync_coordinator_url: "CODEMEM_SYNC_COORDINATOR_URL",
+	sync_coordinator_group: "CODEMEM_SYNC_COORDINATOR_GROUP",
+	sync_coordinator_timeout_s: "CODEMEM_SYNC_COORDINATOR_TIMEOUT_S",
+	sync_coordinator_presence_ttl_s: "CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S",
+	raw_events_sweeper_interval_s: "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
+};
+
 /** Resolve codemem config path with CODEMEM_CONFIG override. */
 export function getCodememConfigPath(): string {
 	const envPath = process.env.CODEMEM_CONFIG?.trim();
@@ -179,6 +209,24 @@ export function readCodememConfigFile(): Record<string, unknown> {
 	} catch {
 		return {};
 	}
+}
+
+/** Persist the codemem config file as normalized JSON. */
+export function writeCodememConfigFile(data: Record<string, unknown>, configPath?: string): string {
+	const targetPath = configPath ? expandUserPath(configPath) : getCodememConfigPath();
+	mkdirSync(dirname(targetPath), { recursive: true });
+	writeFileSync(targetPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+	return targetPath;
+}
+
+/** Return active env overrides for codemem config keys. */
+export function getCodememEnvOverrides(): Record<string, string> {
+	const overrides: Record<string, string> = {};
+	for (const [key, envVar] of Object.entries(CODEMEM_CONFIG_ENV_OVERRIDES)) {
+		const val = process.env[envVar];
+		if (val != null && val !== "") overrides[key] = envVar;
+	}
+	return overrides;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/raw-event-sweeper.ts
+++ b/packages/core/src/raw-event-sweeper.ts
@@ -18,6 +18,7 @@
 
 import type { IngestOptions } from "./ingest-pipeline.js";
 import { ObserverAuthError } from "./observer-client.js";
+import { readCodememConfigFile } from "./observer-config.js";
 import { flushRawEvents } from "./raw-event-flush.js";
 import type { MemoryStore } from "./store.js";
 
@@ -69,7 +70,22 @@ export class RawEventSweeper {
 	}
 
 	private intervalMs(): number {
-		return Math.max(1000, envInt("CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS", 30_000));
+		const envValue = process.env.CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS;
+		if (envValue != null) {
+			const parsed = Number.parseInt(envValue, 10);
+			return Number.isFinite(parsed) ? Math.max(1000, parsed) : 30_000;
+		}
+		const configValue = readCodememConfigFile().raw_events_sweeper_interval_s;
+		const configSeconds =
+			typeof configValue === "number"
+				? configValue
+				: typeof configValue === "string"
+					? Number.parseInt(configValue, 10)
+					: Number.NaN;
+		if (Number.isFinite(configSeconds) && configSeconds > 0) {
+			return Math.max(1000, configSeconds * 1000);
+		}
+		return 30_000;
 	}
 
 	private idleMs(): number {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5,9 +5,12 @@
  * Uses Record<string, unknown> instead of Record<string, any> (fix #6).
  */
 
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { initTestSchema, insertTestSession, type MemoryStore } from "@codemem/core";
 import Database from "better-sqlite3";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createApp } from "./index.js";
 
 // ---------------------------------------------------------------------------
@@ -63,10 +66,11 @@ function createTestStore(): MemoryStore {
 }
 
 /** Create a test Hono app backed by a fresh in-memory DB. */
-function createTestApp() {
+function createTestApp(opts?: { sweeper?: unknown }) {
 	let store: MemoryStore | null = null;
 
 	const app = createApp({
+		sweeper: (opts?.sweeper ?? null) as never,
 		storeFactory: () => {
 			// Reuse the same store for the lifetime of the test
 			if (!store) {
@@ -156,6 +160,158 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.active).toBeNull();
 				expect(body).toHaveProperty("queue");
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	describe("POST /api/config", () => {
+		it("writes config and returns effects", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const notifyConfigChanged = vi.fn();
+			const previous = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			const { app, cleanup } = createTestApp({ sweeper: { notifyConfigChanged } });
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({
+						config: { observer_model: "gpt-4.1-mini", raw_events_sweeper_interval_s: 12 },
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect((body.config as Record<string, unknown>).observer_model).toBe("gpt-4.1-mini");
+				expect((body.effects as Record<string, unknown>).hot_reloaded_keys).toEqual([
+					"raw_events_sweeper_interval_s",
+				]);
+				expect(notifyConfigChanged).toHaveBeenCalledTimes(1);
+				expect(readFileSync(configPath, "utf8")).toContain('"observer_model": "gpt-4.1-mini"');
+			} finally {
+				cleanup();
+				if (previous == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previous;
+			}
+		});
+
+		it("clears hot-reload env override when interval key is removed", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevInterval = process.env.CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS = "12000";
+			const notifyConfigChanged = vi.fn();
+			const { app, cleanup } = createTestApp({ sweeper: { notifyConfigChanged } });
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({ config: { raw_events_sweeper_interval_s: null } }),
+				});
+				expect(res.status).toBe(200);
+				expect(process.env.CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS).toBeUndefined();
+				expect(notifyConfigChanged).toHaveBeenCalledTimes(1);
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevInterval == null) delete process.env.CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS;
+				else process.env.CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS = prevInterval;
+			}
+		});
+
+		it("returns warnings for env-overridden keys", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevModel = process.env.CODEMEM_OBSERVER_MODEL;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_OBSERVER_MODEL = "env-model";
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({ config: { observer_model: "saved-model" } }),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect((body.effective as Record<string, unknown>).observer_model).toBe("env-model");
+				expect((body.effects as Record<string, unknown>).ignored_by_env_keys).toEqual([
+					"observer_model",
+				]);
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevModel == null) delete process.env.CODEMEM_OBSERVER_MODEL;
+				else process.env.CODEMEM_OBSERVER_MODEL = prevModel;
+			}
+		});
+
+		it("validates payload types", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({ config: { observer_headers: { Authorization: 123 } } }),
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.error).toBe("observer_headers must be object of string values");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects non-object config wrapper payloads", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({ config: "bad" }),
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.error).toBe("config must be an object");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("parses integer fields strictly", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({ config: { observer_max_chars: "123abc" } }),
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.error).toBe("observer_max_chars must be int");
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -62,7 +62,7 @@ export function createApp(opts?: AppOptions) {
 	app.route("/", statsRoutes(storeFactory));
 	app.route("/", memoryRoutes(storeFactory));
 	app.route("/", observerStatusRoutes({ getStore: storeFactory, getSweeper: () => sweeper }));
-	app.route("/", configRoutes());
+	app.route("/", configRoutes({ getSweeper: () => sweeper }));
 	app.route("/", rawEventsRoutes(storeFactory, sweeper));
 	app.route("/", syncRoutes(storeFactory));
 

--- a/packages/viewer-server/src/routes/config.ts
+++ b/packages/viewer-server/src/routes/config.ts
@@ -1,42 +1,83 @@
 /**
  * Config routes — GET /api/config, POST /api/config.
  *
- * Ports Python's viewer_routes/config.py.
- * GET returns actual config from disk + effective values + env overrides.
- * POST is not yet fully ported — returns 501.
+ * Ports the user-facing config read/write path from Python's
+ * codemem/viewer_routes/config.py, scoped to the TS runtime's current needs.
  */
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { stripJsonComments, stripTrailingCommas } from "@codemem/core";
+import {
+	CODEMEM_CONFIG_ENV_OVERRIDES,
+	getCodememConfigPath,
+	getCodememEnvOverrides,
+	type RawEventSweeper,
+	readCodememConfigFile,
+	stripJsonComments,
+	stripTrailingCommas,
+	writeCodememConfigFile,
+} from "@codemem/core";
 import { Hono } from "hono";
 
-/** Env var overrides matching Python's CONFIG_ENV_OVERRIDES. */
-const CONFIG_ENV_OVERRIDES: Record<string, string> = {
-	actor_id: "CODEMEM_ACTOR_ID",
-	actor_display_name: "CODEMEM_ACTOR_DISPLAY_NAME",
-	observer_base_url: "CODEMEM_OBSERVER_BASE_URL",
-	observer_provider: "CODEMEM_OBSERVER_PROVIDER",
-	observer_model: "CODEMEM_OBSERVER_MODEL",
-	observer_api_key: "CODEMEM_OBSERVER_API_KEY",
-	observer_runtime: "CODEMEM_OBSERVER_RUNTIME",
-	observer_auth_source: "CODEMEM_OBSERVER_AUTH_SOURCE",
-	observer_auth_file: "CODEMEM_OBSERVER_AUTH_FILE",
-	observer_max_chars: "CODEMEM_OBSERVER_MAX_CHARS",
-	sync_enabled: "CODEMEM_SYNC_ENABLED",
-	sync_host: "CODEMEM_SYNC_HOST",
-	sync_port: "CODEMEM_SYNC_PORT",
-	sync_interval_s: "CODEMEM_SYNC_INTERVAL_S",
-	sync_mdns: "CODEMEM_SYNC_MDNS",
-	raw_events_sweeper_interval_s: "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS",
+type ConfigData = Record<string, unknown>;
+
+const RUNTIMES = new Set(["api_http", "claude_sidecar"]);
+const AUTH_SOURCES = new Set(["auto", "env", "file", "command", "none"]);
+const HOT_RELOAD_KEYS = new Set(["raw_events_sweeper_interval_s"]);
+const ALLOWED_KEYS = [
+	"claude_command",
+	"observer_base_url",
+	"observer_provider",
+	"observer_model",
+	"observer_runtime",
+	"observer_auth_source",
+	"observer_auth_file",
+	"observer_auth_command",
+	"observer_auth_timeout_ms",
+	"observer_auth_cache_ttl_s",
+	"observer_headers",
+	"observer_max_chars",
+	"pack_observation_limit",
+	"pack_session_limit",
+	"sync_enabled",
+	"sync_host",
+	"sync_port",
+	"sync_interval_s",
+	"sync_mdns",
+	"sync_coordinator_url",
+	"sync_coordinator_group",
+	"sync_coordinator_timeout_s",
+	"sync_coordinator_presence_ttl_s",
+	"raw_events_sweeper_interval_s",
+] as const;
+
+const DEFAULTS: ConfigData = {
+	claude_command: ["claude"],
+	observer_runtime: "api_http",
+	observer_auth_source: "auto",
+	observer_auth_command: [],
+	observer_auth_timeout_ms: 1500,
+	observer_auth_cache_ttl_s: 300,
+	observer_headers: {},
+	observer_max_chars: 12000,
+	pack_observation_limit: 50,
+	pack_session_limit: 10,
+	sync_enabled: false,
+	sync_host: "0.0.0.0",
+	sync_port: 7337,
+	sync_interval_s: 120,
+	sync_mdns: true,
+	sync_coordinator_timeout_s: 3,
+	sync_coordinator_presence_ttl_s: 180,
+	raw_events_sweeper_interval_s: 30,
 };
 
-/** Known provider names from OpenCode config. */
+export interface ConfigRouteOptions {
+	getSweeper?: () => RawEventSweeper | null;
+}
+
 function loadProviderOptions(): string[] {
-	// Simplified: return well-known providers.
-	// Python loads this from OpenCode's config.json — we can match
-	// that once the config subsystem is fully ported.
 	return ["openai", "anthropic", "google", "xai", "groq", "deepseek", "mistral", "together"];
 }
 
@@ -48,64 +89,263 @@ function getConfigPath(): string {
 	return candidates.find((p) => existsSync(p)) ?? join(configDir, "config.json");
 }
 
-function readConfigFile(configPath: string): Record<string, unknown> {
+function readConfigFile(configPath: string): ConfigData {
 	if (!existsSync(configPath)) return {};
 	try {
 		let text = readFileSync(configPath, "utf-8").trim();
 		if (!text) return {};
 		try {
-			return JSON.parse(text) as Record<string, unknown>;
+			return JSON.parse(text) as ConfigData;
 		} catch {
 			text = stripTrailingCommas(stripJsonComments(text));
-			return JSON.parse(text) as Record<string, unknown>;
+			return JSON.parse(text) as ConfigData;
 		}
 	} catch {
 		return {};
 	}
 }
 
-function getEnvOverrides(): Record<string, string> {
-	const overrides: Record<string, string> = {};
-	for (const [key, envVar] of Object.entries(CONFIG_ENV_OVERRIDES)) {
+function getEffectiveConfig(configData: ConfigData): ConfigData {
+	const effective: ConfigData = { ...DEFAULTS, ...configData };
+	for (const [key, envVar] of Object.entries(CODEMEM_CONFIG_ENV_OVERRIDES) as Array<
+		[string, string]
+	>) {
 		const val = process.env[envVar];
-		if (val != null && val !== "") {
-			overrides[key] = envVar;
-		}
+		if (val != null && val !== "") effective[key] = val;
 	}
-	return overrides;
+	return effective;
 }
 
-export function configRoutes() {
+function parsePositiveInt(value: unknown, allowZero = false): number | null {
+	if (typeof value === "boolean") return null;
+	const parsed =
+		typeof value === "number"
+			? value
+			: typeof value === "string" && /^-?\d+$/.test(value.trim())
+				? Number(value.trim())
+				: Number.NaN;
+	if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) return null;
+	if (allowZero) return parsed >= 0 ? parsed : null;
+	return parsed > 0 ? parsed : null;
+}
+
+function asStringMap(value: unknown): Record<string, string> | null {
+	if (value == null || typeof value !== "object" || Array.isArray(value)) return null;
+	const parsed: Record<string, string> = {};
+	for (const [key, item] of Object.entries(value)) {
+		if (typeof item !== "string") return null;
+		const stripped = key.trim();
+		if (!stripped) return null;
+		parsed[stripped] = item;
+	}
+	return parsed;
+}
+
+function asExecutableArgv(value: unknown): string[] | null {
+	if (!Array.isArray(value)) return null;
+	const argv: string[] = [];
+	for (const item of value) {
+		if (typeof item !== "string") return null;
+		const token = item.trim();
+		if (!token) return null;
+		argv.push(token);
+	}
+	return argv;
+}
+
+function validateAndApplyUpdate(
+	configData: ConfigData,
+	key: (typeof ALLOWED_KEYS)[number],
+	value: unknown,
+	providers: Set<string>,
+): string | null {
+	if (value == null || value === "") {
+		delete configData[key];
+		return null;
+	}
+	if (key === "observer_provider") {
+		if (typeof value !== "string") return "observer_provider must be string";
+		const provider = value.trim().toLowerCase();
+		const savedBaseUrl = configData.observer_base_url;
+		const hasSavedBaseUrl = typeof savedBaseUrl === "string" && savedBaseUrl.trim().length > 0;
+		if (!providers.has(provider) && !hasSavedBaseUrl) {
+			return "observer_provider must match a configured provider";
+		}
+		configData[key] = provider;
+		return null;
+	}
+	if (key === "observer_runtime") {
+		if (typeof value !== "string") return "observer_runtime must be string";
+		const runtime = value.trim().toLowerCase();
+		if (!RUNTIMES.has(runtime)) {
+			return "observer_runtime must be one of: api_http, claude_sidecar";
+		}
+		configData[key] = runtime;
+		return null;
+	}
+	if (key === "observer_auth_source") {
+		if (typeof value !== "string") return "observer_auth_source must be string";
+		const source = value.trim().toLowerCase();
+		if (!AUTH_SOURCES.has(source)) {
+			return "observer_auth_source must be one of: auto, env, file, command, none";
+		}
+		configData[key] = source;
+		return null;
+	}
+	if (key === "claude_command" || key === "observer_auth_command") {
+		const argv = asExecutableArgv(value);
+		if (argv == null) return `${key} must be string array`;
+		if (argv.length > 0) configData[key] = argv;
+		else delete configData[key];
+		return null;
+	}
+	if (key === "observer_headers") {
+		const headers = asStringMap(value);
+		if (headers == null) return "observer_headers must be object of string values";
+		if (Object.keys(headers).length > 0) configData[key] = headers;
+		else delete configData[key];
+		return null;
+	}
+	if (key === "sync_enabled" || key === "sync_mdns") {
+		if (typeof value !== "boolean") return `${key} must be boolean`;
+		configData[key] = value;
+		return null;
+	}
+	if (
+		key === "observer_base_url" ||
+		key === "observer_model" ||
+		key === "observer_auth_file" ||
+		key === "sync_host" ||
+		key === "sync_coordinator_url" ||
+		key === "sync_coordinator_group"
+	) {
+		if (typeof value !== "string") return `${key} must be string`;
+		const trimmed = value.trim();
+		if (!trimmed) delete configData[key];
+		else configData[key] = trimmed;
+		return null;
+	}
+	const allowZero = key === "observer_auth_cache_ttl_s";
+	const parsed = parsePositiveInt(value, allowZero);
+	if (parsed == null) return `${key} must be ${allowZero ? "non-negative int" : "int"}`;
+	configData[key] = parsed;
+	return null;
+}
+
+function applyRuntimeEffects(changedKeys: string[], opts: ConfigRouteOptions): string[] {
+	const applied: string[] = [];
+	if (changedKeys.includes("raw_events_sweeper_interval_s")) {
+		const configValue = readCodememConfigFile().raw_events_sweeper_interval_s;
+		const seconds =
+			typeof configValue === "number"
+				? configValue
+				: Number.parseInt(String(configValue ?? ""), 10);
+		if (Number.isFinite(seconds) && seconds > 0) {
+			process.env.CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS = String(seconds * 1000);
+		} else {
+			delete process.env.CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_MS;
+		}
+		opts.getSweeper?.()?.notifyConfigChanged();
+		applied.push("raw_events_sweeper_interval_s");
+	}
+	return applied;
+}
+
+export function configRoutes(opts: ConfigRouteOptions = {}) {
 	const app = new Hono();
 
 	app.get("/api/config", (c) => {
 		const configPath = getConfigPath();
 		const configData = readConfigFile(configPath);
-		const envOverrides = getEnvOverrides();
-
-		// Build effective values: config file + env overrides
-		const effective = { ...configData };
-		for (const [key, envVar] of Object.entries(CONFIG_ENV_OVERRIDES)) {
-			const val = process.env[envVar];
-			if (val != null && val !== "") {
-				effective[key] = val;
-			}
-		}
-
 		return c.json({
 			path: configPath,
 			config: configData,
-			defaults: {},
-			effective,
-			env_overrides: envOverrides,
+			defaults: DEFAULTS,
+			effective: getEffectiveConfig(configData),
+			env_overrides: getCodememEnvOverrides(),
 			providers: loadProviderOptions(),
 		});
 	});
 
 	app.post("/api/config", async (c) => {
-		// Config save not yet fully ported to TS.
-		// Python's implementation has 300+ lines of validation + runtime effects.
-		return c.json({ error: "config save not yet implemented in TS viewer" }, 501);
+		let payload: unknown;
+		try {
+			payload = (await c.req.json()) as unknown;
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		if (payload == null || typeof payload !== "object" || Array.isArray(payload)) {
+			return c.json({ error: "payload must be an object" }, 400);
+		}
+		if (
+			"config" in payload &&
+			(payload as ConfigData).config != null &&
+			(typeof (payload as ConfigData).config !== "object" ||
+				Array.isArray((payload as ConfigData).config))
+		) {
+			return c.json({ error: "config must be an object" }, 400);
+		}
+		const updates =
+			"config" in payload &&
+			(payload as ConfigData).config != null &&
+			typeof (payload as ConfigData).config === "object" &&
+			!Array.isArray((payload as ConfigData).config)
+				? ((payload as ConfigData).config as ConfigData)
+				: (payload as ConfigData);
+
+		const configPath = getCodememConfigPath();
+		const beforeConfig = readCodememConfigFile();
+		const beforeEffective = getEffectiveConfig(beforeConfig);
+		const nextConfig: ConfigData = { ...beforeConfig };
+		const providers = new Set(loadProviderOptions());
+
+		const touchedKeys = ALLOWED_KEYS.filter((key) => key in updates);
+		for (const key of ALLOWED_KEYS) {
+			if (!(key in updates)) continue;
+			const error = validateAndApplyUpdate(nextConfig, key, updates[key], providers);
+			if (error) return c.json({ error }, 400);
+		}
+
+		let savedPath: string;
+		try {
+			savedPath = writeCodememConfigFile(nextConfig, configPath);
+		} catch {
+			return c.json({ error: "failed to write config" }, 500);
+		}
+
+		const afterEffective = getEffectiveConfig(nextConfig);
+		const savedChangedKeys = ALLOWED_KEYS.filter((key) => beforeConfig[key] !== nextConfig[key]);
+		const effectiveChangedKeys = ALLOWED_KEYS.filter(
+			(key) => beforeEffective[key] !== afterEffective[key],
+		);
+		const envOverrides = getCodememEnvOverrides();
+		const ignoredByEnvKeys = savedChangedKeys.filter(
+			(key) => !effectiveChangedKeys.includes(key) && key in envOverrides,
+		);
+		const runtimeChangedKeys = [
+			...new Set([...touchedKeys, ...savedChangedKeys, ...effectiveChangedKeys]),
+		];
+		const hotReloadedKeys = applyRuntimeEffects(runtimeChangedKeys, opts);
+		const restartRequiredKeys = effectiveChangedKeys.filter(
+			(key) => !HOT_RELOAD_KEYS.has(key) && !(key in envOverrides),
+		);
+
+		return c.json({
+			path: savedPath,
+			config: nextConfig,
+			effective: afterEffective,
+			effects: {
+				saved_keys: savedChangedKeys,
+				effective_keys: effectiveChangedKeys,
+				hot_reloaded_keys: hotReloadedKeys,
+				restart_required_keys: restartRequiredKeys,
+				ignored_by_env_keys: ignoredByEnvKeys,
+				warnings: ignoredByEnvKeys.map(
+					(key) =>
+						`${key} is currently controlled by ${envOverrides[key]}; saved config will not take effect until that override is removed.`,
+				),
+			},
+		});
 	});
 
 	return app;


### PR DESCRIPTION
## Description

Replaces the TS viewer-server's `POST /api/config` stub with real config persistence so saved settings survive restarts and raw-event sweeper interval changes take effect immediately without falling back to Python.

This PR adds codemem config write/env-override helpers to `@codemem/core`, teaches the sweeper to read `raw_events_sweeper_interval_s` from config when no env override is present, and returns Python-style effect metadata (saved keys, effective keys, env-override warnings, hot-reloaded keys) from the config route.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm clean && pnpm build && pnpm test && pnpm lint`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm lint` — 14 pre-existing warnings, no new warnings from this PR)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced