### PR TITLE
feat: add extraction replay benchmark tooling

### DIFF
--- a/docs/plans/2026-04-07-rich-session-under-extraction-eval-case.md
+++ b/docs/plans/2026-04-07-rich-session-under-extraction-eval-case.md
@@ -155,6 +155,50 @@ For this scenario class, track:
 - whether resulting memory set would materially reduce future scouting and
   rediscovery effort
 
+## Formal benchmark set (current)
+
+This case is now part of a formal replay benchmark profile:
+
+- **benchmark id:** `rich-batch-shape-v1`
+- **generic shape scenario:** `rich-batch-shape`
+- **content-specific scenario for this batch:** `rich-session-under-extraction`
+
+### Shape-quality benchmark batches
+
+These batches should be used when comparing observer models or replay shaping
+changes for output quality:
+
+- `18503` — flagship under-extraction batch (this case)
+- `18502` — adjacent earlier rich batch from the same session
+- `18506` — adjacent later rich batch from the same session
+- `18432` — large snapshot batch from another session
+- `18446` — hard failing snapshot batch from another session
+
+### Replay-robustness bucket
+
+These should **not** be counted as extraction-shape failures when the observer
+returns no output:
+
+- `18476` — stored extraction already passes shape, but replay can return
+  `raw = null`; treat this as observer/replay robustness, not under-extraction
+
+## Current model comparison conclusion
+
+Current benchmark findings:
+
+- **benchmark truth model:** `openai / gpt-5.4`
+  - best overall consistency on the current shape-quality batch set
+- **cheaper candidate worth tracking:** `openai / gpt-5.4-mini @ temperature 0.2`
+  - can pass some hard batches
+  - remains less reliable than full `gpt-5.4`
+- **opencode / claude-sonnet-4-5**
+  - promising on several hard batches
+  - still mixed enough that it should be treated as a candidate, not the current
+    truth baseline
+
+The main cost-conscious takeaway is that cheaper/faster models should be judged
+against this benchmark set, not assumed sufficient by default.
+
 ## Notes
 
 This case should not be interpreted as a repeat of the old structural

--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -15,6 +15,9 @@ describe("memory command aliases", () => {
 			"inject",
 			"role-report",
 			"role-compare",
+			"extraction-report",
+			"extraction-replay",
+			"extraction-benchmark",
 			"relink-report",
 			"relink-plan",
 		]);
@@ -57,6 +60,52 @@ describe("memory command aliases", () => {
 		expect(longs).toContain("--probe");
 		expect(longs).toContain("--scenario");
 		expect(longs).toContain("--inactive");
+		expect(longs).toContain("--json");
+	});
+
+	it("registers extraction-report under memory with session eval options", () => {
+		const extractionReport = memoryCommand.commands.find(
+			(command) => command.name() === "extraction-report",
+		);
+		expect(extractionReport).toBeDefined();
+		const longs = extractionReport?.options.map((option) => option.long) ?? [];
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--session-id");
+		expect(longs).toContain("--batch-id");
+		expect(longs).toContain("--scenario");
+		expect(longs).toContain("--inactive");
+		expect(longs).toContain("--json");
+	});
+
+	it("registers extraction-replay under memory with replay eval options", () => {
+		const extractionReplay = memoryCommand.commands.find(
+			(command) => command.name() === "extraction-replay",
+		);
+		expect(extractionReplay).toBeDefined();
+		const longs = extractionReplay?.options.map((option) => option.long) ?? [];
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--batch-id");
+		expect(longs).toContain("--observer-temperature");
+		expect(longs).toContain("--transcript-budget");
+		expect(longs).toContain("--scenario");
+		expect(longs).toContain("--json");
+	});
+
+	it("registers extraction-benchmark under memory with benchmark-runner options", () => {
+		const extractionBenchmark = memoryCommand.commands.find(
+			(command) => command.name() === "extraction-benchmark",
+		);
+		expect(extractionBenchmark).toBeDefined();
+		const longs = extractionBenchmark?.options.map((option) => option.long) ?? [];
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--benchmark");
+		expect(longs).toContain("--observer-provider");
+		expect(longs).toContain("--observer-model");
+		expect(longs).toContain("--observer-temperature");
+		expect(longs).toContain("--transcript-budget");
 		expect(longs).toContain("--json");
 	});
 

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -8,12 +8,18 @@
 import * as p from "@clack/prompts";
 import {
 	compareMemoryRoleReports,
+	getExtractionBenchmarkProfile,
 	getInjectionEvalScenarioPack,
 	getInjectionEvalScenarioPrompts,
 	getMemoryRoleReport,
 	getRawEventRelinkPlan,
 	getRawEventRelinkReport,
+	getSessionExtractionEval,
+	getSessionExtractionEvalScenario,
+	loadObserverConfig,
 	MemoryStore,
+	ObserverClient,
+	replayBatchExtraction,
 	resolveDbPath,
 	resolveProject,
 } from "@codemem/core";
@@ -498,6 +504,353 @@ function createMemoryRoleCompareCommand(): Command {
 	return cmd;
 }
 
+function createMemoryExtractionReportCommand(): Command {
+	const cmd = new Command("extraction-report")
+		.configureHelp(helpStyle)
+		.description("Score extracted memories for a session against a built-in extraction eval rubric")
+		.option("--session-id <id>", "session ID to evaluate")
+		.option("--batch-id <id>", "raw-event flush batch ID to evaluate")
+		.requiredOption("--scenario <id>", "built-in extraction eval scenario ID")
+		.option("--inactive", "include inactive memories");
+	addDbOption(cmd);
+	addJsonOption(cmd);
+	cmd.action(
+		(
+			opts: DbOpts &
+				JsonOpts & {
+					sessionId: string;
+					batchId?: string;
+					scenario: string;
+					inactive?: boolean;
+				},
+		) => {
+			const sessionIdInput = opts.sessionId?.trim() ?? "";
+			const batchIdInput = opts.batchId?.trim() ?? "";
+			const hasSessionId = sessionIdInput.length > 0;
+			const hasBatchId = batchIdInput.length > 0;
+			if (hasSessionId === hasBatchId) {
+				throw new Error("Provide exactly one of --session-id or --batch-id");
+			}
+			const sessionId = hasSessionId ? parseStrictPositiveId(sessionIdInput) : null;
+			if (hasSessionId && sessionId === null) {
+				throw new Error(`Invalid session ID: ${sessionIdInput || opts.sessionId}`);
+			}
+			const batchId = hasBatchId ? parseStrictPositiveId(batchIdInput) : null;
+			if (hasBatchId && batchId === null) {
+				throw new Error(`Invalid batch ID: ${batchIdInput || opts.batchId}`);
+			}
+			const scenarioId = opts.scenario?.trim() ?? "";
+			const scenario = getSessionExtractionEvalScenario(scenarioId);
+			if (!scenario) {
+				throw new Error(`Unknown extraction eval scenario: ${scenarioId || opts.scenario}`);
+			}
+			const result =
+				batchId != null
+					? getSessionExtractionEval(resolveDbOpt(opts), {
+							batchId,
+							scenarioId: scenario.id,
+							includeInactive: opts.inactive === true,
+						})
+					: getSessionExtractionEval(resolveDbOpt(opts), {
+							sessionId: sessionId as number,
+							scenarioId: scenario.id,
+							includeInactive: opts.inactive === true,
+						});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			p.intro("codemem memory extraction-report");
+			p.log.info(
+				[
+					`Scenario: ${result.scenario.id} — ${result.scenario.title}`,
+					`Target: ${result.target.type}${result.target.batchId != null ? ` #${result.target.batchId}` : ""}`,
+					`Session: ${result.session.id} (${result.session.project ?? "no-project"})`,
+					`Session class: ${result.session.sessionClass}`,
+					`Summary disposition: ${result.session.summaryDisposition}`,
+				].join("\n"),
+			);
+			p.log.info(
+				[
+					`Pass: ${result.pass ? "yes" : "no"}`,
+					`Summary count: ${result.counts.summaries}`,
+					`Observation count: ${result.counts.observations}`,
+					`Summary thread coverage: ${result.coverage.summaryThreadCoverage}`,
+					`Observation thread coverage: ${result.coverage.observationThreadCoverage}`,
+					`Total thread coverage: ${result.coverage.totalThreadCoverage}`,
+					`Duplicate observation threads: ${result.coverage.duplicateObservationThreads}`,
+				].join("\n"),
+			);
+			if (result.failureReasons.length > 0) {
+				p.log.warn("Failure reasons:");
+				for (const reason of result.failureReasons) {
+					p.log.message(`  - ${reason}`);
+				}
+			}
+			p.log.info("Thread coverage:");
+			for (const thread of result.threads) {
+				p.log.message(
+					`  ${thread.id.padEnd(22)} summary=${thread.summaryMatch ? "yes" : "no"} observations=${thread.observationMatch ? "yes" : "no"}`,
+				);
+			}
+			p.outro("done");
+		},
+	);
+	return cmd;
+}
+
+function createMemoryExtractionReplayCommand(): Command {
+	const cmd = new Command("extraction-replay")
+		.configureHelp(helpStyle)
+		.description(
+			"Re-run the observer on a historical flush batch without persisting, then score the fresh output",
+		)
+		.requiredOption("--batch-id <id>", "raw-event flush batch ID to replay")
+		.option(
+			"--transcript-budget <chars>",
+			"override replay transcript budget in characters (replay only)",
+		)
+		.option("--observer-temperature <value>", "override observer temperature for replay only")
+		.requiredOption("--scenario <id>", "built-in extraction eval scenario ID");
+	addDbOption(cmd);
+	addJsonOption(cmd);
+	cmd.action(
+		async (
+			opts: DbOpts &
+				JsonOpts & {
+					batchId: string;
+					observerTemperature?: string;
+					transcriptBudget?: string;
+					scenario: string;
+				},
+		) => {
+			const batchIdInput = opts.batchId?.trim() ?? "";
+			const batchId = parseStrictPositiveId(batchIdInput);
+			if (batchId === null) {
+				throw new Error(`Invalid batch ID: ${batchIdInput || opts.batchId}`);
+			}
+			const scenarioId = opts.scenario?.trim() ?? "";
+			const scenario = getSessionExtractionEvalScenario(scenarioId);
+			if (!scenario) {
+				throw new Error(`Unknown extraction eval scenario: ${scenarioId || opts.scenario}`);
+			}
+			const transcriptBudgetInput = opts.transcriptBudget?.trim() ?? "";
+			const transcriptBudget =
+				transcriptBudgetInput.length > 0 ? parseStrictPositiveId(transcriptBudgetInput) : null;
+			if (transcriptBudgetInput.length > 0 && transcriptBudget === null) {
+				throw new Error(
+					`Invalid transcript budget: ${transcriptBudgetInput || opts.transcriptBudget}`,
+				);
+			}
+			const observerTemperatureInput = opts.observerTemperature?.trim() ?? "";
+			let observerTemperature: number | undefined;
+			if (observerTemperatureInput.length > 0) {
+				const parsed = Number(observerTemperatureInput);
+				if (!Number.isFinite(parsed)) {
+					throw new Error(
+						`Invalid observer temperature: ${observerTemperatureInput || opts.observerTemperature}`,
+					);
+				}
+				observerTemperature = parsed;
+			}
+			const observerConfig = loadObserverConfig();
+			const observer = new ObserverClient({
+				...observerConfig,
+				observerTemperature: observerTemperature ?? observerConfig.observerTemperature,
+			});
+			const result = await replayBatchExtraction(resolveDbOpt(opts), observer, {
+				batchId,
+				scenarioId: scenario.id,
+				transcriptBudget: transcriptBudget ?? undefined,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			p.intro("codemem memory extraction-replay");
+			p.log.info(
+				[
+					`Scenario: ${result.scenario.id} — ${result.scenario.title}`,
+					`Batch: ${result.target.batchId}`,
+					`Session: ${result.target.sessionId}`,
+					`Observer: ${result.observer.provider}/${result.observer.model}`,
+					`Classification: ${result.classification.status}`,
+					`Pass: ${result.evaluation.pass ? "yes" : "no"}`,
+				].join("\n"),
+			);
+			if (result.classification.reason) {
+				p.log.message(`Classification reason: ${result.classification.reason}`);
+			}
+			if (result.evaluation.failureReasons.length > 0) {
+				p.log.warn("Failure reasons:");
+				for (const reason of result.evaluation.failureReasons) {
+					p.log.message(`  - ${reason}`);
+				}
+			}
+			p.log.info(
+				[
+					`Fresh summaries: ${result.evaluation.counts.summaries}`,
+					`Fresh observations: ${result.evaluation.counts.observations}`,
+					`Summary thread coverage: ${result.evaluation.coverage.summaryThreadCoverage}`,
+					`Observation thread coverage: ${result.evaluation.coverage.observationThreadCoverage}`,
+					`Total thread coverage: ${result.evaluation.coverage.totalThreadCoverage}`,
+				].join("\n"),
+			);
+			p.outro("done");
+		},
+	);
+	return cmd;
+}
+
+function createMemoryExtractionBenchmarkCommand(): Command {
+	const cmd = new Command("extraction-benchmark")
+		.configureHelp(helpStyle)
+		.description(
+			"Run the formal extraction replay benchmark set and print a cost/quality scoreboard",
+		)
+		.requiredOption("--benchmark <id>", "benchmark profile id")
+		.option("--observer-provider <provider>", "override observer provider for this benchmark run")
+		.option("--observer-model <model>", "override observer model for this benchmark run")
+		.option(
+			"--observer-temperature <value>",
+			"override observer temperature for this benchmark run",
+		)
+		.option(
+			"--transcript-budget <chars>",
+			"override replay transcript budget in characters for this benchmark run",
+		);
+	addDbOption(cmd);
+	addJsonOption(cmd);
+	cmd.action(
+		async (
+			opts: DbOpts &
+				JsonOpts & {
+					benchmark: string;
+					observerProvider?: string;
+					observerModel?: string;
+					observerTemperature?: string;
+					transcriptBudget?: string;
+				},
+		) => {
+			const benchmarkId = opts.benchmark?.trim() ?? "";
+			const benchmark = getExtractionBenchmarkProfile(benchmarkId);
+			if (!benchmark) {
+				throw new Error(`Unknown extraction benchmark: ${benchmarkId || opts.benchmark}`);
+			}
+			const transcriptBudgetInput = opts.transcriptBudget?.trim() ?? "";
+			const transcriptBudget =
+				transcriptBudgetInput.length > 0 ? parseStrictPositiveId(transcriptBudgetInput) : null;
+			if (transcriptBudgetInput.length > 0 && transcriptBudget === null) {
+				throw new Error(
+					`Invalid transcript budget: ${transcriptBudgetInput || opts.transcriptBudget}`,
+				);
+			}
+			const observerTemperatureInput = opts.observerTemperature?.trim() ?? "";
+			let observerTemperature: number | undefined;
+			if (observerTemperatureInput.length > 0) {
+				const parsed = Number(observerTemperatureInput);
+				if (!Number.isFinite(parsed)) {
+					throw new Error(
+						`Invalid observer temperature: ${observerTemperatureInput || opts.observerTemperature}`,
+					);
+				}
+				observerTemperature = parsed;
+			}
+			const observerConfig = loadObserverConfig();
+			const observer = new ObserverClient({
+				...observerConfig,
+				observerProvider: opts.observerProvider?.trim() || observerConfig.observerProvider,
+				observerModel: opts.observerModel?.trim() || observerConfig.observerModel,
+				observerTemperature: observerTemperature ?? observerConfig.observerTemperature,
+			});
+			const runs = [] as Array<{
+				batchId: number;
+				sessionId: number;
+				label: string;
+				purpose: "shape_quality" | "replay_robustness";
+				status: "pass" | "shape_fail" | "observer_no_output";
+				reason: string;
+				summaries: number;
+				observations: number;
+				repairApplied: boolean;
+			}>;
+			for (const batch of benchmark.batches) {
+				const result = await replayBatchExtraction(resolveDbOpt(opts), observer, {
+					batchId: batch.batchId,
+					scenarioId: benchmark.scenarioId,
+					transcriptBudget: transcriptBudget ?? undefined,
+				});
+				runs.push({
+					batchId: batch.batchId,
+					sessionId: batch.sessionId,
+					label: batch.label,
+					purpose: batch.purpose,
+					status: result.classification.status,
+					reason: result.classification.reason,
+					summaries: result.evaluation.counts.summaries,
+					observations: result.evaluation.counts.observations,
+					repairApplied: result.observer.repairApplied,
+				});
+			}
+			const summary = {
+				total: runs.length,
+				shapeQualityTotal: runs.filter((run) => run.purpose === "shape_quality").length,
+				shapeQualityPasses: runs.filter(
+					(run) => run.purpose === "shape_quality" && run.status === "pass",
+				).length,
+				shapeQualityFails: runs.filter(
+					(run) => run.purpose === "shape_quality" && run.status === "shape_fail",
+				).length,
+				robustnessNoOutput: runs.filter((run) => run.status === "observer_no_output").length,
+			};
+			const output = {
+				benchmark: {
+					id: benchmark.id,
+					title: benchmark.title,
+					scenarioId: benchmark.scenarioId,
+				},
+				observer: {
+					provider: observer.provider,
+					model: observer.model,
+					temperature: observer.temperature,
+					transcriptBudget: transcriptBudget ?? null,
+				},
+				summary,
+				runs,
+			};
+
+			if (opts.json) {
+				console.log(JSON.stringify(output, null, 2));
+				return;
+			}
+
+			p.intro("codemem memory extraction-benchmark");
+			p.log.info(
+				[
+					`Benchmark: ${benchmark.id} — ${benchmark.title}`,
+					`Observer: ${observer.provider}/${observer.model}`,
+					`Temperature: ${observer.temperature ?? "default"}`,
+					`Transcript budget override: ${transcriptBudget ?? "default"}`,
+					`Shape-quality passes: ${summary.shapeQualityPasses}/${summary.shapeQualityTotal}`,
+					`Shape-quality fails: ${summary.shapeQualityFails}`,
+					`Observer no-output cases: ${summary.robustnessNoOutput}`,
+				].join("\n"),
+			);
+			for (const run of runs) {
+				p.log.message(
+					`  [${run.batchId}] ${run.status.padEnd(18)} ${run.purpose.padEnd(18)} summaries=${run.summaries} observations=${run.observations} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
+				);
+			}
+			p.outro("done");
+		},
+	);
+	return cmd;
+}
+
 function createMemoryRelinkReportCommand(): Command {
 	const cmd = new Command("relink-report")
 		.configureHelp(helpStyle)
@@ -638,5 +991,8 @@ memoryCommand.addCommand(createRememberMemoryCommand());
 memoryCommand.addCommand(createInjectMemoryCommand());
 memoryCommand.addCommand(createMemoryRoleReportCommand());
 memoryCommand.addCommand(createMemoryRoleCompareCommand());
+memoryCommand.addCommand(createMemoryExtractionReportCommand());
+memoryCommand.addCommand(createMemoryExtractionReplayCommand());
+memoryCommand.addCommand(createMemoryExtractionBenchmarkCommand());
 memoryCommand.addCommand(createMemoryRelinkReportCommand());
 memoryCommand.addCommand(createMemoryRelinkPlanCommand());

--- a/packages/core/src/extraction-benchmarks.test.ts
+++ b/packages/core/src/extraction-benchmarks.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	getExtractionBenchmarkProfile,
+	listExtractionBenchmarkProfiles,
+} from "./extraction-benchmarks.js";
+
+describe("extraction benchmarks", () => {
+	it("exposes the rich-batch benchmark profile", () => {
+		const profile = getExtractionBenchmarkProfile("rich-batch-shape-v1");
+		expect(profile).not.toBeNull();
+		expect(profile?.scenarioId).toBe("rich-batch-shape");
+		expect(profile?.recommendedTruthModel).toEqual(
+			expect.objectContaining({ provider: "openai", model: "gpt-5.4" }),
+		);
+		expect(profile?.cheapCandidate).toEqual(
+			expect.objectContaining({
+				provider: "openai",
+				model: "gpt-5.4-mini",
+				temperature: 0.2,
+			}),
+		);
+		expect(profile?.batches).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ batchId: 18503, purpose: "shape_quality" }),
+				expect.objectContaining({ batchId: 18476, purpose: "replay_robustness" }),
+			]),
+		);
+	});
+
+	it("returns defensive copies from the benchmark listing", () => {
+		const profiles = listExtractionBenchmarkProfiles();
+		expect(profiles.length).toBeGreaterThan(0);
+		profiles[0]!.batches[0]!.label = "mutated";
+		const fresh = getExtractionBenchmarkProfile("rich-batch-shape-v1");
+		expect(fresh?.batches[0]?.label).not.toBe("mutated");
+	});
+});

--- a/packages/core/src/extraction-benchmarks.ts
+++ b/packages/core/src/extraction-benchmarks.ts
@@ -1,0 +1,111 @@
+export interface ExtractionBenchmarkBatch {
+	batchId: number;
+	sessionId: number;
+	label: string;
+	purpose: "shape_quality" | "replay_robustness";
+	notes: string;
+}
+
+export interface ExtractionBenchmarkProfile {
+	id: string;
+	title: string;
+	description: string;
+	scenarioId: string;
+	recommendedTruthModel: {
+		provider: string;
+		model: string;
+		notes: string;
+	};
+	cheapCandidate: {
+		provider: string;
+		model: string;
+		temperature: number;
+		notes: string;
+	};
+	batches: ExtractionBenchmarkBatch[];
+}
+
+const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
+	{
+		id: "rich-batch-shape-v1",
+		title: "Rich batch shape benchmark v1",
+		description:
+			"Benchmark set for comparing observer models on rich-batch extraction shape. Shape-quality batches are used for observation/summary output quality. Replay-robustness batches are tracked separately and should not be counted as shape failures when the observer returns no output.",
+		scenarioId: "rich-batch-shape",
+		recommendedTruthModel: {
+			provider: "openai",
+			model: "gpt-5.4",
+			notes:
+				"Current best-performing benchmark model across the rich-batch set; use as the acceptance baseline for cheaper candidates.",
+		},
+		cheapCandidate: {
+			provider: "openai",
+			model: "gpt-5.4-mini",
+			temperature: 0.2,
+			notes:
+				"Current cheapest promising candidate. It can pass some hard batches at temperature 0.2, but remains less reliable than full gpt-5.4.",
+		},
+		batches: [
+			{
+				batchId: 18503,
+				sessionId: 166405,
+				label: "Track 3 / release / qd7h under-extraction batch",
+				purpose: "shape_quality",
+				notes:
+					"Flagship hard case: historically under-extracted batch with multiple meaningful subthreads.",
+			},
+			{
+				batchId: 18502,
+				sessionId: 166405,
+				label: "Same session prelude rich batch",
+				purpose: "shape_quality",
+				notes:
+					"Useful adjacent batch from the same long session; helps avoid overfitting to 18503 alone.",
+			},
+			{
+				batchId: 18506,
+				sessionId: 166405,
+				label: "Same session later rich batch",
+				purpose: "shape_quality",
+				notes:
+					"Later large batch from the same session; currently passes on stronger models and validates generalization within the stream.",
+			},
+			{
+				batchId: 18432,
+				sessionId: 166392,
+				label: "Large snapshot batch with mixed success",
+				purpose: "shape_quality",
+				notes:
+					"High-volume snapshot batch used to compare budget and model sensitivity outside the Track 3 stream.",
+			},
+			{
+				batchId: 18446,
+				sessionId: 166392,
+				label: "Hard failing snapshot batch",
+				purpose: "shape_quality",
+				notes:
+					"Useful stubborn case: some models return summary-only or nothing; stronger models plus repair can recover it.",
+			},
+			{
+				batchId: 18476,
+				sessionId: 166405,
+				label: "Replay no-output robustness case",
+				purpose: "replay_robustness",
+				notes:
+					"Stored extraction passes shape, but replay may return no raw output at all. Track separately as observer/replay robustness, not shape quality.",
+			},
+		],
+	},
+];
+
+export function getExtractionBenchmarkProfile(id: string): ExtractionBenchmarkProfile | null {
+	const normalized = id.trim().toLowerCase();
+	return EXTRACTION_BENCHMARK_PROFILES.find((profile) => profile.id === normalized) ?? null;
+}
+
+export function listExtractionBenchmarkProfiles(): ExtractionBenchmarkProfile[] {
+	return EXTRACTION_BENCHMARK_PROFILES.map((profile) => ({
+		...profile,
+		batches: profile.batches.map((batch) => ({ ...batch })),
+	}));
+}

--- a/packages/core/src/extraction-eval.test.ts
+++ b/packages/core/src/extraction-eval.test.ts
@@ -1,0 +1,207 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import {
+	evaluateSessionExtractionItems,
+	getSessionExtractionEval,
+	getSessionExtractionEvalScenario,
+} from "./extraction-eval.js";
+import { initTestSchema } from "./test-utils.js";
+
+function createDbPath(name: string): string {
+	return `/tmp/codemem-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`;
+}
+
+describe("session extraction eval", () => {
+	it("exposes the rich-session under-extraction scenario", () => {
+		expect(getSessionExtractionEvalScenario("rich-session-under-extraction")?.title).toContain(
+			"Rich multi-thread session extraction coverage",
+		);
+	});
+
+	it("exposes the generic rich-batch shape scenario", () => {
+		expect(getSessionExtractionEvalScenario("rich-batch-shape")?.title).toContain(
+			"Rich batch output shape",
+		);
+	});
+
+	it("passes when summary and observations cover the major rich-session threads", () => {
+		const scenario = getSessionExtractionEvalScenario("rich-session-under-extraction");
+		if (!scenario) throw new Error("scenario missing");
+
+		const result = evaluateSessionExtractionItems(
+			{ type: "session", sessionId: 166405 },
+			{
+				id: 166405,
+				project: "codemem",
+				cwd: "/tmp/repo",
+				startedAt: "2026-04-06T21:23:59.631Z",
+				endedAt: "2026-04-07T06:13:45.667Z",
+				sessionClass: "durable",
+				summaryDisposition: "stored",
+			},
+			[
+				{
+					id: 1,
+					kind: "session_summary",
+					title: "Track 3 and release readiness session summary",
+					bodyText:
+						"Closed the qd7h regression investigation after confirming the root cause had already been identified. Prepared 0.23.0 release readiness and reframed Track 3 toward injection-first rediscovery reduction. Also discussed a graph and progressive disclosure direction for future retrieval work.",
+					active: true,
+					createdAt: "2026-04-07T06:13:45.667Z",
+					metadata: {},
+				},
+				{
+					id: 2,
+					kind: "decision",
+					title: "Track 3 reframed around injection-first quality",
+					bodyText:
+						"Track 3 now focuses on reducing rediscovery and scouting effort through injection-first memory quality.",
+					active: true,
+					createdAt: "2026-04-07T06:13:46.000Z",
+					metadata: {},
+				},
+				{
+					id: 3,
+					kind: "discovery",
+					title: "qd7h regression root cause already fixed",
+					bodyText:
+						"The micro-session regression timeline was narrowed and qd7h was closed once the existing root cause fix was confirmed.",
+					active: true,
+					createdAt: "2026-04-07T06:13:47.000Z",
+					metadata: {},
+				},
+				{
+					id: 4,
+					kind: "exploration",
+					title: "Graph relationship layer kept as future direction",
+					bodyText:
+						"Graph and progressive disclosure ideas were captured as a future relationship layer direction rather than a release blocker.",
+					active: true,
+					createdAt: "2026-04-07T06:13:48.000Z",
+					metadata: {},
+				},
+			],
+			scenario,
+		);
+
+		expect(result.pass).toBe(true);
+		expect(result.counts.summaries).toBe(1);
+		expect(result.counts.observations).toBe(3);
+		expect(result.coverage.summaryThreadCoverage).toBeGreaterThanOrEqual(2);
+		expect(result.coverage.observationThreadCoverage).toBeGreaterThanOrEqual(2);
+		expect(result.coverage.totalThreadCoverage).toBeGreaterThanOrEqual(3);
+	});
+
+	it("fails a narrow summary plus single-observation under-extraction case", () => {
+		const scenario = getSessionExtractionEvalScenario("rich-session-under-extraction");
+		if (!scenario) throw new Error("scenario missing");
+
+		const result = evaluateSessionExtractionItems(
+			{ type: "session", sessionId: 166405 },
+			{
+				id: 166405,
+				project: "codemem",
+				cwd: "/tmp/repo",
+				startedAt: "2026-04-06T21:23:59.631Z",
+				endedAt: "2026-04-07T06:13:45.667Z",
+				sessionClass: "durable",
+				summaryDisposition: "stored",
+			},
+			[
+				{
+					id: 1,
+					kind: "session_summary",
+					title: "Regression timeline summary",
+					bodyText:
+						"Investigated a regression timeline and narrowed the micro-session issue to raw-event sessionization changes.",
+					active: true,
+					createdAt: "2026-04-07T06:13:45.667Z",
+					metadata: {},
+				},
+				{
+					id: 2,
+					kind: "discovery",
+					title: "Micro-session regression timeline narrowed",
+					bodyText: "The regression timeline was narrowed to raw-event sessionization changes.",
+					active: true,
+					createdAt: "2026-04-07T06:13:46.000Z",
+					metadata: {},
+				},
+			],
+			scenario,
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.failureReasons).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("observation count 1 outside expected range 2-4"),
+				expect.stringContaining("summary thread coverage"),
+				expect.stringContaining("observation thread coverage"),
+			]),
+		);
+	});
+
+	it("loads and evaluates a session directly from the database", () => {
+		const dbPath = createDbPath("session-extraction-eval");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (166405, '2026-04-06T21:23:59.631Z', '2026-04-07T06:13:45.667Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"post":{"session_class":"durable","summary_disposition":"stored"}}');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+				) VALUES
+				  (1, 166405, 'session_summary', 'Track 3 and release readiness session summary', 'Closed qd7h, prepared 0.23.0, reframed Track 3 toward injection-first rediscovery reduction, and discussed graph progressive disclosure work.', 1, '2026-04-07T06:13:45.667Z', '2026-04-07T06:13:45.667Z', '{}', 'k1'),
+				  (2, 166405, 'decision', 'Track 3 reframed around injection-first quality', 'Track 3 now focuses on reducing rediscovery and scouting effort.', 1, '2026-04-07T06:13:46.000Z', '2026-04-07T06:13:46.000Z', '{}', 'k2'),
+				  (3, 166405, 'exploration', 'Graph relationship layer kept as future direction', 'Graph and progressive disclosure ideas were recorded as future work.', 1, '2026-04-07T06:13:47.000Z', '2026-04-07T06:13:47.000Z', '{}', 'k3');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const result = getSessionExtractionEval(dbPath, {
+			sessionId: 166405,
+			scenarioId: "rich-session-under-extraction",
+		});
+
+		expect(result.session.sessionClass).toBe("durable");
+		expect(result.counts.summaries).toBe(1);
+		expect(result.counts.observations).toBe(2);
+		expect(result.pass).toBe(true);
+	});
+
+	it("evaluates a flush batch using explicit batch metadata on extracted memories", () => {
+		const dbPath = createDbPath("batch-extraction-eval");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (166405, '2026-04-06T21:23:59.631Z', '2026-04-07T06:13:45.667Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"post":{"session_class":"durable","summary_disposition":"stored"}}');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'ses-1', 'ses-1', 166405, '2026-04-06T21:23:59.631Z');
+				INSERT INTO raw_event_flush_batches(id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq, extractor_version, status, attempt_count, created_at, updated_at) VALUES
+				  (18503, 'opencode', 'ses-1', 'ses-1', 1204, 1356, 'raw_events_v1', 'completed', 1, '2026-04-07T06:13:45.600Z', '2026-04-07T06:13:45.700Z');
+				INSERT INTO memory_items(
+					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
+				) VALUES
+				  (1, 166405, 'session_summary', 'Track 3 and release readiness session summary', 'Closed qd7h, prepared 0.23.0, reframed Track 3 toward injection-first rediscovery reduction, and discussed graph progressive disclosure work.', 1, '2026-04-07T06:13:45.650Z', '2026-04-07T06:13:45.650Z', '{"is_summary":true,"source":"observer_summary","flush_batch":{"batch_id":18503}}', 'k1'),
+				  (2, 166405, 'decision', 'Track 3 reframed around injection-first quality', 'Track 3 now focuses on reducing rediscovery and scouting effort.', 1, '2026-04-07T06:13:45.651Z', '2026-04-07T06:13:45.651Z', '{"source":"observer","flush_batch":{"batch_id":18503}}', 'k2'),
+				  (3, 166405, 'exploration', 'Graph relationship layer kept as future direction', 'Graph and progressive disclosure ideas were recorded as future work.', 1, '2026-04-07T06:13:45.652Z', '2026-04-07T06:13:45.652Z', '{"source":"observer","flush_batch":{"batch_id":18503}}', 'k3');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const result = getSessionExtractionEval(dbPath, {
+			batchId: 18503,
+			scenarioId: "rich-session-under-extraction",
+		});
+
+		expect(result.target).toEqual({ type: "batch", sessionId: 166405, batchId: 18503 });
+		expect(result.counts.summaries).toBe(1);
+		expect(result.counts.observations).toBe(2);
+		expect(result.pass).toBe(true);
+	});
+});

--- a/packages/core/src/extraction-eval.ts
+++ b/packages/core/src/extraction-eval.ts
@@ -1,0 +1,406 @@
+import { connect, resolveDbPath } from "./db.js";
+import { getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
+
+export interface SessionExtractionEvalThread {
+	id: string;
+	title: string;
+	keywords: string[];
+}
+
+export interface SessionExtractionEvalScenario {
+	id: string;
+	title: string;
+	description: string;
+	summaryCountRange: { min: number; max: number };
+	observationCountRange: { min: number; max: number };
+	minSummaryThreadCoverage: number;
+	minObservationThreadCoverage: number;
+	minTotalThreadCoverage: number;
+	threads: SessionExtractionEvalThread[];
+}
+
+export interface SessionExtractionEvalItem {
+	id: number;
+	kind: string;
+	title: string;
+	bodyText: string;
+	active: boolean;
+	createdAt: string;
+	metadata: unknown;
+}
+
+export interface SessionExtractionEvalThreadResult {
+	id: string;
+	title: string;
+	summaryMatch: boolean;
+	observationMatch: boolean;
+	matchedSummaryIds: number[];
+	matchedObservationIds: number[];
+}
+
+export interface SessionExtractionEvalResult {
+	scenario: {
+		id: string;
+		title: string;
+		description: string;
+	};
+	target: {
+		type: "session" | "batch";
+		sessionId: number;
+		batchId: number | null;
+	};
+	session: {
+		id: number;
+		project: string | null;
+		cwd: string;
+		startedAt: string;
+		endedAt: string | null;
+		sessionClass: string;
+		summaryDisposition: string;
+	};
+	counts: {
+		total: number;
+		summaries: number;
+		observations: number;
+	};
+	coverage: {
+		summaryThreadCoverage: number;
+		observationThreadCoverage: number;
+		totalThreadCoverage: number;
+		duplicateObservationThreads: number;
+	};
+	rangeChecks: {
+		summaryCountInRange: boolean;
+		observationCountInRange: boolean;
+	};
+	pass: boolean;
+	failureReasons: string[];
+	threads: SessionExtractionEvalThreadResult[];
+	items: Array<SessionExtractionEvalItem & { summaryLike: boolean }>;
+}
+
+type SessionExtractionEvalTarget =
+	| { type: "session"; sessionId: number }
+	| { type: "batch"; sessionId: number; batchId: number };
+
+const EXTRACTION_EVAL_SCENARIOS: SessionExtractionEvalScenario[] = [
+	{
+		id: "rich-batch-shape",
+		title: "Rich batch output shape",
+		description:
+			"Evaluates whether a rich batch yields one broad summary plus a small capped set of durable observations, without enforcing scenario-specific thread topics.",
+		summaryCountRange: { min: 1, max: 1 },
+		observationCountRange: { min: 2, max: 4 },
+		minSummaryThreadCoverage: 0,
+		minObservationThreadCoverage: 0,
+		minTotalThreadCoverage: 0,
+		threads: [],
+	},
+	{
+		id: "rich-session-under-extraction",
+		title: "Rich multi-thread session extraction coverage",
+		description:
+			"Evaluates whether a rich session yields one broad summary plus a small set of durable observations covering the major reusable subthreads.",
+		summaryCountRange: { min: 1, max: 1 },
+		observationCountRange: { min: 2, max: 4 },
+		minSummaryThreadCoverage: 2,
+		minObservationThreadCoverage: 2,
+		minTotalThreadCoverage: 3,
+		threads: [
+			{
+				id: "regression-closure",
+				title: "Regression investigation closure",
+				keywords: ["qd7h", "micro-session regression", "regression timeline", "root cause"],
+			},
+			{
+				id: "release-readiness",
+				title: "Release readiness for 0.23.0",
+				keywords: ["0.23.0", "release readiness", "release candidate", "prepare release"],
+			},
+			{
+				id: "track3-reframing",
+				title: "Track 3 reframing toward injection-first quality",
+				keywords: ["track 3", "injection-first", "rediscovery", "scouting effort"],
+			},
+			{
+				id: "graph-direction",
+				title: "Graph / progressive disclosure future direction",
+				keywords: ["graph", "progressive disclosure", "relationship layer", "silk-graph"],
+			},
+		],
+	},
+];
+
+function normalizeText(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function itemText(item: Pick<SessionExtractionEvalItem, "title" | "bodyText">): string {
+	return normalizeText(`${item.title}\n${item.bodyText}`);
+}
+
+function matchesThread(
+	item: Pick<SessionExtractionEvalItem, "title" | "bodyText">,
+	thread: SessionExtractionEvalThread,
+): boolean {
+	const text = itemText(item);
+	return thread.keywords.some((keyword) => text.includes(normalizeText(keyword)));
+}
+
+function buildFailureReasons(
+	scenario: SessionExtractionEvalScenario,
+	counts: SessionExtractionEvalResult["counts"],
+	coverage: SessionExtractionEvalResult["coverage"],
+	rangeChecks: SessionExtractionEvalResult["rangeChecks"],
+): string[] {
+	const failures: string[] = [];
+	if (!rangeChecks.summaryCountInRange) {
+		failures.push(
+			`summary count ${counts.summaries} outside expected range ${scenario.summaryCountRange.min}-${scenario.summaryCountRange.max}`,
+		);
+	}
+	if (!rangeChecks.observationCountInRange) {
+		failures.push(
+			`observation count ${counts.observations} outside expected range ${scenario.observationCountRange.min}-${scenario.observationCountRange.max}`,
+		);
+	}
+	if (coverage.summaryThreadCoverage < scenario.minSummaryThreadCoverage) {
+		failures.push(
+			`summary thread coverage ${coverage.summaryThreadCoverage} below required minimum ${scenario.minSummaryThreadCoverage}`,
+		);
+	}
+	if (coverage.observationThreadCoverage < scenario.minObservationThreadCoverage) {
+		failures.push(
+			`observation thread coverage ${coverage.observationThreadCoverage} below required minimum ${scenario.minObservationThreadCoverage}`,
+		);
+	}
+	if (coverage.totalThreadCoverage < scenario.minTotalThreadCoverage) {
+		failures.push(
+			`total thread coverage ${coverage.totalThreadCoverage} below required minimum ${scenario.minTotalThreadCoverage}`,
+		);
+	}
+	if (coverage.duplicateObservationThreads > 1) {
+		failures.push(
+			`duplicate observation thread matches ${coverage.duplicateObservationThreads} exceed tolerated maximum 1`,
+		);
+	}
+	return failures;
+}
+
+export function getSessionExtractionEvalScenario(id: string): SessionExtractionEvalScenario | null {
+	const normalized = normalizeText(id);
+	return EXTRACTION_EVAL_SCENARIOS.find((scenario) => scenario.id === normalized) ?? null;
+}
+
+export function evaluateSessionExtractionItems(
+	target: SessionExtractionEvalTarget,
+	session: SessionExtractionEvalResult["session"],
+	items: SessionExtractionEvalItem[],
+	scenario: SessionExtractionEvalScenario,
+): SessionExtractionEvalResult {
+	const decoratedItems = items.map((item) => ({
+		...item,
+		summaryLike: isSummaryLikeMemory({ kind: item.kind, metadata: item.metadata }),
+	}));
+	const summaryItems = decoratedItems.filter((item) => item.summaryLike);
+	const observationItems = decoratedItems.filter((item) => !item.summaryLike);
+	const threads = scenario.threads.map<SessionExtractionEvalThreadResult>((thread) => {
+		const matchedSummaryIds = summaryItems
+			.filter((item) => matchesThread(item, thread))
+			.map((item) => item.id);
+		const matchedObservationIds = observationItems
+			.filter((item) => matchesThread(item, thread))
+			.map((item) => item.id);
+		return {
+			id: thread.id,
+			title: thread.title,
+			summaryMatch: matchedSummaryIds.length > 0,
+			observationMatch: matchedObservationIds.length > 0,
+			matchedSummaryIds,
+			matchedObservationIds,
+		};
+	});
+	const counts = {
+		total: decoratedItems.length,
+		summaries: summaryItems.length,
+		observations: observationItems.length,
+	};
+	const coverage = {
+		summaryThreadCoverage: threads.filter((thread) => thread.summaryMatch).length,
+		observationThreadCoverage: threads.filter((thread) => thread.observationMatch).length,
+		totalThreadCoverage: threads.filter((thread) => thread.summaryMatch || thread.observationMatch)
+			.length,
+		duplicateObservationThreads: threads.reduce(
+			(sum, thread) => sum + Math.max(0, thread.matchedObservationIds.length - 1),
+			0,
+		),
+	};
+	const rangeChecks = {
+		summaryCountInRange:
+			counts.summaries >= scenario.summaryCountRange.min &&
+			counts.summaries <= scenario.summaryCountRange.max,
+		observationCountInRange:
+			counts.observations >= scenario.observationCountRange.min &&
+			counts.observations <= scenario.observationCountRange.max,
+	};
+	const failureReasons = buildFailureReasons(scenario, counts, coverage, rangeChecks);
+	return {
+		scenario: {
+			id: scenario.id,
+			title: scenario.title,
+			description: scenario.description,
+		},
+		target: {
+			type: target.type,
+			sessionId: target.sessionId,
+			batchId: target.type === "batch" ? target.batchId : null,
+		},
+		session,
+		counts,
+		coverage,
+		rangeChecks,
+		pass: failureReasons.length === 0,
+		failureReasons,
+		threads,
+		items: decoratedItems,
+	};
+}
+
+export function getSessionExtractionEval(
+	dbPath: string | undefined,
+	opts:
+		| { sessionId: number; scenarioId: string; includeInactive?: boolean; batchId?: never }
+		| { sessionId?: never; scenarioId: string; includeInactive?: boolean; batchId: number },
+): SessionExtractionEvalResult {
+	const scenario = getSessionExtractionEvalScenario(opts.scenarioId);
+	if (!scenario) {
+		throw new Error(`Unknown session extraction eval scenario: ${opts.scenarioId}`);
+	}
+	const db = connect(resolveDbPath(dbPath));
+	try {
+		const batchRow =
+			"batchId" in opts
+				? (db
+						.prepare(
+							`SELECT
+								b.id,
+								b.opencode_session_id,
+								b.created_at,
+								b.updated_at,
+								os.session_id
+							 FROM raw_event_flush_batches b
+							 LEFT JOIN opencode_sessions os
+							   ON os.source = b.source
+							  AND os.stream_id = b.stream_id
+							 WHERE b.id = ?`,
+						)
+						.get(opts.batchId) as
+						| {
+								id: number;
+								opencode_session_id: string;
+								created_at: string;
+								updated_at: string;
+								session_id: number | null;
+						  }
+						| undefined)
+				: undefined;
+		if ("batchId" in opts && !batchRow) {
+			throw new Error(`Flush batch ${opts.batchId} not found`);
+		}
+		const sessionId = "batchId" in opts ? batchRow?.session_id : opts.sessionId;
+		if (sessionId == null) {
+			throw new Error(
+				`Flush batch ${opts.batchId} is not linked to a local session and cannot be evaluated yet`,
+			);
+		}
+		const sessionRow = db
+			.prepare(
+				`SELECT id, project, cwd, started_at, ended_at, metadata_json
+				 FROM sessions
+				 WHERE id = ?`,
+			)
+			.get(sessionId) as
+			| {
+					id: number;
+					project: string | null;
+					cwd: string;
+					started_at: string;
+					ended_at: string | null;
+					metadata_json: string | null;
+			  }
+			| undefined;
+		if (!sessionRow) {
+			throw new Error(`Session ${sessionId} not found`);
+		}
+		const rows = (
+			"batchId" in opts
+				? db
+						.prepare(
+							`SELECT id, kind, title, body_text, active, created_at, metadata_json
+							 FROM memory_items
+							 WHERE session_id = ?
+							   AND (? = 1 OR active = 1)
+							   AND (
+							     json_extract(metadata_json, '$.flush_batch.batch_id') = ?
+							     OR created_at BETWEEN ? AND ?
+							   )
+							 ORDER BY created_at ASC, id ASC`,
+						)
+						.all(
+							sessionId,
+							opts.includeInactive === true ? 1 : 0,
+							opts.batchId,
+							batchRow?.created_at,
+							batchRow?.updated_at,
+						)
+				: db
+						.prepare(
+							`SELECT id, kind, title, body_text, active, created_at, metadata_json
+							 FROM memory_items
+							 WHERE session_id = ? AND (? = 1 OR active = 1)
+							 ORDER BY created_at ASC, id ASC`,
+						)
+						.all(sessionId, opts.includeInactive === true ? 1 : 0)
+		) as Array<{
+			id: number;
+			kind: string;
+			title: string;
+			body_text: string;
+			active: number;
+			created_at: string;
+			metadata_json: string | null;
+		}>;
+		const sessionMetadata = getSummaryMetadata(sessionRow.metadata_json);
+		const post =
+			sessionMetadata.post &&
+			typeof sessionMetadata.post === "object" &&
+			!Array.isArray(sessionMetadata.post)
+				? (sessionMetadata.post as Record<string, unknown>)
+				: {};
+		const session = {
+			id: sessionRow.id,
+			project: sessionRow.project,
+			cwd: sessionRow.cwd,
+			startedAt: sessionRow.started_at,
+			endedAt: sessionRow.ended_at,
+			sessionClass: String(post.session_class ?? "unknown"),
+			summaryDisposition: String(post.summary_disposition ?? "unknown"),
+		};
+		const items = rows.map<SessionExtractionEvalItem>((row) => ({
+			id: row.id,
+			kind: row.kind,
+			title: row.title,
+			bodyText: row.body_text,
+			active: row.active === 1,
+			createdAt: row.created_at,
+			metadata: row.metadata_json,
+		}));
+		const target: SessionExtractionEvalTarget =
+			"batchId" in opts && typeof opts.batchId === "number"
+				? { type: "batch", sessionId, batchId: opts.batchId }
+				: { type: "session", sessionId };
+		return evaluateSessionExtractionItems(target, session, items, scenario);
+	} finally {
+		db.close();
+	}
+}

--- a/packages/core/src/extraction-replay.test.ts
+++ b/packages/core/src/extraction-replay.test.ts
@@ -1,0 +1,174 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { replayBatchExtraction } from "./extraction-replay.js";
+import { initTestSchema } from "./test-utils.js";
+
+function createDbPath(name: string): string {
+	return `/tmp/codemem-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`;
+}
+
+describe("extraction replay", () => {
+	it("replays a historical batch through the current observer prompt without persisting", async () => {
+		const dbPath = createDbPath("extraction-replay");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (166405, '2026-04-06T21:23:59.631Z', '2026-04-07T06:13:45.667Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"post":{"session_class":"durable","summary_disposition":"stored"}}');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'ses-1', 'ses-1', 166405, '2026-04-06T21:23:59.631Z');
+				INSERT INTO raw_event_flush_batches(id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq, extractor_version, status, attempt_count, created_at, updated_at) VALUES
+				  (18503, 'opencode', 'ses-1', 'ses-1', 1204, 1356, 'raw_events_v1', 'completed', 1, '2026-04-07T06:13:45.600Z', '2026-04-07T06:13:45.700Z');
+				INSERT INTO raw_events(id, source, stream_id, opencode_session_id, event_id, event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at) VALUES
+				  (1, 'opencode', 'ses-1', 'ses-1', 'evt-1', 1204, 'user_prompt', 1000, 1, '{"type":"user_prompt","prompt_text":"Investigate qd7h, prep 0.23.0, and reframe Track 3 around injection-first quality"}', '2026-04-07T06:13:45.600Z'),
+				  (2, 'opencode', 'ses-1', 'ses-1', 'evt-2', 1205, 'assistant_message', 1010, 2, '{"type":"assistant_message","assistant_text":"We should close qd7h, cover release readiness, and capture graph future direction."}', '2026-04-07T06:13:45.610Z'),
+				  (3, 'opencode', 'ses-1', 'ses-1', 'evt-3', 1206, 'tool.execute.after', 1020, 3, '{"type":"tool.execute.after","tool":"read","args":{"filePath":"docs/plans/2026-04-07-track-3-injection-first-memory-policy.md"},"output":"ok"}', '2026-04-07T06:13:45.620Z');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const observer = {
+			observe: async () => {
+				callCount += 1;
+				if (callCount === 1) {
+					return {
+						raw: `<summary>
+						  <request>Investigate qd7h, prep 0.23.0, and reframe Track 3 around injection-first quality.</request>
+						  <investigated>Reviewed the policy plan and discussed qd7h closure, release readiness, and graph future direction.</investigated>
+						  <learned>qd7h could be closed and Track 3 needed reframing.</learned>
+						  <completed>Started the investigation and captured a broad summary only.</completed>
+						  <next_steps>Add durable observations for the missing subthreads.</next_steps>
+						  <notes>This intentionally under-extracts to trigger the repair pass.</notes>
+						  <files_read><file>docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read>
+						  <files_modified></files_modified>
+						</summary>`,
+						parsed: null,
+						provider: "test",
+						model: "test-model",
+					};
+				}
+				return {
+					raw: `<observation>
+				  <type>decision</type>
+				  <title>Track 3 reframed around injection-first quality for 0.23.0 release readiness</title>
+				  <subtitle>Track 3 now targets rediscovery reduction.</subtitle>
+				  <facts><fact>Track 3 was reframed around injection-first quality and rediscovery reduction for 0.23.0 release readiness.</fact></facts>
+				  <narrative>Track 3 was reframed to focus on injection-first quality while 0.23.0 release readiness was discussed as a near-term product pressure.</narrative>
+				  <concepts><concept>decision</concept></concepts>
+				  <files_read><file>docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read>
+				  <files_modified></files_modified>
+				</observation>
+				<observation>
+				  <type>exploration</type>
+				  <title>qd7h closure and graph direction captured as future work</title>
+				  <subtitle>Graph relationship retrieval stayed exploratory.</subtitle>
+				  <facts><fact>qd7h was closed after the root cause had already been identified, and graph progressive disclosure remained future-direction work.</fact></facts>
+				  <narrative>Graph and progressive disclosure ideas were captured as future work while qd7h closure confirmed the regression thread could be wrapped up.</narrative>
+				  <concepts><concept>exploration</concept></concepts>
+				  <files_read></files_read>
+				  <files_modified></files_modified>
+				</observation>
+				<summary>
+				  <request>Investigate qd7h, prep 0.23.0, and reframe Track 3 around injection-first quality.</request>
+				  <investigated>Reviewed the policy plan and discussed qd7h closure, release readiness, and graph future direction.</investigated>
+				  <learned>qd7h could be closed, 0.23.0 readiness mattered, and graph work should remain future-facing.</learned>
+				  <completed>Reframed Track 3 around injection-first quality and captured graph direction as future work.</completed>
+				  <next_steps>Continue quality tuning and finish release readiness.</next_steps>
+				  <notes>Keep the summary broad across the major subthreads.</notes>
+				  <files_read><file>docs/plans/2026-04-07-track-3-injection-first-memory-policy.md</file></files_read>
+				  <files_modified></files_modified>
+				</summary>`,
+					parsed: null,
+					provider: "test",
+					model: "test-model",
+				};
+			},
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		} as any;
+		let callCount = 0;
+
+		const result = await replayBatchExtraction(dbPath, observer, {
+			batchId: 18503,
+			scenarioId: "rich-session-under-extraction",
+		});
+
+		expect(result.target).toEqual({ batchId: 18503, sessionId: 166405 });
+		expect(result.classification.status).toBe("pass");
+		expect(result.evaluation.target).toEqual({ type: "batch", sessionId: 166405, batchId: 18503 });
+		expect(result.evaluation.counts.summaries).toBe(1);
+		expect(result.evaluation.counts.observations).toBe(2);
+		expect(result.observer.provider).toBe("test");
+		expect(result.observer.repairApplied).toBe(true);
+		expect(callCount).toBe(2);
+		expect(result.observerContext.userPrompt).toContain("Track 3");
+		expect(result.evaluation.coverage.totalThreadCoverage).toBeGreaterThanOrEqual(3);
+		expect(result.evaluation.pass).toBe(true);
+	});
+
+	it("ignores replay observations with unsupported memory kinds", async () => {
+		const dbPath = createDbPath("extraction-replay-invalid-kind");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.exec(`
+				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version, metadata_json) VALUES
+				  (200001, '2026-04-06T21:23:59.631Z', '2026-04-07T06:13:45.667Z', '/tmp/repo', 'codemem', 'adam', 'test', '{"post":{"session_class":"durable","summary_disposition":"stored"}}');
+				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+				  ('opencode', 'ses-2', 'ses-2', 200001, '2026-04-06T21:23:59.631Z');
+				INSERT INTO raw_event_flush_batches(id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq, extractor_version, status, attempt_count, created_at, updated_at) VALUES
+				  (19001, 'opencode', 'ses-2', 'ses-2', 1, 20, 'raw_events_v1', 'completed', 1, '2026-04-07T06:13:45.600Z', '2026-04-07T06:13:45.700Z');
+				INSERT INTO raw_events(id, source, stream_id, opencode_session_id, event_id, event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, created_at) VALUES
+				  (1, 'opencode', 'ses-2', 'ses-2', 'evt-1', 1, 'user_prompt', 1000, 1, '{"type":"user_prompt","prompt_text":"Summarize a rich session"}', '2026-04-07T06:13:45.600Z');
+			`);
+		} finally {
+			db.close();
+		}
+
+		const observer = {
+			observe: async () => ({
+				raw: `<observation>
+				  <type>foo</type>
+				  <title>Unsupported observation kind</title>
+				  <subtitle>Should be discarded.</subtitle>
+				  <facts><fact>Not a valid stored kind.</fact></facts>
+				  <narrative>This should never count toward replay observation totals.</narrative>
+				  <concepts><concept>invalid</concept></concepts>
+				  <files_read></files_read>
+				  <files_modified></files_modified>
+				</observation>
+				<summary>
+				  <request>Summarize a rich session.</request>
+				  <completed>Returned an invalid observation kind.</completed>
+				  <notes>This should still count only as a summary.</notes>
+				  <files_read></files_read>
+				  <files_modified></files_modified>
+				</summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		} as any;
+
+		const result = await replayBatchExtraction(dbPath, observer, {
+			batchId: 19001,
+			scenarioId: "rich-batch-shape",
+		});
+
+		expect(result.evaluation.counts.summaries).toBe(1);
+		expect(result.evaluation.counts.observations).toBe(0);
+		expect(result.classification.status).toBe("shape_fail");
+	});
+});

--- a/packages/core/src/extraction-replay.ts
+++ b/packages/core/src/extraction-replay.ts
@@ -1,0 +1,581 @@
+import { connect, resolveDbPath } from "./db.js";
+import {
+	evaluateSessionExtractionItems,
+	getSessionExtractionEvalScenario,
+} from "./extraction-eval.js";
+import {
+	budgetToolEvents,
+	eventToToolEvent,
+	extractAdapterEvent,
+	extractToolEvents,
+	projectAdapterToolEvent,
+} from "./ingest-events.js";
+import { isLowSignalObservation } from "./ingest-filters.js";
+import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
+import {
+	buildTranscript,
+	deriveRequest,
+	extractAssistantMessages,
+	extractPrompts,
+	firstSentence,
+	isTrivialRequest,
+	normalizeAdapterEvents,
+} from "./ingest-transcript.js";
+import type {
+	ObserverContext,
+	ParsedOutput,
+	ParsedSummary,
+	SessionContext,
+	ToolEvent,
+} from "./ingest-types.js";
+import { parseObserverResponse } from "./ingest-xml-parser.js";
+import type { ObserverClient } from "./observer-client.js";
+import { resolveProject } from "./project.js";
+import { buildSessionContext } from "./raw-event-flush.js";
+
+const ALLOWED_KINDS = new Set([
+	"bugfix",
+	"feature",
+	"refactor",
+	"change",
+	"discovery",
+	"decision",
+	"exploration",
+]);
+
+function normalizePath(path: string, repoRoot: string | null): string {
+	if (!path) return "";
+	const cleaned = path.trim();
+	if (!repoRoot) return cleaned;
+	const root = repoRoot.replace(/\/+$/, "");
+	if (cleaned === root) return ".";
+	if (cleaned.startsWith(`${root}/`)) return cleaned.slice(root.length + 1);
+	return cleaned;
+}
+
+function normalizePaths(paths: string[], repoRoot: string | null): string[] {
+	return paths.map((p) => normalizePath(p, repoRoot)).filter(Boolean);
+}
+
+function summaryBody(summary: ParsedSummary): string {
+	const sections: [string, string][] = [
+		["Request", summary.request],
+		["Completed", summary.completed],
+		["Learned", summary.learned],
+		["Investigated", summary.investigated],
+		["Next steps", summary.nextSteps],
+		["Notes", summary.notes],
+	];
+	return sections
+		.filter(([, value]) => value)
+		.map(([label, value]) => `## ${label}\n${value}`)
+		.join("\n\n");
+}
+
+function normalizeEventsForToolExtraction(
+	events: Record<string, unknown>[],
+	maxChars: number,
+): ToolEvent[] {
+	const toolEvents: ToolEvent[] = [];
+	for (const event of events) {
+		const adapter = extractAdapterEvent(event);
+		if (adapter) {
+			if (adapter.event_type === "tool_call") continue;
+			const projected = projectAdapterToolEvent(adapter, event);
+			if (projected) {
+				const te = eventToToolEvent(projected, maxChars);
+				if (te) {
+					toolEvents.push(te);
+					continue;
+				}
+			}
+		}
+		toolEvents.push(...extractToolEvents([event], maxChars));
+	}
+	return toolEvents;
+}
+
+async function observeStructuredOutput(
+	observer: ObserverClient,
+	system: string,
+	user: string,
+): Promise<{ raw: string | null; parsed: ParsedOutput; provider: string; model: string }> {
+	const first = await observer.observe(system, user);
+	const firstParsed = first.raw
+		? parseObserverResponse(first.raw)
+		: { observations: [], summary: null, skipSummaryReason: null };
+	if (
+		!first.raw ||
+		firstParsed.observations.length > 0 ||
+		firstParsed.summary !== null ||
+		firstParsed.skipSummaryReason !== null
+	) {
+		return {
+			raw: first.raw,
+			parsed: firstParsed,
+			provider: first.provider,
+			model: first.model,
+		};
+	}
+
+	const repairSystem = `${system}\n\nYour previous reply was invalid because it did not follow the required XML-only schema. Rewrite the same analysis as valid XML only. Do not include prose outside XML.`;
+	const repairUser = `${user}\n\nPrevious invalid response to rewrite as valid XML:\n${first.raw}`;
+	const repaired = await observer.observe(repairSystem, repairUser);
+	const repairedParsed = repaired.raw
+		? parseObserverResponse(repaired.raw)
+		: { observations: [], summary: null, skipSummaryReason: null };
+	return {
+		raw: repaired.raw,
+		parsed: repairedParsed,
+		provider: repaired.provider,
+		model: repaired.model,
+	};
+}
+
+export interface ExtractionReplayResult {
+	scenario: { id: string; title: string; description: string };
+	target: { batchId: number; sessionId: number };
+	classification: {
+		status: "pass" | "shape_fail" | "observer_no_output";
+		reason: string;
+	};
+	session: {
+		id: number;
+		project: string | null;
+		cwd: string;
+		startedAt: string;
+		endedAt: string | null;
+		sessionClass: string;
+		summaryDisposition: string;
+	};
+	observer: {
+		provider: string;
+		model: string;
+		repairApplied: boolean;
+		initialRaw: string | null;
+		raw: string | null;
+		parsed: ParsedOutput;
+	};
+	observerContext: ObserverContext;
+	evaluation: ReturnType<typeof evaluateSessionExtractionItems>;
+}
+
+function classifyReplayResult(input: {
+	raw: string | null;
+	evaluation: ReturnType<typeof evaluateSessionExtractionItems>;
+}): ExtractionReplayResult["classification"] {
+	if (!input.raw) {
+		return {
+			status: "observer_no_output",
+			reason: "observer returned no raw output",
+		};
+	}
+	if (input.evaluation.pass) {
+		return {
+			status: "pass",
+			reason: "fresh replay output satisfies the extraction rubric",
+		};
+	}
+	return {
+		status: "shape_fail",
+		reason:
+			input.evaluation.failureReasons[0] ?? "fresh replay output failed the extraction rubric",
+	};
+}
+
+function isRichReplayCandidate(
+	observerContext: ObserverContext,
+	sessionContext: SessionContext,
+	scenarioThreadCount: number,
+): boolean {
+	const transcriptLength = observerContext.transcript.trim().length;
+	return (
+		(sessionContext.promptCount ?? 0) >= 2 ||
+		(sessionContext.toolCount ?? 0) >= 3 ||
+		transcriptLength >= 1500 ||
+		scenarioThreadCount >= 3
+	);
+}
+
+function buildReplayItems(
+	parsed: ParsedOutput,
+	batch: {
+		cwd: string | null;
+		updated_at: string;
+		started_at: string | null;
+	},
+	sessionContext: SessionContext,
+): Array<{
+	id: number;
+	kind: string;
+	title: string;
+	bodyText: string;
+	active: boolean;
+	createdAt: string;
+	metadata: unknown;
+}> {
+	const replayItems = [] as Array<{
+		id: number;
+		kind: string;
+		title: string;
+		bodyText: string;
+		active: boolean;
+		createdAt: string;
+		metadata: unknown;
+	}>;
+	let syntheticId = 1;
+	for (const obs of parsed.observations) {
+		const kind = obs.kind.trim().toLowerCase();
+		if (!kind || (!obs.title && !obs.narrative)) continue;
+		if (!ALLOWED_KINDS.has(kind)) continue;
+		if (isLowSignalObservation(obs.title) || isLowSignalObservation(obs.narrative)) continue;
+		const bodyParts: string[] = [];
+		if (obs.narrative) bodyParts.push(obs.narrative);
+		if (obs.facts.length > 0) bodyParts.push(obs.facts.map((f) => `- ${f}`).join("\n"));
+		replayItems.push({
+			id: syntheticId++,
+			kind,
+			title: obs.title || obs.narrative,
+			bodyText: bodyParts.join("\n\n"),
+			active: true,
+			createdAt: batch.updated_at ?? batch.started_at ?? new Date().toISOString(),
+			metadata: {
+				source: "observer",
+				files_read: normalizePaths(obs.filesRead, batch.cwd),
+				files_modified: normalizePaths(obs.filesModified, batch.cwd),
+				flush_batch: sessionContext.flushBatch,
+			},
+		});
+	}
+	if (parsed.summary && !parsed.skipSummaryReason) {
+		const summary = parsed.summary;
+		summary.filesRead = normalizePaths(summary.filesRead, batch.cwd);
+		summary.filesModified = normalizePaths(summary.filesModified, batch.cwd);
+		let request = summary.request;
+		if (isTrivialRequest(request)) {
+			const derived = deriveRequest(summary);
+			if (derived) request = derived;
+		}
+		const body = summaryBody(summary);
+		if (body && !isLowSignalObservation(firstSentence(body))) {
+			replayItems.push({
+				id: syntheticId++,
+				kind: "session_summary",
+				title: request || "Session summary",
+				bodyText: body,
+				active: true,
+				createdAt: batch.updated_at ?? batch.started_at ?? new Date().toISOString(),
+				metadata: {
+					is_summary: true,
+					source: "observer_summary",
+					flush_batch: sessionContext.flushBatch,
+				},
+			});
+		}
+	}
+	return replayItems;
+}
+
+function needsRichSessionRepair(
+	evaluation: ReturnType<typeof evaluateSessionExtractionItems>,
+	observerContext: ObserverContext,
+	sessionContext: SessionContext,
+): boolean {
+	if (!isRichReplayCandidate(observerContext, sessionContext, evaluation.threads.length))
+		return false;
+	if (evaluation.counts.observations === 0 && evaluation.counts.summaries >= 1) return true;
+	return evaluation.counts.observations < 2;
+}
+
+async function observeRichSessionRepair(
+	observer: ObserverClient,
+	baseSystem: string,
+	baseUser: string,
+	initialRaw: string,
+	evaluation: ReturnType<typeof evaluateSessionExtractionItems>,
+): Promise<{ raw: string | null; parsed: ParsedOutput; provider: string; model: string }> {
+	const missingThreads = evaluation.threads
+		.filter((thread) => !thread.observationMatch)
+		.map((thread) => thread.title);
+	const repairSystem = `${baseSystem}
+
+RICH-SESSION REPAIR REQUIREMENT:
+- The previous output under-extracted a rich batch.
+- For a rich session, summary-only output is not acceptable when multiple durable subthreads are present.
+- Return valid XML with one broad <summary> plus at least 2 durable <observation> blocks covering DISTINCT subthreads.
+- Do not repeat the same dominant thread in multiple observations.
+- Choose observations for reusable decisions, learnings, troubleshooting outcomes, or future-facing exploration that would reduce rediscovery in later sessions.`;
+	const repairUser = `${baseUser}
+
+Previous under-extracted XML to repair:
+${initialRaw}
+
+The previous output failed because:
+- observations returned: ${evaluation.counts.observations}
+- total thread coverage: ${evaluation.coverage.totalThreadCoverage}
+- missing observation coverage for: ${missingThreads.length > 0 ? missingThreads.join(", ") : "none recorded"}
+
+Rewrite the analysis as valid XML only.
+Keep the broad summary, but add 2-4 durable observations for distinct subthreads if the transcript supports them.`;
+	return observeStructuredOutput(observer, repairSystem, repairUser);
+}
+
+export async function replayBatchExtraction(
+	dbPath: string | undefined,
+	observer: ObserverClient,
+	opts: {
+		batchId: number;
+		scenarioId: string;
+		maxChars?: number;
+		observerMaxChars?: number;
+		transcriptBudget?: number;
+	},
+): Promise<ExtractionReplayResult> {
+	const scenario = getSessionExtractionEvalScenario(opts.scenarioId);
+	if (!scenario) throw new Error(`Unknown extraction eval scenario: ${opts.scenarioId}`);
+
+	const db = connect(resolveDbPath(dbPath));
+	try {
+		const batch = db
+			.prepare(
+				`SELECT
+					b.id,
+					b.source,
+					b.stream_id,
+					b.opencode_session_id,
+					b.start_event_seq,
+					b.end_event_seq,
+					b.updated_at,
+					os.session_id,
+					s.cwd,
+					s.project,
+					s.started_at,
+					s.ended_at,
+					s.metadata_json
+				 FROM raw_event_flush_batches b
+				 LEFT JOIN opencode_sessions os
+				   ON os.source = b.source AND os.stream_id = b.stream_id
+				 LEFT JOIN sessions s ON s.id = os.session_id
+				 WHERE b.id = ?`,
+			)
+			.get(opts.batchId) as
+			| {
+					id: number;
+					source: string;
+					stream_id: string;
+					opencode_session_id: string;
+					start_event_seq: number;
+					end_event_seq: number;
+					updated_at: string;
+					session_id: number | null;
+					cwd: string | null;
+					project: string | null;
+					started_at: string | null;
+					ended_at: string | null;
+					metadata_json: string | null;
+			  }
+			| undefined;
+		if (!batch) throw new Error(`Flush batch ${opts.batchId} not found`);
+		if (batch.session_id == null) {
+			throw new Error(`Flush batch ${opts.batchId} is not linked to a local session`);
+		}
+
+		const rawRows = db
+			.prepare(
+				`SELECT event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, event_id
+				 FROM raw_events
+				 WHERE source = ?
+				   AND stream_id = ?
+				   AND event_seq >= ?
+				   AND event_seq <= ?
+				 ORDER BY event_seq ASC`,
+			)
+			.all(batch.source, batch.stream_id, batch.start_event_seq, batch.end_event_seq) as Array<{
+			event_seq: number;
+			event_type: string;
+			ts_wall_ms: number | null;
+			ts_mono_ms: number | null;
+			payload_json: string;
+			event_id: string | null;
+		}>;
+		const events = rawRows.map<Record<string, unknown>>((row) => {
+			const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
+			payload.type = payload.type || row.event_type;
+			payload.timestamp_wall_ms = row.ts_wall_ms;
+			payload.timestamp_mono_ms = row.ts_mono_ms;
+			payload.event_seq = row.event_seq;
+			payload.event_id = row.event_id;
+			return payload;
+		});
+		if (events.length === 0) {
+			throw new Error(`Flush batch ${opts.batchId} has no raw events in range`);
+		}
+
+		const sessionContext: SessionContext = buildSessionContext(events);
+		sessionContext.opencodeSessionId = batch.opencode_session_id;
+		sessionContext.source = batch.source;
+		sessionContext.streamId = batch.stream_id;
+		sessionContext.flusher = "raw_events";
+		sessionContext.flushBatch = {
+			batch_id: batch.id,
+			start_event_seq: batch.start_event_seq,
+			end_event_seq: batch.end_event_seq,
+		};
+
+		const maxChars = opts.maxChars ?? 12_000;
+		const observerMaxChars = opts.observerMaxChars ?? observer.maxChars;
+		const normalizedEvents = normalizeAdapterEvents(events);
+		const prompts = extractPrompts(normalizedEvents);
+		const promptNumber =
+			prompts.length > 0 ? (prompts[prompts.length - 1]?.promptNumber ?? prompts.length) : null;
+		let toolEvents = normalizeEventsForToolExtraction(events, maxChars);
+		const toolBudget = Math.max(2000, Math.min(8000, observerMaxChars - 5000));
+		toolEvents = budgetToolEvents(toolEvents, toolBudget, 30);
+		const assistantMessages = extractAssistantMessages(normalizedEvents);
+		const lastAssistantMessage = assistantMessages.at(-1) ?? null;
+		const latestPrompt =
+			sessionContext.firstPrompt ??
+			(prompts.length > 0 ? prompts[prompts.length - 1]?.promptText : null) ??
+			null;
+
+		let shouldProcess =
+			toolEvents.length > 0 || Boolean(latestPrompt) || Boolean(lastAssistantMessage);
+		if (
+			latestPrompt &&
+			isTrivialRequest(latestPrompt) &&
+			toolEvents.length === 0 &&
+			!lastAssistantMessage
+		) {
+			shouldProcess = false;
+		}
+		if (!shouldProcess) {
+			throw new Error(`Flush batch ${opts.batchId} has no meaningful observer input to replay`);
+		}
+
+		const transcript = buildTranscript(normalizedEvents);
+		const sessionSummaryParts: string[] = [];
+		if ((sessionContext.promptCount ?? 0) > 1) {
+			sessionSummaryParts.push(`Session had ${sessionContext.promptCount} prompts`);
+		}
+		if ((sessionContext.toolCount ?? 0) > 0) {
+			sessionSummaryParts.push(`${sessionContext.toolCount} tool executions`);
+		}
+		if ((sessionContext.durationMs ?? 0) > 0) {
+			const durationMin = (sessionContext.durationMs ?? 0) / 60000;
+			sessionSummaryParts.push(`~${durationMin.toFixed(1)} minutes of work`);
+		}
+		if (sessionContext.filesModified?.length) {
+			sessionSummaryParts.push(`Modified: ${sessionContext.filesModified.slice(0, 5).join(", ")}`);
+		}
+		if (sessionContext.filesRead?.length) {
+			sessionSummaryParts.push(`Read: ${sessionContext.filesRead.slice(0, 5).join(", ")}`);
+		}
+		const sessionInfoText = sessionSummaryParts.join("; ");
+		let observerPrompt = latestPrompt ?? "";
+		if (sessionInfoText) {
+			observerPrompt = observerPrompt
+				? `${observerPrompt}\n\n[Session context: ${sessionInfoText}]`
+				: `[Session context: ${sessionInfoText}]`;
+		}
+		const transcriptBudget =
+			opts.transcriptBudget ?? Math.max(1500, Math.min(5000, Math.floor(observerMaxChars * 0.4)));
+		const observerContext: ObserverContext = {
+			project: batch.project ?? resolveProject(batch.cwd ?? process.cwd()) ?? null,
+			userPrompt: observerPrompt,
+			promptNumber,
+			transcript: truncateObserverTranscript(transcript, transcriptBudget),
+			toolEvents,
+			lastAssistantMessage,
+			includeSummary: true,
+			diffSummary: "",
+			recentFiles: "",
+		};
+		const { system, user } = buildObserverPrompt(observerContext);
+		const initialResponse = await observeStructuredOutput(observer, system, user);
+		let finalResponse = initialResponse;
+		let replayItems = buildReplayItems(finalResponse.parsed, batch, sessionContext);
+
+		const sessionMeta = (() => {
+			try {
+				return batch.metadata_json
+					? (JSON.parse(batch.metadata_json) as Record<string, unknown>)
+					: {};
+			} catch {
+				return {};
+			}
+		})();
+		const post =
+			sessionMeta.post && typeof sessionMeta.post === "object" && !Array.isArray(sessionMeta.post)
+				? (sessionMeta.post as Record<string, unknown>)
+				: {};
+		let evaluation = evaluateSessionExtractionItems(
+			{ type: "batch", sessionId: batch.session_id, batchId: batch.id },
+			{
+				id: batch.session_id,
+				project: batch.project,
+				cwd: batch.cwd ?? process.cwd(),
+				startedAt: batch.started_at ?? "",
+				endedAt: batch.ended_at,
+				sessionClass: String(post.session_class ?? "unknown"),
+				summaryDisposition: String(post.summary_disposition ?? "unknown"),
+			},
+			replayItems,
+			scenario,
+		);
+		let repairApplied = false;
+		if (
+			initialResponse.raw &&
+			needsRichSessionRepair(evaluation, observerContext, sessionContext)
+		) {
+			repairApplied = true;
+			finalResponse = await observeRichSessionRepair(
+				observer,
+				system,
+				user,
+				initialResponse.raw,
+				evaluation,
+			);
+			replayItems = buildReplayItems(finalResponse.parsed, batch, sessionContext);
+			evaluation = evaluateSessionExtractionItems(
+				{ type: "batch", sessionId: batch.session_id, batchId: batch.id },
+				{
+					id: batch.session_id,
+					project: batch.project,
+					cwd: batch.cwd ?? process.cwd(),
+					startedAt: batch.started_at ?? "",
+					endedAt: batch.ended_at,
+					sessionClass: String(post.session_class ?? "unknown"),
+					summaryDisposition: String(post.summary_disposition ?? "unknown"),
+				},
+				replayItems,
+				scenario,
+			);
+		}
+
+		return {
+			scenario: {
+				id: scenario.id,
+				title: scenario.title,
+				description: scenario.description,
+			},
+			target: { batchId: batch.id, sessionId: batch.session_id },
+			classification: classifyReplayResult({
+				raw: finalResponse.raw,
+				evaluation,
+			}),
+			session: evaluation.session,
+			observer: {
+				provider: finalResponse.provider,
+				model: finalResponse.model,
+				repairApplied,
+				initialRaw: initialResponse.raw,
+				raw: finalResponse.raw,
+				parsed: finalResponse.parsed,
+			},
+			observerContext,
+			evaluation,
+		};
+	} finally {
+		db.close();
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,6 +125,28 @@ export {
 	mergeSummaryMetadata,
 	readImportPayload,
 } from "./export-import.js";
+export type {
+	ExtractionBenchmarkBatch,
+	ExtractionBenchmarkProfile,
+} from "./extraction-benchmarks.js";
+export {
+	getExtractionBenchmarkProfile,
+	listExtractionBenchmarkProfiles,
+} from "./extraction-benchmarks.js";
+export type {
+	SessionExtractionEvalItem,
+	SessionExtractionEvalResult,
+	SessionExtractionEvalScenario,
+	SessionExtractionEvalThread,
+	SessionExtractionEvalThreadResult,
+} from "./extraction-eval.js";
+export {
+	evaluateSessionExtractionItems,
+	getSessionExtractionEval,
+	getSessionExtractionEvalScenario,
+} from "./extraction-eval.js";
+export type { ExtractionReplayResult } from "./extraction-replay.js";
+export { replayBatchExtraction } from "./extraction-replay.js";
 export { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
 // Ingest pipeline
 export {

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -499,6 +499,10 @@ export async function ingest(
 		}
 
 		const vectorWriteInputs: Array<{ memoryId: number; title: string; bodyText: string }> = [];
+		const flushBatchMetadata =
+			sessionContext.flushBatch && typeof sessionContext.flushBatch === "object"
+				? sessionContext.flushBatch
+				: null;
 
 		// Persist all observations, summary, and usage atomically
 		store.db.transaction(() => {
@@ -531,6 +535,7 @@ export async function ingest(
 					files_modified: obs.filesModified,
 					prompt_number: promptNumber,
 					source: "observer",
+					flush_batch: flushBatchMetadata,
 				});
 				vectorWriteInputs.push({ memoryId, title: memoryTitle, bodyText });
 			}
@@ -567,6 +572,7 @@ export async function ingest(
 						files_read: summary.filesRead,
 						files_modified: summary.filesModified,
 						source: "observer_summary",
+						flush_batch: flushBatchMetadata,
 					},
 				);
 				vectorWriteInputs.push({ memoryId, title: summaryTitle, bodyText: body });

--- a/packages/core/src/ingest-prompts.test.ts
+++ b/packages/core/src/ingest-prompts.test.ts
@@ -23,6 +23,51 @@ describe("buildObserverPrompt", () => {
 		expect(system).toContain(
 			"Otherwise, write a summary that explains the current state of the PRIMARY work (not your observation process).",
 		);
+		expect(system).toContain("When the session contains MULTIPLE meaningful threads:");
+		expect(system).toContain(
+			"Emit a SMALL capped set of durable <observation> blocks for the highest-value reusable subthreads (usually 2-4, not a dump of everything).",
+		);
+		expect(system).toContain(
+			"For rich multi-thread sessions, prefer one broad summary plus a small set of durable observations covering the highest-value subthreads.",
+		);
+		expect(system).toContain(
+			"Treat the <summary> as the broad session-wide state, not a recap of only the latest thread.",
+		);
+		expect(system).toContain(
+			"Before writing XML, mentally inventory the 2-4 highest-value subthreads",
+		);
+		expect(system).toContain("Do not let recency dominate");
+		expect(system).toContain("Summary-only output is not sufficient for a rich session.");
+		expect(system).toContain(
+			"Do not collapse a rich batch into only the final or most recent thread",
+		);
+		expect(system).toContain(
+			"For rich sessions, do not return summary-only output when multiple substantial durable subthreads are present.",
+		);
+	});
+
+	it("guides rich sessions toward broad summary coverage and non-duplicative durable observations", () => {
+		const { system } = buildObserverPrompt({
+			project: "codemem",
+			userPrompt: "Continue the memory injection quality work",
+			promptNumber: 24,
+			transcript:
+				"User: continue track 3\nAssistant: investigated under-extraction\nUser: prep release 0.23.0\nAssistant: reframed the next quality slice",
+			toolEvents: [],
+			lastAssistantMessage: "Next we should improve rich-session extraction quality.",
+			diffSummary: "",
+			recentFiles: "",
+			includeSummary: true,
+		});
+
+		expect(system).toContain("Cover the major subthreads in the summary");
+		expect(system).toContain("Prefer one durable observation per distinct subthread");
+		expect(system).toContain("Prefer coverage diversity");
+		expect(system).toContain("important decisions, durable learnings, shipped changes");
+		expect(system).toContain("If one thread clearly dominates and the rest are trivial");
+		expect(system).toContain(
+			"For rich sessions, make the summary broad enough that a future reader can see the major subthreads",
+		);
 	});
 
 	it("includes observed project and prompt context in the user prompt", () => {
@@ -45,13 +90,15 @@ describe("buildObserverPrompt", () => {
 		expect(user).toContain("<assistant_response>Done.</assistant_response>");
 	});
 
-	it("truncates long transcripts while preserving head and tail context", () => {
+	it("truncates long transcripts while preserving head, middle, and tail context", () => {
 		const transcript = `${"A".repeat(120)} middle context ${"Z".repeat(120)}`;
 		const truncated = truncateObserverTranscript(transcript, 80);
 
 		expect(truncated.length).toBeLessThanOrEqual(80);
 		expect(truncated).toContain("[...]");
+		expect(truncated.split("[...]").length).toBeGreaterThanOrEqual(3);
 		expect(truncated.startsWith("A")).toBe(true);
-		expect(truncated.endsWith("Z".repeat(35))).toBe(true);
+		expect(truncated).toContain("middle context");
+		expect(truncated.endsWith("Z".repeat(16))).toBe(true);
 	});
 });

--- a/packages/core/src/ingest-prompts.ts
+++ b/packages/core/src/ingest-prompts.ts
@@ -63,11 +63,26 @@ Aim for ~120-400 words per significant work item.
 Prefer fewer, higher-signal observations over many small ones.
 Include specific details when present: file paths, function names, configuration values.`;
 
+const RICH_SESSION_GUIDANCE = `When the session contains MULTIPLE meaningful threads:
+- Before writing XML, mentally inventory the 2-4 highest-value subthreads that future sessions would most want for rediscovery reduction.
+- Treat the <summary> as the broad session-wide state, not a recap of only the latest thread.
+- Cover the major subthreads in the summary when they materially changed the direction, outcome, or understanding of the work.
+- Do not let recency dominate: a long transcript often ends on only one thread, but the output should still represent the major work across the full observed batch.
+- Emit a SMALL capped set of durable <observation> blocks for the highest-value reusable subthreads (usually 2-4, not a dump of everything).
+- If the session clearly contains 2 or more substantial durable subthreads, emit at least 2 <observation> blocks. Summary-only output is not sufficient for a rich session.
+- Prefer one durable observation per distinct subthread, not several observations for one thread and silence for the others.
+- Prefer coverage diversity: do not emit multiple observations that mostly restate the same dominant thread.
+- Choose subthreads that future sessions would most want for rediscovery reduction: important decisions, durable learnings, shipped changes, closed investigations, or troubleshooting outcomes.
+- If one thread clearly dominates and the rest are trivial, keep a single observation. Do not invent diversity where none exists.`;
+
 const OUTPUT_GUIDANCE =
 	"Output only XML. Do not include commentary outside XML.\n\n" +
 	"ALWAYS emit at least one <observation> block for any meaningful work. " +
 	"Observations are the PRIMARY output - they capture what was built, fixed, learned, or decided. " +
 	"Also emit a <summary> block to track session progress.\n\n" +
+	"For rich multi-thread sessions, prefer one broad summary plus a small set of durable observations covering the highest-value subthreads.\n\n" +
+	"For rich sessions, do not return summary-only output when multiple substantial durable subthreads are present.\n\n" +
+	"Do not collapse a rich batch into only the final or most recent thread when earlier threads produced durable decisions, learnings, or outcomes.\n\n" +
 	"Prefer fewer, more comprehensive observations over many small ones.";
 
 const OBSERVATION_SCHEMA = `<observation>
@@ -158,6 +173,8 @@ file edits, behaviors, or outcomes that are not explicitly observed.
 
 Keep summaries concise (aim for ~150-450 words total across all fields).
 
+For rich sessions, make the summary broad enough that a future reader can see the major subthreads without reading every observation.
+
 This summary helps future sessions understand where this work left off.`;
 
 // ---------------------------------------------------------------------------
@@ -208,11 +225,24 @@ function formatToolEvent(event: ToolEvent): string {
 
 function truncateMiddle(text: string, limit: number): string {
 	if (text.length <= limit) return text;
-	if (limit <= 20) return text.slice(0, limit);
-	const keep = Math.floor((limit - 9) / 2);
-	const head = text.slice(0, keep).trimEnd();
-	const tail = text.slice(text.length - keep).trimStart();
-	return `${head}\n[...]\n${tail}`;
+	if (limit <= 30) return text.slice(0, limit);
+	const marker = "\n[...]\n";
+	const markerCost = marker.length * 2;
+	const available = limit - markerCost;
+	if (available <= 15) {
+		const keep = Math.floor((limit - marker.length) / 2);
+		const head = text.slice(0, keep).trimEnd();
+		const tail = text.slice(text.length - keep).trimStart();
+		return `${head}${marker}${tail}`;
+	}
+	const headLen = Math.floor(available * 0.35);
+	const middleLen = Math.floor(available * 0.3);
+	const tailLen = available - headLen - middleLen;
+	const head = text.slice(0, headLen).trimEnd();
+	const middleStart = Math.max(0, Math.floor((text.length - middleLen) / 2));
+	const middle = text.slice(middleStart, middleStart + middleLen).trim();
+	const tail = text.slice(text.length - tailLen).trimStart();
+	return `${head}${marker}${middle}${marker}${tail}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -242,6 +272,8 @@ export function buildObserverPrompt(context: ObserverContext): {
 		SKIP_GUIDANCE,
 		"",
 		NARRATIVE_GUIDANCE,
+		"",
+		RICH_SESSION_GUIDANCE,
 		"",
 		OUTPUT_GUIDANCE,
 		"",


### PR DESCRIPTION
## Description
Add the extraction evaluation, replay, and benchmark tooling needed to measure rich-batch memory generation quality. This also records flush batch metadata, improves rich-session prompt shaping, and formalizes the current benchmark batch set.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:
- `pnpm exec biome check --write packages/cli/src/commands/memory.ts packages/core/src/index.ts`
- `pnpm exec vitest run packages/core/src/extraction-eval.test.ts packages/core/src/extraction-replay.test.ts packages/core/src/extraction-benchmarks.test.ts packages/core/src/ingest-prompts.test.ts packages/cli/src/commands/memory.test.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced