### PR TITLE
fix(sync): enforce peer scopes for inbound and outbound ops

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -484,9 +484,8 @@ syncCommand.addCommand(
 				console.log("For machine-friendly output next time, run:");
 				console.log("  codemem sync pair --payload-only");
 				console.log(
-					"On the accepting device, --include/--exclude only control what it sends to peers.",
+					"On the accepting device, --include/--exclude control both what it sends and what it accepts from that peer.",
 				);
-				console.log("This device does not yet enforce incoming project filters.");
 			} finally {
 				store.close();
 			}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -279,6 +279,8 @@ export {
 	chunkOpsBySize,
 	clockTuple,
 	extractReplicationOps,
+	filterReplicationOpsForSync,
+	filterReplicationOpsForSyncWithStatus,
 	getReplicationCursor,
 	isNewerClock,
 	loadReplicationOpsSince,

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -18,6 +18,8 @@ import {
 	backfillReplicationOps,
 	chunkOpsBySize,
 	extractReplicationOps,
+	filterReplicationOpsForSync,
+	filterReplicationOpsForSyncWithStatus,
 	getReplicationCursor,
 	migrateLegacyImportKeys,
 	setReplicationCursor,
@@ -350,37 +352,30 @@ export async function syncOnce(
 				throw new Error("invalid ops response");
 			}
 			const ops = extractReplicationOps(getPayload);
+			const [inboundOps, inboundCursor] = filterReplicationOpsForSyncWithStatus(
+				db,
+				ops,
+				peerDeviceId,
+			);
 
 			// -- 3. Apply incoming ops to local entities --
-			const applied = applyReplicationOps(db, ops, deviceId);
+			const applied = applyReplicationOps(db, inboundOps, deviceId);
 
-			if (ops.length > 0) {
-				const last = ops.at(-1);
-				if (last) {
-					const localNext = computeCursor(last.created_at, last.op_id);
-					if (cursorAdvances(lastApplied, localNext)) {
-						setReplicationCursor(db, peerDeviceId, { lastApplied: localNext });
-						lastApplied = localNext;
-					}
-				}
-			} else {
-				const peerNext =
-					typeof getPayload.next_cursor === "string" ? getPayload.next_cursor.trim() : "";
-				const skippedValue = getPayload.skipped;
-				const skippedCount =
-					typeof skippedValue === "number"
-						? skippedValue
-						: typeof skippedValue === "string"
-							? Number.parseInt(skippedValue, 10) || 0
-							: 0;
-				if (skippedCount > 0 && cursorAdvances(lastApplied, peerNext)) {
-					setReplicationCursor(db, peerDeviceId, { lastApplied: peerNext });
-					lastApplied = peerNext;
-				}
+			const inboundCursorCandidate =
+				inboundCursor ||
+				(typeof getPayload.next_cursor === "string" ? getPayload.next_cursor.trim() : "");
+			if (cursorAdvances(lastApplied, inboundCursorCandidate)) {
+				setReplicationCursor(db, peerDeviceId, { lastApplied: inboundCursorCandidate });
+				lastApplied = inboundCursorCandidate;
 			}
 
 			// -- 5. Push local ops to peer --
-			const [outboundOps, outboundCursor] = loadLocalOpsSince(db, lastAcked, deviceId, limit);
+			const [outboundWindow, outboundCursor] = loadLocalOpsSince(db, lastAcked, deviceId, limit);
+			const [outboundOps, filteredOutboundCursor] = filterReplicationOpsForSync(
+				db,
+				outboundWindow,
+				peerDeviceId,
+			);
 			const postUrl = `${baseUrl}/v1/ops`;
 			if (outboundOps.length > 0) {
 				const batches = chunkOpsBySize(outboundOps, MAX_SYNC_BODY_BYTES);
@@ -388,9 +383,10 @@ export async function syncOnce(
 					await pushOps(postUrl, deviceId, batch, keysDir);
 				}
 			}
-			if (outboundCursor) {
-				setReplicationCursor(db, peerDeviceId, { lastAcked: outboundCursor });
-				lastAcked = outboundCursor;
+			const ackCursor = filteredOutboundCursor ?? outboundCursor;
+			if (ackCursor && cursorAdvances(lastAcked, ackCursor)) {
+				setReplicationCursor(db, peerDeviceId, { lastAcked: ackCursor });
+				lastAcked = ackCursor;
 			}
 
 			// -- 6. Record success --

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1,5 +1,5 @@
 import Database from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toJson } from "./db.js";
 import {
 	applyReplicationOps,
@@ -7,6 +7,8 @@ import {
 	chunkOpsBySize,
 	clockTuple,
 	extractReplicationOps,
+	filterReplicationOpsForSync,
+	filterReplicationOpsForSyncWithStatus,
 	getReplicationCursor,
 	isNewerClock,
 	loadReplicationOpsSince,
@@ -590,6 +592,154 @@ describe("legacy key migration + replication backfill", () => {
 			.prepare("SELECT COUNT(*) AS n FROM memory_items WHERE import_key LIKE 'legacy:local:%'")
 			.get() as { n: number };
 		expect(localLegacyCount.n).toBe(0);
+	});
+});
+
+describe("filterReplicationOpsForSyncWithStatus", () => {
+	let db: InstanceType<typeof Database>;
+	let prevInclude: string | undefined;
+	let prevExclude: string | undefined;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		prevInclude = process.env.CODEMEM_SYNC_PROJECTS_INCLUDE;
+		prevExclude = process.env.CODEMEM_SYNC_PROJECTS_EXCLUDE;
+	});
+
+	afterEach(() => {
+		db.close();
+		if (prevInclude === undefined) delete process.env.CODEMEM_SYNC_PROJECTS_INCLUDE;
+		else process.env.CODEMEM_SYNC_PROJECTS_INCLUDE = prevInclude;
+		if (prevExclude === undefined) delete process.env.CODEMEM_SYNC_PROJECTS_EXCLUDE;
+		else process.env.CODEMEM_SYNC_PROJECTS_EXCLUDE = prevExclude;
+		vi.unstubAllEnvs();
+	});
+
+	function makeOp(overrides: Partial<ReplicationOp> = {}): ReplicationOp {
+		return {
+			op_id: "op-1",
+			entity_type: "memory_item",
+			entity_id: "key-1",
+			op_type: "upsert",
+			payload_json: toJson({ project: "proj-a", visibility: "shared" }),
+			clock_rev: 1,
+			clock_updated_at: "2026-01-01T00:00:00Z",
+			clock_device_id: "peer-1",
+			device_id: "peer-1",
+			created_at: "2026-01-01T00:00:00Z",
+			...overrides,
+		};
+	}
+
+	it("filters by peer include scope and advances cursor past skipped ops", () => {
+		db.prepare(
+			"INSERT INTO sync_peers(peer_device_id, projects_include_json, projects_exclude_json, created_at) VALUES (?, ?, ?, ?)",
+		).run("peer-1", toJson(["proj-a"]), toJson([]), "2026-01-01T00:00:00Z");
+
+		const op1 = makeOp({
+			op_id: "op-1",
+			payload_json: toJson({ project: "proj-b", visibility: "shared" }),
+			created_at: "2026-01-01T00:00:01Z",
+		});
+		const op2 = makeOp({
+			op_id: "op-2",
+			payload_json: toJson({ project: "proj-a", visibility: "shared" }),
+			created_at: "2026-01-01T00:00:02Z",
+		});
+
+		const [allowed, nextCursor, skipped] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[op1, op2],
+			"peer-1",
+		);
+		expect(allowed.map((op) => op.op_id)).toEqual(["op-2"]);
+		expect(nextCursor).toBe("2026-01-01T00:00:02Z|op-2");
+		expect(skipped?.reason).toBe("project_filter");
+		expect(skipped?.skipped_count).toBe(1);
+
+		const [allowedOnly, nextOnly] = filterReplicationOpsForSync(db, [op1, op2], "peer-1");
+		expect(allowedOnly.map((op) => op.op_id)).toEqual(["op-2"]);
+		expect(nextOnly).toBe("2026-01-01T00:00:02Z|op-2");
+	});
+
+	it("filters private visibility unless peer is claimed local actor", () => {
+		db.prepare(
+			"INSERT INTO sync_peers(peer_device_id, projects_include_json, projects_exclude_json, claimed_local_actor, created_at) VALUES (?, ?, ?, ?, ?)",
+		).run("peer-1", toJson([]), toJson([]), 0, "2026-01-01T00:00:00Z");
+
+		const privateOp = makeOp({
+			op_id: "op-private",
+			payload_json: toJson({ project: "proj-a", visibility: "private" }),
+		});
+
+		const [blockedOps, blockedCursor, blockedMeta] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[privateOp],
+			"peer-1",
+		);
+		expect(blockedOps).toEqual([]);
+		expect(blockedCursor).toBe("2026-01-01T00:00:00Z|op-private");
+		expect(blockedMeta?.reason).toBe("visibility_filter");
+
+		db.prepare("UPDATE sync_peers SET claimed_local_actor = 1 WHERE peer_device_id = ?").run(
+			"peer-1",
+		);
+		const [allowedOps, allowedCursor, allowedMeta] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[privateOp],
+			"peer-1",
+		);
+		expect(allowedOps.map((op) => op.op_id)).toEqual(["op-private"]);
+		expect(allowedCursor).toBe("2026-01-01T00:00:00Z|op-private");
+		expect(allowedMeta).toBeNull();
+	});
+
+	it("keeps delete tombstones with null payload_json", () => {
+		db.prepare(
+			"INSERT INTO sync_peers(peer_device_id, projects_include_json, projects_exclude_json, claimed_local_actor, created_at) VALUES (?, ?, ?, ?, ?)",
+		).run("peer-1", toJson(["proj-a"]), toJson([]), 0, "2026-01-01T00:00:00Z");
+
+		const tombstone = makeOp({
+			op_id: "op-del",
+			op_type: "delete",
+			payload_json: null,
+			created_at: "2026-01-01T00:00:05Z",
+		});
+
+		const [allowed, cursor, skipped] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[tombstone],
+			"peer-1",
+		);
+		expect(allowed.map((op) => op.op_id)).toEqual(["op-del"]);
+		expect(cursor).toBe("2026-01-01T00:00:05Z|op-del");
+		expect(skipped).toBeNull();
+	});
+
+	it("respects CODEMEM_SYNC_PROJECTS_* env overrides", () => {
+		vi.stubEnv("CODEMEM_SYNC_PROJECTS_INCLUDE", "proj-env");
+		vi.stubEnv("CODEMEM_SYNC_PROJECTS_EXCLUDE", "proj-blocked");
+
+		const allowedOp = makeOp({
+			op_id: "op-env-allow",
+			payload_json: toJson({ project: "proj-env", visibility: "shared" }),
+			created_at: "2026-01-01T00:00:10Z",
+		});
+		const blockedOp = makeOp({
+			op_id: "op-env-block",
+			payload_json: toJson({ project: "proj-other", visibility: "shared" }),
+			created_at: "2026-01-01T00:00:11Z",
+		});
+
+		const [allowed, cursor, skipped] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[allowedOp, blockedOp],
+			null,
+		);
+		expect(allowed.map((op) => op.op_id)).toEqual(["op-env-allow"]);
+		expect(cursor).toBe("2026-01-01T00:00:11Z|op-env-block");
+		expect(skipped?.reason).toBe("project_filter");
 	});
 });
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -13,6 +13,7 @@ import { and, eq, gt, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import { fromJson, fromJsonStrict, toJson, toJsonNullable } from "./db.js";
+import { readCodememConfigFile } from "./observer-config.js";
 import * as schema from "./schema.js";
 import type { ReplicationOp } from "./types.js";
 
@@ -376,6 +377,252 @@ export function loadReplicationOpsSince(
 	}
 
 	return [ops, nextCursor];
+}
+
+function cleanList(values: unknown): string[] {
+	if (!Array.isArray(values)) return [];
+	const out: string[] = [];
+	for (const raw of values) {
+		const value = String(raw ?? "").trim();
+		if (value) out.push(value);
+	}
+	return out;
+}
+
+function parseStringList(value: unknown): string[] {
+	if (Array.isArray(value)) return cleanList(value);
+	if (typeof value === "string") {
+		return value
+			.split(",")
+			.map((part) => part.trim())
+			.filter(Boolean);
+	}
+	return [];
+}
+
+function parseJsonList(valuesJson: string | null | undefined): string[] {
+	if (!valuesJson) return [];
+	try {
+		return cleanList(JSON.parse(valuesJson));
+	} catch {
+		return [];
+	}
+}
+
+function projectBasename(value: string | null | undefined): string {
+	const raw = String(value ?? "")
+		.trim()
+		.replaceAll("\\", "/");
+	if (!raw) return "";
+	const parts = raw.split("/").filter(Boolean);
+	return parts.length > 0 ? (parts[parts.length - 1] ?? "") : "";
+}
+
+function effectiveSyncProjectFilters(
+	db: Database,
+	peerDeviceId: string | null,
+): { include: string[]; exclude: string[] } {
+	const config = readCodememConfigFile();
+	const includeOverride = process.env.CODEMEM_SYNC_PROJECTS_INCLUDE;
+	const excludeOverride = process.env.CODEMEM_SYNC_PROJECTS_EXCLUDE;
+	const globalInclude =
+		includeOverride !== undefined
+			? parseStringList(includeOverride)
+			: parseStringList(config.sync_projects_include);
+	const globalExclude =
+		excludeOverride !== undefined
+			? parseStringList(excludeOverride)
+			: parseStringList(config.sync_projects_exclude);
+	if (!peerDeviceId) return { include: globalInclude, exclude: globalExclude };
+
+	const row = db
+		.prepare(
+			"SELECT projects_include_json, projects_exclude_json FROM sync_peers WHERE peer_device_id = ? LIMIT 1",
+		)
+		.get(peerDeviceId) as
+		| { projects_include_json: string | null; projects_exclude_json: string | null }
+		| undefined;
+	if (!row) return { include: globalInclude, exclude: globalExclude };
+
+	const hasOverride = row.projects_include_json != null || row.projects_exclude_json != null;
+	if (!hasOverride) {
+		return { include: globalInclude, exclude: globalExclude };
+	}
+
+	return {
+		include: parseJsonList(row.projects_include_json),
+		exclude: parseJsonList(row.projects_exclude_json),
+	};
+}
+
+function syncProjectAllowed(
+	db: Database,
+	project: string | null,
+	peerDeviceId: string | null,
+): boolean {
+	const { include, exclude } = effectiveSyncProjectFilters(db, peerDeviceId);
+	const projectName = String(project ?? "").trim();
+	const basename = projectBasename(projectName);
+
+	if (exclude.some((item) => item === projectName || item === basename)) return false;
+	if (include.length === 0) return true;
+	return include.some((item) => item === projectName || item === basename);
+}
+
+function syncVisibilityAllowed(payload: Record<string, unknown> | null): boolean {
+	if (!payload) return false;
+	let visibility = String(payload.visibility ?? "")
+		.trim()
+		.toLowerCase();
+	const metadata =
+		payload.metadata_json &&
+		typeof payload.metadata_json === "object" &&
+		!Array.isArray(payload.metadata_json)
+			? (payload.metadata_json as Record<string, unknown>)
+			: {};
+	const metadataVisibility = String(metadata.visibility ?? "")
+		.trim()
+		.toLowerCase();
+	if (!visibility && metadataVisibility) {
+		visibility = metadataVisibility;
+	}
+
+	if (!visibility) {
+		let workspaceKind = String(payload.workspace_kind ?? "")
+			.trim()
+			.toLowerCase();
+		let workspaceId = String(payload.workspace_id ?? "")
+			.trim()
+			.toLowerCase();
+		if (!workspaceKind)
+			workspaceKind = String(metadata.workspace_kind ?? "")
+				.trim()
+				.toLowerCase();
+		if (!workspaceId)
+			workspaceId = String(metadata.workspace_id ?? "")
+				.trim()
+				.toLowerCase();
+		if (workspaceKind === "shared" || workspaceId.startsWith("shared:")) {
+			visibility = "shared";
+		} else {
+			return true;
+		}
+	}
+
+	return visibility === "shared";
+}
+
+function peerClaimedLocalActor(db: Database, peerDeviceId: string | null): boolean {
+	if (!peerDeviceId) return false;
+	const row = db
+		.prepare("SELECT claimed_local_actor FROM sync_peers WHERE peer_device_id = ? LIMIT 1")
+		.get(peerDeviceId) as { claimed_local_actor: number | null } | undefined;
+	return Boolean(row?.claimed_local_actor);
+}
+
+function parsePayload(payloadJson: string | null): Record<string, unknown> | null {
+	if (!payloadJson || !payloadJson.trim()) return null;
+	try {
+		const parsed = JSON.parse(payloadJson) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		return parsed as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+export interface FilterReplicationSkipped {
+	reason: "visibility_filter" | "project_filter";
+	op_id: string;
+	created_at: string;
+	entity_type: string;
+	entity_id: string;
+	skipped_count: number;
+	project?: string | null;
+	visibility?: string | null;
+}
+
+/**
+ * Filter replication ops for peer sync scopes.
+ *
+ * Returns ops that pass project/visibility rules, a cursor for the last
+ * processed op (including skipped ops), and skipped metadata when filtering
+ * removed one or more ops.
+ */
+export function filterReplicationOpsForSyncWithStatus(
+	db: Database,
+	ops: ReplicationOp[],
+	peerDeviceId: string | null,
+): [ReplicationOp[], string | null, FilterReplicationSkipped | null] {
+	const allowed: ReplicationOp[] = [];
+	let nextCursor: string | null = null;
+	let skippedCount = 0;
+	let firstSkipped: FilterReplicationSkipped | null = null;
+	for (const op of ops) {
+		if (op.entity_type === "memory_item") {
+			const payload = parsePayload(op.payload_json);
+			if (op.op_type === "delete" && payload == null) {
+				allowed.push(op);
+				nextCursor = computeCursor(op.created_at, op.op_id);
+				continue;
+			}
+			if (!syncVisibilityAllowed(payload) && !peerClaimedLocalActor(db, peerDeviceId)) {
+				skippedCount += 1;
+				if (!firstSkipped) {
+					firstSkipped = {
+						reason: "visibility_filter",
+						op_id: op.op_id,
+						created_at: op.created_at,
+						entity_type: op.entity_type,
+						entity_id: op.entity_id,
+						visibility: typeof payload?.visibility === "string" ? String(payload.visibility) : null,
+						skipped_count: 0,
+					};
+				}
+				nextCursor = computeCursor(op.created_at, op.op_id);
+				continue;
+			}
+
+			const project =
+				typeof payload?.project === "string" && payload.project.trim()
+					? payload.project.trim()
+					: null;
+			if (!syncProjectAllowed(db, project, peerDeviceId)) {
+				skippedCount += 1;
+				if (!firstSkipped) {
+					firstSkipped = {
+						reason: "project_filter",
+						op_id: op.op_id,
+						created_at: op.created_at,
+						entity_type: op.entity_type,
+						entity_id: op.entity_id,
+						project,
+						skipped_count: 0,
+					};
+				}
+				nextCursor = computeCursor(op.created_at, op.op_id);
+				continue;
+			}
+		}
+
+		allowed.push(op);
+		nextCursor = computeCursor(op.created_at, op.op_id);
+	}
+
+	if (firstSkipped) {
+		firstSkipped.skipped_count = skippedCount;
+	}
+
+	return [allowed, nextCursor, firstSkipped];
+}
+
+export function filterReplicationOpsForSync(
+	db: Database,
+	ops: ReplicationOp[],
+	peerDeviceId: string | null,
+): [ReplicationOp[], string | null] {
+	const [allowed, nextCursor] = filterReplicationOpsForSyncWithStatus(db, ops, peerDeviceId);
+	return [allowed, nextCursor];
 }
 
 // Apply inbound replication ops

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -44,8 +44,7 @@ const MAX_SYNC_OPS = intEnvOr("CODEMEM_SYNC_MAX_OPS", 2000);
 
 const PAIRING_FILTER_HINT =
 	"Run this on another device with codemem sync pair --accept '<payload>'. " +
-	"On that accepting device, --include/--exclude only control what it sends to peers. " +
-	"This device does not yet enforce incoming project filters.";
+	"On the accepting device, --include/--exclude control both what it sends and what it accepts from that peer.";
 
 function pathWithQuery(url: string): string {
 	const parsed = new URL(url);
@@ -514,8 +513,12 @@ export function syncRoutes(getStore: StoreFactory) {
 			localDeviceId = { device_id: deviceId };
 		}
 
-		const result = applyReplicationOps(store.db, normalizedOps, localDeviceId.device_id);
-		return c.json(result);
+		const filteredInbound = filterOpsForPeer(store, peerDeviceId, normalizedOps);
+		const result = applyReplicationOps(store.db, filteredInbound.allowed, localDeviceId.device_id);
+		return c.json({
+			...result,
+			skipped: result.skipped + filteredInbound.skipped,
+		});
 	});
 
 	// GET /api/sync/status


### PR DESCRIPTION
## Description
Enforces peer project/visibility scopes consistently for both inbound and outbound replication so sync behavior matches pairing expectations and avoids accepting out-of-scope data.

- Adds reusable replication-op scope filtering utilities and status metadata in `packages/core/src/sync-replication.ts`.
- Applies filtering in sync pass for inbound apply and outbound push cursoring in `packages/core/src/sync-pass.ts`.
- Aligns viewer/CLI copy to documented behavior in `packages/viewer-server/src/routes/sync.ts` and `packages/cli/src/commands/sync.ts`.
- Adds coverage for project/visibility filtering and cursor advancement behavior in `packages/core/src/sync-replication.test.ts`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`vitest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:
- `pnpm exec vitest run packages/core/src/sync-replication.test.ts packages/core/src/sync-pass.test.ts packages/viewer-server/src/index.test.ts packages/cli/src/commands/sync.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Code follows project style checks for this change set (`pnpm run typecheck`; lint baseline unchanged)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced