### PR TITLE
fix(sync): resolve attempt log N/A, allow cross-device actor merge, add delete person

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -342,6 +342,17 @@ export async function mergeActor(primaryActorId: string, secondaryActorId: strin
   return payload;
 }
 
+export async function deactivateActor(actorId: string): Promise<any> {
+  const resp = await fetch('/api/sync/actors/deactivate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ actor_id: actorId }),
+  });
+  const { text, payload } = await readJsonPayload(resp);
+  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
+  return payload;
+}
+
 export async function claimLegacyDeviceIdentity(originDeviceId: string): Promise<any> {
   const resp = await fetch('/api/sync/legacy-devices/claim', {
     method: 'POST',

--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -16,6 +16,7 @@ type SyncActorRowProps = {
   hiddenLocalDuplicateCount: number;
   onRename: (actorId: string, displayName: string) => Promise<void>;
   onMerge: (primaryActorId: string, secondaryActorId: string) => Promise<void>;
+  onDeactivate: (actorId: string) => Promise<void>;
 };
 
 type SyncActorsListProps = {
@@ -23,6 +24,7 @@ type SyncActorsListProps = {
   hiddenLocalDuplicateCount: number;
   onRename: (actorId: string, displayName: string) => Promise<void>;
   onMerge: (primaryActorId: string, secondaryActorId: string) => Promise<void>;
+  onDeactivate: (actorId: string) => Promise<void>;
 };
 
 function localActorNote(hiddenLocalDuplicateCount: number): string {
@@ -32,7 +34,7 @@ function localActorNote(hiddenLocalDuplicateCount: number): string {
   return `Represents you across your devices. ${hiddenLocalDuplicateCount} unresolved duplicate ${hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden until reviewed in Needs attention.`;
 }
 
-function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge }: SyncActorRowProps) {
+function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge, onDeactivate }: SyncActorRowProps) {
   const actorId = String(actor.actor_id || '');
   const label = actorLabel(actor);
   const count = assignedActorCount(actorId);
@@ -162,6 +164,22 @@ function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge }: S
               </button>
             </div>
             <div className="peer-meta actor-merge-note">{mergeNote}</div>
+            <button
+              className="settings-button"
+              disabled={renameBusy || mergeBusy}
+              onClick={async () => {
+                const confirmed = await openSyncConfirmDialog({
+                  title: `Remove ${label}?`,
+                  description: 'This deactivates the person and unassigns their devices. Existing memories keep their current attribution.',
+                  confirmLabel: 'Remove person',
+                  cancelLabel: 'Keep',
+                  tone: 'danger',
+                });
+                if (confirmed) await onDeactivate(actorId);
+              }}
+            >
+              Remove person
+            </button>
           </>
         )}
       </div>
@@ -169,7 +187,7 @@ function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge }: S
   );
 }
 
-function SyncActorsList({ actors, hiddenLocalDuplicateCount, onRename, onMerge }: SyncActorsListProps) {
+function SyncActorsList({ actors, hiddenLocalDuplicateCount, onRename, onMerge, onDeactivate }: SyncActorsListProps) {
   if (!actors.length) {
     return (
       <div className="sync-empty-state">
@@ -190,6 +208,7 @@ function SyncActorsList({ actors, hiddenLocalDuplicateCount, onRename, onMerge }
             hiddenLocalDuplicateCount={hiddenLocalDuplicateCount}
             onRename={onRename}
             onMerge={onMerge}
+            onDeactivate={onDeactivate}
           />
         );
       })}

--- a/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
@@ -8,7 +8,8 @@ export type SyncStatItem = {
 
 export type SyncAttemptItem = {
   status: string;
-  address: string;
+  peerLabel: string;
+  detail: string;
   startedAt: string;
 };
 
@@ -41,10 +42,10 @@ function AttemptsList({ attempts }: { attempts: SyncAttemptItem[] }) {
   return (
     <Fragment>
       {attempts.map((attempt, index) => (
-        <div class="diag-line" key={`${attempt.startedAt}-${attempt.address}-${index}`}>
+        <div class="diag-line" key={`${attempt.startedAt}-${attempt.peerLabel}-${index}`}>
           <div class="left">
-            <div>{attempt.status}</div>
-            <div class="small">{attempt.address}</div>
+            <div>{attempt.peerLabel} — {attempt.status}</div>
+            {attempt.detail ? <div class="small">{attempt.detail}</div> : null}
           </div>
           <div class="right">{attempt.startedAt}</div>
         </div>

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -51,6 +51,11 @@ type SyncStatusState = {
 
 type SyncAttemptState = {
   address?: string;
+  error?: string;
+  finished_at?: string;
+  ops_in?: number;
+  ops_out?: number;
+  peer_device_id?: string;
   started_at?: string;
   started_at_utc?: string;
   status?: string;
@@ -345,9 +350,30 @@ export function renderSyncAttempts() {
 
   const items: SyncAttemptItem[] = attempts.slice(0, 5).map((attempt) => {
     const time = attempt.started_at || attempt.started_at_utc || '';
+    const peerId = String(attempt.peer_device_id || '').trim();
+    const matchedPeer = Array.isArray(state.lastSyncPeers)
+      ? state.lastSyncPeers.find((p: any) => String(p?.peer_device_id || '') === peerId)
+      : null;
+    const peerName = String(matchedPeer?.name || '').trim();
+    const peerLabel = peerName || (peerId ? peerId.slice(0, 8) : 'unknown');
+
+    // Progressive disclosure: show what's relevant for this attempt's outcome
+    const isError = attempt.status === 'error';
+    const detailParts: string[] = [];
+    if (isError && attempt.error) {
+      detailParts.push(String(attempt.error));
+    }
+    if (!isError && (attempt.ops_in || attempt.ops_out)) {
+      detailParts.push(`${attempt.ops_in ?? 0} in · ${attempt.ops_out ?? 0} out`);
+    }
+    if (!isSyncRedactionEnabled() && attempt.address) {
+      detailParts.push(attempt.address);
+    }
+
     return {
       status: attempt.status || 'unknown',
-      address: isSyncRedactionEnabled() ? redactAddress(attempt.address) : attempt.address || 'n/a',
+      peerLabel,
+      detail: detailParts.join(' · '),
       startedAt: time ? formatTimestamp(time) : '',
     };
   });

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -78,6 +78,16 @@ export function renderSyncActors() {
         throw error;
       }
     },
+    onDeactivate: async (actorId) => {
+      try {
+        await api.deactivateActor(actorId);
+        showGlobalNotice('Person removed. Assigned devices have been unassigned.');
+        await _loadSyncData();
+      } catch (error) {
+        showGlobalNotice(friendlyError(error, 'Failed to remove person.'), 'warning');
+        throw error;
+      }
+    },
   });
 }
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -162,9 +162,10 @@ describe("viewer-server", () => {
 	});
 
 	it("sync UI api routes all exist in the viewer sync router", () => {
-		const apiSource = readFileSync(join(process.cwd(), "packages/ui/src/lib/api.ts"), "utf8");
+		const root = join(import.meta.dirname, "../../..");
+		const apiSource = readFileSync(join(root, "packages/ui/src/lib/api.ts"), "utf8");
 		const routeSource = readFileSync(
-			join(process.cwd(), "packages/viewer-server/src/routes/sync.ts"),
+			join(root, "packages/viewer-server/src/routes/sync.ts"),
 			"utf8",
 		);
 		const uiRoutes = [
@@ -2849,7 +2850,7 @@ describe("viewer-server", () => {
 					}),
 				});
 				expect(res.status).toBe(409);
-				expect(await res.json()).toEqual({ error: "cannot merge local actor" });
+				expect(await res.json()).toEqual({ error: "cannot merge this device's own local actor" });
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -31,7 +31,7 @@ import {
 	schema,
 	verifySignature,
 } from "@codemem/core";
-import { count, desc, eq, max, ne } from "drizzle-orm";
+import { and, count, desc, eq, max, ne } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { type Context, Hono } from "hono";
 import { queryBool, queryInt, safeJsonList } from "../helpers.js";
@@ -1157,11 +1157,22 @@ export function syncRoutes(
 				.orderBy(desc(schema.syncAttempts.finished_at))
 				.limit(25)
 				.all();
-			const attemptsItems = attemptRows.map((row) => ({
-				...row,
-				status: attemptStatus(row),
-				address: null,
-			}));
+			const peerAddressMap = new Map<string, string[]>();
+			store.db
+				.prepare("SELECT peer_device_id, addresses_json FROM sync_peers")
+				.all()
+				.forEach((peerRow: any) => {
+					const addrs = safeJsonList(peerRow.addresses_json as string | null);
+					if (addrs.length) peerAddressMap.set(String(peerRow.peer_device_id ?? ""), addrs);
+				});
+			const attemptsItems = attemptRows.map((row) => {
+				const addrs = showDiag ? peerAddressMap.get(String(row.peer_device_id ?? "")) : undefined;
+				return {
+					...row,
+					status: attemptStatus(row),
+					address: addrs?.length ? addrs[0] : null,
+				};
+			});
 			const latestAttemptError = String(attemptsItems[0]?.error || "").trim();
 
 			const statusBlock: Record<string, unknown> = {
@@ -1265,7 +1276,10 @@ export function syncRoutes(
 			const query = d.select().from(schema.actors);
 			const rows = includeMerged
 				? query.orderBy(schema.actors.display_name).all()
-				: query.where(ne(schema.actors.status, "merged")).orderBy(schema.actors.display_name).all();
+				: query
+						.where(and(ne(schema.actors.status, "merged"), ne(schema.actors.status, "deactivated")))
+						.orderBy(schema.actors.display_name)
+						.all();
 			return c.json({ items: rows });
 		}
 	});
@@ -1625,7 +1639,9 @@ export function syncRoutes(
 		if (!primary || !secondary) return c.json({ error: "actor not found" }, 404);
 		if (primary.status !== "active") return c.json({ error: "primary actor not active" }, 409);
 		if (secondary.status !== "active") return c.json({ error: "secondary actor not active" }, 409);
-		if (secondary.is_local) return c.json({ error: "cannot merge local actor" }, 409);
+		if (secondary.is_local && secondary.actor_id === store.actorId) {
+			return c.json({ error: "cannot merge this device's own local actor" }, 409);
+		}
 		const now = new Date().toISOString();
 		const mergedCount = store.db.transaction(() => {
 			const peerUpdate = d
@@ -1646,6 +1662,35 @@ export function syncRoutes(
 			return Number(peerUpdate.changes ?? 0);
 		})();
 		return c.json({ merged_count: mergedCount });
+	});
+
+	app.post("/api/sync/actors/deactivate", async (c) => {
+		const store = getStore();
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const actorId = String(body.actor_id ?? "").trim();
+		if (!actorId) return c.json({ error: "actor_id required" }, 400);
+		if (actorId === store.actorId) {
+			return c.json({ error: "cannot deactivate this device's own local actor" }, 409);
+		}
+		const d = drizzle(store.db, { schema });
+		const actor = d.select().from(schema.actors).where(eq(schema.actors.actor_id, actorId)).get();
+		if (!actor) return c.json({ error: "actor not found" }, 404);
+		if (actor.status !== "active") return c.json({ error: "actor not active" }, 409);
+		const now = new Date().toISOString();
+		d.update(schema.actors)
+			.set({ status: "deactivated", updated_at: now })
+			.where(eq(schema.actors.actor_id, actorId))
+			.run();
+		d.update(schema.syncPeers)
+			.set({ actor_id: null })
+			.where(eq(schema.syncPeers.actor_id, actorId))
+			.run();
+		return c.json({ ok: true });
 	});
 
 	app.post("/api/sync/legacy-devices/claim", async (c) => {


### PR DESCRIPTION
## Description

Fixes three sync bugs:

1. **Sync log always N/A** (codemem-zdda): Attempt log now resolves peer addresses from `sync_peers.addresses_json` instead of hardcoding `address: null`. The redact toggle now has actual data to work with.

2. **Cannot combine local actors across machines** (codemem-ipah): The merge guard now only blocks merging **this device's own** local actor as secondary, not any actor that happens to have `is_local=1` from a remote device. Same person across two machines can now be combined.

3. **No delete person** (codemem-z048): Adds `POST /api/sync/actors/deactivate` route and "Remove person" button with confirmation dialog. Deactivating a person unassigns their devices and marks the actor as deactivated. Cannot deactivate this device's own local actor.

Also fixes a pre-existing test path bug where the route-existence check used `process.cwd()` instead of `import.meta.dirname`.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [x] 🚀 Feature (new functionality)

## Testing

- [x] `pnpm --filter @codemem/ui typecheck`
- [x] `pnpm --filter @codemem/ui build`
- [x] `pnpm --filter @codemem/server typecheck`
- [x] `pnpm --filter @codemem/server exec vitest run src/index.test.ts`