### PR TITLE
fix(sync): implement missing people mutation routes

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -6,6 +6,15 @@ async function fetchJson(url: string): Promise<any> {
   return resp.json();
 }
 
+async function readJsonPayload(resp: Response): Promise<{ text: string; payload: any }> {
+  const text = await resp.text();
+  try {
+    return { text, payload: text ? JSON.parse(text) : {} };
+  } catch {
+    return { text, payload: {} };
+  }
+}
+
 export async function loadStats(): Promise<any> {
   return fetchJson('/api/stats');
 }
@@ -54,8 +63,7 @@ export async function updateMemoryVisibility(memoryId: number, visibility: 'priv
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ memory_id: memoryId, visibility }),
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
   return payload;
 }
@@ -124,8 +132,7 @@ export async function createCoordinatorInvite(payload: {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  const text = await resp.text();
-  const data = text ? JSON.parse(text) : {};
+  const { text, payload: data } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(data?.error || text || 'request failed');
   return data;
 }
@@ -136,8 +143,7 @@ export async function importCoordinatorInvite(invite: string): Promise<any> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ invite }),
   });
-  const text = await resp.text();
-  const data = text ? JSON.parse(text) : {};
+  const { text, payload: data } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(data?.error || text || 'request failed');
   return data;
 }
@@ -148,8 +154,7 @@ export async function reviewJoinRequest(requestId: string, action: 'approve' | '
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ request_id: requestId, action }),
   });
-  const text = await resp.text();
-  const data = text ? JSON.parse(text) : {};
+  const { text, payload: data } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(data?.error || text || 'request failed');
   return data;
 }
@@ -178,8 +183,7 @@ export async function updatePeerScope(
       inherit_global: inheritGlobal,
     }),
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) {
     throw new Error(payload?.error || text || 'request failed');
   }
@@ -195,8 +199,7 @@ export async function updatePeerIdentity(peerDeviceId: string, claimedLocalActor
       claimed_local_actor: claimedLocalActor,
     }),
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
   return payload;
 }
@@ -210,8 +213,7 @@ export async function assignPeerActor(peerDeviceId: string, actorId: string | nu
       actor_id: actorId,
     }),
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
   return payload;
 }
@@ -220,8 +222,7 @@ export async function deletePeer(peerDeviceId: string): Promise<any> {
   const resp = await fetch(`/api/sync/peers/${encodeURIComponent(peerDeviceId)}`, {
     method: 'DELETE',
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
   return payload;
 }
@@ -235,8 +236,7 @@ export async function renamePeer(peerDeviceId: string, name: string): Promise<an
       name,
     }),
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
   return payload;
 }
@@ -267,8 +267,7 @@ export async function createActor(displayName: string): Promise<any> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ display_name: displayName }),
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
   return payload;
 }
@@ -279,8 +278,7 @@ export async function renameActor(actorId: string, displayName: string): Promise
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ actor_id: actorId, display_name: displayName }),
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
   return payload;
 }
@@ -294,8 +292,7 @@ export async function mergeActor(primaryActorId: string, secondaryActorId: strin
       secondary_actor_id: secondaryActorId,
     }),
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
   return payload;
 }
@@ -306,8 +303,7 @@ export async function claimLegacyDeviceIdentity(originDeviceId: string): Promise
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ origin_device_id: originDeviceId }),
   });
-  const text = await resp.text();
-  const payload = text ? JSON.parse(text) : {};
+  const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
   return payload;
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1918,6 +1918,234 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("assigns a sync peer to the local actor through the identity route", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				await app.request("/api/sync/actors");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, created_at) VALUES (?, ?, ?, ?)",
+					)
+					.run("peer-local", "Peer", "fp-local", new Date().toISOString());
+				const localActor = store.db
+					.prepare("SELECT actor_id FROM actors WHERE is_local = 1 LIMIT 1")
+					.get() as { actor_id: string } | undefined;
+				if (!localActor) throw new Error("local actor missing");
+
+				const res = await app.request("/api/sync/peers/identity", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-local", actor_id: localActor.actor_id }),
+				});
+
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({
+					ok: true,
+					actor_id: localActor.actor_id,
+					claimed_local_actor: true,
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("updates peer project scope through the viewer route", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, created_at) VALUES (?, ?, ?, ?)",
+					)
+					.run("peer-scope", "Scoped Peer", "fp-scope", new Date().toISOString());
+
+				const res = await app.request("/api/sync/peers/scope", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						peer_device_id: "peer-scope",
+						include: ["proj-a"],
+						exclude: ["proj-b"],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({
+					ok: true,
+					project_scope: {
+						include: ["proj-a"],
+						exclude: ["proj-b"],
+						effective_include: ["proj-a"],
+						effective_exclude: ["proj-b"],
+						inherits_global: false,
+					},
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns effective global scope when a peer inherits global filters", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_projects_include: ["global-a"],
+					sync_projects_exclude: ["global-b"],
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, created_at) VALUES (?, ?, ?, ?)",
+					)
+					.run("peer-global", "Global Peer", "fp-global", new Date().toISOString());
+				const res = await app.request("/api/sync/peers?includeDiagnostics=1");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					items: Array<{ project_scope: Record<string, unknown> }>;
+				};
+				expect(body.items[0]?.project_scope).toEqual({
+					include: [],
+					exclude: [],
+					effective_include: ["global-a"],
+					effective_exclude: ["global-b"],
+					inherits_global: true,
+				});
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
+		it("creates, renames, and merges actors through viewer routes", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				await app.request("/api/sync/actors");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+
+				const createRes = await app.request("/api/sync/actors", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ display_name: "Adam shadow" }),
+				});
+				expect(createRes.status).toBe(200);
+				const created = (await createRes.json()) as { actor_id: string; display_name: string };
+				expect(created.display_name).toBe("Adam shadow");
+
+				const renameRes = await app.request("/api/sync/actors/rename", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ actor_id: created.actor_id, display_name: "Adam remote" }),
+				});
+				expect(renameRes.status).toBe(200);
+				expect((await renameRes.json()).display_name).toBe("Adam remote");
+
+				const localActor = store.db
+					.prepare("SELECT actor_id FROM actors WHERE is_local = 1 LIMIT 1")
+					.get() as { actor_id: string } | undefined;
+				if (!localActor) throw new Error("local actor missing");
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, actor_id, created_at) VALUES (?, ?, ?, ?, ?)",
+					)
+					.run("peer-merge", "Peer Merge", "fp-merge", created.actor_id, new Date().toISOString());
+
+				const mergeRes = await app.request("/api/sync/actors/merge", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						primary_actor_id: localActor.actor_id,
+						secondary_actor_id: created.actor_id,
+					}),
+				});
+				expect(mergeRes.status).toBe(200);
+				expect(await mergeRes.json()).toEqual({ merged_count: 1 });
+
+				const mergedActor = store.db
+					.prepare("SELECT status, merged_into_actor_id FROM actors WHERE actor_id = ?")
+					.get(created.actor_id) as
+					| { status: string; merged_into_actor_id: string | null }
+					| undefined;
+				expect(mergedActor).toEqual({
+					status: "merged",
+					merged_into_actor_id: localActor.actor_id,
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("maps claimed_local_actor=true to the local actor id when no actor id is provided", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				await app.request("/api/sync/actors");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, created_at) VALUES (?, ?, ?, ?)",
+					)
+					.run("peer-claim", "Peer Claim", "fp-claim", new Date().toISOString());
+				const res = await app.request("/api/sync/peers/identity", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ peer_device_id: "peer-claim", claimed_local_actor: true }),
+				});
+				expect(res.status).toBe(200);
+				expect(await res.json()).toEqual({
+					ok: true,
+					actor_id: store.actorId,
+					claimed_local_actor: true,
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects merging the local actor into another actor", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				await app.request("/api/sync/actors");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const createRes = await app.request("/api/sync/actors", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ display_name: "Other Person" }),
+				});
+				const created = (await createRes.json()) as { actor_id: string };
+				const res = await app.request("/api/sync/actors/merge", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						primary_actor_id: created.actor_id,
+						secondary_actor_id: store.actorId,
+					}),
+				});
+				expect(res.status).toBe(409);
+				expect(await res.json()).toEqual({ error: "cannot merge local actor" });
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("updates an existing peer when the discovered fingerprint matches", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -2,6 +2,7 @@
  * Sync routes — status, peers, actors, attempts, pairing, mutations.
  */
 
+import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import net from "node:net";
 import { dirname, join } from "node:path";
@@ -188,6 +189,43 @@ function readPeerProjectFilters(
 		include: parseJsonList(row.projects_include_json),
 		exclude: parseJsonList(row.projects_exclude_json),
 	};
+}
+
+function currentProjectScope(
+	row: Record<string, unknown>,
+	effective?: { include: string[]; exclude: string[] },
+): Record<string, unknown> {
+	return {
+		include: safeJsonList(row.projects_include_json as string | null),
+		exclude: safeJsonList(row.projects_exclude_json as string | null),
+		effective_include:
+			effective?.include ?? safeJsonList(row.projects_include_json as string | null),
+		effective_exclude:
+			effective?.exclude ?? safeJsonList(row.projects_exclude_json as string | null),
+		inherits_global: row.projects_include_json == null && row.projects_exclude_json == null,
+	};
+}
+
+function ensureLocalActorRecord(store: MemoryStore): void {
+	const d = drizzle(store.db, { schema });
+	const existing = d
+		.select({ actor_id: schema.actors.actor_id })
+		.from(schema.actors)
+		.where(eq(schema.actors.actor_id, store.actorId))
+		.get();
+	if (existing) return;
+	const now = new Date().toISOString();
+	d.insert(schema.actors)
+		.values({
+			actor_id: store.actorId,
+			display_name: store.actorDisplayName,
+			is_local: 1,
+			status: "active",
+			merged_into_actor_id: null,
+			created_at: now,
+			updated_at: now,
+		})
+		.run();
 }
 
 function peerClaimedLocalActor(store: MemoryStore, peerDeviceId: string): boolean {
@@ -438,7 +476,11 @@ function filterOpsForPeer(
  * When showDiag is false, sensitive fields (fingerprint, last_error, addresses)
  * are redacted.
  */
-function mapPeerRow(row: Record<string, unknown>, showDiag: boolean): Record<string, unknown> {
+function mapPeerRow(
+	store: MemoryStore,
+	row: Record<string, unknown>,
+	showDiag: boolean,
+): Record<string, unknown> {
 	return {
 		peer_device_id: row.peer_device_id,
 		name: row.name,
@@ -453,11 +495,7 @@ function mapPeerRow(row: Record<string, unknown>, showDiag: boolean): Record<str
 		actor_id: row.actor_id ?? null,
 		actor_display_name: row.actor_display_name ?? null,
 		project_scope: {
-			include: safeJsonList(row.projects_include_json as string | null),
-			exclude: safeJsonList(row.projects_exclude_json as string | null),
-			effective_include: safeJsonList(row.projects_include_json as string | null),
-			effective_exclude: safeJsonList(row.projects_exclude_json as string | null),
-			inherits_global: row.projects_include_json == null && row.projects_exclude_json == null,
+			...currentProjectScope(row, readPeerProjectFilters(store, String(row.peer_device_id ?? ""))),
 		},
 	};
 }
@@ -917,7 +955,7 @@ export function syncRoutes(
 			// Build peers list using deduplicated mapPeerRow
 			const peerRows = store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[];
 			const peersItems = peerRows.map((row) => {
-				const peer = mapPeerRow(row, showDiag);
+				const peer = mapPeerRow(store, row, showDiag);
 				peer.status = peerStatus(peer);
 				return peer;
 			});
@@ -1035,7 +1073,7 @@ export function syncRoutes(
 			const showDiag = queryBool(c.req.query("includeDiagnostics"));
 			const rows = store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[];
 			// Use deduplicated mapPeerRow helper (fix #4)
-			const peers = rows.map((row) => mapPeerRow(row, showDiag));
+			const peers = rows.map((row) => mapPeerRow(store, row, showDiag));
 			return c.json({ items: peers, redacted: !showDiag });
 		}
 	});
@@ -1044,6 +1082,7 @@ export function syncRoutes(
 	app.get("/api/sync/actors", (c) => {
 		const store = getStore();
 		{
+			ensureLocalActorRecord(store);
 			const d = drizzle(store.db, { schema });
 			const includeMerged = queryBool(c.req.query("includeMerged"));
 			const query = d.select().from(schema.actors);
@@ -1167,6 +1206,225 @@ export function syncRoutes(
 				.run();
 			return c.json({ ok: true });
 		}
+	});
+
+	app.post("/api/sync/peers/scope", async (c) => {
+		const store = getStore();
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const peerDeviceId = String(body.peer_device_id ?? "").trim();
+		if (!peerDeviceId) return c.json({ error: "peer_device_id required" }, 400);
+		const include = Array.isArray(body.include)
+			? body.include
+					.filter((value): value is string => typeof value === "string")
+					.map((value) => value.trim())
+					.filter(Boolean)
+			: null;
+		const exclude = Array.isArray(body.exclude)
+			? body.exclude
+					.filter((value): value is string => typeof value === "string")
+					.map((value) => value.trim())
+					.filter(Boolean)
+			: null;
+		const inheritGlobal = Boolean(body.inherit_global);
+		const d = drizzle(store.db, { schema });
+		const exists = d
+			.select({ peer_device_id: schema.syncPeers.peer_device_id })
+			.from(schema.syncPeers)
+			.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
+			.get();
+		if (!exists) return c.json({ error: "peer not found" }, 404);
+		d.update(schema.syncPeers)
+			.set({
+				projects_include_json: inheritGlobal ? null : JSON.stringify(include ?? []),
+				projects_exclude_json: inheritGlobal ? null : JSON.stringify(exclude ?? []),
+			})
+			.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
+			.run();
+		const row = d
+			.select({
+				projects_include_json: schema.syncPeers.projects_include_json,
+				projects_exclude_json: schema.syncPeers.projects_exclude_json,
+			})
+			.from(schema.syncPeers)
+			.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
+			.get() as Record<string, unknown> | undefined;
+		if (!row) return c.json({ error: "peer not found" }, 404);
+		return c.json({
+			ok: true,
+			project_scope: currentProjectScope(row, readPeerProjectFilters(store, peerDeviceId)),
+		});
+	});
+
+	app.post("/api/sync/peers/identity", async (c) => {
+		const store = getStore();
+		ensureLocalActorRecord(store);
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const peerDeviceId = String(body.peer_device_id ?? "").trim();
+		if (!peerDeviceId) return c.json({ error: "peer_device_id required" }, 400);
+		const requestedActorId =
+			body.actor_id == null ? undefined : String(body.actor_id ?? "").trim() || null;
+		const claimedLocalActor =
+			typeof body.claimed_local_actor === "boolean" ? body.claimed_local_actor : undefined;
+		const d = drizzle(store.db, { schema });
+		const peer = d
+			.select({
+				peer_device_id: schema.syncPeers.peer_device_id,
+				actor_id: schema.syncPeers.actor_id,
+				claimed_local_actor: schema.syncPeers.claimed_local_actor,
+			})
+			.from(schema.syncPeers)
+			.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
+			.get();
+		if (!peer) return c.json({ error: "peer not found" }, 404);
+
+		let nextActorId = peer.actor_id ?? null;
+		let nextClaimedLocalActor = Boolean(peer.claimed_local_actor);
+		if (requestedActorId !== undefined) {
+			nextActorId = requestedActorId;
+			if (requestedActorId) {
+				const actor = d
+					.select({
+						actor_id: schema.actors.actor_id,
+						is_local: schema.actors.is_local,
+						status: schema.actors.status,
+					})
+					.from(schema.actors)
+					.where(eq(schema.actors.actor_id, requestedActorId))
+					.get();
+				if (!actor) return c.json({ error: "actor not found" }, 404);
+				if (actor.status !== "active") return c.json({ error: "actor not active" }, 409);
+				nextClaimedLocalActor = claimedLocalActor ?? Boolean(actor.is_local);
+			} else {
+				nextClaimedLocalActor = claimedLocalActor ?? false;
+			}
+		} else if (claimedLocalActor !== undefined) {
+			nextClaimedLocalActor = claimedLocalActor;
+			if (claimedLocalActor) {
+				nextActorId = store.actorId;
+			} else if (nextActorId === store.actorId) {
+				nextActorId = null;
+			}
+		}
+
+		d.update(schema.syncPeers)
+			.set({
+				actor_id: nextActorId,
+				claimed_local_actor: nextClaimedLocalActor ? 1 : 0,
+			})
+			.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
+			.run();
+		return c.json({ ok: true, actor_id: nextActorId, claimed_local_actor: nextClaimedLocalActor });
+	});
+
+	app.post("/api/sync/actors", async (c) => {
+		const store = getStore();
+		ensureLocalActorRecord(store);
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const displayName = String(body.display_name ?? "").trim();
+		if (!displayName) return c.json({ error: "display_name required" }, 400);
+		const d = drizzle(store.db, { schema });
+		const now = new Date().toISOString();
+		const actor = {
+			actor_id: randomUUID(),
+			display_name: displayName,
+			is_local: 0,
+			status: "active",
+			merged_into_actor_id: null,
+			created_at: now,
+			updated_at: now,
+		};
+		d.insert(schema.actors).values(actor).run();
+		return c.json(actor);
+	});
+
+	app.post("/api/sync/actors/rename", async (c) => {
+		const store = getStore();
+		ensureLocalActorRecord(store);
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const actorId = String(body.actor_id ?? "").trim();
+		const displayName = String(body.display_name ?? "").trim();
+		if (!actorId) return c.json({ error: "actor_id required" }, 400);
+		if (!displayName) return c.json({ error: "display_name required" }, 400);
+		const d = drizzle(store.db, { schema });
+		const actor = d.select().from(schema.actors).where(eq(schema.actors.actor_id, actorId)).get();
+		if (!actor) return c.json({ error: "actor not found" }, 404);
+		const updatedAt = new Date().toISOString();
+		d.update(schema.actors)
+			.set({ display_name: displayName, updated_at: updatedAt })
+			.where(eq(schema.actors.actor_id, actorId))
+			.run();
+		return c.json({ ...actor, display_name: displayName, updated_at: updatedAt });
+	});
+
+	app.post("/api/sync/actors/merge", async (c) => {
+		const store = getStore();
+		ensureLocalActorRecord(store);
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const primaryActorId = String(body.primary_actor_id ?? "").trim();
+		const secondaryActorId = String(body.secondary_actor_id ?? "").trim();
+		if (!primaryActorId) return c.json({ error: "primary_actor_id required" }, 400);
+		if (!secondaryActorId) return c.json({ error: "secondary_actor_id required" }, 400);
+		if (primaryActorId === secondaryActorId) return c.json({ error: "actor ids must differ" }, 400);
+		const d = drizzle(store.db, { schema });
+		const primary = d
+			.select()
+			.from(schema.actors)
+			.where(eq(schema.actors.actor_id, primaryActorId))
+			.get();
+		const secondary = d
+			.select()
+			.from(schema.actors)
+			.where(eq(schema.actors.actor_id, secondaryActorId))
+			.get();
+		if (!primary || !secondary) return c.json({ error: "actor not found" }, 404);
+		if (primary.status !== "active") return c.json({ error: "primary actor not active" }, 409);
+		if (secondary.status !== "active") return c.json({ error: "secondary actor not active" }, 409);
+		if (secondary.is_local) return c.json({ error: "cannot merge local actor" }, 409);
+		const now = new Date().toISOString();
+		const mergedCount = store.db.transaction(() => {
+			const peerUpdate = d
+				.update(schema.syncPeers)
+				.set({ actor_id: primaryActorId })
+				.where(eq(schema.syncPeers.actor_id, secondaryActorId))
+				.run();
+			if (primary.is_local) {
+				d.update(schema.syncPeers)
+					.set({ claimed_local_actor: 1 })
+					.where(eq(schema.syncPeers.actor_id, primaryActorId))
+					.run();
+			}
+			d.update(schema.actors)
+				.set({ status: "merged", merged_into_actor_id: primaryActorId, updated_at: now })
+				.where(eq(schema.actors.actor_id, secondaryActorId))
+				.run();
+			return Number(peerUpdate.changes ?? 0);
+		})();
+		return c.json({ merged_count: mergedCount });
 	});
 
 	app.post("/api/sync/peers/accept-discovered", async (c) => {


### PR DESCRIPTION
## Description
This PR implements the missing sync mutation routes that the People & devices UI was already calling for person assignment, scope updates, and actor create/rename/merge actions.
It also hardens the client-side sync mutation parsing so missing or non-JSON responses fail with useful request errors instead of throwing raw JSON parse exceptions.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Checks run:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts`
- `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced