### PR TITLE
feat(sync): add internal Cloudflare coordinator worker package

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -21,7 +21,7 @@ import {
 	coordinatorRemoveDeviceAction,
 	coordinatorRenameDeviceAction,
 	coordinatorReviewJoinRequestAction,
-	createCoordinatorApp,
+	createBetterSqliteCoordinatorApp,
 	DEFAULT_COORDINATOR_DB_PATH,
 	ensureDeviceIdentity,
 	fingerprintPublicKey,
@@ -1179,7 +1179,7 @@ coordinatorCommand.addCommand(
 			const host = String(opts.host ?? "127.0.0.1").trim() || "127.0.0.1";
 			const port = Number.parseInt(String(opts.port ?? "7347"), 10);
 			const dbPath = opts.db ?? opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH;
-			const app = createCoordinatorApp({ dbPath });
+			const app = createBetterSqliteCoordinatorApp({ dbPath });
 			p.intro("codemem sync coordinator serve");
 			p.log.success(`Coordinator listening at http://${host}:${port}`);
 			p.log.info(`DB: ${dbPath}`);

--- a/packages/cloudflare-coordinator-worker/package.json
+++ b/packages/cloudflare-coordinator-worker/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "@codemem/cloudflare-coordinator-worker",
+	"version": "0.22.0-alpha.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"clean": "rm -rf dist tsconfig.tsbuildinfo",
+		"build": "pnpm exec vite build && pnpm exec tsc --noEmit",
+		"typecheck": "pnpm exec tsc --noEmit"
+	},
+	"devDependencies": {
+		"@types/better-sqlite3": "^7.6.13",
+		"better-sqlite3": "^12.8.0",
+		"typescript": "catalog:",
+		"vite": "8.0.1",
+		"vitest": "4.0.17"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/kunickiaj/codemem.git",
+		"directory": "packages/cloudflare-coordinator-worker"
+	},
+	"license": "MIT"
+}

--- a/packages/cloudflare-coordinator-worker/src/index.test.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connectCoordinator } from "../../core/src/better-sqlite-coordinator-store.js";
+import {
+	D1CoordinatorStore,
+	type D1DatabaseLike,
+	type D1PreparedStatementLike,
+} from "../../core/src/d1-coordinator-store.js";
+import { createCloudflareCoordinatorWorker } from "./index.js";
+
+type SqliteDatabase = ReturnType<typeof connectCoordinator>;
+type SqliteStatement = {
+	get: (...values: unknown[]) => unknown;
+	run: (...values: unknown[]) => { changes: number };
+	all: (...values: unknown[]) => unknown[];
+	raw: (value: boolean) => { all: (...values: unknown[]) => unknown[] };
+};
+
+class SqliteD1Statement implements D1PreparedStatementLike {
+	private bound: unknown[] = [];
+
+	constructor(private readonly statement: SqliteStatement) {}
+
+	bind(...values: unknown[]): D1PreparedStatementLike {
+		this.bound = values;
+		return this;
+	}
+
+	async first<T = unknown>(): Promise<T | null> {
+		return (this.statement.get(...this.bound) as T | undefined) ?? null;
+	}
+
+	async run(): Promise<unknown> {
+		const result = this.statement.run(...this.bound);
+		return { meta: { changes: result.changes } };
+	}
+
+	executeRunSync(): unknown {
+		const result = this.statement.run(...this.bound);
+		return { meta: { changes: result.changes } };
+	}
+
+	async all<T = unknown>(): Promise<{ results?: T[] }> {
+		return { results: this.statement.all(...this.bound) as T[] };
+	}
+
+	async raw<T = unknown>(): Promise<T[]> {
+		return this.statement.raw(true).all(...this.bound) as T[];
+	}
+}
+
+class SqliteD1Database implements D1DatabaseLike {
+	constructor(private readonly db: SqliteDatabase) {}
+
+	prepare(query: string): D1PreparedStatementLike {
+		return new SqliteD1Statement(this.db.prepare(query) as unknown as SqliteStatement);
+	}
+
+	async batch(statements: D1PreparedStatementLike[]): Promise<unknown[]> {
+		return this.db.transaction(() => {
+			const results: unknown[] = [];
+			for (const statement of statements) {
+				if (!(statement instanceof SqliteD1Statement)) {
+					throw new Error("Unsupported D1 statement test double.");
+				}
+				results.push(statement.executeRunSync());
+			}
+			return results;
+		})();
+	}
+}
+
+describe("createCloudflareCoordinatorWorker", () => {
+	let tmpDir: string;
+	let db: SqliteDatabase;
+	let d1db: D1DatabaseLike;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "cloudflare-coord-worker-test-"));
+		db = connectCoordinator(join(tmpDir, "coordinator.sqlite"));
+		d1db = new SqliteD1Database(db);
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns missing_d1_binding when the worker env is incomplete", async () => {
+		const worker = createCloudflareCoordinatorWorker();
+		const res = await worker.fetch(
+			new Request("https://coord.example.test/v1/peers?group_id=g1"),
+			{},
+		);
+		expect(res.status).toBe(500);
+		expect(await res.json()).toEqual({ error: "missing_d1_binding" });
+	});
+
+	it("serves coordinator admin data through the worker entrypoint", async () => {
+		const store = new D1CoordinatorStore(d1db);
+		await store.createGroup("g1", "Team Alpha");
+		await store.enrollDevice("g1", {
+			deviceId: "d1",
+			fingerprint: "fp1",
+			publicKey: "pk1",
+			displayName: "Laptop",
+		});
+		await store.close();
+
+		const worker = createCloudflareCoordinatorWorker({
+			now: () => "2026-03-28T00:00:00Z",
+		});
+
+		const res = await worker.fetch(
+			new Request("https://coord.example.test/v1/admin/devices?group_id=g1", {
+				headers: { "X-Codemem-Coordinator-Admin": "test-secret" },
+			}),
+			{ COORDINATOR_DB: d1db, CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET: "test-secret" },
+		);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			items: [
+				{
+					group_id: "g1",
+					device_id: "d1",
+					fingerprint: "fp1",
+					display_name: "Laptop",
+					enabled: 1,
+					created_at: expect.any(String),
+				},
+			],
+		});
+	});
+});

--- a/packages/cloudflare-coordinator-worker/src/index.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.ts
@@ -1,0 +1,41 @@
+import { createD1CoordinatorApp } from "../../core/src/d1-coordinator-runtime.js";
+import type { D1DatabaseLike } from "../../core/src/d1-coordinator-store.js";
+
+export interface CloudflareCoordinatorEnv {
+	COORDINATOR_DB?: D1DatabaseLike;
+	CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET?: string;
+}
+
+export interface CreateCloudflareCoordinatorWorkerOptions {
+	now?: () => string;
+	adminSecret?: (env: CloudflareCoordinatorEnv) => string | null;
+}
+
+function jsonResponse(payload: Record<string, unknown>, status = 200): Response {
+	return new Response(JSON.stringify(payload), {
+		status,
+		headers: { "content-type": "application/json; charset=utf-8" },
+	});
+}
+
+export function createCloudflareCoordinatorWorker(
+	opts: CreateCloudflareCoordinatorWorkerOptions = {},
+) {
+	return {
+		async fetch(request: Request, env: CloudflareCoordinatorEnv): Promise<Response> {
+			if (!env.COORDINATOR_DB) {
+				return jsonResponse({ error: "missing_d1_binding" }, 500);
+			}
+			const app = createD1CoordinatorApp({
+				db: env.COORDINATOR_DB,
+				adminSecret: opts.adminSecret
+					? opts.adminSecret(env)
+					: String(env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET ?? "").trim() || null,
+				now: opts.now,
+			});
+			return app.fetch(request);
+		},
+	};
+}
+
+export default createCloudflareCoordinatorWorker();

--- a/packages/cloudflare-coordinator-worker/tsconfig.json
+++ b/packages/cloudflare-coordinator-worker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "..",
+		"lib": ["ES2022", "DOM"]
+	},
+	"include": ["src", "../core/src"],
+	"exclude": ["src/**/*.test.ts", "../core/src/**/*.test.ts"]
+}

--- a/packages/cloudflare-coordinator-worker/vite.config.ts
+++ b/packages/cloudflare-coordinator-worker/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		conditions: ["source"],
+	},
+	build: {
+		lib: {
+			entry: "src/index.ts",
+			formats: ["es"],
+			fileName: "index",
+		},
+		rollupOptions: {
+			external: [/^node:/, /^better-sqlite3$/],
+		},
+		outDir: "dist",
+		sourcemap: true,
+		emptyOutDir: true,
+	},
+	test: {
+		name: "cloudflare-coordinator-worker",
+	},
+});

--- a/packages/cloudflare-coordinator-worker/wrangler.toml.example
+++ b/packages/cloudflare-coordinator-worker/wrangler.toml.example
@@ -1,0 +1,12 @@
+name = "codemem-coordinator-worker"
+main = "src/index.ts"
+compatibility_date = "2026-03-28"
+compatibility_flags = ["nodejs_compat"]
+
+# Set the coordinator admin secret separately:
+# wrangler secret put CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET
+
+[[d1_databases]]
+binding = "COORDINATOR_DB"
+database_name = "codemem-coordinator"
+database_id = "REPLACE_WITH_D1_DATABASE_ID"

--- a/packages/core/src/better-sqlite-coordinator-runtime.ts
+++ b/packages/core/src/better-sqlite-coordinator-runtime.ts
@@ -1,0 +1,20 @@
+import {
+	BetterSqliteCoordinatorStore,
+	DEFAULT_COORDINATOR_DB_PATH,
+} from "./better-sqlite-coordinator-store.js";
+import { type CoordinatorRuntimeDeps, createCoordinatorApp } from "./coordinator-api.js";
+
+export interface CreateBetterSqliteCoordinatorAppOptions {
+	dbPath?: string;
+	runtime?: CoordinatorRuntimeDeps;
+}
+
+export function createBetterSqliteCoordinatorApp(
+	opts: CreateBetterSqliteCoordinatorAppOptions = {},
+): ReturnType<typeof createCoordinatorApp> {
+	return createCoordinatorApp({
+		storeFactory: () =>
+			new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH),
+		runtime: opts.runtime,
+	});
+}

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -20,34 +20,46 @@ function createMockStore(
 	overrides?: Partial<CoordinatorStoreInterface>,
 ): CoordinatorStoreInterface {
 	const defaultStore: CoordinatorStoreInterface = {
-		close: vi.fn(),
-		createGroup: vi.fn(),
-		getGroup: vi.fn((): CoordinatorGroup | null => null),
-		listGroups: vi.fn((): CoordinatorGroup[] => []),
-		enrollDevice: vi.fn((_: string, __: CoordinatorEnrollDeviceInput) => undefined),
-		listEnrolledDevices: vi.fn((_: string, __?: boolean): CoordinatorEnrollment[] => []),
-		getEnrollment: vi.fn((_: string, __: string): CoordinatorEnrollment | null => null),
-		renameDevice: vi.fn(() => false),
-		setDeviceEnabled: vi.fn(() => false),
-		removeDevice: vi.fn(() => false),
-		recordNonce: vi.fn(() => true),
-		cleanupNonces: vi.fn(),
-		createInvite: vi.fn((_: CoordinatorCreateInviteInput): CoordinatorInvite => {
-			throw new Error("not implemented");
-		}),
-		getInviteByToken: vi.fn((_: string): CoordinatorInvite | null => null),
-		listInvites: vi.fn((_: string): CoordinatorInvite[] => []),
-		createJoinRequest: vi.fn((_: CoordinatorCreateJoinRequestInput): CoordinatorJoinRequest => {
-			throw new Error("not implemented");
-		}),
-		listJoinRequests: vi.fn((_: string, __?: string): CoordinatorJoinRequest[] => []),
-		reviewJoinRequest: vi.fn(
-			(_: CoordinatorReviewJoinRequestInput): CoordinatorJoinRequestReviewResult | null => null,
+		close: vi.fn(async () => undefined),
+		createGroup: vi.fn(async () => undefined),
+		getGroup: vi.fn(async (): Promise<CoordinatorGroup | null> => null),
+		listGroups: vi.fn(async (): Promise<CoordinatorGroup[]> => []),
+		enrollDevice: vi.fn(async (_: string, __: CoordinatorEnrollDeviceInput) => undefined),
+		listEnrolledDevices: vi.fn(
+			async (_: string, __?: boolean): Promise<CoordinatorEnrollment[]> => [],
 		),
-		upsertPresence: vi.fn((_: CoordinatorUpsertPresenceInput): CoordinatorPresenceRecord => {
+		getEnrollment: vi.fn(
+			async (_: string, __: string): Promise<CoordinatorEnrollment | null> => null,
+		),
+		renameDevice: vi.fn(async () => false),
+		setDeviceEnabled: vi.fn(async () => false),
+		removeDevice: vi.fn(async () => false),
+		recordNonce: vi.fn(async () => true),
+		cleanupNonces: vi.fn(async () => undefined),
+		createInvite: vi.fn(async (_: CoordinatorCreateInviteInput): Promise<CoordinatorInvite> => {
 			throw new Error("not implemented");
 		}),
-		listGroupPeers: vi.fn((_: string, __: string): CoordinatorPeerRecord[] => []),
+		getInviteByToken: vi.fn(async (_: string): Promise<CoordinatorInvite | null> => null),
+		listInvites: vi.fn(async (_: string): Promise<CoordinatorInvite[]> => []),
+		createJoinRequest: vi.fn(
+			async (_: CoordinatorCreateJoinRequestInput): Promise<CoordinatorJoinRequest> => {
+				throw new Error("not implemented");
+			},
+		),
+		listJoinRequests: vi.fn(
+			async (_: string, __?: string): Promise<CoordinatorJoinRequest[]> => [],
+		),
+		reviewJoinRequest: vi.fn(
+			async (
+				_: CoordinatorReviewJoinRequestInput,
+			): Promise<CoordinatorJoinRequestReviewResult | null> => null,
+		),
+		upsertPresence: vi.fn(
+			async (_: CoordinatorUpsertPresenceInput): Promise<CoordinatorPresenceRecord> => {
+				throw new Error("not implemented");
+			},
+		),
+		listGroupPeers: vi.fn(async (_: string, __: string): Promise<CoordinatorPeerRecord[]> => []),
 	};
 	return { ...defaultStore, ...overrides };
 }
@@ -55,7 +67,7 @@ function createMockStore(
 describe("createCoordinatorApp dependency injection", () => {
 	it("uses injected admin secret and store factory for admin routes", async () => {
 		const store = createMockStore({
-			listEnrolledDevices: vi.fn(() => [
+			listEnrolledDevices: vi.fn(async () => [
 				{
 					group_id: "g1",
 					device_id: "d1",

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -7,7 +7,6 @@
 
 import type { Context } from "hono";
 import { Hono } from "hono";
-import { BetterSqliteCoordinatorStore } from "./better-sqlite-coordinator-store.js";
 import type { InvitePayload } from "./coordinator-invites.js";
 import { encodeInvitePayload, inviteLink } from "./coordinator-invites.js";
 import type { CoordinatorEnrollment, CoordinatorStore } from "./coordinator-store-contract.js";
@@ -26,7 +25,6 @@ export interface CoordinatorRuntimeDeps {
 }
 
 export interface CreateCoordinatorAppOptions {
-	dbPath?: string;
 	storeFactory?: () => CoordinatorStore;
 	runtime?: CoordinatorRuntimeDeps;
 }
@@ -141,12 +139,14 @@ async function authorizeRequest(
 export function createCoordinatorApp(
 	opts?: CreateCoordinatorAppOptions,
 ): InstanceType<typeof Hono> {
-	const dbPath = opts?.dbPath;
 	const runtime: CoordinatorRuntimeDeps = opts?.runtime ?? {
 		adminSecret: defaultAdminSecret,
 		now: () => new Date().toISOString(),
 	};
-	const createStore = opts?.storeFactory ?? (() => new BetterSqliteCoordinatorStore(dbPath));
+	if (!opts?.storeFactory) {
+		throw new Error("createCoordinatorApp requires a storeFactory.");
+	}
+	const createStore = opts.storeFactory;
 	const app = new Hono();
 
 	// -----------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,8 @@
 export const VERSION = "0.22.0-alpha.0";
 
 export * as Api from "./api-types.js";
+export type { CreateBetterSqliteCoordinatorAppOptions } from "./better-sqlite-coordinator-runtime.js";
+export { createBetterSqliteCoordinatorApp } from "./better-sqlite-coordinator-runtime.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";
 export {
 	buildIngestPayloadFromHook,

--- a/packages/core/src/sync-http-client.ts
+++ b/packages/core/src/sync-http-client.ts
@@ -61,11 +61,12 @@ export async function requestJson(
 	if (headers) {
 		Object.assign(requestHeaders, headers);
 	}
+	const requestBody = (bodyBytes ?? null) as RequestInit["body"] | null;
 
 	const response = await fetch(url, {
 		method,
 		headers: requestHeaders,
-		body: bodyBytes ?? null,
+		body: requestBody,
 		signal: AbortSignal.timeout(timeoutS * 1000),
 	});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,24 @@ importers:
         specifier: 4.0.17
         version: 4.0.17(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
 
+  packages/cloudflare-coordinator-worker:
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      better-sqlite3:
+        specifier: ^12.8.0
+        version: 12.8.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 8.0.1
+        version: 8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
+      vitest:
+        specifier: 4.0.17
+        version: 4.0.17(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
+
   packages/core:
     dependencies:
       better-sqlite3:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "files": [],
-  "references": [
-    { "path": "packages/core" },
-    { "path": "packages/mcp-server" },
-    { "path": "packages/viewer-server" },
-    { "path": "packages/cli" }
-  ]
+	"files": [],
+	"references": [
+		{ "path": "packages/core" },
+		{ "path": "packages/cloudflare-coordinator-worker" },
+		{ "path": "packages/mcp-server" },
+		{ "path": "packages/viewer-server" },
+		{ "path": "packages/cli" }
+	]
 }


### PR DESCRIPTION
## Description
- Adds an internal Cloudflare Worker package/entrypoint that wraps the existing D1-backed coordinator app factory instead of introducing a second coordinator contract.
- Wires the package into the workspace build/typecheck graph and includes a focused worker-entrypoint test against the D1-backed adapter.
- Keeps the package explicitly internal/experimental and makes the example `wrangler.toml` honest about `nodejs_compat` and the required admin secret.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Validation used for this slice:
  - `pnpm vitest run packages/cloudflare-coordinator-worker/src/index.test.ts packages/core/src/d1-coordinator-runtime.test.ts packages/core/src/d1-coordinator-store.test.ts packages/core/src/coordinator-api.test.ts packages/core/src/coordinator-store.test.ts packages/core/src/coordinator-actions.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
