### PR TITLE
fix(sync): clarify 'You' identity across devices

### DIFF
--- a/packages/ui/src/components/primitives/radix-select.tsx
+++ b/packages/ui/src/components/primitives/radix-select.tsx
@@ -1,5 +1,15 @@
 import * as Select from '@radix-ui/react-select';
 
+const EMPTY_SENTINEL = '__codemem-empty-select__';
+
+function encodeValue(value: string): string {
+  return value === '' ? EMPTY_SENTINEL : value;
+}
+
+function decodeValue(value: string): string {
+  return value === EMPTY_SENTINEL ? '' : value;
+}
+
 export type RadixSelectOption = {
   value: string;
   label: string;
@@ -35,11 +45,13 @@ export function RadixSelect({
   value,
   viewportClassName,
 }: RadixSelectProps) {
+  const encodedValue = value ? encodeValue(value) : undefined;
+
   return (
     <Select.Root
       disabled={disabled}
-      onValueChange={onValueChange}
-      value={value || undefined}
+      onValueChange={(nextValue) => onValueChange(decodeValue(nextValue))}
+      value={encodedValue}
     >
       <Select.Trigger
         aria-label={ariaLabel ?? placeholder}
@@ -58,10 +70,10 @@ export function RadixSelect({
           <Select.Viewport className={viewportClassName}>
             {options.map((option) => (
               <Select.Item
-                key={option.value}
+                key={encodeValue(option.value)}
                 className={itemClassName}
                 disabled={option.disabled}
-                value={option.value}
+                value={encodeValue(option.value)}
               >
                 <Select.ItemText>{option.label}</Select.ItemText>
                 <Select.ItemIndicator className="sync-radix-select-indicator">✓</Select.ItemIndicator>

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -52,6 +52,7 @@ export const state = {
   lastSyncStatus: null as any,
   lastSyncActors: [] as any[],
   lastSyncPeers: [] as any[],
+  pendingAcceptedSyncPeers: [] as any[],
   lastSyncSharingReview: [] as any[],
   lastSyncCoordinator: null as any,
   lastSyncJoinRequests: [] as any[],

--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'preact/hooks';
 import { renderIntoSyncMount } from './render-root';
 import { openSyncConfirmDialog } from '../sync-dialogs';
 import {
+  actorDisplayLabel,
   actorLabel,
   actorMergeNote,
   assignedActorCount,
@@ -26,9 +27,9 @@ type SyncActorsListProps = {
 
 function localActorNote(hiddenLocalDuplicateCount: number): string {
   if (hiddenLocalDuplicateCount <= 0) {
-    return 'Used for this device and same-person devices.';
+    return 'Represents you across your devices.';
   }
-  return `Used for this device and same-person devices. ${hiddenLocalDuplicateCount} unresolved duplicate ${hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden until reviewed in Needs attention.`;
+  return `Represents you across your devices. ${hiddenLocalDuplicateCount} unresolved duplicate ${hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden until reviewed in Needs attention.`;
 }
 
 function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge }: SyncActorRowProps) {
@@ -106,9 +107,9 @@ function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge }: S
     <div className="actor-row">
       <div className="actor-details">
         <div className="actor-title">
-          <strong>{label}</strong>
+          <strong>{actorDisplayLabel(actor)}</strong>
           <span className={`badge actor-badge${actor.is_local ? ' local' : ''}`}>
-            {actor.is_local ? 'Local' : `${count} device${count === 1 ? '' : 's'}`}
+            {actor.is_local ? 'You' : `${count} device${count === 1 ? '' : 's'}`}
           </span>
         </div>
         <div className="peer-meta">
@@ -146,7 +147,7 @@ function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge }: S
                   const targetId = String(target.actor_id || '');
                   return (
                     <option key={targetId} value={targetId}>
-                      {target.is_local ? `${actorLabel(target)} (local)` : actorLabel(target)}
+                      {target.is_local ? actorDisplayLabel(target) : actorLabel(target)}
                     </option>
                   );
                 })}

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -7,7 +7,9 @@ import { state, isSyncRedactionEnabled } from '../../../lib/state';
 import { openSyncConfirmDialog } from '../sync-dialogs';
 import { PeerScopeCollapsible } from '../peer-scope-collapsible';
 import {
+  actorDisplayLabel,
   assignmentNote,
+  buildActorSelectOptions,
   consumePeerScopeReviewRequest,
   createChipEditor,
   isPeerScopeReviewPending,
@@ -53,20 +55,6 @@ type SyncPeerCardProps = {
 type SyncPeersListProps = Omit<SyncPeerCardProps, 'peer'> & {
   peers: SyncPeer[];
 };
-
-function actorOptions(): RadixSelectOption[] {
-  const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
-  return [
-    { value: '', label: 'No person assigned' },
-    ...actors.map((actor) => {
-      const actorId = String(actor?.actor_id || '');
-      const label = actor.is_local
-        ? `${String(actor.display_name || actorId || 'Unknown person')} (local)`
-        : String(actor.display_name || actorId || 'Unknown person');
-      return { value: actorId, label };
-    }),
-  ].filter((option, index, all) => index === all.findIndex((candidate) => candidate.value === option.value));
-}
 
 function listText(value: unknown): string[] {
   return Array.isArray(value) ? value.map((item) => String(item || '').trim()).filter(Boolean) : [];
@@ -141,6 +129,17 @@ function SyncPeerCard({
   const [saveScopeLabel, setSaveScopeLabel] = useState('Save scope');
   const [resetScopeBusy, setResetScopeBusy] = useState(false);
   const [resetScopeLabel, setResetScopeLabel] = useState('Reset to global scope');
+  const actorSelectOptions = useMemo(() => {
+    const options = buildActorSelectOptions(selectedActorId);
+    const hasSelected = options.some((option) => option.value === selectedActorId);
+    if (selectedActorId && !hasSelected) {
+      options.push({
+        value: selectedActorId,
+        label: peer.claimed_local_actor ? 'You' : String(peer.actor_display_name || 'Current assignment'),
+      });
+    }
+    return options;
+  }, [peer.actor_display_name, peer.claimed_local_actor, selectedActorId, state.lastSyncActors, state.lastSyncPeers, state.lastSyncViewModel]);
 
   const includeEditor = useMemo(
     () => createChipEditor(includeList, 'Add included project', 'All projects'),
@@ -375,7 +374,7 @@ function SyncPeerCard({
         <div className="peer-scope-summary">Assigned person</div>
         <div className="peer-meta">
           {peer.actor_display_name
-            ? `Assigned to ${String(peer.actor_display_name)}${peer.claimed_local_actor ? ' · you' : ''}`
+            ? `Assigned to ${peer.claimed_local_actor ? 'You' : String(peer.actor_display_name)}`
             : 'Unassigned person'}
         </div>
         <div className="peer-meta">{trustSummary.description}</div>
@@ -387,7 +386,8 @@ function SyncPeerCard({
               disabled={applyActorBusy}
               itemClassName="sync-radix-select-item"
               onValueChange={setSelectedActorId}
-              options={actorOptions()}
+              options={actorSelectOptions}
+              placeholder="No person assigned"
               triggerClassName="sync-radix-select-trigger sync-actor-select"
               value={selectedActorId}
               viewportClassName="sync-radix-select-viewport"

--- a/packages/ui/src/tabs/sync/helpers.test.ts
+++ b/packages/ui/src/tabs/sync/helpers.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { state } from '../../lib/state';
+import { actorDisplayLabel, assignmentNote, buildActorSelectOptions } from './helpers';
+
+const originalActors = state.lastSyncActors;
+const originalPeers = state.lastSyncPeers;
+const originalViewModel = state.lastSyncViewModel;
+
+afterEach(() => {
+  state.lastSyncActors = originalActors;
+  state.lastSyncPeers = originalPeers;
+  state.lastSyncViewModel = originalViewModel;
+});
+
+describe('actorDisplayLabel', () => {
+  it('labels the local actor as You', () => {
+    expect(actorDisplayLabel({ actor_id: 'actor-local', display_name: 'Adam', is_local: true })).toBe('You');
+  });
+});
+
+describe('assignmentNote', () => {
+  it('describes local assignment as identity across devices', () => {
+    state.lastSyncActors = [{ actor_id: 'actor-local', display_name: 'Adam', is_local: true }];
+
+    expect(assignmentNote('actor-local')).toContain('identity across your devices');
+  });
+});
+
+describe('buildActorSelectOptions', () => {
+  it('keeps You available while hiding unresolved duplicate people elsewhere', () => {
+    state.lastSyncActors = [
+      { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
+      { actor_id: 'actor-shadow', display_name: 'Adam', is_local: false },
+      { actor_id: 'actor-other', display_name: 'Pat', is_local: false },
+    ];
+    state.lastSyncPeers = [];
+    state.lastSyncViewModel = {
+      duplicatePeople: [
+        {
+          displayName: 'Adam',
+          actorIds: ['actor-local', 'actor-shadow'],
+          includesLocal: true,
+        },
+      ],
+    };
+
+    expect(buildActorSelectOptions()).toEqual([
+      { value: '', label: 'No person assigned' },
+      { value: 'actor-local', label: 'You' },
+      { value: 'actor-other', label: 'Pat' },
+    ]);
+  });
+
+  it('preserves a selected hidden actor so the control never renders blank', () => {
+    state.lastSyncActors = [
+      { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
+      { actor_id: 'actor-shadow', display_name: 'Adam', is_local: false },
+    ];
+    state.lastSyncPeers = [];
+    state.lastSyncViewModel = {
+      duplicatePeople: [
+        {
+          displayName: 'Adam',
+          actorIds: ['actor-local', 'actor-shadow'],
+          includesLocal: true,
+        },
+      ],
+    };
+
+    expect(buildActorSelectOptions('actor-shadow')).toEqual([
+      { value: '', label: 'No person assigned' },
+      { value: 'actor-local', label: 'You' },
+      { value: 'actor-shadow', label: 'Adam' },
+    ]);
+  });
+
+  it('keeps an explicit unassigned choice in the option list', () => {
+    state.lastSyncActors = [{ actor_id: 'actor-local', display_name: 'Adam', is_local: true }];
+    state.lastSyncPeers = [];
+    state.lastSyncViewModel = { duplicatePeople: [] };
+
+    expect(buildActorSelectOptions()).toEqual([
+      { value: '', label: 'No person assigned' },
+      { value: 'actor-local', label: 'You' },
+    ]);
+  });
+});

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -2,6 +2,8 @@
 
 import { el, copyToClipboard } from '../../lib/dom';
 import { state } from '../../lib/state';
+import { deriveVisiblePeopleActors } from './view-model';
+import type { RadixSelectOption } from '../../components/primitives/radix-select';
 
 /* ── Skeleton helpers ────────────────────────────────────── */
 
@@ -131,6 +133,11 @@ export function actorLabel(actor: any): string {
   return displayName;
 }
 
+export function actorDisplayLabel(actor: any): string {
+  if (!actor || typeof actor !== 'object') return 'Unknown person';
+  return actor.is_local ? 'You' : actorLabel(actor);
+}
+
 export function assignedActorCount(actorId: string): number {
   const peers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
   return peers.filter((peer) => String(peer?.actor_id || '') === actorId).length;
@@ -141,9 +148,37 @@ export function assignmentNote(actorId: string): string {
   const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
   const actor = actors.find((item) => String(item?.actor_id || '') === actorId);
   if (actor?.is_local) {
-    return 'Assigning this device to you keeps it in your same-person continuity path, including private sync.';
+    return 'Assigning this device to you keeps it in your identity across your devices, including private sync.';
   }
   return 'This person receives memories from allowed projects by default. Use Only me on a memory when it should stay local.';
+}
+
+export function visibleSyncActors() {
+  return deriveVisiblePeopleActors({
+    actors: state.lastSyncActors,
+    peers: state.lastSyncPeers,
+    duplicatePeople: state.lastSyncViewModel?.duplicatePeople,
+  }).visibleActors;
+}
+
+export function buildActorSelectOptions(selectedActorId = ''): RadixSelectOption[] {
+  const options: RadixSelectOption[] = [{ value: '', label: 'No person assigned' }];
+  const visibleActors = visibleSyncActors();
+  const allActors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
+  const selectedActor = allActors.find((actor) => String(actor?.actor_id || '') === selectedActorId);
+  const actors = selectedActor && !visibleActors.some((actor) => String(actor?.actor_id || '') === selectedActorId)
+    ? [...visibleActors, selectedActor]
+    : visibleActors;
+
+  actors.forEach((actor) => {
+    const actorId = String(actor?.actor_id || '').trim();
+    if (!actorId) return;
+    options.push({ value: actorId, label: actorDisplayLabel(actor) });
+  });
+
+  return options.filter(
+    (option, index, all) => index === all.findIndex((candidate) => candidate.value === option.value),
+  );
 }
 
 export function buildActorOptions(selectedActorId: string): HTMLOptionElement[] {
@@ -153,11 +188,12 @@ export function buildActorOptions(selectedActorId: string): HTMLOptionElement[] 
   unassigned.textContent = 'No person assigned';
   options.push(unassigned);
 
-  const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
-  actors.forEach((actor) => {
+  buildActorSelectOptions(selectedActorId)
+    .filter((option) => option.value)
+    .forEach((selectOption) => {
     const option = document.createElement('option');
-    option.value = String(actor.actor_id || '');
-    option.textContent = actor.is_local ? `${actorLabel(actor)} (local)` : actorLabel(actor);
+    option.value = selectOption.value;
+    option.textContent = selectOption.label;
     option.selected = option.value === selectedActorId;
     options.push(option);
   });
@@ -166,7 +202,7 @@ export function buildActorOptions(selectedActorId: string): HTMLOptionElement[] 
 }
 
 export function mergeTargetActors(actorId: string): any[] {
-  const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
+  const actors = visibleSyncActors();
   return actors.filter((actor) => String(actor?.actor_id || '') !== actorId);
 }
 
@@ -177,7 +213,7 @@ export function actorMergeNote(targetActorId: string, secondaryActorId: string):
   if (!targetActorId || !target) {
     return 'Choose which person should keep these devices.';
   }
-  return `Merge into ${actorLabel(target)}. Assigned devices move now; existing memories keep their current provenance.`;
+  return `Merge into ${actorDisplayLabel(target)}. Assigned devices move now; existing memories keep their current provenance.`;
 }
 
 /* ── Chip editor component ───────────────────────────────── */

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -87,8 +87,21 @@ export async function loadSyncData() {
     const statusPayload =
       payload.status && typeof payload.status === 'object' ? payload.status : null;
     if (statusPayload) state.lastSyncStatus = statusPayload;
-    state.lastSyncActors = Array.isArray(actorsPayload?.items) ? actorsPayload.items : [];
-    state.lastSyncPeers = payload.peers || [];
+    if (Array.isArray(actorsPayload?.items)) {
+      state.lastSyncActors = actorsPayload.items;
+    } else if (!actorLoadError) {
+      state.lastSyncActors = [];
+    }
+    const payloadPeers = Array.isArray(payload.peers) ? payload.peers : [];
+    const realPeerIds = new Set(payloadPeers.map((peer: any) => String(peer?.peer_device_id || '').trim()).filter(Boolean));
+    const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
+      ? state.pendingAcceptedSyncPeers.filter((peer: any) => {
+          const peerId = String(peer?.peer_device_id || '').trim();
+          return peerId && !realPeerIds.has(peerId);
+        })
+      : [];
+    state.pendingAcceptedSyncPeers = pendingPeers;
+    state.lastSyncPeers = [...payloadPeers, ...pendingPeers];
     state.lastSyncSharingReview = payload.sharing_review || [];
     state.lastSyncCoordinator = payload.coordinator || null;
     if (Array.isArray(payload.join_requests)) {

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -526,6 +526,25 @@ export function renderTeamSync() {
       onReviewDiscoveredDevice: async (row) => {
         try {
           const result = await api.acceptDiscoveredPeer(row.deviceId, row.fingerprint);
+          const optimisticName =
+            String(result?.name || row.displayName || '').trim() || row.displayName;
+          const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
+            ? state.pendingAcceptedSyncPeers.filter(
+                (peer) => String(peer?.peer_device_id || '').trim() !== row.deviceId,
+              )
+            : [];
+          state.pendingAcceptedSyncPeers = [
+            ...pendingPeers,
+            {
+              peer_device_id: row.deviceId,
+              name: optimisticName,
+              fingerprint: row.fingerprint,
+              addresses: [],
+              claimed_local_actor: false,
+              status: { peer_state: 'degraded' },
+              last_error: 'Waiting for the other device to approve this one.',
+            },
+          ];
           requestPeerScopeReview(row.deviceId);
           showGlobalNotice(
             row.approvalBadgeLabel === 'Needs your approval'
@@ -535,7 +554,7 @@ export function renderTeamSync() {
           try {
             await promptForDeviceName(
               row.deviceId,
-              String(result?.name || row.displayName || '').trim() || row.displayName,
+              optimisticName,
             );
           } catch (error) {
             showGlobalNotice(


### PR DESCRIPTION
## Description

Clarifies sync identity semantics so the local actor is presented as **You** across devices instead of the misleading **local** label. This also unifies actor-option generation for device assignment, keeps the current actor available when duplicate filtering would otherwise hide it, and adds regression tests so the assignment dropdown does not render with no usable choices.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- Ran `pnpm exec vitest run packages/ui/src/tabs/sync/helpers.test.ts`
- Ran `pnpm --filter @codemem/ui typecheck`
- Ran `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
