### PR TITLE
feat(sync): show discovered coordinator devices

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1774,6 +1774,11 @@
         </div>
         <div class="actor-list" id="syncTeamStatus" aria-live="polite"></div>
         <div class="actor-list" id="syncJoinRequests"></div>
+        <div id="syncCoordinatorDiscovered" hidden>
+          <h3 class="settings-group-title" style="margin-top: 20px">Coordinator-discovered devices</h3>
+          <div class="section-meta" id="syncCoordinatorDiscoveredMeta"></div>
+          <div class="actor-list" id="syncCoordinatorDiscoveredList"></div>
+        </div>
         <div class="sync-actions" id="syncTeamActions" hidden></div>
       </div>
 

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -457,12 +457,32 @@ export interface ApiLegacyDeviceItem {
  * Coordinator status snapshot (from coordinator.status_snapshot()).
  * Shape varies by state — fields are optional to cover enabled/disabled modes.
  */
+export interface ApiCoordinatorDiscoveredDevice {
+	device_id: string;
+	display_name?: string | null;
+	fingerprint?: string | null;
+	addresses?: string[];
+	groups?: string[];
+	last_seen_at?: string | null;
+	expires_at?: string | null;
+	stale?: boolean;
+}
+
 export interface ApiCoordinatorStatus {
 	enabled: boolean;
 	configured: boolean;
 	coordinator_url?: string | null;
 	groups?: string[];
 	group_id?: string | null;
+	presence_status?: string | null;
+	presence_error?: string | null;
+	lookup_error?: string | null;
+	advertised_addresses?: string[];
+	paired_peer_count?: number;
+	fresh_peer_count?: number;
+	stale_peer_count?: number;
+	discovered_peer_count?: number;
+	discovered_devices?: ApiCoordinatorDiscoveredDevice[];
 	last_sync_at?: string | null;
 	last_error?: string | null;
 }

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -294,6 +294,7 @@ export async function coordinatorStatusSnapshot(
 		fresh_peer_count: 0,
 		stale_peer_count: 0,
 		discovered_peer_count: 0,
+		discovered_devices: [],
 	};
 	const cacheKey = presenceCacheKey(store, config);
 	const now = Date.now();
@@ -337,6 +338,16 @@ export async function coordinatorStatusSnapshot(
 		snapshot.discovered_peer_count = peers.length;
 		snapshot.fresh_peer_count = peers.filter((peer) => !peer.stale).length;
 		snapshot.stale_peer_count = peers.filter((peer) => Boolean(peer.stale)).length;
+		snapshot.discovered_devices = peers.map((peer) => ({
+			device_id: peer.device_id,
+			display_name: peer.display_name ?? null,
+			fingerprint: peer.fingerprint ?? null,
+			addresses: Array.isArray(peer.addresses) ? peer.addresses : [],
+			groups: Array.isArray(peer.groups) ? peer.groups : [],
+			last_seen_at: peer.last_seen_at ?? null,
+			expires_at: peer.expires_at ?? null,
+			stale: Boolean(peer.stale),
+		}));
 	} catch (error) {
 		snapshot.lookup_error = error instanceof Error ? error.message : String(error);
 	}

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -1,7 +1,7 @@
 /* Team sync card — coordinator onboarding, invites, join requests. */
 
 import { el, copyToClipboard } from '../../lib/dom';
-import { state, setFeedScopeFilter } from '../../lib/state';
+import { state, setFeedScopeFilter, isSyncRedactionEnabled } from '../../lib/state';
 import * as api from '../../lib/api';
 import { showGlobalNotice } from '../../lib/notice';
 import { markFieldError, clearFieldError, friendlyError } from '../../lib/form';
@@ -11,6 +11,7 @@ import {
   teamInvitePanelOpen,
   setTeamInvitePanelOpen,
   hideSkeleton,
+  redactAddress,
 } from './helpers';
 
 /* ── DOM placement helpers ───────────────────────────────── */
@@ -105,6 +106,9 @@ export function renderTeamSync() {
   const toggleAdmin = document.getElementById('syncToggleAdmin') as HTMLButtonElement | null;
   const joinPanel = document.getElementById('syncJoinPanel');
   const joinRequests = document.getElementById('syncJoinRequests');
+  const discoveredPanel = document.getElementById('syncCoordinatorDiscovered');
+  const discoveredMeta = document.getElementById('syncCoordinatorDiscoveredMeta');
+  const discoveredList = document.getElementById('syncCoordinatorDiscoveredList');
   if (!meta || !setupPanel || !list || !actions) return;
   hideSkeleton('syncTeamSkeleton');
   // Move panels back to their home sections BEFORE clearing, so they survive the wipe
@@ -113,6 +117,7 @@ export function renderTeamSync() {
   list.textContent = '';
   actions.textContent = '';
   if (joinRequests) joinRequests.textContent = '';
+  if (discoveredList) discoveredList.textContent = '';
   setInviteOutputVisibility();
   const coordinator = state.lastSyncCoordinator;
   const configured = Boolean(coordinator && coordinator.configured);
@@ -124,6 +129,7 @@ export function renderTeamSync() {
     list.hidden = true;
     actions.hidden = true;
     if (joinRequests) joinRequests.hidden = true;
+    if (discoveredPanel) discoveredPanel.hidden = true;
     if (invitePanel) invitePanel.hidden = !adminSetupExpanded;
     if (toggleAdmin) {
       toggleAdmin.textContent = adminSetupExpanded
@@ -136,6 +142,7 @@ export function renderTeamSync() {
   list.hidden = false;
   actions.hidden = false;
   if (joinRequests) joinRequests.hidden = false;
+  if (discoveredPanel) discoveredPanel.hidden = true;
   const presenceLabel =
     coordinator.presence_status === 'posted'
       ? 'Connected'
@@ -152,7 +159,7 @@ export function renderTeamSync() {
   );
   const metricParts = [
     `Paired devices: ${Number(coordinator.paired_peer_count || 0)}`,
-    `Discovered: ${Number(coordinator.fresh_peer_count || 0)}`,
+    `Fresh discovered: ${Number(coordinator.fresh_peer_count || 0)}`,
   ];
   if (Number(coordinator.stale_peer_count || 0) > 0) {
     metricParts.push(`Inactive: ${Number(coordinator.stale_peer_count || 0)}`);
@@ -160,6 +167,68 @@ export function renderTeamSync() {
   statusLine.append(statusLabel, statusBadge);
   statusRow.append(statusLine, el('div', 'sync-team-metrics', metricParts.join(' \u00b7 ')));
   list.appendChild(statusRow);
+
+  const localPeers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
+  const unhealthyPeers = localPeers.filter((peer) => {
+    const status = peer?.status || {};
+    return Boolean(peer?.has_error) || ['offline', 'stale', 'degraded'].includes(String(status.peer_state || ''));
+  });
+  if (unhealthyPeers.length) {
+    const row = el('div', 'sync-action');
+    const textWrap = el('div', 'sync-action-text');
+    textWrap.textContent = `${unhealthyPeers.length} paired device${unhealthyPeers.length === 1 ? '' : 's'} look stale or unhealthy.`;
+    textWrap.appendChild(
+      el('span', 'sync-action-command', 'Use Remove peer in People or codemem sync peers remove <peer> before re-pairing.'),
+    );
+    row.appendChild(textWrap);
+    actions.appendChild(row);
+  }
+
+  const discoveredDevices = Array.isArray(coordinator.discovered_devices)
+    ? coordinator.discovered_devices
+    : [];
+  if (discoveredPanel && discoveredMeta && discoveredList && discoveredDevices.length) {
+    discoveredPanel.hidden = false;
+    discoveredMeta.textContent =
+      'These devices are visible through coordinator discovery only. They are not active sync peers unless you pair them.';
+    discoveredDevices.forEach((device) => {
+      const row = el('div', 'actor-row');
+      const details = el('div', 'actor-details');
+      const title = el('div', 'actor-title');
+      const deviceId = String(device.device_id || '').trim();
+      const displayName = String(device.display_name || '').trim() || deviceId || 'Discovered device';
+      const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || '') === deviceId);
+      title.append(el('strong', null, displayName));
+      title.appendChild(
+        el(
+          'span',
+          `badge actor-badge${device.stale ? '' : ' local'}`,
+          device.stale ? 'Inactive' : 'Fresh',
+        ),
+      );
+      title.appendChild(
+        el('span', 'badge actor-badge', pairedPeer ? 'Paired locally' : 'Not paired locally'),
+      );
+      const addresses = Array.isArray(device.addresses) ? device.addresses : [];
+      const addressLabel = addresses.length
+        ? addresses
+            .map((address) =>
+              isSyncRedactionEnabled() ? redactAddress(String(address || '')) : String(address || ''),
+            )
+            .filter(Boolean)
+            .join(' · ')
+        : 'No fresh addresses';
+      const noteParts = [deviceId, addressLabel];
+      if (pairedPeer?.last_error) {
+        noteParts.push(`paired error: ${String(pairedPeer.last_error)}`);
+      } else if (pairedPeer?.status?.peer_state) {
+        noteParts.push(`paired status: ${String(pairedPeer.status.peer_state)}`);
+      }
+      details.append(title, el('div', 'peer-meta', noteParts.join(' · ')));
+      row.appendChild(details);
+      discoveredList.appendChild(row);
+    });
+  }
 
   const inviteToggleRow = el('div', 'sync-action');
   const inviteToggleText = el('div', 'sync-action-text');

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1618,6 +1618,167 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("returns read-only coordinator discovered devices and counts", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/presence")) {
+					return new Response(JSON.stringify({ ok: true, addresses: ["http://1.2.3.4:7337"] }), {
+						status: 200,
+					});
+				}
+				if (url.includes("/v1/peers")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Fresh Device",
+									fingerprint: "fp-fresh",
+									addresses: ["http://10.0.0.5:7337"],
+									last_seen_at: new Date().toISOString(),
+									expires_at: new Date(Date.now() + 60_000).toISOString(),
+									stale: false,
+								},
+								{
+									device_id: "peer-stale",
+									display_name: "Stale Device",
+									fingerprint: "fp-stale",
+									addresses: [],
+									last_seen_at: new Date().toISOString(),
+									expires_at: new Date(Date.now() - 60_000).toISOString(),
+									stale: true,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, any>;
+				expect(body.coordinator.discovered_peer_count).toBe(2);
+				expect(body.coordinator.fresh_peer_count).toBe(1);
+				expect(body.coordinator.stale_peer_count).toBe(1);
+				expect(body.coordinator.discovered_devices).toEqual([
+					expect.objectContaining({
+						device_id: "peer-fresh",
+						display_name: "Fresh Device",
+						stale: false,
+					}),
+					expect.objectContaining({
+						device_id: "peer-stale",
+						display_name: "Stale Device",
+						stale: true,
+					}),
+				]);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("redacts discovered coordinator device metadata without diagnostics", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/presence")) {
+					return new Response(JSON.stringify({ ok: true, addresses: ["http://1.2.3.4:7337"] }), {
+						status: 200,
+					});
+				}
+				if (url.includes("/v1/peers")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Fresh Device",
+									fingerprint: "fp-fresh",
+									groups: ["team-a"],
+									addresses: ["http://10.0.0.5:7337"],
+									last_seen_at: new Date().toISOString(),
+									expires_at: new Date(Date.now() + 60_000).toISOString(),
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/status");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, any>;
+				expect(body.coordinator.discovered_devices).toEqual([
+					expect.objectContaining({
+						device_id: "peer-fresh",
+						display_name: "Fresh Device",
+						groups: ["team-a"],
+						stale: false,
+						fingerprint: null,
+						addresses: [],
+					}),
+				]);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
 		it("returns real legacy device and sharing review summaries", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -206,6 +206,33 @@ function parseOpPayload(op: { payload_json: string | null }): Record<string, unk
 	}
 }
 
+function redactCoordinatorStatus(
+	coordinator: Record<string, unknown>,
+	showDiag: boolean,
+): Record<string, unknown> {
+	if (showDiag) return coordinator;
+	const discovered = Array.isArray(coordinator.discovered_devices)
+		? coordinator.discovered_devices.map((item) => {
+				if (!item || typeof item !== "object") return item;
+				const record = item as Record<string, unknown>;
+				return {
+					device_id: record.device_id,
+					display_name: record.display_name ?? null,
+					groups: Array.isArray(record.groups) ? record.groups : [],
+					last_seen_at: record.last_seen_at ?? null,
+					expires_at: record.expires_at ?? null,
+					stale: Boolean(record.stale),
+					fingerprint: null,
+					addresses: [],
+				};
+			})
+		: [];
+	return {
+		...coordinator,
+		discovered_devices: discovered,
+	};
+}
+
 function isSharedVisibility(payload: Record<string, unknown> | null): boolean {
 	if (!payload) return false;
 	let visibility = String(payload.visibility ?? "")
@@ -817,7 +844,10 @@ export function syncRoutes(
 			};
 			const legacyDevices = store.claimableLegacyDeviceIds();
 			const sharingReview = store.sharingReviewSummary(project);
-			const coordinator = await coordinatorStatusSnapshot(store, config);
+			const coordinator = redactCoordinatorStatus(
+				await coordinatorStatusSnapshot(store, config),
+				showDiag,
+			);
 			let joinRequests: Record<string, unknown>[] = [];
 			if (includeJoinRequests && config.syncCoordinatorAdminSecret) {
 				try {


### PR DESCRIPTION
## Description
- Extends the sync status payload with a read-only `coordinator.discovered_devices` view derived from existing coordinator lookup results.
- Surfaces coordinator-discovered devices in the Team sync UI without creating peers, acceptance workflows, or new durable state.
- Adds stale/unhealthy peer guidance so operators can see discovery separately from existing broken local peer records.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm vitest run packages/viewer-server/src/index.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
