### PR TITLE
feat(sync): require friendly device naming on setup

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -226,6 +226,21 @@ export async function deletePeer(peerDeviceId: string): Promise<any> {
   return payload;
 }
 
+export async function renamePeer(peerDeviceId: string, name: string): Promise<any> {
+  const resp = await fetch('/api/sync/peers/rename', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      peer_device_id: peerDeviceId,
+      name,
+    }),
+  });
+  const text = await resp.text();
+  const payload = text ? JSON.parse(text) : {};
+  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  return payload;
+}
+
 export async function acceptDiscoveredPeer(peerDeviceId: string, fingerprint: string): Promise<any> {
   const resp = await fetch('/api/sync/peers/accept-discovered', {
     method: 'POST',

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -214,6 +214,37 @@ export function renderSyncPeers() {
     }
 
     const actions = el('div', 'peer-actions');
+    const renameInput = document.createElement('input');
+    renameInput.className = 'peer-scope-input';
+    renameInput.value = displayName;
+    renameInput.setAttribute('aria-label', `Friendly name for ${displayName}`);
+    renameInput.placeholder = 'Friendly device name';
+    const renameBtn = el('button', null, 'Save name') as HTMLButtonElement;
+    renameBtn.addEventListener('click', async () => {
+      if (!peerId) return;
+      const nextName = String(renameInput.value || '').trim();
+      if (!nextName) {
+        showGlobalNotice('Enter a friendly name for this device.', 'warning');
+        renameInput.focus();
+        return;
+      }
+      renameBtn.disabled = true;
+      renameInput.disabled = true;
+      renameBtn.textContent = 'Saving…';
+      try {
+        await api.renamePeer(peerId, nextName);
+        showGlobalNotice('Device name saved.');
+        await _loadSyncData();
+      } catch (error) {
+        showGlobalNotice(friendlyError(error, 'Failed to save device name.'), 'warning');
+        renameBtn.textContent = 'Retry save';
+      } finally {
+        renameBtn.disabled = false;
+        renameInput.disabled = false;
+        if (renameBtn.textContent === 'Saving…') renameBtn.textContent = 'Save name';
+      }
+    });
+    actions.append(renameInput, renameBtn);
     const primaryAddress = pickPrimaryAddress(peer.addresses);
     const syncBtn = el('button', null, 'Sync now') as HTMLButtonElement;
     syncBtn.disabled = !primaryAddress;

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -143,6 +143,21 @@ export function renderTeamSync() {
       discoveredRow.scrollIntoView({ block: 'center', behavior: 'smooth' });
     }
   };
+
+  const promptForDeviceName = async (deviceId: string, suggestedName: string) => {
+    const nextName = window.prompt(
+      'What should this device be called? You can change it later in People & devices.',
+      suggestedName,
+    );
+    const value = String(nextName || '').trim();
+    if (!value) {
+      showGlobalNotice('You can name this device later from People & devices.', 'warning');
+      return false;
+    }
+    await api.renamePeer(deviceId, value);
+    showGlobalNotice(`Saved device name: ${value}.`);
+    return true;
+  };
   const configured = Boolean(coordinator && coordinator.configured);
   meta.textContent = configured
     ? `Connected to ${String(coordinator.coordinator_url || '')} \u00b7 group: ${(coordinator.groups || []).join(', ') || 'none'}`
@@ -288,12 +303,30 @@ export function renderTeamSync() {
           acceptBtn.disabled = true;
           acceptBtn.textContent = 'Opening…';
           try {
-            await api.acceptDiscoveredPeer(deviceId, fingerprint);
+            const result = await api.acceptDiscoveredPeer(deviceId, fingerprint);
             requestPeerScopeReview(deviceId);
             showGlobalNotice(
               `Connected ${displayName}. Its device settings are now open in People & devices so you can review sync scope next.`,
             );
-            await _loadSyncData();
+            try {
+              await promptForDeviceName(
+                deviceId,
+                String(result?.name || displayName || '').trim() || displayName,
+              );
+            } catch (error) {
+              showGlobalNotice(
+                friendlyError(error, 'Device connected, but naming did not finish.'),
+                'warning',
+              );
+            }
+            try {
+              await _loadSyncData();
+            } catch (error) {
+              showGlobalNotice(
+                friendlyError(error, 'Device connected, but the screen did not refresh yet.'),
+                'warning',
+              );
+            }
           } catch (error) {
             showGlobalNotice(friendlyError(error, 'Failed to review this device.'), 'warning');
             acceptBtn.textContent = 'Retry review';


### PR DESCRIPTION
## Description
This PR makes friendly device naming part of the setup flow by prompting after a device is connected and by exposing inline rename controls in People & devices.
It closes the gap between raw device identifiers and human-recognizable names so the sync UI can stop falling back to UUID soup during normal use.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:
- `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts`
- `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced