### PR TITLE
feat(pack): use semantic candidate merging in CLI and viewer pack flows

### DIFF
--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -153,7 +153,7 @@ function createInjectMemoryCommand(): Command {
 		.allowUnknownOption(true)
 		.allowExcessArguments(true)
 		.action(
-			(
+			async (
 				context: string,
 				opts: {
 					db?: string;
@@ -180,7 +180,7 @@ function createInjectMemoryCommand(): Command {
 					if ((opts.workingSetFile?.length ?? 0) > 0) {
 						filters.working_set_paths = opts.workingSetFile;
 					}
-					const pack = store.buildMemoryPack(context, limit, budget, filters);
+					const pack = await store.buildMemoryPackAsync(context, limit, budget, filters);
 					console.log(pack.pack_text ?? "");
 				} finally {
 					store.close();

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -26,7 +26,7 @@ export const packCommand = new Command("pack")
 	.option("--all-projects", "search across all projects")
 	.option("--json", "output as JSON")
 	.action(
-		(
+		async (
 			context: string,
 			opts: {
 				db?: string;
@@ -54,7 +54,7 @@ export const packCommand = new Command("pack")
 				if ((opts.workingSetFile?.length ?? 0) > 0) {
 					filters.working_set_paths = opts.workingSetFile;
 				}
-				const result = store.buildMemoryPack(context, limit, budget, filters);
+				const result = await store.buildMemoryPackAsync(context, limit, budget, filters);
 
 				if (opts.json) {
 					console.log(JSON.stringify(result, null, 2));

--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -6,6 +6,7 @@ import { connect } from "./db.js";
 import { buildMemoryPack, estimateTokens } from "./pack.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
+import type { MemoryResult } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Unit tests: estimateTokens
@@ -170,5 +171,47 @@ describe("buildMemoryPack", () => {
 		expect(item).toHaveProperty("confidence");
 		expect(item).toHaveProperty("tags");
 		expect(item).toHaveProperty("metadata");
+	});
+
+	it("keeps working-set overlaps prioritized when semantic candidates are merged", () => {
+		const semanticResults: MemoryResult[] = [
+			{
+				id: 1,
+				kind: "feature",
+				title: "Overlapping file",
+				body_text: "Directly related to current file",
+				confidence: 0.9,
+				created_at: "2026-01-01T00:00:00.000Z",
+				updated_at: "2026-01-01T00:00:00.000Z",
+				tags_text: "",
+				score: 0.22,
+				session_id: sessionId,
+				metadata: { files_modified: ["src/important.ts"] },
+			},
+			{
+				id: 2,
+				kind: "feature",
+				title: "Non-overlapping file",
+				body_text: "Not tied to working set",
+				confidence: 0.9,
+				created_at: "2026-01-01T00:00:00.000Z",
+				updated_at: "2026-01-01T00:00:00.000Z",
+				tags_text: "",
+				score: 0.25,
+				session_id: sessionId,
+				metadata: { files_modified: ["src/other.ts"] },
+			},
+		];
+
+		const pack = buildMemoryPack(
+			store,
+			"zzz_nomatch_zzz",
+			10,
+			null,
+			{ working_set_paths: ["src/important.ts"] },
+			semanticResults,
+		);
+
+		expect(pack.item_ids[0]).toBe(1);
 	});
 });

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -16,7 +16,7 @@
 
 import type { Database } from "./db.js";
 import type { StoreHandle } from "./search.js";
-import { search } from "./search.js";
+import { rerankResults, search } from "./search.js";
 import type { MemoryFilters, MemoryResult, PackItem, PackResponse } from "./types.js";
 import { semanticSearch } from "./vectors.js";
 
@@ -187,9 +187,11 @@ function countOverlap(tags: string, tokens: Set<string>): number {
  * Matches Python's always-merge behavior when semantic results are available.
  */
 function mergeResults(
+	store: StoreHandle,
 	ftsResults: MemoryResult[],
 	semanticResults: MemoryResult[],
 	limit: number,
+	filters?: MemoryFilters,
 ): { merged: MemoryResult[]; ftsCount: number; semanticCount: number } {
 	const seen = new Map<number, MemoryResult>();
 	for (const r of ftsResults) {
@@ -202,8 +204,7 @@ function mergeResults(
 		const existing = seen.get(r.id);
 		if (!existing || r.score > existing.score) seen.set(r.id, r);
 	}
-	// Sort by score descending, then truncate to limit
-	const merged = [...seen.values()].sort((a, b) => b.score - a.score).slice(0, limit);
+	const merged = rerankResults(store, [...seen.values()], limit, filters);
 	return { merged, ftsCount: ftsResults.length, semanticCount };
 }
 
@@ -226,7 +227,7 @@ export function buildMemoryPack(
 	// Step 1b: merge semantic candidates when provided
 	let results: MemoryResult[];
 	if (semanticResults && semanticResults.length > 0) {
-		const merge = mergeResults(ftsResults, semanticResults, effectiveLimit);
+		const merge = mergeResults(store, ftsResults, semanticResults, effectiveLimit, filters);
 		results = merge.merged;
 		ftsCount = merge.ftsCount;
 		semanticCount = merge.semanticCount;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -388,6 +388,44 @@ describe("viewer-server", () => {
 		});
 	});
 
+	describe("GET /api/pack", () => {
+		it("uses async pack builder path", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+
+				const expected = {
+					context: "semantic context",
+					items: [],
+					item_ids: [],
+					pack_text: "",
+					metrics: {
+						total_items: 0,
+						pack_tokens: 0,
+						fallback_used: true,
+						sources: { fts: 0, semantic: 0, fuzzy: 0 },
+					},
+				};
+
+				const asyncSpy = vi.spyOn(store, "buildMemoryPackAsync").mockResolvedValue(expected);
+				const syncSpy = vi.spyOn(store, "buildMemoryPack").mockImplementation(() => {
+					throw new Error("sync pack builder should not be called");
+				});
+
+				const res = await app.request("/api/pack?context=semantic%20context");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toEqual(expected);
+				expect(asyncSpy).toHaveBeenCalledTimes(1);
+				expect(syncSpy).not.toHaveBeenCalled();
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
 	describe("GET /api/observer-status", () => {
 		it("returns live observer status and suppresses stale failures after success", async () => {
 			const { store, cleanup } = createTestStore();

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -323,7 +323,7 @@ export function memoryRoutes(getStore: StoreFactory) {
 	});
 
 	// GET /api/pack
-	app.get("/api/pack", (c) => {
+	app.get("/api/pack", async (c) => {
 		const store = getStore();
 		{
 			const context = c.req.query("context") || "";
@@ -340,9 +340,9 @@ export function memoryRoutes(getStore: StoreFactory) {
 				}
 			}
 			const project = c.req.query("project") || undefined;
-			const filters: Record<string, unknown> = {};
+			const filters: { project?: string } = {};
 			if (project) filters.project = project;
-			const pack = store.buildMemoryPack(context, limit, tokenBudget ?? null, filters);
+			const pack = await store.buildMemoryPackAsync(context, limit, tokenBudget ?? null, filters);
 			return c.json(pack);
 		}
 	});


### PR DESCRIPTION
## Description
- Switch CLI pack flows (`codemem pack` and `codemem memory inject`) to use `buildMemoryPackAsync()` so semantic/vector candidates are merged by default when embeddings are available.
- Switch viewer `/api/pack` route to use the same async semantic-aware pack builder for parity with MCP behavior.
- Add a viewer-server route test that asserts `/api/pack` uses the async path (and does not call the sync builder).

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `pnpm run test -- packages/viewer-server/src/index.test.ts packages/cli/src/commands/memory.test.ts`
- `pnpm run typecheck`
- `pnpm exec biome check packages/cli/src/commands/pack.ts packages/cli/src/commands/memory.ts packages/viewer-server/src/routes/memory.ts packages/viewer-server/src/index.test.ts`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
