### PR TITLE
feat(sync): replace remaining people popups with dialogs

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -1,6 +1,7 @@
 import type { TargetedInputEvent } from 'preact';
 import { useEffect, useState } from 'preact/hooks';
 import { renderIntoSyncMount } from './render-root';
+import { openSyncConfirmDialog } from '../sync-dialogs';
 import {
   actorLabel,
   actorMergeNote,
@@ -77,11 +78,14 @@ function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge }: S
     if (!mergeTargetId) return;
     const target = mergeTargets.find((candidate) => String(candidate.actor_id || '') === mergeTargetId);
     if (!target) return;
-    if (
-      !window.confirm(
-        `Combine ${label} into ${actorLabel(target)}? Assigned devices move now, but older memories keep their current stamped provenance for now.`,
-      )
-    ) {
+    const confirmed = await openSyncConfirmDialog({
+      title: `Combine ${label} into ${actorLabel(target)}?`,
+      description: 'Assigned devices move now, but older memories keep their current stamped provenance for now.',
+      confirmLabel: 'Combine people',
+      cancelLabel: 'Keep separate',
+      tone: 'danger',
+    });
+    if (!confirmed) {
       return;
     }
     setMergeBusy(true);

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -4,6 +4,7 @@ import { RadixSelect, type RadixSelectOption } from '../../../components/primiti
 import { formatTimestamp } from '../../../lib/format';
 import { showGlobalNotice } from '../../../lib/notice';
 import { state, isSyncRedactionEnabled } from '../../../lib/state';
+import { openSyncConfirmDialog } from '../sync-dialogs';
 import { PeerScopeCollapsible } from '../peer-scope-collapsible';
 import {
   assignmentNote,
@@ -199,9 +200,12 @@ function SyncPeerCard({
   async function sync() {
     if (!primaryAddress) return;
     if (pendingScopeReview) {
-      const proceed = window.confirm(
-        `Sync scope review is still pending for ${displayName}. Continue with a manual sync anyway?`,
-      );
+      const proceed = await openSyncConfirmDialog({
+        title: `Sync ${displayName} before scope review?`,
+        description: 'This manual sync will use the current effective scope until you finish reviewing and saving the device scope.',
+        confirmLabel: 'Sync anyway',
+        cancelLabel: 'Review scope first',
+      });
       if (!proceed) return;
     }
     setSyncBusy(true);
@@ -214,7 +218,14 @@ function SyncPeerCard({
 
   async function remove() {
     if (!peerId) return;
-    if (!window.confirm(`Remove peer ${destructiveLabel}? This deletes the local sync peer entry.`)) return;
+    const confirmed = await openSyncConfirmDialog({
+      title: `Remove peer ${destructiveLabel}?`,
+      description: 'This deletes the local sync peer entry on this device.',
+      confirmLabel: 'Remove peer',
+      cancelLabel: 'Keep peer',
+      tone: 'danger',
+    });
+    if (!confirmed) return;
     setRemoveBusy(true);
     setRemoveLabel('Removing…');
     let ok = false;

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -14,6 +14,7 @@ import {
   isPeerScopeReviewPending,
   hideSkeleton,
 } from './helpers';
+import { openSyncConfirmDialog } from './sync-dialogs';
 import { renderSyncActorsList } from './components/sync-actors';
 import { renderSyncPeersList } from './components/sync-peers';
 import { renderLegacyClaimsSlice } from './components/sync-legacy-claims';
@@ -229,12 +230,14 @@ export function initPeopleEvents(loadSyncData: () => Promise<void>) {
   syncLegacyClaimButton?.addEventListener('click', async () => {
     const originDeviceId = String(legacyDeviceValue || '').trim();
     if (!originDeviceId || !syncLegacyClaimButton) return;
-    if (
-      !window.confirm(
-        `Attach old device history from ${originDeviceId} to you? This updates legacy provenance for that device.`,
-      )
-    )
-      return;
+    const confirmed = await openSyncConfirmDialog({
+      title: `Attach history from ${originDeviceId}?`,
+      description: 'This updates legacy provenance so the older device history is attached to you on this device.',
+      confirmLabel: 'Attach history',
+      cancelLabel: 'Cancel',
+      tone: 'danger',
+    });
+    if (!confirmed) return;
     syncLegacyClaimButton.disabled = true;
     const originalText = syncLegacyClaimButton.textContent || 'Attach device history';
     syncLegacyClaimButton.textContent = 'Attaching\u2026';


### PR DESCRIPTION
## Description

Finishes the sync popup cleanup by replacing the remaining people/device confirmation flows with the shared dialog patterns introduced below. This removes the last targeted native popup usage from the sync people/devices surfaces while keeping the existing notices and async update behavior intact.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- Ran `pnpm --filter @codemem/ui typecheck`
- Ran `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
