### PR TITLE
fix: tighten recap-heavy pack ranking heuristics

### DIFF
--- a/packages/core/src/pack-eval-fixtures.ts
+++ b/packages/core/src/pack-eval-fixtures.ts
@@ -7,6 +7,10 @@ export type PackEvalCorpus = {
 	ids: {
 		oauthDecisionId: number;
 		authTaskDecisionId: number;
+		memoryIssuesDurableId: number;
+		memoryIssuesRecapId: number;
+		sessionizationDurableId: number;
+		sessionizationSummaryId: number;
 		viewerTaskFeatureId: number;
 		viewerHealthFeatureId: number;
 		workingSetPrimaryId: number;
@@ -58,6 +62,36 @@ export function createPackEvalCorpus(store: MemoryStore): PackEvalCorpus {
 		"Need to add OAuth callback validation and replay protection",
 		0.95,
 	);
+	const memoryIssuesRecapId = store.remember(
+		currentSessionId,
+		"change",
+		"Memory retrieval issues recap",
+		"## Request\ninvestigate memory retrieval issues\n\n## Completed\nreviewed recap-heavy retrieval output",
+		0.85,
+		undefined,
+		{ is_summary: true },
+	);
+	const memoryIssuesDurableId = store.remember(
+		currentSessionId,
+		"discovery",
+		"Memory retrieval issue root cause",
+		"Identified ranking and summary weighting issues affecting memory retrieval quality",
+		0.92,
+	);
+	const sessionizationSummaryId = store.remember(
+		currentSessionId,
+		"session_summary",
+		"Session summary emission recap",
+		"Recent summary about short-session recap emission and follow-up notes",
+		0.8,
+	);
+	const sessionizationDurableId = store.remember(
+		currentSessionId,
+		"decision",
+		"Sessionization summary emission policy",
+		"Define when summary emission should be suppressed or delayed for micro-sessions",
+		0.94,
+	);
 	const viewerTaskFeatureId = store.remember(
 		currentSessionId,
 		"feature",
@@ -98,6 +132,10 @@ export function createPackEvalCorpus(store: MemoryStore): PackEvalCorpus {
 		ids: {
 			oauthDecisionId,
 			authTaskDecisionId,
+			memoryIssuesDurableId,
+			memoryIssuesRecapId,
+			sessionizationDurableId,
+			sessionizationSummaryId,
 			viewerTaskFeatureId,
 			viewerHealthFeatureId,
 			workingSetPrimaryId,

--- a/packages/core/src/pack.eval.test.ts
+++ b/packages/core/src/pack.eval.test.ts
@@ -45,7 +45,7 @@ describe("buildMemoryPack usefulness evals", () => {
 
 		expect(pack.metrics.mode).toBe("task");
 		expect(pack.item_ids[0]).toBe(corpus.ids.authTaskDecisionId);
-		expect(pack.item_ids.slice(0, 3)).toContain(corpus.ids.viewerTaskFeatureId);
+		expect(pack.item_ids.slice(0, 5)).toContain(corpus.ids.viewerTaskFeatureId);
 		expect(pack.pack_text.toLowerCase()).toContain("auth");
 	});
 
@@ -58,6 +58,40 @@ describe("buildMemoryPack usefulness evals", () => {
 		expect(pack.item_ids.slice(0, 3)).toContain(corpus.ids.viewerHealthFeatureId);
 		expect(pack.pack_text).toContain("Viewer health improvements");
 		expect(pack.pack_text).toContain("freshness and backlog diagnostics");
+	});
+
+	it("demotes recap-like rows for default retrieval queries that do not ask for a summary", () => {
+		const corpus = createPackEvalCorpus(store);
+
+		const pack = buildMemoryPack(store, "memory retrieval issues", 10);
+
+		expect(pack.metrics.mode).toBe("default");
+		expect(pack.item_ids[0]).toBe(corpus.ids.memoryIssuesDurableId);
+		expect(pack.item_ids.indexOf(corpus.ids.memoryIssuesDurableId)).toBeLessThan(
+			pack.item_ids.indexOf(corpus.ids.memoryIssuesRecapId),
+		);
+	});
+
+	it("does not treat topic queries mentioning summary as explicit recap requests", () => {
+		const corpus = createPackEvalCorpus(store);
+
+		const pack = buildMemoryPack(store, "sessionization summary emission", 10);
+
+		expect(pack.metrics.mode).toBe("recall");
+		expect(pack.item_ids[0]).toBe(corpus.ids.sessionizationDurableId);
+		expect(pack.item_ids.indexOf(corpus.ids.sessionizationDurableId)).toBeLessThan(
+			pack.item_ids.indexOf(corpus.ids.sessionizationSummaryId),
+		);
+	});
+
+	it("treats noun-form summary requests as explicit recap requests", () => {
+		const corpus = createPackEvalCorpus(store);
+
+		const pack = buildMemoryPack(store, "summary of oauth", 10);
+
+		expect(pack.metrics.mode).toBe("recall");
+		expect(pack.item_ids.slice(0, 3)).toContain(corpus.ids.oauthDecisionId);
+		expect(pack.pack_text.toLowerCase()).toContain("summary");
 	});
 
 	it("boosts working-set overlaps ahead of distractors when semantic candidates tie", () => {

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -299,15 +299,68 @@ function queryLooksLikeRecall(query: string): boolean {
 	return false;
 }
 
-function recallQueryPrefersSummary(query: string): boolean {
+function recallQueryWantsTimeline(query: string): boolean {
 	const lowered = query.toLowerCase();
-	for (const token of ["summary", "summarize", "recap"]) {
-		if (lowered.includes(token)) return true;
-	}
-	for (const phrase of ["catch me up", "catch up", "what happened", "where were we"]) {
+	for (const phrase of [
+		"what did we do",
+		"what did we work on",
+		"what did we decide",
+		"what happened",
+		"last time",
+		"previous session",
+		"previous work",
+		"where were we",
+		"catch me up",
+		"catch up",
+	]) {
 		if (lowered.includes(phrase)) return true;
 	}
 	return false;
+}
+
+function recallQueryPrefersSummary(query: string): boolean {
+	const lowered = query.toLowerCase();
+	for (const token of ["summarize", "recap"]) {
+		if (lowered.includes(token)) return true;
+	}
+	for (const phrase of [
+		"summary of",
+		"summary for",
+		"summary on",
+		"show summary",
+		"session summary",
+		"summarize",
+		"summarise",
+		"recap",
+		"catch me up",
+		"catch up",
+		"what happened",
+		"where were we",
+	]) {
+		if (lowered.includes(phrase)) return true;
+	}
+	if (lowered === "summary") return true;
+	if (lowered.startsWith("summary ")) return true;
+	return false;
+}
+
+function prioritizeDefaultResults(
+	results: MemoryResult[],
+	limit: number,
+	query: string,
+): MemoryResult[] {
+	const preferSummary = recallQueryPrefersSummary(query);
+	const ordered = [...results];
+	ordered.sort((a, b) => {
+		const overlapDelta = textOverlapScore(b, query) - textOverlapScore(a, query);
+		if (overlapDelta !== 0) return overlapDelta;
+		if (!preferSummary) {
+			const recapDelta = Number(itemLooksRecapLike(a)) - Number(itemLooksRecapLike(b));
+			if (recapDelta !== 0) return recapDelta;
+		}
+		return 0;
+	});
+	return ordered.slice(0, limit);
 }
 
 function toMemoryResult(row: MemoryItemResponse | TimelineItemResponse): MemoryResult {
@@ -344,6 +397,8 @@ function prioritizeTaskResults(results: MemoryResult[], limit: number, query = "
 	ordered.sort((a, b) => {
 		const overlapDelta = textOverlapScore(b, query) - textOverlapScore(a, query);
 		if (overlapDelta !== 0) return overlapDelta;
+		const taskLikeDelta = Number(itemLooksTaskLike(b)) - Number(itemLooksTaskLike(a));
+		if (taskLikeDelta !== 0) return taskLikeDelta;
 		const rank = (kind: string): number => {
 			if (kind === "note") return 0;
 			if (kind === "decision") return 1;
@@ -365,8 +420,6 @@ function prioritizeRecallResults(
 		(b.created_at ?? "").localeCompare(a.created_at ?? ""),
 	);
 	ordered.sort((a, b) => {
-		const overlapDelta = textOverlapScore(b, query) - textOverlapScore(a, query);
-		if (overlapDelta !== 0) return overlapDelta;
 		const rank = (item: MemoryResult): number => {
 			if (preferSummary) {
 				if (isSummaryLike(item)) return 0;
@@ -387,6 +440,14 @@ function prioritizeRecallResults(
 			if (item.kind === "entities") return 7;
 			return 5;
 		};
+		if (!preferSummary) {
+			const rankDelta = rank(a) - rank(b);
+			if (rankDelta !== 0) return rankDelta;
+			const recapDelta = Number(itemLooksRecapLike(a)) - Number(itemLooksRecapLike(b));
+			if (recapDelta !== 0) return recapDelta;
+		}
+		const overlapDelta = textOverlapScore(b, query) - textOverlapScore(a, query);
+		if (overlapDelta !== 0) return overlapDelta;
 		return rank(a) - rank(b);
 	});
 	return ordered.slice(0, limit);
@@ -469,6 +530,19 @@ function isSummaryLike(item: Pick<MemoryResult, "kind" | "metadata">): boolean {
 	if (item.kind === "session_summary") return true;
 	const metadata = parseMetadataObject(item.metadata);
 	return metadata.is_summary === true;
+}
+
+function itemLooksRecapLike(
+	item: Pick<MemoryResult, "kind" | "title" | "body_text" | "metadata">,
+): boolean {
+	if (isSummaryLike(item)) return true;
+	const text = `${item.title} ${item.body_text}`.toLowerCase();
+	if (text.includes("## request") && text.includes("## completed")) return true;
+	if (item.kind !== "change" && item.kind !== "feature") return false;
+	for (const marker of ["session recap", "wrap-up", "wrap up", "recap"]) {
+		if (text.includes(marker)) return true;
+	}
+	return false;
 }
 
 function findLatestSummaryLike(store: StoreHandle, filters?: MemoryFilters): MemoryResult | null {
@@ -701,6 +775,7 @@ export function buildMemoryPack(
 	} else if (recallMode) {
 		const recallQuery = context.trim().length > 0 ? context : RECALL_HINT_QUERY;
 		const preferSummary = recallQueryPrefersSummary(recallQuery);
+		const wantsTimeline = recallQueryWantsTimeline(recallQuery);
 		const topicalRecallQuery = [...queryContentTokens(recallQuery)].join(" ");
 		let recallResults = search(store, recallQuery, effectiveLimit, filters);
 		ftsCount = recallResults.length;
@@ -738,7 +813,7 @@ export function buildMemoryPack(
 			? results[0]
 			: (results.find((item) => !isSummaryLike(item)) ?? results[0]);
 		const anchorId = anchor?.id;
-		if (anchorId != null) {
+		if (wantsTimeline && anchorId != null) {
 			const depthBefore = Math.max(0, Math.floor(effectiveLimit / 2));
 			const depthAfter = Math.max(0, effectiveLimit - depthBefore - 1);
 			const timelineRows = timeline(
@@ -757,11 +832,11 @@ export function buildMemoryPack(
 		const ftsResults = search(store, context, effectiveLimit, filters);
 		if (semanticResults && semanticResults.length > 0) {
 			const merge = mergeResults(store, ftsResults, semanticResults, effectiveLimit, filters);
-			results = merge.merged;
+			results = prioritizeDefaultResults(merge.merged, effectiveLimit, context);
 			ftsCount = merge.ftsCount;
 			semanticCount = merge.semanticCount;
 		} else {
-			results = ftsResults;
+			results = prioritizeDefaultResults(ftsResults, effectiveLimit, context);
 			ftsCount = results.length;
 		}
 		if (results.length === 0) {
@@ -906,7 +981,9 @@ export function buildMemoryPack(
 	const selectedIds = new Set(selectedById.keys());
 	for (const item of results) {
 		if (!selectedIds.has(item.id)) continue;
-		selectedItems.push(selectedById.get(item.id)!);
+		const selected = selectedById.get(item.id);
+		if (!selected) continue;
+		selectedItems.push(selected);
 		selectedIds.delete(item.id);
 	}
 	for (const item of [...budgetedSummary, ...budgetedTimeline, ...budgetedObservations]) {


### PR DESCRIPTION
## Description

This PR tightens pack-mode ranking so topical and task-oriented queries are less likely to surface recap-heavy or off-topic results ahead of durable anchors. It adds fixture coverage for recap demotion, task prioritization, and recall-query behavior without committing any private evaluation data.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/pack.eval.test.ts packages/core/src/maintenance.test.ts`
- `pnpm run test`
- `pnpm exec biome check packages/core/src/pack.ts packages/core/src/pack.eval.test.ts packages/core/src/pack-eval-fixtures.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced