### PR TITLE
feat(viewer): show runtime version in header

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -346,6 +346,13 @@
         max-width: 300px;
       }
 
+      .runtime-label {
+        font-size: 11px;
+        color: var(--text-tertiary);
+        opacity: 0.8;
+        white-space: nowrap;
+      }
+
       /* ── Tab bar ───────────────────────────────────────────── */
 
       .tab-bar {
@@ -1625,6 +1632,7 @@
           <span class="sr-only" id="refreshAnnouncer" aria-live="polite"></span>
         </div>
         <div class="header-right">
+          <span class="runtime-label" id="runtimeLabel" hidden></span>
           <span class="meta-line" id="metaLine"></span>
           <select class="project-filter" id="projectFilter" aria-label="Project filter">
             <option value="">All Projects</option>

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -7,6 +7,8 @@
 
 /* global marked, lucide */
 
+declare const __CODEMEM_GIT_COMMIT__: string;
+
 import { $, $select } from './lib/dom';
 import { getTheme, setTheme, initThemeSelect } from './lib/theme';
 import { state, initState, setActiveTab, type TabId } from './lib/state';
@@ -16,6 +18,24 @@ import { initFeedTab, loadFeedData, updateFeedView } from './tabs/feed';
 import { initHealthTab, loadHealthData, renderHealthOverview } from './tabs/health';
 import { initSyncTab, loadSyncData, loadPairingData, renderSyncStatus, renderSyncPeers, renderSyncAttempts, renderPairing } from './tabs/sync';
 import { initSettings, loadConfigData, isSettingsOpen } from './tabs/settings';
+
+function setRuntimeLabel(version: string, commit: string | null) {
+  const el = $('runtimeLabel');
+  if (!el) return;
+  const label = commit ? `v${version} (${commit})` : `v${version}`;
+  el.textContent = label;
+  el.title = commit ? `codemem ${version} (${commit})` : `codemem ${version}`;
+  el.hidden = false;
+}
+
+async function loadRuntimeLabel() {
+  try {
+    const runtime = await api.loadRuntimeInfo();
+    if (!runtime?.version) return;
+    const commit = __CODEMEM_GIT_COMMIT__ || null;
+    setRuntimeLabel(runtime.version, commit);
+  } catch {}
+}
 
 /* ── Refresh status ──────────────────────────────────────── */
 
@@ -199,6 +219,9 @@ initSettings(stopPolling, startPolling, () => refresh());
 
 // Projects
 loadProjects();
+
+// Version label
+loadRuntimeLabel();
 
 // Start
 refresh();

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -14,6 +14,10 @@ export interface SyncRunResponse {
   items: SyncRunItem[];
 }
 
+export interface RuntimeInfo {
+  version: string;
+}
+
 function payloadError(payload: unknown): string | undefined {
   if (!payload || typeof payload !== 'object') return undefined;
   const maybeError = (payload as { error?: unknown }).error;
@@ -39,6 +43,10 @@ async function readJsonPayload<T = Record<string, unknown>>(
 
 export async function loadStats(): Promise<any> {
   return fetchJson('/api/stats');
+}
+
+export async function loadRuntimeInfo(): Promise<RuntimeInfo> {
+  return fetchJson('/api/runtime');
 }
 
 export async function loadUsage(project: string): Promise<any> {

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { resolve } from "node:path";
 
 import preact from "@preact/preset-vite";
@@ -8,7 +9,25 @@ function isOutputChunk(value: unknown): value is OutputChunk {
 	return Boolean(value) && typeof value === "object" && "type" in value && (value as { type?: string }).type === "chunk";
 }
 
+function resolveGitCommit(): string {
+	try {
+		return execSync("git rev-parse --short=7 HEAD", {
+			cwd: __dirname,
+			encoding: "utf-8",
+		})
+			.trim()
+			.slice(0, 7);
+	} catch {
+		return "";
+	}
+}
+
+const gitCommit = resolveGitCommit();
+
 export default defineConfig(({ mode }) => ({
+	define: {
+		__CODEMEM_GIT_COMMIT__: JSON.stringify(gitCommit),
+	},
 	resolve: {
 		alias: {
 			react: "preact/compat",

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -16,6 +16,7 @@ import {
 	insertTestSession,
 	loadPublicKey,
 	MemoryStore,
+	VERSION,
 } from "@codemem/core";
 import Database from "better-sqlite3";
 import { describe, expect, it, vi } from "vitest";
@@ -188,6 +189,21 @@ describe("viewer-server", () => {
 				expect(db).toHaveProperty("path");
 				expect(db).toHaveProperty("sessions");
 				expect(db).toHaveProperty("memory_items");
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
+	describe("GET /api/runtime", () => {
+		it("returns viewer runtime version info", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/runtime");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.version).toBe(VERSION);
+				expect(body).not.toHaveProperty("commit");
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -4,7 +4,7 @@
  * Ports Python's viewer_routes/stats.py.
  */
 
-import type { MemoryStore } from "@codemem/core";
+import { type MemoryStore, VERSION } from "@codemem/core";
 import { Hono } from "hono";
 
 /**
@@ -28,6 +28,12 @@ export function statsRoutes(getStore: () => MemoryStore) {
 		return c.json({
 			...store.stats(),
 			viewer_pid: process.pid,
+		});
+	});
+
+	app.get("/api/runtime", (c) => {
+		return c.json({
+			version: VERSION,
 		});
 	});
 


### PR DESCRIPTION
## Description

Adds a subtle runtime label to the viewer header so it is easier to tell which build is running. The label shows the runtime version from the server and appends the current short git commit hash injected at UI build time.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] `pnpm --filter @codemem/ui build`
- [x] `pnpm exec vitest run packages/viewer-server/src/index.test.ts`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced