### PR TITLE
fix(sync): derive tags for replicated memories arriving without tags

### DIFF
--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1662,4 +1662,97 @@ describe("applyReplicationOps", () => {
 		const row = db.prepare("SELECT op_id FROM replication_ops WHERE op_id = ?").get("track-me");
 		expect(row).toBeDefined();
 	});
+
+	it("derives tags for inserted memories arriving with empty tags_text", () => {
+		const op = makeReplicationOp({
+			entity_id: "key:no-tags",
+			payload_json: toJson({
+				kind: "feature",
+				title: "Add authentication flow",
+				body_text: "Implements login and signup",
+				tags_text: "",
+				active: 1,
+				created_at: "2026-01-01T00:00:00Z",
+				updated_at: "2026-01-01T00:00:00Z",
+				concepts: ["authentication", "login"],
+				files_modified: ["src/auth/login.ts"],
+			}),
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+
+		const mem = db
+			.prepare("SELECT tags_text FROM memory_items WHERE import_key = ?")
+			.get("key:no-tags") as { tags_text: string };
+		expect(mem.tags_text).toBeTruthy();
+		expect(mem.tags_text).toContain("feature");
+		expect(mem.tags_text).toContain("authentication");
+	});
+
+	it("preserves incoming tags when source provides non-empty tags_text", () => {
+		const op = makeReplicationOp({
+			entity_id: "key:has-tags",
+			payload_json: toJson({
+				kind: "bugfix",
+				title: "Fix crash",
+				body_text: "Null check",
+				tags_text: "custom-tag-1 custom-tag-2",
+				active: 1,
+				created_at: "2026-01-01T00:00:00Z",
+				updated_at: "2026-01-01T00:00:00Z",
+			}),
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+
+		const mem = db
+			.prepare("SELECT tags_text FROM memory_items WHERE import_key = ?")
+			.get("key:has-tags") as { tags_text: string };
+		expect(mem.tags_text).toBe("custom-tag-1 custom-tag-2");
+	});
+
+	it("does not overwrite existing tags with empty incoming tags on update", () => {
+		// Insert initial memory with tags
+		const sessionId = insertTestSession(db);
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, tags_text, created_at, updated_at, import_key, rev, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Original",
+			"body",
+			"existing-tag",
+			"2026-01-01T00:00:00Z",
+			"2026-01-01T00:00:00Z",
+			"key:keep-tags",
+			1,
+			toJson({ clock_device_id: "dev-remote" }),
+		);
+
+		// Update with empty tags_text
+		const op = makeReplicationOp({
+			entity_id: "key:keep-tags",
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Updated title",
+				body_text: "updated body",
+				tags_text: "",
+				updated_at: "2026-01-02T00:00:00Z",
+			}),
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+
+		const mem = db
+			.prepare("SELECT title, tags_text FROM memory_items WHERE import_key = ?")
+			.get("key:keep-tags") as { title: string; tags_text: string };
+		expect(mem.title).toBe("Updated title");
+		expect(mem.tags_text).toBe("existing-tag");
+	});
 });

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -15,6 +15,7 @@ import type { Database } from "./db.js";
 import { fromJson, fromJsonStrict, toJson, toJsonNullable } from "./db.js";
 import { readCodememConfigFile } from "./observer-config.js";
 import * as schema from "./schema.js";
+import { deriveTags } from "./tags.js";
 import type {
 	ReplicationOp,
 	ReplicationOpsAgePrunePlan,
@@ -168,6 +169,28 @@ function parseMemoryPayload(op: ReplicationOp, errors: string[]): MemoryPayload 
 		rev: asNumberOrNull(raw.rev) ?? 0,
 		import_key: asStringOrNull(raw.import_key),
 	};
+}
+
+/**
+ * Resolve tags_text for a replicated memory: use incoming tags if non-empty,
+ * otherwise derive tags from available metadata (kind, title, concepts, files).
+ */
+function resolveReplicatedTags(payload: MemoryPayload): string {
+	const incoming = (payload.tags_text ?? "").trim();
+	if (incoming) return incoming;
+	const concepts = Array.isArray(payload.concepts) ? payload.concepts.map(String) : [];
+	const filesRead = Array.isArray(payload.files_read) ? payload.files_read.map(String) : [];
+	const filesModified = Array.isArray(payload.files_modified)
+		? payload.files_modified.map(String)
+		: [];
+	const tags = deriveTags({
+		kind: payload.kind ?? "",
+		title: payload.title ?? undefined,
+		concepts,
+		filesRead,
+		filesModified,
+	});
+	return tags.join(" ");
 }
 
 function normalizeCursor(value: string | null | undefined): string | null {
@@ -1745,7 +1768,7 @@ export function applyReplicationOps(
 								subtitle: payload.subtitle,
 								body_text: sql`COALESCE(${payload.body_text}, ${schema.memoryItems.body_text})`,
 								confidence: sql`COALESCE(${payload.confidence != null ? Number(payload.confidence) : null}, ${schema.memoryItems.confidence})`,
-								tags_text: sql`COALESCE(${payload.tags_text}, ${schema.memoryItems.tags_text})`,
+								tags_text: sql`COALESCE(NULLIF(TRIM(${payload.tags_text}), ''), ${schema.memoryItems.tags_text})`,
 								active: sql`COALESCE(${payload.active != null ? Number(payload.active) : null}, ${schema.memoryItems.active})`,
 								updated_at: op.clock_updated_at,
 								metadata_json: toJson(metaObj),
@@ -1782,7 +1805,7 @@ export function applyReplicationOps(
 								subtitle: payload.subtitle,
 								body_text: payload.body_text ?? "",
 								confidence: payload.confidence != null ? Number(payload.confidence) : 0.5,
-								tags_text: payload.tags_text ?? "",
+								tags_text: resolveReplicatedTags(payload),
 								active: payload.active != null ? Number(payload.active) : 1,
 								created_at: payload.created_at ?? op.clock_updated_at,
 								updated_at: op.clock_updated_at,


### PR DESCRIPTION
## Description

Synced memories arriving with empty `tags_text` (pre-tags-era memories, observer summaries, or devices that hadn't run `backfill-tags`) persist without tags on the receiving device, degrading search quality and showing low tag coverage in the health dashboard.

**Insert path:** Now calls `deriveTags()` from the payload's kind, title, concepts, and file paths when incoming `tags_text` is empty — generating tags on the receiving side.

**Update path:** Uses `NULLIF` to avoid overwriting existing locally-derived tags with an empty incoming `tags_text` from the source.

Fixes: codemem-dpaf

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 793 pass, 3 new)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Tests added:
- Insert derives tags when incoming `tags_text` is empty
- Insert preserves incoming tags when source provides non-empty `tags_text`
- Update does not overwrite existing tags with empty incoming `tags_text`

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced