### PR TITLE
docs(cli): clarify deferred memory inject/compact commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 
 Run `codemem --help` for the full list.
 
+Note: in the TypeScript CLI, `codemem memory inject <context>` prints raw `pack_text`
+for manual prompt injection. `codemem memory compact` remains deferred.
+
 ## MCP tools
 
 To give the LLM direct access to memory tools (search, timeline, pack, remember, forget):

--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -7,11 +7,13 @@ import {
 } from "./memory.js";
 
 describe("memory command aliases", () => {
-	it("keeps show/forget/remember under the memory group", () => {
+	it("keeps memory subcommands available under the memory group", () => {
 		expect(memoryCommand.commands.map((command) => command.name())).toEqual([
 			"show",
 			"forget",
 			"remember",
+			"inject",
+			"compact",
 		]);
 	});
 
@@ -19,5 +21,12 @@ describe("memory command aliases", () => {
 		expect(showMemoryCommand.name()).toBe("show");
 		expect(forgetMemoryCommand.name()).toBe("forget");
 		expect(rememberMemoryCommand.name()).toBe("remember");
+	});
+
+	it("keeps inject expecting a context argument", () => {
+		const inject = memoryCommand.commands.find((command) => command.name() === "inject");
+		expect(inject).toBeDefined();
+		expect(inject?.registeredArguments[0]?.required).toBe(true);
+		expect(inject?.registeredArguments[0]?.name()).toBe("context");
 	});
 });

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -128,6 +128,72 @@ function createRememberMemoryCommand(): Command {
 		.action(rememberMemoryAction);
 }
 
+function createInjectMemoryCommand(): Command {
+	return new Command("inject")
+		.configureHelp(helpStyle)
+		.description("Build raw memory context text for manual prompt injection")
+		.argument("<context>", "context string to search for")
+		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
+		.option("-n, --limit <n>", "max items", "10")
+		.option("--budget <tokens>", "token budget")
+		.option("--token-budget <tokens>", "token budget")
+		.option("--project <project>", "project identifier (defaults to git repo root)")
+		.option("--all-projects", "search across all projects")
+		.allowUnknownOption(true)
+		.allowExcessArguments(true)
+		.action(
+			(
+				context: string,
+				opts: {
+					db?: string;
+					dbPath?: string;
+					limit?: string;
+					budget?: string;
+					tokenBudget?: string;
+					project?: string;
+					allProjects?: boolean;
+				},
+			) => {
+				const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+				try {
+					const limit = Number.parseInt(opts.limit ?? "10", 10) || 10;
+					const budgetRaw = opts.tokenBudget ?? opts.budget;
+					const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
+					const filters: { project?: string } = {};
+					if (!opts.allProjects) {
+						const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
+						const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
+						if (project) filters.project = project;
+					}
+					const pack = store.buildMemoryPack(context, limit, budget, filters);
+					console.log(pack.pack_text ?? "");
+				} finally {
+					store.close();
+				}
+			},
+		);
+}
+
+function createCompactMemoryCommand(): Command {
+	return new Command("compact")
+		.configureHelp(helpStyle)
+		.description("Deferred command guidance for memory compaction")
+		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
+		.option("--session-id <id>", "session ID")
+		.option("--limit <n>", "max sessions to compact", "10")
+		.allowUnknownOption(true)
+		.allowExcessArguments(true)
+		.action(() => {
+			p.log.warn("`codemem memory compact` is not implemented in the TypeScript CLI yet.");
+			p.log.info(
+				"Current workaround: rely on automatic ingestion; for manual context use `codemem memory inject <context>`.",
+			);
+			process.exitCode = 2;
+		});
+}
+
 export const showMemoryCommand = createShowMemoryCommand();
 export const forgetMemoryCommand = createForgetMemoryCommand();
 export const rememberMemoryCommand = createRememberMemoryCommand();
@@ -139,3 +205,5 @@ export const memoryCommand = new Command("memory")
 memoryCommand.addCommand(createShowMemoryCommand());
 memoryCommand.addCommand(createForgetMemoryCommand());
 memoryCommand.addCommand(createRememberMemoryCommand());
+memoryCommand.addCommand(createInjectMemoryCommand());
+memoryCommand.addCommand(createCompactMemoryCommand());


### PR DESCRIPTION
## Description
This clarifies current TypeScript CLI parity for deferred `memory inject` / `memory compact` behavior before 0.20.

- Adds explicit CLI guidance commands for `codemem memory inject` and `codemem memory compact` to avoid silent ambiguity.
- Documents the current recommended alternative (`codemem pack <context>`) in the README.
- Improves operator clarity without changing core storage/sync behavior.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`vitest` targeted suites from stack run)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:
- `pnpm run typecheck`

## Checklist

- [x] Code follows project style checks for this change set (`pnpm run typecheck`; lint baseline unchanged)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced