### PR TITLE
Add seed scoped bootstrap grant support

### DIFF
--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -156,6 +156,8 @@ describe("formatSyncAttempt", () => {
 			"disable-device",
 			"remove-device",
 			"serve",
+			"list-bootstrap-grants",
+			"revoke-bootstrap-grant",
 			"create-invite",
 			"import-invite",
 			"list-join-requests",

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -18,12 +18,14 @@ import {
 	coordinatorDisableDeviceAction,
 	coordinatorEnrollDeviceAction,
 	coordinatorImportInviteAction,
+	coordinatorListBootstrapGrantsAction,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
 	coordinatorListJoinRequestsAction,
 	coordinatorRemoveDeviceAction,
 	coordinatorRenameDeviceAction,
 	coordinatorReviewJoinRequestAction,
+	coordinatorRevokeBootstrapGrantAction,
 	createBetterSqliteCoordinatorApp,
 	DEFAULT_COORDINATOR_DB_PATH,
 	ensureDeviceIdentity,
@@ -921,6 +923,7 @@ syncCommand.addCommand(
 		.configureHelp(helpStyle)
 		.description("Fast-bootstrap memories from a peer (full snapshot transfer)")
 		.requiredOption("--peer <device-id>", "peer device ID to bootstrap from")
+		.option("--bootstrap-grant <grant-id>", "bootstrap grant id for seed-authorized bootstrap")
 		.option("--page-size <n>", "items per snapshot page (default: 2000)", "2000")
 		.option("--db <path>", "database path")
 		.option("--db-path <path>", "database path")
@@ -930,6 +933,7 @@ syncCommand.addCommand(
 		.action(
 			async (opts: {
 				peer: string;
+				bootstrapGrant?: string;
 				pageSize: string;
 				db?: string;
 				dbPath?: string;
@@ -1024,6 +1028,7 @@ syncCommand.addCommand(
 							method: "GET",
 							url: statusUrl,
 							bodyBytes: Buffer.alloc(0),
+							bootstrapGrantId: opts.bootstrapGrant,
 							keysDir,
 						});
 						try {
@@ -1091,6 +1096,7 @@ syncCommand.addCommand(
 
 					const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
 						keysDir,
+						bootstrapGrantId: opts.bootstrapGrant,
 						pageSize,
 					});
 
@@ -1442,6 +1448,95 @@ coordinatorCommand.addCommand(
 			p.log.info(`DB: ${dbPath}`);
 			honoServe({ fetch: app.fetch, hostname: host, port });
 		}),
+);
+
+coordinatorCommand.addCommand(
+	new Command("list-bootstrap-grants")
+		.configureHelp(helpStyle)
+		.description("List bootstrap grants for a coordinator group")
+		.argument("<group>", "group id")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--remote-url <url>", "remote coordinator URL override")
+		.option("--admin-secret <secret>", "remote coordinator admin secret override")
+		.option("--json", "output as JSON")
+		.action(
+			async (
+				groupId: string,
+				opts: {
+					db?: string;
+					dbPath?: string;
+					remoteUrl?: string;
+					adminSecret?: string;
+					json?: boolean;
+				},
+			) => {
+				const rows = await coordinatorListBootstrapGrantsAction({
+					groupId,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+					remoteUrl: opts.remoteUrl?.trim() || null,
+					adminSecret: opts.adminSecret?.trim() || null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(rows, null, 2));
+					return;
+				}
+				p.intro("codemem sync coordinator list-bootstrap-grants");
+				if (rows.length === 0) {
+					p.outro(`No bootstrap grants for ${groupId.trim()}`);
+					return;
+				}
+				for (const row of rows) {
+					p.log.message(
+						`- ${row.grant_id} seed=${row.seed_device_id} worker=${row.worker_device_id} scope=${row.scope} expires=${row.expires_at} revoked=${row.revoked_at ?? "no"}`,
+					);
+				}
+				p.outro(`${rows.length} bootstrap grant(s)`);
+			},
+		),
+);
+
+coordinatorCommand.addCommand(
+	new Command("revoke-bootstrap-grant")
+		.configureHelp(helpStyle)
+		.description("Revoke a bootstrap grant")
+		.argument("<grant-id>", "bootstrap grant id")
+		.option("--db <path>", "coordinator database path")
+		.option("--db-path <path>", "coordinator database path")
+		.option("--remote-url <url>", "remote coordinator URL override")
+		.option("--admin-secret <secret>", "remote coordinator admin secret override")
+		.option("--json", "output as JSON")
+		.action(
+			async (
+				grantId: string,
+				opts: {
+					db?: string;
+					dbPath?: string;
+					remoteUrl?: string;
+					adminSecret?: string;
+					json?: boolean;
+				},
+			) => {
+				const ok = await coordinatorRevokeBootstrapGrantAction({
+					grantId,
+					dbPath: opts.db ?? opts.dbPath ?? null,
+					remoteUrl: opts.remoteUrl?.trim() || null,
+					adminSecret: opts.adminSecret?.trim() || null,
+				});
+				if (!ok) {
+					p.log.error(`Bootstrap grant not found: ${grantId.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				if (opts.json) {
+					console.log(JSON.stringify({ ok: true, grant_id: grantId.trim() }, null, 2));
+					return;
+				}
+				p.intro("codemem sync coordinator revoke-bootstrap-grant");
+				p.log.success(`Revoked ${grantId.trim()}`);
+				p.outro("revoked");
+			},
+		),
 );
 
 coordinatorCommand.addCommand(

--- a/packages/cloudflare-coordinator-worker/schema.sql
+++ b/packages/cloudflare-coordinator-worker/schema.sql
@@ -70,6 +70,18 @@ CREATE TABLE IF NOT EXISTS coordinator_reciprocal_approvals (
   resolved_at TEXT
 );
 
+CREATE TABLE IF NOT EXISTS coordinator_bootstrap_grants (
+  grant_id TEXT PRIMARY KEY,
+  group_id TEXT NOT NULL,
+  seed_device_id TEXT NOT NULL,
+  worker_device_id TEXT NOT NULL,
+  scope TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  created_by TEXT,
+  revoked_at TEXT
+);
+
 CREATE UNIQUE INDEX IF NOT EXISTS idx_coordinator_reciprocal_pending_pair
 ON coordinator_reciprocal_approvals(group_id, pending_pair_low_device_id, pending_pair_high_device_id)
 WHERE status = 'pending';

--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -17,6 +17,8 @@ import { dirname, join } from "node:path";
 import type { Database as DatabaseType } from "better-sqlite3";
 import Database from "better-sqlite3";
 import type {
+	CoordinatorBootstrapGrant,
+	CoordinatorCreateBootstrapGrantInput,
 	CoordinatorCreateInviteInput,
 	CoordinatorCreateJoinRequestInput,
 	CoordinatorCreateReciprocalApprovalInput,
@@ -30,6 +32,7 @@ import type {
 	CoordinatorPeerRecord,
 	CoordinatorPresenceRecord,
 	CoordinatorReciprocalApproval,
+	CoordinatorReviewJoinRequestBootstrapGrantInput,
 	CoordinatorReviewJoinRequestInput,
 	CoordinatorStore,
 	CoordinatorUpsertPresenceInput,
@@ -92,6 +95,68 @@ function tokenUrlSafe(bytes: number): string {
 function rowToRecord<T>(row: unknown): T {
 	if (row == null) throw new Error("expected row");
 	return row as T;
+}
+
+function normalizeBootstrapGrantRequest(
+	input: CoordinatorReviewJoinRequestBootstrapGrantInput | null | undefined,
+): CoordinatorCreateBootstrapGrantInput | null {
+	if (!input) return null;
+	const seedDeviceId = String(input.seedDeviceId ?? "").trim();
+	const scope = String(input.scope ?? "").trim();
+	const expiresAt = String(input.expiresAt ?? "").trim();
+	const createdBy = String(input.createdBy ?? "").trim() || null;
+	if (!seedDeviceId || !scope || !expiresAt) {
+		throw new Error("bootstrapGrant.seedDeviceId, scope, and expiresAt are required.");
+	}
+	return {
+		groupId: "",
+		seedDeviceId,
+		workerDeviceId: "",
+		scope,
+		expiresAt,
+		createdBy,
+	};
+}
+
+function normalizeBootstrapGrantInput(
+	opts: CoordinatorCreateBootstrapGrantInput,
+): CoordinatorCreateBootstrapGrantInput {
+	const groupId = String(opts.groupId ?? "").trim();
+	const seedDeviceId = String(opts.seedDeviceId ?? "").trim();
+	const workerDeviceId = String(opts.workerDeviceId ?? "").trim();
+	const scope = String(opts.scope ?? "").trim();
+	const expiresAt = String(opts.expiresAt ?? "").trim();
+	const createdBy = String(opts.createdBy ?? "").trim() || null;
+	if (!groupId || !seedDeviceId || !workerDeviceId || !scope || !expiresAt) {
+		throw new Error("groupId, seedDeviceId, workerDeviceId, scope, and expiresAt are required.");
+	}
+	return { groupId, seedDeviceId, workerDeviceId, scope, expiresAt, createdBy };
+}
+
+function insertBootstrapGrantSync(
+	db: DatabaseType,
+	opts: CoordinatorCreateBootstrapGrantInput,
+): CoordinatorBootstrapGrant {
+	const normalized = normalizeBootstrapGrantInput(opts);
+	const grantId = tokenUrlSafe(12);
+	const createdAt = nowISO();
+	db.prepare(`INSERT INTO coordinator_bootstrap_grants(
+			grant_id, group_id, seed_device_id, worker_device_id, scope, expires_at, created_at, created_by, revoked_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`).run(
+		grantId,
+		normalized.groupId,
+		normalized.seedDeviceId,
+		normalized.workerDeviceId,
+		normalized.scope,
+		normalized.expiresAt,
+		createdAt,
+		normalized.createdBy,
+	);
+	const row = db
+		.prepare(`SELECT grant_id, group_id, seed_device_id, worker_device_id, scope, expires_at, created_at, created_by, revoked_at
+			 FROM coordinator_bootstrap_grants WHERE grant_id = ?`)
+		.get(grantId);
+	return rowToRecord<CoordinatorBootstrapGrant>(row);
 }
 
 function initializeSchema(db: DatabaseType): void {
@@ -164,6 +229,18 @@ function initializeSchema(db: DatabaseType): void {
 			status TEXT NOT NULL,
 			created_at TEXT NOT NULL,
 			resolved_at TEXT
+		);
+
+		CREATE TABLE IF NOT EXISTS coordinator_bootstrap_grants (
+			grant_id TEXT PRIMARY KEY,
+			group_id TEXT NOT NULL,
+			seed_device_id TEXT NOT NULL,
+			worker_device_id TEXT NOT NULL,
+			scope TEXT NOT NULL,
+			expires_at TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			created_by TEXT,
+			revoked_at TEXT
 		);
 	`);
 }
@@ -399,9 +476,11 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 		if (!row) return null;
 		if (row.status !== "pending")
 			return { ...rowToRecord<CoordinatorJoinRequest>(row), _no_transition: true };
-		return this.db.transaction(() => {
+		const bootstrapGrantRequest = normalizeBootstrapGrantRequest(opts.bootstrapGrant);
+		const result = this.db.transaction(() => {
 			const reviewedAt = nowISO();
 			const nextStatus = opts.approved ? "approved" : "denied";
+			let bootstrapGrant: CoordinatorBootstrapGrant | null = null;
 			if (opts.approved) {
 				this.enrollDeviceSync(row.group_id, {
 					deviceId: row.device_id,
@@ -409,6 +488,25 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 					publicKey: row.public_key,
 					displayName: (row.display_name ?? "").trim() || null,
 				});
+				if (bootstrapGrantRequest) {
+					const seedEnrollment = this.db
+						.prepare(
+							`SELECT device_id FROM enrolled_devices WHERE group_id = ? AND device_id = ? AND enabled = 1`,
+						)
+						.get(row.group_id, bootstrapGrantRequest.seedDeviceId);
+					if (!seedEnrollment) {
+						throw new Error("bootstrap grant seed device is not enrolled in the group.");
+					}
+					if (bootstrapGrantRequest.seedDeviceId === row.device_id) {
+						throw new Error("bootstrap grant seed and worker device ids must differ.");
+					}
+					const bootstrapGrantInput = {
+						...bootstrapGrantRequest,
+						groupId: row.group_id,
+						workerDeviceId: row.device_id,
+					};
+					bootstrapGrant = insertBootstrapGrantSync(this.db, bootstrapGrantInput);
+				}
 			}
 			this.db
 				.prepare(`UPDATE coordinator_join_requests
@@ -419,8 +517,16 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
 					 FROM coordinator_join_requests WHERE request_id = ?`)
 				.get(opts.requestId);
-			return updated ? rowToRecord<CoordinatorJoinRequestReviewResult>(updated) : null;
+			return {
+				updated: updated ? rowToRecord<CoordinatorJoinRequestReviewResult>(updated) : null,
+				bootstrapGrant,
+			};
 		})();
+		if (!result.updated) return null;
+		return {
+			...result.updated,
+			bootstrap_grant: result.bootstrapGrant,
+		};
 	}
 
 	async createReciprocalApproval(
@@ -484,6 +590,38 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 				.get(requestId);
 			return rowToRecord<CoordinatorReciprocalApproval>(created);
 		})();
+	}
+
+	async createBootstrapGrant(
+		opts: CoordinatorCreateBootstrapGrantInput,
+	): Promise<CoordinatorBootstrapGrant> {
+		return insertBootstrapGrantSync(this.db, opts);
+	}
+
+	async getBootstrapGrant(grantId: string): Promise<CoordinatorBootstrapGrant | null> {
+		const row = this.db
+			.prepare(`SELECT grant_id, group_id, seed_device_id, worker_device_id, scope, expires_at, created_at, created_by, revoked_at
+				 FROM coordinator_bootstrap_grants WHERE grant_id = ?`)
+			.get(grantId);
+		return row ? rowToRecord<CoordinatorBootstrapGrant>(row) : null;
+	}
+
+	async listBootstrapGrants(groupId: string): Promise<CoordinatorBootstrapGrant[]> {
+		return this.db
+			.prepare(`SELECT grant_id, group_id, seed_device_id, worker_device_id, scope, expires_at, created_at, created_by, revoked_at
+				 FROM coordinator_bootstrap_grants WHERE group_id = ?
+				 ORDER BY created_at DESC, grant_id DESC`)
+			.all(groupId)
+			.map((row) => rowToRecord<CoordinatorBootstrapGrant>(row));
+	}
+
+	async revokeBootstrapGrant(grantId: string, revokedAt = nowISO()): Promise<boolean> {
+		const result = this.db
+			.prepare(`UPDATE coordinator_bootstrap_grants
+				 SET revoked_at = COALESCE(revoked_at, ?)
+				 WHERE grant_id = ?`)
+			.run(revokedAt, grantId);
+		return result.changes > 0;
 	}
 
 	async listReciprocalApprovals(

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -12,6 +12,7 @@ import {
 	inviteLink,
 } from "./coordinator-invites.js";
 import type {
+	CoordinatorBootstrapGrant,
 	CoordinatorEnrollment,
 	CoordinatorGroup,
 	CoordinatorJoinRequest,
@@ -489,6 +490,72 @@ export async function coordinatorReviewJoinRequestAction(opts: {
 			approved: opts.approve,
 			reviewedBy: opts.reviewedBy ?? null,
 		});
+	} finally {
+		await store.close();
+	}
+}
+
+export async function coordinatorListBootstrapGrantsAction(opts: {
+	groupId: string;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<CoordinatorBootstrapGrant[]> {
+	const remote = opts.remoteUrl ?? (opts.dbPath ? null : coordinatorRemoteTarget().remoteUrl);
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		const payload = await remoteRequest(
+			"GET",
+			`${remote.replace(/\/+$/, "")}/v1/admin/bootstrap-grants?group_id=${encodeURIComponent(opts.groupId)}`,
+			adminSecret,
+		);
+		return Array.isArray(payload?.items)
+			? payload.items.filter(
+					(row): row is CoordinatorBootstrapGrant => Boolean(row) && typeof row === "object",
+				)
+			: [];
+	}
+	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		return await store.listBootstrapGrants(opts.groupId);
+	} finally {
+		await store.close();
+	}
+}
+
+export async function coordinatorRevokeBootstrapGrantAction(opts: {
+	grantId: string;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<boolean> {
+	const remote = opts.remoteUrl ?? (opts.dbPath ? null : coordinatorRemoteTarget().remoteUrl);
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		try {
+			await remoteRequest(
+				"POST",
+				`${remote.replace(/\/+$/, "")}/v1/admin/bootstrap-grants/revoke`,
+				adminSecret,
+				{ grant_id: opts.grantId },
+			);
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				error.message.includes("(404)") &&
+				error.message.includes("grant_not_found")
+			) {
+				return false;
+			}
+			throw error;
+		}
+		return true;
+	}
+	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		return await store.revokeBootstrapGrant(opts.grantId);
 	} finally {
 		await store.close();
 	}

--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -77,6 +77,12 @@ function createMockStore(
 			},
 		),
 		listGroupPeers: vi.fn(async (_: string, __: string): Promise<CoordinatorPeerRecord[]> => []),
+		createBootstrapGrant: vi.fn(async () => {
+			throw new Error("not implemented");
+		}),
+		getBootstrapGrant: vi.fn(async () => null),
+		listBootstrapGrants: vi.fn(async () => []),
+		revokeBootstrapGrant: vi.fn(async () => false),
 	};
 	return { ...defaultStore, ...overrides };
 }
@@ -212,6 +218,69 @@ describe("createCoordinatorApp dependency injection", () => {
 
 		expect(res.status).toBe(401);
 		expect(await res.json()).toEqual({ error: "admin_not_configured" });
+	});
+
+	it("lists bootstrap grants for admins", async () => {
+		const store = createMockStore({
+			listBootstrapGrants: vi.fn(async () => [
+				{
+					grant_id: "grant-1",
+					group_id: "g1",
+					seed_device_id: "seed-1",
+					worker_device_id: "worker-1",
+					scope: "bootstrap",
+					expires_at: "2099-01-01T00:00:00Z",
+					created_at: "2026-01-01T00:00:00Z",
+					created_by: "admin",
+					revoked_at: null,
+				},
+			]),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+		});
+		const res = await app.request("/v1/admin/bootstrap-grants?group_id=g1", {
+			headers: { "X-Codemem-Coordinator-Admin": "test-secret" },
+		});
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			items: [
+				expect.objectContaining({
+					grant_id: "grant-1",
+					group_id: "g1",
+					seed_device_id: "seed-1",
+				}),
+			],
+		});
+	});
+
+	it("revokes bootstrap grants for admins", async () => {
+		const store = createMockStore({
+			revokeBootstrapGrant: vi.fn(async () => true),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+		});
+		const res = await app.request("/v1/admin/bootstrap-grants/revoke", {
+			method: "POST",
+			headers: {
+				"X-Codemem-Coordinator-Admin": "test-secret",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ grant_id: "grant-1" }),
+		});
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ ok: true, grant_id: "grant-1" });
 	});
 
 	it("lists reciprocal approvals for the authenticated device", async () => {

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -9,7 +9,11 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import type { InvitePayload } from "./coordinator-invites.js";
 import { encodeInvitePayload, inviteLink } from "./coordinator-invites.js";
-import type { CoordinatorEnrollment, CoordinatorStore } from "./coordinator-store-contract.js";
+import type {
+	CoordinatorBootstrapGrantVerification,
+	CoordinatorEnrollment,
+	CoordinatorStore,
+} from "./coordinator-store-contract.js";
 import {
 	createInMemoryRequestRateLimiter,
 	type InMemoryRequestRateLimiter,
@@ -729,6 +733,75 @@ export function createCoordinatorApp(
 		}
 	});
 
+	app.get("/v1/admin/bootstrap-grants/:grantId", async (c) => {
+		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
+
+		const grantId = String(c.req.param("grantId") ?? "").trim();
+		if (!grantId) return c.json({ error: "grant_id_required" }, 400);
+
+		const store = createStore();
+		try {
+			const grant = await store.getBootstrapGrant(grantId);
+			if (!grant) return c.json({ error: "grant_not_found" }, 404);
+			const workerEnrollment = await store.getEnrollment(grant.group_id, grant.worker_device_id);
+			if (!workerEnrollment) return c.json({ error: "worker_enrollment_not_found" }, 404);
+			const payload: CoordinatorBootstrapGrantVerification = {
+				grant,
+				worker_enrollment: workerEnrollment,
+			};
+			return c.json(payload);
+		} finally {
+			await store.close();
+		}
+	});
+
+	app.get("/v1/admin/bootstrap-grants", async (c) => {
+		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
+
+		const groupId = (c.req.query("group_id") ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id_required" }, 400);
+
+		const store = createStore();
+		try {
+			return c.json({ items: await store.listBootstrapGrants(groupId) });
+		} finally {
+			await store.close();
+		}
+	});
+
+	app.post("/v1/admin/bootstrap-grants/revoke", async (c) => {
+		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
+
+		const raw = await readRequestBytes(c);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
+		const data = parseJsonObject(raw);
+		if (!data) return c.json({ error: "invalid_json" }, 400);
+
+		const grantId = String(data.grant_id ?? "").trim();
+		if (!grantId) return c.json({ error: "grant_id_required" }, 400);
+
+		const store = createStore();
+		try {
+			const ok = await store.revokeBootstrapGrant(grantId, runtime.now());
+			if (!ok) return c.json({ error: "grant_not_found" }, 404);
+			return c.json({ ok: true, grant_id: grantId });
+		} finally {
+			await store.close();
+		}
+	});
+
 	// POST /v1/admin/join-requests/approve
 	app.post("/v1/admin/join-requests/approve", async (c) => {
 		return handleJoinRequestReview(c, true, { createStore, runtime, rateLimitedResponse });
@@ -927,8 +1000,22 @@ async function handleJoinRequestReview(
 
 	const requestId = String(data.request_id ?? "").trim();
 	const reviewedBy = String(data.reviewed_by ?? "").trim() || null;
+	const bootstrapGrantSeedDeviceId = String(data.bootstrap_grant_seed_device_id ?? "").trim();
+	const bootstrapGrantScope = String(data.bootstrap_grant_scope ?? "").trim();
+	const bootstrapGrantExpiresAt = String(data.bootstrap_grant_expires_at ?? "").trim();
 
 	if (!requestId) return c.json({ error: "request_id_required" }, 400);
+	const bootstrapGrantFields = [
+		bootstrapGrantSeedDeviceId,
+		bootstrapGrantScope,
+		bootstrapGrantExpiresAt,
+	].filter(Boolean).length;
+	if (bootstrapGrantFields > 0 && bootstrapGrantFields < 3) {
+		return c.json(
+			{ error: "bootstrap_grant_seed_device_id_scope_and_expires_at_required_together" },
+			400,
+		);
+	}
 
 	const store = deps.createStore();
 	try {
@@ -936,6 +1023,15 @@ async function handleJoinRequestReview(
 			requestId,
 			approved,
 			reviewedBy,
+			bootstrapGrant:
+				approved && bootstrapGrantSeedDeviceId && bootstrapGrantScope && bootstrapGrantExpiresAt
+					? {
+							seedDeviceId: bootstrapGrantSeedDeviceId,
+							scope: bootstrapGrantScope,
+							expiresAt: bootstrapGrantExpiresAt,
+							createdBy: reviewedBy,
+						}
+					: null,
 		});
 
 		if (!request) return c.json({ error: "request_not_found" }, 404);

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -42,6 +42,14 @@ export interface CoordinatorJoinRequest {
 
 export interface CoordinatorJoinRequestReviewResult extends CoordinatorJoinRequest {
 	_no_transition?: boolean;
+	bootstrap_grant?: CoordinatorBootstrapGrant | null;
+}
+
+export interface CoordinatorReviewJoinRequestBootstrapGrantInput {
+	seedDeviceId: string;
+	scope: string;
+	expiresAt: string;
+	createdBy?: string | null;
 }
 
 export interface CoordinatorPresenceRecord {
@@ -73,6 +81,18 @@ export interface CoordinatorReciprocalApproval {
 	resolved_at: string | null;
 }
 
+export interface CoordinatorBootstrapGrant {
+	grant_id: string;
+	group_id: string;
+	seed_device_id: string;
+	worker_device_id: string;
+	scope: string;
+	expires_at: string;
+	created_at: string;
+	created_by: string | null;
+	revoked_at: string | null;
+}
+
 export interface CoordinatorEnrollDeviceInput {
 	deviceId: string;
 	fingerprint: string;
@@ -100,6 +120,7 @@ export interface CoordinatorReviewJoinRequestInput {
 	requestId: string;
 	approved: boolean;
 	reviewedBy?: string | null;
+	bootstrapGrant?: CoordinatorReviewJoinRequestBootstrapGrantInput | null;
 }
 
 export interface CoordinatorUpsertPresenceInput {
@@ -114,6 +135,15 @@ export interface CoordinatorCreateReciprocalApprovalInput {
 	groupId: string;
 	requestingDeviceId: string;
 	requestedDeviceId: string;
+}
+
+export interface CoordinatorCreateBootstrapGrantInput {
+	groupId: string;
+	seedDeviceId: string;
+	workerDeviceId: string;
+	scope: string;
+	expiresAt: string;
+	createdBy?: string | null;
 }
 
 export interface CoordinatorListReciprocalApprovalsInput {
@@ -147,9 +177,20 @@ export interface CoordinatorStore {
 	createReciprocalApproval(
 		opts: CoordinatorCreateReciprocalApprovalInput,
 	): Promise<CoordinatorReciprocalApproval>;
+	createBootstrapGrant(
+		opts: CoordinatorCreateBootstrapGrantInput,
+	): Promise<CoordinatorBootstrapGrant>;
+	getBootstrapGrant(grantId: string): Promise<CoordinatorBootstrapGrant | null>;
+	listBootstrapGrants(groupId: string): Promise<CoordinatorBootstrapGrant[]>;
+	revokeBootstrapGrant(grantId: string, revokedAt?: string): Promise<boolean>;
 	listReciprocalApprovals(
 		opts: CoordinatorListReciprocalApprovalsInput,
 	): Promise<CoordinatorReciprocalApproval[]>;
 	upsertPresence(opts: CoordinatorUpsertPresenceInput): Promise<CoordinatorPresenceRecord>;
 	listGroupPeers(groupId: string, requestingDeviceId: string): Promise<CoordinatorPeerRecord[]>;
+}
+
+export interface CoordinatorBootstrapGrantVerification {
+	grant: CoordinatorBootstrapGrant;
+	worker_enrollment: CoordinatorEnrollment;
 }

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -361,6 +361,47 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 				});
 			});
 
+			it("can mint a bootstrap grant when approving a join request", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1");
+					await store.enrollDevice("g1", {
+						deviceId: "seed-1",
+						fingerprint: "seed-fp",
+						publicKey: "seed-pk",
+					});
+					const invite = await store.createInvite({
+						groupId: "g1",
+						policy: "approval_required",
+						expiresAt: "2099-01-01T00:00:00Z",
+					});
+					const req = await store.createJoinRequest({
+						groupId: "g1",
+						deviceId: "worker-1",
+						publicKey: "worker-pk",
+						fingerprint: "worker-fp",
+						token: invite.token,
+					});
+					const reviewed = await store.reviewJoinRequest({
+						requestId: req.request_id as string,
+						approved: true,
+						bootstrapGrant: {
+							seedDeviceId: "seed-1",
+							scope: "bootstrap",
+							expiresAt: "2099-02-01T00:00:00Z",
+						},
+					});
+					expect(reviewed?.status).toBe("approved");
+					expect(reviewed?.bootstrap_grant).toEqual(
+						expect.objectContaining({
+							group_id: "g1",
+							seed_device_id: "seed-1",
+							worker_device_id: "worker-1",
+							scope: "bootstrap",
+						}),
+					);
+				});
+			});
+
 			it("denies a join request without enrolling", async () => {
 				await withContext(async ({ store }) => {
 					await store.createGroup("g1");
@@ -486,6 +527,63 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 							direction: "incoming",
 						}),
 					).toEqual([]);
+				});
+			});
+		});
+
+		describe("bootstrap grants", () => {
+			it("creates and retrieves a bootstrap grant", async () => {
+				await withContext(async ({ store }) => {
+					const grant = await store.createBootstrapGrant({
+						groupId: "g1",
+						seedDeviceId: "seed-1",
+						workerDeviceId: "worker-1",
+						scope: "bootstrap",
+						expiresAt: "2099-01-01T00:00:00Z",
+						createdBy: "admin",
+					});
+					const fetched = await store.getBootstrapGrant(grant.grant_id);
+					expect(fetched).not.toBeNull();
+					expect(fetched?.seed_device_id).toBe("seed-1");
+					expect(fetched?.worker_device_id).toBe("worker-1");
+					expect(fetched?.scope).toBe("bootstrap");
+				});
+			});
+
+			it("lists bootstrap grants for a group", async () => {
+				await withContext(async ({ store }) => {
+					await store.createBootstrapGrant({
+						groupId: "g1",
+						seedDeviceId: "seed-1",
+						workerDeviceId: "worker-1",
+						scope: "bootstrap",
+						expiresAt: "2099-01-01T00:00:00Z",
+					});
+					await store.createBootstrapGrant({
+						groupId: "g1",
+						seedDeviceId: "seed-1",
+						workerDeviceId: "worker-2",
+						scope: "bootstrap,initial_sync",
+						expiresAt: "2099-02-01T00:00:00Z",
+					});
+					expect(await store.listBootstrapGrants("g1")).toHaveLength(2);
+				});
+			});
+
+			it("revokes a bootstrap grant", async () => {
+				await withContext(async ({ store }) => {
+					const grant = await store.createBootstrapGrant({
+						groupId: "g1",
+						seedDeviceId: "seed-1",
+						workerDeviceId: "worker-1",
+						scope: "bootstrap",
+						expiresAt: "2099-01-01T00:00:00Z",
+					});
+					expect(await store.revokeBootstrapGrant(grant.grant_id, "2099-01-02T00:00:00Z")).toBe(
+						true,
+					);
+					const fetched = await store.getBootstrapGrant(grant.grant_id);
+					expect(fetched?.revoked_at).toBe("2099-01-02T00:00:00Z");
 				});
 			});
 		});

--- a/packages/core/src/coordinator-store.test.ts
+++ b/packages/core/src/coordinator-store.test.ts
@@ -29,6 +29,7 @@ describe("CoordinatorStore", () => {
 					.all() as { name: string }[];
 				const names = tables.map((t) => t.name).sort();
 				expect(names).toEqual([
+					"coordinator_bootstrap_grants",
 					"coordinator_invites",
 					"coordinator_join_requests",
 					"coordinator_reciprocal_approvals",

--- a/packages/core/src/coordinator-store.ts
+++ b/packages/core/src/coordinator-store.ts
@@ -4,6 +4,7 @@ export {
 	DEFAULT_COORDINATOR_DB_PATH,
 } from "./better-sqlite-coordinator-store.js";
 export type {
+	CoordinatorBootstrapGrantVerification,
 	CoordinatorCreateInviteInput,
 	CoordinatorCreateJoinRequestInput,
 	CoordinatorCreateReciprocalApprovalInput,

--- a/packages/core/src/d1-coordinator-store.test.ts
+++ b/packages/core/src/d1-coordinator-store.test.ts
@@ -256,4 +256,42 @@ describe("D1CoordinatorStore", () => {
 			await cleanup();
 		}
 	});
+
+	it("normalizes and validates bootstrap grant input consistently", async () => {
+		const { store, cleanup } = setupStore();
+		try {
+			const grant = await store.createBootstrapGrant({
+				groupId: " g1 ",
+				seedDeviceId: " seed-1 ",
+				workerDeviceId: " worker-1 ",
+				scope: " bootstrap ",
+				expiresAt: " 2099-01-01T00:00:00Z ",
+				createdBy: " admin ",
+			});
+			expect(grant).toEqual(
+				expect.objectContaining({
+					group_id: "g1",
+					seed_device_id: "seed-1",
+					worker_device_id: "worker-1",
+					scope: "bootstrap",
+					expires_at: "2099-01-01T00:00:00Z",
+					created_by: "admin",
+				}),
+			);
+
+			await expect(
+				store.createBootstrapGrant({
+					groupId: "   ",
+					seedDeviceId: "seed-1",
+					workerDeviceId: "worker-1",
+					scope: "bootstrap",
+					expiresAt: "2099-01-01T00:00:00Z",
+				}),
+			).rejects.toThrow(
+				"groupId, seedDeviceId, workerDeviceId, scope, and expiresAt are required.",
+			);
+		} finally {
+			await cleanup();
+		}
+	});
 });

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -1,4 +1,6 @@
 import type {
+	CoordinatorBootstrapGrant,
+	CoordinatorCreateBootstrapGrantInput,
 	CoordinatorCreateInviteInput,
 	CoordinatorCreateJoinRequestInput,
 	CoordinatorCreateReciprocalApprovalInput,
@@ -12,6 +14,7 @@ import type {
 	CoordinatorPeerRecord,
 	CoordinatorPresenceRecord,
 	CoordinatorReciprocalApproval,
+	CoordinatorReviewJoinRequestBootstrapGrantInput,
 	CoordinatorReviewJoinRequestInput,
 	CoordinatorStore,
 	CoordinatorUpsertPresenceInput,
@@ -126,6 +129,47 @@ function tokenUrlSafe(bytes: number): string {
 		output.push(alphabet[byte % alphabet.length] ?? "A");
 	}
 	return output.join("");
+}
+
+function requireTrimmedBootstrapGrantInput(opts: CoordinatorCreateBootstrapGrantInput): {
+	groupId: string;
+	seedDeviceId: string;
+	workerDeviceId: string;
+	scope: string;
+	expiresAt: string;
+	createdBy: string | null;
+} {
+	const groupId = String(opts.groupId ?? "").trim();
+	const seedDeviceId = String(opts.seedDeviceId ?? "").trim();
+	const workerDeviceId = String(opts.workerDeviceId ?? "").trim();
+	const scope = String(opts.scope ?? "").trim();
+	const expiresAt = String(opts.expiresAt ?? "").trim();
+	const createdBy = String(opts.createdBy ?? "").trim() || null;
+	if (!groupId || !seedDeviceId || !workerDeviceId || !scope || !expiresAt) {
+		throw new Error("groupId, seedDeviceId, workerDeviceId, scope, and expiresAt are required.");
+	}
+	return { groupId, seedDeviceId, workerDeviceId, scope, expiresAt, createdBy };
+}
+
+function normalizeBootstrapGrantRequest(
+	input: CoordinatorReviewJoinRequestBootstrapGrantInput | null | undefined,
+): CoordinatorCreateBootstrapGrantInput | null {
+	if (!input) return null;
+	const seedDeviceId = String(input.seedDeviceId ?? "").trim();
+	const scope = String(input.scope ?? "").trim();
+	const expiresAt = String(input.expiresAt ?? "").trim();
+	const createdBy = String(input.createdBy ?? "").trim() || null;
+	if (!seedDeviceId || !scope || !expiresAt) {
+		throw new Error("bootstrapGrant.seedDeviceId, scope, and expiresAt are required.");
+	}
+	return {
+		groupId: "",
+		seedDeviceId,
+		workerDeviceId: "",
+		scope,
+		expiresAt,
+		createdBy,
+	};
 }
 
 async function allRows<T>(statement: D1PreparedStatementLike): Promise<T[]> {
@@ -397,8 +441,31 @@ export class D1CoordinatorStore implements CoordinatorStore {
 		if (row.status !== "pending") {
 			return { ...rowToRecord<CoordinatorJoinRequest>(row), _no_transition: true };
 		}
+		const bootstrapGrantRequest = normalizeBootstrapGrantRequest(_opts.bootstrapGrant);
 		const reviewedAt = nowISO();
 		const nextStatus = _opts.approved ? "approved" : "denied";
+		let bootstrapGrantInput: CoordinatorCreateBootstrapGrantInput | null = null;
+		let bootstrapGrantId: string | null = null;
+		if (_opts.approved && bootstrapGrantRequest) {
+			const seedEnrollment = await firstRow<{ device_id: string }>(
+				this.db
+					.prepare(
+						`SELECT device_id FROM enrolled_devices WHERE group_id = ? AND device_id = ? AND enabled = 1`,
+					)
+					.bind(row.group_id, bootstrapGrantRequest.seedDeviceId),
+			);
+			if (!seedEnrollment) {
+				throw new Error("bootstrap grant seed device is not enrolled in the group.");
+			}
+			if (bootstrapGrantRequest.seedDeviceId === row.device_id) {
+				throw new Error("bootstrap grant seed and worker device ids must differ.");
+			}
+			bootstrapGrantInput = {
+				...bootstrapGrantRequest,
+				groupId: row.group_id,
+				workerDeviceId: row.device_id,
+			};
+		}
 		if (this.db.batch) {
 			const statements: D1PreparedStatementLike[] = [];
 			statements.push(
@@ -426,9 +493,52 @@ export class D1CoordinatorStore implements CoordinatorStore {
 							enabled = 1`)
 						.bind(nowISO(), _opts.requestId, reviewedAt),
 				);
+				if (bootstrapGrantInput) {
+					bootstrapGrantId = tokenUrlSafe(12);
+					const createdAt = nowISO();
+					// Conditional INSERT: only mint a grant if the join request was
+					// actually transitioned to 'approved' by the UPDATE in this batch.
+					// This prevents issuing extra grants under concurrent review races.
+					statements.push(
+						this.db
+							.prepare(`INSERT INTO coordinator_bootstrap_grants(
+							grant_id, group_id, seed_device_id, worker_device_id, scope, expires_at, created_at, created_by, revoked_at
+						) SELECT ?, ?, ?, ?, ?, ?, ?, ?, NULL
+						WHERE EXISTS (
+							SELECT 1 FROM coordinator_join_requests
+							WHERE request_id = ? AND status = 'approved' AND reviewed_at = ?
+						)`)
+							.bind(
+								bootstrapGrantId,
+								bootstrapGrantInput.groupId,
+								bootstrapGrantInput.seedDeviceId,
+								bootstrapGrantInput.workerDeviceId,
+								bootstrapGrantInput.scope,
+								bootstrapGrantInput.expiresAt,
+								createdAt,
+								bootstrapGrantInput.createdBy ?? null,
+								_opts.requestId,
+								reviewedAt,
+							),
+					);
+				}
 			}
 			await this.db.batch(statements);
 		} else {
+			let createdGrantId: string | null = null;
+			if (_opts.approved) {
+				await this.enrollDevice(row.group_id, {
+					deviceId: row.device_id,
+					fingerprint: row.fingerprint,
+					publicKey: row.public_key,
+					displayName: (row.display_name ?? "").trim() || null,
+				});
+				if (bootstrapGrantInput) {
+					const grant = await this.createBootstrapGrant(bootstrapGrantInput);
+					createdGrantId = grant.grant_id;
+					bootstrapGrantId = grant.grant_id;
+				}
+			}
 			const changes = await runChanges(
 				this.db
 					.prepare(`UPDATE coordinator_join_requests
@@ -437,6 +547,9 @@ export class D1CoordinatorStore implements CoordinatorStore {
 					.bind(nextStatus, reviewedAt, _opts.reviewedBy ?? null, _opts.requestId),
 			);
 			if (changes === 0) {
+				if (createdGrantId) {
+					await this.revokeBootstrapGrant(createdGrantId);
+				}
 				const latest = await firstRow<CoordinatorJoinRequestReviewResult>(
 					this.db
 						.prepare(`SELECT request_id, group_id, device_id, public_key, fingerprint, display_name, token, status, created_at, reviewed_at, reviewed_by
@@ -447,14 +560,6 @@ export class D1CoordinatorStore implements CoordinatorStore {
 					? { ...rowToRecord<CoordinatorJoinRequestReviewResult>(latest), _no_transition: true }
 					: null;
 			}
-			if (_opts.approved) {
-				await this.enrollDevice(row.group_id, {
-					deviceId: row.device_id,
-					fingerprint: row.fingerprint,
-					publicKey: row.public_key,
-					displayName: (row.display_name ?? "").trim() || null,
-				});
-			}
 		}
 		const updated = await firstRow<CoordinatorJoinRequestReviewResult>(
 			this.db
@@ -462,7 +567,16 @@ export class D1CoordinatorStore implements CoordinatorStore {
 					 FROM coordinator_join_requests WHERE request_id = ?`)
 				.bind(_opts.requestId),
 		);
-		return updated ? rowToRecord<CoordinatorJoinRequestReviewResult>(updated) : null;
+		if (!updated) return null;
+		const bootstrapGrant = bootstrapGrantInput
+			? bootstrapGrantId
+				? await this.getBootstrapGrant(bootstrapGrantId)
+				: await this.createBootstrapGrant(bootstrapGrantInput)
+			: null;
+		return {
+			...rowToRecord<CoordinatorJoinRequestReviewResult>(updated),
+			bootstrap_grant: bootstrapGrant,
+		};
 	}
 
 	async createReciprocalApproval(
@@ -580,6 +694,70 @@ export class D1CoordinatorStore implements CoordinatorStore {
 				.bind(requestId),
 		);
 		return rowToRecord<CoordinatorReciprocalApproval>(created);
+	}
+
+	async createBootstrapGrant(
+		opts: CoordinatorCreateBootstrapGrantInput,
+	): Promise<CoordinatorBootstrapGrant> {
+		const normalized = requireTrimmedBootstrapGrantInput(opts);
+		const grantId = tokenUrlSafe(12);
+		const createdAt = nowISO();
+		await this.db
+			.prepare(`INSERT INTO coordinator_bootstrap_grants(
+				grant_id, group_id, seed_device_id, worker_device_id, scope, expires_at, created_at, created_by, revoked_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`)
+			.bind(
+				grantId,
+				normalized.groupId,
+				normalized.seedDeviceId,
+				normalized.workerDeviceId,
+				normalized.scope,
+				normalized.expiresAt,
+				createdAt,
+				normalized.createdBy,
+			)
+			.run();
+		const row = await firstRow<CoordinatorBootstrapGrant>(
+			this.db
+				.prepare(`SELECT grant_id, group_id, seed_device_id, worker_device_id, scope, expires_at, created_at, created_by, revoked_at
+					 FROM coordinator_bootstrap_grants WHERE grant_id = ?`)
+				.bind(grantId),
+		);
+		return rowToRecord<CoordinatorBootstrapGrant>(row);
+	}
+
+	async getBootstrapGrant(grantId: string): Promise<CoordinatorBootstrapGrant | null> {
+		const row = await firstRow<CoordinatorBootstrapGrant>(
+			this.db
+				.prepare(`SELECT grant_id, group_id, seed_device_id, worker_device_id, scope, expires_at, created_at, created_by, revoked_at
+					 FROM coordinator_bootstrap_grants WHERE grant_id = ?`)
+				.bind(grantId),
+		);
+		return row ? rowToRecord<CoordinatorBootstrapGrant>(row) : null;
+	}
+
+	async listBootstrapGrants(groupId: string): Promise<CoordinatorBootstrapGrant[]> {
+		return (
+			await allRows<CoordinatorBootstrapGrant>(
+				this.db
+					.prepare(`SELECT grant_id, group_id, seed_device_id, worker_device_id, scope, expires_at, created_at, created_by, revoked_at
+						 FROM coordinator_bootstrap_grants WHERE group_id = ?
+						 ORDER BY created_at DESC, grant_id DESC`)
+					.bind(groupId),
+			)
+		).map((row) => rowToRecord<CoordinatorBootstrapGrant>(row));
+	}
+
+	async revokeBootstrapGrant(grantId: string, revokedAt = nowISO()): Promise<boolean> {
+		return (
+			(await runChanges(
+				this.db
+					.prepare(`UPDATE coordinator_bootstrap_grants
+						 SET revoked_at = COALESCE(revoked_at, ?)
+						 WHERE grant_id = ?`)
+					.bind(revokedAt, grantId),
+			)) > 0
+		);
 	}
 
 	async listReciprocalApprovals(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,12 +25,14 @@ export {
 	coordinatorDisableDeviceAction,
 	coordinatorEnrollDeviceAction,
 	coordinatorImportInviteAction,
+	coordinatorListBootstrapGrantsAction,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
 	coordinatorListJoinRequestsAction,
 	coordinatorRemoveDeviceAction,
 	coordinatorRenameDeviceAction,
 	coordinatorReviewJoinRequestAction,
+	coordinatorRevokeBootstrapGrantAction,
 } from "./coordinator-actions.js";
 export type {
 	CoordinatorRequestVerifier,
@@ -57,6 +59,7 @@ export {
 	registerCoordinatorPresence,
 } from "./coordinator-runtime.js";
 export type {
+	CoordinatorBootstrapGrantVerification,
 	CoordinatorCreateInviteInput,
 	CoordinatorCreateJoinRequestInput,
 	CoordinatorCreateReciprocalApprovalInput,

--- a/packages/core/src/sync-auth.ts
+++ b/packages/core/src/sync-auth.ts
@@ -219,6 +219,7 @@ export interface BuildAuthHeadersOptions {
 	method: string;
 	url: string;
 	bodyBytes: Buffer;
+	bootstrapGrantId?: string;
 	keysDir?: string;
 	timestamp?: string;
 	nonce?: string;
@@ -230,6 +231,7 @@ export interface BuildAuthHeadersOptions {
 export function buildAuthHeaders(options: BuildAuthHeadersOptions): Record<string, string> {
 	return {
 		"X-Opencode-Device": options.deviceId,
+		...(options.bootstrapGrantId ? { "X-Codemem-Bootstrap-Grant": options.bootstrapGrantId } : {}),
 		...signRequest({
 			method: options.method,
 			url: options.url,

--- a/packages/core/src/sync-bootstrap.test.ts
+++ b/packages/core/src/sync-bootstrap.test.ts
@@ -1,7 +1,11 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { toJson } from "./db.js";
-import { applyBootstrapSnapshot } from "./sync-bootstrap.js";
+import { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
+import { ensureDeviceIdentity } from "./sync-identity.js";
 import { getSyncResetState, setSyncResetState } from "./sync-replication.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import type { SyncMemorySnapshotItem, SyncResetRequired } from "./types.js";
@@ -166,5 +170,47 @@ describe("applyBootstrapSnapshot", () => {
 		expect(result.ok).toBe(true);
 		expect(result.deleted).toBe(1);
 		expect(result.applied).toBe(0);
+	});
+});
+
+describe("fetchAllSnapshotPages", () => {
+	it("forwards bootstrap grant id as an auth header", async () => {
+		const db = new Database(":memory:");
+		initTestSchema(db);
+		const keysDir = mkdtempSync(join(tmpdir(), "codemem-bootstrap-keys-"));
+		const [deviceId] = ensureDeviceIdentity(db, { keysDir });
+		const prevFetch = globalThis.fetch;
+		try {
+			globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+				expect(init?.headers).toMatchObject({
+					"X-Codemem-Bootstrap-Grant": "grant-1",
+					"X-Opencode-Device": deviceId,
+				});
+				return new Response(
+					JSON.stringify({
+						generation: 2,
+						snapshot_id: "snap-2",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+						items: [],
+						next_page_token: null,
+						has_more: false,
+					}),
+					{ status: 200 },
+				);
+			}) as typeof fetch;
+
+			const result = await fetchAllSnapshotPages(
+				"http://peer.example.test:47337",
+				makeResetInfo(),
+				deviceId,
+				{ keysDir, bootstrapGrantId: "grant-1" },
+			);
+			expect(result.snapshot_id).toBe("snap-2");
+		} finally {
+			globalThis.fetch = prevFetch;
+			db.close();
+			rmSync(keysDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -33,6 +33,7 @@ export interface BootstrapResult {
 
 export interface BootstrapOptions {
 	keysDir?: string;
+	bootstrapGrantId?: string;
 	/** Max items per page request. Defaults to 200. */
 	pageSize?: number;
 	/** Timeout per HTTP request in seconds. Defaults to 10. */
@@ -73,6 +74,7 @@ export async function fetchAllSnapshotPages(
 	const pageSize = options?.pageSize ?? 200;
 	const timeoutS = options?.timeoutS ?? 10;
 	const keysDir = options?.keysDir;
+	const bootstrapGrantId = options?.bootstrapGrantId?.trim() || undefined;
 	const maxItems = options?.maxItems ?? 100_000;
 
 	const allItems: SyncMemorySnapshotItem[] = [];
@@ -99,6 +101,7 @@ export async function fetchAllSnapshotPages(
 			method: "GET",
 			url,
 			bodyBytes: Buffer.alloc(0),
+			bootstrapGrantId,
 			keysDir,
 		});
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1131,6 +1131,94 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("allows /v1/status with a valid bootstrap grant", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			const peerDir = mkdtempSync(join(tmpdir(), "codemem-sync-bootstrap-grant-test-"));
+			const peerDbPath = join(peerDir, "peer.sqlite");
+			const peerKeysDir = join(peerDir, "keys");
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			let peerDeviceIdValue = "";
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/bootstrap-grants/grant-1")) {
+					return new Response(
+						JSON.stringify({
+							grant: {
+								grant_id: "grant-1",
+								group_id: "g1",
+								seed_device_id: "test-device-001",
+								worker_device_id: peerDeviceIdValue,
+								scope: "bootstrap",
+								expires_at: "2099-01-01T00:00:00Z",
+								created_at: "2026-01-01T00:00:00Z",
+								created_by: "admin",
+								revoked_at: null,
+							},
+							worker_enrollment: {
+								group_id: "g1",
+								device_id: peerDeviceIdValue,
+								public_key: peerPublicKeyValue,
+								fingerprint: peerFingerprintValue,
+								display_name: "Peer Bootstrap",
+								enabled: 1,
+								created_at: "2026-01-01T00:00:00Z",
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			let peerPublicKeyValue = "";
+			let peerFingerprintValue = "";
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const peerDb = connect(peerDbPath);
+				try {
+					initTestSchema(peerDb);
+					const [peerDeviceId] = ensureDeviceIdentity(peerDb, { keysDir: peerKeysDir });
+					peerDeviceIdValue = peerDeviceId;
+					peerPublicKeyValue = loadPublicKey(peerKeysDir) ?? "";
+					const peerFingerprint = peerDb
+						.prepare("SELECT fingerprint FROM sync_device LIMIT 1")
+						.get() as { fingerprint: string } | undefined;
+					peerFingerprintValue = peerFingerprint?.fingerprint ?? "";
+					const url = "http://localhost/v1/status";
+					const headers = buildAuthHeaders({
+						deviceId: peerDeviceId,
+						method: "GET",
+						url,
+						bodyBytes: Buffer.alloc(0),
+						keysDir: peerKeysDir,
+						bootstrapGrantId: "grant-1",
+					});
+					const res = await syncApp.request(url, { headers });
+					expect(res.status).toBe(200);
+				} finally {
+					peerDb.close();
+				}
+			} finally {
+				cleanup();
+				rmSync(peerDir, { recursive: true, force: true });
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
 		it("rate limits repeated sync listener requests", async () => {
 			const { syncApp, cleanup } = createTestApp({
 				syncRequestRateLimit: { unauthenticatedReadLimit: 1 },
@@ -1217,6 +1305,189 @@ describe("viewer-server", () => {
 				expect(postRes.status).toBe(401);
 			} finally {
 				cleanup();
+			}
+		});
+
+		it("does not allow a bootstrap grant to access /v1/ops", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			const peerDir = mkdtempSync(join(tmpdir(), "codemem-sync-bootstrap-grant-test-"));
+			const peerDbPath = join(peerDir, "peer.sqlite");
+			const peerKeysDir = join(peerDir, "keys");
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			let peerDeviceIdValue = "";
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/bootstrap-grants/grant-1")) {
+					return new Response(
+						JSON.stringify({
+							grant: {
+								grant_id: "grant-1",
+								group_id: "g1",
+								seed_device_id: "test-device-001",
+								worker_device_id: peerDeviceIdValue,
+								scope: "bootstrap",
+								expires_at: "2099-01-01T00:00:00Z",
+								created_at: "2026-01-01T00:00:00Z",
+								created_by: "admin",
+								revoked_at: null,
+							},
+							worker_enrollment: {
+								group_id: "g1",
+								device_id: peerDeviceIdValue,
+								public_key: peerPublicKeyValue,
+								fingerprint: peerFingerprintValue,
+								display_name: "Peer Bootstrap",
+								enabled: 1,
+								created_at: "2026-01-01T00:00:00Z",
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			let peerPublicKeyValue = "";
+			let peerFingerprintValue = "";
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const peerDb = connect(peerDbPath);
+				try {
+					initTestSchema(peerDb);
+					const [peerDeviceId] = ensureDeviceIdentity(peerDb, { keysDir: peerKeysDir });
+					peerDeviceIdValue = peerDeviceId;
+					peerPublicKeyValue = loadPublicKey(peerKeysDir) ?? "";
+					const peerFingerprint = peerDb
+						.prepare("SELECT fingerprint FROM sync_device LIMIT 1")
+						.get() as { fingerprint: string } | undefined;
+					peerFingerprintValue = peerFingerprint?.fingerprint ?? "";
+					const url = "http://localhost/v1/ops";
+					const headers = buildAuthHeaders({
+						deviceId: peerDeviceId,
+						method: "POST",
+						url,
+						bodyBytes: Buffer.from(JSON.stringify({ ops: [] })),
+						keysDir: peerKeysDir,
+						bootstrapGrantId: "grant-1",
+					});
+					const res = await syncApp.request(url, {
+						method: "POST",
+						headers: {
+							...headers,
+							"Content-Type": "application/json",
+						},
+						body: JSON.stringify({ ops: [] }),
+					});
+					expect(res.status).toBe(401);
+				} finally {
+					peerDb.close();
+				}
+			} finally {
+				cleanup();
+				rmSync(peerDir, { recursive: true, force: true });
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
+		it("rejects bootstrap grants whose worker enrollment does not match the granted worker", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			const peerDir = mkdtempSync(join(tmpdir(), "codemem-sync-bootstrap-grant-test-"));
+			const peerDbPath = join(peerDir, "peer.sqlite");
+			const peerKeysDir = join(peerDir, "keys");
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			let peerDeviceIdValue = "";
+			let peerPublicKeyValue = "";
+			let peerFingerprintValue = "";
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/bootstrap-grants/grant-1")) {
+					return new Response(
+						JSON.stringify({
+							grant: {
+								grant_id: "grant-1",
+								group_id: "g1",
+								seed_device_id: "test-device-001",
+								worker_device_id: peerDeviceIdValue,
+								scope: "bootstrap",
+								expires_at: "2099-01-01T00:00:00Z",
+								created_at: "2026-01-01T00:00:00Z",
+								created_by: "admin",
+								revoked_at: null,
+							},
+							worker_enrollment: {
+								group_id: "g1",
+								device_id: "different-worker-id",
+								public_key: peerPublicKeyValue,
+								fingerprint: peerFingerprintValue,
+								display_name: "Peer Bootstrap",
+								enabled: 1,
+								created_at: "2026-01-01T00:00:00Z",
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const peerDb = connect(peerDbPath);
+				try {
+					initTestSchema(peerDb);
+					const [peerDeviceId] = ensureDeviceIdentity(peerDb, { keysDir: peerKeysDir });
+					peerDeviceIdValue = peerDeviceId;
+					peerPublicKeyValue = loadPublicKey(peerKeysDir) ?? "";
+					const peerFingerprint = peerDb
+						.prepare("SELECT fingerprint FROM sync_device LIMIT 1")
+						.get() as { fingerprint: string } | undefined;
+					peerFingerprintValue = peerFingerprint?.fingerprint ?? "";
+					const url = "http://localhost/v1/status";
+					const headers = buildAuthHeaders({
+						deviceId: peerDeviceId,
+						method: "GET",
+						url,
+						bodyBytes: Buffer.alloc(0),
+						keysDir: peerKeysDir,
+						bootstrapGrantId: "grant-1",
+					});
+					const res = await syncApp.request(url, { headers });
+					expect(res.status).toBe(401);
+				} finally {
+					peerDb.close();
+				}
+			} finally {
+				cleanup();
+				rmSync(peerDir, { recursive: true, force: true });
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
 			}
 		});
 
@@ -1544,6 +1815,101 @@ describe("viewer-server", () => {
 				expect(body.error).toBe("unauthorized");
 			} finally {
 				cleanup();
+			}
+		});
+
+		it("lists bootstrap grants through viewer sync routes", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/bootstrap-grants?group_id=g1")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									grant_id: "grant-1",
+									group_id: "g1",
+									seed_device_id: "seed-1",
+									worker_device_id: "worker-1",
+									scope: "bootstrap",
+									expires_at: "2099-01-01T00:00:00Z",
+									created_at: "2026-01-01T00:00:00Z",
+									created_by: "admin",
+									revoked_at: null,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const res = await app.request("/api/sync/bootstrap-grants?group_id=g1");
+					expect(res.status).toBe(200);
+					expect(await res.json()).toEqual({
+						items: [expect.objectContaining({ grant_id: "grant-1", group_id: "g1" })],
+					});
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
+		it("revokes bootstrap grants through viewer sync routes", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/bootstrap-grants/revoke")) {
+					return new Response(JSON.stringify({ ok: true, grant_id: "grant-1" }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const res = await app.request("/api/sync/bootstrap-grants/revoke", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ grant_id: "grant-1" }),
+					});
+					expect(res.status).toBe(200);
+					expect(await res.json()).toEqual({ ok: true, grant_id: "grant-1" });
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
 			}
 		});
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -6,13 +6,20 @@ import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import net from "node:net";
 import { dirname, join } from "node:path";
-import type { MemoryStore, ReplicationOp } from "@codemem/core";
+import type {
+	CoordinatorBootstrapGrantVerification,
+	MemoryStore,
+	ReplicationOp,
+} from "@codemem/core";
 import {
 	applyReplicationOps,
+	buildBaseUrl,
 	cleanupNonces,
 	coordinatorCreateInviteAction,
 	coordinatorImportInviteAction,
+	coordinatorListBootstrapGrantsAction,
 	coordinatorReviewJoinRequestAction,
+	coordinatorRevokeBootstrapGrantAction,
 	coordinatorStatusSnapshot,
 	createCoordinatorReciprocalApproval,
 	DEFAULT_TIME_WINDOW_S,
@@ -27,6 +34,7 @@ import {
 	mergeAddresses,
 	readCoordinatorSyncConfig,
 	recordNonce,
+	requestJson,
 	runSyncPass,
 	schema,
 	verifySignature,
@@ -115,8 +123,8 @@ function pathWithQuery(url: string): string {
 	return parsed.search ? `${parsed.pathname}${parsed.search}` : parsed.pathname;
 }
 
-function unauthorizedPayload(reason: string): Record<string, string> {
-	if (process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS === "1") {
+function unauthorizedPayload(reason: string, exposeReason = false): Record<string, string> {
+	if (exposeReason && process.env.CODEMEM_SYNC_AUTH_DIAGNOSTICS === "1") {
 		return { error: "unauthorized", reason };
 	}
 	return { error: "unauthorized" };
@@ -178,6 +186,105 @@ function authorizeSyncRequest(
 		return { ok: false, reason: "nonce_replay", deviceId };
 	}
 
+	const cutoff = new Date(Date.now() - DEFAULT_TIME_WINDOW_S * 2 * 1000).toISOString();
+	cleanupNonces(store.db, cutoff);
+	return { ok: true, reason: "ok", deviceId };
+}
+
+async function authorizeBootstrapGrantRequest(
+	store: MemoryStore,
+	request: { method: string; url: string; header(name: string): string | undefined },
+	body: Buffer,
+	allowedScopes: string[],
+): Promise<{ ok: boolean; reason: string; deviceId: string }> {
+	const grantId = (request.header("X-Codemem-Bootstrap-Grant") ?? "").trim();
+	const deviceId = (request.header("X-Opencode-Device") ?? "").trim();
+	const signature = request.header("X-Opencode-Signature") ?? "";
+	const timestamp = request.header("X-Opencode-Timestamp") ?? "";
+	const nonce = request.header("X-Opencode-Nonce") ?? "";
+	if (!grantId || !deviceId || !signature || !timestamp || !nonce) {
+		return { ok: false, reason: "missing_bootstrap_grant_headers", deviceId };
+	}
+
+	const config = readCoordinatorSyncConfig();
+	if (!config.syncCoordinatorUrl || !config.syncCoordinatorAdminSecret) {
+		return { ok: false, reason: "bootstrap_grant_coordinator_not_configured", deviceId };
+	}
+
+	const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
+	let verification: CoordinatorBootstrapGrantVerification;
+	try {
+		const [status, payload] = await requestJson(
+			"GET",
+			`${buildBaseUrl(config.syncCoordinatorUrl)}/v1/admin/bootstrap-grants/${encodeURIComponent(grantId)}`,
+			{
+				headers: { "X-Codemem-Coordinator-Admin": config.syncCoordinatorAdminSecret },
+				timeoutS: Math.max(1, config.syncCoordinatorTimeoutS),
+			},
+		);
+		if (status !== 200 || !payload) {
+			return { ok: false, reason: "bootstrap_grant_lookup_failed", deviceId };
+		}
+		verification = payload as unknown as CoordinatorBootstrapGrantVerification;
+	} catch {
+		return { ok: false, reason: "bootstrap_grant_lookup_failed", deviceId };
+	}
+
+	const grant = verification.grant;
+	const workerEnrollment = verification.worker_enrollment;
+	if (!grant || !workerEnrollment) {
+		return { ok: false, reason: "bootstrap_grant_invalid_payload", deviceId };
+	}
+	if (grant.revoked_at) return { ok: false, reason: "bootstrap_grant_revoked", deviceId };
+	if (String(workerEnrollment.device_id) !== String(grant.worker_device_id)) {
+		return { ok: false, reason: "bootstrap_grant_worker_enrollment_mismatch", deviceId };
+	}
+	if (String(workerEnrollment.group_id) !== String(grant.group_id)) {
+		return { ok: false, reason: "bootstrap_grant_group_mismatch", deviceId };
+	}
+	if (Number(workerEnrollment.enabled) !== 1) {
+		return { ok: false, reason: "bootstrap_grant_worker_disabled", deviceId };
+	}
+	if (grant.worker_device_id !== deviceId) {
+		return { ok: false, reason: "bootstrap_grant_worker_mismatch", deviceId };
+	}
+	if (grant.seed_device_id !== localDeviceId) {
+		return { ok: false, reason: "bootstrap_grant_seed_mismatch", deviceId };
+	}
+	if (new Date(grant.expires_at) <= new Date()) {
+		return { ok: false, reason: "bootstrap_grant_expired", deviceId };
+	}
+	const scopes = String(grant.scope ?? "")
+		.split(",")
+		.map((item) => item.trim())
+		.filter(Boolean);
+	if (!allowedScopes.some((scope) => scopes.includes(scope))) {
+		return { ok: false, reason: "bootstrap_grant_scope_denied", deviceId };
+	}
+
+	let valid = false;
+	try {
+		valid = verifySignature({
+			method: request.method,
+			pathWithQuery: pathWithQuery(request.url),
+			bodyBytes: body,
+			timestamp,
+			nonce,
+			signature,
+			publicKey: String(workerEnrollment.public_key),
+			deviceId,
+		});
+	} catch {
+		return { ok: false, reason: "bootstrap_grant_signature_verification_error", deviceId };
+	}
+	if (!valid) {
+		return { ok: false, reason: "bootstrap_grant_invalid_signature", deviceId };
+	}
+
+	const createdAt = new Date().toISOString();
+	if (!recordNonce(store.db, deviceId, nonce, createdAt)) {
+		return { ok: false, reason: "nonce_replay", deviceId };
+	}
 	const cutoff = new Date(Date.now() - DEFAULT_TIME_WINDOW_S * 2 * 1000).toISOString();
 	cleanupNonces(store.db, cutoff);
 	return { ok: true, reason: "ok", deviceId };
@@ -765,28 +872,49 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 	// GET /v1/status (peer sync protocol)
 	app.get("/v1/status", (c) => {
 		const store = getStore();
-		const auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
-		if (!auth.ok)
-			return (
-				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
-			);
-		const limited = rateLimitedResponse(c, auth.deviceId, true);
-		if (limited) return limited;
+		return (async () => {
+			let auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
+			let exposeBootstrapReason = false;
+			let preauthChecked = false;
+			if (!auth.ok) {
+				const bootstrapGrantId = (c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim();
+				if (bootstrapGrantId) {
+					preauthChecked = true;
+					// Use unauthenticated bucket with stable key — grant is not yet verified,
+					// so caller-controlled headers must not influence rate-limit identity.
+					const bootstrapLimited = rateLimitedResponse(c, c.req.path, false);
+					if (bootstrapLimited) return bootstrapLimited;
+				} else {
+					preauthChecked = true;
+					const unauthLimited = rateLimitedResponse(c, c.req.path, false);
+					if (unauthLimited) return unauthLimited;
+				}
+				auth = await authorizeBootstrapGrantRequest(store, c.req, Buffer.alloc(0), ["bootstrap"]);
+				exposeBootstrapReason = auth.reason.startsWith("bootstrap_grant_");
+			}
+			if (!auth.ok)
+				return (
+					(preauthChecked ? null : rateLimitedResponse(c, c.req.path, false)) ??
+					c.json(unauthorizedPayload(auth.reason, exposeBootstrapReason), 401)
+				);
+			const limited = rateLimitedResponse(c, auth.deviceId, true);
+			if (limited) return limited;
 
-		try {
-			const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, {
-				keysDir: syncKeysDir(),
-			});
-			const syncReset = getSyncResetState(store.db);
-			return c.json({
-				device_id: deviceId,
-				protocol_version: SYNC_PROTOCOL_VERSION,
-				fingerprint,
-				sync_reset: syncReset,
-			});
-		} catch {
-			return c.json({ error: "internal_error" }, 500);
-		}
+			try {
+				const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, {
+					keysDir: syncKeysDir(),
+				});
+				const syncReset = getSyncResetState(store.db);
+				return c.json({
+					device_id: deviceId,
+					protocol_version: SYNC_PROTOCOL_VERSION,
+					fingerprint,
+					sync_reset: syncReset,
+				});
+			} catch {
+				return c.json({ error: "internal_error" }, 500);
+			}
+		})();
 	});
 
 	// GET /v1/ops (peer sync protocol)
@@ -850,59 +978,80 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 	// GET /v1/snapshot (peer sync protocol — bootstrap snapshot pages)
 	app.get("/v1/snapshot", (c) => {
 		const store = getStore();
-		const auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
-		if (!auth.ok)
-			return (
-				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
-			);
-		const limited = rateLimitedResponse(c, auth.deviceId, true);
-		if (limited) return limited;
-
-		try {
-			const rawGeneration = c.req.query("generation");
-			const generation =
-				rawGeneration != null && rawGeneration.trim().length > 0
-					? Number.parseInt(rawGeneration, 10)
-					: null;
-			const snapshotId = c.req.query("snapshot_id") ?? null;
-			const baselineCursor = c.req.query("baseline_cursor") ?? null;
-			const pageToken = c.req.query("page_token") ?? null;
-			const rawLimit = Number.parseInt(c.req.query("limit") ?? "200", 10);
-			// Cap raised to 5000 to support elevated bootstrap page sizes (default 2000).
-			const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(rawLimit, 5000)) : 200;
-
-			if (generation == null || !Number.isFinite(generation)) {
-				return c.json({ error: "missing_generation" }, 400);
+		return (async () => {
+			let auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
+			let exposeBootstrapReason = false;
+			let preauthChecked = false;
+			if (!auth.ok) {
+				const bootstrapGrantId = (c.req.header("X-Codemem-Bootstrap-Grant") ?? "").trim();
+				if (bootstrapGrantId) {
+					preauthChecked = true;
+					// Use unauthenticated bucket with stable key — grant is not yet verified,
+					// so caller-controlled headers must not influence rate-limit identity.
+					const bootstrapLimited = rateLimitedResponse(c, c.req.path, false);
+					if (bootstrapLimited) return bootstrapLimited;
+				} else {
+					preauthChecked = true;
+					const unauthLimited = rateLimitedResponse(c, c.req.path, false);
+					if (unauthLimited) return unauthLimited;
+				}
+				auth = await authorizeBootstrapGrantRequest(store, c.req, Buffer.alloc(0), ["bootstrap"]);
+				exposeBootstrapReason = auth.reason.startsWith("bootstrap_grant_");
 			}
-			if (!snapshotId) {
-				return c.json({ error: "missing_snapshot_id" }, 400);
-			}
+			if (!auth.ok)
+				return (
+					(preauthChecked ? null : rateLimitedResponse(c, c.req.path, false)) ??
+					c.json(unauthorizedPayload(auth.reason, exposeBootstrapReason), 401)
+				);
+			const limited = rateLimitedResponse(c, auth.deviceId, true);
+			if (limited) return limited;
 
-			const result = loadMemorySnapshotPageForPeer(store.db, {
-				generation,
-				snapshotId,
-				baselineCursor,
-				pageToken,
-				limit,
-				peerDeviceId: auth.deviceId,
-			});
+			try {
+				const rawGeneration = c.req.query("generation");
+				const generation =
+					rawGeneration != null && rawGeneration.trim().length > 0
+						? Number.parseInt(rawGeneration, 10)
+						: null;
+				const snapshotId = c.req.query("snapshot_id") ?? null;
+				const baselineCursor = c.req.query("baseline_cursor") ?? null;
+				const pageToken = c.req.query("page_token") ?? null;
+				const rawLimit = Number.parseInt(c.req.query("limit") ?? "200", 10);
+				// Cap raised to 5000 to support elevated bootstrap page sizes (default 2000).
+				const limit = Number.isFinite(rawLimit) ? Math.max(1, Math.min(rawLimit, 5000)) : 200;
 
-			return c.json({
-				generation: result.boundary.generation,
-				snapshot_id: result.boundary.snapshot_id,
-				baseline_cursor: result.boundary.baseline_cursor,
-				retained_floor_cursor: result.boundary.retained_floor_cursor,
-				items: result.items,
-				next_page_token: result.nextPageToken,
-				has_more: result.hasMore,
-			});
-		} catch (err) {
-			const message = err instanceof Error ? err.message : "";
-			if (message === "generation_mismatch" || message === "boundary_mismatch") {
-				return c.json({ error: message }, 409);
+				if (generation == null || !Number.isFinite(generation)) {
+					return c.json({ error: "missing_generation" }, 400);
+				}
+				if (!snapshotId) {
+					return c.json({ error: "missing_snapshot_id" }, 400);
+				}
+
+				const result = loadMemorySnapshotPageForPeer(store.db, {
+					generation,
+					snapshotId,
+					baselineCursor,
+					pageToken,
+					limit,
+					peerDeviceId: auth.deviceId,
+				});
+
+				return c.json({
+					generation: result.boundary.generation,
+					snapshot_id: result.boundary.snapshot_id,
+					baseline_cursor: result.boundary.baseline_cursor,
+					retained_floor_cursor: result.boundary.retained_floor_cursor,
+					items: result.items,
+					next_page_token: result.nextPageToken,
+					has_more: result.hasMore,
+				});
+			} catch (err) {
+				const message = err instanceof Error ? err.message : "";
+				if (message === "generation_mismatch" || message === "boundary_mismatch") {
+					return c.json({ error: message }, 409);
+				}
+				return c.json({ error: "internal_error" }, 500);
 			}
-			return c.json({ error: "internal_error" }, 500);
-		}
+		})();
 	});
 
 	// POST /v1/ops (peer sync protocol)
@@ -1820,6 +1969,47 @@ export function syncRoutes(
 				{ error: message },
 				message.includes("request_not_found") || message.includes("not found") ? 404 : 400,
 			);
+		}
+	});
+
+	app.get("/api/sync/bootstrap-grants", async (c) => {
+		const groupId = String(c.req.query("group_id") ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id_required" }, 400);
+		const config = readCoordinatorSyncConfig();
+		try {
+			const items = await coordinatorListBootstrapGrantsAction({
+				groupId,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			return c.json({ items });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "unknown";
+			return c.json({ error: message }, 500);
+		}
+	});
+
+	app.post("/api/sync/bootstrap-grants/revoke", async (c) => {
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json" }, 400);
+		}
+		const grantId = String(body.grant_id ?? "").trim();
+		if (!grantId) return c.json({ error: "grant_id_required" }, 400);
+		const config = readCoordinatorSyncConfig();
+		try {
+			const ok = await coordinatorRevokeBootstrapGrantAction({
+				grantId,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!ok) return c.json({ error: "grant_not_found" }, 404);
+			return c.json({ ok: true, grant_id: grantId });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "unknown";
+			return c.json({ error: message }, 500);
 		}
 	});
 


### PR DESCRIPTION
## Description
- add coordinator-side bootstrap grant persistence and issuance support
- allow seed sync status and snapshot endpoints to accept valid bootstrap grants without widening normal sync auth
- add worker bootstrap support for presenting bootstrap grants and add grant list/revoke diagnostics surfaces

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] Relevant JS/TS tests pass locally

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

## Notes
- targeted validation run: pnpm run test -- packages/core/src/coordinator-api.test.ts packages/core/src/coordinator-store.test.ts packages/core/src/d1-coordinator-store.test.ts packages/core/src/d1-coordinator-runtime.test.ts packages/viewer-server/src/index.test.ts packages/cli/src/commands/sync.test.ts
- scoped to seed-scoped bootstrap authorization only; broader CLI simplification remains separate follow-up work
