### PR TITLE
feat: add OpenAI Responses support for observer benchmarking

### DIFF
--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -87,6 +87,10 @@ describe("memory command aliases", () => {
 		expect(longs).toContain("--db");
 		expect(longs).toContain("--db-path");
 		expect(longs).toContain("--batch-id");
+		expect(longs).toContain("--openai-responses");
+		expect(longs).toContain("--reasoning-effort");
+		expect(longs).toContain("--reasoning-summary");
+		expect(longs).toContain("--max-output-tokens");
 		expect(longs).toContain("--observer-temperature");
 		expect(longs).toContain("--transcript-budget");
 		expect(longs).toContain("--scenario");
@@ -104,6 +108,10 @@ describe("memory command aliases", () => {
 		expect(longs).toContain("--benchmark");
 		expect(longs).toContain("--observer-provider");
 		expect(longs).toContain("--observer-model");
+		expect(longs).toContain("--openai-responses");
+		expect(longs).toContain("--reasoning-effort");
+		expect(longs).toContain("--reasoning-summary");
+		expect(longs).toContain("--max-output-tokens");
 		expect(longs).toContain("--observer-temperature");
 		expect(longs).toContain("--transcript-budget");
 		expect(longs).toContain("--json");

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -613,6 +613,19 @@ function createMemoryExtractionReplayCommand(): Command {
 			"override replay transcript budget in characters (replay only)",
 		)
 		.option("--observer-temperature <value>", "override observer temperature for replay only")
+		.option("--openai-responses", "use OpenAI Responses API for replay only")
+		.option(
+			"--reasoning-effort <level>",
+			"set OpenAI reasoning.effort for replay only (responses path)",
+		)
+		.option(
+			"--reasoning-summary <mode>",
+			"set OpenAI reasoning.summary for replay only (responses path)",
+		)
+		.option(
+			"--max-output-tokens <n>",
+			"override OpenAI max_output_tokens for replay only (responses path)",
+		)
 		.requiredOption("--scenario <id>", "built-in extraction eval scenario ID");
 	addDbOption(cmd);
 	addJsonOption(cmd);
@@ -621,6 +634,10 @@ function createMemoryExtractionReplayCommand(): Command {
 			opts: DbOpts &
 				JsonOpts & {
 					batchId: string;
+					openaiResponses?: boolean;
+					reasoningEffort?: string;
+					reasoningSummary?: string;
+					maxOutputTokens?: string;
 					observerTemperature?: string;
 					transcriptBudget?: string;
 					scenario: string;
@@ -655,10 +672,22 @@ function createMemoryExtractionReplayCommand(): Command {
 				}
 				observerTemperature = parsed;
 			}
+			const maxOutputTokensInput = opts.maxOutputTokens?.trim() ?? "";
+			const maxOutputTokens =
+				maxOutputTokensInput.length > 0 ? parseStrictPositiveId(maxOutputTokensInput) : null;
+			if (maxOutputTokensInput.length > 0 && maxOutputTokens === null) {
+				throw new Error(
+					`Invalid max output tokens: ${maxOutputTokensInput || opts.maxOutputTokens}`,
+				);
+			}
 			const observerConfig = loadObserverConfig();
 			const observer = new ObserverClient({
 				...observerConfig,
 				observerTemperature: observerTemperature ?? observerConfig.observerTemperature,
+				observerOpenAIUseResponses: opts.openaiResponses === true,
+				observerReasoningEffort: opts.reasoningEffort?.trim() || null,
+				observerReasoningSummary: opts.reasoningSummary?.trim() || null,
+				observerMaxOutputTokens: maxOutputTokens ?? observerConfig.observerMaxTokens,
 			});
 			const result = await replayBatchExtraction(resolveDbOpt(opts), observer, {
 				batchId,
@@ -678,6 +707,8 @@ function createMemoryExtractionReplayCommand(): Command {
 					`Batch: ${result.target.batchId}`,
 					`Session: ${result.target.sessionId}`,
 					`Observer: ${result.observer.provider}/${result.observer.model}`,
+					`OpenAI Responses: ${observer.openaiUseResponses ? "yes" : "no"}`,
+					`Reasoning effort: ${observer.reasoningEffort ?? "none"}`,
 					`Classification: ${result.classification.status}`,
 					`Pass: ${result.evaluation.pass ? "yes" : "no"}`,
 				].join("\n"),
@@ -715,6 +746,19 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 		.requiredOption("--benchmark <id>", "benchmark profile id")
 		.option("--observer-provider <provider>", "override observer provider for this benchmark run")
 		.option("--observer-model <model>", "override observer model for this benchmark run")
+		.option("--openai-responses", "use OpenAI Responses API for this benchmark run")
+		.option(
+			"--reasoning-effort <level>",
+			"set OpenAI reasoning.effort for this benchmark run (responses path)",
+		)
+		.option(
+			"--reasoning-summary <mode>",
+			"set OpenAI reasoning.summary for this benchmark run (responses path)",
+		)
+		.option(
+			"--max-output-tokens <n>",
+			"override OpenAI max_output_tokens for this benchmark run (responses path)",
+		)
 		.option(
 			"--observer-temperature <value>",
 			"override observer temperature for this benchmark run",
@@ -732,6 +776,10 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					benchmark: string;
 					observerProvider?: string;
 					observerModel?: string;
+					openaiResponses?: boolean;
+					reasoningEffort?: string;
+					reasoningSummary?: string;
+					maxOutputTokens?: string;
 					observerTemperature?: string;
 					transcriptBudget?: string;
 				},
@@ -760,12 +808,24 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 				}
 				observerTemperature = parsed;
 			}
+			const maxOutputTokensInput = opts.maxOutputTokens?.trim() ?? "";
+			const maxOutputTokens =
+				maxOutputTokensInput.length > 0 ? parseStrictPositiveId(maxOutputTokensInput) : null;
+			if (maxOutputTokensInput.length > 0 && maxOutputTokens === null) {
+				throw new Error(
+					`Invalid max output tokens: ${maxOutputTokensInput || opts.maxOutputTokens}`,
+				);
+			}
 			const observerConfig = loadObserverConfig();
 			const observer = new ObserverClient({
 				...observerConfig,
 				observerProvider: opts.observerProvider?.trim() || observerConfig.observerProvider,
 				observerModel: opts.observerModel?.trim() || observerConfig.observerModel,
 				observerTemperature: observerTemperature ?? observerConfig.observerTemperature,
+				observerOpenAIUseResponses: opts.openaiResponses === true,
+				observerReasoningEffort: opts.reasoningEffort?.trim() || null,
+				observerReasoningSummary: opts.reasoningSummary?.trim() || null,
+				observerMaxOutputTokens: maxOutputTokens ?? observerConfig.observerMaxTokens,
 			});
 			const runs = [] as Array<{
 				batchId: number;
@@ -816,6 +876,10 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 				observer: {
 					provider: observer.provider,
 					model: observer.model,
+					openaiUseResponses: observer.openaiUseResponses,
+					reasoningEffort: observer.reasoningEffort,
+					reasoningSummary: observer.reasoningSummary,
+					maxOutputTokens: observer.maxOutputTokens,
 					temperature: observer.temperature,
 					transcriptBudget: transcriptBudget ?? null,
 				},
@@ -833,6 +897,10 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 				[
 					`Benchmark: ${benchmark.id} — ${benchmark.title}`,
 					`Observer: ${observer.provider}/${observer.model}`,
+					`OpenAI Responses: ${observer.openaiUseResponses ? "yes" : "no"}`,
+					`Reasoning effort: ${observer.reasoningEffort ?? "none"}`,
+					`Reasoning summary: ${observer.reasoningSummary ?? "none"}`,
+					`Max output tokens: ${observer.maxOutputTokens}`,
 					`Temperature: ${observer.temperature ?? "default"}`,
 					`Transcript budget override: ${transcriptBudget ?? "default"}`,
 					`Shape-quality passes: ${summary.shapeQualityPasses}/${summary.shapeQualityTotal}`,

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -209,6 +209,10 @@ describe("ObserverClient", () => {
 				observerApiKey: null,
 				observerBaseUrl: null,
 				observerTemperature: 0.2,
+				observerOpenAIUseResponses: true,
+				observerReasoningEffort: "low",
+				observerReasoningSummary: "auto",
+				observerMaxOutputTokens: 12000,
 				observerMaxChars: 12_000,
 				observerMaxTokens: 4_000,
 				observerHeaders: {},
@@ -219,7 +223,10 @@ describe("ObserverClient", () => {
 				observerAuthCacheTtlS: 300,
 			});
 			expect(client.model).toBe("gpt-4o");
-			expect(client.temperature).toBe(0.2);
+			expect(client.openaiUseResponses).toBe(true);
+			expect(client.reasoningEffort).toBe("low");
+			expect(client.reasoningSummary).toBe("auto");
+			expect(client.maxOutputTokens).toBe(12000);
 		});
 
 		it("infers anthropic from claude model prefix", () => {
@@ -446,6 +453,33 @@ describe("ObserverClient", () => {
 			const status = client.getStatus();
 			expect(status.auth.hasToken).toBe(true);
 			expect(status.auth.type).toBe("api_direct");
+		});
+
+		it("does not report responses_api runtime when OpenAI OAuth codex transport is active", () => {
+			const client = new ObserverClient({
+				observerProvider: "openai",
+				observerModel: "gpt-5.4",
+				observerRuntime: null,
+				observerApiKey: null,
+				observerBaseUrl: null,
+				observerTemperature: 0.2,
+				observerOpenAIUseResponses: true,
+				observerReasoningEffort: "low",
+				observerReasoningSummary: "auto",
+				observerMaxOutputTokens: 12000,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "auto",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+			(client as unknown as { _codexAccess: string | null })._codexAccess = "oauth-token";
+			const status = client.getStatus();
+			expect(status.auth.type).toBe("codex_consumer");
+			expect(status.runtime).toBe("api_http");
 		});
 
 		it("reports sdk_client auth type for opencode cached key auth", () => {

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -77,6 +77,10 @@ export interface ObserverConfig {
 	observerApiKey: string | null;
 	observerBaseUrl: string | null;
 	observerTemperature?: number | null;
+	observerOpenAIUseResponses?: boolean;
+	observerReasoningEffort?: string | null;
+	observerReasoningSummary?: string | null;
+	observerMaxOutputTokens?: number | null;
 	observerMaxChars: number;
 	observerMaxTokens: number;
 	observerHeaders: Record<string, string>;
@@ -425,6 +429,41 @@ function buildOpenAIPayload(
 	return payload;
 }
 
+function buildOpenAIResponsesPayload(
+	model: string,
+	systemPrompt: string,
+	userPrompt: string,
+	maxOutputTokens: number,
+	reasoningEffort: string | null,
+	reasoningSummary: string | null,
+	temperature: number | null,
+): Record<string, unknown> {
+	const payload: Record<string, unknown> = {
+		model,
+		max_output_tokens: maxOutputTokens,
+		input: [
+			{
+				role: "developer",
+				content: [{ type: "input_text", text: systemPrompt }],
+			},
+			{
+				role: "user",
+				content: [{ type: "input_text", text: userPrompt }],
+			},
+		],
+	};
+	if (typeof temperature === "number" && Number.isFinite(temperature)) {
+		payload.temperature = temperature;
+	}
+	if (reasoningEffort || reasoningSummary) {
+		const reasoning: Record<string, unknown> = {};
+		if (reasoningEffort) reasoning.effort = reasoningEffort;
+		if (reasoningSummary) reasoning.summary = reasoningSummary;
+		payload.reasoning = reasoning;
+	}
+	return payload;
+}
+
 function parseOpenAIResponse(body: Record<string, unknown>): string | null {
 	const choices = body.choices;
 	if (!Array.isArray(choices) || choices.length === 0) return null;
@@ -434,6 +473,27 @@ function parseOpenAIResponse(body: Record<string, unknown>): string | null {
 	if (!message) return null;
 	const content = message.content;
 	return typeof content === "string" ? content : null;
+}
+
+function parseOpenAIResponsesResponse(body: Record<string, unknown>): string | null {
+	const outputText = body.output_text;
+	if (typeof outputText === "string" && outputText.trim()) return outputText;
+	const output = body.output;
+	if (!Array.isArray(output)) return null;
+	const parts: string[] = [];
+	for (const item of output) {
+		if (typeof item !== "object" || item == null) continue;
+		const content = (item as Record<string, unknown>).content;
+		if (!Array.isArray(content)) continue;
+		for (const block of content) {
+			if (typeof block !== "object" || block == null) continue;
+			const record = block as Record<string, unknown>;
+			if (record.type === "output_text" && typeof record.text === "string") {
+				parts.push(record.text);
+			}
+		}
+	}
+	return parts.length > 0 ? parts.join("") : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -530,8 +590,12 @@ export class ObserverClient {
 	model: string;
 	readonly runtime: string;
 	readonly temperature: number | null;
+	readonly openaiUseResponses: boolean;
+	readonly reasoningEffort: string | null;
+	readonly reasoningSummary: string | null;
 	readonly maxChars: number;
 	readonly maxTokens: number;
+	readonly maxOutputTokens: number;
 
 	/** Resolved auth material — updated on refresh. */
 	auth: ObserverAuthMaterial;
@@ -608,8 +672,22 @@ export class ObserverClient {
 			typeof cfg.observerTemperature === "number" && Number.isFinite(cfg.observerTemperature)
 				? cfg.observerTemperature
 				: 0.2;
+		this.openaiUseResponses = cfg.observerOpenAIUseResponses === true;
+		this.reasoningEffort =
+			typeof cfg.observerReasoningEffort === "string" && cfg.observerReasoningEffort.trim()
+				? cfg.observerReasoningEffort.trim()
+				: null;
+		this.reasoningSummary =
+			typeof cfg.observerReasoningSummary === "string" && cfg.observerReasoningSummary.trim()
+				? cfg.observerReasoningSummary.trim()
+				: null;
 		this.maxChars = cfg.observerMaxChars;
 		this.maxTokens = cfg.observerMaxTokens;
+		this.maxOutputTokens =
+			typeof cfg.observerMaxOutputTokens === "number" &&
+			Number.isFinite(cfg.observerMaxOutputTokens)
+				? cfg.observerMaxOutputTokens
+				: this.maxTokens;
 		this._observerHeaders = { ...cfg.observerHeaders };
 		this._apiKey = cfg.observerApiKey ?? null;
 
@@ -643,10 +721,15 @@ export class ObserverClient {
 			method = "api_direct";
 		}
 
+		const runtime =
+			this.provider === "openai" && this.openaiUseResponses && method === "api_direct"
+				? "responses_api"
+				: this.runtime;
+
 		const status: ObserverStatus = {
 			provider: this.provider,
 			model: this.model,
-			runtime: this.runtime,
+			runtime,
 			auth: {
 				source: this.auth.source,
 				type: method,
@@ -859,9 +942,11 @@ export class ObserverClient {
 	): Promise<string | null> {
 		let url: string;
 		if (this._customBaseUrl) {
-			url = `${this._customBaseUrl.replace(/\/+$/, "")}/chat/completions`;
+			url = `${this._customBaseUrl.replace(/\/+$/, "")}/${this.openaiUseResponses ? "responses" : "chat/completions"}`;
 		} else {
-			url = "https://api.openai.com/v1/chat/completions";
+			url = this.openaiUseResponses
+				? "https://api.openai.com/v1/responses"
+				: "https://api.openai.com/v1/chat/completions";
 		}
 
 		const headers = buildOpenAIHeaders(this.auth.token ?? "");
@@ -869,16 +954,20 @@ export class ObserverClient {
 			headers,
 			renderObserverHeaders(this._observerHeaders, this.auth),
 		);
-		const payload = buildOpenAIPayload(
-			this.model,
-			systemPrompt,
-			userPrompt,
-			this.maxTokens,
-			this.temperature,
-		);
+		const payload = this.openaiUseResponses
+			? buildOpenAIResponsesPayload(
+					this.model,
+					systemPrompt,
+					userPrompt,
+					this.maxOutputTokens,
+					this.reasoningEffort,
+					this.reasoningSummary,
+					this.temperature,
+				)
+			: buildOpenAIPayload(this.model, systemPrompt, userPrompt, this.maxTokens, this.temperature);
 
 		return this._fetchJSON(url, mergedHeaders, payload, {
-			parseResponse: parseOpenAIResponse,
+			parseResponse: this.openaiUseResponses ? parseOpenAIResponsesResponse : parseOpenAIResponse,
 			providerLabel: capitalize(this.provider),
 		});
 	}


### PR DESCRIPTION
## Description
Add OpenAI Responses API support to the observer benchmarking path so replay and benchmark runs can exercise `reasoning.effort`, `reasoning.summary`, and `max_output_tokens` without changing the live ingestion path by default.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:
- `pnpm exec vitest run packages/core/src/observer-client.test.ts packages/core/src/extraction-replay.test.ts packages/cli/src/commands/memory.test.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`
- `pnpm run codemem memory extraction-benchmark --benchmark rich-batch-shape-v1 --observer-provider openai --observer-model gpt-5.4-mini --openai-responses --observer-temperature 0.2 --reasoning-effort low --max-output-tokens 12000 --json`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced