### PR TITLE
feat(sync): add conflict repair actions for discovered peers

### DIFF
--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -198,6 +198,7 @@ export function renderSyncPeers() {
     const card = el('div', 'peer-card');
     const titleRow = el('div', 'peer-title');
     const peerId = peer.peer_device_id ? String(peer.peer_device_id) : '';
+    if (peerId) card.dataset.peerDeviceId = peerId;
     const displayName = peer.name || (peerId ? peerId.slice(0, 8) : 'unknown');
     const destructiveLabel = peer.name || peerId || displayName;
     const pendingScopeReview = isPeerScopeReviewPending(peerId);

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -264,7 +264,42 @@ export function renderTeamSync() {
       } else if (!pairedPeer && device.stale) {
         rowActions.appendChild(el('div', 'peer-meta', 'Wait for a fresh coordinator presence update.'));
       } else if (hasConflict) {
-        rowActions.appendChild(el('div', 'peer-meta', 'Remove or repair the conflicting local peer in People first.'));
+        const inspectBtn = el('button', 'settings-button', 'Jump to local peer') as HTMLButtonElement;
+        inspectBtn.addEventListener('click', () => {
+          const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(deviceId)}"]`);
+          if (peerCard instanceof HTMLElement) {
+            peerCard.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            showGlobalNotice(`Jumped to the conflicting local peer for ${displayName}.`, 'warning');
+            return;
+          }
+          showGlobalNotice('Conflicting local peer is not visible yet. Scroll to the People area and try again.', 'warning');
+        });
+        const removeConflictBtn = el('button', 'settings-button', 'Remove conflicting peer') as HTMLButtonElement;
+        removeConflictBtn.addEventListener('click', async () => {
+          if (!pairedPeer) return;
+          const confirmed = window.confirm(
+            `Remove the conflicting local peer for ${displayName}? You can accept the discovered device again after this refreshes.`,
+          );
+          if (!confirmed) return;
+          removeConflictBtn.disabled = true;
+          inspectBtn.disabled = true;
+          removeConflictBtn.textContent = 'Removing…';
+          try {
+            await api.deletePeer(deviceId);
+            showGlobalNotice(`Removed the conflicting local peer for ${displayName}. If it is still fresh, you can now accept it from Team sync.`);
+            await _loadSyncData();
+          } catch (error) {
+            showGlobalNotice(friendlyError(error, 'Failed to remove the conflicting local peer.'), 'warning');
+            removeConflictBtn.textContent = 'Retry remove';
+          } finally {
+            removeConflictBtn.disabled = false;
+            inspectBtn.disabled = false;
+            if (removeConflictBtn.textContent === 'Removing…') {
+              removeConflictBtn.textContent = 'Remove conflicting peer';
+            }
+          }
+        });
+        rowActions.append(inspectBtn, removeConflictBtn);
       } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
         rowActions.appendChild(el('div', 'peer-meta', 'Review this peer\'s scope in People next.'));
       } else if (pairedPeer) {


### PR DESCRIPTION
## Description
- Makes discovered/local fingerprint conflicts actionable from Team sync.
- Adds direct repair actions for conflict rows: jump to the existing local peer in People or remove the conflicting local peer in place.
- Keeps the flow explicit and reversible: no silent overwrite, no auto-delete+accept chain, and no new durable conflict state.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
