### PR TITLE
test(sync): add coordinator store parity harness

### DIFF
--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -1,0 +1,433 @@
+import { describe, expect, it } from "vitest";
+import type { CoordinatorStore } from "./coordinator-store-contract.js";
+
+export interface CoordinatorStoreHarnessContext<
+	TStore extends CoordinatorStore = CoordinatorStore,
+> {
+	store: TStore;
+	cleanup: () => Promise<void> | void;
+}
+
+export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
+	label: string,
+	setup: () => CoordinatorStoreHarnessContext<TStore>,
+): void {
+	describe(label, () => {
+		async function withContext(
+			run: (ctx: CoordinatorStoreHarnessContext<TStore>) => Promise<void> | void,
+		) {
+			const ctx = setup();
+			try {
+				await run(ctx);
+			} finally {
+				await ctx.cleanup();
+			}
+		}
+
+		describe("groups", () => {
+			it("creates and retrieves a group", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1", "Team Alpha");
+					const group = await store.getGroup("g1");
+					expect(group).not.toBeNull();
+					expect(group?.group_id).toBe("g1");
+					expect(group?.display_name).toBe("Team Alpha");
+					expect(group?.created_at).toBeTruthy();
+				});
+			});
+
+			it("returns null for missing group", async () => {
+				await withContext(async ({ store }) => {
+					expect(await store.getGroup("nope")).toBeNull();
+				});
+			});
+
+			it("INSERT OR IGNORE on duplicate group_id", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1", "Original");
+					await store.createGroup("g1", "Changed");
+					const group = await store.getGroup("g1");
+					expect(group?.display_name).toBe("Original");
+				});
+			});
+
+			it("lists groups", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.createGroup("g2", "Second");
+					expect(await store.listGroups()).toHaveLength(2);
+				});
+			});
+		});
+
+		describe("devices", () => {
+			it("enrolls and retrieves a device", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", {
+						deviceId: "d1",
+						fingerprint: "fp1",
+						publicKey: "pk1",
+						displayName: "Laptop",
+					});
+					const enrollment = await store.getEnrollment("g1", "d1");
+					expect(enrollment).not.toBeNull();
+					expect(enrollment?.device_id).toBe("d1");
+					expect(enrollment?.display_name).toBe("Laptop");
+				});
+			});
+
+			it("returns null for missing enrollment", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					expect(await store.getEnrollment("g1", "missing")).toBeNull();
+				});
+			});
+
+			it("upserts on re-enroll", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", {
+						deviceId: "d1",
+						fingerprint: "fp1",
+						publicKey: "pk1",
+						displayName: "Old",
+					});
+					await store.enrollDevice("g1", {
+						deviceId: "d1",
+						fingerprint: "fp2",
+						publicKey: "pk2",
+						displayName: "New",
+					});
+					const enrollment = await store.getEnrollment("g1", "d1");
+					expect(enrollment?.fingerprint).toBe("fp2");
+					expect(enrollment?.display_name).toBe("New");
+				});
+			});
+
+			it("lists enrolled devices", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
+					await store.enrollDevice("g1", { deviceId: "d2", fingerprint: "fp2", publicKey: "pk2" });
+					expect(await store.listEnrolledDevices("g1")).toHaveLength(2);
+				});
+			});
+
+			it("renames a device", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
+					expect(await store.renameDevice("g1", "d1", "Desktop")).toBe(true);
+					expect(await store.getEnrollment("g1", "d1")?.display_name).toBe("Desktop");
+				});
+			});
+
+			it("disables and re-enables a device", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
+					await store.setDeviceEnabled("g1", "d1", false);
+					expect(await store.listEnrolledDevices("g1")).toHaveLength(0);
+					expect(await store.listEnrolledDevices("g1", true)).toHaveLength(1);
+					await store.setDeviceEnabled("g1", "d1", true);
+					expect(await store.listEnrolledDevices("g1")).toHaveLength(1);
+				});
+			});
+
+			it("removes a device and its presence", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
+					await store.upsertPresence({
+						groupId: "g1",
+						deviceId: "d1",
+						addresses: ["http://localhost:9000"],
+						ttlS: 300,
+					});
+					expect(await store.removeDevice("g1", "d1")).toBe(true);
+					expect(await store.getEnrollment("g1", "d1")).toBeNull();
+					expect(await store.listGroupPeers("g1", "d2")).toEqual([]);
+				});
+			});
+
+			it("returns false when removing a non-existent device", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					expect(await store.removeDevice("g1", "ghost")).toBe(false);
+				});
+			});
+		});
+
+		describe("presence", () => {
+			it("upserts presence and returns normalized data", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
+					const result = await store.upsertPresence({
+						groupId: "g1",
+						deviceId: "d1",
+						addresses: ["http://localhost:9000"],
+						ttlS: 300,
+					});
+					expect(result.group_id).toBe("g1");
+					expect(result.device_id).toBe("d1");
+					expect(result.addresses).toEqual(["http://localhost:9000"]);
+					expect(result.expires_at).toBeTruthy();
+				});
+			});
+
+			it("lists group peers excluding requesting device", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
+					await store.enrollDevice("g1", { deviceId: "d2", fingerprint: "fp2", publicKey: "pk2" });
+					await store.upsertPresence({
+						groupId: "g1",
+						deviceId: "d1",
+						addresses: ["http://localhost:9000"],
+						ttlS: 300,
+					});
+					await store.upsertPresence({
+						groupId: "g1",
+						deviceId: "d2",
+						addresses: ["http://localhost:9001"],
+						ttlS: 300,
+					});
+					const peers = await store.listGroupPeers("g1", "d1");
+					expect(peers).toHaveLength(1);
+					const peer = peers[0]!;
+					expect(peer.device_id).toBe("d2");
+					expect(peer.stale).toBe(false);
+					expect(peer.addresses).toEqual(["http://localhost:9001"]);
+				});
+			});
+
+			it("marks stale presence with empty addresses", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
+					await store.enrollDevice("g1", { deviceId: "d2", fingerprint: "fp2", publicKey: "pk2" });
+					await store.upsertPresence({
+						groupId: "g1",
+						deviceId: "d2",
+						addresses: ["http://localhost:9001"],
+						ttlS: 0,
+					});
+					const peers = await store.listGroupPeers("g1", "d1");
+					expect(peers).toHaveLength(1);
+					const peer = peers[0]!;
+					expect(peer.stale).toBe(true);
+					expect(peer.addresses).toEqual([]);
+				});
+			});
+
+			it("shows enrolled peers with no presence record", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
+					await store.enrollDevice("g1", { deviceId: "d2", fingerprint: "fp2", publicKey: "pk2" });
+					const peers = await store.listGroupPeers("g1", "d1");
+					expect(peers).toHaveLength(1);
+					const peer = peers[0]!;
+					expect(peer.device_id).toBe("d2");
+					expect(peer.stale).toBe(true);
+					expect(peer.addresses).toEqual([]);
+				});
+			});
+		});
+
+		describe("invites", () => {
+			it("creates an invite and retrieves by token", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1", "Team Alpha");
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "auto_approve",
+						expiresAt: "2099-01-01T00:00:00Z",
+						createdBy: "admin",
+					});
+					expect(invite.invite_id).toBeTruthy();
+					expect(invite.group_id).toBe("g1");
+					expect(invite.policy).toBe("auto_approve");
+					expect(invite.team_name_snapshot).toBe("Team Alpha");
+					const byToken = await store.getInviteByToken(invite.token as string);
+					expect(byToken).not.toBeNull();
+					expect(byToken?.invite_id).toBe(invite.invite_id);
+				});
+			});
+
+			it("returns null for unknown token", async () => {
+				await withContext(async ({ store }) => {
+					expect(await store.getInviteByToken("nonexistent")).toBeNull();
+				});
+			});
+
+			it("lists invites for a group", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1", "Team Alpha");
+					await store.createInvite({
+						groupId: "g1",
+						policy: "auto_approve",
+						expiresAt: "2099-01-01T00:00:00Z",
+					});
+					await store.createInvite({
+						groupId: "g1",
+						policy: "manual_review",
+						expiresAt: "2099-06-01T00:00:00Z",
+					});
+					expect(await store.listInvites("g1")).toHaveLength(2);
+				});
+			});
+		});
+
+		describe("join requests", () => {
+			it("creates a join request in pending status", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "manual_review",
+						expiresAt: "2099-01-01T00:00:00Z",
+					});
+					const req = await store.createJoinRequest({
+						groupId: "g1",
+						deviceId: "d-new",
+						publicKey: "pk-new",
+						fingerprint: "fp-new",
+						displayName: "New Device",
+						token: invite.token,
+					});
+					expect(req.request_id).toBeTruthy();
+					expect(req.status).toBe("pending");
+					expect(req.device_id).toBe("d-new");
+				});
+			});
+
+			it("lists pending join requests", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "manual_review",
+						expiresAt: "2099-01-01T00:00:00Z",
+					});
+					await store.createJoinRequest({
+						groupId: "g1",
+						deviceId: "d1",
+						publicKey: "pk1",
+						fingerprint: "fp1",
+						token: invite.token,
+					});
+					await store.createJoinRequest({
+						groupId: "g1",
+						deviceId: "d2",
+						publicKey: "pk2",
+						fingerprint: "fp2",
+						token: invite.token,
+					});
+					expect(await store.listJoinRequests("g1")).toHaveLength(2);
+				});
+			});
+
+			it("approves a join request and enrolls the device", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "manual_review",
+						expiresAt: "2099-01-01T00:00:00Z",
+					});
+					const req = await store.createJoinRequest({
+						groupId: "g1",
+						deviceId: "d-new",
+						publicKey: "pk-new",
+						fingerprint: "fp-new",
+						displayName: "New Device",
+						token: invite.token,
+					});
+					const reviewed = await store.reviewJoinRequest({
+						requestId: req.request_id as string,
+						approved: true,
+						reviewedBy: "admin",
+					});
+					expect(reviewed).not.toBeNull();
+					expect(reviewed?.status).toBe("approved");
+					expect(reviewed?.reviewed_by).toBe("admin");
+					expect(await store.getEnrollment("g1", "d-new")?.fingerprint).toBe("fp-new");
+				});
+			});
+
+			it("denies a join request without enrolling", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "manual_review",
+						expiresAt: "2099-01-01T00:00:00Z",
+					});
+					const req = await store.createJoinRequest({
+						groupId: "g1",
+						deviceId: "d-new",
+						publicKey: "pk-new",
+						fingerprint: "fp-new",
+						token: invite.token,
+					});
+					const reviewed = await store.reviewJoinRequest({
+						requestId: req.request_id as string,
+						approved: false,
+					});
+					expect(reviewed?.status).toBe("denied");
+					expect(await store.getEnrollment("g1", "d-new")).toBeNull();
+				});
+			});
+
+			it("returns null for missing request_id", async () => {
+				await withContext(async ({ store }) => {
+					expect(await store.reviewJoinRequest({ requestId: "nope", approved: true })).toBeNull();
+				});
+			});
+
+			it("returns _no_transition for already-reviewed request", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "manual_review",
+						expiresAt: "2099-01-01T00:00:00Z",
+					});
+					const req = await store.createJoinRequest({
+						groupId: "g1",
+						deviceId: "d-new",
+						publicKey: "pk-new",
+						fingerprint: "fp-new",
+						token: invite.token,
+					});
+					await store.reviewJoinRequest({ requestId: req.request_id as string, approved: true });
+					const again = await store.reviewJoinRequest({
+						requestId: req.request_id as string,
+						approved: false,
+					});
+					expect(again?._no_transition).toBe(true);
+				});
+			});
+		});
+
+		describe("nonces", () => {
+			it("records a nonce once and rejects replay", async () => {
+				await withContext(async ({ store }) => {
+					expect(await store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:00Z")).toBe(true);
+					expect(await store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:01Z")).toBe(false);
+				});
+			});
+
+			it("allows nonce cleanup and reuse after cutoff", async () => {
+				await withContext(async ({ store }) => {
+					expect(await store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:00Z")).toBe(true);
+					await store.cleanupNonces("2026-03-28T00:00:01Z");
+					expect(await store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:02Z")).toBe(true);
+				});
+			});
+		});
+	});
+}

--- a/packages/core/src/coordinator-store.test.ts
+++ b/packages/core/src/coordinator-store.test.ts
@@ -1,358 +1,46 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { BetterSqliteCoordinatorStore as CoordinatorStore } from "./coordinator-store.js";
+import { describe, expect, it } from "vitest";
+import { BetterSqliteCoordinatorStore } from "./better-sqlite-coordinator-store.js";
+import { runCoordinatorStoreContract } from "./coordinator-store-test-harness.js";
 
 describe("CoordinatorStore", () => {
-	let tmpDir: string;
-	let store: CoordinatorStore;
-
-	beforeEach(async () => {
-		tmpDir = mkdtempSync(join(tmpdir(), "coord-test-"));
-		store = new CoordinatorStore(join(tmpDir, "coordinator.sqlite"));
-	});
-
-	afterEach(async () => {
-		await store.close();
-		rmSync(tmpDir, { recursive: true, force: true });
-	});
+	function setupStore() {
+		const tmpDir = mkdtempSync(join(tmpdir(), "coord-test-"));
+		const store = new BetterSqliteCoordinatorStore(join(tmpDir, "coordinator.sqlite"));
+		return {
+			store,
+			cleanup: async () => {
+				await store.close();
+				rmSync(tmpDir, { recursive: true, force: true });
+			},
+		};
+	}
 
 	describe("schema", () => {
 		it("creates all expected tables", async () => {
-			const tables = store.db
-				.prepare(
-					"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
-				)
-				.all() as { name: string }[];
-			const names = tables.map((t) => t.name).sort();
-			expect(names).toEqual([
-				"coordinator_invites",
-				"coordinator_join_requests",
-				"enrolled_devices",
-				"groups",
-				"presence_records",
-				"request_nonces",
-			]);
+			const { store, cleanup } = setupStore();
+			try {
+				const tables = store.db
+					.prepare(
+						"SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+					)
+					.all() as { name: string }[];
+				const names = tables.map((t) => t.name).sort();
+				expect(names).toEqual([
+					"coordinator_invites",
+					"coordinator_join_requests",
+					"enrolled_devices",
+					"groups",
+					"presence_records",
+					"request_nonces",
+				]);
+			} finally {
+				await cleanup();
+			}
 		});
 	});
 
-	describe("groups", () => {
-		it("creates and retrieves a group", async () => {
-			await store.createGroup("g1", "Team Alpha");
-			const group = await store.getGroup("g1");
-			expect(group).not.toBeNull();
-			expect(group?.group_id).toBe("g1");
-			expect(group?.display_name).toBe("Team Alpha");
-			expect(group?.created_at).toBeTruthy();
-		});
-
-		it("returns null for missing group", async () => {
-			expect(await store.getGroup("nope")).toBeNull();
-		});
-
-		it("INSERT OR IGNORE on duplicate group_id", async () => {
-			await store.createGroup("g1", "Original");
-			await store.createGroup("g1", "Changed");
-			const group = await store.getGroup("g1");
-			expect(group?.display_name).toBe("Original");
-		});
-
-		it("lists groups", async () => {
-			await store.createGroup("g1");
-			await store.createGroup("g2", "Second");
-			const groups = await store.listGroups();
-			expect(groups).toHaveLength(2);
-		});
-	});
-
-	describe("devices", () => {
-		beforeEach(async () => {
-			await store.createGroup("g1");
-		});
-
-		it("enrolls and retrieves a device", async () => {
-			await store.enrollDevice("g1", {
-				deviceId: "d1",
-				fingerprint: "fp1",
-				publicKey: "pk1",
-				displayName: "Laptop",
-			});
-			const enrollment = await store.getEnrollment("g1", "d1");
-			expect(enrollment).not.toBeNull();
-			expect(enrollment?.device_id).toBe("d1");
-			expect(enrollment?.display_name).toBe("Laptop");
-		});
-
-		it("returns null for missing enrollment", async () => {
-			expect(await store.getEnrollment("g1", "missing")).toBeNull();
-		});
-
-		it("upserts on re-enroll", async () => {
-			await store.enrollDevice("g1", {
-				deviceId: "d1",
-				fingerprint: "fp1",
-				publicKey: "pk1",
-				displayName: "Old",
-			});
-			await store.enrollDevice("g1", {
-				deviceId: "d1",
-				fingerprint: "fp2",
-				publicKey: "pk2",
-				displayName: "New",
-			});
-			const enrollment = await store.getEnrollment("g1", "d1");
-			expect(enrollment?.fingerprint).toBe("fp2");
-			expect(enrollment?.display_name).toBe("New");
-		});
-
-		it("lists enrolled devices", async () => {
-			await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
-			await store.enrollDevice("g1", { deviceId: "d2", fingerprint: "fp2", publicKey: "pk2" });
-			expect(await store.listEnrolledDevices("g1")).toHaveLength(2);
-		});
-
-		it("renames a device", async () => {
-			await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
-			expect(await store.renameDevice("g1", "d1", "Desktop")).toBe(true);
-			const enrollment = await store.getEnrollment("g1", "d1");
-			expect(enrollment?.display_name).toBe("Desktop");
-		});
-
-		it("disables and re-enables a device", async () => {
-			await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
-			await store.setDeviceEnabled("g1", "d1", false);
-			expect(await store.listEnrolledDevices("g1")).toHaveLength(0);
-			expect(await store.listEnrolledDevices("g1", true)).toHaveLength(1);
-			await store.setDeviceEnabled("g1", "d1", true);
-			expect(await store.listEnrolledDevices("g1")).toHaveLength(1);
-		});
-
-		it("removes a device and its presence", async () => {
-			await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
-			await store.upsertPresence({
-				groupId: "g1",
-				deviceId: "d1",
-				addresses: ["http://localhost:9000"],
-				ttlS: 300,
-			});
-			expect(await store.removeDevice("g1", "d1")).toBe(true);
-			expect(await store.getEnrollment("g1", "d1")).toBeNull();
-			const presence = store.db
-				.prepare("SELECT * FROM presence_records WHERE group_id = ? AND device_id = ?")
-				.get("g1", "d1");
-			expect(presence).toBeUndefined();
-		});
-
-		it("returns false when removing a non-existent device", async () => {
-			expect(await store.removeDevice("g1", "ghost")).toBe(false);
-		});
-	});
-
-	describe("presence", () => {
-		beforeEach(async () => {
-			await store.createGroup("g1");
-			await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
-			await store.enrollDevice("g1", { deviceId: "d2", fingerprint: "fp2", publicKey: "pk2" });
-		});
-
-		it("upserts presence and returns normalized data", async () => {
-			const result = await store.upsertPresence({
-				groupId: "g1",
-				deviceId: "d1",
-				addresses: ["http://localhost:9000"],
-				ttlS: 300,
-			});
-			expect(result.group_id).toBe("g1");
-			expect(result.device_id).toBe("d1");
-			expect(result.addresses).toEqual(["http://localhost:9000"]);
-			expect(result.expires_at).toBeTruthy();
-		});
-
-		it("lists group peers excluding requesting device", async () => {
-			await store.upsertPresence({
-				groupId: "g1",
-				deviceId: "d1",
-				addresses: ["http://localhost:9000"],
-				ttlS: 300,
-			});
-			await store.upsertPresence({
-				groupId: "g1",
-				deviceId: "d2",
-				addresses: ["http://localhost:9001"],
-				ttlS: 300,
-			});
-			const peers = await store.listGroupPeers("g1", "d1");
-			expect(peers).toHaveLength(1);
-			expect(peers[0]?.device_id).toBe("d2");
-			expect(peers[0]?.stale).toBe(false);
-			expect(peers[0]?.addresses).toEqual(["http://localhost:9001"]);
-		});
-
-		it("marks stale presence with empty addresses", async () => {
-			await store.upsertPresence({
-				groupId: "g1",
-				deviceId: "d2",
-				addresses: ["http://localhost:9001"],
-				ttlS: 0,
-			});
-			const peers = await store.listGroupPeers("g1", "d1");
-			expect(peers).toHaveLength(1);
-			expect(peers[0]?.stale).toBe(true);
-			expect(peers[0]?.addresses).toEqual([]);
-		});
-
-		it("shows enrolled peers with no presence record", async () => {
-			const peers = await store.listGroupPeers("g1", "d1");
-			expect(peers).toHaveLength(1);
-			expect(peers[0]?.device_id).toBe("d2");
-			expect(peers[0]?.stale).toBe(true);
-			expect(peers[0]?.addresses).toEqual([]);
-		});
-	});
-
-	describe("invites", () => {
-		beforeEach(async () => {
-			await store.createGroup("g1", "Team Alpha");
-		});
-
-		it("creates an invite and retrieves by token", async () => {
-			const invite = await store.createInvite({
-				groupId: "g1",
-				policy: "auto_approve",
-				expiresAt: "2099-01-01T00:00:00Z",
-				createdBy: "admin",
-			});
-			expect(invite.invite_id).toBeTruthy();
-			expect(invite.group_id).toBe("g1");
-			expect(invite.policy).toBe("auto_approve");
-			expect(invite.team_name_snapshot).toBe("Team Alpha");
-			const byToken = await store.getInviteByToken(invite.token as string);
-			expect(byToken).not.toBeNull();
-			expect(byToken?.invite_id).toBe(invite.invite_id);
-		});
-
-		it("returns null for unknown token", async () => {
-			expect(await store.getInviteByToken("nonexistent")).toBeNull();
-		});
-
-		it("lists invites for a group", async () => {
-			await store.createInvite({
-				groupId: "g1",
-				policy: "auto_approve",
-				expiresAt: "2099-01-01T00:00:00Z",
-			});
-			await store.createInvite({
-				groupId: "g1",
-				policy: "manual_review",
-				expiresAt: "2099-06-01T00:00:00Z",
-			});
-			expect(await store.listInvites("g1")).toHaveLength(2);
-		});
-	});
-
-	describe("join requests", () => {
-		let inviteToken: string;
-
-		beforeEach(async () => {
-			await store.createGroup("g1");
-			const invite = await store.createInvite({
-				groupId: "g1",
-				policy: "manual_review",
-				expiresAt: "2099-01-01T00:00:00Z",
-			});
-			inviteToken = invite.token as string;
-		});
-
-		it("creates a join request in pending status", async () => {
-			const req = await store.createJoinRequest({
-				groupId: "g1",
-				deviceId: "d-new",
-				publicKey: "pk-new",
-				fingerprint: "fp-new",
-				displayName: "New Device",
-				token: inviteToken,
-			});
-			expect(req.request_id).toBeTruthy();
-			expect(req.status).toBe("pending");
-			expect(req.device_id).toBe("d-new");
-		});
-
-		it("lists pending join requests", async () => {
-			await store.createJoinRequest({
-				groupId: "g1",
-				deviceId: "d1",
-				publicKey: "pk1",
-				fingerprint: "fp1",
-				token: inviteToken,
-			});
-			await store.createJoinRequest({
-				groupId: "g1",
-				deviceId: "d2",
-				publicKey: "pk2",
-				fingerprint: "fp2",
-				token: inviteToken,
-			});
-			const pending = await store.listJoinRequests("g1");
-			expect(pending).toHaveLength(2);
-		});
-
-		it("approves a join request and enrolls the device", async () => {
-			const req = await store.createJoinRequest({
-				groupId: "g1",
-				deviceId: "d-new",
-				publicKey: "pk-new",
-				fingerprint: "fp-new",
-				displayName: "New Device",
-				token: inviteToken,
-			});
-			const reviewed = await store.reviewJoinRequest({
-				requestId: req.request_id as string,
-				approved: true,
-				reviewedBy: "admin",
-			});
-			expect(reviewed).not.toBeNull();
-			expect(reviewed?.status).toBe("approved");
-			expect(reviewed?.reviewed_by).toBe("admin");
-			const enrollment = await store.getEnrollment("g1", "d-new");
-			expect(enrollment).not.toBeNull();
-			expect(enrollment?.fingerprint).toBe("fp-new");
-		});
-
-		it("denies a join request without enrolling", async () => {
-			const req = await store.createJoinRequest({
-				groupId: "g1",
-				deviceId: "d-new",
-				publicKey: "pk-new",
-				fingerprint: "fp-new",
-				token: inviteToken,
-			});
-			const reviewed = await store.reviewJoinRequest({
-				requestId: req.request_id as string,
-				approved: false,
-			});
-			expect(reviewed?.status).toBe("denied");
-			expect(await store.getEnrollment("g1", "d-new")).toBeNull();
-		});
-
-		it("returns null for missing request_id", async () => {
-			expect(await store.reviewJoinRequest({ requestId: "nope", approved: true })).toBeNull();
-		});
-
-		it("returns _no_transition for already-reviewed request", async () => {
-			const req = await store.createJoinRequest({
-				groupId: "g1",
-				deviceId: "d-new",
-				publicKey: "pk-new",
-				fingerprint: "fp-new",
-				token: inviteToken,
-			});
-			await store.reviewJoinRequest({ requestId: req.request_id as string, approved: true });
-			const again = await store.reviewJoinRequest({
-				requestId: req.request_id as string,
-				approved: false,
-			});
-			expect(again?._no_transition).toBe(true);
-		});
-	});
+	runCoordinatorStoreContract("contract", setupStore);
 });

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -1,0 +1,130 @@
+import type {
+	CoordinatorCreateInviteInput,
+	CoordinatorCreateJoinRequestInput,
+	CoordinatorEnrollDeviceInput,
+	CoordinatorEnrollment,
+	CoordinatorGroup,
+	CoordinatorInvite,
+	CoordinatorJoinRequest,
+	CoordinatorJoinRequestReviewResult,
+	CoordinatorPeerRecord,
+	CoordinatorPresenceRecord,
+	CoordinatorReviewJoinRequestInput,
+	CoordinatorStore,
+	CoordinatorUpsertPresenceInput,
+} from "./coordinator-store-contract.js";
+
+/**
+ * Experimental D1 adapter scaffold.
+ *
+ * This is intentionally internal for now while the sync-only store contract
+ * is still being validated against an async backend shape.
+ */
+
+export interface D1PreparedStatementLike {
+	bind(...values: unknown[]): D1PreparedStatementLike;
+	first<T = unknown>(): Promise<T | null>;
+	run(): Promise<unknown>;
+	all<T = unknown>(): Promise<{ results?: T[] }>;
+	raw<T = unknown>(): Promise<T[]>;
+}
+
+export interface D1DatabaseLike {
+	prepare(query: string): D1PreparedStatementLike;
+	batch?(statements: D1PreparedStatementLike[]): Promise<unknown[]>;
+	exec?(query: string): Promise<unknown>;
+}
+
+function notImplemented(method: string): never {
+	throw new Error(`D1CoordinatorStore.${method} is not implemented yet.`);
+}
+
+export class D1CoordinatorStore implements CoordinatorStore {
+	readonly db: D1DatabaseLike;
+
+	constructor(db: D1DatabaseLike) {
+		this.db = db;
+	}
+
+	close(): void {
+		// No-op for D1 bindings.
+	}
+
+	createGroup(_groupId: string, _displayName?: string | null): void {
+		notImplemented("createGroup");
+	}
+
+	getGroup(_groupId: string): CoordinatorGroup | null {
+		notImplemented("getGroup");
+	}
+
+	listGroups(): CoordinatorGroup[] {
+		notImplemented("listGroups");
+	}
+
+	enrollDevice(_groupId: string, _opts: CoordinatorEnrollDeviceInput): void {
+		notImplemented("enrollDevice");
+	}
+
+	listEnrolledDevices(_groupId: string, _includeDisabled?: boolean): CoordinatorEnrollment[] {
+		notImplemented("listEnrolledDevices");
+	}
+
+	getEnrollment(_groupId: string, _deviceId: string): CoordinatorEnrollment | null {
+		notImplemented("getEnrollment");
+	}
+
+	renameDevice(_groupId: string, _deviceId: string, _displayName: string): boolean {
+		notImplemented("renameDevice");
+	}
+
+	setDeviceEnabled(_groupId: string, _deviceId: string, _enabled: boolean): boolean {
+		notImplemented("setDeviceEnabled");
+	}
+
+	removeDevice(_groupId: string, _deviceId: string): boolean {
+		notImplemented("removeDevice");
+	}
+
+	recordNonce(_deviceId: string, _nonce: string, _createdAt: string): boolean {
+		notImplemented("recordNonce");
+	}
+
+	cleanupNonces(_cutoff: string): void {
+		notImplemented("cleanupNonces");
+	}
+
+	createInvite(_opts: CoordinatorCreateInviteInput): CoordinatorInvite {
+		notImplemented("createInvite");
+	}
+
+	getInviteByToken(_token: string): CoordinatorInvite | null {
+		notImplemented("getInviteByToken");
+	}
+
+	listInvites(_groupId: string): CoordinatorInvite[] {
+		notImplemented("listInvites");
+	}
+
+	createJoinRequest(_opts: CoordinatorCreateJoinRequestInput): CoordinatorJoinRequest {
+		notImplemented("createJoinRequest");
+	}
+
+	listJoinRequests(_groupId: string, _status?: string): CoordinatorJoinRequest[] {
+		notImplemented("listJoinRequests");
+	}
+
+	reviewJoinRequest(
+		_opts: CoordinatorReviewJoinRequestInput,
+	): CoordinatorJoinRequestReviewResult | null {
+		notImplemented("reviewJoinRequest");
+	}
+
+	upsertPresence(_opts: CoordinatorUpsertPresenceInput): CoordinatorPresenceRecord {
+		notImplemented("upsertPresence");
+	}
+
+	listGroupPeers(_groupId: string, _requestingDeviceId: string): CoordinatorPeerRecord[] {
+		notImplemented("listGroupPeers");
+	}
+}


### PR DESCRIPTION
## Description
- Extracts a reusable coordinator store parity harness from the current better-sqlite store tests.
- Keeps the current better-sqlite adapter on that shared contract while adding an internal `D1CoordinatorStore` scaffold as a future async adapter target.
- Intentionally keeps the D1 scaffold internal-only for now, so the slice improves adapter groundwork without pretending D1 support already exists.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Validation used for this slice:
  - `pnpm vitest run packages/core/src/coordinator-api.test.ts packages/core/src/coordinator-store.test.ts packages/core/src/coordinator-actions.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
