### PR TITLE
feat: add injection-first memory policy foundations

### DIFF
--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -43,6 +43,19 @@ describe("memory command aliases", () => {
 		expect(longs).toContain("--project");
 		expect(longs).toContain("--all-projects");
 		expect(longs).toContain("--probe");
+		expect(longs).toContain("--scenario");
+		expect(longs).toContain("--inactive");
+		expect(longs).toContain("--json");
+	});
+
+	it("registers role-compare under memory with scenario options", () => {
+		const roleCompare = memoryCommand.commands.find((command) => command.name() === "role-compare");
+		expect(roleCompare).toBeDefined();
+		const longs = roleCompare?.options.map((option) => option.long) ?? [];
+		expect(longs).toContain("--project");
+		expect(longs).toContain("--all-projects");
+		expect(longs).toContain("--probe");
+		expect(longs).toContain("--scenario");
 		expect(longs).toContain("--inactive");
 		expect(longs).toContain("--json");
 	});

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -8,6 +8,8 @@
 import * as p from "@clack/prompts";
 import {
 	compareMemoryRoleReports,
+	getInjectionEvalScenarioPack,
+	getInjectionEvalScenarioPrompts,
 	getMemoryRoleReport,
 	getRawEventRelinkPlan,
 	getRawEventRelinkReport,
@@ -245,6 +247,12 @@ function createMemoryRoleReportCommand(): Command {
 			(value, prev: string[]) => [...prev, value],
 			[],
 		)
+		.option(
+			"--scenario <id>",
+			"run a named injection-first eval scenario pack (can be repeated)",
+			(value, prev: string[]) => [...prev, value],
+			[],
+		)
 		.option("--inactive", "include inactive memories");
 	addDbOption(cmd);
 	addJsonOption(cmd);
@@ -255,6 +263,7 @@ function createMemoryRoleReportCommand(): Command {
 					project?: string;
 					allProjects?: boolean;
 					probe?: string[];
+					scenario?: string[];
 					inactive?: boolean;
 				},
 		) => {
@@ -264,11 +273,21 @@ function createMemoryRoleReportCommand(): Command {
 					: opts.project?.trim() ||
 						process.env.CODEMEM_PROJECT?.trim() ||
 						resolveProject(process.cwd(), null);
+			const invalidScenario = (opts.scenario ?? []).find(
+				(id) => getInjectionEvalScenarioPack(id) == null,
+			);
+			if (invalidScenario) {
+				throw new Error(`Unknown eval scenario pack: ${invalidScenario}`);
+			}
+			const probes = [
+				...(opts.probe ?? []),
+				...getInjectionEvalScenarioPrompts(opts.scenario ?? []),
+			];
 			const result = getMemoryRoleReport(resolveDbOpt(opts), {
 				project,
 				allProjects: opts.allProjects === true,
 				includeInactive: opts.inactive === true,
-				probes: opts.probe,
+				probes,
 			});
 
 			if (opts.json) {
@@ -351,6 +370,12 @@ function createMemoryRoleCompareCommand(): Command {
 			(value, prev: string[]) => [...prev, value],
 			[],
 		)
+		.option(
+			"--scenario <id>",
+			"run a named injection-first eval scenario pack (can be repeated)",
+			(value, prev: string[]) => [...prev, value],
+			[],
+		)
 		.option("--inactive", "include inactive memories");
 	addJsonOption(cmd);
 	cmd.action(
@@ -361,6 +386,7 @@ function createMemoryRoleCompareCommand(): Command {
 				project?: string;
 				allProjects?: boolean;
 				probe?: string[];
+				scenario?: string[];
 				inactive?: boolean;
 			},
 		) => {
@@ -370,11 +396,21 @@ function createMemoryRoleCompareCommand(): Command {
 					: opts.project?.trim() ||
 						process.env.CODEMEM_PROJECT?.trim() ||
 						resolveProject(process.cwd(), null);
+			const invalidScenario = (opts.scenario ?? []).find(
+				(id) => getInjectionEvalScenarioPack(id) == null,
+			);
+			if (invalidScenario) {
+				throw new Error(`Unknown eval scenario pack: ${invalidScenario}`);
+			}
+			const probes = [
+				...(opts.probe ?? []),
+				...getInjectionEvalScenarioPrompts(opts.scenario ?? []),
+			];
 			const result = compareMemoryRoleReports(baselineDb, candidateDb, {
 				project,
 				allProjects: opts.allProjects === true,
 				includeInactive: opts.inactive === true,
-				probes: opts.probe,
+				probes,
 			});
 
 			if (opts.json) {

--- a/packages/core/src/eval-scenarios.test.ts
+++ b/packages/core/src/eval-scenarios.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+	getInjectionEvalScenarioPack,
+	getInjectionEvalScenarioPrompts,
+	INJECTION_EVAL_SCENARIO_PACKS,
+} from "./eval-scenarios.js";
+
+describe("injection eval scenarios", () => {
+	it("exposes the expected built-in scenario packs", () => {
+		expect(INJECTION_EVAL_SCENARIO_PACKS.map((pack) => pack.id)).toEqual([
+			"track3-core",
+			"track3-explicit-recap",
+		]);
+	});
+
+	it("looks up scenario packs case-insensitively", () => {
+		expect(getInjectionEvalScenarioPack("TRACK3-CORE")?.id).toBe("track3-core");
+	});
+
+	it("expands scenario prompts without duplicates", () => {
+		const prompts = getInjectionEvalScenarioPrompts(["track3-core", "track3-explicit-recap"]);
+		expect(prompts).toContain("memory retrieval issues");
+		expect(prompts).toContain("summary of oauth");
+		expect(new Set(prompts).size).toBe(prompts.length);
+	});
+});

--- a/packages/core/src/eval-scenarios.ts
+++ b/packages/core/src/eval-scenarios.ts
@@ -1,0 +1,109 @@
+export interface InjectionEvalScenario {
+	id: string;
+	title: string;
+	category: "locating" | "decision" | "outcome" | "troubleshooting" | "continuation";
+	prompt: string;
+	expectedPrimary: string[];
+	expectedAntiSignals: string[];
+}
+
+export interface InjectionEvalScenarioPack {
+	id: string;
+	title: string;
+	description: string;
+	scenarios: InjectionEvalScenario[];
+}
+
+export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
+	{
+		id: "track3-core",
+		title: "Track 3 core injection scenarios",
+		description:
+			"Core scenarios covering decision continuity, recap control, locating value, and workstream continuation.",
+		scenarios: [
+			{
+				id: "decision-recap-weighting",
+				title: "Recap weighting decision continuity",
+				category: "decision",
+				prompt: "what did we decide about recap weighting",
+				expectedPrimary: ["decision", "discovery", "durable"],
+				expectedAntiSignals: ["generic recap sludge", "wrong-thread summary"],
+			},
+			{
+				id: "topic-memory-retrieval",
+				title: "Memory retrieval topic quality",
+				category: "outcome",
+				prompt: "memory retrieval issues",
+				expectedPrimary: ["discovery", "bugfix", "decision"],
+				expectedAntiSignals: ["recap takeover", "unmapped recap"],
+			},
+			{
+				id: "sessionization-summary-emission",
+				title: "Sessionization summary emission policy",
+				category: "decision",
+				prompt: "sessionization summary emission",
+				expectedPrimary: ["decision", "durable policy memory"],
+				expectedAntiSignals: ["explicit recap bias", "summary-first sludge"],
+			},
+			{
+				id: "oauth-recurrence",
+				title: "OAuth recurrence troubleshooting continuity",
+				category: "troubleshooting",
+				prompt: "what did we decide last time about oauth",
+				expectedPrimary: ["decision", "bugfix", "troubleshooting outcome"],
+				expectedAntiSignals: ["wrong-thread latest summary", "recap-only output"],
+			},
+			{
+				id: "track3-continuation",
+				title: "Track 3 continuation context",
+				category: "continuation",
+				prompt: "what should we do next about recap policy",
+				expectedPrimary: ["decision", "next-step context", "durable workstream context"],
+				expectedAntiSignals: ["generic summary", "administrative chatter"],
+			},
+		],
+	},
+	{
+		id: "track3-explicit-recap",
+		title: "Explicit recap quality scenarios",
+		description: "Scenarios that verify recap remains useful when the user explicitly asks for it.",
+		scenarios: [
+			{
+				id: "summary-of-oauth",
+				title: "Explicit recap request for OAuth work",
+				category: "decision",
+				prompt: "summary of oauth",
+				expectedPrimary: ["session_summary", "recap"],
+				expectedAntiSignals: ["missing summary intent", "topic-only refusal"],
+			},
+			{
+				id: "catch-up-retrieval",
+				title: "Explicit catch-up request",
+				category: "continuation",
+				prompt: "catch me up on memory retrieval work",
+				expectedPrimary: ["session_summary", "recap", "orientation context"],
+				expectedAntiSignals: ["totally summary-free output"],
+			},
+		],
+	},
+];
+
+export function getInjectionEvalScenarioPack(id: string): InjectionEvalScenarioPack | null {
+	const normalized = id.trim().toLowerCase();
+	return INJECTION_EVAL_SCENARIO_PACKS.find((pack) => pack.id === normalized) ?? null;
+}
+
+export function getInjectionEvalScenarioPrompts(ids: string[]): string[] {
+	const prompts: string[] = [];
+	const seen = new Set<string>();
+	for (const id of ids) {
+		const pack = getInjectionEvalScenarioPack(id);
+		if (!pack) continue;
+		for (const scenario of pack.scenarios) {
+			if (seen.has(scenario.prompt)) continue;
+			seen.add(scenario.prompt);
+			prompts.push(scenario.prompt);
+		}
+	}
+	return prompts;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,12 @@ export {
 	hashText,
 	serializeFloat32,
 } from "./embeddings.js";
+export type { InjectionEvalScenario, InjectionEvalScenarioPack } from "./eval-scenarios.js";
+export {
+	getInjectionEvalScenarioPack,
+	getInjectionEvalScenarioPrompts,
+	INJECTION_EVAL_SCENARIO_PACKS,
+} from "./eval-scenarios.js";
 export type { ExportOptions, ExportPayload, ImportOptions, ImportResult } from "./export-import.js";
 export {
 	buildImportKey,

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -576,7 +576,7 @@ describe("ingest() integration", () => {
 			events: [
 				{
 					type: "user_prompt",
-					prompt_text: "ok",
+					prompt_text: "check retrieval noise",
 					prompt_number: 1,
 					timestamp: new Date().toISOString(),
 				},
@@ -868,6 +868,49 @@ describe("ingest() integration", () => {
 			.prepare("SELECT ended_at FROM sessions ORDER BY id DESC LIMIT 1")
 			.get() as { ended_at: string | null };
 		expect(session.ended_at).not.toBeNull();
+	});
+
+	it("does not terminally no-op a prompt-only raw-event flush before assistant context arrives", async () => {
+		const observer = {
+			observe: async () => ({
+				raw: `<summary>
+					<request>Check retrieval noise</request>
+					<completed>Reviewed the current ranking behavior</completed>
+				</summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			events: [
+				{
+					type: "user_prompt",
+					prompt_text: "ok",
+					prompt_number: 1,
+					timestamp: new Date().toISOString(),
+				},
+			],
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-prompt-only",
+				promptCount: 1,
+				toolCount: 0,
+				durationMs: 20_000,
+				flusher: "raw_events",
+			},
+		});
+
+		await expect(ingest(payload, store, { observer } as unknown as IngestOptions)).rejects.toThrow(
+			"observer produced no storable output for raw-event flush",
+		);
 	});
 
 	it("retries once when observer returns plain text instead of XML during raw-event flush", async () => {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -54,6 +54,7 @@ import { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-pa
 import type { ObserverClient } from "./observer-client.js";
 import { resolveProject } from "./project.js";
 import * as schema from "./schema.js";
+import { shouldSuppressSummaryOnlyOutput } from "./session-policy.js";
 import type { MemoryStore } from "./store.js";
 import { deriveTags } from "./tags.js";
 import { storeVectors } from "./vectors.js";
@@ -107,32 +108,6 @@ function summaryBody(summary: ParsedSummary): string {
 		.filter(([, value]) => value)
 		.map(([label, value]) => `## ${label}\n${value}`)
 		.join("\n\n");
-}
-
-function shouldSuppressSummaryOnlyMicroSession(
-	sessionContext: SessionContext,
-	observationsCount: number,
-	summaryToStore: { summary: ParsedSummary; request: string; body: string } | null,
-	latestPrompt: string | null,
-	toolEventCount: number,
-	hasAssistantMessage: boolean,
-	skipSummaryReason: string | null,
-): boolean {
-	if (!summaryToStore) return false;
-	if (observationsCount > 0) return false;
-	if (skipSummaryReason) return false;
-	const durationMs = sessionContext.durationMs ?? 0;
-	const promptCount = sessionContext.promptCount ?? 0;
-	const toolCount = sessionContext.toolCount ?? 0;
-	const hasModifiedFiles = (sessionContext.filesModified?.length ?? 0) > 0;
-	if (durationMs <= 0 || durationMs >= 60_000) return false;
-	if (promptCount > 1) return false;
-	if (toolCount > 2) return false;
-	if (hasModifiedFiles) return false;
-	if (!isTrivialRequest(latestPrompt)) return false;
-	if (toolEventCount > 0) return false;
-	if (!hasAssistantMessage) return false;
-	return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -331,6 +306,9 @@ export async function ingest(
 		}
 
 		if (!shouldProcess) {
+			if (sessionContext?.flusher === "raw_events") {
+				throw new Error("observer produced no storable output for raw-event flush");
+			}
 			endSession(store, sessionId, events.length, sessionContext);
 			return;
 		}
@@ -456,16 +434,26 @@ export async function ingest(
 		}
 
 		if (
-			shouldSuppressSummaryOnlyMicroSession(
+			shouldSuppressSummaryOnlyOutput({
 				sessionContext,
-				observationsToStore.length,
-				summaryToStore,
+				observationsCount: observationsToStore.length,
+				hasSummaryCandidate: summaryToStore != null,
 				latestPrompt,
-				toolEvents.length,
-				Boolean(lastAssistantMessage),
-				parsed.skipSummaryReason,
-			)
+				toolEventCount: toolEvents.length,
+				hasAssistantMessage: Boolean(lastAssistantMessage),
+				skipSummaryReason: parsed.skipSummaryReason,
+			})
 		) {
+			summaryToStore = null;
+		}
+
+		const promptOnlyRawEventSummary =
+			sessionContext?.flusher === "raw_events" &&
+			observationsToStore.length === 0 &&
+			summaryToStore != null &&
+			toolEvents.length === 0 &&
+			!lastAssistantMessage;
+		if (promptOnlyRawEventSummary) {
 			summaryToStore = null;
 		}
 
@@ -479,19 +467,15 @@ export async function ingest(
 				const locallySuppressedSummaryOnlyMicro =
 					parsed.observations.length === 0 &&
 					parsed.summary !== null &&
-					shouldSuppressSummaryOnlyMicroSession(
+					shouldSuppressSummaryOnlyOutput({
 						sessionContext,
-						0,
-						{
-							summary: parsed.summary,
-							request: parsed.summary.request,
-							body: summaryBody(parsed.summary),
-						},
+						observationsCount: 0,
+						hasSummaryCandidate: true,
 						latestPrompt,
-						toolEvents.length,
-						Boolean(lastAssistantMessage),
-						parsed.skipSummaryReason,
-					);
+						toolEventCount: toolEvents.length,
+						hasAssistantMessage: Boolean(lastAssistantMessage),
+						skipSummaryReason: parsed.skipSummaryReason,
+					});
 				if (pureLowSignalSkip || locallySuppressedSummaryOnlyMicro) {
 					endSession(store, sessionId, events.length, sessionContext);
 					return;

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -17,6 +17,7 @@
 import type { Database } from "./db.js";
 import { buildFilterClausesWithContext } from "./filters.js";
 import { projectBasename } from "./project.js";
+import { memoryLooksRecapLike, queryPrefersRecap } from "./recap-policy.js";
 import type { StoreHandle } from "./search.js";
 import { rerankResults, search, timeline } from "./search.js";
 import {
@@ -324,42 +325,16 @@ function recallQueryWantsTimeline(query: string): boolean {
 	return false;
 }
 
-function recallQueryPrefersSummary(query: string): boolean {
-	const lowered = query.toLowerCase();
-	for (const token of ["summarize", "recap"]) {
-		if (lowered.includes(token)) return true;
-	}
-	for (const phrase of [
-		"summary of",
-		"summary for",
-		"summary on",
-		"show summary",
-		"session summary",
-		"summarize",
-		"summarise",
-		"recap",
-		"catch me up",
-		"catch up",
-		"what happened",
-		"where were we",
-	]) {
-		if (lowered.includes(phrase)) return true;
-	}
-	if (lowered === "summary") return true;
-	if (lowered.startsWith("summary ")) return true;
-	return false;
-}
-
 function prioritizeDefaultResults(
 	results: MemoryResult[],
 	limit: number,
 	query: string,
 ): MemoryResult[] {
-	const preferSummary = recallQueryPrefersSummary(query);
+	const preferSummary = queryPrefersRecap(query);
 	const ordered = [...results];
 	ordered.sort((a, b) => {
 		if (!preferSummary) {
-			const recapDelta = Number(itemLooksRecapLike(a)) - Number(itemLooksRecapLike(b));
+			const recapDelta = Number(memoryLooksRecapLike(a)) - Number(memoryLooksRecapLike(b));
 			if (recapDelta !== 0) return recapDelta;
 			const taskLikeDelta = Number(itemLooksTaskLike(a)) - Number(itemLooksTaskLike(b));
 			if (taskLikeDelta !== 0) return taskLikeDelta;
@@ -466,7 +441,7 @@ function prioritizeRecallResults(
 		if (!preferSummary) {
 			const rankDelta = rank(a) - rank(b);
 			if (rankDelta !== 0) return rankDelta;
-			const recapDelta = Number(itemLooksRecapLike(a)) - Number(itemLooksRecapLike(b));
+			const recapDelta = Number(memoryLooksRecapLike(a)) - Number(memoryLooksRecapLike(b));
 			if (recapDelta !== 0) return recapDelta;
 		}
 		const overlapDelta = textOverlapScore(b, query) - textOverlapScore(a, query);
@@ -536,19 +511,6 @@ function parseMetadataObject(value: unknown): Record<string, unknown> {
 
 function isSummaryLike(item: Pick<MemoryResult, "kind" | "metadata">): boolean {
 	return isSummaryLikeMemory(item);
-}
-
-function itemLooksRecapLike(
-	item: Pick<MemoryResult, "kind" | "title" | "body_text" | "metadata">,
-): boolean {
-	if (isSummaryLike(item)) return true;
-	const text = `${item.title} ${item.body_text}`.toLowerCase();
-	if (text.includes("## request") && text.includes("## completed")) return true;
-	if (item.kind !== "change" && item.kind !== "feature") return false;
-	for (const marker of ["session recap", "wrap-up", "wrap up", "recap"]) {
-		if (text.includes(marker)) return true;
-	}
-	return false;
 }
 
 function findLatestSummaryLike(store: StoreHandle, filters?: MemoryFilters): MemoryResult | null {
@@ -788,7 +750,7 @@ export function buildMemoryPack(
 		}
 	} else if (recallMode) {
 		const recallQuery = context.trim().length > 0 ? context : RECALL_HINT_QUERY;
-		const preferSummary = recallQueryPrefersSummary(recallQuery);
+		const preferSummary = queryPrefersRecap(recallQuery);
 		const wantsTimeline = recallQueryWantsTimeline(recallQuery);
 		const topicalRecallQuery = [...queryContentTokens(recallQuery)].join(" ");
 		let recallResults = search(store, recallQuery, effectiveLimit, filters);
@@ -878,11 +840,11 @@ export function buildMemoryPack(
 	// Summary: prefer search match; only inject a global fallback when the user
 	// explicitly wants a summary or we're in non-recall mode.
 	const directSummaryMatches =
-		recallMode && !recallQueryPrefersSummary(context)
+		recallMode && !queryPrefersRecap(context)
 			? results.filter((item) => isNativeSessionSummaryMemory(item))
 			: results.filter(isSummaryLike);
 	let summaryItems = directSummaryMatches.slice(0, 1);
-	const allowGlobalSummaryFallback = !recallMode || recallQueryPrefersSummary(context);
+	const allowGlobalSummaryFallback = !recallMode || queryPrefersRecap(context);
 	if (summaryItems.length === 0 && allowGlobalSummaryFallback) {
 		const s = findLatestSummaryLike(store, filters);
 		if (s) {

--- a/packages/core/src/recap-policy.ts
+++ b/packages/core/src/recap-policy.ts
@@ -1,0 +1,39 @@
+import { isSummaryLikeMemory } from "./summary-memory.js";
+import type { MemoryResult } from "./types.js";
+
+export function queryPrefersRecap(query: string): boolean {
+	const lowered = query.toLowerCase();
+	for (const token of ["summarize", "summarise", "recap"]) {
+		if (lowered.includes(token)) return true;
+	}
+	for (const phrase of [
+		"summary of",
+		"summary for",
+		"summary on",
+		"show summary",
+		"session summary",
+		"catch me up",
+		"catch up",
+		"what happened",
+		"where were we",
+	]) {
+		if (lowered.includes(phrase)) return true;
+	}
+	if (lowered === "summary") return true;
+	if (lowered.startsWith("summary ")) return true;
+	return false;
+}
+
+export function memoryLooksRecapLike(
+	item: Pick<MemoryResult, "kind" | "title" | "body_text" | "metadata">,
+): boolean {
+	if (isSummaryLikeMemory(item)) return true;
+	const metadata = item.metadata ?? {};
+	if (metadata.source === "observer_summary") return true;
+	if (typeof metadata.request === "string" && typeof metadata.completed === "string") return true;
+	const text = `${item.title} ${item.body_text}`.toLowerCase();
+	for (const marker of ["session recap", "wrap-up", "wrap up", "recap", "## request"]) {
+		if (text.includes(marker)) return true;
+	}
+	return false;
+}

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -18,8 +18,9 @@ import {
 } from "./filters.js";
 import { parsePositiveMemoryId } from "./integers.js";
 import { projectMatchesFilter } from "./project.js";
+import { memoryLooksRecapLike, queryPrefersRecap } from "./recap-policy.js";
 import * as schema from "./schema.js";
-import { canonicalMemoryKind, isSummaryLikeMemory } from "./summary-memory.js";
+import { canonicalMemoryKind } from "./summary-memory.js";
 import type {
 	ExplainError,
 	ExplainItem,
@@ -269,17 +270,6 @@ function personalBias(
 	return store.memoryOwnedBySelf(item) ? PERSONAL_FIRST_BONUS : 0.0;
 }
 
-function searchQueryPrefersSummary(query: string): boolean {
-	const lowered = query.toLowerCase();
-	for (const token of ["summarize", "summarise", "recap"]) {
-		if (lowered.includes(token)) return true;
-	}
-	for (const phrase of ["session summary", "catch me up", "catch up", "what happened"]) {
-		if (lowered.includes(phrase)) return true;
-	}
-	return false;
-}
-
 function searchQueryLooksTaskLike(query: string): boolean {
 	const lowered = query.toLowerCase();
 	for (const phrase of [
@@ -297,24 +287,8 @@ function searchQueryLooksTaskLike(query: string): boolean {
 	return false;
 }
 
-function itemIsSummaryLike(item: MemoryResult): boolean {
-	return isSummaryLikeMemory(item);
-}
-
-function itemLooksRecapLikeForSearch(item: MemoryResult): boolean {
-	if (itemIsSummaryLike(item)) return true;
-	const metadata = item.metadata ?? {};
-	if (metadata.source === "observer_summary") return true;
-	if (typeof metadata.request === "string" && typeof metadata.completed === "string") return true;
-	const text = `${item.title} ${item.body_text}`.toLowerCase();
-	for (const marker of ["session recap", "wrap-up", "wrap up", "recap", "## request"]) {
-		if (text.includes(marker)) return true;
-	}
-	return false;
-}
-
 function recapPenaltyForSearch(item: MemoryResult, preferSummary: boolean): number {
-	if (preferSummary || !itemLooksRecapLikeForSearch(item)) return 0.0;
+	if (preferSummary || !memoryLooksRecapLike(item)) return 0.0;
 	const metadata = item.metadata ?? {};
 	if (metadata.source === "observer_summary") return NON_SUMMARY_OBSERVER_RECAP_PENALTY;
 	if (typeof metadata.request === "string" && typeof metadata.completed === "string") {
@@ -462,7 +436,7 @@ export function rerankResults(
 ): MemoryResult[] {
 	const referenceNow = new Date();
 	const workingSetPaths = normalizeWorkingSetPaths(filters?.working_set_paths);
-	const preferSummary = searchQueryPrefersSummary(query);
+	const preferSummary = queryPrefersRecap(query);
 	const taskLikeQuery = searchQueryLooksTaskLike(query);
 
 	const scored = results.map((item) => ({

--- a/packages/core/src/session-policy.test.ts
+++ b/packages/core/src/session-policy.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+	classifySessionForInjection,
+	type SessionClassificationInput,
+	type SummarySuppressionInput,
+	shouldSuppressSummaryOnlyOutput,
+} from "./session-policy.js";
+
+function input(overrides: Partial<SessionClassificationInput> = {}): SessionClassificationInput {
+	return {
+		sessionContext: {
+			promptCount: 1,
+			toolCount: 0,
+			durationMs: 20_000,
+			filesModified: [],
+			filesRead: [],
+		},
+		latestPrompt: "ok",
+		toolEventCount: 0,
+		hasAssistantMessage: true,
+		observationsCount: 0,
+		hasSummaryCandidate: true,
+		...overrides,
+	};
+}
+
+function suppressionInput(
+	overrides: Partial<SummarySuppressionInput> = {},
+): SummarySuppressionInput {
+	return {
+		...input(),
+		skipSummaryReason: null,
+		...overrides,
+	};
+}
+
+describe("session policy classification", () => {
+	it("classifies trivial acknowledgement turns", () => {
+		const result = classifySessionForInjection(
+			input({ hasSummaryCandidate: false, hasAssistantMessage: false }),
+		);
+		expect(result).toBe("trivial_turn");
+	});
+
+	it("classifies low-value micro sessions", () => {
+		const result = classifySessionForInjection(input({ latestPrompt: "check logs" }));
+		expect(result).toBe("micro_low_value");
+	});
+
+	it("classifies high-signal micro sessions when typed observations exist", () => {
+		const result = classifySessionForInjection(input({ observationsCount: 1 }));
+		expect(result).toBe("micro_high_signal");
+	});
+
+	it("classifies working sessions in the middle band", () => {
+		const result = classifySessionForInjection(
+			input({
+				sessionContext: {
+					promptCount: 2,
+					toolCount: 3,
+					durationMs: 240_000,
+					filesModified: [],
+					filesRead: ["src/foo.ts"],
+				},
+				latestPrompt: "investigate auth",
+				toolEventCount: 3,
+				hasAssistantMessage: true,
+				observationsCount: 1,
+			}),
+		);
+		expect(result).toBe("working");
+	});
+
+	it("classifies durable sessions from strong duration/activity signals", () => {
+		const result = classifySessionForInjection(
+			input({
+				sessionContext: {
+					promptCount: 6,
+					toolCount: 12,
+					durationMs: 900_000,
+					filesModified: ["src/index.ts"],
+					filesRead: ["src/index.ts"],
+				},
+				latestPrompt: "fix recap extraction",
+				toolEventCount: 12,
+				observationsCount: 2,
+			}),
+		);
+		expect(result).toBe("durable");
+	});
+});
+
+describe("summary-only suppression policy", () => {
+	it("suppresses trivial-turn summary-only output", () => {
+		expect(
+			shouldSuppressSummaryOnlyOutput(
+				suppressionInput({ hasSummaryCandidate: true, hasAssistantMessage: false }),
+			),
+		).toBe(false);
+		expect(
+			shouldSuppressSummaryOnlyOutput(
+				suppressionInput({ hasSummaryCandidate: true, hasAssistantMessage: true }),
+			),
+		).toBe(true);
+	});
+
+	it("suppresses low-value micro-session summary-only output", () => {
+		expect(shouldSuppressSummaryOnlyOutput(suppressionInput())).toBe(true);
+	});
+
+	it("keeps high-signal micro-session summary candidates when typed observations exist", () => {
+		expect(
+			shouldSuppressSummaryOnlyOutput(
+				suppressionInput({ observationsCount: 1, hasSummaryCandidate: true }),
+			),
+		).toBe(false);
+	});
+
+	it("keeps longer working-session summary candidates", () => {
+		expect(
+			shouldSuppressSummaryOnlyOutput(
+				suppressionInput({
+					sessionContext: {
+						promptCount: 2,
+						toolCount: 3,
+						durationMs: 240_000,
+						filesModified: [],
+						filesRead: ["src/foo.ts"],
+					},
+					latestPrompt: "investigate auth",
+					toolEventCount: 3,
+					observationsCount: 0,
+				}),
+			),
+		).toBe(false);
+	});
+
+	it("never suppresses when skip_summary reason is already present", () => {
+		expect(
+			shouldSuppressSummaryOnlyOutput(suppressionInput({ skipSummaryReason: "low-signal" })),
+		).toBe(false);
+	});
+});

--- a/packages/core/src/session-policy.ts
+++ b/packages/core/src/session-policy.ts
@@ -1,0 +1,86 @@
+import { isTrivialRequest } from "./ingest-transcript.js";
+import type { SessionContext } from "./ingest-types.js";
+
+export type SessionClass =
+	| "trivial_turn"
+	| "micro_low_value"
+	| "micro_high_signal"
+	| "working"
+	| "durable";
+
+export interface SessionClassificationInput {
+	sessionContext: SessionContext;
+	latestPrompt: string | null;
+	toolEventCount: number;
+	hasAssistantMessage: boolean;
+	observationsCount: number;
+	hasSummaryCandidate: boolean;
+}
+
+export function classifySessionForInjection(input: SessionClassificationInput): SessionClass {
+	const durationMs = input.sessionContext.durationMs ?? 0;
+	const promptCount = input.sessionContext.promptCount ?? 0;
+	const derivedToolCount = input.toolEventCount;
+	const sessionToolCount = input.sessionContext.toolCount ?? derivedToolCount;
+	const toolCount = Math.max(derivedToolCount, sessionToolCount);
+	const hasModifiedFiles = (input.sessionContext.filesModified?.length ?? 0) > 0;
+	const hasReadFiles = (input.sessionContext.filesRead?.length ?? 0) > 0;
+	const trivialPrompt = isTrivialRequest(input.latestPrompt);
+	const hasTypedObservations = input.observationsCount > 0;
+	const hasStrongSignals =
+		hasTypedObservations ||
+		hasModifiedFiles ||
+		toolCount >= 3 ||
+		hasReadFiles ||
+		(toolCount > 0 && !trivialPrompt);
+
+	if (
+		trivialPrompt &&
+		durationMs > 0 &&
+		durationMs < 60_000 &&
+		promptCount <= 1 &&
+		toolCount === 0 &&
+		!hasModifiedFiles &&
+		!hasTypedObservations
+	) {
+		return "trivial_turn";
+	}
+
+	if (durationMs > 0 && durationMs < 60_000) {
+		if (hasStrongSignals) {
+			return hasTypedObservations ||
+				hasModifiedFiles ||
+				(toolCount > 0 && !trivialPrompt) ||
+				hasReadFiles
+				? "micro_high_signal"
+				: "micro_low_value";
+		}
+		return "micro_low_value";
+	}
+
+	if (
+		durationMs >= 600_000 ||
+		hasModifiedFiles ||
+		toolCount >= 10 ||
+		input.observationsCount >= 3
+	) {
+		return "durable";
+	}
+
+	return "working";
+}
+
+export interface SummarySuppressionInput extends SessionClassificationInput {
+	skipSummaryReason: string | null;
+}
+
+export function shouldSuppressSummaryOnlyOutput(input: SummarySuppressionInput): boolean {
+	if (!input.hasSummaryCandidate) return false;
+	if (input.observationsCount > 0) return false;
+	if (input.skipSummaryReason) return false;
+	if (!input.hasAssistantMessage) return false;
+	const sessionClass = classifySessionForInjection(input);
+	if (sessionClass === "trivial_turn") return true;
+	if (sessionClass === "micro_low_value") return true;
+	return false;
+}


### PR DESCRIPTION
## Description

This PR introduces the first Track 3 code foundations for injection-first memory policy. It adds shared helpers for session classification, recap policy, and named evaluation scenarios, and wires those helpers into ingest and retrieval paths so later Track 3 work has a real implementation seam instead of scattered heuristics.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/session-policy.test.ts packages/core/src/ingest-pipeline.test.ts packages/core/src/pack.test.ts packages/core/src/pack.eval.test.ts packages/core/src/search.test.ts`
- `pnpm --filter @codemem/core run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced