### PR TITLE
fix(release): guard tag workflow to merged main head

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,23 @@ permissions:
   contents: write
 
 jobs:
+  preflight-tag:
+    name: Release Tag Preflight
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag points at merged main HEAD
+        env:
+          RELEASE_TAG_COMMIT: ${{ github.sha }}
+        run: bash scripts/release-tag-preflight.sh
+
   ci:
     name: CI
+    needs: preflight-tag
     uses: ./.github/workflows/ci.yml
 
   publish-npm:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -31,6 +31,19 @@ The script updates/checks:
 - `plugins/claude/.claude-plugin/plugin.json` (`version` and `codemem==X.Y.Z` MCP arg)
 - `.claude-plugin/marketplace.json` (`metadata.version` and `plugins[*].version` for `codemem`)
 
+## Release tag preflight
+
+Before creating or pushing a release tag, run:
+
+```bash
+pnpm run release:preflight-tag
+```
+
+This verifies release tagging safety in two contexts:
+
+- local preflight: target commit must match `origin/main` HEAD, and the working tree must be clean
+- CI tag workflow: tagged commit must be reachable from `origin/main` (avoids false failures if `main` advances after tag push)
+
 ## Compatibility check
 
 The OpenCode plugin performs a runtime CLI version check and warns if the local CLI is below

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "pnpm exec biome check --write packages/",
     "typecheck": "pnpm exec tsc --build",
     "check": "pnpm run typecheck && pnpm run lint && pnpm run test",
-    "codemem": "tsx --conditions source packages/cli/src/index.ts"
+    "codemem": "tsx --conditions source packages/cli/src/index.ts",
+    "release:preflight-tag": "bash scripts/release-tag-preflight.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.0.6",

--- a/scripts/release-tag-preflight.sh
+++ b/scripts/release-tag-preflight.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_BRANCH="${RELEASE_EXPECTED_BRANCH:-main}"
+MAIN_REF="origin/${EXPECTED_BRANCH}"
+TARGET_COMMIT="${RELEASE_TAG_COMMIT:-${GITHUB_SHA:-HEAD}}"
+
+git fetch origin "${EXPECTED_BRANCH}" --quiet
+
+main_commit="$(git rev-parse "${MAIN_REF}^{commit}")"
+tag_commit="$(git rev-parse "${TARGET_COMMIT}^{commit}")"
+
+if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+	if ! git merge-base --is-ancestor "${tag_commit}" "${main_commit}"; then
+		echo "Release tag preflight failed: tag commit is not reachable from origin/${EXPECTED_BRANCH}." >&2
+		echo "  tag commit:  ${tag_commit}" >&2
+		echo "  main commit: ${main_commit}" >&2
+		echo "Tag only after the release commit is merged to ${EXPECTED_BRANCH}." >&2
+		exit 1
+	fi
+elif [[ "${tag_commit}" != "${main_commit}" ]]; then
+	echo "Release tag preflight failed: local tag target is not origin/${EXPECTED_BRANCH} HEAD." >&2
+	echo "  tag commit:  ${tag_commit}" >&2
+	echo "  main commit: ${main_commit}" >&2
+	echo "Tag from updated ${EXPECTED_BRANCH} after the release PR merge commit is at HEAD." >&2
+	exit 1
+fi
+
+if [[ -z "${GITHUB_ACTIONS:-}" && "${RELEASE_SKIP_LOCAL_GUARDS:-0}" != "1" ]]; then
+	current_branch="$(git branch --show-current || true)"
+	if [[ "${current_branch}" != "${EXPECTED_BRANCH}" ]]; then
+		echo "Release tag preflight failed: current branch is '${current_branch}', expected '${EXPECTED_BRANCH}'." >&2
+		exit 1
+	fi
+
+	if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+		echo "Release tag preflight failed: working tree is not clean." >&2
+		exit 1
+	fi
+fi
+
+echo "Release tag preflight passed for commit ${tag_commit}."


### PR DESCRIPTION
## Description
Add an automated release-tag guard so tag-triggered release jobs only run when the tag points at the merged `main` HEAD commit.

- Add `scripts/release-tag-preflight.sh` to validate tag-target commit equals `origin/main` HEAD.
- Run this preflight at the top of `.github/workflows/release.yml` before CI/publish jobs.
- Add `pnpm run release:preflight-tag` for local pre-tag checks.
- Document the preflight in `docs/versioning.md`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run typecheck`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
  - `bash -n scripts/release-tag-preflight.sh`
  - `GITHUB_ACTIONS=1 RELEASE_TAG_COMMIT=origin/main bash scripts/release-tag-preflight.sh`

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced