### PR TITLE
fix(flush): give up on raw event batches after max retry attempts

### DIFF
--- a/packages/core/src/raw-event-flush.test.ts
+++ b/packages/core/src/raw-event-flush.test.ts
@@ -1,0 +1,207 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import type { IngestOptions } from "./ingest-pipeline.js";
+import { flushRawEvents } from "./raw-event-flush.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema } from "./test-utils.js";
+
+describe("flushRawEvents max retry", () => {
+	let tmpDir: string;
+	let store: MemoryStore;
+	let prevMaxAttempts: string | undefined;
+
+	beforeEach(() => {
+		prevMaxAttempts = process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-flush-test-"));
+		const dbPath = join(tmpDir, "test.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store.close();
+		if (prevMaxAttempts === undefined) delete process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS;
+		else process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = prevMaxAttempts;
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function seedEvents(sessionId: string) {
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-1",
+			eventType: "user_prompt",
+			payload: { type: "user_prompt", prompt_text: "Hello" },
+			tsWallMs: 100,
+		});
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-2",
+			eventType: "tool.execute.after",
+			payload: { type: "tool.execute.after", tool: "read", args: { filePath: "/tmp/x.ts" } },
+			tsWallMs: 200,
+		});
+	}
+
+	const nullObserver = {
+		observe: async () => ({
+			raw: null as string | null,
+			parsed: null,
+			provider: "test",
+			model: "test-model",
+		}),
+		getStatus: () => ({
+			provider: "test",
+			model: "test-model",
+			runtime: "test",
+			auth: { source: "none", type: "none", hasToken: false },
+		}),
+	};
+
+	it("gives up after max attempts and advances flush cursor", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "3";
+		const sessionId = "ses_max_retry_test";
+		seedEvents(sessionId);
+
+		const ingestOpts = { observer: nullObserver } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		// Fail 3 times — each attempt claims the batch and increments attempt_count
+		for (let i = 0; i < 3; i++) {
+			await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow(
+				"observer failed during raw-event flush",
+			);
+		}
+
+		// 4th attempt should give up instead of retrying
+		const result = await flushRawEvents(store, ingestOpts, flushOpts);
+		expect(result.updatedState).toBe(1);
+		expect(result.flushed).toBe(0);
+
+		// Batch should be marked gave_up
+		const batch = store.db
+			.prepare(
+				"SELECT status, attempt_count FROM raw_event_flush_batches WHERE opencode_session_id = ?",
+			)
+			.get(sessionId) as { status: string; attempt_count: number };
+		expect(batch.status).toBe("gave_up");
+		expect(batch.attempt_count).toBe(3);
+
+		// Flush state should be advanced so the session isn't retried
+		const flushState = store.rawEventFlushState(sessionId, "opencode");
+		expect(flushState).toBeGreaterThanOrEqual(0);
+	});
+
+	it("does not give up when under the max attempts", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "5";
+		const sessionId = "ses_under_max";
+		seedEvents(sessionId);
+
+		const ingestOpts = { observer: nullObserver } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		// Fail twice — still under the limit
+		for (let i = 0; i < 2; i++) {
+			await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow(
+				"observer failed during raw-event flush",
+			);
+		}
+
+		// 3rd attempt should still try (and fail), not give up
+		await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow(
+			"observer failed during raw-event flush",
+		);
+
+		const batch = store.db
+			.prepare("SELECT status FROM raw_event_flush_batches WHERE opencode_session_id = ?")
+			.get(sessionId) as { status: string };
+		expect(batch.status).toBe("failed");
+	});
+
+	it("uses default max of 5 when env var is not set", async () => {
+		delete process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS;
+		const sessionId = "ses_default_max";
+		seedEvents(sessionId);
+
+		const ingestOpts = { observer: nullObserver } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		// Fail 5 times
+		for (let i = 0; i < 5; i++) {
+			await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow(
+				"observer failed during raw-event flush",
+			);
+		}
+
+		// 6th attempt should give up
+		const result = await flushRawEvents(store, ingestOpts, flushOpts);
+		expect(result.updatedState).toBe(1);
+
+		const batch = store.db
+			.prepare("SELECT status FROM raw_event_flush_batches WHERE opencode_session_id = ?")
+			.get(sessionId) as { status: string };
+		expect(batch.status).toBe("gave_up");
+	});
+
+	it("gave_up batches are not resurrected by retryRawEventFailures", async () => {
+		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "1";
+		const sessionId = "ses_no_resurrect";
+		seedEvents(sessionId);
+
+		const ingestOpts = { observer: nullObserver } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: null,
+			maxEvents: null,
+		};
+
+		// Fail once, then give up
+		await expect(flushRawEvents(store, ingestOpts, flushOpts)).rejects.toThrow();
+		await flushRawEvents(store, ingestOpts, flushOpts);
+
+		// Verify gave_up
+		const before = store.db
+			.prepare("SELECT status FROM raw_event_flush_batches WHERE opencode_session_id = ?")
+			.get(sessionId) as { status: string };
+		expect(before.status).toBe("gave_up");
+
+		// retryRawEventFailures should not touch it
+		const { retryRawEventFailures } = await import("./maintenance.js");
+		const retried = retryRawEventFailures(store.dbPath);
+		expect(retried.retried).toBe(0);
+
+		// Still gave_up
+		const after = store.db
+			.prepare("SELECT status FROM raw_event_flush_batches WHERE opencode_session_id = ?")
+			.get(sessionId) as { status: string };
+		expect(after.status).toBe("gave_up");
+	});
+});

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -17,6 +17,10 @@ import type { MemoryStore } from "./store.js";
 
 const EXTRACTOR_VERSION = "raw_events_v1";
 
+/** Max flush attempts before a batch is permanently abandoned.
+ *  Override via CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS. */
+const DEFAULT_MAX_FLUSH_ATTEMPTS = 5;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -247,7 +251,7 @@ export async function flushRawEvents(
 	}
 
 	// Get or create flush batch (idempotency guard)
-	const { batchId, status } = store.getOrCreateRawEventFlushBatch(
+	const { batchId, status, attemptCount } = store.getOrCreateRawEventFlushBatch(
 		opencodeSessionId,
 		source,
 		startEventSeq,
@@ -257,6 +261,19 @@ export async function flushRawEvents(
 
 	// If already completed, just advance flush state
 	if (status === "completed") {
+		store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
+		return { flushed: 0, updatedState: 1 };
+	}
+
+	// Give up after too many failed attempts — mark batch as permanently failed
+	// and advance the cursor so the pipeline isn't blocked forever.
+	// Only trigger from terminal failure states; if another worker has the batch
+	// claimed/running, fall through to the claim step which will correctly bail.
+	const maxAttempts = Number.parseInt(process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS ?? "", 10);
+	const effectiveMax =
+		Number.isFinite(maxAttempts) && maxAttempts > 0 ? maxAttempts : DEFAULT_MAX_FLUSH_ATTEMPTS;
+	if (attemptCount >= effectiveMax && (status === "failed" || status === "error")) {
+		store.updateRawEventFlushBatchStatus(batchId, "gave_up");
 		store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
 		return { flushed: 0, updatedState: 1 };
 	}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1214,7 +1214,7 @@ export class MemoryStore {
 		startEventSeq: number,
 		endEventSeq: number,
 		extractorVersion: string,
-	): { batchId: number; status: string } {
+	): { batchId: number; status: string; attemptCount: number } {
 		const [s, sid] = this.normalizeStreamIdentity(source, opencodeSessionId);
 		const now = new Date().toISOString();
 
@@ -1245,7 +1245,7 @@ export class MemoryStore {
 					END`,
 				},
 			})
-			.returning({ id: t.id, status: t.status })
+			.returning({ id: t.id, status: t.status, attempt_count: t.attempt_count })
 			.get();
 
 		if (!row) throw new Error("Failed to create flush batch");
@@ -1259,7 +1259,11 @@ export class MemoryStore {
 					: rawStatus === "error"
 						? "failed"
 						: rawStatus;
-		return { batchId: Number(row.id), status: canonicalStatus };
+		return {
+			batchId: Number(row.id),
+			status: canonicalStatus,
+			attemptCount: Number(row.attempt_count ?? 0),
+		};
 	}
 
 	/**
@@ -1293,8 +1297,8 @@ export class MemoryStore {
 	 */
 	updateRawEventFlushBatchStatus(batchId: number, status: string): void {
 		const now = new Date().toISOString();
-		if (status === "failed") {
-			// Preserve existing error details when marking as failed
+		if (status === "failed" || status === "gave_up") {
+			// Preserve existing error details when marking as failed/gave_up
 			this.d
 				.update(schema.rawEventFlushBatches)
 				.set({ status, updated_at: now })


### PR DESCRIPTION
## Description

When the observer returns null during raw-event flush, the batch was retried indefinitely (117+ attempts observed in production). This wasted API calls, blocked flush progress for all sessions in the pipeline, and showed a perpetual error in the health dashboard.

Adds a max attempt check (default 5, configurable via `CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS`). When exceeded, the batch is marked `gave_up` with error details preserved, and the flush cursor advances so the pipeline isn't blocked forever.

- `gave_up` batches are excluded from `claimRawEventFlushBatch` (already implicit — only claims pending/failed/started/error)
- `gave_up` batches are excluded from `retryRawEventFailures` (only retries failed/error)
- `gave_up` batches are excluded from `latestRawEventFlushFailure` health query (only shows failed/error)
- Error details are preserved on the batch row for post-mortem inspection

Fixes: codemem-ge3h

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 798 pass, 4 new)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Tests added:
- Gives up after max attempts and advances flush cursor
- Does not give up when under the max attempts
- Uses default max of 5 when env var is not set
- `gave_up` batches are not resurrected by `retryRawEventFailures`

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced