### PR TITLE
feat(sync): implement first D1 coordinator store slice

### DIFF
--- a/packages/core/src/d1-coordinator-store.test.ts
+++ b/packages/core/src/d1-coordinator-store.test.ts
@@ -1,0 +1,171 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Database as DatabaseType, Statement } from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connectCoordinator } from "./better-sqlite-coordinator-store.js";
+import {
+	D1CoordinatorStore,
+	type D1DatabaseLike,
+	type D1PreparedStatementLike,
+} from "./d1-coordinator-store.js";
+
+class SqliteD1Statement implements D1PreparedStatementLike {
+	private bound: unknown[] = [];
+
+	constructor(private readonly statement: Statement) {}
+
+	bind(...values: unknown[]): D1PreparedStatementLike {
+		this.bound = values;
+		return this;
+	}
+
+	async first<T = unknown>(): Promise<T | null> {
+		return (this.statement.get(...this.bound) as T | undefined) ?? null;
+	}
+
+	async run(): Promise<unknown> {
+		const result = this.statement.run(...this.bound);
+		return { meta: { changes: result.changes } };
+	}
+
+	async all<T = unknown>(): Promise<{ results?: T[] }> {
+		return { results: this.statement.all(...this.bound) as T[] };
+	}
+
+	async raw<T = unknown>(): Promise<T[]> {
+		return this.statement.raw(true).all(...this.bound) as T[];
+	}
+}
+
+class SqliteD1Database implements D1DatabaseLike {
+	constructor(private readonly db: DatabaseType) {}
+
+	prepare(query: string): D1PreparedStatementLike {
+		return new SqliteD1Statement(this.db.prepare(query));
+	}
+}
+
+describe("D1CoordinatorStore", () => {
+	let tmpDir: string;
+	let db: DatabaseType;
+	let store: D1CoordinatorStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "d1-coord-test-"));
+		db = connectCoordinator(join(tmpDir, "coordinator.sqlite"));
+		store = new D1CoordinatorStore(new SqliteD1Database(db));
+	});
+
+	afterEach(async () => {
+		await store.close();
+		db.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("creates and lists groups", async () => {
+		await store.createGroup("g1", "Team Alpha");
+		await store.createGroup("g2", null);
+		expect(await store.getGroup("g1")).toEqual(
+			expect.objectContaining({ group_id: "g1", display_name: "Team Alpha" }),
+		);
+		expect(await store.listGroups()).toHaveLength(2);
+	});
+
+	it("enrolls, renames, disables, and removes devices", async () => {
+		await store.createGroup("g1");
+		await store.enrollDevice("g1", {
+			deviceId: "d1",
+			fingerprint: "fp1",
+			publicKey: "pk1",
+			displayName: "Laptop",
+		});
+		expect(await store.getEnrollment("g1", "d1")).toEqual(
+			expect.objectContaining({ device_id: "d1", display_name: "Laptop", fingerprint: "fp1" }),
+		);
+		expect(await store.renameDevice("g1", "d1", "Desktop")).toBe(true);
+		expect(await store.getEnrollment("g1", "d1")).toEqual(
+			expect.objectContaining({ display_name: "Desktop" }),
+		);
+		await store.setDeviceEnabled("g1", "d1", false);
+		expect(await store.listEnrolledDevices("g1")).toEqual([]);
+		expect(await store.listEnrolledDevices("g1", true)).toEqual([
+			expect.objectContaining({ device_id: "d1", enabled: 0 }),
+		]);
+		expect(await store.removeDevice("g1", "d1")).toBe(true);
+		expect(await store.listEnrolledDevices("g1", true)).toEqual([]);
+	});
+
+	it("creates and lists invites", async () => {
+		await store.createGroup("g1", "Team Alpha");
+		const invite = await store.createInvite({
+			groupId: "g1",
+			policy: "auto_admit",
+			expiresAt: "2099-01-01T00:00:00Z",
+			createdBy: "admin",
+		});
+		expect(invite.team_name_snapshot).toBe("Team Alpha");
+		expect(await store.getInviteByToken(invite.token)).toEqual(
+			expect.objectContaining({ invite_id: invite.invite_id, group_id: "g1" }),
+		);
+		expect(await store.listInvites("g1")).toHaveLength(1);
+	});
+
+	it("creates, lists, and reviews join requests", async () => {
+		await store.createGroup("g1");
+		const request = await store.createJoinRequest({
+			groupId: "g1",
+			deviceId: "d1",
+			publicKey: "pk1",
+			fingerprint: "fp1",
+			displayName: "Laptop",
+			token: "token-1",
+		});
+		expect(request.status).toBe("pending");
+		expect(await store.listJoinRequests("g1")).toHaveLength(1);
+		const approved = await store.reviewJoinRequest({
+			requestId: request.request_id,
+			approved: true,
+			reviewedBy: "admin",
+		});
+		expect(approved).toEqual(expect.objectContaining({ status: "approved", reviewed_by: "admin" }));
+		expect(await store.getEnrollment("g1", "d1")).toEqual(
+			expect.objectContaining({ device_id: "d1", fingerprint: "fp1" }),
+		);
+		const again = await store.reviewJoinRequest({ requestId: request.request_id, approved: false });
+		expect(again?._no_transition).toBe(true);
+		expect(again?.status).toBe("approved");
+	});
+
+	it("denies a join request without enrolling the device", async () => {
+		await store.createGroup("g1");
+		const request = await store.createJoinRequest({
+			groupId: "g1",
+			deviceId: "d2",
+			publicKey: "pk2",
+			fingerprint: "fp2",
+			token: "token-2",
+		});
+		const denied = await store.reviewJoinRequest({
+			requestId: request.request_id,
+			approved: false,
+		});
+		expect(denied).toEqual(expect.objectContaining({ status: "denied" }));
+		expect(await store.getEnrollment("g1", "d2")).toBeNull();
+	});
+
+	it("still throws for unimplemented presence and nonce operations", async () => {
+		await expect(store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:00Z")).rejects.toThrow(
+			"D1CoordinatorStore.recordNonce is not implemented yet.",
+		);
+		await expect(store.cleanupNonces("2026-03-28T00:00:00Z")).rejects.toThrow(
+			"D1CoordinatorStore.cleanupNonces is not implemented yet.",
+		);
+		await expect(
+			store.upsertPresence({ groupId: "g1", deviceId: "d1", addresses: [], ttlS: 60 }),
+		).rejects.toThrow("D1CoordinatorStore.upsertPresence is not implemented yet.");
+		await expect(store.listGroupPeers("g1", "d1")).rejects.toThrow(
+			"D1CoordinatorStore.listGroupPeers is not implemented yet.",
+		);
+	});
+});

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -14,6 +14,12 @@ import type {
 	CoordinatorUpsertPresenceInput,
 } from "./coordinator-store-contract.js";
 
+interface D1RunResultLike {
+	meta?: {
+		changes?: number;
+	};
+}
+
 /**
  * Experimental D1 adapter scaffold.
  *
@@ -39,6 +45,40 @@ function notImplemented(method: string): never {
 	throw new Error(`D1CoordinatorStore.${method} is not implemented yet.`);
 }
 
+function rowToRecord<T>(row: unknown): T {
+	if (row == null) throw new Error("expected row");
+	return row as T;
+}
+
+function nowISO(): string {
+	return new Date().toISOString();
+}
+
+function tokenUrlSafe(bytes: number): string {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+	const random = new Uint8Array(bytes);
+	globalThis.crypto.getRandomValues(random);
+	const output: string[] = [];
+	for (const byte of random) {
+		output.push(alphabet[byte % alphabet.length] ?? "A");
+	}
+	return output.join("");
+}
+
+async function allRows<T>(statement: D1PreparedStatementLike): Promise<T[]> {
+	const result = await statement.all<T>();
+	return Array.isArray(result?.results) ? result.results : [];
+}
+
+async function firstRow<T>(statement: D1PreparedStatementLike): Promise<T | null> {
+	return await statement.first<T>();
+}
+
+async function runChanges(statement: D1PreparedStatementLike): Promise<number> {
+	const result = (await statement.run()) as D1RunResultLike | undefined;
+	return Number(result?.meta?.changes ?? 0);
+}
+
 export class D1CoordinatorStore implements CoordinatorStore {
 	readonly db: D1DatabaseLike;
 
@@ -51,42 +91,114 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	}
 
 	async createGroup(_groupId: string, _displayName?: string | null): Promise<void> {
-		notImplemented("createGroup");
+		await this.db
+			.prepare("INSERT OR IGNORE INTO groups(group_id, display_name, created_at) VALUES (?, ?, ?)")
+			.bind(_groupId, _displayName ?? null, nowISO())
+			.run();
 	}
 
 	async getGroup(_groupId: string): Promise<CoordinatorGroup | null> {
-		notImplemented("getGroup");
+		const row = await firstRow<CoordinatorGroup>(
+			this.db
+				.prepare("SELECT group_id, display_name, created_at FROM groups WHERE group_id = ?")
+				.bind(_groupId),
+		);
+		return row ? rowToRecord<CoordinatorGroup>(row) : null;
 	}
 
 	async listGroups(): Promise<CoordinatorGroup[]> {
-		notImplemented("listGroups");
+		return (
+			await allRows<CoordinatorGroup>(
+				this.db.prepare(
+					"SELECT group_id, display_name, created_at FROM groups ORDER BY created_at ASC",
+				),
+			)
+		).map((row) => rowToRecord<CoordinatorGroup>(row));
 	}
 
 	async enrollDevice(_groupId: string, _opts: CoordinatorEnrollDeviceInput): Promise<void> {
-		notImplemented("enrollDevice");
+		await this.db
+			.prepare(`INSERT INTO enrolled_devices(
+				group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+			) VALUES (?, ?, ?, ?, ?, 1, ?)
+			ON CONFLICT(group_id, device_id) DO UPDATE SET
+				public_key = excluded.public_key,
+				fingerprint = excluded.fingerprint,
+				display_name = excluded.display_name,
+				enabled = 1`)
+			.bind(
+				_groupId,
+				_opts.deviceId,
+				_opts.publicKey,
+				_opts.fingerprint,
+				_opts.displayName ?? null,
+				nowISO(),
+			)
+			.run();
 	}
 
 	async listEnrolledDevices(
 		_groupId: string,
 		_includeDisabled?: boolean,
 	): Promise<CoordinatorEnrollment[]> {
-		notImplemented("listEnrolledDevices");
+		const where = _includeDisabled ? "" : "AND enabled = 1";
+		return (
+			await allRows<CoordinatorEnrollment>(
+				this.db
+					.prepare(`SELECT group_id, device_id, fingerprint, display_name, enabled, created_at
+					 FROM enrolled_devices
+					 WHERE group_id = ? ${where}
+					 ORDER BY created_at ASC, device_id ASC`)
+					.bind(_groupId),
+			)
+		).map((row) => rowToRecord<CoordinatorEnrollment>(row));
 	}
 
 	async getEnrollment(_groupId: string, _deviceId: string): Promise<CoordinatorEnrollment | null> {
-		notImplemented("getEnrollment");
+		const row = await firstRow<CoordinatorEnrollment>(
+			this.db
+				.prepare(`SELECT device_id, public_key, fingerprint, display_name
+					 FROM enrolled_devices
+					 WHERE group_id = ? AND device_id = ? AND enabled = 1`)
+				.bind(_groupId, _deviceId),
+		);
+		return row ? rowToRecord<CoordinatorEnrollment>(row) : null;
 	}
 
 	async renameDevice(_groupId: string, _deviceId: string, _displayName: string): Promise<boolean> {
-		notImplemented("renameDevice");
+		return (
+			(await runChanges(
+				this.db
+					.prepare(`UPDATE enrolled_devices SET display_name = ?
+					 WHERE group_id = ? AND device_id = ?`)
+					.bind(_displayName, _groupId, _deviceId),
+			)) > 0
+		);
 	}
 
 	async setDeviceEnabled(_groupId: string, _deviceId: string, _enabled: boolean): Promise<boolean> {
-		notImplemented("setDeviceEnabled");
+		return (
+			(await runChanges(
+				this.db
+					.prepare(`UPDATE enrolled_devices SET enabled = ?
+					 WHERE group_id = ? AND device_id = ?`)
+					.bind(_enabled ? 1 : 0, _groupId, _deviceId),
+			)) > 0
+		);
 	}
 
 	async removeDevice(_groupId: string, _deviceId: string): Promise<boolean> {
-		notImplemented("removeDevice");
+		await this.db
+			.prepare("DELETE FROM presence_records WHERE group_id = ? AND device_id = ?")
+			.bind(_groupId, _deviceId)
+			.run();
+		return (
+			(await runChanges(
+				this.db
+					.prepare("DELETE FROM enrolled_devices WHERE group_id = ? AND device_id = ?")
+					.bind(_groupId, _deviceId),
+			)) > 0
+		);
 	}
 
 	async recordNonce(_deviceId: string, _nonce: string, _createdAt: string): Promise<boolean> {
@@ -98,31 +210,182 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	}
 
 	async createInvite(_opts: CoordinatorCreateInviteInput): Promise<CoordinatorInvite> {
-		notImplemented("createInvite");
+		const now = nowISO();
+		const inviteId = tokenUrlSafe(12);
+		const token = tokenUrlSafe(24);
+		const group = await this.getGroup(_opts.groupId);
+		await this.db
+			.prepare(`INSERT INTO coordinator_invites(
+				invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`)
+			.bind(
+				inviteId,
+				_opts.groupId,
+				token,
+				_opts.policy,
+				_opts.expiresAt,
+				now,
+				_opts.createdBy ?? null,
+				group?.display_name ?? null,
+			)
+			.run();
+		const row = await firstRow<CoordinatorInvite>(
+			this.db
+				.prepare(`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+					 FROM coordinator_invites WHERE invite_id = ?`)
+				.bind(inviteId),
+		);
+		return rowToRecord<CoordinatorInvite>(row);
 	}
 
 	async getInviteByToken(_token: string): Promise<CoordinatorInvite | null> {
-		notImplemented("getInviteByToken");
+		const row = await firstRow<CoordinatorInvite>(
+			this.db
+				.prepare(`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+					 FROM coordinator_invites
+					 WHERE token = ?
+					   AND revoked_at IS NULL
+					   AND expires_at > ?`)
+				.bind(_token, nowISO()),
+		);
+		return row ? rowToRecord<CoordinatorInvite>(row) : null;
 	}
 
 	async listInvites(_groupId: string): Promise<CoordinatorInvite[]> {
-		notImplemented("listInvites");
+		return (
+			await allRows<CoordinatorInvite>(
+				this.db
+					.prepare(`SELECT invite_id, group_id, token, policy, expires_at, created_at, created_by, team_name_snapshot, revoked_at
+					 FROM coordinator_invites WHERE group_id = ?
+					 ORDER BY created_at DESC`)
+					.bind(_groupId),
+			)
+		).map((row) => rowToRecord<CoordinatorInvite>(row));
 	}
 
 	async createJoinRequest(
 		_opts: CoordinatorCreateJoinRequestInput,
 	): Promise<CoordinatorJoinRequest> {
-		notImplemented("createJoinRequest");
+		const now = nowISO();
+		const requestId = tokenUrlSafe(12);
+		await this.db
+			.prepare(`INSERT INTO coordinator_join_requests(
+				request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+			) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, NULL, NULL)`)
+			.bind(
+				requestId,
+				_opts.groupId,
+				_opts.deviceId,
+				_opts.publicKey,
+				_opts.fingerprint,
+				_opts.displayName ?? null,
+				_opts.token,
+				now,
+			)
+			.run();
+		const row = await firstRow<CoordinatorJoinRequest>(
+			this.db
+				.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+					 FROM coordinator_join_requests WHERE request_id = ?`)
+				.bind(requestId),
+		);
+		return rowToRecord<CoordinatorJoinRequest>(row);
 	}
 
 	async listJoinRequests(_groupId: string, _status?: string): Promise<CoordinatorJoinRequest[]> {
-		notImplemented("listJoinRequests");
+		const status = _status ?? "pending";
+		return (
+			await allRows<CoordinatorJoinRequest>(
+				this.db
+					.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+					 FROM coordinator_join_requests
+					 WHERE group_id = ? AND status = ?
+					 ORDER BY created_at ASC, device_id ASC`)
+					.bind(_groupId, status),
+			)
+		).map((row) => rowToRecord<CoordinatorJoinRequest>(row));
 	}
 
 	async reviewJoinRequest(
 		_opts: CoordinatorReviewJoinRequestInput,
 	): Promise<CoordinatorJoinRequestReviewResult | null> {
-		notImplemented("reviewJoinRequest");
+		const row = await firstRow<CoordinatorJoinRequest & { public_key: string }>(
+			this.db
+				.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status,
+					        created_at, reviewed_at, reviewed_by
+					 FROM coordinator_join_requests WHERE request_id = ?`)
+				.bind(_opts.requestId),
+		);
+		if (!row) return null;
+		if (row.status !== "pending") {
+			return { ...rowToRecord<CoordinatorJoinRequest>(row), _no_transition: true };
+		}
+		const reviewedAt = nowISO();
+		const nextStatus = _opts.approved ? "approved" : "denied";
+		if (this.db.batch) {
+			const statements: D1PreparedStatementLike[] = [];
+			statements.push(
+				this.db
+					.prepare(`UPDATE coordinator_join_requests
+						 SET status = ?, reviewed_at = ?, reviewed_by = ?
+						 WHERE request_id = ? AND status = 'pending'`)
+					.bind(nextStatus, reviewedAt, _opts.reviewedBy ?? null, _opts.requestId),
+			);
+			if (_opts.approved) {
+				statements.push(
+					this.db
+						.prepare(`INSERT INTO enrolled_devices(
+							group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+						)
+						SELECT group_id, device_id, public_key, fingerprint, display_name, 1, ?
+						FROM coordinator_join_requests
+						WHERE request_id = ?
+						  AND status = 'approved'
+						  AND reviewed_at = ?
+						ON CONFLICT(group_id, device_id) DO UPDATE SET
+							public_key = excluded.public_key,
+							fingerprint = excluded.fingerprint,
+							display_name = excluded.display_name,
+							enabled = 1`)
+						.bind(nowISO(), _opts.requestId, reviewedAt),
+				);
+			}
+			await this.db.batch(statements);
+		} else {
+			const changes = await runChanges(
+				this.db
+					.prepare(`UPDATE coordinator_join_requests
+						 SET status = ?, reviewed_at = ?, reviewed_by = ?
+						 WHERE request_id = ? AND status = 'pending'`)
+					.bind(nextStatus, reviewedAt, _opts.reviewedBy ?? null, _opts.requestId),
+			);
+			if (changes === 0) {
+				const latest = await firstRow<CoordinatorJoinRequestReviewResult>(
+					this.db
+						.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+							 FROM coordinator_join_requests WHERE request_id = ?`)
+						.bind(_opts.requestId),
+				);
+				return latest
+					? { ...rowToRecord<CoordinatorJoinRequestReviewResult>(latest), _no_transition: true }
+					: null;
+			}
+			if (_opts.approved) {
+				await this.enrollDevice(row.group_id, {
+					deviceId: row.device_id,
+					fingerprint: row.fingerprint,
+					publicKey: row.public_key,
+					displayName: (row.display_name ?? "").trim() || null,
+				});
+			}
+		}
+		const updated = await firstRow<CoordinatorJoinRequestReviewResult>(
+			this.db
+				.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+					 FROM coordinator_join_requests WHERE request_id = ?`)
+				.bind(_opts.requestId),
+		);
+		return updated ? rowToRecord<CoordinatorJoinRequestReviewResult>(updated) : null;
 	}
 
 	async upsertPresence(_opts: CoordinatorUpsertPresenceInput): Promise<CoordinatorPresenceRecord> {


### PR DESCRIPTION
## Description
- Implements the first real `D1CoordinatorStore` subset on top of the async coordinator contract.
- Covers groups, enrollments/reads, invites, join requests, and join review/enrollment.
- Keeps unsupported areas explicit for now: presence, peer listing, and nonce operations still throw `not implemented`.
- Adds local tests using a SQLite-backed D1-shaped test double to validate the supported subset before Cloudflare runtime wiring.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Validation used for this slice:
  - `pnpm vitest run packages/core/src/d1-coordinator-store.test.ts packages/core/src/coordinator-api.test.ts packages/core/src/coordinator-store.test.ts packages/core/src/coordinator-actions.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
