### PR TITLE
fix: improve raw-event flush and observer context

### DIFF
--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -31,7 +31,7 @@ import {
 	projectAdapterToolEvent,
 } from "./ingest-events.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
-import { buildObserverPrompt } from "./ingest-prompts.js";
+import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
 import {
 	buildTranscript,
 	deriveRequest,
@@ -369,10 +369,12 @@ export async function ingest(
 				: `[Session context: ${sessionInfoText}]`;
 		}
 
+		const transcriptBudget = Math.max(1500, Math.min(5000, Math.floor(observerMaxChars * 0.4)));
 		const observerContext: ObserverContext = {
 			project,
 			userPrompt: observerPrompt,
 			promptNumber,
+			transcript: truncateObserverTranscript(transcript, transcriptBudget),
 			toolEvents,
 			lastAssistantMessage: storeSummary ? lastAssistantMessage : null,
 			includeSummary: storeSummary,

--- a/packages/core/src/ingest-prompts.test.ts
+++ b/packages/core/src/ingest-prompts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildObserverPrompt } from "./ingest-prompts.js";
+import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
 
 describe("buildObserverPrompt", () => {
 	it("includes the Python parity examples and schema guidance", () => {
@@ -7,6 +7,7 @@ describe("buildObserverPrompt", () => {
 			project: "codemem",
 			userPrompt: "Fix observer quality drift",
 			promptNumber: 1,
+			transcript: "User: Fix observer quality drift",
 			toolEvents: [],
 			lastAssistantMessage: null,
 			diffSummary: "",
@@ -29,6 +30,7 @@ describe("buildObserverPrompt", () => {
 			project: "codemem",
 			userPrompt: "Tighten observer prompt quality",
 			promptNumber: 3,
+			transcript: "User: Tighten observer prompt quality\n\nAssistant: Done.",
 			toolEvents: [],
 			lastAssistantMessage: "Done.",
 			diffSummary: "",
@@ -38,6 +40,18 @@ describe("buildObserverPrompt", () => {
 
 		expect(user).toContain("<project>codemem</project>");
 		expect(user).toContain("<prompt_number>3</prompt_number>");
+		expect(user).toContain("<conversation_transcript>");
+		expect(user).toContain("Assistant: Done.");
 		expect(user).toContain("<assistant_response>Done.</assistant_response>");
+	});
+
+	it("truncates long transcripts while preserving head and tail context", () => {
+		const transcript = `${"A".repeat(120)} middle context ${"Z".repeat(120)}`;
+		const truncated = truncateObserverTranscript(transcript, 80);
+
+		expect(truncated.length).toBeLessThanOrEqual(80);
+		expect(truncated).toContain("[...]");
+		expect(truncated.startsWith("A")).toBe(true);
+		expect(truncated.endsWith("Z".repeat(35))).toBe(true);
 	});
 });

--- a/packages/core/src/ingest-prompts.ts
+++ b/packages/core/src/ingest-prompts.ts
@@ -206,6 +206,15 @@ function formatToolEvent(event: ToolEvent): string {
 	return parts.join("\n");
 }
 
+function truncateMiddle(text: string, limit: number): string {
+	if (text.length <= limit) return text;
+	if (limit <= 20) return text.slice(0, limit);
+	const keep = Math.floor((limit - 9) / 2);
+	const head = text.slice(0, keep).trimEnd();
+	const tail = text.slice(text.length - keep).trimStart();
+	return `${head}\n[...]\n${tail}`;
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -260,6 +269,12 @@ export function buildObserverPrompt(context: ObserverContext): {
 		userBlocks.push(promptBlock.join("\n"));
 	}
 
+	if (context.transcript.trim()) {
+		userBlocks.push(
+			`<conversation_transcript>\n${escapeXml(context.transcript)}\n</conversation_transcript>`,
+		);
+	}
+
 	if (context.diffSummary) {
 		userBlocks.push(
 			`<observed_from_primary_session>\n  <diff_summary>${escapeXml(context.diffSummary)}</diff_summary>\n</observed_from_primary_session>`,
@@ -286,4 +301,10 @@ export function buildObserverPrompt(context: ObserverContext): {
 	const user = userBlocks.join("\n\n").trim();
 
 	return { system, user };
+}
+
+export function truncateObserverTranscript(transcript: string, maxChars: number): string {
+	const trimmed = transcript.trim();
+	if (!trimmed) return "";
+	return truncateMiddle(trimmed, maxChars);
 }

--- a/packages/core/src/ingest-types.ts
+++ b/packages/core/src/ingest-types.ts
@@ -26,6 +26,7 @@ export interface ObserverContext {
 	project: string | null;
 	userPrompt: string;
 	promptNumber: number | null;
+	transcript: string;
 	toolEvents: ToolEvent[];
 	lastAssistantMessage: string | null;
 	includeSummary: boolean;

--- a/packages/core/src/raw-event-sweeper.test.ts
+++ b/packages/core/src/raw-event-sweeper.test.ts
@@ -18,10 +18,12 @@ describe("RawEventSweeper auto flush", () => {
 	let store: MemoryStore;
 	let prevAutoFlush: string | undefined;
 	let prevDebounce: string | undefined;
+	let prevWorkerMaxEvents: string | undefined;
 
 	beforeEach(() => {
 		prevAutoFlush = process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH;
 		prevDebounce = process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS;
+		prevWorkerMaxEvents = process.env.CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS;
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-raw-event-sweeper-test-"));
 		dbPath = join(tmpDir, "test.sqlite");
 		const db = connect(dbPath);
@@ -36,6 +38,8 @@ describe("RawEventSweeper auto flush", () => {
 		else process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = prevAutoFlush;
 		if (prevDebounce == null) delete process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS;
 		else process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = prevDebounce;
+		if (prevWorkerMaxEvents == null) delete process.env.CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS;
+		else process.env.CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS = prevWorkerMaxEvents;
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -303,6 +307,75 @@ describe("RawEventSweeper auto flush", () => {
 		await sleep(100);
 
 		expect(store.rawEventFlushState("sess-auto")).toBe(1);
+	});
+
+	it("does not postpone debounced auto flush forever during continued activity", async () => {
+		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
+		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "40";
+		seedSession("sess-bounded-debounce");
+		const sweeper = new RawEventSweeper(store, ingestOpts);
+
+		sweeper.nudge("sess-bounded-debounce");
+		await sleep(20);
+		store.recordRawEvent({
+			opencodeSessionId: "sess-bounded-debounce",
+			eventId: "evt-2",
+			eventType: "assistant_message",
+			payload: { type: "assistant_message", assistant_text: "still active" },
+			tsWallMs: 300,
+		});
+		store.updateRawEventSessionMeta({
+			opencodeSessionId: "sess-bounded-debounce",
+			cwd: tmpDir,
+			project: "codemem",
+			startedAt: "2026-01-01T00:00:00Z",
+			lastSeenTsWallMs: 300,
+		});
+		sweeper.nudge("sess-bounded-debounce");
+		await sleep(70);
+
+		expect(store.rawEventFlushState("sess-bounded-debounce")).toBeGreaterThanOrEqual(1);
+	});
+
+	it("flushes active sessions in smaller batches by default", async () => {
+		process.env.CODEMEM_RAW_EVENTS_AUTO_FLUSH = "1";
+		process.env.CODEMEM_RAW_EVENTS_DEBOUNCE_MS = "0";
+		process.env.CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS = "2";
+		seedSession("sess-small-batches");
+		store.recordRawEvent({
+			opencodeSessionId: "sess-small-batches",
+			eventId: "evt-2",
+			eventType: "assistant_message",
+			payload: { type: "assistant_message", assistant_text: "a" },
+			tsWallMs: 300,
+		});
+		store.recordRawEvent({
+			opencodeSessionId: "sess-small-batches",
+			eventId: "evt-3",
+			eventType: "assistant_message",
+			payload: { type: "assistant_message", assistant_text: "b" },
+			tsWallMs: 400,
+		});
+		store.recordRawEvent({
+			opencodeSessionId: "sess-small-batches",
+			eventId: "evt-4",
+			eventType: "assistant_message",
+			payload: { type: "assistant_message", assistant_text: "c" },
+			tsWallMs: 500,
+		});
+		store.updateRawEventSessionMeta({
+			opencodeSessionId: "sess-small-batches",
+			cwd: tmpDir,
+			project: "codemem",
+			startedAt: "2026-01-01T00:00:00Z",
+			lastSeenTsWallMs: 500,
+		});
+
+		const sweeper = new RawEventSweeper(store, ingestOpts);
+		sweeper.nudge("sess-small-batches");
+		await sleep(120);
+
+		expect(store.rawEventFlushState("sess-small-batches")).toBe(1);
 	});
 
 	it("terminally completes low-signal skip_summary batches and advances the flush cursor", async () => {

--- a/packages/core/src/raw-event-sweeper.ts
+++ b/packages/core/src/raw-event-sweeper.ts
@@ -102,7 +102,7 @@ export class RawEventSweeper {
 	}
 
 	private workerMaxEvents(): number | null {
-		const parsed = envInt("CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS", 250);
+		const parsed = envInt("CODEMEM_RAW_EVENTS_WORKER_MAX_EVENTS", 100);
 		return parsed <= 0 ? null : parsed;
 	}
 
@@ -228,7 +228,7 @@ export class RawEventSweeper {
 			return;
 		}
 		const existing = this.autoFlushTimers.get(key);
-		if (existing) clearTimeout(existing);
+		if (existing) return;
 		const timer = setTimeout(() => {
 			this.autoFlushTimers.delete(key);
 			this.trackAutoFlush(this.flushNow(streamId, sourceNorm));
@@ -279,13 +279,14 @@ export class RawEventSweeper {
 			this.autoFlushTimers.delete(key);
 		}
 		try {
+			const maxEvents = this.workerMaxEvents();
 			await flushRawEvents(this.store, this.ingestOpts, {
 				opencodeSessionId,
 				source,
 				cwd: null,
 				project: null,
 				startedAt: null,
-				maxEvents: null,
+				maxEvents,
 			});
 		} catch (exc) {
 			if (exc instanceof ObserverAuthError) {


### PR DESCRIPTION
## Description

This PR fixes two product-path issues in raw-event processing. First, active-session auto-flush now uses bounded debounce behavior and respects the configured worker batch limit so hot sessions do not wait indefinitely and then flush as one oversized batch. Second, the observer prompt now includes the actual conversation transcript (with bounded truncation) instead of only a prompt stub, tool events, and the last assistant message, which materially improves long-session extraction quality.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/raw-event-sweeper.test.ts packages/core/src/raw-event-flush.test.ts`
- `pnpm vitest run packages/core/src/ingest-prompts.test.ts packages/core/src/ingest-pipeline.test.ts packages/core/src/raw-event-sweeper.test.ts packages/core/src/raw-event-flush.test.ts`
- `pnpm exec biome check packages/core/src/ingest-types.ts packages/core/src/ingest-prompts.ts packages/core/src/ingest-prompts.test.ts packages/core/src/ingest-pipeline.ts packages/core/src/raw-event-sweeper.ts packages/core/src/raw-event-sweeper.test.ts`
- `pnpm --filter @codemem/core run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced