### PR TITLE
feat: compare injection scenario diagnostics

### DIFF
--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -480,6 +480,16 @@ function createMemoryRoleCompareCommand(): Command {
 							`    mapping delta: mapped=${probe.delta_top_mapping_counts.mapped} unmapped=${probe.delta_top_mapping_counts.unmapped}`,
 						);
 					}
+					if (probe.baseline_scenario_score || probe.candidate_scenario_score) {
+						p.log.message(
+							`    scenario scores: baseline=${probe.baseline_scenario_score?.score ?? "-"} candidate=${probe.candidate_scenario_score?.score ?? "-"}`,
+						);
+					}
+					if (probe.delta_scenario_score) {
+						p.log.message(
+							`    scenario delta: mode_match=${probe.delta_scenario_score.mode_match ?? "-"} top1_primary=${probe.delta_scenario_score.primary_in_top1 ?? "-"} top3_primary=${probe.delta_scenario_score.primary_in_top3_count ?? "-"} top1_anti=${probe.delta_scenario_score.anti_signal_in_top1 ?? "-"} primary=${probe.delta_scenario_score.primary_match_count ?? "-"} anti=${probe.delta_scenario_score.anti_signal_count ?? "-"} recap=${probe.delta_scenario_score.recap_count ?? "-"} unmapped_recap=${probe.delta_scenario_score.unmapped_recap_count ?? "-"} chatter=${probe.delta_scenario_score.administrative_chatter_count ?? "-"} net=${probe.delta_scenario_score.score ?? "-"}`,
+						);
+					}
 				}
 			}
 			p.outro("done");

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -521,6 +521,15 @@ describe("maintenance", () => {
 				},
 			}),
 		);
+		expect(comparison.probe_comparisons[0]).toEqual(
+			expect.objectContaining({
+				baseline_scenario_id: undefined,
+				candidate_scenario_id: undefined,
+				baseline_scenario_score: undefined,
+				candidate_scenario_score: undefined,
+				delta_scenario_score: undefined,
+			}),
+		);
 	});
 
 	it("reports relinkable raw-event session groups", () => {

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -143,6 +143,12 @@ export interface MemoryRoleReportComparisonOptions extends MemoryRoleReportOptio
 
 export interface MemoryRoleProbeComparison {
 	query: string;
+	baseline_scenario_id?: string;
+	candidate_scenario_id?: string;
+	baseline_scenario_title?: string;
+	candidate_scenario_title?: string;
+	baseline_scenario_category?: string;
+	candidate_scenario_category?: string;
 	baseline_mode: string | null;
 	candidate_mode: string | null;
 	baseline_item_ids: number[];
@@ -154,6 +160,11 @@ export interface MemoryRoleProbeComparison {
 	baseline_top_mapping_counts: Record<"mapped" | "unmapped", number> | null;
 	candidate_top_mapping_counts: Record<"mapped" | "unmapped", number> | null;
 	delta_top_mapping_counts: Record<"mapped" | "unmapped", number> | null;
+	baseline_scenario_score?: MemoryRoleProbeResult["scenario_score"];
+	candidate_scenario_score?: MemoryRoleProbeResult["scenario_score"];
+	delta_scenario_score?: Partial<
+		Record<keyof NonNullable<MemoryRoleProbeResult["scenario_score"]>, number>
+	>;
 }
 
 export interface MemoryRoleReportComparison {
@@ -355,6 +366,12 @@ function compareProbeResults(
 			const sharedItemKeys = baselineKeys.filter((key) => candidateKeySet.has(key));
 			return {
 				query,
+				baseline_scenario_id: baselineProbe?.scenario_id,
+				candidate_scenario_id: candidateProbe?.scenario_id,
+				baseline_scenario_title: baselineProbe?.scenario_title,
+				candidate_scenario_title: candidateProbe?.scenario_title,
+				baseline_scenario_category: baselineProbe?.scenario_category,
+				candidate_scenario_category: candidateProbe?.scenario_category,
 				baseline_mode: baselineProbe?.mode ?? null,
 				candidate_mode: candidateProbe?.mode ?? null,
 				baseline_item_ids: baselineIds,
@@ -375,6 +392,41 @@ function compareProbeResults(
 								candidateProbe.top_mapping_counts,
 							)
 						: null,
+				baseline_scenario_score: baselineProbe?.scenario_score,
+				candidate_scenario_score: candidateProbe?.scenario_score,
+				delta_scenario_score:
+					baselineProbe?.scenario_score && candidateProbe?.scenario_score
+						? {
+								mode_match:
+									Number(candidateProbe.scenario_score.mode_match) -
+									Number(baselineProbe.scenario_score.mode_match),
+								primary_in_top1:
+									Number(candidateProbe.scenario_score.primary_in_top1) -
+									Number(baselineProbe.scenario_score.primary_in_top1),
+								primary_in_top3_count:
+									candidateProbe.scenario_score.primary_in_top3_count -
+									baselineProbe.scenario_score.primary_in_top3_count,
+								anti_signal_in_top1:
+									Number(candidateProbe.scenario_score.anti_signal_in_top1) -
+									Number(baselineProbe.scenario_score.anti_signal_in_top1),
+								primary_match_count:
+									candidateProbe.scenario_score.primary_match_count -
+									baselineProbe.scenario_score.primary_match_count,
+								anti_signal_count:
+									candidateProbe.scenario_score.anti_signal_count -
+									baselineProbe.scenario_score.anti_signal_count,
+								recap_count:
+									candidateProbe.scenario_score.recap_count -
+									baselineProbe.scenario_score.recap_count,
+								unmapped_recap_count:
+									candidateProbe.scenario_score.unmapped_recap_count -
+									baselineProbe.scenario_score.unmapped_recap_count,
+								administrative_chatter_count:
+									candidateProbe.scenario_score.administrative_chatter_count -
+									baselineProbe.scenario_score.administrative_chatter_count,
+								score: candidateProbe.scenario_score.score - baselineProbe.scenario_score.score,
+							}
+						: undefined,
 			};
 		});
 }


### PR DESCRIPTION
## Description

This PR extends role-compare output so Track 3 scenarios can be compared diagnostically across snapshots, not just through burden and mapping deltas. It adds baseline/candidate scenario identity and scenario-score deltas to make comparison output more useful for policy and ranking iteration.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm vitest run packages/core/src/maintenance.test.ts packages/cli/src/commands/memory.test.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced