### PR TITLE
fix(sync): persist peer public key during acceptance

### DIFF
--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -535,7 +535,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 	): Promise<CoordinatorPeerRecord[]> {
 		const now = new Date();
 		const rows = this.db
-			.prepare(`SELECT enrolled_devices.device_id, enrolled_devices.fingerprint, enrolled_devices.display_name,
+			.prepare(`SELECT enrolled_devices.device_id, enrolled_devices.public_key, enrolled_devices.fingerprint, enrolled_devices.display_name,
 					presence_records.addresses_json, presence_records.last_seen_at, presence_records.expires_at,
 					presence_records.capabilities_json
 				 FROM enrolled_devices
@@ -559,6 +559,7 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				: mergeAddresses([], JSON.parse((row.addresses_json as string) || "[]") as string[]);
 			return {
 				device_id: String(row.device_id ?? ""),
+				public_key: String(row.public_key ?? ""),
 				fingerprint: String(row.fingerprint ?? ""),
 				display_name: (row.display_name as string | null) ?? null,
 				addresses,

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -53,6 +53,7 @@ export interface CoordinatorPresenceRecord {
 
 export interface CoordinatorPeerRecord {
 	device_id: string;
+	public_key: string;
 	fingerprint: string;
 	display_name: string | null;
 	addresses: string[];

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -199,6 +199,7 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					expect(peers).toHaveLength(1);
 					const peer = peers[0]!;
 					expect(peer.device_id).toBe("d2");
+					expect(peer.public_key).toBe("pk2");
 					expect(peer.stale).toBe(false);
 					expect(peer.addresses).toEqual(["http://localhost:9001"]);
 				});

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -636,7 +636,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		const now = nowISO();
 		const rows = await allRows<Record<string, unknown>>(
 			this.db
-				.prepare(`SELECT enrolled_devices.device_id, enrolled_devices.fingerprint, enrolled_devices.display_name,
+				.prepare(`SELECT enrolled_devices.device_id, enrolled_devices.public_key, enrolled_devices.fingerprint, enrolled_devices.display_name,
 						presence_records.addresses_json, presence_records.last_seen_at, presence_records.expires_at,
 						presence_records.capabilities_json
 					 FROM enrolled_devices
@@ -661,6 +661,7 @@ export class D1CoordinatorStore implements CoordinatorStore {
 				: mergeAddresses([], JSON.parse(String(row.addresses_json ?? "[]")) as string[]);
 			return {
 				device_id: String(row.device_id ?? ""),
+				public_key: String(row.public_key ?? ""),
 				fingerprint: String(row.fingerprint ?? ""),
 				display_name: (row.display_name as string | null) ?? null,
 				addresses,

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1703,6 +1703,7 @@ describe("viewer-server", () => {
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
 									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -1790,6 +1791,7 @@ describe("viewer-server", () => {
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
 									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
 									groups: ["team-a"],
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
@@ -1984,6 +1986,7 @@ describe("viewer-server", () => {
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
 									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -2054,7 +2057,7 @@ describe("viewer-server", () => {
 				});
 				const peerRow = store.db
 					.prepare(
-						"SELECT peer_device_id, name, pinned_fingerprint, addresses_json, last_error FROM sync_peers WHERE peer_device_id = ?",
+						"SELECT peer_device_id, name, pinned_fingerprint, public_key, addresses_json, last_error FROM sync_peers WHERE peer_device_id = ?",
 					)
 					.get("peer-fresh") as Record<string, unknown> | undefined;
 				expect(peerRow).toEqual(
@@ -2062,6 +2065,7 @@ describe("viewer-server", () => {
 						peer_device_id: "peer-fresh",
 						name: "Fresh Device",
 						pinned_fingerprint: "fp-fresh",
+						public_key: "peer-public-key",
 						last_error: null,
 					}),
 				);
@@ -2093,6 +2097,7 @@ describe("viewer-server", () => {
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
 									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
 									groups: ["team-a"],
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
@@ -2166,6 +2171,7 @@ describe("viewer-server", () => {
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
 									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -2184,6 +2190,7 @@ describe("viewer-server", () => {
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
 									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
 									addresses: ["http://10.0.0.6:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -2582,6 +2589,7 @@ describe("viewer-server", () => {
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
 									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -2703,6 +2711,7 @@ describe("viewer-server", () => {
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
 									fingerprint: "fp-new",
+									public_key: "peer-public-key",
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),
@@ -2849,6 +2858,7 @@ describe("viewer-server", () => {
 									device_id: "peer-fresh",
 									display_name: "Fresh Device",
 									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
 									addresses: ["http://10.0.0.5:7337"],
 									last_seen_at: new Date().toISOString(),
 									expires_at: new Date(Date.now() + 60_000).toISOString(),

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -373,10 +373,21 @@ async function acceptDiscoveredPeer(
 		};
 	}
 	const nextFingerprint = String(match.fingerprint ?? "").trim();
+	const nextPublicKey = String(match.public_key ?? "").trim();
 	const nextName = String(match.display_name ?? "").trim() || null;
 	const nextAddresses = Array.isArray(match.addresses)
 		? match.addresses.filter((value): value is string => typeof value === "string")
 		: [];
+	if (!nextPublicKey) {
+		return {
+			ok: false,
+			status: 409,
+			error: "discovered_peer_missing_public_key",
+			detail:
+				"This discovered device is missing its coordinator public key. Refresh sync status and try again.",
+		};
+	}
+
 	const groupIds = Array.isArray(match.groups)
 		? match.groups.map((value) => String(value ?? "").trim()).filter(Boolean)
 		: [];
@@ -397,6 +408,7 @@ async function acceptDiscoveredPeer(
 		.select({
 			peer_device_id: schema.syncPeers.peer_device_id,
 			pinned_fingerprint: schema.syncPeers.pinned_fingerprint,
+			public_key: schema.syncPeers.public_key,
 			addresses_json: schema.syncPeers.addresses_json,
 		})
 		.from(schema.syncPeers)
@@ -435,6 +447,7 @@ async function acceptDiscoveredPeer(
 					peer_device_id: input.peerDeviceId,
 					name: nextName,
 					pinned_fingerprint: nextFingerprint || null,
+					public_key: nextPublicKey,
 					addresses_json: addressesJson,
 					created_at: now,
 					last_seen_at: now,
@@ -452,6 +465,7 @@ async function acceptDiscoveredPeer(
 			.set({
 				name: nextName,
 				pinned_fingerprint: nextFingerprint || existing.pinned_fingerprint || null,
+				public_key: nextPublicKey || existing.public_key || null,
 				addresses_json: addressesJson,
 				last_seen_at: now,
 			})


### PR DESCRIPTION
## Description

Persists the discovered device's `public_key` when accepting a coordinator-discovered peer. Without this, the local `sync_peers` record can have the fingerprint but not the peer public key, which allows the device to look approved in the UI while actual sync auth still fails with one-way unauthorized errors.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- Ran `pnpm exec vitest run packages/viewer-server/src/index.test.ts -t "accepts and persists a discovered peer|does not persist a local peer when reciprocal approval publish fails"`
- Ran `pnpm --filter @codemem/server exec tsc -p tsconfig.json --noEmit`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
