### PR TITLE
fix(raw-events): restore structured observer output

### DIFF
--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -636,6 +636,91 @@ describe("ingest() integration", () => {
 		expect(store.recent(10)).toHaveLength(0);
 	});
 
+	it("retries once when observer returns plain text instead of XML during raw-event flush", async () => {
+		let calls = 0;
+		const retryingObserver = {
+			observe: async () => {
+				calls += 1;
+				if (calls === 1) {
+					return {
+						raw: "Got it — the session inspected current pack stats and restart state.",
+						parsed: null,
+						provider: "test",
+						model: "test-model",
+					};
+				}
+				return {
+					raw: `<summary><request>Check restart state</request><completed>Confirmed the observer needed an XML retry.</completed></summary>`,
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-retry-xml",
+				promptCount: 1,
+				toolCount: 1,
+				durationMs: 1000,
+				flusher: "raw_events",
+			},
+		});
+
+		await ingest(payload, store, { observer: retryingObserver } as unknown as IngestOptions);
+
+		expect(calls).toBe(2);
+		const memories = store.recent(10);
+		expect(memories[0]?.title).toBe("Check restart state");
+	});
+
+	it("still fails raw-event flush when observer stays non-XML after retry", async () => {
+		let calls = 0;
+		const invalidObserver = {
+			observe: async () => {
+				calls += 1;
+				return {
+					raw: "I can summarize the session in plain English if you want.",
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-invalid-xml",
+				promptCount: 1,
+				toolCount: 1,
+				durationMs: 1000,
+				flusher: "raw_events",
+			},
+		});
+
+		await expect(
+			ingest(payload, store, { observer: invalidObserver } as unknown as IngestOptions),
+		).rejects.toThrow("observer produced no storable output for raw-event flush");
+
+		expect(calls).toBe(2);
+		expect(store.recent(10)).toHaveLength(0);
+	});
+
 	it("skips trivial requests", async () => {
 		let observerCalled = false;
 		const trackingObserver = {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -45,6 +45,7 @@ import {
 import type {
 	IngestPayload,
 	ObserverContext,
+	ParsedOutput,
 	ParsedSummary,
 	SessionContext,
 	ToolEvent,
@@ -158,6 +159,44 @@ export interface IngestOptions {
 	storeSummary?: boolean;
 	/** Whether to store typed observations. Default true. */
 	storeTyped?: boolean;
+}
+
+function hasStructuredObserverOutput(parsed: ParsedOutput): boolean {
+	return (
+		parsed.observations.length > 0 || parsed.summary !== null || parsed.skipSummaryReason !== null
+	);
+}
+
+async function observeStructuredOutput(
+	observer: ObserverClient,
+	system: string,
+	user: string,
+): Promise<{ raw: string | null; parsed: ParsedOutput; provider: string; model: string }> {
+	const first = await observer.observe(system, user);
+	const firstParsed = first.raw
+		? parseObserverResponse(first.raw)
+		: { observations: [], summary: null, skipSummaryReason: null };
+	if (!first.raw || hasStructuredObserverOutput(firstParsed)) {
+		return {
+			raw: first.raw,
+			parsed: firstParsed,
+			provider: first.provider,
+			model: first.model,
+		};
+	}
+
+	const repairSystem = `${system}\n\nYour previous reply was invalid because it did not follow the required XML-only schema. Rewrite the same analysis as valid XML only. Do not include prose outside XML.`;
+	const repairUser = `${user}\n\nPrevious invalid response to rewrite as valid XML:\n${first.raw}`;
+	const repaired = await observer.observe(repairSystem, repairUser);
+	const repairedParsed = repaired.raw
+		? parseObserverResponse(repaired.raw)
+		: { observations: [], summary: null, skipSummaryReason: null };
+	return {
+		raw: repaired.raw,
+		parsed: repairedParsed,
+		provider: repaired.provider,
+		model: repaired.model,
+	};
 }
 
 /**
@@ -305,7 +344,7 @@ export async function ingest(
 		// ------------------------------------------------------------------
 		// Call observer LLM
 		// ------------------------------------------------------------------
-		const response = await options.observer.observe(system, user);
+		const response = await observeStructuredOutput(options.observer, system, user);
 
 		if (!response.raw) {
 			// Raw-event flushes must be lossless: if the observer returns no output,
@@ -328,7 +367,7 @@ export async function ingest(
 		// Parse response
 		// ------------------------------------------------------------------
 		const rawText = response.raw;
-		const parsed = parseObserverResponse(rawText);
+		const parsed = response.parsed;
 
 		const observationsToStore: typeof parsed.observations = [];
 		if (storeTyped && hasMeaningfulObservation(parsed.observations)) {

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -691,6 +691,59 @@ describe("ObserverClient.observe()", () => {
 		expect(result.raw).toBe("retry success");
 	});
 
+	it("passes the full system prompt to the codex consumer instructions field", async () => {
+		const prevHome = process.env.HOME;
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-codex-consumer-test-"));
+		mkdirSync(join(tmpDir, ".local", "share", "opencode"), { recursive: true });
+		writeFileSync(
+			join(tmpDir, ".local", "share", "opencode", "auth.json"),
+			JSON.stringify({
+				openai: {
+					access: "oauth-test-token",
+					accountId: "acct-test",
+					expires: Date.now() + 60_000,
+				},
+			}),
+		);
+
+		let capturedBody: Record<string, unknown> | undefined;
+		globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
+			return new Response(
+				'data: {"type":"response.output_text.delta","delta":"<summary><request>ok</request></summary>"}\n\n',
+				{ status: 200, headers: { "content-type": "text/event-stream" } },
+			);
+		}) as typeof globalThis.fetch;
+
+		try {
+			process.env.HOME = tmpDir;
+			const client = new ObserverClient({
+				observerProvider: "openai",
+				observerModel: "gpt-5.4-mini",
+				observerRuntime: null,
+				observerApiKey: null,
+				observerBaseUrl: null,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "auto",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+
+			await client.observe("SYSTEM XML CONTRACT", "USER SESSION TRANSCRIPT");
+
+			expect(client.getStatus().auth.type).toBe("codex_consumer");
+			expect(capturedBody?.instructions).toBe("SYSTEM XML CONTRACT");
+		} finally {
+			if (prevHome == null) delete process.env.HOME;
+			else process.env.HOME = prevHome;
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
 	it("returns null raw when no credentials available", async () => {
 		const client = new ObserverClient({
 			observerProvider: "openai",

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -430,10 +430,14 @@ function resolveCodexEndpoint(): string {
 	return process.env.CODEMEM_CODEX_ENDPOINT ?? CODEX_API_ENDPOINT;
 }
 
-function buildCodexPayload(model: string, userPrompt: string): Record<string, unknown> {
+function buildCodexPayload(
+	model: string,
+	systemPrompt: string,
+	userPrompt: string,
+): Record<string, unknown> {
 	return {
 		model,
-		instructions: "You are a memory observer.",
+		instructions: systemPrompt,
 		input: [
 			{
 				role: "user",
@@ -777,7 +781,7 @@ export class ObserverClient {
 	private async _callOnce(systemPrompt: string, userPrompt: string): Promise<string | null> {
 		// Codex consumer path (OpenAI OAuth)
 		if (this._codexAccess) {
-			return this._callCodexConsumer(userPrompt);
+			return this._callCodexConsumer(systemPrompt, userPrompt);
 		}
 
 		// Anthropic OAuth consumer path
@@ -788,7 +792,7 @@ export class ObserverClient {
 		// Refresh if we have no token
 		if (!this.auth.token) {
 			this._initProvider(true);
-			if (this._codexAccess) return this._callCodexConsumer(userPrompt);
+			if (this._codexAccess) return this._callCodexConsumer(systemPrompt, userPrompt);
 			if (this._anthropicOAuthAccess) return this._callAnthropicConsumer(systemPrompt, userPrompt);
 			if (!this.auth.token) {
 				this._setLastError(`${capitalize(this.provider)} credentials are missing.`, "auth_missing");
@@ -858,7 +862,10 @@ export class ObserverClient {
 	// Codex consumer (OpenAI OAuth + SSE streaming)
 	// -----------------------------------------------------------------------
 
-	private async _callCodexConsumer(userPrompt: string): Promise<string | null> {
+	private async _callCodexConsumer(
+		systemPrompt: string,
+		userPrompt: string,
+	): Promise<string | null> {
 		if (!this._codexAccess) return null;
 
 		const headers = buildCodexHeaders(this._codexAccess, this._codexAccountId);
@@ -875,7 +882,7 @@ export class ObserverClient {
 		}
 		headers["content-type"] = "application/json";
 
-		const payload = buildCodexPayload(this.model, userPrompt);
+		const payload = buildCodexPayload(this.model, systemPrompt, userPrompt);
 		const url = resolveCodexEndpoint();
 
 		return this._fetchSSE(url, headers, payload, extractCodexDelta, {

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -8,7 +8,9 @@
  * and updates flush state on success (or records failure details).
  */
 
+import { extractAdapterEvent, projectAdapterToolEvent } from "./ingest-events.js";
 import { type IngestOptions, ingest } from "./ingest-pipeline.js";
+import { normalizeAdapterEvents } from "./ingest-transcript.js";
 import type { IngestPayload, SessionContext } from "./ingest-types.js";
 import { ObserverAuthError } from "./observer-client.js";
 import type { MemoryStore } from "./store.js";
@@ -86,10 +88,14 @@ export function buildSessionContext(events: Record<string, unknown>[]): SessionC
 	}
 	let durationMs = 0;
 	if (tsValues.length > 0) {
-		let minTs = tsValues[0]!;
-		let maxTs = tsValues[0]!;
-		for (let i = 1; i < tsValues.length; i++) {
-			const v = tsValues[i]!;
+		const firstTs = tsValues[0];
+		if (firstTs == null) {
+			throw new Error("Expected timestamp when tsValues is non-empty");
+		}
+		const restTs = tsValues.slice(1);
+		let minTs = firstTs;
+		let maxTs = firstTs;
+		for (const v of restTs) {
 			if (v < minTs) minTs = v;
 			if (v > maxTs) maxTs = v;
 		}
@@ -130,6 +136,42 @@ export function buildSessionContext(events: Record<string, unknown>[]): SessionC
 	};
 }
 
+function isTerminalLowSignalSession(
+	events: Record<string, unknown>[],
+	sessionContext: SessionContext,
+): boolean {
+	const promptCount = sessionContext.promptCount ?? 0;
+	const toolCount = sessionContext.toolCount ?? 0;
+	if (promptCount > 0 || toolCount > 0 || sessionContext.firstPrompt) {
+		return false;
+	}
+	if (events.length > 4) return false;
+
+	const normalizedEvents = normalizeAdapterEvents(events);
+	const hasPromptOrAssistant = normalizedEvents.some((event) => {
+		const type = String(event.type ?? "");
+		return type === "user_prompt" || type === "assistant_message";
+	});
+	if (hasPromptOrAssistant) return false;
+
+	const hasToolSignal = events.some((event) => {
+		const adapter = extractAdapterEvent(event);
+		if (adapter) return projectAdapterToolEvent(adapter, event) != null;
+		return String(event.type ?? "") === "tool.execute.after";
+	});
+	if (hasToolSignal) return false;
+
+	const allowedTopLevelTypes = new Set(["session.started", "session.idle", "session.ended"]);
+	const allowedAdapterTypes = new Set(["session_start", "session_end", "error"]);
+	return events.every((event) => {
+		const adapter = extractAdapterEvent(event);
+		if (adapter) {
+			return allowedAdapterTypes.has(String(adapter.event_type ?? ""));
+		}
+		return allowedTopLevelTypes.has(String(event.type ?? ""));
+	});
+}
+
 // ---------------------------------------------------------------------------
 // Main flush function
 // ---------------------------------------------------------------------------
@@ -141,7 +183,6 @@ export interface FlushRawEventsOptions {
 	project?: string | null;
 	startedAt?: string | null;
 	maxEvents?: number | null;
-	allowEmptyFlush?: boolean;
 }
 
 /**
@@ -162,7 +203,6 @@ export async function flushRawEvents(
 ): Promise<{ flushed: number; updatedState: number }> {
 	let { source = "opencode", cwd, project, startedAt } = opts;
 	const { opencodeSessionId, maxEvents } = opts;
-	const allowEmptyFlush = opts.allowEmptyFlush ?? false;
 
 	source = (source ?? "").trim().toLowerCase() || "opencode";
 
@@ -191,10 +231,14 @@ export async function flushRawEvents(
 		return { flushed: 0, updatedState: 0 };
 	}
 
-	let startEventSeq = eventSeqs[0]!;
-	let lastEventSeq = eventSeqs[0]!;
-	for (let i = 1; i < eventSeqs.length; i++) {
-		const v = eventSeqs[i]!;
+	const firstEventSeq = eventSeqs[0];
+	if (firstEventSeq == null) {
+		return { flushed: 0, updatedState: 0 };
+	}
+	const restEventSeqs = eventSeqs.slice(1);
+	let startEventSeq = firstEventSeq;
+	let lastEventSeq = firstEventSeq;
+	for (const v of restEventSeqs) {
 		if (v < startEventSeq) startEventSeq = v;
 		if (v > lastEventSeq) lastEventSeq = v;
 	}
@@ -234,6 +278,12 @@ export async function flushRawEvents(
 		end_event_seq: lastEventSeq,
 	};
 
+	if (isTerminalLowSignalSession(events, sessionContext)) {
+		store.updateRawEventFlushBatchStatus(batchId, "completed");
+		store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
+		return { flushed: events.length, updatedState: 1 };
+	}
+
 	// Build ingest payload
 	const payload: IngestPayload = {
 		cwd: cwd ?? undefined,
@@ -249,14 +299,6 @@ export async function flushRawEvents(
 	} catch (exc) {
 		// Record failure details on the batch
 		const err = exc instanceof Error ? exc : new Error(String(exc));
-		if (
-			allowEmptyFlush &&
-			err.message === "observer produced no storable output for raw-event flush"
-		) {
-			store.updateRawEventFlushBatchStatus(batchId, "completed");
-			store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
-			return { flushed: events.length, updatedState: 1 };
-		}
 		const provider = ingestOpts.observer?.getStatus?.()?.provider as string | undefined;
 		const message = truncateErrorMessage(summarizeFlushFailure(err, provider));
 		store.recordRawEventFlushBatchFailure(batchId, {

--- a/packages/core/src/raw-event-sweeper.test.ts
+++ b/packages/core/src/raw-event-sweeper.test.ts
@@ -67,6 +67,86 @@ describe("RawEventSweeper auto flush", () => {
 		});
 	}
 
+	function seedLifecycleOnlySession(sessionId: string) {
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-0",
+			eventType: "session.started",
+			payload: { type: "session.started" },
+			tsWallMs: 100,
+		});
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-1",
+			eventType: "session.idle",
+			payload: { type: "session.idle" },
+			tsWallMs: 150,
+		});
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-2",
+			eventType: "session.ended",
+			payload: { type: "session.ended" },
+			tsWallMs: 200,
+		});
+		store.updateRawEventSessionMeta({
+			opencodeSessionId: sessionId,
+			cwd: tmpDir,
+			project: "codemem",
+			startedAt: "2026-01-01T00:00:00Z",
+			lastSeenTsWallMs: 200,
+		});
+	}
+
+	function seedAdapterPromptSession(sessionId: string) {
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			source: "claude",
+			eventId: "evt-0",
+			eventType: "claude.hook",
+			payload: {
+				type: "claude.hook",
+				_adapter: {
+					schema_version: "1.0",
+					source: "claude",
+					session_id: sessionId,
+					event_id: "evt-0",
+					event_type: "prompt",
+					payload: { text: "Investigate a real issue", prompt_number: 1 },
+					ts: "2026-01-01T00:00:00Z",
+				},
+			},
+			tsWallMs: 100,
+		});
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			source: "claude",
+			eventId: "evt-1",
+			eventType: "claude.hook",
+			payload: {
+				type: "claude.hook",
+				_adapter: {
+					schema_version: "1.0",
+					source: "claude",
+					session_id: sessionId,
+					event_id: "evt-1",
+					event_type: "assistant",
+					payload: { text: "I found the likely root cause." },
+					ts: "2026-01-01T00:00:01Z",
+				},
+			},
+			tsWallMs: 150,
+		});
+		store.updateRawEventSessionMeta({
+			opencodeSessionId: sessionId,
+			source: "claude",
+			cwd: tmpDir,
+			project: "codemem",
+			startedAt: "2026-01-01T00:00:00Z",
+			lastSeenTsWallMs: 150,
+		});
+	}
+
 	const ingestOpts: IngestOptions = {
 		observer: {
 			observe: async () => ({
@@ -225,7 +305,7 @@ describe("RawEventSweeper auto flush", () => {
 		expect(store.rawEventFlushState("sess-auto")).toBe(1);
 	});
 
-	it("advances flush cursor when observer output has no storable memories", async () => {
+	it("records a failed batch and keeps the flush cursor when observer output has no storable memories", async () => {
 		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
 		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
 		seedSession("sess-low-signal");
@@ -250,7 +330,77 @@ describe("RawEventSweeper auto flush", () => {
 		sweeper.nudge("sess-low-signal");
 		await sleep(150);
 
-		expect(store.rawEventFlushState("sess-low-signal")).toBe(1);
-		expect(store.latestRawEventFlushFailure("opencode")).toBeNull();
+		expect(store.rawEventFlushState("sess-low-signal")).toBe(-1);
+		expect(store.latestRawEventFlushFailure("opencode")).toMatchObject({
+			stream_id: "sess-low-signal",
+			error_message: "Test returned no usable output for raw-event processing.",
+		});
+	});
+
+	it("terminally skips tiny lifecycle-only sessions without calling the observer", async () => {
+		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
+		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
+		seedLifecycleOnlySession("sess-lifecycle-only");
+
+		let observerCalls = 0;
+		const sweeper = new RawEventSweeper(store, {
+			observer: {
+				observe: async () => {
+					observerCalls += 1;
+					return {
+						raw: '<skip_summary reason="low-signal"/>',
+						parsed: null,
+						provider: "test",
+						model: "test",
+					};
+				},
+				getStatus: () => ({
+					provider: "test",
+					model: "test",
+					runtime: "api_http",
+					auth: { source: "test", type: "api_direct", hasToken: true },
+				}),
+			} as never,
+		});
+
+		sweeper.nudge("sess-lifecycle-only");
+		await sleep(150);
+
+		expect(observerCalls).toBe(0);
+		expect(store.rawEventFlushState("sess-lifecycle-only")).toBe(2);
+		expect(store.latestRawEventFlushFailure("opencode")?.stream_id).not.toBe("sess-lifecycle-only");
+	});
+
+	it("does not terminally skip adapter-wrapped prompt sessions", async () => {
+		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
+		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
+		seedAdapterPromptSession("sess-adapter-prompt");
+
+		let observerCalls = 0;
+		const sweeper = new RawEventSweeper(store, {
+			observer: {
+				observe: async () => {
+					observerCalls += 1;
+					return {
+						raw: `<summary><request>Investigate a real issue</request><completed>Captured adapter wrapped session.</completed></summary>`,
+						parsed: null,
+						provider: "test",
+						model: "test",
+					};
+				},
+				getStatus: () => ({
+					provider: "test",
+					model: "test",
+					runtime: "api_http",
+					auth: { source: "test", type: "api_direct", hasToken: true },
+				}),
+			} as never,
+		});
+
+		sweeper.nudge("sess-adapter-prompt", "claude");
+		await sleep(150);
+
+		expect(observerCalls).toBe(1);
+		expect(store.rawEventFlushState("sess-adapter-prompt", "claude")).toBe(1);
 	});
 });

--- a/packages/core/src/raw-event-sweeper.ts
+++ b/packages/core/src/raw-event-sweeper.ts
@@ -286,7 +286,6 @@ export class RawEventSweeper {
 				project: null,
 				startedAt: null,
 				maxEvents: null,
-				allowEmptyFlush: true,
 			});
 		} catch (exc) {
 			if (exc instanceof ObserverAuthError) {
@@ -412,7 +411,6 @@ export class RawEventSweeper {
 					project: null,
 					startedAt: null,
 					maxEvents,
-					allowEmptyFlush: true,
 				});
 				drained.add(`${source}:${streamId}`);
 			} catch (exc) {
@@ -447,7 +445,6 @@ export class RawEventSweeper {
 					project: null,
 					startedAt: null,
 					maxEvents,
-					allowEmptyFlush: true,
 				});
 			} catch (exc) {
 				if (exc instanceof ObserverAuthError) {


### PR DESCRIPTION
## Description
Fix the raw-event ingestion hotfix path that regressed on OpenAI OAuth/Codex consumer auth. The core issue was that the Codex consumer transport dropped the full XML system prompt and only sent a generic instruction string, which caused plain-prose observer responses, zero storable output, and missing memories on affected machines.

This PR:
- passes the full XML system prompt through the Codex consumer path
- retries once when observer output is non-structured
- fails closed instead of silently completing zero-output flushes
- terminally skips tiny lifecycle-only sessions so they do not spam endless retry failures
- adds regression coverage for the broken paths

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] JS validation passed locally (`pnpm exec vitest run packages/core/src/observer-client.test.ts packages/core/src/ingest-pipeline.test.ts packages/core/src/raw-event-sweeper.test.ts`, `pnpm exec tsc --build packages/core/tsconfig.json`, `pnpm exec biome check packages/core/src/observer-client.ts packages/core/src/observer-client.test.ts packages/core/src/ingest-pipeline.ts packages/core/src/ingest-pipeline.test.ts packages/core/src/raw-event-flush.ts packages/core/src/raw-event-sweeper.ts packages/core/src/raw-event-sweeper.test.ts`)

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced

## Follow-up
- Retry/log spam from tiny stale sessions is handled here for lifecycle-only sessions.
- Remaining broader retry policy tuning, if needed, can follow in `codemem-tdpi`.
