### PR TITLE
chore(release): cut 0.20.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.20.4"
+    "version": "0.20.5"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.20.4",
+      "version": "0.20.5",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.5-alpha.2";
+const PINNED_BACKEND_VERSION = "0.20.5";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.20.5-alpha.2",
+	"version": "0.20.5",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.5-alpha.2",
+	"version": "0.20.5",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.5-alpha.2");
+		expect(VERSION).toBe("0.20.5");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.5-alpha.2";
+export const VERSION = "0.20.5";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.5-alpha.2",
+	"version": "0.20.5",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.5-alpha.2",
+	"version": "0.20.5",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description

Cut stable `0.20.5` from the validated `0.20.5-alpha.2` line.

This release ships the startup and lifecycle fixes that were dogfooded against the large sync-enabled database:

- bind the viewer immediately and defer sync daemon startup until after listener bind
- expose runtime sync startup/stopping/error phases via `/api/sync/status`
- make stop/restart honest and safer with a 30s graceful wait (no automatic `SIGKILL`)
- keep the viewer responsive even when sync is enabled and large `replication_ops` history exists

It also updates the stable Claude plugin marketplace/plugin metadata to `0.20.5`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm build`
- `pnpm run test` — 628 tests passing
- `pnpm --filter ./packages/cli run test:packed-artifact`
- local large-DB repro (`~/Downloads/mem.sqlite`, sync enabled): time-to-listen ~295ms

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced