### PR TITLE
chore(release): cut 0.20.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.20.5"
+    "version": "0.20.6"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.20.5",
+      "version": "0.20.6",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.5";
+const PINNED_BACKEND_VERSION = "0.20.6";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.20.5",
+	"version": "0.20.6",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.5",
+	"version": "0.20.6",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.5");
+		expect(VERSION).toBe("0.20.6");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.5";
+export const VERSION = "0.20.6";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.5",
+	"version": "0.20.6",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.5",
+	"version": "0.20.6",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description
Cut the 0.20.6 hotfix release so the custom-provider observer auth-header dedupe fix can ship in the published packages and packaged plugins.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm install`
- `pnpm build`
- `pnpm exec vitest run packages/core/src/index.test.ts packages/core/src/observer-client.test.ts`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced