### PR TITLE
Add config-first workspace config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,13 @@ This updates your OpenCode config to install the plugin and register the MCP ser
 
 ## Configuration
 
-Config file: `~/.config/codemem/config.json` (override with `CODEMEM_CONFIG`). Environment variables take precedence over file settings.
+Config resolution precedence for runtime commands is:
+
+1. explicit `CODEMEM_CONFIG`
+2. workspace-scoped config derived from `CODEMEM_RUNTIME_ROOT` or `CODEMEM_WORKSPACE_ID`
+3. legacy global config at `~/.config/codemem/config.json{c}`
+
+Environment variables still override file values once a config file has been selected.
 
 Common overrides:
 
@@ -190,7 +196,7 @@ Replicate memories across devices without a central server.
 ```text
 codemem sync enable        # generate device keys
 codemem sync pair          # generate pairing payload
-codemem sync start         # start sync daemon
+codemem sync start         # start the viewer-backed sync runtime
 codemem sync once          # run one immediate sync pass
 ```
 

--- a/docs/contracts/pre-provisioned-workspace-runtime-attachment.md
+++ b/docs/contracts/pre-provisioned-workspace-runtime-attachment.md
@@ -38,7 +38,7 @@ Each workspace attachment operation must receive the following inputs.
 ### Runtime target information
 
 - `workspace_selector` or equivalent target identifier
-- `config_path`
+- `config_path` (for the current codemem CLI/runtime this should be translated to `CODEMEM_CONFIG` or `--config`)
 - `db_path`
 - `keys_path`
 - `bootstrap_hook` or startup script entrypoint
@@ -91,6 +91,12 @@ Expected outcome:
 ### 2. Configure
 
 The runtime adapter writes or updates codemem configuration for the node.
+
+Recommended config resolution precedence for workspace automation:
+
+1. explicit `config_path` translated to the runtime's actual config selector (`CODEMEM_CONFIG` or `--config`)
+2. workspace-scoped config derived from runtime root / workspace identifier
+3. legacy global config fallback
 
 Expected configuration includes:
 - database path

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -26,7 +26,10 @@
 - Connection/auth settings map to `claude_command`, `observer_runtime`, `observer_provider`, `observer_model`, `observer_base_url`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, and `observer_headers`.
 - Sync settings can also be updated here (`sync_enabled`, `sync_host`, `sync_port`, `sync_interval_s`, `sync_mdns`).
 - Environment variables still override file values.
-- Config file supports JSON and JSONC (`~/.config/codemem/config.json` or `~/.config/codemem/config.jsonc`).
+- Config resolution supports JSON and JSONC with this precedence:
+  1. explicit `CODEMEM_CONFIG`
+  2. workspace-scoped config derived from `CODEMEM_RUNTIME_ROOT` or `CODEMEM_WORKSPACE_ID`
+  3. legacy global config (`~/.config/codemem/config.json` or `~/.config/codemem/config.jsonc`)
 
 ## Observer auth configuration
 
@@ -100,7 +103,7 @@ Command/file token caching notes:
 ### Enable + run
 
 - `codemem sync enable` generates keys and writes config.
-- `codemem sync start` starts sync daemon processing.
+- `codemem sync start` starts the viewer-backed sync runtime.
 - `codemem sync status` shows device info and peer health.
 
 ### Pair devices
@@ -144,7 +147,8 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 
 ### Service helpers
 
-- `codemem sync status` and `codemem sync start|stop|restart` for daemon control.
+- `codemem sync status` shows sync config and peer health.
+- `codemem sync start|stop|restart` currently manage the viewer-backed sync runtime rather than a separate sync-only daemon.
 
 ### Coordinator-backed discovery
 

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1,0 +1,151 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	buildWorkspaceConfigPatch,
+	configCommand,
+	mergeWorkspaceConfig,
+	runWorkspaceConfigCommand,
+} from "./config.js";
+
+describe("runWorkspaceConfigCommand", () => {
+	let tmpHome: string;
+	let prevHome: string | undefined;
+
+	beforeEach(() => {
+		tmpHome = mkdtempSync(join(tmpdir(), "codemem-config-command-"));
+		prevHome = process.env.HOME;
+		process.env.HOME = tmpHome;
+	});
+
+	afterEach(() => {
+		if (prevHome == null) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		rmSync(tmpHome, { recursive: true, force: true });
+	});
+
+	it("rejects no-op workspace config writes", () => {
+		expect(() => runWorkspaceConfigCommand({ workspaceId: "pilot-1" })).toThrow(
+			"Provide at least one config field to update",
+		);
+	});
+
+	it("rejects conflicting sync enable flags", () => {
+		expect(() =>
+			runWorkspaceConfigCommand({
+				workspaceId: "pilot-1",
+				enableSync: true,
+				disableSync: true,
+			}),
+		).toThrow("Use only one of --enable-sync or --disable-sync");
+	});
+
+	it("writes the workspace config file and reports updated keys", () => {
+		const result = runWorkspaceConfigCommand({
+			workspaceId: "pilot-1",
+			enableSync: true,
+			syncHost: "0.0.0.0",
+			coordinatorGroup: "team-a",
+			json: true,
+		});
+		expect(result.config_path).toBe(
+			join(tmpHome, ".codemem", "workspaces", "pilot-1", "config", "codemem.json"),
+		);
+		expect(result.updated_keys).toEqual(["sync_coordinator_group", "sync_enabled", "sync_host"]);
+		expect(result.config).toMatchObject({
+			sync_enabled: true,
+			sync_host: "0.0.0.0",
+			sync_coordinator_group: "team-a",
+		});
+	});
+
+	it("seeds a first workspace config from the currently effective config", () => {
+		process.env.CODEMEM_CONFIG = join(tmpHome, ".config", "codemem", "config.json");
+		const result = runWorkspaceConfigCommand({
+			workspaceId: "pilot-3",
+			coordinatorGroup: "team-c",
+		});
+		expect(result.config).toMatchObject({
+			sync_coordinator_group: "team-c",
+		});
+	});
+
+	it("supports the commander command path with json output", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			await configCommand.parseAsync(
+				[
+					"workspace",
+					"--workspace-id",
+					"pilot-2",
+					"--enable-sync",
+					"--coordinator-group",
+					"team-b",
+					"--json",
+				],
+				{ from: "user" },
+			);
+			const output = logSpy.mock.calls.at(-1)?.[0];
+			expect(typeof output).toBe("string");
+			expect(JSON.parse(String(output))).toMatchObject({
+				workspace_id: "pilot-2",
+				updated_keys: ["sync_coordinator_group", "sync_enabled"],
+			});
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+});
+
+describe("buildWorkspaceConfigPatch", () => {
+	it("builds a patch from supported sync options", () => {
+		expect(
+			buildWorkspaceConfigPatch({
+				workspaceId: "pilot-1",
+				syncEnabled: true,
+				syncHost: "0.0.0.0",
+				syncPort: "47337",
+				syncIntervalS: "5",
+				coordinatorUrl: "http://coord.example.test:47347",
+				coordinatorGroup: "team-a",
+			}),
+		).toEqual({
+			sync_enabled: true,
+			sync_host: "0.0.0.0",
+			sync_port: 47337,
+			sync_interval_s: 5,
+			sync_coordinator_url: "http://coord.example.test:47347",
+			sync_coordinator_group: "team-a",
+		});
+	});
+
+	it("ignores unset values and preserves disable-sync", () => {
+		expect(
+			buildWorkspaceConfigPatch({
+				workspaceId: "pilot-1",
+				syncEnabled: false,
+			}),
+		).toEqual({ sync_enabled: false });
+	});
+
+	it("rejects invalid numeric flags", () => {
+		expect(() =>
+			buildWorkspaceConfigPatch({
+				workspaceId: "pilot-1",
+				syncPort: "not-a-port",
+			}),
+		).toThrow("Invalid --sync-port");
+	});
+});
+
+describe("mergeWorkspaceConfig", () => {
+	it("merges the patch over existing config", () => {
+		expect(
+			mergeWorkspaceConfig(
+				{ sync_enabled: false, observer_model: "gpt-5.1" },
+				{ sync_enabled: true, sync_port: 47337 },
+			),
+		).toEqual({ sync_enabled: true, observer_model: "gpt-5.1", sync_port: 47337 });
+	});
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,122 @@
+import { existsSync } from "node:fs";
+import {
+	getWorkspaceCodememConfigPath,
+	readCodememConfigFile,
+	readCodememConfigFileAtPath,
+	writeCodememConfigFile,
+} from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+
+type WorkspaceConfigOptions = {
+	workspaceId: string;
+	syncEnabled?: boolean;
+	syncHost?: string;
+	syncPort?: string;
+	syncIntervalS?: string;
+	coordinatorUrl?: string;
+	coordinatorGroup?: string;
+	json?: boolean;
+};
+
+type WorkspaceConfigResult = {
+	workspace_id: string;
+	config_path: string;
+	updated_keys: string[];
+	config: Record<string, unknown>;
+};
+
+function parseIntegerOption(value: string | undefined, flagName: string): number | undefined {
+	if (value == null) return undefined;
+	const trimmed = value.trim();
+	if (!/^\d+$/.test(trimmed)) {
+		throw new Error(`Invalid ${flagName}: ${value}`);
+	}
+	return Number.parseInt(trimmed, 10);
+}
+
+function buildWorkspaceConfigPatch(opts: WorkspaceConfigOptions): Record<string, unknown> {
+	const patch: Record<string, unknown> = {};
+	if (opts.syncEnabled === true) patch.sync_enabled = true;
+	if (opts.syncEnabled === false) patch.sync_enabled = false;
+	if (opts.syncHost?.trim()) patch.sync_host = opts.syncHost.trim();
+	const syncPort = parseIntegerOption(opts.syncPort, "--sync-port");
+	if (syncPort != null) patch.sync_port = syncPort;
+	const syncInterval = parseIntegerOption(opts.syncIntervalS, "--sync-interval-s");
+	if (syncInterval != null) patch.sync_interval_s = syncInterval;
+	if (opts.coordinatorUrl?.trim()) patch.sync_coordinator_url = opts.coordinatorUrl.trim();
+	if (opts.coordinatorGroup?.trim()) patch.sync_coordinator_group = opts.coordinatorGroup.trim();
+	return patch;
+}
+
+function mergeWorkspaceConfig(
+	existingConfig: Record<string, unknown>,
+	patch: Record<string, unknown>,
+): Record<string, unknown> {
+	return { ...existingConfig, ...patch };
+}
+
+function runWorkspaceConfigCommand(
+	opts: WorkspaceConfigOptions & { enableSync?: boolean; disableSync?: boolean },
+): WorkspaceConfigResult {
+	if (opts.enableSync && opts.disableSync) {
+		throw new Error("Use only one of --enable-sync or --disable-sync");
+	}
+	const configPath = getWorkspaceCodememConfigPath(opts.workspaceId);
+	const existingConfig = existsSync(configPath)
+		? readCodememConfigFileAtPath(configPath)
+		: readCodememConfigFile();
+	const patch = buildWorkspaceConfigPatch({
+		workspaceId: opts.workspaceId,
+		syncEnabled: opts.enableSync ? true : opts.disableSync ? false : undefined,
+		syncHost: opts.syncHost,
+		syncPort: opts.syncPort,
+		syncIntervalS: opts.syncIntervalS,
+		coordinatorUrl: opts.coordinatorUrl,
+		coordinatorGroup: opts.coordinatorGroup,
+		json: opts.json,
+	});
+	if (Object.keys(patch).length === 0) {
+		throw new Error("Provide at least one config field to update");
+	}
+	const nextConfig = mergeWorkspaceConfig(existingConfig, patch);
+	const savedPath = writeCodememConfigFile(nextConfig, configPath);
+	return {
+		workspace_id: opts.workspaceId,
+		config_path: savedPath,
+		updated_keys: Object.keys(patch).sort(),
+		config: nextConfig,
+	};
+}
+
+export const configCommand = new Command("config")
+	.configureHelp(helpStyle)
+	.description("Manage codemem configuration");
+
+configCommand.addCommand(
+	new Command("workspace")
+		.configureHelp(helpStyle)
+		.description("Create or update workspace-scoped codemem config")
+		.requiredOption("--workspace-id <id>", "workspace identifier")
+		.option("--enable-sync", "set sync_enabled=true")
+		.option("--disable-sync", "set sync_enabled=false")
+		.option("--sync-host <host>", "set sync_host")
+		.option("--sync-port <port>", "set sync_port")
+		.option("--sync-interval-s <seconds>", "set sync_interval_s")
+		.option("--coordinator-url <url>", "set sync_coordinator_url")
+		.option("--coordinator-group <group>", "set sync_coordinator_group")
+		.option("--json", "output as JSON")
+		.action((opts: WorkspaceConfigOptions & { enableSync?: boolean; disableSync?: boolean }) => {
+			const result = runWorkspaceConfigCommand(opts);
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			console.log(`Updated workspace config: ${result.config_path}`);
+			console.log(`Updated keys: ${result.updated_keys.join(", ")}`);
+		}),
+);
+
+export { buildWorkspaceConfigPatch, mergeWorkspaceConfig, runWorkspaceConfigCommand };

--- a/packages/cli/src/commands/serve-invocation.ts
+++ b/packages/cli/src/commands/serve-invocation.ts
@@ -5,6 +5,7 @@ export type ServeAction = ServeMode | undefined;
 export interface LegacyServeOptions {
 	db?: string;
 	dbPath?: string;
+	config?: string;
 	host: string;
 	port: string;
 	background?: boolean;
@@ -16,6 +17,7 @@ export interface LegacyServeOptions {
 export interface StartServeOptions {
 	db?: string;
 	dbPath?: string;
+	config?: string;
 	host: string;
 	port: string;
 	foreground?: boolean;
@@ -24,6 +26,7 @@ export interface StartServeOptions {
 export interface StopRestartServeOptions {
 	db?: string;
 	dbPath?: string;
+	config?: string;
 	host: string;
 	port: string;
 }
@@ -31,6 +34,7 @@ export interface StopRestartServeOptions {
 export interface ResolvedServeInvocation {
 	mode: ServeMode;
 	dbPath: string | null;
+	configPath: string | null;
 	host: string;
 	port: number;
 	background: boolean;
@@ -55,6 +59,7 @@ export function resolveLegacyServeInvocation(opts: LegacyServeOptions): Resolved
 	return {
 		mode: opts.stop ? "stop" : opts.restart ? "restart" : "start",
 		dbPath,
+		configPath: opts.config ?? null,
 		host: opts.host,
 		port: parsePort(opts.port),
 		background: opts.restart ? true : opts.background ? true : false,
@@ -82,6 +87,7 @@ export function resolveStartServeInvocation(opts: StartServeOptions): ResolvedSe
 	return {
 		mode: "start",
 		dbPath,
+		configPath: opts.config ?? null,
 		host: opts.host,
 		port: parsePort(opts.port),
 		background: !opts.foreground,
@@ -96,6 +102,7 @@ export function resolveStopRestartInvocation(
 	return {
 		mode,
 		dbPath,
+		configPath: opts.config ?? null,
 		host: opts.host,
 		port: parsePort(opts.port),
 		background: mode === "restart",

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -27,6 +27,7 @@ describe("serve command option resolution", () => {
 		expect(resolved).toEqual({
 			mode: "start",
 			dbPath: null,
+			configPath: null,
 			host: "127.0.0.1",
 			port: 38888,
 			background: false,
@@ -113,9 +114,11 @@ describe("serve command option resolution", () => {
 			host: "127.0.0.1",
 			port: "38888",
 			foreground: true,
+			config: "/tmp/workspace-config.json",
 		});
 		expect(resolved.mode).toBe("start");
 		expect(resolved.background).toBe(false);
+		expect(resolved.configPath).toBe("/tmp/workspace-config.json");
 	});
 
 	it("builds background child args from the current runner", () => {
@@ -124,6 +127,7 @@ describe("serve command option resolution", () => {
 			{
 				mode: "start",
 				dbPath: "/tmp/test.sqlite",
+				configPath: null,
 				host: "127.0.0.1",
 				port: 38991,
 				background: true,

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -10,6 +10,7 @@ import {
 	ObserverClient,
 	RawEventSweeper,
 	readCodememConfigFile,
+	readCodememConfigFileAtPath,
 	readCoordinatorSyncConfig,
 	resolveDbPath,
 	runSyncDaemon,
@@ -326,6 +327,7 @@ async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promi
 		env: {
 			...process.env,
 			...(invocation.dbPath ? { CODEMEM_DB: invocation.dbPath } : {}),
+			...(invocation.configPath ? { CODEMEM_CONFIG: invocation.configPath } : {}),
 		},
 	});
 	child.unref();
@@ -347,6 +349,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	const { serve } = await import("@hono/node-server");
 
 	if (invocation.dbPath) process.env.CODEMEM_DB = invocation.dbPath;
+	if (invocation.configPath) process.env.CODEMEM_CONFIG = invocation.configPath;
 	warnIfViewerExposed(invocation.host, invocation.port);
 	if (await isPortOpen(invocation.host, invocation.port)) {
 		p.log.warn(`Viewer already running at http://${invocation.host}:${invocation.port}`);
@@ -382,7 +385,9 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 
 	const syncAbort = new AbortController();
 	const retentionAbort = new AbortController();
-	const config = readCodememConfigFile();
+	const config = invocation.configPath
+		? readCodememConfigFileAtPath(invocation.configPath)
+		: readCodememConfigFile();
 	const syncConfig = readCoordinatorSyncConfig(config);
 	const syncEnabled = syncConfig.syncEnabled;
 	const retentionRunner = new SyncRetentionRunner({
@@ -607,6 +612,7 @@ function addSharedServeOptions(command: Command): Command {
 	return command
 		.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 		.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
+		.option("--config <path>", "config path (default: CODEMEM_CONFIG or resolved config)")
 		.option("--host <host>", "bind host", "127.0.0.1")
 		.option("--port <port>", "bind port", "38888");
 }

--- a/packages/cli/src/commands/sync-helpers.ts
+++ b/packages/cli/src/commands/sync-helpers.ts
@@ -17,6 +17,7 @@ export function formatSyncAttempt(row: SyncAttemptRow): string {
 export interface SyncLifecycleOptions {
 	db?: string;
 	dbPath?: string;
+	config?: string;
 	host?: string;
 	port?: string;
 	user?: boolean;
@@ -39,6 +40,7 @@ export function buildServeLifecycleArgs(
 		args.push("--restart");
 	}
 	if (opts.db ?? opts.dbPath) args.push("--db-path", opts.db ?? opts.dbPath ?? "");
+	if (opts.config) args.push("--config", opts.config);
 	if (opts.host) args.push("--host", opts.host);
 	if (opts.port) args.push("--port", opts.port);
 	return args;

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -81,6 +81,25 @@ describe("formatSyncAttempt", () => {
 		]);
 	});
 
+	it("passes config path through sync lifecycle args", () => {
+		expect(
+			buildServeLifecycleArgs(
+				"start",
+				{ dbPath: "/tmp/test.sqlite", config: "/tmp/workspace-config.json" },
+				"/repo/packages/cli/src/index.ts",
+				[],
+			),
+		).toEqual([
+			"/repo/packages/cli/src/index.ts",
+			"serve",
+			"--restart",
+			"--db-path",
+			"/tmp/test.sqlite",
+			"--config",
+			"/tmp/workspace-config.json",
+		]);
+	});
+
 	it("builds sync restart as a serve restart invocation", () => {
 		expect(
 			buildServeLifecycleArgs(

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -33,6 +33,8 @@ import {
 	loadPublicKey,
 	MemoryStore,
 	readCodememConfigFile,
+	readCodememConfigFileAtPath,
+	readCoordinatorSyncConfig,
 	requestJson,
 	resolveDbPath,
 	runSyncPass,
@@ -56,11 +58,31 @@ import {
 	type SyncLifecycleOptions,
 } from "./sync-helpers.js";
 
+function readCliConfig(configPath?: string): Record<string, unknown> {
+	return configPath ? readCodememConfigFileAtPath(configPath) : readCodememConfigFile();
+}
+
+function writeCliConfig(config: Record<string, unknown>, configPath?: string): string {
+	return writeCodememConfigFile(config, configPath || undefined);
+}
+
 function parseAttemptsLimit(value: string): number {
 	if (!/^\d+$/.test(value.trim())) {
 		throw new Error(`Invalid --limit: ${value}`);
 	}
 	return Number.parseInt(value, 10);
+}
+
+function parsePositiveIntegerOption(
+	value: string | undefined,
+	flagName: string,
+): number | undefined {
+	if (value == null) return undefined;
+	const trimmed = value.trim();
+	if (!/^\d+$/.test(trimmed)) {
+		throw new Error(`Invalid ${flagName}: ${value}`);
+	}
+	return Number.parseInt(trimmed, 10);
 }
 
 interface SyncOnceOptions {
@@ -79,6 +101,7 @@ interface SyncPairOptions {
 	exclude?: string;
 	all?: boolean;
 	default?: boolean;
+	config?: string;
 	dbPath?: string;
 }
 
@@ -166,8 +189,8 @@ async function runServeLifecycle(
 		);
 	}
 	if (action === "start") {
-		const config = readCodememConfigFile();
-		if (config.sync_enabled !== true) {
+		const config = readCoordinatorSyncConfig(readCliConfig(opts.config));
+		if (config.syncEnabled !== true) {
 			p.log.error("Sync is disabled. Run `codemem sync enable` first.");
 			process.exitCode = 1;
 			return;
@@ -185,6 +208,7 @@ async function runServeLifecycle(
 			env: {
 				...process.env,
 				...((opts.db ?? opts.dbPath) ? { CODEMEM_DB: opts.db ?? opts.dbPath } : {}),
+				...(opts.config ? { CODEMEM_CONFIG: opts.config } : {}),
 			},
 		});
 		child.once("error", reject);
@@ -249,6 +273,7 @@ syncCommand.addCommand(
 		.description("Start sync daemon")
 		.option("--db <path>", "database path")
 		.option("--db-path <path>", "database path")
+		.option("--config <path>", "config path")
 		.option("--host <host>", "viewer host")
 		.option("--port <port>", "viewer port")
 		.option("--user", "accepted for compatibility", true)
@@ -264,6 +289,7 @@ syncCommand.addCommand(
 		.description("Stop sync daemon")
 		.option("--db <path>", "database path")
 		.option("--db-path <path>", "database path")
+		.option("--config <path>", "config path")
 		.option("--host <host>", "viewer host")
 		.option("--port <port>", "viewer port")
 		.option("--user", "accepted for compatibility", true)
@@ -279,6 +305,7 @@ syncCommand.addCommand(
 		.description("Restart sync daemon")
 		.option("--db <path>", "database path")
 		.option("--db-path <path>", "database path")
+		.option("--config <path>", "config path")
 		.option("--host <host>", "viewer host")
 		.option("--port <port>", "viewer port")
 		.option("--user", "accepted for compatibility", true)
@@ -360,6 +387,7 @@ syncCommand.addCommand(
 		.option("--exclude <projects>", "outbound-only blocklist for accepted peer")
 		.option("--all", "with --accept, push all projects to that peer")
 		.option("--default", "with --accept, use default/global push filters")
+		.option("--config <path>", "config path")
 		.option("--db-path <path>", "database path")
 		.action(async (opts: SyncPairOptions) => {
 			const store = new MemoryStore(resolveDbPath(opts.dbPath));
@@ -492,7 +520,7 @@ syncCommand.addCommand(
 					return;
 				}
 
-				const config = readCodememConfigFile();
+				const config = readCliConfig(opts.config);
 				const explicitAddress = opts.address?.trim();
 				const configuredHost = typeof config.sync_host === "string" ? config.sync_host : null;
 				const configuredPort = typeof config.sync_port === "number" ? config.sync_port : 7337;
@@ -540,8 +568,9 @@ syncCommand.addCommand(
 		.description("Diagnose common sync setup and connectivity issues")
 		.option("--db <path>", "database path")
 		.option("--db-path <path>", "database path")
-		.action(async (opts: { db?: string; dbPath?: string }) => {
-			const config = readCodememConfigFile();
+		.option("--config <path>", "config path")
+		.action(async (opts: { db?: string; dbPath?: string; config?: string }) => {
+			const config = readCliConfig(opts.config);
 			const dbPath = resolveDbPath(opts.db ?? opts.dbPath);
 			const store = new MemoryStore(dbPath);
 			try {
@@ -644,9 +673,10 @@ syncCommand.addCommand(
 		.description("Show sync configuration and peer summary")
 		.option("--db <path>", "database path")
 		.option("--db-path <path>", "database path")
+		.option("--config <path>", "config path")
 		.option("--json", "output as JSON")
-		.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
-			const config = readCodememConfigFile();
+		.action((opts: { db?: string; dbPath?: string; config?: string; json?: boolean }) => {
+			const config = readCliConfig(opts.config);
 			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 			try {
 				const d = drizzle(store.db, { schema });
@@ -732,20 +762,30 @@ syncCommand.addCommand(
 		.description("Enable sync and initialize device identity")
 		.option("--db <path>", "database path")
 		.option("--db-path <path>", "database path")
+		.option("--config <path>", "config path")
 		.option("--host <host>", "sync listen host")
 		.option("--port <port>", "sync listen port")
 		.option("--interval <seconds>", "sync interval in seconds")
 		.action(
-			(opts: { db?: string; dbPath?: string; host?: string; port?: string; interval?: string }) => {
+			(opts: {
+				db?: string;
+				dbPath?: string;
+				config?: string;
+				host?: string;
+				port?: string;
+				interval?: string;
+			}) => {
 				const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
 				try {
 					const [deviceId, fingerprint] = ensureDeviceIdentity(store.db);
-					const config = readCodememConfigFile();
+					const config = readCliConfig(opts.config);
 					config.sync_enabled = true;
 					if (opts.host) config.sync_host = opts.host;
-					if (opts.port) config.sync_port = Number.parseInt(opts.port, 10);
-					if (opts.interval) config.sync_interval_s = Number.parseInt(opts.interval, 10);
-					writeCodememConfigFile(config);
+					const syncPort = parsePositiveIntegerOption(opts.port, "--port");
+					const syncInterval = parsePositiveIntegerOption(opts.interval, "--interval");
+					if (syncPort != null) config.sync_port = syncPort;
+					if (syncInterval != null) config.sync_interval_s = syncInterval;
+					writeCliConfig(config, opts.config);
 
 					p.intro("codemem sync enable");
 					p.log.success(
@@ -770,10 +810,11 @@ syncCommand.addCommand(
 	new Command("disable")
 		.configureHelp(helpStyle)
 		.description("Disable sync without deleting keys or peers")
-		.action(() => {
-			const config = readCodememConfigFile();
+		.option("--config <path>", "config path")
+		.action((opts: { config?: string }) => {
+			const config = readCliConfig(opts.config);
 			config.sync_enabled = false;
-			writeCodememConfigFile(config);
+			writeCliConfig(config, opts.config);
 			p.intro("codemem sync disable");
 			p.outro("Sync disabled — restart `codemem serve` to take effect");
 		}),
@@ -1089,11 +1130,12 @@ syncCommand.addCommand(
 		.description("Configure coordinator URL for cloud sync")
 		.argument("<url>", "coordinator URL (e.g. https://coordinator.example.com)")
 		.option("--group <group>", "sync group ID")
-		.action((url: string, opts: { group?: string }) => {
-			const config = readCodememConfigFile();
+		.option("--config <path>", "config path")
+		.action((url: string, opts: { group?: string; config?: string }) => {
+			const config = readCliConfig(opts.config);
 			config.sync_coordinator_url = url.trim();
 			if (opts.group) config.sync_coordinator_group = opts.group.trim();
-			writeCodememConfigFile(config);
+			writeCliConfig(config, opts.config);
 			p.intro("codemem sync connect");
 			p.log.success(`Coordinator: ${url.trim()}`);
 			if (opts.group) p.log.info(`Group: ${opts.group.trim()}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import { VERSION } from "@codemem/core";
 import { Command } from "commander";
 import omelette from "omelette";
 import { claudeHookIngestCommand } from "./commands/claude-hook-ingest.js";
+import { configCommand } from "./commands/config.js";
 import { dbCommand } from "./commands/db.js";
 import { embedCommand } from "./commands/embed.js";
 import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
@@ -47,6 +48,7 @@ const completion = omelette("codemem <command>") as CompletionWithScriptGenerato
 completion.on("command", ({ reply }) => {
 	reply([
 		"claude-hook-ingest",
+		"config",
 		"db",
 		"embed",
 		"export-memories",
@@ -115,6 +117,7 @@ if (hasRootFlag("--cleanup-completion")) {
 }
 
 program.addCommand(serveCommand);
+program.addCommand(configCommand);
 program.addCommand(mcpCommand);
 program.addCommand(claudeHookIngestCommand);
 program.addCommand(dbCommand);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -209,11 +209,15 @@ export {
 	getProviderBaseUrl,
 	getProviderHeaders,
 	getProviderOptions,
+	getWorkspaceCodememConfigPath,
+	getWorkspaceScopedCodememConfigPath,
 	listConfiguredOpenCodeProviders,
 	listCustomProviders,
 	listObserverProviderOptions,
 	loadOpenCodeConfig,
 	readCodememConfigFile,
+	readCodememConfigFileAtPath,
+	readWorkspaceCodememConfigFile,
 	resolveBuiltInProviderDefaultModel,
 	resolveBuiltInProviderFromModel,
 	resolveBuiltInProviderModel,
@@ -224,6 +228,7 @@ export {
 	stripJsonComments,
 	stripTrailingCommas,
 	writeCodememConfigFile,
+	writeWorkspaceCodememConfigFile,
 } from "./observer-config.js";
 export { buildMemoryPack, buildMemoryPackAsync, estimateTokens } from "./pack.js";
 export {

--- a/packages/core/src/observer-config.test.ts
+++ b/packages/core/src/observer-config.test.ts
@@ -1,13 +1,145 @@
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+	getCodememConfigPath,
 	getCodememEnvOverrides,
 	getProviderApiKey,
+	getWorkspaceCodememConfigPath,
+	getWorkspaceScopedCodememConfigPath,
 	loadOpenCodeConfig,
+	readCodememConfigFileAtPath,
+	readWorkspaceCodememConfigFile,
 	resolveCustomProviderFromModel,
 	resolvePlaceholder,
 	stripJsonComments,
 	stripTrailingCommas,
+	writeCodememConfigFile,
+	writeWorkspaceCodememConfigFile,
 } from "./observer-config.js";
+
+describe("codemem config path resolution", () => {
+	let tmpHome: string;
+	let prevHome: string | undefined;
+	let prevCodememConfig: string | undefined;
+	let prevRuntimeRoot: string | undefined;
+	let prevWorkspaceId: string | undefined;
+
+	beforeEach(() => {
+		tmpHome = mkdtempSync(join(tmpdir(), "codemem-config-home-"));
+		prevHome = process.env.HOME;
+		prevCodememConfig = process.env.CODEMEM_CONFIG;
+		prevRuntimeRoot = process.env.CODEMEM_RUNTIME_ROOT;
+		prevWorkspaceId = process.env.CODEMEM_WORKSPACE_ID;
+		process.env.HOME = tmpHome;
+		delete process.env.CODEMEM_CONFIG;
+		delete process.env.CODEMEM_RUNTIME_ROOT;
+		delete process.env.CODEMEM_WORKSPACE_ID;
+	});
+
+	afterEach(() => {
+		if (prevHome == null) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		if (prevCodememConfig == null) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevCodememConfig;
+		if (prevRuntimeRoot == null) delete process.env.CODEMEM_RUNTIME_ROOT;
+		else process.env.CODEMEM_RUNTIME_ROOT = prevRuntimeRoot;
+		if (prevWorkspaceId == null) delete process.env.CODEMEM_WORKSPACE_ID;
+		else process.env.CODEMEM_WORKSPACE_ID = prevWorkspaceId;
+	});
+
+	it("resolves workspace config path from workspace id", () => {
+		expect(getWorkspaceCodememConfigPath("pilot-1")).toBe(
+			join(tmpHome, ".codemem", "workspaces", "pilot-1", "config", "codemem.json"),
+		);
+	});
+
+	it("rejects unsafe workspace ids for config path", () => {
+		expect(() => getWorkspaceCodememConfigPath("../pilot-1")).toThrow(
+			"Invalid workspace id for config path",
+		);
+		expect(() => getWorkspaceCodememConfigPath(".")).toThrow(
+			"Invalid workspace id for config path",
+		);
+		expect(() => getWorkspaceCodememConfigPath("..")).toThrow(
+			"Invalid workspace id for config path",
+		);
+	});
+
+	it("prefers CODEMEM_CONFIG over workspace-scoped config", () => {
+		process.env.CODEMEM_CONFIG = "~/explicit/config.json";
+		process.env.CODEMEM_WORKSPACE_ID = "pilot-1";
+		expect(getCodememConfigPath()).toBe(join(tmpHome, "explicit", "config.json"));
+	});
+
+	it("uses CODEMEM_RUNTIME_ROOT when present", () => {
+		process.env.CODEMEM_RUNTIME_ROOT = join(tmpHome, "runtime-root");
+		expect(getWorkspaceScopedCodememConfigPath()).toBe(
+			join(tmpHome, "runtime-root", "config", "codemem.json"),
+		);
+	});
+
+	it("ignores relative CODEMEM_RUNTIME_ROOT values", () => {
+		process.env.CODEMEM_RUNTIME_ROOT = "../runtime-root";
+		expect(getWorkspaceScopedCodememConfigPath()).toBeNull();
+		expect(getCodememConfigPath()).toBe(join(tmpHome, ".config", "codemem", "config.json"));
+	});
+
+	it("uses workspace-scoped config path when workspace id is known", () => {
+		process.env.CODEMEM_WORKSPACE_ID = "pilot-1";
+		expect(getCodememConfigPath()).toBe(
+			join(tmpHome, ".codemem", "workspaces", "pilot-1", "config", "codemem.json"),
+		);
+	});
+
+	it("falls back to legacy config for reads until workspace config exists", () => {
+		const legacyPath = join(tmpHome, ".config", "codemem", "config.jsonc");
+		mkdirSync(join(tmpHome, ".config", "codemem"), { recursive: true });
+		writeFileSync(legacyPath, '{"sync_enabled": true}\n', "utf8");
+		process.env.CODEMEM_WORKSPACE_ID = "pilot-1";
+		expect(getCodememConfigPath()).toBe(legacyPath);
+	});
+
+	it("falls back to legacy global config when workspace id is absent", () => {
+		const legacyPath = join(tmpHome, ".config", "codemem", "config.jsonc");
+		mkdirSync(join(tmpHome, ".config", "codemem"), { recursive: true });
+		writeFileSync(legacyPath, "{}\n", "utf8");
+		expect(getCodememConfigPath()).toBe(legacyPath);
+	});
+
+	it("returns default legacy global config path when no config exists", () => {
+		expect(getCodememConfigPath()).toBe(join(tmpHome, ".config", "codemem", "config.json"));
+	});
+
+	it("writes and reads workspace-scoped config files", () => {
+		const targetPath = writeWorkspaceCodememConfigFile("pilot-1", {
+			sync_enabled: true,
+			sync_port: 47337,
+		});
+		expect(targetPath).toBe(
+			join(tmpHome, ".codemem", "workspaces", "pilot-1", "config", "codemem.json"),
+		);
+		expect(readWorkspaceCodememConfigFile("pilot-1")).toEqual({
+			sync_enabled: true,
+			sync_port: 47337,
+		});
+	});
+
+	it("writes to the workspace path when workspace mode is active", () => {
+		process.env.CODEMEM_WORKSPACE_ID = "pilot-1";
+		const targetPath = writeCodememConfigFile({ sync_enabled: true });
+		expect(targetPath).toBe(
+			join(tmpHome, ".codemem", "workspaces", "pilot-1", "config", "codemem.json"),
+		);
+	});
+
+	it("reads JSONC config from an explicit path", () => {
+		const configPath = join(tmpHome, "workspace-config.jsonc");
+		writeFileSync(configPath, '{\n  // comment\n  "sync_enabled": true,\n}\n', "utf8");
+		expect(readCodememConfigFileAtPath(configPath)).toEqual({ sync_enabled: true });
+	});
+});
 
 describe("stripJsonComments", () => {
 	it("removes line comments", () => {

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -138,6 +138,52 @@ export function expandUserPath(value: string): string {
 	return value.startsWith("~/") ? join(homedir(), value.slice(2)) : value;
 }
 
+function isSafeWorkspaceId(value: string): boolean {
+	return /^[A-Za-z0-9._:-]+$/.test(value) && !/^\.+$/.test(value);
+}
+
+export function getWorkspaceCodememConfigPath(workspaceId: string): string {
+	const trimmed = workspaceId.trim();
+	if (!trimmed || !isSafeWorkspaceId(trimmed)) {
+		throw new Error(`Invalid workspace id for config path: ${workspaceId}`);
+	}
+	return join(homedir(), ".codemem", "workspaces", trimmed, "config", "codemem.json");
+}
+
+export function getWorkspaceScopedCodememConfigPath(): string | null {
+	const runtimeRoot = process.env.CODEMEM_RUNTIME_ROOT?.trim();
+	if (runtimeRoot) {
+		const expandedRoot = expandUserPath(runtimeRoot);
+		if (expandedRoot.startsWith("/")) {
+			return join(expandedRoot, "config", "codemem.json");
+		}
+		// Invalid/relative runtime root — fall through to workspace-id lookup
+	}
+
+	const workspaceId = process.env.CODEMEM_WORKSPACE_ID?.trim();
+	if (!workspaceId) return null;
+	if (!isSafeWorkspaceId(workspaceId)) return null;
+	return getWorkspaceCodememConfigPath(workspaceId);
+}
+
+function getLegacyCodememConfigPath(): string {
+	const configDir = join(homedir(), ".config", "codemem");
+	const candidates = [join(configDir, "config.json"), join(configDir, "config.jsonc")];
+	return candidates.find((p) => existsSync(p)) ?? join(configDir, "config.json");
+}
+
+function getCodememConfigWritePath(): string {
+	const envPath = process.env.CODEMEM_CONFIG?.trim();
+	if (envPath) return expandUserPath(envPath);
+	const workspaceConfigPath = getWorkspaceScopedCodememConfigPath();
+	if (workspaceConfigPath) return workspaceConfigPath;
+	return getLegacyCodememConfigPath();
+}
+
+export function readWorkspaceCodememConfigFile(workspaceId: string): Record<string, unknown> {
+	return readCodememConfigFileAtPath(getWorkspaceCodememConfigPath(workspaceId));
+}
+
 /** Env var overrides matching Python's CONFIG_ENV_OVERRIDES. */
 export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
 	actor_id: "CODEMEM_ACTOR_ID",
@@ -179,23 +225,35 @@ export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
 	raw_events_sweeper_interval_s: "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
 };
 
-/** Resolve codemem config path with CODEMEM_CONFIG override. */
+/**
+ * Resolve codemem config path with precedence:
+ * 1. explicit CODEMEM_CONFIG override
+ * 2. workspace-scoped config via CODEMEM_RUNTIME_ROOT or CODEMEM_WORKSPACE_ID
+ * 3. legacy global config under ~/.config/codemem/
+ */
 export function getCodememConfigPath(): string {
 	const envPath = process.env.CODEMEM_CONFIG?.trim();
 	if (envPath) return expandUserPath(envPath);
-	const configDir = join(homedir(), ".config", "codemem");
-	const candidates = [join(configDir, "config.json"), join(configDir, "config.jsonc")];
-	return candidates.find((p) => existsSync(p)) ?? join(configDir, "config.json");
+	const workspaceConfigPath = getWorkspaceScopedCodememConfigPath();
+	if (workspaceConfigPath && existsSync(workspaceConfigPath)) return workspaceConfigPath;
+	const legacyConfigPath = getLegacyCodememConfigPath();
+	if (existsSync(legacyConfigPath)) return legacyConfigPath;
+	return workspaceConfigPath ?? legacyConfigPath;
 }
 
 /** Read codemem config file with the same JSON/JSONC behavior as Python. */
 export function readCodememConfigFile(): Record<string, unknown> {
 	const configPath = getCodememConfigPath();
-	if (!existsSync(configPath)) return {};
+	return readCodememConfigFileAtPath(configPath);
+}
+
+export function readCodememConfigFileAtPath(configPath: string): Record<string, unknown> {
+	const resolvedPath = expandUserPath(configPath);
+	if (!existsSync(resolvedPath)) return {};
 
 	let text: string;
 	try {
-		text = readFileSync(configPath, "utf-8");
+		text = readFileSync(resolvedPath, "utf-8");
 	} catch {
 		return {};
 	}
@@ -224,10 +282,17 @@ export function readCodememConfigFile(): Record<string, unknown> {
 
 /** Persist the codemem config file as normalized JSON. */
 export function writeCodememConfigFile(data: Record<string, unknown>, configPath?: string): string {
-	const targetPath = configPath ? expandUserPath(configPath) : getCodememConfigPath();
+	const targetPath = configPath ? expandUserPath(configPath) : getCodememConfigWritePath();
 	mkdirSync(dirname(targetPath), { recursive: true });
 	writeFileSync(targetPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
 	return targetPath;
+}
+
+export function writeWorkspaceCodememConfigFile(
+	workspaceId: string,
+	data: Record<string, unknown>,
+): string {
+	return writeCodememConfigFile(data, getWorkspaceCodememConfigPath(workspaceId));
 }
 
 /** Return active env overrides for codemem config keys. */


### PR DESCRIPTION
## Description
- add workspace-scoped config resolution and helper APIs for runtime automation
- add a codemem config workspace command to materialize or update workspace-scoped config files
- thread explicit config selection through pilot-facing serve and sync commands while preserving legacy global-config fallback for reads

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] Relevant JS/TS tests pass locally

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

## Notes
- targeted validation run: pnpm run test -- packages/core/src/observer-config.test.ts packages/cli/src/commands/config.test.ts packages/cli/src/commands/sync.test.ts packages/cli/src/commands/serve.test.ts
- scoped to config-first workspace automation foundations only; follow-up integration work will happen separately
