### PR TITLE
feat(metrics): report retry_depth_max from flush attempts

### DIFF
--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import {
 	getRawEventStatus,
+	getReliabilityMetrics,
 	initDatabase,
 	retryRawEventFailures,
 	vacuumDatabase,
@@ -93,5 +94,37 @@ describe("maintenance", () => {
 		const vacuum = vacuumDatabase(dbPath);
 		expect(vacuum.path).toBe(dbPath);
 		expect(vacuum.sizeBytes).toBeGreaterThan(0);
+	});
+
+	it("reports max retry depth from raw_event_flush_batches.attempt_count", () => {
+		const dbPath = createDbPath("retry-depth");
+		seedMaintenanceDb(dbPath);
+
+		const db = new Database(dbPath);
+		try {
+			db.prepare("UPDATE raw_event_flush_batches SET attempt_count = ? WHERE id = 1").run(4);
+			db.prepare(
+				`INSERT INTO raw_event_flush_batches(
+					source, stream_id, opencode_session_id, start_event_seq, end_event_seq,
+					extractor_version, status, updated_at, created_at, attempt_count
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			).run(
+				"opencode",
+				"sess-2",
+				"sess-2",
+				1,
+				1,
+				"raw_events_v1",
+				"completed",
+				"2026-03-01T11:00:00Z",
+				"2026-03-01T10:59:00Z",
+				2,
+			);
+		} finally {
+			db.close();
+		}
+
+		const metrics = getReliabilityMetrics(dbPath);
+		expect(metrics.counts.retry_depth_max).toBe(3);
 	});
 });

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -227,6 +227,16 @@ export function getReliabilityMetrics(
 		const sessionBoundaryAccuracy =
 			sessionsWithEvents > 0 ? sessionsWithStartedAt / sessionsWithEvents : 1.0;
 
+		const retryDepthSql = `
+			SELECT COALESCE(MAX(attempt_count), 0) AS retry_depth_max
+			FROM raw_event_flush_batches
+			${cutoffIso ? "WHERE updated_at >= ?" : ""}
+		`;
+		const retryDepthRow = (
+			cutoffIso ? db.prepare(retryDepthSql).get(cutoffIso) : db.prepare(retryDepthSql).get()
+		) as Record<string, number> | undefined;
+		const retryDepthMax = Math.max(0, Number(retryDepthRow?.retry_depth_max ?? 0) - 1);
+
 		return {
 			counts: {
 				inserted_events: insertedEvents,
@@ -238,7 +248,7 @@ export function getReliabilityMetrics(
 				terminal_batches: terminalBatches,
 				sessions_with_events: sessionsWithEvents,
 				sessions_with_started_at: sessionsWithStartedAt,
-				retry_depth_max: 0, // TODO: needs attempt_count column
+				retry_depth_max: retryDepthMax,
 			},
 			rates: {
 				flush_success_rate: flushSuccessRate,


### PR DESCRIPTION
## Description
This implements the missing `retry_depth_max` reliability metric so raw-event reliability reporting reflects actual flush retry depth.

- Computes `retry_depth_max` from `raw_event_flush_batches.attempt_count`.
- Wires the computed value into `getReliabilityMetrics(...)` output.
- Adds test coverage validating max retry depth aggregation.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`vitest` targeted suites)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Commands run:
- `pnpm exec vitest run packages/core/src/maintenance.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Code follows project style checks for this change set (`pnpm run typecheck`; lint baseline unchanged)
- [x] Self-review completed
- [x] Documentation updated (if needed) (not needed for this PR)
- [x] No new warnings introduced