### PR TITLE
feat: score injection-first eval scenarios

### DIFF
--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -331,6 +331,11 @@ function createMemoryRoleReportCommand(): Command {
 				p.log.info("Probe results:");
 				for (const probe of result.probe_results) {
 					p.log.message(`  query: ${probe.query}`);
+					if (probe.scenario_id) {
+						p.log.message(
+							`    scenario: ${probe.scenario_id} (${probe.scenario_category ?? "unknown"})${probe.scenario_title ? ` — ${probe.scenario_title}` : ""}`,
+						);
+					}
 					p.log.message(`    mode: ${probe.mode}`);
 					p.log.message(
 						`    top roles: durable=${probe.top_role_counts.durable} recap=${probe.top_role_counts.recap} ephemeral=${probe.top_role_counts.ephemeral} general=${probe.top_role_counts.general}`,
@@ -349,6 +354,11 @@ function createMemoryRoleReportCommand(): Command {
 					if (probe.simulated_demoted_unmapped_recap_and_ephemeral) {
 						p.log.message(
 							`    simulated demote-unmapped-recap+ephemeral burden: recap_share=${probe.simulated_demoted_unmapped_recap_and_ephemeral.top_burden.recap_share.toFixed(2)} unmapped_share=${probe.simulated_demoted_unmapped_recap_and_ephemeral.top_burden.unmapped_share.toFixed(2)} recap_unmapped_share=${probe.simulated_demoted_unmapped_recap_and_ephemeral.top_burden.recap_unmapped_share.toFixed(2)}`,
+						);
+					}
+					if (probe.scenario_score) {
+						p.log.message(
+							`    scenario score: primary=${probe.scenario_score.primary_match_count} anti=${probe.scenario_score.anti_signal_count} net=${probe.scenario_score.score}`,
 						);
 					}
 					for (const item of probe.items.slice(0, 5)) {

--- a/packages/core/src/eval-scenarios.ts
+++ b/packages/core/src/eval-scenarios.ts
@@ -14,6 +14,16 @@ export interface InjectionEvalScenarioPack {
 	scenarios: InjectionEvalScenario[];
 }
 
+export function getInjectionEvalScenarioByPrompt(prompt: string): InjectionEvalScenario | null {
+	const normalized = prompt.trim().toLowerCase();
+	for (const pack of INJECTION_EVAL_SCENARIO_PACKS) {
+		for (const scenario of pack.scenarios) {
+			if (scenario.prompt.trim().toLowerCase() === normalized) return scenario;
+		}
+	}
+	return null;
+}
+
 export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
 	{
 		id: "track3-core",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,7 @@ export {
 } from "./embeddings.js";
 export type { InjectionEvalScenario, InjectionEvalScenarioPack } from "./eval-scenarios.js";
 export {
+	getInjectionEvalScenarioByPrompt,
 	getInjectionEvalScenarioPack,
 	getInjectionEvalScenarioPrompts,
 	INJECTION_EVAL_SCENARIO_PACKS,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -365,10 +365,12 @@ describe("maintenance", () => {
 			db.close();
 		}
 
-		const report = getMemoryRoleReport(dbPath, { probes: ["oauth callback"] });
+		const report = getMemoryRoleReport(dbPath, {
+			probes: ["what did we decide about recap weighting"],
+		});
 
 		expect(report.probe_results).toHaveLength(1);
-		expect(report.probe_results[0]?.query).toBe("oauth callback");
+		expect(report.probe_results[0]?.query).toBe("what did we decide about recap weighting");
 		expect(report.probe_results[0]?.top_role_counts).toEqual({
 			recap: 1,
 			durable: 1,
@@ -395,13 +397,24 @@ describe("maintenance", () => {
 		});
 		expect(report.probe_results[0]?.items[0]).toEqual(
 			expect.objectContaining({
-				kind: "decision",
+				kind: "session_summary",
 				mapping: "mapped",
-				role: "durable",
-				role_reason: "durable_kind",
+				role: "recap",
+				role_reason: "session_summary_kind",
 				session_class: "unknown",
 				summary_disposition: "unknown",
-				title: "OAuth callback fix",
+				title: "Session recap",
+			}),
+		);
+		expect(report.probe_results[0]).toEqual(
+			expect.objectContaining({
+				scenario_id: "decision-recap-weighting",
+				scenario_category: "decision",
+				scenario_score: expect.objectContaining({
+					primary_match_count: expect.any(Number),
+					anti_signal_count: expect.any(Number),
+					score: expect.any(Number),
+				}),
 			}),
 		);
 		expect(report.session_class_buckets).toEqual({ unknown: 1 });

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -8,6 +8,7 @@ import {
 	getSchemaVersion,
 	resolveDbPath,
 } from "./db.js";
+import { getInjectionEvalScenarioByPrompt } from "./eval-scenarios.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
 import { buildMemoryPack } from "./pack.js";
 import { projectClause } from "./project.js";
@@ -60,6 +61,9 @@ export interface MemoryRoleProbeItem {
 
 export interface MemoryRoleProbeResult {
 	query: string;
+	scenario_id?: string;
+	scenario_title?: string;
+	scenario_category?: string;
 	mode: string;
 	item_ids: number[];
 	items: MemoryRoleProbeItem[];
@@ -89,6 +93,11 @@ export interface MemoryRoleProbeResult {
 			unmapped_share: number;
 			recap_unmapped_share: number;
 		};
+	};
+	scenario_score?: {
+		primary_match_count: number;
+		anti_signal_count: number;
+		score: number;
 	};
 }
 
@@ -361,6 +370,80 @@ function compareProbeResults(
 						: null,
 			};
 		});
+}
+
+function scoreProbeScenario(
+	items: MemoryRoleProbeItem[],
+	query: string,
+): MemoryRoleProbeResult["scenario_score"] | undefined {
+	const scenario = getInjectionEvalScenarioByPrompt(query);
+	if (!scenario) return undefined;
+	const topItems = items.slice(0, 5);
+	const matchToken = (text: string, token: string): boolean => text.includes(token.toLowerCase());
+	const primaryMatchCount = topItems.filter((item) => {
+		const haystack = [
+			item.kind,
+			item.role,
+			item.title,
+			item.role_reason,
+			item.session_class,
+			item.summary_disposition,
+		]
+			.join(" ")
+			.toLowerCase();
+		return scenario.expectedPrimary.some((token) => matchToken(haystack, token));
+	}).length;
+	const antiSignalCount = topItems.filter((item) => {
+		const genericRecap = item.role === "recap" && item.session_class === "micro_low_value";
+		const unmappedRecap = item.role === "recap" && item.mapping === "unmapped";
+		const wrongThreadSummary = item.role === "recap" && item.summary_disposition === "unknown";
+		const administrativeChatter =
+			item.role === "ephemeral" &&
+			item.kind !== "decision" &&
+			item.kind !== "bugfix" &&
+			item.kind !== "discovery";
+		const explicitRecapBias = item.role === "recap" && topItems[0]?.id === item.id;
+		const summaryFirstSludge = item.role === "recap" && item.kind === "session_summary";
+		const missingSummaryIntent =
+			scenario.expectedPrimary.includes("session_summary") && item.role !== "recap";
+		const topicOnlyRefusal = scenario.expectedPrimary.includes("recap") && item.role !== "recap";
+		const totallySummaryFreeOutput =
+			scenario.expectedPrimary.includes("session_summary") &&
+			!topItems.some((candidate) => candidate.role === "recap");
+		if (scenario.expectedAntiSignals.includes("generic recap sludge") && genericRecap) return true;
+		if (scenario.expectedAntiSignals.includes("recap takeover") && item.role === "recap")
+			return true;
+		if (scenario.expectedAntiSignals.includes("unmapped recap") && unmappedRecap) return true;
+		if (scenario.expectedAntiSignals.includes("wrong-thread summary") && wrongThreadSummary)
+			return true;
+		if (scenario.expectedAntiSignals.includes("wrong-thread latest summary") && wrongThreadSummary)
+			return true;
+		if (scenario.expectedAntiSignals.includes("recap-only output") && item.role === "recap")
+			return true;
+		if (scenario.expectedAntiSignals.includes("generic summary") && item.role === "recap")
+			return true;
+		if (scenario.expectedAntiSignals.includes("explicit recap bias") && explicitRecapBias)
+			return true;
+		if (scenario.expectedAntiSignals.includes("summary-first sludge") && summaryFirstSludge)
+			return true;
+		if (scenario.expectedAntiSignals.includes("missing summary intent") && missingSummaryIntent)
+			return true;
+		if (scenario.expectedAntiSignals.includes("topic-only refusal") && topicOnlyRefusal)
+			return true;
+		if (
+			scenario.expectedAntiSignals.includes("totally summary-free output") &&
+			totallySummaryFreeOutput
+		)
+			return true;
+		if (scenario.expectedAntiSignals.includes("administrative chatter") && administrativeChatter)
+			return true;
+		return false;
+	}).length;
+	return {
+		primary_match_count: primaryMatchCount,
+		anti_signal_count: antiSignalCount,
+		score: primaryMatchCount - antiSignalCount,
+	};
 }
 
 function stableProbeItemKey(input: {
@@ -894,6 +977,7 @@ export function getMemoryRoleReport(
 			const store = new MemoryStore(resolvedPath);
 			try {
 				for (const query of opts.probes ?? []) {
+					const scenario = getInjectionEvalScenarioByPrompt(query);
 					const pack = buildMemoryPack(
 						store,
 						query,
@@ -1000,6 +1084,9 @@ export function getMemoryRoleReport(
 					}
 					probeResults.push({
 						query,
+						scenario_id: scenario?.id,
+						scenario_title: scenario?.title,
+						scenario_category: scenario?.category,
 						mode: String(pack.metrics.mode ?? "default"),
 						item_ids: pack.item_ids,
 						items: probeItems,
@@ -1030,6 +1117,7 @@ export function getMemoryRoleReport(
 								recap_unmapped_share: simulated2RecapUnmappedCount / topCount,
 							},
 						},
+						scenario_score: scoreProbeScenario(probeItems, query),
 					});
 				}
 			} finally {


### PR DESCRIPTION
## Description

This PR adds scenario-aware scoring to the memory role report path so named evaluation scenarios can report more than raw burden counts. It introduces scenario metadata, primary/anti-signal scoring, and report output that starts turning Track 3 scenarios into measurable checks instead of prompt aliases.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/maintenance.test.ts packages/cli/src/commands/memory.test.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced