### PR TITLE
refactor(sync-ui): demote advanced sync details

### DIFF
--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -32,6 +32,7 @@ export interface TeamSyncPendingJoinRequest {
 
 type TeamSyncPanelProps = {
   actionItems: UiSyncAttentionItem[];
+  actionableCount: number;
   children?: ComponentChildren;
   discoveredListMount: HTMLElement | null;
   discoveredRows: TeamSyncDiscoveredRow[];
@@ -99,8 +100,7 @@ function PendingJoinRequestRow({
   return (
     <div className="actor-row">
       <div className="actor-details">
-        <div className="actor-title">{request.displayName}</div>
-        <div className="peer-meta">request: {request.requestId}</div>
+        <div className="actor-title" title={request.requestId || undefined}>{request.displayName}</div>
       </div>
       <div className="actor-actions">
         <button
@@ -198,7 +198,7 @@ function DiscoveredDeviceRow({
             {reviewLabel}
           </button>
         ) : null}
-        {row.mode === 'stale' || row.mode === 'ambiguous' || row.mode === 'scope-pending' ? (
+        {(row.mode === 'stale' || row.mode === 'ambiguous' || row.mode === 'scope-pending') && row.actionMessage ? (
           <div className="peer-meta">{row.actionMessage}</div>
         ) : null}
         {row.mode === 'paired' && row.pairedMessage ? (
@@ -242,18 +242,24 @@ function DiscoveredDeviceRow({
 
 function ActionContent(props: TeamSyncPanelProps) {
   const hasAttentionItems = props.actionItems.length > 0;
+  const hasOtherActionableWork = props.actionableCount > props.actionItems.length;
 
   return (
     <>
       {hasAttentionItems ? <div className="sync-action-text">Needs attention</div> : null}
       {hasAttentionItems
-        ? props.actionItems.slice(0, 4).map((item) => (
+        ? props.actionItems.map((item) => (
             <AttentionRow key={item.id} item={item} onAction={props.onAttentionAction} />
           ))
         : null}
-      {!hasAttentionItems && props.presenceStatus === 'posted' ? (
+      {!hasAttentionItems && !hasOtherActionableWork && props.presenceStatus === 'posted' ? (
         <div className="sync-action">
           <div className="sync-action-text">No immediate issues</div>
+        </div>
+      ) : null}
+      {!hasAttentionItems && hasOtherActionableWork && props.presenceStatus === 'posted' ? (
+        <div className="sync-action">
+          <div className="sync-action-text">Review the team items below</div>
         </div>
       ) : null}
       {!hasAttentionItems && props.presenceStatus === 'not_enrolled' ? (

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -281,8 +281,9 @@ export function renderTeamSync() {
 
   const configured = Boolean(coordinator && coordinator.configured);
   meta.textContent = configured
-    ? `Coordinator: ${String(coordinator.coordinator_url || '')} · group: ${(coordinator.groups || []).join(', ') || 'none'}`
+    ? `Team: ${(coordinator.groups || []).join(', ') || 'none'}`
     : 'Join an existing team or create one before connecting devices and people.';
+  meta.title = configured ? String(coordinator.coordinator_url || '').trim() : '';
 
   if (!configured) {
     teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
@@ -314,19 +315,6 @@ export function renderTeamSync() {
   if (offlineTeamDeviceCount > 0) {
     metricParts.push(`Offline ${offlineTeamDeviceCount}`);
   }
-  const statusSummary: TeamSyncStatusSummary = {
-    badgeClassName: `pill ${presenceStatus === 'posted' ? 'pill-success' : presenceStatus === 'not_enrolled' ? 'pill-warning' : 'pill-error'}`,
-    headline:
-      presenceStatus === 'posted'
-        ? attentionItems.length > 0
-          ? `${attentionItems.length} item${attentionItems.length === 1 ? '' : 's'} need review`
-          : 'Everything important looks healthy'
-        : presenceStatus === 'not_enrolled'
-          ? 'This device is not enrolled in the team yet'
-          : 'Sync needs attention',
-    metricsText: metricParts.join(' · '),
-    presenceLabel,
-  };
 
   const discoveredDevices = Array.isArray(coordinator.discovered_devices)
     ? coordinator.discovered_devices
@@ -430,11 +418,28 @@ export function renderTeamSync() {
     displayName: String(request.display_name || request.device_id || 'Pending device'),
     requestId: String(request.request_id || ''),
   }));
+  const discoveredActionableCount = discoveredRows.filter(
+    (row) => row.mode === 'accept' || row.mode === 'scope-pending',
+  ).length;
+  const actionableCount = attentionItems.length + pendingJoinRequests.length + discoveredActionableCount;
+  const statusSummary: TeamSyncStatusSummary = {
+    badgeClassName: `pill ${presenceStatus === 'posted' ? 'pill-success' : presenceStatus === 'not_enrolled' ? 'pill-warning' : 'pill-error'}`,
+    headline:
+      presenceStatus === 'posted'
+        ? actionableCount > 0
+          ? `${actionableCount} item${actionableCount === 1 ? '' : 's'} need attention`
+          : 'Everything important looks healthy'
+        : presenceStatus === 'not_enrolled'
+          ? 'This device is not enrolled in the team yet'
+          : 'Sync needs attention',
+    metricsText: metricParts.join(' · '),
+    presenceLabel,
+  };
 
   if (discoveredPanel) discoveredPanel.hidden = discoveredRows.length === 0;
   if (discoveredMeta) {
     discoveredMeta.textContent = discoveredRows.length
-      ? 'Visible through team discovery. Review before connecting them on this machine.'
+      ? 'Team devices and discovery results. Review anything that still needs trust, repair, or approval.'
       : '';
   }
   if (joinRequests) joinRequests.hidden = pendingJoinRequests.length === 0;
@@ -448,6 +453,7 @@ export function renderTeamSync() {
     actionMount,
     h(TeamSyncPanel, {
       actionItems: attentionItems,
+      actionableCount,
       children: h(SyncInviteJoinPanels, {
         invitePanel,
         invitePanelOpen: teamInvitePanelOpen,


### PR DESCRIPTION
## Description
Demotes advanced sync details behind lower-emphasis UI so the default sync-tab view stays focused on names, status, and actions.

This trims visible request/transport plumbing from default card surfaces, keeps UUID-heavy details secondary, and finalizes the first declutter pass with more progressive disclosure.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced