### PR TITLE
refactor(sync-ui): compress device card chrome

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -362,12 +362,10 @@ function SyncPeerCard({
       <div className="peer-scope">
         {scopeReviewRequested ? (
           <div className="peer-meta">
-            Review this device&apos;s sync scope now. Global defaults apply until you save an override here.
+            Review this device&apos;s sharing scope now.
           </div>
         ) : pendingScopeReview ? (
-          <div className="peer-meta">
-            Scope review still pending. Save an override here or reset to global scope when you are done reviewing. Manual syncs can proceed, but they will use the current effective scope until you change it.
-          </div>
+          <div className="peer-meta">Scope review still pending.</div>
         ) : null}
 
         <div className="peer-scope-summary">Assigned person</div>
@@ -376,7 +374,6 @@ function SyncPeerCard({
             ? `Assigned to ${peer.claimed_local_actor ? 'You' : String(peer.actor_display_name)}`
             : 'Unassigned person'}
         </div>
-        <div className="peer-meta">{trustSummary.description}</div>
         <div className="peer-actor-row">
           <div className="sync-radix-select-host sync-actor-select-host">
             <RadixSelect

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -370,28 +370,25 @@ export function renderTeamSync() {
           .join(' · ')
       : 'No fresh addresses';
     const noteParts = [addressLabel];
-    if (displayTitle) noteParts.push(`device id: ${deviceId}`);
+    if (displayTitle && !addresses.length) noteParts.push(`device id: ${deviceId}`);
     let actionMessage: string | null = null;
     let mode: TeamSyncDiscoveredRow['mode'] = canAccept ? 'accept' : 'none';
     let pairedMessage: string | null = null;
 
     if (hasConflict) {
-      noteParts.push('repair the local peer before accepting this discovered device');
       mode = 'conflict';
     } else if (hasAmbiguousCoordinatorGroup) {
-      noteParts.push('this device appears in multiple coordinator groups; review team setup before approving it here');
       actionMessage =
         'This device is visible through multiple coordinator groups. Fix that team setup first, then approve it here.';
       mode = 'ambiguous';
     } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
-      noteParts.push('scope review pending in People');
       actionMessage = `Review this device's scope in People & devices next.`;
       mode = 'scope-pending';
     } else if (pairedPeer?.last_error) {
-      noteParts.push(`paired error: ${String(pairedPeer.last_error)}`);
+      noteParts.push(`error: ${String(pairedPeer.last_error)}`);
       mode = 'paired';
     } else if (pairedPeer?.status?.peer_state) {
-      noteParts.push(`paired status: ${String(pairedPeer.status.peer_state)}`);
+      noteParts.push(`status: ${String(pairedPeer.status.peer_state)}`);
       mode = 'paired';
     } else if (!pairedPeer && device.stale) {
       actionMessage = 'Wait for a fresh coordinator presence update.';
@@ -399,7 +396,6 @@ export function renderTeamSync() {
     } else if (pairedPeer) {
       mode = 'paired';
     }
-    if (approvalSummary.description) noteParts.push(approvalSummary.description);
     if (mode === 'paired') {
       pairedMessage =
         approvalSummary.state === 'waiting-for-other-device'


### PR DESCRIPTION
## Description
Reduces steady-state visual density in People 6 devices and discovery rows.

This removes repeated explanatory prose from normal device cards, keeps discovery rows quieter, and favors high-signal metadata over repeated setup/recovery text.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced