### PR TITLE
docs: scrub stale Python references across README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,7 @@ Persistent memory for [OpenCode](https://opencode.ai) and [Claude Code](https://
 
 ## Quick start
 
-**Prerequisites:** Python 3.11+ and [uv](https://docs.astral.sh/uv/)
-
-If `uv` is not installed yet:
-
-```bash
-# Homebrew
-brew install uv
-
-# mise
-mise use -g uv@latest
-```
+**Prerequisites:** Node.js 22+ and npm (or pnpm)
 
 1. Add the plugin to your OpenCode config (`~/.config/opencode/opencode.jsonc`):
 
@@ -40,24 +30,23 @@ mise use -g uv@latest
 
 2. Restart OpenCode.
 
-By default, the OpenCode plugin resolves backend CLI calls from a `uvx` source pinned to the plugin version, so plugin and backend stay aligned unless you override `CODEMEM_RUNNER` / `CODEMEM_RUNNER_FROM`. That means the backend is fetched on first use; no separate `codemem` install is required for the basic OpenCode path.
+The OpenCode plugin manages backend execution automatically — no separate global install is required.
 
 3. Verify:
 
 ```bash
-uvx codemem stats
-uvx codemem raw-events-status
+# Works on fresh installs (no global codemem needed)
+npx -y codemem stats
+npx -y codemem db raw-events-status
 ```
 
 That's it. The plugin captures activity, builds memories, and injects context from here on.
 
-If you want `codemem` available directly on your `PATH` for repeated manual commands, install the CLI separately:
+If you want `codemem` available directly on your `PATH` for manual commands, install the CLI globally:
 
 ```bash
-uv tool install --upgrade codemem
+npm install -g codemem
 ```
-
-First startup may be slower because `uvx` can fetch/install the backend on demand.
 
 ### Claude Code (marketplace install)
 
@@ -68,19 +57,9 @@ In [Claude Code](https://claude.ai/code), add the codemem marketplace source and
 /plugin install codemem
 ```
 
-The Claude plugin starts MCP with:
+The Claude plugin starts MCP with the TS CLI (`codemem mcp`).
 
-- `uvx codemem==<plugin-version> mcp`
-
-We still recommend installing/upgrading the CLI for local hook ingestion and manual `codemem` commands:
-
-```bash
-uv tool install --upgrade codemem
-```
-
-Claude MCP launch uses `uvx`; first startup may be slower because `uvx` can fetch/install tooling on demand.
-
-Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks`) and falls back to direct local DB enqueue via `codemem claude-hook-ingest` (or pinned `uvx codemem==<plugin-version> claude-hook-ingest`) when the local server path is unavailable.
+Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks`) and falls back to direct local DB enqueue via `codemem claude-hook-ingest` when the local server path is unavailable.
 
 Claude hook events share the same raw-event queue pipeline used by OpenCode. `UserPromptSubmit` runs
 capture ingest in the background and injects memory context via Claude `additionalContext` using
@@ -88,7 +67,6 @@ local CLI/store pack generation by default, with optional HTTP `/api/pack` fallb
 
 The packaged Claude hook shell scripts are thin wrappers over TS CLI commands:
 `codemem claude-hook-ingest` and `codemem claude-hook-inject`.
-`claude-hook-inject` does not use `uvx` fallback by default to keep prompt-submit latency low.
 
 > Migrating from `opencode-mem`? See [docs/rename-migration.md](docs/rename-migration.md).
 
@@ -207,8 +185,8 @@ Replicate memories across devices without a central server.
 ```bash
 codemem sync enable        # generate device keys
 codemem sync pair          # generate pairing payload
-codemem sync daemon        # start sync daemon
-codemem sync install       # autostart on macOS + Linux
+codemem sync start         # start sync daemon
+codemem sync once          # run one immediate sync pass
 ```
 
 The viewer now includes actor management for mapping multiple peers to one logical person, plus owned-memory visibility controls so project-filtered memories share by default while `Only me` stays a per-memory local override.
@@ -221,38 +199,23 @@ For cross-network setups where peer addresses change frequently or mDNS does not
 
 Embeddings are stored in sqlite-vec and written automatically when memories are created. Use `codemem embed` to backfill existing memories. If sqlite-vec cannot load, keyword search still works.
 
-> **aarch64 Linux note:** The PyPI wheels currently ship a 32-bit `vec0.so` on aarch64. See [docs/user-guide.md](docs/user-guide.md) for the workaround.
-
 ## Alternative install methods
 
 <details>
-<summary>Local development, uvx, git install</summary>
+<summary>Local development, npx, git install</summary>
 
 ### Local development
 
 ```bash
-uv sync
-source .venv/bin/activate  # bash/zsh
-source .venv/bin/activate.fish  # fish
-codemem --help
+pnpm install
+pnpm build
+pnpm run codemem --help
 ```
 
-### Via uvx (no install)
+### Via npx (no install)
 
 ```bash
-uvx --from git+ssh://git@github.com/kunickiaj/codemem.git codemem stats
-```
-
-### Install from GitHub
-
-```bash
-uv pip install git+ssh://git@github.com/kunickiaj/codemem.git
-```
-
-### Plugin from git (advanced)
-
-```bash
-uvx --from git+ssh://git@github.com/kunickiaj/codemem.git codemem install-plugin
+npx -y codemem stats
 ```
 
 ### Plugin for development

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,13 +6,13 @@ codemem has five main pieces: **adapters** that capture shell/runtime activity, 
 
 | Component | What it does | Key files |
 |-----------|-------------|-----------|
-| Adapters | Capture OpenCode/Claude events and enqueue raw events for ingest | `.opencode/plugin/codemem.js`, `plugins/claude/scripts/ingest-hook.sh`, `codemem/commands/claude_integration_cmds.py`, `codemem/claude_hooks.py` |
-| Ingest pipeline | Extracts tool events, builds transcripts, runs the observer | `codemem/plugin_ingest.py`, `codemem/ingest/` |
-| Observer | Produces typed observations and session summaries from transcripts | `codemem/observer_prompts.py`, `codemem/xml_parser.py` |
-| Store | SQLite persistence for sessions, memories, artifacts, embeddings | `codemem/store/`, `codemem/db.py` |
-| Viewer | Local web UI + JSON APIs for stats, sessions, and memory items | `codemem/viewer.py`, `codemem/viewer_routes/` |
-| MCP server | Exposes memory tools (search, timeline, pack, remember, forget) to OpenCode | `codemem/mcp_server.py` |
-| CLI | Ties everything together: ingest, serve, search, export/import, sync | `codemem/cli_app.py` |
+| Adapters | Capture OpenCode/Claude events and enqueue raw events for ingest | `.opencode/plugin/codemem.js`, `plugins/claude/scripts/ingest-hook.sh`, `packages/core/src/claude-hooks.ts` |
+| Ingest pipeline | Extracts tool events, builds transcripts, runs the observer | `packages/core/src/ingest-pipeline.ts`, `packages/core/src/ingest-events.ts` |
+| Observer | Produces typed observations and session summaries from transcripts | `packages/core/src/ingest-prompts.ts`, `packages/core/src/ingest-xml-parser.ts` |
+| Store | SQLite persistence for sessions, memories, artifacts, embeddings | `packages/core/src/store.ts`, `packages/core/src/schema.ts` |
+| Viewer | Local web UI + JSON APIs for stats, sessions, and memory items | `packages/viewer-server/src/`, `packages/ui/src/` |
+| MCP server | Exposes memory tools (search, timeline, pack, remember, forget) to OpenCode | `packages/mcp-server/src/` |
+| CLI | Ties everything together: ingest, serve, search, export/import, sync | `packages/cli/src/` |
 
 ## Data flow
 
@@ -34,7 +34,7 @@ flowchart LR
 
 1. Adapters capture tool/conversation lifecycle events and normalize them into raw events with optional `_adapter` envelopes.
 2. OpenCode streams raw events to the viewer ingest API (`POST /api/raw-events`) with preflight checks (`GET /api/raw-events/status`) and can fall back to CLI queue enqueue when stream writes fail.
-3. Claude hook ingestion posts to `POST /api/claude-hooks` first and falls back to `codemem claude-hook-ingest` direct enqueue (or pinned `uvx`) when the local viewer API is unavailable.
+3. Claude hook ingestion posts to `POST /api/claude-hooks` first and falls back to `codemem claude-hook-ingest` direct enqueue when the local viewer API is unavailable.
 4. The viewer/store persists raw events and queues durable flush batches.
 5. Idle and sweeper workers claim batches and run them through ingest.
 6. Ingest builds a transcript from user prompts and assistant messages, then hands it to the observer.
@@ -117,7 +117,7 @@ If sqlite-vec can't load (e.g., missing native extension), semantic search is si
 
 ### Hybrid merge and re-rank (pack path)
 
-In the pack-building path — CLI `pack`/`inject`, MCP `memory_pack`, and plugin injection — results from both backends are merged and re-ranked. This happens in `_merge_ranked_results` (`codemem/store/search.py`):
+In the pack-building path — CLI `pack`/`inject`, MCP `memory_pack`, and plugin injection — results from both backends are merged and re-ranked. This happens in the hybrid merge layer (`packages/core/src/search.ts`):
 
 1. Run FTS5 search to get lexical candidates.
 2. Run semantic search to get vector candidates.
@@ -177,7 +177,7 @@ These are concatenated into a single query string, capped at 500 characters.
 
 ### How the pack is built
 
-`build_memory_pack` (`codemem/store/packs.py`) assembles three sections:
+`buildMemoryPack` (`packages/core/src/pack.ts`) assembles three sections:
 
 1. **Summary** — the most recent `session_summary` matching the query (or the latest one if none match)
 2. **Timeline** — recent memories from search results, ordered by relevance
@@ -238,7 +238,7 @@ The observer turns raw session transcripts into typed, structured memories. It's
 
 ### Memory taxonomy
 
-Observations use a fixed set of kinds defined in `codemem/memory_kinds.py`:
+Observations use a fixed set of kinds defined in `packages/core/src/store.ts`:
 
 | Kind | When to use | Example |
 |------|------------|---------|
@@ -258,11 +258,11 @@ Observations use a fixed set of kinds defined in `codemem/memory_kinds.py`:
 
 Noise control happens at three layers:
 
-1. **Event extraction** (`codemem/ingest/events.py`) — Low-signal tool types (`tui`, `shell`, `task`, `slashcommand`, `skill`, `todowrite`, `askuserquestion`) are dropped before they reach the observer. Internal codemem memory tools (anything starting with `codemem_memory_`) are also excluded to prevent feedback loops.
+1. **Event extraction** (`packages/core/src/ingest-events.ts`) — Low-signal tool types (`tui`, `shell`, `task`, `slashcommand`, `skill`, `todowrite`, `askuserquestion`) are dropped before they reach the observer. Internal codemem memory tools (anything starting with `codemem_memory_`) are also excluded to prevent feedback loops.
 
-2. **Observer prompt guidance** (`codemem/observer_prompts.py`) — The observer prompt instructs the LLM to skip routine/noise-only work and focus on meaningful changes, decisions, and discoveries.
+2. **Observer prompt guidance** (`packages/core/src/ingest-prompts.ts`) — The observer prompt instructs the LLM to skip routine/noise-only work and focus on meaningful changes, decisions, and discoveries.
 
-3. **Post-observer text filtering** (`codemem/summarizer.py`) — `is_low_signal_observation` applies regex patterns to catch formulaic low-value outputs that the observer sometimes produces despite guidance (e.g., "no code changes were recorded", "only file inspection occurred").
+3. **Post-observer text filtering** (`packages/core/src/ingest-filters.ts`) — `isLowSignalObservation` applies regex patterns to catch formulaic low-value outputs that the observer sometimes produces despite guidance (e.g., "no code changes were recorded", "only file inspection occurred").
 
 ### Structured fields
 
@@ -272,7 +272,7 @@ Each observation is persisted with structured metadata that improves retrieval:
 - **`concepts`** — domain concepts and technical terms mentioned
 - **`files_read`** / **`files_modified`** — file paths involved in the work
 - **`narrative`** — the full observation text
-- **`tags_text`** — auto-derived from kind, concepts, and file paths (`codemem/store/tags.py`); used in FTS5 indexing
+- **`tags_text`** — auto-derived from kind, concepts, and file paths (`packages/core/src/tags.ts`); used in FTS5 indexing
 
 These fields feed into tag derivation, which directly influences FTS5 recall and pack section ordering (tag overlap with the query boosts observation ranking).
 

--- a/docs/autostart/launchd/com.codemem.sync.plist
+++ b/docs/autostart/launchd/com.codemem.sync.plist
@@ -7,8 +7,9 @@
     <key>ProgramArguments</key>
     <array>
       <string>codemem</string>
-      <string>sync</string>
-      <string>daemon</string>
+      <string>serve</string>
+      <string>start</string>
+      <string>--foreground</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/docs/autostart/systemd/codemem-sync.service
+++ b/docs/autostart/systemd/codemem-sync.service
@@ -1,9 +1,9 @@
 [Unit]
-Description=codemem sync daemon
+Description=codemem viewer + sync daemon
 After=network-online.target
 
 [Service]
-ExecStart=codemem sync daemon
+ExecStart=codemem serve start --foreground
 Restart=on-failure
 Environment=CODEMEM_CONFIG=%h/.config/codemem/config.json
 

--- a/docs/coordinator-deployment.md
+++ b/docs/coordinator-deployment.md
@@ -1,19 +1,19 @@
-# Deploying the Python coordinator
+# Deploying the coordinator
 
-The built-in Python coordinator is the canonical deployment target for team sync. This guide covers how to run it
+The built-in coordinator is the canonical deployment target for team sync. This guide covers how to run it
 natively, in a container, and how to expose it to teammates outside your local network.
 
 ## Quick start (native)
 
 ```fish
-# Install codemem (makes the `codemem` command available)
-pip install codemem
+# Install codemem CLI (makes the `codemem` command available)
+npm install -g codemem
 
 # Create a coordinator group
 codemem sync coordinator group-create my-team --db-path ~/.codemem/coordinator.sqlite
 
 # Set an admin secret (required for creating invites via the API)
-set -x CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET (python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+set -x CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET (openssl rand -base64 32)
 
 # Start the coordinator
 codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
@@ -79,9 +79,9 @@ codemem sync coordinator deny-join-request <request-id> --db-path <path>
 No official Dockerfile is shipped yet. Here is a minimal example:
 
 ```dockerfile
-FROM python:3.12-slim
+FROM node:24-slim
 
-RUN pip install --no-cache-dir codemem
+RUN npm install -g codemem
 
 VOLUME /data
 

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -84,7 +84,7 @@ codemem sync coordinator remove-device team-alpha <device-id> --db-path ~/.codem
 codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
 ```
 
-This keeps the primary deployment path inside the main `codemem` artifact and reuses the existing Python signature
+This keeps the primary deployment path inside the main `codemem` artifact and reuses the existing signature
 verification code directly.
 
 These management commands operate on the built-in local coordinator store only. Remote coordinator admin flows require a
@@ -137,7 +137,7 @@ is only for remote mutation/listing endpoints.
 
 ## Canonical deployment target
 
-The built-in Python coordinator (`codemem sync coordinator serve`) is the canonical deployment target for ongoing
+The built-in coordinator (`codemem sync coordinator serve`) is the canonical deployment target for ongoing
 product development and dogfooding.
 
 Recommended deployment patterns:
@@ -146,17 +146,17 @@ Recommended deployment patterns:
 - **Container**: run via Docker/Podman with the coordinator SQLite volume mounted
 - **Exposure**: use Tailscale Funnel or Cloudflare Tunnel to make the coordinator reachable from outside a local network
 
-This keeps the deployment path inside the main `codemem` artifact, avoids a separate JS runtime dependency, and ensures
-new coordinator features (invites, join requests, admin flows) are immediately available without porting.
+This keeps the deployment path inside the main `codemem` artifact and ensures new coordinator features (invites, join
+requests, admin flows) are immediately available.
 
 ## Cloudflare Worker reference deployment
 
 A Cloudflare Worker reference implementation exists in `examples/cloudflare-coordinator/`. It implements the same HTTP
-contract against D1, but is secondary to the Python coordinator for ongoing feature development.
+contract against D1, but is secondary to the built-in coordinator for ongoing feature development.
 
 Use the Cloudflare Worker path when you specifically want a serverless/edge deployment and are comfortable with the
-feature lag — new coordinator capabilities (invite/join flows, admin endpoints) land in the Python coordinator first and
-may not be ported to the Worker immediately.
+feature lag — new coordinator capabilities (invite/join flows, admin endpoints) land in the built-in coordinator first
+and may not be ported to the Worker immediately.
 
 ## Current limitations
 

--- a/docs/migration-python-to-ts.md
+++ b/docs/migration-python-to-ts.md
@@ -1,102 +1,32 @@
 # Migration: Python to TypeScript backend
 
-## Overview
+> **Status: Complete.** The TypeScript backend is the primary and only shipped runtime
+> as of `0.20.x`. The Python backend code remains in the repo for reference but is not
+> part of the release artifacts.
 
-codemem is migrating from a Python backend (`uvx codemem`) to a TypeScript backend
-(`npx @codemem/cli`). Both backends share the same SQLite database.
+## Background
 
-## How to switch
-
-### Using npx (recommended)
-
-```bash
-export CODEMEM_RUNNER=npx
-```
-
-This runs the TS CLI via `npx @codemem/cli`. No global install required.
-
-### Using a global install
-
-```bash
-npm install -g @codemem/cli
-export CODEMEM_RUNNER=node
-export CODEMEM_RUNNER_FROM=$(which codemem)
-```
-
-### Using a local repo (dev mode)
-
-```bash
-export CODEMEM_RUNNER=node
-export CODEMEM_RUNNER_FROM=/path/to/codemem
-```
-
-Requires `pnpm build` in the repo first.
-
-### Switching back to Python
-
-```bash
-export CODEMEM_RUNNER=uvx
-# or unset CODEMEM_RUNNER
-```
+codemem originally used a Python backend (`uvx codemem`). The TS backend
+(`codemem` npm package) reached full feature parity and is now the sole shipped path.
 
 ## Database compatibility
 
-Both backends share `~/.codemem/mem.sqlite`. The coexistence contract:
-
-- **Schema ownership**: Python currently owns DDL (schema migrations). TS validates
-  but does not create or migrate tables.
-- **Additive tolerance**: TS tolerates newer schema versions from Python.
-- **Backup on first TS access**: The TS runtime creates a timestamped backup
-  (`mem.sqlite.pre-ts-YYYYMMDDTHHMMSS.bak`) before its first write.
-- **Required tables**: TS hard-fails if required tables are missing, with clear
-  messages pointing to the Python runtime for initialization.
+Both backends share `~/.codemem/mem.sqlite`. The TS backend owns schema initialization
+and migrations. If you previously ran the Python backend, the TS runtime handles the
+existing database seamlessly — no manual migration is needed.
 
 ## Environment variables
 
 | Variable | Purpose |
 |---|---|
-| `CODEMEM_RUNNER` | Backend runner: `uvx` (default), `uv`, `node`, `npx` |
-| `CODEMEM_RUNNER_FROM` | Runner source path/package override |
-| `CODEMEM_DB` | Database path (shared by both backends) |
-| `CODEMEM_DEVICE_ID` | Device identity (shared) |
-| `CODEMEM_ACTOR_ID` | Actor identity (shared) |
+| `CODEMEM_DB` | Database path |
+| `CODEMEM_DEVICE_ID` | Device identity |
+| `CODEMEM_ACTOR_ID` | Actor identity |
 
-## Staged rollout
+## Migration history
 
-### Stage 1: Opt-in (current)
-
-Python is the default. Users opt in to TS via `CODEMEM_RUNNER=npx`.
-
-### Stage 2: TS as default
-
-Plugin default runner switches from `uvx` to `npx`. Python still available
-via `CODEMEM_RUNNER=uvx`.
-
-### Stage 3: Python removal
-
-Python backend, `pyproject.toml`, and `uv`/`uvx` runner paths removed.
-
-## Known gaps (TS vs Python)
-
-| Area | Status |
+| Stage | Status |
 |---|---|
-| Core CRUD, search, pack | Complete |
-| MCP server (13 tools) | Complete |
-| CLI (stats, search, pack, serve, mcp) | Complete |
-| Viewer server (all routes) | Complete |
-| Raw event sweeper (background ingest) | Complete |
-| POST /api/raw-events | Complete |
-| Config read | Complete |
-| Config write + runtime effects | Not yet ported |
-| Schema initialization (DDL) | Python-only |
-| `/api/claude-hooks` ingestion | Complete (HTTP-first + direct enqueue fallback) |
-
-## Rollback
-
-If issues arise with the TS backend:
-
-1. Set `CODEMEM_RUNNER=uvx` to return to Python
-2. Restore the database backup if needed:
-   ```bash
-   cp ~/.codemem/mem.sqlite.pre-ts-*.bak ~/.codemem/mem.sqlite
-   ```
+| Stage 1: Opt-in TS via `CODEMEM_RUNNER=npx` | Complete |
+| Stage 2: TS as default runner | Complete |
+| Stage 3: Python removal from release path | Complete (`0.20.x`) |

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -24,31 +24,13 @@ In Claude Code, add the marketplace and install the plugin:
 /plugin install codemem
 ```
 
-Prerequisite: `uvx` must be available (provided by `uv`). If needed:
+The plugin starts MCP with the TS CLI:
 
-```bash
-# Homebrew
-brew install uv
+- `codemem mcp`
 
-# mise
-mise use -g uv@latest
-```
+Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks` to the local codemem server) with a CLI direct-enqueue fallback when the server path is unavailable:
 
-The plugin starts MCP with:
-
-- `uvx codemem==<plugin-version> mcp`
-
-We still recommend installing the CLI explicitly for local hook ingestion and manual `codemem` usage:
-
-```bash
-uv tool install --upgrade codemem
-```
-
-Claude MCP launch uses `uvx`; startup can be slower on first run because it may install dependencies on demand.
-
-Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks` to the local codemem server) with a version-pinned CLI direct-enqueue fallback when the server path is unavailable:
-
-- `uvx codemem==<plugin-version> claude-hook-ingest`
+- `codemem claude-hook-ingest`
 
 Contract note: fallback is direct local DB enqueue from the TS CLI. There is currently no file spool/lock durability path in the fallback contract.
 
@@ -67,8 +49,6 @@ printf '%s\n' '{"hook_event_name":"SessionStart","session_id":"sess-1","cwd":"/t
 `inject-context-hook.sh` is also a thin wrapper and delegates prompt-time context output to:
 
 - `codemem claude-hook-inject`
-
-To avoid prompt-time latency spikes, `inject-context-hook.sh` does not use `uvx` by default. You can opt in with `CODEMEM_INJECT_ALLOW_UVX=1`.
 
 By default, `SessionEnd` triggers a boundary flush after enqueue to preserve progress without waiting for sweeper timing. Set `CODEMEM_CLAUDE_HOOK_FLUSH=0` to force enqueue-only behavior, and set `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` to include `Stop` boundary flush.
 
@@ -102,12 +82,12 @@ After restarting OpenCode or the viewer, run this quick check when behavior look
 2. Check backend stats and recent writes (`codemem stats`, `codemem recent`).
 3. Verify runner mode and source (`CODEMEM_RUNNER`, `CODEMEM_RUNNER_FROM`) match your install strategy.
 4. Confirm injection controls are what you expect (`CODEMEM_INJECT_CONTEXT`, `CODEMEM_INJECT_LIMIT`, `CODEMEM_INJECT_TOKEN_BUDGET`).
-5. If stream mode is enabled, check backlog health (`codemem raw-events-status`) and Claude-specific health (`codemem claude-integration-status`).
+5. If stream mode is enabled, check backlog health (`codemem db raw-events-status`).
 
 If needed, restart viewer + plugin flow:
 
 ```bash
-codemem serve --restart
+codemem serve restart
 ```
 
 If compatibility toasts appear after restart, follow the runner-specific guidance in Compatibility guidance behavior below.
@@ -186,7 +166,7 @@ Stream contract:
 - Event streaming: `POST /api/raw-events`
 - Non-2xx and network failures are treated as stream failures.
 - Raw events are delivered through the viewer ingest API.
-- Raw-event batches accepted by the viewer are retried by Python flush workers.
+- Raw-event batches accepted by the viewer are retried by the sweeper flush workers.
 
 Suggested settings:
 
@@ -204,13 +184,13 @@ export CODEMEM_RAW_EVENTS_STUCK_BATCH_MS=300000
 To monitor backlog:
 
 ```bash
-codemem raw-events-status
+codemem db raw-events-status
 ```
 
 If `raw-events-status` shows `batches=error:N` (legacy label) or `queue=... failed:N` for a stream, retry:
 
 ```bash
-codemem raw-events-retry <session_stream_id>
+codemem db raw-events-retry <session_stream_id>
 ```
 
 ## Hook lifecycle and flush boundaries
@@ -231,7 +211,7 @@ Force-flush thresholds (immediate flush):
 Failure semantics:
 - Stream POST failures are backoff-gated in plugin runtime (`CODEMEM_RAW_EVENTS_BACKOFF_MS`).
 - Availability checks are rate-limited (`CODEMEM_RAW_EVENTS_STATUS_CHECK_MS`).
-- Accepted raw-event batches are retried by viewer/store queue workers (`codemem raw-events-retry`).
+- Accepted raw-event batches are retried by viewer/store queue workers (`codemem db raw-events-retry`).
 
 ## Project label normalization
 
@@ -252,8 +232,8 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 
 | Env var | Description |
 | --- | --- |
-| `CODEMEM_RUNNER` | Override auto-detected runner: `uv` (dev mode), `uvx` (installed mode), or direct binary path. |
-| `CODEMEM_RUNNER_FROM` | Override source location: directory path for `uv run --directory`, or package/git/path source for `uvx --from` (default OpenCode source is pinned to plugin version). |
+| `CODEMEM_RUNNER` | Override auto-detected runner: `codemem` (global), `npx`, `node` (repo/dev), or custom binary name. |
+| `CODEMEM_RUNNER_FROM` | Runner source override: npm package spec for `npx` (for example `codemem@0.20.0-alpha.7`), or repo/CLI entry path for `node`. |
 | `CODEMEM_VIEWER` | Set to `0`, `false`, or `off` to disable the viewer entirely. |
 | `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Customize the viewer host/port printed on startup. |
 | `CODEMEM_VIEWER_AUTO` | Set to `0`/`false`/`off` to disable auto-start (default on). |
@@ -266,7 +246,6 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_INJECT_HTTP_MAX_TIME_S` | `UserPromptSubmit` pack injection total timeout in seconds (default `2`). |
 | `CODEMEM_INJECT_HTTP_FALLBACK` | Set to `0` to disable HTTP `/api/pack` fallback for `claude-hook-inject` (default `1`). |
 | `CODEMEM_INJECT_MAX_CHARS` | Max chars returned as Claude `additionalContext` (default `16000`). |
-| `CODEMEM_INJECT_ALLOW_UVX` | Set to `1` to allow `uvx` fallback for `claude-hook-inject` (default `0`, disabled for prompt latency). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |
 | `CODEMEM_BACKEND_UPDATE_POLICY` | Backend update behavior on compatibility mismatch: `notify` (default), `auto`, or `off`. |
@@ -310,18 +289,17 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 
 When the plugin detects CLI/runtime version mismatch, it shows guidance based on runner mode:
 
-- `CODEMEM_RUNNER=uv`: pull latest in your repo, run `uv sync`, restart OpenCode
-- `CODEMEM_RUNNER=uvx` with package source: update `CODEMEM_RUNNER_FROM` (or update plugin package version), restart OpenCode
-- `CODEMEM_RUNNER=uvx` with git source: update `CODEMEM_RUNNER_FROM` to newer ref/source, restart OpenCode
-- `CODEMEM_RUNNER=uvx` with custom source: update `CODEMEM_RUNNER_FROM`, restart OpenCode
-- other/unknown runner: run `uv tool install --upgrade codemem`, restart OpenCode
+- `CODEMEM_RUNNER=codemem`: run `npm install -g codemem`, then restart OpenCode
+- `CODEMEM_RUNNER=npx`: update `CODEMEM_RUNNER_FROM` to a newer package/version (or reinstall plugin), then restart OpenCode
+- `CODEMEM_RUNNER=node`: pull latest repo changes and run `pnpm build`, then restart OpenCode
+- custom/unknown runner: update the underlying `codemem` binary or package source, then restart OpenCode
 
 Update policy:
 
 - `CODEMEM_BACKEND_UPDATE_POLICY=notify` (default): show warning toast with suggested action
 - `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible runners, then warn if still outdated
-  - skipped in `uv` dev mode
-  - skipped when `CODEMEM_RUNNER_FROM` is pinned to a git ref (for example `...git@vX.Y.Z`)
+  - skipped for `node` dev-mode runners
+  - skipped when `CODEMEM_RUNNER_FROM` is pinned to a fixed package/version
 - `CODEMEM_BACKEND_UPDATE_POLICY=off`: no compatibility toast (logging still records mismatch)
 
 Compatibility checks do not block plugin startup.

--- a/docs/rename-migration.md
+++ b/docs/rename-migration.md
@@ -69,7 +69,7 @@ cp ~/.config/opencode-mem/config.json ~/.config/codemem/config.json
 
 ```bash
 codemem stats
-codemem raw-events-status
+codemem db raw-events-status
 ```
 
 7. Confirm migrated default DB exists:

--- a/docs/trusted-publisher.md
+++ b/docs/trusted-publisher.md
@@ -1,51 +1,41 @@
-# PyPI Trusted Publisher Setup
+# npm Trusted Publishing Setup
 
-This project uses GitHub OIDC to publish to PyPI without long-lived API tokens.
+This project uses GitHub OIDC + npm provenance for release publishing.
 
-## Required PyPI configuration
+## Required npm configuration
 
-Create a Trusted Publisher entry for each project:
-
-- `codemem`
-- `codemem-core`
-
-Production PyPI values:
+Use npm trusted publishing for this GitHub repo:
 
 - **Owner**: `kunickiaj`
-- **Repository name**: `codemem`
-- **Workflow name**: `release.yml`
-- **Environment name**: `release`
-
-TestPyPI values:
-
-- **Owner**: `kunickiaj`
-- **Repository name**: `codemem`
-- **Workflow name**: `release.yml`
-- **Environment name**: `testpypi`
+- **Repository**: `codemem`
+- **Workflow**: `release.yml`
+- **Environment**: `release`
 
 ## GitHub workflow behavior
 
-`.github/workflows/release.yml` includes:
+`.github/workflows/release.yml` publishes on `v*` tags via the `publish-npm` job.
 
-- `publish-pypi` on tag pushes (`v*`) for production PyPI
-- `publish-testpypi` on manual workflow dispatch when `publish_target=testpypi`
+Published packages (in dependency order):
 
-Both jobs:
+1. `@codemem/core`
+2. `@codemem/mcp`
+3. `@codemem/server`
+4. `codemem`
 
-1. downloads `dist/` artifacts from the build job
-2. publishes via `pypa/gh-action-pypi-publish@release/v1`
-3. authenticates using OIDC (`permissions: id-token: write`)
+Publish command shape:
 
-## TestPyPI verification process
+- `pnpm --filter <package> publish --provenance --access public --tag <dist-tag>`
 
-1. In GitHub Actions, run the `Release` workflow manually.
-2. Set `publish_target` to `testpypi`.
-3. Confirm `publish-testpypi` succeeds.
-4. Verify package appears on TestPyPI.
+Dist-tag selection is automatic from the Git tag:
+
+- `*-alpha*` → `alpha`
+- `*-beta*` → `beta`
+- `*-rc*` → `rc`
+- otherwise → `latest`
 
 ## Verification checklist
 
-- Tag push `vX.Y.Z` runs `Release` workflow
-- `publish-pypi` job completes successfully
-- Package appears on PyPI with matching version
-- `uvx`/`pipx` install command resolves published version
+- Tag push `vX.Y.Z` runs `Release`
+- `publish-npm` job succeeds
+- Package versions on npm match the release tag
+- npm provenance attestation is present for published artifacts

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -3,13 +3,11 @@
 ## Start or restart the viewer
 - `codemem serve` runs the viewer in the foreground.
 - `codemem serve --background` runs it in the background.
-- `codemem serve --restart` restarts the background viewer.
+- `codemem serve restart` restarts the background viewer.
 
 ## Seeing UI changes
-- The viewer is a static HTML string in `codemem/viewer.py`.
-- Restart the viewer after updates.
-- If changes don’t show up, ensure the installed package matches this repo:
-  - `uv pip install -e .` then rerun `codemem serve --restart`.
+- The viewer UI is built from `packages/ui/` and served by `packages/viewer-server/`.
+- Restart the viewer after updates: `codemem serve restart`.
 
 ## Settings modal
 - Open via the Settings button in the header.
@@ -114,7 +112,7 @@ Judged query JSONL format:
 ### Enable + run
 
 - `codemem sync enable` generates keys and writes config.
-- `codemem sync daemon` starts the sync daemon (foreground).
+- `codemem sync start` starts sync daemon processing.
 - `codemem sync status` shows device info and peer health.
 
 ### Pair devices
@@ -152,9 +150,9 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 
 ### Autostart
 
-- macOS: `codemem sync install` then `launchctl load -w ~/Library/LaunchAgents/com.codemem.sync.plist`.
-- Linux (user service): `codemem sync install --user` then `systemctl --user enable --now codemem-sync.service`.
-- Linux (system service): `codemem sync install --system` then `systemctl enable --now codemem-sync.service`.
+- codemem does not ship a `sync install` helper in the TS CLI.
+- Use an OS service manager to run `codemem serve start --foreground` at login/boot.
+- Example service templates live in `docs/autostart/launchd/` and `docs/autostart/systemd/`.
 
 ### Service helpers
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,11 +1,10 @@
 # CodeMem Versioning Policy
 
-CodeMem uses one shared semantic version stream across npm and PyPI artifacts.
+CodeMem uses one shared semantic version stream across its npm packages.
 
 ## Canonical packages
 
-- npm: `@kunickiaj/codemem`
-- PyPI: `codemem` (runtime/CLI)
+- npm: `codemem` (plugin + CLI)
 
 ## Policy
 
@@ -13,23 +12,17 @@ CodeMem uses one shared semantic version stream across npm and PyPI artifacts.
 - npm and PyPI artifacts should publish the same `X.Y.Z`.
 - Changelog/release notes are shared per version.
 
-## Release helper
+## Release workflow
 
-Use the helper script to keep versioned files aligned:
+Version bumps are prepared on a release branch and touch these files:
 
-```bash
-uv run python scripts/release_version.py set X.Y.Z
-uv run python scripts/release_version.py check
-```
-
-The script updates/checks:
-
-- `pyproject.toml` (`[project].version`)
-- `codemem/__init__.py` (`__version__`)
-- `package.json` (`version`)
-- `.opencode/plugin/codemem.js` (`PINNED_BACKEND_VERSION`)
-- `plugins/claude/.claude-plugin/plugin.json` (`version` and `codemem==X.Y.Z` MCP arg)
-- `.claude-plugin/marketplace.json` (`metadata.version` and `plugins[*].version` for `codemem`)
+- `packages/core/package.json` (`version`)
+- `packages/cli/package.json` (`version`)
+- `packages/mcp-server/package.json` (`version`)
+- `packages/viewer-server/package.json` (`version`)
+- `packages/core/src/index.ts` (`VERSION` export)
+- `packages/core/src/index.test.ts` (version assertion)
+- `packages/cli/.opencode/plugins/codemem.js` (`PINNED_BACKEND_VERSION`)
 
 ## Release tag preflight
 
@@ -63,6 +56,5 @@ export CODEMEM_MIN_VERSION=0.9.20
 
 ## Transition notes
 
-- `codemem` and `codemem-core` are reserved on PyPI.
-- `codemem` and `@kunickiaj/codemem` are reserved on npm.
-- Git-based install paths remain fallback only during migration.
+- `codemem` is published on npm (CLI + plugin).
+- `@kunickiaj/codemem` is the OpenCode plugin identifier.


### PR DESCRIPTION
## Description

Docs command/accuracy sweep across README and user-facing docs to fully align with the TypeScript CLI and current command surface.

### What changed

- **README.md**
  - Quick-start verification now works on fresh installs with `npx -y codemem ...`
  - Corrected backlog check to `codemem db raw-events-status`
  - Corrected global install package name to `npm install -g codemem`
  - Updated sync quick commands (`sync start`, `sync once`)
  - Corrected npx example (`npx -y codemem stats`)

- **docs/plugin-reference.md**
  - Replaced stale raw-event commands with `codemem db raw-events-*`
  - Removed non-existent `codemem claude-integration-status` reference
  - Updated restart command to `codemem serve restart`
  - Updated runner/env guidance from legacy uv/uvx language to codemem/npx/node paths

- **docs/user-guide.md**
  - Updated sync command from `codemem sync daemon` to `codemem sync start`
  - Replaced removed `sync install` helper instructions with current autostart guidance

- **docs/autostart/** templates
  - Updated launchd + systemd examples to run `codemem serve start --foreground`

- **docs/coordinator-deployment.md**
  - Removed Python-specific deployment language
  - Updated install path to `npm install -g codemem`
  - Updated container example to Node/npm

- **docs/rename-migration.md**
  - Corrected health check command to `codemem db raw-events-status`

- **docs/trusted-publisher.md**
  - Rewritten from old PyPI trusted publisher doc to npm trusted publishing/provenance guidance

### Feedback addressed

- PR #402 review: fixed package-name/install mismatch (`codemem`, not `@codemem/cli`)
- PR #402 review: quick-start verify no longer assumes a global `codemem` binary

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Manually validated command availability via CLI help:
  - `pnpm run codemem db raw-events-status --help`
  - `pnpm run codemem sync start --help`
  - `pnpm run codemem serve restart --help`
  - `pnpm run codemem serve start --help`

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced