### PR TITLE
fix(ui): remove textContent='' that breaks Preact VDOM in health tab

### DIFF
--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -234,7 +234,6 @@ export function renderHealthOverview() {
   const healthActions = document.getElementById('healthActions');
   const healthDot = document.getElementById('healthDot');
   if (!healthGrid || !healthMeta) return;
-  healthGrid.textContent = '';
 
   const stats = state.lastStatsPayload || {};
   const usagePayload = state.lastUsagePayload || {};
@@ -401,7 +400,6 @@ export function renderSessionSummary() {
   const sessionGrid = document.getElementById('sessionGrid');
   const sessionMeta = document.getElementById('sessionMeta');
   if (!sessionGrid || !sessionMeta) return;
-  sessionGrid.textContent = '';
 
   const usagePayload = state.lastUsagePayload || {};
   const project = state.currentProject;


### PR DESCRIPTION
## Description

Health cards on the Health tab flicker briefly then vanish. Both `renderHealthOverview()` and `renderSessionSummary()` used `container.textContent = ''` before calling Preact's `render()`, which destroys Preact's internal VDOM reference for the container. When `loadHealthData()` and `loadSyncData()` both call `renderHealthOverview()` concurrently during refresh, one call's `textContent = ''` wipes the other's rendered output.

Removes the `textContent = ''` calls and lets Preact's `render()` handle reconciliation natively — matching the pattern already used successfully by `renderStats()`.

Fixes: codemem-edyh

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 793 pass)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced