### PR TITLE
fix: harden viewer config exposure

### DIFF
--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -16,6 +16,7 @@ let settingsBaseline: Record<string, unknown> = {};
 let settingsEnvOverrides: Record<string, unknown> = {};
 let settingsTouchedKeys = new Set<string>();
 let settingsShellMounted = false;
+let settingsProtectedKeys = new Set<string>();
 let settingsStartPolling: (() => void) | null = null;
 let settingsRefresh: (() => void) | null = null;
 const SETTINGS_ADVANCED_KEY = 'codemem-settings-advanced';
@@ -105,6 +106,15 @@ const INPUT_TO_CONFIG_KEY: Record<keyof SettingsFormState, string> = {
   syncCoordinatorTimeout: 'sync_coordinator_timeout_s',
   syncCoordinatorPresenceTtl: 'sync_coordinator_presence_ttl_s',
 };
+
+const PROTECTED_VIEWER_CONFIG_KEYS = new Set([
+  'claude_command',
+  'observer_base_url',
+  'observer_auth_file',
+  'observer_auth_command',
+  'observer_headers',
+  'sync_coordinator_url',
+]);
 
 const EMPTY_FORM_STATE: SettingsFormState = {
   claudeCommand: '',
@@ -674,6 +684,14 @@ function buildSettingsNotice(payload: any): { message: string; type: 'success' |
   return { message: lines.join(' '), type: hasWarning ? 'warning' : 'success' };
 }
 
+function isProtectedConfigKey(key: string): boolean {
+  return settingsProtectedKeys.has(key) || PROTECTED_VIEWER_CONFIG_KEYS.has(key);
+}
+
+function protectedConfigHelp(key: string): string {
+  return `${key} is read-only in the viewer for security. Edit the config file or environment instead.`;
+}
+
 function formStateFromPayload(payload: any): SettingsFormState {
   const config = payload.config || {};
   const effective = payload.effective || {};
@@ -743,9 +761,15 @@ export function renderConfigModal(payload: any) {
   const config = payload.config || {};
   const envOverrides =
     payload.env_overrides && typeof payload.env_overrides === 'object' ? payload.env_overrides : {};
+  const protectedKeys = Array.isArray(payload.protected_keys)
+    ? payload.protected_keys.filter(
+        (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0,
+      )
+    : [];
   const values = formStateFromPayload(payload);
 
   settingsEnvOverrides = envOverrides;
+  settingsProtectedKeys = new Set(protectedKeys);
   state.configDefaults = defaults;
   state.configPath = payload.path || '';
 
@@ -947,6 +971,9 @@ export async function saveSettings(startPolling: () => void, refreshCallback: ()
     const current = collectSettingsPayload({ allowUntouchedParseErrors: true });
     const changed: Record<string, unknown> = {};
     Object.entries(current).forEach(([key, value]) => {
+      if (isProtectedConfigKey(key)) {
+        return;
+      }
       if (hasOwn(settingsEnvOverrides, key) && !settingsTouchedKeys.has(key)) {
         return;
       }
@@ -1295,8 +1322,8 @@ function SettingsDialogContent() {
             </Field>
             <Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
               <label htmlFor="claudeCommand">Claude command (JSON argv)</label>
-              <textarea id="claudeCommand" onInput={onTextInput('claudeCommand')} placeholder='["claude"]' rows={2} value={values.claudeCommand} />
-              <div className="small">Used by `claude_sidecar` runtime. Example wrapper: `["wrapper", "claude", "--"]`.</div>
+              <textarea disabled id="claudeCommand" placeholder='["claude"]' rows={2} value={values.claudeCommand} />
+              <div className="small">{protectedConfigHelp('claude_command')}</div>
             </Field>
             <Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
               <label htmlFor="observerMaxChars">Request size limit (chars)</label>
@@ -1323,16 +1350,16 @@ function SettingsDialogContent() {
             </Field>
             <Field hidden={!showAuthFile} id="observerAuthFileField">
               <label htmlFor="observerAuthFile">Token file path</label>
-              <input id="observerAuthFile" onInput={onTextInput('observerAuthFile')} placeholder="~/.codemem/work-token.txt" value={values.observerAuthFile} />
-              <div className="small">Reads token text from this file when method is `file`.</div>
+              <input disabled id="observerAuthFile" placeholder="~/.codemem/work-token.txt" value={values.observerAuthFile} />
+              <div className="small">{protectedConfigHelp('observer_auth_file')}</div>
             </Field>
             <Field hidden={!showAuthCommand} id="observerAuthCommandField">
               <div className="field-label">
                 <label htmlFor="observerAuthCommand">Token command</label>
                 <button aria-label="About token command" className="help-icon" data-tooltip="Runs this command and uses stdout as the token. JSON argv only, no shell parsing." type="button">?</button>
               </div>
-              <textarea id="observerAuthCommand" onInput={onTextInput('observerAuthCommand')} placeholder='["iap-auth", "--audience", "gateway"]' rows={3} value={values.observerAuthCommand} />
-              <div className="small">When method is `command`, command stdout is used as the token.</div>
+              <textarea disabled id="observerAuthCommand" placeholder='["iap-auth", "--audience", "gateway"]' rows={3} value={values.observerAuthCommand} />
+              <div className="small">{protectedConfigHelp('observer_auth_command')}</div>
             </Field>
             <div className="small" hidden={!showAuthCommand} id="observerAuthCommandNote">
               Command format: JSON string array, e.g. `["iap-auth", "--audience", "gateway"]`.
@@ -1350,8 +1377,8 @@ function SettingsDialogContent() {
                 <label htmlFor="observerHeaders">Request headers (JSON)</label>
                 <button aria-label="About request headers" className="help-icon" data-tooltip={'Optional extra headers. Supports templates like ${auth.token}, ${auth.type}, ${auth.source}.'} type="button">?</button>
               </div>
-              <textarea id="observerHeaders" onInput={onTextInput('observerHeaders')} placeholder='{"Authorization":"Bearer ${auth.token}"}' rows={4} value={values.observerHeaders} />
-              <div className="small">Template variables: {'`${auth.token}`, `${auth.type}`, `${auth.source}`.'}</div>
+              <textarea disabled id="observerHeaders" placeholder='{"Authorization":"Bearer ${auth.token}"}' rows={4} value={values.observerHeaders} />
+              <div className="small">{protectedConfigHelp('observer_headers')}</div>
             </Field>
           </div>
         </div>
@@ -1393,8 +1420,8 @@ function SettingsDialogContent() {
             <div className="field field-checkbox settings-advanced" hidden={hiddenUnlessAdvanced()}><input checked={values.syncMdns} className="cm-checkbox" id="syncMdns" onChange={onCheckboxInput('syncMdns')} type="checkbox" /><label htmlFor="syncMdns">Enable mDNS discovery</label></div>
             <div className="field">
               <label htmlFor="syncCoordinatorUrl">Coordinator URL</label>
-              <input id="syncCoordinatorUrl" onInput={onTextInput('syncCoordinatorUrl')} placeholder="https://coord.example.com" value={values.syncCoordinatorUrl} />
-              <div className="small">Optional self-hosted/operator-run discovery service. Direct peer-to-peer sync remains the data path.</div>
+              <input disabled id="syncCoordinatorUrl" placeholder="https://coord.example.com" value={values.syncCoordinatorUrl} />
+              <div className="small">{protectedConfigHelp('sync_coordinator_url')}</div>
             </div>
             <div className="field">
               <label htmlFor="syncCoordinatorGroup">Coordinator group</label>

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -780,13 +780,74 @@ describe("viewer-server", () => {
 						"Content-Type": "application/json",
 						Origin: "http://localhost",
 					},
-					body: JSON.stringify({ config: { observer_headers: { Authorization: 123 } } }),
+					body: JSON.stringify({ config: { sync_enabled: "yes" } }),
 				});
 				expect(res.status).toBe(400);
 				const body = (await res.json()) as Record<string, unknown>;
-				expect(body.error).toBe("observer_headers must be object of string values");
+				expect(body.error).toBe("sync_enabled must be boolean");
 			} finally {
 				cleanup();
+			}
+		});
+
+		it("rejects protected config mutations from the viewer API", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({ config: { observer_auth_command: ["print-token"] } }),
+				});
+				expect(res.status).toBe(403);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.error).toBe(
+					"observer_auth_command cannot be changed from the viewer API; edit the config file or environment instead",
+				);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("ignores unchanged protected keys during full config saves", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const previous = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					observer_model: "old-model",
+					observer_auth_command: ["print-token"],
+					sync_coordinator_url: "https://coord.example.test",
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({
+						config: {
+							observer_model: "new-model",
+							observer_auth_command: "[redacted]",
+							sync_coordinator_url: "https://coord.example.test",
+						},
+					}),
+				});
+				expect(res.status).toBe(200);
+				const saved = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+				expect(saved.observer_model).toBe("new-model");
+				expect(saved.observer_auth_command).toEqual(["print-token"]);
+				expect(saved.sync_coordinator_url).toBe("https://coord.example.test");
+			} finally {
+				cleanup();
+				if (previous == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previous;
 			}
 		});
 

--- a/packages/viewer-server/src/routes/config.ts
+++ b/packages/viewer-server/src/routes/config.ts
@@ -23,9 +23,25 @@ import { Hono } from "hono";
 
 type ConfigData = Record<string, unknown>;
 
+const REDACTED_VALUE = "[redacted]";
+
 const RUNTIMES = new Set(["api_http", "claude_sidecar"]);
 const AUTH_SOURCES = new Set(["auto", "env", "file", "command", "none"]);
 const HOT_RELOAD_KEYS = new Set(["raw_events_sweeper_interval_s"]);
+const PROTECTED_WRITE_KEYS = new Set<string>([
+	"claude_command",
+	"observer_base_url",
+	"observer_auth_file",
+	"observer_auth_command",
+	"observer_headers",
+	"sync_coordinator_url",
+] as const);
+const SECRET_CONFIG_KEYS = new Set<string>([
+	"observer_auth_file",
+	"observer_auth_command",
+	"observer_headers",
+	"sync_coordinator_admin_secret",
+] as const);
 const ALLOWED_KEYS = [
 	"claude_command",
 	"observer_base_url",
@@ -121,6 +137,57 @@ function getEffectiveConfig(configData: ConfigData): ConfigData {
 		if (val != null && val !== "") effective[key] = val;
 	}
 	return effective;
+}
+
+function redactConfigValue(key: string, value: unknown): unknown {
+	if (value == null || !SECRET_CONFIG_KEYS.has(key)) return value;
+	if (Array.isArray(value)) return value.length > 0 ? REDACTED_VALUE : [];
+	if (typeof value === "object") {
+		return Object.keys(value as Record<string, unknown>).length > 0 ? REDACTED_VALUE : {};
+	}
+	if (typeof value === "string") return value.trim() ? REDACTED_VALUE : "";
+	return REDACTED_VALUE;
+}
+
+function sanitizeConfigForResponse(configData: ConfigData): ConfigData {
+	const sanitized: ConfigData = {};
+	for (const [key, value] of Object.entries(configData)) {
+		sanitized[key] = redactConfigValue(key, value);
+	}
+	return sanitized;
+}
+
+function configValuesEqual(left: unknown, right: unknown): boolean {
+	if (Object.is(left, right)) return true;
+	if (left == null || right == null) return left == null && right == null;
+	if (typeof left === "object" || typeof right === "object") {
+		return JSON.stringify(left) === JSON.stringify(right);
+	}
+	return false;
+}
+
+function partitionViewerUpdates(
+	updates: ConfigData,
+	beforeConfig: ConfigData,
+): { allowedUpdates: ConfigData; error: string | null } {
+	const allowedUpdates: ConfigData = {};
+	for (const [key, value] of Object.entries(updates)) {
+		if (!PROTECTED_WRITE_KEYS.has(key)) {
+			allowedUpdates[key] = value;
+			continue;
+		}
+		if (SECRET_CONFIG_KEYS.has(key) && value === REDACTED_VALUE) {
+			continue;
+		}
+		if (configValuesEqual(value, beforeConfig[key])) {
+			continue;
+		}
+		return {
+			allowedUpdates: {},
+			error: `${key} cannot be changed from the viewer API; edit the config file or environment instead`,
+		};
+	}
+	return { allowedUpdates, error: null };
 }
 
 function parsePositiveInt(value: unknown, allowZero = false): number | null {
@@ -264,12 +331,14 @@ export function configRoutes(opts: ConfigRouteOptions = {}) {
 	app.get("/api/config", (c) => {
 		const configPath = getConfigPath();
 		const configData = readConfigFile(configPath);
+		const effective = getEffectiveConfig(configData);
 		return c.json({
 			path: configPath,
-			config: configData,
+			config: sanitizeConfigForResponse(configData),
 			defaults: DEFAULTS,
-			effective: getEffectiveConfig(configData),
+			effective: sanitizeConfigForResponse(effective),
 			env_overrides: getCodememEnvOverrides(),
+			protected_keys: [...PROTECTED_WRITE_KEYS].sort(),
 			providers: loadProviderOptions(),
 		});
 	});
@@ -302,14 +371,22 @@ export function configRoutes(opts: ConfigRouteOptions = {}) {
 
 		const configPath = getCodememConfigPath();
 		const beforeConfig = readCodememConfigFile();
+		const { allowedUpdates, error: protectedKeyError } = partitionViewerUpdates(
+			updates,
+			beforeConfig,
+		);
+		if (protectedKeyError) {
+			return c.json({ error: protectedKeyError }, 403);
+		}
+
 		const beforeEffective = getEffectiveConfig(beforeConfig);
 		const nextConfig: ConfigData = { ...beforeConfig };
 		const providers = new Set(loadProviderOptions());
 
-		const touchedKeys = ALLOWED_KEYS.filter((key) => key in updates);
+		const touchedKeys = ALLOWED_KEYS.filter((key) => key in allowedUpdates);
 		for (const key of ALLOWED_KEYS) {
-			if (!(key in updates)) continue;
-			const error = validateAndApplyUpdate(nextConfig, key, updates[key], providers);
+			if (!(key in allowedUpdates)) continue;
+			const error = validateAndApplyUpdate(nextConfig, key, allowedUpdates[key], providers);
 			if (error) return c.json({ error }, 400);
 		}
 
@@ -339,8 +416,9 @@ export function configRoutes(opts: ConfigRouteOptions = {}) {
 
 		return c.json({
 			path: savedPath,
-			config: nextConfig,
-			effective: afterEffective,
+			config: sanitizeConfigForResponse(nextConfig),
+			effective: sanitizeConfigForResponse(afterEffective),
+			protected_keys: [...PROTECTED_WRITE_KEYS].sort(),
 			effects: {
 				saved_keys: savedChangedKeys,
 				effective_keys: effectiveChangedKeys,


### PR DESCRIPTION
## Description
Harden the localhost viewer config surface by redacting sensitive values from `/api/config` and blocking high-risk config mutations from the viewer API. This keeps secrets and dangerous execution/network settings out of an unauthenticated browser-managed path.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/cloudflare-coordinator-worker/src/index.test.ts packages/core/src/d1-coordinator-runtime.test.ts`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run typecheck` pass; existing Biome warnings unchanged in untouched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced