### PR TITLE
fix raw event auto flush batching

### DIFF
--- a/packages/core/src/raw-event-sweeper.test.ts
+++ b/packages/core/src/raw-event-sweeper.test.ts
@@ -1,0 +1,227 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import type { IngestOptions } from "./ingest-pipeline.js";
+import { RawEventSweeper } from "./raw-event-sweeper.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema } from "./test-utils.js";
+
+function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("RawEventSweeper auto flush", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+	let prevAutoFlush: string | undefined;
+	let prevDebounce: string | undefined;
+
+	beforeEach(() => {
+		prevAutoFlush = process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH;
+		prevDebounce = process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-raw-event-sweeper-test-"));
+		dbPath = join(tmpDir, "test.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store.close();
+		if (prevAutoFlush == null) delete process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH;
+		else process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = prevAutoFlush;
+		if (prevDebounce == null) delete process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS;
+		else process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = prevDebounce;
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function seedSession(sessionId: string) {
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-0",
+			eventType: "user_prompt",
+			payload: { type: "user_prompt", prompt_text: "Hello from auto flush" },
+			tsWallMs: 100,
+		});
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-1",
+			eventType: "tool.execute.after",
+			payload: {
+				type: "tool.execute.after",
+				tool: "read",
+				args: { filePath: "x" },
+			},
+			tsWallMs: 200,
+		});
+		store.updateRawEventSessionMeta({
+			opencodeSessionId: sessionId,
+			cwd: tmpDir,
+			project: "codemem",
+			startedAt: "2026-01-01T00:00:00Z",
+			lastSeenTsWallMs: 200,
+		});
+	}
+
+	const ingestOpts: IngestOptions = {
+		observer: {
+			observe: async () => ({
+				raw: `<summary>
+  <request>Auto flush request</request>
+  <completed>Flushed debounced raw events</completed>
+</summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test",
+				runtime: "api_http",
+				auth: { source: "test", type: "api_direct", hasToken: true },
+			}),
+		} as never,
+	};
+
+	it("suppresses auto flush during auth backoff after an auth failure", async () => {
+		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
+		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
+		seedSession("sess-auth");
+		let calls = 0;
+		const sweeper = new RawEventSweeper(store, {
+			observer: {
+				observe: async () => {
+					calls += 1;
+					const { ObserverAuthError } = await import("./observer-client.js");
+					throw new ObserverAuthError("auth failed");
+				},
+				getStatus: () => ({
+					provider: "test",
+					model: "test",
+					runtime: "api_http",
+					auth: { source: "test", type: "api_direct", hasToken: true },
+				}),
+			} as never,
+		});
+
+		sweeper.nudge("sess-auth");
+		await sleep(50);
+		sweeper.nudge("sess-auth");
+		await sleep(50);
+
+		expect(calls).toBe(1);
+	});
+
+	it("waits for active auto flush work during stop", async () => {
+		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
+		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
+		seedSession("sess-stop");
+		let resolved = false;
+		const sweeper = new RawEventSweeper(store, {
+			observer: {
+				observe: async () => {
+					await sleep(80);
+					resolved = true;
+					return {
+						raw: `<summary><request>stop</request><completed>done</completed></summary>`,
+						parsed: null,
+						provider: "test",
+						model: "test",
+					};
+				},
+				getStatus: () => ({
+					provider: "test",
+					model: "test",
+					runtime: "api_http",
+					auth: { source: "test", type: "api_direct", hasToken: true },
+				}),
+			} as never,
+		});
+
+		sweeper.nudge("sess-stop");
+		await sweeper.stop();
+
+		expect(resolved).toBe(true);
+		expect(store.rawEventFlushState("sess-stop")).toBe(1);
+	});
+
+	it("requeues activity that arrives during an active auto flush", async () => {
+		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
+		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
+		seedSession("sess-rerun");
+		let firstCall = true;
+		const sweeper = new RawEventSweeper(store, {
+			observer: {
+				observe: async () => {
+					if (firstCall) {
+						firstCall = false;
+						store.recordRawEvent({
+							opencodeSessionId: "sess-rerun",
+							eventId: "evt-2",
+							eventType: "tool.execute.after",
+							payload: {
+								type: "tool.execute.after",
+								tool: "read",
+								args: { filePath: "y" },
+							},
+							tsWallMs: 300,
+						});
+						store.updateRawEventSessionMeta({
+							opencodeSessionId: "sess-rerun",
+							cwd: tmpDir,
+							project: "codemem",
+							startedAt: "2026-01-01T00:00:00Z",
+							lastSeenTsWallMs: 300,
+						});
+						sweeper.nudge("sess-rerun");
+						await sleep(60);
+					}
+					return {
+						raw: `<summary><request>rerun</request><completed>done</completed></summary>`,
+						parsed: null,
+						provider: "test",
+						model: "test",
+					};
+				},
+				getStatus: () => ({
+					provider: "test",
+					model: "test",
+					runtime: "api_http",
+					auth: { source: "test", type: "api_direct", hasToken: true },
+				}),
+			} as never,
+		});
+
+		sweeper.nudge("sess-rerun");
+		await sleep(220);
+
+		expect(store.rawEventFlushState("sess-rerun")).toBe(2);
+	});
+
+	it("does not auto flush when auto flush is disabled", async () => {
+		delete process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH;
+		seedSession("sess-disabled");
+		const sweeper = new RawEventSweeper(store, ingestOpts);
+
+		sweeper.nudge("sess-disabled");
+		await sleep(150);
+
+		expect(store.rawEventFlushState("sess-disabled")).toBe(-1);
+	});
+
+	it("debounced auto flush advances flush state when enabled", async () => {
+		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
+		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
+		seedSession("sess-auto");
+		const sweeper = new RawEventSweeper(store, ingestOpts);
+
+		sweeper.nudge("sess-auto");
+		await sleep(100);
+
+		expect(store.rawEventFlushState("sess-auto")).toBe(1);
+	});
+});

--- a/packages/core/src/raw-event-sweeper.ts
+++ b/packages/core/src/raw-event-sweeper.ts
@@ -54,6 +54,10 @@ export class RawEventSweeper {
 	private currentTick: Promise<void> | null = null;
 	private wakeHandle: ReturnType<typeof setTimeout> | null = null;
 	private loopHandle: ReturnType<typeof setTimeout> | null = null;
+	private autoFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	private sessionFlushing = new Set<string>();
+	private autoFlushPending = new Set<string>();
+	private autoFlushPromises = new Set<Promise<void>>();
 	private authBackoffUntil = 0; // epoch seconds
 	private authErrorLogged = false;
 
@@ -104,6 +108,14 @@ export class RawEventSweeper {
 
 	private retentionMs(): number {
 		return envInt("CODEMEM_RAW_EVENTS_RETENTION_MS", 0);
+	}
+
+	private autoFlushEnabled(): boolean {
+		return (process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH ?? "").trim() === "1";
+	}
+
+	private debounceMs(): number {
+		return envInt("CODEMEM_RAW_EVENTS_DEBOUNCE_MS", 60_000);
 	}
 
 	private stuckBatchMs(): number {
@@ -177,8 +189,13 @@ export class RawEventSweeper {
 			clearTimeout(this.wakeHandle);
 			this.wakeHandle = null;
 		}
+		for (const timer of this.autoFlushTimers.values()) clearTimeout(timer);
+		this.autoFlushTimers.clear();
 		if (this.currentTick != null) {
 			await this.currentTick;
+		}
+		if (this.autoFlushPromises.size > 0) {
+			await Promise.allSettled([...this.autoFlushPromises]);
 		}
 	}
 
@@ -191,13 +208,100 @@ export class RawEventSweeper {
 	}
 
 	/**
-	 * Notify the sweeper that new events arrived (nudge it to flush soon).
-	 * Mirrors Python's RawEventFlusher.note_activity() — schedules a near-
-	 * immediate extra tick so events are processed without waiting for the
-	 * full interval.
+	 * Notify the debounced auto-flush path that new events arrived.
+	 * Mirrors Python's RawEventAutoFlusher.note_activity() behavior.
 	 */
-	nudge(): void {
-		this.wake();
+	nudge(opencodeSessionId: string, source = "opencode"): void {
+		if (!this.autoFlushEnabled()) return;
+		if (Date.now() / 1000 < this.authBackoffUntil) return;
+		const streamId = opencodeSessionId.trim();
+		if (!streamId) return;
+		const sourceNorm = source.trim().toLowerCase() || "opencode";
+		const key = `${sourceNorm}:${streamId}`;
+		if (this.sessionFlushing.has(key)) {
+			this.autoFlushPending.add(key);
+			return;
+		}
+		const delayMs = this.debounceMs();
+		if (delayMs <= 0) {
+			this.trackAutoFlush(this.flushNow(streamId, sourceNorm));
+			return;
+		}
+		const existing = this.autoFlushTimers.get(key);
+		if (existing) clearTimeout(existing);
+		const timer = setTimeout(() => {
+			this.autoFlushTimers.delete(key);
+			this.trackAutoFlush(this.flushNow(streamId, sourceNorm));
+		}, delayMs);
+		if (typeof timer === "object" && "unref" in timer) timer.unref();
+		this.autoFlushTimers.set(key, timer);
+	}
+
+	private trackAutoFlush(promise: Promise<void>): void {
+		this.autoFlushPromises.add(promise);
+		void promise.finally(() => {
+			this.autoFlushPromises.delete(promise);
+		});
+	}
+
+	private scheduleAutoFlush(opencodeSessionId: string, source: string): void {
+		const key = `${source}:${opencodeSessionId}`;
+		if (this.sessionFlushing.has(key)) {
+			this.autoFlushPending.add(key);
+			return;
+		}
+		const delayMs = this.debounceMs();
+		if (delayMs <= 0) {
+			this.trackAutoFlush(this.flushNow(opencodeSessionId, source));
+			return;
+		}
+		const existing = this.autoFlushTimers.get(key);
+		if (existing) clearTimeout(existing);
+		const timer = setTimeout(() => {
+			this.autoFlushTimers.delete(key);
+			this.trackAutoFlush(this.flushNow(opencodeSessionId, source));
+		}, delayMs);
+		if (typeof timer === "object" && "unref" in timer) timer.unref();
+		this.autoFlushTimers.set(key, timer);
+	}
+
+	private async flushNow(opencodeSessionId: string, source: string): Promise<void> {
+		if (Date.now() / 1000 < this.authBackoffUntil) return;
+		const key = `${source}:${opencodeSessionId}`;
+		if (this.sessionFlushing.has(key)) {
+			this.autoFlushPending.add(key);
+			return;
+		}
+		this.sessionFlushing.add(key);
+		const existing = this.autoFlushTimers.get(key);
+		if (existing) {
+			clearTimeout(existing);
+			this.autoFlushTimers.delete(key);
+		}
+		try {
+			await flushRawEvents(this.store, this.ingestOpts, {
+				opencodeSessionId,
+				source,
+				cwd: null,
+				project: null,
+				startedAt: null,
+				maxEvents: null,
+			});
+		} catch (exc) {
+			if (exc instanceof ObserverAuthError) {
+				this.handleAuthError(exc);
+				return;
+			}
+			console.error(
+				`codemem: raw event auto flush failed for ${opencodeSessionId}:`,
+				exc instanceof Error ? exc.message : exc,
+			);
+		} finally {
+			this.sessionFlushing.delete(key);
+			if (this.autoFlushPending.delete(key)) {
+				this.scheduleAutoFlush(opencodeSessionId, source);
+			}
+		}
 	}
 
 	/** Schedule the next tick after the configured interval. */
@@ -295,6 +399,9 @@ export class RawEventSweeper {
 		for (const item of queueSessions) {
 			const { source, streamId } = item;
 			if (!streamId) continue;
+			const key = `${source}:${streamId}`;
+			if (this.sessionFlushing.has(key)) continue;
+			this.sessionFlushing.add(key);
 
 			try {
 				await flushRawEvents(this.store, this.ingestOpts, {
@@ -315,6 +422,8 @@ export class RawEventSweeper {
 					`codemem: raw event queue worker flush failed for ${streamId}:`,
 					exc instanceof Error ? exc.message : exc,
 				);
+			} finally {
+				this.sessionFlushing.delete(key);
 			}
 		}
 
@@ -324,6 +433,9 @@ export class RawEventSweeper {
 			const { source, streamId } = item;
 			if (!streamId) continue;
 			if (drained.has(`${source}:${streamId}`)) continue;
+			const key = `${source}:${streamId}`;
+			if (this.sessionFlushing.has(key)) continue;
+			this.sessionFlushing.add(key);
 
 			try {
 				await flushRawEvents(this.store, this.ingestOpts, {
@@ -343,6 +455,8 @@ export class RawEventSweeper {
 					`codemem: raw event sweeper flush failed for ${streamId}:`,
 					exc instanceof Error ? exc.message : exc,
 				);
+			} finally {
+				this.sessionFlushing.delete(key);
 			}
 		}
 	}

--- a/packages/viewer-server/src/routes/raw-events.ts
+++ b/packages/viewer-server/src/routes/raw-events.ts
@@ -88,9 +88,15 @@ async function parseJsonObjectBody(
 }
 
 /** Nudge the sweeper safely — never crashes the caller. */
-function nudgeSweeper(sweeper: RawEventSweeper | null | undefined): void {
+function nudgeSweeper(
+	sweeper: RawEventSweeper | null | undefined,
+	sessionIds: Iterable<string>,
+	source = "opencode",
+): void {
 	try {
-		sweeper?.nudge();
+		for (const sessionId of sessionIds) {
+			sweeper?.nudge(sessionId, source);
+		}
 	} catch {
 		// never crash the request if sweeper nudge fails
 	}
@@ -362,8 +368,8 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 				});
 			}
 
-			// Nudge sweeper once after all metadata updates (mirrors Python note_activity)
-			nudgeSweeper(sweeper);
+			// Note per-session activity for optional debounced auto-flush.
+			nudgeSweeper(sweeper, sessionIds);
 
 			return c.json({ inserted, received: (items as unknown[]).length });
 		} catch (err) {
@@ -412,8 +418,8 @@ export function rawEventsRoutes(getStore: StoreFactory, sweeper?: RawEventSweepe
 				lastSeenTsWallMs: envelope.ts_wall_ms,
 			});
 
-			// Nudge sweeper to process promptly
-			nudgeSweeper(sweeper);
+			// Note activity for optional debounced auto-flush.
+			nudgeSweeper(sweeper, [opencodeSessionId], source);
 
 			return c.json({ inserted: inserted ? 1 : 0, skipped: 0 });
 		} catch (err) {


### PR DESCRIPTION
## Description

This PR ports Python's debounced raw-event auto-flush behavior to the TypeScript sweeper path. Instead of nudging an almost-immediate flush on every raw-event POST, it adds a per-session debounced auto-flush behind `CODEMEM_RAW_EVENTS_AUTO_FLUSH` / `CODEMEM_RAW_EVENTS_DEBOUNCE_MS`, keeps the periodic sweeper path intact, honors auth backoff for auto-flush attempts, and waits for in-flight auto-flush work during shutdown.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:
- `pnpm exec vitest run packages/core/src/raw-event-sweeper.test.ts packages/viewer-server/src/index.test.ts`
- `pnpm --filter @codemem/ui typecheck`
- `pnpm run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced