### PR TITLE
fix(sync): decouple coordinator presence refresh from ui poll

### DIFF
--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -61,6 +61,33 @@ export interface CoordinatorSyncConfig {
 	syncCoordinatorAdminSecret: string;
 }
 
+type PresenceStatus = "posted" | "not_enrolled" | "error";
+
+interface PresenceSnapshot {
+	status: PresenceStatus;
+	error: string | null;
+	advertisedAddresses: unknown;
+	nextRefreshAtMs: number;
+}
+
+const coordinatorPresenceCache = new Map<string, PresenceSnapshot>();
+
+function presenceCacheKey(store: MemoryStore, config: CoordinatorSyncConfig): string {
+	const groups = [...config.syncCoordinatorGroups].sort().join(",");
+	return `${store.dbPath}|${config.syncCoordinatorUrl}|${groups}`;
+}
+
+function presenceRefreshIntervalMs(config: CoordinatorSyncConfig): number {
+	const ttl = Math.max(1, config.syncCoordinatorPresenceTtlS);
+	const halfTtl = Math.floor(ttl / 2);
+	const refreshS = Math.max(5, Math.min(60, halfTtl > 0 ? halfTtl : 1));
+	return refreshS * 1000;
+}
+
+function presenceRetryIntervalMs(): number {
+	return 30_000;
+}
+
 export function readCoordinatorSyncConfig(config?: ConfigRecord): CoordinatorSyncConfig {
 	const raw = { ...(config ?? readCodememConfigFile()) } as ConfigRecord;
 	const envOverrides = getCodememEnvOverrides();
@@ -256,17 +283,42 @@ export async function coordinatorStatusSnapshot(
 		stale_peer_count: 0,
 		discovered_peer_count: 0,
 	};
-	try {
-		const registration = await registerCoordinatorPresence(store, config);
-		snapshot.presence_status = "posted";
-		const first = registration?.responses?.[0];
-		if (first && typeof first === "object") {
-			snapshot.advertised_addresses = (first as Record<string, unknown>).addresses ?? [];
+	const cacheKey = presenceCacheKey(store, config);
+	const now = Date.now();
+	const cachedPresence = coordinatorPresenceCache.get(cacheKey);
+	if (cachedPresence && now < cachedPresence.nextRefreshAtMs) {
+		snapshot.presence_status = cachedPresence.status;
+		snapshot.presence_error = cachedPresence.error;
+		snapshot.advertised_addresses = cachedPresence.advertisedAddresses;
+	} else {
+		try {
+			const registration = await registerCoordinatorPresence(store, config);
+			const first = registration?.responses?.[0];
+			const advertisedAddresses =
+				first && typeof first === "object"
+					? ((first as Record<string, unknown>).addresses ?? [])
+					: [];
+			snapshot.presence_status = "posted";
+			snapshot.advertised_addresses = advertisedAddresses;
+			coordinatorPresenceCache.set(cacheKey, {
+				status: "posted",
+				error: null,
+				advertisedAddresses,
+				nextRefreshAtMs: now + presenceRefreshIntervalMs(config),
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			const status: PresenceStatus = message.includes("unknown_device") ? "not_enrolled" : "error";
+			const nextRefreshAtMs = status === "not_enrolled" ? now : now + presenceRetryIntervalMs();
+			snapshot.presence_status = status;
+			snapshot.presence_error = message;
+			coordinatorPresenceCache.set(cacheKey, {
+				status,
+				error: message,
+				advertisedAddresses: [],
+				nextRefreshAtMs,
+			});
 		}
-	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		snapshot.presence_status = message.includes("unknown_device") ? "not_enrolled" : "error";
-		snapshot.presence_error = message;
 	}
 	try {
 		const peers = await lookupCoordinatorPeers(store, config);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -986,6 +986,13 @@ describe("viewer-server", () => {
 				expect(body.coordinator.groups).toEqual(["team-a"]);
 				expect(body.join_requests).toHaveLength(1);
 				expect(body.join_requests[0].request_id).toBe("req-1");
+
+				const second = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(second.status).toBe(200);
+
+				const calls = fetchMock.mock.calls.map(([input]) => String(input));
+				const presenceCalls = calls.filter((url) => url.includes("/v1/presence"));
+				expect(presenceCalls).toHaveLength(1);
 			} finally {
 				cleanup();
 				globalThis.fetch = prevFetch;
@@ -1016,6 +1023,68 @@ describe("viewer-server", () => {
 				else process.env.CODEMEM_CONFIG = prevConfig;
 				if (prevEnabled == null) delete process.env.CODEMEM_SYNC_ENABLED;
 				else process.env.CODEMEM_SYNC_ENABLED = prevEnabled;
+			}
+		});
+
+		it("retries coordinator presence immediately after not_enrolled status", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			let presenceCalls = 0;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/presence")) {
+					presenceCalls += 1;
+					if (presenceCalls === 1) {
+						return new Response(JSON.stringify({ error: "unknown_device" }), { status: 401 });
+					}
+					return new Response(JSON.stringify({ ok: true, addresses: ["http://1.2.3.4:7337"] }), {
+						status: 200,
+					});
+				}
+				if (url.includes("/v1/peers")) {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+
+				const first = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(first.status).toBe(200);
+				const firstBody = (await first.json()) as Record<string, any>;
+				expect(firstBody.coordinator.presence_status).toBe("not_enrolled");
+
+				const second = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(second.status).toBe(200);
+				const secondBody = (await second.json()) as Record<string, any>;
+				expect(secondBody.coordinator.presence_status).toBe("posted");
+				expect(presenceCalls).toBe(2);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+				delete process.env.CODEMEM_SYNC_ENABLED;
 			}
 		});
 


### PR DESCRIPTION
## Description
Reduce coordinator write churn from UI polling by decoupling coordinator presence registration from every `/api/sync/status` request.

- Add in-process presence snapshot cache keyed by db path + coordinator target/groups.
- Refresh presence on a bounded cadence derived from presence TTL (instead of every 5s UI poll).
- Keep faster retry cadence for error/not-enrolled states.
- Preserve coordinator peer lookup behavior and existing status payload shape.
- Add regression assertion in viewer-server sync status test to verify repeated status polls only trigger one `/v1/presence` call inside the refresh window.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test -- packages/viewer-server/src/index.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced