### PR TITLE
feat(sync): replace per-op age pruning with bulk cutoff deletes

### DIFF
--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1020,6 +1020,46 @@ describe("pruneReplicationOps", () => {
 		expect(result.deleted).toBe(1);
 		expect(result.stopped_by_budget).toBe(true);
 	});
+
+	it("bulk deletes an oldest-first age cutoff chunk and updates retained floor to its boundary cursor", () => {
+		insertOp("op-1", "2026-01-01T00:00:01Z");
+		insertOp("op-2", "2026-01-01T00:00:02Z");
+		insertOp("op-3", "2026-01-01T00:00:03Z");
+		insertOp("op-4", "2026-03-26T00:00:00Z");
+
+		const result = pruneReplicationOps(db, {
+			maxAgeDays: 30,
+			maxSizeBytes: 1_000_000,
+			maxDeleteOps: 3,
+			maxRuntimeMs: 60_000,
+		});
+
+		expect(result.deleted).toBe(3);
+		expect(result.retained_floor_cursor).toBe("2026-01-01T00:00:03Z|op-3");
+		const remaining = db
+			.prepare("SELECT op_id FROM replication_ops ORDER BY created_at, op_id")
+			.all() as Array<{ op_id: string }>;
+		expect(remaining.map((row) => row.op_id)).toEqual(["op-4"]);
+		expect(getSyncResetState(db).retained_floor_cursor).toBe("2026-01-01T00:00:03Z|op-3");
+	});
+
+	it("does not overshoot the remaining delete budget during bulk age pruning", () => {
+		insertOp("op-1", "2026-01-01T00:00:01Z");
+		insertOp("op-2", "2026-01-01T00:00:02Z");
+		insertOp("op-3", "2026-01-01T00:00:03Z");
+		insertOp("op-4", "2026-01-01T00:00:04Z");
+		insertOp("op-5", "2026-01-01T00:00:05Z");
+
+		const result = pruneReplicationOps(db, {
+			maxAgeDays: 30,
+			maxSizeBytes: 1,
+			maxDeleteOps: 4,
+			maxRuntimeMs: 60_000,
+		});
+
+		expect(result.deleted).toBe(4);
+		expect(result.retained_floor_cursor).toBe("2026-01-01T00:00:04Z|op-4");
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -870,6 +870,9 @@ export function pruneReplicationOps(
 	let deleted = 0;
 	let lastDeletedCursor: string | null = null;
 	const deleteStmt = db.prepare("DELETE FROM replication_ops WHERE op_id = ?");
+	const bulkDeleteBeforeStmt = db.prepare(
+		"DELETE FROM replication_ops WHERE created_at < ? OR (created_at = ? AND op_id <= ?)",
+	);
 	const estimatedBytesBefore = estimateReplicationOpsStorageBytes(db);
 	if (estimatedBytesBefore == null) {
 		throw new Error("replication_ops_size_unavailable");
@@ -887,12 +890,13 @@ export function pruneReplicationOps(
 			).changes ?? 0;
 	};
 
-	const ageBatchSize = Math.max(1, Math.min(maxDeleteOps, 500));
 	while (true) {
 		if (budgetExceeded()) {
 			stoppedByBudget = true;
 			break;
 		}
+		const remainingDeleteBudget = Math.max(1, maxDeleteOps - deleted);
+		const ageBatchSize = Math.max(1, Math.min(remainingDeleteBudget, 10_000));
 		const ageCandidates = d
 			.select({
 				op_id: schema.replicationOps.op_id,
@@ -904,12 +908,18 @@ export function pruneReplicationOps(
 			.limit(ageBatchSize)
 			.all();
 		if (ageCandidates.length === 0) break;
-		for (const row of ageCandidates) {
-			if (budgetExceeded()) {
-				stoppedByBudget = true;
-				break;
-			}
-			deleteOp(row);
+		const boundary = ageCandidates[ageCandidates.length - 1];
+		if (!boundary) break;
+		lastDeletedCursor = computeCursor(String(boundary.created_at), String(boundary.op_id));
+		deleted +=
+			(
+				bulkDeleteBeforeStmt.run(boundary.created_at, boundary.created_at, boundary.op_id) as {
+					changes?: number;
+				}
+			).changes ?? 0;
+		if (budgetExceeded()) {
+			stoppedByBudget = true;
+			break;
 		}
 		if (ageCandidates.length < ageBatchSize) break;
 	}


### PR DESCRIPTION
## Description

Implements `codemem-i22l`.

### What changed
- replaces per-op age pruning with cutoff-based bulk deletes over the ordered cursor `(created_at, op_id)`
- for each age-prune pass, compute the last cursor in the oldest eligible chunk and delete the entire oldest prefix through that boundary in one statement
- update `retained_floor_cursor` to the last deleted cutoff cursor
- keep size trimming behavior unchanged for now (next PR)
- add test coverage proving bulk oldest-first age deletion and retained-floor updates

### Why
Deleting age-prune candidates one row at a time is far too slow on multi-GB replication logs. Bulk oldest-first cutoff deletes are the intended fast path for age-based retention.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run test -- packages/core/src/sync-replication.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced