### PR TITLE
fix(ui): show actionable restart command instead of vague manual restart notice

### DIFF
--- a/packages/ui/src/tabs/settings.ts
+++ b/packages/ui/src/tabs/settings.ts
@@ -418,7 +418,7 @@ function buildSettingsNotice(payload: any): { message: string; type: 'success' |
     lines.push(`Sync: ${sync.reason}.`);
   }
   if (restartRequired.length) {
-    lines.push(`Manual restart required: ${joinPhrases(restartRequired)}.`);
+    lines.push(`Restart required for ${joinPhrases(restartRequired)}. Run: codemem serve restart`);
   }
   warnings.forEach((warning) => {
     lines.push(warning);


### PR DESCRIPTION
## Description

Replace the vague "Manual restart required: sync coordinator url." settings notice with an actionable message: "Restart required for sync coordinator url. Run: codemem serve restart".

Users now see the exact command to run instead of wondering what "manual restart" means.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 612 passed)
- [x] Typecheck passes (`pnpm run typecheck`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced