### PR TITLE
fix(sync): refresh coordinator presence from daemon

### DIFF
--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -8,6 +8,7 @@ import { buildBaseUrl, requestJson } from "./sync-http-client.js";
 import { ensureDeviceIdentity, loadPublicKey } from "./sync-identity.js";
 
 type ConfigRecord = Record<string, unknown>;
+type PresenceStoreLike = Pick<MemoryStore, "db" | "dbPath">;
 
 function clean(value: unknown): string {
 	return typeof value === "string" ? value.trim() : "";
@@ -79,7 +80,7 @@ interface PresenceSnapshot {
 
 const coordinatorPresenceCache = new Map<string, PresenceSnapshot>();
 
-function presenceCacheKey(store: MemoryStore, config: CoordinatorSyncConfig): string {
+function presenceCacheKey(store: PresenceStoreLike, config: CoordinatorSyncConfig): string {
 	const groups = [...config.syncCoordinatorGroups].sort().join(",");
 	return `${store.dbPath}|${config.syncCoordinatorUrl}|${groups}`;
 }
@@ -160,11 +161,12 @@ function advertisedSyncAddresses(config: CoordinatorSyncConfig): string[] {
 }
 
 export async function registerCoordinatorPresence(
-	store: MemoryStore,
+	store: PresenceStoreLike,
 	config: CoordinatorSyncConfig,
+	options?: { keysDir?: string },
 ): Promise<{ groups: string[]; responses: Record<string, unknown>[] } | null> {
 	if (!coordinatorEnabled(config)) return null;
-	const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+	const keysDir = options?.keysDir ?? (process.env.CODEMEM_KEYS_DIR?.trim() || undefined);
 	const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, { keysDir });
 	const publicKey = loadPublicKey(keysDir);
 	if (!publicKey) throw new Error("public key missing");

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -2,12 +2,19 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	getSyncDaemonPhase,
+	refreshCoordinatorPresenceForDaemon,
 	setSyncDaemonError,
 	setSyncDaemonOk,
 	setSyncDaemonPhase,
 	syncDaemonTick,
 } from "./sync-daemon.js";
 import { initTestSchema } from "./test-utils.js";
+
+vi.mock("./coordinator-runtime.js", () => ({
+	coordinatorEnabled: vi.fn().mockReturnValue(false),
+	readCoordinatorSyncConfig: vi.fn().mockReturnValue({}),
+	registerCoordinatorPresence: vi.fn().mockResolvedValue(null),
+}));
 
 // Mock sync-pass to avoid needing real keys/network
 vi.mock("./sync-pass.js", () => ({
@@ -77,6 +84,50 @@ describe("syncDaemonTick", () => {
 		expect(results).toHaveLength(1);
 		expect(results[0].skipped).toBe(true);
 		expect(results[0].reason).toContain("backoff");
+	});
+});
+
+describe("refreshCoordinatorPresenceForDaemon", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("does nothing when coordinator sync is not configured", async () => {
+		const { coordinatorEnabled, registerCoordinatorPresence } = await import(
+			"./coordinator-runtime.js"
+		);
+		vi.mocked(coordinatorEnabled).mockReturnValue(false);
+
+		expect(await refreshCoordinatorPresenceForDaemon(db, ":memory:")).toBe(false);
+		expect(registerCoordinatorPresence).not.toHaveBeenCalled();
+	});
+
+	it("posts coordinator presence with the daemon db and keys context when enabled", async () => {
+		const { coordinatorEnabled, readCoordinatorSyncConfig, registerCoordinatorPresence } =
+			await import("./coordinator-runtime.js");
+		vi.mocked(coordinatorEnabled).mockReturnValue(true);
+		vi.mocked(readCoordinatorSyncConfig).mockReturnValue({
+			syncCoordinatorUrl: "http://coord",
+			syncCoordinatorGroups: ["team"],
+		} as never);
+
+		expect(await refreshCoordinatorPresenceForDaemon(db, ":memory:", "/tmp/keys")).toBe(true);
+		expect(registerCoordinatorPresence).toHaveBeenCalledWith(
+			{ db, dbPath: ":memory:" },
+			expect.objectContaining({
+				syncCoordinatorUrl: "http://coord",
+				syncCoordinatorGroups: ["team"],
+			}),
+			{ keysDir: "/tmp/keys" },
+		);
 	});
 });
 

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -1,13 +1,18 @@
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	getSyncDaemonPhase,
 	refreshCoordinatorPresenceForDaemon,
+	runTickOnce,
 	setSyncDaemonError,
 	setSyncDaemonOk,
 	setSyncDaemonPhase,
 	syncDaemonTick,
 } from "./sync-daemon.js";
+
 import { initTestSchema } from "./test-utils.js";
 
 vi.mock("./coordinator-runtime.js", () => ({
@@ -128,6 +133,35 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 			}),
 			{ keysDir: "/tmp/keys" },
 		);
+	});
+
+	it("keeps direct peer sync running when coordinator heartbeat fails", async () => {
+		const { coordinatorEnabled, readCoordinatorSyncConfig, registerCoordinatorPresence } =
+			await import("./coordinator-runtime.js");
+		const { syncPassPreflight } = await import("./sync-pass.js");
+		vi.mocked(coordinatorEnabled).mockReturnValue(true);
+		vi.mocked(readCoordinatorSyncConfig).mockReturnValue({
+			syncCoordinatorUrl: "http://coord",
+			syncCoordinatorGroups: ["team"],
+		} as never);
+		vi.mocked(registerCoordinatorPresence).mockRejectedValue(new Error("coordinator timeout"));
+
+		const dbPath = join(tmpdir(), `codemem-sync-daemon-${Date.now()}.sqlite`);
+		const fileDb = new Database(dbPath);
+		try {
+			initTestSchema(fileDb);
+			fileDb
+				.prepare(
+					"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+				)
+				.run("peer-1", "fp1", new Date().toISOString());
+
+			await runTickOnce(dbPath);
+			expect(syncPassPreflight).toHaveBeenCalledTimes(1);
+		} finally {
+			fileDb.close();
+			rmSync(dbPath, { force: true });
+		}
 	});
 });
 

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -8,6 +8,11 @@
 
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
+import {
+	coordinatorEnabled,
+	readCoordinatorSyncConfig,
+	registerCoordinatorPresence,
+} from "./coordinator-runtime.js";
 import type { Database } from "./db.js";
 import { connect as connectDb, resolveDbPath } from "./db.js";
 import * as schema from "./schema.js";
@@ -112,6 +117,17 @@ export function setSyncDaemonPhase(db: Database, phase: SyncDaemonPhase): void {
 			set: { phase },
 		})
 		.run();
+}
+
+export async function refreshCoordinatorPresenceForDaemon(
+	db: Database,
+	dbPath: string,
+	keysDir?: string,
+): Promise<boolean> {
+	const config = readCoordinatorSyncConfig();
+	if (!coordinatorEnabled(config)) return false;
+	await registerCoordinatorPresence({ db, dbPath }, config, { keysDir });
+	return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -247,6 +263,7 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
 async function runTickOnce(dbPath: string, keysDir?: string): Promise<void> {
 	const db = connectDb(dbPath);
 	try {
+		await refreshCoordinatorPresenceForDaemon(db, dbPath, keysDir);
 		const results = await syncDaemonTick(db, keysDir);
 		const needsAttention = results.some((r) => !r.ok && r.error?.includes("needs_attention"));
 		if (needsAttention) {

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -260,10 +260,15 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
  *
  * Errors are caught and recorded in sync_daemon_state.
  */
-async function runTickOnce(dbPath: string, keysDir?: string): Promise<void> {
+export async function runTickOnce(dbPath: string, keysDir?: string): Promise<void> {
 	const db = connectDb(dbPath);
 	try {
-		await refreshCoordinatorPresenceForDaemon(db, dbPath, keysDir);
+		try {
+			await refreshCoordinatorPresenceForDaemon(db, dbPath, keysDir);
+		} catch {
+			// Coordinator discovery is a supplemental surface. Keep direct peer sync running
+			// even when heartbeat posting fails for this tick.
+		}
 		const results = await syncDaemonTick(db, keysDir);
 		const needsAttention = results.some((r) => !r.ok && r.error?.includes("needs_attention"));
 		if (needsAttention) {


### PR DESCRIPTION
## Description
Refreshes coordinator presence from the sync daemon so discovery records stay fresh even when the viewer UI is not open and `/api/sync/status` is not being polled.

Before this change, coordinator presence posting was effectively coupled to the viewer status path. That allowed coordinator discovery to go stale even while direct peer sync remained healthy. This PR moves the heartbeat into the daemon lifecycle using the daemon's DB/keys context.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm vitest packages/core/src/sync-daemon.test.ts`
- `pnpm --filter @codemem/core typecheck`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced