### PR TITLE
fix(sync): show directional trust state honestly

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -1,17 +1,39 @@
 /* API fetch wrappers — thin layer over the viewer HTTP endpoints. */
 
-async function fetchJson(url: string): Promise<any> {
-  const resp = await fetch(url);
-  if (!resp.ok) throw new Error(`${url}: ${resp.status} ${resp.statusText}`);
-  return resp.json();
+export interface SyncRunItem {
+  peer_device_id: string;
+  ok: boolean;
+  error?: string;
+  address?: string;
+  opsIn: number;
+  opsOut: number;
+  addressErrors: Array<{ address: string; error: string }>;
 }
 
-async function readJsonPayload(resp: Response): Promise<{ text: string; payload: any }> {
+export interface SyncRunResponse {
+  items: SyncRunItem[];
+}
+
+function payloadError(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const maybeError = (payload as { error?: unknown }).error;
+  return typeof maybeError === 'string' ? maybeError : undefined;
+}
+
+async function fetchJson<T = Record<string, unknown>>(url: string): Promise<T> {
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`${url}: ${resp.status} ${resp.statusText}`);
+  return resp.json() as Promise<T>;
+}
+
+async function readJsonPayload<T = Record<string, unknown>>(
+  resp: Response,
+): Promise<{ text: string; payload: T }> {
   const text = await resp.text();
   try {
-    return { text, payload: text ? JSON.parse(text) : {} };
+    return { text, payload: (text ? JSON.parse(text) : {}) as T };
   } catch {
-    return { text, payload: {} };
+    return { text, payload: {} as T };
   }
 }
 
@@ -64,7 +86,7 @@ export async function updateMemoryVisibility(memoryId: number, visibility: 'priv
     body: JSON.stringify({ memory_id: memoryId, visibility }),
   });
   const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
   return payload;
 }
 
@@ -133,7 +155,7 @@ export async function createCoordinatorInvite(payload: {
     body: JSON.stringify(payload),
   });
   const { text, payload: data } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(data?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(data) || text || 'request failed');
   return data;
 }
 
@@ -144,7 +166,7 @@ export async function importCoordinatorInvite(invite: string): Promise<any> {
     body: JSON.stringify({ invite }),
   });
   const { text, payload: data } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(data?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(data) || text || 'request failed');
   return data;
 }
 
@@ -155,7 +177,7 @@ export async function reviewJoinRequest(requestId: string, action: 'approve' | '
     body: JSON.stringify({ request_id: requestId, action }),
   });
   const { text, payload: data } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(data?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(data) || text || 'request failed');
   return data;
 }
 
@@ -185,7 +207,7 @@ export async function updatePeerScope(
   });
   const { text, payload } = await readJsonPayload(resp);
   if (!resp.ok) {
-    throw new Error(payload?.error || text || 'request failed');
+    throw new Error(payloadError(payload) || text || 'request failed');
   }
   return payload;
 }
@@ -200,7 +222,7 @@ export async function updatePeerIdentity(peerDeviceId: string, claimedLocalActor
     }),
   });
   const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
   return payload;
 }
 
@@ -214,7 +236,7 @@ export async function assignPeerActor(peerDeviceId: string, actorId: string | nu
     }),
   });
   const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
   return payload;
 }
 
@@ -223,7 +245,7 @@ export async function deletePeer(peerDeviceId: string): Promise<any> {
     method: 'DELETE',
   });
   const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
   return payload;
 }
 
@@ -237,7 +259,7 @@ export async function renamePeer(peerDeviceId: string, name: string): Promise<an
     }),
   });
   const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
   return payload;
 }
 
@@ -257,7 +279,8 @@ export async function acceptDiscoveredPeer(peerDeviceId: string, fingerprint: st
   } catch {
     payload = {};
   }
-  if (!resp.ok) throw new Error(payload?.detail || payload?.error || text || 'request failed');
+  const detail = typeof payload?.detail === 'string' ? payload.detail : undefined;
+  if (!resp.ok) throw new Error(detail || payloadError(payload) || text || 'request failed');
   return payload;
 }
 
@@ -268,7 +291,7 @@ export async function createActor(displayName: string): Promise<any> {
     body: JSON.stringify({ display_name: displayName }),
   });
   const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
   return payload;
 }
 
@@ -279,7 +302,7 @@ export async function renameActor(actorId: string, displayName: string): Promise
     body: JSON.stringify({ actor_id: actorId, display_name: displayName }),
   });
   const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
   return payload;
 }
 
@@ -293,7 +316,7 @@ export async function mergeActor(primaryActorId: string, secondaryActorId: strin
     }),
   });
   const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
   return payload;
 }
 
@@ -304,28 +327,25 @@ export async function claimLegacyDeviceIdentity(originDeviceId: string): Promise
     body: JSON.stringify({ origin_device_id: originDeviceId }),
   });
   const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payload?.error || text || 'request failed');
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
   return payload;
 }
 
 export async function loadProjects(): Promise<string[]> {
-  const payload = await fetchJson('/api/projects');
+  const payload = await fetchJson<{ projects?: string[] }>('/api/projects');
   return payload.projects || [];
 }
 
-export async function triggerSync(address?: string): Promise<void> {
+export async function triggerSync(address?: string): Promise<SyncRunResponse> {
   const payload = address ? { address } : {};
   const resp = await fetch('/api/sync/run', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  const text = await resp.text();
-  let body: any = {};
-  try {
-    body = text ? JSON.parse(text) : {};
-  } catch {
-    body = {};
-  }
-  if (!resp.ok) throw new Error(body?.error || text || 'request failed');
+  const { text, payload: body } = await readJsonPayload<SyncRunResponse>(resp);
+  if (!resp.ok) throw new Error(payloadError(body) || text || 'request failed');
+  if (!text) throw new Error('empty sync response');
+  if (!Array.isArray(body?.items)) throw new Error(text || 'invalid sync response');
+  return body;
 }

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -7,6 +7,8 @@ import * as api from '../../lib/api';
 import { showGlobalNotice } from '../../lib/notice';
 import { markFieldError, clearFieldError, friendlyError } from '../../lib/form';
 import {
+  derivePeerTrustSummary,
+  summarizeSyncRunResult,
   deriveVisiblePeopleActors,
   type VisiblePeopleResult,
 } from './view-model';
@@ -222,8 +224,12 @@ export function renderSyncPeers() {
     if (peerId) name.title = peerId;
 
     const peerStatus = peer.status || {};
-    const online = peerStatus.sync_status === 'ok' || peerStatus.ping_status === 'ok';
-    const badge = el('span', `badge ${online ? 'badge-online' : 'badge-offline'}`, online ? 'Online' : 'Offline');
+    const trustSummary = derivePeerTrustSummary(peer);
+    const badge = el(
+      'span',
+      `badge ${trustSummary.isWarning ? 'badge-offline' : 'badge-online'}`,
+      trustSummary.badgeLabel,
+    );
     name.append(' ', badge);
     if (pendingScopeReview) {
       name.append(' ', el('span', 'badge actor-badge', 'Needs scope review'));
@@ -275,14 +281,17 @@ export function renderSyncPeers() {
       syncBtn.disabled = true;
       syncBtn.textContent = 'Syncing\u2026';
       try {
-        await api.triggerSync(primaryAddress);
-        if (pendingScopeReview) {
+        const result = await api.triggerSync(primaryAddress);
+        const summary = summarizeSyncRunResult(result);
+        if (!summary.ok) {
+          showGlobalNotice(summary.message, 'warning');
+        } else if (pendingScopeReview) {
           showGlobalNotice(
             `Triggered sync for ${displayName} before scope review was finished. Review scope in this card if you want tighter sharing rules.`,
             'warning',
           );
         } else {
-          showGlobalNotice(`Started sync with ${displayName}.`);
+          showGlobalNotice(summary.message);
         }
       } catch (error) {
         showGlobalNotice(friendlyError(error, 'Failed to trigger sync.'), 'warning');
@@ -349,6 +358,7 @@ export function renderSyncPeers() {
         ? `Assigned to ${String(peer.actor_display_name)}${peer.claimed_local_actor ? ' \u00b7 you' : ''}`
         : 'Unassigned person',
     );
+    const trustMeta = el('div', 'peer-meta', trustSummary.description);
 
     const scope = peer.project_scope || {};
     const includeList = Array.isArray(scope.include) ? scope.include : [];
@@ -485,7 +495,7 @@ export function renderSyncPeers() {
         ),
       );
     }
-    scopePanel.append(identityRow, identityMeta, actorRow, actorHint, scopeSummary, effectiveSummary, editorWrap);
+    scopePanel.append(identityRow, identityMeta, trustMeta, actorRow, actorHint, scopeSummary, effectiveSummary, editorWrap);
 
     titleRow.append(name, actions);
     card.append(titleRow, addressLabel, meta, scopePanel);

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -17,7 +17,7 @@ import {
   clearDuplicatePersonDecision,
   saveDuplicatePersonDecision,
 } from './helpers';
-import { SYNC_TERMINOLOGY } from './view-model';
+import { SYNC_TERMINOLOGY, summarizeSyncRunResult } from './view-model';
 
 /* ── DOM placement helpers ───────────────────────────────── */
 
@@ -370,7 +370,7 @@ export function renderTeamSync() {
             const result = await api.acceptDiscoveredPeer(deviceId, fingerprint);
             requestPeerScopeReview(deviceId);
             showGlobalNotice(
-              `Connected ${displayName}. Its device settings are now open in People & devices so you can review sync scope next.`,
+              `Step 1 complete on this device for ${displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
             );
             try {
               await promptForDeviceName(
@@ -442,7 +442,16 @@ export function renderTeamSync() {
       } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
         rowActions.appendChild(el('div', 'peer-meta', 'Review this device\'s scope in People & devices next.'));
       } else if (pairedPeer) {
-        rowActions.appendChild(el('div', 'peer-meta', 'Manage this device in People & devices.'));
+        const lowerError = String(pairedPeer?.last_error || '').toLowerCase();
+        rowActions.appendChild(
+          el(
+            'div',
+            'peer-meta',
+            lowerError.includes('401') && lowerError.includes('unauthorized')
+              ? 'Waiting for the other device to trust this one before sync can work.'
+              : 'Manage this device in People & devices.',
+          ),
+        );
       }
       row.append(details, rowActions);
       discoveredList.appendChild(row);
@@ -686,8 +695,9 @@ export function initTeamSyncEvents(
     syncNowButton.disabled = true;
     syncNowButton.textContent = 'Syncing\u2026';
     try {
-      await api.triggerSync();
-      showGlobalNotice('Sync pass started.');
+      const result = await api.triggerSync();
+      const summary = summarizeSyncRunResult(result);
+      showGlobalNotice(summary.message, summary.warning ? 'warning' : undefined);
     } catch (error) {
       showGlobalNotice(friendlyError(error, 'Failed to start sync.'), 'warning');
     }

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import {
   deriveDuplicatePeople,
+  derivePeerTrustSummary,
   derivePeerUiStatus,
   deriveSyncViewModel,
   deriveVisiblePeopleActors,
   deviceNeedsFriendlyName,
   resolveFriendlyDeviceName,
+  summarizeSyncRunResult,
 } from './view-model';
 
 describe('resolveFriendlyDeviceName', () => {
@@ -63,6 +65,71 @@ describe('derivePeerUiStatus', () => {
 
   it('maps stale peers to offline', () => {
     expect(derivePeerUiStatus({ status: { peer_state: 'stale' } })).toBe('offline');
+  });
+});
+
+describe('derivePeerTrustSummary', () => {
+  it('prioritizes current offline state over stale unauthorized history', () => {
+    expect(
+      derivePeerTrustSummary({
+        last_error: 'peer status failed (401: unauthorized)',
+        status: { peer_state: 'offline' },
+        has_error: false,
+      }).state,
+    ).toBe('offline');
+  });
+
+  it('surfaces one-way trust when the remote device rejects us with unauthorized', () => {
+    expect(
+      derivePeerTrustSummary({
+        last_error: 'peer status failed (401: unauthorized)',
+        status: { peer_state: 'degraded' },
+        has_error: true,
+      }),
+    ).toEqual({
+      state: 'trusted-by-you',
+      badgeLabel: 'Waiting for other device',
+      description:
+        'You accepted this device, but the other device still needs to trust this one before sync can work.',
+      isWarning: true,
+    });
+  });
+
+  it('surfaces two-way trust once sync or ping succeeds', () => {
+    expect(derivePeerTrustSummary({ status: { sync_status: 'ok', peer_state: 'online' } }).state).toBe(
+      'mutual-trust',
+    );
+  });
+});
+
+describe('summarizeSyncRunResult', () => {
+  it('summarizes mixed failures without pretending they are all one-way trust', () => {
+    expect(
+      summarizeSyncRunResult({
+        items: [
+          { peer_device_id: 'a', ok: false, error: 'peer status failed (401: unauthorized)', opsIn: 0, opsOut: 0, addressErrors: [] },
+          { peer_device_id: 'b', ok: false, error: 'connection refused', opsIn: 0, opsOut: 0, addressErrors: [] },
+          { peer_device_id: 'c', ok: true, opsIn: 2, opsOut: 1, addressErrors: [] },
+        ],
+      }),
+    ).toEqual({
+      ok: false,
+      message: '2 of 3 device sync attempts failed. Review device details for the specific errors.',
+      warning: true,
+    });
+  });
+
+  it('turns unauthorized sync failures into a directional trust message', () => {
+    expect(
+      summarizeSyncRunResult({
+        items: [{ peer_device_id: 'peer-a', ok: false, error: 'all addresses failed | http://x: peer status failed (401: unauthorized)', opsIn: 0, opsOut: 0, addressErrors: [] }],
+      }),
+    ).toEqual({
+      ok: false,
+      message:
+        'This device trusts the peer, but the other device still needs to trust this one before sync can work.',
+      warning: true,
+    });
   });
 });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -13,6 +13,28 @@ export const SYNC_TERMINOLOGY = {
 } as const;
 
 export type UiSyncStatus = 'connected' | 'available' | 'needs-repair' | 'offline' | 'waiting';
+export type UiTrustState = 'available' | 'trusted-by-you' | 'mutual-trust' | 'needs-repair' | 'offline';
+
+interface SyncPeerStatusLike {
+  peer_state?: string;
+  sync_status?: string;
+  ping_status?: string;
+  fresh?: boolean;
+}
+
+export interface UiSyncRunItem {
+  peer_device_id: string;
+  ok: boolean;
+  error?: string;
+  address?: string;
+  opsIn: number;
+  opsOut: number;
+  addressErrors: Array<{ address: string; error: string }>;
+}
+
+export interface UiSyncRunResponse {
+  items: UiSyncRunItem[];
+}
 
 export interface UiSyncAttentionItem {
   id: string;
@@ -41,17 +63,47 @@ export interface UiSyncViewModel {
   attentionItems: UiSyncAttentionItem[];
 }
 
+export interface UiPeerTrustSummary {
+  state: UiTrustState;
+  badgeLabel: string;
+  description: string;
+  isWarning: boolean;
+}
+
 export interface VisiblePeopleResult {
-  visibleActors: any[];
+  visibleActors: ActorLike[];
   hiddenLocalDuplicateCount: number;
+}
+
+export interface ActorLike {
+  actor_id?: string;
+  display_name?: string;
+  is_local?: boolean;
+}
+
+export interface PeerLike {
+  peer_device_id?: string;
+  name?: string;
+  has_error?: boolean;
+  last_error?: string;
+  fingerprint?: string;
+  actor_id?: string;
+  status?: SyncPeerStatusLike;
+}
+
+export interface DiscoveredDeviceLike {
+  device_id?: string;
+  display_name?: string;
+  stale?: boolean;
+  fingerprint?: string;
 }
 
 interface MergedDevice {
   deviceId: string;
   localName: string;
   coordinatorName: string;
-  peer: any | null;
-  discovered: any | null;
+  peer: PeerLike | null;
+  discovered: DiscoveredDeviceLike | null;
 }
 
 function cleanText(value: unknown): string {
@@ -94,7 +146,7 @@ export function deviceNeedsFriendlyName(input: {
   return Boolean(cleanText(input.deviceId));
 }
 
-export function derivePeerUiStatus(peer: any): UiSyncStatus {
+export function derivePeerUiStatus(peer: PeerLike): UiSyncStatus {
   const peerState = cleanText(peer?.status?.peer_state);
   if (peer?.has_error || peerState === 'degraded') return 'needs-repair';
   if (peerState === 'online') return 'connected';
@@ -103,7 +155,95 @@ export function derivePeerUiStatus(peer: any): UiSyncStatus {
   return 'waiting';
 }
 
-export function deriveDuplicatePeople(actors: any[]): UiDuplicatePersonCandidate[] {
+function peerErrorText(peer: PeerLike): string {
+  return cleanText(peer?.last_error).toLowerCase();
+}
+
+export function derivePeerTrustSummary(peer: PeerLike): UiPeerTrustSummary {
+  const peerStatus = peer?.status || {};
+  const peerState = cleanText(peerStatus.peer_state);
+  const lastError = peerErrorText(peer);
+  const syncOk = cleanText(peerStatus.sync_status) === 'ok' || cleanText(peerStatus.ping_status) === 'ok';
+  if (peerState === 'offline' || peerState === 'stale') {
+    return {
+      state: 'offline',
+      badgeLabel: 'Offline',
+      description: 'This device is known locally, but it is not reachable right now.',
+      isWarning: true,
+    };
+  }
+  if (lastError.includes('401') && lastError.includes('unauthorized')) {
+    return {
+      state: 'trusted-by-you',
+      badgeLabel: 'Waiting for other device',
+      description:
+        'You accepted this device, but the other device still needs to trust this one before sync can work.',
+      isWarning: true,
+    };
+  }
+  if (syncOk || peerState === 'online') {
+    return {
+      state: 'mutual-trust',
+      badgeLabel: 'Two-way trust',
+      description: 'Both devices trust each other and sync can run in both directions.',
+      isWarning: false,
+    };
+  }
+  if (peer?.has_error || peerState === 'degraded') {
+    return {
+      state: 'needs-repair',
+      badgeLabel: 'Needs repair',
+      description: 'This device has a sync problem that needs review before trust can be relied on.',
+      isWarning: true,
+    };
+  }
+  return {
+    state: 'trusted-by-you',
+    badgeLabel: 'Trusted on this device',
+    description:
+      'This device is trusted locally. Finish onboarding on the other device if sync is still blocked.',
+    isWarning: false,
+  };
+}
+
+export function summarizeSyncRunResult(payload: UiSyncRunResponse): { ok: boolean; message: string; warning: boolean } {
+  const items = Array.isArray(payload?.items) ? payload.items : [];
+  if (!items.length) {
+    return { ok: true, message: 'Sync pass completed with no eligible devices.', warning: false };
+  }
+  const failedItems = items.filter((item) => item && item.ok === false);
+  if (!failedItems.length) {
+    return {
+      ok: true,
+      message: `Sync pass finished for ${items.length} device${items.length === 1 ? '' : 's'}.`,
+      warning: false,
+    };
+  }
+  const unauthorizedFailures = failedItems.filter((item) => cleanText(item.error).toLowerCase().includes('401') && cleanText(item.error).toLowerCase().includes('unauthorized'));
+  if (unauthorizedFailures.length === failedItems.length) {
+    return {
+      ok: false,
+      message:
+        'This device trusts the peer, but the other device still needs to trust this one before sync can work.',
+      warning: true,
+    };
+  }
+  if (failedItems.length < items.length) {
+    return {
+      ok: false,
+      message: `${failedItems.length} of ${items.length} device sync attempts failed. Review device details for the specific errors.`,
+      warning: true,
+    };
+  }
+  const error = cleanText(failedItems[0]?.error);
+  return {
+    ok: false,
+    message: error || 'Sync failed for at least one device.',
+    warning: true,
+  };
+}
+
+export function deriveDuplicatePeople(actors: ActorLike[]): UiDuplicatePersonCandidate[] {
   const groups = new Map<string, UiDuplicatePersonCandidate>();
   (Array.isArray(actors) ? actors : []).forEach((actor) => {
     const displayName = cleanText(actor?.display_name);
@@ -125,8 +265,8 @@ export function deriveDuplicatePeople(actors: any[]): UiDuplicatePersonCandidate
 }
 
 export function deriveVisiblePeopleActors(input: {
-  actors?: any[];
-  peers?: any[];
+  actors?: ActorLike[];
+  peers?: PeerLike[];
   duplicatePeople?: UiDuplicatePersonCandidate[];
 }): VisiblePeopleResult {
   const actors = Array.isArray(input.actors) ? input.actors : [];
@@ -192,7 +332,7 @@ function createNamingItem(device: { id: string; name: string; summary: string })
   };
 }
 
-function mergeDevices(peers: any[], discoveredDevices: any[]): MergedDevice[] {
+function mergeDevices(peers: PeerLike[], discoveredDevices: DiscoveredDeviceLike[]): MergedDevice[] {
   const devices = new Map<string, MergedDevice>();
   const getOrCreate = (deviceId: string): MergedDevice => {
     const current = devices.get(deviceId) ?? {
@@ -226,9 +366,9 @@ function mergeDevices(peers: any[], discoveredDevices: any[]): MergedDevice[] {
 }
 
 export function deriveSyncViewModel(input: {
-  actors?: any[];
-  peers?: any[];
-  coordinator?: any;
+  actors?: ActorLike[];
+  peers?: PeerLike[];
+  coordinator?: { discovered_devices?: DiscoveredDeviceLike[] };
   duplicatePersonDecisions?: Record<string, string>;
 }): UiSyncViewModel {
   const actors = Array.isArray(input.actors) ? input.actors : [];
@@ -264,6 +404,7 @@ export function deriveSyncViewModel(input: {
       deviceId: device.deviceId,
     });
     const peerStatus = device.peer ? derivePeerUiStatus(device.peer) : 'waiting';
+    const trustSummary = device.peer ? derivePeerTrustSummary(device.peer) : null;
     const discoveredFingerprint = cleanText(device.discovered?.fingerprint);
     const peerFingerprint = cleanText(device.peer?.fingerprint);
     const hasConflict = Boolean(device.peer) && Boolean(discoveredFingerprint) && Boolean(peerFingerprint) && discoveredFingerprint !== peerFingerprint;
@@ -280,7 +421,9 @@ export function deriveSyncViewModel(input: {
     }
 
     if (device.peer && peerStatus === 'needs-repair') {
-      const detail = cleanText(device.peer?.last_error) || 'Sync health is degraded or broken.';
+      const detail = trustSummary?.state === 'trusted-by-you'
+        ? trustSummary.description
+        : cleanText(device.peer?.last_error) || 'Sync health is degraded or broken.';
       attentionItems.push(createRepairItem({ id: device.deviceId, name, summary: detail }));
     } else if (device.peer && peerStatus === 'offline') {
       attentionItems.push(
@@ -296,6 +439,17 @@ export function deriveSyncViewModel(input: {
           id: device.deviceId,
           name,
           summary: 'This device is seen on the team and is ready for review or connection on this machine.',
+        }),
+      );
+    }
+
+    if (device.peer && trustSummary?.state === 'trusted-by-you') {
+      attentionItems.push(
+        createReviewItem({
+          id: device.deviceId,
+          name,
+          summary:
+            'You accepted this device. Finish onboarding on the other device so it trusts this one too.',
         }),
       );
     }
@@ -322,7 +476,7 @@ export function deriveSyncViewModel(input: {
     summary: {
       connectedDeviceCount: peers.filter((peer) => derivePeerUiStatus(peer) === 'connected').length,
       seenOnTeamCount: discoveredDevices.length,
-      offlineTeamDeviceCount: discoveredDevices.filter((device: any) => Boolean(device?.stale)).length,
+      offlineTeamDeviceCount: discoveredDevices.filter((device) => Boolean(device?.stale)).length,
     },
     duplicatePeople,
     attentionItems: attentionItems.sort((a, b) => a.priority - b.priority || a.title.localeCompare(b.title)),


### PR DESCRIPTION
## Description
This PR makes the sync UI communicate directional trust honestly instead of implying that coordinator acceptance automatically means full connectivity.
It adds one-way vs two-way trust derivation, surfaces unauthorized sync failures as "the other device still needs to trust this one," and updates sync copy so accepted devices are described as step-one onboarding rather than fully connected.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Checks run:
- `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts`
- `pnpm run typecheck`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced