### PR TITLE
fix(sync): streamline discovered device review flow

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -935,6 +935,7 @@
         border-radius: var(--radius-sm);
         background: var(--surface-2);
       }
+      .sync-action + .sync-action { margin-top: var(--sp-2); }
 
       .health-action-text, .sync-action-text { font-size: 13px; color: var(--text-primary); flex: 1; min-width: 0; }
       .health-action-command, .sync-action-command { display: block; margin-top: 2px; font-family: var(--font-mono); font-size: 12px; color: var(--text-tertiary); }

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -258,23 +258,16 @@ export function renderTeamSync() {
     }
   };
 
-  const promptForDeviceName = async (deviceId: string, suggestedName: string) => {
-    const value = await openSyncInputDialog({
-      title: 'Name this device',
-      description: 'Choose a friendly device name. You can change it later in People & devices.',
+  const reviewDiscoveredDeviceName = async (suggestedName: string) => {
+    return await openSyncInputDialog({
+      title: 'Review device',
+      description: 'Choose a friendly name for this device before connecting it on this machine.',
       initialValue: suggestedName,
       placeholder: 'Desk Mini',
-      confirmLabel: 'Save name',
-      cancelLabel: 'Skip for now',
-      validate: (nextValue) => (nextValue.trim() ? null : 'Enter a device name or skip for now.'),
+      confirmLabel: 'Connect device',
+      cancelLabel: 'Cancel',
+      validate: (nextValue) => (nextValue.trim() ? null : 'Enter a device name to connect this device.'),
     });
-    if (!value) {
-      showGlobalNotice('You can name this device later from People & devices.', 'warning');
-      return false;
-    }
-    await api.renamePeer(deviceId, value);
-    showGlobalNotice(`Saved device name: ${value}.`);
-    return true;
   };
 
   const configured = Boolean(coordinator && coordinator.configured);
@@ -525,9 +518,10 @@ export function renderTeamSync() {
       },
       onReviewDiscoveredDevice: async (row) => {
         try {
+          const reviewedName = await reviewDiscoveredDeviceName(row.displayName);
+          if (!reviewedName) return;
           const result = await api.acceptDiscoveredPeer(row.deviceId, row.fingerprint);
-          const optimisticName =
-            String(result?.name || row.displayName || '').trim() || row.displayName;
+          const optimisticName = String(result?.name || row.displayName || '').trim() || row.displayName;
           const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
             ? state.pendingAcceptedSyncPeers.filter(
                 (peer) => String(peer?.peer_device_id || '').trim() !== row.deviceId,
@@ -552,15 +546,12 @@ export function renderTeamSync() {
               : `Step 1 complete on this device for ${row.displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
           );
           try {
-            await promptForDeviceName(
-              row.deviceId,
-              optimisticName,
-            );
+            if (reviewedName.trim() !== optimisticName.trim()) {
+              await api.renamePeer(row.deviceId, reviewedName.trim());
+              showGlobalNotice(`Saved device name: ${reviewedName.trim()}.`);
+            }
           } catch (error) {
-            showGlobalNotice(
-              friendlyError(error, 'Device connected, but naming did not finish.'),
-              'warning',
-            );
+            showGlobalNotice(friendlyError(error, 'Device connected, but naming did not finish.'), 'warning');
           }
           try {
             await _loadSyncData();

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -280,7 +280,6 @@ describe('deriveSyncViewModel', () => {
     expect(view.attentionItems.map((item) => item.kind)).toEqual([
       'possible-duplicate-person',
       'device-needs-repair',
-      'review-team-device',
     ]);
   });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -473,14 +473,6 @@ export function deriveSyncViewModel(input: {
           summary: 'This device is offline or stale. Review it before re-pairing or retrying sync.',
         }),
       );
-    } else if (!device.peer && device.discovered && !device.discovered?.stale) {
-      attentionItems.push(
-        createReviewItem({
-          id: device.deviceId,
-          name,
-          summary: 'This device is seen on the team and is ready for review or connection on this machine.',
-        }),
-      );
     }
 
     if (device.peer && trustSummary?.state === 'trusted-by-you') {


### PR DESCRIPTION
## Description

Cleans up the discovered-device review UX in Sync. This removes the duplicate “Review device” surfacing under Needs attention, makes the top review action behave like an actual review/name-before-connect step instead of silently accepting first, and adds a small spacing tweak between attention cards.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- Ran `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts packages/ui/src/tabs/sync/helpers.test.ts`
- Ran `pnpm --filter @codemem/ui typecheck`
- Ran `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
