### PR TITLE
feat(sync): add local coordinator admin commands

### DIFF
--- a/docs/coordinator-deployment.md
+++ b/docs/coordinator-deployment.md
@@ -14,8 +14,8 @@ Cloudflare runtime.
 # Install codemem CLI (makes the `codemem` command available)
 npm install -g codemem
 
-# Bootstrap a coordinator group in the local DB
-sqlite3 ~/.codemem/coordinator.sqlite "insert into groups (group_id, display_name, created_at) values ('my-team', 'my-team', datetime('now')) on conflict(group_id) do nothing;"
+# Create a coordinator group
+codemem sync coordinator group-create my-team --db-path ~/.codemem/coordinator.sqlite
 
 # Set an admin secret (required for creating invites via the API)
 set -x CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET (openssl rand -base64 32)
@@ -39,25 +39,37 @@ codemem sync coordinator serve [OPTIONS]
 
 | Option      | Default       | Description                            |
 |-------------|---------------|----------------------------------------|
-| `--db-path` | (required)    | Path to coordinator SQLite database    |
+| `--db-path` | `~/.codemem/coordinator.sqlite` | Path to coordinator SQLite database    |
 | `--host`    | `127.0.0.1`   | Bind address (`0.0.0.0` for all interfaces) |
 | `--port`    | `7347`        | Listen port                            |
 
 ### Team management
 
-Current status: the shipped TS CLI only exposes the invite/join-request management surface today. Full local
-group/device admin verbs are planned but not all shipped yet.
-
 ```fish
-# Current shipped commands
+# Create a group
+codemem sync coordinator group-create <group-id> --db-path <path>
+
+# List groups
+codemem sync coordinator list-groups --db-path <path>
+
+# Enroll a device directly (admin)
+codemem sync coordinator enroll-device <group-id> <device-id> \
+  --fingerprint <fingerprint> --public-key-file <path> --db-path <path>
+
+# List enrolled devices
+codemem sync coordinator list-devices <group-id> --db-path <path>
+
+# Rename, disable, or remove a device
+codemem sync coordinator rename-device <group-id> <device-id> --name "work-laptop" --db-path <path>
+codemem sync coordinator disable-device <group-id> <device-id> --db-path <path>
+codemem sync coordinator remove-device <group-id> <device-id> --db-path <path>
+
+# Invite / join-request commands
 codemem sync coordinator create-invite <group-id> --db-path <path>
 codemem sync coordinator list-join-requests <group-id> --db-path <path>
 codemem sync coordinator approve-join-request <request-id> --db-path <path>
 codemem sync coordinator deny-join-request <request-id> --db-path <path>
 ```
-
-Until local coordinator admin parity lands, group bootstrap and direct DB-backed inspection may still require `sqlite3`
-on the coordinator machine.
 
 ### Invite and join flow
 
@@ -104,7 +116,7 @@ docker run -d --name coordinator -p 7347:7347 -v coordinator-data:/data codemem-
 Initialize the group from the host:
 
 ```fish
-docker exec coordinator sqlite3 /data/coordinator.sqlite "insert into groups (group_id, display_name, created_at) values ('my-team', 'my-team', datetime('now')) on conflict(group_id) do nothing;"
+docker exec coordinator codemem sync coordinator group-create my-team --db-path /data/coordinator.sqlite
 ```
 
 ## Exposing the coordinator
@@ -188,8 +200,7 @@ local sync peer relationship. Direct sync still depends on explicit `sync_peers`
 
 ### Admin-driven enrollment
 
-The admin enrolls a teammate's device directly once the missing local admin CLI verbs land. Today, the practical TS
-path is invite-driven enrollment.
+The admin can enroll a teammate's device directly from the local coordinator machine:
 
 ```fish
 codemem sync coordinator enroll-device my-team <device-id> \
@@ -234,9 +245,8 @@ peer-to-peer sync remains the data path.
 **Coordinator not reachable**: verify the `--host` binding. Use `0.0.0.0` to listen on all interfaces. Check firewall
 rules and that the tunnel/funnel is active.
 
-**Device not enrolled**: use the invite flow for self-service enrollment. Until local coordinator admin parity lands,
-confirm coordinator enrollment from the coordinator machine with `sqlite3` or the pending join-request flow rather than
-assuming `list-devices` is already available in the TS CLI.
+**Device not enrolled**: run `codemem sync coordinator list-devices <group> --db-path <path>` to confirm enrollment.
+Use the invite flow for self-service enrollment.
 
 **Presence not refreshing**: check that the client's `sync_coordinator_url` matches the coordinator's reachable address
 and that `sync_coordinator_group` matches a group the device is enrolled in.

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -76,9 +76,16 @@ Backward compatibility:
 The preferred self-hosted deployment path is the first-party TypeScript coordinator service shipped in the main
 `codemem` CLI. Its HTTP surface is implemented with Hono and exposed through `codemem sync coordinator serve`.
 
-Current shipped coordinator CLI surface:
+Current shipped local coordinator CLI surface:
 
 ```fish
+codemem sync coordinator group-create team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator list-groups --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator enroll-device team-alpha <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/device.key.pub --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator list-devices team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator rename-device team-alpha <device-id> --name "work-laptop" --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator disable-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
+codemem sync coordinator remove-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
 codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
 codemem sync coordinator create-invite team-alpha --db-path ~/.codemem/coordinator.sqlite
 codemem sync coordinator import-invite <invite>
@@ -90,13 +97,9 @@ codemem sync coordinator deny-join-request <request-id> --db-path ~/.codemem/coo
 This keeps the primary deployment path inside the main `codemem` artifact and reuses the current TypeScript sync
 auth/signature verification code directly.
 
-Current limitation:
-
-- local coordinator admin parity is incomplete in the shipped TS CLI
-- direct group/device administration commands are planned but not all available yet
-
-These management commands operate on the built-in local coordinator store only. Remote coordinator admin flows require
-a separate access-control model before they should be exposed over HTTP.
+These group/device management commands operate on the built-in local coordinator store only in the current TS CLI.
+Remote coordinator admin for invites and join-request review exists separately; remote device-admin parity remains a
+follow-up.
 
 ## Discovery groups vs sync peers
 
@@ -139,17 +142,8 @@ not accumulate as mixed `host:port` and `http://host:port` variants in local pee
 
 Built-in local coordinator management commands operate directly on the local SQLite store.
 
-For remote coordinators, the first admin model uses a separate operator-managed admin secret. Remote management commands
-reuse the same `codemem sync coordinator ...` verbs once those admin commands ship in the TS CLI, targeting a remote
-coordinator when you pass `--remote-url` and an admin secret (or configure `sync_coordinator_admin_secret`).
-
-Planned examples once admin parity ships:
-
-```fish
-codemem sync coordinator list-devices nerdworld --remote-url "https://coord.codemem.sh"
-codemem sync coordinator enroll-device nerdworld <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/device.key.pub --remote-url "https://coord.codemem.sh"
-codemem sync coordinator rename-device nerdworld <device-id> --name "work-laptop" --remote-url "https://coord.codemem.sh"
-```
+For remote coordinators, the first admin model uses a separate operator-managed admin secret. The currently shipped TS
+CLI uses that remote admin path for invite creation and join-request review; remote device-admin parity is deferred.
 
 Device participation auth still uses the enrolled device keypair for `presence` and `peers` endpoints; the admin secret
 is only for remote mutation/listing endpoints.

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -125,6 +125,13 @@ describe("formatSyncAttempt", () => {
 		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
 		expect(coordinator).toBeDefined();
 		expect(coordinator?.commands.map((command) => command.name())).toEqual([
+			"group-create",
+			"list-groups",
+			"enroll-device",
+			"list-devices",
+			"rename-device",
+			"disable-device",
+			"remove-device",
 			"serve",
 			"create-invite",
 			"import-invite",
@@ -137,6 +144,13 @@ describe("formatSyncAttempt", () => {
 	it("documents the coordinator command surface in help output", () => {
 		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
 		const help = coordinator?.helpInformation() ?? "";
+		expect(help).toContain("group-create");
+		expect(help).toContain("list-groups");
+		expect(help).toContain("enroll-device");
+		expect(help).toContain("list-devices");
+		expect(help).toContain("rename-device");
+		expect(help).toContain("disable-device");
+		expect(help).toContain("remove-device");
 		expect(help).toContain("serve");
 		expect(help).toContain("create-invite");
 		expect(help).toContain("import-invite");

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -10,9 +10,16 @@ import { dirname, join } from "node:path";
 
 import * as p from "@clack/prompts";
 import {
+	coordinatorCreateGroupAction,
 	coordinatorCreateInviteAction,
+	coordinatorDisableDeviceAction,
+	coordinatorEnrollDeviceAction,
 	coordinatorImportInviteAction,
+	coordinatorListDevicesAction,
+	coordinatorListGroupsAction,
 	coordinatorListJoinRequestsAction,
+	coordinatorRemoveDeviceAction,
+	coordinatorRenameDeviceAction,
 	coordinatorReviewJoinRequestAction,
 	createCoordinatorApp,
 	DEFAULT_COORDINATOR_DB_PATH,
@@ -67,6 +74,19 @@ interface SyncPairOptions {
 	all?: boolean;
 	default?: boolean;
 	dbPath?: string;
+}
+
+function readCoordinatorPublicKey(opts: { publicKey?: string; publicKeyFile?: string }): string {
+	const inline = String(opts.publicKey ?? "").trim();
+	const filePath = String(opts.publicKeyFile ?? "").trim();
+	if (inline && filePath) throw new Error("Use only one of --public-key or --public-key-file");
+	if (filePath) {
+		const text = readFileSync(filePath, "utf8").trim();
+		if (!text) throw new Error(`Public key file is empty: ${filePath}`);
+		return text;
+	}
+	if (!inline) throw new Error("Public key required via --public-key or --public-key-file");
+	return inline;
 }
 
 async function portOpen(host: string, port: number): Promise<boolean> {
@@ -801,6 +821,283 @@ syncCommand.addCommand(
 const coordinatorCommand = new Command("coordinator")
 	.configureHelp(helpStyle)
 	.description("Manage coordinator invites, join requests, and relay server");
+
+coordinatorCommand.addCommand(
+	new Command("group-create")
+		.configureHelp(helpStyle)
+		.description("Create a coordinator group in the local store")
+		.argument("<group>", "group id")
+		.option("--name <name>", "display name override")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--json", "output as JSON")
+		.action(
+			async (
+				groupId: string,
+				opts: { name?: string; db?: string; dbPath?: string; json?: boolean },
+			) => {
+				const group = coordinatorCreateGroupAction({
+					groupId,
+					displayName: opts.name?.trim() || null,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(group, null, 2));
+					return;
+				}
+				p.intro("codemem sync coordinator group-create");
+				p.log.success(`Group ready: ${groupId.trim()}`);
+				p.outro(String(group.display_name ?? group.group_id ?? groupId.trim()));
+			},
+		),
+);
+
+coordinatorCommand.addCommand(
+	new Command("list-groups")
+		.configureHelp(helpStyle)
+		.description("List coordinator groups from the local store")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--json", "output as JSON")
+		.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
+			const groups = coordinatorListGroupsAction({ dbPath: opts.db ?? opts.dbPath ?? null });
+			if (opts.json) {
+				console.log(JSON.stringify(groups, null, 2));
+				return;
+			}
+			p.intro("codemem sync coordinator list-groups");
+			if (groups.length === 0) {
+				p.outro("No coordinator groups found");
+				return;
+			}
+			for (const group of groups) {
+				p.log.message(
+					`- ${String(group.group_id ?? "")}${group.display_name ? ` (${String(group.display_name)})` : ""}`,
+				);
+			}
+			p.outro(`${groups.length} group(s)`);
+		}),
+);
+
+coordinatorCommand.addCommand(
+	new Command("enroll-device")
+		.configureHelp(helpStyle)
+		.description("Enroll a device in a local coordinator group")
+		.argument("<group>", "group id")
+		.argument("<device-id>", "device id")
+		.option("--fingerprint <fingerprint>", "device fingerprint")
+		.option("--public-key <key>", "device public key")
+		.option("--public-key-file <path>", "path to device public key")
+		.option("--name <name>", "display name")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--json", "output as JSON")
+		.action(
+			async (
+				groupId: string,
+				deviceId: string,
+				opts: {
+					fingerprint?: string;
+					publicKey?: string;
+					publicKeyFile?: string;
+					name?: string;
+					db?: string;
+					dbPath?: string;
+					json?: boolean;
+				},
+			) => {
+				const publicKey = readCoordinatorPublicKey(opts);
+				const fingerprint = String(opts.fingerprint ?? "").trim();
+				if (!fingerprint) {
+					p.log.error("Fingerprint required via --fingerprint");
+					process.exitCode = 1;
+					return;
+				}
+				const actualFingerprint = fingerprintPublicKey(publicKey);
+				if (actualFingerprint !== fingerprint) {
+					p.log.error("Fingerprint does not match the provided public key");
+					process.exitCode = 1;
+					return;
+				}
+				const enrollment = coordinatorEnrollDeviceAction({
+					groupId,
+					deviceId,
+					fingerprint,
+					publicKey,
+					displayName: opts.name?.trim() || null,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(enrollment, null, 2));
+					return;
+				}
+				p.intro("codemem sync coordinator enroll-device");
+				p.log.success(`Enrolled ${deviceId.trim()} in ${groupId.trim()}`);
+				p.outro(String(enrollment.display_name ?? enrollment.device_id ?? deviceId.trim()));
+			},
+		),
+);
+
+coordinatorCommand.addCommand(
+	new Command("list-devices")
+		.configureHelp(helpStyle)
+		.description("List enrolled devices in a local coordinator group")
+		.argument("<group>", "group id")
+		.option("--include-disabled", "include disabled devices")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--json", "output as JSON")
+		.action(
+			(
+				groupId: string,
+				opts: { includeDisabled?: boolean; db?: string; dbPath?: string; json?: boolean },
+			) => {
+				const rows = coordinatorListDevicesAction({
+					groupId,
+					includeDisabled: opts.includeDisabled === true,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(rows, null, 2));
+					return;
+				}
+				p.intro("codemem sync coordinator list-devices");
+				if (rows.length === 0) {
+					p.outro(`No enrolled devices for ${groupId.trim()}`);
+					return;
+				}
+				for (const row of rows) {
+					const label =
+						String(row.display_name ?? row.device_id ?? "").trim() || String(row.device_id ?? "");
+					const enabled = Number(row.enabled ?? 1) === 1 ? "enabled" : "disabled";
+					p.log.message(`- ${label} (${String(row.device_id ?? "")}) ${enabled}`);
+				}
+				p.outro(`${rows.length} device(s)`);
+			},
+		),
+);
+
+coordinatorCommand.addCommand(
+	new Command("rename-device")
+		.configureHelp(helpStyle)
+		.description("Rename an enrolled device in the local coordinator store")
+		.argument("<group>", "group id")
+		.argument("<device-id>", "device id")
+		.requiredOption("--name <name>", "display name")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--json", "output as JSON")
+		.action(
+			(
+				groupId: string,
+				deviceId: string,
+				opts: { name: string; db?: string; dbPath?: string; json?: boolean },
+			) => {
+				const result = coordinatorRenameDeviceAction({
+					groupId,
+					deviceId,
+					displayName: opts.name.trim(),
+					dbPath: opts.db ?? opts.dbPath ?? null,
+				});
+				if (!result) {
+					p.log.error(`Device not found: ${deviceId.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				if (opts.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+				p.intro("codemem sync coordinator rename-device");
+				p.log.success(`Renamed ${deviceId.trim()} in ${groupId.trim()}`);
+				p.outro(String(result.display_name ?? result.device_id ?? deviceId.trim()));
+			},
+		),
+);
+
+coordinatorCommand.addCommand(
+	new Command("disable-device")
+		.configureHelp(helpStyle)
+		.description("Disable an enrolled device in the local coordinator store")
+		.argument("<group>", "group id")
+		.argument("<device-id>", "device id")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--json", "output as JSON")
+		.action(
+			(
+				groupId: string,
+				deviceId: string,
+				opts: { db?: string; dbPath?: string; json?: boolean },
+			) => {
+				const ok = coordinatorDisableDeviceAction({
+					groupId,
+					deviceId,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+				});
+				if (!ok) {
+					p.log.error(`Device not found: ${deviceId.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				if (opts.json) {
+					console.log(
+						JSON.stringify(
+							{ ok: true, group_id: groupId.trim(), device_id: deviceId.trim() },
+							null,
+							2,
+						),
+					);
+					return;
+				}
+				p.intro("codemem sync coordinator disable-device");
+				p.log.success(`Disabled ${deviceId.trim()} in ${groupId.trim()}`);
+				p.outro("disabled");
+			},
+		),
+);
+
+coordinatorCommand.addCommand(
+	new Command("remove-device")
+		.configureHelp(helpStyle)
+		.description("Remove an enrolled device from the local coordinator store")
+		.argument("<group>", "group id")
+		.argument("<device-id>", "device id")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--json", "output as JSON")
+		.action(
+			(
+				groupId: string,
+				deviceId: string,
+				opts: { db?: string; dbPath?: string; json?: boolean },
+			) => {
+				const ok = coordinatorRemoveDeviceAction({
+					groupId,
+					deviceId,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+				});
+				if (!ok) {
+					p.log.error(`Device not found: ${deviceId.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				if (opts.json) {
+					console.log(
+						JSON.stringify(
+							{ ok: true, group_id: groupId.trim(), device_id: deviceId.trim() },
+							null,
+							2,
+						),
+					);
+					return;
+				}
+				p.intro("codemem sync coordinator remove-device");
+				p.log.success(`Removed ${deviceId.trim()} from ${groupId.trim()}`);
+				p.outro("removed");
+			},
+		),
+);
 
 coordinatorCommand.addCommand(
 	new Command("serve")

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	coordinatorCreateGroupAction,
+	coordinatorDisableDeviceAction,
+	coordinatorEnrollDeviceAction,
+	coordinatorListDevicesAction,
+	coordinatorListGroupsAction,
+	coordinatorRemoveDeviceAction,
+	coordinatorRenameDeviceAction,
+} from "./coordinator-actions.js";
+
+describe("coordinator local admin actions", () => {
+	let tmpDir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "coord-actions-test-"));
+		dbPath = join(tmpDir, "coordinator.sqlite");
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("creates and lists groups", () => {
+		const group = coordinatorCreateGroupAction({
+			groupId: "team-a",
+			displayName: "Team A",
+			dbPath,
+		});
+		expect(group.group_id).toBe("team-a");
+		expect(coordinatorListGroupsAction({ dbPath })).toEqual([
+			expect.objectContaining({ group_id: "team-a", display_name: "Team A" }),
+		]);
+	});
+
+	it("enrolls and lists devices for an existing group", () => {
+		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		const enrollment = coordinatorEnrollDeviceAction({
+			groupId: "team-a",
+			deviceId: "device-1",
+			fingerprint: "fp-1",
+			publicKey: "pk-1",
+			displayName: "Laptop",
+			dbPath,
+		});
+		expect(enrollment.device_id).toBe("device-1");
+		expect(coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([
+			expect.objectContaining({ device_id: "device-1", display_name: "Laptop" }),
+		]);
+	});
+
+	it("renames, disables, and removes devices", () => {
+		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		coordinatorEnrollDeviceAction({
+			groupId: "team-a",
+			deviceId: "device-1",
+			fingerprint: "fp-1",
+			publicKey: "pk-1",
+			dbPath,
+		});
+		expect(
+			coordinatorRenameDeviceAction({
+				groupId: "team-a",
+				deviceId: "device-1",
+				displayName: "Work Laptop",
+				dbPath,
+			}),
+		).toEqual(expect.objectContaining({ display_name: "Work Laptop" }));
+		expect(
+			coordinatorDisableDeviceAction({ groupId: "team-a", deviceId: "device-1", dbPath }),
+		).toBe(true);
+		expect(coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([]);
+		expect(
+			coordinatorListDevicesAction({ groupId: "team-a", includeDisabled: true, dbPath }),
+		).toEqual([expect.objectContaining({ device_id: "device-1", enabled: 0 })]);
+		expect(coordinatorRemoveDeviceAction({ groupId: "team-a", deviceId: "device-1", dbPath })).toBe(
+			true,
+		);
+		expect(
+			coordinatorListDevicesAction({ groupId: "team-a", includeDisabled: true, dbPath }),
+		).toEqual([]);
+	});
+
+	it("rejects enrollment into a missing group", () => {
+		expect(() =>
+			coordinatorEnrollDeviceAction({
+				groupId: "missing",
+				deviceId: "device-1",
+				fingerprint: "fp-1",
+				publicKey: "pk-1",
+				dbPath,
+			}),
+		).toThrow("Group not found: missing");
+	});
+});

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -49,6 +49,131 @@ async function remoteRequest(
 	return payload;
 }
 
+export function coordinatorCreateGroupAction(opts: {
+	groupId: string;
+	displayName?: string | null;
+	dbPath?: string | null;
+}): Record<string, unknown> {
+	const groupId = String(opts.groupId ?? "").trim();
+	if (!groupId) throw new Error("Group id required.");
+	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		store.createGroup(groupId, opts.displayName ?? null);
+		return store.getGroup(groupId) ?? {};
+	} finally {
+		store.close();
+	}
+}
+
+export function coordinatorListGroupsAction(opts?: {
+	dbPath?: string | null;
+}): Record<string, unknown>[] {
+	const store = new CoordinatorStore(opts?.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		return store.listGroups();
+	} finally {
+		store.close();
+	}
+}
+
+export function coordinatorEnrollDeviceAction(opts: {
+	groupId: string;
+	deviceId: string;
+	fingerprint: string;
+	publicKey: string;
+	displayName?: string | null;
+	dbPath?: string | null;
+}): Record<string, unknown> {
+	const groupId = String(opts.groupId ?? "").trim();
+	const deviceId = String(opts.deviceId ?? "").trim();
+	const fingerprint = String(opts.fingerprint ?? "").trim();
+	const publicKey = String(opts.publicKey ?? "").trim();
+	if (!groupId || !deviceId || !fingerprint || !publicKey) {
+		throw new Error("group_id, device_id, fingerprint, and public_key are required.");
+	}
+	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		if (!store.getGroup(groupId)) throw new Error(`Group not found: ${groupId}`);
+		store.enrollDevice(groupId, {
+			deviceId,
+			fingerprint,
+			publicKey,
+			displayName: opts.displayName ?? null,
+		});
+		return store.getEnrollment(groupId, deviceId) ?? {};
+	} finally {
+		store.close();
+	}
+}
+
+export function coordinatorListDevicesAction(opts: {
+	groupId: string;
+	includeDisabled?: boolean;
+	dbPath?: string | null;
+}): Record<string, unknown>[] {
+	const groupId = String(opts.groupId ?? "").trim();
+	if (!groupId) throw new Error("Group id required.");
+	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		return store.listEnrolledDevices(groupId, opts.includeDisabled === true);
+	} finally {
+		store.close();
+	}
+}
+
+export function coordinatorRenameDeviceAction(opts: {
+	groupId: string;
+	deviceId: string;
+	displayName: string;
+	dbPath?: string | null;
+}): Record<string, unknown> | null {
+	const groupId = String(opts.groupId ?? "").trim();
+	const deviceId = String(opts.deviceId ?? "").trim();
+	const displayName = String(opts.displayName ?? "").trim();
+	if (!groupId || !deviceId || !displayName) {
+		throw new Error("group_id, device_id, and display_name are required.");
+	}
+	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		const ok = store.renameDevice(groupId, deviceId, displayName);
+		return ok ? (store.getEnrollment(groupId, deviceId) ?? {}) : null;
+	} finally {
+		store.close();
+	}
+}
+
+export function coordinatorDisableDeviceAction(opts: {
+	groupId: string;
+	deviceId: string;
+	dbPath?: string | null;
+}): boolean {
+	const groupId = String(opts.groupId ?? "").trim();
+	const deviceId = String(opts.deviceId ?? "").trim();
+	if (!groupId || !deviceId) throw new Error("group_id and device_id are required.");
+	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		return store.setDeviceEnabled(groupId, deviceId, false);
+	} finally {
+		store.close();
+	}
+}
+
+export function coordinatorRemoveDeviceAction(opts: {
+	groupId: string;
+	deviceId: string;
+	dbPath?: string | null;
+}): boolean {
+	const groupId = String(opts.groupId ?? "").trim();
+	const deviceId = String(opts.deviceId ?? "").trim();
+	if (!groupId || !deviceId) throw new Error("group_id and device_id are required.");
+	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		return store.removeDevice(groupId, deviceId);
+	} finally {
+		store.close();
+	}
+}
+
 export async function coordinatorCreateInviteAction(opts: {
 	groupId: string;
 	coordinatorUrl?: string | null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,9 +18,16 @@ export {
 	resolveHookProject,
 } from "./claude-hooks.js";
 export {
+	coordinatorCreateGroupAction,
 	coordinatorCreateInviteAction,
+	coordinatorDisableDeviceAction,
+	coordinatorEnrollDeviceAction,
 	coordinatorImportInviteAction,
+	coordinatorListDevicesAction,
+	coordinatorListGroupsAction,
 	coordinatorListJoinRequestsAction,
+	coordinatorRemoveDeviceAction,
+	coordinatorRenameDeviceAction,
 	coordinatorReviewJoinRequestAction,
 } from "./coordinator-actions.js";
 export { createCoordinatorApp } from "./coordinator-api.js";


### PR DESCRIPTION
## Description
- Restores local coordinator admin CLI parity in the TS runtime with group and device management commands.
- Adds local admin actions and tests for `group-create`, `list-groups`, `enroll-device`, `list-devices`, `rename-device`, `disable-device`, and `remove-device`.
- Updates coordinator docs so the local admin surface matches the shipped CLI instead of the old sqlite-only workaround.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm vitest run packages/cli/src/commands/sync.test.ts packages/core/src/coordinator-actions.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
