### PR TITLE
fix(sync): include session project in replication ops

### DIFF
--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1539,6 +1539,33 @@ describe("applyReplicationOps", () => {
 		expect(result.applied).toBe(0);
 	});
 
+	it("preserves project on newly replicated memories", () => {
+		const op = makeReplicationOp({
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Remote memory",
+				body_text: "Remote body",
+				visibility: "shared",
+				project: "proj-replicated",
+			}),
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+
+		const row = db
+			.prepare(
+				`SELECT s.project
+				   FROM memory_items m
+				   JOIN sessions s ON s.id = m.session_id
+				  WHERE m.import_key = ?
+				  LIMIT 1`,
+			)
+			.get(op.entity_id) as { project: string | null } | undefined;
+
+		expect(row?.project).toBe("proj-replicated");
+	});
+
 	it("skips duplicate op_ids (idempotent)", () => {
 		const op = makeReplicationOp({ op_id: "fixed-op-id" });
 		const r1 = applyReplicationOps(db, [op], "dev-local");


### PR DESCRIPTION
## Description
This base PR carries the existing `opencode/misty-mountain` branch that the E2E stack is built on top of. It is included so the stacked E2E harness PRs can land cleanly with the correct base history.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced