### PR TITLE
feat: publish workspace packages to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,16 @@ jobs:
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish codemem
+      - name: Publish packages
         env:
           NODE_AUTH_TOKEN: ""
-        run: npm publish ./packages/cli --tag ${{ steps.dist-tag.outputs.tag }} --provenance --access public
+        run: |
+          DIST_TAG="${{ steps.dist-tag.outputs.tag }}"
+          # Publish in dependency order: core → mcp, server → cli
+          npm publish ./packages/core --tag "$DIST_TAG" --provenance --access public
+          npm publish ./packages/mcp-server --tag "$DIST_TAG" --provenance --access public
+          npm publish ./packages/viewer-server --tag "$DIST_TAG" --provenance --access public
+          npm publish ./packages/cli --tag "$DIST_TAG" --provenance --access public
 
   release:
     name: Create GitHub Release

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,8 +21,8 @@
 	"dependencies": {
 		"@clack/prompts": "^1.1.0",
 		"@codemem/core": "workspace:*",
-		"@codemem/mcp-server": "workspace:*",
-		"@codemem/viewer-server": "workspace:*",
+		"@codemem/mcp": "workspace:*",
+		"@codemem/server": "workspace:*",
 		"@hono/node-server": "^1.14.3",
 		"commander": "^14.0.3",
 		"drizzle-orm": "^0.45.1",

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -8,5 +8,5 @@ export const mcpCommand = new Command("mcp")
 	.action(async (opts: { db?: string }) => {
 		if (opts.db) process.env.CODEMEM_DB = opts.db;
 		// Dynamic import — MCP server is its own entry point
-		await import("@codemem/mcp-server");
+		await import("@codemem/mcp");
 	});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -108,7 +108,7 @@ export const serveCommand = new Command("serve")
 			restart?: boolean;
 		}) => {
 			// Dynamic import to avoid loading hono/server deps for non-serve commands
-			const { createApp, closeStore, getStore } = await import("@codemem/viewer-server");
+			const { createApp, closeStore, getStore } = await import("@codemem/server");
 			const { serve } = await import("@hono/node-server");
 
 			const dbPath = resolveDbPath(opts.db);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.0.1",
-	"private": true,
+	"version": "0.20.0-alpha.1",
 	"type": "module",
 	"exports": {
 		".": {
@@ -10,6 +9,9 @@
 			"types": "./dist/index.d.ts"
 		}
 	},
+	"files": [
+		"dist/"
+	],
 	"scripts": {
 		"clean": "rm -rf dist",
 		"build": "pnpm exec vite build && pnpm exec tsc --emitDeclarationOnly",
@@ -26,5 +28,14 @@
 		"drizzle-orm": "^0.45.1",
 		"hono": "^4.7.10",
 		"sqlite-vec": "0.1.7-alpha.2"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kunickiaj/codemem.git",
+		"directory": "packages/core"
+	},
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,6 @@
 {
-	"name": "@codemem/mcp-server",
-	"version": "0.0.1",
-	"private": true,
+	"name": "@codemem/mcp",
+	"version": "0.20.0-alpha.1",
 	"type": "module",
 	"exports": {
 		".": {
@@ -13,6 +12,9 @@
 	"bin": {
 		"codemem-mcp-ts": "./dist/index.js"
 	},
+	"files": [
+		"dist/"
+	],
 	"scripts": {
 		"clean": "rm -rf dist",
 		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist",
@@ -28,5 +30,14 @@
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kunickiaj/codemem.git",
+		"directory": "packages/mcp-server"
+	},
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @codemem/mcp-server — MCP stdio server.
+ * @codemem/mcp — MCP stdio server.
  *
  * Runs as a separate process spawned by the host (OpenCode/Claude).
  * Owns its own better-sqlite3 connection. Communicates via stdio JSON-RPC.

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,7 +1,6 @@
 {
-	"name": "@codemem/viewer-server",
-	"version": "0.0.1",
-	"private": true,
+	"name": "@codemem/server",
+	"version": "0.20.0-alpha.1",
 	"type": "module",
 	"exports": {
 		".": {
@@ -10,6 +9,9 @@
 			"types": "./dist/index.d.ts"
 		}
 	},
+	"files": [
+		"dist/"
+	],
 	"scripts": {
 		"clean": "rm -rf dist",
 		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist",
@@ -29,5 +31,14 @@
 		"typescript": "catalog:",
 		"vite": "catalog:",
 		"vitest": "catalog:"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kunickiaj/codemem.git",
+		"directory": "packages/viewer-server"
+	},
+	"license": "MIT",
+	"publishConfig": {
+		"access": "public"
 	}
 }

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @codemem/viewer-server — unified viewer + sync process.
+ * @codemem/server — HTTP server (viewer, sync, API).
  *
  * Single HTTP server handling viewer routes and sync daemon.
  * Shares one better-sqlite3 connection between viewer and sync.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,10 +47,10 @@ importers:
       '@codemem/core':
         specifier: workspace:*
         version: link:../core
-      '@codemem/mcp-server':
+      '@codemem/mcp':
         specifier: workspace:*
         version: link:../mcp-server
-      '@codemem/viewer-server':
+      '@codemem/server':
         specifier: workspace:*
         version: link:../viewer-server
       '@hono/node-server':


### PR DESCRIPTION
## Description

Fix `npm i -g codemem@alpha` failing because workspace packages weren't published. The CLI's `workspace:*` dependencies on `@codemem/core`, `@codemem/mcp-server`, `@codemem/viewer-server` couldn't resolve since those packages didn't exist on npm.

### Changes

**Publish workspace packages:**
- `@codemem/core` — store, embeddings, types
- `@codemem/mcp` (renamed from `@codemem/mcp-server`) — MCP stdio server
- `@codemem/server` (renamed from `@codemem/viewer-server`) — HTTP server (viewer + sync + API)

All set to `0.20.0-alpha.1`, `publishConfig.access: public`, with `files`, `repository`, `license`.

**Renames:**
- `@codemem/mcp-server` → `@codemem/mcp` (matches `codemem mcp` subcommand)
- `@codemem/viewer-server` → `@codemem/server` (it hosts viewer, sync, config, raw-events — not just viewer)

**Release workflow:** publishes all 4 packages in dependency order (core → mcp, server → cli).

### npm setup needed
Create placeholder packages on npm and configure trusted publishing for:
- `@codemem/core` — repo `kunickiaj/codemem`, workflow `release.yml`, environment `release`
- `@codemem/mcp` — same
- `@codemem/server` — same

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Tests pass (`pnpm test` — 498 tests)
- [x] Build passes (`pnpm clean && pnpm build`)
- [x] Lint passes

## Checklist

- [x] Code follows project style
- [x] Self-review completed