### PR TITLE
feat(sync): clarify manual sync feedback

### DIFF
--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -233,9 +233,19 @@ export function renderSyncPeers() {
             `Triggered sync for ${displayName} before scope review was finished. Review scope in this card if you want tighter sharing rules.`,
             'warning',
           );
+        } else {
+          showGlobalNotice(`Started sync with ${displayName}.`);
         }
       } catch (error) {
         showGlobalNotice(friendlyError(error, 'Failed to trigger sync.'), 'warning');
+        syncBtn.disabled = false;
+        syncBtn.textContent = 'Sync now';
+        return;
+      }
+      try {
+        await _loadSyncData();
+      } catch {
+        showGlobalNotice('Sync started, but the local status view did not refresh yet.', 'warning');
       } finally {
         syncBtn.disabled = false;
         syncBtn.textContent = 'Sync now';


### PR DESCRIPTION
## Description
- Improves feedback after manual peer sync actions so the UI acknowledges a successful trigger without pretending sync completed.
- Shows a lightweight success notice after trigger success, then refreshes local sync status once.
- Separates trigger failure from refresh failure so users do not get misleading "failed to trigger" messaging when the refresh is the only thing that failed.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- TS validation used for this slice:
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
