### PR TITLE
feat(sync): auto-bootstrap from peer snapshot when reset required

### DIFF
--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -37,6 +37,8 @@ export interface BootstrapOptions {
 	pageSize?: number;
 	/** Timeout per HTTP request in seconds. Defaults to 10. */
 	timeoutS?: number;
+	/** Safety cap on total snapshot items. Defaults to 100,000. */
+	maxItems?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -44,7 +46,10 @@ export interface BootstrapOptions {
 // ---------------------------------------------------------------------------
 
 interface SnapshotPageResponse {
-	boundary: { generation: number; snapshot_id: string; baseline_cursor: string | null };
+	generation: number;
+	snapshot_id: string;
+	baseline_cursor: string | null;
+	retained_floor_cursor: string | null;
 	items: SyncMemorySnapshotItem[];
 	next_page_token: string | null;
 	has_more: boolean;
@@ -59,14 +64,21 @@ export async function fetchAllSnapshotPages(
 	resetInfo: SyncResetRequired,
 	deviceId: string,
 	options?: BootstrapOptions,
-): Promise<{ items: SyncMemorySnapshotItem[]; boundary: SnapshotPageResponse["boundary"] }> {
+): Promise<{
+	items: SyncMemorySnapshotItem[];
+	generation: number;
+	snapshot_id: string;
+	baseline_cursor: string | null;
+}> {
 	const pageSize = options?.pageSize ?? 200;
 	const timeoutS = options?.timeoutS ?? 10;
 	const keysDir = options?.keysDir;
+	const maxItems = options?.maxItems ?? 100_000;
 
 	const allItems: SyncMemorySnapshotItem[] = [];
 	let pageToken: string | null = null;
-	let boundary: SnapshotPageResponse["boundary"] | null = null;
+	let boundary: { generation: number; snapshot_id: string; baseline_cursor: string | null } | null =
+		null;
 
 	for (;;) {
 		const params = new URLSearchParams({
@@ -97,12 +109,22 @@ export async function fetchAllSnapshotPages(
 		}
 
 		const page = payload as unknown as SnapshotPageResponse;
-		if (!page.boundary || !Array.isArray(page.items)) {
+		if (!Array.isArray(page.items) || page.generation == null) {
 			throw new Error("invalid snapshot response shape");
 		}
 
-		boundary = page.boundary;
+		boundary = {
+			generation: page.generation,
+			snapshot_id: page.snapshot_id,
+			baseline_cursor: page.baseline_cursor,
+		};
 		allItems.push(...page.items);
+
+		if (allItems.length > maxItems) {
+			throw new Error(
+				`snapshot too large: ${allItems.length} items exceeds safety limit of ${maxItems}`,
+			);
+		}
 
 		if (!page.has_more || !page.next_page_token) {
 			break;
@@ -114,7 +136,7 @@ export async function fetchAllSnapshotPages(
 		throw new Error("no snapshot pages returned");
 	}
 
-	return { items: allItems, boundary };
+	return { items: allItems, ...boundary };
 }
 
 // ---------------------------------------------------------------------------
@@ -180,14 +202,19 @@ export function applyBootstrapSnapshot(
 	db.transaction(() => {
 		const d = drizzle(db, { schema });
 
-		// 1. Delete all local shared-visibility memories.
-		// Private memories (visibility = 'private' or NULL) are preserved.
+		// 1. Delete all local sync-eligible memories that have been synced.
+		// - Only memories with import_key (i.e. previously synced) are deleted.
+		// - Only explicitly private memories are preserved; NULL visibility is
+		//   treated as sync-eligible (matching syncVisibilityAllowed semantics)
+		//   to avoid leaving stale rows that could create duplicate import_keys.
+		// - The dirty-local gate in sync-pass ensures we only reach here when
+		//   no unsynced shared changes exist.
 		const deleteResult = d
 			.delete(schema.memoryItems)
 			.where(
 				and(
 					isNotNull(schema.memoryItems.import_key),
-					ne(sql`COALESCE(${schema.memoryItems.visibility}, 'private')`, "private"),
+					ne(sql`COALESCE(${schema.memoryItems.visibility}, '')`, "private"),
 				),
 			)
 			.run();

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -11,6 +11,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import * as schema from "./schema.js";
 import { buildAuthHeaders } from "./sync-auth.js";
+import { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
 import { buildBaseUrl, requestJson } from "./sync-http-client.js";
 import { ensureDeviceIdentity } from "./sync-identity.js";
 import {
@@ -439,23 +440,80 @@ export async function syncOnce(
 							: null,
 				};
 
-				recordSyncAttempt(db, peerDeviceId, {
-					ok: false,
-					error: dirtyLocal.dirty
-						? `needs_attention:local_unsynced_shared_memory:${dirtyLocal.count}`
-						: `reset_required:${resetRequired.reason}`,
-				});
-				return {
-					ok: false,
-					address: baseUrl,
-					error: dirtyLocal.dirty
-						? `needs attention: ${dirtyLocal.count} unsynced shared memory change(s) block automatic reset`
-						: `reset required: ${resetRequired.reason}`,
-					opsIn: 0,
-					opsOut: 0,
-					addressErrors: [],
-					resetRequired,
-				};
+				if (dirtyLocal.dirty) {
+					recordSyncAttempt(db, peerDeviceId, {
+						ok: false,
+						error: `needs_attention:local_unsynced_shared_memory:${dirtyLocal.count}`,
+					});
+					return {
+						ok: false,
+						address: baseUrl,
+						error: `needs attention: ${dirtyLocal.count} unsynced shared memory change(s) block automatic reset`,
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+						resetRequired,
+					};
+				}
+
+				// No dirty local state — safe to auto-bootstrap from peer snapshot.
+				try {
+					const { items } = await fetchAllSnapshotPages(baseUrl, resetRequired, deviceId, {
+						keysDir,
+					});
+
+					// Re-check dirty state after network fetch to close the TOCTOU window.
+					// A user may have created shared memories while we were fetching pages.
+					const dirtyAfterFetch = hasUnsyncedSharedMemoryChanges(db);
+					if (dirtyAfterFetch.dirty) {
+						recordSyncAttempt(db, peerDeviceId, {
+							ok: false,
+							error: `needs_attention:local_unsynced_shared_memory:${dirtyAfterFetch.count}`,
+						});
+						return {
+							ok: false,
+							address: baseUrl,
+							error: `needs attention: ${dirtyAfterFetch.count} unsynced shared memory change(s) appeared during bootstrap fetch`,
+							opsIn: 0,
+							opsOut: 0,
+							addressErrors: [],
+							resetRequired,
+						};
+					}
+
+					const bootstrapResult = applyBootstrapSnapshot(db, peerDeviceId, items, resetRequired);
+					if (!bootstrapResult.ok) {
+						throw new Error("bootstrap apply failed");
+					}
+					recordPeerSuccess(db, peerDeviceId);
+					recordSyncAttempt(db, peerDeviceId, {
+						ok: true,
+						opsIn: bootstrapResult.applied,
+						opsOut: 0,
+					});
+					return {
+						ok: true,
+						address: baseUrl,
+						opsIn: bootstrapResult.applied,
+						opsOut: 0,
+						addressErrors: [],
+					};
+				} catch (bootstrapErr) {
+					const msg = bootstrapErr instanceof Error ? bootstrapErr.message : String(bootstrapErr);
+					recordSyncAttempt(db, peerDeviceId, {
+						ok: false,
+						error: `bootstrap_failed:${msg}`,
+					});
+					return {
+						ok: false,
+						address: baseUrl,
+						error: `bootstrap failed: ${msg}`,
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+						resetRequired,
+					};
+				}
 			}
 			if (getStatus !== 200 || getPayload == null) {
 				const detail = errorDetail(getPayload);


### PR DESCRIPTION
## Description

Completes the bootstrap protocol (codemem-omm6) by wiring the snapshot consumer into the sync pass.

When a peer returns `reset_required` (409):
- If dirty local shared-memory exists → returns `needs_attention` (unchanged, blocks mutations)
- If no dirty local state → **automatically fetches and applies the bootstrap snapshot**, then records peer success

Key behaviors:
- `recordPeerSuccess` is called after bootstrap so `last_sync_at` / `last_error` are correctly updated
- Bootstrap failures are recorded as `bootstrap_failed:...` (retryable, doesn't block mutations)
- The daemon phase logic is unchanged — `needs_attention` blocks, `bootstrap_failed` doesn't

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 742 tests)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced