### PR TITLE
add sync coordinator cli commands

### DIFF
--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const packageRoot = process.cwd();
+const workspaceRoot = resolve(packageRoot, "..", "..");
 const packageJson = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
 const packageVersion = String(packageJson.version);
 const tempDir = mkdtempSync(join(tmpdir(), "codemem-packed-artifact-"));
@@ -36,6 +37,21 @@ function assert(condition, message) {
 }
 
 try {
+	const coreTarball = run("pnpm", ["pack", "--pack-destination", tempDir], resolve(workspaceRoot, "packages/core"))
+		.stdout.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.at(-1);
+	const mcpTarball = run("pnpm", ["pack", "--pack-destination", tempDir], resolve(workspaceRoot, "packages/mcp-server"))
+		.stdout.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.at(-1);
+	const serverTarball = run("pnpm", ["pack", "--pack-destination", tempDir], resolve(workspaceRoot, "packages/viewer-server"))
+		.stdout.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.at(-1);
 	const packResult = run("pnpm", ["pack", "--pack-destination", tempDir]);
 	const packedTarball = packResult.stdout
 		.split(/\r?\n/)
@@ -43,7 +59,13 @@ try {
 		.filter(Boolean)
 		.at(-1);
 
+	assert(Boolean(coreTarball), "pnpm pack did not report a core tarball path");
+	assert(Boolean(mcpTarball), "pnpm pack did not report an mcp tarball path");
+	assert(Boolean(serverTarball), "pnpm pack did not report a server tarball path");
 	assert(Boolean(packedTarball), "pnpm pack did not report a tarball path");
+	assert(existsSync(coreTarball), `Packed core tarball not found: ${coreTarball}`);
+	assert(existsSync(mcpTarball), `Packed mcp tarball not found: ${mcpTarball}`);
+	assert(existsSync(serverTarball), `Packed server tarball not found: ${serverTarball}`);
 	assert(existsSync(packedTarball), `Packed tarball not found: ${packedTarball}`);
 
 	const tarListing = run("tar", ["-tf", packedTarball]).stdout;
@@ -61,7 +83,7 @@ try {
 	);
 
 	const installDir = join(tempDir, "install");
-	run("npm", ["install", "--prefix", installDir, packedTarball]);
+	run("npm", ["install", "--prefix", installDir, coreTarball, mcpTarball, serverTarball, packedTarball]);
 
 	const installedPackageRoot = join(installDir, "node_modules", "codemem");
 	const installedPluginRoot = join(installedPackageRoot, ".opencode");

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { syncCommand } from "./sync.js";
 import {
 	buildServeLifecycleArgs,
 	collectAdvertiseAddresses,
@@ -99,5 +100,52 @@ describe("formatSyncAttempt", () => {
 				en0: [{ address: "192.168.1.10", internal: false, family: "IPv4" }],
 			}),
 		).toEqual(["192.168.1.10:7337"]);
+	});
+
+	it("registers coordinator parity subcommands", () => {
+		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
+		expect(coordinator).toBeDefined();
+		expect(coordinator?.commands.map((command) => command.name())).toEqual([
+			"serve",
+			"create-invite",
+			"import-invite",
+			"list-join-requests",
+			"approve-join-request",
+			"deny-join-request",
+		]);
+	});
+
+	it("documents the coordinator command surface in help output", () => {
+		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
+		const help = coordinator?.helpInformation() ?? "";
+		expect(help).toContain("serve");
+		expect(help).toContain("create-invite");
+		expect(help).toContain("import-invite");
+		expect(help).toContain("list-join-requests");
+		expect(help).toContain("approve-join-request");
+		expect(help).toContain("deny-join-request");
+	});
+
+	it("defaults coordinator serve to the coordinator store database", () => {
+		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
+		const serve = coordinator?.commands.find((command) => command.name() === "serve");
+		expect(serve?.options.find((opt) => opt.long === "--db")?.defaultValue).toBeUndefined();
+		// runtime default is enforced in action code, not commander metadata
+		const help = serve?.helpInformation() ?? "";
+		expect(help).toContain("coordinator database path");
+	});
+
+	it("allows positional group ids for create-invite and list-join-requests", () => {
+		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
+		const createInvite = coordinator?.commands.find(
+			(command) => command.name() === "create-invite",
+		);
+		const listRequests = coordinator?.commands.find(
+			(command) => command.name() === "list-join-requests",
+		);
+		expect(createInvite?.registeredArguments[0]?.required).toBe(false);
+		expect(listRequests?.registeredArguments[0]?.required).toBe(false);
+		expect(createInvite?.helpInformation()).toContain("[group]");
+		expect(listRequests?.helpInformation()).toContain("[group]");
 	});
 });

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -10,6 +10,12 @@ import { dirname, join } from "node:path";
 
 import * as p from "@clack/prompts";
 import {
+	coordinatorCreateInviteAction,
+	coordinatorImportInviteAction,
+	coordinatorListJoinRequestsAction,
+	coordinatorReviewJoinRequestAction,
+	createCoordinatorApp,
+	DEFAULT_COORDINATOR_DB_PATH,
 	ensureDeviceIdentity,
 	fingerprintPublicKey,
 	loadPublicKey,
@@ -23,6 +29,7 @@ import {
 	updatePeerAddresses,
 	writeCodememConfigFile,
 } from "@codemem/core";
+import { serve as honoServe } from "@hono/node-server";
 import { Command } from "commander";
 import { desc, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -797,3 +804,218 @@ syncCommand.addCommand(
 			p.outro("Restart `codemem serve` to activate coordinator sync");
 		}),
 );
+
+const coordinatorCommand = new Command("coordinator")
+	.configureHelp(helpStyle)
+	.description("Manage coordinator invites, join requests, and relay server");
+
+coordinatorCommand.addCommand(
+	new Command("serve")
+		.configureHelp(helpStyle)
+		.description("Run the coordinator relay HTTP server")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--host <host>", "bind host", "127.0.0.1")
+		.option("--port <port>", "bind port", "7340")
+		.action(async (opts: { db?: string; dbPath?: string; host?: string; port?: string }) => {
+			const host = String(opts.host ?? "127.0.0.1").trim() || "127.0.0.1";
+			const port = Number.parseInt(String(opts.port ?? "7340"), 10);
+			const dbPath = opts.db ?? opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH;
+			const app = createCoordinatorApp({ dbPath });
+			p.intro("codemem sync coordinator serve");
+			p.log.success(`Coordinator listening at http://${host}:${port}`);
+			p.log.info(`DB: ${dbPath}`);
+			honoServe({ fetch: app.fetch, hostname: host, port });
+		}),
+);
+
+coordinatorCommand.addCommand(
+	new Command("create-invite")
+		.configureHelp(helpStyle)
+		.description("Create a coordinator team invite")
+		.argument("[group]", "group id")
+		.option("--group <group>", "group id")
+		.option("--coordinator-url <url>", "coordinator URL override")
+		.option("--policy <policy>", "invite policy", "auto_admit")
+		.option("--ttl-hours <hours>", "invite TTL hours", "24")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--remote-url <url>", "remote coordinator URL override")
+		.option("--admin-secret <secret>", "remote coordinator admin secret override")
+		.option("--json", "output as JSON")
+		.action(
+			async (
+				groupArg: string | undefined,
+				opts: {
+					group?: string;
+					coordinatorUrl?: string;
+					policy?: string;
+					ttlHours?: string;
+					db?: string;
+					dbPath?: string;
+					remoteUrl?: string;
+					adminSecret?: string;
+					json?: boolean;
+				},
+			) => {
+				const ttlHours = Number.parseInt(String(opts.ttlHours ?? "24"), 10);
+				const groupId = String(opts.group ?? "").trim() || String(groupArg ?? "").trim();
+				const result = await coordinatorCreateInviteAction({
+					groupId,
+					coordinatorUrl: opts.coordinatorUrl?.trim() || null,
+					policy: String(opts.policy ?? "auto_admit").trim(),
+					ttlHours,
+					createdBy: null,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+					remoteUrl: opts.remoteUrl?.trim() || null,
+					adminSecret: opts.adminSecret?.trim() || null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+				p.intro("codemem sync coordinator create-invite");
+				p.log.success(`Invite created for ${groupId}`);
+				if (typeof result.link === "string") p.log.message(`- link: ${result.link}`);
+				if (typeof result.encoded === "string") p.log.message(`- invite: ${result.encoded}`);
+				p.outro("Invite ready");
+			},
+		),
+);
+
+coordinatorCommand.addCommand(
+	new Command("import-invite")
+		.configureHelp(helpStyle)
+		.description("Import a coordinator invite")
+		.argument("<invite>", "invite value or link")
+		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
+		.option("--keys-dir <path>", "keys directory")
+		.option("--config <path>", "config path")
+		.option("--json", "output as JSON")
+		.action(
+			async (
+				invite: string,
+				opts: { db?: string; dbPath?: string; keysDir?: string; config?: string; json?: boolean },
+			) => {
+				const result = await coordinatorImportInviteAction({
+					inviteValue: invite,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+					keysDir: opts.keysDir ?? null,
+					configPath: opts.config ?? null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+				p.intro("codemem sync coordinator import-invite");
+				p.log.success(`Invite imported for ${result.group_id}`);
+				p.log.message(`- coordinator: ${result.coordinator_url}`);
+				p.log.message(`- status: ${result.status}`);
+				p.outro("Coordinator config updated");
+			},
+		),
+);
+
+coordinatorCommand.addCommand(
+	new Command("list-join-requests")
+		.configureHelp(helpStyle)
+		.description("List pending coordinator join requests")
+		.argument("[group]", "group id")
+		.option("--group <group>", "group id")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--remote-url <url>", "remote coordinator URL override")
+		.option("--admin-secret <secret>", "remote coordinator admin secret override")
+		.option("--json", "output as JSON")
+		.action(
+			async (
+				groupArg: string | undefined,
+				opts: {
+					group?: string;
+					db?: string;
+					dbPath?: string;
+					remoteUrl?: string;
+					adminSecret?: string;
+					json?: boolean;
+				},
+			) => {
+				const groupId = String(opts.group ?? "").trim() || String(groupArg ?? "").trim();
+				const rows = await coordinatorListJoinRequestsAction({
+					groupId,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+					remoteUrl: opts.remoteUrl?.trim() || null,
+					adminSecret: opts.adminSecret?.trim() || null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(rows, null, 2));
+					return;
+				}
+				p.intro("codemem sync coordinator list-join-requests");
+				if (rows.length === 0) {
+					p.outro(`No pending join requests for ${groupId}`);
+					return;
+				}
+				for (const row of rows) {
+					const displayName = row.display_name || row.device_id;
+					p.log.message(`- ${displayName} (${row.device_id}) request_id=${row.request_id}`);
+				}
+				p.outro(`${rows.length} pending join request(s)`);
+			},
+		),
+);
+
+function addReviewJoinRequestCommand(
+	name: "approve-join-request" | "deny-join-request",
+	approve: boolean,
+) {
+	coordinatorCommand.addCommand(
+		new Command(name)
+			.configureHelp(helpStyle)
+			.description(`${approve ? "Approve" : "Deny"} a coordinator join request`)
+			.argument("<request-id>", "join request id")
+			.option("--db <path>", "coordinator database path")
+			.option("--db-path <path>", "coordinator database path")
+			.option("--remote-url <url>", "remote coordinator URL override")
+			.option("--admin-secret <secret>", "remote coordinator admin secret override")
+			.option("--json", "output as JSON")
+			.action(
+				async (
+					requestId: string,
+					opts: {
+						db?: string;
+						dbPath?: string;
+						remoteUrl?: string;
+						adminSecret?: string;
+						json?: boolean;
+					},
+				) => {
+					const request = await coordinatorReviewJoinRequestAction({
+						requestId: requestId.trim(),
+						approve,
+						reviewedBy: null,
+						dbPath: opts.db ?? opts.dbPath ?? null,
+						remoteUrl: opts.remoteUrl?.trim() || null,
+						adminSecret: opts.adminSecret?.trim() || null,
+					});
+					if (!request) {
+						p.log.error(`Join request not found: ${requestId.trim()}`);
+						process.exitCode = 1;
+						return;
+					}
+					if (opts.json) {
+						console.log(JSON.stringify(request, null, 2));
+						return;
+					}
+					p.intro(`codemem sync coordinator ${name}`);
+					p.log.success(`${approve ? "Approved" : "Denied"} join request ${requestId.trim()}`);
+					p.outro(String(request.status ?? "updated"));
+				},
+			),
+	);
+}
+
+addReviewJoinRequestCommand("approve-join-request", true);
+addReviewJoinRequestCommand("deny-join-request", false);
+
+syncCommand.addCommand(coordinatorCommand);


### PR DESCRIPTION
## Description

This PR ports the Python 0.19 `codemem sync coordinator ...` command surface into the TypeScript CLI. It adds coordinator serve, create/import invite, list join requests, and approve/deny join request commands, reusing the shared coordinator action layer introduced in the stack below so the CLI, viewer, and coordinator primitives stay aligned.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:
- `pnpm exec vitest run packages/cli/src/commands/sync.test.ts packages/viewer-server/src/index.test.ts packages/core/src/store.test.ts`
- `pnpm run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced