### PR TITLE
fix(ts): resolve workspace package imports from source

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,22 +1,29 @@
 {
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "lib": ["ES2022"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "isolatedModules": true,
-    "verbatimModuleSyntax": true,
-    "noUncheckedIndexedAccess": true,
-    "emitDeclarationOnly": true,
-    "composite": true
-  }
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "Node16",
+		"moduleResolution": "Node16",
+		"baseUrl": ".",
+		"paths": {
+			"@codemem/core": ["packages/core/src/index.ts"],
+			"@codemem/core/internal/cloudflare-coordinator": [
+				"packages/core/src/internal/cloudflare-coordinator.ts"
+			]
+		},
+		"lib": ["ES2022"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"isolatedModules": true,
+		"verbatimModuleSyntax": true,
+		"noUncheckedIndexedAccess": true,
+		"emitDeclarationOnly": true,
+		"composite": true
+	}
 }


### PR DESCRIPTION
## Description
- Repairs workspace TypeScript package resolution for internal package imports like `@codemem/core`.
- Adds explicit workspace `paths` mappings in the shared TS config so typecheck/build resolve source files consistently instead of fighting package outputs/project references.
- Unblocks the remaining Cloudflare validation work by removing the repo-wide `TS6305` output-file errors.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- Validation used for this slice:
  - `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
