### PR TITLE
refactor CLI commands for design conventions compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,24 +108,37 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 
 ## CLI
 
-| Command | Description |
-|---------|-------------|
-| `codemem stats` | Database statistics |
-| `codemem recent` | Recent memories |
-| `codemem search <query>` | Search memories |
-| `codemem embed` | Backfill semantic embeddings |
-| `codemem serve` | Launch the web viewer |
-| `codemem db backfill-tags` | Populate missing `tags_text` values |
-| `codemem db prune-observations` | Deactivate low-signal observations |
-| `codemem db prune-memories` | Deactivate low-signal memories (`--dry-run` to preview) |
-| `codemem export-memories` | Export memories by project |
-| `codemem import-memories` | Import memories (idempotent) |
-| `codemem sync` | Peer-to-peer sync commands |
+| Group | Command | Description |
+|-------|---------|-------------|
+| **Core** | `codemem stats` | Database statistics |
+| | `codemem recent` | Recent memories |
+| | `codemem search <query>` | Search memories |
+| | `codemem pack <context>` | Build a context-aware memory pack |
+| | `codemem embed` | Backfill semantic embeddings |
+| **Memory** | `codemem memory show <id>` | Print a memory item as JSON |
+| | `codemem memory forget <id>` | Deactivate a memory item |
+| | `codemem memory remember` | Manually add a memory |
+| | `codemem memory inject <context>` | Raw pack text for prompt injection |
+| | `codemem memory export <output>` | Export memories by project |
+| | `codemem memory import <file>` | Import memories (idempotent) |
+| **Viewer** | `codemem serve [start\|stop\|restart]` | Launch / manage the web viewer |
+| **Sync** | `codemem sync enable\|disable` | Enable or disable peer-to-peer sync |
+| | `codemem sync status` | Device info and peer health |
+| | `codemem sync pair` | Generate or accept a pairing payload |
+| | `codemem sync once` | Run one immediate sync pass |
+| | `codemem sync doctor` | Diagnose sync configuration issues |
+| | `codemem sync bootstrap` | Bootstrap sync from a peer snapshot |
+| **Coordinator** | `codemem coordinator` | Self-hosted coordinator admin (groups, devices, invites) |
+| **Database** | `codemem db prune-memories` | Deactivate low-signal memories (`--dry-run` to preview) |
+| | `codemem db prune-observations` | Deactivate low-signal observations |
+| | `codemem db backfill-tags` | Populate missing `tags_text` values |
+| | `codemem db raw-events-status` | Show raw-event queue status |
+| **Config** | `codemem config` | View or update configuration |
+| | `codemem setup` | Interactive first-run setup |
+| **Plumbing** | `codemem mcp` | MCP stdio server |
+| | `codemem claude-hook-ingest` | Claude hook event ingestion (stdin) |
 
-Run `codemem --help` for the full list.
-
-Note: in the TypeScript CLI, `codemem memory inject <context>` prints raw `pack_text`
-for manual prompt injection. `codemem memory compact` remains deferred.
+Run `codemem --help` for the full list. Legacy top-level aliases (`export-memories`, `import-memories`, `show`, `forget`, `remember`) still work but are hidden from help.
 
 ## MCP tools
 
@@ -204,7 +217,7 @@ The viewer now includes actor management for mapping multiple peers to one logic
 
 Project filters, peer-to-actor assignment, visibility controls, and config keys are documented in [docs/user-guide.md](docs/user-guide.md).
 
-For cross-network setups where peer addresses change frequently or mDNS does not cross VPN/network boundaries, codemem also supports optional coordinator-backed discovery with a self-hosted coordinator. The preferred deployment path is the built-in `codemem sync coordinator` service; see [docs/coordinator-discovery.md](docs/coordinator-discovery.md).
+For cross-network setups where peer addresses change frequently or mDNS does not cross VPN/network boundaries, codemem also supports optional coordinator-backed discovery with a self-hosted coordinator. The preferred deployment path is the built-in `codemem coordinator` service; see [docs/coordinator-discovery.md](docs/coordinator-discovery.md).
 
 ## Semantic recall
 

--- a/docs/coordinator-discovery.md
+++ b/docs/coordinator-discovery.md
@@ -74,24 +74,29 @@ Backward compatibility:
 ## Built-in coordinator service
 
 The preferred self-hosted deployment path is the first-party TypeScript coordinator service shipped in the main
-`codemem` CLI. Its HTTP surface is implemented with Hono and exposed through `codemem sync coordinator serve`.
+`codemem` CLI. Its HTTP surface is implemented with Hono and exposed through `codemem coordinator serve`.
+
+`coordinator` is now a **top-level command** (`codemem coordinator ...`). The legacy path `codemem sync coordinator ...`
+still works as a compatibility alias but is hidden from help and shell completion.
 
 Current shipped local coordinator CLI surface:
 
 ```fish
-codemem sync coordinator group-create team-alpha --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator list-groups --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator enroll-device team-alpha <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/device.key.pub --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator list-devices team-alpha --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator rename-device team-alpha <device-id> --name "work-laptop" --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator disable-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator remove-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
-codemem sync coordinator create-invite team-alpha --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator import-invite <invite>
-codemem sync coordinator list-join-requests team-alpha --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator approve-join-request <request-id> --db-path ~/.codemem/coordinator.sqlite
-codemem sync coordinator deny-join-request <request-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator group-create team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator list-groups --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator enroll-device team-alpha <device-id> --fingerprint <fingerprint> --public-key-file ~/.codemem/keys/device.key.pub --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator list-devices team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator rename-device team-alpha <device-id> --name "work-laptop" --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator disable-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator remove-device team-alpha <device-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator list-bootstrap-grants team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator revoke-bootstrap-grant <grant-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator serve --db-path ~/.codemem/coordinator.sqlite --host 0.0.0.0 --port 7347
+codemem coordinator create-invite team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator import-invite <invite>
+codemem coordinator list-join-requests team-alpha --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator approve-join-request <request-id> --db-path ~/.codemem/coordinator.sqlite
+codemem coordinator deny-join-request <request-id> --db-path ~/.codemem/coordinator.sqlite
 ```
 
 This keeps the primary deployment path inside the main `codemem` artifact and reuses the current TypeScript sync
@@ -150,12 +155,12 @@ is only for remote mutation/listing endpoints.
 
 ## Canonical deployment target
 
-The built-in coordinator (`codemem sync coordinator serve`) is the canonical deployment target for ongoing product
+The built-in coordinator (`codemem coordinator serve`) is the canonical deployment target for ongoing product
 development, E2E validation, and dogfooding.
 
 Recommended deployment patterns:
 
-- **Native**: run `codemem sync coordinator serve` on a reachable machine (VPS, homelab, always-on workstation)
+- **Native**: run `codemem coordinator serve` on a reachable machine (VPS, homelab, always-on workstation)
 - **Container**: run via Docker/Podman with the coordinator SQLite volume mounted
 - **Exposure**: use Tailscale Funnel or Cloudflare Tunnel to make the coordinator reachable from outside a local network
 
@@ -177,7 +182,7 @@ It remains useful for experimentation, but it is not the canonical runtime for c
 The long-term Cloudflare direction should build from the TypeScript coordinator contract rather than from the old Python
 era deployment story. Today, the practical sequence is:
 
-1. validate the built-in TS coordinator on Node/Linux with `codemem sync coordinator serve`
+1. validate the built-in TS coordinator on Node/Linux with `codemem coordinator serve`
 2. adapt/package that validated coordinator surface for Cloudflare
 
 Use the Worker reference path only when you specifically want a serverless/edge experiment and are comfortable with

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -145,10 +145,16 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 - Use an OS service manager to run `codemem serve start --foreground` at login/boot.
 - Example service templates live in `docs/autostart/launchd/` and `docs/autostart/systemd/`.
 
+### Diagnostics
+
+- `codemem sync doctor` diagnoses sync configuration issues (keys, config, peer reachability).
+- `codemem sync bootstrap <peer-device-id>` bootstraps sync state from a peer's snapshot.
+- `codemem sync attempts` shows recent sync attempt history per peer.
+
 ### Service helpers
 
 - `codemem sync status` shows sync config and peer health.
-- `codemem sync start|stop|restart` currently manage the viewer-backed sync runtime rather than a separate sync-only daemon.
+- `codemem sync start|stop|restart` are deprecated — use `codemem serve start|stop|restart` instead. The viewer process manages the sync runtime; there is no separate sync-only daemon.
 
 ### Coordinator-backed discovery
 

--- a/packages/cli/src/commands/claude-hook-ingest.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.ts
@@ -21,21 +21,25 @@ import {
 } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import { addDbOption, addViewerHostOptions, type DbOpts, resolveDbOpt } from "../shared-options.js";
 
 type IngestResult = { inserted: number; skipped: number; via: "http" | "direct" };
 
 type IngestOpts = {
 	host: string;
-	port: number;
-	db?: string;
-	dbPath?: string;
-};
+	port: string | number;
+} & DbOpts;
 
 type IngestDeps = {
 	httpIngest?: typeof tryHttpIngest;
 	directIngest?: typeof directEnqueue;
 	resolveDb?: typeof resolveDbPath;
 };
+
+function emitStructuredError(errorCode: string, message: string): void {
+	console.log(JSON.stringify({ error: errorCode, message }));
+	process.exitCode = 1;
+}
 
 /** Try to POST the hook payload to the running viewer server. */
 async function tryHttpIngest(
@@ -163,34 +167,36 @@ export async function ingestClaudeHookPayload(
 	const directIngest = deps.directIngest ?? directEnqueue;
 	const resolveDb = deps.resolveDb ?? resolveDbPath;
 
-	const httpResult = await httpIngest(payload, opts.host, opts.port);
+	const port = typeof opts.port === "number" ? opts.port : Number.parseInt(opts.port, 10);
+	const httpResult = await httpIngest(payload, opts.host, port);
 	if (httpResult.ok) {
 		return { inserted: httpResult.inserted, skipped: httpResult.skipped, via: "http" };
 	}
 
-	const dbPath = resolveDb(opts.db ?? opts.dbPath);
+	const dbPath = resolveDb(resolveDbOpt(opts));
 	const directResult = directIngest(payload, dbPath);
 	return { ...directResult, via: "direct" };
 }
 
-export const claudeHookIngestCommand = new Command("claude-hook-ingest")
+const claudeHookCmd = new Command("claude-hook-ingest")
 	.configureHelp(helpStyle)
-	.description("Ingest Claude hook payload: HTTP first, direct DB fallback")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--host <host>", "viewer server host", "127.0.0.1")
-	.option("--port <port>", "viewer server port", "38888")
-	.action(async (opts: { db?: string; dbPath?: string; host: string; port: string }) => {
+	.description("Ingest Claude hook payload: HTTP first, direct DB fallback");
+
+addDbOption(claudeHookCmd);
+addViewerHostOptions(claudeHookCmd);
+
+export const claudeHookIngestCommand = claudeHookCmd.action(
+	async (opts: DbOpts & { host: string; port: string }) => {
 		// Read payload from stdin
 		let raw: string;
 		try {
 			raw = readFileSync(0, "utf8").trim();
 		} catch {
-			process.exitCode = 1;
+			emitStructuredError("read_error", "failed to read stdin");
 			return;
 		}
 		if (!raw) {
-			process.exitCode = 1;
+			emitStructuredError("read_error", "empty stdin");
 			return;
 		}
 
@@ -198,27 +204,20 @@ export const claudeHookIngestCommand = new Command("claude-hook-ingest")
 		try {
 			const parsed = JSON.parse(raw) as unknown;
 			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-				process.exitCode = 1;
+				emitStructuredError("parse_error", "payload must be a JSON object");
 				return;
 			}
 			payload = parsed as Record<string, unknown>;
 		} catch {
-			process.exitCode = 1;
+			emitStructuredError("parse_error", "invalid JSON");
 			return;
 		}
 
-		const port = Number.parseInt(opts.port, 10);
-		const host = opts.host;
-
 		try {
-			const result = await ingestClaudeHookPayload(payload, {
-				host,
-				port,
-				db: opts.db,
-				dbPath: opts.dbPath,
-			});
+			const result = await ingestClaudeHookPayload(payload, opts);
 			console.log(JSON.stringify(result));
-		} catch {
-			process.exitCode = 1;
+		} catch (err) {
+			emitStructuredError("ingest_error", err instanceof Error ? err.message : String(err));
 		}
-	});
+	},
+);

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -5,18 +5,18 @@ import {
 	readCodememConfigFileAtPath,
 	writeCodememConfigFile,
 } from "@codemem/core";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { helpStyle } from "../help-style.js";
+import { addJsonOption, type JsonOpts } from "../shared-options.js";
 
-type WorkspaceConfigOptions = {
-	workspaceId: string;
+type WorkspaceConfigOptions = JsonOpts & {
+	workspaceId?: string;
 	syncEnabled?: boolean;
 	syncHost?: string;
 	syncPort?: string;
 	syncIntervalS?: string;
 	coordinatorUrl?: string;
 	coordinatorGroup?: string;
-	json?: boolean;
 };
 
 type WorkspaceConfigResult = {
@@ -62,12 +62,16 @@ function runWorkspaceConfigCommand(
 	if (opts.enableSync && opts.disableSync) {
 		throw new Error("Use only one of --enable-sync or --disable-sync");
 	}
-	const configPath = getWorkspaceCodememConfigPath(opts.workspaceId);
+	const workspaceId = opts.workspaceId;
+	if (!workspaceId) {
+		throw new Error("workspace-id is required");
+	}
+	const configPath = getWorkspaceCodememConfigPath(workspaceId);
 	const existingConfig = existsSync(configPath)
 		? readCodememConfigFileAtPath(configPath)
 		: readCodememConfigFile();
 	const patch = buildWorkspaceConfigPatch({
-		workspaceId: opts.workspaceId,
+		workspaceId,
 		syncEnabled: opts.enableSync ? true : opts.disableSync ? false : undefined,
 		syncHost: opts.syncHost,
 		syncPort: opts.syncPort,
@@ -82,7 +86,7 @@ function runWorkspaceConfigCommand(
 	const nextConfig = mergeWorkspaceConfig(existingConfig, patch);
 	const savedPath = writeCodememConfigFile(nextConfig, configPath);
 	return {
-		workspace_id: opts.workspaceId,
+		workspace_id: workspaceId,
 		config_path: savedPath,
 		updated_keys: Object.keys(patch).sort(),
 		config: nextConfig,
@@ -93,21 +97,40 @@ export const configCommand = new Command("config")
 	.configureHelp(helpStyle)
 	.description("Manage codemem configuration");
 
-configCommand.addCommand(
-	new Command("workspace")
-		.configureHelp(helpStyle)
-		.description("Create or update workspace-scoped codemem config")
-		.requiredOption("--workspace-id <id>", "workspace identifier")
-		.option("--enable-sync", "set sync_enabled=true")
-		.option("--disable-sync", "set sync_enabled=false")
-		.option("--sync-host <host>", "set sync_host")
-		.option("--sync-port <port>", "set sync_port")
-		.option("--sync-interval-s <seconds>", "set sync_interval_s")
-		.option("--coordinator-url <url>", "set sync_coordinator_url")
-		.option("--coordinator-group <group>", "set sync_coordinator_group")
-		.option("--json", "output as JSON")
-		.action((opts: WorkspaceConfigOptions & { enableSync?: boolean; disableSync?: boolean }) => {
-			const result = runWorkspaceConfigCommand(opts);
+const workspaceCmd = new Command("workspace")
+	.configureHelp(helpStyle)
+	.description("Create or update workspace-scoped codemem config")
+	.argument("[workspace-id]", "workspace identifier")
+	.option("--enable-sync", "set sync_enabled=true")
+	.option("--disable-sync", "set sync_enabled=false")
+	.option("--sync-host <host>", "set sync_host")
+	.option("--sync-port <port>", "set sync_port")
+	.option("--sync-interval-s <seconds>", "set sync_interval_s")
+	.option("--coordinator-url <url>", "set sync_coordinator_url")
+	.option("--coordinator-group <group>", "set sync_coordinator_group");
+
+// Hidden backwards-compat alias for --workspace-id <id>
+workspaceCmd.addOption(
+	new Option("--workspace-id <id>", "workspace identifier (use positional instead)").hideHelp(),
+);
+
+addJsonOption(workspaceCmd);
+
+workspaceCmd.action(
+	(
+		workspaceIdArg: string | undefined,
+		opts: WorkspaceConfigOptions & { enableSync?: boolean; disableSync?: boolean },
+	) => {
+		try {
+			// Positional takes precedence over hidden flag alias
+			const workspaceId = workspaceIdArg || opts.workspaceId;
+			if (!workspaceId) {
+				console.error("Error: missing required argument 'workspace-id'");
+				process.exitCode = 2;
+				return;
+			}
+
+			const result = runWorkspaceConfigCommand({ ...opts, workspaceId });
 
 			if (opts.json) {
 				console.log(JSON.stringify(result, null, 2));
@@ -116,7 +139,22 @@ configCommand.addCommand(
 
 			console.log(`Updated workspace config: ${result.config_path}`);
 			console.log(`Updated keys: ${result.updated_keys.join(", ")}`);
-		}),
+		} catch (err) {
+			if (opts.json) {
+				console.log(
+					JSON.stringify({
+						error: "config_error",
+						message: err instanceof Error ? err.message : String(err),
+					}),
+				);
+			} else {
+				console.error(err instanceof Error ? err.message : String(err));
+			}
+			process.exitCode = 1;
+		}
+	},
 );
+
+configCommand.addCommand(workspaceCmd);
 
 export { buildWorkspaceConfigPatch, mergeWorkspaceConfig, runWorkspaceConfigCommand };

--- a/packages/cli/src/commands/coordinator.ts
+++ b/packages/cli/src/commands/coordinator.ts
@@ -1,0 +1,830 @@
+/**
+ * Coordinator CLI commands — manage coordinator invites, join requests, and relay server.
+ *
+ * Extracted from sync.ts to give coordinator admin its own top-level group
+ * per cli-design-conventions.md (operator/admin surfaces belong in their own group).
+ *
+ * buildCoordinatorCommand() is a factory that creates a fresh command tree.
+ * This allows both the canonical top-level `coordinator` and the deprecated
+ * `sync coordinator` alias to have independent Commander instances (Commander
+ * re-parents commands on addCommand, so sharing instances between two parents
+ * is not possible).
+ */
+
+import { readFileSync } from "node:fs";
+
+import * as p from "@clack/prompts";
+import {
+	coordinatorCreateGroupAction,
+	coordinatorCreateInviteAction,
+	coordinatorDisableDeviceAction,
+	coordinatorEnrollDeviceAction,
+	coordinatorImportInviteAction,
+	coordinatorListBootstrapGrantsAction,
+	coordinatorListDevicesAction,
+	coordinatorListGroupsAction,
+	coordinatorListJoinRequestsAction,
+	coordinatorRemoveDeviceAction,
+	coordinatorRenameDeviceAction,
+	coordinatorReviewJoinRequestAction,
+	coordinatorRevokeBootstrapGrantAction,
+	createBetterSqliteCoordinatorApp,
+	DEFAULT_COORDINATOR_DB_PATH,
+	fingerprintPublicKey,
+} from "@codemem/core";
+import { serve as honoServe } from "@hono/node-server";
+import { Command, Option } from "commander";
+import { helpStyle } from "../help-style.js";
+import {
+	addConfigOption,
+	addDbOption,
+	addJsonOption,
+	emitJsonError,
+	resolveDbOpt,
+} from "../shared-options.js";
+
+function readCoordinatorPublicKey(opts: { publicKey?: string; publicKeyFile?: string }): string {
+	const inline = String(opts.publicKey ?? "").trim();
+	const filePath = String(opts.publicKeyFile ?? "").trim();
+	if (inline && filePath) throw new Error("Use only one of --public-key or --public-key-file");
+	if (filePath) {
+		const text = readFileSync(filePath, "utf8").trim();
+		if (!text) throw new Error(`Public key file is empty: ${filePath}`);
+		return text;
+	}
+	if (!inline) throw new Error("Public key required via --public-key or --public-key-file");
+	return inline;
+}
+
+/**
+ * Build a fresh coordinator command tree. Each call returns independent
+ * Commander instances so the tree can be mounted under multiple parents.
+ */
+export function buildCoordinatorCommand(): Command {
+	const cmd = new Command("coordinator")
+		.configureHelp(helpStyle)
+		.description("Manage coordinator invites, join requests, and relay server");
+
+	// ---- group-create ----
+
+	const groupCreateCmd = new Command("group-create")
+		.configureHelp(helpStyle)
+		.description("Create a coordinator group in the local store")
+		.argument("<group>", "group id")
+		.option("--name <name>", "display name override");
+	addDbOption(groupCreateCmd);
+	addJsonOption(groupCreateCmd);
+	groupCreateCmd.action(
+		async (
+			groupId: string,
+			opts: { name?: string; db?: string; dbPath?: string; json?: boolean },
+		) => {
+			try {
+				const group = await coordinatorCreateGroupAction({
+					groupId,
+					displayName: opts.name?.trim() || null,
+					dbPath: resolveDbOpt(opts) ?? null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(group, null, 2));
+					return;
+				}
+				p.intro("codemem coordinator group-create");
+				p.log.success(`Group ready: ${groupId.trim()}`);
+				p.outro(String(group.display_name ?? group.group_id ?? groupId.trim()));
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError("group_create_failed", err instanceof Error ? err.message : String(err));
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(groupCreateCmd);
+
+	// ---- list-groups ----
+
+	const listGroupsCmd = new Command("list-groups")
+		.configureHelp(helpStyle)
+		.description("List coordinator groups from the local store");
+	addDbOption(listGroupsCmd);
+	addJsonOption(listGroupsCmd);
+	listGroupsCmd.action(async (opts: { db?: string; dbPath?: string; json?: boolean }) => {
+		try {
+			const groups = await coordinatorListGroupsAction({ dbPath: resolveDbOpt(opts) ?? null });
+			if (opts.json) {
+				console.log(JSON.stringify(groups, null, 2));
+				return;
+			}
+			p.intro("codemem coordinator list-groups");
+			if (groups.length === 0) {
+				p.outro("No coordinator groups found");
+				return;
+			}
+			for (const group of groups) {
+				p.log.message(
+					`- ${String(group.group_id ?? "")}${group.display_name ? ` (${String(group.display_name)})` : ""}`,
+				);
+			}
+			p.outro(`${groups.length} group(s)`);
+		} catch (err) {
+			if (opts.json) {
+				emitJsonError("list_groups_failed", err instanceof Error ? err.message : String(err));
+				return;
+			}
+			p.log.error(err instanceof Error ? err.message : String(err));
+			process.exitCode = 1;
+		}
+	});
+	cmd.addCommand(listGroupsCmd);
+
+	// ---- enroll-device ----
+
+	const enrollDeviceCmd = new Command("enroll-device")
+		.configureHelp(helpStyle)
+		.description("Enroll a device in a local coordinator group")
+		.argument("<group>", "group id")
+		.argument("<device-id>", "device id")
+		.option("--fingerprint <fingerprint>", "device fingerprint")
+		.option("--public-key <key>", "device public key")
+		.option("--public-key-file <path>", "path to device public key")
+		.option("--name <name>", "display name");
+	addDbOption(enrollDeviceCmd);
+	addJsonOption(enrollDeviceCmd);
+	enrollDeviceCmd.action(
+		async (
+			groupId: string,
+			deviceId: string,
+			opts: {
+				fingerprint?: string;
+				publicKey?: string;
+				publicKeyFile?: string;
+				name?: string;
+				db?: string;
+				dbPath?: string;
+				json?: boolean;
+			},
+		) => {
+			try {
+				const publicKey = readCoordinatorPublicKey(opts);
+				const fingerprint = String(opts.fingerprint ?? "").trim();
+				if (!fingerprint) {
+					if (opts.json) {
+						emitJsonError("usage_error", "Fingerprint required via --fingerprint", 2);
+						return;
+					}
+					p.log.error("Fingerprint required via --fingerprint");
+					process.exitCode = 1;
+					return;
+				}
+				const actualFingerprint = fingerprintPublicKey(publicKey);
+				if (actualFingerprint !== fingerprint) {
+					if (opts.json) {
+						emitJsonError(
+							"fingerprint_mismatch",
+							"Fingerprint does not match the provided public key",
+						);
+						return;
+					}
+					p.log.error("Fingerprint does not match the provided public key");
+					process.exitCode = 1;
+					return;
+				}
+				const enrollment = await coordinatorEnrollDeviceAction({
+					groupId,
+					deviceId,
+					fingerprint,
+					publicKey,
+					displayName: opts.name?.trim() || null,
+					dbPath: resolveDbOpt(opts) ?? null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(enrollment, null, 2));
+					return;
+				}
+				p.intro("codemem coordinator enroll-device");
+				p.log.success(`Enrolled ${deviceId.trim()} in ${groupId.trim()}`);
+				p.outro(String(enrollment.display_name ?? enrollment.device_id ?? deviceId.trim()));
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError("enroll_failed", err instanceof Error ? err.message : String(err));
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(enrollDeviceCmd);
+
+	// ---- list-devices ----
+
+	const listDevicesCmd = new Command("list-devices")
+		.configureHelp(helpStyle)
+		.description("List enrolled devices in a local coordinator group")
+		.argument("<group>", "group id")
+		.option("--include-disabled", "include disabled devices");
+	addDbOption(listDevicesCmd);
+	addJsonOption(listDevicesCmd);
+	listDevicesCmd.action(
+		async (
+			groupId: string,
+			opts: { includeDisabled?: boolean; db?: string; dbPath?: string; json?: boolean },
+		) => {
+			try {
+				const rows = await coordinatorListDevicesAction({
+					groupId,
+					includeDisabled: opts.includeDisabled === true,
+					dbPath: resolveDbOpt(opts) ?? null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(rows, null, 2));
+					return;
+				}
+				p.intro("codemem coordinator list-devices");
+				if (rows.length === 0) {
+					p.outro(`No enrolled devices for ${groupId.trim()}`);
+					return;
+				}
+				for (const row of rows) {
+					const label =
+						String(row.display_name ?? row.device_id ?? "").trim() || String(row.device_id ?? "");
+					const enabled = Number(row.enabled ?? 1) === 1 ? "enabled" : "disabled";
+					p.log.message(`- ${label} (${String(row.device_id ?? "")}) ${enabled}`);
+				}
+				p.outro(`${rows.length} device(s)`);
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError("list_devices_failed", err instanceof Error ? err.message : String(err));
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(listDevicesCmd);
+
+	// ---- rename-device ----
+
+	const renameDeviceCmd = new Command("rename-device")
+		.configureHelp(helpStyle)
+		.description("Rename an enrolled device in the local coordinator store")
+		.argument("<group>", "group id")
+		.argument("<device-id>", "device id")
+		.requiredOption("--name <name>", "display name");
+	addDbOption(renameDeviceCmd);
+	addJsonOption(renameDeviceCmd);
+	renameDeviceCmd.action(
+		async (
+			groupId: string,
+			deviceId: string,
+			opts: { name: string; db?: string; dbPath?: string; json?: boolean },
+		) => {
+			try {
+				const result = await coordinatorRenameDeviceAction({
+					groupId,
+					deviceId,
+					displayName: opts.name.trim(),
+					dbPath: resolveDbOpt(opts) ?? null,
+				});
+				if (!result) {
+					if (opts.json) {
+						emitJsonError("device_not_found", `Device not found: ${deviceId.trim()}`);
+						return;
+					}
+					p.log.error(`Device not found: ${deviceId.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				if (opts.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+				p.intro("codemem coordinator rename-device");
+				p.log.success(`Renamed ${deviceId.trim()} in ${groupId.trim()}`);
+				p.outro(String(result.display_name ?? result.device_id ?? deviceId.trim()));
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError("rename_failed", err instanceof Error ? err.message : String(err));
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(renameDeviceCmd);
+
+	// ---- disable-device ----
+
+	const disableDeviceCmd = new Command("disable-device")
+		.configureHelp(helpStyle)
+		.description("Disable an enrolled device in the local coordinator store")
+		.argument("<group>", "group id")
+		.argument("<device-id>", "device id");
+	addDbOption(disableDeviceCmd);
+	addJsonOption(disableDeviceCmd);
+	disableDeviceCmd.action(
+		async (
+			groupId: string,
+			deviceId: string,
+			opts: { db?: string; dbPath?: string; json?: boolean },
+		) => {
+			try {
+				const ok = await coordinatorDisableDeviceAction({
+					groupId,
+					deviceId,
+					dbPath: resolveDbOpt(opts) ?? null,
+				});
+				if (!ok) {
+					if (opts.json) {
+						emitJsonError("device_not_found", `Device not found: ${deviceId.trim()}`);
+						return;
+					}
+					p.log.error(`Device not found: ${deviceId.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				if (opts.json) {
+					console.log(
+						JSON.stringify(
+							{ ok: true, group_id: groupId.trim(), device_id: deviceId.trim() },
+							null,
+							2,
+						),
+					);
+					return;
+				}
+				p.intro("codemem coordinator disable-device");
+				p.log.success(`Disabled ${deviceId.trim()} in ${groupId.trim()}`);
+				p.outro("disabled");
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError("disable_failed", err instanceof Error ? err.message : String(err));
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(disableDeviceCmd);
+
+	// ---- remove-device ----
+
+	const removeDeviceCmd = new Command("remove-device")
+		.configureHelp(helpStyle)
+		.description("Remove an enrolled device from the local coordinator store")
+		.argument("<group>", "group id")
+		.argument("<device-id>", "device id");
+	addDbOption(removeDeviceCmd);
+	addJsonOption(removeDeviceCmd);
+	removeDeviceCmd.action(
+		async (
+			groupId: string,
+			deviceId: string,
+			opts: { db?: string; dbPath?: string; json?: boolean },
+		) => {
+			try {
+				const ok = await coordinatorRemoveDeviceAction({
+					groupId,
+					deviceId,
+					dbPath: resolveDbOpt(opts) ?? null,
+				});
+				if (!ok) {
+					if (opts.json) {
+						emitJsonError("device_not_found", `Device not found: ${deviceId.trim()}`);
+						return;
+					}
+					p.log.error(`Device not found: ${deviceId.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				if (opts.json) {
+					console.log(
+						JSON.stringify(
+							{ ok: true, group_id: groupId.trim(), device_id: deviceId.trim() },
+							null,
+							2,
+						),
+					);
+					return;
+				}
+				p.intro("codemem coordinator remove-device");
+				p.log.success(`Removed ${deviceId.trim()} from ${groupId.trim()}`);
+				p.outro("removed");
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError("remove_failed", err instanceof Error ? err.message : String(err));
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(removeDeviceCmd);
+
+	// ---- serve (coordinator relay) ----
+
+	const coordServeCmd = new Command("serve")
+		.configureHelp(helpStyle)
+		.description("Run the coordinator relay HTTP server")
+		.option("--coordinator-host <host>", "bind host")
+		.option("--coordinator-port <port>", "bind port");
+	// Coordinator serve uses its own DB, not the main codemem DB
+	coordServeCmd.addOption(new Option("-d, --db-path <path>", "coordinator database path"));
+	coordServeCmd.addOption(new Option("--db <path>", "coordinator database path").hideHelp());
+	// Hidden host/port aliases for backwards compat
+	coordServeCmd.addOption(new Option("--host <host>", "bind host").hideHelp());
+	coordServeCmd.addOption(new Option("--port <port>", "bind port").hideHelp());
+	coordServeCmd.action(
+		async (opts: {
+			db?: string;
+			dbPath?: string;
+			coordinatorHost?: string;
+			coordinatorPort?: string;
+			host?: string;
+			port?: string;
+		}) => {
+			// Prefer canonical flags; fall back to hidden aliases; then defaults.
+			// Defaults must NOT be set on the Option definitions, otherwise Commander
+			// populates them and ?? cannot distinguish "explicitly passed" from "default".
+			const host = String(opts.coordinatorHost ?? opts.host ?? "127.0.0.1").trim() || "127.0.0.1";
+			const port = Number.parseInt(String(opts.coordinatorPort ?? opts.port ?? "7347"), 10);
+			const dbPath = resolveDbOpt(opts) ?? DEFAULT_COORDINATOR_DB_PATH;
+			const app = createBetterSqliteCoordinatorApp({ dbPath });
+			p.intro("codemem coordinator serve");
+			p.log.success(`Coordinator listening at http://${host}:${port}`);
+			p.log.info(`DB: ${dbPath}`);
+			honoServe({ fetch: app.fetch, hostname: host, port });
+		},
+	);
+	cmd.addCommand(coordServeCmd);
+
+	// ---- list-bootstrap-grants ----
+
+	const listBootstrapGrantsCmd = new Command("list-bootstrap-grants")
+		.configureHelp(helpStyle)
+		.description("List bootstrap grants for a coordinator group")
+		.argument("<group>", "group id")
+		.option("--remote-url <url>", "remote coordinator URL override")
+		.option("--admin-secret <secret>", "remote coordinator admin secret override");
+	addDbOption(listBootstrapGrantsCmd);
+	addJsonOption(listBootstrapGrantsCmd);
+	listBootstrapGrantsCmd.action(
+		async (
+			groupId: string,
+			opts: {
+				db?: string;
+				dbPath?: string;
+				remoteUrl?: string;
+				adminSecret?: string;
+				json?: boolean;
+			},
+		) => {
+			try {
+				const rows = await coordinatorListBootstrapGrantsAction({
+					groupId,
+					dbPath: resolveDbOpt(opts) ?? null,
+					remoteUrl: opts.remoteUrl?.trim() || null,
+					adminSecret: opts.adminSecret?.trim() || null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(rows, null, 2));
+					return;
+				}
+				p.intro("codemem coordinator list-bootstrap-grants");
+				if (rows.length === 0) {
+					p.outro(`No bootstrap grants for ${groupId.trim()}`);
+					return;
+				}
+				for (const row of rows) {
+					p.log.message(
+						`- ${row.grant_id} seed=${row.seed_device_id} worker=${row.worker_device_id} scope=${row.scope} expires=${row.expires_at} revoked=${row.revoked_at ?? "no"}`,
+					);
+				}
+				p.outro(`${rows.length} bootstrap grant(s)`);
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError(
+						"list_bootstrap_grants_failed",
+						err instanceof Error ? err.message : String(err),
+					);
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(listBootstrapGrantsCmd);
+
+	// ---- revoke-bootstrap-grant ----
+
+	const revokeBootstrapGrantCmd = new Command("revoke-bootstrap-grant")
+		.configureHelp(helpStyle)
+		.description("Revoke a bootstrap grant")
+		.argument("<grant-id>", "bootstrap grant id")
+		.option("--remote-url <url>", "remote coordinator URL override")
+		.option("--admin-secret <secret>", "remote coordinator admin secret override");
+	addDbOption(revokeBootstrapGrantCmd);
+	addJsonOption(revokeBootstrapGrantCmd);
+	revokeBootstrapGrantCmd.action(
+		async (
+			grantId: string,
+			opts: {
+				db?: string;
+				dbPath?: string;
+				remoteUrl?: string;
+				adminSecret?: string;
+				json?: boolean;
+			},
+		) => {
+			try {
+				const ok = await coordinatorRevokeBootstrapGrantAction({
+					grantId,
+					dbPath: resolveDbOpt(opts) ?? null,
+					remoteUrl: opts.remoteUrl?.trim() || null,
+					adminSecret: opts.adminSecret?.trim() || null,
+				});
+				if (!ok) {
+					if (opts.json) {
+						emitJsonError("grant_not_found", `Bootstrap grant not found: ${grantId.trim()}`);
+						return;
+					}
+					p.log.error(`Bootstrap grant not found: ${grantId.trim()}`);
+					process.exitCode = 1;
+					return;
+				}
+				if (opts.json) {
+					console.log(JSON.stringify({ ok: true, grant_id: grantId.trim() }, null, 2));
+					return;
+				}
+				p.intro("codemem coordinator revoke-bootstrap-grant");
+				p.log.success(`Revoked ${grantId.trim()}`);
+				p.outro("revoked");
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError("revoke_failed", err instanceof Error ? err.message : String(err));
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(revokeBootstrapGrantCmd);
+
+	// ---- create-invite ----
+
+	const createInviteCmd = new Command("create-invite")
+		.configureHelp(helpStyle)
+		.description("Create a coordinator team invite")
+		.argument("[group]", "group id")
+		.option("--group <group>", "group id")
+		.option("--coordinator-url <url>", "coordinator URL override")
+		.option("--policy <policy>", "invite policy", "auto_admit")
+		.option("--ttl-hours <hours>", "invite TTL hours", "24")
+		.option("--remote-url <url>", "remote coordinator URL override")
+		.option("--admin-secret <secret>", "remote coordinator admin secret override");
+	addDbOption(createInviteCmd);
+	addJsonOption(createInviteCmd);
+	createInviteCmd.action(
+		async (
+			groupArg: string | undefined,
+			opts: {
+				group?: string;
+				coordinatorUrl?: string;
+				policy?: string;
+				ttlHours?: string;
+				db?: string;
+				dbPath?: string;
+				remoteUrl?: string;
+				adminSecret?: string;
+				json?: boolean;
+			},
+		) => {
+			try {
+				const ttlHours = Number.parseInt(String(opts.ttlHours ?? "24"), 10);
+				const groupId = String(opts.group ?? "").trim() || String(groupArg ?? "").trim();
+				const result = await coordinatorCreateInviteAction({
+					groupId,
+					coordinatorUrl: opts.coordinatorUrl?.trim() || null,
+					policy: String(opts.policy ?? "auto_admit").trim(),
+					ttlHours,
+					createdBy: null,
+					dbPath: resolveDbOpt(opts) ?? null,
+					remoteUrl: opts.remoteUrl?.trim() || null,
+					adminSecret: opts.adminSecret?.trim() || null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+				p.intro("codemem coordinator create-invite");
+				p.log.success(`Invite created for ${groupId}`);
+				if (typeof result.link === "string") p.log.message(`- link: ${result.link}`);
+				if (typeof result.encoded === "string") p.log.message(`- invite: ${result.encoded}`);
+				for (const warning of Array.isArray(result.warnings) ? result.warnings : []) {
+					p.log.warn(String(warning));
+				}
+				p.outro("Invite ready");
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError("create_invite_failed", err instanceof Error ? err.message : String(err));
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(createInviteCmd);
+
+	// ---- import-invite ----
+
+	const importInviteCmd = new Command("import-invite")
+		.configureHelp(helpStyle)
+		.description("Import a coordinator invite")
+		.argument("<invite>", "invite value or link")
+		.option("--keys-dir <path>", "keys directory");
+	addDbOption(importInviteCmd);
+	addConfigOption(importInviteCmd);
+	addJsonOption(importInviteCmd);
+	importInviteCmd.action(
+		async (
+			invite: string,
+			opts: {
+				db?: string;
+				dbPath?: string;
+				keysDir?: string;
+				config?: string;
+				json?: boolean;
+			},
+		) => {
+			try {
+				const result = await coordinatorImportInviteAction({
+					inviteValue: invite,
+					dbPath: resolveDbOpt(opts) ?? null,
+					keysDir: opts.keysDir ?? null,
+					configPath: opts.config ?? null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(result, null, 2));
+					return;
+				}
+				p.intro("codemem coordinator import-invite");
+				p.log.success(`Invite imported for ${result.group_id}`);
+				p.log.message(`- coordinator: ${result.coordinator_url}`);
+				p.log.message(`- status: ${result.status}`);
+				p.outro("Coordinator config updated");
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError("import_invite_failed", err instanceof Error ? err.message : String(err));
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(importInviteCmd);
+
+	// ---- list-join-requests ----
+
+	const listJoinRequestsCmd = new Command("list-join-requests")
+		.configureHelp(helpStyle)
+		.description("List pending coordinator join requests")
+		.argument("[group]", "group id")
+		.option("--group <group>", "group id")
+		.option("--remote-url <url>", "remote coordinator URL override")
+		.option("--admin-secret <secret>", "remote coordinator admin secret override");
+	addDbOption(listJoinRequestsCmd);
+	addJsonOption(listJoinRequestsCmd);
+	listJoinRequestsCmd.action(
+		async (
+			groupArg: string | undefined,
+			opts: {
+				group?: string;
+				db?: string;
+				dbPath?: string;
+				remoteUrl?: string;
+				adminSecret?: string;
+				json?: boolean;
+			},
+		) => {
+			try {
+				const groupId = String(opts.group ?? "").trim() || String(groupArg ?? "").trim();
+				const rows = await coordinatorListJoinRequestsAction({
+					groupId,
+					dbPath: resolveDbOpt(opts) ?? null,
+					remoteUrl: opts.remoteUrl?.trim() || null,
+					adminSecret: opts.adminSecret?.trim() || null,
+				});
+				if (opts.json) {
+					console.log(JSON.stringify(rows, null, 2));
+					return;
+				}
+				p.intro("codemem coordinator list-join-requests");
+				if (rows.length === 0) {
+					p.outro(`No pending join requests for ${groupId}`);
+					return;
+				}
+				for (const row of rows) {
+					const displayName = row.display_name || row.device_id;
+					p.log.message(`- ${displayName} (${row.device_id}) request_id=${row.request_id}`);
+				}
+				p.outro(`${rows.length} pending join request(s)`);
+			} catch (err) {
+				if (opts.json) {
+					emitJsonError(
+						"list_join_requests_failed",
+						err instanceof Error ? err.message : String(err),
+					);
+					return;
+				}
+				p.log.error(err instanceof Error ? err.message : String(err));
+				process.exitCode = 1;
+			}
+		},
+	);
+	cmd.addCommand(listJoinRequestsCmd);
+
+	// ---- approve-join-request / deny-join-request ----
+
+	function addReviewJoinRequestCommand(
+		name: "approve-join-request" | "deny-join-request",
+		approve: boolean,
+	) {
+		const reviewCmd = new Command(name)
+			.configureHelp(helpStyle)
+			.description(`${approve ? "Approve" : "Deny"} a coordinator join request`)
+			.argument("<request-id>", "join request id")
+			.option("--remote-url <url>", "remote coordinator URL override")
+			.option("--admin-secret <secret>", "remote coordinator admin secret override");
+		addDbOption(reviewCmd);
+		addJsonOption(reviewCmd);
+		reviewCmd.action(
+			async (
+				requestId: string,
+				opts: {
+					db?: string;
+					dbPath?: string;
+					remoteUrl?: string;
+					adminSecret?: string;
+					json?: boolean;
+				},
+			) => {
+				try {
+					const request = await coordinatorReviewJoinRequestAction({
+						requestId: requestId.trim(),
+						approve,
+						reviewedBy: null,
+						dbPath: resolveDbOpt(opts) ?? null,
+						remoteUrl: opts.remoteUrl?.trim() || null,
+						adminSecret: opts.adminSecret?.trim() || null,
+					});
+					if (!request) {
+						if (opts.json) {
+							emitJsonError(
+								"join_request_not_found",
+								`Join request not found: ${requestId.trim()}`,
+							);
+							return;
+						}
+						p.log.error(`Join request not found: ${requestId.trim()}`);
+						process.exitCode = 1;
+						return;
+					}
+					if (opts.json) {
+						console.log(JSON.stringify(request, null, 2));
+						return;
+					}
+					p.intro(`codemem coordinator ${name}`);
+					p.log.success(`${approve ? "Approved" : "Denied"} join request ${requestId.trim()}`);
+					p.outro(String(request.status ?? "updated"));
+				} catch (err) {
+					if (opts.json) {
+						emitJsonError("review_failed", err instanceof Error ? err.message : String(err));
+						return;
+					}
+					p.log.error(err instanceof Error ? err.message : String(err));
+					process.exitCode = 1;
+				}
+			},
+		);
+		cmd.addCommand(reviewCmd);
+	}
+
+	addReviewJoinRequestCommand("approve-join-request", true);
+	addReviewJoinRequestCommand("deny-join-request", false);
+
+	return cmd;
+}
+
+/** Canonical top-level coordinator command for registration in index.ts. */
+export const coordinatorCommand = buildCoordinatorCommand();

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -18,6 +18,13 @@ import {
 } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
 
 function formatBytes(bytes: number): string {
 	if (bytes < 1024) return `${bytes} B`;
@@ -64,592 +71,567 @@ export const dbCommand = new Command("db")
 	.configureHelp(helpStyle)
 	.description("Database maintenance");
 
-dbCommand
-	.addCommand(
-		new Command("init")
-			.configureHelp(helpStyle)
-			.description("Create or verify the SQLite database and schema")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.action((opts: { db?: string; dbPath?: string }) => {
-				const result = initDatabase(opts.db ?? opts.dbPath);
-				p.intro("codemem db init");
-				p.log.success(`Database ready: ${result.path}`);
-				p.outro(`Size: ${result.sizeBytes.toLocaleString()} bytes`);
-			}),
-	)
-	.addCommand(
-		new Command("vacuum")
-			.configureHelp(helpStyle)
-			.description("Run VACUUM on the SQLite database")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.action((opts: { db?: string; dbPath?: string }) => {
-				const result = vacuumDatabase(opts.db ?? opts.dbPath);
-				p.intro("codemem db vacuum");
-				p.log.success(`Vacuumed: ${result.path}`);
-				p.outro(`Size: ${result.sizeBytes.toLocaleString()} bytes`);
-			}),
-	)
-	.addCommand(
-		new Command("prune-replication-ops")
-			.configureHelp(helpStyle)
-			.description(
-				"Prune replication op history with approximate oldest-first retention, dry-run, and progress reporting",
-			)
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--dry-run", "show current size/targets without deleting")
-			.option("--max-age-days <days>", "retention age threshold in days", "30")
-			.option("--max-size-mb <mb>", "target replication log budget in MB", "512")
-			.option("--batch-ops <n>", "max ops deleted per batch", "5000")
-			.option("--batch-runtime-ms <ms>", "max runtime per batch in ms", "2000")
-			.option("--vacuum", "run VACUUM explicitly after prune completes")
-			.action(
-				(opts: {
-					db?: string;
-					dbPath?: string;
-					dryRun?: boolean;
-					maxAgeDays: string;
-					maxSizeMb: string;
-					batchOps: string;
-					batchRuntimeMs: string;
-					vacuum?: boolean;
-				}) => {
-					const dbPath = resolveDbPath(opts.db ?? opts.dbPath);
-					const db = connect(dbPath);
-					let dbOpen = true;
-					try {
-						const maxAgeDays = Number.parseInt(opts.maxAgeDays, 10) || 30;
-						const maxSizeMb = Number.parseInt(opts.maxSizeMb, 10) || 512;
-						const batchOps = Number.parseInt(opts.batchOps, 10) || 5000;
-						const batchRuntimeMs = Number.parseInt(opts.batchRuntimeMs, 10) || 2000;
-						const beforeBytes = estimateReplicationOpsBytes(db);
-						p.intro("codemem db prune-replication-ops");
-						p.log.info(`Replication ops size: ${formatBytes(beforeBytes)}`);
-						p.log.info(
-							`Policy: approximately prune oldest-first toward <= ${maxSizeMb} MB while removing history older than ${maxAgeDays} day(s), subject to per-pass batch/runtime limits`,
-						);
-						const agePlan = planReplicationOpsAgePrune(db, maxAgeDays, batchOps);
-						if (agePlan.candidate_ops > 0) {
-							p.log.info(
-								`Age pass plan: ${agePlan.candidate_ops.toLocaleString()} ops, ~${formatBytes(agePlan.estimated_candidate_bytes)} in ~${agePlan.estimated_batches.toLocaleString()} batch(es), cutoff ${agePlan.cutoff_cursor}`,
-							);
-						} else {
-							p.log.info("Age pass plan: no ops older than cutoff");
-						}
+// --- db init ---
+const initCmd = new Command("init")
+	.configureHelp(helpStyle)
+	.description("Create or verify the SQLite database and schema");
+addDbOption(initCmd);
+initCmd.action((opts: DbOpts) => {
+	const result = initDatabase(resolveDbOpt(opts));
+	p.intro("codemem db init");
+	p.log.success(`Database ready: ${result.path}`);
+	p.outro(`Size: ${result.sizeBytes.toLocaleString()} bytes`);
+});
+dbCommand.addCommand(initCmd);
 
-						if (opts.dryRun) {
-							p.outro("Dry run only; no changes made");
-							return;
-						}
+// --- db vacuum ---
+const vacuumCmd = new Command("vacuum")
+	.configureHelp(helpStyle)
+	.description("Run VACUUM on the SQLite database");
+addDbOption(vacuumCmd);
+vacuumCmd.action((opts: DbOpts) => {
+	const result = vacuumDatabase(resolveDbOpt(opts));
+	p.intro("codemem db vacuum");
+	p.log.success(`Vacuumed: ${result.path}`);
+	p.outro(`Size: ${result.sizeBytes.toLocaleString()} bytes`);
+});
+dbCommand.addCommand(vacuumCmd);
 
-						const loopResult = pruneReplicationOpsUntilCaughtUp(db, {
-							maxAgeDays,
-							maxSizeBytes: maxSizeMb * 1024 * 1024,
-							maxDeleteOps: batchOps,
-							maxRuntimeMs: batchRuntimeMs,
-							onPass: (pass) => {
-								if (pass.deleted === 0 && !pass.stoppedByBudget) return;
-								const suffix = pass.stoppedByBudget ? " (budget-limited)" : "";
-								p.log.step(
-									`Pass ${pass.passNumber}: deleted ${pass.deleted.toLocaleString()} ops, remaining size ~${formatBytes(pass.afterBytes)}${suffix}`,
-								);
-							},
-						});
-
-						p.log.info(`Deleted ops: ${loopResult.totalDeleted.toLocaleString()}`);
-						p.log.info(
-							`Estimated replication ops size after prune: ${formatBytes(loopResult.afterBytes)} (approximate)`,
-						);
-						if (loopResult.lastFloor) p.log.info(`Retained floor: ${loopResult.lastFloor}`);
-						if (loopResult.stoppedByBudget) {
-							p.log.warn(
-								"Prune stopped because the current batch/runtime budget was exhausted before retention caught up. Re-run with higher --batch-ops or --batch-runtime-ms for faster catch-up.",
-							);
-						}
-						if (opts.vacuum) {
-							p.log.step("Running VACUUM as requested...");
-							db.close();
-							dbOpen = false;
-							const vacuumed = vacuumDatabase(dbPath);
-							p.outro(
-								`Done. VACUUM complete. File size is now ${formatBytes(vacuumed.sizeBytes)}.`,
-							);
-							return;
-						}
-						p.outro(
-							"Done. Retention is approximate oldest-first pruning. SQLite file size may not shrink until you run `codemem db vacuum` explicitly (or re-run this command with --vacuum).",
-						);
-					} finally {
-						if (dbOpen) db.close();
-					}
-				},
-			),
+// --- db prune-replication-ops ---
+const pruneReplCmd = new Command("prune-replication-ops")
+	.configureHelp(helpStyle)
+	.description(
+		"Prune replication op history with approximate oldest-first retention, dry-run, and progress reporting",
 	)
-	.addCommand(
-		new Command("raw-events-status")
-			.configureHelp(helpStyle)
-			.description("Show pending raw-event backlog by source stream")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("-n, --limit <n>", "max rows to show", "25")
-			.option("--json", "output as JSON")
-			.action((opts: { db?: string; dbPath?: string; limit: string; json?: boolean }) => {
-				const result = getRawEventStatus(
-					opts.db ?? opts.dbPath,
-					Number.parseInt(opts.limit, 10) || 25,
-				);
-				if (opts.json) {
-					console.log(JSON.stringify(result, null, 2));
-					return;
-				}
-				p.intro("codemem db raw-events-status");
+	.option("--dry-run", "show current size/targets without deleting")
+	.option("--max-age-days <days>", "retention age threshold in days", "30")
+	.option("--max-size-mb <mb>", "target replication log budget in MB", "512")
+	.option("--batch-ops <n>", "max ops deleted per batch", "5000")
+	.option("--batch-runtime-ms <ms>", "max runtime per batch in ms", "2000")
+	.option("--vacuum", "run VACUUM explicitly after prune completes");
+addDbOption(pruneReplCmd);
+pruneReplCmd.action(
+	(
+		opts: DbOpts & {
+			dryRun?: boolean;
+			maxAgeDays: string;
+			maxSizeMb: string;
+			batchOps: string;
+			batchRuntimeMs: string;
+			vacuum?: boolean;
+		},
+	) => {
+		const dbPath = resolveDbPath(resolveDbOpt(opts));
+		const db = connect(dbPath);
+		let dbOpen = true;
+		try {
+			const maxAgeDays = Number.parseInt(opts.maxAgeDays, 10) || 30;
+			const maxSizeMb = Number.parseInt(opts.maxSizeMb, 10) || 512;
+			const batchOps = Number.parseInt(opts.batchOps, 10) || 5000;
+			const batchRuntimeMs = Number.parseInt(opts.batchRuntimeMs, 10) || 2000;
+			const beforeBytes = estimateReplicationOpsBytes(db);
+			p.intro("codemem db prune-replication-ops");
+			p.log.info(`Replication ops size: ${formatBytes(beforeBytes)}`);
+			p.log.info(
+				`Policy: approximately prune oldest-first toward <= ${maxSizeMb} MB while removing history older than ${maxAgeDays} day(s), subject to per-pass batch/runtime limits`,
+			);
+			const agePlan = planReplicationOpsAgePrune(db, maxAgeDays, batchOps);
+			if (agePlan.candidate_ops > 0) {
 				p.log.info(
-					`Totals: ${result.totals.pending.toLocaleString()} pending across ${result.totals.sessions.toLocaleString()} session(s)`,
+					`Age pass plan: ${agePlan.candidate_ops.toLocaleString()} ops, ~${formatBytes(agePlan.estimated_candidate_bytes)} in ~${agePlan.estimated_batches.toLocaleString()} batch(es), cutoff ${agePlan.cutoff_cursor}`,
 				);
-				if (result.items.length === 0) {
-					p.outro("No pending raw events");
-					return;
-				}
-				for (const item of result.items) {
-					p.log.message(
-						`${item.source}:${item.stream_id} pending=${Math.max(0, item.last_received_event_seq - item.last_flushed_event_seq)} ` +
-							`received=${item.last_received_event_seq} flushed=${item.last_flushed_event_seq} project=${item.project ?? ""}`,
+			} else {
+				p.log.info("Age pass plan: no ops older than cutoff");
+			}
+
+			if (opts.dryRun) {
+				p.outro("Dry run only; no changes made");
+				return;
+			}
+
+			const loopResult = pruneReplicationOpsUntilCaughtUp(db, {
+				maxAgeDays,
+				maxSizeBytes: maxSizeMb * 1024 * 1024,
+				maxDeleteOps: batchOps,
+				maxRuntimeMs: batchRuntimeMs,
+				onPass: (pass) => {
+					if (pass.deleted === 0 && !pass.stoppedByBudget) return;
+					const suffix = pass.stoppedByBudget ? " (budget-limited)" : "";
+					p.log.step(
+						`Pass ${pass.passNumber}: deleted ${pass.deleted.toLocaleString()} ops, remaining size ~${formatBytes(pass.afterBytes)}${suffix}`,
 					);
-				}
-				p.outro("done");
-			}),
-	)
-	.addCommand(
-		new Command("raw-events-retry")
-			.configureHelp(helpStyle)
-			.description("Requeue failed raw-event flush batches")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("-n, --limit <n>", "max failed batches to requeue", "25")
-			.action((opts: { db?: string; dbPath?: string; limit: string }) => {
-				const result = retryRawEventFailures(
-					opts.db ?? opts.dbPath,
-					Number.parseInt(opts.limit, 10) || 25,
+				},
+			});
+
+			p.log.info(`Deleted ops: ${loopResult.totalDeleted.toLocaleString()}`);
+			p.log.info(
+				`Estimated replication ops size after prune: ${formatBytes(loopResult.afterBytes)} (approximate)`,
+			);
+			if (loopResult.lastFloor) p.log.info(`Retained floor: ${loopResult.lastFloor}`);
+			if (loopResult.stoppedByBudget) {
+				p.log.warn(
+					"Prune stopped because the current batch/runtime budget was exhausted before retention caught up. Re-run with higher --batch-ops or --batch-runtime-ms for faster catch-up.",
 				);
-				p.intro("codemem db raw-events-retry");
-				p.outro(`Requeued ${result.retried.toLocaleString()} failed batch(es)`);
-			}),
-	)
-	.addCommand(
-		new Command("raw-events-gate")
-			.configureHelp(helpStyle)
-			.description("Validate raw-event reliability thresholds (non-zero exit on failure)")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--min-flush-success-rate <rate>", "minimum flush success rate", "0.95")
-			.option("--max-dropped-event-rate <rate>", "maximum dropped event rate", "0.05")
-			.option("--min-session-boundary-accuracy <rate>", "minimum session boundary accuracy", "0.9")
-			.option("--window-hours <hours>", "lookback window in hours", "24")
-			.option("--json", "output as JSON")
-			.action(
-				(opts: {
-					db?: string;
-					dbPath?: string;
-					minFlushSuccessRate: string;
-					maxDroppedEventRate: string;
-					minSessionBoundaryAccuracy: string;
-					windowHours: string;
-					json?: boolean;
-				}) => {
-					const result = rawEventsGate(opts.db ?? opts.dbPath, {
-						minFlushSuccessRate: Number.parseFloat(opts.minFlushSuccessRate),
-						maxDroppedEventRate: Number.parseFloat(opts.maxDroppedEventRate),
-						minSessionBoundaryAccuracy: Number.parseFloat(opts.minSessionBoundaryAccuracy),
-						windowHours: Number.parseFloat(opts.windowHours),
-					});
+			}
+			if (opts.vacuum) {
+				p.log.step("Running VACUUM as requested...");
+				db.close();
+				dbOpen = false;
+				const vacuumed = vacuumDatabase(dbPath);
+				p.outro(`Done. VACUUM complete. File size is now ${formatBytes(vacuumed.sizeBytes)}.`);
+				return;
+			}
+			p.outro(
+				"Done. Retention is approximate oldest-first pruning. SQLite file size may not shrink until you run `codemem db vacuum` explicitly (or re-run this command with --vacuum).",
+			);
+		} finally {
+			if (dbOpen) db.close();
+		}
+	},
+);
+dbCommand.addCommand(pruneReplCmd);
 
-					if (opts.json) {
-						console.log(JSON.stringify(result, null, 2));
-						if (!result.passed) process.exitCode = 1;
-						return;
-					}
-
-					p.intro("codemem db raw-events-gate");
-					p.log.info(
-						[
-							`flush_success_rate:          ${result.metrics.rates.flush_success_rate.toFixed(4)}`,
-							`dropped_event_rate:          ${result.metrics.rates.dropped_event_rate.toFixed(4)}`,
-							`session_boundary_accuracy:   ${result.metrics.rates.session_boundary_accuracy.toFixed(4)}`,
-							`window_hours:                ${result.metrics.window_hours ?? "all"}`,
-						].join("\n"),
-					);
-
-					if (result.passed) {
-						p.outro("reliability gate passed");
-					} else {
-						for (const f of result.failures) {
-							p.log.error(f);
-						}
-						p.outro("reliability gate FAILED");
-						process.exitCode = 1;
-					}
-				},
-			),
-	)
-	.addCommand(
-		new Command("rename-project")
-			.configureHelp(helpStyle)
-			.description("Rename a project across sessions and related tables")
-			.argument("<old-name>", "current project name")
-			.argument("<new-name>", "new project name")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--apply", "apply changes (default is dry-run)")
-			.action(
-				(
-					oldName: string,
-					newName: string,
-					opts: { db?: string; dbPath?: string; apply?: boolean },
-				) => {
-					const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-					try {
-						const dryRun = !opts.apply;
-						const escapedOld = oldName.replace(/%/g, "\\%").replace(/_/g, "\\_");
-						const suffixPattern = `%/${escapedOld}`;
-						const tables = ["sessions", "raw_event_sessions"] as const;
-						const counts: Record<string, number> = {};
-						const run = () => {
-							for (const table of tables) {
-								const rows = store.db
-									.prepare(
-										`SELECT COUNT(*) as cnt FROM ${table} WHERE project = ? OR project LIKE ? ESCAPE '\\'`,
-									)
-									.get(oldName, suffixPattern) as { cnt: number };
-								counts[table] = rows.cnt;
-								if (!dryRun && rows.cnt > 0) {
-									store.db
-										.prepare(`UPDATE ${table} SET project = ? WHERE project = ?`)
-										.run(newName, oldName);
-									store.db
-										.prepare(
-											`UPDATE ${table} SET project = ? WHERE project LIKE ? ESCAPE '\\' AND project != ?`,
-										)
-										.run(newName, suffixPattern, newName);
-								}
-							}
-						};
-						if (dryRun) {
-							run();
-						} else {
-							store.db.transaction(run)();
-						}
-						const action = dryRun ? "Will rename" : "Renamed";
-						p.intro("codemem db rename-project");
-						p.log.info(`${action} ${oldName} → ${newName}`);
-						p.log.info(
-							[
-								`Sessions: ${counts.sessions}`,
-								`Raw event sessions: ${counts.raw_event_sessions}`,
-							].join("\n"),
-						);
-						if (dryRun) {
-							p.outro("Pass --apply to execute");
-						} else {
-							p.outro("done");
-						}
-					} finally {
-						store.close();
-					}
-				},
-			),
-	)
-	.addCommand(
-		new Command("normalize-projects")
-			.configureHelp(helpStyle)
-			.description("Normalize path-like project identifiers to their basename")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--apply", "apply changes (default is dry-run)")
-			.action((opts: { db?: string; dbPath?: string; apply?: boolean }) => {
-				const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-				try {
-					const dryRun = !opts.apply;
-					const tables = ["sessions", "raw_event_sessions"] as const;
-					const rewrites: Map<string, string> = new Map();
-					const counts: Record<string, number> = {};
-
-					const run = () => {
-						for (const table of tables) {
-							const projects = store.db
-								.prepare(
-									`SELECT DISTINCT project FROM ${table} WHERE project IS NOT NULL AND project LIKE '%/%'`,
-								)
-								.all() as Array<{ project: string }>;
-							let updated = 0;
-							for (const row of projects) {
-								const basename = row.project.split("/").pop() ?? row.project;
-								if (basename !== row.project) {
-									rewrites.set(row.project, basename);
-									if (!dryRun) {
-										const info = store.db
-											.prepare(`UPDATE ${table} SET project = ? WHERE project = ?`)
-											.run(basename, row.project);
-										updated += info.changes;
-									} else {
-										const cnt = store.db
-											.prepare(`SELECT COUNT(*) as cnt FROM ${table} WHERE project = ?`)
-											.get(row.project) as { cnt: number };
-										updated += cnt.cnt;
-									}
-								}
-							}
-							counts[table] = updated;
-						}
-					};
-					if (dryRun) {
-						run();
-					} else {
-						store.db.transaction(run)();
-					}
-
-					p.intro("codemem db normalize-projects");
-					p.log.info(`Dry run: ${dryRun}`);
-					p.log.info(
-						[
-							`Sessions to update: ${counts.sessions}`,
-							`Raw event sessions to update: ${counts.raw_event_sessions}`,
-						].join("\n"),
-					);
-					if (rewrites.size > 0) {
-						p.log.info("Rewritten paths:");
-						for (const [from, to] of [...rewrites.entries()].sort()) {
-							p.log.message(`  ${from} → ${to}`);
-						}
-					}
-					if (dryRun) {
-						p.outro("Pass --apply to execute");
-					} else {
-						p.outro("done");
-					}
-				} finally {
-					store.close();
-				}
-			}),
-	)
-	.addCommand(
-		new Command("size-report")
-			.configureHelp(helpStyle)
-			.description("Show SQLite file size and major storage consumers")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--limit <n>", "number of largest tables/indexes to show", "12")
-			.option("--json", "output as JSON")
-			.action((opts: { db?: string; dbPath?: string; limit: string; json?: boolean }) => {
-				const dbPath = resolveDbPath(opts.db ?? opts.dbPath);
-				const db = connect(dbPath);
-				try {
-					const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 12);
-					const fileSizeBytes = statSync(dbPath).size;
-					const pageInfo = db
-						.prepare(
-							"SELECT page_count * page_size as total FROM pragma_page_count, pragma_page_size",
-						)
-						.get() as { total: number } | undefined;
-					const freePages = db.prepare("SELECT freelist_count FROM pragma_freelist_count").get() as
-						| { freelist_count: number }
-						| undefined;
-					const pageSize = db.prepare("PRAGMA page_size").get() as
-						| { page_size: number }
-						| undefined;
-					const tables = db
-						.prepare(
-							`SELECT name, SUM(pgsize) as size_bytes
-							 FROM dbstat
-							 GROUP BY name
-							 ORDER BY size_bytes DESC
-							 LIMIT ?`,
-						)
-						.all(limit) as Array<{ name: string; size_bytes: number }>;
-
-					if (opts.json) {
-						console.log(
-							JSON.stringify(
-								{
-									file_size_bytes: fileSizeBytes,
-									db_size_bytes: pageInfo?.total ?? 0,
-									free_bytes: (freePages?.freelist_count ?? 0) * (pageSize?.page_size ?? 4096),
-									tables: tables.map((t) => ({ name: t.name, size_bytes: t.size_bytes })),
-								},
-								null,
-								2,
-							),
-						);
-						return;
-					}
-
-					p.intro("codemem db size-report");
-					p.log.info(
-						[
-							`File size:     ${formatBytes(fileSizeBytes)}`,
-							`DB size:       ${formatBytes(pageInfo?.total ?? 0)}`,
-							`Free space:    ${formatBytes((freePages?.freelist_count ?? 0) * (pageSize?.page_size ?? 4096))}`,
-						].join("\n"),
-					);
-					if (tables.length > 0) {
-						p.log.info("Largest objects:");
-						for (const t of tables) {
-							p.log.message(`  ${t.name.padEnd(40)} ${formatBytes(t.size_bytes).padStart(10)}`);
-						}
-					}
-					p.outro("done");
-				} finally {
-					db.close();
-				}
-			}),
-	)
-	.addCommand(
-		new Command("backfill-tags")
-			.configureHelp(helpStyle)
-			.description("Populate tags_text for memories where tags are empty")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--limit <n>", "max memories to check")
-			.option("--since <iso>", "only memories created at/after this ISO timestamp")
-			.option("--project <project>", "project identifier (defaults to git repo root)")
-			.option("--all-projects", "backfill across all projects")
-			.option("--inactive", "include inactive memories")
-			.option("--dry-run", "preview updates without writing")
-			.option("--json", "output as JSON")
-			.action(
-				(opts: {
-					db?: string;
-					dbPath?: string;
-					limit?: string;
-					since?: string;
-					project?: string;
-					allProjects?: boolean;
-					inactive?: boolean;
-					dryRun?: boolean;
-					json?: boolean;
-				}) => {
-					const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-					try {
-						const limit = parseOptionalPositiveInt(opts.limit);
-						const project =
-							opts.allProjects === true
-								? null
-								: opts.project?.trim() ||
-									process.env.CODEMEM_PROJECT?.trim() ||
-									resolveProject(process.cwd(), null);
-						const result = backfillTagsText(store.db, {
-							limit,
-							since: opts.since ?? null,
-							project,
-							activeOnly: !opts.inactive,
-							dryRun: opts.dryRun === true,
-						});
-
-						if (opts.json) {
-							console.log(JSON.stringify(result, null, 2));
-							return;
-						}
-
-						const action = opts.dryRun ? "Would update" : "Updated";
-						p.intro("codemem db backfill-tags");
-						p.log.success(`${action} ${result.updated} memories (skipped ${result.skipped})`);
-						p.outro(`Checked ${result.checked} memories`);
-					} catch (error) {
-						p.log.error(error instanceof Error ? error.message : String(error));
-						process.exitCode = 1;
-					} finally {
-						store.close();
-					}
-				},
-			),
-	)
-	.addCommand(
-		new Command("prune-observations")
-			.configureHelp(helpStyle)
-			.description("Deactivate low-signal observations (does not delete rows)")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--limit <n>", "max observations to check")
-			.option("--dry-run", "preview deactivations without writing")
-			.option("--json", "output as JSON")
-			.action(
-				(opts: {
-					db?: string;
-					dbPath?: string;
-					limit?: string;
-					dryRun?: boolean;
-					json?: boolean;
-				}) => {
-					const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-					try {
-						const limit = parseOptionalPositiveInt(opts.limit);
-						const result = deactivateLowSignalObservations(
-							store.db,
-							limit ?? null,
-							opts.dryRun === true,
-						);
-
-						if (opts.json) {
-							console.log(JSON.stringify(result, null, 2));
-							return;
-						}
-
-						const action = opts.dryRun ? "Would deactivate" : "Deactivated";
-						p.intro("codemem db prune-observations");
-						p.outro(`${action} ${result.deactivated} of ${result.checked} observations`);
-					} catch (error) {
-						p.log.error(error instanceof Error ? error.message : String(error));
-						process.exitCode = 1;
-					} finally {
-						store.close();
-					}
-				},
-			),
-	)
-	.addCommand(
-		new Command("prune-memories")
-			.configureHelp(helpStyle)
-			.description("Deactivate low-signal memories across selected kinds")
-			.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-			.option("--limit <n>", "max memories to check")
-			.option("--kinds <csv>", "comma-separated memory kinds (default set when omitted)")
-			.option("--dry-run", "preview deactivations without writing")
-			.option("--json", "output as JSON")
-			.action(
-				(opts: {
-					db?: string;
-					dbPath?: string;
-					limit?: string;
-					kinds?: string;
-					dryRun?: boolean;
-					json?: boolean;
-				}) => {
-					const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-					try {
-						const limit = parseOptionalPositiveInt(opts.limit);
-						const kinds = parseKindsCsv(opts.kinds);
-						const result = deactivateLowSignalMemories(store.db, {
-							kinds,
-							limit: limit ?? null,
-							dryRun: opts.dryRun === true,
-						});
-
-						if (opts.json) {
-							console.log(JSON.stringify(result, null, 2));
-							return;
-						}
-
-						const action = opts.dryRun ? "Would deactivate" : "Deactivated";
-						p.intro("codemem db prune-memories");
-						p.outro(`${action} ${result.deactivated} of ${result.checked} memories`);
-					} catch (error) {
-						p.log.error(error instanceof Error ? error.message : String(error));
-						process.exitCode = 1;
-					} finally {
-						store.close();
-					}
-				},
-			),
+// --- db raw-events-status ---
+const rawEventsStatusCmd = new Command("raw-events-status")
+	.configureHelp(helpStyle)
+	.description("Show pending raw-event backlog by source stream")
+	.option("-n, --limit <n>", "max rows to show", "25");
+addDbOption(rawEventsStatusCmd);
+addJsonOption(rawEventsStatusCmd);
+rawEventsStatusCmd.action((opts: DbOpts & JsonOpts & { limit: string }) => {
+	const result = getRawEventStatus(resolveDbOpt(opts), Number.parseInt(opts.limit, 10) || 25);
+	if (opts.json) {
+		console.log(JSON.stringify(result, null, 2));
+		return;
+	}
+	p.intro("codemem db raw-events-status");
+	p.log.info(
+		`Totals: ${result.totals.pending.toLocaleString()} pending across ${result.totals.sessions.toLocaleString()} session(s)`,
 	);
+	if (result.items.length === 0) {
+		p.outro("No pending raw events");
+		return;
+	}
+	for (const item of result.items) {
+		p.log.message(
+			`${item.source}:${item.stream_id} pending=${Math.max(0, item.last_received_event_seq - item.last_flushed_event_seq)} ` +
+				`received=${item.last_received_event_seq} flushed=${item.last_flushed_event_seq} project=${item.project ?? ""}`,
+		);
+	}
+	p.outro("done");
+});
+dbCommand.addCommand(rawEventsStatusCmd);
+
+// --- db raw-events-retry ---
+const rawEventsRetryCmd = new Command("raw-events-retry")
+	.configureHelp(helpStyle)
+	.description("Requeue failed raw-event flush batches")
+	.option("-n, --limit <n>", "max failed batches to requeue", "25");
+addDbOption(rawEventsRetryCmd);
+rawEventsRetryCmd.action((opts: DbOpts & { limit: string }) => {
+	const result = retryRawEventFailures(resolveDbOpt(opts), Number.parseInt(opts.limit, 10) || 25);
+	p.intro("codemem db raw-events-retry");
+	p.outro(`Requeued ${result.retried.toLocaleString()} failed batch(es)`);
+});
+dbCommand.addCommand(rawEventsRetryCmd);
+
+// --- db raw-events-gate ---
+const rawEventsGateCmd = new Command("raw-events-gate")
+	.configureHelp(helpStyle)
+	.description("Validate raw-event reliability thresholds (non-zero exit on failure)")
+	.option("--min-flush-success-rate <rate>", "minimum flush success rate", "0.95")
+	.option("--max-dropped-event-rate <rate>", "maximum dropped event rate", "0.05")
+	.option("--min-session-boundary-accuracy <rate>", "minimum session boundary accuracy", "0.9")
+	.option("--window-hours <hours>", "lookback window in hours", "24");
+addDbOption(rawEventsGateCmd);
+addJsonOption(rawEventsGateCmd);
+rawEventsGateCmd.action(
+	(
+		opts: DbOpts &
+			JsonOpts & {
+				minFlushSuccessRate: string;
+				maxDroppedEventRate: string;
+				minSessionBoundaryAccuracy: string;
+				windowHours: string;
+			},
+	) => {
+		const result = rawEventsGate(resolveDbOpt(opts), {
+			minFlushSuccessRate: Number.parseFloat(opts.minFlushSuccessRate),
+			maxDroppedEventRate: Number.parseFloat(opts.maxDroppedEventRate),
+			minSessionBoundaryAccuracy: Number.parseFloat(opts.minSessionBoundaryAccuracy),
+			windowHours: Number.parseFloat(opts.windowHours),
+		});
+
+		if (opts.json) {
+			console.log(JSON.stringify(result, null, 2));
+			if (!result.passed) process.exitCode = 1;
+			return;
+		}
+
+		p.intro("codemem db raw-events-gate");
+		p.log.info(
+			[
+				`flush_success_rate:          ${result.metrics.rates.flush_success_rate.toFixed(4)}`,
+				`dropped_event_rate:          ${result.metrics.rates.dropped_event_rate.toFixed(4)}`,
+				`session_boundary_accuracy:   ${result.metrics.rates.session_boundary_accuracy.toFixed(4)}`,
+				`window_hours:                ${result.metrics.window_hours ?? "all"}`,
+			].join("\n"),
+		);
+
+		if (result.passed) {
+			p.outro("reliability gate passed");
+		} else {
+			for (const f of result.failures) {
+				p.log.error(f);
+			}
+			p.outro("reliability gate FAILED");
+			process.exitCode = 1;
+		}
+	},
+);
+dbCommand.addCommand(rawEventsGateCmd);
+
+// --- db rename-project ---
+const renameProjectCmd = new Command("rename-project")
+	.configureHelp(helpStyle)
+	.description("Rename a project across sessions and related tables")
+	.argument("<old-name>", "current project name")
+	.argument("<new-name>", "new project name")
+	.option("--apply", "apply changes (default is dry-run)");
+addDbOption(renameProjectCmd);
+renameProjectCmd.action((oldName: string, newName: string, opts: DbOpts & { apply?: boolean }) => {
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const dryRun = !opts.apply;
+		const escapedOld = oldName.replace(/%/g, "\\%").replace(/_/g, "\\_");
+		const suffixPattern = `%/${escapedOld}`;
+		const tables = ["sessions", "raw_event_sessions"] as const;
+		const counts: Record<string, number> = {};
+		const run = () => {
+			for (const table of tables) {
+				const rows = store.db
+					.prepare(
+						`SELECT COUNT(*) as cnt FROM ${table} WHERE project = ? OR project LIKE ? ESCAPE '\\'`,
+					)
+					.get(oldName, suffixPattern) as { cnt: number };
+				counts[table] = rows.cnt;
+				if (!dryRun && rows.cnt > 0) {
+					store.db
+						.prepare(`UPDATE ${table} SET project = ? WHERE project = ?`)
+						.run(newName, oldName);
+					store.db
+						.prepare(
+							`UPDATE ${table} SET project = ? WHERE project LIKE ? ESCAPE '\\' AND project != ?`,
+						)
+						.run(newName, suffixPattern, newName);
+				}
+			}
+		};
+		if (dryRun) {
+			run();
+		} else {
+			store.db.transaction(run)();
+		}
+		const action = dryRun ? "Will rename" : "Renamed";
+		p.intro("codemem db rename-project");
+		p.log.info(`${action} ${oldName} → ${newName}`);
+		p.log.info(
+			[`Sessions: ${counts.sessions}`, `Raw event sessions: ${counts.raw_event_sessions}`].join(
+				"\n",
+			),
+		);
+		if (dryRun) {
+			p.outro("Pass --apply to execute");
+		} else {
+			p.outro("done");
+		}
+	} finally {
+		store.close();
+	}
+});
+dbCommand.addCommand(renameProjectCmd);
+
+// --- db normalize-projects ---
+const normalizeProjectsCmd = new Command("normalize-projects")
+	.configureHelp(helpStyle)
+	.description("Normalize path-like project identifiers to their basename")
+	.option("--apply", "apply changes (default is dry-run)");
+addDbOption(normalizeProjectsCmd);
+normalizeProjectsCmd.action((opts: DbOpts & { apply?: boolean }) => {
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const dryRun = !opts.apply;
+		const tables = ["sessions", "raw_event_sessions"] as const;
+		const rewrites: Map<string, string> = new Map();
+		const counts: Record<string, number> = {};
+
+		const run = () => {
+			for (const table of tables) {
+				const projects = store.db
+					.prepare(
+						`SELECT DISTINCT project FROM ${table} WHERE project IS NOT NULL AND project LIKE '%/%'`,
+					)
+					.all() as Array<{ project: string }>;
+				let updated = 0;
+				for (const row of projects) {
+					const basename = row.project.split("/").pop() ?? row.project;
+					if (basename !== row.project) {
+						rewrites.set(row.project, basename);
+						if (!dryRun) {
+							const info = store.db
+								.prepare(`UPDATE ${table} SET project = ? WHERE project = ?`)
+								.run(basename, row.project);
+							updated += info.changes;
+						} else {
+							const cnt = store.db
+								.prepare(`SELECT COUNT(*) as cnt FROM ${table} WHERE project = ?`)
+								.get(row.project) as { cnt: number };
+							updated += cnt.cnt;
+						}
+					}
+				}
+				counts[table] = updated;
+			}
+		};
+		if (dryRun) {
+			run();
+		} else {
+			store.db.transaction(run)();
+		}
+
+		p.intro("codemem db normalize-projects");
+		p.log.info(`Dry run: ${dryRun}`);
+		p.log.info(
+			[
+				`Sessions to update: ${counts.sessions}`,
+				`Raw event sessions to update: ${counts.raw_event_sessions}`,
+			].join("\n"),
+		);
+		if (rewrites.size > 0) {
+			p.log.info("Rewritten paths:");
+			for (const [from, to] of [...rewrites.entries()].sort()) {
+				p.log.message(`  ${from} → ${to}`);
+			}
+		}
+		if (dryRun) {
+			p.outro("Pass --apply to execute");
+		} else {
+			p.outro("done");
+		}
+	} finally {
+		store.close();
+	}
+});
+dbCommand.addCommand(normalizeProjectsCmd);
+
+// --- db size-report ---
+const sizeReportCmd = new Command("size-report")
+	.configureHelp(helpStyle)
+	.description("Show SQLite file size and major storage consumers")
+	.option("--limit <n>", "number of largest tables/indexes to show", "12");
+addDbOption(sizeReportCmd);
+addJsonOption(sizeReportCmd);
+sizeReportCmd.action((opts: DbOpts & JsonOpts & { limit: string }) => {
+	const dbPath = resolveDbPath(resolveDbOpt(opts));
+	const db = connect(dbPath);
+	try {
+		const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 12);
+		const fileSizeBytes = statSync(dbPath).size;
+		const pageInfo = db
+			.prepare("SELECT page_count * page_size as total FROM pragma_page_count, pragma_page_size")
+			.get() as { total: number } | undefined;
+		const freePages = db.prepare("SELECT freelist_count FROM pragma_freelist_count").get() as
+			| { freelist_count: number }
+			| undefined;
+		const pageSize = db.prepare("PRAGMA page_size").get() as { page_size: number } | undefined;
+		const tables = db
+			.prepare(
+				`SELECT name, SUM(pgsize) as size_bytes
+				 FROM dbstat
+				 GROUP BY name
+				 ORDER BY size_bytes DESC
+				 LIMIT ?`,
+			)
+			.all(limit) as Array<{ name: string; size_bytes: number }>;
+
+		if (opts.json) {
+			console.log(
+				JSON.stringify(
+					{
+						file_size_bytes: fileSizeBytes,
+						db_size_bytes: pageInfo?.total ?? 0,
+						free_bytes: (freePages?.freelist_count ?? 0) * (pageSize?.page_size ?? 4096),
+						tables: tables.map((t) => ({ name: t.name, size_bytes: t.size_bytes })),
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
+
+		p.intro("codemem db size-report");
+		p.log.info(
+			[
+				`File size:     ${formatBytes(fileSizeBytes)}`,
+				`DB size:       ${formatBytes(pageInfo?.total ?? 0)}`,
+				`Free space:    ${formatBytes((freePages?.freelist_count ?? 0) * (pageSize?.page_size ?? 4096))}`,
+			].join("\n"),
+		);
+		if (tables.length > 0) {
+			p.log.info("Largest objects:");
+			for (const t of tables) {
+				p.log.message(`  ${t.name.padEnd(40)} ${formatBytes(t.size_bytes).padStart(10)}`);
+			}
+		}
+		p.outro("done");
+	} finally {
+		db.close();
+	}
+});
+dbCommand.addCommand(sizeReportCmd);
+
+// --- db backfill-tags ---
+const backfillTagsCmd = new Command("backfill-tags")
+	.configureHelp(helpStyle)
+	.description("Populate tags_text for memories where tags are empty")
+	.option("--limit <n>", "max memories to check")
+	.option("--since <iso>", "only memories created at/after this ISO timestamp")
+	.option("--project <project>", "project identifier (defaults to git repo root)")
+	.option("--all-projects", "backfill across all projects")
+	.option("--inactive", "include inactive memories")
+	.option("--dry-run", "preview updates without writing");
+addDbOption(backfillTagsCmd);
+addJsonOption(backfillTagsCmd);
+backfillTagsCmd.action(
+	(
+		opts: DbOpts &
+			JsonOpts & {
+				limit?: string;
+				since?: string;
+				project?: string;
+				allProjects?: boolean;
+				inactive?: boolean;
+				dryRun?: boolean;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = parseOptionalPositiveInt(opts.limit);
+			const project =
+				opts.allProjects === true
+					? null
+					: opts.project?.trim() ||
+						process.env.CODEMEM_PROJECT?.trim() ||
+						resolveProject(process.cwd(), null);
+			const result = backfillTagsText(store.db, {
+				limit,
+				since: opts.since ?? null,
+				project,
+				activeOnly: !opts.inactive,
+				dryRun: opts.dryRun === true,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			const action = opts.dryRun ? "Would update" : "Updated";
+			p.intro("codemem db backfill-tags");
+			p.log.success(`${action} ${result.updated} memories (skipped ${result.skipped})`);
+			p.outro(`Checked ${result.checked} memories`);
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);
+dbCommand.addCommand(backfillTagsCmd);
+
+// --- db prune-observations ---
+const pruneObsCmd = new Command("prune-observations")
+	.configureHelp(helpStyle)
+	.description("Deactivate low-signal observations (does not delete rows)")
+	.option("--limit <n>", "max observations to check")
+	.option("--dry-run", "preview deactivations without writing");
+addDbOption(pruneObsCmd);
+addJsonOption(pruneObsCmd);
+pruneObsCmd.action(
+	(
+		opts: DbOpts &
+			JsonOpts & {
+				limit?: string;
+				dryRun?: boolean;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = parseOptionalPositiveInt(opts.limit);
+			const result = deactivateLowSignalObservations(store.db, limit ?? null, opts.dryRun === true);
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			const action = opts.dryRun ? "Would deactivate" : "Deactivated";
+			p.intro("codemem db prune-observations");
+			p.outro(`${action} ${result.deactivated} of ${result.checked} observations`);
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);
+dbCommand.addCommand(pruneObsCmd);
+
+// --- db prune-memories ---
+const pruneMemCmd = new Command("prune-memories")
+	.configureHelp(helpStyle)
+	.description("Deactivate low-signal memories across selected kinds")
+	.option("--limit <n>", "max memories to check")
+	.option("--kinds <csv>", "comma-separated memory kinds (default set when omitted)")
+	.option("--dry-run", "preview deactivations without writing");
+addDbOption(pruneMemCmd);
+addJsonOption(pruneMemCmd);
+pruneMemCmd.action(
+	(
+		opts: DbOpts &
+			JsonOpts & {
+				limit?: string;
+				kinds?: string;
+				dryRun?: boolean;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = parseOptionalPositiveInt(opts.limit);
+			const kinds = parseKindsCsv(opts.kinds);
+			const result = deactivateLowSignalMemories(store.db, {
+				kinds,
+				limit: limit ?? null,
+				dryRun: opts.dryRun === true,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			const action = opts.dryRun ? "Would deactivate" : "Deactivated";
+			p.intro("codemem db prune-memories");
+			p.outro(`${action} ${result.deactivated} of ${result.checked} memories`);
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);
+dbCommand.addCommand(pruneMemCmd);

--- a/packages/cli/src/commands/embed.ts
+++ b/packages/cli/src/commands/embed.ts
@@ -2,6 +2,13 @@ import * as p from "@clack/prompts";
 import { backfillVectors, MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
 
 function parseOptionalPositiveInt(value: string | undefined): number | undefined {
 	if (!value) return undefined;
@@ -25,59 +32,60 @@ export function resolveEmbedProjectScope(
 	return resolveProject(cwd, null);
 }
 
-export const embedCommand = new Command("embed")
+const embedCmd = new Command("embed")
 	.configureHelp(helpStyle)
 	.description("Backfill semantic embeddings")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--limit <n>", "max memories to check")
 	.option("--since <iso>", "only memories created at/after this ISO timestamp")
 	.option("--project <project>", "project identifier (defaults to git repo root)")
 	.option("--all-projects", "embed across all projects")
 	.option("--inactive", "include inactive memories")
-	.option("--dry-run", "preview work without writing vectors")
-	.option("--json", "output as JSON")
-	.action(
-		async (opts: {
-			db?: string;
-			dbPath?: string;
-			limit?: string;
-			since?: string;
-			project?: string;
-			allProjects?: boolean;
-			inactive?: boolean;
-			dryRun?: boolean;
-			json?: boolean;
-		}) => {
-			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-			try {
-				const limit = parseOptionalPositiveInt(opts.limit);
-				const project = resolveEmbedProjectScope(process.cwd(), opts.project, opts.allProjects);
+	.option("--dry-run", "preview work without writing vectors");
 
-				const result = await backfillVectors(store.db, {
-					limit,
-					since: opts.since ?? null,
-					project,
-					activeOnly: !opts.inactive,
-					dryRun: opts.dryRun === true,
-				});
+addDbOption(embedCmd);
+addJsonOption(embedCmd);
 
-				if (opts.json) {
-					console.log(JSON.stringify(result, null, 2));
-					return;
-				}
+export const embedCommand = embedCmd.action(
+	async (
+		opts: DbOpts &
+			JsonOpts & {
+				limit?: string;
+				since?: string;
+				project?: string;
+				allProjects?: boolean;
+				inactive?: boolean;
+				dryRun?: boolean;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = parseOptionalPositiveInt(opts.limit);
+			const project = resolveEmbedProjectScope(process.cwd(), opts.project, opts.allProjects);
 
-				const action = opts.dryRun ? "Would embed" : "Embedded";
-				p.intro("codemem embed");
-				p.log.success(
-					`${action} ${result.embedded} vectors (${result.inserted} inserted, ${result.skipped} skipped)`,
-				);
-				p.outro(`Checked ${result.checked} memories`);
-			} catch (error) {
-				p.log.error(error instanceof Error ? error.message : String(error));
-				process.exitCode = 1;
-			} finally {
-				store.close();
+			const result = await backfillVectors(store.db, {
+				limit,
+				since: opts.since ?? null,
+				project,
+				activeOnly: !opts.inactive,
+				dryRun: opts.dryRun === true,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
 			}
-		},
-	);
+
+			const action = opts.dryRun ? "Would embed" : "Embedded";
+			p.intro("codemem embed");
+			p.log.success(
+				`${action} ${result.embedded} vectors (${result.inserted} inserted, ${result.skipped} skipped)`,
+			);
+			p.outro(`Checked ${result.checked} memories`);
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);

--- a/packages/cli/src/commands/enqueue-raw-event.ts
+++ b/packages/cli/src/commands/enqueue-raw-event.ts
@@ -1,6 +1,7 @@
 import { MemoryStore, resolveDbPath, stripPrivateObj } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
 
 const SESSION_ID_KEYS = [
 	"session_stream_id",
@@ -19,7 +20,7 @@ function resolveSessionStreamId(payload: Record<string, unknown>): string | null
 	}
 	if (values.size === 0) return null;
 	const unique = new Set(values.values());
-	if (unique.size > 1) throw new Error("conflicting session id fields");
+	if (unique.size > 1) return null;
 	for (const key of SESSION_ID_KEYS) {
 		const value = values.get(key);
 		if (value) return value;
@@ -41,19 +42,35 @@ async function readStdinJson(): Promise<Record<string, unknown>> {
 	return parsed as Record<string, unknown>;
 }
 
-export const enqueueRawEventCommand = new Command("enqueue-raw-event")
+function emitStructuredError(errorCode: string, message: string): void {
+	console.log(JSON.stringify({ error: errorCode, message }));
+	process.exitCode = 1;
+}
+
+const enqueueCmd = new Command("enqueue-raw-event")
 	.configureHelp(helpStyle)
-	.description("Enqueue one raw event from stdin into the durable queue")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.action(async (opts: { db?: string; dbPath?: string }) => {
+	.description("Enqueue one raw event from stdin into the durable queue");
+
+addDbOption(enqueueCmd);
+
+export const enqueueRawEventCommand = enqueueCmd.action(async (opts: DbOpts) => {
+	try {
 		const payload = await readStdinJson();
 		const sessionId = resolveSessionStreamId(payload);
-		if (!sessionId) throw new Error("session id required");
-		if (sessionId.startsWith("msg_")) throw new Error("invalid session id");
+		if (!sessionId) {
+			emitStructuredError("validation_error", "session id required");
+			return;
+		}
+		if (sessionId.startsWith("msg_")) {
+			emitStructuredError("validation_error", "invalid session id");
+			return;
+		}
 
 		const eventType = typeof payload.event_type === "string" ? payload.event_type.trim() : "";
-		if (!eventType) throw new Error("event_type required");
+		if (!eventType) {
+			emitStructuredError("validation_error", "event_type required");
+			return;
+		}
 
 		const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
 		const project = typeof payload.project === "string" ? payload.project : null;
@@ -70,7 +87,7 @@ export const enqueueRawEventCommand = new Command("enqueue-raw-event")
 				? (stripPrivateObj(payload.payload) as Record<string, unknown>)
 				: {};
 
-		const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 		try {
 			store.updateRawEventSessionMeta({
 				opencodeSessionId: sessionId,
@@ -92,4 +109,7 @@ export const enqueueRawEventCommand = new Command("enqueue-raw-event")
 		} finally {
 			store.close();
 		}
-	});
+	} catch (err) {
+		emitStructuredError("enqueue_error", err instanceof Error ? err.message : String(err));
+	}
+});

--- a/packages/cli/src/commands/export-memories.ts
+++ b/packages/cli/src/commands/export-memories.ts
@@ -5,57 +5,59 @@ import * as p from "@clack/prompts";
 import { exportMemories, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
 
 function expandUserPath(value: string): string {
 	return value.startsWith("~/") ? join(homedir(), value.slice(2)) : value;
 }
 
-export const exportMemoriesCommand = new Command("export-memories")
+const cmd = new Command("export-memories")
 	.configureHelp(helpStyle)
 	.description("Export memories to a JSON file for sharing or backup")
 	.argument("<output>", "output file path (use '-' for stdout)")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--project <project>", "filter by project (defaults to git repo root)")
 	.option("--all-projects", "export all projects")
 	.option("--include-inactive", "include deactivated memories")
-	.option("--since <iso>", "only export memories created after this ISO timestamp")
-	.action(
-		(
-			output: string,
-			opts: {
-				db?: string;
-				dbPath?: string;
-				project?: string;
-				allProjects?: boolean;
-				includeInactive?: boolean;
-				since?: string;
-			},
-		) => {
-			const payload = exportMemories({
-				dbPath: resolveDbPath(opts.db ?? opts.dbPath),
-				project: opts.project,
-				allProjects: opts.allProjects,
-				includeInactive: opts.includeInactive,
-				since: opts.since,
-			});
-			const text = `${JSON.stringify(payload, null, 2)}\n`;
-			if (output === "-") {
-				process.stdout.write(text);
-				return;
-			}
-			const outputPath = expandUserPath(output);
-			writeFileSync(outputPath, text, "utf8");
-			p.intro("codemem export-memories");
-			p.log.success(
-				[
-					`Output:    ${outputPath}`,
-					`Sessions:  ${payload.sessions.length.toLocaleString()}`,
-					`Memories:  ${payload.memory_items.length.toLocaleString()}`,
-					`Summaries: ${payload.session_summaries.length.toLocaleString()}`,
-					`Prompts:   ${payload.user_prompts.length.toLocaleString()}`,
-				].join("\n"),
-			);
-			p.outro("done");
+	.option("--since <iso>", "only export memories created after this ISO timestamp");
+
+addDbOption(cmd);
+
+cmd.action(
+	(
+		output: string,
+		opts: DbOpts & {
+			project?: string;
+			allProjects?: boolean;
+			includeInactive?: boolean;
+			since?: string;
 		},
-	);
+	) => {
+		const payload = exportMemories({
+			dbPath: resolveDbPath(resolveDbOpt(opts)),
+			project: opts.project,
+			allProjects: opts.allProjects,
+			includeInactive: opts.includeInactive,
+			since: opts.since,
+		});
+		const text = `${JSON.stringify(payload, null, 2)}\n`;
+		if (output === "-") {
+			process.stdout.write(text);
+			return;
+		}
+		const outputPath = expandUserPath(output);
+		writeFileSync(outputPath, text, "utf8");
+		p.intro("codemem export-memories");
+		p.log.success(
+			[
+				`Output:    ${outputPath}`,
+				`Sessions:  ${payload.sessions.length.toLocaleString()}`,
+				`Memories:  ${payload.memory_items.length.toLocaleString()}`,
+				`Summaries: ${payload.session_summaries.length.toLocaleString()}`,
+				`Prompts:   ${payload.user_prompts.length.toLocaleString()}`,
+			].join("\n"),
+		);
+		p.outro("done");
+	},
+);
+
+export const exportMemoriesCommand = cmd;

--- a/packages/cli/src/commands/import-memories.ts
+++ b/packages/cli/src/commands/import-memories.ts
@@ -3,29 +3,49 @@ import type { ExportPayload } from "@codemem/core";
 import { importMemories, readImportPayload, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	emitJsonError,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
 
-export const importMemoriesCommand = new Command("import-memories")
+const cmd = new Command("import-memories")
 	.configureHelp(helpStyle)
 	.description("Import memories from an exported JSON file")
 	.argument("<inputFile>", "input JSON file (use '-' for stdin)")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--remap-project <path>", "remap all projects to this path on import")
-	.option("--dry-run", "preview import without writing")
-	.action(
-		(
-			inputFile: string,
-			opts: { db?: string; dbPath?: string; remapProject?: string; dryRun?: boolean },
-		) => {
-			let payload: ExportPayload;
-			try {
-				payload = readImportPayload(inputFile);
-			} catch (error) {
-				p.log.error(error instanceof Error ? error.message : "Invalid import file");
-				process.exitCode = 1;
-				return;
-			}
+	.option("--dry-run", "preview import without writing");
 
+addDbOption(cmd);
+addJsonOption(cmd);
+
+cmd.action(
+	(
+		inputFile: string,
+		opts: DbOpts &
+			JsonOpts & {
+				remapProject?: string;
+				dryRun?: boolean;
+			},
+	) => {
+		let payload: ExportPayload;
+		try {
+			payload = readImportPayload(inputFile);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Invalid import file";
+			if (opts.json) {
+				emitJsonError("invalid_input", message);
+			} else {
+				p.log.error(message);
+				process.exitCode = 1;
+			}
+			return;
+		}
+
+		if (!opts.json) {
 			p.intro("codemem import-memories");
 			p.log.info(
 				[
@@ -37,25 +57,39 @@ export const importMemoriesCommand = new Command("import-memories")
 					`Prompts:        ${payload.user_prompts.length.toLocaleString()}`,
 				].join("\n"),
 			);
+		}
 
-			const result = importMemories(payload, {
-				dbPath: resolveDbPath(opts.db ?? opts.dbPath),
-				remapProject: opts.remapProject,
-				dryRun: opts.dryRun,
-			});
+		const result = importMemories(payload, {
+			dbPath: resolveDbPath(resolveDbOpt(opts)),
+			remapProject: opts.remapProject,
+			dryRun: opts.dryRun,
+		});
 
-			if (result.dryRun) {
-				p.outro("dry run complete");
-				return;
-			}
-			p.log.success(
-				[
-					`Imported sessions:  ${result.sessions.toLocaleString()}`,
-					`Imported prompts:   ${result.user_prompts.toLocaleString()}`,
-					`Imported memories:  ${result.memory_items.toLocaleString()}`,
-					`Imported summaries: ${result.session_summaries.toLocaleString()}`,
-				].join("\n"),
+		if (opts.json) {
+			console.log(
+				JSON.stringify({
+					sessions: result.sessions,
+					memory_items: result.memory_items,
+					skipped: result.dryRun,
+				}),
 			);
-			p.outro("done");
-		},
-	);
+			return;
+		}
+
+		if (result.dryRun) {
+			p.outro("dry run complete");
+			return;
+		}
+		p.log.success(
+			[
+				`Imported sessions:  ${result.sessions.toLocaleString()}`,
+				`Imported prompts:   ${result.user_prompts.toLocaleString()}`,
+				`Imported memories:  ${result.memory_items.toLocaleString()}`,
+				`Imported summaries: ${result.session_summaries.toLocaleString()}`,
+			].join("\n"),
+		);
+		p.outro("done");
+	},
+);
+
+export const importMemoriesCommand = cmd;

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,14 +1,22 @@
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
 
-export const mcpCommand = new Command("mcp")
+const mcpCmd = new Command("mcp")
 	.configureHelp(helpStyle)
-	.description("Start the MCP stdio server")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.action(async (opts: { db?: string; dbPath?: string }) => {
-		const dbPath = opts.db ?? opts.dbPath;
-		if (dbPath) process.env.CODEMEM_DB = dbPath;
-		// Dynamic import — MCP server is its own entry point
+	.description("Start the MCP stdio server");
+
+addDbOption(mcpCmd);
+
+export const mcpCommand = mcpCmd.action(async (opts: DbOpts) => {
+	const dbPath = resolveDbOpt(opts);
+	if (dbPath) process.env.CODEMEM_DB = dbPath;
+	try {
 		await import("@codemem/mcp");
-	});
+	} catch (err) {
+		console.error(
+			`Failed to start MCP server: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		process.exitCode = 1;
+	}
+});

--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -13,7 +13,6 @@ describe("memory command aliases", () => {
 			"forget",
 			"remember",
 			"inject",
-			"compact",
 		]);
 	});
 

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -1,15 +1,23 @@
 /**
- * Memory management CLI commands — show, forget, remember.
+ * Memory management CLI commands — show, forget, remember, inject.
  *
  * Ports codemem/commands/memory_cmds.py (show_cmd, forget_cmd, remember_cmd).
- * Compact and inject are deferred — compact requires the summarizer pipeline,
- * and inject is just pack_text output which the existing pack command covers.
+ * Inject is deprecated in favor of `codemem pack`.
  */
 
 import * as p from "@clack/prompts";
 import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	emitDeprecationWarning,
+	emitJsonError,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
 
 function collectWorkingSetFile(value: string, previous: string[]): string[] {
 	return [...previous, value];
@@ -22,55 +30,82 @@ function parseStrictPositiveId(value: string): number | null {
 	return Number.isFinite(n) && n >= 1 && Number.isInteger(n) ? n : null;
 }
 
-function showMemoryAction(idStr: string, opts: { db?: string; dbPath?: string }): void {
+function showMemoryAction(idStr: string, opts: DbOpts & JsonOpts): void {
 	const memoryId = parseStrictPositiveId(idStr);
 	if (memoryId === null) {
-		p.log.error(`Invalid memory ID: ${idStr}`);
-		process.exitCode = 1;
+		if (opts.json) {
+			emitJsonError("invalid_id", `Invalid memory ID: ${idStr}`);
+		} else {
+			p.log.error(`Invalid memory ID: ${idStr}`);
+			process.exitCode = 1;
+		}
 		return;
 	}
-	const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 	try {
 		const item = store.get(memoryId);
 		if (!item) {
-			p.log.error(`Memory ${memoryId} not found`);
-			process.exitCode = 1;
+			if (opts.json) {
+				emitJsonError("not_found", `Memory ${memoryId} not found`);
+			} else {
+				p.log.error(`Memory ${memoryId} not found`);
+				process.exitCode = 1;
+			}
 			return;
 		}
-		console.log(JSON.stringify(item, null, 2));
+		if (opts.json) {
+			console.log(JSON.stringify(item, null, 2));
+		} else {
+			// Human-readable format
+			console.log(`#${item.id} [${item.kind}] ${item.title}`);
+			if (item.subtitle) console.log(`  ${item.subtitle}`);
+			console.log(`  created: ${item.created_at}  confidence: ${item.confidence}`);
+			if (item.tags_text) console.log(`  tags: ${item.tags_text}`);
+			if (item.body_text) {
+				const preview =
+					item.body_text.length > 300 ? `${item.body_text.slice(0, 300)}…` : item.body_text;
+				console.log(`\n${preview}`);
+			}
+		}
 	} finally {
 		store.close();
 	}
 }
 
-function forgetMemoryAction(idStr: string, opts: { db?: string; dbPath?: string }): void {
+function forgetMemoryAction(idStr: string, opts: DbOpts & JsonOpts): void {
 	const memoryId = parseStrictPositiveId(idStr);
 	if (memoryId === null) {
-		p.log.error(`Invalid memory ID: ${idStr}`);
-		process.exitCode = 1;
+		if (opts.json) {
+			emitJsonError("invalid_id", `Invalid memory ID: ${idStr}`);
+		} else {
+			p.log.error(`Invalid memory ID: ${idStr}`);
+			process.exitCode = 1;
+		}
 		return;
 	}
-	const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 	try {
 		store.forget(memoryId);
-		p.log.success(`Memory ${memoryId} marked inactive`);
+		if (opts.json) {
+			console.log(JSON.stringify({ id: memoryId, status: "forgotten" }));
+		} else {
+			p.log.success(`Memory ${memoryId} marked inactive`);
+		}
 	} finally {
 		store.close();
 	}
 }
 
-interface RememberMemoryOptions {
+interface RememberMemoryOptions extends DbOpts, JsonOpts {
 	kind: string;
 	title: string;
 	body: string;
 	tags?: string[];
 	project?: string;
-	db?: string;
-	dbPath?: string;
 }
 
 async function rememberMemoryAction(opts: RememberMemoryOptions): Promise<void> {
-	const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 	let sessionId: number | null = null;
 	try {
 		const project = resolveProject(process.cwd(), opts.project ?? null);
@@ -84,7 +119,11 @@ async function rememberMemoryAction(opts: RememberMemoryOptions): Promise<void> 
 		const memId = store.remember(sessionId, opts.kind, opts.title, opts.body, 0.5, opts.tags);
 		await store.flushPendingVectorWrites();
 		store.endSession(sessionId, { manual: true });
-		p.log.success(`Stored memory ${memId}`);
+		if (opts.json) {
+			console.log(JSON.stringify({ id: memId }));
+		} else {
+			p.log.success(`Stored memory ${memId}`);
+		}
 	} catch (err) {
 		if (sessionId !== null) {
 			try {
@@ -93,53 +132,60 @@ async function rememberMemoryAction(opts: RememberMemoryOptions): Promise<void> 
 				// ignore — already in error path
 			}
 		}
-		throw err;
+		const message = err instanceof Error ? err.message : String(err);
+		if (opts.json) {
+			emitJsonError("remember_failed", message);
+		} else {
+			p.log.error(`Failed to store memory: ${message}`);
+			process.exitCode = 1;
+		}
 	} finally {
 		store.close();
 	}
 }
 
 function createShowMemoryCommand(): Command {
-	return new Command("show")
+	const cmd = new Command("show")
 		.configureHelp(helpStyle)
-		.description("Print a memory item as JSON")
-		.argument("<id>", "memory ID")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.action(showMemoryAction);
+		.description("Show a memory item")
+		.argument("<id>", "memory ID");
+	addDbOption(cmd);
+	addJsonOption(cmd);
+	cmd.action(showMemoryAction);
+	return cmd;
 }
 
 function createForgetMemoryCommand(): Command {
-	return new Command("forget")
+	const cmd = new Command("forget")
 		.configureHelp(helpStyle)
 		.description("Deactivate a memory item")
-		.argument("<id>", "memory ID")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.action(forgetMemoryAction);
+		.argument("<id>", "memory ID");
+	addDbOption(cmd);
+	addJsonOption(cmd);
+	cmd.action(forgetMemoryAction);
+	return cmd;
 }
 
 function createRememberMemoryCommand(): Command {
-	return new Command("remember")
+	const cmd = new Command("remember")
 		.configureHelp(helpStyle)
 		.description("Manually add a memory item")
 		.requiredOption("-k, --kind <kind>", "memory kind (discovery, decision, feature, bugfix, etc.)")
 		.requiredOption("-t, --title <title>", "memory title")
 		.requiredOption("-b, --body <body>", "memory body text")
 		.option("--tags <tags...>", "tags (space-separated)")
-		.option("--project <project>", "project name (defaults to git repo root)")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.action(rememberMemoryAction);
+		.option("--project <project>", "project name (defaults to git repo root)");
+	addDbOption(cmd);
+	addJsonOption(cmd);
+	cmd.action(rememberMemoryAction);
+	return cmd;
 }
 
 function createInjectMemoryCommand(): Command {
-	return new Command("inject")
+	const cmd = new Command("inject")
 		.configureHelp(helpStyle)
 		.description("Build raw memory context text for manual prompt injection")
 		.argument("<context>", "context string to search for")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
 		.option("-n, --limit <n>", "max items", "10")
 		.option("--budget <tokens>", "token budget")
 		.option("--token-budget <tokens>", "token budget")
@@ -152,61 +198,43 @@ function createInjectMemoryCommand(): Command {
 		.option("--project <project>", "project identifier (defaults to git repo root)")
 		.option("--all-projects", "search across all projects")
 		.allowUnknownOption(true)
-		.allowExcessArguments(true)
-		.action(
-			async (
-				context: string,
-				opts: {
-					db?: string;
-					dbPath?: string;
-					limit?: string;
-					budget?: string;
-					tokenBudget?: string;
-					workingSetFile?: string[];
-					project?: string;
-					allProjects?: boolean;
-				},
-			) => {
-				const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-				try {
-					const limit = Number.parseInt(opts.limit ?? "10", 10) || 10;
-					const budgetRaw = opts.tokenBudget ?? opts.budget;
-					const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
-					const filters: { project?: string; working_set_paths?: string[] } = {};
-					if (!opts.allProjects) {
-						const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
-						const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
-						if (project) filters.project = project;
-					}
-					if ((opts.workingSetFile?.length ?? 0) > 0) {
-						filters.working_set_paths = opts.workingSetFile;
-					}
-					const pack = await store.buildMemoryPackAsync(context, limit, budget, filters);
-					console.log(pack.pack_text ?? "");
-				} finally {
-					store.close();
-				}
+		.allowExcessArguments(true);
+	addDbOption(cmd);
+	cmd.action(
+		async (
+			context: string,
+			opts: DbOpts & {
+				limit?: string;
+				budget?: string;
+				tokenBudget?: string;
+				workingSetFile?: string[];
+				project?: string;
+				allProjects?: boolean;
 			},
-		);
-}
-
-function createCompactMemoryCommand(): Command {
-	return new Command("compact")
-		.configureHelp(helpStyle)
-		.description("Deferred command guidance for memory compaction")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--session-id <id>", "session ID")
-		.option("--limit <n>", "max sessions to compact", "10")
-		.allowUnknownOption(true)
-		.allowExcessArguments(true)
-		.action(() => {
-			p.log.warn("`codemem memory compact` is not implemented in the TypeScript CLI yet.");
-			p.log.info(
-				"Current workaround: rely on automatic ingestion; for manual context use `codemem memory inject <context>`.",
-			);
-			process.exitCode = 2;
-		});
+		) => {
+			emitDeprecationWarning("codemem memory inject", "codemem pack");
+			const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+			try {
+				const limit = Number.parseInt(opts.limit ?? "10", 10) || 10;
+				const budgetRaw = opts.tokenBudget ?? opts.budget;
+				const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
+				const filters: { project?: string; working_set_paths?: string[] } = {};
+				if (!opts.allProjects) {
+					const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
+					const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
+					if (project) filters.project = project;
+				}
+				if ((opts.workingSetFile?.length ?? 0) > 0) {
+					filters.working_set_paths = opts.workingSetFile;
+				}
+				const pack = await store.buildMemoryPackAsync(context, limit, budget, filters);
+				console.log(pack.pack_text ?? "");
+			} finally {
+				store.close();
+			}
+		},
+	);
+	return cmd;
 }
 
 export const showMemoryCommand = createShowMemoryCommand();
@@ -221,4 +249,3 @@ memoryCommand.addCommand(createShowMemoryCommand());
 memoryCommand.addCommand(createForgetMemoryCommand());
 memoryCommand.addCommand(createRememberMemoryCommand());
 memoryCommand.addCommand(createInjectMemoryCommand());
-memoryCommand.addCommand(createCompactMemoryCommand());

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -2,17 +2,22 @@ import * as p from "@clack/prompts";
 import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
 
 function collectWorkingSetFile(value: string, previous: string[]): string[] {
 	return [...previous, value];
 }
 
-export const packCommand = new Command("pack")
+const packCmd = new Command("pack")
 	.configureHelp(helpStyle)
 	.description("Build a context-aware memory pack")
 	.argument("<context>", "context string to search for")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("-n, --limit <n>", "max items", "10")
 	.option("--budget <tokens>", "token budget")
 	.option("--token-budget <tokens>", "token budget")
@@ -23,68 +28,69 @@ export const packCommand = new Command("pack")
 		[],
 	)
 	.option("--project <project>", "project identifier (defaults to git repo root)")
-	.option("--all-projects", "search across all projects")
-	.option("--json", "output as JSON")
-	.action(
-		async (
-			context: string,
-			opts: {
-				db?: string;
-				dbPath?: string;
+	.option("--all-projects", "search across all projects");
+
+addDbOption(packCmd);
+addJsonOption(packCmd);
+
+export const packCommand = packCmd.action(
+	async (
+		context: string,
+		opts: DbOpts &
+			JsonOpts & {
 				limit: string;
 				budget?: string;
 				tokenBudget?: string;
 				workingSetFile?: string[];
 				project?: string;
 				allProjects?: boolean;
-				json?: boolean;
 			},
-		) => {
-			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-			try {
-				const limit = Number.parseInt(opts.limit, 10) || 10;
-				const budgetRaw = opts.tokenBudget ?? opts.budget;
-				const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
-				const filters: { project?: string; working_set_paths?: string[] } = {};
-				if (!opts.allProjects) {
-					const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
-					const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
-					if (project) filters.project = project;
-				}
-				if ((opts.workingSetFile?.length ?? 0) > 0) {
-					filters.working_set_paths = opts.workingSetFile;
-				}
-				const result = await store.buildMemoryPackAsync(context, limit, budget, filters);
-
-				if (opts.json) {
-					console.log(JSON.stringify(result, null, 2));
-					return;
-				}
-
-				p.intro(`Memory pack for "${context}"`);
-
-				if (result.items.length === 0) {
-					p.log.warn("No relevant memories found.");
-					p.outro("done");
-					return;
-				}
-
-				const m = result.metrics;
-				p.log.info(
-					`${m.total_items} items, ~${m.pack_tokens} tokens` +
-						(m.fallback_used ? " (fallback)" : "") +
-						`  [fts:${m.sources.fts} sem:${m.sources.semantic} fuzzy:${m.sources.fuzzy}]`,
-				);
-
-				for (const item of result.items) {
-					p.log.step(`#${item.id}  ${item.kind}  ${item.title}`);
-				}
-
-				p.note(result.pack_text, "pack_text");
-
-				p.outro("done");
-			} finally {
-				store.close();
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = Number.parseInt(opts.limit, 10) || 10;
+			const budgetRaw = opts.tokenBudget ?? opts.budget;
+			const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
+			const filters: { project?: string; working_set_paths?: string[] } = {};
+			if (!opts.allProjects) {
+				const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
+				const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
+				if (project) filters.project = project;
 			}
-		},
-	);
+			if ((opts.workingSetFile?.length ?? 0) > 0) {
+				filters.working_set_paths = opts.workingSetFile;
+			}
+			const result = await store.buildMemoryPackAsync(context, limit, budget, filters);
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			p.intro(`Memory pack for "${context}"`);
+
+			if (result.items.length === 0) {
+				p.log.warn("No relevant memories found.");
+				p.outro("done");
+				return;
+			}
+
+			const m = result.metrics;
+			p.log.info(
+				`${m.total_items} items, ~${m.pack_tokens} tokens` +
+					(m.fallback_used ? " (fallback)" : "") +
+					`  [fts:${m.sources.fts} sem:${m.sources.semantic} fuzzy:${m.sources.fuzzy}]`,
+			);
+
+			for (const item of result.items) {
+				p.log.step(`#${item.id}  ${item.kind}  ${item.title}`);
+			}
+
+			p.note(result.pack_text, "pack_text");
+
+			p.outro("done");
+		} finally {
+			store.close();
+		}
+	},
+);

--- a/packages/cli/src/commands/recent.ts
+++ b/packages/cli/src/commands/recent.ts
@@ -1,41 +1,57 @@
 import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
 
-export const recentCommand = new Command("recent")
+const cmd = new Command("recent")
 	.configureHelp(helpStyle)
 	.description("Show recent memories")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("--limit <n>", "max results", "5")
 	.option("--project <project>", "project identifier (defaults to git repo root)")
 	.option("--all-projects", "search across all projects")
-	.option("--kind <kind>", "filter by memory kind")
-	.action(
-		(opts: {
-			db?: string;
-			dbPath?: string;
-			limit: string;
-			project?: string;
-			allProjects?: boolean;
-			kind?: string;
-		}) => {
-			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-			try {
-				const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 5);
-				const filters: { kind?: string; project?: string } = {};
-				if (opts.kind) filters.kind = opts.kind;
-				if (!opts.allProjects) {
-					const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
-					const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
-					if (project) filters.project = project;
-				}
-				const items = store.recent(limit, filters);
+	.option("--kind <kind>", "filter by memory kind");
+
+addDbOption(cmd);
+addJsonOption(cmd);
+
+cmd.action(
+	(
+		opts: DbOpts &
+			JsonOpts & {
+				limit: string;
+				project?: string;
+				allProjects?: boolean;
+				kind?: string;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 5);
+			const filters: { kind?: string; project?: string } = {};
+			if (opts.kind) filters.kind = opts.kind;
+			if (!opts.allProjects) {
+				const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
+				const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
+				if (project) filters.project = project;
+			}
+			const items = store.recent(limit, filters);
+			if (opts.json) {
+				console.log(JSON.stringify(items));
+			} else {
 				for (const item of items) {
 					console.log(`#${item.id} [${item.kind}] ${item.title}`);
 				}
-			} finally {
-				store.close();
 			}
-		},
-	);
+		} finally {
+			store.close();
+		}
+	},
+);
+
+export const recentCommand = cmd;

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -2,72 +2,78 @@ import * as p from "@clack/prompts";
 import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
 
-export const searchCommand = new Command("search")
+const searchCmd = new Command("search")
 	.configureHelp(helpStyle)
 	.description("Search memories by query")
 	.argument("<query>", "search query")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
 	.option("-n, --limit <n>", "max results", "5")
 	.option("--project <project>", "project identifier (defaults to git repo root)")
 	.option("--all-projects", "search across all projects")
-	.option("--kind <kind>", "filter by memory kind")
-	.option("--json", "output as JSON")
-	.action(
-		(
-			query: string,
-			opts: {
-				db?: string;
-				dbPath?: string;
+	.option("--kind <kind>", "filter by memory kind");
+
+addDbOption(searchCmd);
+addJsonOption(searchCmd);
+
+export const searchCommand = searchCmd.action(
+	(
+		query: string,
+		opts: DbOpts &
+			JsonOpts & {
 				limit: string;
 				project?: string;
 				allProjects?: boolean;
 				kind?: string;
-				json?: boolean;
 			},
-		) => {
-			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-			try {
-				const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 5);
-				const filters: { kind?: string; project?: string } = {};
-				if (opts.kind) filters.kind = opts.kind;
-				if (!opts.allProjects) {
-					const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
-					const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
-					if (project) filters.project = project;
-				}
-				const results = store.search(query, limit, filters);
-
-				if (opts.json) {
-					console.log(JSON.stringify(results, null, 2));
-					return;
-				}
-
-				if (results.length === 0) {
-					p.log.warn("No results found.");
-					return;
-				}
-
-				p.intro(`${results.length} result(s) for "${query}"`);
-
-				for (const item of results) {
-					const score = item.score.toFixed(3);
-					const age = timeSince(item.created_at);
-					const preview =
-						item.body_text.length > 120 ? `${item.body_text.slice(0, 120)}…` : item.body_text;
-
-					p.log.message(
-						[`#${item.id}  ${item.kind}  ${age}  [${score}]`, item.title, preview].join("\n"),
-					);
-				}
-
-				p.outro("done");
-			} finally {
-				store.close();
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = Math.max(1, Number.parseInt(opts.limit, 10) || 5);
+			const filters: { kind?: string; project?: string } = {};
+			if (opts.kind) filters.kind = opts.kind;
+			if (!opts.allProjects) {
+				const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
+				const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
+				if (project) filters.project = project;
 			}
-		},
-	);
+			const results = store.search(query, limit, filters);
+
+			if (opts.json) {
+				console.log(JSON.stringify(results, null, 2));
+				return;
+			}
+
+			if (results.length === 0) {
+				p.log.warn("No results found.");
+				return;
+			}
+
+			p.intro(`${results.length} result(s) for "${query}"`);
+
+			for (const item of results) {
+				const score = item.score.toFixed(3);
+				const age = timeSince(item.created_at);
+				const preview =
+					item.body_text.length > 120 ? `${item.body_text.slice(0, 120)}…` : item.body_text;
+
+				p.log.message(
+					[`#${item.id}  ${item.kind}  ${age}  [${score}]`, item.title, preview].join("\n"),
+				);
+			}
+
+			p.outro("done");
+		} finally {
+			store.close();
+		}
+	},
+);
 
 function timeSince(isoDate: string): string {
 	const ms = Date.now() - new Date(isoDate).getTime();

--- a/packages/cli/src/commands/serve-invocation.ts
+++ b/packages/cli/src/commands/serve-invocation.ts
@@ -1,10 +1,10 @@
+import { type DbOpts, resolveDbOpt } from "../shared-options.js";
+
 export type ServeMode = "start" | "stop" | "restart";
 
 export type ServeAction = ServeMode | undefined;
 
-export interface LegacyServeOptions {
-	db?: string;
-	dbPath?: string;
+export interface LegacyServeOptions extends DbOpts {
 	config?: string;
 	host: string;
 	port: string;
@@ -14,18 +14,14 @@ export interface LegacyServeOptions {
 	restart?: boolean;
 }
 
-export interface StartServeOptions {
-	db?: string;
-	dbPath?: string;
+export interface StartServeOptions extends DbOpts {
 	config?: string;
 	host: string;
 	port: string;
 	foreground?: boolean;
 }
 
-export interface StopRestartServeOptions {
-	db?: string;
-	dbPath?: string;
+export interface StopRestartServeOptions extends DbOpts {
 	config?: string;
 	host: string;
 	port: string;
@@ -40,7 +36,11 @@ export interface ResolvedServeInvocation {
 	background: boolean;
 }
 
-function parsePort(rawPort: string): number {
+/**
+ * Parse and validate a port string. Throws a user-friendly message (no stack trace)
+ * that callers in serve.ts catch at the action boundary.
+ */
+export function parsePort(rawPort: string): number {
 	const port = Number.parseInt(rawPort, 10);
 	if (!Number.isFinite(port) || port < 1 || port > 65535) {
 		throw new Error(`Invalid port: ${rawPort}`);
@@ -55,7 +55,7 @@ export function resolveLegacyServeInvocation(opts: LegacyServeOptions): Resolved
 	if (opts.foreground && opts.background) {
 		throw new Error("Use only one of --background or --foreground");
 	}
-	const dbPath = opts.db ?? opts.dbPath ?? null;
+	const dbPath = resolveDbOpt(opts) ?? null;
 	return {
 		mode: opts.stop ? "stop" : opts.restart ? "restart" : "start",
 		dbPath,
@@ -83,7 +83,7 @@ export function resolveServeInvocation(
 }
 
 export function resolveStartServeInvocation(opts: StartServeOptions): ResolvedServeInvocation {
-	const dbPath = opts.db ?? opts.dbPath ?? null;
+	const dbPath = resolveDbOpt(opts) ?? null;
 	return {
 		mode: "start",
 		dbPath,
@@ -98,7 +98,7 @@ export function resolveStopRestartInvocation(
 	mode: "stop" | "restart",
 	opts: StopRestartServeOptions,
 ): ResolvedServeInvocation {
-	const dbPath = opts.db ?? opts.dbPath ?? null;
+	const dbPath = resolveDbOpt(opts) ?? null;
 	return {
 		mode,
 		dbPath,

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -16,8 +16,14 @@ import {
 	runSyncDaemon,
 	SyncRetentionRunner,
 } from "@codemem/core";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { helpStyle } from "../help-style.js";
+import {
+	addConfigOption,
+	addDbOption,
+	addViewerHostOptions,
+	emitDeprecationWarning,
+} from "../shared-options.js";
 import {
 	type LegacyServeOptions,
 	type ResolvedServeInvocation,
@@ -319,7 +325,11 @@ async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promi
 		return;
 	}
 	const scriptPath = process.argv[1];
-	if (!scriptPath) throw new Error("Unable to resolve CLI entrypoint for background launch");
+	if (!scriptPath) {
+		p.log.error("Unable to resolve CLI entrypoint for background launch");
+		process.exitCode = 1;
+		return;
+	}
 	const child = spawn(process.execPath, buildForegroundRunnerArgs(scriptPath, invocation), {
 		cwd: process.cwd(),
 		detached: true,
@@ -608,36 +618,46 @@ async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<
 	}
 }
 
-function addSharedServeOptions(command: Command): Command {
-	return command
-		.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-		.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-		.option("--config <path>", "config path (default: CODEMEM_CONFIG or resolved config)")
-		.option("--host <host>", "bind host", "127.0.0.1")
-		.option("--port <port>", "bind port", "38888");
-}
+const serveCmd = new Command("serve")
+	.configureHelp(helpStyle)
+	.description("Run or manage the viewer")
+	.argument("[action]", "lifecycle action (start|stop|restart)");
 
-export const serveCommand = addSharedServeOptions(
-	new Command("serve")
-		.configureHelp(helpStyle)
-		.description("Run or manage the viewer")
-		.argument("[action]", "lifecycle action (start|stop|restart)"),
-)
-	.option("--background", "run viewer in background")
-	.option("--foreground", "run viewer in foreground")
-	.option("--stop", "stop background viewer")
-	.option("--restart", "restart background viewer")
-	.action(async (action: string | undefined, opts: LegacyServeOptions) => {
-		const normalizedAction =
-			action === undefined
-				? undefined
-				: action === "start" || action === "stop" || action === "restart"
-					? (action as ServeAction)
-					: null;
-		if (normalizedAction === null) {
-			p.log.error(`Unknown serve action: ${action}`);
+addDbOption(serveCmd);
+addConfigOption(serveCmd);
+addViewerHostOptions(serveCmd);
+
+// Legacy lifecycle flags — hidden from --help, emit deprecation warnings when used.
+serveCmd.addOption(new Option("--background", "run viewer in background").hideHelp());
+serveCmd.addOption(new Option("--foreground", "run viewer in foreground").hideHelp());
+serveCmd.addOption(new Option("--stop", "stop background viewer").hideHelp());
+serveCmd.addOption(new Option("--restart", "restart background viewer").hideHelp());
+
+export const serveCommand = serveCmd.action(
+	async (action: string | undefined, opts: LegacyServeOptions) => {
+		try {
+			// Emit deprecation warnings for legacy flags
+			if (opts.stop) emitDeprecationWarning("--stop", "codemem serve stop");
+			if (opts.restart) emitDeprecationWarning("--restart", "codemem serve restart");
+			if (opts.background) emitDeprecationWarning("--background", "codemem serve start");
+			if (opts.foreground)
+				emitDeprecationWarning("--foreground", "codemem serve start --foreground");
+
+			const normalizedAction =
+				action === undefined
+					? undefined
+					: action === "start" || action === "stop" || action === "restart"
+						? (action as ServeAction)
+						: null;
+			if (normalizedAction === null) {
+				p.log.error(`Unknown serve action: ${action}`);
+				process.exitCode = 1;
+				return;
+			}
+			await runServeInvocation(resolveServeInvocation(normalizedAction, opts));
+		} catch (err) {
+			p.log.error(err instanceof Error ? err.message : String(err));
 			process.exitCode = 1;
-			return;
 		}
-		await runServeInvocation(resolveServeInvocation(normalizedAction, opts));
-	});
+	},
+);

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -2,6 +2,13 @@ import * as p from "@clack/prompts";
 import { MemoryStore, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
 
 function fmtPct(n: number): string {
 	return `${Math.round(n * 100)}%`;
@@ -14,58 +21,59 @@ function fmtTokens(n: number): string {
 	return `${n}`;
 }
 
-export const statsCommand = new Command("stats")
+const statsCmd = new Command("stats")
 	.configureHelp(helpStyle)
-	.description("Show database statistics")
-	.option("--db <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--db-path <path>", "database path (default: $CODEMEM_DB or ~/.codemem/mem.sqlite)")
-	.option("--json", "output as JSON")
-	.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
-		const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-		try {
-			const result = store.stats();
-			if (opts.json) {
-				console.log(JSON.stringify(result, null, 2));
-				return;
-			}
+	.description("Show database statistics");
 
-			const db = result.database;
-			const sizeMb = (db.size_bytes / 1_048_576).toFixed(1);
+addDbOption(statsCmd);
+addJsonOption(statsCmd);
 
-			p.intro("codemem stats");
+export const statsCommand = statsCmd.action((opts: DbOpts & JsonOpts) => {
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const result = store.stats();
+		if (opts.json) {
+			console.log(JSON.stringify(result, null, 2));
+			return;
+		}
 
-			p.log.info([`Path:        ${db.path}`, `Size:        ${sizeMb} MB`].join("\n"));
+		const db = result.database;
+		const sizeMb = (db.size_bytes / 1_048_576).toFixed(1);
 
-			p.log.success(
-				[
-					`Sessions:    ${db.sessions.toLocaleString()}`,
-					`Memories:    ${db.active_memory_items.toLocaleString()} active / ${db.memory_items.toLocaleString()} total`,
-					`Tags:        ${db.tags_filled.toLocaleString()} filled (${fmtPct(db.tags_coverage)} of active)`,
-					`Artifacts:   ${db.artifacts.toLocaleString()}`,
-					`Vectors:     ${db.vector_rows.toLocaleString()} (${fmtPct(db.vector_coverage)} coverage)`,
-					`Raw events:  ${db.raw_events.toLocaleString()}`,
-				].join("\n"),
+		p.intro("codemem stats");
+
+		p.log.info([`Path:        ${db.path}`, `Size:        ${sizeMb} MB`].join("\n"));
+
+		p.log.success(
+			[
+				`Sessions:    ${db.sessions.toLocaleString()}`,
+				`Memories:    ${db.active_memory_items.toLocaleString()} active / ${db.memory_items.toLocaleString()} total`,
+				`Tags:        ${db.tags_filled.toLocaleString()} filled (${fmtPct(db.tags_coverage)} of active)`,
+				`Artifacts:   ${db.artifacts.toLocaleString()}`,
+				`Vectors:     ${db.vector_rows.toLocaleString()} (${fmtPct(db.vector_coverage)} coverage)`,
+				`Raw events:  ${db.raw_events.toLocaleString()}`,
+			].join("\n"),
+		);
+
+		if (result.usage.events.length > 0) {
+			const lines = result.usage.events.map((e: (typeof result.usage.events)[number]) => {
+				const parts = [`${e.event}: ${e.count.toLocaleString()}`];
+				if (e.tokens_read > 0) parts.push(`read ${fmtTokens(e.tokens_read)} tokens`);
+				if (e.tokens_saved > 0) parts.push(`est. saved ${fmtTokens(e.tokens_saved)} tokens`);
+				return `  ${parts.join(", ")}`;
+			});
+
+			const t = result.usage.totals;
+			lines.push("");
+			lines.push(
+				`  Total: ${t.events.toLocaleString()} events, read ${fmtTokens(t.tokens_read)} tokens, est. saved ${fmtTokens(t.tokens_saved)} tokens`,
 			);
 
-			if (result.usage.events.length > 0) {
-				const lines = result.usage.events.map((e: (typeof result.usage.events)[number]) => {
-					const parts = [`${e.event}: ${e.count.toLocaleString()}`];
-					if (e.tokens_read > 0) parts.push(`read ${fmtTokens(e.tokens_read)} tokens`);
-					if (e.tokens_saved > 0) parts.push(`est. saved ${fmtTokens(e.tokens_saved)} tokens`);
-					return `  ${parts.join(", ")}`;
-				});
-
-				const t = result.usage.totals;
-				lines.push("");
-				lines.push(
-					`  Total: ${t.events.toLocaleString()} events, read ${fmtTokens(t.tokens_read)} tokens, est. saved ${fmtTokens(t.tokens_saved)} tokens`,
-				);
-
-				p.log.step(`Usage\n${lines.join("\n")}`);
-			}
-
-			p.outro("done");
-		} finally {
-			store.close();
+			p.log.step(`Usage\n${lines.join("\n")}`);
 		}
-	});
+
+		p.outro("done");
+	} finally {
+		store.close();
+	}
+});

--- a/packages/cli/src/commands/sync-helpers.ts
+++ b/packages/cli/src/commands/sync-helpers.ts
@@ -1,3 +1,5 @@
+import { resolveDbOpt } from "../shared-options.js";
+
 export interface SyncAttemptRow {
 	peer_device_id: string;
 	ok: number;
@@ -39,7 +41,8 @@ export function buildServeLifecycleArgs(
 	} else {
 		args.push("--restart");
 	}
-	if (opts.db ?? opts.dbPath) args.push("--db-path", opts.db ?? opts.dbPath ?? "");
+	const dbResolved = resolveDbOpt(opts);
+	if (dbResolved) args.push("--db-path", dbResolved);
 	if (opts.config) args.push("--config", opts.config);
 	if (opts.host) args.push("--host", opts.host);
 	if (opts.port) args.push("--port", opts.port);

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -188,11 +188,14 @@ describe("formatSyncAttempt", () => {
 		const coordinator = syncCommand.commands.find((command) => command.name() === "coordinator");
 		const serve = coordinator?.commands.find((command) => command.name() === "serve");
 		expect(serve?.options.find((opt) => opt.long === "--db")?.defaultValue).toBeUndefined();
-		expect(serve?.options.find((opt) => opt.long === "--port")?.defaultValue).toBe("7347");
-		// runtime default is enforced in action code, not commander metadata
+		// Defaults live in the action handler, not on the Option definitions,
+		// so that hidden --host/--port aliases can fall through correctly.
+		expect(
+			serve?.options.find((opt) => opt.long === "--coordinator-port")?.defaultValue,
+		).toBeUndefined();
 		const help = serve?.helpInformation() ?? "";
 		expect(help).toContain("coordinator database path");
-		expect(help).toContain("7347");
+		expect(help).toContain("bind port");
 	});
 
 	it("allows positional group ids for create-invite and list-join-requests", () => {

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -13,21 +13,6 @@ import {
 	applyBootstrapSnapshot,
 	buildAuthHeaders,
 	buildBaseUrl,
-	coordinatorCreateGroupAction,
-	coordinatorCreateInviteAction,
-	coordinatorDisableDeviceAction,
-	coordinatorEnrollDeviceAction,
-	coordinatorImportInviteAction,
-	coordinatorListBootstrapGrantsAction,
-	coordinatorListDevicesAction,
-	coordinatorListGroupsAction,
-	coordinatorListJoinRequestsAction,
-	coordinatorRemoveDeviceAction,
-	coordinatorRenameDeviceAction,
-	coordinatorReviewJoinRequestAction,
-	coordinatorRevokeBootstrapGrantAction,
-	createBetterSqliteCoordinatorApp,
-	DEFAULT_COORDINATOR_DB_PATH,
 	ensureDeviceIdentity,
 	fetchAllSnapshotPages,
 	fingerprintPublicKey,
@@ -46,11 +31,21 @@ import {
 	updatePeerAddresses,
 	writeCodememConfigFile,
 } from "@codemem/core";
-import { serve as honoServe } from "@hono/node-server";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { desc, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { helpStyle } from "../help-style.js";
+import {
+	addConfigOption,
+	addDbOption,
+	addJsonOption,
+	addLegacyServiceFlags,
+	addViewerHostOptions,
+	emitDeprecationWarning,
+	emitJsonError,
+	resolveDbOpt,
+} from "../shared-options.js";
+import { buildCoordinatorCommand } from "./coordinator.js";
 import {
 	buildServeLifecycleArgs,
 	collectAdvertiseAddresses,
@@ -87,12 +82,6 @@ function parsePositiveIntegerOption(
 	return Number.parseInt(trimmed, 10);
 }
 
-interface SyncOnceOptions {
-	db?: string;
-	dbPath?: string;
-	peer?: string;
-}
-
 interface SyncPairOptions {
 	accept?: string;
 	acceptFile?: string;
@@ -104,7 +93,9 @@ interface SyncPairOptions {
 	all?: boolean;
 	default?: boolean;
 	config?: string;
+	db?: string;
 	dbPath?: string;
+	json?: boolean;
 }
 
 function resolvePeerMatch(
@@ -126,19 +117,6 @@ function resolvePeerMatch(
 		.all();
 	if (byName.length > 1) return "ambiguous";
 	return byName[0] ?? null;
-}
-
-function readCoordinatorPublicKey(opts: { publicKey?: string; publicKeyFile?: string }): string {
-	const inline = String(opts.publicKey ?? "").trim();
-	const filePath = String(opts.publicKeyFile ?? "").trim();
-	if (inline && filePath) throw new Error("Use only one of --public-key or --public-key-file");
-	if (filePath) {
-		const text = readFileSync(filePath, "utf8").trim();
-		if (!text) throw new Error(`Public key file is empty: ${filePath}`);
-		return text;
-	}
-	if (!inline) throw new Error("Public key required via --public-key or --public-key-file");
-	return inline;
 }
 
 async function portOpen(host: string, port: number): Promise<boolean> {
@@ -202,6 +180,7 @@ async function runServeLifecycle(
 		// and the sync protocol listener reads sync_host/sync_port
 		// internally from readCoordinatorSyncConfig().
 	}
+	const dbResolved = resolveDbOpt(opts);
 	const args = buildServeLifecycleArgs(action, opts, process.argv[1] ?? "", process.execArgv);
 	await new Promise<void>((resolve, reject) => {
 		const child = spawn(process.execPath, args, {
@@ -209,7 +188,7 @@ async function runServeLifecycle(
 			stdio: "inherit",
 			env: {
 				...process.env,
-				...((opts.db ?? opts.dbPath) ? { CODEMEM_DB: opts.db ?? opts.dbPath } : {}),
+				...(dbResolved ? { CODEMEM_DB: dbResolved } : {}),
 				...(opts.config ? { CODEMEM_CONFIG: opts.config } : {}),
 			},
 		});
@@ -227,1508 +206,1089 @@ export const syncCommand = new Command("sync")
 	.configureHelp(helpStyle)
 	.description("Sync configuration and peer management");
 
-// codemem sync attempts
-syncCommand.addCommand(
-	new Command("attempts")
-		.configureHelp(helpStyle)
-		.description("Show recent sync attempts")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--limit <n>", "max attempts", "10")
-		.option("--json", "output as JSON")
-		.action((opts: { db?: string; dbPath?: string; limit: string; json?: boolean }) => {
-			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-			try {
-				const d = drizzle(store.db, { schema });
-				const limit = parseAttemptsLimit(opts.limit);
-				const rows = d
-					.select({
-						peer_device_id: schema.syncAttempts.peer_device_id,
-						ok: schema.syncAttempts.ok,
-						ops_in: schema.syncAttempts.ops_in,
-						ops_out: schema.syncAttempts.ops_out,
-						error: schema.syncAttempts.error,
-						finished_at: schema.syncAttempts.finished_at,
-					})
-					.from(schema.syncAttempts)
-					.orderBy(desc(schema.syncAttempts.finished_at))
-					.limit(limit)
-					.all();
+// ---- sync attempts ----
 
-				if (opts.json) {
-					console.log(JSON.stringify(rows, null, 2));
-					return;
-				}
-
-				for (const row of rows) {
-					console.log(formatSyncAttempt(row));
-				}
-			} finally {
-				store.close();
-			}
-		}),
-);
-
-syncCommand.addCommand(
-	new Command("start")
-		.configureHelp(helpStyle)
-		.description("Start sync daemon")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--config <path>", "config path")
-		.option("--host <host>", "viewer host")
-		.option("--port <port>", "viewer port")
-		.option("--user", "accepted for compatibility", true)
-		.option("--system", "accepted for compatibility")
-		.action(async (opts: SyncLifecycleOptions) => {
-			await runServeLifecycle("start", opts);
-		}),
-);
-
-syncCommand.addCommand(
-	new Command("stop")
-		.configureHelp(helpStyle)
-		.description("Stop sync daemon")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--config <path>", "config path")
-		.option("--host <host>", "viewer host")
-		.option("--port <port>", "viewer port")
-		.option("--user", "accepted for compatibility", true)
-		.option("--system", "accepted for compatibility")
-		.action(async (opts: SyncLifecycleOptions) => {
-			await runServeLifecycle("stop", opts);
-		}),
-);
-
-syncCommand.addCommand(
-	new Command("restart")
-		.configureHelp(helpStyle)
-		.description("Restart sync daemon")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--config <path>", "config path")
-		.option("--host <host>", "viewer host")
-		.option("--port <port>", "viewer port")
-		.option("--user", "accepted for compatibility", true)
-		.option("--system", "accepted for compatibility")
-		.action(async (opts: SyncLifecycleOptions) => {
-			await runServeLifecycle("restart", opts);
-		}),
-);
-
-syncCommand.addCommand(
-	new Command("once")
-		.configureHelp(helpStyle)
-		.description("Run a single sync pass")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--peer <peer>", "peer device id or name")
-		.action(async (opts: SyncOnceOptions) => {
-			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-			try {
-				const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
-				syncPassPreflight(store.db);
-				const d = drizzle(store.db, { schema });
-				const rows = opts.peer
-					? (() => {
-							const deviceMatches = d
-								.select({ peer_device_id: schema.syncPeers.peer_device_id })
-								.from(schema.syncPeers)
-								.where(eq(schema.syncPeers.peer_device_id, opts.peer))
-								.all();
-							if (deviceMatches.length > 0) return deviceMatches;
-							const nameMatches = d
-								.select({ peer_device_id: schema.syncPeers.peer_device_id })
-								.from(schema.syncPeers)
-								.where(eq(schema.syncPeers.name, opts.peer))
-								.all();
-							if (nameMatches.length > 1) {
-								p.log.error(`Peer name is ambiguous: ${opts.peer}`);
-								process.exitCode = 1;
-								return [];
-							}
-							return nameMatches;
-						})()
-					: d
-							.select({ peer_device_id: schema.syncPeers.peer_device_id })
-							.from(schema.syncPeers)
-							.all();
-
-				if (rows.length === 0) {
-					p.log.warn("No peers available for sync");
-					process.exitCode = 1;
-					return;
-				}
-
-				let hadFailure = false;
-				for (const row of rows) {
-					const result = await runSyncPass(store.db, row.peer_device_id, { keysDir });
-					if (!result.ok) hadFailure = true;
-					console.log(formatSyncOnceResult(row.peer_device_id, result));
-				}
-				if (hadFailure) {
-					process.exitCode = 1;
-				}
-			} finally {
-				store.close();
-			}
-		}),
-);
-
-syncCommand.addCommand(
-	new Command("pair")
-		.configureHelp(helpStyle)
-		.description("Print pairing payload or accept a peer payload")
-		.option("--accept <json>", "accept pairing payload JSON from another device")
-		.option("--accept-file <path>", "accept pairing payload from file path, or '-' for stdin")
-		.option("--payload-only", "when generating pairing payload, print JSON only")
-		.option("--name <name>", "label for the peer")
-		.option("--address <host:port>", "override peer address (host:port)")
-		.option("--include <projects>", "outbound-only allowlist for accepted peer")
-		.option("--exclude <projects>", "outbound-only blocklist for accepted peer")
-		.option("--all", "with --accept, push all projects to that peer")
-		.option("--default", "with --accept, use default/global push filters")
-		.option("--config <path>", "config path")
-		.option("--db-path <path>", "database path")
-		.action(async (opts: SyncPairOptions) => {
-			const store = new MemoryStore(resolveDbPath(opts.dbPath));
-			try {
-				const acceptModeRequested = opts.accept != null || opts.acceptFile != null;
-				if (opts.payloadOnly && acceptModeRequested) {
-					p.log.error("--payload-only cannot be combined with --accept or --accept-file");
-					process.exitCode = 1;
-					return;
-				}
-				if (opts.accept && opts.acceptFile) {
-					p.log.error("Use only one of --accept or --accept-file");
-					process.exitCode = 1;
-					return;
-				}
-
-				let acceptText = opts.accept;
-				if (opts.acceptFile) {
-					try {
-						acceptText =
-							opts.acceptFile === "-"
-								? await new Promise<string>((resolve, reject) => {
-										let text = "";
-										process.stdin.setEncoding("utf8");
-										process.stdin.on("data", (chunk) => {
-											text += chunk;
-										});
-										process.stdin.on("end", () => resolve(text));
-										process.stdin.on("error", reject);
-									})
-								: readFileSync(opts.acceptFile, "utf8");
-					} catch (error) {
-						p.log.error(
-							error instanceof Error
-								? `Failed to read pairing payload from ${opts.acceptFile}: ${error.message}`
-								: `Failed to read pairing payload from ${opts.acceptFile}`,
-						);
-						process.exitCode = 1;
-						return;
-					}
-				}
-
-				if (acceptModeRequested && !(acceptText ?? "").trim()) {
-					p.log.error("Empty pairing payload; provide JSON via --accept or --accept-file");
-					process.exitCode = 1;
-					return;
-				}
-
-				if (!acceptText && (opts.include || opts.exclude || opts.all || opts.default)) {
-					p.log.error(
-						"Project filters are outbound-only and must be set on the device running --accept",
-					);
-					process.exitCode = 1;
-					return;
-				}
-
-				if (acceptText?.trim()) {
-					if (opts.all && opts.default) {
-						p.log.error("Use only one of --all or --default");
-						process.exitCode = 1;
-						return;
-					}
-					if ((opts.all || opts.default) && (opts.include || opts.exclude)) {
-						p.log.error("--include/--exclude cannot be combined with --all/--default");
-						process.exitCode = 1;
-						return;
-					}
-
-					let payload: Record<string, unknown>;
-					try {
-						payload = JSON.parse(acceptText) as Record<string, unknown>;
-					} catch (error) {
-						p.log.error(
-							error instanceof Error
-								? `Invalid pairing payload: ${error.message}`
-								: "Invalid pairing payload",
-						);
-						process.exitCode = 1;
-						return;
-					}
-
-					const deviceId = String(payload.device_id || "").trim();
-					const fingerprint = String(payload.fingerprint || "").trim();
-					const publicKey = String(payload.public_key || "").trim();
-					const resolvedAddresses = opts.address?.trim()
-						? [opts.address.trim()]
-						: Array.isArray(payload.addresses)
-							? (payload.addresses as unknown[])
-									.filter(
-										(item): item is string => typeof item === "string" && item.trim().length > 0,
-									)
-									.map((item) => item.trim())
-							: [];
-					if (!deviceId || !fingerprint || !publicKey || resolvedAddresses.length === 0) {
-						p.log.error("Pairing payload missing device_id, fingerprint, public_key, or addresses");
-						process.exitCode = 1;
-						return;
-					}
-					if (fingerprintPublicKey(publicKey) !== fingerprint) {
-						p.log.error("Pairing payload fingerprint mismatch");
-						process.exitCode = 1;
-						return;
-					}
-
-					updatePeerAddresses(store.db, deviceId, resolvedAddresses, {
-						name: opts.name,
-						pinnedFingerprint: fingerprint,
-						publicKey,
-					});
-
-					if (opts.default) {
-						setPeerProjectFilter(store.db, deviceId, { include: null, exclude: null });
-					} else if (opts.all || opts.include || opts.exclude) {
-						setPeerProjectFilter(store.db, deviceId, {
-							include: opts.all ? [] : parseProjectList(opts.include),
-							exclude: opts.all ? [] : parseProjectList(opts.exclude),
-						});
-					}
-
-					p.log.success(`Paired with ${deviceId}`);
-					return;
-				}
-
-				const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
-				const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, { keysDir });
-				const publicKey = loadPublicKey(keysDir);
-				if (!publicKey) {
-					p.log.error("Public key missing");
-					process.exitCode = 1;
-					return;
-				}
-
-				const config = readCliConfig(opts.config);
-				const explicitAddress = opts.address?.trim();
-				const configuredHost = typeof config.sync_host === "string" ? config.sync_host : null;
-				const configuredPort = typeof config.sync_port === "number" ? config.sync_port : 7337;
-				const addresses = collectAdvertiseAddresses(
-					explicitAddress ?? null,
-					configuredHost,
-					configuredPort,
-					networkInterfaces(),
-				);
-				const payload = {
-					device_id: deviceId,
-					fingerprint,
-					public_key: publicKey,
-					address: addresses[0] ?? "",
-					addresses,
-				};
-				const payloadText = JSON.stringify(payload);
-
-				if (opts.payloadOnly) {
-					process.stdout.write(`${payloadText}\n`);
-					return;
-				}
-
-				const escaped = payloadText.replaceAll("'", "'\\''");
-				console.log("Pairing payload");
-				console.log(payloadText);
-				console.log("On the other device, save this JSON to pairing.json, then run:");
-				console.log("  codemem sync pair --accept-file pairing.json");
-				console.log("If you prefer inline JSON, run:");
-				console.log(`  codemem sync pair --accept '${escaped}'`);
-				console.log("For machine-friendly output next time, run:");
-				console.log("  codemem sync pair --payload-only");
-				console.log(
-					"On the accepting device, --include/--exclude control both what it sends and what it accepts from that peer.",
-				);
-			} finally {
-				store.close();
-			}
-		}),
-);
-
-syncCommand.addCommand(
-	new Command("doctor")
-		.configureHelp(helpStyle)
-		.description("Diagnose common sync setup and connectivity issues")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--config <path>", "config path")
-		.action(async (opts: { db?: string; dbPath?: string; config?: string }) => {
-			const config = readCliConfig(opts.config);
-			const dbPath = resolveDbPath(opts.db ?? opts.dbPath);
-			const store = new MemoryStore(dbPath);
-			try {
-				const d = drizzle(store.db, { schema });
-				const device = d
-					.select({ device_id: schema.syncDevice.device_id })
-					.from(schema.syncDevice)
-					.limit(1)
-					.get();
-				const daemonState = d
-					.select()
-					.from(schema.syncDaemonState)
-					.where(eq(schema.syncDaemonState.id, 1))
-					.get();
-				const peers = d
-					.select({
-						peer_device_id: schema.syncPeers.peer_device_id,
-						addresses_json: schema.syncPeers.addresses_json,
-						pinned_fingerprint: schema.syncPeers.pinned_fingerprint,
-						public_key: schema.syncPeers.public_key,
-					})
-					.from(schema.syncPeers)
-					.all();
-
-				const issues: string[] = [];
-				const syncHost = typeof config.sync_host === "string" ? config.sync_host : "0.0.0.0";
-				const syncPort = typeof config.sync_port === "number" ? config.sync_port : 7337;
-				const viewerBinding = readViewerBinding(dbPath);
-
-				console.log("Sync doctor");
-				console.log(`- Enabled: ${config.sync_enabled === true}`);
-				console.log(`- Listen: ${syncHost}:${syncPort}`);
-				console.log(`- mDNS: ${process.env.CODEMEM_SYNC_MDNS ? "env-configured" : "default/off"}`);
-
-				const reachable = viewerBinding
-					? await portOpen(viewerBinding.host, viewerBinding.port)
-					: false;
-				console.log(`- Daemon: ${reachable ? "running" : "not running"}`);
-				if (!reachable) issues.push("daemon not running");
-
-				if (!device) {
-					console.log("- Identity: missing (run `codemem sync enable`)");
-					issues.push("identity missing");
-				} else {
-					console.log(`- Identity: ${device.device_id}`);
-				}
-
-				if (
-					daemonState?.last_error &&
-					(!daemonState.last_ok_at || daemonState.last_ok_at < (daemonState.last_error_at ?? ""))
-				) {
-					console.log(
-						`- Daemon error: ${daemonState.last_error} (at ${daemonState.last_error_at ?? "unknown"})`,
-					);
-					issues.push("daemon error");
-				}
-
-				if (peers.length === 0) {
-					console.log("- Peers: none (pair a device first)");
-					issues.push("no peers");
-				} else {
-					console.log(`- Peers: ${peers.length}`);
-					for (const peer of peers) {
-						const addresses = peer.addresses_json
-							? (JSON.parse(peer.addresses_json) as string[])
-							: [];
-						const endpoint = parseStoredAddressEndpoint(addresses[0] ?? "");
-						const reach = endpoint
-							? (await portOpen(endpoint.host, endpoint.port))
-								? "ok"
-								: "unreachable"
-							: "unknown";
-						const pinned = Boolean(peer.pinned_fingerprint);
-						const hasKey = Boolean(peer.public_key);
-						console.log(
-							`  - ${peer.peer_device_id}: addresses=${addresses.length} reach=${reach} pinned=${pinned} public_key=${hasKey}`,
-						);
-						if (reach !== "ok") issues.push(`peer ${peer.peer_device_id} unreachable`);
-						if (!pinned || !hasKey) issues.push(`peer ${peer.peer_device_id} not pinned`);
-					}
-				}
-
-				if (!config.sync_enabled) issues.push("sync is disabled");
-
-				if (issues.length > 0) {
-					console.log(`WARN: ${[...new Set(issues)].slice(0, 3).join(", ")}`);
-				} else {
-					console.log("OK: sync looks healthy");
-				}
-			} finally {
-				store.close();
-			}
-		}),
-);
-
-// codemem sync status
-syncCommand.addCommand(
-	new Command("status")
-		.configureHelp(helpStyle)
-		.description("Show sync configuration and peer summary")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--config <path>", "config path")
-		.option("--json", "output as JSON")
-		.action((opts: { db?: string; dbPath?: string; config?: string; json?: boolean }) => {
-			const config = readCliConfig(opts.config);
-			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-			try {
-				const d = drizzle(store.db, { schema });
-				const deviceRow = d
-					.select({
-						device_id: schema.syncDevice.device_id,
-						fingerprint: schema.syncDevice.fingerprint,
-					})
-					.from(schema.syncDevice)
-					.limit(1)
-					.get();
-				const peers = d
-					.select({
-						peer_device_id: schema.syncPeers.peer_device_id,
-						name: schema.syncPeers.name,
-						last_sync_at: schema.syncPeers.last_sync_at,
-						last_error: schema.syncPeers.last_error,
-					})
-					.from(schema.syncPeers)
-					.all();
-
-				if (opts.json) {
-					console.log(
-						JSON.stringify(
-							{
-								enabled: config.sync_enabled === true,
-								host: config.sync_host ?? "0.0.0.0",
-								port: config.sync_port ?? 7337,
-								interval_s: config.sync_interval_s ?? 120,
-								device_id: deviceRow?.device_id ?? null,
-								fingerprint: deviceRow?.fingerprint ?? null,
-								coordinator_url: config.sync_coordinator_url ?? null,
-								peers: peers.map((peer) => ({
-									device_id: peer.peer_device_id,
-									name: peer.name,
-									last_sync: peer.last_sync_at,
-									status: peer.last_error ?? "ok",
-								})),
-							},
-							null,
-							2,
-						),
-					);
-					return;
-				}
-
-				p.intro("codemem sync status");
-				p.log.info(
-					[
-						`Enabled:    ${config.sync_enabled === true ? "yes" : "no"}`,
-						`Host:       ${config.sync_host ?? "0.0.0.0"}`,
-						`Port:       ${config.sync_port ?? 7337}`,
-						`Interval:   ${config.sync_interval_s ?? 120}s`,
-						`Coordinator: ${config.sync_coordinator_url ?? "(not configured)"}`,
-					].join("\n"),
-				);
-				if (deviceRow) {
-					p.log.info(`Device ID:   ${deviceRow.device_id}\nFingerprint: ${deviceRow.fingerprint}`);
-				} else {
-					p.log.warn("Device identity not initialized (run `codemem sync enable`)");
-				}
-				if (peers.length === 0) {
-					p.log.info("Peers: none");
-				} else {
-					for (const peer of peers) {
-						const label = peer.name || peer.peer_device_id;
-						p.log.message(
-							`  ${label}: last_sync=${peer.last_sync_at ?? "never"}, status=${peer.last_error ?? "ok"}`,
-						);
-					}
-				}
-				p.outro(`${peers.length} peer(s)`);
-			} finally {
-				store.close();
-			}
-		}),
-);
-
-// codemem sync enable
-syncCommand.addCommand(
-	new Command("enable")
-		.configureHelp(helpStyle)
-		.description("Enable sync and initialize device identity")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--config <path>", "config path")
-		.option("--host <host>", "sync listen host")
-		.option("--port <port>", "sync listen port")
-		.option("--interval <seconds>", "sync interval in seconds")
-		.action(
-			(opts: {
-				db?: string;
-				dbPath?: string;
-				config?: string;
-				host?: string;
-				port?: string;
-				interval?: string;
-			}) => {
-				const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-				try {
-					const [deviceId, fingerprint] = ensureDeviceIdentity(store.db);
-					const config = readCliConfig(opts.config);
-					config.sync_enabled = true;
-					if (opts.host) config.sync_host = opts.host;
-					const syncPort = parsePositiveIntegerOption(opts.port, "--port");
-					const syncInterval = parsePositiveIntegerOption(opts.interval, "--interval");
-					if (syncPort != null) config.sync_port = syncPort;
-					if (syncInterval != null) config.sync_interval_s = syncInterval;
-					writeCliConfig(config, opts.config);
-
-					p.intro("codemem sync enable");
-					p.log.success(
-						[
-							`Device ID:   ${deviceId}`,
-							`Fingerprint: ${fingerprint}`,
-							`Host:        ${config.sync_host ?? "0.0.0.0"}`,
-							`Port:        ${config.sync_port ?? 7337}`,
-							`Interval:    ${config.sync_interval_s ?? 120}s`,
-						].join("\n"),
-					);
-					p.outro("Sync enabled — restart `codemem serve` to activate");
-				} finally {
-					store.close();
-				}
-			},
-		),
-);
-
-// codemem sync disable
-syncCommand.addCommand(
-	new Command("disable")
-		.configureHelp(helpStyle)
-		.description("Disable sync without deleting keys or peers")
-		.option("--config <path>", "config path")
-		.action((opts: { config?: string }) => {
-			const config = readCliConfig(opts.config);
-			config.sync_enabled = false;
-			writeCliConfig(config, opts.config);
-			p.intro("codemem sync disable");
-			p.outro("Sync disabled — restart `codemem serve` to take effect");
-		}),
-);
-
-// codemem sync peers
-const peersCommand = new Command("peers")
+const attemptsCmd = new Command("attempts")
 	.configureHelp(helpStyle)
-	.description("List known sync peers")
-	.option("--db <path>", "database path")
-	.option("--db-path <path>", "database path")
-	.option("--json", "output as JSON")
-	.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
-		const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
+	.description("Show recent sync attempts")
+	.option("--limit <n>", "max attempts", "10");
+addDbOption(attemptsCmd);
+addJsonOption(attemptsCmd);
+attemptsCmd.action((opts: { db?: string; dbPath?: string; limit: string; json?: boolean }) => {
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const d = drizzle(store.db, { schema });
+		const limit = parseAttemptsLimit(opts.limit);
+		const rows = d
+			.select({
+				peer_device_id: schema.syncAttempts.peer_device_id,
+				ok: schema.syncAttempts.ok,
+				ops_in: schema.syncAttempts.ops_in,
+				ops_out: schema.syncAttempts.ops_out,
+				error: schema.syncAttempts.error,
+				finished_at: schema.syncAttempts.finished_at,
+			})
+			.from(schema.syncAttempts)
+			.orderBy(desc(schema.syncAttempts.finished_at))
+			.limit(limit)
+			.all();
+
+		if (opts.json) {
+			console.log(JSON.stringify(rows, null, 2));
+			return;
+		}
+
+		for (const row of rows) {
+			console.log(formatSyncAttempt(row));
+		}
+	} finally {
+		store.close();
+	}
+});
+syncCommand.addCommand(attemptsCmd);
+
+// ---- sync start/stop/restart [deprecated] ----
+
+function addDeprecatedLifecycleCommand(action: "start" | "stop" | "restart") {
+	const cmd = new Command(action)
+		.configureHelp(helpStyle)
+		.description(`[deprecated] ${action} sync daemon — use 'codemem serve ${action}'`);
+	addDbOption(cmd);
+	addConfigOption(cmd);
+	addViewerHostOptions(cmd);
+	addLegacyServiceFlags(cmd);
+	cmd.action(async (opts: SyncLifecycleOptions) => {
+		emitDeprecationWarning(`codemem sync ${action}`, `codemem serve ${action}`);
+		await runServeLifecycle(action, opts);
+	});
+	syncCommand.addCommand(cmd, { hidden: true });
+}
+
+addDeprecatedLifecycleCommand("start");
+addDeprecatedLifecycleCommand("stop");
+addDeprecatedLifecycleCommand("restart");
+
+// ---- sync once ----
+
+const onceCmd = new Command("once")
+	.configureHelp(helpStyle)
+	.description("Run a single sync pass")
+	.option("--peer <peer>", "peer device id or name");
+addDbOption(onceCmd);
+addJsonOption(onceCmd);
+onceCmd.action(async (opts: { db?: string; dbPath?: string; peer?: string; json?: boolean }) => {
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+		syncPassPreflight(store.db);
+		const d = drizzle(store.db, { schema });
+		const rows = opts.peer
+			? (() => {
+					const deviceMatches = d
+						.select({ peer_device_id: schema.syncPeers.peer_device_id })
+						.from(schema.syncPeers)
+						.where(eq(schema.syncPeers.peer_device_id, opts.peer))
+						.all();
+					if (deviceMatches.length > 0) return deviceMatches;
+					const nameMatches = d
+						.select({ peer_device_id: schema.syncPeers.peer_device_id })
+						.from(schema.syncPeers)
+						.where(eq(schema.syncPeers.name, opts.peer))
+						.all();
+					if (nameMatches.length > 1) {
+						if (opts.json) {
+							emitJsonError("ambiguous_peer", `Peer name is ambiguous: ${opts.peer}`);
+							return [];
+						}
+						p.log.error(`Peer name is ambiguous: ${opts.peer}`);
+						process.exitCode = 1;
+						return [];
+					}
+					return nameMatches;
+				})()
+			: d.select({ peer_device_id: schema.syncPeers.peer_device_id }).from(schema.syncPeers).all();
+
+		if (rows.length === 0) {
+			if (process.exitCode) return; // already set by ambiguous peer
+			if (opts.json) {
+				emitJsonError("no_peers", "No peers available for sync");
+				return;
+			}
+			p.log.warn("No peers available for sync");
+			process.exitCode = 1;
+			return;
+		}
+
+		let hadFailure = false;
+		const results: Array<{
+			peer_device_id: string;
+			ok: boolean;
+			error?: string;
+		}> = [];
+		for (const row of rows) {
+			const result = await runSyncPass(store.db, row.peer_device_id, { keysDir });
+			if (!result.ok) hadFailure = true;
+			results.push({
+				peer_device_id: row.peer_device_id,
+				ok: result.ok,
+				...(result.error ? { error: result.error } : {}),
+			});
+			if (!opts.json) {
+				console.log(formatSyncOnceResult(row.peer_device_id, result));
+			}
+		}
+		if (opts.json) {
+			console.log(JSON.stringify({ ok: !hadFailure, results }, null, 2));
+		}
+		if (hadFailure) {
+			process.exitCode = 1;
+		}
+	} finally {
+		store.close();
+	}
+});
+syncCommand.addCommand(onceCmd);
+
+// ---- sync pair ----
+
+const pairCmd = new Command("pair")
+	.configureHelp(helpStyle)
+	.description("Print pairing payload or accept a peer payload")
+	.option("--accept <json>", "accept pairing payload JSON from another device")
+	.option("--accept-file <path>", "accept pairing payload from file path, or '-' for stdin")
+	.option("--payload-only", "when generating pairing payload, print JSON only")
+	.option("--name <name>", "label for the peer")
+	.option("--address <host:port>", "override peer address (host:port)")
+	.option("--include <projects>", "outbound-only allowlist for accepted peer")
+	.option("--exclude <projects>", "outbound-only blocklist for accepted peer")
+	.option("--all", "with --accept, push all projects to that peer")
+	.option("--default", "with --accept, use default/global push filters");
+addDbOption(pairCmd);
+addConfigOption(pairCmd);
+addJsonOption(pairCmd);
+pairCmd.action(async (opts: SyncPairOptions) => {
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const acceptModeRequested = opts.accept != null || opts.acceptFile != null;
+		if (opts.payloadOnly && acceptModeRequested) {
+			if (opts.json) {
+				emitJsonError(
+					"usage_error",
+					"--payload-only cannot be combined with --accept or --accept-file",
+					2,
+				);
+				return;
+			}
+			p.log.error("--payload-only cannot be combined with --accept or --accept-file");
+			process.exitCode = 1;
+			return;
+		}
+		if (opts.accept && opts.acceptFile) {
+			if (opts.json) {
+				emitJsonError("usage_error", "Use only one of --accept or --accept-file", 2);
+				return;
+			}
+			p.log.error("Use only one of --accept or --accept-file");
+			process.exitCode = 1;
+			return;
+		}
+
+		let acceptText = opts.accept;
+		if (opts.acceptFile) {
+			try {
+				acceptText =
+					opts.acceptFile === "-"
+						? await new Promise<string>((resolve, reject) => {
+								let text = "";
+								process.stdin.setEncoding("utf8");
+								process.stdin.on("data", (chunk) => {
+									text += chunk;
+								});
+								process.stdin.on("end", () => resolve(text));
+								process.stdin.on("error", reject);
+							})
+						: readFileSync(opts.acceptFile, "utf8");
+			} catch (error) {
+				const msg =
+					error instanceof Error
+						? `Failed to read pairing payload from ${opts.acceptFile}: ${error.message}`
+						: `Failed to read pairing payload from ${opts.acceptFile}`;
+				if (opts.json) {
+					emitJsonError("read_error", msg);
+					return;
+				}
+				p.log.error(msg);
+				process.exitCode = 1;
+				return;
+			}
+		}
+
+		if (acceptModeRequested && !(acceptText ?? "").trim()) {
+			if (opts.json) {
+				emitJsonError(
+					"usage_error",
+					"Empty pairing payload; provide JSON via --accept or --accept-file",
+					2,
+				);
+				return;
+			}
+			p.log.error("Empty pairing payload; provide JSON via --accept or --accept-file");
+			process.exitCode = 1;
+			return;
+		}
+
+		if (!acceptText && (opts.include || opts.exclude || opts.all || opts.default)) {
+			if (opts.json) {
+				emitJsonError(
+					"usage_error",
+					"Project filters are outbound-only and must be set on the device running --accept",
+					2,
+				);
+				return;
+			}
+			p.log.error(
+				"Project filters are outbound-only and must be set on the device running --accept",
+			);
+			process.exitCode = 1;
+			return;
+		}
+
+		if (acceptText?.trim()) {
+			if (opts.all && opts.default) {
+				if (opts.json) {
+					emitJsonError("usage_error", "Use only one of --all or --default", 2);
+					return;
+				}
+				p.log.error("Use only one of --all or --default");
+				process.exitCode = 1;
+				return;
+			}
+			if ((opts.all || opts.default) && (opts.include || opts.exclude)) {
+				if (opts.json) {
+					emitJsonError(
+						"usage_error",
+						"--include/--exclude cannot be combined with --all/--default",
+						2,
+					);
+					return;
+				}
+				p.log.error("--include/--exclude cannot be combined with --all/--default");
+				process.exitCode = 1;
+				return;
+			}
+
+			let payload: Record<string, unknown>;
+			try {
+				payload = JSON.parse(acceptText) as Record<string, unknown>;
+			} catch (error) {
+				const msg =
+					error instanceof Error
+						? `Invalid pairing payload: ${error.message}`
+						: "Invalid pairing payload";
+				if (opts.json) {
+					emitJsonError("invalid_payload", msg);
+					return;
+				}
+				p.log.error(msg);
+				process.exitCode = 1;
+				return;
+			}
+
+			const deviceId = String(payload.device_id || "").trim();
+			const fingerprint = String(payload.fingerprint || "").trim();
+			const publicKey = String(payload.public_key || "").trim();
+			const resolvedAddresses = opts.address?.trim()
+				? [opts.address.trim()]
+				: Array.isArray(payload.addresses)
+					? (payload.addresses as unknown[])
+							.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+							.map((item) => item.trim())
+					: [];
+			if (!deviceId || !fingerprint || !publicKey || resolvedAddresses.length === 0) {
+				const msg = "Pairing payload missing device_id, fingerprint, public_key, or addresses";
+				if (opts.json) {
+					emitJsonError("invalid_payload", msg);
+					return;
+				}
+				p.log.error(msg);
+				process.exitCode = 1;
+				return;
+			}
+			if (fingerprintPublicKey(publicKey) !== fingerprint) {
+				if (opts.json) {
+					emitJsonError("fingerprint_mismatch", "Pairing payload fingerprint mismatch");
+					return;
+				}
+				p.log.error("Pairing payload fingerprint mismatch");
+				process.exitCode = 1;
+				return;
+			}
+
+			updatePeerAddresses(store.db, deviceId, resolvedAddresses, {
+				name: opts.name,
+				pinnedFingerprint: fingerprint,
+				publicKey,
+			});
+
+			if (opts.default) {
+				setPeerProjectFilter(store.db, deviceId, { include: null, exclude: null });
+			} else if (opts.all || opts.include || opts.exclude) {
+				setPeerProjectFilter(store.db, deviceId, {
+					include: opts.all ? [] : parseProjectList(opts.include),
+					exclude: opts.all ? [] : parseProjectList(opts.exclude),
+				});
+			}
+
+			if (opts.json) {
+				console.log(JSON.stringify({ ok: true, peer_device_id: deviceId }));
+				return;
+			}
+			p.log.success(`Paired with ${deviceId}`);
+			return;
+		}
+
+		const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+		const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, { keysDir });
+		const publicKey = loadPublicKey(keysDir);
+		if (!publicKey) {
+			if (opts.json) {
+				emitJsonError("missing_key", "Public key missing");
+				return;
+			}
+			p.log.error("Public key missing");
+			process.exitCode = 1;
+			return;
+		}
+
+		const config = readCliConfig(opts.config);
+		const explicitAddress = opts.address?.trim();
+		const configuredHost = typeof config.sync_host === "string" ? config.sync_host : null;
+		const configuredPort = typeof config.sync_port === "number" ? config.sync_port : 7337;
+		const addresses = collectAdvertiseAddresses(
+			explicitAddress ?? null,
+			configuredHost,
+			configuredPort,
+			networkInterfaces(),
+		);
+		const payloadObj = {
+			device_id: deviceId,
+			fingerprint,
+			public_key: publicKey,
+			address: addresses[0] ?? "",
+			addresses,
+		};
+		const payloadText = JSON.stringify(payloadObj);
+
+		if (opts.payloadOnly || opts.json) {
+			process.stdout.write(`${payloadText}\n`);
+			return;
+		}
+
+		const escaped = payloadText.replaceAll("'", "'\\''");
+		console.log("Pairing payload");
+		console.log(payloadText);
+		console.log("On the other device, save this JSON to pairing.json, then run:");
+		console.log("  codemem sync pair --accept-file pairing.json");
+		console.log("If you prefer inline JSON, run:");
+		console.log(`  codemem sync pair --accept '${escaped}'`);
+		console.log("For machine-friendly output next time, run:");
+		console.log("  codemem sync pair --payload-only");
+		console.log(
+			"On the accepting device, --include/--exclude control both what it sends and what it accepts from that peer.",
+		);
+	} finally {
+		store.close();
+	}
+});
+syncCommand.addCommand(pairCmd);
+
+// ---- sync doctor ----
+
+const doctorCmd = new Command("doctor")
+	.configureHelp(helpStyle)
+	.description("Diagnose common sync setup and connectivity issues");
+addDbOption(doctorCmd);
+addConfigOption(doctorCmd);
+addJsonOption(doctorCmd);
+doctorCmd.action(
+	async (opts: { db?: string; dbPath?: string; config?: string; json?: boolean }) => {
+		const config = readCliConfig(opts.config);
+		const dbPath = resolveDbPath(resolveDbOpt(opts));
+		const store = new MemoryStore(dbPath);
 		try {
 			const d = drizzle(store.db, { schema });
+			const device = d
+				.select({ device_id: schema.syncDevice.device_id })
+				.from(schema.syncDevice)
+				.limit(1)
+				.get();
+			const daemonState = d
+				.select()
+				.from(schema.syncDaemonState)
+				.where(eq(schema.syncDaemonState.id, 1))
+				.get();
 			const peers = d
 				.select({
 					peer_device_id: schema.syncPeers.peer_device_id,
-					name: schema.syncPeers.name,
-					addresses: schema.syncPeers.addresses_json,
-					last_sync_at: schema.syncPeers.last_sync_at,
-					last_error: schema.syncPeers.last_error,
+					addresses_json: schema.syncPeers.addresses_json,
+					pinned_fingerprint: schema.syncPeers.pinned_fingerprint,
+					public_key: schema.syncPeers.public_key,
 				})
 				.from(schema.syncPeers)
-				.orderBy(desc(schema.syncPeers.last_sync_at))
 				.all();
 
+			const issues: string[] = [];
+			const syncHost = typeof config.sync_host === "string" ? config.sync_host : "0.0.0.0";
+			const syncPort = typeof config.sync_port === "number" ? config.sync_port : 7337;
+			const viewerBinding = readViewerBinding(dbPath);
+
+			const reachable = viewerBinding
+				? await portOpen(viewerBinding.host, viewerBinding.port)
+				: false;
+
+			if (!reachable) issues.push("daemon not running");
+			if (!device) issues.push("identity missing");
+			if (
+				daemonState?.last_error &&
+				(!daemonState.last_ok_at || daemonState.last_ok_at < (daemonState.last_error_at ?? ""))
+			) {
+				issues.push("daemon error");
+			}
+			if (peers.length === 0) issues.push("no peers");
+			if (!config.sync_enabled) issues.push("sync is disabled");
+
+			const peerDetails: Array<{
+				peer_device_id: string;
+				addresses: number;
+				reachable: string;
+				pinned: boolean;
+				has_public_key: boolean;
+			}> = [];
+
+			for (const peer of peers) {
+				const addresses = peer.addresses_json ? (JSON.parse(peer.addresses_json) as string[]) : [];
+				const endpoint = parseStoredAddressEndpoint(addresses[0] ?? "");
+				const reach = endpoint
+					? (await portOpen(endpoint.host, endpoint.port))
+						? "ok"
+						: "unreachable"
+					: "unknown";
+				const pinned = Boolean(peer.pinned_fingerprint);
+				const hasKey = Boolean(peer.public_key);
+				peerDetails.push({
+					peer_device_id: peer.peer_device_id,
+					addresses: addresses.length,
+					reachable: reach,
+					pinned,
+					has_public_key: hasKey,
+				});
+				if (reach !== "ok") issues.push(`peer ${peer.peer_device_id} unreachable`);
+				if (!pinned || !hasKey) issues.push(`peer ${peer.peer_device_id} not pinned`);
+			}
+
 			if (opts.json) {
-				console.log(JSON.stringify(peers, null, 2));
+				console.log(
+					JSON.stringify({
+						enabled: config.sync_enabled === true,
+						listen: `${syncHost}:${syncPort}`,
+						mdns: process.env.CODEMEM_SYNC_MDNS ? "env-configured" : "default/off",
+						daemon: reachable ? "running" : "not running",
+						identity: device?.device_id ?? null,
+						daemon_error: daemonState?.last_error ?? null,
+						peers: peerDetails,
+						issues: [...new Set(issues)],
+						ok: issues.length === 0,
+					}),
+				);
 				return;
 			}
 
-			p.intro("codemem sync peers");
-			if (peers.length === 0) {
-				p.outro("No peers configured");
-				return;
+			console.log("Sync doctor");
+			console.log(`- Enabled: ${config.sync_enabled === true}`);
+			console.log(`- Listen: ${syncHost}:${syncPort}`);
+			console.log(`- mDNS: ${process.env.CODEMEM_SYNC_MDNS ? "env-configured" : "default/off"}`);
+			console.log(`- Daemon: ${reachable ? "running" : "not running"}`);
+
+			if (!device) {
+				console.log("- Identity: missing (run `codemem sync enable`)");
+			} else {
+				console.log(`- Identity: ${device.device_id}`);
 			}
-			for (const peer of peers) {
-				const label = peer.name || peer.peer_device_id;
-				const addrs = peer.addresses || "(no addresses)";
-				p.log.message(
-					`${label}\n  addresses: ${addrs}\n  last_sync: ${peer.last_sync_at ?? "never"}\n  status: ${peer.last_error ?? "ok"}`,
+
+			if (
+				daemonState?.last_error &&
+				(!daemonState.last_ok_at || daemonState.last_ok_at < (daemonState.last_error_at ?? ""))
+			) {
+				console.log(
+					`- Daemon error: ${daemonState.last_error} (at ${daemonState.last_error_at ?? "unknown"})`,
 				);
 			}
-			p.outro(`${peers.length} peer(s)`);
+
+			if (peers.length === 0) {
+				console.log("- Peers: none (pair a device first)");
+			} else {
+				console.log(`- Peers: ${peers.length}`);
+				for (const detail of peerDetails) {
+					console.log(
+						`  - ${detail.peer_device_id}: addresses=${detail.addresses} reach=${detail.reachable} pinned=${detail.pinned} public_key=${detail.has_public_key}`,
+					);
+				}
+			}
+
+			if (issues.length > 0) {
+				console.log(`WARN: ${[...new Set(issues)].slice(0, 3).join(", ")}`);
+			} else {
+				console.log("OK: sync looks healthy");
+			}
 		} finally {
 			store.close();
 		}
-	});
-
-peersCommand.addCommand(
-	new Command("remove")
-		.configureHelp(helpStyle)
-		.description("Remove a sync peer by device id or exact name")
-		.argument("<peer>", "peer device id or exact name")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--json", "output as JSON")
-		.action((peerRef: string, opts: { db?: string; dbPath?: string; json?: boolean }) => {
-			const store = new MemoryStore(resolveDbPath(opts.db ?? opts.dbPath));
-			try {
-				const d = drizzle(store.db, { schema });
-				const match = resolvePeerMatch(d, peerRef);
-				if (match === "ambiguous") {
-					p.log.error(`Peer name is ambiguous: ${peerRef.trim()}`);
-					process.exitCode = 1;
-					return;
-				}
-				if (!match) {
-					p.log.error(`Peer not found: ${peerRef.trim()}`);
-					process.exitCode = 1;
-					return;
-				}
-				d.delete(schema.replicationCursors)
-					.where(eq(schema.replicationCursors.peer_device_id, match.peer_device_id))
-					.run();
-				d.delete(schema.syncPeers)
-					.where(eq(schema.syncPeers.peer_device_id, match.peer_device_id))
-					.run();
-				const payload = {
-					ok: true,
-					peer_device_id: match.peer_device_id,
-					name: match.name,
-				};
-				if (opts.json) {
-					console.log(JSON.stringify(payload, null, 2));
-					return;
-				}
-				p.intro("codemem sync peers remove");
-				p.log.success(`Removed peer ${match.name || match.peer_device_id}`);
-				p.outro(match.peer_device_id);
-			} finally {
-				store.close();
-			}
-		}),
+	},
 );
+syncCommand.addCommand(doctorCmd);
 
-syncCommand.addCommand(peersCommand);
+// ---- sync status ----
 
-// codemem sync bootstrap --peer <device-id>
-syncCommand.addCommand(
-	new Command("bootstrap")
-		.configureHelp(helpStyle)
-		.description("Fast-bootstrap memories from a peer (full snapshot transfer)")
-		.requiredOption("--peer <device-id>", "peer device ID to bootstrap from")
-		.option("--bootstrap-grant <grant-id>", "bootstrap grant id for seed-authorized bootstrap")
-		.option("--page-size <n>", "items per snapshot page (default: 2000)", "2000")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--keys-dir <path>", "keys directory")
-		.option("--force", "skip dirty-local-state safety check")
-		.option("--json", "output as JSON")
-		.action(
-			async (opts: {
-				peer: string;
-				bootstrapGrant?: string;
-				pageSize: string;
-				db?: string;
-				dbPath?: string;
-				keysDir?: string;
-				force?: boolean;
-				json?: boolean;
-			}) => {
-				const dbPath = resolveDbPath(opts.db ?? opts.dbPath);
-				const store = new MemoryStore(dbPath);
-				try {
-					const peerDeviceId = opts.peer.trim();
-					const pageSize = Math.max(1, Number.parseInt(opts.pageSize, 10) || 2000);
-					const keysDir = opts.keysDir ?? undefined;
-					const d = drizzle(store.db, { schema });
-
-					// Look up peer
-					const peer = d
-						.select()
-						.from(schema.syncPeers)
-						.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
-						.get();
-					if (!peer) {
-						if (opts.json) {
-							console.log(JSON.stringify({ ok: false, error: "peer not found" }));
-						} else {
-							p.log.error(`Peer ${peerDeviceId} not found in sync_peers.`);
-						}
-						process.exitCode = 1;
-						return;
-					}
-					if (!peer.pinned_fingerprint) {
-						if (opts.json) {
-							console.log(JSON.stringify({ ok: false, error: "peer not pinned" }));
-						} else {
-							p.log.error(`Peer ${peerDeviceId} has no pinned fingerprint. Accept it first.`);
-						}
-						process.exitCode = 1;
-						return;
-					}
-
-					// Safety check
-					if (!opts.force) {
-						const dirty = hasUnsyncedSharedMemoryChanges(store.db);
-						if (dirty.dirty) {
-							if (opts.json) {
-								console.log(
-									JSON.stringify({
-										ok: false,
-										error: "local_unsynced_changes",
-										count: dirty.count,
-									}),
-								);
-							} else {
-								p.log.error(
-									`${dirty.count} unsynced shared memory change(s) would be lost. Use --force to override.`,
-								);
-							}
-							process.exitCode = 1;
-							return;
-						}
-					}
-
-					// Resolve device identity
-					const [deviceId] = ensureDeviceIdentity(store.db, { keysDir });
-
-					// Get peer status to obtain reset boundary
-					const addresses = JSON.parse(String(peer.addresses_json ?? "[]")) as string[];
-					if (!addresses.length) {
-						if (opts.json) {
-							console.log(JSON.stringify({ ok: false, error: "no peer addresses" }));
-						} else {
-							p.log.error("Peer has no known addresses. Run a sync first or add addresses.");
-						}
-						process.exitCode = 1;
-						return;
-					}
-
-					let boundary: {
-						generation: number;
-						snapshot_id: string;
-						baseline_cursor: string | null;
-					} | null = null;
-					let baseUrl = "";
-					const addressResults: Array<{ address: string; result: string }> = [];
-
-					for (const address of addresses) {
-						const candidate = buildBaseUrl(address);
-						if (!candidate) continue;
-						const statusUrl = `${candidate}/v1/status`;
-						const headers = buildAuthHeaders({
-							deviceId,
-							method: "GET",
-							url: statusUrl,
-							bodyBytes: Buffer.alloc(0),
-							bootstrapGrantId: opts.bootstrapGrant,
-							keysDir,
-						});
-						try {
-							const [code, payload] = await requestJson("GET", statusUrl, { headers });
-							if (code !== 200 || !payload) {
-								addressResults.push({ address: candidate, result: `status ${code}` });
-								continue;
-							}
-							if (payload.fingerprint !== peer.pinned_fingerprint) {
-								addressResults.push({ address: candidate, result: "fingerprint mismatch" });
-								continue;
-							}
-							const reset = payload.sync_reset as Record<string, unknown> | undefined;
-							if (
-								reset &&
-								typeof reset.generation === "number" &&
-								typeof reset.snapshot_id === "string"
-							) {
-								boundary = {
-									generation: reset.generation,
-									snapshot_id: reset.snapshot_id,
-									baseline_cursor:
-										typeof reset.baseline_cursor === "string" ? reset.baseline_cursor : null,
-								};
-								baseUrl = candidate;
-								addressResults.push({ address: candidate, result: "ok" });
-								break;
-							}
-							addressResults.push({ address: candidate, result: "missing sync_reset boundary" });
-						} catch (err) {
-							addressResults.push({
-								address: candidate,
-								result: err instanceof Error ? err.message : String(err),
-							});
-						}
-					}
-
-					if (!boundary || !baseUrl) {
-						const summary = addressResults.map((r) => `${r.address}: ${r.result}`).join("; ");
-						const detail = summary
-							? `no reachable peer with valid reset boundary. Tried: ${summary}`
-							: "peer unreachable or missing reset boundary";
-						if (opts.json) {
-							console.log(JSON.stringify({ ok: false, error: detail, addresses: addressResults }));
-						} else {
-							p.log.error(detail);
-						}
-						process.exitCode = 1;
-						return;
-					}
-
-					if (!opts.json) {
-						p.intro("codemem sync bootstrap");
-						p.log.step(`Bootstrapping from ${peer.name || peerDeviceId}...`);
-					}
-
-					const resetInfo = {
-						generation: boundary.generation,
-						snapshot_id: boundary.snapshot_id,
-						baseline_cursor: boundary.baseline_cursor,
-						retained_floor_cursor: null,
-						reset_required: true as const,
-						reason: "initial_bootstrap" as const,
-					};
-
-					const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
-						keysDir,
-						bootstrapGrantId: opts.bootstrapGrant,
-						pageSize,
-					});
-
-					const result = applyBootstrapSnapshot(store.db, peerDeviceId, items, resetInfo);
-
-					if (opts.json) {
-						console.log(
-							JSON.stringify({
-								ok: result.ok,
-								applied: result.applied,
-								deleted: result.deleted,
-								error: result.error ?? null,
-							}),
-						);
-					} else {
-						if (result.ok) {
-							p.log.success(
-								`Applied ${result.applied} memories (removed ${result.deleted} stale).`,
-							);
-						} else {
-							p.log.error(result.error || "Bootstrap apply failed.");
-						}
-						p.outro(result.ok ? "Bootstrap complete" : "Bootstrap failed");
-					}
-					if (!result.ok) process.exitCode = 1;
-				} finally {
-					store.close();
-				}
-			},
-		),
-);
-
-// codemem sync connect <coordinator-url>
-syncCommand.addCommand(
-	new Command("connect")
-		.configureHelp(helpStyle)
-		.description("Configure coordinator URL for cloud sync")
-		.argument("<url>", "coordinator URL (e.g. https://coordinator.example.com)")
-		.option("--group <group>", "sync group ID")
-		.option("--config <path>", "config path")
-		.action((url: string, opts: { group?: string; config?: string }) => {
-			const config = readCliConfig(opts.config);
-			config.sync_coordinator_url = url.trim();
-			if (opts.group) config.sync_coordinator_group = opts.group.trim();
-			writeCliConfig(config, opts.config);
-			p.intro("codemem sync connect");
-			p.log.success(`Coordinator: ${url.trim()}`);
-			if (opts.group) p.log.info(`Group: ${opts.group.trim()}`);
-			p.outro("Restart `codemem serve` to activate coordinator sync");
-		}),
-);
-
-const coordinatorCommand = new Command("coordinator")
+const statusCmd = new Command("status")
 	.configureHelp(helpStyle)
-	.description("Manage coordinator invites, join requests, and relay server");
+	.description("Show sync configuration and peer summary");
+addDbOption(statusCmd);
+addConfigOption(statusCmd);
+addJsonOption(statusCmd);
+statusCmd.action((opts: { db?: string; dbPath?: string; config?: string; json?: boolean }) => {
+	const config = readCliConfig(opts.config);
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const d = drizzle(store.db, { schema });
+		const deviceRow = d
+			.select({
+				device_id: schema.syncDevice.device_id,
+				fingerprint: schema.syncDevice.fingerprint,
+			})
+			.from(schema.syncDevice)
+			.limit(1)
+			.get();
+		const peers = d
+			.select({
+				peer_device_id: schema.syncPeers.peer_device_id,
+				name: schema.syncPeers.name,
+				last_sync_at: schema.syncPeers.last_sync_at,
+				last_error: schema.syncPeers.last_error,
+			})
+			.from(schema.syncPeers)
+			.all();
 
-coordinatorCommand.addCommand(
-	new Command("group-create")
-		.configureHelp(helpStyle)
-		.description("Create a coordinator group in the local store")
-		.argument("<group>", "group id")
-		.option("--name <name>", "display name override")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				groupId: string,
-				opts: { name?: string; db?: string; dbPath?: string; json?: boolean },
-			) => {
-				const group = await coordinatorCreateGroupAction({
-					groupId,
-					displayName: opts.name?.trim() || null,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-				});
-				if (opts.json) {
-					console.log(JSON.stringify(group, null, 2));
-					return;
-				}
-				p.intro("codemem sync coordinator group-create");
-				p.log.success(`Group ready: ${groupId.trim()}`);
-				p.outro(String(group.display_name ?? group.group_id ?? groupId.trim()));
-			},
-		),
-);
+		if (opts.json) {
+			console.log(
+				JSON.stringify(
+					{
+						enabled: config.sync_enabled === true,
+						host: config.sync_host ?? "0.0.0.0",
+						port: config.sync_port ?? 7337,
+						interval_s: config.sync_interval_s ?? 120,
+						device_id: deviceRow?.device_id ?? null,
+						fingerprint: deviceRow?.fingerprint ?? null,
+						coordinator_url: config.sync_coordinator_url ?? null,
+						peers: peers.map((peer) => ({
+							device_id: peer.peer_device_id,
+							name: peer.name,
+							last_sync: peer.last_sync_at,
+							status: peer.last_error ?? "ok",
+						})),
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
 
-coordinatorCommand.addCommand(
-	new Command("list-groups")
-		.configureHelp(helpStyle)
-		.description("List coordinator groups from the local store")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--json", "output as JSON")
-		.action(async (opts: { db?: string; dbPath?: string; json?: boolean }) => {
-			const groups = await coordinatorListGroupsAction({ dbPath: opts.db ?? opts.dbPath ?? null });
-			if (opts.json) {
-				console.log(JSON.stringify(groups, null, 2));
-				return;
-			}
-			p.intro("codemem sync coordinator list-groups");
-			if (groups.length === 0) {
-				p.outro("No coordinator groups found");
-				return;
-			}
-			for (const group of groups) {
+		p.intro("codemem sync status");
+		p.log.info(
+			[
+				`Enabled:    ${config.sync_enabled === true ? "yes" : "no"}`,
+				`Host:       ${config.sync_host ?? "0.0.0.0"}`,
+				`Port:       ${config.sync_port ?? 7337}`,
+				`Interval:   ${config.sync_interval_s ?? 120}s`,
+				`Coordinator: ${config.sync_coordinator_url ?? "(not configured)"}`,
+			].join("\n"),
+		);
+		if (deviceRow) {
+			p.log.info(`Device ID:   ${deviceRow.device_id}\nFingerprint: ${deviceRow.fingerprint}`);
+		} else {
+			p.log.warn("Device identity not initialized (run `codemem sync enable`)");
+		}
+		if (peers.length === 0) {
+			p.log.info("Peers: none");
+		} else {
+			for (const peer of peers) {
+				const label = peer.name || peer.peer_device_id;
 				p.log.message(
-					`- ${String(group.group_id ?? "")}${group.display_name ? ` (${String(group.display_name)})` : ""}`,
+					`  ${label}: last_sync=${peer.last_sync_at ?? "never"}, status=${peer.last_error ?? "ok"}`,
 				);
 			}
-			p.outro(`${groups.length} group(s)`);
-		}),
-);
+		}
+		p.outro(`${peers.length} peer(s)`);
+	} finally {
+		store.close();
+	}
+});
+syncCommand.addCommand(statusCmd);
 
-coordinatorCommand.addCommand(
-	new Command("enroll-device")
-		.configureHelp(helpStyle)
-		.description("Enroll a device in a local coordinator group")
-		.argument("<group>", "group id")
-		.argument("<device-id>", "device id")
-		.option("--fingerprint <fingerprint>", "device fingerprint")
-		.option("--public-key <key>", "device public key")
-		.option("--public-key-file <path>", "path to device public key")
-		.option("--name <name>", "display name")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				groupId: string,
-				deviceId: string,
-				opts: {
-					fingerprint?: string;
-					publicKey?: string;
-					publicKeyFile?: string;
-					name?: string;
-					db?: string;
-					dbPath?: string;
-					json?: boolean;
-				},
-			) => {
-				const publicKey = readCoordinatorPublicKey(opts);
-				const fingerprint = String(opts.fingerprint ?? "").trim();
-				if (!fingerprint) {
-					p.log.error("Fingerprint required via --fingerprint");
-					process.exitCode = 1;
-					return;
-				}
-				const actualFingerprint = fingerprintPublicKey(publicKey);
-				if (actualFingerprint !== fingerprint) {
-					p.log.error("Fingerprint does not match the provided public key");
-					process.exitCode = 1;
-					return;
-				}
-				const enrollment = await coordinatorEnrollDeviceAction({
-					groupId,
-					deviceId,
-					fingerprint,
-					publicKey,
-					displayName: opts.name?.trim() || null,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-				});
-				if (opts.json) {
-					console.log(JSON.stringify(enrollment, null, 2));
-					return;
-				}
-				p.intro("codemem sync coordinator enroll-device");
-				p.log.success(`Enrolled ${deviceId.trim()} in ${groupId.trim()}`);
-				p.outro(String(enrollment.display_name ?? enrollment.device_id ?? deviceId.trim()));
-			},
-		),
-);
+// ---- sync enable ----
 
-coordinatorCommand.addCommand(
-	new Command("list-devices")
-		.configureHelp(helpStyle)
-		.description("List enrolled devices in a local coordinator group")
-		.argument("<group>", "group id")
-		.option("--include-disabled", "include disabled devices")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				groupId: string,
-				opts: { includeDisabled?: boolean; db?: string; dbPath?: string; json?: boolean },
-			) => {
-				const rows = await coordinatorListDevicesAction({
-					groupId,
-					includeDisabled: opts.includeDisabled === true,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-				});
-				if (opts.json) {
-					console.log(JSON.stringify(rows, null, 2));
-					return;
-				}
-				p.intro("codemem sync coordinator list-devices");
-				if (rows.length === 0) {
-					p.outro(`No enrolled devices for ${groupId.trim()}`);
-					return;
-				}
-				for (const row of rows) {
-					const label =
-						String(row.display_name ?? row.device_id ?? "").trim() || String(row.device_id ?? "");
-					const enabled = Number(row.enabled ?? 1) === 1 ? "enabled" : "disabled";
-					p.log.message(`- ${label} (${String(row.device_id ?? "")}) ${enabled}`);
-				}
-				p.outro(`${rows.length} device(s)`);
-			},
-		),
-);
+const enableCmd = new Command("enable")
+	.configureHelp(helpStyle)
+	.description("Enable sync and initialize device identity")
+	.option("--sync-host <host>", "sync listen host")
+	.option("--sync-port <port>", "sync listen port")
+	.option("--interval <seconds>", "sync interval in seconds");
+addDbOption(enableCmd);
+addConfigOption(enableCmd);
+addJsonOption(enableCmd);
+// Hidden aliases for backwards compat
+enableCmd.addOption(new Option("--host <host>", "sync listen host").hideHelp());
+enableCmd.addOption(new Option("--port <port>", "sync listen port").hideHelp());
+enableCmd.action(
+	(opts: {
+		db?: string;
+		dbPath?: string;
+		config?: string;
+		syncHost?: string;
+		syncPort?: string;
+		host?: string;
+		port?: string;
+		interval?: string;
+		json?: boolean;
+	}) => {
+		// Emit deprecation warnings for legacy --host/--port
+		if (opts.host && !opts.syncHost) {
+			emitDeprecationWarning("--host on sync enable", "--sync-host");
+		}
+		if (opts.port && !opts.syncPort) {
+			emitDeprecationWarning("--port on sync enable", "--sync-port");
+		}
+		const effectiveHost = opts.syncHost ?? opts.host;
+		const effectivePort = opts.syncPort ?? opts.port;
 
-coordinatorCommand.addCommand(
-	new Command("rename-device")
-		.configureHelp(helpStyle)
-		.description("Rename an enrolled device in the local coordinator store")
-		.argument("<group>", "group id")
-		.argument("<device-id>", "device id")
-		.requiredOption("--name <name>", "display name")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				groupId: string,
-				deviceId: string,
-				opts: { name: string; db?: string; dbPath?: string; json?: boolean },
-			) => {
-				const result = await coordinatorRenameDeviceAction({
-					groupId,
-					deviceId,
-					displayName: opts.name.trim(),
-					dbPath: opts.db ?? opts.dbPath ?? null,
-				});
-				if (!result) {
-					p.log.error(`Device not found: ${deviceId.trim()}`);
-					process.exitCode = 1;
-					return;
-				}
-				if (opts.json) {
-					console.log(JSON.stringify(result, null, 2));
-					return;
-				}
-				p.intro("codemem sync coordinator rename-device");
-				p.log.success(`Renamed ${deviceId.trim()} in ${groupId.trim()}`);
-				p.outro(String(result.display_name ?? result.device_id ?? deviceId.trim()));
-			},
-		),
-);
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const [deviceId, fingerprint] = ensureDeviceIdentity(store.db);
+			const config = readCliConfig(opts.config);
+			config.sync_enabled = true;
+			if (effectiveHost) config.sync_host = effectiveHost;
+			const syncPort = parsePositiveIntegerOption(effectivePort, "--sync-port");
+			const syncInterval = parsePositiveIntegerOption(opts.interval, "--interval");
+			if (syncPort != null) config.sync_port = syncPort;
+			if (syncInterval != null) config.sync_interval_s = syncInterval;
+			writeCliConfig(config, opts.config);
 
-coordinatorCommand.addCommand(
-	new Command("disable-device")
-		.configureHelp(helpStyle)
-		.description("Disable an enrolled device in the local coordinator store")
-		.argument("<group>", "group id")
-		.argument("<device-id>", "device id")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				groupId: string,
-				deviceId: string,
-				opts: { db?: string; dbPath?: string; json?: boolean },
-			) => {
-				const ok = await coordinatorDisableDeviceAction({
-					groupId,
-					deviceId,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-				});
-				if (!ok) {
-					p.log.error(`Device not found: ${deviceId.trim()}`);
-					process.exitCode = 1;
-					return;
-				}
+			if (opts.json) {
+				console.log(
+					JSON.stringify({
+						ok: true,
+						device_id: deviceId,
+						fingerprint,
+						host: config.sync_host ?? "0.0.0.0",
+						port: config.sync_port ?? 7337,
+						interval_s: config.sync_interval_s ?? 120,
+					}),
+				);
+				return;
+			}
+
+			p.intro("codemem sync enable");
+			p.log.success(
+				[
+					`Device ID:   ${deviceId}`,
+					`Fingerprint: ${fingerprint}`,
+					`Host:        ${config.sync_host ?? "0.0.0.0"}`,
+					`Port:        ${config.sync_port ?? 7337}`,
+					`Interval:    ${config.sync_interval_s ?? 120}s`,
+				].join("\n"),
+			);
+			p.outro("Sync enabled — restart `codemem serve` to activate");
+		} finally {
+			store.close();
+		}
+	},
+);
+syncCommand.addCommand(enableCmd);
+
+// ---- sync disable ----
+
+const disableCmd = new Command("disable")
+	.configureHelp(helpStyle)
+	.description("Disable sync without deleting keys or peers");
+addConfigOption(disableCmd);
+disableCmd.action((opts: { config?: string }) => {
+	const config = readCliConfig(opts.config);
+	config.sync_enabled = false;
+	writeCliConfig(config, opts.config);
+	p.intro("codemem sync disable");
+	p.outro("Sync disabled — restart `codemem serve` to take effect");
+});
+syncCommand.addCommand(disableCmd);
+
+// ---- sync peers ----
+
+const peersCommand = new Command("peers")
+	.configureHelp(helpStyle)
+	.description("List known sync peers");
+addDbOption(peersCommand);
+addJsonOption(peersCommand);
+peersCommand.action((opts: { db?: string; dbPath?: string; json?: boolean }) => {
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const d = drizzle(store.db, { schema });
+		const peers = d
+			.select({
+				peer_device_id: schema.syncPeers.peer_device_id,
+				name: schema.syncPeers.name,
+				addresses: schema.syncPeers.addresses_json,
+				last_sync_at: schema.syncPeers.last_sync_at,
+				last_error: schema.syncPeers.last_error,
+			})
+			.from(schema.syncPeers)
+			.orderBy(desc(schema.syncPeers.last_sync_at))
+			.all();
+
+		if (opts.json) {
+			console.log(JSON.stringify(peers, null, 2));
+			return;
+		}
+
+		p.intro("codemem sync peers");
+		if (peers.length === 0) {
+			p.outro("No peers configured");
+			return;
+		}
+		for (const peer of peers) {
+			const label = peer.name || peer.peer_device_id;
+			const addrs = peer.addresses || "(no addresses)";
+			p.log.message(
+				`${label}\n  addresses: ${addrs}\n  last_sync: ${peer.last_sync_at ?? "never"}\n  status: ${peer.last_error ?? "ok"}`,
+			);
+		}
+		p.outro(`${peers.length} peer(s)`);
+	} finally {
+		store.close();
+	}
+});
+
+const peersRemoveCmd = new Command("remove")
+	.configureHelp(helpStyle)
+	.description("Remove a sync peer by device id or exact name")
+	.argument("<peer>", "peer device id or exact name");
+addDbOption(peersRemoveCmd);
+addJsonOption(peersRemoveCmd);
+peersRemoveCmd.action((peerRef: string, opts: { db?: string; dbPath?: string; json?: boolean }) => {
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const d = drizzle(store.db, { schema });
+		const match = resolvePeerMatch(d, peerRef);
+		if (match === "ambiguous") {
+			if (opts.json) {
+				emitJsonError("ambiguous_peer", `Peer name is ambiguous: ${peerRef.trim()}`);
+				return;
+			}
+			p.log.error(`Peer name is ambiguous: ${peerRef.trim()}`);
+			process.exitCode = 1;
+			return;
+		}
+		if (!match) {
+			if (opts.json) {
+				emitJsonError("peer_not_found", `Peer not found: ${peerRef.trim()}`);
+				return;
+			}
+			p.log.error(`Peer not found: ${peerRef.trim()}`);
+			process.exitCode = 1;
+			return;
+		}
+		d.delete(schema.replicationCursors)
+			.where(eq(schema.replicationCursors.peer_device_id, match.peer_device_id))
+			.run();
+		d.delete(schema.syncPeers)
+			.where(eq(schema.syncPeers.peer_device_id, match.peer_device_id))
+			.run();
+		const payload = {
+			ok: true,
+			peer_device_id: match.peer_device_id,
+			name: match.name,
+		};
+		if (opts.json) {
+			console.log(JSON.stringify(payload, null, 2));
+			return;
+		}
+		p.intro("codemem sync peers remove");
+		p.log.success(`Removed peer ${match.name || match.peer_device_id}`);
+		p.outro(match.peer_device_id);
+	} finally {
+		store.close();
+	}
+});
+peersCommand.addCommand(peersRemoveCmd);
+syncCommand.addCommand(peersCommand);
+
+// ---- sync bootstrap <peer-device-id> ----
+
+const bootstrapCmd = new Command("bootstrap")
+	.configureHelp(helpStyle)
+	.description("Fast-bootstrap memories from a peer (full snapshot transfer)")
+	.argument("[peer-device-id]", "peer device ID to bootstrap from")
+	.option("--bootstrap-grant <grant-id>", "bootstrap grant id for seed-authorized bootstrap")
+	.option("--page-size <n>", "items per snapshot page (default: 2000)", "2000")
+	.option("--keys-dir <path>", "keys directory")
+	.option("--force", "skip dirty-local-state safety check");
+addDbOption(bootstrapCmd);
+addJsonOption(bootstrapCmd);
+// Hidden alias for backwards compat
+bootstrapCmd.addOption(new Option("--peer <device-id>", "peer device ID").hideHelp());
+bootstrapCmd.action(
+	async (
+		peerArg: string | undefined,
+		opts: {
+			peer?: string;
+			bootstrapGrant?: string;
+			pageSize: string;
+			db?: string;
+			dbPath?: string;
+			keysDir?: string;
+			force?: boolean;
+			json?: boolean;
+		},
+	) => {
+		// Resolve peer from positional or hidden --peer alias
+		const peerDeviceId = (peerArg || opts.peer || "").trim();
+		if (!peerDeviceId) {
+			if (opts.json) {
+				emitJsonError("usage_error", "missing required argument: <peer-device-id>", 2);
+				return;
+			}
+			p.log.error("missing required argument: <peer-device-id>");
+			process.exitCode = 2;
+			return;
+		}
+
+		const dbPath = resolveDbPath(resolveDbOpt(opts));
+		const store = new MemoryStore(dbPath);
+		try {
+			const pageSize = Math.max(1, Number.parseInt(opts.pageSize, 10) || 2000);
+			const keysDir = opts.keysDir ?? undefined;
+			const d = drizzle(store.db, { schema });
+
+			// Look up peer
+			const peer = d
+				.select()
+				.from(schema.syncPeers)
+				.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
+				.get();
+			if (!peer) {
 				if (opts.json) {
-					console.log(
-						JSON.stringify(
-							{ ok: true, group_id: groupId.trim(), device_id: deviceId.trim() },
-							null,
-							2,
-						),
+					emitJsonError("peer_not_found", `Peer ${peerDeviceId} not found in sync_peers.`);
+				} else {
+					p.log.error(`Peer ${peerDeviceId} not found in sync_peers.`);
+				}
+				process.exitCode = 1;
+				return;
+			}
+			if (!peer.pinned_fingerprint) {
+				if (opts.json) {
+					emitJsonError(
+						"peer_not_pinned",
+						`Peer ${peerDeviceId} has no pinned fingerprint. Accept it first.`,
 					);
-					return;
+				} else {
+					p.log.error(`Peer ${peerDeviceId} has no pinned fingerprint. Accept it first.`);
 				}
-				p.intro("codemem sync coordinator disable-device");
-				p.log.success(`Disabled ${deviceId.trim()} in ${groupId.trim()}`);
-				p.outro("disabled");
-			},
-		),
-);
+				process.exitCode = 1;
+				return;
+			}
 
-coordinatorCommand.addCommand(
-	new Command("remove-device")
-		.configureHelp(helpStyle)
-		.description("Remove an enrolled device from the local coordinator store")
-		.argument("<group>", "group id")
-		.argument("<device-id>", "device id")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				groupId: string,
-				deviceId: string,
-				opts: { db?: string; dbPath?: string; json?: boolean },
-			) => {
-				const ok = await coordinatorRemoveDeviceAction({
-					groupId,
-					deviceId,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-				});
-				if (!ok) {
-					p.log.error(`Device not found: ${deviceId.trim()}`);
-					process.exitCode = 1;
-					return;
-				}
-				if (opts.json) {
-					console.log(
-						JSON.stringify(
-							{ ok: true, group_id: groupId.trim(), device_id: deviceId.trim() },
-							null,
-							2,
-						),
-					);
-					return;
-				}
-				p.intro("codemem sync coordinator remove-device");
-				p.log.success(`Removed ${deviceId.trim()} from ${groupId.trim()}`);
-				p.outro("removed");
-			},
-		),
-);
-
-coordinatorCommand.addCommand(
-	new Command("serve")
-		.configureHelp(helpStyle)
-		.description("Run the coordinator relay HTTP server")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--host <host>", "bind host", "127.0.0.1")
-		.option("--port <port>", "bind port", "7347")
-		.action(async (opts: { db?: string; dbPath?: string; host?: string; port?: string }) => {
-			const host = String(opts.host ?? "127.0.0.1").trim() || "127.0.0.1";
-			const port = Number.parseInt(String(opts.port ?? "7347"), 10);
-			const dbPath = opts.db ?? opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH;
-			const app = createBetterSqliteCoordinatorApp({ dbPath });
-			p.intro("codemem sync coordinator serve");
-			p.log.success(`Coordinator listening at http://${host}:${port}`);
-			p.log.info(`DB: ${dbPath}`);
-			honoServe({ fetch: app.fetch, hostname: host, port });
-		}),
-);
-
-coordinatorCommand.addCommand(
-	new Command("list-bootstrap-grants")
-		.configureHelp(helpStyle)
-		.description("List bootstrap grants for a coordinator group")
-		.argument("<group>", "group id")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--remote-url <url>", "remote coordinator URL override")
-		.option("--admin-secret <secret>", "remote coordinator admin secret override")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				groupId: string,
-				opts: {
-					db?: string;
-					dbPath?: string;
-					remoteUrl?: string;
-					adminSecret?: string;
-					json?: boolean;
-				},
-			) => {
-				const rows = await coordinatorListBootstrapGrantsAction({
-					groupId,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-					remoteUrl: opts.remoteUrl?.trim() || null,
-					adminSecret: opts.adminSecret?.trim() || null,
-				});
-				if (opts.json) {
-					console.log(JSON.stringify(rows, null, 2));
-					return;
-				}
-				p.intro("codemem sync coordinator list-bootstrap-grants");
-				if (rows.length === 0) {
-					p.outro(`No bootstrap grants for ${groupId.trim()}`);
-					return;
-				}
-				for (const row of rows) {
-					p.log.message(
-						`- ${row.grant_id} seed=${row.seed_device_id} worker=${row.worker_device_id} scope=${row.scope} expires=${row.expires_at} revoked=${row.revoked_at ?? "no"}`,
-					);
-				}
-				p.outro(`${rows.length} bootstrap grant(s)`);
-			},
-		),
-);
-
-coordinatorCommand.addCommand(
-	new Command("revoke-bootstrap-grant")
-		.configureHelp(helpStyle)
-		.description("Revoke a bootstrap grant")
-		.argument("<grant-id>", "bootstrap grant id")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--remote-url <url>", "remote coordinator URL override")
-		.option("--admin-secret <secret>", "remote coordinator admin secret override")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				grantId: string,
-				opts: {
-					db?: string;
-					dbPath?: string;
-					remoteUrl?: string;
-					adminSecret?: string;
-					json?: boolean;
-				},
-			) => {
-				const ok = await coordinatorRevokeBootstrapGrantAction({
-					grantId,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-					remoteUrl: opts.remoteUrl?.trim() || null,
-					adminSecret: opts.adminSecret?.trim() || null,
-				});
-				if (!ok) {
-					p.log.error(`Bootstrap grant not found: ${grantId.trim()}`);
-					process.exitCode = 1;
-					return;
-				}
-				if (opts.json) {
-					console.log(JSON.stringify({ ok: true, grant_id: grantId.trim() }, null, 2));
-					return;
-				}
-				p.intro("codemem sync coordinator revoke-bootstrap-grant");
-				p.log.success(`Revoked ${grantId.trim()}`);
-				p.outro("revoked");
-			},
-		),
-);
-
-coordinatorCommand.addCommand(
-	new Command("create-invite")
-		.configureHelp(helpStyle)
-		.description("Create a coordinator team invite")
-		.argument("[group]", "group id")
-		.option("--group <group>", "group id")
-		.option("--coordinator-url <url>", "coordinator URL override")
-		.option("--policy <policy>", "invite policy", "auto_admit")
-		.option("--ttl-hours <hours>", "invite TTL hours", "24")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--remote-url <url>", "remote coordinator URL override")
-		.option("--admin-secret <secret>", "remote coordinator admin secret override")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				groupArg: string | undefined,
-				opts: {
-					group?: string;
-					coordinatorUrl?: string;
-					policy?: string;
-					ttlHours?: string;
-					db?: string;
-					dbPath?: string;
-					remoteUrl?: string;
-					adminSecret?: string;
-					json?: boolean;
-				},
-			) => {
-				const ttlHours = Number.parseInt(String(opts.ttlHours ?? "24"), 10);
-				const groupId = String(opts.group ?? "").trim() || String(groupArg ?? "").trim();
-				const result = await coordinatorCreateInviteAction({
-					groupId,
-					coordinatorUrl: opts.coordinatorUrl?.trim() || null,
-					policy: String(opts.policy ?? "auto_admit").trim(),
-					ttlHours,
-					createdBy: null,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-					remoteUrl: opts.remoteUrl?.trim() || null,
-					adminSecret: opts.adminSecret?.trim() || null,
-				});
-				if (opts.json) {
-					console.log(JSON.stringify(result, null, 2));
-					return;
-				}
-				p.intro("codemem sync coordinator create-invite");
-				p.log.success(`Invite created for ${groupId}`);
-				if (typeof result.link === "string") p.log.message(`- link: ${result.link}`);
-				if (typeof result.encoded === "string") p.log.message(`- invite: ${result.encoded}`);
-				for (const warning of Array.isArray(result.warnings) ? result.warnings : []) {
-					p.log.warn(String(warning));
-				}
-				p.outro("Invite ready");
-			},
-		),
-);
-
-coordinatorCommand.addCommand(
-	new Command("import-invite")
-		.configureHelp(helpStyle)
-		.description("Import a coordinator invite")
-		.argument("<invite>", "invite value or link")
-		.option("--db <path>", "database path")
-		.option("--db-path <path>", "database path")
-		.option("--keys-dir <path>", "keys directory")
-		.option("--config <path>", "config path")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				invite: string,
-				opts: { db?: string; dbPath?: string; keysDir?: string; config?: string; json?: boolean },
-			) => {
-				const result = await coordinatorImportInviteAction({
-					inviteValue: invite,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-					keysDir: opts.keysDir ?? null,
-					configPath: opts.config ?? null,
-				});
-				if (opts.json) {
-					console.log(JSON.stringify(result, null, 2));
-					return;
-				}
-				p.intro("codemem sync coordinator import-invite");
-				p.log.success(`Invite imported for ${result.group_id}`);
-				p.log.message(`- coordinator: ${result.coordinator_url}`);
-				p.log.message(`- status: ${result.status}`);
-				p.outro("Coordinator config updated");
-			},
-		),
-);
-
-coordinatorCommand.addCommand(
-	new Command("list-join-requests")
-		.configureHelp(helpStyle)
-		.description("List pending coordinator join requests")
-		.argument("[group]", "group id")
-		.option("--group <group>", "group id")
-		.option("--db <path>", "coordinator database path")
-		.option("--db-path <path>", "coordinator database path")
-		.option("--remote-url <url>", "remote coordinator URL override")
-		.option("--admin-secret <secret>", "remote coordinator admin secret override")
-		.option("--json", "output as JSON")
-		.action(
-			async (
-				groupArg: string | undefined,
-				opts: {
-					group?: string;
-					db?: string;
-					dbPath?: string;
-					remoteUrl?: string;
-					adminSecret?: string;
-					json?: boolean;
-				},
-			) => {
-				const groupId = String(opts.group ?? "").trim() || String(groupArg ?? "").trim();
-				const rows = await coordinatorListJoinRequestsAction({
-					groupId,
-					dbPath: opts.db ?? opts.dbPath ?? null,
-					remoteUrl: opts.remoteUrl?.trim() || null,
-					adminSecret: opts.adminSecret?.trim() || null,
-				});
-				if (opts.json) {
-					console.log(JSON.stringify(rows, null, 2));
-					return;
-				}
-				p.intro("codemem sync coordinator list-join-requests");
-				if (rows.length === 0) {
-					p.outro(`No pending join requests for ${groupId}`);
-					return;
-				}
-				for (const row of rows) {
-					const displayName = row.display_name || row.device_id;
-					p.log.message(`- ${displayName} (${row.device_id}) request_id=${row.request_id}`);
-				}
-				p.outro(`${rows.length} pending join request(s)`);
-			},
-		),
-);
-
-function addReviewJoinRequestCommand(
-	name: "approve-join-request" | "deny-join-request",
-	approve: boolean,
-) {
-	coordinatorCommand.addCommand(
-		new Command(name)
-			.configureHelp(helpStyle)
-			.description(`${approve ? "Approve" : "Deny"} a coordinator join request`)
-			.argument("<request-id>", "join request id")
-			.option("--db <path>", "coordinator database path")
-			.option("--db-path <path>", "coordinator database path")
-			.option("--remote-url <url>", "remote coordinator URL override")
-			.option("--admin-secret <secret>", "remote coordinator admin secret override")
-			.option("--json", "output as JSON")
-			.action(
-				async (
-					requestId: string,
-					opts: {
-						db?: string;
-						dbPath?: string;
-						remoteUrl?: string;
-						adminSecret?: string;
-						json?: boolean;
-					},
-				) => {
-					const request = await coordinatorReviewJoinRequestAction({
-						requestId: requestId.trim(),
-						approve,
-						reviewedBy: null,
-						dbPath: opts.db ?? opts.dbPath ?? null,
-						remoteUrl: opts.remoteUrl?.trim() || null,
-						adminSecret: opts.adminSecret?.trim() || null,
-					});
-					if (!request) {
-						p.log.error(`Join request not found: ${requestId.trim()}`);
-						process.exitCode = 1;
-						return;
-					}
+			// Safety check
+			if (!opts.force) {
+				const dirty = hasUnsyncedSharedMemoryChanges(store.db);
+				if (dirty.dirty) {
 					if (opts.json) {
-						console.log(JSON.stringify(request, null, 2));
-						return;
+						emitJsonError(
+							"local_unsynced_changes",
+							`${dirty.count} unsynced shared memory change(s) would be lost. Use --force to override.`,
+						);
+					} else {
+						p.log.error(
+							`${dirty.count} unsynced shared memory change(s) would be lost. Use --force to override.`,
+						);
 					}
-					p.intro(`codemem sync coordinator ${name}`);
-					p.log.success(`${approve ? "Approved" : "Denied"} join request ${requestId.trim()}`);
-					p.outro(String(request.status ?? "updated"));
-				},
-			),
-	);
-}
+					process.exitCode = 1;
+					return;
+				}
+			}
 
-addReviewJoinRequestCommand("approve-join-request", true);
-addReviewJoinRequestCommand("deny-join-request", false);
+			// Resolve device identity
+			const [deviceId] = ensureDeviceIdentity(store.db, { keysDir });
 
-syncCommand.addCommand(coordinatorCommand);
+			// Get peer status to obtain reset boundary
+			const addresses = JSON.parse(String(peer.addresses_json ?? "[]")) as string[];
+			if (!addresses.length) {
+				if (opts.json) {
+					emitJsonError(
+						"no_peer_addresses",
+						"Peer has no known addresses. Run a sync first or add addresses.",
+					);
+				} else {
+					p.log.error("Peer has no known addresses. Run a sync first or add addresses.");
+				}
+				process.exitCode = 1;
+				return;
+			}
+
+			let boundary: {
+				generation: number;
+				snapshot_id: string;
+				baseline_cursor: string | null;
+			} | null = null;
+			let baseUrl = "";
+			const addressResults: Array<{ address: string; result: string }> = [];
+
+			for (const address of addresses) {
+				const candidate = buildBaseUrl(address);
+				if (!candidate) continue;
+				const statusUrl = `${candidate}/v1/status`;
+				const headers = buildAuthHeaders({
+					deviceId,
+					method: "GET",
+					url: statusUrl,
+					bodyBytes: Buffer.alloc(0),
+					bootstrapGrantId: opts.bootstrapGrant,
+					keysDir,
+				});
+				try {
+					const [code, payload] = await requestJson("GET", statusUrl, { headers });
+					if (code !== 200 || !payload) {
+						addressResults.push({ address: candidate, result: `status ${code}` });
+						continue;
+					}
+					if (payload.fingerprint !== peer.pinned_fingerprint) {
+						addressResults.push({ address: candidate, result: "fingerprint mismatch" });
+						continue;
+					}
+					const reset = payload.sync_reset as Record<string, unknown> | undefined;
+					if (
+						reset &&
+						typeof reset.generation === "number" &&
+						typeof reset.snapshot_id === "string"
+					) {
+						boundary = {
+							generation: reset.generation,
+							snapshot_id: reset.snapshot_id,
+							baseline_cursor:
+								typeof reset.baseline_cursor === "string" ? reset.baseline_cursor : null,
+						};
+						baseUrl = candidate;
+						addressResults.push({ address: candidate, result: "ok" });
+						break;
+					}
+					addressResults.push({ address: candidate, result: "missing sync_reset boundary" });
+				} catch (err) {
+					addressResults.push({
+						address: candidate,
+						result: err instanceof Error ? err.message : String(err),
+					});
+				}
+			}
+
+			if (!boundary || !baseUrl) {
+				const summary = addressResults.map((r) => `${r.address}: ${r.result}`).join("; ");
+				const detail = summary
+					? `no reachable peer with valid reset boundary. Tried: ${summary}`
+					: "peer unreachable or missing reset boundary";
+				if (opts.json) {
+					console.log(JSON.stringify({ ok: false, error: detail, addresses: addressResults }));
+				} else {
+					p.log.error(detail);
+				}
+				process.exitCode = 1;
+				return;
+			}
+
+			if (!opts.json) {
+				p.intro("codemem sync bootstrap");
+				p.log.step(`Bootstrapping from ${peer.name || peerDeviceId}...`);
+			}
+
+			const resetInfo = {
+				generation: boundary.generation,
+				snapshot_id: boundary.snapshot_id,
+				baseline_cursor: boundary.baseline_cursor,
+				retained_floor_cursor: null,
+				reset_required: true as const,
+				reason: "initial_bootstrap" as const,
+			};
+
+			const { items } = await fetchAllSnapshotPages(baseUrl, resetInfo, deviceId, {
+				keysDir,
+				bootstrapGrantId: opts.bootstrapGrant,
+				pageSize,
+			});
+
+			const result = applyBootstrapSnapshot(store.db, peerDeviceId, items, resetInfo);
+
+			if (opts.json) {
+				console.log(
+					JSON.stringify({
+						ok: result.ok,
+						applied: result.applied,
+						deleted: result.deleted,
+						error: result.error ?? null,
+					}),
+				);
+			} else {
+				if (result.ok) {
+					p.log.success(`Applied ${result.applied} memories (removed ${result.deleted} stale).`);
+				} else {
+					p.log.error(result.error || "Bootstrap apply failed.");
+				}
+				p.outro(result.ok ? "Bootstrap complete" : "Bootstrap failed");
+			}
+			if (!result.ok) process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);
+syncCommand.addCommand(bootstrapCmd);
+
+// ---- sync connect <coordinator-url> ----
+
+const connectCmd = new Command("connect")
+	.configureHelp(helpStyle)
+	.description("Configure coordinator URL for cloud sync")
+	.argument("<url>", "coordinator URL (e.g. https://coordinator.example.com)")
+	.option("--group <group>", "sync group ID");
+addConfigOption(connectCmd);
+connectCmd.action((url: string, opts: { group?: string; config?: string }) => {
+	const config = readCliConfig(opts.config);
+	config.sync_coordinator_url = url.trim();
+	if (opts.group) config.sync_coordinator_group = opts.group.trim();
+	writeCliConfig(config, opts.config);
+	p.intro("codemem sync connect");
+	p.log.success(`Coordinator: ${url.trim()}`);
+	if (opts.group) p.log.info(`Group: ${opts.group.trim()}`);
+	p.outro("Restart `codemem serve` to activate coordinator sync");
+});
+syncCommand.addCommand(connectCmd);
+
+// ---- Deprecation alias: sync coordinator → coordinator ----
+// Build a separate coordinator command tree for the sync alias (Commander
+// re-parents commands on addCommand, so sharing instances is not possible).
+// The canonical coordinatorCommand lives in coordinator.ts and is registered
+// at the top level by index.ts.
+
+const syncCoordinatorAlias = buildCoordinatorCommand();
+
+syncCoordinatorAlias.hook("preAction", (_thisCmd: Command, actionCmd: Command) => {
+	const subName = actionCmd.name();
+	emitDeprecationWarning(`codemem sync coordinator ${subName}`, `codemem coordinator ${subName}`);
+});
+
+syncCommand.addCommand(syncCoordinatorAlias);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import { Command } from "commander";
 import omelette from "omelette";
 import { claudeHookIngestCommand } from "./commands/claude-hook-ingest.js";
 import { configCommand } from "./commands/config.js";
+import { coordinatorCommand } from "./commands/coordinator.js";
 import { dbCommand } from "./commands/db.js";
 import { embedCommand } from "./commands/embed.js";
 import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
@@ -49,23 +50,21 @@ completion.on("command", ({ reply }) => {
 	reply([
 		"claude-hook-ingest",
 		"config",
+		"coordinator",
 		"db",
 		"embed",
-		"export-memories",
-		"forget",
-		"memory",
-		"import-memories",
-		"setup",
-		"show",
-		"sync",
-		"stats",
-		"recent",
-		"remember",
-		"search",
-		"pack",
-		"serve",
-		"mcp",
 		"enqueue-raw-event",
+		"export-memories",
+		"import-memories",
+		"mcp",
+		"memory",
+		"pack",
+		"recent",
+		"search",
+		"serve",
+		"setup",
+		"stats",
+		"sync",
 		"version",
 		"help",
 		"--help",
@@ -116,8 +115,58 @@ if (hasRootFlag("--cleanup-completion")) {
 	process.exit(0);
 }
 
+// --- Memory subcommands: export/import registered under `memory` group ---
+// Per cli-design-conventions.md, export/import belong under their noun group.
+// The top-level export-memories/import-memories remain as compatibility aliases.
+//
+// We create thin wrapper commands that replicate the same argument/option shape
+// and delegate to the original command's parseAsync with synthetic argv.
+// This avoids accessing Commander internals while keeping a single source of
+// truth for the action logic in the original command modules.
+{
+	const memExport = new Command("export")
+		.description("Export memories to a JSON file for sharing or backup")
+		.argument("<output>", "output file path (use '-' for stdout)")
+		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
+		.option("--project <project>", "filter by project")
+		.option("--all-projects", "export all projects")
+		.option("--include-inactive", "include deactivated memories")
+		.option("--since <iso>", "only export memories created after this ISO timestamp")
+		.configureHelp(helpStyle)
+		.allowUnknownOption(true)
+		.allowExcessArguments(true)
+		.action(async () => {
+			// Forward to the original command by re-parsing the raw argv tail.
+			// `memory export <args>` → `export-memories <args>`
+			const idx = process.argv.indexOf("export");
+			const tail = idx >= 0 ? process.argv.slice(idx + 1) : [];
+			await exportMemoriesCommand.parseAsync(["node", "export-memories", ...tail]);
+		});
+
+	const memImport = new Command("import")
+		.description("Import memories from an exported JSON file")
+		.argument("<inputFile>", "input JSON file (use '-' for stdin)")
+		.option("--db <path>", "database path")
+		.option("--db-path <path>", "database path")
+		.option("--remap-project <path>", "remap all projects to this path on import")
+		.option("--dry-run", "preview import without writing")
+		.configureHelp(helpStyle)
+		.allowUnknownOption(true)
+		.allowExcessArguments(true)
+		.action(async () => {
+			const idx = process.argv.indexOf("import");
+			const tail = idx >= 0 ? process.argv.slice(idx + 1) : [];
+			await importMemoriesCommand.parseAsync(["node", "import-memories", ...tail]);
+		});
+
+	memoryCommand.addCommand(memExport);
+	memoryCommand.addCommand(memImport);
+}
+
 program.addCommand(serveCommand);
 program.addCommand(configCommand);
+program.addCommand(coordinatorCommand);
 program.addCommand(mcpCommand);
 program.addCommand(claudeHookIngestCommand);
 program.addCommand(dbCommand);
@@ -128,9 +177,11 @@ program.addCommand(embedCommand);
 program.addCommand(recentCommand);
 program.addCommand(searchCommand);
 program.addCommand(packCommand);
-program.addCommand(showMemoryCommand);
-program.addCommand(forgetMemoryCommand);
-program.addCommand(rememberMemoryCommand);
+// Deprecated top-level aliases — use `memory show`, `memory forget`, `memory remember` instead.
+// These are hidden from --help and shell completion but still functional for backwards compat.
+program.addCommand(showMemoryCommand, { hidden: true });
+program.addCommand(forgetMemoryCommand, { hidden: true });
+program.addCommand(rememberMemoryCommand, { hidden: true });
 program.addCommand(memoryCommand);
 program.addCommand(syncCommand);
 program.addCommand(setupCommand);


### PR DESCRIPTION
## Description

Full CLI compliance refactor per `docs/cli-design-conventions.md` (from PR #596).
Addresses audit epic codemem-vcam and child tasks codemem-e700, codemem-p58i,
codemem-qdtk, codemem-mmdh, codemem-6w02, codemem-2fqp, codemem-uni7,
codemem-a417, codemem-9rrl, codemem-ekrw.

### Shared option builders (codemem-e700)
- ~90 ad-hoc `.option()` calls replaced with `addDbOption()`/`addConfigOption()`/`addJsonOption()` across all 17 command modules
- `-d`/`-c`/`-j` short flags work everywhere
- `--db` hidden as legacy alias; `--user`/`--system` hidden no-ops

### Positional argument fixes (codemem-qdtk)
- `sync bootstrap <peer-device-id>` (was `--peer` required flag)
- `config workspace <workspace-id>` (was `--workspace-id` required flag)
- Old flags kept as hidden aliases for backwards compat

### Lifecycle deprecation (codemem-p58i)
- `sync start/stop/restart` emit deprecation warnings, delegate to `serve`
- `serve --stop/--restart/--background` hidden from help with warnings

### Error handling (codemem-mmdh)
- `enqueue-raw-event`, `memory remember`, `serve`, `mcp`, `config`, `claude-hook-ingest`: all action handlers catch at boundary, emit structured errors
- All `--json` failure paths emit `{error, message}` instead of falling through to `p.log.error`

### `--json` support (codemem-6w02)
- Added to: `recent`, `sync once/enable/doctor/pair`, `memory show/remember/forget`, `import-memories`

### Coordinator promotion (codemem-2fqp)
- 16 subcommands extracted from `sync.ts` to new `coordinator.ts`
- Top-level `codemem coordinator` registered
- `sync coordinator` kept as hidden deprecation alias

### Memory group (codemem-uni7, codemem-a417)
- `memory export`/`memory import` registered as subcommands
- Top-level `show/forget/remember` hidden from help
- `memory inject` deprecated (warns → use `pack`)
- `memory compact` removed (dead stub)

### Host/port fix (codemem-9rrl)
- `sync enable` uses `--sync-host`/`--sync-port`
- Old `--host`/`--port` kept as hidden aliases with warnings

### Docs + completion (codemem-ekrw)
- Shell completion list synced with all registered commands
- README command table grouped by concern
- User guide updated with missing sync commands
- Coordinator docs updated with bootstrap grant commands

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 📚 Documentation (docs-only change)

## Testing

- [x] Tests pass locally — 64/64 CLI tests, 697/700 core tests (3 pre-existing viewer-asset failures)
- [x] Updated memory.test.ts for compact removal
- [x] Typecheck clean
- [x] Lint clean (0 errors)
- [x] Build passes (`pnpm run build`)

## Checklist

- [x] Code follows project style (biome check passes)
- [x] Self-review completed
- [x] Documentation updated (README, user-guide, coordinator-discovery)
- [x] No new warnings introduced