### PR TITLE
chore(release): prepare 0.22.0-alpha.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.21.2"
+    "version": "0.22.0-alpha.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.21.2",
+      "version": "0.22.0-alpha.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/lib/compat.js
+++ b/packages/cli/.opencode/lib/compat.js
@@ -37,8 +37,8 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
 
   if (normalizedRunner === "uv") {
     return {
-      mode: "uv-dev",
-      action: "In your codemem repo, pull latest changes and run `uv sync`, then restart OpenCode.",
+      mode: "repo-dev",
+      action: "In your codemem repo, pull latest changes and run `pnpm install` and `pnpm build`, then restart OpenCode.",
       note: "detected dev repo mode",
     };
   }
@@ -60,7 +60,7 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
 
   return {
     mode: "generic",
-    action: "Run `uv tool install --upgrade codemem`, then restart OpenCode.",
+    action: "Update codemem using your normal install method, then restart OpenCode.",
     note: "fallback guidance",
   };
 };
@@ -138,34 +138,18 @@ export const resolveAutoUpdatePlan = ({ runner, runnerFrom }) => {
   }
 
   if (normalizedRunner === "uvx") {
-    if (!source) {
-      return {
-        allowed: false,
-        reason: "missing-source",
-        command: null,
-        commandText: null,
-      };
-    }
-    if (isPinnedGitSource(source)) {
-      return {
-        allowed: false,
-        reason: "pinned-source",
-        command: null,
-        commandText: null,
-      };
-    }
     return {
-      allowed: true,
-      reason: null,
-      command: ["uvx", "--refresh", "--from", source, "codemem", "version"],
-      commandText: "uvx --refresh --from <source> codemem version",
+      allowed: false,
+      reason: !source ? "missing-source" : isPinnedGitSource(source) ? "pinned-source" : "custom-source",
+      command: null,
+      commandText: null,
     };
   }
 
   return {
     allowed: true,
     reason: null,
-    command: ["uv", "tool", "install", "--upgrade", "codemem"],
-    commandText: "uv tool install --upgrade codemem",
+    command: ["npm", "install", "-g", "codemem@latest"],
+    commandText: "npm install -g codemem@latest",
   };
 };

--- a/packages/cli/.opencode/tests/compat.test.js
+++ b/packages/cli/.opencode/tests/compat.test.js
@@ -33,13 +33,14 @@ describe("isVersionAtLeast", () => {
 });
 
 describe("resolveUpgradeGuidance", () => {
-  test("returns uv-dev guidance", () => {
+  test("returns repo-dev guidance for local dev runner", () => {
     const guidance = resolveUpgradeGuidance({
       runner: "uv",
       runnerFrom: "/tmp/codemem",
     });
-    expect(guidance.mode).toBe("uv-dev");
-    expect(guidance.action).toContain("uv sync");
+    expect(guidance.mode).toBe("repo-dev");
+    expect(guidance.action).toContain("pnpm install");
+    expect(guidance.action).toContain("pnpm build");
   });
 
   test("returns uvx-git guidance", () => {
@@ -61,11 +62,11 @@ describe("resolveUpgradeGuidance", () => {
 
   test("returns generic fallback guidance", () => {
     const guidance = resolveUpgradeGuidance({
-      runner: "node",
+      runner: "other",
       runnerFrom: "",
     });
-    expect(guidance.mode).toBe("node-dev");
-    expect(guidance.action).toContain("pnpm build");
+    expect(guidance.mode).toBe("generic");
+    expect(guidance.action).toContain("normal install method");
   });
 });
 
@@ -96,20 +97,14 @@ describe("resolveAutoUpdatePlan", () => {
     expect(plan.reason).toBe("dev-runner");
   });
 
-  test("returns uvx refresh command for unpinned git source", () => {
+  test("blocks auto-update for unpinned git source", () => {
     const plan = resolveAutoUpdatePlan({
       runner: "uvx",
       runnerFrom: "git+https://github.com/kunickiaj/codemem.git",
     });
-    expect(plan.allowed).toBe(true);
-    expect(plan.command).toEqual([
-      "uvx",
-      "--refresh",
-      "--from",
-      "git+https://github.com/kunickiaj/codemem.git",
-      "codemem",
-      "version",
-    ]);
+    expect(plan.allowed).toBe(false);
+    expect(plan.reason).toBe("custom-source");
+    expect(plan.command).toBeNull();
   });
 
   test("blocks auto-update for pinned git source", () => {
@@ -121,12 +116,13 @@ describe("resolveAutoUpdatePlan", () => {
     expect(plan.reason).toBe("pinned-source");
   });
 
-  test("allows unpinned ssh git source", () => {
+  test("blocks unpinned ssh git source", () => {
     const plan = resolveAutoUpdatePlan({
       runner: "uvx",
       runnerFrom: "git+ssh://git@github.com/kunickiaj/codemem.git",
     });
-    expect(plan.allowed).toBe(true);
+    expect(plan.allowed).toBe(false);
+    expect(plan.reason).toBe("custom-source");
   });
 
   test("blocks pinned ssh git source", () => {
@@ -144,12 +140,13 @@ describe("resolveAutoUpdatePlan", () => {
     expect(plan.reason).toBe("missing-source");
   });
 
-  test("allows unpinned git source with query string", () => {
+  test("blocks unpinned git source with query string", () => {
     const plan = resolveAutoUpdatePlan({
       runner: "uvx",
       runnerFrom: "git+https://github.com/kunickiaj/codemem.git?subdirectory=plugin",
     });
-    expect(plan.allowed).toBe(true);
+    expect(plan.allowed).toBe(false);
+    expect(plan.reason).toBe("custom-source");
   });
 
   test("blocks pinned git source with fragment", () => {

--- a/packages/cli/.opencode/tests/plugin-adapter.test.js
+++ b/packages/cli/.opencode/tests/plugin-adapter.test.js
@@ -312,7 +312,7 @@ describe("opencode adapter event mapping", () => {
     expect(args).toEqual(["-y", `codemem@${__testUtils.PINNED_BACKEND_VERSION}`]);
   });
 
-  test("pinned backend version matches package version", () => {
+  test("pinned backend version remains on the latest stable backend during alpha releases", () => {
     const packageJsonPath = resolve(
       fileURLToPath(new URL(".", import.meta.url)),
       "..",
@@ -321,6 +321,7 @@ describe("opencode adapter event mapping", () => {
     );
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 
-    expect(__testUtils.PINNED_BACKEND_VERSION).toBe(packageJson.version);
+    expect(packageJson.version).toBe("0.22.0-alpha.0");
+    expect(__testUtils.PINNED_BACKEND_VERSION).toBe("0.21.2");
   });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.21.2",
+	"version": "0.22.0-alpha.0",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.21.2",
+	"version": "0.22.0-alpha.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.21.2");
+		expect(VERSION).toBe("0.22.0-alpha.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.21.2";
+export const VERSION = "0.22.0-alpha.0";
 
 export * as Api from "./api-types.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.21.2",
+	"version": "0.22.0-alpha.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/lib/compat.js
+++ b/packages/opencode-plugin/.opencode/lib/compat.js
@@ -37,8 +37,8 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
 
   if (normalizedRunner === "uv") {
     return {
-      mode: "uv-dev",
-      action: "In your codemem repo, pull latest changes and run `uv sync`, then restart OpenCode.",
+      mode: "repo-dev",
+      action: "In your codemem repo, pull latest changes and run `pnpm install` and `pnpm build`, then restart OpenCode.",
       note: "detected dev repo mode",
     };
   }
@@ -60,7 +60,7 @@ export const resolveUpgradeGuidance = ({ runner, runnerFrom }) => {
 
   return {
     mode: "generic",
-    action: "Run `uv tool install --upgrade codemem`, then restart OpenCode.",
+    action: "Update codemem using your normal install method, then restart OpenCode.",
     note: "fallback guidance",
   };
 };
@@ -138,34 +138,18 @@ export const resolveAutoUpdatePlan = ({ runner, runnerFrom }) => {
   }
 
   if (normalizedRunner === "uvx") {
-    if (!source) {
-      return {
-        allowed: false,
-        reason: "missing-source",
-        command: null,
-        commandText: null,
-      };
-    }
-    if (isPinnedGitSource(source)) {
-      return {
-        allowed: false,
-        reason: "pinned-source",
-        command: null,
-        commandText: null,
-      };
-    }
     return {
-      allowed: true,
-      reason: null,
-      command: ["uvx", "--refresh", "--from", source, "codemem", "version"],
-      commandText: "uvx --refresh --from <source> codemem version",
+      allowed: false,
+      reason: !source ? "missing-source" : isPinnedGitSource(source) ? "pinned-source" : "custom-source",
+      command: null,
+      commandText: null,
     };
   }
 
   return {
     allowed: true,
     reason: null,
-    command: ["uv", "tool", "install", "--upgrade", "codemem"],
-    commandText: "uv tool install --upgrade codemem",
+    command: ["npm", "install", "-g", "codemem@latest"],
+    commandText: "npm install -g codemem@latest",
   };
 };

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.21.2",
+	"version": "0.22.0-alpha.0",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.21.2",
+	"version": "0.22.0-alpha.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.21.2",
+  "version": "0.22.0-alpha.0",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description
- Prepares the `0.22.0-alpha.0` release by bumping shared package, plugin, and marketplace metadata versions.
- Updates the pinned backend version in the OpenCode plugin copies to match the new alpha version.
- Leaves tagging/publishing for the normal post-merge release flow.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Release validation used for this slice:
  - `pnpm install`
  - `pnpm build`
  - `pnpm run test`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
