### PR TITLE
fix(db): bootstrap planner stats for FTS queries

### DIFF
--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -9,6 +9,7 @@ import {
 	columnExists,
 	connect,
 	ensureAdditiveSchemaCompatibility,
+	ensurePlannerStats,
 	fromJson,
 	getSchemaVersion,
 	isEmbeddingDisabled,
@@ -377,6 +378,43 @@ describe("ensureAdditiveSchemaCompatibility", () => {
 
 	it("is a no-op when raw_event_flush_batches does not exist", () => {
 		expect(() => ensureAdditiveSchemaCompatibility(db)).not.toThrow();
+	});
+});
+
+describe("ensurePlannerStats", () => {
+	let tmpDir: string;
+	let db: Database;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
+		db = connect(join(tmpDir, "test.sqlite"));
+	});
+
+	afterEach(() => {
+		db?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("is a no-op for fresh databases without search tables", () => {
+		expect(() => ensurePlannerStats(db)).not.toThrow();
+		expect(tableExists(db, "sqlite_stat1")).toBe(false);
+	});
+
+	it("bootstraps sqlite_stat1 once search tables exist", () => {
+		db.exec(
+			"CREATE TABLE memory_items (id INTEGER PRIMARY KEY, active INTEGER NOT NULL DEFAULT 1, created_at TEXT, title TEXT, body_text TEXT, tags_text TEXT)",
+		);
+		db.exec(
+			"CREATE VIRTUAL TABLE memory_fts USING fts5(title, body_text, tags_text, content='memory_items', content_rowid='id')",
+		);
+		db.exec("CREATE INDEX idx_memory_items_active_created ON memory_items(active, created_at)");
+
+		expect(tableExists(db, "sqlite_stat1")).toBe(false);
+
+		ensurePlannerStats(db);
+
+		expect(tableExists(db, "sqlite_stat1")).toBe(true);
+		expect(db.prepare("SELECT 1 FROM sqlite_stat1 LIMIT 1").pluck().get()).toBe(1);
 	});
 });
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -212,6 +212,31 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 	return db;
 }
 
+function hasPlannerStats(db: DatabaseType): boolean {
+	try {
+		return !!db.prepare("SELECT 1 FROM sqlite_stat1 LIMIT 1").pluck().get();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Keep SQLite planner statistics healthy for FTS-heavy queries.
+ *
+ * We always run PRAGMA optimize as a cheap maintenance hint. If planner
+ * statistics have never been collected and the core search tables exist,
+ * bootstrap them with ANALYZE so Node SQLite picks stable FTS query plans.
+ */
+export function ensurePlannerStats(db: DatabaseType): void {
+	db.pragma("optimize");
+
+	if (hasPlannerStats(db)) return;
+	if (!tableExists(db, "memory_items") || !tableExists(db, "memory_fts")) return;
+
+	db.exec("ANALYZE");
+	db.pragma("optimize");
+}
+
 /**
  * Load the sqlite-vec extension into an open database connection.
  *

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -22,6 +22,7 @@ import {
 	connect,
 	DEFAULT_DB_PATH,
 	ensureAdditiveSchemaCompatibility,
+	ensurePlannerStats,
 	fromJson,
 	isEmbeddingDisabled,
 	loadSqliteVec,
@@ -179,6 +180,7 @@ export class MemoryStore {
 			loadSqliteVec(this.db);
 			assertSchemaReady(this.db);
 			ensureAdditiveSchemaCompatibility(this.db);
+			ensurePlannerStats(this.db);
 		} catch (err) {
 			this.db.close();
 			throw err;
@@ -1979,6 +1981,7 @@ export class MemoryStore {
 
 	/** Close the database connection. */
 	close(): void {
+		this.db.pragma("optimize");
 		this.db.close();
 	}
 }


### PR DESCRIPTION
## Description
- bootstrap SQLite planner stats with a one-time `ANALYZE` when `sqlite_stat1` is missing and the core search tables exist
- run `PRAGMA optimize` during planner-stats maintenance and on store close to keep FTS query planning healthy
- add targeted coverage for fresh databases and the `sqlite_stat1` bootstrap path

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 🚀 Feature (new functionality)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `pnpm exec vitest run packages/core/src/db.test.ts`
- `pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `CODEMEM_EMBEDDING_DISABLED=1 pnpm run codemem pack "Read-only repo inspection for code review of PR #430 on branch 03-26-fix_sync_make_retention_config_driven in /Users/adam/workspace/codemem. Determine likely base branch and summarize changed files and code diff in detail." --json`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
