### PR TITLE
docs(cloudflare): point example bootstrap at real worker source

### DIFF
--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -165,9 +165,11 @@ introducing Cloudflare-specific runtime/storage constraints.
 
 ## Cloudflare Worker reference deployment
 
-A Cloudflare Worker reference implementation exists in `examples/cloudflare-coordinator/`. It was built as a separate
-Worker/D1 implementation of the coordinator contract and remains useful for experimentation, but it is not the
-canonical runtime for current product development.
+A Cloudflare Worker reference path exists for the coordinator contract. The current Worker implementation source lives in
+`packages/cloudflare-coordinator-worker/`, while `examples/cloudflare-coordinator/` provides the bootstrap/smoke-check
+helpers and a Wrangler wrapper config for that package worker.
+
+It remains useful for experimentation, but it is not the canonical runtime for current product development.
 
 The long-term Cloudflare direction should build from the TypeScript coordinator contract rather than from the old Python
 era deployment story. Today, the practical sequence is:

--- a/examples/cloudflare-coordinator/README.md
+++ b/examples/cloudflare-coordinator/README.md
@@ -1,11 +1,19 @@
 # Cloudflare Worker reference coordinator
 
 This is a secondary reference deployment for the coordinator-backed discovery contract. The canonical deployment target
-is the built-in TypeScript coordinator (`codemem sync coordinator serve`). See `docs/coordinator-discovery.md` for the
-recommended deployment path.
+is still the built-in TypeScript coordinator (`codemem sync coordinator serve`). See `docs/coordinator-discovery.md`
+for the recommended deployment path.
 
-The product is now TS-first. This Worker example remains useful for experimenting with Workers + D1, but it is not the
-mainline coordinator runtime and should not be assumed to have feature parity with the built-in coordinator.
+The product is now TS-first. The live Worker implementation source lives in
+`packages/cloudflare-coordinator-worker/src/index.ts`. This example directory now exists to provide:
+
+- bootstrap helpers
+- smoke-check tooling
+- a local `wrangler.toml` wrapper for deploying the package worker source with D1 bindings
+- schema/bootstrap guidance for the experimental Worker path
+
+It remains useful for experimenting with Workers + D1, but it is not the mainline coordinator runtime and should not be
+assumed to have feature parity with the built-in coordinator.
 
 It is intentionally narrow:
 
@@ -17,9 +25,9 @@ It is not a relay, queue, or central memory store.
 
 ## Files
 
-- `src/index.mjs` - Worker implementation
-- `schema.sql` - D1 schema
-- `wrangler.toml.example` - example Wrangler config
+- `../../packages/cloudflare-coordinator-worker/src/index.ts` - Worker implementation source used by this example's Wrangler config
+- `../../packages/cloudflare-coordinator-worker/schema.sql` - D1 schema used by the package worker
+- `wrangler.toml.example` - example Wrangler config that points at the package worker source
 - `bootstrap.py` - guided bootstrap helper for local device enrollment
 - `smoke_check.py` - live smoke-check script for deployed endpoints
 
@@ -52,11 +60,20 @@ Then edit `examples/cloudflare-coordinator/wrangler.toml` and replace:
 
 with the actual D1 database ID from step 2.
 
+That `wrangler.toml` already points at the package worker source:
+
+- `../../packages/cloudflare-coordinator-worker/src/index.ts`
+
+So you are deploying the current TS Worker implementation, not a dead copy in this examples directory.
+
 ### 4. Apply the schema
 
 ```fish
-wrangler d1 execute codemem-coordinator --remote --file examples/cloudflare-coordinator/schema.sql
+wrangler d1 execute codemem-coordinator --remote --file packages/cloudflare-coordinator-worker/schema.sql
 ```
+
+Use the package worker schema here, not the older cut-down example schema. The package worker includes invite, join,
+and reciprocal-approval tables that the old example-only schema does not.
 
 ### 5. Deploy the Worker
 

--- a/examples/cloudflare-coordinator/bootstrap.py
+++ b/examples/cloudflare-coordinator/bootstrap.py
@@ -19,7 +19,12 @@ from codemem.sync_identity import ensure_device_identity, fingerprint_public_key
 app = typer.Typer(add_completion=False, help="Bootstrap the Cloudflare coordinator example")
 console = Console()
 WRANGLER_TOML_TEMPLATE = Path(__file__).with_name("wrangler.toml.example")
-SCHEMA_SQL_PATH = Path(__file__).with_name("schema.sql")
+SCHEMA_SQL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "packages"
+    / "cloudflare-coordinator-worker"
+    / "schema.sql"
+)
 DRY_RUN_DATABASE_ID = "00000000-0000-0000-0000-000000000000"
 
 

--- a/examples/cloudflare-coordinator/wrangler.toml.example
+++ b/examples/cloudflare-coordinator/wrangler.toml.example
@@ -1,6 +1,7 @@
 name = "codemem-coordinator"
-main = "src/index.mjs"
-compatibility_date = "2026-03-12"
+main = "../../packages/cloudflare-coordinator-worker/src/index.ts"
+compatibility_date = "2026-03-28"
+compatibility_flags = ["nodejs_compat"]
 
 [[d1_databases]]
 binding = "COORDINATOR_DB"


### PR DESCRIPTION
## Description

The Cloudflare example docs/config had drifted into nonsense: the example Wrangler config and README still pointed at `examples/cloudflare-coordinator/src/index.mjs`, which does not exist anymore.

This fixes the example path so it reflects the actual repo layout:
- `examples/cloudflare-coordinator/wrangler.toml.example` now points at `../../packages/cloudflare-coordinator-worker/src/index.ts`
- `examples/cloudflare-coordinator/README.md` explains that the example directory is a bootstrap/smoke-check wrapper around the package worker, not a dead duplicated implementation
- `docs/coordinator-discovery.md` now describes the Worker reference path accurately instead of implying the example directory itself is the implementation

Refs: codemem-ppk9

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- Documentation/config correctness update only

## Checklist

- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced