### PR TITLE
fix(viewer): return recent pack usage

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -153,6 +153,46 @@ describe("viewer-server", () => {
 		});
 	});
 
+	describe("GET /api/usage", () => {
+		it("returns recent pack rows for the current scope", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				store.db.prepare("UPDATE sessions SET project = ? WHERE id = ?").run("codemem", sessionId);
+				store.db
+					.prepare(
+						`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+						 VALUES (?, 'pack', 123, 0, 456, ?, ?)`,
+					)
+					.run(
+						sessionId,
+						"2026-03-26T23:30:00Z",
+						JSON.stringify({ pack_tokens: 123, exact_duplicates_collapsed: 4 }),
+					);
+
+				const res = await app.request("/api/usage?project=codemem");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				const recentPacks = body.recent_packs as Array<Record<string, unknown>>;
+				expect(recentPacks).toHaveLength(1);
+				expect(recentPacks[0]).toMatchObject({
+					session_id: sessionId,
+					event: "pack",
+					tokens_read: 123,
+					tokens_saved: 456,
+				});
+				expect(recentPacks[0]?.metadata_json).toMatchObject({
+					exact_duplicates_collapsed: 4,
+				});
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
 	describe("GET /api/sessions", () => {
 		it("returns sessions list", async () => {
 			const { app, getStore, cleanup } = createTestApp();

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -14,6 +14,15 @@ import { Hono } from "hono";
 export function statsRoutes(getStore: () => MemoryStore) {
 	const app = new Hono();
 
+	const parseMetadataJson = (value: unknown): Record<string, unknown> | null => {
+		if (typeof value !== "string" || !value.trim()) return null;
+		try {
+			return JSON.parse(value) as Record<string, unknown>;
+		} catch {
+			return null;
+		}
+	};
+
 	app.get("/api/stats", (c) => {
 		const store = getStore();
 		return c.json({
@@ -26,6 +35,24 @@ export function statsRoutes(getStore: () => MemoryStore) {
 		const store = getStore();
 		{
 			const projectFilter = c.req.query("project") || null;
+			const recentPacksQuery = projectFilter
+				? store.db.prepare(
+						`SELECT usage_events.id, usage_events.session_id, usage_events.event,
+						usage_events.tokens_read, usage_events.tokens_written, usage_events.tokens_saved,
+						usage_events.created_at, usage_events.metadata_json
+					 FROM usage_events
+					 JOIN sessions ON sessions.id = usage_events.session_id
+					 WHERE usage_events.event = 'pack' AND sessions.project = ?
+					 ORDER BY usage_events.created_at DESC
+					 LIMIT 10`,
+					)
+				: store.db.prepare(
+						`SELECT id, session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json
+					 FROM usage_events
+					 WHERE event = 'pack'
+					 ORDER BY created_at DESC
+					 LIMIT 10`,
+					);
 			const eventsGlobal = store.db
 				.prepare(
 					`SELECT event,
@@ -73,6 +100,20 @@ export function statsRoutes(getStore: () => MemoryStore) {
 					)
 					.get(projectFilter) as Record<string, unknown>;
 			}
+			const recentPacksRaw = (
+				projectFilter ? recentPacksQuery.all(projectFilter) : recentPacksQuery.all()
+			) as Record<string, unknown>[];
+			const recentPacks = recentPacksRaw.map((row) => ({
+				id: Number(row.id ?? 0),
+				session_id: row.session_id == null ? null : Number(row.session_id),
+				event: String(row.event ?? "pack"),
+				tokens_read: Number(row.tokens_read ?? 0),
+				tokens_written: Number(row.tokens_written ?? 0),
+				tokens_saved: Number(row.tokens_saved ?? 0),
+				created_at: String(row.created_at ?? ""),
+				metadata_json: parseMetadataJson(row.metadata_json),
+			}));
+
 			return c.json({
 				project: projectFilter,
 				events: projectFilter ? eventsFiltered : eventsGlobal,
@@ -81,7 +122,7 @@ export function statsRoutes(getStore: () => MemoryStore) {
 				totals_global: totalsGlobal,
 				events_filtered: eventsFiltered,
 				totals_filtered: totalsFiltered,
-				recent_packs: [],
+				recent_packs: recentPacks,
 			});
 		}
 	});


### PR DESCRIPTION
## Description
Fix the viewer usage API so the dashboard can render current-session pack metrics instead of always showing `n/a`. The root cause was `/api/usage` hardcoding `recent_packs: []` even when recent pack usage rows existed.

This PR returns recent pack rows from `usage_events`, scoped by project when filtered, and adds integration coverage for the route.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] JS validation passed locally (`pnpm exec vitest run packages/viewer-server/src/index.test.ts`, `pnpm exec tsc --build packages/viewer-server/tsconfig.json`)

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
