### PR TITLE
feat(ui): migrate sync tab to preact and radix controls

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -531,6 +531,56 @@
         outline-offset: 2px;
       }
 
+      .sync-redact-control {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .sync-redact-switch {
+        width: 34px;
+        height: 20px;
+        border: 1px solid var(--control-border);
+        border-radius: var(--radius-pill);
+        background: var(--surface-1);
+        box-shadow: inset 0 0 0 1px transparent;
+        cursor: pointer;
+        flex-shrink: 0;
+        padding: 1px;
+        transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      .sync-redact-switch:hover {
+        border-color: var(--control-hover-border);
+      }
+
+      .sync-redact-switch:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .sync-redact-switch[data-state="checked"] {
+        background: var(--control-bg);
+        border-color: var(--control-hover-border);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
+      }
+
+      .sync-redact-switch-thumb {
+        display: block;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        background: var(--surface-0);
+        box-shadow: var(--shadow-sm);
+        transition: transform 0.15s ease, background 0.15s ease;
+        transform: translateX(0);
+      }
+
+      .sync-redact-switch[data-state="checked"] .sync-redact-switch-thumb {
+        transform: translateX(14px);
+        background: var(--accent);
+      }
+
       /* ── Selects / inputs ──────────────────────────────────── */
 
       .project-filter,
@@ -1051,11 +1101,81 @@
         color: var(--text-secondary);
         font-feature-settings: 'tnum' 1;
       }
-      .sync-legacy-claim-row { margin-top: 12px; gap: 12px; align-items: center; flex-wrap: wrap; }
-      .sync-legacy-select {
+      .sync-radix-select-host {
+        min-width: 0;
+        max-width: 100%;
+      }
+      .sync-actor-select-host {
+        min-width: 220px;
+        max-width: 100%;
+        flex: 1 1 220px;
+      }
+      .sync-legacy-select-host {
         min-width: 320px;
         max-width: 100%;
         flex: 1 1 320px;
+      }
+      .sync-radix-select-trigger {
+        display: inline-flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        width: 100%;
+        text-align: left;
+      }
+      .sync-radix-select-trigger > span:first-child {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .sync-radix-select-icon {
+        color: var(--text-tertiary);
+        flex: 0 0 auto;
+      }
+      .sync-radix-select-content {
+        z-index: 30;
+        min-width: var(--radix-select-trigger-width);
+        max-width: min(420px, calc(100vw - 24px));
+        overflow: hidden;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-1);
+        box-shadow: var(--shadow-lg);
+      }
+      .sync-radix-select-viewport {
+        padding: 6px;
+      }
+      .sync-radix-select-item {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        min-height: 36px;
+        padding: 8px 12px;
+        border-radius: var(--radius-sm);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 13px;
+        cursor: pointer;
+        user-select: none;
+      }
+      .sync-radix-select-item[data-highlighted] {
+        outline: none;
+        background: var(--accent-subtle);
+        color: var(--accent);
+      }
+      .sync-radix-select-item[data-disabled] {
+        opacity: 0.45;
+        cursor: default;
+      }
+      .sync-radix-select-indicator {
+        color: var(--accent);
+        flex: 0 0 auto;
+      }
+      .sync-legacy-claim-row { margin-top: 12px; gap: 12px; align-items: center; flex-wrap: wrap; }
+      .sync-legacy-select {
         padding: 8px 12px;
         border-radius: var(--radius-md);
         border: 1px solid var(--border);
@@ -1098,9 +1218,6 @@
         transform: none;
       }
       .sync-actor-select {
-        min-width: 220px;
-        max-width: 100%;
-        flex: 1 1 220px;
         padding: 8px 12px;
         border-radius: var(--radius-md);
         border: 1px solid var(--border);
@@ -1748,28 +1865,7 @@
             </div>
           </div>
           <div id="syncAdminSection">
-            <button class="sync-toggle-admin" id="syncToggleAdmin" aria-expanded="false" aria-controls="syncInvitePanel">Set up a new team instead…</button>
-            <div id="syncInvitePanel" hidden>
-              <h3 class="settings-group-title" style="margin-top:12px">Create a team</h3>
-              <div class="section-meta">Generate an invite to share with teammates.</div>
-              <div class="actor-create-row">
-                <label for="syncInviteGroup" class="sr-only">Team name</label>
-                <input class="peer-scope-input" id="syncInviteGroup" placeholder="Team name (e.g. my-team)" />
-                <label for="syncInvitePolicy" class="sr-only">Join policy</label>
-                <select class="sync-actor-select" id="syncInvitePolicy">
-                  <option value="auto_admit">Auto-admit</option>
-                  <option value="approval_required">Approval required</option>
-                </select>
-                <div class="sync-ttl-group">
-                  <label for="syncInviteTtl">Expires in</label>
-                  <input class="peer-scope-input" id="syncInviteTtl" type="number" min="1" value="24" style="width:64px" />
-                  <label>hours</label>
-                </div>
-                <button class="settings-button" id="syncCreateInviteButton">Create invite</button>
-              </div>
-              <label for="syncInviteOutput" class="sr-only">Generated invite</label>
-              <textarea class="feed-search" id="syncInviteOutput" placeholder="Invite will appear here" readonly hidden></textarea>
-            </div>
+            <div id="syncAdminDisclosureMount" style="display: contents"></div>
           </div>
         </div>
         <h3 class="settings-group-title" style="margin-top: 20px">Team status</h3>
@@ -1818,7 +1914,7 @@
           <div class="peer-meta" id="syncLegacyClaimsMeta"></div>
           <div class="peer-actions sync-legacy-claim-row">
             <label for="syncLegacyDeviceSelect" class="sr-only">Legacy device</label>
-            <select class="sync-legacy-select" id="syncLegacyDeviceSelect"></select>
+            <div class="sync-radix-select-host sync-legacy-select-host" id="syncLegacyDeviceSelectMount"></div>
             <button class="sync-legacy-button" id="syncLegacyClaimButton">Attach device history</button>
           </div>
         </div>
@@ -1829,10 +1925,10 @@
         <div class="section-header">
           <h2>Advanced diagnostics</h2>
           <div class="section-actions">
-            <button class="settings-button" id="syncPairingToggle">Show pairing</button>
-            <label class="small" style="display:inline-flex;align-items:center;gap:6px;">
-              <input id="syncRedact" type="checkbox" checked />
-              Redact
+            <div id="syncPairingDisclosureMount" style="display: contents"></div>
+            <label class="small sync-redact-control">
+              <span id="syncRedactMount"></span>
+              <span id="syncRedactLabel">Redact</span>
             </label>
           </div>
         </div>
@@ -1845,16 +1941,7 @@
         <div class="sync-actions" id="syncActions"></div>
         <div class="grid-2" id="syncStatusGrid"></div>
 
-        <div class="pairing-card" id="syncPairing" hidden>
-          <div class="peer-title">
-            <strong>Pairing command</strong>
-            <div class="peer-actions"><button id="pairingCopy">Copy command</button></div>
-          </div>
-          <div class="pairing-body">
-            <pre id="pairingPayload" style="user-select:all">Loading…</pre>
-          </div>
-          <div class="peer-meta" id="pairingHint">Copy and run on the other device. Use --include/--exclude to control which projects sync.</div>
-        </div>
+        <div id="syncPairingPanelMount" style="display: contents"></div>
 
         <h3 class="settings-group-title" style="margin-top: 20px">Recent sync attempts</h3>
         <div class="attempts-list" id="syncAttempts"></div>

--- a/packages/ui/src/tabs/sync/components/render-root.tsx
+++ b/packages/ui/src/tabs/sync/components/render-root.tsx
@@ -1,0 +1,21 @@
+import { render, type ComponentChildren } from 'preact';
+
+function markMount(mount: HTMLElement) {
+  mount.dataset.syncRenderRoot = 'preact';
+}
+
+export function ensureSyncRenderBoundary() {
+  const syncTab = document.getElementById('tab-sync');
+  if (!syncTab) return;
+  syncTab.dataset.syncRenderBoundary = 'preact-hybrid';
+}
+
+export function renderIntoSyncMount(mount: HTMLElement, content: ComponentChildren) {
+  markMount(mount);
+  render(content, mount);
+}
+
+export function clearSyncMount(mount: HTMLElement) {
+  if (mount.dataset.syncRenderRoot !== 'preact') return;
+  render(null, mount);
+}

--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -1,0 +1,191 @@
+import type { TargetedInputEvent } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import { renderIntoSyncMount } from './render-root';
+import {
+  actorLabel,
+  actorMergeNote,
+  assignedActorCount,
+  mergeTargetActors,
+} from '../helpers';
+import type { ActorLike } from '../view-model';
+
+type SyncActorRowProps = {
+  actor: ActorLike;
+  hiddenLocalDuplicateCount: number;
+  onRename: (actorId: string, displayName: string) => Promise<void>;
+  onMerge: (primaryActorId: string, secondaryActorId: string) => Promise<void>;
+};
+
+type SyncActorsListProps = {
+  actors: ActorLike[];
+  hiddenLocalDuplicateCount: number;
+  onRename: (actorId: string, displayName: string) => Promise<void>;
+  onMerge: (primaryActorId: string, secondaryActorId: string) => Promise<void>;
+};
+
+function localActorNote(hiddenLocalDuplicateCount: number): string {
+  if (hiddenLocalDuplicateCount <= 0) {
+    return 'Used for this device and same-person devices.';
+  }
+  return `Used for this device and same-person devices. ${hiddenLocalDuplicateCount} unresolved duplicate ${hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden until reviewed in Needs attention.`;
+}
+
+function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge }: SyncActorRowProps) {
+  const actorId = String(actor.actor_id || '');
+  const label = actorLabel(actor);
+  const count = assignedActorCount(actorId);
+  const mergeTargets = mergeTargetActors(actorId);
+  const mergeTargetKeys = mergeTargets.map((target) => String(target.actor_id || '')).join('|');
+  const [name, setName] = useState(label);
+  const [renameBusy, setRenameBusy] = useState(false);
+  const [renameLabel, setRenameLabel] = useState('Rename');
+  const [mergeBusy, setMergeBusy] = useState(false);
+  const [mergeLabel, setMergeLabel] = useState('Combine into selected person');
+  const [mergeTargetId, setMergeTargetId] = useState('');
+
+  useEffect(() => {
+    setName(label);
+    setRenameBusy(false);
+    setRenameLabel('Rename');
+    setMergeBusy(false);
+    setMergeLabel('Combine into selected person');
+    setMergeTargetId('');
+  }, [actorId, count, hiddenLocalDuplicateCount, label, mergeTargetKeys]);
+
+  const mergeNote = !mergeTargets.length
+    ? 'No people available to combine yet. Create another person or use You.'
+    : actorMergeNote(mergeTargetId, actorId);
+
+  async function rename() {
+    const nextName = name.trim();
+    if (!nextName) return;
+    setRenameBusy(true);
+    setRenameLabel('Saving…');
+    let ok = false;
+    try {
+      await onRename(actorId, nextName);
+      ok = true;
+    } catch {
+      setRenameLabel('Retry rename');
+    } finally {
+      setRenameBusy(false);
+      if (ok) setRenameLabel('Rename');
+    }
+  }
+
+  async function merge() {
+    if (!mergeTargetId) return;
+    const target = mergeTargets.find((candidate) => String(candidate.actor_id || '') === mergeTargetId);
+    if (!target) return;
+    if (
+      !window.confirm(
+        `Combine ${label} into ${actorLabel(target)}? Assigned devices move now, but older memories keep their current stamped provenance for now.`,
+      )
+    ) {
+      return;
+    }
+    setMergeBusy(true);
+    setMergeLabel('Merging…');
+    let ok = false;
+    try {
+      await onMerge(mergeTargetId, actorId);
+      ok = true;
+    } catch {
+      setMergeLabel('Retry merge');
+    } finally {
+      setMergeBusy(false);
+      if (ok) setMergeLabel('Combine into selected person');
+    }
+  }
+
+  return (
+    <div className="actor-row">
+      <div className="actor-details">
+        <div className="actor-title">
+          <strong>{label}</strong>
+          <span className={`badge actor-badge${actor.is_local ? ' local' : ''}`}>
+            {actor.is_local ? 'Local' : `${count} device${count === 1 ? '' : 's'}`}
+          </span>
+        </div>
+        <div className="peer-meta">
+          {actor.is_local ? localActorNote(hiddenLocalDuplicateCount) : `${count} assigned device${count === 1 ? '' : 's'}`}
+        </div>
+      </div>
+
+      <div className="actor-actions">
+        {actor.is_local ? (
+          <div className="peer-meta">Rename in config</div>
+        ) : (
+          <>
+            <input
+              aria-label={`Rename ${label}`}
+              className="peer-scope-input actor-name-input"
+              disabled={renameBusy || mergeBusy}
+              value={name}
+              onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
+                setName(event.currentTarget.value)
+              }
+            />
+            <button className="settings-button" disabled={renameBusy || mergeBusy} onClick={() => void rename()}>
+              {renameLabel}
+            </button>
+            <div className="actor-merge-controls">
+              <select
+                aria-label={`Combine ${label} into another person`}
+                className="sync-actor-select actor-merge-select"
+                disabled={mergeBusy}
+                value={mergeTargetId}
+                onChange={(event) => setMergeTargetId(event.currentTarget.value)}
+              >
+                <option value="">Combine into person</option>
+                {mergeTargets.map((target) => {
+                  const targetId = String(target.actor_id || '');
+                  return (
+                    <option key={targetId} value={targetId}>
+                      {target.is_local ? `${actorLabel(target)} (local)` : actorLabel(target)}
+                    </option>
+                  );
+                })}
+              </select>
+              <button
+                className="settings-button"
+                disabled={mergeBusy || mergeTargets.length === 0}
+                onClick={() => void merge()}
+              >
+                {mergeLabel}
+              </button>
+            </div>
+            <div className="peer-meta actor-merge-note">{mergeNote}</div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SyncActorsList({ actors, hiddenLocalDuplicateCount, onRename, onMerge }: SyncActorsListProps) {
+  if (!actors.length) {
+    return <div className="sync-empty-state">No people yet. Create one to represent yourself or a teammate.</div>;
+  }
+
+  return (
+    <>
+      {actors.map((actor) => {
+        const actorId = String(actor.actor_id || actor.display_name || actor.is_local || '');
+        return (
+          <SyncActorRow
+            key={actorId}
+            actor={actor}
+            hiddenLocalDuplicateCount={hiddenLocalDuplicateCount}
+            onRename={onRename}
+            onMerge={onMerge}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+export function renderSyncActorsList(mount: HTMLElement, props: SyncActorsListProps) {
+  renderIntoSyncMount(mount, <SyncActorsList {...props} />);
+}

--- a/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
@@ -1,0 +1,82 @@
+import { Fragment } from 'preact';
+import { clearSyncMount, renderIntoSyncMount } from './render-root';
+
+export type SyncStatItem = {
+  label: string;
+  value: number | string;
+};
+
+export type SyncAttemptItem = {
+  status: string;
+  address: string;
+  startedAt: string;
+};
+
+export type PairingView = {
+  payloadText: string;
+  hintText: string;
+};
+
+function DiagnosticsGrid({ items }: { items: SyncStatItem[] }) {
+  return (
+    <Fragment>
+      {items.map((item, index) => (
+        <div class="stat" key={`${item.label}-${index}`}>
+          <div class="stat-content">
+            <div class="value">{item.value}</div>
+            <div class="label">{item.label}</div>
+          </div>
+        </div>
+      ))}
+    </Fragment>
+  );
+}
+
+function AttemptsList({ attempts }: { attempts: SyncAttemptItem[] }) {
+  return (
+    <Fragment>
+      {attempts.map((attempt, index) => (
+        <div class="diag-line" key={`${attempt.startedAt}-${attempt.address}-${index}`}>
+          <div class="left">
+            <div>{attempt.status}</div>
+            <div class="small">{attempt.address}</div>
+          </div>
+          <div class="right">{attempt.startedAt}</div>
+        </div>
+      ))}
+    </Fragment>
+  );
+}
+
+function PairingText({ text }: { text: string }) {
+  return <Fragment>{text}</Fragment>;
+}
+
+export function renderDiagnosticsGrid(mount: HTMLElement, items: SyncStatItem[]) {
+  if (!items.length) {
+    clearSyncMount(mount);
+    return;
+  }
+
+  renderIntoSyncMount(mount, <DiagnosticsGrid items={items} />);
+}
+
+export function renderAttemptsList(mount: HTMLElement, attempts: SyncAttemptItem[]) {
+  if (!attempts.length) {
+    clearSyncMount(mount);
+    return;
+  }
+
+  renderIntoSyncMount(mount, <AttemptsList attempts={attempts} />);
+}
+
+export function renderPairingView(
+  payloadMount: HTMLElement,
+  hintMount: HTMLElement | null,
+  view: PairingView,
+) {
+  renderIntoSyncMount(payloadMount, <PairingText text={view.payloadText} />);
+  if (hintMount) {
+    renderIntoSyncMount(hintMount, <PairingText text={view.hintText} />);
+  }
+}

--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -1,0 +1,181 @@
+import * as Collapsible from '@radix-ui/react-collapsible';
+import type { ComponentChildren } from 'preact';
+import { createPortal } from 'preact/compat';
+import { useLayoutEffect, useRef } from 'preact/hooks';
+import { renderIntoSyncMount } from './render-root';
+
+type SyncDisclosureProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  triggerId: string;
+  triggerClassName: string;
+  closedLabel: string;
+  openLabel: string;
+  contentId: string;
+  contentClassName?: string;
+  contentHost?: HTMLElement | null;
+  children: ComponentChildren;
+};
+
+function SyncDisclosure({
+  open,
+  onOpenChange,
+  triggerId,
+  triggerClassName,
+  closedLabel,
+  openLabel,
+  contentId,
+  contentClassName,
+  contentHost = null,
+  children,
+}: SyncDisclosureProps) {
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (triggerRef.current) {
+      triggerRef.current.id = triggerId;
+      triggerRef.current.setAttribute('aria-controls', contentId);
+    }
+    if (contentRef.current) {
+      contentRef.current.id = contentId;
+    }
+  }, [contentId, triggerId, open]);
+
+  const content = (
+    <Collapsible.Content forceMount asChild>
+      <div ref={contentRef} id={contentId} className={contentClassName}>
+        {children}
+      </div>
+    </Collapsible.Content>
+  );
+
+  return (
+    <Collapsible.Root open={open} onOpenChange={onOpenChange}>
+      <Collapsible.Trigger asChild>
+        <button
+          ref={triggerRef}
+          type="button"
+          className={triggerClassName}
+          id={triggerId}
+          aria-controls={contentId}
+        >
+          {open ? openLabel : closedLabel}
+        </button>
+      </Collapsible.Trigger>
+      {contentHost ? createPortal(content, contentHost) : content}
+    </Collapsible.Root>
+  );
+}
+
+type TeamSetupDisclosureProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+function TeamSetupDisclosure({ open, onOpenChange }: TeamSetupDisclosureProps) {
+  return (
+    <SyncDisclosure
+      open={open}
+      onOpenChange={onOpenChange}
+      triggerId="syncToggleAdmin"
+      triggerClassName="sync-toggle-admin"
+      closedLabel="Set up a new team instead…"
+      openLabel="Hide team setup"
+      contentId="syncInvitePanel"
+    >
+      <h3 className="settings-group-title" style={{ marginTop: '12px' }}>
+        Create a team
+      </h3>
+      <div className="section-meta">Generate an invite to share with teammates.</div>
+      <div className="actor-create-row">
+        <label htmlFor="syncInviteGroup" className="sr-only">
+          Team name
+        </label>
+        <input className="peer-scope-input" id="syncInviteGroup" placeholder="Team name (e.g. my-team)" />
+        <label htmlFor="syncInvitePolicy" className="sr-only">
+          Join policy
+        </label>
+        <div className="sync-radix-select-host sync-actor-select-host" id="syncInvitePolicyMount" />
+        <div className="sync-ttl-group">
+          <label htmlFor="syncInviteTtl">Expires in</label>
+          <input
+            className="peer-scope-input"
+            defaultValue="24"
+            id="syncInviteTtl"
+            min="1"
+            style={{ width: '64px' }}
+            type="number"
+          />
+          <label>hours</label>
+        </div>
+        <button className="settings-button" id="syncCreateInviteButton" type="button">
+          Create invite
+        </button>
+      </div>
+      <label htmlFor="syncInviteOutput" className="sr-only">
+        Generated invite
+      </label>
+      <textarea
+        className="feed-search"
+        id="syncInviteOutput"
+        placeholder="Invite will appear here"
+        readOnly
+        hidden
+      />
+    </SyncDisclosure>
+  );
+}
+
+type PairingDisclosureProps = {
+  contentHost: HTMLElement | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+function PairingDisclosure({ contentHost, open, onOpenChange }: PairingDisclosureProps) {
+  return (
+    <SyncDisclosure
+      open={open}
+      onOpenChange={onOpenChange}
+      triggerId="syncPairingToggle"
+      triggerClassName="settings-button"
+      closedLabel="Show pairing"
+      openLabel="Hide pairing"
+      contentId="syncPairing"
+      contentClassName="pairing-card"
+      contentHost={contentHost}
+    >
+      <div className="peer-title">
+        <strong>Pairing command</strong>
+        <div className="peer-actions">
+          <button id="pairingCopy" type="button">
+            Copy command
+          </button>
+        </div>
+      </div>
+      <div className="pairing-body">
+        <pre id="pairingPayload" style={{ userSelect: 'all' }}>
+          Loading…
+        </pre>
+      </div>
+      <div className="peer-meta" id="pairingHint">
+        Copy and run on the other device. Use --include/--exclude to control which projects sync.
+      </div>
+    </SyncDisclosure>
+  );
+}
+
+export function renderTeamSetupDisclosure(
+  mount: HTMLElement,
+  props: TeamSetupDisclosureProps,
+) {
+  renderIntoSyncMount(mount, <TeamSetupDisclosure {...props} />);
+}
+
+export function renderPairingDisclosure(
+  mount: HTMLElement,
+  props: PairingDisclosureProps,
+) {
+  renderIntoSyncMount(mount, <PairingDisclosure {...props} />);
+}

--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -1,0 +1,134 @@
+import { copyToClipboard } from '../../../lib/dom';
+import { useLayoutEffect, useRef } from 'preact/hooks';
+
+type ExistingElementSlotProps = {
+  element: HTMLElement | null;
+  hidden?: boolean;
+  restoreParent?: HTMLElement | null;
+};
+
+function ExistingElementSlot({
+  element,
+  hidden = false,
+  restoreParent = null,
+}: ExistingElementSlotProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (!element) return;
+    element.hidden = hidden;
+  }, [element, hidden]);
+
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    if (!host || !element) return;
+    if (element.parentElement !== host) host.appendChild(element);
+    return () => {
+      if (!restoreParent || element.parentElement !== host) return;
+      restoreParent.appendChild(element);
+    };
+  }, [element, restoreParent]);
+
+  return <div ref={hostRef} />;
+}
+
+function InviteToggleRow({
+  invitePanel,
+  invitePanelOpen,
+  inviteRestoreParent,
+  onToggle,
+}: {
+  invitePanel: HTMLElement | null;
+  invitePanelOpen: boolean;
+  inviteRestoreParent: HTMLElement | null;
+  onToggle: () => void;
+}) {
+  return (
+    <>
+      <div className="sync-action">
+        <div className="sync-action-text">Generate an invite to add another teammate to this team.</div>
+        <button type="button" className="settings-button" onClick={onToggle}>
+          {invitePanelOpen ? 'Hide invite form' : 'Invite a teammate'}
+        </button>
+      </div>
+      {invitePanel ? (
+        <ExistingElementSlot
+          element={invitePanel}
+          hidden={!invitePanelOpen}
+          restoreParent={inviteRestoreParent}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function PairingCopyRow() {
+  return (
+    <div className="sync-action">
+      <div className="sync-action-text">
+        No devices are paired yet.
+        <span className="sync-action-command">codemem sync pair --payload-only</span>
+      </div>
+      <button
+        type="button"
+        className="settings-button sync-action-copy"
+        onClick={(event) =>
+          copyToClipboard('codemem sync pair --payload-only', event.currentTarget as HTMLButtonElement)
+        }
+      >
+        Copy
+      </button>
+    </div>
+  );
+}
+
+export type SyncInviteJoinPanelsProps = {
+  invitePanel: HTMLElement | null;
+  invitePanelOpen: boolean;
+  inviteRestoreParent: HTMLElement | null;
+  joinPanel: HTMLElement | null;
+  joinRestoreParent: HTMLElement | null;
+  onToggleInvitePanel: () => void;
+  pairedPeerCount: number;
+  presenceStatus: string;
+};
+
+export function SyncInviteJoinPanels({
+  invitePanel,
+  invitePanelOpen,
+  inviteRestoreParent,
+  joinPanel,
+  joinRestoreParent,
+  onToggleInvitePanel,
+  pairedPeerCount,
+  presenceStatus,
+}: SyncInviteJoinPanelsProps) {
+  return (
+    <>
+      <InviteToggleRow
+        invitePanel={invitePanel}
+        invitePanelOpen={invitePanelOpen}
+        inviteRestoreParent={inviteRestoreParent}
+        onToggle={onToggleInvitePanel}
+      />
+
+      {presenceStatus === 'not_enrolled' ? (
+        <>
+          {joinPanel ? (
+            <ExistingElementSlot element={joinPanel} hidden={false} restoreParent={joinRestoreParent} />
+          ) : null}
+          <div className="sync-action">
+            <div className="sync-action-text">
+              This device is not connected to the team yet.
+              <span className="sync-action-command">
+                Import a team invite or ask your admin to enroll this device
+              </span>
+            </div>
+          </div>
+        </>
+      ) : null}
+
+      {!pairedPeerCount && presenceStatus === 'posted' ? <PairingCopyRow /> : null}
+    </>
+  );
+}

--- a/packages/ui/src/tabs/sync/components/sync-legacy-claims.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-legacy-claims.tsx
@@ -1,0 +1,78 @@
+import { Fragment } from 'preact';
+import { clearSyncMount, renderIntoSyncMount } from './render-root';
+import { formatTimestamp } from '../../../lib/format';
+import { RadixSelect, type RadixSelectOption } from '../../../components/primitives/radix-select';
+
+type LegacyDeviceClaim = {
+  origin_device_id?: string;
+  memory_count?: number;
+  last_seen_at?: string;
+};
+
+function validDevices(devices: LegacyDeviceClaim[]): LegacyDeviceClaim[] {
+  return devices.filter((device) => String(device.origin_device_id || '').trim());
+}
+
+function metaText(devices: LegacyDeviceClaim[]): string {
+  const withLastSeen = devices.find((device) => String(device.last_seen_at || '').trim());
+  if (withLastSeen?.last_seen_at) {
+    return `Detected from older synced memories. Latest memory: ${formatTimestamp(String(withLastSeen.last_seen_at).trim())}`;
+  }
+  return 'Detected from older synced memories not yet attached to a current device.';
+}
+
+function LegacyClaimMeta({ devices }: { devices: LegacyDeviceClaim[] }) {
+  return <Fragment>{metaText(devices)}</Fragment>;
+}
+
+function option(device: LegacyDeviceClaim): RadixSelectOption {
+  const deviceId = String(device.origin_device_id || '').trim();
+  const count = Number(device.memory_count || 0);
+  return {
+    label: count > 0 ? `${deviceId} (${count} memories)` : deviceId,
+    value: deviceId,
+  };
+}
+
+export function renderLegacyClaimsSlice(input: {
+  panel: HTMLElement;
+  mount: HTMLElement;
+  meta: HTMLElement;
+  devices: LegacyDeviceClaim[];
+  value: string;
+  onValueChange: (value: string) => void;
+}) {
+  const devices = validDevices(input.devices);
+  if (!devices.length) {
+    input.panel.hidden = true;
+    input.onValueChange('');
+    clearSyncMount(input.mount);
+    clearSyncMount(input.meta);
+    return;
+  }
+
+  const options = devices.map(option);
+  const nextValue = options.some((item) => item.value === input.value)
+    ? input.value
+    : options[0]?.value || '';
+
+  if (nextValue !== input.value) input.onValueChange(nextValue);
+
+  input.panel.hidden = false;
+  renderIntoSyncMount(
+    input.mount,
+    <RadixSelect
+      ariaLabel="Legacy device"
+      contentClassName="sync-radix-select-content sync-legacy-select-content"
+      id="syncLegacyDeviceSelect"
+      itemClassName="sync-radix-select-item"
+      name="syncLegacyDeviceSelect"
+      onValueChange={input.onValueChange}
+      options={options}
+      triggerClassName="sync-radix-select-trigger sync-legacy-select"
+      value={nextValue}
+      viewportClassName="sync-radix-select-viewport"
+    />,
+  );
+  renderIntoSyncMount(input.meta, <LegacyClaimMeta devices={devices} />);
+}

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -1,0 +1,425 @@
+import type { TargetedInputEvent } from 'preact';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { RadixSelect, type RadixSelectOption } from '../../../components/primitives/radix-select';
+import { formatTimestamp } from '../../../lib/format';
+import { showGlobalNotice } from '../../../lib/notice';
+import { state, isSyncRedactionEnabled } from '../../../lib/state';
+import { PeerScopeCollapsible } from '../peer-scope-collapsible';
+import {
+  assignmentNote,
+  consumePeerScopeReviewRequest,
+  createChipEditor,
+  isPeerScopeReviewPending,
+  openPeerScopeEditors,
+  pickPrimaryAddress,
+  redactAddress,
+} from '../helpers';
+import { derivePeerTrustSummary, summarizeSyncRunResult, type PeerLike } from '../view-model';
+import { renderIntoSyncMount } from './render-root';
+
+type PeerScopeLike = {
+  include?: string[];
+  exclude?: string[];
+  effective_include?: string[];
+  effective_exclude?: string[];
+  inherits_global?: boolean;
+};
+
+type SyncPeer = PeerLike & {
+  actor_display_name?: string;
+  addresses?: unknown[];
+  claimed_local_actor?: boolean;
+  project_scope?: PeerScopeLike;
+};
+
+type SyncPeerStatus = NonNullable<SyncPeer['status']> & {
+  last_ping_at?: string;
+  last_ping_at_utc?: string;
+  last_sync_at?: string;
+  last_sync_at_utc?: string;
+};
+
+type SyncPeerCardProps = {
+  peer: SyncPeer;
+  onAssignActor: (peerId: string, actorId: string | null) => Promise<void>;
+  onRemove: (peerId: string, label: string) => Promise<void>;
+  onRename: (peerId: string, name: string) => Promise<void>;
+  onResetScope: (peerId: string) => Promise<void>;
+  onSaveScope: (peerId: string, include: string[], exclude: string[]) => Promise<void>;
+  onSync: (peer: SyncPeer, address: string | undefined) => Promise<ReturnType<typeof summarizeSyncRunResult> | null>;
+};
+
+type SyncPeersListProps = Omit<SyncPeerCardProps, 'peer'> & {
+  peers: SyncPeer[];
+};
+
+function actorOptions(): RadixSelectOption[] {
+  const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
+  return [
+    { value: '', label: 'No person assigned' },
+    ...actors.map((actor) => {
+      const actorId = String(actor?.actor_id || '');
+      const label = actor.is_local
+        ? `${String(actor.display_name || actorId || 'Unknown person')} (local)`
+        : String(actor.display_name || actorId || 'Unknown person');
+      return { value: actorId, label };
+    }),
+  ].filter((option, index, all) => index === all.findIndex((candidate) => candidate.value === option.value));
+}
+
+function listText(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((item) => String(item || '').trim()).filter(Boolean) : [];
+}
+
+function summaryText(prefix: string, values: string[], emptyLabel: string): string {
+  return `${prefix}: ${values.join(', ') || emptyLabel}`;
+}
+
+function ExistingElementSlot({ element }: { element: HTMLElement }) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    if (element.parentElement !== host) host.appendChild(element);
+    return () => {
+      if (element.parentElement === host) {
+        host.removeChild(element);
+      }
+    };
+  }, [element]);
+
+  return <div ref={hostRef} />;
+}
+
+function SyncPeerCard({
+  peer,
+  onAssignActor,
+  onRemove,
+  onRename,
+  onResetScope,
+  onSaveScope,
+  onSync,
+}: SyncPeerCardProps) {
+  const peerId = String(peer.peer_device_id || '');
+  const displayName = peer.name || (peerId ? peerId.slice(0, 8) : 'unknown');
+  const destructiveLabel = peer.name || peerId || displayName;
+  const pendingScopeReview = isPeerScopeReviewPending(peerId);
+  const trustSummary = derivePeerTrustSummary(peer);
+  const peerStatus: SyncPeerStatus = peer.status || {};
+  const scope = peer.project_scope || {};
+  const includeList = listText(scope.include);
+  const excludeList = listText(scope.exclude);
+  const effectiveInclude = listText(scope.effective_include);
+  const effectiveExclude = listText(scope.effective_exclude);
+  const inheritsGlobal = Boolean(scope.inherits_global);
+  const primaryAddress = pickPrimaryAddress(peer.addresses);
+  const peerAddresses = Array.isArray(peer.addresses)
+    ? Array.from(new Set(peer.addresses.filter(Boolean).map((value) => String(value))))
+    : [];
+  const addressLine = peerAddresses.length
+    ? peerAddresses.map((address) => (isSyncRedactionEnabled() ? redactAddress(address) : address)).join(' · ')
+    : 'No addresses';
+  const lastSyncAt = String(peerStatus.last_sync_at || peerStatus.last_sync_at_utc || '');
+  const lastPingAt = String(peerStatus.last_ping_at || peerStatus.last_ping_at_utc || '');
+  const scopeEditorOpen = openPeerScopeEditors.has(peerId);
+  const scopeReviewRequested = consumePeerScopeReviewRequest(peerId);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [scopeHost, setScopeHost] = useState<HTMLDivElement | null>(null);
+
+  const [renameValue, setRenameValue] = useState(displayName);
+  const [renameBusy, setRenameBusy] = useState(false);
+  const [renameLabel, setRenameLabel] = useState('Save name');
+  const [syncBusy, setSyncBusy] = useState(false);
+  const [removeBusy, setRemoveBusy] = useState(false);
+  const [removeLabel, setRemoveLabel] = useState('Remove peer');
+  const [selectedActorId, setSelectedActorId] = useState(String(peer.actor_id || ''));
+  const [applyActorBusy, setApplyActorBusy] = useState(false);
+  const [applyActorLabel, setApplyActorLabel] = useState('Save person');
+  const [saveScopeBusy, setSaveScopeBusy] = useState(false);
+  const [saveScopeLabel, setSaveScopeLabel] = useState('Save scope');
+  const [resetScopeBusy, setResetScopeBusy] = useState(false);
+  const [resetScopeLabel, setResetScopeLabel] = useState('Reset to global scope');
+
+  const includeEditor = useMemo(
+    () => createChipEditor(includeList, 'Add included project', 'All projects'),
+    [peerId, includeList.join('|')],
+  );
+  const excludeEditor = useMemo(
+    () => createChipEditor(excludeList, 'Add excluded project', 'No exclusions'),
+    [peerId, excludeList.join('|')],
+  );
+
+  useEffect(() => {
+    setRenameValue(displayName);
+    setRenameBusy(false);
+    setRenameLabel('Save name');
+    setSyncBusy(false);
+    setRemoveBusy(false);
+    setRemoveLabel('Remove peer');
+    setSelectedActorId(String(peer.actor_id || ''));
+    setApplyActorBusy(false);
+    setApplyActorLabel('Save person');
+    setSaveScopeBusy(false);
+    setSaveScopeLabel('Save scope');
+    setResetScopeBusy(false);
+    setResetScopeLabel('Reset to global scope');
+  }, [displayName, peer.actor_id, peerId, includeList.join('|'), excludeList.join('|')]);
+
+  useEffect(() => {
+    if (!scopeReviewRequested || !cardRef.current) return;
+    queueMicrotask(() => cardRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' }));
+  }, [scopeReviewRequested]);
+
+  async function rename() {
+    if (!peerId) return;
+    const nextName = renameValue.trim();
+    if (!nextName) {
+      showGlobalNotice('Enter a friendly name for this device.', 'warning');
+      const input = document.querySelector(`[data-device-name-input="${CSS.escape(peerId)}"]`) as
+        | HTMLInputElement
+        | null;
+      input?.focus();
+      return;
+    }
+    setRenameBusy(true);
+    setRenameLabel('Saving…');
+    let ok = false;
+    try {
+      await onRename(peerId, nextName);
+      ok = true;
+    } catch {
+      setRenameLabel('Retry save');
+    } finally {
+      setRenameBusy(false);
+      if (ok) setRenameLabel('Save name');
+    }
+  }
+
+  async function sync() {
+    if (!primaryAddress) return;
+    if (pendingScopeReview) {
+      const proceed = window.confirm(
+        `Sync scope review is still pending for ${displayName}. Continue with a manual sync anyway?`,
+      );
+      if (!proceed) return;
+    }
+    setSyncBusy(true);
+    try {
+      await onSync(peer, primaryAddress);
+    } finally {
+      setSyncBusy(false);
+    }
+  }
+
+  async function remove() {
+    if (!peerId) return;
+    if (!window.confirm(`Remove peer ${destructiveLabel}? This deletes the local sync peer entry.`)) return;
+    setRemoveBusy(true);
+    setRemoveLabel('Removing…');
+    let ok = false;
+    try {
+      await onRemove(peerId, destructiveLabel);
+      ok = true;
+    } catch {
+      setRemoveLabel('Retry remove');
+    } finally {
+      setRemoveBusy(false);
+      if (ok) setRemoveLabel('Remove peer');
+    }
+  }
+
+  async function savePerson() {
+    if (!peerId) return;
+    setApplyActorBusy(true);
+    setApplyActorLabel('Applying…');
+    let ok = false;
+    try {
+      await onAssignActor(peerId, selectedActorId || null);
+      ok = true;
+    } catch {
+      setApplyActorLabel('Retry');
+    } finally {
+      setApplyActorBusy(false);
+      if (ok) setApplyActorLabel('Save person');
+    }
+  }
+
+  async function saveScope() {
+    if (!peerId) return;
+    setSaveScopeBusy(true);
+    setSaveScopeLabel('Saving…');
+    let ok = false;
+    try {
+      await onSaveScope(peerId, includeEditor.values(), excludeEditor.values());
+      ok = true;
+    } catch {
+      setSaveScopeLabel('Retry save');
+    } finally {
+      setSaveScopeBusy(false);
+      if (ok) setSaveScopeLabel('Save scope');
+    }
+  }
+
+  async function resetScope() {
+    if (!peerId) return;
+    setResetScopeBusy(true);
+    setResetScopeLabel('Resetting…');
+    let ok = false;
+    try {
+      await onResetScope(peerId);
+      ok = true;
+    } catch {
+      setResetScopeLabel('Retry reset');
+    } finally {
+      setResetScopeBusy(false);
+      if (ok) setResetScopeLabel('Reset to global scope');
+    }
+  }
+
+  return (
+    <div ref={cardRef} className="peer-card" data-peer-device-id={peerId || undefined}>
+      <div className="peer-title">
+        <strong title={peerId || undefined}>
+          {displayName}{' '}
+          <span className={`badge ${trustSummary.isWarning ? 'badge-offline' : 'badge-online'}`}>
+            {trustSummary.badgeLabel}
+          </span>
+          {pendingScopeReview ? <span className="badge actor-badge">Needs scope review</span> : null}
+        </strong>
+
+        <div className="peer-actions">
+          <input
+            aria-label={`Friendly name for ${displayName}`}
+            className="peer-scope-input"
+            data-device-name-input={peerId || undefined}
+            disabled={renameBusy}
+            placeholder="Friendly device name"
+            value={renameValue}
+            onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
+              setRenameValue(event.currentTarget.value)
+            }
+          />
+          <button disabled={renameBusy} onClick={() => void rename()}>
+            {renameLabel}
+          </button>
+          <button disabled={!primaryAddress || syncBusy} onClick={() => void sync()}>
+            {syncBusy ? 'Syncing…' : 'Sync now'}
+          </button>
+          <button disabled={removeBusy} onClick={() => void remove()}>
+            {removeLabel}
+          </button>
+          <PeerScopeCollapsible
+            contentHost={scopeHost}
+            initialOpen={scopeEditorOpen}
+            onOpenChange={(open) => {
+              if (open) openPeerScopeEditors.add(peerId);
+              else openPeerScopeEditors.delete(peerId);
+            }}
+          >
+            <div>
+              <div className="peer-scope-row">
+                <ExistingElementSlot element={includeEditor.element} />
+                <ExistingElementSlot element={excludeEditor.element} />
+              </div>
+              <div className="peer-scope-actions">
+                <button
+                  type="button"
+                  className="settings-button"
+                  disabled={saveScopeBusy}
+                  onClick={() => void saveScope()}
+                >
+                  {saveScopeLabel}
+                </button>
+                <button
+                  type="button"
+                  className="settings-button"
+                  disabled={resetScopeBusy}
+                  onClick={() => void resetScope()}
+                >
+                  {resetScopeLabel}
+                </button>
+              </div>
+            </div>
+          </PeerScopeCollapsible>
+        </div>
+      </div>
+
+      <div className="peer-addresses">{addressLine}</div>
+      <div className="peer-meta">
+        {[lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : 'Sync: never', lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : 'Ping: never'].join(' · ')}
+      </div>
+
+      <div className="peer-scope">
+        {scopeReviewRequested ? (
+          <div className="peer-meta">
+            Review this device&apos;s sync scope now. Global defaults apply until you save an override here.
+          </div>
+        ) : pendingScopeReview ? (
+          <div className="peer-meta">
+            Scope review still pending. Save an override here or reset to global scope when you are done reviewing. Manual syncs can proceed, but they will use the current effective scope until you change it.
+          </div>
+        ) : null}
+
+        <div className="peer-scope-summary">Assigned person</div>
+        <div className="peer-meta">
+          {peer.actor_display_name
+            ? `Assigned to ${String(peer.actor_display_name)}${peer.claimed_local_actor ? ' · you' : ''}`
+            : 'Unassigned person'}
+        </div>
+        <div className="peer-meta">{trustSummary.description}</div>
+        <div className="peer-actor-row">
+          <div className="sync-radix-select-host sync-actor-select-host">
+            <RadixSelect
+              ariaLabel={`Assigned person for ${displayName}`}
+              contentClassName="sync-radix-select-content sync-actor-select-content"
+              disabled={applyActorBusy}
+              itemClassName="sync-radix-select-item"
+              onValueChange={setSelectedActorId}
+              options={actorOptions()}
+              triggerClassName="sync-radix-select-trigger sync-actor-select"
+              value={selectedActorId}
+              viewportClassName="sync-radix-select-viewport"
+            />
+          </div>
+          <button className="settings-button" disabled={applyActorBusy} onClick={() => void savePerson()}>
+            {applyActorLabel}
+          </button>
+        </div>
+        <div className="peer-scope-effective">{assignmentNote(selectedActorId)}</div>
+        <div className="peer-scope-summary">
+          {inheritsGlobal
+            ? 'Using global sync scope'
+            : `Device override · include: ${includeList.join(', ') || 'all'} · exclude: ${excludeList.join(', ') || 'none'}`}
+        </div>
+        <div className="peer-scope-effective">
+          {`Effective scope · ${summaryText('include', effectiveInclude, 'all')} · ${summaryText('exclude', effectiveExclude, 'none')}`}
+        </div>
+        <div ref={setScopeHost} />
+      </div>
+    </div>
+  );
+}
+
+function SyncPeersList(props: SyncPeersListProps) {
+  if (!props.peers.length) {
+    return (
+      <div className="sync-empty-state">
+        No devices connected on this machine yet. Use the pairing command in Diagnostics to connect another device.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {props.peers.map((peer) => {
+        const peerId = String(peer.peer_device_id || peer.name || 'unknown-peer');
+        return <SyncPeerCard key={peerId} peer={peer} {...props} />;
+      })}
+    </>
+  );
+}
+
+export function renderSyncPeersList(mount: HTMLElement, props: SyncPeersListProps) {
+  renderIntoSyncMount(mount, <SyncPeersList {...props} />);
+}

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
@@ -1,0 +1,54 @@
+export interface SyncSharingReviewItem {
+  actorDisplayName: string;
+  actorId: string;
+  peerName: string;
+  privateCount: number;
+  scopeLabel: string;
+  shareableCount: number;
+}
+
+type SyncSharingReviewProps = {
+  items: SyncSharingReviewItem[];
+  onReview: () => void;
+};
+
+function SharingReviewRow({
+  item,
+  onReview,
+}: {
+  item: SyncSharingReviewItem;
+  onReview: () => void;
+}) {
+  return (
+    <div className="actor-row">
+      <div className="actor-details">
+        <div className="actor-title">
+          <strong>{item.peerName}</strong>
+          <span className="badge actor-badge">person: {item.actorDisplayName || item.actorId}</span>
+        </div>
+        <div className="peer-meta">
+          {item.shareableCount} share by default · {item.privateCount} marked Only me · {item.scopeLabel}
+        </div>
+      </div>
+      <div className="actor-actions">
+        <button type="button" className="settings-button" onClick={onReview}>
+          Review my memories in Feed
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SyncSharingReview({ items, onReview }: SyncSharingReviewProps) {
+  return (
+    <>
+      {items.map((item) => (
+        <SharingReviewRow
+          key={`${item.peerName}:${item.actorId}:${item.scopeLabel}`}
+          item={item}
+          onReview={onReview}
+        />
+      ))}
+    </>
+  );
+}

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -1,0 +1,376 @@
+import { createPortal } from 'preact/compat';
+import type { ComponentChildren } from 'preact';
+import { useState } from 'preact/hooks';
+import type { UiSyncAttentionItem } from '../view-model';
+
+export interface TeamSyncStatusSummary {
+  badgeClassName: string;
+  presenceLabel: string;
+  metricsText: string;
+}
+
+export interface TeamSyncDiscoveredRow {
+  actionMessage: string | null;
+  actionLabel: string | null;
+  approvalBadgeLabel: string | null;
+  availabilityLabel: string;
+  deviceId: string;
+  displayName: string;
+  fingerprint: string;
+  mode: 'accept' | 'ambiguous' | 'conflict' | 'none' | 'paired' | 'scope-pending' | 'stale';
+  note: string;
+  pairedMessage: string | null;
+  connectionLabel: string;
+}
+
+export interface TeamSyncPendingJoinRequest {
+  displayName: string;
+  requestId: string;
+}
+
+type TeamSyncPanelProps = {
+  actionItems: UiSyncAttentionItem[];
+  children?: ComponentChildren;
+  discoveredListMount: HTMLElement | null;
+  discoveredRows: TeamSyncDiscoveredRow[];
+  joinRequestsMount: HTMLElement | null;
+  listMount: HTMLElement;
+  onApproveJoinRequest: (request: TeamSyncPendingJoinRequest) => Promise<void>;
+  onAttentionAction: (item: UiSyncAttentionItem) => Promise<void>;
+  onDenyJoinRequest: (request: TeamSyncPendingJoinRequest) => Promise<void>;
+  onInspectConflict: (row: TeamSyncDiscoveredRow) => void;
+  onRemoveConflict: (row: TeamSyncDiscoveredRow) => Promise<void>;
+  onReviewDiscoveredDevice: (row: TeamSyncDiscoveredRow) => Promise<void>;
+  pendingJoinRequests: TeamSyncPendingJoinRequest[];
+  presenceStatus: string;
+  statusSummary: TeamSyncStatusSummary;
+};
+
+function AttentionRow({
+  item,
+  onAction,
+}: {
+  item: UiSyncAttentionItem;
+  onAction: (item: UiSyncAttentionItem) => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  return (
+    <div className="sync-action">
+      <div className="sync-action-text">
+        {item.title}
+        <span className="sync-action-command">{item.summary}</span>
+      </div>
+      <button
+        type="button"
+        className="settings-button"
+        disabled={busy}
+        onClick={async () => {
+          setBusy(true);
+          try {
+            await onAction(item);
+          } finally {
+            setBusy(false);
+          }
+        }}
+      >
+        {item.actionLabel || 'Review'}
+      </button>
+    </div>
+  );
+}
+
+
+function PendingJoinRequestRow({
+  request,
+  onApprove,
+  onDeny,
+}: {
+  request: TeamSyncPendingJoinRequest;
+  onApprove: (request: TeamSyncPendingJoinRequest) => Promise<void>;
+  onDeny: (request: TeamSyncPendingJoinRequest) => Promise<void>;
+}) {
+  const [busyAction, setBusyAction] = useState<'approve' | 'deny' | null>(null);
+  const [approveLabel, setApproveLabel] = useState('Approve');
+  const [denyLabel, setDenyLabel] = useState('Deny');
+
+  return (
+    <div className="actor-row">
+      <div className="actor-details">
+        <div className="actor-title">{request.displayName}</div>
+        <div className="peer-meta">request: {request.requestId}</div>
+      </div>
+      <div className="actor-actions">
+        <button
+          type="button"
+          className="settings-button"
+          disabled={busyAction !== null}
+          onClick={async () => {
+            setBusyAction('approve');
+            setApproveLabel('Approving…');
+            try {
+              await onApprove(request);
+              setApproveLabel('Approve');
+            } catch {
+              setApproveLabel('Retry');
+            } finally {
+              setBusyAction(null);
+            }
+          }}
+        >
+          {approveLabel}
+        </button>
+        <button
+          type="button"
+          className="settings-button"
+          disabled={busyAction !== null}
+          onClick={async () => {
+            setBusyAction('deny');
+            setDenyLabel('Denying…');
+            try {
+              await onDeny(request);
+              setDenyLabel('Deny');
+            } catch {
+              setDenyLabel('Retry deny');
+            } finally {
+              setBusyAction(null);
+            }
+          }}
+        >
+          {denyLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DiscoveredDeviceRow({
+  row,
+  onInspectConflict,
+  onRemoveConflict,
+  onReview,
+}: {
+  row: TeamSyncDiscoveredRow;
+  onInspectConflict: (row: TeamSyncDiscoveredRow) => void;
+  onRemoveConflict: (row: TeamSyncDiscoveredRow) => Promise<void>;
+  onReview: (row: TeamSyncDiscoveredRow) => Promise<void>;
+}) {
+  const [busy, setBusy] = useState<'remove' | 'review' | null>(null);
+  const [reviewLabel, setReviewLabel] = useState(row.actionLabel || 'Review device');
+  const [removeLabel, setRemoveLabel] = useState('Remove broken device record');
+
+  return (
+    <div className="actor-row" data-discovered-device-id={row.deviceId}>
+      <div className="actor-details">
+        <div className="actor-title">
+          <strong>{row.displayName}</strong>
+          <span className={`badge actor-badge${row.availabilityLabel === 'Offline' ? '' : ' local'}`}>
+            {row.availabilityLabel}
+          </span>
+          <span className="badge actor-badge">{row.connectionLabel}</span>
+          {row.approvalBadgeLabel ? (
+            <span className="badge actor-badge">{row.approvalBadgeLabel}</span>
+          ) : null}
+        </div>
+        <div className="peer-meta">{row.note}</div>
+      </div>
+      <div className="actor-actions">
+        {row.mode === 'accept' ? (
+          <button
+            type="button"
+            className="settings-button"
+            disabled={busy !== null}
+            onClick={async () => {
+              setBusy('review');
+              setReviewLabel('Opening…');
+              try {
+                await onReview(row);
+                setReviewLabel(row.actionLabel || 'Review device');
+              } catch {
+                setReviewLabel('Retry review');
+              } finally {
+                setBusy(null);
+              }
+            }}
+          >
+            {reviewLabel}
+          </button>
+        ) : null}
+        {row.mode === 'stale' || row.mode === 'ambiguous' || row.mode === 'scope-pending' ? (
+          <div className="peer-meta">{row.actionMessage}</div>
+        ) : null}
+        {row.mode === 'paired' && row.pairedMessage ? (
+          <div className="peer-meta">{row.pairedMessage}</div>
+        ) : null}
+        {row.mode === 'conflict' ? (
+          <>
+            <button
+              type="button"
+              className="settings-button"
+              disabled={busy !== null}
+              onClick={() => onInspectConflict(row)}
+            >
+              Open device details
+            </button>
+            <button
+              type="button"
+              className="settings-button"
+              disabled={busy !== null}
+              onClick={async () => {
+                setBusy('remove');
+                setRemoveLabel('Removing…');
+                try {
+                  await onRemoveConflict(row);
+                  setRemoveLabel('Remove broken device record');
+                } catch {
+                  setRemoveLabel('Retry remove');
+                } finally {
+                  setBusy(null);
+                }
+              }}
+            >
+              {removeLabel}
+            </button>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ActionContent(props: TeamSyncPanelProps) {
+  const hasAttentionItems = props.actionItems.length > 0;
+
+  return (
+    <>
+      {hasAttentionItems ? <div className="sync-action-text">Needs attention</div> : null}
+      {hasAttentionItems
+        ? props.actionItems.slice(0, 4).map((item) => (
+            <AttentionRow key={item.id} item={item} onAction={props.onAttentionAction} />
+          ))
+        : null}
+      {!hasAttentionItems && props.presenceStatus === 'posted' ? (
+        <div className="sync-action">
+          <div className="sync-action-text">
+            No immediate issues
+            <span className="sync-action-command">
+              Your devices and team records do not currently need review.
+            </span>
+          </div>
+        </div>
+      ) : null}
+      {!hasAttentionItems && props.presenceStatus === 'not_enrolled' ? (
+        <div className="sync-action">
+          <div className="sync-action-text">
+            This device still needs team enrollment
+            <span className="sync-action-command">
+              Import an invite or ask your admin to enroll this device before expecting sync activity here.
+            </span>
+          </div>
+        </div>
+      ) : null}
+      {props.children}
+    </>
+  );
+}
+
+function TeamStatusPortal({
+  mount,
+  statusSummary,
+}: {
+  mount: HTMLElement;
+  statusSummary: TeamSyncStatusSummary;
+}) {
+  return createPortal(
+    <div className="sync-team-summary">
+      <div className="sync-team-status-row">
+        <span className="sync-team-status-label">Status</span>
+        <span className={statusSummary.badgeClassName}>{statusSummary.presenceLabel}</span>
+      </div>
+      <div className="sync-team-metrics">{statusSummary.metricsText}</div>
+    </div>,
+    mount,
+  );
+}
+
+function DiscoveredPortal({
+  mount,
+  rows,
+  onInspectConflict,
+  onRemoveConflict,
+  onReview,
+}: {
+  mount: HTMLElement | null;
+  rows: TeamSyncDiscoveredRow[];
+  onInspectConflict: (row: TeamSyncDiscoveredRow) => void;
+  onRemoveConflict: (row: TeamSyncDiscoveredRow) => Promise<void>;
+  onReview: (row: TeamSyncDiscoveredRow) => Promise<void>;
+}) {
+  if (!mount) return null;
+  return createPortal(
+    <>
+      {rows.map((row) => (
+        <DiscoveredDeviceRow
+          key={row.deviceId}
+          row={row}
+          onInspectConflict={onInspectConflict}
+          onRemoveConflict={onRemoveConflict}
+          onReview={onReview}
+        />
+      ))}
+    </>,
+    mount,
+  );
+}
+
+function PendingRequestsPortal({
+  mount,
+  requests,
+  onApprove,
+  onDeny,
+}: {
+  mount: HTMLElement | null;
+  requests: TeamSyncPendingJoinRequest[];
+  onApprove: (request: TeamSyncPendingJoinRequest) => Promise<void>;
+  onDeny: (request: TeamSyncPendingJoinRequest) => Promise<void>;
+}) {
+  if (!mount || !requests.length) return null;
+  return createPortal(
+    <>
+      <div className="peer-meta">
+        {requests.length} pending join request{requests.length === 1 ? '' : 's'}
+      </div>
+      {requests.map((request) => (
+        <PendingJoinRequestRow
+          key={request.requestId}
+          request={request}
+          onApprove={onApprove}
+          onDeny={onDeny}
+        />
+      ))}
+    </>,
+    mount,
+  );
+}
+
+export function TeamSyncPanel(props: TeamSyncPanelProps) {
+  return (
+    <>
+      <ActionContent {...props} />
+      <TeamStatusPortal mount={props.listMount} statusSummary={props.statusSummary} />
+      <PendingRequestsPortal
+        mount={props.joinRequestsMount}
+        requests={props.pendingJoinRequests}
+        onApprove={props.onApproveJoinRequest}
+        onDeny={props.onDenyJoinRequest}
+      />
+      <DiscoveredPortal
+        mount={props.discoveredListMount}
+        rows={props.discoveredRows}
+        onInspectConflict={props.onInspectConflict}
+        onRemoveConflict={props.onRemoveConflict}
+        onReview={props.onReviewDiscoveredDevice}
+      />
+    </>
+  );
+}

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -1,21 +1,112 @@
 /* Diagnostics card — sync status grid, attempts log, pairing. */
 
-import { el, copyToClipboard } from '../../lib/dom';
+import { h } from 'preact';
+import { RadixSwitch } from '../../components/primitives/radix-switch';
+import { copyToClipboard } from '../../lib/dom';
 import { formatAgeShort, formatTimestamp, secondsSince, titleCase } from '../../lib/format';
+import { state, setSyncPairingOpen, isSyncRedactionEnabled, setSyncRedactionEnabled } from '../../lib/state';
+import { clearSyncMount, renderIntoSyncMount } from './components/render-root';
+import { renderPairingDisclosure } from './components/sync-disclosure';
 import {
-  state,
-  isSyncPairingOpen,
-  setSyncPairingOpen,
-  isSyncRedactionEnabled,
-  setSyncRedactionEnabled,
-} from '../../lib/state';
+  renderAttemptsList,
+  renderDiagnosticsGrid,
+  renderPairingView,
+  type PairingView,
+  type SyncAttemptItem,
+  type SyncStatItem,
+} from './components/sync-diagnostics';
 import { redactAddress, renderActionList, hideSkeleton } from './helpers';
+
+type SyncRetention = {
+  enabled?: boolean;
+  last_deleted_ops?: number | string;
+  last_error?: string;
+  last_run_at?: string | null;
+};
+
+type SyncPayloadState = {
+  seconds_since_last?: number;
+};
+
+type PingPayloadState = SyncPayloadState & {
+  last_ping_at?: string | null;
+};
+
+type SyncStatusState = {
+  daemon_detail?: string;
+  daemon_state?: string;
+  enabled?: boolean;
+  last_ping_at?: string | null;
+  last_ping_error?: string;
+  last_sync_at?: string | null;
+  last_sync_at_utc?: string | null;
+  last_sync_error?: string;
+  pending?: number | string;
+  peers?: Record<string, unknown>;
+  ping?: PingPayloadState;
+  retention?: SyncRetention;
+  sync?: SyncPayloadState;
+};
+
+type SyncAttemptState = {
+  address?: string;
+  started_at?: string;
+  started_at_utc?: string;
+  status?: string;
+};
+
+type PairingPayloadState = Record<string, unknown> & {
+  addresses?: unknown[];
+  redacted?: boolean;
+};
+
+const SYNC_REDACT_MOUNT_ID = 'syncRedactMount';
+const SYNC_REDACT_LABEL_ID = 'syncRedactLabel';
 
 /* ── Import render functions needed for redact toggle ────── */
 // These are set by the index module to avoid circular imports.
 let _renderSyncPeers: () => void = () => {};
 export function setRenderSyncPeers(fn: () => void) {
   _renderSyncPeers = fn;
+}
+
+let _refreshPairing: () => void = () => {};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function pairingView(payload: unknown): PairingView {
+  if (!isRecord(payload)) {
+    state.pairingCommandRaw = '';
+    return {
+      payloadText: 'Pairing not available',
+      hintText: 'Enable sync and retry.',
+    };
+  }
+
+  const pairingPayload = payload as PairingPayloadState;
+  if (pairingPayload.redacted) {
+    state.pairingCommandRaw = '';
+    return {
+      payloadText: 'Pairing payload hidden',
+      hintText: 'Diagnostics are required to view the pairing payload.',
+    };
+  }
+
+  const safePayload = {
+    ...pairingPayload,
+    addresses: Array.isArray(pairingPayload.addresses) ? pairingPayload.addresses : [],
+  };
+  const compact = JSON.stringify(safePayload);
+  const b64 = btoa(compact);
+  const command = `echo '${b64}' | base64 -d | codemem sync pair --accept-file -`;
+  state.pairingCommandRaw = command;
+  return {
+    payloadText: command,
+    hintText:
+      'Copy this command and run it on the other device. Use --include/--exclude to control which projects sync.',
+  };
 }
 
 /* ── Sync status renderer ────────────────────────────────── */
@@ -25,13 +116,14 @@ export function renderSyncStatus() {
   const syncMeta = document.getElementById('syncMeta');
   const syncActions = document.getElementById('syncActions');
   if (!syncStatusGrid) return;
-  hideSkeleton('syncDiagSkeleton');
-  syncStatusGrid.textContent = '';
 
-  const status = state.lastSyncStatus;
+  hideSkeleton('syncDiagSkeleton');
+
+  const status = state.lastSyncStatus as SyncStatusState | null;
   if (!status) {
+    clearSyncMount(syncStatusGrid);
     renderActionList(syncActions, []);
-    if (syncMeta) syncMeta.textContent = 'Loading sync status\u2026';
+    if (syncMeta) syncMeta.textContent = 'Loading sync status…';
     return;
   }
 
@@ -72,9 +164,12 @@ export function renderSyncStatus() {
             `Peers: ${peerCount}`,
             lastSync ? `Last sync: ${formatAgeShort(secondsSince(lastSync))} ago` : 'Last sync: never',
           ];
-    if (daemonState === 'offline-peers')
+    if (daemonState === 'offline-peers') {
       parts.push('All peers are currently offline; sync will resume automatically');
-    if (daemonDetail && daemonState === 'stopped') parts.push(`Detail: ${daemonDetail}`);
+    }
+    if (daemonDetail && daemonState === 'stopped') {
+      parts.push(`Detail: ${daemonDetail}`);
+    }
     if (daemonDetail && (daemonState === 'needs_attention' || daemonState === 'rebootstrapping')) {
       parts.push(`Detail: ${daemonDetail}`);
     }
@@ -85,11 +180,10 @@ export function renderSyncStatus() {
           : 'Retention enabled',
       );
     }
-    syncMeta.textContent = parts.join(' \u00b7 ');
+    syncMeta.textContent = parts.join(' · ');
   }
 
-  // Status grid
-  const diagItems = syncDisabled
+  const items: SyncStatItem[] = syncDisabled
     ? [
         { label: 'State', value: 'Disabled' },
         { label: 'Mode', value: 'Optional' },
@@ -124,56 +218,36 @@ export function renderSyncStatus() {
           },
         ];
 
-  diagItems.forEach((item) => {
-    const block = el('div', 'stat');
-    const content = el('div', 'stat-content');
-    content.append(el('div', 'value', item.value), el('div', 'label', item.label));
-    block.appendChild(content);
-    syncStatusGrid.appendChild(block);
-  });
-
   if (!syncDisabled && !syncNoPeers && (syncError || pingError)) {
-    const block = el('div', 'stat');
-    const content = el('div', 'stat-content');
-    content.append(
-      el('div', 'value', 'Errors'),
-      el('div', 'label', [syncError, pingError].filter(Boolean).join(' \u00b7 ')),
-    );
-    block.appendChild(content);
-    syncStatusGrid.appendChild(block);
+    items.push({
+      label: [syncError, pingError].filter(Boolean).join(' · '),
+      value: 'Errors',
+    });
   }
 
-  if (!syncDisabled && !syncNoPeers && syncPayload?.seconds_since_last) {
-    const block = el('div', 'stat');
-    const content = el('div', 'stat-content');
-    content.append(
-      el('div', 'value', `${syncPayload.seconds_since_last}s`),
-      el('div', 'label', 'Since last sync'),
-    );
-    block.appendChild(content);
-    syncStatusGrid.appendChild(block);
+  if (!syncDisabled && !syncNoPeers && syncPayload.seconds_since_last) {
+    items.push({
+      label: 'Since last sync',
+      value: `${syncPayload.seconds_since_last}s`,
+    });
   }
 
-  if (!syncDisabled && !syncNoPeers && pingPayload?.seconds_since_last) {
-    const block = el('div', 'stat');
-    const content = el('div', 'stat-content');
-    content.append(
-      el('div', 'value', `${pingPayload.seconds_since_last}s`),
-      el('div', 'label', 'Since last ping'),
-    );
-    block.appendChild(content);
-    syncStatusGrid.appendChild(block);
+  if (!syncDisabled && !syncNoPeers && pingPayload.seconds_since_last) {
+    items.push({
+      label: 'Since last ping',
+      value: `${pingPayload.seconds_since_last}s`,
+    });
   }
 
   if (!syncDisabled && retentionEnabled && retentionLastError) {
-    const block = el('div', 'stat');
-    const content = el('div', 'stat-content');
-    content.append(el('div', 'value', 'Retention'), el('div', 'label', retentionLastError));
-    block.appendChild(content);
-    syncStatusGrid.appendChild(block);
+    items.push({
+      label: retentionLastError,
+      value: 'Retention',
+    });
   }
 
-  // Actions
+  renderDiagnosticsGrid(syncStatusGrid, items);
+
   const actions: Array<{ label: string; command: string }> = [];
   if (syncNoPeers) {
     /* no action */
@@ -212,112 +286,98 @@ export function renderSyncStatus() {
 export function renderSyncAttempts() {
   const syncAttempts = document.getElementById('syncAttempts');
   if (!syncAttempts) return;
-  syncAttempts.textContent = '';
-  const attempts = state.lastSyncAttempts;
-  if (!Array.isArray(attempts) || !attempts.length) return;
 
-  attempts.slice(0, 5).forEach((attempt) => {
-    const line = el('div', 'diag-line');
-    const left = el('div', 'left');
-    left.append(
-      el('div', null, attempt.status || 'unknown'),
-      el(
-        'div',
-        'small',
-        isSyncRedactionEnabled() ? redactAddress(attempt.address) : attempt.address || 'n/a',
-      ),
-    );
-    const right = el('div', 'right');
+  const attempts = state.lastSyncAttempts as SyncAttemptState[];
+  if (!Array.isArray(attempts) || !attempts.length) {
+    clearSyncMount(syncAttempts);
+    return;
+  }
+
+  const items: SyncAttemptItem[] = attempts.slice(0, 5).map((attempt) => {
     const time = attempt.started_at || attempt.started_at_utc || '';
-    right.textContent = time ? formatTimestamp(time) : '';
-    line.append(left, right);
-    syncAttempts.appendChild(line);
+    return {
+      status: attempt.status || 'unknown',
+      address: isSyncRedactionEnabled() ? redactAddress(attempt.address) : attempt.address || 'n/a',
+      startedAt: time ? formatTimestamp(time) : '',
+    };
   });
+
+  renderAttemptsList(syncAttempts, items);
 }
 
 /* ── Pairing renderer ────────────────────────────────────── */
 
+function renderPairingCollapsible() {
+  const mount = document.getElementById('syncPairingDisclosureMount') as HTMLElement | null;
+  const contentHost = document.getElementById('syncPairingPanelMount') as HTMLElement | null;
+  if (!mount || !contentHost) return;
+
+  renderPairingDisclosure(mount, {
+    contentHost,
+    open: state.syncPairingOpen,
+    onOpenChange: (open) => {
+      setSyncPairingOpen(open);
+      renderPairingCollapsible();
+      if (open) {
+        const pairingPayloadEl = document.getElementById('pairingPayload');
+        const pairingHint = document.getElementById('pairingHint');
+        if (pairingPayloadEl) {
+          renderPairingView(pairingPayloadEl, pairingHint, {
+            payloadText: 'Loading…',
+            hintText: 'Fetching pairing payload…',
+          });
+        }
+      }
+      _refreshPairing();
+    },
+  });
+
+  const pairingCopy = document.getElementById('pairingCopy') as HTMLButtonElement | null;
+  if (pairingCopy) {
+    pairingCopy.onclick = async () => {
+      const text = state.pairingCommandRaw || document.getElementById('pairingPayload')?.textContent || '';
+      if (text) await copyToClipboard(text, pairingCopy);
+    };
+  }
+}
+
 export function renderPairing() {
+  renderPairingCollapsible();
   const pairingPayloadEl = document.getElementById('pairingPayload');
   const pairingHint = document.getElementById('pairingHint');
   if (!pairingPayloadEl) return;
 
-  const payload = state.pairingPayloadRaw;
-  if (!payload || typeof payload !== 'object') {
-    pairingPayloadEl.textContent = 'Pairing not available';
-    if (pairingHint) pairingHint.textContent = 'Enable sync and retry.';
-    state.pairingCommandRaw = '';
-    return;
-  }
-  if (payload.redacted) {
-    pairingPayloadEl.textContent = 'Pairing payload hidden';
-    if (pairingHint)
-      pairingHint.textContent = 'Diagnostics are required to view the pairing payload.';
-    state.pairingCommandRaw = '';
-    return;
-  }
+  renderPairingView(pairingPayloadEl, pairingHint, pairingView(state.pairingPayloadRaw));
+}
 
-  const safePayload = {
-    ...payload,
-    addresses: Array.isArray(payload.addresses) ? payload.addresses : [],
-  };
-  const compact = JSON.stringify(safePayload);
-  const b64 = btoa(compact);
-  const command = `echo '${b64}' | base64 -d | codemem sync pair --accept-file -`;
-  pairingPayloadEl.textContent = command;
-  state.pairingCommandRaw = command;
-  if (pairingHint) {
-    pairingHint.textContent =
-      'Copy this command and run it on the other device. Use --include/--exclude to control which projects sync.';
-  }
+function renderRedactControl() {
+  const mount = document.getElementById(SYNC_REDACT_MOUNT_ID) as HTMLElement | null;
+  if (!mount) return;
+
+  renderIntoSyncMount(
+    mount,
+    h(RadixSwitch, {
+      'aria-labelledby': SYNC_REDACT_LABEL_ID,
+      checked: isSyncRedactionEnabled(),
+      className: 'sync-redact-switch',
+      id: 'syncRedact',
+      onCheckedChange: (checked: boolean) => {
+        setSyncRedactionEnabled(checked);
+        renderRedactControl();
+        renderSyncStatus();
+        _renderSyncPeers();
+        renderSyncAttempts();
+        renderPairing();
+      },
+      thumbClassName: 'sync-redact-switch-thumb',
+    }),
+  );
 }
 
 /* ── Event wiring ────────────────────────────────────────── */
 
 export function initDiagnosticsEvents(refreshCallback: () => void) {
-  const syncPairingToggle = document.getElementById(
-    'syncPairingToggle',
-  ) as HTMLButtonElement | null;
-  const syncRedact = document.getElementById('syncRedact') as HTMLInputElement | null;
-  const pairingCopy = document.getElementById('pairingCopy') as HTMLButtonElement | null;
-  const syncPairing = document.getElementById('syncPairing');
-
-  // Apply initial toggle states
-  if (syncPairing) syncPairing.hidden = !state.syncPairingOpen;
-  if (syncPairingToggle) {
-    syncPairingToggle.textContent = state.syncPairingOpen ? 'Hide pairing' : 'Show pairing';
-    syncPairingToggle.setAttribute('aria-expanded', String(state.syncPairingOpen));
-  }
-  if (syncRedact) syncRedact.checked = isSyncRedactionEnabled();
-
-  syncPairingToggle?.addEventListener('click', () => {
-    const next = !state.syncPairingOpen;
-    setSyncPairingOpen(next);
-    if (syncPairing) syncPairing.hidden = !next;
-    if (syncPairingToggle) {
-      syncPairingToggle.textContent = next ? 'Hide pairing' : 'Show pairing';
-      syncPairingToggle.setAttribute('aria-expanded', String(next));
-    }
-    if (next) {
-      const pairingPayloadEl = document.getElementById('pairingPayload');
-      const pairingHint = document.getElementById('pairingHint');
-      if (pairingPayloadEl) pairingPayloadEl.textContent = 'Loading\u2026';
-      if (pairingHint) pairingHint.textContent = 'Fetching pairing payload\u2026';
-    }
-    refreshCallback();
-  });
-
-  syncRedact?.addEventListener('change', () => {
-    setSyncRedactionEnabled(Boolean(syncRedact.checked));
-    renderSyncStatus();
-    _renderSyncPeers();
-    renderSyncAttempts();
-    renderPairing();
-  });
-
-  pairingCopy?.addEventListener('click', async () => {
-    const text =
-      state.pairingCommandRaw || document.getElementById('pairingPayload')?.textContent || '';
-    if (text && pairingCopy) await copyToClipboard(text, pairingCopy);
-  });
+  _refreshPairing = refreshCallback;
+  renderPairingCollapsible();
+  renderRedactControl();
 }

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -8,6 +8,7 @@ import { deriveSyncViewModel } from './view-model';
 import { renderSyncStatus, renderSyncAttempts, renderPairing, initDiagnosticsEvents, setRenderSyncPeers } from './diagnostics';
 import { renderTeamSync, renderSyncSharingReview, initTeamSyncEvents, setLoadSyncData as setTeamSyncLoadData } from './team-sync';
 import { renderSyncActors, renderSyncPeers, renderLegacyDeviceClaims, initPeopleEvents, setLoadSyncData as setPeopleLoadData } from './people';
+import { ensureSyncRenderBoundary } from './components/render-root';
 import { hideSkeleton, readDuplicatePersonDecisions } from './helpers';
 
 /* ── Re-exports consumed by app.ts ───────────────────────── */
@@ -140,6 +141,7 @@ export async function loadPairingData() {
 /* ── Init ────────────────────────────────────────────────── */
 
 export function initSyncTab(refreshCallback: () => void) {
+  ensureSyncRenderBoundary();
   // Wire cross-module callbacks to avoid circular imports
   setTeamSyncLoadData(loadSyncData);
   setPeopleLoadData(loadSyncData);

--- a/packages/ui/src/tabs/sync/peer-scope-collapsible.tsx
+++ b/packages/ui/src/tabs/sync/peer-scope-collapsible.tsx
@@ -1,0 +1,60 @@
+import * as Collapsible from '@radix-ui/react-collapsible';
+import type { ComponentChildren } from 'preact';
+import { createPortal } from 'preact/compat';
+import { useEffect, useLayoutEffect, useState } from 'preact/hooks';
+import { renderIntoSyncMount } from './components/render-root';
+
+export type PeerScopeCollapsibleProps = {
+  contentHost: HTMLElement | null;
+  initialOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ComponentChildren;
+};
+
+export function PeerScopeCollapsible({
+  contentHost,
+  initialOpen,
+  onOpenChange,
+  children,
+}: PeerScopeCollapsibleProps) {
+  const [open, setOpen] = useState(initialOpen);
+
+  useEffect(() => {
+    setOpen(initialOpen);
+  }, [initialOpen]);
+
+  useLayoutEffect(() => {
+    onOpenChange(open);
+  }, [onOpenChange, open]);
+
+  const content = (
+    <Collapsible.Content
+      forceMount
+      className={`peer-scope-editor-wrap${open ? '' : ' collapsed'}`}
+      hidden={!open}
+      inert={!open}
+    >
+      <ScopeEditorContent>{children}</ScopeEditorContent>
+    </Collapsible.Content>
+  );
+
+  return (
+    <Collapsible.Root open={open} onOpenChange={setOpen}>
+      <Collapsible.Trigger asChild>
+        <button type="button">{open ? 'Hide scope editor' : 'Edit scope'}</button>
+      </Collapsible.Trigger>
+      {contentHost ? createPortal(content, contentHost) : null}
+    </Collapsible.Root>
+  );
+}
+
+function ScopeEditorContent({ children }: { children: ComponentChildren }) {
+  return <div>{children}</div>;
+}
+
+export function renderPeerScopeCollapsible(
+  mount: HTMLElement,
+  props: PeerScopeCollapsibleProps,
+) {
+  renderIntoSyncMount(mount, <PeerScopeCollapsible {...props} />);
+}

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -1,37 +1,28 @@
 /* People card — people, devices, sharing review, legacy device claims. */
 
-import { el } from '../../lib/dom';
-import { formatTimestamp } from '../../lib/format';
-import { state, isSyncRedactionEnabled } from '../../lib/state';
+import { state } from '../../lib/state';
 import * as api from '../../lib/api';
 import { showGlobalNotice } from '../../lib/notice';
 import { markFieldError, clearFieldError, friendlyError } from '../../lib/form';
 import {
-  derivePeerTrustSummary,
   summarizeSyncRunResult,
   deriveVisiblePeopleActors,
   type VisiblePeopleResult,
 } from './view-model';
 import {
-  redactAddress,
-  pickPrimaryAddress,
-  actorLabel,
-  assignedActorCount,
-  assignmentNote,
-  buildActorOptions,
-  mergeTargetActors,
-  actorMergeNote,
-  createChipEditor,
   clearPeerScopeReview,
   isPeerScopeReviewPending,
-  openPeerScopeEditors,
-  consumePeerScopeReviewRequest,
   hideSkeleton,
 } from './helpers';
+import { renderSyncActorsList } from './components/sync-actors';
+import { renderSyncPeersList } from './components/sync-peers';
+import { renderLegacyClaimsSlice } from './components/sync-legacy-claims';
 
 /* ── loadSyncData callback (set by index module) ─────────── */
 
 let _loadSyncData: () => Promise<void> = async () => {};
+let legacyDeviceValue = '';
+
 export function setLoadSyncData(fn: () => Promise<void>) {
   _loadSyncData = fn;
 }
@@ -43,7 +34,6 @@ export function renderSyncActors() {
   const actorMeta = document.getElementById('syncActorsMeta');
   if (!actorList) return;
   hideSkeleton('syncActorsSkeleton');
-  actorList.textContent = '';
 
   const actorVisibility: VisiblePeopleResult = deriveVisiblePeopleActors({
     actors: state.lastSyncActors,
@@ -60,136 +50,23 @@ export function renderSyncActors() {
     }
   }
 
-  if (!actors.length) {
-    actorList.appendChild(
-      el('div', 'sync-empty-state', 'No people yet. Create one to represent yourself or a teammate.'),
-    );
-    return;
-  }
-
-  actors.forEach((actor) => {
-    const row = el('div', 'actor-row');
-    const details = el('div', 'actor-details');
-    const title = el('div', 'actor-title');
-    const name = el('strong', null, actorLabel(actor));
-    const count = assignedActorCount(String(actor.actor_id || ''));
-    const badge = el(
-      'span',
-      `badge actor-badge${actor.is_local ? ' local' : ''}`,
-      actor.is_local ? 'Local' : `${count} device${count === 1 ? '' : 's'}`,
-    );
-    title.append(name, badge);
-    const note = el(
-      'div',
-      'peer-meta',
-      actor.is_local
-        ? `Used for this device and same-person devices.${
-            actorVisibility.hiddenLocalDuplicateCount > 0
-              ? ` ${actorVisibility.hiddenLocalDuplicateCount} unresolved duplicate ${actorVisibility.hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden until reviewed in Needs attention.`
-              : ''
-          }`
-        : `${count} assigned device${count === 1 ? '' : 's'}`,
-    );
-    details.append(title, note);
-
-    const actions = el('div', 'actor-actions');
-    if (actor.is_local) {
-      actions.appendChild(el('div', 'peer-meta', 'Rename in config'));
-    } else {
-      const actorId = String(actor.actor_id || '');
-      const input = document.createElement('input');
-      input.className = 'peer-scope-input actor-name-input';
-      input.value = actorLabel(actor);
-      input.setAttribute('aria-label', `Rename ${actorLabel(actor)}`);
-      const renameBtn = el('button', 'settings-button', 'Rename') as HTMLButtonElement;
-      renameBtn.addEventListener('click', async () => {
-        const nextName = input.value.trim();
-        if (!nextName) return;
-        renameBtn.disabled = true;
-        input.disabled = true;
-        renameBtn.textContent = 'Saving\u2026';
-        try {
-          await api.renameActor(actorId, nextName);
-          await _loadSyncData();
-        } catch {
-          renameBtn.textContent = 'Retry rename';
-        } finally {
-          renameBtn.disabled = false;
-          input.disabled = false;
-          if (renameBtn.textContent === 'Saving\u2026') renameBtn.textContent = 'Rename';
-        }
-      });
-      const mergeTargets = mergeTargetActors(actorId);
-      const mergeControls = el('div', 'actor-merge-controls');
-      const mergeSelect = document.createElement('select');
-      mergeSelect.className = 'sync-actor-select actor-merge-select';
-      mergeSelect.setAttribute('aria-label', `Combine ${actorLabel(actor)} into another person`);
-      const placeholder = document.createElement('option');
-      placeholder.value = '';
-      placeholder.textContent = 'Combine into person';
-      placeholder.selected = true;
-      mergeSelect.appendChild(placeholder);
-      mergeTargets.forEach((target) => {
-        const option = document.createElement('option');
-        option.value = String(target.actor_id || '');
-        option.textContent = target.is_local ? `${actorLabel(target)} (local)` : actorLabel(target);
-        mergeSelect.appendChild(option);
-      });
-      const mergeBtn = el(
-        'button',
-        'settings-button',
-        'Combine into selected person',
-      ) as HTMLButtonElement;
-      mergeBtn.disabled = mergeTargets.length === 0;
-      const mergeNote = el(
-        'div',
-        'peer-meta actor-merge-note',
-        mergeTargets.length
-          ? actorMergeNote('', actorId)
-          : 'No people available to combine yet. Create another person or use You.',
-      );
-      mergeSelect.addEventListener('change', () => {
-        mergeNote.textContent = actorMergeNote(mergeSelect.value, actorId);
-      });
-      mergeBtn.addEventListener('click', async () => {
-        if (!mergeSelect.value) return;
-        const target = mergeTargets.find(
-          (candidate) => String(candidate.actor_id || '') === mergeSelect.value,
-        );
-        if (
-          !window.confirm(
-            `Combine ${actorLabel(actor)} into ${actorLabel(target)}? Assigned devices move now, but older memories keep their current stamped provenance for now.`,
-          )
-        ) {
-          return;
-        }
-        mergeBtn.disabled = true;
-        mergeSelect.disabled = true;
-        input.disabled = true;
-        renameBtn.disabled = true;
-        mergeBtn.textContent = 'Merging\u2026';
-        try {
-          await api.mergeActor(mergeSelect.value, actorId);
-          showGlobalNotice('People combined. Assigned devices moved to the selected person.');
-          await _loadSyncData();
-        } catch (error) {
-          showGlobalNotice(friendlyError(error, 'Failed to combine people.'), 'warning');
-          mergeBtn.textContent = 'Retry merge';
-        } finally {
-          mergeBtn.disabled = mergeTargets.length === 0;
-          mergeSelect.disabled = false;
-          input.disabled = false;
-          renameBtn.disabled = false;
-          if (mergeBtn.textContent === 'Merging\u2026')
-            mergeBtn.textContent = 'Combine into selected person';
-        }
-      });
-      mergeControls.append(mergeSelect, mergeBtn);
-      actions.append(input, renameBtn, mergeControls, mergeNote);
-    }
-
-    row.append(details, actions);
-    actorList.appendChild(row);
+  renderSyncActorsList(actorList, {
+    actors,
+    hiddenLocalDuplicateCount: actorVisibility.hiddenLocalDuplicateCount,
+    onRename: async (actorId, nextName) => {
+      await api.renameActor(actorId, nextName);
+      await _loadSyncData();
+    },
+    onMerge: async (primaryActorId, secondaryActorId) => {
+      try {
+        await api.mergeActor(primaryActorId, secondaryActorId);
+        showGlobalNotice('People combined. Assigned devices moved to the selected person.');
+        await _loadSyncData();
+      } catch (error) {
+        showGlobalNotice(friendlyError(error, 'Failed to combine people.'), 'warning');
+        throw error;
+      }
+    },
   });
 }
 
@@ -201,91 +78,27 @@ export function renderSyncPeers() {
   hideSkeleton('syncPeersSkeleton');
   syncPeers.textContent = '';
   const peers = state.lastSyncPeers;
-  if (!Array.isArray(peers) || !peers.length) {
-    syncPeers.appendChild(
-      el(
-        'div',
-        'sync-empty-state',
-        'No devices connected on this machine yet. Use the pairing command in Diagnostics to connect another device.',
-      ),
-    );
-    return;
-  }
-
-  peers.forEach((peer) => {
-    const card = el('div', 'peer-card');
-    const titleRow = el('div', 'peer-title');
-    const peerId = peer.peer_device_id ? String(peer.peer_device_id) : '';
-    if (peerId) card.dataset.peerDeviceId = peerId;
-    const displayName = peer.name || (peerId ? peerId.slice(0, 8) : 'unknown');
-    const destructiveLabel = peer.name || peerId || displayName;
-    const pendingScopeReview = isPeerScopeReviewPending(peerId);
-    const name = el('strong', null, displayName);
-    if (peerId) name.title = peerId;
-
-    const peerStatus = peer.status || {};
-    const trustSummary = derivePeerTrustSummary(peer);
-    const badge = el(
-      'span',
-      `badge ${trustSummary.isWarning ? 'badge-offline' : 'badge-online'}`,
-      trustSummary.badgeLabel,
-    );
-    name.append(' ', badge);
-    if (pendingScopeReview) {
-      name.append(' ', el('span', 'badge actor-badge', 'Needs scope review'));
-    }
-
-    const actions = el('div', 'peer-actions');
-    const renameInput = document.createElement('input');
-    renameInput.className = 'peer-scope-input';
-    renameInput.value = displayName;
-    if (peerId) renameInput.dataset.deviceNameInput = peerId;
-    renameInput.setAttribute('aria-label', `Friendly name for ${displayName}`);
-    renameInput.placeholder = 'Friendly device name';
-    const renameBtn = el('button', null, 'Save name') as HTMLButtonElement;
-    renameBtn.addEventListener('click', async () => {
-      if (!peerId) return;
-      const nextName = String(renameInput.value || '').trim();
-      if (!nextName) {
-        showGlobalNotice('Enter a friendly name for this device.', 'warning');
-        renameInput.focus();
-        return;
-      }
-      renameBtn.disabled = true;
-      renameInput.disabled = true;
-      renameBtn.textContent = 'Saving…';
+  renderSyncPeersList(syncPeers, {
+    peers: Array.isArray(peers) ? peers : [],
+    onRename: async (peerId, nextName) => {
       try {
         await api.renamePeer(peerId, nextName);
         showGlobalNotice('Device name saved.');
         await _loadSyncData();
       } catch (error) {
         showGlobalNotice(friendlyError(error, 'Failed to save device name.'), 'warning');
-        renameBtn.textContent = 'Retry save';
-      } finally {
-        renameBtn.disabled = false;
-        renameInput.disabled = false;
-        if (renameBtn.textContent === 'Saving…') renameBtn.textContent = 'Save name';
+        throw error;
       }
-    });
-    actions.append(renameInput, renameBtn);
-    const primaryAddress = pickPrimaryAddress(peer.addresses);
-    const syncBtn = el('button', null, 'Sync now') as HTMLButtonElement;
-    syncBtn.disabled = !primaryAddress;
-    syncBtn.addEventListener('click', async () => {
-      if (pendingScopeReview) {
-        const proceed = window.confirm(
-          `Sync scope review is still pending for ${displayName}. Continue with a manual sync anyway?`,
-        );
-        if (!proceed) return;
-      }
-      syncBtn.disabled = true;
-      syncBtn.textContent = 'Syncing\u2026';
+    },
+    onSync: async (peer, address) => {
       try {
-        const result = await api.triggerSync(primaryAddress);
+        const result = await api.triggerSync(address);
         const summary = summarizeSyncRunResult(result);
+        const peerId = String(peer?.peer_device_id || '');
         if (!summary.ok) {
           showGlobalNotice(summary.message, 'warning');
-        } else if (pendingScopeReview) {
+        } else if (peerId && isPeerScopeReviewPending(peerId)) {
+          const displayName = peer?.name || (peerId ? peerId.slice(0, 8) : 'unknown');
           showGlobalNotice(
             `Triggered sync for ${displayName} before scope review was finished. Review scope in this card if you want tighter sharing rules.`,
             'warning',
@@ -295,161 +108,47 @@ export function renderSyncPeers() {
         }
       } catch (error) {
         showGlobalNotice(friendlyError(error, 'Failed to trigger sync.'), 'warning');
-        syncBtn.disabled = false;
-        syncBtn.textContent = 'Sync now';
-        return;
+        throw error;
       }
       try {
         await _loadSyncData();
       } catch {
         showGlobalNotice('Sync started, but the local status view did not refresh yet.', 'warning');
-      } finally {
-        syncBtn.disabled = false;
-        syncBtn.textContent = 'Sync now';
       }
-    });
-    actions.appendChild(syncBtn);
-    const removeBtn = el('button', null, 'Remove peer') as HTMLButtonElement;
-    removeBtn.addEventListener('click', async () => {
-      if (!peerId) return;
-      if (!window.confirm(`Remove peer ${destructiveLabel}? This deletes the local sync peer entry.`)) return;
-      removeBtn.disabled = true;
-      removeBtn.textContent = 'Removing…';
+      return null;
+    },
+    onRemove: async (peerId, label) => {
       try {
         await api.deletePeer(peerId);
-        showGlobalNotice(`Removed peer ${destructiveLabel}.`);
+        showGlobalNotice(`Removed peer ${label}.`);
         await _loadSyncData();
       } catch (error) {
         showGlobalNotice(friendlyError(error, 'Failed to remove peer.'), 'warning');
-        removeBtn.textContent = 'Retry remove';
-      } finally {
-        removeBtn.disabled = false;
-        if (removeBtn.textContent === 'Removing…') removeBtn.textContent = 'Remove peer';
+        throw error;
       }
-    });
-    actions.appendChild(removeBtn);
-    const toggleScopeBtn = el('button', null, 'Edit scope') as HTMLButtonElement;
-    actions.appendChild(toggleScopeBtn);
-
-    const peerAddresses = Array.isArray(peer.addresses)
-      ? Array.from(new Set(peer.addresses.filter(Boolean)))
-      : [];
-    const addressLine = peerAddresses.length
-      ? peerAddresses
-          .map((a: any) => (isSyncRedactionEnabled() ? redactAddress(a) : a))
-          .join(' \u00b7 ')
-      : 'No addresses';
-    const addressLabel = el('div', 'peer-addresses', addressLine);
-
-    const lastSyncAt = peerStatus.last_sync_at || peerStatus.last_sync_at_utc || '';
-    const lastPingAt = peerStatus.last_ping_at || peerStatus.last_ping_at_utc || '';
-    const meta = el(
-      'div',
-      'peer-meta',
-      [
-        lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : 'Sync: never',
-        lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : 'Ping: never',
-      ].join(' \u00b7 '),
-    );
-    const identityMeta = el(
-      'div',
-      'peer-meta',
-      peer.actor_display_name
-        ? `Assigned to ${String(peer.actor_display_name)}${peer.claimed_local_actor ? ' \u00b7 you' : ''}`
-        : 'Unassigned person',
-    );
-    const trustMeta = el('div', 'peer-meta', trustSummary.description);
-
-    const scope = peer.project_scope || {};
-    const includeList = Array.isArray(scope.include) ? scope.include : [];
-    const excludeList = Array.isArray(scope.exclude) ? scope.exclude : [];
-    const effectiveInclude = Array.isArray(scope.effective_include) ? scope.effective_include : [];
-    const effectiveExclude = Array.isArray(scope.effective_exclude) ? scope.effective_exclude : [];
-    const inheritsGlobal = Boolean(scope.inherits_global);
-    const scopePanel = el('div', 'peer-scope');
-    const identityRow = el('div', 'peer-scope-summary');
-    identityRow.textContent = 'Assigned person';
-    const actorRow = el('div', 'peer-actor-row');
-    const actorSelect = document.createElement('select');
-    actorSelect.className = 'sync-actor-select';
-    actorSelect.setAttribute('aria-label', `Assigned person for ${displayName}`);
-    buildActorOptions(String(peer.actor_id || '')).forEach((option) =>
-      actorSelect.appendChild(option),
-    );
-    const applyActorBtn = el('button', 'settings-button', 'Save person') as HTMLButtonElement;
-    const actorHint = el(
-      'div',
-      'peer-scope-effective',
-      assignmentNote(String(peer.actor_id || '')),
-    );
-    actorSelect.addEventListener('change', () => {
-      actorHint.textContent = assignmentNote(actorSelect.value);
-    });
-    applyActorBtn.addEventListener('click', async () => {
-      applyActorBtn.disabled = true;
-      actorSelect.disabled = true;
-      applyActorBtn.textContent = 'Applying\u2026';
+    },
+    onAssignActor: async (peerId, actorId) => {
       try {
-        await api.assignPeerActor(peerId, actorSelect.value || null);
-          showGlobalNotice(actorSelect.value ? 'Device person updated.' : 'Device person cleared.');
+        await api.assignPeerActor(peerId, actorId);
+        showGlobalNotice(actorId ? 'Device person updated.' : 'Device person cleared.');
         await _loadSyncData();
       } catch (error) {
         showGlobalNotice(friendlyError(error, 'Failed to update device person.'), 'warning');
-        applyActorBtn.textContent = 'Retry';
-      } finally {
-        actorSelect.disabled = false;
-        applyActorBtn.disabled = false;
-        if (applyActorBtn.textContent === 'Applying\u2026')
-          applyActorBtn.textContent = 'Save person';
+        throw error;
       }
-    });
-    actorRow.append(actorSelect, applyActorBtn);
-    const scopeSummary = el(
-      'div',
-      'peer-scope-summary',
-      inheritsGlobal
-        ? 'Using global sync scope'
-        : `Device override \u00b7 include: ${includeList.join(', ') || 'all'} \u00b7 exclude: ${excludeList.join(', ') || 'none'}`,
-    );
-    const effectiveSummary = el(
-      'div',
-      'peer-scope-effective',
-      `Effective scope \u00b7 include: ${effectiveInclude.join(', ') || 'all'} \u00b7 exclude: ${effectiveExclude.join(', ') || 'none'}`,
-    );
-    const includeEditor = createChipEditor(includeList, 'Add included project', 'All projects');
-    const excludeEditor = createChipEditor(excludeList, 'Add excluded project', 'No exclusions');
-    const scopeEditorOpen = openPeerScopeEditors.has(peerId);
-    const scopeReviewRequested = consumePeerScopeReviewRequest(peerId);
-    const editorWrap = el('div', `peer-scope-editor-wrap${scopeEditorOpen ? '' : ' collapsed'}`);
-    if (!scopeEditorOpen) editorWrap.inert = true;
-    const inputRow = el('div', 'peer-scope-row');
-    inputRow.append(includeEditor.element, excludeEditor.element);
-    const scopeActions = el('div', 'peer-scope-actions');
-    const saveScopeBtn = el('button', 'settings-button', 'Save scope') as HTMLButtonElement;
-    const inheritBtn = el(
-      'button',
-      'settings-button',
-      'Reset to global scope',
-    ) as HTMLButtonElement;
-    saveScopeBtn.addEventListener('click', async () => {
-      saveScopeBtn.disabled = true;
-      saveScopeBtn.textContent = 'Saving\u2026';
+    },
+    onSaveScope: async (peerId, include, exclude) => {
       try {
-        await api.updatePeerScope(peerId, includeEditor.values(), excludeEditor.values());
+        await api.updatePeerScope(peerId, include, exclude);
         clearPeerScopeReview(peerId);
         showGlobalNotice('Device sync scope saved.');
         await _loadSyncData();
       } catch (error) {
         showGlobalNotice(friendlyError(error, 'Failed to save device scope.'), 'warning');
-        saveScopeBtn.textContent = 'Retry save';
-      } finally {
-        saveScopeBtn.disabled = false;
-        if (saveScopeBtn.textContent === 'Saving\u2026') saveScopeBtn.textContent = 'Save scope';
+        throw error;
       }
-    });
-    inheritBtn.addEventListener('click', async () => {
-      inheritBtn.disabled = true;
-      inheritBtn.textContent = 'Resetting\u2026';
+    },
+    onResetScope: async (peerId) => {
       try {
         await api.updatePeerScope(peerId, null, null, true);
         clearPeerScopeReview(peerId);
@@ -457,49 +156,9 @@ export function renderSyncPeers() {
         await _loadSyncData();
       } catch (error) {
         showGlobalNotice(friendlyError(error, 'Failed to reset device scope.'), 'warning');
-        inheritBtn.textContent = 'Retry reset';
-      } finally {
-        inheritBtn.disabled = false;
-        if (inheritBtn.textContent === 'Resetting\u2026')
-          inheritBtn.textContent = 'Reset to global scope';
+        throw error;
       }
-    });
-    scopeActions.append(saveScopeBtn, inheritBtn);
-    editorWrap.append(inputRow, scopeActions);
-    toggleScopeBtn.textContent = scopeEditorOpen ? 'Hide scope editor' : 'Edit scope';
-    toggleScopeBtn.setAttribute('aria-expanded', String(scopeEditorOpen));
-    toggleScopeBtn.addEventListener('click', () => {
-      const isCollapsed = editorWrap.classList.contains('collapsed');
-      editorWrap.classList.toggle('collapsed', !isCollapsed);
-      editorWrap.inert = !isCollapsed;
-      if (!isCollapsed) openPeerScopeEditors.delete(peerId);
-      else openPeerScopeEditors.add(peerId);
-      toggleScopeBtn.setAttribute('aria-expanded', String(isCollapsed));
-      toggleScopeBtn.textContent = isCollapsed ? 'Hide scope editor' : 'Edit scope';
-    });
-    if (scopeReviewRequested) {
-      scopePanel.prepend(
-        el(
-          'div',
-          'peer-meta',
-          'Review this device\'s sync scope now. Global defaults apply until you save an override here.',
-        ),
-      );
-      queueMicrotask(() => card.scrollIntoView({ block: 'center', behavior: 'smooth' }));
-    } else if (pendingScopeReview) {
-      scopePanel.prepend(
-        el(
-          'div',
-          'peer-meta',
-          'Scope review still pending. Save an override here or reset to global scope when you are done reviewing. Manual syncs can proceed, but they will use the current effective scope until you change it.',
-        ),
-      );
-    }
-    scopePanel.append(identityRow, identityMeta, trustMeta, actorRow, actorHint, scopeSummary, effectiveSummary, editorWrap);
-
-    titleRow.append(name, actions);
-    card.append(titleRow, addressLabel, meta, scopePanel);
-    syncPeers.appendChild(card);
+    },
   });
 }
 
@@ -507,37 +166,23 @@ export function renderSyncPeers() {
 
 export function renderLegacyDeviceClaims() {
   const panel = document.getElementById('syncLegacyClaims');
-  const select = document.getElementById('syncLegacyDeviceSelect') as HTMLSelectElement | null;
-  const button = document.getElementById('syncLegacyClaimButton') as HTMLButtonElement | null;
+  const mount = document.getElementById('syncLegacyDeviceSelectMount') as HTMLElement | null;
   const meta = document.getElementById('syncLegacyClaimsMeta');
-  if (!panel || !select || !button || !meta) return;
+  if (!panel || !mount || !meta) return;
 
   const devices = Array.isArray(state.lastSyncLegacyDevices) ? state.lastSyncLegacyDevices : [];
-  select.textContent = '';
-  meta.textContent = '';
-  if (!devices.length) {
-    panel.hidden = true;
-    return;
-  }
-
-  panel.hidden = false;
-  devices.forEach((device, index) => {
-    const option = document.createElement('option');
-    const deviceId = String(device.origin_device_id || '').trim();
-    if (!deviceId) return;
-    const count = Number(device.memory_count || 0);
-    const lastSeen = String(device.last_seen_at || '').trim();
-    option.value = deviceId;
-    option.textContent = count > 0 ? `${deviceId} (${count} memories)` : deviceId;
-    if (index === 0) option.selected = true;
-    select.appendChild(option);
-    if (!meta.textContent && lastSeen) {
-      meta.textContent = `Detected from older synced memories. Latest memory: ${formatTimestamp(lastSeen)}`;
-    }
+  renderLegacyClaimsSlice({
+    devices,
+    meta,
+    mount,
+    onValueChange: (value) => {
+      if (value === legacyDeviceValue) return;
+      legacyDeviceValue = value;
+      renderLegacyDeviceClaims();
+    },
+    panel,
+    value: legacyDeviceValue,
   });
-  if (!meta.textContent) {
-    meta.textContent = 'Detected from older synced memories not yet attached to a current device.';
-  }
 }
 
 /* ── Event wiring ────────────────────────────────────────── */
@@ -552,9 +197,6 @@ export function initPeopleEvents(loadSyncData: () => Promise<void>) {
   const syncLegacyClaimButton = document.getElementById(
     'syncLegacyClaimButton',
   ) as HTMLButtonElement | null;
-  const syncLegacyDeviceSelect = document.getElementById(
-    'syncLegacyDeviceSelect',
-  ) as HTMLSelectElement | null;
 
   syncActorCreateButton?.addEventListener('click', async () => {
     if (!syncActorCreateButton || !syncActorCreateInput) return;
@@ -585,7 +227,7 @@ export function initPeopleEvents(loadSyncData: () => Promise<void>) {
   });
 
   syncLegacyClaimButton?.addEventListener('click', async () => {
-    const originDeviceId = String(syncLegacyDeviceSelect?.value || '').trim();
+    const originDeviceId = String(legacyDeviceValue || '').trim();
     if (!originDeviceId || !syncLegacyClaimButton) return;
     if (
       !window.confirm(

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -1,6 +1,6 @@
 /* Team sync card — coordinator onboarding, invites, join requests. */
 
-import { el, copyToClipboard } from '../../lib/dom';
+import { h } from 'preact';
 import { state, setFeedScopeFilter, isSyncRedactionEnabled } from '../../lib/state';
 import * as api from '../../lib/api';
 import { showGlobalNotice } from '../../lib/notice';
@@ -17,15 +17,45 @@ import {
   clearDuplicatePersonDecision,
   saveDuplicatePersonDecision,
 } from './helpers';
+import { clearSyncMount, renderIntoSyncMount } from './components/render-root';
+import { renderTeamSetupDisclosure } from './components/sync-disclosure';
+import { SyncInviteJoinPanels } from './components/sync-invite-join-panels';
+import { SyncSharingReview, type SyncSharingReviewItem } from './components/sync-sharing-review';
+import {
+  TeamSyncPanel,
+  type TeamSyncDiscoveredRow,
+  type TeamSyncPendingJoinRequest,
+  type TeamSyncStatusSummary,
+} from './components/team-sync-panel';
 import { deriveCoordinatorApprovalSummary, SYNC_TERMINOLOGY, summarizeSyncRunResult } from './view-model';
+import { RadixSelect, type RadixSelectOption } from '../../components/primitives/radix-select';
+
+const TEAM_SYNC_ACTIONS_MOUNT_ID = 'syncTeamActionsMount';
+const INVITE_POLICY_OPTIONS: RadixSelectOption[] = [
+  { value: 'auto_admit', label: 'Auto-admit' },
+  { value: 'approval_required', label: 'Approval required' },
+];
+
+let invitePolicyValue: 'auto_admit' | 'approval_required' = 'auto_admit';
+
+function renderAdminSetupDisclosure() {
+  const mount = document.getElementById('syncAdminDisclosureMount') as HTMLElement | null;
+  if (!mount) return;
+  renderTeamSetupDisclosure(mount, {
+    open: adminSetupExpanded,
+    onOpenChange: (open) => {
+      setAdminSetupExpanded(open);
+      renderAdminSetupDisclosure();
+      renderInvitePolicySelect();
+      setInviteOutputVisibility();
+    },
+  });
+}
 
 /* ── DOM placement helpers ───────────────────────────────── */
 
 function ensureInvitePanelInAdminSection() {
-  const invitePanel = document.getElementById('syncInvitePanel');
-  const adminSection = document.getElementById('syncAdminSection');
-  if (!invitePanel || !adminSection) return;
-  if (invitePanel.parentElement !== adminSection) adminSection.appendChild(invitePanel);
+  // Team setup disclosure now renders in-place through Radix collapsible.
 }
 
 function ensureJoinPanelInSetupSection() {
@@ -43,6 +73,45 @@ function setInviteOutputVisibility() {
   syncInviteOutput.hidden = !encoded;
 }
 
+function clearContent(node: HTMLElement | null) {
+  if (node) node.textContent = '';
+}
+
+function renderInvitePolicySelect() {
+  const mount = document.getElementById('syncInvitePolicyMount') as HTMLElement | null;
+  if (!mount) return;
+  renderIntoSyncMount(
+    mount,
+    h(RadixSelect, {
+      ariaLabel: 'Join policy',
+      contentClassName: 'sync-radix-select-content sync-actor-select-content',
+      id: 'syncInvitePolicy',
+      itemClassName: 'sync-radix-select-item',
+      name: 'syncInvitePolicy',
+      onValueChange: (value) => {
+        const nextValue = value === 'approval_required' ? 'approval_required' : 'auto_admit';
+        if (nextValue === invitePolicyValue) return;
+        invitePolicyValue = nextValue;
+        renderInvitePolicySelect();
+      },
+      options: INVITE_POLICY_OPTIONS,
+      triggerClassName: 'sync-radix-select-trigger sync-actor-select',
+      value: invitePolicyValue,
+      viewportClassName: 'sync-radix-select-viewport',
+    }),
+  );
+}
+
+function teardownTeamSyncRender(actions: HTMLElement | null, targets: Array<HTMLElement | null>) {
+  const mount = document.getElementById(TEAM_SYNC_ACTIONS_MOUNT_ID) as HTMLElement | null;
+  if (mount) {
+    clearSyncMount(mount);
+    mount.remove();
+  }
+  clearContent(actions);
+  targets.forEach((target) => clearContent(target));
+}
+
 /* ── Sharing review renderer ─────────────────────────────── */
 
 function openFeedSharingReview() {
@@ -54,11 +123,11 @@ function openFeedSharingReview() {
 export function renderSyncSharingReview() {
   const panel = document.getElementById('syncSharingReview');
   const meta = document.getElementById('syncSharingReviewMeta');
-  const list = document.getElementById('syncSharingReviewList');
+  const list = document.getElementById('syncSharingReviewList') as HTMLElement | null;
   if (!panel || !meta || !list) return;
-  list.textContent = '';
   const items = Array.isArray(state.lastSyncSharingReview) ? state.lastSyncSharingReview : [];
   if (!items.length) {
+    clearSyncMount(list);
     panel.hidden = true;
     return;
   }
@@ -67,31 +136,15 @@ export function renderSyncSharingReview() {
     ? `current project (${state.currentProject})`
     : 'all allowed projects';
   meta.textContent = `Teammates receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
-  items.forEach((item) => {
-    const row = el('div', 'actor-row');
-    const details = el('div', 'actor-details');
-    const title = el('div', 'actor-title');
-    title.append(
-      el('strong', null, String(item.peer_name || item.peer_device_id || 'Device')),
-      el(
-        'span',
-        'badge actor-badge',
-        `person: ${String(item.actor_display_name || item.actor_id || 'unknown')}`,
-      ),
-    );
-    const note = el(
-      'div',
-      'peer-meta',
-      `${Number(item.shareable_count || 0)} share by default \u00b7 ${Number(item.private_count || 0)} marked Only me \u00b7 ${String(item.scope_label || 'All allowed projects')}`,
-    );
-    details.append(title, note);
-    const actions = el('div', 'actor-actions');
-    const reviewBtn = el('button', 'settings-button', 'Review my memories in Feed') as HTMLButtonElement;
-    reviewBtn.addEventListener('click', () => openFeedSharingReview());
-    actions.appendChild(reviewBtn);
-    row.append(details, actions);
-    list.appendChild(row);
-  });
+  const reviewItems: SyncSharingReviewItem[] = items.map((item) => ({
+    actorDisplayName: String(item.actor_display_name || item.actor_id || 'unknown'),
+    actorId: String(item.actor_id || 'unknown'),
+    peerName: String(item.peer_name || item.peer_device_id || 'Device'),
+    privateCount: Number(item.private_count || 0),
+    scopeLabel: String(item.scope_label || 'All allowed projects'),
+    shareableCount: Number(item.shareable_count || 0),
+  }));
+  renderIntoSyncMount(list, h(SyncSharingReview, { items: reviewItems, onReview: openFeedSharingReview }));
 }
 
 /* ── Team sync renderer ──────────────────────────────────── */
@@ -107,30 +160,34 @@ export function renderTeamSync() {
   const setupPanel = document.getElementById('syncSetupPanel');
   const list = document.getElementById('syncTeamStatus');
   const actions = document.getElementById('syncTeamActions');
+  if (!meta || !setupPanel || !list || !actions) return;
+
+  renderAdminSetupDisclosure();
+  renderInvitePolicySelect();
+  setInviteOutputVisibility();
+
   const invitePanel = document.getElementById('syncInvitePanel');
-  const toggleAdmin = document.getElementById('syncToggleAdmin') as HTMLButtonElement | null;
+  const inviteRestoreParent = document.getElementById('syncAdminSection');
   const joinPanel = document.getElementById('syncJoinPanel');
+  const joinRestoreParent = document.getElementById('syncJoinSection');
   const joinRequests = document.getElementById('syncJoinRequests');
   const discoveredPanel = document.getElementById('syncCoordinatorDiscovered');
   const discoveredMeta = document.getElementById('syncCoordinatorDiscoveredMeta');
   const discoveredList = document.getElementById('syncCoordinatorDiscoveredList');
-  if (!meta || !setupPanel || !list || !actions) return;
+
   hideSkeleton('syncTeamSkeleton');
-  // Move panels back to their home sections BEFORE clearing, so they survive the wipe
   ensureInvitePanelInAdminSection();
   ensureJoinPanelInSetupSection();
-  list.textContent = '';
-  actions.textContent = '';
-  if (joinRequests) joinRequests.textContent = '';
-  if (discoveredList) discoveredList.textContent = '';
-  setInviteOutputVisibility();
+
   const coordinator = state.lastSyncCoordinator;
   const syncView = state.lastSyncViewModel || { summary: {}, attentionItems: [] };
 
-  const focusAttentionTarget = (item: any) => {
+  const focusAttentionTarget = (item: { kind?: string; deviceId?: string }) => {
     if (item.kind === 'possible-duplicate-person') {
       const actorList = document.getElementById('syncActorsList');
-      if (actorList instanceof HTMLElement) actorList.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      if (actorList instanceof HTMLElement) {
+        actorList.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
       return;
     }
     const deviceId = String(item.deviceId || '').trim();
@@ -155,8 +212,10 @@ export function renderTeamSync() {
     }
   };
 
-  const reviewDuplicatePeople = async (item: any) => {
-    const actorIds = Array.isArray(item.actorIds) ? item.actorIds.map((value: unknown) => String(value || '').trim()).filter(Boolean) : [];
+  const reviewDuplicatePeople = async (item: { actorIds?: unknown[]; title: string }) => {
+    const actorIds = Array.isArray(item.actorIds)
+      ? item.actorIds.map((value: unknown) => String(value || '').trim()).filter(Boolean)
+      : [];
     const actors = (Array.isArray(state.lastSyncActors) ? state.lastSyncActors : []).filter((actor) =>
       actorIds.includes(String(actor?.actor_id || '').trim()),
     );
@@ -180,7 +239,10 @@ export function renderTeamSync() {
     const localIndex = actors.findIndex((actor) => Boolean(actor?.is_local));
     const defaultChoice = localIndex >= 0 ? String(localIndex + 1) : '1';
     const options = actors
-      .map((actor, index) => `${index + 1} = ${String(actor?.display_name || actor?.actor_id || `Person ${index + 1}`)}${actor?.is_local ? ' (You)' : ''}`)
+      .map(
+        (actor, index) =>
+          `${index + 1} = ${String(actor?.display_name || actor?.actor_id || `Person ${index + 1}`)}${actor?.is_local ? ' (You)' : ''}`,
+      )
       .join('\n');
     const keepAnswer = window.prompt(
       `Which person should remain after combining them?\n\n${options}`,
@@ -216,43 +278,33 @@ export function renderTeamSync() {
     showGlobalNotice(`Saved device name: ${value}.`);
     return true;
   };
+
   const configured = Boolean(coordinator && coordinator.configured);
   meta.textContent = configured
-    ? `Connected to ${String(coordinator.coordinator_url || '')} \u00b7 group: ${(coordinator.groups || []).join(', ') || 'none'}`
+    ? `Connected to ${String(coordinator.coordinator_url || '')} · group: ${(coordinator.groups || []).join(', ') || 'none'}`
     : 'Start here: join an existing team or create a new one before connecting devices and people.';
+
   if (!configured) {
+    teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
     setupPanel.hidden = false;
     list.hidden = true;
     actions.hidden = true;
     if (joinRequests) joinRequests.hidden = true;
     if (discoveredPanel) discoveredPanel.hidden = true;
-    if (invitePanel) invitePanel.hidden = !adminSetupExpanded;
-    if (toggleAdmin) {
-      toggleAdmin.textContent = adminSetupExpanded
-        ? 'Hide team setup'
-        : 'Set up a new team instead\u2026';
-    }
     return;
   }
+
   setupPanel.hidden = true;
   list.hidden = false;
   actions.hidden = false;
-  if (joinRequests) joinRequests.hidden = false;
-  if (discoveredPanel) discoveredPanel.hidden = true;
+
+  const presenceStatus = String(coordinator.presence_status || '');
   const presenceLabel =
-    coordinator.presence_status === 'posted'
+    presenceStatus === 'posted'
       ? 'Connected'
-      : coordinator.presence_status === 'not_enrolled'
-        ? 'Not connected \u2014 import an invite or ask your admin to enroll this device'
+      : presenceStatus === 'not_enrolled'
+        ? 'Not connected — import an invite or ask your admin to enroll this device'
         : 'Connection error';
-  const statusRow = el('div', 'sync-team-summary');
-  const statusLine = el('div', 'sync-team-status-row');
-  const statusLabel = el('span', 'sync-team-status-label', 'Status');
-  const statusBadge = el(
-    'span',
-    `pill ${coordinator.presence_status === 'posted' ? 'pill-success' : coordinator.presence_status === 'not_enrolled' ? 'pill-warning' : 'pill-error'}`,
-    presenceLabel,
-  );
   const metricParts = [
     `Connected devices: ${Number(syncView.summary?.connectedDeviceCount || 0)}`,
     `Seen on team: ${Number(syncView.summary?.seenOnTeamCount || 0)}`,
@@ -260,360 +312,252 @@ export function renderTeamSync() {
   if (Number(syncView.summary?.offlineTeamDeviceCount || 0) > 0) {
     metricParts.push(`Offline on team: ${Number(syncView.summary?.offlineTeamDeviceCount || 0)}`);
   }
-  statusLine.append(statusLabel, statusBadge);
-  statusRow.append(statusLine, el('div', 'sync-team-metrics', metricParts.join(' \u00b7 ')));
-  list.appendChild(statusRow);
+  const statusSummary: TeamSyncStatusSummary = {
+    badgeClassName: `pill ${presenceStatus === 'posted' ? 'pill-success' : presenceStatus === 'not_enrolled' ? 'pill-warning' : 'pill-error'}`,
+    metricsText: metricParts.join(' · '),
+    presenceLabel,
+  };
 
   const localPeers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
   const attentionItems = Array.isArray(syncView.attentionItems) ? syncView.attentionItems : [];
-  if (attentionItems.length) {
-    const heading = el('div', 'sync-action-text');
-    heading.textContent = 'Needs attention';
-    actions.appendChild(heading);
-    attentionItems.slice(0, 4).forEach((item: any) => {
-      const row = el('div', 'sync-action');
-      const textWrap = el('div', 'sync-action-text');
-      textWrap.textContent = item.title;
-      textWrap.appendChild(el('span', 'sync-action-command', item.summary));
-      const actionButton = el('button', 'settings-button', item.actionLabel || 'Review') as HTMLButtonElement;
-      actionButton.addEventListener('click', async () => {
+  const discoveredDevices = Array.isArray(coordinator.discovered_devices)
+    ? coordinator.discovered_devices
+    : [];
+  const discoveredRows: TeamSyncDiscoveredRow[] = discoveredDevices.map((device) => {
+    const deviceId = String(device.device_id || '').trim();
+    const displayName = String(device.display_name || '').trim() || deviceId || 'Discovered device';
+    const fingerprint = String(device.fingerprint || '').trim();
+    const groupIds = Array.isArray(device.groups)
+      ? device.groups.map((value) => String(value || '').trim()).filter(Boolean)
+      : [];
+    const hasAmbiguousCoordinatorGroup = groupIds.length > 1;
+    const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || '') === deviceId);
+    const approvalSummary = deriveCoordinatorApprovalSummary({
+      device,
+      pairedLocally: Boolean(pairedPeer),
+    });
+    const pairedFingerprint = String(pairedPeer?.fingerprint || '').trim();
+    const hasConflict =
+      Boolean(pairedPeer) &&
+      Boolean(fingerprint) &&
+      Boolean(pairedFingerprint) &&
+      pairedFingerprint !== fingerprint;
+    const canAccept =
+      Boolean(deviceId) &&
+      Boolean(fingerprint) &&
+      !pairedPeer &&
+      !device.stale &&
+      !hasAmbiguousCoordinatorGroup;
+    const addresses = Array.isArray(device.addresses) ? device.addresses : [];
+    const addressLabel = addresses.length
+      ? addresses
+          .map((address) =>
+            isSyncRedactionEnabled() ? redactAddress(String(address || '')) : String(address || ''),
+          )
+          .filter(Boolean)
+          .join(' · ')
+      : 'No fresh addresses';
+    const noteParts = [deviceId, addressLabel];
+    let actionMessage: string | null = null;
+    let mode: TeamSyncDiscoveredRow['mode'] = canAccept ? 'accept' : 'none';
+    let pairedMessage: string | null = null;
+
+    if (hasConflict) {
+      noteParts.push('repair the local peer before accepting this discovered device');
+      mode = 'conflict';
+    } else if (hasAmbiguousCoordinatorGroup) {
+      noteParts.push('this device appears in multiple coordinator groups; review team setup before approving it here');
+      actionMessage =
+        'This device is visible through multiple coordinator groups. Fix that team setup first, then approve it here.';
+      mode = 'ambiguous';
+    } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
+      noteParts.push('scope review pending in People');
+      actionMessage = `Review this device's scope in People & devices next.`;
+      mode = 'scope-pending';
+    } else if (pairedPeer?.last_error) {
+      noteParts.push(`paired error: ${String(pairedPeer.last_error)}`);
+      mode = 'paired';
+    } else if (pairedPeer?.status?.peer_state) {
+      noteParts.push(`paired status: ${String(pairedPeer.status.peer_state)}`);
+      mode = 'paired';
+    } else if (!pairedPeer && device.stale) {
+      actionMessage = 'Wait for a fresh coordinator presence update.';
+      mode = 'stale';
+    } else if (pairedPeer) {
+      mode = 'paired';
+    }
+
+    if (approvalSummary.description) noteParts.push(approvalSummary.description);
+    if (mode === 'paired') {
+      pairedMessage =
+        approvalSummary.state === 'waiting-for-other-device'
+          ? approvalSummary.description || 'Waiting on the other device.'
+          : String(pairedPeer?.last_error || '').toLowerCase().includes('401') &&
+              String(pairedPeer?.last_error || '').toLowerCase().includes('unauthorized')
+            ? 'Waiting for the other device to trust this one before sync can work.'
+            : 'Manage this device in People & devices.';
+    }
+
+    return {
+      actionMessage,
+      actionLabel: approvalSummary.actionLabel || 'Review device',
+      approvalBadgeLabel: approvalSummary.badgeLabel,
+      availabilityLabel: device.stale ? 'Offline' : 'Available',
+      connectionLabel: hasConflict
+        ? SYNC_TERMINOLOGY.conflicts
+        : pairedPeer
+          ? SYNC_TERMINOLOGY.pairedLocally
+          : 'Not connected on this device',
+      deviceId,
+      displayName,
+      fingerprint,
+      mode,
+      note: noteParts.join(' · '),
+      pairedMessage,
+    };
+  });
+
+  const pending = Array.isArray(state.lastSyncJoinRequests) ? state.lastSyncJoinRequests : [];
+  const pendingJoinRequests: TeamSyncPendingJoinRequest[] = pending.map((request) => ({
+    displayName: String(request.display_name || request.device_id || 'Pending device'),
+    requestId: String(request.request_id || ''),
+  }));
+
+  if (discoveredPanel) discoveredPanel.hidden = discoveredRows.length === 0;
+  if (discoveredMeta) {
+    discoveredMeta.textContent = discoveredRows.length
+      ? 'These devices are visible through team discovery. Review them before connecting them on this machine.'
+      : '';
+  }
+  if (joinRequests) joinRequests.hidden = pendingJoinRequests.length === 0;
+
+  teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
+  const actionMount = document.createElement('div');
+  actionMount.id = TEAM_SYNC_ACTIONS_MOUNT_ID;
+  actions.appendChild(actionMount);
+
+  renderIntoSyncMount(
+    actionMount,
+    h(TeamSyncPanel, {
+      actionItems: attentionItems,
+      children: h(SyncInviteJoinPanels, {
+        invitePanel,
+        invitePanelOpen: teamInvitePanelOpen,
+        inviteRestoreParent,
+        joinPanel,
+        joinRestoreParent,
+        onToggleInvitePanel: () => {
+          if (!invitePanel) return;
+          setTeamInvitePanelOpen(!teamInvitePanelOpen);
+          renderTeamSync();
+        },
+        pairedPeerCount: Number(coordinator.paired_peer_count || 0),
+        presenceStatus,
+      }),
+      discoveredListMount: discoveredList,
+      discoveredRows,
+      joinRequestsMount: joinRequests,
+      listMount: list,
+      onApproveJoinRequest: async (request) => {
+        try {
+          await api.reviewJoinRequest(request.requestId, 'approve');
+          showGlobalNotice(`Approved ${request.displayName}. They can now sync with the team.`);
+          await _loadSyncData();
+        } catch (error) {
+          showGlobalNotice(friendlyError(error, 'Failed to approve join request.'), 'warning');
+          throw error;
+        }
+      },
+      onAttentionAction: async (item) => {
         if (item.kind === 'possible-duplicate-person') {
           await reviewDuplicatePeople(item);
           return;
         }
         focusAttentionTarget(item);
-      });
-      row.append(textWrap, actionButton);
-      actions.appendChild(row);
-    });
-  } else if (coordinator.presence_status === 'posted') {
-    const row = el('div', 'sync-action');
-    const textWrap = el('div', 'sync-action-text');
-    textWrap.textContent = 'No immediate issues';
-    textWrap.appendChild(
-      el('span', 'sync-action-command', 'Your devices and team records do not currently need review.'),
-    );
-    row.appendChild(textWrap);
-    actions.appendChild(row);
-  } else if (coordinator.presence_status === 'not_enrolled') {
-    const row = el('div', 'sync-action');
-    const textWrap = el('div', 'sync-action-text');
-    textWrap.textContent = 'This device still needs team enrollment';
-    textWrap.appendChild(
-      el('span', 'sync-action-command', 'Import an invite or ask your admin to enroll this device before expecting sync activity here.'),
-    );
-    row.appendChild(textWrap);
-    actions.appendChild(row);
-  }
-
-  const discoveredDevices = Array.isArray(coordinator.discovered_devices)
-    ? coordinator.discovered_devices
-    : [];
-  if (discoveredPanel && discoveredMeta && discoveredList && discoveredDevices.length) {
-    discoveredPanel.hidden = false;
-    discoveredMeta.textContent =
-      'These devices are visible through team discovery. Review them before connecting them on this machine.';
-    discoveredDevices.forEach((device) => {
-      const row = el('div', 'actor-row');
-      const details = el('div', 'actor-details');
-      const title = el('div', 'actor-title');
-      const rowActions = el('div', 'actor-actions');
-      const deviceId = String(device.device_id || '').trim();
-      if (deviceId) row.dataset.discoveredDeviceId = deviceId;
-      const displayName = String(device.display_name || '').trim() || deviceId || 'Discovered device';
-      const fingerprint = String(device.fingerprint || '').trim();
-      const groupIds = Array.isArray(device.groups)
-        ? device.groups.map((value) => String(value || '').trim()).filter(Boolean)
-        : [];
-      const hasAmbiguousCoordinatorGroup = groupIds.length > 1;
-      const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || '') === deviceId);
-      const approvalSummary = deriveCoordinatorApprovalSummary({
-        device,
-        pairedLocally: Boolean(pairedPeer),
-      });
-      const pairedFingerprint = String(pairedPeer?.fingerprint || '').trim();
-      const hasConflict = Boolean(pairedPeer) && Boolean(fingerprint) && Boolean(pairedFingerprint) && pairedFingerprint !== fingerprint;
-      const canAccept =
-        Boolean(deviceId) &&
-        Boolean(fingerprint) &&
-        !pairedPeer &&
-        !device.stale &&
-        !hasAmbiguousCoordinatorGroup;
-      title.append(el('strong', null, displayName));
-      title.appendChild(
-        el(
-          'span',
-          `badge actor-badge${device.stale ? '' : ' local'}`,
-          device.stale ? 'Offline' : 'Available',
-        ),
-      );
-      title.appendChild(
-        el(
-          'span',
-          'badge actor-badge',
-          hasConflict ? SYNC_TERMINOLOGY.conflicts : pairedPeer ? SYNC_TERMINOLOGY.pairedLocally : 'Not connected on this device',
-        ),
-      );
-      if (approvalSummary.badgeLabel) {
-        title.appendChild(el('span', 'badge actor-badge', approvalSummary.badgeLabel));
-      }
-      const addresses = Array.isArray(device.addresses) ? device.addresses : [];
-      const addressLabel = addresses.length
-        ? addresses
-            .map((address) =>
-              isSyncRedactionEnabled() ? redactAddress(String(address || '')) : String(address || ''),
-            )
-            .filter(Boolean)
-            .join(' · ')
-        : 'No fresh addresses';
-      const noteParts = [deviceId, addressLabel];
-      if (hasConflict) {
-        noteParts.push('repair the local peer before accepting this discovered device');
-      } else if (hasAmbiguousCoordinatorGroup) {
-        noteParts.push('this device appears in multiple coordinator groups; review team setup before approving it here');
-      } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
-        noteParts.push('scope review pending in People');
-      } else if (pairedPeer?.last_error) {
-        noteParts.push(`paired error: ${String(pairedPeer.last_error)}`);
-      } else if (pairedPeer?.status?.peer_state) {
-        noteParts.push(`paired status: ${String(pairedPeer.status.peer_state)}`);
-      }
-      if (approvalSummary.description) noteParts.push(approvalSummary.description);
-      details.append(title, el('div', 'peer-meta', noteParts.join(' · ')));
-      if (canAccept) {
-        const acceptBtn = el(
-          'button',
-          'settings-button',
-          approvalSummary.actionLabel || 'Review device',
-        ) as HTMLButtonElement;
-        acceptBtn.addEventListener('click', async () => {
-          acceptBtn.disabled = true;
-          acceptBtn.textContent = 'Opening…';
-          try {
-            const result = await api.acceptDiscoveredPeer(deviceId, fingerprint);
-            requestPeerScopeReview(deviceId);
-            showGlobalNotice(
-              approvalSummary.state === 'needs-your-approval'
-                ? `Approved ${displayName} on this device. Two-way trust should be ready once both devices refresh.`
-                : `Step 1 complete on this device for ${displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
-            );
-            try {
-              await promptForDeviceName(
-                deviceId,
-                String(result?.name || displayName || '').trim() || displayName,
-              );
-            } catch (error) {
-              showGlobalNotice(
-                friendlyError(error, 'Device connected, but naming did not finish.'),
-                'warning',
-              );
-            }
-            try {
-              await _loadSyncData();
-            } catch (error) {
-              showGlobalNotice(
-                friendlyError(error, 'Device connected, but the screen did not refresh yet.'),
-                'warning',
-              );
-            }
-          } catch (error) {
-            showGlobalNotice(friendlyError(error, 'Failed to review this device.'), 'warning');
-            acceptBtn.textContent = 'Retry review';
-          } finally {
-            acceptBtn.disabled = false;
-            if (acceptBtn.textContent === 'Opening…') {
-              acceptBtn.textContent = approvalSummary.actionLabel || 'Review device';
-            }
-          }
-        });
-        rowActions.appendChild(acceptBtn);
-      } else if (!pairedPeer && device.stale) {
-        rowActions.appendChild(el('div', 'peer-meta', 'Wait for a fresh coordinator presence update.'));
-      } else if (!pairedPeer && hasAmbiguousCoordinatorGroup) {
-        rowActions.appendChild(
-          el('div', 'peer-meta', 'This device is visible through multiple coordinator groups. Fix that team setup first, then approve it here.'),
-        );
-      } else if (hasConflict) {
-        const inspectBtn = el('button', 'settings-button', 'Open device details') as HTMLButtonElement;
-        inspectBtn.addEventListener('click', () => {
-          const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(deviceId)}"]`);
-          if (peerCard instanceof HTMLElement) {
-            peerCard.scrollIntoView({ block: 'center', behavior: 'smooth' });
-            showGlobalNotice(`Opened the conflicting local device record for ${displayName}.`, 'warning');
-            return;
-          }
-          showGlobalNotice('The conflicting local device record is not visible yet. Scroll to People & devices and try again.', 'warning');
-        });
-        const removeConflictBtn = el('button', 'settings-button', 'Remove broken device record') as HTMLButtonElement;
-        removeConflictBtn.addEventListener('click', async () => {
-          if (!pairedPeer) return;
-          const confirmed = window.confirm(
-            `Remove the broken local device record for ${displayName}? You can review this device again after the screen refreshes.`,
-          );
-          if (!confirmed) return;
-          removeConflictBtn.disabled = true;
-          inspectBtn.disabled = true;
-            removeConflictBtn.textContent = 'Removing…';
-          try {
-            await api.deletePeer(deviceId);
-            showGlobalNotice(`Removed the broken local device record for ${displayName}. If it is still available, you can review it again from Needs attention.`);
-            await _loadSyncData();
-          } catch (error) {
-            showGlobalNotice(friendlyError(error, 'Failed to remove the broken local device record.'), 'warning');
-            removeConflictBtn.textContent = 'Retry remove';
-          } finally {
-            removeConflictBtn.disabled = false;
-            inspectBtn.disabled = false;
-            if (removeConflictBtn.textContent === 'Removing…') {
-              removeConflictBtn.textContent = 'Remove broken device record';
-            }
-          }
-        });
-        rowActions.append(inspectBtn, removeConflictBtn);
-      } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
-        rowActions.appendChild(el('div', 'peer-meta', 'Review this device\'s scope in People & devices next.'));
-      } else if (pairedPeer) {
-        rowActions.appendChild(
-          el(
-            'div',
-            'peer-meta',
-            approvalSummary.state === 'waiting-for-other-device'
-              ? approvalSummary.description || 'Waiting on the other device.'
-              : String(pairedPeer?.last_error || '').toLowerCase().includes('401') && String(pairedPeer?.last_error || '').toLowerCase().includes('unauthorized')
-                ? 'Waiting for the other device to trust this one before sync can work.'
-                : 'Manage this device in People & devices.',
-          ),
-        );
-      }
-      row.append(details, rowActions);
-      discoveredList.appendChild(row);
-    });
-  }
-
-  const inviteToggleRow = el('div', 'sync-action');
-  const inviteToggleText = el('div', 'sync-action-text');
-  inviteToggleText.textContent = 'Generate an invite to add another teammate to this team.';
-  const inviteToggleBtn = el(
-    'button',
-    'settings-button',
-    'Invite a teammate',
-  ) as HTMLButtonElement;
-  inviteToggleBtn.addEventListener('click', () => {
-    if (!invitePanel) return;
-    setTeamInvitePanelOpen(!teamInvitePanelOpen);
-    if (invitePanel.parentElement !== actions) actions.appendChild(invitePanel);
-    invitePanel.hidden = !teamInvitePanelOpen;
-    inviteToggleBtn.textContent = teamInvitePanelOpen ? 'Hide invite form' : 'Invite a teammate';
-  });
-  inviteToggleRow.append(inviteToggleText, inviteToggleBtn);
-  actions.appendChild(inviteToggleRow);
-  if (invitePanel) {
-    if (teamInvitePanelOpen) {
-      if (invitePanel.parentElement !== actions) actions.appendChild(invitePanel);
-      invitePanel.hidden = false;
-      inviteToggleBtn.textContent = 'Hide invite form';
-    } else {
-      invitePanel.hidden = true;
-    }
-  }
-
-  if (coordinator.presence_status === 'not_enrolled') {
-    if (joinPanel) {
-      if (joinPanel.parentElement !== actions) actions.appendChild(joinPanel);
-      joinPanel.hidden = false;
-    }
-    const row = el('div', 'sync-action');
-    const textWrap = el('div', 'sync-action-text');
-    textWrap.textContent = 'This device is not connected to the team yet.';
-    textWrap.appendChild(
-      el(
-        'span',
-        'sync-action-command',
-        'Import a team invite or ask your admin to enroll this device',
-      ),
-    );
-    actions.appendChild(row);
-    row.appendChild(textWrap);
-  }
-  if (!Number(coordinator.paired_peer_count || 0) && coordinator.presence_status === 'posted') {
-    const row = el('div', 'sync-action');
-    const textWrap = el('div', 'sync-action-text');
-    textWrap.textContent = 'No devices are paired yet.';
-    textWrap.appendChild(
-      el('span', 'sync-action-command', 'codemem sync pair --payload-only'),
-    );
-    const btn = el('button', 'settings-button sync-action-copy', 'Copy') as HTMLButtonElement;
-    btn.addEventListener('click', () =>
-      copyToClipboard('codemem sync pair --payload-only', btn),
-    );
-    row.append(textWrap, btn);
-    actions.appendChild(row);
-  }
-
-  const pending = Array.isArray(state.lastSyncJoinRequests) ? state.lastSyncJoinRequests : [];
-  if (joinRequests && pending.length) {
-    const title = el(
-      'div',
-      'peer-meta',
-      `${pending.length} pending join request${pending.length === 1 ? '' : 's'}`,
-    );
-    joinRequests.appendChild(title);
-    pending.forEach((request) => {
-      const row = el('div', 'actor-row');
-      const details = el('div', 'actor-details');
-      const name = String(request.display_name || request.device_id || 'Pending device');
-      details.append(
-        el('div', 'actor-title', name),
-        el('div', 'peer-meta', `request: ${String(request.request_id || '')}`),
-      );
-      const rowActions = el('div', 'actor-actions');
-      const approveBtn = el('button', 'settings-button', 'Approve') as HTMLButtonElement;
-      const denyBtn = el('button', 'settings-button', 'Deny') as HTMLButtonElement;
-      approveBtn.addEventListener('click', async () => {
-        approveBtn.disabled = true;
-        denyBtn.disabled = true;
-        approveBtn.textContent = 'Approving\u2026';
-        try {
-          await api.reviewJoinRequest(String(request.request_id || ''), 'approve');
-          showGlobalNotice(`Approved ${name}. They can now sync with the team.`);
-          await _loadSyncData();
-        } catch (error) {
-          showGlobalNotice(friendlyError(error, 'Failed to approve join request.'), 'warning');
-          approveBtn.textContent = 'Retry';
-        } finally {
-          approveBtn.disabled = false;
-          denyBtn.disabled = false;
-        }
-      });
-      denyBtn.addEventListener('click', async () => {
+      },
+      onDenyJoinRequest: async (request) => {
         if (
           !window.confirm(
-            `Deny join request from ${name}? They will need a new invite to try again.`,
+            `Deny join request from ${request.displayName}? They will need a new invite to try again.`,
           )
-        )
+        ) {
           return;
-        approveBtn.disabled = true;
-        denyBtn.disabled = true;
-        denyBtn.textContent = 'Denying\u2026';
+        }
         try {
-          await api.reviewJoinRequest(String(request.request_id || ''), 'deny');
-          showGlobalNotice(`Denied join request from ${name}.`);
+          await api.reviewJoinRequest(request.requestId, 'deny');
+          showGlobalNotice(`Denied join request from ${request.displayName}.`);
           await _loadSyncData();
         } catch (error) {
           showGlobalNotice(friendlyError(error, 'Failed to deny join request.'), 'warning');
-          denyBtn.textContent = 'Retry deny';
-        } finally {
-          approveBtn.disabled = false;
-          denyBtn.disabled = false;
+          throw error;
         }
-      });
-      rowActions.append(approveBtn, denyBtn);
-      row.append(details, rowActions);
-      joinRequests.appendChild(row);
-    });
-  } else if (joinRequests) {
-    joinRequests.hidden = true;
-  }
+      },
+      onInspectConflict: (row) => {
+        const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(row.deviceId)}"]`);
+        if (peerCard instanceof HTMLElement) {
+          peerCard.scrollIntoView({ block: 'center', behavior: 'smooth' });
+          showGlobalNotice(`Opened the conflicting local device record for ${row.displayName}.`, 'warning');
+          return;
+        }
+        showGlobalNotice(
+          'The conflicting local device record is not visible yet. Scroll to People & devices and try again.',
+          'warning',
+        );
+      },
+      onRemoveConflict: async (row) => {
+        const confirmed = window.confirm(
+          `Remove the broken local device record for ${row.displayName}? You can review this device again after the screen refreshes.`,
+        );
+        if (!confirmed) return;
+        try {
+          await api.deletePeer(row.deviceId);
+          showGlobalNotice(
+            `Removed the broken local device record for ${row.displayName}. If it is still available, you can review it again from Needs attention.`,
+          );
+          await _loadSyncData();
+        } catch (error) {
+          showGlobalNotice(friendlyError(error, 'Failed to remove the broken local device record.'), 'warning');
+          throw error;
+        }
+      },
+      onReviewDiscoveredDevice: async (row) => {
+        try {
+          const result = await api.acceptDiscoveredPeer(row.deviceId, row.fingerprint);
+          requestPeerScopeReview(row.deviceId);
+          showGlobalNotice(
+            row.approvalBadgeLabel === 'Needs your approval'
+              ? `Approved ${row.displayName} on this device. Two-way trust should be ready once both devices refresh.`
+              : `Step 1 complete on this device for ${row.displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
+          );
+          try {
+            await promptForDeviceName(
+              row.deviceId,
+              String(result?.name || row.displayName || '').trim() || row.displayName,
+            );
+          } catch (error) {
+            showGlobalNotice(
+              friendlyError(error, 'Device connected, but naming did not finish.'),
+              'warning',
+            );
+          }
+          try {
+            await _loadSyncData();
+          } catch (error) {
+            showGlobalNotice(
+              friendlyError(error, 'Device connected, but the screen did not refresh yet.'),
+              'warning',
+            );
+          }
+        } catch (error) {
+          showGlobalNotice(friendlyError(error, 'Failed to review this device.'), 'warning');
+          throw error;
+        }
+      },
+      pendingJoinRequests,
+      presenceStatus,
+      statusSummary,
+    }),
+  );
 }
 
 /* ── Event wiring ────────────────────────────────────────── */
@@ -622,14 +566,14 @@ export function initTeamSyncEvents(
   refreshCallback: () => void,
   loadSyncData: () => Promise<void>,
 ) {
+  renderAdminSetupDisclosure();
+  renderInvitePolicySelect();
+
   const syncNowButton = document.getElementById('syncNowButton') as HTMLButtonElement | null;
-  const syncToggleAdmin = document.getElementById('syncToggleAdmin') as HTMLButtonElement | null;
-  const syncInvitePanel = document.getElementById('syncInvitePanel');
   const syncCreateInviteButton = document.getElementById(
     'syncCreateInviteButton',
   ) as HTMLButtonElement | null;
   const syncInviteGroup = document.getElementById('syncInviteGroup') as HTMLInputElement | null;
-  const syncInvitePolicy = document.getElementById('syncInvitePolicy') as HTMLSelectElement | null;
   const syncInviteTtl = document.getElementById('syncInviteTtl') as HTMLInputElement | null;
   const syncInviteOutput = document.getElementById(
     'syncInviteOutput',
@@ -637,21 +581,10 @@ export function initTeamSyncEvents(
   const syncJoinButton = document.getElementById('syncJoinButton') as HTMLButtonElement | null;
   const syncJoinInvite = document.getElementById('syncJoinInvite') as HTMLTextAreaElement | null;
 
-  syncToggleAdmin?.addEventListener('click', () => {
-    if (!syncInvitePanel) return;
-    setAdminSetupExpanded(!adminSetupExpanded);
-    syncInvitePanel.hidden = !adminSetupExpanded;
-    syncToggleAdmin.setAttribute('aria-expanded', String(adminSetupExpanded));
-    syncToggleAdmin.textContent = adminSetupExpanded
-      ? 'Hide team setup'
-      : 'Set up a new team instead\u2026';
-  });
-
   syncCreateInviteButton?.addEventListener('click', async () => {
     if (
       !syncCreateInviteButton ||
       !syncInviteGroup ||
-      !syncInvitePolicy ||
       !syncInviteTtl ||
       !syncInviteOutput
     )
@@ -675,7 +608,7 @@ export function initTeamSyncEvents(
     try {
       const result = await api.createCoordinatorInvite({
         group_id: groupName,
-        policy: syncInvitePolicy.value as 'auto_admit' | 'approval_required',
+        policy: invitePolicyValue,
         ttl_hours: ttlValue || 24,
       });
       state.lastTeamInvite = result;


### PR DESCRIPTION
## Description

Migrates the sync tab from imperative DOM assembly to Preact-rendered slices and moves the remaining sync interactive controls onto Radix-backed primitives. This keeps the existing sync flows and CSS hooks intact while putting the heaviest viewer tab onto the new component framework.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- Ran `pnpm --filter @codemem/ui typecheck`
- Ran `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
