### PR TITLE
feat(sync): guide reciprocal onboarding in the UI

### DIFF
--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -17,7 +17,7 @@ import {
   clearDuplicatePersonDecision,
   saveDuplicatePersonDecision,
 } from './helpers';
-import { SYNC_TERMINOLOGY, summarizeSyncRunResult } from './view-model';
+import { deriveCoordinatorApprovalSummary, SYNC_TERMINOLOGY, summarizeSyncRunResult } from './view-model';
 
 /* ── DOM placement helpers ───────────────────────────────── */
 
@@ -322,10 +322,23 @@ export function renderTeamSync() {
       if (deviceId) row.dataset.discoveredDeviceId = deviceId;
       const displayName = String(device.display_name || '').trim() || deviceId || 'Discovered device';
       const fingerprint = String(device.fingerprint || '').trim();
+      const groupIds = Array.isArray(device.groups)
+        ? device.groups.map((value) => String(value || '').trim()).filter(Boolean)
+        : [];
+      const hasAmbiguousCoordinatorGroup = groupIds.length > 1;
       const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || '') === deviceId);
+      const approvalSummary = deriveCoordinatorApprovalSummary({
+        device,
+        pairedLocally: Boolean(pairedPeer),
+      });
       const pairedFingerprint = String(pairedPeer?.fingerprint || '').trim();
       const hasConflict = Boolean(pairedPeer) && Boolean(fingerprint) && Boolean(pairedFingerprint) && pairedFingerprint !== fingerprint;
-      const canAccept = Boolean(deviceId) && Boolean(fingerprint) && !pairedPeer && !device.stale;
+      const canAccept =
+        Boolean(deviceId) &&
+        Boolean(fingerprint) &&
+        !pairedPeer &&
+        !device.stale &&
+        !hasAmbiguousCoordinatorGroup;
       title.append(el('strong', null, displayName));
       title.appendChild(
         el(
@@ -341,6 +354,9 @@ export function renderTeamSync() {
           hasConflict ? SYNC_TERMINOLOGY.conflicts : pairedPeer ? SYNC_TERMINOLOGY.pairedLocally : 'Not connected on this device',
         ),
       );
+      if (approvalSummary.badgeLabel) {
+        title.appendChild(el('span', 'badge actor-badge', approvalSummary.badgeLabel));
+      }
       const addresses = Array.isArray(device.addresses) ? device.addresses : [];
       const addressLabel = addresses.length
         ? addresses
@@ -353,6 +369,8 @@ export function renderTeamSync() {
       const noteParts = [deviceId, addressLabel];
       if (hasConflict) {
         noteParts.push('repair the local peer before accepting this discovered device');
+      } else if (hasAmbiguousCoordinatorGroup) {
+        noteParts.push('this device appears in multiple coordinator groups; review team setup before approving it here');
       } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
         noteParts.push('scope review pending in People');
       } else if (pairedPeer?.last_error) {
@@ -360,9 +378,14 @@ export function renderTeamSync() {
       } else if (pairedPeer?.status?.peer_state) {
         noteParts.push(`paired status: ${String(pairedPeer.status.peer_state)}`);
       }
+      if (approvalSummary.description) noteParts.push(approvalSummary.description);
       details.append(title, el('div', 'peer-meta', noteParts.join(' · ')));
       if (canAccept) {
-        const acceptBtn = el('button', 'settings-button', 'Review device') as HTMLButtonElement;
+        const acceptBtn = el(
+          'button',
+          'settings-button',
+          approvalSummary.actionLabel || 'Review device',
+        ) as HTMLButtonElement;
         acceptBtn.addEventListener('click', async () => {
           acceptBtn.disabled = true;
           acceptBtn.textContent = 'Opening…';
@@ -370,7 +393,9 @@ export function renderTeamSync() {
             const result = await api.acceptDiscoveredPeer(deviceId, fingerprint);
             requestPeerScopeReview(deviceId);
             showGlobalNotice(
-              `Step 1 complete on this device for ${displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
+              approvalSummary.state === 'needs-your-approval'
+                ? `Approved ${displayName} on this device. Two-way trust should be ready once both devices refresh.`
+                : `Step 1 complete on this device for ${displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
             );
             try {
               await promptForDeviceName(
@@ -396,12 +421,18 @@ export function renderTeamSync() {
             acceptBtn.textContent = 'Retry review';
           } finally {
             acceptBtn.disabled = false;
-            if (acceptBtn.textContent === 'Opening…') acceptBtn.textContent = 'Review device';
+            if (acceptBtn.textContent === 'Opening…') {
+              acceptBtn.textContent = approvalSummary.actionLabel || 'Review device';
+            }
           }
         });
         rowActions.appendChild(acceptBtn);
       } else if (!pairedPeer && device.stale) {
         rowActions.appendChild(el('div', 'peer-meta', 'Wait for a fresh coordinator presence update.'));
+      } else if (!pairedPeer && hasAmbiguousCoordinatorGroup) {
+        rowActions.appendChild(
+          el('div', 'peer-meta', 'This device is visible through multiple coordinator groups. Fix that team setup first, then approve it here.'),
+        );
       } else if (hasConflict) {
         const inspectBtn = el('button', 'settings-button', 'Open device details') as HTMLButtonElement;
         inspectBtn.addEventListener('click', () => {
@@ -442,14 +473,15 @@ export function renderTeamSync() {
       } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
         rowActions.appendChild(el('div', 'peer-meta', 'Review this device\'s scope in People & devices next.'));
       } else if (pairedPeer) {
-        const lowerError = String(pairedPeer?.last_error || '').toLowerCase();
         rowActions.appendChild(
           el(
             'div',
             'peer-meta',
-            lowerError.includes('401') && lowerError.includes('unauthorized')
-              ? 'Waiting for the other device to trust this one before sync can work.'
-              : 'Manage this device in People & devices.',
+            approvalSummary.state === 'waiting-for-other-device'
+              ? approvalSummary.description || 'Waiting on the other device.'
+              : String(pairedPeer?.last_error || '').toLowerCase().includes('401') && String(pairedPeer?.last_error || '').toLowerCase().includes('unauthorized')
+                ? 'Waiting for the other device to trust this one before sync can work.'
+                : 'Manage this device in People & devices.',
           ),
         );
       }

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  deriveCoordinatorApprovalSummary,
   deriveDuplicatePeople,
   derivePeerTrustSummary,
   derivePeerUiStatus,
@@ -99,6 +100,38 @@ describe('derivePeerTrustSummary', () => {
     expect(derivePeerTrustSummary({ status: { sync_status: 'ok', peer_state: 'online' } }).state).toBe(
       'mutual-trust',
     );
+  });
+});
+
+describe('deriveCoordinatorApprovalSummary', () => {
+  it('flags coordinator devices that need approval on this device', () => {
+    expect(
+      deriveCoordinatorApprovalSummary({
+        device: { device_id: 'peer-a', needs_local_approval: true },
+        pairedLocally: false,
+      }),
+    ).toEqual({
+      state: 'needs-your-approval',
+      badgeLabel: 'Needs your approval',
+      description:
+        'Another device already trusted this one. Approve it on this device to finish reciprocal onboarding.',
+      actionLabel: 'Approve on this device',
+    });
+  });
+
+  it('flags coordinator devices that are still waiting on the other device', () => {
+    expect(
+      deriveCoordinatorApprovalSummary({
+        device: { device_id: 'peer-a', waiting_for_peer_approval: true },
+        pairedLocally: true,
+      }),
+    ).toEqual({
+      state: 'waiting-for-other-device',
+      badgeLabel: 'Waiting on other device',
+      description:
+        'You already trusted this device here. The other device still needs to approve this one before sync can work both ways.',
+      actionLabel: null,
+    });
   });
 });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -14,6 +14,7 @@ export const SYNC_TERMINOLOGY = {
 
 export type UiSyncStatus = 'connected' | 'available' | 'needs-repair' | 'offline' | 'waiting';
 export type UiTrustState = 'available' | 'trusted-by-you' | 'mutual-trust' | 'needs-repair' | 'offline';
+export type UiCoordinatorApprovalState = 'none' | 'needs-your-approval' | 'waiting-for-other-device';
 
 interface SyncPeerStatusLike {
   peer_state?: string;
@@ -96,6 +97,15 @@ export interface DiscoveredDeviceLike {
   display_name?: string;
   stale?: boolean;
   fingerprint?: string;
+  needs_local_approval?: boolean;
+  waiting_for_peer_approval?: boolean;
+}
+
+export interface UiCoordinatorApprovalSummary {
+  state: UiCoordinatorApprovalState;
+  badgeLabel: string | null;
+  description: string | null;
+  actionLabel: string | null;
 }
 
 interface MergedDevice {
@@ -203,6 +213,36 @@ export function derivePeerTrustSummary(peer: PeerLike): UiPeerTrustSummary {
     description:
       'This device is trusted locally. Finish onboarding on the other device if sync is still blocked.',
     isWarning: false,
+  };
+}
+
+export function deriveCoordinatorApprovalSummary(input: {
+  device: DiscoveredDeviceLike;
+  pairedLocally?: boolean;
+}): UiCoordinatorApprovalSummary {
+  if (Boolean(input.device?.needs_local_approval) && !input.pairedLocally) {
+    return {
+      state: 'needs-your-approval',
+      badgeLabel: 'Needs your approval',
+      description:
+        'Another device already trusted this one. Approve it on this device to finish reciprocal onboarding.',
+      actionLabel: 'Approve on this device',
+    };
+  }
+  if (Boolean(input.device?.waiting_for_peer_approval)) {
+    return {
+      state: 'waiting-for-other-device',
+      badgeLabel: 'Waiting on other device',
+      description:
+        'You already trusted this device here. The other device still needs to approve this one before sync can work both ways.',
+      actionLabel: null,
+    };
+  }
+  return {
+    state: 'none',
+    badgeLabel: null,
+    description: null,
+    actionLabel: null,
   };
 }
 


### PR DESCRIPTION
## Description

- Add sync UI states for coordinator-driven reciprocal onboarding so the second device can see when it needs to approve locally.
- Update onboarding copy and actions to distinguish “approve on this device” from “waiting on the other device.”

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm vitest run packages/ui/src/tabs/sync/view-model.test.ts packages/viewer-server/src/index.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run typecheck` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
