### PR TITLE
feat(sync): surface reset recovery states in diagnostics and UI

### DIFF
--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -485,7 +485,9 @@ export type ApiSyncDaemonState =
 	| "offline-peers"
 	| "stale"
 	| "starting"
-	| "stopping";
+	| "stopping"
+	| "rebootstrapping"
+	| "needs_attention";
 
 /** Status block nested in sync status response. */
 export interface ApiSyncStatusBlock {

--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -113,7 +113,14 @@ export function renderHealthOverview() {
   const reductionPercent = parsePercentValue(reductionLabel);
   const tagCoverage = Number(dbStats.tags_coverage || 0);
   const syncState = String(syncStatus.daemon_state || 'unknown');
-  const syncStateLabel = syncState === 'offline-peers' ? 'Offline peers' : titleCase(syncState);
+  const syncStateLabel =
+    syncState === 'offline-peers'
+      ? 'Offline peers'
+      : syncState === 'needs_attention'
+        ? 'Needs attention'
+        : syncState === 'rebootstrapping'
+          ? 'Rebootstrapping'
+          : titleCase(syncState);
   const peerCount = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers.length : 0;
   const syncDisabled = syncState === 'disabled' || syncStatus.enabled === false;
   const syncOfflinePeers = syncState === 'offline-peers';
@@ -136,6 +143,7 @@ export function renderHealthOverview() {
   else if (droppedRate > 0.005) { riskScore += 10; drivers.push('non-trivial dropped-event rate'); }
   if (!syncDisabled && !syncNoPeers) {
     if (syncState === 'error') { riskScore += 36; drivers.push('sync daemon reports errors'); }
+    else if (syncState === 'needs_attention') { riskScore += 40; drivers.push('sync needs manual attention'); }
     else if (syncState === 'stopped') { riskScore += 22; drivers.push('sync daemon stopped'); }
     else if (syncState === 'degraded') { riskScore += 20; drivers.push('sync daemon degraded'); }
     if (syncOfflinePeers) { riskScore += 4; drivers.push('all peers currently offline'); if (syncLooksStale) { riskScore += 4; drivers.push('offline peers and sync not recent'); } }

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -45,7 +45,14 @@ export function renderSyncStatus() {
   const pending = Number(status.pending || 0);
   const daemonDetail = String(status.daemon_detail || '');
   const daemonState = String(status.daemon_state || 'unknown');
-  const daemonStateLabel = daemonState === 'offline-peers' ? 'Offline peers' : titleCase(daemonState);
+  const daemonStateLabel =
+    daemonState === 'offline-peers'
+      ? 'Offline peers'
+      : daemonState === 'needs_attention'
+        ? 'Needs attention'
+        : daemonState === 'rebootstrapping'
+          ? 'Rebootstrapping'
+          : titleCase(daemonState);
   const syncDisabled = daemonState === 'disabled' || status.enabled === false;
   const peerCount = Object.keys(peers).length;
   const syncNoPeers = !syncDisabled && peerCount === 0;
@@ -63,6 +70,9 @@ export function renderSyncStatus() {
     if (daemonState === 'offline-peers')
       parts.push('All peers are currently offline; sync will resume automatically');
     if (daemonDetail && daemonState === 'stopped') parts.push(`Detail: ${daemonDetail}`);
+    if (daemonDetail && (daemonState === 'needs_attention' || daemonState === 'rebootstrapping')) {
+      parts.push(`Detail: ${daemonDetail}`);
+    }
     syncMeta.textContent = parts.join(' \u00b7 ');
   }
 
@@ -144,6 +154,13 @@ export function renderSyncStatus() {
   } else if (daemonState === 'stopped') {
     actions.push({ label: 'Sync daemon is stopped. Start it.', command: 'codemem sync start' });
     actions.push({ label: 'Then run one immediate sync pass.', command: 'codemem sync once' });
+  } else if (daemonState === 'needs_attention') {
+    actions.push({
+      label: 'Sync needs manual attention before reset can continue.',
+      command: 'codemem sync doctor',
+    });
+  } else if (daemonState === 'rebootstrapping') {
+    actions.push({ label: 'Sync is rebuilding state in the background.', command: 'codemem sync status' });
   } else if (syncError || pingError || daemonState === 'error') {
     actions.push({
       label: 'Sync reports errors. Restart now.',

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1423,6 +1423,38 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("does not let latest needs_attention metadata override live starting state", async () => {
+			const { app, getStore, cleanup } = createTestApp({
+				getSyncRuntimeStatus: () => ({
+					phase: "starting",
+					detail: "Running initial sync in background",
+				}),
+			});
+			try {
+				await app.request("/api/sync/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						`INSERT INTO sync_attempts(peer_device_id, started_at, finished_at, ok, ops_in, ops_out, error)
+						 VALUES ('peer-1', ?, ?, 0, 0, 0, ?)`,
+					)
+					.run(
+						new Date().toISOString(),
+						new Date().toISOString(),
+						"needs_attention:local_unsynced_shared_memory:2",
+					);
+
+				const res = await app.request("/api/sync/status");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.daemon_state).toBe("starting");
+				expect(body.daemon_detail).toBe("Running initial sync in background");
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("retries coordinator presence immediately after not_enrolled status", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -50,7 +50,15 @@ export interface AppOptions {
 	sweeper?: RawEventSweeper | null;
 	observer?: ObserverClient | null;
 	getSyncRuntimeStatus?: () => {
-		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
+		phase:
+			| "starting"
+			| "running"
+			| "stopping"
+			| "error"
+			| "disabled"
+			| "rebootstrapping"
+			| "needs_attention"
+			| null;
 		detail?: string | null;
 	} | null;
 }

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -33,7 +33,15 @@ import { queryBool, queryInt, safeJsonList } from "../helpers.js";
 
 type StoreFactory = () => MemoryStore;
 type SyncRuntimeStatus = {
-	phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
+	phase:
+		| "starting"
+		| "running"
+		| "stopping"
+		| "error"
+		| "disabled"
+		| "rebootstrapping"
+		| "needs_attention"
+		| null;
 	detail?: string | null;
 };
 
@@ -748,6 +756,7 @@ export function syncRoutes(
 				status: attemptStatus(row),
 				address: null,
 			}));
+			const latestAttemptError = String(attemptsItems[0]?.error || "").trim();
 
 			const statusBlock: Record<string, unknown> = {
 				...statusPayload,
@@ -766,6 +775,14 @@ export function syncRoutes(
 				} catch {
 					joinRequests = [];
 				}
+			}
+
+			if (daemonStateValue === "ok" && latestAttemptError.startsWith("needs_attention:")) {
+				daemonStateValue = "needs_attention";
+				statusPayload.daemon_state = daemonStateValue;
+				statusPayload.daemon_detail = latestAttemptError.replace(/^needs_attention:/, "");
+				statusBlock.daemon_state = daemonStateValue;
+				statusBlock.daemon_detail = latestAttemptError.replace(/^needs_attention:/, "");
 			}
 
 			if (daemonStateValue === "ok") {


### PR DESCRIPTION
## Description

Implements `codemem-lsod`, the phase-1 visibility slice for stale-peer recovery.

### What changed
- add `needs_attention` and `rebootstrapping` sync daemon states to public API types
- surface `needs_attention` in `/api/sync/status` when the latest sync attempt failed closed because local unsynced shared-memory changes block auto-reset
- update Sync diagnostics UI to label and explain `needs_attention` / `rebootstrapping`
- update Health tab risk heuristics to treat `needs_attention` as a higher-severity state
- add server-side test coverage for `needs_attention` status propagation

### Why
This is the visibility slice of `codemem-etuk`. It makes automatic recovery behavior observable so users can tell the difference between normal sync startup, background rebootstrap, and fail-closed recovery states.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run test -- packages/viewer-server/src/index.test.ts packages/core/src/sync-replication.test.ts packages/core/src/sync-pass.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced