### PR TITLE
fix(core): restore ownership parity for claimed peer memories

### DIFF
--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -209,6 +209,76 @@ describe("MemoryStore", () => {
 
 	// -- forget --------------------------------------------------------------
 
+	describe("memoryOwnedBySelf", () => {
+		it("returns false (without throwing) when sync_peers table is unavailable", () => {
+			store.db.prepare("DROP TABLE IF EXISTS sync_peers").run();
+
+			expect(() =>
+				store.memoryOwnedBySelf({
+					actor_id: "legacy-sync:peer-missing",
+					origin_device_id: "peer-missing",
+					metadata: {},
+				}),
+			).not.toThrow();
+			expect(
+				store.memoryOwnedBySelf({
+					actor_id: "legacy-sync:peer-missing",
+					origin_device_id: "peer-missing",
+					metadata: {},
+				}),
+			).toBe(false);
+		});
+
+		it("returns true for claimed same-actor peer origin_device_id", () => {
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+				)
+				.run("peer-claimed-1", store.actorId, 1, "2026-01-01T00:00:00Z");
+
+			expect(
+				store.memoryOwnedBySelf({
+					actor_id: null,
+					origin_device_id: "peer-claimed-1",
+					metadata: {},
+				}),
+			).toBe(true);
+		});
+
+		it("returns true for legacy-sync actor IDs tied to claimed peers", () => {
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+				)
+				.run("peer-claimed-2", store.actorId, 1, "2026-01-01T00:00:00Z");
+
+			expect(
+				store.memoryOwnedBySelf({
+					actor_id: "legacy-sync:peer-claimed-2",
+					origin_device_id: null,
+					metadata: {},
+				}),
+			).toBe(true);
+		});
+
+		it("reads actor/origin ownership from metadata when top-level fields are absent", () => {
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+				)
+				.run("peer-claimed-3", store.actorId, 1, "2026-01-01T00:00:00Z");
+
+			expect(
+				store.memoryOwnedBySelf({
+					metadata: {
+						actor_id: "legacy-sync:peer-claimed-3",
+						origin_device_id: "peer-claimed-3",
+					},
+				}),
+			).toBe(true);
+		});
+	});
+
 	describe("forget", () => {
 		it("soft-deletes an existing memory", () => {
 			const sessionId = insertTestSession(store.db);

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -439,9 +439,6 @@ export class MemoryStore {
 	 * 1. actor_id == self.actor_id → owned
 	 * 2. origin_device_id in claimed_same_actor_peers → owned
 	 * 3. actor_id in legacy sync actor ids → owned
-	 *
-	 * Simplified: check actor_id first, then origin_device_id.
-	 * Peer claim/legacy checks deferred until sync parity is needed.
 	 */
 	memoryOwnedBySelf(item: MemoryItem | MemoryResult | Record<string, unknown>): boolean {
 		const rec = item as Record<string, unknown>;
@@ -454,6 +451,12 @@ export class MemoryStore {
 
 		const deviceId = cleanStr(rec.origin_device_id) ?? cleanStr(meta.origin_device_id);
 		if (deviceId === this.deviceId) return true;
+
+		const claimedPeers = new Set(this.sameActorPeerIds());
+		if (deviceId && claimedPeers.has(deviceId)) return true;
+
+		const legacyActorIds = new Set(this.claimedSameActorLegacyActorIds());
+		if (actorId && legacyActorIds.has(actorId)) return true;
 
 		return false;
 	}
@@ -1668,6 +1671,7 @@ export class MemoryStore {
 	}
 
 	sameActorPeerIds(): string[] {
+		if (!tableExists(this.db, "sync_peers")) return [];
 		const rows = this.db
 			.prepare(
 				"SELECT peer_device_id FROM sync_peers WHERE claimed_local_actor = 1 OR actor_id = ? ORDER BY peer_device_id",


### PR DESCRIPTION
## Description
Restores `memoryOwnedBySelf` parity with Python for claimed peer ownership semantics so shared-memory ranking and ownership-sensitive logic stop misclassifying valid local ownership.

- Adds claimed-peer origin-device ownership checks and legacy-sync actor ownership checks in `packages/core/src/store.ts`.
- Keeps existing direct actor/device ownership checks while restoring the deferred parity paths.
- Adds targeted tests for claimed peer IDs, legacy actor IDs, and metadata-only ownership inputs in `packages/core/src/store.test.ts`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`vitest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:
- `pnpm exec vitest run packages/core/src/store.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Code follows project style checks for this change set (`pnpm run typecheck`; lint baseline unchanged)
- [x] Self-review completed
- [x] Documentation updated (if needed) (not needed for this PR)
- [x] No new warnings introduced