### PR TITLE
chore(release): cut 0.20.1 with schema hotfix and npm README

### DIFF
--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.0";
+const PINNED_BACKEND_VERSION = "0.20.1";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,35 @@
+# codemem
+
+Persistent memory for AI coding agents — local-first SQLite storage, hybrid retrieval,
+automatic OpenCode injection, and optional peer-to-peer sync.
+
+This is the published npm package for the `codemem` CLI.
+
+## Install
+
+```bash
+npm install -g codemem
+```
+
+Or run without installing:
+
+```bash
+npx -y codemem stats
+```
+
+## Quick commands
+
+```bash
+codemem --help
+codemem stats
+codemem search "query"
+codemem serve start
+codemem mcp
+```
+
+## Documentation
+
+- Repository: https://github.com/kunickiaj/codemem
+- Full README: https://github.com/kunickiaj/codemem#readme
+- User guide: https://github.com/kunickiaj/codemem/blob/main/docs/user-guide.md
+- Architecture: https://github.com/kunickiaj/codemem/blob/main/docs/architecture.md

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -81,6 +81,7 @@ try {
 		tarListing.includes("package/.opencode/package.json"),
 		"Packed artifact is missing .opencode/package.json",
 	);
+	assert(tarListing.includes("package/README.md"), "Packed artifact is missing README.md");
 
 	const installDir = join(tempDir, "install");
 	run("npm", ["install", "--prefix", installDir, coreTarball, mcpTarball, serverTarball, packedTarball]);
@@ -97,6 +98,10 @@ try {
 	assert(
 		existsSync(join(installedPluginRoot, "package.json")),
 		"Installed artifact is missing .opencode/package.json",
+	);
+	assert(
+		existsSync(join(installedPackageRoot, "README.md")),
+		"Installed artifact is missing README.md",
 	);
 
 	const helpOutput = run(cliBin, ["--help"]).stdout;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Database } from "./db.js";
 import {
 	assertSchemaReady,
+	columnExists,
 	connect,
+	ensureAdditiveSchemaCompatibility,
 	fromJson,
 	getSchemaVersion,
 	isEmbeddingDisabled,
@@ -215,6 +217,54 @@ describe("tableExists", () => {
 	it("returns true for an existing table", () => {
 		db.exec("CREATE TABLE test_table (id INTEGER PRIMARY KEY)");
 		expect(tableExists(db, "test_table")).toBe(true);
+	});
+});
+
+describe("ensureAdditiveSchemaCompatibility", () => {
+	let tmpDir: string;
+	let db: Database;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+		db = connect(join(tmpDir, "test.sqlite"));
+	});
+
+	afterEach(() => {
+		db?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("adds missing raw_event_flush_batches compatibility columns", () => {
+		db.exec(`
+			CREATE TABLE raw_event_flush_batches (
+				id INTEGER PRIMARY KEY,
+				source TEXT NOT NULL,
+				stream_id TEXT NOT NULL,
+				opencode_session_id TEXT NOT NULL,
+				start_event_seq INTEGER NOT NULL,
+				end_event_seq INTEGER NOT NULL,
+				extractor_version TEXT NOT NULL,
+				status TEXT NOT NULL,
+				created_at TEXT NOT NULL,
+				updated_at TEXT NOT NULL
+			)
+		`);
+
+		expect(columnExists(db, "raw_event_flush_batches", "error_message")).toBe(false);
+		expect(columnExists(db, "raw_event_flush_batches", "attempt_count")).toBe(false);
+
+		ensureAdditiveSchemaCompatibility(db);
+
+		expect(columnExists(db, "raw_event_flush_batches", "error_message")).toBe(true);
+		expect(columnExists(db, "raw_event_flush_batches", "error_type")).toBe(true);
+		expect(columnExists(db, "raw_event_flush_batches", "observer_provider")).toBe(true);
+		expect(columnExists(db, "raw_event_flush_batches", "observer_model")).toBe(true);
+		expect(columnExists(db, "raw_event_flush_batches", "observer_runtime")).toBe(true);
+		expect(columnExists(db, "raw_event_flush_batches", "attempt_count")).toBe(true);
+	});
+
+	it("is a no-op when raw_event_flush_batches does not exist", () => {
+		expect(() => ensureAdditiveSchemaCompatibility(db)).not.toThrow();
 	});
 });
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -304,6 +304,40 @@ export function tableExists(db: DatabaseType, table: string): boolean {
 	return row !== undefined;
 }
 
+/** Check if a column exists in a table. */
+export function columnExists(db: DatabaseType, table: string, column: string): boolean {
+	if (!tableExists(db, table)) return false;
+	const row = db
+		.prepare("SELECT 1 FROM pragma_table_info(?) WHERE name = ? LIMIT 1")
+		.get(table, column);
+	return row !== undefined;
+}
+
+/**
+ * Apply additive compatibility fixes for legacy TS-era schemas.
+ *
+ * These are safe, one-way `ALTER TABLE ... ADD COLUMN` updates used to
+ * prevent runtime failures when older local databases are missing columns
+ * introduced in later releases.
+ */
+export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
+	if (!tableExists(db, "raw_event_flush_batches")) return;
+
+	const additiveColumns: Array<{ name: string; ddl: string }> = [
+		{ name: "error_message", ddl: "TEXT" },
+		{ name: "error_type", ddl: "TEXT" },
+		{ name: "observer_provider", ddl: "TEXT" },
+		{ name: "observer_model", ddl: "TEXT" },
+		{ name: "observer_runtime", ddl: "TEXT" },
+		{ name: "attempt_count", ddl: "INTEGER NOT NULL DEFAULT 0" },
+	];
+
+	for (const { name, ddl } of additiveColumns) {
+		if (columnExists(db, "raw_event_flush_batches", name)) continue;
+		db.exec(`ALTER TABLE raw_event_flush_batches ADD COLUMN ${name} ${ddl}`);
+	}
+}
+
 /** Safely parse a JSON string, returning {} on failure. */
 export function fromJson(text: string | null | undefined): Record<string, unknown> {
 	if (!text) return {};

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.0");
+		expect(VERSION).toBe("0.20.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.0";
+export const VERSION = "0.20.1";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -22,6 +22,7 @@ import {
 	backupOnFirstAccess,
 	connect,
 	DEFAULT_DB_PATH,
+	ensureAdditiveSchemaCompatibility,
 	fromJson,
 	isEmbeddingDisabled,
 	loadSqliteVec,
@@ -179,6 +180,7 @@ export class MemoryStore {
 		try {
 			loadSqliteVec(this.db);
 			assertSchemaReady(this.db);
+			ensureAdditiveSchemaCompatibility(this.db);
 		} catch (err) {
 			this.db.close();
 			throw err;

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {


### PR DESCRIPTION
## Description
- cut `0.20.1` to ship a startup compatibility hotfix for legacy DBs missing newer `raw_event_flush_batches` columns (for example `error_message`), which caused sweeper error spam after upgrade.
- add additive startup schema compatibility repair so missing flush-batch columns are auto-added before sweeper processing.
- add a package-level `packages/cli/README.md` and assert README presence in packed artifact smoke tests so the published `codemem` npm package includes docs.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run test`
- `pnpm build`
- `pnpm --filter ./packages/cli run test:packed-artifact`
- `pnpm --filter ./packages/core run typecheck`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced