### PR TITLE
fix(sync): remove heavy pruning from startup preflight

### DIFF
--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -1,6 +1,5 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import * as observerConfig from "./observer-config.js";
 import {
 	consecutiveConnectivityFailures,
 	cursorAdvances,
@@ -152,29 +151,12 @@ describe("syncPassPreflight", () => {
 		db.close();
 	});
 
-	it("does not prune replication ops when retention is disabled by default", () => {
+	it("does not run retention pruning in sync preflight", () => {
 		const pruneSpy = vi.spyOn(syncReplication, "pruneReplicationOps");
-		vi.spyOn(observerConfig, "readCodememConfigFile").mockReturnValue({});
 
 		syncPassPreflight(db);
 
 		expect(pruneSpy).not.toHaveBeenCalled();
-	});
-
-	it("uses configured age and size retention settings when enabled", () => {
-		const pruneSpy = vi.spyOn(syncReplication, "pruneReplicationOps");
-		vi.spyOn(observerConfig, "readCodememConfigFile").mockReturnValue({
-			sync_retention_enabled: true,
-			sync_retention_max_age_days: 7,
-			sync_retention_max_size_mb: 3,
-		});
-
-		syncPassPreflight(db);
-
-		expect(pruneSpy).toHaveBeenCalledWith(db, {
-			maxAgeDays: 7,
-			maxSizeBytes: 3 * 1024 * 1024,
-		});
 	});
 });
 

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -8,9 +8,7 @@
 
 import { and, desc, eq, gt, or } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import { readCoordinatorSyncConfig } from "./coordinator-runtime.js";
 import type { Database } from "./db.js";
-import { readCodememConfigFile } from "./observer-config.js";
 import * as schema from "./schema.js";
 import { buildAuthHeaders } from "./sync-auth.js";
 import { buildBaseUrl, requestJson } from "./sync-http-client.js";
@@ -25,7 +23,6 @@ import {
 	getReplicationCursor,
 	hasUnsyncedSharedMemoryChanges,
 	migrateLegacyImportKeys,
-	pruneReplicationOps,
 	setReplicationCursor,
 } from "./sync-replication.js";
 import type { ReplicationOp, SyncResetRequired } from "./types.js";
@@ -313,12 +310,6 @@ async function pushOps(
 export function syncPassPreflight(db: Database): void {
 	migrateLegacyImportKeys(db, 2000);
 	backfillReplicationOps(db, 200);
-	const config = readCoordinatorSyncConfig(readCodememConfigFile());
-	if (!config.syncRetentionEnabled) return;
-	pruneReplicationOps(db, {
-		maxAgeDays: config.syncRetentionMaxAgeDays,
-		maxSizeBytes: config.syncRetentionMaxSizeMb * 1024 * 1024,
-	});
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Implements `codemem-flpi`.

### What changed
- removes heavy `pruneReplicationOps()` execution from `syncPassPreflight()`
- leaves retention policy/config surfaces intact
- ensures sync startup/backfill preflight no longer performs large destructive pruning work inline

### Why
The previous design allowed retention pruning to run from the sync preflight path, which made the viewer/sync process unresponsive on giant databases. This PR makes startup safe again by removing heavy pruning from the critical path.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run test -- packages/core/src/sync-pass.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced