### PR TITLE
feat(sync): accept discovered peers from team sync

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -226,6 +226,26 @@ export async function deletePeer(peerDeviceId: string): Promise<any> {
   return payload;
 }
 
+export async function acceptDiscoveredPeer(peerDeviceId: string, fingerprint: string): Promise<any> {
+  const resp = await fetch('/api/sync/peers/accept-discovered', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      peer_device_id: peerDeviceId,
+      fingerprint,
+    }),
+  });
+  const text = await resp.text();
+  let payload: any = {};
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    payload = {};
+  }
+  if (!resp.ok) throw new Error(payload?.detail || payload?.error || text || 'request failed');
+  return payload;
+}
+
 export async function createActor(displayName: string): Promise<any> {
   const resp = await fetch('/api/sync/actors', {
     method: 'POST',

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -23,6 +23,21 @@ export function setTeamInvitePanelOpen(v: boolean) {
 }
 
 export const openPeerScopeEditors = new Set<string>();
+const pendingPeerScopeReviewIds = new Set<string>();
+
+export function requestPeerScopeReview(peerDeviceId: string) {
+  const value = String(peerDeviceId || '').trim();
+  if (!value) return;
+  pendingPeerScopeReviewIds.add(value);
+  openPeerScopeEditors.add(value);
+}
+
+export function consumePeerScopeReviewRequest(peerDeviceId: string): boolean {
+  const value = String(peerDeviceId || '').trim();
+  if (!value || !pendingPeerScopeReviewIds.has(value)) return false;
+  pendingPeerScopeReviewIds.delete(value);
+  return true;
+}
 
 /* ── Text helpers ────────────────────────────────────────── */
 

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -17,6 +17,7 @@ import {
   actorMergeNote,
   createChipEditor,
   openPeerScopeEditors,
+  consumePeerScopeReviewRequest,
   hideSkeleton,
 } from './helpers';
 
@@ -328,6 +329,7 @@ export function renderSyncPeers() {
     const includeEditor = createChipEditor(includeList, 'Add included project', 'All projects');
     const excludeEditor = createChipEditor(excludeList, 'Add excluded project', 'No exclusions');
     const scopeEditorOpen = openPeerScopeEditors.has(peerId);
+    const scopeReviewRequested = consumePeerScopeReviewRequest(peerId);
     const editorWrap = el('div', `peer-scope-editor-wrap${scopeEditorOpen ? '' : ' collapsed'}`);
     if (!scopeEditorOpen) editorWrap.inert = true;
     const inputRow = el('div', 'peer-scope-row');
@@ -383,6 +385,16 @@ export function renderSyncPeers() {
       toggleScopeBtn.setAttribute('aria-expanded', String(isCollapsed));
       toggleScopeBtn.textContent = isCollapsed ? 'Hide scope editor' : 'Edit scope';
     });
+    if (scopeReviewRequested) {
+      scopePanel.prepend(
+        el(
+          'div',
+          'peer-meta',
+          'Review this device\'s sync scope now. Global defaults apply until you save an override here.',
+        ),
+      );
+      queueMicrotask(() => card.scrollIntoView({ block: 'center', behavior: 'smooth' }));
+    }
     scopePanel.append(identityRow, identityMeta, actorRow, actorHint, scopeSummary, effectiveSummary, editorWrap);
 
     titleRow.append(name, actions);

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -12,6 +12,7 @@ import {
   setTeamInvitePanelOpen,
   hideSkeleton,
   redactAddress,
+  requestPeerScopeReview,
 } from './helpers';
 
 /* ── DOM placement helpers ───────────────────────────────── */
@@ -195,9 +196,14 @@ export function renderTeamSync() {
       const row = el('div', 'actor-row');
       const details = el('div', 'actor-details');
       const title = el('div', 'actor-title');
+      const rowActions = el('div', 'actor-actions');
       const deviceId = String(device.device_id || '').trim();
       const displayName = String(device.display_name || '').trim() || deviceId || 'Discovered device';
+      const fingerprint = String(device.fingerprint || '').trim();
       const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || '') === deviceId);
+      const pairedFingerprint = String(pairedPeer?.fingerprint || '').trim();
+      const hasConflict = Boolean(pairedPeer) && Boolean(fingerprint) && Boolean(pairedFingerprint) && pairedFingerprint !== fingerprint;
+      const canAccept = Boolean(deviceId) && Boolean(fingerprint) && !pairedPeer && !device.stale;
       title.append(el('strong', null, displayName));
       title.appendChild(
         el(
@@ -207,7 +213,11 @@ export function renderTeamSync() {
         ),
       );
       title.appendChild(
-        el('span', 'badge actor-badge', pairedPeer ? 'Paired locally' : 'Not paired locally'),
+        el(
+          'span',
+          'badge actor-badge',
+          hasConflict ? 'Conflicts with local peer' : pairedPeer ? 'Paired locally' : 'Not paired locally',
+        ),
       );
       const addresses = Array.isArray(device.addresses) ? device.addresses : [];
       const addressLabel = addresses.length
@@ -219,13 +229,43 @@ export function renderTeamSync() {
             .join(' · ')
         : 'No fresh addresses';
       const noteParts = [deviceId, addressLabel];
-      if (pairedPeer?.last_error) {
+      if (hasConflict) {
+        noteParts.push('repair the local peer before accepting this discovered device');
+      } else if (pairedPeer?.last_error) {
         noteParts.push(`paired error: ${String(pairedPeer.last_error)}`);
       } else if (pairedPeer?.status?.peer_state) {
         noteParts.push(`paired status: ${String(pairedPeer.status.peer_state)}`);
       }
       details.append(title, el('div', 'peer-meta', noteParts.join(' · ')));
-      row.appendChild(details);
+      if (canAccept) {
+        const acceptBtn = el('button', 'settings-button', 'Accept peer') as HTMLButtonElement;
+        acceptBtn.addEventListener('click', async () => {
+          acceptBtn.disabled = true;
+          acceptBtn.textContent = 'Accepting…';
+          try {
+            await api.acceptDiscoveredPeer(deviceId, fingerprint);
+            requestPeerScopeReview(deviceId);
+            showGlobalNotice(
+              `Accepted ${displayName}. Its scope editor is now open in People so you can review sync scope next.`,
+            );
+            await _loadSyncData();
+          } catch (error) {
+            showGlobalNotice(friendlyError(error, 'Failed to accept discovered peer.'), 'warning');
+            acceptBtn.textContent = 'Retry accept';
+          } finally {
+            acceptBtn.disabled = false;
+            if (acceptBtn.textContent === 'Accepting…') acceptBtn.textContent = 'Accept peer';
+          }
+        });
+        rowActions.appendChild(acceptBtn);
+      } else if (!pairedPeer && device.stale) {
+        rowActions.appendChild(el('div', 'peer-meta', 'Wait for a fresh coordinator presence update.'));
+      } else if (hasConflict) {
+        rowActions.appendChild(el('div', 'peer-meta', 'Remove or repair the conflicting local peer in People first.'));
+      } else if (pairedPeer) {
+        rowActions.appendChild(el('div', 'peer-meta', 'Manage this peer in People.'));
+      }
+      row.append(details, rowActions);
       discoveredList.appendChild(row);
     });
   }


### PR DESCRIPTION
## Description
- Adds an **Accept peer** action to coordinator-discovered devices in the Team sync UI.
- Uses the new backend acceptance route from PR 461 and refreshes sync state after success.
- Keeps the flow explicit: no auto-sync, no durable suggestion state, and no new workflow engine; the UI instead points users to People to review scope next.
- Distinguishes a conflicting local peer from a valid existing pairing so users are told to repair/remove stale local state instead of being told everything is already fine.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
