### PR TITLE
feat: persist and report session policy signals

### DIFF
--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -319,6 +319,14 @@ function createMemoryRoleReportCommand(): Command {
 			for (const [bucket, count] of Object.entries(result.project_quality)) {
 				p.log.message(`  ${bucket.padEnd(12)} ${String(count)}`);
 			}
+			p.log.info("Session classes:");
+			for (const [bucket, count] of Object.entries(result.session_class_buckets)) {
+				p.log.message(`  ${bucket.padEnd(20)} ${String(count)}`);
+			}
+			p.log.info("Summary dispositions:");
+			for (const [bucket, count] of Object.entries(result.summary_disposition_buckets)) {
+				p.log.message(`  ${bucket.padEnd(20)} ${String(count)}`);
+			}
 			if (result.probe_results.length > 0) {
 				p.log.info("Probe results:");
 				for (const probe of result.probe_results) {
@@ -345,7 +353,7 @@ function createMemoryRoleReportCommand(): Command {
 					}
 					for (const item of probe.items.slice(0, 5)) {
 						p.log.message(
-							`    [${item.id}] (${item.kind}/${item.role}/${item.mapping}) ${item.title} — ${item.role_reason}`,
+							`    [${item.id}] (${item.kind}/${item.role}/${item.mapping}/${item.session_class}/${item.summary_disposition}) ${item.title} — ${item.role_reason}`,
 						);
 					}
 				}
@@ -433,6 +441,14 @@ function createMemoryRoleCompareCommand(): Command {
 			p.log.info("Role deltas:");
 			for (const [role, count] of Object.entries(result.delta.counts_by_role)) {
 				p.log.message(`  ${role.padEnd(10)} ${String(count)}`);
+			}
+			p.log.info("Session class deltas:");
+			for (const [bucket, count] of Object.entries(result.delta.session_class_buckets)) {
+				p.log.message(`  ${bucket.padEnd(20)} ${String(count)}`);
+			}
+			p.log.info("Summary disposition deltas:");
+			for (const [bucket, count] of Object.entries(result.delta.summary_disposition_buckets)) {
+				p.log.message(`  ${bucket.padEnd(20)} ${String(count)}`);
 			}
 			if (result.probe_comparisons.length > 0) {
 				p.log.info("Probe comparisons:");

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -598,6 +598,13 @@ describe("ingest() integration", () => {
 		await ingest(payload, store, { observer: summaryOnlyObserver } as unknown as IngestOptions);
 
 		expect(store.recent(10)).toHaveLength(0);
+		const sessionMeta = store.db
+			.prepare("SELECT metadata_json FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as { metadata_json: string };
+		expect(JSON.parse(sessionMeta.metadata_json).post).toEqual({
+			session_class: "micro_low_value",
+			summary_disposition: "suppressed",
+		});
 	});
 
 	it("keeps summary-only output for longer sessions", async () => {
@@ -650,10 +657,18 @@ describe("ingest() integration", () => {
 
 		const summaryMemory = store.db
 			.prepare(
-				"SELECT kind FROM memory_items WHERE json_extract(metadata_json, '$.is_summary') = 1 ORDER BY id DESC LIMIT 1",
+				"SELECT kind, metadata_json FROM memory_items WHERE json_extract(metadata_json, '$.is_summary') = 1 ORDER BY id DESC LIMIT 1",
 			)
-			.get() as { kind: string };
+			.get() as { kind: string; metadata_json: string };
 		expect(summaryMemory.kind).toBe("session_summary");
+		expect(JSON.parse(summaryMemory.metadata_json).session_class).toBe("working");
+		const sessionMeta = store.db
+			.prepare("SELECT metadata_json FROM sessions ORDER BY id DESC LIMIT 1")
+			.get() as { metadata_json: string };
+		expect(JSON.parse(sessionMeta.metadata_json).post).toEqual({
+			session_class: "working",
+			summary_disposition: "stored",
+		});
 	});
 
 	it("falls back to cwd basename when payload project is missing", async () => {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -54,7 +54,7 @@ import { hasMeaningfulObservation, parseObserverResponse } from "./ingest-xml-pa
 import type { ObserverClient } from "./observer-client.js";
 import { resolveProject } from "./project.js";
 import * as schema from "./schema.js";
-import { shouldSuppressSummaryOnlyOutput } from "./session-policy.js";
+import { classifySessionForInjection, shouldSuppressSummaryOnlyOutput } from "./session-policy.js";
 import type { MemoryStore } from "./store.js";
 import { deriveTags } from "./tags.js";
 import { storeVectors } from "./vectors.js";
@@ -433,6 +433,16 @@ export async function ingest(
 			}
 		}
 
+		const sessionClass = classifySessionForInjection({
+			sessionContext,
+			latestPrompt,
+			toolEventCount: toolEvents.length,
+			hasAssistantMessage: Boolean(lastAssistantMessage),
+			observationsCount: observationsToStore.length,
+			hasSummaryCandidate: summaryToStore != null,
+		});
+		let summaryDisposition: "stored" | "suppressed" | "none" = summaryToStore ? "stored" : "none";
+
 		if (
 			shouldSuppressSummaryOnlyOutput({
 				sessionContext,
@@ -445,6 +455,7 @@ export async function ingest(
 			})
 		) {
 			summaryToStore = null;
+			summaryDisposition = "suppressed";
 		}
 
 		const promptOnlyRawEventSummary =
@@ -477,7 +488,10 @@ export async function ingest(
 						skipSummaryReason: parsed.skipSummaryReason,
 					});
 				if (pureLowSignalSkip || locallySuppressedSummaryOnlyMicro) {
-					endSession(store, sessionId, events.length, sessionContext);
+					endSession(store, sessionId, events.length, sessionContext, {
+						session_class: sessionClass,
+						summary_disposition: locallySuppressedSummaryOnlyMicro ? "suppressed" : "none",
+					});
 					return;
 				}
 				throw new Error("observer produced no storable output for raw-event flush");
@@ -549,6 +563,7 @@ export async function ingest(
 						next_steps: summary.nextSteps,
 						notes: summary.notes,
 						prompt_number: promptNumber,
+						session_class: sessionClass,
 						files_read: summary.filesRead,
 						files_modified: summary.filesModified,
 						source: "observer_summary",
@@ -575,6 +590,8 @@ export async function ingest(
 						project,
 						observation_count: observationsToStore.length,
 						has_summary: summaryToStore != null,
+						session_class: sessionClass,
+						summary_disposition: summaryDisposition,
 						provider: response.provider,
 						model: response.model,
 						session_usage_tokens: usageTokenTotal,
@@ -594,7 +611,10 @@ export async function ingest(
 		// ------------------------------------------------------------------
 		// End session
 		// ------------------------------------------------------------------
-		endSession(store, sessionId, events.length, sessionContext);
+		endSession(store, sessionId, events.length, sessionContext, {
+			session_class: sessionClass,
+			summary_disposition: summaryDisposition,
+		});
 	} catch (err) {
 		// End session even on error
 		try {
@@ -615,11 +635,12 @@ function endSession(
 	sessionId: number,
 	eventCount: number,
 	sessionContext: SessionContext,
+	extraPost: Record<string, unknown> = {},
 ): void {
 	// Use store.endSession() which merges metadata instead of replacing it,
 	// preserving fields set during session creation (startedAt, session_context, etc.)
 	store.endSession(sessionId, {
-		post: {},
+		post: extraPost,
 		source: "plugin",
 		event_count: eventCount,
 		session_context: sessionContext,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -399,9 +399,37 @@ describe("maintenance", () => {
 				mapping: "mapped",
 				role: "durable",
 				role_reason: "durable_kind",
+				session_class: "unknown",
+				summary_disposition: "unknown",
 				title: "OAuth callback fix",
 			}),
 		);
+		expect(report.session_class_buckets).toEqual({ unknown: 1 });
+		expect(report.summary_disposition_buckets).toEqual({ unknown: 1 });
+	});
+
+	it("reports persisted session policy buckets from session metadata", () => {
+		const dbPath = createDbPath("memory-role-session-policy-buckets");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:00:20Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"post":{"session_class":"micro_low_value","summary_disposition":"suppressed"}}'),
+				  (2, '2026-03-01T10:30:00Z', '2026-03-01T10:40:00Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"post":{"session_class":"durable","summary_disposition":"stored"}}');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+				) VALUES
+				  (1, 1, 'decision', 'Micro decision', 'body', 1, '2026-03-01T10:00:20Z', '2026-03-01T10:00:20Z', '{}', 'k1'),
+				  (2, 2, 'session_summary', 'Durable summary', 'body', 1, '2026-03-01T10:40:00Z', '2026-03-01T10:40:00Z', '{}', 'k2');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const report = getMemoryRoleReport(dbPath, { project: "codemem" });
+		expect(report.session_class_buckets).toEqual({ micro_low_value: 1, durable: 1 });
+		expect(report.summary_disposition_buckets).toEqual({ suppressed: 1, stored: 1 });
 	});
 
 	it("compares memory role reports across two database snapshots", () => {
@@ -460,6 +488,8 @@ describe("maintenance", () => {
 		expect(comparison.delta.totals.sessions).toBe(-1);
 		expect(comparison.delta.counts_by_mapping).toEqual({ mapped: 1, unmapped: -2 });
 		expect(comparison.delta.summary_mapping).toEqual({ mapped: 0, unmapped: -1 });
+		expect(comparison.delta.session_class_buckets).toEqual({ unknown: -1 });
+		expect(comparison.delta.summary_disposition_buckets).toEqual({ unknown: -1 });
 		expect(comparison.probe_comparisons).toHaveLength(1);
 		expect(comparison.probe_comparisons[0]).toEqual(
 			expect.objectContaining({

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -54,6 +54,8 @@ export interface MemoryRoleProbeItem {
 	role: MemoryRole;
 	role_reason: string;
 	mapping: "mapped" | "unmapped";
+	session_class: string;
+	summary_disposition: string;
 }
 
 export interface MemoryRoleProbeResult {
@@ -113,6 +115,8 @@ export interface MemoryRoleReport {
 		garbage_like: number;
 	};
 	session_duration_buckets: Record<string, number>;
+	session_class_buckets: Record<string, number>;
+	summary_disposition_buckets: Record<string, number>;
 	role_examples: Partial<
 		Record<MemoryRole, Array<{ id: number; kind: string; title: string; role_reason: string }>>
 	>;
@@ -145,6 +149,8 @@ export interface MemoryRoleReportComparison {
 		counts_by_mapping: Record<"mapped" | "unmapped", number>;
 		summary_mapping: Record<"mapped" | "unmapped", number>;
 		session_duration_buckets: Record<string, number>;
+		session_class_buckets: Record<string, number>;
+		summary_disposition_buckets: Record<string, number>;
 	};
 	probe_comparisons: MemoryRoleProbeComparison[];
 }
@@ -748,6 +754,7 @@ export function getMemoryRoleReport(
 					m.active,
 					m.metadata_json,
 					s.project,
+					s.metadata_json AS session_metadata_json,
 					CASE
 						WHEN s.ended_at IS NOT NULL THEN (julianday(s.ended_at) - julianday(s.started_at)) * 24 * 60
 						ELSE NULL
@@ -772,6 +779,7 @@ export function getMemoryRoleReport(
 			active: number;
 			metadata_json: string | null;
 			project: string | null;
+			session_metadata_json: string | null;
 			session_minutes: number | null;
 			has_opencode_mapping: number;
 		}>;
@@ -793,6 +801,8 @@ export function getMemoryRoleReport(
 			"120m+": 0,
 			open: 0,
 		};
+		const sessionClassBuckets: Record<string, number> = {};
+		const summaryDispositionBuckets: Record<string, number> = {};
 		const roleExamples: MemoryRoleReport["role_examples"] = {};
 		let sessionSummaryCount = 0;
 		let legacySummaryCount = 0;
@@ -837,6 +847,19 @@ export function getMemoryRoleReport(
 
 			if (!seenSessionBuckets.has(row.session_id)) {
 				seenSessionBuckets.add(row.session_id);
+				const sessionMeta = safeParseMetadata(row.session_metadata_json);
+				const post =
+					sessionMeta.post &&
+					typeof sessionMeta.post === "object" &&
+					!Array.isArray(sessionMeta.post)
+						? (sessionMeta.post as Record<string, unknown>)
+						: {};
+				const sessionClass = String(post.session_class ?? "unknown").trim() || "unknown";
+				const summaryDisposition =
+					String(post.summary_disposition ?? "unknown").trim() || "unknown";
+				sessionClassBuckets[sessionClass] = (sessionClassBuckets[sessionClass] ?? 0) + 1;
+				summaryDispositionBuckets[summaryDisposition] =
+					(summaryDispositionBuckets[summaryDisposition] ?? 0) + 1;
 				const minutes = row.session_minutes;
 				const bucket: keyof typeof sessionDurationBuckets =
 					minutes == null
@@ -888,6 +911,13 @@ export function getMemoryRoleReport(
 						const mapping: "mapped" | "unmapped" = source?.has_opencode_mapping
 							? "mapped"
 							: "unmapped";
+						const sessionMeta = safeParseMetadata(source?.session_metadata_json ?? null);
+						const post =
+							sessionMeta.post &&
+							typeof sessionMeta.post === "object" &&
+							!Array.isArray(sessionMeta.post)
+								? (sessionMeta.post as Record<string, unknown>)
+								: {};
 						return {
 							id: item.id,
 							stable_key: stableProbeItemKey({
@@ -901,6 +931,8 @@ export function getMemoryRoleReport(
 							role: inferred.role,
 							role_reason: inferred.reason,
 							mapping,
+							session_class: String(post.session_class ?? "unknown"),
+							summary_disposition: String(post.summary_disposition ?? "unknown"),
 						};
 					});
 					const topRoleCounts: Record<MemoryRole, number> = {
@@ -1024,6 +1056,8 @@ export function getMemoryRoleReport(
 			},
 			project_quality: projectQuality,
 			session_duration_buckets: sessionDurationBuckets,
+			session_class_buckets: sessionClassBuckets,
+			summary_disposition_buckets: summaryDispositionBuckets,
 			role_examples: roleExamples,
 			probe_results: probeResults,
 		};
@@ -1055,6 +1089,14 @@ export function compareMemoryRoleReports(
 			session_duration_buckets: subtractKeyedCounts(
 				baseline.session_duration_buckets,
 				candidate.session_duration_buckets,
+			),
+			session_class_buckets: subtractKeyedCounts(
+				baseline.session_class_buckets,
+				candidate.session_class_buckets,
+			),
+			summary_disposition_buckets: subtractKeyedCounts(
+				baseline.summary_disposition_buckets,
+				candidate.summary_disposition_buckets,
 			),
 		},
 		probe_comparisons: compareProbeResults(baseline.probe_results, candidate.probe_results),

--- a/packages/core/src/recap-policy.ts
+++ b/packages/core/src/recap-policy.ts
@@ -1,6 +1,9 @@
 import { isSummaryLikeMemory } from "./summary-memory.js";
 import type { MemoryResult } from "./types.js";
 
+export const MICRO_LOW_VALUE_RECAP_PENALTY = 2.0;
+export const DURABLE_RECAP_PENALTY = 0.5;
+
 export function queryPrefersRecap(query: string): boolean {
 	const lowered = query.toLowerCase();
 	for (const token of ["summarize", "summarise", "recap"]) {
@@ -36,4 +39,18 @@ export function memoryLooksRecapLike(
 		if (text.includes(marker)) return true;
 	}
 	return false;
+}
+
+export function recapPenaltyMultiplier(
+	item: Pick<MemoryResult, "metadata">,
+	preferRecap: boolean,
+): number {
+	if (preferRecap) return 0;
+	const metadata = item.metadata ?? {};
+	const sessionClass = String(metadata.session_class ?? "")
+		.trim()
+		.toLowerCase();
+	if (sessionClass === "micro_low_value") return MICRO_LOW_VALUE_RECAP_PENALTY;
+	if (sessionClass === "durable") return DURABLE_RECAP_PENALTY;
+	return 1;
 }

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -278,6 +278,63 @@ describe("rerankResults", () => {
 		expect(reranked[0]?.id).toBe(2);
 	});
 
+	it("penalizes low-value micro-session recap more aggressively than durable recap", () => {
+		const results = [
+			makeResult({
+				id: 1,
+				score: 4.0,
+				kind: "session_summary",
+				title: "Micro recap",
+				metadata: { session_class: "micro_low_value" },
+			}),
+			makeResult({
+				id: 2,
+				score: 4.0,
+				kind: "session_summary",
+				title: "Durable recap",
+				metadata: { session_class: "durable" },
+			}),
+			makeResult({
+				id: 3,
+				score: 3.4,
+				kind: "decision",
+				title: "Useful decision",
+			}),
+		];
+		const reranked = rerankResults(mockStore, results, 10, undefined, "memory retrieval issues");
+		expect(reranked.map((item) => item.id)).toEqual([3, 2, 1]);
+	});
+
+	it("applies session-class recap multiplier to observer-summary rows", () => {
+		const results = [
+			makeResult({
+				id: 1,
+				score: 4.0,
+				kind: "session_summary",
+				title: "Micro observer recap",
+				metadata: { source: "observer_summary", session_class: "micro_low_value" },
+			}),
+			makeResult({
+				id: 2,
+				score: 4.0,
+				kind: "session_summary",
+				title: "Durable observer recap",
+				metadata: { source: "observer_summary", session_class: "durable" },
+			}),
+			makeResult({
+				id: 3,
+				score: 3.5,
+				kind: "decision",
+				title: "Useful durable decision",
+			}),
+		];
+		const reranked = rerankResults(mockStore, results, 10, undefined, "memory retrieval issues");
+		const orderedIds = reranked.map((item) => item.id);
+		const microIndex = orderedIds.indexOf(1);
+		const durableIndex = orderedIds.indexOf(2);
+		expect(microIndex).toBeGreaterThan(durableIndex);
+	});
+
 	it("applies a stronger penalty to observer-summary recap blobs than ordinary summary rows", () => {
 		const results = [
 			makeResult({

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -18,7 +18,7 @@ import {
 } from "./filters.js";
 import { parsePositiveMemoryId } from "./integers.js";
 import { projectMatchesFilter } from "./project.js";
-import { memoryLooksRecapLike, queryPrefersRecap } from "./recap-policy.js";
+import { memoryLooksRecapLike, queryPrefersRecap, recapPenaltyMultiplier } from "./recap-policy.js";
 import * as schema from "./schema.js";
 import { canonicalMemoryKind } from "./summary-memory.js";
 import type {
@@ -290,11 +290,13 @@ function searchQueryLooksTaskLike(query: string): boolean {
 function recapPenaltyForSearch(item: MemoryResult, preferSummary: boolean): number {
 	if (preferSummary || !memoryLooksRecapLike(item)) return 0.0;
 	const metadata = item.metadata ?? {};
-	if (metadata.source === "observer_summary") return NON_SUMMARY_OBSERVER_RECAP_PENALTY;
+	const multiplier = recapPenaltyMultiplier(item, preferSummary);
+	if (metadata.source === "observer_summary")
+		return NON_SUMMARY_OBSERVER_RECAP_PENALTY * multiplier;
 	if (typeof metadata.request === "string" && typeof metadata.completed === "string") {
-		return NON_SUMMARY_OBSERVER_RECAP_PENALTY;
+		return NON_SUMMARY_OBSERVER_RECAP_PENALTY * multiplier;
 	}
-	return NON_SUMMARY_RECAP_PENALTY;
+	return NON_SUMMARY_RECAP_PENALTY * multiplier;
 }
 
 function itemLooksTaskLikeForSearch(item: MemoryResult): boolean {


### PR DESCRIPTION
## Description

This PR persists session policy decisions into session metadata and surfaces them through memory-role reporting. It records session class and summary disposition so later retrieval, diagnostics, and evaluation work can use the policy as inspectable state instead of treating it as write-time-only behavior.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/ingest-pipeline.test.ts packages/core/src/session-policy.test.ts packages/core/src/maintenance.test.ts packages/cli/src/commands/memory.test.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced