### PR TITLE
fix(sync): fetch coordinator join requests only on sync tab

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -100,10 +100,15 @@ export async function saveConfig(payload: any): Promise<void> {
   return parsed;
 }
 
-export async function loadSyncStatus(includeDiagnostics: boolean, project = ''): Promise<any> {
+export async function loadSyncStatus(
+  includeDiagnostics: boolean,
+  project = '',
+  options?: { includeJoinRequests?: boolean },
+): Promise<any> {
   const params = new URLSearchParams();
   if (includeDiagnostics) params.set('includeDiagnostics', '1');
   if (project) params.set('project', project);
+  if (options?.includeJoinRequests) params.set('includeJoinRequests', '1');
   const suffix = params.size ? `?${params.toString()}` : '';
   return fetchJson(`/api/sync/status${suffix}`);
 }

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -20,7 +20,9 @@ let lastSyncHash = '';
 
 export async function loadSyncData() {
   try {
-    const payload = await api.loadSyncStatus(true, state.currentProject || '');
+    const payload = await api.loadSyncStatus(true, state.currentProject || '', {
+      includeJoinRequests: state.activeTab === 'sync',
+    });
     let actorsPayload: any = null;
     let actorLoadError = false;
     try {
@@ -41,7 +43,9 @@ export async function loadSyncData() {
     state.lastSyncPeers = payload.peers || [];
     state.lastSyncSharingReview = payload.sharing_review || [];
     state.lastSyncCoordinator = payload.coordinator || null;
-    state.lastSyncJoinRequests = payload.join_requests || [];
+    if (Array.isArray(payload.join_requests)) {
+      state.lastSyncJoinRequests = payload.join_requests;
+    }
     state.lastSyncAttempts = payload.attempts || [];
     state.lastSyncLegacyDevices = payload.legacy_devices || [];
     renderSyncStatus();

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -974,7 +974,9 @@ describe("viewer-server", () => {
 				const store = getStore();
 				if (!store) throw new Error("store not initialized");
 				ensureDeviceIdentity(store.db, { keysDir });
-				const res = await app.request("/api/sync/status?includeDiagnostics=1");
+				const res = await app.request(
+					"/api/sync/status?includeDiagnostics=1&includeJoinRequests=1",
+				);
 				expect(res.status).toBe(200);
 				const body = (await res.json()) as Record<string, any>;
 				expect(body.enabled).toBe(true);
@@ -987,12 +989,73 @@ describe("viewer-server", () => {
 				expect(body.join_requests).toHaveLength(1);
 				expect(body.join_requests[0].request_id).toBe("req-1");
 
-				const second = await app.request("/api/sync/status?includeDiagnostics=1");
+				const second = await app.request(
+					"/api/sync/status?includeDiagnostics=1&includeJoinRequests=1",
+				);
 				expect(second.status).toBe(200);
 
 				const calls = fetchMock.mock.calls.map(([input]) => String(input));
 				const presenceCalls = calls.filter((url) => url.includes("/v1/presence"));
 				expect(presenceCalls).toHaveLength(1);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+				delete process.env.CODEMEM_SYNC_ENABLED;
+			}
+		});
+
+		it("skips coordinator join request lookup unless includeJoinRequests=1", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/presence")) {
+					return new Response(JSON.stringify({ ok: true, addresses: ["http://1.2.3.4:7337"] }), {
+						status: 200,
+					});
+				}
+				if (url.includes("/v1/peers")) {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				if (url.includes("/v1/admin/join-requests")) {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+
+				const res = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).not.toHaveProperty("join_requests");
+
+				const calls = fetchMock.mock.calls.map(([input]) => String(input));
+				const joinRequestCalls = calls.filter((url) => url.includes("/v1/admin/join-requests"));
+				expect(joinRequestCalls).toHaveLength(0);
 			} finally {
 				cleanup();
 				globalThis.fetch = prevFetch;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -526,6 +526,7 @@ export function syncRoutes(getStore: StoreFactory) {
 		const store = getStore();
 		{
 			const showDiag = queryBool(c.req.query("includeDiagnostics"));
+			const includeJoinRequests = queryBool(c.req.query("includeJoinRequests"));
 			const project = c.req.query("project") || null;
 			const config = readCoordinatorSyncConfig();
 
@@ -646,10 +647,12 @@ export function syncRoutes(getStore: StoreFactory) {
 			const sharingReview = store.sharingReviewSummary(project);
 			const coordinator = await coordinatorStatusSnapshot(store, config);
 			let joinRequests: Record<string, unknown>[] = [];
-			try {
-				joinRequests = await listCoordinatorJoinRequests(config);
-			} catch {
-				joinRequests = [];
+			if (includeJoinRequests && config.syncCoordinatorAdminSecret) {
+				try {
+					joinRequests = await listCoordinatorJoinRequests(config);
+				} catch {
+					joinRequests = [];
+				}
 			}
 
 			if (daemonStateValue === "ok") {
@@ -685,7 +688,7 @@ export function syncRoutes(getStore: StoreFactory) {
 				statusBlock.daemon_state = daemonStateValue;
 			}
 
-			return c.json({
+			const responsePayload: Record<string, unknown> = {
 				...statusPayload,
 				status: statusBlock,
 				peers: peersItems,
@@ -693,8 +696,11 @@ export function syncRoutes(getStore: StoreFactory) {
 				legacy_devices: legacyDevices,
 				sharing_review: sharingReview,
 				coordinator,
-				join_requests: joinRequests,
-			});
+			};
+			if (includeJoinRequests) {
+				responsePayload.join_requests = joinRequests;
+			}
+			return c.json(responsePayload);
 		}
 	});
 


### PR DESCRIPTION
## Description
Cut unnecessary coordinator admin traffic by only looking up join requests when the UI explicitly asks for them.

- Add `includeJoinRequests=1` query gating in `/api/sync/status`.
- Keep join-request lookup disabled by default, even when coordinator admin secret exists.
- Update UI sync loader to request join requests only when Sync tab is active.
- Add regression test proving `/v1/admin/join-requests` is not called when the flag is omitted.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test -- packages/viewer-server/src/index.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced