### PR TITLE
fix(release): allow hotfix tags from release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify tag points at merged main HEAD
+      - name: Verify tag points at merged main or release branch
         env:
           RELEASE_TAG_COMMIT: ${{ github.sha }}
         run: bash scripts/release-tag-preflight.sh

--- a/scripts/release-tag-preflight.sh
+++ b/scripts/release-tag-preflight.sh
@@ -6,30 +6,71 @@ MAIN_REF="origin/${EXPECTED_BRANCH}"
 TARGET_COMMIT="${RELEASE_TAG_COMMIT:-${GITHUB_SHA:-HEAD}}"
 
 git fetch origin "${EXPECTED_BRANCH}" --quiet
+git fetch origin 'refs/heads/release/*:refs/remotes/origin/release/*' --quiet || true
 
 main_commit="$(git rev-parse "${MAIN_REF}^{commit}")"
 tag_commit="$(git rev-parse "${TARGET_COMMIT}^{commit}")"
 
+matches_main=0
+if git merge-base --is-ancestor "${tag_commit}" "${main_commit}"; then
+	matches_main=1
+fi
+
+matching_release_branches=()
+while IFS= read -r branch_ref; do
+	[[ -z "${branch_ref}" ]] && continue
+	if git merge-base --is-ancestor "${tag_commit}" "${branch_ref}"; then
+		matching_release_branches+=("${branch_ref#origin/}")
+	fi
+done < <(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/release/*')
+
+qualified_branch=""
+if [[ "${matches_main}" -eq 1 ]]; then
+	qualified_branch="${EXPECTED_BRANCH}"
+elif [[ "${#matching_release_branches[@]}" -eq 1 ]]; then
+	qualified_branch="${matching_release_branches[0]}"
+fi
+
 if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-	if ! git merge-base --is-ancestor "${tag_commit}" "${main_commit}"; then
-		echo "Release tag preflight failed: tag commit is not reachable from origin/${EXPECTED_BRANCH}." >&2
+	if [[ -z "${qualified_branch}" ]]; then
+		echo "Release tag preflight failed: tag commit is not reachable from origin/${EXPECTED_BRANCH} or an origin/release/* branch." >&2
 		echo "  tag commit:  ${tag_commit}" >&2
 		echo "  main commit: ${main_commit}" >&2
-		echo "Tag only after the release commit is merged to ${EXPECTED_BRANCH}." >&2
+		if [[ "${#matching_release_branches[@]}" -gt 1 ]]; then
+			echo "  matching release branches: ${matching_release_branches[*]}" >&2
+		fi
+		echo "Tag only after the release commit is merged to ${EXPECTED_BRANCH} or a single release branch." >&2
 		exit 1
 	fi
-elif [[ "${tag_commit}" != "${main_commit}" ]]; then
-	echo "Release tag preflight failed: local tag target is not origin/${EXPECTED_BRANCH} HEAD." >&2
+	if [[ "${qualified_branch}" == "${EXPECTED_BRANCH}" && "${tag_commit}" != "${main_commit}" ]]; then
+		echo "Release tag preflight passed for commit ${tag_commit} on ${qualified_branch}."
+		exit 0
+	fi
+	if [[ "${qualified_branch}" != "${EXPECTED_BRANCH}" ]]; then
+		echo "Release tag preflight passed for commit ${tag_commit} on ${qualified_branch}."
+		exit 0
+	fi
+	if [[ "${tag_commit}" != "${main_commit}" ]]; then
+		echo "Release tag preflight failed: local tag target is not origin/${EXPECTED_BRANCH} HEAD." >&2
+		echo "  tag commit:  ${tag_commit}" >&2
+		echo "  main commit: ${main_commit}" >&2
+		echo "Tag from updated ${EXPECTED_BRANCH} after the release PR merge commit is at HEAD." >&2
+		exit 1
+	fi
+	elif [[ -z "${qualified_branch}" ]]; then
+	echo "Release tag preflight failed: local tag target is not on origin/${EXPECTED_BRANCH} or a single origin/release/* branch." >&2
 	echo "  tag commit:  ${tag_commit}" >&2
 	echo "  main commit: ${main_commit}" >&2
-	echo "Tag from updated ${EXPECTED_BRANCH} after the release PR merge commit is at HEAD." >&2
+	if [[ "${#matching_release_branches[@]}" -gt 1 ]]; then
+		echo "  matching release branches: ${matching_release_branches[*]}" >&2
+	fi
 	exit 1
 fi
 
 if [[ -z "${GITHUB_ACTIONS:-}" && "${RELEASE_SKIP_LOCAL_GUARDS:-0}" != "1" ]]; then
 	current_branch="$(git branch --show-current || true)"
-	if [[ "${current_branch}" != "${EXPECTED_BRANCH}" ]]; then
-		echo "Release tag preflight failed: current branch is '${current_branch}', expected '${EXPECTED_BRANCH}'." >&2
+	if [[ -n "${qualified_branch}" && "${current_branch}" != "${qualified_branch}" ]]; then
+		echo "Release tag preflight failed: current branch is '${current_branch}', expected '${qualified_branch}'." >&2
 		exit 1
 	fi
 
@@ -39,4 +80,4 @@ if [[ -z "${GITHUB_ACTIONS:-}" && "${RELEASE_SKIP_LOCAL_GUARDS:-0}" != "1" ]]; t
 	fi
 fi
 
-echo "Release tag preflight passed for commit ${tag_commit}."
+echo "Release tag preflight passed for commit ${tag_commit} on ${qualified_branch:-${EXPECTED_BRANCH}}."


### PR DESCRIPTION
## Description
- allow release tag preflight to accept tag commits reachable from `main` or exactly one `release/*` branch
- keep rejecting tags from feature branches or ambiguous branch ancestry
- update the workflow step label so it matches the new hotfix-friendly rule

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `bash -n scripts/release-tag-preflight.sh`
- `env GITHUB_ACTIONS=1 RELEASE_TAG_COMMIT=d96af20 bash scripts/release-tag-preflight.sh`
- `env GITHUB_ACTIONS=1 RELEASE_TAG_COMMIT=de5ead8133e4eabc7f0156a07f12b3606693dcf5 bash scripts/release-tag-preflight.sh`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
