### PR TITLE
feat: add quality-aware ranking boosts

### DIFF
--- a/docs/plans/2026-04-07-rich-session-under-extraction-eval-case.md
+++ b/docs/plans/2026-04-07-rich-session-under-extraction-eval-case.md
@@ -66,7 +66,7 @@ At inspection time:
 
 - `last_received_event_seq`: `1398`
 - `last_flushed_event_seq`: `1356`
-- pending gap: `37` events
+- pending gap: `42` events
 
 The pending tail was not low-value noise. Event-type counts for the tail after
 `1356` were:

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -257,56 +257,32 @@ describe("rerankResults", () => {
 		expect(reranked[0]?.id).toBe(1);
 	});
 
-	it("treats non-TS/JS filenames as path hints too", () => {
+	it("boosts decisions for decision-oriented queries", () => {
 		const results = [
-			makeResult({
-				id: 1,
-				score: 1.0,
-				kind: "decision",
-				title: "Package metadata decision",
-				metadata: { files_modified: ["package.json"] },
-			}),
-			makeResult({
-				id: 2,
-				score: 1.0,
-				kind: "decision",
-				title: "Other file decision",
-				metadata: { files_modified: ["src/index.ts"] },
-			}),
+			makeResult({ id: 1, score: 1.0, kind: "discovery", title: "Discovery item" }),
+			makeResult({ id: 2, score: 0.95, kind: "decision", title: "Decision item" }),
 		];
 		const reranked = rerankResults(
 			mockStore,
 			results,
 			10,
 			undefined,
-			"what changed in package.json",
+			"what did we decide about recap weighting",
 		);
-		expect(reranked[0]?.id).toBe(1);
+		expect(reranked[0]?.id).toBe(2);
 	});
 
-	it("caps query path overlap boosts so large touched-file sets do not dominate", () => {
-		const manyFiles = Array.from({ length: 20 }, (_, i) => `src/feature/${i}/index.ts`);
+	it("boosts bugfix/discovery for troubleshooting-oriented queries", () => {
 		const results = [
-			makeResult({
-				id: 1,
-				score: 1.0,
-				kind: "decision",
-				title: "Broad file touch memory",
-				metadata: { files_modified: manyFiles },
-			}),
-			makeResult({
-				id: 2,
-				score: 1.2,
-				kind: "decision",
-				title: "Focused textual match",
-			}),
+			makeResult({ id: 1, score: 1.0, kind: "decision", title: "Decision item" }),
+			makeResult({ id: 2, score: 0.94, kind: "bugfix", title: "Bugfix item" }),
 		];
 		const reranked = rerankResults(
 			mockStore,
 			results,
 			10,
 			undefined,
-			"what decisions affected index.ts",
+			"what was the fix for raw-event relinking bug",
 		);
 		expect(reranked[0]?.id).toBe(2);
 	});

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -287,6 +287,70 @@ function searchQueryLooksTaskLike(query: string): boolean {
 	return false;
 }
 
+function searchQueryLooksDecisionLike(query: string): boolean {
+	const lowered = query.toLowerCase();
+	for (const phrase of ["what did we decide", "decision", "why did we", "rationale", "tradeoff"]) {
+		if (lowered.includes(phrase)) return true;
+	}
+	return false;
+}
+
+function searchQueryLooksTroubleshootingLike(query: string): boolean {
+	const lowered = query.toLowerCase();
+	const wordTokens = new Set(lowered.match(/[a-z0-9_]+/g) ?? []);
+	for (const phrase of [
+		"root cause",
+		"what was the fix",
+		"fix for",
+		"how did we fix",
+		"how did we debug",
+		"what happened last time",
+		"regression",
+	]) {
+		if (lowered.includes(phrase)) return true;
+	}
+	if (wordTokens.has("bug") || wordTokens.has("bugs")) return true;
+	return false;
+}
+
+function searchQueryLooksContinuationLike(query: string): boolean {
+	const lowered = query.toLowerCase();
+	for (const phrase of [
+		"what should we do next",
+		"what remains",
+		"continue",
+		"next step",
+		"next steps",
+		"follow up",
+	]) {
+		if (lowered.includes(phrase)) return true;
+	}
+	return false;
+}
+
+function qualityDimensionBoost(item: MemoryResult, query: string): number {
+	const decisionLike = searchQueryLooksDecisionLike(query);
+	const troubleshootingLike = searchQueryLooksTroubleshootingLike(query);
+	const continuationLike = searchQueryLooksContinuationLike(query);
+	if (!decisionLike && !troubleshootingLike && !continuationLike) return 0.0;
+	let boost = 0.0;
+	if (decisionLike) {
+		if (item.kind === "decision") boost += 0.2;
+		if (item.kind === "discovery") boost += 0.08;
+	}
+	if (troubleshootingLike) {
+		if (item.kind === "bugfix") boost += 0.24;
+		if (item.kind === "discovery") boost += 0.16;
+		if (item.kind === "decision") boost += 0.04;
+	}
+	if (continuationLike) {
+		if (item.kind === "decision") boost += 0.1;
+		if (item.kind === "feature") boost += 0.08;
+		if (item.kind === "discovery") boost += 0.06;
+	}
+	return boost;
+}
+
 function recapPenaltyForSearch(item: MemoryResult, preferSummary: boolean): number {
 	if (preferSummary || !memoryLooksRecapLike(item)) return 0.0;
 	const metadata = item.metadata ?? {};
@@ -493,6 +557,7 @@ export function rerankResults(
 			item.score * 1.5 +
 			recencyScore(item.created_at, referenceNow) +
 			kindBonus(item.kind) +
+			qualityDimensionBoost(item, query) +
 			workingSetOverlapBoost(item, workingSetPaths) +
 			queryPathOverlapBoost(item, query) +
 			personalBias(store, item, filters) -


### PR DESCRIPTION
## Description

This PR adds the first quality-dimension-aware ranking boosts for Track 3. Retrieval now gives small, query-type-aware preference to decisions, bugfixes, discoveries, and continuation-relevant memories so results align better with decision, troubleshooting, and continuation prompts.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/search.test.ts packages/core/src/pack.test.ts packages/core/src/pack.eval.test.ts`
- `pnpm --filter @codemem/core run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced