### PR TITLE
fix viewer summary routing and scope filters

### DIFF
--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -122,11 +122,14 @@ export function buildFilterClausesWithContext(
 		.trim()
 		.toLowerCase();
 	if (ownership && (ownershipScope === "mine" || ownershipScope === "theirs")) {
-		const ownedClause = "(memory_items.actor_id = ? OR memory_items.origin_device_id = ?)";
+		const ownedClause =
+			"(COALESCE(memory_items.actor_id, '') = ? OR COALESCE(memory_items.origin_device_id, '') = ?)";
 		if (ownershipScope === "mine") {
 			clauses.push(ownedClause);
 		} else {
-			clauses.push(`NOT ${ownedClause}`);
+			clauses.push(
+				"(COALESCE(memory_items.actor_id, '') != ? AND COALESCE(memory_items.origin_device_id, '') != ?)",
+			);
 		}
 		params.push(ownership.actorId, ownership.deviceId);
 	}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,7 +66,7 @@ export {
 	mergeSummaryMetadata,
 	readImportPayload,
 } from "./export-import.js";
-export { buildFilterClauses } from "./filters.js";
+export { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
 // Ingest pipeline
 export {
 	budgetToolEvents,

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -516,7 +516,18 @@ describe("buildFilterClauses", () => {
 			{ actorId: "local:device-1", deviceId: "device-1" },
 		);
 		expect(result.clauses).toEqual([
-			"(memory_items.actor_id = ? OR memory_items.origin_device_id = ?)",
+			"(COALESCE(memory_items.actor_id, '') = ? OR COALESCE(memory_items.origin_device_id, '') = ?)",
+		]);
+		expect(result.params).toEqual(["local:device-1", "device-1"]);
+	});
+
+	it("builds ownership_scope theirs clause with null-safe comparisons", () => {
+		const result = buildFilterClausesWithContext(
+			{ ownership_scope: "theirs" },
+			{ actorId: "local:device-1", deviceId: "device-1" },
+		);
+		expect(result.clauses).toEqual([
+			"(COALESCE(memory_items.actor_id, '') != ? AND COALESCE(memory_items.origin_device_id, '') != ?)",
 		]);
 		expect(result.params).toEqual(["local:device-1", "device-1"]);
 	});

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -45,7 +45,7 @@ export async function loadMemoriesPage(
   options?: { limit?: number; offset?: number; scope?: string },
 ): Promise<any> {
   const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
-  return fetchJson(`/api/memories?${query}`);
+  return fetchJson(`/api/observations?${query}`);
 }
 
 export async function updateMemoryVisibility(memoryId: number, visibility: 'private' | 'shared'): Promise<any> {

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -181,7 +181,35 @@ function getSummaryObject(item: any): Record<string, any> | null {
   const metadata = item?.metadata_json;
   if (looksLikeSummary(metadata)) return metadata;
   if (looksLikeSummary(metadata?.summary)) return metadata.summary;
+  const bodyText = String(item?.body_text || '').trim();
+  if (bodyText.includes('## ')) {
+    const headingMap: Record<string, string> = {
+      request: 'request',
+      completed: 'completed',
+      learned: 'learned',
+      investigated: 'investigated',
+      'next steps': 'next_steps',
+      notes: 'notes',
+    };
+    const parsed: Record<string, string> = {};
+    const sectionRe = /(?:^|\n)##\s+([^\n]+)\n([\s\S]*?)(?=\n##\s+|$)/g;
+    for (let match = sectionRe.exec(bodyText); match; match = sectionRe.exec(bodyText)) {
+      const rawLabel = String(match[1] || '').trim().toLowerCase();
+      const key = headingMap[rawLabel];
+      const content = String(match[2] || '').trim();
+      if (key && content) parsed[key] = content;
+    }
+    if (looksLikeSummary(parsed)) return parsed;
+  }
   return null;
+}
+
+function isSummaryLikeItem(item: any, metadata: any): boolean {
+  const kindValue = String(item?.kind || '').toLowerCase();
+  if (kindValue === 'session_summary') return true;
+  if (metadata?.is_summary === true) return true;
+  const source = String(metadata?.source || '').trim().toLowerCase();
+  return source === 'observer_summary';
 }
 
 function getFactsList(item: any): string[] {
@@ -331,6 +359,23 @@ function renderSummaryObject(summary: Record<string, any>): HTMLElement | null {
 function renderFacts(facts: string[]): HTMLElement | null {
   const trimmed = facts.map((f) => String(f || '').trim()).filter(Boolean);
   if (!trimmed.length) return null;
+  const labeledFacts = trimmed.every((f) => /.+?:\s+.+/.test(f));
+  if (labeledFacts) {
+    const container = el('div', 'feed-body facts') as HTMLDivElement;
+    trimmed.forEach((fact) => {
+      const splitAt = fact.indexOf(':');
+      const labelText = fact.slice(0, splitAt).trim();
+      const contentText = fact.slice(splitAt + 1).trim();
+      if (!labelText || !contentText) return;
+      const row = el('div', 'summary-section');
+      const label = el('div', 'summary-section-label', labelText);
+      const value = el('div', 'summary-section-content');
+      value.innerHTML = renderMarkdownSafe(contentText);
+      row.append(label, value);
+      container.appendChild(row);
+    });
+    if (container.childElementCount > 0) return container;
+  }
   const container = el('div', 'feed-body');
   const list = document.createElement('ul');
   trimmed.forEach((f) => { const li = document.createElement('li'); li.textContent = f; list.appendChild(li); });
@@ -377,10 +422,11 @@ function createTagChip(tag: any): HTMLElement | null {
 
 function renderFeedItem(item: any): HTMLElement {
   const kindValue = String(item.kind || 'session_summary').toLowerCase();
-  const isSessionSummary = kindValue === 'session_summary';
   const metadata = mergeMetadata(item?.metadata_json);
+  const isSessionSummary = isSummaryLikeItem(item, metadata);
+  const displayKindValue = isSessionSummary ? 'session_summary' : kindValue;
 
-  const card = el('div', `feed-item ${kindValue}`.trim());
+  const card = el('div', `feed-item ${displayKindValue}`.trim());
   const rowKey = itemKey(item);
   (card as any).dataset.key = rowKey;
 
@@ -396,7 +442,7 @@ function renderFeedItem(item: any): HTMLElement {
   const displayTitle = isSessionSummary && metadata?.request ? metadata.request : defaultTitle;
   const title = el('div', 'feed-title title');
   title.innerHTML = highlightText(displayTitle, state.feedQuery);
-  const kind = el('span', `kind-pill ${kindValue}`.trim(), kindValue.replace(/_/g, ' '));
+  const kind = el('span', `kind-pill ${displayKindValue}`.trim(), displayKindValue.replace(/_/g, ' '));
   titleWrap.append(kind, title);
 
   const rightWrap = el('div', 'feed-actions');
@@ -409,7 +455,7 @@ function renderFeedItem(item: any): HTMLElement {
   let bodyNode: HTMLElement = el('div', 'feed-body');
 
   if (isSessionSummary) {
-    const summaryObj = getSummaryObject({ metadata_json: metadata });
+    const summaryObj = getSummaryObject({ ...item, metadata_json: metadata });
     const rendered = summaryObj ? renderSummaryObject(summaryObj) : null;
     bodyNode = rendered || renderNarrative(String(item.body_text || '')) || bodyNode;
   } else {
@@ -566,8 +612,8 @@ function renderFeedItem(item: any): HTMLElement {
 /* ── Filtering ───────────────────────────────────────────── */
 
 function filterByType(items: any[]): any[] {
-  if (state.feedTypeFilter === 'observations') return items.filter((i) => String(i.kind || '').toLowerCase() !== 'session_summary');
-  if (state.feedTypeFilter === 'summaries') return items.filter((i) => String(i.kind || '').toLowerCase() === 'session_summary');
+  if (state.feedTypeFilter === 'observations') return items.filter((i) => !isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
+  if (state.feedTypeFilter === 'summaries') return items.filter((i) => isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
   return items;
 }
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -45,6 +45,8 @@ function createTestStore(): MemoryStore {
 		db: rawDb,
 		dbPath: ":memory:",
 		deviceId: "test-device-001",
+		actorId: "local:test-device-001",
+		actorDisplayName: "Test User",
 		stats() {
 			return {
 				database: {
@@ -63,6 +65,49 @@ function createTestStore(): MemoryStore {
 			rawDb.close();
 		},
 	} as unknown as MemoryStore;
+}
+
+function insertTestMemory(
+	store: MemoryStore,
+	options: {
+		sessionId: number;
+		kind: string;
+		title: string;
+		bodyText?: string;
+		metadata?: Record<string, unknown>;
+		actorId?: string | null;
+		originDeviceId?: string | null;
+		createdAt?: string;
+		active?: boolean;
+	},
+) {
+	const now = options.createdAt ?? new Date().toISOString();
+	store.db
+		.prepare(
+			`INSERT INTO memory_items (
+				session_id, kind, title, subtitle, body_text, confidence, tags_text, active,
+				created_at, updated_at, metadata_json, actor_id, actor_display_name, visibility,
+				workspace_id, workspace_kind, origin_device_id, origin_source, trust_state,
+				facts, narrative, concepts, files_read, files_modified, prompt_number, rev, import_key
+			) VALUES (?, ?, ?, NULL, ?, 0.5, '', ?, ?, ?, ?, ?, ?, 'shared', 'shared:default', 'shared', ?, ?, 'trusted', NULL, NULL, NULL, NULL, NULL, NULL, 1, ?)`,
+		)
+		.run(
+			options.sessionId,
+			options.kind,
+			options.title,
+			options.bodyText ?? options.title,
+			options.active === false ? 0 : 1,
+			now,
+			now,
+			JSON.stringify(options.metadata ?? {}),
+			options.actorId === undefined ? "local:test-device-001" : options.actorId,
+			options.actorId == null || options.actorId === "local:test-device-001"
+				? "Test User"
+				: options.actorId,
+			options.originDeviceId === undefined ? "test-device-001" : options.originDeviceId,
+			String(options.metadata?.source ?? "test"),
+			`${options.kind}-${options.title}-${now}`,
+		);
 }
 
 /** Create a test Hono app backed by a fresh in-memory DB. */
@@ -145,6 +190,221 @@ describe("viewer-server", () => {
 				expect(res.status).toBe(200);
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body).toHaveProperty("projects");
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	describe("memory feed routes", () => {
+		it("applies mine/theirs scope filters to observations", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "bugfix",
+					title: "Mine",
+					actorId: "local:test-device-001",
+					originDeviceId: "test-device-001",
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "feature",
+					title: "Theirs",
+					actorId: "peer:other",
+					originDeviceId: "peer-device-002",
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Null owned fields",
+					actorId: null,
+					originDeviceId: null,
+					metadata: { source: "observer" },
+				});
+
+				const mineRes = await app.request("/api/observations?scope=mine");
+				expect(mineRes.status).toBe(200);
+				const mineItems = ((await mineRes.json()) as { items: Array<{ title: string }> }).items;
+				expect(mineItems.map((item) => item.title)).toEqual(["Mine"]);
+
+				const theirsRes = await app.request("/api/observations?scope=theirs");
+				expect(theirsRes.status).toBe(200);
+				const theirsItems = ((await theirsRes.json()) as { items: Array<{ title: string }> }).items;
+				expect(theirsItems.map((item) => item.title).sort()).toEqual([
+					"Null owned fields",
+					"Theirs",
+				]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("preserves query parameters on the /api/memories alias", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "bugfix",
+					title: "Mine",
+					bodyText: "Owned by local actor",
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "feature",
+					title: "Theirs",
+					bodyText: "Owned by remote actor",
+					actorId: "peer:other",
+					originDeviceId: "peer-device-002",
+				});
+
+				const aliasRes = await app.request(
+					"/api/memories?project=test-project&scope=mine&limit=1&offset=0",
+				);
+				expect(aliasRes.status).toBe(301);
+				expect(aliasRes.headers.get("location")).toBe(
+					"/api/observations?project=test-project&scope=mine&limit=1&offset=0",
+				);
+
+				const res = await app.request(aliasRes.headers.get("location")!);
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					items: Array<{ title: string }>;
+					pagination: { limit: number; offset: number };
+				};
+				expect(body.items.map((item) => item.title)).toEqual(["Mine"]);
+				expect(body.pagination.limit).toBe(1);
+				expect(body.pagination.offset).toBe(0);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("routes observer summaries into summaries and excludes them from observations", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Observer summary memory",
+					bodyText: "## Request\nFix feed\n\n## Completed\nShipped route fix",
+					metadata: {
+						is_summary: true,
+						source: "observer_summary",
+						request: "Fix feed",
+						completed: "Shipped route fix",
+					},
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "session_summary",
+					title: "Legacy summary",
+					metadata: { request: "Legacy request" },
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Regular change",
+					metadata: { source: "observer" },
+				});
+
+				const summariesRes = await app.request("/api/summaries");
+				expect(summariesRes.status).toBe(200);
+				const summaries = (
+					(await summariesRes.json()) as { items: Array<{ title: string; kind: string }> }
+				).items;
+				expect(summaries).toHaveLength(2);
+				expect(summaries.map((item) => item.title).sort()).toEqual([
+					"Legacy summary",
+					"Observer summary memory",
+				]);
+
+				const observationsRes = await app.request("/api/observations");
+				expect(observationsRes.status).toBe(200);
+				const observations = ((await observationsRes.json()) as { items: Array<{ title: string }> })
+					.items;
+				expect(observations.map((item) => item.title)).toContain("Regular change");
+				expect(observations.map((item) => item.title)).not.toContain("Observer summary memory");
+				expect(observations.map((item) => item.title)).not.toContain("Legacy summary");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("keeps session observation counts aligned with active feed items", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "bugfix",
+					title: "Active observation",
+					bodyText: "Still visible",
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "bugfix",
+					title: "Inactive observation",
+					bodyText: "Soft deleted",
+					active: false,
+				});
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Observer summary memory",
+					bodyText: "## Request\nCount summary\n\n## Completed\nDone",
+					metadata: { is_summary: true, source: "observer_summary" },
+				});
+
+				const res = await app.request("/api/session");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as { observations: number };
+				expect(body.observations).toBe(1);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("tolerates malformed metadata when classifying summaries", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Broken metadata row",
+					bodyText: "Should still render as observation",
+				});
+				store.db
+					.prepare("UPDATE memory_items SET metadata_json = ? WHERE title = ?")
+					.run("{not-json", "Broken metadata row");
+
+				const observationsRes = await app.request("/api/observations");
+				expect(observationsRes.status).toBe(200);
+				const observations = ((await observationsRes.json()) as { items: Array<{ title: string }> })
+					.items;
+				expect(observations.map((item) => item.title)).toContain("Broken metadata row");
+
+				const summariesRes = await app.request("/api/summaries");
+				expect(summariesRes.status).toBe(200);
 			} finally {
 				cleanup();
 			}
@@ -395,6 +655,25 @@ describe("viewer-server", () => {
 			try {
 				const res = await app.request("/api/stats");
 				expect(res.status).toBe(200);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns 400 for invalid JSON on visibility updates", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/memories/visibility", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: "{bad json",
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.error).toBe("invalid JSON");
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -3,7 +3,7 @@
  */
 
 import type { MemoryStore } from "@codemem/core";
-import { fromJson, parseStrictInteger, schema } from "@codemem/core";
+import { buildFilterClausesWithContext, fromJson, parseStrictInteger, schema } from "@codemem/core";
 import { desc, eq, inArray, isNotNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { Hono } from "hono";
@@ -66,6 +66,93 @@ function projectBasename(raw: string): string {
 	return parts[parts.length - 1] ?? raw;
 }
 
+function normalizeScope(raw: string | undefined): "mine" | "theirs" | undefined {
+	const value = String(raw ?? "")
+		.trim()
+		.toLowerCase();
+	if (value === "mine" || value === "theirs") return value;
+	return undefined;
+}
+
+function queryMemoryPage(
+	store: MemoryStore,
+	options: {
+		limit: number;
+		offset: number;
+		project?: string;
+		scope?: "mine" | "theirs";
+	},
+): Record<string, unknown>[] {
+	const filters: Record<string, unknown> = {};
+	if (options.project) filters.project = options.project;
+	if (options.scope) filters.ownership_scope = options.scope;
+
+	const filterResult = buildFilterClausesWithContext(filters, {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+	});
+	const clauses = ["memory_items.active = 1", ...filterResult.clauses];
+	const where = clauses.join(" AND ");
+	const from = filterResult.joinSessions
+		? "memory_items JOIN sessions ON sessions.id = memory_items.session_id"
+		: "memory_items";
+
+	const rows = store.db
+		.prepare(
+			`SELECT memory_items.* FROM ${from}
+			 WHERE ${where}
+			 ORDER BY memory_items.created_at DESC
+			 LIMIT ? OFFSET ?`,
+		)
+		.all(...filterResult.params, options.limit + 1, options.offset) as Record<string, unknown>[];
+
+	return rows.map((row) => ({
+		...row,
+		metadata_json: fromJson((row.metadata_json as string) ?? null),
+	}));
+}
+
+function isSummaryLikeMemory(item: Record<string, unknown>): boolean {
+	if (String(item.kind ?? "").toLowerCase() === "session_summary") return true;
+	const metadata = (item.metadata_json ?? {}) as Record<string, unknown>;
+	if (metadata.is_summary === true) return true;
+	return (
+		String(metadata.source ?? "")
+			.trim()
+			.toLowerCase() === "observer_summary"
+	);
+}
+
+function selectMemoryPage(
+	store: MemoryStore,
+	options: {
+		limit: number;
+		offset: number;
+		project?: string;
+		scope?: "mine" | "theirs";
+		matcher: (item: Record<string, unknown>) => boolean;
+	},
+): Record<string, unknown>[] {
+	const pageSize = Math.max(options.limit + options.offset + 10, 50);
+	let rawOffset = 0;
+	const matched: Record<string, unknown>[] = [];
+
+	while (matched.length < options.offset + options.limit + 1) {
+		const page = queryMemoryPage(store, {
+			limit: pageSize,
+			offset: rawOffset,
+			project: options.project,
+			scope: options.scope,
+		});
+		if (page.length === 0) break;
+		matched.push(...page.filter(options.matcher));
+		if (page.length < pageSize) break;
+		rawOffset += page.length;
+	}
+
+	return matched.slice(options.offset, options.offset + options.limit + 1);
+}
+
 export function memoryRoutes(getStore: StoreFactory) {
 	const app = new Hono();
 
@@ -113,7 +200,10 @@ export function memoryRoutes(getStore: StoreFactory) {
 	});
 
 	// GET /api/observations (aliased from /api/memories)
-	app.get("/api/memories", (c) => c.redirect("/api/observations", 301));
+	app.get("/api/memories", (c) => {
+		const search = new URL(c.req.url).search;
+		return c.redirect(`/api/observations${search}`, 301);
+	});
 
 	app.get("/api/observations", (c) => {
 		const store = getStore();
@@ -121,19 +211,14 @@ export function memoryRoutes(getStore: StoreFactory) {
 			const limit = Math.max(1, queryInt(c.req.query("limit"), 20));
 			const offset = Math.max(0, queryInt(c.req.query("offset"), 0));
 			const project = c.req.query("project") || undefined;
-			const kinds = [
-				"bugfix",
-				"change",
-				"decision",
-				"discovery",
-				"exploration",
-				"feature",
-				"refactor",
-			];
-			const filters: Record<string, unknown> = {};
-			if (project) filters.project = project;
-
-			const items = store.recentByKinds(kinds, limit + 1, filters, offset);
+			const scope = normalizeScope(c.req.query("scope"));
+			const items = selectMemoryPage(store, {
+				limit,
+				offset,
+				project,
+				scope,
+				matcher: (item) => !isSummaryLikeMemory(item),
+			});
 			const hasMore = items.length > limit;
 			const result = hasMore ? items.slice(0, limit) : items;
 			const asRecords = result as unknown as Record<string, unknown>[];
@@ -157,10 +242,14 @@ export function memoryRoutes(getStore: StoreFactory) {
 			const limit = Math.max(1, queryInt(c.req.query("limit"), 50));
 			const offset = Math.max(0, queryInt(c.req.query("offset"), 0));
 			const project = c.req.query("project") || undefined;
-			const filters: Record<string, unknown> = { kind: "session_summary" };
-			if (project) filters.project = project;
-
-			const items = store.recent(limit + 1, filters, offset);
+			const scope = normalizeScope(c.req.query("scope"));
+			const items = selectMemoryPage(store, {
+				limit,
+				offset,
+				project,
+				scope,
+				matcher: (item) => isSummaryLikeMemory(item),
+			});
 			const hasMore = items.length > limit;
 			const result = hasMore ? items.slice(0, limit) : items;
 			const asRecords = result as unknown as Record<string, unknown>[];
@@ -191,6 +280,22 @@ export function memoryRoutes(getStore: StoreFactory) {
 			let artifacts: number;
 			let memories: number;
 			let observations: number;
+			const countObservations = (scopeProject?: string) => {
+				let offset = 0;
+				let total = 0;
+				while (true) {
+					const page = queryMemoryPage(store, {
+						limit: 200,
+						offset,
+						project: scopeProject,
+					});
+					if (page.length === 0) break;
+					total += page.filter((item) => !isSummaryLikeMemory(item)).length;
+					if (page.length < 200) break;
+					offset += page.length;
+				}
+				return total;
+			};
 			if (project) {
 				prompts = count("SELECT COUNT(*) AS total FROM user_prompts WHERE project = ?", project);
 				artifacts = count(
@@ -205,19 +310,12 @@ export function memoryRoutes(getStore: StoreFactory) {
 					 WHERE sessions.project = ?`,
 					project,
 				);
-				observations = count(
-					`SELECT COUNT(*) AS total FROM memory_items
-					 JOIN sessions ON sessions.id = memory_items.session_id
-					 WHERE kind != 'session_summary' AND sessions.project = ?`,
-					project,
-				);
+				observations = countObservations(project);
 			} else {
 				prompts = count("SELECT COUNT(*) AS total FROM user_prompts");
 				artifacts = count("SELECT COUNT(*) AS total FROM artifacts");
 				memories = count("SELECT COUNT(*) AS total FROM memory_items");
-				observations = count(
-					"SELECT COUNT(*) AS total FROM memory_items WHERE kind != 'session_summary'",
-				);
+				observations = countObservations();
 			}
 			const total = prompts + artifacts + memories;
 			return c.json({ total, memories, artifacts, prompts, observations });
@@ -291,7 +389,12 @@ export function memoryRoutes(getStore: StoreFactory) {
 	// POST /api/memories/visibility
 	app.post("/api/memories/visibility", async (c) => {
 		const store = getStore();
-		const body = await c.req.json<Record<string, unknown>>();
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid JSON" }, 400);
+		}
 		const memoryId = parseStrictInteger(
 			typeof body.memory_id === "string" ? body.memory_id : String(body.memory_id ?? ""),
 		);


### PR DESCRIPTION
## Description

This PR makes summary-like observer memories behave like summaries throughout the viewer stack instead of looking like broken observations. It updates the UI, viewer routes, and store filtering so summary cards render correctly, ownership scope filters are enforced server-side, and feed/session counts stay aligned.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:
- `pnpm exec vitest run packages/core/src/store.test.ts packages/viewer-server/src/index.test.ts packages/core/src/ingest-pipeline.test.ts packages/core/src/ingest-prompts.test.ts`
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced