### PR TITLE
fix: dedupe observer auth headers for custom providers

### DIFF
--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -556,6 +556,76 @@ describe("ObserverClient.observe()", () => {
 		expect(result.provider).toBe("openai");
 	});
 
+	it("dedupes authorization headers case-insensitively for custom providers", async () => {
+		const prevHome = process.env.HOME;
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-custom-auth-header-test-"));
+		const configDir = join(tmpDir, ".config", "opencode");
+		mkdirSync(configDir, { recursive: true });
+		let capturedHeaders: Record<string, string> | undefined;
+
+		writeFileSync(
+			join(configDir, "opencode.jsonc"),
+			JSON.stringify({
+				provider: {
+					acme: {
+						options: {
+							baseURL: "https://proxy.example.test/v1",
+							apiKey: "sk-provider-token",
+							headers: {
+								// biome-ignore lint/suspicious/noTemplateCurlyInString: intentional placeholder syntax
+								Authorization: "Bearer ${auth.token}",
+							},
+						},
+						models: {
+							foo: { id: "foo-model" },
+						},
+					},
+				},
+			}),
+		);
+
+		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedHeaders = Object.fromEntries(
+				Object.entries((init?.headers as Record<string, string>) ?? {}),
+			);
+			return new Response(
+				JSON.stringify({
+					choices: [{ message: { content: "custom provider response" } }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+
+		try {
+			process.env.HOME = tmpDir;
+			const client = new ObserverClient({
+				observerProvider: "acme",
+				observerModel: "acme/foo",
+				observerRuntime: null,
+				observerApiKey: null,
+				observerBaseUrl: null,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "auto",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+
+			const result = await client.observe("system", "user");
+
+			expect(result.raw).toBe("custom provider response");
+			expect(capturedHeaders?.Authorization).toBe("Bearer sk-provider-token");
+			expect(capturedHeaders?.authorization).toBeUndefined();
+		} finally {
+			if (prevHome == null) delete process.env.HOME;
+			else process.env.HOME = prevHome;
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
 	it("truncates prompts to maxChars", async () => {
 		let capturedBody: Record<string, unknown> | undefined;
 

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -366,6 +366,34 @@ function buildOpenAIHeaders(token: string): Record<string, string> {
 	};
 }
 
+function mergeHeadersCaseInsensitive(
+	base: Record<string, string>,
+	override: Record<string, string>,
+): Record<string, string> {
+	const merged: Record<string, string> = { ...base };
+	for (const [key, value] of Object.entries(override)) {
+		const normalizedKey = key.toLowerCase();
+		for (const existingKey of Object.keys(merged)) {
+			if (existingKey.toLowerCase() === normalizedKey) {
+				delete merged[existingKey];
+			}
+		}
+		merged[key] = value;
+	}
+	return merged;
+}
+
+function replaceHeadersCaseInsensitive(
+	target: Record<string, string>,
+	override: Record<string, string>,
+): void {
+	const merged = mergeHeadersCaseInsensitive(target, override);
+	for (const key of Object.keys(target)) {
+		delete target[key];
+	}
+	Object.assign(target, merged);
+}
+
 function buildOpenAIPayload(
 	model: string,
 	systemPrompt: string,
@@ -786,10 +814,10 @@ export class ObserverClient {
 		const url = resolveAnthropicEndpoint();
 		const token = this.auth.token ?? "";
 		const headers = buildAnthropicHeaders(token, false);
-		const mergedHeaders = {
-			...headers,
-			...renderObserverHeaders(this._observerHeaders, this.auth),
-		};
+		const mergedHeaders = mergeHeadersCaseInsensitive(
+			headers,
+			renderObserverHeaders(this._observerHeaders, this.auth),
+		);
 		const payload = buildAnthropicPayload(this.model, systemPrompt, userPrompt, this.maxTokens);
 
 		return this._fetchJSON(url, mergedHeaders, payload, {
@@ -814,10 +842,10 @@ export class ObserverClient {
 		}
 
 		const headers = buildOpenAIHeaders(this.auth.token ?? "");
-		const mergedHeaders = {
-			...headers,
-			...renderObserverHeaders(this._observerHeaders, this.auth),
-		};
+		const mergedHeaders = mergeHeadersCaseInsensitive(
+			headers,
+			renderObserverHeaders(this._observerHeaders, this.auth),
+		);
 		const payload = buildOpenAIPayload(this.model, systemPrompt, userPrompt, this.maxTokens);
 
 		return this._fetchJSON(url, mergedHeaders, payload, {
@@ -840,7 +868,10 @@ export class ObserverClient {
 				authType: "bearer",
 				source: this.auth.source,
 			};
-			Object.assign(headers, renderObserverHeaders(this._observerHeaders, codexAuth));
+			replaceHeadersCaseInsensitive(
+				headers,
+				renderObserverHeaders(this._observerHeaders, codexAuth),
+			);
 		}
 		headers["content-type"] = "application/json";
 
@@ -870,7 +901,10 @@ export class ObserverClient {
 				authType: "bearer",
 				source: this.auth.source,
 			};
-			Object.assign(headers, renderObserverHeaders(this._observerHeaders, anthropicAuth));
+			replaceHeadersCaseInsensitive(
+				headers,
+				renderObserverHeaders(this._observerHeaders, anthropicAuth),
+			);
 		}
 
 		// Append ?beta=true to the endpoint


### PR DESCRIPTION
## Description
Fix custom-provider observer requests that accidentally send duplicate auth headers when provider config already defines `Authorization`. This keeps codemem compatible with LiteLLM/IAP-backed providers while preserving provider-specific header casing and adds a regression test for the merge behavior.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [ ] 🚀 Feature (new functionality)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Manual / targeted validation:
- `pnpm exec vitest run packages/core/src/observer-client.test.ts`
- `pnpm exec biome check packages/core/src/observer-client.ts packages/core/src/observer-client.test.ts`
- direct `ObserverClient` repro with a custom provider config containing `Authorization: \"Bearer ${auth.token}\"` now sends only one `Authorization` header and succeeds

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced