### PR TITLE
feat: boost scouting-oriented retrieval queries

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -230,6 +230,87 @@ describe("rerankResults", () => {
 		expect(reranked[0]?.id).toBe(1);
 	});
 
+	it("boosts results that reference file paths mentioned in the query", () => {
+		const results = [
+			makeResult({
+				id: 1,
+				score: 1.0,
+				kind: "decision",
+				title: "Index.ts decision",
+				metadata: { files_modified: ["packages/core/src/index.ts"] },
+			}),
+			makeResult({
+				id: 2,
+				score: 1.0,
+				kind: "decision",
+				title: "Other file decision",
+				metadata: { files_modified: ["packages/core/src/store.ts"] },
+			}),
+		];
+		const reranked = rerankResults(
+			mockStore,
+			results,
+			10,
+			undefined,
+			"what decisions affected packages/core/src/index.ts",
+		);
+		expect(reranked[0]?.id).toBe(1);
+	});
+
+	it("treats non-TS/JS filenames as path hints too", () => {
+		const results = [
+			makeResult({
+				id: 1,
+				score: 1.0,
+				kind: "decision",
+				title: "Package metadata decision",
+				metadata: { files_modified: ["package.json"] },
+			}),
+			makeResult({
+				id: 2,
+				score: 1.0,
+				kind: "decision",
+				title: "Other file decision",
+				metadata: { files_modified: ["src/index.ts"] },
+			}),
+		];
+		const reranked = rerankResults(
+			mockStore,
+			results,
+			10,
+			undefined,
+			"what changed in package.json",
+		);
+		expect(reranked[0]?.id).toBe(1);
+	});
+
+	it("caps query path overlap boosts so large touched-file sets do not dominate", () => {
+		const manyFiles = Array.from({ length: 20 }, (_, i) => `src/feature/${i}/index.ts`);
+		const results = [
+			makeResult({
+				id: 1,
+				score: 1.0,
+				kind: "decision",
+				title: "Broad file touch memory",
+				metadata: { files_modified: manyFiles },
+			}),
+			makeResult({
+				id: 2,
+				score: 1.2,
+				kind: "decision",
+				title: "Focused textual match",
+			}),
+		];
+		const reranked = rerankResults(
+			mockStore,
+			results,
+			10,
+			undefined,
+			"what decisions affected index.ts",
+		);
+		expect(reranked[0]?.id).toBe(2);
+	});
+
 	it("returns empty array for empty input", () => {
 		expect(rerankResults(mockStore, [], 10)).toEqual([]);
 	});

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -397,6 +397,52 @@ function memoryFilesModified(item: MemoryResult): string[] {
 	return normalized;
 }
 
+function memoryFilesTouched(item: MemoryResult): string[] {
+	const metadata = item.metadata ?? {};
+	const collected: string[] = [];
+	for (const key of ["files_modified", "files_read"] as const) {
+		const rawPaths = metadata[key];
+		if (!Array.isArray(rawPaths)) continue;
+		for (const raw of rawPaths) {
+			if (typeof raw !== "string") continue;
+			const path = canonicalPath(raw);
+			if (path) collected.push(path);
+		}
+	}
+	return [...new Set(collected)];
+}
+
+function queryPathHints(query: string): string[] {
+	const rawTokens = query.match(/[A-Za-z0-9_./-]+/g) ?? [];
+	const normalized = rawTokens
+		.map((token) => canonicalPath(token))
+		.filter((token) => token.includes("/") || token.includes("."));
+	return [...new Set(normalized)];
+}
+
+function queryPathOverlapBoost(item: MemoryResult, query: string): number {
+	const hintedPaths = queryPathHints(query);
+	if (hintedPaths.length === 0) return 0.0;
+	const itemPaths = memoryFilesTouched(item);
+	if (itemPaths.length === 0) return 0.0;
+	const itemSegments = itemPaths.map((path) => pathSegments(path));
+	const hintedSegments = hintedPaths.map((path) => pathSegments(path));
+	let directHits = 0;
+	for (const itemSegment of itemSegments) {
+		if (hintedSegments.some((hintSegment) => pathSegmentsOverlap(itemSegment, hintSegment))) {
+			directHits += 1;
+		}
+	}
+	const itemBasenames = new Set(itemPaths.map((path) => pathBasename(path)).filter(Boolean));
+	const hintedBasenames = new Set(hintedPaths.map((path) => pathBasename(path)).filter(Boolean));
+	let basenameHits = 0;
+	for (const basename of itemBasenames) {
+		if (hintedBasenames.has(basename)) basenameHits += 1;
+	}
+	const boost = directHits * 0.18 + basenameHits * 0.06;
+	return Math.min(0.18, boost);
+}
+
 function workingSetOverlapBoost(item: MemoryResult, workingSetPaths: string[]): number {
 	if (workingSetPaths.length === 0) return 0.0;
 	const itemPaths = memoryFilesModified(item);
@@ -448,6 +494,7 @@ export function rerankResults(
 			recencyScore(item.created_at, referenceNow) +
 			kindBonus(item.kind) +
 			workingSetOverlapBoost(item, workingSetPaths) +
+			queryPathOverlapBoost(item, query) +
 			personalBias(store, item, filters) -
 			sharedTrustPenalty(store, item, filters) -
 			recapPenaltyForSearch(item, preferSummary) -


### PR DESCRIPTION
## Description

This PR improves retrieval for file- and path-oriented scouting prompts by boosting memories that reference files touched by the query. It is the first Track 3 ranking change aimed directly at reducing manual code scouting effort rather than only recap cleanup.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/search.test.ts packages/core/src/pack.test.ts packages/core/src/pack.eval.test.ts`
- `pnpm --filter @codemem/core run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced