### PR TITLE
fix: unify summary memory handling

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -278,6 +278,7 @@ export {
 	timeline,
 } from "./search.js";
 export { MemoryStore } from "./store.js";
+export { canonicalMemoryKind, getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
 export type {
 	BuildAuthHeadersOptions,
 	SignRequestOptions,

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -549,6 +549,113 @@ describe("ingest() integration", () => {
 		expect(summaryMetadata.learned).toBe("Race condition in handler");
 	});
 
+	it("suppresses summary-only micro-session recap output", async () => {
+		const summaryOnlyObserver = {
+			observe: async () => ({
+				raw: `<summary>
+					<request>Check retrieval noise</request>
+					<investigated>Looked at role report output</investigated>
+					<learned>Recap-heavy rows still dominate</learned>
+					<completed>Reviewed the current ranking behavior</completed>
+					<next_steps>Tighten recap weighting</next_steps>
+					<notes></notes>
+				</summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			events: [
+				{
+					type: "user_prompt",
+					prompt_text: "ok",
+					prompt_number: 1,
+					timestamp: new Date().toISOString(),
+				},
+				{
+					type: "assistant_message",
+					assistant_text: "Done.",
+					timestamp: new Date().toISOString(),
+				},
+			],
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-micro-summary",
+				promptCount: 1,
+				toolCount: 0,
+				durationMs: 20_000,
+			},
+		});
+
+		await ingest(payload, store, { observer: summaryOnlyObserver } as unknown as IngestOptions);
+
+		expect(store.recent(10)).toHaveLength(0);
+	});
+
+	it("keeps summary-only output for longer sessions", async () => {
+		const summaryOnlyObserver = {
+			observe: async () => ({
+				raw: `<summary>
+					<request>Check retrieval noise</request>
+					<investigated>Looked at role report output</investigated>
+					<learned>Recap-heavy rows still dominate</learned>
+					<completed>Reviewed the current ranking behavior</completed>
+					<next_steps>Tighten recap weighting</next_steps>
+					<notes></notes>
+				</summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			events: [
+				{
+					type: "user_prompt",
+					prompt_text: "ok",
+					prompt_number: 1,
+					timestamp: new Date().toISOString(),
+				},
+				{
+					type: "assistant_message",
+					assistant_text: "Done.",
+					timestamp: new Date().toISOString(),
+				},
+			],
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-long-summary",
+				promptCount: 1,
+				toolCount: 0,
+				durationMs: 120_000,
+			},
+		});
+
+		await ingest(payload, store, { observer: summaryOnlyObserver } as unknown as IngestOptions);
+
+		const summaryMemory = store.db
+			.prepare(
+				"SELECT kind FROM memory_items WHERE json_extract(metadata_json, '$.is_summary') = 1 ORDER BY id DESC LIMIT 1",
+			)
+			.get() as { kind: string };
+		expect(summaryMemory.kind).toBe("session_summary");
+	});
+
 	it("falls back to cwd basename when payload project is missing", async () => {
 		const payload = buildPayload({ cwd: "/tmp/workspaces/codemem" });
 		await ingest(payload, store, { observer: mockObserver } as unknown as IngestOptions);
@@ -705,6 +812,62 @@ describe("ingest() integration", () => {
 		).rejects.toThrow("observer produced no storable output for raw-event flush");
 
 		expect(store.recent(10)).toHaveLength(0);
+	});
+
+	it("treats summary-only micro-session raw-event flushes as terminal no-op", async () => {
+		const summaryOnlyObserver = {
+			observe: async () => ({
+				raw: `<summary>
+					<request>Check retrieval noise</request>
+					<investigated>Looked at role report output</investigated>
+					<learned>Recap-heavy rows still dominate</learned>
+					<completed>Reviewed the current ranking behavior</completed>
+					<next_steps>Tighten recap weighting</next_steps>
+					<notes></notes>
+				</summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			events: [
+				{
+					type: "user_prompt",
+					prompt_text: "ok",
+					prompt_number: 1,
+					timestamp: new Date().toISOString(),
+				},
+				{
+					type: "assistant_message",
+					assistant_text: "Done.",
+					timestamp: new Date().toISOString(),
+				},
+			],
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-summary-only-micro",
+				promptCount: 1,
+				toolCount: 0,
+				durationMs: 20_000,
+				flusher: "raw_events",
+			},
+		});
+
+		await ingest(payload, store, { observer: summaryOnlyObserver } as unknown as IngestOptions);
+
+		expect(store.recent(10)).toHaveLength(0);
+		const session = store.db
+			.prepare("SELECT ended_at FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as { ended_at: string | null };
+		expect(session.ended_at).not.toBeNull();
 	});
 
 	it("retries once when observer returns plain text instead of XML during raw-event flush", async () => {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -109,6 +109,32 @@ function summaryBody(summary: ParsedSummary): string {
 		.join("\n\n");
 }
 
+function shouldSuppressSummaryOnlyMicroSession(
+	sessionContext: SessionContext,
+	observationsCount: number,
+	summaryToStore: { summary: ParsedSummary; request: string; body: string } | null,
+	latestPrompt: string | null,
+	toolEventCount: number,
+	hasAssistantMessage: boolean,
+	skipSummaryReason: string | null,
+): boolean {
+	if (!summaryToStore) return false;
+	if (observationsCount > 0) return false;
+	if (skipSummaryReason) return false;
+	const durationMs = sessionContext.durationMs ?? 0;
+	const promptCount = sessionContext.promptCount ?? 0;
+	const toolCount = sessionContext.toolCount ?? 0;
+	const hasModifiedFiles = (sessionContext.filesModified?.length ?? 0) > 0;
+	if (durationMs <= 0 || durationMs >= 60_000) return false;
+	if (promptCount > 1) return false;
+	if (toolCount > 2) return false;
+	if (hasModifiedFiles) return false;
+	if (!isTrivialRequest(latestPrompt)) return false;
+	if (toolEventCount > 0) return false;
+	if (!hasAssistantMessage) return false;
+	return true;
+}
+
 // ---------------------------------------------------------------------------
 // Event normalization (adapter projection)
 // ---------------------------------------------------------------------------
@@ -427,6 +453,20 @@ export async function ingest(
 			}
 		}
 
+		if (
+			shouldSuppressSummaryOnlyMicroSession(
+				sessionContext,
+				observationsToStore.length,
+				summaryToStore,
+				latestPrompt,
+				toolEvents.length,
+				Boolean(lastAssistantMessage),
+				parsed.skipSummaryReason,
+			)
+		) {
+			summaryToStore = null;
+		}
+
 		if (sessionContext?.flusher === "raw_events") {
 			const storableCount = observationsToStore.length + (summaryToStore ? 1 : 0);
 			if (storableCount === 0) {
@@ -434,7 +474,23 @@ export async function ingest(
 					parsed.skipSummaryReason?.trim().toLowerCase() === "low-signal" &&
 					parsed.observations.length === 0 &&
 					parsed.summary === null;
-				if (pureLowSignalSkip) {
+				const locallySuppressedSummaryOnlyMicro =
+					parsed.observations.length === 0 &&
+					parsed.summary !== null &&
+					shouldSuppressSummaryOnlyMicroSession(
+						sessionContext,
+						0,
+						{
+							summary: parsed.summary,
+							request: parsed.summary.request,
+							body: summaryBody(parsed.summary),
+						},
+						latestPrompt,
+						toolEvents.length,
+						Boolean(lastAssistantMessage),
+						parsed.skipSummaryReason,
+					);
+				if (pureLowSignalSkip || locallySuppressedSummaryOnlyMicro) {
 					endSession(store, sessionId, events.length, sessionContext);
 					return;
 				}

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -14,6 +14,7 @@ import { projectClause } from "./project.js";
 import * as schema from "./schema.js";
 import { bootstrapSchema } from "./schema-bootstrap.js";
 import { MemoryStore } from "./store.js";
+import { canonicalMemoryKind, getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
 
 export interface RawEventStatusItem {
 	source: string;
@@ -255,15 +256,7 @@ function classifyProjectQuality(project: unknown): "normal" | "empty" | "garbage
 }
 
 function safeParseMetadata(raw: string | null): Record<string, unknown> {
-	if (!raw) return {};
-	try {
-		const parsed = JSON.parse(raw) as unknown;
-		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-			? (parsed as Record<string, unknown>)
-			: {};
-	} catch {
-		return {};
-	}
+	return getSummaryMetadata(raw);
 }
 
 function hasAnyMarker(text: string, markers: string[]): boolean {
@@ -658,7 +651,7 @@ function inferMemoryRole(row: {
 	has_opencode_mapping: number;
 }): InferredMemoryRole {
 	const metadata = safeParseMetadata(row.metadata_json);
-	const isSummary = row.kind === "session_summary" || metadata?.is_summary === true;
+	const isSummary = isSummaryLikeMemory({ kind: row.kind, metadata });
 	if (isSummary) {
 		return {
 			role: "recap",
@@ -817,7 +810,7 @@ export function getMemoryRoleReport(
 			const metadata = safeParseMetadata(row.metadata_json);
 			if (row.kind === "session_summary") sessionSummaryCount += 1;
 			if (row.kind === "change" && metadata?.is_summary === true) legacySummaryCount += 1;
-			if (row.kind === "session_summary" || metadata?.is_summary === true) {
+			if (isSummaryLikeMemory({ kind: row.kind, metadata })) {
 				if (mapping === "mapped") mappedSummaryCount += 1;
 				else unmappedSummaryCount += 1;
 			}
@@ -889,7 +882,7 @@ export function getMemoryRoleReport(
 						const source = rows.find((row) => row.id === item.id);
 						const inferred = source
 							? inferMemoryRole(source)
-							: item.kind === "session_summary"
+							: canonicalMemoryKind(item.kind, item.metadata) === "session_summary"
 								? { role: "recap" as const, reason: "session_summary_kind" }
 								: { role: "ephemeral" as const, reason: "missing_source_row" };
 						const mapping: "mapped" | "unmapped" = source?.has_opencode_mapping
@@ -903,7 +896,7 @@ export function getMemoryRoleReport(
 								title: source?.title ?? item.title,
 								body_text: source?.body_text ?? "",
 							}),
-							kind: item.kind,
+							kind: canonicalMemoryKind(item.kind, item.metadata),
 							title: item.title,
 							role: inferred.role,
 							role_reason: inferred.reason,

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -19,6 +19,12 @@ import { buildFilterClausesWithContext } from "./filters.js";
 import { projectBasename } from "./project.js";
 import type { StoreHandle } from "./search.js";
 import { rerankResults, search, timeline } from "./search.js";
+import {
+	canonicalMemoryKind,
+	getSummaryMetadata,
+	isNativeSessionSummaryMemory,
+	isSummaryLikeMemory,
+} from "./summary-memory.js";
 import type {
 	MemoryFilters,
 	MemoryItemResponse,
@@ -383,7 +389,7 @@ function prioritizeDefaultResults(
 function toMemoryResult(row: MemoryItemResponse | TimelineItemResponse): MemoryResult {
 	return {
 		id: row.id,
-		kind: row.kind,
+		kind: canonicalMemoryKind(row.kind, row.metadata_json),
 		title: row.title,
 		body_text: row.body_text,
 		confidence: row.confidence ?? 0,
@@ -525,28 +531,11 @@ function coercePackItemIds(value: unknown): { ids: number[]; valid: boolean } {
 }
 
 function parseMetadataObject(value: unknown): Record<string, unknown> {
-	if (!value) return {};
-	if (typeof value === "string") {
-		try {
-			const parsed = JSON.parse(value) as unknown;
-			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-				return parsed as Record<string, unknown>;
-			}
-			return {};
-		} catch {
-			return {};
-		}
-	}
-	if (typeof value === "object" && !Array.isArray(value)) {
-		return value as Record<string, unknown>;
-	}
-	return {};
+	return getSummaryMetadata(value);
 }
 
 function isSummaryLike(item: Pick<MemoryResult, "kind" | "metadata">): boolean {
-	if (item.kind === "session_summary") return true;
-	const metadata = parseMetadataObject(item.metadata);
-	return metadata.is_summary === true;
+	return isSummaryLikeMemory(item);
 }
 
 function itemLooksRecapLike(
@@ -890,7 +879,7 @@ export function buildMemoryPack(
 	// explicitly wants a summary or we're in non-recall mode.
 	const directSummaryMatches =
 		recallMode && !recallQueryPrefersSummary(context)
-			? results.filter((item) => item.kind === "session_summary")
+			? results.filter((item) => isNativeSessionSummaryMemory(item))
 			: results.filter(isSummaryLike);
 	let summaryItems = directSummaryMatches.slice(0, 1);
 	const allowGlobalSummaryFallback = !recallMode || recallQueryPrefersSummary(context);

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -431,6 +431,25 @@ describe("MemoryStore.search", () => {
 		}
 	});
 
+	it("preserves explicit raw kind filters in emitted search results", () => {
+		const sessionId = insertTestSession(store.db);
+		const legacySummaryId = store.remember(
+			sessionId,
+			"change",
+			"Legacy summary",
+			"## Request\nFix auth timeout\n\n## Completed\nAdded callback validation",
+			0.8,
+			undefined,
+			{ is_summary: true },
+		);
+
+		const filtered = store.search("auth timeout", 10, { kind: "change" });
+		const summary = filtered.find((item) => item.id === legacySummaryId);
+
+		expect(summary).toBeDefined();
+		expect(summary?.kind).toBe("change");
+	});
+
 	it("matches project filters by basename and suffix like Python", () => {
 		const now = new Date().toISOString();
 		const matchingSessionId = Number(

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -19,6 +19,7 @@ import {
 import { parsePositiveMemoryId } from "./integers.js";
 import { projectMatchesFilter } from "./project.js";
 import * as schema from "./schema.js";
+import { canonicalMemoryKind, isSummaryLikeMemory } from "./summary-memory.js";
 import type {
 	ExplainError,
 	ExplainItem,
@@ -297,8 +298,7 @@ function searchQueryLooksTaskLike(query: string): boolean {
 }
 
 function itemIsSummaryLike(item: MemoryResult): boolean {
-	if (item.kind === "session_summary") return true;
-	return item.metadata?.is_summary === true;
+	return isSummaryLikeMemory(item);
 }
 
 function itemLooksRecapLikeForSearch(item: MemoryResult): boolean {
@@ -577,6 +577,7 @@ function searchOnce(
 	params.push(queryLimit);
 
 	const rows = store.db.prepare(sql).all(...params) as Record<string, unknown>[];
+	const preserveFilteredKind = typeof filters?.kind === "string" && filters.kind.trim().length > 0;
 
 	const results: MemoryResult[] = rows.map((row) => {
 		const metadata: Record<string, unknown> = {
@@ -610,7 +611,9 @@ function searchOnce(
 
 		return {
 			id: row.id as number,
-			kind: row.kind as string,
+			kind: preserveFilteredKind
+				? (row.kind as string)
+				: canonicalMemoryKind(row.kind as string, metadata),
 			title: row.title as string,
 			body_text: row.body_text as string,
 			confidence: row.confidence as number,
@@ -902,7 +905,7 @@ function loadItemsByIdsForExplain(
 
 	const items = scopedRows.map((row) => ({
 		id: row.id,
-		kind: row.kind,
+		kind: canonicalMemoryKind(row.kind, row.metadata_json),
 		title: row.title,
 		body_text: row.body_text,
 		confidence: row.confidence ?? 0,

--- a/packages/core/src/summary-memory.test.ts
+++ b/packages/core/src/summary-memory.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { canonicalMemoryKind, isSummaryLikeMemory } from "./summary-memory.js";
+
+describe("summary memory normalization", () => {
+	it("treats legacy summary metadata rows as summary memories", () => {
+		expect(isSummaryLikeMemory({ kind: "change", metadata: { is_summary: true } })).toBe(true);
+		expect(canonicalMemoryKind("change", { is_summary: true })).toBe("session_summary");
+	});
+
+	it("treats observer_summary source rows as summary memories", () => {
+		expect(isSummaryLikeMemory({ kind: "change", metadata: { source: "observer_summary" } })).toBe(
+			true,
+		);
+		expect(canonicalMemoryKind("change", { source: "observer_summary" })).toBe("session_summary");
+	});
+
+	it("leaves ordinary non-summary memories alone", () => {
+		expect(isSummaryLikeMemory({ kind: "change", metadata: { source: "observer" } })).toBe(false);
+		expect(canonicalMemoryKind("change", { source: "observer" })).toBe("change");
+	});
+});

--- a/packages/core/src/summary-memory.ts
+++ b/packages/core/src/summary-memory.ts
@@ -1,0 +1,74 @@
+import type { MemoryResult } from "./types.js";
+
+type SummaryLikeInput = {
+	kind?: string | null;
+	metadata?: unknown;
+};
+
+function parseMetadataObject(value: unknown): Record<string, unknown> {
+	if (!value) return {};
+	if (typeof value === "string") {
+		try {
+			const parsed = JSON.parse(value) as unknown;
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				return parsed as Record<string, unknown>;
+			}
+			return {};
+		} catch {
+			return {};
+		}
+	}
+	if (typeof value === "object" && !Array.isArray(value)) {
+		return value as Record<string, unknown>;
+	}
+	return {};
+}
+
+export function getSummaryMetadata(metadata: unknown): Record<string, unknown> {
+	return parseMetadataObject(metadata);
+}
+
+export function isSummaryLikeMemory(input: SummaryLikeInput): boolean {
+	const kindValue = String(input.kind ?? "")
+		.trim()
+		.toLowerCase();
+	if (kindValue === "session_summary") return true;
+	const metadata = getSummaryMetadata(input.metadata);
+	if (metadata.is_summary === true) return true;
+	return (
+		String(metadata.source ?? "")
+			.trim()
+			.toLowerCase() === "observer_summary"
+	);
+}
+
+export function isNativeSessionSummaryMemory(input: SummaryLikeInput): boolean {
+	const kindValue = String(input.kind ?? "")
+		.trim()
+		.toLowerCase();
+	if (kindValue !== "session_summary") return false;
+	const metadata = getSummaryMetadata(input.metadata);
+	if (metadata.is_summary === true) return false;
+	return (
+		String(metadata.source ?? "")
+			.trim()
+			.toLowerCase() !== "observer_summary"
+	);
+}
+
+export function canonicalMemoryKind(kind: string | null | undefined, metadata?: unknown): string {
+	const normalized = String(kind ?? "")
+		.trim()
+		.toLowerCase();
+	if (isSummaryLikeMemory({ kind: normalized, metadata })) return "session_summary";
+	return normalized || "change";
+}
+
+export function canonicalizeMemoryResultKind<T extends Pick<MemoryResult, "kind" | "metadata">>(
+	item: T,
+): T {
+	return {
+		...item,
+		kind: canonicalMemoryKind(item.kind, item.metadata),
+	};
+}

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -229,6 +229,11 @@ function isSummaryLikeItem(item: any, metadata: any): boolean {
   return source === 'observer_summary';
 }
 
+function canonicalKind(item: any, metadata: any): string {
+  const kindValue = String(item?.kind || '').trim().toLowerCase();
+  return isSummaryLikeItem(item, metadata) ? 'session_summary' : (kindValue || 'change');
+}
+
 function getFactsList(item: any): string[] {
   const summary = getSummaryObject(item);
   if (summary) {
@@ -456,10 +461,9 @@ function TagChip({ tag }: { tag: any }) {
 /* ── Feed item card renderer ─────────────────────────────── */
 
 function FeedItemCard({ item }: { item: any }) {
-  const kindValue = String(item.kind || 'session_summary').toLowerCase();
   const metadata = mergeMetadata(item?.metadata_json);
   const isSessionSummary = isSummaryLikeItem(item, metadata);
-  const displayKindValue = isSessionSummary ? 'session_summary' : kindValue;
+  const displayKindValue = canonicalKind(item, metadata);
   const rowKey = itemKey(item);
   const defaultTitle = item.title || '(untitled)';
   const displayTitle = isSessionSummary && metadata?.request ? metadata.request : defaultTitle;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -430,6 +430,7 @@ describe("viewer-server", () => {
 					"Legacy summary",
 					"Observer summary memory",
 				]);
+				expect(new Set(summaries.map((item) => item.kind))).toEqual(new Set(["session_summary"]));
 
 				const observationsRes = await app.request("/api/observations");
 				expect(observationsRes.status).toBe(200);

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -3,7 +3,14 @@
  */
 
 import type { MemoryStore } from "@codemem/core";
-import { buildFilterClausesWithContext, fromJson, parseStrictInteger, schema } from "@codemem/core";
+import {
+	buildFilterClausesWithContext,
+	canonicalMemoryKind,
+	fromJson,
+	isSummaryLikeMemory as isCoreSummaryLikeMemory,
+	parseStrictInteger,
+	schema,
+} from "@codemem/core";
 import { desc, eq, inArray, isNotNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { Hono } from "hono";
@@ -108,19 +115,16 @@ function queryMemoryPage(
 
 	return rows.map((row) => ({
 		...row,
+		kind: canonicalMemoryKind((row.kind as string | null | undefined) ?? null, row.metadata_json),
 		metadata_json: fromJson((row.metadata_json as string) ?? null),
 	}));
 }
 
 function isSummaryLikeMemory(item: Record<string, unknown>): boolean {
-	if (String(item.kind ?? "").toLowerCase() === "session_summary") return true;
-	const metadata = (item.metadata_json ?? {}) as Record<string, unknown>;
-	if (metadata.is_summary === true) return true;
-	return (
-		String(metadata.source ?? "")
-			.trim()
-			.toLowerCase() === "observer_summary"
-	);
+	return isCoreSummaryLikeMemory({
+		kind: item.kind as string | null | undefined,
+		metadata: item.metadata_json,
+	});
 }
 
 function selectMemoryPage(


### PR DESCRIPTION
## Description

This PR unifies summary-memory handling on the read path so legacy `change` memories marked as summaries are exposed consistently as `session_summary` alongside newer summary memories. It also tightens micro-session summary suppression to avoid storing trivial summary-only recap output while preserving legitimate summary behavior for longer or substantive sessions.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/ingest-pipeline.test.ts packages/core/src/search.test.ts packages/core/src/pack.test.ts packages/core/src/pack.eval.test.ts packages/core/src/maintenance.test.ts packages/viewer-server/src/index.test.ts`
- `pnpm run test`
- `pnpm exec biome check packages/core/src/summary-memory.ts packages/core/src/summary-memory.test.ts packages/core/src/ingest-pipeline.ts packages/core/src/pack.ts packages/core/src/search.ts packages/viewer-server/src/routes/memory.ts packages/ui/src/tabs/feed.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter @codemem/server run build`
- `pnpm --filter codemem run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced