### PR TITLE
perf(sync): cache coordinator-backed sync status on health tab

### DIFF
--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -17,12 +17,56 @@ export { renderSyncPeers } from './people';
 /* ── Data loading ────────────────────────────────────────── */
 
 let lastSyncHash = '';
+let cachedSyncStatus: { key: string; expiresAtMs: number; payload: any } | null = null;
+
+const HEALTH_SYNC_STATUS_CACHE_TTL_MS = 15_000;
+
+function syncStatusCacheKey(project: string): string {
+  return `project:${project || ''}|includeJoinRequests:false`;
+}
+
+function readCachedSyncStatus(project: string): any | null {
+  const key = syncStatusCacheKey(project);
+  if (!cachedSyncStatus) return null;
+  if (cachedSyncStatus.key !== key) return null;
+  if (Date.now() >= cachedSyncStatus.expiresAtMs) return null;
+  return cachedSyncStatus.payload;
+}
+
+function writeCachedSyncStatus(project: string, payload: any): void {
+  cachedSyncStatus = {
+    key: syncStatusCacheKey(project),
+    expiresAtMs: Date.now() + HEALTH_SYNC_STATUS_CACHE_TTL_MS,
+    payload,
+  };
+}
+
+function normalizeSyncStatusForCache(payload: any): any {
+  if (!payload || typeof payload !== 'object') return payload;
+  return {
+    ...payload,
+    join_requests: [],
+  };
+}
 
 export async function loadSyncData() {
   try {
-    const payload = await api.loadSyncStatus(true, state.currentProject || '', {
-      includeJoinRequests: state.activeTab === 'sync',
-    });
+    const project = state.currentProject || '';
+    const includeJoinRequests = state.activeTab === 'sync';
+    const useCache = state.activeTab === 'health';
+
+    let payload: any;
+    if (useCache) {
+      payload = readCachedSyncStatus(project);
+      if (!payload) {
+        payload = await api.loadSyncStatus(true, project, { includeJoinRequests: false });
+        writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
+      }
+    } else {
+      payload = await api.loadSyncStatus(true, project, { includeJoinRequests });
+      writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
+    }
+
     let actorsPayload: any = null;
     let actorLoadError = false;
     try {


### PR DESCRIPTION
## Description
Reduce repeated coordinator-backed status fetches while the Health tab is open by adding a short client-side TTL cache for sync status payloads.

- Cache `/api/sync/status` payloads for health-tab refreshes for 15 seconds.
- Keep Sync tab behavior uncached so team-management interactions stay responsive.
- Preserve join-request behavior by keeping join-request fetches tied to Sync tab requests.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test -- packages/viewer-server/src/index.test.ts` and `pnpm run typecheck`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced