### PR TITLE
fix(sync): harden D1 reciprocal approval races

### DIFF
--- a/packages/cloudflare-coordinator-worker/migrations/0003_harden_reciprocal_approval_pending_pairs.sql
+++ b/packages/cloudflare-coordinator-worker/migrations/0003_harden_reciprocal_approval_pending_pairs.sql
@@ -1,0 +1,18 @@
+ALTER TABLE coordinator_reciprocal_approvals ADD COLUMN pending_pair_low_device_id TEXT;
+ALTER TABLE coordinator_reciprocal_approvals ADD COLUMN pending_pair_high_device_id TEXT;
+
+UPDATE coordinator_reciprocal_approvals
+SET
+  pending_pair_low_device_id = CASE
+    WHEN requesting_device_id <= requested_device_id THEN requesting_device_id
+    ELSE requested_device_id
+  END,
+  pending_pair_high_device_id = CASE
+    WHEN requesting_device_id <= requested_device_id THEN requested_device_id
+    ELSE requesting_device_id
+  END
+WHERE pending_pair_low_device_id IS NULL OR pending_pair_high_device_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_coordinator_reciprocal_pending_pair
+ON coordinator_reciprocal_approvals(group_id, pending_pair_low_device_id, pending_pair_high_device_id)
+WHERE status = 'pending';

--- a/packages/cloudflare-coordinator-worker/schema.sql
+++ b/packages/cloudflare-coordinator-worker/schema.sql
@@ -63,7 +63,13 @@ CREATE TABLE IF NOT EXISTS coordinator_reciprocal_approvals (
   group_id TEXT NOT NULL,
   requesting_device_id TEXT NOT NULL,
   requested_device_id TEXT NOT NULL,
+  pending_pair_low_device_id TEXT,
+  pending_pair_high_device_id TEXT,
   status TEXT NOT NULL,
   created_at TEXT NOT NULL,
   resolved_at TEXT
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_coordinator_reciprocal_pending_pair
+ON coordinator_reciprocal_approvals(group_id, pending_pair_low_device_id, pending_pair_high_device_id)
+WHERE status = 'pending';

--- a/packages/core/src/d1-coordinator-store.test.ts
+++ b/packages/core/src/d1-coordinator-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Database as DatabaseType, Statement } from "better-sqlite3";
@@ -44,7 +44,7 @@ class SqliteD1Statement implements D1PreparedStatementLike {
 }
 
 class SqliteD1Database implements D1DatabaseLike {
-	constructor(private readonly db: DatabaseType) {}
+	constructor(protected readonly db: DatabaseType) {}
 
 	prepare(query: string): D1PreparedStatementLike {
 		return new SqliteD1Statement(this.db.prepare(query));
@@ -64,6 +64,68 @@ class SqliteD1Database implements D1DatabaseLike {
 	}
 }
 
+class RacingReciprocalApprovalStatement implements D1PreparedStatementLike {
+	private bound: unknown[] = [];
+	private injected = false;
+
+	constructor(
+		private readonly db: DatabaseType,
+		private readonly query: string,
+	) {}
+
+	bind(...values: unknown[]): D1PreparedStatementLike {
+		this.bound = values;
+		return this;
+	}
+
+	async first<T = unknown>(): Promise<T | null> {
+		return (this.db.prepare(this.query).get(...this.bound) as T | undefined) ?? null;
+	}
+
+	async run(): Promise<unknown> {
+		if (!this.injected) {
+			this.injected = true;
+			const [, groupId, requestingDeviceId, requestedDeviceId, low, high, createdAt] = this
+				.bound as [string, string, string, string, string, string, string];
+			this.db
+				.prepare(`INSERT INTO coordinator_reciprocal_approvals(
+					request_id,
+					group_id,
+					requesting_device_id,
+					requested_device_id,
+					pending_pair_low_device_id,
+					pending_pair_high_device_id,
+					status,
+					created_at,
+					resolved_at
+				) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, NULL)`)
+				.run("race-existing", groupId, requestedDeviceId, requestingDeviceId, low, high, createdAt);
+		}
+		const result = this.db.prepare(this.query).run(...this.bound);
+		return { meta: { changes: result.changes } };
+	}
+
+	async all<T = unknown>(): Promise<{ results?: T[] }> {
+		return { results: this.db.prepare(this.query).all(...this.bound) as T[] };
+	}
+
+	async raw<T = unknown>(): Promise<T[]> {
+		return this.db
+			.prepare(this.query)
+			.raw(true)
+			.all(...this.bound) as T[];
+	}
+}
+
+class RacingSqliteD1Database extends SqliteD1Database {
+	override prepare(query: string): D1PreparedStatementLike {
+		if (query.includes("INSERT INTO coordinator_reciprocal_approvals(")) {
+			return new RacingReciprocalApprovalStatement(this.db, query);
+		}
+		return super.prepare(query);
+	}
+}
+
 describe("D1CoordinatorStore", () => {
 	let tmpDir: string;
 	let db: DatabaseType;
@@ -72,6 +134,21 @@ describe("D1CoordinatorStore", () => {
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "d1-coord-test-"));
 		db = connectCoordinator(join(tmpDir, "coordinator.sqlite"));
+		db.exec(`
+			DROP TABLE IF EXISTS coordinator_reciprocal_approvals;
+			DROP TABLE IF EXISTS coordinator_join_requests;
+			DROP TABLE IF EXISTS coordinator_invites;
+			DROP TABLE IF EXISTS request_nonces;
+			DROP TABLE IF EXISTS presence_records;
+			DROP TABLE IF EXISTS enrolled_devices;
+			DROP TABLE IF EXISTS groups;
+		`);
+		db.exec(
+			readFileSync(
+				join(import.meta.dirname, "../../cloudflare-coordinator-worker/schema.sql"),
+				"utf8",
+			),
+		);
 		store = new D1CoordinatorStore(new SqliteD1Database(db));
 	});
 
@@ -192,6 +269,25 @@ describe("D1CoordinatorStore", () => {
 		expect(
 			await store.listReciprocalApprovals({ groupId: "g1", deviceId: "d1", direction: "incoming" }),
 		).toEqual([]);
+	});
+
+	it("converges to completed when a reverse pending row appears during insert", async () => {
+		const racingStore = new D1CoordinatorStore(new RacingSqliteD1Database(db));
+		await racingStore.createGroup("g1");
+		const result = await racingStore.createReciprocalApproval({
+			groupId: "g1",
+			requestingDeviceId: "d1",
+			requestedDeviceId: "d2",
+		});
+		expect(result).toEqual(
+			expect.objectContaining({
+				request_id: "race-existing",
+				status: "completed",
+				requesting_device_id: "d2",
+				requested_device_id: "d1",
+			}),
+		);
+		await racingStore.close();
 	});
 
 	it("implements nonce replay protection, presence upsert, and peer listing", async () => {

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -101,6 +101,22 @@ function nowISO(): string {
 	return new Date().toISOString();
 }
 
+function reciprocalPendingPair(
+	requestingDeviceId: string,
+	requestedDeviceId: string,
+): {
+	low: string;
+	high: string;
+} {
+	return requestingDeviceId <= requestedDeviceId
+		? { low: requestingDeviceId, high: requestedDeviceId }
+		: { low: requestedDeviceId, high: requestingDeviceId };
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+	return error instanceof Error && /unique|constraint/i.test(error.message);
+}
+
 function tokenUrlSafe(bytes: number): string {
 	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 	const random = new Uint8Array(bytes);
@@ -461,6 +477,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		if (requestingDeviceId === requestedDeviceId) {
 			throw new Error("requesting and requested device ids must differ.");
 		}
+		const pendingPair = reciprocalPendingPair(requestingDeviceId, requestedDeviceId);
 		const existing = await firstRow<CoordinatorReciprocalApproval>(
 			this.db
 				.prepare(`SELECT request_id, group_id, requesting_device_id, requested_device_id, status, created_at, resolved_at
@@ -496,12 +513,66 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		}
 		const requestId = tokenUrlSafe(12);
 		const createdAt = nowISO();
-		await this.db
-			.prepare(`INSERT INTO coordinator_reciprocal_approvals(
-					request_id, group_id, requesting_device_id, requested_device_id, status, created_at, resolved_at
-				) VALUES (?, ?, ?, ?, 'pending', ?, NULL)`)
-			.bind(requestId, groupId, requestingDeviceId, requestedDeviceId, createdAt)
-			.run();
+		try {
+			await this.db
+				.prepare(`INSERT INTO coordinator_reciprocal_approvals(
+						request_id,
+						group_id,
+						requesting_device_id,
+						requested_device_id,
+						pending_pair_low_device_id,
+						pending_pair_high_device_id,
+						status,
+						created_at,
+						resolved_at
+					) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, NULL)`)
+				.bind(
+					requestId,
+					groupId,
+					requestingDeviceId,
+					requestedDeviceId,
+					pendingPair.low,
+					pendingPair.high,
+					createdAt,
+				)
+				.run();
+		} catch (error) {
+			if (!isUniqueConstraintError(error)) throw error;
+			const sameDirection = await firstRow<CoordinatorReciprocalApproval>(
+				this.db
+					.prepare(`SELECT request_id, group_id, requesting_device_id, requested_device_id, status, created_at, resolved_at
+						 FROM coordinator_reciprocal_approvals
+						 WHERE group_id = ? AND requesting_device_id = ? AND requested_device_id = ? AND status = 'pending'
+						 ORDER BY created_at DESC LIMIT 1`)
+					.bind(groupId, requestingDeviceId, requestedDeviceId),
+			);
+			if (sameDirection) return rowToRecord<CoordinatorReciprocalApproval>(sameDirection);
+			const reverseAfterConflict = await firstRow<CoordinatorReciprocalApproval>(
+				this.db
+					.prepare(`SELECT request_id, group_id, requesting_device_id, requested_device_id, status, created_at, resolved_at
+						 FROM coordinator_reciprocal_approvals
+						 WHERE group_id = ? AND requesting_device_id = ? AND requested_device_id = ? AND status = 'pending'
+						 ORDER BY created_at DESC LIMIT 1`)
+					.bind(groupId, requestedDeviceId, requestingDeviceId),
+			);
+			if (reverseAfterConflict) {
+				const resolvedAt = nowISO();
+				await this.db
+					.prepare(
+						`UPDATE coordinator_reciprocal_approvals SET status = 'completed', resolved_at = ? WHERE request_id = ?`,
+					)
+					.bind(resolvedAt, reverseAfterConflict.request_id)
+					.run();
+				const completed = await firstRow<CoordinatorReciprocalApproval>(
+					this.db
+						.prepare(`SELECT request_id, group_id, requesting_device_id, requested_device_id, status, created_at, resolved_at
+							 FROM coordinator_reciprocal_approvals WHERE request_id = ?`)
+						.bind(reverseAfterConflict.request_id),
+				);
+				return rowToRecord<CoordinatorReciprocalApproval>(completed);
+			}
+			throw error;
+		}
 		const created = await firstRow<CoordinatorReciprocalApproval>(
 			this.db
 				.prepare(`SELECT request_id, group_id, requesting_device_id, requested_device_id, status, created_at, resolved_at


### PR DESCRIPTION
## Description

- Harden D1 reciprocal approvals against cross-over races by adding pending-pair uniqueness at the schema level.
- Update the D1 store to recover cleanly from uniqueness conflicts and converge reciprocal approvals to a completed state.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm vitest run packages/core/src/d1-coordinator-store.test.ts packages/cloudflare-coordinator-worker/src/index.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run typecheck` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
