### PR TITLE
feat: wire semantic candidates into pack and MCP memory_pack

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -152,7 +152,7 @@ export {
 	stripTrailingCommas,
 	writeCodememConfigFile,
 } from "./observer-config.js";
-export { buildMemoryPack, estimateTokens } from "./pack.js";
+export { buildMemoryPack, buildMemoryPackAsync, estimateTokens } from "./pack.js";
 export {
 	projectBasename,
 	projectClause,

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -1,16 +1,21 @@
 /**
- * Memory pack builder — simplified port of codemem/store/packs.py.
+ * Memory pack builder — port of codemem/store/packs.py.
  *
  * Builds a formatted "memory pack" from search results, organized into
  * sections (summary, timeline, observations) with token budgeting.
  *
- * NOT ported: semantic search, fuzzy search, task/recall mode detection,
- * _merge_ranked_results, exact dedup, pack delta tracking.
+ * Semantic candidate merging is supported via `buildMemoryPackAsync` or
+ * by passing pre-computed semantic results to `buildMemoryPack`.
+ *
+ * NOT ported: fuzzy search, task/recall mode detection, exact dedup,
+ * pack delta tracking.
  */
 
+import type { Database } from "./db.js";
 import type { StoreHandle } from "./search.js";
 import { search } from "./search.js";
 import type { MemoryFilters, MemoryResult, PackItem, PackResponse } from "./types.js";
+import { semanticSearch } from "./vectors.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -84,20 +89,58 @@ function toPackItem(result: MemoryResult): PackItem {
  * 4. Apply token budget (truncate items if budget exceeded)
  * 5. Format sections into pack_text
  */
+/**
+ * Merge FTS and semantic results by ID, keeping the higher score for dupes.
+ * Matches Python's always-merge behavior when semantic results are available.
+ */
+function mergeResults(
+	ftsResults: MemoryResult[],
+	semanticResults: MemoryResult[],
+	limit: number,
+): { merged: MemoryResult[]; ftsCount: number; semanticCount: number } {
+	const seen = new Map<number, MemoryResult>();
+	for (const r of ftsResults) {
+		const existing = seen.get(r.id);
+		if (!existing || r.score > existing.score) seen.set(r.id, r);
+	}
+	let semanticCount = 0;
+	for (const r of semanticResults) {
+		if (!seen.has(r.id)) semanticCount++;
+		const existing = seen.get(r.id);
+		if (!existing || r.score > existing.score) seen.set(r.id, r);
+	}
+	// Sort by score descending, then truncate to limit
+	const merged = [...seen.values()].sort((a, b) => b.score - a.score).slice(0, limit);
+	return { merged, ftsCount: ftsResults.length, semanticCount };
+}
+
 export function buildMemoryPack(
 	store: StoreHandle,
 	context: string,
 	limit = 10,
 	tokenBudget: number | null = null,
 	filters?: MemoryFilters,
+	semanticResults?: MemoryResult[],
 ): PackResponse {
 	const effectiveLimit = Math.max(1, Math.trunc(limit));
 	let fallbackUsed = false;
 	let ftsCount = 0;
+	let semanticCount = 0;
 
-	// Step 1: search for matching memories
-	let results = search(store, context, effectiveLimit, filters);
-	ftsCount = results.length;
+	// Step 1: search for matching memories (FTS)
+	const ftsResults = search(store, context, effectiveLimit, filters);
+
+	// Step 1b: merge semantic candidates when provided
+	let results: MemoryResult[];
+	if (semanticResults && semanticResults.length > 0) {
+		const merge = mergeResults(ftsResults, semanticResults, effectiveLimit);
+		results = merge.merged;
+		ftsCount = merge.ftsCount;
+		semanticCount = merge.semanticCount;
+	} else {
+		results = ftsResults;
+		ftsCount = results.length;
+	}
 
 	// Step 3: fall back to recent if no search results
 	if (results.length === 0) {
@@ -192,7 +235,69 @@ export function buildMemoryPack(
 			total_items: allItems.length,
 			pack_tokens: estimateTokens(packText),
 			fallback_used: fallbackUsed,
-			sources: { fts: ftsCount, semantic: 0, fuzzy: 0 },
+			sources: { fts: ftsCount, semantic: semanticCount, fuzzy: 0 },
 		},
 	};
+}
+
+// ---------------------------------------------------------------------------
+// Async pack builder (with semantic search)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a memory pack with semantic candidate merging.
+ *
+ * This is the async version that runs `semanticSearch` against the
+ * sqlite-vec `memory_vectors` table, then merges those candidates
+ * with FTS results via the sync `buildMemoryPack`.
+ *
+ * Callers that don't want/need async can still use the sync
+ * `buildMemoryPack` directly — semantic candidates simply won't
+ * be included.
+ */
+export async function buildMemoryPackAsync(
+	store: StoreHandle & { db: Database },
+	context: string,
+	limit = 10,
+	tokenBudget: number | null = null,
+	filters?: MemoryFilters,
+): Promise<PackResponse> {
+	// Run semantic search (returns [] when embeddings unavailable)
+	let semResults: MemoryResult[] = [];
+	try {
+		const raw = await semanticSearch(store.db, context, limit, {
+			project: filters?.project,
+		});
+		semResults = raw.map((r) => {
+			// Parse metadata_json if present, matching FTS result shape
+			let metadata: Record<string, unknown> = {};
+			if (r.metadata_json) {
+				try {
+					const parsed = JSON.parse(r.metadata_json) as unknown;
+					if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
+						metadata = parsed as Record<string, unknown>;
+					}
+				} catch {
+					// Invalid JSON metadata — use empty object
+				}
+			}
+			return {
+				id: r.id,
+				kind: r.kind,
+				title: r.title,
+				body_text: r.body_text,
+				confidence: r.confidence,
+				created_at: r.created_at,
+				updated_at: r.updated_at,
+				tags_text: r.tags_text,
+				score: r.score,
+				session_id: r.session_id,
+				metadata,
+			};
+		});
+	} catch {
+		// Semantic search failure is non-fatal — fall through to FTS-only
+	}
+
+	return buildMemoryPack(store, context, limit, tokenBudget, filters, semResults);
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -28,7 +28,7 @@ import {
 } from "./db.js";
 import { buildFilterClauses } from "./filters.js";
 import { readCodememConfigFile } from "./observer-config.js";
-import { buildMemoryPack } from "./pack.js";
+import { buildMemoryPack, buildMemoryPackAsync } from "./pack.js";
 import { explain as explainFn, search as searchFn, timeline as timelineFn } from "./search.js";
 import type {
 	ExplainResponse,
@@ -669,6 +669,22 @@ export class MemoryStore {
 		filters?: MemoryFilters,
 	): PackResponse {
 		return buildMemoryPack(this, context, limit, tokenBudget ?? null, filters);
+	}
+
+	/**
+	 * Build a memory pack with semantic candidate merging.
+	 *
+	 * Async version that runs vector KNN search via sqlite-vec and merges
+	 * semantic candidates with FTS results.  Falls back to FTS-only when
+	 * embeddings are disabled or unavailable.
+	 */
+	async buildMemoryPackAsync(
+		context: string,
+		limit?: number,
+		tokenBudget?: number | null,
+		filters?: MemoryFilters,
+	): Promise<PackResponse> {
+		return buildMemoryPackAsync(this, context, limit, tokenBudget ?? null, filters);
 	}
 
 	// -----------------------------------------------------------------------

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -442,7 +442,12 @@ async function main() {
 		async (args) => {
 			try {
 				const filters = buildFilters(args);
-				const result = store.buildMemoryPack(args.context, args.limit ?? undefined, null, filters);
+				const result = await store.buildMemoryPackAsync(
+					args.context,
+					args.limit ?? undefined,
+					null,
+					filters,
+				);
 				return jsonContent(result);
 			} catch (err) {
 				return errorContent(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Description

Connects the vector search primitives from PR #297 into the pack builder and MCP server so the TS backend merges semantic candidates with FTS results, matching Python's default pack behavior.

**Changes:**
- `pack.ts`: add `mergeResults` helper (dedup by ID, keep higher score, sort merged set), update `buildMemoryPack` to accept optional semantic results, add async `buildMemoryPackAsync` that runs `semanticSearch` then delegates to the sync builder
- `store.ts`: add `buildMemoryPackAsync` method wrapping the async pack builder
- `mcp-server/index.ts`: switch `memory_pack` tool to use the async path so semantic candidates are included when embeddings are available
- The sync `buildMemoryPack` still works standalone for FTS-only callers

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Tests pass locally (`pnpm clean && pnpm build && pnpm test && pnpm lint`)
- [x] Existing pack tests pass unchanged (semantic results are optional)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced