### PR TITLE
fix: transparently relink raw-event session fragments on startup

### DIFF
--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -208,6 +208,50 @@ describe("serve command option resolution", () => {
 		}
 	});
 
+	it("repairs relinkable raw-event session fragments during viewer DB preparation", () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-serve-relink-"));
+		const dbPath = join(dir, "viewer.sqlite");
+		try {
+			prepareViewerDatabase(dbPath);
+			const db = new MemoryStore(dbPath);
+			try {
+				db.db.exec(`
+					INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+					  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"flusher":"raw_events","streamId":"ses-1","source":"opencode"}}'),
+					  (2, '2026-03-01T10:12:00Z', '2026-03-01T10:13:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"flusher":"raw_events","streamId":"ses-1","source":"opencode"}}');
+					INSERT INTO memory_items(
+						id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+					) VALUES
+					  (1, 1, 'session_summary', 'Summary 1', 'body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1'),
+					  (2, 2, 'decision', 'Decision 2', 'body', 1, '2026-03-01T10:13:00Z', '2026-03-01T10:13:00Z', '{}', 'k2');
+				`);
+			} finally {
+				db.close();
+			}
+
+			prepareViewerDatabase(dbPath);
+
+			const verify = new MemoryStore(dbPath);
+			try {
+				const bridge = verify.db
+					.prepare(
+						"SELECT session_id FROM opencode_sessions WHERE source = 'opencode' AND stream_id = 'ses-1'",
+					)
+					.get() as { session_id: number };
+				expect(bridge.session_id).toBe(1);
+
+				const movedMemory = verify.db
+					.prepare("SELECT session_id FROM memory_items WHERE id = 2")
+					.get() as { session_id: number };
+				expect(movedMemory.session_id).toBe(1);
+			} finally {
+				verify.close();
+			}
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("distinguishes loopback-only viewer binds from network-exposed binds", () => {
 		expect(isLoopbackOnlyHost("127.0.0.1")).toBe(true);
 		expect(isLoopbackOnlyHost("127.0.0.2")).toBe(true);

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import {
+	applyRawEventRelinkPlan,
 	initDatabase,
 	isEmbeddingDisabled,
 	type MemoryStore,
@@ -83,7 +84,9 @@ export function isLikelyViewerCommand(command: string): boolean {
 }
 
 export function prepareViewerDatabase(dbPath?: string | null): string {
-	return initDatabase(dbPath ?? undefined).path;
+	const path = initDatabase(dbPath ?? undefined).path;
+	applyRawEventRelinkPlan(path, { dryRun: false });
+	return path;
 }
 
 export function pickViewerPidCandidate(

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -536,6 +536,12 @@ describe("maintenance", () => {
 		expect(result.memory_repoints).toBe(1);
 		expect(result.session_compactions).toBe(1);
 
+		const secondRun = applyRawEventRelinkPlan(dbPath, { limit: 10, dryRun: false });
+		expect(secondRun.dry_run).toBe(false);
+		expect(secondRun.bridge_creations).toBe(0);
+		expect(secondRun.memory_repoints).toBe(0);
+		expect(secondRun.session_compactions).toBe(0);
+
 		const verify = new Database(dbPath);
 		try {
 			const bridge = verify

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -707,6 +707,7 @@ export function getRawEventRelinkReport(
 						json_extract(s.metadata_json, '$.session_context.opencodeSessionId'),
 						json_extract(s.metadata_json, '$.session_context.streamId')
 					  ) IS NOT NULL
+				  AND json_extract(s.metadata_json, '$.merged_into_session_id') IS NULL
 				  ${projectClause}
 				ORDER BY s.started_at DESC, s.id DESC`,
 			)

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -676,7 +676,7 @@ export function getRawEventRelinkReport(
 		const projectFilter = opts.allProjects ? null : opts.project?.trim() || null;
 		const projectClause = projectFilter ? "AND s.project = ?" : "";
 		const params = projectFilter ? [projectFilter] : [];
-		const limit = Math.max(1, opts.limit ?? 25);
+		const limit = opts.limit == null ? Number.MAX_SAFE_INTEGER : Math.max(1, opts.limit);
 
 		const rows = db
 			.prepare(


### PR DESCRIPTION
## Description
Wires the raw-event relink repair path into viewer startup so the database can transparently repair eligible fragmented raw-event sessions without requiring user action. Startup now runs the internal relink executor after database initialization, creating missing bridges and relinking safe groups automatically.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [ ] Tests pass locally (`pytest`)
- Validated with:
  - `pnpm vitest run packages/core/src/maintenance.test.ts packages/cli/src/commands/serve.test.ts packages/cli/src/commands/memory.test.ts packages/cli/src/commands/db.test.ts`
  - `pnpm exec biome check packages/core/src/maintenance.ts packages/core/src/maintenance.test.ts packages/core/src/index.ts packages/cli/src/commands/serve.ts packages/cli/src/commands/serve.test.ts packages/cli/src/commands/memory.ts packages/cli/src/commands/memory.test.ts packages/cli/src/commands/db.test.ts`
  - `pnpm --filter @codemem/core run build`

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] No new warnings introduced
