### PR TITLE
fix(build): stage viewer shell assets for source runs

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -173,7 +173,7 @@ async function runServeLifecycle(
 	}
 	const args = buildServeLifecycleArgs(action, opts, process.argv[1] ?? "", process.execArgv);
 	await new Promise<void>((resolve, reject) => {
-		const child: ReturnType<typeof spawn> = spawn(process.execPath, args, {
+		const child = spawn(process.execPath, args, {
 			cwd: process.cwd(),
 			stdio: "inherit",
 			env: {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,9 +3,9 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"clean": "rm -f ../viewer-server/static/app.js",
+		"clean": "rm -rf ../viewer-server/static",
 		"dev": "vite",
-		"build": "vite build --mode production",
+		"build": "vite build --mode production && node ./scripts/stage-viewer-static.mjs",
 		"build:watch": "vite build --watch --mode development",
 		"typecheck": "tsc -p tsconfig.json --noEmit"
 	},

--- a/packages/ui/scripts/stage-viewer-static.mjs
+++ b/packages/ui/scripts/stage-viewer-static.mjs
@@ -1,0 +1,21 @@
+import { cpSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "../../..");
+const legacyStaticDir = join(repoRoot, "codemem", "viewer_static");
+const viewerStaticDir = join(repoRoot, "packages", "viewer-server", "static");
+
+if (!existsSync(legacyStaticDir)) {
+	throw new Error(`Legacy viewer static directory missing: ${legacyStaticDir}`);
+}
+
+mkdirSync(viewerStaticDir, { recursive: true });
+
+for (const entry of readdirSync(legacyStaticDir, { withFileTypes: true })) {
+	if (!entry.isFile()) continue;
+	if (entry.name === "app.js") continue;
+	if (extname(entry.name) === ".map") continue;
+	cpSync(join(legacyStaticDir, entry.name), join(viewerStaticDir, entry.name));
+}

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -134,6 +134,23 @@ function createTestApp(opts?: {
 // ---------------------------------------------------------------------------
 
 describe("viewer-server", () => {
+	it("createApp fails with a clear build hint when viewer assets are missing", () => {
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-viewer-static-missing-"));
+		const previousStaticDir = process.env.CODEMEM_VIEWER_STATIC_DIR;
+		process.env.CODEMEM_VIEWER_STATIC_DIR = tmpDir;
+		try {
+			expect(() =>
+				createApp({
+					storeFactory: () => createTestStore().store,
+				}),
+			).toThrow(/Run `pnpm build` from the repo root before starting the viewer\./);
+		} finally {
+			if (previousStaticDir == null) delete process.env.CODEMEM_VIEWER_STATIC_DIR;
+			else process.env.CODEMEM_VIEWER_STATIC_DIR = previousStaticDir;
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
 	describe("GET /api/stats", () => {
 		it("returns database stats", async () => {
 			const { app, cleanup } = createTestApp();

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -8,7 +8,7 @@
  * Entry: `codemem serve`
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ObserverClient } from "@codemem/core";
 import { MemoryStore, type RawEventSweeper, resolveDbPath, VERSION } from "@codemem/core";
@@ -103,7 +103,13 @@ export function createApp(opts?: AppOptions) {
 	);
 
 	// SPA — serve index.html for root and all client-side routes
-	const indexHtml = readFileSync(join(staticRoot, "index.html"), "utf-8");
+	const indexPath = join(staticRoot, "index.html");
+	if (!existsSync(indexPath)) {
+		throw new Error(
+			`Viewer assets missing at ${indexPath}. Run \`pnpm build\` from the repo root before starting the viewer.`,
+		);
+	}
+	const indexHtml = readFileSync(indexPath, "utf-8");
 	app.get("*", (c) => {
 		if (c.req.path.startsWith("/api/")) {
 			return c.json({ error: "not found" }, 404);


### PR DESCRIPTION
## Description
This PR fixes the source-build contract for the viewer by making `@codemem/ui build` stage the HTML shell and static assets into `packages/viewer-server/static` alongside the built `app.js` bundle.
It also makes viewer startup fail with a clear `pnpm build` hint when those assets are missing, instead of crashing with a raw ENOENT on `static/index.html`.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Checks run:
- `pnpm --filter @codemem/ui clean && pnpm --filter @codemem/ui build`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts`
- `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced