### PR TITLE
refactor(sync): make coordinator store contract async

### DIFF
--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -176,31 +176,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		this.db = connectCoordinator(this.path);
 	}
 
-	close(): void {
-		this.db.close();
-	}
-
-	createGroup(groupId: string, displayName?: string | null): void {
-		this.db
-			.prepare("INSERT OR IGNORE INTO groups(group_id, display_name, created_at) VALUES (?, ?, ?)")
-			.run(groupId, displayName ?? null, nowISO());
-	}
-
-	getGroup(groupId: string): CoordinatorGroup | null {
-		const row = this.db
-			.prepare("SELECT group_id, display_name, created_at FROM groups WHERE group_id = ?")
-			.get(groupId);
-		return row ? rowToRecord<CoordinatorGroup>(row) : null;
-	}
-
-	listGroups(): CoordinatorGroup[] {
-		return this.db
-			.prepare("SELECT group_id, display_name, created_at FROM groups ORDER BY created_at ASC")
-			.all()
-			.map((row) => rowToRecord<CoordinatorGroup>(row));
-	}
-
-	enrollDevice(groupId: string, opts: CoordinatorEnrollDeviceInput): void {
+	private enrollDeviceSync(groupId: string, opts: CoordinatorEnrollDeviceInput): void {
 		this.db
 			.prepare(`INSERT INTO enrolled_devices(
 					group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
@@ -220,7 +196,38 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 			);
 	}
 
-	listEnrolledDevices(groupId: string, includeDisabled = false): CoordinatorEnrollment[] {
+	async close(): Promise<void> {
+		this.db.close();
+	}
+
+	async createGroup(groupId: string, displayName?: string | null): Promise<void> {
+		this.db
+			.prepare("INSERT OR IGNORE INTO groups(group_id, display_name, created_at) VALUES (?, ?, ?)")
+			.run(groupId, displayName ?? null, nowISO());
+	}
+
+	async getGroup(groupId: string): Promise<CoordinatorGroup | null> {
+		const row = this.db
+			.prepare("SELECT group_id, display_name, created_at FROM groups WHERE group_id = ?")
+			.get(groupId);
+		return row ? rowToRecord<CoordinatorGroup>(row) : null;
+	}
+
+	async listGroups(): Promise<CoordinatorGroup[]> {
+		return this.db
+			.prepare("SELECT group_id, display_name, created_at FROM groups ORDER BY created_at ASC")
+			.all()
+			.map((row) => rowToRecord<CoordinatorGroup>(row));
+	}
+
+	async enrollDevice(groupId: string, opts: CoordinatorEnrollDeviceInput): Promise<void> {
+		this.enrollDeviceSync(groupId, opts);
+	}
+
+	async listEnrolledDevices(
+		groupId: string,
+		includeDisabled = false,
+	): Promise<CoordinatorEnrollment[]> {
 		const where = includeDisabled ? "" : "AND enabled = 1";
 		return this.db
 			.prepare(`SELECT group_id, device_id, fingerprint, display_name, enabled, created_at
@@ -231,7 +238,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 			.map((row) => rowToRecord<CoordinatorEnrollment>(row));
 	}
 
-	getEnrollment(groupId: string, deviceId: string): CoordinatorEnrollment | null {
+	async getEnrollment(groupId: string, deviceId: string): Promise<CoordinatorEnrollment | null> {
 		const row = this.db
 			.prepare(`SELECT device_id, public_key, fingerprint, display_name
 				 FROM enrolled_devices
@@ -240,7 +247,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		return row ? rowToRecord<CoordinatorEnrollment>(row) : null;
 	}
 
-	renameDevice(groupId: string, deviceId: string, displayName: string): boolean {
+	async renameDevice(groupId: string, deviceId: string, displayName: string): Promise<boolean> {
 		const result = this.db
 			.prepare(`UPDATE enrolled_devices SET display_name = ?
 				 WHERE group_id = ? AND device_id = ?`)
@@ -248,7 +255,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		return result.changes > 0;
 	}
 
-	setDeviceEnabled(groupId: string, deviceId: string, enabled: boolean): boolean {
+	async setDeviceEnabled(groupId: string, deviceId: string, enabled: boolean): Promise<boolean> {
 		const result = this.db
 			.prepare(`UPDATE enrolled_devices SET enabled = ?
 				 WHERE group_id = ? AND device_id = ?`)
@@ -256,7 +263,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		return result.changes > 0;
 	}
 
-	removeDevice(groupId: string, deviceId: string): boolean {
+	async removeDevice(groupId: string, deviceId: string): Promise<boolean> {
 		this.db
 			.prepare("DELETE FROM presence_records WHERE group_id = ? AND device_id = ?")
 			.run(groupId, deviceId);
@@ -266,7 +273,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		return result.changes > 0;
 	}
 
-	recordNonce(deviceId: string, nonce: string, createdAt: string): boolean {
+	async recordNonce(deviceId: string, nonce: string, createdAt: string): Promise<boolean> {
 		try {
 			this.db
 				.prepare("INSERT INTO request_nonces(device_id, nonce, created_at) VALUES (?, ?, ?)")
@@ -277,15 +284,15 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		}
 	}
 
-	cleanupNonces(cutoff: string): void {
+	async cleanupNonces(cutoff: string): Promise<void> {
 		this.db.prepare("DELETE FROM request_nonces WHERE created_at < ?").run(cutoff);
 	}
 
-	createInvite(opts: CoordinatorCreateInviteInput): CoordinatorInvite {
+	async createInvite(opts: CoordinatorCreateInviteInput): Promise<CoordinatorInvite> {
 		const now = nowISO();
 		const inviteId = tokenUrlSafe(12);
 		const token = tokenUrlSafe(24);
-		const group = this.getGroup(opts.groupId);
+		const group = await this.getGroup(opts.groupId);
 		this.db
 			.prepare(`INSERT INTO coordinator_invites(
 					invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
@@ -307,7 +314,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		return rowToRecord<CoordinatorInvite>(row);
 	}
 
-	getInviteByToken(token: string): CoordinatorInvite | null {
+	async getInviteByToken(token: string): Promise<CoordinatorInvite | null> {
 		const row = this.db
 			.prepare(`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
 				 FROM coordinator_invites
@@ -318,7 +325,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		return row ? rowToRecord<CoordinatorInvite>(row) : null;
 	}
 
-	listInvites(groupId: string): CoordinatorInvite[] {
+	async listInvites(groupId: string): Promise<CoordinatorInvite[]> {
 		return this.db
 			.prepare(`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
 				 FROM coordinator_invites WHERE group_id = ?
@@ -327,7 +334,9 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 			.map((row) => rowToRecord<CoordinatorInvite>(row));
 	}
 
-	createJoinRequest(opts: CoordinatorCreateJoinRequestInput): CoordinatorJoinRequest {
+	async createJoinRequest(
+		opts: CoordinatorCreateJoinRequestInput,
+	): Promise<CoordinatorJoinRequest> {
 		const now = nowISO();
 		const requestId = tokenUrlSafe(12);
 		this.db
@@ -351,7 +360,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		return rowToRecord<CoordinatorJoinRequest>(row);
 	}
 
-	listJoinRequests(groupId: string, status = "pending"): CoordinatorJoinRequest[] {
+	async listJoinRequests(groupId: string, status = "pending"): Promise<CoordinatorJoinRequest[]> {
 		return this.db
 			.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
 				 FROM coordinator_join_requests
@@ -361,9 +370,9 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 			.map((row) => rowToRecord<CoordinatorJoinRequest>(row));
 	}
 
-	reviewJoinRequest(
+	async reviewJoinRequest(
 		opts: CoordinatorReviewJoinRequestInput,
-	): CoordinatorJoinRequestReviewResult | null {
+	): Promise<CoordinatorJoinRequestReviewResult | null> {
 		const row = this.db
 			.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status,
 				        created_at, reviewed_at, reviewed_by
@@ -376,7 +385,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 			const reviewedAt = nowISO();
 			const nextStatus = opts.approved ? "approved" : "denied";
 			if (opts.approved) {
-				this.enrollDevice(row.group_id, {
+				this.enrollDeviceSync(row.group_id, {
 					deviceId: row.device_id,
 					fingerprint: row.fingerprint,
 					publicKey: row.public_key,
@@ -396,7 +405,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		})();
 	}
 
-	upsertPresence(opts: CoordinatorUpsertPresenceInput): CoordinatorPresenceRecord {
+	async upsertPresence(opts: CoordinatorUpsertPresenceInput): Promise<CoordinatorPresenceRecord> {
 		const now = new Date();
 		const expiresAt = new Date(now.getTime() + opts.ttlS * 1000).toISOString();
 		const normalized = mergeAddresses([], opts.addresses);
@@ -424,7 +433,10 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		};
 	}
 
-	listGroupPeers(groupId: string, requestingDeviceId: string): CoordinatorPeerRecord[] {
+	async listGroupPeers(
+		groupId: string,
+		requestingDeviceId: string,
+	): Promise<CoordinatorPeerRecord[]> {
 		const now = new Date();
 		const rows = this.db
 			.prepare(`SELECT enrolled_devices.device_id, enrolled_devices.fingerprint, enrolled_devices.display_name,

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -170,7 +170,7 @@ export async function coordinatorCreateGroupAction(opts: {
 		if (!group) throw new Error(`Failed to create group: ${groupId}`);
 		return group;
 	} finally {
-		store.close();
+		await store.close();
 	}
 }
 
@@ -181,7 +181,7 @@ export async function coordinatorListGroupsAction(opts?: {
 	try {
 		return await store.listGroups();
 	} finally {
-		store.close();
+		await store.close();
 	}
 }
 
@@ -213,7 +213,7 @@ export async function coordinatorEnrollDeviceAction(opts: {
 		if (!enrollment) throw new Error(`Failed to enroll device: ${deviceId}`);
 		return enrollment;
 	} finally {
-		store.close();
+		await store.close();
 	}
 }
 
@@ -228,7 +228,7 @@ export async function coordinatorListDevicesAction(opts: {
 	try {
 		return await store.listEnrolledDevices(groupId, opts.includeDisabled === true);
 	} finally {
-		store.close();
+		await store.close();
 	}
 }
 
@@ -253,7 +253,7 @@ export async function coordinatorRenameDeviceAction(opts: {
 		const all = await store.listEnrolledDevices(groupId, true);
 		return all.find((device) => device.device_id === deviceId) ?? null;
 	} finally {
-		store.close();
+		await store.close();
 	}
 }
 
@@ -269,7 +269,7 @@ export async function coordinatorDisableDeviceAction(opts: {
 	try {
 		return await store.setDeviceEnabled(groupId, deviceId, false);
 	} finally {
-		store.close();
+		await store.close();
 	}
 }
 
@@ -285,7 +285,7 @@ export async function coordinatorRemoveDeviceAction(opts: {
 	try {
 		return await store.removeDevice(groupId, deviceId);
 	} finally {
-		store.close();
+		await store.close();
 	}
 }
 
@@ -333,7 +333,7 @@ export async function coordinatorCreateInviteAction(opts: {
 	if (!resolvedCoordinatorUrl) throw new Error("Coordinator URL required.");
 	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		const group = store.getGroup(opts.groupId);
+		const group = await store.getGroup(opts.groupId);
 		if (!group) throw new Error(`Group not found: ${opts.groupId}`);
 		const invite = await store.createInvite({
 			groupId: opts.groupId,
@@ -361,7 +361,7 @@ export async function coordinatorCreateInviteAction(opts: {
 			mode: "local",
 		};
 	} finally {
-		store.close();
+		await store.close();
 	}
 }
 
@@ -449,7 +449,7 @@ export async function coordinatorListJoinRequestsAction(opts: {
 	try {
 		return await store.listJoinRequests(opts.groupId);
 	} finally {
-		store.close();
+		await store.close();
 	}
 }
 
@@ -490,6 +490,6 @@ export async function coordinatorReviewJoinRequestAction(opts: {
 			reviewedBy: opts.reviewedBy ?? null,
 		});
 	} finally {
-		store.close();
+		await store.close();
 	}
 }

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -224,7 +224,7 @@ export function createCoordinatorApp(
 
 			return c.json({ ok: true, ...response });
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -257,7 +257,7 @@ export function createCoordinatorApp(
 			const items = await store.listGroupPeers(groupId, String(auth.enrollment.device_id));
 			return c.json({ items });
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -303,14 +303,14 @@ export function createCoordinatorApp(
 				displayName,
 			});
 		} finally {
-			store.close();
+			await store.close();
 		}
 
 		return c.json({ ok: true });
 	});
 
 	// GET /v1/admin/devices — list enrolled devices
-	app.get("/v1/admin/devices", (c) => {
+	app.get("/v1/admin/devices", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
@@ -323,9 +323,9 @@ export function createCoordinatorApp(
 
 		const store = createStore();
 		try {
-			return c.json({ items: store.listEnrolledDevices(groupId, includeDisabled) });
+			return c.json({ items: await store.listEnrolledDevices(groupId, includeDisabled) });
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -360,11 +360,11 @@ export function createCoordinatorApp(
 
 		const store = createStore();
 		try {
-			const ok = store.renameDevice(groupId, deviceId, displayName);
+			const ok = await store.renameDevice(groupId, deviceId, displayName);
 			if (!ok) return c.json({ error: "device_not_found" }, 404);
 			return c.json({ ok: true });
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -395,11 +395,11 @@ export function createCoordinatorApp(
 
 		const store = createStore();
 		try {
-			const ok = store.setDeviceEnabled(groupId, deviceId, false);
+			const ok = await store.setDeviceEnabled(groupId, deviceId, false);
 			if (!ok) return c.json({ error: "device_not_found" }, 404);
 			return c.json({ ok: true });
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -430,11 +430,11 @@ export function createCoordinatorApp(
 
 		const store = createStore();
 		try {
-			const ok = store.removeDevice(groupId, deviceId);
+			const ok = await store.removeDevice(groupId, deviceId);
 			if (!ok) return c.json({ error: "device_not_found" }, 404);
 			return c.json({ ok: true });
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -500,7 +500,7 @@ export function createCoordinatorApp(
 				link: inviteLink(encoded),
 			});
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -519,7 +519,7 @@ export function createCoordinatorApp(
 			);
 			return c.json({ items: rows });
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -545,7 +545,7 @@ export function createCoordinatorApp(
 		try {
 			return c.json({ items: await store.listJoinRequests(groupId) });
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -640,7 +640,7 @@ export function createCoordinatorApp(
 				policy: invite.policy,
 			});
 		} finally {
-			store.close();
+			await store.close();
 		}
 	});
 
@@ -693,6 +693,6 @@ async function handleJoinRequestReview(
 
 		return c.json({ ok: true, request });
 	} finally {
-		store.close();
+		await store.close();
 	}
 }

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -100,26 +100,26 @@ export interface CoordinatorUpsertPresenceInput {
 }
 
 export interface CoordinatorStore {
-	close(): void;
-	createGroup(groupId: string, displayName?: string | null): void;
-	getGroup(groupId: string): CoordinatorGroup | null;
-	listGroups(): CoordinatorGroup[];
-	enrollDevice(groupId: string, opts: CoordinatorEnrollDeviceInput): void;
-	listEnrolledDevices(groupId: string, includeDisabled?: boolean): CoordinatorEnrollment[];
-	getEnrollment(groupId: string, deviceId: string): CoordinatorEnrollment | null;
-	renameDevice(groupId: string, deviceId: string, displayName: string): boolean;
-	setDeviceEnabled(groupId: string, deviceId: string, enabled: boolean): boolean;
-	removeDevice(groupId: string, deviceId: string): boolean;
-	recordNonce(deviceId: string, nonce: string, createdAt: string): boolean;
-	cleanupNonces(cutoff: string): void;
-	createInvite(opts: CoordinatorCreateInviteInput): CoordinatorInvite;
-	getInviteByToken(token: string): CoordinatorInvite | null;
-	listInvites(groupId: string): CoordinatorInvite[];
-	createJoinRequest(opts: CoordinatorCreateJoinRequestInput): CoordinatorJoinRequest;
-	listJoinRequests(groupId: string, status?: string): CoordinatorJoinRequest[];
+	close(): Promise<void>;
+	createGroup(groupId: string, displayName?: string | null): Promise<void>;
+	getGroup(groupId: string): Promise<CoordinatorGroup | null>;
+	listGroups(): Promise<CoordinatorGroup[]>;
+	enrollDevice(groupId: string, opts: CoordinatorEnrollDeviceInput): Promise<void>;
+	listEnrolledDevices(groupId: string, includeDisabled?: boolean): Promise<CoordinatorEnrollment[]>;
+	getEnrollment(groupId: string, deviceId: string): Promise<CoordinatorEnrollment | null>;
+	renameDevice(groupId: string, deviceId: string, displayName: string): Promise<boolean>;
+	setDeviceEnabled(groupId: string, deviceId: string, enabled: boolean): Promise<boolean>;
+	removeDevice(groupId: string, deviceId: string): Promise<boolean>;
+	recordNonce(deviceId: string, nonce: string, createdAt: string): Promise<boolean>;
+	cleanupNonces(cutoff: string): Promise<void>;
+	createInvite(opts: CoordinatorCreateInviteInput): Promise<CoordinatorInvite>;
+	getInviteByToken(token: string): Promise<CoordinatorInvite | null>;
+	listInvites(groupId: string): Promise<CoordinatorInvite[]>;
+	createJoinRequest(opts: CoordinatorCreateJoinRequestInput): Promise<CoordinatorJoinRequest>;
+	listJoinRequests(groupId: string, status?: string): Promise<CoordinatorJoinRequest[]>;
 	reviewJoinRequest(
 		opts: CoordinatorReviewJoinRequestInput,
-	): CoordinatorJoinRequestReviewResult | null;
-	upsertPresence(opts: CoordinatorUpsertPresenceInput): CoordinatorPresenceRecord;
-	listGroupPeers(groupId: string, requestingDeviceId: string): CoordinatorPeerRecord[];
+	): Promise<CoordinatorJoinRequestReviewResult | null>;
+	upsertPresence(opts: CoordinatorUpsertPresenceInput): Promise<CoordinatorPresenceRecord>;
+	listGroupPeers(groupId: string, requestingDeviceId: string): Promise<CoordinatorPeerRecord[]>;
 }

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -119,7 +119,8 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					await store.createGroup("g1");
 					await store.enrollDevice("g1", { deviceId: "d1", fingerprint: "fp1", publicKey: "pk1" });
 					expect(await store.renameDevice("g1", "d1", "Desktop")).toBe(true);
-					expect(await store.getEnrollment("g1", "d1")?.display_name).toBe("Desktop");
+					const enrollment = await store.getEnrollment("g1", "d1");
+					expect(enrollment?.display_name).toBe("Desktop");
 				});
 			});
 
@@ -354,7 +355,8 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					expect(reviewed).not.toBeNull();
 					expect(reviewed?.status).toBe("approved");
 					expect(reviewed?.reviewed_by).toBe("admin");
-					expect(await store.getEnrollment("g1", "d-new")?.fingerprint).toBe("fp-new");
+					const enrollment = await store.getEnrollment("g1", "d-new");
+					expect(enrollment?.fingerprint).toBe("fp-new");
 				});
 			});
 

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -46,85 +46,93 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		this.db = db;
 	}
 
-	close(): void {
+	async close(): Promise<void> {
 		// No-op for D1 bindings.
 	}
 
-	createGroup(_groupId: string, _displayName?: string | null): void {
+	async createGroup(_groupId: string, _displayName?: string | null): Promise<void> {
 		notImplemented("createGroup");
 	}
 
-	getGroup(_groupId: string): CoordinatorGroup | null {
+	async getGroup(_groupId: string): Promise<CoordinatorGroup | null> {
 		notImplemented("getGroup");
 	}
 
-	listGroups(): CoordinatorGroup[] {
+	async listGroups(): Promise<CoordinatorGroup[]> {
 		notImplemented("listGroups");
 	}
 
-	enrollDevice(_groupId: string, _opts: CoordinatorEnrollDeviceInput): void {
+	async enrollDevice(_groupId: string, _opts: CoordinatorEnrollDeviceInput): Promise<void> {
 		notImplemented("enrollDevice");
 	}
 
-	listEnrolledDevices(_groupId: string, _includeDisabled?: boolean): CoordinatorEnrollment[] {
+	async listEnrolledDevices(
+		_groupId: string,
+		_includeDisabled?: boolean,
+	): Promise<CoordinatorEnrollment[]> {
 		notImplemented("listEnrolledDevices");
 	}
 
-	getEnrollment(_groupId: string, _deviceId: string): CoordinatorEnrollment | null {
+	async getEnrollment(_groupId: string, _deviceId: string): Promise<CoordinatorEnrollment | null> {
 		notImplemented("getEnrollment");
 	}
 
-	renameDevice(_groupId: string, _deviceId: string, _displayName: string): boolean {
+	async renameDevice(_groupId: string, _deviceId: string, _displayName: string): Promise<boolean> {
 		notImplemented("renameDevice");
 	}
 
-	setDeviceEnabled(_groupId: string, _deviceId: string, _enabled: boolean): boolean {
+	async setDeviceEnabled(_groupId: string, _deviceId: string, _enabled: boolean): Promise<boolean> {
 		notImplemented("setDeviceEnabled");
 	}
 
-	removeDevice(_groupId: string, _deviceId: string): boolean {
+	async removeDevice(_groupId: string, _deviceId: string): Promise<boolean> {
 		notImplemented("removeDevice");
 	}
 
-	recordNonce(_deviceId: string, _nonce: string, _createdAt: string): boolean {
+	async recordNonce(_deviceId: string, _nonce: string, _createdAt: string): Promise<boolean> {
 		notImplemented("recordNonce");
 	}
 
-	cleanupNonces(_cutoff: string): void {
+	async cleanupNonces(_cutoff: string): Promise<void> {
 		notImplemented("cleanupNonces");
 	}
 
-	createInvite(_opts: CoordinatorCreateInviteInput): CoordinatorInvite {
+	async createInvite(_opts: CoordinatorCreateInviteInput): Promise<CoordinatorInvite> {
 		notImplemented("createInvite");
 	}
 
-	getInviteByToken(_token: string): CoordinatorInvite | null {
+	async getInviteByToken(_token: string): Promise<CoordinatorInvite | null> {
 		notImplemented("getInviteByToken");
 	}
 
-	listInvites(_groupId: string): CoordinatorInvite[] {
+	async listInvites(_groupId: string): Promise<CoordinatorInvite[]> {
 		notImplemented("listInvites");
 	}
 
-	createJoinRequest(_opts: CoordinatorCreateJoinRequestInput): CoordinatorJoinRequest {
+	async createJoinRequest(
+		_opts: CoordinatorCreateJoinRequestInput,
+	): Promise<CoordinatorJoinRequest> {
 		notImplemented("createJoinRequest");
 	}
 
-	listJoinRequests(_groupId: string, _status?: string): CoordinatorJoinRequest[] {
+	async listJoinRequests(_groupId: string, _status?: string): Promise<CoordinatorJoinRequest[]> {
 		notImplemented("listJoinRequests");
 	}
 
-	reviewJoinRequest(
+	async reviewJoinRequest(
 		_opts: CoordinatorReviewJoinRequestInput,
-	): CoordinatorJoinRequestReviewResult | null {
+	): Promise<CoordinatorJoinRequestReviewResult | null> {
 		notImplemented("reviewJoinRequest");
 	}
 
-	upsertPresence(_opts: CoordinatorUpsertPresenceInput): CoordinatorPresenceRecord {
+	async upsertPresence(_opts: CoordinatorUpsertPresenceInput): Promise<CoordinatorPresenceRecord> {
 		notImplemented("upsertPresence");
 	}
 
-	listGroupPeers(_groupId: string, _requestingDeviceId: string): CoordinatorPeerRecord[] {
+	async listGroupPeers(
+		_groupId: string,
+		_requestingDeviceId: string,
+	): Promise<CoordinatorPeerRecord[]> {
 		notImplemented("listGroupPeers");
 	}
 }


### PR DESCRIPTION
## Description
- Converts the coordinator store contract to async so future backends like D1 fit the contract naturally instead of being forced through a sync-shaped adapter.
- Updates the current better-sqlite implementation, coordinator app/actions, and parity tests to await the contract while preserving behavior.
- Keeps the D1 scaffold aligned with the new async contract shape without claiming real D1 support yet.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Validation used for this slice:
  - `pnpm vitest run packages/core/src/coordinator-api.test.ts packages/core/src/coordinator-store.test.ts packages/core/src/coordinator-actions.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
