### PR TITLE
fix(serve): guard sqlite-vec startup failures with diagnostics

### DIFF
--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildForegroundRunnerArgs } from "./serve.js";
+import {
+	buildForegroundRunnerArgs,
+	isSqliteVecLoadFailure,
+	sqliteVecFailureDiagnostics,
+} from "./serve.js";
 import {
 	resolveLegacyServeInvocation,
 	resolveServeInvocation,
@@ -130,5 +134,21 @@ describe("serve command option resolution", () => {
 			"--db-path",
 			"/tmp/test.sqlite",
 		]);
+	});
+
+	it("detects sqlite-vec load errors for viewer startup fallback", () => {
+		expect(isSqliteVecLoadFailure(new Error("sqlite-vec loaded but version check failed"))).toBe(
+			true,
+		);
+		expect(isSqliteVecLoadFailure(new Error("no such function: vec_version"))).toBe(true);
+		expect(isSqliteVecLoadFailure(new Error("database is locked"))).toBe(false);
+	});
+
+	it("formats sqlite-vec diagnostics with runtime context", () => {
+		const lines = sqliteVecFailureDiagnostics(new Error("vec0 load failed"), "/tmp/mem.sqlite");
+		expect(lines.some((line) => line.startsWith("db=/tmp/mem.sqlite"))).toBe(true);
+		expect(lines.some((line) => line.startsWith("node="))).toBe(true);
+		expect(lines.some((line) => line.startsWith("exec="))).toBe(true);
+		expect(lines.some((line) => line.startsWith("error=vec0 load failed"))).toBe(true);
 	});
 });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -4,6 +4,8 @@ import net from "node:net";
 import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import {
+	isEmbeddingDisabled,
+	type MemoryStore,
 	ObserverClient,
 	RawEventSweeper,
 	readCodememConfigFile,
@@ -141,6 +143,29 @@ export function buildForegroundRunnerArgs(
 	return args;
 }
 
+export function isSqliteVecLoadFailure(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const text = error.message.toLowerCase();
+	return (
+		text.includes("sqlite-vec") ||
+		text.includes("vec_version") ||
+		text.includes("vec0") ||
+		(text.includes("sqlite") && text.includes("vec"))
+	);
+}
+
+export function sqliteVecFailureDiagnostics(error: unknown, dbPath: string): string[] {
+	const message = error instanceof Error ? error.message : String(error);
+	return [
+		`db=${dbPath}`,
+		`node=${process.version}`,
+		`exec=${process.execPath}`,
+		`cwd=${process.cwd()}`,
+		`embedding_disabled=${process.env.CODEMEM_EMBEDDING_DISABLED ?? ""}`,
+		`error=${message}`,
+	];
+}
+
 async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promise<void> {
 	if (await isPortOpen(invocation.host, invocation.port)) {
 		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
@@ -183,7 +208,28 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	}
 
 	const observer = new ObserverClient();
-	const sweeper = new RawEventSweeper(getStore(), { observer });
+	let store: MemoryStore;
+	try {
+		store = getStore();
+	} catch (err) {
+		if (isEmbeddingDisabled() || !isSqliteVecLoadFailure(err)) {
+			throw err;
+		}
+
+		p.log.warn("sqlite-vec failed to load; retrying viewer startup with embeddings disabled");
+		for (const line of sqliteVecFailureDiagnostics(
+			err,
+			resolveDbPath(invocation.dbPath ?? undefined),
+		)) {
+			p.log.warn(`sqlite-vec diagnostic: ${line}`);
+		}
+		process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+		closeStore();
+		store = getStore();
+		p.log.warn("Embeddings disabled for this viewer process; raw-event ingestion remains active.");
+	}
+
+	const sweeper = new RawEventSweeper(store, { observer });
 	sweeper.start();
 
 	const syncAbort = new AbortController();
@@ -213,7 +259,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			});
 	}
 
-	const app = createApp({ storeFactory: getStore, sweeper, observer });
+	const app = createApp({ storeFactory: () => store, sweeper, observer });
 	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
 	const pidPath = pidFilePath(dbPath);
 

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -468,6 +468,29 @@ describe("MemoryStore", () => {
 			expect(result.database.memory_items).toBe(2);
 			expect(result.database.active_memory_items).toBe(1);
 		});
+
+		it("handles memory_vectors count failures without crashing", () => {
+			const sessionId = insertTestSession(store.db);
+			store.remember(sessionId, "discovery", "Vector test", "Body");
+			store.db.exec("CREATE TABLE IF NOT EXISTS memory_vectors(id INTEGER)");
+
+			const originalPrepare = store.db.prepare.bind(store.db);
+			(store.db as unknown as { prepare: typeof store.db.prepare }).prepare = ((
+				statement: string,
+			) => {
+				if (statement.includes("FROM memory_vectors")) {
+					throw new Error("no such module: vec0");
+				}
+				return originalPrepare(statement);
+			}) as typeof store.db.prepare;
+
+			try {
+				const result = store.stats();
+				expect(result.database.vector_coverage).toBe(0);
+			} finally {
+				(store.db as unknown as { prepare: typeof store.db.prepare }).prepare = originalPrepare;
+			}
+		});
 	});
 
 	// -- updateMemoryVisibility ----------------------------------------------

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -23,6 +23,7 @@ import {
 	connect,
 	DEFAULT_DB_PATH,
 	fromJson,
+	isEmbeddingDisabled,
 	loadSqliteVec,
 	resolveDbPath,
 	tableExists,
@@ -646,9 +647,13 @@ export class MemoryStore {
 		const rawEvents = countRows(schema.rawEvents);
 
 		let vectorCount = 0;
-		if (tableExists(this.db, "memory_vectors")) {
-			const row = this.d.get<{ c: number | null }>(sql`SELECT COUNT(*) AS c FROM memory_vectors`);
-			vectorCount = row?.c ?? 0;
+		if (!isEmbeddingDisabled() && tableExists(this.db, "memory_vectors")) {
+			try {
+				const row = this.d.get<{ c: number | null }>(sql`SELECT COUNT(*) AS c FROM memory_vectors`);
+				vectorCount = row?.c ?? 0;
+			} catch {
+				vectorCount = 0;
+			}
 		}
 		const vectorCoverage = activeMemories > 0 ? Math.min(1, vectorCount / activeMemories) : 0;
 


### PR DESCRIPTION
## Description
Harden viewer startup against sqlite-vec load failures so raw-event ingestion/sweeper behavior remains available even when embeddings cannot initialize in the current process environment.

- Detect sqlite-vec startup failures in `serve` foreground startup.
- Log focused diagnostics (db path, node/runtime context, error message) for debugging env mismatches.
- Retry viewer startup once with `CODEMEM_EMBEDDING_DISABLED=1` to keep ingestion online.
- Add tests for sqlite-vec failure detection and diagnostics formatting.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test -- packages/cli/src/commands/serve.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm exec biome check packages/cli/src/commands/serve.ts packages/cli/src/commands/serve.test.ts`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced