### PR TITLE
refactor(sync-ui): clarify section modes

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -105,13 +105,6 @@ export function SyncInviteJoinPanels({
 }: SyncInviteJoinPanelsProps) {
   return (
     <>
-      <InviteToggleRow
-        invitePanel={invitePanel}
-        invitePanelOpen={invitePanelOpen}
-        inviteRestoreParent={inviteRestoreParent}
-        onToggle={onToggleInvitePanel}
-      />
-
       {presenceStatus === 'not_enrolled' ? (
         <>
           {joinPanel ? (
@@ -127,6 +120,13 @@ export function SyncInviteJoinPanels({
           </div>
         </>
       ) : null}
+
+      <InviteToggleRow
+        invitePanel={invitePanel}
+        invitePanelOpen={invitePanelOpen}
+        inviteRestoreParent={inviteRestoreParent}
+        onToggle={onToggleInvitePanel}
+      />
 
       {!pairedPeerCount && presenceStatus === 'posted' ? <PairingCopyRow /> : null}
     </>

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -278,7 +278,7 @@ function TeamActionsContent({ children }: { children?: ComponentChildren }) {
 	if (!children) return null;
 	return (
 		<>
-			<div className="sync-action-text">Team actions</div>
+			<div className="sync-action-text">Team setup and invites</div>
 			{children}
 		</>
 	);
@@ -320,6 +320,7 @@ function DiscoveredPortal({
   if (!mount) return null;
   return createPortal(
     <>
+      <div className="sync-action-text">Devices seen on team</div>
       {rows.map((row) => (
         <DiscoveredDeviceRow
           key={row.deviceId}
@@ -348,6 +349,7 @@ function PendingRequestsPortal({
   if (!mount || !requests.length) return null;
   return createPortal(
     <>
+      <div className="sync-action-text">Pending join requests</div>
       <div className="peer-meta">
         {requests.length} pending join request{requests.length === 1 ? '' : 's'}
       </div>


### PR DESCRIPTION
## Description
Starts the second sync-tab architecture wave by separating section modes more clearly.

This gives setup/enrollment, pending approvals, and team discovery more explicit framing so the tab better matches the user’s decision flow instead of blending setup, recovery, and review into one muddy block.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced