### PR TITLE
fix(sync): restore TS replication parity before 0.20

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -275,12 +275,14 @@ export {
 export type { ApplyResult } from "./sync-replication.js";
 export {
 	applyReplicationOps,
+	backfillReplicationOps,
 	chunkOpsBySize,
 	clockTuple,
 	extractReplicationOps,
 	getReplicationCursor,
 	isNewerClock,
 	loadReplicationOpsSince,
+	migrateLegacyImportKeys,
 	recordReplicationOp,
 	setReplicationCursor,
 } from "./sync-replication.js";

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -13,7 +13,15 @@ import * as schema from "./schema.js";
 import { buildAuthHeaders } from "./sync-auth.js";
 import { buildBaseUrl, requestJson } from "./sync-http-client.js";
 import { ensureDeviceIdentity } from "./sync-identity.js";
-import { chunkOpsBySize, getReplicationCursor, setReplicationCursor } from "./sync-replication.js";
+import {
+	applyReplicationOps,
+	backfillReplicationOps,
+	chunkOpsBySize,
+	extractReplicationOps,
+	getReplicationCursor,
+	migrateLegacyImportKeys,
+	setReplicationCursor,
+} from "./sync-replication.js";
 import type { ReplicationOp } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -118,47 +126,6 @@ function recordPeerSuccess(db: Database, peerDeviceId: string): void {
 		.set({ last_sync_at: now, last_seen_at: now, last_error: null })
 		.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
 		.run();
-}
-
-/**
- * Apply incoming replication ops to the local store.
- *
- * Uses INSERT OR IGNORE as a placeholder — full apply_replication_ops
- * semantics (clock comparison, upsert into entity tables) are not yet ported.
- */
-function applyOpsPlaceholder(
-	db: Database,
-	ops: ReplicationOp[],
-	_sourceDeviceId: string,
-): { inserted: number; skipped: number } {
-	if (ops.length === 0) return { inserted: 0, skipped: 0 };
-
-	const d = drizzle(db, { schema });
-	let inserted = 0;
-	for (const op of ops) {
-		try {
-			const result = d
-				.insert(schema.replicationOps)
-				.values({
-					op_id: op.op_id,
-					entity_type: op.entity_type,
-					entity_id: op.entity_id,
-					op_type: op.op_type,
-					payload_json: op.payload_json ?? null,
-					clock_rev: op.clock_rev,
-					clock_updated_at: op.clock_updated_at,
-					clock_device_id: op.clock_device_id,
-					device_id: op.device_id,
-					created_at: op.created_at,
-				})
-				.onConflictDoNothing()
-				.run();
-			if (result.changes > 0) inserted++;
-		} catch {
-			// Skip malformed ops (missing NOT NULL fields) — matches INSERT OR IGNORE
-		}
-	}
-	return { inserted, skipped: ops.length - inserted };
 }
 
 /**
@@ -277,14 +244,10 @@ async function pushOps(
 // Preflight
 // ---------------------------------------------------------------------------
 
-/**
- * Placeholder for legacy migration + replication backfill.
- *
- * In the Python implementation this calls migrate_legacy_import_keys and
- * backfill_replication_ops. Those are not yet ported to TS.
- */
-export function syncPassPreflight(_db: Database): void {
-	// TODO: port migrate_legacy_import_keys + backfill_replication_ops
+/** Run migration + replication backfill preflight. */
+export function syncPassPreflight(db: Database): void {
+	migrateLegacyImportKeys(db, 2000);
+	backfillReplicationOps(db, 200);
 }
 
 // ---------------------------------------------------------------------------
@@ -383,20 +346,38 @@ export async function syncOnce(
 				const suffix = detail ? ` (${getStatus}: ${detail})` : ` (${getStatus})`;
 				throw new Error(`peer ops fetch failed${suffix}`);
 			}
-			const ops = getPayload.ops;
-			if (!Array.isArray(ops)) {
+			if (!Array.isArray(getPayload.ops)) {
 				throw new Error("invalid ops response");
 			}
+			const ops = extractReplicationOps(getPayload);
 
-			// -- 3. Store incoming ops --
-			// IMPORTANT: applyOpsPlaceholder only stores ops (INSERT OR IGNORE).
-			// It does NOT materialize changes to entity tables (memory_items etc).
-			// We deliberately DO NOT advance the applied cursor here — when the
-			// real apply logic is ported, it will re-process these ops from the
-			// current cursor position and advance it after successful materialization.
-			// Advancing the cursor now would permanently skip ops that need real
-			// conflict resolution.
-			const applied = applyOpsPlaceholder(db, ops as ReplicationOp[], peerDeviceId);
+			// -- 3. Apply incoming ops to local entities --
+			const applied = applyReplicationOps(db, ops, deviceId);
+
+			if (ops.length > 0) {
+				const last = ops.at(-1);
+				if (last) {
+					const localNext = computeCursor(last.created_at, last.op_id);
+					if (cursorAdvances(lastApplied, localNext)) {
+						setReplicationCursor(db, peerDeviceId, { lastApplied: localNext });
+						lastApplied = localNext;
+					}
+				}
+			} else {
+				const peerNext =
+					typeof getPayload.next_cursor === "string" ? getPayload.next_cursor.trim() : "";
+				const skippedValue = getPayload.skipped;
+				const skippedCount =
+					typeof skippedValue === "number"
+						? skippedValue
+						: typeof skippedValue === "string"
+							? Number.parseInt(skippedValue, 10) || 0
+							: 0;
+				if (skippedCount > 0 && cursorAdvances(lastApplied, peerNext)) {
+					setReplicationCursor(db, peerDeviceId, { lastApplied: peerNext });
+					lastApplied = peerNext;
+				}
+			}
 
 			// -- 5. Push local ops to peer --
 			const [outboundOps, outboundCursor] = loadLocalOpsSince(db, lastAcked, deviceId, limit);
@@ -416,13 +397,13 @@ export async function syncOnce(
 			recordPeerSuccess(db, peerDeviceId);
 			recordSyncAttempt(db, peerDeviceId, {
 				ok: true,
-				opsIn: applied.inserted,
+				opsIn: applied.applied,
 				opsOut: outboundOps.length,
 			});
 			return {
 				ok: true,
 				address: baseUrl,
-				opsIn: ops.length,
+				opsIn: applied.applied,
 				opsOut: outboundOps.length,
 				addressErrors: [],
 			};

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -3,12 +3,14 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { toJson } from "./db.js";
 import {
 	applyReplicationOps,
+	backfillReplicationOps,
 	chunkOpsBySize,
 	clockTuple,
 	extractReplicationOps,
 	getReplicationCursor,
 	isNewerClock,
 	loadReplicationOpsSince,
+	migrateLegacyImportKeys,
 	recordReplicationOp,
 	setReplicationCursor,
 } from "./sync-replication.js";
@@ -468,6 +470,126 @@ describe("loadReplicationOpsSince", () => {
 		const [ops, cursor] = loadReplicationOpsSince(db, null);
 		expect(ops).toEqual([]);
 		expect(cursor).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// migrateLegacyImportKeys / backfillReplicationOps
+// ---------------------------------------------------------------------------
+
+describe("legacy key migration + replication backfill", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("rewrites old-format legacy import keys to device-scoped keys", () => {
+		db.prepare(
+			"INSERT INTO sync_device(device_id, public_key, fingerprint, created_at) VALUES (?, ?, ?, ?)",
+		).run("dev-local", "pub", "fp", "2026-01-01T00:00:00Z");
+
+		const sessionId = insertTestSession(db);
+		const now = "2026-01-01T00:00:00Z";
+
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, metadata_json, rev)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(sessionId, "discovery", "A", "a", now, now, null, toJson({}), 1);
+
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, metadata_json, rev)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(sessionId, "discovery", "B", "b", now, now, "legacy:memory_item:42", toJson({}), 2);
+
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, metadata_json, rev)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"C",
+			"c",
+			now,
+			now,
+			"legacy:memory_item:99",
+			toJson({ clock_device_id: "peer-9" }),
+			3,
+		);
+
+		const changed = migrateLegacyImportKeys(db, 100);
+		expect(changed).toBe(3);
+
+		const rows = db.prepare("SELECT id, import_key FROM memory_items ORDER BY id").all() as Array<{
+			id: number;
+			import_key: string;
+		}>;
+		expect(rows[0]?.import_key).toBe(`legacy:dev-local:memory_item:${rows[0]?.id}`);
+		expect(rows[1]?.import_key).toBe("legacy:dev-local:memory_item:42");
+		expect(rows[2]?.import_key).toBe("legacy:peer-9:memory_item:99");
+	});
+
+	it("backfills missing delete/upsert ops once and remains idempotent", () => {
+		db.prepare(
+			"INSERT INTO sync_device(device_id, public_key, fingerprint, created_at) VALUES (?, ?, ?, ?)",
+		).run("dev-local", "pub", "fp", "2026-01-01T00:00:00Z");
+		const sessionId = insertTestSession(db);
+		const now = "2026-01-02T00:00:00Z";
+
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, active, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(sessionId, "feature", "Live row", "live", now, now, "key:live", 1, 1, toJson({}));
+
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, active, deleted_at, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(sessionId, "bugfix", "Deleted row", "gone", now, now, "key:gone", 2, 0, now, toJson({}));
+
+		const first = backfillReplicationOps(db, 10);
+		expect(first).toBe(2);
+
+		const ops = db
+			.prepare(
+				"SELECT op_id, entity_id, op_type, clock_rev FROM replication_ops ORDER BY op_type, entity_id",
+			)
+			.all() as Array<{ op_id: string; entity_id: string; op_type: string; clock_rev: number }>;
+		expect(ops).toHaveLength(2);
+		expect(ops.map((op) => op.op_type).sort()).toEqual(["delete", "upsert"]);
+		expect(ops[0]?.op_id).toContain("backfill:memory_item:");
+
+		const second = backfillReplicationOps(db, 10);
+		expect(second).toBe(0);
+		const count = db.prepare("SELECT COUNT(*) AS n FROM replication_ops").get() as { n: number };
+		expect(count.n).toBe(2);
+	});
+
+	it("does not mint legacy:local import keys before device identity exists", () => {
+		const sessionId = insertTestSession(db);
+		const now = "2026-01-02T00:00:00Z";
+
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, active, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(sessionId, "feature", "Live row", "live", now, now, null, 1, 1, toJson({}));
+
+		const inserted = backfillReplicationOps(db, 10);
+		expect(inserted).toBe(0);
+
+		const row = db.prepare("SELECT import_key FROM memory_items LIMIT 1").get() as {
+			import_key: string | null;
+		};
+		expect(row.import_key).toBeNull();
+
+		const localLegacyCount = db
+			.prepare("SELECT COUNT(*) AS n FROM memory_items WHERE import_key LIKE 'legacy:local:%'")
+			.get() as { n: number };
+		expect(localLegacyCount.n).toBe(0);
 	});
 });
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -387,6 +387,246 @@ export interface ApplyResult {
 	errors: string[];
 }
 
+const LEGACY_IMPORT_KEY_OLD_RE = /^legacy:memory_item:(.+)$/;
+
+/**
+ * Rewrite legacy import keys into globally unique, device-scoped keys.
+ *
+ * Older databases may contain keys like `legacy:memory_item:<id>`, which can
+ * collide across peers. This rewrites them to
+ * `legacy:<device_id>:memory_item:<id>`.
+ */
+export function migrateLegacyImportKeys(db: Database, limit = 2000): number {
+	const d = drizzle(db, { schema });
+	const deviceRow = d
+		.select({ device_id: schema.syncDevice.device_id })
+		.from(schema.syncDevice)
+		.limit(1)
+		.get();
+	const localDeviceId = String(deviceRow?.device_id ?? "").trim();
+	if (!localDeviceId) return 0;
+
+	const rows = db
+		.prepare(
+			`SELECT id, import_key, metadata_json
+			 FROM memory_items
+			 WHERE import_key IS NULL
+			    OR TRIM(import_key) = ''
+			    OR import_key LIKE 'legacy:memory_item:%'
+			 ORDER BY id ASC
+			 LIMIT ?`,
+		)
+		.all(limit) as Array<{ id: number; import_key: string | null; metadata_json: string | null }>;
+
+	if (rows.length === 0) return 0;
+
+	let updated = 0;
+	for (const row of rows) {
+		const memoryId = Number(row.id);
+		const current = String(row.import_key ?? "").trim();
+		const metadata = fromJson(row.metadata_json);
+		const clockDeviceId = String(metadata.clock_device_id ?? "").trim();
+
+		let canonical = "";
+		if (!current) {
+			canonical = `legacy:${localDeviceId}:memory_item:${memoryId}`;
+		} else {
+			const match = current.match(LEGACY_IMPORT_KEY_OLD_RE);
+			if (!match) continue;
+			const suffix = match[1] ?? "";
+			const origin = clockDeviceId && clockDeviceId !== "local" ? clockDeviceId : localDeviceId;
+			canonical = origin ? `legacy:${origin}:memory_item:${suffix}` : "";
+		}
+
+		if (!canonical || canonical === current) continue;
+
+		const existing = db
+			.prepare("SELECT id FROM memory_items WHERE import_key = ? LIMIT 1")
+			.get(canonical) as { id: number } | undefined;
+		if (existing && Number(existing.id) !== memoryId) {
+			continue;
+		}
+
+		db.prepare("UPDATE memory_items SET import_key = ? WHERE id = ?").run(canonical, memoryId);
+		updated++;
+	}
+
+	return updated;
+}
+
+/**
+ * Generate replication ops for rows that predate replication.
+ *
+ * Prioritizes delete/tombstone ops first, then active upserts, and only
+ * generates ops when a matching op for the same entity/rev/op_type is missing.
+ */
+export function backfillReplicationOps(db: Database, limit = 200): number {
+	if (limit <= 0) return 0;
+
+	migrateLegacyImportKeys(db, 2000);
+
+	const d = drizzle(db, { schema });
+	const deviceRow = d
+		.select({ device_id: schema.syncDevice.device_id })
+		.from(schema.syncDevice)
+		.limit(1)
+		.get();
+	const localDeviceId = String(deviceRow?.device_id ?? "").trim();
+
+	const deletedRows = db
+		.prepare(
+			`SELECT mi.*
+			 FROM memory_items mi
+			 WHERE (mi.deleted_at IS NOT NULL OR mi.active = 0)
+			   AND NOT EXISTS (
+			     SELECT 1
+			     FROM replication_ops ro
+			     WHERE ro.entity_type = 'memory_item'
+			       AND ro.entity_id = mi.import_key
+			       AND ro.op_type = 'delete'
+			       AND ro.clock_rev = COALESCE(mi.rev, 0)
+			   )
+			 ORDER BY mi.updated_at ASC
+			 LIMIT ?`,
+		)
+		.all(limit) as Array<Record<string, unknown>>;
+
+	const remaining = Math.max(0, limit - deletedRows.length);
+	let rows = deletedRows;
+	if (remaining > 0) {
+		const upsertRows = db
+			.prepare(
+				`SELECT mi.*
+				 FROM memory_items mi
+				 WHERE mi.deleted_at IS NULL
+				   AND mi.active = 1
+				   AND NOT EXISTS (
+				     SELECT 1
+				     FROM replication_ops ro
+				     WHERE ro.entity_type = 'memory_item'
+				       AND ro.entity_id = mi.import_key
+				       AND ro.op_type = 'upsert'
+				       AND ro.clock_rev = COALESCE(mi.rev, 0)
+				   )
+				 ORDER BY mi.updated_at ASC
+				 LIMIT ?`,
+			)
+			.all(remaining) as Array<Record<string, unknown>>;
+		rows = [...rows, ...upsertRows];
+	}
+
+	if (rows.length === 0) return 0;
+
+	const now = new Date().toISOString();
+	let inserted = 0;
+
+	for (const row of rows) {
+		const rowId = Number(row.id ?? 0);
+		if (!rowId) continue;
+
+		const metadata =
+			typeof row.metadata_json === "string"
+				? fromJson(row.metadata_json)
+				: fromJsonNullableLike(row.metadata_json);
+		const metadataClockDeviceId = String(metadata.clock_device_id ?? "").trim();
+		const originDeviceId =
+			metadataClockDeviceId && metadataClockDeviceId !== "local"
+				? metadataClockDeviceId
+				: localDeviceId;
+
+		let importKey = String(row.import_key ?? "").trim();
+		if (!importKey) {
+			if (!originDeviceId) continue;
+			importKey = `legacy:${originDeviceId}:memory_item:${rowId}`;
+			db.prepare("UPDATE memory_items SET import_key = ? WHERE id = ?").run(importKey, rowId);
+		}
+
+		const rev = Number(row.rev ?? 0);
+		const active = Number(row.active ?? 1);
+		const deletedAt = String(row.deleted_at ?? "").trim();
+		const opType: "upsert" | "delete" = deletedAt || active === 0 ? "delete" : "upsert";
+		const opId = `backfill:memory_item:${importKey}:${rev}:${opType}`;
+
+		const exists = db.prepare("SELECT 1 FROM replication_ops WHERE op_id = ? LIMIT 1").get(opId) as
+			| { 1: number }
+			| undefined;
+		if (exists) continue;
+
+		const clockDeviceId = originDeviceId;
+		if (!clockDeviceId) continue;
+		const payload = buildPayloadFromMemoryRow(row);
+
+		d.insert(schema.replicationOps)
+			.values({
+				op_id: opId,
+				entity_type: "memory_item",
+				entity_id: importKey,
+				op_type: opType,
+				payload_json: toJson(payload),
+				clock_rev: rev,
+				clock_updated_at: String(row.updated_at ?? now),
+				clock_device_id: clockDeviceId,
+				device_id: clockDeviceId,
+				created_at: now,
+			})
+			.onConflictDoNothing()
+			.run();
+
+		inserted++;
+	}
+
+	return inserted;
+}
+
+function fromJsonNullableLike(value: unknown): Record<string, unknown> {
+	if (typeof value === "string") return fromJson(value);
+	if (value && typeof value === "object") return value as Record<string, unknown>;
+	return {};
+}
+
+function buildPayloadFromMemoryRow(row: Record<string, unknown>): Record<string, unknown> {
+	const parseSqliteJson = (val: unknown): unknown => {
+		if (typeof val !== "string") return val ?? null;
+		try {
+			return JSON.parse(val);
+		} catch {
+			return val;
+		}
+	};
+
+	return {
+		session_id: row.session_id ?? null,
+		kind: row.kind ?? null,
+		title: row.title ?? null,
+		subtitle: row.subtitle ?? null,
+		body_text: row.body_text ?? null,
+		confidence: row.confidence ?? null,
+		tags_text: row.tags_text ?? null,
+		active: row.active ?? null,
+		created_at: row.created_at ?? null,
+		updated_at: row.updated_at ?? null,
+		metadata_json: parseSqliteJson(row.metadata_json),
+		actor_id: row.actor_id ?? null,
+		actor_display_name: row.actor_display_name ?? null,
+		visibility: row.visibility ?? null,
+		workspace_id: row.workspace_id ?? null,
+		workspace_kind: row.workspace_kind ?? null,
+		origin_device_id: row.origin_device_id ?? null,
+		origin_source: row.origin_source ?? null,
+		trust_state: row.trust_state ?? null,
+		narrative: row.narrative ?? null,
+		facts: parseSqliteJson(row.facts),
+		concepts: parseSqliteJson(row.concepts),
+		files_read: parseSqliteJson(row.files_read),
+		files_modified: parseSqliteJson(row.files_modified),
+		user_prompt_id: row.user_prompt_id ?? null,
+		prompt_number: row.prompt_number ?? null,
+		deleted_at: row.deleted_at ?? null,
+		rev: row.rev ?? 0,
+		import_key: row.import_key ?? null,
+	};
+}
+
 /**
  * Apply inbound replication ops from a remote peer.
  *

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -607,13 +607,13 @@ async function main() {
 						"Notable regressions or follow-ups that should be remembered.",
 					],
 					how: [
-						"Use memory.remember with kind decision/observation/note.",
+						"Use memory.remember with kind decision/discovery/change/exploration.",
 						"Keep titles short and bodies high-signal.",
 						"ALWAYS pass the project parameter if known.",
 					],
 					examples: [
 						'memory.remember(kind="decision", title="Switch to async cache", body="...why...", project="my-service")',
-						'memory.remember(kind="observation", title="Fixed retry loop", body="...impact...", project="my-service")',
+						'memory.remember(kind="change", title="Fixed retry loop", body="...impact...", project="my-service")',
 					],
 				},
 				forget: {
@@ -646,7 +646,7 @@ async function main() {
 					"",
 					"Persistence:",
 					"- On milestones (task done, key decision, new facts learned), call memory.remember.",
-					"- Use kind=decision for tradeoffs, kind=observation for outcomes, kind=note for small useful facts.",
+					"- Use kind=decision for tradeoffs, kind=change for outcomes, kind=discovery/exploration for useful findings.",
 					"- Keep titles short and bodies high-signal.",
 					"- ALWAYS pass the project parameter if known.",
 					"",
@@ -658,7 +658,7 @@ async function main() {
 					"- memory.timeline(memory_id=123)",
 					"- memory.get_observations([123, 456])",
 					'- memory.remember(kind="decision", title="Use async cache", body="Chose async cache to avoid lock contention in X.", project="my-service")',
-					'- memory.remember(kind="observation", title="Fixed retry loop", body="Root cause was Y; added guard in Z.", project="my-service")',
+					'- memory.remember(kind="change", title="Fixed retry loop", body="Root cause was Y; added guard in Z.", project="my-service")',
 					"- memory.forget(123)",
 				].join("\n"),
 			});

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -814,6 +814,34 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("exposes /v1/status sync endpoint (auth-gated)", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/v1/status");
+				expect(res.status).toBe(401);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.error).toBe("unauthorized");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("exposes /v1/ops sync endpoint (auth-gated)", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const getRes = await app.request("/v1/ops");
+				expect(getRes.status).toBe(401);
+				const postRes = await app.request("/v1/ops", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ ops: [] }),
+				});
+				expect(postRes.status).toBe(401);
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("returns real sync config and coordinator status details", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -5,16 +5,24 @@
 import { readFileSync } from "node:fs";
 import net from "node:net";
 import { dirname, join } from "node:path";
-import type { MemoryStore } from "@codemem/core";
+import type { MemoryStore, ReplicationOp } from "@codemem/core";
 import {
+	applyReplicationOps,
+	cleanupNonces,
 	coordinatorCreateInviteAction,
 	coordinatorImportInviteAction,
 	coordinatorReviewJoinRequestAction,
 	coordinatorStatusSnapshot,
+	DEFAULT_TIME_WINDOW_S,
 	ensureDeviceIdentity,
+	extractReplicationOps,
+	fingerprintPublicKey,
 	listCoordinatorJoinRequests,
+	loadReplicationOpsSince,
 	readCoordinatorSyncConfig,
+	recordNonce,
 	schema,
+	verifySignature,
 } from "@codemem/core";
 import { count, desc, eq, max, ne } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -24,11 +32,250 @@ import { queryBool, queryInt, safeJsonList } from "../helpers.js";
 type StoreFactory = () => MemoryStore;
 
 const SYNC_STALE_AFTER_SECONDS = 10 * 60;
+const SYNC_PROTOCOL_VERSION = "1";
+
+function intEnvOr(name: string, fallback: number): number {
+	const value = Number.parseInt(process.env[name] ?? "", 10);
+	return Number.isFinite(value) ? value : fallback;
+}
+
+const MAX_SYNC_BODY_BYTES = intEnvOr("CODEMEM_SYNC_MAX_BODY_BYTES", 1_048_576);
+const MAX_SYNC_OPS = intEnvOr("CODEMEM_SYNC_MAX_OPS", 2000);
 
 const PAIRING_FILTER_HINT =
 	"Run this on another device with codemem sync pair --accept '<payload>'. " +
 	"On that accepting device, --include/--exclude only control what it sends to peers. " +
 	"This device does not yet enforce incoming project filters.";
+
+function pathWithQuery(url: string): string {
+	const parsed = new URL(url);
+	return parsed.search ? `${parsed.pathname}${parsed.search}` : parsed.pathname;
+}
+
+function unauthorizedPayload(reason: string): Record<string, string> {
+	if (process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS === "1") {
+		return { error: "unauthorized", reason };
+	}
+	return { error: "unauthorized" };
+}
+
+function authorizeSyncRequest(
+	store: MemoryStore,
+	request: { method: string; url: string; header(name: string): string | undefined },
+	body: Buffer,
+): { ok: boolean; reason: string; deviceId: string } {
+	const deviceId = (request.header("X-Opencode-Device") ?? "").trim();
+	const signature = request.header("X-Opencode-Signature") ?? "";
+	const timestamp = request.header("X-Opencode-Timestamp") ?? "";
+	const nonce = request.header("X-Opencode-Nonce") ?? "";
+	if (!deviceId || !signature || !timestamp || !nonce) {
+		return { ok: false, reason: "missing_headers", deviceId };
+	}
+
+	const peerRow = store.db
+		.prepare(
+			"SELECT pinned_fingerprint, public_key FROM sync_peers WHERE peer_device_id = ? LIMIT 1",
+		)
+		.get(deviceId) as { pinned_fingerprint: string | null; public_key: string | null } | undefined;
+	if (!peerRow) {
+		return { ok: false, reason: "unknown_peer", deviceId };
+	}
+
+	const pinnedFingerprint = String(peerRow.pinned_fingerprint ?? "").trim();
+	const publicKey = String(peerRow.public_key ?? "").trim();
+	if (!pinnedFingerprint || !publicKey) {
+		return { ok: false, reason: "peer_record_incomplete", deviceId };
+	}
+	if (fingerprintPublicKey(publicKey) !== pinnedFingerprint) {
+		return { ok: false, reason: "fingerprint_mismatch", deviceId };
+	}
+
+	let valid = false;
+	try {
+		valid = verifySignature({
+			method: request.method,
+			pathWithQuery: pathWithQuery(request.url),
+			bodyBytes: body,
+			timestamp,
+			nonce,
+			signature,
+			publicKey,
+			deviceId,
+		});
+	} catch {
+		return { ok: false, reason: "signature_verification_error", deviceId };
+	}
+
+	if (!valid) {
+		return { ok: false, reason: "invalid_signature", deviceId };
+	}
+
+	const createdAt = new Date().toISOString();
+	if (!recordNonce(store.db, deviceId, nonce, createdAt)) {
+		return { ok: false, reason: "nonce_replay", deviceId };
+	}
+
+	const cutoff = new Date(Date.now() - DEFAULT_TIME_WINDOW_S * 2 * 1000).toISOString();
+	cleanupNonces(store.db, cutoff);
+	return { ok: true, reason: "ok", deviceId };
+}
+
+function projectBasename(value: string | null | undefined): string {
+	const project = String(value ?? "")
+		.trim()
+		.replaceAll("\\", "/");
+	if (!project) return "";
+	const parts = project.split("/").filter(Boolean);
+	return parts.length > 0 ? (parts[parts.length - 1] ?? "") : "";
+}
+
+function parseJsonList(value: unknown): string[] {
+	if (value == null) return [];
+	if (typeof value === "string") {
+		try {
+			const parsed = JSON.parse(value) as unknown;
+			if (!Array.isArray(parsed)) return [];
+			return parsed.map((entry) => String(entry ?? "").trim()).filter(Boolean);
+		} catch {
+			return [];
+		}
+	}
+	if (!Array.isArray(value)) return [];
+	return value.map((entry) => String(entry ?? "").trim()).filter(Boolean);
+}
+
+function readPeerProjectFilters(
+	store: MemoryStore,
+	peerDeviceId: string,
+): { include: string[]; exclude: string[] } {
+	const globalConfig = readCoordinatorSyncConfig();
+	const row = store.db
+		.prepare(
+			"SELECT projects_include_json, projects_exclude_json FROM sync_peers WHERE peer_device_id = ? LIMIT 1",
+		)
+		.get(peerDeviceId) as
+		| { projects_include_json: string | null; projects_exclude_json: string | null }
+		| undefined;
+	if (!row) {
+		return {
+			include: globalConfig.syncProjectsInclude,
+			exclude: globalConfig.syncProjectsExclude,
+		};
+	}
+	const hasOverride = row.projects_include_json != null || row.projects_exclude_json != null;
+	if (!hasOverride) {
+		return {
+			include: globalConfig.syncProjectsInclude,
+			exclude: globalConfig.syncProjectsExclude,
+		};
+	}
+	return {
+		include: parseJsonList(row.projects_include_json),
+		exclude: parseJsonList(row.projects_exclude_json),
+	};
+}
+
+function peerClaimedLocalActor(store: MemoryStore, peerDeviceId: string): boolean {
+	const row = store.db
+		.prepare("SELECT claimed_local_actor FROM sync_peers WHERE peer_device_id = ? LIMIT 1")
+		.get(peerDeviceId) as { claimed_local_actor: number | null } | undefined;
+	return Boolean(row?.claimed_local_actor);
+}
+
+function parseOpPayload(op: { payload_json: string | null }): Record<string, unknown> | null {
+	if (!op.payload_json || !String(op.payload_json).trim()) return null;
+	try {
+		const parsed = JSON.parse(op.payload_json) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		return parsed as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+function isSharedVisibility(payload: Record<string, unknown> | null): boolean {
+	if (!payload) return false;
+	let visibility = String(payload.visibility ?? "")
+		.trim()
+		.toLowerCase();
+	const metadata =
+		payload.metadata_json &&
+		typeof payload.metadata_json === "object" &&
+		!Array.isArray(payload.metadata_json)
+			? (payload.metadata_json as Record<string, unknown>)
+			: {};
+	const metadataVisibility = String(metadata.visibility ?? "")
+		.trim()
+		.toLowerCase();
+	if (!visibility && metadataVisibility) visibility = metadataVisibility;
+	if (!visibility) {
+		let workspaceKind = String(payload.workspace_kind ?? "")
+			.trim()
+			.toLowerCase();
+		let workspaceId = String(payload.workspace_id ?? "")
+			.trim()
+			.toLowerCase();
+		if (!workspaceKind)
+			workspaceKind = String(metadata.workspace_kind ?? "")
+				.trim()
+				.toLowerCase();
+		if (!workspaceId)
+			workspaceId = String(metadata.workspace_id ?? "")
+				.trim()
+				.toLowerCase();
+		if (workspaceKind === "shared" || workspaceId.startsWith("shared:")) {
+			visibility = "shared";
+		} else {
+			return true;
+		}
+	}
+	return visibility === "shared";
+}
+
+function projectAllowed(
+	projectValue: string | null,
+	filters: { include: string[]; exclude: string[] },
+): boolean {
+	const value = String(projectValue ?? "").trim();
+	const valueBase = projectBasename(value);
+	for (const blocked of filters.exclude) {
+		if (blocked === value || blocked === valueBase) return false;
+	}
+	if (filters.include.length === 0) return true;
+	for (const allowed of filters.include) {
+		if (allowed === value || allowed === valueBase) return true;
+	}
+	return false;
+}
+
+function filterOpsForPeer(
+	store: MemoryStore,
+	peerDeviceId: string,
+	ops: ReplicationOp[],
+): { allowed: ReplicationOp[]; skipped: number } {
+	const filters = readPeerProjectFilters(store, peerDeviceId);
+	const allowPrivate = peerClaimedLocalActor(store, peerDeviceId);
+	const allowed: ReplicationOp[] = [];
+	let skipped = 0;
+	for (const op of ops) {
+		if (op.entity_type !== "memory_item") {
+			allowed.push(op);
+			continue;
+		}
+		const payload = parseOpPayload(op);
+		if (!allowPrivate && !isSharedVisibility(payload)) {
+			skipped++;
+			continue;
+		}
+		const project = payload && typeof payload.project === "string" ? payload.project : null;
+		if (!projectAllowed(project, filters)) {
+			skipped++;
+			continue;
+		}
+		allowed.push(op);
+	}
+	return { allowed, skipped };
+}
 
 // ---------------------------------------------------------------------------
 // Peer row mapping — deduplicated helper (fix #4)
@@ -156,6 +403,120 @@ const PEERS_QUERY = `
 
 export function syncRoutes(getStore: StoreFactory) {
 	const app = new Hono();
+
+	// GET /v1/status (peer sync protocol)
+	app.get("/v1/status", (c) => {
+		const store = getStore();
+		const auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
+		if (!auth.ok) return c.json(unauthorizedPayload(auth.reason), 401);
+
+		try {
+			let device = store.db
+				.prepare("SELECT device_id, fingerprint FROM sync_device LIMIT 1")
+				.get() as { device_id: string; fingerprint: string } | undefined;
+			if (!device) {
+				const [deviceId, fingerprint] = ensureDeviceIdentity(store.db);
+				device = { device_id: deviceId, fingerprint };
+			}
+			return c.json({
+				device_id: device.device_id,
+				protocol_version: SYNC_PROTOCOL_VERSION,
+				fingerprint: device.fingerprint,
+			});
+		} catch {
+			return c.json({ error: "internal_error" }, 500);
+		}
+	});
+
+	// GET /v1/ops (peer sync protocol)
+	app.get("/v1/ops", (c) => {
+		const store = getStore();
+		const auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
+		if (!auth.ok) return c.json(unauthorizedPayload(auth.reason), 401);
+		const peerDeviceId = auth.deviceId;
+
+		try {
+			const since = c.req.query("since") ?? null;
+			const rawLimit = Number.parseInt(c.req.query("limit") ?? "200", 10);
+			const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(rawLimit, 1000)) : 200;
+			let localDeviceId = store.db.prepare("SELECT device_id FROM sync_device LIMIT 1").get() as
+				| { device_id: string }
+				| undefined;
+			if (!localDeviceId) {
+				const [deviceId] = ensureDeviceIdentity(store.db);
+				localDeviceId = { device_id: deviceId };
+			}
+			const [ops, nextCursor] = loadReplicationOpsSince(
+				store.db,
+				since,
+				limit,
+				localDeviceId.device_id,
+			);
+			const filtered = filterOpsForPeer(store, peerDeviceId, ops);
+			return c.json({
+				ops: filtered.allowed,
+				next_cursor: nextCursor,
+				skipped: filtered.skipped,
+			});
+		} catch {
+			return c.json({ error: "internal_error" }, 500);
+		}
+	});
+
+	// POST /v1/ops (peer sync protocol)
+	app.post("/v1/ops", async (c) => {
+		const store = getStore();
+		const raw = Buffer.from(await c.req.arrayBuffer());
+		if (raw.length > MAX_SYNC_BODY_BYTES) {
+			return c.json({ error: "payload_too_large" }, 413);
+		}
+
+		const auth = authorizeSyncRequest(store, c.req, raw);
+		if (!auth.ok) return c.json(unauthorizedPayload(auth.reason), 401);
+		const peerDeviceId = auth.deviceId;
+
+		let body: Record<string, unknown>;
+		try {
+			const parsed = JSON.parse(raw.toString("utf-8")) as unknown;
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+				return c.json({ error: "invalid_json" }, 400);
+			}
+			body = parsed as Record<string, unknown>;
+		} catch {
+			return c.json({ error: "invalid_json" }, 400);
+		}
+
+		if (!Array.isArray(body.ops)) {
+			return c.json({ error: "invalid_ops" }, 400);
+		}
+		if (body.ops.length > MAX_SYNC_OPS) {
+			return c.json({ error: "too_many_ops" }, 413);
+		}
+
+		const normalizedOps = extractReplicationOps(body);
+		for (const op of normalizedOps) {
+			if (op.device_id !== peerDeviceId || op.clock_device_id !== peerDeviceId) {
+				return c.json(
+					{
+						error: "invalid_op_device",
+						reason: "device_id_mismatch",
+						op_id: op.op_id,
+					},
+					400,
+				);
+			}
+		}
+		let localDeviceId = store.db.prepare("SELECT device_id FROM sync_device LIMIT 1").get() as
+			| { device_id: string }
+			| undefined;
+		if (!localDeviceId) {
+			const [deviceId] = ensureDeviceIdentity(store.db);
+			localDeviceId = { device_id: deviceId };
+		}
+
+		const result = applyReplicationOps(store.db, normalizedOps, localDeviceId.device_id);
+		return c.json(result);
+	});
 
 	// GET /api/sync/status
 	app.get("/api/sync/status", async (c) => {


### PR DESCRIPTION
## Description
This fixes pre-0.20 sync parity gaps in the TypeScript port so peer sync can complete safely and materialize data correctly.

- Implements authenticated peer sync protocol endpoints in the TS viewer server (`/v1/status`, `GET /v1/ops`, `POST /v1/ops`).
- Replaces the inbound replication placeholder path with real `applyReplicationOps(...)` handling and cursor advancement.
- Ports legacy replication preflight behavior (legacy import-key migration + replication backfill).
- Aligns MCP memory-kind examples with the supported enum values.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`vitest` targeted suites)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `pnpm exec vitest run packages/core/src/sync-replication.test.ts packages/core/src/sync-pass.test.ts packages/viewer-server/src/index.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Code follows project style checks for this change set (`pnpm run typecheck`; lint baseline unchanged)
- [x] Self-review completed
- [x] Documentation updated (if needed) (not needed for this PR)
- [x] No new warnings introduced