### PR TITLE
fix: restore serve lifecycle commands and foreground semantics

### DIFF
--- a/packages/cli/src/commands/serve-invocation.ts
+++ b/packages/cli/src/commands/serve-invocation.ts
@@ -1,0 +1,103 @@
+export type ServeMode = "start" | "stop" | "restart";
+
+export type ServeAction = ServeMode | undefined;
+
+export interface LegacyServeOptions {
+	db?: string;
+	dbPath?: string;
+	host: string;
+	port: string;
+	background?: boolean;
+	foreground?: boolean;
+	stop?: boolean;
+	restart?: boolean;
+}
+
+export interface StartServeOptions {
+	db?: string;
+	dbPath?: string;
+	host: string;
+	port: string;
+	foreground?: boolean;
+}
+
+export interface StopRestartServeOptions {
+	db?: string;
+	dbPath?: string;
+	host: string;
+	port: string;
+}
+
+export interface ResolvedServeInvocation {
+	mode: ServeMode;
+	dbPath: string | null;
+	host: string;
+	port: number;
+	background: boolean;
+}
+
+function parsePort(rawPort: string): number {
+	const port = Number.parseInt(rawPort, 10);
+	if (!Number.isFinite(port) || port < 1 || port > 65535) {
+		throw new Error(`Invalid port: ${rawPort}`);
+	}
+	return port;
+}
+
+export function resolveLegacyServeInvocation(opts: LegacyServeOptions): ResolvedServeInvocation {
+	if (opts.stop && opts.restart) {
+		throw new Error("Use only one of --stop or --restart");
+	}
+	if (opts.foreground && opts.background) {
+		throw new Error("Use only one of --background or --foreground");
+	}
+	const dbPath = opts.db ?? opts.dbPath ?? null;
+	return {
+		mode: opts.stop ? "stop" : opts.restart ? "restart" : "start",
+		dbPath,
+		host: opts.host,
+		port: parsePort(opts.port),
+		background: opts.restart ? true : opts.background ? true : false,
+	};
+}
+
+export function resolveServeInvocation(
+	action: ServeAction,
+	opts: LegacyServeOptions,
+): ResolvedServeInvocation {
+	if (action === undefined) {
+		return resolveLegacyServeInvocation(opts);
+	}
+	if (opts.stop || opts.restart) {
+		throw new Error("Do not combine lifecycle flags with a serve action");
+	}
+	if (action === "start") {
+		return resolveStartServeInvocation(opts);
+	}
+	return resolveStopRestartInvocation(action, opts);
+}
+
+export function resolveStartServeInvocation(opts: StartServeOptions): ResolvedServeInvocation {
+	const dbPath = opts.db ?? opts.dbPath ?? null;
+	return {
+		mode: "start",
+		dbPath,
+		host: opts.host,
+		port: parsePort(opts.port),
+		background: !opts.foreground,
+	};
+}
+
+export function resolveStopRestartInvocation(
+	mode: "stop" | "restart",
+	opts: StopRestartServeOptions,
+): ResolvedServeInvocation {
+	const dbPath = opts.db ?? opts.dbPath ?? null;
+	return {
+		mode,
+		dbPath,
+		host: opts.host,
+		port: parsePort(opts.port),
+		background: mode === "restart",
+	};
+}

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { buildForegroundRunnerArgs } from "./serve.js";
+import {
+	resolveLegacyServeInvocation,
+	resolveServeInvocation,
+	resolveStartServeInvocation,
+	resolveStopRestartInvocation,
+} from "./serve-invocation.js";
+
+describe("serve command option resolution", () => {
+	it("treats bare serve as a foreground start", () => {
+		const resolved = resolveLegacyServeInvocation({ host: "127.0.0.1", port: "38888" });
+		expect(resolved).toEqual({
+			mode: "start",
+			dbPath: null,
+			host: "127.0.0.1",
+			port: 38888,
+			background: false,
+		});
+	});
+
+	it("treats serve --background as a background start", () => {
+		const resolved = resolveLegacyServeInvocation({
+			host: "127.0.0.1",
+			port: "38888",
+			background: true,
+		});
+		expect(resolved.mode).toBe("start");
+		expect(resolved.background).toBe(true);
+	});
+
+	it("maps serve --stop to stop mode", () => {
+		const resolved = resolveLegacyServeInvocation({
+			host: "127.0.0.1",
+			port: "38888",
+			stop: true,
+		});
+		expect(resolved.mode).toBe("stop");
+		expect(resolved.background).toBe(false);
+	});
+
+	it("maps serve --restart to restart mode", () => {
+		const resolved = resolveLegacyServeInvocation({
+			host: "127.0.0.1",
+			port: "38888",
+			restart: true,
+		});
+		expect(resolved.mode).toBe("restart");
+		expect(resolved.background).toBe(true);
+	});
+
+	it("rejects conflicting legacy stop and restart flags", () => {
+		expect(() =>
+			resolveLegacyServeInvocation({
+				host: "127.0.0.1",
+				port: "38888",
+				stop: true,
+				restart: true,
+			}),
+		).toThrow("Use only one of --stop or --restart");
+	});
+
+	it("maps serve stop to stop mode", () => {
+		const resolved = resolveStopRestartInvocation("stop", {
+			host: "127.0.0.1",
+			port: "38888",
+		});
+		expect(resolved.mode).toBe("stop");
+		expect(resolved.background).toBe(false);
+	});
+
+	it("maps serve restart to restart mode", () => {
+		const resolved = resolveStopRestartInvocation("restart", {
+			host: "127.0.0.1",
+			port: "38888",
+		});
+		expect(resolved.mode).toBe("restart");
+		expect(resolved.background).toBe(true);
+	});
+
+	it("defaults serve start to background mode", () => {
+		const resolved = resolveStartServeInvocation({ host: "127.0.0.1", port: "38888" });
+		expect(resolved.mode).toBe("start");
+		expect(resolved.background).toBe(true);
+	});
+
+	it("supports serve start --foreground", () => {
+		const resolved = resolveStartServeInvocation({
+			host: "127.0.0.1",
+			port: "38888",
+			foreground: true,
+		});
+		expect(resolved.mode).toBe("start");
+		expect(resolved.background).toBe(false);
+	});
+
+	it("supports serve start through the shared action resolver", () => {
+		const resolved = resolveServeInvocation("start", {
+			host: "127.0.0.1",
+			port: "38888",
+			foreground: true,
+		});
+		expect(resolved.mode).toBe("start");
+		expect(resolved.background).toBe(false);
+	});
+
+	it("builds background child args from the current runner", () => {
+		const args = buildForegroundRunnerArgs(
+			"/repo/packages/cli/src/index.ts",
+			{
+				mode: "start",
+				dbPath: "/tmp/test.sqlite",
+				host: "127.0.0.1",
+				port: 38991,
+				background: true,
+			},
+			["--conditions", "source"],
+		);
+		expect(args).toEqual([
+			"--conditions",
+			"source",
+			"/repo/packages/cli/src/index.ts",
+			"serve",
+			"start",
+			"--foreground",
+			"--host",
+			"127.0.0.1",
+			"--port",
+			"38991",
+			"--db-path",
+			"/tmp/test.sqlite",
+		]);
+	});
+});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,4 +1,6 @@
+import { spawn } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
 import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import {
@@ -10,15 +12,21 @@ import {
 } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
-
-function pidFilePath(dbPath: string): string {
-	return join(dirname(dbPath), "viewer.pid");
-}
+import {
+	type LegacyServeOptions,
+	type ResolvedServeInvocation,
+	resolveServeInvocation,
+	type ServeAction,
+} from "./serve-invocation.js";
 
 interface ViewerPidRecord {
 	pid: number;
 	host: string;
 	port: number;
+}
+
+function pidFilePath(dbPath: string): string {
+	return join(dirname(dbPath), "viewer.pid");
 }
 
 function readViewerPidRecord(dbPath: string): ViewerPidRecord | null {
@@ -43,6 +51,15 @@ function readViewerPidRecord(dbPath: string): ViewerPidRecord | null {
 	return null;
 }
 
+function isProcessRunning(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 async function respondsLikeCodememViewer(record: ViewerPidRecord): Promise<boolean> {
 	try {
 		const controller = new AbortController();
@@ -57,23 +74,35 @@ async function respondsLikeCodememViewer(record: ViewerPidRecord): Promise<boole
 	}
 }
 
+async function isPortOpen(host: string, port: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const socket = net.createConnection({ host, port });
+		const done = (open: boolean) => {
+			socket.removeAllListeners();
+			socket.destroy();
+			resolve(open);
+		};
+		socket.setTimeout(300);
+		socket.once("connect", () => done(true));
+		socket.once("timeout", () => done(false));
+		socket.once("error", () => done(false));
+	});
+}
+
 async function waitForProcessExit(pid: number, timeoutMs = 5000): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
-		try {
-			process.kill(pid, 0);
-			await new Promise((resolve) => setTimeout(resolve, 100));
-		} catch {
-			return;
-		}
+		if (!isProcessRunning(pid)) return;
+		await new Promise((resolve) => setTimeout(resolve, 100));
 	}
 }
 
-async function stopExistingViewer(dbPath: string): Promise<void> {
+async function stopExistingViewer(
+	dbPath: string,
+): Promise<{ stopped: boolean; pid: number | null }> {
 	const pidPath = pidFilePath(dbPath);
 	const record = readViewerPidRecord(dbPath);
-	if (!record) return;
-	// Only signal the process if the recorded endpoint still looks like codemem.
+	if (!record) return { stopped: false, pid: null };
 	if (await respondsLikeCodememViewer(record)) {
 		try {
 			process.kill(record.pid, "SIGTERM");
@@ -87,122 +116,219 @@ async function stopExistingViewer(dbPath: string): Promise<void> {
 	} catch {
 		// ignore
 	}
+	return { stopped: true, pid: record.pid };
 }
 
-export const serveCommand = new Command("serve")
-	.configureHelp(helpStyle)
-	.description("Start the viewer server")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--host <host>", "bind host", "127.0.0.1")
-	.option("--port <port>", "bind port", "38888")
-	.option("--background", "run under a caller-managed background process")
-	.option("--stop", "stop an existing viewer process")
-	.option("--restart", "restart an existing viewer process")
-	.action(
-		async (opts: {
-			db?: string;
-			host: string;
-			port: string;
-			background?: boolean;
-			stop?: boolean;
-			restart?: boolean;
-		}) => {
-			// Dynamic import to avoid loading hono/server deps for non-serve commands
-			const { createApp, closeStore, getStore } = await import("@codemem/server");
-			const { serve } = await import("@hono/node-server");
+export function buildForegroundRunnerArgs(
+	scriptPath: string,
+	invocation: ResolvedServeInvocation,
+	execArgv: string[] = process.execArgv,
+): string[] {
+	const args = [
+		...execArgv,
+		scriptPath,
+		"serve",
+		"start",
+		"--foreground",
+		"--host",
+		invocation.host,
+		"--port",
+		String(invocation.port),
+	];
+	if (invocation.dbPath) {
+		args.push("--db-path", invocation.dbPath);
+	}
+	return args;
+}
 
-			const dbPath = resolveDbPath(opts.db);
-			if (opts.stop || opts.restart) {
-				await stopExistingViewer(dbPath);
-				if (opts.stop && !opts.restart) return;
-			}
-			process.env.CODEMEM_DB = dbPath;
+async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promise<void> {
+	if (await isPortOpen(invocation.host, invocation.port)) {
+		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
+		return;
+	}
+	const scriptPath = process.argv[1];
+	if (!scriptPath) throw new Error("Unable to resolve CLI entrypoint for background launch");
+	const child = spawn(process.execPath, buildForegroundRunnerArgs(scriptPath, invocation), {
+		cwd: process.cwd(),
+		detached: true,
+		stdio: "ignore",
+		env: {
+			...process.env,
+			...(invocation.dbPath ? { CODEMEM_DB: invocation.dbPath } : {}),
+		},
+	});
+	child.unref();
+	if (invocation.dbPath) {
+		writeFileSync(
+			pidFilePath(invocation.dbPath),
+			JSON.stringify({ pid: child.pid, host: invocation.host, port: invocation.port }),
+			"utf-8",
+		);
+	}
+	p.intro("codemem viewer");
+	p.outro(
+		`Viewer started in background (pid ${child.pid}) at http://${invocation.host}:${invocation.port}`,
+	);
+}
 
-			const port = Number.parseInt(opts.port, 10);
-			// Start the raw event sweeper — shares the same store as the viewer
-			const observer = new ObserverClient();
-			const sweeper = new RawEventSweeper(getStore(), { observer });
-			sweeper.start();
+async function startForegroundViewer(invocation: ResolvedServeInvocation): Promise<void> {
+	const { createApp, closeStore, getStore } = await import("@codemem/server");
+	const { serve } = await import("@hono/node-server");
 
-			// Start the sync daemon if enabled — shares the same DB path.
-			// Uses an AbortController so serve shutdown cleanly stops sync.
-			const syncAbort = new AbortController();
-			let syncRunning = false;
-			const config = readCodememConfigFile();
-			const syncEnabled =
-				config.sync_enabled === true ||
-				process.env.CODEMEM_SYNC_ENABLED?.toLowerCase() === "true" ||
-				process.env.CODEMEM_SYNC_ENABLED === "1";
+	if (invocation.dbPath) process.env.CODEMEM_DB = invocation.dbPath;
+	if (await isPortOpen(invocation.host, invocation.port)) {
+		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
+		process.exitCode = 1;
+		return;
+	}
 
-			if (syncEnabled) {
-				syncRunning = true;
-				const syncIntervalS =
-					typeof config.sync_interval_s === "number" ? config.sync_interval_s : 120;
-				runSyncDaemon({
-					dbPath,
-					intervalS: syncIntervalS,
-					host: opts.host,
-					port,
-					signal: syncAbort.signal,
-				})
-					.catch((err: unknown) => {
-						const msg = err instanceof Error ? err.message : String(err);
-						p.log.error(`Sync daemon failed: ${msg}`);
-						// Non-fatal — viewer continues without sync
-					})
-					.finally(() => {
-						syncRunning = false;
-					});
-			}
+	const observer = new ObserverClient();
+	const sweeper = new RawEventSweeper(getStore(), { observer });
+	sweeper.start();
 
-			const app = createApp({ storeFactory: getStore, sweeper });
-			const pidPath = pidFilePath(dbPath);
+	const syncAbort = new AbortController();
+	let syncRunning = false;
+	const config = readCodememConfigFile();
+	const syncEnabled =
+		config.sync_enabled === true ||
+		process.env.CODEMEM_SYNC_ENABLED?.toLowerCase() === "true" ||
+		process.env.CODEMEM_SYNC_ENABLED === "1";
 
-			const server = serve({ fetch: app.fetch, hostname: opts.host, port }, (info) => {
-				writeFileSync(
-					pidPath,
-					JSON.stringify({ pid: process.pid, host: opts.host, port }),
-					"utf-8",
-				);
-				p.intro("codemem viewer");
-				p.log.success(`Listening on http://${info.address}:${info.port}`);
-				p.log.info(`Database: ${dbPath}`);
-				p.log.step("Raw event sweeper started");
-				if (syncRunning) p.log.step("Sync daemon started");
+	if (syncEnabled) {
+		syncRunning = true;
+		const syncIntervalS = typeof config.sync_interval_s === "number" ? config.sync_interval_s : 120;
+		runSyncDaemon({
+			dbPath: resolveDbPath(invocation.dbPath ?? undefined),
+			intervalS: syncIntervalS,
+			host: invocation.host,
+			port: invocation.port,
+			signal: syncAbort.signal,
+		})
+			.catch((err: unknown) => {
+				const msg = err instanceof Error ? err.message : String(err);
+				p.log.error(`Sync daemon failed: ${msg}`);
+			})
+			.finally(() => {
+				syncRunning = false;
 			});
+	}
 
-			const shutdown = async () => {
-				p.outro("shutting down");
-				// Stop sync daemon via abort signal
-				syncAbort.abort();
-				// Stop sweeper first and wait for any in-flight tick to drain.
-				await sweeper.stop();
-				// Close HTTP server, wait for in-flight requests to drain
-				server.close(() => {
-					try {
-						rmSync(pidPath);
-					} catch {
-						// ignore
-					}
-					closeStore();
-					process.exit(0);
-				});
-				// Force exit after 5s if graceful shutdown stalls
-				setTimeout(() => {
-					try {
-						rmSync(pidPath);
-					} catch {
-						// ignore
-					}
-					closeStore();
-					process.exit(1);
-				}, 5000).unref();
-			};
-			process.on("SIGINT", () => {
-				void shutdown();
-			});
-			process.on("SIGTERM", () => {
-				void shutdown();
-			});
+	const app = createApp({ storeFactory: getStore, sweeper });
+	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
+	const pidPath = pidFilePath(dbPath);
+
+	const server = serve(
+		{ fetch: app.fetch, hostname: invocation.host, port: invocation.port },
+		(info) => {
+			writeFileSync(
+				pidPath,
+				JSON.stringify({ pid: process.pid, host: invocation.host, port: invocation.port }),
+				"utf-8",
+			);
+			p.intro("codemem viewer");
+			p.log.success(`Listening on http://${info.address}:${info.port}`);
+			p.log.info(`Database: ${dbPath}`);
+			p.log.step("Raw event sweeper started");
+			if (syncRunning) p.log.step("Sync daemon started");
 		},
 	);
+
+	server.on("error", (err: NodeJS.ErrnoException) => {
+		if (err.code === "EADDRINUSE") {
+			p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
+		} else {
+			p.log.error(err.message);
+		}
+		process.exit(1);
+	});
+
+	const shutdown = async () => {
+		p.outro("shutting down");
+		syncAbort.abort();
+		await sweeper.stop();
+		server.close(() => {
+			try {
+				rmSync(pidPath);
+			} catch {
+				// ignore
+			}
+			closeStore();
+			process.exit(0);
+		});
+		setTimeout(() => {
+			try {
+				rmSync(pidPath);
+			} catch {
+				// ignore
+			}
+			closeStore();
+			process.exit(1);
+		}, 5000).unref();
+	};
+	process.on("SIGINT", () => {
+		void shutdown();
+	});
+	process.on("SIGTERM", () => {
+		void shutdown();
+	});
+}
+
+async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<void> {
+	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
+	if (invocation.mode === "stop" || invocation.mode === "restart") {
+		const result = await stopExistingViewer(dbPath);
+		if (result.stopped) {
+			p.intro("codemem viewer");
+			p.log.success(`Stopped viewer${result.pid ? ` (pid ${result.pid})` : ""}`);
+			if (invocation.mode === "stop") {
+				p.outro("done");
+				return;
+			}
+		} else if (invocation.mode === "stop") {
+			p.intro("codemem viewer");
+			p.outro("No background viewer found");
+			return;
+		}
+	}
+
+	if (invocation.mode === "start" || invocation.mode === "restart") {
+		if (invocation.background) {
+			await startBackgroundViewer({ ...invocation, dbPath });
+			return;
+		}
+		await startForegroundViewer({ ...invocation, dbPath });
+	}
+}
+
+function addSharedServeOptions(command: Command): Command {
+	return command
+		.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+		.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+		.option("--host <host>", "bind host", "127.0.0.1")
+		.option("--port <port>", "bind port", "38888");
+}
+
+export const serveCommand = addSharedServeOptions(
+	new Command("serve")
+		.configureHelp(helpStyle)
+		.description("Run or manage the viewer")
+		.argument("[action]", "lifecycle action (start|stop|restart)"),
+)
+	.option("--background", "run viewer in background")
+	.option("--foreground", "run viewer in foreground")
+	.option("--stop", "stop background viewer")
+	.option("--restart", "restart background viewer")
+	.action(async (action: string | undefined, opts: LegacyServeOptions) => {
+		const normalizedAction =
+			action === undefined
+				? undefined
+				: action === "start" || action === "stop" || action === "restart"
+					? (action as ServeAction)
+					: null;
+		if (normalizedAction === null) {
+			p.log.error(`Unknown serve action: ${action}`);
+			process.exitCode = 1;
+			return;
+		}
+		await runServeInvocation(resolveServeInvocation(normalizedAction, opts));
+	});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
 	"name": "@codemem/core",
 	"version": "0.20.0-alpha.2",
 	"type": "module",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"source": "./src/index.ts",
@@ -13,8 +14,8 @@
 		"dist/"
 	],
 	"scripts": {
-		"clean": "rm -rf dist",
-		"build": "pnpm exec vite build && pnpm exec tsc --emitDeclarationOnly",
+		"clean": "rm -rf dist tsconfig.tsbuildinfo",
+		"build": "pnpm exec vite build && pnpm exec tsc --build --force",
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"devDependencies": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -2,6 +2,7 @@
 	"name": "@codemem/mcp",
 	"version": "0.20.0-alpha.2",
 	"type": "module",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"source": "./src/index.ts",
@@ -16,8 +17,8 @@
 		"dist/"
 	],
 	"scripts": {
-		"clean": "rm -rf dist",
-		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist",
+		"clean": "rm -rf dist tsconfig.tsbuildinfo",
+		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist && pnpm exec tsc --build --force",
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -350,7 +350,7 @@ async function main() {
 					timeline: timelineItems,
 					observations,
 					missing_ids: orderedIds.filter(
-						(memoryId) =>
+						(memoryId: number) =>
 							missingNotFound.includes(memoryId) || missingProjectMismatch.includes(memoryId),
 					),
 					errors,

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -2,8 +2,11 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "dist"
+		"outDir": "dist",
+		"declaration": true,
+		"emitDeclarationOnly": true
 	},
 	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"],
 	"references": [{ "path": "../core" }]
 }

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -2,6 +2,7 @@
 	"name": "@codemem/server",
 	"version": "0.20.0-alpha.2",
 	"type": "module",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"source": "./src/index.ts",
@@ -14,8 +15,8 @@
 		"static/"
 	],
 	"scripts": {
-		"clean": "rm -rf dist",
-		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist",
+		"clean": "rm -rf dist tsconfig.tsbuildinfo",
+		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist && pnpm exec tsc --build --force",
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/viewer-server/tsconfig.json
+++ b/packages/viewer-server/tsconfig.json
@@ -2,8 +2,11 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "dist"
+		"outDir": "dist",
+		"declaration": true,
+		"emitDeclarationOnly": true
 	},
 	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"],
 	"references": [{ "path": "../core" }]
 }


### PR DESCRIPTION
## Description

Restore the approved `serve` lifecycle UX and fix the TS CLI wiring issues behind it.

### What changed
- `codemem serve` now acts as a lifecycle group and shows help
- added `codemem serve start|stop|restart`
- `codemem serve start` defaults to background mode
- `codemem serve start --foreground` runs attached in the terminal
- `codemem serve stop` / `codemem serve restart` operate on the background viewer pidfile
- added `--db-path` alongside `--db` on serve lifecycle commands
- extracted pure option-resolution logic into `packages/cli/src/commands/serve-invocation.ts`
- added focused tests for serve invocation resolution in `packages/cli/src/commands/serve.test.ts`

### Build prerequisite included
To get the CLI slice through normal TS build/type resolution, this PR also fixes declaration emission for internal workspace packages:
- `@codemem/core`
- `@codemem/mcp`
- `@codemem/server`

That includes adding reliable declaration build steps and one existing strictness fix in `packages/mcp-server/src/index.ts`.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Focused serve tests pass (`pnpm exec vitest run packages/cli/src/commands/serve.test.ts`)
- [x] Workspace build passes (`pnpm build`)
- [x] Manual smoke test: `serve start` detached on a test port, listener came up, `serve stop` shut it down cleanly
- [x] Local help output verified for `codemem serve` and `codemem serve start`

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No unrelated refactors included