### PR TITLE
replace bun plugin tests with vitest smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
         with:
-          bun-version: 1.3.4
+          node-version: 24
+          cache: pnpm
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Install plugin runtime dependency
-        run: |
-          cd packages/cli/.opencode
-          echo '{"dependencies":{"@opencode-ai/plugin":"1.2.27"}}' > package.json
-          bun install
+        run: npm install --prefix packages/cli/.opencode --no-save @opencode-ai/plugin@1.2.27
 
       - name: Run plugin unit tests
-        run: bun test ./packages/cli/.opencode/tests/*.test.js
+        run: pnpm --filter codemem test:plugin && pnpm --filter codemem test:smoke

--- a/packages/cli/.opencode/tests/compat.test.js
+++ b/packages/cli/.opencode/tests/compat.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vitest";
 
 import {
   isVersionAtLeast,

--- a/packages/cli/.opencode/tests/plugin-adapter.test.js
+++ b/packages/cli/.opencode/tests/plugin-adapter.test.js
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { __testUtils } from "../plugins/codemem.js";
 
@@ -312,7 +313,12 @@ describe("opencode adapter event mapping", () => {
   });
 
   test("pinned backend version matches package version", () => {
-    const packageJsonPath = resolve(import.meta.dir, "..", "..", "package.json");
+    const packageJsonPath = resolve(
+      fileURLToPath(new URL(".", import.meta.url)),
+      "..",
+      "..",
+      "package.json",
+    );
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 
     expect(__testUtils.PINNED_BACKEND_VERSION).toBe(packageJson.version);

--- a/packages/cli/.opencode/tests/plugin-toast.test.js
+++ b/packages/cli/.opencode/tests/plugin-toast.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vitest";
 
 import { buildInjectionToastMessage } from "../plugins/codemem.js";
 

--- a/packages/cli/.opencode/tests/plugin-working-set.test.js
+++ b/packages/cli/.opencode/tests/plugin-working-set.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vitest";
 
 import { __testUtils } from "../plugins/codemem.js";
 

--- a/packages/cli/.opencode/vitest.config.ts
+++ b/packages/cli/.opencode/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		name: "cli-plugin",
+		include: [".opencode/tests/**/*.test.js"],
+		exclude: ["node_modules/**"],
+	},
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,9 @@
 	"scripts": {
 		"clean": "rm -rf dist",
 		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist",
+		"test": "pnpm exec vitest run",
+		"test:plugin": "pnpm exec vitest run --config .opencode/vitest.config.ts",
+		"test:smoke": "pnpm exec vitest run --config smoke.vitest.config.ts",
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/cli/smoke.vitest.config.ts
+++ b/packages/cli/smoke.vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		name: "cli-smoke",
+		hookTimeout: 30000,
+		include: ["src/index.smoke.test.ts"],
+		exclude: ["node_modules/**"],
+	},
+});

--- a/packages/cli/src/index.smoke.test.ts
+++ b/packages/cli/src/index.smoke.test.ts
@@ -1,0 +1,54 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const packageDir = dirname(fileURLToPath(import.meta.url));
+const cliPackageRoot = resolve(packageDir, "..");
+const workspaceRoot = resolve(cliPackageRoot, "..", "..");
+const distEntrypoint = resolve(cliPackageRoot, "dist/index.js");
+const cliPackageVersion = JSON.parse(readFileSync(resolve(cliPackageRoot, "package.json"), "utf8"))
+	.version as string;
+
+function runCommand(command: string, args: string[], cwd = cliPackageRoot) {
+	return spawnSync(command, args, {
+		cwd,
+		encoding: "utf8",
+		env: process.env,
+	});
+}
+
+function runCli(args: string[]) {
+	return runCommand(process.execPath, [distEntrypoint, ...args]);
+}
+
+describe("cli smoke", () => {
+	beforeAll(() => {
+		const build = runCommand("pnpm", ["run", "build"], workspaceRoot);
+
+		expect(build.status).toBe(0);
+	});
+
+	it("prints top-level help", () => {
+		const result = runCli(["--help"]);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("persistent memory for AI coding agents");
+		expect(result.stdout).toContain("serve");
+		expect(result.stdout).toContain("search");
+	});
+
+	it("prints the current version", () => {
+		const result = runCli(["version"]);
+
+		expect(result.status).toBe(0);
+		expect(result.stdout.trim()).toBe(cliPackageVersion);
+	});
+
+	it("emits an executable dist entrypoint", () => {
+		const mode = statSync(distEntrypoint).mode & 0o777;
+
+		expect(mode & 0o111).not.toBe(0);
+	});
+});

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -35,6 +35,6 @@ export default defineConfig({
 	},
 	test: {
 		name: "cli",
-		exclude: [".opencode/**", "node_modules/**"],
+		exclude: ["src/index.smoke.test.ts", ".opencode/**", "node_modules/**"],
 	},
 });


### PR DESCRIPTION
## Description

This PR removes Bun from the CLI/plugin test path and moves the plugin unit tests onto the same Vitest + pnpm workflow used by the rest of the TypeScript workspace. It also adds built-artifact smoke coverage for the CLI entrypoint and updates CI to run the new plugin and smoke scripts directly.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:
- `pnpm --filter codemem test`
- `pnpm --filter codemem test:plugin`
- `pnpm --filter codemem test:smoke`
- `pnpm --filter codemem typecheck`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced