### PR TITLE
test: restore Claude hook injection contract and cover adapter context injection

### DIFF
--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -161,6 +161,111 @@ const appendWorkingSetFileArgs = (args, workingSetFiles) => {
   return args;
 };
 
+const buildInjectQuery = ({ firstPrompt, lastPromptText, projectName, filesModified }) => {
+  const parts = [];
+
+  if (firstPrompt && String(firstPrompt).trim()) {
+    parts.push(String(firstPrompt).trim());
+  }
+
+  if (
+    lastPromptText
+    && String(lastPromptText).trim()
+    && String(lastPromptText).trim() !== String(firstPrompt || "").trim()
+    && String(lastPromptText).trim().length > 5
+  ) {
+    parts.push(String(lastPromptText).trim());
+  }
+
+  if (projectName) {
+    parts.push(String(projectName));
+  }
+
+  const recentFiles = Array.from(filesModified || [])
+    .slice(-5)
+    .map((filePath) => String(filePath || "").split("/").pop())
+    .filter(Boolean)
+    .join(" ");
+  if (recentFiles) {
+    parts.push(recentFiles);
+  }
+
+  if (parts.length === 0) {
+    return "recent work";
+  }
+
+  const query = parts.join(" ");
+  return query.length > 500 ? query.slice(0, 500) : query;
+};
+
+const buildPackArgs = ({ query, filesModified, injectLimit, injectTokenBudget }) => {
+  const workingSetFiles = Array.from(filesModified || [])
+    .slice(-8)
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+  const args = ["pack", query];
+  if (injectLimit !== null && Number.isFinite(injectLimit) && injectLimit > 0) {
+    args.push("--limit", String(injectLimit));
+  }
+  if (
+    injectTokenBudget !== null
+    && Number.isFinite(injectTokenBudget)
+    && injectTokenBudget > 0
+  ) {
+    args.push("--token-budget", String(injectTokenBudget));
+  }
+  return appendWorkingSetFileArgs(args, workingSetFiles);
+};
+
+const applyInjectedContextToOutput = async ({
+  injectEnabled,
+  input,
+  output,
+  injectedSessions,
+  injectionToastShown,
+  showToast,
+  resolveInjectQuery,
+  buildInjectedContext,
+}) => {
+  if (!injectEnabled) {
+    return false;
+  }
+
+  const query = resolveInjectQuery();
+  const cached = injectedSessions.get(input.sessionID);
+  let contextText = cached?.text || "";
+
+  if (!contextText || cached?.query !== query) {
+    const injected = await buildInjectedContext(query);
+    if (injected?.text) {
+      injectedSessions.set(input.sessionID, {
+        query,
+        text: injected.text,
+        metrics: injected.metrics || null,
+      });
+      contextText = injected.text;
+
+      if (!injectionToastShown.has(input.sessionID) && showToast) {
+        injectionToastShown.add(input.sessionID);
+        try {
+          await showToast(buildInjectionToastMessage(injected.metrics));
+        } catch {
+          // best-effort only
+        }
+      }
+    }
+  }
+
+  if (!contextText) {
+    return false;
+  }
+  if (!Array.isArray(output.system)) {
+    output.system = [];
+  }
+  output.system.push(contextText);
+  return true;
+};
+
 const mapOpencodeEventTypeToAdapterType = (eventType) => {
   if (eventType === "user_prompt") {
     return "prompt";
@@ -1335,63 +1440,13 @@ export const OpencodeMemPlugin = async ({
     await showToast(`${message}. Suggested action: ${guidance.action}`, "warning");
   };
 
-  const resolveInjectQuery = () => {
-    const parts = [];
-
-    // First prompt captures session intent (most stable signal)
-    if (sessionContext.firstPrompt && sessionContext.firstPrompt.trim()) {
-      parts.push(sessionContext.firstPrompt.trim());
-    }
-
-    // Latest prompt adds current focus (skip if same as first, or trivial)
-    if (
-      lastPromptText &&
-      lastPromptText.trim() &&
-      lastPromptText.trim() !== (sessionContext.firstPrompt || "").trim() &&
-      lastPromptText.trim().length > 5
-    ) {
-      parts.push(lastPromptText.trim());
-    }
-
-    // Project name for scoping
-    const projectName = resolveProjectName(project, cwd);
-    if (projectName) {
-      parts.push(projectName);
-    }
-
-    // Recently modified files signal what area of the codebase we're in
-    if (sessionContext.filesModified.size > 0) {
-      const recentFiles = Array.from(sessionContext.filesModified)
-        .slice(-5)
-        .map((f) => f.split("/").pop())
-        .join(" ");
-      parts.push(recentFiles);
-    }
-
-    if (parts.length === 0) {
-      return "recent work";
-    }
-
-    // Cap total length to avoid overly long CLI args
-    const query = parts.join(" ");
-    return query.length > 500 ? query.slice(0, 500) : query;
-  };
-
-  const buildPackArgs = (query) => {
-    const workingSetFiles = Array.from(sessionContext.filesModified)
-      .slice(-8)
-      .map((value) => String(value || "").trim())
-      .filter(Boolean);
-    const args = ["pack", query];
-    if (injectLimit !== null && Number.isFinite(injectLimit) && injectLimit > 0) {
-      args.push("--limit", String(injectLimit));
-    }
-    if (injectTokenBudget !== null && Number.isFinite(injectTokenBudget) && injectTokenBudget > 0) {
-      args.push("--token-budget", String(injectTokenBudget));
-    }
-    appendWorkingSetFileArgs(args, workingSetFiles);
-    return args;
-  };
+  const resolveInjectQuery = () =>
+    buildInjectQuery({
+      firstPrompt: sessionContext.firstPrompt,
+      lastPromptText,
+      projectName: resolveProjectName(project, cwd),
+      filesModified: sessionContext.filesModified,
+    });
 
   const parsePackText = (stdout) => {
     if (!stdout || !stdout.trim()) {
@@ -1424,7 +1479,12 @@ export const OpencodeMemPlugin = async ({
   };
 
   const buildInjectedContext = async (query) => {
-    const packArgs = buildPackArgs(query);
+    const packArgs = buildPackArgs({
+      query,
+      filesModified: sessionContext.filesModified,
+      injectLimit,
+      injectTokenBudget,
+    });
     const result = await runCli(packArgs);
     if (!result || result.exitCode !== 0) {
       const exitCode = result?.exitCode ?? "unknown";
@@ -1681,9 +1741,6 @@ export const OpencodeMemPlugin = async ({
 
   return {
     "experimental.chat.system.transform": async (input, output) => {
-      if (!injectEnabled) {
-        return;
-      }
       const query = resolveInjectQuery();
       if (debug) {
         await logLine(
@@ -1692,40 +1749,25 @@ export const OpencodeMemPlugin = async ({
           } tui_toast=${Boolean(client.tui?.showToast)}`
         );
       }
-      const cached = injectedSessions.get(input.sessionID);
-      let contextText = cached?.text || "";
-      if (!contextText || cached?.query !== query) {
-        const injected = await buildInjectedContext(query);
-        if (injected?.text) {
-          injectedSessions.set(input.sessionID, {
-            query,
-            text: injected.text,
-            metrics: injected.metrics || null,
-          });
-          contextText = injected.text;
-
-            if (!injectionToastShown.has(input.sessionID) && client.tui?.showToast) {
-              injectionToastShown.add(input.sessionID);
-              try {
-                await client.tui.showToast({
-                  body: {
-                    message: buildInjectionToastMessage(injected.metrics),
-                    variant: "info",
-                  },
-                });
-            } catch (toastErr) {
-              // best-effort only
-            }
+      await applyInjectedContextToOutput({
+        injectEnabled,
+        input,
+        output,
+        injectedSessions,
+        injectionToastShown,
+        showToast: client.tui?.showToast
+          ? async (message) => {
+            await client.tui.showToast({
+              body: {
+                message,
+                variant: "info",
+              },
+            });
           }
-        }
-      }
-      if (!contextText) {
-        return;
-      }
-      if (!Array.isArray(output.system)) {
-        output.system = [];
-      }
-      output.system.push(contextText);
+          : null,
+        resolveInjectQuery,
+        buildInjectedContext,
+      });
     },
     event: async ({ event }) => {
       const eventType = event?.type || "unknown";
@@ -2009,6 +2051,9 @@ export const __testUtils = {
   inferProjectFromCwd,
   normalizeProjectLabel,
   resolveProjectName,
+  buildInjectQuery,
+  buildPackArgs,
+  applyInjectedContextToOutput,
   buildRunnerArgs,
   appendWorkingSetFileArgs,
   extractApplyPatchPaths,

--- a/packages/cli/.opencode/tests/plugin-injection.test.js
+++ b/packages/cli/.opencode/tests/plugin-injection.test.js
@@ -1,0 +1,246 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { __testUtils } from "../plugins/codemem.js";
+
+describe("buildInjectQuery", () => {
+  test("combines prompts, project, and recent modified file basenames", () => {
+    const query = __testUtils.buildInjectQuery({
+      firstPrompt: "fix auth callback",
+      lastPromptText: "add regression coverage",
+      projectName: "codemem",
+      filesModified: [
+        "packages/core/src/pack.ts",
+        "packages/cli/.opencode/plugins/codemem.js",
+      ],
+    });
+
+    expect(query).toBe(
+      "fix auth callback add regression coverage codemem pack.ts codemem.js",
+    );
+  });
+
+  test("omits trivial or duplicate latest prompt and falls back to recent work", () => {
+    expect(
+      __testUtils.buildInjectQuery({
+        firstPrompt: "same prompt",
+        lastPromptText: "same prompt",
+        projectName: "",
+        filesModified: [],
+      }),
+    ).toBe("same prompt");
+
+    expect(
+      __testUtils.buildInjectQuery({
+        firstPrompt: null,
+        lastPromptText: "todo",
+        projectName: "",
+        filesModified: [],
+      }),
+    ).toBe("recent work");
+  });
+
+  test("caps query length at 500 characters", () => {
+    const query = __testUtils.buildInjectQuery({
+      firstPrompt: "x".repeat(490),
+      lastPromptText: "y".repeat(40),
+      projectName: "codemem",
+      filesModified: [],
+    });
+
+    expect(query).toHaveLength(500);
+  });
+});
+
+describe("buildPackArgs", () => {
+  test("includes limit, token budget, and recent working set files", () => {
+    const args = __testUtils.buildPackArgs({
+      query: "fix auth",
+      filesModified: [
+        "a.ts",
+        "b.ts",
+        "c.ts",
+        "d.ts",
+        "e.ts",
+        "f.ts",
+        "g.ts",
+        "h.ts",
+        "i.ts",
+        "   ",
+      ],
+      injectLimit: 4,
+      injectTokenBudget: 250,
+    });
+
+    expect(args).toEqual([
+      "pack",
+      "fix auth",
+      "--limit",
+      "4",
+      "--token-budget",
+      "250",
+      "--working-set-file",
+      "c.ts",
+      "--working-set-file",
+      "d.ts",
+      "--working-set-file",
+      "e.ts",
+      "--working-set-file",
+      "f.ts",
+      "--working-set-file",
+      "g.ts",
+      "--working-set-file",
+      "h.ts",
+      "--working-set-file",
+      "i.ts",
+    ]);
+  });
+
+  test("omits non-positive limit and budget values", () => {
+    const args = __testUtils.buildPackArgs({
+      query: "recent work",
+      filesModified: [],
+      injectLimit: 0,
+      injectTokenBudget: null,
+    });
+
+    expect(args).toEqual(["pack", "recent work"]);
+  });
+});
+
+describe("applyInjectedContextToOutput", () => {
+  test("injects context into output.system, caches by query, and toasts once", async () => {
+    const injectedSessions = new Map();
+    const injectionToastShown = new Set();
+    const buildInjectedContext = vi.fn().mockResolvedValue({
+      text: "[codemem context]\n## Summary\n[1] (decision) Auth fix",
+      metrics: {
+        items: 1,
+        pack_tokens: 42,
+        pack_delta_available: false,
+      },
+    });
+    const showToast = vi.fn().mockResolvedValue(undefined);
+    const resolveInjectQuery = vi.fn().mockReturnValue("auth fix codemem");
+
+    const firstOutput = {};
+    const firstApplied = await __testUtils.applyInjectedContextToOutput({
+      injectEnabled: true,
+      input: { sessionID: "sess-1" },
+      output: firstOutput,
+      injectedSessions,
+      injectionToastShown,
+      showToast,
+      resolveInjectQuery,
+      buildInjectedContext,
+    });
+
+    const secondOutput = { system: [] };
+    const secondApplied = await __testUtils.applyInjectedContextToOutput({
+      injectEnabled: true,
+      input: { sessionID: "sess-1" },
+      output: secondOutput,
+      injectedSessions,
+      injectionToastShown,
+      showToast,
+      resolveInjectQuery,
+      buildInjectedContext,
+    });
+
+    expect(firstApplied).toBe(true);
+    expect(firstOutput.system).toEqual([
+      "[codemem context]\n## Summary\n[1] (decision) Auth fix",
+    ]);
+    expect(secondApplied).toBe(true);
+    expect(secondOutput.system).toEqual([
+      "[codemem context]\n## Summary\n[1] (decision) Auth fix",
+    ]);
+    expect(buildInjectedContext).toHaveBeenCalledTimes(1);
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(injectedSessions.get("sess-1")).toEqual({
+      query: "auth fix codemem",
+      text: "[codemem context]\n## Summary\n[1] (decision) Auth fix",
+      metrics: {
+        items: 1,
+        pack_tokens: 42,
+        pack_delta_available: false,
+      },
+    });
+  });
+
+  test("rebuilds injected context when query changes", async () => {
+    const injectedSessions = new Map();
+    const injectionToastShown = new Set();
+    const buildInjectedContext = vi
+      .fn()
+      .mockResolvedValueOnce({ text: "[codemem context]\nfirst" })
+      .mockResolvedValueOnce({ text: "[codemem context]\nsecond" });
+    const resolveInjectQuery = vi
+      .fn()
+      .mockReturnValueOnce("first query")
+      .mockReturnValueOnce("second query");
+
+    const firstOutput = {};
+    await __testUtils.applyInjectedContextToOutput({
+      injectEnabled: true,
+      input: { sessionID: "sess-2" },
+      output: firstOutput,
+      injectedSessions,
+      injectionToastShown,
+      showToast: null,
+      resolveInjectQuery,
+      buildInjectedContext,
+    });
+
+    const secondOutput = {};
+    await __testUtils.applyInjectedContextToOutput({
+      injectEnabled: true,
+      input: { sessionID: "sess-2" },
+      output: secondOutput,
+      injectedSessions,
+      injectionToastShown,
+      showToast: null,
+      resolveInjectQuery,
+      buildInjectedContext,
+    });
+
+    expect(buildInjectedContext).toHaveBeenCalledTimes(2);
+    expect(firstOutput.system).toEqual(["[codemem context]\nfirst"]);
+    expect(secondOutput.system).toEqual(["[codemem context]\nsecond"]);
+  });
+
+  test("returns false and leaves output untouched when injection yields no text", async () => {
+    const output = { system: ["existing"] };
+
+    const applied = await __testUtils.applyInjectedContextToOutput({
+      injectEnabled: true,
+      input: { sessionID: "sess-3" },
+      output,
+      injectedSessions: new Map(),
+      injectionToastShown: new Set(),
+      showToast: vi.fn(),
+      resolveInjectQuery: () => "recent work",
+      buildInjectedContext: vi.fn().mockResolvedValue(""),
+    });
+
+    expect(applied).toBe(false);
+    expect(output.system).toEqual(["existing"]);
+  });
+
+  test("returns false immediately when injection is disabled", async () => {
+    const buildInjectedContext = vi.fn();
+
+    const applied = await __testUtils.applyInjectedContextToOutput({
+      injectEnabled: false,
+      input: { sessionID: "sess-4" },
+      output: {},
+      injectedSessions: new Map(),
+      injectionToastShown: new Set(),
+      showToast: null,
+      resolveInjectQuery: () => "ignored",
+      buildInjectedContext,
+    });
+
+    expect(applied).toBe(false);
+    expect(buildInjectedContext).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/claude-hook-inject.test.ts
+++ b/packages/cli/src/commands/claude-hook-inject.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { buildClaudeHookInjection, claudeHookInjectCommand } from "./claude-hook-inject.js";
+
+describe("claude-hook-inject command", () => {
+	it("registers expected options and help text", () => {
+		const longs = claudeHookInjectCommand.options.map((option) => option.long);
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+
+		const help = claudeHookInjectCommand.helpInformation();
+		expect(help).toContain("additionalContext");
+	});
+
+	it("returns continue with local additionalContext when local pack succeeds", async () => {
+		const result = await buildClaudeHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "sess-1",
+				prompt: "fix auth callback",
+				cwd: "/tmp/codemem",
+				project: "codemem",
+			},
+			{},
+			{
+				buildLocalPack: async (context, project, dbPath) => {
+					expect(context).toBe("fix auth callback");
+					expect(project).toBe("codemem");
+					expect(dbPath).toBe("/tmp/test.sqlite");
+					return "## Summary\n[1] (decision) Auth fix";
+				},
+				httpPack: async () => {
+					throw new Error("http fallback should not run");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result).toEqual({
+			continue: true,
+			hookSpecificOutput: {
+				additionalContext: "## Summary\n[1] (decision) Auth fix",
+			},
+		});
+	});
+
+	it("falls back to HTTP pack generation when local generation fails", async () => {
+		const originalFallback = process.env.CODEMEM_INJECT_HTTP_FALLBACK;
+		const originalHttpMax = process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S;
+		process.env.CODEMEM_INJECT_HTTP_FALLBACK = "1";
+		process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S = "7";
+		try {
+			const result = await buildClaudeHookInjection(
+				{
+					hook_event_name: "UserPromptSubmit",
+					session_id: "sess-2",
+					prompt: "continue sync work",
+					cwd: "/tmp/codemem",
+					project: "codemem",
+				},
+				{},
+				{
+					buildLocalPack: async () => {
+						throw new Error("local pack failed");
+					},
+					httpPack: async (context, project, maxTimeMs) => {
+						expect(context).toBe("continue sync work");
+						expect(project).toBe("codemem");
+						expect(maxTimeMs).toBe(7000);
+						return "## Timeline\n[4] (feature) Sync continuation";
+					},
+					resolveDb: () => "/tmp/test.sqlite",
+				},
+			);
+
+			expect(result).toEqual({
+				continue: true,
+				hookSpecificOutput: {
+					additionalContext: "## Timeline\n[4] (feature) Sync continuation",
+				},
+			});
+		} finally {
+			if (originalFallback === undefined) delete process.env.CODEMEM_INJECT_HTTP_FALLBACK;
+			else process.env.CODEMEM_INJECT_HTTP_FALLBACK = originalFallback;
+			if (originalHttpMax === undefined) delete process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S;
+			else process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S = originalHttpMax;
+		}
+	});
+
+	it("returns continue without additionalContext when CODEMEM_INJECT_CONTEXT disables injection", async () => {
+		const originalInjectContext = process.env.CODEMEM_INJECT_CONTEXT;
+		process.env.CODEMEM_INJECT_CONTEXT = "0";
+		try {
+			const result = await buildClaudeHookInjection(
+				{
+					hook_event_name: "UserPromptSubmit",
+					session_id: "sess-disabled",
+					prompt: "fix auth callback",
+				},
+				{},
+				{
+					buildLocalPack: async () => {
+						throw new Error("should not build local pack when injection disabled");
+					},
+					httpPack: async () => {
+						throw new Error("should not call http fallback when injection disabled");
+					},
+					resolveDb: () => "/tmp/test.sqlite",
+				},
+			);
+
+			expect(result).toEqual({ continue: true });
+		} finally {
+			if (originalInjectContext === undefined) delete process.env.CODEMEM_INJECT_CONTEXT;
+			else process.env.CODEMEM_INJECT_CONTEXT = originalInjectContext;
+		}
+	});
+
+	it("returns continue without additionalContext when no prompt is present", async () => {
+		const result = await buildClaudeHookInjection(
+			{
+				hook_event_name: "SessionStart",
+				session_id: "sess-3",
+				cwd: "/tmp/codemem",
+			},
+			{},
+			{
+				buildLocalPack: async () => {
+					throw new Error("should not build local pack");
+				},
+				httpPack: async () => {
+					throw new Error("should not call http fallback");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result).toEqual({ continue: true });
+	});
+
+	it("truncates additionalContext to CODEMEM_INJECT_MAX_CHARS", async () => {
+		const originalMaxChars = process.env.CODEMEM_INJECT_MAX_CHARS;
+		process.env.CODEMEM_INJECT_MAX_CHARS = "12";
+		try {
+			const result = await buildClaudeHookInjection(
+				{
+					hook_event_name: "UserPromptSubmit",
+					session_id: "sess-4",
+					prompt: "viewer cards",
+				},
+				{},
+				{
+					buildLocalPack: async () => "12345678901234567890",
+					httpPack: async () => "",
+					resolveDb: () => "/tmp/test.sqlite",
+				},
+			);
+
+			expect(result).toEqual({
+				continue: true,
+				hookSpecificOutput: {
+					additionalContext: "123456789012",
+				},
+			});
+		} finally {
+			if (originalMaxChars === undefined) delete process.env.CODEMEM_INJECT_MAX_CHARS;
+			else process.env.CODEMEM_INJECT_MAX_CHARS = originalMaxChars;
+		}
+	});
+
+	it("returns continue without additionalContext when all generation paths fail", async () => {
+		const originalFallback = process.env.CODEMEM_INJECT_HTTP_FALLBACK;
+		process.env.CODEMEM_INJECT_HTTP_FALLBACK = "1";
+		try {
+			const result = await buildClaudeHookInjection(
+				{
+					hook_event_name: "UserPromptSubmit",
+					session_id: "sess-5",
+					prompt: "oauth follow-up",
+				},
+				{},
+				{
+					buildLocalPack: async () => {
+						throw new Error("local pack failed");
+					},
+					httpPack: async () => "",
+					resolveDb: () => "/tmp/test.sqlite",
+				},
+			);
+
+			expect(result).toEqual({ continue: true });
+		} finally {
+			if (originalFallback === undefined) delete process.env.CODEMEM_INJECT_HTTP_FALLBACK;
+			else process.env.CODEMEM_INJECT_HTTP_FALLBACK = originalFallback;
+		}
+	});
+});

--- a/packages/cli/src/commands/claude-hook-inject.ts
+++ b/packages/cli/src/commands/claude-hook-inject.ts
@@ -1,0 +1,207 @@
+import { MemoryStore, resolveDbPath, resolveHookProject } from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
+
+type InjectResult = {
+	continue: true;
+	hookSpecificOutput?: {
+		additionalContext: string;
+	};
+};
+
+type InjectOpts = DbOpts;
+
+type HttpPackResponse = {
+	pack_text?: string;
+};
+
+type InjectDeps = {
+	buildLocalPack?: typeof buildLocalPack;
+	httpPack?: typeof tryHttpPack;
+	resolveDb?: typeof resolveDbPath;
+};
+
+const DEFAULT_VIEWER_HOST = "127.0.0.1";
+const DEFAULT_VIEWER_PORT = 38888;
+const DEFAULT_MAX_CHARS = 16000;
+const DEFAULT_HTTP_MAX_TIME_S = 2;
+
+function emitJson(value: InjectResult | { error: string; message: string }): void {
+	console.log(JSON.stringify(value));
+}
+
+function envNotDisabled(value: string | undefined): boolean {
+	const normalized = String(value ?? "")
+		.trim()
+		.toLowerCase();
+	return normalized !== "0" && normalized !== "false" && normalized !== "off";
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+	const parsed = Number.parseInt(String(value ?? ""), 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		return fallback;
+	}
+	return parsed;
+}
+
+function continueResult(additionalContext?: string): InjectResult {
+	if (!additionalContext) {
+		return { continue: true };
+	}
+	return {
+		continue: true,
+		hookSpecificOutput: {
+			additionalContext,
+		},
+	};
+}
+
+function truncateAdditionalContext(text: string, maxChars: number): string {
+	const normalized = text.trim();
+	if (!normalized) {
+		return "";
+	}
+	if (!Number.isFinite(maxChars) || maxChars <= 0 || normalized.length <= maxChars) {
+		return normalized;
+	}
+	return normalized.slice(0, maxChars);
+}
+
+function extractInjectContext(payload: Record<string, unknown>): string | null {
+	const prompt = String(payload.prompt ?? "").trim();
+	return prompt || null;
+}
+
+function resolveInjectProject(payload: Record<string, unknown>): string | null {
+	const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
+	return resolveHookProject(cwd, payload.project);
+}
+
+async function buildLocalPack(
+	context: string,
+	project: string | null,
+	dbPath: string,
+): Promise<string> {
+	const store = new MemoryStore(dbPath);
+	try {
+		const limit = parsePositiveInt(process.env.CODEMEM_INJECT_LIMIT, 8);
+		const budget = parsePositiveInt(process.env.CODEMEM_INJECT_TOKEN_BUDGET, 800);
+		const filters: { project?: string } = {};
+		if (project) {
+			filters.project = project;
+		}
+		const pack = await store.buildMemoryPackAsync(context, limit, budget, filters);
+		return String(pack.pack_text ?? "").trim();
+	} finally {
+		store.close();
+	}
+}
+
+async function tryHttpPack(
+	context: string,
+	project: string | null,
+	maxTimeMs = DEFAULT_HTTP_MAX_TIME_S * 1000,
+): Promise<string> {
+	const host = process.env.CODEMEM_VIEWER_HOST || DEFAULT_VIEWER_HOST;
+	const port = parsePositiveInt(process.env.CODEMEM_VIEWER_PORT, DEFAULT_VIEWER_PORT);
+	const url = new URL(`http://${host}:${port}/api/pack`);
+	url.searchParams.set("context", context);
+	url.searchParams.set("limit", String(parsePositiveInt(process.env.CODEMEM_INJECT_LIMIT, 8)));
+	url.searchParams.set(
+		"token_budget",
+		String(parsePositiveInt(process.env.CODEMEM_INJECT_TOKEN_BUDGET, 800)),
+	);
+	if (project) {
+		url.searchParams.set("project", project);
+	}
+
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), maxTimeMs);
+	try {
+		const res = await fetch(url, { signal: controller.signal });
+		if (!res.ok) {
+			return "";
+		}
+		const body = (await res.json()) as HttpPackResponse;
+		return String(body.pack_text ?? "").trim();
+	} catch {
+		return "";
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+export async function buildClaudeHookInjection(
+	payload: Record<string, unknown>,
+	opts: InjectOpts,
+	deps: InjectDeps = {},
+): Promise<InjectResult> {
+	if (!envNotDisabled(process.env.CODEMEM_INJECT_CONTEXT || "1")) {
+		return continueResult();
+	}
+
+	const context = extractInjectContext(payload);
+	if (!context) {
+		return continueResult();
+	}
+
+	const buildPack = deps.buildLocalPack ?? buildLocalPack;
+	const httpPack = deps.httpPack ?? tryHttpPack;
+	const resolveDb = deps.resolveDb ?? resolveDbPath;
+	const project = resolveInjectProject(payload);
+	const maxChars = parsePositiveInt(process.env.CODEMEM_INJECT_MAX_CHARS, DEFAULT_MAX_CHARS);
+	const httpMaxTimeMs =
+		parsePositiveInt(process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S, DEFAULT_HTTP_MAX_TIME_S) * 1000;
+
+	let additionalContext = "";
+	try {
+		const dbPath = resolveDb(resolveDbOpt(opts));
+		additionalContext = await buildPack(context, project, dbPath);
+	} catch {
+		additionalContext = "";
+	}
+
+	if (!additionalContext && envNotDisabled(process.env.CODEMEM_INJECT_HTTP_FALLBACK || "1")) {
+		additionalContext = await httpPack(context, project, httpMaxTimeMs);
+	}
+
+	return continueResult(truncateAdditionalContext(additionalContext, maxChars));
+}
+
+const claudeHookInjectCmd = new Command("claude-hook-inject")
+	.configureHelp(helpStyle)
+	.description("Return Claude hook additionalContext from local pack generation");
+
+addDbOption(claudeHookInjectCmd);
+
+export const claudeHookInjectCommand = claudeHookInjectCmd.action(async (opts: InjectOpts) => {
+	let raw = "";
+	for await (const chunk of process.stdin) {
+		raw += String(chunk);
+	}
+	const trimmed = raw.trim();
+	if (!trimmed) {
+		emitJson(continueResult());
+		return;
+	}
+
+	let payload: Record<string, unknown>;
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			emitJson({ error: "parse_error", message: "payload must be a JSON object" });
+			process.exitCode = 1;
+			return;
+		}
+		payload = parsed as Record<string, unknown>;
+	} catch {
+		emitJson({ error: "parse_error", message: "invalid JSON" });
+		process.exitCode = 1;
+		return;
+	}
+
+	const result = await buildClaudeHookInjection(payload, opts);
+	emitJson(result);
+});

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -18,10 +18,7 @@ import {
 	type JsonOpts,
 	resolveDbOpt,
 } from "../shared-options.js";
-
-function collectWorkingSetFile(value: string, previous: string[]): string[] {
-	return [...previous, value];
-}
+import { buildPackRequestOptions, collectWorkingSetFile } from "./pack-shared.js";
 
 /** Parse a strict positive integer, rejecting prefixes like "12abc". */
 function parseStrictPositiveId(value: string): number | null {
@@ -215,18 +212,9 @@ function createInjectMemoryCommand(): Command {
 			emitDeprecationWarning("codemem memory inject", "codemem pack");
 			const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 			try {
-				const limit = Number.parseInt(opts.limit ?? "10", 10) || 10;
-				const budgetRaw = opts.tokenBudget ?? opts.budget;
-				const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
-				const filters: { project?: string; working_set_paths?: string[] } = {};
-				if (!opts.allProjects) {
-					const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
-					const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
-					if (project) filters.project = project;
-				}
-				if ((opts.workingSetFile?.length ?? 0) > 0) {
-					filters.working_set_paths = opts.workingSetFile;
-				}
+				const { limit, budget, filters } = buildPackRequestOptions(opts, {
+					envProject: process.env.CODEMEM_PROJECT,
+				});
 				const pack = await store.buildMemoryPackAsync(context, limit, budget, filters);
 				console.log(pack.pack_text ?? "");
 			} finally {

--- a/packages/cli/src/commands/pack-shared.test.ts
+++ b/packages/cli/src/commands/pack-shared.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { buildPackRequestOptions, collectWorkingSetFile } from "./pack-shared.js";
+
+describe("collectWorkingSetFile", () => {
+	it("appends paths in order", () => {
+		expect(collectWorkingSetFile("src/a.ts", ["src/z.ts"])).toEqual(["src/z.ts", "src/a.ts"]);
+	});
+});
+
+describe("buildPackRequestOptions", () => {
+	it("prefers CODEMEM_PROJECT over explicit project option", () => {
+		const result = buildPackRequestOptions(
+			{
+				limit: "12",
+				budget: "300",
+				project: "from-option",
+				workingSetFile: ["src/a.ts"],
+			},
+			{
+				envProject: "from-env",
+				resolveProjectFn: () => "from-resolver",
+			},
+		);
+
+		expect(result).toEqual({
+			limit: 12,
+			budget: 300,
+			filters: {
+				project: "from-env",
+				working_set_paths: ["src/a.ts"],
+			},
+		});
+	});
+
+	it("uses resolver project when env override is absent", () => {
+		const result = buildPackRequestOptions(
+			{
+				limit: "8",
+				tokenBudget: "250",
+				project: "from-option",
+			},
+			{
+				cwd: "/tmp/worktree",
+				resolveProjectFn: (cwd, project) => `${cwd}:${project}`,
+			},
+		);
+
+		expect(result).toEqual({
+			limit: 8,
+			budget: 250,
+			filters: {
+				project: "/tmp/worktree:from-option",
+			},
+		});
+	});
+
+	it("omits project filter when allProjects is enabled", () => {
+		const result = buildPackRequestOptions(
+			{
+				allProjects: true,
+				workingSetFile: ["src/a.ts", "src/b.ts"],
+			},
+			{
+				envProject: "from-env",
+				resolveProjectFn: () => "from-resolver",
+			},
+		);
+
+		expect(result).toEqual({
+			limit: 10,
+			budget: undefined,
+			filters: {
+				working_set_paths: ["src/a.ts", "src/b.ts"],
+			},
+		});
+	});
+});

--- a/packages/cli/src/commands/pack-shared.ts
+++ b/packages/cli/src/commands/pack-shared.ts
@@ -1,0 +1,50 @@
+import { resolveProject } from "@codemem/core";
+
+export type PackFilters = { project?: string; working_set_paths?: string[] };
+
+export type PackRequestOptions = {
+	limit: number;
+	budget: number | undefined;
+	filters: PackFilters;
+};
+
+export function collectWorkingSetFile(value: string, previous: string[]): string[] {
+	return [...previous, value];
+}
+
+export function buildPackRequestOptions(
+	opts: {
+		limit?: string;
+		budget?: string;
+		tokenBudget?: string;
+		workingSetFile?: string[];
+		project?: string;
+		allProjects?: boolean;
+	},
+	ctx: {
+		cwd?: string;
+		envProject?: string | null;
+		resolveProjectFn?: typeof resolveProject;
+	} = {},
+): PackRequestOptions {
+	const limit = Number.parseInt(opts.limit ?? "10", 10) || 10;
+	const budgetRaw = opts.tokenBudget ?? opts.budget;
+	const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
+	const filters: PackFilters = {};
+
+	if (!opts.allProjects) {
+		const defaultProject = ctx.envProject?.trim() || null;
+		const resolveProjectFn = ctx.resolveProjectFn ?? resolveProject;
+		const cwd = ctx.cwd ?? process.cwd();
+		const project = defaultProject || resolveProjectFn(cwd, opts.project ?? null);
+		if (project) {
+			filters.project = project;
+		}
+	}
+
+	if ((opts.workingSetFile?.length ?? 0) > 0) {
+		filters.working_set_paths = opts.workingSetFile;
+	}
+
+	return { limit, budget, filters };
+}

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -1,5 +1,5 @@
 import * as p from "@clack/prompts";
-import { MemoryStore, resolveDbPath, resolveProject } from "@codemem/core";
+import { MemoryStore, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 import {
@@ -9,10 +9,7 @@ import {
 	type JsonOpts,
 	resolveDbOpt,
 } from "../shared-options.js";
-
-function collectWorkingSetFile(value: string, previous: string[]): string[] {
-	return [...previous, value];
-}
+import { buildPackRequestOptions, collectWorkingSetFile } from "./pack-shared.js";
 
 const packCmd = new Command("pack")
 	.configureHelp(helpStyle)
@@ -48,18 +45,9 @@ export const packCommand = packCmd.action(
 	) => {
 		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 		try {
-			const limit = Number.parseInt(opts.limit, 10) || 10;
-			const budgetRaw = opts.tokenBudget ?? opts.budget;
-			const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
-			const filters: { project?: string; working_set_paths?: string[] } = {};
-			if (!opts.allProjects) {
-				const defaultProject = process.env.CODEMEM_PROJECT?.trim() || null;
-				const project = defaultProject || resolveProject(process.cwd(), opts.project ?? null);
-				if (project) filters.project = project;
-			}
-			if ((opts.workingSetFile?.length ?? 0) > 0) {
-				filters.working_set_paths = opts.workingSetFile;
-			}
+			const { limit, budget, filters } = buildPackRequestOptions(opts, {
+				envProject: process.env.CODEMEM_PROJECT,
+			});
 			const result = await store.buildMemoryPackAsync(context, limit, budget, filters);
 
 			if (opts.json) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import { VERSION } from "@codemem/core";
 import { Command } from "commander";
 import omelette from "omelette";
 import { claudeHookIngestCommand } from "./commands/claude-hook-ingest.js";
+import { claudeHookInjectCommand } from "./commands/claude-hook-inject.js";
 import { configCommand } from "./commands/config.js";
 import { coordinatorCommand } from "./commands/coordinator.js";
 import { dbCommand } from "./commands/db.js";
@@ -48,6 +49,7 @@ type CompletionWithScriptGenerators = ReturnType<typeof omelette> & {
 const completion = omelette("codemem <command>") as CompletionWithScriptGenerators;
 completion.on("command", ({ reply }) => {
 	reply([
+		"claude-hook-inject",
 		"claude-hook-ingest",
 		"config",
 		"coordinator",
@@ -168,6 +170,7 @@ program.addCommand(serveCommand);
 program.addCommand(configCommand);
 program.addCommand(coordinatorCommand);
 program.addCommand(mcpCommand);
+program.addCommand(claudeHookInjectCommand);
 program.addCommand(claudeHookIngestCommand);
 program.addCommand(dbCommand);
 program.addCommand(exportMemoriesCommand);

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -161,6 +161,111 @@ const appendWorkingSetFileArgs = (args, workingSetFiles) => {
   return args;
 };
 
+const buildInjectQuery = ({ firstPrompt, lastPromptText, projectName, filesModified }) => {
+  const parts = [];
+
+  if (firstPrompt && String(firstPrompt).trim()) {
+    parts.push(String(firstPrompt).trim());
+  }
+
+  if (
+    lastPromptText
+    && String(lastPromptText).trim()
+    && String(lastPromptText).trim() !== String(firstPrompt || "").trim()
+    && String(lastPromptText).trim().length > 5
+  ) {
+    parts.push(String(lastPromptText).trim());
+  }
+
+  if (projectName) {
+    parts.push(String(projectName));
+  }
+
+  const recentFiles = Array.from(filesModified || [])
+    .slice(-5)
+    .map((filePath) => String(filePath || "").split("/").pop())
+    .filter(Boolean)
+    .join(" ");
+  if (recentFiles) {
+    parts.push(recentFiles);
+  }
+
+  if (parts.length === 0) {
+    return "recent work";
+  }
+
+  const query = parts.join(" ");
+  return query.length > 500 ? query.slice(0, 500) : query;
+};
+
+const buildPackArgs = ({ query, filesModified, injectLimit, injectTokenBudget }) => {
+  const workingSetFiles = Array.from(filesModified || [])
+    .slice(-8)
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+  const args = ["pack", query];
+  if (injectLimit !== null && Number.isFinite(injectLimit) && injectLimit > 0) {
+    args.push("--limit", String(injectLimit));
+  }
+  if (
+    injectTokenBudget !== null
+    && Number.isFinite(injectTokenBudget)
+    && injectTokenBudget > 0
+  ) {
+    args.push("--token-budget", String(injectTokenBudget));
+  }
+  return appendWorkingSetFileArgs(args, workingSetFiles);
+};
+
+const applyInjectedContextToOutput = async ({
+  injectEnabled,
+  input,
+  output,
+  injectedSessions,
+  injectionToastShown,
+  showToast,
+  resolveInjectQuery,
+  buildInjectedContext,
+}) => {
+  if (!injectEnabled) {
+    return false;
+  }
+
+  const query = resolveInjectQuery();
+  const cached = injectedSessions.get(input.sessionID);
+  let contextText = cached?.text || "";
+
+  if (!contextText || cached?.query !== query) {
+    const injected = await buildInjectedContext(query);
+    if (injected?.text) {
+      injectedSessions.set(input.sessionID, {
+        query,
+        text: injected.text,
+        metrics: injected.metrics || null,
+      });
+      contextText = injected.text;
+
+      if (!injectionToastShown.has(input.sessionID) && showToast) {
+        injectionToastShown.add(input.sessionID);
+        try {
+          await showToast(buildInjectionToastMessage(injected.metrics));
+        } catch {
+          // best-effort only
+        }
+      }
+    }
+  }
+
+  if (!contextText) {
+    return false;
+  }
+  if (!Array.isArray(output.system)) {
+    output.system = [];
+  }
+  output.system.push(contextText);
+  return true;
+};
+
 const mapOpencodeEventTypeToAdapterType = (eventType) => {
   if (eventType === "user_prompt") {
     return "prompt";
@@ -1335,63 +1440,13 @@ export const OpencodeMemPlugin = async ({
     await showToast(`${message}. Suggested action: ${guidance.action}`, "warning");
   };
 
-  const resolveInjectQuery = () => {
-    const parts = [];
-
-    // First prompt captures session intent (most stable signal)
-    if (sessionContext.firstPrompt && sessionContext.firstPrompt.trim()) {
-      parts.push(sessionContext.firstPrompt.trim());
-    }
-
-    // Latest prompt adds current focus (skip if same as first, or trivial)
-    if (
-      lastPromptText &&
-      lastPromptText.trim() &&
-      lastPromptText.trim() !== (sessionContext.firstPrompt || "").trim() &&
-      lastPromptText.trim().length > 5
-    ) {
-      parts.push(lastPromptText.trim());
-    }
-
-    // Project name for scoping
-    const projectName = resolveProjectName(project, cwd);
-    if (projectName) {
-      parts.push(projectName);
-    }
-
-    // Recently modified files signal what area of the codebase we're in
-    if (sessionContext.filesModified.size > 0) {
-      const recentFiles = Array.from(sessionContext.filesModified)
-        .slice(-5)
-        .map((f) => f.split("/").pop())
-        .join(" ");
-      parts.push(recentFiles);
-    }
-
-    if (parts.length === 0) {
-      return "recent work";
-    }
-
-    // Cap total length to avoid overly long CLI args
-    const query = parts.join(" ");
-    return query.length > 500 ? query.slice(0, 500) : query;
-  };
-
-  const buildPackArgs = (query) => {
-    const workingSetFiles = Array.from(sessionContext.filesModified)
-      .slice(-8)
-      .map((value) => String(value || "").trim())
-      .filter(Boolean);
-    const args = ["pack", query];
-    if (injectLimit !== null && Number.isFinite(injectLimit) && injectLimit > 0) {
-      args.push("--limit", String(injectLimit));
-    }
-    if (injectTokenBudget !== null && Number.isFinite(injectTokenBudget) && injectTokenBudget > 0) {
-      args.push("--token-budget", String(injectTokenBudget));
-    }
-    appendWorkingSetFileArgs(args, workingSetFiles);
-    return args;
-  };
+  const resolveInjectQuery = () =>
+    buildInjectQuery({
+      firstPrompt: sessionContext.firstPrompt,
+      lastPromptText,
+      projectName: resolveProjectName(project, cwd),
+      filesModified: sessionContext.filesModified,
+    });
 
   const parsePackText = (stdout) => {
     if (!stdout || !stdout.trim()) {
@@ -1424,7 +1479,12 @@ export const OpencodeMemPlugin = async ({
   };
 
   const buildInjectedContext = async (query) => {
-    const packArgs = buildPackArgs(query);
+    const packArgs = buildPackArgs({
+      query,
+      filesModified: sessionContext.filesModified,
+      injectLimit,
+      injectTokenBudget,
+    });
     const result = await runCli(packArgs);
     if (!result || result.exitCode !== 0) {
       const exitCode = result?.exitCode ?? "unknown";
@@ -1681,9 +1741,6 @@ export const OpencodeMemPlugin = async ({
 
   return {
     "experimental.chat.system.transform": async (input, output) => {
-      if (!injectEnabled) {
-        return;
-      }
       const query = resolveInjectQuery();
       if (debug) {
         await logLine(
@@ -1692,40 +1749,25 @@ export const OpencodeMemPlugin = async ({
           } tui_toast=${Boolean(client.tui?.showToast)}`
         );
       }
-      const cached = injectedSessions.get(input.sessionID);
-      let contextText = cached?.text || "";
-      if (!contextText || cached?.query !== query) {
-        const injected = await buildInjectedContext(query);
-        if (injected?.text) {
-          injectedSessions.set(input.sessionID, {
-            query,
-            text: injected.text,
-            metrics: injected.metrics || null,
-          });
-          contextText = injected.text;
-
-            if (!injectionToastShown.has(input.sessionID) && client.tui?.showToast) {
-              injectionToastShown.add(input.sessionID);
-              try {
-                await client.tui.showToast({
-                  body: {
-                    message: buildInjectionToastMessage(injected.metrics),
-                    variant: "info",
-                  },
-                });
-            } catch (toastErr) {
-              // best-effort only
-            }
+      await applyInjectedContextToOutput({
+        injectEnabled,
+        input,
+        output,
+        injectedSessions,
+        injectionToastShown,
+        showToast: client.tui?.showToast
+          ? async (message) => {
+            await client.tui.showToast({
+              body: {
+                message,
+                variant: "info",
+              },
+            });
           }
-        }
-      }
-      if (!contextText) {
-        return;
-      }
-      if (!Array.isArray(output.system)) {
-        output.system = [];
-      }
-      output.system.push(contextText);
+          : null,
+        resolveInjectQuery,
+        buildInjectedContext,
+      });
     },
     event: async ({ event }) => {
       const eventType = event?.type || "unknown";
@@ -2009,6 +2051,9 @@ export const __testUtils = {
   inferProjectFromCwd,
   normalizeProjectLabel,
   resolveProjectName,
+  buildInjectQuery,
+  buildPackArgs,
+  applyInjectedContextToOutput,
   buildRunnerArgs,
   appendWorkingSetFileArgs,
   extractApplyPatchPaths,


### PR DESCRIPTION
## Description
Restores and validates the adapter-side context injection contract. This adds direct OpenCode injection coverage, restores the missing Claude hook injection command, and consolidates shared CLI pack-request plumbing so adapter behavior stops drifting silently.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 🚀 Feature (new functionality)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [ ] Tests pass locally (`pytest`)
- Validated with:
  - `pnpm --filter codemem test:plugin`
  - `pnpm --filter codemem exec vitest run src/commands/pack-shared.test.ts src/commands/memory.test.ts src/commands/claude-hook-inject.test.ts src/commands/claude-hook-ingest.test.ts`
  - `pnpm --filter codemem run build`

## Checklist
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] No new warnings introduced
