### PR TITLE
fix(sync-ui): harden sync accessibility details

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -522,10 +522,15 @@
         background: var(--control-bg);
         color: var(--control-text);
         padding: 5px 12px;
+        min-width: 28px;
+        min-height: 28px;
         border-radius: var(--radius-pill);
         font-size: 12px;
         font-family: var(--font-sans);
         cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         transition: background 0.15s ease, border-color 0.15s ease;
         white-space: nowrap;
       }
@@ -1008,8 +1013,14 @@
       .peer-scope-input { width: 100%; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--text-primary); padding: 8px 10px; font: inherit; }
       .peer-scope-actions { display: flex; gap: var(--sp-2); }
       .peer-actions { display: flex; gap: 6px; }
-      .peer-actions button { border: 1px solid var(--border); background: transparent; border-radius: var(--radius-pill); padding: 5px 10px; font-family: var(--font-sans); font-size: 12px; cursor: pointer; color: var(--text-secondary); }
+      .peer-actions button { border: 1px solid var(--border); background: transparent; border-radius: var(--radius-pill); padding: 5px 10px; min-width: 28px; min-height: 28px; display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-sans); font-size: 12px; cursor: pointer; color: var(--text-secondary); }
       .peer-actions button:hover { border-color: var(--border-hover); background: var(--surface-2); }
+      .peer-card,
+      .actor-row,
+      .peer-scope-input,
+      .actor-list {
+        scroll-margin-top: 110px;
+      }
       .peer-scope-editor-wrap {
         display: grid;
         gap: var(--sp-2);

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -170,7 +170,12 @@ function SyncPeerCard({
 
   useEffect(() => {
     if (!scopeReviewRequested || !cardRef.current) return;
-    queueMicrotask(() => cardRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' }));
+    queueMicrotask(() =>
+      cardRef.current?.scrollIntoView({
+        block: 'center',
+        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+      }),
+    );
   }, [scopeReviewRequested]);
 
   async function rename() {

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -109,6 +109,14 @@ function pulseAttentionTarget(target: HTMLElement | null) {
   window.setTimeout(() => target.classList.remove('sync-attention-target'), 900);
 }
 
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function syncScrollBehavior(): ScrollBehavior {
+  return prefersReducedMotion() ? 'auto' : 'smooth';
+}
+
 function renderInvitePolicySelect() {
   const mount = document.getElementById('syncInvitePolicyMount') as HTMLElement | null;
   if (!mount) return;
@@ -223,7 +231,7 @@ export function renderTeamSync() {
     if (item.kind === 'possible-duplicate-person') {
       const actorList = document.getElementById('syncActorsList');
       if (actorList instanceof HTMLElement) {
-        actorList.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        actorList.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
         pulseAttentionTarget(actorList);
       }
       return;
@@ -233,7 +241,7 @@ export function renderTeamSync() {
     if (item.kind === 'name-device') {
       const renameInput = document.querySelector(`[data-device-name-input="${CSS.escape(deviceId)}"]`);
       if (renameInput instanceof HTMLInputElement) {
-        renameInput.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        renameInput.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
         renameInput.focus();
         renameInput.select();
         pulseAttentionTarget(renameInput);
@@ -242,13 +250,13 @@ export function renderTeamSync() {
     }
     const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(deviceId)}"]`);
     if (peerCard instanceof HTMLElement) {
-      peerCard.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      peerCard.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
       pulseAttentionTarget(peerCard);
       return;
     }
     const discoveredRow = document.querySelector(`[data-discovered-device-id="${CSS.escape(deviceId)}"]`);
     if (discoveredRow instanceof HTMLElement) {
-      discoveredRow.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      discoveredRow.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
       pulseAttentionTarget(discoveredRow);
     }
   };
@@ -565,7 +573,7 @@ export function renderTeamSync() {
       onInspectConflict: (row) => {
         const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(row.deviceId)}"]`);
         if (peerCard instanceof HTMLElement) {
-          peerCard.scrollIntoView({ block: 'center', behavior: 'smooth' });
+          peerCard.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
           showGlobalNotice(`Opened the conflicting local device record for ${row.displayName}.`, 'warning');
           return;
         }


### PR DESCRIPTION
## Description

Closes the sync refinement roadmap with a small accessibility hardening pass. The changes make guided scroll behavior respect reduced motion, increase sync control target sizes, and add scroll margins so focused or scrolled-to sync targets do not disappear under sticky viewer chrome.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm --filter @codemem/ui typecheck`
- [x] `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
