### PR TITLE
add fleet cleanup and workspace bootstrap template

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -54,6 +54,14 @@ pnpm run e2e:fleet-ready
 
 This scenario materializes swarm groups from the fleet spec, joins workers, bootstraps them from the shared seed peer, and records a readiness snapshot.
 
+## Run the fleet cleanup scenario
+
+```fish
+pnpm run e2e:fleet-cleanup
+```
+
+This scenario proves ephemeral worker peers can be removed from coordinator and local peer state while protecting the shared seed peer.
+
 ## Run the bootstrap scenario
 
 ```fish

--- a/e2e/bin/run-local.ts
+++ b/e2e/bin/run-local.ts
@@ -1,4 +1,5 @@
 import { runFleetReadyScenario } from "../scenarios/fleet-ready.js";
+import { runFleetCleanupScenario } from "../scenarios/fleet-cleanup.js";
 import { runFleetSmokeScenario } from "../scenarios/fleet-smoke.js";
 import { runBootstrapScenario } from "../scenarios/bootstrap.js";
 import { runCoordinatorScenario } from "../scenarios/coordinator.js";
@@ -10,6 +11,7 @@ const scenarios = {
 	bootstrap: runBootstrapScenario,
 	coordinator: runCoordinatorScenario,
 	directSync: runDirectSyncScenario,
+	fleetCleanup: runFleetCleanupScenario,
 	fleetReady: runFleetReadyScenario,
 	fleetSmoke: runFleetSmokeScenario,
 	smoke: runSmokeScenario,

--- a/e2e/scenarios/fleet-cleanup.ts
+++ b/e2e/scenarios/fleet-cleanup.ts
@@ -1,0 +1,304 @@
+import { assert, assertStatus } from "../lib/assert.js";
+import {
+	ADMIN_SECRET,
+	CLI_PREFIX,
+	parseJson,
+	readPeerIdentity,
+	writePeerConfig,
+} from "../lib/coordinator.js";
+import { collectComposeServices, loadFleetSpec } from "../fleet/spec.js";
+import type { ScenarioContext } from "../lib/scenario-context.js";
+import { seedPeer } from "../lib/seed.js";
+
+const DEFAULT_SPEC_PATH = "e2e/fleet/examples/compose-shared-seed.json";
+const processRef = globalThis as typeof globalThis & {
+	process: { env: Record<string, string | undefined> };
+};
+
+function removeCoordinatorDevice(
+	ctx: ScenarioContext,
+	service: string,
+	groupId: string,
+	deviceId: string,
+	artifactName: string,
+) {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"node",
+			"--input-type=module",
+			"-e",
+			`const res = await fetch('http://127.0.0.1:7347/v1/admin/devices/remove', { method: 'POST', headers: { 'content-type': 'application/json', 'X-Codemem-Coordinator-Admin': '${ADMIN_SECRET}' }, body: JSON.stringify({ group_id: '${groupId}', device_id: '${deviceId}' }) }); const body = await res.text(); console.log(body); if (res.status !== 200) throw new Error('coordinator remove failed');`,
+		],
+		artifactName,
+		60_000,
+	);
+	assertStatus(result.status, 0, `failed to remove device ${deviceId} from coordinator group ${groupId}`);
+	return parseJson<{ ok: boolean }>(result.stdout, artifactName);
+}
+
+function removeLocalPeer(ctx: ScenarioContext, service: string, peerDeviceId: string, artifactName: string) {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"pnpm",
+			"exec",
+			"tsx",
+			"--conditions",
+			"source",
+			"e2e/scripts/remove-local-peer.ts",
+			"--peer-device-id",
+			peerDeviceId,
+			"--db-path",
+			"/data/mem.sqlite",
+		],
+		artifactName,
+		60_000,
+	);
+	assertStatus(result.status, 0, `failed to remove local peer ${peerDeviceId} on ${service}`);
+	return parseJson<{ ok: boolean; peer_device_id: string }>(result.stdout, artifactName);
+}
+
+function pinPeer(
+	ctx: ScenarioContext,
+	service: string,
+	peerDeviceId: string,
+	fingerprint: string,
+	publicKey: string,
+	address: string,
+	artifactName: string,
+) {
+	const result = ctx.compose.exec(
+		service,
+		[
+			"pnpm",
+			"exec",
+			"tsx",
+			"--conditions",
+			"source",
+			"e2e/scripts/pin-peer.ts",
+			"--peer-device-id",
+			peerDeviceId,
+			"--fingerprint",
+			fingerprint,
+			"--public-key",
+			publicKey,
+			"--address",
+			address,
+			"--db-path",
+			"/data/mem.sqlite",
+		],
+		artifactName,
+		120_000,
+	);
+	assertStatus(result.status, 0, `failed to pin peer ${peerDeviceId} on ${service}`);
+}
+
+export async function runFleetCleanupScenario(ctx: ScenarioContext): Promise<void> {
+	const specPath = processRef.process.env.CODEMEM_E2E_FLEET_SPEC?.trim() || DEFAULT_SPEC_PATH;
+	const spec = loadFleetSpec(specPath);
+	const coordinatorService = spec.coordinator.runtime.service ?? "coordinator";
+	const seedService = spec.seed_peer.runtime.service;
+	assert(seedService, "seed peer compose service missing");
+
+	ctx.recordNote(
+		"scenario.txt",
+		"Fleet cleanup scenario: materialize workers from the fleet spec, then remove ephemeral workers from coordinator and local peer state while protecting the shared seed peer.",
+	);
+	ctx.recordNote("fleet-spec.json", JSON.stringify(spec, null, 2));
+
+	ctx.compose.down("00-compose-down-pre", true);
+	ctx.compose.up(collectComposeServices(spec), "01-compose-up");
+	ctx.compose.ps("02-compose-ps");
+
+	seedPeer(ctx.compose, ctx.artifactsDir, seedService, "empty", "03-seed-shared-seed");
+	writePeerConfig(
+		ctx,
+		seedService,
+		{
+			sync_enabled: true,
+			sync_host: "0.0.0.0",
+			sync_port: 7337,
+			sync_interval_s: 5,
+			sync_coordinator_url: "http://coordinator:7347",
+			sync_coordinator_group: spec.swarms[0]?.coordinator_group ?? "",
+			sync_coordinator_groups: spec.swarms.map((swarm) => swarm.coordinator_group),
+			sync_coordinator_admin_secret: ADMIN_SECRET,
+		},
+		"04-write-seed-config",
+	);
+	const enableSeed = ctx.compose.exec(
+		seedService,
+		[...CLI_PREFIX, "sync", "enable", "--db-path", "/data/mem.sqlite", "--host", "0.0.0.0", "--port", "7337", "--interval", "5"],
+		"05-enable-seed",
+		120_000,
+	);
+	assertStatus(enableSeed.status, 0, "failed to enable sync on seed peer");
+
+	const seedIdentity = readPeerIdentity(ctx, seedService, "06-seed-identity");
+	const cleanupResults: Array<Record<string, unknown>> = [];
+
+	for (const swarm of spec.swarms) {
+		const groupCreate = ctx.compose.exec(
+			coordinatorService,
+			[...CLI_PREFIX, "sync", "coordinator", "group-create", swarm.coordinator_group, "--db-path", "/data/coordinator.sqlite"],
+			`07-group-create-${swarm.id}`,
+			120_000,
+		);
+		assertStatus(groupCreate.status, 0, `failed to create group ${swarm.id}`);
+		const enrollSeed = ctx.compose.exec(
+			coordinatorService,
+			[
+				...CLI_PREFIX,
+				"sync",
+				"coordinator",
+				"enroll-device",
+				swarm.coordinator_group,
+				seedIdentity.device_id,
+				"--fingerprint",
+				seedIdentity.fingerprint,
+				"--public-key",
+				seedIdentity.public_key,
+				"--db-path",
+				"/data/coordinator.sqlite",
+				"--json",
+			],
+			`08-enroll-seed-${swarm.id}`,
+			120_000,
+		);
+		assertStatus(enrollSeed.status, 0, `failed to enroll seed for ${swarm.id}`);
+
+		const inviteResult = ctx.compose.exec(
+			seedService,
+			[...CLI_PREFIX, "sync", "coordinator", "create-invite", swarm.coordinator_group, "--policy", "approval_required", "--json"],
+			`09-create-invite-${swarm.id}`,
+			120_000,
+		);
+		assertStatus(inviteResult.status, 0, `failed to create invite for ${swarm.id}`);
+		const invitePayload = parseJson<{ encoded: string }>(inviteResult.stdout, `invite-${swarm.id}`);
+
+		for (const worker of swarm.workers) {
+			const service = worker.runtime.service;
+			assert(service, `worker '${worker.id}' missing compose service`);
+			seedPeer(ctx.compose, ctx.artifactsDir, service, "empty", `10-seed-${worker.id}-empty`);
+			writePeerConfig(
+				ctx,
+				service,
+				{
+					sync_enabled: true,
+					sync_host: "0.0.0.0",
+					sync_port: 7337,
+					sync_interval_s: 5,
+					sync_coordinator_url: "http://coordinator:7347",
+					sync_coordinator_group: swarm.coordinator_group,
+					sync_coordinator_admin_secret: ADMIN_SECRET,
+				},
+				`11-write-config-${worker.id}`,
+			);
+			const importResult = ctx.compose.exec(
+				service,
+				[
+					...CLI_PREFIX,
+					"sync",
+					"coordinator",
+					"import-invite",
+					invitePayload.encoded,
+					"--db-path",
+					"/data/mem.sqlite",
+					"--keys-dir",
+					"/keys",
+					"--config",
+					"/config/codemem.json",
+					"--json",
+				],
+				`12-import-invite-${worker.id}`,
+				120_000,
+			);
+			assertStatus(importResult.status, 0, `failed to import invite on ${worker.id}`);
+			const enableWorker = ctx.compose.exec(
+				service,
+				[...CLI_PREFIX, "sync", "enable", "--db-path", "/data/mem.sqlite", "--host", "0.0.0.0", "--port", "7337", "--interval", "5"],
+				`13-enable-${worker.id}`,
+				120_000,
+			);
+			assertStatus(enableWorker.status, 0, `failed to enable worker ${worker.id}`);
+			const joinRequestsResult = ctx.compose.exec(
+				coordinatorService,
+				[...CLI_PREFIX, "sync", "coordinator", "list-join-requests", swarm.coordinator_group, "--db-path", "/data/coordinator.sqlite", "--json"],
+				`14-list-join-requests-${worker.id}`,
+				120_000,
+			);
+			assertStatus(joinRequestsResult.status, 0, `failed to list join requests for ${worker.id}`);
+			const joinRequests = parseJson<Array<{ request_id: string }>>(joinRequestsResult.stdout, `join-requests-${worker.id}`);
+			const requestId = joinRequests[joinRequests.length - 1]?.request_id;
+			assert(requestId, `missing join request for ${worker.id}`);
+			const approveResult = ctx.compose.exec(
+				coordinatorService,
+				[
+					...CLI_PREFIX,
+					"sync",
+					"coordinator",
+					"approve-join-request",
+					requestId,
+					"--db-path",
+					"/data/coordinator.sqlite",
+					"--json",
+				],
+				`15-approve-${worker.id}`,
+				120_000,
+			);
+			assertStatus(approveResult.status, 0, `failed to approve ${worker.id}`);
+
+			const workerIdentity = readPeerIdentity(ctx, service, `16-identity-${worker.id}`);
+			pinPeer(
+				ctx,
+				seedService,
+				workerIdentity.device_id,
+				workerIdentity.fingerprint,
+				workerIdentity.public_key,
+				`${service}:7337`,
+				`17-pin-${worker.id}-on-seed`,
+			);
+			const coordinatorRemoval = removeCoordinatorDevice(
+				ctx,
+				coordinatorService,
+				swarm.coordinator_group,
+				workerIdentity.device_id,
+				`18-remove-coordinator-${worker.id}`,
+			);
+			const localSeedRemoval = removeLocalPeer(ctx, seedService, workerIdentity.device_id, `19-remove-seed-peer-${worker.id}`);
+			cleanupResults.push({
+				worker_id: worker.id,
+				worker_device_id: workerIdentity.device_id,
+				swarm_id: swarm.id,
+				group_id: swarm.coordinator_group,
+				coordinator_removed: coordinatorRemoval.ok,
+				seed_removed: localSeedRemoval.ok,
+			});
+		}
+	}
+
+	const devicesResult = ctx.compose.exec(
+		seedService,
+		[
+			"node",
+			"--input-type=module",
+			"-e",
+			`const groups = ${JSON.stringify(spec.swarms.map((swarm) => swarm.coordinator_group))}; const out = []; for (const groupId of groups) { const res = await fetch('http://coordinator:7347/v1/admin/devices?group_id=' + encodeURIComponent(groupId), { headers: { 'X-Codemem-Coordinator-Admin': '${ADMIN_SECRET}' } }); const body = await res.json(); out.push({ group_id: groupId, items: body.items ?? [] }); } console.log(JSON.stringify(out, null, 2));`,
+		],
+		"20-list-devices-post-cleanup",
+		60_000,
+	);
+	assertStatus(devicesResult.status, 0, "failed to inspect coordinator devices after cleanup");
+	const groups = parseJson<Array<{ group_id: string; items: Array<{ device_id?: string }> }>>(devicesResult.stdout, "post-cleanup-devices");
+	for (const group of groups) {
+		assert(group.items.length === 1, `expected only seed peer to remain in ${group.group_id}, got ${group.items.length}`);
+		assert(group.items[0]?.device_id === seedIdentity.device_id, `expected seed peer to remain in ${group.group_id}`);
+	}
+
+	ctx.recordNote("fleet-cleanup.json", JSON.stringify({ ok: true, workers_removed: cleanupResults }, null, 2));
+
+	if (!ctx.keepStackOnFailure) {
+		ctx.compose.down("21-compose-down-post");
+	}
+}

--- a/e2e/scripts/pin-peer.ts
+++ b/e2e/scripts/pin-peer.ts
@@ -1,0 +1,56 @@
+import { connect } from "../../packages/core/src/db.ts";
+
+const processRef = globalThis as typeof globalThis & {
+	process: { argv: string[] };
+};
+
+function parseArgs(argv: string[]) {
+	let dbPath = "/data/mem.sqlite";
+	let peerDeviceId = "";
+	let fingerprint = "";
+	let publicKey = "";
+	let address = "";
+	for (let index = 2; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--db-path") {
+			dbPath = String(argv[index + 1] ?? dbPath);
+			index += 1;
+		} else if (arg === "--peer-device-id") {
+			peerDeviceId = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--fingerprint") {
+			fingerprint = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--public-key") {
+			publicKey = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--address") {
+			address = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		}
+	}
+	if (!peerDeviceId || !fingerprint || !publicKey) {
+		throw new Error("--peer-device-id, --fingerprint, and --public-key are required");
+	}
+	return { dbPath, peerDeviceId, fingerprint, publicKey, address };
+}
+
+const { dbPath, peerDeviceId, fingerprint, publicKey, address } = parseArgs(processRef.process.argv);
+const db = connect(dbPath);
+try {
+	const now = new Date().toISOString();
+	const addressesJson = JSON.stringify(address ? [address] : []);
+	db.prepare(
+		`INSERT INTO sync_peers(
+			peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at, last_seen_at
+		 ) VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(peer_device_id) DO UPDATE SET
+			pinned_fingerprint = excluded.pinned_fingerprint,
+			public_key = excluded.public_key,
+			addresses_json = excluded.addresses_json,
+			last_seen_at = excluded.last_seen_at`,
+	).run(peerDeviceId, fingerprint, publicKey, addressesJson, now, now);
+	console.log(JSON.stringify({ ok: true, peer_device_id: peerDeviceId }, null, 2));
+} finally {
+	db.close();
+}

--- a/e2e/scripts/remove-local-peer.ts
+++ b/e2e/scripts/remove-local-peer.ts
@@ -1,0 +1,35 @@
+import { connect } from "../../packages/core/src/db.ts";
+
+const processRef = globalThis as typeof globalThis & {
+	process: { argv: string[] };
+};
+
+function parseArgs(argv: string[]) {
+	let dbPath = "/data/mem.sqlite";
+	let peerDeviceId = "";
+	for (let index = 2; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--db-path") {
+			dbPath = String(argv[index + 1] ?? dbPath);
+			index += 1;
+		} else if (arg === "--peer-device-id") {
+			peerDeviceId = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		}
+	}
+	if (!peerDeviceId) throw new Error("--peer-device-id is required");
+	return { dbPath, peerDeviceId };
+}
+
+const { dbPath, peerDeviceId } = parseArgs(processRef.process.argv);
+const db = connect(dbPath);
+try {
+	const cursorResult = db.prepare("DELETE FROM replication_cursors WHERE peer_device_id = ?").run(peerDeviceId);
+	const peerResult = db.prepare("DELETE FROM sync_peers WHERE peer_device_id = ?").run(peerDeviceId);
+	if (peerResult.changes < 1) throw new Error("peer not found");
+	console.log(
+		JSON.stringify({ ok: true, peer_device_id: peerDeviceId, removed_peer_rows: peerResult.changes, removed_cursor_rows: cursorResult.changes }, null, 2),
+	);
+} finally {
+	db.close();
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "e2e:bootstrap": "pnpm exec tsx e2e/bin/run-local.ts bootstrap",
     "e2e:coordinator": "pnpm exec tsx e2e/bin/run-local.ts coordinator",
     "e2e:direct-sync": "pnpm exec tsx e2e/bin/run-local.ts directSync",
+    "e2e:fleet-cleanup": "pnpm exec tsx e2e/bin/run-local.ts fleetCleanup",
     "e2e:fleet-ready": "pnpm exec tsx e2e/bin/run-local.ts fleetReady",
     "e2e:fleet-smoke": "pnpm exec tsx e2e/bin/run-local.ts fleetSmoke",
     "e2e:smoke": "pnpm exec tsx e2e/bin/run-local.ts smoke",

--- a/scripts/templates/workspace-codemem-bootstrap.sh
+++ b/scripts/templates/workspace-codemem-bootstrap.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env sh
+set -eu
+
+# Public-safe template for attaching codemem to a pre-provisioned workspace runtime.
+#
+# This script is intentionally generic. It assumes the workspace already exists and
+# that agent execution is handled elsewhere. Its only job is to install/configure
+# codemem, initialize identity, join the correct coordinator group, bootstrap from
+# the seed peer when needed, and verify readiness.
+
+require_var() {
+  name="$1"
+  value="$2"
+  if [ -z "$value" ]; then
+    printf '%s\n' "$name is required" >&2
+    exit 1
+  fi
+}
+
+CODEMEM_NODE_ROLE="${CODEMEM_NODE_ROLE:-}"
+CODEMEM_DB="${CODEMEM_DB:-}"
+CODEMEM_CONFIG="${CODEMEM_CONFIG:-}"
+CODEMEM_KEYS_DIR="${CODEMEM_KEYS_DIR:-}"
+CODEMEM_COORDINATOR_URL="${CODEMEM_COORDINATOR_URL:-}"
+CODEMEM_COORDINATOR_GROUP="${CODEMEM_COORDINATOR_GROUP:-}"
+CODEMEM_SYNC_HOST="${CODEMEM_SYNC_HOST:-0.0.0.0}"
+CODEMEM_SYNC_PORT="${CODEMEM_SYNC_PORT:-7337}"
+CODEMEM_INVITE="${CODEMEM_INVITE:-}"
+CODEMEM_SEED_PEER_DEVICE_ID="${CODEMEM_SEED_PEER_DEVICE_ID:-}"
+CODEMEM_SEED_PEER_FINGERPRINT="${CODEMEM_SEED_PEER_FINGERPRINT:-}"
+CODEMEM_SEED_PEER_PUBLIC_KEY="${CODEMEM_SEED_PEER_PUBLIC_KEY:-}"
+CODEMEM_SEED_PEER_ADDRESS="${CODEMEM_SEED_PEER_ADDRESS:-}"
+
+require_var CODEMEM_NODE_ROLE "$CODEMEM_NODE_ROLE"
+require_var CODEMEM_DB "$CODEMEM_DB"
+require_var CODEMEM_CONFIG "$CODEMEM_CONFIG"
+require_var CODEMEM_KEYS_DIR "$CODEMEM_KEYS_DIR"
+require_var CODEMEM_COORDINATOR_URL "$CODEMEM_COORDINATOR_URL"
+require_var CODEMEM_COORDINATOR_GROUP "$CODEMEM_COORDINATOR_GROUP"
+
+mkdir -p "$(dirname "$CODEMEM_DB")"
+mkdir -p "$(dirname "$CODEMEM_CONFIG")"
+mkdir -p "$CODEMEM_KEYS_DIR"
+
+cat > "$CODEMEM_CONFIG" <<EOF
+{
+  "sync_enabled": true,
+  "sync_host": "$CODEMEM_SYNC_HOST",
+  "sync_port": $CODEMEM_SYNC_PORT,
+  "sync_interval_s": 5,
+  "sync_coordinator_url": "$CODEMEM_COORDINATOR_URL",
+  "sync_coordinator_group": "$CODEMEM_COORDINATOR_GROUP"
+}
+EOF
+
+printf '%s\n' '{"status":"configured"}'
+
+if [ "$CODEMEM_NODE_ROLE" = "seed-peer" ]; then
+  pnpm run codemem -- sync enable --db-path "$CODEMEM_DB" --host "$CODEMEM_SYNC_HOST" --port "$CODEMEM_SYNC_PORT" --interval 5
+  printf '%s\n' '{"status":"ready","role":"seed-peer"}'
+  exit 0
+fi
+
+if [ "$CODEMEM_NODE_ROLE" = "worker-peer" ]; then
+  require_var CODEMEM_INVITE "$CODEMEM_INVITE"
+  require_var CODEMEM_SEED_PEER_DEVICE_ID "$CODEMEM_SEED_PEER_DEVICE_ID"
+  require_var CODEMEM_SEED_PEER_FINGERPRINT "$CODEMEM_SEED_PEER_FINGERPRINT"
+  require_var CODEMEM_SEED_PEER_PUBLIC_KEY "$CODEMEM_SEED_PEER_PUBLIC_KEY"
+  require_var CODEMEM_SEED_PEER_ADDRESS "$CODEMEM_SEED_PEER_ADDRESS"
+
+  pnpm run codemem -- sync coordinator import-invite "$CODEMEM_INVITE" --db-path "$CODEMEM_DB" --keys-dir "$CODEMEM_KEYS_DIR" --config "$CODEMEM_CONFIG" --json
+  pnpm run codemem -- sync enable --db-path "$CODEMEM_DB" --host "$CODEMEM_SYNC_HOST" --port "$CODEMEM_SYNC_PORT" --interval 5
+  node --input-type=module -e "import Database from 'better-sqlite3'; const db = new Database(process.env.CODEMEM_DB); const now = new Date().toISOString(); const addrJson = JSON.stringify([process.env.CODEMEM_SEED_PEER_ADDRESS]); db.prepare(\"INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(peer_device_id) DO UPDATE SET pinned_fingerprint = excluded.pinned_fingerprint, public_key = excluded.public_key, addresses_json = excluded.addresses_json, last_seen_at = excluded.last_seen_at\").run(process.env.CODEMEM_SEED_PEER_DEVICE_ID, process.env.CODEMEM_SEED_PEER_FINGERPRINT, process.env.CODEMEM_SEED_PEER_PUBLIC_KEY, addrJson, now, now); db.close();"
+  pnpm run codemem -- sync bootstrap --peer "$CODEMEM_SEED_PEER_DEVICE_ID" --db-path "$CODEMEM_DB" --keys-dir "$CODEMEM_KEYS_DIR" --json --force
+  pnpm run codemem -- sync once --db-path "$CODEMEM_DB"
+  printf '%s\n' '{"status":"ready","role":"worker-peer"}'
+  exit 0
+fi
+
+printf '%s\n' "Unsupported CODEMEM_NODE_ROLE: $CODEMEM_NODE_ROLE" >&2
+exit 1


### PR DESCRIPTION
## Description
This PR adds the first operator-facing cleanup and runtime-template layer for the fleet pilot. It introduces `fleetCleanup`, which proves ephemeral worker peers can be removed safely without touching the shared seed peer, and adds a public-safe workspace bootstrap script template aligned with the workspace runtime attachment contract.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

  Verified with:
  - `sh -n "scripts/templates/workspace-codemem-bootstrap.sh"`
  - `pnpm run e2e:fleet-cleanup`
  - `pnpm run e2e:fleet-ready`
  - `pnpm run e2e:fleet-smoke`
  - `pnpm run e2e:smoke`

## Checklist
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] No new warnings introduced