### PR TITLE
fix(viewer): add periodic WAL checkpoint to prevent unbounded WAL growth

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -474,8 +474,22 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		process.exit(1);
 	});
 
+	// Periodic WAL checkpoint — keeps the WAL file bounded.
+	// Without this, long-running viewer processes accumulate a WAL that can
+	// grow to match the main DB size when concurrent readers hold it open.
+	const WAL_CHECKPOINT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+	const walCheckpointTimer = setInterval(() => {
+		try {
+			store.db.pragma("wal_checkpoint(TRUNCATE)");
+		} catch (err) {
+			p.log.warn(`WAL checkpoint failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}, WAL_CHECKPOINT_INTERVAL_MS);
+	walCheckpointTimer.unref();
+
 	const shutdown = async () => {
 		p.outro("shutting down");
+		clearInterval(walCheckpointTimer);
 		syncAbort.abort();
 		retentionAbort.abort();
 		await sweeper.stop();


### PR DESCRIPTION
## Description

The viewer process holds the DB open for its entire lifetime but never checkpoints the WAL. With concurrent readers (MCP server, plugin), the WAL can grow to match the main DB size (observed: 1.9GB WAL on 1.9GB DB).

Adds a 5-minute `PRAGMA wal_checkpoint(TRUNCATE)` interval to the viewer's foreground server. The timer is `unref()`'d so it doesn't prevent graceful shutdown, and is cleared on SIGINT/SIGTERM.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced