### PR TITLE
refactor(sync-ui): demote diagnostics to advanced

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1975,7 +1975,7 @@
             </label>
           </div>
         </div>
-        <div class="section-meta" id="syncMeta">Debug details for sync status, pairing, and recent attempts.</div>
+        <div class="section-meta" id="syncMeta">Use this section for sync debugging, pairing, and recent attempt details.</div>
         <div class="sync-skeleton" id="syncDiagSkeleton" role="status" aria-label="Loading diagnostics">
           <div class="sync-skeleton-line long"></div>
           <div class="sync-skeleton-line medium"></div>
@@ -1986,7 +1986,7 @@
 
         <div id="syncPairingPanelMount" style="display: contents"></div>
 
-        <h3 class="settings-group-title" style="margin-top: 20px">Recent sync attempts</h3>
+        <h3 class="settings-group-title" style="margin-top: 20px">Recent sync attempts (advanced)</h3>
         <div class="attempts-list" id="syncAttempts"></div>
       </div>
     </div>

--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -103,6 +103,8 @@ export function SyncInviteJoinPanels({
   pairedPeerCount,
   presenceStatus,
 }: SyncInviteJoinPanelsProps) {
+  const showInviteActions = presenceStatus !== 'not_enrolled';
+
   return (
     <>
       {presenceStatus === 'not_enrolled' ? (
@@ -121,12 +123,14 @@ export function SyncInviteJoinPanels({
         </>
       ) : null}
 
-      <InviteToggleRow
-        invitePanel={invitePanel}
-        invitePanelOpen={invitePanelOpen}
-        inviteRestoreParent={inviteRestoreParent}
-        onToggle={onToggleInvitePanel}
-      />
+      {showInviteActions ? (
+        <InviteToggleRow
+          invitePanel={invitePanel}
+          invitePanelOpen={invitePanelOpen}
+          inviteRestoreParent={inviteRestoreParent}
+          onToggle={onToggleInvitePanel}
+        />
+      ) : null}
 
       {!pairedPeerCount && presenceStatus === 'posted' ? <PairingCopyRow /> : null}
     </>

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -278,7 +278,7 @@ function TeamActionsContent({ children }: { children?: ComponentChildren }) {
 	if (!children) return null;
 	return (
 		<>
-			<div className="sync-action-text">Team setup and invites</div>
+			<div className="sync-action-text">Team setup</div>
 			{children}
 		</>
 	);

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -156,11 +156,11 @@ export function renderSyncStatus() {
 
   if (syncMeta) {
     const parts = syncDisabled
-      ? ['State: Disabled', 'Sync is optional and currently off']
+      ? ['Advanced sync state', 'Sync is optional and currently off']
       : syncNoPeers
-        ? ['State: No peers', 'Add peers to enable replication']
+        ? ['Advanced sync state', 'Add peers to enable replication']
         : [
-            `State: ${daemonStateLabel}`,
+            `Advanced state: ${daemonStateLabel}`,
             `Peers: ${peerCount}`,
             lastSync ? `Last sync: ${formatAgeShort(secondsSince(lastSync))} ago` : 'Last sync: never',
           ];

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -164,6 +164,7 @@ export function renderTeamSync() {
   const meta = document.getElementById('syncTeamMeta');
   const setupPanel = document.getElementById('syncSetupPanel');
   const list = document.getElementById('syncTeamStatus');
+  const listHeading = list?.previousElementSibling as HTMLElement | null;
   const actions = document.getElementById('syncTeamActions');
   if (!meta || !setupPanel || !list || !actions) return;
 
@@ -289,6 +290,7 @@ export function renderTeamSync() {
     teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
     setupPanel.hidden = false;
     list.hidden = true;
+    if (listHeading) listHeading.hidden = true;
     actions.hidden = true;
     if (joinRequests) joinRequests.hidden = true;
     if (discoveredPanel) discoveredPanel.hidden = true;
@@ -297,6 +299,7 @@ export function renderTeamSync() {
 
   setupPanel.hidden = true;
   list.hidden = false;
+  if (listHeading) listHeading.hidden = false;
   actions.hidden = false;
 
   const presenceStatus = String(coordinator.presence_status || '');


### PR DESCRIPTION
## Description
Makes diagnostics read more clearly as an advanced/debug workflow instead of a co-equal primary section of the sync tab.

This keeps the tooling available while reducing how much the diagnostics surface competes with the main recovery, discovery, and management flows.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced