### PR TITLE
fix(ui): replace legacy uv run commands with codemem CLI

### DIFF
--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -175,18 +175,18 @@ export function renderHealthOverview() {
   const triggerSync = () => api.triggerSync();
   const recommendations: HealthAction[] = [];
   if (hasBacklog) {
-    recommendations.push({ label: 'Pipeline needs attention. Check queue health first.', command: 'uv run codemem raw-events-status' });
-    recommendations.push({ label: 'Then retry failed batches for impacted sessions.', command: 'uv run codemem raw-events-retry <opencode_session_id>' });
+    recommendations.push({ label: 'Pipeline needs attention. Check queue health first.', command: 'codemem db raw-events-status' });
+    recommendations.push({ label: 'Then retry failed batches for impacted sessions.', command: 'codemem db raw-events-retry <opencode_session_id>' });
   } else if (syncState === 'stopped') {
-    recommendations.push({ label: 'Sync daemon is stopped. Start the background service.', command: 'uv run codemem sync start' });
+    recommendations.push({ label: 'Sync daemon is stopped. Start the background service.', command: 'codemem sync start' });
   } else if (!syncDisabled && !syncNoPeers && (syncState === 'error' || syncState === 'degraded')) {
-    recommendations.push({ label: 'Sync is unhealthy. Restart and run one immediate pass.', command: 'uv run codemem sync restart', action: triggerSync, actionLabel: 'Sync now' });
-    recommendations.push({ label: 'Then run doctor to see root cause details.', command: 'uv run codemem sync doctor' });
+    recommendations.push({ label: 'Sync is unhealthy. Restart and run one immediate pass.', command: 'codemem sync restart', action: triggerSync, actionLabel: 'Sync now' });
+    recommendations.push({ label: 'Then run doctor to see root cause details.', command: 'codemem sync doctor' });
   } else if (!syncDisabled && !syncNoPeers && syncLooksStale) {
-    recommendations.push({ label: 'Sync is stale. Run one immediate sync pass.', command: 'uv run codemem sync once', action: triggerSync, actionLabel: 'Sync now' });
+    recommendations.push({ label: 'Sync is stale. Run one immediate sync pass.', command: 'codemem sync once', action: triggerSync, actionLabel: 'Sync now' });
   }
   if (tagCoverage > 0 && tagCoverage < 0.7 && recommendations.length < 2) {
-    recommendations.push({ label: 'Tag coverage is low. Preview backfill impact.', command: 'uv run codemem backfill-tags --dry-run' });
+    recommendations.push({ label: 'Tag coverage is low. Preview backfill impact.', command: 'codemem db backfill-tags --dry-run' });
   }
   renderActionList(healthActions, recommendations);
 

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -142,21 +142,21 @@ export function renderSyncStatus() {
   } else if (daemonState === 'offline-peers') {
     /* informational */
   } else if (daemonState === 'stopped') {
-    actions.push({ label: 'Sync daemon is stopped. Start it.', command: 'uv run codemem sync start' });
-    actions.push({ label: 'Then run one immediate sync pass.', command: 'uv run codemem sync once' });
+    actions.push({ label: 'Sync daemon is stopped. Start it.', command: 'codemem sync start' });
+    actions.push({ label: 'Then run one immediate sync pass.', command: 'codemem sync once' });
   } else if (syncError || pingError || daemonState === 'error') {
     actions.push({
       label: 'Sync reports errors. Restart now.',
-      command: 'uv run codemem sync restart && uv run codemem sync once',
+      command: 'codemem sync restart && codemem sync once',
     });
     actions.push({
       label: 'Then run doctor for root cause.',
-      command: 'uv run codemem sync doctor',
+      command: 'codemem sync doctor',
     });
   } else if (!syncDisabled && !syncNoPeers && pending > 0) {
     actions.push({
       label: 'Pending sync work detected. Run one pass now.',
-      command: 'uv run codemem sync once',
+      command: 'codemem sync once',
     });
   }
   renderActionList(syncActions, actions);

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -211,11 +211,11 @@ export function renderTeamSync() {
     const textWrap = el('div', 'sync-action-text');
     textWrap.textContent = 'No devices are paired yet.';
     textWrap.appendChild(
-      el('span', 'sync-action-command', 'uv run codemem sync pair --payload-only'),
+      el('span', 'sync-action-command', 'codemem sync pair --payload-only'),
     );
     const btn = el('button', 'settings-button sync-action-copy', 'Copy') as HTMLButtonElement;
     btn.addEventListener('click', () =>
-      copyToClipboard('uv run codemem sync pair --payload-only', btn),
+      copyToClipboard('codemem sync pair --payload-only', btn),
     );
     row.append(textWrap, btn);
     actions.appendChild(row);


### PR DESCRIPTION
## Description

Replace all `uv run codemem ...` command references in the viewer UI with `codemem ...`. The Python backend won't ship in the release, so troubleshooting recommendations and copy-to-clipboard commands need to reference the TS CLI directly.

Affects `health.ts` (6 commands), `diagnostics.ts` (5 commands), and `team-sync.ts` (2 commands + clipboard). Also fixes the backfill-tags recommendation to use the correct subcommand path: `codemem db backfill-tags --dry-run`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 612 passed)
- [x] Typecheck passes (`pnpm run typecheck`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced