### PR TITLE
fix: restore top-level memory command aliases

### DIFF
--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+	forgetMemoryCommand,
+	memoryCommand,
+	rememberMemoryCommand,
+	showMemoryCommand,
+} from "./memory.js";
+
+describe("memory command aliases", () => {
+	it("keeps show/forget/remember under the memory group", () => {
+		expect(memoryCommand.commands.map((command) => command.name())).toEqual([
+			"show",
+			"forget",
+			"remember",
+		]);
+	});
+
+	it("exports top-level compatibility aliases", () => {
+		expect(showMemoryCommand.name()).toBe("show");
+		expect(forgetMemoryCommand.name()).toBe("forget");
+		expect(rememberMemoryCommand.name()).toBe("remember");
+	});
+});

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -18,66 +18,101 @@ function parseStrictPositiveId(value: string): number | null {
 	return Number.isFinite(n) && n >= 1 && Number.isInteger(n) ? n : null;
 }
 
-export const memoryCommand = new Command("memory")
-	.configureHelp(helpStyle)
-	.description("Memory item management");
+function showMemoryAction(idStr: string, opts: { db?: string }): void {
+	const memoryId = parseStrictPositiveId(idStr);
+	if (memoryId === null) {
+		p.log.error(`Invalid memory ID: ${idStr}`);
+		process.exitCode = 1;
+		return;
+	}
+	const store = new MemoryStore(resolveDbPath(opts.db));
+	try {
+		const item = store.get(memoryId);
+		if (!item) {
+			p.log.error(`Memory ${memoryId} not found`);
+			process.exitCode = 1;
+			return;
+		}
+		console.log(JSON.stringify(item, null, 2));
+	} finally {
+		store.close();
+	}
+}
 
-// codemem memory show <id>
-memoryCommand.addCommand(
-	new Command("show")
+function forgetMemoryAction(idStr: string, opts: { db?: string }): void {
+	const memoryId = parseStrictPositiveId(idStr);
+	if (memoryId === null) {
+		p.log.error(`Invalid memory ID: ${idStr}`);
+		process.exitCode = 1;
+		return;
+	}
+	const store = new MemoryStore(resolveDbPath(opts.db));
+	try {
+		store.forget(memoryId);
+		p.log.success(`Memory ${memoryId} marked inactive`);
+	} finally {
+		store.close();
+	}
+}
+
+interface RememberMemoryOptions {
+	kind: string;
+	title: string;
+	body: string;
+	tags?: string[];
+	project?: string;
+	db?: string;
+}
+
+function rememberMemoryAction(opts: RememberMemoryOptions): void {
+	const store = new MemoryStore(resolveDbPath(opts.db));
+	let sessionId: number | null = null;
+	try {
+		const project = resolveProject(process.cwd(), opts.project ?? null);
+		sessionId = store.startSession({
+			cwd: process.cwd(),
+			project,
+			user: process.env.USER ?? "unknown",
+			toolVersion: "manual",
+			metadata: { manual: true },
+		});
+		const memId = store.remember(sessionId, opts.kind, opts.title, opts.body, 0.5, opts.tags);
+		store.endSession(sessionId, { manual: true });
+		p.log.success(`Stored memory ${memId}`);
+	} catch (err) {
+		if (sessionId !== null) {
+			try {
+				store.endSession(sessionId, { manual: true, error: true });
+			} catch {
+				// ignore — already in error path
+			}
+		}
+		throw err;
+	} finally {
+		store.close();
+	}
+}
+
+function createShowMemoryCommand(): Command {
+	return new Command("show")
 		.configureHelp(helpStyle)
 		.description("Print a memory item as JSON")
 		.argument("<id>", "memory ID")
 		.option("--db <path>", "database path")
-		.action((idStr: string, opts: { db?: string }) => {
-			const memoryId = parseStrictPositiveId(idStr);
-			if (memoryId === null) {
-				p.log.error(`Invalid memory ID: ${idStr}`);
-				process.exitCode = 1;
-				return;
-			}
-			const store = new MemoryStore(resolveDbPath(opts.db));
-			try {
-				const item = store.get(memoryId);
-				if (!item) {
-					p.log.error(`Memory ${memoryId} not found`);
-					process.exitCode = 1;
-					return;
-				}
-				console.log(JSON.stringify(item, null, 2));
-			} finally {
-				store.close();
-			}
-		}),
-);
+		.action(showMemoryAction);
+}
 
-// codemem memory forget <id>
-memoryCommand.addCommand(
-	new Command("forget")
+function createForgetMemoryCommand(): Command {
+	return new Command("forget")
 		.configureHelp(helpStyle)
 		.description("Deactivate a memory item")
 		.argument("<id>", "memory ID")
 		.option("--db <path>", "database path")
-		.action((idStr: string, opts: { db?: string }) => {
-			const memoryId = parseStrictPositiveId(idStr);
-			if (memoryId === null) {
-				p.log.error(`Invalid memory ID: ${idStr}`);
-				process.exitCode = 1;
-				return;
-			}
-			const store = new MemoryStore(resolveDbPath(opts.db));
-			try {
-				store.forget(memoryId);
-				p.log.success(`Memory ${memoryId} marked inactive`);
-			} finally {
-				store.close();
-			}
-		}),
-);
+		.action(forgetMemoryAction);
+}
 
-// codemem memory remember --kind <kind> --title <title> --body <body>
-memoryCommand.addCommand(
-	new Command("remember")
+function createRememberMemoryCommand(): Command {
+	return new Command("remember")
 		.configureHelp(helpStyle)
 		.description("Manually add a memory item")
 		.requiredOption("-k, --kind <kind>", "memory kind (discovery, decision, feature, bugfix, etc.)")
@@ -86,42 +121,17 @@ memoryCommand.addCommand(
 		.option("--tags <tags...>", "tags (space-separated)")
 		.option("--project <project>", "project name (defaults to git repo root)")
 		.option("--db <path>", "database path")
-		.action(
-			(opts: {
-				kind: string;
-				title: string;
-				body: string;
-				tags?: string[];
-				project?: string;
-				db?: string;
-			}) => {
-				const store = new MemoryStore(resolveDbPath(opts.db));
-				let sessionId: number | null = null;
-				try {
-					const project = resolveProject(process.cwd(), opts.project ?? null);
-					sessionId = store.startSession({
-						cwd: process.cwd(),
-						project,
-						user: process.env.USER ?? "unknown",
-						toolVersion: "manual",
-						metadata: { manual: true },
-					});
-					const memId = store.remember(sessionId, opts.kind, opts.title, opts.body, 0.5, opts.tags);
-					store.endSession(sessionId, { manual: true });
-					p.log.success(`Stored memory ${memId}`);
-				} catch (err) {
-					// Always close the session even if remember() throws (e.g. invalid kind)
-					if (sessionId !== null) {
-						try {
-							store.endSession(sessionId, { manual: true, error: true });
-						} catch {
-							// ignore — already in error path
-						}
-					}
-					throw err;
-				} finally {
-					store.close();
-				}
-			},
-		),
-);
+		.action(rememberMemoryAction);
+}
+
+export const showMemoryCommand = createShowMemoryCommand();
+export const forgetMemoryCommand = createForgetMemoryCommand();
+export const rememberMemoryCommand = createRememberMemoryCommand();
+
+export const memoryCommand = new Command("memory")
+	.configureHelp(helpStyle)
+	.description("Memory item management");
+
+memoryCommand.addCommand(createShowMemoryCommand());
+memoryCommand.addCommand(createForgetMemoryCommand());
+memoryCommand.addCommand(createRememberMemoryCommand());

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,7 +20,12 @@ import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
 import { exportMemoriesCommand } from "./commands/export-memories.js";
 import { importMemoriesCommand } from "./commands/import-memories.js";
 import { mcpCommand } from "./commands/mcp.js";
-import { memoryCommand } from "./commands/memory.js";
+import {
+	forgetMemoryCommand,
+	memoryCommand,
+	rememberMemoryCommand,
+	showMemoryCommand,
+} from "./commands/memory.js";
 import { packCommand } from "./commands/pack.js";
 import { recentCommand } from "./commands/recent.js";
 import { searchCommand } from "./commands/search.js";
@@ -38,12 +43,15 @@ completion.on("command", ({ reply }) => {
 		"claude-hook-ingest",
 		"db",
 		"export-memories",
+		"forget",
 		"memory",
 		"import-memories",
 		"setup",
+		"show",
 		"sync",
 		"stats",
 		"recent",
+		"remember",
 		"search",
 		"pack",
 		"serve",
@@ -86,6 +94,9 @@ program.addCommand(statsCommand);
 program.addCommand(recentCommand);
 program.addCommand(searchCommand);
 program.addCommand(packCommand);
+program.addCommand(showMemoryCommand);
+program.addCommand(forgetMemoryCommand);
+program.addCommand(rememberMemoryCommand);
 program.addCommand(memoryCommand);
 program.addCommand(syncCommand);
 program.addCommand(setupCommand);


### PR DESCRIPTION
## Description

Restore Python-era top-level `codemem show`, `codemem remember`, and `codemem forget` commands as compatibility aliases while keeping the `codemem memory ...` group.

### What changed
- extracted the shared memory command implementations into reusable action helpers
- exported top-level compatibility commands:
  - `showMemoryCommand`
  - `forgetMemoryCommand`
  - `rememberMemoryCommand`
- wired those aliases into the root CLI alongside the existing `memory` group
- updated shell completion suggestions to include `show`, `remember`, and `forget`
- added focused tests verifying the aliases are exported and the `memory` group still contains the same three subcommands

### Behavior
- existing `codemem memory show|remember|forget` continues to work
- Python-era top-level commands work again:
  - `codemem show <id>`
  - `codemem forget <id>`
  - `codemem remember ...`

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Focused tests pass (`pnpm exec vitest run packages/cli/src/commands/memory.test.ts`)
- [x] Workspace build passes (`pnpm build`)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Change is scoped to compatibility aliases only