### PR TITLE
docs: align public docs with 0.22 CLI and release flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,37 +4,38 @@ Thanks for helping improve codemem.
 
 ## Local setup
 
-```bash
-uv sync
-uv run codemem --help
+```text
+pnpm install
+pnpm run codemem --help
 ```
 
 ## Quality checks
 
 Run these before opening a PR:
 
-```bash
-uv run pytest
-uv run ruff check codemem tests
-uv run ruff format --check codemem tests
+```text
+pnpm run lint
+pnpm run typecheck
+pnpm run test
+pnpm build
 ```
 
 Targeted test examples:
 
-```bash
-uv run pytest tests/test_store.py
-uv run pytest tests/test_store.py::test_store_roundtrip
-uv run pytest -k "raw_event and sweeper"
+```text
+pnpm vitest run packages/cli/src/commands/serve.test.ts
+pnpm vitest run packages/viewer-server/src/index.test.ts
+pnpm vitest run packages/core/src/index.test.ts
 ```
 
 ## Viewer/plugin development
 
-- Viewer UI is embedded in `codemem/viewer.py`.
+- Viewer UI source is `packages/ui/` and is served by `packages/viewer-server/`.
 - OpenCode plugin source is `packages/opencode-plugin/.opencode/plugins/codemem.js`.
 - Restart the viewer after UI changes:
 
-```bash
-uv run codemem serve --restart
+```text
+pnpm run codemem serve restart
 ```
 
 ## Release workflow
@@ -43,23 +44,24 @@ Releases are tag-driven (`vX.Y.Z`) and run via `.github/workflows/release.yml`.
 
 Before tagging:
 
-1. Ensure CI is green on `main`
-2. Bump version fields:
-   - Run `uv run python scripts/release_version.py set X.Y.Z`
-3. Regenerate and commit artifacts:
-   - `uv sync` (commit `uv.lock`)
-   - `viewer_ui/`: `bun install` then `bun run build` (commit updated `codemem/viewer_static/app.js`)
-4. Tag and push:
+1. Create a release branch and PR. Do not push release changes directly to `main`.
+2. Bump the shared version fields listed in `docs/versioning.md`.
+3. Regenerate JS artifacts and lockfiles:
+   - `pnpm install`
+   - `pnpm build`
+4. Wait for CI to pass and merge the release PR.
+5. Switch to updated `main`, verify `HEAD` is the merged release commit, and confirm the worktree is clean.
+6. Tag from `main` and push the tag:
 
-```bash
+```text
 git tag vX.Y.Z
 git push origin vX.Y.Z
 ```
 
 Verify release version alignment before tagging:
 
-```bash
-uv run python scripts/release_version.py check
+```text
+pnpm run release:preflight-tag
 ```
 
 ## Docs expectations

--- a/README.md
+++ b/README.md
@@ -19,13 +19,12 @@ Persistent memory for [OpenCode](https://opencode.ai) and [Claude Code](https://
 
 **Prerequisites:** Node.js 22+ and npm (or pnpm)
 
-1. Add the plugin to your OpenCode config (`~/.config/opencode/opencode.jsonc`):
+### OpenCode
 
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@codemem/opencode-plugin"]
-}
+1. Install the OpenCode plugin and MCP config:
+
+```text
+npx -y codemem setup --opencode-only
 ```
 
 2. Restart OpenCode.
@@ -34,7 +33,7 @@ The OpenCode plugin manages backend execution automatically — no separate glob
 
 3. Verify:
 
-```bash
+```text
 # Works on fresh installs (no global codemem needed)
 npx -y codemem stats
 npx -y codemem db raw-events-status
@@ -44,7 +43,7 @@ That's it. The plugin captures activity, builds memories, and injects context fr
 
 If you want `codemem` available directly on your `PATH` for manual commands, install the CLI globally:
 
-```bash
+```text
 npm install -g codemem
 ```
 
@@ -55,7 +54,13 @@ OpenCode plugin and CLI are now split intentionally:
 
 ### Claude Code (marketplace install)
 
-In [Claude Code](https://claude.ai/code), add the codemem marketplace source and install the plugin:
+1. Install codemem's Claude MCP config:
+
+```text
+npx -y codemem setup --claude-only
+```
+
+2. In [Claude Code](https://claude.ai/code), add the codemem marketplace source and install the plugin:
 
 ```text
 /plugin marketplace add kunickiaj/codemem
@@ -68,10 +73,7 @@ Claude hook ingestion is HTTP enqueue-first (`POST /api/claude-hooks`) and falls
 
 Claude hook events share the same raw-event queue pipeline used by OpenCode. `UserPromptSubmit` runs
 capture ingest in the background and injects memory context via Claude `additionalContext` using
-local CLI/store pack generation by default, with optional HTTP `/api/pack` fallback.
-
-The packaged Claude hook shell scripts are thin wrappers over TS CLI commands:
-`codemem claude-hook-ingest` and `codemem claude-hook-inject`.
+local pack generation by default, with optional HTTP `/api/pack` fallback.
 
 > Migrating from `opencode-mem`? See [docs/rename-migration.md](docs/rename-migration.md).
 
@@ -129,11 +131,11 @@ for manual prompt injection. `codemem memory compact` remains deferred.
 
 To give the LLM direct access to memory tools (search, timeline, pack, remember, forget):
 
-```bash
-codemem install-mcp
+```text
+codemem setup --opencode-only
 ```
 
-This updates your OpenCode config to register the MCP server. Restart OpenCode to activate.
+This updates your OpenCode config to install the plugin and register the MCP server. Restart OpenCode to activate.
 
 ## Configuration
 
@@ -150,7 +152,7 @@ Common overrides:
 The viewer includes a grouped Settings modal (`Connection`, `Processing`, `Device Sync`) with shell-agnostic labels and an advanced-controls toggle for technical fields.
 - Settings show effective values (configured or default) and only persist changed fields on save.
 
-Observer runtime/auth in `0.16`:
+Observer runtime/auth:
 
 - Runtime options: `api_http` and `claude_sidecar`.
 - `api_http` defaults to `gpt-5.1-codex-mini` (OpenAI path) unless you set `observer_model`.
@@ -170,15 +172,12 @@ Observer runtime/auth in `0.16`:
 
 Share project knowledge with teammates or back up memories across machines.
 
-```bash
+```text
 # Export current project
 codemem export-memories project.json
 
 # Import on another machine (idempotent, safe to re-run)
 codemem import-memories project.json --remap-project ~/workspace/myproject
-
-# Import from claude-mem
-codemem import-from-claude-mem ~/.claude-mem/claude-mem.db
 ```
 
 See `codemem export-memories --help` and `codemem import-memories --help` for full options.
@@ -187,7 +186,7 @@ See `codemem export-memories --help` and `codemem import-memories --help` for fu
 
 Replicate memories across devices without a central server.
 
-```bash
+```text
 codemem sync enable        # generate device keys
 codemem sync pair          # generate pairing payload
 codemem sync start         # start sync daemon
@@ -211,7 +210,7 @@ Embeddings are stored in sqlite-vec and written automatically when memories are 
 
 ### Local development
 
-```bash
+```text
 pnpm install
 pnpm build
 pnpm run codemem --help
@@ -219,7 +218,7 @@ pnpm run codemem --help
 
 ### Via npx (no install)
 
-```bash
+```text
 npx -y codemem stats
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -222,7 +222,7 @@ PL->>OC: append codemem context to system prompt
 
 The observer turns raw session transcripts into typed, structured memories. It's the quality gate — everything that ends up in the store passes through here.
 
-### Runtime and auth adapter (0.16)
+### Runtime and auth adapter
 
 - The observer still uses one pipeline (extract -> prompt -> parse -> persist); runtime/auth choices are adapter inputs, not a separate path.
 - Supported runtime values are `api_http` and `claude_sidecar`.
@@ -295,7 +295,10 @@ The OpenCode adapter streams each captured event to the viewer API (`captureEven
 
 When stream delivery is unavailable, the adapter can enqueue raw events through the CLI fallback path (`enqueue-raw-event`) so events still enter durable queue processing.
 
-Claude hook ingestion is enqueue-first (`POST /api/claude-hooks`) with CLI fallback and does not flush by default.
+Claude hook ingestion is enqueue-first (`POST /api/claude-hooks`) with CLI fallback. The route nudges the raw-event
+sweeper after enqueue, but actual auto-flush still depends on `CODEMEM_RAW_EVENTS_AUTO_FLUSH=1`; otherwise processing
+waits for the normal idle/sweeper path. `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` remains a separate opt-in for `Stop`
+events.
 
 ### OpenCode session finalization triggers
 - `session.idle` — finalizes current local buffer

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -46,9 +46,8 @@ Ingest one Claude hook payload from stdin (this is what the installed hook scrip
 printf '%s\n' '{"hook_event_name":"SessionStart","session_id":"sess-1","cwd":"/tmp/demo"}' | codemem claude-hook-ingest
 ```
 
-`inject-context-hook.sh` is also a thin wrapper and delegates prompt-time context output to:
-
-- `codemem claude-hook-inject`
+`inject-context-hook.sh` is also a thin wrapper and delegates prompt-time context output to
+codemem's local pack-generation path, with optional HTTP `/api/pack` fallback.
 
 By default, `SessionEnd` triggers a boundary flush after enqueue to preserve progress without waiting for sweeper timing. Set `CODEMEM_CLAUDE_HOOK_FLUSH=0` to force enqueue-only behavior, and set `CODEMEM_CLAUDE_HOOK_FLUSH_ON_STOP=1` to include `Stop` boundary flush.
 
@@ -64,7 +63,7 @@ The packaged template currently registers these hook events in `plugins/claude/h
 - sends the hook payload into capture ingest (`ingest-hook.sh`) in the background, and
 - returns `hookSpecificOutput.additionalContext` from local CLI/store pack generation for prompt-time memory injection.
 
-`claude-hook-inject` uses local pack generation first and falls back to `/api/pack` only when local pack generation fails and `CODEMEM_INJECT_HTTP_FALLBACK` is enabled.
+Prompt-time Claude injection uses local pack generation first and falls back to `/api/pack` only when local generation fails and `CODEMEM_INJECT_HTTP_FALLBACK` is enabled.
 
 For Claude hooks, project resolution precedence is:
 
@@ -109,9 +108,9 @@ slash commands in the OpenCode chat input.
 Provider/model selection can be overridden with `CODEMEM_OBSERVER_PROVIDER` and
 `CODEMEM_OBSERVER_MODEL`. Custom providers are loaded from OpenCode config.
 
-### Observer auth modes (0.16)
+### Observer auth modes
 
-Observer execution in `0.16` supports both API and Claude runtime paths.
+Observer execution supports both API and Claude runtime paths.
 
 - Runtime values: `api_http`, `claude_sidecar`.
 - `claude_sidecar` runs observer calls via local Claude runtime auth (no `ANTHROPIC_API_KEY` required).
@@ -244,7 +243,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_CLAUDE_HOOK_HTTP_MAX_TIME_S` | Claude hook HTTP enqueue total timeout in seconds (default `2`). |
 | `CODEMEM_INJECT_HTTP_CONNECT_TIMEOUT_S` | `UserPromptSubmit` pack injection connect timeout in seconds (default `1`). |
 | `CODEMEM_INJECT_HTTP_MAX_TIME_S` | `UserPromptSubmit` pack injection total timeout in seconds (default `2`). |
-| `CODEMEM_INJECT_HTTP_FALLBACK` | Set to `0` to disable HTTP `/api/pack` fallback for `claude-hook-inject` (default `1`). |
+| `CODEMEM_INJECT_HTTP_FALLBACK` | Set to `0` to disable HTTP `/api/pack` fallback for Claude prompt-time injection (default `1`). |
 | `CODEMEM_INJECT_MAX_CHARS` | Max chars returned as Claude `additionalContext` (default `16000`). |
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -87,26 +87,6 @@ Command/file token caching notes:
 - Backfill existing memories with: `codemem embed --dry-run` then `codemem embed`.
 - If sqlite-vec fails to load, semantic recall is skipped and keyword search remains.
 
-## Hybrid retrieval evaluation
-
-- Evaluate baseline vs hybrid retrieval with judged queries:
-  - `codemem hybrid-eval /path/to/judged.jsonl --limit 8`
-- Use threshold gates for rollout decisions:
-  - `codemem hybrid-eval /path/to/judged.jsonl --min-delta-precision 0.01 --min-delta-recall 0.01`
-- Save machine-readable output:
-  - `codemem hybrid-eval /path/to/judged.jsonl --json-out .tmp/hybrid-eval.json`
-
-Judged query JSONL format:
-
-```json
-{"query":"sync diagnostics","relevant_ids":[123,456],"filters":{"project":"codemem"}}
-{"query":"viewer autostart","relevant_ids":[789]}
-```
-
-- `relevant_ids` are memory item IDs expected in top-k.
-- `filters` is optional and uses the same retrieval filter shape as normal search commands.
-- Supported retrieval filters include `project`, `kind`, `include_actor_ids`, `exclude_actor_ids`, `include_workspace_ids`, `exclude_workspace_ids`, `include_workspace_kinds`, `exclude_workspace_kinds`, and `personal_first`.
-
 ## Sync
 
 ### Enable + run

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -25,6 +25,17 @@ Version bumps are prepared on a release branch and touch these files:
 - `packages/core/src/index.ts` (`VERSION` export)
 - `packages/core/src/index.test.ts` (version assertion)
 - `packages/opencode-plugin/.opencode/plugins/codemem.js` (`PINNED_BACKEND_VERSION`)
+- `.claude-plugin/marketplace.json` (marketplace metadata version)
+- `plugins/claude/.claude-plugin/plugin.json` (Claude plugin metadata version)
+
+Regenerate release artifacts before opening the release PR:
+
+- `pnpm install` (lockfile and generated artifacts when applicable)
+- `pnpm build` (viewer UI bundle/assets)
+
+Keep `.opencode/.npmrc` pinned to the public npm registry:
+
+- `registry=https://registry.npmjs.org/`
 
 ## Release tag preflight
 
@@ -38,6 +49,8 @@ This verifies release tagging safety in two contexts:
 
 - local preflight: target commit must match `origin/main` HEAD, and the working tree must be clean
 - CI tag workflow: tagged commit must be reachable from `origin/main` (avoids false failures if `main` advances after tag push)
+
+Tag only after the release PR has merged to `main` and you have verified that `HEAD` on `main` is the merged release commit. Do not tag the release branch tip directly.
 
 ## Compatibility check
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,7 @@ npx -y codemem stats
 
 ```bash
 codemem --help
+codemem setup --opencode-only
 codemem stats
 codemem search "query"
 codemem serve start

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -4,7 +4,13 @@ Persistent memory plugin for [OpenCode](https://opencode.ai).
 
 ## Install
 
-Add the package name to your OpenCode config:
+Recommended:
+
+```text
+npx -y codemem setup --opencode-only
+```
+
+Manual config also works. Add the package name to your OpenCode config:
 
 ```json
 {


### PR DESCRIPTION
## Description
- update public docs to match the shipped 0.22 TypeScript CLI and setup flow
- remove stale references to commands and install paths that no longer exist
- align release and contributor docs with the current pnpm-based workflow

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm run codemem --help`
- `pnpm run codemem setup --help`
- `pnpm run codemem memory --help`
- `pnpm run codemem serve --help`
- `pnpm run codemem sync coordinator --help`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
