### PR TITLE
feat(sync): expose retention telemetry in diagnostics

### DIFF
--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -494,6 +494,13 @@ export interface ApiSyncRetentionStatus {
 	max_age_days: number;
 	max_size_mb: number;
 	retained_floor_cursor: string | null;
+	last_run_at?: string | null;
+	last_duration_ms?: number | null;
+	last_deleted_ops?: number | null;
+	last_estimated_bytes_before?: number | null;
+	last_estimated_bytes_after?: number | null;
+	last_error?: string | null;
+	last_error_at?: string | null;
 }
 
 /** Status block nested in sync status response. */

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -9,6 +9,18 @@ import { TEST_SCHEMA_BASE_DDL } from "./test-schema.generated.js";
 const TEST_SCHEMA_AUX_DDL = `
 CREATE INDEX IF NOT EXISTS idx_sync_peers_actor_id ON sync_peers(actor_id);
 
+CREATE TABLE IF NOT EXISTS sync_retention_state (
+	id INTEGER PRIMARY KEY,
+	last_run_at TEXT,
+	last_duration_ms INTEGER,
+	last_deleted_ops INTEGER NOT NULL DEFAULT 0,
+	last_estimated_bytes_before INTEGER,
+	last_estimated_bytes_after INTEGER,
+	retained_floor_cursor TEXT,
+	last_error TEXT,
+	last_error_at TEXT
+);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
 	title, body_text, tags_text,
 	content='memory_items',

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -45,6 +45,11 @@ export function renderSyncStatus() {
   const pending = Number(status.pending || 0);
   const daemonDetail = String(status.daemon_detail || '');
   const daemonState = String(status.daemon_state || 'unknown');
+  const retention = status.retention || {};
+  const retentionEnabled = retention.enabled === true;
+  const retentionDeleted = Number(retention.last_deleted_ops || 0);
+  const retentionLastRunAt = retention.last_run_at || null;
+  const retentionLastError = String(retention.last_error || '');
   const daemonStateLabel =
     daemonState === 'offline-peers'
       ? 'Offline peers'
@@ -72,6 +77,13 @@ export function renderSyncStatus() {
     if (daemonDetail && daemonState === 'stopped') parts.push(`Detail: ${daemonDetail}`);
     if (daemonDetail && (daemonState === 'needs_attention' || daemonState === 'rebootstrapping')) {
       parts.push(`Detail: ${daemonDetail}`);
+    }
+    if (retentionEnabled) {
+      parts.push(
+        retentionLastRunAt
+          ? `Retention last ran ${formatAgeShort(secondsSince(retentionLastRunAt))} ago`
+          : 'Retention enabled',
+      );
     }
     syncMeta.textContent = parts.join(' \u00b7 ');
   }
@@ -101,6 +113,14 @@ export function renderSyncStatus() {
           {
             label: 'Last ping',
             value: lastPing ? `${formatAgeShort(secondsSince(lastPing))} ago` : 'never',
+          },
+          {
+            label: 'Retention',
+            value: retentionEnabled
+              ? retentionLastRunAt
+                ? `${retentionDeleted.toLocaleString()} ops last run`
+                : 'Enabled'
+              : 'Disabled',
           },
         ];
 
@@ -141,6 +161,14 @@ export function renderSyncStatus() {
       el('div', 'value', `${pingPayload.seconds_since_last}s`),
       el('div', 'label', 'Since last ping'),
     );
+    block.appendChild(content);
+    syncStatusGrid.appendChild(block);
+  }
+
+  if (!syncDisabled && retentionEnabled && retentionLastError) {
+    const block = el('div', 'stat');
+    const content = el('div', 'stat-content');
+    content.append(el('div', 'value', 'Retention'), el('div', 'label', retentionLastError));
     block.appendChild(content);
     syncStatusGrid.appendChild(block);
   }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1402,12 +1402,14 @@ describe("viewer-server", () => {
 				expect(res.status).toBe(200);
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.enabled).toBe(true);
-				expect(body.retention).toEqual({
-					enabled: true,
-					max_age_days: 14,
-					max_size_mb: 256,
-					retained_floor_cursor: null,
-				});
+				expect(body.retention).toEqual(
+					expect.objectContaining({
+						enabled: true,
+						max_age_days: 14,
+						max_size_mb: 256,
+						retained_floor_cursor: null,
+					}),
+				);
 			} finally {
 				cleanup();
 				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
@@ -1436,6 +1438,48 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.daemon_state).toBe("starting");
 				expect(body.daemon_detail).toBe("Running initial sync in background");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("includes retention telemetry in sync status output", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/sync/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						`INSERT INTO sync_retention_state(id, last_run_at, last_duration_ms, last_deleted_ops, last_estimated_bytes_before, last_estimated_bytes_after, retained_floor_cursor, last_error, last_error_at)
+						 VALUES (1, ?, 1200, 42, 1000, 900, 'floor-cursor', 'boom', ?)`,
+					)
+					.run(new Date().toISOString(), new Date().toISOString());
+
+				const prevRetentionEnabled = process.env.CODEMEM_SYNC_RETENTION_ENABLED;
+				const prevMaxAge = process.env.CODEMEM_SYNC_RETENTION_MAX_AGE_DAYS;
+				const prevMaxSize = process.env.CODEMEM_SYNC_RETENTION_MAX_SIZE_MB;
+				process.env.CODEMEM_SYNC_RETENTION_ENABLED = "1";
+				process.env.CODEMEM_SYNC_RETENTION_MAX_AGE_DAYS = "14";
+				process.env.CODEMEM_SYNC_RETENTION_MAX_SIZE_MB = "256";
+				try {
+					const res = await app.request("/api/sync/status");
+					const body = (await res.json()) as Record<string, unknown>;
+					const retention = body.retention as Record<string, unknown>;
+					expect(retention.enabled).toBe(true);
+					expect(retention.max_age_days).toBe(14);
+					expect(retention.max_size_mb).toBe(256);
+					expect(retention.last_deleted_ops).toBe(42);
+					expect(retention.retained_floor_cursor).toBe("floor-cursor");
+					expect(retention.last_error).toBe("boom");
+				} finally {
+					if (prevRetentionEnabled === undefined) delete process.env.CODEMEM_SYNC_RETENTION_ENABLED;
+					else process.env.CODEMEM_SYNC_RETENTION_ENABLED = prevRetentionEnabled;
+					if (prevMaxAge === undefined) delete process.env.CODEMEM_SYNC_RETENTION_MAX_AGE_DAYS;
+					else process.env.CODEMEM_SYNC_RETENTION_MAX_AGE_DAYS = prevMaxAge;
+					if (prevMaxSize === undefined) delete process.env.CODEMEM_SYNC_RETENTION_MAX_SIZE_MB;
+					else process.env.CODEMEM_SYNC_RETENTION_MAX_SIZE_MB = prevMaxSize;
+				}
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -662,6 +662,27 @@ export function syncRoutes(
 				.get();
 
 			const peerCountRow = d.select({ total: count() }).from(schema.syncPeers).get();
+			let retentionState:
+				| {
+						last_run_at?: string | null;
+						last_duration_ms?: number | null;
+						last_deleted_ops?: number | null;
+						last_estimated_bytes_before?: number | null;
+						last_estimated_bytes_after?: number | null;
+						retained_floor_cursor?: string | null;
+						last_error?: string | null;
+						last_error_at?: string | null;
+				  }
+				| undefined;
+			try {
+				retentionState = d
+					.select()
+					.from(schema.syncRetentionState)
+					.where(eq(schema.syncRetentionState.id, 1))
+					.get();
+			} catch {
+				retentionState = undefined;
+			}
 
 			const lastSyncRow = d
 				.select({ last_sync_at: max(schema.syncPeers.last_sync_at) })
@@ -697,7 +718,29 @@ export function syncRoutes(
 					enabled: config.syncRetentionEnabled,
 					max_age_days: config.syncRetentionMaxAgeDays,
 					max_size_mb: config.syncRetentionMaxSizeMb,
-					retained_floor_cursor: syncReset.retained_floor_cursor,
+					retained_floor_cursor:
+						syncReset.retained_floor_cursor ??
+						(retentionState?.retained_floor_cursor as string | null) ??
+						null,
+					last_run_at: (retentionState?.last_run_at as string | null) ?? null,
+					last_duration_ms:
+						typeof retentionState?.last_duration_ms === "number"
+							? retentionState.last_duration_ms
+							: null,
+					last_deleted_ops:
+						typeof retentionState?.last_deleted_ops === "number"
+							? retentionState.last_deleted_ops
+							: null,
+					last_estimated_bytes_before:
+						typeof retentionState?.last_estimated_bytes_before === "number"
+							? retentionState.last_estimated_bytes_before
+							: null,
+					last_estimated_bytes_after:
+						typeof retentionState?.last_estimated_bytes_after === "number"
+							? retentionState.last_estimated_bytes_after
+							: null,
+					last_error: (retentionState?.last_error as string | null) ?? null,
+					last_error_at: (retentionState?.last_error_at as string | null) ?? null,
 				},
 				peer_count: Number(peerCountRow?.total ?? 0),
 				last_sync_at: lastSyncRow?.last_sync_at ?? null,


### PR DESCRIPTION
## Description

Implements `codemem-4h6e`.

### What changed
- exposes retention telemetry in `/api/sync/status`
- includes:
  - enabled
  - max age days
  - max size MB
  - retained floor cursor
  - last run timestamp
  - last duration
  - last deleted ops
  - estimated bytes before/after
  - last retention error
- updates Sync diagnostics UI to show retention activity and errors
- adds server-side coverage for retention telemetry in sync status
- updates test schema scaffolding for `sync_retention_state`

### Why
The bounded background runner needs visibility. This PR makes retention execution observable so operators can see whether retention is enabled, whether it has actually run, and whether it is failing.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run test -- packages/viewer-server/src/index.test.ts packages/core/src/sync-replication.test.ts packages/core/src/sync-pass.test.ts packages/core/src/observer-config.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced