### PR TITLE
fix: reuse stable sessions for raw-event ingest

### DIFF
--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -225,25 +225,40 @@ export async function ingest(
 	const now = new Date().toISOString();
 	const project = normalizeProjectLabel(payload.project) ?? resolveProject(cwd) ?? null;
 
-	const rows = d
-		.insert(schema.sessions)
-		.values({
-			started_at: now,
-			cwd,
-			project,
-			user: process.env.USER ?? "unknown",
-			tool_version: "plugin-ts",
-			metadata_json: toJson({
-				source: "plugin",
-				event_count: events.length,
-				started_at: payload.startedAt,
-				session_context: sessionContext,
-			}),
-		})
-		.returning({ id: schema.sessions.id })
-		.all();
-	const sessionId = rows[0]?.id;
-	if (sessionId == null) throw new Error("session insert returned no id");
+	const sessionMetadata = {
+		source: "plugin",
+		event_count: events.length,
+		started_at: payload.startedAt,
+		session_context: sessionContext,
+	};
+	const sessionId =
+		sessionContext.flusher === "raw_events" && sessionContext.opencodeSessionId
+			? store.getOrCreateSessionForOpencodeSession({
+					opencodeSessionId: sessionContext.opencodeSessionId,
+					source: sessionContext.source,
+					cwd,
+					project,
+					metadata: sessionMetadata,
+					startedAt: payload.startedAt ?? now,
+					toolVersion: "raw_events",
+				})
+			: (() => {
+					const rows = d
+						.insert(schema.sessions)
+						.values({
+							started_at: now,
+							cwd,
+							project,
+							user: process.env.USER ?? "unknown",
+							tool_version: "plugin-ts",
+							metadata_json: toJson(sessionMetadata),
+						})
+						.returning({ id: schema.sessions.id })
+						.all();
+					const id = rows[0]?.id;
+					if (id == null) throw new Error("session insert returned no id");
+					return id;
+				})();
 
 	try {
 		// ------------------------------------------------------------------

--- a/packages/core/src/raw-event-flush.test.ts
+++ b/packages/core/src/raw-event-flush.test.ts
@@ -62,6 +62,28 @@ describe("flushRawEvents max retry", () => {
 		}),
 	};
 
+	const summaryObserver = {
+		observe: async () => ({
+			raw: `<summary>
+				<request>Investigate auth timeout</request>
+				<investigated>Session handling code</investigated>
+				<learned>Race condition in handler</learned>
+				<completed>Added callback validation</completed>
+				<next_steps>Add regression test</next_steps>
+				<notes></notes>
+			</summary>`,
+			parsed: null,
+			provider: "test",
+			model: "test-model",
+		}),
+		getStatus: () => ({
+			provider: "test",
+			model: "test-model",
+			runtime: "test",
+			auth: { source: "none", type: "none", hasToken: false },
+		}),
+	};
+
 	it("gives up after max attempts and advances flush cursor", async () => {
 		process.env.CODEMEM_RAW_EVENTS_MAX_FLUSH_ATTEMPTS = "3";
 		const sessionId = "ses_max_retry_test";
@@ -203,5 +225,64 @@ describe("flushRawEvents max retry", () => {
 			.prepare("SELECT status FROM raw_event_flush_batches WHERE opencode_session_id = ?")
 			.get(sessionId) as { status: string };
 		expect(after.status).toBe("gave_up");
+	});
+
+	it("reuses one local session per stable raw-event session id", async () => {
+		const sessionId = "ses_bridge_reuse";
+		seedEvents(sessionId);
+
+		const ingestOpts = { observer: summaryObserver } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: null,
+			project: null,
+			startedAt: "2026-03-01T10:00:00Z",
+			maxEvents: null,
+		};
+
+		const first = await flushRawEvents(store, ingestOpts, flushOpts);
+		expect(first.updatedState).toBe(1);
+
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-3",
+			eventType: "assistant_message",
+			payload: { type: "assistant_message", assistant_text: "Added validation." },
+			tsWallMs: 300,
+		});
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			eventId: "evt-4",
+			eventType: "tool.execute.after",
+			payload: {
+				type: "tool.execute.after",
+				tool: "edit",
+				args: { filePath: "/tmp/y.ts" },
+			},
+			tsWallMs: 400,
+		});
+
+		const second = await flushRawEvents(store, ingestOpts, flushOpts);
+		expect(second.updatedState).toBe(1);
+
+		const opencodeBridge = store.db
+			.prepare(
+				"SELECT session_id FROM opencode_sessions WHERE source = 'opencode' AND stream_id = ?",
+			)
+			.get(sessionId) as { session_id: number } | undefined;
+		expect(opencodeBridge?.session_id).toBeDefined();
+
+		const localSessionCount = store.db.prepare("SELECT COUNT(*) AS count FROM sessions").get() as {
+			count: number;
+		};
+		expect(localSessionCount.count).toBe(1);
+
+		const memorySessionCounts = store.db
+			.prepare(
+				"SELECT COUNT(DISTINCT session_id) AS count FROM memory_items WHERE active = 1 AND json_extract(metadata_json, '$.source') = 'observer_summary'",
+			)
+			.get() as { count: number };
+		expect(memorySessionCounts.count).toBe(1);
 	});
 });

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -312,6 +312,73 @@ export class MemoryStore {
 		return id;
 	}
 
+	getOrCreateSessionForOpencodeSession(opts: {
+		opencodeSessionId: string;
+		source?: string;
+		cwd?: string;
+		project?: string | null;
+		metadata?: Record<string, unknown>;
+		startedAt?: string | null;
+		toolVersion?: string;
+		user?: string;
+	}): number {
+		const [source, streamId] = this.normalizeStreamIdentity(
+			opts.source ?? "opencode",
+			opts.opencodeSessionId,
+		);
+		const existing = this.d
+			.select({ session_id: schema.opencodeSessions.session_id })
+			.from(schema.opencodeSessions)
+			.where(
+				and(
+					eq(schema.opencodeSessions.source, source),
+					eq(schema.opencodeSessions.stream_id, streamId),
+				),
+			)
+			.get();
+		if (existing?.session_id != null) {
+			return Number(existing.session_id);
+		}
+
+		const startedAt = opts.startedAt ?? nowIso();
+		const sessionRows = this.d
+			.insert(schema.sessions)
+			.values({
+				started_at: startedAt,
+				cwd: opts.cwd ?? process.cwd(),
+				project: opts.project ?? null,
+				git_remote: null,
+				git_branch: null,
+				user: opts.user ?? process.env.USER ?? "unknown",
+				tool_version: opts.toolVersion ?? "raw_events",
+				metadata_json: toJson(opts.metadata ?? {}),
+			})
+			.returning({ id: schema.sessions.id })
+			.all();
+		const sessionId = sessionRows[0]?.id;
+		if (sessionId == null) throw new Error("session insert returned no id");
+
+		this.d
+			.insert(schema.opencodeSessions)
+			.values({
+				opencode_session_id: streamId,
+				source,
+				stream_id: streamId,
+				session_id: sessionId,
+				created_at: nowIso(),
+			})
+			.onConflictDoUpdate({
+				target: [schema.opencodeSessions.source, schema.opencodeSessions.stream_id],
+				set: {
+					opencode_session_id: sql`excluded.opencode_session_id`,
+					session_id: sql`excluded.session_id`,
+				},
+			})
+			.run();
+
+		return Number(sessionId);
+	}
+
 	/**
 	 * End a session by recording ended_at.
 	 * FIX: merges incoming metadata with existing instead of replacing.


### PR DESCRIPTION
## Description
Restores Python-parity raw-event session bridging in the TypeScript ingest path. Raw-event flushes now reuse or create one local session per stable OpenCode stream and upsert the `opencode_sessions` bridge row, preventing repeated flushes from creating detached unmapped micro-sessions and summary rows.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [ ] Tests pass locally (`pytest`)
- Validated with:
  - `pnpm vitest run packages/core/src/raw-event-flush.test.ts packages/core/src/ingest-pipeline.test.ts packages/core/src/store.test.ts`
  - `pnpm --filter @codemem/core run build`

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] No new warnings introduced
