### PR TITLE
release: v0.22.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.22.0-alpha.5"
+    "version": "0.22.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.22.0-alpha.5",
+      "version": "0.22.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.26.1",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "pnpm": {
     "strictPeerDependencies": false,
     "onlyBuiltDependencies": [

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.21.2";
+const PINNED_BACKEND_VERSION = "0.22.0";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/cli/.opencode/tests/plugin-adapter.test.js
+++ b/packages/cli/.opencode/tests/plugin-adapter.test.js
@@ -321,7 +321,7 @@ describe("opencode adapter event mapping", () => {
     );
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 
-    expect(packageJson.version).toBe("0.22.0-alpha.5");
-    expect(__testUtils.PINNED_BACKEND_VERSION).toBe("0.21.2");
+    expect(packageJson.version).toBe("0.22.0");
+    expect(__testUtils.PINNED_BACKEND_VERSION).toBe("0.22.0");
   });
 });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.22.0-alpha.5",
+	"version": "0.22.0",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.22.0-alpha.5",
+	"version": "0.22.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.22.0-alpha.5");
+		expect(VERSION).toBe("0.22.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.22.0-alpha.5";
+export const VERSION = "0.22.0";
 
 export * as Api from "./api-types.js";
 export type { CreateBetterSqliteCoordinatorAppOptions } from "./better-sqlite-coordinator-runtime.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.22.0-alpha.5",
+	"version": "0.22.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.21.2";
+const PINNED_BACKEND_VERSION = "0.22.0";
 
 const normalizeEnvValue = (value) => (value || "").toLowerCase();
 const envHasValue = (value, truthyValues) =>

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.22.0-alpha.5",
+	"version": "0.22.0",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.22.0-alpha.5",
+	"version": "0.22.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.22.0-alpha.5",
+  "version": "0.22.0",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description

Release v0.22.0 — first stable release of the 0.22 series.

**Highlights since v0.21.2:**
- Preact/Radix UI migration (feed, health, settings, sync tabs)
- Sync peer onboarding flow (coordinator reciprocal approval, discovered device review, trust clarity)
- Raw event flush diagnostics and max retry limit (no more infinite retry poison pills)
- VDOM rendering fixes (health cards, devices list no longer vanish)
- Tag derivation during sync replication for tagless memories
- "Other actors" → "Other people" label clarity
- Various sync hardening (D1 races, public key persistence, etc.)
- pnpm bumped to 10.33.0

**Version bumps:**
- `packages/core/package.json` → 0.22.0
- `packages/cli/package.json` → 0.22.0
- `packages/opencode-plugin/package.json` → 0.22.0
- `packages/mcp-server/package.json` → 0.22.0
- `packages/viewer-server/package.json` → 0.22.0
- `packages/core/src/index.ts` VERSION → 0.22.0
- `packages/core/src/index.test.ts` → 0.22.0
- `packages/opencode-plugin/.opencode/plugins/codemem.js` PINNED_BACKEND_VERSION → 0.22.0
- `packages/cli/.opencode/plugins/codemem.js` PINNED_BACKEND_VERSION → 0.22.0
- `.claude-plugin/marketplace.json` → 0.22.0
- `plugins/claude/.claude-plugin/plugin.json` → 0.22.0

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm run test` — 798 pass)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] Multi-device sync verified on m4x + pi4 setup

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced