### PR TITLE
feat(viewer): show reconnecting splash during server restarts

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1395,6 +1395,64 @@
         background: rgba(212, 100, 46, 0.1);
         color: var(--accent-warm);
       }
+      .viewer-reconnect-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 30;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--sp-6);
+        background: color-mix(in srgb, var(--surface-0) 82%, transparent);
+        backdrop-filter: blur(10px);
+      }
+      .viewer-reconnect-card {
+        width: min(460px, 100%);
+        display: flex;
+        flex-direction: column;
+        gap: var(--sp-3);
+        padding: var(--sp-5);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-xl);
+        background: var(--surface-1);
+        box-shadow: var(--shadow-md);
+      }
+      .viewer-reconnect-eyebrow {
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--text-tertiary);
+      }
+      .viewer-reconnect-title {
+        font-size: 18px;
+        font-weight: 700;
+        color: var(--text-primary);
+      }
+      .viewer-reconnect-detail {
+        font-size: 13px;
+        line-height: 1.5;
+        color: var(--text-secondary);
+      }
+      .viewer-reconnect-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        color: var(--text-secondary);
+        font-size: 12px;
+      }
+      .viewer-reconnect-spinner {
+        width: 14px;
+        height: 14px;
+        border-radius: 50%;
+        border: 2px solid color-mix(in srgb, var(--accent) 22%, transparent);
+        border-top-color: var(--accent);
+        animation: reconnectSpin 0.9s linear infinite;
+      }
+      @keyframes reconnectSpin {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+      }
 
       .settings-tabs { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 6px; }
       .settings-tab {
@@ -1725,6 +1783,22 @@
       <button class="tab-btn" id="tabBtn-sync">Sync</button>
     </nav>
     <div class="app-notice" id="globalNotice" hidden aria-live="polite"></div>
+    <div class="viewer-reconnect-overlay" id="viewerReconnectOverlay" hidden>
+      <div class="viewer-reconnect-card" role="status" aria-live="assertive">
+        <div class="viewer-reconnect-eyebrow">Viewer connection</div>
+        <div class="viewer-reconnect-title">Reconnecting to codemem…</div>
+        <div class="viewer-reconnect-detail" id="viewerReconnectDetail">
+          The viewer server is restarting or temporarily unavailable. Trying again automatically…
+        </div>
+        <div class="viewer-reconnect-status">
+          <span class="viewer-reconnect-spinner" aria-hidden="true"></span>
+          <span>The page will recover automatically when the server responds.</span>
+        </div>
+        <div>
+          <button class="settings-button" id="viewerReconnectRetry">Retry now</button>
+        </div>
+      </div>
+    </div>
 
     <!-- ── Settings modal ──────────────────────────────────── -->
     <div id="settingsDialogMount"></div>

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -41,6 +41,67 @@ async function loadRuntimeLabel() {
 
 type RefreshState = 'idle' | 'refreshing' | 'paused' | 'error';
 let lastAnnouncedRefreshState: RefreshState | null = null;
+const RECONNECT_POLL_MS = 1500;
+
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnecting = false;
+
+function setReconnectOverlay(open: boolean, detail?: string) {
+  const overlay = $('viewerReconnectOverlay');
+  const detailEl = $('viewerReconnectDetail');
+  if (!overlay || !detailEl) return;
+  overlay.hidden = !open;
+  detailEl.textContent = detail || 'Trying again automatically while the viewer comes back.';
+}
+
+async function isViewerReady() {
+  try {
+    await api.pingViewerReady();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stopReconnectLoop() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  reconnecting = false;
+  setReconnectOverlay(false);
+}
+
+function canResumeRefresh() {
+  return document.visibilityState !== 'hidden' && !isSettingsOpen();
+}
+
+function scheduleReconnectLoop() {
+  if (reconnecting) return;
+  reconnecting = true;
+  stopPolling();
+  setRefreshStatus('error', '(reconnecting)');
+  setReconnectOverlay(true, 'The viewer server is restarting or temporarily unavailable. Trying again automatically…');
+
+  const tick = async () => {
+    const ready = await isViewerReady();
+    if (ready) {
+      stopReconnectLoop();
+      if (canResumeRefresh()) {
+        setRefreshStatus('refreshing');
+        startPolling();
+        void doRefresh();
+      } else {
+        setRefreshStatus('paused', document.visibilityState === 'hidden' ? '(tab hidden)' : '(settings open)');
+      }
+      return;
+    }
+    setReconnectOverlay(true, 'Still reconnecting… the viewer will recover automatically as soon as the server responds.');
+    reconnectTimer = setTimeout(tick, RECONNECT_POLL_MS);
+  };
+
+  reconnectTimer = setTimeout(tick, RECONNECT_POLL_MS);
+}
 
 function setRefreshStatus(rs: RefreshState, detail?: string) {
   state.refreshState = rs;
@@ -56,6 +117,11 @@ function setRefreshStatus(rs: RefreshState, detail?: string) {
 
   if (rs === 'refreshing') { el.textContent = "refreshing…"; return; }
   if (rs === 'paused') { el.textContent = "paused"; announce('Auto refresh paused.'); return; }
+  if (rs === 'error' && detail === '(reconnecting)') {
+    el.textContent = 'reconnecting…';
+    announce('Viewer reconnecting.');
+    return;
+  }
   if (rs === 'error') { el.textContent = "refresh failed"; announce('Refresh failed.'); return; }
   const suffix = detail ? ` ${detail}` : '';
   el.textContent = "updated " + new Date().toLocaleTimeString() + suffix;
@@ -77,7 +143,7 @@ document.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'hidden') {
     stopPolling();
     setRefreshStatus('paused', '(tab hidden)');
-  } else if (!isSettingsOpen()) {
+  } else if (!isSettingsOpen() && !reconnecting) {
     startPolling();
     refresh();
   }
@@ -155,12 +221,14 @@ $select('projectFilter')?.addEventListener('change', () => {
 let refreshDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 async function refresh() {
+  if (reconnecting) return;
   // Debounce rapid calls (tab switch + hash change + visibility)
   if (refreshDebounceTimer) clearTimeout(refreshDebounceTimer);
   refreshDebounceTimer = setTimeout(() => doRefresh(), 80);
 }
 
 async function doRefresh() {
+  if (reconnecting) return;
   if (state.refreshInFlight) { state.refreshQueued = true; return; }
   state.refreshInFlight = true;
 
@@ -190,10 +258,15 @@ async function doRefresh() {
     await Promise.all(promises);
     setRefreshStatus('idle');
   } catch {
-    setRefreshStatus('error');
+    const ready = await isViewerReady();
+    if (!ready) {
+      scheduleReconnectLoop();
+    } else {
+      setRefreshStatus('error');
+    }
   } finally {
     state.refreshInFlight = false;
-    if (state.refreshQueued) {
+    if (state.refreshQueued && !reconnecting) {
       state.refreshQueued = false;
       doRefresh();
     }
@@ -219,6 +292,18 @@ initSettings(stopPolling, startPolling, () => refresh());
 
 // Projects
 loadProjects();
+
+$('viewerReconnectRetry')?.addEventListener('click', async () => {
+  setReconnectOverlay(true, 'Checking whether the viewer server is back…');
+  const ready = await isViewerReady();
+  if (!ready) {
+    scheduleReconnectLoop();
+    return;
+  }
+  stopReconnectLoop();
+  startPolling();
+  void doRefresh();
+});
 
 // Version label
 loadRuntimeLabel();

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -30,6 +30,20 @@ async function fetchJson<T = Record<string, unknown>>(url: string): Promise<T> {
   return resp.json() as Promise<T>;
 }
 
+export async function pingViewerReady(timeoutMs = 1200): Promise<void> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const resp = await fetch('/api/stats', {
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    if (!resp.ok) throw new Error(`/api/stats: ${resp.status} ${resp.statusText}`);
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
 async function readJsonPayload<T = Record<string, unknown>>(
   resp: Response,
 ): Promise<{ text: string; payload: T }> {


### PR DESCRIPTION
## Description

Adds a reconnecting overlay to the viewer UI for the case where the already-open page loses contact with the local server during a restart or upgrade. The UI now distinguishes ordinary refresh failures from viewer-unavailable conditions, pauses normal polling while disconnected, probes a real readiness endpoint with a short timeout, and automatically resumes refresh once the server is back.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm --filter @codemem/ui typecheck`
- [x] `pnpm --filter @codemem/ui build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
