### PR TITLE
feat: add replay-only observer tier routing

### DIFF
--- a/docs/plans/2026-04-07-rich-session-under-extraction-eval-case.md
+++ b/docs/plans/2026-04-07-rich-session-under-extraction-eval-case.md
@@ -199,6 +199,71 @@ Current benchmark findings:
 The main cost-conscious takeaway is that cheaper/faster models should be judged
 against this benchmark set, not assumed sufficient by default.
 
+## Current routing conclusion
+
+The current replay-only quality-first routing result is stronger than any
+single-model cheap configuration tested so far.
+
+### Replay-only tier routing (current best)
+
+- **simple tier:** `openai / gpt-5.4-mini @ temperature 0.2`
+- **rich tier:** `openai / gpt-5.4` via Responses API, no reasoning, `max_output_tokens = 12000`
+
+### Current benchmark outcome
+
+On `rich-batch-shape-v1`, replay-only tier routing currently yields:
+
+- shape-quality passes: `5 / 5`
+- shape-quality fails: `0`
+- replay robustness no-output cases: `1` (`18476`)
+
+All shape-quality benchmark batches currently route to the rich tier under the
+initial thresholds, which is acceptable for this benchmark because the set is
+explicitly composed of hard rich-batch cases. The next question is whether live
+routing should use the same thresholds or introduce a broader mixed-complexity
+benchmark before rollout.
+
+## Mixed-complexity routing follow-up
+
+A second benchmark profile now checks whether replay-only tier routing can stay
+cheap on genuinely simple batches while still escalating the harder ones.
+
+- **benchmark id:** `mixed-batch-routing-v1`
+
+### Current mixed benchmark result
+
+After refining both the benchmark candidates and the routing thresholds, the
+current replay-only router yields:
+
+- shape-quality passes: `8 / 8`
+- shape-quality fails: `0`
+- replay robustness no-output cases: `1` (`18476`)
+- expected-tier matches: `7 / 9`
+
+### Current routing split
+
+- **simple tier:** `4` batches
+- **rich tier:** `5` batches
+
+On the current mixed benchmark, this is no longer a "rich for everything"
+router. Two moderate working batches (`18524`, `18525`) now intentionally route
+to the rich tier because the cheap tier under-extracted them; that is a quality-
+first tradeoff, not accidental over-escalation.
+
+### Current threshold summary
+
+The current replay-only rich-tier promotion rules are:
+
+- `eventSpan >= 100`
+- `transcriptLength >= 6000`
+- `toolCount >= 25`
+- `toolCount >= 9 && transcriptLength >= 2000`
+- `promptCount >= 3 && toolCount >= 8`
+
+This threshold set currently preserves quality on both the rich-only benchmark
+and the refined mixed benchmark better than the earlier, more aggressive
+transcript-heavy version.
+
 ## Notes
 
 This case should not be interpreted as a repeat of the old structural

--- a/docs/plans/2026-04-08-observer-tier-routing-rollout.md
+++ b/docs/plans/2026-04-08-observer-tier-routing-rollout.md
@@ -1,0 +1,211 @@
+# Observer Tier Routing Rollout Plan
+
+**Status:** Draft rollout design
+**Date:** 2026-04-08
+**Depends on:** replay-only tier routing benchmark work in PR #642
+
+## Goal
+
+Roll out observer tier routing in a way that preserves memory-generation quality
+without blindly sending most batches to the expensive model.
+
+## Current replay evidence
+
+### Rich-only benchmark
+
+- benchmark: `rich-batch-shape-v1`
+- result with replay-only tier routing:
+  - shape-quality passes: `5 / 5`
+  - shape-quality fails: `0`
+  - robustness no-output cases: `1`
+
+### Mixed-complexity benchmark
+
+- benchmark: `mixed-batch-routing-v1`
+- result with refined thresholds:
+  - shape-quality passes: `8 / 8`
+  - shape-quality fails: `0`
+  - robustness no-output cases: `1`
+  - expected-tier matches: `7 / 9`
+
+### Current routing split on mixed benchmark
+
+- simple tier: `4 / 9`
+- rich tier: `5 / 9`
+
+Interpretation:
+
+- the router is no longer a crude “rich for everything” hammer
+- truly small/simple batches can stay on the cheap path
+- some moderate working batches still escalate intentionally because the cheap
+  path under-extracted them
+
+## Current replay-only routing policy
+
+### Simple tier
+
+- provider: `openai`
+- model: `gpt-5.4-mini`
+- temperature: `0.2`
+
+### Rich tier
+
+- provider: `openai`
+- model: `gpt-5.4`
+- API mode: Responses
+- reasoning: none
+- max output tokens: `12000`
+- temperature: `0.2`
+
+### Promotion rules
+
+Promote to rich tier when **any** of these are true:
+
+- `eventSpan >= 100`
+- `transcriptLength >= 6000`
+- `toolCount >= 25`
+- `toolCount >= 9 && transcriptLength >= 2000`
+- `promptCount >= 3 && toolCount >= 8`
+
+## Recommended live rollout sequence
+
+### Phase 0 — Complete replay-only validation
+
+**Status:** done enough to justify a guarded live rollout.
+
+Requirements already met:
+
+- replay benchmark exists
+- rich-only benchmark passes cleanly
+- mixed benchmark passes cleanly on shape-quality cases
+- no-output robustness failures are tracked separately
+
+### Phase 1 — Live routing behind explicit flag
+
+Add config flag:
+
+- `observer_tier_routing_enabled: false` by default
+
+When disabled:
+
+- preserve current single-model behavior
+
+When enabled:
+
+- compute batch richness signals during ingest
+- route observer config through the same tiering decision logic used by replay
+
+### Phase 2 — Instrumentation and visibility
+
+Persist enough metadata to understand live behavior:
+
+- selected tier (`simple` / `rich`)
+- selected provider/model
+- whether Responses path was used
+- routing reasons
+- replay/observer no-output failures
+
+Recommended persistence location:
+
+- session post metadata
+- observer-created memory metadata
+- optional structured maintenance/report output
+
+### Phase 3 — Limited dogfood window
+
+Enable tier routing only for controlled dogfooding first.
+
+Success criteria:
+
+- no increase in no-output failures
+- no obvious regression in simple-batch quality
+- rich sessions retain or improve durable observation coverage
+- observed live routing ratio stays in a sane range (not “rich almost always”)
+
+### Phase 4 — Default-on decision
+
+Only consider default-on when all are true:
+
+- replay benchmarks remain green
+- dogfood evidence does not show quality regressions
+- routing ratio remains economically sane
+- no new systemic robustness failures appear
+
+## Required config surface for live rollout
+
+At minimum:
+
+- `observer_tier_routing_enabled`
+- `observer_simple_model`
+- `observer_simple_temperature`
+- `observer_rich_model`
+- `observer_rich_temperature`
+- `observer_rich_openai_responses`
+- `observer_rich_max_output_tokens`
+
+Optional later:
+
+- `observer_rich_reasoning_effort`
+- `observer_rich_reasoning_summary`
+- threshold override settings if we need environment-specific tuning
+
+## Risks
+
+### 1. Over-escalation
+
+Risk:
+
+- router silently sends too many batches to the expensive tier
+
+Mitigation:
+
+- keep flag off by default initially
+- log tier selections and ratio
+- compare live ratios to replay benchmark expectations
+
+### 2. Under-escalation on moderate working batches
+
+Risk:
+
+- cheap tier under-extracts moderate/high-signal batches that did not trip the
+  thresholds
+
+Mitigation:
+
+- keep mixed benchmark maintained
+- add new failing live examples back into the benchmark set
+
+### 3. Transport divergence
+
+Risk:
+
+- rich tier uses Responses while simple tier may still use the older path,
+  causing operational/debugging complexity
+
+Mitigation:
+
+- persist actual selected transport in metadata
+- keep benchmark runner able to compare both paths directly
+
+### 4. No-output robustness failures
+
+Risk:
+
+- batches like `18476` still fail due to observer/transport issues unrelated to
+  shape quality
+
+Mitigation:
+
+- classify and report no-output separately from shape failures
+- do not tune routing thresholds to “solve” transport failures
+
+## Recommendation
+
+Proceed with **Phase 1** next:
+
+- implement live tier-routing behind a flag
+- reuse the replay decision function directly
+- persist routing metadata for observability
+- do not enable by default yet
+
+This is the smallest sane step from replay success to production validation.

--- a/packages/cli/src/commands/memory.test.ts
+++ b/packages/cli/src/commands/memory.test.ts
@@ -87,6 +87,7 @@ describe("memory command aliases", () => {
 		expect(longs).toContain("--db");
 		expect(longs).toContain("--db-path");
 		expect(longs).toContain("--batch-id");
+		expect(longs).toContain("--observer-tier-routing");
 		expect(longs).toContain("--openai-responses");
 		expect(longs).toContain("--reasoning-effort");
 		expect(longs).toContain("--reasoning-summary");
@@ -108,6 +109,7 @@ describe("memory command aliases", () => {
 		expect(longs).toContain("--benchmark");
 		expect(longs).toContain("--observer-provider");
 		expect(longs).toContain("--observer-model");
+		expect(longs).toContain("--observer-tier-routing");
 		expect(longs).toContain("--openai-responses");
 		expect(longs).toContain("--reasoning-effort");
 		expect(longs).toContain("--reasoning-summary");

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -20,6 +20,7 @@ import {
 	MemoryStore,
 	ObserverClient,
 	replayBatchExtraction,
+	replayBatchExtractionWithTierRouting,
 	resolveDbPath,
 	resolveProject,
 } from "@codemem/core";
@@ -612,6 +613,7 @@ function createMemoryExtractionReplayCommand(): Command {
 			"--transcript-budget <chars>",
 			"override replay transcript budget in characters (replay only)",
 		)
+		.option("--observer-tier-routing", "use replay-only benchmark-backed observer tier routing")
 		.option("--observer-temperature <value>", "override observer temperature for replay only")
 		.option("--openai-responses", "use OpenAI Responses API for replay only")
 		.option(
@@ -634,6 +636,7 @@ function createMemoryExtractionReplayCommand(): Command {
 			opts: DbOpts &
 				JsonOpts & {
 					batchId: string;
+					observerTierRouting?: boolean;
 					openaiResponses?: boolean;
 					reasoningEffort?: string;
 					reasoningSummary?: string;
@@ -681,19 +684,31 @@ function createMemoryExtractionReplayCommand(): Command {
 				);
 			}
 			const observerConfig = loadObserverConfig();
-			const observer = new ObserverClient({
+			const observerConfigWithOverrides = {
 				...observerConfig,
 				observerTemperature: observerTemperature ?? observerConfig.observerTemperature,
 				observerOpenAIUseResponses: opts.openaiResponses === true,
 				observerReasoningEffort: opts.reasoningEffort?.trim() || null,
 				observerReasoningSummary: opts.reasoningSummary?.trim() || null,
 				observerMaxOutputTokens: maxOutputTokens ?? observerConfig.observerMaxTokens,
-			});
-			const result = await replayBatchExtraction(resolveDbOpt(opts), observer, {
-				batchId,
-				scenarioId: scenario.id,
-				transcriptBudget: transcriptBudget ?? undefined,
-			});
+			};
+			const observer = new ObserverClient(observerConfigWithOverrides);
+			const result =
+				opts.observerTierRouting === true
+					? await replayBatchExtractionWithTierRouting(
+							resolveDbOpt(opts),
+							observerConfigWithOverrides,
+							{
+								batchId,
+								scenarioId: scenario.id,
+								transcriptBudget: transcriptBudget ?? undefined,
+							},
+						)
+					: await replayBatchExtraction(resolveDbOpt(opts), observer, {
+							batchId,
+							scenarioId: scenario.id,
+							transcriptBudget: transcriptBudget ?? undefined,
+						});
 
 			if (opts.json) {
 				console.log(JSON.stringify(result, null, 2));
@@ -707,8 +722,9 @@ function createMemoryExtractionReplayCommand(): Command {
 					`Batch: ${result.target.batchId}`,
 					`Session: ${result.target.sessionId}`,
 					`Observer: ${result.observer.provider}/${result.observer.model}`,
-					`OpenAI Responses: ${observer.openaiUseResponses ? "yes" : "no"}`,
-					`Reasoning effort: ${observer.reasoningEffort ?? "none"}`,
+					`Tier: ${result.observer.tier ?? "manual"}`,
+					`OpenAI Responses: ${result.observer.openaiUseResponses ? "yes" : "no"}`,
+					`Reasoning effort: ${result.observer.reasoningEffort ?? "none"}`,
 					`Classification: ${result.classification.status}`,
 					`Pass: ${result.evaluation.pass ? "yes" : "no"}`,
 				].join("\n"),
@@ -746,6 +762,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 		.requiredOption("--benchmark <id>", "benchmark profile id")
 		.option("--observer-provider <provider>", "override observer provider for this benchmark run")
 		.option("--observer-model <model>", "override observer model for this benchmark run")
+		.option("--observer-tier-routing", "use replay-only benchmark-backed observer tier routing")
 		.option("--openai-responses", "use OpenAI Responses API for this benchmark run")
 		.option(
 			"--reasoning-effort <level>",
@@ -776,6 +793,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					benchmark: string;
 					observerProvider?: string;
 					observerModel?: string;
+					observerTierRouting?: boolean;
 					openaiResponses?: boolean;
 					reasoningEffort?: string;
 					reasoningSummary?: string;
@@ -817,7 +835,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 				);
 			}
 			const observerConfig = loadObserverConfig();
-			const observer = new ObserverClient({
+			const observerConfigWithOverrides = {
 				...observerConfig,
 				observerProvider: opts.observerProvider?.trim() || observerConfig.observerProvider,
 				observerModel: opts.observerModel?.trim() || observerConfig.observerModel,
@@ -826,31 +844,78 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 				observerReasoningEffort: opts.reasoningEffort?.trim() || null,
 				observerReasoningSummary: opts.reasoningSummary?.trim() || null,
 				observerMaxOutputTokens: maxOutputTokens ?? observerConfig.observerMaxTokens,
-			});
+			};
+			const observer = new ObserverClient(observerConfigWithOverrides);
 			const runs = [] as Array<{
 				batchId: number;
 				sessionId: number;
 				label: string;
 				purpose: "shape_quality" | "replay_robustness";
+				complexity: string;
+				scenarioId: string;
+				expectedTier: string | null;
+				analysis: {
+					eventSpan: number;
+					promptCount: number;
+					toolCount: number;
+					transcriptLength: number;
+				};
 				status: "pass" | "shape_fail" | "observer_no_output";
 				reason: string;
+				tier: string;
+				provider: string;
+				model: string;
+				openaiUseResponses: boolean;
+				reasoningEffort: string | null;
+				reasoningSummary: string | null;
+				maxOutputTokens: number;
+				temperature: number | null;
 				summaries: number;
 				observations: number;
 				repairApplied: boolean;
 			}>;
 			for (const batch of benchmark.batches) {
-				const result = await replayBatchExtraction(resolveDbOpt(opts), observer, {
-					batchId: batch.batchId,
-					scenarioId: benchmark.scenarioId,
-					transcriptBudget: transcriptBudget ?? undefined,
-				});
+				const scenarioId = batch.scenarioId ?? benchmark.scenarioId;
+				const result =
+					opts.observerTierRouting === true
+						? await replayBatchExtractionWithTierRouting(
+								resolveDbOpt(opts),
+								observerConfigWithOverrides,
+								{
+									batchId: batch.batchId,
+									scenarioId,
+									transcriptBudget: transcriptBudget ?? undefined,
+								},
+							)
+						: await replayBatchExtraction(resolveDbOpt(opts), observer, {
+								batchId: batch.batchId,
+								scenarioId,
+								transcriptBudget: transcriptBudget ?? undefined,
+							});
 				runs.push({
 					batchId: batch.batchId,
 					sessionId: batch.sessionId,
 					label: batch.label,
 					purpose: batch.purpose,
+					complexity: batch.complexity,
+					scenarioId,
+					expectedTier: batch.expectedTier ?? null,
+					analysis: {
+						eventSpan: result.analysis.eventSpan,
+						promptCount: result.analysis.promptCount,
+						toolCount: result.analysis.toolCount,
+						transcriptLength: result.analysis.transcriptLength,
+					},
 					status: result.classification.status,
 					reason: result.classification.reason,
+					tier: result.observer.tier ?? "manual",
+					provider: result.observer.provider,
+					model: result.observer.model,
+					openaiUseResponses: result.observer.openaiUseResponses,
+					reasoningEffort: result.observer.reasoningEffort,
+					reasoningSummary: result.observer.reasoningSummary,
+					maxOutputTokens: result.observer.maxOutputTokens,
+					temperature: result.observer.temperature,
 					summaries: result.evaluation.counts.summaries,
 					observations: result.evaluation.counts.observations,
 					repairApplied: result.observer.repairApplied,
@@ -865,24 +930,71 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 				shapeQualityFails: runs.filter(
 					(run) => run.purpose === "shape_quality" && run.status === "shape_fail",
 				).length,
+				expectedTierTotal: runs.filter((run) => run.expectedTier != null).length,
+				expectedTierMatches: runs.filter(
+					(run) => run.expectedTier != null && run.expectedTier === run.tier,
+				).length,
 				robustnessNoOutput: runs.filter((run) => run.status === "observer_no_output").length,
 			};
+			const uniqueObserverKeys = Array.from(
+				new Set(
+					runs.map(
+						(run) =>
+							`${run.provider}::${run.model}::${run.openaiUseResponses ? "responses" : "chat"}`,
+					),
+				),
+			);
+			const observerSummary =
+				opts.observerTierRouting === true
+					? {
+							provider:
+								uniqueObserverKeys.length === 1
+									? (runs[0]?.provider ?? observer.provider)
+									: "mixed",
+							model: uniqueObserverKeys.length === 1 ? (runs[0]?.model ?? observer.model) : "mixed",
+							tierRouting: true,
+							openaiUseResponses:
+								uniqueObserverKeys.length === 1
+									? (runs[0]?.openaiUseResponses ?? observer.openaiUseResponses)
+									: null,
+							reasoningEffort:
+								uniqueObserverKeys.length === 1
+									? (runs[0]?.reasoningEffort ?? observer.reasoningEffort)
+									: "mixed",
+							reasoningSummary:
+								uniqueObserverKeys.length === 1
+									? (runs[0]?.reasoningSummary ?? observer.reasoningSummary)
+									: "mixed",
+							maxOutputTokens:
+								uniqueObserverKeys.length === 1
+									? (runs[0]?.maxOutputTokens ?? observer.maxOutputTokens)
+									: null,
+							temperature:
+								uniqueObserverKeys.length === 1
+									? (runs[0]?.temperature ?? observer.temperature)
+									: null,
+							transcriptBudget: transcriptBudget ?? null,
+							selectedObservers: uniqueObserverKeys,
+						}
+					: {
+							provider: observer.provider,
+							model: observer.model,
+							tierRouting: false,
+							openaiUseResponses: observer.openaiUseResponses,
+							reasoningEffort: observer.reasoningEffort,
+							reasoningSummary: observer.reasoningSummary,
+							maxOutputTokens: observer.maxOutputTokens,
+							temperature: observer.temperature,
+							transcriptBudget: transcriptBudget ?? null,
+							selectedObservers: uniqueObserverKeys,
+						};
 			const output = {
 				benchmark: {
 					id: benchmark.id,
 					title: benchmark.title,
 					scenarioId: benchmark.scenarioId,
 				},
-				observer: {
-					provider: observer.provider,
-					model: observer.model,
-					openaiUseResponses: observer.openaiUseResponses,
-					reasoningEffort: observer.reasoningEffort,
-					reasoningSummary: observer.reasoningSummary,
-					maxOutputTokens: observer.maxOutputTokens,
-					temperature: observer.temperature,
-					transcriptBudget: transcriptBudget ?? null,
-				},
+				observer: observerSummary,
 				summary,
 				runs,
 			};
@@ -896,21 +1008,23 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 			p.log.info(
 				[
 					`Benchmark: ${benchmark.id} — ${benchmark.title}`,
-					`Observer: ${observer.provider}/${observer.model}`,
-					`OpenAI Responses: ${observer.openaiUseResponses ? "yes" : "no"}`,
-					`Reasoning effort: ${observer.reasoningEffort ?? "none"}`,
-					`Reasoning summary: ${observer.reasoningSummary ?? "none"}`,
-					`Max output tokens: ${observer.maxOutputTokens}`,
-					`Temperature: ${observer.temperature ?? "default"}`,
+					`Observer: ${observerSummary.provider}/${observerSummary.model}`,
+					`Tier routing: ${opts.observerTierRouting === true ? "yes" : "no"}`,
+					`OpenAI Responses: ${observerSummary.openaiUseResponses === null ? "mixed" : observerSummary.openaiUseResponses ? "yes" : "no"}`,
+					`Reasoning effort: ${observerSummary.reasoningEffort ?? "none"}`,
+					`Reasoning summary: ${observerSummary.reasoningSummary ?? "none"}`,
+					`Max output tokens: ${observerSummary.maxOutputTokens ?? "mixed"}`,
+					`Temperature: ${observerSummary.temperature ?? "mixed"}`,
 					`Transcript budget override: ${transcriptBudget ?? "default"}`,
 					`Shape-quality passes: ${summary.shapeQualityPasses}/${summary.shapeQualityTotal}`,
 					`Shape-quality fails: ${summary.shapeQualityFails}`,
+					`Expected-tier matches: ${summary.expectedTierMatches}/${summary.expectedTierTotal}`,
 					`Observer no-output cases: ${summary.robustnessNoOutput}`,
 				].join("\n"),
 			);
 			for (const run of runs) {
 				p.log.message(
-					`  [${run.batchId}] ${run.status.padEnd(18)} ${run.purpose.padEnd(18)} summaries=${run.summaries} observations=${run.observations} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
+					`  [${run.batchId}] ${run.status.padEnd(18)} ${run.complexity.padEnd(10)} tier=${run.tier.padEnd(6)} expected=${(run.expectedTier ?? "n/a").padEnd(6)} span=${String(run.analysis.eventSpan).padEnd(3)} prompts=${run.analysis.promptCount} tools=${String(run.analysis.toolCount).padEnd(2)} transcript=${run.analysis.transcriptLength} ${run.provider}/${run.model}${run.openaiUseResponses ? " [responses]" : ""} summaries=${run.summaries} observations=${run.observations} repair=${run.repairApplied ? "yes" : "no"} — ${run.label}`,
 				);
 			}
 			p.outro("done");

--- a/packages/core/src/extraction-benchmarks.test.ts
+++ b/packages/core/src/extraction-benchmarks.test.ts
@@ -27,6 +27,18 @@ describe("extraction benchmarks", () => {
 		);
 	});
 
+	it("exposes the mixed-complexity routing benchmark profile", () => {
+		const profile = getExtractionBenchmarkProfile("mixed-batch-routing-v1");
+		expect(profile).not.toBeNull();
+		expect(profile?.batches).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ batchId: 18530, complexity: "simple", expectedTier: "simple" }),
+				expect.objectContaining({ batchId: 18524, complexity: "working", expectedTier: "simple" }),
+				expect.objectContaining({ batchId: 18503, complexity: "rich", expectedTier: "rich" }),
+			]),
+		);
+	});
+
 	it("returns defensive copies from the benchmark listing", () => {
 		const profiles = listExtractionBenchmarkProfiles();
 		expect(profiles.length).toBeGreaterThan(0);

--- a/packages/core/src/extraction-benchmarks.ts
+++ b/packages/core/src/extraction-benchmarks.ts
@@ -3,6 +3,9 @@ export interface ExtractionBenchmarkBatch {
 	sessionId: number;
 	label: string;
 	purpose: "shape_quality" | "replay_robustness";
+	complexity: "simple" | "working" | "rich" | "robustness";
+	scenarioId?: string;
+	expectedTier?: "simple" | "rich";
 	notes: string;
 }
 
@@ -51,6 +54,9 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				sessionId: 166405,
 				label: "Track 3 / release / qd7h under-extraction batch",
 				purpose: "shape_quality",
+				complexity: "rich",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
 				notes:
 					"Flagship hard case: historically under-extracted batch with multiple meaningful subthreads.",
 			},
@@ -59,6 +65,9 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				sessionId: 166405,
 				label: "Same session prelude rich batch",
 				purpose: "shape_quality",
+				complexity: "rich",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
 				notes:
 					"Useful adjacent batch from the same long session; helps avoid overfitting to 18503 alone.",
 			},
@@ -67,6 +76,9 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				sessionId: 166405,
 				label: "Same session later rich batch",
 				purpose: "shape_quality",
+				complexity: "rich",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
 				notes:
 					"Later large batch from the same session; currently passes on stronger models and validates generalization within the stream.",
 			},
@@ -75,6 +87,9 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				sessionId: 166392,
 				label: "Large snapshot batch with mixed success",
 				purpose: "shape_quality",
+				complexity: "rich",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
 				notes:
 					"High-volume snapshot batch used to compare budget and model sensitivity outside the Track 3 stream.",
 			},
@@ -83,6 +98,9 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				sessionId: 166392,
 				label: "Hard failing snapshot batch",
 				purpose: "shape_quality",
+				complexity: "rich",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
 				notes:
 					"Useful stubborn case: some models return summary-only or nothing; stronger models plus repair can recover it.",
 			},
@@ -91,8 +109,125 @@ const EXTRACTION_BENCHMARK_PROFILES: ExtractionBenchmarkProfile[] = [
 				sessionId: 166405,
 				label: "Replay no-output robustness case",
 				purpose: "replay_robustness",
+				complexity: "robustness",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
 				notes:
 					"Stored extraction passes shape, but replay may return no raw output at all. Track separately as observer/replay robustness, not shape quality.",
+			},
+		],
+	},
+	{
+		id: "mixed-batch-routing-v1",
+		title: "Mixed-complexity routing benchmark v1",
+		description:
+			"Benchmark set for validating whether replay-only tier routing stays cheap on simpler batches while still escalating richer batches to the stronger observer path.",
+		scenarioId: "working-batch-shape",
+		recommendedTruthModel: {
+			provider: "openai",
+			model: "gpt-5.4",
+			notes:
+				"Use the stronger model as the truth baseline when validating that richer batches genuinely benefit from escalation.",
+		},
+		cheapCandidate: {
+			provider: "openai",
+			model: "gpt-5.4-mini",
+			temperature: 0.2,
+			notes:
+				"Cheaper path that should remain selected for simpler batches unless routing thresholds are too aggressive.",
+		},
+		batches: [
+			{
+				batchId: 18530,
+				sessionId: 166430,
+				label: "Tiny prompt-only batch",
+				purpose: "shape_quality",
+				complexity: "simple",
+				scenarioId: "simple-batch-shape",
+				expectedTier: "simple",
+				notes: "Very small batch that should clearly remain on the cheap/simple tier.",
+			},
+			{
+				batchId: 18490,
+				sessionId: 166412,
+				label: "Compact low-tool batch",
+				purpose: "shape_quality",
+				complexity: "simple",
+				scenarioId: "simple-batch-shape",
+				expectedTier: "simple",
+				notes: "Small batch with low tool count that should not trigger the rich tier.",
+			},
+			{
+				batchId: 18494,
+				sessionId: 166413,
+				label: "Compact short-session batch",
+				purpose: "shape_quality",
+				complexity: "simple",
+				scenarioId: "simple-batch-shape",
+				expectedTier: "simple",
+				notes: "Short-session compact batch chosen for genuinely low-complexity characteristics.",
+			},
+			{
+				batchId: 18524,
+				sessionId: 166429,
+				label: "Moderate small-tool working batch",
+				purpose: "shape_quality",
+				complexity: "working",
+				scenarioId: "working-batch-shape",
+				expectedTier: "simple",
+				notes: "Moderate batch that should remain cheap unless thresholds are too aggressive.",
+			},
+			{
+				batchId: 18525,
+				sessionId: 166430,
+				label: "Moderate prompt-heavy batch",
+				purpose: "shape_quality",
+				complexity: "working",
+				scenarioId: "working-batch-shape",
+				expectedTier: "simple",
+				notes: "Moderate batch with some prompt/tool activity but still below rich-batch scale.",
+			},
+			{
+				batchId: 18460,
+				sessionId: 166400,
+				label: "Cross-session moderate batch",
+				purpose: "shape_quality",
+				complexity: "working",
+				scenarioId: "working-batch-shape",
+				expectedTier: "simple",
+				notes:
+					"Cross-session moderate batch to verify the simple tier remains viable outside the main stream.",
+			},
+			{
+				batchId: 18503,
+				sessionId: 166405,
+				label: "Track 3 / release / qd7h under-extraction batch",
+				purpose: "shape_quality",
+				complexity: "rich",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
+				notes: "Flagship hard case that should still escalate to the rich tier.",
+			},
+			{
+				batchId: 18432,
+				sessionId: 166392,
+				label: "Large snapshot rich batch",
+				purpose: "shape_quality",
+				complexity: "rich",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
+				notes: "High-volume snapshot batch that should continue escalating.",
+			},
+			{
+				batchId: 18476,
+				sessionId: 166405,
+				label: "Replay no-output robustness case",
+				purpose: "replay_robustness",
+				complexity: "robustness",
+				scenarioId: "rich-batch-shape",
+				expectedTier: "rich",
+				notes:
+					"Known no-output replay robustness case retained to make sure routing does not hide robustness failures.",
 			},
 		],
 	},

--- a/packages/core/src/extraction-eval.test.ts
+++ b/packages/core/src/extraction-eval.test.ts
@@ -24,6 +24,15 @@ describe("session extraction eval", () => {
 		);
 	});
 
+	it("exposes simple and working batch shape scenarios", () => {
+		expect(getSessionExtractionEvalScenario("simple-batch-shape")?.title).toContain(
+			"Simple batch output shape",
+		);
+		expect(getSessionExtractionEvalScenario("working-batch-shape")?.title).toContain(
+			"Working batch output shape",
+		);
+	});
+
 	it("passes when summary and observations cover the major rich-session threads", () => {
 		const scenario = getSessionExtractionEvalScenario("rich-session-under-extraction");
 		if (!scenario) throw new Error("scenario missing");

--- a/packages/core/src/extraction-eval.ts
+++ b/packages/core/src/extraction-eval.ts
@@ -85,6 +85,30 @@ type SessionExtractionEvalTarget =
 
 const EXTRACTION_EVAL_SCENARIOS: SessionExtractionEvalScenario[] = [
 	{
+		id: "simple-batch-shape",
+		title: "Simple batch output shape",
+		description:
+			"Evaluates whether a smaller/simple batch yields one summary and at most one durable observation without unnecessary output sprawl.",
+		summaryCountRange: { min: 1, max: 1 },
+		observationCountRange: { min: 0, max: 1 },
+		minSummaryThreadCoverage: 0,
+		minObservationThreadCoverage: 0,
+		minTotalThreadCoverage: 0,
+		threads: [],
+	},
+	{
+		id: "working-batch-shape",
+		title: "Working batch output shape",
+		description:
+			"Evaluates whether a moderate working batch yields one summary and a small set of 1-2 durable observations without over-compressing or over-emitting.",
+		summaryCountRange: { min: 1, max: 1 },
+		observationCountRange: { min: 1, max: 2 },
+		minSummaryThreadCoverage: 0,
+		minObservationThreadCoverage: 0,
+		minTotalThreadCoverage: 0,
+		threads: [],
+	},
+	{
 		id: "rich-batch-shape",
 		title: "Rich batch output shape",
 		description:

--- a/packages/core/src/extraction-replay.ts
+++ b/packages/core/src/extraction-replay.ts
@@ -3,6 +3,7 @@ import {
 	evaluateSessionExtractionItems,
 	getSessionExtractionEvalScenario,
 } from "./extraction-eval.js";
+import { decideExtractionReplayTier } from "./extraction-tier-routing.js";
 import {
 	budgetToolEvents,
 	eventToToolEvent,
@@ -29,7 +30,11 @@ import type {
 	ToolEvent,
 } from "./ingest-types.js";
 import { parseObserverResponse } from "./ingest-xml-parser.js";
-import type { ObserverClient } from "./observer-client.js";
+import {
+	type ObserverClient,
+	ObserverClient as ObserverClientImpl,
+	type ObserverConfig,
+} from "./observer-client.js";
 import { resolveProject } from "./project.js";
 import { buildSessionContext } from "./raw-event-flush.js";
 
@@ -135,6 +140,7 @@ async function observeStructuredOutput(
 export interface ExtractionReplayResult {
 	scenario: { id: string; title: string; description: string };
 	target: { batchId: number; sessionId: number };
+	analysis: ReplayBatchAnalysis;
 	classification: {
 		status: "pass" | "shape_fail" | "observer_no_output";
 		reason: string;
@@ -151,6 +157,13 @@ export interface ExtractionReplayResult {
 	observer: {
 		provider: string;
 		model: string;
+		tier: "simple" | "rich" | null;
+		tierReasons: string[];
+		openaiUseResponses: boolean;
+		reasoningEffort: string | null;
+		reasoningSummary: string | null;
+		maxOutputTokens: number;
+		temperature: number | null;
 		repairApplied: boolean;
 		initialRaw: string | null;
 		raw: string | null;
@@ -158,6 +171,42 @@ export interface ExtractionReplayResult {
 	};
 	observerContext: ObserverContext;
 	evaluation: ReturnType<typeof evaluateSessionExtractionItems>;
+}
+
+export interface ReplayBatchAnalysis {
+	batchId: number;
+	sessionId: number;
+	eventSpan: number;
+	promptCount: number;
+	toolCount: number;
+	transcriptLength: number;
+}
+
+interface PreparedReplayBatch {
+	scenario: ReturnType<typeof getSessionExtractionEvalScenario> extends infer T
+		? Exclude<T, null>
+		: never;
+	batch: {
+		id: number;
+		source: string;
+		stream_id: string;
+		opencode_session_id: string;
+		start_event_seq: number;
+		end_event_seq: number;
+		updated_at: string;
+		session_id: number;
+		cwd: string | null;
+		project: string | null;
+		started_at: string | null;
+		ended_at: string | null;
+		metadata_json: string | null;
+	};
+	sessionContext: SessionContext;
+	observerContext: ObserverContext;
+	system: string;
+	user: string;
+	sessionPost: Record<string, unknown>;
+	analysis: ReplayBatchAnalysis;
 }
 
 function classifyReplayResult(input: {
@@ -320,9 +369,8 @@ Keep the broad summary, but add 2-4 durable observations for distinct subthreads
 	return observeStructuredOutput(observer, repairSystem, repairUser);
 }
 
-export async function replayBatchExtraction(
+async function prepareReplayBatch(
 	dbPath: string | undefined,
-	observer: ObserverClient,
 	opts: {
 		batchId: number;
 		scenarioId: string;
@@ -330,7 +378,7 @@ export async function replayBatchExtraction(
 		observerMaxChars?: number;
 		transcriptBudget?: number;
 	},
-): Promise<ExtractionReplayResult> {
+): Promise<PreparedReplayBatch> {
 	const scenario = getSessionExtractionEvalScenario(opts.scenarioId);
 	if (!scenario) throw new Error(`Unknown extraction eval scenario: ${opts.scenarioId}`);
 
@@ -423,7 +471,7 @@ export async function replayBatchExtraction(
 		};
 
 		const maxChars = opts.maxChars ?? 12_000;
-		const observerMaxChars = opts.observerMaxChars ?? observer.maxChars;
+		const observerMaxChars = opts.observerMaxChars ?? 12_000;
 		const normalizedEvents = normalizeAdapterEvents(events);
 		const prompts = extractPrompts(normalizedEvents);
 		const promptNumber =
@@ -491,10 +539,6 @@ export async function replayBatchExtraction(
 			recentFiles: "",
 		};
 		const { system, user } = buildObserverPrompt(observerContext);
-		const initialResponse = await observeStructuredOutput(observer, system, user);
-		let finalResponse = initialResponse;
-		let replayItems = buildReplayItems(finalResponse.parsed, batch, sessionContext);
-
 		const sessionMeta = (() => {
 			try {
 				return batch.metadata_json
@@ -508,74 +552,155 @@ export async function replayBatchExtraction(
 			sessionMeta.post && typeof sessionMeta.post === "object" && !Array.isArray(sessionMeta.post)
 				? (sessionMeta.post as Record<string, unknown>)
 				: {};
-		let evaluation = evaluateSessionExtractionItems(
-			{ type: "batch", sessionId: batch.session_id, batchId: batch.id },
-			{
-				id: batch.session_id,
-				project: batch.project,
-				cwd: batch.cwd ?? process.cwd(),
-				startedAt: batch.started_at ?? "",
-				endedAt: batch.ended_at,
-				sessionClass: String(post.session_class ?? "unknown"),
-				summaryDisposition: String(post.summary_disposition ?? "unknown"),
-			},
-			replayItems,
-			scenario,
-		);
-		let repairApplied = false;
-		if (
-			initialResponse.raw &&
-			needsRichSessionRepair(evaluation, observerContext, sessionContext)
-		) {
-			repairApplied = true;
-			finalResponse = await observeRichSessionRepair(
-				observer,
-				system,
-				user,
-				initialResponse.raw,
-				evaluation,
-			);
-			replayItems = buildReplayItems(finalResponse.parsed, batch, sessionContext);
-			evaluation = evaluateSessionExtractionItems(
-				{ type: "batch", sessionId: batch.session_id, batchId: batch.id },
-				{
-					id: batch.session_id,
-					project: batch.project,
-					cwd: batch.cwd ?? process.cwd(),
-					startedAt: batch.started_at ?? "",
-					endedAt: batch.ended_at,
-					sessionClass: String(post.session_class ?? "unknown"),
-					summaryDisposition: String(post.summary_disposition ?? "unknown"),
-				},
-				replayItems,
-				scenario,
-			);
-		}
-
 		return {
-			scenario: {
-				id: scenario.id,
-				title: scenario.title,
-				description: scenario.description,
+			scenario,
+			batch: {
+				...batch,
+				session_id: batch.session_id,
 			},
-			target: { batchId: batch.id, sessionId: batch.session_id },
-			classification: classifyReplayResult({
-				raw: finalResponse.raw,
-				evaluation,
-			}),
-			session: evaluation.session,
-			observer: {
-				provider: finalResponse.provider,
-				model: finalResponse.model,
-				repairApplied,
-				initialRaw: initialResponse.raw,
-				raw: finalResponse.raw,
-				parsed: finalResponse.parsed,
-			},
+			sessionContext,
 			observerContext,
-			evaluation,
+			system,
+			user,
+			sessionPost: post,
+			analysis: {
+				batchId: batch.id,
+				sessionId: batch.session_id,
+				eventSpan: batch.end_event_seq - batch.start_event_seq + 1,
+				promptCount: sessionContext.promptCount ?? 0,
+				toolCount: sessionContext.toolCount ?? 0,
+				transcriptLength: transcript.length,
+			},
 		};
 	} finally {
 		db.close();
 	}
+}
+
+async function replayPreparedBatch(
+	prepared: PreparedReplayBatch,
+	observer: ObserverClient,
+	tier: "simple" | "rich" | null,
+	tierReasons: string[],
+): Promise<ExtractionReplayResult> {
+	const initialResponse = await observeStructuredOutput(observer, prepared.system, prepared.user);
+	let finalResponse = initialResponse;
+	let replayItems = buildReplayItems(finalResponse.parsed, prepared.batch, prepared.sessionContext);
+	let evaluation = evaluateSessionExtractionItems(
+		{ type: "batch", sessionId: prepared.batch.session_id, batchId: prepared.batch.id },
+		{
+			id: prepared.batch.session_id,
+			project: prepared.batch.project,
+			cwd: prepared.batch.cwd ?? process.cwd(),
+			startedAt: prepared.batch.started_at ?? "",
+			endedAt: prepared.batch.ended_at,
+			sessionClass: String(prepared.sessionPost.session_class ?? "unknown"),
+			summaryDisposition: String(prepared.sessionPost.summary_disposition ?? "unknown"),
+		},
+		replayItems,
+		prepared.scenario,
+	);
+	let repairApplied = false;
+	if (
+		initialResponse.raw &&
+		needsRichSessionRepair(evaluation, prepared.observerContext, prepared.sessionContext)
+	) {
+		repairApplied = true;
+		finalResponse = await observeRichSessionRepair(
+			observer,
+			prepared.system,
+			prepared.user,
+			initialResponse.raw,
+			evaluation,
+		);
+		replayItems = buildReplayItems(finalResponse.parsed, prepared.batch, prepared.sessionContext);
+		evaluation = evaluateSessionExtractionItems(
+			{ type: "batch", sessionId: prepared.batch.session_id, batchId: prepared.batch.id },
+			{
+				id: prepared.batch.session_id,
+				project: prepared.batch.project,
+				cwd: prepared.batch.cwd ?? process.cwd(),
+				startedAt: prepared.batch.started_at ?? "",
+				endedAt: prepared.batch.ended_at,
+				sessionClass: String(prepared.sessionPost.session_class ?? "unknown"),
+				summaryDisposition: String(prepared.sessionPost.summary_disposition ?? "unknown"),
+			},
+			replayItems,
+			prepared.scenario,
+		);
+	}
+
+	return {
+		scenario: {
+			id: prepared.scenario.id,
+			title: prepared.scenario.title,
+			description: prepared.scenario.description,
+		},
+		target: { batchId: prepared.batch.id, sessionId: prepared.batch.session_id },
+		analysis: prepared.analysis,
+		classification: classifyReplayResult({
+			raw: finalResponse.raw,
+			evaluation,
+		}),
+		session: evaluation.session,
+		observer: {
+			provider: finalResponse.provider,
+			model: finalResponse.model,
+			tier,
+			tierReasons,
+			openaiUseResponses: observer.openaiUseResponses,
+			reasoningEffort: observer.reasoningEffort,
+			reasoningSummary: observer.reasoningSummary,
+			maxOutputTokens: observer.maxOutputTokens,
+			temperature: observer.temperature,
+			repairApplied,
+			initialRaw: initialResponse.raw,
+			raw: finalResponse.raw,
+			parsed: finalResponse.parsed,
+		},
+		observerContext: prepared.observerContext,
+		evaluation,
+	};
+}
+
+export async function replayBatchExtraction(
+	dbPath: string | undefined,
+	observer: ObserverClient,
+	opts: {
+		batchId: number;
+		scenarioId: string;
+		maxChars?: number;
+		observerMaxChars?: number;
+		transcriptBudget?: number;
+	},
+): Promise<ExtractionReplayResult> {
+	const prepared = await prepareReplayBatch(dbPath, {
+		...opts,
+		observerMaxChars: opts.observerMaxChars ?? observer.maxChars,
+	});
+	return replayPreparedBatch(prepared, observer, null, []);
+}
+
+export async function replayBatchExtractionWithTierRouting(
+	dbPath: string | undefined,
+	baseConfig: ObserverConfig,
+	opts: {
+		batchId: number;
+		scenarioId: string;
+		maxChars?: number;
+		observerMaxChars?: number;
+		transcriptBudget?: number;
+	},
+): Promise<ExtractionReplayResult> {
+	const baseObserver = new ObserverClientImpl(baseConfig);
+	const prepared = await prepareReplayBatch(dbPath, {
+		...opts,
+		observerMaxChars: opts.observerMaxChars ?? baseObserver.maxChars,
+	});
+	const decision = decideExtractionReplayTier(prepared.analysis);
+	const observer = new ObserverClientImpl({
+		...baseConfig,
+		...decision.observer,
+	});
+	return replayPreparedBatch(prepared, observer, decision.tier, decision.reasons);
 }

--- a/packages/core/src/extraction-tier-routing.test.ts
+++ b/packages/core/src/extraction-tier-routing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { decideExtractionReplayTier } from "./extraction-tier-routing.js";
+
+describe("extraction tier routing", () => {
+	it("routes rich batches to the rich tier when thresholds are exceeded", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+
+		expect(decision.tier).toBe("rich");
+		expect(decision.observer.observerModel).toBe("gpt-5.4");
+		expect(decision.observer.observerOpenAIUseResponses).toBe(true);
+		expect(decision.reasons.length).toBeGreaterThan(0);
+	});
+
+	it("routes smaller batches to the simple tier when rich thresholds are not met", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 19001,
+			sessionId: 200001,
+			eventSpan: 12,
+			promptCount: 1,
+			toolCount: 1,
+			transcriptLength: 320,
+		});
+
+		expect(decision.tier).toBe("simple");
+		expect(decision.observer.observerModel).toBe("gpt-5.4-mini");
+		expect(decision.observer.observerTemperature).toBe(0.2);
+	});
+});

--- a/packages/core/src/extraction-tier-routing.ts
+++ b/packages/core/src/extraction-tier-routing.ts
@@ -1,0 +1,61 @@
+import type { ObserverConfig } from "./observer-client.js";
+
+export interface ExtractionReplayTierRoutingInput {
+	batchId: number;
+	sessionId: number;
+	eventSpan: number;
+	promptCount: number;
+	toolCount: number;
+	transcriptLength: number;
+}
+
+export interface ExtractionReplayTierRoutingDecision {
+	tier: "simple" | "rich";
+	reasons: string[];
+	observer: Partial<ObserverConfig>;
+}
+
+export const SIMPLE_TIER_DEFAULTS: Partial<ObserverConfig> = {
+	observerProvider: "openai",
+	observerModel: "gpt-5.4-mini",
+	observerTemperature: 0.2,
+};
+
+export const RICH_TIER_DEFAULTS: Partial<ObserverConfig> = {
+	observerProvider: "openai",
+	observerModel: "gpt-5.4",
+	observerTemperature: 0.2,
+	observerOpenAIUseResponses: true,
+	observerReasoningEffort: null,
+	observerReasoningSummary: null,
+	observerMaxOutputTokens: 12000,
+};
+
+export function decideExtractionReplayTier(
+	input: ExtractionReplayTierRoutingInput,
+): ExtractionReplayTierRoutingDecision {
+	const reasons: string[] = [];
+	if (input.eventSpan >= 100) reasons.push(`event_span=${input.eventSpan}`);
+	if (input.transcriptLength >= 6000) reasons.push(`transcript_length=${input.transcriptLength}`);
+	if (input.toolCount >= 25) reasons.push(`tool_count=${input.toolCount}`);
+	if (input.toolCount >= 9 && input.transcriptLength >= 2000) {
+		reasons.push(`tool_count=${input.toolCount}+transcript_length=${input.transcriptLength}`);
+	}
+	if (input.promptCount >= 3 && input.toolCount >= 8) {
+		reasons.push(`prompt_count=${input.promptCount}+tool_count=${input.toolCount}`);
+	}
+
+	if (reasons.length > 0) {
+		return {
+			tier: "rich",
+			reasons,
+			observer: { ...RICH_TIER_DEFAULTS },
+		};
+	}
+
+	return {
+		tier: "simple",
+		reasons: ["fell below rich-batch thresholds"],
+		observer: { ...SIMPLE_TIER_DEFAULTS },
+	};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,7 +146,19 @@ export {
 	getSessionExtractionEvalScenario,
 } from "./extraction-eval.js";
 export type { ExtractionReplayResult } from "./extraction-replay.js";
-export { replayBatchExtraction } from "./extraction-replay.js";
+export {
+	replayBatchExtraction,
+	replayBatchExtractionWithTierRouting,
+} from "./extraction-replay.js";
+export type {
+	ExtractionReplayTierRoutingDecision,
+	ExtractionReplayTierRoutingInput,
+} from "./extraction-tier-routing.js";
+export {
+	decideExtractionReplayTier,
+	RICH_TIER_DEFAULTS,
+	SIMPLE_TIER_DEFAULTS,
+} from "./extraction-tier-routing.js";
 export { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
 // Ingest pipeline
 export {


### PR DESCRIPTION
## Description
Add a replay-only, benchmark-backed observer tier router for extraction benchmarking. The router chooses between a cheap simple tier and a stronger rich tier based on batch richness signals, and reports the actual selected observer configuration in replay/benchmark output.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Commands run:
- `pnpm exec vitest run packages/core/src/extraction-tier-routing.test.ts packages/core/src/extraction-replay.test.ts packages/core/src/extraction-benchmarks.test.ts packages/cli/src/commands/memory.test.ts`
- `pnpm --filter @codemem/core run build`
- `pnpm --filter codemem run build`
- `pnpm run codemem memory extraction-benchmark --benchmark rich-batch-shape-v1 --observer-tier-routing --json`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced