### PR TITLE
fix: suppress low-signal recap summaries at ingest

### DIFF
--- a/packages/core/src/ingest-filters.ts
+++ b/packages/core/src/ingest-filters.ts
@@ -30,6 +30,14 @@ const LOW_SIGNAL_OBSERVATION_PATTERNS: RegExp[] = [
 	/\bprimary\s+user\s+request\s+details\s+were\s+absent\b/i,
 ];
 
+const LOW_SIGNAL_SUMMARY_PATTERNS: RegExp[] = [
+	/\bcheck\s+logs?\b/i,
+	/\binspect(?:ed|ion)?\s+(?:the\s+)?current\s+state\b/i,
+	/\breview(?:ed|ing)?\s+(?:the\s+)?current\s+state\b/i,
+	/\bverify\s+the\s+current\s+state\b/i,
+	/\bno\s+(?:meaningful|substantive)\s+(?:changes|updates|deliverables?)\b/i,
+];
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -51,4 +59,11 @@ export function isLowSignalObservation(text: string): boolean {
 	const normalized = normalizeObservation(text);
 	if (!normalized) return true;
 	return LOW_SIGNAL_OBSERVATION_PATTERNS.some((p) => p.test(normalized));
+}
+
+export function isLowSignalSummary(text: string): boolean {
+	const normalized = normalizeObservation(text);
+	if (!normalized) return true;
+	if (normalized.length < 40) return true;
+	return LOW_SIGNAL_SUMMARY_PATTERNS.some((p) => p.test(normalized));
 }

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -707,6 +707,84 @@ describe("ingest() integration", () => {
 		expect(store.recent(10)).toHaveLength(0);
 	});
 
+	it("suppresses low-signal summary-only output for tiny sessions", async () => {
+		const weakSummaryObserver = {
+			observe: async () => ({
+				raw: `<summary><request>Check logs</request><completed>Checked logs</completed></summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-summary-weak",
+				promptCount: 1,
+				toolCount: 1,
+				durationMs: 1000,
+				flusher: "raw_events",
+			},
+		});
+
+		await expect(
+			ingest(payload, store, { observer: weakSummaryObserver } as unknown as IngestOptions),
+		).rejects.toThrow("observer produced no storable output for raw-event flush");
+
+		expect(store.recent(10)).toHaveLength(0);
+	});
+
+	it("keeps substantive summary output when it carries clear signal", async () => {
+		const strongSummaryObserver = {
+			observe: async () => ({
+				raw: `<summary>
+				<request>Investigate auth timeout</request>
+				<investigated>Reviewed the callback validation path and request timing to isolate where duplicate retries were introduced.</investigated>
+				<learned>Discovered the retry loop was triggered by a state mismatch after callback validation completed, which explains the intermittent timeout symptoms.</learned>
+				<completed>Documented the auth timeout root cause and outlined the regression coverage needed before changing retry handling.</completed>
+			</summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-summary-strong",
+				promptCount: 2,
+				toolCount: 3,
+				durationMs: 4 * 60_000,
+				flusher: "raw_events",
+			},
+		});
+
+		await ingest(payload, store, { observer: strongSummaryObserver } as unknown as IngestOptions);
+
+		const summary = store.db
+			.prepare(
+				"SELECT kind, title, body_text FROM memory_items WHERE kind = 'session_summary' ORDER BY id DESC LIMIT 1",
+			)
+			.get() as { kind: string; title: string; body_text: string };
+		expect(summary.kind).toBe("session_summary");
+		expect(summary.title).toBe("Investigate auth timeout");
+		expect(summary.body_text).toContain("retry loop");
+	});
+
 	it("retries once when observer returns plain text instead of XML during raw-event flush", async () => {
 		let calls = 0;
 		const retryingObserver = {
@@ -721,7 +799,12 @@ describe("ingest() integration", () => {
 					};
 				}
 				return {
-					raw: `<summary><request>Check restart state</request><completed>Confirmed the observer needed an XML retry.</completed></summary>`,
+					raw: `<summary>
+						<request>Check restart state</request>
+						<investigated>Reviewed the restart flow and observer response handling to confirm why the first pass produced plain text instead of XML.</investigated>
+						<completed>Confirmed the observer needed an XML retry and documented the restart-state path that should be preserved in future retries.</completed>
+						<learned>The retry path must preserve the original restart context or the summary becomes too generic to store safely.</learned>
+					</summary>`,
 					parsed: null,
 					provider: "test",
 					model: "test-model",

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -30,7 +30,7 @@ import {
 	extractToolEvents,
 	projectAdapterToolEvent,
 } from "./ingest-events.js";
-import { isLowSignalObservation } from "./ingest-filters.js";
+import { isLowSignalObservation, isLowSignalSummary } from "./ingest-filters.js";
 import { buildObserverPrompt } from "./ingest-prompts.js";
 import {
 	buildTranscript,
@@ -107,6 +107,39 @@ function summaryBody(summary: ParsedSummary): string {
 		.filter(([, value]) => value)
 		.map(([label, value]) => `## ${label}\n${value}`)
 		.join("\n\n");
+}
+
+function summaryHasMeaningfulSignal(args: {
+	summary: ParsedSummary;
+	body: string;
+	observationsCount: number;
+	sessionContext: SessionContext | null;
+}): boolean {
+	const { summary, body, observationsCount, sessionContext } = args;
+	if (!body || isLowSignalSummary(firstSentence(body))) {
+		return false;
+	}
+	if (observationsCount > 0) return true;
+	if ((summary.filesModified?.length ?? 0) > 0) return true;
+	if ((summary.filesRead?.length ?? 0) > 0) return true;
+
+	const substantiveSections = [
+		summary.completed,
+		summary.learned,
+		summary.investigated,
+		summary.nextSteps,
+		summary.notes,
+	].filter((value) => value && value.trim().length >= 40);
+	if (substantiveSections.length >= 2) return true;
+
+	const promptCount = sessionContext?.promptCount ?? 0;
+	const toolCount = sessionContext?.toolCount ?? 0;
+	const durationMs = sessionContext?.durationMs ?? 0;
+	if (promptCount <= 1 && toolCount <= 1 && durationMs < 2 * 60_000) {
+		return false;
+	}
+
+	return substantiveSections.length >= 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -421,7 +454,14 @@ export async function ingest(
 				}
 
 				const body = summaryBody(summary);
-				if (body && !isLowSignalObservation(firstSentence(body))) {
+				if (
+					summaryHasMeaningfulSignal({
+						summary,
+						body,
+						observationsCount: observationsToStore.length,
+						sessionContext,
+					})
+				) {
 					summaryToStore = { summary, request, body };
 				}
 			}

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -38,7 +38,6 @@ import {
 	extractAssistantMessages,
 	extractAssistantUsage,
 	extractPrompts,
-	firstSentence,
 	isTrivialRequest,
 	normalizeAdapterEvents,
 } from "./ingest-transcript.js";
@@ -116,7 +115,7 @@ function summaryHasMeaningfulSignal(args: {
 	sessionContext: SessionContext | null;
 }): boolean {
 	const { summary, body, observationsCount, sessionContext } = args;
-	if (!body || isLowSignalSummary(firstSentence(body))) {
+	if (!body) {
 		return false;
 	}
 	if (observationsCount > 0) return true;
@@ -136,10 +135,10 @@ function summaryHasMeaningfulSignal(args: {
 	const toolCount = sessionContext?.toolCount ?? 0;
 	const durationMs = sessionContext?.durationMs ?? 0;
 	if (promptCount <= 1 && toolCount <= 1 && durationMs < 2 * 60_000) {
-		return false;
+		return !isLowSignalSummary(body) && substantiveSections.length >= 1;
 	}
 
-	return substantiveSections.length >= 1;
+	return !isLowSignalSummary(body) && substantiveSections.length >= 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/raw-event-flush.test.ts
+++ b/packages/core/src/raw-event-flush.test.ts
@@ -66,10 +66,10 @@ describe("flushRawEvents max retry", () => {
 		observe: async () => ({
 			raw: `<summary>
 				<request>Investigate auth timeout</request>
-				<investigated>Session handling code</investigated>
-				<learned>Race condition in handler</learned>
-				<completed>Added callback validation</completed>
-				<next_steps>Add regression test</next_steps>
+				<investigated>Reviewed the session handling code to trace why callback retries were creating duplicate raw-event flushes for the same stable session stream.</investigated>
+				<learned>Discovered the retry path could race with callback validation and create fragmented local sessions unless the stable stream mapping was reused consistently.</learned>
+				<completed>Added callback validation and confirmed the raw-event ingest path reused the stable session mapping instead of minting another detached local session.</completed>
+				<next_steps>Add regression coverage for repeated raw-event flushes on one stable session id.</next_steps>
 				<notes></notes>
 			</summary>`,
 			parsed: null,

--- a/packages/core/src/raw-event-sweeper.test.ts
+++ b/packages/core/src/raw-event-sweeper.test.ts
@@ -151,8 +151,10 @@ describe("RawEventSweeper auto flush", () => {
 		observer: {
 			observe: async () => ({
 				raw: `<summary>
-  <request>Auto flush request</request>
-  <completed>Flushed debounced raw events</completed>
+	<request>Auto flush request</request>
+	<investigated>Reviewed the debounced raw-event flush path to confirm the sweeper still preserves enough context for a durable summary after automatic flushing.</investigated>
+	<completed>Flushed debounced raw events and verified the resulting session summary captured the key outcome instead of collapsing into low-signal recap text.</completed>
+	<learned>Automatic raw-event flushes need richer summary content than a tiny completed note or the ingest gate will correctly discard them.</learned>
 </summary>`,
 				parsed: null,
 				provider: "test",
@@ -207,7 +209,12 @@ describe("RawEventSweeper auto flush", () => {
 					await sleep(80);
 					resolved = true;
 					return {
-						raw: `<summary><request>stop</request><completed>done</completed></summary>`,
+						raw: `<summary>
+							<request>stop</request>
+							<investigated>Reviewed the stop path to ensure the active raw-event flush can finish cleanly before shutdown returns control to the caller.</investigated>
+							<completed>Confirmed the in-flight flush completed and persisted the stop-state handoff without dropping the current batch.</completed>
+							<learned>Shutdown correctness depends on preserving enough context for the flush summary to remain storable after the observer finishes.</learned>
+						</summary>`,
 						parsed: null,
 						provider: "test",
 						model: "test",
@@ -261,7 +268,12 @@ describe("RawEventSweeper auto flush", () => {
 						await sleep(60);
 					}
 					return {
-						raw: `<summary><request>rerun</request><completed>done</completed></summary>`,
+						raw: `<summary>
+							<request>rerun</request>
+							<investigated>Observed the rerun path while new activity arrived mid-flush so the sweeper could prove it schedules a second pass instead of discarding the extra event.</investigated>
+							<completed>Confirmed the second pass preserved the late-arriving tool event and advanced the flush state after the queued rerun finished.</completed>
+							<learned>Mid-flush arrivals need enough retained context to produce a real summary on the rerun rather than collapsing into low-signal recap sludge.</learned>
+						</summary>`,
 						parsed: null,
 						provider: "test",
 						model: "test",
@@ -422,7 +434,12 @@ describe("RawEventSweeper auto flush", () => {
 				observe: async () => {
 					observerCalls += 1;
 					return {
-						raw: `<summary><request>Investigate a real issue</request><completed>Captured adapter wrapped session.</completed></summary>`,
+						raw: `<summary>
+							<request>Investigate a real issue</request>
+							<investigated>Reviewed the adapter-wrapped prompt path to confirm the sweeper still forwards a meaningful observer transcript for wrapped user prompts.</investigated>
+							<completed>Captured the adapter wrapped session and verified it produced a durable summary rather than being misclassified as low-signal lifecycle noise.</completed>
+							<learned>Adapter-wrapped prompts must keep enough semantic context for summary storage or the raw-event path regresses into repeated unstorable flushes.</learned>
+						</summary>`,
 						parsed: null,
 						provider: "test",
 						model: "test",


### PR DESCRIPTION
## Description
Tightens recap/session-summary emission so weak summary-only micro-session output is suppressed earlier in ingest. This reduces recap sludge at write time by requiring stronger signal before a `session_summary` is persisted, while still preserving substantive summary output.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [ ] Tests pass locally (`pytest`)
- Validated with:
  - `pnpm vitest run packages/core/src/ingest-pipeline.test.ts packages/core/src/maintenance.test.ts packages/cli/src/commands/serve.test.ts`
  - `pnpm exec biome check packages/core/src/ingest-filters.ts packages/core/src/ingest-pipeline.ts packages/core/src/ingest-pipeline.test.ts`
  - `pnpm --filter @codemem/core run build`

## Checklist
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] No new warnings introduced
