### PR TITLE
test(sync): cover device rename and advanced diagnostics copy

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1824,10 +1824,10 @@
         </div>
       </div>
 
-      <!-- 3. Diagnostics — status, pairing, attempts -->
+      <!-- 3. Advanced diagnostics — status, pairing, attempts -->
       <div class="card" style="animation-delay: 0.06s">
         <div class="section-header">
-          <h2>Diagnostics</h2>
+          <h2>Advanced diagnostics</h2>
           <div class="section-actions">
             <button class="settings-button" id="syncPairingToggle">Show pairing</button>
             <label class="small" style="display:inline-flex;align-items:center;gap:6px;">
@@ -1836,7 +1836,7 @@
             </label>
           </div>
         </div>
-        <div class="section-meta" id="syncMeta">Loading sync status…</div>
+        <div class="section-meta" id="syncMeta">Debug details for sync status, pairing, and recent attempts.</div>
         <div class="sync-skeleton" id="syncDiagSkeleton" role="status" aria-label="Loading diagnostics">
           <div class="sync-skeleton-line long"></div>
           <div class="sync-skeleton-line medium"></div>

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -70,6 +70,7 @@ export async function loadSyncData() {
 
     let actorsPayload: any = null;
     let actorLoadError = false;
+    const duplicatePersonDecisions = readDuplicatePersonDecisions();
     try {
       actorsPayload = await api.loadSyncActors();
     } catch {
@@ -77,7 +78,7 @@ export async function loadSyncData() {
     }
 
     // Skip re-render if data hasn't changed since last poll
-    const hash = JSON.stringify([payload, actorsPayload]);
+    const hash = JSON.stringify([payload, actorsPayload, duplicatePersonDecisions]);
     if (hash === lastSyncHash) return;
     lastSyncHash = hash;
 
@@ -93,7 +94,7 @@ export async function loadSyncData() {
     }
     state.lastSyncAttempts = payload.attempts || [];
     state.lastSyncLegacyDevices = payload.legacy_devices || [];
-    state.lastSyncDuplicatePersonDecisions = readDuplicatePersonDecisions();
+    state.lastSyncDuplicatePersonDecisions = duplicatePersonDecisions;
     state.lastSyncViewModel = deriveSyncViewModel({
       actors: state.lastSyncActors,
       peers: state.lastSyncPeers,

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -217,6 +217,7 @@ export function renderSyncPeers() {
     const renameInput = document.createElement('input');
     renameInput.className = 'peer-scope-input';
     renameInput.value = displayName;
+    if (peerId) renameInput.dataset.deviceNameInput = peerId;
     renameInput.setAttribute('aria-label', `Friendly name for ${displayName}`);
     renameInput.placeholder = 'Friendly device name';
     const renameBtn = el('button', null, 'Save name') as HTMLButtonElement;

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -135,6 +135,15 @@ export function renderTeamSync() {
     }
     const deviceId = String(item.deviceId || '').trim();
     if (!deviceId) return;
+    if (item.kind === 'name-device') {
+      const renameInput = document.querySelector(`[data-device-name-input="${CSS.escape(deviceId)}"]`);
+      if (renameInput instanceof HTMLInputElement) {
+        renameInput.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        renameInput.focus();
+        renameInput.select();
+        return;
+      }
+    }
     const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(deviceId)}"]`);
     if (peerCard instanceof HTMLElement) {
       peerCard.scrollIntoView({ block: 'center', behavior: 'smooth' });

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -264,11 +264,12 @@ export function deriveSyncViewModel(input: {
     }
 
     if (
+      device.peer &&
       deviceNeedsFriendlyName({
         localName: device.localName,
         coordinatorName: device.coordinatorName,
         deviceId: device.deviceId,
-      }) && looksLikeDeviceId(name)
+      })
     ) {
       attentionItems.push(
         createNamingItem({

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1888,6 +1888,36 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("renames an existing sync peer through the viewer route", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, created_at) VALUES (?, ?, ?, ?)",
+					)
+					.run("peer-rename", "Old Device", "fp-rename", new Date().toISOString());
+
+				const res = await app.request("/api/sync/peers/rename", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-rename", name: "Desk Mini" }),
+				});
+
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({ ok: true });
+
+				const peerRow = store.db
+					.prepare("SELECT name FROM sync_peers WHERE peer_device_id = ?")
+					.get("peer-rename") as { name: string } | undefined;
+				expect(peerRow?.name).toBe("Desk Mini");
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("updates an existing peer when the discovered fingerprint matches", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));


### PR DESCRIPTION
## Description
This PR finishes the sync UX stack by reframing diagnostics as advanced diagnostics and by adding viewer-server coverage for device rename support.
It also folds in final stack polish so duplicate-person decisions rerender correctly, naming follow-up stays separate from successful device connection, and name-device attention items focus a real rename control.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/ui/src/tabs/sync/view-model.test.ts`
- `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced