### PR TITLE
refactor(sync-ui): polish healthy state copy

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -945,6 +945,7 @@
       .sync-action + .sync-action { margin-top: var(--sp-2); }
 
       .health-action-text, .sync-action-text { font-size: 13px; color: var(--text-primary); flex: 1; min-width: 0; }
+      .sync-section-label { margin-top: 10px; }
       .health-action-command, .sync-action-command { display: block; margin-top: 2px; font-family: var(--font-mono); font-size: 12px; color: var(--text-tertiary); }
       .health-action-buttons { display: flex; gap: 6px; flex-shrink: 0; }
 

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -261,7 +261,7 @@ function ActionContent(props: TeamSyncPanelProps) {
         : null}
       {!hasAttentionItems && !hasOtherActionableWork && props.presenceStatus === 'posted' ? (
         <div className="sync-action">
-          <div className="sync-action-text">Everything important looks healthy.</div>
+          <div className="sync-action-text">Everything is healthy.</div>
         </div>
       ) : null}
       {!hasAttentionItems && hasOtherActionableWork && props.presenceStatus === 'posted' ? (
@@ -285,7 +285,7 @@ function TeamActionsContent({ children }: { children?: ComponentChildren }) {
 	if (!children) return null;
 	return (
 		<>
-			<div className="sync-action-text">Team setup</div>
+			<div className="sync-action-text sync-section-label">Team setup</div>
 			{children}
 		</>
 	);

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -450,7 +450,7 @@ export function renderTeamSync() {
       presenceStatus === 'posted'
         ? actionableCount > 0
           ? `${actionableCount} item${actionableCount === 1 ? '' : 's'} need attention`
-          : 'Everything important looks healthy'
+          : 'Everything is healthy'
         : presenceStatus === 'not_enrolled'
           ? 'This device is not enrolled in the team yet'
           : 'Sync needs attention',


### PR DESCRIPTION
## Description
Polishes the healthy-state sync summary copy and gives the Team setup section label better spacing.

This makes the steady-state sync tab read less awkwardly when everything is fine, and improves the visual separation before the setup/invite section.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced