### PR TITLE
fix: improve attention headline specificity and hide scope-pending discovered rows

### DIFF
--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -461,21 +461,28 @@ export function renderTeamSync() {
     requestId: String(request.request_id || ''),
   }));
   const visibleDiscoveredRows = discoveredRows.filter(
-    (row) => row.mode !== 'paired' && row.mode !== 'none',
+    (row) => row.mode !== 'paired' && row.mode !== 'none' && row.mode !== 'scope-pending',
   );
-  const discoveredActionableCount = visibleDiscoveredRows.filter(
+  // Count actionable items from the unfiltered list so scope-pending devices
+  // still contribute to the attention count even though they are hidden from
+  // the discovered section (they already appear in the devices section).
+  const discoveredActionableCount = discoveredRows.filter(
     (row) => row.mode === 'accept' || row.mode === 'scope-pending',
   ).length;
   const actionableCount = attentionItems.length + pendingJoinRequests.length + discoveredActionableCount;
   const attentionParts: string[] = [];
   if (attentionItems.length > 0) {
-    const deviceItems = attentionItems.filter((item) => item.kind !== 'possible-duplicate-person');
+    const repairItems = attentionItems.filter((item) => item.kind === 'device-needs-repair');
+    const nameItems = attentionItems.filter((item) => item.kind === 'name-device');
+    const reviewItems = attentionItems.filter((item) => item.kind === 'review-team-device');
     const duplicateItems = attentionItems.filter((item) => item.kind === 'possible-duplicate-person');
-    if (deviceItems.length > 0) attentionParts.push(`${deviceItems.length} device${deviceItems.length === 1 ? '' : 's'}`);
-    if (duplicateItems.length > 0) attentionParts.push(`${duplicateItems.length} duplicate${duplicateItems.length === 1 ? '' : 's'}`);
+    if (repairItems.length > 0) attentionParts.push(`${repairItems.length} device${repairItems.length === 1 ? '' : 's'} to repair`);
+    if (nameItems.length > 0) attentionParts.push(`${nameItems.length} device${nameItems.length === 1 ? '' : 's'} to name`);
+    if (reviewItems.length > 0) attentionParts.push(`${reviewItems.length} device${reviewItems.length === 1 ? '' : 's'} to review`);
+    if (duplicateItems.length > 0) attentionParts.push(`${duplicateItems.length} possible duplicate${duplicateItems.length === 1 ? '' : 's'}`);
   }
-  if (pendingJoinRequests.length > 0) attentionParts.push(`${pendingJoinRequests.length} join request${pendingJoinRequests.length === 1 ? '' : 's'}`);
-  if (discoveredActionableCount > 0) attentionParts.push(`${discoveredActionableCount} discovered`);
+  if (pendingJoinRequests.length > 0) attentionParts.push(`${pendingJoinRequests.length} join request${pendingJoinRequests.length === 1 ? '' : 's'} to review`);
+  if (discoveredActionableCount > 0) attentionParts.push(`${discoveredActionableCount} discovered device${discoveredActionableCount === 1 ? '' : 's'}`);
   const attentionDetail = attentionParts.join(', ');
   const teamLabel = (coordinator.groups || []).join(', ') || 'none';
   const statusSummary: TeamSyncStatusSummary = {
@@ -483,7 +490,7 @@ export function renderTeamSync() {
     headline:
       presenceStatus === 'posted'
         ? actionableCount > 0
-          ? `${attentionDetail} need${actionableCount === 1 ? 's' : ''} attention`
+          ? attentionDetail
           : 'Everything is healthy'
         : presenceStatus === 'not_enrolled'
           ? 'This device is not enrolled in the team yet'


### PR DESCRIPTION
## Description

Two viewer UI bug fixes in one small change (11 lines).

### Attention headline specificity (codemem-l4s2)

**Before:** `"1 device, 1 join request need attention"` — vague about what action is needed, grammar awkward with compound subjects.

**After:** `"1 device to repair, 1 join request to review"` — each category now includes the action needed. No generic "needs attention" suffix.

Categories now reported:
- `N device(s) to repair` — devices with sync errors
- `N device(s) to name` — devices without a friendly name
- `N device(s) to review` — devices needing trust or group review
- `N possible duplicate(s)` — people with matching display names
- `N join request(s) to review` — pending coordinator join requests
- `N discovered device(s)` — actionable devices seen on team

### Renamed peer UUID showing in discovered list (codemem-ssb0)

**Before:** A device accepted and renamed but with a pending scope review (`mode: 'scope-pending'`) was not filtered from the "Devices seen on team" section, showing the raw UUID as a separate entry.

**After:** `scope-pending` mode is now filtered alongside `paired` and `none`, since those devices are already managed in the devices section.

### Delete person (codemem-z048)

Already implemented — "Remove person" button exists in `sync-actors.tsx` with `deactivateActor` API. Closed as stale.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] 27/27 UI tests pass
- [x] Full suite 898/898

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced