### PR TITLE
feat: add baseline TS database maintenance commands

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -1,0 +1,81 @@
+import * as p from "@clack/prompts";
+import {
+	getRawEventStatus,
+	initDatabase,
+	retryRawEventFailures,
+	vacuumDatabase,
+} from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+
+export const dbCommand = new Command("db")
+	.configureHelp(helpStyle)
+	.description("Database maintenance");
+
+dbCommand
+	.addCommand(
+		new Command("init")
+			.configureHelp(helpStyle)
+			.description("Verify the SQLite database is present and schema-ready")
+			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.action((opts: { db?: string }) => {
+				const result = initDatabase(opts.db);
+				p.intro("codemem db init");
+				p.log.success(`Database ready: ${result.path}`);
+				p.outro(`Size: ${result.sizeBytes.toLocaleString()} bytes`);
+			}),
+	)
+	.addCommand(
+		new Command("vacuum")
+			.configureHelp(helpStyle)
+			.description("Run VACUUM on the SQLite database")
+			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.action((opts: { db?: string }) => {
+				const result = vacuumDatabase(opts.db);
+				p.intro("codemem db vacuum");
+				p.log.success(`Vacuumed: ${result.path}`);
+				p.outro(`Size: ${result.sizeBytes.toLocaleString()} bytes`);
+			}),
+	)
+	.addCommand(
+		new Command("raw-events-status")
+			.configureHelp(helpStyle)
+			.description("Show pending raw-event backlog by source stream")
+			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("-n, --limit <n>", "max rows to show", "25")
+			.option("--json", "output as JSON")
+			.action((opts: { db?: string; limit: string; json?: boolean }) => {
+				const result = getRawEventStatus(opts.db, Number.parseInt(opts.limit, 10) || 25);
+				if (opts.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+				p.intro("codemem db raw-events-status");
+				p.log.info(
+					`Totals: ${result.totals.pending.toLocaleString()} pending across ${result.totals.sessions.toLocaleString()} session(s)`,
+				);
+				if (result.items.length === 0) {
+					p.outro("No pending raw events");
+					return;
+				}
+				for (const item of result.items) {
+					p.log.message(
+						`${item.source}:${item.stream_id} pending=${Math.max(0, item.last_received_event_seq - item.last_flushed_event_seq)} ` +
+							`received=${item.last_received_event_seq} flushed=${item.last_flushed_event_seq} project=${item.project ?? ""}`,
+					);
+				}
+				p.outro("done");
+			}),
+	)
+	.addCommand(
+		new Command("raw-events-retry")
+			.configureHelp(helpStyle)
+			.description("Requeue failed raw-event flush batches")
+			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("-n, --limit <n>", "max failed batches to requeue", "25")
+			.action((opts: { db?: string; limit: string }) => {
+				const result = retryRawEventFailures(opts.db, Number.parseInt(opts.limit, 10) || 25);
+				p.intro("codemem db raw-events-retry");
+				p.outro(`Requeued ${result.retried.toLocaleString()} failed batch(es)`);
+			}),
+	);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@
 import { VERSION } from "@codemem/core";
 import { Command } from "commander";
 import omelette from "omelette";
+import { dbCommand } from "./commands/db.js";
 import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
 import { exportMemoriesCommand } from "./commands/export-memories.js";
 import { importMemoriesCommand } from "./commands/import-memories.js";
@@ -30,6 +31,7 @@ import { helpStyle } from "./help-style.js";
 const completion = omelette("codemem <command>");
 completion.on("command", ({ reply }) => {
 	reply([
+		"db",
 		"export-memories",
 		"import-memories",
 		"stats",
@@ -68,6 +70,7 @@ program
 
 program.addCommand(serveCommand);
 program.addCommand(mcpCommand);
+program.addCommand(dbCommand);
 program.addCommand(exportMemoriesCommand);
 program.addCommand(importMemoriesCommand);
 program.addCommand(statsCommand);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,6 +100,13 @@ export type {
 } from "./ingest-types.js";
 export { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
 export { parsePositiveMemoryId, parseStrictInteger } from "./integers.js";
+export type { RawEventStatusItem, RawEventStatusResult } from "./maintenance.js";
+export {
+	getRawEventStatus,
+	initDatabase,
+	retryRawEventFailures,
+	vacuumDatabase,
+} from "./maintenance.js";
 export type { ObserverAuthMaterial } from "./observer-auth.js";
 export {
 	buildCodexHeaders,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import {
+	getRawEventStatus,
+	initDatabase,
+	retryRawEventFailures,
+	vacuumDatabase,
+} from "./maintenance.js";
+import { initTestSchema } from "./test-utils.js";
+
+function createDbPath(name: string): string {
+	const dir = mkdtempSync(join(tmpdir(), "codemem-maintenance-"));
+	return join(dir, `${name}.sqlite`);
+}
+
+function seedMaintenanceDb(dbPath: string): void {
+	const db = new Database(dbPath);
+	try {
+		initTestSchema(db);
+		db.exec(`
+			INSERT INTO sessions(id, started_at, cwd, project, user, tool_version) VALUES
+			  (1, '2026-03-01T10:00:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
+			INSERT INTO raw_event_sessions(
+				source, stream_id, opencode_session_id, cwd, project, started_at,
+				last_seen_ts_wall_ms, last_received_event_seq, last_flushed_event_seq, updated_at
+			) VALUES (
+				'opencode', 'sess-1', 'sess-1', '/tmp/repo', 'codemem', '2026-03-01T10:00:00Z',
+				1000, 4, 1, '2026-03-01T10:10:00Z'
+			);
+			INSERT INTO raw_events(source, stream_id, opencode_session_id, event_id, event_seq, event_type, ts_wall_ms, payload_json, created_at) VALUES
+			  ('opencode', 'sess-1', 'sess-1', 'e1', 1, 'tool.execute.after', 1000, '{}', '2026-03-01T10:00:01Z'),
+			  ('opencode', 'sess-1', 'sess-1', 'e2', 2, 'tool.execute.after', 1001, '{}', '2026-03-01T10:00:02Z'),
+			  ('opencode', 'sess-1', 'sess-1', 'e3', 3, 'tool.execute.after', 1002, '{}', '2026-03-01T10:00:03Z'),
+			  ('opencode', 'sess-1', 'sess-1', 'e4', 4, 'tool.execute.after', 1003, '{}', '2026-03-01T10:00:04Z');
+			INSERT INTO raw_event_flush_batches(
+				source, stream_id, opencode_session_id, start_event_seq, end_event_seq,
+				extractor_version, status, error_message, updated_at, created_at
+			) VALUES (
+				'opencode', 'sess-1', 'sess-1', 2, 4,
+				'raw_events_v1', 'failed', 'boom', '2026-03-01T10:10:00Z', '2026-03-01T10:05:00Z'
+			);
+		`);
+	} finally {
+		db.close();
+	}
+}
+
+describe("maintenance", () => {
+	it("returns raw event backlog status", () => {
+		const dbPath = createDbPath("status");
+		seedMaintenanceDb(dbPath);
+
+		const result = getRawEventStatus(dbPath, 10);
+
+		expect(result.totals).toEqual({ pending: 3, sessions: 1 });
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]?.session_stream_id).toBe("sess-1");
+		expect(result.items[0]?.project).toBe("codemem");
+	});
+
+	it("requeues failed raw event batches", () => {
+		const dbPath = createDbPath("retry");
+		seedMaintenanceDb(dbPath);
+
+		const result = retryRawEventFailures(dbPath, 10);
+		expect(result.retried).toBe(1);
+
+		const db = new Database(dbPath, { readonly: true });
+		try {
+			const row = db
+				.prepare("SELECT status, error_message FROM raw_event_flush_batches LIMIT 1")
+				.get() as {
+				status: string;
+				error_message: string | null;
+			};
+			expect(row).toEqual({ status: "pending", error_message: null });
+		} finally {
+			db.close();
+		}
+	});
+
+	it("initializes and vacuums a schema-ready database", () => {
+		const dbPath = createDbPath("init-vacuum");
+		seedMaintenanceDb(dbPath);
+
+		const init = initDatabase(dbPath);
+		expect(init.path).toBe(dbPath);
+		expect(init.sizeBytes).toBeGreaterThan(0);
+
+		const vacuum = vacuumDatabase(dbPath);
+		expect(vacuum.path).toBe(dbPath);
+		expect(vacuum.sizeBytes).toBeGreaterThan(0);
+	});
+});

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -1,0 +1,147 @@
+import { statSync } from "node:fs";
+import { assertSchemaReady, connect, type Database, resolveDbPath } from "./db.js";
+
+export interface RawEventStatusItem {
+	source: string;
+	stream_id: string;
+	opencode_session_id: string | null;
+	cwd: string | null;
+	project: string | null;
+	started_at: string | null;
+	last_seen_ts_wall_ms: number | null;
+	last_received_event_seq: number;
+	last_flushed_event_seq: number;
+	updated_at: string;
+	session_stream_id: string;
+	session_id: string;
+}
+
+export interface RawEventStatusResult {
+	items: RawEventStatusItem[];
+	totals: { pending: number; sessions: number };
+	ingest: { available: true; mode: "stream_queue"; max_body_bytes: number };
+}
+
+function withDb<T>(dbPath: string | undefined, fn: (db: Database, resolvedPath: string) => T): T {
+	const resolvedPath = resolveDbPath(dbPath);
+	const db = connect(resolvedPath);
+	try {
+		assertSchemaReady(db);
+		return fn(db, resolvedPath);
+	} finally {
+		db.close();
+	}
+}
+
+export function initDatabase(dbPath?: string): { path: string; sizeBytes: number } {
+	return withDb(dbPath, (_db, resolvedPath) => {
+		const stats = statSync(resolvedPath);
+		return { path: resolvedPath, sizeBytes: stats.size };
+	});
+}
+
+export function vacuumDatabase(dbPath?: string): { path: string; sizeBytes: number } {
+	return withDb(dbPath, (db, resolvedPath) => {
+		db.exec("VACUUM");
+		const stats = statSync(resolvedPath);
+		return { path: resolvedPath, sizeBytes: stats.size };
+	});
+}
+
+export function getRawEventStatus(dbPath?: string, limit = 25): RawEventStatusResult {
+	return withDb(dbPath, (db) => {
+		const rows = db
+			.prepare(
+				`WITH max_events AS (
+					SELECT source, stream_id, MAX(event_seq) AS max_seq
+					FROM raw_events
+					GROUP BY source, stream_id
+				)
+				SELECT s.source, s.stream_id, s.opencode_session_id, s.cwd, s.project,
+					s.started_at, s.last_seen_ts_wall_ms,
+					s.last_received_event_seq, s.last_flushed_event_seq, s.updated_at
+				FROM raw_event_sessions s
+				JOIN max_events e ON e.source = s.source AND e.stream_id = s.stream_id
+				WHERE e.max_seq > s.last_flushed_event_seq
+				ORDER BY s.updated_at DESC
+				 LIMIT ?`,
+			)
+			.all(limit) as Array<Record<string, unknown>>;
+
+		const items = rows.map((row) => {
+			const streamId = String(row.stream_id ?? row.opencode_session_id ?? "");
+			return {
+				source: String(row.source ?? "opencode"),
+				stream_id: streamId,
+				opencode_session_id:
+					row.opencode_session_id == null ? null : String(row.opencode_session_id),
+				cwd: row.cwd == null ? null : String(row.cwd),
+				project: row.project == null ? null : String(row.project),
+				started_at: row.started_at == null ? null : String(row.started_at),
+				last_seen_ts_wall_ms:
+					row.last_seen_ts_wall_ms == null ? null : Number(row.last_seen_ts_wall_ms),
+				last_received_event_seq: Number(row.last_received_event_seq ?? -1),
+				last_flushed_event_seq: Number(row.last_flushed_event_seq ?? -1),
+				updated_at: String(row.updated_at ?? ""),
+				session_stream_id: streamId,
+				session_id: streamId,
+			};
+		});
+
+		const totalsRow = db
+			.prepare(
+				`WITH max_events AS (
+					SELECT source, stream_id, MAX(event_seq) AS max_seq
+					FROM raw_events
+					GROUP BY source, stream_id
+				)
+				SELECT
+					COUNT(1) AS sessions,
+					SUM(e.max_seq - s.last_flushed_event_seq) AS pending
+				FROM raw_event_sessions s
+				JOIN max_events e ON e.source = s.source AND e.stream_id = s.stream_id
+				WHERE e.max_seq > s.last_flushed_event_seq`,
+			)
+			.get() as { sessions: number | null; pending: number | null } | undefined;
+
+		return {
+			items,
+			totals: {
+				pending: Number(totalsRow?.pending ?? 0),
+				sessions: Number(totalsRow?.sessions ?? 0),
+			},
+			ingest: {
+				available: true,
+				mode: "stream_queue",
+				max_body_bytes: 2_000_000,
+			},
+		};
+	});
+}
+
+export function retryRawEventFailures(dbPath?: string, limit = 25): { retried: number } {
+	return withDb(dbPath, (db) => {
+		const now = new Date().toISOString();
+		const result = db
+			.prepare(
+				`WITH candidates AS (
+					SELECT id
+					FROM raw_event_flush_batches
+					WHERE status IN ('failed', 'error')
+					ORDER BY updated_at ASC
+					LIMIT ?
+				)
+				UPDATE raw_event_flush_batches
+				SET status = 'pending',
+					updated_at = ?,
+					error_message = NULL,
+					error_type = NULL,
+					observer_provider = NULL,
+					observer_model = NULL,
+					observer_runtime = NULL
+				WHERE id IN (SELECT id FROM candidates)`,
+			)
+			.run(limit, now);
+		return { retried: result.changes };
+	});
+}

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -152,16 +152,19 @@ export function initTestSchema(db: Database): void {
 		);
 
 		CREATE TABLE IF NOT EXISTS raw_event_flush_batches (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			source TEXT NOT NULL,
-			stream_id TEXT NOT NULL,
-			opencode_session_id TEXT,
+			id INTEGER PRIMARY KEY,
+			source TEXT NOT NULL DEFAULT 'opencode',
+			stream_id TEXT NOT NULL DEFAULT '',
+			opencode_session_id TEXT NOT NULL,
 			start_event_seq INTEGER NOT NULL,
 			end_event_seq INTEGER NOT NULL,
-			extractor_version TEXT,
-			status TEXT NOT NULL DEFAULT 'pending',
+			extractor_version TEXT NOT NULL,
+			status TEXT NOT NULL,
 			error_message TEXT,
-			error_category TEXT,
+			error_type TEXT,
+			observer_provider TEXT,
+			observer_model TEXT,
+			observer_runtime TEXT,
 			created_at TEXT NOT NULL,
 			updated_at TEXT NOT NULL,
 			UNIQUE(source, stream_id, start_event_seq, end_event_seq, extractor_version)


### PR DESCRIPTION
## Description

Adds the first TS `codemem db` maintenance slice so operators can verify schema readiness, inspect raw-event backlog, requeue failed flush batches, and vacuum the shared SQLite database without dropping back to Python.

This PR adds `@codemem/core` maintenance helpers plus CLI subcommands for `db init`, `db vacuum`, `db raw-events-status`, and `db raw-events-retry`. It intentionally leaves `raw-events-gate` for a follow-up under `codemem-l3b7`, since the TS runtime does not yet expose Python's reliability-metrics surface.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm clean && pnpm build && pnpm test && pnpm lint`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm lint` — 14 pre-existing warnings, no new warnings from this PR)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced