### PR TITLE
feat(sync): add client-side bootstrap snapshot consumer

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -254,6 +254,8 @@ export {
 	signRequest,
 	verifySignature,
 } from "./sync-auth.js";
+export type { BootstrapOptions, BootstrapResult } from "./sync-bootstrap.js";
+export { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
 export type { SyncDaemonOptions, SyncDaemonPhase, SyncTickResult } from "./sync-daemon.js";
 export {
 	getSyncDaemonPhase,

--- a/packages/core/src/sync-bootstrap.test.ts
+++ b/packages/core/src/sync-bootstrap.test.ts
@@ -1,0 +1,170 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toJson } from "./db.js";
+import { applyBootstrapSnapshot } from "./sync-bootstrap.js";
+import { getSyncResetState, setSyncResetState } from "./sync-replication.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+import type { SyncMemorySnapshotItem, SyncResetRequired } from "./types.js";
+
+function makeResetInfo(overrides?: Partial<SyncResetRequired>): SyncResetRequired {
+	return {
+		reset_required: true,
+		reason: "generation_mismatch",
+		generation: 2,
+		snapshot_id: "snap-2",
+		baseline_cursor: "2026-01-01T00:00:05Z|base-op",
+		retained_floor_cursor: null,
+		...overrides,
+	};
+}
+
+function makeSnapshotItem(
+	entityId: string,
+	overrides?: Partial<SyncMemorySnapshotItem> & { payload?: Record<string, unknown> },
+): SyncMemorySnapshotItem {
+	const payload = overrides?.payload ?? {};
+	return {
+		entity_id: entityId,
+		op_type: overrides?.op_type ?? "upsert",
+		payload_json: JSON.stringify({
+			kind: "discovery",
+			title: `Title ${entityId}`,
+			body_text: `Body ${entityId}`,
+			visibility: "shared",
+			workspace_kind: "shared",
+			workspace_id: "shared:default",
+			created_at: "2026-01-01T00:00:01Z",
+			metadata_json: { clock_device_id: "peer-dev" },
+			...payload,
+		}),
+		clock_rev: overrides?.clock_rev ?? 1,
+		clock_updated_at: overrides?.clock_updated_at ?? "2026-01-01T00:00:02Z",
+		clock_device_id: overrides?.clock_device_id ?? "peer-dev",
+	};
+}
+
+describe("applyBootstrapSnapshot", () => {
+	let db: InstanceType<typeof Database>;
+	let sessionId: number;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		sessionId = insertTestSession(db);
+		// Set initial sync state so the function can bump it
+		setSyncResetState(db, {
+			generation: 1,
+			snapshot_id: "snap-1",
+			baseline_cursor: null,
+		});
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("replaces shared memories with snapshot items", () => {
+		// Insert existing shared memory
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, visibility, metadata_json)
+			 VALUES (?, 'discovery', 'old-shared', 'old body', ?, ?, 'old-key', 1, 'shared', ?)`,
+		).run(sessionId, now, now, toJson({ clock_device_id: "local" }));
+
+		const items = [makeSnapshotItem("new-key-a"), makeSnapshotItem("new-key-b")];
+		const result = applyBootstrapSnapshot(db, "peer-1", items, makeResetInfo());
+
+		expect(result.ok).toBe(true);
+		expect(result.deleted).toBe(1); // old-key deleted
+		expect(result.applied).toBe(2); // new-key-a, new-key-b inserted
+
+		// Verify old memory is gone
+		const old = db.prepare("SELECT * FROM memory_items WHERE import_key = 'old-key'").get();
+		expect(old).toBeUndefined();
+
+		// Verify new memories exist
+		const newA = db
+			.prepare("SELECT * FROM memory_items WHERE import_key = 'new-key-a'")
+			.get() as Record<string, unknown>;
+		expect(newA).toBeTruthy();
+		expect(newA.title).toBe("Title new-key-a");
+		expect(newA.visibility).toBe("shared");
+	});
+
+	it("preserves private memories during bootstrap", () => {
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, visibility, metadata_json)
+			 VALUES (?, 'discovery', 'my-private', 'private body', ?, ?, 'private-key', 1, 'private', ?)`,
+		).run(sessionId, now, now, toJson({ clock_device_id: "local" }));
+
+		const items = [makeSnapshotItem("new-key")];
+		const result = applyBootstrapSnapshot(db, "peer-1", items, makeResetInfo());
+
+		expect(result.ok).toBe(true);
+		expect(result.deleted).toBe(0); // private not deleted
+
+		const priv = db
+			.prepare("SELECT * FROM memory_items WHERE import_key = 'private-key'")
+			.get() as Record<string, unknown>;
+		expect(priv).toBeTruthy();
+		expect(priv.title).toBe("my-private");
+	});
+
+	it("handles tombstoned snapshot items correctly", () => {
+		const items = [
+			makeSnapshotItem("alive-key"),
+			makeSnapshotItem("dead-key", { op_type: "delete" }),
+		];
+		const result = applyBootstrapSnapshot(db, "peer-1", items, makeResetInfo());
+
+		expect(result.ok).toBe(true);
+		expect(result.applied).toBe(2);
+
+		const alive = db
+			.prepare("SELECT active, deleted_at FROM memory_items WHERE import_key = 'alive-key'")
+			.get() as Record<string, unknown>;
+		expect(alive.active).toBe(1);
+		expect(alive.deleted_at).toBeNull();
+
+		const dead = db
+			.prepare("SELECT active, deleted_at FROM memory_items WHERE import_key = 'dead-key'")
+			.get() as Record<string, unknown>;
+		expect(dead.active).toBe(0);
+		expect(dead.deleted_at).toBeTruthy();
+	});
+
+	it("bumps generation and snapshot_id to match peer", () => {
+		const items = [makeSnapshotItem("key-a")];
+		applyBootstrapSnapshot(db, "peer-1", items, makeResetInfo());
+
+		const state = getSyncResetState(db);
+		expect(state.generation).toBe(2);
+		expect(state.snapshot_id).toBe("snap-2");
+		expect(state.baseline_cursor).toBe("2026-01-01T00:00:05Z|base-op");
+	});
+
+	it("updates replication cursor to baseline_cursor", () => {
+		const items = [makeSnapshotItem("key-a")];
+		applyBootstrapSnapshot(db, "peer-1", items, makeResetInfo());
+
+		const cursor = db
+			.prepare("SELECT last_applied_cursor FROM replication_cursors WHERE peer_device_id = ?")
+			.get("peer-1") as { last_applied_cursor: string } | undefined;
+		expect(cursor?.last_applied_cursor).toBe("2026-01-01T00:00:05Z|base-op");
+	});
+
+	it("applies empty snapshot (wipes shared, inserts nothing)", () => {
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, visibility, metadata_json)
+			 VALUES (?, 'discovery', 'old-shared', 'body', ?, ?, 'old-key', 1, 'shared', ?)`,
+		).run(sessionId, now, now, toJson({ clock_device_id: "local" }));
+
+		const result = applyBootstrapSnapshot(db, "peer-1", [], makeResetInfo());
+
+		expect(result.ok).toBe(true);
+		expect(result.deleted).toBe(1);
+		expect(result.applied).toBe(0);
+	});
+});

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -1,0 +1,273 @@
+/**
+ * Sync bootstrap: client-side snapshot consumer for re-bootstrapping
+ * shared memories from a peer when the incremental op log is no longer
+ * sufficient (generation mismatch, stale cursor beyond retained floor).
+ *
+ * The bootstrap protocol:
+ * 1. Fetch paginated snapshot pages from GET /v1/snapshot
+ * 2. Collect all canonical shared memory items (including tombstones)
+ * 3. In a single transaction: wipe local shared memories, apply snapshot,
+ *    update replication cursor to baseline_cursor, bump generation
+ */
+
+import { and, eq, isNotNull, ne, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import type { Database } from "./db.js";
+import { toJson } from "./db.js";
+import * as schema from "./schema.js";
+import { buildAuthHeaders } from "./sync-auth.js";
+import { requestJson } from "./sync-http-client.js";
+import { setReplicationCursor, setSyncResetState } from "./sync-replication.js";
+import type { SyncMemorySnapshotItem, SyncResetRequired } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BootstrapResult {
+	ok: boolean;
+	applied: number;
+	deleted: number;
+	error?: string;
+}
+
+export interface BootstrapOptions {
+	keysDir?: string;
+	/** Max items per page request. Defaults to 200. */
+	pageSize?: number;
+	/** Timeout per HTTP request in seconds. Defaults to 10. */
+	timeoutS?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot page fetcher
+// ---------------------------------------------------------------------------
+
+interface SnapshotPageResponse {
+	boundary: { generation: number; snapshot_id: string; baseline_cursor: string | null };
+	items: SyncMemorySnapshotItem[];
+	next_page_token: string | null;
+	has_more: boolean;
+}
+
+/**
+ * Fetch all snapshot pages from a peer's /v1/snapshot endpoint.
+ * Returns the full list of items and the boundary metadata.
+ */
+export async function fetchAllSnapshotPages(
+	baseUrl: string,
+	resetInfo: SyncResetRequired,
+	deviceId: string,
+	options?: BootstrapOptions,
+): Promise<{ items: SyncMemorySnapshotItem[]; boundary: SnapshotPageResponse["boundary"] }> {
+	const pageSize = options?.pageSize ?? 200;
+	const timeoutS = options?.timeoutS ?? 10;
+	const keysDir = options?.keysDir;
+
+	const allItems: SyncMemorySnapshotItem[] = [];
+	let pageToken: string | null = null;
+	let boundary: SnapshotPageResponse["boundary"] | null = null;
+
+	for (;;) {
+		const params = new URLSearchParams({
+			generation: String(resetInfo.generation),
+			snapshot_id: resetInfo.snapshot_id,
+			limit: String(pageSize),
+		});
+		if (resetInfo.baseline_cursor) {
+			params.set("baseline_cursor", resetInfo.baseline_cursor);
+		}
+		if (pageToken) {
+			params.set("page_token", pageToken);
+		}
+
+		const url = `${baseUrl}/v1/snapshot?${params.toString()}`;
+		const headers = buildAuthHeaders({
+			deviceId,
+			method: "GET",
+			url,
+			bodyBytes: Buffer.alloc(0),
+			keysDir,
+		});
+
+		const [status, payload] = await requestJson("GET", url, { headers, timeoutS });
+		if (status !== 200 || !payload) {
+			const detail = payload?.error ? String(payload.error) : `status ${status}`;
+			throw new Error(`snapshot fetch failed: ${detail}`);
+		}
+
+		const page = payload as unknown as SnapshotPageResponse;
+		if (!page.boundary || !Array.isArray(page.items)) {
+			throw new Error("invalid snapshot response shape");
+		}
+
+		boundary = page.boundary;
+		allItems.push(...page.items);
+
+		if (!page.has_more || !page.next_page_token) {
+			break;
+		}
+		pageToken = page.next_page_token;
+	}
+
+	if (!boundary) {
+		throw new Error("no snapshot pages returned");
+	}
+
+	return { items: allItems, boundary };
+}
+
+// ---------------------------------------------------------------------------
+// Local application
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a snapshot item's payload_json into memory fields.
+ * Returns null if the payload is malformed.
+ */
+function parseSnapshotPayload(item: SyncMemorySnapshotItem): Record<string, unknown> | null {
+	if (!item.payload_json) return null;
+	try {
+		const parsed = JSON.parse(item.payload_json);
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+		return parsed as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+function ensureSessionForBootstrap(d: ReturnType<typeof drizzle>, updatedAt: string): number {
+	const existing = d
+		.select({ id: schema.sessions.id })
+		.from(schema.sessions)
+		.where(eq(schema.sessions.cwd, "__sync_bootstrap__"))
+		.limit(1)
+		.get();
+	if (existing) return existing.id;
+
+	const rows = d
+		.insert(schema.sessions)
+		.values({
+			started_at: updatedAt,
+			cwd: "__sync_bootstrap__",
+			project: null,
+			user: "sync",
+			tool_version: "bootstrap",
+		})
+		.returning({ id: schema.sessions.id })
+		.all();
+	return rows[0]?.id ?? 0;
+}
+
+/**
+ * Apply a bootstrap snapshot to the local database, atomically replacing
+ * all shared memories with the snapshot contents.
+ *
+ * This runs in a single IMMEDIATE transaction:
+ * 1. Delete all local shared-visibility memory_items (preserving private)
+ * 2. Insert all snapshot items (upsert handles tombstones via active/deleted_at)
+ * 3. Update the replication cursor to baseline_cursor
+ * 4. Bump the local generation + snapshot_id to match the peer
+ */
+export function applyBootstrapSnapshot(
+	db: Database,
+	peerDeviceId: string,
+	items: SyncMemorySnapshotItem[],
+	resetInfo: SyncResetRequired,
+): BootstrapResult {
+	const result: BootstrapResult = { ok: false, applied: 0, deleted: 0 };
+
+	db.transaction(() => {
+		const d = drizzle(db, { schema });
+
+		// 1. Delete all local shared-visibility memories.
+		// Private memories (visibility = 'private' or NULL) are preserved.
+		const deleteResult = d
+			.delete(schema.memoryItems)
+			.where(
+				and(
+					isNotNull(schema.memoryItems.import_key),
+					ne(sql`COALESCE(${schema.memoryItems.visibility}, 'private')`, "private"),
+				),
+			)
+			.run();
+		result.deleted = deleteResult.changes;
+
+		// 2. Insert snapshot items.
+		const sessionId = ensureSessionForBootstrap(d, new Date().toISOString());
+
+		for (const item of items) {
+			const payload = parseSnapshotPayload(item);
+			if (!payload) continue;
+
+			const metaRaw = payload.metadata_json;
+			const meta =
+				metaRaw && typeof metaRaw === "object" && !Array.isArray(metaRaw)
+					? (metaRaw as Record<string, unknown>)
+					: {};
+			meta.clock_device_id = item.clock_device_id;
+
+			const isDeleted = item.op_type === "delete";
+
+			d.insert(schema.memoryItems)
+				.values({
+					session_id: sessionId,
+					kind: typeof payload.kind === "string" ? payload.kind : "discovery",
+					title: typeof payload.title === "string" ? payload.title : "",
+					subtitle: typeof payload.subtitle === "string" ? payload.subtitle : null,
+					body_text: typeof payload.body_text === "string" ? payload.body_text : "",
+					confidence: typeof payload.confidence === "number" ? payload.confidence : 0.5,
+					tags_text: typeof payload.tags_text === "string" ? payload.tags_text : "",
+					active: isDeleted ? 0 : 1,
+					created_at:
+						typeof payload.created_at === "string" ? payload.created_at : item.clock_updated_at,
+					updated_at: item.clock_updated_at,
+					metadata_json: toJson(meta),
+					import_key: item.entity_id,
+					deleted_at: isDeleted ? item.clock_updated_at : null,
+					rev: item.clock_rev,
+					actor_id: typeof payload.actor_id === "string" ? payload.actor_id : null,
+					actor_display_name:
+						typeof payload.actor_display_name === "string" ? payload.actor_display_name : null,
+					visibility: typeof payload.visibility === "string" ? payload.visibility : "shared",
+					workspace_id:
+						typeof payload.workspace_id === "string" ? payload.workspace_id : "shared:default",
+					workspace_kind:
+						typeof payload.workspace_kind === "string" ? payload.workspace_kind : "shared",
+					origin_device_id:
+						typeof payload.origin_device_id === "string"
+							? payload.origin_device_id
+							: item.clock_device_id,
+					origin_source: typeof payload.origin_source === "string" ? payload.origin_source : null,
+					trust_state: typeof payload.trust_state === "string" ? payload.trust_state : "trusted",
+					narrative: typeof payload.narrative === "string" ? payload.narrative : null,
+					facts: Array.isArray(payload.facts) ? JSON.stringify(payload.facts) : null,
+					concepts: Array.isArray(payload.concepts) ? JSON.stringify(payload.concepts) : null,
+					files_read: Array.isArray(payload.files_read) ? JSON.stringify(payload.files_read) : null,
+					files_modified: Array.isArray(payload.files_modified)
+						? JSON.stringify(payload.files_modified)
+						: null,
+				})
+				.run();
+			result.applied++;
+		}
+
+		// 3. Update replication cursor to baseline_cursor.
+		if (resetInfo.baseline_cursor) {
+			setReplicationCursor(db, peerDeviceId, {
+				lastApplied: resetInfo.baseline_cursor,
+			});
+		}
+
+		// 4. Bump local generation + snapshot_id to match the peer.
+		setSyncResetState(db, {
+			generation: resetInfo.generation,
+			snapshot_id: resetInfo.snapshot_id,
+			baseline_cursor: resetInfo.baseline_cursor,
+		});
+
+		result.ok = true;
+	}).immediate();
+
+	return result;
+}


### PR DESCRIPTION
## Description

Adds `sync-bootstrap.ts` — the client-side bootstrap snapshot consumer for re-bootstrapping shared memories when the incremental op log is insufficient.

- `fetchAllSnapshotPages()` — pages through `GET /v1/snapshot`, accumulates items with a 100k safety cap
- `applyBootstrapSnapshot()` — in an IMMEDIATE transaction: deletes all synced shared memories, inserts snapshot items (including tombstones), updates cursor to baseline_cursor, bumps generation/snapshot_id
- Private memories are explicitly preserved
- 6 unit tests covering replacement, preservation, tombstones, generation bump, cursor update, empty snapshot

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 742 tests)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced