### PR TITLE
refactor(sync): tighten coordinator record query shapes

### DIFF
--- a/packages/cloudflare-coordinator-worker/src/index.test.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.test.ts
@@ -144,6 +144,7 @@ describe("createCloudflareCoordinatorWorker", () => {
 				{
 					group_id: "g1",
 					device_id: "d1",
+					public_key: "pk1",
 					fingerprint: "fp1",
 					display_name: "Laptop",
 					enabled: 1,

--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -230,7 +230,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 	): Promise<CoordinatorEnrollment[]> {
 		const where = includeDisabled ? "" : "AND enabled = 1";
 		return this.db
-			.prepare(`SELECT group_id, device_id, fingerprint, display_name, enabled, created_at
+			.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
 				 FROM enrolled_devices
 				 WHERE group_id = ? ${where}
 				 ORDER BY created_at ASC, device_id ASC`)
@@ -240,7 +240,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 
 	async getEnrollment(groupId: string, deviceId: string): Promise<CoordinatorEnrollment | null> {
 		const row = this.db
-			.prepare(`SELECT device_id, public_key, fingerprint, display_name
+			.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
 				 FROM enrolled_devices
 				 WHERE group_id = ? AND device_id = ? AND enabled = 1`)
 			.get(groupId, deviceId);
@@ -354,7 +354,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				now,
 			);
 		const row = this.db
-			.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+			.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
 				 FROM coordinator_join_requests WHERE request_id = ?`)
 			.get(requestId);
 		return rowToRecord<CoordinatorJoinRequest>(row);
@@ -362,7 +362,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 
 	async listJoinRequests(groupId: string, status = "pending"): Promise<CoordinatorJoinRequest[]> {
 		return this.db
-			.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+			.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
 				 FROM coordinator_join_requests
 				 WHERE group_id = ? AND status = ?
 				 ORDER BY created_at ASC, device_id ASC`)
@@ -398,7 +398,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 					 WHERE request_id = ?`)
 				.run(nextStatus, reviewedAt, opts.reviewedBy ?? null, opts.requestId);
 			const updated = this.db
-				.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+				.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
 					 FROM coordinator_join_requests WHERE request_id = ?`)
 				.get(opts.requestId);
 			return updated ? rowToRecord<CoordinatorJoinRequestReviewResult>(updated) : null;

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -71,6 +71,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				{
 					group_id: "g1",
 					device_id: "d1",
+					public_key: "pk1",
 					fingerprint: "fp1",
 					display_name: "Laptop",
 					enabled: 1,
@@ -97,6 +98,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				{
 					group_id: "g1",
 					device_id: "d1",
+					public_key: "pk1",
 					fingerprint: "fp1",
 					display_name: "Laptop",
 					enabled: 1,

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -5,13 +5,13 @@ export interface CoordinatorGroup {
 }
 
 export interface CoordinatorEnrollment {
-	group_id?: string;
+	group_id: string;
 	device_id: string;
-	public_key?: string;
+	public_key: string;
 	fingerprint: string;
 	display_name: string | null;
-	enabled?: number;
-	created_at?: string;
+	enabled: number;
+	created_at: string;
 }
 
 export interface CoordinatorInvite {
@@ -30,7 +30,7 @@ export interface CoordinatorJoinRequest {
 	request_id: string;
 	group_id: string;
 	device_id: string;
-	public_key?: string;
+	public_key: string;
 	fingerprint: string;
 	display_name: string | null;
 	token: string;

--- a/packages/core/src/d1-coordinator-runtime.test.ts
+++ b/packages/core/src/d1-coordinator-runtime.test.ts
@@ -108,6 +108,7 @@ describe("createD1CoordinatorApp", () => {
 				{
 					group_id: "g1",
 					device_id: "d1",
+					public_key: "pk1",
 					fingerprint: "fp1",
 					display_name: "Laptop",
 					enabled: 1,

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -189,10 +189,10 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		return (
 			await allRows<CoordinatorEnrollment>(
 				this.db
-					.prepare(`SELECT group_id, device_id, fingerprint, display_name, enabled, created_at
-					 FROM enrolled_devices
-					 WHERE group_id = ? ${where}
-					 ORDER BY created_at ASC, device_id ASC`)
+					.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
+						 FROM enrolled_devices
+						 WHERE group_id = ? ${where}
+						 ORDER BY created_at ASC, device_id ASC`)
 					.bind(_groupId),
 			)
 		).map((row) => rowToRecord<CoordinatorEnrollment>(row));
@@ -201,7 +201,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	async getEnrollment(_groupId: string, _deviceId: string): Promise<CoordinatorEnrollment | null> {
 		const row = await firstRow<CoordinatorEnrollment>(
 			this.db
-				.prepare(`SELECT device_id, public_key, fingerprint, display_name
+				.prepare(`SELECT group_id, device_id, public_key, fingerprint, display_name, enabled, created_at
 					 FROM enrolled_devices
 					 WHERE group_id = ? AND device_id = ? AND enabled = 1`)
 				.bind(_groupId, _deviceId),
@@ -337,7 +337,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 			.run();
 		const row = await firstRow<CoordinatorJoinRequest>(
 			this.db
-				.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+				.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
 					 FROM coordinator_join_requests WHERE request_id = ?`)
 				.bind(requestId),
 		);
@@ -349,10 +349,10 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		return (
 			await allRows<CoordinatorJoinRequest>(
 				this.db
-					.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
-					 FROM coordinator_join_requests
-					 WHERE group_id = ? AND status = ?
-					 ORDER BY created_at ASC, device_id ASC`)
+					.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+						 FROM coordinator_join_requests
+						 WHERE group_id = ? AND status = ?
+						 ORDER BY created_at ASC, device_id ASC`)
 					.bind(_groupId, status),
 			)
 		).map((row) => rowToRecord<CoordinatorJoinRequest>(row));
@@ -414,7 +414,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 			if (changes === 0) {
 				const latest = await firstRow<CoordinatorJoinRequestReviewResult>(
 					this.db
-						.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+						.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
 							 FROM coordinator_join_requests WHERE request_id = ?`)
 						.bind(_opts.requestId),
 				);
@@ -433,7 +433,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		}
 		const updated = await firstRow<CoordinatorJoinRequestReviewResult>(
 			this.db
-				.prepare(`SELECT request_id, group_id, device_id, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
+				.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
 					 FROM coordinator_join_requests WHERE request_id = ?`)
 				.bind(_opts.requestId),
 		);


### PR DESCRIPTION
## Description
- Tightens the coordinator record types so auth- and admin-critical fields are no longer modeled as maybe-present when the code actually depends on them.
- Updates the SQLite and D1 adapter queries to return the stricter shapes they now promise.
- Keeps the scope deliberately small by tightening the existing record/query shapes rather than introducing a whole zoo of new record types in one shot.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Validation used for this slice:
  - `pnpm vitest run packages/core/src/coordinator-api.test.ts packages/core/src/coordinator-store.test.ts packages/core/src/coordinator-actions.test.ts packages/core/src/d1-coordinator-store.test.ts`
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
