### PR TITLE
refactor(sync-ui): move recovery guidance to inbox

### DIFF
--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -378,8 +378,7 @@ export function renderTeamSync() {
     if (hasConflict) {
       mode = 'conflict';
     } else if (hasAmbiguousCoordinatorGroup) {
-      actionMessage =
-        'This device is visible through multiple coordinator groups. Fix that team setup first, then approve it here.';
+      actionMessage = 'This device appears in multiple coordinator groups. Review the team setup before approving it here.';
       mode = 'ambiguous';
     } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
       actionMessage = `Review this device's scope in People & devices next.`;
@@ -403,7 +402,7 @@ export function renderTeamSync() {
           : String(pairedPeer?.last_error || '').toLowerCase().includes('401') &&
               String(pairedPeer?.last_error || '').toLowerCase().includes('unauthorized')
             ? 'Waiting for the other device to trust this one before sync can work.'
-            : 'Manage this device in People & devices.';
+            : null;
     }
 
     return {

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -97,6 +97,7 @@ export interface DiscoveredDeviceLike {
   display_name?: string;
   stale?: boolean;
   fingerprint?: string;
+  groups?: string[];
   needs_local_approval?: boolean;
   waiting_for_peer_approval?: boolean;
 }
@@ -353,9 +354,9 @@ function createRepairItem(device: { id: string; name: string; summary: string })
   };
 }
 
-function createReviewItem(device: { id: string; name: string; summary: string }): UiSyncAttentionItem {
+function createReviewItem(device: { id: string; name: string; summary: string; key?: string }): UiSyncAttentionItem {
   return {
-    id: `review:${device.id}`,
+    id: `review:${device.id}:${device.key || 'default'}`,
     kind: 'review-team-device',
     priority: 20,
     title: `${device.name} is available to review`,
@@ -484,9 +485,32 @@ export function deriveSyncViewModel(input: {
       attentionItems.push(
         createReviewItem({
           id: device.deviceId,
+          key: 'other-device-trust',
           name,
           summary:
             'You accepted this device. Finish onboarding on the other device so it trusts this one too.',
+        }),
+      );
+    }
+
+    if (!device.peer && device.discovered?.stale) {
+      attentionItems.push(
+        createReviewItem({
+          id: device.deviceId,
+          key: 'stale-discovery',
+          name,
+          summary: 'This device is no longer advertising fresh coordinator presence. Wait for it to check in again before connecting it here.',
+        }),
+      );
+    }
+
+    if (!device.peer && Array.isArray(device.discovered?.groups) && device.discovered.groups.length > 1) {
+      attentionItems.push(
+        createReviewItem({
+          id: device.deviceId,
+          key: 'ambiguous-groups',
+          name,
+          summary: 'This device appears in multiple coordinator groups. Review the team setup before approving it here.',
         }),
       );
     }


### PR DESCRIPTION
## Description
Makes Needs attention the primary recovery inbox for the sync tab.

This moves more blocked/recovery guidance into the dedicated attention model instead of repeating it across steady-state device rows, while keeping the top summary honest about remaining actionable work.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced