### PR TITLE
refactor(sync): add coordinator store interface and typed records

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -904,7 +904,7 @@ coordinatorCommand.addCommand(
 				groupId: string,
 				opts: { name?: string; db?: string; dbPath?: string; json?: boolean },
 			) => {
-				const group = coordinatorCreateGroupAction({
+				const group = await coordinatorCreateGroupAction({
 					groupId,
 					displayName: opts.name?.trim() || null,
 					dbPath: opts.db ?? opts.dbPath ?? null,
@@ -927,8 +927,8 @@ coordinatorCommand.addCommand(
 		.option("--db <path>", "coordinator database path")
 		.option("--db-path <path>", "coordinator database path")
 		.option("--json", "output as JSON")
-		.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
-			const groups = coordinatorListGroupsAction({ dbPath: opts.db ?? opts.dbPath ?? null });
+		.action(async (opts: { db?: string; dbPath?: string; json?: boolean }) => {
+			const groups = await coordinatorListGroupsAction({ dbPath: opts.db ?? opts.dbPath ?? null });
 			if (opts.json) {
 				console.log(JSON.stringify(groups, null, 2));
 				return;
@@ -987,7 +987,7 @@ coordinatorCommand.addCommand(
 					process.exitCode = 1;
 					return;
 				}
-				const enrollment = coordinatorEnrollDeviceAction({
+				const enrollment = await coordinatorEnrollDeviceAction({
 					groupId,
 					deviceId,
 					fingerprint,
@@ -1016,11 +1016,11 @@ coordinatorCommand.addCommand(
 		.option("--db-path <path>", "coordinator database path")
 		.option("--json", "output as JSON")
 		.action(
-			(
+			async (
 				groupId: string,
 				opts: { includeDisabled?: boolean; db?: string; dbPath?: string; json?: boolean },
 			) => {
-				const rows = coordinatorListDevicesAction({
+				const rows = await coordinatorListDevicesAction({
 					groupId,
 					includeDisabled: opts.includeDisabled === true,
 					dbPath: opts.db ?? opts.dbPath ?? null,
@@ -1056,12 +1056,12 @@ coordinatorCommand.addCommand(
 		.option("--db-path <path>", "coordinator database path")
 		.option("--json", "output as JSON")
 		.action(
-			(
+			async (
 				groupId: string,
 				deviceId: string,
 				opts: { name: string; db?: string; dbPath?: string; json?: boolean },
 			) => {
-				const result = coordinatorRenameDeviceAction({
+				const result = await coordinatorRenameDeviceAction({
 					groupId,
 					deviceId,
 					displayName: opts.name.trim(),
@@ -1093,12 +1093,12 @@ coordinatorCommand.addCommand(
 		.option("--db-path <path>", "coordinator database path")
 		.option("--json", "output as JSON")
 		.action(
-			(
+			async (
 				groupId: string,
 				deviceId: string,
 				opts: { db?: string; dbPath?: string; json?: boolean },
 			) => {
-				const ok = coordinatorDisableDeviceAction({
+				const ok = await coordinatorDisableDeviceAction({
 					groupId,
 					deviceId,
 					dbPath: opts.db ?? opts.dbPath ?? null,
@@ -1135,12 +1135,12 @@ coordinatorCommand.addCommand(
 		.option("--db-path <path>", "coordinator database path")
 		.option("--json", "output as JSON")
 		.action(
-			(
+			async (
 				groupId: string,
 				deviceId: string,
 				opts: { db?: string; dbPath?: string; json?: boolean },
 			) => {
-				const ok = coordinatorRemoveDeviceAction({
+				const ok = await coordinatorRemoveDeviceAction({
 					groupId,
 					deviceId,
 					dbPath: opts.db ?? opts.dbPath ?? null,

--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -31,21 +31,21 @@ describe("coordinator local admin actions", () => {
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
-	it("creates and lists groups", () => {
-		const group = coordinatorCreateGroupAction({
+	it("creates and lists groups", async () => {
+		const group = await coordinatorCreateGroupAction({
 			groupId: "team-a",
 			displayName: "Team A",
 			dbPath,
 		});
 		expect(group.group_id).toBe("team-a");
-		expect(coordinatorListGroupsAction({ dbPath })).toEqual([
+		expect(await coordinatorListGroupsAction({ dbPath })).toEqual([
 			expect.objectContaining({ group_id: "team-a", display_name: "Team A" }),
 		]);
 	});
 
-	it("enrolls and lists devices for an existing group", () => {
-		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
-		const enrollment = coordinatorEnrollDeviceAction({
+	it("enrolls and lists devices for an existing group", async () => {
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		const enrollment = await coordinatorEnrollDeviceAction({
 			groupId: "team-a",
 			deviceId: "device-1",
 			fingerprint: "fp-1",
@@ -54,14 +54,14 @@ describe("coordinator local admin actions", () => {
 			dbPath,
 		});
 		expect(enrollment.device_id).toBe("device-1");
-		expect(coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([
+		expect(await coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([
 			expect.objectContaining({ device_id: "device-1", display_name: "Laptop" }),
 		]);
 	});
 
-	it("renames, disables, and removes devices", () => {
-		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
-		coordinatorEnrollDeviceAction({
+	it("renames, disables, and removes devices", async () => {
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		await coordinatorEnrollDeviceAction({
 			groupId: "team-a",
 			deviceId: "device-1",
 			fingerprint: "fp-1",
@@ -69,7 +69,7 @@ describe("coordinator local admin actions", () => {
 			dbPath,
 		});
 		expect(
-			coordinatorRenameDeviceAction({
+			await coordinatorRenameDeviceAction({
 				groupId: "team-a",
 				deviceId: "device-1",
 				displayName: "Work Laptop",
@@ -77,22 +77,48 @@ describe("coordinator local admin actions", () => {
 			}),
 		).toEqual(expect.objectContaining({ display_name: "Work Laptop" }));
 		expect(
-			coordinatorDisableDeviceAction({ groupId: "team-a", deviceId: "device-1", dbPath }),
+			await coordinatorDisableDeviceAction({ groupId: "team-a", deviceId: "device-1", dbPath }),
 		).toBe(true);
-		expect(coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([]);
+		expect(await coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([]);
 		expect(
-			coordinatorListDevicesAction({ groupId: "team-a", includeDisabled: true, dbPath }),
+			await coordinatorListDevicesAction({ groupId: "team-a", includeDisabled: true, dbPath }),
 		).toEqual([expect.objectContaining({ device_id: "device-1", enabled: 0 })]);
-		expect(coordinatorRemoveDeviceAction({ groupId: "team-a", deviceId: "device-1", dbPath })).toBe(
-			true,
-		);
 		expect(
-			coordinatorListDevicesAction({ groupId: "team-a", includeDisabled: true, dbPath }),
+			await coordinatorRemoveDeviceAction({ groupId: "team-a", deviceId: "device-1", dbPath }),
+		).toBe(true);
+		expect(
+			await coordinatorListDevicesAction({ groupId: "team-a", includeDisabled: true, dbPath }),
 		).toEqual([]);
 	});
 
-	it("rejects enrollment into a missing group", () => {
-		expect(() =>
+	it("returns the renamed disabled device instead of null", async () => {
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		await coordinatorEnrollDeviceAction({
+			groupId: "team-a",
+			deviceId: "device-1",
+			fingerprint: "fp-1",
+			publicKey: "pk-1",
+			dbPath,
+		});
+		await coordinatorDisableDeviceAction({ groupId: "team-a", deviceId: "device-1", dbPath });
+		await expect(
+			coordinatorRenameDeviceAction({
+				groupId: "team-a",
+				deviceId: "device-1",
+				displayName: "Disabled Laptop",
+				dbPath,
+			}),
+		).resolves.toEqual(
+			expect.objectContaining({
+				device_id: "device-1",
+				display_name: "Disabled Laptop",
+				enabled: 0,
+			}),
+		);
+	});
+
+	it("rejects enrollment into a missing group", async () => {
+		await expect(
 			coordinatorEnrollDeviceAction({
 				groupId: "missing",
 				deviceId: "device-1",
@@ -100,11 +126,11 @@ describe("coordinator local admin actions", () => {
 				publicKey: "pk-1",
 				dbPath,
 			}),
-		).toThrow("Group not found: missing");
+		).rejects.toThrow("Group not found: missing");
 	});
 
 	it("warns when local invite coordinator URL looks private-only", async () => {
-		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
 		const invite = await coordinatorCreateInviteAction({
 			groupId: "team-a",
 			coordinatorUrl: "http://100.103.98.49:7347",
@@ -118,7 +144,7 @@ describe("coordinator local admin actions", () => {
 	});
 
 	it("does not warn for public-looking invite coordinator URLs", async () => {
-		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
 		const invite = await coordinatorCreateInviteAction({
 			groupId: "team-a",
 			coordinatorUrl: "https://coord.example.test",
@@ -130,7 +156,7 @@ describe("coordinator local admin actions", () => {
 	});
 
 	it("warns when local invite coordinator URL uses private IPv6 space", async () => {
-		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
 		const invite = await coordinatorCreateInviteAction({
 			groupId: "team-a",
 			coordinatorUrl: "http://[fd7a:115c:a1e0::1234]:7347",
@@ -144,7 +170,7 @@ describe("coordinator local admin actions", () => {
 	});
 
 	it("warns when local invite coordinator URL uses link-local IPv6 space", async () => {
-		coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
 		const invite = await coordinatorCreateInviteAction({
 			groupId: "team-a",
 			coordinatorUrl: "http://[fe80::1]:7347",

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -7,7 +7,14 @@ import {
 	type InvitePayload,
 	inviteLink,
 } from "./coordinator-invites.js";
-import { CoordinatorStore, DEFAULT_COORDINATOR_DB_PATH } from "./coordinator-store.js";
+import {
+	type CoordinatorEnrollment,
+	type CoordinatorGroup,
+	type CoordinatorJoinRequest,
+	type CoordinatorJoinRequestReviewResult,
+	CoordinatorStore,
+	DEFAULT_COORDINATOR_DB_PATH,
+} from "./coordinator-store.js";
 import { connect } from "./db.js";
 import { initDatabase } from "./maintenance.js";
 import { readCodememConfigFile, writeCodememConfigFile } from "./observer-config.js";
@@ -147,41 +154,43 @@ function inviteImportTransportError(error: unknown, coordinatorUrl: string): Err
 	return error instanceof Error ? error : new Error(message);
 }
 
-export function coordinatorCreateGroupAction(opts: {
+export async function coordinatorCreateGroupAction(opts: {
 	groupId: string;
 	displayName?: string | null;
 	dbPath?: string | null;
-}): Record<string, unknown> {
+}): Promise<CoordinatorGroup> {
 	const groupId = String(opts.groupId ?? "").trim();
 	if (!groupId) throw new Error("Group id required.");
 	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		store.createGroup(groupId, opts.displayName ?? null);
-		return store.getGroup(groupId) ?? {};
+		await store.createGroup(groupId, opts.displayName ?? null);
+		const group = await store.getGroup(groupId);
+		if (!group) throw new Error(`Failed to create group: ${groupId}`);
+		return group;
 	} finally {
 		store.close();
 	}
 }
 
-export function coordinatorListGroupsAction(opts?: {
+export async function coordinatorListGroupsAction(opts?: {
 	dbPath?: string | null;
-}): Record<string, unknown>[] {
+}): Promise<CoordinatorGroup[]> {
 	const store = new CoordinatorStore(opts?.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		return store.listGroups();
+		return await store.listGroups();
 	} finally {
 		store.close();
 	}
 }
 
-export function coordinatorEnrollDeviceAction(opts: {
+export async function coordinatorEnrollDeviceAction(opts: {
 	groupId: string;
 	deviceId: string;
 	fingerprint: string;
 	publicKey: string;
 	displayName?: string | null;
 	dbPath?: string | null;
-}): Record<string, unknown> {
+}): Promise<CoordinatorEnrollment> {
 	const groupId = String(opts.groupId ?? "").trim();
 	const deviceId = String(opts.deviceId ?? "").trim();
 	const fingerprint = String(opts.fingerprint ?? "").trim();
@@ -191,40 +200,42 @@ export function coordinatorEnrollDeviceAction(opts: {
 	}
 	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		if (!store.getGroup(groupId)) throw new Error(`Group not found: ${groupId}`);
-		store.enrollDevice(groupId, {
+		if (!(await store.getGroup(groupId))) throw new Error(`Group not found: ${groupId}`);
+		await store.enrollDevice(groupId, {
 			deviceId,
 			fingerprint,
 			publicKey,
 			displayName: opts.displayName ?? null,
 		});
-		return store.getEnrollment(groupId, deviceId) ?? {};
+		const enrollment = await store.getEnrollment(groupId, deviceId);
+		if (!enrollment) throw new Error(`Failed to enroll device: ${deviceId}`);
+		return enrollment;
 	} finally {
 		store.close();
 	}
 }
 
-export function coordinatorListDevicesAction(opts: {
+export async function coordinatorListDevicesAction(opts: {
 	groupId: string;
 	includeDisabled?: boolean;
 	dbPath?: string | null;
-}): Record<string, unknown>[] {
+}): Promise<CoordinatorEnrollment[]> {
 	const groupId = String(opts.groupId ?? "").trim();
 	if (!groupId) throw new Error("Group id required.");
 	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		return store.listEnrolledDevices(groupId, opts.includeDisabled === true);
+		return await store.listEnrolledDevices(groupId, opts.includeDisabled === true);
 	} finally {
 		store.close();
 	}
 }
 
-export function coordinatorRenameDeviceAction(opts: {
+export async function coordinatorRenameDeviceAction(opts: {
 	groupId: string;
 	deviceId: string;
 	displayName: string;
 	dbPath?: string | null;
-}): Record<string, unknown> | null {
+}): Promise<CoordinatorEnrollment | null> {
 	const groupId = String(opts.groupId ?? "").trim();
 	const deviceId = String(opts.deviceId ?? "").trim();
 	const displayName = String(opts.displayName ?? "").trim();
@@ -233,40 +244,44 @@ export function coordinatorRenameDeviceAction(opts: {
 	}
 	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		const ok = store.renameDevice(groupId, deviceId, displayName);
-		return ok ? (store.getEnrollment(groupId, deviceId) ?? {}) : null;
+		const ok = await store.renameDevice(groupId, deviceId, displayName);
+		if (!ok) return null;
+		const active = await store.getEnrollment(groupId, deviceId);
+		if (active) return active;
+		const all = await store.listEnrolledDevices(groupId, true);
+		return all.find((device) => device.device_id === deviceId) ?? null;
 	} finally {
 		store.close();
 	}
 }
 
-export function coordinatorDisableDeviceAction(opts: {
+export async function coordinatorDisableDeviceAction(opts: {
 	groupId: string;
 	deviceId: string;
 	dbPath?: string | null;
-}): boolean {
+}): Promise<boolean> {
 	const groupId = String(opts.groupId ?? "").trim();
 	const deviceId = String(opts.deviceId ?? "").trim();
 	if (!groupId || !deviceId) throw new Error("group_id and device_id are required.");
 	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		return store.setDeviceEnabled(groupId, deviceId, false);
+		return await store.setDeviceEnabled(groupId, deviceId, false);
 	} finally {
 		store.close();
 	}
 }
 
-export function coordinatorRemoveDeviceAction(opts: {
+export async function coordinatorRemoveDeviceAction(opts: {
 	groupId: string;
 	deviceId: string;
 	dbPath?: string | null;
-}): boolean {
+}): Promise<boolean> {
 	const groupId = String(opts.groupId ?? "").trim();
 	const deviceId = String(opts.deviceId ?? "").trim();
 	if (!groupId || !deviceId) throw new Error("group_id and device_id are required.");
 	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		return store.removeDevice(groupId, deviceId);
+		return await store.removeDevice(groupId, deviceId);
 	} finally {
 		store.close();
 	}
@@ -318,7 +333,7 @@ export async function coordinatorCreateInviteAction(opts: {
 	try {
 		const group = store.getGroup(opts.groupId);
 		if (!group) throw new Error(`Group not found: ${opts.groupId}`);
-		const invite = store.createInvite({
+		const invite = await store.createInvite({
 			groupId: opts.groupId,
 			policy: opts.policy,
 			expiresAt,
@@ -412,7 +427,7 @@ export async function coordinatorListJoinRequestsAction(opts: {
 	dbPath?: string | null;
 	remoteUrl?: string | null;
 	adminSecret?: string | null;
-}): Promise<Record<string, unknown>[]> {
+}): Promise<CoordinatorJoinRequest[]> {
 	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
 	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
 	if (remote) {
@@ -424,13 +439,13 @@ export async function coordinatorListJoinRequestsAction(opts: {
 		);
 		return Array.isArray(payload?.items)
 			? payload.items.filter(
-					(row): row is Record<string, unknown> => Boolean(row) && typeof row === "object",
+					(row): row is CoordinatorJoinRequest => Boolean(row) && typeof row === "object",
 				)
 			: [];
 	}
 	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		return store.listJoinRequests(opts.groupId);
+		return await store.listJoinRequests(opts.groupId);
 	} finally {
 		store.close();
 	}
@@ -443,7 +458,7 @@ export async function coordinatorReviewJoinRequestAction(opts: {
 	dbPath?: string | null;
 	remoteUrl?: string | null;
 	adminSecret?: string | null;
-}): Promise<Record<string, unknown> | null> {
+}): Promise<CoordinatorJoinRequestReviewResult | null> {
 	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
 	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
 	if (remote) {
@@ -461,11 +476,13 @@ export async function coordinatorReviewJoinRequestAction(opts: {
 			},
 		);
 		const request = payload?.request;
-		return request && typeof request === "object" ? (request as Record<string, unknown>) : null;
+		return request && typeof request === "object"
+			? (request as CoordinatorJoinRequestReviewResult)
+			: null;
 	}
 	const store = new CoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		return store.reviewJoinRequest({
+		return await store.reviewJoinRequest({
 			requestId: opts.requestId,
 			approved: opts.approve,
 			reviewedBy: opts.reviewedBy ?? null,

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -9,7 +9,7 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import type { InvitePayload } from "./coordinator-invites.js";
 import { encodeInvitePayload, inviteLink } from "./coordinator-invites.js";
-import { CoordinatorStore } from "./coordinator-store.js";
+import { type CoordinatorEnrollment, CoordinatorStore } from "./coordinator-store.js";
 import { DEFAULT_TIME_WINDOW_S, verifySignature } from "./sync-auth.js";
 
 // ---------------------------------------------------------------------------
@@ -43,33 +43,26 @@ function pathWithQuery(url: string): string {
 	return parsed.search ? `${parsed.pathname}${parsed.search}` : parsed.pathname;
 }
 
-function recordNonce(
+async function recordNonce(
 	store: CoordinatorStore,
 	deviceId: string,
 	nonce: string,
 	createdAt: string,
-): boolean {
-	try {
-		store.db
-			.prepare("INSERT INTO request_nonces(device_id, nonce, created_at) VALUES (?, ?, ?)")
-			.run(deviceId, nonce, createdAt);
-		return true;
-	} catch {
-		return false;
-	}
+): Promise<boolean> {
+	return await store.recordNonce(deviceId, nonce, createdAt);
 }
 
-function cleanupNonces(store: CoordinatorStore, cutoff: string): void {
-	store.db.prepare("DELETE FROM request_nonces WHERE created_at < ?").run(cutoff);
+async function cleanupNonces(store: CoordinatorStore, cutoff: string): Promise<void> {
+	await store.cleanupNonces(cutoff);
 }
 
 interface AuthResult {
 	ok: boolean;
 	error: string;
-	enrollment: Record<string, unknown> | null;
+	enrollment: CoordinatorEnrollment | null;
 }
 
-function authorizeRequest(
+async function authorizeRequest(
 	store: CoordinatorStore,
 	opts: {
 		method: string;
@@ -81,13 +74,13 @@ function authorizeRequest(
 		timestamp: string | null;
 		nonce: string | null;
 	},
-): AuthResult {
+): Promise<AuthResult> {
 	const { deviceId, signature, timestamp, nonce } = opts;
 	if (!deviceId || !signature || !timestamp || !nonce) {
 		return { ok: false, error: "missing_headers", enrollment: null };
 	}
 
-	const enrollment = store.getEnrollment(opts.groupId, deviceId);
+	const enrollment = await store.getEnrollment(opts.groupId, deviceId);
 	if (!enrollment) {
 		return { ok: false, error: "unknown_device", enrollment: null };
 	}
@@ -113,12 +106,12 @@ function authorizeRequest(
 	}
 
 	const createdAt = new Date().toISOString();
-	if (!recordNonce(store, deviceId, nonce, createdAt)) {
+	if (!(await recordNonce(store, deviceId, nonce, createdAt))) {
 		return { ok: false, error: "nonce_replay", enrollment: null };
 	}
 
 	const cutoff = new Date(Date.now() - DEFAULT_TIME_WINDOW_S * 2 * 1000).toISOString();
-	cleanupNonces(store, cutoff);
+	await cleanupNonces(store, cutoff);
 
 	return { ok: true, error: "ok", enrollment };
 }
@@ -158,7 +151,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 
 		const store = new CoordinatorStore(dbPath);
 		try {
-			const auth = authorizeRequest(store, {
+			const auth = await authorizeRequest(store, {
 				method: c.req.method,
 				url: c.req.url,
 				groupId,
@@ -191,7 +184,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 				return c.json({ error: "ttl_s_must_be_int" }, 400);
 			}
 
-			const response = store.upsertPresence({
+			const response = await store.upsertPresence({
 				groupId,
 				deviceId: String(auth.enrollment.device_id),
 				addresses: rawAddresses as string[],
@@ -214,7 +207,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 	// GET /v1/peers — list group peers (authenticated)
 	// -----------------------------------------------------------------------
 
-	app.get("/v1/peers", (c) => {
+	app.get("/v1/peers", async (c) => {
 		const groupId = (c.req.query("group_id") ?? "").trim();
 		if (!groupId) {
 			return c.json({ error: "group_id_required" }, 400);
@@ -222,7 +215,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 
 		const store = new CoordinatorStore(dbPath);
 		try {
-			const auth = authorizeRequest(store, {
+			const auth = await authorizeRequest(store, {
 				method: c.req.method,
 				url: c.req.url,
 				groupId,
@@ -236,7 +229,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 				return c.json({ error: auth.error }, 401);
 			}
 
-			const items = store.listGroupPeers(groupId, String(auth.enrollment.device_id));
+			const items = await store.listGroupPeers(groupId, String(auth.enrollment.device_id));
 			return c.json({ items });
 		} finally {
 			store.close();
@@ -277,8 +270,8 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 
 		const store = new CoordinatorStore(dbPath);
 		try {
-			store.createGroup(groupId);
-			store.enrollDevice(groupId, {
+			await store.createGroup(groupId);
+			await store.enrollDevice(groupId, {
 				deviceId,
 				fingerprint,
 				publicKey,
@@ -449,10 +442,10 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 
 		const store = new CoordinatorStore(dbPath);
 		try {
-			const group = store.getGroup(groupId);
+			const group = await store.getGroup(groupId);
 			if (!group) return c.json({ error: "group_not_found" }, 404);
 
-			const invite = store.createInvite({
+			const invite = await store.createInvite({
 				groupId,
 				policy,
 				expiresAt,
@@ -487,7 +480,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 	});
 
 	// GET /v1/admin/invites — list invites
-	app.get("/v1/admin/invites", (c) => {
+	app.get("/v1/admin/invites", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER));
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
@@ -496,14 +489,9 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 
 		const store = new CoordinatorStore(dbPath);
 		try {
-			const rows = store.db
-				.prepare(
-					`SELECT invite_id, group_id, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
-					 FROM coordinator_invites
-					 WHERE group_id = ?
-					 ORDER BY created_at DESC`,
-				)
-				.all(groupId) as Record<string, unknown>[];
+			const rows = (await store.listInvites(groupId)).map(
+				({ token: _token, ...inviteWithoutToken }) => inviteWithoutToken,
+			);
 			return c.json({ items: rows });
 		} finally {
 			store.close();
@@ -521,7 +509,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 	});
 
 	// GET /v1/admin/join-requests — list join requests
-	app.get("/v1/admin/join-requests", (c) => {
+	app.get("/v1/admin/join-requests", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER));
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
@@ -530,7 +518,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 
 		const store = new CoordinatorStore(dbPath);
 		try {
-			return c.json({ items: store.listJoinRequests(groupId) });
+			return c.json({ items: await store.listJoinRequests(groupId) });
 		} finally {
 			store.close();
 		}
@@ -566,7 +554,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 
 		const store = new CoordinatorStore(dbPath);
 		try {
-			const invite = store.getInviteByToken(token);
+			const invite = await store.getInviteByToken(token);
 			if (!invite) return c.json({ error: "invalid_token" }, 404);
 
 			if (invite.revoked_at) return c.json({ error: "revoked_token" }, 400);
@@ -580,7 +568,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 			}
 
 			const inviteGroupId = String(invite.group_id);
-			const existing = store.getEnrollment(inviteGroupId, deviceId);
+			const existing = await store.getEnrollment(inviteGroupId, deviceId);
 			if (existing) {
 				return c.json({
 					ok: true,
@@ -596,7 +584,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 			}
 
 			if (invitePolicy === "approval_required") {
-				const request = store.createJoinRequest({
+				const request = await store.createJoinRequest({
 					groupId: inviteGroupId,
 					deviceId,
 					publicKey,
@@ -613,7 +601,7 @@ export function createCoordinatorApp(opts?: { dbPath?: string }): InstanceType<t
 				});
 			}
 
-			store.enrollDevice(inviteGroupId, {
+			await store.enrollDevice(inviteGroupId, {
 				deviceId,
 				fingerprint,
 				publicKey,
@@ -662,7 +650,7 @@ async function handleJoinRequestReview(c: Context, approved: boolean, dbPath: st
 
 	const store = new CoordinatorStore(dbPath);
 	try {
-		const request = store.reviewJoinRequest({
+		const request = await store.reviewJoinRequest({
 			requestId,
 			approved,
 			reviewedBy,

--- a/packages/core/src/coordinator-store.test.ts
+++ b/packages/core/src/coordinator-store.test.ts
@@ -2,26 +2,26 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { CoordinatorStore } from "./coordinator-store.js";
+import { BetterSqliteCoordinatorStore as CoordinatorStore } from "./coordinator-store.js";
 
 describe("CoordinatorStore", () => {
 	let tmpDir: string;
 	let store: CoordinatorStore;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		tmpDir = mkdtempSync(join(tmpdir(), "coord-test-"));
 		store = new CoordinatorStore(join(tmpDir, "coordinator.sqlite"));
 	});
 
-	afterEach(() => {
-		store.close();
+	afterEach(async () => {
+		await store.close();
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
 	// -- Schema -------------------------------------------------------------
 
 	describe("schema", () => {
-		it("creates all expected tables", () => {
+		it("creates all expected tables", async () => {
 			const tables = store.db
 				.prepare(
 					"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
@@ -42,29 +42,30 @@ describe("CoordinatorStore", () => {
 	// -- Groups -------------------------------------------------------------
 
 	describe("groups", () => {
-		it("creates and retrieves a group", () => {
-			store.createGroup("g1", "Team Alpha");
-			const group = store.getGroup("g1");
+		it("creates and retrieves a group", async () => {
+			await store.createGroup("g1", "Team Alpha");
+			const group = await store.getGroup("g1");
 			expect(group).not.toBeNull();
 			expect(group?.group_id).toBe("g1");
 			expect(group?.display_name).toBe("Team Alpha");
 			expect(group?.created_at).toBeTruthy();
 		});
 
-		it("returns null for missing group", () => {
-			expect(store.getGroup("nope")).toBeNull();
+		it("returns null for missing group", async () => {
+			expect(await store.getGroup("nope")).toBeNull();
 		});
 
-		it("INSERT OR IGNORE on duplicate group_id", () => {
-			store.createGroup("g1", "Original");
-			store.createGroup("g1", "Changed");
-			expect(store.getGroup("g1")?.display_name).toBe("Original");
+		it("INSERT OR IGNORE on duplicate group_id", async () => {
+			await store.createGroup("g1", "Original");
+			await store.createGroup("g1", "Changed");
+			const group = await store.getGroup("g1");
+			expect(group?.display_name).toBe("Original");
 		});
 
-		it("lists groups", () => {
-			store.createGroup("g1");
-			store.createGroup("g2", "Second");
-			const groups = store.listGroups();
+		it("lists groups", async () => {
+			await store.createGroup("g1");
+			await store.createGroup("g2", "Second");
+			const groups = await store.listGroups();
 			expect(groups).toHaveLength(2);
 		});
 	});
@@ -72,99 +73,100 @@ describe("CoordinatorStore", () => {
 	// -- Devices ------------------------------------------------------------
 
 	describe("devices", () => {
-		beforeEach(() => {
-			store.createGroup("g1");
+		beforeEach(async () => {
+			await store.createGroup("g1");
 		});
 
-		it("enrolls and retrieves a device", () => {
-			store.enrollDevice("g1", {
+		it("enrolls and retrieves a device", async () => {
+			await store.enrollDevice("g1", {
 				deviceId: "d1",
 				fingerprint: "fp1",
 				publicKey: "pk1",
 				displayName: "Laptop",
 			});
-			const enrollment = store.getEnrollment("g1", "d1");
+			const enrollment = await store.getEnrollment("g1", "d1");
 			expect(enrollment).not.toBeNull();
 			expect(enrollment?.device_id).toBe("d1");
 			expect(enrollment?.display_name).toBe("Laptop");
 		});
 
-		it("returns null for missing enrollment", () => {
-			expect(store.getEnrollment("g1", "missing")).toBeNull();
+		it("returns null for missing enrollment", async () => {
+			expect(await store.getEnrollment("g1", "missing")).toBeNull();
 		});
 
-		it("upserts on re-enroll", () => {
-			store.enrollDevice("g1", {
+		it("upserts on re-enroll", async () => {
+			await store.enrollDevice("g1", {
 				deviceId: "d1",
 				fingerprint: "fp1",
 				publicKey: "pk1",
 				displayName: "Old",
 			});
-			store.enrollDevice("g1", {
+			await store.enrollDevice("g1", {
 				deviceId: "d1",
 				fingerprint: "fp2",
 				publicKey: "pk2",
 				displayName: "New",
 			});
-			const enrollment = store.getEnrollment("g1", "d1");
+			const enrollment = await store.getEnrollment("g1", "d1");
 			expect(enrollment?.fingerprint).toBe("fp2");
 			expect(enrollment?.display_name).toBe("New");
 		});
 
-		it("lists enrolled devices", () => {
-			store.enrollDevice("g1", {
+		it("lists enrolled devices", async () => {
+			await store.enrollDevice("g1", {
 				deviceId: "d1",
 				fingerprint: "fp1",
 				publicKey: "pk1",
 			});
-			store.enrollDevice("g1", {
+			await store.enrollDevice("g1", {
 				deviceId: "d2",
 				fingerprint: "fp2",
 				publicKey: "pk2",
 			});
-			expect(store.listEnrolledDevices("g1")).toHaveLength(2);
+			expect(await store.listEnrolledDevices("g1")).toHaveLength(2);
 		});
 
-		it("renames a device", () => {
-			store.enrollDevice("g1", {
+		it("renames a device", async () => {
+			await store.enrollDevice("g1", {
 				deviceId: "d1",
 				fingerprint: "fp1",
 				publicKey: "pk1",
 			});
-			expect(store.renameDevice("g1", "d1", "Desktop")).toBe(true);
-			expect(store.getEnrollment("g1", "d1")?.display_name).toBe("Desktop");
+			expect(await store.renameDevice("g1", "d1", "Desktop")).toBe(true);
+			const enrollment = await store.getEnrollment("g1", "d1");
+			expect(enrollment?.display_name).toBe("Desktop");
 		});
 
-		it("disables and re-enables a device", () => {
-			store.enrollDevice("g1", {
+		it("disables and re-enables a device", async () => {
+			await store.enrollDevice("g1", {
 				deviceId: "d1",
 				fingerprint: "fp1",
 				publicKey: "pk1",
 			});
-			store.setDeviceEnabled("g1", "d1", false);
+			await store.setDeviceEnabled("g1", "d1", false);
 			// Disabled device not returned by default
-			expect(store.listEnrolledDevices("g1")).toHaveLength(0);
+			expect(await store.listEnrolledDevices("g1")).toHaveLength(0);
 			// But shows up with includeDisabled
-			expect(store.listEnrolledDevices("g1", true)).toHaveLength(1);
+			expect(await store.listEnrolledDevices("g1", true)).toHaveLength(1);
 			// Re-enable
-			store.setDeviceEnabled("g1", "d1", true);
-			expect(store.listEnrolledDevices("g1")).toHaveLength(1);
+			await store.setDeviceEnabled("g1", "d1", true);
+			expect(await store.listEnrolledDevices("g1")).toHaveLength(1);
 		});
 
-		it("removes a device and its presence", () => {
-			store.enrollDevice("g1", {
+		it("removes a device and its presence", async () => {
+			await store.enrollDevice("g1", {
 				deviceId: "d1",
 				fingerprint: "fp1",
 				publicKey: "pk1",
 			});
-			store.upsertPresence({
+			await store.upsertPresence({
 				groupId: "g1",
 				deviceId: "d1",
 				addresses: ["http://localhost:9000"],
 				ttlS: 300,
 			});
-			expect(store.removeDevice("g1", "d1")).toBe(true);
-			expect(store.getEnrollment("g1", "d1")).toBeNull();
+			expect(await store.removeDevice("g1", "d1")).toBe(true);
+			expect(await store.getEnrollment("g1", "d1")).toBeNull();
 			// Verify presence was also cleaned up
 			const presence = store.db
 				.prepare("SELECT * FROM presence_records WHERE group_id = ? AND device_id = ?")
@@ -172,30 +174,30 @@ describe("CoordinatorStore", () => {
 			expect(presence).toBeUndefined();
 		});
 
-		it("returns false when removing a non-existent device", () => {
-			expect(store.removeDevice("g1", "ghost")).toBe(false);
+		it("returns false when removing a non-existent device", async () => {
+			expect(await store.removeDevice("g1", "ghost")).toBe(false);
 		});
 	});
 
 	// -- Presence -----------------------------------------------------------
 
 	describe("presence", () => {
-		beforeEach(() => {
-			store.createGroup("g1");
-			store.enrollDevice("g1", {
+		beforeEach(async () => {
+			await store.createGroup("g1");
+			await store.enrollDevice("g1", {
 				deviceId: "d1",
 				fingerprint: "fp1",
 				publicKey: "pk1",
 			});
-			store.enrollDevice("g1", {
+			await store.enrollDevice("g1", {
 				deviceId: "d2",
 				fingerprint: "fp2",
 				publicKey: "pk2",
 			});
 		});
 
-		it("upserts presence and returns normalized data", () => {
-			const result = store.upsertPresence({
+		it("upserts presence and returns normalized data", async () => {
+			const result = await store.upsertPresence({
 				groupId: "g1",
 				deviceId: "d1",
 				addresses: ["http://localhost:9000"],
@@ -207,44 +209,44 @@ describe("CoordinatorStore", () => {
 			expect(result.expires_at).toBeTruthy();
 		});
 
-		it("lists group peers excluding requesting device", () => {
-			store.upsertPresence({
+		it("lists group peers excluding requesting device", async () => {
+			await store.upsertPresence({
 				groupId: "g1",
 				deviceId: "d1",
 				addresses: ["http://localhost:9000"],
 				ttlS: 300,
 			});
-			store.upsertPresence({
+			await store.upsertPresence({
 				groupId: "g1",
 				deviceId: "d2",
 				addresses: ["http://localhost:9001"],
 				ttlS: 300,
 			});
 			// d1 asks for peers — should only see d2
-			const peers = store.listGroupPeers("g1", "d1");
+			const peers = await store.listGroupPeers("g1", "d1");
 			expect(peers).toHaveLength(1);
 			expect(peers[0].device_id).toBe("d2");
 			expect(peers[0].stale).toBe(false);
 			expect(peers[0].addresses).toEqual(["http://localhost:9001"]);
 		});
 
-		it("marks stale presence with empty addresses", () => {
+		it("marks stale presence with empty addresses", async () => {
 			// Set presence with 0 TTL so it expires immediately
-			store.upsertPresence({
+			await store.upsertPresence({
 				groupId: "g1",
 				deviceId: "d2",
 				addresses: ["http://localhost:9001"],
 				ttlS: 0,
 			});
-			const peers = store.listGroupPeers("g1", "d1");
+			const peers = await store.listGroupPeers("g1", "d1");
 			expect(peers).toHaveLength(1);
 			expect(peers[0].stale).toBe(true);
 			expect(peers[0].addresses).toEqual([]);
 		});
 
-		it("shows enrolled peers with no presence record", () => {
+		it("shows enrolled peers with no presence record", async () => {
 			// d2 never reported presence
-			const peers = store.listGroupPeers("g1", "d1");
+			const peers = await store.listGroupPeers("g1", "d1");
 			expect(peers).toHaveLength(1);
 			expect(peers[0].device_id).toBe("d2");
 			expect(peers[0].stale).toBe(true);
@@ -255,12 +257,12 @@ describe("CoordinatorStore", () => {
 	// -- Invites ------------------------------------------------------------
 
 	describe("invites", () => {
-		beforeEach(() => {
-			store.createGroup("g1", "Team Alpha");
+		beforeEach(async () => {
+			await store.createGroup("g1", "Team Alpha");
 		});
 
-		it("creates an invite and retrieves by token", () => {
-			const invite = store.createInvite({
+		it("creates an invite and retrieves by token", async () => {
+			const invite = await store.createInvite({
 				groupId: "g1",
 				policy: "auto_approve",
 				expiresAt: "2099-01-01T00:00:00Z",
@@ -271,27 +273,27 @@ describe("CoordinatorStore", () => {
 			expect(invite.policy).toBe("auto_approve");
 			expect(invite.team_name_snapshot).toBe("Team Alpha");
 
-			const byToken = store.getInviteByToken(invite.token as string);
+			const byToken = await store.getInviteByToken(invite.token as string);
 			expect(byToken).not.toBeNull();
 			expect(byToken?.invite_id).toBe(invite.invite_id);
 		});
 
-		it("returns null for unknown token", () => {
-			expect(store.getInviteByToken("nonexistent")).toBeNull();
+		it("returns null for unknown token", async () => {
+			expect(await store.getInviteByToken("nonexistent")).toBeNull();
 		});
 
-		it("lists invites for a group", () => {
-			store.createInvite({
+		it("lists invites for a group", async () => {
+			await store.createInvite({
 				groupId: "g1",
 				policy: "auto_approve",
 				expiresAt: "2099-01-01T00:00:00Z",
 			});
-			store.createInvite({
+			await store.createInvite({
 				groupId: "g1",
 				policy: "manual_review",
 				expiresAt: "2099-06-01T00:00:00Z",
 			});
-			expect(store.listInvites("g1")).toHaveLength(2);
+			expect(await store.listInvites("g1")).toHaveLength(2);
 		});
 	});
 
@@ -300,9 +302,9 @@ describe("CoordinatorStore", () => {
 	describe("join requests", () => {
 		let inviteToken: string;
 
-		beforeEach(() => {
-			store.createGroup("g1");
-			const invite = store.createInvite({
+		beforeEach(async () => {
+			await store.createGroup("g1");
+			const invite = await store.createInvite({
 				groupId: "g1",
 				policy: "manual_review",
 				expiresAt: "2099-01-01T00:00:00Z",
@@ -310,8 +312,8 @@ describe("CoordinatorStore", () => {
 			inviteToken = invite.token as string;
 		});
 
-		it("creates a join request in pending status", () => {
-			const req = store.createJoinRequest({
+		it("creates a join request in pending status", async () => {
+			const req = await store.createJoinRequest({
 				groupId: "g1",
 				deviceId: "d-new",
 				publicKey: "pk-new",
@@ -324,27 +326,27 @@ describe("CoordinatorStore", () => {
 			expect(req.device_id).toBe("d-new");
 		});
 
-		it("lists pending join requests", () => {
-			store.createJoinRequest({
+		it("lists pending join requests", async () => {
+			await store.createJoinRequest({
 				groupId: "g1",
 				deviceId: "d1",
 				publicKey: "pk1",
 				fingerprint: "fp1",
 				token: inviteToken,
 			});
-			store.createJoinRequest({
+			await store.createJoinRequest({
 				groupId: "g1",
 				deviceId: "d2",
 				publicKey: "pk2",
 				fingerprint: "fp2",
 				token: inviteToken,
 			});
-			const pending = store.listJoinRequests("g1");
+			const pending = await store.listJoinRequests("g1");
 			expect(pending).toHaveLength(2);
 		});
 
-		it("approves a join request and enrolls the device", () => {
-			const req = store.createJoinRequest({
+		it("approves a join request and enrolls the device", async () => {
+			const req = await store.createJoinRequest({
 				groupId: "g1",
 				deviceId: "d-new",
 				publicKey: "pk-new",
@@ -352,7 +354,7 @@ describe("CoordinatorStore", () => {
 				displayName: "New Device",
 				token: inviteToken,
 			});
-			const reviewed = store.reviewJoinRequest({
+			const reviewed = await store.reviewJoinRequest({
 				requestId: req.request_id as string,
 				approved: true,
 				reviewedBy: "admin",
@@ -362,44 +364,44 @@ describe("CoordinatorStore", () => {
 			expect(reviewed?.reviewed_by).toBe("admin");
 
 			// Device should now be enrolled
-			const enrollment = store.getEnrollment("g1", "d-new");
+			const enrollment = await store.getEnrollment("g1", "d-new");
 			expect(enrollment).not.toBeNull();
 			expect(enrollment?.fingerprint).toBe("fp-new");
 		});
 
-		it("denies a join request without enrolling", () => {
-			const req = store.createJoinRequest({
+		it("denies a join request without enrolling", async () => {
+			const req = await store.createJoinRequest({
 				groupId: "g1",
 				deviceId: "d-new",
 				publicKey: "pk-new",
 				fingerprint: "fp-new",
 				token: inviteToken,
 			});
-			const reviewed = store.reviewJoinRequest({
+			const reviewed = await store.reviewJoinRequest({
 				requestId: req.request_id as string,
 				approved: false,
 			});
 			expect(reviewed?.status).toBe("denied");
-			expect(store.getEnrollment("g1", "d-new")).toBeNull();
+			expect(await store.getEnrollment("g1", "d-new")).toBeNull();
 		});
 
-		it("returns null for missing request_id", () => {
-			expect(store.reviewJoinRequest({ requestId: "nope", approved: true })).toBeNull();
+		it("returns null for missing request_id", async () => {
+			expect(await store.reviewJoinRequest({ requestId: "nope", approved: true })).toBeNull();
 		});
 
-		it("returns _no_transition for already-reviewed request", () => {
-			const req = store.createJoinRequest({
+		it("returns _no_transition for already-reviewed request", async () => {
+			const req = await store.createJoinRequest({
 				groupId: "g1",
 				deviceId: "d-new",
 				publicKey: "pk-new",
 				fingerprint: "fp-new",
 				token: inviteToken,
 			});
-			store.reviewJoinRequest({
+			await store.reviewJoinRequest({
 				requestId: req.request_id as string,
 				approved: true,
 			});
-			const again = store.reviewJoinRequest({
+			const again = await store.reviewJoinRequest({
 				requestId: req.request_id as string,
 				approved: false,
 			});

--- a/packages/core/src/coordinator-store.ts
+++ b/packages/core/src/coordinator-store.ts
@@ -19,6 +19,132 @@ import Database from "better-sqlite3";
 
 export const DEFAULT_COORDINATOR_DB_PATH = join(homedir(), ".codemem", "coordinator.sqlite");
 
+export interface CoordinatorGroup {
+	group_id: string;
+	display_name: string | null;
+	created_at: string;
+}
+
+export interface CoordinatorEnrollment {
+	group_id?: string;
+	device_id: string;
+	public_key?: string;
+	fingerprint: string;
+	display_name: string | null;
+	enabled?: number;
+	created_at?: string;
+}
+
+export interface CoordinatorInvite {
+	invite_id: string;
+	group_id: string;
+	token: string;
+	policy: string;
+	expires_at: string;
+	created_at: string;
+	created_by: string | null;
+	team_name_snapshot: string | null;
+	revoked_at: string | null;
+}
+
+export interface CoordinatorJoinRequest {
+	request_id: string;
+	group_id: string;
+	device_id: string;
+	public_key?: string;
+	fingerprint: string;
+	display_name: string | null;
+	token: string;
+	status: string;
+	created_at: string;
+	reviewed_at: string | null;
+	reviewed_by: string | null;
+}
+
+export interface CoordinatorJoinRequestReviewResult extends CoordinatorJoinRequest {
+	_no_transition?: boolean;
+}
+
+export interface CoordinatorPresenceRecord {
+	group_id: string;
+	device_id: string;
+	addresses: string[];
+	expires_at: string;
+}
+
+export interface CoordinatorPeerRecord {
+	device_id: string;
+	fingerprint: string;
+	display_name: string | null;
+	addresses: string[];
+	last_seen_at: string | null;
+	expires_at: string | null;
+	stale: boolean;
+	capabilities: Record<string, unknown>;
+}
+
+export interface CoordinatorEnrollDeviceInput {
+	deviceId: string;
+	fingerprint: string;
+	publicKey: string;
+	displayName?: string | null;
+}
+
+export interface CoordinatorCreateInviteInput {
+	groupId: string;
+	policy: string;
+	expiresAt: string;
+	createdBy?: string | null;
+}
+
+export interface CoordinatorCreateJoinRequestInput {
+	groupId: string;
+	deviceId: string;
+	publicKey: string;
+	fingerprint: string;
+	displayName?: string | null;
+	token: string;
+}
+
+export interface CoordinatorReviewJoinRequestInput {
+	requestId: string;
+	approved: boolean;
+	reviewedBy?: string | null;
+}
+
+export interface CoordinatorUpsertPresenceInput {
+	groupId: string;
+	deviceId: string;
+	addresses: string[];
+	ttlS: number;
+	capabilities?: Record<string, unknown> | null;
+}
+
+export interface CoordinatorStore {
+	close(): Promise<void>;
+	createGroup(groupId: string, displayName?: string | null): Promise<void>;
+	getGroup(groupId: string): Promise<CoordinatorGroup | null>;
+	listGroups(): Promise<CoordinatorGroup[]>;
+	enrollDevice(groupId: string, opts: CoordinatorEnrollDeviceInput): Promise<void>;
+	listEnrolledDevices(groupId: string, includeDisabled?: boolean): Promise<CoordinatorEnrollment[]>;
+	getEnrollment(groupId: string, deviceId: string): Promise<CoordinatorEnrollment | null>;
+	renameDevice(groupId: string, deviceId: string, displayName: string): Promise<boolean>;
+	setDeviceEnabled(groupId: string, deviceId: string, enabled: boolean): Promise<boolean>;
+	removeDevice(groupId: string, deviceId: string): Promise<boolean>;
+	recordNonce(deviceId: string, nonce: string, createdAt: string): Promise<boolean>;
+	cleanupNonces(cutoff: string): Promise<void>;
+	createInvite(opts: CoordinatorCreateInviteInput): Promise<CoordinatorInvite>;
+	getInviteByToken(token: string): Promise<CoordinatorInvite | null>;
+	listInvites(groupId: string): Promise<CoordinatorInvite[]>;
+	createJoinRequest(opts: CoordinatorCreateJoinRequestInput): Promise<CoordinatorJoinRequest>;
+	listJoinRequests(groupId: string, status?: string): Promise<CoordinatorJoinRequest[]>;
+	reviewJoinRequest(
+		opts: CoordinatorReviewJoinRequestInput,
+	): Promise<CoordinatorJoinRequestReviewResult | null>;
+	upsertPresence(opts: CoordinatorUpsertPresenceInput): Promise<CoordinatorPresenceRecord>;
+	listGroupPeers(groupId: string, requestingDeviceId: string): Promise<CoordinatorPeerRecord[]>;
+}
+
 // ---------------------------------------------------------------------------
 // Address helpers (subset of sync/discovery.py, inlined to avoid circular deps)
 // ---------------------------------------------------------------------------
@@ -87,10 +213,10 @@ function tokenUrlSafe(bytes: number): string {
 	return randomBytes(bytes).toString("base64url").replace(/=+$/, "");
 }
 
-function rowToRecord(row: unknown): Record<string, unknown> {
-	if (row == null) return {};
+function rowToRecord<T>(row: unknown): T {
+	if (row == null) throw new Error("expected row");
 	// better-sqlite3 returns plain objects when using .get()/.all()
-	return row as Record<string, unknown>;
+	return row as T;
 }
 
 // ---------------------------------------------------------------------------
@@ -181,7 +307,7 @@ export function connectCoordinator(path?: string): DatabaseType {
 // CoordinatorStore
 // ---------------------------------------------------------------------------
 
-export class CoordinatorStore {
+export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 	readonly path: string;
 	readonly db: DatabaseType;
 
@@ -190,43 +316,35 @@ export class CoordinatorStore {
 		this.db = connectCoordinator(this.path);
 	}
 
-	close(): void {
+	async close(): Promise<void> {
 		this.db.close();
 	}
 
 	// -- Groups -------------------------------------------------------------
 
-	createGroup(groupId: string, displayName?: string | null): void {
+	async createGroup(groupId: string, displayName?: string | null): Promise<void> {
 		this.db
 			.prepare("INSERT OR IGNORE INTO groups(group_id, display_name, created_at) VALUES (?, ?, ?)")
 			.run(groupId, displayName ?? null, nowISO());
 	}
 
-	getGroup(groupId: string): Record<string, unknown> | null {
+	async getGroup(groupId: string): Promise<CoordinatorGroup | null> {
 		const row = this.db
 			.prepare("SELECT group_id, display_name, created_at FROM groups WHERE group_id = ?")
 			.get(groupId);
-		return row ? rowToRecord(row) : null;
+		return row ? rowToRecord<CoordinatorGroup>(row) : null;
 	}
 
-	listGroups(): Record<string, unknown>[] {
+	async listGroups(): Promise<CoordinatorGroup[]> {
 		return this.db
 			.prepare("SELECT group_id, display_name, created_at FROM groups ORDER BY created_at ASC")
 			.all()
-			.map(rowToRecord);
+			.map((row) => rowToRecord<CoordinatorGroup>(row));
 	}
 
 	// -- Devices ------------------------------------------------------------
 
-	enrollDevice(
-		groupId: string,
-		opts: {
-			deviceId: string;
-			fingerprint: string;
-			publicKey: string;
-			displayName?: string | null;
-		},
-	): void {
+	async enrollDevice(groupId: string, opts: CoordinatorEnrollDeviceInput): Promise<void> {
 		this.db
 			.prepare(
 				`INSERT INTO enrolled_devices(
@@ -248,7 +366,10 @@ export class CoordinatorStore {
 			);
 	}
 
-	listEnrolledDevices(groupId: string, includeDisabled = false): Record<string, unknown>[] {
+	async listEnrolledDevices(
+		groupId: string,
+		includeDisabled = false,
+	): Promise<CoordinatorEnrollment[]> {
 		const where = includeDisabled ? "" : "AND enabled = 1";
 		return this.db
 			.prepare(
@@ -258,10 +379,10 @@ export class CoordinatorStore {
 				 ORDER BY created_at ASC, device_id ASC`,
 			)
 			.all(groupId)
-			.map(rowToRecord);
+			.map((row) => rowToRecord<CoordinatorEnrollment>(row));
 	}
 
-	getEnrollment(groupId: string, deviceId: string): Record<string, unknown> | null {
+	async getEnrollment(groupId: string, deviceId: string): Promise<CoordinatorEnrollment | null> {
 		const row = this.db
 			.prepare(
 				`SELECT device_id, public_key, fingerprint, display_name
@@ -269,10 +390,10 @@ export class CoordinatorStore {
 				 WHERE group_id = ? AND device_id = ? AND enabled = 1`,
 			)
 			.get(groupId, deviceId);
-		return row ? rowToRecord(row) : null;
+		return row ? rowToRecord<CoordinatorEnrollment>(row) : null;
 	}
 
-	renameDevice(groupId: string, deviceId: string, displayName: string): boolean {
+	async renameDevice(groupId: string, deviceId: string, displayName: string): Promise<boolean> {
 		const result = this.db
 			.prepare(
 				`UPDATE enrolled_devices SET display_name = ?
@@ -282,7 +403,7 @@ export class CoordinatorStore {
 		return result.changes > 0;
 	}
 
-	setDeviceEnabled(groupId: string, deviceId: string, enabled: boolean): boolean {
+	async setDeviceEnabled(groupId: string, deviceId: string, enabled: boolean): Promise<boolean> {
 		const result = this.db
 			.prepare(
 				`UPDATE enrolled_devices SET enabled = ?
@@ -292,7 +413,7 @@ export class CoordinatorStore {
 		return result.changes > 0;
 	}
 
-	removeDevice(groupId: string, deviceId: string): boolean {
+	async removeDevice(groupId: string, deviceId: string): Promise<boolean> {
 		this.db
 			.prepare("DELETE FROM presence_records WHERE group_id = ? AND device_id = ?")
 			.run(groupId, deviceId);
@@ -302,18 +423,30 @@ export class CoordinatorStore {
 		return result.changes > 0;
 	}
 
+	// -- Nonces -------------------------------------------------------------
+
+	async recordNonce(deviceId: string, nonce: string, createdAt: string): Promise<boolean> {
+		try {
+			this.db
+				.prepare("INSERT INTO request_nonces(device_id, nonce, created_at) VALUES (?, ?, ?)")
+				.run(deviceId, nonce, createdAt);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async cleanupNonces(cutoff: string): Promise<void> {
+		this.db.prepare("DELETE FROM request_nonces WHERE created_at < ?").run(cutoff);
+	}
+
 	// -- Invites ------------------------------------------------------------
 
-	createInvite(opts: {
-		groupId: string;
-		policy: string;
-		expiresAt: string;
-		createdBy?: string | null;
-	}): Record<string, unknown> {
+	async createInvite(opts: CoordinatorCreateInviteInput): Promise<CoordinatorInvite> {
 		const now = nowISO();
 		const inviteId = tokenUrlSafe(12);
 		const token = tokenUrlSafe(24);
-		const group = this.getGroup(opts.groupId);
+		const group = await this.getGroup(opts.groupId);
 
 		this.db
 			.prepare(
@@ -338,10 +471,10 @@ export class CoordinatorStore {
 				 FROM coordinator_invites WHERE invite_id = ?`,
 			)
 			.get(inviteId);
-		return row ? rowToRecord(row) : {};
+		return rowToRecord<CoordinatorInvite>(row);
 	}
 
-	getInviteByToken(token: string): Record<string, unknown> | null {
+	async getInviteByToken(token: string): Promise<CoordinatorInvite | null> {
 		const row = this.db
 			.prepare(
 				`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
@@ -351,30 +484,25 @@ export class CoordinatorStore {
 				   AND expires_at > ?`,
 			)
 			.get(token, new Date().toISOString());
-		return row ? rowToRecord(row) : null;
+		return row ? rowToRecord<CoordinatorInvite>(row) : null;
 	}
 
-	listInvites(groupId: string): Record<string, unknown>[] {
+	async listInvites(groupId: string): Promise<CoordinatorInvite[]> {
 		return this.db
 			.prepare(
 				`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
 				 FROM coordinator_invites WHERE group_id = ?
-				 ORDER BY created_at ASC`,
+				 ORDER BY created_at DESC`,
 			)
 			.all(groupId)
-			.map(rowToRecord);
+			.map((row) => rowToRecord<CoordinatorInvite>(row));
 	}
 
 	// -- Join requests ------------------------------------------------------
 
-	createJoinRequest(opts: {
-		groupId: string;
-		deviceId: string;
-		publicKey: string;
-		fingerprint: string;
-		displayName?: string | null;
-		token: string;
-	}): Record<string, unknown> {
+	async createJoinRequest(
+		opts: CoordinatorCreateJoinRequestInput,
+	): Promise<CoordinatorJoinRequest> {
 		const now = nowISO();
 		const requestId = tokenUrlSafe(12);
 
@@ -401,10 +529,10 @@ export class CoordinatorStore {
 				 FROM coordinator_join_requests WHERE request_id = ?`,
 			)
 			.get(requestId);
-		return row ? rowToRecord(row) : {};
+		return rowToRecord<CoordinatorJoinRequest>(row);
 	}
 
-	listJoinRequests(groupId: string, status = "pending"): Record<string, unknown>[] {
+	async listJoinRequests(groupId: string, status = "pending"): Promise<CoordinatorJoinRequest[]> {
 		return this.db
 			.prepare(
 				`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
@@ -413,25 +541,24 @@ export class CoordinatorStore {
 				 ORDER BY created_at ASC, device_id ASC`,
 			)
 			.all(groupId, status)
-			.map(rowToRecord);
+			.map((row) => rowToRecord<CoordinatorJoinRequest>(row));
 	}
 
-	reviewJoinRequest(opts: {
-		requestId: string;
-		approved: boolean;
-		reviewedBy?: string | null;
-	}): (Record<string, unknown> & { _no_transition?: boolean }) | null {
+	async reviewJoinRequest(
+		opts: CoordinatorReviewJoinRequestInput,
+	): Promise<CoordinatorJoinRequestReviewResult | null> {
 		const row = this.db
 			.prepare(
-				`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status
+				`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status,
+				        created_at, reviewed_at, reviewed_by
 				 FROM coordinator_join_requests WHERE request_id = ?`,
 			)
-			.get(opts.requestId) as Record<string, unknown> | undefined;
+			.get(opts.requestId) as (CoordinatorJoinRequest & { public_key: string }) | undefined;
 
 		if (!row) return null;
 
 		if (row.status !== "pending") {
-			return { ...rowToRecord(row), _no_transition: true };
+			return { ...rowToRecord<CoordinatorJoinRequest>(row), _no_transition: true };
 		}
 
 		// Wrap enroll + status update in a transaction for atomicity
@@ -440,11 +567,11 @@ export class CoordinatorStore {
 			const nextStatus = opts.approved ? "approved" : "denied";
 
 			if (opts.approved) {
-				this.enrollDevice(row.group_id as string, {
-					deviceId: row.device_id as string,
-					fingerprint: row.fingerprint as string,
-					publicKey: row.public_key as string,
-					displayName: ((row.display_name as string) ?? "").trim() || null,
+				void this.enrollDevice(row.group_id, {
+					deviceId: row.device_id,
+					fingerprint: row.fingerprint,
+					publicKey: row.public_key,
+					displayName: (row.display_name ?? "").trim() || null,
 				});
 			}
 
@@ -462,19 +589,13 @@ export class CoordinatorStore {
 					 FROM coordinator_join_requests WHERE request_id = ?`,
 				)
 				.get(opts.requestId);
-			return updated ? rowToRecord(updated) : null;
+			return updated ? rowToRecord<CoordinatorJoinRequestReviewResult>(updated) : null;
 		})();
 	}
 
 	// -- Presence -----------------------------------------------------------
 
-	upsertPresence(opts: {
-		groupId: string;
-		deviceId: string;
-		addresses: string[];
-		ttlS: number;
-		capabilities?: Record<string, unknown> | null;
-	}): Record<string, unknown> {
+	async upsertPresence(opts: CoordinatorUpsertPresenceInput): Promise<CoordinatorPresenceRecord> {
 		const now = new Date();
 		const expiresAt = new Date(now.getTime() + opts.ttlS * 1000).toISOString();
 		const normalized = mergeAddresses([], opts.addresses);
@@ -506,7 +627,10 @@ export class CoordinatorStore {
 		};
 	}
 
-	listGroupPeers(groupId: string, requestingDeviceId: string): Record<string, unknown>[] {
+	async listGroupPeers(
+		groupId: string,
+		requestingDeviceId: string,
+	): Promise<CoordinatorPeerRecord[]> {
 		const now = new Date();
 		const rows = this.db
 			.prepare(
@@ -537,15 +661,20 @@ export class CoordinatorStore {
 				: mergeAddresses([], JSON.parse((row.addresses_json as string) || "[]") as string[]);
 
 			return {
-				device_id: row.device_id,
-				fingerprint: row.fingerprint,
-				display_name: row.display_name,
+				device_id: String(row.device_id ?? ""),
+				fingerprint: String(row.fingerprint ?? ""),
+				display_name: (row.display_name as string | null) ?? null,
 				addresses,
-				last_seen_at: row.last_seen_at,
-				expires_at: row.expires_at,
+				last_seen_at: (row.last_seen_at as string | null) ?? null,
+				expires_at: (row.expires_at as string | null) ?? null,
 				stale,
-				capabilities: JSON.parse((row.capabilities_json as string) || "{}"),
-			};
+				capabilities: JSON.parse((row.capabilities_json as string) || "{}") as Record<
+					string,
+					unknown
+				>,
+			} satisfies CoordinatorPeerRecord;
 		});
 	}
 }
+
+export const CoordinatorStore = BetterSqliteCoordinatorStore;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,7 +46,23 @@ export {
 	readCoordinatorSyncConfig,
 	registerCoordinatorPresence,
 } from "./coordinator-runtime.js";
+export type {
+	CoordinatorCreateInviteInput,
+	CoordinatorCreateJoinRequestInput,
+	CoordinatorEnrollDeviceInput,
+	CoordinatorEnrollment,
+	CoordinatorGroup,
+	CoordinatorInvite,
+	CoordinatorJoinRequest,
+	CoordinatorJoinRequestReviewResult,
+	CoordinatorPeerRecord,
+	CoordinatorPresenceRecord,
+	CoordinatorReviewJoinRequestInput,
+	CoordinatorStore as CoordinatorStoreInterface,
+	CoordinatorUpsertPresenceInput,
+} from "./coordinator-store.js";
 export {
+	BetterSqliteCoordinatorStore,
 	CoordinatorStore,
 	connectCoordinator,
 	DEFAULT_COORDINATOR_DB_PATH,


### PR DESCRIPTION
## Description
- Introduces explicit coordinator domain record/input types and the first server-side `CoordinatorStore` abstraction seam.
- Converts the coordinator store contract to async so the current better-sqlite implementation and future async backends like D1 share the same structural shape.
- Updates the current SQLite-backed store, coordinator actions, coordinator API, CLI callers, and local tests to await the contract without changing behavior.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Validation used for this slice:
  - `pnpm vitest run packages/core/src/coordinator-store.test.ts packages/core/src/coordinator-actions.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
