### PR TITLE
docs: capture injection-first policy and eval notes

### DIFF
--- a/docs/plans/2026-04-07-injection-first-eval-scenarios.md
+++ b/docs/plans/2026-04-07-injection-first-eval-scenarios.md
@@ -1,0 +1,216 @@
+# Injection-First Eval Scenarios for Track 3
+
+**Status:** Draft
+**Date:** 2026-04-07
+**Parent policy:** `docs/plans/2026-04-07-track-3-injection-first-memory-policy.md`
+**Depends on:**
+- `docs/plans/2026-04-07-session-boundary-matrix.md`
+- `docs/plans/2026-04-07-recap-policy.md`
+- `docs/plans/2026-04-07-memory-quality-model.md`
+**Primary bead:** `codemem-24q2`
+
+## Purpose
+
+Define evaluation scenarios that measure whether codemem improves **automatic
+injection quality** by reducing rediscovery, scouting, and repeated work.
+
+These evals should not treat explicit recap prompts as the main product path.
+They should instead focus on whether codemem helps the agent continue work with
+less manual context excavation.
+
+## Core Evaluation Question
+
+For a given prompt or work continuation moment:
+
+> Did codemem inject enough of the right prior context that the agent could avoid
+> repeated scouting, repeated decision archaeology, and repeated troubleshooting?
+
+## Eval Classes
+
+### 1. Locating / code scouting scenarios
+
+Measure whether codemem helps the agent find relevant implementation context
+faster.
+
+Example prompts:
+
+- `what decisions affected index.ts?`
+- `what do we know about auth?`
+- `where did we already touch recap weighting?`
+- `what work touched the viewer health tab?`
+
+What success looks like:
+
+- injected context points to relevant files/modules/workstreams
+- less manual file/session scouting is needed
+- durable locating memories outrank broad recap blobs
+
+### 2. Decision continuity scenarios
+
+Measure whether codemem helps the agent understand past decisions well enough to
+make better new ones.
+
+Example prompts:
+
+- `what did we decide about recap weighting?`
+- `what was the rationale for session summary suppression?`
+- `what tradeoff drove the summary handling changes?`
+
+What success looks like:
+
+- prior decisions are surfaced with rationale/tradeoffs
+- recap does not drown out decision memories
+- the agent can use prior reasoning to inform the next step
+
+### 3. Outcome continuity scenarios
+
+Measure whether codemem helps the agent reuse what worked or failed.
+
+Example prompts:
+
+- `what changed for memory retrieval issues?`
+- `what was the fix for raw-event relinking?`
+- `what happened after the recap fallback fix?`
+
+What success looks like:
+
+- shipped fixes and meaningful outcomes surface cleanly
+- low-value recap does not dominate top injected context
+
+### 4. Troubleshooting recurrence scenarios
+
+Measure whether codemem reduces repeated investigation when a similar issue
+returns.
+
+Example prompts:
+
+- `what did we decide last time about oauth?`
+- `what was the root cause of the micro-session regression?`
+- `how did we debug the raw-event flush issue before?`
+
+What success looks like:
+
+- prior root cause and fix path appear quickly
+- irrelevant recap or wrong-thread summary material stays out of the way
+
+### 5. Workstream continuation scenarios
+
+Measure whether codemem helps continue ongoing work without manual session
+archaeology.
+
+Example prompts:
+
+- `continue the Track 3 work`
+- `what should we do next about recap policy?`
+- `what remains on sessionization policy?`
+
+What success looks like:
+
+- codemem injects next-step-relevant context
+- recap supports orientation without becoming the whole payload
+
+## Scenario Format
+
+Each scenario should specify:
+
+1. **Prompt or injection moment**
+2. **Expected primary context types**
+3. **Expected anti-signals** (what should *not* dominate)
+4. **Measured burden**
+5. **Pass criteria**
+
+### Example schema
+
+| Field | Description |
+|---|---|
+| scenario_id | stable identifier |
+| class | locating / decision / outcome / troubleshooting / continuation |
+| prompt | query or injection context |
+| expected_primary | kinds/roles that should dominate |
+| expected_anti_signals | recap noise, wrong-thread summary, unmapped sludge |
+| pass_criteria | concrete acceptance conditions |
+
+## Metrics
+
+### Burden metrics
+
+- recap share in top injected context
+- unmapped share in top injected context
+- recap-unmapped share in top injected context
+
+### Utility metrics
+
+- proportion of injected items with locating value
+- proportion of injected items with decision value
+- proportion of injected items with outcome or troubleshooting value
+
+### Continuity metrics
+
+- how often the right workstream/session lineage is represented
+- whether follow-up prompts can continue without manual scouting
+
+## Existing Candidate Scenarios
+
+The current codebase already contains useful fixture/eval prompts that should be
+formalized under this bead:
+
+- `memory retrieval issues`
+- `sessionization summary emission`
+- `what did we decide last time about oauth`
+- `what should we do next about auth`
+- `summary of oauth`
+
+These should be treated as seed scenarios, not the entire evaluation corpus.
+
+## Rich Session Under-Extraction Case
+
+The captured case in
+`docs/plans/2026-04-07-rich-session-under-extraction-eval-case.md`
+should become a first-class Track 3 eval scenario.
+
+### Why it matters
+
+- rich session input
+- structurally successful flush
+- semantically weak memory output
+
+This scenario tests whether the system can extract multiple durable memories and
+a representative summary from a long, high-signal session.
+
+### What to measure
+
+- number of durable typed observations produced
+- summary coverage of major subthreads
+- whether key decision/outcome/location context survives
+- whether output would reduce future scouting and rediscovery effort
+
+## Pass/Fail Direction
+
+### Better looks like
+
+- lower recap burden for non-summary automatic injection
+- stable or improved recap usefulness for explicit recap prompts
+- more durable observations from rich sessions
+- higher locating/decision/outcome value in top injected context
+
+### Worse looks like
+
+- more recap sludge in non-summary injection
+- under-extraction of rich sessions
+- summary dominance without locating or decision value
+- the agent still needing manual session/file scouting to continue work
+
+## First Implementation Slice
+
+1. codify scenario metadata in a small fixture format
+2. convert current useful prompts into named scenarios
+3. add the rich-session under-extraction case as a tracked non-fixture scenario
+4. wire burden + utility metrics into comparison reporting over time
+
+## Open Questions
+
+- Should the first eval harness remain lightweight and prompt-based, or should it
+  simulate transform-hook injection more directly?
+- Which scenarios should be synthetic fixtures versus captured live-session cases?
+- How should we score locating value and decision value without collapsing back
+  into vague human vibes?

--- a/docs/plans/2026-04-07-memory-quality-model.md
+++ b/docs/plans/2026-04-07-memory-quality-model.md
@@ -1,0 +1,285 @@
+# Memory Quality Model Around Rediscovery Reduction
+
+**Status:** Draft
+**Date:** 2026-04-07
+**Parent policy:** `docs/plans/2026-04-07-track-3-injection-first-memory-policy.md`
+**Depends on:**
+- `docs/plans/2026-04-07-session-boundary-matrix.md`
+- `docs/plans/2026-04-07-recap-policy.md`
+**Primary bead:** `codemem-gwez`
+
+## Purpose
+
+Define what makes a codemem memory worth storing and prioritizing by grounding
+quality in a single question:
+
+> Does this memory reduce rediscovery effort for future work?
+
+This is broader than troubleshooting alone. High-quality memory should reduce the
+effort required to:
+
+- locate relevant code, files, modules, or workstreams
+- understand previous decisions and tradeoffs
+- reuse prior outcomes and fixes
+- avoid repeated investigation or context scouting
+- make better new decisions with less archaeology
+
+## Core Principle
+
+Memory quality is not the same thing as textual relevance or session richness.
+
+A memory is high-quality when it increases future leverage. A memory is low-quality
+when it adds words without materially helping the next session orient, decide,
+locate, or act.
+
+## Quality Dimensions
+
+Evaluate a memory along five primary axes.
+
+### 1. Locating value
+
+Does the memory help find relevant code or implementation context faster?
+
+Examples:
+
+- names relevant files or modules
+- identifies the workstream, component, or domain area
+- points to an implementation pattern or repeated touchpoint
+
+### 2. Decision value
+
+Does the memory preserve a decision and its rationale well enough to improve a
+future decision?
+
+Examples:
+
+- explains why a decision was made
+- records constraints or tradeoffs
+- captures what was rejected and why
+
+### 3. Outcome value
+
+Does the memory preserve what changed or what worked/failed?
+
+Examples:
+
+- shipped bugfix or behavior change
+- discovery that altered understanding of the system
+- successful implementation or operational outcome
+
+### 4. Troubleshooting value
+
+Does the memory reduce repeated investigation?
+
+Examples:
+
+- root cause
+- failed hypotheses
+- gotchas or edge cases
+- prior diagnosis/fix path
+
+### 5. Future-decision value
+
+Does the memory improve future planning or next-step choices?
+
+Examples:
+
+- clarifies what remains unresolved
+- records blockers or follow-up logic
+- helps distinguish recap from durable next-step context
+
+## Memory Classes
+
+### A. Durable
+
+#### Definition
+
+Memories that should usually survive and rank well because they preserve high
+future leverage.
+
+Typical examples:
+
+- `decision`
+- `bugfix`
+- `discovery`
+- durable `feature`
+- meaningful `refactor`
+
+#### Expected value
+
+- high locating value, decision value, or outcome value
+- often also high troubleshooting or future-decision value
+
+#### Retrieval posture
+
+- prefer in automatic injection when relevant
+- should usually outrank recap-like material for non-summary topical work
+
+### B. Recap
+
+#### Definition
+
+Memories whose primary role is orientation or summarization rather than durable
+knowledge preservation.
+
+Typical examples:
+
+- `session_summary`
+- summary-like legacy rows
+- observer-summary-like wrap-ups
+
+#### Expected value
+
+- useful for orientation
+- lower trust than durable memory for default injection
+- high value in explicit recap mode, conditional value in automatic injection
+
+#### Retrieval posture
+
+- allowed but conservative in automatic injection
+- preferred in explicit recap mode
+
+### C. Ephemeral
+
+#### Definition
+
+Memories that may be useful briefly but usually do not justify durable priority.
+
+Typical examples:
+
+- tiny acknowledgements
+- narrow process-status notes
+- weak one-off observations without future leverage
+
+#### Expected value
+
+- low or situational
+- often poor locating/decision/outcome value
+
+#### Retrieval posture
+
+- demote heavily for automatic injection
+- often suppress at write time when possible
+
+### D. General / cross-project
+
+#### Definition
+
+Memories that capture durable patterns, how-things-work explanations, or broadly
+reusable knowledge beyond one narrow session.
+
+Typical examples:
+
+- explanation of flush semantics
+- relationship between observer schema and typed memory output
+- stable architectural patterns
+
+#### Expected value
+
+- often high future-decision and troubleshooting value
+- good candidates for broader reuse if they remain specific enough to be useful
+
+#### Retrieval posture
+
+- useful when topical scope matches
+- should not override concrete project-local durable evidence when that exists
+
+## What Good Memory Looks Like
+
+High-quality memory usually has one or more of these traits:
+
+- names a specific subsystem, file, concept, or decision
+- explains cause and effect
+- preserves what changed and why
+- reduces the need to re-open old sessions or scout the repo manually
+- helps the next agent/session choose a good next step quickly
+
+## What Bad Memory Looks Like
+
+Low-quality memory usually has one or more of these traits:
+
+- broad process narration without durable outcomes
+- generic recap that does not help locate, decide, or act
+- little or no future leverage beyond the exact moment it was created
+- redundant restatement of nearby recap memory
+- weak connection to code, decisions, or consequences
+
+## Quality Matrix
+
+| Memory class | Locating value | Decision value | Outcome value | Troubleshooting value | Future-decision value | Automatic injection default |
+|---|---|---|---|---|---|---|
+| Durable | high or medium | high or medium | high | medium/high | medium/high | prefer when relevant |
+| Recap | low/medium | low/medium | medium | low/medium | medium | support-only unless explicit recap |
+| Ephemeral | low | low | low | low | low | suppress or heavily demote |
+| General / cross-project | medium | medium/high | medium | medium/high | high | allow when scope matches |
+
+## Relationship to Current Types
+
+Current type/kind is not sufficient by itself to determine quality.
+
+Examples:
+
+- a `change` can be low-value recap sludge or a meaningful configuration outcome
+- a `session_summary` can be useful orientation or noisy wrap-up
+- a short-session `discovery` might still be highly durable
+
+Track 3 should therefore treat quality as:
+
+- **kind-informed**
+- but not **kind-determined**
+
+## Practical Policy Implications
+
+### Rule 1 — do not optimize for memory count
+
+More memories is not better. Better memories are better.
+
+### Rule 2 — optimize for future leverage
+
+If a memory would not materially help a later session find, understand, decide,
+or reuse, it should usually be demoted or suppressed.
+
+### Rule 3 — typed durable output should beat broad recap
+
+When the system can represent a concrete outcome, decision, or discovery, that is
+usually preferable to one more recap-like summary blob.
+
+### Rule 4 — preserve rationale, not just results
+
+Decision/value quality is much higher when the memory captures:
+
+- why the decision happened
+- what tradeoff was being protected
+- what consequence followed
+
+### Rule 5 — locating value matters
+
+Track 3 must explicitly value memories that help reduce code/context scouting,
+not just ones that sound conceptually important.
+
+## Evaluation Questions
+
+To evaluate quality, ask:
+
+- Did this memory help find the right code or workstream faster?
+- Did it explain a prior decision well enough to improve a new one?
+- Did it preserve what worked or failed?
+- Did it reduce repeated investigation?
+- Did it make future action easier, not just future reading longer?
+
+## First Implementation Slice
+
+The first implementation slice for this model should be modest:
+
+1. annotate policy docs and eval scenarios with these quality dimensions
+2. use the quality model to refine summary-only gating and recap demotion
+3. bias extraction toward multiple durable observations when a session contains
+   multiple distinct high-value outcomes
+4. use this model to score/inspect the rich-session under-extraction case
+
+## Open Questions
+
+- Should quality dimensions be persisted as metadata or remain implicit policy rules?
+- How much of the quality model should influence write-time suppression versus
+  retrieval-time ranking?
+- When should general/cross-project memory outrank project-local recap?

--- a/docs/plans/2026-04-07-recap-policy.md
+++ b/docs/plans/2026-04-07-recap-policy.md
@@ -1,0 +1,232 @@
+# Recap Policy for Automatic Injection vs Explicit Recap
+
+**Status:** Draft
+**Date:** 2026-04-07
+**Parent policy:** `docs/plans/2026-04-07-track-3-injection-first-memory-policy.md`
+**Depends on:** `docs/plans/2026-04-07-session-boundary-matrix.md`
+**Primary bead:** `codemem-l92r`
+
+## Purpose
+
+Define how recap-like material should behave differently in:
+
+- **automatic transform-hook injection**
+- **explicit recap / summary requests**
+
+The goal is not to eliminate recap. The goal is to stop recap from drowning out
+durable, reusable context during default injection while still supporting
+intentional summary-oriented workflows.
+
+## Core Principle
+
+Recap may be acceptable for `summary of X`, `catch me up`, or explicit review
+questions while still being too noisy for default automatic injection.
+
+In other words:
+
+> recap is a useful mode, not a universal default
+
+## Definitions
+
+### Recap-like memory
+
+Any memory whose primary purpose is summarization or progress narration rather
+than preserving a durable, reusable outcome.
+
+Examples:
+
+- `session_summary`
+- observer-generated `change` rows with summary metadata
+- observer-summary-like rows with `request/completed/learned` recap structure
+- broad wrap-up memories that restate process without adding much future utility
+
+### Durable memory
+
+A memory that helps future sessions reduce rediscovery effort by preserving:
+
+- decision rationale
+- implementation outcomes
+- troubleshooting discoveries
+- bugfixes
+- reusable explanations of how things work
+
+## Modes
+
+### 1. Automatic injection mode
+
+This is the default transform-hook path. It should be stricter.
+
+#### Policy
+
+- recap is **allowed but conservative**
+- durable memories should beat recap by default
+- recap should be demoted when it is:
+  - unmapped
+  - from a low-value micro-session
+  - observer-summary-like and generic
+  - not clearly tied to the current workstream
+
+#### Default rule
+
+Automatic injection should use recap only when recap materially improves
+orientation and does not crowd out better durable context.
+
+### 2. Explicit recap mode
+
+This is activated by explicit user intent such as:
+
+- `summary of ...`
+- `recap`
+- `catch me up`
+- `what happened`
+
+#### Policy
+
+- recap can be preferred
+- legacy summary-like rows may be tolerated
+- broader summarization context is acceptable
+- summary-first output is expected and useful
+
+#### Default rule
+
+When the user explicitly requests recap, recap material is not a bug. It is the
+desired response mode.
+
+## Recap Decision Matrix
+
+| Context | Recap allowed? | Recap preferred? | Recap demoted? | Notes |
+|---|---:|---:|---:|---|
+| Automatic injection, trivial turn noise | no | no | n/a | suppress entirely |
+| Automatic injection, low-value micro-session | rarely | no | yes (strong) | usually suppress or heavily demote |
+| Automatic injection, high-signal short session | maybe | no | yes (mild) | typed output preferred |
+| Automatic injection, working session | yes | no | conditional | recap can support orientation but not dominate |
+| Automatic injection, durable work session | yes | sometimes | conditional | durable typed output still primary |
+| Explicit summary / recap request | yes | yes | no | recap-first is intended |
+
+## Practical Rules
+
+### Rule 1 — recap should not dominate default injection
+
+In automatic injection mode:
+
+- recap should not be the highest-ranked class unless there is no better durable
+  candidate
+- broad recap blobs should lose to decisions, bugfixes, discoveries, and durable
+  explanations when those are relevant
+
+### Rule 2 — unmapped recap is especially risky
+
+Unmapped recap often behaves like loose process narration rather than durable
+knowledge. In automatic injection:
+
+- strongly demote unmapped recap
+- use it only when no better mapped or durable context exists
+
+### Rule 3 — low-value micro-session recap should usually disappear
+
+If recap comes from the low-value micro-session class defined in the session
+boundary matrix:
+
+- prefer suppression at write time
+- if it survives, demote it aggressively at retrieval/injection time
+
+### Rule 4 — explicit recap mode should be broad but honest
+
+When the user asks for recap, the system may prefer:
+
+- summary artifacts
+- summary-like legacy rows
+- workstream recap context
+
+But it should still avoid irrelevant or wrong-thread summary injection.
+
+### Rule 5 — recap can support orientation, not replace durable memory
+
+Even in automatic injection mode, recap is useful when it helps answer:
+
+- where this work left off
+- what thread is active
+- what broader effort the current prompt belongs to
+
+But recap should usually be supporting context, not the whole meal.
+
+## Indicators of Bad Recap
+
+Recap should be treated as low-value in automatic injection when it has one or
+more of these traits:
+
+- generic process narration ("investigated / completed / next steps" with little durable content)
+- weak linkage to current files, concepts, or workstream
+- obvious observer-summary boilerplate
+- no decision value, no locating value, and no outcome value
+- merely restates a broad session without reducing scouting effort
+
+## Indicators of Good Recap
+
+Recap is valuable when it improves orientation by clearly summarizing:
+
+- current workstream state
+- active blockers
+- major thread transitions
+- what was just completed and what logically follows
+
+Good recap should help automatic injection answer:
+
+- what is this workstream about?
+- what should happen next?
+- what larger thread does this prompt belong to?
+
+## Evaluation Metrics
+
+Track recap policy using automatic-injection metrics, not just explicit summary
+prompt quality.
+
+### Suggested metrics
+
+- top-5 recap share for non-summary topical queries
+- top-5 unmapped recap share for non-summary topical queries
+- top-5 recap share for explicit recap queries
+- percentage of automatic injection packs where recap outranks more durable
+  relevant memories
+- percentage of micro-session recap memories that survive into injected context
+
+### Desired direction
+
+- non-summary recap share: **down**
+- unmapped recap share: **down hard**
+- explicit recap quality: **flat or up**
+- wrong-thread recap intrusion: **down**
+
+## Relationship to Current Code
+
+The current implementation already contains early recap-control heuristics in
+`search.ts` and `pack.ts`, including:
+
+- recap detection
+- observer-summary penalties
+- explicit recap intent detection
+- demotion of recap-heavy fallbacks
+
+This policy exists to unify those heuristics into a principled rule set rather
+than letting recap logic accrete as scattered special cases.
+
+## First Implementation Slice
+
+The first implementation slice should:
+
+1. classify recap by session class from `fbpg`
+2. formalize automatic-vs-explicit recap mode in one shared policy helper
+3. apply stronger demotion to recap that is both:
+   - low-value micro-session derived
+   - and unmapped or observer-summary-like
+4. add eval scenarios that show recap helps explicit summary requests without
+   retaking over default injection
+
+## Open Questions
+
+- Should recap demotion be encoded numerically in one shared policy helper or as
+  separate rank rules by mode?
+- Should recap from durable work sessions still be limited to a maximum share of
+  injected context?
+- Should recap become its own first-class artifact distinct from durable summary
+  and legacy summary-like rows?

--- a/docs/plans/2026-04-07-rich-session-under-extraction-eval-case.md
+++ b/docs/plans/2026-04-07-rich-session-under-extraction-eval-case.md
@@ -1,0 +1,163 @@
+# Rich Session Under-Extraction Eval Case
+
+**Status:** Draft evaluation artifact
+**Date:** 2026-04-07
+**Related bead:** `codemem-31ha`
+**Related Track 3 eval bead:** `codemem-24q2`
+
+## Why this case matters
+
+This case is a strong candidate regression / evaluation scenario for Track 3.
+
+It demonstrates a session where the raw-event pipeline appears to work
+structurally:
+
+- the session is correctly linked
+- the relevant flush batch completed successfully
+- there is no persisted observer/provider/auth failure on that batch
+
+But semantically the output is weak:
+
+- only one narrow `discovery` memory and one narrow `session_summary`
+- despite a rich, high-signal event tail that covered multiple substantive
+  planning and product-quality threads
+
+This suggests that the problem is not "garbage raw events" but likely:
+
+- memory-generation prompt / extraction policy weakness
+- long-batch shaping weakness
+- or summary-vs-observation persistence policy that is too lossy
+
+## Session identity
+
+- **stream / opencode session id:** `ses_29b51abf5ffefPNFnFBKCHdiF2`
+- **local session id:** `166405`
+
+## Session-level context
+
+Session row summary at inspection time:
+
+- `started_at`: `2026-04-06T21:23:59.631Z`
+- `ended_at`: `2026-04-07T06:13:45.667Z`
+- `prompt_count`: `24`
+- `tool_count`: `84`
+- `duration_ms`: `1392062`
+
+This is not a tiny or trivial session. It is a long, high-signal working session.
+
+## Completed flush batch under evaluation
+
+From `raw_event_flush_batches`:
+
+- **batch id:** `18503`
+- **range:** `1204–1356`
+- **status:** `completed`
+- **attempt_count:** `1`
+- **error_message:** `null`
+
+The batch completed cleanly, which makes the resulting semantic under-extraction
+more significant.
+
+## Pending tail observed during investigation
+
+After the completed batch, the live session continued accumulating events.
+
+At inspection time:
+
+- `last_received_event_seq`: `1398`
+- `last_flushed_event_seq`: `1356`
+- pending gap: `37` events
+
+The pending tail was not low-value noise. Event-type counts for the tail after
+`1356` were:
+
+- `tool.execute.after`: `20`
+- `assistant_message`: `12`
+- `user_prompt`: `11`
+
+## Observed persisted outputs from the completed batch
+
+Latest active memories on the session after the completed flush were:
+
+1. **Memory `13597`**
+   - kind: `session_summary`
+   - title: `Investigate a regression causing many under-one-minute sessions and unmapped summaries; determine whether the issue originated in the Python-to-TypeScript migration or later raw-event/sessionization changes.`
+
+2. **Memory `13596`**
+   - kind: `discovery`
+   - title: `Micro-session regression timeline narrowed to raw-event/sessionization changes, not TS migration alone`
+
+These two memories are coherent, but they are too narrow relative to the volume
+and richness of the batch.
+
+## Why the raw events appear high-signal
+
+Inspection of the completed range `1204–1356` shows discussion and work around:
+
+- starting and narrowing the `codemem-qd7h` regression investigation
+- deciding the root cause had already been identified/fixed and closing `qd7h`
+- release readiness / preparing `0.23.0`
+- reframing Track 3 around injection-first policy
+- graph / progressive disclosure future direction
+- release-vs-quality tradeoff discussion
+- evaluation methodology and whether under-extraction should block release
+
+This is the opposite of a junk batch.
+
+## Expected output (roughly)
+
+Even if only one final session summary were emitted, a stronger output would
+likely have included multiple durable typed observations, such as:
+
+- release-readiness / urgency reasoning for `0.23.0`
+- Track 3 reframing to injection-first / reduce rediscovery and scouting effort
+- graph / progressive disclosure future-direction insight
+- closure of the `qd7h` root-cause investigation
+
+The session summary also should likely have been broader and more representative
+of the major shifts in the batch, rather than focusing mostly on the regression
+timeline thread.
+
+## Preliminary diagnosis
+
+This case currently points more strongly to semantic under-extraction than to raw
+event quality issues.
+
+Most plausible explanations:
+
+1. **Observer prompt / schema is too weak for long, multi-thread session tails**
+2. **Long-batch shaping causes the model to over-focus on a narrow recent thread**
+3. **Summary-vs-observation persistence policy is too lossy**
+4. **Filtering/suppression may be removing useful typed output**
+
+Least plausible explanation:
+
+- the raw events were low-value or mostly junk
+
+## How to use this case
+
+This should be used as a Track 3 evaluation artifact to answer questions like:
+
+- Does codemem reduce rediscovery and scouting effort on long, rich sessions?
+- Does a structurally successful flush yield enough durable observations?
+- Does summary output adequately reflect the breadth of meaningful work in the
+  batch?
+- Does the system over-compress long sessions into a single recap plus one typed
+  memory?
+
+## Suggested future eval harness expectations
+
+For this scenario class, track:
+
+- number of durable typed observations emitted from a rich batch
+- summary breadth / coverage across major subthreads
+- whether key decision/outcome/location context survives the flush
+- whether resulting memory set would materially reduce future scouting and
+  rediscovery effort
+
+## Notes
+
+This case should not be interpreted as a repeat of the old structural
+session-linking failure. The batch completed and the session linkage appears
+correct. The concern here is quality of extracted memory, not basic ingestion
+correctness.

--- a/docs/plans/2026-04-07-session-boundary-matrix.md
+++ b/docs/plans/2026-04-07-session-boundary-matrix.md
@@ -1,0 +1,266 @@
+# Injection-First Session Boundary Matrix
+
+**Status:** Draft
+**Date:** 2026-04-07
+**Parent policy:** `docs/plans/2026-04-07-track-3-injection-first-memory-policy.md`
+**Primary bead:** `codemem-fbpg`
+
+## Purpose
+
+Turn Track 3 sessionization policy into a concrete, implementation-oriented
+matrix that determines:
+
+- what class of session codemem is observing
+- whether that session should emit no summary, delayed recap, or durable summary
+- how automatic injection should treat memories from that session class
+
+The objective is not to maximize summary coverage. The objective is to reduce
+rediscovery, scouting, and repeated work during automatic injection.
+
+## Available Signals Today
+
+The current raw-event / ingest path already derives these useful signals:
+
+- `promptCount`
+- `toolCount`
+- `durationMs`
+- `filesModified`
+- `filesRead`
+- `firstPrompt`
+- whether the latest prompt is trivial (`yes`, `ok`, `approved`, etc.)
+- whether any typed observations were produced
+- whether only a summary would be stored
+
+This matrix is intentionally grounded in those existing signals so the first
+implementation slice can be small and testable.
+
+## Session Classes
+
+### 1. Trivial turn / acknowledgement
+
+#### Typical signals
+
+- trivial prompt or acknowledgement
+- `promptCount <= 1`
+- `toolCount == 0`
+- no file modifications
+- duration very short
+- no typed observations
+
+#### Default storage policy
+
+- no durable summary
+- no recap
+- session may exist structurally, but should not emit reusable memory by default
+
+#### Automatic injection treatment
+
+- never a preferred source
+- effectively ignored unless linked to a later richer session artifact
+
+#### Why
+
+These events do not reduce future scouting or decision rediscovery. They are
+almost pure prompt noise.
+
+---
+
+### 2. Micro-session (low-value)
+
+#### Typical signals
+
+- duration `< 1 minute`
+- `promptCount <= 1`
+- `toolCount <= 2`
+- no file modifications
+- no typed observations
+- maybe one assistant response and a summary-like observer output
+
+#### Default storage policy
+
+- suppress summary-only output by default
+- keep no durable summary unless explicit recap request or unusually strong evidence
+
+#### Automatic injection treatment
+
+- recap from this class should be strongly demoted or absent
+- typed outputs from this class should only survive if they contain unusually high-value learning
+
+#### Why
+
+This is the class most likely to flood the system with recap sludge while adding
+little scouting or decision value.
+
+---
+
+### 3. Micro-session (high-signal)
+
+#### Typical signals
+
+- duration still short, but one or more of:
+  - typed observations were produced
+  - meaningful file modification occurred
+  - strong troubleshooting / decision / discovery content is present
+  - explicit summary request
+
+#### Default storage policy
+
+- allow typed observations
+- summary optional, but should be concise and justified by strong evidence
+
+#### Automatic injection treatment
+
+- typed observations may be eligible
+- summary/recap should still be conservative unless explicitly requested
+
+#### Why
+
+Short sessions are not inherently useless. Some concentrated fixes or decisions
+really do happen quickly. The key is whether the output reduces future effort.
+
+---
+
+### 4. Working session
+
+#### Typical signals
+
+- duration roughly `1–10 minutes`
+- multiple prompts and/or multiple tool events
+- some work movement, maybe file reads/modifications
+- likely multiple substeps in one coherent thread
+
+#### Default storage policy
+
+- allow typed observations when present
+- allow summary only if it adds orientation or outcome value
+- prefer observations over broad recap
+
+#### Automatic injection treatment
+
+- durable observations are good candidates
+- summaries are secondary support artifacts, not the main payload
+
+#### Why
+
+This is the main middle category. It should produce reusable memory when it
+contains real progress, but it should not default to summary-first behavior.
+
+---
+
+### 5. Durable work session
+
+#### Typical signals
+
+- duration `> 10 minutes` or clearly substantial multi-step work
+- meaningful tool + prompt depth
+- multiple decisions, discoveries, fixes, or implementation steps
+- file modifications and coherent thread continuity
+
+#### Default storage policy
+
+- allow multiple typed observations
+- allow durable `session_summary`
+- summary should reflect the primary thread and outcomes, not generic process narration
+
+#### Automatic injection treatment
+
+- strong candidate source for future decisions, code scouting, and troubleshooting reuse
+- summaries may be included, but typed durable observations should remain primary
+
+#### Why
+
+This is the intended summary-producing class.
+
+---
+
+## Decision Matrix
+
+| Session class | Summary-only output | Typed observations | Default summary behavior | Automatic injection treatment |
+|---|---:|---:|---|---|
+| Trivial turn / acknowledgement | suppress | suppress | none | ignore |
+| Micro-session (low-value) | suppress | usually suppress | none or explicit-only | heavily demote |
+| Micro-session (high-signal) | allow only with strong evidence | allow | optional, narrow | prefer typed output over recap |
+| Working session | usually avoid summary-only | allow | conditional | durable typed output preferred |
+| Durable work session | allow | allow multiple | durable summary allowed | good source for injection |
+
+## Concrete Rule Proposals
+
+### Rule A — summary-only output requires stronger evidence than today
+
+Do not store summary-only output unless at least one of the following is true:
+
+- explicit summary / recap request
+- non-trivial duration and activity
+- meaningful file modification
+- strong completed/learned/investigated content with future-use value
+
+### Rule B — typed observations are the main reusable artifact
+
+For working and durable sessions, extraction should favor multiple durable typed
+observations over one broad recap whenever the session contains multiple distinct
+high-signal outcomes.
+
+### Rule C — automatic injection should trust session class
+
+Session class should influence injection defaults:
+
+- trivial + low-value micro sessions should rarely inject directly
+- working sessions should prefer typed durable outputs
+- durable sessions may contribute summaries, but only as support for the main
+  observations
+
+### Rule D — explicit recap mode is different
+
+Some recap content is acceptable for `summary of X` or `catch me up`, even when it
+would be too noisy for default automatic injection.
+
+## Edge Cases
+
+### Fast but meaningful fix
+
+A short session that contains a real bugfix or decision should not be discarded
+just because it is short. This is why the matrix distinguishes low-value and
+high-signal micro-sessions.
+
+### Long but low-value session
+
+Duration alone is not enough. A long session with mostly administrative chatter
+should not automatically earn a durable summary if it still does not reduce
+future effort.
+
+### Multi-thread session
+
+If a session covers multiple substantive threads, extraction should not collapse
+everything into one generic summary. The model should produce multiple typed
+observations when justified.
+
+## Known pressure from current dogfooding
+
+The captured rich-session under-extraction case (`codemem-31ha`) is a good
+example of why this matrix matters. A long, high-signal session produced too few
+durable memories and an overly narrow summary. That failure suggests:
+
+- current extraction is too lossy for rich sessions
+- typed observations are under-produced relative to session richness
+- summary-only or summary-dominant behavior still needs stronger controls
+
+## First Implementation Slice
+
+Keep the first slice small and grounded in current signals:
+
+1. Formalize the session classes in code-level helper logic
+2. Strengthen summary-only gating using the matrix above
+3. Add explicit tests for:
+   - trivial turn suppression
+   - low-value micro-session suppression
+   - high-signal short-session preservation
+   - working session with typed observations
+   - durable session producing multiple typed outputs + summary
+4. Feed the rich-session eval case into `codemem-24q2`
+
+## Open Questions
+
+- Should delayed recap exist as a separate artifact from durable `session_summary`?
+- How should the system merge conceptually continuous work across local session rows?
+- Which parts of session class should be persisted as metadata for later injection/ranking?
+- How much should session class affect retrieval weighting directly versus write-time filtering?

--- a/docs/plans/2026-04-07-track-3-injection-first-memory-policy.md
+++ b/docs/plans/2026-04-07-track-3-injection-first-memory-policy.md
@@ -1,0 +1,289 @@
+# Track 3: Injection-First Memory Policy
+
+**Status:** Draft
+**Date:** 2026-04-07
+
+## Context
+
+The merged 0.23.0 candidate stack fixed a severe sessionization and retrieval quality
+problem:
+
+- raw-event session reconciliation now repairs detached fragmented sessions
+- retrieval no longer blindly ORs low-signal filler words into candidate queries
+- recap-heavy fallbacks are demoted for non-summary retrieval
+- legacy summary handling is more consistent on the read path
+
+Those changes improve the system substantially, but they do not yet answer the
+deeper policy question:
+
+**What kinds of memories and summaries should automatic context injection prefer,
+emit, suppress, or demote so codemem materially reduces rediscovery effort during
+normal work?**
+
+Track 3 is the policy/model follow-up to the merged retrieval and reconciliation
+fixes.
+
+## Core Objective
+
+Codemem should reduce **rediscovery, scouting, and rework effort** during automatic
+transform-hook injection by surfacing the prior decisions, outcomes,
+implementation context, and troubleshooting knowledge most useful for the current
+work.
+
+Success is not defined primarily by explicit prompt-time Q&A. Explicit prompting
+is useful for evaluation and debugging, but the product succeeds or fails on
+whether automatic injection improves normal work without requiring the user to ask
+for perfect recap prompts.
+
+## Product Success Criterion
+
+Automatic injection should help the agent more quickly:
+
+- locate relevant prior code, files, modules, or workstreams
+- understand previous decisions and the tradeoffs behind them
+- reuse prior outcomes, successful fixes, and debugging paths
+- avoid repeated context scouting and manual session archaeology
+- make better next decisions with less rediscovery cost
+
+Codemem should allow the agent to say, implicitly:
+
+- "I already know where to look."
+- "I already know what we decided and why."
+- "I already know what worked last time."
+- "I do not need to re-scout half the repo or revisit five old sessions first."
+
+## Failure Modes
+
+Track 3 should explicitly defend against these common failures:
+
+- recap blobs dominate injected context instead of durable evidence
+- wrong-session or wrong-thread summaries are injected because they look similar
+- micro-session turn noise produces low-value summary artifacts
+- the agent still has to manually scout files/sessions to find the real answer
+- prior decisions are discoverable only as isolated snapshots without rationale,
+  causality, or outcomes
+
+## Scope
+
+Track 3 consists of three related policy/model workstreams:
+
+1. **Sessionization and summary emission policy** (`codemem-1y5q`)
+2. **Recap emission and weighting policy** (`codemem-izlc`)
+3. **Memory quality model and taxonomy evolution** (`codemem-euue`)
+
+These are separate concerns, but they form one coherent track and should be
+developed in order.
+
+## Injection-First Design Principles
+
+### 1. Automatic injection is the primary product path
+
+The most important question is not "can codemem answer a direct prompt?" It is:
+
+**Does codemem inject the right context during normal work without flooding the
+prompt with recap sludge or wrong-session noise?**
+
+### 2. Reduce rediscovery effort, not just retrieve relevant text
+
+High-value memory is not merely text that matches a query. High-value memory
+reduces effort in one or more of these ways:
+
+- it helps find relevant code or implementation patterns faster
+- it helps understand previous decisions and tradeoffs
+- it helps reuse past outcomes and troubleshooting paths
+- it helps orient the agent within the correct workstream/session lineage
+
+### 3. Progressive disclosure beats giant memory dumps
+
+Longer-term, codemem should favor a model where injection starts with a compact
+index and expands only when deeper context is needed. Candidate index data may
+include:
+
+- title
+- type/kind
+- timestamp
+- session/workstream hint
+- compact rationale or outcome tags
+- file/module or concept hints
+
+Then the system can selectively fetch full observations, neighbors, related
+decisions, or causal context.
+
+### 4. Causality matters more than isolated snapshots
+
+Useful memory should preserve more than a static fact. The system should favor
+memories that help answer:
+
+- what led to this decision?
+- what changed because of it?
+- what happened afterward?
+- what work is downstream of this result?
+
+### 5. Explicit recap requests and automatic injection are different modes
+
+Some recap material is acceptable when the user explicitly asks for summary, but
+too noisy for default automatic injection. Track 3 should keep those modes
+distinct.
+
+## Track 3 Workstream Definitions
+
+### A. `codemem-1y5q` — Sessionization and Summary Emission Policy
+
+#### Key Question
+
+What should count as a meaningful work session, and when should a summary artifact
+exist at all?
+
+#### Desired Output
+
+A policy matrix that distinguishes:
+
+- micro sessions
+- working sessions
+- durable work sessions
+
+For each class, define:
+
+- whether to emit no summary, delayed recap, or durable `session_summary`
+- what signals count as meaningful work
+- how automatic injection should treat resulting artifacts
+
+#### Why This Comes First
+
+If session boundaries are mushy, recap policy and quality policy rest on sand.
+
+### B. `codemem-izlc` — Recap Emission and Weighting Policy
+
+#### Key Question
+
+How should recap behave differently in automatic injection versus explicit recap
+requests?
+
+#### Desired Output
+
+Rules for:
+
+- when recap is allowed or suppressed at write time
+- how recap is weighted/demoted at retrieval time
+- how unmapped recap should behave
+- how micro-session recap should be treated
+- which metrics count as recap regression
+
+#### Key Principle
+
+Recap may be valid for `summary of X` while still being too dangerous for default
+automatic injection.
+
+### C. `codemem-euue` — Memory Quality Model and Taxonomy Evolution
+
+#### Key Question
+
+What kinds of memories deserve to exist and be prioritized because they reduce
+rediscovery effort?
+
+#### Desired Output
+
+A model for memory categories such as:
+
+- durable
+- recap
+- ephemeral
+- general/cross-project
+
+Evaluate them by:
+
+- locating value (does this reduce code/context scouting?)
+- decision value (does this preserve rationale/tradeoffs?)
+- outcome value (does this preserve what worked/failed?)
+- troubleshooting value (does this reduce repeated investigation?)
+- future-decision value (does this help make better next choices?)
+
+## Recommended Sequence
+
+1. **`codemem-qd7h`** — investigate micro-session regression timeline and root
+   causes so policy is evidence-based
+2. **`codemem-1y5q`** — define session boundary and summary emission matrix
+3. **`codemem-izlc`** — define recap policy and weighting for injection vs explicit
+   recap
+4. **`codemem-euue`** — formalize the broader memory quality/taxonomy model using
+   outputs from the first two
+
+## Track 3 Task Graph
+
+Current concrete child tasks created from this track:
+
+- `codemem-fbpg` — Define injection-first session boundary matrix
+- `codemem-l92r` — Define recap policy for automatic injection vs explicit recap
+- `codemem-gwez` — Define memory quality criteria around rediscovery reduction
+- `codemem-24q2` — Add injection-first eval scenarios for Track 3
+
+### Intended dependency flow
+
+- `codemem-qd7h` informs `codemem-1y5q`
+- `codemem-fbpg` is the first concrete output of `codemem-1y5q`
+- `codemem-l92r` depends on the session matrix from `codemem-fbpg`
+- `codemem-gwez` depends on the practical distinctions established in
+  `codemem-fbpg` and `codemem-l92r`
+- `codemem-24q2` should reflect and validate all of the above
+
+## Evaluation Strategy
+
+Track 3 should be evaluated primarily through automatic-injection usefulness,
+not just explicit recall prompts.
+
+### Questions to Answer
+
+- Does codemem reduce code/context scouting for the next prompt?
+- Does it surface prior decisions and tradeoffs quickly enough to help new
+  decisions?
+- Does it reduce repeated debugging and investigation effort when similar issues
+  recur?
+- Does it avoid flooding the prompt with low-value recap or wrong-session noise?
+
+### Suggested evaluation classes
+
+- locating relevant code or modules
+- understanding prior decisions and rationale
+- reusing prior outcomes and fixes
+- troubleshooting recurrence or adjacent failures
+- continuing an existing workstream without manual session archaeology
+
+### Suggested metrics
+
+- recap share in top injected context
+- unmapped recap share in top injected context
+- summary-only micro-session rate
+- percentage of injected items with clear locating or decision value
+- relative reduction in manual scouting for repeated or adjacent tasks
+
+## Release Guidance
+
+Track 3 is important, but it is not automatically a release blocker. The merged
+0.23.0 candidate stack already fixes severe sessionization and retrieval issues.
+
+Use Track 3 to shape post-release policy work unless dogfooding reveals a fresh
+severe regression in automatic injection quality.
+
+## Non-Goals
+
+Track 3 does **not** yet require:
+
+- a graph-native source of truth
+- a full schema rewrite
+- destructive retroactive cleanup of existing databases
+- replacing current retrieval with a full knowledge graph implementation
+
+Those are possible future exploration areas, but the current objective is to make
+automatic injection materially better at reducing rediscovery effort.
+
+## Future Directions
+
+Once Track 3 policy stabilizes, codemem may benefit from:
+
+- progressive disclosure retrieval
+- graph-derived relationship context
+- causal/neighbor expansion around observations
+- file-path and concept-linked decision exploration
+
+That work is explicitly separate from this policy draft and is currently tracked
+as future exploration (`codemem-am33`).


### PR DESCRIPTION
## Description

This PR adds the Track 3 design and evaluation documentation for injection-first memory policy. It captures the session boundary matrix, recap policy, memory quality model, scenario framework, and the rich-session under-extraction eval case so the implementation stack above it has a clear design spine.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- Reviewed against the implemented Track 3 seams and current evaluation artifacts

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced