### PR TITLE
fix(raw-events): block cursor advance on zero-memory micro-batches

### DIFF
--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -602,6 +602,40 @@ describe("ingest() integration", () => {
 		expect(session.ended_at).not.toBeNull();
 	});
 
+	it("throws during direct raw-event flush when observer yields no storable memories", async () => {
+		const lowSignalObserver = {
+			observe: async () => ({
+				raw: '<skip_summary reason="low-signal"/>',
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-low-signal",
+				promptCount: 1,
+				toolCount: 1,
+				durationMs: 1000,
+				flusher: "raw_events",
+			},
+		});
+
+		await expect(
+			ingest(payload, store, { observer: lowSignalObserver } as unknown as IngestOptions),
+		).rejects.toThrow("observer produced no storable output for raw-event flush");
+
+		expect(store.recent(10)).toHaveLength(0);
+	});
+
 	it("skips trivial requests", async () => {
 		let observerCalled = false;
 		const trackingObserver = {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -328,91 +328,100 @@ export async function ingest(
 		const rawText = response.raw;
 		const parsed = parseObserverResponse(rawText);
 
+		const observationsToStore: typeof parsed.observations = [];
+		if (storeTyped && hasMeaningfulObservation(parsed.observations)) {
+			for (const obs of parsed.observations) {
+				const kind = obs.kind.trim().toLowerCase();
+				if (!ALLOWED_KINDS.has(kind)) continue;
+				if (!obs.title && !obs.narrative) continue;
+				if (isLowSignalObservation(obs.title) || isLowSignalObservation(obs.narrative)) {
+					continue;
+				}
+
+				obs.filesRead = normalizePaths(obs.filesRead, cwd);
+				obs.filesModified = normalizePaths(obs.filesModified, cwd);
+				observationsToStore.push(obs);
+			}
+		}
+
+		let summaryToStore: { summary: ParsedSummary; request: string; body: string } | null = null;
+		if (storeSummary && parsed.summary && !parsed.skipSummaryReason) {
+			const summary = parsed.summary;
+			if (
+				summary.request ||
+				summary.investigated ||
+				summary.learned ||
+				summary.completed ||
+				summary.nextSteps ||
+				summary.notes
+			) {
+				summary.filesRead = normalizePaths(summary.filesRead, cwd);
+				summary.filesModified = normalizePaths(summary.filesModified, cwd);
+
+				let request = summary.request;
+				if (isTrivialRequest(request)) {
+					const derived = deriveRequest(summary);
+					if (derived) request = derived;
+				}
+
+				const body = summaryBody(summary);
+				if (body && !isLowSignalObservation(firstSentence(body))) {
+					summaryToStore = { summary, request, body };
+				}
+			}
+		}
+
+		if (sessionContext?.flusher === "raw_events") {
+			const storableCount = observationsToStore.length + (summaryToStore ? 1 : 0);
+			if (storableCount === 0) {
+				throw new Error("observer produced no storable output for raw-event flush");
+			}
+		}
+
 		// Persist all observations, summary, and usage atomically
 		store.db.transaction(() => {
 			// ------------------------------------------------------------------
 			// Filter and persist observations
 			// ------------------------------------------------------------------
-			if (storeTyped && hasMeaningfulObservation(parsed.observations)) {
-				for (const obs of parsed.observations) {
-					const kind = obs.kind.trim().toLowerCase();
-					if (!ALLOWED_KINDS.has(kind)) continue;
-					if (!obs.title && !obs.narrative) continue;
-					if (isLowSignalObservation(obs.title) || isLowSignalObservation(obs.narrative)) {
-						continue;
-					}
+			for (const obs of observationsToStore) {
+				const kind = obs.kind.trim().toLowerCase();
 
-					const filesRead = normalizePaths(obs.filesRead, cwd);
-					const filesModified = normalizePaths(obs.filesModified, cwd);
-
-					// Build body text from narrative
-					const bodyParts: string[] = [];
-					if (obs.narrative) bodyParts.push(obs.narrative);
-					if (obs.facts.length > 0) {
-						bodyParts.push(obs.facts.map((f) => `- ${f}`).join("\n"));
-					}
-					const bodyText = bodyParts.join("\n\n");
-
-					store.remember(sessionId, kind, obs.title || obs.narrative, bodyText, 0.5, undefined, {
-						subtitle: obs.subtitle,
-						facts: obs.facts,
-						concepts: obs.concepts,
-						files_read: filesRead,
-						files_modified: filesModified,
-						prompt_number: promptNumber,
-						source: "observer",
-					});
+				const bodyParts: string[] = [];
+				if (obs.narrative) bodyParts.push(obs.narrative);
+				if (obs.facts.length > 0) {
+					bodyParts.push(obs.facts.map((f) => `- ${f}`).join("\n"));
 				}
+				const bodyText = bodyParts.join("\n\n");
+
+				store.remember(sessionId, kind, obs.title || obs.narrative, bodyText, 0.5, undefined, {
+					subtitle: obs.subtitle,
+					facts: obs.facts,
+					concepts: obs.concepts,
+					files_read: obs.filesRead,
+					files_modified: obs.filesModified,
+					prompt_number: promptNumber,
+					source: "observer",
+				});
 			}
 
 			// ------------------------------------------------------------------
 			// Persist session summary
 			// ------------------------------------------------------------------
-			if (storeSummary && parsed.summary && !parsed.skipSummaryReason) {
-				const summary = parsed.summary;
-				if (
-					summary.request ||
-					summary.investigated ||
-					summary.learned ||
-					summary.completed ||
-					summary.nextSteps ||
-					summary.notes
-				) {
-					summary.filesRead = normalizePaths(summary.filesRead, cwd);
-					summary.filesModified = normalizePaths(summary.filesModified, cwd);
-
-					// Derive meaningful request if trivial
-					let request = summary.request;
-					if (isTrivialRequest(request)) {
-						const derived = deriveRequest(summary);
-						if (derived) request = derived;
-					}
-
-					const body = summaryBody(summary);
-					if (body && !isLowSignalObservation(firstSentence(body))) {
-						store.remember(
-							sessionId,
-							"change",
-							request || "Session summary",
-							body,
-							0.3,
-							undefined,
-							{
-								is_summary: true,
-								request,
-								investigated: summary.investigated,
-								learned: summary.learned,
-								completed: summary.completed,
-								next_steps: summary.nextSteps,
-								notes: summary.notes,
-								prompt_number: promptNumber,
-								files_read: summary.filesRead,
-								files_modified: summary.filesModified,
-								source: "observer_summary",
-							},
-						);
-					}
-				}
+			if (summaryToStore) {
+				const { summary, request, body } = summaryToStore;
+				store.remember(sessionId, "change", request || "Session summary", body, 0.3, undefined, {
+					is_summary: true,
+					request,
+					investigated: summary.investigated,
+					learned: summary.learned,
+					completed: summary.completed,
+					next_steps: summary.nextSteps,
+					notes: summary.notes,
+					prompt_number: promptNumber,
+					files_read: summary.filesRead,
+					files_modified: summary.filesModified,
+					source: "observer_summary",
+				});
 			}
 
 			// ------------------------------------------------------------------
@@ -431,8 +440,8 @@ export async function ingest(
 					created_at: new Date().toISOString(),
 					metadata_json: toJson({
 						project,
-						observation_count: parsed.observations.length,
-						has_summary: parsed.summary != null,
+						observation_count: observationsToStore.length,
+						has_summary: summaryToStore != null,
 						provider: response.provider,
 						model: response.model,
 						session_usage_tokens: usageTokenTotal,

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -45,7 +45,10 @@ function summarizeFlushFailure(exc: Error, provider: string | null | undefined):
 	if (exc.name === "TimeoutError" || rawMessage.includes("timeout")) {
 		return `${providerTitle} request timed out during raw-event processing.`;
 	}
-	if (rawMessage === "observer failed during raw-event flush") {
+	if (
+		rawMessage === "observer failed during raw-event flush" ||
+		rawMessage === "observer produced no storable output for raw-event flush"
+	) {
 		return `${providerTitle} returned no usable output for raw-event processing.`;
 	}
 	if (/parse|xml|json/i.test(rawMessage)) {
@@ -138,6 +141,7 @@ export interface FlushRawEventsOptions {
 	project?: string | null;
 	startedAt?: string | null;
 	maxEvents?: number | null;
+	allowEmptyFlush?: boolean;
 }
 
 /**
@@ -158,6 +162,7 @@ export async function flushRawEvents(
 ): Promise<{ flushed: number; updatedState: number }> {
 	let { source = "opencode", cwd, project, startedAt } = opts;
 	const { opencodeSessionId, maxEvents } = opts;
+	const allowEmptyFlush = opts.allowEmptyFlush ?? false;
 
 	source = (source ?? "").trim().toLowerCase() || "opencode";
 
@@ -244,6 +249,14 @@ export async function flushRawEvents(
 	} catch (exc) {
 		// Record failure details on the batch
 		const err = exc instanceof Error ? exc : new Error(String(exc));
+		if (
+			allowEmptyFlush &&
+			err.message === "observer produced no storable output for raw-event flush"
+		) {
+			store.updateRawEventFlushBatchStatus(batchId, "completed");
+			store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
+			return { flushed: events.length, updatedState: 1 };
+		}
 		const provider = ingestOpts.observer?.getStatus?.()?.provider as string | undefined;
 		const message = truncateErrorMessage(summarizeFlushFailure(err, provider));
 		store.recordRawEventFlushBatchFailure(batchId, {

--- a/packages/core/src/raw-event-sweeper.test.ts
+++ b/packages/core/src/raw-event-sweeper.test.ts
@@ -224,4 +224,33 @@ describe("RawEventSweeper auto flush", () => {
 
 		expect(store.rawEventFlushState("sess-auto")).toBe(1);
 	});
+
+	it("advances flush cursor when observer output has no storable memories", async () => {
+		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
+		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
+		seedSession("sess-low-signal");
+
+		const sweeper = new RawEventSweeper(store, {
+			observer: {
+				observe: async () => ({
+					raw: '<skip_summary reason="low-signal"/>',
+					parsed: null,
+					provider: "test",
+					model: "test",
+				}),
+				getStatus: () => ({
+					provider: "test",
+					model: "test",
+					runtime: "api_http",
+					auth: { source: "test", type: "api_direct", hasToken: true },
+				}),
+			} as never,
+		});
+
+		sweeper.nudge("sess-low-signal");
+		await sleep(150);
+
+		expect(store.rawEventFlushState("sess-low-signal")).toBe(1);
+		expect(store.latestRawEventFlushFailure("opencode")).toBeNull();
+	});
 });

--- a/packages/core/src/raw-event-sweeper.ts
+++ b/packages/core/src/raw-event-sweeper.ts
@@ -286,6 +286,7 @@ export class RawEventSweeper {
 				project: null,
 				startedAt: null,
 				maxEvents: null,
+				allowEmptyFlush: true,
 			});
 		} catch (exc) {
 			if (exc instanceof ObserverAuthError) {
@@ -411,6 +412,7 @@ export class RawEventSweeper {
 					project: null,
 					startedAt: null,
 					maxEvents,
+					allowEmptyFlush: true,
 				});
 				drained.add(`${source}:${streamId}`);
 			} catch (exc) {
@@ -445,6 +447,7 @@ export class RawEventSweeper {
 					project: null,
 					startedAt: null,
 					maxEvents,
+					allowEmptyFlush: true,
 				});
 			} catch (exc) {
 				if (exc instanceof ObserverAuthError) {


### PR DESCRIPTION
## Description
Fixes a raw-event flush data-loss-class path where micro-batches could advance `last_flushed_event_seq` despite yielding zero storable memories.

- Adds a raw-event flush guard in `ingest()` that throws when observer output produces no storable observation/summary records.
- Refactors ingest post-parse flow to compute storable observations/summaries before transaction commit and uses those values in usage metadata.
- Extends flush failure summarization to classify this new guard as "no usable output" for consistent operator messaging.
- Adds regression tests covering:
  - raw-event flush ingest rejecting low-signal/no-storable observer output
  - sweeper keeping flush cursor pinned and recording batch failure in that scenario.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`vitest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:
- `pnpm exec vitest run packages/core/src/ingest-pipeline.test.ts packages/core/src/raw-event-sweeper.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Code follows project style checks for this change set (`pnpm run typecheck`)
- [x] Self-review completed
- [x] Documentation updated (if needed) (not needed for this PR)
- [x] No new warnings introduced