### PR TITLE
fix: add sync attempts command parity

### DIFF
--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { formatSyncAttempt } from "./sync.js";
+
+describe("formatSyncAttempt", () => {
+	it("matches the compact Python-era output shape", () => {
+		expect(
+			formatSyncAttempt({
+				peer_device_id: "peer-1",
+				ok: 1,
+				ops_in: 3,
+				ops_out: 5,
+				error: null,
+				finished_at: "2026-03-18T20:00:00Z",
+			}),
+		).toBe("peer-1|ok|in=3|out=5|2026-03-18T20:00:00Z");
+	});
+
+	it("includes the error suffix when present", () => {
+		expect(
+			formatSyncAttempt({
+				peer_device_id: "peer-2",
+				ok: 0,
+				ops_in: 0,
+				ops_out: 1,
+				error: "timeout",
+				finished_at: "2026-03-18T21:00:00Z",
+			}),
+		).toBe("peer-2|error|in=0|out=1|2026-03-18T21:00:00Z | timeout");
+	});
+});

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -16,9 +16,74 @@ import { desc } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { helpStyle } from "../help-style.js";
 
+interface SyncAttemptRow {
+	peer_device_id: string;
+	ok: number;
+	ops_in: number;
+	ops_out: number;
+	error: string | null;
+	finished_at: string | null;
+}
+
+export function formatSyncAttempt(row: SyncAttemptRow): string {
+	const status = row.ok ? "ok" : "error";
+	const error = String(row.error || "");
+	const suffix = error ? ` | ${error}` : "";
+	return `${row.peer_device_id}|${status}|in=${row.ops_in}|out=${row.ops_out}|${row.finished_at ?? ""}${suffix}`;
+}
+
+function parseAttemptsLimit(value: string): number {
+	if (!/^\d+$/.test(value.trim())) {
+		throw new Error(`Invalid --limit: ${value}`);
+	}
+	return Number.parseInt(value, 10);
+}
+
 export const syncCommand = new Command("sync")
 	.configureHelp(helpStyle)
 	.description("Sync configuration and peer management");
+
+// codemem sync attempts
+syncCommand.addCommand(
+	new Command("attempts")
+		.configureHelp(helpStyle)
+		.description("Show recent sync attempts")
+		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
+		.option("--limit <n>", "max attempts", "10")
+		.option("--json", "output as JSON")
+		.action((opts: { db?: string; dbPath?: string; limit: string; json?: boolean }) => {
+			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+			try {
+				const d = drizzle(store.db, { schema });
+				const limit = parseAttemptsLimit(opts.limit);
+				const rows = d
+					.select({
+						peer_device_id: schema.syncAttempts.peer_device_id,
+						ok: schema.syncAttempts.ok,
+						ops_in: schema.syncAttempts.ops_in,
+						ops_out: schema.syncAttempts.ops_out,
+						error: schema.syncAttempts.error,
+						finished_at: schema.syncAttempts.finished_at,
+					})
+					.from(schema.syncAttempts)
+					.orderBy(desc(schema.syncAttempts.finished_at))
+					.limit(limit)
+					.all();
+
+				if (opts.json) {
+					console.log(JSON.stringify(rows, null, 2));
+					return;
+				}
+
+				for (const row of rows) {
+					console.log(formatSyncAttempt(row));
+				}
+			} finally {
+				store.close();
+			}
+		}),
+);
 
 // codemem sync status
 syncCommand.addCommand(


### PR DESCRIPTION
## Description

Restore the Python-era `codemem sync attempts` command in the TS CLI.

### What changed
- added `codemem sync attempts`
- supports `--db`, `--db-path`, `--limit`, and `--json`
- queries the existing `sync_attempts` table ordered by latest finished attempt
- restores the compact human-readable output shape from the Python CLI:
  `peer|ok|in=3|out=5|timestamp`
  with ` | error` suffix when present
- extracted `formatSyncAttempt()` as a tiny pure formatter helper with focused unit tests

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Focused tests pass (`pnpm exec vitest run packages/cli/src/commands/sync.test.ts`)
- [x] Workspace build passes (`pnpm build`)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Change is scoped to the `sync attempts` parity slice only