### PR TITLE
feat: add raw-events reliability metrics and gate command

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -2,6 +2,7 @@ import * as p from "@clack/prompts";
 import {
 	getRawEventStatus,
 	initDatabase,
+	rawEventsGate,
 	retryRawEventFailures,
 	vacuumDatabase,
 } from "@codemem/core";
@@ -78,4 +79,58 @@ dbCommand
 				p.intro("codemem db raw-events-retry");
 				p.outro(`Requeued ${result.retried.toLocaleString()} failed batch(es)`);
 			}),
+	)
+	.addCommand(
+		new Command("raw-events-gate")
+			.configureHelp(helpStyle)
+			.description("Validate raw-event reliability thresholds (non-zero exit on failure)")
+			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--min-flush-success-rate <rate>", "minimum flush success rate", "0.95")
+			.option("--max-dropped-event-rate <rate>", "maximum dropped event rate", "0.05")
+			.option("--min-session-boundary-accuracy <rate>", "minimum session boundary accuracy", "0.9")
+			.option("--window-hours <hours>", "lookback window in hours", "24")
+			.option("--json", "output as JSON")
+			.action(
+				(opts: {
+					db?: string;
+					minFlushSuccessRate: string;
+					maxDroppedEventRate: string;
+					minSessionBoundaryAccuracy: string;
+					windowHours: string;
+					json?: boolean;
+				}) => {
+					const result = rawEventsGate(opts.db, {
+						minFlushSuccessRate: Number.parseFloat(opts.minFlushSuccessRate),
+						maxDroppedEventRate: Number.parseFloat(opts.maxDroppedEventRate),
+						minSessionBoundaryAccuracy: Number.parseFloat(opts.minSessionBoundaryAccuracy),
+						windowHours: Number.parseFloat(opts.windowHours),
+					});
+
+					if (opts.json) {
+						console.log(JSON.stringify(result, null, 2));
+						if (!result.passed) process.exitCode = 1;
+						return;
+					}
+
+					p.intro("codemem db raw-events-gate");
+					p.log.info(
+						[
+							`flush_success_rate:          ${result.metrics.rates.flush_success_rate.toFixed(4)}`,
+							`dropped_event_rate:          ${result.metrics.rates.dropped_event_rate.toFixed(4)}`,
+							`session_boundary_accuracy:   ${result.metrics.rates.session_boundary_accuracy.toFixed(4)}`,
+							`window_hours:                ${result.metrics.window_hours ?? "all"}`,
+						].join("\n"),
+					);
+
+					if (result.passed) {
+						p.outro("reliability gate passed");
+					} else {
+						for (const f of result.failures) {
+							p.log.error(f);
+						}
+						p.outro("reliability gate FAILED");
+						process.exitCode = 1;
+					}
+				},
+			),
 	);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,10 +109,17 @@ export type {
 } from "./ingest-types.js";
 export { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
 export { parsePositiveMemoryId, parseStrictInteger } from "./integers.js";
-export type { RawEventStatusItem, RawEventStatusResult } from "./maintenance.js";
+export type {
+	GateResult,
+	RawEventStatusItem,
+	RawEventStatusResult,
+	ReliabilityMetrics,
+} from "./maintenance.js";
 export {
 	getRawEventStatus,
+	getReliabilityMetrics,
 	initDatabase,
+	rawEventsGate,
 	retryRawEventFailures,
 	vacuumDatabase,
 } from "./maintenance.js";

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -119,6 +119,183 @@ export function getRawEventStatus(dbPath?: string, limit = 25): RawEventStatusRe
 	});
 }
 
+// ---------------------------------------------------------------------------
+// Reliability metrics
+// ---------------------------------------------------------------------------
+
+export interface ReliabilityMetrics {
+	counts: {
+		inserted_events: number;
+		dropped_events: number;
+		started_batches: number;
+		running_batches: number;
+		completed_batches: number;
+		errored_batches: number;
+		terminal_batches: number;
+		sessions_with_events: number;
+		sessions_with_started_at: number;
+		retry_depth_max: number;
+	};
+	rates: {
+		flush_success_rate: number;
+		dropped_event_rate: number;
+		session_boundary_accuracy: number;
+	};
+	window_hours: number | null;
+}
+
+export function getReliabilityMetrics(
+	dbPath?: string,
+	windowHours?: number | null,
+): ReliabilityMetrics {
+	return withDb(dbPath, (db) => {
+		const cutoffIso =
+			windowHours != null ? new Date(Date.now() - windowHours * 3600 * 1000).toISOString() : null;
+
+		// Batch counts
+		const batchSql = `
+			SELECT
+				COALESCE(SUM(CASE WHEN status IN ('started', 'pending') THEN 1 ELSE 0 END), 0) AS started,
+				COALESCE(SUM(CASE WHEN status IN ('running', 'claimed') THEN 1 ELSE 0 END), 0) AS running,
+				COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0) AS completed,
+				COALESCE(SUM(CASE WHEN status IN ('error', 'failed') THEN 1 ELSE 0 END), 0) AS errored
+			FROM raw_event_flush_batches
+			${cutoffIso ? "WHERE updated_at >= ?" : ""}
+		`;
+		const batchRow = (
+			cutoffIso ? db.prepare(batchSql).get(cutoffIso) : db.prepare(batchSql).get()
+		) as Record<string, number> | undefined;
+
+		const startedBatches = Number(batchRow?.started ?? 0);
+		const runningBatches = Number(batchRow?.running ?? 0);
+		const completedBatches = Number(batchRow?.completed ?? 0);
+		const erroredBatches = Number(batchRow?.errored ?? 0);
+		const terminalBatches = completedBatches + erroredBatches;
+		const flushSuccessRate = terminalBatches > 0 ? completedBatches / terminalBatches : 1.0;
+
+		// Event counts from raw_event_sessions
+		// Sequences are 0-based indexes, so +1 converts to counts.
+		const eventSql = `
+			SELECT
+				COALESCE(SUM(last_received_event_seq + 1), 0) AS total_received,
+				COALESCE(SUM(CASE WHEN last_flushed_event_seq >= 0 THEN last_flushed_event_seq + 1 ELSE 0 END), 0) AS total_flushed
+			FROM raw_event_sessions
+			${cutoffIso ? "WHERE updated_at >= ?" : ""}
+		`;
+		const eventRow = (
+			cutoffIso ? db.prepare(eventSql).get(cutoffIso) : db.prepare(eventSql).get()
+		) as Record<string, number> | undefined;
+
+		// In-flight events: sum of (end_event_seq - start_event_seq + 1) for active batches
+		const inFlightSql = `
+			SELECT COALESCE(SUM(end_event_seq - start_event_seq + 1), 0) AS in_flight
+			FROM raw_event_flush_batches
+			WHERE status IN ('started', 'pending', 'running', 'claimed')
+			${cutoffIso ? "AND updated_at >= ?" : ""}
+		`;
+		const inFlightRow = (
+			cutoffIso ? db.prepare(inFlightSql).get(cutoffIso) : db.prepare(inFlightSql).get()
+		) as Record<string, number> | undefined;
+		const inFlightEvents = Number(inFlightRow?.in_flight ?? 0);
+
+		const insertedEvents = Number(eventRow?.total_flushed ?? 0);
+		const droppedEvents = Math.max(
+			0,
+			Number(eventRow?.total_received ?? 0) - Number(eventRow?.total_flushed ?? 0) - inFlightEvents,
+		);
+		const droppedDenom = insertedEvents + droppedEvents;
+		const droppedEventRate = droppedDenom > 0 ? droppedEvents / droppedDenom : 0.0;
+
+		// Session boundary accuracy
+		const boundarySql = `
+			WITH has_events AS (
+				SELECT DISTINCT source, stream_id FROM raw_events
+				${cutoffIso ? "WHERE created_at >= ?" : ""}
+			)
+			SELECT
+				COUNT(1) AS sessions_with_events,
+				COALESCE(SUM(CASE WHEN COALESCE(s.started_at, '') != '' THEN 1 ELSE 0 END), 0) AS sessions_with_started_at
+			FROM has_events e
+			LEFT JOIN raw_event_sessions s ON s.source = e.source AND s.stream_id = e.stream_id
+		`;
+		const boundaryRow = (
+			cutoffIso ? db.prepare(boundarySql).get(cutoffIso) : db.prepare(boundarySql).get()
+		) as Record<string, number> | undefined;
+
+		const sessionsWithEvents = Number(boundaryRow?.sessions_with_events ?? 0);
+		const sessionsWithStartedAt = Number(boundaryRow?.sessions_with_started_at ?? 0);
+		const sessionBoundaryAccuracy =
+			sessionsWithEvents > 0 ? sessionsWithStartedAt / sessionsWithEvents : 1.0;
+
+		return {
+			counts: {
+				inserted_events: insertedEvents,
+				dropped_events: droppedEvents,
+				started_batches: startedBatches,
+				running_batches: runningBatches,
+				completed_batches: completedBatches,
+				errored_batches: erroredBatches,
+				terminal_batches: terminalBatches,
+				sessions_with_events: sessionsWithEvents,
+				sessions_with_started_at: sessionsWithStartedAt,
+				retry_depth_max: 0, // TODO: needs attempt_count column
+			},
+			rates: {
+				flush_success_rate: flushSuccessRate,
+				dropped_event_rate: droppedEventRate,
+				session_boundary_accuracy: sessionBoundaryAccuracy,
+			},
+			window_hours: windowHours ?? null,
+		};
+	});
+}
+
+export interface GateResult {
+	passed: boolean;
+	failures: string[];
+	metrics: ReliabilityMetrics;
+}
+
+export function rawEventsGate(
+	dbPath?: string,
+	opts?: {
+		minFlushSuccessRate?: number;
+		maxDroppedEventRate?: number;
+		minSessionBoundaryAccuracy?: number;
+		windowHours?: number;
+	},
+): GateResult {
+	const minFlushSuccessRate = opts?.minFlushSuccessRate ?? 0.95;
+	const maxDroppedEventRate = opts?.maxDroppedEventRate ?? 0.05;
+	const minSessionBoundaryAccuracy = opts?.minSessionBoundaryAccuracy ?? 0.9;
+	const windowHours = opts?.windowHours ?? 24;
+
+	const metrics = getReliabilityMetrics(dbPath, windowHours);
+	const failures: string[] = [];
+
+	if (metrics.rates.flush_success_rate < minFlushSuccessRate) {
+		failures.push(
+			`flush_success_rate=${metrics.rates.flush_success_rate.toFixed(4)} < min ${minFlushSuccessRate.toFixed(4)}`,
+		);
+	}
+	if (metrics.rates.dropped_event_rate > maxDroppedEventRate) {
+		failures.push(
+			`dropped_event_rate=${metrics.rates.dropped_event_rate.toFixed(4)} > max ${maxDroppedEventRate.toFixed(4)}`,
+		);
+	}
+	if (metrics.rates.session_boundary_accuracy < minSessionBoundaryAccuracy) {
+		failures.push(
+			`session_boundary_accuracy=${metrics.rates.session_boundary_accuracy.toFixed(4)} < min ${minSessionBoundaryAccuracy.toFixed(4)}`,
+		);
+	}
+
+	return { passed: failures.length === 0, failures, metrics };
+}
+
+// ---------------------------------------------------------------------------
+// Retry
+// ---------------------------------------------------------------------------
+
 export function retryRawEventFailures(dbPath?: string, limit = 25): { retried: number } {
 	return withDb(dbPath, (db) => {
 		const now = new Date().toISOString();


### PR DESCRIPTION
## Description

Ports the raw-events reliability metrics and gate command from Python so operators can validate pipeline health without Python.

- `getReliabilityMetrics`: query flush success rate, dropped event rate, session boundary accuracy with optional time-window lookback
- `rawEventsGate`: threshold check returning pass/fail with failure details
- `codemem db raw-events-gate` CLI with configurable thresholds and --json output

Completes the DB maintenance epic baseline (codemem-l3b7).

## Type of Change
- [x] 🚀 Feature (new functionality)

## Testing
- [x] Tests pass locally (496 tests)
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced