### PR TITLE
fix(worker): narrow cloudflare worker tsconfig root dir

### DIFF
--- a/packages/cloudflare-coordinator-worker/tsconfig.json
+++ b/packages/cloudflare-coordinator-worker/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": ".",
+		"rootDir": "src",
+		"outDir": "dist",
 		"lib": ["ES2022", "DOM"],
 		"types": ["@cloudflare/workers-types"]
 	},


### PR DESCRIPTION
## Description

Narrows the Cloudflare coordinator worker TypeScript config to compile from `src` and emit to `dist`. This fixes the Linux build issue caused by using `rootDir: "."` for the package instead of the actual source root.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- Ran `pnpm --filter @codemem/cloudflare-coordinator-worker exec tsc -p tsconfig.json --noEmit`
- Ran `pnpm --filter @codemem/cloudflare-coordinator-worker build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
