### PR TITLE
fix(db): bootstrap fresh databases for init and serve

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -68,7 +68,7 @@ dbCommand
 	.addCommand(
 		new Command("init")
 			.configureHelp(helpStyle)
-			.description("Verify the SQLite database is present and schema-ready")
+			.description("Create or verify the SQLite database and schema")
 			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 			.action((opts: { db?: string; dbPath?: string }) => {

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemoryStore } from "@codemem/core";
 import { describe, expect, it } from "vitest";
 import {
 	buildForegroundRunnerArgs,
@@ -7,6 +11,7 @@ import {
 	isLoopbackOnlyHost,
 	isSqliteVecLoadFailure,
 	pickViewerPidCandidate,
+	prepareViewerDatabase,
 	sqliteVecFailureDiagnostics,
 } from "./serve.js";
 import {
@@ -177,6 +182,26 @@ describe("serve command option resolution", () => {
 		expect(isLocalHost("::1")).toBe(true);
 		expect(isLocalHost("0.0.0.0")).toBe(true);
 		expect(isLocalHost("example.com")).toBe(false);
+	});
+
+	it("prepares a fresh viewer database before startup", () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-serve-"));
+		const dbPath = join(dir, "viewer.sqlite");
+		try {
+			const prepared = prepareViewerDatabase(dbPath);
+			expect(prepared).toBe(dbPath);
+
+			process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+			const db = new MemoryStore(dbPath);
+			try {
+				expect(db.dbPath).toBe(dbPath);
+			} finally {
+				db.close();
+				delete process.env.CODEMEM_EMBEDDING_DISABLED;
+			}
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("distinguishes loopback-only viewer binds from network-exposed binds", () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import {
+	initDatabase,
 	isEmbeddingDisabled,
 	type MemoryStore,
 	ObserverClient,
@@ -72,6 +73,10 @@ export function isLikelyViewerCommand(command: string): boolean {
 		lowered.includes("packages/cli/dist/index.js") ||
 		lowered.includes("/cli/dist/index.js")
 	);
+}
+
+export function prepareViewerDatabase(dbPath?: string | null): string {
+	return initDatabase(dbPath ?? undefined).path;
 }
 
 export function pickViewerPidCandidate(
@@ -342,6 +347,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	const { serve } = await import("@hono/node-server");
 
 	if (invocation.dbPath) process.env.CODEMEM_DB = invocation.dbPath;
+	const preparedDb = prepareViewerDatabase(invocation.dbPath);
 	warnIfViewerExposed(invocation.host, invocation.port);
 	if (await isPortOpen(invocation.host, invocation.port)) {
 		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
@@ -436,7 +442,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			);
 			p.intro("codemem viewer");
 			p.log.success(`Listening on http://${info.address}:${info.port}`);
-			p.log.info(`Database: ${dbPath}`);
+			p.log.info(`Database: ${preparedDb}`);
 			p.log.step("Raw event sweeper started");
 			if (syncConfig.syncRetentionEnabled) {
 				retentionRunner.start();

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -347,13 +347,13 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	const { serve } = await import("@hono/node-server");
 
 	if (invocation.dbPath) process.env.CODEMEM_DB = invocation.dbPath;
-	const preparedDb = prepareViewerDatabase(invocation.dbPath);
 	warnIfViewerExposed(invocation.host, invocation.port);
 	if (await isPortOpen(invocation.host, invocation.port)) {
 		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
 		process.exitCode = 1;
 		return;
 	}
+	const preparedDb = prepareViewerDatabase(invocation.dbPath);
 
 	const observer = new ObserverClient();
 	let store: MemoryStore;

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -99,6 +99,23 @@ describe("maintenance", () => {
 		expect(vacuum.sizeBytes).toBeGreaterThan(0);
 	});
 
+	it("initializes a fresh database schema", () => {
+		const dbPath = createDbPath("fresh-init");
+
+		const init = initDatabase(dbPath);
+		expect(init.path).toBe(dbPath);
+		expect(init.sizeBytes).toBeGreaterThan(0);
+
+		const db = new Database(dbPath, { readonly: true });
+		try {
+			expect(() => db.prepare("SELECT 1 FROM memory_items LIMIT 1").get()).not.toThrow();
+			expect(() => db.prepare("SELECT 1 FROM sessions LIMIT 1").get()).not.toThrow();
+			expect(db.pragma("user_version", { simple: true })).toBeGreaterThan(0);
+		} finally {
+			db.close();
+		}
+	});
+
 	it("reports max retry depth from raw_event_flush_batches.attempt_count", () => {
 		const dbPath = createDbPath("retry-depth");
 		seedMaintenanceDb(dbPath);

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -1,10 +1,17 @@
 import { statSync } from "node:fs";
 import { and, eq, gt, gte, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
-import { assertSchemaReady, connect, type Database, resolveDbPath } from "./db.js";
+import {
+	assertSchemaReady,
+	connect,
+	type Database,
+	getSchemaVersion,
+	resolveDbPath,
+} from "./db.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
 import { projectClause } from "./project.js";
 import * as schema from "./schema.js";
+import { bootstrapSchema } from "./schema-bootstrap.js";
 
 export interface RawEventStatusItem {
 	source: string;
@@ -39,10 +46,18 @@ function withDb<T>(dbPath: string | undefined, fn: (db: Database, resolvedPath: 
 }
 
 export function initDatabase(dbPath?: string): { path: string; sizeBytes: number } {
-	return withDb(dbPath, (_db, resolvedPath) => {
+	const resolvedPath = resolveDbPath(dbPath);
+	const db = connect(resolvedPath);
+	try {
+		if (getSchemaVersion(db) === 0) {
+			bootstrapSchema(db);
+		}
+		assertSchemaReady(db);
 		const stats = statSync(resolvedPath);
 		return { path: resolvedPath, sizeBytes: stats.size };
-	});
+	} finally {
+		db.close();
+	}
 }
 
 export function vacuumDatabase(dbPath?: string): { path: string; sizeBytes: number } {

--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -1,0 +1,50 @@
+import type { Database } from "./db.js";
+import { SCHEMA_VERSION } from "./db.js";
+import { TEST_SCHEMA_BASE_DDL } from "./test-schema.generated.js";
+
+const SCHEMA_AUX_DDL = `
+CREATE INDEX IF NOT EXISTS idx_sync_peers_actor_id ON sync_peers(actor_id);
+
+CREATE TABLE IF NOT EXISTS sync_retention_state (
+	id INTEGER PRIMARY KEY,
+	last_run_at TEXT,
+	last_duration_ms INTEGER,
+	last_deleted_ops INTEGER NOT NULL DEFAULT 0,
+	last_estimated_bytes_before INTEGER,
+	last_estimated_bytes_after INTEGER,
+	retained_floor_cursor TEXT,
+	last_error TEXT,
+	last_error_at TEXT
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+	title, body_text, tags_text,
+	content='memory_items',
+	content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS memory_items_ai AFTER INSERT ON memory_items BEGIN
+	INSERT INTO memory_fts(rowid, title, body_text, tags_text)
+	VALUES (new.id, new.title, new.body_text, new.tags_text);
+END;
+
+DROP TRIGGER IF EXISTS memory_items_au;
+CREATE TRIGGER memory_items_au AFTER UPDATE ON memory_items BEGIN
+	INSERT INTO memory_fts(memory_fts, rowid, title, body_text, tags_text)
+	VALUES('delete', old.id, old.title, old.body_text, old.tags_text);
+	INSERT INTO memory_fts(rowid, title, body_text, tags_text)
+	VALUES (new.id, new.title, new.body_text, new.tags_text);
+END;
+
+DROP TRIGGER IF EXISTS memory_items_ad;
+CREATE TRIGGER memory_items_ad AFTER DELETE ON memory_items BEGIN
+	INSERT INTO memory_fts(memory_fts, rowid, title, body_text, tags_text)
+	VALUES('delete', old.id, old.title, old.body_text, old.tags_text);
+END;
+`;
+
+export function bootstrapSchema(db: Database): void {
+	db.exec(TEST_SCHEMA_BASE_DDL);
+	db.exec(SCHEMA_AUX_DDL);
+	db.pragma(`user_version = ${SCHEMA_VERSION}`);
+}

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -3,57 +3,13 @@
  */
 
 import type { Database } from "./db.js";
-import { SCHEMA_VERSION } from "./db.js";
-import { TEST_SCHEMA_BASE_DDL } from "./test-schema.generated.js";
-
-const TEST_SCHEMA_AUX_DDL = `
-CREATE INDEX IF NOT EXISTS idx_sync_peers_actor_id ON sync_peers(actor_id);
-
-CREATE TABLE IF NOT EXISTS sync_retention_state (
-	id INTEGER PRIMARY KEY,
-	last_run_at TEXT,
-	last_duration_ms INTEGER,
-	last_deleted_ops INTEGER NOT NULL DEFAULT 0,
-	last_estimated_bytes_before INTEGER,
-	last_estimated_bytes_after INTEGER,
-	retained_floor_cursor TEXT,
-	last_error TEXT,
-	last_error_at TEXT
-);
-
-CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
-	title, body_text, tags_text,
-	content='memory_items',
-	content_rowid='id'
-);
-
-CREATE TRIGGER IF NOT EXISTS memory_items_ai AFTER INSERT ON memory_items BEGIN
-	INSERT INTO memory_fts(rowid, title, body_text, tags_text)
-	VALUES (new.id, new.title, new.body_text, new.tags_text);
-END;
-
-DROP TRIGGER IF EXISTS memory_items_au;
-CREATE TRIGGER memory_items_au AFTER UPDATE ON memory_items BEGIN
-	INSERT INTO memory_fts(memory_fts, rowid, title, body_text, tags_text)
-	VALUES('delete', old.id, old.title, old.body_text, old.tags_text);
-	INSERT INTO memory_fts(rowid, title, body_text, tags_text)
-	VALUES (new.id, new.title, new.body_text, new.tags_text);
-END;
-
-DROP TRIGGER IF EXISTS memory_items_ad;
-CREATE TRIGGER memory_items_ad AFTER DELETE ON memory_items BEGIN
-	INSERT INTO memory_fts(memory_fts, rowid, title, body_text, tags_text)
-	VALUES('delete', old.id, old.title, old.body_text, old.tags_text);
-END;
-`;
+import { bootstrapSchema } from "./schema-bootstrap.js";
 
 /**
  * Create the full schema for test databases.
  */
 export function initTestSchema(db: Database): void {
-	db.exec(TEST_SCHEMA_BASE_DDL);
-	db.exec(TEST_SCHEMA_AUX_DDL);
-	db.pragma(`user_version = ${SCHEMA_VERSION}`);
+	bootstrapSchema(db);
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes a fresh-database bootstrap bug in the TypeScript runtime. `codemem db init` now actually creates and initializes a missing/uninitialized SQLite database instead of only validating readiness, and `codemem serve start` prepares the database before opening the viewer store. The shared bootstrap DDL was moved into production core code so tests and runtime use the same schema bootstrap path.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm --filter @codemem/core exec vitest run src/maintenance.test.ts src/db.test.ts`
- [x] `pnpm --filter codemem test -- serve.test.ts`
- [x] `pnpm --filter @codemem/core typecheck`
- [x] `pnpm --filter codemem typecheck`
- [x] `pnpm run codemem db init --db-path /tmp/...`
- [x] `pnpm run codemem serve start --db-path /tmp/... --background` then stop

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
