### PR TITLE
feat(sync): replace per-op size trimming with chunked prefix deletes

### DIFF
--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1060,6 +1060,74 @@ describe("pruneReplicationOps", () => {
 		expect(result.deleted).toBe(4);
 		expect(result.retained_floor_cursor).toBe("2026-01-01T00:00:04Z|op-4");
 	});
+
+	it("bulk deletes oldest-prefix chunks during size trimming and remeasures between chunks", () => {
+		insertOp("op-1", "2026-03-20T00:00:01Z");
+		insertOp("op-2", "2026-03-20T00:00:02Z");
+		insertOp("op-3", "2026-03-20T00:00:03Z");
+		insertOp("op-4", "2026-03-20T00:00:04Z");
+
+		const estimatedBytes = Number(
+			(
+				db
+					.prepare(
+						`SELECT COALESCE(SUM(pgsize), 0) AS total_bytes
+						 FROM dbstat
+						 WHERE name = 'replication_ops'
+						    OR name LIKE 'idx_replication_ops_%'
+						    OR name LIKE 'sqlite_autoindex_replication_ops_%'`,
+					)
+					.get() as { total_bytes: number }
+			).total_bytes,
+		);
+
+		const result = pruneReplicationOps(db, {
+			maxAgeDays: 3650,
+			maxSizeBytes: Math.max(1, estimatedBytes - 1),
+			maxDeleteOps: 2,
+			maxRuntimeMs: 60_000,
+		});
+
+		expect(result.deleted).toBe(2);
+		expect(result.retained_floor_cursor).toBe("2026-03-20T00:00:02Z|op-2");
+		expect(result.stopped_by_budget).toBe(true);
+		const remaining = db
+			.prepare("SELECT op_id FROM replication_ops ORDER BY created_at, op_id")
+			.all() as Array<{ op_id: string }>;
+		expect(remaining.map((row) => row.op_id)).toEqual(["op-3", "op-4"]);
+	});
+
+	it("does not overshoot the remaining delete budget during size trimming", () => {
+		insertOp("op-1", "2026-03-20T00:00:01Z");
+		insertOp("op-2", "2026-03-20T00:00:02Z");
+		insertOp("op-3", "2026-03-20T00:00:03Z");
+		insertOp("op-4", "2026-03-20T00:00:04Z");
+		insertOp("op-5", "2026-03-20T00:00:05Z");
+
+		const estimatedBytes = Number(
+			(
+				db
+					.prepare(
+						`SELECT COALESCE(SUM(pgsize), 0) AS total_bytes
+						 FROM dbstat
+						 WHERE name = 'replication_ops'
+						    OR name LIKE 'idx_replication_ops_%'
+						    OR name LIKE 'sqlite_autoindex_replication_ops_%'`,
+					)
+					.get() as { total_bytes: number }
+			).total_bytes,
+		);
+
+		const result = pruneReplicationOps(db, {
+			maxAgeDays: 3650,
+			maxSizeBytes: Math.max(1, estimatedBytes - 1),
+			maxDeleteOps: 4,
+			maxRuntimeMs: 60_000,
+		});
+
+		expect(result.deleted).toBe(4);
+		expect(result.retained_floor_cursor).toBe("2026-03-20T00:00:04Z|op-4");
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -930,17 +930,26 @@ export function pruneReplicationOps(
 			stoppedByBudget = true;
 			break;
 		}
-		const oldest = d
+		const remainingDeleteBudget = Math.max(1, maxDeleteOps - deleted);
+		const sizeBatchSize = Math.max(1, Math.min(remainingDeleteBudget, 10_000));
+		const oldestChunk = d
 			.select({
 				op_id: schema.replicationOps.op_id,
 				created_at: schema.replicationOps.created_at,
 			})
 			.from(schema.replicationOps)
 			.orderBy(schema.replicationOps.created_at, schema.replicationOps.op_id)
-			.limit(1)
-			.get();
-		if (!oldest) break;
-		deleteOp(oldest);
+			.limit(sizeBatchSize)
+			.all();
+		const boundary = oldestChunk[oldestChunk.length - 1];
+		if (!boundary) break;
+		lastDeletedCursor = computeCursor(String(boundary.created_at), String(boundary.op_id));
+		deleted +=
+			(
+				bulkDeleteBeforeStmt.run(boundary.created_at, boundary.created_at, boundary.op_id) as {
+					changes?: number;
+				}
+			).changes ?? 0;
 		const nextEstimatedSize = estimateReplicationOpsStorageBytes(db);
 		if (nextEstimatedSize == null) {
 			throw new Error("replication_ops_size_unavailable");


### PR DESCRIPTION
## Description

Implements `codemem-3k4i`.

### What changed
- replaces one-op-at-a-time size trimming with chunked oldest-prefix deletes
- size enforcement now deletes oldest ordered ranges in op-count chunks
- remeasures `replication_ops` size only between chunks, not after every single row delete
- updates retained floor to the last deleted cutoff cursor for each chunk
- adds tests proving size trimming deletes oldest prefixes in bulk and remains budget-aware

### Why
The previous size-trimming path was still far too slow on huge logs because it deleted one row at a time and remeasured after each delete. This PR makes size-based retention use the same bulk-cutoff strategy as age pruning.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run test -- packages/core/src/sync-replication.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced