### PR TITLE
add coordinator invite and review routes

### DIFF
--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -1,0 +1,245 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	decodeInvitePayload,
+	encodeInvitePayload,
+	extractInvitePayload,
+	type InvitePayload,
+	inviteLink,
+} from "./coordinator-invites.js";
+import { CoordinatorStore, DEFAULT_COORDINATOR_DB_PATH } from "./coordinator-store.js";
+import { connect } from "./db.js";
+import { initDatabase } from "./maintenance.js";
+import { readCodememConfigFile, writeCodememConfigFile } from "./observer-config.js";
+import { requestJson } from "./sync-http-client.js";
+import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
+
+const VALID_INVITE_POLICIES = new Set(["auto_admit", "approval_required"]);
+
+function coordinatorRemoteTarget(config = readCodememConfigFile()): {
+	remoteUrl: string | null;
+	adminSecret: string | null;
+} {
+	const remoteUrl = String(config.sync_coordinator_url ?? "").trim() || null;
+	const adminSecret = remoteUrl
+		? String(
+				process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET ??
+					config.sync_coordinator_admin_secret ??
+					"",
+			).trim() || null
+		: null;
+	return { remoteUrl, adminSecret };
+}
+
+async function remoteRequest(
+	method: string,
+	url: string,
+	adminSecret: string,
+	body?: Record<string, unknown>,
+): Promise<Record<string, unknown> | null> {
+	const [status, payload] = await requestJson(method, url, {
+		headers: { "X-Codemem-Coordinator-Admin": adminSecret },
+		body,
+		timeoutS: 3,
+	});
+	if (status < 200 || status >= 300) {
+		const detail = typeof payload?.error === "string" ? payload.error : "unknown";
+		throw new Error(`Remote coordinator request failed (${status}): ${detail}`);
+	}
+	return payload;
+}
+
+export async function coordinatorCreateInviteAction(opts: {
+	groupId: string;
+	coordinatorUrl?: string | null;
+	policy: string;
+	ttlHours: number;
+	createdBy?: string | null;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<Record<string, unknown>> {
+	if (!VALID_INVITE_POLICIES.has(opts.policy)) throw new Error(`Invalid policy: ${opts.policy}`);
+	const expiresAt = new Date(Date.now() + opts.ttlHours * 3600 * 1000).toISOString();
+	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret)
+			throw new Error("Admin secret required to create invites via the coordinator API.");
+		const payload = await remoteRequest(
+			"POST",
+			`${remote.replace(/\/+$/, "")}/v1/admin/invites`,
+			adminSecret,
+			{
+				group_id: opts.groupId,
+				policy: opts.policy,
+				expires_at: expiresAt,
+				created_by: opts.createdBy ?? null,
+				coordinator_url: opts.coordinatorUrl || remote,
+			},
+		);
+		return {
+			group_id: opts.groupId,
+			encoded: payload?.encoded,
+			link: payload?.link,
+			payload: payload?.payload,
+			mode: "remote",
+		};
+	}
+	const resolvedCoordinatorUrl = String(
+		opts.coordinatorUrl ?? readCodememConfigFile().sync_coordinator_url ?? "",
+	).trim();
+	if (!resolvedCoordinatorUrl) throw new Error("Coordinator URL required.");
+	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		const group = store.getGroup(opts.groupId);
+		if (!group) throw new Error(`Group not found: ${opts.groupId}`);
+		const invite = store.createInvite({
+			groupId: opts.groupId,
+			policy: opts.policy,
+			expiresAt,
+			createdBy: opts.createdBy ?? null,
+		});
+		const payload: InvitePayload = {
+			v: 1,
+			kind: "coordinator_team_invite",
+			coordinator_url: resolvedCoordinatorUrl,
+			group_id: opts.groupId,
+			policy: opts.policy,
+			token: String(invite.token ?? ""),
+			expires_at: expiresAt,
+			team_name: (invite.team_name_snapshot as string) ?? null,
+		};
+		const encoded = encodeInvitePayload(payload);
+		return {
+			group_id: opts.groupId,
+			encoded,
+			link: inviteLink(encoded),
+			payload,
+			mode: "local",
+		};
+	} finally {
+		store.close();
+	}
+}
+
+export async function coordinatorImportInviteAction(opts: {
+	inviteValue: string;
+	dbPath?: string | null;
+	keysDir?: string | null;
+	configPath?: string | null;
+}): Promise<Record<string, unknown>> {
+	const payload = decodeInvitePayload(extractInvitePayload(opts.inviteValue));
+	const resolvedDbPath = opts.dbPath ?? join(homedir(), ".codemem", "mem.sqlite");
+	initDatabase(resolvedDbPath);
+	const conn = connect(resolvedDbPath);
+	let deviceId = "";
+	let fingerprint = "";
+	try {
+		[deviceId, fingerprint] = ensureDeviceIdentity(conn, { keysDir: opts.keysDir ?? undefined });
+	} finally {
+		conn.close();
+	}
+	const publicKey = loadPublicKey(opts.keysDir ?? undefined);
+	if (!publicKey) throw new Error("public key missing");
+	const coordinatorUrl = String(payload.coordinator_url ?? "").trim();
+	if (!coordinatorUrl) throw new Error("Invite is missing a coordinator URL.");
+	const config = readCodememConfigFile();
+	const displayName = String(config.actor_display_name ?? deviceId).trim() || deviceId;
+	const [status, response] = await requestJson(
+		"POST",
+		`${coordinatorUrl.replace(/\/+$/, "")}/v1/join`,
+		{
+			body: {
+				token: String(payload.token),
+				device_id: deviceId,
+				public_key: publicKey,
+				fingerprint,
+				display_name: displayName,
+			},
+			timeoutS: 3,
+		},
+	);
+	if (status < 200 || status >= 300) {
+		const detail = typeof response?.error === "string" ? response.error : "unknown";
+		throw new Error(`Invite import failed (${status}): ${detail}`);
+	}
+	const nextConfig = readCodememConfigFile();
+	nextConfig.sync_coordinator_url = coordinatorUrl;
+	nextConfig.sync_coordinator_group = String(payload.group_id);
+	const configPath = writeCodememConfigFile(nextConfig, opts.configPath ?? undefined);
+	return {
+		group_id: payload.group_id,
+		coordinator_url: payload.coordinator_url,
+		status: response?.status ?? null,
+		config_path: configPath,
+	};
+}
+
+export async function coordinatorListJoinRequestsAction(opts: {
+	groupId: string;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<Record<string, unknown>[]> {
+	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		const payload = await remoteRequest(
+			"GET",
+			`${remote.replace(/\/+$/, "")}/v1/admin/join-requests?group_id=${encodeURIComponent(opts.groupId)}`,
+			adminSecret,
+		);
+		return Array.isArray(payload?.items)
+			? payload.items.filter(
+					(row): row is Record<string, unknown> => Boolean(row) && typeof row === "object",
+				)
+			: [];
+	}
+	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		return store.listJoinRequests(opts.groupId);
+	} finally {
+		store.close();
+	}
+}
+
+export async function coordinatorReviewJoinRequestAction(opts: {
+	requestId: string;
+	approve: boolean;
+	reviewedBy?: string | null;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<Record<string, unknown> | null> {
+	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		const endpoint = opts.approve
+			? "/v1/admin/join-requests/approve"
+			: "/v1/admin/join-requests/deny";
+		const payload = await remoteRequest(
+			"POST",
+			`${remote.replace(/\/+$/, "")}${endpoint}`,
+			adminSecret,
+			{
+				request_id: opts.requestId,
+				reviewed_by: opts.reviewedBy ?? null,
+			},
+		);
+		const request = payload?.request;
+		return request && typeof request === "object" ? (request as Record<string, unknown>) : null;
+	}
+	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		return store.reviewJoinRequest({
+			requestId: opts.requestId,
+			approved: opts.approve,
+			reviewedBy: opts.reviewedBy ?? null,
+		});
+	} finally {
+		store.close();
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,12 @@ export {
 	normalizeProjectLabel,
 	resolveHookProject,
 } from "./claude-hooks.js";
+export {
+	coordinatorCreateInviteAction,
+	coordinatorImportInviteAction,
+	coordinatorListJoinRequestsAction,
+	coordinatorReviewJoinRequestAction,
+} from "./coordinator-actions.js";
 export { createCoordinatorApp } from "./coordinator-api.js";
 export type { InvitePayload } from "./coordinator-invites.js";
 export {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -993,5 +993,170 @@ describe("viewer-server", () => {
 				else process.env.CODEMEM_CONFIG = prevConfig;
 			}
 		});
+
+		it("creates coordinator invites through the viewer route", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/invites")) {
+					return new Response(
+						JSON.stringify({
+							encoded: "invite-blob",
+							link: "https://example.test/invite",
+							payload: { group_id: "team-a" },
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/invites/create", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ group_id: "team-a", policy: "auto_admit", ttl_hours: 24 }),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.encoded).toBe("invite-blob");
+				expect(body.link).toBe("https://example.test/invite");
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
+		it("imports coordinator invites through the viewer route", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const invitePayload = {
+				v: 1,
+				kind: "coordinator_team_invite",
+				coordinator_url: "https://coord.example.test",
+				group_id: "team-a",
+				policy: "approval_required",
+				token: "tok-123",
+				expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+				team_name: "Team A",
+			};
+			const invite = Buffer.from(JSON.stringify(invitePayload), "utf8").toString("base64url");
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/join")) {
+					return new Response(JSON.stringify({ status: "pending" }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Adam" }));
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite }),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.group_id).toBe("team-a");
+				expect(body.status).toBe("pending");
+				const writtenConfig = JSON.parse(readFileSync(configPath, "utf8")) as Record<
+					string,
+					unknown
+				>;
+				expect(writtenConfig.sync_coordinator_url).toBe("https://coord.example.test");
+				expect(writtenConfig.sync_coordinator_group).toBe("team-a");
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("reviews join requests through the viewer route", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input);
+				const requestBody = init?.body
+					? JSON.parse(new TextDecoder().decode(init.body as ArrayBufferView))
+					: {};
+				if (url.includes("/v1/admin/join-requests/approve") && requestBody.request_id === "req-1") {
+					return new Response(
+						JSON.stringify({ request: { request_id: "req-1", status: "approved" } }),
+						{ status: 200 },
+					);
+				}
+				if (
+					url.includes("/v1/admin/join-requests/approve") &&
+					requestBody.request_id === "missing"
+				) {
+					return new Response(JSON.stringify({ error: "request_not_found" }), { status: 404 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/join-requests/review", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ request_id: "req-1", action: "approve" }),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, any>;
+				expect(body.ok).toBe(true);
+				expect(body.request.request_id).toBe("req-1");
+				expect(body.request.status).toBe("approved");
+
+				const missing = await app.request("/api/sync/join-requests/review", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ request_id: "missing", action: "approve" }),
+				});
+				expect(missing.status).toBe(404);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
 	});
 });

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -7,6 +7,9 @@ import net from "node:net";
 import { dirname, join } from "node:path";
 import type { MemoryStore } from "@codemem/core";
 import {
+	coordinatorCreateInviteAction,
+	coordinatorImportInviteAction,
+	coordinatorReviewJoinRequestAction,
 	coordinatorStatusSnapshot,
 	ensureDeviceIdentity,
 	listCoordinatorJoinRequests,
@@ -469,6 +472,93 @@ export function syncRoutes(getStore: StoreFactory) {
 				.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
 				.run();
 			return c.json({ ok: true });
+		}
+	});
+
+	app.post("/api/sync/invites/create", async (c) => {
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const groupId = String(body.group_id ?? "").trim();
+		const coordinatorUrl = body.coordinator_url == null ? null : String(body.coordinator_url ?? "");
+		const policy = String(body.policy ?? "auto_admit").trim();
+		const ttlHours = Number.parseInt(String(body.ttl_hours ?? 24), 10);
+		if (!groupId) return c.json({ error: "group_id required" }, 400);
+		if (body.coordinator_url != null && typeof body.coordinator_url !== "string") {
+			return c.json({ error: "coordinator_url must be string" }, 400);
+		}
+		if (!["auto_admit", "approval_required"].includes(policy)) {
+			return c.json({ error: "policy must be auto_admit or approval_required" }, 400);
+		}
+		if (!Number.isFinite(ttlHours)) return c.json({ error: "ttl_hours must be int" }, 400);
+		try {
+			const config = readCoordinatorSyncConfig();
+			const result = await coordinatorCreateInviteAction({
+				groupId,
+				coordinatorUrl,
+				policy,
+				ttlHours,
+				createdBy: null,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			return c.json(result);
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		}
+	});
+
+	app.post("/api/sync/invites/import", async (c) => {
+		const store = getStore();
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const inviteValue = String(body.invite ?? "").trim();
+		if (!inviteValue) return c.json({ error: "invite required" }, 400);
+		try {
+			const result = await coordinatorImportInviteAction({ inviteValue, dbPath: store.dbPath });
+			return c.json(result);
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		}
+	});
+
+	app.post("/api/sync/join-requests/review", async (c) => {
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const requestId = String(body.request_id ?? "").trim();
+		const action = String(body.action ?? "").trim();
+		if (!requestId) return c.json({ error: "request_id required" }, 400);
+		if (!["approve", "deny"].includes(action)) {
+			return c.json({ error: "action must be approve or deny" }, 400);
+		}
+		try {
+			const config = readCoordinatorSyncConfig();
+			const result = await coordinatorReviewJoinRequestAction({
+				requestId,
+				approve: action === "approve",
+				reviewedBy: null,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!result) return c.json({ error: "join request not found" }, 404);
+			return c.json({ ok: true, request: result });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return c.json(
+				{ error: message },
+				message.includes("request_not_found") || message.includes("not found") ? 404 : 400,
+			);
 		}
 	});
 


### PR DESCRIPTION
## Description

This PR adds the missing coordinator invite/import/review workflow to the TypeScript viewer/server stack. It exposes the routes the sync UI already expects, extracts the shared coordinator actions into core, and makes the viewer-side coordinator onboarding and join-review flow usable end-to-end instead of depending on unported Python paths.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/core/src/store.test.ts`
- `pnpm run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced