### PR TITLE
fix retention prune catch-up and reporting

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -2,7 +2,6 @@ import { statSync } from "node:fs";
 import * as p from "@clack/prompts";
 import {
 	backfillTagsText,
-	bulkPruneReplicationOpsByAgeCutoff,
 	connect,
 	deactivateLowSignalMemories,
 	deactivateLowSignalObservations,
@@ -10,7 +9,7 @@ import {
 	initDatabase,
 	MemoryStore,
 	planReplicationOpsAgePrune,
-	pruneReplicationOps,
+	pruneReplicationOpsUntilCaughtUp,
 	rawEventsGate,
 	resolveDbPath,
 	resolveProject,
@@ -129,7 +128,7 @@ dbCommand
 						p.intro("codemem db prune-replication-ops");
 						p.log.info(`Replication ops size: ${formatBytes(beforeBytes)}`);
 						p.log.info(
-							`Policy: approximately keep <= ${maxSizeMb} MB and <= ${maxAgeDays} day old history via oldest-first chunk pruning`,
+							`Policy: approximately prune oldest-first toward <= ${maxSizeMb} MB while removing history older than ${maxAgeDays} day(s), subject to per-pass batch/runtime limits`,
 						);
 						const agePlan = planReplicationOpsAgePrune(db, maxAgeDays, batchOps);
 						if (agePlan.candidate_ops > 0) {
@@ -145,42 +144,30 @@ dbCommand
 							return;
 						}
 
-						let totalDeleted = 0;
-						let batches = 0;
-						let lastFloor: string | null = null;
-						let afterBytes = beforeBytes;
-						const ageResult = bulkPruneReplicationOpsByAgeCutoff(db, maxAgeDays, batchOps);
-						totalDeleted += ageResult.deleted;
-						lastFloor = ageResult.retained_floor_cursor;
-						afterBytes = ageResult.estimated_bytes_after ?? beforeBytes;
-						if (ageResult.deleted > 0) {
-							batches += 1;
-							p.log.step(
-								`Age pass batch: deleted ${ageResult.deleted.toLocaleString()} ops, remaining size ~${formatBytes(afterBytes)}`,
-							);
-						}
-						while (true) {
-							const result = pruneReplicationOps(db, {
-								maxAgeDays: 365000,
-								maxSizeBytes: maxSizeMb * 1024 * 1024,
-								maxDeleteOps: batchOps,
-								maxRuntimeMs: batchRuntimeMs,
-							});
-							batches += 1;
-							totalDeleted += result.deleted;
-							lastFloor = result.retained_floor_cursor;
-							afterBytes = result.estimated_bytes_after ?? estimateReplicationOpsBytes(db);
-							p.log.step(
-								`Batch ${batches}: deleted ${result.deleted.toLocaleString()} ops, remaining size ~${formatBytes(afterBytes)}`,
-							);
-							if (result.deleted === 0 || !result.stopped_by_budget) break;
-						}
+						const loopResult = pruneReplicationOpsUntilCaughtUp(db, {
+							maxAgeDays,
+							maxSizeBytes: maxSizeMb * 1024 * 1024,
+							maxDeleteOps: batchOps,
+							maxRuntimeMs: batchRuntimeMs,
+							onPass: (pass) => {
+								if (pass.deleted === 0 && !pass.stoppedByBudget) return;
+								const suffix = pass.stoppedByBudget ? " (budget-limited)" : "";
+								p.log.step(
+									`Pass ${pass.passNumber}: deleted ${pass.deleted.toLocaleString()} ops, remaining size ~${formatBytes(pass.afterBytes)}${suffix}`,
+								);
+							},
+						});
 
-						p.log.info(`Deleted ops: ${totalDeleted.toLocaleString()}`);
+						p.log.info(`Deleted ops: ${loopResult.totalDeleted.toLocaleString()}`);
 						p.log.info(
-							`Estimated replication ops size after prune: ${formatBytes(afterBytes)} (approximate)`,
+							`Estimated replication ops size after prune: ${formatBytes(loopResult.afterBytes)} (approximate)`,
 						);
-						if (lastFloor) p.log.info(`Retained floor: ${lastFloor}`);
+						if (loopResult.lastFloor) p.log.info(`Retained floor: ${loopResult.lastFloor}`);
+						if (loopResult.stoppedByBudget) {
+							p.log.warn(
+								"Prune stopped because the current batch/runtime budget was exhausted before retention caught up. Re-run with higher --batch-ops or --batch-runtime-ms for faster catch-up.",
+							);
+						}
 						if (opts.vacuum) {
 							p.log.step("Running VACUUM as requested...");
 							db.close();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -298,6 +298,7 @@ export {
 	migrateLegacyImportKeys,
 	planReplicationOpsAgePrune,
 	pruneReplicationOps,
+	pruneReplicationOpsUntilCaughtUp,
 	recordReplicationOp,
 	setReplicationCursor,
 	setSyncResetState,

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -20,6 +20,7 @@ import {
 	migrateLegacyImportKeys,
 	planReplicationOpsAgePrune,
 	pruneReplicationOps,
+	pruneReplicationOpsUntilCaughtUp,
 	recordReplicationOp,
 	setReplicationCursor,
 	setSyncResetState,
@@ -1170,6 +1171,55 @@ describe("pruneReplicationOps", () => {
 
 		expect(result.deleted).toBe(4);
 		expect(result.retained_floor_cursor).toBe("2026-03-20T00:00:04Z|op-4");
+	});
+
+	it("keeps applying prune passes until retention is no longer budget-limited", () => {
+		insertOp("op-1", "2026-01-01T00:00:01Z");
+		insertOp("op-2", "2026-01-01T00:00:02Z");
+		insertOp("op-3", "2026-01-01T00:00:03Z");
+		insertOp("op-4", "2026-01-01T00:00:04Z");
+		insertOp("op-5", "2026-03-26T00:00:00Z");
+
+		const result = pruneReplicationOpsUntilCaughtUp(db, {
+			maxAgeDays: 30,
+			maxSizeBytes: 1024 * 1024 * 1024,
+			maxDeleteOps: 2,
+			maxRuntimeMs: 60_000,
+		});
+
+		expect(result.totalDeleted).toBe(4);
+		expect(result.passes).toBe(3);
+		expect(result.stoppedByBudget).toBe(false);
+		expect(result.lastFloor).toBe("2026-01-01T00:00:04Z|op-4");
+		const remaining = db
+			.prepare("SELECT op_id FROM replication_ops ORDER BY created_at, op_id")
+			.all() as Array<{ op_id: string }>;
+		expect(remaining.map((row) => row.op_id)).toEqual(["op-5"]);
+	});
+
+	it("stops multi-pass catch-up after the configured pass cap", () => {
+		insertOp("op-1", "2026-01-01T00:00:01Z");
+		insertOp("op-2", "2026-01-01T00:00:02Z");
+		insertOp("op-3", "2026-01-01T00:00:03Z");
+		insertOp("op-4", "2026-01-01T00:00:04Z");
+		insertOp("op-5", "2026-01-01T00:00:05Z");
+		insertOp("op-6", "2026-03-26T00:00:00Z");
+
+		const result = pruneReplicationOpsUntilCaughtUp(db, {
+			maxAgeDays: 30,
+			maxSizeBytes: 1024 * 1024 * 1024,
+			maxDeleteOps: 2,
+			maxRuntimeMs: 60_000,
+			maxPasses: 2,
+		});
+
+		expect(result.totalDeleted).toBe(4);
+		expect(result.passes).toBe(2);
+		expect(result.stoppedByBudget).toBe(true);
+		const remaining = db
+			.prepare("SELECT op_id FROM replication_ops ORDER BY created_at, op_id")
+			.all() as Array<{ op_id: string }>;
+		expect(remaining.map((row) => row.op_id)).toEqual(["op-5", "op-6"]);
 	});
 });
 

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -870,7 +870,6 @@ export function pruneReplicationOps(
 	const startedAt = Date.now();
 	let deleted = 0;
 	let lastDeletedCursor: string | null = null;
-	const deleteStmt = db.prepare("DELETE FROM replication_ops WHERE op_id = ?");
 	const bulkDeleteBeforeStmt = db.prepare(
 		"DELETE FROM replication_ops WHERE created_at < ? OR (created_at = ? AND op_id <= ?)",
 	);
@@ -880,16 +879,6 @@ export function pruneReplicationOps(
 	}
 	let stoppedByBudget = false;
 	const budgetExceeded = () => deleted >= maxDeleteOps || Date.now() - startedAt >= maxRuntimeMs;
-
-	const deleteOp = (row: { op_id: string; created_at: string }) => {
-		lastDeletedCursor = computeCursor(String(row.created_at), String(row.op_id));
-		deleted +=
-			(
-				deleteStmt.run(row.op_id) as {
-					changes?: number;
-				}
-			).changes ?? 0;
-	};
 
 	while (true) {
 		if (budgetExceeded()) {
@@ -968,6 +957,67 @@ export function pruneReplicationOps(
 		estimated_bytes_before: estimatedBytesBefore,
 		estimated_bytes_after: estimatedSizeBytes,
 		stopped_by_budget: stoppedByBudget,
+	};
+}
+
+export interface ReplicationOpsPruneLoopResult {
+	totalDeleted: number;
+	passes: number;
+	lastFloor: string | null;
+	afterBytes: number;
+	stoppedByBudget: boolean;
+}
+
+export function pruneReplicationOpsUntilCaughtUp(
+	db: Database,
+	options: {
+		maxAgeDays: number;
+		maxSizeBytes: number;
+		maxDeleteOps: number;
+		maxRuntimeMs: number;
+		maxPasses?: number;
+		signal?: AbortSignal;
+		onPass?: (pass: {
+			passNumber: number;
+			deleted: number;
+			afterBytes: number;
+			stoppedByBudget: boolean;
+		}) => void;
+	},
+): ReplicationOpsPruneLoopResult {
+	const maxPasses = Math.max(1, Math.floor(options.maxPasses ?? 25));
+	let totalDeleted = 0;
+	let passes = 0;
+	let lastFloor: string | null = null;
+	let afterBytes = estimateReplicationOpsStorageBytes(db) ?? 0;
+	let stoppedByBudget = false;
+
+	while (true) {
+		if (options.signal?.aborted || passes >= maxPasses) {
+			stoppedByBudget = true;
+			break;
+		}
+		const result = pruneReplicationOps(db, options);
+		passes += 1;
+		totalDeleted += result.deleted;
+		lastFloor = result.retained_floor_cursor;
+		afterBytes = result.estimated_bytes_after ?? estimateReplicationOpsStorageBytes(db) ?? 0;
+		stoppedByBudget = result.stopped_by_budget ?? false;
+		options.onPass?.({
+			passNumber: passes,
+			deleted: result.deleted,
+			afterBytes,
+			stoppedByBudget,
+		});
+		if (result.deleted === 0 || !result.stopped_by_budget) break;
+	}
+
+	return {
+		totalDeleted,
+		passes,
+		lastFloor,
+		afterBytes,
+		stoppedByBudget,
 	};
 }
 

--- a/packages/core/src/sync-retention-runner.test.ts
+++ b/packages/core/src/sync-retention-runner.test.ts
@@ -1,0 +1,66 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import { runSyncRetentionPass } from "./sync-retention-runner.js";
+import { initTestSchema } from "./test-utils.js";
+
+function insertReplicationOp(db: ReturnType<typeof connect>, opId: string, createdAt: string) {
+	db.prepare(
+		`INSERT INTO replication_ops(op_id, entity_type, entity_id, op_type, payload_json, clock_rev, clock_updated_at, clock_device_id, device_id, created_at)
+		 VALUES (?, 'memory_item', ?, 'upsert', NULL, 1, ?, 'dev-a', 'dev-a', ?)`,
+	).run(opId, `ent-${opId}`, createdAt, createdAt);
+}
+
+describe("runSyncRetentionPass", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let db: ReturnType<typeof connect>;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-sync-retention-test-"));
+		dbPath = join(tmpDir, "retention.sqlite");
+		db = connect(dbPath);
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("persists aggregated multi-pass pruning results", async () => {
+		insertReplicationOp(db, "op-1", "2026-01-01T00:00:01Z");
+		insertReplicationOp(db, "op-2", "2026-01-01T00:00:02Z");
+		insertReplicationOp(db, "op-3", "2026-01-01T00:00:03Z");
+		insertReplicationOp(db, "op-4", "2026-01-01T00:00:04Z");
+		insertReplicationOp(db, "op-5", "2026-03-26T00:00:00Z");
+
+		await runSyncRetentionPass(db, {
+			syncRetentionEnabled: true,
+			syncRetentionMaxAgeDays: 30,
+			syncRetentionMaxSizeMb: 1024,
+			syncRetentionMaxOpsPerPass: 2,
+			syncRetentionMaxRuntimeMs: 60_000,
+		});
+
+		const state = db.prepare("SELECT * FROM sync_retention_state WHERE id = 1").get() as {
+			last_deleted_ops: number;
+			last_estimated_bytes_before: number | null;
+			last_estimated_bytes_after: number | null;
+			retained_floor_cursor: string | null;
+			last_error: string | null;
+		};
+		expect(state.last_deleted_ops).toBe(4);
+		expect(state.last_estimated_bytes_before).not.toBeNull();
+		expect(state.last_estimated_bytes_after).not.toBeNull();
+		expect(state.retained_floor_cursor).toBe("2026-01-01T00:00:04Z|op-4");
+		expect(state.last_error).toBeNull();
+
+		const remaining = db
+			.prepare("SELECT op_id FROM replication_ops ORDER BY created_at, op_id")
+			.all() as Array<{ op_id: string }>;
+		expect(remaining.map((row) => row.op_id)).toEqual(["op-5"]);
+	});
+});

--- a/packages/core/src/sync-retention-runner.ts
+++ b/packages/core/src/sync-retention-runner.ts
@@ -4,11 +4,115 @@ import { readCoordinatorSyncConfig } from "./coordinator-runtime.js";
 import { connect, resolveDbPath } from "./db.js";
 import { readCodememConfigFile } from "./observer-config.js";
 import * as schema from "./schema.js";
-import { pruneReplicationOps } from "./sync-replication.js";
+import { pruneReplicationOpsUntilCaughtUp } from "./sync-replication.js";
 
 export interface SyncRetentionRunnerOptions {
 	dbPath?: string;
 	signal?: AbortSignal;
+}
+
+export interface SyncRetentionPassConfig {
+	syncRetentionEnabled: boolean;
+	syncRetentionMaxAgeDays: number;
+	syncRetentionMaxSizeMb: number;
+	syncRetentionMaxOpsPerPass: number;
+	syncRetentionMaxRuntimeMs: number;
+	maxCatchUpPasses?: number;
+	signal?: AbortSignal;
+}
+
+export async function runSyncRetentionPass(
+	db: Database,
+	config: SyncRetentionPassConfig,
+): Promise<void> {
+	if (!config.syncRetentionEnabled) return;
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS sync_retention_state (
+			id INTEGER PRIMARY KEY,
+			last_run_at TEXT,
+			last_duration_ms INTEGER,
+			last_deleted_ops INTEGER NOT NULL DEFAULT 0,
+			last_estimated_bytes_before INTEGER,
+			last_estimated_bytes_after INTEGER,
+			retained_floor_cursor TEXT,
+			last_error TEXT,
+			last_error_at TEXT
+		)
+	`);
+	const d = drizzle(db, { schema });
+	const startedAt = new Date().toISOString();
+	try {
+		const estimatedBytesBefore = db
+			.prepare(
+				`SELECT COALESCE(SUM(pgsize), 0) AS total_bytes
+				 FROM dbstat
+				 WHERE name = 'replication_ops'
+				    OR name LIKE 'idx_replication_ops_%'
+				    OR name LIKE 'sqlite_autoindex_replication_ops_%'`,
+			)
+			.get() as { total_bytes?: number } | undefined;
+		const result = pruneReplicationOpsUntilCaughtUp(db, {
+			maxAgeDays: config.syncRetentionMaxAgeDays,
+			maxSizeBytes: config.syncRetentionMaxSizeMb * 1024 * 1024,
+			maxDeleteOps: config.syncRetentionMaxOpsPerPass,
+			maxRuntimeMs: config.syncRetentionMaxRuntimeMs,
+			maxPasses: config.maxCatchUpPasses,
+			signal: config.signal,
+		});
+		d.insert(schema.syncRetentionState)
+			.values({
+				id: 1,
+				last_run_at: startedAt,
+				last_duration_ms: Date.now() - Date.parse(startedAt),
+				last_deleted_ops: result.totalDeleted,
+				last_estimated_bytes_before: estimatedBytesBefore?.total_bytes ?? null,
+				last_estimated_bytes_after: result.afterBytes,
+				retained_floor_cursor: result.lastFloor,
+				last_error: null,
+				last_error_at: null,
+			})
+			.onConflictDoUpdate({
+				target: schema.syncRetentionState.id,
+				set: {
+					last_run_at: startedAt,
+					last_duration_ms: Date.now() - Date.parse(startedAt),
+					last_deleted_ops: result.totalDeleted,
+					last_estimated_bytes_before: estimatedBytesBefore?.total_bytes ?? null,
+					last_estimated_bytes_after: result.afterBytes,
+					retained_floor_cursor: result.lastFloor,
+					last_error: null,
+					last_error_at: null,
+				},
+			})
+			.run();
+	} catch (err) {
+		d.insert(schema.syncRetentionState)
+			.values({
+				id: 1,
+				last_run_at: startedAt,
+				last_duration_ms: Date.now() - Date.parse(startedAt),
+				last_deleted_ops: 0,
+				last_estimated_bytes_before: null,
+				last_estimated_bytes_after: null,
+				retained_floor_cursor: null,
+				last_error: err instanceof Error ? err.message : String(err),
+				last_error_at: new Date().toISOString(),
+			})
+			.onConflictDoUpdate({
+				target: schema.syncRetentionState.id,
+				set: {
+					last_run_at: startedAt,
+					last_duration_ms: Date.now() - Date.parse(startedAt),
+					last_deleted_ops: 0,
+					last_estimated_bytes_before: null,
+					last_estimated_bytes_after: null,
+					retained_floor_cursor: null,
+					last_error: err instanceof Error ? err.message : String(err),
+					last_error_at: new Date().toISOString(),
+				},
+			})
+			.run();
+	}
 }
 
 export class SyncRetentionRunner {
@@ -58,83 +162,9 @@ export class SyncRetentionRunner {
 	private async runOnce(): Promise<void> {
 		if (!this.active || this.signal?.aborted) return;
 		const config = readCoordinatorSyncConfig(readCodememConfigFile());
-		if (!config.syncRetentionEnabled) return;
 		const db = connect(this.dbPath) as Database;
-		db.exec(`
-			CREATE TABLE IF NOT EXISTS sync_retention_state (
-				id INTEGER PRIMARY KEY,
-				last_run_at TEXT,
-				last_duration_ms INTEGER,
-				last_deleted_ops INTEGER NOT NULL DEFAULT 0,
-				last_estimated_bytes_before INTEGER,
-				last_estimated_bytes_after INTEGER,
-				retained_floor_cursor TEXT,
-				last_error TEXT,
-				last_error_at TEXT
-			)
-		`);
-		const d = drizzle(db, { schema });
-		const startedAt = new Date().toISOString();
 		try {
-			const result = pruneReplicationOps(db, {
-				maxAgeDays: config.syncRetentionMaxAgeDays,
-				maxSizeBytes: config.syncRetentionMaxSizeMb * 1024 * 1024,
-				maxDeleteOps: config.syncRetentionMaxOpsPerPass,
-				maxRuntimeMs: config.syncRetentionMaxRuntimeMs,
-			});
-			d.insert(schema.syncRetentionState)
-				.values({
-					id: 1,
-					last_run_at: startedAt,
-					last_duration_ms: Date.now() - Date.parse(startedAt),
-					last_deleted_ops: result.deleted,
-					last_estimated_bytes_before: result.estimated_bytes_before ?? null,
-					last_estimated_bytes_after: result.estimated_bytes_after ?? null,
-					retained_floor_cursor: result.retained_floor_cursor,
-					last_error: null,
-					last_error_at: null,
-				})
-				.onConflictDoUpdate({
-					target: schema.syncRetentionState.id,
-					set: {
-						last_run_at: startedAt,
-						last_duration_ms: Date.now() - Date.parse(startedAt),
-						last_deleted_ops: result.deleted,
-						last_estimated_bytes_before: result.estimated_bytes_before ?? null,
-						last_estimated_bytes_after: result.estimated_bytes_after ?? null,
-						retained_floor_cursor: result.retained_floor_cursor,
-						last_error: null,
-						last_error_at: null,
-					},
-				})
-				.run();
-		} catch (err) {
-			d.insert(schema.syncRetentionState)
-				.values({
-					id: 1,
-					last_run_at: startedAt,
-					last_duration_ms: Date.now() - Date.parse(startedAt),
-					last_deleted_ops: 0,
-					last_estimated_bytes_before: null,
-					last_estimated_bytes_after: null,
-					retained_floor_cursor: null,
-					last_error: err instanceof Error ? err.message : String(err),
-					last_error_at: new Date().toISOString(),
-				})
-				.onConflictDoUpdate({
-					target: schema.syncRetentionState.id,
-					set: {
-						last_run_at: startedAt,
-						last_duration_ms: Date.now() - Date.parse(startedAt),
-						last_deleted_ops: 0,
-						last_estimated_bytes_before: null,
-						last_estimated_bytes_after: null,
-						retained_floor_cursor: null,
-						last_error: err instanceof Error ? err.message : String(err),
-						last_error_at: new Date().toISOString(),
-					},
-				})
-				.run();
+			await runSyncRetentionPass(db, { ...config, signal: this.signal });
 		} finally {
 			db.close();
 		}


### PR DESCRIPTION
## Description
Fix replication-op retention so both the CLI command and background runner keep applying oldest-first prune passes until they are no longer budget-limited, instead of stopping after a single age pass or silently exiting while still far above the target budget.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/sync-replication.test.ts packages/core/src/sync-retention-runner.test.ts packages/cli/src/commands/db.test.ts`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] Typecheck passes locally (`pnpm exec tsc --build`)
- [x] Targeted lint ran locally (`pnpm exec biome check packages/core/src/sync-replication.ts packages/core/src/sync-replication.test.ts packages/core/src/sync-retention-runner.ts packages/core/src/sync-retention-runner.test.ts packages/cli/src/commands/db.ts packages/cli/src/commands/db.test.ts`)

## Checklist
- [x] Code follows project style for the touched paths
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced