### PR TITLE
add packed plugin artifact CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,37 @@ jobs:
 
       - name: Run plugin unit tests
         run: pnpm --filter codemem test:plugin && pnpm --filter codemem test:smoke
+
+  packaged-plugin-smoke:
+    name: Packaged Plugin Smoke Test
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Copy viewer static assets
+        run: |
+          mkdir -p packages/viewer-server/static
+          cp codemem/viewer_static/index.html codemem/viewer_static/favicon.svg packages/viewer-server/static/
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Run packed artifact smoke test
+        run: pnpm --filter codemem test:packed-artifact

--- a/packages/cli/.opencode/.gitignore
+++ b/packages/cli/.opencode/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-package.json
 bun.lock

--- a/packages/cli/.opencode/package.json
+++ b/packages/cli/.opencode/package.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"@opencode-ai/plugin": "1.2.27"
+	}
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,7 @@
 	},
 	"files": [
 		"dist/",
+		".opencode/package.json",
 		".opencode/plugins/",
 		".opencode/lib/",
 		"README.md",
@@ -17,6 +18,7 @@
 		"clean": "rm -rf dist",
 		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist",
 		"test": "pnpm exec vitest run",
+		"test:packed-artifact": "node ./scripts/packed-artifact-smoke.mjs",
 		"test:plugin": "pnpm exec vitest run --config .opencode/vitest.config.ts",
 		"test:smoke": "pnpm exec vitest run --config smoke.vitest.config.ts",
 		"typecheck": "pnpm exec tsc --noEmit"

--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -1,0 +1,103 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const packageRoot = process.cwd();
+const packageJson = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
+const packageVersion = String(packageJson.version);
+const tempDir = mkdtempSync(join(tmpdir(), "codemem-packed-artifact-"));
+
+function fail(message, result) {
+	if (result) {
+		if (result.stdout) process.stderr.write(result.stdout);
+		if (result.stderr) process.stderr.write(result.stderr);
+	}
+	throw new Error(message);
+}
+
+function run(command, args, cwd = packageRoot) {
+	const result = spawnSync(command, args, {
+		cwd,
+		encoding: "utf8",
+		env: process.env,
+	});
+	if (result.status !== 0) {
+		fail(`Command failed: ${command} ${args.join(" ")}`, result);
+	}
+	return result;
+}
+
+function assert(condition, message) {
+	if (!condition) {
+		throw new Error(message);
+	}
+}
+
+try {
+	const packResult = run("pnpm", ["pack", "--pack-destination", tempDir]);
+	const packedTarball = packResult.stdout
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.at(-1);
+
+	assert(Boolean(packedTarball), "pnpm pack did not report a tarball path");
+	assert(existsSync(packedTarball), `Packed tarball not found: ${packedTarball}`);
+
+	const tarListing = run("tar", ["-tf", packedTarball]).stdout;
+	assert(
+		tarListing.includes("package/.opencode/plugins/codemem.js"),
+		"Packed artifact is missing .opencode/plugins/codemem.js",
+	);
+	assert(
+		tarListing.includes("package/.opencode/lib/compat.js"),
+		"Packed artifact is missing .opencode/lib/compat.js",
+	);
+	assert(
+		tarListing.includes("package/.opencode/package.json"),
+		"Packed artifact is missing .opencode/package.json",
+	);
+
+	const installDir = join(tempDir, "install");
+	run("npm", ["install", "--prefix", installDir, packedTarball]);
+
+	const installedPackageRoot = join(installDir, "node_modules", "codemem");
+	const installedPluginRoot = join(installedPackageRoot, ".opencode");
+	const cliBin = join(installDir, "node_modules", ".bin", process.platform === "win32" ? "codemem.cmd" : "codemem");
+
+	assert(existsSync(cliBin), "Installed artifact is missing the codemem binary");
+	assert(
+		existsSync(join(installedPluginRoot, "plugins", "codemem.js")),
+		"Installed artifact is missing .opencode/plugins/codemem.js",
+	);
+	assert(
+		existsSync(join(installedPluginRoot, "package.json")),
+		"Installed artifact is missing .opencode/package.json",
+	);
+
+	const helpOutput = run(cliBin, ["--help"]).stdout;
+	assert(helpOutput.includes("persistent memory for AI coding agents"), "Installed CLI help output is missing expected text");
+
+	const versionOutput = run(cliBin, ["version"]).stdout.trim();
+	assert(versionOutput === packageVersion, `Installed CLI reported ${versionOutput}, expected ${packageVersion}`);
+
+	run("npm", ["install", "--prefix", installedPluginRoot, "--no-save"]);
+	const installedPluginPackage = JSON.parse(
+		readFileSync(resolve(installedPluginRoot, "node_modules", "@opencode-ai", "plugin", "package.json"), "utf8"),
+	);
+	assert(
+		installedPluginPackage.version === "1.2.27",
+		`Installed plugin runtime version was ${installedPluginPackage.version}, expected 1.2.27`,
+	);
+	const pluginModuleUrl = pathToFileURL(join(installedPluginRoot, "plugins", "codemem.js")).href;
+	run(process.execPath, [
+		"--input-type=module",
+		"-e",
+		"const mod = await import(process.argv[1]); if (!mod.default) throw new Error('plugin default export missing');",
+		pluginModuleUrl,
+	]);
+} finally {
+	rmSync(tempDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Description

This PR adds a packaged-artifact smoke lane to CI so we validate the published `codemem` npm tarball rather than only the checkout-path plugin tests. It verifies the packed package includes the OpenCode plugin payload, installs cleanly from the tarball, runs the installed CLI, and resolves plugin runtime dependencies from the packaged `.opencode/package.json`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:
- `pnpm run build`
- `pnpm --filter codemem test:packed-artifact`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced