### PR TITLE
feat(sync): warn before syncing peers pending scope review

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -304,9 +304,17 @@ export async function loadProjects(): Promise<string[]> {
 
 export async function triggerSync(address?: string): Promise<void> {
   const payload = address ? { address } : {};
-  await fetch('/api/sync/run', {
+  const resp = await fetch('/api/sync/run', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
+  const text = await resp.text();
+  let body: any = {};
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = {};
+  }
+  if (!resp.ok) throw new Error(body?.error || text || 'request failed');
 }

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -217,13 +217,28 @@ export function renderSyncPeers() {
     const syncBtn = el('button', null, 'Sync now') as HTMLButtonElement;
     syncBtn.disabled = !primaryAddress;
     syncBtn.addEventListener('click', async () => {
+      if (pendingScopeReview) {
+        const proceed = window.confirm(
+          `Sync scope review is still pending for ${displayName}. Continue with a manual sync anyway?`,
+        );
+        if (!proceed) return;
+      }
       syncBtn.disabled = true;
       syncBtn.textContent = 'Syncing\u2026';
       try {
         await api.triggerSync(primaryAddress);
-      } catch {}
-      syncBtn.disabled = false;
-      syncBtn.textContent = 'Sync now';
+        if (pendingScopeReview) {
+          showGlobalNotice(
+            `Triggered sync for ${displayName} before scope review was finished. Review scope in this card if you want tighter sharing rules.`,
+            'warning',
+          );
+        }
+      } catch (error) {
+        showGlobalNotice(friendlyError(error, 'Failed to trigger sync.'), 'warning');
+      } finally {
+        syncBtn.disabled = false;
+        syncBtn.textContent = 'Sync now';
+      }
     });
     actions.appendChild(syncBtn);
     const removeBtn = el('button', null, 'Remove peer') as HTMLButtonElement;
@@ -407,7 +422,7 @@ export function renderSyncPeers() {
         el(
           'div',
           'peer-meta',
-          'Scope review still pending. Save an override here or reset to global scope when you are done reviewing.',
+          'Scope review still pending. Save an override here or reset to global scope when you are done reviewing. Manual syncs can proceed, but they will use the current effective scope until you change it.',
         ),
       );
     }


### PR DESCRIPTION
## Description
- Adds a lightweight manual-sync warning when a peer still has pending scope review.
- Keeps sync available, but warns before proceeding and reminds the user that the current effective scope still applies until they review it.
- Extends the pending-scope-review hint in People so the guardrail is visible both before and during the manual sync action.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
