### PR TITLE
fix: harden raw-event session reconciliation

### DIFF
--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import {
+	applyRawEventRelinkPlan,
 	backfillTagsText,
 	deactivateLowSignalMemories,
 	deactivateLowSignalObservations,
@@ -449,6 +450,37 @@ describe("maintenance", () => {
 		);
 	});
 
+	it("ignores unrelated bridge rows when selecting mapped canonical sessions", () => {
+		const dbPath = createDbPath("raw-event-relink-report-unrelated-bridge");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-1"}}'),
+				  (2, '2026-03-01T10:12:00Z', '2026-03-01T10:13:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-1"}}'),
+				  (3, '2026-03-01T10:14:00Z', '2026-03-01T10:15:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-other"}}');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'ses-other', 'ses-other', 2, '2026-03-01T10:14:00Z');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const report = getRawEventRelinkReport(dbPath, { limit: 10 });
+		const ses1Group = report.groups.find((group) => group.stable_id === "ses-1");
+
+		expect(ses1Group).toEqual(
+			expect.objectContaining({
+				mapped_sessions: 0,
+				unmapped_sessions: 2,
+				canonical_session_id: 1,
+				canonical_reason: "oldest_unmapped_session",
+				would_create_bridge: true,
+			}),
+		);
+	});
+
 	it("separates relink groups by source even when stable ids match", () => {
 		const dbPath = createDbPath("raw-event-relink-report-source-scope");
 		const db = new Database(dbPath);
@@ -517,5 +549,210 @@ describe("maintenance", () => {
 				canonical_session_id: 1,
 			}),
 		]);
+	});
+
+	it("applies raw-event relink remediation and compacts duplicate sessions", () => {
+		const dbPath = createDbPath("raw-event-relink-apply");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"source":"plugin","session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-1"}}'),
+				  (2, '2026-03-01T10:12:00Z', '2026-03-01T10:13:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"source":"plugin","session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-1"}}');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+				) VALUES
+				  (1, 1, 'session_summary', 'Summary 1', 'body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1'),
+				  (2, 2, 'decision', 'Decision 2', 'body', 1, '2026-03-01T10:13:00Z', '2026-03-01T10:13:00Z', '{}', 'k2');
+				INSERT INTO session_summaries(
+					id, session_id, project, request, created_at, created_at_epoch, metadata_json, import_key
+				) VALUES
+				  (1, 2, 'codemem', 'repair me', '2026-03-01T10:13:00Z', 1740823980, '{}', 'summary-1');
+				INSERT INTO user_prompts(
+					id, session_id, project, prompt_text, created_at, created_at_epoch, metadata_json, import_key
+				) VALUES
+				  (1, 2, 'codemem', 'repair me', '2026-03-01T10:12:30Z', 1740823950, '{}', 'prompt-1');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const result = applyRawEventRelinkPlan(dbPath, { limit: 10 });
+
+		expect(result.totals).toEqual({
+			groups: 1,
+			eligible_groups: 1,
+			skipped_groups: 0,
+			bridge_creations: 1,
+			memory_repoints: 1,
+			session_compactions: 1,
+		});
+
+		const verify = new Database(dbPath, { readonly: true });
+		try {
+			const sessions = verify.prepare("SELECT id FROM sessions ORDER BY id").all() as Array<{
+				id: number;
+			}>;
+			expect(sessions).toEqual([{ id: 1 }]);
+
+			const bridge = verify
+				.prepare(
+					"SELECT source, stream_id, session_id FROM opencode_sessions WHERE stream_id = 'ses-1'",
+				)
+				.get() as { source: string; stream_id: string; session_id: number };
+			expect(bridge).toEqual({ source: "opencode", stream_id: "ses-1", session_id: 1 });
+
+			const memorySessionIds = verify
+				.prepare("SELECT id, session_id FROM memory_items ORDER BY id")
+				.all() as Array<{ id: number; session_id: number }>;
+			expect(memorySessionIds).toEqual([
+				{ id: 1, session_id: 1 },
+				{ id: 2, session_id: 1 },
+			]);
+
+			const sessionSummary = verify
+				.prepare("SELECT session_id FROM session_summaries WHERE id = 1")
+				.get() as { session_id: number };
+			expect(sessionSummary.session_id).toBe(1);
+
+			const userPrompt = verify
+				.prepare("SELECT session_id FROM user_prompts WHERE id = 1")
+				.get() as { session_id: number };
+			expect(userPrompt.session_id).toBe(1);
+		} finally {
+			verify.close();
+		}
+	});
+
+	it("runs raw-event relink remediation during initDatabase", () => {
+		const dbPath = createDbPath("init-relink-apply");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-2"}}'),
+				  (2, '2026-03-01T10:12:00Z', '2026-03-01T10:13:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-2"}}');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+				) VALUES
+				  (1, 2, 'decision', 'Decision 2', 'body', 1, '2026-03-01T10:13:00Z', '2026-03-01T10:13:00Z', '{}', 'k2');
+			`);
+		} finally {
+			db.close();
+		}
+
+		initDatabase(dbPath);
+
+		const verify = new Database(dbPath, { readonly: true });
+		try {
+			const sessions = verify.prepare("SELECT id FROM sessions ORDER BY id").all() as Array<{
+				id: number;
+			}>;
+			expect(sessions).toEqual([{ id: 1 }]);
+
+			const bridge = verify
+				.prepare(
+					"SELECT source, stream_id, session_id FROM opencode_sessions WHERE stream_id = 'ses-2'",
+				)
+				.get() as { source: string; stream_id: string; session_id: number };
+			expect(bridge).toEqual({ source: "opencode", stream_id: "ses-2", session_id: 1 });
+
+			const memory = verify.prepare("SELECT session_id FROM memory_items WHERE id = 1").get() as {
+				session_id: number;
+			};
+			expect(memory.session_id).toBe(1);
+		} finally {
+			verify.close();
+		}
+	});
+
+	it("is idempotent when raw-event relink remediation is applied twice", () => {
+		const dbPath = createDbPath("raw-event-relink-apply-idempotent");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-3"}}'),
+				  (2, '2026-03-01T10:12:00Z', '2026-03-01T10:13:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-3"}}');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+				) VALUES
+				  (1, 2, 'decision', 'Decision 3', 'body', 1, '2026-03-01T10:13:00Z', '2026-03-01T10:13:00Z', '{}', 'k3');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const first = applyRawEventRelinkPlan(dbPath, { limit: 10 });
+		const second = applyRawEventRelinkPlan(dbPath, { limit: 10 });
+
+		expect(first.totals.bridge_creations).toBe(1);
+		expect(first.totals.memory_repoints).toBe(1);
+		expect(first.totals.session_compactions).toBe(1);
+		expect(second.totals.bridge_creations).toBe(0);
+		expect(second.totals.memory_repoints).toBe(0);
+		expect(second.totals.session_compactions).toBe(0);
+	});
+
+	it("blocks compaction when redundant sessions still carry other bridge rows", () => {
+		const dbPath = createDbPath("raw-event-relink-foreign-bridge-blocker");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-4"}}'),
+				  (2, '2026-03-01T10:12:00Z', '2026-03-01T10:13:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"session_context":{"source":"opencode","flusher":"raw_events","streamId":"ses-4"}}');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'other-stream', 'other-stream', 2, '2026-03-01T10:12:00Z');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+				) VALUES
+				  (1, 2, 'decision', 'Decision 4', 'body', 1, '2026-03-01T10:13:00Z', '2026-03-01T10:13:00Z', '{}', 'k4');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const report = getRawEventRelinkReport(dbPath, { limit: 10 });
+		expect(report.groups[0]).toEqual(
+			expect.objectContaining({
+				stable_id: "ses-4",
+				eligible: false,
+				blockers: expect.arrayContaining(["out_of_group_bridge_rows"]),
+			}),
+		);
+
+		const result = applyRawEventRelinkPlan(dbPath, { limit: 10 });
+		expect(result.totals).toEqual({
+			groups: 1,
+			eligible_groups: 0,
+			skipped_groups: 1,
+			bridge_creations: 0,
+			memory_repoints: 0,
+			session_compactions: 0,
+		});
+		expect(result.skipped_groups).toEqual([
+			{ stable_id: "ses-4", blockers: ["out_of_group_bridge_rows"] },
+		]);
+
+		const verify = new Database(dbPath, { readonly: true });
+		try {
+			const sessions = verify.prepare("SELECT id FROM sessions ORDER BY id").all() as Array<{
+				id: number;
+			}>;
+			expect(sessions).toEqual([{ id: 1 }, { id: 2 }]);
+			const bridgeRows = verify
+				.prepare("SELECT source, stream_id, session_id FROM opencode_sessions ORDER BY stream_id")
+				.all() as Array<{ source: string; stream_id: string; session_id: number }>;
+			expect(bridgeRows).toEqual([
+				{ source: "opencode", stream_id: "other-stream", session_id: 2 },
+			]);
+		} finally {
+			verify.close();
+		}
 	});
 });

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -184,6 +184,20 @@ export interface RawEventRelinkPlan {
 	skipped_groups: Array<{ stable_id: string; blockers: string[] }>;
 }
 
+export interface RawEventRelinkApplyOptions extends RawEventRelinkReportOptions {}
+
+export interface RawEventRelinkApplyResult {
+	totals: {
+		groups: number;
+		eligible_groups: number;
+		skipped_groups: number;
+		bridge_creations: number;
+		memory_repoints: number;
+		session_compactions: number;
+	};
+	skipped_groups: Array<{ stable_id: string; blockers: string[] }>;
+}
+
 interface InferredMemoryRole {
 	role: MemoryRole;
 	reason: string;
@@ -223,6 +237,299 @@ function safeParseMetadata(raw: string | null): Record<string, unknown> {
 
 function hasAnyMarker(text: string, markers: string[]): boolean {
 	return markers.some((marker) => text.includes(marker));
+}
+
+function hasOutOfGroupBridgeRows(
+	db: Database,
+	sessionIds: number[],
+	source: string,
+	stableId: string,
+): boolean {
+	if (sessionIds.length === 0) return false;
+	const placeholders = sessionIds.map(() => "?").join(", ");
+	const row = db
+		.prepare(
+			`SELECT 1
+			 FROM opencode_sessions
+			 WHERE session_id IN (${placeholders})
+			   AND NOT (source = ? AND stream_id = ?)
+			 LIMIT 1`,
+		)
+		.get(...sessionIds, source, stableId);
+	return row != null;
+}
+
+function getRawEventRelinkReportFromDb(
+	db: Database,
+	opts: RawEventRelinkReportOptions = {},
+): RawEventRelinkReport {
+	const projectFilter = opts.allProjects ? null : opts.project?.trim() || null;
+	const projectClauseSql = projectFilter ? "AND s.project = ?" : "";
+	const params = projectFilter ? [projectFilter] : [];
+	const limit = Math.max(1, opts.limit ?? 25);
+
+	const rows = db
+		.prepare(
+			`SELECT
+				s.id,
+				COALESCE(
+					json_extract(s.metadata_json, '$.session_context.source'),
+					json_extract(s.metadata_json, '$.source'),
+					'opencode'
+				) AS source,
+				s.project,
+				s.started_at,
+				s.ended_at,
+				COALESCE(
+					json_extract(s.metadata_json, '$.session_context.opencodeSessionId'),
+					json_extract(s.metadata_json, '$.session_context.streamId')
+				) AS stable_id,
+				CASE WHEN os.session_id IS NULL THEN 0 ELSE 1 END AS has_mapping,
+				(
+					SELECT COUNT(*)
+					FROM memory_items m
+					WHERE m.session_id = s.id AND m.active = 1
+				) AS active_memories
+			FROM sessions s
+			LEFT JOIN opencode_sessions os
+				ON os.session_id = s.id
+				AND os.source = COALESCE(
+					json_extract(s.metadata_json, '$.session_context.source'),
+					json_extract(s.metadata_json, '$.source'),
+					'opencode'
+				)
+				AND os.stream_id = COALESCE(
+					json_extract(s.metadata_json, '$.session_context.opencodeSessionId'),
+					json_extract(s.metadata_json, '$.session_context.streamId')
+				)
+			WHERE json_extract(s.metadata_json, '$.session_context.flusher') = 'raw_events'
+			  AND COALESCE(
+					json_extract(s.metadata_json, '$.session_context.opencodeSessionId'),
+					json_extract(s.metadata_json, '$.session_context.streamId')
+				  ) IS NOT NULL
+			  ${projectClauseSql}
+			ORDER BY s.started_at DESC, s.id DESC`,
+		)
+		.all(...params) as Array<{
+		id: number;
+		source: string;
+		project: string | null;
+		started_at: string | null;
+		ended_at: string | null;
+		stable_id: string;
+		has_mapping: number;
+		active_memories: number;
+	}>;
+
+	const groups = new Map<string, typeof rows>();
+	for (const row of rows) {
+		const stableId = String(row.stable_id || "").trim();
+		const source = String(row.source || "opencode").trim() || "opencode";
+		const key = `${source}:${stableId}`;
+		if (!key) continue;
+		const list = groups.get(key) ?? [];
+		list.push(row);
+		groups.set(key, list);
+	}
+
+	const reportGroups: RawEventRelinkGroup[] = [];
+	let activeMemories = 0;
+	let repointableActiveMemories = 0;
+	let groupsWithMappedSession = 0;
+	let groupsWithoutMappedSession = 0;
+	let eligibleGroups = 0;
+	let ineligibleGroups = 0;
+
+	for (const [groupKey, groupRows] of groups.entries()) {
+		const stableId = groupRows[0]?.stable_id ?? groupKey;
+		const groupSource = groupRows[0]?.source ?? "opencode";
+		const sorted = [...groupRows].sort((a, b) => {
+			if (b.has_mapping !== a.has_mapping) return b.has_mapping - a.has_mapping;
+			const aStarted = a.started_at ?? "";
+			const bStarted = b.started_at ?? "";
+			if (aStarted !== bStarted) return aStarted.localeCompare(bStarted);
+			return a.id - b.id;
+		});
+		const canonical = sorted[0];
+		if (!canonical) continue;
+		const mappedSessions = groupRows.filter((row) => row.has_mapping === 1).length;
+		const unmappedSessions = groupRows.length - mappedSessions;
+		const totalActiveMemories = groupRows.reduce(
+			(sum, row) => sum + Number(row.active_memories ?? 0),
+			0,
+		);
+		const canonicalActiveMemories = Number(canonical.active_memories ?? 0);
+		const repointable = Math.max(0, totalActiveMemories - canonicalActiveMemories);
+		const canonicalReason =
+			canonical.has_mapping === 1 ? "existing_mapped_session" : "oldest_unmapped_session";
+		const projectValues = new Set(groupRows.map((row) => row.project ?? null));
+		const blockers: string[] = [];
+		if (mappedSessions > 1) blockers.push("multiple_mapped_sessions");
+		if (projectValues.size > 1) blockers.push("mixed_projects");
+		if (
+			hasOutOfGroupBridgeRows(
+				db,
+				groupRows.map((row) => row.id),
+				groupSource,
+				stableId,
+			)
+		) {
+			blockers.push("out_of_group_bridge_rows");
+		}
+		const eligible = blockers.length === 0;
+		activeMemories += totalActiveMemories;
+		repointableActiveMemories += repointable;
+		if (mappedSessions > 0) groupsWithMappedSession += 1;
+		else groupsWithoutMappedSession += 1;
+		if (eligible) eligibleGroups += 1;
+		else ineligibleGroups += 1;
+
+		reportGroups.push({
+			source: groupSource,
+			stable_id: stableId,
+			local_sessions: groupRows.length,
+			mapped_sessions: mappedSessions,
+			unmapped_sessions: unmappedSessions,
+			eligible,
+			blockers,
+			canonical_session_id: canonical.id,
+			canonical_reason: canonicalReason,
+			would_create_bridge: canonical.has_mapping === 0,
+			sessions_to_compact: Math.max(0, groupRows.length - 1),
+			all_session_ids: groupRows.map((row) => row.id),
+			sample_session_ids: groupRows.slice(0, 5).map((row) => row.id),
+			active_memories: totalActiveMemories,
+			repointable_active_memories: repointable,
+			oldest_started_at:
+				[...groupRows]
+					.map((row) => row.started_at)
+					.filter(Boolean)
+					.sort()[0] ?? null,
+			latest_started_at:
+				[...groupRows]
+					.map((row) => row.started_at)
+					.filter(Boolean)
+					.sort()
+					.at(-1) ?? null,
+			project: canonical.project,
+		});
+	}
+
+	reportGroups.sort((a, b) => {
+		if (b.repointable_active_memories !== a.repointable_active_memories) {
+			return b.repointable_active_memories - a.repointable_active_memories;
+		}
+		if (b.local_sessions !== a.local_sessions) return b.local_sessions - a.local_sessions;
+		return a.stable_id.localeCompare(b.stable_id);
+	});
+
+	return {
+		totals: {
+			recoverable_sessions: rows.length,
+			distinct_stable_ids: groups.size,
+			groups_with_multiple_sessions: reportGroups.filter((group) => group.local_sessions > 1)
+				.length,
+			groups_with_mapped_session: groupsWithMappedSession,
+			groups_without_mapped_session: groupsWithoutMappedSession,
+			eligible_groups: eligibleGroups,
+			ineligible_groups: ineligibleGroups,
+			active_memories: activeMemories,
+			repointable_active_memories: repointableActiveMemories,
+		},
+		groups: reportGroups.slice(0, limit),
+	};
+}
+
+function applyRawEventRelinkPlanWithDb(
+	db: Database,
+	opts: RawEventRelinkApplyOptions = {},
+): RawEventRelinkApplyResult {
+	const d = drizzle(db, { schema });
+	const report = getRawEventRelinkReportFromDb(db, {
+		...opts,
+		limit: opts.limit ?? Number.MAX_SAFE_INTEGER,
+	});
+	const skippedGroups: Array<{ stable_id: string; blockers: string[] }> = [];
+	let eligibleGroups = 0;
+	let bridgeCreations = 0;
+	let memoryRepoints = 0;
+	let sessionCompactions = 0;
+	const now = new Date().toISOString();
+
+	const reconcile = db.transaction(() => {
+		for (const group of report.groups) {
+			if (!group.eligible) {
+				skippedGroups.push({ stable_id: group.stable_id, blockers: group.blockers });
+				continue;
+			}
+			eligibleGroups += 1;
+			if (group.would_create_bridge) {
+				d.insert(schema.opencodeSessions)
+					.values({
+						source: group.source,
+						stream_id: group.stable_id,
+						opencode_session_id: group.stable_id,
+						session_id: group.canonical_session_id,
+						created_at: now,
+					})
+					.onConflictDoUpdate({
+						target: [schema.opencodeSessions.source, schema.opencodeSessions.stream_id],
+						set: {
+							opencode_session_id: sql`excluded.opencode_session_id`,
+							session_id: sql`excluded.session_id`,
+						},
+					})
+					.run();
+				bridgeCreations += 1;
+			}
+
+			const redundantSessionIds = group.all_session_ids.filter(
+				(id) => id !== group.canonical_session_id,
+			);
+			if (redundantSessionIds.length === 0) continue;
+
+			memoryRepoints += Number(
+				d
+					.update(schema.memoryItems)
+					.set({ session_id: group.canonical_session_id })
+					.where(inArray(schema.memoryItems.session_id, redundantSessionIds))
+					.run().changes ?? 0,
+			);
+			d.update(schema.artifacts)
+				.set({ session_id: group.canonical_session_id })
+				.where(inArray(schema.artifacts.session_id, redundantSessionIds))
+				.run();
+			d.update(schema.usageEvents)
+				.set({ session_id: group.canonical_session_id })
+				.where(inArray(schema.usageEvents.session_id, redundantSessionIds))
+				.run();
+			d.update(schema.userPrompts)
+				.set({ session_id: group.canonical_session_id })
+				.where(inArray(schema.userPrompts.session_id, redundantSessionIds))
+				.run();
+			d.update(schema.sessionSummaries)
+				.set({ session_id: group.canonical_session_id })
+				.where(inArray(schema.sessionSummaries.session_id, redundantSessionIds))
+				.run();
+			sessionCompactions += Number(
+				d.delete(schema.sessions).where(inArray(schema.sessions.id, redundantSessionIds)).run()
+					.changes ?? 0,
+			);
+		}
+	});
+
+	reconcile();
+	return {
+		totals: {
+			groups: report.groups.length,
+			eligible_groups: eligibleGroups,
+			skipped_groups: skippedGroups.length,
+			bridge_creations: bridgeCreations,
+			memory_repoints: memoryRepoints,
+			session_compactions: sessionCompactions,
+		},
+		skipped_groups: skippedGroups,
+	};
 }
 
 function inferMemoryRole(row: {
@@ -610,167 +917,7 @@ export function getRawEventRelinkReport(
 	dbPath?: string,
 	opts: RawEventRelinkReportOptions = {},
 ): RawEventRelinkReport {
-	return withDb(dbPath, (db) => {
-		const projectFilter = opts.allProjects ? null : opts.project?.trim() || null;
-		const projectClause = projectFilter ? "AND s.project = ?" : "";
-		const params = projectFilter ? [projectFilter] : [];
-		const limit = Math.max(1, opts.limit ?? 25);
-
-		const rows = db
-			.prepare(
-				`SELECT
-					s.id,
-					COALESCE(
-						json_extract(s.metadata_json, '$.source'),
-						json_extract(s.metadata_json, '$.session_context.source'),
-						'opencode'
-					) AS source,
-					s.project,
-					s.started_at,
-					s.ended_at,
-					COALESCE(
-						json_extract(s.metadata_json, '$.session_context.opencodeSessionId'),
-						json_extract(s.metadata_json, '$.session_context.streamId')
-					) AS stable_id,
-					CASE WHEN os.session_id IS NULL THEN 0 ELSE 1 END AS has_mapping,
-					(
-						SELECT COUNT(*)
-						FROM memory_items m
-						WHERE m.session_id = s.id AND m.active = 1
-					) AS active_memories
-				FROM sessions s
-				LEFT JOIN (
-					SELECT DISTINCT session_id
-					FROM opencode_sessions
-					WHERE session_id IS NOT NULL
-				) os ON os.session_id = s.id
-				WHERE json_extract(s.metadata_json, '$.session_context.flusher') = 'raw_events'
-				  AND COALESCE(
-						json_extract(s.metadata_json, '$.session_context.opencodeSessionId'),
-						json_extract(s.metadata_json, '$.session_context.streamId')
-					  ) IS NOT NULL
-				  ${projectClause}
-				ORDER BY s.started_at DESC, s.id DESC`,
-			)
-			.all(...params) as Array<{
-			id: number;
-			source: string;
-			project: string | null;
-			started_at: string | null;
-			ended_at: string | null;
-			stable_id: string;
-			has_mapping: number;
-			active_memories: number;
-		}>;
-
-		const groups = new Map<string, typeof rows>();
-		for (const row of rows) {
-			const stableId = String(row.stable_id || "").trim();
-			const source = String(row.source || "opencode").trim() || "opencode";
-			const key = `${source}:${stableId}`;
-			if (!key) continue;
-			const list = groups.get(key) ?? [];
-			list.push(row);
-			groups.set(key, list);
-		}
-
-		const reportGroups: RawEventRelinkGroup[] = [];
-		let activeMemories = 0;
-		let repointableActiveMemories = 0;
-		let groupsWithMappedSession = 0;
-		let groupsWithoutMappedSession = 0;
-		let eligibleGroups = 0;
-		let ineligibleGroups = 0;
-
-		for (const [groupKey, groupRows] of groups.entries()) {
-			const stableId = groupRows[0]?.stable_id ?? groupKey;
-			const groupSource = groupRows[0]?.source ?? "opencode";
-			const sorted = [...groupRows].sort((a, b) => {
-				if (b.has_mapping !== a.has_mapping) return b.has_mapping - a.has_mapping;
-				const aStarted = a.started_at ?? "";
-				const bStarted = b.started_at ?? "";
-				if (aStarted !== bStarted) return aStarted.localeCompare(bStarted);
-				return a.id - b.id;
-			});
-			const canonical = sorted[0];
-			if (!canonical) continue;
-			const mappedSessions = groupRows.filter((row) => row.has_mapping === 1).length;
-			const unmappedSessions = groupRows.length - mappedSessions;
-			const totalActiveMemories = groupRows.reduce(
-				(sum, row) => sum + Number(row.active_memories ?? 0),
-				0,
-			);
-			const canonicalActiveMemories = Number(canonical.active_memories ?? 0);
-			const repointable = Math.max(0, totalActiveMemories - canonicalActiveMemories);
-			const canonicalReason =
-				canonical.has_mapping === 1 ? "existing_mapped_session" : "oldest_unmapped_session";
-			const projectValues = new Set(groupRows.map((row) => row.project ?? null));
-			const blockers: string[] = [];
-			if (mappedSessions > 1) blockers.push("multiple_mapped_sessions");
-			if (projectValues.size > 1) blockers.push("mixed_projects");
-			const eligible = blockers.length === 0;
-			activeMemories += totalActiveMemories;
-			repointableActiveMemories += repointable;
-			if (mappedSessions > 0) groupsWithMappedSession += 1;
-			else groupsWithoutMappedSession += 1;
-			if (eligible) eligibleGroups += 1;
-			else ineligibleGroups += 1;
-
-			reportGroups.push({
-				source: groupSource,
-				stable_id: stableId,
-				local_sessions: groupRows.length,
-				mapped_sessions: mappedSessions,
-				unmapped_sessions: unmappedSessions,
-				eligible,
-				blockers,
-				canonical_session_id: canonical.id,
-				canonical_reason: canonicalReason,
-				would_create_bridge: canonical.has_mapping === 0,
-				sessions_to_compact: Math.max(0, groupRows.length - 1),
-				all_session_ids: groupRows.map((row) => row.id),
-				sample_session_ids: groupRows.slice(0, 5).map((row) => row.id),
-				active_memories: totalActiveMemories,
-				repointable_active_memories: repointable,
-				oldest_started_at:
-					[...groupRows]
-						.map((row) => row.started_at)
-						.filter(Boolean)
-						.sort()[0] ?? null,
-				latest_started_at:
-					[...groupRows]
-						.map((row) => row.started_at)
-						.filter(Boolean)
-						.sort()
-						.at(-1) ?? null,
-				project: canonical.project,
-			});
-		}
-
-		reportGroups.sort((a, b) => {
-			if (b.repointable_active_memories !== a.repointable_active_memories) {
-				return b.repointable_active_memories - a.repointable_active_memories;
-			}
-			if (b.local_sessions !== a.local_sessions) return b.local_sessions - a.local_sessions;
-			return a.stable_id.localeCompare(b.stable_id);
-		});
-
-		return {
-			totals: {
-				recoverable_sessions: rows.length,
-				distinct_stable_ids: groups.size,
-				groups_with_multiple_sessions: reportGroups.filter((group) => group.local_sessions > 1)
-					.length,
-				groups_with_mapped_session: groupsWithMappedSession,
-				groups_without_mapped_session: groupsWithoutMappedSession,
-				eligible_groups: eligibleGroups,
-				ineligible_groups: ineligibleGroups,
-				active_memories: activeMemories,
-				repointable_active_memories: repointableActiveMemories,
-			},
-			groups: reportGroups.slice(0, limit),
-		};
-	});
+	return withDb(dbPath, (db) => getRawEventRelinkReportFromDb(db, opts));
 }
 
 export function getRawEventRelinkPlan(
@@ -843,6 +990,13 @@ export function getRawEventRelinkPlan(
 	};
 }
 
+export function applyRawEventRelinkPlan(
+	dbPath?: string,
+	opts: RawEventRelinkApplyOptions = {},
+): RawEventRelinkApplyResult {
+	return withDb(dbPath, (db) => applyRawEventRelinkPlanWithDb(db, opts));
+}
+
 export function initDatabase(dbPath?: string): { path: string; sizeBytes: number } {
 	const resolvedPath = resolveDbPath(dbPath);
 	const db = connect(resolvedPath);
@@ -851,6 +1005,7 @@ export function initDatabase(dbPath?: string): { path: string; sizeBytes: number
 			bootstrapSchema(db);
 		}
 		assertSchemaReady(db);
+		applyRawEventRelinkPlanWithDb(db);
 		const stats = statSync(resolvedPath);
 		return { path: resolvedPath, sizeBytes: stats.size };
 	} finally {


### PR DESCRIPTION
## Description

This PR turns the raw-event relink work into a real startup repair instead of leaving it as dry-run analysis only. It adds an idempotent reconciliation executor, runs it during DB init, and hardens canonical-session detection so unrelated bridge rows do not cause the wrong session to be treated as already mapped.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/maintenance.test.ts`
- `pnpm exec biome check packages/core/src/maintenance.ts packages/core/src/maintenance.test.ts`
- `pnpm --filter @codemem/core run build`
- verified live DB reconciliation behavior against the default local sqlite database

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced