### PR TITLE
fix: restore search recent and pack flag parity

### DIFF
--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -1,23 +1,62 @@
 import * as p from "@clack/prompts";
-import { MemoryStore, resolveDbPath } from "@codemem/core";
+import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+
+function collectWorkingSetFile(value: string, previous: string[]): string[] {
+	return [...previous, value];
+}
 
 export const packCommand = new Command("pack")
 	.configureHelp(helpStyle)
 	.description("Build a context-aware memory pack")
 	.argument("<context>", "context string to search for")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("-n, --limit <n>", "max items", "10")
 	.option("--budget <tokens>", "token budget")
+	.option("--token-budget <tokens>", "token budget")
+	.option(
+		"--working-set-file <path>",
+		"recently modified file path used as ranking hint",
+		collectWorkingSetFile,
+		[],
+	)
+	.option("--project <project>", "project identifier (defaults to git repo root)")
+	.option("--all-projects", "search across all projects")
 	.option("--json", "output as JSON")
 	.action(
-		(context: string, opts: { db?: string; limit: string; budget?: string; json?: boolean }) => {
-			const store = new MemoryStore(resolveDbPath(opts.db));
+		(
+			context: string,
+			opts: {
+				db?: string;
+				dbPath?: string;
+				limit: string;
+				budget?: string;
+				tokenBudget?: string;
+				workingSetFile?: string[];
+				project?: string;
+				allProjects?: boolean;
+				json?: boolean;
+			},
+		) => {
+			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 			try {
 				const limit = Number.parseInt(opts.limit, 10) || 10;
-				const budget = opts.budget ? Number.parseInt(opts.budget, 10) : undefined;
-				const result = store.buildMemoryPack(context, limit, budget);
+				const budgetRaw = opts.tokenBudget ?? opts.budget;
+				const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
+				const filters: { project?: string } = {};
+				if (!opts.allProjects) {
+					const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
+					const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
+					if (project) filters.project = project;
+				}
+				if ((opts.workingSetFile?.length ?? 0) > 0) {
+					p.log.warn(
+						"--working-set-file is accepted for compatibility but is not yet used by the TS pack builder.",
+					);
+				}
+				const result = store.buildMemoryPack(context, limit, budget, filters);
 
 				if (opts.json) {
 					console.log(JSON.stringify(result, null, 2));

--- a/packages/cli/src/commands/recent.ts
+++ b/packages/cli/src/commands/recent.ts
@@ -1,4 +1,4 @@
-import { MemoryStore, resolveDbPath } from "@codemem/core";
+import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 
@@ -6,18 +6,36 @@ export const recentCommand = new Command("recent")
 	.configureHelp(helpStyle)
 	.description("Show recent memories")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--limit <n>", "max results", "5")
+	.option("--project <project>", "project identifier (defaults to git repo root)")
+	.option("--all-projects", "search across all projects")
 	.option("--kind <kind>", "filter by memory kind")
-	.action((opts: { db?: string; limit: string; kind?: string }) => {
-		const store = new MemoryStore(resolveDbPath(opts.db));
-		try {
-			const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 5);
-			const filters = opts.kind ? { kind: opts.kind } : undefined;
-			const items = store.recent(limit, filters);
-			for (const item of items) {
-				console.log(`#${item.id} [${item.kind}] ${item.title}`);
+	.action(
+		(opts: {
+			db?: string;
+			dbPath?: string;
+			limit: string;
+			project?: string;
+			allProjects?: boolean;
+			kind?: string;
+		}) => {
+			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+			try {
+				const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 5);
+				const filters: { kind?: string; project?: string } = {};
+				if (opts.kind) filters.kind = opts.kind;
+				if (!opts.allProjects) {
+					const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
+					const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
+					if (project) filters.project = project;
+				}
+				const items = store.recent(limit, filters);
+				for (const item of items) {
+					console.log(`#${item.id} [${item.kind}] ${item.title}`);
+				}
+			} finally {
+				store.close();
 			}
-		} finally {
-			store.close();
-		}
-	});
+		},
+	);

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { MemoryStore, resolveDbPath } from "@codemem/core";
+import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 
@@ -8,44 +8,66 @@ export const searchCommand = new Command("search")
 	.description("Search memories by query")
 	.argument("<query>", "search query")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("-n, --limit <n>", "max results", "10")
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("-n, --limit <n>", "max results", "5")
+	.option("--project <project>", "project identifier (defaults to git repo root)")
+	.option("--all-projects", "search across all projects")
 	.option("--kind <kind>", "filter by memory kind")
 	.option("--json", "output as JSON")
-	.action((query: string, opts: { db?: string; limit: string; kind?: string; json?: boolean }) => {
-		const store = new MemoryStore(resolveDbPath(opts.db));
-		try {
-			const limit = Number.parseInt(opts.limit, 10) || 10;
-			const filters = opts.kind ? { kind: opts.kind } : undefined;
-			const results = store.search(query, limit, filters);
+	.action(
+		(
+			query: string,
+			opts: {
+				db?: string;
+				dbPath?: string;
+				limit: string;
+				project?: string;
+				allProjects?: boolean;
+				kind?: string;
+				json?: boolean;
+			},
+		) => {
+			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+			try {
+				const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 5);
+				const filters: { kind?: string; project?: string } = {};
+				if (opts.kind) filters.kind = opts.kind;
+				if (!opts.allProjects) {
+					const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
+					const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
+					if (project) filters.project = project;
+				}
+				const results = store.search(query, limit, filters);
 
-			if (opts.json) {
-				console.log(JSON.stringify(results, null, 2));
-				return;
+				if (opts.json) {
+					console.log(JSON.stringify(results, null, 2));
+					return;
+				}
+
+				if (results.length === 0) {
+					p.log.warn("No results found.");
+					return;
+				}
+
+				p.intro(`${results.length} result(s) for "${query}"`);
+
+				for (const item of results) {
+					const score = item.score.toFixed(3);
+					const age = timeSince(item.created_at);
+					const preview =
+						item.body_text.length > 120 ? `${item.body_text.slice(0, 120)}…` : item.body_text;
+
+					p.log.message(
+						[`#${item.id}  ${item.kind}  ${age}  [${score}]`, item.title, preview].join("\n"),
+					);
+				}
+
+				p.outro("done");
+			} finally {
+				store.close();
 			}
-
-			if (results.length === 0) {
-				p.log.warn("No results found.");
-				return;
-			}
-
-			p.intro(`${results.length} result(s) for "${query}"`);
-
-			for (const item of results) {
-				const score = item.score.toFixed(3);
-				const age = timeSince(item.created_at);
-				const preview =
-					item.body_text.length > 120 ? `${item.body_text.slice(0, 120)}…` : item.body_text;
-
-				p.log.message(
-					[`#${item.id}  ${item.kind}  ${age}  [${score}]`, item.title, preview].join("\n"),
-				);
-			}
-
-			p.outro("done");
-		} finally {
-			store.close();
-		}
-	});
+		},
+	);
 
 function timeSince(isoDate: string): string {
 	const ms = Date.now() - new Date(isoDate).getTime();


### PR DESCRIPTION
## Description

Restore the most important Python-era flag parity for `search`, `recent`, and `pack`.

### What changed
- `search`
  - restored `--db-path`
  - restored `--project`
  - restored `--all-projects`
  - restored Python default `--limit` of 5
- `recent`
  - restored `--db-path`
  - restored `--project`
  - restored `--all-projects`
- `pack`
  - restored `--db-path`
  - restored `--project`
  - restored `--all-projects`
  - restored `--token-budget` as an alias to the existing `--budget`
  - accepted `--working-set-file` for compatibility

### Notes
- `--working-set-file` is accepted for compatibility but currently logs a warning and is not yet used by the TS pack builder. This avoids hard failures while preserving invocation compatibility.
- Existing TS-only flags like `search --json` remain available.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Local help output verified for `search`, `recent`, and `pack`
- [x] Workspace build passes (`pnpm build`)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Change is scoped to flag/default parity for these three commands