### PR TITLE
fix(raw-events): treat low-signal flushes as terminal no-op

### DIFF
--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -602,7 +602,7 @@ describe("ingest() integration", () => {
 		expect(session.ended_at).not.toBeNull();
 	});
 
-	it("throws during direct raw-event flush when observer yields no storable memories", async () => {
+	it("treats skip_summary low-signal raw-event flushes as terminal no-op", async () => {
 		const lowSignalObserver = {
 			observe: async () => ({
 				raw: '<skip_summary reason="low-signal"/>',
@@ -629,8 +629,78 @@ describe("ingest() integration", () => {
 			},
 		});
 
+		await ingest(payload, store, { observer: lowSignalObserver } as unknown as IngestOptions);
+
+		expect(store.recent(10)).toHaveLength(0);
+		const session = store.db
+			.prepare("SELECT ended_at FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as { ended_at: string | null };
+		expect(session.ended_at).not.toBeNull();
+	});
+
+	it("still fails raw-event flush when skip_summary reason is not low-signal", async () => {
+		const oddSkipObserver = {
+			observe: async () => ({
+				raw: '<skip_summary reason="other"/>',
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-skip-other",
+				promptCount: 1,
+				toolCount: 1,
+				durationMs: 1000,
+				flusher: "raw_events",
+			},
+		});
+
 		await expect(
-			ingest(payload, store, { observer: lowSignalObserver } as unknown as IngestOptions),
+			ingest(payload, store, { observer: oddSkipObserver } as unknown as IngestOptions),
+		).rejects.toThrow("observer produced no storable output for raw-event flush");
+
+		expect(store.recent(10)).toHaveLength(0);
+	});
+
+	it("still fails raw-event flush when low-signal skip is mixed with summary output", async () => {
+		const mixedObserver = {
+			observe: async () => ({
+				raw: '<summary><request>Check logs</request></summary><skip_summary reason="low-signal"/>',
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-skip-mixed",
+				promptCount: 1,
+				toolCount: 1,
+				durationMs: 1000,
+				flusher: "raw_events",
+			},
+		});
+
+		await expect(
+			ingest(payload, store, { observer: mixedObserver } as unknown as IngestOptions),
 		).rejects.toThrow("observer produced no storable output for raw-event flush");
 
 		expect(store.recent(10)).toHaveLength(0);

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -415,6 +415,14 @@ export async function ingest(
 		if (sessionContext?.flusher === "raw_events") {
 			const storableCount = observationsToStore.length + (summaryToStore ? 1 : 0);
 			if (storableCount === 0) {
+				const pureLowSignalSkip =
+					parsed.skipSummaryReason?.trim().toLowerCase() === "low-signal" &&
+					parsed.observations.length === 0 &&
+					parsed.summary === null;
+				if (pureLowSignalSkip) {
+					endSession(store, sessionId, events.length, sessionContext);
+					return;
+				}
 				throw new Error("observer produced no storable output for raw-event flush");
 			}
 		}

--- a/packages/core/src/raw-event-sweeper.test.ts
+++ b/packages/core/src/raw-event-sweeper.test.ts
@@ -305,7 +305,7 @@ describe("RawEventSweeper auto flush", () => {
 		expect(store.rawEventFlushState("sess-auto")).toBe(1);
 	});
 
-	it("records a failed batch and keeps the flush cursor when observer output has no storable memories", async () => {
+	it("terminally completes low-signal skip_summary batches and advances the flush cursor", async () => {
 		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
 		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
 		seedSession("sess-low-signal");
@@ -330,11 +330,8 @@ describe("RawEventSweeper auto flush", () => {
 		sweeper.nudge("sess-low-signal");
 		await sleep(150);
 
-		expect(store.rawEventFlushState("sess-low-signal")).toBe(-1);
-		expect(store.latestRawEventFlushFailure("opencode")).toMatchObject({
-			stream_id: "sess-low-signal",
-			error_message: "Test returned no usable output for raw-event processing.",
-		});
+		expect(store.rawEventFlushState("sess-low-signal")).toBe(1);
+		expect(store.latestRawEventFlushFailure("opencode")?.stream_id).not.toBe("sess-low-signal");
 	});
 
 	it("terminally skips tiny lifecycle-only sessions without calling the observer", async () => {


### PR DESCRIPTION
## Description

Fixes raw-event queue backlog growth caused by legitimate low-signal sessions being retried forever.

Previously, raw-event flush treated **any zero-storable-output observer result** as a hard failure and left the flush cursor pinned. That was correct for malformed/non-XML observer output, but wrong for valid low-signal output like `<skip_summary reason=\"low-signal\"/>`.

This change narrows the behavior:
- explicit `skip_summary reason=\"low-signal\"` during raw-event flush is treated as a **terminal no-op**
- the session is ended and the flush cursor can advance
- malformed / non-XML / otherwise zero-output observer responses still fail and remain retryable
- unknown skip reasons still fail (only `low-signal` is terminal)

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced