### PR TITLE
feat(db): add backfill-tags maintenance command in TS CLI

### DIFF
--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { dbCommand } from "./db.js";
+
+describe("db command", () => {
+	it("registers backfill-tags maintenance subcommand", () => {
+		const backfill = dbCommand.commands.find((command) => command.name() === "backfill-tags");
+		expect(backfill).toBeDefined();
+		const longs = backfill?.options.map((option) => option.long) ?? [];
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--limit");
+		expect(longs).toContain("--since");
+		expect(longs).toContain("--project");
+		expect(longs).toContain("--all-projects");
+		expect(longs).toContain("--inactive");
+		expect(longs).toContain("--dry-run");
+		expect(longs).toContain("--json");
+	});
+});

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -1,12 +1,14 @@
 import { statSync } from "node:fs";
 import * as p from "@clack/prompts";
 import {
+	backfillTagsText,
 	connect,
 	getRawEventStatus,
 	initDatabase,
 	MemoryStore,
 	rawEventsGate,
 	resolveDbPath,
+	resolveProject,
 	retryRawEventFailures,
 	vacuumDatabase,
 } from "@codemem/core";
@@ -17,6 +19,15 @@ function formatBytes(bytes: number): string {
 	if (bytes < 1024) return `${bytes} B`;
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function parseOptionalPositiveInt(value: string | undefined): number | undefined {
+	if (!value) return undefined;
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(`invalid positive integer: ${value}`);
+	}
+	return parsed;
 }
 
 export const dbCommand = new Command("db")
@@ -366,4 +377,64 @@ dbCommand
 					db.close();
 				}
 			}),
+	)
+	.addCommand(
+		new Command("backfill-tags")
+			.configureHelp(helpStyle)
+			.description("Populate tags_text for memories where tags are empty")
+			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--limit <n>", "max memories to check")
+			.option("--since <iso>", "only memories created at/after this ISO timestamp")
+			.option("--project <project>", "project identifier (defaults to git repo root)")
+			.option("--all-projects", "backfill across all projects")
+			.option("--inactive", "include inactive memories")
+			.option("--dry-run", "preview updates without writing")
+			.option("--json", "output as JSON")
+			.action(
+				(opts: {
+					db?: string;
+					dbPath?: string;
+					limit?: string;
+					since?: string;
+					project?: string;
+					allProjects?: boolean;
+					inactive?: boolean;
+					dryRun?: boolean;
+					json?: boolean;
+				}) => {
+					const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+					try {
+						const limit = parseOptionalPositiveInt(opts.limit);
+						const project =
+							opts.allProjects === true
+								? null
+								: opts.project?.trim() ||
+									process.env.CODEMEM_PROJECT?.trim() ||
+									resolveProject(process.cwd(), null);
+						const result = backfillTagsText(store.db, {
+							limit,
+							since: opts.since ?? null,
+							project,
+							activeOnly: !opts.inactive,
+							dryRun: opts.dryRun === true,
+						});
+
+						if (opts.json) {
+							console.log(JSON.stringify(result, null, 2));
+							return;
+						}
+
+						const action = opts.dryRun ? "Would update" : "Updated";
+						p.intro("codemem db backfill-tags");
+						p.log.success(`${action} ${result.updated} memories (skipped ${result.skipped})`);
+						p.outro(`Checked ${result.checked} memories`);
+					} catch (error) {
+						p.log.error(error instanceof Error ? error.message : String(error));
+						process.exitCode = 1;
+					} finally {
+						store.close();
+					}
+				},
+			),
 	);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,12 +127,15 @@ export type {
 export { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-parser.js";
 export { parsePositiveMemoryId, parseStrictInteger } from "./integers.js";
 export type {
+	BackfillTagsTextOptions,
+	BackfillTagsTextResult,
 	GateResult,
 	RawEventStatusItem,
 	RawEventStatusResult,
 	ReliabilityMetrics,
 } from "./maintenance.js";
 export {
+	backfillTagsText,
 	getRawEventStatus,
 	getReliabilityMetrics,
 	initDatabase,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import {
+	backfillTagsText,
 	getRawEventStatus,
 	getReliabilityMetrics,
 	initDatabase,
@@ -126,5 +127,68 @@ describe("maintenance", () => {
 
 		const metrics = getReliabilityMetrics(dbPath);
 		expect(metrics.counts.retry_depth_max).toBe(3);
+	});
+
+	it("backfills tags_text for memories with empty tags", () => {
+		const dbPath = createDbPath("backfill-tags");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, cwd, project, user, tool_version) VALUES
+				  (1, '2026-03-01T10:00:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, tags_text, active,
+					created_at, updated_at, concepts, files_modified, import_key
+				) VALUES
+					(1, 1, 'feature', 'Auth login flow', 'body', '', 1,
+					 '2026-03-01T10:00:00Z', '2026-03-01T10:00:00Z', '["authentication"]', '["src/auth/login.ts"]', 'k1');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const dbRw = new Database(dbPath);
+		try {
+			const result = backfillTagsText(dbRw, {});
+			expect(result).toEqual({ checked: 1, updated: 1, skipped: 0 });
+
+			const row = dbRw.prepare("SELECT tags_text FROM memory_items WHERE id = 1").get() as {
+				tags_text: string;
+			};
+			expect(row.tags_text).toContain("feature");
+			expect(row.tags_text).toContain("authentication");
+			expect(row.tags_text).toContain("login-ts");
+		} finally {
+			dbRw.close();
+		}
+	});
+
+	it("supports backfill-tags dry-run mode", () => {
+		const dbPath = createDbPath("backfill-tags-dry-run");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, cwd, project, user, tool_version) VALUES
+				  (1, '2026-03-01T10:00:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, tags_text, active,
+					created_at, updated_at, import_key
+				) VALUES
+					(1, 1, 'feature', 'Needs tags', 'body', '', 1,
+					 '2026-03-01T10:00:00Z', '2026-03-01T10:00:00Z', 'k1');
+			`);
+
+			const result = backfillTagsText(db, { dryRun: true });
+			expect(result).toEqual({ checked: 1, updated: 1, skipped: 0 });
+
+			const row = db.prepare("SELECT tags_text FROM memory_items WHERE id = 1").get() as {
+				tags_text: string;
+			};
+			expect(row.tags_text).toBe("");
+		} finally {
+			db.close();
+		}
 	});
 });

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -1,5 +1,6 @@
 import { statSync } from "node:fs";
 import { assertSchemaReady, connect, type Database, resolveDbPath } from "./db.js";
+import { projectClause } from "./project.js";
 
 export interface RawEventStatusItem {
 	source: string;
@@ -332,4 +333,197 @@ export function retryRawEventFailures(dbPath?: string, limit = 25): { retried: n
 
 		return { retried: result.changes };
 	});
+}
+
+export interface BackfillTagsTextOptions {
+	limit?: number | null;
+	since?: string | null;
+	project?: string | null;
+	activeOnly?: boolean;
+	dryRun?: boolean;
+	memoryIds?: number[] | null;
+}
+
+export interface BackfillTagsTextResult {
+	checked: number;
+	updated: number;
+	skipped: number;
+}
+
+function normalizeTag(value: string): string {
+	let normalized = value.trim().toLowerCase();
+	if (!normalized) return "";
+	normalized = normalized.replace(/[^a-z0-9_]+/g, "-");
+	normalized = normalized.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
+	if (!normalized) return "";
+	if (normalized.length > 40) normalized = normalized.slice(0, 40).replace(/-+$/g, "");
+	return normalized;
+}
+
+function fileTags(pathValue: string): string[] {
+	const raw = pathValue.trim();
+	if (!raw) return [];
+	const parts = raw.split(/[\\/]+/).filter((part) => part && part !== "." && part !== "..");
+	if (parts.length === 0) return [];
+	const tags: string[] = [];
+	const basename = normalizeTag(parts[parts.length - 1] ?? "");
+	if (basename) tags.push(basename);
+	if (parts.length >= 2) {
+		const parent = normalizeTag(parts[parts.length - 2] ?? "");
+		if (parent) tags.push(parent);
+	}
+	if (parts.length >= 3) {
+		const top = normalizeTag(parts[0] ?? "");
+		if (top) tags.push(top);
+	}
+	return tags;
+}
+
+function parseJsonStringList(value: string | null): string[] {
+	if (!value) return [];
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		return parsed
+			.map((item) => (typeof item === "string" ? item.trim() : ""))
+			.filter((item) => item.length > 0);
+	} catch {
+		return [];
+	}
+}
+
+function deriveTags(input: {
+	kind: string;
+	title: string;
+	concepts: string[];
+	filesRead: string[];
+	filesModified: string[];
+}): string[] {
+	const tags: string[] = [];
+	const kindTag = normalizeTag(input.kind);
+	if (kindTag) tags.push(kindTag);
+
+	for (const concept of input.concepts) {
+		const tag = normalizeTag(concept);
+		if (tag) tags.push(tag);
+	}
+
+	for (const filePath of [...input.filesRead, ...input.filesModified]) {
+		tags.push(...fileTags(filePath));
+	}
+
+	if (tags.length === 0 && input.title.trim()) {
+		const tokens = input.title.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
+		for (const token of tokens) {
+			const tag = normalizeTag(token);
+			if (tag) tags.push(tag);
+		}
+	}
+
+	const deduped: string[] = [];
+	const seen = new Set<string>();
+	for (const tag of tags) {
+		if (seen.has(tag)) continue;
+		seen.add(tag);
+		deduped.push(tag);
+		if (deduped.length >= 20) break;
+	}
+	return deduped;
+}
+
+/**
+ * Populate memory_items.tags_text for rows where it is empty.
+ * Port of Python's backfill_tags_text() maintenance helper.
+ */
+export function backfillTagsText(
+	db: Database,
+	opts: BackfillTagsTextOptions = {},
+): BackfillTagsTextResult {
+	const { limit, since, project, activeOnly = true, dryRun = false, memoryIds } = opts;
+
+	const params: unknown[] = [];
+	const whereClauses = ["(memory_items.tags_text IS NULL OR TRIM(memory_items.tags_text) = '')"];
+
+	if (activeOnly) whereClauses.push("memory_items.active = 1");
+	if (since) {
+		whereClauses.push("memory_items.created_at >= ?");
+		params.push(since);
+	}
+
+	let joinSessions = false;
+	if (project) {
+		const pc = projectClause(project);
+		if (pc.clause) {
+			whereClauses.push(pc.clause);
+			params.push(...pc.params);
+			joinSessions = true;
+		}
+	}
+
+	if (memoryIds && memoryIds.length > 0) {
+		const placeholders = memoryIds.map(() => "?").join(",");
+		whereClauses.push(`memory_items.id IN (${placeholders})`);
+		params.push(...memoryIds.map((id) => Number(id)));
+	}
+
+	const where = whereClauses.join(" AND ");
+	const joinClause = joinSessions ? "JOIN sessions ON sessions.id = memory_items.session_id" : "";
+	const limitClause = limit != null && limit > 0 ? "LIMIT ?" : "";
+	if (limit != null && limit > 0) params.push(limit);
+
+	const rows = db
+		.prepare(
+			`SELECT memory_items.id, memory_items.kind, memory_items.title,
+			        memory_items.concepts, memory_items.files_read, memory_items.files_modified
+			 FROM memory_items
+			 ${joinClause}
+			 WHERE ${where}
+			 ORDER BY memory_items.created_at ASC
+			 ${limitClause}`,
+		)
+		.all(...params) as Array<{
+		id: number;
+		kind: string | null;
+		title: string | null;
+		concepts: string | null;
+		files_read: string | null;
+		files_modified: string | null;
+	}>;
+
+	let checked = 0;
+	let updated = 0;
+	let skipped = 0;
+	const now = new Date().toISOString();
+	const updateStmt = db.prepare(
+		"UPDATE memory_items SET tags_text = ?, updated_at = ? WHERE id = ?",
+	);
+	const updates: Array<{ id: number; tagsText: string }> = [];
+
+	for (const row of rows) {
+		checked += 1;
+		const tags = deriveTags({
+			kind: String(row.kind ?? ""),
+			title: String(row.title ?? ""),
+			concepts: parseJsonStringList(row.concepts),
+			filesRead: parseJsonStringList(row.files_read),
+			filesModified: parseJsonStringList(row.files_modified),
+		});
+		const tagsText = tags.join(" ");
+		if (!tagsText) {
+			skipped += 1;
+			continue;
+		}
+		updates.push({ id: row.id, tagsText });
+		updated += 1;
+	}
+
+	if (!dryRun && updates.length > 0) {
+		db.transaction(() => {
+			for (const update of updates) {
+				updateStmt.run(update.tagsText, now, update.id);
+			}
+		})();
+	}
+
+	return { checked, updated, skipped };
 }


### PR DESCRIPTION
## Description
- Add a TypeScript port of the tags backfill maintenance helper in core (`backfillTagsText`) to populate `memory_items.tags_text` for rows where tags are empty.
- Add `codemem db backfill-tags` to the TS CLI with parity options (`--limit`, `--since`, `--project`, `--all-projects`, `--inactive`, `--dry-run`, `--json`).
- Add core + CLI tests to cover backfill behavior and command registration/help surface.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `pnpm run test -- packages/core/src/maintenance.test.ts packages/cli/src/commands/db.test.ts packages/cli/src/index.smoke.test.ts`
- `pnpm run typecheck`
- `pnpm exec biome check packages/core/src/maintenance.ts packages/core/src/maintenance.test.ts packages/core/src/index.ts packages/cli/src/commands/db.ts packages/cli/src/commands/db.test.ts`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
