### PR TITLE
feat: add semantic/vector retrieval primitives to TS core

### DIFF
--- a/packages/core/src/embeddings.test.ts
+++ b/packages/core/src/embeddings.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for embeddings.ts — text chunking, hashing, serialization.
+ *
+ * These tests cover the pure-function utilities that don't require an
+ * actual embedding model.  Integration tests with a real model belong
+ * in a separate test file gated on CODEMEM_EMBEDDING_DISABLED.
+ */
+
+import { describe, expect, it } from "vitest";
+import { chunkText, hashText, serializeFloat32 } from "./embeddings.js";
+
+describe("hashText", () => {
+	it("returns a 64-char hex SHA-256 digest", () => {
+		const h = hashText("hello world");
+		expect(h).toHaveLength(64);
+		expect(h).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("produces identical hashes for identical inputs", () => {
+		expect(hashText("abc")).toBe(hashText("abc"));
+	});
+
+	it("produces different hashes for different inputs", () => {
+		expect(hashText("abc")).not.toBe(hashText("def"));
+	});
+});
+
+describe("chunkText", () => {
+	it("returns empty array for empty/whitespace input", () => {
+		expect(chunkText("")).toEqual([]);
+		expect(chunkText("   ")).toEqual([]);
+	});
+
+	it("returns single chunk for short text", () => {
+		const chunks = chunkText("Short text.", 100);
+		expect(chunks).toEqual(["Short text."]);
+	});
+
+	it("splits on paragraph boundaries", () => {
+		const text = "Paragraph one.\n\nParagraph two.\n\nParagraph three.";
+		const chunks = chunkText(text, 25);
+		expect(chunks.length).toBeGreaterThanOrEqual(2);
+		expect(chunks[0]).toBe("Paragraph one.");
+	});
+
+	it("splits long paragraphs on sentence boundaries", () => {
+		const sentences = Array.from({ length: 20 }, (_, i) => `Sentence ${i}.`);
+		const text = sentences.join(" ");
+		const chunks = chunkText(text, 60);
+		expect(chunks.length).toBeGreaterThan(1);
+		for (const chunk of chunks) {
+			expect(chunk.length).toBeLessThanOrEqual(60);
+		}
+	});
+
+	it("handles text with no natural break points", () => {
+		const text = "a".repeat(200);
+		// No sentence/paragraph breaks — should still produce chunks
+		const chunks = chunkText(text, 100);
+		expect(chunks.length).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("serializeFloat32", () => {
+	it("produces a Buffer of 4 bytes per element", () => {
+		const vec = new Float32Array([1.0, 2.0, 3.0]);
+		const buf = serializeFloat32(vec);
+		expect(buf).toBeInstanceOf(Buffer);
+		expect(buf.length).toBe(12);
+	});
+
+	it("round-trips through DataView", () => {
+		const vec = new Float32Array([1.5, -2.5, 0.0]);
+		const buf = serializeFloat32(vec);
+		const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+		expect(view.getFloat32(0, true)).toBeCloseTo(1.5);
+		expect(view.getFloat32(4, true)).toBeCloseTo(-2.5);
+		expect(view.getFloat32(8, true)).toBeCloseTo(0.0);
+	});
+
+	it("handles empty vector", () => {
+		const buf = serializeFloat32(new Float32Array(0));
+		expect(buf.length).toBe(0);
+	});
+});

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -1,0 +1,185 @@
+/**
+ * Embedding primitives for semantic search.
+ *
+ * Ports codemem/semantic.py — text chunking, hashing, and embedding via a
+ * pluggable client interface.  The default client uses `@xenova/transformers`
+ * (same BAAI/bge-small-en-v1.5 model as Python's fastembed).  When the
+ * embedding runtime is unavailable the helpers return empty arrays and callers
+ * fall back to FTS-only retrieval.
+ *
+ * Embeddings are always disabled when CODEMEM_EMBEDDING_DISABLED=1.
+ */
+
+import { createHash } from "node:crypto";
+import { isEmbeddingDisabled } from "./db.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Minimal interface a concrete embedding backend must satisfy. */
+export interface EmbeddingClient {
+	readonly model: string;
+	readonly dimensions: number;
+	embed(texts: string[]): Promise<Float32Array[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Text helpers (ports of semantic.py)
+// ---------------------------------------------------------------------------
+
+/** SHA-256 hex digest of UTF-8 encoded text. */
+export function hashText(text: string): string {
+	return createHash("sha256").update(text, "utf-8").digest("hex");
+}
+
+/**
+ * Split long text into ≤ `maxChars` chunks, preferring paragraph then
+ * sentence boundaries.  Matches Python's `chunk_text()`.
+ */
+export function chunkText(text: string, maxChars = 1200): string[] {
+	const cleaned = text.trim();
+	if (!cleaned) return [];
+	if (cleaned.length <= maxChars) return [cleaned];
+
+	const paragraphs = cleaned
+		.split(/\n{2,}/)
+		.map((p) => p.trim())
+		.filter(Boolean);
+	const chunks: string[] = [];
+	let buffer: string[] = [];
+	let bufferLen = 0;
+
+	for (const paragraph of paragraphs) {
+		if (bufferLen + paragraph.length + 2 <= maxChars) {
+			buffer.push(paragraph);
+			bufferLen += paragraph.length + 2;
+			continue;
+		}
+		if (buffer.length > 0) {
+			chunks.push(buffer.join("\n\n"));
+			buffer = [];
+			bufferLen = 0;
+		}
+		if (paragraph.length <= maxChars) {
+			chunks.push(paragraph);
+			continue;
+		}
+		// Split long paragraph by sentence
+		const sentences = paragraph
+			.split(/(?<=[.!?])\s+/)
+			.map((s) => s.trim())
+			.filter(Boolean);
+		const sentBuf: string[] = [];
+		let sentLen = 0;
+		for (const sentence of sentences) {
+			// Hard-split sentences that exceed maxChars on their own
+			if (sentence.length > maxChars) {
+				if (sentBuf.length > 0) {
+					chunks.push(sentBuf.join(" "));
+					sentBuf.length = 0;
+					sentLen = 0;
+				}
+				for (let i = 0; i < sentence.length; i += maxChars) {
+					chunks.push(sentence.slice(i, i + maxChars));
+				}
+				continue;
+			}
+			if (sentLen + sentence.length + 1 <= maxChars) {
+				sentBuf.push(sentence);
+				sentLen += sentence.length + 1;
+				continue;
+			}
+			if (sentBuf.length > 0) chunks.push(sentBuf.join(" "));
+			sentBuf.length = 0;
+			sentBuf.push(sentence);
+			sentLen = sentence.length;
+		}
+		if (sentBuf.length > 0) chunks.push(sentBuf.join(" "));
+	}
+	if (buffer.length > 0) chunks.push(buffer.join("\n\n"));
+	return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy singleton client
+// ---------------------------------------------------------------------------
+
+let _client: EmbeddingClient | null | undefined;
+
+/** Reset the singleton (for tests). */
+export function _resetEmbeddingClient(): void {
+	_client = undefined;
+}
+
+/**
+ * Get the shared embedding client, creating it lazily on first call.
+ * Returns null when embeddings are disabled or the runtime is unavailable.
+ */
+export async function getEmbeddingClient(): Promise<EmbeddingClient | null> {
+	if (_client !== undefined) return _client;
+	if (isEmbeddingDisabled()) {
+		_client = null;
+		return null;
+	}
+	const model = process.env.CODEMEM_EMBEDDING_MODEL || "BAAI/bge-small-en-v1.5";
+	try {
+		_client = await createTransformersClient(model);
+	} catch {
+		_client = null;
+	}
+	return _client;
+}
+
+/**
+ * Embed texts using the shared client.
+ * Returns an empty array when embeddings are unavailable.
+ */
+export async function embedTexts(texts: string[]): Promise<Float32Array[]> {
+	const client = await getEmbeddingClient();
+	if (!client) return [];
+	return client.embed(texts);
+}
+
+// ---------------------------------------------------------------------------
+// @xenova/transformers backend (runtime-detected)
+// ---------------------------------------------------------------------------
+
+async function createTransformersClient(model: string): Promise<EmbeddingClient> {
+	// Dynamic import so the package is optional at install time
+	const { pipeline } = await import("@xenova/transformers");
+	const extractor = await pipeline("feature-extraction", model, {
+		quantized: true,
+	});
+
+	// Infer dimensions from a probe embedding
+	const probe = await extractor("probe", { pooling: "mean", normalize: true });
+	const dims = probe.dims?.at(-1) ?? 384;
+
+	return {
+		model,
+		dimensions: dims,
+		async embed(texts: string[]): Promise<Float32Array[]> {
+			const results: Float32Array[] = [];
+			for (const text of texts) {
+				const output = await extractor(text, { pooling: "mean", normalize: true });
+				// output.data is a Float32Array of shape [1, dims]
+				results.push(new Float32Array(output.data));
+			}
+			return results;
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Serialization helpers (sqlite-vec wire format)
+// ---------------------------------------------------------------------------
+
+/** Serialize a Float32Array to a little-endian Buffer for sqlite-vec. */
+export function serializeFloat32(vector: Float32Array): Buffer {
+	const buf = Buffer.alloc(vector.length * 4);
+	for (let i = 0; i < vector.length; i++) {
+		buf.writeFloatLE(vector[i] ?? 0, i * 4);
+	}
+	return buf;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,15 @@ export {
 	tableExists,
 	toJson,
 } from "./db.js";
+export type { EmbeddingClient } from "./embeddings.js";
+export {
+	_resetEmbeddingClient,
+	chunkText,
+	embedTexts,
+	getEmbeddingClient,
+	hashText,
+	serializeFloat32,
+} from "./embeddings.js";
 export type { ExportOptions, ExportPayload, ImportOptions, ImportResult } from "./export-import.js";
 export {
 	buildImportKey,
@@ -239,7 +248,6 @@ export {
 } from "./sync-replication.js";
 // Test utilities (exported for consumer packages like viewer-server)
 export { initTestSchema, insertTestSession } from "./test-utils.js";
-
 export type {
 	Actor,
 	Artifact,
@@ -274,3 +282,9 @@ export type {
 	UsageEvent,
 	UserPrompt,
 } from "./types.js";
+export type {
+	BackfillVectorsOptions,
+	BackfillVectorsResult,
+	SemanticSearchResult,
+} from "./vectors.js";
+export { backfillVectors, semanticSearch, storeVectors } from "./vectors.js";

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -1,0 +1,268 @@
+/**
+ * Vector store operations for semantic search.
+ *
+ * Ports codemem/store/vectors.py — backfill and on-insert vector writes
+ * against the sqlite-vec `memory_vectors` virtual table.
+ *
+ * All functions accept a raw better-sqlite3 Database so they work outside
+ * the MemoryStore class.  Embedding is async; callers await then write
+ * synchronously (matches the runtime-topology decision: main thread owns DB).
+ */
+
+import type { Database } from "./db.js";
+import {
+	chunkText,
+	embedTexts,
+	getEmbeddingClient,
+	hashText,
+	serializeFloat32,
+} from "./embeddings.js";
+import { projectClause } from "./project.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BackfillVectorsResult {
+	checked: number;
+	embedded: number;
+	inserted: number;
+	skipped: number;
+}
+
+export interface BackfillVectorsOptions {
+	limit?: number | null;
+	since?: string | null;
+	project?: string | null;
+	activeOnly?: boolean;
+	dryRun?: boolean;
+	memoryIds?: number[] | null;
+}
+
+// ---------------------------------------------------------------------------
+// storeVectors — called inline when a memory is created/remembered
+// ---------------------------------------------------------------------------
+
+/**
+ * Embed and store vectors for a single memory item.
+ * No-op when embeddings are disabled or the client is unavailable.
+ */
+export async function storeVectors(
+	db: Database,
+	memoryId: number,
+	title: string,
+	bodyText: string,
+): Promise<void> {
+	const client = await getEmbeddingClient();
+	if (!client) return;
+
+	const text = `${title}\n${bodyText}`.trim();
+	const chunks = chunkText(text);
+	if (chunks.length === 0) return;
+
+	const embeddings = await embedTexts(chunks);
+	if (embeddings.length === 0) return;
+
+	const model = client.model;
+	const stmt = db.prepare(
+		"INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model) VALUES (?, ?, ?, ?, ?)",
+	);
+
+	for (let i = 0; i < chunks.length && i < embeddings.length; i++) {
+		const vector = embeddings[i];
+		if (!vector || vector.length === 0) continue;
+		stmt.run(serializeFloat32(vector), memoryId, i, hashText(chunks[i]!), model);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// backfillVectors — CLI batch backfill
+// ---------------------------------------------------------------------------
+
+/**
+ * Backfill vectors for memories that don't have them yet.
+ * Matches Python's `backfill_vectors()` in store/vectors.py.
+ */
+export async function backfillVectors(
+	db: Database,
+	opts: BackfillVectorsOptions = {},
+): Promise<BackfillVectorsResult> {
+	const client = await getEmbeddingClient();
+	if (!client) return { checked: 0, embedded: 0, inserted: 0, skipped: 0 };
+
+	const { limit, since, project, activeOnly = true, dryRun = false, memoryIds } = opts;
+
+	const params: unknown[] = [];
+	const whereClauses: string[] = [];
+
+	if (activeOnly) whereClauses.push("memory_items.active = 1");
+	if (since) {
+		whereClauses.push("memory_items.created_at >= ?");
+		params.push(since);
+	}
+	if (project) {
+		const pc = projectClause(project);
+		if (pc.clause) {
+			whereClauses.push(pc.clause);
+			params.push(...pc.params);
+		}
+	}
+	if (memoryIds && memoryIds.length > 0) {
+		const placeholders = memoryIds.map(() => "?").join(",");
+		whereClauses.push(`memory_items.id IN (${placeholders})`);
+		params.push(...memoryIds);
+	}
+
+	const where = whereClauses.length > 0 ? whereClauses.join(" AND ") : "1=1";
+	const joinSessions = project != null;
+	const joinClause = joinSessions ? "JOIN sessions ON sessions.id = memory_items.session_id" : "";
+	const limitClause = limit != null && limit > 0 ? "LIMIT ?" : "";
+	if (limit != null && limit > 0) params.push(limit);
+
+	const rows = db
+		.prepare(
+			`SELECT memory_items.id, memory_items.title, memory_items.body_text
+			 FROM memory_items ${joinClause}
+			 WHERE ${where}
+			 ORDER BY memory_items.created_at ASC ${limitClause}`,
+		)
+		.all(...params) as Array<{ id: number; title: string | null; body_text: string | null }>;
+
+	const model = client.model;
+	let checked = 0;
+	let embedded = 0;
+	let inserted = 0;
+	let skipped = 0;
+
+	for (const row of rows) {
+		checked++;
+		const text = `${row.title ?? ""}\n${row.body_text ?? ""}`.trim();
+		const chunks = chunkText(text);
+		if (chunks.length === 0) continue;
+
+		// Check existing hashes
+		const existingRows = db
+			.prepare("SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ?")
+			.all(row.id, model) as Array<{ content_hash: string | null }>;
+		const existingHashes = new Set(
+			existingRows.map((r) => r.content_hash).filter((h): h is string => h != null),
+		);
+
+		const pendingChunks: string[] = [];
+		const pendingHashes: string[] = [];
+		for (const chunk of chunks) {
+			const h = hashText(chunk);
+			if (existingHashes.has(h)) {
+				skipped++;
+				continue;
+			}
+			pendingChunks.push(chunk);
+			pendingHashes.push(h);
+		}
+
+		if (pendingChunks.length === 0) continue;
+
+		const embeddings = await embedTexts(pendingChunks);
+		if (embeddings.length === 0) continue;
+		embedded += embeddings.length;
+
+		if (dryRun) {
+			inserted += embeddings.length;
+			continue;
+		}
+
+		const stmt = db.prepare(
+			"INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model) VALUES (?, ?, ?, ?, ?)",
+		);
+		for (let i = 0; i < embeddings.length; i++) {
+			const vector = embeddings[i];
+			if (!vector || vector.length === 0) continue;
+			stmt.run(serializeFloat32(vector), row.id, i, pendingHashes[i], model);
+			inserted++;
+		}
+	}
+
+	return { checked, embedded, inserted, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// semanticSearch — vector KNN query
+// ---------------------------------------------------------------------------
+
+export interface SemanticSearchResult {
+	id: number;
+	kind: string;
+	title: string;
+	body_text: string;
+	confidence: number;
+	tags_text: string;
+	metadata_json: string | null;
+	created_at: string;
+	updated_at: string;
+	session_id: number;
+	score: number;
+	distance: number;
+}
+
+/**
+ * Search for memories by vector similarity (KNN via sqlite-vec MATCH).
+ * Returns an empty array when embeddings are disabled or unavailable.
+ *
+ * Matches Python's `_semantic_search()` in store/search.py.
+ */
+export async function semanticSearch(
+	db: Database,
+	query: string,
+	limit = 10,
+	filters?: { project?: string | null } | null,
+): Promise<SemanticSearchResult[]> {
+	if (query.trim().length < 3) return [];
+
+	const embeddings = await embedTexts([query]);
+	if (embeddings.length === 0) return [];
+
+	const queryEmbedding = serializeFloat32(embeddings[0]!);
+	const params: unknown[] = [queryEmbedding, limit];
+	const whereClauses: string[] = ["memory_items.active = 1"];
+	let joinSessions = false;
+
+	if (filters?.project) {
+		const pc = projectClause(filters.project);
+		if (pc.clause) {
+			whereClauses.push(pc.clause);
+			params.push(...pc.params);
+			joinSessions = true;
+		}
+	}
+
+	const where = whereClauses.join(" AND ");
+	const joinClause = joinSessions ? "JOIN sessions ON sessions.id = memory_items.session_id" : "";
+
+	const sql = `
+		SELECT memory_items.*, memory_vectors.distance
+		FROM memory_vectors
+		JOIN memory_items ON memory_items.id = memory_vectors.memory_id
+		${joinClause}
+		WHERE memory_vectors.embedding MATCH ?
+		  AND k = ?
+		  AND ${where}
+		ORDER BY memory_vectors.distance ASC
+	`;
+
+	const rows = db.prepare(sql).all(...params) as Array<Record<string, unknown>>;
+
+	return rows.map((row) => ({
+		id: Number(row.id),
+		kind: String(row.kind ?? "observation"),
+		title: String(row.title ?? ""),
+		body_text: String(row.body_text ?? ""),
+		confidence: Number(row.confidence ?? 0),
+		tags_text: String(row.tags_text ?? ""),
+		metadata_json: row.metadata_json == null ? null : String(row.metadata_json),
+		created_at: String(row.created_at ?? ""),
+		updated_at: String(row.updated_at ?? ""),
+		session_id: Number(row.session_id),
+		score: 1.0 / (1.0 + Number(row.distance ?? 0)),
+		distance: Number(row.distance ?? 0),
+	}));
+}

--- a/packages/core/src/xenova-transformers.d.ts
+++ b/packages/core/src/xenova-transformers.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Minimal type declarations for @xenova/transformers.
+ *
+ * This package is an optional runtime dependency — only needed when
+ * CODEMEM_EMBEDDING_DISABLED is not set and semantic search is active.
+ * The dynamic import in embeddings.ts gracefully falls back when absent.
+ */
+declare module "@xenova/transformers" {
+	interface PipelineOutput {
+		data: Float32Array;
+		dims?: number[];
+	}
+
+	type FeatureExtractionPipeline = (
+		text: string,
+		options?: { pooling?: string; normalize?: boolean },
+	) => Promise<PipelineOutput>;
+
+	export function pipeline(
+		task: "feature-extraction",
+		model: string,
+		options?: { quantized?: boolean },
+	): Promise<FeatureExtractionPipeline>;
+}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 			fileName: "index",
 		},
 		rollupOptions: {
-			external: ["better-sqlite3", "sqlite-vec", /^node:/],
+			external: ["better-sqlite3", "sqlite-vec", "@xenova/transformers", /^node:/],
 		},
 		outDir: "dist",
 		sourcemap: true,


### PR DESCRIPTION
## Description

Adds the embedding, vector store, and semantic search primitives needed for pack/injection parity with Python's default behavior. All functions gracefully return empty results when `CODEMEM_EMBEDDING_DISABLED=1` or the embedding runtime is unavailable, matching Python's fallback behavior.

**New files:**
- `embeddings.ts` — pluggable `EmbeddingClient` interface, `@xenova/transformers` backend with runtime detection, text chunking (paragraph→sentence), SHA-256 content hashing, Float32Array→Buffer serialization for sqlite-vec
- `vectors.ts` — `storeVectors` (inline on memory create), `backfillVectors` (CLI batch), `semanticSearch` (KNN via sqlite-vec MATCH with project filters)
- `xenova-transformers.d.ts` — type declaration for optional `@xenova/transformers` dependency

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm clean && pnpm build && pnpm test && pnpm lint`)
- [x] Added/updated tests for changes — 11 tests for text chunking, hashing, serialization
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced (2 new `noNonNullAssertion` follow existing codebase pattern)