### PR TITLE
chore(release): cut 0.20.3 for startup latency hotfixes

### DIFF
--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.2";
+const PINNED_BACKEND_VERSION = "0.20.3";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.20.2",
+	"version": "0.20.3",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.2",
+	"version": "0.20.3",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -103,6 +103,36 @@ describe("backupOnFirstAccess", () => {
 	it("writes marker when a viable pre-ts backup already exists", () => {
 		const existingBackup = `${dbPath}.pre-ts-20260324T1710.bak`;
 		writeFileSync(existingBackup, "test-db-content");
+
+		backupOnFirstAccess(dbPath);
+
+		const markerPath = join(tmpDir, ".codemem-ts-accessed");
+		expect(existsSync(markerPath)).toBe(true);
+		const backups = readdirSync(tmpDir).filter(
+			(name) => name.startsWith("mem.sqlite.pre-ts-") && name.endsWith(".bak"),
+		);
+		expect(backups.length).toBe(1);
+	});
+
+	it("skips backup when lock contention is active", () => {
+		const lockPath = join(tmpDir, ".codemem-ts-backup.lock");
+		writeFileSync(lockPath, "live");
+
+		backupOnFirstAccess(dbPath);
+
+		const markerPath = join(tmpDir, ".codemem-ts-accessed");
+		expect(existsSync(markerPath)).toBe(false);
+		const backups = readdirSync(tmpDir).filter(
+			(name) => name.startsWith("mem.sqlite.pre-ts-") && name.endsWith(".bak"),
+		);
+		expect(backups.length).toBe(0);
+	});
+
+	it("treats stale lock files as recoverable", () => {
+		const lockPath = join(tmpDir, ".codemem-ts-backup.lock");
+		writeFileSync(lockPath, "stale");
+		const old = new Date(Date.now() - 20 * 60 * 1000);
+		utimesSync(lockPath, old, old);
 
 		backupOnFirstAccess(dbPath);
 

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -1,10 +1,11 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Database } from "./db.js";
 import {
 	assertSchemaReady,
+	backupOnFirstAccess,
 	columnExists,
 	connect,
 	ensureAdditiveSchemaCompatibility,
@@ -65,6 +66,52 @@ describe("connect", () => {
 
 	it("expands ~/ paths like Python", () => {
 		expect(resolveDbPath("~/codemem-test.sqlite")).toBe(join(homedir(), "codemem-test.sqlite"));
+	});
+});
+
+describe("backupOnFirstAccess", () => {
+	let tmpDir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-backup-"));
+		dbPath = join(tmpDir, "mem.sqlite");
+		writeFileSync(dbPath, "test-db-content");
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("creates marker and skips repeated backups", () => {
+		backupOnFirstAccess(dbPath);
+		const markerPath = join(tmpDir, ".codemem-ts-accessed");
+		expect(existsSync(markerPath)).toBe(true);
+
+		const firstBackups = readdirSync(tmpDir).filter(
+			(name) => name.startsWith("mem.sqlite.pre-ts-") && name.endsWith(".bak"),
+		);
+		expect(firstBackups.length).toBe(1);
+
+		backupOnFirstAccess(dbPath);
+		const secondBackups = readdirSync(tmpDir).filter(
+			(name) => name.startsWith("mem.sqlite.pre-ts-") && name.endsWith(".bak"),
+		);
+		expect(secondBackups.length).toBe(1);
+	});
+
+	it("writes marker when a viable pre-ts backup already exists", () => {
+		const existingBackup = `${dbPath}.pre-ts-20260324T1710.bak`;
+		writeFileSync(existingBackup, "test-db-content");
+
+		backupOnFirstAccess(dbPath);
+
+		const markerPath = join(tmpDir, ".codemem-ts-accessed");
+		expect(existsSync(markerPath)).toBe(true);
+		const backups = readdirSync(tmpDir).filter(
+			(name) => name.startsWith("mem.sqlite.pre-ts-") && name.endsWith(".bak"),
+		);
+		expect(backups.length).toBe(1);
 	});
 });
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -55,6 +55,63 @@ const TS_MARKER = ".codemem-ts-accessed";
 /** Lock file to avoid concurrent first-access backups. */
 const TS_BACKUP_LOCK = ".codemem-ts-backup.lock";
 
+/** Consider a backup lock stale after 15 minutes. */
+const TS_BACKUP_LOCK_STALE_MS = 15 * 60 * 1000;
+
+interface BackupLockAcquireResult {
+	fd: number | null;
+	contention: boolean;
+}
+
+function acquireBackupLock(lockPath: string): BackupLockAcquireResult {
+	mkdirSync(dirname(lockPath), { recursive: true });
+	try {
+		return { fd: openSync(lockPath, "wx"), contention: false };
+	} catch (err) {
+		const code = err && typeof err === "object" ? (err as NodeJS.ErrnoException).code : undefined;
+		if (code === "EEXIST") {
+			let stale = false;
+			try {
+				const ageMs = Date.now() - statSync(lockPath).mtimeMs;
+				stale = Number.isFinite(ageMs) && ageMs > TS_BACKUP_LOCK_STALE_MS;
+			} catch {
+				// If we can't read lock metadata, treat as live contention.
+			}
+
+			if (!stale) {
+				return { fd: null, contention: true };
+			}
+
+			try {
+				unlinkSync(lockPath);
+			} catch (unlinkErr) {
+				console.error(
+					`[codemem] Warning: failed to clear stale backup lock at ${lockPath}:`,
+					unlinkErr,
+				);
+				return { fd: null, contention: false };
+			}
+
+			try {
+				return { fd: openSync(lockPath, "wx"), contention: false };
+			} catch (retryErr) {
+				const retryCode =
+					retryErr && typeof retryErr === "object"
+						? (retryErr as NodeJS.ErrnoException).code
+						: undefined;
+				if (retryCode === "EEXIST") {
+					return { fd: null, contention: true };
+				}
+				console.error(`[codemem] Warning: failed to acquire backup lock at ${lockPath}:`, retryErr);
+				return { fd: null, contention: false };
+			}
+		}
+
+		console.error(`[codemem] Warning: failed to acquire backup lock at ${lockPath}:`, err);
+		return { fd: null, contention: false };
+	}
+}
+
 /** Default database path — matches Python's DEFAULT_DB_PATH. */
 export const DEFAULT_DB_PATH = join(homedir(), ".codemem", "mem.sqlite");
 
@@ -222,10 +279,8 @@ export function backupOnFirstAccess(dbPath: string): void {
 	}
 
 	const lockPath = join(dirname(dbPath), TS_BACKUP_LOCK);
-	let lockFd: number | null = null;
-	try {
-		lockFd = openSync(lockPath, "wx");
-	} catch {
+	const { fd: lockFd, contention } = acquireBackupLock(lockPath);
+	if (contention) {
 		// Another process is handling first-access backup.
 		return;
 	}

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -7,15 +7,19 @@
  */
 
 import {
+	closeSync,
 	copyFileSync,
 	existsSync,
 	mkdirSync,
+	openSync,
+	readdirSync,
 	renameSync,
+	statSync,
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import type { Database as DatabaseType } from "better-sqlite3";
 import Database from "better-sqlite3";
 import * as sqliteVec from "sqlite-vec";
@@ -47,6 +51,9 @@ const REQUIRED_TABLES = [
 
 /** Marker file written after the first successful TS access to a DB. */
 const TS_MARKER = ".codemem-ts-accessed";
+
+/** Lock file to avoid concurrent first-access backups. */
+const TS_BACKUP_LOCK = ".codemem-ts-backup.lock";
 
 /** Default database path — matches Python's DEFAULT_DB_PATH. */
 export const DEFAULT_DB_PATH = join(homedir(), ".codemem", "mem.sqlite");
@@ -214,10 +221,62 @@ export function backupOnFirstAccess(dbPath: string): void {
 		}
 	}
 
+	const lockPath = join(dirname(dbPath), TS_BACKUP_LOCK);
+	let lockFd: number | null = null;
+	try {
+		lockFd = openSync(lockPath, "wx");
+	} catch {
+		// Another process is handling first-access backup.
+		return;
+	}
+
+	const writeMarker = (): void => {
+		try {
+			mkdirSync(dirname(markerPath), { recursive: true });
+			writeFileSync(markerPath, new Date().toISOString(), "utf-8");
+		} catch {
+			// Non-fatal — worst case we attempt backup again later.
+		}
+	};
+
+	const hasViableExistingBackup = (): boolean => {
+		let sourceSize = 0;
+		try {
+			sourceSize = statSync(sourceDbPath).size;
+		} catch {
+			sourceSize = 0;
+		}
+		const minViableSize = sourceSize > 0 ? Math.floor(sourceSize * 0.9) : 1;
+		const prefix = `${basename(sourceDbPath)}.pre-ts-`;
+		try {
+			const entries = readdirSync(dirname(sourceDbPath));
+			for (const entry of entries) {
+				if (!entry.startsWith(prefix) || !entry.endsWith(".bak")) continue;
+				const fullPath = join(dirname(sourceDbPath), entry);
+				try {
+					if (statSync(fullPath).size >= minViableSize) {
+						return true;
+					}
+				} catch {
+					// Ignore races while inspecting backup candidates.
+				}
+			}
+		} catch {
+			// Ignore directory read errors — proceed with normal backup path.
+		}
+		return false;
+	};
+
 	const ts = new Date().toISOString().replace(/[:.]/g, "").slice(0, 15);
 	const backupPath = `${sourceDbPath}.pre-ts-${ts}.bak`;
 	let backupSucceeded = false;
 	try {
+		if (existsSync(markerPath)) return;
+		if (hasViableExistingBackup()) {
+			writeMarker();
+			return;
+		}
+
 		copyFileSync(sourceDbPath, backupPath);
 		// Also back up WAL/SHM if present (they contain uncommitted data)
 		const walPath = `${sourceDbPath}-wal`;
@@ -229,17 +288,25 @@ export function backupOnFirstAccess(dbPath: string): void {
 	} catch (err) {
 		console.error(`[codemem] Warning: failed to create backup at ${backupPath}:`, err);
 		// Continue — backup failure shouldn't prevent operation, but don't write marker
+	} finally {
+		if (lockFd != null) {
+			try {
+				closeSync(lockFd);
+			} catch {
+				// Ignore close errors.
+			}
+			try {
+				unlinkSync(lockPath);
+			} catch {
+				// Ignore lock cleanup errors.
+			}
+		}
 	}
 
 	// Only write marker after backup succeeds — a transient failure should
 	// retry on next access, not permanently suppress the safety net.
 	if (backupSucceeded) {
-		try {
-			mkdirSync(dirname(markerPath), { recursive: true });
-			writeFileSync(markerPath, new Date().toISOString(), "utf-8");
-		} catch {
-			// Non-fatal — worst case we back up again next time
-		}
+		writeMarker();
 	}
 }
 

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.2");
+		expect(VERSION).toBe("0.20.3");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.2";
+export const VERSION = "0.20.3";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -25,6 +25,7 @@ describe("syncDaemonTick", () => {
 	let db: InstanceType<typeof Database>;
 
 	beforeEach(() => {
+		vi.clearAllMocks();
 		db = new Database(":memory:");
 		initTestSchema(db);
 	});
@@ -34,11 +35,14 @@ describe("syncDaemonTick", () => {
 	});
 
 	it("returns empty array when no peers exist", async () => {
+		const { syncPassPreflight } = await import("./sync-pass.js");
 		const results = await syncDaemonTick(db);
 		expect(results).toEqual([]);
+		expect(syncPassPreflight).not.toHaveBeenCalled();
 	});
 
 	it("runs sync for each peer", async () => {
+		const { syncPassPreflight } = await import("./sync-pass.js");
 		const now = new Date().toISOString();
 		db.prepare(
 			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
@@ -51,6 +55,7 @@ describe("syncDaemonTick", () => {
 		expect(results).toHaveLength(2);
 		expect(results[0].ok).toBe(true);
 		expect(results[1].ok).toBe(true);
+		expect(syncPassPreflight).toHaveBeenCalledTimes(1);
 	});
 
 	it("skips offline peers in backoff", async () => {

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -90,13 +90,19 @@ export function setSyncDaemonError(db: Database, error: string, traceback?: stri
  * Returns per-peer results. Peers in backoff are skipped.
  */
 export async function syncDaemonTick(db: Database, keysDir?: string): Promise<SyncTickResult[]> {
-	syncPassPreflight(db);
-
 	const d = drizzle(db, { schema });
 	const rows = d
 		.select({ peer_device_id: schema.syncPeers.peer_device_id })
 		.from(schema.syncPeers)
 		.all();
+
+	// Skip heavy preflight work when there are no peers configured.
+	// This keeps startup and idle daemon ticks responsive on large local stores.
+	if (rows.length === 0) {
+		return [];
+	}
+
+	syncPassPreflight(db);
 
 	const results: SyncTickResult[] = [];
 	for (const row of rows) {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.2",
+	"version": "0.20.3",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.2",
+	"version": "0.20.3",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {


### PR DESCRIPTION
## Description
- cut `0.20.3` to ship startup-latency hotfixes for large local databases.
- make `backupOnFirstAccess` race-safe/idempotent with a lock file and existing-backup detection so concurrent startups do not repeatedly create multi-GB `pre-ts` backups.
- skip sync daemon preflight when no peers are configured, avoiding unnecessary heavy startup work on large `replication_ops` datasets.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run test -- packages/core/src/db.test.ts packages/core/src/sync-daemon.test.ts`
- `pnpm run test`
- `pnpm build`
- `pnpm --filter ./packages/cli run test:packed-artifact`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced