### PR TITLE
fix(viewer): warn on non-loopback binds

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Common overrides:
 
 The viewer includes a grouped Settings modal (`Connection`, `Processing`, `Device Sync`) with shell-agnostic labels and an advanced-controls toggle for technical fields.
 - Settings show effective values (configured or default) and only persist changed fields on save.
+- The viewer HTTP service is intended for localhost-only use. It does not currently provide a general-purpose auth/session layer for safe public exposure.
 
 Observer runtime/auth:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,10 @@ codemem has five main pieces: **adapters** that capture shell/runtime activity, 
 | MCP server | Exposes memory tools (search, timeline, pack, remember, forget) to OpenCode | `packages/mcp-server/src/` |
 | CLI | Ties everything together: ingest, serve, search, export/import, sync | `packages/cli/src/` |
 
+The viewer trust model is intentionally local-first: it is designed for loopback access from the same machine, with
+cross-origin protections for browser callers and limited config-route guardrails, but not a full remote auth/session
+boundary.
+
 ## Data flow
 
 ```mermaid

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -5,6 +5,14 @@
 - `codemem serve --background` runs it in the background.
 - `codemem serve restart` restarts the background viewer.
 
+## Viewer trust model
+
+- The viewer and its JSON APIs are designed for **localhost-only** use.
+- codemem currently relies on loopback-origin checks and local-process assumptions, not a real login/session auth layer.
+- Binding the viewer to `0.0.0.0`, putting it behind a reverse proxy, or exposing it through a tunnel can make local APIs reachable in ways the current trust model was not built for.
+- Treat the viewer as a local tool. If you must expose it beyond loopback, add your own auth and network restrictions first.
+- This warning applies to the viewer HTTP service, not the separate sync/coordinator listeners documented elsewhere.
+
 ## Seeing UI changes
 - The viewer UI is built from `packages/ui/` and served by `packages/viewer-server/`.
 - Restart the viewer after updates: `codemem serve restart`.
@@ -145,6 +153,7 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 - The Settings UI exposes coordinator URL, group, timeout, and presence TTL fields under the Sync tab.
 - The coordinator is self-hosted/operator-run and only helps peers discover fresh addresses; direct peer-to-peer sync remains the data path.
 - See [docs/coordinator-discovery.md](coordinator-discovery.md) for setup, config, and current limitations.
+- Do **not** expose the viewer itself just because the coordinator or sync protocol needs cross-network reachability; those are separate surfaces.
 
 ### Keychain (optional)
 

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -4,6 +4,7 @@ import {
 	extractViewerPid,
 	isLikelyViewerCommand,
 	isLocalHost,
+	isLoopbackOnlyHost,
 	isSqliteVecLoadFailure,
 	pickViewerPidCandidate,
 	sqliteVecFailureDiagnostics,
@@ -176,6 +177,18 @@ describe("serve command option resolution", () => {
 		expect(isLocalHost("::1")).toBe(true);
 		expect(isLocalHost("0.0.0.0")).toBe(true);
 		expect(isLocalHost("example.com")).toBe(false);
+	});
+
+	it("distinguishes loopback-only viewer binds from network-exposed binds", () => {
+		expect(isLoopbackOnlyHost("127.0.0.1")).toBe(true);
+		expect(isLoopbackOnlyHost("127.0.0.2")).toBe(true);
+		expect(isLoopbackOnlyHost("127.1")).toBe(true);
+		expect(isLoopbackOnlyHost("localhost")).toBe(true);
+		expect(isLoopbackOnlyHost("::1")).toBe(true);
+		expect(isLoopbackOnlyHost("0:0:0:0:0:0:0:1")).toBe(true);
+		expect(isLoopbackOnlyHost("0.0.0.0")).toBe(false);
+		expect(isLoopbackOnlyHost("::")).toBe(false);
+		expect(isLoopbackOnlyHost("example.com")).toBe(false);
 	});
 
 	it("matches likely codemem viewer command lines", () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -47,6 +47,23 @@ export function isLocalHost(host: string): boolean {
 	);
 }
 
+export function isLoopbackOnlyHost(host: string): boolean {
+	const normalized = host.trim().toLowerCase();
+	return (
+		normalized === "localhost" ||
+		/^127(?:\.\d{1,3}){0,3}$/.test(normalized) ||
+		normalized === "::1" ||
+		normalized === "0:0:0:0:0:0:0:1"
+	);
+}
+
+function warnIfViewerExposed(host: string, port: number): void {
+	if (isLoopbackOnlyHost(host)) return;
+	p.log.warn(
+		`Viewer bound to ${host}:${port}. codemem's viewer trust model assumes localhost-only access; do not expose it through a reverse proxy, tunnel, or public bind without adding your own auth layer.`,
+	);
+}
+
 export function isLikelyViewerCommand(command: string): boolean {
 	const lowered = command.toLowerCase();
 	if (!/\bserve\s+start\b/.test(lowered)) return false;
@@ -290,6 +307,7 @@ export function sqliteVecFailureDiagnostics(error: unknown, dbPath: string): str
 }
 
 async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promise<void> {
+	warnIfViewerExposed(invocation.host, invocation.port);
 	if (await isPortOpen(invocation.host, invocation.port)) {
 		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
 		return;
@@ -324,6 +342,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	const { serve } = await import("@hono/node-server");
 
 	if (invocation.dbPath) process.env.CODEMEM_DB = invocation.dbPath;
+	warnIfViewerExposed(invocation.host, invocation.port);
 	if (await isPortOpen(invocation.host, invocation.port)) {
 		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
 		process.exitCode = 1;


### PR DESCRIPTION
## Description
Documents the viewer's localhost-only trust model and adds a startup warning when the viewer is bound to a non-loopback host.

This keeps the current local-first security assumptions explicit in user-facing docs and adds a guardrail for the easy-to-make mistake of exposing the viewer through `0.0.0.0`, a proxy, or a tunnel without an auth layer.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm vitest packages/cli/src/commands/serve.test.ts`
- read-back verification of README / user-guide / architecture trust-model docs

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced