### PR TITLE
feat(pack): support working-set path reranking in TS search

### DIFF
--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -28,5 +28,6 @@ describe("memory command aliases", () => {
 		expect(inject).toBeDefined();
 		expect(inject?.registeredArguments[0]?.required).toBe(true);
 		expect(inject?.registeredArguments[0]?.name()).toBe("context");
+		expect(inject?.options.some((option) => option.long === "--working-set-file")).toBe(true);
 	});
 });

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -11,6 +11,10 @@ import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 
+function collectWorkingSetFile(value: string, previous: string[]): string[] {
+	return [...previous, value];
+}
+
 /** Parse a strict positive integer, rejecting prefixes like "12abc". */
 function parseStrictPositiveId(value: string): number | null {
 	if (!/^\d+$/.test(value.trim())) return null;
@@ -138,6 +142,12 @@ function createInjectMemoryCommand(): Command {
 		.option("-n, --limit <n>", "max items", "10")
 		.option("--budget <tokens>", "token budget")
 		.option("--token-budget <tokens>", "token budget")
+		.option(
+			"--working-set-file <path>",
+			"recently modified file path used as ranking hint",
+			collectWorkingSetFile,
+			[],
+		)
 		.option("--project <project>", "project identifier (defaults to git repo root)")
 		.option("--all-projects", "search across all projects")
 		.allowUnknownOption(true)
@@ -151,6 +161,7 @@ function createInjectMemoryCommand(): Command {
 					limit?: string;
 					budget?: string;
 					tokenBudget?: string;
+					workingSetFile?: string[];
 					project?: string;
 					allProjects?: boolean;
 				},
@@ -160,11 +171,14 @@ function createInjectMemoryCommand(): Command {
 					const limit = Number.parseInt(opts.limit ?? "10", 10) || 10;
 					const budgetRaw = opts.tokenBudget ?? opts.budget;
 					const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
-					const filters: { project?: string } = {};
+					const filters: { project?: string; working_set_paths?: string[] } = {};
 					if (!opts.allProjects) {
 						const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
 						const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
 						if (project) filters.project = project;
+					}
+					if ((opts.workingSetFile?.length ?? 0) > 0) {
+						filters.working_set_paths = opts.workingSetFile;
 					}
 					const pack = store.buildMemoryPack(context, limit, budget, filters);
 					console.log(pack.pack_text ?? "");

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -45,16 +45,14 @@ export const packCommand = new Command("pack")
 				const limit = Number.parseInt(opts.limit, 10) || 10;
 				const budgetRaw = opts.tokenBudget ?? opts.budget;
 				const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
-				const filters: { project?: string } = {};
+				const filters: { project?: string; working_set_paths?: string[] } = {};
 				if (!opts.allProjects) {
 					const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
 					const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
 					if (project) filters.project = project;
 				}
 				if ((opts.workingSetFile?.length ?? 0) > 0) {
-					p.log.warn(
-						"--working-set-file is accepted for compatibility but is not yet used by the TS pack builder.",
-					);
+					filters.working_set_paths = opts.workingSetFile;
 				}
 				const result = store.buildMemoryPack(context, limit, budget, filters);
 

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -193,6 +193,25 @@ describe("rerankResults", () => {
 		expect(reranked[0]?.id).toBe(1);
 	});
 
+	it("boosts results that overlap working_set_paths", () => {
+		const results = [
+			makeResult({
+				id: 1,
+				score: 1.0,
+				metadata: { files_modified: ["src/features/auth/login.ts"] },
+			}),
+			makeResult({
+				id: 2,
+				score: 1.0,
+				metadata: { files_modified: ["docs/architecture.md"] },
+			}),
+		];
+		const reranked = rerankResults(mockStore, results, 10, {
+			working_set_paths: ["src/features/auth/login.ts"],
+		});
+		expect(reranked[0]?.id).toBe(1);
+	});
+
 	it("returns empty array for empty input", () => {
 		expect(rerankResults(mockStore, [], 10)).toEqual([]);
 	});

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -251,6 +251,91 @@ function sharedTrustPenalty(
 	return 0.0;
 }
 
+function canonicalPath(rawPath: string): string {
+	let path = rawPath.trim().replaceAll("\\", "/");
+	if (path.startsWith("./")) {
+		path = path.slice(2);
+	}
+	const parts = path.split("/").filter((part) => part && part !== ".");
+	if (parts.length === 0) return "";
+	return parts.join("/").toLowerCase();
+}
+
+function pathSegments(path: string): string[] {
+	const canonical = canonicalPath(path);
+	if (!canonical) return [];
+	return canonical.split("/");
+}
+
+function pathBasename(path: string): string {
+	const segments = pathSegments(path);
+	if (segments.length === 0) return "";
+	return segments[segments.length - 1] ?? "";
+}
+
+function pathSegmentsOverlap(a: string[], b: string[]): boolean {
+	if (a.length === 0 || b.length === 0) return false;
+	if (a.length <= b.length) {
+		return b.slice(b.length - a.length).join("/") === a.join("/");
+	}
+	return a.slice(a.length - b.length).join("/") === b.join("/");
+}
+
+function normalizeWorkingSetPaths(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	const normalized: string[] = [];
+	const seen = new Set<string>();
+	for (const raw of value) {
+		if (typeof raw !== "string") continue;
+		const path = canonicalPath(raw);
+		if (!path || seen.has(path)) continue;
+		seen.add(path);
+		normalized.push(path);
+	}
+	return normalized;
+}
+
+function memoryFilesModified(item: MemoryResult): string[] {
+	const metadata = item.metadata ?? {};
+	const rawPaths = metadata.files_modified;
+	if (!Array.isArray(rawPaths)) return [];
+	const normalized: string[] = [];
+	for (const raw of rawPaths) {
+		if (typeof raw !== "string") continue;
+		const path = canonicalPath(raw);
+		if (path) normalized.push(path);
+	}
+	return normalized;
+}
+
+function workingSetOverlapBoost(item: MemoryResult, workingSetPaths: string[]): number {
+	if (workingSetPaths.length === 0) return 0.0;
+	const itemPaths = memoryFilesModified(item);
+	if (itemPaths.length === 0) return 0.0;
+
+	const itemPathSegments = [...new Set(itemPaths)].map((path) => pathSegments(path));
+	const workingSetSegments = [...new Set(workingSetPaths)].map((path) => pathSegments(path));
+	const itemBasenames = new Set(itemPaths.map((path) => pathBasename(path)).filter(Boolean));
+	const workingSetBasenames = new Set(
+		workingSetPaths.map((path) => pathBasename(path)).filter(Boolean),
+	);
+
+	let directHits = 0;
+	for (const itemSegment of itemPathSegments) {
+		if (workingSetSegments.some((wsSegment) => pathSegmentsOverlap(itemSegment, wsSegment))) {
+			directHits += 1;
+		}
+	}
+
+	let basenameHits = 0;
+	for (const basename of itemBasenames) {
+		if (workingSetBasenames.has(basename)) basenameHits += 1;
+	}
+
+	const boost = directHits * 0.16 + basenameHits * 0.06;
+	return Math.min(0.32, boost);
+}
+
 /**
  * Re-rank search results by combining BM25 score, recency, kind bonus,
  * personal bias, and shared trust penalty.
@@ -262,6 +347,7 @@ export function rerankResults(
 	filters?: MemoryFilters,
 ): MemoryResult[] {
 	const referenceNow = new Date();
+	const workingSetPaths = normalizeWorkingSetPaths(filters?.working_set_paths);
 
 	const scored = results.map((item) => ({
 		item,
@@ -269,6 +355,7 @@ export function rerankResults(
 			item.score * 1.5 +
 			recencyScore(item.created_at, referenceNow) +
 			kindBonus(item.kind) +
+			workingSetOverlapBoost(item, workingSetPaths) +
 			personalBias(store, item, filters) -
 			sharedTrustPenalty(store, item, filters),
 	}));

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -455,6 +455,7 @@ export interface MemoryFilters {
 	kind?: string;
 	session_id?: number;
 	since?: string;
+	working_set_paths?: string[];
 	/** Project scope — matches sessions.project. Triggers session JOIN. */
 	project?: string;
 	visibility?: string | string[];


### PR DESCRIPTION
## Description
Implements TS parity for `--working-set-file` by feeding working-set paths into reranking so memory pack results prioritize items that overlap recently modified files.

- Adds `working_set_paths` to core filter types in `packages/core/src/types.ts`.
- Implements path normalization and overlap scoring boosts in reranking in `packages/core/src/search.ts`.
- Wires CLI pack `--working-set-file` values into filters in `packages/cli/src/commands/pack.ts` and removes the previous unused warning path.
- Adds ranking coverage for working-set overlap behavior in `packages/core/src/search.test.ts`.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`vitest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:
- `pnpm exec vitest run packages/core/src/search.test.ts packages/cli/src/commands/pack.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Code follows project style checks for this change set (`pnpm run typecheck`; lint baseline unchanged)
- [x] Self-review completed
- [x] Documentation updated (if needed) (not needed for this PR)
- [x] No new warnings introduced