### PR TITLE
refactor(sync-ui): separate recovery and team actions

### DIFF
--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -264,9 +264,18 @@ function ActionContent(props: TeamSyncPanelProps) {
           </div>
         </div>
       ) : null}
-      {props.children}
     </>
   );
+}
+
+function TeamActionsContent({ children }: { children?: ComponentChildren }) {
+	if (!children) return null;
+	return (
+		<>
+			<div className="sync-action-text">Team actions</div>
+			{children}
+		</>
+	);
 }
 
 function TeamStatusPortal({
@@ -353,6 +362,7 @@ export function TeamSyncPanel(props: TeamSyncPanelProps) {
   return (
     <>
       <ActionContent {...props} />
+      <TeamActionsContent>{props.children}</TeamActionsContent>
       <TeamStatusPortal mount={props.listMount} statusSummary={props.statusSummary} />
       <PendingRequestsPortal
         mount={props.joinRequestsMount}


### PR DESCRIPTION
## Description
Separates recovery-focused content from normal team-management controls in the sync tab.

This makes Needs attention read like an actual recovery inbox while team-management actions sit in their own quieter section instead of blending into the same visual block.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced