### PR TITLE
fix(ui): rename 'Other actors' filter to 'Other people'

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -104,7 +104,7 @@ function renderIntoFeedMount(mount: HTMLElement, content: ComponentChildren) {
 
 function feedScopeLabel(scope: string): string {
   if (scope === 'mine') return ' · my memories';
-  if (scope === 'theirs') return ' · other actors';
+  if (scope === 'theirs') return ' · other people';
   return '';
 }
 
@@ -852,7 +852,7 @@ function FeedTabView({ items, loadingText }: { items: any[]; loadingText?: strin
           options: [
             { value: 'all', label: 'All' },
             { value: 'mine', label: 'My memories' },
-            { value: 'theirs', label: 'Other actors' },
+            { value: 'theirs', label: 'Other people' },
           ],
         }),
         h(FeedToggle, {


### PR DESCRIPTION
## Description

The `ownership_scope: "theirs"` filter uses identity-based matching (`actor_id != local AND origin_device_id != local`). Memories created by the same person on a different device still count as "mine" because the actor_id matches. The label "Other actors" was confusing in multi-device single-person setups since it implies device-level separation.

Renames to "Other people" which better conveys that this filter shows memories from different identities, not different devices.

Fixes: codemem-yuc0

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 798 pass)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced