### PR TITLE
fix(sync): hide unresolved local duplicate rows

### DIFF
--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -7,6 +7,10 @@ import * as api from '../../lib/api';
 import { showGlobalNotice } from '../../lib/notice';
 import { markFieldError, clearFieldError, friendlyError } from '../../lib/form';
 import {
+  deriveVisiblePeopleActors,
+  type VisiblePeopleResult,
+} from './view-model';
+import {
   redactAddress,
   pickPrimaryAddress,
   actorLabel,
@@ -39,11 +43,19 @@ export function renderSyncActors() {
   hideSkeleton('syncActorsSkeleton');
   actorList.textContent = '';
 
-  const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
+  const actorVisibility: VisiblePeopleResult = deriveVisiblePeopleActors({
+    actors: state.lastSyncActors,
+    peers: state.lastSyncPeers,
+    duplicatePeople: state.lastSyncViewModel?.duplicatePeople,
+  });
+  const actors = actorVisibility.visibleActors;
   if (actorMeta) {
     actorMeta.textContent = actors.length
       ? 'Create, rename, and combine people here. Assign each device below. Non-local people receive memories from allowed projects unless you mark them Only me.'
       : 'No named people yet. Create one here, then assign devices below.';
+    if (actorVisibility.hiddenLocalDuplicateCount > 0) {
+      actorMeta.textContent += ` ${actorVisibility.hiddenLocalDuplicateCount} unresolved duplicate ${actorVisibility.hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden here until reviewed in Needs attention.`;
+    }
   }
 
   if (!actors.length) {
@@ -69,7 +81,11 @@ export function renderSyncActors() {
       'div',
       'peer-meta',
       actor.is_local
-        ? 'Used for this device and same-person devices.'
+        ? `Used for this device and same-person devices.${
+            actorVisibility.hiddenLocalDuplicateCount > 0
+              ? ` ${actorVisibility.hiddenLocalDuplicateCount} unresolved duplicate ${actorVisibility.hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden until reviewed in Needs attention.`
+              : ''
+          }`
         : `${count} assigned device${count === 1 ? '' : 's'}`,
     );
     details.append(title, note);

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -4,6 +4,7 @@ import {
   deriveDuplicatePeople,
   derivePeerUiStatus,
   deriveSyncViewModel,
+  deriveVisiblePeopleActors,
   deviceNeedsFriendlyName,
   resolveFriendlyDeviceName,
 } from './view-model';
@@ -80,6 +81,59 @@ describe('deriveDuplicatePeople', () => {
         includesLocal: true,
       },
     ]);
+  });
+});
+
+describe('deriveVisiblePeopleActors', () => {
+  it('hides unresolved zero-device duplicates of the local person from the people list', () => {
+    expect(
+      deriveVisiblePeopleActors({
+        actors: [
+          { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
+          { actor_id: 'actor-shadow', display_name: 'Adam', is_local: false },
+          { actor_id: 'actor-other', display_name: 'Pat', is_local: false },
+        ],
+        peers: [],
+        duplicatePeople: [
+          {
+            displayName: 'Adam',
+            actorIds: ['actor-local', 'actor-shadow'],
+            includesLocal: true,
+          },
+        ],
+      }),
+    ).toEqual({
+      visibleActors: [
+        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
+        { actor_id: 'actor-other', display_name: 'Pat', is_local: false },
+      ],
+      hiddenLocalDuplicateCount: 1,
+    });
+  });
+
+  it('keeps duplicate rows visible when the non-local duplicate already owns devices', () => {
+    expect(
+      deriveVisiblePeopleActors({
+        actors: [
+          { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
+          { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
+        ],
+        peers: [{ actor_id: 'actor-remote' }],
+        duplicatePeople: [
+          {
+            displayName: 'Adam',
+            actorIds: ['actor-local', 'actor-remote'],
+            includesLocal: true,
+          },
+        ],
+      }),
+    ).toEqual({
+      visibleActors: [
+        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
+        { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
+      ],
+      hiddenLocalDuplicateCount: 0,
+    });
   });
 });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -41,6 +41,11 @@ export interface UiSyncViewModel {
   attentionItems: UiSyncAttentionItem[];
 }
 
+export interface VisiblePeopleResult {
+  visibleActors: any[];
+  hiddenLocalDuplicateCount: number;
+}
+
 interface MergedDevice {
   deviceId: string;
   localName: string;
@@ -117,6 +122,38 @@ export function deriveDuplicatePeople(actors: any[]): UiDuplicatePersonCandidate
   return [...groups.values()]
     .filter((item) => item.actorIds.length > 1)
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+export function deriveVisiblePeopleActors(input: {
+  actors?: any[];
+  peers?: any[];
+  duplicatePeople?: UiDuplicatePersonCandidate[];
+}): VisiblePeopleResult {
+  const actors = Array.isArray(input.actors) ? input.actors : [];
+  const peers = Array.isArray(input.peers) ? input.peers : [];
+  const duplicatePeople = Array.isArray(input.duplicatePeople) ? input.duplicatePeople : [];
+  const assignedCounts = new Map<string, number>();
+  peers.forEach((peer) => {
+    const actorId = cleanText(peer?.actor_id);
+    if (!actorId) return;
+    assignedCounts.set(actorId, (assignedCounts.get(actorId) ?? 0) + 1);
+  });
+
+  const hiddenIds = new Set<string>();
+  duplicatePeople.forEach((candidate) => {
+    if (!candidate.includesLocal) return;
+    candidate.actorIds.forEach((actorId) => {
+      const actor = actors.find((item) => cleanText(item?.actor_id) === actorId);
+      if (!actor || actor.is_local) return;
+      if ((assignedCounts.get(actorId) ?? 0) > 0) return;
+      hiddenIds.add(actorId);
+    });
+  });
+
+  return {
+    visibleActors: actors.filter((actor) => !hiddenIds.has(cleanText(actor?.actor_id))),
+    hiddenLocalDuplicateCount: hiddenIds.size,
+  };
 }
 
 function createRepairItem(device: { id: string; name: string; summary: string }): UiSyncAttentionItem {


### PR DESCRIPTION
## Description
This PR stops the People & devices list from surfacing unresolved zero-device shadow duplicates of the local person as normal rows.
It makes the People renderer duplicate-aware so the local identity no longer looks perpetually unresolved when the extra same-name record should instead be handled through Needs attention.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Checks run:
- `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts`
- `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced