### PR TITLE
feat(sync): replace coordinator popups with radix dialogs

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -540,10 +540,10 @@
       .sync-redact-switch {
         width: 34px;
         height: 20px;
-        border: 1px solid var(--control-border);
+        border: 1px solid color-mix(in srgb, var(--text-tertiary) 42%, var(--control-border));
         border-radius: var(--radius-pill);
-        background: var(--surface-1);
-        box-shadow: inset 0 0 0 1px transparent;
+        background: color-mix(in srgb, var(--surface-1) 82%, var(--surface-0));
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-tertiary) 8%, transparent);
         cursor: pointer;
         flex-shrink: 0;
         padding: 1px;
@@ -551,7 +551,7 @@
       }
 
       .sync-redact-switch:hover {
-        border-color: var(--control-hover-border);
+        border-color: color-mix(in srgb, var(--accent) 38%, var(--control-hover-border));
       }
 
       .sync-redact-switch:focus-visible {
@@ -560,9 +560,9 @@
       }
 
       .sync-redact-switch[data-state="checked"] {
-        background: var(--control-bg);
-        border-color: var(--control-hover-border);
-        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
+        background: color-mix(in srgb, var(--accent) 18%, var(--surface-1));
+        border-color: color-mix(in srgb, var(--accent) 54%, var(--control-hover-border));
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
       }
 
       .sync-redact-switch-thumb {
@@ -570,15 +570,17 @@
         width: 16px;
         height: 16px;
         border-radius: 50%;
-        background: var(--surface-0);
-        box-shadow: var(--shadow-sm);
+        background: color-mix(in srgb, var(--surface-0) 88%, white);
+        border: 1px solid color-mix(in srgb, var(--text-tertiary) 24%, transparent);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
         transition: transform 0.15s ease, background 0.15s ease;
         transform: translateX(0);
       }
 
       .sync-redact-switch[data-state="checked"] .sync-redact-switch-thumb {
         transform: translateX(14px);
-        background: var(--accent);
+        background: color-mix(in srgb, var(--accent) 88%, white);
+        border-color: color-mix(in srgb, var(--accent) 42%, transparent);
       }
 
       /* ── Selects / inputs ──────────────────────────────────── */
@@ -1514,6 +1516,38 @@
         transition: background 0.15s ease;
       }
       .settings-save:hover { background: var(--control-hover-bg); }
+      .sync-dialog-card {
+        width: min(560px, 100%);
+      }
+      .sync-dialog-actions {
+        display: flex;
+        gap: var(--sp-2);
+        align-items: center;
+      }
+      .sync-dialog-input {
+        width: 100%;
+        padding: var(--sp-2) var(--sp-3);
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--input-bg);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 13px;
+      }
+      .sync-dialog-input:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--focus-ring);
+      }
+      .sync-dialog-confirm.danger {
+        background: rgba(182, 75, 47, 0.12);
+        border-color: rgba(182, 75, 47, 0.28);
+        color: var(--accent-warm);
+      }
+      .sync-dialog-confirm.danger:hover {
+        background: rgba(182, 75, 47, 0.18);
+        border-color: rgba(182, 75, 47, 0.38);
+      }
       .settings-save:disabled { opacity: 0.6; cursor: not-allowed; }
       .settings-note { color: var(--text-tertiary); font-size: 12px; }
 

--- a/packages/ui/src/components/primitives/radix-dialog.tsx
+++ b/packages/ui/src/components/primitives/radix-dialog.tsx
@@ -41,25 +41,34 @@ export function RadixDialog({
 }: RadixDialogProps) {
   return (
     <Dialog.Root modal={modal} open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal forceMount>
-        <Dialog.Overlay asChild forceMount>
-          <div className={overlayClassName} hidden={!open} id={overlayId} />
-        </Dialog.Overlay>
-        <Dialog.Content
-          aria-describedby={ariaDescribedby}
-          aria-labelledby={ariaLabelledby}
-          asChild
-          forceMount
-          onCloseAutoFocus={onCloseAutoFocus}
-          onEscapeKeyDown={onEscapeKeyDown}
-          onInteractOutside={onInteractOutside}
-          onOpenAutoFocus={onOpenAutoFocus}
-        >
-          <div className={contentClassName} hidden={!open} id={contentId} tabIndex={-1}>
-            {children ?? (slotId ? <div id={slotId} /> : null)}
-          </div>
-        </Dialog.Content>
-      </Dialog.Portal>
+      {open ? (
+        <Dialog.Portal>
+          <Dialog.Overlay asChild>
+            <div className={overlayClassName} id={overlayId} />
+          </Dialog.Overlay>
+          <Dialog.Content
+            aria-describedby={ariaDescribedby}
+            aria-labelledby={ariaLabelledby}
+            asChild
+            onCloseAutoFocus={onCloseAutoFocus}
+            onEscapeKeyDown={onEscapeKeyDown}
+            onInteractOutside={onInteractOutside}
+            onOpenAutoFocus={onOpenAutoFocus}
+          >
+            <div
+              className={contentClassName}
+              id={contentId}
+              onClick={(event) => {
+                if (event.target !== event.currentTarget) return;
+                onOpenChange(false);
+              }}
+              tabIndex={-1}
+            >
+              {children ?? (slotId ? <div id={slotId} /> : null)}
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      ) : null}
     </Dialog.Root>
   );
 }

--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -43,8 +43,8 @@ function SyncDisclosure({
   }, [contentId, triggerId, open]);
 
   const content = (
-    <Collapsible.Content forceMount asChild>
-      <div ref={contentRef} id={contentId} className={contentClassName}>
+    <Collapsible.Content asChild>
+      <div ref={contentRef} id={contentId} className={contentClassName} hidden={!open}>
         {children}
       </div>
     </Collapsible.Content>
@@ -155,13 +155,9 @@ function PairingDisclosure({ contentHost, open, onOpenChange }: PairingDisclosur
         </div>
       </div>
       <div className="pairing-body">
-        <pre id="pairingPayload" style={{ userSelect: 'all' }}>
-          Loading…
-        </pre>
+        <pre id="pairingPayload" style={{ userSelect: 'all' }} />
       </div>
-      <div className="peer-meta" id="pairingHint">
-        Copy and run on the other device. Use --include/--exclude to control which projects sync.
-      </div>
+      <div className="peer-meta" id="pairingHint" />
     </SyncDisclosure>
   );
 }

--- a/packages/ui/src/tabs/sync/components/sync-legacy-claims.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-legacy-claims.tsx
@@ -66,7 +66,6 @@ export function renderLegacyClaimsSlice(input: {
       contentClassName="sync-radix-select-content sync-legacy-select-content"
       id="syncLegacyDeviceSelect"
       itemClassName="sync-radix-select-item"
-      name="syncLegacyDeviceSelect"
       onValueChange={input.onValueChange}
       options={options}
       triggerClassName="sync-radix-select-trigger sync-legacy-select"

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -9,6 +9,7 @@ import { renderSyncStatus, renderSyncAttempts, renderPairing, initDiagnosticsEve
 import { renderTeamSync, renderSyncSharingReview, initTeamSyncEvents, setLoadSyncData as setTeamSyncLoadData } from './team-sync';
 import { renderSyncActors, renderSyncPeers, renderLegacyDeviceClaims, initPeopleEvents, setLoadSyncData as setPeopleLoadData } from './people';
 import { ensureSyncRenderBoundary } from './components/render-root';
+import { ensureSyncDialogHost } from './sync-dialogs';
 import { hideSkeleton, readDuplicatePersonDecisions } from './helpers';
 
 /* ── Re-exports consumed by app.ts ───────────────────────── */
@@ -142,6 +143,7 @@ export async function loadPairingData() {
 
 export function initSyncTab(refreshCallback: () => void) {
   ensureSyncRenderBoundary();
+  ensureSyncDialogHost();
   // Wire cross-module callbacks to avoid circular imports
   setTeamSyncLoadData(loadSyncData);
   setPeopleLoadData(loadSyncData);

--- a/packages/ui/src/tabs/sync/sync-dialogs.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs.tsx
@@ -1,0 +1,350 @@
+import { render } from 'preact';
+import { useEffect, useMemo, useState } from 'preact/hooks';
+import { RadixDialog } from '../../components/primitives/radix-dialog';
+
+type DialogTone = 'default' | 'danger';
+
+type ConfirmDialogRequest = {
+  kind: 'confirm';
+  cancelLabel?: string;
+  confirmLabel?: string;
+  description: string;
+  tone?: DialogTone;
+  title: string;
+};
+
+type InputDialogRequest = {
+  kind: 'input';
+  cancelLabel?: string;
+  confirmLabel?: string;
+  description: string;
+  initialValue?: string;
+  placeholder?: string;
+  title: string;
+  validate?: (value: string) => string | null;
+};
+
+export type DuplicatePersonActorOption = {
+  actorId: string;
+  isLocal?: boolean;
+  label: string;
+};
+
+type DuplicatePersonDialogResult =
+  | { action: 'cancel' }
+  | { action: 'different-people' }
+  | { action: 'merge'; primaryActorId: string; secondaryActorId: string };
+
+type DuplicatePersonDialogRequest = {
+  actors: DuplicatePersonActorOption[];
+  kind: 'duplicate-person';
+  summary: string;
+  title: string;
+};
+
+type SyncDialogRequest = ConfirmDialogRequest | InputDialogRequest | DuplicatePersonDialogRequest;
+type SyncDialogResult = boolean | string | null | DuplicatePersonDialogResult;
+
+let dialogMount: HTMLElement | null = null;
+let currentRequest: SyncDialogRequest | null = null;
+let resolveDialog: ((value: SyncDialogResult) => void) | null = null;
+let setHostRequest: ((request: SyncDialogRequest | null) => void) | null = null;
+
+function fallbackResult(request: SyncDialogRequest | null): SyncDialogResult {
+  if (!request) return null;
+  if (request.kind === 'confirm') return false;
+  if (request.kind === 'input') return null;
+  return { action: 'cancel' };
+}
+
+function ensureDialogAvailable(requestKind: SyncDialogRequest['kind']): boolean {
+  if (!currentRequest || !resolveDialog) return true;
+  console.warn(`Ignored sync ${requestKind} dialog request because another sync dialog is already open.`);
+  return false;
+}
+
+function setRequest(nextRequest: SyncDialogRequest | null) {
+  currentRequest = nextRequest;
+  setHostRequest?.(nextRequest);
+}
+
+function resolveCurrentDialog(value: SyncDialogResult) {
+  const resolver = resolveDialog;
+  resolveDialog = null;
+  setRequest(null);
+  resolver?.(value);
+}
+
+function dialogToneClassName(tone: DialogTone | undefined) {
+  return tone === 'danger' ? 'sync-dialog-confirm danger' : 'sync-dialog-confirm';
+}
+
+function SyncDialogHost() {
+  const [request, setDialogState] = useState<SyncDialogRequest | null>(currentRequest);
+
+  useEffect(() => {
+    setHostRequest = setDialogState;
+    return () => {
+      if (setHostRequest === setDialogState) setHostRequest = null;
+    };
+  }, []);
+
+  const open = Boolean(request);
+  const titleId = useMemo(() => `sync-dialog-title-${request?.kind || 'none'}`, [request?.kind]);
+  const descriptionId = useMemo(() => `sync-dialog-description-${request?.kind || 'none'}`, [request?.kind]);
+
+  if (!request) return null;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) return;
+    resolveCurrentDialog(request?.kind === 'confirm' ? false : null);
+  };
+
+  const handleOpenAutoFocus = (event: Event) => {
+    const primary = document.querySelector<HTMLElement>('#syncDialog [data-sync-primary-action="true"]');
+    if (!primary) return;
+    event.preventDefault();
+    primary.focus();
+  };
+
+  const body = request ? <SyncDialogBody descriptionId={descriptionId} request={request} titleId={titleId} /> : null;
+
+  return (
+    <RadixDialog
+      ariaDescribedby={descriptionId}
+      ariaLabelledby={titleId}
+      contentClassName="modal"
+      contentId="syncDialog"
+      onOpenAutoFocus={handleOpenAutoFocus}
+      onOpenChange={handleOpenChange}
+      open={open}
+      overlayClassName="modal-backdrop"
+      overlayId="syncDialogBackdrop"
+    >
+      {body}
+    </RadixDialog>
+  );
+}
+
+function SyncDialogBody({
+  descriptionId,
+  request,
+  titleId,
+}: {
+  descriptionId: string;
+  request: SyncDialogRequest;
+  titleId: string;
+}) {
+  const [inputValue, setInputValue] = useState(request.kind === 'input' ? request.initialValue || '' : '');
+  const [errorText, setErrorText] = useState<string | null>(null);
+  const supportsLabels = request.kind !== 'duplicate-person';
+  const inputErrorId = 'syncDialogInputError';
+
+  useEffect(() => {
+    if (request.kind === 'input') {
+      setInputValue(request.initialValue || '');
+      setErrorText(null);
+    }
+  }, [request]);
+
+  const cancelLabel = supportsLabels ? request.cancelLabel || 'Cancel' : 'Cancel';
+  const confirmLabel = supportsLabels ? request.confirmLabel || (request.kind === 'confirm' ? 'Confirm' : 'Save') : 'Confirm';
+
+  const submit = () => {
+    if (request.kind === 'confirm') {
+      resolveCurrentDialog(true);
+      return;
+    }
+    if (request.kind === 'duplicate-person') return;
+    const trimmed = inputValue.trim();
+    const validation = request.validate?.(trimmed) || null;
+    if (validation) {
+      setErrorText(validation);
+      return;
+    }
+    resolveCurrentDialog(trimmed);
+  };
+
+  return (
+    <div className="modal-card sync-dialog-card">
+      <div className="modal-header">
+        <h2 id={titleId}>{request.title}</h2>
+        <button className="modal-close" onClick={() => resolveCurrentDialog(request.kind === 'confirm' ? false : null)} type="button">
+          close
+        </button>
+      </div>
+      <div className="modal-body">
+        {request.kind !== 'duplicate-person' ? <div className="small" id={descriptionId}>{request.description}</div> : null}
+        {request.kind === 'duplicate-person' ? <div className="small" id={descriptionId}>{request.summary}</div> : null}
+        {request.kind === 'input' ? (
+          <div className="field">
+            <input
+              aria-describedby={errorText ? `${descriptionId} ${inputErrorId}` : descriptionId}
+              autoFocus
+              className={errorText ? 'sync-dialog-input sync-field-error' : 'sync-dialog-input'}
+              data-sync-primary-action="true"
+              onInput={(event) => {
+                setInputValue(event.currentTarget.value);
+                if (errorText) setErrorText(null);
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== 'Enter') return;
+                event.preventDefault();
+                submit();
+              }}
+              placeholder={request.placeholder}
+              type="text"
+              value={inputValue}
+            />
+            {errorText ? <div className="sync-field-hint" id={inputErrorId}>{errorText}</div> : null}
+          </div>
+        ) : null}
+        {request.kind === 'duplicate-person' ? <DuplicatePersonDialogContent descriptionId={descriptionId} request={request} /> : null}
+      </div>
+      <div className="modal-footer">
+        <div className="small" />
+        <div className="sync-dialog-actions">
+          <button className="settings-button" onClick={() => resolveCurrentDialog(request.kind === 'confirm' ? false : null)} type="button">
+            {cancelLabel}
+          </button>
+          {request.kind !== 'duplicate-person' ? (
+            <button autoFocus className={`settings-button ${dialogToneClassName(request.kind === 'confirm' ? request.tone : undefined)}`} data-sync-primary-action="true" onClick={submit} type="button">
+              {confirmLabel}
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DuplicatePersonDialogContent({
+  descriptionId,
+  request,
+}: {
+  descriptionId: string;
+  request: DuplicatePersonDialogRequest;
+}) {
+  const [step, setStep] = useState<'choice' | 'merge'>('choice');
+  const defaultPrimary = request.actors.find((actor) => actor.isLocal)?.actorId || request.actors[0]?.actorId || '';
+  const [primaryActorId, setPrimaryActorId] = useState(defaultPrimary);
+  const [secondaryActorId, setSecondaryActorId] = useState('');
+
+  useEffect(() => {
+    setStep('choice');
+    const nextPrimaryActorId = request.actors.find((actor) => actor.isLocal)?.actorId || request.actors[0]?.actorId || '';
+    const nextSecondaryActorId = request.actors.find((actor) => actor.actorId !== nextPrimaryActorId)?.actorId || '';
+    setPrimaryActorId(nextPrimaryActorId);
+    setSecondaryActorId(nextSecondaryActorId);
+  }, [request]);
+
+  const primary = request.actors.find((actor) => actor.actorId === primaryActorId) || request.actors[0];
+  const mergeCandidates = request.actors.filter((actor) => actor.actorId !== primaryActorId);
+  const secondary = mergeCandidates.find((actor) => actor.actorId === secondaryActorId) || mergeCandidates[0];
+
+  return step === 'choice' ? (
+    <div className="sync-dialog-stack">
+      <div className="sync-dialog-choice-list" role="list">
+        <button autoFocus className="settings-button" data-sync-primary-action="true" onClick={() => setStep('merge')} type="button">These are both me</button>
+        <button className="settings-button" onClick={() => resolveCurrentDialog({ action: 'different-people' })} type="button">These are different people</button>
+        <button className="settings-button" onClick={() => resolveCurrentDialog({ action: 'cancel' })} type="button">Decide later</button>
+      </div>
+    </div>
+  ) : (
+    <div className="sync-dialog-stack">
+      <div className="small" id={descriptionId}>Choose which person should remain after combining these duplicates.</div>
+      <div className="sync-dialog-radio-list" role="radiogroup" aria-describedby={descriptionId} aria-label="Person to keep after combining duplicates">
+        {request.actors.map((actor) => (
+          <label className="sync-dialog-radio-option" key={actor.actorId}>
+            <input
+              autoFocus={primaryActorId === actor.actorId}
+              checked={primaryActorId === actor.actorId}
+              data-sync-primary-action={primaryActorId === actor.actorId ? 'true' : undefined}
+              name="syncDuplicatePrimaryActor"
+              onChange={() => setPrimaryActorId(actor.actorId)}
+              type="radio"
+              value={actor.actorId}
+            />
+            <span>{actor.label}{actor.isLocal ? ' (You)' : ''}</span>
+          </label>
+        ))}
+      </div>
+      <div className="field">
+        <label className="small" htmlFor="syncDuplicateSecondaryActor">Person to combine into the selected record</label>
+        <select
+          className="sync-dialog-input"
+          data-sync-primary-action="true"
+          id="syncDuplicateSecondaryActor"
+          value={secondary?.actorId || ''}
+          onChange={(event) => setSecondaryActorId(event.currentTarget.value)}
+        >
+          {mergeCandidates.map((actor) => (
+            <option key={actor.actorId} value={actor.actorId}>
+              {actor.label}{actor.isLocal ? ' (You)' : ''}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="sync-dialog-actions">
+        <button className="settings-button" onClick={() => setStep('choice')} type="button">Back</button>
+        <button
+          className="settings-button"
+          disabled={!primary?.actorId || !secondary?.actorId}
+          onClick={() => {
+            if (!primary?.actorId || !secondary?.actorId) return;
+            resolveCurrentDialog({
+              action: 'merge',
+              primaryActorId: primary.actorId,
+              secondaryActorId: secondary.actorId,
+            });
+          }}
+          type="button"
+        >
+          Combine people
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ensureSyncDialogHost() {
+  if (dialogMount && dialogMount.isConnected) return;
+  dialogMount = document.getElementById('syncDialogMount') as HTMLElement | null;
+  if (!dialogMount) {
+    dialogMount = document.createElement('div');
+    dialogMount.id = 'syncDialogMount';
+    document.body.appendChild(dialogMount);
+  }
+  render(<SyncDialogHost />, dialogMount);
+}
+
+export function openSyncConfirmDialog(request: Omit<ConfirmDialogRequest, 'kind'>): Promise<boolean> {
+  ensureSyncDialogHost();
+  if (!ensureDialogAvailable('confirm')) return Promise.resolve(false);
+  return new Promise<boolean>((resolve) => {
+    resolveDialog = (value) => resolve(Boolean(value));
+    setRequest({ kind: 'confirm', ...request });
+  });
+}
+
+export function openSyncInputDialog(request: Omit<InputDialogRequest, 'kind'>): Promise<string | null> {
+  ensureSyncDialogHost();
+  if (!ensureDialogAvailable('input')) return Promise.resolve(null);
+  return new Promise<string | null>((resolve) => {
+    resolveDialog = (value) => resolve(typeof value === 'string' ? value : null);
+    setRequest({ kind: 'input', ...request });
+  });
+}
+
+export function openDuplicatePersonDialog(
+  request: Omit<DuplicatePersonDialogRequest, 'kind'>,
+): Promise<DuplicatePersonDialogResult> {
+  ensureSyncDialogHost();
+  if (!ensureDialogAvailable('duplicate-person')) {
+    return Promise.resolve(fallbackResult({ kind: 'duplicate-person', ...request }) as DuplicatePersonDialogResult);
+  }
+  return new Promise<DuplicatePersonDialogResult>((resolve) => {
+    resolveDialog = (value) => resolve((value as DuplicatePersonDialogResult) || { action: 'cancel' });
+    setRequest({ kind: 'duplicate-person', ...request });
+  });
+}

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -27,6 +27,7 @@ import {
   type TeamSyncPendingJoinRequest,
   type TeamSyncStatusSummary,
 } from './components/team-sync-panel';
+import { openDuplicatePersonDialog, openSyncConfirmDialog, openSyncInputDialog } from './sync-dialogs';
 import { deriveCoordinatorApprovalSummary, SYNC_TERMINOLOGY, summarizeSyncRunResult } from './view-model';
 import { RadixSelect, type RadixSelectOption } from '../../components/primitives/radix-select';
 
@@ -87,7 +88,6 @@ function renderInvitePolicySelect() {
       contentClassName: 'sync-radix-select-content sync-actor-select-content',
       id: 'syncInvitePolicy',
       itemClassName: 'sync-radix-select-item',
-      name: 'syncInvitePolicy',
       onValueChange: (value) => {
         const nextValue = value === 'approval_required' ? 'approval_required' : 'auto_admit';
         if (nextValue === invitePolicyValue) return;
@@ -223,53 +223,51 @@ export function renderTeamSync() {
       showGlobalNotice('This possible duplicate no longer has enough people to review.', 'warning');
       return;
     }
-    const firstAnswer = window.prompt(
-      `Possible duplicate person: ${item.title.replace(/^Possible duplicate person:\s*/, '')}\n\nChoose an option:\n1 = These are both me\n2 = These are different people\n3 = Decide later`,
-      '1',
-    );
-    const choice = String(firstAnswer || '').trim();
-    if (choice === '2') {
+    const result = await openDuplicatePersonDialog({
+      title: 'Review possible duplicate people',
+      summary: item.title.replace(/^Possible duplicate person:\s*/, ''),
+      actors: actors.map((actor) => ({
+        actorId: String(actor?.actor_id || ''),
+        label: String(actor?.display_name || actor?.actor_id || 'Unknown person'),
+        isLocal: Boolean(actor?.is_local),
+      })),
+    });
+    if (result.action === 'different-people') {
       saveDuplicatePersonDecision(actorIds, 'different-people');
       showGlobalNotice('Okay. I will keep these people separate on this device.');
       await _loadSyncData();
       return;
     }
-    if (choice !== '1') return;
-    clearDuplicatePersonDecision(actorIds);
-    const localIndex = actors.findIndex((actor) => Boolean(actor?.is_local));
-    const defaultChoice = localIndex >= 0 ? String(localIndex + 1) : '1';
-    const options = actors
-      .map(
-        (actor, index) =>
-          `${index + 1} = ${String(actor?.display_name || actor?.actor_id || `Person ${index + 1}`)}${actor?.is_local ? ' (You)' : ''}`,
-      )
-      .join('\n');
-    const keepAnswer = window.prompt(
-      `Which person should remain after combining them?\n\n${options}`,
-      defaultChoice,
-    );
-    const keepIndex = Number.parseInt(String(keepAnswer || defaultChoice), 10) - 1;
-    const primary = actors[keepIndex] ?? actors[0];
-    const secondary = actors.find((actor) => actor !== primary);
+    if (result.action !== 'merge') return;
+    const primary = actors.find((actor) => String(actor?.actor_id || '') === result.primaryActorId);
+    const secondary = actors.find((actor) => String(actor?.actor_id || '') === result.secondaryActorId);
     if (!primary?.actor_id || !secondary?.actor_id) {
       showGlobalNotice('Could not determine which people to combine.', 'warning');
       return;
     }
     try {
       await api.mergeActor(String(primary.actor_id), String(secondary.actor_id));
+      clearDuplicatePersonDecision(actorIds);
       showGlobalNotice(`Combined duplicate people into ${String(primary.display_name || primary.actor_id)}.`);
       await _loadSyncData();
     } catch (error) {
+      try {
+        await _loadSyncData();
+      } catch {}
       showGlobalNotice(friendlyError(error, 'Failed to combine these people.'), 'warning');
     }
   };
 
   const promptForDeviceName = async (deviceId: string, suggestedName: string) => {
-    const nextName = window.prompt(
-      'What should this device be called? You can change it later in People & devices.',
-      suggestedName,
-    );
-    const value = String(nextName || '').trim();
+    const value = await openSyncInputDialog({
+      title: 'Name this device',
+      description: 'Choose a friendly device name. You can change it later in People & devices.',
+      initialValue: suggestedName,
+      placeholder: 'Desk Mini',
+      confirmLabel: 'Save name',
+      cancelLabel: 'Skip for now',
+      validate: (nextValue) => (nextValue.trim() ? null : 'Enter a device name or skip for now.'),
+    });
     if (!value) {
       showGlobalNotice('You can name this device later from People & devices.', 'warning');
       return false;
@@ -476,13 +474,14 @@ export function renderTeamSync() {
         focusAttentionTarget(item);
       },
       onDenyJoinRequest: async (request) => {
-        if (
-          !window.confirm(
-            `Deny join request from ${request.displayName}? They will need a new invite to try again.`,
-          )
-        ) {
-          return;
-        }
+        const confirmed = await openSyncConfirmDialog({
+          title: `Deny join request from ${request.displayName}?`,
+          description: 'They will need a new invite to try joining this team again.',
+          confirmLabel: 'Deny request',
+          cancelLabel: 'Keep request pending',
+          tone: 'danger',
+        });
+        if (!confirmed) return;
         try {
           await api.reviewJoinRequest(request.requestId, 'deny');
           showGlobalNotice(`Denied join request from ${request.displayName}.`);
@@ -505,9 +504,13 @@ export function renderTeamSync() {
         );
       },
       onRemoveConflict: async (row) => {
-        const confirmed = window.confirm(
-          `Remove the broken local device record for ${row.displayName}? You can review this device again after the screen refreshes.`,
-        );
+        const confirmed = await openSyncConfirmDialog({
+          title: `Remove ${row.displayName}?`,
+          description: 'This deletes the broken local device record. You can review this device again after the screen refreshes.',
+          confirmLabel: 'Remove device record',
+          cancelLabel: 'Keep device record',
+          tone: 'danger',
+        });
         if (!confirmed) return;
         try {
           await api.deletePeer(row.deviceId);


### PR DESCRIPTION
## Description

Replaces the coordinator-side native popup flows in Sync with Radix-backed dialogs. This adds the shared sync dialog foundation, migrates discovered-device review naming and destructive confirmations, and replaces the duplicate-person prompt chain with a guided modal while preserving the existing async sync/coordinator behavior.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- Ran `pnpm --filter @codemem/ui typecheck`
- Ran `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
