### PR TITLE
refactor(sync): derive people and device attention state

### DIFF
--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -59,6 +59,7 @@ export const state = {
   lastTeamJoin: null as any,
   lastSyncAttempts: [] as any[],
   lastSyncLegacyDevices: [] as any[],
+  lastSyncViewModel: null as any,
   pairingPayloadRaw: null as any,
   pairingCommandRaw: '',
 

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -81,9 +81,9 @@ export function parseScopeList(value: string): string[] {
 /* ── Actor helpers ───────────────────────────────────────── */
 
 export function actorLabel(actor: any): string {
-  if (!actor || typeof actor !== 'object') return 'Unknown actor';
+  if (!actor || typeof actor !== 'object') return 'Unknown person';
   const displayName = String(actor.display_name || '').trim();
-  if (!displayName) return String(actor.actor_id || 'Unknown actor');
+  if (!displayName) return String(actor.actor_id || 'Unknown person');
   return displayName;
 }
 
@@ -93,20 +93,20 @@ export function assignedActorCount(actorId: string): number {
 }
 
 export function assignmentNote(actorId: string): string {
-  if (!actorId) return 'Unassigned devices keep legacy fallback attribution until you choose an actor.';
+  if (!actorId) return 'Unassigned devices keep legacy fallback attribution until you choose a person.';
   const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
   const actor = actors.find((item) => String(item?.actor_id || '') === actorId);
   if (actor?.is_local) {
-    return 'Local actor assignment keeps this device in your same-person continuity path, including private sync.';
+    return 'Assigning this device to you keeps it in your same-person continuity path, including private sync.';
   }
-  return 'This actor receives memories from allowed projects by default. Use Only me on a memory when it should stay local.';
+  return 'This person receives memories from allowed projects by default. Use Only me on a memory when it should stay local.';
 }
 
 export function buildActorOptions(selectedActorId: string): HTMLOptionElement[] {
   const options: HTMLOptionElement[] = [];
   const unassigned = document.createElement('option');
   unassigned.value = '';
-  unassigned.textContent = 'No actor assigned';
+  unassigned.textContent = 'No person assigned';
   options.push(unassigned);
 
   const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
@@ -131,7 +131,7 @@ export function actorMergeNote(targetActorId: string, secondaryActorId: string):
     (actor) => String(actor?.actor_id || '') === targetActorId,
   );
   if (!targetActorId || !target) {
-    return 'Choose where this duplicate actor should collapse.';
+    return 'Choose which person should keep these devices.';
   }
   return `Merge into ${actorLabel(target)}. Assigned devices move now; existing memories keep their current provenance.`;
 }

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -3,6 +3,7 @@
 import * as api from '../../lib/api';
 import { state } from '../../lib/state';
 import { renderHealthOverview } from '../health';
+import { deriveSyncViewModel } from './view-model';
 
 import { renderSyncStatus, renderSyncAttempts, renderPairing, initDiagnosticsEvents, setRenderSyncPeers } from './diagnostics';
 import { renderTeamSync, renderSyncSharingReview, initTeamSyncEvents, setLoadSyncData as setTeamSyncLoadData } from './team-sync';
@@ -92,6 +93,11 @@ export async function loadSyncData() {
     }
     state.lastSyncAttempts = payload.attempts || [];
     state.lastSyncLegacyDevices = payload.legacy_devices || [];
+    state.lastSyncViewModel = deriveSyncViewModel({
+      actors: state.lastSyncActors,
+      peers: state.lastSyncPeers,
+      coordinator: state.lastSyncCoordinator,
+    });
     renderSyncStatus();
     renderTeamSync();
     renderSyncActors();
@@ -105,7 +111,7 @@ export async function loadSyncData() {
       const actorMeta = document.getElementById('syncActorsMeta');
       if (actorMeta)
         actorMeta.textContent =
-          'Actor controls are temporarily unavailable. Peer status and sync health still loaded.';
+          'People controls are temporarily unavailable. Device status and sync health still loaded.';
     }
   } catch {
     // Clear all skeletons so the error state is visible, not masked by loading placeholders

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -1,4 +1,4 @@
-/* People card — actors, devices/peers, sharing review, legacy device claims. */
+/* People card — people, devices, sharing review, legacy device claims. */
 
 import { el } from '../../lib/dom';
 import { formatTimestamp } from '../../lib/format';
@@ -42,13 +42,13 @@ export function renderSyncActors() {
   const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
   if (actorMeta) {
     actorMeta.textContent = actors.length
-      ? 'Create, rename, and merge actors here. Assign each device below. Non-local actors receive memories from allowed projects unless you mark them Only me.'
-      : 'No named actors yet. Create one here, then assign devices below.';
+      ? 'Create, rename, and combine people here. Assign each device below. Non-local people receive memories from allowed projects unless you mark them Only me.'
+      : 'No named people yet. Create one here, then assign devices below.';
   }
 
   if (!actors.length) {
     actorList.appendChild(
-      el('div', 'sync-empty-state', 'No actors yet. Create one to represent yourself or a teammate.'),
+      el('div', 'sync-empty-state', 'No people yet. Create one to represent yourself or a teammate.'),
     );
     return;
   }
@@ -105,10 +105,10 @@ export function renderSyncActors() {
       const mergeControls = el('div', 'actor-merge-controls');
       const mergeSelect = document.createElement('select');
       mergeSelect.className = 'sync-actor-select actor-merge-select';
-      mergeSelect.setAttribute('aria-label', `Merge ${actorLabel(actor)} into another actor`);
+      mergeSelect.setAttribute('aria-label', `Combine ${actorLabel(actor)} into another person`);
       const placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = 'Merge into actor';
+      placeholder.textContent = 'Combine into person';
       placeholder.selected = true;
       mergeSelect.appendChild(placeholder);
       mergeTargets.forEach((target) => {
@@ -120,7 +120,7 @@ export function renderSyncActors() {
       const mergeBtn = el(
         'button',
         'settings-button',
-        'Merge into selected actor',
+        'Combine into selected person',
       ) as HTMLButtonElement;
       mergeBtn.disabled = mergeTargets.length === 0;
       const mergeNote = el(
@@ -128,7 +128,7 @@ export function renderSyncActors() {
         'peer-meta actor-merge-note',
         mergeTargets.length
           ? actorMergeNote('', actorId)
-          : 'No merge targets yet. Create another actor or use the local actor.',
+          : 'No people available to combine yet. Create another person or use You.',
       );
       mergeSelect.addEventListener('change', () => {
         mergeNote.textContent = actorMergeNote(mergeSelect.value, actorId);
@@ -140,7 +140,7 @@ export function renderSyncActors() {
         );
         if (
           !window.confirm(
-            `Merge ${actorLabel(actor)} into ${actorLabel(target)}? Assigned devices move now, but older memories keep their current stamped provenance for now.`,
+            `Combine ${actorLabel(actor)} into ${actorLabel(target)}? Assigned devices move now, but older memories keep their current stamped provenance for now.`,
           )
         ) {
           return;
@@ -152,10 +152,10 @@ export function renderSyncActors() {
         mergeBtn.textContent = 'Merging\u2026';
         try {
           await api.mergeActor(mergeSelect.value, actorId);
-          showGlobalNotice('Actor merged. Assigned devices moved to the selected actor.');
+          showGlobalNotice('People combined. Assigned devices moved to the selected person.');
           await _loadSyncData();
         } catch (error) {
-          showGlobalNotice(friendlyError(error, 'Failed to merge actor.'), 'warning');
+          showGlobalNotice(friendlyError(error, 'Failed to combine people.'), 'warning');
           mergeBtn.textContent = 'Retry merge';
         } finally {
           mergeBtn.disabled = mergeTargets.length === 0;
@@ -163,7 +163,7 @@ export function renderSyncActors() {
           input.disabled = false;
           renameBtn.disabled = false;
           if (mergeBtn.textContent === 'Merging\u2026')
-            mergeBtn.textContent = 'Merge into selected actor';
+            mergeBtn.textContent = 'Combine into selected person';
         }
       });
       mergeControls.append(mergeSelect, mergeBtn);
@@ -188,7 +188,7 @@ export function renderSyncPeers() {
       el(
         'div',
         'sync-empty-state',
-        'No devices paired yet. Use the pairing command in Diagnostics to connect another device.',
+        'No devices connected on this machine yet. Use the pairing command in Diagnostics to connect another device.',
       ),
     );
     return;
@@ -298,8 +298,8 @@ export function renderSyncPeers() {
       'div',
       'peer-meta',
       peer.actor_display_name
-        ? `Assigned to ${String(peer.actor_display_name)}${peer.claimed_local_actor ? ' \u00b7 local actor' : ''}`
-        : 'Unassigned actor',
+        ? `Assigned to ${String(peer.actor_display_name)}${peer.claimed_local_actor ? ' \u00b7 you' : ''}`
+        : 'Unassigned person',
     );
 
     const scope = peer.project_scope || {};
@@ -310,15 +310,15 @@ export function renderSyncPeers() {
     const inheritsGlobal = Boolean(scope.inherits_global);
     const scopePanel = el('div', 'peer-scope');
     const identityRow = el('div', 'peer-scope-summary');
-    identityRow.textContent = 'Assigned actor';
+    identityRow.textContent = 'Assigned person';
     const actorRow = el('div', 'peer-actor-row');
     const actorSelect = document.createElement('select');
     actorSelect.className = 'sync-actor-select';
-    actorSelect.setAttribute('aria-label', `Assigned actor for ${displayName}`);
+    actorSelect.setAttribute('aria-label', `Assigned person for ${displayName}`);
     buildActorOptions(String(peer.actor_id || '')).forEach((option) =>
       actorSelect.appendChild(option),
     );
-    const applyActorBtn = el('button', 'settings-button', 'Save actor') as HTMLButtonElement;
+    const applyActorBtn = el('button', 'settings-button', 'Save person') as HTMLButtonElement;
     const actorHint = el(
       'div',
       'peer-scope-effective',
@@ -333,16 +333,16 @@ export function renderSyncPeers() {
       applyActorBtn.textContent = 'Applying\u2026';
       try {
         await api.assignPeerActor(peerId, actorSelect.value || null);
-        showGlobalNotice(actorSelect.value ? 'Device actor updated.' : 'Device actor cleared.');
+          showGlobalNotice(actorSelect.value ? 'Device person updated.' : 'Device person cleared.');
         await _loadSyncData();
       } catch (error) {
-        showGlobalNotice(friendlyError(error, 'Failed to update device actor.'), 'warning');
+        showGlobalNotice(friendlyError(error, 'Failed to update device person.'), 'warning');
         applyActorBtn.textContent = 'Retry';
       } finally {
         actorSelect.disabled = false;
         applyActorBtn.disabled = false;
         if (applyActorBtn.textContent === 'Applying\u2026')
-          applyActorBtn.textContent = 'Save actor';
+          applyActorBtn.textContent = 'Save person';
       }
     });
     actorRow.append(actorSelect, applyActorBtn);
@@ -502,7 +502,7 @@ export function initPeopleEvents(loadSyncData: () => Promise<void>) {
     if (!syncActorCreateButton || !syncActorCreateInput) return;
     const displayName = String(syncActorCreateInput.value || '').trim();
     if (!displayName) {
-      markFieldError(syncActorCreateInput, 'Enter a name for the actor.');
+      markFieldError(syncActorCreateInput, 'Enter a name for the person.');
       return;
     }
     clearFieldError(syncActorCreateInput);
@@ -511,17 +511,17 @@ export function initPeopleEvents(loadSyncData: () => Promise<void>) {
     syncActorCreateButton.textContent = 'Creating\u2026';
     try {
       await api.createActor(displayName);
-      showGlobalNotice('Actor created.');
+      showGlobalNotice('Person created.');
       syncActorCreateInput.value = '';
       await loadSyncData();
     } catch (error) {
-      showGlobalNotice(friendlyError(error, 'Failed to create actor.'), 'warning');
+      showGlobalNotice(friendlyError(error, 'Failed to create person.'), 'warning');
       syncActorCreateButton.textContent = 'Retry';
       syncActorCreateButton.disabled = false;
       syncActorCreateInput.disabled = false;
       return;
     }
-    syncActorCreateButton.textContent = 'Create actor';
+    syncActorCreateButton.textContent = 'Create person';
     syncActorCreateButton.disabled = false;
     syncActorCreateInput.disabled = false;
   });
@@ -531,7 +531,7 @@ export function initPeopleEvents(loadSyncData: () => Promise<void>) {
     if (!originDeviceId || !syncLegacyClaimButton) return;
     if (
       !window.confirm(
-        `Attach old device history from ${originDeviceId} to your local actor? This updates legacy provenance for that device.`,
+        `Attach old device history from ${originDeviceId} to you? This updates legacy provenance for that device.`,
       )
     )
       return;
@@ -540,7 +540,7 @@ export function initPeopleEvents(loadSyncData: () => Promise<void>) {
     syncLegacyClaimButton.textContent = 'Attaching\u2026';
     try {
       await api.claimLegacyDeviceIdentity(originDeviceId);
-      showGlobalNotice('Old device history attached to your local actor.');
+      showGlobalNotice('Old device history attached to you.');
       await loadSyncData();
     } catch (error) {
       showGlobalNotice(friendlyError(error, 'Failed to attach old device history.'), 'warning');

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -15,6 +15,7 @@ import {
   redactAddress,
   requestPeerScopeReview,
 } from './helpers';
+import { SYNC_TERMINOLOGY } from './view-model';
 
 /* ── DOM placement helpers ───────────────────────────────── */
 
@@ -73,7 +74,7 @@ export function renderSyncSharingReview() {
       el(
         'span',
         'badge actor-badge',
-        `actor: ${String(item.actor_display_name || item.actor_id || 'unknown')}`,
+        `person: ${String(item.actor_display_name || item.actor_id || 'unknown')}`,
       ),
     );
     const note = el(
@@ -122,6 +123,26 @@ export function renderTeamSync() {
   if (discoveredList) discoveredList.textContent = '';
   setInviteOutputVisibility();
   const coordinator = state.lastSyncCoordinator;
+  const syncView = state.lastSyncViewModel || { summary: {}, attentionItems: [] };
+
+  const focusAttentionTarget = (item: any) => {
+    if (item.kind === 'possible-duplicate-person') {
+      const actorList = document.getElementById('syncActorsList');
+      if (actorList instanceof HTMLElement) actorList.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      return;
+    }
+    const deviceId = String(item.deviceId || '').trim();
+    if (!deviceId) return;
+    const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(deviceId)}"]`);
+    if (peerCard instanceof HTMLElement) {
+      peerCard.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      return;
+    }
+    const discoveredRow = document.querySelector(`[data-discovered-device-id="${CSS.escape(deviceId)}"]`);
+    if (discoveredRow instanceof HTMLElement) {
+      discoveredRow.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  };
   const configured = Boolean(coordinator && coordinator.configured);
   meta.textContent = configured
     ? `Connected to ${String(coordinator.coordinator_url || '')} \u00b7 group: ${(coordinator.groups || []).join(', ') || 'none'}`
@@ -160,30 +181,32 @@ export function renderTeamSync() {
     presenceLabel,
   );
   const metricParts = [
-    `Paired devices: ${Number(coordinator.paired_peer_count || 0)}`,
-    `Fresh discovered: ${Number(coordinator.fresh_peer_count || 0)}`,
+    `Connected devices: ${Number(syncView.summary?.connectedDeviceCount || 0)}`,
+    `Seen on team: ${Number(syncView.summary?.seenOnTeamCount || 0)}`,
   ];
-  if (Number(coordinator.stale_peer_count || 0) > 0) {
-    metricParts.push(`Inactive: ${Number(coordinator.stale_peer_count || 0)}`);
+  if (Number(syncView.summary?.offlineTeamDeviceCount || 0) > 0) {
+    metricParts.push(`Offline on team: ${Number(syncView.summary?.offlineTeamDeviceCount || 0)}`);
   }
   statusLine.append(statusLabel, statusBadge);
   statusRow.append(statusLine, el('div', 'sync-team-metrics', metricParts.join(' \u00b7 ')));
   list.appendChild(statusRow);
 
   const localPeers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
-  const unhealthyPeers = localPeers.filter((peer) => {
-    const status = peer?.status || {};
-    return Boolean(peer?.has_error) || ['offline', 'stale', 'degraded'].includes(String(status.peer_state || ''));
-  });
-  if (unhealthyPeers.length) {
-    const row = el('div', 'sync-action');
-    const textWrap = el('div', 'sync-action-text');
-    textWrap.textContent = `${unhealthyPeers.length} paired device${unhealthyPeers.length === 1 ? '' : 's'} look stale or unhealthy.`;
-    textWrap.appendChild(
-      el('span', 'sync-action-command', 'Use Remove peer in People or codemem sync peers remove <peer> before re-pairing.'),
-    );
-    row.appendChild(textWrap);
-    actions.appendChild(row);
+  const attentionItems = Array.isArray(syncView.attentionItems) ? syncView.attentionItems : [];
+  if (attentionItems.length) {
+    const heading = el('div', 'sync-action-text');
+    heading.textContent = 'Needs attention';
+    actions.appendChild(heading);
+    attentionItems.slice(0, 4).forEach((item: any) => {
+      const row = el('div', 'sync-action');
+      const textWrap = el('div', 'sync-action-text');
+      textWrap.textContent = item.title;
+      textWrap.appendChild(el('span', 'sync-action-command', item.summary));
+      const actionButton = el('button', 'settings-button', item.actionLabel || 'Review') as HTMLButtonElement;
+      actionButton.addEventListener('click', () => focusAttentionTarget(item));
+      row.append(textWrap, actionButton);
+      actions.appendChild(row);
+    });
   }
 
   const discoveredDevices = Array.isArray(coordinator.discovered_devices)
@@ -199,6 +222,7 @@ export function renderTeamSync() {
       const title = el('div', 'actor-title');
       const rowActions = el('div', 'actor-actions');
       const deviceId = String(device.device_id || '').trim();
+      if (deviceId) row.dataset.discoveredDeviceId = deviceId;
       const displayName = String(device.display_name || '').trim() || deviceId || 'Discovered device';
       const fingerprint = String(device.fingerprint || '').trim();
       const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || '') === deviceId);
@@ -217,7 +241,7 @@ export function renderTeamSync() {
         el(
           'span',
           'badge actor-badge',
-          hasConflict ? 'Conflicts with local peer' : pairedPeer ? 'Paired locally' : 'Not paired locally',
+          hasConflict ? SYNC_TERMINOLOGY.conflicts : pairedPeer ? SYNC_TERMINOLOGY.pairedLocally : 'Not connected on this device',
         ),
       );
       const addresses = Array.isArray(device.addresses) ? device.addresses : [];

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveDuplicatePeople,
+  derivePeerUiStatus,
+  deriveSyncViewModel,
+  deviceNeedsFriendlyName,
+  resolveFriendlyDeviceName,
+} from './view-model';
+
+describe('resolveFriendlyDeviceName', () => {
+  it('prefers the explicit local name first', () => {
+    expect(
+      resolveFriendlyDeviceName({
+        localName: 'Work MacBook',
+        coordinatorName: 'Adam laptop',
+        deviceId: '12345678-1234-1234-1234-123456789abc',
+      }),
+    ).toBe('Work MacBook');
+  });
+
+  it('falls back to coordinator display name before raw device ids', () => {
+    expect(
+      resolveFriendlyDeviceName({
+        localName: '',
+        coordinatorName: 'Desk Mini',
+        deviceId: '12345678-1234-1234-1234-123456789abc',
+      }),
+    ).toBe('Desk Mini');
+  });
+
+  it('uses a short fallback when nothing friendly exists', () => {
+    expect(
+      resolveFriendlyDeviceName({
+        deviceId: '12345678-1234-1234-1234-123456789abc',
+      }),
+    ).toBe('12345678');
+  });
+});
+
+describe('deviceNeedsFriendlyName', () => {
+  it('requires naming when no local or coordinator name exists', () => {
+    expect(
+      deviceNeedsFriendlyName({ deviceId: '12345678-1234-1234-1234-123456789abc' }),
+    ).toBe(true);
+  });
+
+  it('does not require naming when a friendly label already exists', () => {
+    expect(
+      deviceNeedsFriendlyName({
+        localName: 'Work MacBook',
+        deviceId: '12345678-1234-1234-1234-123456789abc',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('derivePeerUiStatus', () => {
+  it('flags peers with explicit errors as needs-repair', () => {
+    expect(derivePeerUiStatus({ has_error: true, status: { peer_state: 'online' } })).toBe('needs-repair');
+  });
+
+  it('maps stale peers to offline', () => {
+    expect(derivePeerUiStatus({ status: { peer_state: 'stale' } })).toBe('offline');
+  });
+});
+
+describe('deriveDuplicatePeople', () => {
+  it('groups duplicate display names and preserves local involvement', () => {
+    expect(
+      deriveDuplicatePeople([
+        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
+        { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
+        { actor_id: 'actor-other', display_name: 'Pat', is_local: false },
+      ]),
+    ).toEqual([
+      {
+        displayName: 'Adam',
+        actorIds: ['actor-local', 'actor-remote'],
+        includesLocal: true,
+      },
+    ]);
+  });
+});
+
+describe('deriveSyncViewModel', () => {
+  it('creates attention items for duplicates, repairs, reviewable devices, and naming gaps', () => {
+    const view = deriveSyncViewModel({
+      actors: [
+        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
+        { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
+      ],
+      peers: [
+        {
+          peer_device_id: 'peer-1',
+          name: '',
+          has_error: true,
+          last_error: 'all addresses failed',
+          status: { peer_state: 'degraded' },
+          fingerprint: 'fp-old',
+        },
+      ],
+      coordinator: {
+        discovered_devices: [
+          {
+            device_id: 'peer-1',
+            display_name: '',
+            stale: false,
+            fingerprint: 'fp-new',
+          },
+          {
+            device_id: 'peer-2',
+            display_name: 'Desk Mini',
+            stale: false,
+            fingerprint: 'fp-2',
+          },
+        ],
+      },
+    });
+
+    expect(view.summary).toEqual({
+      connectedDeviceCount: 0,
+      seenOnTeamCount: 2,
+      offlineTeamDeviceCount: 0,
+    });
+    expect(view.attentionItems.map((item) => item.kind)).toEqual([
+      'possible-duplicate-person',
+      'device-needs-repair',
+      'review-team-device',
+    ]);
+  });
+});

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -1,0 +1,288 @@
+/* Derived sync view-model helpers. Keep these pure so UX logic is testable. */
+
+export const SYNC_TERMINOLOGY = {
+  actor: 'person',
+  actors: 'people',
+  actorAssignment: 'person assignment',
+  localActor: 'you',
+  peer: 'device',
+  peers: 'devices',
+  pairedLocally: 'Connected on this device',
+  discovered: 'Seen on team',
+  conflicts: 'Needs repair',
+} as const;
+
+export type UiSyncStatus = 'connected' | 'available' | 'needs-repair' | 'offline' | 'waiting';
+
+export interface UiSyncAttentionItem {
+  id: string;
+  kind: 'possible-duplicate-person' | 'device-needs-repair' | 'review-team-device' | 'name-device';
+  priority: number;
+  title: string;
+  summary: string;
+  actionLabel: string;
+  deviceId?: string;
+  actorIds?: string[];
+}
+
+export interface UiDuplicatePersonCandidate {
+  displayName: string;
+  actorIds: string[];
+  includesLocal: boolean;
+}
+
+export interface UiSyncViewModel {
+  summary: {
+    connectedDeviceCount: number;
+    seenOnTeamCount: number;
+    offlineTeamDeviceCount: number;
+  };
+  duplicatePeople: UiDuplicatePersonCandidate[];
+  attentionItems: UiSyncAttentionItem[];
+}
+
+interface MergedDevice {
+  deviceId: string;
+  localName: string;
+  coordinatorName: string;
+  peer: any | null;
+  discovered: any | null;
+}
+
+function cleanText(value: unknown): string {
+  return String(value ?? '').trim();
+}
+
+function normalizeDisplayName(value: unknown): string {
+  return cleanText(value).replace(/\s+/g, ' ').toLowerCase();
+}
+
+function looksLikeDeviceId(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(value);
+}
+
+function friendlyDeviceFallback(deviceId: string): string {
+  const cleanId = cleanText(deviceId);
+  return cleanId ? cleanId.slice(0, 8) : 'Unnamed device';
+}
+
+export function resolveFriendlyDeviceName(input: {
+  localName?: unknown;
+  coordinatorName?: unknown;
+  deviceId?: unknown;
+}): string {
+  const localName = cleanText(input.localName);
+  if (localName) return localName;
+  const coordinatorName = cleanText(input.coordinatorName);
+  if (coordinatorName) return coordinatorName;
+  return friendlyDeviceFallback(cleanText(input.deviceId));
+}
+
+export function deviceNeedsFriendlyName(input: {
+  localName?: unknown;
+  coordinatorName?: unknown;
+  deviceId?: unknown;
+}): boolean {
+  const localName = cleanText(input.localName);
+  const coordinatorName = cleanText(input.coordinatorName);
+  if (localName || coordinatorName) return false;
+  return Boolean(cleanText(input.deviceId));
+}
+
+export function derivePeerUiStatus(peer: any): UiSyncStatus {
+  const peerState = cleanText(peer?.status?.peer_state);
+  if (peer?.has_error || peerState === 'degraded') return 'needs-repair';
+  if (peerState === 'online') return 'connected';
+  if (peerState === 'offline' || peerState === 'stale') return 'offline';
+  if (peer?.status?.fresh) return 'connected';
+  return 'waiting';
+}
+
+export function deriveDuplicatePeople(actors: any[]): UiDuplicatePersonCandidate[] {
+  const groups = new Map<string, UiDuplicatePersonCandidate>();
+  (Array.isArray(actors) ? actors : []).forEach((actor) => {
+    const displayName = cleanText(actor?.display_name);
+    const actorId = cleanText(actor?.actor_id);
+    const normalized = normalizeDisplayName(displayName);
+    if (!displayName || !actorId || !normalized) return;
+    const current = groups.get(normalized) ?? {
+      displayName,
+      actorIds: [],
+      includesLocal: false,
+    };
+    current.actorIds = [...current.actorIds, actorId];
+    current.includesLocal = current.includesLocal || Boolean(actor?.is_local);
+    groups.set(normalized, current);
+  });
+  return [...groups.values()]
+    .filter((item) => item.actorIds.length > 1)
+    .sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+function createRepairItem(device: { id: string; name: string; summary: string }): UiSyncAttentionItem {
+  return {
+    id: `repair:${device.id}`,
+    kind: 'device-needs-repair',
+    priority: 10,
+    title: `${device.name} needs repair`,
+    summary: device.summary,
+    actionLabel: 'Review device',
+    deviceId: device.id,
+  };
+}
+
+function createReviewItem(device: { id: string; name: string; summary: string }): UiSyncAttentionItem {
+  return {
+    id: `review:${device.id}`,
+    kind: 'review-team-device',
+    priority: 20,
+    title: `${device.name} is available to review`,
+    summary: device.summary,
+    actionLabel: 'Review device',
+    deviceId: device.id,
+  };
+}
+
+function createNamingItem(device: { id: string; name: string; summary: string }): UiSyncAttentionItem {
+  return {
+    id: `name:${device.id}`,
+    kind: 'name-device',
+    priority: 30,
+    title: `Name ${device.name}`,
+    summary: device.summary,
+    actionLabel: 'Name device',
+    deviceId: device.id,
+  };
+}
+
+function mergeDevices(peers: any[], discoveredDevices: any[]): MergedDevice[] {
+  const devices = new Map<string, MergedDevice>();
+  const getOrCreate = (deviceId: string): MergedDevice => {
+    const current = devices.get(deviceId) ?? {
+      deviceId,
+      localName: '',
+      coordinatorName: '',
+      peer: null,
+      discovered: null,
+    };
+    devices.set(deviceId, current);
+    return current;
+  };
+
+  peers.forEach((peer) => {
+    const deviceId = cleanText(peer?.peer_device_id);
+    if (!deviceId) return;
+    const current = getOrCreate(deviceId);
+    current.peer = peer;
+    current.localName = cleanText(peer?.name);
+  });
+
+  discoveredDevices.forEach((device) => {
+    const deviceId = cleanText(device?.device_id);
+    if (!deviceId) return;
+    const current = getOrCreate(deviceId);
+    current.discovered = device;
+    current.coordinatorName = cleanText(device?.display_name);
+  });
+
+  return [...devices.values()];
+}
+
+export function deriveSyncViewModel(input: {
+  actors?: any[];
+  peers?: any[];
+  coordinator?: any;
+}): UiSyncViewModel {
+  const actors = Array.isArray(input.actors) ? input.actors : [];
+  const peers = Array.isArray(input.peers) ? input.peers : [];
+  const discoveredDevices = Array.isArray(input.coordinator?.discovered_devices)
+    ? input.coordinator.discovered_devices
+    : [];
+  const mergedDevices = mergeDevices(peers, discoveredDevices);
+  const duplicatePeople = deriveDuplicatePeople(actors);
+  const attentionItems: UiSyncAttentionItem[] = [];
+
+  duplicatePeople.forEach((candidate) => {
+    attentionItems.push({
+      id: `duplicate:${candidate.actorIds.join(':')}`,
+      kind: 'possible-duplicate-person',
+      priority: candidate.includesLocal ? 5 : 15,
+      title: `Possible duplicate person: ${candidate.displayName}`,
+      summary: candidate.includesLocal
+        ? 'At least one entry is marked as you. Confirm whether these records represent the same person.'
+        : 'Multiple people share this name. Confirm whether they should stay separate or be combined.',
+      actionLabel: 'Review people',
+      actorIds: candidate.actorIds,
+    });
+  });
+
+  mergedDevices.forEach((device) => {
+    const name = resolveFriendlyDeviceName({
+      localName: device.localName,
+      coordinatorName: device.coordinatorName,
+      deviceId: device.deviceId,
+    });
+    const peerStatus = device.peer ? derivePeerUiStatus(device.peer) : 'waiting';
+    const discoveredFingerprint = cleanText(device.discovered?.fingerprint);
+    const peerFingerprint = cleanText(device.peer?.fingerprint);
+    const hasConflict = Boolean(device.peer) && Boolean(discoveredFingerprint) && Boolean(peerFingerprint) && discoveredFingerprint !== peerFingerprint;
+
+    if (hasConflict) {
+      attentionItems.push(
+        createRepairItem({
+          id: device.deviceId,
+          name,
+          summary: 'This device identity changed. Repair or remove the older local record before reconnecting it.',
+        }),
+      );
+      return;
+    }
+
+    if (device.peer && peerStatus === 'needs-repair') {
+      const detail = cleanText(device.peer?.last_error) || 'Sync health is degraded or broken.';
+      attentionItems.push(createRepairItem({ id: device.deviceId, name, summary: detail }));
+    } else if (device.peer && peerStatus === 'offline') {
+      attentionItems.push(
+        createRepairItem({
+          id: device.deviceId,
+          name,
+          summary: 'This device is offline or stale. Review it before re-pairing or retrying sync.',
+        }),
+      );
+    } else if (!device.peer && device.discovered && !device.discovered?.stale) {
+      attentionItems.push(
+        createReviewItem({
+          id: device.deviceId,
+          name,
+          summary: 'This device is seen on the team and is ready for review or connection on this machine.',
+        }),
+      );
+    }
+
+    if (
+      deviceNeedsFriendlyName({
+        localName: device.localName,
+        coordinatorName: device.coordinatorName,
+        deviceId: device.deviceId,
+      }) && looksLikeDeviceId(name)
+    ) {
+      attentionItems.push(
+        createNamingItem({
+          id: device.deviceId,
+          name,
+          summary: 'Give this device a friendly name so it is easier to recognize later.',
+        }),
+      );
+    }
+  });
+
+  return {
+    summary: {
+      connectedDeviceCount: peers.filter((peer) => derivePeerUiStatus(peer) === 'connected').length,
+      seenOnTeamCount: discoveredDevices.length,
+      offlineTeamDeviceCount: discoveredDevices.filter((device: any) => Boolean(device?.stale)).length,
+    },
+    duplicatePeople,
+    attentionItems: attentionItems.sort((a, b) => a.priority - b.priority || a.title.localeCompare(b.title)),
+  };
+}


### PR DESCRIPTION
## Description
This PR adds the first sync UX foundation layer by deriving people, devices, statuses, and attention items from the existing sync payloads.
It reduces direct renderer dependence on raw sync/coordinator state so later UI slices can present a clearer model without duplicating every backend concept in the DOM code.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:
- `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts`
- `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced