### PR TITLE
fix(pack): restore section/metrics parity in TS pack output

### DIFF
--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -110,10 +110,18 @@ describe("buildMemoryPack", () => {
 		expect(pack.metrics).toHaveProperty("total_items");
 		expect(pack.metrics).toHaveProperty("pack_tokens");
 		expect(pack.metrics).toHaveProperty("fallback_used");
+		expect(pack.metrics).toHaveProperty("fallback");
+		expect(pack.metrics).toHaveProperty("limit");
+		expect(pack.metrics).toHaveProperty("token_budget");
+		expect(pack.metrics).toHaveProperty("project");
+		expect(pack.metrics).toHaveProperty("pack_item_ids");
 		expect(pack.metrics).toHaveProperty("sources");
 		expect(typeof pack.metrics.total_items).toBe("number");
 		expect(typeof pack.metrics.pack_tokens).toBe("number");
 		expect(typeof pack.metrics.fallback_used).toBe("boolean");
+		expect(["recent", null]).toContain(pack.metrics.fallback);
+		expect(typeof pack.metrics.limit).toBe("number");
+		expect(Array.isArray(pack.metrics.pack_item_ids)).toBe(true);
 
 		expect(pack.metrics.sources).toHaveProperty("fts");
 		expect(pack.metrics.sources).toHaveProperty("semantic");
@@ -126,11 +134,37 @@ describe("buildMemoryPack", () => {
 		const pack = buildMemoryPack(store, "anything");
 
 		expect(pack.items.length).toBe(0);
-		expect(pack.pack_text).toBe("");
+		expect(pack.pack_text).toContain("## Summary");
+		expect(pack.pack_text).toContain("## Timeline");
+		expect(pack.pack_text).toContain("## Observations");
 		expect(pack.item_ids.length).toBe(0);
 
 		expect(pack.metrics.total_items).toBe(0);
 		expect(pack.metrics.fallback_used).toBe(true);
+	});
+
+	it("always emits all three section headers", () => {
+		const pack = buildMemoryPack(store, "anything");
+
+		expect(pack.pack_text).toContain("## Summary");
+		expect(pack.pack_text).toContain("## Timeline");
+		expect(pack.pack_text).toContain("## Observations");
+	});
+
+	it("falls back to timeline items for observations when none exist", () => {
+		store.remember(sessionId, "feature", "Runtime entities", "Tracked agent entities", 0.7);
+
+		const originalRecentByKinds = store.recentByKinds.bind(store);
+		(store as unknown as { recentByKinds: typeof store.recentByKinds }).recentByKinds = () => [];
+		try {
+			const pack = buildMemoryPack(store, "runtime entities");
+
+			const observationsBlock = pack.pack_text.split("## Observations")[1] ?? "";
+			expect(observationsBlock).toContain("(feature)");
+		} finally {
+			(store as unknown as { recentByKinds: typeof store.recentByKinds }).recentByKinds =
+				originalRecentByKinds;
+		}
 	});
 
 	it("includes context in the result", () => {

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -56,9 +56,9 @@ function formatItem(item: MemoryResult): string {
 
 /** Build a formatted section with header and items. */
 function formatSection(header: string, items: MemoryResult[]): string {
-	if (items.length === 0) return "";
-	const lines = [`## ${header}`, ...items.map(formatItem)];
-	return lines.join("\n");
+	const heading = `## ${header}`;
+	if (items.length === 0) return `${heading}\n`;
+	return [heading, ...items.map(formatItem)].join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +315,10 @@ export function buildMemoryPack(
 		}));
 	}
 
+	if (observationItems.length === 0) {
+		observationItems = [...timelineItems];
+	}
+
 	// Sort observations by tag overlap with context, then by kind priority
 	observationItems = sortByTagOverlap(observationItems, context);
 
@@ -365,7 +369,7 @@ export function buildMemoryPack(
 		formatSection("Summary", budgetedSummary),
 		formatSection("Timeline", budgetedTimeline),
 		formatSection("Observations", budgetedObservations),
-	].filter((s) => s.length > 0);
+	];
 
 	const packText = sections.join("\n\n");
 
@@ -389,6 +393,11 @@ export function buildMemoryPack(
 			total_items: allItems.length,
 			pack_tokens: estimateTokens(packText),
 			fallback_used: fallbackUsed,
+			fallback: fallbackUsed ? "recent" : null,
+			limit: effectiveLimit,
+			token_budget: tokenBudget,
+			project: filters?.project ?? null,
+			pack_item_ids: allItemIds,
 			sources: { fts: ftsCount, semantic: semanticCount, fuzzy: 0 },
 		},
 	};

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -425,6 +425,11 @@ export interface PackResponse {
 		total_items: number;
 		pack_tokens: number;
 		fallback_used: boolean;
+		fallback: "recent" | null;
+		limit: number;
+		token_budget: number | null;
+		project: string | null;
+		pack_item_ids: number[];
 		sources: { fts: number; semantic: number; fuzzy: number };
 	};
 }


### PR DESCRIPTION
## Description
Restore the first TS pack parity slice so output shape better matches Python behavior for downstream consumers. This updates section rendering and metrics fields in the pack response while expanding tests to lock in the behavior.

- Always emit `Summary`, `Timeline`, and `Observations` section headers in `pack_text`, even when sections are empty.
- Keep observation fallback aligned by using timeline items when observation candidates are empty.
- Expand pack metrics with `fallback`, `limit`, `token_budget`, `project`, and `pack_item_ids`.
- Update `PackResponse` typing and pack tests accordingly.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test -- packages/core/src/pack.test.ts` and `pnpm run typecheck`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [ ] Code follows project style (`pnpm run lint` currently reports existing workspace warnings)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] No new warnings introduced