### PR TITLE
fix: add sync once command parity

### DIFF
--- a/packages/cli/src/commands/sync-helpers.ts
+++ b/packages/cli/src/commands/sync-helpers.ts
@@ -1,0 +1,54 @@
+export interface SyncAttemptRow {
+	peer_device_id: string;
+	ok: number;
+	ops_in: number;
+	ops_out: number;
+	error: string | null;
+	finished_at: string | null;
+}
+
+export function formatSyncAttempt(row: SyncAttemptRow): string {
+	const status = row.ok ? "ok" : "error";
+	const error = String(row.error || "");
+	const suffix = error ? ` | ${error}` : "";
+	return `${row.peer_device_id}|${status}|in=${row.ops_in}|out=${row.ops_out}|${row.finished_at ?? ""}${suffix}`;
+}
+
+export interface SyncLifecycleOptions {
+	db?: string;
+	dbPath?: string;
+	host?: string;
+	port?: string;
+	user?: boolean;
+	system?: boolean;
+}
+
+export function buildServeLifecycleArgs(
+	action: "start" | "stop" | "restart",
+	opts: SyncLifecycleOptions,
+	scriptPath: string,
+	execArgv: string[] = [],
+): string[] {
+	if (!scriptPath) throw new Error("Unable to resolve CLI entrypoint for sync lifecycle command");
+	const args = [...execArgv, scriptPath, "serve"];
+	if (action === "start") {
+		args.push("--restart");
+	} else if (action === "stop") {
+		args.push("--stop");
+	} else {
+		args.push("--restart");
+	}
+	if (opts.db ?? opts.dbPath) args.push("--db-path", opts.db ?? opts.dbPath ?? "");
+	if (opts.host) args.push("--host", opts.host);
+	if (opts.port) args.push("--port", opts.port);
+	return args;
+}
+
+export function formatSyncOnceResult(
+	peerDeviceId: string,
+	result: { ok: boolean; error?: string },
+): string {
+	if (result.ok) return `- ${peerDeviceId}: ok`;
+	const suffix = result.error ? `: ${result.error}` : "";
+	return `- ${peerDeviceId}: error${suffix}`;
+}

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildServeLifecycleArgs, formatSyncAttempt } from "./sync.js";
+import {
+	buildServeLifecycleArgs,
+	formatSyncAttempt,
+	formatSyncOnceResult,
+} from "./sync-helpers.js";
 
 describe("formatSyncAttempt", () => {
 	it("matches the compact Python-era output shape", () => {
@@ -66,5 +70,15 @@ describe("formatSyncAttempt", () => {
 			"--db-path",
 			"/tmp/test.sqlite",
 		]);
+	});
+
+	it("formats sync once success output like the Python command", () => {
+		expect(formatSyncOnceResult("peer-1", { ok: true })).toBe("- peer-1: ok");
+	});
+
+	it("formats sync once error output like the Python command", () => {
+		expect(formatSyncOnceResult("peer-2", { ok: false, error: "timeout" })).toBe(
+			"- peer-2: error: timeout",
+		);
 	});
 });

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -9,29 +9,21 @@ import {
 	MemoryStore,
 	readCodememConfigFile,
 	resolveDbPath,
+	runSyncPass,
 	schema,
+	syncPassPreflight,
 	writeCodememConfigFile,
 } from "@codemem/core";
 import { Command } from "commander";
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { helpStyle } from "../help-style.js";
-
-interface SyncAttemptRow {
-	peer_device_id: string;
-	ok: number;
-	ops_in: number;
-	ops_out: number;
-	error: string | null;
-	finished_at: string | null;
-}
-
-export function formatSyncAttempt(row: SyncAttemptRow): string {
-	const status = row.ok ? "ok" : "error";
-	const error = String(row.error || "");
-	const suffix = error ? ` | ${error}` : "";
-	return `${row.peer_device_id}|${status}|in=${row.ops_in}|out=${row.ops_out}|${row.finished_at ?? ""}${suffix}`;
-}
+import {
+	buildServeLifecycleArgs,
+	formatSyncAttempt,
+	formatSyncOnceResult,
+	type SyncLifecycleOptions,
+} from "./sync-helpers.js";
 
 function parseAttemptsLimit(value: string): number {
 	if (!/^\d+$/.test(value.trim())) {
@@ -40,34 +32,10 @@ function parseAttemptsLimit(value: string): number {
 	return Number.parseInt(value, 10);
 }
 
-interface SyncLifecycleOptions {
+interface SyncOnceOptions {
 	db?: string;
 	dbPath?: string;
-	host?: string;
-	port?: string;
-	user?: boolean;
-	system?: boolean;
-}
-
-export function buildServeLifecycleArgs(
-	action: "start" | "stop" | "restart",
-	opts: SyncLifecycleOptions,
-	scriptPath = process.argv[1],
-	execArgv: string[] = process.execArgv,
-): string[] {
-	if (!scriptPath) throw new Error("Unable to resolve CLI entrypoint for sync lifecycle command");
-	const args = [...execArgv, scriptPath, "serve"];
-	if (action === "start") {
-		args.push("--restart");
-	} else if (action === "stop") {
-		args.push("--stop");
-	} else {
-		args.push("--restart");
-	}
-	if (opts.db ?? opts.dbPath) args.push("--db-path", opts.db ?? opts.dbPath ?? "");
-	if (opts.host) args.push("--host", opts.host);
-	if (opts.port) args.push("--port", opts.port);
-	return args;
+	peer?: string;
 }
 
 async function runServeLifecycle(
@@ -97,7 +65,7 @@ async function runServeLifecycle(
 		opts.host ??= configuredHost;
 		opts.port ??= configuredPort;
 	}
-	const args = buildServeLifecycleArgs(action, opts);
+	const args = buildServeLifecycleArgs(action, opts, process.argv[1] ?? "", process.execArgv);
 	await new Promise<void>((resolve, reject) => {
 		const child = spawn(process.execPath, args, {
 			cwd: process.cwd(),
@@ -205,6 +173,64 @@ syncCommand.addCommand(
 		.option("--system", "accepted for compatibility")
 		.action(async (opts: SyncLifecycleOptions) => {
 			await runServeLifecycle("restart", opts);
+		}),
+);
+
+syncCommand.addCommand(
+	new Command("once")
+		.configureHelp(helpStyle)
+		.description("Run a single sync pass")
+		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
+		.option("--peer <peer>", "peer device id or name")
+		.action(async (opts: SyncOnceOptions) => {
+			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+			try {
+				syncPassPreflight(store.db);
+				const d = drizzle(store.db, { schema });
+				const rows = opts.peer
+					? (() => {
+							const deviceMatches = d
+								.select({ peer_device_id: schema.syncPeers.peer_device_id })
+								.from(schema.syncPeers)
+								.where(eq(schema.syncPeers.peer_device_id, opts.peer))
+								.all();
+							if (deviceMatches.length > 0) return deviceMatches;
+							const nameMatches = d
+								.select({ peer_device_id: schema.syncPeers.peer_device_id })
+								.from(schema.syncPeers)
+								.where(eq(schema.syncPeers.name, opts.peer))
+								.all();
+							if (nameMatches.length > 1) {
+								p.log.error(`Peer name is ambiguous: ${opts.peer}`);
+								process.exitCode = 1;
+								return [];
+							}
+							return nameMatches;
+						})()
+					: d
+							.select({ peer_device_id: schema.syncPeers.peer_device_id })
+							.from(schema.syncPeers)
+							.all();
+
+				if (rows.length === 0) {
+					p.log.warn("No peers available for sync");
+					process.exitCode = 1;
+					return;
+				}
+
+				let hadFailure = false;
+				for (const row of rows) {
+					const result = await runSyncPass(store.db, row.peer_device_id);
+					if (!result.ok) hadFailure = true;
+					console.log(formatSyncOnceResult(row.peer_device_id, result));
+				}
+				if (hadFailure) {
+					process.exitCode = 1;
+				}
+			} finally {
+				store.close();
+			}
 		}),
 );
 


### PR DESCRIPTION
## Description

Restore the Python-era `codemem sync once` command in the TS CLI.

### What changed
- added `codemem sync once`
- supports `--db`, `--db-path`, and optional `--peer <peer>` to target a specific peer by device ID or name
- reuses the existing TS sync runtime (`syncPassPreflight`, `runSyncPass`) rather than inventing a new sync path
- prints the same compact Python-style results:
  - `- peer-id: ok`
  - `- peer-id: error: <message>`
- extracted the human-readable formatters and lifecycle arg builder into a pure `sync-helpers.ts` module so sync tests do not drag in the runtime dependency graph

### Notes
- this slice uses the current stored peer list only
- mDNS-assisted peer discovery is still a later sync parity slice

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Focused tests pass (`pnpm exec vitest run packages/cli/src/commands/sync.test.ts`)
- [x] Workspace build passes (`pnpm build`)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Change is scoped to the `sync once` parity slice only