### PR TITLE
fix(ui): remove textContent='' that breaks Preact VDOM in devices list

### DIFF
--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -77,7 +77,6 @@ export function renderSyncPeers() {
   const syncPeers = document.getElementById('syncPeers');
   if (!syncPeers) return;
   hideSkeleton('syncPeersSkeleton');
-  syncPeers.textContent = '';
   const peers = state.lastSyncPeers;
   renderSyncPeersList(syncPeers, {
     peers: Array.isArray(peers) ? peers : [],


### PR DESCRIPTION
## Description

The devices list under People & Devices goes blank when accepting a discovered peer or during other route changes. `renderSyncPeers()` in `people.ts` used `syncPeers.textContent = ''` before calling `renderSyncPeersList()` which renders via Preact. This destroys Preact's internal VDOM reference, so when rapid `loadSyncData()` re-renders fire (e.g., after accepting a peer), the list goes blank. Hard refresh worked because it resets Preact's internal state.

Same root cause and fix pattern as PR #524 — removes `textContent = ''` and lets Preact handle reconciliation.

Fixes: codemem-1umm

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 793 pass)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced