### PR TITLE
build: enforce tsc in CI and require Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,28 @@ on:
   workflow_call:
 
 jobs:
+  tsc:
+    name: TypeScript Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: TypeScript project reference check
+        run: pnpm run tsc
+
   ts-test:
     name: TypeScript Test
     runs-on: ubuntu-latest
@@ -112,10 +134,6 @@ jobs:
   packaged-plugin-smoke:
     name: Packaged Plugin Smoke Test
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v4
@@ -126,7 +144,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24
           cache: pnpm
 
       - name: Install workspace dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Release checklist:
 
 ## Stack
 
-- Node: >=22
+- Node: >=24
 - Package manager: pnpm (workspace at root)
 - Build: Vite 8 (library mode, Rolldown-powered)
 - Tests: vitest
@@ -92,7 +92,7 @@ The published OpenCode plugin package is `@codemem/opencode-plugin` from `packag
 - Build all TS packages: `pnpm build`
 - Run tests: `pnpm run test`
 - Lint: `pnpm run lint`
-- Typecheck: `pnpm run typecheck`
+- Typecheck: `pnpm run tsc`
 - Run TS CLI from source: `pnpm run codemem --help`
 
 ### Legacy Python setup (only when required)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Run these before opening a PR:
 
 ```text
 pnpm run lint
-pnpm run typecheck
+pnpm run tsc
 pnpm run test
 pnpm build
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Persistent memory for [OpenCode](https://opencode.ai) and [Claude Code](https://
 
 ## Quick start
 
-**Prerequisites:** Node.js 22+ and npm (or pnpm)
+**Prerequisites:** Node.js 24+ and npm (or pnpm)
 
 ### OpenCode
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "test:release-version": "node --test scripts/release-version.test.mjs",
     "lint": "pnpm exec biome check packages/",
     "format": "pnpm exec biome check --write packages/",
-    "typecheck": "pnpm exec tsc --build",
-    "check": "pnpm run typecheck && pnpm run lint && pnpm run test",
+    "tsc": "pnpm exec tsc --build",
+    "typecheck": "pnpm run tsc",
+    "check": "pnpm run tsc && pnpm run lint && pnpm run test",
     "codemem": "tsx --conditions source packages/cli/src/index.ts",
     "release:version": "node scripts/release-version.mjs",
     "release:preflight-tag": "bash scripts/release-tag-preflight.sh"
@@ -33,7 +34,7 @@
 		"vitest": "catalog:"
 	},
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "pnpm": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
 		"vitest": "catalog:"
 	},
 	"engines": {
-		"node": ">=22"
+		"node": ">=24"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,9 @@
 		"url": "git+https://github.com/kunickiaj/codemem.git",
 		"directory": "packages/core"
 	},
+	"engines": {
+		"node": ">=24"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -37,6 +37,9 @@
 		"url": "git+https://github.com/kunickiaj/codemem.git",
 		"directory": "packages/mcp-server"
 	},
+	"engines": {
+		"node": ">=24"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -32,6 +32,9 @@
 	"bugs": {
 		"url": "https://github.com/kunickiaj/codemem/issues"
 	},
+	"engines": {
+		"node": ">=24"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -40,6 +40,9 @@
 		"url": "git+https://github.com/kunickiaj/codemem.git",
 		"directory": "packages/viewer-server"
 	},
+	"engines": {
+		"node": ">=24"
+	},
 	"license": "MIT",
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Description
This PR adds a canonical root `pnpm run tsc` command, keeps `typecheck` as a compatibility alias, and updates CI to enforce the workspace TypeScript project-reference check. It also raises the declared Node support floor to 24+ and aligns package metadata and user-facing docs with the runtime version we actually test and run.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:
- `pnpm run tsc`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] No new warnings introduced