### PR TITLE
docs(sync): describe retention as approximate oldest-first

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -93,7 +93,9 @@ dbCommand
 	.addCommand(
 		new Command("prune-replication-ops")
 			.configureHelp(helpStyle)
-			.description("Prune replication op history with dry-run and progress reporting")
+			.description(
+				"Prune replication op history with approximate oldest-first retention, dry-run, and progress reporting",
+			)
 			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 			.option("--dry-run", "show current size/targets without deleting")
@@ -125,7 +127,7 @@ dbCommand
 						p.intro("codemem db prune-replication-ops");
 						p.log.info(`Replication ops size: ${formatBytes(beforeBytes)}`);
 						p.log.info(
-							`Policy: keep <= ${maxSizeMb} MB and <= ${maxAgeDays} day old history (oldest-first pruning)`,
+							`Policy: approximately keep <= ${maxSizeMb} MB and <= ${maxAgeDays} day old history via oldest-first chunk pruning`,
 						);
 
 						if (opts.dryRun) {
@@ -155,7 +157,9 @@ dbCommand
 						}
 
 						p.log.info(`Deleted ops: ${totalDeleted.toLocaleString()}`);
-						p.log.info(`Estimated replication ops size after prune: ${formatBytes(afterBytes)}`);
+						p.log.info(
+							`Estimated replication ops size after prune: ${formatBytes(afterBytes)} (approximate)`,
+						);
 						if (lastFloor) p.log.info(`Retained floor: ${lastFloor}`);
 						if (opts.vacuum) {
 							p.log.step("Running VACUUM as requested...");
@@ -168,7 +172,7 @@ dbCommand
 							return;
 						}
 						p.outro(
-							"Done. SQLite file size may not shrink until you run `codemem db vacuum` explicitly (or re-run this command with --vacuum).",
+							"Done. Retention is approximate oldest-first pruning. SQLite file size may not shrink until you run `codemem db vacuum` explicitly (or re-run this command with --vacuum).",
 						);
 					} finally {
 						if (dbOpen) db.close();

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -81,7 +81,7 @@ export function renderSyncStatus() {
     if (retentionEnabled) {
       parts.push(
         retentionLastRunAt
-          ? `Retention last ran ${formatAgeShort(secondsSince(retentionLastRunAt))} ago`
+          ? `Retention last ran ${formatAgeShort(secondsSince(retentionLastRunAt))} ago (approx oldest-first)`
           : 'Retention enabled',
       );
     }
@@ -118,7 +118,7 @@ export function renderSyncStatus() {
             label: 'Retention',
             value: retentionEnabled
               ? retentionLastRunAt
-                ? `${retentionDeleted.toLocaleString()} ops last run`
+                ? `${retentionDeleted.toLocaleString()} ops last run (approx)`
                 : 'Enabled'
               : 'Disabled',
           },


### PR DESCRIPTION
## Description

Implements `codemem-v2q8`.

### What changed
- updates operator-facing prune command/help wording to explicitly describe retention as **approximate oldest-first**
- clarifies that size reporting after prune is approximate
- updates diagnostics wording to match the new retention model

### Why
The new pruning algorithm intentionally works in large oldest-first chunks and does not aim for byte-perfect trimming. Operator-facing output should say that explicitly so users understand what the tool is doing.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run typecheck`

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced