### PR TITLE
fix(vectors): avoid sqlite-vec integer binding bug

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -11,7 +11,7 @@ CodeMem uses one shared semantic version stream across its npm packages.
 
 - Release tags `vX.Y.Z` represent the product version.
 - npm packages publish the same `X.Y.Z`.
-- Changelog/release notes are shared per version.
+- GitHub Release notes are shared per version.
 
 ## Release workflow
 

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -1,0 +1,104 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSqliteVec } from "./db.js";
+import * as embeddings from "./embeddings.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+import { backfillVectors, storeVectors } from "./vectors.js";
+
+vi.mock("./embeddings.js", async () => {
+	const actual = await vi.importActual<typeof import("./embeddings.js")>("./embeddings.js");
+	return {
+		...actual,
+		getEmbeddingClient: vi.fn(),
+		embedTexts: vi.fn(),
+	};
+});
+
+describe("vectors", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		db = new Database(":memory:");
+		initTestSchema(db);
+		loadSqliteVec(db);
+		db.exec(`
+			CREATE VIRTUAL TABLE memory_vectors USING vec0(
+				embedding float[384],
+				memory_id INTEGER,
+				chunk_index INTEGER,
+				content_hash TEXT,
+				model TEXT
+			)
+		`);
+		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValue({
+			model: "test-model",
+			dimensions: 384,
+			embed: vi.fn(),
+		});
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("stores vectors with integer metadata columns via sqlite-vec workaround", async () => {
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+
+		await expect(storeVectors(db, 123, "Title", "Body")).resolves.toBeUndefined();
+
+		const row = db
+			.prepare(
+				"SELECT memory_id, chunk_index, content_hash, model FROM memory_vectors WHERE memory_id = ?",
+			)
+			.get(123) as
+			| { memory_id: number; chunk_index: number; content_hash: string; model: string }
+			| undefined;
+
+		expect(row).toMatchObject({
+			memory_id: 123,
+			chunk_index: 0,
+			model: "test-model",
+		});
+		expect(row?.content_hash).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("rejects non-integer memory ids instead of truncating them", async () => {
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+
+		await expect(storeVectors(db, 123.5, "Title", "Body")).rejects.toThrow(
+			"Expected integer, received 123.5",
+		);
+		expect(db.prepare("SELECT COUNT(*) AS c FROM memory_vectors").get()).toMatchObject({ c: 0 });
+	});
+
+	it("backfills vectors with integer metadata columns via sqlite-vec workaround", async () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'feature', 'Backfill title', 'Backfill body', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, now, now);
+		const memoryId = Number(info.lastInsertRowid);
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+
+		const result = await backfillVectors(db, { memoryIds: [memoryId] });
+
+		expect(result).toMatchObject({ checked: 1, embedded: 1, inserted: 1, skipped: 0 });
+		const row = db
+			.prepare(
+				"SELECT memory_id, chunk_index, content_hash, model FROM memory_vectors WHERE memory_id = ?",
+			)
+			.get(memoryId) as
+			| { memory_id: number; chunk_index: number; content_hash: string; model: string }
+			| undefined;
+		expect(row).toMatchObject({
+			memory_id: memoryId,
+			chunk_index: 0,
+			model: "test-model",
+		});
+	});
+});

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -19,6 +19,44 @@ import {
 } from "./embeddings.js";
 import { projectClause } from "./project.js";
 
+function toSqlStringLiteral(value: string): string {
+	return `'${value.replaceAll("'", "''")}'`;
+}
+
+function toVecF32Literal(vector: Float32Array): string {
+	return `vec_f32(${toSqlStringLiteral(JSON.stringify(Array.from(vector)))})`;
+}
+
+function toSqlIntegerLiteral(value: number): string {
+	if (!Number.isFinite(value)) {
+		throw new TypeError(`Expected finite integer, received ${String(value)}`);
+	}
+	if (!Number.isInteger(value)) {
+		throw new TypeError(`Expected integer, received ${String(value)}`);
+	}
+	return String(value);
+}
+
+function insertMemoryVector(
+	db: Database,
+	vector: Float32Array,
+	memoryId: number,
+	chunkIndex: number,
+	contentHash: string,
+	model: string,
+): void {
+	db.exec(`
+		INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model)
+		VALUES (
+			${toVecF32Literal(vector)},
+			${toSqlIntegerLiteral(memoryId)},
+			${toSqlIntegerLiteral(chunkIndex)},
+			${toSqlStringLiteral(contentHash)},
+			${toSqlStringLiteral(model)}
+		)
+	`);
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -64,14 +102,13 @@ export async function storeVectors(
 	if (embeddings.length === 0) return;
 
 	const model = client.model;
-	const stmt = db.prepare(
-		"INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model) VALUES (?, ?, ?, ?, ?)",
-	);
 
 	for (let i = 0; i < chunks.length && i < embeddings.length; i++) {
 		const vector = embeddings[i];
+		const chunk = chunks[i];
 		if (!vector || vector.length === 0) continue;
-		stmt.run(serializeFloat32(vector), memoryId, i, hashText(chunks[i]!), model);
+		if (!chunk) continue;
+		insertMemoryVector(db, vector, memoryId, i, hashText(chunk), model);
 	}
 }
 
@@ -171,13 +208,12 @@ export async function backfillVectors(
 			continue;
 		}
 
-		const stmt = db.prepare(
-			"INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model) VALUES (?, ?, ?, ?, ?)",
-		);
 		for (let i = 0; i < embeddings.length; i++) {
 			const vector = embeddings[i];
+			const contentHash = pendingHashes[i];
 			if (!vector || vector.length === 0) continue;
-			stmt.run(serializeFloat32(vector), row.id, i, pendingHashes[i], model);
+			if (!contentHash) continue;
+			insertMemoryVector(db, vector, row.id, i, contentHash, model);
 			inserted++;
 		}
 	}


### PR DESCRIPTION
## Description

Fix sqlite-vec vector writes for `memory_vectors` by avoiding the prepared-statement binding path that incorrectly coerces INTEGER metadata columns after the embedding blob. This adds a regression test for current sqlite-vec behavior and keeps release communication in the GitHub Release notes rather than repository docs.

Resolves [#423](https://github.com/kunickiaj/codemem/issues/423)

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] JS validation passed locally (`pnpm exec vitest run packages/core/src/vectors.test.ts`, `pnpm exec biome check packages/core/src/vectors.ts packages/core/src/vectors.test.ts docs/versioning.md`, `pnpm exec tsc --build packages/core/tsconfig.json`)

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced