### PR TITLE
refactor(sync-ui): improve sync empty and unavailable states

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1056,6 +1056,18 @@
         border-radius: 8px;
         margin: 8px 0;
       }
+      .sync-empty-state strong {
+        display: block;
+        margin-bottom: 6px;
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+      }
+      .sync-empty-state span {
+        display: block;
+        max-width: 54ch;
+        margin: 0 auto;
+        line-height: 1.5;
+      }
       .sync-inline-feedback {
         margin-top: 8px;
         font-size: 12px;

--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -171,7 +171,12 @@ function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge }: S
 
 function SyncActorsList({ actors, hiddenLocalDuplicateCount, onRename, onMerge }: SyncActorsListProps) {
   if (!actors.length) {
-    return <div className="sync-empty-state">No people yet. Create one to represent yourself or a teammate.</div>;
+    return (
+      <div className="sync-empty-state">
+        <strong>No people yet.</strong>
+        <span>Create a named person here, then assign each device below to keep sync ownership readable.</span>
+      </div>
+    );
   }
 
   return (

--- a/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
@@ -17,6 +17,11 @@ export type PairingView = {
   hintText: string;
 };
 
+export type SyncEmptyStateView = {
+  title: string;
+  detail: string;
+};
+
 function DiagnosticsGrid({ items }: { items: SyncStatItem[] }) {
   return (
     <Fragment>
@@ -52,6 +57,15 @@ function PairingText({ text }: { text: string }) {
   return <Fragment>{text}</Fragment>;
 }
 
+function SyncEmptyState({ title, detail }: SyncEmptyStateView) {
+  return (
+    <div class="sync-empty-state">
+      <strong>{title}</strong>
+      <span>{detail}</span>
+    </div>
+  );
+}
+
 export function renderDiagnosticsGrid(mount: HTMLElement, items: SyncStatItem[]) {
   if (!items.length) {
     clearSyncMount(mount);
@@ -68,6 +82,10 @@ export function renderAttemptsList(mount: HTMLElement, attempts: SyncAttemptItem
   }
 
   renderIntoSyncMount(mount, <AttemptsList attempts={attempts} />);
+}
+
+export function renderSyncEmptyState(mount: HTMLElement, view: SyncEmptyStateView) {
+  renderIntoSyncMount(mount, <SyncEmptyState {...view} />);
 }
 
 export function renderPairingView(

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -409,12 +409,19 @@ function SyncPeerCard({
 
 function SyncPeersList(props: SyncPeersListProps) {
   const sectionFeedback = state.syncPeersSectionFeedback;
+  const syncStatus = state.lastSyncStatus as { daemon_state?: string; enabled?: boolean } | null;
+  const syncDisabled = syncStatus?.daemon_state === 'disabled' || syncStatus?.enabled === false;
   if (!props.peers.length) {
     return (
       <>
         <SyncInlineFeedback feedback={sectionFeedback} />
         <div className="sync-empty-state">
-          No devices connected on this machine yet. Pair another device from Advanced diagnostics when you are ready.
+          <strong>No paired devices yet.</strong>
+          <span>
+            {syncDisabled
+              ? 'Turn on sync in Settings → Device Sync first, then use Show pairing in Advanced diagnostics to connect another device.'
+              : 'Use the Show pairing control in Advanced diagnostics, run the command on the other device, then come back here to name and assign it.'}
+          </span>
         </div>
       </>
     );

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -5,12 +5,13 @@ import { RadixSwitch } from '../../components/primitives/radix-switch';
 import { copyToClipboard } from '../../lib/dom';
 import { formatAgeShort, formatTimestamp, secondsSince, titleCase } from '../../lib/format';
 import { state, setSyncPairingOpen, isSyncRedactionEnabled, setSyncRedactionEnabled } from '../../lib/state';
-import { clearSyncMount, renderIntoSyncMount } from './components/render-root';
+import { renderIntoSyncMount } from './components/render-root';
 import { renderPairingDisclosure } from './components/sync-disclosure';
 import {
   renderAttemptsList,
   renderDiagnosticsGrid,
   renderPairingView,
+  renderSyncEmptyState,
   type PairingView,
   type SyncAttemptItem,
   type SyncStatItem,
@@ -120,6 +121,38 @@ function pairingView(payload: unknown): PairingView {
   };
 }
 
+function diagnosticsLoadingState() {
+  return {
+    title: 'Diagnostics still loading.',
+    detail: 'Wait a moment for local sync status. If it stays blank, refresh the page or check whether sync is enabled on this device.',
+  };
+}
+
+function diagnosticsUnavailableState() {
+  return {
+    title: 'Diagnostics unavailable right now.',
+    detail: 'The viewer could not load sync status. Refresh this page, or check that the local codemem sync service is reachable before retrying.',
+  };
+}
+
+function noAttemptsState() {
+  const syncStatus = state.lastSyncStatus as { daemon_state?: string; enabled?: boolean } | null;
+  const syncDisabled = syncStatus?.daemon_state === 'disabled' || syncStatus?.enabled === false;
+  return {
+    title: 'No recent sync attempts yet.',
+    detail: syncDisabled
+      ? 'Turn on sync in Settings → Device Sync first. Recent attempts will appear here after this device can actually run sync work.'
+      : 'Trigger a sync pass or pair another device to generate activity here when you need low-level troubleshooting.',
+  };
+}
+
+function unavailableAttemptsState() {
+  return {
+    title: 'Recent attempts unavailable right now.',
+    detail: 'Attempt history could not be loaded because sync diagnostics failed. Refresh the page after local sync status is reachable again.',
+  };
+}
+
 /* ── Sync status renderer ────────────────────────────────── */
 
 export function renderSyncStatus() {
@@ -132,9 +165,9 @@ export function renderSyncStatus() {
 
   const status = state.lastSyncStatus as SyncStatusState | null;
   if (!status) {
-    clearSyncMount(syncStatusGrid);
+    renderSyncEmptyState(syncStatusGrid, diagnosticsLoadingState());
     renderActionList(syncActions, []);
-    if (syncMeta) syncMeta.textContent = 'Loading sync status…';
+    if (syncMeta) syncMeta.textContent = 'Loading advanced sync diagnostics…';
     return;
   }
 
@@ -167,9 +200,15 @@ export function renderSyncStatus() {
 
   if (syncMeta) {
     const parts = syncDisabled
-      ? ['Advanced sync state', 'Sync is optional and currently off']
+      ? [
+          'Advanced sync is off on this device',
+          'Turn on sync in Settings → Device Sync when you want pairing payloads, peer status, and recent attempt details here',
+        ]
       : syncNoPeers
-        ? ['Advanced sync state', 'Add peers to enable replication']
+        ? [
+            'Advanced sync is ready but idle',
+            'Use Show pairing to connect another device, then this panel will start showing live peer status and recent attempts',
+          ]
         : [
             `Advanced state: ${daemonStateLabel}`,
             `Peers: ${peerCount}`,
@@ -199,14 +238,14 @@ export function renderSyncStatus() {
         { label: 'State', value: 'Disabled' },
         { label: 'Mode', value: 'Optional' },
         { label: 'Pending events', value: pending },
-        { label: 'Last sync', value: 'n/a' },
+        { label: 'Last sync', value: 'Not running' },
       ]
     : syncNoPeers
       ? [
           { label: 'State', value: 'No peers' },
-          { label: 'Mode', value: 'Idle' },
+          { label: 'Mode', value: 'Ready to pair' },
           { label: 'Pending events', value: pending },
-          { label: 'Last sync', value: 'n/a' },
+          { label: 'Last sync', value: 'Waiting for first peer' },
         ]
       : [
           { label: 'State', value: daemonStateLabel },
@@ -300,7 +339,7 @@ export function renderSyncAttempts() {
 
   const attempts = state.lastSyncAttempts as SyncAttemptState[];
   if (!Array.isArray(attempts) || !attempts.length) {
-    clearSyncMount(syncAttempts);
+    renderSyncEmptyState(syncAttempts, noAttemptsState());
     return;
   }
 
@@ -314,6 +353,20 @@ export function renderSyncAttempts() {
   });
 
   renderAttemptsList(syncAttempts, items);
+}
+
+export function renderSyncDiagnosticsUnavailable() {
+  const syncStatusGrid = document.getElementById('syncStatusGrid');
+  const syncAttempts = document.getElementById('syncAttempts');
+  const syncMeta = document.getElementById('syncMeta');
+  const syncActions = document.getElementById('syncActions');
+  if (syncStatusGrid) renderSyncEmptyState(syncStatusGrid, diagnosticsUnavailableState());
+  if (syncAttempts) renderSyncEmptyState(syncAttempts, unavailableAttemptsState());
+  if (syncMeta) {
+    syncMeta.textContent =
+      'Advanced diagnostics are unavailable right now. Refresh the page, or verify the local sync service before retrying.';
+  }
+  renderActionList(syncActions, []);
 }
 
 /* ── Pairing renderer ────────────────────────────────────── */

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -5,9 +5,9 @@ import { state } from '../../lib/state';
 import { renderHealthOverview } from '../health';
 import { deriveSyncViewModel } from './view-model';
 
-import { renderSyncStatus, renderSyncAttempts, renderPairing, initDiagnosticsEvents, setRenderSyncPeers } from './diagnostics';
+import { renderSyncStatus, renderSyncAttempts, renderPairing, renderSyncDiagnosticsUnavailable, initDiagnosticsEvents, setRenderSyncPeers } from './diagnostics';
 import { renderTeamSync, renderSyncSharingReview, initTeamSyncEvents, setLoadSyncData as setTeamSyncLoadData } from './team-sync';
-import { renderSyncActors, renderSyncPeers, renderLegacyDeviceClaims, initPeopleEvents, setLoadSyncData as setPeopleLoadData } from './people';
+import { renderSyncActors, renderSyncPeers, renderLegacyDeviceClaims, renderSyncActorsUnavailable, renderSyncPeopleUnavailable, initPeopleEvents, setLoadSyncData as setPeopleLoadData } from './people';
 import { ensureSyncRenderBoundary } from './components/render-root';
 import { ensureSyncDialogHost } from './sync-dialogs';
 import { hideSkeleton, readDuplicatePersonDecisions } from './helpers';
@@ -69,6 +69,19 @@ function normalizeSyncStatusForCache(payload: SyncStatusResponseLike): SyncStatu
     ...payload,
     join_requests: [],
   };
+}
+
+function hideStaleSyncSecondarySections() {
+  const sharingReview = document.getElementById('syncSharingReview');
+  const sharingReviewList = document.getElementById('syncSharingReviewList');
+  const sharingReviewMeta = document.getElementById('syncSharingReviewMeta');
+  const legacyClaims = document.getElementById('syncLegacyClaims');
+  const legacyClaimsMeta = document.getElementById('syncLegacyClaimsMeta');
+  if (sharingReview) sharingReview.hidden = true;
+  if (sharingReviewList) sharingReviewList.textContent = '';
+  if (sharingReviewMeta) sharingReviewMeta.textContent = '';
+  if (legacyClaims) legacyClaims.hidden = true;
+  if (legacyClaimsMeta) legacyClaimsMeta.textContent = '';
 }
 
 export async function loadSyncData() {
@@ -153,20 +166,19 @@ export async function loadSyncData() {
     // Re-render health indicators since they consume sync state (health dot, etc.)
     renderHealthOverview();
     if (actorLoadError) {
-      const actorMeta = document.getElementById('syncActorsMeta');
-      if (actorMeta)
-        actorMeta.textContent =
-          'People controls are temporarily unavailable. Device status and sync health still loaded.';
+      renderSyncActorsUnavailable();
     }
   } catch {
     if (requestId !== latestSyncLoadRequestId) return;
+    lastSyncHash = '';
     // Clear all skeletons so the error state is visible, not masked by loading placeholders
     hideSkeleton('syncTeamSkeleton');
     hideSkeleton('syncActorsSkeleton');
     hideSkeleton('syncPeersSkeleton');
     hideSkeleton('syncDiagSkeleton');
-    const syncMeta = document.getElementById('syncMeta');
-    if (syncMeta) syncMeta.textContent = 'Sync unavailable';
+    hideStaleSyncSecondarySections();
+    renderSyncPeopleUnavailable();
+    renderSyncDiagnosticsUnavailable();
   }
 }
 
@@ -182,6 +194,7 @@ export async function loadPairingData() {
     state.pairingPayloadRaw = payload || null;
     renderPairing();
   } catch {
+    state.pairingPayloadRaw = null;
     renderPairing();
   }
 }

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -17,6 +17,7 @@ import {
 import { openSyncConfirmDialog } from './sync-dialogs';
 import { renderSyncActorsList } from './components/sync-actors';
 import { renderSyncPeersList } from './components/sync-peers';
+import { renderSyncEmptyState } from './components/sync-diagnostics';
 import { renderLegacyClaimsSlice } from './components/sync-legacy-claims';
 import type { SyncActionFeedback } from './components/sync-inline-feedback';
 
@@ -24,6 +25,13 @@ import type { SyncActionFeedback } from './components/sync-inline-feedback';
 
 let _loadSyncData: () => Promise<void> = async () => {};
 let legacyDeviceValue = '';
+
+function setPeopleCreateControlsDisabled(disabled: boolean) {
+  const createButton = document.getElementById('syncActorCreateButton') as HTMLButtonElement | null;
+  const createInput = document.getElementById('syncActorCreateInput') as HTMLInputElement | null;
+  if (createButton) createButton.disabled = disabled;
+  if (createInput) createInput.disabled = disabled;
+}
 
 export function setLoadSyncData(fn: () => Promise<void>) {
   _loadSyncData = fn;
@@ -36,6 +44,7 @@ export function renderSyncActors() {
   const actorMeta = document.getElementById('syncActorsMeta');
   if (!actorList) return;
   hideSkeleton('syncActorsSkeleton');
+  setPeopleCreateControlsDisabled(false);
 
   const actorVisibility: VisiblePeopleResult = deriveVisiblePeopleActors({
     actors: state.lastSyncActors,
@@ -46,7 +55,7 @@ export function renderSyncActors() {
   if (actorMeta) {
     actorMeta.textContent = actors.length
       ? 'Manage people here, then assign devices below.'
-      : 'No named people yet. Create a person here when you want to organize devices by owner.';
+      : 'No named people yet. Create a person here, then assign devices below so sync ownership is easier to review.';
     if (actorVisibility.hiddenLocalDuplicateCount > 0) {
       actorMeta.textContent += ` ${actorVisibility.hiddenLocalDuplicateCount} unresolved duplicate ${actorVisibility.hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden here until reviewed in Needs attention.`;
     }
@@ -70,6 +79,22 @@ export function renderSyncActors() {
       }
     },
   });
+}
+
+export function renderSyncActorsUnavailable() {
+  const actorList = document.getElementById('syncActorsList');
+  const actorMeta = document.getElementById('syncActorsMeta');
+  setPeopleCreateControlsDisabled(true);
+  if (actorMeta) {
+    actorMeta.textContent =
+      'People controls are temporarily unavailable. Refresh this page to retry, but device status and sync health are still available below.';
+  }
+  if (actorList) {
+    renderSyncEmptyState(actorList, {
+      title: 'People unavailable right now.',
+      detail: 'Refresh this page to reload named people once the people endpoint is responding again.',
+    });
+  }
 }
 
 /* ── Devices renderer ────────────────────────────────────── */
@@ -159,6 +184,29 @@ export function renderSyncPeers() {
       }
     },
   });
+}
+
+export function renderSyncPeopleUnavailable() {
+  const actorList = document.getElementById('syncActorsList');
+  const actorMeta = document.getElementById('syncActorsMeta');
+  const syncPeers = document.getElementById('syncPeers');
+  setPeopleCreateControlsDisabled(true);
+  if (actorMeta) {
+    actorMeta.textContent =
+      'People and device details are unavailable right now. Refresh this page to retry once local sync status is reachable again.';
+  }
+  if (actorList) {
+    renderSyncEmptyState(actorList, {
+      title: 'People unavailable right now.',
+      detail: 'Refresh this page to reload named people once the local sync status endpoint is responding again.',
+    });
+  }
+  if (syncPeers) {
+    renderSyncEmptyState(syncPeers, {
+      title: 'Devices unavailable right now.',
+      detail: 'Refresh this page to reload paired devices. When sync is reachable again, you can rename, assign, or pair devices here.',
+    });
+  }
 }
 
 /* ── Legacy device claims renderer ───────────────────────── */


### PR DESCRIPTION
## Description

Improves the sync tab's empty, unavailable, and not-yet states so they explain the next move instead of just reporting absence. It also tightens advanced diagnostics copy for disabled and no-peer conditions, adds a reusable diagnostics-style empty state, and clears stale sync sub-sections when a full sync load fails.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm --filter @codemem/ui typecheck`
- [x] `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
