### PR TITLE
fix: demote recap-heavy retrieval fallbacks

### DIFF
--- a/packages/core/src/pack.eval.test.ts
+++ b/packages/core/src/pack.eval.test.ts
@@ -34,6 +34,7 @@ describe("buildMemoryPack usefulness evals", () => {
 
 		expect(pack.metrics.mode).toBe("recall");
 		expect(pack.item_ids.slice(0, 3)).toContain(corpus.ids.oauthDecisionId);
+		expect(pack.item_ids).not.toContain(corpus.ids.sessionizationSummaryId);
 		expect(pack.pack_text).toContain("OAuth callback fix");
 		expect(pack.pack_text).toContain("callback verification");
 	});

--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -402,7 +402,7 @@ describe("buildMemoryPack", () => {
 		expect(pack.item_ids[0]).not.toBe(decisionId);
 	});
 
-	it("treats legacy change memories with is_summary metadata as summaries", () => {
+	it("does not inject legacy summary rows into non-summary recall packs", () => {
 		const now = new Date().toISOString();
 		store.db
 			.prepare(
@@ -429,7 +429,7 @@ describe("buildMemoryPack", () => {
 		const pack = buildMemoryPack(store, "what did we do last time about oauth", 10);
 
 		expect(pack.pack_text).toContain("## Summary");
-		expect(pack.pack_text).toContain("Legacy summary");
+		expect(pack.pack_text).not.toContain("Legacy summary");
 		expect(pack.pack_text).toContain("## Timeline\n[2] (decision) OAuth callback fix");
 	});
 

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -728,6 +728,7 @@ function mergeResults(
 	ftsResults: MemoryResult[],
 	semanticResults: MemoryResult[],
 	limit: number,
+	query: string,
 	filters?: MemoryFilters,
 ): { merged: MemoryResult[]; ftsCount: number; semanticCount: number } {
 	const seen = new Map<number, MemoryResult>();
@@ -741,7 +742,7 @@ function mergeResults(
 		const existing = seen.get(r.id);
 		if (!existing || r.score > existing.score) seen.set(r.id, r);
 	}
-	const merged = rerankResults(store, [...seen.values()], limit, filters);
+	const merged = rerankResults(store, [...seen.values()], limit, filters, query);
 	return { merged, ftsCount: ftsResults.length, semanticCount };
 }
 
@@ -766,7 +767,14 @@ export function buildMemoryPack(
 		let taskResults = search(store, taskQuery, effectiveLimit, filters);
 		ftsCount = taskResults.length;
 		if (semanticResults && semanticResults.length > 0) {
-			const merge = mergeResults(store, taskResults, semanticResults, effectiveLimit, filters);
+			const merge = mergeResults(
+				store,
+				taskResults,
+				semanticResults,
+				effectiveLimit,
+				taskQuery,
+				filters,
+			);
 			taskResults = merge.merged;
 			semanticCount = merge.semanticCount;
 		}
@@ -817,7 +825,14 @@ export function buildMemoryPack(
 			ftsCount = recallResults.length;
 		}
 		if (semanticResults && semanticResults.length > 0) {
-			const merge = mergeResults(store, recallResults, semanticResults, effectiveLimit, filters);
+			const merge = mergeResults(
+				store,
+				recallResults,
+				semanticResults,
+				effectiveLimit,
+				recallQuery,
+				filters,
+			);
 			recallResults = merge.merged;
 			semanticCount = merge.semanticCount;
 		}
@@ -848,7 +863,14 @@ export function buildMemoryPack(
 	} else {
 		const ftsResults = search(store, context, effectiveLimit, filters);
 		if (semanticResults && semanticResults.length > 0) {
-			const merge = mergeResults(store, ftsResults, semanticResults, effectiveLimit, filters);
+			const merge = mergeResults(
+				store,
+				ftsResults,
+				semanticResults,
+				effectiveLimit,
+				context,
+				filters,
+			);
 			results = prioritizeDefaultResults(merge.merged, effectiveLimit, context);
 			ftsCount = merge.ftsCount;
 			semanticCount = merge.semanticCount;
@@ -864,9 +886,15 @@ export function buildMemoryPack(
 
 	// Step 2: categorize results
 
-	// Summary: prefer search match, fall back to most recent session_summary
-	let summaryItems = results.filter(isSummaryLike).slice(0, 1);
-	if (summaryItems.length === 0) {
+	// Summary: prefer search match; only inject a global fallback when the user
+	// explicitly wants a summary or we're in non-recall mode.
+	const directSummaryMatches =
+		recallMode && !recallQueryPrefersSummary(context)
+			? results.filter((item) => item.kind === "session_summary")
+			: results.filter(isSummaryLike);
+	let summaryItems = directSummaryMatches.slice(0, 1);
+	const allowGlobalSummaryFallback = !recallMode || recallQueryPrefersSummary(context);
+	if (summaryItems.length === 0 && allowGlobalSummaryFallback) {
 		const s = findLatestSummaryLike(store, filters);
 		if (s) {
 			summaryItems = [

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -233,6 +233,107 @@ describe("rerankResults", () => {
 	it("returns empty array for empty input", () => {
 		expect(rerankResults(mockStore, [], 10)).toEqual([]);
 	});
+
+	it("penalizes summary-like rows for non-summary topical queries", () => {
+		const results = [
+			makeResult({
+				id: 1,
+				score: 4.0,
+				kind: "change",
+				title: "Memory retrieval issues recap",
+				metadata: { is_summary: true },
+			}),
+			makeResult({
+				id: 2,
+				score: 3.7,
+				kind: "discovery",
+				title: "Memory retrieval issue root cause",
+			}),
+		];
+		const reranked = rerankResults(mockStore, results, 10, undefined, "memory retrieval issues");
+		expect(reranked[0]?.id).toBe(2);
+	});
+
+	it("penalizes observer-summary recap blobs for non-summary topical queries", () => {
+		const results = [
+			makeResult({
+				id: 1,
+				score: 4.2,
+				kind: "change",
+				title: "User wanted to preserve important discussion items",
+				metadata: {
+					source: "observer_summary",
+					request: "investigate memory retrieval issues",
+					completed: "created follow-up tasks",
+				},
+			}),
+			makeResult({
+				id: 2,
+				score: 3.6,
+				kind: "discovery",
+				title: "Memory retrieval issue root cause",
+			}),
+		];
+		const reranked = rerankResults(mockStore, results, 10, undefined, "memory retrieval issues");
+		expect(reranked[0]?.id).toBe(2);
+	});
+
+	it("applies a stronger penalty to observer-summary recap blobs than ordinary summary rows", () => {
+		const results = [
+			makeResult({
+				id: 1,
+				score: 4.6,
+				kind: "change",
+				title: "Observer recap blob",
+				metadata: {
+					source: "observer_summary",
+					request: "investigate memory retrieval issues",
+					completed: "created follow-up tasks",
+				},
+			}),
+			makeResult({
+				id: 2,
+				score: 4.0,
+				kind: "change",
+				title: "Ordinary recap row",
+				metadata: { is_summary: true },
+			}),
+			makeResult({
+				id: 3,
+				score: 3.5,
+				kind: "discovery",
+				title: "Memory retrieval issue root cause",
+			}),
+		];
+		const reranked = rerankResults(mockStore, results, 10, undefined, "memory retrieval issues");
+		expect(reranked.map((item) => item.id)).toEqual([3, 2, 1]);
+	});
+
+	it("does not penalize summary-like rows when the query explicitly asks for a summary", () => {
+		const results = [
+			makeResult({
+				id: 1,
+				score: 4.0,
+				kind: "change",
+				title: "Memory retrieval issues recap",
+				metadata: { is_summary: true },
+			}),
+			makeResult({
+				id: 2,
+				score: 3.7,
+				kind: "discovery",
+				title: "Memory retrieval issue root cause",
+			}),
+		];
+		const reranked = rerankResults(
+			mockStore,
+			results,
+			10,
+			undefined,
+			"summarize memory retrieval issues",
+		);
+		expect(reranked[0]?.id).toBe(1);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -75,6 +75,9 @@ const TRUST_BIAS_UNREVIEWED_PENALTY = 0.12;
 const WIDEN_SHARED_DEFAULT_MIN_PERSONAL_RESULTS = 3;
 const WIDEN_SHARED_DEFAULT_MIN_PERSONAL_SCORE = 0.0;
 const WIDEN_SHARED_MAX_SHARED_RESULTS = 2;
+const NON_SUMMARY_RECAP_PENALTY = 2.5;
+const NON_SUMMARY_OBSERVER_RECAP_PENALTY = 6.5;
+const NON_TASK_TASKLIKE_PENALTY = 0.35;
 const PERSONAL_QUERY_PATTERNS = [
 	/\bwhat did i\b/i,
 	/\bmy notes\b/i,
@@ -265,6 +268,79 @@ function personalBias(
 	return store.memoryOwnedBySelf(item) ? PERSONAL_FIRST_BONUS : 0.0;
 }
 
+function searchQueryPrefersSummary(query: string): boolean {
+	const lowered = query.toLowerCase();
+	for (const token of ["summarize", "summarise", "recap"]) {
+		if (lowered.includes(token)) return true;
+	}
+	for (const phrase of ["session summary", "catch me up", "catch up", "what happened"]) {
+		if (lowered.includes(phrase)) return true;
+	}
+	return false;
+}
+
+function searchQueryLooksTaskLike(query: string): boolean {
+	const lowered = query.toLowerCase();
+	for (const phrase of [
+		"what should",
+		"what do next",
+		"next step",
+		"next steps",
+		"todo",
+		"to do",
+		"follow up",
+		"continue",
+	]) {
+		if (lowered.includes(phrase)) return true;
+	}
+	return false;
+}
+
+function itemIsSummaryLike(item: MemoryResult): boolean {
+	if (item.kind === "session_summary") return true;
+	return item.metadata?.is_summary === true;
+}
+
+function itemLooksRecapLikeForSearch(item: MemoryResult): boolean {
+	if (itemIsSummaryLike(item)) return true;
+	const metadata = item.metadata ?? {};
+	if (metadata.source === "observer_summary") return true;
+	if (typeof metadata.request === "string" && typeof metadata.completed === "string") return true;
+	const text = `${item.title} ${item.body_text}`.toLowerCase();
+	for (const marker of ["session recap", "wrap-up", "wrap up", "recap", "## request"]) {
+		if (text.includes(marker)) return true;
+	}
+	return false;
+}
+
+function recapPenaltyForSearch(item: MemoryResult, preferSummary: boolean): number {
+	if (preferSummary || !itemLooksRecapLikeForSearch(item)) return 0.0;
+	const metadata = item.metadata ?? {};
+	if (metadata.source === "observer_summary") return NON_SUMMARY_OBSERVER_RECAP_PENALTY;
+	if (typeof metadata.request === "string" && typeof metadata.completed === "string") {
+		return NON_SUMMARY_OBSERVER_RECAP_PENALTY;
+	}
+	return NON_SUMMARY_RECAP_PENALTY;
+}
+
+function itemLooksTaskLikeForSearch(item: MemoryResult): boolean {
+	const text = `${item.title} ${item.body_text}`.toLowerCase();
+	for (const marker of [
+		"next step",
+		"next steps",
+		"follow-up",
+		"follow up",
+		"todo",
+		"to do",
+		"continue",
+		"should do",
+		"should we",
+	]) {
+		if (text.includes(marker)) return true;
+	}
+	return false;
+}
+
 function sharedTrustPenalty(
 	store: StoreHandle,
 	item: MemoryResult,
@@ -382,9 +458,12 @@ export function rerankResults(
 	results: MemoryResult[],
 	limit: number,
 	filters?: MemoryFilters,
+	query = "",
 ): MemoryResult[] {
 	const referenceNow = new Date();
 	const workingSetPaths = normalizeWorkingSetPaths(filters?.working_set_paths);
+	const preferSummary = searchQueryPrefersSummary(query);
+	const taskLikeQuery = searchQueryLooksTaskLike(query);
 
 	const scored = results.map((item) => ({
 		item,
@@ -394,7 +473,9 @@ export function rerankResults(
 			kindBonus(item.kind) +
 			workingSetOverlapBoost(item, workingSetPaths) +
 			personalBias(store, item, filters) -
-			sharedTrustPenalty(store, item, filters),
+			sharedTrustPenalty(store, item, filters) -
+			recapPenaltyForSearch(item, preferSummary) -
+			(!taskLikeQuery && itemLooksTaskLikeForSearch(item) ? NON_TASK_TASKLIKE_PENALTY : 0.0),
 	}));
 
 	scored.sort((a, b) => b.combinedScore - a.combinedScore);
@@ -542,7 +623,7 @@ function searchOnce(
 		};
 	});
 
-	return rerankResults(store, results, effectiveLimit, filters);
+	return rerankResults(store, results, effectiveLimit, filters, query);
 }
 
 /**


### PR DESCRIPTION
## Description

This PR reduces recap-heavy retrieval pollution by demoting observer-summary recap blobs for non-summary topical queries and by avoiding unrelated summary fallback injection in recall packs. It keeps explicit summary requests intact while making normal retrieval and recall paths less likely to surface irrelevant recap sludge.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/search.test.ts packages/core/src/pack.eval.test.ts packages/core/src/maintenance.test.ts`
- `pnpm run test`
- `pnpm exec biome check packages/core/src/search.ts packages/core/src/pack.ts packages/core/src/pack.eval.test.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced