### PR TITLE
chore: bump to alpha.5 and auto-bump version after releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,3 +98,70 @@ jobs:
               --title "Release ${{ github.ref_name }}" \
               $PRERELEASE_FLAG
           fi
+
+  bump-version:
+    name: Bump to next unreleased version
+    needs: [publish-npm, release]
+    runs-on: ubuntu-latest
+    if: contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc')
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Compute next version
+        id: next
+        run: |
+          # Extract current prerelease: v0.20.0-alpha.4 → 0.20.0-alpha.4
+          RELEASED="${GITHUB_REF_NAME#v}"
+          # Increment the trailing number: alpha.4 → alpha.5
+          BASE="${RELEASED%-*}"
+          PRERELEASE="${RELEASED##*-}"
+          CHANNEL="${PRERELEASE%%.*}"
+          NUM="${PRERELEASE##*.}"
+          NEXT_NUM=$((NUM + 1))
+          NEXT="${BASE}-${CHANNEL}.${NEXT_NUM}"
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "Bumping to $NEXT"
+
+      - name: Guard against overwriting a newer main train
+        id: guard
+        run: |
+          RELEASED="${GITHUB_REF_NAME#v}"
+          CURRENT_MAIN=$(node -p "require('./packages/core/package.json').version")
+          echo "released=$RELEASED" >> "$GITHUB_OUTPUT"
+          echo "current_main=$CURRENT_MAIN" >> "$GITHUB_OUTPUT"
+          if [ "$CURRENT_MAIN" != "$RELEASED" ]; then
+            echo "should_bump=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping auto-bump: main is already at $CURRENT_MAIN, tag released $RELEASED"
+          else
+            echo "should_bump=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version
+        if: steps.guard.outputs.should_bump == 'true'
+        run: |
+          chmod +x scripts/bump-version.sh
+          ./scripts/bump-version.sh "${{ steps.next.outputs.version }}"
+          pnpm install --no-frozen-lockfile
+
+      - name: Commit and push
+        if: steps.guard.outputs.should_bump == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: bump version to ${{ steps.next.outputs.version }} [skip ci]"
+          git push origin main

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.0-alpha.4";
+const PINNED_BACKEND_VERSION = "0.20.0-alpha.5";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.20.0-alpha.4",
+	"version": "0.20.0-alpha.5",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.0-alpha.4",
+	"version": "0.20.0-alpha.5",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.0-alpha.4");
+		expect(VERSION).toBe("0.20.0-alpha.5");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.0-alpha.4";
+export const VERSION = "0.20.0-alpha.5";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.0-alpha.4",
+	"version": "0.20.0-alpha.5",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.0-alpha.4",
+	"version": "0.20.0-alpha.5",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {


### PR DESCRIPTION
## Description

Two changes:

1. **Bump all packages to 0.20.0-alpha.5** — main always carries the next unreleased version
2. **Auto-bump workflow job** — after publishing a prerelease (alpha/beta/rc), the release workflow automatically increments the trailing version number on main and pushes it with `[skip ci]`

### New release flow
1. Tag: `git tag v0.20.0-alpha.5 && git push origin v0.20.0-alpha.5`
2. Release workflow: CI → publish → GitHub release → auto-bump main to alpha.6
3. No more manual version bump PRs

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Checklist

- [x] Tests pass
- [x] Self-review completed