### PR TITLE
fix(sync): include session project in replication ops

### DIFF
--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -158,27 +158,43 @@ function parseSnapshotPayload(item: SyncMemorySnapshotItem): Record<string, unkn
 	}
 }
 
-function ensureSessionForBootstrap(d: ReturnType<typeof drizzle>, updatedAt: string): number {
+const bootstrapSessionCache = new Map<string, number>();
+
+function ensureSessionForBootstrap(
+	d: ReturnType<typeof drizzle>,
+	updatedAt: string,
+	project?: string | null,
+): number {
+	const projectKey = project ?? "__none__";
+	const cached = bootstrapSessionCache.get(projectKey);
+	if (cached != null) return cached;
+
+	const cwd = project ? `__sync_bootstrap__:${project}` : "__sync_bootstrap__";
 	const existing = d
 		.select({ id: schema.sessions.id })
 		.from(schema.sessions)
-		.where(eq(schema.sessions.cwd, "__sync_bootstrap__"))
+		.where(eq(schema.sessions.cwd, cwd))
 		.limit(1)
 		.get();
-	if (existing) return existing.id;
+	if (existing) {
+		bootstrapSessionCache.set(projectKey, existing.id);
+		return existing.id;
+	}
 
 	const rows = d
 		.insert(schema.sessions)
 		.values({
 			started_at: updatedAt,
-			cwd: "__sync_bootstrap__",
-			project: null,
+			cwd,
+			project: project ?? null,
 			user: "sync",
 			tool_version: "bootstrap",
 		})
 		.returning({ id: schema.sessions.id })
 		.all();
-	return rows[0]?.id ?? 0;
+	const id = rows[0]?.id ?? 0;
+	bootstrapSessionCache.set(projectKey, id);
+	return id;
 }
 
 /**
@@ -220,12 +236,17 @@ export function applyBootstrapSnapshot(
 			.run();
 		result.deleted = deleteResult.changes;
 
-		// 2. Insert snapshot items.
-		const sessionId = ensureSessionForBootstrap(d, new Date().toISOString());
+		// 2. Insert snapshot items, grouping by project.
+		bootstrapSessionCache.clear();
 
 		for (const item of items) {
 			const payload = parseSnapshotPayload(item);
 			if (!payload) continue;
+			const project =
+				typeof payload.project === "string" && payload.project.trim()
+					? payload.project.trim()
+					: null;
+			const sessionId = ensureSessionForBootstrap(d, new Date().toISOString(), project);
 
 			const metaRaw = payload.metadata_json;
 			const meta =
@@ -274,6 +295,9 @@ export function applyBootstrapSnapshot(
 					files_modified: Array.isArray(payload.files_modified)
 						? JSON.stringify(payload.files_modified)
 						: null,
+					user_prompt_id:
+						typeof payload.user_prompt_id === "number" ? payload.user_prompt_id : null,
+					prompt_number: typeof payload.prompt_number === "number" ? payload.prompt_number : null,
 				})
 				.run();
 			result.applied++;

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1756,3 +1756,237 @@ describe("applyReplicationOps", () => {
 		expect(mem.tags_text).toBe("existing-tag");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Payload round-trip parity — ensures recordReplicationOp, parseMemoryPayload,
+// and applyReplicationOps all agree on which fields are carried through the
+// replication pipeline.  If you add a field to one and not the others, this
+// test will catch the drift.
+// ---------------------------------------------------------------------------
+
+describe("replication payload round-trip parity", () => {
+	let db: InstanceType<typeof Database>;
+	let sessionId: number;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		sessionId = insertTestSession(db);
+		setSyncResetState(db, { generation: 1, snapshot_id: "snap-rt", baseline_cursor: null });
+	});
+
+	afterEach(() => db.close());
+
+	it("round-trips all payload fields through record → parse → apply", () => {
+		const now = new Date().toISOString();
+
+		// Insert a memory with every field populated
+		db.prepare(`
+			INSERT INTO memory_items (
+				session_id, kind, title, subtitle, body_text, confidence,
+				tags_text, active, created_at, updated_at, metadata_json,
+				actor_id, actor_display_name, visibility, workspace_id,
+				workspace_kind, origin_device_id, origin_source, trust_state,
+				narrative, facts, concepts, files_read, files_modified,
+				user_prompt_id, prompt_number, import_key, rev
+			) VALUES (
+				?, 'decision', 'Round Trip Title', 'Sub', 'Body text here', 0.85,
+				'tag-a tag-b', 1, ?, ?, '{"custom_key":"custom_val"}',
+				'actor-rt', 'Actor Name', 'shared', 'ws-1',
+				'shared', 'device-origin', 'test', 'trusted',
+				'A narrative', '["fact-1"]', '["concept-1"]', '["file-a"]', '["file-b"]',
+				42, 7, 'roundtrip-key-1', 1
+			)
+		`).run(sessionId, now, now);
+
+		// Also set the session project so it flows through
+		db.prepare("UPDATE sessions SET project = ? WHERE id = ?").run("test-project", sessionId);
+
+		const memoryId = (
+			db.prepare("SELECT id FROM memory_items WHERE import_key = 'roundtrip-key-1'").get() as {
+				id: number;
+			}
+		).id;
+
+		// Record a replication op (source side)
+		const opId = recordReplicationOp(db, {
+			memoryId,
+			opType: "upsert",
+			deviceId: "source-device",
+		});
+
+		// Read the op back
+		const op = db.prepare("SELECT * FROM replication_ops WHERE op_id = ?").get(opId) as any;
+		const payload = JSON.parse(op.payload_json);
+
+		// Verify the payload includes all the fields we care about
+		expect(payload.project).toBe("test-project");
+		expect(payload.kind).toBe("decision");
+		expect(payload.title).toBe("Round Trip Title");
+		expect(payload.subtitle).toBe("Sub");
+		expect(payload.body_text).toBe("Body text here");
+		expect(payload.confidence).toBe(0.85);
+		expect(payload.actor_id).toBe("actor-rt");
+		expect(payload.actor_display_name).toBe("Actor Name");
+		expect(payload.visibility).toBe("shared");
+		expect(payload.workspace_id).toBe("ws-1");
+		expect(payload.workspace_kind).toBe("shared");
+		expect(payload.origin_device_id).toBe("device-origin");
+		expect(payload.origin_source).toBe("test");
+		expect(payload.trust_state).toBe("trusted");
+		expect(payload.narrative).toBe("A narrative");
+		expect(payload.user_prompt_id).toBe(42);
+		expect(payload.prompt_number).toBe(7);
+
+		// Now apply this op on a "target" DB (same DB, different import key scenario)
+		// Delete the original memory AND the recorded op so the apply treats this as new
+		db.prepare("DELETE FROM memory_items WHERE id = ?").run(memoryId);
+		db.prepare("DELETE FROM replication_ops WHERE op_id = ?").run(opId);
+
+		const replicationOp: ReplicationOp = {
+			op_id: "roundtrip-apply-op",
+			entity_type: "memory_item",
+			entity_id: "roundtrip-key-1",
+			op_type: "upsert",
+			payload_json: op.payload_json,
+			clock_rev: op.clock_rev,
+			clock_updated_at: op.clock_updated_at,
+			clock_device_id: "remote-device",
+			device_id: "remote-device",
+			created_at: op.created_at,
+		};
+
+		const result = applyReplicationOps(db, [replicationOp], "target-device");
+		expect(result.applied).toBe(1);
+
+		// Verify the round-tripped memory has the right fields
+		const applied = db
+			.prepare(
+				"SELECT m.*, s.project as session_project FROM memory_items m JOIN sessions s ON s.id = m.session_id WHERE m.import_key = 'roundtrip-key-1'",
+			)
+			.get() as any;
+
+		expect(applied).toBeTruthy();
+		expect(applied.session_project).toBe("test-project");
+		expect(applied.kind).toBe("decision");
+		expect(applied.title).toBe("Round Trip Title");
+		expect(applied.subtitle).toBe("Sub");
+		expect(applied.body_text).toBe("Body text here");
+		expect(applied.confidence).toBe(0.85);
+		expect(applied.actor_id).toBe("actor-rt");
+		expect(applied.actor_display_name).toBe("Actor Name");
+		expect(applied.visibility).toBe("shared");
+		expect(applied.workspace_id).toBe("ws-1");
+		expect(applied.workspace_kind).toBe("shared");
+		expect(applied.origin_device_id).toBe("device-origin");
+		expect(applied.origin_source).toBe("test");
+		expect(applied.trust_state).toBe("trusted");
+		expect(applied.narrative).toBe("A narrative");
+		expect(applied.user_prompt_id).toBe(42);
+		expect(applied.prompt_number).toBe(7);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap snapshot round-trip parity — ensures the snapshot page builder
+// (loadMemorySnapshotPageForPeer) and applyBootstrapSnapshot agree on which
+// fields survive a full snapshot transfer.  If you add a field to one side
+// and not the other, this test will catch the drift.
+// ---------------------------------------------------------------------------
+
+describe("bootstrap snapshot round-trip parity", () => {
+	let db: InstanceType<typeof Database>;
+	let sessionId: number;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		sessionId = insertTestSession(db);
+		setSyncResetState(db, { generation: 1, snapshot_id: "snap-bs", baseline_cursor: null });
+	});
+
+	afterEach(() => db.close());
+
+	it("round-trips all fields through snapshot page → applyBootstrapSnapshot", async () => {
+		const now = new Date().toISOString();
+
+		// Set the session project
+		db.prepare("UPDATE sessions SET project = ? WHERE id = ?").run("bootstrap-project", sessionId);
+
+		// Insert a fully-populated shared memory
+		db.prepare(`
+			INSERT INTO memory_items (
+				session_id, kind, title, subtitle, body_text, confidence,
+				tags_text, active, created_at, updated_at, metadata_json,
+				actor_id, actor_display_name, visibility, workspace_id,
+				workspace_kind, origin_device_id, origin_source, trust_state,
+				narrative, facts, concepts, files_read, files_modified,
+				user_prompt_id, prompt_number, import_key, rev
+			) VALUES (
+				?, 'feature', 'Bootstrap Title', 'BSub', 'Bootstrap body', 0.9,
+				'btag-a btag-b', 1, ?, ?, '{"bs_key":"bs_val"}',
+				'actor-bs', 'Bootstrap Actor', 'shared', 'ws-bs',
+				'shared', 'device-bs-origin', 'bootstrap-test', 'trusted',
+				'Bootstrap narrative', '["bs-fact"]', '["bs-concept"]', '["bs-file-r"]', '["bs-file-w"]',
+				99, 3, 'bootstrap-roundtrip-key', 2
+			)
+		`).run(sessionId, now, now);
+
+		// Build a snapshot page from the source DB (simulates the serving side)
+		const { applyBootstrapSnapshot } = await import("./sync-bootstrap.js");
+
+		const page = loadMemorySnapshotPageForPeer(db, {
+			generation: 1,
+			snapshotId: "snap-bs",
+			baselineCursor: null,
+			limit: 100,
+		});
+
+		expect(page.items.length).toBeGreaterThanOrEqual(1);
+		const snapshotItem = page.items.find((i) => i.entity_id === "bootstrap-roundtrip-key");
+		expect(snapshotItem).toBeTruthy();
+
+		// Now apply the snapshot on a "target" DB (same DB after wiping source data)
+		db.prepare("DELETE FROM memory_items").run();
+		db.prepare("DELETE FROM sessions WHERE id = ?").run(sessionId);
+
+		const resetInfo = {
+			generation: 1,
+			snapshot_id: "snap-bs",
+			baseline_cursor: null,
+			retained_floor_cursor: null,
+			reset_required: true as const,
+			reason: "initial_bootstrap" as const,
+		};
+
+		const result = applyBootstrapSnapshot(db, "target-peer", page.items, resetInfo);
+		expect(result.ok).toBe(true);
+		expect(result.applied).toBeGreaterThanOrEqual(1);
+
+		// Verify every field round-tripped through the bootstrap pipeline
+		const applied = db
+			.prepare(
+				"SELECT m.*, s.project as session_project FROM memory_items m JOIN sessions s ON s.id = m.session_id WHERE m.import_key = 'bootstrap-roundtrip-key'",
+			)
+			.get() as any;
+
+		expect(applied).toBeTruthy();
+		expect(applied.session_project).toBe("bootstrap-project");
+		expect(applied.kind).toBe("feature");
+		expect(applied.title).toBe("Bootstrap Title");
+		expect(applied.subtitle).toBe("BSub");
+		expect(applied.body_text).toBe("Bootstrap body");
+		expect(applied.confidence).toBe(0.9);
+		expect(applied.actor_id).toBe("actor-bs");
+		expect(applied.actor_display_name).toBe("Bootstrap Actor");
+		expect(applied.visibility).toBe("shared");
+		expect(applied.workspace_id).toBe("ws-bs");
+		expect(applied.workspace_kind).toBe("shared");
+		expect(applied.origin_device_id).toBe("device-bs-origin");
+		expect(applied.origin_source).toBe("bootstrap-test");
+		expect(applied.trust_state).toBe("trusted");
+		expect(applied.narrative).toBe("Bootstrap narrative");
+		expect(applied.user_prompt_id).toBe(99);
+		expect(applied.prompt_number).toBe(3);
+	});
+});

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -105,6 +105,7 @@ interface MemoryPayload {
 	deleted_at: string | null;
 	rev: number;
 	import_key: string | null;
+	project?: string | null;
 }
 
 function asNumberOrNull(value: unknown): number | null {
@@ -168,6 +169,7 @@ function parseMemoryPayload(op: ReplicationOp, errors: string[]): MemoryPayload 
 		deleted_at: asStringOrNull(raw.deleted_at),
 		rev: asNumberOrNull(raw.rev) ?? 0,
 		import_key: asStringOrNull(raw.import_key),
+		project: asStringOrNull(raw.project),
 	};
 }
 
@@ -546,6 +548,15 @@ export function recordReplicationOp(
 			? metadata.clock_device_id
 			: opts.deviceId;
 
+	// Resolve session project so peers can reconstruct the project association.
+	const sessionProject = row?.session_id
+		? (d
+				.select({ project: schema.sessions.project })
+				.from(schema.sessions)
+				.where(eq(schema.sessions.id, row.session_id))
+				.get()?.project ?? null)
+		: null;
+
 	// Build payload from the memory row so peers can reconstruct the full item.
 	// Explicit payload override takes precedence (used by tests).
 	let payloadJson: string | null;
@@ -563,6 +574,7 @@ export function recordReplicationOp(
 		};
 
 		payloadJson = toJson({
+			project: sessionProject,
 			session_id: row.session_id,
 			kind: row.kind,
 			title: row.title,
@@ -822,10 +834,13 @@ export function loadMemorySnapshotPageForPeer(
 				typeof metadata.clock_device_id === "string" && metadata.clock_device_id.trim()
 					? metadata.clock_device_id.trim()
 					: String(row.memory.origin_device_id ?? "local");
+			// Include session project in the payload so targets can associate
+			// replicated memories with the correct project.
+			const payloadWithProject = { ...payload, project: row.sessionProject ?? null };
 			items.push({
 				entity_id: importKey,
 				op_type: row.memory.deleted_at || row.memory.active === 0 ? "delete" : "upsert",
-				payload_json: toJson(payload),
+				payload_json: toJson(payloadWithProject),
 				clock_rev: Number(row.memory.rev ?? 0),
 				clock_updated_at: String(
 					row.memory.updated_at ?? row.memory.created_at ?? new Date().toISOString(),
@@ -1792,6 +1807,8 @@ export function applyReplicationOps(
 								concepts: toJsonNullable(payload.concepts),
 								files_read: toJsonNullable(payload.files_read),
 								files_modified: toJsonNullable(payload.files_modified),
+								user_prompt_id: payload.user_prompt_id,
+								prompt_number: payload.prompt_number,
 							})
 							.where(eq(schema.memoryItems.import_key, importKey))
 							.run();
@@ -1799,7 +1816,16 @@ export function applyReplicationOps(
 						// Insert new memory item — skip if malformed
 						const payload = parseMemoryPayload(op, result.errors);
 						if (!payload) continue;
-						const sessionId = ensureSessionForReplication(d, null, op.clock_updated_at);
+						const replicatedProject =
+							typeof payload.project === "string" && payload.project.trim()
+								? payload.project.trim()
+								: null;
+						const sessionId = ensureSessionForReplication(
+							d,
+							null,
+							op.clock_updated_at,
+							replicatedProject,
+						);
 						const metaObj = mergePayloadMetadata(payload.metadata_json, op.clock_device_id);
 
 						d.insert(schema.memoryItems)
@@ -1831,6 +1857,8 @@ export function applyReplicationOps(
 								concepts: toJsonNullable(payload.concepts),
 								files_read: toJsonNullable(payload.files_read),
 								files_modified: toJsonNullable(payload.files_modified),
+								user_prompt_id: payload.user_prompt_id,
+								prompt_number: payload.prompt_number,
 							})
 							.run();
 					}
@@ -1919,6 +1947,7 @@ function ensureSessionForReplication(
 	d: ReturnType<typeof drizzle>,
 	sessionId: number | null,
 	createdAt: string,
+	project?: string | null,
 ): number {
 	if (sessionId != null) {
 		const row = d
@@ -1928,12 +1957,13 @@ function ensureSessionForReplication(
 			.get();
 		if (row) return sessionId;
 	}
-	// Create a new session for replicated data
+	// Create a new session for replicated data, preserving the source project.
 	const now = createdAt || new Date().toISOString();
 	const rows = d
 		.insert(schema.sessions)
 		.values({
 			started_at: now,
+			project: project ?? null,
 			user: "sync",
 			tool_version: "sync_replication",
 			metadata_json: toJson({ source: "sync" }),


### PR DESCRIPTION
## Description

Fixes synced memories showing "project: n/a" on target nodes because replication ops never included the session's project field.

### Root cause

`recordReplicationOp` and the snapshot page builder both used `buildPayloadFromMemoryRow` which only reads from `memory_items` — never joining the session table for the project. When the target node created a replication session via `ensureSessionForReplication`, it set `project: null`.

### Fix

1. `recordReplicationOp` now resolves and includes `project` from the source session in the op payload
2. Snapshot page builder includes `project` from `row.sessionProject` in snapshot item payloads
3. `ensureSessionForReplication` now accepts and sets `project` when creating replication sessions
4. `MemoryPayload` type updated with optional `project` field
5. `applyReplicationOps` passes `payload.project` through to session creation

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] `pnpm --filter @codemem/core typecheck`
- [x] `pnpm --filter @codemem/core exec vitest run src/sync-replication.test.ts src/sync-pass.test.ts` (99 passed)