### PR TITLE
consolidate config path resolution into a single resolver

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,13 +1,20 @@
 import { existsSync } from "node:fs";
 import {
+	type ConfigResolutionResult,
 	getWorkspaceCodememConfigPath,
 	readCodememConfigFile,
 	readCodememConfigFileAtPath,
+	resolveCodememConfigPath,
 	writeCodememConfigFile,
 } from "@codemem/core";
 import { Command, Option } from "commander";
 import { helpStyle } from "../help-style.js";
-import { addJsonOption, type JsonOpts } from "../shared-options.js";
+import {
+	addConfigOption,
+	addJsonOption,
+	type ConfigOpts,
+	type JsonOpts,
+} from "../shared-options.js";
 
 type WorkspaceConfigOptions = JsonOpts & {
 	workspaceId?: string;
@@ -67,6 +74,8 @@ function runWorkspaceConfigCommand(
 		throw new Error("workspace-id is required");
 	}
 	const configPath = getWorkspaceCodememConfigPath(workspaceId);
+	// Seeds new workspace config from legacy global config on first write,
+	// so existing settings are inherited.
 	const existingConfig = existsSync(configPath)
 		? readCodememConfigFileAtPath(configPath)
 		: readCodememConfigFile();
@@ -156,5 +165,66 @@ workspaceCmd.action(
 );
 
 configCommand.addCommand(workspaceCmd);
+
+// ---------------------------------------------------------------------------
+// config where — show resolved config path with full traceability
+// ---------------------------------------------------------------------------
+
+type WhereOptions = ConfigOpts & JsonOpts;
+
+function formatWhereHuman(result: ConfigResolutionResult): string {
+	const lines: string[] = [];
+	const allEntries = [result.resolved, ...result.fallbackChain];
+	// Sort by original precedence order for display
+	const sourceOrder: Record<string, number> = {
+		"cli-flag": 0,
+		"env-codemem-config": 1,
+		"env-runtime-root": 2,
+		"env-workspace-id": 3,
+		"legacy-global": 4,
+	};
+	allEntries.sort((a, b) => (sourceOrder[a.source] ?? 99) - (sourceOrder[b.source] ?? 99));
+
+	for (const entry of allEntries) {
+		const isSelected = entry === result.resolved;
+		const marker = isSelected ? ">>>" : "   ";
+		const existsLabel = entry.exists ? "exists" : "missing";
+		lines.push(`${marker} [${entry.source}] ${entry.path}`);
+		lines.push(`       ${entry.reason} (${existsLabel})`);
+	}
+	return lines.join("\n");
+}
+
+const whereCmd = new Command("where")
+	.configureHelp(helpStyle)
+	.description("show resolved config file path");
+
+addConfigOption(whereCmd);
+addJsonOption(whereCmd);
+
+whereCmd.action((opts: WhereOptions) => {
+	try {
+		const result = resolveCodememConfigPath(opts.config, "read");
+		if (opts.json) {
+			console.log(JSON.stringify(result, null, 2));
+		} else {
+			console.log(formatWhereHuman(result));
+		}
+	} catch (err) {
+		if (opts.json) {
+			console.log(
+				JSON.stringify({
+					error: "config_error",
+					message: err instanceof Error ? err.message : String(err),
+				}),
+			);
+		} else {
+			console.error(err instanceof Error ? err.message : String(err));
+		}
+		process.exitCode = 1;
+	}
+});
+
+configCommand.addCommand(whereCmd);
 
 export { buildWorkspaceConfigPatch, mergeWorkspaceConfig, runWorkspaceConfigCommand };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -203,6 +203,11 @@ export {
 } from "./observer-auth.js";
 export type { ObserverConfig, ObserverResponse, ObserverStatus } from "./observer-client.js";
 export { loadObserverConfig, ObserverAuthError, ObserverClient } from "./observer-client.js";
+export type {
+	ConfigPathResolution,
+	ConfigPathSource,
+	ConfigResolutionResult,
+} from "./observer-config.js";
 export {
 	CODEMEM_CONFIG_ENV_OVERRIDES,
 	getCodememConfigPath,
@@ -224,6 +229,7 @@ export {
 	resolveBuiltInProviderDefaultModel,
 	resolveBuiltInProviderFromModel,
 	resolveBuiltInProviderModel,
+	resolveCodememConfigPath,
 	resolveCustomProviderDefaultModel,
 	resolveCustomProviderFromModel,
 	resolveCustomProviderModel,

--- a/packages/core/src/observer-config.test.ts
+++ b/packages/core/src/observer-config.test.ts
@@ -11,6 +11,7 @@ import {
 	loadOpenCodeConfig,
 	readCodememConfigFileAtPath,
 	readWorkspaceCodememConfigFile,
+	resolveCodememConfigPath,
 	resolveCustomProviderFromModel,
 	resolvePlaceholder,
 	stripJsonComments,
@@ -278,5 +279,157 @@ describe("getCodememEnvOverrides", () => {
 			delete process.env.CODEMEM_SYNC_RETENTION_MAX_AGE_DAYS;
 			delete process.env.CODEMEM_SYNC_RETENTION_MAX_SIZE_MB;
 		}
+	});
+});
+
+describe("resolveCodememConfigPath", () => {
+	let tmpHome: string;
+	let prevHome: string | undefined;
+	let prevCodememConfig: string | undefined;
+	let prevRuntimeRoot: string | undefined;
+	let prevWorkspaceId: string | undefined;
+
+	beforeEach(() => {
+		tmpHome = mkdtempSync(join(tmpdir(), "codemem-resolve-"));
+		prevHome = process.env.HOME;
+		prevCodememConfig = process.env.CODEMEM_CONFIG;
+		prevRuntimeRoot = process.env.CODEMEM_RUNTIME_ROOT;
+		prevWorkspaceId = process.env.CODEMEM_WORKSPACE_ID;
+		process.env.HOME = tmpHome;
+		delete process.env.CODEMEM_CONFIG;
+		delete process.env.CODEMEM_RUNTIME_ROOT;
+		delete process.env.CODEMEM_WORKSPACE_ID;
+	});
+
+	afterEach(() => {
+		if (prevHome == null) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		if (prevCodememConfig == null) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevCodememConfig;
+		if (prevRuntimeRoot == null) delete process.env.CODEMEM_RUNTIME_ROOT;
+		else process.env.CODEMEM_RUNTIME_ROOT = prevRuntimeRoot;
+		if (prevWorkspaceId == null) delete process.env.CODEMEM_WORKSPACE_ID;
+		else process.env.CODEMEM_WORKSPACE_ID = prevWorkspaceId;
+	});
+
+	it("CLI flag takes precedence over everything", () => {
+		process.env.CODEMEM_CONFIG = join(tmpHome, "env-config.json");
+		process.env.CODEMEM_WORKSPACE_ID = "pilot-1";
+		const cliPath = join(tmpHome, "cli-config.json");
+
+		const result = resolveCodememConfigPath(cliPath, "read");
+		expect(result.resolved.source).toBe("cli-flag");
+		expect(result.resolved.path).toBe(cliPath);
+	});
+
+	it("CODEMEM_CONFIG env takes precedence over workspace/legacy", () => {
+		const envPath = join(tmpHome, "env-config.json");
+		writeFileSync(envPath, "{}\n", "utf8");
+		process.env.CODEMEM_CONFIG = envPath;
+		process.env.CODEMEM_WORKSPACE_ID = "pilot-1";
+
+		const result = resolveCodememConfigPath(undefined, "read");
+		expect(result.resolved.source).toBe("env-codemem-config");
+		expect(result.resolved.path).toBe(envPath);
+	});
+
+	it("relative CODEMEM_RUNTIME_ROOT is recorded in fallbackChain with reason", () => {
+		process.env.CODEMEM_RUNTIME_ROOT = "../relative-root";
+
+		const result = resolveCodememConfigPath(undefined, "read");
+		expect(result.resolved.source).toBe("legacy-global");
+		const runtimeEntry = result.fallbackChain.find((c) => c.source === "env-runtime-root");
+		expect(runtimeEntry).toBeDefined();
+		expect(runtimeEntry!.reason).toContain("is relative, not absolute");
+	});
+
+	it("mode 'write' returns first candidate even if it doesn't exist", () => {
+		const envPath = join(tmpHome, "nonexistent", "config.json");
+		process.env.CODEMEM_CONFIG = envPath;
+
+		const result = resolveCodememConfigPath(undefined, "write");
+		expect(result.resolved.source).toBe("env-codemem-config");
+		expect(result.resolved.path).toBe(envPath);
+		expect(result.resolved.exists).toBe(false);
+	});
+
+	it("mode 'read' skips non-existent non-authoritative candidates", () => {
+		// CODEMEM_CONFIG and cli-flag are authoritative (always win in read mode).
+		// Non-authoritative sources (runtime root, workspace id) are skipped when missing.
+		process.env.CODEMEM_RUNTIME_ROOT = join(tmpHome, "nonexistent-runtime");
+		process.env.CODEMEM_WORKSPACE_ID = "pilot-1";
+		const legacyDir = join(tmpHome, ".config", "codemem");
+		mkdirSync(legacyDir, { recursive: true });
+		const legacyPath = join(legacyDir, "config.json");
+		writeFileSync(legacyPath, "{}\n", "utf8");
+
+		const result = resolveCodememConfigPath(undefined, "read");
+		expect(result.resolved.source).toBe("legacy-global");
+		expect(result.resolved.path).toBe(legacyPath);
+		expect(result.resolved.exists).toBe(true);
+	});
+
+	it("CODEMEM_CONFIG is authoritative in read mode even when file is missing", () => {
+		process.env.CODEMEM_CONFIG = join(tmpHome, "nonexistent.json");
+
+		const result = resolveCodememConfigPath(undefined, "read");
+		expect(result.resolved.source).toBe("env-codemem-config");
+		expect(result.resolved.exists).toBe(false);
+	});
+
+	it("full fallback chain is populated with all evaluated candidates", () => {
+		process.env.CODEMEM_CONFIG = join(tmpHome, "env.json");
+		process.env.CODEMEM_RUNTIME_ROOT = join(tmpHome, "runtime");
+		process.env.CODEMEM_WORKSPACE_ID = "pilot-1";
+
+		const result = resolveCodememConfigPath(join(tmpHome, "cli.json"), "read");
+		// All 5 sources should be present (1 resolved + 4 in fallbackChain)
+		const allSources = [
+			result.resolved.source,
+			...result.fallbackChain.map((c) => c.source),
+		].sort();
+		expect(allSources).toEqual([
+			"cli-flag",
+			"env-codemem-config",
+			"env-runtime-root",
+			"env-workspace-id",
+			"legacy-global",
+		]);
+	});
+
+	it("unsafe CODEMEM_WORKSPACE_ID is recorded with safety-check reason", () => {
+		process.env.CODEMEM_WORKSPACE_ID = "../evil";
+
+		const result = resolveCodememConfigPath(undefined, "read");
+		const wsEntry = result.fallbackChain.find((c) => c.source === "env-workspace-id");
+		expect(wsEntry).toBeDefined();
+		expect(wsEntry!.reason).toContain("failed safety check");
+	});
+
+	it("write mode skips relative runtime root", () => {
+		process.env.CODEMEM_RUNTIME_ROOT = "../relative";
+
+		const result = resolveCodememConfigPath(undefined, "write");
+		// Should resolve to legacy, not the relative runtime root
+		expect(result.resolved.source).toBe("legacy-global");
+	});
+
+	it("delegates correctly from getCodememConfigPath", () => {
+		// Verify the refactored getCodememConfigPath still works
+		const legacyDir = join(tmpHome, ".config", "codemem");
+		mkdirSync(legacyDir, { recursive: true });
+		const legacyPath = join(legacyDir, "config.jsonc");
+		writeFileSync(legacyPath, "{}\n", "utf8");
+
+		expect(getCodememConfigPath()).toBe(legacyPath);
+	});
+
+	it("resolved entry has exists=true when file is present", () => {
+		const envPath = join(tmpHome, "existing-config.json");
+		writeFileSync(envPath, "{}\n", "utf8");
+		process.env.CODEMEM_CONFIG = envPath;
+
+		const result = resolveCodememConfigPath(undefined, "read");
+		expect(result.resolved.exists).toBe(true);
 	});
 });

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -173,11 +173,7 @@ function getLegacyCodememConfigPath(): string {
 }
 
 function getCodememConfigWritePath(): string {
-	const envPath = process.env.CODEMEM_CONFIG?.trim();
-	if (envPath) return expandUserPath(envPath);
-	const workspaceConfigPath = getWorkspaceScopedCodememConfigPath();
-	if (workspaceConfigPath) return workspaceConfigPath;
-	return getLegacyCodememConfigPath();
+	return resolveCodememConfigPath(undefined, "write").resolved.path;
 }
 
 export function readWorkspaceCodememConfigFile(workspaceId: string): Record<string, unknown> {
@@ -225,6 +221,166 @@ export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
 	raw_events_sweeper_interval_s: "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
 };
 
+// ---------------------------------------------------------------------------
+// Unified config path resolver with full traceability
+// ---------------------------------------------------------------------------
+
+export type ConfigPathSource =
+	| "cli-flag"
+	| "env-codemem-config"
+	| "env-runtime-root"
+	| "env-workspace-id"
+	| "legacy-global";
+
+export interface ConfigPathResolution {
+	path: string;
+	source: ConfigPathSource;
+	reason: string;
+	exists: boolean;
+	/** Whether this candidate is structurally valid (absolute path, safe workspace id, etc.). */
+	valid: boolean;
+}
+
+export interface ConfigResolutionResult {
+	resolved: ConfigPathResolution;
+	fallbackChain: ConfigPathResolution[];
+}
+
+/**
+ * Resolve the codemem config path with full traceability.
+ *
+ * Every candidate in the precedence chain is evaluated and recorded.
+ * The `resolved` field is the winner; `fallbackChain` holds all rejected candidates
+ * with a reason string explaining why each was skipped.
+ *
+ * @param cliConfigPath - explicit --config flag value (highest precedence)
+ * @param mode - 'read' checks existence and falls back; 'write' takes first match
+ */
+export function resolveCodememConfigPath(
+	cliConfigPath?: string,
+	mode: "read" | "write" = "read",
+): ConfigResolutionResult {
+	const candidates: ConfigPathResolution[] = [];
+
+	// 1. CLI flag (highest precedence)
+	if (cliConfigPath?.trim()) {
+		const path = expandUserPath(cliConfigPath.trim());
+		candidates.push({
+			path,
+			source: "cli-flag",
+			reason: `--config ${cliConfigPath}`,
+			exists: existsSync(path),
+			valid: true,
+		});
+	}
+
+	// 2. CODEMEM_CONFIG env
+	const envConfig = process.env.CODEMEM_CONFIG?.trim();
+	if (envConfig) {
+		const path = expandUserPath(envConfig);
+		candidates.push({
+			path,
+			source: "env-codemem-config",
+			reason: `CODEMEM_CONFIG='${envConfig}'`,
+			exists: existsSync(path),
+			valid: true,
+		});
+	}
+
+	// 3. CODEMEM_RUNTIME_ROOT env (must be absolute after expandUser)
+	const runtimeRoot = process.env.CODEMEM_RUNTIME_ROOT?.trim();
+	if (runtimeRoot) {
+		const expandedRoot = expandUserPath(runtimeRoot);
+		const isAbsolute = expandedRoot.startsWith("/");
+		const path = join(expandedRoot, "config", "codemem.json");
+		candidates.push({
+			path,
+			source: "env-runtime-root",
+			reason: isAbsolute
+				? `CODEMEM_RUNTIME_ROOT='${runtimeRoot}'`
+				: `CODEMEM_RUNTIME_ROOT='${runtimeRoot}' is relative, not absolute`,
+			exists: isAbsolute ? existsSync(path) : false,
+			valid: isAbsolute,
+		});
+	}
+
+	// 4. CODEMEM_WORKSPACE_ID env (must pass isSafeWorkspaceId)
+	const workspaceId = process.env.CODEMEM_WORKSPACE_ID?.trim();
+	if (workspaceId) {
+		const safe = isSafeWorkspaceId(workspaceId);
+		const path = safe
+			? getWorkspaceCodememConfigPath(workspaceId)
+			: join(homedir(), ".codemem", "workspaces", workspaceId, "config", "codemem.json");
+		candidates.push({
+			path,
+			source: "env-workspace-id",
+			reason: safe
+				? `CODEMEM_WORKSPACE_ID='${workspaceId}'`
+				: `CODEMEM_WORKSPACE_ID='${workspaceId}' failed safety check`,
+			exists: safe ? existsSync(path) : false,
+			valid: safe,
+		});
+	}
+
+	// 5. Legacy global config (~/.config/codemem/config.json{c})
+	const legacyPath = getLegacyCodememConfigPath();
+	candidates.push({
+		path: legacyPath,
+		source: "legacy-global",
+		reason: "legacy global config",
+		exists: existsSync(legacyPath),
+		valid: true,
+	});
+
+	// Explicit overrides (cli-flag, env-codemem-config) are authoritative:
+	// they win in both read and write mode regardless of file existence.
+	// This matches the original getCodememConfigPath behavior where
+	// CODEMEM_CONFIG is returned immediately without an existence check.
+	const isAuthoritative = (c: ConfigPathResolution): boolean =>
+		c.source === "cli-flag" || c.source === "env-codemem-config";
+
+	// Select the winner based on mode.
+	// Validity is determined structurally via the `valid` flag on each candidate,
+	// not by inspecting the `reason` string.
+	let resolvedIndex: number;
+	if (mode === "write") {
+		// Write mode: first valid candidate regardless of existence
+		resolvedIndex = candidates.findIndex((c) => c.valid);
+	} else {
+		// Read mode: authoritative sources win immediately; otherwise first existing candidate
+		const authoritativeIndex = candidates.findIndex((c) => isAuthoritative(c) && c.valid);
+		if (authoritativeIndex >= 0) {
+			resolvedIndex = authoritativeIndex;
+		} else {
+			const existingIndex = candidates.findIndex((c) => c.valid && c.exists);
+			// If none exist, fall back to first valid candidate (matches getCodememConfigPath behavior)
+			resolvedIndex = existingIndex >= 0 ? existingIndex : candidates.findIndex((c) => c.valid);
+		}
+	}
+
+	// Should always find at least the legacy candidate, but guard anyway
+	if (resolvedIndex < 0) resolvedIndex = candidates.length - 1;
+
+	const resolved = candidates[resolvedIndex]!;
+	const fallbackChain = candidates.filter((_, i) => i !== resolvedIndex);
+
+	// Annotate skipped candidates with why they were not selected
+	for (const entry of fallbackChain) {
+		if (entry.source === "env-runtime-root" && entry.reason.includes("is relative")) {
+			// Already has a descriptive reason
+		} else if (
+			entry.source === "env-workspace-id" &&
+			entry.reason.includes("failed safety check")
+		) {
+			// Already has a descriptive reason
+		} else if (mode === "read" && !entry.exists) {
+			entry.reason += " (does not exist)";
+		}
+	}
+
+	return { resolved, fallbackChain };
+}
+
 /**
  * Resolve codemem config path with precedence:
  * 1. explicit CODEMEM_CONFIG override
@@ -232,13 +388,7 @@ export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
  * 3. legacy global config under ~/.config/codemem/
  */
 export function getCodememConfigPath(): string {
-	const envPath = process.env.CODEMEM_CONFIG?.trim();
-	if (envPath) return expandUserPath(envPath);
-	const workspaceConfigPath = getWorkspaceScopedCodememConfigPath();
-	if (workspaceConfigPath && existsSync(workspaceConfigPath)) return workspaceConfigPath;
-	const legacyConfigPath = getLegacyCodememConfigPath();
-	if (existsSync(legacyConfigPath)) return legacyConfigPath;
-	return workspaceConfigPath ?? legacyConfigPath;
+	return resolveCodememConfigPath(undefined, "read").resolved.path;
 }
 
 /** Read codemem config file with the same JSON/JSONC behavior as Python. */


### PR DESCRIPTION
## Description

Consolidates codemem's config path resolution — previously spread across 6+ functions
with 5 precedence paths — into a single `resolveCodememConfigPath()` that returns full
traceability: resolved path, source, reason, existence flag, and the complete fallback
chain of all candidates evaluated.

### New resolver

`resolveCodememConfigPath(cliConfigPath?, mode: 'read' | 'write')` returns:

```typescript
interface ConfigResolutionResult {
  resolved: ConfigPathResolution;     // the winner
  fallbackChain: ConfigPathResolution[]; // all candidates that were skipped, with reasons
}
```

Resolution order (unchanged from current behavior):
1. `--config` CLI flag → source `cli-flag`
2. `CODEMEM_CONFIG` env → source `env-codemem-config`
3. `CODEMEM_RUNTIME_ROOT` env → source `env-runtime-root`
4. `CODEMEM_WORKSPACE_ID` env → source `env-workspace-id`
5. Legacy `~/.config/codemem/` → source `legacy-global`

Key design point: `cli-flag` and `env-codemem-config` are **authoritative** — they
win in read mode even if the file doesn't exist, matching the pre-existing behavior
that caused confusion when it wasn't explicit.

### Refactored delegates

`getCodememConfigPath()` and `getCodememConfigWritePath()` now delegate to the resolver.
All existing callers (13 files, 78 references) work unchanged.

### New CLI command

`codemem config where [--config <path>] [--json]` prints the full resolution chain
so operators can debug "which config file is being used and why."

### Tests

11 new tests covering: CLI flag precedence, env precedence, relative runtime root
in fallback chain, write vs read mode, authoritative source behavior, unsafe workspace
IDs, and delegation regression.

### Also

- Documented the seed-from-legacy behavior in `config workspace` command
- Added `.opencode/package-lock.json` to `.gitignore`

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🚀 Feature (new functionality — `config where` command)

## Testing

- [x] 898/898 tests pass (11 new)
- [x] Typecheck clean (no new errors)
- [x] All existing config resolution tests pass unchanged

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (inline comments, CLI help text)
- [x] No new warnings introduced
- [x] Backwards compatible — no existing function signatures changed