### PR TITLE
feat(vectors): trigger memory vector writes on remember

### DIFF
--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -69,7 +69,7 @@ interface RememberMemoryOptions {
 	dbPath?: string;
 }
 
-function rememberMemoryAction(opts: RememberMemoryOptions): void {
+async function rememberMemoryAction(opts: RememberMemoryOptions): Promise<void> {
 	const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 	let sessionId: number | null = null;
 	try {
@@ -82,6 +82,7 @@ function rememberMemoryAction(opts: RememberMemoryOptions): void {
 			metadata: { manual: true },
 		});
 		const memId = store.remember(sessionId, opts.kind, opts.title, opts.body, 0.5, opts.tags);
+		await store.flushPendingVectorWrites();
 		store.endSession(sessionId, { manual: true });
 		p.log.success(`Stored memory ${memId}`);
 	} catch (err) {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -54,6 +54,7 @@ import type { ObserverClient } from "./observer-client.js";
 import { resolveProject } from "./project.js";
 import * as schema from "./schema.js";
 import type { MemoryStore } from "./store.js";
+import { storeVectors } from "./vectors.js";
 
 // ---------------------------------------------------------------------------
 // Allowed memory kinds (matches Python)
@@ -378,6 +379,8 @@ export async function ingest(
 			}
 		}
 
+		const vectorWriteInputs: Array<{ memoryId: number; title: string; bodyText: string }> = [];
+
 		// Persist all observations, summary, and usage atomically
 		store.db.transaction(() => {
 			// ------------------------------------------------------------------
@@ -393,7 +396,8 @@ export async function ingest(
 				}
 				const bodyText = bodyParts.join("\n\n");
 
-				store.remember(sessionId, kind, obs.title || obs.narrative, bodyText, 0.5, undefined, {
+				const memoryTitle = obs.title || obs.narrative;
+				const memoryId = store.remember(sessionId, kind, memoryTitle, bodyText, 0.5, undefined, {
 					subtitle: obs.subtitle,
 					facts: obs.facts,
 					concepts: obs.concepts,
@@ -402,6 +406,7 @@ export async function ingest(
 					prompt_number: promptNumber,
 					source: "observer",
 				});
+				vectorWriteInputs.push({ memoryId, title: memoryTitle, bodyText });
 			}
 
 			// ------------------------------------------------------------------
@@ -409,7 +414,8 @@ export async function ingest(
 			// ------------------------------------------------------------------
 			if (summaryToStore) {
 				const { summary, request, body } = summaryToStore;
-				store.remember(sessionId, "change", request || "Session summary", body, 0.3, undefined, {
+				const summaryTitle = request || "Session summary";
+				const memoryId = store.remember(sessionId, "change", summaryTitle, body, 0.3, undefined, {
 					is_summary: true,
 					request,
 					investigated: summary.investigated,
@@ -422,6 +428,7 @@ export async function ingest(
 					files_modified: summary.filesModified,
 					source: "observer_summary",
 				});
+				vectorWriteInputs.push({ memoryId, title: summaryTitle, bodyText: body });
 			}
 
 			// ------------------------------------------------------------------
@@ -449,6 +456,14 @@ export async function ingest(
 				})
 				.run();
 		})();
+
+		for (const input of vectorWriteInputs) {
+			try {
+				await storeVectors(store.db, input.memoryId, input.title, input.bodyText);
+			} catch {
+				// Non-fatal — ingestion should not fail when embeddings are unavailable
+			}
+		}
 
 		// ------------------------------------------------------------------
 		// End session

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1,11 +1,12 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { connect } from "./db.js";
 import { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
+import * as vectors from "./vectors.js";
 
 // ---------------------------------------------------------------------------
 // Helper: create a MemoryStore backed by a temp DB with test schema.
@@ -204,6 +205,52 @@ describe("MemoryStore", () => {
 
 			const row = store.get(memId);
 			expect(row?.tags_text).toBe("alpha beta");
+		});
+
+		it("kicks off vector storage after remembering a memory", () => {
+			const storeVectorsSpy = vi.spyOn(vectors, "storeVectors").mockResolvedValue();
+			try {
+				const sessionId = insertTestSession(store.db);
+				const memId = store.remember(sessionId, "feature", "Vector title", "Vector body");
+
+				expect(storeVectorsSpy).toHaveBeenCalledTimes(1);
+				expect(storeVectorsSpy).toHaveBeenCalledWith(
+					store.db,
+					memId,
+					"Vector title",
+					"Vector body",
+				);
+			} finally {
+				storeVectorsSpy.mockRestore();
+			}
+		});
+
+		it("does not fail remember when vector storage fails", () => {
+			const storeVectorsSpy = vi
+				.spyOn(vectors, "storeVectors")
+				.mockRejectedValue(new Error("embedding unavailable"));
+			try {
+				const sessionId = insertTestSession(store.db);
+				expect(() =>
+					store.remember(sessionId, "feature", "Resilient title", "Resilient body"),
+				).not.toThrow();
+			} finally {
+				storeVectorsSpy.mockRestore();
+			}
+		});
+
+		it("does not launch vector writes from inside an open transaction", () => {
+			const storeVectorsSpy = vi.spyOn(vectors, "storeVectors").mockResolvedValue();
+			try {
+				const sessionId = insertTestSession(store.db);
+				store.db.transaction(() => {
+					store.remember(sessionId, "feature", "Tx title", "Tx body");
+					expect(storeVectorsSpy).not.toHaveBeenCalled();
+				})();
+				expect(storeVectorsSpy).not.toHaveBeenCalled();
+			} finally {
+				storeVectorsSpy.mockRestore();
+			}
 		});
 	});
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -50,6 +50,7 @@ import type {
 	StoreStats,
 	TimelineItemResponse,
 } from "./types.js";
+import { storeVectors } from "./vectors.js";
 
 // Memory kind validation (mirrors codemem/memory_kinds.py)
 
@@ -130,6 +131,7 @@ export class MemoryStore {
 	readonly deviceId: string;
 	readonly actorId: string;
 	readonly actorDisplayName: string;
+	private readonly pendingVectorWrites = new Set<Promise<void>>();
 
 	/** Lazy Drizzle ORM wrapper — shares the same better-sqlite3 connection. */
 	private _drizzle: ReturnType<typeof drizzle> | null = null;
@@ -184,6 +186,24 @@ export class MemoryStore {
 			: (cleanStr(config.actor_display_name) ?? null);
 		this.actorDisplayName =
 			configDisplayName || process.env.USER?.trim() || process.env.USERNAME?.trim() || this.actorId;
+	}
+
+	private enqueueVectorWrite(memoryId: number, title: string, bodyText: string): void {
+		if (this.db.inTransaction) return;
+		let op: Promise<void> | null = null;
+		op = storeVectors(this.db, memoryId, title, bodyText)
+			.catch(() => {
+				// Non-fatal — keep memory writes resilient when embeddings are unavailable
+			})
+			.finally(() => {
+				if (op) this.pendingVectorWrites.delete(op);
+			});
+		this.pendingVectorWrites.add(op);
+	}
+
+	async flushPendingVectorWrites(): Promise<void> {
+		if (this.pendingVectorWrites.size === 0) return;
+		await Promise.allSettled([...this.pendingVectorWrites]);
 	}
 
 	// get
@@ -355,6 +375,8 @@ export class MemoryStore {
 		} catch {
 			// Non-fatal — don't block memory creation
 		}
+
+		this.enqueueVectorWrite(memoryId, title, bodyText);
 
 		return memoryId;
 	}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -16,6 +16,7 @@ import {
 	MemoryStore,
 	projectClause,
 	resolveDbPath,
+	storeVectors,
 	toJson,
 	VERSION,
 } from "@codemem/core";
@@ -505,10 +506,16 @@ async function main() {
 						.prepare("UPDATE sessions SET ended_at = ?, metadata_json = ? WHERE id = ?")
 						.run(nowIso(), toJson({ mcp: true }), sessionId);
 
-					return memId;
+					return { memId, title: args.title, body: args.body };
 				})();
 
-				return jsonContent({ id: result });
+				try {
+					await storeVectors(store.db, result.memId, result.title, result.body);
+				} catch {
+					// Non-fatal — memory writes should succeed even if embeddings are unavailable
+				}
+
+				return jsonContent({ id: result.memId });
 			} catch (err) {
 				return errorContent(err instanceof Error ? err.message : String(err));
 			}


### PR DESCRIPTION
## Description
- Wire memory creation to trigger vector storage: `MemoryStore.remember()` now starts `storeVectors(...)` after a successful insert.
- Keep writes resilient by treating embedding/vector failures as non-fatal (memory insert still succeeds).
- Add store tests proving vector write is invoked and failures do not break `remember()`.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `pnpm run test -- packages/core/src/store.test.ts packages/core/src/pack.test.ts`
- `pnpm run typecheck`
- `pnpm exec biome check packages/core/src/store.ts packages/core/src/store.test.ts packages/core/src/pack.ts packages/core/src/pack.test.ts`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
