### PR TITLE
fix(sync): replace dirty-state full table scan and close bootstrap TOCTOU window

### DIFF
--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -428,10 +428,30 @@ export async function syncOnce(
 							pageSize: BOOTSTRAP_PAGE_SIZE,
 						});
 
-						// No TOCTOU dirty-state re-check here: the localSharedCount === 0
-						// guard above ensures there are no shared memories to lose. Unlike
-						// the re-bootstrap path (which runs on nodes that already have shared
-						// data), this path only fires on truly empty nodes.
+						// Re-check after network fetch: another process (plugin, CLI, another
+						// sync pass) could have created shared memories while we were fetching
+						// pages.  Same TOCTOU guard as the re-bootstrap path.
+						const postFetchSharedCount = Number(
+							(
+								db
+									.prepare("SELECT count(*) as n FROM memory_items WHERE import_key IS NOT NULL")
+									.get() as { n: number }
+							)?.n ?? 0,
+						);
+						if (postFetchSharedCount > 0) {
+							recordSyncAttempt(db, peerDeviceId, {
+								ok: false,
+								error: "needs_attention:shared_memories_appeared_during_bootstrap",
+							});
+							return {
+								ok: false,
+								address: baseUrl,
+								error: `needs attention: ${postFetchSharedCount} shared memory change(s) appeared during initial bootstrap fetch`,
+								opsIn: 0,
+								opsOut: 0,
+								addressErrors: [],
+							};
+						}
 						const bootstrapResult = applyBootstrapSnapshot(db, peerDeviceId, items, resetInfo);
 						if (!bootstrapResult.ok) {
 							throw new Error("initial bootstrap apply failed");

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -850,31 +850,33 @@ export function loadMemorySnapshotPageForPeer(
 }
 
 export function hasUnsyncedSharedMemoryChanges(db: Database, limit = 25): SyncDirtyLocalState {
-	const d = drizzle(db, { schema });
-	const rows = d.select().from(schema.memoryItems).orderBy(schema.memoryItems.updated_at).all();
-	let count = 0;
-	for (const row of rows) {
-		if (!row.import_key) continue;
-		const payload = buildPayloadFromMemoryRow(row);
-		if (!syncVisibilityAllowed(payload as unknown as Record<string, unknown>)) continue;
-		const opType: "upsert" | "delete" = row.deleted_at || row.active === 0 ? "delete" : "upsert";
-		const exists = d
-			.select({ one: sql<number>`1` })
-			.from(schema.replicationOps)
-			.where(
-				and(
-					eq(schema.replicationOps.entity_type, "memory_item"),
-					eq(schema.replicationOps.entity_id, row.import_key),
-					eq(schema.replicationOps.op_type, opType),
-					eq(schema.replicationOps.clock_rev, Number(row.rev ?? 0)),
-				),
-			)
-			.limit(1)
-			.get();
-		if (exists) continue;
-		count += 1;
-		if (count >= limit) break;
-	}
+	// Single SQL query replacing the old O(N×M) JS loop that loaded every
+	// memory item then queried replication_ops per-row.  This uses NOT EXISTS
+	// to find shared memories whose current rev lacks a matching replication op,
+	// which is exactly the "dirty" condition the old loop was checking.
+	//
+	// Visibility matching follows syncVisibilityAllowed semantics:
+	//  - explicit 'shared', 'shared:default', 'shared:legacy' → sync-eligible
+	//  - NULL/empty visibility with non-private content → sync-eligible (legacy default)
+	//  - explicit 'private' or 'personal:*' → not sync-eligible
+	const stmt = db.prepare(`
+		SELECT count(*) as n FROM (
+			SELECT 1 FROM memory_items m
+			WHERE m.import_key IS NOT NULL
+			  AND COALESCE(m.visibility, '') NOT LIKE 'private%'
+			  AND COALESCE(m.visibility, '') NOT LIKE 'personal%'
+			  AND NOT EXISTS (
+				SELECT 1 FROM replication_ops r
+				WHERE r.entity_type = 'memory_item'
+				  AND r.entity_id = m.import_key
+				  AND r.op_type = CASE WHEN m.deleted_at IS NOT NULL OR m.active = 0 THEN 'delete' ELSE 'upsert' END
+				  AND r.clock_rev = COALESCE(m.rev, 0)
+			  )
+			LIMIT ?
+		)
+	`);
+	const row = stmt.get(limit) as { n: number } | undefined;
+	const count = Number(row?.n ?? 0);
 	return { dirty: count > 0, count };
 }
 


### PR DESCRIPTION
## Description

Fixes two P0 critical issues from the sync system audit (Gordon review):

### 1. `hasUnsyncedSharedMemoryChanges` full table scan (codemem-7cix)

The old implementation loaded **every memory item** into JavaScript, then ran a per-row query against `replication_ops` — O(N×M) on every 409 reset response. On a node with 23k+ memories this blocks the event loop and stalls the sync daemon.

Replaced with a single SQL query using `NOT EXISTS` that does the entire check in SQLite where it belongs. The query filters by shared visibility, checks for missing replication ops at the current rev, and respects the existing `limit` parameter.

### 2. Auto-bootstrap TOCTOU window (codemem-cmum)

The auto-bootstrap path had no dirty-state re-check after the network fetch. Between the `localSharedCount === 0` check and `applyBootstrapSnapshot`, another process (plugin, CLI, another sync pass) could create shared memories during the multi-page fetch. Now re-checks `localSharedCount` after the fetch and bails if shared memories appeared, matching the re-bootstrap path's safety pattern.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] `pnpm --filter @codemem/core typecheck`
- [x] `pnpm --filter @codemem/core exec vitest run src/sync-pass.test.ts src/sync-replication.test.ts` (99 passed)