### PR TITLE
fix sync status coordinator parity

### DIFF
--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -427,9 +427,22 @@ export interface ApiSyncAttemptItemEnriched extends ApiSyncAttemptItem {
 	address: string | null;
 }
 
-/** Sharing review summary. */
-export interface ApiSharingReviewSummary {
-	unreviewed: number;
+export interface ApiSharingReviewItem {
+	peer_device_id: string;
+	peer_name: string;
+	actor_id: string;
+	actor_display_name: string;
+	project: string | null;
+	scope_label: string;
+	shareable_count: number;
+	private_count: number;
+	total_count: number;
+}
+
+export interface ApiLegacyDeviceItem {
+	origin_device_id: string;
+	memory_count: number;
+	last_seen_at: string | null;
 }
 
 /**
@@ -498,8 +511,8 @@ export interface ApiSyncStatusResponse {
 	status: ApiSyncStatusBlock;
 	peers: ApiSyncPeerItem[];
 	attempts: ApiSyncAttemptItemEnriched[];
-	legacy_devices: string[];
-	sharing_review: ApiSharingReviewSummary;
+	legacy_devices: ApiLegacyDeviceItem[];
+	sharing_review: ApiSharingReviewItem[];
 	coordinator: ApiCoordinatorStatus;
 	join_requests: ApiJoinRequest[];
 }

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -1,0 +1,298 @@
+import { networkInterfaces } from "node:os";
+import { mergeAddresses } from "./address-utils.js";
+import { getCodememEnvOverrides, readCodememConfigFile } from "./observer-config.js";
+import type { MemoryStore } from "./store.js";
+import { buildAuthHeaders } from "./sync-auth.js";
+import { buildBaseUrl, requestJson } from "./sync-http-client.js";
+import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
+
+type ConfigRecord = Record<string, unknown>;
+
+function clean(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function parseIntOr(value: unknown, fallback: number): number {
+	if (typeof value === "number" && Number.isFinite(value)) return Math.trunc(value);
+	if (typeof value === "string" && /^-?\d+$/.test(value.trim()))
+		return Number.parseInt(value.trim(), 10);
+	return fallback;
+}
+
+function parseBoolOr(value: unknown, fallback: boolean): boolean {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (["1", "true", "yes", "on"].includes(normalized)) return true;
+		if (["0", "false", "no", "off"].includes(normalized)) return false;
+	}
+	return fallback;
+}
+
+function parseStringList(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value
+			.filter((item): item is string => typeof item === "string")
+			.map((item) => item.trim())
+			.filter(Boolean);
+	}
+	if (typeof value === "string") {
+		return value
+			.split(",")
+			.map((item) => item.trim())
+			.filter(Boolean);
+	}
+	return [];
+}
+
+export interface CoordinatorSyncConfig {
+	syncEnabled: boolean;
+	syncHost: string;
+	syncPort: number;
+	syncIntervalS: number;
+	syncAdvertise: string;
+	syncProjectsInclude: string[];
+	syncProjectsExclude: string[];
+	syncCoordinatorUrl: string;
+	syncCoordinatorGroup: string;
+	syncCoordinatorGroups: string[];
+	syncCoordinatorTimeoutS: number;
+	syncCoordinatorPresenceTtlS: number;
+	syncCoordinatorAdminSecret: string;
+}
+
+export function readCoordinatorSyncConfig(config?: ConfigRecord): CoordinatorSyncConfig {
+	const raw = { ...(config ?? readCodememConfigFile()) } as ConfigRecord;
+	const envOverrides = getCodememEnvOverrides();
+	for (const key of Object.keys(envOverrides)) {
+		const value = process.env[envOverrides[key] as string];
+		if (value != null) raw[key] = value;
+	}
+	const syncCoordinatorGroup = clean(raw.sync_coordinator_group);
+	const syncCoordinatorGroups = parseStringList(raw.sync_coordinator_groups);
+	return {
+		syncEnabled: parseBoolOr(raw.sync_enabled, false),
+		syncHost: clean(raw.sync_host) || "0.0.0.0",
+		syncPort: parseIntOr(raw.sync_port, 7337),
+		syncIntervalS: parseIntOr(raw.sync_interval_s, 120),
+		syncAdvertise: clean(raw.sync_advertise) || "auto",
+		syncProjectsInclude: parseStringList(raw.sync_projects_include),
+		syncProjectsExclude: parseStringList(raw.sync_projects_exclude),
+		syncCoordinatorUrl: clean(raw.sync_coordinator_url),
+		syncCoordinatorGroup,
+		syncCoordinatorGroups:
+			syncCoordinatorGroups.length > 0
+				? syncCoordinatorGroups
+				: syncCoordinatorGroup
+					? [syncCoordinatorGroup]
+					: [],
+		syncCoordinatorTimeoutS: parseIntOr(raw.sync_coordinator_timeout_s, 3),
+		syncCoordinatorPresenceTtlS: parseIntOr(raw.sync_coordinator_presence_ttl_s, 180),
+		syncCoordinatorAdminSecret: clean(raw.sync_coordinator_admin_secret),
+	};
+}
+
+export function coordinatorEnabled(config: CoordinatorSyncConfig): boolean {
+	return Boolean(config.syncCoordinatorUrl && config.syncCoordinatorGroups.length > 0);
+}
+
+function advertisedSyncAddresses(config: CoordinatorSyncConfig): string[] {
+	const advertise = config.syncAdvertise.toLowerCase();
+	if (advertise && advertise !== "auto" && advertise !== "default") {
+		return mergeAddresses(
+			[],
+			advertise
+				.split(",")
+				.map((item) => item.trim())
+				.filter(Boolean),
+		);
+	}
+	if (config.syncHost && config.syncHost !== "0.0.0.0") {
+		return [`${config.syncHost}:${config.syncPort}`];
+	}
+	const addresses = Object.values(networkInterfaces())
+		.flatMap((entries) => entries ?? [])
+		.filter((entry) => !entry.internal)
+		.map((entry) => entry.address)
+		.filter((address) => address && address !== "127.0.0.1" && address !== "::1")
+		.map((address) => `${address}:${config.syncPort}`);
+	return [...new Set(addresses)];
+}
+
+export async function registerCoordinatorPresence(
+	store: MemoryStore,
+	config: CoordinatorSyncConfig,
+): Promise<{ groups: string[]; responses: Record<string, unknown>[] } | null> {
+	if (!coordinatorEnabled(config)) return null;
+	const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+	const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, { keysDir });
+	const publicKey = loadPublicKey(keysDir);
+	if (!publicKey) throw new Error("public key missing");
+	const baseUrl = buildBaseUrl(config.syncCoordinatorUrl);
+	const payload = {
+		fingerprint,
+		public_key: publicKey,
+		addresses: advertisedSyncAddresses(config),
+		ttl_s: Math.max(1, config.syncCoordinatorPresenceTtlS),
+	};
+	const responses: Record<string, unknown>[] = [];
+	for (const groupId of config.syncCoordinatorGroups) {
+		const groupPayload = { ...payload, group_id: groupId };
+		const bodyBytes = Buffer.from(JSON.stringify(groupPayload), "utf8");
+		const url = `${baseUrl}/v1/presence`;
+		const headers = buildAuthHeaders({ deviceId, method: "POST", url, bodyBytes, keysDir });
+		const [status, response] = await requestJson("POST", url, {
+			headers,
+			body: groupPayload,
+			bodyBytes,
+			timeoutS: Math.max(1, config.syncCoordinatorTimeoutS),
+		});
+		if (status !== 200 || !response) {
+			const detail = typeof response?.error === "string" ? response.error : "unknown";
+			throw new Error(`coordinator presence failed (${status}: ${detail})`);
+		}
+		responses.push(response);
+	}
+	return { groups: config.syncCoordinatorGroups, responses };
+}
+
+export async function lookupCoordinatorPeers(
+	store: MemoryStore,
+	config: CoordinatorSyncConfig,
+): Promise<Record<string, unknown>[]> {
+	if (!coordinatorEnabled(config)) return [];
+	const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+	const [deviceId] = ensureDeviceIdentity(store.db, { keysDir });
+	const baseUrl = buildBaseUrl(config.syncCoordinatorUrl);
+	const merged = new Map<string, Record<string, unknown>>();
+	for (const groupId of config.syncCoordinatorGroups) {
+		const url = `${baseUrl}/v1/peers?group_id=${encodeURIComponent(groupId)}`;
+		const headers = buildAuthHeaders({
+			deviceId,
+			method: "GET",
+			url,
+			bodyBytes: Buffer.alloc(0),
+			keysDir,
+		});
+		const [status, response] = await requestJson("GET", url, {
+			headers,
+			timeoutS: Math.max(1, config.syncCoordinatorTimeoutS),
+		});
+		if (status !== 200 || !response) {
+			const detail = typeof response?.error === "string" ? response.error : "unknown";
+			throw new Error(`coordinator lookup failed (${status}: ${detail})`);
+		}
+		const items = Array.isArray(response.items) ? response.items : [];
+		for (const item of items) {
+			if (!item || typeof item !== "object") continue;
+			const record = item as Record<string, unknown>;
+			const device = clean(record.device_id);
+			const fingerprint = clean(record.fingerprint);
+			if (!device) continue;
+			const key = `${device}:${fingerprint}`;
+			const existing = merged.get(key);
+			if (!existing) {
+				merged.set(key, {
+					...record,
+					addresses: mergeAddresses(
+						[],
+						Array.isArray(record.addresses)
+							? record.addresses.filter((x): x is string => typeof x === "string")
+							: [],
+					),
+					groups: [groupId],
+				});
+				continue;
+			}
+			existing.addresses = mergeAddresses(
+				(Array.isArray(existing.addresses) ? existing.addresses : []) as string[],
+				Array.isArray(record.addresses)
+					? record.addresses.filter((x): x is string => typeof x === "string")
+					: [],
+			);
+			existing.groups = mergeAddresses(
+				(Array.isArray(existing.groups) ? existing.groups : []) as string[],
+				[groupId],
+			);
+			existing.stale = Boolean(existing.stale) && Boolean(record.stale);
+			if (clean(record.last_seen_at) > clean(existing.last_seen_at)) {
+				existing.last_seen_at = record.last_seen_at;
+				existing.expires_at = record.expires_at;
+			}
+		}
+	}
+	return [...merged.values()];
+}
+
+export async function coordinatorStatusSnapshot(
+	store: MemoryStore,
+	config: CoordinatorSyncConfig,
+): Promise<Record<string, unknown>> {
+	const pairedPeerCount = Number(
+		(
+			store.db.prepare("SELECT COUNT(1) AS total FROM sync_peers").get() as
+				| { total?: number }
+				| undefined
+		)?.total ?? 0,
+	);
+	if (!coordinatorEnabled(config)) {
+		return {
+			enabled: false,
+			configured: false,
+			groups: config.syncCoordinatorGroups,
+			paired_peer_count: pairedPeerCount,
+		};
+	}
+	const snapshot: Record<string, unknown> = {
+		enabled: true,
+		configured: true,
+		coordinator_url: config.syncCoordinatorUrl,
+		groups: config.syncCoordinatorGroups,
+		paired_peer_count: pairedPeerCount,
+		presence_status: "unknown",
+		presence_error: null,
+		advertised_addresses: [],
+		fresh_peer_count: 0,
+		stale_peer_count: 0,
+		discovered_peer_count: 0,
+	};
+	try {
+		const registration = await registerCoordinatorPresence(store, config);
+		snapshot.presence_status = "posted";
+		const first = registration?.responses?.[0];
+		if (first && typeof first === "object") {
+			snapshot.advertised_addresses = (first as Record<string, unknown>).addresses ?? [];
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		snapshot.presence_status = message.includes("unknown_device") ? "not_enrolled" : "error";
+		snapshot.presence_error = message;
+	}
+	try {
+		const peers = await lookupCoordinatorPeers(store, config);
+		snapshot.discovered_peer_count = peers.length;
+		snapshot.fresh_peer_count = peers.filter((peer) => !peer.stale).length;
+		snapshot.stale_peer_count = peers.filter((peer) => Boolean(peer.stale)).length;
+	} catch (error) {
+		snapshot.lookup_error = error instanceof Error ? error.message : String(error);
+	}
+	return snapshot;
+}
+
+export async function listCoordinatorJoinRequests(
+	config: CoordinatorSyncConfig,
+): Promise<Record<string, unknown>[]> {
+	const groupId = config.syncCoordinatorGroup || config.syncCoordinatorGroups[0] || "";
+	if (!groupId || !config.syncCoordinatorUrl || !config.syncCoordinatorAdminSecret) return [];
+	const url = `${buildBaseUrl(config.syncCoordinatorUrl)}/v1/admin/join-requests?group_id=${encodeURIComponent(groupId)}`;
+	const [status, response] = await requestJson("GET", url, {
+		headers: { "X-Codemem-Coordinator-Admin": config.syncCoordinatorAdminSecret },
+		timeoutS: Math.max(1, config.syncCoordinatorTimeoutS),
+	});
+	if (status !== 200 || !response) return [];
+	return Array.isArray(response.items)
+		? response.items.filter(
+				(item): item is Record<string, unknown> => Boolean(item) && typeof item === "object",
+			)
+		: [];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,14 @@ export {
 	inviteLink,
 } from "./coordinator-invites.js";
 export {
+	coordinatorEnabled,
+	coordinatorStatusSnapshot,
+	listCoordinatorJoinRequests,
+	lookupCoordinatorPeers,
+	readCoordinatorSyncConfig,
+	registerCoordinatorPresence,
+} from "./coordinator-runtime.js";
+export {
 	CoordinatorStore,
 	connectCoordinator,
 	DEFAULT_COORDINATOR_DB_PATH,

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -161,10 +161,15 @@ export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
 	sync_port: "CODEMEM_SYNC_PORT",
 	sync_interval_s: "CODEMEM_SYNC_INTERVAL_S",
 	sync_mdns: "CODEMEM_SYNC_MDNS",
+	sync_advertise: "CODEMEM_SYNC_ADVERTISE",
 	sync_coordinator_url: "CODEMEM_SYNC_COORDINATOR_URL",
 	sync_coordinator_group: "CODEMEM_SYNC_COORDINATOR_GROUP",
+	sync_coordinator_groups: "CODEMEM_SYNC_COORDINATOR_GROUPS",
 	sync_coordinator_timeout_s: "CODEMEM_SYNC_COORDINATOR_TIMEOUT_S",
 	sync_coordinator_presence_ttl_s: "CODEMEM_SYNC_COORDINATOR_PRESENCE_TTL_S",
+	sync_coordinator_admin_secret: "CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET",
+	sync_projects_include: "CODEMEM_SYNC_PROJECTS_INCLUDE",
+	sync_projects_exclude: "CODEMEM_SYNC_PROJECTS_EXCLUDE",
 	raw_events_sweeper_interval_s: "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
 };
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -83,6 +83,31 @@ function cleanStr(value: unknown): string | null {
 	return trimmed.length > 0 ? trimmed : null;
 }
 
+function parseJsonList(value: unknown): string[] {
+	if (typeof value !== "string" || !value.trim()) return [];
+	try {
+		const parsed = JSON.parse(value);
+		return Array.isArray(parsed)
+			? parsed
+					.filter((item): item is string => typeof item === "string")
+					.map((item) => item.trim())
+					.filter(Boolean)
+			: [];
+	} catch {
+		return [];
+	}
+}
+
+function projectBasename(value: string | null | undefined): string {
+	const raw = cleanStr(value);
+	if (!raw) return "";
+	const parts = raw.replace(/\\/g, "/").split("/").filter(Boolean);
+	return parts[parts.length - 1] ?? raw;
+}
+
+const LEGACY_SYNC_ACTOR_DISPLAY_NAME = "Legacy synced peer";
+const LEGACY_SHARED_WORKSPACE_ID = "shared:legacy";
+
 /**
  * Parse a row's metadata_json string into a plain object.
  * Returns a new MemoryItemResponse with metadata_json as a parsed object.
@@ -1625,6 +1650,163 @@ export class MemoryStore {
 		const row = this.db.prepare(query).get(...params) as Record<string, unknown> | undefined;
 		if (!row) return null;
 		return { ...row, status: "error" };
+	}
+
+	getSyncDaemonState(): Record<string, unknown> | null {
+		const row = this.db
+			.prepare(
+				"SELECT last_error, last_traceback, last_error_at, last_ok_at FROM sync_daemon_state WHERE id = 1",
+			)
+			.get() as Record<string, unknown> | undefined;
+		return row ? { ...row } : null;
+	}
+
+	sameActorPeerIds(): string[] {
+		const rows = this.db
+			.prepare(
+				"SELECT peer_device_id FROM sync_peers WHERE claimed_local_actor = 1 OR actor_id = ? ORDER BY peer_device_id",
+			)
+			.all(this.actorId) as Array<Record<string, unknown>>;
+		return rows.map((row) => String(row.peer_device_id ?? "").trim()).filter(Boolean);
+	}
+
+	claimedSameActorLegacyActorIds(): string[] {
+		return this.sameActorPeerIds().map((peerId) => `legacy-sync:${peerId}`);
+	}
+
+	claimableLegacyDeviceIds(): Record<string, unknown>[] {
+		const rows = this.db
+			.prepare(
+				`SELECT origin_device_id, COUNT(*) AS memory_count, MAX(created_at) AS last_seen_at
+				 FROM memory_items
+				 WHERE origin_device_id IS NOT NULL
+				   AND origin_device_id != ''
+				   AND origin_device_id != 'unknown'
+				   AND ((actor_id IS NULL OR TRIM(actor_id) = '' OR actor_id LIKE 'legacy-sync:%')
+				     AND (actor_id IS NULL OR TRIM(actor_id) = '' OR actor_id LIKE 'legacy-sync:%' OR actor_display_name = ? OR workspace_id = ? OR trust_state = 'legacy_unknown'))
+				   AND origin_device_id != ?
+				   AND origin_device_id NOT IN (SELECT peer_device_id FROM sync_peers WHERE peer_device_id IS NOT NULL)
+				 GROUP BY origin_device_id
+				 ORDER BY last_seen_at DESC, origin_device_id ASC`,
+			)
+			.all(LEGACY_SYNC_ACTOR_DISPLAY_NAME, LEGACY_SHARED_WORKSPACE_ID, this.deviceId) as Array<
+			Record<string, unknown>
+		>;
+		return rows
+			.filter((row) => cleanStr(row.origin_device_id))
+			.map((row) => ({
+				origin_device_id: String(row.origin_device_id),
+				memory_count: Number(row.memory_count ?? 0),
+				last_seen_at: row.last_seen_at ?? null,
+			}));
+	}
+
+	private effectiveSyncProjectFilters(peerDeviceId?: string | null): {
+		include: string[];
+		exclude: string[];
+	} {
+		const config = readCodememConfigFile();
+		let include = parseJsonList(JSON.stringify(config.sync_projects_include ?? []));
+		let exclude = parseJsonList(JSON.stringify(config.sync_projects_exclude ?? []));
+		if (peerDeviceId) {
+			const row = this.db
+				.prepare(
+					"SELECT projects_include_json, projects_exclude_json FROM sync_peers WHERE peer_device_id = ?",
+				)
+				.get(peerDeviceId) as Record<string, unknown> | undefined;
+			if (row) {
+				if (row.projects_include_json != null) include = parseJsonList(row.projects_include_json);
+				if (row.projects_exclude_json != null) exclude = parseJsonList(row.projects_exclude_json);
+			}
+		}
+		return { include, exclude };
+	}
+
+	private syncProjectAllowed(project: string | null, peerDeviceId?: string | null): boolean {
+		const { include, exclude } = this.effectiveSyncProjectFilters(peerDeviceId);
+		const name = cleanStr(project);
+		const basename = projectBasename(name);
+		if (include.length > 0 && !include.some((item) => item === name || item === basename))
+			return false;
+		if (exclude.some((item) => item === name || item === basename)) return false;
+		return true;
+	}
+
+	sharingReviewSummary(project?: string | null): Record<string, unknown>[] {
+		const selectedProject = cleanStr(project);
+		const claimedPeers = this.sameActorPeerIds();
+		const legacyActorIds = this.claimedSameActorLegacyActorIds();
+		const ownershipClauses = ["memory_items.actor_id = ?"];
+		const params: unknown[] = [this.actorId];
+		if (claimedPeers.length > 0) {
+			ownershipClauses.push(
+				`memory_items.origin_device_id IN (${claimedPeers.map(() => "?").join(", ")})`,
+			);
+			params.push(...claimedPeers);
+		}
+		if (legacyActorIds.length > 0) {
+			ownershipClauses.push(
+				`memory_items.actor_id IN (${legacyActorIds.map(() => "?").join(", ")})`,
+			);
+			params.push(...legacyActorIds);
+		}
+		const rows = this.db
+			.prepare(
+				`SELECT sync_peers.peer_device_id, sync_peers.name, sync_peers.actor_id,
+				        actors.display_name AS actor_display_name,
+				        sessions.project AS project, memory_items.visibility AS visibility,
+				        COUNT(*) AS total
+				 FROM sync_peers
+				 LEFT JOIN actors ON actors.actor_id = sync_peers.actor_id
+				 JOIN memory_items ON memory_items.active = 1
+				 JOIN sessions ON sessions.id = memory_items.session_id
+				 WHERE sync_peers.actor_id IS NOT NULL
+				   AND TRIM(sync_peers.actor_id) != ''
+				   AND sync_peers.actor_id != ?
+				   AND (${ownershipClauses.join(" OR ")})
+				 GROUP BY sync_peers.peer_device_id, sync_peers.name, sync_peers.actor_id, sessions.project, memory_items.visibility
+				 ORDER BY sync_peers.name, sync_peers.peer_device_id`,
+			)
+			.all(this.actorId, ...params) as Array<Record<string, unknown>>;
+		const byPeer = new Map<string, Record<string, unknown>>();
+		for (const row of rows) {
+			const peerDeviceId = String(row.peer_device_id ?? "").trim();
+			const actorId = String(row.actor_id ?? "").trim();
+			if (!peerDeviceId || !actorId || actorId === this.actorId) continue;
+			const projectName = cleanStr(row.project);
+			if (selectedProject) {
+				const selectedBase = projectBasename(selectedProject);
+				const projectBase = projectBasename(projectName);
+				if (projectName !== selectedProject && projectBase !== selectedBase) continue;
+			}
+			if (!this.syncProjectAllowed(projectName, peerDeviceId)) continue;
+			const current = byPeer.get(peerDeviceId) ?? {
+				peer_device_id: peerDeviceId,
+				peer_name: cleanStr(row.name) ?? peerDeviceId,
+				actor_id: actorId,
+				actor_display_name: cleanStr(row.actor_display_name) ?? actorId,
+				project: selectedProject,
+				scope_label: selectedProject ?? "All allowed projects",
+				shareable_count: 0,
+				private_count: 0,
+			};
+			const total = Number(row.total ?? 0);
+			if (String(row.visibility ?? "") === "private") {
+				current.private_count = Number(current.private_count ?? 0) + total;
+			} else {
+				current.shareable_count = Number(current.shareable_count ?? 0) + total;
+			}
+			byPeer.set(peerDeviceId, current);
+		}
+		const results = [...byPeer.values()].map((item) => ({
+			...item,
+			total_count: Number(item.shareable_count ?? 0) + Number(item.private_count ?? 0),
+		}));
+		return results.sort(
+			(a: Record<string, unknown>, b: Record<string, unknown>) =>
+				String(a.peer_name ?? "").localeCompare(String(b.peer_name ?? "")) ||
+				String(a.peer_device_id ?? "").localeCompare(String(b.peer_device_id ?? "")),
+		);
 	}
 
 	// close

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5,10 +5,15 @@
  * Uses Record<string, unknown> instead of Record<string, any> (fix #6).
  */
 
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { initTestSchema, insertTestSession, type MemoryStore } from "@codemem/core";
+import {
+	ensureDeviceIdentity,
+	initTestSchema,
+	insertTestSession,
+	MemoryStore,
+} from "@codemem/core";
 import Database from "better-sqlite3";
 import { describe, expect, it, vi } from "vitest";
 import { createApp } from "./index.js";
@@ -17,54 +22,25 @@ import { createApp } from "./index.js";
 // Test helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Create an in-memory MemoryStore backed by a fresh test schema.
- * The caller must close() when done.
- */
-function createTestStore(): MemoryStore {
-	// Create raw DB, init schema, then wrap in MemoryStore via its constructor
-	// MemoryStore constructor calls connect() which creates a new DB.
-	// Instead, we need to use the store directly with a test DB path.
-	// Use :memory: via a temporary approach.
-	const rawDb = new Database(":memory:");
+function createTestStore(): { store: MemoryStore; cleanup: () => void } {
+	const tmpDir = mkdtempSync(join(tmpdir(), "codemem-viewer-store-test-"));
+	const dbPath = join(tmpDir, "test.sqlite");
+	const rawDb = new Database(dbPath);
 	initTestSchema(rawDb);
-
-	// MemoryStore expects a file path; for tests we create a thin wrapper
-	// that reuses the raw DB.
-	// Since MemoryStore.constructor calls connect() internally, we need to
-	// create a store-compatible object. For now, create a real MemoryStore
-	// using a temp file, but that's slow. Instead, create a lightweight
-	// test harness.
-	//
-	// Actually, MemoryStore from core re-opens the db. For in-memory tests,
-	// we need to work around this. The cleanest approach: insert test data
-	// into the raw DB, then use it directly for assertions.
-
-	// Return the raw DB wrapped to match the subset of MemoryStore we need.
+	rawDb
+		.prepare(
+			"INSERT INTO sync_device(device_id, public_key, fingerprint, created_at) VALUES (?, ?, ?, ?)",
+		)
+		.run("test-device-001", "test-public-key", "test-fingerprint", new Date().toISOString());
+	rawDb.close();
+	const store = new MemoryStore(dbPath);
 	return {
-		db: rawDb,
-		dbPath: ":memory:",
-		deviceId: "test-device-001",
-		actorId: "local:test-device-001",
-		actorDisplayName: "Test User",
-		stats() {
-			return {
-				database: {
-					path: ":memory:",
-					size_bytes: 0,
-					sessions: 0,
-					memory_items: 0,
-					active_memory_items: 0,
-					artifacts: 0,
-					vector_rows: 0,
-					raw_events: 0,
-				},
-			};
+		store,
+		cleanup: () => {
+			store.close();
+			rmSync(tmpDir, { recursive: true, force: true });
 		},
-		close() {
-			rawDb.close();
-		},
-	} as unknown as MemoryStore;
+	};
 }
 
 function insertTestMemory(
@@ -113,13 +89,15 @@ function insertTestMemory(
 /** Create a test Hono app backed by a fresh in-memory DB. */
 function createTestApp(opts?: { sweeper?: unknown }) {
 	let store: MemoryStore | null = null;
+	let storeCleanup: (() => void) | null = null;
 
 	const app = createApp({
 		sweeper: (opts?.sweeper ?? null) as never,
 		storeFactory: () => {
-			// Reuse the same store for the lifetime of the test
 			if (!store) {
-				store = createTestStore();
+				const created = createTestStore();
+				store = created.store;
+				storeCleanup = created.cleanup;
 			}
 			return store;
 		},
@@ -129,10 +107,9 @@ function createTestApp(opts?: { sweeper?: unknown }) {
 		app,
 		getStore: () => store,
 		cleanup: () => {
-			if (store) {
-				store.close();
-				store = null;
-			}
+			storeCleanup?.();
+			store = null;
+			storeCleanup = null;
 		},
 	};
 }
@@ -413,7 +390,7 @@ describe("viewer-server", () => {
 
 	describe("GET /api/observer-status", () => {
 		it("returns live observer status and suppresses stale failures after success", async () => {
-			const store = createTestStore();
+			const { store, cleanup } = createTestStore();
 			try {
 				(
 					store as MemoryStore & {
@@ -461,7 +438,7 @@ describe("viewer-server", () => {
 				expect(body).toHaveProperty("queue");
 				expect(body.latest_failure).toBeNull();
 			} finally {
-				store.close();
+				cleanup();
 			}
 		});
 	});
@@ -834,6 +811,186 @@ describe("viewer-server", () => {
 				expect(body.status.peers["peer-1"]?.sync_status).toBe("ok");
 			} finally {
 				cleanup();
+			}
+		});
+
+		it("returns real sync config and coordinator status details", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/presence")) {
+					return new Response(JSON.stringify({ ok: true, addresses: ["http://1.2.3.4:7337"] }), {
+						status: 200,
+					});
+				}
+				if (url.includes("/v1/peers")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-1",
+									fingerprint: "fp1",
+									addresses: ["http://10.0.0.2:7337"],
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (url.includes("/v1/admin/join-requests")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									request_id: "req-1",
+									device_id: "joiner-1",
+									fingerprint: "fpj",
+									status: "pending",
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_host: "127.0.0.1",
+					sync_port: 7337,
+					sync_interval_s: 45,
+					sync_projects_include: ["codemem"],
+					sync_projects_exclude: ["junk"],
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, any>;
+				expect(body.enabled).toBe(true);
+				expect(body.interval_s).toBe(45);
+				expect(body.project_filter_active).toBe(true);
+				expect(body.project_filter).toEqual({ include: ["codemem"], exclude: ["junk"] });
+				expect(body.coordinator.enabled).toBe(true);
+				expect(body.coordinator.configured).toBe(true);
+				expect(body.coordinator.groups).toEqual(["team-a"]);
+				expect(body.join_requests).toHaveLength(1);
+				expect(body.join_requests[0].request_id).toBe("req-1");
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+				delete process.env.CODEMEM_SYNC_ENABLED;
+			}
+		});
+
+		it("respects env-only sync configuration in status output", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevEnabled = process.env.CODEMEM_SYNC_ENABLED;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_SYNC_ENABLED = "1";
+			writeFileSync(configPath, JSON.stringify({ sync_enabled: false }));
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/status");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.enabled).toBe(true);
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevEnabled == null) delete process.env.CODEMEM_SYNC_ENABLED;
+				else process.env.CODEMEM_SYNC_ENABLED = prevEnabled;
+			}
+		});
+
+		it("returns real legacy device and sharing review summaries", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({ sync_enabled: true, sync_projects_include: ["codemem"] }),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				store.db.prepare("UPDATE sessions SET project = ? WHERE id = ?").run("codemem", sessionId);
+				store.db
+					.prepare(
+						"INSERT OR REPLACE INTO actors(actor_id, display_name, is_local, status, created_at, updated_at) VALUES (?, ?, 0, 'active', ?, ?)",
+					)
+					.run("actor:peer", "Peer Person", new Date().toISOString(), new Date().toISOString());
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, 0, ?)",
+					)
+					.run("peer-actor", "Peer Device", "actor:peer", new Date().toISOString());
+				insertTestMemory(store, {
+					sessionId,
+					kind: "feature",
+					title: "Shared memory",
+					bodyText: "body",
+					metadata: { source: "observer" },
+				});
+				store.db
+					.prepare(
+						`UPDATE memory_items SET actor_id = ?, actor_display_name = ?, visibility = 'shared', workspace_id = 'shared:default', trust_state = 'trusted' WHERE title = ?`,
+					)
+					.run(store.actorId, store.actorDisplayName, "Shared memory");
+				insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Legacy memory",
+					bodyText: "legacy",
+					actorId: null,
+					originDeviceId: "legacy-peer-1",
+					metadata: { source: "observer" },
+				});
+				store.db
+					.prepare(
+						`UPDATE memory_items SET actor_id = NULL, actor_display_name = ?, workspace_id = ?, trust_state = 'legacy_unknown' WHERE title = ?`,
+					)
+					.run("Legacy synced peer", "shared:legacy", "Legacy memory");
+				const res = await app.request("/api/sync/status?includeDiagnostics=1&project=codemem");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, any>;
+				expect(body.legacy_devices).toHaveLength(1);
+				expect(body.legacy_devices[0].origin_device_id).toBe("legacy-peer-1");
+				expect(body.sharing_review).toHaveLength(1);
+				expect(body.sharing_review[0].peer_device_id).toBe("peer-actor");
+				expect(body.sharing_review[0].actor_display_name).toBe("Peer Person");
+				expect(body.sharing_review[0].shareable_count).toBe(1);
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
 			}
 		});
 	});

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -2,8 +2,17 @@
  * Sync routes — status, peers, actors, attempts, pairing, mutations.
  */
 
+import { readFileSync } from "node:fs";
+import net from "node:net";
+import { dirname, join } from "node:path";
 import type { MemoryStore } from "@codemem/core";
-import { ensureDeviceIdentity, schema } from "@codemem/core";
+import {
+	coordinatorStatusSnapshot,
+	ensureDeviceIdentity,
+	listCoordinatorJoinRequests,
+	readCoordinatorSyncConfig,
+	schema,
+} from "@codemem/core";
 import { count, desc, eq, max, ne } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { Hono } from "hono";
@@ -100,6 +109,34 @@ function attemptStatus(attempt: Record<string, unknown>): string {
 	return "unknown";
 }
 
+function readViewerBinding(dbPath: string): { host: string; port: number } | null {
+	try {
+		const raw = readFileSync(join(dirname(dbPath), "viewer.pid"), "utf8");
+		const parsed = JSON.parse(raw) as Partial<{ host: string; port: number }>;
+		if (typeof parsed.host === "string" && typeof parsed.port === "number") {
+			return { host: parsed.host, port: parsed.port };
+		}
+	} catch {
+		// ignore missing/malformed pidfile
+	}
+	return null;
+}
+
+async function portOpen(host: string, port: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		const socket = net.createConnection({ host, port });
+		const done = (ok: boolean) => {
+			socket.removeAllListeners();
+			socket.destroy();
+			resolve(ok);
+		};
+		socket.setTimeout(300);
+		socket.once("connect", () => done(true));
+		socket.once("timeout", () => done(false));
+		socket.once("error", () => done(false));
+	});
+}
+
 const PEERS_QUERY = `
 	SELECT p.peer_device_id, p.name, p.pinned_fingerprint, p.addresses_json,
 	       p.last_seen_at, p.last_sync_at, p.last_error,
@@ -118,11 +155,12 @@ export function syncRoutes(getStore: StoreFactory) {
 	const app = new Hono();
 
 	// GET /api/sync/status
-	app.get("/api/sync/status", (c) => {
+	app.get("/api/sync/status", async (c) => {
 		const store = getStore();
 		{
 			const showDiag = queryBool(c.req.query("includeDiagnostics"));
-			const _project = c.req.query("project") || null;
+			const project = c.req.query("project") || null;
+			const config = readCoordinatorSyncConfig();
 
 			const d = drizzle(store.db, { schema });
 
@@ -151,30 +189,46 @@ export function syncRoutes(getStore: StoreFactory) {
 			const lastError = daemonState?.last_error as string | null;
 			const lastErrorAt = daemonState?.last_error_at as string | null;
 			const lastOkAt = daemonState?.last_ok_at as string | null;
+			const viewerBinding = readViewerBinding(store.dbPath);
+			const daemonRunning = viewerBinding
+				? await portOpen(viewerBinding.host, viewerBinding.port)
+				: false;
+			const daemonDetail = viewerBinding
+				? daemonRunning
+					? `viewer pidfile at ${viewerBinding.host}:${viewerBinding.port}`
+					: `pidfile present but ${viewerBinding.host}:${viewerBinding.port} is unreachable`
+				: null;
 
 			let daemonStateValue = "ok";
-			// Simplified: without full config access, default to enabled
-			if (lastError && (!lastOkAt || String(lastOkAt) < String(lastErrorAt ?? ""))) {
+			if (!config.syncEnabled) {
+				daemonStateValue = "disabled";
+			} else if (lastError && (!lastOkAt || String(lastOkAt) < String(lastErrorAt ?? ""))) {
 				daemonStateValue = "error";
+			} else if (!daemonRunning) {
+				daemonStateValue = "stopped";
 			}
 
 			const statusPayload: Record<string, unknown> = {
-				enabled: true,
-				interval_s: 60,
+				enabled: config.syncEnabled,
+				interval_s: config.syncIntervalS,
 				peer_count: Number(peerCountRow?.total ?? 0),
 				last_sync_at: lastSyncRow?.last_sync_at ?? null,
 				daemon_state: daemonStateValue,
-				daemon_running: false,
-				daemon_detail: null,
-				project_filter_active: false,
-				project_filter: { include: [], exclude: [] },
+				daemon_running: daemonRunning,
+				daemon_detail: daemonDetail,
+				project_filter_active:
+					config.syncProjectsInclude.length > 0 || config.syncProjectsExclude.length > 0,
+				project_filter: {
+					include: config.syncProjectsInclude,
+					exclude: config.syncProjectsExclude,
+				},
 				redacted: !showDiag,
 			};
 
 			if (showDiag) {
 				statusPayload.device_id = deviceRow?.device_id ?? null;
 				statusPayload.fingerprint = deviceRow?.fingerprint ?? null;
-				statusPayload.bind = null;
+				statusPayload.bind = `${config.syncHost}:${config.syncPort}`;
 				statusPayload.daemon_last_error = lastError;
 				statusPayload.daemon_last_error_at = lastErrorAt;
 				statusPayload.daemon_last_ok_at = lastOkAt;
@@ -214,23 +268,65 @@ export function syncRoutes(getStore: StoreFactory) {
 				address: null,
 			}));
 
-			const statusBlock = {
+			const statusBlock: Record<string, unknown> = {
 				...statusPayload,
 				peers: peersMap,
 				pending: 0,
 				sync: {},
 				ping: {},
 			};
+			const legacyDevices = store.claimableLegacyDeviceIds();
+			const sharingReview = store.sharingReviewSummary(project);
+			const coordinator = await coordinatorStatusSnapshot(store, config);
+			let joinRequests: Record<string, unknown>[] = [];
+			try {
+				joinRequests = await listCoordinatorJoinRequests(config);
+			} catch {
+				joinRequests = [];
+			}
+
+			if (daemonStateValue === "ok") {
+				const peerStates = new Set(
+					peersItems.map((peer) =>
+						String((peer.status as Record<string, unknown> | undefined)?.peer_state ?? ""),
+					),
+				);
+				const latestFailedRecently = Boolean(
+					attemptsItems[0] &&
+						attemptsItems[0].status === "error" &&
+						isRecentIso(attemptsItems[0].finished_at),
+				);
+				const allOffline =
+					peersItems.length > 0 &&
+					peersItems.every(
+						(peer) =>
+							String((peer.status as Record<string, unknown>)?.peer_state ?? "") === "offline",
+					);
+				if (latestFailedRecently) {
+					const hasLivePeer = peerStates.has("online") || peerStates.has("degraded");
+					if (hasLivePeer) daemonStateValue = "degraded";
+					else if (allOffline) daemonStateValue = "offline-peers";
+					else if (peersItems.length > 0) daemonStateValue = "stale";
+				} else if (peerStates.has("degraded")) {
+					daemonStateValue = "degraded";
+				} else if (allOffline) {
+					daemonStateValue = "offline-peers";
+				} else if (peersItems.length > 0 && !peerStates.has("online")) {
+					daemonStateValue = "stale";
+				}
+				statusPayload.daemon_state = daemonStateValue;
+				statusBlock.daemon_state = daemonStateValue;
+			}
 
 			return c.json({
 				...statusPayload,
 				status: statusBlock,
 				peers: peersItems,
 				attempts: attemptsItems.slice(0, 5),
-				legacy_devices: [],
-				sharing_review: { unreviewed: 0 },
-				coordinator: { enabled: false, configured: false },
-				join_requests: [],
+				legacy_devices: legacyDevices,
+				sharing_review: sharingReview,
+				coordinator,
+				join_requests: joinRequests,
 			});
 		}
 	});


### PR DESCRIPTION
## Description

This PR ports the Python 0.19 sync/coordinator status behavior into the TypeScript viewer/server. It replaces placeholder sync status fields with real config/runtime state, surfaces a real coordinator snapshot and join requests in `/api/sync/status`, and ports the legacy device + sharing review summaries so the sync tab reflects the actual coordinator/sync state instead of placeholder values.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/core/src/store.test.ts`
- `pnpm run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced