### PR TITLE
add seed-peer fleet pilot foundation

### DIFF
--- a/docs/contracts/pre-provisioned-workspace-runtime-attachment.md
+++ b/docs/contracts/pre-provisioned-workspace-runtime-attachment.md
@@ -1,0 +1,219 @@
+# Pre-provisioned workspace runtime attachment contract
+
+**Status:** Draft contract  
+**Related design:** `docs/plans/2026-04-02-seed-peer-fleet-orchestration-pilot-design.md`  
+**Related epic:** `codemem-5gz6`
+
+## Purpose
+
+This contract defines how codemem attaches to an already-existing workspace runtime for the seed-peer fleet pilot.
+
+It does **not** define how compute is provisioned or how AI agents are scheduled. It only defines the contract for installing, configuring, joining, bootstrapping, validating, and cleaning up codemem in a pre-provisioned workspace environment.
+
+## Scope
+
+The contract applies to workspace-style runtimes where:
+
+- the environment already exists before codemem attachment begins
+- codemem behaves as a sidecar, plugin, or bootstrap layer
+- the runtime already has its own lifecycle for compute, agent execution, and teardown
+
+This is intentionally public-safe and generic. It should not depend on private product or company terminology.
+
+## Required inputs
+
+Each workspace attachment operation must receive the following inputs.
+
+### Fleet and node identity
+
+- `fleet_name`
+- `swarm_id`
+- `coordinator_group`
+- `node_id`
+- `node_role`
+  - `seed-peer`
+  - `worker-peer`
+  - optionally later: durable workspace role variants
+
+### Runtime target information
+
+- `workspace_selector` or equivalent target identifier
+- `config_path`
+- `db_path`
+- `keys_path`
+- `bootstrap_hook` or startup script entrypoint
+
+### Sync attachment configuration
+
+- `coordinator_url`
+- `coordinator_admin_secret` when required
+- `seed_peer_device_id` when the node bootstraps from a seed peer
+- `seed_peer_address` or reachable sync endpoint
+- identity policy
+  - `stable`
+  - `ephemeral`
+
+### Policy inputs
+
+- cleanup class
+  - `stable`
+  - `ephemeral`
+- stale and expiry thresholds when the node is ephemeral
+
+## Required environment guarantees
+
+The workspace runtime must provide:
+
+- a writable config location
+- a writable DB location
+- a writable keys location
+- a reachable network path to the coordinator
+- a reachable network path to the seed peer when bootstrap is required
+- the ability to run codemem CLI commands and helper scripts during bootstrap
+
+For stable peers, the runtime must also provide durable persistence for:
+
+- keys
+- DB
+- config
+
+For ephemeral peers, persistence may be disposable as long as it survives long enough for the swarm run.
+
+## Attachment phases
+
+### 1. Install
+
+The runtime adapter ensures codemem is available in the workspace.
+
+Expected outcome:
+- `codemem` CLI or source-run equivalent is runnable
+
+### 2. Configure
+
+The runtime adapter writes or updates codemem configuration for the node.
+
+Expected configuration includes:
+- database path
+- keys path
+- coordinator URL and group
+- sync host and port
+- identity policy hints
+
+### 3. Identity initialization
+
+The adapter ensures the node has the correct identity behavior:
+
+- stable peers reuse durable keys
+- ephemeral peers create disposable keys
+
+Expected outcome:
+- a valid device identity exists before join/bootstrap begins
+
+### 4. Coordinator join
+
+The adapter joins the node to the expected coordinator group.
+
+Expected outcome:
+- node is admitted to the intended group
+- node appears in coordinator discovery state
+
+### 5. Bootstrap
+
+If the node is not the seed peer, the adapter bootstraps it from the seed peer.
+
+Expected outcome:
+- the baseline shared memory corpus is present locally
+- the node is no longer in pre-bootstrap state
+
+### 6. Sync verification
+
+The adapter performs at least one sync verification step after bootstrap.
+
+Expected outcome:
+- peer communication succeeds
+- the node passes a minimal data-plane assertion
+
+### 7. Readiness publication
+
+The adapter records the node's readiness state.
+
+Minimum state model:
+- `pending`
+- `joining`
+- `joined`
+- `bootstrapping`
+- `bootstrapped`
+- `sync_verifying`
+- `ready`
+- `failed`
+
+## Readiness contract
+
+A workspace node is only considered **ready** when all of the following are true:
+
+1. coordinator join is complete
+2. bootstrap is complete when required
+3. one verified sync step has completed successfully
+
+Anything less should be reported as a non-ready intermediate state.
+
+## Required outputs
+
+Each attachment run must emit:
+
+- final node state
+- device identity summary
+- coordinator group
+- bootstrap source used
+- readiness result
+- artifact directory or log location
+- failure detail when unsuccessful
+
+## Artifact expectations
+
+The adapter should capture enough information to debug failures without rerunning blind.
+
+Recommended minimum artifacts:
+- CLI command transcripts
+- config snapshot used for the run
+- identity summary
+- bootstrap result summary
+- sync verification result summary
+- failure detail if attachment fails
+
+Sensitive material such as private keys must never be copied into shared artifacts.
+
+## Cleanup contract
+
+### Stable nodes
+
+- never auto-cleaned by the attachment process
+- retirement must be explicit
+
+### Ephemeral nodes
+
+- should be eligible for scheduled coordinator cleanup
+- may support explicit teardown hooks in the runtime adapter
+- should not leave permanent identity clutter in the coordinator when the swarm is over
+
+## Failure modes the adapter must surface clearly
+
+- codemem install not available
+- configuration path not writable
+- keys path not writable
+- coordinator join failure
+- bootstrap unreachable or refused
+- sync verification failure
+- cleanup failure for ephemeral nodes
+
+## Non-goals
+
+- no requirement to provision the workspace itself
+- no requirement to define workspace scheduling semantics
+- no requirement to define a generic Kubernetes abstraction layer in this contract
+
+## Recommendation
+
+Use this contract as the boundary between the fleet spec and any real workspace runtime integration.
+
+That keeps the pilot architecture public-safe, runtime-agnostic, and cheap to validate while still being concrete enough to implement against a real pre-provisioned workspace environment.

--- a/docs/plans/2026-04-02-seed-peer-fleet-orchestration-pilot-design.md
+++ b/docs/plans/2026-04-02-seed-peer-fleet-orchestration-pilot-design.md
@@ -1,0 +1,457 @@
+# Seed-peer fleet orchestration pilot design
+
+**Date:** 2026-04-02  
+**Status:** Design  
+**Bead:** `codemem-kp8m`
+
+## Problem
+
+codemem now has a working local E2E harness for coordinator enrollment, direct sync, and bootstrap. That proves the underlying sync model can work across multiple peers, but it does not yet provide a usable operational model for the next phase that matters most:
+
+- running multiple parallel coordinated swarms of ephemeral workers
+- attaching codemem to pre-provisioned workspace environments
+- validating whether a durable seed peer can support realistic internal adoption before committing to a more centralized backend architecture
+
+The current gap is not primarily about test coverage anymore. It is about orchestration and attachment:
+
+1. **There is no fleet model for seed-peer-based swarms**
+   - peers can sync, but there is no declared model for durable anchors, ephemeral workers, swarm groups, and readiness requirements
+   - parallel swarm isolation depends on manual topology choices instead of an explicit design
+
+2. **There is no runtime attachment contract for workspace environments**
+   - codemem is a plugin or sidecar capability, not the system that provisions or runs AI agents
+   - local Docker or Compose is useful as a proving backend, but the more important near-term target is attaching codemem to already-provisioned pod or workspace environments
+
+3. **The backend evolution path is unclear without an operational pilot**
+   - a stronger central backend such as Postgres may eventually help with concurrency, administration, or enterprise requirements
+   - but introducing it now would be a premature architecture bet without evidence that the cheaper seed-peer model is insufficient
+
+## Goals
+
+- Define a pilot architecture for one durable seed peer serving multiple isolated swarm groups.
+- Keep the initial path cheap to try and credible for internal adoption.
+- Preserve codemem's peer-first model while allowing future backend evolution if scale demands it.
+- Define a single fleet spec that can drive both local proving and pre-provisioned workspace attachment.
+- Define stable and ephemeral identity policies, including coordinator-managed cleanup for ephemeral workers.
+- Define readiness as join + bootstrap + verified sync, not just successful startup.
+- Leave room for later browser coverage, broader orchestration, or stronger central backends without forcing them into the pilot.
+
+## Non-goals
+
+- No requirement to design a universal compute orchestrator.
+- No requirement to provision infrastructure from scratch.
+- No requirement to adopt Postgres or another central backend in the pilot.
+- No requirement to add browser automation in this design.
+- No embedding of private company terminology or internal environment names in the public design.
+
+## Recommended approach
+
+The recommended pilot architecture is:
+
+- **one durable seed peer by default**
+- **multiple isolated swarm groups**
+- **one coordinator group per swarm**
+- **local Compose as the proving backend**
+- **a pre-provisioned workspace attachment adapter for real pilot usage**
+- **stable seed identity, configurable worker identity policy, and coordinator-managed lifecycle cleanup**
+
+This is deliberately a cheap proving step. It tests whether a durable seed peer backed by SQLite and durable storage can support realistic swarm-style usage before any larger backend migration is justified.
+
+## Options considered
+
+### Option 1: central backend first
+
+Introduce a stronger central store and use it as the default shared-memory source for workers.
+
+**Pros:**
+- easier central administration and concurrency handling
+- easier enterprise-oriented story for reporting, backup, and policy later
+
+**Cons:**
+- premature architecture bet
+- weakens the immediate peer-first product story before the cheaper model has been proven inadequate
+- increases pilot scope substantially
+
+### Option 2: pure peer mesh with no durable seed peer
+
+Treat all peers as equivalent and let workers bootstrap opportunistically from each other.
+
+**Pros:**
+- maximally peer-first
+- minimal central role concentration
+
+**Cons:**
+- weak operational predictability for ephemeral swarms
+- harder to reason about bootstrap reliability and readiness
+- poor fit for a cheap, internally sellable pilot
+
+### Option 3: durable seed peer plus isolated swarms (recommended)
+
+Use one durable seed peer as the default memory anchor, let each swarm have its own coordinator group, and attach codemem onto either local Compose nodes or pre-provisioned workspace nodes.
+
+**Pros:**
+- cheap to pilot
+- operationally understandable
+- preserves peer-first roots
+- leaves room for later backend evolution
+
+**Cons:**
+- the seed peer becomes a practical availability and throughput concentration point
+- may eventually expose SQLite or single-node scaling limits
+
+The recommended choice is **Option 3**.
+
+## Roles and responsibilities
+
+### Seed peer
+
+The seed peer is the durable memory anchor for the pilot.
+
+Responsibilities:
+- holds the durable shared memory base
+- serves as the bootstrap source for new workers
+- remains stable across swarm runs
+- uses stable identity and durable storage
+
+Non-responsibilities:
+- provisioning compute
+- scheduling agents
+- acting as the primary lifecycle manager for dead workers
+
+### Coordinator
+
+The coordinator is the control-plane service for group admission and peer lifecycle.
+
+Responsibilities:
+- invite, join, approval, and discovery
+- one coordinator group per swarm
+- stale and expired peer lifecycle tracking
+- scheduled cleanup for ephemeral workers
+
+Non-responsibilities:
+- acting as the authoritative memory corpus
+- replacing the seed peer as the bootstrap source in the pilot
+
+### Ephemeral workers
+
+Ephemeral workers are disposable swarm participants.
+
+Responsibilities:
+- join the correct coordinator group
+- bootstrap from the seed peer
+- complete at least one verified sync step
+- age off cleanly after the swarm run or inactivity window
+
+### Durable workers
+
+Durable workers are optional long-lived peers such as user workspaces or long-running VMs.
+
+Responsibilities:
+- participate in the same join, bootstrap, and sync model
+- preserve stable identity across sessions
+- avoid accidental cleanup automation intended for ephemeral workers
+
+### Runtime attachment adapters
+
+codemem is not the compute orchestrator. The pilot therefore uses runtime attachment adapters rather than general infrastructure executors.
+
+#### Compose proving backend
+- creates and manages local peer containers
+- wires config, keys, and data paths
+- validates topology and lifecycle logic cheaply
+
+#### Pre-provisioned workspace adapter
+- assumes worker environments already exist
+- installs and configures codemem in those environments
+- joins them to swarms, bootstraps them, verifies readiness, and captures artifacts
+
+This split keeps the pilot grounded in the real deployment story: local proving plus real runtime attachment.
+
+## Fleet spec shape
+
+The pilot needs one fleet spec that describes codemem topology and lifecycle independently of the attachment backend.
+
+The spec should define:
+- fleet metadata
+- seed peer role
+- coordinator policy
+- swarm definitions
+- worker role policy
+- runtime attachment metadata
+- readiness and success criteria
+
+### Illustrative shape
+
+```yaml
+fleet:
+  name: agent-memory-pilot
+  mode: seed-peer-swarms
+
+seed_peer:
+  id: seed-main
+  runtime: compose | workspace
+  identity: stable
+  storage:
+    kind: sqlite
+    persistence: durable
+
+coordinator:
+  mode: shared
+  cleanup:
+    stale_after_minutes: 30
+    expire_after_minutes: 120
+
+swarms:
+  - id: swarm-a
+    coordinator_group: swarm-a
+    seed_peer: seed-main
+    workers:
+      count: 8
+      runtime: compose | workspace
+      identity: ephemeral
+
+  - id: swarm-b
+    coordinator_group: swarm-b
+    seed_peer: seed-main
+    workers:
+      count: 8
+      runtime: compose | workspace
+      identity: ephemeral
+```
+
+The exact serialization format is not the important part in this design. The important part is the model.
+
+### Runtime detail level
+
+The spec should include **moderate runtime detail**:
+- runtime type
+- target identifiers or selectors
+- config, key, and DB path expectations
+- bootstrap hook names or commands
+- storage durability hints
+- readiness checks
+
+It should not try to become a full platform deployment schema, Helm replacement, or infrastructure DSL.
+
+## Runtime attachment model
+
+### Compose proving backend
+
+Purpose:
+- prove the model locally
+- reproduce topology and lifecycle behavior cheaply
+- validate failure modes before touching shared environments
+
+Responsibilities:
+- create and manage local seed, coordinator, and worker peers
+- attach config, keys, and storage
+- run join, bootstrap, and sync verification steps
+- collect local artifacts
+
+The Compose backend is the lab bench, not the production runtime.
+
+### Pre-provisioned workspace adapter
+
+Purpose:
+- attach codemem onto already-existing workspace environments
+- support a cheap internal pilot in real pod-based development environments
+
+Responsibilities:
+- target selected workspaces
+- install codemem or plugin components
+- set up config, DB, and keys paths
+- join the correct coordinator group
+- bootstrap from the seed peer
+- verify worker readiness
+- optionally tear down or age off ephemeral workers cleanly
+
+This is intentionally an attachment model, not a compute provisioner.
+
+## Identity lifecycle policy
+
+### Stable identities
+
+Used for:
+- seed peer
+- durable user or workspace peers
+- long-lived anchors
+
+Behavior:
+- persistent keys
+- persistent DB and config paths
+- never auto-cleaned by default
+- manual retirement only
+
+### Ephemeral identities
+
+Used for:
+- swarm workers
+- disposable agent peers
+- burst fan-out participants
+
+Behavior:
+- disposable by design
+- safe to recreate
+- eligible for staleness tracking, expiry, and cleanup
+
+### Policy recommendation
+
+The pilot should support a **configurable identity policy by role and runtime**:
+- stable for the seed peer and durable peers
+- ephemeral for swarm workers by default
+
+## Coordinator cleanup policy
+
+The coordinator should manage swarm membership hygiene.
+
+### Recommended model
+
+- **scheduled cleanup plus manual override**
+- stale ephemeral peers become expired after a configurable TTL
+- cleanup removes or archives ephemeral membership and discovery state
+- stable peers are never auto-cleaned
+- the seed peer is explicitly protected from cleanup automation
+
+### Why this matters
+
+Without lifecycle cleanup:
+- repeated swarm runs pollute discovery state
+- dead workers pile up
+- operators lose trust in the topology
+
+With lifecycle cleanup:
+- swarms stay repeatable
+- coordinator state stays legible
+- the pilot looks operationally credible
+
+## Readiness model
+
+A worker is only considered **ready** when all three of the following are true:
+
+1. **Join complete**
+   - the worker has a valid identity
+   - it has been admitted to the correct coordinator group
+   - it appears in discovery state as expected
+
+2. **Bootstrap complete**
+   - it has loaded the expected baseline from the seed peer
+   - local data is present and queryable
+
+3. **Verified sync complete**
+   - it has completed at least one sync step after bootstrap
+   - a minimal data-plane assertion confirms the node is actually usable
+
+Anything less is not real readiness.
+
+### Suggested readiness states
+
+- `pending`
+- `joining`
+- `joined`
+- `bootstrapping`
+- `bootstrapped`
+- `sync_verifying`
+- `ready`
+- `stale`
+- `expired`
+- `failed`
+
+## Shared seed peer versus cohort-specific seed peers
+
+### Default mode
+
+The pilot should use a **shared seed peer by default**.
+
+Why:
+- simpler to operate
+- cheaper to validate
+- stronger signal about whether a single durable seed peer is viable for internal use
+
+### Advanced mode
+
+The design should still allow **cohort-specific seed peers** as an explicit advanced option.
+
+This matters for later scenarios such as:
+- stricter swarm isolation
+- workload-specific seed data
+- higher fan-out loads
+- future partial centralization or sharding strategies
+
+The recommendation is therefore:
+- shared seed peer by default
+- cohort-specific seed peers as an advanced mode
+
+## Validation model
+
+For the pilot, validation should remain straightforward and black-box-oriented.
+
+Each worker should prove:
+- it joined the expected coordinator group
+- it bootstrapped from the expected seed peer
+- it completed at least one verified sync step
+- expected shared data is present
+- expected private data did not leak
+
+This validation model should work in both:
+- local Compose proving
+- pre-provisioned workspace attachment
+
+## Scale-trigger signals for backend evolution
+
+The purpose of the pilot is not to preemptively adopt a stronger central backend. It is to gather evidence about whether the cheaper seed-peer model holds up well enough.
+
+### Signals the seed-peer model is still sufficient
+
+- bootstrap latency remains acceptable for 20–50 workers
+- parallel swarm startup remains operationally manageable
+- the seed peer does not become an obvious throughput bottleneck
+- lifecycle cleanup stays understandable
+- operators can reason about failures and recovery without heroic effort
+
+### Signals that stronger backend work may be justified later
+
+- the seed peer becomes a persistent throughput or availability bottleneck
+- SQLite durability or administrative ergonomics become painful in practice
+- large-scale reporting, audit, or policy requirements exceed the current peer-first model
+- the internal pilot demands stronger centralized operational controls than the seed-peer model can comfortably support
+
+At that point, re-evaluating a stronger backend or coordinator storage adapter becomes reasonable. Before that, it is premature.
+
+## Recommended pilot phases
+
+### Phase 1: local Compose proving
+
+- finalize the fleet spec
+- validate one seed peer plus multiple swarm groups locally
+- exercise join, bootstrap, sync verification, and cleanup policy cheaply
+
+### Phase 2: workspace attachment pilot
+
+- define the workspace bootstrap contract
+- attach codemem to pre-provisioned workspace environments
+- validate readiness and cleanup behavior in a real pod-based runtime
+
+### Phase 3: repeated swarm operation
+
+- run multiple swarms repeatedly
+- validate aging-off behavior and manual cleanup override
+- measure bootstrap and sync bottlenecks under realistic pilot load
+
+### Phase 4: backend pressure review
+
+- assess whether the seed-peer model remains acceptable
+- decide whether a stronger backend is justified by real adoption pressure rather than speculation
+
+## Recommended next steps
+
+1. Write the fleet spec and adapter contract in concrete terms.
+2. Implement the local Compose proving path for one seed peer and multiple swarm groups.
+3. Define the workspace bootstrap script contract for attaching codemem to pre-provisioned workspaces.
+4. Add lifecycle cleanup commands or scheduled cleanup logic for ephemeral peers.
+5. Measure bootstrap and sync readiness for 20–50 worker targets before making any backend escalation decision.
+
+## Final recommendation
+
+The pilot should proceed with a **shared durable seed peer, isolated coordinator groups per swarm, local Compose proving, and a pre-provisioned workspace attachment path**.
+
+This is the cheapest credible path to proving codemem as a real foundation for internal swarm-style workflows while preserving a clear option to scale later if adoption and operational pain justify a stronger backend.

--- a/docs/plans/2026-04-02-seed-peer-fleet-orchestration-pilot-implementation-plan.md
+++ b/docs/plans/2026-04-02-seed-peer-fleet-orchestration-pilot-implementation-plan.md
@@ -1,0 +1,149 @@
+# Seed-peer fleet orchestration pilot implementation plan
+
+**Date:** 2026-04-02  
+**Status:** Draft plan  
+**Design:** `docs/plans/2026-04-02-seed-peer-fleet-orchestration-pilot-design.md`  
+**Epic:** `codemem-5gz6`
+
+## Objective
+
+Implement the seed-peer fleet orchestration pilot in thin, verifiable slices that prove the model cheaply before expanding into broader workspace attachment or backend evolution work.
+
+The implementation should preserve three principles:
+
+1. **Cheap to try**
+   - reuse the existing sync and E2E foundations
+   - avoid new infrastructure bets
+   - avoid speculative backend work
+
+2. **Credible to scale later**
+   - use an explicit fleet spec
+   - keep runtime attachment concerns separate from topology intent
+   - preserve room for later workspace and backend adaptation
+
+3. **Operationally honest**
+   - readiness must mean join + bootstrap + verified sync
+   - ephemeral peers must not accumulate forever
+   - artifacts and status must make failures diagnosable
+
+## Implementation slices
+
+### Slice 1: fleet spec and local Compose proving path
+
+Deliver:
+- an executable fleet spec format for the pilot
+- a checked-in Compose-backed example spec with one durable seed peer and two isolated swarm groups
+- a fleet-smoke scenario that loads the spec, resolves topology, starts the required services, and proves basic codemem attachment on the declared nodes
+
+Success criteria:
+- one command runs a spec-backed fleet smoke scenario locally
+- the runner produces artifacts describing the resolved topology
+- the first slice stays narrow and does not yet attempt full swarm lifecycle automation
+
+### Slice 2: shared-seed coordinator group materialization
+
+Deliver:
+- compose fleet flow for creating multiple coordinator groups from the spec
+- group-scoped attachment for workers defined in the fleet spec
+- evidence that swarm groups are isolated even when sharing the same durable seed peer
+
+Success criteria:
+- two swarm groups can be materialized from one spec without manual command choreography
+- artifacts show which peer belongs to which group
+
+### Slice 3: seed-peer bootstrap and readiness workflow
+
+Deliver:
+- fleet-driven join and bootstrap choreography for compose-backed workers
+- readiness state transitions driven by join + bootstrap + verified sync
+- spec-aware assertions that workers are actually ready, not merely started
+
+Success criteria:
+- a worker defined in the fleet spec can reach `ready`
+- readiness failures produce useful artifacts and explicit state
+
+### Slice 4: pre-provisioned workspace attachment contract
+
+Deliver:
+- a documented workspace bootstrap contract for attaching codemem to already-existing environments
+- required inputs, outputs, hooks, and readiness checks
+- a script/template boundary that can later be adapted to real workspace runtimes
+
+Success criteria:
+- the contract is explicit enough to implement against a real workspace environment without redesigning the fleet model
+
+### Slice 5: lifecycle cleanup and operator workflows
+
+Deliver:
+- cleanup commands or lifecycle helpers for ephemeral peers
+- stale and expired peer policy aligned with the fleet design
+- operator-facing workflow notes for swarm teardown and cleanup
+
+Success criteria:
+- ephemeral peers do not accumulate indefinitely
+- cleanup can be scheduled or manually triggered without risking stable peers or the seed peer
+
+## First slice recommendation
+
+The first slice should be intentionally narrow:
+
+1. add a fleet spec type and validator
+2. check in a Compose-backed sample spec
+3. add a `fleetSmoke` scenario that loads the spec and brings up the declared services
+4. verify codemem CLI reachability on the seed peer and worker peers
+5. write a topology artifact showing swarm groups, roles, and resolved runtime targets
+
+This proves that the pilot has a real attachment model without prematurely implementing every lifecycle step.
+
+## File plan
+
+### First slice
+
+- `e2e/fleet/spec.ts`
+- `e2e/fleet/examples/compose-shared-seed.json`
+- `e2e/scenarios/fleet-smoke.ts`
+- `e2e/bin/run-local.ts`
+- `e2e/README.md`
+- `package.json`
+
+### Likely later slices
+
+- `e2e/fleet/compose.ts`
+- `e2e/fleet/workspace-contract.md` or equivalent public-safe contract doc
+- `e2e/scripts/*` helpers for group materialization and readiness probes
+- coordinator cleanup or lifecycle helpers if pilot work exposes missing surfaces
+
+## Validation strategy
+
+### First slice validation
+
+- `pnpm exec tsx e2e/bin/run-local.ts list`
+- `pnpm run e2e -- fleetSmoke`
+
+### Broader regression after slice 1 if touched paths warrant it
+
+- `pnpm run e2e:smoke`
+
+## Risks and mitigations
+
+### Risk: spec gets too abstract too early
+
+**Mitigation:** keep the first spec executable and concrete, with explicit nodes for the Compose example.
+
+### Risk: runtime attachment and topology intent get mixed together
+
+**Mitigation:** keep moderate runtime detail in the spec and move backend-specific behavior into adapter helpers later.
+
+### Risk: the first slice pretends readiness is solved
+
+**Mitigation:** keep slice 1 explicitly scoped to topology materialization and CLI attachment, not full readiness.
+
+### Risk: internal workspace terminology leaks into OSS surfaces
+
+**Mitigation:** keep public-safe naming such as `workspace runtime` and `pre-provisioned workspace adapter`.
+
+## Recommendation
+
+Implement the pilot in thin vertical slices starting with a **fleet spec plus Compose-backed fleet smoke scenario**.
+
+That gives codemem a concrete first implementation step toward swarm-style orchestration without locking the project into a premature backend or runtime-specific architecture.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,6 +7,7 @@ This directory holds the first local Docker/Compose-based E2E harness for sync s
 - Docker Compose topology for `coordinator`, `peer-a`, and `peer-b`
 - host-run TypeScript runner
 - smoke scenario for stack bring-up and coordinator reachability
+- fleet spec and Compose fleet-smoke proving scenario
 - coordinator invite/join/approval/discovery scenario
 - direct peer sync scenario with data-plane assertions
 - bootstrap scenario plus dirty-local refusal validation
@@ -36,6 +37,14 @@ pnpm run e2e:coordinator
 ```fish
 pnpm run e2e:direct-sync
 ```
+
+## Run the fleet smoke scenario
+
+```fish
+pnpm run e2e:fleet-smoke
+```
+
+Set `CODEMEM_E2E_FLEET_SPEC` to point at a different fleet spec file.
 
 ## Run the bootstrap scenario
 

--- a/e2e/bin/run-local.ts
+++ b/e2e/bin/run-local.ts
@@ -1,3 +1,4 @@
+import { runFleetSmokeScenario } from "../scenarios/fleet-smoke.js";
 import { runBootstrapScenario } from "../scenarios/bootstrap.js";
 import { runCoordinatorScenario } from "../scenarios/coordinator.js";
 import { runDirectSyncScenario } from "../scenarios/direct-sync.js";
@@ -8,8 +9,13 @@ const scenarios = {
 	bootstrap: runBootstrapScenario,
 	coordinator: runCoordinatorScenario,
 	directSync: runDirectSyncScenario,
+	fleetSmoke: runFleetSmokeScenario,
 	smoke: runSmokeScenario,
 } as const;
+
+const processRef = globalThis as typeof globalThis & {
+	process: { env: Record<string, string | undefined>; argv: string[]; exitCode?: number };
+};
 
 type ScenarioName = keyof typeof scenarios;
 
@@ -20,7 +26,7 @@ interface CliOptions {
 
 function parseCliArgs(argv: string[]): CliOptions {
 	let scenarioName: CliOptions["scenarioName"] = "smoke";
-	let json = process.env.CODEMEM_E2E_JSON === "1";
+	let json = processRef.process.env.CODEMEM_E2E_JSON === "1";
 	for (const arg of argv) {
 		if (arg === "--help" || arg === "-h" || arg === "list") {
 			scenarioName = arg as CliOptions["scenarioName"];
@@ -46,7 +52,7 @@ function printUsage(): void {
 }
 
 async function main(): Promise<void> {
-	const { scenarioName, json } = parseCliArgs(process.argv.slice(2));
+	const { scenarioName, json } = parseCliArgs(processRef.process.argv.slice(2));
 	if (scenarioName === "list") {
 		printUsage();
 		return;
@@ -99,5 +105,5 @@ async function main(): Promise<void> {
 
 void main().catch((error) => {
 	console.error(error instanceof Error ? error.stack ?? error.message : String(error));
-	process.exitCode = 1;
+	processRef.process.exitCode = 1;
 });

--- a/e2e/fleet/examples/compose-shared-seed.json
+++ b/e2e/fleet/examples/compose-shared-seed.json
@@ -1,0 +1,70 @@
+{
+  "fleet": {
+    "name": "compose-shared-seed-pilot",
+    "mode": "seed-peer-swarms"
+  },
+  "seed_peer": {
+    "id": "seed-main",
+    "runtime": {
+      "type": "compose",
+      "service": "peer-a",
+      "config_path": "/config/codemem.json",
+      "db_path": "/data/mem.sqlite",
+      "keys_path": "/keys"
+    },
+    "identity": "stable",
+    "storage": {
+      "kind": "sqlite",
+      "persistence": "durable"
+    }
+  },
+  "coordinator": {
+    "mode": "shared",
+    "runtime": {
+      "type": "compose",
+      "service": "coordinator"
+    },
+    "cleanup": {
+      "stale_after_minutes": 30,
+      "expire_after_minutes": 120
+    }
+  },
+  "swarms": [
+    {
+      "id": "swarm-a",
+      "coordinator_group": "swarm-a",
+      "seed_peer": "seed-main",
+      "workers": [
+        {
+          "id": "swarm-a-worker-1",
+          "runtime": {
+            "type": "compose",
+            "service": "peer-b",
+            "config_path": "/config/codemem.json",
+            "db_path": "/data/mem.sqlite",
+            "keys_path": "/keys"
+          },
+          "identity": "ephemeral"
+        }
+      ]
+    },
+    {
+      "id": "swarm-b",
+      "coordinator_group": "swarm-b",
+      "seed_peer": "seed-main",
+      "workers": [
+        {
+          "id": "swarm-b-worker-1",
+          "runtime": {
+            "type": "compose",
+            "service": "peer-c",
+            "config_path": "/config/codemem.json",
+            "db_path": "/data/mem.sqlite",
+            "keys_path": "/keys"
+          },
+          "identity": "ephemeral"
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fleet/readiness.ts
+++ b/e2e/fleet/readiness.ts
@@ -1,0 +1,70 @@
+import type { FleetSpec } from "./spec.js";
+
+export type FleetNodeState =
+	| "pending"
+	| "reachable"
+	| "group_ready"
+	| "joining"
+	| "joined"
+	| "bootstrapping"
+	| "bootstrapped"
+	| "sync_verifying"
+	| "ready"
+	| "failed";
+
+export interface FleetNodeStatus {
+	id: string;
+	role: "seed-peer" | "worker-peer" | "coordinator";
+	swarm_id: string | null;
+	coordinator_group: string | null;
+	runtime_type: string;
+	runtime_target: string | null;
+	identity: "stable" | "ephemeral" | null;
+	state: FleetNodeState;
+	detail: string;
+}
+
+export interface FleetStatusSnapshot {
+	fleet_name: string;
+	mode: string;
+	nodes: FleetNodeStatus[];
+	counts: Record<FleetNodeState, number>;
+}
+
+export function updateFleetNodeStatus(
+	nodes: FleetNodeStatus[],
+	nodeId: string,
+	state: FleetNodeState,
+	detail: string,
+): void {
+	const node = nodes.find((entry) => entry.id === nodeId);
+	if (!node) throw new Error(`Unknown fleet node status '${nodeId}'`);
+	node.state = state;
+	node.detail = detail;
+}
+
+function countStates(nodes: FleetNodeStatus[]): Record<FleetNodeState, number> {
+	const counts: Record<FleetNodeState, number> = {
+		pending: 0,
+		reachable: 0,
+		group_ready: 0,
+		joining: 0,
+		joined: 0,
+		bootstrapping: 0,
+		bootstrapped: 0,
+		sync_verifying: 0,
+		ready: 0,
+		failed: 0,
+	};
+	for (const node of nodes) counts[node.state] += 1;
+	return counts;
+}
+
+export function createFleetStatusSnapshot(spec: FleetSpec, nodes: FleetNodeStatus[]): FleetStatusSnapshot {
+	return {
+		fleet_name: spec.fleet.name,
+		mode: spec.fleet.mode,
+		nodes,
+		counts: countStates(nodes),
+	};
+}

--- a/e2e/fleet/spec.ts
+++ b/e2e/fleet/spec.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export type FleetRuntimeType = "compose" | "workspace";
+export type IdentityPolicy = "stable" | "ephemeral";
+export type StoragePersistence = "durable" | "ephemeral";
+
+export interface FleetRuntimeTarget {
+	type: FleetRuntimeType;
+	service?: string;
+	selector?: string;
+	config_path?: string;
+	db_path?: string;
+	keys_path?: string;
+	bootstrap_hook?: string;
+}
+
+export interface FleetWorkerSpec {
+	id: string;
+	runtime: FleetRuntimeTarget;
+	identity: IdentityPolicy;
+}
+
+export interface FleetSwarmSpec {
+	id: string;
+	coordinator_group: string;
+	seed_peer: string;
+	workers: FleetWorkerSpec[];
+}
+
+export interface FleetSpec {
+	fleet: {
+		name: string;
+		mode: string;
+	};
+	seed_peer: {
+		id: string;
+		runtime: FleetRuntimeTarget;
+		identity: "stable";
+		storage: {
+			kind: "sqlite";
+			persistence: StoragePersistence;
+		};
+	};
+	coordinator: {
+		mode: "shared";
+		runtime: FleetRuntimeTarget;
+		cleanup: {
+			stale_after_minutes: number;
+			expire_after_minutes: number;
+		};
+	};
+	swarms: FleetSwarmSpec[];
+}
+
+function assertCondition(condition: unknown, message: string): asserts condition {
+	if (!condition) throw new Error(message);
+}
+
+function asObject(value: unknown, message: string): Record<string, unknown> {
+	assertCondition(value && typeof value === "object" && !Array.isArray(value), message);
+	return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, message: string): string {
+	assertCondition(typeof value === "string" && value.trim().length > 0, message);
+	return value.trim();
+}
+
+function asNumber(value: unknown, message: string): number {
+	assertCondition(typeof value === "number" && Number.isFinite(value), message);
+	return value;
+}
+
+function parseRuntimeTarget(value: unknown, messagePrefix: string): FleetRuntimeTarget {
+	const raw = asObject(value, `${messagePrefix} must be an object`);
+	const type = asString(raw.type, `${messagePrefix}.type must be a non-empty string`);
+	assertCondition(type === "compose" || type === "workspace", `${messagePrefix}.type must be 'compose' or 'workspace'`);
+	return {
+		type,
+		service: typeof raw.service === "string" ? raw.service.trim() : undefined,
+		selector: typeof raw.selector === "string" ? raw.selector.trim() : undefined,
+		config_path: typeof raw.config_path === "string" ? raw.config_path.trim() : undefined,
+		db_path: typeof raw.db_path === "string" ? raw.db_path.trim() : undefined,
+		keys_path: typeof raw.keys_path === "string" ? raw.keys_path.trim() : undefined,
+		bootstrap_hook: typeof raw.bootstrap_hook === "string" ? raw.bootstrap_hook.trim() : undefined,
+	};
+}
+
+function parseWorkers(value: unknown, messagePrefix: string): FleetWorkerSpec[] {
+	assertCondition(Array.isArray(value) && value.length > 0, `${messagePrefix} must be a non-empty array`);
+	return value.map((worker, index) => {
+		const raw = asObject(worker, `${messagePrefix}[${index}] must be an object`);
+		const identity = asString(raw.identity, `${messagePrefix}[${index}].identity must be set`);
+		assertCondition(identity === "stable" || identity === "ephemeral", `${messagePrefix}[${index}].identity must be 'stable' or 'ephemeral'`);
+		return {
+			id: asString(raw.id, `${messagePrefix}[${index}].id must be set`),
+			runtime: parseRuntimeTarget(raw.runtime, `${messagePrefix}[${index}].runtime`),
+			identity,
+		};
+	});
+}
+
+export function parseFleetSpec(input: string): FleetSpec {
+	const raw = asObject(JSON.parse(input), "fleet spec root must be an object");
+	const fleet = asObject(raw.fleet, "fleet must be an object");
+	const seedPeerRaw = asObject(raw.seed_peer, "seed_peer must be an object");
+	const coordinatorRaw = asObject(raw.coordinator, "coordinator must be an object");
+	assertCondition(Array.isArray(raw.swarms) && raw.swarms.length > 0, "swarms must be a non-empty array");
+
+	const spec: FleetSpec = {
+		fleet: {
+			name: asString(fleet.name, "fleet.name must be set"),
+			mode: asString(fleet.mode, "fleet.mode must be set"),
+		},
+		seed_peer: {
+			id: asString(seedPeerRaw.id, "seed_peer.id must be set"),
+			runtime: parseRuntimeTarget(seedPeerRaw.runtime, "seed_peer.runtime"),
+			identity: "stable",
+			storage: {
+				kind: "sqlite",
+				persistence: asString(asObject(seedPeerRaw.storage, "seed_peer.storage must be an object").persistence, "seed_peer.storage.persistence must be set") as StoragePersistence,
+			},
+		},
+		coordinator: {
+			mode: "shared",
+			runtime: parseRuntimeTarget(coordinatorRaw.runtime, "coordinator.runtime"),
+			cleanup: {
+				stale_after_minutes: asNumber(asObject(coordinatorRaw.cleanup, "coordinator.cleanup must be an object").stale_after_minutes, "coordinator.cleanup.stale_after_minutes must be a number"),
+				expire_after_minutes: asNumber(asObject(coordinatorRaw.cleanup, "coordinator.cleanup must be an object").expire_after_minutes, "coordinator.cleanup.expire_after_minutes must be a number"),
+			},
+		},
+		swarms: raw.swarms.map((swarm, index) => {
+			const swarmRaw = asObject(swarm, `swarms[${index}] must be an object`);
+			return {
+				id: asString(swarmRaw.id, `swarms[${index}].id must be set`),
+				coordinator_group: asString(swarmRaw.coordinator_group, `swarms[${index}].coordinator_group must be set`),
+				seed_peer: asString(swarmRaw.seed_peer, `swarms[${index}].seed_peer must be set`),
+				workers: parseWorkers(swarmRaw.workers, `swarms[${index}].workers`),
+			};
+		}),
+	};
+
+	assertCondition(spec.fleet.mode === "seed-peer-swarms", "fleet.mode must be 'seed-peer-swarms'");
+	assertCondition(spec.seed_peer.storage.persistence === "durable" || spec.seed_peer.storage.persistence === "ephemeral", "seed_peer.storage.persistence must be 'durable' or 'ephemeral'");
+	assertCondition(spec.coordinator.cleanup.expire_after_minutes >= spec.coordinator.cleanup.stale_after_minutes, "coordinator cleanup expire_after_minutes must be >= stale_after_minutes");
+	assertCondition(spec.seed_peer.runtime.type === "compose" || spec.seed_peer.runtime.type === "workspace", "seed_peer runtime must be supported");
+	const swarmIds = new Set<string>();
+	const groups = new Set<string>();
+	for (const swarm of spec.swarms) {
+		assertCondition(swarm.seed_peer === spec.seed_peer.id, `swarm '${swarm.id}' references unknown seed_peer '${swarm.seed_peer}'`);
+		assertCondition(!swarmIds.has(swarm.id), `duplicate swarm id '${swarm.id}'`);
+		assertCondition(!groups.has(swarm.coordinator_group), `duplicate coordinator_group '${swarm.coordinator_group}'`);
+		swarmIds.add(swarm.id);
+		groups.add(swarm.coordinator_group);
+	}
+	return spec;
+}
+
+export function loadFleetSpec(filePath: string): FleetSpec {
+	return parseFleetSpec(readFileSync(resolve(filePath), "utf8"));
+}
+
+export function collectComposeServices(spec: FleetSpec): string[] {
+	const services = new Set<string>();
+	if (spec.coordinator.runtime.type === "compose" && spec.coordinator.runtime.service) services.add(spec.coordinator.runtime.service);
+	if (spec.seed_peer.runtime.type === "compose" && spec.seed_peer.runtime.service) services.add(spec.seed_peer.runtime.service);
+	for (const swarm of spec.swarms) {
+		for (const worker of swarm.workers) {
+			if (worker.runtime.type === "compose" && worker.runtime.service) services.add(worker.runtime.service);
+		}
+	}
+	return [...services];
+}

--- a/e2e/scenarios/fleet-smoke.ts
+++ b/e2e/scenarios/fleet-smoke.ts
@@ -1,0 +1,170 @@
+import { assert, assertStatus } from "../lib/assert.js";
+import { createFleetStatusSnapshot, type FleetNodeStatus } from "../fleet/readiness.js";
+import { collectComposeServices, loadFleetSpec } from "../fleet/spec.js";
+import type { ScenarioContext } from "../lib/scenario-context.js";
+import { waitFor } from "../lib/wait.js";
+
+const CLI_PREFIX = ["pnpm", "exec", "tsx", "--conditions", "source", "packages/cli/src/index.ts"];
+const ADMIN_SECRET = "e2e-admin-secret";
+const DEFAULT_SPEC_PATH = "e2e/fleet/examples/compose-shared-seed.json";
+const processRef = globalThis as typeof globalThis & {
+	process: { env: Record<string, string | undefined> };
+};
+
+export async function runFleetSmokeScenario(ctx: ScenarioContext): Promise<void> {
+	const specPath = processRef.process.env.CODEMEM_E2E_FLEET_SPEC?.trim() || DEFAULT_SPEC_PATH;
+	const spec = loadFleetSpec(specPath);
+	const composeServices = collectComposeServices(spec);
+	assert(composeServices.length > 0, "fleet spec did not resolve any compose services");
+	const coordinatorService = spec.coordinator.runtime.service ?? "coordinator";
+
+	ctx.recordNote(
+		"scenario.txt",
+		"Fleet smoke scenario: load fleet spec, start declared compose services, verify codemem CLI reachability on the seed and workers, and materialize coordinator groups for each swarm.",
+	);
+	ctx.recordNote("fleet-spec.json", JSON.stringify(spec, null, 2));
+	ctx.recordNote(
+		"resolved-topology.json",
+		JSON.stringify(
+			{
+				specPath,
+				composeServices,
+				seed_peer: spec.seed_peer,
+				coordinator: spec.coordinator,
+				swarms: spec.swarms,
+			},
+			null,
+			2,
+		),
+	);
+	const nodeStatuses: FleetNodeStatus[] = [
+		{
+			id: spec.coordinator.runtime.service ?? "coordinator",
+			role: "coordinator",
+			swarm_id: null,
+			coordinator_group: null,
+			runtime_type: spec.coordinator.runtime.type,
+			runtime_target: spec.coordinator.runtime.service ?? spec.coordinator.runtime.selector ?? null,
+			identity: null,
+			state: "pending",
+			detail: "Coordinator service declared in fleet spec.",
+		},
+		{
+			id: spec.seed_peer.id,
+			role: "seed-peer",
+			swarm_id: null,
+			coordinator_group: null,
+			runtime_type: spec.seed_peer.runtime.type,
+			runtime_target: spec.seed_peer.runtime.service ?? spec.seed_peer.runtime.selector ?? null,
+			identity: spec.seed_peer.identity,
+			state: "pending",
+			detail: "Seed peer declared in fleet spec.",
+		},
+		...spec.swarms.flatMap((swarm) =>
+			swarm.workers.map((worker) => ({
+				id: worker.id,
+				role: "worker-peer" as const,
+				swarm_id: swarm.id,
+				coordinator_group: swarm.coordinator_group,
+				runtime_type: worker.runtime.type,
+				runtime_target: worker.runtime.service ?? worker.runtime.selector ?? null,
+				identity: worker.identity,
+				state: "pending" as const,
+				detail: "Worker declared in fleet spec.",
+			})),
+		),
+	];
+
+	ctx.compose.down("00-compose-down-pre", true);
+	ctx.compose.up(composeServices, "01-compose-up");
+	ctx.compose.ps("02-compose-ps");
+	nodeStatuses[0]!.state = "reachable";
+	nodeStatuses[0]!.detail = "Compose services started successfully.";
+
+	const seedService = spec.seed_peer.runtime.service;
+	assert(seedService, "seed peer compose service missing");
+
+	await waitFor(
+		async () => {
+			const result = ctx.compose.exec(seedService, [...CLI_PREFIX, "version"], "03-seed-version-check", 30_000);
+			assertStatus(result.status, 0, "seed peer codemem version check failed");
+		},
+		{ description: "seed peer CLI readiness", timeoutMs: 120_000, intervalMs: 2_000 },
+	);
+	const seedStatus = nodeStatuses.find((node) => node.id === spec.seed_peer.id);
+	if (seedStatus) {
+		seedStatus.state = "reachable";
+		seedStatus.detail = "Seed peer CLI is reachable.";
+	}
+
+	for (const swarm of spec.swarms) {
+		const groupCreate = ctx.compose.exec(
+			coordinatorService,
+			[
+				...CLI_PREFIX,
+				"sync",
+				"coordinator",
+				"group-create",
+				swarm.coordinator_group,
+				"--db-path",
+				"/data/coordinator.sqlite",
+			],
+			`04-group-create-${swarm.id}`,
+		);
+		assertStatus(groupCreate.status, 0, `failed to create coordinator group for ${swarm.id}`);
+		for (const worker of swarm.workers) {
+			const status = nodeStatuses.find((node) => node.id === worker.id);
+			if (status) {
+				status.state = "group_ready";
+				status.detail = `Coordinator group '${swarm.coordinator_group}' materialized for swarm '${swarm.id}'.`;
+			}
+		}
+
+		for (const worker of swarm.workers) {
+			const service = worker.runtime.service;
+			assert(service, `worker '${worker.id}' is missing compose service`);
+			await waitFor(
+				async () => {
+					const result = ctx.compose.exec(service, [...CLI_PREFIX, "version"], `05-${worker.id}-version-check`, 30_000);
+					assertStatus(result.status, 0, `worker ${worker.id} codemem version check failed`);
+				},
+				{ description: `${worker.id} CLI readiness`, timeoutMs: 120_000, intervalMs: 2_000 },
+			);
+
+			const adminCheck = ctx.compose.exec(
+				service,
+				[
+					"node",
+					"--input-type=module",
+					"-e",
+					`const res = await fetch('http://${coordinatorService}:7347/v1/admin/devices?group_id=${swarm.coordinator_group}', { headers: { 'X-Codemem-Coordinator-Admin': '${ADMIN_SECRET}' } }); const body = await res.text(); console.log(body); process.exit(res.status === 200 ? 0 : 1);`,
+				],
+				`06-${worker.id}-admin-check`,
+				30_000,
+			);
+			assertStatus(adminCheck.status, 0, `failed admin reachability check for ${worker.id}`);
+			assert(adminCheck.stdout.includes('"items"'), `${worker.id} admin response missing items payload`);
+			const status = nodeStatuses.find((node) => node.id === worker.id);
+			if (status) {
+				status.state = "reachable";
+				status.detail = `Worker CLI is reachable and coordinator admin endpoint responded for group '${swarm.coordinator_group}'.`;
+			}
+		}
+	}
+
+	ctx.recordNote(
+		"fleet-status.json",
+		JSON.stringify(createFleetStatusSnapshot(spec, nodeStatuses), null, 2),
+	);
+
+	ctx.compose.copyFromContainer(
+		`${coordinatorService}:/data/coordinator.sqlite`,
+		`${ctx.artifactsDir}/db/coordinator-fleet-smoke.sqlite`,
+		"07-copy-coordinator-db",
+		false,
+	);
+
+	if (!ctx.keepStackOnFailure) {
+		ctx.compose.down("08-compose-down-post");
+	}
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "e2e:bootstrap": "pnpm exec tsx e2e/bin/run-local.ts bootstrap",
     "e2e:coordinator": "pnpm exec tsx e2e/bin/run-local.ts coordinator",
     "e2e:direct-sync": "pnpm exec tsx e2e/bin/run-local.ts directSync",
+    "e2e:fleet-smoke": "pnpm exec tsx e2e/bin/run-local.ts fleetSmoke",
     "e2e:smoke": "pnpm exec tsx e2e/bin/run-local.ts smoke",
     "test": "pnpm exec vitest run",
     "test:watch": "pnpm exec vitest",


### PR DESCRIPTION
## Description
This PR lays the seed-peer fleet pilot foundation on top of the existing E2E harness. It adds the seed-peer fleet design and implementation plan docs, a public-safe workspace runtime attachment contract, an executable fleet spec with a Compose-backed shared-seed example, and a `fleetSmoke` scenario that materializes the declared topology and records resolved fleet artifacts.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

  Verified with:
  - `pnpm exec tsx e2e/bin/run-local.ts list`
  - `pnpm run e2e:fleet-smoke`
  - `pnpm run e2e:smoke`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] No new warnings introduced