### PR TITLE
fix(sync-ui): prefer connected peer state over stale discovery

### DIFF
--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -297,4 +297,31 @@ describe('deriveSyncViewModel', () => {
     expect(view.duplicatePeople).toEqual([]);
     expect(view.attentionItems).toEqual([]);
   });
+
+  it('does not count a stale coordinator record as offline when the paired peer is actively connected', () => {
+    const view = deriveSyncViewModel({
+      peers: [
+        {
+          peer_device_id: 'peer-1',
+          status: { peer_state: 'online', fresh: true, sync_status: 'ok' },
+        },
+      ],
+      coordinator: {
+        discovered_devices: [
+          {
+            device_id: 'peer-1',
+            display_name: 'Desk Mini',
+            stale: true,
+            fingerprint: 'fp-1',
+          },
+        ],
+      },
+    });
+
+    expect(view.summary).toEqual({
+      connectedDeviceCount: 1,
+      seenOnTeamCount: 1,
+      offlineTeamDeviceCount: 0,
+    });
+  });
 });

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -165,6 +165,11 @@ export function derivePeerUiStatus(peer: PeerLike): UiSyncStatus {
   return 'waiting';
 }
 
+function isOfflineTeamDevice(device: MergedDevice): boolean {
+  if (!device.discovered?.stale) return false;
+  return device.peer ? derivePeerUiStatus(device.peer) !== 'connected' : true;
+}
+
 function peerErrorText(peer: PeerLike): string {
   return cleanText(peer?.last_error).toLowerCase();
 }
@@ -508,7 +513,7 @@ export function deriveSyncViewModel(input: {
     summary: {
       connectedDeviceCount: peers.filter((peer) => derivePeerUiStatus(peer) === 'connected').length,
       seenOnTeamCount: discoveredDevices.length,
-      offlineTeamDeviceCount: discoveredDevices.filter((device) => Boolean(device?.stale)).length,
+      offlineTeamDeviceCount: mergedDevices.filter((device) => isOfflineTeamDevice(device)).length,
     },
     duplicatePeople,
     attentionItems: attentionItems.sort((a, b) => a.priority - b.priority || a.title.localeCompare(b.title)),


### PR DESCRIPTION
## Description
Fixes the sync UI summary so a stale coordinator discovery record does not count a device as offline when the same device is locally paired and actively connected.

The main sync status area was mixing coordinator presence freshness with local peer sync health too aggressively, which could show online devices as offline in stable day-to-day use.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm vitest packages/ui/src/tabs/sync/view-model.test.ts`
- `pnpm --filter @codemem/server typecheck`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced