### PR TITLE
fix(serve): restart without pidfile after upgrades

### DIFF
--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildForegroundRunnerArgs,
+	extractViewerPid,
+	isLikelyViewerCommand,
+	isLocalHost,
 	isSqliteVecLoadFailure,
+	pickViewerPidCandidate,
 	sqliteVecFailureDiagnostics,
 } from "./serve.js";
 import {
@@ -150,5 +154,39 @@ describe("serve command option resolution", () => {
 		expect(lines.some((line) => line.startsWith("node="))).toBe(true);
 		expect(lines.some((line) => line.startsWith("exec="))).toBe(true);
 		expect(lines.some((line) => line.startsWith("error=vec0 load failed"))).toBe(true);
+	});
+
+	it("extracts viewer_pid from stats payload", () => {
+		expect(extractViewerPid({ viewer_pid: 12345 })).toBe(12345);
+		expect(extractViewerPid({ viewer_pid: -1 })).toBeNull();
+		expect(extractViewerPid({ viewer_pid: "12345" })).toBeNull();
+		expect(extractViewerPid({})).toBeNull();
+	});
+
+	it("selects pid candidate from stats and listener with mismatch protection", () => {
+		expect(pickViewerPidCandidate(123, 123)).toBe(123);
+		expect(pickViewerPidCandidate(null, 456)).toBe(456);
+		expect(pickViewerPidCandidate(123, null)).toBe(123);
+		expect(pickViewerPidCandidate(111, 222)).toBeNull();
+	});
+
+	it("recognizes local hosts for safe process control", () => {
+		expect(isLocalHost("127.0.0.1")).toBe(true);
+		expect(isLocalHost("localhost")).toBe(true);
+		expect(isLocalHost("::1")).toBe(true);
+		expect(isLocalHost("0.0.0.0")).toBe(true);
+		expect(isLocalHost("example.com")).toBe(false);
+	});
+
+	it("matches likely codemem viewer command lines", () => {
+		expect(
+			isLikelyViewerCommand(
+				"node /Users/adam/.local/share/mise/installs/node/24.14.0/bin/codemem serve start --foreground --host 127.0.0.1 --port 38888",
+			),
+		).toBe(true);
+		expect(
+			isLikelyViewerCommand("node /repo/packages/cli/dist/index.js serve start --foreground"),
+		).toBe(true);
+		expect(isLikelyViewerCommand("node /usr/bin/python -m http.server 38888")).toBe(false);
 	});
 });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import { dirname, join } from "node:path";
@@ -25,6 +25,80 @@ interface ViewerPidRecord {
 	pid: number;
 	host: string;
 	port: number;
+}
+
+export function extractViewerPid(payload: unknown): number | null {
+	if (!payload || typeof payload !== "object") return null;
+	const rawPid = (payload as { viewer_pid?: unknown }).viewer_pid;
+	if (typeof rawPid !== "number" || !Number.isFinite(rawPid) || rawPid <= 0) return null;
+	return Math.trunc(rawPid);
+}
+
+export function isLocalHost(host: string): boolean {
+	const normalized = host.trim().toLowerCase();
+	return (
+		normalized === "127.0.0.1" ||
+		normalized === "localhost" ||
+		normalized === "::1" ||
+		normalized === "0.0.0.0" ||
+		normalized === "::"
+	);
+}
+
+export function isLikelyViewerCommand(command: string): boolean {
+	const lowered = command.toLowerCase();
+	if (!/\bserve\s+start\b/.test(lowered)) return false;
+	return (
+		lowered.includes("codemem") ||
+		lowered.includes("packages/cli/dist/index.js") ||
+		lowered.includes("/cli/dist/index.js")
+	);
+}
+
+export function pickViewerPidCandidate(
+	statsPid: number | null,
+	listenerPid: number | null,
+): number | null {
+	if (statsPid && listenerPid && statsPid !== listenerPid) return null;
+	return statsPid ?? listenerPid ?? null;
+}
+
+function lookupListeningPid(host: string, port: number): number | null {
+	if (!isLocalHost(host)) return null;
+	const result = spawnSync("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-t"], {
+		encoding: "utf-8",
+		timeout: 1000,
+	});
+	if (result.status !== 0) return null;
+	const first = (result.stdout || "")
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.find((line) => line.length > 0);
+	if (!first) return null;
+	const parsed = Number.parseInt(first, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function readProcessCommand(pid: number): string | null {
+	const result = spawnSync("ps", ["-p", String(pid), "-o", "command="], {
+		encoding: "utf-8",
+		timeout: 1000,
+	});
+	if (result.status !== 0) return null;
+	const cmd = (result.stdout || "").trim();
+	return cmd.length > 0 ? cmd : null;
+}
+
+function isTrustedViewerPid(
+	pid: number,
+	target: { host: string; port: number },
+	listenerPid: number | null,
+): boolean {
+	if (!isLocalHost(target.host)) return false;
+	if (listenerPid && listenerPid !== pid) return false;
+	const command = readProcessCommand(pid);
+	if (!command) return false;
+	return isLikelyViewerCommand(command);
 }
 
 function pidFilePath(dbPath: string): string {
@@ -76,6 +150,22 @@ async function respondsLikeCodememViewer(record: ViewerPidRecord): Promise<boole
 	}
 }
 
+async function lookupViewerPidFromStats(host: string, port: number): Promise<number | null> {
+	try {
+		const controller = new AbortController();
+		const timer = setTimeout(() => controller.abort(), 1000);
+		const res = await fetch(`http://${host}:${port}/api/stats`, {
+			signal: controller.signal,
+		});
+		clearTimeout(timer);
+		if (!res.ok) return null;
+		const payload = await res.json();
+		return extractViewerPid(payload);
+	} catch {
+		return null;
+	}
+}
+
 async function isPortOpen(host: string, port: number): Promise<boolean> {
 	return new Promise((resolve) => {
 		const socket = net.createConnection({ host, port });
@@ -101,10 +191,30 @@ async function waitForProcessExit(pid: number, timeoutMs = 5000): Promise<void> 
 
 async function stopExistingViewer(
 	dbPath: string,
+	target: { host: string; port: number },
 ): Promise<{ stopped: boolean; pid: number | null }> {
 	const pidPath = pidFilePath(dbPath);
 	const record = readViewerPidRecord(dbPath);
+	const viewerPidFromStats = await lookupViewerPidFromStats(target.host, target.port);
+	const listenerPid = lookupListeningPid(target.host, target.port);
+	const viewerPid = pickViewerPidCandidate(viewerPidFromStats, listenerPid);
+	if (viewerPid && isTrustedViewerPid(viewerPid, target, listenerPid)) {
+		try {
+			process.kill(viewerPid, "SIGTERM");
+			await waitForProcessExit(viewerPid);
+		} catch {
+			// process may have already exited
+		}
+		try {
+			rmSync(pidPath);
+		} catch {
+			// ignore
+		}
+		return { stopped: true, pid: viewerPid };
+	}
+
 	if (!record) return { stopped: false, pid: null };
+
 	if (await respondsLikeCodememViewer(record)) {
 		try {
 			process.kill(record.pid, "SIGTERM");
@@ -322,7 +432,10 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<void> {
 	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
 	if (invocation.mode === "stop" || invocation.mode === "restart") {
-		const result = await stopExistingViewer(dbPath);
+		const result = await stopExistingViewer(dbPath, {
+			host: invocation.host,
+			port: invocation.port,
+		});
 		if (result.stopped) {
 			p.intro("codemem viewer");
 			p.log.success(`Stopped viewer${result.pid ? ` (pid ${result.pid})` : ""}`);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -127,6 +127,7 @@ describe("viewer-server", () => {
 				expect(res.status).toBe(200);
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body).toHaveProperty("database");
+				expect(typeof body.viewer_pid).toBe("number");
 				const db = body.database as Record<string, unknown>;
 				expect(db).toHaveProperty("path");
 				expect(db).toHaveProperty("sessions");

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -16,7 +16,10 @@ export function statsRoutes(getStore: () => MemoryStore) {
 
 	app.get("/api/stats", (c) => {
 		const store = getStore();
-		return c.json(store.stats());
+		return c.json({
+			...store.stats(),
+			viewer_pid: process.pid,
+		});
 	});
 
 	app.get("/api/usage", (c) => {


### PR DESCRIPTION
## Description

Fix lifecycle restart behavior after upgrades when the viewer pidfile is missing/stale.

### Repro addressed
- Upgrade CLI (`npm i -g codemem@alpha`)
- Run `codemem serve restart`
- Existing viewer is running, but restart reports "Viewer already running" and does not restart

### Root cause
`serve restart` only stopped viewers discoverable via pidfile. If pidfile was missing (while viewer still listened on the port), restart could not stop it and then aborted start due port conflict.

### Fix
- Add `viewer_pid` to `GET /api/stats` response.
- In CLI `serve restart`, add stats-based fallback:
  - Query `http://<host>:<port>/api/stats`
  - Extract `viewer_pid`
  - Send SIGTERM + wait for exit
- Keep pidfile path cleanup behavior unchanged.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Targeted tests pass:
  - `pnpm run test -- packages/cli/src/commands/serve.test.ts packages/viewer-server/src/index.test.ts`
- [x] Targeted builds pass:
  - `pnpm --filter codemem build`
  - `pnpm --filter @codemem/server build`
- [x] Added tests:
  - `extractViewerPid` unit coverage in `serve.test.ts`
  - `viewer_pid` presence assertion in `/api/stats` viewer-server test

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced