### PR TITLE
feat: add scenario diagnostics to injection reports

### DIFF
--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -358,7 +358,7 @@ function createMemoryRoleReportCommand(): Command {
 					}
 					if (probe.scenario_score) {
 						p.log.message(
-							`    scenario score: primary=${probe.scenario_score.primary_match_count} anti=${probe.scenario_score.anti_signal_count} recap=${probe.scenario_score.recap_count} unmapped_recap=${probe.scenario_score.unmapped_recap_count} chatter=${probe.scenario_score.administrative_chatter_count} net=${probe.scenario_score.score}`,
+							`    scenario score: mode_match=${probe.scenario_score.mode_match ? "yes" : "no"} top1_primary=${probe.scenario_score.primary_in_top1 ? "yes" : "no"} top3_primary=${probe.scenario_score.primary_in_top3_count} top1_anti=${probe.scenario_score.anti_signal_in_top1 ? "yes" : "no"} primary=${probe.scenario_score.primary_match_count} anti=${probe.scenario_score.anti_signal_count} recap=${probe.scenario_score.recap_count} unmapped_recap=${probe.scenario_score.unmapped_recap_count} chatter=${probe.scenario_score.administrative_chatter_count} net=${probe.scenario_score.score}`,
 						);
 					}
 					for (const item of probe.items.slice(0, 5)) {

--- a/packages/core/src/eval-scenarios.ts
+++ b/packages/core/src/eval-scenarios.ts
@@ -3,6 +3,7 @@ export interface InjectionEvalScenario {
 	title: string;
 	category: "locating" | "decision" | "outcome" | "troubleshooting" | "continuation";
 	prompt: string;
+	expectedModes?: string[];
 	expectedPrimary: string[];
 	expectedAntiSignals: string[];
 }
@@ -36,6 +37,7 @@ export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
 				title: "Recap weighting decision continuity",
 				category: "decision",
 				prompt: "what did we decide about recap weighting",
+				expectedModes: ["default", "recall"],
 				expectedPrimary: ["decision", "discovery", "durable"],
 				expectedAntiSignals: ["generic recap sludge", "wrong-thread summary"],
 			},
@@ -44,6 +46,7 @@ export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
 				title: "Memory retrieval topic quality",
 				category: "outcome",
 				prompt: "memory retrieval issues",
+				expectedModes: ["default"],
 				expectedPrimary: ["discovery", "bugfix", "decision"],
 				expectedAntiSignals: ["recap takeover", "unmapped recap"],
 			},
@@ -52,6 +55,7 @@ export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
 				title: "Sessionization summary emission policy",
 				category: "decision",
 				prompt: "sessionization summary emission",
+				expectedModes: ["recall", "default"],
 				expectedPrimary: ["decision", "durable policy memory"],
 				expectedAntiSignals: ["explicit recap bias", "summary-first sludge"],
 			},
@@ -60,6 +64,7 @@ export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
 				title: "OAuth recurrence troubleshooting continuity",
 				category: "troubleshooting",
 				prompt: "what did we decide last time about oauth",
+				expectedModes: ["recall"],
 				expectedPrimary: ["decision", "bugfix", "troubleshooting outcome"],
 				expectedAntiSignals: ["wrong-thread latest summary", "recap-only output"],
 			},
@@ -68,6 +73,7 @@ export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
 				title: "Track 3 continuation context",
 				category: "continuation",
 				prompt: "what should we do next about recap policy",
+				expectedModes: ["task", "default"],
 				expectedPrimary: ["decision", "next-step context", "durable workstream context"],
 				expectedAntiSignals: ["generic summary", "administrative chatter"],
 			},
@@ -83,6 +89,7 @@ export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
 				title: "Explicit recap request for OAuth work",
 				category: "decision",
 				prompt: "summary of oauth",
+				expectedModes: ["recall"],
 				expectedPrimary: ["session_summary", "recap"],
 				expectedAntiSignals: ["missing summary intent", "topic-only refusal"],
 			},
@@ -91,6 +98,7 @@ export const INJECTION_EVAL_SCENARIO_PACKS: InjectionEvalScenarioPack[] = [
 				title: "Explicit catch-up request",
 				category: "continuation",
 				prompt: "catch me up on memory retrieval work",
+				expectedModes: ["recall"],
 				expectedPrimary: ["session_summary", "recap", "orientation context"],
 				expectedAntiSignals: ["totally summary-free output"],
 			},

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -95,6 +95,10 @@ export interface MemoryRoleProbeResult {
 		};
 	};
 	scenario_score?: {
+		mode_match: boolean;
+		primary_in_top1: boolean;
+		primary_in_top3_count: number;
+		anti_signal_in_top1: boolean;
 		primary_match_count: number;
 		anti_signal_count: number;
 		recap_count: number;
@@ -378,12 +382,14 @@ function compareProbeResults(
 function scoreProbeScenario(
 	items: MemoryRoleProbeItem[],
 	query: string,
+	mode: string,
 ): MemoryRoleProbeResult["scenario_score"] | undefined {
 	const scenario = getInjectionEvalScenarioByPrompt(query);
 	if (!scenario) return undefined;
 	const topItems = items.slice(0, 5);
+	const topThree = items.slice(0, 3);
 	const matchToken = (text: string, token: string): boolean => text.includes(token.toLowerCase());
-	const primaryMatchCount = topItems.filter((item) => {
+	const itemMatchesPrimary = (item: MemoryRoleProbeItem): boolean => {
 		const haystack = [
 			item.kind,
 			item.role,
@@ -395,8 +401,8 @@ function scoreProbeScenario(
 			.join(" ")
 			.toLowerCase();
 		return scenario.expectedPrimary.some((token) => matchToken(haystack, token));
-	}).length;
-	const antiSignalCount = topItems.filter((item) => {
+	};
+	const itemMatchesAntiSignal = (item: MemoryRoleProbeItem): boolean => {
 		const genericRecap = item.role === "recap" && item.session_class === "micro_low_value";
 		const unmappedRecap = item.role === "recap" && item.mapping === "unmapped";
 		const wrongThreadSummary = item.role === "recap" && item.summary_disposition === "unknown";
@@ -441,7 +447,18 @@ function scoreProbeScenario(
 		if (scenario.expectedAntiSignals.includes("administrative chatter") && administrativeChatter)
 			return true;
 		return false;
+	};
+	const primaryMatchCount = topItems.filter((item) => {
+		return itemMatchesPrimary(item);
 	}).length;
+	const antiSignalCount = topItems.filter((item) => itemMatchesAntiSignal(item)).length;
+	const expectedModes = scenario.expectedModes ?? [];
+	const modeMatch = expectedModes.length === 0 || expectedModes.includes(mode);
+	const primaryInTop1 =
+		topItems.length > 0 ? itemMatchesPrimary(topItems[0] as MemoryRoleProbeItem) : false;
+	const primaryInTop3Count = topThree.filter((item) => itemMatchesPrimary(item)).length;
+	const antiSignalInTop1 =
+		topItems.length > 0 ? itemMatchesAntiSignal(topItems[0] as MemoryRoleProbeItem) : false;
 	const recapCount = topItems.filter((item) => item.role === "recap").length;
 	const unmappedRecapCount = topItems.filter(
 		(item) => item.role === "recap" && item.mapping === "unmapped",
@@ -454,14 +471,24 @@ function scoreProbeScenario(
 			item.kind !== "discovery",
 	).length;
 	return {
+		mode_match: modeMatch,
+		primary_in_top1: primaryInTop1,
+		primary_in_top3_count: primaryInTop3Count,
+		anti_signal_in_top1: antiSignalInTop1,
 		primary_match_count: primaryMatchCount,
 		anti_signal_count: antiSignalCount,
 		recap_count: recapCount,
 		unmapped_recap_count: unmappedRecapCount,
 		administrative_chatter_count: administrativeChatterCount,
-		score: primaryMatchCount - antiSignalCount,
+		score:
+			primaryMatchCount -
+			antiSignalCount +
+			(modeMatch ? 1 : 0) +
+			(primaryInTop1 ? 1 : 0) -
+			(antiSignalInTop1 ? 1 : 0),
 	};
 }
+
 function stableProbeItemKey(input: {
 	import_key?: string | null;
 	kind: string;
@@ -1133,7 +1160,11 @@ export function getMemoryRoleReport(
 								recap_unmapped_share: simulated2RecapUnmappedCount / topCount,
 							},
 						},
-						scenario_score: scoreProbeScenario(probeItems, query),
+						scenario_score: scoreProbeScenario(
+							probeItems,
+							query,
+							String(pack.metrics.mode ?? "default"),
+						),
 					});
 				}
 			} finally {


### PR DESCRIPTION
## Description

This PR adds richer scenario diagnostics to Track 3 role-report output so named scenarios report more than burden counts. It surfaces scenario identity and additional diagnostic details that make the eval output easier to interpret when tuning injection quality.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/maintenance.test.ts packages/cli/src/commands/memory.test.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced