### PR TITLE
feat(sync): accept discovered peers via coordinator

### DIFF
--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -689,6 +689,22 @@ export interface ApiPeerIdentityResponse {
 	claimed_local_actor: boolean;
 }
 
+/** POST /api/sync/peers/accept-discovered — request. */
+export interface ApiAcceptDiscoveredPeerRequest {
+	peer_device_id: string;
+	fingerprint: string;
+}
+
+/** POST /api/sync/peers/accept-discovered — response. */
+export interface ApiAcceptDiscoveredPeerResponse {
+	ok: true;
+	peer_device_id: string;
+	created: boolean;
+	updated: boolean;
+	name: string | null;
+	needs_scope_review: true;
+}
+
 /** POST /api/sync/legacy-devices/claim — request. */
 export interface ApiClaimLegacyDeviceRequest {
 	origin_device_id: string;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1779,6 +1779,451 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("accepts a discovered coordinator device into sync peers", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/peers")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Fresh Device",
+									fingerprint: "fp-fresh",
+									addresses: ["http://10.0.0.5:7337"],
+									last_seen_at: new Date().toISOString(),
+									expires_at: new Date(Date.now() + 60_000).toISOString(),
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+				});
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({
+					ok: true,
+					peer_device_id: "peer-fresh",
+					created: true,
+					updated: false,
+					name: "Fresh Device",
+					needs_scope_review: true,
+				});
+				const peerRow = store.db
+					.prepare(
+						"SELECT peer_device_id, name, pinned_fingerprint, addresses_json, last_error FROM sync_peers WHERE peer_device_id = ?",
+					)
+					.get("peer-fresh") as Record<string, unknown> | undefined;
+				expect(peerRow).toEqual(
+					expect.objectContaining({
+						peer_device_id: "peer-fresh",
+						name: "Fresh Device",
+						pinned_fingerprint: "fp-fresh",
+						last_error: null,
+					}),
+				);
+				expect(JSON.parse(String(peerRow?.addresses_json ?? "[]"))).toEqual([
+					"http://10.0.0.5:7337",
+				]);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("updates an existing peer when the discovered fingerprint matches", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/peers")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Fresh Device",
+									fingerprint: "fp-fresh",
+									addresses: ["http://10.0.0.5:7337"],
+									last_seen_at: new Date().toISOString(),
+									expires_at: new Date(Date.now() + 60_000).toISOString(),
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, addresses_json, last_error, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+					)
+					.run(
+						"peer-fresh",
+						"Old Name",
+						"fp-fresh",
+						JSON.stringify(["http://old.example:7337"]),
+						"offline",
+						new Date().toISOString(),
+					);
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+				});
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({
+					ok: true,
+					peer_device_id: "peer-fresh",
+					created: false,
+					updated: true,
+					name: "Fresh Device",
+					needs_scope_review: true,
+				});
+				const peerRow = store.db
+					.prepare(
+						"SELECT name, pinned_fingerprint, addresses_json, last_error FROM sync_peers WHERE peer_device_id = ?",
+					)
+					.get("peer-fresh") as Record<string, unknown> | undefined;
+				expect(peerRow).toEqual(
+					expect.objectContaining({
+						name: "Fresh Device",
+						pinned_fingerprint: "fp-fresh",
+						last_error: "offline",
+					}),
+				);
+				expect(JSON.parse(String(peerRow?.addresses_json ?? "[]"))).toEqual([
+					"http://old.example:7337",
+					"http://10.0.0.5:7337",
+				]);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("rejects accepting a discovered device when an existing peer is pinned to another fingerprint", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/peers")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Fresh Device",
+									fingerprint: "fp-new",
+									addresses: ["http://10.0.0.5:7337"],
+									last_seen_at: new Date().toISOString(),
+									expires_at: new Date(Date.now() + 60_000).toISOString(),
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, created_at) VALUES (?, ?, ?, ?)",
+					)
+					.run("peer-fresh", "Old Peer", "fp-old", new Date().toISOString());
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-new" }),
+				});
+				expect(res.status).toBe(409);
+				expect(await res.json()).toEqual({
+					error: "peer_conflict",
+					detail:
+						"An existing peer with this device id is pinned to a different fingerprint. Remove or repair the old peer before accepting this discovered device.",
+				});
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("returns 404 when the discovered device is no longer present", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/peers")) {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+				});
+				expect(res.status).toBe(404);
+				expect(await res.json()).toEqual({
+					error: "discovered_peer_not_found",
+					detail:
+						"That discovered device is no longer available. Refresh sync status and try again.",
+				});
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("returns 400 when coordinator sync is not configured", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(configPath, JSON.stringify({ sync_enabled: false }));
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+				});
+				expect(res.status).toBe(400);
+				expect(await res.json()).toEqual({
+					error: "coordinator_not_configured",
+					detail: "Coordinator must be configured before accepting discovered peers.",
+				});
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
+		it("accepts discovered peers when only plural coordinator groups are configured", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/peers?group_id=team-a")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Fresh Device",
+									fingerprint: "fp-fresh",
+									addresses: ["http://10.0.0.5:7337"],
+									last_seen_at: new Date().toISOString(),
+									expires_at: new Date(Date.now() + 60_000).toISOString(),
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_groups: ["team-a"],
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+				});
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual(
+					expect.objectContaining({
+						ok: true,
+						peer_device_id: "peer-fresh",
+						created: true,
+						updated: false,
+						name: "Fresh Device",
+						needs_scope_review: true,
+					}),
+				);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
+		it("returns 502 when coordinator lookup fails during acceptance", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(
+				async () => new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 }),
+			);
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/peers/accept-discovered", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-fresh", fingerprint: "fp-fresh" }),
+				});
+				expect(res.status).toBe(502);
+				expect(await res.json()).toEqual({
+					error: "coordinator_lookup_failed",
+					detail: "coordinator lookup failed (401: unauthorized)",
+				});
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
 		it("returns real legacy device and sharing review summaries", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -21,6 +21,8 @@ import {
 	listCoordinatorJoinRequests,
 	loadMemorySnapshotPageForPeer,
 	loadReplicationOpsForPeer,
+	lookupCoordinatorPeers,
+	mergeAddresses,
 	readCoordinatorSyncConfig,
 	recordNonce,
 	schema,
@@ -231,6 +233,116 @@ function redactCoordinatorStatus(
 		...coordinator,
 		discovered_devices: discovered,
 	};
+}
+
+async function acceptDiscoveredPeer(
+	store: MemoryStore,
+	input: { peerDeviceId: string; fingerprint: string },
+): Promise<
+	| { ok: true; peer_device_id: string; created: boolean; updated: boolean; name: string | null }
+	| { ok: false; status: number; error: string; detail: string }
+> {
+	const config = readCoordinatorSyncConfig();
+	if (
+		!config.syncEnabled ||
+		!config.syncCoordinatorUrl ||
+		config.syncCoordinatorGroups.length === 0
+	) {
+		return {
+			ok: false,
+			status: 400,
+			error: "coordinator_not_configured",
+			detail: "Coordinator must be configured before accepting discovered peers.",
+		};
+	}
+	const discovered = await lookupCoordinatorPeers(store, config);
+	const match = discovered.find(
+		(peer) =>
+			String(peer.device_id ?? "").trim() === input.peerDeviceId &&
+			String(peer.fingerprint ?? "").trim() === input.fingerprint,
+	);
+	if (!match) {
+		return {
+			ok: false,
+			status: 404,
+			error: "discovered_peer_not_found",
+			detail: "That discovered device is no longer available. Refresh sync status and try again.",
+		};
+	}
+	const nextFingerprint = String(match.fingerprint ?? "").trim();
+	const nextName = String(match.display_name ?? "").trim() || null;
+	const nextAddresses = Array.isArray(match.addresses)
+		? match.addresses.filter((value): value is string => typeof value === "string")
+		: [];
+	const d = drizzle(store.db, { schema });
+	const now = new Date().toISOString();
+	return store.db.transaction(() => {
+		const existing = d
+			.select({
+				peer_device_id: schema.syncPeers.peer_device_id,
+				pinned_fingerprint: schema.syncPeers.pinned_fingerprint,
+				addresses_json: schema.syncPeers.addresses_json,
+			})
+			.from(schema.syncPeers)
+			.where(eq(schema.syncPeers.peer_device_id, input.peerDeviceId))
+			.get();
+		const existingFingerprint = String(existing?.pinned_fingerprint ?? "").trim();
+		if (existing && existingFingerprint && existingFingerprint !== nextFingerprint) {
+			return {
+				ok: false as const,
+				status: 409,
+				error: "peer_conflict",
+				detail:
+					"An existing peer with this device id is pinned to a different fingerprint. Remove or repair the old peer before accepting this discovered device.",
+			};
+		}
+		const existingAddresses = (() => {
+			try {
+				const raw = JSON.parse(String(existing?.addresses_json ?? "[]"));
+				return Array.isArray(raw)
+					? raw.filter((value): value is string => typeof value === "string")
+					: [];
+			} catch {
+				return [];
+			}
+		})();
+		const addressesJson = JSON.stringify(mergeAddresses(existingAddresses, nextAddresses));
+		if (!existing) {
+			d.insert(schema.syncPeers)
+				.values({
+					peer_device_id: input.peerDeviceId,
+					name: nextName,
+					pinned_fingerprint: nextFingerprint || null,
+					addresses_json: addressesJson,
+					created_at: now,
+					last_seen_at: now,
+				})
+				.run();
+			return {
+				ok: true as const,
+				peer_device_id: input.peerDeviceId,
+				created: true,
+				updated: false,
+				name: nextName,
+			};
+		}
+		d.update(schema.syncPeers)
+			.set({
+				name: nextName,
+				pinned_fingerprint: nextFingerprint || existing.pinned_fingerprint || null,
+				addresses_json: addressesJson,
+				last_seen_at: now,
+			})
+			.where(eq(schema.syncPeers.peer_device_id, input.peerDeviceId))
+			.run();
+		return {
+			ok: true as const,
+			peer_device_id: input.peerDeviceId,
+			created: false,
+			updated: true,
+			name: nextName,
+		};
+	})();
 }
 
 function isSharedVisibility(payload: Record<string, unknown> | null): boolean {
@@ -1052,6 +1164,45 @@ export function syncRoutes(
 				.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
 				.run();
 			return c.json({ ok: true });
+		}
+	});
+
+	app.post("/api/sync/peers/accept-discovered", async (c) => {
+		const store = getStore();
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const peerDeviceId = String(body.peer_device_id ?? "").trim();
+		const fingerprint = String(body.fingerprint ?? "").trim();
+		if (!peerDeviceId) return c.json({ error: "peer_device_id required" }, 400);
+		if (!fingerprint) return c.json({ error: "fingerprint required" }, 400);
+		try {
+			const result = await acceptDiscoveredPeer(store, { peerDeviceId, fingerprint });
+			if (!result.ok) {
+				return c.json(
+					{ error: result.error, detail: result.detail },
+					{ status: result.status as 400 | 404 | 409 },
+				);
+			}
+			return c.json({
+				ok: true,
+				peer_device_id: result.peer_device_id,
+				created: result.created,
+				updated: result.updated,
+				name: result.name,
+				needs_scope_review: true,
+			});
+		} catch (error) {
+			return c.json(
+				{
+					error: "coordinator_lookup_failed",
+					detail: error instanceof Error ? error.message : String(error),
+				},
+				{ status: 502 },
+			);
 		}
 	});
 


### PR DESCRIPTION
## Description
- Adds a backend acceptance route for coordinator-discovered devices: `POST /api/sync/peers/accept-discovered`.
- Creates or updates a real `sync_peer` only when the discovered device fingerprint matches, and returns a 409 conflict instead of silently overwriting an existing peer pinned to a different fingerprint.
- Keeps the slice read-model only: no durable suggestion state, no auto-peering, and no scope workflow engine; the response only signals that scope review is still needed.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm vitest run packages/viewer-server/src/index.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
