### PR TITLE
chore(release): prepare 0.20.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.20.6"
+    "version": "0.20.7"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.20.6",
+      "version": "0.20.7",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.6";
+const PINNED_BACKEND_VERSION = "0.20.7";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,8 +1,14 @@
 {
 	"name": "codemem",
-	"version": "0.20.6",
+	"version": "0.20.7",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
+	"main": "./dist/index.js",
+	"exports": {
+		".": {
+			"import": "./dist/index.js"
+		}
+	},
 	"bin": {
 		"codemem": "./dist/index.js"
 	},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.6",
+	"version": "0.20.7",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.6");
+		expect(VERSION).toBe("0.20.7");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.6";
+export const VERSION = "0.20.7";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.6",
+	"version": "0.20.7",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.6",
+	"version": "0.20.7",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Summary

Hotfix release to fix OpenCode plugin loading from npm.

### Bug Fix
- **Add `main` and `exports` fields to CLI `package.json`** — OpenCode uses Bun to install npm plugins into `~/.cache/opencode/node_modules/` and then `import()` the package. Without a `main` or `exports` field, Bun cannot resolve the module entry point, causing a silent plugin load failure:
  ```
  ERROR service=plugin path=codemem error=ResolveMessage: Cannot find module
  '~/.cache/opencode/node_modules/codemem' failed to load plugin
  ```
  This meant the OpenCode plugin hook never fired, so no raw events were captured for new sessions. The MCP server (separate process) was unaffected.

### Version Bump
- All packages, plugin metadata, and version constants bumped from 0.20.5 → 0.20.7 (0.20.6 shipped without bumping source versions).

## Type of Change
- [x] Bug fix
- [x] Release prep

## Testing
- [x] `pnpm build` — all packages build
- [x] `pnpm run typecheck` — clean
- [x] Core + CLI tests pass (57/57)
- [x] `codemem --version` → `0.20.7`
- [x] Verified `exports` field matches pattern used by working OpenCode plugins (`opencode-helicone-session`, `opencode-wakatime`)

## Checklist
- [x] Version bumped in all required locations
- [x] No secrets or private references
- [x] No unrelated changes