### PR TITLE
feat: port core replication logic (clock comparison, op recording, apply with conflict resolution)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -240,10 +240,16 @@ export {
 	syncOnce,
 	syncPassPreflight,
 } from "./sync-pass.js";
+export type { ApplyResult } from "./sync-replication.js";
 export {
+	applyReplicationOps,
 	chunkOpsBySize,
+	clockTuple,
 	extractReplicationOps,
 	getReplicationCursor,
+	isNewerClock,
+	loadReplicationOpsSince,
+	recordReplicationOp,
 	setReplicationCursor,
 } from "./sync-replication.js";
 // Test utilities (exported for consumer packages like viewer-server)

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1,12 +1,18 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toJson } from "./db.js";
 import {
+	applyReplicationOps,
 	chunkOpsBySize,
+	clockTuple,
 	extractReplicationOps,
 	getReplicationCursor,
+	isNewerClock,
+	loadReplicationOpsSince,
+	recordReplicationOp,
 	setReplicationCursor,
 } from "./sync-replication.js";
-import { initTestSchema } from "./test-utils.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
 import type { ReplicationOp } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -133,5 +139,368 @@ describe("extractReplicationOps", () => {
 
 	it("returns empty array when ops is not an array", () => {
 		expect(extractReplicationOps({ ops: "not-array" })).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// clockTuple
+// ---------------------------------------------------------------------------
+
+describe("clockTuple", () => {
+	it("builds a 3-element tuple", () => {
+		const t = clockTuple(3, "2026-01-01T00:00:00Z", "dev-a");
+		expect(t).toEqual([3, "2026-01-01T00:00:00Z", "dev-a"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// isNewerClock
+// ---------------------------------------------------------------------------
+
+describe("isNewerClock", () => {
+	it("higher rev wins", () => {
+		expect(isNewerClock([2, "a", "a"], [1, "z", "z"])).toBe(true);
+		expect(isNewerClock([1, "z", "z"], [2, "a", "a"])).toBe(false);
+	});
+
+	it("same rev — tiebreaks on updated_at", () => {
+		expect(isNewerClock([1, "b", "a"], [1, "a", "z"])).toBe(true);
+		expect(isNewerClock([1, "a", "z"], [1, "b", "a"])).toBe(false);
+	});
+
+	it("same rev and updated_at — tiebreaks on device_id", () => {
+		expect(isNewerClock([1, "a", "dev-b"], [1, "a", "dev-a"])).toBe(true);
+		expect(isNewerClock([1, "a", "dev-a"], [1, "a", "dev-b"])).toBe(false);
+	});
+
+	it("identical clocks are not newer", () => {
+		expect(isNewerClock([1, "a", "a"], [1, "a", "a"])).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// recordReplicationOp
+// ---------------------------------------------------------------------------
+
+describe("recordReplicationOp", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("inserts an op and returns a UUID op_id", () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Test",
+			"body",
+			now,
+			now,
+			"key:1",
+			3,
+			toJson({ clock_device_id: "dev-a" }),
+		);
+
+		const memId = (
+			db.prepare("SELECT id FROM memory_items WHERE import_key = ?").get("key:1") as { id: number }
+		).id;
+
+		const opId = recordReplicationOp(db, {
+			memoryId: memId,
+			opType: "upsert",
+			deviceId: "dev-a",
+		});
+
+		expect(opId).toMatch(/^[0-9a-f-]{36}$/);
+
+		const row = db.prepare("SELECT * FROM replication_ops WHERE op_id = ?").get(opId) as Record<
+			string,
+			unknown
+		>;
+		expect(row.entity_type).toBe("memory_item");
+		expect(row.entity_id).toBe("key:1");
+		expect(row.op_type).toBe("upsert");
+		expect(row.clock_rev).toBe(3);
+		expect(row.clock_device_id).toBe("dev-a");
+	});
+
+	it("falls back to memoryId as entity_id when import_key is null", () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, rev)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		).run(sessionId, "discovery", "Test", "body", now, now, 0);
+
+		const memId = Number(
+			(db.prepare("SELECT last_insert_rowid() as id").get() as { id: number }).id,
+		);
+
+		const opId = recordReplicationOp(db, {
+			memoryId: memId,
+			opType: "delete",
+			deviceId: "dev-b",
+		});
+
+		const row = db.prepare("SELECT * FROM replication_ops WHERE op_id = ?").get(opId) as Record<
+			string,
+			unknown
+		>;
+		expect(row.entity_id).toBe(String(memId));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// loadReplicationOpsSince
+// ---------------------------------------------------------------------------
+
+describe("loadReplicationOpsSince", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	function insertOp(opId: string, createdAt: string, deviceId = "dev-a") {
+		db.prepare(
+			`INSERT INTO replication_ops(op_id, entity_type, entity_id, op_type, payload_json, clock_rev, clock_updated_at, clock_device_id, device_id, created_at)
+			 VALUES (?, 'memory_item', ?, 'upsert', NULL, 1, ?, ?, ?, ?)`,
+		).run(opId, `ent-${opId}`, createdAt, deviceId, deviceId, createdAt);
+	}
+
+	it("returns all ops when cursor is null", () => {
+		insertOp("op-1", "2026-01-01T00:00:00Z");
+		insertOp("op-2", "2026-01-01T00:00:01Z");
+
+		const [ops, cursor] = loadReplicationOpsSince(db, null);
+		expect(ops).toHaveLength(2);
+		expect(ops[0].op_id).toBe("op-1");
+		expect(ops[1].op_id).toBe("op-2");
+		expect(cursor).toBe("2026-01-01T00:00:01Z|op-2");
+	});
+
+	it("returns ops after cursor", () => {
+		insertOp("op-1", "2026-01-01T00:00:00Z");
+		insertOp("op-2", "2026-01-01T00:00:01Z");
+		insertOp("op-3", "2026-01-01T00:00:02Z");
+
+		const [ops, cursor] = loadReplicationOpsSince(db, "2026-01-01T00:00:00Z|op-1");
+		expect(ops).toHaveLength(2);
+		expect(ops[0].op_id).toBe("op-2");
+		expect(cursor).toBe("2026-01-01T00:00:02Z|op-3");
+	});
+
+	it("respects limit", () => {
+		insertOp("op-1", "2026-01-01T00:00:00Z");
+		insertOp("op-2", "2026-01-01T00:00:01Z");
+		insertOp("op-3", "2026-01-01T00:00:02Z");
+
+		const [ops, cursor] = loadReplicationOpsSince(db, null, 2);
+		expect(ops).toHaveLength(2);
+		expect(cursor).toBe("2026-01-01T00:00:01Z|op-2");
+	});
+
+	it("filters by deviceId", () => {
+		insertOp("op-1", "2026-01-01T00:00:00Z", "dev-a");
+		insertOp("op-2", "2026-01-01T00:00:01Z", "dev-b");
+
+		const [ops] = loadReplicationOpsSince(db, null, 100, "dev-a");
+		expect(ops).toHaveLength(1);
+		expect(ops[0].op_id).toBe("op-1");
+	});
+
+	it("returns [[], null] when no ops match", () => {
+		const [ops, cursor] = loadReplicationOpsSince(db, null);
+		expect(ops).toEqual([]);
+		expect(cursor).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// applyReplicationOps
+// ---------------------------------------------------------------------------
+
+describe("applyReplicationOps", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	function makeReplicationOp(overrides: Partial<ReplicationOp> = {}): ReplicationOp {
+		return {
+			op_id: `op-${Math.random().toString(36).slice(2, 8)}`,
+			entity_type: "memory_item",
+			entity_id: "key:test-1",
+			op_type: "upsert",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Remote memory",
+				body_text: "Remote body",
+				confidence: 0.8,
+				tags_text: "test",
+				active: 1,
+				created_at: "2026-01-01T00:00:00Z",
+				updated_at: "2026-01-01T00:00:00Z",
+			}),
+			clock_rev: 1,
+			clock_updated_at: "2026-01-01T00:00:00Z",
+			clock_device_id: "dev-remote",
+			device_id: "dev-remote",
+			created_at: "2026-01-01T00:00:00Z",
+			...overrides,
+		};
+	}
+
+	it("skips ops from the local device", () => {
+		const op = makeReplicationOp({ device_id: "dev-local" });
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.skipped).toBe(1);
+		expect(result.applied).toBe(0);
+	});
+
+	it("skips duplicate op_ids (idempotent)", () => {
+		const op = makeReplicationOp({ op_id: "fixed-op-id" });
+		const r1 = applyReplicationOps(db, [op], "dev-local");
+		expect(r1.applied).toBe(1);
+
+		const r2 = applyReplicationOps(db, [op], "dev-local");
+		expect(r2.skipped).toBe(1);
+		expect(r2.applied).toBe(0);
+	});
+
+	it("inserts a new memory item on upsert", () => {
+		const op = makeReplicationOp();
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+
+		const mem = db
+			.prepare("SELECT * FROM memory_items WHERE import_key = ?")
+			.get("key:test-1") as Record<string, unknown>;
+		expect(mem).toBeDefined();
+		expect(mem.title).toBe("Remote memory");
+		expect(mem.rev).toBe(1);
+	});
+
+	it("updates existing memory when op clock is newer", () => {
+		// Insert initial memory
+		const sessionId = insertTestSession(db);
+		const now = "2026-01-01T00:00:00Z";
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Old title",
+			"old body",
+			now,
+			now,
+			"key:test-1",
+			1,
+			toJson({ clock_device_id: "dev-remote" }),
+		);
+
+		const op = makeReplicationOp({
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Updated title",
+				body_text: "updated body",
+				updated_at: "2026-01-02T00:00:00Z",
+			}),
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+
+		const mem = db
+			.prepare("SELECT * FROM memory_items WHERE import_key = ?")
+			.get("key:test-1") as Record<string, unknown>;
+		expect(mem.title).toBe("Updated title");
+		expect(mem.rev).toBe(2);
+	});
+
+	it("counts conflict when existing memory has newer clock", () => {
+		const sessionId = insertTestSession(db);
+		const now = "2026-01-02T00:00:00Z";
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Newer title",
+			"newer body",
+			now,
+			now,
+			"key:test-1",
+			5,
+			toJson({ clock_device_id: "dev-remote" }),
+		);
+
+		const op = makeReplicationOp({ clock_rev: 1 });
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.conflicts).toBe(1);
+		expect(result.applied).toBe(0);
+
+		// Original memory unchanged
+		const mem = db
+			.prepare("SELECT title FROM memory_items WHERE import_key = ?")
+			.get("key:test-1") as { title: string };
+		expect(mem.title).toBe("Newer title");
+	});
+
+	it("soft-deletes on delete op_type", () => {
+		const sessionId = insertTestSession(db);
+		const now = "2026-01-01T00:00:00Z";
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, active)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(sessionId, "discovery", "To delete", "body", now, now, "key:del-1", 1, 1);
+
+		const op = makeReplicationOp({
+			entity_id: "key:del-1",
+			op_type: "delete",
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+
+		const mem = db
+			.prepare("SELECT active, deleted_at FROM memory_items WHERE import_key = ?")
+			.get("key:del-1") as { active: number; deleted_at: string | null };
+		expect(mem.active).toBe(0);
+		expect(mem.deleted_at).not.toBeNull();
+	});
+
+	it("records applied ops in replication_ops table", () => {
+		const op = makeReplicationOp({ op_id: "track-me" });
+		applyReplicationOps(db, [op], "dev-local");
+
+		const row = db.prepare("SELECT op_id FROM replication_ops WHERE op_id = ?").get("track-me");
+		expect(row).toBeDefined();
 	});
 });

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -5,7 +5,9 @@
  * a raw Database handle. Ported from codemem/sync/replication.py.
  */
 
+import { randomUUID } from "node:crypto";
 import type { Database } from "./db.js";
+import { fromJson, toJson } from "./db.js";
 import type { ReplicationOp } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -148,4 +150,437 @@ export function extractReplicationOps(payload: unknown): ReplicationOp[] {
 			(field) => record[field] !== undefined && record[field] !== null,
 		);
 	});
+}
+
+// ---------------------------------------------------------------------------
+// Clock comparison
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a clock tuple from individual fields.
+ *
+ * Clock tuples enable lexicographic comparison for last-writer-wins
+ * conflict resolution: higher rev wins, tiebreak on updated_at, then device_id.
+ */
+export function clockTuple(
+	rev: number,
+	updatedAt: string,
+	deviceId: string,
+): [number, string, string] {
+	return [rev, updatedAt, deviceId];
+}
+
+/**
+ * Return true if `candidate` clock is strictly newer than `existing`.
+ *
+ * Comparison order: rev (higher wins) → updated_at → device_id.
+ * Mirrors Python's `_is_newer_clock` which relies on tuple ordering.
+ */
+export function isNewerClock(
+	candidate: [number, string, string],
+	existing: [number, string, string],
+): boolean {
+	if (candidate[0] !== existing[0]) return candidate[0] > existing[0];
+	if (candidate[1] !== existing[1]) return candidate[1] > existing[1];
+	return candidate[2] > existing[2];
+}
+
+// ---------------------------------------------------------------------------
+// Record a replication op
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate and INSERT a single replication op for a memory item.
+ *
+ * Reads the memory item's clock fields (rev, updated_at, metadata_json)
+ * from the DB, builds the op row, and inserts into `replication_ops`.
+ * Returns the generated op_id (UUID).
+ */
+export function recordReplicationOp(
+	db: Database,
+	opts: {
+		memoryId: number;
+		opType: "upsert" | "delete";
+		deviceId: string;
+		payload?: Record<string, unknown>;
+	},
+): string {
+	const opId = randomUUID();
+	const now = new Date().toISOString();
+
+	// Read clock fields from the memory item
+	const row = db
+		.prepare("SELECT rev, updated_at, import_key, metadata_json FROM memory_items WHERE id = ?")
+		.get(opts.memoryId) as
+		| {
+				rev: number | null;
+				updated_at: string | null;
+				import_key: string | null;
+				metadata_json: string | null;
+		  }
+		| undefined;
+
+	const rev = row?.rev ?? 0;
+	const updatedAt = row?.updated_at ?? now;
+	const entityId = row?.import_key ?? String(opts.memoryId);
+	const metadata = fromJson(row?.metadata_json);
+	const clockDeviceId = (metadata.clock_device_id as string) || opts.deviceId;
+
+	const payloadJson = opts.payload ? toJson(opts.payload) : null;
+
+	db.prepare(
+		`INSERT INTO replication_ops(
+			op_id, entity_type, entity_id, op_type, payload_json,
+			clock_rev, clock_updated_at, clock_device_id, device_id, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		opId,
+		"memory_item",
+		entityId,
+		opts.opType,
+		payloadJson,
+		rev,
+		updatedAt,
+		clockDeviceId,
+		opts.deviceId,
+		now,
+	);
+
+	return opId;
+}
+
+// ---------------------------------------------------------------------------
+// Load replication ops with cursor pagination
+// ---------------------------------------------------------------------------
+
+/** Parse a `created_at|op_id` cursor into its two components. */
+function parseCursor(cursor: string): [createdAt: string, opId: string] | null {
+	const idx = cursor.indexOf("|");
+	if (idx < 0) return null;
+	return [cursor.slice(0, idx), cursor.slice(idx + 1)];
+}
+
+/** Build a `created_at|op_id` cursor string. */
+function computeCursor(createdAt: string, opId: string): string {
+	return `${createdAt}|${opId}`;
+}
+
+/**
+ * Load replication ops created after `cursor`, ordered by (created_at, op_id).
+ *
+ * Returns `[ops, nextCursor]` where nextCursor is the cursor for the last
+ * returned row (or null if no rows matched). The cursor format is
+ * `created_at|op_id`.
+ */
+export function loadReplicationOpsSince(
+	db: Database,
+	cursor: string | null,
+	limit = 100,
+	deviceId?: string,
+): [ReplicationOp[], string | null] {
+	const params: (string | number)[] = [];
+	const conditions: string[] = [];
+
+	if (cursor) {
+		const parsed = parseCursor(cursor);
+		if (parsed) {
+			const [createdAt, opId] = parsed;
+			conditions.push("(created_at > ? OR (created_at = ? AND op_id > ?))");
+			params.push(createdAt, createdAt, opId);
+		}
+	}
+
+	if (deviceId) {
+		conditions.push("(device_id = ? OR device_id = 'local')");
+		params.push(deviceId);
+	}
+
+	const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+	params.push(limit);
+
+	const rows = db
+		.prepare(
+			`SELECT op_id, entity_type, entity_id, op_type, payload_json,
+				clock_rev, clock_updated_at, clock_device_id, device_id, created_at
+			 FROM replication_ops
+			 ${whereClause}
+			 ORDER BY created_at ASC, op_id ASC
+			 LIMIT ?`,
+		)
+		.all(...params) as Array<{
+		op_id: string;
+		entity_type: string;
+		entity_id: string;
+		op_type: string;
+		payload_json: string | null;
+		clock_rev: number;
+		clock_updated_at: string;
+		clock_device_id: string;
+		device_id: string;
+		created_at: string;
+	}>;
+
+	const ops: ReplicationOp[] = rows.map((r) => ({
+		op_id: r.op_id,
+		entity_type: r.entity_type,
+		entity_id: r.entity_id,
+		op_type: r.op_type,
+		payload_json: r.payload_json,
+		clock_rev: r.clock_rev,
+		clock_updated_at: r.clock_updated_at,
+		clock_device_id: r.clock_device_id,
+		device_id: r.device_id,
+		created_at: r.created_at,
+	}));
+
+	let nextCursor: string | null = null;
+	if (rows.length > 0) {
+		const last = rows.at(-1);
+		if (last) {
+			nextCursor = computeCursor(last.created_at, last.op_id);
+		}
+	}
+
+	return [ops, nextCursor];
+}
+
+// ---------------------------------------------------------------------------
+// Apply inbound replication ops
+// ---------------------------------------------------------------------------
+
+export interface ApplyResult {
+	applied: number;
+	skipped: number;
+	conflicts: number;
+	errors: string[];
+}
+
+/**
+ * Apply inbound replication ops from a remote peer.
+ *
+ * Runs all ops in a single transaction. For each op:
+ * - Skips if device_id matches localDeviceId (don't re-apply own ops)
+ * - Skips if op_id already exists (idempotent)
+ * - For upsert: finds existing memory by import_key; if existing has a newer
+ *   clock, counts as conflict and skips; otherwise INSERT or UPDATE
+ * - For delete: soft-deletes (active=0, deleted_at) by import_key
+ * - Records the applied op in replication_ops
+ */
+export function applyReplicationOps(
+	db: Database,
+	ops: ReplicationOp[],
+	localDeviceId: string,
+): ApplyResult {
+	const result: ApplyResult = { applied: 0, skipped: 0, conflicts: 0, errors: [] };
+
+	const applyAll = db.transaction(() => {
+		for (const op of ops) {
+			try {
+				// Skip own ops
+				if (op.device_id === localDeviceId) {
+					result.skipped++;
+					continue;
+				}
+
+				// Idempotent: skip if already applied
+				const existing = db.prepare("SELECT 1 FROM replication_ops WHERE op_id = ?").get(op.op_id);
+				if (existing) {
+					result.skipped++;
+					continue;
+				}
+
+				if (op.op_type === "upsert") {
+					const importKey = op.entity_id;
+					const memRow = db
+						.prepare(
+							"SELECT id, rev, updated_at, metadata_json FROM memory_items WHERE import_key = ?",
+						)
+						.get(importKey) as
+						| {
+								id: number;
+								rev: number | null;
+								updated_at: string | null;
+								metadata_json: string | null;
+						  }
+						| undefined;
+
+					if (memRow) {
+						const existingMeta = fromJson(memRow.metadata_json);
+						const existingClockDeviceId = (existingMeta.clock_device_id as string) || "";
+						const existingClock = clockTuple(
+							memRow.rev ?? 0,
+							memRow.updated_at ?? "",
+							existingClockDeviceId,
+						);
+						const opClock = clockTuple(op.clock_rev, op.clock_updated_at, op.clock_device_id);
+
+						if (!isNewerClock(opClock, existingClock)) {
+							result.conflicts++;
+							// Still record the op so we don't re-process it
+							insertReplicationOpRow(db, op);
+							continue;
+						}
+
+						// Update existing row from payload
+						const payload = op.payload_json ? fromJson(op.payload_json) : {};
+						const newMeta = payload.metadata_json ?? {};
+						const metaObj =
+							typeof newMeta === "object" && newMeta !== null
+								? (newMeta as Record<string, unknown>)
+								: {};
+						metaObj.clock_device_id = op.clock_device_id;
+
+						db.prepare(
+							`UPDATE memory_items SET
+								kind = COALESCE(?, kind),
+								title = COALESCE(?, title),
+								body_text = COALESCE(?, body_text),
+								confidence = COALESCE(?, confidence),
+								tags_text = COALESCE(?, tags_text),
+								active = COALESCE(?, active),
+								updated_at = ?,
+								metadata_json = ?,
+								rev = ?,
+								deleted_at = ?
+							WHERE import_key = ?`,
+						).run(
+							(payload.kind as string) || null,
+							(payload.title as string) || null,
+							(payload.body_text as string) || null,
+							payload.confidence != null ? Number(payload.confidence) : null,
+							(payload.tags_text as string) ?? null,
+							payload.active != null ? Number(payload.active) : null,
+							op.clock_updated_at,
+							toJson(metaObj),
+							op.clock_rev,
+							(payload.deleted_at as string) || null,
+							importKey,
+						);
+					} else {
+						// Insert new memory item — need a local session (never reuse remote session_id)
+						const payload = op.payload_json ? fromJson(op.payload_json) : {};
+						const sessionId = ensureSessionForReplication(db, null, op.clock_updated_at);
+
+						const newMeta = payload.metadata_json ?? {};
+						const metaObj =
+							typeof newMeta === "object" && newMeta !== null
+								? (newMeta as Record<string, unknown>)
+								: {};
+						metaObj.clock_device_id = op.clock_device_id;
+
+						db.prepare(
+							`INSERT INTO memory_items(
+								session_id, kind, title, body_text, confidence, tags_text,
+								active, created_at, updated_at, metadata_json, import_key,
+								deleted_at, rev
+							) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+						).run(
+							sessionId,
+							(payload.kind as string) || "discovery",
+							(payload.title as string) || "",
+							(payload.body_text as string) || "",
+							payload.confidence != null ? Number(payload.confidence) : 0.5,
+							(payload.tags_text as string) || "",
+							payload.active != null ? Number(payload.active) : 1,
+							(payload.created_at as string) || op.clock_updated_at,
+							op.clock_updated_at,
+							toJson(metaObj),
+							importKey,
+							(payload.deleted_at as string) || null,
+							op.clock_rev,
+						);
+					}
+				} else if (op.op_type === "delete") {
+					const importKey = op.entity_id;
+					const existingForDelete = db
+						.prepare(
+							"SELECT id, rev, updated_at, metadata_json FROM memory_items WHERE import_key = ? LIMIT 1",
+						)
+						.get(importKey) as Record<string, unknown> | undefined;
+
+					if (existingForDelete) {
+						// Clock-compare: only delete if the incoming op is newer
+						const existingMeta =
+							typeof existingForDelete.metadata_json === "string"
+								? (fromJson(existingForDelete.metadata_json) as Record<string, unknown>)
+								: {};
+						const existingClock = clockTuple(
+							Number(existingForDelete.rev ?? 1),
+							String(existingForDelete.updated_at ?? ""),
+							String(existingMeta.clock_device_id ?? ""),
+						);
+						const incomingClock = clockTuple(op.clock_rev, op.clock_updated_at, op.clock_device_id);
+						if (!isNewerClock(incomingClock, existingClock)) {
+							result.conflicts++;
+							insertReplicationOpRow(db, op);
+							continue;
+						}
+						const now = new Date().toISOString();
+						db.prepare(
+							"UPDATE memory_items SET active = 0, deleted_at = COALESCE(deleted_at, ?), rev = ?, updated_at = ? WHERE id = ?",
+						).run(now, op.clock_rev, op.clock_updated_at, existingForDelete.id);
+					}
+					// If import_key not found, record the op as a tombstone for future resolution
+				} else {
+					result.skipped++;
+					insertReplicationOpRow(db, op);
+					continue;
+				}
+
+				// Record the applied op
+				insertReplicationOpRow(db, op);
+				result.applied++;
+			} catch (err) {
+				result.errors.push(`op ${op.op_id}: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+	});
+
+	applyAll();
+	return result;
+}
+
+/** Insert a replication op row into the replication_ops table. */
+function insertReplicationOpRow(db: Database, op: ReplicationOp): void {
+	db.prepare(
+		`INSERT OR IGNORE INTO replication_ops(
+			op_id, entity_type, entity_id, op_type, payload_json,
+			clock_rev, clock_updated_at, clock_device_id, device_id, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		op.op_id,
+		op.entity_type,
+		op.entity_id,
+		op.op_type,
+		op.payload_json,
+		op.clock_rev,
+		op.clock_updated_at,
+		op.clock_device_id,
+		op.device_id,
+		op.created_at,
+	);
+}
+
+/**
+ * Ensure a session row exists for replication inserts.
+ * Creates a minimal session if one doesn't exist yet.
+ */
+function ensureSessionForReplication(
+	db: Database,
+	sessionId: number | null,
+	createdAt: string,
+): number {
+	if (sessionId != null) {
+		const row = db.prepare("SELECT id FROM sessions WHERE id = ?").get(sessionId);
+		if (row) return sessionId;
+	}
+	// Create a new session for replicated data
+	const now = createdAt || new Date().toISOString();
+	const info = db
+		.prepare(
+			`INSERT INTO sessions(started_at, user, tool_version, metadata_json)
+			 VALUES (?, ?, ?, ?)`,
+		)
+		.run(now, "sync", "sync_replication", toJson({ source: "sync" }));
+	return Number(info.lastInsertRowid);
 }


### PR DESCRIPTION
## Description

Ports the core replication primitives needed for multi-device sync to actually exchange and apply memory items. Adds clock comparison, op recording, cursor-based pagination, and transactional apply with last-writer-wins conflict resolution.

**New functions:** `clockTuple`, `isNewerClock`, `recordReplicationOp`, `loadReplicationOpsSince`, `applyReplicationOps`

19 new tests covering clock comparison, op recording, cursor pagination, conflict resolution, idempotent duplicates, soft-delete propagation, and local-device skip logic.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (496 tests)
- [x] Added 19 new tests

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced