### PR TITLE
fix: auto-detect pre-release tags in GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ github.ref_name }}" == *"-alpha"* ]] || \
+             [[ "${{ github.ref_name }}" == *"-beta"* ]] || \
+             [[ "${{ github.ref_name }}" == *"-rc"* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
           if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
             echo "Release already exists"
           else
             gh release create "${{ github.ref_name }}" \
               --generate-notes \
-              --title "Release ${{ github.ref_name }}"
+              --title "Release ${{ github.ref_name }}" \
+              $PRERELEASE_FLAG
           fi


### PR DESCRIPTION
## Description

Tags containing `-alpha`, `-beta`, or `-rc` now automatically get the `--prerelease` flag when creating the GitHub release. Previously all releases were created as stable regardless of the tag.

Also already fixed `v0.20.0-alpha.1` via `gh release edit --prerelease`.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Checklist

- [x] Self-review completed