### PR TITLE
fix: tighten sync and coordinator request guards

### DIFF
--- a/packages/cloudflare-coordinator-worker/src/index.test.ts
+++ b/packages/cloudflare-coordinator-worker/src/index.test.ts
@@ -155,6 +155,27 @@ describe("createCloudflareCoordinatorWorker", () => {
 		});
 	});
 
+	it("rejects oversized presence bodies before auth processing", async () => {
+		const worker = createCloudflareCoordinatorWorker({
+			now: () => "2026-03-28T00:00:00Z",
+		});
+		const hugeBody = JSON.stringify({
+			group_id: "g1",
+			addresses: ["http://127.0.0.1:7337"],
+			padding: "x".repeat(70_000),
+		});
+		const res = await worker.fetch(
+			new Request("https://coord.example.test/v1/presence", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: hugeBody,
+			}),
+			{ COORDINATOR_DB: d1db, CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET: "test-secret" },
+		);
+		expect(res.status).toBe(413);
+		expect(await res.json()).toEqual({ error: "body_too_large" });
+	});
+
 	it("supports invite, join approval, signed presence, and signed peer lookup through the worker entrypoint", async () => {
 		const worker = createCloudflareCoordinatorWorker({
 			now: () => "2026-03-28T00:00:00Z",

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -11,6 +11,7 @@ import type { InvitePayload } from "./coordinator-invites.js";
 import { encodeInvitePayload, inviteLink } from "./coordinator-invites.js";
 import type { CoordinatorEnrollment, CoordinatorStore } from "./coordinator-store-contract.js";
 import { DEFAULT_TIME_WINDOW_S } from "./sync-auth-constants.js";
+import { fingerprintPublicKey } from "./sync-fingerprint.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -160,8 +161,38 @@ export function createCoordinatorApp(
 	const app = new Hono();
 	const textDecoder = new TextDecoder();
 
-	async function readRequestBytes(c: Context): Promise<Uint8Array> {
-		return new Uint8Array(await c.req.arrayBuffer());
+	async function readRequestBytes(c: Context): Promise<Uint8Array | null> {
+		const contentLength = Number.parseInt(c.req.header("content-length") ?? "", 10);
+		if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+			return null;
+		}
+		const stream = c.req.raw.body;
+		if (!stream) return new Uint8Array();
+		const reader = stream.getReader();
+		const chunks: Uint8Array[] = [];
+		let total = 0;
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				if (!value) continue;
+				total += value.byteLength;
+				if (total > MAX_BODY_BYTES) {
+					await reader.cancel();
+					return null;
+				}
+				chunks.push(value);
+			}
+		} finally {
+			reader.releaseLock();
+		}
+		const combined = new Uint8Array(total);
+		let offset = 0;
+		for (const chunk of chunks) {
+			combined.set(chunk, offset);
+			offset += chunk.byteLength;
+		}
+		return combined;
 	}
 
 	function parseJsonObject(raw: Uint8Array): Record<string, unknown> | null {
@@ -182,7 +213,7 @@ export function createCoordinatorApp(
 
 	app.post("/v1/presence", async (c) => {
 		const raw = await readRequestBytes(c);
-		if (raw.length > MAX_BODY_BYTES) {
+		if (raw == null) {
 			return c.json({ error: "body_too_large" }, 413);
 		}
 
@@ -331,7 +362,7 @@ export function createCoordinatorApp(
 
 	app.post("/v1/reciprocal-approvals", async (c) => {
 		const raw = await readRequestBytes(c);
-		if (raw.length > MAX_BODY_BYTES) {
+		if (raw == null) {
 			return c.json({ error: "body_too_large" }, 413);
 		}
 
@@ -389,7 +420,7 @@ export function createCoordinatorApp(
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
 		const raw = await readRequestBytes(c);
-		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
 
 		const data = parseJsonObject(raw);
 		if (!data) {
@@ -404,6 +435,9 @@ export function createCoordinatorApp(
 
 		if (!groupId || !deviceId || !fingerprint || !publicKey) {
 			return c.json({ error: "group_id_device_id_fingerprint_public_key_required" }, 400);
+		}
+		if (fingerprintPublicKey(publicKey) !== fingerprint) {
+			return c.json({ error: "fingerprint_mismatch" }, 400);
 		}
 
 		const store = createStore();
@@ -448,7 +482,7 @@ export function createCoordinatorApp(
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
 		const raw = await readRequestBytes(c);
-		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
 
 		const data = parseJsonObject(raw);
 		if (!data) {
@@ -482,7 +516,7 @@ export function createCoordinatorApp(
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
 		const raw = await readRequestBytes(c);
-		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
 
 		const data = parseJsonObject(raw);
 		if (!data) {
@@ -512,7 +546,7 @@ export function createCoordinatorApp(
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
 		const raw = await readRequestBytes(c);
-		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
 
 		const data = parseJsonObject(raw);
 		if (!data) {
@@ -542,7 +576,7 @@ export function createCoordinatorApp(
 		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
 		const raw = await readRequestBytes(c);
-		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
 
 		const data = parseJsonObject(raw);
 		if (!data) {
@@ -648,7 +682,7 @@ export function createCoordinatorApp(
 
 	app.post("/v1/join", async (c) => {
 		const raw = await readRequestBytes(c);
-		if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
 
 		const data = parseJsonObject(raw);
 		if (!data) {
@@ -663,6 +697,9 @@ export function createCoordinatorApp(
 
 		if (!token || !deviceId || !fingerprint || !publicKey) {
 			return c.json({ error: "token_device_id_fingerprint_public_key_required" }, 400);
+		}
+		if (fingerprintPublicKey(publicKey) !== fingerprint) {
+			return c.json({ error: "fingerprint_mismatch" }, 400);
 		}
 
 		const store = createStore();
@@ -747,8 +784,40 @@ async function handleJoinRequestReview(
 	const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), deps.runtime);
 	if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
 
-	const raw = new Uint8Array(await c.req.arrayBuffer());
-	if (raw.length > MAX_BODY_BYTES) return c.json({ error: "body_too_large" }, 413);
+	const raw = await (async () => {
+		const contentLength = Number.parseInt(c.req.header("content-length") ?? "", 10);
+		if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+			return null;
+		}
+		const stream = c.req.raw.body;
+		if (!stream) return new Uint8Array();
+		const reader = stream.getReader();
+		const chunks: Uint8Array[] = [];
+		let total = 0;
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				if (!value) continue;
+				total += value.byteLength;
+				if (total > MAX_BODY_BYTES) {
+					await reader.cancel();
+					return null;
+				}
+				chunks.push(value);
+			}
+		} finally {
+			reader.releaseLock();
+		}
+		const combined = new Uint8Array(total);
+		let offset = 0;
+		for (const chunk of chunks) {
+			combined.set(chunk, offset);
+			offset += chunk.byteLength;
+		}
+		return combined;
+	})();
+	if (raw == null) return c.json({ error: "body_too_large" }, 413);
 
 	let data: Record<string, unknown> | null;
 	try {

--- a/packages/core/src/d1-coordinator-runtime.test.ts
+++ b/packages/core/src/d1-coordinator-runtime.test.ts
@@ -11,6 +11,9 @@ import {
 	type D1DatabaseLike,
 	type D1PreparedStatementLike,
 } from "./d1-coordinator-store.js";
+import { connect } from "./db.js";
+import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
+import { initTestSchema } from "./test-utils.js";
 
 class SqliteD1Statement implements D1PreparedStatementLike {
 	private bound: unknown[] = [];
@@ -136,5 +139,50 @@ describe("createD1CoordinatorApp", () => {
 
 		expect(res.status).toBe(401);
 		expect(await res.json()).toEqual({ error: "admin_not_configured" });
+	});
+
+	it("rejects join requests with mismatched fingerprint and public key", async () => {
+		const store = new D1CoordinatorStore(d1db);
+		await store.createGroup("g1", "Team Alpha");
+		const invite = await store.createInvite({
+			groupId: "g1",
+			policy: "approval_required",
+			expiresAt: "2099-01-01T00:00:00Z",
+			createdBy: null,
+		});
+		await store.close();
+
+		const joinerDb = connect(join(tmpDir, "joiner.sqlite"));
+		try {
+			initTestSchema(joinerDb);
+			const keysDir = join(tmpDir, "joiner-keys");
+			const [deviceId] = ensureDeviceIdentity(joinerDb, { keysDir });
+			const publicKey = loadPublicKey(keysDir);
+			if (!publicKey) throw new Error("public key missing");
+
+			const app = createD1CoordinatorApp({
+				db: d1db,
+				adminSecret: "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+				requestVerifier,
+			});
+
+			const res = await app.request("/v1/join", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					token: invite.token,
+					device_id: deviceId,
+					public_key: publicKey,
+					fingerprint: "wrong-fingerprint",
+					display_name: "Joiner Device",
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			expect(await res.json()).toEqual({ error: "fingerprint_mismatch" });
+		} finally {
+			joinerDb.close();
+		}
 	});
 });

--- a/packages/core/src/sync-fingerprint.ts
+++ b/packages/core/src/sync-fingerprint.ts
@@ -1,0 +1,6 @@
+import { createHash } from "node:crypto";
+
+/** SHA-256 hex digest of a public key string. */
+export function fingerprintPublicKey(publicKey: string): string {
+	return createHash("sha256").update(publicKey, "utf-8").digest("hex");
+}

--- a/packages/core/src/sync-identity.ts
+++ b/packages/core/src/sync-identity.ts
@@ -6,13 +6,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import {
-	createHash,
-	createPrivateKey,
-	createPublicKey,
-	generateKeyPairSync,
-	randomUUID,
-} from "node:crypto";
+import { createPrivateKey, createPublicKey, generateKeyPairSync, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -21,6 +15,9 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import { connect as connectDb, resolveDbPath } from "./db.js";
 import * as schema from "./schema.js";
+import { fingerprintPublicKey } from "./sync-fingerprint.js";
+
+export { fingerprintPublicKey } from "./sync-fingerprint.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -34,11 +31,6 @@ const KEYCHAIN_SERVICE = "codemem-sync";
 // ---------------------------------------------------------------------------
 // Fingerprint
 // ---------------------------------------------------------------------------
-
-/** SHA-256 hex digest of a public key string. */
-export function fingerprintPublicKey(publicKey: string): string {
-	return createHash("sha256").update(publicKey, "utf-8").digest("hex");
-}
 
 // ---------------------------------------------------------------------------
 // Key store mode

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -649,6 +649,50 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("redacts sensitive config values from config responses", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevSecret = process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = "coord-secret";
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					observer_auth_file: "~/.codemem/token.txt",
+					observer_auth_command: ["print-token"],
+					observer_headers: { Authorization: "Bearer abc" },
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				const config = body.config as Record<string, unknown>;
+				const effective = body.effective as Record<string, unknown>;
+				expect(config.observer_auth_file).toBe("[redacted]");
+				expect(config.observer_auth_command).toBe("[redacted]");
+				expect(config.observer_headers).toBe("[redacted]");
+				expect(effective.sync_coordinator_admin_secret).toBe("[redacted]");
+				expect(body.protected_keys).toEqual(
+					expect.arrayContaining([
+						"claude_command",
+						"observer_auth_file",
+						"observer_auth_command",
+						"observer_headers",
+						"observer_base_url",
+						"sync_coordinator_url",
+					]),
+				);
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevSecret == null) delete process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+				else process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = prevSecret;
+			}
+		});
+
 		it("writes config and returns effects", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const notifyConfigChanged = vi.fn();
@@ -1088,6 +1132,22 @@ describe("viewer-server", () => {
 					body: JSON.stringify({ ops: [] }),
 				});
 				expect(postRes.status).toBe(401);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects oversized sync request bodies before auth processing", async () => {
+			const { syncApp, cleanup } = createTestApp();
+			try {
+				const hugeBody = JSON.stringify({ ops: [], padding: "x".repeat(1_048_600) });
+				const res = await syncApp.request("/v1/ops", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: hugeBody,
+				});
+				expect(res.status).toBe(413);
+				expect(await res.json()).toEqual({ error: "payload_too_large" });
 			} finally {
 				cleanup();
 			}
@@ -1547,6 +1607,68 @@ describe("viewer-server", () => {
 				ensureDeviceIdentity(store.db, { keysDir });
 
 				const res = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).not.toHaveProperty("join_requests");
+
+				const calls = fetchMock.mock.calls.map(([input]) => String(input));
+				const joinRequestCalls = calls.filter((url) => url.includes("/v1/admin/join-requests"));
+				expect(joinRequestCalls).toHaveLength(0);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+				delete process.env.CODEMEM_SYNC_ENABLED;
+			}
+		});
+
+		it("does not expose join requests without diagnostics", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/presence")) {
+					return new Response(JSON.stringify({ ok: true, addresses: ["http://1.2.3.4:7337"] }), {
+						status: 200,
+					});
+				}
+				if (url.includes("/v1/peers")) {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				if (url.includes("/v1/admin/join-requests")) {
+					return new Response(
+						JSON.stringify({ items: [{ request_id: "req-1", token: "secret-token" }] }),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+
+				const res = await app.request("/api/sync/status?includeJoinRequests=1");
 				expect(res.status).toBe(200);
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body).not.toHaveProperty("join_requests");

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -63,6 +63,34 @@ function intEnvOr(name: string, fallback: number): number {
 const MAX_SYNC_BODY_BYTES = intEnvOr("CODEMEM_SYNC_MAX_BODY_BYTES", 1_048_576);
 const MAX_SYNC_OPS = intEnvOr("CODEMEM_SYNC_MAX_OPS", 2000);
 
+async function readBoundedRequestBytes(request: Request, maxBytes: number): Promise<Buffer | null> {
+	const contentLength = Number.parseInt(request.headers.get("content-length") ?? "", 10);
+	if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+		return null;
+	}
+	const stream = request.body;
+	if (!stream) return Buffer.alloc(0);
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value) continue;
+			total += value.byteLength;
+			if (total > maxBytes) {
+				await reader.cancel();
+				return null;
+			}
+			chunks.push(value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+}
+
 const PAIRING_FILTER_HINT =
 	"Run this on another device with codemem sync pair --accept '<payload>'. " +
 	"On the accepting device, --include/--exclude control both what it sends and what it accepts from that peer.";
@@ -840,8 +868,8 @@ export function syncProtocolRoutes(getStore: StoreFactory) {
 	// POST /v1/ops (peer sync protocol)
 	app.post("/v1/ops", async (c) => {
 		const store = getStore();
-		const raw = Buffer.from(await c.req.arrayBuffer());
-		if (raw.length > MAX_SYNC_BODY_BYTES) {
+		const raw = await readBoundedRequestBytes(c.req.raw, MAX_SYNC_BODY_BYTES);
+		if (raw == null) {
 			return c.json({ error: "payload_too_large" }, 413);
 		}
 
@@ -1100,7 +1128,7 @@ export function syncRoutes(
 				showDiag,
 			);
 			let joinRequests: Record<string, unknown>[] = [];
-			if (includeJoinRequests && config.syncCoordinatorAdminSecret) {
+			if (includeJoinRequests && showDiag && config.syncCoordinatorAdminSecret) {
 				try {
 					joinRequests = await listCoordinatorJoinRequests(config);
 				} catch {
@@ -1158,7 +1186,7 @@ export function syncRoutes(
 				sharing_review: sharingReview,
 				coordinator,
 			};
-			if (includeJoinRequests) {
+			if (includeJoinRequests && showDiag) {
 				responsePayload.join_requests = joinRequests;
 			}
 			return c.json(responsePayload);


### PR DESCRIPTION
## Description
Tighten the network-exposed sync and coordinator surfaces by rejecting oversized request bodies before full buffering, gating join-request data behind diagnostics, and validating coordinator fingerprint/public-key consistency. This reduces denial-of-service exposure and prevents inconsistent or overexposed coordinator identity data.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/cloudflare-coordinator-worker/src/index.test.ts packages/core/src/d1-coordinator-runtime.test.ts`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm run typecheck` pass; existing Biome warnings unchanged in untouched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced