### PR TITLE
add seeded coordinator E2E scenario

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,6 +7,8 @@ This directory holds the first local Docker/Compose-based E2E harness for sync s
 - Docker Compose topology for `coordinator`, `peer-a`, and `peer-b`
 - host-run TypeScript runner
 - smoke scenario for stack bring-up and coordinator reachability
+- coordinator invite/join/approval/discovery scenario
+- seed modes: `empty`, `fixture-small`, `fixture-large`, `local-import`
 - automatic artifact capture under `.tmp/e2e-artifacts/`
 
 ## Run the smoke scenario
@@ -19,6 +21,20 @@ Or:
 
 ```fish
 pnpm run e2e -- smoke
+```
+
+## Run the coordinator scenario
+
+```fish
+pnpm run e2e:coordinator
+```
+
+## Local import seed mode
+
+When you want to use a local export payload instead of synthetic fixtures for a run:
+
+```fish
+set -lx CODEMEM_E2E_LOCAL_IMPORT /absolute/path/to/export.json
 ```
 
 ## Keep the stack around after the run

--- a/e2e/bin/run-local.ts
+++ b/e2e/bin/run-local.ts
@@ -1,7 +1,9 @@
+import { runCoordinatorScenario } from "../scenarios/coordinator.js";
 import { runSmokeScenario } from "../scenarios/smoke.js";
 import { createScenarioContext } from "../lib/scenario-context.js";
 
 const scenarios = {
+	coordinator: runCoordinatorScenario,
 	smoke: runSmokeScenario,
 } as const;
 

--- a/e2e/lib/seed.ts
+++ b/e2e/lib/seed.ts
@@ -1,0 +1,54 @@
+import { existsSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { assert } from "./assert.js";
+import type { ComposeManager } from "./compose.js";
+
+export type SeedMode = "empty" | "fixture-small" | "fixture-large" | "local-import";
+
+const CLI_PREFIX = ["pnpm", "exec", "tsx", "--conditions", "source", "packages/cli/src/index.ts"];
+const TSX_PREFIX = ["pnpm", "exec", "tsx", "--conditions", "source"];
+
+export function seedPeer(
+	compose: ComposeManager,
+	artifactsDir: string,
+	service: string,
+	mode: SeedMode,
+	artifactName: string,
+	dbPath = "/data/mem.sqlite",
+): void {
+	if (mode === "local-import") {
+		const inputFile = process.env.CODEMEM_E2E_LOCAL_IMPORT?.trim();
+		assert(inputFile, "CODEMEM_E2E_LOCAL_IMPORT is required for local-import seed mode");
+		const resolvedInput = resolve(inputFile);
+		assert(existsSync(resolvedInput), `Local import payload not found: ${resolvedInput}`);
+		const containerPath = `${service}:/tmp/${basename(resolvedInput)}`;
+		compose.copyToContainer(resolvedInput, containerPath, `${artifactName}-copy-local-import`);
+		compose.exec(
+			service,
+			[...CLI_PREFIX, "import-memories", `/tmp/${basename(resolvedInput)}`, "--db-path", dbPath],
+			`${artifactName}-import-local-import`,
+			300_000,
+		);
+		return;
+	}
+
+	compose.exec(
+		service,
+		[
+			...TSX_PREFIX,
+			"e2e/seeds/load.ts",
+			"--mode",
+			mode,
+			"--db-path",
+			dbPath,
+		],
+		artifactName,
+		300_000,
+	);
+
+	compose.copyFromContainer(
+		`${service}:${dbPath}`,
+		join(artifactsDir, "db", `${service}-${mode}.sqlite`),
+		`${artifactName}-db-snapshot`,
+	);
+}

--- a/e2e/scenarios/coordinator.ts
+++ b/e2e/scenarios/coordinator.ts
@@ -1,0 +1,256 @@
+import { assert, assertStatus } from "../lib/assert.js";
+import type { ScenarioContext } from "../lib/scenario-context.js";
+import { seedPeer } from "../lib/seed.js";
+import { waitFor } from "../lib/wait.js";
+
+const CLI_PREFIX = ["pnpm", "exec", "tsx", "--conditions", "source", "packages/cli/src/index.ts"];
+const GROUP_ID = "e2e-team";
+const ADMIN_SECRET = "e2e-admin-secret";
+
+function parseJson<T>(raw: string, label: string): T {
+	try {
+		return JSON.parse(raw) as T;
+	} catch (error) {
+		throw new Error(`Failed to parse JSON for ${label}: ${error instanceof Error ? error.message : String(error)}`);
+	}
+}
+
+function readPeerIdentity(
+	ctx: ScenarioContext,
+	service: string,
+	artifactName: string,
+): { device_id: string; fingerprint: string; public_key: string } {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"pnpm",
+			"exec",
+			"tsx",
+			"--conditions",
+			"source",
+			"e2e/scripts/peer-identity.ts",
+		],
+		artifactName,
+		60_000,
+	);
+	assertStatus(result.status, 0, `failed to read identity for ${service}`);
+	return parseJson<{ device_id: string; fingerprint: string; public_key: string }>(
+		result.stdout,
+		`${service}:identity`,
+	);
+}
+
+function writePeerConfig(ctx: ScenarioContext, service: string, values: Record<string, unknown>, artifactName: string) {
+	const script = `import { mkdirSync, writeFileSync } from 'node:fs'; mkdirSync('/config', { recursive: true }); writeFileSync('/config/codemem.json', JSON.stringify(${JSON.stringify(values)}, null, 2));`;
+	const result = ctx.compose.exec(
+		service,
+		["node", "--input-type=module", "-e", script],
+		artifactName,
+		30_000,
+	);
+	assertStatus(result.status, 0, `failed to write config for ${service}`);
+}
+
+function fetchCoordinatorSnapshot<T>(ctx: ScenarioContext, service: string, artifactName: string): T {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"pnpm",
+			"exec",
+			"tsx",
+			"--conditions",
+			"source",
+			"e2e/scripts/coordinator-status.ts",
+			"--db-path",
+			"/data/mem.sqlite",
+			"--run-tick",
+		],
+		artifactName,
+		120_000,
+	);
+	assertStatus(result.status, 0, `failed to fetch coordinator snapshot from ${service}`);
+	return parseJson<T>(result.stdout, `${service}:coordinator-snapshot`);
+}
+
+export async function runCoordinatorScenario(ctx: ScenarioContext): Promise<void> {
+	ctx.recordNote(
+		"scenario.txt",
+		"Coordinator scenario: configure admin peer, create approval-required invite, import on joiner peer, approve join request, start both peer viewers, and wait for coordinator-discovered devices on both peers.",
+	);
+
+	ctx.compose.down("00-compose-down-pre", true);
+	ctx.compose.up(["coordinator", "peer-a", "peer-b"], "01-compose-up");
+	ctx.compose.ps("02-compose-ps");
+
+	seedPeer(ctx.compose, ctx.artifactsDir, "peer-a", "empty", "03-seed-peer-a-empty");
+	seedPeer(ctx.compose, ctx.artifactsDir, "peer-b", "empty", "04-seed-peer-b-empty");
+
+	writePeerConfig(
+		ctx,
+		"peer-a",
+		{
+			sync_enabled: true,
+			sync_host: "0.0.0.0",
+			sync_port: 7337,
+			sync_interval_s: 5,
+			sync_coordinator_url: "http://coordinator:7347",
+			sync_coordinator_group: GROUP_ID,
+			sync_coordinator_admin_secret: ADMIN_SECRET,
+		},
+		"05-write-peer-a-config",
+	);
+
+	const enablePeerA = ctx.compose.exec(
+		"peer-a",
+		[...CLI_PREFIX, "sync", "enable", "--db-path", "/data/mem.sqlite", "--host", "0.0.0.0", "--port", "7337", "--interval", "5"],
+		"06-enable-peer-a",
+		120_000,
+	);
+	assertStatus(enablePeerA.status, 0, "failed to enable sync on peer-a");
+
+	const groupCreate = ctx.compose.exec(
+		"coordinator",
+		[...CLI_PREFIX, "sync", "coordinator", "group-create", GROUP_ID, "--db-path", "/data/coordinator.sqlite"],
+		"07-group-create",
+		120_000,
+	);
+	assertStatus(groupCreate.status, 0, "failed to create coordinator group");
+
+	const peerAIdentity = readPeerIdentity(ctx, "peer-a", "08-peer-a-identity");
+	assert(peerAIdentity.device_id, "peer-a identity missing device_id");
+	assert(peerAIdentity.fingerprint, "peer-a identity missing fingerprint");
+	assert(peerAIdentity.public_key, "peer-a identity missing public key");
+
+	const enrollPeerA = ctx.compose.exec(
+		"coordinator",
+		[
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"enroll-device",
+			GROUP_ID,
+			peerAIdentity.device_id,
+			"--fingerprint",
+			peerAIdentity.fingerprint,
+			"--public-key",
+			peerAIdentity.public_key,
+			"--db-path",
+			"/data/coordinator.sqlite",
+			"--json",
+		],
+		"09-enroll-peer-a",
+		120_000,
+	);
+	assertStatus(enrollPeerA.status, 0, "failed to enroll peer-a in coordinator");
+
+	const inviteResult = ctx.compose.exec(
+		"peer-a",
+		[...CLI_PREFIX, "sync", "coordinator", "create-invite", GROUP_ID, "--policy", "approval_required", "--json"],
+		"10-create-invite",
+		120_000,
+	);
+	assertStatus(inviteResult.status, 0, "failed to create invite");
+	const invitePayload = parseJson<{ encoded: string }>(inviteResult.stdout, "invite payload");
+	assert(invitePayload.encoded, "invite payload missing encoded invite");
+
+	const importResult = ctx.compose.exec(
+		"peer-b",
+		[
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"import-invite",
+			invitePayload.encoded,
+			"--db-path",
+			"/data/mem.sqlite",
+			"--keys-dir",
+			"/keys",
+			"--config",
+			"/config/codemem.json",
+			"--json",
+		],
+		"11-import-invite",
+		120_000,
+	);
+	assertStatus(importResult.status, 0, "failed to import invite on peer-b");
+
+	const enablePeerB = ctx.compose.exec(
+		"peer-b",
+		[...CLI_PREFIX, "sync", "enable", "--db-path", "/data/mem.sqlite", "--host", "0.0.0.0", "--port", "7337", "--interval", "5"],
+		"12-enable-peer-b",
+		120_000,
+	);
+	assertStatus(enablePeerB.status, 0, "failed to enable sync on peer-b");
+
+	const joinRequestsResult = ctx.compose.exec(
+		"coordinator",
+		[...CLI_PREFIX, "sync", "coordinator", "list-join-requests", GROUP_ID, "--db-path", "/data/coordinator.sqlite", "--json"],
+		"13-list-join-requests",
+		120_000,
+	);
+	assertStatus(joinRequestsResult.status, 0, "failed to list join requests");
+	const joinRequests = parseJson<Array<{ request_id: string }>>(joinRequestsResult.stdout, "join requests");
+	assert(joinRequests.length === 1, `expected exactly one join request, got ${joinRequests.length}`);
+
+	const approveResult = ctx.compose.exec(
+		"coordinator",
+		[
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"approve-join-request",
+			joinRequests[0]?.request_id ?? "",
+			"--db-path",
+			"/data/coordinator.sqlite",
+			"--json",
+		],
+		"14-approve-join-request",
+		120_000,
+	);
+	assertStatus(approveResult.status, 0, "failed to approve join request");
+
+	await waitFor(
+		async () => {
+			const body = fetchCoordinatorSnapshot<{ discovered_peer_count?: number; discovered_devices?: Array<{ device_id: string }> }>(
+				ctx,
+				"peer-a",
+				"13-peer-a-snapshot",
+			);
+			const devices = Array.isArray(body.discovered_devices) ? body.discovered_devices : [];
+			assert((body.discovered_peer_count ?? 0) >= 1, "peer-a has no discovered peers yet");
+			assert(devices.some((device) => String(device.device_id) !== ""), "peer-a discovered devices payload is empty");
+		},
+		{ description: "peer-a coordinator discovery", timeoutMs: 180_000, intervalMs: 3_000 },
+	);
+
+	await waitFor(
+		async () => {
+			const body = fetchCoordinatorSnapshot<{ discovered_peer_count?: number; discovered_devices?: Array<{ device_id: string }> }>(
+				ctx,
+				"peer-b",
+				"14-peer-b-snapshot",
+			);
+			const devices = Array.isArray(body.discovered_devices) ? body.discovered_devices : [];
+			assert((body.discovered_peer_count ?? 0) >= 1, "peer-b has no discovered peers yet");
+			assert(devices.some((device) => String(device.device_id) !== ""), "peer-b discovered devices payload is empty");
+		},
+		{ description: "peer-b coordinator discovery", timeoutMs: 180_000, intervalMs: 3_000 },
+	);
+
+	const peerAStatus = fetchCoordinatorSnapshot<Record<string, unknown>>(
+		ctx,
+		"peer-a",
+		"15-peer-a-final-snapshot",
+	);
+	const peerBStatus = fetchCoordinatorSnapshot<Record<string, unknown>>(
+		ctx,
+		"peer-b",
+		"16-peer-b-final-snapshot",
+	);
+	ctx.recordNote("final-status-peer-a.json", JSON.stringify(peerAStatus, null, 2));
+	ctx.recordNote("final-status-peer-b.json", JSON.stringify(peerBStatus, null, 2));
+
+	if (!ctx.keepStackOnFailure) {
+		ctx.compose.down("17-compose-down-post");
+	}
+}

--- a/e2e/scripts/coordinator-status.ts
+++ b/e2e/scripts/coordinator-status.ts
@@ -1,0 +1,42 @@
+import {
+	coordinatorStatusSnapshot,
+	MemoryStore,
+	readCoordinatorSyncConfig,
+	resolveDbPath,
+} from "../../packages/core/src/index.ts";
+import { runTickOnce } from "../../packages/core/src/sync-daemon.ts";
+
+function parseArgs(argv: string[]): { dbPath: string; runTick: boolean } {
+	let dbPath = "/data/mem.sqlite";
+	let runTick = false;
+	for (let index = 2; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--db-path") {
+			dbPath = String(argv[index + 1] ?? dbPath);
+			index += 1;
+		} else if (arg === "--run-tick") {
+			runTick = true;
+		}
+	}
+	return { dbPath, runTick };
+}
+
+async function main(): Promise<void> {
+	const { dbPath, runTick } = parseArgs(process.argv);
+	const resolvedDbPath = resolveDbPath(dbPath);
+	if (runTick) {
+		await runTickOnce(resolvedDbPath, process.env.CODEMEM_KEYS_DIR?.trim() || undefined);
+	}
+	const store = new MemoryStore(resolvedDbPath);
+	try {
+		const snapshot = await coordinatorStatusSnapshot(store, readCoordinatorSyncConfig());
+		console.log(JSON.stringify(snapshot, null, 2));
+	} finally {
+		store.close();
+	}
+}
+
+void main().catch((error) => {
+	console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/e2e/scripts/peer-identity.ts
+++ b/e2e/scripts/peer-identity.ts
@@ -1,0 +1,21 @@
+import { connect } from "../../packages/core/src/db.ts";
+import { ensureDeviceIdentity, loadPublicKey } from "../../packages/core/src/index.ts";
+
+const db = connect("/data/mem.sqlite");
+try {
+	const [deviceId, fingerprint] = ensureDeviceIdentity(db, { keysDir: "/keys" });
+	const publicKey = loadPublicKey("/keys");
+	console.log(
+		JSON.stringify(
+			{
+				device_id: deviceId,
+				fingerprint,
+				public_key: publicKey,
+			},
+			null,
+			2,
+		),
+	);
+} finally {
+	db.close();
+}

--- a/e2e/seeds/load.ts
+++ b/e2e/seeds/load.ts
@@ -1,0 +1,95 @@
+import { initDatabase, MemoryStore, resolveDbPath } from "../../packages/core/src/index.ts";
+
+type SeedMode = "empty" | "fixture-small" | "fixture-large";
+
+function parseArgs(argv: string[]): { mode: SeedMode; dbPath: string } {
+	let mode: SeedMode = "empty";
+	let dbPath = "/data/mem.sqlite";
+	for (let index = 2; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--mode") {
+			mode = String(argv[index + 1] ?? "empty") as SeedMode;
+			index += 1;
+		} else if (arg === "--db-path") {
+			dbPath = String(argv[index + 1] ?? dbPath);
+			index += 1;
+		}
+	}
+	if (!["empty", "fixture-small", "fixture-large"].includes(mode)) {
+		throw new Error(`Unsupported seed mode: ${mode}`);
+	}
+	return { mode, dbPath };
+}
+
+function isoAt(offsetMinutes: number): string {
+	return new Date(Date.UTC(2026, 0, 1, 12, 0 + offsetMinutes, 0)).toISOString();
+}
+
+function createFixture(store: MemoryStore, mode: Exclude<SeedMode, "empty">): number {
+	const batchSize = mode === "fixture-large" ? 240 : 12;
+	const sessionCount = mode === "fixture-large" ? 8 : 2;
+	let created = 0;
+	for (let sessionIndex = 0; sessionIndex < sessionCount; sessionIndex += 1) {
+		const sessionId = store.startSession({
+			cwd: `/workspace/e2e-fixture-${sessionIndex}`,
+			project: sessionIndex % 2 === 0 ? "e2e-project-alpha" : "e2e-project-beta",
+			user: "e2e",
+			toolVersion: "e2e-seed",
+			metadata: { seed_mode: mode, session_index: sessionIndex },
+		});
+		for (let memoryIndex = 0; memoryIndex < batchSize; memoryIndex += 1) {
+			const ordinal = sessionIndex * batchSize + memoryIndex;
+			const shared = ordinal % 3 !== 0;
+			const title = `${mode} memory ${ordinal.toString().padStart(4, "0")}`;
+			const body = `Synthetic ${shared ? "shared" : "private"} fixture memory ${ordinal} for ${mode}.`;
+			store.remember(sessionId, ordinal % 2 === 0 ? "feature" : "discovery", title, body, 0.5, [mode], {
+				visibility: shared ? "shared" : "private",
+				workspace_kind: shared ? "shared" : "personal",
+				workspace_id: shared ? `shared:${sessionIndex % 2 === 0 ? "alpha" : "beta"}` : undefined,
+				files_read: [`src/e2e/${mode}/${ordinal}.ts`],
+				created_at: isoAt(ordinal),
+				updated_at: isoAt(ordinal),
+				seed_mode: mode,
+				seed_ordinal: ordinal,
+			});
+			created += 1;
+		}
+		store.endSession(sessionId, { seed_mode: mode, created_count: batchSize });
+	}
+	return created;
+}
+
+async function main(): Promise<void> {
+	process.env.CODEMEM_EMBEDDING_DISABLED = process.env.CODEMEM_EMBEDDING_DISABLED || "1";
+	const { mode, dbPath } = parseArgs(process.argv);
+	const resolvedDbPath = resolveDbPath(dbPath);
+	initDatabase(resolvedDbPath);
+	const store = new MemoryStore(resolvedDbPath);
+	try {
+		let created = 0;
+		if (mode !== "empty") {
+			created = createFixture(store, mode);
+			await store.flushPendingVectorWrites();
+		}
+		console.log(
+			JSON.stringify(
+				{
+					ok: true,
+					mode,
+					db_path: resolvedDbPath,
+					created_memories: created,
+					device_id: store.deviceId,
+				},
+				null,
+				2,
+			),
+		);
+	} finally {
+		store.close();
+	}
+}
+
+void main().catch((error) => {
+	console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "clean": "pnpm -r run clean && pnpm exec tsc --build --clean",
     "build": "pnpm -r run build && pnpm exec tsc --build",
     "e2e": "pnpm exec tsx e2e/bin/run-local.ts",
+    "e2e:coordinator": "pnpm exec tsx e2e/bin/run-local.ts coordinator",
     "e2e:smoke": "pnpm exec tsx e2e/bin/run-local.ts smoke",
     "test": "pnpm exec vitest run",
     "test:watch": "pnpm exec vitest",


### PR DESCRIPTION
## Description
This PR adds the first real multi-node sync workflow on top of the harness foundation: deterministic seed generation plus coordinator invite, join, approval, and discovery validation. It proves that enrolled peers can discover each other through the coordinator using reproducible local test data.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

  Verified with:
  - `pnpm run e2e:smoke`
  - `pnpm run e2e:coordinator`
  - targeted `fixture-small` seed loader validation

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] No new warnings introduced