### PR TITLE
fix(worker): split coordinator auth by runtime and drop nodejs_compat from prod

### DIFF
--- a/packages/cloudflare-coordinator-worker/src/index.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.ts
@@ -1,5 +1,6 @@
 import type { D1DatabaseLike } from "@codemem/core/internal/cloudflare-coordinator";
 import { createD1CoordinatorApp } from "@codemem/core/internal/cloudflare-coordinator";
+import { verifyCloudflareCoordinatorRequest } from "./request-verifier.js";
 
 export interface CloudflareCoordinatorEnv {
 	COORDINATOR_DB?: D1DatabaseLike;
@@ -32,6 +33,7 @@ export function createCloudflareCoordinatorWorker(
 					? opts.adminSecret(env)
 					: String(env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET ?? "").trim() || null,
 				now: opts.now,
+				requestVerifier: verifyCloudflareCoordinatorRequest,
 			});
 			return app.fetch(request);
 		},

--- a/packages/cloudflare-coordinator-worker/src/request-verifier.ts
+++ b/packages/cloudflare-coordinator-worker/src/request-verifier.ts
@@ -1,0 +1,118 @@
+import {
+	type CoordinatorRequestVerifier,
+	DEFAULT_TIME_WINDOW_S,
+} from "@codemem/core/internal/cloudflare-coordinator";
+
+const textEncoder = new TextEncoder();
+
+function bytesToHex(bytes: Uint8Array): string {
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let index = 0; index < binary.length; index += 1) {
+		bytes[index] = binary.charCodeAt(index);
+	}
+	return bytes;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	const copy = new Uint8Array(bytes.byteLength);
+	copy.set(bytes);
+	return copy.buffer;
+}
+
+function readUint32BE(bytes: Uint8Array, offset: number): number {
+	return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(offset, false);
+}
+
+function buildSpkiDer(rawKey: Uint8Array): Uint8Array {
+	const prefix = Uint8Array.from([
+		0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+	]);
+	const spki = new Uint8Array(prefix.length + rawKey.length);
+	spki.set(prefix, 0);
+	spki.set(rawKey, prefix.length);
+	return spki;
+}
+
+async function importSshEd25519PublicKey(publicKey: string): Promise<CryptoKey> {
+	const parts = publicKey.trim().split(/\s+/);
+	if (parts.length < 2 || parts[0] !== "ssh-ed25519") {
+		throw new Error("not an ssh-ed25519 key");
+	}
+	const wire = base64ToBytes(parts[1]!);
+	if (wire.length < 4) throw new Error("truncated wire format");
+	const typeLen = readUint32BE(wire, 0);
+	const typeEnd = 4 + typeLen;
+	if (wire.length < typeEnd + 4) throw new Error("truncated wire format");
+	const keyLen = readUint32BE(wire, typeEnd);
+	const keyStart = typeEnd + 4;
+	if (wire.length < keyStart + keyLen) throw new Error("truncated wire format");
+	const rawKey = wire.slice(keyStart, keyStart + keyLen);
+	if (rawKey.length !== 32) throw new Error(`unexpected Ed25519 key length: ${rawKey.length}`);
+	return crypto.subtle.importKey(
+		"spki",
+		toArrayBuffer(buildSpkiDer(rawKey)),
+		{ name: "Ed25519" },
+		false,
+		["verify"],
+	);
+}
+
+async function buildCanonicalRequest(
+	method: string,
+	pathWithQuery: string,
+	timestamp: string,
+	nonce: string,
+	bodyBytes: Uint8Array,
+): Promise<Uint8Array> {
+	const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", toArrayBuffer(bodyBytes)));
+	const canonical = [
+		method.toUpperCase(),
+		pathWithQuery,
+		timestamp,
+		nonce,
+		bytesToHex(digest),
+	].join("\n");
+	return textEncoder.encode(canonical);
+}
+
+export const verifyCloudflareCoordinatorRequest: CoordinatorRequestVerifier = async (input) => {
+	if (!/^\d+$/.test(input.timestamp)) return false;
+	const timestamp = Number.parseInt(input.timestamp, 10);
+	if (Number.isNaN(timestamp)) return false;
+	const now = Math.floor(Date.now() / 1000);
+	if (Math.abs(now - timestamp) > DEFAULT_TIME_WINDOW_S) return false;
+
+	const colonIndex = input.signature.indexOf(":");
+	if (colonIndex < 1) return false;
+	const version = input.signature.slice(0, colonIndex);
+	if (!version || !["v1", "v2"].includes(version)) return false;
+	const encodedSignature = input.signature.slice(colonIndex + 1);
+	if (!encodedSignature) return false;
+
+	try {
+		const [key, canonical, signatureBytes] = await Promise.all([
+			importSshEd25519PublicKey(input.publicKey),
+			buildCanonicalRequest(
+				input.method,
+				input.pathWithQuery,
+				input.timestamp,
+				input.nonce,
+				input.bodyBytes,
+			),
+			Promise.resolve(base64ToBytes(encodedSignature)),
+		]);
+		return await crypto.subtle.verify(
+			"Ed25519",
+			key,
+			toArrayBuffer(signatureBytes),
+			toArrayBuffer(canonical),
+		);
+	} catch {
+		return false;
+	}
+};

--- a/packages/core/src/better-sqlite-coordinator-runtime.ts
+++ b/packages/core/src/better-sqlite-coordinator-runtime.ts
@@ -2,7 +2,12 @@ import {
 	BetterSqliteCoordinatorStore,
 	DEFAULT_COORDINATOR_DB_PATH,
 } from "./better-sqlite-coordinator-store.js";
-import { type CoordinatorRuntimeDeps, createCoordinatorApp } from "./coordinator-api.js";
+import {
+	type CoordinatorRequestVerifier,
+	type CoordinatorRuntimeDeps,
+	createCoordinatorApp,
+} from "./coordinator-api.js";
+import { verifySignature } from "./sync-auth.js";
 
 export interface CreateBetterSqliteCoordinatorAppOptions {
 	dbPath?: string;
@@ -12,9 +17,20 @@ export interface CreateBetterSqliteCoordinatorAppOptions {
 export function createBetterSqliteCoordinatorApp(
 	opts: CreateBetterSqliteCoordinatorAppOptions = {},
 ): ReturnType<typeof createCoordinatorApp> {
+	const runtime: CoordinatorRuntimeDeps = opts.runtime ?? {
+		adminSecret: () =>
+			String(process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET ?? "").trim() || null,
+		now: () => new Date().toISOString(),
+	};
+	const requestVerifier: CoordinatorRequestVerifier = async (input) =>
+		verifySignature({
+			...input,
+			bodyBytes: Buffer.from(input.bodyBytes),
+		});
 	return createCoordinatorApp({
 		storeFactory: () =>
 			new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH),
-		runtime: opts.runtime,
+		runtime,
+		requestVerifier,
 	});
 }

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -13,12 +13,12 @@ import {
 	type CoordinatorPeerRecord,
 	type CoordinatorPresenceRecord,
 	type CoordinatorReciprocalApproval,
+	type CoordinatorRequestVerifier,
 	type CoordinatorReviewJoinRequestInput,
 	type CoordinatorStoreInterface,
 	type CoordinatorUpsertPresenceInput,
 	createCoordinatorApp,
 } from "./index.js";
-import * as syncAuth from "./sync-auth.js";
 
 function createMockStore(
 	overrides?: Partial<CoordinatorStoreInterface>,
@@ -80,6 +80,8 @@ function createMockStore(
 	return { ...defaultStore, ...overrides };
 }
 
+const allowRequest: CoordinatorRequestVerifier = async () => true;
+
 describe("createCoordinatorApp dependency injection", () => {
 	it("uses injected admin secret and store factory for admin routes", async () => {
 		const store = createMockStore({
@@ -102,6 +104,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				adminSecret: () => "test-secret",
 				now: () => "2026-03-28T00:00:00Z",
 			},
+			requestVerifier: allowRequest,
 		});
 
 		const res = await app.request("/v1/admin/devices?group_id=g1", {
@@ -134,6 +137,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				adminSecret: () => null,
 				now: () => "2026-03-28T00:00:00Z",
 			},
+			requestVerifier: allowRequest,
 		});
 
 		const res = await app.request("/v1/admin/devices?group_id=g1", {
@@ -145,7 +149,6 @@ describe("createCoordinatorApp dependency injection", () => {
 	});
 
 	it("lists reciprocal approvals for the authenticated device", async () => {
-		vi.spyOn(syncAuth, "verifySignature").mockReturnValue(true);
 		const store = createMockStore({
 			getEnrollment: vi.fn(async () => ({
 				group_id: "g1",
@@ -174,6 +177,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				adminSecret: () => "test-secret",
 				now: () => "2026-03-28T00:00:00Z",
 			},
+			requestVerifier: allowRequest,
 		});
 
 		const res = await app.request(
@@ -211,7 +215,6 @@ describe("createCoordinatorApp dependency injection", () => {
 	});
 
 	it("creates a reciprocal approval for the authenticated device", async () => {
-		vi.spyOn(syncAuth, "verifySignature").mockReturnValue(true);
 		const store = createMockStore({
 			getEnrollment: vi.fn(async (groupId: string, deviceId: string) => {
 				if (groupId !== "g1") return null;
@@ -244,6 +247,7 @@ describe("createCoordinatorApp dependency injection", () => {
 				adminSecret: () => "test-secret",
 				now: () => "2026-03-28T00:00:00Z",
 			},
+			requestVerifier: allowRequest,
 		});
 
 		const res = await app.request("/v1/reciprocal-approvals", {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -10,7 +10,7 @@ import { Hono } from "hono";
 import type { InvitePayload } from "./coordinator-invites.js";
 import { encodeInvitePayload, inviteLink } from "./coordinator-invites.js";
 import type { CoordinatorEnrollment, CoordinatorStore } from "./coordinator-store-contract.js";
-import { DEFAULT_TIME_WINDOW_S, verifySignature } from "./sync-auth.js";
+import { DEFAULT_TIME_WINDOW_S } from "./sync-auth-constants.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -25,18 +25,29 @@ export interface CoordinatorRuntimeDeps {
 }
 
 export interface CreateCoordinatorAppOptions {
-	storeFactory?: () => CoordinatorStore;
-	runtime?: CoordinatorRuntimeDeps;
+	storeFactory: () => CoordinatorStore;
+	runtime: CoordinatorRuntimeDeps;
+	requestVerifier: CoordinatorRequestVerifier;
 }
+
+export interface CoordinatorVerifyRequestInput {
+	method: string;
+	pathWithQuery: string;
+	bodyBytes: Uint8Array;
+	timestamp: string;
+	nonce: string;
+	signature: string;
+	publicKey: string;
+	deviceId: string;
+}
+
+export type CoordinatorRequestVerifier = (
+	input: CoordinatorVerifyRequestInput,
+) => Promise<boolean> | boolean;
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function defaultAdminSecret(): string | null {
-	const value = (process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET ?? "").trim();
-	return value || null;
-}
 
 function authorizeAdmin(
 	headerValue: string | null | undefined,
@@ -78,11 +89,12 @@ interface AuthResult {
 async function authorizeRequest(
 	store: CoordinatorStore,
 	runtime: CoordinatorRuntimeDeps,
+	requestVerifier: CoordinatorRequestVerifier,
 	opts: {
 		method: string;
 		url: string;
 		groupId: string;
-		body: Buffer;
+		body: Uint8Array;
 		deviceId: string | null;
 		signature: string | null;
 		timestamp: string | null;
@@ -101,7 +113,7 @@ async function authorizeRequest(
 
 	let valid: boolean;
 	try {
-		valid = verifySignature({
+		valid = await requestVerifier({
 			method: opts.method,
 			pathWithQuery: pathWithQuery(opts.url),
 			bodyBytes: opts.body,
@@ -139,33 +151,43 @@ async function authorizeRequest(
 export function createCoordinatorApp(
 	opts?: CreateCoordinatorAppOptions,
 ): InstanceType<typeof Hono> {
-	const runtime: CoordinatorRuntimeDeps = opts?.runtime ?? {
-		adminSecret: defaultAdminSecret,
-		now: () => new Date().toISOString(),
-	};
-	if (!opts?.storeFactory) {
-		throw new Error("createCoordinatorApp requires a storeFactory.");
+	if (!opts?.storeFactory || !opts.runtime || !opts.requestVerifier) {
+		throw new Error("createCoordinatorApp requires storeFactory, runtime, and requestVerifier.");
 	}
+	const runtime = opts.runtime;
 	const createStore = opts.storeFactory;
+	const requestVerifier = opts.requestVerifier;
 	const app = new Hono();
+	const textDecoder = new TextDecoder();
+
+	async function readRequestBytes(c: Context): Promise<Uint8Array> {
+		return new Uint8Array(await c.req.arrayBuffer());
+	}
+
+	function parseJsonObject(raw: Uint8Array): Record<string, unknown> | null {
+		try {
+			const data: unknown = JSON.parse(textDecoder.decode(raw));
+			if (typeof data !== "object" || data === null || Array.isArray(data)) {
+				return null;
+			}
+			return data as Record<string, unknown>;
+		} catch {
+			return null;
+		}
+	}
 
 	// -----------------------------------------------------------------------
 	// POST /v1/presence — upsert device presence (authenticated)
 	// -----------------------------------------------------------------------
 
 	app.post("/v1/presence", async (c) => {
-		const raw = Buffer.from(await c.req.arrayBuffer());
+		const raw = await readRequestBytes(c);
 		if (raw.length > MAX_BODY_BYTES) {
 			return c.json({ error: "body_too_large" }, 413);
 		}
 
-		let data: Record<string, unknown>;
-		try {
-			data = JSON.parse(raw.toString("utf-8"));
-			if (typeof data !== "object" || data === null || Array.isArray(data)) {
-				return c.json({ error: "invalid_json" }, 400);
-			}
-		} catch {
+		const data = parseJsonObject(raw);
+		if (!data) {
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
@@ -176,7 +198,7 @@ export function createCoordinatorApp(
 
 		const store = createStore();
 		try {
-			const auth = await authorizeRequest(store, runtime, {
+			const auth = await authorizeRequest(store, runtime, requestVerifier, {
 				method: c.req.method,
 				url: c.req.url,
 				groupId,
@@ -240,11 +262,11 @@ export function createCoordinatorApp(
 
 		const store = createStore();
 		try {
-			const auth = await authorizeRequest(store, runtime, {
+			const auth = await authorizeRequest(store, runtime, requestVerifier, {
 				method: c.req.method,
 				url: c.req.url,
 				groupId,
-				body: Buffer.alloc(0),
+				body: new Uint8Array(0),
 				deviceId: c.req.header("X-Opencode-Device") ?? null,
 				signature: c.req.header("X-Opencode-Signature") ?? null,
 				timestamp: c.req.header("X-Opencode-Timestamp") ?? null,
@@ -278,11 +300,11 @@ export function createCoordinatorApp(
 
 		const store = createStore();
 		try {
-			const auth = await authorizeRequest(store, runtime, {
+			const auth = await authorizeRequest(store, runtime, requestVerifier, {
 				method: c.req.method,
 				url: c.req.url,
 				groupId,
-				body: Buffer.alloc(0),
+				body: new Uint8Array(0),
 				deviceId: c.req.header("X-Opencode-Device") ?? null,
 				signature: c.req.header("X-Opencode-Signature") ?? null,
 				timestamp: c.req.header("X-Opencode-Timestamp") ?? null,
@@ -308,18 +330,13 @@ export function createCoordinatorApp(
 	// -----------------------------------------------------------------------
 
 	app.post("/v1/reciprocal-approvals", async (c) => {
-		const raw = Buffer.from(await c.req.arrayBuffer());
+		const raw = await readRequestBytes(c);
 		if (raw.length > MAX_BODY_BYTES) {
 			return c.json({ error: "body_too_large" }, 413);
 		}
 
-		let data: Record<string, unknown>;
-		try {
-			data = JSON.parse(raw.toString("utf-8"));
-			if (typeof data !== "object" || data === null || Array.isArray(data)) {
-				return c.json({ error: "invalid_json" }, 400);
-			}
-		} catch {
+		const data = parseJsonObject(raw);
+		if (!data) {
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
@@ -331,7 +348,7 @@ export function createCoordinatorApp(
 
 		const store = createStore();
 		try {
-			const auth = await authorizeRequest(store, runtime, {
+			const auth = await authorizeRequest(store, runtime, requestVerifier, {
 				method: c.req.method,
 				url: c.req.url,
 				groupId,
@@ -371,16 +388,11 @@ export function createCoordinatorApp(
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
-		const raw = Buffer.from(await c.req.arrayBuffer());
+		const raw = await readRequestBytes(c);
 		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
 
-		let data: Record<string, unknown>;
-		try {
-			data = JSON.parse(raw.toString("utf-8"));
-			if (typeof data !== "object" || data === null || Array.isArray(data)) {
-				return c.json({ error: "invalid_json" }, 400);
-			}
-		} catch {
+		const data = parseJsonObject(raw);
+		if (!data) {
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
@@ -435,16 +447,11 @@ export function createCoordinatorApp(
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
-		const raw = Buffer.from(await c.req.arrayBuffer());
+		const raw = await readRequestBytes(c);
 		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
 
-		let data: Record<string, unknown>;
-		try {
-			data = JSON.parse(raw.toString("utf-8"));
-			if (typeof data !== "object" || data === null || Array.isArray(data)) {
-				return c.json({ error: "invalid_json" }, 400);
-			}
-		} catch {
+		const data = parseJsonObject(raw);
+		if (!data) {
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
@@ -474,16 +481,11 @@ export function createCoordinatorApp(
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
-		const raw = Buffer.from(await c.req.arrayBuffer());
+		const raw = await readRequestBytes(c);
 		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
 
-		let data: Record<string, unknown>;
-		try {
-			data = JSON.parse(raw.toString("utf-8"));
-			if (typeof data !== "object" || data === null || Array.isArray(data)) {
-				return c.json({ error: "invalid_json" }, 400);
-			}
-		} catch {
+		const data = parseJsonObject(raw);
+		if (!data) {
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
@@ -509,16 +511,11 @@ export function createCoordinatorApp(
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
-		const raw = Buffer.from(await c.req.arrayBuffer());
+		const raw = await readRequestBytes(c);
 		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
 
-		let data: Record<string, unknown>;
-		try {
-			data = JSON.parse(raw.toString("utf-8"));
-			if (typeof data !== "object" || data === null || Array.isArray(data)) {
-				return c.json({ error: "invalid_json" }, 400);
-			}
-		} catch {
+		const data = parseJsonObject(raw);
+		if (!data) {
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
@@ -544,16 +541,11 @@ export function createCoordinatorApp(
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
-		const raw = Buffer.from(await c.req.arrayBuffer());
+		const raw = await readRequestBytes(c);
 		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
 
-		let data: Record<string, unknown>;
-		try {
-			data = JSON.parse(raw.toString("utf-8"));
-			if (typeof data !== "object" || data === null || Array.isArray(data)) {
-				return c.json({ error: "invalid_json" }, 400);
-			}
-		} catch {
+		const data = parseJsonObject(raw);
+		if (!data) {
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
@@ -655,16 +647,11 @@ export function createCoordinatorApp(
 	// -----------------------------------------------------------------------
 
 	app.post("/v1/join", async (c) => {
-		const raw = Buffer.from(await c.req.arrayBuffer());
+		const raw = await readRequestBytes(c);
 		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
 
-		let data: Record<string, unknown>;
-		try {
-			data = JSON.parse(raw.toString("utf-8"));
-			if (typeof data !== "object" || data === null || Array.isArray(data)) {
-				return c.json({ error: "invalid_json" }, 400);
-			}
-		} catch {
+		const data = parseJsonObject(raw);
+		if (!data) {
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
@@ -760,16 +747,21 @@ async function handleJoinRequestReview(
 	const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), deps.runtime);
 	if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
-	const raw = Buffer.from(await c.req.arrayBuffer());
+	const raw = new Uint8Array(await c.req.arrayBuffer());
 	if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
 
-	let data: Record<string, unknown>;
+	let data: Record<string, unknown> | null;
 	try {
-		data = JSON.parse(raw.toString("utf-8"));
-		if (typeof data !== "object" || data === null || Array.isArray(data)) {
-			return c.json({ error: "invalid_json" }, 400);
-		}
+		const textDecoder = new TextDecoder();
+		const parsed: unknown = JSON.parse(textDecoder.decode(raw));
+		data =
+			typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+				? (parsed as Record<string, unknown>)
+				: null;
 	} catch {
+		data = null;
+	}
+	if (!data) {
 		return c.json({ error: "invalid_json" }, 400);
 	}
 

--- a/packages/core/src/coordinator-invites.ts
+++ b/packages/core/src/coordinator-invites.ts
@@ -15,20 +15,40 @@ export interface InvitePayload {
 	team_name: string | null;
 }
 
+function bytesToBase64(bytes: Uint8Array): string {
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary);
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+	const binary = atob(base64);
+	const bytes = new Uint8Array(binary.length);
+	for (let index = 0; index < binary.length; index += 1) {
+		bytes[index] = binary.charCodeAt(index);
+	}
+	return bytes;
+}
+
+function toBase64Url(base64: string): string {
+	return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(value: string): string {
+	const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+	return padded + "=".repeat((4 - (padded.length % 4)) % 4);
+}
+
 /** Encode an invite payload as a compact base64url string (no padding). */
 export function encodeInvitePayload(payload: InvitePayload): string {
 	const json = JSON.stringify(payload);
 	const bytes = new TextEncoder().encode(json);
-	const base64 = Buffer.from(bytes).toString("base64url");
-	// base64url from Buffer already omits padding — strip defensively
-	return base64.replace(/=+$/, "");
+	return toBase64Url(bytesToBase64(bytes));
 }
 
 /** Decode a base64url invite payload string back to an InvitePayload. */
 export function decodeInvitePayload(value: string): InvitePayload {
-	// Re-add padding that was stripped
-	const padded = value + "=".repeat((4 - (value.length % 4)) % 4);
-	const json = Buffer.from(padded, "base64url").toString("utf-8");
+	const json = new TextDecoder().decode(base64ToBytes(fromBase64Url(value)));
 	const data: unknown = JSON.parse(json);
 	if (typeof data !== "object" || data === null) {
 		throw new Error("invalid invite payload");

--- a/packages/core/src/d1-coordinator-runtime.test.ts
+++ b/packages/core/src/d1-coordinator-runtime.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { Database as DatabaseType, Statement } from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connectCoordinator } from "./better-sqlite-coordinator-store.js";
+import type { CoordinatorRequestVerifier } from "./coordinator-api.js";
 import { createD1CoordinatorApp } from "./d1-coordinator-runtime.js";
 import {
 	D1CoordinatorStore,
@@ -81,6 +82,8 @@ describe("createD1CoordinatorApp", () => {
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
+	const requestVerifier: CoordinatorRequestVerifier = async () => true;
+
 	it("serves coordinator admin data from the D1-backed adapter", async () => {
 		const store = new D1CoordinatorStore(d1db);
 		await store.createGroup("g1", "Team Alpha");
@@ -96,6 +99,7 @@ describe("createD1CoordinatorApp", () => {
 			db: d1db,
 			adminSecret: "test-secret",
 			now: () => "2026-03-28T00:00:00Z",
+			requestVerifier,
 		});
 
 		const res = await app.request("/v1/admin/devices?group_id=g1", {
@@ -123,6 +127,7 @@ describe("createD1CoordinatorApp", () => {
 			db: d1db,
 			adminSecret: null,
 			now: () => "2026-03-28T00:00:00Z",
+			requestVerifier,
 		});
 
 		const res = await app.request("/v1/admin/devices?group_id=g1", {

--- a/packages/core/src/d1-coordinator-runtime.ts
+++ b/packages/core/src/d1-coordinator-runtime.ts
@@ -1,10 +1,15 @@
-import { type CoordinatorRuntimeDeps, createCoordinatorApp } from "./coordinator-api.js";
+import {
+	type CoordinatorRequestVerifier,
+	type CoordinatorRuntimeDeps,
+	createCoordinatorApp,
+} from "./coordinator-api.js";
 import { D1CoordinatorStore, type D1DatabaseLike } from "./d1-coordinator-store.js";
 
 export interface CreateD1CoordinatorAppOptions {
 	db: D1DatabaseLike;
 	adminSecret?: string | null;
 	now?: () => string;
+	requestVerifier: CoordinatorRequestVerifier;
 }
 
 export function createD1CoordinatorApp(
@@ -17,5 +22,6 @@ export function createD1CoordinatorApp(
 	return createCoordinatorApp({
 		storeFactory: () => new D1CoordinatorStore(opts.db),
 		runtime,
+		requestVerifier: opts.requestVerifier,
 	});
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,12 @@ export {
 	coordinatorRenameDeviceAction,
 	coordinatorReviewJoinRequestAction,
 } from "./coordinator-actions.js";
-export type { CoordinatorRuntimeDeps, CreateCoordinatorAppOptions } from "./coordinator-api.js";
+export type {
+	CoordinatorRequestVerifier,
+	CoordinatorRuntimeDeps,
+	CoordinatorVerifyRequestInput,
+	CreateCoordinatorAppOptions,
+} from "./coordinator-api.js";
 export { createCoordinatorApp } from "./coordinator-api.js";
 export type { InvitePayload } from "./coordinator-invites.js";
 export {
@@ -253,12 +258,12 @@ export {
 	buildAuthHeaders,
 	buildCanonicalRequest,
 	cleanupNonces,
-	DEFAULT_TIME_WINDOW_S,
 	recordNonce,
 	SIGNATURE_VERSION,
 	signRequest,
 	verifySignature,
 } from "./sync-auth.js";
+export { DEFAULT_TIME_WINDOW_S } from "./sync-auth-constants.js";
 export type { BootstrapOptions, BootstrapResult } from "./sync-bootstrap.js";
 export { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
 export type { SyncDaemonOptions, SyncDaemonPhase, SyncTickResult } from "./sync-daemon.js";

--- a/packages/core/src/internal/cloudflare-coordinator.ts
+++ b/packages/core/src/internal/cloudflare-coordinator.ts
@@ -1,4 +1,11 @@
+export type {
+	CoordinatorRequestVerifier,
+	CoordinatorRuntimeDeps,
+	CoordinatorVerifyRequestInput,
+	CreateCoordinatorAppOptions,
+} from "../coordinator-api.js";
 export type { CreateD1CoordinatorAppOptions } from "../d1-coordinator-runtime.js";
 export { createD1CoordinatorApp } from "../d1-coordinator-runtime.js";
 export type { D1DatabaseLike, D1PreparedStatementLike } from "../d1-coordinator-store.js";
 export { D1CoordinatorStore } from "../d1-coordinator-store.js";
+export { DEFAULT_TIME_WINDOW_S } from "../sync-auth-constants.js";

--- a/packages/core/src/sync-auth-constants.ts
+++ b/packages/core/src/sync-auth-constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TIME_WINDOW_S = 300;

--- a/packages/core/src/sync-auth.ts
+++ b/packages/core/src/sync-auth.ts
@@ -17,6 +17,7 @@ import { lt } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import * as schema from "./schema.js";
+import { DEFAULT_TIME_WINDOW_S } from "./sync-auth-constants.js";
 import { loadPrivateKey } from "./sync-identity.js";
 
 // ---------------------------------------------------------------------------
@@ -31,7 +32,6 @@ import { loadPrivateKey } from "./sync-identity.js";
  * be removed.  During migration, the verifier accepts both versions.
  */
 export const SIGNATURE_VERSION = "v2";
-export const DEFAULT_TIME_WINDOW_S = 300;
 
 // ---------------------------------------------------------------------------
 // Canonical request


### PR DESCRIPTION
## Description

The original attempt to remove `nodejs_compat` from the Cloudflare coordinator worker was unsafe: builds passed and tests stayed green, but the worker runtime still pulled in Node-only auth code through `coordinator-api`, `sync-auth`, `Buffer`, and `process.env` references.

This makes the runtime boundary explicit instead of relying on implicit Node behavior:

- `coordinator-api` now requires injected `runtime` + `requestVerifier`
- BetterSQLite runtime provides the existing Node verifier (`sync-auth`)
- D1 runtime requires a verifier explicitly
- Cloudflare worker provides a WebCrypto Ed25519 verifier
- invite encoding/decoding is now runtime-safe (no `Buffer` dependency)
- coordinator request parsing uses `Uint8Array` / `TextDecoder` on the shared path
- `DEFAULT_TIME_WINDOW_S` moved to a lightweight shared constants module
- `wrangler.jsonc` stays free of `nodejs_compat`; tests keep compat only in Miniflare where the Vitest runner itself still needs it

This keeps the production worker runtime clean without a broad crypto rewrite and preserves the existing Node path intact.

Refs: codemem-ck3v

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests/build pass for changed surfaces
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:
- `pnpm --filter @codemem/core build`
- `pnpm exec vitest run packages/core/src/coordinator-api.test.ts packages/core/src/d1-coordinator-runtime.test.ts packages/core/src/coordinator-invites.test.ts`
- `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker`
- `pnpm --filter @codemem/cloudflare-coordinator-worker build`

Also verified the rebuilt worker bundle no longer contains `node:crypto`, `process.env`, or `Buffer` references on the runtime path.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced