### PR TITLE
chore(release): cut 0.20.2 for schema repair race

### DIFF
--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.1";
+const PINNED_BACKEND_VERSION = "0.20.2";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.20.1",
+	"version": "0.20.2",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.1",
+	"version": "0.20.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -263,6 +263,41 @@ describe("ensureAdditiveSchemaCompatibility", () => {
 		expect(columnExists(db, "raw_event_flush_batches", "attempt_count")).toBe(true);
 	});
 
+	it("treats duplicate-column races as benign when column now exists", () => {
+		let racedColumnVisible = false;
+		let alterAttempts = 0;
+
+		const fakeDb = {
+			prepare(query: string) {
+				return {
+					get(...args: unknown[]) {
+						if (query.includes("sqlite_master")) {
+							return { ok: 1 };
+						}
+						if (query.includes("pragma_table_info")) {
+							const requestedColumn = String(args[1] ?? "");
+							if (requestedColumn === "error_message") {
+								return racedColumnVisible ? { ok: 1 } : undefined;
+							}
+							return { ok: 1 };
+						}
+						return undefined;
+					},
+				};
+			},
+			exec(sqlText: string) {
+				if (sqlText.includes("ADD COLUMN error_message")) {
+					alterAttempts += 1;
+					racedColumnVisible = true;
+					throw new Error("duplicate column name: error_message");
+				}
+			},
+		} as unknown as Database;
+
+		expect(() => ensureAdditiveSchemaCompatibility(fakeDb)).not.toThrow();
+		expect(alterAttempts).toBe(1);
+	});
+
 	it("is a no-op when raw_event_flush_batches does not exist", () => {
 		expect(() => ensureAdditiveSchemaCompatibility(db)).not.toThrow();
 	});

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -334,7 +334,17 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 
 	for (const { name, ddl } of additiveColumns) {
 		if (columnExists(db, "raw_event_flush_batches", name)) continue;
-		db.exec(`ALTER TABLE raw_event_flush_batches ADD COLUMN ${name} ${ddl}`);
+		try {
+			db.exec(`ALTER TABLE raw_event_flush_batches ADD COLUMN ${name} ${ddl}`);
+		} catch (err) {
+			const message = err instanceof Error ? err.message.toLowerCase() : "";
+			const duplicateColumn = message.includes("duplicate column name");
+			if (duplicateColumn && columnExists(db, "raw_event_flush_batches", name)) {
+				// Another process may have raced and added the column first.
+				continue;
+			}
+			throw err;
+		}
 	}
 }
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.1");
+		expect(VERSION).toBe("0.20.2");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.1";
+export const VERSION = "0.20.2";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.1",
+	"version": "0.20.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.1",
+	"version": "0.20.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {


### PR DESCRIPTION
## Description
- cut `0.20.2` to fix a startup race in additive schema compatibility repair.
- make `ensureAdditiveSchemaCompatibility` resilient when two processes concurrently attempt `ALTER TABLE ... ADD COLUMN` on the same legacy DB: duplicate-column errors are now treated as benign if the column is visible after the error.
- keep all required release version surfaces in sync for `0.20.2`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run test -- packages/core/src/db.test.ts packages/core/src/store.test.ts packages/core/src/raw-event-sweeper.test.ts`
- `pnpm --filter ./packages/core run typecheck`
- `pnpm build`
- `pnpm run test`
- `pnpm --filter ./packages/cli run test:packed-artifact`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced