### PR TITLE
feat: add memory show/forget/remember CLI commands

### DIFF
--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -1,0 +1,127 @@
+/**
+ * Memory management CLI commands — show, forget, remember.
+ *
+ * Ports codemem/commands/memory_cmds.py (show_cmd, forget_cmd, remember_cmd).
+ * Compact and inject are deferred — compact requires the summarizer pipeline,
+ * and inject is just pack_text output which the existing pack command covers.
+ */
+
+import * as p from "@clack/prompts";
+import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+
+/** Parse a strict positive integer, rejecting prefixes like "12abc". */
+function parseStrictPositiveId(value: string): number | null {
+	if (!/^\d+$/.test(value.trim())) return null;
+	const n = Number(value.trim());
+	return Number.isFinite(n) && n >= 1 && Number.isInteger(n) ? n : null;
+}
+
+export const memoryCommand = new Command("memory")
+	.configureHelp(helpStyle)
+	.description("Memory item management");
+
+// codemem memory show <id>
+memoryCommand.addCommand(
+	new Command("show")
+		.configureHelp(helpStyle)
+		.description("Print a memory item as JSON")
+		.argument("<id>", "memory ID")
+		.option("--db <path>", "database path")
+		.action((idStr: string, opts: { db?: string }) => {
+			const memoryId = parseStrictPositiveId(idStr);
+			if (memoryId === null) {
+				p.log.error(`Invalid memory ID: ${idStr}`);
+				process.exitCode = 1;
+				return;
+			}
+			const store = new MemoryStore(resolveDbPath(opts.db));
+			try {
+				const item = store.get(memoryId);
+				if (!item) {
+					p.log.error(`Memory ${memoryId} not found`);
+					process.exitCode = 1;
+					return;
+				}
+				console.log(JSON.stringify(item, null, 2));
+			} finally {
+				store.close();
+			}
+		}),
+);
+
+// codemem memory forget <id>
+memoryCommand.addCommand(
+	new Command("forget")
+		.configureHelp(helpStyle)
+		.description("Deactivate a memory item")
+		.argument("<id>", "memory ID")
+		.option("--db <path>", "database path")
+		.action((idStr: string, opts: { db?: string }) => {
+			const memoryId = parseStrictPositiveId(idStr);
+			if (memoryId === null) {
+				p.log.error(`Invalid memory ID: ${idStr}`);
+				process.exitCode = 1;
+				return;
+			}
+			const store = new MemoryStore(resolveDbPath(opts.db));
+			try {
+				store.forget(memoryId);
+				p.log.success(`Memory ${memoryId} marked inactive`);
+			} finally {
+				store.close();
+			}
+		}),
+);
+
+// codemem memory remember --kind <kind> --title <title> --body <body>
+memoryCommand.addCommand(
+	new Command("remember")
+		.configureHelp(helpStyle)
+		.description("Manually add a memory item")
+		.requiredOption("-k, --kind <kind>", "memory kind (discovery, decision, feature, bugfix, etc.)")
+		.requiredOption("-t, --title <title>", "memory title")
+		.requiredOption("-b, --body <body>", "memory body text")
+		.option("--tags <tags...>", "tags (space-separated)")
+		.option("--project <project>", "project name (defaults to git repo root)")
+		.option("--db <path>", "database path")
+		.action(
+			(opts: {
+				kind: string;
+				title: string;
+				body: string;
+				tags?: string[];
+				project?: string;
+				db?: string;
+			}) => {
+				const store = new MemoryStore(resolveDbPath(opts.db));
+				let sessionId: number | null = null;
+				try {
+					const project = resolveProject(process.cwd(), opts.project ?? null);
+					sessionId = store.startSession({
+						cwd: process.cwd(),
+						project,
+						user: process.env.USER ?? "unknown",
+						toolVersion: "manual",
+						metadata: { manual: true },
+					});
+					const memId = store.remember(sessionId, opts.kind, opts.title, opts.body, 0.5, opts.tags);
+					store.endSession(sessionId, { manual: true });
+					p.log.success(`Stored memory ${memId}`);
+				} catch (err) {
+					// Always close the session even if remember() throws (e.g. invalid kind)
+					if (sessionId !== null) {
+						try {
+							store.endSession(sessionId, { manual: true, error: true });
+						} catch {
+							// ignore — already in error path
+						}
+					}
+					throw err;
+				} finally {
+					store.close();
+				}
+			},
+		),
+);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
 import { exportMemoriesCommand } from "./commands/export-memories.js";
 import { importMemoriesCommand } from "./commands/import-memories.js";
 import { mcpCommand } from "./commands/mcp.js";
+import { memoryCommand } from "./commands/memory.js";
 import { packCommand } from "./commands/pack.js";
 import { recentCommand } from "./commands/recent.js";
 import { searchCommand } from "./commands/search.js";
@@ -33,6 +34,7 @@ completion.on("command", ({ reply }) => {
 	reply([
 		"db",
 		"export-memories",
+		"memory",
 		"import-memories",
 		"stats",
 		"recent",
@@ -77,6 +79,7 @@ program.addCommand(statsCommand);
 program.addCommand(recentCommand);
 program.addCommand(searchCommand);
 program.addCommand(packCommand);
+program.addCommand(memoryCommand);
 program.addCommand(enqueueRawEventCommand);
 program.addCommand(versionCommand);
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -165,6 +165,56 @@ export class MemoryStore {
 	}
 
 	// -----------------------------------------------------------------------
+	// startSession / endSession
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Create a new session row. Returns the session ID.
+	 * Matches Python's store.start_session().
+	 */
+	startSession(opts: {
+		cwd?: string;
+		project?: string | null;
+		gitRemote?: string | null;
+		gitBranch?: string | null;
+		user?: string;
+		toolVersion?: string;
+		metadata?: Record<string, unknown>;
+	}): number {
+		const now = nowIso();
+		const info = this.db
+			.prepare(
+				`INSERT INTO sessions(started_at, cwd, project, git_remote, git_branch, user, tool_version, metadata_json)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.run(
+				now,
+				opts.cwd ?? process.cwd(),
+				opts.project ?? null,
+				opts.gitRemote ?? null,
+				opts.gitBranch ?? null,
+				opts.user ?? process.env.USER ?? "unknown",
+				opts.toolVersion ?? "manual",
+				toJson(opts.metadata ?? {}),
+			);
+		return Number(info.lastInsertRowid);
+	}
+
+	/**
+	 * End a session by recording ended_at. No-op if session doesn't exist.
+	 */
+	endSession(sessionId: number, metadata?: Record<string, unknown>): void {
+		const now = nowIso();
+		if (metadata) {
+			this.db
+				.prepare("UPDATE sessions SET ended_at = ?, metadata_json = ? WHERE id = ?")
+				.run(now, toJson(metadata), sessionId);
+		} else {
+			this.db.prepare("UPDATE sessions SET ended_at = ? WHERE id = ?").run(now, sessionId);
+		}
+	}
+
+	// -----------------------------------------------------------------------
 	// remember
 	// -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

Ports the core memory management commands from Python's memory_cmds.py so the TS CLI can show, deactivate, and manually create memories without Python.

- `codemem memory show <id>` — prints a memory item as JSON
- `codemem memory forget <id>` — soft-deletes a memory
- `codemem memory remember -k <kind> -t <title> -b <body>` — creates a manual memory with a short-lived session, project resolution, and optional tags

Also adds `MemoryStore.startSession()` and `endSession()` to the core store for the remember command's session lifecycle.

Compact and inject are deferred — compact requires the summarizer pipeline, and inject is already covered by `codemem pack` output.

## Type of Change
- [x] 🚀 Feature (new functionality)

## Testing
- [x] Tests pass locally (`pnpm clean && pnpm build && pnpm test && pnpm lint`)
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced