### PR TITLE
feat(sync): implement D1 coordinator discovery core

### DIFF
--- a/packages/core/src/d1-coordinator-store.test.ts
+++ b/packages/core/src/d1-coordinator-store.test.ts
@@ -29,6 +29,11 @@ class SqliteD1Statement implements D1PreparedStatementLike {
 		return { meta: { changes: result.changes } };
 	}
 
+	executeRunSync(): unknown {
+		const result = this.statement.run(...this.bound);
+		return { meta: { changes: result.changes } };
+	}
+
 	async all<T = unknown>(): Promise<{ results?: T[] }> {
 		return { results: this.statement.all(...this.bound) as T[] };
 	}
@@ -43,6 +48,19 @@ class SqliteD1Database implements D1DatabaseLike {
 
 	prepare(query: string): D1PreparedStatementLike {
 		return new SqliteD1Statement(this.db.prepare(query));
+	}
+
+	async batch(statements: D1PreparedStatementLike[]): Promise<unknown[]> {
+		return this.db.transaction(() => {
+			const results: unknown[] = [];
+			for (const statement of statements) {
+				if (!(statement instanceof SqliteD1Statement)) {
+					throw new Error("Unsupported D1 statement test double.");
+				}
+				results.push(statement.executeRunSync());
+			}
+			return results;
+		})();
 	}
 }
 
@@ -154,18 +172,67 @@ describe("D1CoordinatorStore", () => {
 		expect(await store.getEnrollment("g1", "d2")).toBeNull();
 	});
 
-	it("still throws for unimplemented presence and nonce operations", async () => {
-		await expect(store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:00Z")).rejects.toThrow(
-			"D1CoordinatorStore.recordNonce is not implemented yet.",
+	it("implements nonce replay protection, presence upsert, and peer listing", async () => {
+		await expect(store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:00Z")).resolves.toBe(true);
+		await expect(store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:01Z")).resolves.toBe(false);
+		await store.cleanupNonces("2026-03-28T00:00:01Z");
+		await expect(store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:02Z")).resolves.toBe(true);
+		await store.createGroup("g1");
+		await store.enrollDevice("g1", {
+			deviceId: "d1",
+			fingerprint: "fp1",
+			publicKey: "pk1",
+		});
+		await store.enrollDevice("g1", {
+			deviceId: "d2",
+			fingerprint: "fp2",
+			publicKey: "pk2",
+		});
+		const presence = await store.upsertPresence({
+			groupId: "g1",
+			deviceId: "d2",
+			addresses: ["http://localhost:9001", "localhost:9001/"],
+			ttlS: 60,
+			capabilities: { role: "peer" },
+		});
+		expect(presence).toEqual(
+			expect.objectContaining({
+				group_id: "g1",
+				device_id: "d2",
+				addresses: ["http://localhost:9001"],
+			}),
 		);
-		await expect(store.cleanupNonces("2026-03-28T00:00:00Z")).rejects.toThrow(
-			"D1CoordinatorStore.cleanupNonces is not implemented yet.",
-		);
-		await expect(
-			store.upsertPresence({ groupId: "g1", deviceId: "d1", addresses: [], ttlS: 60 }),
-		).rejects.toThrow("D1CoordinatorStore.upsertPresence is not implemented yet.");
-		await expect(store.listGroupPeers("g1", "d1")).rejects.toThrow(
-			"D1CoordinatorStore.listGroupPeers is not implemented yet.",
-		);
+		await expect(store.listGroupPeers("g1", "d1")).resolves.toEqual([
+			expect.objectContaining({
+				device_id: "d2",
+				fingerprint: "fp2",
+				stale: false,
+				addresses: ["http://localhost:9001"],
+				capabilities: { role: "peer" },
+			}),
+		]);
+	});
+
+	it("marks stale peers with empty addresses", async () => {
+		await store.createGroup("g1");
+		await store.enrollDevice("g1", {
+			deviceId: "d1",
+			fingerprint: "fp1",
+			publicKey: "pk1",
+		});
+		await store.enrollDevice("g1", {
+			deviceId: "d2",
+			fingerprint: "fp2",
+			publicKey: "pk2",
+		});
+		await store.upsertPresence({
+			groupId: "g1",
+			deviceId: "d2",
+			addresses: ["http://localhost:9001"],
+			ttlS: 0,
+		});
+		await expect(store.listGroupPeers("g1", "d1")).resolves.toEqual([
+			expect.objectContaining({ device_id: "d2", stale: true, addresses: [] }),
+		]);
 	});
 });

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -50,6 +50,50 @@ function rowToRecord<T>(row: unknown): T {
 	return row as T;
 }
 
+function normalizeAddress(address: string): string {
+	const value = address.trim();
+	if (!value) return "";
+	const withScheme = value.includes("://") ? value : `http://${value}`;
+	try {
+		const url = new URL(withScheme);
+		if (!url.hostname) return "";
+		if (url.port && (Number(url.port) <= 0 || Number(url.port) > 65535)) return "";
+		return url.origin + url.pathname.replace(/\/+$/, "");
+	} catch {
+		return "";
+	}
+}
+
+function addressDedupeKey(address: string): string {
+	if (!address) return "";
+	try {
+		const parsed = new URL(address);
+		const host = parsed.hostname.toLowerCase();
+		if (
+			(parsed.protocol === "http:" || parsed.protocol === "") &&
+			host &&
+			parsed.port &&
+			parsed.pathname === "/"
+		) {
+			return `${host}:${parsed.port}`;
+		}
+	} catch {}
+	return address;
+}
+
+function mergeAddresses(existing: string[], candidates: string[]): string[] {
+	const normalized: string[] = [];
+	const seen = new Set<string>();
+	for (const address of [...existing, ...candidates]) {
+		const cleaned = normalizeAddress(address);
+		const key = addressDedupeKey(cleaned);
+		if (!cleaned || seen.has(key)) continue;
+		seen.add(key);
+		normalized.push(cleaned);
+	}
+	return normalized;
+}
+
 function nowISO(): string {
 	return new Date().toISOString();
 }
@@ -202,11 +246,19 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	}
 
 	async recordNonce(_deviceId: string, _nonce: string, _createdAt: string): Promise<boolean> {
-		notImplemented("recordNonce");
+		return (
+			(await runChanges(
+				this.db
+					.prepare(
+						"INSERT OR IGNORE INTO request_nonces(device_id, nonce, created_at) VALUES (?, ?, ?)",
+					)
+					.bind(_deviceId, _nonce, _createdAt),
+			)) > 0
+		);
 	}
 
 	async cleanupNonces(_cutoff: string): Promise<void> {
-		notImplemented("cleanupNonces");
+		await this.db.prepare("DELETE FROM request_nonces WHERE created_at < ?").bind(_cutoff).run();
 	}
 
 	async createInvite(_opts: CoordinatorCreateInviteInput): Promise<CoordinatorInvite> {
@@ -389,13 +441,74 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	}
 
 	async upsertPresence(_opts: CoordinatorUpsertPresenceInput): Promise<CoordinatorPresenceRecord> {
-		notImplemented("upsertPresence");
+		const now = new Date();
+		const expiresAt = new Date(now.getTime() + _opts.ttlS * 1000).toISOString();
+		const normalized = mergeAddresses([], _opts.addresses);
+		await this.db
+			.prepare(`INSERT INTO presence_records(group_id, device_id, addresses_json, last_seen_at, expires_at, capabilities_json)
+				 VALUES (?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(group_id, device_id) DO UPDATE SET
+					addresses_json = excluded.addresses_json,
+					last_seen_at = excluded.last_seen_at,
+					expires_at = excluded.expires_at,
+					capabilities_json = excluded.capabilities_json`)
+			.bind(
+				_opts.groupId,
+				_opts.deviceId,
+				JSON.stringify(normalized),
+				now.toISOString(),
+				expiresAt,
+				JSON.stringify(_opts.capabilities ?? {}),
+			)
+			.run();
+		return {
+			group_id: _opts.groupId,
+			device_id: _opts.deviceId,
+			addresses: normalized,
+			expires_at: expiresAt,
+		};
 	}
 
 	async listGroupPeers(
 		_groupId: string,
 		_requestingDeviceId: string,
 	): Promise<CoordinatorPeerRecord[]> {
-		notImplemented("listGroupPeers");
+		const now = nowISO();
+		const rows = await allRows<Record<string, unknown>>(
+			this.db
+				.prepare(`SELECT enrolled_devices.device_id, enrolled_devices.fingerprint, enrolled_devices.display_name,
+						presence_records.addresses_json, presence_records.last_seen_at, presence_records.expires_at,
+						presence_records.capabilities_json
+					 FROM enrolled_devices
+					 LEFT JOIN presence_records
+					   ON presence_records.group_id = enrolled_devices.group_id
+					  AND presence_records.device_id = enrolled_devices.device_id
+					 WHERE enrolled_devices.group_id = ?
+					   AND enrolled_devices.enabled = 1
+					   AND enrolled_devices.device_id != ?
+					 ORDER BY enrolled_devices.device_id ASC`)
+				.bind(_groupId, _requestingDeviceId),
+		);
+		return rows.map((row) => {
+			const expiresRaw = String(row.expires_at ?? "").trim();
+			let stale = true;
+			if (expiresRaw) {
+				const expiresAt = new Date(expiresRaw);
+				stale = Number.isNaN(expiresAt.getTime()) || expiresAt.toISOString() <= now;
+			}
+			const addresses = stale
+				? []
+				: mergeAddresses([], JSON.parse(String(row.addresses_json ?? "[]")) as string[]);
+			return {
+				device_id: String(row.device_id ?? ""),
+				fingerprint: String(row.fingerprint ?? ""),
+				display_name: (row.display_name as string | null) ?? null,
+				addresses,
+				last_seen_at: (row.last_seen_at as string | null) ?? null,
+				expires_at: (row.expires_at as string | null) ?? null,
+				stale,
+				capabilities: JSON.parse(String(row.capabilities_json ?? "{}")) as Record<string, unknown>,
+			} satisfies CoordinatorPeerRecord;
+		});
 	}
 }


### PR DESCRIPTION
## Description
- Completes the next D1CoordinatorStore slice by implementing nonce replay recording/cleanup, presence upsert, and group peer listing.
- Extends the D1 adapter from the earlier admin/invite subset into the actual coordinator discovery core.
- Validates the supported D1 subset locally with a SQLite-backed D1-shaped test double, including the `batch()`-backed join review path.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Validation used for this slice:
  - `pnpm vitest run packages/core/src/d1-coordinator-store.test.ts packages/core/src/coordinator-api.test.ts packages/core/src/coordinator-store.test.ts packages/core/src/coordinator-actions.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
