### PR TITLE
feat(sync): add peer repair tooling

### DIFF
--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, initTestSchema, MemoryStore } from "@codemem/core";
+import { describe, expect, it, vi } from "vitest";
 import { syncCommand } from "./sync.js";
 import {
 	buildServeLifecycleArgs,
@@ -182,5 +186,53 @@ describe("formatSyncAttempt", () => {
 		expect(listRequests?.registeredArguments[0]?.required).toBe(false);
 		expect(createInvite?.helpInformation()).toContain("[group]");
 		expect(listRequests?.helpInformation()).toContain("[group]");
+	});
+
+	it("registers peer repair subcommands", () => {
+		const peers = syncCommand.commands.find((command) => command.name() === "peers");
+		expect(peers?.commands.map((command) => command.name())).toEqual(["remove"]);
+		expect(peers?.helpInformation()).toContain("remove");
+	});
+
+	it("removes a peer by exact name", async () => {
+		const tmpDbDir = mkdtempSync(join(tmpdir(), "sync-peers-remove-test-"));
+		const dbPath = join(tmpDbDir, "mem.sqlite");
+		const rawDb = connect(dbPath);
+		initTestSchema(rawDb);
+		rawDb.close();
+		const store = new MemoryStore(dbPath);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const prevExitCode = process.exitCode;
+		process.exitCode = undefined;
+		try {
+			store.db
+				.prepare("INSERT INTO sync_peers(peer_device_id, name, created_at) VALUES (?, ?, ?)")
+				.run("peer-1", "work", new Date().toISOString());
+			store.db
+				.prepare(
+					"INSERT INTO replication_cursors(peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+				)
+				.run("peer-1", "cursor-1", "cursor-1", new Date().toISOString());
+			const peers = syncCommand.commands.find((command) => command.name() === "peers");
+			const remove = peers?.commands.find((command) => command.name() === "remove");
+			await remove?.parseAsync(["work", "--db-path", dbPath, "--json"], { from: "user" });
+			expect(logSpy).toHaveBeenCalledWith(
+				JSON.stringify({ ok: true, peer_device_id: "peer-1", name: "work" }, null, 2),
+			);
+			const row = store.db
+				.prepare("SELECT peer_device_id FROM sync_peers WHERE peer_device_id = ?")
+				.get("peer-1");
+			const cursor = store.db
+				.prepare("SELECT peer_device_id FROM replication_cursors WHERE peer_device_id = ?")
+				.get("peer-1");
+			expect(row).toBeUndefined();
+			expect(cursor).toBeUndefined();
+			expect(process.exitCode).toBeUndefined();
+		} finally {
+			logSpy.mockRestore();
+			store.close();
+			rmSync(tmpDbDir, { recursive: true, force: true });
+			process.exitCode = prevExitCode;
+		}
 	});
 });

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -76,6 +76,27 @@ interface SyncPairOptions {
 	dbPath?: string;
 }
 
+function resolvePeerMatch(
+	db: ReturnType<typeof drizzle>,
+	peerRef: string,
+): { peer_device_id: string; name: string | null } | null | "ambiguous" {
+	const trimmed = peerRef.trim();
+	if (!trimmed) return null;
+	const byId = db
+		.select({ peer_device_id: schema.syncPeers.peer_device_id, name: schema.syncPeers.name })
+		.from(schema.syncPeers)
+		.where(eq(schema.syncPeers.peer_device_id, trimmed))
+		.get();
+	if (byId) return byId;
+	const byName = db
+		.select({ peer_device_id: schema.syncPeers.peer_device_id, name: schema.syncPeers.name })
+		.from(schema.syncPeers)
+		.where(eq(schema.syncPeers.name, trimmed))
+		.all();
+	if (byName.length > 1) return "ambiguous";
+	return byName[0] ?? null;
+}
+
 function readCoordinatorPublicKey(opts: { publicKey?: string; publicKeyFile?: string }): string {
 	const inline = String(opts.publicKey ?? "").trim();
 	const filePath = String(opts.publicKeyFile ?? "").trim();
@@ -152,7 +173,7 @@ async function runServeLifecycle(
 	}
 	const args = buildServeLifecycleArgs(action, opts, process.argv[1] ?? "", process.execArgv);
 	await new Promise<void>((resolve, reject) => {
-		const child = spawn(process.execPath, args, {
+		const child: ReturnType<typeof spawn> = spawn(process.execPath, args, {
 			cwd: process.cwd(),
 			stdio: "inherit",
 			env: {
@@ -161,7 +182,7 @@ async function runServeLifecycle(
 			},
 		});
 		child.once("error", reject);
-		child.once("exit", (code) => {
+		child.once("exit", (code: number | null) => {
 			if (code && code !== 0) {
 				process.exitCode = code;
 			}
@@ -752,52 +773,99 @@ syncCommand.addCommand(
 );
 
 // codemem sync peers
-syncCommand.addCommand(
-	new Command("peers")
+const peersCommand = new Command("peers")
+	.configureHelp(helpStyle)
+	.description("List known sync peers")
+	.option("--db <path>", "database path")
+	.option("--db-path <path>", "database path")
+	.option("--json", "output as JSON")
+	.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
+		const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+		try {
+			const d = drizzle(store.db, { schema });
+			const peers = d
+				.select({
+					peer_device_id: schema.syncPeers.peer_device_id,
+					name: schema.syncPeers.name,
+					addresses: schema.syncPeers.addresses_json,
+					last_sync_at: schema.syncPeers.last_sync_at,
+					last_error: schema.syncPeers.last_error,
+				})
+				.from(schema.syncPeers)
+				.orderBy(desc(schema.syncPeers.last_sync_at))
+				.all();
+
+			if (opts.json) {
+				console.log(JSON.stringify(peers, null, 2));
+				return;
+			}
+
+			p.intro("codemem sync peers");
+			if (peers.length === 0) {
+				p.outro("No peers configured");
+				return;
+			}
+			for (const peer of peers) {
+				const label = peer.name || peer.peer_device_id;
+				const addrs = peer.addresses || "(no addresses)";
+				p.log.message(
+					`${label}\n  addresses: ${addrs}\n  last_sync: ${peer.last_sync_at ?? "never"}\n  status: ${peer.last_error ?? "ok"}`,
+				);
+			}
+			p.outro(`${peers.length} peer(s)`);
+		} finally {
+			store.close();
+		}
+	});
+
+peersCommand.addCommand(
+	new Command("remove")
 		.configureHelp(helpStyle)
-		.description("List known sync peers")
+		.description("Remove a sync peer by device id or exact name")
+		.argument("<peer>", "peer device id or exact name")
 		.option("--db <path>", "database path")
 		.option("--db-path <path>", "database path")
 		.option("--json", "output as JSON")
-		.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
+		.action((peerRef: string, opts: { db?: string; dbPath?: string; json?: boolean }) => {
 			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 			try {
 				const d = drizzle(store.db, { schema });
-				const peers = d
-					.select({
-						peer_device_id: schema.syncPeers.peer_device_id,
-						name: schema.syncPeers.name,
-						addresses: schema.syncPeers.addresses_json,
-						last_sync_at: schema.syncPeers.last_sync_at,
-						last_error: schema.syncPeers.last_error,
-					})
-					.from(schema.syncPeers)
-					.orderBy(desc(schema.syncPeers.last_sync_at))
-					.all();
-
+				const match = resolvePeerMatch(d, peerRef);
+				if (match === "ambiguous") {
+					p.log.error(`Peer name is ambiguous: ${peerRef.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				if (!match) {
+					p.log.error(`Peer not found: ${peerRef.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				d.delete(schema.replicationCursors)
+					.where(eq(schema.replicationCursors.peer_device_id, match.peer_device_id))
+					.run();
+				d.delete(schema.syncPeers)
+					.where(eq(schema.syncPeers.peer_device_id, match.peer_device_id))
+					.run();
+				const payload = {
+					ok: true,
+					peer_device_id: match.peer_device_id,
+					name: match.name,
+				};
 				if (opts.json) {
-					console.log(JSON.stringify(peers, null, 2));
+					console.log(JSON.stringify(payload, null, 2));
 					return;
 				}
-
-				p.intro("codemem sync peers");
-				if (peers.length === 0) {
-					p.outro("No peers configured");
-					return;
-				}
-				for (const peer of peers) {
-					const label = peer.name || peer.peer_device_id;
-					const addrs = peer.addresses || "(no addresses)";
-					p.log.message(
-						`${label}\n  addresses: ${addrs}\n  last_sync: ${peer.last_sync_at ?? "never"}\n  status: ${peer.last_error ?? "ok"}`,
-					);
-				}
-				p.outro(`${peers.length} peer(s)`);
+				p.intro("codemem sync peers remove");
+				p.log.success(`Removed peer ${match.name || match.peer_device_id}`);
+				p.outro(match.peer_device_id);
 			} finally {
 				store.close();
 			}
 		}),
 );
+
+syncCommand.addCommand(peersCommand);
 
 // codemem sync connect <coordinator-url>
 syncCommand.addCommand(

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -409,13 +409,13 @@ export function assertSchemaReady(db: DatabaseType): void {
 	if (version === 0) {
 		throw new Error(
 			"Database schema is not initialized. " +
-				"Run the Python runtime to initialize: uv run codemem stats",
+				"Initialize the SQLite database with the current TypeScript runtime before retrying.",
 		);
 	}
 	if (version < MIN_COMPATIBLE_SCHEMA) {
 		throw new Error(
 			`Database schema version ${version} is older than minimum compatible (${MIN_COMPATIBLE_SCHEMA}). ` +
-				"Run the Python runtime to complete migrations: uv run codemem stats",
+				"Upgrade the database schema with the current TypeScript runtime before retrying.",
 		);
 	}
 	if (version > SCHEMA_VERSION) {
@@ -438,7 +438,7 @@ export function assertSchemaReady(db: DatabaseType): void {
 	if (!tableExists(db, "memory_fts")) {
 		throw new Error(
 			"FTS5 index (memory_fts) is missing. " +
-				"Run the Python runtime to rebuild: uv run codemem stats",
+				"Rebuild the database schema with the current TypeScript runtime before retrying.",
 		);
 	}
 }

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -216,6 +216,16 @@ export async function assignPeerActor(peerDeviceId: string, actorId: string | nu
   return payload;
 }
 
+export async function deletePeer(peerDeviceId: string): Promise<any> {
+  const resp = await fetch(`/api/sync/peers/${encodeURIComponent(peerDeviceId)}`, {
+    method: 'DELETE',
+  });
+  const text = await resp.text();
+  const payload = text ? JSON.parse(text) : {};
+  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  return payload;
+}
+
 export async function createActor(displayName: string): Promise<any> {
   const resp = await fetch('/api/sync/actors', {
     method: 'POST',

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -196,6 +196,7 @@ export function renderSyncPeers() {
     const titleRow = el('div', 'peer-title');
     const peerId = peer.peer_device_id ? String(peer.peer_device_id) : '';
     const displayName = peer.name || (peerId ? peerId.slice(0, 8) : 'unknown');
+    const destructiveLabel = peer.name || peerId || displayName;
     const name = el('strong', null, displayName);
     if (peerId) name.title = peerId;
 
@@ -218,6 +219,25 @@ export function renderSyncPeers() {
       syncBtn.textContent = 'Sync now';
     });
     actions.appendChild(syncBtn);
+    const removeBtn = el('button', null, 'Remove peer') as HTMLButtonElement;
+    removeBtn.addEventListener('click', async () => {
+      if (!peerId) return;
+      if (!window.confirm(`Remove peer ${destructiveLabel}? This deletes the local sync peer entry.`)) return;
+      removeBtn.disabled = true;
+      removeBtn.textContent = 'Removing…';
+      try {
+        await api.deletePeer(peerId);
+        showGlobalNotice(`Removed peer ${destructiveLabel}.`);
+        await _loadSyncData();
+      } catch (error) {
+        showGlobalNotice(friendlyError(error, 'Failed to remove peer.'), 'warning');
+        removeBtn.textContent = 'Retry remove';
+      } finally {
+        removeBtn.disabled = false;
+        if (removeBtn.textContent === 'Removing…') removeBtn.textContent = 'Remove peer';
+      }
+    });
+    actions.appendChild(removeBtn);
     const toggleScopeBtn = el('button', null, 'Edit scope') as HTMLButtonElement;
     actions.appendChild(toggleScopeBtn);
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1849,5 +1849,46 @@ describe("viewer-server", () => {
 				else process.env.CODEMEM_CONFIG = prevConfig;
 			}
 		});
+
+		it("deletes sync peers through the viewer route", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare("INSERT INTO sync_peers(peer_device_id, name, created_at) VALUES (?, ?, ?)")
+					.run("peer-delete-me", "Old Peer", new Date().toISOString());
+				store.db
+					.prepare(
+						"INSERT INTO replication_cursors(peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+					)
+					.run("peer-delete-me", "cursor-1", "cursor-1", new Date().toISOString());
+				const res = await app.request("/api/sync/peers/peer-delete-me", { method: "DELETE" });
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({ ok: true });
+				const remaining = store.db
+					.prepare("SELECT peer_device_id FROM sync_peers WHERE peer_device_id = ?")
+					.get("peer-delete-me");
+				const cursor = store.db
+					.prepare("SELECT peer_device_id FROM replication_cursors WHERE peer_device_id = ?")
+					.get("peer-delete-me");
+				expect(remaining).toBeUndefined();
+				expect(cursor).toBeUndefined();
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns 404 when deleting a missing sync peer", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/peers/missing-peer", { method: "DELETE" });
+				expect(res.status).toBe(404);
+				expect(await res.json()).toEqual({ error: "peer not found" });
+			} finally {
+				cleanup();
+			}
+		});
 	});
 });

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1125,6 +1125,9 @@ export function syncRoutes(
 				.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
 				.get();
 			if (!exists) return c.json({ error: "peer not found" }, 404);
+			d.delete(schema.replicationCursors)
+				.where(eq(schema.replicationCursors.peer_device_id, peerDeviceId))
+				.run();
 			d.delete(schema.syncPeers).where(eq(schema.syncPeers.peer_device_id, peerDeviceId)).run();
 			return c.json({ ok: true });
 		}


### PR DESCRIPTION
## Description
- Adds a repair-oriented peer removal path to the TS CLI with `codemem sync peers remove <peer>`.
- Exposes a visible "Remove peer" action in the existing sync People tab using the already-shipped delete route.
- Adds route/test coverage for peer deletion and removes stale Python/uv schema guidance we tripped over while testing.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm vitest run packages/cli/src/commands/sync.test.ts packages/viewer-server/src/index.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
