### PR TITLE
fix(sync-ui): tighten status summary hierarchy

### DIFF
--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -5,6 +5,7 @@ import type { UiSyncAttentionItem } from '../view-model';
 
 export interface TeamSyncStatusSummary {
   badgeClassName: string;
+  headline: string | null;
   presenceLabel: string;
   metricsText: string;
 }
@@ -252,21 +253,14 @@ function ActionContent(props: TeamSyncPanelProps) {
         : null}
       {!hasAttentionItems && props.presenceStatus === 'posted' ? (
         <div className="sync-action">
-          <div className="sync-action-text">
-            No immediate issues
-            <span className="sync-action-command">
-              Your devices and team records do not currently need review.
-            </span>
-          </div>
+          <div className="sync-action-text">No immediate issues</div>
         </div>
       ) : null}
       {!hasAttentionItems && props.presenceStatus === 'not_enrolled' ? (
         <div className="sync-action">
           <div className="sync-action-text">
             This device still needs team enrollment
-            <span className="sync-action-command">
-              Import an invite or ask your admin to enroll this device before expecting sync activity here.
-            </span>
+            <span className="sync-action-command">Import an invite or ask an admin to enroll it.</span>
           </div>
         </div>
       ) : null}
@@ -288,6 +282,7 @@ function TeamStatusPortal({
         <span className="sync-team-status-label">Status</span>
         <span className={statusSummary.badgeClassName}>{statusSummary.presenceLabel}</span>
       </div>
+      {statusSummary.headline ? <div className="sync-team-metrics">{statusSummary.headline}</div> : null}
       <div className="sync-team-metrics">{statusSummary.metricsText}</div>
     </div>,
     mount,

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -281,8 +281,8 @@ export function renderTeamSync() {
 
   const configured = Boolean(coordinator && coordinator.configured);
   meta.textContent = configured
-    ? `Connected to ${String(coordinator.coordinator_url || '')} · group: ${(coordinator.groups || []).join(', ') || 'none'}`
-    : 'Start here: join an existing team or create a new one before connecting devices and people.';
+    ? `Coordinator: ${String(coordinator.coordinator_url || '')} · group: ${(coordinator.groups || []).join(', ') || 'none'}`
+    : 'Join an existing team or create one before connecting devices and people.';
 
   if (!configured) {
     teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
@@ -303,23 +303,31 @@ export function renderTeamSync() {
     presenceStatus === 'posted'
       ? 'Connected'
       : presenceStatus === 'not_enrolled'
-        ? 'Not connected — import an invite or ask your admin to enroll this device'
+        ? 'Needs enrollment'
         : 'Connection error';
-  const metricParts = [
-    `Connected devices: ${Number(syncView.summary?.connectedDeviceCount || 0)}`,
-    `Seen on team: ${Number(syncView.summary?.seenOnTeamCount || 0)}`,
-  ];
-  if (Number(syncView.summary?.offlineTeamDeviceCount || 0) > 0) {
-    metricParts.push(`Offline on team: ${Number(syncView.summary?.offlineTeamDeviceCount || 0)}`);
+  const localPeers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
+  const attentionItems = Array.isArray(syncView.attentionItems) ? syncView.attentionItems : [];
+  const connectedCount = Number(syncView.summary?.connectedDeviceCount || 0);
+  const seenOnTeamCount = Number(syncView.summary?.seenOnTeamCount || 0);
+  const offlineTeamDeviceCount = Number(syncView.summary?.offlineTeamDeviceCount || 0);
+  const metricParts = [`Connected ${connectedCount}`, `Team ${seenOnTeamCount}`];
+  if (offlineTeamDeviceCount > 0) {
+    metricParts.push(`Offline ${offlineTeamDeviceCount}`);
   }
   const statusSummary: TeamSyncStatusSummary = {
     badgeClassName: `pill ${presenceStatus === 'posted' ? 'pill-success' : presenceStatus === 'not_enrolled' ? 'pill-warning' : 'pill-error'}`,
+    headline:
+      presenceStatus === 'posted'
+        ? attentionItems.length > 0
+          ? `${attentionItems.length} item${attentionItems.length === 1 ? '' : 's'} need review`
+          : 'Everything important looks healthy'
+        : presenceStatus === 'not_enrolled'
+          ? 'This device is not enrolled in the team yet'
+          : 'Sync needs attention',
     metricsText: metricParts.join(' · '),
     presenceLabel,
   };
 
-  const localPeers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
-  const attentionItems = Array.isArray(syncView.attentionItems) ? syncView.attentionItems : [];
   const discoveredDevices = Array.isArray(coordinator.discovered_devices)
     ? coordinator.discovered_devices
     : [];
@@ -391,7 +399,6 @@ export function renderTeamSync() {
     } else if (pairedPeer) {
       mode = 'paired';
     }
-
     if (approvalSummary.description) noteParts.push(approvalSummary.description);
     if (mode === 'paired') {
       pairedMessage =
@@ -432,7 +439,7 @@ export function renderTeamSync() {
   if (discoveredPanel) discoveredPanel.hidden = discoveredRows.length === 0;
   if (discoveredMeta) {
     discoveredMeta.textContent = discoveredRows.length
-      ? 'These devices are visible through team discovery. Review them before connecting them on this machine.'
+      ? 'Visible through team discovery. Review before connecting them on this machine.'
       : '';
   }
   if (joinRequests) joinRequests.hidden = pendingJoinRequests.length === 0;


### PR DESCRIPTION
## Description
Tightens the top of the sync tab so the status summary answers health and next-step questions in one scan.

This simplifies the coordinator meta copy, reduces the top-level status wording, and makes the summary headline better reflect whether the tab is actually healthy or still has actionable work.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced