### PR TITLE
chore(release): cut 0.20.5-alpha.1 — remove startup backup, fix restart race

### DIFF
--- a/packages/cli/.opencode/lib/compat.js
+++ b/packages/cli/.opencode/lib/compat.js
@@ -1,5 +1,5 @@
 export const parseSemver = (value) => {
-  const match = String(value || "").trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  const match = String(value || "").trim().match(/^(\d+)\.(\d+)\.(\d+)(?:-.*)?$/);
   if (!match) return null;
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 };

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.4";
+const PINNED_BACKEND_VERSION = "0.20.5-alpha.1";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.20.4",
+	"version": "0.20.5-alpha.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -190,6 +190,15 @@ async function waitForProcessExit(pid: number, timeoutMs = 5000): Promise<void> 
 	}
 }
 
+async function waitForPortRelease(host: string, port: number, timeoutMs = 10000): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!(await isPortOpen(host, port))) return true;
+		await new Promise((resolve) => setTimeout(resolve, 200));
+	}
+	return false;
+}
+
 async function stopExistingViewer(
 	dbPath: string,
 	target: { host: string; port: number },
@@ -484,6 +493,11 @@ async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<
 			if (invocation.mode === "stop") {
 				p.outro("done");
 				return;
+			}
+			// Wait for port to be fully released before restarting.
+			const released = await waitForPortRelease(invocation.host, invocation.port);
+			if (!released) {
+				p.log.warn(`Port ${invocation.port} still in use after stop — restart may fail`);
 			}
 		} else if (invocation.mode === "stop") {
 			p.intro("codemem viewer");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.4",
+	"version": "0.20.5-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.4");
+		expect(VERSION).toBe("0.20.5-alpha.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.4";
+export const VERSION = "0.20.5-alpha.1";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";
@@ -47,7 +47,6 @@ export {
 export type { Database } from "./db.js";
 export {
 	assertSchemaReady,
-	backupOnFirstAccess,
 	connect,
 	DEFAULT_DB_PATH,
 	fromJson,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -19,7 +19,6 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import {
 	assertSchemaReady,
-	backupOnFirstAccess,
 	connect,
 	DEFAULT_DB_PATH,
 	ensureAdditiveSchemaCompatibility,
@@ -175,7 +174,6 @@ export class MemoryStore {
 
 	constructor(dbPath: string = DEFAULT_DB_PATH) {
 		this.dbPath = resolveDbPath(dbPath);
-		backupOnFirstAccess(this.dbPath);
 		this.db = connect(this.dbPath);
 		try {
 			loadSqliteVec(this.db);

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.4",
+	"version": "0.20.5-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.4",
+	"version": "0.20.5-alpha.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {


### PR DESCRIPTION
## Description

Alpha release for dogfooding two startup/lifecycle fixes on large DBs before stable `0.20.5`.

### Changes

1. **Remove `backupOnFirstAccess` from startup path** — this was causing repeated multi-GB file copies on the 18GB DB machine (3× 18GB `.pre-ts-*.bak` files observed). The migration safety net has served its purpose; DB open + WAL + sqlite-vec confirmed fast (~200ms) without it.

2. **Fix restart race condition** — after stopping the old viewer, poll for port release (`waitForPortRelease`) before starting the new one. Previously the new process could hit `EADDRINUSE` because the old listener hadn't fully released the port yet.

### What to test

On the large DB machine:
```
npm install -g codemem@0.20.5-alpha.1
time codemem serve --foreground  # should be fast now
# then in another terminal:
codemem serve restart  # should not report "already running"
```

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation: `pnpm build` + `pnpm run test` (627 tests) + `pnpm --filter ./packages/cli run test:packed-artifact`

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced