### PR TITLE
feat(serve): split viewer and sync into separate listeners

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -9,6 +9,7 @@ import {
 	ObserverClient,
 	RawEventSweeper,
 	readCodememConfigFile,
+	readCoordinatorSyncConfig,
 	resolveDbPath,
 	runSyncDaemon,
 } from "@codemem/core";
@@ -307,7 +308,7 @@ async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promi
 }
 
 async function startForegroundViewer(invocation: ResolvedServeInvocation): Promise<void> {
-	const { createApp, closeStore, getStore } = await import("@codemem/server");
+	const { createApp, createSyncApp, closeStore, getStore } = await import("@codemem/server");
 	const { serve } = await import("@hono/node-server");
 
 	if (invocation.dbPath) process.env.CODEMEM_DB = invocation.dbPath;
@@ -345,19 +346,17 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	const syncAbort = new AbortController();
 	let syncRunning = false;
 	const config = readCodememConfigFile();
-	const syncEnabled =
-		config.sync_enabled === true ||
-		process.env.CODEMEM_SYNC_ENABLED?.toLowerCase() === "true" ||
-		process.env.CODEMEM_SYNC_ENABLED === "1";
+	const syncConfig = readCoordinatorSyncConfig(config);
+	const syncEnabled = syncConfig.syncEnabled;
 
 	if (syncEnabled) {
 		syncRunning = true;
-		const syncIntervalS = typeof config.sync_interval_s === "number" ? config.sync_interval_s : 120;
+		const syncIntervalS = syncConfig.syncIntervalS;
 		runSyncDaemon({
 			dbPath: resolveDbPath(invocation.dbPath ?? undefined),
 			intervalS: syncIntervalS,
-			host: invocation.host,
-			port: invocation.port,
+			host: syncConfig.syncHost,
+			port: syncConfig.syncPort,
 			signal: syncAbort.signal,
 		})
 			.catch((err: unknown) => {
@@ -369,9 +368,35 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			});
 	}
 
-	const app = createApp({ storeFactory: () => store, sweeper, observer });
+	const appOpts = { storeFactory: () => store, sweeper, observer };
+	const app = createApp(appOpts);
 	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
 	const pidPath = pidFilePath(dbPath);
+
+	// Sync protocol listener — separate port, network-accessible for peers.
+	// syncServerRef is never nulled after creation so shutdown always drains it.
+	let syncServer: ReturnType<typeof serve> | null = null;
+	let syncListenerReady = false;
+	if (syncEnabled) {
+		const syncApp = createSyncApp(appOpts);
+		syncServer = serve(
+			{ fetch: syncApp.fetch, hostname: syncConfig.syncHost, port: syncConfig.syncPort },
+			(info) => {
+				syncListenerReady = true;
+				p.log.step(`Sync protocol listening on http://${info.address}:${info.port}`);
+			},
+		);
+		syncServer.on("error", (err: NodeJS.ErrnoException) => {
+			if (!syncListenerReady && err.code === "EADDRINUSE") {
+				p.log.warn(
+					`Sync port ${syncConfig.syncPort} already in use; peer sync protocol unavailable`,
+				);
+			} else {
+				p.log.warn(`Sync listener error: ${err.message}`);
+			}
+			// Non-fatal — viewer continues. syncServer ref is kept for shutdown drain.
+		});
+	}
 
 	const server = serve(
 		{ fetch: app.fetch, hostname: invocation.host, port: invocation.port },
@@ -402,15 +427,30 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		p.outro("shutting down");
 		syncAbort.abort();
 		await sweeper.stop();
-		server.close(() => {
-			try {
-				rmSync(pidPath);
-			} catch {
-				// ignore
-			}
-			closeStore();
-			process.exit(0);
+
+		// Drain both listeners before closing the shared store.
+		await new Promise<void>((resolve) => {
+			let remaining = syncServer ? 2 : 1;
+			const done = () => {
+				if (--remaining === 0) resolve();
+			};
+			syncServer?.close(done);
+			server.close(done);
+		}).catch(() => {
+			// Best-effort drain — proceed to cleanup.
 		});
+
+		try {
+			rmSync(pidPath);
+		} catch {
+			// ignore
+		}
+		closeStore();
+		process.exit(0);
+	};
+
+	// Force-exit safety net if graceful shutdown stalls.
+	const forceShutdown = () => {
 		setTimeout(() => {
 			try {
 				rmSync(pidPath);
@@ -422,9 +462,11 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		}, 5000).unref();
 	};
 	process.on("SIGINT", () => {
+		forceShutdown();
 		void shutdown();
 	});
 	process.on("SIGTERM", () => {
+		forceShutdown();
 		void shutdown();
 	});
 }

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -58,6 +58,25 @@ describe("formatSyncAttempt", () => {
 		]);
 	});
 
+	it("builds sync start without host/port when not explicitly provided", () => {
+		expect(
+			buildServeLifecycleArgs(
+				"start",
+				{ dbPath: "/tmp/test.sqlite" },
+				"/repo/packages/cli/src/index.ts",
+				["--conditions", "source"],
+			),
+		).toEqual([
+			"--conditions",
+			"source",
+			"/repo/packages/cli/src/index.ts",
+			"serve",
+			"--restart",
+			"--db-path",
+			"/tmp/test.sqlite",
+		]);
+	});
+
 	it("builds sync restart as a serve restart invocation", () => {
 		expect(
 			buildServeLifecycleArgs(

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -125,16 +125,10 @@ async function runServeLifecycle(
 			process.exitCode = 1;
 			return;
 		}
-		const configuredHost = typeof config.sync_host === "string" ? config.sync_host : "0.0.0.0";
-		const configuredPort = typeof config.sync_port === "number" ? String(config.sync_port) : "7337";
-		opts.host ??= configuredHost;
-		opts.port ??= configuredPort;
-	} else if (action === "restart") {
-		const config = readCodememConfigFile();
-		const configuredHost = typeof config.sync_host === "string" ? config.sync_host : "0.0.0.0";
-		const configuredPort = typeof config.sync_port === "number" ? String(config.sync_port) : "7337";
-		opts.host ??= configuredHost;
-		opts.port ??= configuredPort;
+		// Don't pass sync_host/sync_port as viewer bind values.
+		// The viewer binds its own host/port (default 127.0.0.1:38888)
+		// and the sync protocol listener reads sync_host/sync_port
+		// internally from readCoordinatorSyncConfig().
 	}
 	const args = buildServeLifecycleArgs(action, opts, process.argv[1] ?? "", process.execArgv);
 	await new Promise<void>((resolve, reject) => {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -16,7 +16,7 @@ import {
 } from "@codemem/core";
 import Database from "better-sqlite3";
 import { describe, expect, it, vi } from "vitest";
-import { createApp } from "./index.js";
+import { createApp, createSyncApp } from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -91,20 +91,25 @@ function createTestApp(opts?: { sweeper?: unknown }) {
 	let store: MemoryStore | null = null;
 	let storeCleanup: (() => void) | null = null;
 
+	const storeFactory = () => {
+		if (!store) {
+			const created = createTestStore();
+			store = created.store;
+			storeCleanup = created.cleanup;
+		}
+		return store;
+	};
+
 	const app = createApp({
 		sweeper: (opts?.sweeper ?? null) as never,
-		storeFactory: () => {
-			if (!store) {
-				const created = createTestStore();
-				store = created.store;
-				storeCleanup = created.cleanup;
-			}
-			return store;
-		},
+		storeFactory,
 	});
+
+	const syncApp = createSyncApp({ storeFactory });
 
 	return {
 		app,
+		syncApp,
 		getStore: () => store,
 		cleanup: () => {
 			storeCleanup?.();
@@ -879,10 +884,23 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("exposes /v1/status sync endpoint (auth-gated)", async () => {
+		it("does not expose /v1/status on viewer app (moved to sync listener)", async () => {
 			const { app, cleanup } = createTestApp();
 			try {
 				const res = await app.request("/v1/status");
+				// Should return SPA fallback (200 html), not 401 — route is gone from viewer
+				expect(res.status).toBe(200);
+				const ct = res.headers.get("content-type") ?? "";
+				expect(ct).toContain("text/html");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("exposes /v1/status on sync app (auth-gated)", async () => {
+			const { syncApp, cleanup } = createTestApp();
+			try {
+				const res = await syncApp.request("/v1/status");
 				expect(res.status).toBe(401);
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.error).toBe("unauthorized");
@@ -891,17 +909,54 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("exposes /v1/ops sync endpoint (auth-gated)", async () => {
-			const { app, cleanup } = createTestApp();
+		it("exposes /v1/ops on sync app (auth-gated)", async () => {
+			const { syncApp, cleanup } = createTestApp();
 			try {
-				const getRes = await app.request("/v1/ops");
+				const getRes = await syncApp.request("/v1/ops");
 				expect(getRes.status).toBe(401);
-				const postRes = await app.request("/v1/ops", {
+				const postRes = await syncApp.request("/v1/ops", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({ ops: [] }),
 				});
 				expect(postRes.status).toBe(401);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("does not expose viewer routes on sync app", async () => {
+			const { syncApp, cleanup } = createTestApp();
+			try {
+				const statsRes = await syncApp.request("/api/stats");
+				expect(statsRes.status).toBe(404);
+
+				const peersRes = await syncApp.request("/api/sync/peers");
+				expect(peersRes.status).toBe(404);
+
+				const obsRes = await syncApp.request("/api/observations");
+				expect(obsRes.status).toBe(404);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("sync app does not apply CORS origin guard on POST", async () => {
+			const { syncApp, cleanup } = createTestApp();
+			try {
+				// POST with a non-loopback origin — sync app should return 401 (auth),
+				// not 403 (CORS rejection), since it has no origin guard middleware.
+				const res = await syncApp.request("/v1/ops", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "https://evil.example.com",
+					},
+					body: JSON.stringify({ ops: [] }),
+				});
+				expect(res.status).toBe(401);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.error).toBe("unauthorized");
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -20,7 +20,7 @@ import { memoryRoutes } from "./routes/memory.js";
 import { observerStatusRoutes } from "./routes/observer-status.js";
 import { rawEventsRoutes } from "./routes/raw-events.js";
 import { statsRoutes } from "./routes/stats.js";
-import { syncRoutes } from "./routes/sync.js";
+import { syncProtocolRoutes, syncRoutes } from "./routes/sync.js";
 
 export { VERSION };
 
@@ -97,6 +97,27 @@ export function createApp(opts?: AppOptions) {
 		}
 		return c.html(indexHtml);
 	});
+
+	return app;
+}
+
+/**
+ * Create the Hono app for peer-to-peer sync protocol routes only.
+ *
+ * This app is bound to a separate network-accessible listener
+ * (default 0.0.0.0:7337) so remote peers can reach the sync
+ * endpoints without exposing the viewer UI or local API routes.
+ *
+ * No CORS/origin guard is applied — sync requests are authenticated
+ * via cryptographic signature verification instead.
+ */
+export function createSyncApp(opts?: AppOptions) {
+	const storeFactory = opts?.storeFactory ?? getStore;
+	const app = new Hono();
+	app.route("/", syncProtocolRoutes(storeFactory));
+
+	// Catch-all — return generic 404 to avoid fingerprinting the server.
+	app.all("*", (c) => c.json({ error: "not found" }, 404));
 
 	return app;
 }

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -400,7 +400,14 @@ const PEERS_QUERY = `
 // Route factory
 // ---------------------------------------------------------------------------
 
-export function syncRoutes(getStore: StoreFactory) {
+/**
+ * Peer-to-peer sync protocol routes (/v1/*).
+ *
+ * These are mounted on the sync listener (0.0.0.0:7337) and are
+ * network-accessible. All requests are auth-gated via signature
+ * verification so unauthenticated callers are rejected.
+ */
+export function syncProtocolRoutes(getStore: StoreFactory) {
 	const app = new Hono();
 
 	// GET /v1/status (peer sync protocol)
@@ -520,6 +527,19 @@ export function syncRoutes(getStore: StoreFactory) {
 			skipped: result.skipped + filteredInbound.skipped,
 		});
 	});
+
+	return app;
+}
+
+/**
+ * Viewer-facing sync management routes (/api/sync/*).
+ *
+ * These are mounted on the viewer listener (127.0.0.1:38888) and
+ * provide sync status, peer management, and coordinator UI for the
+ * local viewer.
+ */
+export function syncRoutes(getStore: StoreFactory) {
+	const app = new Hono();
 
 	// GET /api/sync/status
 	app.get("/api/sync/status", async (c) => {


### PR DESCRIPTION
## Description

Split the viewer and sync protocol into separate network listeners within the same Node.js process, matching the Python implementation's separate-port model.

- **Viewer**: `127.0.0.1:38888` — UI + `/api/*` routes (localhost only, CORS/origin guarded)
- **Sync**: `0.0.0.0:7337` — `/v1/*` protocol routes only (network-accessible, auth-gated via crypto signatures)

Both listeners share the same `MemoryStore`, `RawEventSweeper`, and process lifecycle.

### Changes

- Split `syncRoutes()` into `syncProtocolRoutes()` (sync listener) and `syncRoutes()` (viewer management)
- Added `createSyncApp()` export to `@codemem/server`
- Wired second listener in CLI serve command using `readCoordinatorSyncConfig()` (matching Python defaults: `sync_host=0.0.0.0`, `sync_port=7337`)
- Sync listener failure is non-fatal — viewer continues without peer sync protocol
- Fixed config duplication: uses `syncConfig.syncEnabled` as single source of truth
- Proper shutdown ordering: drains both listeners before closing shared store
- Error handler preserves `syncServer` ref (only tracks startup vs runtime errors)
- Added catch-all 404 on sync app to prevent server fingerprinting
- Tests verify route isolation, CORS bypass on sync app, and auth gating

### Review notes

- Reviewed by gordon-ramsay agent before submission; all flagged issues addressed
- Pre-existing typecheck error in `packages/cli/src/commands/sync.ts` (not introduced by this change)

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- \`pnpm run test\` — 626 tests passing
- \`pnpm run typecheck\` — no new errors (pre-existing sync.ts error only)

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced