### PR TITLE
chore(release): cut 0.20.5-alpha.2 — defer sync startup behind viewer bind

### DIFF
--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.5-alpha.1";
+const PINNED_BACKEND_VERSION = "0.20.5-alpha.2";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.20.5-alpha.1",
+	"version": "0.20.5-alpha.2",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -182,12 +182,13 @@ async function isPortOpen(host: string, port: number): Promise<boolean> {
 	});
 }
 
-async function waitForProcessExit(pid: number, timeoutMs = 5000): Promise<void> {
+async function waitForProcessExit(pid: number, timeoutMs = 5000): Promise<boolean> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
-		if (!isProcessRunning(pid)) return;
+		if (!isProcessRunning(pid)) return true;
 		await new Promise((resolve) => setTimeout(resolve, 100));
 	}
+	return !isProcessRunning(pid);
 }
 
 async function waitForPortRelease(host: string, port: number, timeoutMs = 10000): Promise<boolean> {
@@ -203,18 +204,30 @@ async function stopExistingViewer(
 	dbPath: string,
 	target: { host: string; port: number },
 ): Promise<{ stopped: boolean; pid: number | null }> {
+	const terminatePid = async (pid: number): Promise<boolean> => {
+		try {
+			process.kill(pid, "SIGTERM");
+			if (await waitForProcessExit(pid)) return true;
+		} catch {
+			return true;
+		}
+
+		try {
+			process.kill(pid, "SIGKILL");
+			return await waitForProcessExit(pid, 2000);
+		} catch {
+			return !isProcessRunning(pid);
+		}
+	};
+
 	const pidPath = pidFilePath(dbPath);
 	const record = readViewerPidRecord(dbPath);
 	const viewerPidFromStats = await lookupViewerPidFromStats(target.host, target.port);
 	const listenerPid = lookupListeningPid(target.host, target.port);
 	const viewerPid = pickViewerPidCandidate(viewerPidFromStats, listenerPid);
 	if (viewerPid && isTrustedViewerPid(viewerPid, target, listenerPid)) {
-		try {
-			process.kill(viewerPid, "SIGTERM");
-			await waitForProcessExit(viewerPid);
-		} catch {
-			// process may have already exited
-		}
+		const stopped = await terminatePid(viewerPid);
+		if (!stopped) return { stopped: false, pid: viewerPid };
 		try {
 			rmSync(pidPath);
 		} catch {
@@ -226,12 +239,8 @@ async function stopExistingViewer(
 	if (!record) return { stopped: false, pid: null };
 
 	if (await respondsLikeCodememViewer(record)) {
-		try {
-			process.kill(record.pid, "SIGTERM");
-			await waitForProcessExit(record.pid);
-		} catch {
-			// stale pidfile or already exited
-		}
+		const stopped = await terminatePid(record.pid);
+		if (!stopped) return { stopped: false, pid: record.pid };
 	}
 	try {
 		rmSync(pidPath);
@@ -353,31 +362,23 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	sweeper.start();
 
 	const syncAbort = new AbortController();
-	let syncRunning = false;
 	const config = readCodememConfigFile();
 	const syncConfig = readCoordinatorSyncConfig(config);
 	const syncEnabled = syncConfig.syncEnabled;
+	const syncRuntimeStatus: {
+		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
+		detail: string | null;
+	} = {
+		phase: syncEnabled ? "starting" : "disabled",
+		detail: syncEnabled ? "Waiting for viewer startup to finish" : "Sync is disabled",
+	};
 
-	if (syncEnabled) {
-		syncRunning = true;
-		const syncIntervalS = syncConfig.syncIntervalS;
-		runSyncDaemon({
-			dbPath: resolveDbPath(invocation.dbPath ?? undefined),
-			intervalS: syncIntervalS,
-			host: syncConfig.syncHost,
-			port: syncConfig.syncPort,
-			signal: syncAbort.signal,
-		})
-			.catch((err: unknown) => {
-				const msg = err instanceof Error ? err.message : String(err);
-				p.log.error(`Sync daemon failed: ${msg}`);
-			})
-			.finally(() => {
-				syncRunning = false;
-			});
-	}
-
-	const appOpts = { storeFactory: () => store, sweeper, observer };
+	const appOpts = {
+		storeFactory: () => store,
+		sweeper,
+		observer,
+		getSyncRuntimeStatus: () => syncRuntimeStatus,
+	};
 	const app = createApp(appOpts);
 	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
 	const pidPath = pidFilePath(dbPath);
@@ -419,7 +420,45 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			p.log.success(`Listening on http://${info.address}:${info.port}`);
 			p.log.info(`Database: ${dbPath}`);
 			p.log.step("Raw event sweeper started");
-			if (syncRunning) p.log.step("Sync daemon started");
+			if (syncEnabled) {
+				const syncStartDelayMs = 3000;
+				p.log.step(`Sync daemon will start in background (${syncStartDelayMs / 1000}s delay)`);
+				setTimeout(() => {
+					syncRuntimeStatus.phase = "starting";
+					syncRuntimeStatus.detail = "Starting sync in background";
+					void runSyncDaemon({
+						dbPath: resolveDbPath(invocation.dbPath ?? undefined),
+						intervalS: syncConfig.syncIntervalS,
+						host: syncConfig.syncHost,
+						port: syncConfig.syncPort,
+						signal: syncAbort.signal,
+						onPhaseChange: (phase) => {
+							if (phase === "running") {
+								syncRuntimeStatus.phase = null;
+								syncRuntimeStatus.detail = null;
+							} else {
+								syncRuntimeStatus.phase = phase;
+								syncRuntimeStatus.detail =
+									phase === "starting"
+										? "Running initial sync in background"
+										: "Stopping sync daemon";
+							}
+						},
+					})
+						.catch((err: unknown) => {
+							const msg = err instanceof Error ? err.message : String(err);
+							syncRuntimeStatus.phase = "error";
+							syncRuntimeStatus.detail = msg;
+							p.log.error(`Sync daemon failed: ${msg}`);
+						})
+						.finally(() => {
+							if (syncRuntimeStatus.phase !== "error") {
+								syncRuntimeStatus.phase = syncAbort.signal.aborted ? "stopping" : null;
+								syncRuntimeStatus.detail = syncAbort.signal.aborted ? "Sync stopped" : null;
+							}
+						});
+				}, syncStartDelayMs).unref();
+			}
 		},
 	);
 
@@ -499,6 +538,11 @@ async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<
 			if (!released) {
 				p.log.warn(`Port ${invocation.port} still in use after stop — restart may fail`);
 			}
+		} else if (result.pid) {
+			p.intro("codemem viewer");
+			p.log.error(`Viewer is still shutting down (pid ${result.pid})`);
+			process.exitCode = 1;
+			return;
 		} else if (invocation.mode === "stop") {
 			p.intro("codemem viewer");
 			p.outro("No background viewer found");

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -182,7 +182,7 @@ async function isPortOpen(host: string, port: number): Promise<boolean> {
 	});
 }
 
-async function waitForProcessExit(pid: number, timeoutMs = 5000): Promise<boolean> {
+async function waitForProcessExit(pid: number, timeoutMs = 30000): Promise<boolean> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
 		if (!isProcessRunning(pid)) return true;
@@ -207,16 +207,9 @@ async function stopExistingViewer(
 	const terminatePid = async (pid: number): Promise<boolean> => {
 		try {
 			process.kill(pid, "SIGTERM");
-			if (await waitForProcessExit(pid)) return true;
+			return await waitForProcessExit(pid);
 		} catch {
 			return true;
-		}
-
-		try {
-			process.kill(pid, "SIGKILL");
-			return await waitForProcessExit(pid, 2000);
-		} catch {
-			return !isProcessRunning(pid);
 		}
 	};
 
@@ -497,7 +490,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		process.exit(0);
 	};
 
-	// Force-exit safety net if graceful shutdown stalls.
+	// Force-exit safety net if graceful shutdown stalls for an unusually long time.
 	const forceShutdown = () => {
 		setTimeout(() => {
 			try {
@@ -507,7 +500,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			}
 			closeStore();
 			process.exit(1);
-		}, 5000).unref();
+		}, 30000).unref();
 	};
 	process.on("SIGINT", () => {
 		forceShutdown();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.5-alpha.1",
+	"version": "0.20.5-alpha.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -467,13 +467,25 @@ export interface ApiJoinRequest {
 	status: string;
 }
 
+/** Public sync daemon state enum returned by /api/sync/status. */
+export type ApiSyncDaemonState =
+	| "ok"
+	| "disabled"
+	| "error"
+	| "stopped"
+	| "degraded"
+	| "offline-peers"
+	| "stale"
+	| "starting"
+	| "stopping";
+
 /** Status block nested in sync status response. */
 export interface ApiSyncStatusBlock {
 	enabled: boolean;
 	interval_s: number;
 	peer_count: number;
 	last_sync_at: string | null;
-	daemon_state: "ok" | "disabled" | "error" | "stopped" | "degraded" | "offline-peers" | "stale";
+	daemon_state: ApiSyncDaemonState;
 	daemon_running: boolean;
 	daemon_detail: string | null;
 	project_filter_active: boolean;
@@ -494,7 +506,7 @@ export interface ApiSyncStatusResponse {
 	interval_s: number;
 	peer_count: number;
 	last_sync_at: string | null;
-	daemon_state: "ok" | "disabled" | "error" | "stopped" | "degraded" | "offline-peers" | "stale";
+	daemon_state: ApiSyncDaemonState;
 	daemon_running: boolean;
 	daemon_detail: string | null;
 	project_filter_active: boolean;

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.5-alpha.1");
+		expect(VERSION).toBe("0.20.5-alpha.2");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.5-alpha.1";
+export const VERSION = "0.20.5-alpha.2";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -26,6 +26,7 @@ export interface SyncDaemonOptions {
 	dbPath?: string;
 	keysDir?: string;
 	signal?: AbortSignal;
+	onPhaseChange?: (phase: "starting" | "running" | "stopping") => void;
 }
 
 export interface SyncTickResult {
@@ -144,6 +145,8 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
 	const dbPath = resolveDbPath(options?.dbPath);
 	const keysDir = options?.keysDir;
 	const signal = options?.signal;
+	const onPhaseChange = options?.onPhaseChange;
+	onPhaseChange?.("starting");
 
 	// Ensure device identity
 	const db = connectDb(dbPath);
@@ -165,29 +168,31 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
 		return;
 	}
 
-	// Run initial tick
-	await runTickOnce(dbPath, keysDir);
-
-	// If aborted during initial tick, clean up
-	if (signal?.aborted) {
-		mdnsHandle?.close();
-		return;
-	}
-
-	// Set up periodic ticks — serialized to avoid overlapping sync passes
+	// Set up periodic ticks — serialized to avoid overlapping sync passes.
+	// Importantly, the first tick is scheduled asynchronously so startup callers
+	// are not blocked by large sync preflight work on the main request path.
 	return new Promise<void>((resolve) => {
 		let tickRunning = false;
-		const timer = setInterval(() => {
+		let firstTickCompleted = false;
+		const runTick = () => {
 			if (tickRunning) return; // Skip if previous tick still running
 			tickRunning = true;
 			runTickOnce(dbPath, keysDir).finally(() => {
 				tickRunning = false;
+				if (!firstTickCompleted) {
+					firstTickCompleted = true;
+					onPhaseChange?.("running");
+				}
 			});
-		}, intervalS * 1000);
+		};
+
+		const timer = setInterval(runTick, intervalS * 1000);
+		setTimeout(runTick, 0).unref?.();
 
 		const cleanup = () => {
 			clearInterval(timer);
 			mdnsHandle?.close();
+			onPhaseChange?.("stopping");
 			resolve();
 		};
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.5-alpha.1",
+	"version": "0.20.5-alpha.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.5-alpha.1",
+	"version": "0.20.5-alpha.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -87,7 +87,13 @@ function insertTestMemory(
 }
 
 /** Create a test Hono app backed by a fresh in-memory DB. */
-function createTestApp(opts?: { sweeper?: unknown }) {
+function createTestApp(opts?: {
+	sweeper?: unknown;
+	getSyncRuntimeStatus?: () => {
+		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
+		detail?: string | null;
+	} | null;
+}) {
 	let store: MemoryStore | null = null;
 	let storeCleanup: (() => void) | null = null;
 
@@ -103,6 +109,7 @@ function createTestApp(opts?: { sweeper?: unknown }) {
 	const app = createApp({
 		sweeper: (opts?.sweeper ?? null) as never,
 		storeFactory,
+		getSyncRuntimeStatus: opts?.getSyncRuntimeStatus,
 	});
 
 	const syncApp = createSyncApp({ storeFactory });
@@ -1142,6 +1149,24 @@ describe("viewer-server", () => {
 				else process.env.CODEMEM_CONFIG = prevConfig;
 				if (prevEnabled == null) delete process.env.CODEMEM_SYNC_ENABLED;
 				else process.env.CODEMEM_SYNC_ENABLED = prevEnabled;
+			}
+		});
+
+		it("surfaces runtime sync startup state before daemon settles", async () => {
+			const { app, cleanup } = createTestApp({
+				getSyncRuntimeStatus: () => ({
+					phase: "starting",
+					detail: "Running initial sync in background",
+				}),
+			});
+			try {
+				const res = await app.request("/api/sync/status");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.daemon_state).toBe("starting");
+				expect(body.daemon_detail).toBe("Running initial sync in background");
+			} finally {
+				cleanup();
 			}
 		});
 

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -49,12 +49,17 @@ export interface AppOptions {
 	storeFactory?: () => MemoryStore;
 	sweeper?: RawEventSweeper | null;
 	observer?: ObserverClient | null;
+	getSyncRuntimeStatus?: () => {
+		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
+		detail?: string | null;
+	} | null;
 }
 
 export function createApp(opts?: AppOptions) {
 	const storeFactory = opts?.storeFactory ?? getStore;
 	const sweeper = opts?.sweeper ?? null;
 	const observer = opts?.observer ?? null;
+	const getSyncRuntimeStatus = opts?.getSyncRuntimeStatus ?? (() => null);
 	const app = new Hono();
 
 	// CORS / origin guard
@@ -74,7 +79,7 @@ export function createApp(opts?: AppOptions) {
 	);
 	app.route("/", configRoutes({ getSweeper: () => sweeper }));
 	app.route("/", rawEventsRoutes(storeFactory, sweeper));
-	app.route("/", syncRoutes(storeFactory));
+	app.route("/", syncRoutes(storeFactory, getSyncRuntimeStatus));
 
 	// Static assets — serve under /assets/*
 	// Resolves to packages/viewer-server/static/ both in dev and when installed from npm.

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -30,6 +30,10 @@ import { Hono } from "hono";
 import { queryBool, queryInt, safeJsonList } from "../helpers.js";
 
 type StoreFactory = () => MemoryStore;
+type SyncRuntimeStatus = {
+	phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
+	detail?: string | null;
+};
 
 const SYNC_STALE_AFTER_SECONDS = 10 * 60;
 const SYNC_PROTOCOL_VERSION = "1";
@@ -538,7 +542,10 @@ export function syncProtocolRoutes(getStore: StoreFactory) {
  * provide sync status, peer management, and coordinator UI for the
  * local viewer.
  */
-export function syncRoutes(getStore: StoreFactory) {
+export function syncRoutes(
+	getStore: StoreFactory,
+	getSyncRuntimeStatus?: () => SyncRuntimeStatus | null,
+) {
 	const app = new Hono();
 
 	// GET /api/sync/status
@@ -620,6 +627,14 @@ export function syncRoutes(getStore: StoreFactory) {
 				statusPayload.daemon_last_error = lastError;
 				statusPayload.daemon_last_error_at = lastErrorAt;
 				statusPayload.daemon_last_ok_at = lastOkAt;
+			}
+
+			const runtimeStatus = getSyncRuntimeStatus?.() ?? null;
+			if (runtimeStatus?.phase && runtimeStatus.phase !== "running") {
+				daemonStateValue = runtimeStatus.phase;
+				statusPayload.daemon_state = daemonStateValue;
+				statusPayload.daemon_running = runtimeStatus.phase === "starting" || daemonRunning;
+				statusPayload.daemon_detail = runtimeStatus.detail ?? daemonDetail;
 			}
 
 			// Build peers list using deduplicated mapPeerRow


### PR DESCRIPTION
## Description

Alpha release for the real startup-path fix: make the viewer fast again even when sync is enabled on huge DBs.

### Changes

1. **Viewer binds first, sync starts later**
   - The viewer no longer starts the sync daemon on the critical startup path.
   - Sync startup is deferred until after the viewer listener is already bound.
   - On the local 17GB repro DB, time-to-listen is now ~294ms with sync enabled.

2. **Runtime sync startup state exposed in UI**
   - `/api/sync/status` can now report runtime phases like `starting`, `stopping`, and `error`.
   - The Sync tab can tell the user that sync is still starting in the background instead of implying startup is broken.

3. **serve stop/restart no longer lies**
   - Stop now escalates from `SIGTERM` to `SIGKILL` if needed.
   - If the process is still alive, it returns failure instead of claiming success.
   - Restart continues to wait for port release before rebinding.

### Why this matters

On large databases with sync enabled, startup was still taking minutes even after removing first-access backup. Profiling on a copied 17GB DB showed DB open is fast, but deferring sync behind listener bind restores fast viewer availability.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:
- `pnpm build`
- `pnpm run test` — 628 tests passing
- `pnpm --filter ./packages/cli run test:packed-artifact`
- local repro against copied 17GB DB with `CODEMEM_SYNC_ENABLED=1`: time-to-listen ~294ms

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced