### PR TITLE
fix: include memory payload in replication upsert ops

### DIFF
--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -235,6 +235,145 @@ describe("recordReplicationOp", () => {
 		expect(row.clock_device_id).toBe("dev-a");
 	});
 
+	it("includes full memory payload in upsert ops and round-trips all columns", () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		const meta = { clock_device_id: "dev-a", custom_field: "preserved" };
+		db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, subtitle, body_text, confidence, tags_text,
+				created_at, updated_at, import_key, rev, metadata_json, active,
+				actor_id, actor_display_name, visibility, workspace_id, workspace_kind,
+				origin_device_id, origin_source, trust_state, narrative,
+				facts, concepts, files_read, files_modified
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"feature",
+			"Ship TS port",
+			"The big one",
+			"Ported all the things",
+			0.95,
+			"ts port",
+			now,
+			now,
+			"key:payload",
+			2,
+			toJson(meta),
+			1,
+			"actor-1",
+			"Adam",
+			"shared",
+			"shared:team",
+			"shared",
+			"dev-a",
+			"manual",
+			"verified",
+			"Full narrative text",
+			toJson(["fact-1"]),
+			toJson(["concept-1"]),
+			toJson(["src/a.ts"]),
+			toJson(["src/b.ts"]),
+		);
+
+		const memId = (
+			db.prepare("SELECT id FROM memory_items WHERE import_key = ?").get("key:payload") as {
+				id: number;
+			}
+		).id;
+
+		const opId = recordReplicationOp(db, { memoryId: memId, opType: "upsert", deviceId: "dev-a" });
+		const row = db
+			.prepare("SELECT payload_json FROM replication_ops WHERE op_id = ?")
+			.get(opId) as { payload_json: string | null };
+
+		expect(row.payload_json).not.toBeNull();
+		const payload = JSON.parse(row.payload_json!) as Record<string, unknown>;
+		// Core fields
+		expect(payload.kind).toBe("feature");
+		expect(payload.title).toBe("Ship TS port");
+		expect(payload.subtitle).toBe("The big one");
+		expect(payload.body_text).toBe("Ported all the things");
+		expect(payload.confidence).toBe(0.95);
+		expect(payload.tags_text).toBe("ts port");
+		// Provenance fields
+		expect(payload.actor_id).toBe("actor-1");
+		expect(payload.visibility).toBe("shared");
+		expect(payload.workspace_id).toBe("shared:team");
+		expect(payload.origin_device_id).toBe("dev-a");
+		expect(payload.trust_state).toBe("verified");
+		// metadata_json should be an object, not a double-encoded string
+		expect(payload.metadata_json).toEqual({ clock_device_id: "dev-a", custom_field: "preserved" });
+		// JSON array fields should be arrays, not strings
+		expect(payload.facts).toEqual(["fact-1"]);
+		expect(payload.files_read).toEqual(["src/a.ts"]);
+
+		// Full round-trip: load op → apply to a second DB → verify all columns
+		const [ops] = loadReplicationOpsSince(db, null);
+		const op = ops.find((o) => o.op_id === opId);
+		expect(op).toBeDefined();
+
+		const db2 = new Database(":memory:");
+		initTestSchema(db2);
+		try {
+			const result = applyReplicationOps(db2, [op!], "dev-local");
+			expect(result.applied).toBe(1);
+
+			const applied = db2
+				.prepare("SELECT * FROM memory_items WHERE import_key = ?")
+				.get("key:payload") as Record<string, unknown>;
+			// Core fields
+			expect(applied.kind).toBe("feature");
+			expect(applied.title).toBe("Ship TS port");
+			expect(applied.subtitle).toBe("The big one");
+			expect(applied.body_text).toBe("Ported all the things");
+			expect(applied.confidence).toBe(0.95);
+			expect(applied.tags_text).toBe("ts port");
+			// Provenance fields survive
+			expect(applied.actor_id).toBe("actor-1");
+			expect(applied.actor_display_name).toBe("Adam");
+			expect(applied.visibility).toBe("shared");
+			expect(applied.workspace_id).toBe("shared:team");
+			expect(applied.workspace_kind).toBe("shared");
+			expect(applied.origin_device_id).toBe("dev-a");
+			expect(applied.origin_source).toBe("manual");
+			expect(applied.trust_state).toBe("verified");
+			expect(applied.narrative).toBe("Full narrative text");
+			// metadata_json round-trips as proper JSON with clock_device_id added
+			const appliedMeta = JSON.parse(applied.metadata_json as string);
+			expect(appliedMeta.custom_field).toBe("preserved");
+			expect(appliedMeta.clock_device_id).toBe("dev-a");
+			// JSON array columns round-trip
+			expect(JSON.parse(applied.facts as string)).toEqual(["fact-1"]);
+			expect(JSON.parse(applied.concepts as string)).toEqual(["concept-1"]);
+			expect(JSON.parse(applied.files_read as string)).toEqual(["src/a.ts"]);
+			expect(JSON.parse(applied.files_modified as string)).toEqual(["src/b.ts"]);
+		} finally {
+			db2.close();
+		}
+	});
+
+	it("stores null payload for delete ops", () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(sessionId, "discovery", "Will delete", "gone", now, now, "key:del", 1);
+
+		const memId = (
+			db.prepare("SELECT id FROM memory_items WHERE import_key = ?").get("key:del") as {
+				id: number;
+			}
+		).id;
+
+		const opId = recordReplicationOp(db, { memoryId: memId, opType: "delete", deviceId: "dev-a" });
+		const row = db
+			.prepare("SELECT payload_json FROM replication_ops WHERE op_id = ?")
+			.get(opId) as { payload_json: string | null };
+		expect(row.payload_json).toBeNull();
+	});
+
 	it("falls back to memoryId as entity_id when import_key is null", () => {
 		const sessionId = insertTestSession(db);
 		const now = new Date().toISOString();

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -208,25 +208,65 @@ export function recordReplicationOp(
 	const opId = randomUUID();
 	const now = new Date().toISOString();
 
-	// Read clock fields from the memory item
-	const row = db
-		.prepare("SELECT rev, updated_at, import_key, metadata_json FROM memory_items WHERE id = ?")
-		.get(opts.memoryId) as
-		| {
-				rev: number | null;
-				updated_at: string | null;
-				import_key: string | null;
-				metadata_json: string | null;
-		  }
+	// Read the full memory row for clock fields and payload
+	const row = db.prepare("SELECT * FROM memory_items WHERE id = ?").get(opts.memoryId) as
+		| Record<string, unknown>
 		| undefined;
 
-	const rev = row?.rev ?? 0;
-	const updatedAt = row?.updated_at ?? now;
-	const entityId = row?.import_key ?? String(opts.memoryId);
-	const metadata = fromJson(row?.metadata_json);
+	const rev = Number(row?.rev ?? 0);
+	const updatedAt = (row?.updated_at as string) ?? now;
+	const entityId = (row?.import_key as string) ?? String(opts.memoryId);
+	const metadata = fromJson(row?.metadata_json as string | null);
 	const clockDeviceId = (metadata.clock_device_id as string) || opts.deviceId;
 
-	const payloadJson = opts.payload ? toJson(opts.payload) : null;
+	// Build payload from the memory row so peers can reconstruct the full item.
+	// Explicit payload override takes precedence (used by tests).
+	let payloadJson: string | null;
+	if (opts.payload) {
+		payloadJson = toJson(opts.payload);
+	} else if (row && opts.opType === "upsert") {
+		// Parse JSON-string columns so they round-trip as objects, not double-encoded strings
+		const parseSqliteJson = (val: unknown): unknown => {
+			if (typeof val !== "string") return val ?? null;
+			try {
+				return JSON.parse(val);
+			} catch {
+				return val;
+			}
+		};
+
+		payloadJson = toJson({
+			session_id: row.session_id,
+			kind: row.kind,
+			title: row.title,
+			subtitle: row.subtitle,
+			body_text: row.body_text,
+			confidence: row.confidence,
+			tags_text: row.tags_text,
+			active: row.active,
+			created_at: row.created_at,
+			updated_at: row.updated_at,
+			metadata_json: parseSqliteJson(row.metadata_json),
+			actor_id: row.actor_id,
+			actor_display_name: row.actor_display_name,
+			visibility: row.visibility,
+			workspace_id: row.workspace_id,
+			workspace_kind: row.workspace_kind,
+			origin_device_id: row.origin_device_id,
+			origin_source: row.origin_source,
+			trust_state: row.trust_state,
+			facts: parseSqliteJson(row.facts),
+			narrative: row.narrative,
+			concepts: parseSqliteJson(row.concepts),
+			files_read: parseSqliteJson(row.files_read),
+			files_modified: parseSqliteJson(row.files_modified),
+			user_prompt_id: row.user_prompt_id,
+			prompt_number: row.prompt_number,
+			deleted_at: row.deleted_at,
+		});
+	} else {
+		payloadJson = null;
+	}
 
 	db.prepare(
 		`INSERT INTO replication_ops(
@@ -432,20 +472,35 @@ export function applyReplicationOps(
 
 						db.prepare(
 							`UPDATE memory_items SET
-								kind = COALESCE(?, kind),
-								title = COALESCE(?, title),
-								body_text = COALESCE(?, body_text),
-								confidence = COALESCE(?, confidence),
-								tags_text = COALESCE(?, tags_text),
-								active = COALESCE(?, active),
-								updated_at = ?,
-								metadata_json = ?,
-								rev = ?,
-								deleted_at = ?
-							WHERE import_key = ?`,
+							kind = COALESCE(?, kind),
+							title = COALESCE(?, title),
+							subtitle = ?,
+							body_text = COALESCE(?, body_text),
+							confidence = COALESCE(?, confidence),
+							tags_text = COALESCE(?, tags_text),
+							active = COALESCE(?, active),
+							updated_at = ?,
+							metadata_json = ?,
+							rev = ?,
+							deleted_at = ?,
+							actor_id = COALESCE(?, actor_id),
+							actor_display_name = COALESCE(?, actor_display_name),
+							visibility = COALESCE(?, visibility),
+							workspace_id = COALESCE(?, workspace_id),
+							workspace_kind = COALESCE(?, workspace_kind),
+							origin_device_id = COALESCE(?, origin_device_id),
+							origin_source = COALESCE(?, origin_source),
+							trust_state = COALESCE(?, trust_state),
+							narrative = ?,
+							facts = ?,
+							concepts = ?,
+							files_read = ?,
+							files_modified = ?
+						WHERE import_key = ?`,
 						).run(
 							(payload.kind as string) || null,
 							(payload.title as string) || null,
+							(payload.subtitle as string) ?? null,
 							(payload.body_text as string) || null,
 							payload.confidence != null ? Number(payload.confidence) : null,
 							(payload.tags_text as string) ?? null,
@@ -454,6 +509,19 @@ export function applyReplicationOps(
 							toJson(metaObj),
 							op.clock_rev,
 							(payload.deleted_at as string) || null,
+							(payload.actor_id as string) ?? null,
+							(payload.actor_display_name as string) ?? null,
+							(payload.visibility as string) ?? null,
+							(payload.workspace_id as string) ?? null,
+							(payload.workspace_kind as string) ?? null,
+							(payload.origin_device_id as string) ?? null,
+							(payload.origin_source as string) ?? null,
+							(payload.trust_state as string) ?? null,
+							(payload.narrative as string) ?? null,
+							toJson(payload.facts ?? null),
+							toJson(payload.concepts ?? null),
+							toJson(payload.files_read ?? null),
+							toJson(payload.files_modified ?? null),
 							importKey,
 						);
 					} else {
@@ -470,14 +538,18 @@ export function applyReplicationOps(
 
 						db.prepare(
 							`INSERT INTO memory_items(
-								session_id, kind, title, body_text, confidence, tags_text,
-								active, created_at, updated_at, metadata_json, import_key,
-								deleted_at, rev
-							) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+							session_id, kind, title, subtitle, body_text, confidence, tags_text,
+							active, created_at, updated_at, metadata_json, import_key,
+							deleted_at, rev,
+							actor_id, actor_display_name, visibility, workspace_id,
+							workspace_kind, origin_device_id, origin_source, trust_state,
+							narrative, facts, concepts, files_read, files_modified
+						) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 						).run(
 							sessionId,
 							(payload.kind as string) || "discovery",
 							(payload.title as string) || "",
+							(payload.subtitle as string) ?? null,
 							(payload.body_text as string) || "",
 							payload.confidence != null ? Number(payload.confidence) : 0.5,
 							(payload.tags_text as string) || "",
@@ -488,6 +560,19 @@ export function applyReplicationOps(
 							importKey,
 							(payload.deleted_at as string) || null,
 							op.clock_rev,
+							(payload.actor_id as string) ?? null,
+							(payload.actor_display_name as string) ?? null,
+							(payload.visibility as string) ?? null,
+							(payload.workspace_id as string) ?? null,
+							(payload.workspace_kind as string) ?? null,
+							(payload.origin_device_id as string) ?? null,
+							(payload.origin_source as string) ?? null,
+							(payload.trust_state as string) ?? null,
+							(payload.narrative as string) ?? null,
+							toJson(payload.facts ?? null),
+							toJson(payload.concepts ?? null),
+							toJson(payload.files_read ?? null),
+							toJson(payload.files_modified ?? null),
 						);
 					}
 				} else if (op.op_type === "delete") {


### PR DESCRIPTION
## Description

Fixes a bug where `recordReplicationOp()` stored `payload_json=null` for upsert ops, causing peers to insert blank memories (kind="discovery", empty title/body, default confidence) instead of the actual content.

**Root cause:** The calls added in PR #309 (`remember()`, `forget()`, `updateMemoryVisibility()`) pass `opType: "upsert"` but no `payload`. The `recordReplicationOp` function stored `null` when no payload was provided. `applyReplicationOps()` rebuilds the memory entirely from the payload, so `null` → blank defaults.

**Fix:** When `opType` is `"upsert"` and no explicit payload is passed, `recordReplicationOp` now reads the full `memory_items` row (`SELECT *`) and builds the payload automatically. Delete ops continue to store `null` payload (correct — only the import_key and clock are needed).

**Verification:** Added a round-trip test: `remember → recordReplicationOp → loadReplicationOpsSince → applyReplicationOps` on a second in-memory DB, asserting kind/title/body/confidence survive intact. Also added a test confirming delete ops store null payload.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (498 tests — 2 new)
- [x] Round-trip test verifies the exact scenario from the review

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced