### PR TITLE
fix(sync-ui): ignore stale refresh results

### DIFF
--- a/packages/ui/src/tabs/sync/index.test.ts
+++ b/packages/ui/src/tabs/sync/index.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../lib/api', () => ({
+  loadSyncStatus: vi.fn(),
+  loadSyncActors: vi.fn(),
+}));
+
+vi.mock('../health', () => ({ renderHealthOverview: vi.fn() }));
+vi.mock('./diagnostics', () => ({
+  renderSyncStatus: vi.fn(),
+  renderSyncAttempts: vi.fn(),
+  renderPairing: vi.fn(),
+  initDiagnosticsEvents: vi.fn(),
+  setRenderSyncPeers: vi.fn(),
+}));
+vi.mock('./team-sync', () => ({
+  renderTeamSync: vi.fn(),
+  renderSyncSharingReview: vi.fn(),
+  initTeamSyncEvents: vi.fn(),
+  setLoadSyncData: vi.fn(),
+}));
+vi.mock('./people', () => ({
+  renderSyncActors: vi.fn(),
+  renderSyncPeers: vi.fn(),
+  renderLegacyDeviceClaims: vi.fn(),
+  initPeopleEvents: vi.fn(),
+  setLoadSyncData: vi.fn(),
+}));
+vi.mock('./components/render-root', () => ({ ensureSyncRenderBoundary: vi.fn() }));
+vi.mock('./sync-dialogs', () => ({ ensureSyncDialogHost: vi.fn() }));
+vi.mock('./helpers', () => ({
+  hideSkeleton: vi.fn(),
+  readDuplicatePersonDecisions: vi.fn(() => ({})),
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('loadSyncData', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { state } = await import('../../lib/state');
+    const { resetSyncLoadStateForTests } = await import('./index');
+    resetSyncLoadStateForTests();
+    state.activeTab = 'sync';
+    state.currentProject = '';
+    state.lastSyncPeers = [];
+    state.pendingAcceptedSyncPeers = [];
+    state.lastSyncActors = [];
+    state.lastSyncCoordinator = null;
+    state.lastSyncViewModel = null;
+  });
+
+  it('ignores stale out-of-order sync payloads from older refreshes', async () => {
+    const api = await import('../../lib/api');
+    const { state } = await import('../../lib/state');
+    const { loadSyncData } = await import('./index');
+
+    const first = deferred<{ peers: Array<{ peer_device_id: string }>; sharing_review: []; attempts: []; legacy_devices: [] }>();
+    const second = deferred<{ peers: Array<{ peer_device_id: string }>; sharing_review: []; attempts: []; legacy_devices: [] }>();
+
+    vi.mocked(api.loadSyncStatus)
+      .mockReturnValueOnce(first.promise as never)
+      .mockReturnValueOnce(second.promise as never);
+    vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+
+    const firstLoad = loadSyncData();
+    const secondLoad = loadSyncData();
+
+    second.resolve({
+      peers: [{ peer_device_id: 'peer-new' }],
+      sharing_review: [],
+      attempts: [],
+      legacy_devices: [],
+    });
+    await secondLoad;
+    expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(['peer-new']);
+
+    first.resolve({
+      peers: [{ peer_device_id: 'peer-old' }],
+      sharing_review: [],
+      attempts: [],
+      legacy_devices: [],
+    });
+    await firstLoad;
+    expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(['peer-new']);
+  });
+
+  it('does not extend the health-tab cache ttl on cache hits', async () => {
+    const api = await import('../../lib/api');
+    const { state } = await import('../../lib/state');
+    const { loadSyncData } = await import('./index');
+
+    state.activeTab = 'health';
+
+    vi.mocked(api.loadSyncStatus).mockResolvedValue({
+      peers: [{ peer_device_id: 'peer-cached' }],
+      sharing_review: [],
+      attempts: [],
+      legacy_devices: [],
+    } as never);
+    vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+
+    await loadSyncData();
+    await loadSyncData();
+
+    expect(api.loadSyncStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -20,7 +20,26 @@ export { renderSyncPeers } from './people';
 /* ── Data loading ────────────────────────────────────────── */
 
 let lastSyncHash = '';
-let cachedSyncStatus: { key: string; expiresAtMs: number; payload: any } | null = null;
+type SyncStatusResponseLike = {
+  status?: Record<string, unknown> | null;
+  peers?: Array<{ peer_device_id?: string }>;
+  coordinator?: Record<string, unknown> | null;
+  join_requests?: unknown[];
+  sharing_review?: unknown[];
+  attempts?: unknown[];
+  legacy_devices?: unknown[];
+};
+
+type SyncActorListResponseLike = {
+  items?: unknown[];
+};
+
+type SyncPeerSummaryLike = {
+  peer_device_id?: string;
+};
+
+let cachedSyncStatus: { key: string; expiresAtMs: number; payload: SyncStatusResponseLike } | null = null;
+let latestSyncLoadRequestId = 0;
 
 const HEALTH_SYNC_STATUS_CACHE_TTL_MS = 15_000;
 
@@ -28,7 +47,7 @@ function syncStatusCacheKey(project: string): string {
   return `project:${project || ''}|includeJoinRequests:false`;
 }
 
-function readCachedSyncStatus(project: string): any | null {
+function readCachedSyncStatus(project: string): SyncStatusResponseLike | null {
   const key = syncStatusCacheKey(project);
   if (!cachedSyncStatus) return null;
   if (cachedSyncStatus.key !== key) return null;
@@ -36,7 +55,7 @@ function readCachedSyncStatus(project: string): any | null {
   return cachedSyncStatus.payload;
 }
 
-function writeCachedSyncStatus(project: string, payload: any): void {
+function writeCachedSyncStatus(project: string, payload: SyncStatusResponseLike): void {
   cachedSyncStatus = {
     key: syncStatusCacheKey(project),
     expiresAtMs: Date.now() + HEALTH_SYNC_STATUS_CACHE_TTL_MS,
@@ -44,7 +63,7 @@ function writeCachedSyncStatus(project: string, payload: any): void {
   };
 }
 
-function normalizeSyncStatusForCache(payload: any): any {
+function normalizeSyncStatusForCache(payload: SyncStatusResponseLike): SyncStatusResponseLike {
   if (!payload || typeof payload !== 'object') return payload;
   return {
     ...payload,
@@ -53,30 +72,38 @@ function normalizeSyncStatusForCache(payload: any): any {
 }
 
 export async function loadSyncData() {
+  const requestId = ++latestSyncLoadRequestId;
   try {
     const project = state.currentProject || '';
     const includeJoinRequests = state.activeTab === 'sync';
     const useCache = state.activeTab === 'health';
+    let fetchedFreshSyncStatus = false;
 
-    let payload: any;
+    let payload: SyncStatusResponseLike;
     if (useCache) {
       payload = readCachedSyncStatus(project);
       if (!payload) {
         payload = await api.loadSyncStatus(true, project, { includeJoinRequests: false });
-        writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
+        fetchedFreshSyncStatus = true;
       }
     } else {
       payload = await api.loadSyncStatus(true, project, { includeJoinRequests });
-      writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
+      fetchedFreshSyncStatus = true;
     }
 
-    let actorsPayload: any = null;
+    let actorsPayload: SyncActorListResponseLike | null = null;
     let actorLoadError = false;
     const duplicatePersonDecisions = readDuplicatePersonDecisions();
     try {
       actorsPayload = await api.loadSyncActors();
     } catch {
       actorLoadError = true;
+    }
+
+    if (requestId !== latestSyncLoadRequestId) return;
+
+    if (fetchedFreshSyncStatus) {
+      writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
     }
 
     // Skip re-render if data hasn't changed since last poll
@@ -93,9 +120,9 @@ export async function loadSyncData() {
       state.lastSyncActors = [];
     }
     const payloadPeers = Array.isArray(payload.peers) ? payload.peers : [];
-    const realPeerIds = new Set(payloadPeers.map((peer: any) => String(peer?.peer_device_id || '').trim()).filter(Boolean));
+    const realPeerIds = new Set(payloadPeers.map((peer: SyncPeerSummaryLike) => String(peer?.peer_device_id || '').trim()).filter(Boolean));
     const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
-      ? state.pendingAcceptedSyncPeers.filter((peer: any) => {
+      ? state.pendingAcceptedSyncPeers.filter((peer: SyncPeerSummaryLike) => {
           const peerId = String(peer?.peer_device_id || '').trim();
           return peerId && !realPeerIds.has(peerId);
         })
@@ -132,6 +159,7 @@ export async function loadSyncData() {
           'People controls are temporarily unavailable. Device status and sync health still loaded.';
     }
   } catch {
+    if (requestId !== latestSyncLoadRequestId) return;
     // Clear all skeletons so the error state is visible, not masked by loading placeholders
     hideSkeleton('syncTeamSkeleton');
     hideSkeleton('syncActorsSkeleton');
@@ -140,6 +168,12 @@ export async function loadSyncData() {
     const syncMeta = document.getElementById('syncMeta');
     if (syncMeta) syncMeta.textContent = 'Sync unavailable';
   }
+}
+
+export function resetSyncLoadStateForTests() {
+  lastSyncHash = '';
+  cachedSyncStatus = null;
+  latestSyncLoadRequestId = 0;
 }
 
 export async function loadPairingData() {


### PR DESCRIPTION
## Description
Prevents stale sync-tab refresh responses from overwriting newer sync state.

This fixes the race where direct sync-tab reloads (such as after assigning a person) could overlap with auto-refresh polling, allowing an older `loadSyncData()` completion to replace newer peer state and temporarily make a device disappear until the next refresh.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm vitest packages/ui/src/tabs/sync/index.test.ts`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced