### PR TITLE
refactor(sync-ui): refine team sync hierarchy and next steps

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -945,7 +945,25 @@
       .sync-action + .sync-action { margin-top: var(--sp-2); }
 
       .health-action-text, .sync-action-text { font-size: 13px; color: var(--text-primary); flex: 1; min-width: 0; }
-      .sync-section-label { margin-top: 10px; }
+      .sync-section-heading {
+        display: flex;
+        align-items: center;
+        gap: var(--sp-2);
+        margin-top: var(--sp-2);
+        flex-wrap: wrap;
+      }
+      .sync-section-label {
+        margin-top: 0;
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: var(--text-tertiary);
+      }
+      .sync-section-count {
+        font-size: 11px;
+        padding: 2px 8px;
+      }
       .health-action-command, .sync-action-command { display: block; margin-top: 2px; font-family: var(--font-mono); font-size: 12px; color: var(--text-tertiary); }
       .health-action-buttons { display: flex; gap: 6px; flex-shrink: 0; }
 
@@ -1060,6 +1078,23 @@
         40%, 80% { transform: translateX(4px); }
       }
       .sync-shake { animation: sync-shake 0.3s ease-in-out; }
+      @keyframes sync-attention-target {
+        0% {
+          transform: translateY(0);
+          box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+        }
+        35% {
+          transform: translateY(-1px);
+          box-shadow: 0 0 0 3px var(--focus-ring);
+        }
+        100% {
+          transform: translateY(0);
+          box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+        }
+      }
+      .sync-attention-target {
+        animation: sync-attention-target 900ms ease-out;
+      }
       .settings-button:disabled {
         opacity: 0.55;
         cursor: not-allowed;
@@ -1114,10 +1149,18 @@
         text-transform: uppercase;
         color: var(--text-tertiary);
       }
+      .sync-team-headline {
+        font-size: 15px;
+        font-weight: 700;
+        color: var(--text-primary);
+      }
       .sync-team-metrics {
         font-size: 13px;
         color: var(--text-secondary);
         font-feature-settings: 'tnum' 1;
+      }
+      .sync-team-metrics-secondary {
+        color: var(--text-tertiary);
       }
       .sync-radix-select-host {
         min-width: 0;
@@ -1894,17 +1937,18 @@
       <!-- 1. Needs attention + team setup/status -->
       <div class="card" id="syncTeamCard">
         <div class="section-header">
-          <h2>Needs attention</h2>
+          <h2>Team sync</h2>
           <div class="section-actions">
             <button class="settings-button" id="syncNowButton">Sync now</button>
           </div>
         </div>
-        <div class="section-meta" id="syncTeamMeta">See what needs action first, then review the current team status below.</div>
+        <div class="section-meta" id="syncTeamMeta">Start with the next step below, then review team status and device details.</div>
         <div class="sync-skeleton" id="syncTeamSkeleton" role="status" aria-label="Loading team sync">
           <div class="sync-skeleton-line medium"></div>
           <div class="sync-skeleton-block"></div>
           <div class="sync-skeleton-line short"></div>
         </div>
+        <div class="sync-actions" id="syncTeamActions" hidden></div>
         <div id="syncSetupPanel">
           <div id="syncJoinSection">
             <h3 class="settings-group-title">Join a team</h3>
@@ -1927,7 +1971,6 @@
           <div class="section-meta" id="syncCoordinatorDiscoveredMeta"></div>
           <div class="actor-list" id="syncCoordinatorDiscoveredList"></div>
         </div>
-        <div class="sync-actions" id="syncTeamActions" hidden></div>
       </div>
 
       <!-- 2. People & devices -->

--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -46,7 +46,10 @@ function InviteToggleRow({
   return (
     <>
       <div className="sync-action">
-        <div className="sync-action-text">Generate an invite to add another teammate to this team.</div>
+        <div className="sync-action-text">
+          Add another teammate.
+          <span className="sync-action-command">Generate an invite when you are ready to bring another device into this team.</span>
+        </div>
         <button type="button" className="settings-button" onClick={onToggle}>
           {invitePanelOpen ? 'Hide invite form' : 'Invite a teammate'}
         </button>
@@ -66,8 +69,8 @@ function PairingCopyRow() {
   return (
     <div className="sync-action">
       <div className="sync-action-text">
-        No devices are paired yet.
-        <span className="sync-action-command">Use the pairing command in Advanced diagnostics when you are ready to connect another device.</span>
+        Pair another device.
+        <span className="sync-action-command">Use the pairing command in Advanced diagnostics when you are ready to connect one.</span>
       </div>
       <button
         type="button"
@@ -115,9 +118,9 @@ export function SyncInviteJoinPanels({
           <div className="peer-meta" id="syncJoinFeedback" hidden />
           <div className="sync-action">
             <div className="sync-action-text">
-              This device is not connected to the team yet.
+              This device is not on the team yet.
               <span className="sync-action-command">
-                Import a team invite or ask your admin to enroll this device
+                Import an invite or ask an admin to enroll it first.
               </span>
             </div>
           </div>

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -52,6 +52,21 @@ type TeamSyncPanelProps = {
   statusSummary: TeamSyncStatusSummary;
 };
 
+function SectionHeading({
+  count,
+  label,
+}: {
+  count?: number;
+  label: string;
+}) {
+  return (
+    <div className="sync-section-heading">
+      <div className="sync-action-text sync-section-label">{label}</div>
+      {count ? <span className="badge actor-badge sync-section-count">{count}</span> : null}
+    </div>
+  );
+}
+
 function AttentionRow({
   item,
   onAction,
@@ -250,10 +265,11 @@ function DiscoveredDeviceRow({
 function ActionContent(props: TeamSyncPanelProps) {
   const hasAttentionItems = props.actionItems.length > 0;
   const hasOtherActionableWork = props.actionableCount > props.actionItems.length;
+  const showNextStepsLabel = hasAttentionItems || hasOtherActionableWork || props.presenceStatus !== 'posted';
 
   return (
     <>
-      {hasAttentionItems ? <div className="sync-action-text">Needs attention</div> : null}
+      {showNextStepsLabel ? <SectionHeading label="Next steps" /> : null}
       {hasAttentionItems
         ? props.actionItems.map((item) => (
             <AttentionRow key={item.id} item={item} onAction={props.onAttentionAction} />
@@ -285,7 +301,7 @@ function TeamActionsContent({ children }: { children?: ComponentChildren }) {
 	if (!children) return null;
 	return (
 		<>
-			<div className="sync-action-text sync-section-label">Team setup</div>
+			<SectionHeading label="Keep the team moving" />
 			{children}
 		</>
 	);
@@ -301,11 +317,11 @@ function TeamStatusPortal({
   return createPortal(
     <div className="sync-team-summary">
       <div className="sync-team-status-row">
-        <span className="sync-team-status-label">Status</span>
+        <span className="sync-team-status-label">Team status</span>
         <span className={statusSummary.badgeClassName}>{statusSummary.presenceLabel}</span>
       </div>
-      {statusSummary.headline ? <div className="sync-team-metrics">{statusSummary.headline}</div> : null}
-      <div className="sync-team-metrics">{statusSummary.metricsText}</div>
+      {statusSummary.headline ? <div className="sync-team-headline">{statusSummary.headline}</div> : null}
+      <div className="sync-team-metrics sync-team-metrics-secondary">{statusSummary.metricsText}</div>
     </div>,
     mount,
   );
@@ -327,7 +343,7 @@ function DiscoveredPortal({
   if (!mount || (!rows.length && !state.syncDiscoveredFeedback)) return null;
   return createPortal(
     <>
-      <div className="sync-action-text">Devices seen on team</div>
+      <SectionHeading count={rows.length || undefined} label="Devices seen on team" />
       <SyncInlineFeedback feedback={state.syncDiscoveredFeedback} />
       {rows.map((row) => (
         <DiscoveredDeviceRow
@@ -357,11 +373,8 @@ function PendingRequestsPortal({
   if (!mount || (!requests.length && !state.syncJoinRequestsFeedback)) return null;
   return createPortal(
     <>
-      <div className="sync-action-text">Pending join requests</div>
+      <SectionHeading count={requests.length || undefined} label="Pending join requests" />
       <SyncInlineFeedback feedback={state.syncJoinRequestsFeedback} />
-      <div className="peer-meta">
-        {requests.length} pending join request{requests.length === 1 ? '' : 's'}
-      </div>
       {requests.map((request) => (
         <PendingJoinRequestRow
           key={request.requestId}

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -101,6 +101,14 @@ function clearContent(node: HTMLElement | null) {
   if (node) node.textContent = '';
 }
 
+function pulseAttentionTarget(target: HTMLElement | null) {
+  if (!(target instanceof HTMLElement)) return;
+  target.classList.remove('sync-attention-target');
+  void target.offsetWidth;
+  target.classList.add('sync-attention-target');
+  window.setTimeout(() => target.classList.remove('sync-attention-target'), 900);
+}
+
 function renderInvitePolicySelect() {
   const mount = document.getElementById('syncInvitePolicyMount') as HTMLElement | null;
   if (!mount) return;
@@ -216,6 +224,7 @@ export function renderTeamSync() {
       const actorList = document.getElementById('syncActorsList');
       if (actorList instanceof HTMLElement) {
         actorList.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        pulseAttentionTarget(actorList);
       }
       return;
     }
@@ -227,17 +236,20 @@ export function renderTeamSync() {
         renameInput.scrollIntoView({ block: 'center', behavior: 'smooth' });
         renameInput.focus();
         renameInput.select();
+        pulseAttentionTarget(renameInput);
         return;
       }
     }
     const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(deviceId)}"]`);
     if (peerCard instanceof HTMLElement) {
       peerCard.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      pulseAttentionTarget(peerCard);
       return;
     }
     const discoveredRow = document.querySelector(`[data-discovered-device-id="${CSS.escape(deviceId)}"]`);
     if (discoveredRow instanceof HTMLElement) {
       discoveredRow.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      pulseAttentionTarget(discoveredRow);
     }
   };
 
@@ -302,7 +314,7 @@ export function renderTeamSync() {
   const configured = Boolean(coordinator && coordinator.configured);
   meta.textContent = configured
     ? `Team: ${(coordinator.groups || []).join(', ') || 'none'}`
-    : 'Join an existing team or create one before connecting devices and people.';
+    : 'Start by joining an existing team or creating one, then connect people and devices.';
   meta.title = configured ? String(coordinator.coordinator_url || '').trim() : '';
 
   if (!configured) {
@@ -444,6 +456,7 @@ export function renderTeamSync() {
     (row) => row.mode === 'accept' || row.mode === 'scope-pending',
   ).length;
   const actionableCount = attentionItems.length + pendingJoinRequests.length + discoveredActionableCount;
+  const teamLabel = (coordinator.groups || []).join(', ') || 'none';
   const statusSummary: TeamSyncStatusSummary = {
     badgeClassName: `pill ${presenceStatus === 'posted' ? 'pill-success' : presenceStatus === 'not_enrolled' ? 'pill-warning' : 'pill-error'}`,
     headline:
@@ -457,14 +470,26 @@ export function renderTeamSync() {
     metricsText: metricParts.join(' · '),
     presenceLabel,
   };
+  meta.textContent =
+    presenceStatus === 'posted'
+      ? actionableCount > 0
+        ? `Team: ${teamLabel}. Start with the next step below, then scan the current team status.`
+        : `Team: ${teamLabel}. Team status and device details are below.`
+      : presenceStatus === 'not_enrolled'
+        ? `Team: ${teamLabel}. Enroll this device first, then return here to review the rest of the team.`
+        : `Team: ${teamLabel}. Fix the current sync issue first, then use the rest of this card to verify the team state.`;
 
-  if (discoveredPanel) discoveredPanel.hidden = discoveredRows.length === 0;
+  if (discoveredPanel) {
+    discoveredPanel.hidden = discoveredRows.length === 0 && !state.syncDiscoveredFeedback;
+  }
   if (discoveredMeta) {
     discoveredMeta.textContent = discoveredRows.length
-      ? 'Team devices and discovery results. Review anything that still needs trust, repair, or approval.'
+      ? 'Review anything here that still needs trust, repair, or approval.'
       : '';
   }
-  if (joinRequests) joinRequests.hidden = pendingJoinRequests.length === 0;
+  if (joinRequests) {
+    joinRequests.hidden = pendingJoinRequests.length === 0 && !state.syncJoinRequestsFeedback;
+  }
 
   teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
   const actionMount = document.createElement('div');

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -349,7 +349,7 @@ function createRepairItem(device: { id: string; name: string; summary: string })
     priority: 10,
     title: `${device.name} needs repair`,
     summary: device.summary,
-    actionLabel: 'Review device',
+    actionLabel: 'Open device',
     deviceId: device.id,
   };
 }
@@ -361,7 +361,7 @@ function createReviewItem(device: { id: string; name: string; summary: string; k
     priority: 20,
     title: `${device.name} is available to review`,
     summary: device.summary,
-    actionLabel: 'Review device',
+    actionLabel: 'Open device',
     deviceId: device.id,
   };
 }
@@ -373,7 +373,7 @@ function createNamingItem(device: { id: string; name: string; summary: string })
     priority: 30,
     title: `Name ${device.name}`,
     summary: device.summary,
-    actionLabel: 'Name device',
+    actionLabel: 'Go to name field',
     deviceId: device.id,
   };
 }
@@ -438,7 +438,7 @@ export function deriveSyncViewModel(input: {
       summary: candidate.includesLocal
         ? 'At least one entry is marked as you. Confirm whether these records represent the same person.'
         : 'Multiple people share this name. Confirm whether they should stay separate or be combined.',
-      actionLabel: 'Review people',
+      actionLabel: 'Go to people',
       actorIds: candidate.actorIds,
     });
   });


### PR DESCRIPTION
## Description

Tightens the sync team card so it reads in a clearer order: next steps first, then setup, then status and supporting team details. It also makes guided action labels honest about what they do and adds a lightweight target pulse after guided scrolls so users can quickly find the place the UI sent them.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm --filter @codemem/ui typecheck`
- [x] `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
