### PR TITLE
harden E2E harness for CI smoke runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,37 @@ jobs:
 
       - name: Run packed artifact smoke test
         run: pnpm --filter @codemem/opencode-plugin test:packed-artifact
+
+  e2e-smoke:
+    name: E2E Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run E2E smoke scenario
+        env:
+          CODEMEM_E2E_BUILD: "1"
+          CODEMEM_E2E_ARTIFACTS_DIR: .tmp/e2e-artifacts
+          CODEMEM_E2E_JSON: "1"
+        run: pnpm run e2e:smoke -- --json
+
+      - name: Upload E2E artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-smoke-artifacts
+          path: .tmp/e2e-artifacts
+          if-no-files-found: ignore

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -61,3 +61,7 @@ pnpm run e2e:smoke
 Set `CODEMEM_E2E_BUILD=1` when you want to force an image rebuild for a run.
 
 Artifacts are written to `.tmp/e2e-artifacts/`, which is intentionally ignored by git.
+
+Set `CODEMEM_E2E_ARTIFACTS_DIR` to override the artifact root for CI or scripted runs.
+
+For machine-readable runner status, pass `--json` or set `CODEMEM_E2E_JSON=1`.

--- a/e2e/bin/run-local.ts
+++ b/e2e/bin/run-local.ts
@@ -13,6 +13,30 @@ const scenarios = {
 
 type ScenarioName = keyof typeof scenarios;
 
+interface CliOptions {
+	scenarioName: ScenarioName | "list" | "--help" | "-h";
+	json: boolean;
+}
+
+function parseCliArgs(argv: string[]): CliOptions {
+	let scenarioName: CliOptions["scenarioName"] = "smoke";
+	let json = process.env.CODEMEM_E2E_JSON === "1";
+	for (const arg of argv) {
+		if (arg === "--help" || arg === "-h" || arg === "list") {
+			scenarioName = arg as CliOptions["scenarioName"];
+			continue;
+		}
+		if (arg === "--json") {
+			json = true;
+			continue;
+		}
+		if (!arg.startsWith("-")) {
+			scenarioName = arg as CliOptions["scenarioName"];
+		}
+	}
+	return { scenarioName, json };
+}
+
 function printUsage(): void {
 	console.log("Usage: pnpm run e2e -- <scenario>");
 	console.log("Scenarios:");
@@ -22,7 +46,7 @@ function printUsage(): void {
 }
 
 async function main(): Promise<void> {
-	const scenarioName = (process.argv[2] ?? "smoke") as ScenarioName | "list" | "--help" | "-h";
+	const { scenarioName, json } = parseCliArgs(process.argv.slice(2));
 	if (scenarioName === "list") {
 		printUsage();
 		return;
@@ -38,18 +62,37 @@ async function main(): Promise<void> {
 	}
 
 	const ctx = createScenarioContext(scenarioName);
-	console.log(`Running E2E scenario '${scenarioName}'`);
-	console.log(`Artifacts: ${ctx.artifactsDir}`);
+	if (json) {
+		console.log(JSON.stringify({ status: "starting", scenario: scenarioName, artifactsDir: ctx.artifactsDir }));
+	} else {
+		console.log(`Running E2E scenario '${scenarioName}'`);
+		console.log(`Artifacts: ${ctx.artifactsDir}`);
+	}
 	try {
 		await scenario(ctx);
-		console.log(`Scenario '${scenarioName}' passed. Artifacts: ${ctx.artifactsDir}`);
+		if (json) {
+			console.log(JSON.stringify({ status: "passed", scenario: scenarioName, artifactsDir: ctx.artifactsDir }));
+		} else {
+			console.log(`Scenario '${scenarioName}' passed. Artifacts: ${ctx.artifactsDir}`);
+		}
 	} catch (error) {
 		ctx.captureFailure(error);
 		ctx.compose.logs("99-compose-logs-on-failure", true);
 		if (!ctx.keepStackOnFailure) {
 			ctx.compose.down("98-compose-down-on-failure", true);
 		}
-		console.error(`Scenario '${scenarioName}' failed. Artifacts: ${ctx.artifactsDir}`);
+		if (json) {
+			console.error(
+				JSON.stringify({
+					status: "failed",
+					scenario: scenarioName,
+					artifactsDir: ctx.artifactsDir,
+					error: error instanceof Error ? error.message : String(error),
+				}),
+			);
+		} else {
+			console.error(`Scenario '${scenarioName}' failed. Artifacts: ${ctx.artifactsDir}`);
+		}
 		throw error;
 	}
 }

--- a/e2e/lib/artifacts.ts
+++ b/e2e/lib/artifacts.ts
@@ -15,7 +15,10 @@ function slugify(value: string): string {
 
 export function createArtifactDir(scenario: string): string {
 	const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-	const dir = resolve(".tmp", "e2e-artifacts", `${timestamp}-${slugify(scenario)}`);
+	const root = process.env.CODEMEM_E2E_ARTIFACTS_DIR?.trim()
+		? resolve(process.env.CODEMEM_E2E_ARTIFACTS_DIR)
+		: resolve(".tmp", "e2e-artifacts");
+	const dir = join(root, `${timestamp}-${slugify(scenario)}`);
 	mkdirSync(dir, { recursive: true });
 	return dir;
 }

--- a/e2e/lib/compose.ts
+++ b/e2e/lib/compose.ts
@@ -1,6 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { writeCommandArtifact, type CommandRecord } from "./artifacts.js";
 
+const DEFAULT_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+
 export interface RunCommandOptions {
 	artifactsDir: string;
 	artifactName: string;
@@ -23,6 +25,7 @@ export function runCommand(command: string, args: string[], options: RunCommandO
 		env: options.env ?? process.env,
 		encoding: "utf8",
 		timeout: options.timeoutMs ?? 120_000,
+		maxBuffer: DEFAULT_MAX_BUFFER_BYTES,
 	});
 	const record: RunCommandResult = {
 		command: stringifyCommand(command, args),

--- a/e2e/scripts/add-shared-memory.ts
+++ b/e2e/scripts/add-shared-memory.ts
@@ -1,4 +1,6 @@
-import { initDatabase, MemoryStore, resolveDbPath } from "../../packages/core/src/index.ts";
+import { randomUUID } from "node:crypto";
+import { initDatabase, resolveDbPath } from "../../packages/core/src/index.ts";
+import { connect } from "../../packages/core/src/db.ts";
 
 function parseArgs(argv: string[]): { dbPath: string; title: string; body: string } {
 	let dbPath = "/data/mem.sqlite";
@@ -25,24 +27,49 @@ async function main(): Promise<void> {
 	const { dbPath, title, body } = parseArgs(process.argv);
 	const resolvedDbPath = resolveDbPath(dbPath);
 	initDatabase(resolvedDbPath);
-	const store = new MemoryStore(resolvedDbPath);
+	const db = connect(resolvedDbPath);
 	try {
-		const sessionId = store.startSession({
-			cwd: "/workspace/e2e-local-dirty",
-			project: "e2e-bootstrap-refusal",
-			user: "e2e",
-			toolVersion: "e2e-local-dirty",
-		});
-		store.remember(sessionId, "exploration", title, body, 0.5, ["e2e", "bootstrap"], {
-			visibility: "shared",
-			workspace_kind: "shared",
-			workspace_id: "shared:bootstrap-refusal",
-		});
-		store.endSession(sessionId, { local_dirty_marker: true });
-		await store.flushPendingVectorWrites();
-		console.log(JSON.stringify({ ok: true, title }, null, 2));
+		const now = new Date().toISOString();
+		const sessionInsert = db
+			.prepare(
+				"INSERT INTO sessions (started_at, cwd, project, user, tool_version, metadata_json) VALUES (?, ?, ?, ?, ?, ?)",
+			)
+			.run(
+				now,
+				"/workspace/e2e-local-dirty",
+				"e2e-bootstrap-refusal",
+				"e2e",
+				"e2e-local-dirty",
+				JSON.stringify({ local_dirty_marker: true }),
+			);
+		const sessionId = Number(sessionInsert.lastInsertRowid);
+		const importKey = `e2e-local-dirty-${randomUUID()}`;
+		db.prepare(
+			`INSERT INTO memory_items (
+				session_id, kind, title, body_text, confidence, tags_text,
+				active, created_at, updated_at, metadata_json,
+				visibility, workspace_id, workspace_kind, import_key, rev
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"exploration",
+			title,
+			body,
+			0.5,
+			"e2e,bootstrap",
+			1,
+			now,
+			now,
+			JSON.stringify({ local_dirty_marker: true }),
+			"shared",
+			"shared:bootstrap-refusal",
+			"shared",
+			importKey,
+			0,
+		);
+		console.log(JSON.stringify({ ok: true, title, import_key: importKey }, null, 2));
 	} finally {
-		store.close();
+		db.close();
 	}
 }
 


### PR DESCRIPTION
## Description
This PR hardens the E2E harness for future CI usage without forcing the full suite onto every PR. It adds machine-readable runner output, configurable artifact roots, and a GitHub Actions smoke job that rebuilds the image and uploads artifacts on failure.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

  Verified with:
  - `pnpm exec tsx e2e/bin/run-local.ts list`
  - `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_ARTIFACTS_DIR=\".tmp/e2e-artifacts-ci\" pnpm run e2e:smoke -- --json`
  - `pnpm run e2e:smoke`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] No new warnings introduced