### PR TITLE
chore(release): prepare 0.22.0-alpha.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.22.0-alpha.4"
+    "version": "0.22.0-alpha.5"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.22.0-alpha.4",
+      "version": "0.22.0-alpha.5",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/tests/plugin-adapter.test.js
+++ b/packages/cli/.opencode/tests/plugin-adapter.test.js
@@ -321,7 +321,7 @@ describe("opencode adapter event mapping", () => {
     );
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 
-    expect(packageJson.version).toBe("0.22.0-alpha.4");
+    expect(packageJson.version).toBe("0.22.0-alpha.5");
     expect(__testUtils.PINNED_BACKEND_VERSION).toBe("0.21.2");
   });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.22.0-alpha.4",
+	"version": "0.22.0-alpha.5",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/cloudflare-coordinator-worker/vitest.config.ts
+++ b/packages/cloudflare-coordinator-worker/vitest.config.ts
@@ -6,10 +6,20 @@ export default defineConfig(async () => {
 	const migrations = await readD1Migrations(path.join(import.meta.dirname, "migrations"));
 
 	return {
+		resolve: {
+			alias: {
+				"@codemem/core": path.resolve(import.meta.dirname, "../core/src/index.ts"),
+				"@codemem/core/internal/cloudflare-coordinator": path.resolve(
+					import.meta.dirname,
+					"../core/src/internal/cloudflare-coordinator.ts",
+				),
+			},
+			conditions: ["source"],
+		},
 		plugins: [
 			cloudflareTest({
 				wrangler: {
-					configPath: "./wrangler.jsonc",
+					configPath: path.resolve(import.meta.dirname, "wrangler.jsonc"),
 				},
 				miniflare: {
 					bindings: {

--- a/packages/cloudflare-coordinator-worker/vitest.config.ts
+++ b/packages/cloudflare-coordinator-worker/vitest.config.ts
@@ -8,11 +8,11 @@ export default defineConfig(async () => {
 	return {
 		resolve: {
 			alias: {
-				"@codemem/core": path.resolve(import.meta.dirname, "../core/src/index.ts"),
 				"@codemem/core/internal/cloudflare-coordinator": path.resolve(
 					import.meta.dirname,
 					"../core/src/internal/cloudflare-coordinator.ts",
 				),
+				"@codemem/core": path.resolve(import.meta.dirname, "../core/src/index.ts"),
 			},
 			conditions: ["source"],
 		},

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.22.0-alpha.4",
+	"version": "0.22.0-alpha.5",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.22.0-alpha.4");
+		expect(VERSION).toBe("0.22.0-alpha.5");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.22.0-alpha.4";
+export const VERSION = "0.22.0-alpha.5";
 
 export * as Api from "./api-types.js";
 export type { CreateBetterSqliteCoordinatorAppOptions } from "./better-sqlite-coordinator-runtime.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.22.0-alpha.4",
+	"version": "0.22.0-alpha.5",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.22.0-alpha.4",
+	"version": "0.22.0-alpha.5",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.22.0-alpha.4",
+	"version": "0.22.0-alpha.5",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.22.0-alpha.4",
+  "version": "0.22.0-alpha.5",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description
This PR prepares the next alpha release by bumping the shared package/plugin/version metadata from `0.22.0-alpha.4` to `0.22.0-alpha.5`.
It also includes the minimal Cloudflare coordinator worker Vitest config fix needed to keep full workspace release validation green on this branch.

Note: the backend pin remains on the existing stable target for alpha prep; this PR does **not** retarget plugin-installed backend pins to the alpha version.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Checks run:
- `pnpm install`
- `pnpm build`
- `pnpm run test`
- `pnpm run typecheck`

Note: `pnpm run release:preflight-tag` intentionally requires `main`, so final tag preflight should run after this PR merges and `main` is current.

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced