### PR TITLE
feat: expose tiered observer settings in viewer

### DIFF
--- a/docs/plans/2026-04-08-tiered-observer-settings-ui-design.md
+++ b/docs/plans/2026-04-08-tiered-observer-settings-ui-design.md
@@ -1,0 +1,246 @@
+# Tiered Observer Settings UI Design
+
+**Status:** Approved design
+**Date:** 2026-04-08
+**Related bead:** `codemem-b1f7`
+
+## Context
+
+codemem recently added tiered observer routing configuration so extraction can use
+different model settings for simple versus rich batches. The config/runtime layer
+already supports these keys, but the viewer settings UI still only exposes the
+single-model observer configuration.
+
+The missing viewer support creates a bad split-brain experience:
+
+- config files can express tiered routing
+- runtime behavior can use tiered routing
+- the viewer cannot inspect or edit the same settings
+
+The UI already uses task-oriented tabs and a global `Show advanced controls`
+toggle. That structure is good enough to extend, but a flat dump of all tiered
+settings would make the modal harder to scan and understand.
+
+## Goals
+
+- Expose the full tiered observer routing config in the viewer
+- Keep the default settings view understandable for users who do not want to tune
+  every routing knob
+- Preserve the existing task-oriented settings structure
+- Keep fallback/default behavior legible so users understand when base observer
+  settings still apply
+
+## Non-Goals
+
+- Redesign the entire settings modal
+- Add new routing logic or change tier-selection thresholds
+- Add provider/model validation beyond the current viewer config validation model
+
+## Config Surface To Expose
+
+The viewer should support the same tier-routing fields already present in config
+and runtime code:
+
+- `observer_tier_routing_enabled`
+- `observer_simple_model`
+- `observer_simple_temperature`
+- `observer_rich_model`
+- `observer_rich_temperature`
+- `observer_rich_openai_use_responses`
+- `observer_rich_reasoning_effort`
+- `observer_rich_reasoning_summary`
+- `observer_rich_max_output_tokens`
+
+## Design Decision
+
+Add a new **Tiered observer routing** group to the existing **Processing** tab.
+
+This feature belongs in Processing rather than Connection because it controls how
+codemem chooses extraction settings for different batch shapes, not how the base
+observer authenticates or connects.
+
+### Group structure
+
+Inside the Processing tab, the order should be:
+
+1. Background processing interval
+2. Tiered observer routing
+3. Context pack limits (advanced only, existing)
+
+### Tiered observer routing layout
+
+The new group should contain:
+
+1. **Enable tiered routing** checkbox
+   - Primary control for the feature
+   - Short helper text explaining that codemem can route simple batches to a
+     cheaper/faster model and rich batches to a higher-quality model
+
+2. **When disabled**
+   - Show a short note that codemem uses the base observer settings from the
+     Connection tab
+   - Hide tier-specific sections
+
+3. **When enabled**
+   - Reveal two clearly labeled subsections:
+     - **Simple tier**
+     - **Rich tier**
+
+### Simple tier subsection
+
+Default-visible fields:
+
+- `observer_simple_model`
+
+Advanced-only fields:
+
+- `observer_simple_temperature`
+
+Helper text should explain that blank values fall back to codemem's routing
+defaults or the base observer settings where applicable.
+
+### Rich tier subsection
+
+Default-visible fields:
+
+- `observer_rich_model`
+- `observer_rich_openai_use_responses`
+
+Advanced-only fields:
+
+- `observer_rich_temperature`
+- `observer_rich_reasoning_effort`
+- `observer_rich_reasoning_summary`
+- `observer_rich_max_output_tokens`
+
+Helper text should explain that the rich tier is intended for larger or more
+complex replay batches and that blank values continue to use built-in defaults.
+
+## Progressive Disclosure Rules
+
+To avoid overwhelming the modal:
+
+- Tier-specific controls are hidden unless `observer_tier_routing_enabled` is on
+- Tuning-heavy numeric/reasoning controls remain hidden unless `Show advanced
+  controls` is on
+- The most important routing choices remain visible in the default view:
+  - enable/disable toggle
+  - simple model
+  - rich model
+  - rich Responses API toggle
+
+This keeps the feature discoverable without turning the Processing tab into a
+wall of specialist tuning fields.
+
+## UX Copy Guidance
+
+Use concise labels and helper text that describe intent, not internal jargon.
+
+Recommended labels:
+
+- `Enable tiered routing`
+- `Simple tier model`
+- `Simple tier temperature`
+- `Rich tier model`
+- `Use OpenAI Responses API for rich tier`
+- `Rich tier temperature`
+- `Rich tier reasoning effort`
+- `Rich tier reasoning summary`
+- `Rich tier max output tokens`
+
+Recommended helper themes:
+
+- explain what the toggle does in plain language
+- explain that blank values keep defaults/fallbacks
+- explain that rich-tier controls apply only when routing selects the rich tier
+
+## Data Flow Changes
+
+The viewer stack needs matching support across three layers:
+
+### Viewer server
+
+Add the tiered routing keys to config route handling so `/api/config` can:
+
+- return saved values
+- include defaults where appropriate
+- accept validated updates for the new fields
+
+Validation expectations:
+
+- booleans for `observer_tier_routing_enabled` and
+  `observer_rich_openai_use_responses`
+- strings for model/reasoning fields
+- numeric integer/number validation for token and temperature fields following
+  existing route conventions
+
+### UI state
+
+Extend the settings form state and config-key mapping so the UI can:
+
+- hydrate the new values from config/effective payloads
+- track dirty state correctly
+- serialize only changed values back to the API
+
+### UI rendering
+
+Render the tier routing group in the Processing tab using the existing field,
+helper text, and advanced-control patterns.
+
+## Testing Strategy
+
+Minimum required coverage:
+
+### Viewer server tests
+
+- GET `/api/config` includes tiered routing values when configured
+- POST `/api/config` accepts valid tiered routing updates
+- POST `/api/config` rejects invalid types for new boolean/numeric fields
+
+### UI tests or targeted UI validation
+
+- tier sections stay hidden when routing is off
+- tier sections appear when routing is on
+- advanced-only tier controls follow the existing advanced toggle
+- save payload includes the newly edited tiered keys
+
+If automated UI tests are not already practical for this surface, at minimum the
+implementation should be validated with targeted viewer-server tests plus a
+manual viewer sanity pass.
+
+## Documentation Impact
+
+Update the user-facing settings docs so the viewer no longer implies that only
+single-model observer settings are editable there.
+
+The Settings modal section should mention:
+
+- tiered routing lives under Processing
+- simple/rich tier tuning exists
+- advanced controls hide the more technical routing knobs
+
+## Rejected Alternatives
+
+### Separate nested tab for tier routing
+
+Rejected because it adds navigation complexity for a single feature group and
+breaks the current simple task-based information architecture.
+
+### Flat advanced-only field dump
+
+Rejected because it hides the feature relationship between the enable toggle and
+the simple/rich tier settings, making the UI harder to understand.
+
+### Put tier routing under Connection
+
+Rejected because routing is a processing concern. Connection already owns base
+provider/runtime/auth settings and should stay focused on that job.
+
+## Implementation Outline
+
+1. Add config-route support for the tiered keys in `packages/viewer-server`
+2. Extend settings form state and config mapping in `packages/ui`
+3. Add the Tiered observer routing group to the Processing tab
+4. Wire conditional visibility and advanced-only controls
+5. Update tests for new config API behavior and UI state handling
+6. Update `docs/user-guide.md` to describe the new settings surface

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -22,8 +22,10 @@
 - Shows effective values (configured or default) to avoid blank/ambiguous fields.
 - Persists only changed settings on save (unchanged effective defaults are not rewritten to config).
 - Uses task-oriented sections: `Connection`, `Processing`, and `Device Sync`.
-- Includes a `Show advanced controls` toggle for technical tuning fields (JSON headers, cache/timeout, network overrides, and pack limits).
+- Includes a `Show advanced controls` toggle for technical tuning fields (JSON headers, cache/timeout, tier-routing tuning, network overrides, and pack limits).
 - Connection/auth settings map to `claude_command`, `observer_runtime`, `observer_provider`, `observer_model`, `observer_base_url`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, and `observer_headers`.
+- Processing settings include `raw_events_sweeper_interval_s` plus tiered observer routing controls for `observer_tier_routing_enabled`, `observer_simple_model`, `observer_simple_temperature`, `observer_rich_model`, `observer_rich_temperature`, `observer_rich_openai_use_responses`, `observer_rich_reasoning_effort`, `observer_rich_reasoning_summary`, and `observer_rich_max_output_tokens`.
+- When tiered routing is enabled, the Processing tab becomes the primary place for model selection; the Connection tab's base `observer_model` acts as a fallback rather than a competing primary control.
 - Sync settings can also be updated here (`sync_enabled`, `sync_host`, `sync_port`, `sync_interval_s`, `sync_mdns`).
 - Environment variables still override file values.
 - Config resolution supports JSON and JSONC with this precedence:
@@ -49,6 +51,8 @@
 - Header templates can use `${auth.token}`, `${auth.type}`, and `${auth.source}`.
 - Settings are grouped into `Connection`, `Processing`, and `Device Sync` sections with shell-agnostic labels.
 - Queue settings include `raw_events_sweeper_interval_s` (seconds), which controls background pending-event drain cadence.
+- Tiered routing settings live in the Processing tab. The basic view exposes the tier-routing toggle plus simple/rich model choices, while advanced controls reveal the extra rich-tier tuning knobs.
+- To avoid overlapping primary controls, the Connection tab reframes `observer_model` as a fallback whenever tiered routing is enabled.
 
 Example command-token gateway config:
 

--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -31,6 +31,15 @@ type SettingsFormState = {
   claudeCommand: string;
   observerProvider: string;
   observerModel: string;
+  observerTierRoutingEnabled: boolean;
+  observerSimpleModel: string;
+  observerSimpleTemperature: string;
+  observerRichModel: string;
+  observerRichTemperature: string;
+  observerRichOpenAIUseResponses: boolean;
+  observerRichReasoningEffort: string;
+  observerRichReasoningSummary: string;
+  observerRichMaxOutputTokens: string;
   observerRuntime: string;
   observerAuthSource: string;
   observerAuthFile: string;
@@ -85,6 +94,15 @@ const INPUT_TO_CONFIG_KEY: Record<keyof SettingsFormState, string> = {
   claudeCommand: 'claude_command',
   observerProvider: 'observer_provider',
   observerModel: 'observer_model',
+  observerTierRoutingEnabled: 'observer_tier_routing_enabled',
+  observerSimpleModel: 'observer_simple_model',
+  observerSimpleTemperature: 'observer_simple_temperature',
+  observerRichModel: 'observer_rich_model',
+  observerRichTemperature: 'observer_rich_temperature',
+  observerRichOpenAIUseResponses: 'observer_rich_openai_use_responses',
+  observerRichReasoningEffort: 'observer_rich_reasoning_effort',
+  observerRichReasoningSummary: 'observer_rich_reasoning_summary',
+  observerRichMaxOutputTokens: 'observer_rich_max_output_tokens',
   observerRuntime: 'observer_runtime',
   observerAuthSource: 'observer_auth_source',
   observerAuthFile: 'observer_auth_file',
@@ -120,6 +138,15 @@ const EMPTY_FORM_STATE: SettingsFormState = {
   claudeCommand: '',
   observerProvider: '',
   observerModel: '',
+  observerTierRoutingEnabled: false,
+  observerSimpleModel: '',
+  observerSimpleTemperature: '',
+  observerRichModel: '',
+  observerRichTemperature: '',
+  observerRichOpenAIUseResponses: false,
+  observerRichReasoningEffort: '',
+  observerRichReasoningSummary: '',
+  observerRichMaxOutputTokens: '',
   observerRuntime: 'api_http',
   observerAuthSource: 'auto',
   observerAuthFile: '',
@@ -182,6 +209,18 @@ function asInputString(value: unknown): string {
   return String(value);
 }
 
+function asBooleanValue(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return false;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  }
+  return Boolean(value);
+}
+
 function toProviderList(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
@@ -229,6 +268,10 @@ function configuredValueForKey(config: any, key: string): unknown {
     }
     case 'observer_provider':
     case 'observer_model':
+    case 'observer_simple_model':
+    case 'observer_rich_model':
+    case 'observer_rich_reasoning_effort':
+    case 'observer_rich_reasoning_summary':
     case 'observer_auth_file':
     case 'sync_host':
     case 'sync_coordinator_url':
@@ -256,6 +299,9 @@ function configuredValueForKey(config: any, key: string): unknown {
     }
     case 'observer_auth_timeout_ms':
     case 'observer_max_chars':
+    case 'observer_simple_temperature':
+    case 'observer_rich_temperature':
+    case 'observer_rich_max_output_tokens':
     case 'pack_observation_limit':
     case 'pack_session_limit':
     case 'raw_events_sweeper_interval_s':
@@ -278,7 +324,9 @@ function configuredValueForKey(config: any, key: string): unknown {
     }
     case 'sync_enabled':
     case 'sync_mdns':
-      return Boolean(config?.[key]);
+    case 'observer_tier_routing_enabled':
+    case 'observer_rich_openai_use_responses':
+      return asBooleanValue(config?.[key]);
     default:
       return hasOwn(config, key) ? config[key] : '';
   }
@@ -300,6 +348,9 @@ function mergeOverrideBaseline(
 
 function getObserverModelHint(): string {
   const values = settingsRenderState.values;
+  if (values.observerTierRoutingEnabled) {
+    return 'Tiered routing is enabled: simple/rich model selection now lives in Processing.';
+  }
   const inferred = inferObserverModel(
     values.observerRuntime.trim() || 'api_http',
     values.observerProvider.trim(),
@@ -310,6 +361,29 @@ function getObserverModelHint(): string {
   );
   const source = overrideActive ? 'Env override' : inferred.source;
   return `${source}: ${inferred.model}`;
+}
+
+function getTieredRoutingHelperText(): string {
+  if (!settingsRenderState.values.observerTierRoutingEnabled) {
+    return 'Off: codemem uses the base observer settings from the Connection tab for all batches.';
+  }
+  return 'On: codemem can route simpler batches to a lighter model and richer batches to a higher-quality configuration.';
+}
+
+function getObserverModelLabel(): string {
+  return settingsRenderState.values.observerTierRoutingEnabled ? 'Base model fallback' : 'Model';
+}
+
+function getObserverModelTooltip(): string {
+  return settingsRenderState.values.observerTierRoutingEnabled
+    ? 'Tiered routing is enabled, so Processing controls the simple/rich models. This base model is only a fallback.'
+    : 'Leave blank to use a recommended model for your selected mode/provider.';
+}
+
+function getObserverModelDescription(): string {
+  return settingsRenderState.values.observerTierRoutingEnabled
+    ? 'Tiered routing is active. Use this only as a fallback while the Processing tab owns simple/rich model selection.'
+    : 'Default: `gpt-5.1-codex-mini` for Direct API; `claude-4.5-haiku` for Local Claude session.';
 }
 
 function positionHelpTooltipElement(el: HTMLElement, anchor: HTMLElement) {
@@ -717,6 +791,31 @@ function formStateFromPayload(payload: any): SettingsFormState {
     claudeCommand: claudeCommand.length ? JSON.stringify(claudeCommand, null, 2) : '',
     observerProvider: asInputString(effectiveOrConfigured(config, effective, 'observer_provider')),
     observerModel: asInputString(effectiveOrConfigured(config, effective, 'observer_model')),
+    observerTierRoutingEnabled: asBooleanValue(
+      effectiveOrConfigured(config, effective, 'observer_tier_routing_enabled'),
+    ),
+    observerSimpleModel: asInputString(
+      effectiveOrConfigured(config, effective, 'observer_simple_model'),
+    ),
+    observerSimpleTemperature: asInputString(
+      effectiveOrConfigured(config, effective, 'observer_simple_temperature'),
+    ),
+    observerRichModel: asInputString(effectiveOrConfigured(config, effective, 'observer_rich_model')),
+    observerRichTemperature: asInputString(
+      effectiveOrConfigured(config, effective, 'observer_rich_temperature'),
+    ),
+    observerRichOpenAIUseResponses: asBooleanValue(
+      effectiveOrConfigured(config, effective, 'observer_rich_openai_use_responses'),
+    ),
+    observerRichReasoningEffort: asInputString(
+      effectiveOrConfigured(config, effective, 'observer_rich_reasoning_effort'),
+    ),
+    observerRichReasoningSummary: asInputString(
+      effectiveOrConfigured(config, effective, 'observer_rich_reasoning_summary'),
+    ),
+    observerRichMaxOutputTokens: asInputString(
+      effectiveOrConfigured(config, effective, 'observer_rich_max_output_tokens'),
+    ),
     observerRuntime: asInputString(effectiveOrConfigured(config, effective, 'observer_runtime')) || 'api_http',
     observerAuthSource:
       asInputString(effectiveOrConfigured(config, effective, 'observer_auth_source')) || 'auto',
@@ -737,11 +836,11 @@ function formStateFromPayload(payload: any): SettingsFormState {
     rawEventsSweeperIntervalS: asInputString(
       effectiveOrConfigured(config, effective, 'raw_events_sweeper_interval_s'),
     ),
-    syncEnabled: Boolean(effectiveOrConfigured(config, effective, 'sync_enabled')),
+    syncEnabled: asBooleanValue(effectiveOrConfigured(config, effective, 'sync_enabled')),
     syncHost: asInputString(effectiveOrConfigured(config, effective, 'sync_host')),
     syncPort: asInputString(effectiveOrConfigured(config, effective, 'sync_port')),
     syncInterval: asInputString(effectiveOrConfigured(config, effective, 'sync_interval_s')),
-    syncMdns: Boolean(effectiveOrConfigured(config, effective, 'sync_mdns')),
+    syncMdns: asBooleanValue(effectiveOrConfigured(config, effective, 'sync_mdns')),
     syncCoordinatorUrl: asInputString(effectiveOrConfigured(config, effective, 'sync_coordinator_url')),
     syncCoordinatorGroup: asInputString(
       effectiveOrConfigured(config, effective, 'sync_coordinator_group'),
@@ -882,13 +981,42 @@ function collectSettingsPayload(options: { allowUntouchedParseErrors?: boolean }
   }
 
   const authCacheTtlInput = values.observerAuthCacheTtlS.trim();
+  const simpleTemperatureInput = values.observerSimpleTemperature.trim();
+  const richTemperatureInput = values.observerRichTemperature.trim();
+  const richMaxOutputTokensInput = values.observerRichMaxOutputTokens.trim();
   const sweeperIntervalInput = values.rawEventsSweeperIntervalS.trim();
   const authCacheTtl = authCacheTtlInput === '' ? '' : Number(authCacheTtlInput);
+  const simpleTemperature = simpleTemperatureInput === '' ? '' : Number(simpleTemperatureInput);
+  const richTemperature = richTemperatureInput === '' ? '' : Number(richTemperatureInput);
+  const richMaxOutputTokens = richMaxOutputTokensInput === '' ? '' : Number(richMaxOutputTokensInput);
   const sweeperIntervalNum = Number(sweeperIntervalInput);
   const sweeperInterval = sweeperIntervalInput === '' ? '' : sweeperIntervalNum;
 
   if (authCacheTtlInput !== '' && !Number.isFinite(authCacheTtl)) {
     throw new Error('observer auth cache ttl must be a number');
+  }
+  if (
+    simpleTemperatureInput !== '' &&
+    (typeof simpleTemperature !== 'number' || !Number.isFinite(simpleTemperature) || simpleTemperature < 0)
+  ) {
+    throw new Error('simple tier temperature must be a non-negative number');
+  }
+  if (
+    richTemperatureInput !== '' &&
+    (typeof richTemperature !== 'number' || !Number.isFinite(richTemperature) || richTemperature < 0)
+  ) {
+    throw new Error('rich tier temperature must be a non-negative number');
+  }
+  if (
+    richMaxOutputTokensInput !== '' &&
+    (
+      typeof richMaxOutputTokens !== 'number' ||
+      !Number.isFinite(richMaxOutputTokens) ||
+      richMaxOutputTokens <= 0 ||
+      !Number.isInteger(richMaxOutputTokens)
+    )
+  ) {
+    throw new Error('rich tier max output tokens must be a positive integer');
   }
   if (sweeperIntervalInput !== '' && (!Number.isFinite(sweeperIntervalNum) || sweeperIntervalNum <= 0)) {
     throw new Error('raw-event sweeper interval must be a positive number');
@@ -898,6 +1026,15 @@ function collectSettingsPayload(options: { allowUntouchedParseErrors?: boolean }
     claude_command: claudeCommand,
     observer_provider: normalizeTextValue(values.observerProvider),
     observer_model: normalizeTextValue(values.observerModel),
+    observer_tier_routing_enabled: values.observerTierRoutingEnabled,
+    observer_simple_model: normalizeTextValue(values.observerSimpleModel),
+    observer_simple_temperature: simpleTemperature,
+    observer_rich_model: normalizeTextValue(values.observerRichModel),
+    observer_rich_temperature: richTemperature,
+    observer_rich_openai_use_responses: values.observerRichOpenAIUseResponses,
+    observer_rich_reasoning_effort: normalizeTextValue(values.observerRichReasoningEffort),
+    observer_rich_reasoning_summary: normalizeTextValue(values.observerRichReasoningSummary),
+    observer_rich_max_output_tokens: richMaxOutputTokens,
     observer_runtime: normalizeTextValue(values.observerRuntime || 'api_http') || 'api_http',
     observer_auth_source: normalizeTextValue(values.observerAuthSource || 'auto') || 'auto',
     observer_auth_file: normalizeTextValue(values.observerAuthFile),
@@ -1202,6 +1339,7 @@ function SettingsDialogContent() {
   const observerMaxCharsDefault = state.configDefaults?.observer_max_chars || '';
   const showAuthFile = values.observerAuthSource === 'file';
   const showAuthCommand = values.observerAuthSource === 'command';
+  const showTieredRouting = values.observerTierRoutingEnabled;
 
   return (
     <div className="modal-card">
@@ -1302,11 +1440,11 @@ function SettingsDialogContent() {
             </Field>
             <Field>
               <div className="field-label">
-                <label htmlFor="observerModel">Model</label>
-                <button aria-label="About model defaults" className="help-icon" data-tooltip="Leave blank to use a recommended model for your selected mode/provider." type="button">?</button>
+                <label htmlFor="observerModel">{getObserverModelLabel()}</label>
+                <button aria-label="About model defaults" className="help-icon" data-tooltip={getObserverModelTooltip()} type="button">?</button>
               </div>
               <input id="observerModel" onInput={onTextInput('observerModel')} placeholder="leave empty for default" value={values.observerModel} />
-              <div className="small">Default: `gpt-5.1-codex-mini` for Direct API; `claude-4.5-haiku` for Local Claude session.</div>
+              <div className="small">{getObserverModelDescription()}</div>
               <div className="small" id="observerModelHint">{getObserverModelHint()}</div>
             </Field>
             <Field>
@@ -1393,6 +1531,54 @@ function SettingsDialogContent() {
               </div>
               <input id="rawEventsSweeperIntervalS" min="1" onInput={onTextInput('rawEventsSweeperIntervalS')} type="number" value={values.rawEventsSweeperIntervalS} />
               <div className="small">How often background flush checks pending raw events.</div>
+            </Field>
+          </div>
+          <div className="settings-group">
+            <h3 className="settings-group-title">Tiered observer routing</h3>
+            <div className="field field-checkbox">
+              <input checked={values.observerTierRoutingEnabled} className="cm-checkbox" id="observerTierRoutingEnabled" onChange={onCheckboxInput('observerTierRoutingEnabled')} type="checkbox" />
+              <label htmlFor="observerTierRoutingEnabled">Enable tiered routing</label>
+            </div>
+            <div className="small">{getTieredRoutingHelperText()}</div>
+            <Field hidden={!showTieredRouting}>
+              <div className="field-label">
+                <label htmlFor="observerSimpleModel">Simple tier model</label>
+                <button aria-label="About simple tier model" className="help-icon" data-tooltip="Used for lighter replay batches. Leave blank to keep codemem's routing defaults or base observer fallback." type="button">?</button>
+              </div>
+              <input id="observerSimpleModel" onInput={onTextInput('observerSimpleModel')} placeholder="leave empty for default" value={values.observerSimpleModel} />
+              <div className="small">Used when a batch falls below rich-routing thresholds.</div>
+            </Field>
+            <Field hidden={!showTieredRouting}>
+              <div className="field-label">
+                <label htmlFor="observerRichModel">Rich tier model</label>
+                <button aria-label="About rich tier model" className="help-icon" data-tooltip="Used for larger or more complex replay batches. Leave blank to keep codemem's rich-tier defaults." type="button">?</button>
+              </div>
+              <input id="observerRichModel" onInput={onTextInput('observerRichModel')} placeholder="leave empty for default" value={values.observerRichModel} />
+              <div className="small">Used when routing detects a richer replay batch.</div>
+            </Field>
+            <Field className="field field-checkbox" hidden={!showTieredRouting}>
+              <input checked={values.observerRichOpenAIUseResponses} className="cm-checkbox" id="observerRichOpenAIUseResponses" onChange={onCheckboxInput('observerRichOpenAIUseResponses')} type="checkbox" />
+              <label htmlFor="observerRichOpenAIUseResponses">Use OpenAI Responses API for rich tier</label>
+            </Field>
+            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
+              <label htmlFor="observerSimpleTemperature">Simple tier temperature</label>
+              <input id="observerSimpleTemperature" min="0" onInput={onTextInput('observerSimpleTemperature')} step="0.1" type="number" value={values.observerSimpleTemperature} />
+            </Field>
+            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
+              <label htmlFor="observerRichTemperature">Rich tier temperature</label>
+              <input id="observerRichTemperature" min="0" onInput={onTextInput('observerRichTemperature')} step="0.1" type="number" value={values.observerRichTemperature} />
+            </Field>
+            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
+              <label htmlFor="observerRichReasoningEffort">Rich tier reasoning effort</label>
+              <input id="observerRichReasoningEffort" onInput={onTextInput('observerRichReasoningEffort')} placeholder="leave empty for default" value={values.observerRichReasoningEffort} />
+            </Field>
+            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
+              <label htmlFor="observerRichReasoningSummary">Rich tier reasoning summary</label>
+              <input id="observerRichReasoningSummary" onInput={onTextInput('observerRichReasoningSummary')} placeholder="leave empty for default" value={values.observerRichReasoningSummary} />
+            </Field>
+            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
+              <label htmlFor="observerRichMaxOutputTokens">Rich tier max output tokens</label>
+              <input id="observerRichMaxOutputTokens" min="1" onInput={onTextInput('observerRichMaxOutputTokens')} step="1" type="number" value={values.observerRichMaxOutputTokens} />
             </Field>
           </div>
           <div className="settings-group settings-advanced" hidden={hiddenUnlessAdvanced()}>

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -737,6 +737,81 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("returns tiered observer routing fields from config", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const previous = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					observer_tier_routing_enabled: true,
+					observer_simple_model: "gpt-5.4-mini",
+					observer_rich_model: "gpt-5.4",
+					observer_rich_openai_use_responses: true,
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				const config = body.config as Record<string, unknown>;
+				const effective = body.effective as Record<string, unknown>;
+				expect(config.observer_tier_routing_enabled).toBe(true);
+				expect(config.observer_simple_model).toBe("gpt-5.4-mini");
+				expect(config.observer_rich_model).toBe("gpt-5.4");
+				expect(config.observer_rich_openai_use_responses).toBe(true);
+				expect(effective.observer_tier_routing_enabled).toBe(true);
+			} finally {
+				cleanup();
+				if (previous == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previous;
+			}
+		});
+
+		it("writes tiered observer routing config", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const previous = process.env.CODEMEM_CONFIG;
+			process.env.CODEMEM_CONFIG = configPath;
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({
+						config: {
+							observer_tier_routing_enabled: true,
+							observer_simple_model: "gpt-5.4-mini",
+							observer_simple_temperature: 0.2,
+							observer_rich_model: "gpt-5.4",
+							observer_rich_temperature: 0.1,
+							observer_rich_openai_use_responses: true,
+							observer_rich_reasoning_effort: "medium",
+							observer_rich_reasoning_summary: "auto",
+							observer_rich_max_output_tokens: 12000,
+						},
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				const config = body.config as Record<string, unknown>;
+				expect(config.observer_tier_routing_enabled).toBe(true);
+				expect(config.observer_rich_openai_use_responses).toBe(true);
+				const saved = JSON.parse(readFileSync(configPath, "utf8")) as Record<string, unknown>;
+				expect(saved.observer_simple_temperature).toBe(0.2);
+				expect(saved.observer_rich_temperature).toBe(0.1);
+				expect(saved.observer_rich_max_output_tokens).toBe(12000);
+			} finally {
+				cleanup();
+				if (previous == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = previous;
+			}
+		});
+
 		it("accepts built-in observer providers on a clean config", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;
@@ -840,6 +915,25 @@ describe("viewer-server", () => {
 				expect(res.status).toBe(400);
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.error).toBe("sync_enabled must be boolean");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects invalid tiered observer routing values", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/config", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://localhost",
+					},
+					body: JSON.stringify({ config: { observer_simple_temperature: "hot" } }),
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.error).toBe("observer_simple_temperature must be non-negative number");
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/config.ts
+++ b/packages/viewer-server/src/routes/config.ts
@@ -47,6 +47,15 @@ const ALLOWED_KEYS = [
 	"observer_base_url",
 	"observer_provider",
 	"observer_model",
+	"observer_tier_routing_enabled",
+	"observer_simple_model",
+	"observer_simple_temperature",
+	"observer_rich_model",
+	"observer_rich_temperature",
+	"observer_rich_openai_use_responses",
+	"observer_rich_reasoning_effort",
+	"observer_rich_reasoning_summary",
+	"observer_rich_max_output_tokens",
 	"observer_runtime",
 	"observer_auth_source",
 	"observer_auth_file",
@@ -76,6 +85,8 @@ const DEFAULTS: ConfigData = {
 	claude_command: ["claude"],
 	observer_runtime: "api_http",
 	observer_auth_source: "auto",
+	observer_tier_routing_enabled: false,
+	observer_rich_openai_use_responses: false,
 	observer_auth_command: [],
 	observer_auth_timeout_ms: 1500,
 	observer_auth_cache_ttl_s: 300,
@@ -203,6 +214,19 @@ function parsePositiveInt(value: unknown, allowZero = false): number | null {
 	return parsed > 0 ? parsed : null;
 }
 
+function parseFiniteNumber(value: unknown, allowZero = true): number | null {
+	if (typeof value === "boolean") return null;
+	const parsed =
+		typeof value === "number"
+			? value
+			: typeof value === "string" && value.trim().length > 0
+				? Number(value.trim())
+				: Number.NaN;
+	if (!Number.isFinite(parsed)) return null;
+	if (allowZero) return parsed >= 0 ? parsed : null;
+	return parsed > 0 ? parsed : null;
+}
+
 function asStringMap(value: unknown): Record<string, string> | null {
 	if (value == null || typeof value !== "object" || Array.isArray(value)) return null;
 	const parsed: Record<string, string> = {};
@@ -285,9 +309,18 @@ function validateAndApplyUpdate(
 		configData[key] = value;
 		return null;
 	}
+	if (key === "observer_tier_routing_enabled" || key === "observer_rich_openai_use_responses") {
+		if (typeof value !== "boolean") return `${key} must be boolean`;
+		configData[key] = value;
+		return null;
+	}
 	if (
 		key === "observer_base_url" ||
 		key === "observer_model" ||
+		key === "observer_simple_model" ||
+		key === "observer_rich_model" ||
+		key === "observer_rich_reasoning_effort" ||
+		key === "observer_rich_reasoning_summary" ||
 		key === "observer_auth_file" ||
 		key === "sync_host" ||
 		key === "sync_coordinator_url" ||
@@ -297,6 +330,12 @@ function validateAndApplyUpdate(
 		const trimmed = value.trim();
 		if (!trimmed) delete configData[key];
 		else configData[key] = trimmed;
+		return null;
+	}
+	if (key === "observer_simple_temperature" || key === "observer_rich_temperature") {
+		const parsed = parseFiniteNumber(value, true);
+		if (parsed == null) return `${key} must be non-negative number`;
+		configData[key] = parsed;
 		return null;
 	}
 	const allowZero = key === "observer_auth_cache_ttl_s";


### PR DESCRIPTION
## Description
Expose the new tiered observer routing config in the viewer settings so users can inspect and edit the same simple/rich model controls already supported by config files and runtime behavior.

This also tightens the UX by making Processing the primary owner of simple/rich model selection when tiered routing is enabled, while reframing the Connection tab's base model field as a fallback instead of a competing control.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm exec vitest run packages/viewer-server/src/index.test.ts`
- [x] `pnpm exec tsc -p packages/ui/tsconfig.json --noEmit`
- [x] `pnpm exec biome check "packages/ui/src/tabs/settings.tsx" "packages/viewer-server/src/routes/config.ts"`

## Checklist
- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced