### PR TITLE
refactor(sync): harden internal worker package boundary

### DIFF
--- a/packages/cloudflare-coordinator-worker/package.json
+++ b/packages/cloudflare-coordinator-worker/package.json
@@ -5,8 +5,11 @@
 	"type": "module",
 	"scripts": {
 		"clean": "rm -rf dist tsconfig.tsbuildinfo",
-		"build": "pnpm exec vite build && pnpm exec tsc --noEmit",
-		"typecheck": "pnpm exec tsc --noEmit"
+		"build": "pnpm --filter @codemem/core build && pnpm exec vite build && pnpm exec tsc --noEmit",
+		"typecheck": "pnpm --filter @codemem/core build && pnpm exec tsc --noEmit"
+	},
+	"dependencies": {
+		"@codemem/core": "workspace:^"
 	},
 	"devDependencies": {
 		"@types/better-sqlite3": "^7.6.13",

--- a/packages/cloudflare-coordinator-worker/src/index.test.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.test.ts
@@ -1,17 +1,20 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+	buildAuthHeaders,
+	connect,
+	connectCoordinator,
+	ensureDeviceIdentity,
+	initTestSchema,
+	loadPublicKey,
+} from "@codemem/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { connectCoordinator } from "../../core/src/better-sqlite-coordinator-store.js";
 import {
 	D1CoordinatorStore,
 	type D1DatabaseLike,
 	type D1PreparedStatementLike,
-} from "../../core/src/d1-coordinator-store.js";
-import { connect } from "../../core/src/db.js";
-import { buildAuthHeaders } from "../../core/src/sync-auth.js";
-import { ensureDeviceIdentity, loadPublicKey } from "../../core/src/sync-identity.js";
-import { initTestSchema } from "../../core/src/test-utils.js";
+} from "../../core/src/internal/cloudflare-coordinator.js";
 import { createCloudflareCoordinatorWorker } from "./index.js";
 
 type SqliteDatabase = ReturnType<typeof connectCoordinator>;

--- a/packages/cloudflare-coordinator-worker/src/index.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.ts
@@ -1,5 +1,5 @@
-import { createD1CoordinatorApp } from "../../core/src/d1-coordinator-runtime.js";
-import type { D1DatabaseLike } from "../../core/src/d1-coordinator-store.js";
+import type { D1DatabaseLike } from "@codemem/core/internal/cloudflare-coordinator";
+import { createD1CoordinatorApp } from "@codemem/core/internal/cloudflare-coordinator";
 
 export interface CloudflareCoordinatorEnv {
 	COORDINATOR_DB?: D1DatabaseLike;

--- a/packages/cloudflare-coordinator-worker/tsconfig.json
+++ b/packages/cloudflare-coordinator-worker/tsconfig.json
@@ -1,9 +1,10 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "..",
+		"rootDir": ".",
 		"lib": ["ES2022", "DOM"]
 	},
-	"include": ["src", "../core/src"],
-	"exclude": ["src/**/*.test.ts", "../core/src/**/*.test.ts"]
+	"include": ["src"],
+	"exclude": ["src/**/*.test.ts"],
+	"references": [{ "path": "../core" }]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,11 @@
 			"source": "./src/index.ts",
 			"import": "./dist/index.js",
 			"types": "./dist/index.d.ts"
+		},
+		"./internal/cloudflare-coordinator": {
+			"source": "./src/internal/cloudflare-coordinator.ts",
+			"import": "./dist/internal/cloudflare-coordinator.js",
+			"types": "./dist/internal/cloudflare-coordinator.d.ts"
 		}
 	},
 	"files": [

--- a/packages/core/src/internal/cloudflare-coordinator.ts
+++ b/packages/core/src/internal/cloudflare-coordinator.ts
@@ -1,0 +1,4 @@
+export type { CreateD1CoordinatorAppOptions } from "../d1-coordinator-runtime.js";
+export { createD1CoordinatorApp } from "../d1-coordinator-runtime.js";
+export type { D1DatabaseLike, D1PreparedStatementLike } from "../d1-coordinator-store.js";
+export { D1CoordinatorStore } from "../d1-coordinator-store.js";

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -4,9 +4,15 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	build: {
 		lib: {
-			entry: resolve(import.meta.dirname, "src/index.ts"),
+			entry: {
+				index: resolve(import.meta.dirname, "src/index.ts"),
+				"internal/cloudflare-coordinator": resolve(
+					import.meta.dirname,
+					"src/internal/cloudflare-coordinator.ts",
+				),
+			},
 			formats: ["es"],
-			fileName: "index",
+			fileName: (_format, entryName) => `${entryName}.js`,
 		},
 		rollupOptions: {
 			external: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,10 @@ importers:
         version: 4.0.17(@types/node@25.5.0)(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/cloudflare-coordinator-worker:
+    dependencies:
+      '@codemem/core':
+        specifier: workspace:^
+        version: link:../core
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13


### PR DESCRIPTION
## Description
- Hardens the internal Cloudflare worker package boundary by replacing deep `../../core/src/...` imports with a single deliberate internal core entrypoint.
- Converts the internal core subpath into a real built artifact instead of pointing package exports at raw TS source.
- Restores the worker package TS boundary and makes its build explicitly honor the core dependency/reference boundary.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Validation used for this slice:
  - `pnpm --filter @codemem/core build`
  - `pnpm --filter @codemem/cloudflare-coordinator-worker build`
  - `pnpm run typecheck`
  - `pnpm vitest run packages/cloudflare-coordinator-worker/src/index.test.ts packages/core/src/d1-coordinator-runtime.test.ts packages/core/src/d1-coordinator-store.test.ts packages/core/src/coordinator-api.test.ts packages/core/src/coordinator-store.test.ts packages/core/src/coordinator-actions.test.ts`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
