### PR TITLE
feat: add memory role snapshot comparison

### DIFF
--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -14,6 +14,7 @@ describe("memory command aliases", () => {
 			"remember",
 			"inject",
 			"role-report",
+			"role-compare",
 			"relink-report",
 			"relink-plan",
 		]);

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -7,6 +7,7 @@
 
 import * as p from "@clack/prompts";
 import {
+	compareMemoryRoleReports,
 	getMemoryRoleReport,
 	getRawEventRelinkPlan,
 	getRawEventRelinkReport,
@@ -336,6 +337,95 @@ function createMemoryRoleReportCommand(): Command {
 	return cmd;
 }
 
+function createMemoryRoleCompareCommand(): Command {
+	const cmd = new Command("role-compare")
+		.configureHelp(helpStyle)
+		.description("Compare inferred memory-role and probe metrics across two DB snapshots")
+		.argument("<baseline_db>", "baseline sqlite database path")
+		.argument("<candidate_db>", "candidate sqlite database path")
+		.option("--project <project>", "project identifier (defaults to git repo root)")
+		.option("--all-projects", "analyze across all projects")
+		.option(
+			"--probe <query>",
+			"run a retrieval probe query against both snapshots",
+			(value, prev: string[]) => [...prev, value],
+			[],
+		)
+		.option("--inactive", "include inactive memories");
+	addJsonOption(cmd);
+	cmd.action(
+		(
+			baselineDb: string,
+			candidateDb: string,
+			opts: JsonOpts & {
+				project?: string;
+				allProjects?: boolean;
+				probe?: string[];
+				inactive?: boolean;
+			},
+		) => {
+			const project =
+				opts.allProjects === true
+					? null
+					: opts.project?.trim() ||
+						process.env.CODEMEM_PROJECT?.trim() ||
+						resolveProject(process.cwd(), null);
+			const result = compareMemoryRoleReports(baselineDb, candidateDb, {
+				project,
+				allProjects: opts.allProjects === true,
+				includeInactive: opts.inactive === true,
+				probes: opts.probe,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			p.intro("codemem memory role-compare");
+			p.log.info(
+				[
+					`Baseline sessions: ${result.baseline.totals.sessions}`,
+					`Candidate sessions: ${result.candidate.totals.sessions}`,
+					`Delta sessions: ${result.delta.totals.sessions}`,
+					`Mapped delta: ${result.delta.counts_by_mapping.mapped}`,
+					`Unmapped delta: ${result.delta.counts_by_mapping.unmapped}`,
+					`Summary mapped delta: ${result.delta.summary_mapping.mapped}`,
+					`Summary unmapped delta: ${result.delta.summary_mapping.unmapped}`,
+				].join("\n"),
+			);
+			p.log.info("Role deltas:");
+			for (const [role, count] of Object.entries(result.delta.counts_by_role)) {
+				p.log.message(`  ${role.padEnd(10)} ${String(count)}`);
+			}
+			if (result.probe_comparisons.length > 0) {
+				p.log.info("Probe comparisons:");
+				for (const probe of result.probe_comparisons) {
+					p.log.message(`  query: ${probe.query}`);
+					p.log.message(
+						`    modes: baseline=${probe.baseline_mode ?? "-"} candidate=${probe.candidate_mode ?? "-"}`,
+					);
+					p.log.message(
+						`    overlap: shared_top_keys=${probe.shared_item_keys.length} baseline_top=${probe.baseline_item_ids.slice(0, 5).join(",") || "-"} candidate_top=${probe.candidate_item_ids.slice(0, 5).join(",") || "-"}`,
+					);
+					if (probe.delta_top_burden) {
+						p.log.message(
+							`    burden delta: recap_share=${probe.delta_top_burden.recap_share.toFixed(2)} unmapped_share=${probe.delta_top_burden.unmapped_share.toFixed(2)} recap_unmapped_share=${probe.delta_top_burden.recap_unmapped_share.toFixed(2)}`,
+						);
+					}
+					if (probe.delta_top_mapping_counts) {
+						p.log.message(
+							`    mapping delta: mapped=${probe.delta_top_mapping_counts.mapped} unmapped=${probe.delta_top_mapping_counts.unmapped}`,
+						);
+					}
+				}
+			}
+			p.outro("done");
+		},
+	);
+	return cmd;
+}
+
 function createMemoryRelinkReportCommand(): Command {
 	const cmd = new Command("relink-report")
 		.configureHelp(helpStyle)
@@ -475,5 +565,6 @@ memoryCommand.addCommand(createForgetMemoryCommand());
 memoryCommand.addCommand(createRememberMemoryCommand());
 memoryCommand.addCommand(createInjectMemoryCommand());
 memoryCommand.addCommand(createMemoryRoleReportCommand());
+memoryCommand.addCommand(createMemoryRoleCompareCommand());
 memoryCommand.addCommand(createMemoryRelinkReportCommand());
 memoryCommand.addCommand(createMemoryRelinkPlanCommand());

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -172,6 +172,8 @@ export type {
 	GateResult,
 	MemoryRole,
 	MemoryRoleReport,
+	MemoryRoleReportComparison,
+	MemoryRoleReportComparisonOptions,
 	MemoryRoleReportOptions,
 	RawEventRelinkAction,
 	RawEventRelinkGroup,
@@ -185,6 +187,7 @@ export type {
 } from "./maintenance.js";
 export {
 	backfillTagsText,
+	compareMemoryRoleReports,
 	deactivateLowSignalMemories,
 	deactivateLowSignalObservations,
 	getMemoryRoleReport,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
 	applyRawEventRelinkPlan,
 	backfillTagsText,
+	compareMemoryRoleReports,
 	deactivateLowSignalMemories,
 	deactivateLowSignalObservations,
 	getMemoryRoleReport,
@@ -399,6 +400,79 @@ describe("maintenance", () => {
 				role: "durable",
 				role_reason: "durable_kind",
 				title: "OAuth callback fix",
+			}),
+		);
+	});
+
+	it("compares memory role reports across two database snapshots", () => {
+		const baselinePath = createDbPath("memory-role-compare-baseline");
+		const candidatePath = createDbPath("memory-role-compare-candidate");
+		for (const dbPath of [baselinePath, candidatePath]) {
+			const db = new Database(dbPath);
+			try {
+				initTestSchema(db);
+			} finally {
+				db.close();
+			}
+		}
+
+		const baselineDb = new Database(baselinePath);
+		try {
+			baselineDb.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version) VALUES
+				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test'),
+				  (2, '2026-03-01T10:20:00Z', '2026-03-01T10:20:20Z', '/tmp/repo', 'codemem', 'adam', 'test');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'ses-1', 'ses-1', 1, '2026-03-01T10:00:00Z');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+				) VALUES
+				  (1, 1, 'session_summary', 'Session recap', 'Summary body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1'),
+				  (2, 2, 'change', 'Legacy recap', '## Request\nfoo\n\n## Completed\nbar', 1, '2026-03-01T10:20:20Z', '2026-03-01T10:20:20Z', '{"is_summary":true}', 'k2'),
+				  (3, 2, 'decision', 'OAuth callback fix', 'Patched callback validation', 1, '2026-03-01T10:20:21Z', '2026-03-01T10:20:21Z', '{}', 'k3');
+			`);
+		} finally {
+			baselineDb.close();
+		}
+
+		const candidateDb = new Database(candidatePath);
+		try {
+			candidateDb.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version) VALUES
+				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'ses-1', 'ses-1', 1, '2026-03-01T10:00:00Z');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+				) VALUES
+				  (20, 1, 'decision', 'OAuth callback fix', 'Patched callback validation', 1, '2026-03-01T10:20:21Z', '2026-03-01T10:20:21Z', '{}', 'k3'),
+				  (21, 1, 'session_summary', 'Session recap', 'Summary body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1');
+			`);
+		} finally {
+			candidateDb.close();
+		}
+
+		const comparison = compareMemoryRoleReports(baselinePath, candidatePath, {
+			project: "codemem",
+			probes: ["oauth callback"],
+		});
+
+		expect(comparison.delta.totals.sessions).toBe(-1);
+		expect(comparison.delta.counts_by_mapping).toEqual({ mapped: 1, unmapped: -2 });
+		expect(comparison.delta.summary_mapping).toEqual({ mapped: 0, unmapped: -1 });
+		expect(comparison.probe_comparisons).toHaveLength(1);
+		expect(comparison.probe_comparisons[0]).toEqual(
+			expect.objectContaining({
+				query: "oauth callback",
+				baseline_item_ids: [3, 2],
+				candidate_item_ids: [20, 21],
+				shared_item_keys: ["import:k3"],
+				delta_top_mapping_counts: { mapped: 2, unmapped: -2 },
+				delta_top_burden: {
+					recap_share: 0,
+					unmapped_share: -1,
+					recap_unmapped_share: -0.5,
+				},
 			}),
 		);
 	});

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -47,6 +47,7 @@ export interface MemoryRoleReportOptions {
 
 export interface MemoryRoleProbeItem {
 	id: number;
+	stable_key: string;
 	kind: string;
 	title: string;
 	role: MemoryRole;
@@ -115,6 +116,36 @@ export interface MemoryRoleReport {
 		Record<MemoryRole, Array<{ id: number; kind: string; title: string; role_reason: string }>>
 	>;
 	probe_results: MemoryRoleProbeResult[];
+}
+
+export interface MemoryRoleReportComparisonOptions extends MemoryRoleReportOptions {}
+
+export interface MemoryRoleProbeComparison {
+	query: string;
+	baseline_mode: string | null;
+	candidate_mode: string | null;
+	baseline_item_ids: number[];
+	candidate_item_ids: number[];
+	shared_item_keys: string[];
+	baseline_top_burden: MemoryRoleProbeResult["top_burden"] | null;
+	candidate_top_burden: MemoryRoleProbeResult["top_burden"] | null;
+	delta_top_burden: MemoryRoleProbeResult["top_burden"] | null;
+	baseline_top_mapping_counts: Record<"mapped" | "unmapped", number> | null;
+	candidate_top_mapping_counts: Record<"mapped" | "unmapped", number> | null;
+	delta_top_mapping_counts: Record<"mapped" | "unmapped", number> | null;
+}
+
+export interface MemoryRoleReportComparison {
+	baseline: MemoryRoleReport;
+	candidate: MemoryRoleReport;
+	delta: {
+		totals: MemoryRoleReport["totals"];
+		counts_by_role: Record<MemoryRole, number>;
+		counts_by_mapping: Record<"mapped" | "unmapped", number>;
+		summary_mapping: Record<"mapped" | "unmapped", number>;
+		session_duration_buckets: Record<string, number>;
+	};
+	probe_comparisons: MemoryRoleProbeComparison[];
 }
 
 export interface RawEventRelinkGroup {
@@ -257,6 +288,91 @@ function hasOutOfGroupBridgeRows(
 		)
 		.get(...sessionIds, source, stableId);
 	return row != null;
+}
+
+function subtractKeyedCounts<T extends string>(
+	baseline: Partial<Record<T, number>>,
+	candidate: Partial<Record<T, number>>,
+): Record<T, number> {
+	const keys = new Set<T>([...(Object.keys(baseline) as T[]), ...(Object.keys(candidate) as T[])]);
+	const result = {} as Record<T, number>;
+	for (const key of keys) {
+		result[key] = Number(candidate[key] ?? 0) - Number(baseline[key] ?? 0);
+	}
+	return result;
+}
+
+function subtractBurden(
+	baseline: MemoryRoleProbeResult["top_burden"] | null,
+	candidate: MemoryRoleProbeResult["top_burden"] | null,
+): MemoryRoleProbeResult["top_burden"] | null {
+	if (!baseline || !candidate) return null;
+	return {
+		recap_share: candidate.recap_share - baseline.recap_share,
+		unmapped_share: candidate.unmapped_share - baseline.unmapped_share,
+		recap_unmapped_share: candidate.recap_unmapped_share - baseline.recap_unmapped_share,
+	};
+}
+
+function compareProbeResults(
+	baseline: MemoryRoleProbeResult[],
+	candidate: MemoryRoleProbeResult[],
+): MemoryRoleProbeComparison[] {
+	const byQuery = new Map<
+		string,
+		{ baseline?: MemoryRoleProbeResult; candidate?: MemoryRoleProbeResult }
+	>();
+	for (const probe of baseline) {
+		byQuery.set(probe.query, { ...(byQuery.get(probe.query) ?? {}), baseline: probe });
+	}
+	for (const probe of candidate) {
+		byQuery.set(probe.query, { ...(byQuery.get(probe.query) ?? {}), candidate: probe });
+	}
+	return [...byQuery.entries()]
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([query, value]) => {
+			const baselineProbe = value.baseline;
+			const candidateProbe = value.candidate;
+			const baselineIds = baselineProbe?.item_ids ?? [];
+			const candidateIds = candidateProbe?.item_ids ?? [];
+			const baselineKeys = baselineProbe?.items.map((item) => item.stable_key) ?? [];
+			const candidateKeySet = new Set(candidateProbe?.items.map((item) => item.stable_key) ?? []);
+			const sharedItemKeys = baselineKeys.filter((key) => candidateKeySet.has(key));
+			return {
+				query,
+				baseline_mode: baselineProbe?.mode ?? null,
+				candidate_mode: candidateProbe?.mode ?? null,
+				baseline_item_ids: baselineIds,
+				candidate_item_ids: candidateIds,
+				shared_item_keys: sharedItemKeys,
+				baseline_top_burden: baselineProbe?.top_burden ?? null,
+				candidate_top_burden: candidateProbe?.top_burden ?? null,
+				delta_top_burden: subtractBurden(
+					baselineProbe?.top_burden ?? null,
+					candidateProbe?.top_burden ?? null,
+				),
+				baseline_top_mapping_counts: baselineProbe?.top_mapping_counts ?? null,
+				candidate_top_mapping_counts: candidateProbe?.top_mapping_counts ?? null,
+				delta_top_mapping_counts:
+					baselineProbe && candidateProbe
+						? subtractKeyedCounts(
+								baselineProbe.top_mapping_counts,
+								candidateProbe.top_mapping_counts,
+							)
+						: null,
+			};
+		});
+}
+
+function stableProbeItemKey(input: {
+	import_key?: string | null;
+	kind: string;
+	title: string;
+	body_text: string;
+}): string {
+	const importKey = input.import_key?.trim();
+	if (importKey) return `import:${importKey}`;
+	return `fallback:${input.kind}\u241f${input.title}\u241f${input.body_text}`;
 }
 
 function getRawEventRelinkReportFromDb(
@@ -632,6 +748,7 @@ export function getMemoryRoleReport(
 				`SELECT
 					m.id,
 					m.session_id,
+					m.import_key,
 					m.kind,
 					m.title,
 					m.body_text,
@@ -655,6 +772,7 @@ export function getMemoryRoleReport(
 			.all(...params) as Array<{
 			id: number;
 			session_id: number;
+			import_key: string | null;
 			kind: string;
 			title: string;
 			body_text: string;
@@ -779,6 +897,12 @@ export function getMemoryRoleReport(
 							: "unmapped";
 						return {
 							id: item.id,
+							stable_key: stableProbeItemKey({
+								import_key: source?.import_key ?? null,
+								kind: source?.kind ?? item.kind,
+								title: source?.title ?? item.title,
+								body_text: source?.body_text ?? "",
+							}),
 							kind: item.kind,
 							title: item.title,
 							role: inferred.role,
@@ -911,6 +1035,37 @@ export function getMemoryRoleReport(
 			probe_results: probeResults,
 		};
 	});
+}
+
+export function compareMemoryRoleReports(
+	baselineDbPath: string,
+	candidateDbPath: string,
+	opts: MemoryRoleReportComparisonOptions = {},
+): MemoryRoleReportComparison {
+	const baseline = getMemoryRoleReport(baselineDbPath, opts);
+	const candidate = getMemoryRoleReport(candidateDbPath, opts);
+	return {
+		baseline,
+		candidate,
+		delta: {
+			totals: {
+				memories: candidate.totals.memories - baseline.totals.memories,
+				active: candidate.totals.active - baseline.totals.active,
+				sessions: candidate.totals.sessions - baseline.totals.sessions,
+			},
+			counts_by_role: subtractKeyedCounts(baseline.counts_by_role, candidate.counts_by_role),
+			counts_by_mapping: subtractKeyedCounts(
+				baseline.counts_by_mapping,
+				candidate.counts_by_mapping,
+			),
+			summary_mapping: subtractKeyedCounts(baseline.summary_mapping, candidate.summary_mapping),
+			session_duration_buckets: subtractKeyedCounts(
+				baseline.session_duration_buckets,
+				candidate.session_duration_buckets,
+			),
+		},
+		probe_comparisons: compareProbeResults(baseline.probe_results, candidate.probe_results),
+	};
 }
 
 export function getRawEventRelinkReport(


### PR DESCRIPTION
## Description

This PR adds a public-safe snapshot comparison workflow for memory-role analysis so retrieval changes can be evaluated with aggregate metrics instead of ad hoc manual inspection. It introduces comparison output for baseline vs candidate databases, including role/mapping deltas and probe-level top-result burden changes, without committing any private database content.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/maintenance.test.ts`
- `pnpm run test`
- `pnpm exec biome check packages/core/src/maintenance.ts packages/core/src/maintenance.test.ts packages/core/src/index.ts packages/cli/src/commands/memory.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced