### PR TITLE
refactor(sync-ui): tighten recovery copy

### DIFF
--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -265,7 +265,7 @@ function ActionContent(props: TeamSyncPanelProps) {
       {!hasAttentionItems && props.presenceStatus === 'not_enrolled' ? (
         <div className="sync-action">
           <div className="sync-action-text">
-            This device still needs team enrollment
+            This device needs team enrollment
             <span className="sync-action-command">Import an invite or ask an admin to enroll it.</span>
           </div>
         </div>

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -255,7 +255,7 @@ export function renderSyncStatus() {
     /* informational */
   } else if (daemonState === 'stopped') {
     actions.push({ label: 'Sync daemon is stopped. Start it.', command: 'codemem sync start' });
-    actions.push({ label: 'Then run one immediate sync pass.', command: 'codemem sync once' });
+    actions.push({ label: 'Run one sync pass now.', command: 'codemem sync once' });
   } else if (daemonState === 'needs_attention') {
     actions.push({
       label: 'Sync needs manual attention before reset can continue.',
@@ -269,7 +269,7 @@ export function renderSyncStatus() {
       command: 'codemem sync restart && codemem sync once',
     });
     actions.push({
-      label: 'Then run doctor for root cause.',
+      label: 'Run doctor for the root cause.',
       command: 'codemem sync doctor',
     });
   } else if (!syncDisabled && !syncNoPeers && pending > 0) {

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -44,7 +44,7 @@ export function renderSyncActors() {
   const actors = actorVisibility.visibleActors;
   if (actorMeta) {
     actorMeta.textContent = actors.length
-      ? 'Create, rename, and combine people here. Assign each device below. Non-local people receive memories from allowed projects unless you mark them Only me.'
+      ? 'Manage people here, then assign devices below.'
       : 'No named people yet. Create one here, then assign devices below.';
     if (actorVisibility.hiddenLocalDuplicateCount > 0) {
       actorMeta.textContent += ` ${actorVisibility.hiddenLocalDuplicateCount} unresolved duplicate ${actorVisibility.hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden here until reviewed in Needs attention.`;
@@ -100,7 +100,7 @@ export function renderSyncPeers() {
         } else if (peerId && isPeerScopeReviewPending(peerId)) {
           const displayName = peer?.name || (peerId ? peerId.slice(0, 8) : 'unknown');
           showGlobalNotice(
-            `Triggered sync for ${displayName} before scope review was finished. Review scope in this card if you want tighter sharing rules.`,
+            `Triggered sync for ${displayName}. Review scope in this card if you want tighter sharing rules.`,
             'warning',
           );
         } else {
@@ -113,7 +113,7 @@ export function renderSyncPeers() {
       try {
         await _loadSyncData();
       } catch {
-        showGlobalNotice('Sync started, but the local status view did not refresh yet.', 'warning');
+        showGlobalNotice('Sync started, but this view has not refreshed yet.', 'warning');
       }
       return null;
     },


### PR DESCRIPTION
## Description
Tightens sync-tab blocked-state and recovery copy so it is shorter, more action-led, and less repetitive in steady-state surfaces.

This trims support-article energy from the sync tab while keeping the important recovery guidance intact where it actually matters.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced