### PR TITLE
fix(ingest): derive tags inline at ingest time

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -295,6 +295,7 @@ export {
 	recordReplicationOp,
 	setReplicationCursor,
 } from "./sync-replication.js";
+export { deriveTags, fileTags, normalizeTag } from "./tags.js";
 // Test utilities (exported for consumer packages like viewer-server)
 export { initTestSchema, insertTestSession } from "./test-utils.js";
 export type {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -54,6 +54,7 @@ import type { ObserverClient } from "./observer-client.js";
 import { resolveProject } from "./project.js";
 import * as schema from "./schema.js";
 import type { MemoryStore } from "./store.js";
+import { deriveTags } from "./tags.js";
 import { storeVectors } from "./vectors.js";
 
 // ---------------------------------------------------------------------------
@@ -397,7 +398,14 @@ export async function ingest(
 				const bodyText = bodyParts.join("\n\n");
 
 				const memoryTitle = obs.title || obs.narrative;
-				const memoryId = store.remember(sessionId, kind, memoryTitle, bodyText, 0.5, undefined, {
+				const tags = deriveTags({
+					kind,
+					title: memoryTitle,
+					concepts: obs.concepts,
+					filesRead: obs.filesRead,
+					filesModified: obs.filesModified,
+				});
+				const memoryId = store.remember(sessionId, kind, memoryTitle, bodyText, 0.5, tags, {
 					subtitle: obs.subtitle,
 					facts: obs.facts,
 					concepts: obs.concepts,
@@ -415,7 +423,13 @@ export async function ingest(
 			if (summaryToStore) {
 				const { summary, request, body } = summaryToStore;
 				const summaryTitle = request || "Session summary";
-				const memoryId = store.remember(sessionId, "change", summaryTitle, body, 0.3, undefined, {
+				const summaryTags = deriveTags({
+					kind: "change",
+					title: summaryTitle,
+					filesRead: summary.filesRead,
+					filesModified: summary.filesModified,
+				});
+				const memoryId = store.remember(sessionId, "change", summaryTitle, body, 0.3, summaryTags, {
 					is_summary: true,
 					request,
 					investigated: summary.investigated,

--- a/packages/core/src/tags.ts
+++ b/packages/core/src/tags.ts
@@ -1,0 +1,169 @@
+/**
+ * Tag derivation — port of Python's codemem/store/tags.py.
+ *
+ * Derives searchable tags from memory kind, title, concepts, and file paths.
+ * Used at ingest time to populate memory_items.tags_text inline (matching
+ * Python's store_observation → derive_tags flow).
+ */
+
+const STOPWORDS = new Set([
+	"the",
+	"and",
+	"for",
+	"with",
+	"this",
+	"that",
+	"from",
+	"are",
+	"was",
+	"were",
+	"has",
+	"have",
+	"had",
+	"not",
+	"but",
+	"can",
+	"will",
+	"all",
+	"been",
+	"each",
+	"which",
+	"their",
+	"said",
+	"its",
+	"into",
+	"than",
+	"other",
+	"some",
+	"could",
+	"them",
+	"about",
+	"then",
+	"made",
+	"after",
+	"many",
+	"also",
+	"did",
+	"just",
+	"should",
+	"over",
+	"such",
+	"there",
+	"would",
+	"more",
+	"now",
+	"very",
+	"when",
+	"what",
+	"your",
+	"how",
+	"out",
+	"our",
+	"his",
+	"her",
+	"she",
+	"him",
+	"most",
+]);
+
+/**
+ * Normalize a raw value into a tag-safe lowercase slug.
+ * Returns empty string if the value is empty, a stopword, or too short.
+ */
+export function normalizeTag(value: string, stopwords?: Set<string>): string {
+	let lowered = (value || "").trim().toLowerCase();
+	if (!lowered) return "";
+	lowered = lowered
+		.replace(/[^a-z0-9_]+/g, "-")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "");
+	if (!lowered) return "";
+	const words = stopwords ?? STOPWORDS;
+	if (words.has(lowered)) return "";
+	if (lowered.length > 40) lowered = lowered.slice(0, 40).replace(/-$/, "");
+	return lowered;
+}
+
+/**
+ * Extract tags from a file path (basename, parent dir, top-level dir).
+ */
+export function fileTags(pathValue: string, stopwords?: Set<string>): string[] {
+	const raw = (pathValue || "").trim();
+	if (!raw) return [];
+	const parts = raw.split(/[\\/]+/).filter((p): p is string => !!p && p !== "." && p !== "..");
+	if (!parts.length) return [];
+
+	const tags: string[] = [];
+	const last = parts.at(-1);
+	if (last) {
+		const basename = normalizeTag(last, stopwords);
+		if (basename) tags.push(basename);
+	}
+	if (parts.length >= 2) {
+		const secondLast = parts.at(-2);
+		if (secondLast) {
+			const parent = normalizeTag(secondLast, stopwords);
+			if (parent) tags.push(parent);
+		}
+	}
+	if (parts.length >= 3) {
+		const first = parts.at(0);
+		if (first) {
+			const top = normalizeTag(first, stopwords);
+			if (top) tags.push(top);
+		}
+	}
+	return tags;
+}
+
+/**
+ * Derive tags from memory metadata, matching Python's derive_tags().
+ *
+ * Sources (in priority order):
+ * 1. Memory kind
+ * 2. Concepts (from observer XML output)
+ * 3. File paths (read + modified)
+ * 4. Title tokens (fallback when nothing else produced tags)
+ */
+export function deriveTags(opts: {
+	kind: string;
+	title?: string;
+	concepts?: string[];
+	filesRead?: string[];
+	filesModified?: string[];
+	stopwords?: Set<string>;
+}): string[] {
+	const words = opts.stopwords ?? STOPWORDS;
+	const tags: string[] = [];
+
+	const kindTag = normalizeTag(opts.kind, words);
+	if (kindTag) tags.push(kindTag);
+
+	for (const concept of opts.concepts ?? []) {
+		const normalized = normalizeTag(concept, words);
+		if (normalized) tags.push(normalized);
+	}
+
+	for (const pathValue of [...(opts.filesRead ?? []), ...(opts.filesModified ?? [])]) {
+		tags.push(...fileTags(pathValue, words));
+	}
+
+	// Fallback: extract tokens from title if no other tags were found
+	if (!tags.length && opts.title) {
+		for (const match of opts.title.toLowerCase().matchAll(/[a-z0-9_]+/g)) {
+			const normalized = normalizeTag(match[0], words);
+			if (normalized) tags.push(normalized);
+		}
+	}
+
+	// Dedupe while preserving order, cap at 20
+	const deduped: string[] = [];
+	const seen = new Set<string>();
+	for (const tag of tags) {
+		if (seen.has(tag)) continue;
+		seen.add(tag);
+		deduped.push(tag);
+		if (deduped.length >= 20) break;
+	}
+	return deduped;
+}


### PR DESCRIPTION
## Description

Port Python's `derive_tags()` to TypeScript (`packages/core/src/tags.ts`) and wire it into the ingest pipeline so `memory_items.tags_text` is populated at creation time instead of requiring a separate `backfill-tags` pass.

Previously, the TS ingest path passed `undefined` for tags on every `store.remember()` call, meaning all new memories had empty `tags_text` — causing the "Tag coverage is low" health warning.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 612 passed)
- [x] Typecheck passes (`pnpm run typecheck`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced