### PR TITLE
feat(cli): add embed command for vector backfill parity

### DIFF
--- a/packages/cli/src/commands/embed.test.ts
+++ b/packages/cli/src/commands/embed.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { embedCommand, resolveEmbedProjectScope } from "./embed.js";
+
+const prevProject = process.env.CODEMEM_PROJECT;
+
+afterEach(() => {
+	if (prevProject === undefined) delete process.env.CODEMEM_PROJECT;
+	else process.env.CODEMEM_PROJECT = prevProject;
+});
+
+describe("embed command", () => {
+	it("registers expected options for vector backfill", () => {
+		const longs = embedCommand.options.map((option) => option.long);
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--limit");
+		expect(longs).toContain("--since");
+		expect(longs).toContain("--project");
+		expect(longs).toContain("--all-projects");
+		expect(longs).toContain("--inactive");
+		expect(longs).toContain("--dry-run");
+		expect(longs).toContain("--json");
+	});
+
+	it("documents embed backfill behavior in help output", () => {
+		const help = embedCommand.helpInformation();
+		expect(help).toContain("Backfill semantic embeddings");
+		expect(help).toContain("--all-projects");
+		expect(help).toContain("--dry-run");
+	});
+
+	it("prefers explicit --project over CODEMEM_PROJECT", () => {
+		process.env.CODEMEM_PROJECT = "env-project";
+		expect(resolveEmbedProjectScope("/tmp", "cli-project", false)).toBe("cli-project");
+	});
+
+	it("supports all-projects override", () => {
+		process.env.CODEMEM_PROJECT = "env-project";
+		expect(resolveEmbedProjectScope("/tmp", "cli-project", true)).toBeNull();
+	});
+});

--- a/packages/cli/src/commands/embed.ts
+++ b/packages/cli/src/commands/embed.ts
@@ -1,0 +1,83 @@
+import * as p from "@clack/prompts";
+import { backfillVectors, MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+
+function parseOptionalPositiveInt(value: string | undefined): number | undefined {
+	if (!value) return undefined;
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(`invalid positive integer: ${value}`);
+	}
+	return parsed;
+}
+
+export function resolveEmbedProjectScope(
+	cwd: string,
+	projectOpt: string | undefined,
+	allProjects: boolean | undefined,
+): string | null {
+	if (allProjects === true) return null;
+	const explicit = projectOpt?.trim();
+	if (explicit) return explicit;
+	const envProject = process.env.CODEMEM_PROJECT?.trim();
+	if (envProject) return envProject;
+	return resolveProject(cwd, null);
+}
+
+export const embedCommand = new Command("embed")
+	.configureHelp(helpStyle)
+	.description("Backfill semantic embeddings")
+	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+	.option("--limit <n>", "max memories to check")
+	.option("--since <iso>", "only memories created at/after this ISO timestamp")
+	.option("--project <project>", "project identifier (defaults to git repo root)")
+	.option("--all-projects", "embed across all projects")
+	.option("--inactive", "include inactive memories")
+	.option("--dry-run", "preview work without writing vectors")
+	.option("--json", "output as JSON")
+	.action(
+		async (opts: {
+			db?: string;
+			dbPath?: string;
+			limit?: string;
+			since?: string;
+			project?: string;
+			allProjects?: boolean;
+			inactive?: boolean;
+			dryRun?: boolean;
+			json?: boolean;
+		}) => {
+			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+			try {
+				const limit = parseOptionalPositiveInt(opts.limit);
+				const project = resolveEmbedProjectScope(process.cwd(), opts.project, opts.allProjects);
+
+				const result = await backfillVectors(store.db, {
+					limit,
+					since: opts.since ?? null,
+					project,
+					activeOnly: !opts.inactive,
+					dryRun: opts.dryRun === true,
+				});
+
+				if (opts.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+
+				const action = opts.dryRun ? "Would embed" : "Embedded";
+				p.intro("codemem embed");
+				p.log.success(
+					`${action} ${result.embedded} vectors (${result.inserted} inserted, ${result.skipped} skipped)`,
+				);
+				p.outro(`Checked ${result.checked} memories`);
+			} catch (error) {
+				p.log.error(error instanceof Error ? error.message : String(error));
+				process.exitCode = 1;
+			} finally {
+				store.close();
+			}
+		},
+	);

--- a/packages/cli/src/index.smoke.test.ts
+++ b/packages/cli/src/index.smoke.test.ts
@@ -37,6 +37,7 @@ describe("cli smoke", () => {
 		expect(result.stdout).toContain("persistent memory for AI coding agents");
 		expect(result.stdout).toContain("serve");
 		expect(result.stdout).toContain("search");
+		expect(result.stdout).toContain("embed");
 	});
 
 	it("prints the current version", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import { Command } from "commander";
 import omelette from "omelette";
 import { claudeHookIngestCommand } from "./commands/claude-hook-ingest.js";
 import { dbCommand } from "./commands/db.js";
+import { embedCommand } from "./commands/embed.js";
 import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
 import { exportMemoriesCommand } from "./commands/export-memories.js";
 import { importMemoriesCommand } from "./commands/import-memories.js";
@@ -42,6 +43,7 @@ completion.on("command", ({ reply }) => {
 	reply([
 		"claude-hook-ingest",
 		"db",
+		"embed",
 		"export-memories",
 		"forget",
 		"memory",
@@ -99,6 +101,7 @@ program.addCommand(dbCommand);
 program.addCommand(exportMemoriesCommand);
 program.addCommand(importMemoriesCommand);
 program.addCommand(statsCommand);
+program.addCommand(embedCommand);
 program.addCommand(recentCommand);
 program.addCommand(searchCommand);
 program.addCommand(packCommand);


### PR DESCRIPTION
## Description
- Add `codemem embed` to the TypeScript CLI so users can backfill semantic vectors for existing memories (parity with documented behavior and Python command surface).
- Wire embed command into top-level command registration and shell completion.
- Add CLI tests for embed command option surface/help text and ensure top-level help advertises `embed`.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `pnpm run test -- packages/cli/src/commands/embed.test.ts packages/cli/src/index.smoke.test.ts`
- `pnpm run typecheck`
- `pnpm exec biome check packages/cli/src/commands/embed.ts packages/cli/src/commands/embed.test.ts packages/cli/src/index.ts packages/cli/src/index.smoke.test.ts`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
