### PR TITLE
chore: bump version to 0.20.0-alpha.3

### DIFF
--- a/packages/cli/.opencode/plugin/codemem.js
+++ b/packages/cli/.opencode/plugin/codemem.js
@@ -13,7 +13,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.0-alpha.2";
+const PINNED_BACKEND_VERSION = "0.20.0-alpha.3";
 const DEFAULT_UVX_SOURCE = `codemem==${PINNED_BACKEND_VERSION}`;
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.20.0-alpha.2",
+	"version": "0.20.0-alpha.3",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.0-alpha.2",
+	"version": "0.20.0-alpha.3",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.0-alpha.2");
+		expect(VERSION).toBe("0.20.0-alpha.3");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.0-alpha.2";
+export const VERSION = "0.20.0-alpha.3";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.0-alpha.2",
+	"version": "0.20.0-alpha.3",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.0-alpha.2",
+	"version": "0.20.0-alpha.3",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {


### PR DESCRIPTION
## Description

Bump all packages from 0.20.0-alpha.2 to 0.20.0-alpha.3 for the next alpha release. Includes CLI parity work from #327–#338.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Checklist

- [x] All 7 version references updated
- [x] Tests pass