### PR TITLE
fix(sync): improve invite join timeout diagnostics

### DIFF
--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -15,6 +15,7 @@ import { buildBaseUrl, requestJson } from "./sync-http-client.js";
 import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
 
 const VALID_INVITE_POLICIES = new Set(["auto_admit", "approval_required"]);
+const INVITE_IMPORT_TIMEOUT_S = 10;
 
 function coordinatorRemoteTarget(config = readCodememConfigFile()): {
 	remoteUrl: string | null;
@@ -127,6 +128,23 @@ function inviteUrlWarnings(rawUrl: string | null | undefined): string[] {
 		];
 	}
 	return [];
+}
+
+function inviteImportTransportError(error: unknown, coordinatorUrl: string): Error {
+	const name = typeof error === "object" && error && "name" in error ? String(error.name) : "";
+	const message = error instanceof Error ? error.message : String(error ?? "");
+	const base = buildBaseUrl(coordinatorUrl);
+	if (name === "TimeoutError" || /timed? out/i.test(message)) {
+		return new Error(
+			`Invite import timed out contacting the coordinator at ${base}. Check that this machine can reach that URL and try again.`,
+		);
+	}
+	if (name === "TypeError" || /fetch failed|network/i.test(message)) {
+		return new Error(
+			`Invite import could not reach the coordinator at ${base}. Check the invite URL and this machine's network access before retrying.`,
+		);
+	}
+	return error instanceof Error ? error : new Error(message);
 }
 
 export function coordinatorCreateGroupAction(opts: {
@@ -353,20 +371,26 @@ export async function coordinatorImportInviteAction(opts: {
 	if (!coordinatorUrl) throw new Error("Invite is missing a coordinator URL.");
 	const config = readCodememConfigFile();
 	const displayName = String(config.actor_display_name ?? deviceId).trim() || deviceId;
-	const [status, response] = await requestJson(
-		"POST",
-		`${coordinatorUrl.replace(/\/+$/, "")}/v1/join`,
-		{
-			body: {
-				token: String(payload.token),
-				device_id: deviceId,
-				public_key: publicKey,
-				fingerprint,
-				display_name: displayName,
+	let status = 0;
+	let response: Record<string, unknown> | null = null;
+	try {
+		[status, response] = await requestJson(
+			"POST",
+			`${coordinatorUrl.replace(/\/+$/, "")}/v1/join`,
+			{
+				body: {
+					token: String(payload.token),
+					device_id: deviceId,
+					public_key: publicKey,
+					fingerprint,
+					display_name: displayName,
+				},
+				timeoutS: INVITE_IMPORT_TIMEOUT_S,
 			},
-			timeoutS: 3,
-		},
-	);
+		);
+	} catch (error) {
+		throw inviteImportTransportError(error, coordinatorUrl);
+	}
 	if (status < 200 || status >= 300) {
 		const detail = typeof response?.error === "string" ? response.error : "unknown";
 		throw new Error(`Invite import failed (${status}): ${detail}`);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2001,6 +2001,109 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("returns a clearer timeout error when invite import cannot reach the coordinator in time", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const invitePayload = {
+				v: 1,
+				kind: "coordinator_team_invite",
+				coordinator_url: "https://coord.example.test",
+				group_id: "team-a",
+				policy: "approval_required",
+				token: "tok-123",
+				expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+				team_name: "Team A",
+			};
+			const invite = Buffer.from(JSON.stringify(invitePayload), "utf8").toString("base64url");
+			const fetchMock = vi.fn(async () => {
+				const error = new Error("The operation was aborted due to timeout");
+				Object.assign(error, { name: "TimeoutError" });
+				throw error;
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Adam" }));
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite }),
+				});
+				expect(res.status).toBe(400);
+				expect(await res.json()).toEqual({
+					error:
+						"Invite import timed out contacting the coordinator at https://coord.example.test. Check that this machine can reach that URL and try again.",
+				});
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("returns a clearer reachability error when invite import cannot contact the coordinator", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const invitePayload = {
+				v: 1,
+				kind: "coordinator_team_invite",
+				coordinator_url: "https://coord.example.test",
+				group_id: "team-a",
+				policy: "approval_required",
+				token: "tok-123",
+				expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+				team_name: "Team A",
+			};
+			const invite = Buffer.from(JSON.stringify(invitePayload), "utf8").toString("base64url");
+			const fetchMock = vi.fn(async () => {
+				const error = new TypeError("fetch failed");
+				throw error;
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Adam" }));
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite }),
+				});
+				expect(res.status).toBe(400);
+				expect(await res.json()).toEqual({
+					error:
+						"Invite import could not reach the coordinator at https://coord.example.test. Check the invite URL and this machine's network access before retrying.",
+				});
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
 		it("reviews join requests through the viewer route", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;


### PR DESCRIPTION
## Description
- Replaces the brittle hardcoded 3-second invite import/join timeout with a more reasonable default for real networked deployments.
- Improves invite import diagnostics so timeouts and reachability failures produce actionable messages instead of generic fetch/abort noise.
- Keeps this as a no-knob UX improvement rather than adding new timeout configuration surface.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm vitest run packages/viewer-server/src/index.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
