### PR TITLE
fix: reduce auth error backoff from 300s to 30s

### DIFF
--- a/packages/core/src/raw-event-sweeper.ts
+++ b/packages/core/src/raw-event-sweeper.ts
@@ -22,8 +22,9 @@ import { readCodememConfigFile } from "./observer-config.js";
 import { flushRawEvents } from "./raw-event-flush.js";
 import type { MemoryStore } from "./store.js";
 
-/** Back off for 5 minutes after an auth error (seconds). */
-const AUTH_BACKOFF_S = 300;
+/** Back off after an auth error. 60s gives OpenCode time to refresh its
+ *  OAuth token while staying longer than the default 30s sweep interval. */
+const AUTH_BACKOFF_S = 60;
 
 // ---------------------------------------------------------------------------
 // Env helpers — read config from env vars matching Python exactly


### PR DESCRIPTION
OAuth token refresh in OpenCode happens asynchronously. 300s backoff meant 5 minutes offline per token rotation. 30s is enough for OpenCode to write the refreshed token. Closes codemem-ip0y.