### PR TITLE
fix(sync): add listener rate limiting

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
 		"better-sqlite3": "^12.8.0",
 		"drizzle-orm": "^0.45.1",
 		"hono": "^4.7.10",
+		"limiter": "^3.0.0",
 		"sqlite-vec": "0.1.7-alpha.2"
 	},
 	"repository": {

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -19,6 +19,7 @@ import {
 	type CoordinatorUpsertPresenceInput,
 	createCoordinatorApp,
 } from "./index.js";
+import { createInMemoryRequestRateLimiter } from "./request-rate-limit.js";
 
 function createMockStore(
 	overrides?: Partial<CoordinatorStoreInterface>,
@@ -128,6 +129,71 @@ describe("createCoordinatorApp dependency injection", () => {
 		expect(storeFactory).toHaveBeenCalledTimes(1);
 		expect(store.listEnrolledDevices).toHaveBeenCalledWith("g1", false);
 		expect(store.close).toHaveBeenCalledTimes(1);
+	});
+
+	it("rate limits repeated coordinator reads before route handling continues", async () => {
+		const store = createMockStore({
+			listEnrolledDevices: vi.fn(async () => []),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+			requestRateLimit: {
+				limiter: createInMemoryRequestRateLimiter(),
+				readLimit: 1,
+			},
+		});
+
+		expect(
+			await app.request("/v1/admin/devices?group_id=g1", {
+				headers: { "X-Codemem-Coordinator-Admin": "test-secret" },
+			}),
+		).toHaveProperty("status", 200);
+
+		const limited = await app.request("/v1/admin/devices?group_id=g1", {
+			headers: { "X-Codemem-Coordinator-Admin": "test-secret" },
+		});
+		expect(limited.status).toBe(429);
+		expect(limited.headers.get("retry-after")).toBeTruthy();
+		expect(await limited.json()).toEqual({
+			error: "rate_limited",
+			retry_after_s: expect.any(Number),
+		});
+	});
+
+	it("does not let invalid admin requests consume the authenticated admin bucket", async () => {
+		const store = createMockStore({
+			listEnrolledDevices: vi.fn(async () => []),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+			requestRateLimit: {
+				limiter: createInMemoryRequestRateLimiter(),
+				readLimit: 1,
+				unauthenticatedReadLimit: 1,
+			},
+		});
+
+		expect(
+			await app.request("/v1/admin/devices?group_id=g1", {
+				headers: { "X-Codemem-Coordinator-Admin": "wrong-secret" },
+			}),
+		).toHaveProperty("status", 401);
+
+		expect(
+			await app.request("/v1/admin/devices?group_id=g1", {
+				headers: { "X-Codemem-Coordinator-Admin": "test-secret" },
+			}),
+		).toHaveProperty("status", 200);
 	});
 
 	it("does not rely on process env when runtime admin secret is unset", async () => {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -10,6 +10,10 @@ import { Hono } from "hono";
 import type { InvitePayload } from "./coordinator-invites.js";
 import { encodeInvitePayload, inviteLink } from "./coordinator-invites.js";
 import type { CoordinatorEnrollment, CoordinatorStore } from "./coordinator-store-contract.js";
+import {
+	createInMemoryRequestRateLimiter,
+	type InMemoryRequestRateLimiter,
+} from "./request-rate-limit.js";
 import { DEFAULT_TIME_WINDOW_S } from "./sync-auth-constants.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 
@@ -19,6 +23,16 @@ import { fingerprintPublicKey } from "./sync-fingerprint.js";
 
 const MAX_BODY_BYTES = 64 * 1024;
 const ADMIN_HEADER = "X-Codemem-Coordinator-Admin";
+const DEFAULT_COORDINATOR_READ_LIMIT = 120;
+const DEFAULT_COORDINATOR_MUTATION_LIMIT = 30;
+
+export interface CoordinatorRequestRateLimitOptions {
+	limiter?: InMemoryRequestRateLimiter;
+	readLimit?: number;
+	mutationLimit?: number;
+	unauthenticatedReadLimit?: number;
+	unauthenticatedMutationLimit?: number;
+}
 
 export interface CoordinatorRuntimeDeps {
 	adminSecret(): string | null;
@@ -29,6 +43,7 @@ export interface CreateCoordinatorAppOptions {
 	storeFactory: () => CoordinatorStore;
 	runtime: CoordinatorRuntimeDeps;
 	requestVerifier: CoordinatorRequestVerifier;
+	requestRateLimit?: CoordinatorRequestRateLimitOptions;
 }
 
 export interface CoordinatorVerifyRequestInput {
@@ -158,8 +173,43 @@ export function createCoordinatorApp(
 	const runtime = opts.runtime;
 	const createStore = opts.storeFactory;
 	const requestVerifier = opts.requestVerifier;
+	const requestRateLimit = opts.requestRateLimit ?? {};
+	const rateLimiter = requestRateLimit.limiter ?? createInMemoryRequestRateLimiter();
+	const readLimit = Math.max(
+		1,
+		Math.trunc(requestRateLimit.readLimit ?? DEFAULT_COORDINATOR_READ_LIMIT),
+	);
+	const mutationLimit = Math.max(
+		1,
+		Math.trunc(requestRateLimit.mutationLimit ?? DEFAULT_COORDINATOR_MUTATION_LIMIT),
+	);
+	const unauthenticatedReadLimit = Math.max(
+		1,
+		Math.trunc(requestRateLimit.unauthenticatedReadLimit ?? Math.min(20, readLimit)),
+	);
+	const unauthenticatedMutationLimit = Math.max(
+		1,
+		Math.trunc(requestRateLimit.unauthenticatedMutationLimit ?? Math.min(10, mutationLimit)),
+	);
 	const app = new Hono();
 	const textDecoder = new TextDecoder();
+
+	function rateLimitedResponse(c: Context, key: string, authenticated: boolean) {
+		const isRead = c.req.method === "GET" || c.req.method === "HEAD" || c.req.method === "OPTIONS";
+		const result = rateLimiter.check(
+			`${c.req.method}:${authenticated ? "auth" : "anon"}:${key}`,
+			authenticated
+				? isRead
+					? readLimit
+					: mutationLimit
+				: isRead
+					? unauthenticatedReadLimit
+					: unauthenticatedMutationLimit,
+		);
+		if (result.allowed) return null;
+		c.header("Retry-After", String(result.retryAfterS));
+		return c.json({ error: "rate_limited", retry_after_s: result.retryAfterS }, 429);
+	}
 
 	async function readRequestBytes(c: Context): Promise<Uint8Array | null> {
 		const contentLength = Number.parseInt(c.req.header("content-length") ?? "", 10);
@@ -240,8 +290,10 @@ export function createCoordinatorApp(
 				nonce: c.req.header("X-Opencode-Nonce") ?? null,
 			});
 			if (!auth.ok || !auth.enrollment) {
-				return c.json({ error: auth.error }, 401);
+				return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: auth.error }, 401);
 			}
+			const limited = rateLimitedResponse(c, String(auth.enrollment.device_id), true);
+			if (limited) return limited;
 
 			if (data.fingerprint && String(data.fingerprint) !== String(auth.enrollment.fingerprint)) {
 				return c.json({ error: "fingerprint_mismatch" }, 401);
@@ -304,8 +356,10 @@ export function createCoordinatorApp(
 				nonce: c.req.header("X-Opencode-Nonce") ?? null,
 			});
 			if (!auth.ok || !auth.enrollment) {
-				return c.json({ error: auth.error }, 401);
+				return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: auth.error }, 401);
 			}
+			const limited = rateLimitedResponse(c, String(auth.enrollment.device_id), true);
+			if (limited) return limited;
 
 			const items = await store.listGroupPeers(groupId, String(auth.enrollment.device_id));
 			return c.json({ items });
@@ -342,8 +396,10 @@ export function createCoordinatorApp(
 				nonce: c.req.header("X-Opencode-Nonce") ?? null,
 			});
 			if (!auth.ok || !auth.enrollment) {
-				return c.json({ error: auth.error }, 401);
+				return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: auth.error }, 401);
 			}
+			const limited = rateLimitedResponse(c, String(auth.enrollment.device_id), true);
+			if (limited) return limited;
 			const items = await store.listReciprocalApprovals({
 				groupId,
 				deviceId: String(auth.enrollment.device_id),
@@ -390,8 +446,10 @@ export function createCoordinatorApp(
 				nonce: c.req.header("X-Opencode-Nonce") ?? null,
 			});
 			if (!auth.ok || !auth.enrollment) {
-				return c.json({ error: auth.error }, 401);
+				return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: auth.error }, 401);
 			}
+			const limited = rateLimitedResponse(c, String(auth.enrollment.device_id), true);
+			if (limited) return limited;
 			if (requestedDeviceId === String(auth.enrollment.device_id)) {
 				return c.json({ error: "requested_device_must_differ" }, 400);
 			}
@@ -417,7 +475,10 @@ export function createCoordinatorApp(
 	// POST /v1/admin/devices — enroll a device
 	app.post("/v1/admin/devices", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
-		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
 
 		const raw = await readRequestBytes(c);
 		if (raw == null) return c.json({ error: "body_too_large" }, 413);
@@ -459,7 +520,10 @@ export function createCoordinatorApp(
 	// GET /v1/admin/devices — list enrolled devices
 	app.get("/v1/admin/devices", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
-		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
 
 		const groupId = (c.req.query("group_id") ?? "").trim();
 		if (!groupId) return c.json({ error: "group_id_required" }, 400);
@@ -479,7 +543,10 @@ export function createCoordinatorApp(
 	// POST /v1/admin/devices/rename
 	app.post("/v1/admin/devices/rename", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
-		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
 
 		const raw = await readRequestBytes(c);
 		if (raw == null) return c.json({ error: "body_too_large" }, 413);
@@ -513,7 +580,10 @@ export function createCoordinatorApp(
 	// POST /v1/admin/devices/disable
 	app.post("/v1/admin/devices/disable", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
-		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
 
 		const raw = await readRequestBytes(c);
 		if (raw == null) return c.json({ error: "body_too_large" }, 413);
@@ -543,7 +613,10 @@ export function createCoordinatorApp(
 	// POST /v1/admin/devices/remove
 	app.post("/v1/admin/devices/remove", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
-		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
 
 		const raw = await readRequestBytes(c);
 		if (raw == null) return c.json({ error: "body_too_large" }, 413);
@@ -573,7 +646,10 @@ export function createCoordinatorApp(
 	// POST /v1/admin/invites — create an invite
 	app.post("/v1/admin/invites", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
-		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
 
 		const raw = await readRequestBytes(c);
 		if (raw == null) return c.json({ error: "body_too_large" }, 413);
@@ -634,7 +710,10 @@ export function createCoordinatorApp(
 	// GET /v1/admin/invites — list invites
 	app.get("/v1/admin/invites", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
-		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
 
 		const groupId = (c.req.query("group_id") ?? "").trim();
 		if (!groupId) return c.json({ error: "group_id_required" }, 400);
@@ -652,18 +731,21 @@ export function createCoordinatorApp(
 
 	// POST /v1/admin/join-requests/approve
 	app.post("/v1/admin/join-requests/approve", async (c) => {
-		return handleJoinRequestReview(c, true, { createStore, runtime });
+		return handleJoinRequestReview(c, true, { createStore, runtime, rateLimitedResponse });
 	});
 
 	// POST /v1/admin/join-requests/deny
 	app.post("/v1/admin/join-requests/deny", async (c) => {
-		return handleJoinRequestReview(c, false, { createStore, runtime });
+		return handleJoinRequestReview(c, false, { createStore, runtime, rateLimitedResponse });
 	});
 
 	// GET /v1/admin/join-requests — list join requests
 	app.get("/v1/admin/join-requests", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
-		if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
 
 		const groupId = (c.req.query("group_id") ?? "").trim();
 		if (!groupId) return c.json({ error: "group_id_required" }, 400);
@@ -779,10 +861,19 @@ export function createCoordinatorApp(
 async function handleJoinRequestReview(
 	c: Context,
 	approved: boolean,
-	deps: { createStore: () => CoordinatorStore; runtime: CoordinatorRuntimeDeps },
+	deps: {
+		createStore: () => CoordinatorStore;
+		runtime: CoordinatorRuntimeDeps;
+		rateLimitedResponse: (c: Context, key: string, authenticated: boolean) => Response | null;
+	},
 ) {
 	const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), deps.runtime);
-	if (!adminAuth.ok) return c.json({ error: adminAuth.error }, 401);
+	if (!adminAuth.ok)
+		return (
+			deps.rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401)
+		);
+	const limited = deps.rateLimitedResponse(c, "admin", true);
+	if (limited) return limited;
 
 	const raw = await (async () => {
 		const contentLength = Number.parseInt(c.req.header("content-length") ?? "", 10);

--- a/packages/core/src/request-rate-limit.ts
+++ b/packages/core/src/request-rate-limit.ts
@@ -1,0 +1,58 @@
+import { RateLimiter } from "limiter";
+
+export interface InMemoryRequestRateLimiter {
+	check(key: string, limit: number): { allowed: boolean; retryAfterS: number };
+}
+
+export interface CreateInMemoryRequestRateLimiterOptions {
+	windowMs?: number;
+	now?: () => number;
+}
+
+export function createInMemoryRequestRateLimiter(
+	options: CreateInMemoryRequestRateLimiterOptions = {},
+): InMemoryRequestRateLimiter {
+	const windowMs = Math.max(1000, Math.trunc(options.windowMs ?? 60_000));
+	const now = options.now ?? (() => Date.now());
+	const buckets = new Map<string, { limiter: RateLimiter; lastUsedAt: number }>();
+	let checks = 0;
+
+	function estimatedRetryAfterS(limit: number): number {
+		return Math.max(1, Math.ceil(windowMs / Math.max(1, limit) / 1000));
+	}
+
+	function cleanupExpiredBuckets(currentNow: number): void {
+		if (buckets.size < 64 || checks % 64 !== 0) return;
+		const staleBefore = currentNow - windowMs * 10;
+		for (const [key, bucket] of buckets) {
+			if (bucket.lastUsedAt < staleBefore) buckets.delete(key);
+		}
+	}
+
+	return {
+		check(key: string, limit: number) {
+			const safeLimit = Math.max(1, Math.trunc(limit));
+			checks += 1;
+			const currentNow = now();
+			cleanupExpiredBuckets(currentNow);
+			const bucketKey = `${safeLimit}:${key}`;
+			let bucket = buckets.get(bucketKey);
+			if (!bucket) {
+				bucket = {
+					limiter: new RateLimiter({
+						tokensPerInterval: safeLimit,
+						interval: windowMs,
+						fireImmediately: true,
+					}),
+					lastUsedAt: currentNow,
+				};
+				buckets.set(bucketKey, bucket);
+			}
+			bucket.lastUsedAt = currentNow;
+			if (bucket.limiter.tryRemoveTokens(1)) {
+				return { allowed: true, retryAfterS: 0 };
+			}
+			return { allowed: false, retryAfterS: estimatedRetryAfterS(safeLimit) };
+		},
+	};
+}

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -23,7 +23,8 @@
 		"@codemem/core": "workspace:^",
 		"@hono/node-server": "^1.14.3",
 		"drizzle-orm": "^0.45.1",
-		"hono": "^4.7.10"
+		"hono": "^4.7.10",
+		"limiter": "^3.0.0"
 	},
 	"devDependencies": {
 		"@types/better-sqlite3": "^7.6.13",

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -93,6 +93,12 @@ function insertTestMemory(
 /** Create a test Hono app backed by a fresh in-memory DB. */
 function createTestApp(opts?: {
 	sweeper?: unknown;
+	syncRequestRateLimit?: {
+		readLimit?: number;
+		mutationLimit?: number;
+		unauthenticatedReadLimit?: number;
+		unauthenticatedMutationLimit?: number;
+	};
 	getSyncRuntimeStatus?: () => {
 		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
 		detail?: string | null;
@@ -116,7 +122,10 @@ function createTestApp(opts?: {
 		getSyncRuntimeStatus: opts?.getSyncRuntimeStatus,
 	});
 
-	const syncApp = createSyncApp({ storeFactory });
+	const syncApp = createSyncApp({
+		storeFactory,
+		syncRequestRateLimit: opts?.syncRequestRateLimit,
+	});
 
 	return {
 		app,
@@ -1118,6 +1127,79 @@ describe("viewer-server", () => {
 				expect(body.error).toBe("unauthorized");
 			} finally {
 				cleanup();
+			}
+		});
+
+		it("rate limits repeated sync listener requests", async () => {
+			const { syncApp, cleanup } = createTestApp({
+				syncRequestRateLimit: { unauthenticatedReadLimit: 1 },
+			});
+			try {
+				expect((await syncApp.request("/v1/status")).status).toBe(401);
+				const limited = await syncApp.request("/v1/status");
+				expect(limited.status).toBe(429);
+				expect(limited.headers.get("retry-after")).toBeTruthy();
+				expect(await limited.json()).toEqual({
+					error: "rate_limited",
+					retry_after_s: expect.any(Number),
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("does not let unauthorized sync requests consume a verified peer bucket", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp({
+				syncRequestRateLimit: { readLimit: 1, unauthenticatedReadLimit: 1 },
+			});
+			const peerDir = mkdtempSync(join(tmpdir(), "codemem-sync-peer-test-"));
+			const peerDbPath = join(peerDir, "peer.sqlite");
+			const peerKeysDir = join(peerDir, "keys");
+			try {
+				expect((await syncApp.request("/v1/status")).status).toBe(401);
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+
+				const peerDb = connect(peerDbPath);
+				try {
+					initTestSchema(peerDb);
+					const [peerDeviceId] = ensureDeviceIdentity(peerDb, { keysDir: peerKeysDir });
+					const peerPublicKey = loadPublicKey(peerKeysDir);
+					if (!peerPublicKey) throw new Error("peer public key missing");
+					const peerFingerprint = peerDb
+						.prepare("SELECT fingerprint FROM sync_device LIMIT 1")
+						.get() as { fingerprint: string } | undefined;
+					if (!peerFingerprint?.fingerprint) throw new Error("peer fingerprint missing");
+
+					store.db
+						.prepare(
+							`INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, created_at)
+							 VALUES (?, ?, ?, ?)`,
+						)
+						.run(
+							peerDeviceId,
+							peerFingerprint.fingerprint,
+							peerPublicKey,
+							new Date().toISOString(),
+						);
+
+					const url = "http://localhost/v1/status";
+					const headers = buildAuthHeaders({
+						deviceId: peerDeviceId,
+						method: "GET",
+						url,
+						bodyBytes: Buffer.alloc(0),
+						keysDir: peerKeysDir,
+					});
+
+					expect((await syncApp.request(url, { headers })).status).toBe(200);
+				} finally {
+					peerDb.close();
+				}
+			} finally {
+				cleanup();
+				rmSync(peerDir, { recursive: true, force: true });
 			}
 		});
 

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -15,6 +15,10 @@ import { MemoryStore, type RawEventSweeper, resolveDbPath, VERSION } from "@code
 import { serveStatic } from "@hono/node-server/serve-static";
 import { Hono } from "hono";
 import { originGuard, preflightHandler } from "./middleware.js";
+import {
+	createInMemoryRequestRateLimiter,
+	type InMemoryRequestRateLimiter,
+} from "./request-rate-limit.js";
 import { configRoutes } from "./routes/config.js";
 import { memoryRoutes } from "./routes/memory.js";
 import { observerStatusRoutes } from "./routes/observer-status.js";
@@ -49,6 +53,13 @@ export interface AppOptions {
 	storeFactory?: () => MemoryStore;
 	sweeper?: RawEventSweeper | null;
 	observer?: ObserverClient | null;
+	syncRequestRateLimit?: {
+		limiter?: InMemoryRequestRateLimiter;
+		readLimit?: number;
+		mutationLimit?: number;
+		unauthenticatedReadLimit?: number;
+		unauthenticatedMutationLimit?: number;
+	};
 	getSyncRuntimeStatus?: () => {
 		phase:
 			| "starting"
@@ -132,8 +143,29 @@ export function createApp(opts?: AppOptions) {
  */
 export function createSyncApp(opts?: AppOptions) {
 	const storeFactory = opts?.storeFactory ?? getStore;
+	const requestRateLimit = opts?.syncRequestRateLimit ?? {};
+	const rateLimiter = requestRateLimit.limiter ?? createInMemoryRequestRateLimiter();
+	const readLimit = Math.max(1, Math.trunc(requestRateLimit.readLimit ?? 120));
+	const mutationLimit = Math.max(1, Math.trunc(requestRateLimit.mutationLimit ?? 30));
 	const app = new Hono();
-	app.route("/", syncProtocolRoutes(storeFactory));
+	app.route(
+		"/",
+		syncProtocolRoutes(storeFactory, {
+			routeRateLimit: {
+				limiter: rateLimiter,
+				readLimit,
+				mutationLimit,
+				unauthenticatedReadLimit: Math.max(
+					1,
+					Math.trunc(requestRateLimit.unauthenticatedReadLimit ?? Math.min(20, readLimit)),
+				),
+				unauthenticatedMutationLimit: Math.max(
+					1,
+					Math.trunc(requestRateLimit.unauthenticatedMutationLimit ?? Math.min(10, mutationLimit)),
+				),
+			},
+		}),
+	);
 
 	// Catch-all — return generic 404 to avoid fingerprinting the server.
 	app.all("*", (c) => c.json({ error: "not found" }, 404));

--- a/packages/viewer-server/src/request-rate-limit.ts
+++ b/packages/viewer-server/src/request-rate-limit.ts
@@ -1,0 +1,50 @@
+import { RateLimiter } from "limiter";
+
+export interface InMemoryRequestRateLimiter {
+	check(key: string, limit: number): { allowed: boolean; retryAfterS: number };
+}
+
+export function createInMemoryRequestRateLimiter(windowMs = 60_000): InMemoryRequestRateLimiter {
+	const safeWindowMs = Math.max(1000, Math.trunc(windowMs));
+	const buckets = new Map<string, { limiter: RateLimiter; lastUsedAt: number }>();
+	let checks = 0;
+
+	function estimatedRetryAfterS(limit: number): number {
+		return Math.max(1, Math.ceil(safeWindowMs / Math.max(1, limit) / 1000));
+	}
+
+	function cleanupExpiredBuckets(currentNow: number): void {
+		if (buckets.size < 64 || checks % 64 !== 0) return;
+		const staleBefore = currentNow - safeWindowMs * 10;
+		for (const [key, bucket] of buckets) {
+			if (bucket.lastUsedAt < staleBefore) buckets.delete(key);
+		}
+	}
+
+	return {
+		check(key: string, limit: number) {
+			checks += 1;
+			const currentNow = Date.now();
+			cleanupExpiredBuckets(currentNow);
+			const safeLimit = Math.max(1, Math.trunc(limit));
+			const bucketKey = `${safeLimit}:${key}`;
+			let bucket = buckets.get(bucketKey);
+			if (!bucket) {
+				bucket = {
+					limiter: new RateLimiter({
+						tokensPerInterval: safeLimit,
+						interval: safeWindowMs,
+						fireImmediately: true,
+					}),
+					lastUsedAt: currentNow,
+				};
+				buckets.set(bucketKey, bucket);
+			}
+			bucket.lastUsedAt = currentNow;
+			if (bucket.limiter.tryRemoveTokens(1)) {
+				return { allowed: true, retryAfterS: 0 };
+			}
+			return { allowed: false, retryAfterS: estimatedRetryAfterS(safeLimit) };
+		},
+	};
+}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -33,8 +33,9 @@ import {
 } from "@codemem/core";
 import { count, desc, eq, max, ne } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { queryBool, queryInt, safeJsonList } from "../helpers.js";
+import type { InMemoryRequestRateLimiter } from "../request-rate-limit.js";
 
 type StoreFactory = () => MemoryStore;
 type SyncRuntimeStatus = {
@@ -49,6 +50,16 @@ type SyncRuntimeStatus = {
 		| null;
 	detail?: string | null;
 };
+
+interface SyncProtocolRouteOptions {
+	routeRateLimit?: {
+		limiter: InMemoryRequestRateLimiter;
+		readLimit: number;
+		mutationLimit: number;
+		unauthenticatedReadLimit: number;
+		unauthenticatedMutationLimit: number;
+	};
+}
 
 const SYNC_STALE_AFTER_SECONDS = 10 * 60;
 const SYNC_PROTOCOL_VERSION = "2";
@@ -725,14 +736,38 @@ const PEERS_QUERY = `
  * network-accessible. All requests are auth-gated via signature
  * verification so unauthenticated callers are rejected.
  */
-export function syncProtocolRoutes(getStore: StoreFactory) {
+export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRouteOptions = {}) {
 	const app = new Hono();
+	const routeRateLimit = opts.routeRateLimit ?? null;
+
+	function rateLimitedResponse(c: Context, key: string, authenticated: boolean) {
+		if (!routeRateLimit) return null;
+		const isRead = c.req.method === "GET" || c.req.method === "HEAD" || c.req.method === "OPTIONS";
+		const result = routeRateLimit.limiter.check(
+			`${c.req.method}:${authenticated ? "auth" : "anon"}:${key}`,
+			authenticated
+				? isRead
+					? routeRateLimit.readLimit
+					: routeRateLimit.mutationLimit
+				: isRead
+					? routeRateLimit.unauthenticatedReadLimit
+					: routeRateLimit.unauthenticatedMutationLimit,
+		);
+		if (result.allowed) return null;
+		c.header("Retry-After", String(result.retryAfterS));
+		return c.json({ error: "rate_limited", retry_after_s: result.retryAfterS }, 429);
+	}
 
 	// GET /v1/status (peer sync protocol)
 	app.get("/v1/status", (c) => {
 		const store = getStore();
 		const auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
-		if (!auth.ok) return c.json(unauthorizedPayload(auth.reason), 401);
+		if (!auth.ok)
+			return (
+				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
+			);
+		const limited = rateLimitedResponse(c, auth.deviceId, true);
+		if (limited) return limited;
 
 		try {
 			let device = store.db
@@ -758,7 +793,12 @@ export function syncProtocolRoutes(getStore: StoreFactory) {
 	app.get("/v1/ops", (c) => {
 		const store = getStore();
 		const auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
-		if (!auth.ok) return c.json(unauthorizedPayload(auth.reason), 401);
+		if (!auth.ok)
+			return (
+				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
+			);
+		const limited = rateLimitedResponse(c, auth.deviceId, true);
+		if (limited) return limited;
 		const peerDeviceId = auth.deviceId;
 
 		try {
@@ -817,7 +857,12 @@ export function syncProtocolRoutes(getStore: StoreFactory) {
 	app.get("/v1/snapshot", (c) => {
 		const store = getStore();
 		const auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
-		if (!auth.ok) return c.json(unauthorizedPayload(auth.reason), 401);
+		if (!auth.ok)
+			return (
+				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
+			);
+		const limited = rateLimitedResponse(c, auth.deviceId, true);
+		if (limited) return limited;
 
 		try {
 			const rawGeneration = c.req.query("generation");
@@ -874,7 +919,12 @@ export function syncProtocolRoutes(getStore: StoreFactory) {
 		}
 
 		const auth = authorizeSyncRequest(store, c.req, raw);
-		if (!auth.ok) return c.json(unauthorizedPayload(auth.reason), 401);
+		if (!auth.ok)
+			return (
+				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
+			);
+		const limited = rateLimitedResponse(c, auth.deviceId, true);
+		if (limited) return limited;
 		const peerDeviceId = auth.deviceId;
 
 		let body: Record<string, unknown>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       hono:
         specifier: ^4.7.10
         version: 4.12.8
+      limiter:
+        specifier: ^3.0.0
+        version: 3.0.0
       sqlite-vec:
         specifier: 0.1.7-alpha.2
         version: 0.1.7-alpha.2
@@ -223,6 +226,9 @@ importers:
       hono:
         specifier: ^4.7.10
         version: 4.12.8
+      limiter:
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -2581,6 +2587,9 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  limiter@3.0.0:
+    resolution: {integrity: sha512-hev7DuXojsTFl2YwyzUJMDnZ/qBDd3yZQLSH3aD4tdL1cqfc3TMnoecEJtWFaQFdErZsKoFMBTxF/FBSkgDbEg==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -5070,6 +5079,8 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  limiter@3.0.0: {}
 
   lru-cache@5.1.1:
     dependencies:


### PR DESCRIPTION
## Description
Adds lightweight request rate limiting to the network-exposed coordinator and sync listener surfaces.

This uses the off-the-shelf `limiter` package for the token-bucket behavior, applies route-level buckets before deeper request processing, and keeps the bucket keys non-spoofable by avoiding unauthenticated header-derived identities.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm vitest packages/core/src/coordinator-api.test.ts packages/viewer-server/src/index.test.ts`
- `pnpm --filter @codemem/core typecheck && pnpm --filter @codemem/server typecheck`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced