### PR TITLE
fix(plugin): use inert module entry for OpenCode resolution (0.20.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.20.7"
+    "version": "0.20.8"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.20.7",
+      "version": "0.20.8",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 dist/
 .worktrees/
 .tmp/
+.wrangler/
 node_modules/
 viewer_ui/node_modules/
 viewer_ui/.vite/

--- a/.wrangler/cache/wrangler-account.json
+++ b/.wrangler/cache/wrangler-account.json
@@ -1,0 +1,6 @@
+{
+  "account": {
+    "id": "e2ff1c6f56fc893848ffa269c1d328c9",
+    "name": "Kunickiaj@gmail.com's Account"
+  }
+}

--- a/.wrangler/cache/wrangler-account.json
+++ b/.wrangler/cache/wrangler-account.json
@@ -1,6 +1,0 @@
-{
-  "account": {
-    "id": "e2ff1c6f56fc893848ffa269c1d328c9",
-    "name": "Kunickiaj@gmail.com's Account"
-  }
-}

--- a/packages/cli/.opencode/entry.js
+++ b/packages/cli/.opencode/entry.js
@@ -1,0 +1,5 @@
+// Minimal module entry point for package resolution.
+// OpenCode needs to resolve this package as a module to discover
+// .opencode/plugins/codemem.js — the actual plugin is loaded from there.
+// This file intentionally does nothing; the CLI lives at bin/codemem.
+export const name = "codemem";

--- a/packages/cli/.opencode/package.json
+++ b/packages/cli/.opencode/package.json
@@ -1,4 +1,5 @@
 {
+	"type": "module",
 	"dependencies": {
 		"@opencode-ai/plugin": "1.2.27"
 	}

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.20.7";
+const PINNED_BACKEND_VERSION = "0.20.8";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,12 +1,12 @@
 {
 	"name": "codemem",
-	"version": "0.20.7",
+	"version": "0.20.8",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
-	"main": "./dist/index.js",
+	"main": "./.opencode/entry.js",
 	"exports": {
 		".": {
-			"import": "./dist/index.js"
+			"import": "./.opencode/entry.js"
 		}
 	},
 	"bin": {
@@ -14,6 +14,7 @@
 	},
 	"files": [
 		"dist/",
+		".opencode/entry.js",
 		".opencode/package.json",
 		".opencode/plugins/",
 		".opencode/lib/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.20.7",
+	"version": "0.20.8",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.20.7");
+		expect(VERSION).toBe("0.20.8");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.20.7";
+export const VERSION = "0.20.8";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.20.7",
+	"version": "0.20.8",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.20.7",
+	"version": "0.20.8",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Summary

Emergency fix for 0.20.7 regression that caused OpenCode to infinite-loop when loading the codemem plugin.

### What happened
- 0.20.7 added `main` and `exports` pointing to `./dist/index.js` (the CLI entry point)
- When OpenCode does `import("codemem")` to resolve the package, Bun executes the CLI which dumps help text in a loop

### Fix
- Replace `main`/`exports` with `.opencode/entry.js` — a minimal stub that exports only the package name
- This satisfies Bun's module resolution (so OpenCode can find `.opencode/plugins/codemem.js`) without triggering CLI execution
- Added `entry.js` to the `files` array so it's included in the npm tarball

### Version bump
- 0.20.7 → 0.20.8 across all packages and metadata

## Testing
- [x] `pnpm build` — all packages
- [x] Core + CLI tests pass (57/57)
- [x] `codemem --version` → `0.20.8`
- [x] No stale 0.20.7 references remaining

## Checklist
- [x] Version bumped in all required locations
- [x] No secrets or private references
- [x] No unrelated changes