### PR TITLE
feat(sync): highlight pending scope review for accepted peers

### DIFF
--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -24,18 +24,31 @@ export function setTeamInvitePanelOpen(v: boolean) {
 
 export const openPeerScopeEditors = new Set<string>();
 const pendingPeerScopeReviewIds = new Set<string>();
+const freshPeerScopeReviewIds = new Set<string>();
 
 export function requestPeerScopeReview(peerDeviceId: string) {
   const value = String(peerDeviceId || '').trim();
   if (!value) return;
   pendingPeerScopeReviewIds.add(value);
+  freshPeerScopeReviewIds.add(value);
   openPeerScopeEditors.add(value);
+}
+
+export function isPeerScopeReviewPending(peerDeviceId: string): boolean {
+  const value = String(peerDeviceId || '').trim();
+  return Boolean(value) && pendingPeerScopeReviewIds.has(value);
+}
+
+export function clearPeerScopeReview(peerDeviceId: string) {
+  const value = String(peerDeviceId || '').trim();
+  if (!value) return;
+  pendingPeerScopeReviewIds.delete(value);
 }
 
 export function consumePeerScopeReviewRequest(peerDeviceId: string): boolean {
   const value = String(peerDeviceId || '').trim();
-  if (!value || !pendingPeerScopeReviewIds.has(value)) return false;
-  pendingPeerScopeReviewIds.delete(value);
+  if (!value || !freshPeerScopeReviewIds.has(value)) return false;
+  freshPeerScopeReviewIds.delete(value);
   return true;
 }
 

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -16,6 +16,8 @@ import {
   mergeTargetActors,
   actorMergeNote,
   createChipEditor,
+  clearPeerScopeReview,
+  isPeerScopeReviewPending,
   openPeerScopeEditors,
   consumePeerScopeReviewRequest,
   hideSkeleton,
@@ -198,6 +200,7 @@ export function renderSyncPeers() {
     const peerId = peer.peer_device_id ? String(peer.peer_device_id) : '';
     const displayName = peer.name || (peerId ? peerId.slice(0, 8) : 'unknown');
     const destructiveLabel = peer.name || peerId || displayName;
+    const pendingScopeReview = isPeerScopeReviewPending(peerId);
     const name = el('strong', null, displayName);
     if (peerId) name.title = peerId;
 
@@ -205,6 +208,9 @@ export function renderSyncPeers() {
     const online = peerStatus.sync_status === 'ok' || peerStatus.ping_status === 'ok';
     const badge = el('span', `badge ${online ? 'badge-online' : 'badge-offline'}`, online ? 'Online' : 'Offline');
     name.append(' ', badge);
+    if (pendingScopeReview) {
+      name.append(' ', el('span', 'badge actor-badge', 'Needs scope review'));
+    }
 
     const actions = el('div', 'peer-actions');
     const primaryAddress = pickPrimaryAddress(peer.addresses);
@@ -346,6 +352,7 @@ export function renderSyncPeers() {
       saveScopeBtn.textContent = 'Saving\u2026';
       try {
         await api.updatePeerScope(peerId, includeEditor.values(), excludeEditor.values());
+        clearPeerScopeReview(peerId);
         showGlobalNotice('Device sync scope saved.');
         await _loadSyncData();
       } catch (error) {
@@ -361,6 +368,7 @@ export function renderSyncPeers() {
       inheritBtn.textContent = 'Resetting\u2026';
       try {
         await api.updatePeerScope(peerId, null, null, true);
+        clearPeerScopeReview(peerId);
         showGlobalNotice('Device sync scope reset to global defaults.');
         await _loadSyncData();
       } catch (error) {
@@ -394,6 +402,14 @@ export function renderSyncPeers() {
         ),
       );
       queueMicrotask(() => card.scrollIntoView({ block: 'center', behavior: 'smooth' }));
+    } else if (pendingScopeReview) {
+      scopePanel.prepend(
+        el(
+          'div',
+          'peer-meta',
+          'Scope review still pending. Save an override here or reset to global scope when you are done reviewing.',
+        ),
+      );
     }
     scopePanel.append(identityRow, identityMeta, actorRow, actorHint, scopeSummary, effectiveSummary, editorWrap);
 

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -11,6 +11,7 @@ import {
   teamInvitePanelOpen,
   setTeamInvitePanelOpen,
   hideSkeleton,
+  isPeerScopeReviewPending,
   redactAddress,
   requestPeerScopeReview,
 } from './helpers';
@@ -231,6 +232,8 @@ export function renderTeamSync() {
       const noteParts = [deviceId, addressLabel];
       if (hasConflict) {
         noteParts.push('repair the local peer before accepting this discovered device');
+      } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
+        noteParts.push('scope review pending in People');
       } else if (pairedPeer?.last_error) {
         noteParts.push(`paired error: ${String(pairedPeer.last_error)}`);
       } else if (pairedPeer?.status?.peer_state) {
@@ -262,6 +265,8 @@ export function renderTeamSync() {
         rowActions.appendChild(el('div', 'peer-meta', 'Wait for a fresh coordinator presence update.'));
       } else if (hasConflict) {
         rowActions.appendChild(el('div', 'peer-meta', 'Remove or repair the conflicting local peer in People first.'));
+      } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
+        rowActions.appendChild(el('div', 'peer-meta', 'Review this peer\'s scope in People next.'));
       } else if (pairedPeer) {
         rowActions.appendChild(el('div', 'peer-meta', 'Manage this peer in People.'));
       }


### PR DESCRIPTION
## Description
- Makes accepted peers visibly incomplete until scope review is finished, without adding any durable onboarding state.
- Shows a pending-scope-review badge and hint on accepted peers in People, and clears that transient state once the user saves or resets scope.
- Reflects the same pending state in Team sync so acceptance no longer looks fully done the moment the peer is created.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
