### PR TITLE
add direct sync E2E validation

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -26,8 +26,6 @@ services:
     environment:
       CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET: e2e-admin-secret
       CODEMEM_EMBEDDING_DISABLED: "1"
-    ports:
-      - "17347:7347"
     volumes:
       - coordinator-data:/data
       - coordinator-config:/config
@@ -58,6 +56,7 @@ services:
       CODEMEM_CONFIG: /config/codemem.json
       CODEMEM_KEYS_DIR: /keys
       CODEMEM_EMBEDDING_DISABLED: "1"
+      CODEMEM_SYNC_AUTH_DIAGNOSTICS: "1"
     depends_on:
       coordinator:
         condition: service_healthy
@@ -78,6 +77,7 @@ services:
       CODEMEM_CONFIG: /config/codemem.json
       CODEMEM_KEYS_DIR: /keys
       CODEMEM_EMBEDDING_DISABLED: "1"
+      CODEMEM_SYNC_AUTH_DIAGNOSTICS: "1"
     depends_on:
       coordinator:
         condition: service_healthy
@@ -99,6 +99,7 @@ services:
       CODEMEM_CONFIG: /config/codemem.json
       CODEMEM_KEYS_DIR: /keys
       CODEMEM_EMBEDDING_DISABLED: "1"
+      CODEMEM_SYNC_AUTH_DIAGNOSTICS: "1"
     depends_on:
       coordinator:
         condition: service_healthy

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -8,6 +8,7 @@ This directory holds the first local Docker/Compose-based E2E harness for sync s
 - host-run TypeScript runner
 - smoke scenario for stack bring-up and coordinator reachability
 - coordinator invite/join/approval/discovery scenario
+- direct peer sync scenario with data-plane assertions
 - seed modes: `empty`, `fixture-small`, `fixture-large`, `local-import`
 - automatic artifact capture under `.tmp/e2e-artifacts/`
 
@@ -27,6 +28,12 @@ pnpm run e2e -- smoke
 
 ```fish
 pnpm run e2e:coordinator
+```
+
+## Run the direct sync scenario
+
+```fish
+pnpm run e2e:direct-sync
 ```
 
 ## Local import seed mode

--- a/e2e/bin/run-local.ts
+++ b/e2e/bin/run-local.ts
@@ -1,9 +1,11 @@
 import { runCoordinatorScenario } from "../scenarios/coordinator.js";
+import { runDirectSyncScenario } from "../scenarios/direct-sync.js";
 import { runSmokeScenario } from "../scenarios/smoke.js";
 import { createScenarioContext } from "../lib/scenario-context.js";
 
 const scenarios = {
 	coordinator: runCoordinatorScenario,
+	directSync: runDirectSyncScenario,
 	smoke: runSmokeScenario,
 } as const;
 

--- a/e2e/lib/coordinator.ts
+++ b/e2e/lib/coordinator.ts
@@ -1,0 +1,75 @@
+import { assertStatus } from "./assert.js";
+import type { ScenarioContext } from "./scenario-context.js";
+
+export const CLI_PREFIX = ["pnpm", "exec", "tsx", "--conditions", "source", "packages/cli/src/index.ts"];
+export const GROUP_ID = "e2e-team";
+export const ADMIN_SECRET = "e2e-admin-secret";
+
+export function parseJson<T>(raw: string, label: string): T {
+	try {
+		return JSON.parse(raw) as T;
+	} catch (error) {
+		throw new Error(
+			`Failed to parse JSON for ${label}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+export function readPeerIdentity(
+	ctx: ScenarioContext,
+	service: string,
+	artifactName: string,
+): { device_id: string; fingerprint: string; public_key: string } {
+	const result = ctx.compose.exec(
+		service,
+		["pnpm", "exec", "tsx", "--conditions", "source", "e2e/scripts/peer-identity.ts"],
+		artifactName,
+		60_000,
+	);
+	assertStatus(result.status, 0, `failed to read identity for ${service}`);
+	return parseJson<{ device_id: string; fingerprint: string; public_key: string }>(
+		result.stdout,
+		`${service}:identity`,
+	);
+}
+
+export function writePeerConfig(
+	ctx: ScenarioContext,
+	service: string,
+	values: Record<string, unknown>,
+	artifactName: string,
+) {
+	const script = `import { mkdirSync, writeFileSync } from 'node:fs'; mkdirSync('/config', { recursive: true }); writeFileSync('/config/codemem.json', JSON.stringify(${JSON.stringify(values)}, null, 2));`;
+	const result = ctx.compose.exec(
+		service,
+		["node", "--input-type=module", "-e", script],
+		artifactName,
+		30_000,
+	);
+	assertStatus(result.status, 0, `failed to write config for ${service}`);
+}
+
+export function fetchCoordinatorSnapshot<T>(
+	ctx: ScenarioContext,
+	service: string,
+	artifactName: string,
+): T {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"pnpm",
+			"exec",
+			"tsx",
+			"--conditions",
+			"source",
+			"e2e/scripts/coordinator-status.ts",
+			"--db-path",
+			"/data/mem.sqlite",
+			"--run-tick",
+		],
+		artifactName,
+		120_000,
+	);
+	assertStatus(result.status, 0, `failed to fetch coordinator snapshot from ${service}`);
+	return parseJson<T>(result.stdout, `${service}:coordinator-snapshot`);
+}

--- a/e2e/scenarios/coordinator.ts
+++ b/e2e/scenarios/coordinator.ts
@@ -1,76 +1,16 @@
 import { assert, assertStatus } from "../lib/assert.js";
+import {
+	ADMIN_SECRET,
+	CLI_PREFIX,
+	fetchCoordinatorSnapshot,
+	GROUP_ID,
+	parseJson,
+	readPeerIdentity,
+	writePeerConfig,
+} from "../lib/coordinator.js";
 import type { ScenarioContext } from "../lib/scenario-context.js";
 import { seedPeer } from "../lib/seed.js";
 import { waitFor } from "../lib/wait.js";
-
-const CLI_PREFIX = ["pnpm", "exec", "tsx", "--conditions", "source", "packages/cli/src/index.ts"];
-const GROUP_ID = "e2e-team";
-const ADMIN_SECRET = "e2e-admin-secret";
-
-function parseJson<T>(raw: string, label: string): T {
-	try {
-		return JSON.parse(raw) as T;
-	} catch (error) {
-		throw new Error(`Failed to parse JSON for ${label}: ${error instanceof Error ? error.message : String(error)}`);
-	}
-}
-
-function readPeerIdentity(
-	ctx: ScenarioContext,
-	service: string,
-	artifactName: string,
-): { device_id: string; fingerprint: string; public_key: string } {
-	const result = ctx.compose.exec(
-		service,
-		[
-			"pnpm",
-			"exec",
-			"tsx",
-			"--conditions",
-			"source",
-			"e2e/scripts/peer-identity.ts",
-		],
-		artifactName,
-		60_000,
-	);
-	assertStatus(result.status, 0, `failed to read identity for ${service}`);
-	return parseJson<{ device_id: string; fingerprint: string; public_key: string }>(
-		result.stdout,
-		`${service}:identity`,
-	);
-}
-
-function writePeerConfig(ctx: ScenarioContext, service: string, values: Record<string, unknown>, artifactName: string) {
-	const script = `import { mkdirSync, writeFileSync } from 'node:fs'; mkdirSync('/config', { recursive: true }); writeFileSync('/config/codemem.json', JSON.stringify(${JSON.stringify(values)}, null, 2));`;
-	const result = ctx.compose.exec(
-		service,
-		["node", "--input-type=module", "-e", script],
-		artifactName,
-		30_000,
-	);
-	assertStatus(result.status, 0, `failed to write config for ${service}`);
-}
-
-function fetchCoordinatorSnapshot<T>(ctx: ScenarioContext, service: string, artifactName: string): T {
-	const result = ctx.compose.exec(
-		service,
-		[
-			"pnpm",
-			"exec",
-			"tsx",
-			"--conditions",
-			"source",
-			"e2e/scripts/coordinator-status.ts",
-			"--db-path",
-			"/data/mem.sqlite",
-			"--run-tick",
-		],
-		artifactName,
-		120_000,
-	);
-	assertStatus(result.status, 0, `failed to fetch coordinator snapshot from ${service}`);
-	return parseJson<T>(result.stdout, `${service}:coordinator-snapshot`);
-}
 
 export async function runCoordinatorScenario(ctx: ScenarioContext): Promise<void> {
 	ctx.recordNote(

--- a/e2e/scenarios/direct-sync.ts
+++ b/e2e/scenarios/direct-sync.ts
@@ -1,0 +1,341 @@
+import { assert, assertStatus } from "../lib/assert.js";
+import {
+	ADMIN_SECRET,
+	CLI_PREFIX,
+	fetchCoordinatorSnapshot,
+	GROUP_ID,
+	parseJson,
+	readPeerIdentity,
+	writePeerConfig,
+} from "../lib/coordinator.js";
+import type { ScenarioContext } from "../lib/scenario-context.js";
+import { seedPeer } from "../lib/seed.js";
+import { waitFor } from "../lib/wait.js";
+
+function fetchFixtureSummary(
+	ctx: ScenarioContext,
+	service: string,
+	artifactName: string,
+): {
+	total: number;
+	shared_count: number;
+	private_count: number;
+	shared_titles: string[];
+	private_titles: string[];
+} {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"pnpm",
+			"exec",
+			"tsx",
+			"--conditions",
+			"source",
+			"e2e/scripts/fixture-summary.ts",
+			"--db-path",
+			"/data/mem.sqlite",
+		],
+		artifactName,
+		60_000,
+	);
+	assertStatus(result.status, 0, `failed to fetch fixture summary for ${service}`);
+	return parseJson(result.stdout, `${service}:fixture-summary`);
+}
+
+function startSyncServer(ctx: ScenarioContext, service: string, artifactName: string) {
+	const prepareStaticDir = ctx.compose.exec(
+		service,
+		[
+			"node",
+			"--input-type=module",
+			"-e",
+			"import { mkdirSync, writeFileSync } from 'node:fs'; mkdirSync('/tmp/viewer-static', { recursive: true }); writeFileSync('/tmp/viewer-static/index.html', '<!doctype html><title>e2e</title>');",
+		],
+		`${artifactName}-prepare-static`,
+		30_000,
+	);
+	assertStatus(prepareStaticDir.status, 0, `failed to prepare static dir for ${service}`);
+	const result = ctx.compose.execDetached(
+		service,
+		[
+			"env",
+			"CODEMEM_VIEWER_STATIC_DIR=/tmp/viewer-static",
+			...CLI_PREFIX,
+			"serve",
+			"start",
+			"--foreground",
+			"--db-path",
+			"/data/mem.sqlite",
+			"--host",
+			"0.0.0.0",
+			"--port",
+			"38888",
+		],
+		artifactName,
+		120_000,
+	);
+	assertStatus(result.status, 0, `failed to start sync protocol for ${service}`);
+}
+
+function waitForSyncServer(ctx: ScenarioContext, service: string, artifactName: string) {
+	return waitFor(
+		async () => {
+			const result = ctx.compose.exec(
+				service,
+				[
+					"node",
+					"--input-type=module",
+					"-e",
+					"const res = await fetch('http://127.0.0.1:7337/'); process.exit(res.status === 404 ? 0 : 1);",
+				],
+				artifactName,
+				30_000,
+			);
+			assertStatus(result.status, 0, `${service} sync server is not ready`);
+		},
+		{ description: `${service} sync server readiness`, timeoutMs: 120_000, intervalMs: 2_000 },
+	);
+}
+
+function acceptDiscoveredPeer(
+	ctx: ScenarioContext,
+	service: string,
+	peerDeviceId: string,
+	fingerprint: string,
+	artifactName: string,
+) {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"pnpm",
+			"exec",
+			"tsx",
+			"--conditions",
+			"source",
+			"e2e/scripts/accept-discovered.ts",
+			"--peer-device-id",
+			peerDeviceId,
+			"--fingerprint",
+			fingerprint,
+			"--db-path",
+			"/data/mem.sqlite",
+		],
+		artifactName,
+		120_000,
+	);
+	assertStatus(result.status, 0, `failed to accept discovered peer ${peerDeviceId} on ${service}`);
+	return parseJson<{ ok: boolean; created: boolean; updated: boolean }>(result.stdout, artifactName);
+}
+
+export async function runDirectSyncScenario(ctx: ScenarioContext): Promise<void> {
+	ctx.recordNote(
+		"scenario.txt",
+		"Direct sync scenario: seed peer-a with fixture-small, onboard peer-b via coordinator, accept discovered peers on both sides, run direct sync, and assert only shared fixture data replicates.",
+	);
+
+	ctx.compose.down("00-compose-down-pre", true);
+	ctx.compose.up(["coordinator", "peer-a", "peer-b"], "01-compose-up");
+	ctx.compose.ps("02-compose-ps");
+
+	seedPeer(ctx.compose, ctx.artifactsDir, "peer-a", "fixture-small", "03-seed-peer-a-small");
+	seedPeer(ctx.compose, ctx.artifactsDir, "peer-b", "empty", "04-seed-peer-b-empty");
+
+	writePeerConfig(
+		ctx,
+		"peer-a",
+		{
+			sync_enabled: true,
+			sync_host: "0.0.0.0",
+			sync_port: 7337,
+			sync_interval_s: 5,
+			sync_coordinator_url: "http://coordinator:7347",
+			sync_coordinator_group: GROUP_ID,
+			sync_coordinator_admin_secret: ADMIN_SECRET,
+		},
+		"05-write-peer-a-config",
+	);
+
+	const enablePeerA = ctx.compose.exec(
+		"peer-a",
+		[...CLI_PREFIX, "sync", "enable", "--db-path", "/data/mem.sqlite", "--host", "0.0.0.0", "--port", "7337", "--interval", "5"],
+		"06-enable-peer-a",
+		120_000,
+	);
+	assertStatus(enablePeerA.status, 0, "failed to enable sync on peer-a");
+
+	const groupCreate = ctx.compose.exec(
+		"coordinator",
+		[...CLI_PREFIX, "sync", "coordinator", "group-create", GROUP_ID, "--db-path", "/data/coordinator.sqlite"],
+		"07-group-create",
+		120_000,
+	);
+	assertStatus(groupCreate.status, 0, "failed to create coordinator group");
+
+	const peerAIdentity = readPeerIdentity(ctx, "peer-a", "08-peer-a-identity");
+	const enrollPeerA = ctx.compose.exec(
+		"coordinator",
+		[
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"enroll-device",
+			GROUP_ID,
+			peerAIdentity.device_id,
+			"--fingerprint",
+			peerAIdentity.fingerprint,
+			"--public-key",
+			peerAIdentity.public_key,
+			"--db-path",
+			"/data/coordinator.sqlite",
+			"--json",
+		],
+		"09-enroll-peer-a",
+		120_000,
+	);
+	assertStatus(enrollPeerA.status, 0, "failed to enroll peer-a in coordinator");
+
+	const inviteResult = ctx.compose.exec(
+		"peer-a",
+		[...CLI_PREFIX, "sync", "coordinator", "create-invite", GROUP_ID, "--policy", "approval_required", "--json"],
+		"10-create-invite",
+		120_000,
+	);
+	assertStatus(inviteResult.status, 0, "failed to create invite");
+	const invitePayload = parseJson<{ encoded: string }>(inviteResult.stdout, "invite payload");
+
+	const importResult = ctx.compose.exec(
+		"peer-b",
+		[
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"import-invite",
+			invitePayload.encoded,
+			"--db-path",
+			"/data/mem.sqlite",
+			"--keys-dir",
+			"/keys",
+			"--config",
+			"/config/codemem.json",
+			"--json",
+		],
+		"11-import-invite",
+		120_000,
+	);
+	assertStatus(importResult.status, 0, "failed to import invite on peer-b");
+
+	const enablePeerB = ctx.compose.exec(
+		"peer-b",
+		[...CLI_PREFIX, "sync", "enable", "--db-path", "/data/mem.sqlite", "--host", "0.0.0.0", "--port", "7337", "--interval", "5"],
+		"12-enable-peer-b",
+		120_000,
+	);
+	assertStatus(enablePeerB.status, 0, "failed to enable sync on peer-b");
+
+	const joinRequestsResult = ctx.compose.exec(
+		"coordinator",
+		[...CLI_PREFIX, "sync", "coordinator", "list-join-requests", GROUP_ID, "--db-path", "/data/coordinator.sqlite", "--json"],
+		"13-list-join-requests",
+		120_000,
+	);
+	assertStatus(joinRequestsResult.status, 0, "failed to list join requests");
+	const joinRequests = parseJson<Array<{ request_id: string }>>(joinRequestsResult.stdout, "join requests");
+	assert(joinRequests.length === 1, `expected exactly one join request, got ${joinRequests.length}`);
+
+	const approveResult = ctx.compose.exec(
+		"coordinator",
+		[
+			...CLI_PREFIX,
+			"sync",
+			"coordinator",
+			"approve-join-request",
+			joinRequests[0]?.request_id ?? "",
+			"--db-path",
+			"/data/coordinator.sqlite",
+			"--json",
+		],
+		"14-approve-join-request",
+		120_000,
+	);
+	assertStatus(approveResult.status, 0, "failed to approve join request");
+
+	await waitFor(
+		async () => {
+			const body = fetchCoordinatorSnapshot<{ discovered_peer_count?: number }>(ctx, "peer-a", "15-peer-a-snapshot");
+			assert((body.discovered_peer_count ?? 0) >= 1, "peer-a has no discovered peers yet");
+		},
+		{ description: "peer-a coordinator discovery", timeoutMs: 180_000, intervalMs: 3_000 },
+	);
+	await waitFor(
+		async () => {
+			const body = fetchCoordinatorSnapshot<{ discovered_peer_count?: number }>(ctx, "peer-b", "16-peer-b-snapshot");
+			assert((body.discovered_peer_count ?? 0) >= 1, "peer-b has no discovered peers yet");
+		},
+		{ description: "peer-b coordinator discovery", timeoutMs: 180_000, intervalMs: 3_000 },
+	);
+
+	const peerBIdentity = readPeerIdentity(ctx, "peer-b", "17-peer-b-identity");
+	acceptDiscoveredPeer(ctx, "peer-a", peerBIdentity.device_id, peerBIdentity.fingerprint, "18-accept-peer-b");
+	acceptDiscoveredPeer(ctx, "peer-b", peerAIdentity.device_id, peerAIdentity.fingerprint, "19-accept-peer-a");
+
+	startSyncServer(ctx, "peer-a", "20-start-peer-a-sync-server");
+	startSyncServer(ctx, "peer-b", "21-start-peer-b-sync-server");
+	await waitForSyncServer(ctx, "peer-a", "22-peer-a-sync-ready");
+	await waitForSyncServer(ctx, "peer-b", "23-peer-b-sync-ready");
+
+	const syncPeerA = ctx.compose.exec(
+		"peer-a",
+		[...CLI_PREFIX, "sync", "once", "--db-path", "/data/mem.sqlite"],
+		"24-sync-peer-a-once",
+		180_000,
+	);
+	assertStatus(syncPeerA.status, 0, "peer-a sync once failed");
+
+	const syncPeerB = ctx.compose.exec(
+		"peer-b",
+		[...CLI_PREFIX, "sync", "once", "--db-path", "/data/mem.sqlite"],
+		"25-sync-peer-b-once",
+		180_000,
+	);
+	assertStatus(syncPeerB.status, 0, "peer-b sync once failed");
+
+	await waitFor(
+		async () => {
+			const summary = fetchFixtureSummary(ctx, "peer-b", "26-peer-b-fixture-summary");
+			assert(summary.shared_count === 16, `expected 16 shared fixture memories on peer-b, got ${summary.shared_count}`);
+			assert(summary.private_count === 0, `expected 0 private fixture memories on peer-b, got ${summary.private_count}`);
+			assert(summary.shared_titles.includes("fixture-small memory 0001"), "expected shared fixture memory 0001 on peer-b");
+			assert(!summary.shared_titles.includes("fixture-small memory 0000"), "private fixture memory 0000 should not replicate as shared");
+		},
+		{ description: "peer-b replicated fixture data", timeoutMs: 120_000, intervalMs: 3_000 },
+	);
+
+	const attemptsA = ctx.compose.exec(
+		"peer-a",
+		[...CLI_PREFIX, "sync", "attempts", "--db-path", "/data/mem.sqlite", "--json"],
+		"27-peer-a-attempts",
+		60_000,
+	);
+	assertStatus(attemptsA.status, 0, "failed to read peer-a sync attempts");
+	const attemptsB = ctx.compose.exec(
+		"peer-b",
+		[...CLI_PREFIX, "sync", "attempts", "--db-path", "/data/mem.sqlite", "--json"],
+		"28-peer-b-attempts",
+		60_000,
+	);
+	assertStatus(attemptsB.status, 0, "failed to read peer-b sync attempts");
+	const parsedAttemptsA = parseJson<Array<{ ok: number }>>(attemptsA.stdout, "peer-a attempts");
+	const parsedAttemptsB = parseJson<Array<{ ok: number }>>(attemptsB.stdout, "peer-b attempts");
+	assert(parsedAttemptsA.length > 0, "expected at least one sync attempt on peer-a");
+	assert(parsedAttemptsB.length > 0, "expected at least one sync attempt on peer-b");
+
+	ctx.compose.copyFromContainer(
+		"peer-b:/data/mem.sqlite",
+		`${ctx.artifactsDir}/db/peer-b-after-direct-sync.sqlite`,
+		"29-copy-peer-b-db",
+	);
+
+	if (!ctx.keepStackOnFailure) {
+		ctx.compose.down("30-compose-down-post");
+	}
+}

--- a/e2e/scripts/accept-discovered.ts
+++ b/e2e/scripts/accept-discovered.ts
@@ -1,0 +1,130 @@
+import {
+	createCoordinatorReciprocalApproval,
+	lookupCoordinatorPeers,
+	MemoryStore,
+	mergeAddresses,
+	readCoordinatorSyncConfig,
+} from "../../packages/core/src/index.ts";
+
+function parseArgs(argv: string[]): { peerDeviceId: string; fingerprint: string; dbPath: string } {
+	let peerDeviceId = "";
+	let fingerprint = "";
+	let dbPath = "/data/mem.sqlite";
+	for (let index = 2; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--peer-device-id") {
+			peerDeviceId = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--fingerprint") {
+			fingerprint = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--db-path") {
+			dbPath = String(argv[index + 1] ?? dbPath);
+			index += 1;
+		}
+	}
+	if (!peerDeviceId || !fingerprint) {
+		throw new Error("--peer-device-id and --fingerprint are required");
+	}
+	return { peerDeviceId, fingerprint, dbPath };
+}
+
+async function main(): Promise<void> {
+	const { peerDeviceId, fingerprint, dbPath } = parseArgs(process.argv);
+	const store = new MemoryStore(dbPath);
+	try {
+		const config = readCoordinatorSyncConfig();
+		const discovered = await lookupCoordinatorPeers(store, config);
+		const match = discovered.find(
+			(peer) =>
+				String(peer.device_id ?? "").trim() === peerDeviceId &&
+				String(peer.fingerprint ?? "").trim() === fingerprint,
+		);
+		if (!match) throw new Error("discovered_peer_not_found");
+		const nextFingerprint = String(match.fingerprint ?? "").trim();
+		const nextPublicKey = String(match.public_key ?? "").trim();
+		const nextName = String(match.display_name ?? "").trim() || null;
+		const nextAddresses = Array.isArray(match.addresses)
+			? match.addresses.filter((value): value is string => typeof value === "string")
+			: [];
+		if (!nextPublicKey) throw new Error("discovered_peer_missing_public_key");
+		const groupIds = Array.isArray(match.groups)
+			? match.groups.map((value) => String(value ?? "").trim()).filter(Boolean)
+			: [];
+		if (groupIds.length !== 1) throw new Error("ambiguous_coordinator_group");
+		const groupId = groupIds[0] as string;
+		const existing = store.db
+			.prepare(
+				`SELECT peer_device_id, pinned_fingerprint, public_key, addresses_json
+				   FROM sync_peers
+				  WHERE peer_device_id = ?
+				  LIMIT 1`,
+			)
+			.get(peerDeviceId) as
+			| {
+					peer_device_id: string;
+					pinned_fingerprint: string | null;
+					public_key: string | null;
+					addresses_json: string | null;
+			  }
+			| undefined;
+		const existingFingerprint = String(existing?.pinned_fingerprint ?? "").trim();
+		if (existing && existingFingerprint && existingFingerprint !== nextFingerprint) {
+			throw new Error("peer_conflict");
+		}
+		const existingAddresses = (() => {
+			try {
+				const raw = JSON.parse(String(existing?.addresses_json ?? "[]"));
+				return Array.isArray(raw)
+					? raw.filter((value): value is string => typeof value === "string")
+					: [];
+			} catch {
+				return [];
+			}
+		})();
+		const addressesJson = JSON.stringify(mergeAddresses(existingAddresses, nextAddresses));
+		await createCoordinatorReciprocalApproval(store, config, { groupId, requestedDeviceId: peerDeviceId });
+		const now = new Date().toISOString();
+		let result:
+			| { ok: true; peer_device_id: string; created: boolean; updated: boolean; name: string | null }
+			| undefined;
+		if (!existing) {
+			store.db
+				.prepare(
+					`INSERT INTO sync_peers(
+						peer_device_id, name, pinned_fingerprint, public_key, addresses_json, created_at, last_seen_at
+					 ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				)
+				.run(peerDeviceId, nextName, nextFingerprint || null, nextPublicKey, addressesJson, now, now);
+			result = { ok: true, peer_device_id: peerDeviceId, created: true, updated: false, name: nextName };
+		} else {
+			store.db
+				.prepare(
+					`UPDATE sync_peers
+					    SET name = ?,
+					        pinned_fingerprint = ?,
+					        public_key = ?,
+					        addresses_json = ?,
+					        last_seen_at = ?
+					  WHERE peer_device_id = ?`,
+				)
+				.run(
+					nextName,
+					nextFingerprint || existing.pinned_fingerprint || null,
+					nextPublicKey || existing.public_key || null,
+					addressesJson,
+					now,
+					peerDeviceId,
+				);
+			result = { ok: true, peer_device_id: peerDeviceId, created: false, updated: true, name: nextName };
+		}
+		console.log(JSON.stringify(result, null, 2));
+	} finally {
+		store.close();
+	}
+}
+
+void main().catch((error) => {
+	console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/e2e/scripts/fixture-summary.ts
+++ b/e2e/scripts/fixture-summary.ts
@@ -1,0 +1,51 @@
+import { connect } from "../../packages/core/src/db.ts";
+
+function parseArgs(argv: string[]): { dbPath: string; prefix: string } {
+	let dbPath = "/data/mem.sqlite";
+	let prefix = "fixture-small memory ";
+	for (let index = 2; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--db-path") {
+			dbPath = String(argv[index + 1] ?? dbPath);
+			index += 1;
+		} else if (arg === "--prefix") {
+			prefix = String(argv[index + 1] ?? prefix);
+			index += 1;
+		}
+	}
+	return { dbPath, prefix };
+}
+
+const { dbPath, prefix } = parseArgs(process.argv);
+const db = connect(dbPath);
+try {
+	const rows = db
+		.prepare(
+			`SELECT title, visibility
+			   FROM memory_items
+			  WHERE active = 1 AND title LIKE ?
+			  ORDER BY title`,
+		)
+		.all(`${prefix}%`) as Array<{ title: string; visibility: string | null }>;
+	const sharedTitles = rows
+		.filter((row) => String(row.visibility ?? "shared").trim() !== "private")
+		.map((row) => row.title);
+	const privateTitles = rows
+		.filter((row) => String(row.visibility ?? "").trim() === "private")
+		.map((row) => row.title);
+	console.log(
+		JSON.stringify(
+			{
+				total: rows.length,
+				shared_count: sharedTitles.length,
+				private_count: privateTitles.length,
+				shared_titles: sharedTitles,
+				private_titles: privateTitles,
+			},
+			null,
+			2,
+		),
+	);
+} finally {
+	db.close();
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm -r run build && pnpm exec tsc --build",
     "e2e": "pnpm exec tsx e2e/bin/run-local.ts",
     "e2e:coordinator": "pnpm exec tsx e2e/bin/run-local.ts coordinator",
+    "e2e:direct-sync": "pnpm exec tsx e2e/bin/run-local.ts directSync",
     "e2e:smoke": "pnpm exec tsx e2e/bin/run-local.ts smoke",
     "test": "pnpm exec vitest run",
     "test:watch": "pnpm exec vitest",

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -298,6 +298,7 @@ syncCommand.addCommand(
 		.action(async (opts: SyncOnceOptions) => {
 			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 			try {
+				const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
 				syncPassPreflight(store.db);
 				const d = drizzle(store.db, { schema });
 				const rows = opts.peer
@@ -333,7 +334,7 @@ syncCommand.addCommand(
 
 				let hadFailure = false;
 				for (const row of rows) {
-					const result = await runSyncPass(store.db, row.peer_device_id);
+					const result = await runSyncPass(store.db, row.peer_device_id, { keysDir });
 					if (!result.ok) hadFailure = true;
 					console.log(formatSyncOnceResult(row.peer_device_id, result));
 				}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -66,6 +66,10 @@ const SYNC_PROTOCOL_VERSION = "2";
 const LEGACY_SYNC_ACTOR_DISPLAY_NAME = "Legacy synced peer";
 const LEGACY_SHARED_WORKSPACE_ID = "shared:legacy";
 
+function syncKeysDir(): string | undefined {
+	return process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+}
+
 function intEnvOr(name: string, fallback: number): number {
 	const value = Number.parseInt(process.env[name] ?? "", 10);
 	return Number.isFinite(value) ? value : fallback;
@@ -770,18 +774,14 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		if (limited) return limited;
 
 		try {
-			let device = store.db
-				.prepare("SELECT device_id, fingerprint FROM sync_device LIMIT 1")
-				.get() as { device_id: string; fingerprint: string } | undefined;
-			if (!device) {
-				const [deviceId, fingerprint] = ensureDeviceIdentity(store.db);
-				device = { device_id: deviceId, fingerprint };
-			}
+			const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, {
+				keysDir: syncKeysDir(),
+			});
 			const syncReset = getSyncResetState(store.db);
 			return c.json({
-				device_id: device.device_id,
+				device_id: deviceId,
 				protocol_version: SYNC_PROTOCOL_VERSION,
-				fingerprint: device.fingerprint,
+				fingerprint,
 				sync_reset: syncReset,
 			});
 		} catch {
@@ -812,17 +812,11 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			const snapshotId = c.req.query("snapshot_id") ?? null;
 			const baselineCursor = c.req.query("baseline_cursor") ?? null;
 			const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(rawLimit, 1000)) : 200;
-			let localDeviceId = store.db.prepare("SELECT device_id FROM sync_device LIMIT 1").get() as
-				| { device_id: string }
-				| undefined;
-			if (!localDeviceId) {
-				const [deviceId] = ensureDeviceIdentity(store.db);
-				localDeviceId = { device_id: deviceId };
-			}
+			const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 			const result = loadReplicationOpsForPeer(store.db, {
 				since,
 				limit,
-				deviceId: localDeviceId.device_id,
+				deviceId: localDeviceId,
 				generation: Number.isFinite(generation) ? generation : null,
 				snapshotId,
 				baselineCursor,
@@ -959,16 +953,10 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				);
 			}
 		}
-		let localDeviceId = store.db.prepare("SELECT device_id FROM sync_device LIMIT 1").get() as
-			| { device_id: string }
-			| undefined;
-		if (!localDeviceId) {
-			const [deviceId] = ensureDeviceIdentity(store.db);
-			localDeviceId = { device_id: deviceId };
-		}
+		const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 
 		const filteredInbound = filterOpsForPeer(store, peerDeviceId, normalizedOps);
-		const result = applyReplicationOps(store.db, filteredInbound.allowed, localDeviceId.device_id);
+		const result = applyReplicationOps(store.db, filteredInbound.allowed, localDeviceId);
 		return c.json({
 			...result,
 			skipped: result.skipped + filteredInbound.skipped,
@@ -1344,7 +1332,7 @@ export function syncRoutes(
 			} else {
 				// Fall back to ensureDeviceIdentity if no row exists
 				try {
-					const [id, fp] = ensureDeviceIdentity(store.db);
+					const [id, fp] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 					deviceId = id;
 					fingerprint = fp;
 					const newRow = d


### PR DESCRIPTION
## Description
This PR adds direct peer sync E2E coverage with real data-plane assertions. It also fixes bugs uncovered by the harness where `sync once` and the sync protocol routes were not consistently honoring the configured keys directory, which caused invalid signatures and fingerprint mismatches in multi-node runs.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

  Verified with:
  - `pnpm run e2e:smoke`
  - `pnpm run e2e:coordinator`
  - `pnpm run e2e:direct-sync`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] No new warnings introduced