### PR TITLE
fix: restore db-path and completion flag compatibility

### DIFF
--- a/packages/cli/src/commands/claude-hook-ingest.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.ts
@@ -137,9 +137,10 @@ export const claudeHookIngestCommand = new Command("claude-hook-ingest")
 	.configureHelp(helpStyle)
 	.description("Ingest a Claude Code hook payload from stdin")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--host <host>", "viewer server host", "127.0.0.1")
 	.option("--port <port>", "viewer server port", "38888")
-	.action(async (opts: { db?: string; host: string; port: string }) => {
+	.action(async (opts: { db?: string; dbPath?: string; host: string; port: string }) => {
 		// Read payload from stdin
 		let raw: string;
 		try {
@@ -180,7 +181,7 @@ export const claudeHookIngestCommand = new Command("claude-hook-ingest")
 
 		// Strategy 2: direct local enqueue
 		try {
-			const dbPath = resolveDbPath(opts.db);
+			const dbPath = resolveDbPath(opts.db ?? opts.dbPath);
 			const directResult = directEnqueue(payload, dbPath);
 			console.log(JSON.stringify({ ...directResult, via: "direct" }));
 		} catch {

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -19,8 +19,9 @@ dbCommand
 			.configureHelp(helpStyle)
 			.description("Verify the SQLite database is present and schema-ready")
 			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.action((opts: { db?: string }) => {
-				const result = initDatabase(opts.db);
+			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.action((opts: { db?: string; dbPath?: string }) => {
+				const result = initDatabase(opts.db ?? opts.dbPath);
 				p.intro("codemem db init");
 				p.log.success(`Database ready: ${result.path}`);
 				p.outro(`Size: ${result.sizeBytes.toLocaleString()} bytes`);
@@ -31,8 +32,9 @@ dbCommand
 			.configureHelp(helpStyle)
 			.description("Run VACUUM on the SQLite database")
 			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.action((opts: { db?: string }) => {
-				const result = vacuumDatabase(opts.db);
+			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.action((opts: { db?: string; dbPath?: string }) => {
+				const result = vacuumDatabase(opts.db ?? opts.dbPath);
 				p.intro("codemem db vacuum");
 				p.log.success(`Vacuumed: ${result.path}`);
 				p.outro(`Size: ${result.sizeBytes.toLocaleString()} bytes`);
@@ -43,10 +45,14 @@ dbCommand
 			.configureHelp(helpStyle)
 			.description("Show pending raw-event backlog by source stream")
 			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 			.option("-n, --limit <n>", "max rows to show", "25")
 			.option("--json", "output as JSON")
-			.action((opts: { db?: string; limit: string; json?: boolean }) => {
-				const result = getRawEventStatus(opts.db, Number.parseInt(opts.limit, 10) || 25);
+			.action((opts: { db?: string; dbPath?: string; limit: string; json?: boolean }) => {
+				const result = getRawEventStatus(
+					opts.db ?? opts.dbPath,
+					Number.parseInt(opts.limit, 10) || 25,
+				);
 				if (opts.json) {
 					console.log(JSON.stringify(result, null, 2));
 					return;
@@ -73,9 +79,13 @@ dbCommand
 			.configureHelp(helpStyle)
 			.description("Requeue failed raw-event flush batches")
 			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 			.option("-n, --limit <n>", "max failed batches to requeue", "25")
-			.action((opts: { db?: string; limit: string }) => {
-				const result = retryRawEventFailures(opts.db, Number.parseInt(opts.limit, 10) || 25);
+			.action((opts: { db?: string; dbPath?: string; limit: string }) => {
+				const result = retryRawEventFailures(
+					opts.db ?? opts.dbPath,
+					Number.parseInt(opts.limit, 10) || 25,
+				);
 				p.intro("codemem db raw-events-retry");
 				p.outro(`Requeued ${result.retried.toLocaleString()} failed batch(es)`);
 			}),
@@ -85,6 +95,7 @@ dbCommand
 			.configureHelp(helpStyle)
 			.description("Validate raw-event reliability thresholds (non-zero exit on failure)")
 			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 			.option("--min-flush-success-rate <rate>", "minimum flush success rate", "0.95")
 			.option("--max-dropped-event-rate <rate>", "maximum dropped event rate", "0.05")
 			.option("--min-session-boundary-accuracy <rate>", "minimum session boundary accuracy", "0.9")
@@ -93,13 +104,14 @@ dbCommand
 			.action(
 				(opts: {
 					db?: string;
+					dbPath?: string;
 					minFlushSuccessRate: string;
 					maxDroppedEventRate: string;
 					minSessionBoundaryAccuracy: string;
 					windowHours: string;
 					json?: boolean;
 				}) => {
-					const result = rawEventsGate(opts.db, {
+					const result = rawEventsGate(opts.db ?? opts.dbPath, {
 						minFlushSuccessRate: Number.parseFloat(opts.minFlushSuccessRate),
 						maxDroppedEventRate: Number.parseFloat(opts.maxDroppedEventRate),
 						minSessionBoundaryAccuracy: Number.parseFloat(opts.minSessionBoundaryAccuracy),

--- a/packages/cli/src/commands/enqueue-raw-event.ts
+++ b/packages/cli/src/commands/enqueue-raw-event.ts
@@ -45,7 +45,8 @@ export const enqueueRawEventCommand = new Command("enqueue-raw-event")
 	.configureHelp(helpStyle)
 	.description("Enqueue one raw event from stdin into the durable queue")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.action(async (opts: { db?: string }) => {
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.action(async (opts: { db?: string; dbPath?: string }) => {
 		const payload = await readStdinJson();
 		const sessionId = resolveSessionStreamId(payload);
 		if (!sessionId) throw new Error("session id required");
@@ -69,7 +70,7 @@ export const enqueueRawEventCommand = new Command("enqueue-raw-event")
 				? (stripPrivateObj(payload.payload) as Record<string, unknown>)
 				: {};
 
-		const store = new MemoryStore(resolveDbPath(opts.db));
+		const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 		try {
 			store.updateRawEventSessionMeta({
 				opencodeSessionId: sessionId,

--- a/packages/cli/src/commands/export-memories.ts
+++ b/packages/cli/src/commands/export-memories.ts
@@ -15,6 +15,7 @@ export const exportMemoriesCommand = new Command("export-memories")
 	.description("Export memories to a JSON file for sharing or backup")
 	.argument("<output>", "output file path (use '-' for stdout)")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--project <project>", "filter by project (defaults to git repo root)")
 	.option("--all-projects", "export all projects")
 	.option("--include-inactive", "include deactivated memories")
@@ -24,6 +25,7 @@ export const exportMemoriesCommand = new Command("export-memories")
 			output: string,
 			opts: {
 				db?: string;
+				dbPath?: string;
 				project?: string;
 				allProjects?: boolean;
 				includeInactive?: boolean;
@@ -31,7 +33,7 @@ export const exportMemoriesCommand = new Command("export-memories")
 			},
 		) => {
 			const payload = exportMemories({
-				dbPath: resolveDbPath(opts.db),
+				dbPath: resolveDbPath(opts.db ?? opts.dbPath),
 				project: opts.project,
 				allProjects: opts.allProjects,
 				includeInactive: opts.includeInactive,

--- a/packages/cli/src/commands/import-memories.ts
+++ b/packages/cli/src/commands/import-memories.ts
@@ -9,47 +9,53 @@ export const importMemoriesCommand = new Command("import-memories")
 	.description("Import memories from an exported JSON file")
 	.argument("<inputFile>", "input JSON file (use '-' for stdin)")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--remap-project <path>", "remap all projects to this path on import")
 	.option("--dry-run", "preview import without writing")
-	.action((inputFile: string, opts: { db?: string; remapProject?: string; dryRun?: boolean }) => {
-		let payload: ExportPayload;
-		try {
-			payload = readImportPayload(inputFile);
-		} catch (error) {
-			p.log.error(error instanceof Error ? error.message : "Invalid import file");
-			process.exitCode = 1;
-			return;
-		}
+	.action(
+		(
+			inputFile: string,
+			opts: { db?: string; dbPath?: string; remapProject?: string; dryRun?: boolean },
+		) => {
+			let payload: ExportPayload;
+			try {
+				payload = readImportPayload(inputFile);
+			} catch (error) {
+				p.log.error(error instanceof Error ? error.message : "Invalid import file");
+				process.exitCode = 1;
+				return;
+			}
 
-		p.intro("codemem import-memories");
-		p.log.info(
-			[
-				`Export version: ${payload.version}`,
-				`Exported at:    ${payload.exported_at}`,
-				`Sessions:       ${payload.sessions.length.toLocaleString()}`,
-				`Memories:       ${payload.memory_items.length.toLocaleString()}`,
-				`Summaries:      ${payload.session_summaries.length.toLocaleString()}`,
-				`Prompts:        ${payload.user_prompts.length.toLocaleString()}`,
-			].join("\n"),
-		);
+			p.intro("codemem import-memories");
+			p.log.info(
+				[
+					`Export version: ${payload.version}`,
+					`Exported at:    ${payload.exported_at}`,
+					`Sessions:       ${payload.sessions.length.toLocaleString()}`,
+					`Memories:       ${payload.memory_items.length.toLocaleString()}`,
+					`Summaries:      ${payload.session_summaries.length.toLocaleString()}`,
+					`Prompts:        ${payload.user_prompts.length.toLocaleString()}`,
+				].join("\n"),
+			);
 
-		const result = importMemories(payload, {
-			dbPath: resolveDbPath(opts.db),
-			remapProject: opts.remapProject,
-			dryRun: opts.dryRun,
-		});
+			const result = importMemories(payload, {
+				dbPath: resolveDbPath(opts.db ?? opts.dbPath),
+				remapProject: opts.remapProject,
+				dryRun: opts.dryRun,
+			});
 
-		if (result.dryRun) {
-			p.outro("dry run complete");
-			return;
-		}
-		p.log.success(
-			[
-				`Imported sessions:  ${result.sessions.toLocaleString()}`,
-				`Imported prompts:   ${result.user_prompts.toLocaleString()}`,
-				`Imported memories:  ${result.memory_items.toLocaleString()}`,
-				`Imported summaries: ${result.session_summaries.toLocaleString()}`,
-			].join("\n"),
-		);
-		p.outro("done");
-	});
+			if (result.dryRun) {
+				p.outro("dry run complete");
+				return;
+			}
+			p.log.success(
+				[
+					`Imported sessions:  ${result.sessions.toLocaleString()}`,
+					`Imported prompts:   ${result.user_prompts.toLocaleString()}`,
+					`Imported memories:  ${result.memory_items.toLocaleString()}`,
+					`Imported summaries: ${result.session_summaries.toLocaleString()}`,
+				].join("\n"),
+			);
+			p.outro("done");
+		},
+	);

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -5,8 +5,10 @@ export const mcpCommand = new Command("mcp")
 	.configureHelp(helpStyle)
 	.description("Start the MCP stdio server")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.action(async (opts: { db?: string }) => {
-		if (opts.db) process.env.CODEMEM_DB = opts.db;
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.action(async (opts: { db?: string; dbPath?: string }) => {
+		const dbPath = opts.db ?? opts.dbPath;
+		if (dbPath) process.env.CODEMEM_DB = dbPath;
 		// Dynamic import — MCP server is its own entry point
 		await import("@codemem/mcp");
 	});

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -18,14 +18,14 @@ function parseStrictPositiveId(value: string): number | null {
 	return Number.isFinite(n) && n >= 1 && Number.isInteger(n) ? n : null;
 }
 
-function showMemoryAction(idStr: string, opts: { db?: string }): void {
+function showMemoryAction(idStr: string, opts: { db?: string; dbPath?: string }): void {
 	const memoryId = parseStrictPositiveId(idStr);
 	if (memoryId === null) {
 		p.log.error(`Invalid memory ID: ${idStr}`);
 		process.exitCode = 1;
 		return;
 	}
-	const store = new MemoryStore(resolveDbPath(opts.db));
+	const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 	try {
 		const item = store.get(memoryId);
 		if (!item) {
@@ -39,14 +39,14 @@ function showMemoryAction(idStr: string, opts: { db?: string }): void {
 	}
 }
 
-function forgetMemoryAction(idStr: string, opts: { db?: string }): void {
+function forgetMemoryAction(idStr: string, opts: { db?: string; dbPath?: string }): void {
 	const memoryId = parseStrictPositiveId(idStr);
 	if (memoryId === null) {
 		p.log.error(`Invalid memory ID: ${idStr}`);
 		process.exitCode = 1;
 		return;
 	}
-	const store = new MemoryStore(resolveDbPath(opts.db));
+	const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 	try {
 		store.forget(memoryId);
 		p.log.success(`Memory ${memoryId} marked inactive`);
@@ -62,10 +62,11 @@ interface RememberMemoryOptions {
 	tags?: string[];
 	project?: string;
 	db?: string;
+	dbPath?: string;
 }
 
 function rememberMemoryAction(opts: RememberMemoryOptions): void {
-	const store = new MemoryStore(resolveDbPath(opts.db));
+	const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 	let sessionId: number | null = null;
 	try {
 		const project = resolveProject(process.cwd(), opts.project ?? null);
@@ -99,6 +100,7 @@ function createShowMemoryCommand(): Command {
 		.description("Print a memory item as JSON")
 		.argument("<id>", "memory ID")
 		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
 		.action(showMemoryAction);
 }
 
@@ -108,6 +110,7 @@ function createForgetMemoryCommand(): Command {
 		.description("Deactivate a memory item")
 		.argument("<id>", "memory ID")
 		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
 		.action(forgetMemoryAction);
 }
 
@@ -121,6 +124,7 @@ function createRememberMemoryCommand(): Command {
 		.option("--tags <tags...>", "tags (space-separated)")
 		.option("--project <project>", "project name (defaults to git repo root)")
 		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
 		.action(rememberMemoryAction);
 }
 

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -18,9 +18,10 @@ export const statsCommand = new Command("stats")
 	.configureHelp(helpStyle)
 	.description("Show database statistics")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--json", "output as JSON")
-	.action((opts: { db?: string; json?: boolean }) => {
-		const store = new MemoryStore(resolveDbPath(opts.db));
+	.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
+		const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 		try {
 			const result = store.stats();
 			if (opts.json) {

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -26,10 +26,11 @@ syncCommand.addCommand(
 		.configureHelp(helpStyle)
 		.description("Show sync configuration and peer summary")
 		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
 		.option("--json", "output as JSON")
-		.action((opts: { db?: string; json?: boolean }) => {
+		.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
 			const config = readCodememConfigFile();
-			const store = new MemoryStore(resolveDbPath(opts.db));
+			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 			try {
 				const d = drizzle(store.db, { schema });
 				const deviceRow = d
@@ -113,35 +114,38 @@ syncCommand.addCommand(
 		.configureHelp(helpStyle)
 		.description("Enable sync and initialize device identity")
 		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
 		.option("--host <host>", "sync listen host")
 		.option("--port <port>", "sync listen port")
 		.option("--interval <seconds>", "sync interval in seconds")
-		.action((opts: { db?: string; host?: string; port?: string; interval?: string }) => {
-			const store = new MemoryStore(resolveDbPath(opts.db));
-			try {
-				const [deviceId, fingerprint] = ensureDeviceIdentity(store.db);
-				const config = readCodememConfigFile();
-				config.sync_enabled = true;
-				if (opts.host) config.sync_host = opts.host;
-				if (opts.port) config.sync_port = Number.parseInt(opts.port, 10);
-				if (opts.interval) config.sync_interval_s = Number.parseInt(opts.interval, 10);
-				writeCodememConfigFile(config);
+		.action(
+			(opts: { db?: string; dbPath?: string; host?: string; port?: string; interval?: string }) => {
+				const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+				try {
+					const [deviceId, fingerprint] = ensureDeviceIdentity(store.db);
+					const config = readCodememConfigFile();
+					config.sync_enabled = true;
+					if (opts.host) config.sync_host = opts.host;
+					if (opts.port) config.sync_port = Number.parseInt(opts.port, 10);
+					if (opts.interval) config.sync_interval_s = Number.parseInt(opts.interval, 10);
+					writeCodememConfigFile(config);
 
-				p.intro("codemem sync enable");
-				p.log.success(
-					[
-						`Device ID:   ${deviceId}`,
-						`Fingerprint: ${fingerprint}`,
-						`Host:        ${config.sync_host ?? "0.0.0.0"}`,
-						`Port:        ${config.sync_port ?? 7337}`,
-						`Interval:    ${config.sync_interval_s ?? 120}s`,
-					].join("\n"),
-				);
-				p.outro("Sync enabled — restart `codemem serve` to activate");
-			} finally {
-				store.close();
-			}
-		}),
+					p.intro("codemem sync enable");
+					p.log.success(
+						[
+							`Device ID:   ${deviceId}`,
+							`Fingerprint: ${fingerprint}`,
+							`Host:        ${config.sync_host ?? "0.0.0.0"}`,
+							`Port:        ${config.sync_port ?? 7337}`,
+							`Interval:    ${config.sync_interval_s ?? 120}s`,
+						].join("\n"),
+					);
+					p.outro("Sync enabled — restart `codemem serve` to activate");
+				} finally {
+					store.close();
+				}
+			},
+		),
 );
 
 // codemem sync disable
@@ -164,9 +168,10 @@ syncCommand.addCommand(
 		.configureHelp(helpStyle)
 		.description("List known sync peers")
 		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
 		.option("--json", "output as JSON")
-		.action((opts: { db?: string; json?: boolean }) => {
-			const store = new MemoryStore(resolveDbPath(opts.db));
+		.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
+			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 			try {
 				const d = drizzle(store.db, { schema });
 				const peers = d

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -65,15 +65,13 @@ completion.on("command", ({ reply }) => {
 });
 completion.init();
 
-// `codemem --setup-completion` installs shell completion
-if (process.argv.includes("--setup-completion")) {
-	completion.setupShellInitFile();
-	process.exit(0);
-}
-// `codemem --cleanup-completion` removes it
-if (process.argv.includes("--cleanup-completion")) {
-	completion.cleanupShellInitFile();
-	process.exit(0);
+function hasRootFlag(flag: string): boolean {
+	for (const arg of process.argv.slice(2)) {
+		if (arg === "--") return false;
+		if (arg === flag) return true;
+		if (!arg.startsWith("-")) return false;
+	}
+	return false;
 }
 
 const program = new Command();
@@ -83,6 +81,16 @@ program
 	.description("codemem — persistent memory for AI coding agents")
 	.version(VERSION)
 	.configureHelp(helpStyle);
+
+if (hasRootFlag("--setup-completion")) {
+	completion.setupShellInitFile();
+	process.exit(0);
+}
+
+if (hasRootFlag("--cleanup-completion")) {
+	completion.cleanupShellInitFile();
+	process.exit(0);
+}
 
 program.addCommand(serveCommand);
 program.addCommand(mcpCommand);


### PR DESCRIPTION
## Description

Restore broad `--db-path` compatibility across the TS CLI and harden the existing completion flags so they are only treated as top-level CLI flags.

### `--db-path` aliases restored
Added `--db-path` alongside existing `--db` for the remaining CLI commands that still only exposed `--db`:
- `stats`
- `db` subcommands
- `export-memories`
- `import-memories`
- `mcp`
- `memory` aliases/subcommands
- `sync` subcommands
- `enqueue-raw-event`
- `claude-hook-ingest`

### Completion behavior hardened
- kept the existing working completion commands (`--setup-completion`, `--cleanup-completion`)
- restricted completion detection to top-level argv only, so values like `--setup-completion` after `--` are no longer hijacked from subcommands/file arguments

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Workspace build passes (`pnpm build`)
- [x] Built CLI help output spot-checked for `stats` and `mcp`
- [x] Verified `import-memories -- --setup-completion` is not hijacked by the root completion handling

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Change is scoped to compatibility aliases and completion hardening