### PR TITLE
fix ingest project inference and observer prompt guidance

### DIFF
--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,6 +1,6 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { existsSync, readFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { basename, dirname, resolve } from "node:path";
 import { createHash } from "node:crypto";
 import { spawn as nodeSpawn, execSync } from "node:child_process";
 import { tool } from "@opencode-ai/plugin";
@@ -251,11 +251,76 @@ const buildOpencodeAdapterEvent = ({ sessionID, event }) => {
   };
 };
 
-const resolveProjectName = (project) =>
-  project?.name ||
-  (project?.root
-    ? String(project.root).split(/[/\\]/).filter(Boolean).pop()
-    : null) ||
+const normalizeProjectLabel = (value) => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const cleaned = value.trim();
+  if (!cleaned) {
+    return null;
+  }
+  if (cleaned.includes("/") || cleaned.includes("\\")) {
+    const normalized = cleaned.replaceAll("\\", "/").replace(/\/+$/, "");
+    return basename(normalized) || null;
+  }
+  return cleaned;
+};
+
+const inferredProjectByCwd = new Map();
+
+const inferProjectFromCwd = (cwd) => {
+  if (typeof cwd !== "string") {
+    return null;
+  }
+  const cleaned = cwd.trim();
+  if (!cleaned) {
+    return null;
+  }
+  if (inferredProjectByCwd.has(cleaned)) {
+    return inferredProjectByCwd.get(cleaned);
+  }
+
+  let current = cleaned;
+  while (true) {
+    const gitPath = `${current}/.git`;
+    if (existsSync(gitPath)) {
+      try {
+        const text = readFileSync(gitPath, "utf8").trim();
+        if (text.startsWith("gitdir:")) {
+          const normalized = resolve(current, text.slice("gitdir:".length).trim()).replaceAll(
+            "\\",
+            "/",
+          );
+          const worktreeMarker = "/.git/worktrees/";
+          const worktreeIndex = normalized.indexOf(worktreeMarker);
+          if (worktreeIndex >= 0) {
+            const inferred = normalizeProjectLabel(normalized.slice(0, worktreeIndex));
+            inferredProjectByCwd.set(cleaned, inferred);
+            return inferred;
+          }
+        }
+      } catch {
+        // .git is a directory in normal repos; fall through to cwd basename.
+      }
+      const inferred = normalizeProjectLabel(current);
+      inferredProjectByCwd.set(cleaned, inferred);
+      return inferred;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      const inferred = normalizeProjectLabel(cleaned);
+      inferredProjectByCwd.set(cleaned, inferred);
+      return inferred;
+    }
+    current = parent;
+  }
+};
+
+const resolveProjectName = (project, cwd) =>
+  normalizeProjectLabel(process.env.CODEMEM_PROJECT) ||
+  normalizeProjectLabel(project?.name) ||
+  normalizeProjectLabel(project?.root) ||
+  inferProjectFromCwd(cwd) ||
   null;
 
 const selectRawEventId = ({ payload, nextEventId }) => {
@@ -599,7 +664,7 @@ export const OpencodeMemPlugin = async ({
       type,
       payload,
       cwd,
-      project: resolveProjectName(project),
+      project: resolveProjectName(project, cwd),
       startedAt: sessionStartedAt,
       nowMs: now,
       nowMono:
@@ -1231,7 +1296,7 @@ export const OpencodeMemPlugin = async ({
     }
 
     // Project name for scoping
-    const projectName = resolveProjectName(project);
+    const projectName = resolveProjectName(project, cwd);
     if (projectName) {
       parts.push(projectName);
     }
@@ -1822,6 +1887,9 @@ export const OpencodeMemPlugin = async ({
 export default OpencodeMemPlugin;
 export const __testUtils = {
   PINNED_BACKEND_VERSION,
+  inferProjectFromCwd,
+  normalizeProjectLabel,
+  resolveProjectName,
   buildRunnerArgs,
   appendWorkingSetFileArgs,
   extractApplyPatchPaths,

--- a/packages/cli/.opencode/tests/plugin-adapter.test.js
+++ b/packages/cli/.opencode/tests/plugin-adapter.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 import { __testUtils } from "../plugins/codemem.js";
 
@@ -158,6 +159,74 @@ describe("opencode adapter event mapping", () => {
     });
 
     expect(envelope.event_id).toBe("stable-raw-id");
+  });
+
+  test("resolveProjectName falls back to cwd basename when project metadata is missing", () => {
+    const projectName = __testUtils.resolveProjectName(null, "/tmp/workspaces/codemem");
+
+    expect(projectName).toBe("codemem");
+  });
+
+  test("resolveProjectName prefers git root basename for nested cwd", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "codemem-plugin-project-"));
+    try {
+      const repoRoot = join(tmp, "codemem");
+      const nested = join(repoRoot, "packages", "core");
+      mkdirSync(join(repoRoot, ".git"), { recursive: true });
+      mkdirSync(nested, { recursive: true });
+
+      const projectName = __testUtils.resolveProjectName(null, nested);
+      expect(projectName).toBe("codemem");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("resolveProjectName handles git worktree cwd", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "codemem-plugin-project-"));
+    try {
+      const mainRepo = join(tmp, "main-repo");
+      const worktree = join(tmp, "feature-worktree");
+      mkdirSync(join(mainRepo, ".git", "worktrees", "feature-worktree"), { recursive: true });
+      mkdirSync(worktree, { recursive: true });
+      writeFileSync(
+        join(worktree, ".git"),
+        `gitdir: ${join(mainRepo, ".git", "worktrees", "feature-worktree")}`,
+      );
+
+      const projectName = __testUtils.resolveProjectName(null, worktree);
+      expect(projectName).toBe("main-repo");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("resolveProjectName handles relative git worktree markers", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "codemem-plugin-project-"));
+    try {
+      const mainRepo = join(tmp, "main-repo");
+      const worktree = join(tmp, "feature-worktree");
+      mkdirSync(join(mainRepo, ".git", "worktrees", "feature-worktree"), { recursive: true });
+      mkdirSync(worktree, { recursive: true });
+      writeFileSync(
+        join(worktree, ".git"),
+        "gitdir: ../main-repo/.git/worktrees/feature-worktree",
+      );
+
+      const projectName = __testUtils.resolveProjectName(null, worktree);
+      expect(projectName).toBe("main-repo");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("resolveProjectName normalizes path-like project metadata", () => {
+    const projectName = __testUtils.resolveProjectName(
+      { root: "C:\\Users\\adam\\workspace\\codemem" },
+      null,
+    );
+
+    expect(projectName).toBe("codemem");
   });
 
   test("parsePositiveInt falls back for invalid values", () => {

--- a/packages/core/src/claude-hooks.ts
+++ b/packages/core/src/claude-hooks.ts
@@ -116,7 +116,7 @@ function stableEventId(...parts: string[]): string {
 /** Normalize a raw label value to a plain project name (basename if path). */
 export function normalizeProjectLabel(value: unknown): string | null {
 	if (typeof value !== "string") return null;
-	const cleaned = value.trim();
+	const cleaned = value.trim().replace(/[\\/]+$/, "");
 	if (!cleaned) return null;
 	if (cleaned.includes("/") || cleaned.includes("\\")) {
 		// Windows-style path (drive letter or backslash)

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -534,7 +534,41 @@ describe("ingest() integration", () => {
 		const session = store.db
 			.prepare("SELECT * FROM sessions ORDER BY id DESC LIMIT 1")
 			.get() as Record<string, unknown>;
+		expect(session.project).toBe("test-project");
 		expect(session.ended_at).not.toBeNull();
+
+		const summaryMemory = store.db
+			.prepare(
+				"SELECT metadata_json FROM memory_items WHERE json_extract(metadata_json, '$.is_summary') = 1 ORDER BY id DESC LIMIT 1",
+			)
+			.get() as { metadata_json: string };
+		const summaryMetadata = JSON.parse(summaryMemory.metadata_json) as Record<string, unknown>;
+		expect(summaryMetadata.request).toBe("Fix auth timeout");
+		expect(summaryMetadata.completed).toBe("Fixed the timeout");
+		expect(summaryMetadata.learned).toBe("Race condition in handler");
+	});
+
+	it("falls back to cwd basename when payload project is missing", async () => {
+		const payload = buildPayload({ cwd: "/tmp/workspaces/codemem" });
+		await ingest(payload, store, { observer: mockObserver } as unknown as IngestOptions);
+
+		const session = store.db
+			.prepare("SELECT * FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as Record<string, unknown>;
+		expect(session.project).toBe("codemem");
+	});
+
+	it("normalizes explicit path-like project labels before storing the session", async () => {
+		const payload = buildPayload({
+			cwd: "/tmp/workspaces/other-repo",
+			project: "C:\\work\\codemem\\",
+		});
+		await ingest(payload, store, { observer: mockObserver } as unknown as IngestOptions);
+
+		const session = store.db
+			.prepare("SELECT * FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as Record<string, unknown>;
+		expect(session.project).toBe("codemem");
 	});
 
 	it("handles observer returning null gracefully", async () => {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -21,6 +21,7 @@
 
 import { and, isNull, lt } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
+import { normalizeProjectLabel } from "./claude-hooks.js";
 import { toJson } from "./db.js";
 import {
 	budgetToolEvents,
@@ -50,6 +51,7 @@ import type {
 } from "./ingest-types.js";
 import { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
 import type { ObserverClient } from "./observer-client.js";
+import { resolveProject } from "./project.js";
 import * as schema from "./schema.js";
 import type { MemoryStore } from "./store.js";
 
@@ -180,7 +182,7 @@ export async function ingest(
 
 	const d = drizzle(store.db, { schema });
 	const now = new Date().toISOString();
-	const project = payload.project ?? null;
+	const project = normalizeProjectLabel(payload.project) ?? resolveProject(cwd) ?? null;
 
 	const rows = d
 		.insert(schema.sessions)
@@ -397,6 +399,12 @@ export async function ingest(
 							undefined,
 							{
 								is_summary: true,
+								request,
+								investigated: summary.investigated,
+								learned: summary.learned,
+								completed: summary.completed,
+								next_steps: summary.nextSteps,
+								notes: summary.notes,
 								prompt_number: promptNumber,
 								files_read: summary.filesRead,
 								files_modified: summary.filesModified,

--- a/packages/core/src/ingest-prompts.test.ts
+++ b/packages/core/src/ingest-prompts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { buildObserverPrompt } from "./ingest-prompts.js";
+
+describe("buildObserverPrompt", () => {
+	it("includes the Python parity examples and schema guidance", () => {
+		const { system } = buildObserverPrompt({
+			project: "codemem",
+			userPrompt: "Fix observer quality drift",
+			promptNumber: 1,
+			toolEvents: [],
+			lastAssistantMessage: null,
+			diffSummary: "",
+			recentFiles: "",
+			includeSummary: true,
+		});
+
+		expect(system).toContain("GOOD examples (describes what was built or learned)");
+		expect(system).toContain("BAD examples (describes observation process - DO NOT DO THIS)");
+		expect(system).toContain("IMPORTANT: Use 'exploration' when:");
+		expect(system).toContain('Each fact must stand alone - no pronouns like "it" or "this"');
+		expect(system).toContain("If the user prompt is a short approval or acknowledgement");
+		expect(system).toContain(
+			"Otherwise, write a summary that explains the current state of the PRIMARY work (not your observation process).",
+		);
+	});
+
+	it("includes observed project and prompt context in the user prompt", () => {
+		const { user } = buildObserverPrompt({
+			project: "codemem",
+			userPrompt: "Tighten observer prompt quality",
+			promptNumber: 3,
+			toolEvents: [],
+			lastAssistantMessage: "Done.",
+			diffSummary: "",
+			recentFiles: "",
+			includeSummary: true,
+		});
+
+		expect(user).toContain("<project>codemem</project>");
+		expect(user).toContain("<prompt_number>3</prompt_number>");
+		expect(user).toContain("<assistant_response>Done.</assistant_response>");
+	});
+});

--- a/packages/core/src/ingest-prompts.ts
+++ b/packages/core/src/ingest-prompts.ts
@@ -28,7 +28,19 @@ const RECORDING_FOCUS = `Focus on deliverables, capabilities, AND learnings:
 
 Use outcome-focused verbs: implemented, fixed, deployed, configured, migrated, optimized, added, refactored, discovered, learned, debugged.
 Only describe actions that are clearly supported by the observed context.
-Never invent file changes, API behavior, or code edits that are not explicitly present in the session evidence.`;
+Never invent file changes, API behavior, or code edits that are not explicitly present in the session evidence.
+
+GOOD examples (describes what was built or learned):
+- "Authentication now supports OAuth2 with PKCE flow"
+- "Deployment pipeline runs canary releases with auto-rollback"
+- "Fixed race condition in session handler causing duplicate events"
+- "Discovered flush timing strategy needed adaptation for multi-session environment"
+- "Learned transcript building was broken - empty strings passed instead of conversation"
+
+BAD examples (describes observation process - DO NOT DO THIS):
+- "Analyzed authentication implementation and stored findings in database"
+- "Tracked deployment steps and logged outcomes to memory system"
+- "Recorded investigation results for later reference"`;
 
 const SKIP_GUIDANCE = `Skip routine operations WITHOUT learnings:
 - Empty status checks or listings (unless revealing important state)
@@ -60,18 +72,47 @@ const OUTPUT_GUIDANCE =
 
 const OBSERVATION_SCHEMA = `<observation>
   <type>[ ${OBSERVATION_TYPES} ]</type>
+  <!--
+    type MUST be EXACTLY one of these 7 options:
+      - bugfix: something was broken, now fixed
+      - feature: new capability or functionality added
+      - refactor: code restructured, behavior unchanged
+      - change: generic modification (docs, config, misc)
+      - discovery: learning about existing system, debugging insights
+      - decision: architectural/design choice with rationale
+      - exploration: attempted approach that was tried but NOT shipped
+
+    IMPORTANT: Use 'exploration' when:
+      - Multiple approaches were tried for the same problem
+      - An implementation was attempted but then replaced or reverted
+      - Something was tested/experimented with but not kept
+      - The attempt provides useful "why we didn't do X" context
+
+    Exploration memories are valuable. They prevent repeating failed approaches.
+    Include what was tried AND why it didn't work out.
+  -->
   <title>[Short outcome-focused title - what was achieved or learned]</title>
+  <!-- GOOD: "OAuth2 PKCE flow added to authentication" -->
+  <!-- GOOD: "Discovered flush strategy fails in multi-session environments" -->
+  <!-- GOOD (exploration): "Tried emoji theme toggle - poor contrast on light backgrounds" -->
+  <!-- BAD: "Analyzed authentication code" (too vague, no outcome) -->
   <subtitle>[One sentence explanation of the outcome (max 24 words)]</subtitle>
   <facts>
     <fact>[Specific, self-contained statement with concrete details]</fact>
+    <fact>[Include: file paths, function names, config values, error messages]</fact>
+    <fact>[Each fact must stand alone - no pronouns like "it" or "this"]</fact>
   </facts>
   <narrative>[
     Full context: What was done, how it works, why it matters.
-    Aim for 100-500 words.
+    For discoveries/debugging: what was investigated, what was found, what it means.
+    For explorations: what was tried, why it didn't work, what was done instead.
+    Include specific details: file paths, function names, configuration values.
+    Aim for 100-500 words - enough to be useful, not overwhelming.
   ]</narrative>
   <concepts>
     <concept>[how-it-works, why-it-exists, what-changed, problem-solution, gotcha, pattern, trade-off]</concept>
   </concepts>
+  <!-- concepts: 2-5 knowledge categories from the list above -->
   <files_read>
     <file>[full path from project root]</file>
   </files_read>
@@ -81,12 +122,23 @@ const OBSERVATION_SCHEMA = `<observation>
 </observation>`;
 
 const SUMMARY_SCHEMA = `<summary>
-  <request>[What did the user request?]</request>
-  <investigated>[What was explored or examined?]</investigated>
-  <learned>[What was learned about how things work?]</learned>
-  <completed>[What work was done? What shipped?]</completed>
-  <next_steps>[What are the logical next steps?]</next_steps>
-  <notes>[Additional context, insights, or warnings.]</notes>
+  <request>[What did the user request? What was the goal of this work session?]</request>
+
+  <investigated>[What was explored or examined? What files, systems, logs were reviewed?
+  What questions were asked? What did you try to understand?]</investigated>
+
+  <learned>[What was learned about how things work? Any discoveries about the codebase,
+  architecture, or domain? Gotchas or surprises? Understanding gained?]</learned>
+
+  <completed>[What work was done? What shipped? What does the system do now that it
+  didn't before? Be specific: files changed, features added, bugs fixed.]</completed>
+
+  <next_steps>[What are the logical next steps? What remains to be done? What should
+  the next session pick up? Any blockers or dependencies?]</next_steps>
+
+  <notes>[Additional context, insights, or warnings. Anything future sessions should
+  know that doesn't fit above. Design decisions, trade-offs, alternatives considered.]</notes>
+
   <files_read>
     <file>[path]</file>
   </files_read>
@@ -96,12 +148,17 @@ const SUMMARY_SCHEMA = `<summary>
 </summary>
 
 If nothing meaningful happened, emit <skip_summary reason="low-signal"/> and do not emit <summary>.
-Otherwise, write a summary that explains the current state of the PRIMARY work.
+Otherwise, write a summary that explains the current state of the PRIMARY work (not your observation process).
+
+If the user prompt is a short approval or acknowledgement ("yes", "ok", "approved"),
+infer the request from the observed work and the completed/learned sections instead.
 
 Only summarize what is evidenced in the session context. Do not infer or fabricate
 file edits, behaviors, or outcomes that are not explicitly observed.
 
-Keep summaries concise (aim for ~150-450 words total across all fields).`;
+Keep summaries concise (aim for ~150-450 words total across all fields).
+
+This summary helps future sessions understand where this work left off.`;
 
 // ---------------------------------------------------------------------------
 // XML escaping


### PR DESCRIPTION
## Description

This PR fixes TypeScript ingest sessions that were losing their project label and tightening observer prompt guidance so generated memories are more specific and outcome-focused. It also persists structured observer summary fields so the downstream viewer and API can render the new summaries consistently.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:
- `pnpm exec vitest run packages/core/src/ingest-pipeline.test.ts packages/core/src/ingest-prompts.test.ts`
- `bun test ./packages/cli/.opencode/tests/plugin-adapter.test.js`
- `pnpm exec biome check packages/cli/.opencode/plugins/codemem.js packages/cli/.opencode/tests/plugin-adapter.test.js packages/core/src/claude-hooks.ts packages/core/src/ingest-prompts.ts packages/core/src/ingest-prompts.test.ts packages/core/src/ingest-pipeline.ts packages/core/src/ingest-pipeline.test.ts`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced