### PR TITLE
feat(db): fast-path age retention with direct bulk delete

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -2,6 +2,7 @@ import { statSync } from "node:fs";
 import * as p from "@clack/prompts";
 import {
 	backfillTagsText,
+	bulkPruneReplicationOpsByAgeCutoff,
 	connect,
 	deactivateLowSignalMemories,
 	deactivateLowSignalObservations,
@@ -139,9 +140,19 @@ dbCommand
 						let batches = 0;
 						let lastFloor: string | null = null;
 						let afterBytes = beforeBytes;
+						const ageResult = bulkPruneReplicationOpsByAgeCutoff(db, maxAgeDays);
+						totalDeleted += ageResult.deleted;
+						lastFloor = ageResult.retained_floor_cursor;
+						afterBytes = ageResult.estimated_bytes_after ?? beforeBytes;
+						if (ageResult.deleted > 0) {
+							batches += 1;
+							p.log.step(
+								`Age pass: deleted ${ageResult.deleted.toLocaleString()} ops, remaining size ~${formatBytes(afterBytes)}`,
+							);
+						}
 						while (true) {
 							const result = pruneReplicationOps(db, {
-								maxAgeDays,
+								maxAgeDays: 365000,
 								maxSizeBytes: maxSizeMb * 1024 * 1024,
 								maxDeleteOps: batchOps,
 								maxRuntimeMs: batchRuntimeMs,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -282,6 +282,7 @@ export type { ApplyResult } from "./sync-replication.js";
 export {
 	applyReplicationOps,
 	backfillReplicationOps,
+	bulkPruneReplicationOpsByAgeCutoff,
 	chunkOpsBySize,
 	clockTuple,
 	extractReplicationOps,

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -4,6 +4,7 @@ import { toJson } from "./db.js";
 import {
 	applyReplicationOps,
 	backfillReplicationOps,
+	bulkPruneReplicationOpsByAgeCutoff,
 	chunkOpsBySize,
 	clockTuple,
 	extractReplicationOps,
@@ -1041,6 +1042,20 @@ describe("pruneReplicationOps", () => {
 			.all() as Array<{ op_id: string }>;
 		expect(remaining.map((row) => row.op_id)).toEqual(["op-4"]);
 		expect(getSyncResetState(db).retained_floor_cursor).toBe("2026-01-01T00:00:03Z|op-3");
+	});
+
+	it("bulkPruneReplicationOpsByAgeCutoff deletes the full oldest prefix before the cutoff", () => {
+		insertOp("op-1", "2026-01-01T00:00:01Z");
+		insertOp("op-2", "2026-01-01T00:00:02Z");
+		insertOp("op-3", "2026-03-26T00:00:00Z");
+
+		const result = bulkPruneReplicationOpsByAgeCutoff(db, 30);
+		expect(result.deleted).toBe(2);
+		expect(result.retained_floor_cursor).toBe("2026-01-01T00:00:02Z|op-2");
+		const remaining = db
+			.prepare("SELECT op_id FROM replication_ops ORDER BY created_at, op_id")
+			.all() as Array<{ op_id: string }>;
+		expect(remaining.map((row) => row.op_id)).toEqual(["op-3"]);
 	});
 
 	it("does not overshoot the remaining delete budget during bulk age pruning", () => {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -9,7 +9,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { and, eq, gt, isNotNull, isNull, like, or, sql } from "drizzle-orm";
+import { and, desc, eq, gt, isNotNull, isNull, like, or, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import { fromJson, fromJsonStrict, toJson, toJsonNullable } from "./db.js";
@@ -967,6 +967,59 @@ export function pruneReplicationOps(
 		estimated_bytes_before: estimatedBytesBefore,
 		estimated_bytes_after: estimatedSizeBytes,
 		stopped_by_budget: stoppedByBudget,
+	};
+}
+
+export function bulkPruneReplicationOpsByAgeCutoff(
+	db: Database,
+	maxAgeDays: number,
+): ReplicationOpsPruneResult {
+	const d = drizzle(db, { schema });
+	const cutoff = new Date(
+		Date.now() - Math.max(1, Math.floor(maxAgeDays)) * 24 * 60 * 60 * 1000,
+	).toISOString();
+	const estimatedBytesBefore = estimateReplicationOpsStorageBytes(db);
+	if (estimatedBytesBefore == null) {
+		throw new Error("replication_ops_size_unavailable");
+	}
+	const boundary = d
+		.select({ op_id: schema.replicationOps.op_id, created_at: schema.replicationOps.created_at })
+		.from(schema.replicationOps)
+		.where(sql`${schema.replicationOps.created_at} < ${cutoff}`)
+		.orderBy(desc(schema.replicationOps.created_at), desc(schema.replicationOps.op_id))
+		.limit(1)
+		.get();
+	if (!boundary) {
+		const currentBoundary = getSyncResetState(db);
+		return {
+			deleted: 0,
+			retained_floor_cursor: currentBoundary.retained_floor_cursor,
+			estimated_bytes_before: estimatedBytesBefore,
+			estimated_bytes_after: estimatedBytesBefore,
+			stopped_by_budget: false,
+		};
+	}
+	const deleteStmt = db.prepare(
+		"DELETE FROM replication_ops WHERE created_at < ? OR (created_at = ? AND op_id <= ?)",
+	);
+	const deleted =
+		(
+			deleteStmt.run(boundary.created_at, boundary.created_at, boundary.op_id) as {
+				changes?: number;
+			}
+		).changes ?? 0;
+	const retainedFloorCursor = computeCursor(String(boundary.created_at), String(boundary.op_id));
+	setSyncResetState(db, { retained_floor_cursor: retainedFloorCursor });
+	const estimatedBytesAfter = estimateReplicationOpsStorageBytes(db);
+	if (estimatedBytesAfter == null) {
+		throw new Error("replication_ops_size_unavailable");
+	}
+	return {
+		deleted,
+		retained_floor_cursor: retainedFloorCursor,
+		estimated_bytes_before: estimatedBytesBefore,
+		estimated_bytes_after: estimatedBytesAfter,
+		stopped_by_budget: false,
 	};
 }
 


### PR DESCRIPTION
## Description

Optimizes the offline prune path for giant replication logs by making the age-based portion a direct bulk delete fast path.

### What changed
- add `bulkPruneReplicationOpsByAgeCutoff()`
- offline `prune-replication-ops` now runs in two phases:
  1. one direct bulk delete of the oldest prefix through the age cutoff boundary
  2. chunked oldest-prefix size trimming only if still above the target size
- export the new helper from core
- add test coverage proving the full oldest-prefix age delete behavior

### Why
For giant historical logs, the age-based part of retention should not be chunked row-by-row or in small slices once we already know the cutoff boundary. A direct oldest-prefix bulk delete is much faster and is the correct offline fast path.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm run test -- packages/core/src/sync-replication.test.ts`
- `pnpm run typecheck`

## Checklist

- [x] Self-review completed
- [x] No new warnings introduced