### PR TITLE
docs(sync): clarify coordinator semantics and current TS surface

### DIFF
--- a/docs/coordinator-deployment.md
+++ b/docs/coordinator-deployment.md
@@ -1,7 +1,12 @@
 # Deploying the coordinator
 
-The built-in coordinator is the canonical deployment target for team sync. This guide covers how to run it
+The built-in TypeScript coordinator is the canonical deployment target for team sync. This guide covers how to run it
 natively, in a container, and how to expose it to teammates outside your local network.
+
+The coordinator HTTP service is Hono-based, but the supported deployment path today is still the built-in
+`codemem sync coordinator serve` runtime on Node/Linux with a local SQLite database. If your end goal is Cloudflare,
+the recommended sequence is to validate E2E flows here first, then adapt that proven coordinator surface to the target
+Cloudflare runtime.
 
 ## Quick start (native)
 
@@ -9,8 +14,8 @@ natively, in a container, and how to expose it to teammates outside your local n
 # Install codemem CLI (makes the `codemem` command available)
 npm install -g codemem
 
-# Create a coordinator group
-codemem sync coordinator group-create my-team --db-path ~/.codemem/coordinator.sqlite
+# Bootstrap a coordinator group in the local DB
+sqlite3 ~/.codemem/coordinator.sqlite "insert into groups (group_id, display_name, created_at) values ('my-team', 'my-team', datetime('now')) on conflict(group_id) do nothing;"
 
 # Set an admin secret (required for creating invites via the API)
 set -x CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET (openssl rand -base64 32)
@@ -40,22 +45,19 @@ codemem sync coordinator serve [OPTIONS]
 
 ### Team management
 
+Current status: the shipped TS CLI only exposes the invite/join-request management surface today. Full local
+group/device admin verbs are planned but not all shipped yet.
+
 ```fish
-# Create a group
-codemem sync coordinator group-create <group-id> --db-path <path>
-
-# Enroll a device directly (admin)
-codemem sync coordinator enroll-device <group-id> <device-id> \
-  --fingerprint <fingerprint> --public-key-file <path> --db-path <path>
-
-# List enrolled devices
-codemem sync coordinator list-devices <group-id> --db-path <path>
-
-# Rename, disable, or remove a device
-codemem sync coordinator rename-device <group-id> <device-id> --name "work-laptop" --db-path <path>
-codemem sync coordinator disable-device <group-id> <device-id> --db-path <path>
-codemem sync coordinator remove-device <group-id> <device-id> --db-path <path>
+# Current shipped commands
+codemem sync coordinator create-invite <group-id> --db-path <path>
+codemem sync coordinator list-join-requests <group-id> --db-path <path>
+codemem sync coordinator approve-join-request <request-id> --db-path <path>
+codemem sync coordinator deny-join-request <request-id> --db-path <path>
 ```
+
+Until local coordinator admin parity lands, group bootstrap and direct DB-backed inspection may still require `sqlite3`
+on the coordinator machine.
 
 ### Invite and join flow
 
@@ -102,7 +104,7 @@ docker run -d --name coordinator -p 7347:7347 -v coordinator-data:/data codemem-
 Initialize the group from the host:
 
 ```fish
-docker exec coordinator codemem sync coordinator group-create my-team --db-path /data/coordinator.sqlite
+docker exec coordinator sqlite3 /data/coordinator.sqlite "insert into groups (group_id, display_name, created_at) values ('my-team', 'my-team', datetime('now')) on conflict(group_id) do nothing;"
 ```
 
 ## Exposing the coordinator
@@ -126,6 +128,8 @@ Teammates configure their client with the Funnel URL (e.g. `https://your-machine
 ### Cloudflare Tunnel
 
 Cloudflare Tunnel exposes a local port through Cloudflare's network, giving you a stable public hostname with TLS.
+This is the simplest way to put the built-in TS coordinator behind Cloudflare without changing the coordinator runtime
+itself.
 
 ```fish
 # Start the coordinator
@@ -177,11 +181,15 @@ Or through the viewer UI: Settings → Device Sync → Coordinator URL / Group.
 **Note:** Teammates who join via an invite link don't need to configure anything manually — the invite import
 auto-configures `sync_coordinator_url` and `sync_coordinator_group`.
 
+Joining the coordinator team enrolls the device for coordinator-backed discovery, but it does not automatically create a
+local sync peer relationship. Direct sync still depends on explicit `sync_peers` state.
+
 ## Onboarding teammates
 
 ### Admin-driven enrollment
 
-The admin enrolls a teammate's device directly:
+The admin enrolls a teammate's device directly once the missing local admin CLI verbs land. Today, the practical TS
+path is invite-driven enrollment.
 
 ```fish
 codemem sync coordinator enroll-device my-team <device-id> \
@@ -226,8 +234,9 @@ peer-to-peer sync remains the data path.
 **Coordinator not reachable**: verify the `--host` binding. Use `0.0.0.0` to listen on all interfaces. Check firewall
 rules and that the tunnel/funnel is active.
 
-**Device not enrolled**: run `codemem sync coordinator list-devices <group> --db-path <path>` to confirm enrollment.
-Use the invite flow for self-service enrollment.
+**Device not enrolled**: use the invite flow for self-service enrollment. Until local coordinator admin parity lands,
+confirm coordinator enrollment from the coordinator machine with `sqlite3` or the pending join-request flow rather than
+assuming `list-devices` is already available in the TS CLI.
 
 **Presence not refreshing**: check that the client's `sync_coordinator_url` matches the coordinator's reachable address
 and that `sync_coordinator_group` matches a group the device is enrolled in.

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -9,6 +9,7 @@ the network boundary you care about (for example VPNs).
 - lets devices publish current dialable addresses
 - lets peers look up fresh addresses before direct sync
 - keeps direct peer-to-peer sync as the data path
+- can make same-group devices visible for operator review and future onboarding flows
 
 ## What it does not do
 
@@ -16,6 +17,8 @@ the network boundary you care about (for example VPNs).
 - it does not queue offline sync data
 - it does not replace local SQLite as the source of truth
 - it is not a codemem-hosted public service
+- it does not automatically create or repair `sync_peers`
+- joining a coordinator group does not, by itself, create an active sync relationship
 
 ## Config
 
@@ -70,25 +73,41 @@ Backward compatibility:
 
 ## Built-in coordinator service
 
-The preferred self-hosted deployment path is a first-party `codemem` coordinator service.
+The preferred self-hosted deployment path is the first-party TypeScript coordinator service shipped in the main
+`codemem` CLI. Its HTTP surface is implemented with Hono and exposed through `codemem sync coordinator serve`.
 
-Basic flow:
+Current shipped coordinator CLI surface:
 
 ```fish
-codemem sync coordinator group-create team-alpha --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator enroll-device team-alpha <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/id_ed25519.pub --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator list-devices team-alpha --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator rename-device team-alpha <device-id> --name "work-laptop" --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator disable-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator remove-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
 codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
+codemem sync coordinator create-invite team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator import-invite <invite>
+codemem sync coordinator list-join-requests team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator approve-join-request <request-id> --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator deny-join-request <request-id> --db-path ~/.codemem/coordinator.sqlite
 ```
 
-This keeps the primary deployment path inside the main `codemem` artifact and reuses the existing signature
-verification code directly.
+This keeps the primary deployment path inside the main `codemem` artifact and reuses the current TypeScript sync
+auth/signature verification code directly.
 
-These management commands operate on the built-in local coordinator store only. Remote coordinator admin flows require a
-separate access-control model before they should be exposed over HTTP.
+Current limitation:
+
+- local coordinator admin parity is incomplete in the shipped TS CLI
+- direct group/device administration commands are planned but not all available yet
+
+These management commands operate on the built-in local coordinator store only. Remote coordinator admin flows require
+a separate access-control model before they should be exposed over HTTP.
+
+## Discovery groups vs sync peers
+
+Coordinator group membership and sync peer relationships are not the same thing.
+
+- **Coordinator group membership** means a device is enrolled and can participate in coordinator-backed discovery.
+- **Sync peer** means a local device has an explicit `sync_peers` relationship it will use for direct replication.
+
+Today, coordinator-backed discovery refreshes dialable addresses for sync, but it does not automatically create, repair,
+or remove local `sync_peers` entries. That means a same-group device can be enrolled and discoverable without becoming
+an active sync peer.
 
 ## How discovery works
 
@@ -121,10 +140,10 @@ not accumulate as mixed `host:port` and `http://host:port` variants in local pee
 Built-in local coordinator management commands operate directly on the local SQLite store.
 
 For remote coordinators, the first admin model uses a separate operator-managed admin secret. Remote management commands
-reuse the same `codemem sync coordinator ...` verbs, but target a remote coordinator when you pass `--remote-url` and
-an admin secret (or configure `sync_coordinator_admin_secret`).
+reuse the same `codemem sync coordinator ...` verbs once those admin commands ship in the TS CLI, targeting a remote
+coordinator when you pass `--remote-url` and an admin secret (or configure `sync_coordinator_admin_secret`).
 
-Examples:
+Planned examples once admin parity ships:
 
 ```fish
 codemem sync coordinator list-devices nerdworld --remote-url "https://coord.codemem.sh"
@@ -137,8 +156,8 @@ is only for remote mutation/listing endpoints.
 
 ## Canonical deployment target
 
-The built-in coordinator (`codemem sync coordinator serve`) is the canonical deployment target for ongoing
-product development and dogfooding.
+The built-in coordinator (`codemem sync coordinator serve`) is the canonical deployment target for ongoing product
+development, E2E validation, and dogfooding.
 
 Recommended deployment patterns:
 
@@ -147,16 +166,24 @@ Recommended deployment patterns:
 - **Exposure**: use Tailscale Funnel or Cloudflare Tunnel to make the coordinator reachable from outside a local network
 
 This keeps the deployment path inside the main `codemem` artifact and ensures new coordinator features (invites, join
-requests, admin flows) are immediately available.
+requests, admin flows) are immediately available. It is also the fastest path to validate coordinator behavior before
+introducing Cloudflare-specific runtime/storage constraints.
 
 ## Cloudflare Worker reference deployment
 
-A Cloudflare Worker reference implementation exists in `examples/cloudflare-coordinator/`. It implements the same HTTP
-contract against D1, but is secondary to the built-in coordinator for ongoing feature development.
+A Cloudflare Worker reference implementation exists in `examples/cloudflare-coordinator/`. It was built as a separate
+Worker/D1 implementation of the coordinator contract and remains useful for experimentation, but it is not the
+canonical runtime for current product development.
 
-Use the Cloudflare Worker path when you specifically want a serverless/edge deployment and are comfortable with the
-feature lag — new coordinator capabilities (invite/join flows, admin endpoints) land in the built-in coordinator first
-and may not be ported to the Worker immediately.
+The long-term Cloudflare direction should build from the TypeScript coordinator contract rather than from the old Python
+era deployment story. Today, the practical sequence is:
+
+1. validate the built-in TS coordinator on Node/Linux with `codemem sync coordinator serve`
+2. adapt/package that validated coordinator surface for Cloudflare
+
+Use the Worker reference path only when you specifically want a serverless/edge experiment and are comfortable with
+feature lag — new coordinator capabilities may land in the built-in coordinator first and may not be ported to the
+reference Worker immediately.
 
 ## Current limitations
 

--- a/docs/plans/2026-03-26-sync-coordinator-peer-suggestions-design.md
+++ b/docs/plans/2026-03-26-sync-coordinator-peer-suggestions-design.md
@@ -1,0 +1,217 @@
+# Sync / Coordinator Peer Suggestions and Control Surface Plan
+
+**Beads:** `codemem-cbfk`, `codemem-ddx7`, `codemem-oq8h`, `codemem-vr2x`, `codemem-low6`, `codemem-rtmb`  
+**Status:** Design  
+**Date:** 2026-03-26
+
+## Problem
+
+The current TypeScript sync/coordinator flow has three overlapping problems:
+
+1. **Model confusion**
+   - coordinator-backed group membership feels like team connectivity
+   - actual sync still depends on separate manually managed `sync_peers`
+   - old stale peer entries can coexist with fresh coordinator discovery and make the system feel broken
+
+2. **Missing operator controls**
+   - the TypeScript CLI is missing coordinator admin commands that docs and store capabilities imply should exist
+   - peer management CLI parity with the Python flow is incomplete
+   - the UI exposes stale/broken peer state without enough repair affordances
+
+3. **Premature automation pressure**
+   - users naturally expect same-group devices to become usable teammates
+   - but silent auto-peering would blur discovery, trust, and sharing in a way that conflicts with codemem’s explicit local-first model
+
+## Goals
+
+- Make the coordinator/group model explicit and predictable.
+- Restore missing CLI/UI surfaces so users can inspect and repair state without raw SQLite.
+- Introduce a lower-friction onboarding flow for coordinator-discovered devices.
+- Preserve explicit trust and sharing review before replication starts.
+
+## Non-goals
+
+- No assumption that joining a coordinator group should immediately enable memory sharing.
+- No replacement of peer trust with opaque coordinator magic.
+- No full RBAC/account system redesign here.
+- No server-authoritative sync model.
+
+## Recommended Product Model
+
+This design intentionally keeps the durable model small.
+
+Durable concepts:
+- **coordinator membership**
+- **discovered device**
+- **sync peer**
+
+Derived flags or UX labels, not first-class persisted states:
+- stale
+- conflicted
+- unreachable
+- needs repair
+- needs sharing review
+
+### Coordinator group
+
+A coordinator group is a **discovery and eligibility boundary**.
+
+Meaning:
+- devices in the same group may discover each other
+- devices in the same group may be presented as candidate teammates
+- coordinator membership alone does **not** make them active sync peers
+
+This keeps discovery transport separate from replication trust and sharing policy.
+
+### Suggested peer
+
+A suggested peer is a read-model or UX label for a device discovered through the coordinator that:
+- belongs to the same group
+- is reachable enough to advertise fresh presence
+- has not yet been accepted as a real sync peer
+
+Suggested peers are the bridge between coordinator discovery and explicit sync trust. This does not require a durable
+`suggested_peers` table in the first implementation.
+
+### Accepted sync peer
+
+An accepted sync peer is a device the local operator has explicitly approved for replication.
+
+Acceptance creates or updates a real `sync_peers` entry. That peer then participates in the normal sync path.
+
+### Sharing before first sync
+
+Acceptance should not imply immediate replication with inherited defaults hidden in the background.
+
+Before first sync, the user should review sharing policy:
+- inherit default policy
+- selected projects only
+- no sharing yet
+
+This should be treated as a derived onboarding requirement first, not a new persisted workflow state unless experience
+proves the existing peer/share config is insufficient.
+
+## Why suggestion-based onboarding is preferred
+
+Three candidate models were considered:
+
+1. **Auto-peer on discovery**
+   - too implicit
+   - risks surprise replication
+   - over-couples discovery and trust
+
+2. **Suggested peers with explicit acceptance and pre-sync sharing review**
+   - recommended
+   - reduces manual friction while preserving trust and sharing boundaries
+
+3. **Auto-peer with no sharing by default**
+   - safer than immediate auto-sync
+   - but creates more hidden state and “why is this connected but inert?” confusion than the suggestion model
+
+The suggestion model best matches codemem’s explicit trust posture.
+
+## Bead Graph Strategy
+
+### 1. `codemem-cbfk` — Clarify coordinator groups vs manual peer pairing
+
+This bead is the foundation.
+
+It should define:
+- coordinator group semantics
+- suggested peer semantics
+- accepted peer semantics
+- first-sync sharing review requirement
+- expected coexistence with old manual peers
+
+This design must land before implementation work on automation or UX polish.
+
+### 2. `codemem-ddx7` — Add missing coordinator admin CLI commands
+
+Restore and align the coordinator admin surface with the current store and remote-admin design.
+
+Minimum useful commands:
+- `group-create`
+- `list-groups`
+- `list-devices`
+- `enroll-device`
+- `rename-device`
+- `disable-device`
+- `remove-device`
+
+Rationale:
+- operators need a supported way to inspect and repair coordinator state
+- automation without admin visibility is a debugging nightmare
+
+### 3. `codemem-oq8h` — Restore sync peer management CLI commands
+
+Restore direct peer maintenance commands in the TS CLI.
+
+Minimum useful commands:
+- peer removal
+- peer listing/inspection improvements
+- peer repair-oriented commands needed to manage stale pairings
+
+Rationale:
+- stale peer cleanup must be possible without UI dependence or SQLite surgery
+- this is also a prerequisite for a safe suggestion acceptance/rejection workflow in CLI form
+
+### 4. `codemem-vr2x` — Add UI control to delete sync peers
+
+The viewer should expose peer deletion/removal for stale or broken peers.
+
+Rationale:
+- backend support already exists
+- users encountering stale peers in the UI need an obvious recovery path
+- this is especially important while old/manual peers and new coordinator suggestions coexist
+
+### 5. `codemem-low6` — Auto-peer devices discovered in coordinator groups
+
+This bead should be reinterpreted as **suggestion-driven onboarding**, not blind auto-peering.
+
+Recommended scope:
+- first add a read-only discovered-device view separate from existing peers
+- surface likely stale/broken peer conflicts and repair guidance
+- only add accept/reject/dismiss actions after the read model proves necessary
+- reuse existing peer/share config where possible rather than inventing a new persisted workflow state
+
+### 6. `codemem-rtmb` — Simplify create-invite group argument
+
+This is related cleanup, not a blocker for the larger model. It can be folded into coordinator CLI surface cleanup where convenient.
+
+## Recommended Execution Order
+
+1. `codemem-cbfk`
+2. `codemem-ddx7`
+3. `codemem-oq8h`
+4. `codemem-vr2x`
+5. read-only discovered-device / stale-peer visibility
+6. `codemem-low6`
+7. `codemem-rtmb`
+
+`codemem-ddx7` and `codemem-oq8h` can potentially proceed in parallel once the model is fixed, but both should land
+before suggestion acceptance or any new onboarding automation.
+
+## Migration / Coexistence Notes
+
+The design must account for pre-existing manual peers.
+
+Expected realities:
+- users may already have stale peer entries with dead addresses or old identity state
+- coordinator discovery may surface a fresh device that corresponds to an old stale peer record
+- accepted-suggestion flow should not silently merge unsafe state
+
+Recommended first pass:
+- show stale peers and suggestions as separate concepts
+- when a suggestion appears to match an existing peer/device, prompt the user to repair/replace rather than silently mutating both
+
+Conflict and repair should start as a read-model and operator-action problem, not as an automatic merge system.
+
+## Acceptance Criteria
+
+This design is successful when:
+
+1. Coordinator membership, suggested peers, and accepted sync peers are clearly distinct.
+2. The plan restores missing operator controls before adding onboarding automation.
+3. The first implementation restores operator control and read-only visibility before onboarding automation.
+4. Suggested-peer onboarding is explicitly deferred behind the simpler visibility/repair slices.
+5. The bead graph has a documented execution order that reduces rework and debugging ambiguity.

--- a/examples/cloudflare-coordinator/README.md
+++ b/examples/cloudflare-coordinator/README.md
@@ -1,8 +1,11 @@
 # Cloudflare Worker reference coordinator
 
 This is a secondary reference deployment for the coordinator-backed discovery contract. The canonical deployment target
-is the built-in Python coordinator (`codemem sync coordinator serve`). See `docs/coordinator-discovery.md` for the
+is the built-in TypeScript coordinator (`codemem sync coordinator serve`). See `docs/coordinator-discovery.md` for the
 recommended deployment path.
+
+The product is now TS-first. This Worker example remains useful for experimenting with Workers + D1, but it is not the
+mainline coordinator runtime and should not be assumed to have feature parity with the built-in coordinator.
 
 It is intentionally narrow:
 

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -149,9 +149,11 @@ describe("formatSyncAttempt", () => {
 		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
 		const serve = coordinator?.commands.find((command) => command.name() === "serve");
 		expect(serve?.options.find((opt) => opt.long === "--db")?.defaultValue).toBeUndefined();
+		expect(serve?.options.find((opt) => opt.long === "--port")?.defaultValue).toBe("7347");
 		// runtime default is enforced in action code, not commander metadata
 		const help = serve?.helpInformation() ?? "";
 		expect(help).toContain("coordinator database path");
+		expect(help).toContain("7347");
 	});
 
 	it("allows positional group ids for create-invite and list-join-requests", () => {

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -809,10 +809,10 @@ coordinatorCommand.addCommand(
 		.option("--db <path>", "coordinator database path")
 		.option("--db-path <path>", "coordinator database path")
 		.option("--host <host>", "bind host", "127.0.0.1")
-		.option("--port <port>", "bind port", "7340")
+		.option("--port <port>", "bind port", "7347")
 		.action(async (opts: { db?: string; dbPath?: string; host?: string; port?: string }) => {
 			const host = String(opts.host ?? "127.0.0.1").trim() || "127.0.0.1";
-			const port = Number.parseInt(String(opts.port ?? "7340"), 10);
+			const port = Number.parseInt(String(opts.port ?? "7347"), 10);
 			const dbPath = opts.db ?? opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH;
 			const app = createCoordinatorApp({ dbPath });
 			p.intro("codemem sync coordinator serve");


### PR DESCRIPTION
## Description
- Clarifies the current TS coordinator contract so docs stop implying that coordinator team membership automatically creates sync peers.
- Repositions the built-in TS/Hono coordinator as the canonical deployment target and frames Cloudflare as a follow-up deployment target after Linux/Node E2E validation.
- Fixes the `codemem sync coordinator serve` default port mismatch so the CLI and docs both use `7347`.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm vitest run packages/cli/src/commands/sync.test.ts`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
