### PR TITLE
feat(db): add prune-observations and prune-memories TS commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | `codemem search <query>` | Search memories |
 | `codemem embed` | Backfill semantic embeddings |
 | `codemem serve` | Launch the web viewer |
+| `codemem db backfill-tags` | Populate missing `tags_text` values |
+| `codemem db prune-observations` | Deactivate low-signal observations |
 | `codemem db prune-memories` | Deactivate low-signal memories (`--dry-run` to preview) |
 | `codemem export-memories` | Export memories by project |
 | `codemem import-memories` | Import memories (idempotent) |

--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -16,4 +16,22 @@ describe("db command", () => {
 		expect(longs).toContain("--dry-run");
 		expect(longs).toContain("--json");
 	});
+
+	it("registers prune-observations and prune-memories subcommands", () => {
+		const pruneObs = dbCommand.commands.find((command) => command.name() === "prune-observations");
+		const pruneMem = dbCommand.commands.find((command) => command.name() === "prune-memories");
+		expect(pruneObs).toBeDefined();
+		expect(pruneMem).toBeDefined();
+
+		const pruneObsLongs = pruneObs?.options.map((option) => option.long) ?? [];
+		expect(pruneObsLongs).toContain("--limit");
+		expect(pruneObsLongs).toContain("--dry-run");
+		expect(pruneObsLongs).toContain("--json");
+
+		const pruneMemLongs = pruneMem?.options.map((option) => option.long) ?? [];
+		expect(pruneMemLongs).toContain("--limit");
+		expect(pruneMemLongs).toContain("--kinds");
+		expect(pruneMemLongs).toContain("--dry-run");
+		expect(pruneMemLongs).toContain("--json");
+	});
 });

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -3,6 +3,8 @@ import * as p from "@clack/prompts";
 import {
 	backfillTagsText,
 	connect,
+	deactivateLowSignalMemories,
+	deactivateLowSignalObservations,
 	getRawEventStatus,
 	initDatabase,
 	MemoryStore,
@@ -28,6 +30,15 @@ function parseOptionalPositiveInt(value: string | undefined): number | undefined
 		throw new Error(`invalid positive integer: ${value}`);
 	}
 	return parsed;
+}
+
+function parseKindsCsv(value: string | undefined): string[] | undefined {
+	if (!value) return undefined;
+	const kinds = value
+		.split(",")
+		.map((kind) => kind.trim())
+		.filter((kind) => kind.length > 0);
+	return kinds.length > 0 ? kinds : undefined;
 }
 
 export const dbCommand = new Command("db")
@@ -429,6 +440,95 @@ dbCommand
 						p.intro("codemem db backfill-tags");
 						p.log.success(`${action} ${result.updated} memories (skipped ${result.skipped})`);
 						p.outro(`Checked ${result.checked} memories`);
+					} catch (error) {
+						p.log.error(error instanceof Error ? error.message : String(error));
+						process.exitCode = 1;
+					} finally {
+						store.close();
+					}
+				},
+			),
+	)
+	.addCommand(
+		new Command("prune-observations")
+			.configureHelp(helpStyle)
+			.description("Deactivate low-signal observations (does not delete rows)")
+			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--limit <n>", "max observations to check")
+			.option("--dry-run", "preview deactivations without writing")
+			.option("--json", "output as JSON")
+			.action(
+				(opts: {
+					db?: string;
+					dbPath?: string;
+					limit?: string;
+					dryRun?: boolean;
+					json?: boolean;
+				}) => {
+					const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+					try {
+						const limit = parseOptionalPositiveInt(opts.limit);
+						const result = deactivateLowSignalObservations(
+							store.db,
+							limit ?? null,
+							opts.dryRun === true,
+						);
+
+						if (opts.json) {
+							console.log(JSON.stringify(result, null, 2));
+							return;
+						}
+
+						const action = opts.dryRun ? "Would deactivate" : "Deactivated";
+						p.intro("codemem db prune-observations");
+						p.outro(`${action} ${result.deactivated} of ${result.checked} observations`);
+					} catch (error) {
+						p.log.error(error instanceof Error ? error.message : String(error));
+						process.exitCode = 1;
+					} finally {
+						store.close();
+					}
+				},
+			),
+	)
+	.addCommand(
+		new Command("prune-memories")
+			.configureHelp(helpStyle)
+			.description("Deactivate low-signal memories across selected kinds")
+			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+			.option("--limit <n>", "max memories to check")
+			.option("--kinds <csv>", "comma-separated memory kinds (default set when omitted)")
+			.option("--dry-run", "preview deactivations without writing")
+			.option("--json", "output as JSON")
+			.action(
+				(opts: {
+					db?: string;
+					dbPath?: string;
+					limit?: string;
+					kinds?: string;
+					dryRun?: boolean;
+					json?: boolean;
+				}) => {
+					const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+					try {
+						const limit = parseOptionalPositiveInt(opts.limit);
+						const kinds = parseKindsCsv(opts.kinds);
+						const result = deactivateLowSignalMemories(store.db, {
+							kinds,
+							limit: limit ?? null,
+							dryRun: opts.dryRun === true,
+						});
+
+						if (opts.json) {
+							console.log(JSON.stringify(result, null, 2));
+							return;
+						}
+
+						const action = opts.dryRun ? "Would deactivate" : "Deactivated";
+						p.intro("codemem db prune-memories");
+						p.outro(`${action} ${result.deactivated} of ${result.checked} memories`);
 					} catch (error) {
 						p.log.error(error instanceof Error ? error.message : String(error));
 						process.exitCode = 1;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -129,6 +129,8 @@ export { parsePositiveMemoryId, parseStrictInteger } from "./integers.js";
 export type {
 	BackfillTagsTextOptions,
 	BackfillTagsTextResult,
+	DeactivateLowSignalMemoriesOptions,
+	DeactivateLowSignalResult,
 	GateResult,
 	RawEventStatusItem,
 	RawEventStatusResult,
@@ -136,6 +138,8 @@ export type {
 } from "./maintenance.js";
 export {
 	backfillTagsText,
+	deactivateLowSignalMemories,
+	deactivateLowSignalObservations,
 	getRawEventStatus,
 	getReliabilityMetrics,
 	initDatabase,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -5,6 +5,8 @@ import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import {
 	backfillTagsText,
+	deactivateLowSignalMemories,
+	deactivateLowSignalObservations,
 	getRawEventStatus,
 	getReliabilityMetrics,
 	initDatabase,
@@ -187,6 +189,66 @@ describe("maintenance", () => {
 				tags_text: string;
 			};
 			expect(row.tags_text).toBe("");
+		} finally {
+			db.close();
+		}
+	});
+
+	it("deactivates low-signal observations only", () => {
+		const dbPath = createDbPath("prune-observations");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, cwd, project, user, tool_version) VALUES
+				  (1, '2026-03-01T10:00:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, import_key
+				) VALUES
+					(1, 1, 'observation', 'Low signal', 'No code changes were made', 1, '2026-03-01T10:00:00Z', '2026-03-01T10:00:00Z', 'k1'),
+					(2, 1, 'observation', 'High signal', 'Implemented a retry guard', 1, '2026-03-01T10:00:01Z', '2026-03-01T10:00:01Z', 'k2');
+			`);
+
+			const result = deactivateLowSignalObservations(db);
+			expect(result).toEqual({ checked: 2, deactivated: 1 });
+
+			const rows = db.prepare("SELECT id, active FROM memory_items ORDER BY id").all() as Array<{
+				id: number;
+				active: number;
+			}>;
+			expect(rows).toEqual([
+				{ id: 1, active: 0 },
+				{ id: 2, active: 1 },
+			]);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("supports prune-memories dry-run mode", () => {
+		const dbPath = createDbPath("prune-memories-dry-run");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, cwd, project, user, tool_version) VALUES
+				  (1, '2026-03-01T10:00:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, import_key
+				) VALUES
+					(1, 1, 'change', 'Low signal', 'No code changes were made', 1, '2026-03-01T10:00:00Z', '2026-03-01T10:00:00Z', 'k1');
+			`);
+
+			const result = deactivateLowSignalMemories(db, {
+				kinds: ["change"],
+				dryRun: true,
+			});
+			expect(result).toEqual({ checked: 1, deactivated: 1 });
+
+			const row = db.prepare("SELECT active FROM memory_items WHERE id = 1").get() as {
+				active: number;
+			};
+			expect(row.active).toBe(1);
 		} finally {
 			db.close();
 		}

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -1,5 +1,6 @@
 import { statSync } from "node:fs";
 import { assertSchemaReady, connect, type Database, resolveDbPath } from "./db.js";
+import { isLowSignalObservation } from "./ingest-filters.js";
 import { projectClause } from "./project.js";
 
 export interface RawEventStatusItem {
@@ -526,4 +527,104 @@ export function backfillTagsText(
 	}
 
 	return { checked, updated, skipped };
+}
+
+export interface DeactivateLowSignalResult {
+	checked: number;
+	deactivated: number;
+}
+
+export interface DeactivateLowSignalMemoriesOptions {
+	kinds?: string[] | null;
+	limit?: number | null;
+	dryRun?: boolean;
+}
+
+const DEFAULT_LOW_SIGNAL_KINDS = [
+	"observation",
+	"discovery",
+	"change",
+	"feature",
+	"bugfix",
+	"refactor",
+	"decision",
+	"note",
+	"entities",
+	"session_summary",
+];
+
+const OBSERVATION_EQUIVALENT_KINDS = [
+	"observation",
+	"bugfix",
+	"feature",
+	"refactor",
+	"change",
+	"discovery",
+	"decision",
+	"exploration",
+];
+
+/**
+ * Deactivate low-signal observations only.
+ */
+export function deactivateLowSignalObservations(
+	db: Database,
+	limit?: number | null,
+	dryRun = false,
+): DeactivateLowSignalResult {
+	return deactivateLowSignalMemories(db, {
+		kinds: OBSERVATION_EQUIVALENT_KINDS,
+		limit,
+		dryRun,
+	});
+}
+
+/**
+ * Deactivate low-signal memories across selected kinds (does not delete rows).
+ */
+export function deactivateLowSignalMemories(
+	db: Database,
+	opts: DeactivateLowSignalMemoriesOptions = {},
+): DeactivateLowSignalResult {
+	const selectedKinds =
+		opts.kinds?.map((kind) => kind.trim()).filter((kind) => kind.length > 0) ?? [];
+	const kinds = selectedKinds.length > 0 ? selectedKinds : DEFAULT_LOW_SIGNAL_KINDS;
+	const placeholders = kinds.map(() => "?").join(",");
+	const params: unknown[] = [...kinds];
+	let limitClause = "";
+	if (opts.limit != null && opts.limit > 0) {
+		limitClause = "LIMIT ?";
+		params.push(opts.limit);
+	}
+
+	const rows = db
+		.prepare(
+			`SELECT id, title, body_text
+			 FROM memory_items
+			 WHERE kind IN (${placeholders}) AND active = 1
+			 ORDER BY id DESC
+			 ${limitClause}`,
+		)
+		.all(...params) as Array<{ id: number; title: string | null; body_text: string | null }>;
+
+	const checked = rows.length;
+	const ids = rows
+		.filter((row) => isLowSignalObservation(row.body_text || row.title || ""))
+		.map((row) => Number(row.id));
+
+	if (ids.length === 0 || opts.dryRun === true) {
+		return { checked, deactivated: ids.length };
+	}
+
+	const now = new Date().toISOString();
+	const chunkSize = 200;
+	for (let start = 0; start < ids.length; start += chunkSize) {
+		const chunk = ids.slice(start, start + chunkSize);
+		const chunkPlaceholders = chunk.map(() => "?").join(",");
+		db.prepare(
+			`UPDATE memory_items SET active = 0, updated_at = ? WHERE id IN (${chunkPlaceholders})`,
+		).run(now, ...chunk);
+	}
+
+	return { checked, deactivated: ids.length };
 }


### PR DESCRIPTION
## Description
- Add TypeScript ports of low-signal maintenance helpers in core: `deactivateLowSignalObservations()` and `deactivateLowSignalMemories()`.
- Add TS CLI DB commands `codemem db prune-observations` and `codemem db prune-memories` with `--limit`, `--dry-run`, `--json`, and optional `--kinds` for prune-memories.
- Update README CLI command table to include `db backfill-tags` and `db prune-observations` so docs match the TS command surface.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `pnpm run test -- packages/core/src/maintenance.test.ts packages/cli/src/commands/db.test.ts packages/cli/src/index.smoke.test.ts`
- `pnpm run typecheck`
- `pnpm exec biome check packages/core/src/maintenance.ts packages/core/src/maintenance.test.ts packages/core/src/index.ts packages/cli/src/commands/db.ts packages/cli/src/commands/db.test.ts`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
