### PR TITLE
feat(cli): formalize claude-hook-ingest HTTP and direct fallback contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ uv tool install --upgrade codemem
 
 Claude MCP launch uses `uvx`; first startup may be slower because `uvx` can fetch/install tooling on demand.
 
-Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks`) and auto-falls back to `codemem ingest-claude-hook` / `uvx codemem==<plugin-version> ingest-claude-hook` when the local server path is unavailable.
+Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks`) and falls back to direct local DB enqueue via `codemem claude-hook-ingest` (or pinned `uvx codemem==<plugin-version> claude-hook-ingest`) when the local server path is unavailable.
 
 Claude hook events share the same raw-event queue pipeline used by OpenCode. `UserPromptSubmit` runs
 capture ingest in the background and injects memory context via Claude `additionalContext` using
 local CLI/store pack generation by default, with optional HTTP `/api/pack` fallback.
 
-The packaged Claude hook shell scripts are thin wrappers over Python runtime commands:
+The packaged Claude hook shell scripts are thin wrappers over TS CLI commands:
 `codemem claude-hook-ingest` and `codemem claude-hook-inject`.
 `claude-hook-inject` does not use `uvx` fallback by default to keep prompt-submit latency low.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ flowchart LR
     OCA -->|POST /api/raw-events| VW["Viewer API"]
     OCA -->|fallback: enqueue-raw-event CLI| DB
     CH["Claude hooks"] -->|POST /api/claude-hooks| VW
-    CH -->|fallback: ingest-claude-hook CLI| DB
+    CH -->|fallback: claude-hook-ingest direct enqueue| DB
     VW --> DB["SQLite"]
     DB -->|flush batch claimed| IN["Ingest pipeline"]
     IN --> OB["Observer"]
@@ -34,7 +34,7 @@ flowchart LR
 
 1. Adapters capture tool/conversation lifecycle events and normalize them into raw events with optional `_adapter` envelopes.
 2. OpenCode streams raw events to the viewer ingest API (`POST /api/raw-events`) with preflight checks (`GET /api/raw-events/status`) and can fall back to CLI queue enqueue when stream writes fail.
-3. Claude hook ingestion posts to `POST /api/claude-hooks` first and falls back to `codemem ingest-claude-hook` (or pinned `uvx`) when the local viewer API is unavailable.
+3. Claude hook ingestion posts to `POST /api/claude-hooks` first and falls back to `codemem claude-hook-ingest` direct enqueue (or pinned `uvx`) when the local viewer API is unavailable.
 4. The viewer/store persists raw events and queues durable flush batches.
 5. Idle and sweeper workers claim batches and run them through ingest.
 6. Ingest builds a transcript from user prompts and assistant messages, then hands it to the observer.

--- a/docs/migration-python-to-ts.md
+++ b/docs/migration-python-to-ts.md
@@ -89,7 +89,7 @@ Python backend, `pyproject.toml`, and `uv`/`uvx` runner paths removed.
 | Config read | Complete |
 | Config write + runtime effects | Not yet ported |
 | Schema initialization (DDL) | Python-only |
-| `/api/claude-hooks` ingestion | Not yet ported |
+| `/api/claude-hooks` ingestion | Complete (HTTP-first + direct enqueue fallback) |
 
 ## Rollback
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -46,9 +46,11 @@ uv tool install --upgrade codemem
 
 Claude MCP launch uses `uvx`; startup can be slower on first run because it may install dependencies on demand.
 
-Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks` to the local codemem server) with a version-pinned CLI fallback when the server path is unavailable:
+Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks` to the local codemem server) with a version-pinned CLI direct-enqueue fallback when the server path is unavailable:
 
 - `uvx codemem==<plugin-version> claude-hook-ingest`
+
+Contract note: fallback is direct local DB enqueue from the TS CLI. There is currently no file spool/lock durability path in the fallback contract.
 
 You can update an existing marketplace install with:
 
@@ -260,10 +262,6 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_PLUGIN_LOG_PATH` | Explicit log file path for Claude hook script logging (overrides `CODEMEM_PLUGIN_LOG` for that script). |
 | `CODEMEM_CLAUDE_HOOK_HTTP_CONNECT_TIMEOUT_S` | Claude hook HTTP enqueue connect timeout in seconds (default `1`). |
 | `CODEMEM_CLAUDE_HOOK_HTTP_MAX_TIME_S` | Claude hook HTTP enqueue total timeout in seconds (default `2`). |
-| `CODEMEM_CLAUDE_HOOK_LOCK_DIR` | Claude hook fallback lock directory path (default `~/.codemem/claude-hook-ingest.lock`). |
-| `CODEMEM_CLAUDE_HOOK_LOCK_TTL_S` | Reclaim stale Claude hook fallback lock after this many seconds (default `300`). |
-| `CODEMEM_CLAUDE_HOOK_LOCK_GRACE_S` | Grace period before treating lock metadata gaps as stale (default `2`). |
-| `CODEMEM_CLAUDE_HOOK_SPOOL_DIR` | Claude hook durable spool directory for all-fail fallback payloads (default `~/.codemem/claude-hook-spool`). |
 | `CODEMEM_INJECT_HTTP_CONNECT_TIMEOUT_S` | `UserPromptSubmit` pack injection connect timeout in seconds (default `1`). |
 | `CODEMEM_INJECT_HTTP_MAX_TIME_S` | `UserPromptSubmit` pack injection total timeout in seconds (default `2`). |
 | `CODEMEM_INJECT_HTTP_FALLBACK` | Set to `0` to disable HTTP `/api/pack` fallback for `claude-hook-inject` (default `1`). |

--- a/packages/cli/src/commands/claude-hook-ingest.test.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, initTestSchema } from "@codemem/core";
+import { describe, expect, it } from "vitest";
+import {
+	claudeHookIngestCommand,
+	directEnqueue,
+	ingestClaudeHookPayload,
+} from "./claude-hook-ingest.js";
+
+function createTempDbPath(): { dbPath: string; cleanup: () => void } {
+	const dir = mkdtempSync(join(tmpdir(), "codemem-cli-claude-hook-"));
+	const dbPath = join(dir, "test.sqlite");
+	const db = connect(dbPath);
+	initTestSchema(db);
+	db.close();
+	return {
+		dbPath,
+		cleanup: () => rmSync(dir, { recursive: true, force: true }),
+	};
+}
+
+describe("claude-hook-ingest command", () => {
+	it("registers expected options and help text", () => {
+		const longs = claudeHookIngestCommand.options.map((option) => option.long);
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--host");
+		expect(longs).toContain("--port");
+
+		const help = claudeHookIngestCommand.helpInformation();
+		expect(help).toContain("HTTP first");
+		expect(help).toContain("direct DB fallback");
+	});
+
+	it("returns HTTP result when viewer ingest succeeds", async () => {
+		const result = await ingestClaudeHookPayload(
+			{ hook_event_name: "SessionStart", session_id: "sess-http", cwd: "/tmp/demo" },
+			{ host: "127.0.0.1", port: 38888 },
+			{
+				httpIngest: async () => ({ ok: true, inserted: 2, skipped: 1 }),
+				directIngest: () => {
+					throw new Error("direct ingest should not be called");
+				},
+				resolveDb: () => {
+					throw new Error("resolveDb should not be called");
+				},
+			},
+		);
+
+		expect(result).toEqual({ inserted: 2, skipped: 1, via: "http" });
+	});
+
+	it("falls back to direct ingest when HTTP path fails", async () => {
+		const result = await ingestClaudeHookPayload(
+			{ hook_event_name: "SessionStart", session_id: "sess-direct", cwd: "/tmp/demo" },
+			{ host: "127.0.0.1", port: 38888, db: "/tmp/custom.sqlite" },
+			{
+				httpIngest: async () => ({ ok: false, inserted: 0, skipped: 0 }),
+				directIngest: () => ({ inserted: 1, skipped: 0 }),
+				resolveDb: () => "/tmp/resolved.sqlite",
+			},
+		);
+
+		expect(result).toEqual({ inserted: 1, skipped: 0, via: "direct" });
+	});
+
+	it("direct enqueue inserts once and then deduplicates event_id", () => {
+		const { dbPath, cleanup } = createTempDbPath();
+		try {
+			const payload = {
+				hook_event_name: "SessionStart",
+				session_id: "sess-dedup",
+				timestamp: "2026-01-01T00:00:00Z",
+				cwd: "/tmp/demo",
+			};
+
+			const first = directEnqueue(payload, dbPath);
+			const second = directEnqueue(payload, dbPath);
+
+			expect(first).toEqual({ inserted: 1, skipped: 0 });
+			expect(second).toEqual({ inserted: 0, skipped: 0 });
+
+			const db = connect(dbPath);
+			try {
+				const rawCount = db.prepare("SELECT COUNT(*) AS c FROM raw_events").get() as { c: number };
+				const sessionCount = db.prepare("SELECT COUNT(*) AS c FROM raw_event_sessions").get() as {
+					c: number;
+				};
+				expect(rawCount.c).toBe(1);
+				expect(sessionCount.c).toBe(1);
+			} finally {
+				db.close();
+			}
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("direct enqueue skips unsupported hook payloads gracefully", () => {
+		const { dbPath, cleanup } = createTempDbPath();
+		try {
+			const result = directEnqueue(
+				{ hook_event_name: "UnknownEvent", session_id: "sess-x" },
+				dbPath,
+			);
+			expect(result).toEqual({ inserted: 0, skipped: 1 });
+		} finally {
+			cleanup();
+		}
+	});
+});

--- a/packages/cli/src/commands/claude-hook-ingest.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.ts
@@ -22,6 +22,21 @@ import {
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 
+type IngestResult = { inserted: number; skipped: number; via: "http" | "direct" };
+
+type IngestOpts = {
+	host: string;
+	port: number;
+	db?: string;
+	dbPath?: string;
+};
+
+type IngestDeps = {
+	httpIngest?: typeof tryHttpIngest;
+	directIngest?: typeof directEnqueue;
+	resolveDb?: typeof resolveDbPath;
+};
+
 /** Try to POST the hook payload to the running viewer server. */
 async function tryHttpIngest(
 	payload: Record<string, unknown>,
@@ -53,7 +68,7 @@ async function tryHttpIngest(
 }
 
 /** Fall back to direct raw-event enqueue via the local SQLite store. */
-function directEnqueue(
+export function directEnqueue(
 	payload: Record<string, unknown>,
 	dbPath: string,
 ): { inserted: number; skipped: number } {
@@ -133,9 +148,34 @@ function directEnqueue(
 	}
 }
 
+/**
+ * Ingest one Claude hook payload using the TS contract:
+ * HTTP enqueue first, then direct local enqueue fallback.
+ *
+ * This path intentionally does not implement file-spool/lock durability.
+ */
+export async function ingestClaudeHookPayload(
+	payload: Record<string, unknown>,
+	opts: IngestOpts,
+	deps: IngestDeps = {},
+): Promise<IngestResult> {
+	const httpIngest = deps.httpIngest ?? tryHttpIngest;
+	const directIngest = deps.directIngest ?? directEnqueue;
+	const resolveDb = deps.resolveDb ?? resolveDbPath;
+
+	const httpResult = await httpIngest(payload, opts.host, opts.port);
+	if (httpResult.ok) {
+		return { inserted: httpResult.inserted, skipped: httpResult.skipped, via: "http" };
+	}
+
+	const dbPath = resolveDb(opts.db ?? opts.dbPath);
+	const directResult = directIngest(payload, dbPath);
+	return { ...directResult, via: "direct" };
+}
+
 export const claudeHookIngestCommand = new Command("claude-hook-ingest")
 	.configureHelp(helpStyle)
-	.description("Ingest a Claude Code hook payload from stdin")
+	.description("Ingest Claude hook payload: HTTP first, direct DB fallback")
 	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--host <host>", "viewer server host", "127.0.0.1")
@@ -170,20 +210,14 @@ export const claudeHookIngestCommand = new Command("claude-hook-ingest")
 		const port = Number.parseInt(opts.port, 10);
 		const host = opts.host;
 
-		// Strategy 1: try HTTP POST to running viewer
-		const httpResult = await tryHttpIngest(payload, host, port);
-		if (httpResult.ok) {
-			console.log(
-				JSON.stringify({ inserted: httpResult.inserted, skipped: httpResult.skipped, via: "http" }),
-			);
-			return;
-		}
-
-		// Strategy 2: direct local enqueue
 		try {
-			const dbPath = resolveDbPath(opts.db ?? opts.dbPath);
-			const directResult = directEnqueue(payload, dbPath);
-			console.log(JSON.stringify({ ...directResult, via: "direct" }));
+			const result = await ingestClaudeHookPayload(payload, {
+				host,
+				port,
+				db: opts.db,
+				dbPath: opts.dbPath,
+			});
+			console.log(JSON.stringify(result));
 		} catch {
 			process.exitCode = 1;
 		}


### PR DESCRIPTION
## Description
Finalize the TS `claude-hook-ingest` contract as HTTP-first with direct local enqueue fallback, and document that this path does not currently include spool/lock durability semantics.

- Extract and export `ingestClaudeHookPayload(...)` so fallback behavior is explicit and testable.
- Keep command behavior as: try `POST /api/claude-hooks`, then direct local `raw_events` enqueue.
- Add command-level tests for HTTP success path, direct fallback path, direct enqueue dedupe behavior, and unsupported hook skip behavior.
- Update user-facing docs to reflect the current TS contract and remove stale lock/spool env var references.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test -- packages/cli/src/commands/claude-hook-ingest.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm exec biome check packages/cli/src/commands/claude-hook-ingest.ts packages/cli/src/commands/claude-hook-ingest.test.ts`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced