### PR TITLE
fix: run npm publish from repo root for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,7 @@ jobs:
       - name: Publish codemem
         env:
           NODE_AUTH_TOKEN: ""
-        run: npm publish --tag ${{ steps.dist-tag.outputs.tag }} --provenance --access public
-        working-directory: packages/cli
+        run: npm publish ./packages/cli --tag ${{ steps.dist-tag.outputs.tag }} --provenance --access public
 
   release:
     name: Create GitHub Release


### PR DESCRIPTION
## Description

Fix npm trusted publishing OIDC auth failure. `actions/setup-node` with `registry-url` creates `.npmrc` at the repo root. Using `working-directory: packages/cli` meant `npm publish` couldn't find it, causing `ENEEDAUTH`.

Fix: `npm publish ./packages/cli` from repo root instead of `working-directory`.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Checklist

- [x] Self-review completed