### PR TITLE
fix: use pnpm publish, bundle viewer static, workspace:^

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Assemble viewer static assets
+        run: |
+          mkdir -p packages/viewer-server/static
+          cp codemem/viewer_static/index.html codemem/viewer_static/favicon.svg packages/viewer-server/static/
+          cd viewer_ui && npx vite build --mode production
+
       - name: Build
         run: pnpm run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Assemble viewer static assets
+        run: |
+          mkdir -p packages/viewer-server/static
+          cp codemem/viewer_static/index.html codemem/viewer_static/favicon.svg packages/viewer-server/static/
+          cd viewer_ui && npx vite build --mode production
+
       - name: Build
         run: pnpm run build
 
@@ -60,11 +66,12 @@ jobs:
           NODE_AUTH_TOKEN: ""
         run: |
           DIST_TAG="${{ steps.dist-tag.outputs.tag }}"
+          # pnpm publish resolves workspace:^ to actual version ranges.
           # Publish in dependency order: core → mcp, server → cli
-          npm publish ./packages/core --tag "$DIST_TAG" --provenance --access public
-          npm publish ./packages/mcp-server --tag "$DIST_TAG" --provenance --access public
-          npm publish ./packages/viewer-server --tag "$DIST_TAG" --provenance --access public
-          npm publish ./packages/cli --tag "$DIST_TAG" --provenance --access public
+          pnpm --filter @codemem/core publish --tag "$DIST_TAG" --provenance --access public --no-git-checks
+          pnpm --filter @codemem/mcp publish --tag "$DIST_TAG" --provenance --access public --no-git-checks
+          pnpm --filter @codemem/server publish --tag "$DIST_TAG" --provenance --access public --no-git-checks
+          pnpm --filter codemem publish --tag "$DIST_TAG" --provenance --access public --no-git-checks
 
   release:
     name: Create GitHub Release

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ packages/*/dist/
 *.tsbuildinfo
 *.heapsnapshot
 
+# Viewer UI build output (copied/built during CI from codemem/viewer_static/)
+packages/viewer-server/static/
+
 # Agent skill symlink dirs (canonical source is .agents/skills/)
 # Keep .agents/ and .claude/ — ignore other agent tool dirs
 .adal/

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,9 +20,9 @@
 	},
 	"dependencies": {
 		"@clack/prompts": "^1.1.0",
-		"@codemem/core": "workspace:*",
-		"@codemem/mcp": "workspace:*",
-		"@codemem/server": "workspace:*",
+		"@codemem/core": "workspace:^",
+		"@codemem/mcp": "workspace:^",
+		"@codemem/server": "workspace:^",
 		"@hono/node-server": "^1.14.3",
 		"commander": "^14.0.3",
 		"drizzle-orm": "^0.45.1",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -21,7 +21,7 @@
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {
-		"@codemem/core": "workspace:*",
+		"@codemem/core": "workspace:^",
 		"@modelcontextprotocol/sdk": "^1.27.1",
 		"zod": "^4.3.6"
 	},

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -10,7 +10,8 @@
 		}
 	},
 	"files": [
-		"dist/"
+		"dist/",
+		"static/"
 	],
 	"scripts": {
 		"clean": "rm -rf dist",
@@ -18,7 +19,7 @@
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {
-		"@codemem/core": "workspace:*",
+		"@codemem/core": "workspace:^",
 		"@hono/node-server": "^1.14.3",
 		"drizzle-orm": "^0.45.1",
 		"hono": "^4.7.10"

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -66,10 +66,10 @@ export function createApp(opts?: AppOptions) {
 	app.route("/", rawEventsRoutes(storeFactory, sweeper));
 	app.route("/", syncRoutes(storeFactory));
 
-	// Static assets — serve viewer_static/ under /assets/*
+	// Static assets — serve under /assets/*
+	// Resolves to packages/viewer-server/static/ both in dev and when installed from npm.
 	const staticRoot =
-		process.env.CODEMEM_VIEWER_STATIC_DIR ??
-		join(import.meta.dirname ?? ".", "../../../codemem/viewer_static");
+		process.env.CODEMEM_VIEWER_STATIC_DIR ?? join(import.meta.dirname ?? ".", "../static");
 
 	app.use(
 		"/assets/*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,13 +45,13 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       '@codemem/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@codemem/mcp':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../mcp-server
       '@codemem/server':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../viewer-server
       '@hono/node-server':
         specifier: ^1.14.3
@@ -116,7 +116,7 @@ importers:
   packages/mcp-server:
     dependencies:
       '@codemem/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
@@ -141,7 +141,7 @@ importers:
   packages/viewer-server:
     dependencies:
       '@codemem/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@hono/node-server':
         specifier: ^1.14.3

--- a/viewer_ui/vite.config.ts
+++ b/viewer_ui/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig(({ mode }) => ({
   build: {
-    outDir: resolve(__dirname, "../codemem/viewer_static"),
+    outDir: resolve(__dirname, "../packages/viewer-server/static"),
     emptyOutDir: false,
     lib: {
       entry: resolve(__dirname, "src/app.ts"),


### PR DESCRIPTION
## Description

Address PR #324 review feedback — three fixes for npm install to actually work:

1. **workspace:* → workspace:^** — pnpm resolves `workspace:^` to `^0.20.0-alpha.1` in published tarballs. `workspace:*` resolved to `>=0.0.0` which is wrong.

2. **Bundle viewer static assets** — Copy `index.html`, `app.js`, `favicon.svg` into `@codemem/server` package (`static/`). Server resolves from `../static` relative to `dist/`. Previously referenced Python's `codemem/viewer_static/` which doesn't exist when installed from npm.

3. **pnpm publish instead of npm publish** — `pnpm --filter <pkg> publish` resolves `workspace:^` to actual version ranges. `npm publish` leaves them as raw `workspace:^` strings which npm can't resolve.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Tests pass (`pnpm test` — 498 tests)
- [x] Lint passes

## Checklist

- [x] Code follows project style
- [x] Self-review completed