### PR TITLE
feat(sync): warn on private invite coordinator urls

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1236,6 +1236,9 @@ coordinatorCommand.addCommand(
 				p.log.success(`Invite created for ${groupId}`);
 				if (typeof result.link === "string") p.log.message(`- link: ${result.link}`);
 				if (typeof result.encoded === "string") p.log.message(`- invite: ${result.encoded}`);
+				for (const warning of Array.isArray(result.warnings) ? result.warnings : []) {
+					p.log.warn(String(warning));
+				}
 				p.outro("Invite ready");
 			},
 		),

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -710,8 +710,13 @@ export interface ApiCreateInviteRequest {
 }
 
 /** POST /api/sync/invites/create — response. */
-export interface ApiCreateInviteResponse extends ApiOkResponse {
-	invite: string;
+export interface ApiCreateInviteResponse {
+	group_id: string;
+	encoded: string;
+	link: string;
+	payload: Record<string, unknown>;
+	warnings?: string[];
+	mode?: "local" | "remote";
 }
 
 /** POST /api/sync/invites/import — request. */

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	coordinatorCreateGroupAction,
+	coordinatorCreateInviteAction,
 	coordinatorDisableDeviceAction,
 	coordinatorEnrollDeviceAction,
 	coordinatorListDevicesAction,
@@ -15,13 +16,18 @@ import {
 describe("coordinator local admin actions", () => {
 	let tmpDir: string;
 	let dbPath: string;
+	let prevConfigPath: string | undefined;
 
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "coord-actions-test-"));
 		dbPath = join(tmpDir, "coordinator.sqlite");
+		prevConfigPath = process.env.CODEMEM_CONFIG;
+		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
 	});
 
 	afterEach(() => {
+		if (prevConfigPath == null) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevConfigPath;
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -95,5 +101,59 @@ describe("coordinator local admin actions", () => {
 				dbPath,
 			}),
 		).toThrow("Group not found: missing");
+	});
+
+	it("warns when local invite coordinator URL looks private-only", async () => {
+		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		const invite = await coordinatorCreateInviteAction({
+			groupId: "team-a",
+			coordinatorUrl: "http://100.103.98.49:7347",
+			policy: "auto_admit",
+			ttlHours: 24,
+			dbPath,
+		});
+		expect(invite.warnings).toEqual([
+			"Invite uses a CGNAT/Tailscale-style coordinator IP address. This can be correct for Tailnet-only teams, but other teammates may not be able to join unless they share that network.",
+		]);
+	});
+
+	it("does not warn for public-looking invite coordinator URLs", async () => {
+		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		const invite = await coordinatorCreateInviteAction({
+			groupId: "team-a",
+			coordinatorUrl: "https://coord.example.test",
+			policy: "auto_admit",
+			ttlHours: 24,
+			dbPath,
+		});
+		expect(invite.warnings).toEqual([]);
+	});
+
+	it("warns when local invite coordinator URL uses private IPv6 space", async () => {
+		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		const invite = await coordinatorCreateInviteAction({
+			groupId: "team-a",
+			coordinatorUrl: "http://[fd7a:115c:a1e0::1234]:7347",
+			policy: "auto_admit",
+			ttlHours: 24,
+			dbPath,
+		});
+		expect(invite.warnings).toEqual([
+			"Invite uses a ULA/Tailnet-style coordinator IPv6 address. This can be correct for private-network teams, but other teammates may not be able to join unless they share that network.",
+		]);
+	});
+
+	it("warns when local invite coordinator URL uses link-local IPv6 space", async () => {
+		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		const invite = await coordinatorCreateInviteAction({
+			groupId: "team-a",
+			coordinatorUrl: "http://[fe80::1]:7347",
+			policy: "auto_admit",
+			ttlHours: 24,
+			dbPath,
+		});
+		expect(invite.warnings).toEqual([
+			"Invite uses a link-local coordinator IPv6 address. It usually only works on the same local network segment.",
+		]);
 	});
 });

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -11,7 +11,7 @@ import { CoordinatorStore, DEFAULT_COORDINATOR_DB_PATH } from "./coordinator-sto
 import { connect } from "./db.js";
 import { initDatabase } from "./maintenance.js";
 import { readCodememConfigFile, writeCodememConfigFile } from "./observer-config.js";
-import { requestJson } from "./sync-http-client.js";
+import { buildBaseUrl, requestJson } from "./sync-http-client.js";
 import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
 
 const VALID_INVITE_POLICIES = new Set(["auto_admit", "approval_required"]);
@@ -47,6 +47,86 @@ async function remoteRequest(
 		throw new Error(`Remote coordinator request failed (${status}): ${detail}`);
 	}
 	return payload;
+}
+
+function inviteUrlWarnings(rawUrl: string | null | undefined): string[] {
+	const value = String(rawUrl ?? "").trim();
+	if (!value) return [];
+	let hostname = "";
+	try {
+		hostname = new URL(buildBaseUrl(value)).hostname.trim().toLowerCase();
+	} catch {
+		return [
+			"Coordinator URL could not be parsed. Double-check that teammates can reach it before sharing this invite.",
+		];
+	}
+	hostname = hostname.replace(/^\[/, "").replace(/\]$/, "");
+	if (!hostname) return [];
+	if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") {
+		return [
+			"Invite uses a localhost coordinator URL. It will only work on the same machine unless you replace it with a reachable hostname or IP.",
+		];
+	}
+	if (hostname.endsWith(".local")) {
+		return [
+			"Invite uses a local-network coordinator hostname. Teammates outside that network may not be able to join.",
+		];
+	}
+	if (hostname.includes(":")) {
+		const normalized = hostname.toLowerCase();
+		if (normalized === "::1") {
+			return [
+				"Invite uses a localhost coordinator URL. It will only work on the same machine unless you replace it with a reachable hostname or IP.",
+			];
+		}
+		if (normalized.startsWith("fd7a:115c:a1e0:")) {
+			return [
+				"Invite uses a ULA/Tailnet-style coordinator IPv6 address. This can be correct for private-network teams, but other teammates may not be able to join unless they share that network.",
+			];
+		}
+		if (normalized.startsWith("fc") || normalized.startsWith("fd")) {
+			return [
+				"Invite uses a private-network coordinator IPv6 address. This is fine for LAN-only or VPN-only teams, but teammates outside that network may not be able to join.",
+			];
+		}
+		if (
+			normalized.startsWith("fe8") ||
+			normalized.startsWith("fe9") ||
+			normalized.startsWith("fea") ||
+			normalized.startsWith("feb")
+		) {
+			return [
+				"Invite uses a link-local coordinator IPv6 address. It usually only works on the same local network segment.",
+			];
+		}
+	}
+	const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+	if (!ipv4Match) return [];
+	const octets = ipv4Match.slice(1).map((part) => Number.parseInt(part, 10));
+	if (octets.some((part) => !Number.isFinite(part) || part < 0 || part > 255)) {
+		return [
+			"Invite uses an unusual coordinator IP address. Double-check that teammates can reach it before sharing this invite.",
+		];
+	}
+	const a = octets[0] ?? -1;
+	const b = octets[1] ?? -1;
+	const isPrivate =
+		a === 10 ||
+		(a === 172 && b >= 16 && b <= 31) ||
+		(a === 192 && b === 168) ||
+		a === 127 ||
+		(a === 169 && b === 254);
+	if (isPrivate) {
+		return [
+			"Invite uses a private-network coordinator IP address. This is fine for LAN-only teams, but teammates outside that network may not be able to join.",
+		];
+	}
+	if (a === 100 && b >= 64 && b <= 127) {
+		return [
+			"Invite uses a CGNAT/Tailscale-style coordinator IP address. This can be correct for Tailnet-only teams, but other teammates may not be able to join unless they share that network.",
+		];
+	}
+	return [];
 }
 
 export function coordinatorCreateGroupAction(opts: {
@@ -208,6 +288,7 @@ export async function coordinatorCreateInviteAction(opts: {
 			encoded: payload?.encoded,
 			link: payload?.link,
 			payload: payload?.payload,
+			warnings: inviteUrlWarnings(String(opts.coordinatorUrl || remote)),
 			mode: "remote",
 		};
 	}
@@ -241,6 +322,7 @@ export async function coordinatorCreateInviteAction(opts: {
 			encoded,
 			link: inviteLink(encoded),
 			payload,
+			warnings: inviteUrlWarnings(resolvedCoordinatorUrl),
 			mode: "local",
 		};
 	} finally {

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -424,6 +424,8 @@ export function initTeamSyncEvents(
       syncInviteOutput.focus();
       syncInviteOutput.select();
       showGlobalNotice('Invite created. Copy the text above and share it with your teammate.');
+      const warnings = Array.isArray(result.warnings) ? result.warnings : [];
+      warnings.forEach((warning) => showGlobalNotice(String(warning), 'warning'));
     } catch (error) {
       showGlobalNotice(friendlyError(error, 'Failed to create invite.'), 'warning');
     } finally {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1885,6 +1885,55 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.encoded).toBe("invite-blob");
 				expect(body.link).toBe("https://example.test/invite");
+				expect(body.warnings).toEqual([]);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
+		it("returns invite warnings for private-looking coordinator URLs", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/invites")) {
+					return new Response(
+						JSON.stringify({
+							encoded: "invite-blob",
+							link: "https://example.test/invite",
+							payload: { group_id: "team-a" },
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_coordinator_url: "http://100.103.98.49:7347",
+					sync_coordinator_group: "team-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/invites/create", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ group_id: "team-a", policy: "auto_admit", ttl_hours: 24 }),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.warnings).toEqual([
+					"Invite uses a CGNAT/Tailscale-style coordinator IP address. This can be correct for Tailnet-only teams, but other teammates may not be able to join unless they share that network.",
+				]);
 			} finally {
 				cleanup();
 				globalThis.fetch = prevFetch;


### PR DESCRIPTION
## Description
- Adds warning-only invite safety checks for coordinator URLs that look localhost-only, private-network only, or Tailscale/CGNAT scoped.
- Returns invite warnings from the core invite action and surfaces them through both the CLI and the team-sync UI.
- Keeps the behavior non-blocking because private coordinator URLs can be correct for LAN-only or Tailnet-only teams.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm vitest run packages/core/src/coordinator-actions.test.ts packages/viewer-server/src/index.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
