### PR TITLE
feat(sync): add duplicate person confirmation flow

### DIFF
--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -60,6 +60,7 @@ export const state = {
   lastSyncAttempts: [] as any[],
   lastSyncLegacyDevices: [] as any[],
   lastSyncViewModel: null as any,
+  lastSyncDuplicatePersonDecisions: {} as Record<string, string>,
   pairingPayloadRaw: null as any,
   pairingCommandRaw: '',
 

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -25,6 +25,9 @@ export function setTeamInvitePanelOpen(v: boolean) {
 export const openPeerScopeEditors = new Set<string>();
 const pendingPeerScopeReviewIds = new Set<string>();
 const freshPeerScopeReviewIds = new Set<string>();
+const DUPLICATE_PERSON_DECISIONS_KEY = 'codemem-sync-duplicate-person-decisions';
+
+export type DuplicatePersonDecision = 'different-people';
 
 export function requestPeerScopeReview(peerDeviceId: string) {
   const value = String(peerDeviceId || '').trim();
@@ -50,6 +53,47 @@ export function consumePeerScopeReviewRequest(peerDeviceId: string): boolean {
   if (!value || !freshPeerScopeReviewIds.has(value)) return false;
   freshPeerScopeReviewIds.delete(value);
   return true;
+}
+
+function readDuplicatePersonDecisionStore(): Record<string, DuplicatePersonDecision> {
+  try {
+    const raw = localStorage.getItem(DUPLICATE_PERSON_DECISIONS_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeDuplicatePersonDecisionStore(value: Record<string, DuplicatePersonDecision>) {
+  try {
+    localStorage.setItem(DUPLICATE_PERSON_DECISIONS_KEY, JSON.stringify(value));
+  } catch {}
+}
+
+export function duplicatePersonDecisionKey(actorIds: string[]): string {
+  return [...actorIds].map((value) => String(value || '').trim()).filter(Boolean).sort().join('::');
+}
+
+export function readDuplicatePersonDecisions(): Record<string, DuplicatePersonDecision> {
+  return readDuplicatePersonDecisionStore();
+}
+
+export function saveDuplicatePersonDecision(actorIds: string[], decision: DuplicatePersonDecision) {
+  const key = duplicatePersonDecisionKey(actorIds);
+  if (!key) return;
+  const next = readDuplicatePersonDecisionStore();
+  next[key] = decision;
+  writeDuplicatePersonDecisionStore(next);
+}
+
+export function clearDuplicatePersonDecision(actorIds: string[]) {
+  const key = duplicatePersonDecisionKey(actorIds);
+  if (!key) return;
+  const next = readDuplicatePersonDecisionStore();
+  delete next[key];
+  writeDuplicatePersonDecisionStore(next);
 }
 
 /* ── Text helpers ────────────────────────────────────────── */

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -8,7 +8,7 @@ import { deriveSyncViewModel } from './view-model';
 import { renderSyncStatus, renderSyncAttempts, renderPairing, initDiagnosticsEvents, setRenderSyncPeers } from './diagnostics';
 import { renderTeamSync, renderSyncSharingReview, initTeamSyncEvents, setLoadSyncData as setTeamSyncLoadData } from './team-sync';
 import { renderSyncActors, renderSyncPeers, renderLegacyDeviceClaims, initPeopleEvents, setLoadSyncData as setPeopleLoadData } from './people';
-import { hideSkeleton } from './helpers';
+import { hideSkeleton, readDuplicatePersonDecisions } from './helpers';
 
 /* ── Re-exports consumed by app.ts ───────────────────────── */
 
@@ -93,10 +93,12 @@ export async function loadSyncData() {
     }
     state.lastSyncAttempts = payload.attempts || [];
     state.lastSyncLegacyDevices = payload.legacy_devices || [];
+    state.lastSyncDuplicatePersonDecisions = readDuplicatePersonDecisions();
     state.lastSyncViewModel = deriveSyncViewModel({
       actors: state.lastSyncActors,
       peers: state.lastSyncPeers,
       coordinator: state.lastSyncCoordinator,
+      duplicatePersonDecisions: state.lastSyncDuplicatePersonDecisions,
     });
     renderSyncStatus();
     renderTeamSync();

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -14,6 +14,8 @@ import {
   isPeerScopeReviewPending,
   redactAddress,
   requestPeerScopeReview,
+  clearDuplicatePersonDecision,
+  saveDuplicatePersonDecision,
 } from './helpers';
 import { SYNC_TERMINOLOGY } from './view-model';
 
@@ -144,6 +146,53 @@ export function renderTeamSync() {
     }
   };
 
+  const reviewDuplicatePeople = async (item: any) => {
+    const actorIds = Array.isArray(item.actorIds) ? item.actorIds.map((value: unknown) => String(value || '').trim()).filter(Boolean) : [];
+    const actors = (Array.isArray(state.lastSyncActors) ? state.lastSyncActors : []).filter((actor) =>
+      actorIds.includes(String(actor?.actor_id || '').trim()),
+    );
+    if (actors.length < 2) {
+      showGlobalNotice('This possible duplicate no longer has enough people to review.', 'warning');
+      return;
+    }
+    const firstAnswer = window.prompt(
+      `Possible duplicate person: ${item.title.replace(/^Possible duplicate person:\s*/, '')}\n\nChoose an option:\n1 = These are both me\n2 = These are different people\n3 = Decide later`,
+      '1',
+    );
+    const choice = String(firstAnswer || '').trim();
+    if (choice === '2') {
+      saveDuplicatePersonDecision(actorIds, 'different-people');
+      showGlobalNotice('Okay. I will keep these people separate on this device.');
+      await _loadSyncData();
+      return;
+    }
+    if (choice !== '1') return;
+    clearDuplicatePersonDecision(actorIds);
+    const localIndex = actors.findIndex((actor) => Boolean(actor?.is_local));
+    const defaultChoice = localIndex >= 0 ? String(localIndex + 1) : '1';
+    const options = actors
+      .map((actor, index) => `${index + 1} = ${String(actor?.display_name || actor?.actor_id || `Person ${index + 1}`)}${actor?.is_local ? ' (You)' : ''}`)
+      .join('\n');
+    const keepAnswer = window.prompt(
+      `Which person should remain after combining them?\n\n${options}`,
+      defaultChoice,
+    );
+    const keepIndex = Number.parseInt(String(keepAnswer || defaultChoice), 10) - 1;
+    const primary = actors[keepIndex] ?? actors[0];
+    const secondary = actors.find((actor) => actor !== primary);
+    if (!primary?.actor_id || !secondary?.actor_id) {
+      showGlobalNotice('Could not determine which people to combine.', 'warning');
+      return;
+    }
+    try {
+      await api.mergeActor(String(primary.actor_id), String(secondary.actor_id));
+      showGlobalNotice(`Combined duplicate people into ${String(primary.display_name || primary.actor_id)}.`);
+      await _loadSyncData();
+    } catch (error) {
+      showGlobalNotice(friendlyError(error, 'Failed to combine these people.'), 'warning');
+    }
+  };
+
   const promptForDeviceName = async (deviceId: string, suggestedName: string) => {
     const nextName = window.prompt(
       'What should this device be called? You can change it later in People & devices.',
@@ -218,7 +267,13 @@ export function renderTeamSync() {
       textWrap.textContent = item.title;
       textWrap.appendChild(el('span', 'sync-action-command', item.summary));
       const actionButton = el('button', 'settings-button', item.actionLabel || 'Review') as HTMLButtonElement;
-      actionButton.addEventListener('click', () => focusAttentionTarget(item));
+      actionButton.addEventListener('click', async () => {
+        if (item.kind === 'possible-duplicate-person') {
+          await reviewDuplicatePeople(item);
+          return;
+        }
+        focusAttentionTarget(item);
+      });
       row.append(textWrap, actionButton);
       actions.appendChild(row);
     });

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -129,4 +129,19 @@ describe('deriveSyncViewModel', () => {
       'review-team-device',
     ]);
   });
+
+  it('hides duplicate-person attention when the user already marked them as different people', () => {
+    const view = deriveSyncViewModel({
+      actors: [
+        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
+        { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
+      ],
+      duplicatePersonDecisions: {
+        'actor-local::actor-remote': 'different-people',
+      },
+    });
+
+    expect(view.duplicatePeople).toEqual([]);
+    expect(view.attentionItems).toEqual([]);
+  });
 });

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -192,6 +192,7 @@ export function deriveSyncViewModel(input: {
   actors?: any[];
   peers?: any[];
   coordinator?: any;
+  duplicatePersonDecisions?: Record<string, string>;
 }): UiSyncViewModel {
   const actors = Array.isArray(input.actors) ? input.actors : [];
   const peers = Array.isArray(input.peers) ? input.peers : [];
@@ -199,7 +200,10 @@ export function deriveSyncViewModel(input: {
     ? input.coordinator.discovered_devices
     : [];
   const mergedDevices = mergeDevices(peers, discoveredDevices);
-  const duplicatePeople = deriveDuplicatePeople(actors);
+  const duplicateDecisions = input.duplicatePersonDecisions ?? {};
+  const duplicatePeople = deriveDuplicatePeople(actors).filter(
+    (candidate) => !duplicateDecisions[[...candidate.actorIds].sort().join('::')],
+  );
   const attentionItems: UiSyncAttentionItem[] = [];
 
   duplicatePeople.forEach((candidate) => {


### PR DESCRIPTION
## Description
This PR adds a guided duplicate-person confirmation flow for sync so likely duplicates are reviewed explicitly instead of being auto-merged from display-name matches.
It also persists "different people" decisions locally so the same ambiguous duplicate does not keep resurfacing every refresh.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:
- `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts`
- `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced