### PR TITLE
feat(search): support include_pack_context in explain output

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -662,6 +662,17 @@ describe("MemoryStore.explain", () => {
 		expect(result.metadata).toHaveProperty("query", "database");
 		expect(result.metadata).toHaveProperty("requested_ids_count", 0);
 		expect(typeof result.metadata.returned_items_count).toBe("number");
+		expect(result.metadata.include_pack_context).toBe(false);
+	});
+
+	it("includes pack_context when includePackContext option is enabled", () => {
+		seedMemories();
+		const result = store.explain("database", null, 10, undefined, { includePackContext: true });
+		expect(result.metadata.include_pack_context).toBe(true);
+		expect(result.items.length).toBeGreaterThan(0);
+		for (const item of result.items) {
+			expect(item.pack_context).toEqual({ included: null, section: null });
+		}
 	});
 
 	it("rejects booleans and floats in ids (dedupeOrderedIds)", () => {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -30,6 +30,10 @@ import type {
 	TimelineItemResponse,
 } from "./types.js";
 
+export interface ExplainOptions {
+	includePackContext?: boolean;
+}
+
 /** Lazily wrap a better-sqlite3 Database in a Drizzle ORM instance. */
 function getDrizzle(db: Database) {
 	return drizzle(db, { schema });
@@ -566,6 +570,7 @@ function explainItem(
 	queryTokens: string[],
 	projectFilter: string | null | undefined,
 	projectValue: string | null | undefined,
+	includePackContext: boolean,
 	referenceNow: Date,
 ): ExplainItem {
 	const text = `${item.title} ${item.body_text} ${item.tags_text}`.toLowerCase();
@@ -605,7 +610,7 @@ function explainItem(
 			query_terms: matchedTerms,
 			project_match: projectMatchesFilter(projectFilter, projectValue),
 		},
-		pack_context: null, // TODO: port include_pack_context
+		pack_context: includePackContext ? { included: null, section: null } : null,
 	};
 }
 
@@ -735,7 +740,9 @@ export function explain(
 	ids?: unknown[] | null,
 	limit = 10,
 	filters?: MemoryFilters | null,
+	options?: ExplainOptions,
 ): ExplainResponse {
+	const includePackContext = options?.includePackContext ?? false;
 	const normalizedQuery = (query ?? "").trim();
 	const { ordered: orderedIds, invalid: invalidIds } = dedupeOrderedIds(ids ?? []);
 
@@ -765,7 +772,7 @@ export function explain(
 				project: null,
 				requested_ids_count: orderedIds.length,
 				returned_items_count: 0,
-				include_pack_context: false,
+				include_pack_context: includePackContext,
 			},
 		};
 	}
@@ -832,6 +839,7 @@ export function explain(
 			queryTokens,
 			filters?.project ?? null,
 			sessionProjects.get(item.session_id) ?? null,
+			includePackContext,
 			referenceNow,
 		),
 	);
@@ -873,7 +881,7 @@ export function explain(
 			project: filters?.project ?? null,
 			requested_ids_count: orderedIds.length,
 			returned_items_count: itemsPayload.length,
-			include_pack_context: false,
+			include_pack_context: includePackContext,
 		},
 	};
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -33,7 +33,12 @@ import { buildFilterClauses } from "./filters.js";
 import { readCodememConfigFile } from "./observer-config.js";
 import { buildMemoryPack, buildMemoryPackAsync } from "./pack.js";
 import * as schema from "./schema.js";
-import { explain as explainFn, search as searchFn, timeline as timelineFn } from "./search.js";
+import {
+	type ExplainOptions,
+	explain as explainFn,
+	search as searchFn,
+	timeline as timelineFn,
+} from "./search.js";
 import { recordReplicationOp } from "./sync-replication.js";
 import type {
 	ExplainResponse,
@@ -792,8 +797,9 @@ export class MemoryStore {
 		ids?: unknown[] | null,
 		limit = 10,
 		filters?: MemoryFilters | null,
+		options?: ExplainOptions,
 	): ExplainResponse {
-		return explainFn(this, query, ids, limit, filters);
+		return explainFn(this, query, ids, limit, filters, options);
 	}
 
 	// buildMemoryPack

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -373,7 +373,10 @@ export interface ExplainItem {
 		query_terms: string[];
 		project_match: boolean | null;
 	};
-	pack_context: string | null;
+	pack_context: {
+		included: boolean | null;
+		section: string | null;
+	} | null;
 }
 
 /** Explain response */

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -220,7 +220,9 @@ async function main() {
 		async (args) => {
 			try {
 				const filters = buildFilters(args);
-				const result = store.explain(args.query ?? null, args.ids ?? null, args.limit, filters);
+				const result = store.explain(args.query ?? null, args.ids ?? null, args.limit, filters, {
+					includePackContext: args.include_pack_context,
+				});
 				return jsonContent(result);
 			} catch (err) {
 				return errorContent(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Description
This ports `include_pack_context` support for `memory_explain` so the MCP contract matches runtime behavior in the TypeScript implementation.

- Adds explain options plumbing in core search/store to support `includePackContext`.
- Propagates `include_pack_context` from MCP input to store explain calls.
- Returns non-null `pack_context` placeholders when requested and keeps metadata aligned.
- Adds coverage for `includePackContext` behavior.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`vitest` targeted suites)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `pnpm exec vitest run packages/core/src/search.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Code follows project style checks for this change set (`pnpm run typecheck`; lint baseline unchanged)
- [x] Self-review completed
- [x] Documentation updated (if needed) (not needed for this PR)
- [x] No new warnings introduced