### PR TITLE
refactor(sync-ui): tighten remaining ts types

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -18,6 +18,78 @@ export interface RuntimeInfo {
   version: string;
 }
 
+export interface SyncPeerStatus {
+  peer_state?: string;
+  sync_status?: string;
+  ping_status?: string;
+  fresh?: boolean;
+}
+
+export interface SyncPeerSummary {
+  peer_device_id?: string;
+  name?: string;
+  actor_id?: string | null;
+  claimed_local_actor?: boolean;
+  fingerprint?: string | null;
+  addresses?: string[];
+  last_error?: string | null;
+  has_error?: boolean;
+  status?: SyncPeerStatus;
+}
+
+export interface SyncActorSummary {
+  actor_id?: string;
+  display_name?: string;
+  is_local?: boolean;
+}
+
+export interface SyncActorListResponse {
+  items?: SyncActorSummary[];
+}
+
+export interface SyncCoordinatorDeviceSummary {
+  device_id?: string;
+  display_name?: string | null;
+  stale?: boolean;
+  fingerprint?: string | null;
+  groups?: string[];
+  addresses?: string[];
+  needs_local_approval?: boolean;
+  waiting_for_peer_approval?: boolean;
+}
+
+export interface SyncCoordinatorStatus {
+  enabled?: boolean;
+  configured?: boolean;
+  groups?: string[];
+  paired_peer_count?: number;
+  presence_status?: string;
+  admin_secret_configured?: boolean;
+  discovered_devices?: SyncCoordinatorDeviceSummary[];
+  [key: string]: unknown;
+}
+
+export interface SyncAttemptSummary {
+  peer_device_id?: string;
+  ok?: boolean;
+  error?: string;
+  started_at?: string;
+  finished_at?: string;
+  ops_in?: number;
+  ops_out?: number;
+  status?: string;
+}
+
+export interface SyncStatusResponse {
+  status?: Record<string, unknown> | null;
+  peers?: SyncPeerSummary[];
+  coordinator?: SyncCoordinatorStatus | null;
+  join_requests?: Record<string, unknown>[];
+  sharing_review?: unknown[];
+  attempts?: SyncAttemptSummary[];
+  legacy_devices?: unknown[];
+}
+
 function payloadError(payload: unknown): string | undefined {
   if (!payload || typeof payload !== 'object') return undefined;
   const maybeError = (payload as { error?: unknown }).error;
@@ -142,7 +214,7 @@ export async function loadSyncStatus(
   includeDiagnostics: boolean,
   project = '',
   options?: { includeJoinRequests?: boolean },
-): Promise<any> {
+): Promise<SyncStatusResponse> {
   const params = new URLSearchParams();
   if (includeDiagnostics) params.set('includeDiagnostics', '1');
   if (project) params.set('project', project);
@@ -189,7 +261,7 @@ export async function reviewJoinRequest(requestId: string, action: 'approve' | '
   return data;
 }
 
-export async function loadSyncActors(): Promise<any> {
+export async function loadSyncActors(): Promise<SyncActorListResponse> {
   return fetchJson('/api/sync/actors');
 }
 

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -49,18 +49,18 @@ export const state = {
   lastStatsPayload: null as any,
   lastUsagePayload: null as any,
   lastRawEventsPayload: null as any,
-  lastSyncStatus: null as any,
-  lastSyncActors: [] as any[],
-  lastSyncPeers: [] as any[],
-  pendingAcceptedSyncPeers: [] as any[],
+  lastSyncStatus: null as Record<string, unknown> | null,
+  lastSyncActors: [] as SyncActorSummary[],
+  lastSyncPeers: [] as SyncPeerSummary[],
+  pendingAcceptedSyncPeers: [] as SyncPeerSummary[],
   lastSyncSharingReview: [] as any[],
-  lastSyncCoordinator: null as any,
+  lastSyncCoordinator: null as SyncCoordinatorStatus | null,
   lastSyncJoinRequests: [] as any[],
   lastTeamInvite: null as any,
   lastTeamJoin: null as any,
-  lastSyncAttempts: [] as any[],
+  lastSyncAttempts: [] as SyncAttemptSummary[],
   lastSyncLegacyDevices: [] as any[],
-  lastSyncViewModel: null as any,
+  lastSyncViewModel: null as UiSyncViewModel | null,
   lastSyncDuplicatePersonDecisions: {} as Record<string, string>,
   pairingPayloadRaw: null as any,
   pairingCommandRaw: '',
@@ -159,3 +159,10 @@ export function initState() {
     state.syncPairingOpen = false;
   }
 }
+import type {
+  SyncActorSummary,
+  SyncAttemptSummary,
+  SyncCoordinatorStatus,
+  SyncPeerSummary,
+} from './api';
+import type { UiSyncViewModel } from '../tabs/sync/view-model';

--- a/packages/ui/src/tabs/sync/helpers.test.ts
+++ b/packages/ui/src/tabs/sync/helpers.test.ts
@@ -36,6 +36,7 @@ describe('buildActorSelectOptions', () => {
     ];
     state.lastSyncPeers = [];
     state.lastSyncViewModel = {
+      summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
       duplicatePeople: [
         {
           displayName: 'Adam',
@@ -43,6 +44,7 @@ describe('buildActorSelectOptions', () => {
           includesLocal: true,
         },
       ],
+      attentionItems: [],
     };
 
     expect(buildActorSelectOptions()).toEqual([
@@ -59,6 +61,7 @@ describe('buildActorSelectOptions', () => {
     ];
     state.lastSyncPeers = [];
     state.lastSyncViewModel = {
+      summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
       duplicatePeople: [
         {
           displayName: 'Adam',
@@ -66,6 +69,7 @@ describe('buildActorSelectOptions', () => {
           includesLocal: true,
         },
       ],
+      attentionItems: [],
     };
 
     expect(buildActorSelectOptions('actor-shadow')).toEqual([
@@ -78,7 +82,11 @@ describe('buildActorSelectOptions', () => {
   it('keeps an explicit unassigned choice in the option list', () => {
     state.lastSyncActors = [{ actor_id: 'actor-local', display_name: 'Adam', is_local: true }];
     state.lastSyncPeers = [];
-    state.lastSyncViewModel = { duplicatePeople: [] };
+    state.lastSyncViewModel = {
+      summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
+      duplicatePeople: [],
+      attentionItems: [],
+    };
 
     expect(buildActorSelectOptions()).toEqual([
       { value: '', label: 'No person assigned' },

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -3,6 +3,7 @@
 import { el, copyToClipboard } from '../../lib/dom';
 import { state } from '../../lib/state';
 import { deriveVisiblePeopleActors } from './view-model';
+import type { ActorLike } from './view-model';
 import type { RadixSelectOption } from '../../components/primitives/radix-select';
 
 /* ── Skeleton helpers ────────────────────────────────────── */
@@ -105,7 +106,7 @@ export function redactIpOctets(text: string): string {
   return text.replace(/\b(\d{1,3}\.\d{1,3})\.\d{1,3}\.\d{1,3}\b/g, '$1.#.#');
 }
 
-export function redactAddress(address: any): string {
+export function redactAddress(address: unknown): string {
   const raw = String(address || '');
   if (!raw) return '';
   return redactIpOctets(raw);
@@ -126,14 +127,14 @@ export function parseScopeList(value: string): string[] {
 
 /* ── Actor helpers ───────────────────────────────────────── */
 
-export function actorLabel(actor: any): string {
+export function actorLabel(actor: ActorLike | null | undefined): string {
   if (!actor || typeof actor !== 'object') return 'Unknown person';
   const displayName = String(actor.display_name || '').trim();
   if (!displayName) return String(actor.actor_id || 'Unknown person');
   return displayName;
 }
 
-export function actorDisplayLabel(actor: any): string {
+export function actorDisplayLabel(actor: ActorLike | null | undefined): string {
   if (!actor || typeof actor !== 'object') return 'Unknown person';
   return actor.is_local ? 'You' : actorLabel(actor);
 }
@@ -201,7 +202,7 @@ export function buildActorOptions(selectedActorId: string): HTMLOptionElement[] 
   return options;
 }
 
-export function mergeTargetActors(actorId: string): any[] {
+export function mergeTargetActors(actorId: string): ActorLike[] {
   const actors = visibleSyncActors();
   return actors.filter((actor) => String(actor?.actor_id || '') !== actorId);
 }

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -1,6 +1,7 @@
 /* Sync tab orchestrator — re-exports public API and coordinates sub-modules. */
 
 import * as api from '../../lib/api';
+import type { SyncActorListResponse, SyncPeerSummary, SyncStatusResponse } from '../../lib/api';
 import { state } from '../../lib/state';
 import { renderHealthOverview } from '../health';
 import { deriveSyncViewModel } from './view-model';
@@ -20,7 +21,7 @@ export { renderSyncPeers } from './people';
 /* ── Data loading ────────────────────────────────────────── */
 
 let lastSyncHash = '';
-let cachedSyncStatus: { key: string; expiresAtMs: number; payload: any } | null = null;
+let cachedSyncStatus: { key: string; expiresAtMs: number; payload: SyncStatusResponse } | null = null;
 
 const HEALTH_SYNC_STATUS_CACHE_TTL_MS = 15_000;
 
@@ -28,7 +29,7 @@ function syncStatusCacheKey(project: string): string {
   return `project:${project || ''}|includeJoinRequests:false`;
 }
 
-function readCachedSyncStatus(project: string): any | null {
+function readCachedSyncStatus(project: string): SyncStatusResponse | null {
   const key = syncStatusCacheKey(project);
   if (!cachedSyncStatus) return null;
   if (cachedSyncStatus.key !== key) return null;
@@ -36,7 +37,7 @@ function readCachedSyncStatus(project: string): any | null {
   return cachedSyncStatus.payload;
 }
 
-function writeCachedSyncStatus(project: string, payload: any): void {
+function writeCachedSyncStatus(project: string, payload: SyncStatusResponse): void {
   cachedSyncStatus = {
     key: syncStatusCacheKey(project),
     expiresAtMs: Date.now() + HEALTH_SYNC_STATUS_CACHE_TTL_MS,
@@ -44,7 +45,7 @@ function writeCachedSyncStatus(project: string, payload: any): void {
   };
 }
 
-function normalizeSyncStatusForCache(payload: any): any {
+function normalizeSyncStatusForCache(payload: SyncStatusResponse): SyncStatusResponse {
   if (!payload || typeof payload !== 'object') return payload;
   return {
     ...payload,
@@ -58,7 +59,7 @@ export async function loadSyncData() {
     const includeJoinRequests = state.activeTab === 'sync';
     const useCache = state.activeTab === 'health';
 
-    let payload: any;
+    let payload: SyncStatusResponse;
     if (useCache) {
       payload = readCachedSyncStatus(project);
       if (!payload) {
@@ -70,7 +71,7 @@ export async function loadSyncData() {
       writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
     }
 
-    let actorsPayload: any = null;
+    let actorsPayload: SyncActorListResponse | null = null;
     let actorLoadError = false;
     const duplicatePersonDecisions = readDuplicatePersonDecisions();
     try {
@@ -93,9 +94,9 @@ export async function loadSyncData() {
       state.lastSyncActors = [];
     }
     const payloadPeers = Array.isArray(payload.peers) ? payload.peers : [];
-    const realPeerIds = new Set(payloadPeers.map((peer: any) => String(peer?.peer_device_id || '').trim()).filter(Boolean));
+    const realPeerIds = new Set(payloadPeers.map((peer: SyncPeerSummary) => String(peer?.peer_device_id || '').trim()).filter(Boolean));
     const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
-      ? state.pendingAcceptedSyncPeers.filter((peer: any) => {
+      ? state.pendingAcceptedSyncPeers.filter((peer: SyncPeerSummary) => {
           const peerId = String(peer?.peer_device_id || '').trim();
           return peerId && !realPeerIds.has(peerId);
         })

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -5,6 +5,7 @@ import { state, setFeedScopeFilter, isSyncRedactionEnabled } from '../../lib/sta
 import * as api from '../../lib/api';
 import { showGlobalNotice } from '../../lib/notice';
 import { markFieldError, clearFieldError, friendlyError } from '../../lib/form';
+import type { UiSyncViewModel } from './view-model';
 import {
   adminSetupExpanded,
   setAdminSetupExpanded,
@@ -180,7 +181,11 @@ export function renderTeamSync() {
   ensureJoinPanelInSetupSection();
 
   const coordinator = state.lastSyncCoordinator;
-  const syncView = state.lastSyncViewModel || { summary: {}, attentionItems: [] };
+  const syncView: UiSyncViewModel = state.lastSyncViewModel || {
+    summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
+    duplicatePeople: [],
+    attentionItems: [],
+  };
 
   const focusAttentionTarget = (item: { kind?: string; deviceId?: string }) => {
     if (item.kind === 'possible-duplicate-person') {


### PR DESCRIPTION
## Description
Tightens the remaining broad TypeScript `any` usage in the sync UI surfaces without broad unrelated cleanup.

This adds explicit sync-specific types for API payloads, sync state, and a few rendering/helper paths so the current sync UI behavior is easier to reason about and less likely to regress silently.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck && pnpm --filter @codemem/server typecheck`
- `pnpm vitest packages/ui/src/tabs/sync/view-model.test.ts packages/ui/src/tabs/sync/helpers.test.ts`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced