### PR TITLE
feat(core): add PackTrace diagnostics

### DIFF
--- a/docs/plans/2026-04-08-pack-trace-context-inspector-design.md
+++ b/docs/plans/2026-04-08-pack-trace-context-inspector-design.md
@@ -1,0 +1,412 @@
+# Pack Trace and Context Inspector Design
+
+**Status:** Approved design
+**Date:** 2026-04-08
+**Related bead:** `codemem-ei1c`
+
+## Context
+
+codemem's value depends on prompt-time recall actually being useful. The current
+failure symptom is not "the pack command crashed" but "the model behaves like it
+did not remember something it should have known."
+
+Today, codemem does not provide a clean way to inspect:
+
+- what query inputs were used to build a pack
+- what memories were retrieved into the candidate pool
+- which candidates were selected, dropped, deduped, or trimmed
+- what final pack text was produced for the model
+
+That makes quality work too guess-heavy. When context seems missing, the root
+cause could be any of these:
+
+1. useful memories were never extracted
+2. useful memories exist but retrieval missed them
+3. useful candidates were found but ranking or pack assembly lost them
+4. the final pack was produced but formatted poorly enough to be ignored
+5. injection or adapter delivery failed after pack generation
+
+This design addresses the middle of that chain first: **retrieval plus pack
+assembly observability**.
+
+The guiding idea is to professionally steal the good parts of tools like
+`claude-mem`: diagnostics should **prove correctness**, and context should be a
+first-class inspectable product. We should not copy noisy log spam.
+
+## Goals
+
+- Make pack generation inspectable for a manual query
+- Show a wider retrieval pool, not only final selected items
+- Preserve both machine-readable and human-readable diagnostics
+- Reuse one canonical trace object across CLI and future viewer surfaces
+- Prepare for a future viewer **Context Inspector** entered from Search
+- Leave room for a broader future **Doctor** diagnostics surface
+
+## Non-Goals
+
+- Trace the full extraction pipeline in v1
+- Trace adapter injection/delivery in v1
+- Redesign ranking heuristics as part of this design
+- Add a new top-level viewer tab immediately
+- Dump internal SQL/FTS implementation details into the user-facing output
+
+## Design Decision
+
+Add a canonical **PackTrace** diagnostic object in core, then expose it through:
+
+1. **CLI first** via `codemem pack trace "<query>"`
+2. **Viewer later** via a Context Inspector panel entered from Search
+
+The trace object is the source of truth. Human-readable output is derived from
+it rather than maintained as a separate logic path.
+
+## User Experience
+
+### Primary v1 workflow
+
+The operator runs a manual query and inspects:
+
+- inputs used for pack generation
+- retrieval pool and ranks
+- selection and drop decisions
+- final packed text
+
+This should answer the practical questions quickly:
+
+- Did the right memory exist?
+- Did retrieval find it?
+- Did ranking lose it?
+- Did token-budget trimming remove it?
+- Did the final pack text actually contain it?
+
+### Future viewer workflow
+
+The viewer gets a **Context Inspector** panel attached to Search rather than a
+new top-level tab.
+
+That panel should support manual query inspection first. It can later expand to
+historical prompt inspection and broader doctor-style diagnostics.
+
+## CLI Surface
+
+Add a new pack subcommand mode:
+
+```text
+codemem pack trace "<query>"
+```
+
+Supported flags should match the normal pack surface where relevant:
+
+- `--project`
+- `--working-set-file` (repeatable)
+- `--token-budget`
+- `--limit`
+- `--json`
+
+### Output rules
+
+- default output: human-readable trace followed by final pack text
+- `--json`: canonical PackTrace JSON only
+
+This keeps trace a first-class pack operation instead of a weird debug flag.
+
+## Canonical `PackTrace` Shape
+
+The JSON contract should be explicit and deterministic.
+
+### Top-level envelope
+
+```json
+{
+  "version": 1,
+  "inputs": {},
+  "mode": {},
+  "retrieval": {},
+  "assembly": {},
+  "output": {}
+}
+```
+
+## `inputs`
+
+Request inputs and effective knobs used to build the trace:
+
+```json
+{
+  "query": "continue viewer health work",
+  "project": "codemem",
+  "working_set_files": ["packages/ui/src/tabs/feed.ts"],
+  "token_budget": 1800,
+  "limit": 12
+}
+```
+
+Rules:
+
+- arrays are empty arrays, not `null`
+- optional scalars use explicit `null`
+- values should reflect effective inputs used during trace generation
+
+## `mode`
+
+Pack mode selection plus terse reasons:
+
+```json
+{
+  "selected": "task",
+  "reasons": [
+    "query matched task hints",
+    "working set present"
+  ]
+}
+```
+
+This is meant to prove why the pack took a particular route, not expose every
+internal branch in the decision tree.
+
+## `retrieval`
+
+The wider candidate pool used for debugging ranking and selection outcomes.
+
+Recommended default pool size: **top 20 candidates**.
+
+```json
+{
+  "candidate_count": 20,
+  "candidates": [
+    {
+      "id": 13604,
+      "rank": 1,
+      "kind": "session_summary",
+      "title": "Make 24q2 executable by adding scenario-pack support...",
+      "preview": "Added named scenario-pack support with --scenario for role-report and role-compare...",
+      "scores": {
+        "search_score": 0.82,
+        "rerank_score": 0.91,
+        "tag_overlap": 3,
+        "text_overlap": 4,
+        "working_set_overlap": 1,
+        "recency_boost": 0.10
+      },
+      "reasons": [
+        "matched query terms",
+        "working-set overlap",
+        "summary-like memory"
+      ],
+      "disposition": "selected",
+      "section": "summary"
+    }
+  ]
+}
+```
+
+### Candidate rules
+
+- `rank` preserves raw ranked order in JSON
+- `preview` is a short stable body preview for human scanning
+- `scores` may contain nullable components when not derivable
+- `reasons` are terse human-readable explanations, not verbose chain-of-thought
+- `disposition` is one of:
+  - `selected`
+  - `dropped`
+  - `deduped`
+  - `trimmed`
+- `section` is present only when the candidate is selected into a final pack
+  section
+
+The JSON view should preserve ranked order. Human-readable rendering should group
+by disposition while still showing the raw rank.
+
+## `assembly`
+
+Pack-assembly decisions that happen after candidate retrieval:
+
+```json
+{
+  "deduped_ids": [101, 104],
+  "collapsed_groups": [
+    {
+      "kept": 99,
+      "dropped": [101, 104],
+      "support_count": 3
+    }
+  ],
+  "trimmed_ids": [122, 123],
+  "trim_reasons": [
+    "token budget exceeded; lower-priority observation items dropped first"
+  ],
+  "sections": {
+    "summary": [13604],
+    "timeline": [13597, 13596],
+    "observations": [13739, 13668]
+  }
+}
+```
+
+This section exists to prove whether a candidate lost because of exact dedupe,
+section prioritization, or token-budget trimming.
+
+## `output`
+
+Final render details:
+
+```json
+{
+  "estimated_tokens": 734,
+  "truncated": false,
+  "section_counts": {
+    "summary": 1,
+    "timeline": 2,
+    "observations": 2
+  },
+  "pack_text": "## Summary\n..."
+}
+```
+
+This is the final proof artifact: what the model would have seen from pack
+generation.
+
+## Human-Readable Trace Rendering
+
+The default CLI rendering should be optimized for fast debugging, not perfect
+machine re-parsing.
+
+Recommended structure:
+
+1. inputs summary
+2. selected mode
+3. candidates grouped by disposition
+4. assembly summary
+5. final pack text
+
+Example shape:
+
+```text
+Pack trace
+- Query: continue viewer health work
+- Project: codemem
+- Working set: packages/ui/src/tabs/feed.ts
+- Mode: task
+- Token budget: 1800
+
+Selected
+1. [13604] (session_summary) Make 24q2 executable...
+   - section: Summary
+   - reasons: matched query, working-set overlap, summary-like
+   - scores: rerank=0.91 tag=3 text=4 file=1
+
+Dropped
+3. [13431] (session_summary) Audit whether context injection...
+   - reasons: lower-ranked summary after prioritization
+
+Deduped / Trimmed
+- kept [99], dropped [101, 104]
+- trimmed for budget: [122, 123]
+
+Final pack
+## Summary
+...
+```
+
+## Viewer Follow-On: Context Inspector
+
+The future viewer surface should be a **panel entered from Search**, not a new
+top-level tab.
+
+### Why Search first
+
+- manual query inspection is the first supported workflow
+- users already associate Search with retrieval/debugging intent
+- it avoids cluttering primary viewer navigation before the feature proves value
+
+### Initial panel contents
+
+- query input
+- optional project input
+- optional working-set files input
+- candidate list with rank, disposition, reasons, and scores
+- final packed text pane
+
+The panel should consume the same PackTrace JSON produced by the CLI path.
+
+## Future Doctor Direction
+
+This design should leave room for a broader future **Doctor** surface, inspired
+by the useful part of `claude-mem`'s diagnostics philosophy.
+
+Potential later additions:
+
+- recent pack traces
+- injection success/failure proof
+- token-budget and truncation statistics
+- adapter/cache health
+- last successful injection for a session or prompt
+
+That broader doctor surface is intentionally out of scope for v1.
+
+## Implementation Plan
+
+### Phase 1: Core trace contract
+
+- add PackTrace types to core
+- plumb trace capture through pack building without changing normal pack output
+- expose enough ranking and assembly metadata to explain outcomes
+
+### Phase 2: CLI trace command
+
+- add `codemem pack trace "<query>"`
+- support text and JSON output modes
+- keep normal pack command behavior unchanged
+
+### Phase 3: Viewer Context Inspector panel
+
+- add a Search entry point for manual query inspection
+- render canonical PackTrace JSON in the viewer
+- keep this as a panel/debug surface rather than a new primary tab
+
+### Phase 4: Follow-on diagnostics
+
+- evaluate a broader doctor-style debug surface after trace usage proves value
+
+## Testing Strategy
+
+Minimum required coverage:
+
+### Core tests
+
+- PackTrace JSON contains deterministic top-level fields
+- candidate dispositions are correct for selected/dropped/deduped/trimmed cases
+- assembly metadata reflects exact dedupe and token trimming decisions
+- `output.pack_text` matches the normal pack render for the same input
+
+### CLI tests
+
+- `codemem pack trace` emits readable trace text by default
+- `codemem pack trace --json` emits valid deterministic JSON
+- relevant flags flow through to PackTrace inputs and pack generation
+
+### Viewer follow-on tests
+
+- Search entry opens Context Inspector panel
+- manual query inspector renders candidate list and final pack text
+- viewer consumes the canonical JSON shape rather than recreating pack logic
+
+## Risks and Trade-Offs
+
+- surfacing too much internal scoring detail can turn the trace into useless
+  sludge; v1 should prefer terse reasons plus a small raw-score set
+- tracing should not fork pack logic; normal pack output and traced pack output
+  must stay aligned
+- viewer polish should not block the CLI diagnostic path
+
+## Recommended Bead Breakdown
+
+Spin implementation out from `codemem-ei1c` into these follow-on tasks:
+
+1. `codemem-zm46` — core PackTrace contract and pack instrumentation
+2. `codemem-5prk` — CLI `codemem pack trace` command surface
+3. `codemem-b1wo` — viewer Context Inspector panel entered from Search
+4. `codemem-dcho` — future doctor-style diagnostics follow-on
+
+These should be linked back to the parent design bead using
+`discovered-from:codemem-ei1c`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -295,7 +295,13 @@ export {
 	writeCodememConfigFile,
 	writeWorkspaceCodememConfigFile,
 } from "./observer-config.js";
-export { buildMemoryPack, buildMemoryPackAsync, estimateTokens } from "./pack.js";
+export {
+	buildMemoryPack,
+	buildMemoryPackAsync,
+	buildMemoryPackTrace,
+	buildMemoryPackTraceAsync,
+	estimateTokens,
+} from "./pack.js";
 export {
 	projectBasename,
 	projectClause,
@@ -432,6 +438,12 @@ export type {
 	OpenCodeSession,
 	PackItem,
 	PackResponse,
+	PackTrace,
+	PackTraceCandidate,
+	PackTraceCandidateScores,
+	PackTraceDisposition,
+	PackTraceMode,
+	PackTraceSection,
 	RawEvent,
 	RawEventFlushBatch,
 	RawEventIngestSample,

--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connect } from "./db.js";
-import { buildMemoryPack, estimateTokens } from "./pack.js";
+import { buildMemoryPack, buildMemoryPackTrace, estimateTokens } from "./pack.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import type { MemoryResult } from "./types.js";
@@ -245,6 +245,155 @@ describe("buildMemoryPack", () => {
 	it("includes context in the result", () => {
 		const pack = buildMemoryPack(store, "my test context");
 		expect(pack.context).toBe("my test context");
+	});
+
+	it("builds a deterministic pack trace with pack parity", () => {
+		store.remember(
+			sessionId,
+			"decision",
+			"Use SQLite for local state",
+			"Chosen for portability",
+			0.9,
+			undefined,
+			{
+				files_modified: ["packages/core/src/store.ts"],
+			},
+		);
+		store.remember(
+			sessionId,
+			"feature",
+			"Continue viewer health work",
+			"Next step is to improve the viewer health panel",
+			0.8,
+			undefined,
+			{
+				files_modified: ["packages/ui/src/app.ts"],
+			},
+		);
+
+		const pack = buildMemoryPack(store, "continue viewer health work", 10, null, {
+			working_set_paths: ["packages/ui/src/app.ts"],
+		});
+		const trace = buildMemoryPackTrace(store, "continue viewer health work", 10, null, {
+			working_set_paths: ["packages/ui/src/app.ts"],
+		});
+
+		expect(trace.version).toBe(1);
+		expect(trace.inputs.query).toBe("continue viewer health work");
+		expect(trace.mode.selected).toBe(pack.metrics.mode);
+		expect(trace.output.pack_text).toBe(pack.pack_text);
+		expect(trace.output.estimated_tokens).toBe(pack.metrics.pack_tokens);
+		expect(trace.assembly.sections.summary).toEqual(expect.any(Array));
+		expect(trace.assembly.sections.timeline).toEqual(expect.any(Array));
+		expect(trace.assembly.sections.observations).toEqual(expect.any(Array));
+		expect(trace.retrieval.candidates.length).toBeGreaterThan(0);
+		expect(trace.retrieval.candidates[0]).toEqual(
+			expect.objectContaining({
+				rank: 1,
+				disposition: expect.stringMatching(/selected|dropped|deduped|trimmed/),
+				scores: expect.objectContaining({
+					combined_score: expect.any(Number),
+					text_overlap: expect.any(Number),
+					tag_overlap: expect.any(Number),
+				}),
+			}),
+		);
+	});
+
+	it("marks deduped and trimmed candidates in pack trace", () => {
+		for (let i = 0; i < 6; i++) {
+			store.remember(
+				sessionId,
+				"feature",
+				`Feature item ${i} about tracing`,
+				`This is a long body for tracing item ${i} that should consume budget and ranking space`,
+				0.7,
+			);
+		}
+		const canonicalId = store.remember(
+			sessionId,
+			"decision",
+			"Tracing duplicate title",
+			"Tracing duplicate body",
+			0.9,
+		);
+		const duplicateId = store.remember(
+			sessionId,
+			"decision",
+			"Tracing duplicate title",
+			"Tracing duplicate body",
+			0.8,
+		);
+
+		const trace = buildMemoryPackTrace(store, "tracing", 10, 30);
+		const collapsedGroup = trace.assembly.collapsed_groups.find(
+			(group) => group.kept === canonicalId || group.kept === duplicateId,
+		);
+
+		expect(collapsedGroup).toBeTruthy();
+		expect(collapsedGroup?.support_count).toBe(2);
+		expect(
+			[collapsedGroup?.kept, ...(collapsedGroup?.dropped ?? [])].sort((a, b) => a - b),
+		).toEqual([canonicalId, duplicateId].sort((a, b) => a - b));
+		for (const droppedId of collapsedGroup?.dropped ?? []) {
+			expect(trace.assembly.deduped_ids).toContain(droppedId);
+		}
+		expect(trace.assembly.trimmed_ids.length).toBeGreaterThan(0);
+		expect(trace.output.truncated).toBe(true);
+		expect(
+			trace.retrieval.candidates.some((candidate) => candidate.disposition === "trimmed"),
+		).toBe(true);
+		expect(
+			trace.retrieval.candidates.some((candidate) => candidate.disposition === "deduped"),
+		).toBe(true);
+	});
+
+	it("does not record usage events for trace-only calls", () => {
+		store.remember(sessionId, "feature", "Trace-only item", "Useful trace context", 0.8);
+
+		const before = store.db
+			.prepare("SELECT COUNT(*) AS total FROM usage_events WHERE event = 'pack'")
+			.get() as { total: number };
+		const pack = buildMemoryPack(store, "trace-only item", 10);
+		const afterPack = store.db
+			.prepare("SELECT COUNT(*) AS total FROM usage_events WHERE event = 'pack'")
+			.get() as { total: number };
+		buildMemoryPackTrace(store, "trace-only item", 10);
+		const afterTrace = store.db
+			.prepare("SELECT COUNT(*) AS total FROM usage_events WHERE event = 'pack'")
+			.get() as { total: number };
+
+		expect(pack.items.length).toBeGreaterThan(0);
+		expect(afterPack.total).toBe(before.total + 1);
+		expect(afterTrace.total).toBe(afterPack.total);
+	});
+
+	it("uses the effective retrieval query in task-mode trace scoring", () => {
+		store.remember(
+			sessionId,
+			"feature",
+			"Review unresolved stack comments",
+			"Track the unresolved Graphite review thread and CLI follow-up",
+			0.9,
+		);
+
+		const trace = buildMemoryPackTrace(store, "continue review stack comments", 10);
+		const candidate = trace.retrieval.candidates[0];
+
+		expect(trace.mode.selected).toBe("task");
+		expect(candidate).toBeDefined();
+		expect(candidate.scores.text_overlap).toBeGreaterThan(0);
+		expect(candidate.reasons).toContain("matched query terms");
+	});
+
+	it("keeps retrieval candidates anchored to retrieval instead of fallback assembly", () => {
+		store.remember(sessionId, "session_summary", "Latest summary", "Summary fallback text", 0.9);
+
+		const trace = buildMemoryPackTrace(store, "zzz_nomatch_zzz", 10);
+
+		expect(trace.retrieval.candidate_count).toBe(0);
+		expect(trace.output.pack_text).toContain("## Summary");
+		expect(trace.output.pack_text).toContain("Latest summary");
 	});
 
 	it("with tokenBudget=0 skips budget enforcement (treats as no budget)", () => {

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -19,7 +19,7 @@ import { buildFilterClausesWithContext } from "./filters.js";
 import { projectBasename } from "./project.js";
 import { memoryLooksRecapLike, queryPrefersRecap } from "./recap-policy.js";
 import type { StoreHandle } from "./search.js";
-import { rerankResults, search, timeline } from "./search.js";
+import { rerankResults, scoreResult, search, timeline } from "./search.js";
 import {
 	canonicalMemoryKind,
 	getSummaryMetadata,
@@ -32,6 +32,11 @@ import type {
 	MemoryResult,
 	PackItem,
 	PackResponse,
+	PackTrace,
+	PackTraceCandidate,
+	PackTraceDisposition,
+	PackTraceMode,
+	PackTraceSection,
 	TimelineItemResponse,
 } from "./types.js";
 import { semanticSearch } from "./vectors.js";
@@ -58,6 +63,9 @@ const TASK_HINT_QUERY =
 	"todo todos task tasks pending follow up follow-up next resume continue backlog pick up pick-up";
 
 const RECALL_HINT_QUERY = "session summary recap remember last time previous work";
+
+const TRACE_CANDIDATE_LIMIT = 20;
+const TRACE_PREVIEW_LIMIT = 160;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -188,6 +196,108 @@ function countOverlap(tags: string, tokens: Set<string>): number {
 		if (tagSet.has(t)) count++;
 	}
 	return count;
+}
+
+function preview(text: string): string {
+	const trimmed = text.trim().replace(/\s+/g, " ");
+	if (trimmed.length <= TRACE_PREVIEW_LIMIT) return trimmed;
+	return `${trimmed.slice(0, TRACE_PREVIEW_LIMIT - 1).trimEnd()}…`;
+}
+
+function modeReasons(_context: string, mode: PackTraceMode, filters?: MemoryFilters): string[] {
+	const reasons: string[] = [];
+	if (mode === "task") {
+		reasons.push("query matched task hints");
+	} else if (mode === "recall") {
+		reasons.push("query matched recap or recall hints");
+	} else {
+		reasons.push("using default retrieval mode");
+	}
+	if ((filters?.working_set_paths?.length ?? 0) > 0) {
+		reasons.push("working set present");
+	}
+	return reasons;
+}
+
+function flattenDuplicateIds(dedupeState: DedupeState): number[] {
+	return [...dedupeState.duplicateIds.values()].flatMap((ids) => [...ids]).sort((a, b) => a - b);
+}
+
+function collapsedGroups(
+	dedupeState: DedupeState,
+): Array<{ kept: number; dropped: number[]; support_count: number }> {
+	return [...dedupeState.duplicateIds.entries()]
+		.map(([kept, dropped]) => ({
+			kept,
+			dropped: [...dropped].sort((a, b) => a - b),
+			support_count: 1 + dropped.size,
+		}))
+		.sort((a, b) => a.kept - b.kept);
+}
+
+function traceSection(
+	itemId: number,
+	sections: Record<PackTraceSection, number[]>,
+): PackTraceSection | null {
+	if (sections.summary.includes(itemId)) return "summary";
+	if (sections.timeline.includes(itemId)) return "timeline";
+	if (sections.observations.includes(itemId)) return "observations";
+	return null;
+}
+
+function candidateReasons(
+	item: MemoryResult,
+	scores: ReturnType<typeof scoreResult>,
+	section: PackTraceSection | null,
+	disposition: PackTraceDisposition,
+): string[] {
+	const reasons: string[] = [];
+	if ((scores.text_overlap ?? 0) > 0) reasons.push("matched query terms");
+	if ((scores.tag_overlap ?? 0) > 0) reasons.push("matched tag overlap");
+	if ((scores.working_set_overlap ?? 0) > 0) reasons.push("working-set overlap");
+	if ((scores.query_path_overlap ?? 0) > 0) reasons.push("matched file path hints");
+	if (isSummaryLike(item)) reasons.push("summary-like memory");
+	if (section) reasons.push(`selected for ${section}`);
+	if (disposition === "deduped") reasons.push("removed by exact dedupe");
+	if (disposition === "trimmed") reasons.push("trimmed by token budget");
+	if (disposition === "dropped") reasons.push("not selected for final pack");
+	return reasons.length > 0 ? reasons : ["included in retrieval pool"];
+}
+
+type PackArtifacts = {
+	response: PackResponse;
+	trace: PackTrace;
+};
+
+type RawSemanticResult = Awaited<ReturnType<typeof semanticSearch>>[number];
+
+function semanticMemoryResults(results: RawSemanticResult[]): MemoryResult[] {
+	return results.map((result) => {
+		let metadata: Record<string, unknown> = {};
+		if (result.metadata_json) {
+			try {
+				const parsed = JSON.parse(result.metadata_json) as unknown;
+				if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
+					metadata = parsed as Record<string, unknown>;
+				}
+			} catch {
+				// Invalid JSON metadata — use empty object
+			}
+		}
+		return {
+			id: result.id,
+			kind: result.kind,
+			title: result.title,
+			body_text: result.body_text,
+			confidence: result.confidence,
+			created_at: result.created_at,
+			updated_at: result.updated_at,
+			tags_text: result.tags_text,
+			score: result.score,
+			session_id: result.session_id,
+			metadata,
+		};
+	});
 }
 
 function queryContentTokens(query: string): Set<string> {
@@ -697,24 +807,28 @@ function mergeResults(
 	return { merged, ftsCount: ftsResults.length, semanticCount };
 }
 
-export function buildMemoryPack(
+function buildPackArtifacts(
 	store: StoreHandle,
 	context: string,
 	limit = 10,
 	tokenBudget: number | null = null,
 	filters?: MemoryFilters,
 	semanticResults?: MemoryResult[],
-): PackResponse {
+	options: { recordUsage: boolean } = { recordUsage: true },
+): PackArtifacts {
 	const effectiveLimit = Math.max(1, Math.trunc(limit));
 	let fallbackUsed = false;
 	let ftsCount = 0;
 	let semanticCount = 0;
+	let retrievalResults: MemoryResult[] = [];
+	let retrievalQuery = context;
 	let results: MemoryResult[];
 	const taskMode = queryLooksLikeTasks(context);
 	const recallMode = !taskMode && queryLooksLikeRecall(context);
 
 	if (taskMode) {
 		const taskQuery = `${context} ${TASK_HINT_QUERY}`.trim();
+		retrievalQuery = taskQuery;
 		let taskResults = search(store, taskQuery, effectiveLimit, filters);
 		ftsCount = taskResults.length;
 		if (semanticResults && semanticResults.length > 0) {
@@ -729,6 +843,7 @@ export function buildMemoryPack(
 			taskResults = merge.merged;
 			semanticCount = merge.semanticCount;
 		}
+		retrievalResults = [...taskResults];
 		if (taskResults.length === 0) {
 			fallbackUsed = true;
 			results = taskFallbackRecent(store, effectiveLimit, filters);
@@ -750,6 +865,7 @@ export function buildMemoryPack(
 		}
 	} else if (recallMode) {
 		const recallQuery = context.trim().length > 0 ? context : RECALL_HINT_QUERY;
+		retrievalQuery = recallQuery;
 		const preferSummary = queryPrefersRecap(recallQuery);
 		const wantsTimeline = recallQueryWantsTimeline(recallQuery);
 		const topicalRecallQuery = [...queryContentTokens(recallQuery)].join(" ");
@@ -766,6 +882,7 @@ export function buildMemoryPack(
 				if (topicalResults.length > 0) {
 					recallResults = topicalResults;
 					ftsCount = topicalResults.length;
+					retrievalQuery = topicalRecallQuery;
 				}
 			}
 		}
@@ -774,6 +891,7 @@ export function buildMemoryPack(
 				isSummaryLike,
 			);
 			ftsCount = recallResults.length;
+			retrievalQuery = RECALL_HINT_QUERY;
 		}
 		if (semanticResults && semanticResults.length > 0) {
 			const merge = mergeResults(
@@ -787,6 +905,7 @@ export function buildMemoryPack(
 			recallResults = merge.merged;
 			semanticCount = merge.semanticCount;
 		}
+		retrievalResults = [...recallResults];
 		results = prioritizeRecallResults(recallResults, effectiveLimit, preferSummary, context);
 		if (results.length === 0) {
 			fallbackUsed = true;
@@ -825,9 +944,11 @@ export function buildMemoryPack(
 			results = prioritizeDefaultResults(merge.merged, effectiveLimit, context);
 			ftsCount = merge.ftsCount;
 			semanticCount = merge.semanticCount;
+			retrievalResults = [...merge.merged];
 		} else {
 			results = prioritizeDefaultResults(ftsResults, effectiveLimit, context);
 			ftsCount = results.length;
+			retrievalResults = [...ftsResults];
 		}
 		if (results.length === 0) {
 			fallbackUsed = true;
@@ -1047,11 +1168,7 @@ export function buildMemoryPack(
 	const compressionRatio = workTokensUnique > 0 ? packTokens / workTokensUnique : null;
 	const overheadTokens = workTokensUnique > 0 ? packTokens - workTokensUnique : null;
 	const fallbackLabel: "recent" | null = fallbackUsed ? "recent" : null;
-	const modeLabel: "default" | "task" | "recall" = taskMode
-		? "task"
-		: recallMode
-			? "recall"
-			: "default";
+	const modeLabel: PackTraceMode = taskMode ? "task" : recallMode ? "recall" : "default";
 
 	const metrics = {
 		total_items: allItems.length,
@@ -1087,15 +1204,127 @@ export function buildMemoryPack(
 		sources: { fts: ftsCount, semantic: semanticCount, fuzzy: 0 },
 	};
 
-	recordPackUsage(store, metrics);
-
-	return {
+	const response: PackResponse = {
 		context,
 		items: allItems,
 		item_ids: allItemIds,
 		pack_text: packText,
 		metrics,
 	};
+
+	const sectionsById: Record<PackTraceSection, number[]> = {
+		summary: budgetedSummary.map((item) => item.id),
+		timeline: budgetedTimeline.map((item) => item.id),
+		observations: budgetedObservations.map((item) => item.id),
+	};
+	const budgetedIds = new Set([...allItemIds]);
+	const trimmedIds = [...summaryItems, ...timelineItems, ...observationItems]
+		.map((item) => item.id)
+		.filter((itemId) => !budgetedIds.has(itemId))
+		.sort((a, b) => a - b);
+	const dedupedIds = flattenDuplicateIds(dedupeState);
+	const dedupedIdSet = new Set(dedupedIds);
+	const trimmedIdSet = new Set(trimmedIds);
+	const referenceNow = new Date();
+	const tracePool = retrievalResults.slice(0, TRACE_CANDIDATE_LIMIT);
+	const traceCandidates: PackTraceCandidate[] = tracePool.map((item, index) => {
+		const section = traceSection(item.id, sectionsById);
+		const disposition: PackTraceDisposition = section
+			? "selected"
+			: dedupedIdSet.has(item.id)
+				? "deduped"
+				: trimmedIdSet.has(item.id)
+					? "trimmed"
+					: "dropped";
+		const baseScores = scoreResult(store, item, filters, retrievalQuery, referenceNow);
+		const scoredCandidate = {
+			...baseScores,
+			text_overlap: textOverlapScore(item, retrievalQuery),
+			tag_overlap: countOverlap(item.tags_text, queryContentTokens(retrievalQuery)),
+		};
+		return {
+			id: item.id,
+			rank: index + 1,
+			kind: item.kind,
+			title: item.title,
+			preview: preview(item.body_text),
+			scores: scoredCandidate,
+			reasons: candidateReasons(item, scoredCandidate, section, disposition),
+			disposition,
+			section,
+		};
+	});
+
+	const trace: PackTrace = {
+		version: 1,
+		inputs: {
+			query: context,
+			project: filters?.project ?? null,
+			working_set_files: [...(filters?.working_set_paths ?? [])],
+			token_budget: tokenBudget,
+			limit: effectiveLimit,
+		},
+		mode: {
+			selected: modeLabel,
+			reasons: modeReasons(context, modeLabel, filters),
+		},
+		retrieval: {
+			candidate_count: traceCandidates.length,
+			candidates: traceCandidates,
+		},
+		assembly: {
+			deduped_ids: dedupedIds,
+			collapsed_groups: collapsedGroups(dedupeState),
+			trimmed_ids: trimmedIds,
+			trim_reasons:
+				trimmedIds.length > 0
+					? ["token budget exceeded; lower-priority items dropped after section ordering"]
+					: [],
+			sections: sectionsById,
+		},
+		output: {
+			estimated_tokens: packTokens,
+			truncated: trimmedIds.length > 0,
+			section_counts: {
+				summary: sectionsById.summary.length,
+				timeline: sectionsById.timeline.length,
+				observations: sectionsById.observations.length,
+			},
+			pack_text: packText,
+		},
+	};
+
+	if (options.recordUsage) {
+		recordPackUsage(store, metrics);
+	}
+
+	return { response, trace };
+}
+
+export function buildMemoryPack(
+	store: StoreHandle,
+	context: string,
+	limit = 10,
+	tokenBudget: number | null = null,
+	filters?: MemoryFilters,
+	semanticResults?: MemoryResult[],
+): PackResponse {
+	return buildPackArtifacts(store, context, limit, tokenBudget, filters, semanticResults, {
+		recordUsage: true,
+	}).response;
+}
+
+export function buildMemoryPackTrace(
+	store: StoreHandle,
+	context: string,
+	limit = 10,
+	tokenBudget: number | null = null,
+	filters?: MemoryFilters,
+	semanticResults?: MemoryResult[],
+): PackTrace {
+	return buildPackArtifacts(store, context, limit, tokenBudget, filters, semanticResults, {
+		recordUsage: false,
+	}).trace;
 }
 
 // ---------------------------------------------------------------------------
@@ -1126,36 +1355,34 @@ export async function buildMemoryPackAsync(
 		const raw = await semanticSearch(store.db, context, limit, {
 			project: filters?.project,
 		});
-		semResults = raw.map((r) => {
-			// Parse metadata_json if present, matching FTS result shape
-			let metadata: Record<string, unknown> = {};
-			if (r.metadata_json) {
-				try {
-					const parsed = JSON.parse(r.metadata_json) as unknown;
-					if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
-						metadata = parsed as Record<string, unknown>;
-					}
-				} catch {
-					// Invalid JSON metadata — use empty object
-				}
-			}
-			return {
-				id: r.id,
-				kind: r.kind,
-				title: r.title,
-				body_text: r.body_text,
-				confidence: r.confidence,
-				created_at: r.created_at,
-				updated_at: r.updated_at,
-				tags_text: r.tags_text,
-				score: r.score,
-				session_id: r.session_id,
-				metadata,
-			};
-		});
+		semResults = semanticMemoryResults(raw);
 	} catch {
 		// Semantic search failure is non-fatal — fall through to FTS-only
 	}
 
-	return buildMemoryPack(store, context, limit, tokenBudget, filters, semResults);
+	return buildPackArtifacts(store, context, limit, tokenBudget, filters, semResults, {
+		recordUsage: true,
+	}).response;
+}
+
+export async function buildMemoryPackTraceAsync(
+	store: StoreHandle & { db: Database },
+	context: string,
+	limit = 10,
+	tokenBudget: number | null = null,
+	filters?: MemoryFilters,
+): Promise<PackTrace> {
+	let semResults: MemoryResult[] = [];
+	try {
+		const raw = await semanticSearch(store.db, context, limit, {
+			project: filters?.project,
+		});
+		semResults = semanticMemoryResults(raw);
+	} catch {
+		// Semantic search failure is non-fatal — fall through to FTS-only
+	}
+
+	return buildPackArtifacts(store, context, limit, tokenBudget, filters, semResults, {
+		recordUsage: false,
+	}).trace;
 }

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -29,6 +29,7 @@ import type {
 	MemoryItem,
 	MemoryItemResponse,
 	MemoryResult,
+	PackTraceCandidateScores,
 	TimelineItemResponse,
 } from "./types.js";
 
@@ -535,6 +536,58 @@ function workingSetOverlapBoost(item: MemoryResult, workingSetPaths: string[]): 
 	return Math.min(0.32, boost);
 }
 
+export function scoreResult(
+	store: StoreHandle,
+	item: MemoryResult,
+	filters?: MemoryFilters,
+	query = "",
+	referenceNow = new Date(),
+): PackTraceCandidateScores {
+	const workingSetPaths = normalizeWorkingSetPaths(filters?.working_set_paths);
+	const preferSummary = queryPrefersRecap(query);
+	const taskLikeQuery = searchQueryLooksTaskLike(query);
+	const recency = recencyScore(item.created_at, referenceNow);
+	const kind = kindBonus(item.kind);
+	const qualityBoost = qualityDimensionBoost(item, query);
+	const workingSetOverlap = workingSetOverlapBoost(item, workingSetPaths);
+	const queryPathOverlap = queryPathOverlapBoost(item, query);
+	const personalBiasValue = personalBias(store, item, filters);
+	const sharedTrustPenaltyValue = sharedTrustPenalty(store, item, filters);
+	const recapPenalty = recapPenaltyForSearch(item, preferSummary);
+	const tasklikePenalty =
+		!taskLikeQuery && itemLooksTaskLikeForSearch(item) ? NON_TASK_TASKLIKE_PENALTY : 0.0;
+	const baseScore = Number.isFinite(item.score) ? item.score : null;
+	const combinedScore =
+		baseScore == null
+			? null
+			: baseScore * 1.5 +
+				recency +
+				kind +
+				qualityBoost +
+				workingSetOverlap +
+				queryPathOverlap +
+				personalBiasValue -
+				sharedTrustPenaltyValue -
+				recapPenalty -
+				tasklikePenalty;
+
+	return {
+		base_score: baseScore,
+		combined_score: combinedScore,
+		recency,
+		kind_bonus: kind,
+		quality_boost: qualityBoost,
+		working_set_overlap: workingSetOverlap,
+		query_path_overlap: queryPathOverlap,
+		personal_bias: personalBiasValue,
+		shared_trust_penalty: sharedTrustPenaltyValue,
+		recap_penalty: recapPenalty,
+		tasklike_penalty: tasklikePenalty,
+		text_overlap: 0,
+		tag_overlap: 0,
+	};
+}
+
 /**
  * Re-rank search results by combining BM25 score, recency, kind bonus,
  * personal bias, and shared trust penalty.
@@ -547,23 +600,12 @@ export function rerankResults(
 	query = "",
 ): MemoryResult[] {
 	const referenceNow = new Date();
-	const workingSetPaths = normalizeWorkingSetPaths(filters?.working_set_paths);
-	const preferSummary = queryPrefersRecap(query);
-	const taskLikeQuery = searchQueryLooksTaskLike(query);
 
 	const scored = results.map((item) => ({
 		item,
 		combinedScore:
-			item.score * 1.5 +
-			recencyScore(item.created_at, referenceNow) +
-			kindBonus(item.kind) +
-			qualityDimensionBoost(item, query) +
-			workingSetOverlapBoost(item, workingSetPaths) +
-			queryPathOverlapBoost(item, query) +
-			personalBias(store, item, filters) -
-			sharedTrustPenalty(store, item, filters) -
-			recapPenaltyForSearch(item, preferSummary) -
-			(!taskLikeQuery && itemLooksTaskLikeForSearch(item) ? NON_TASK_TASKLIKE_PENALTY : 0.0),
+			scoreResult(store, item, filters, query, referenceNow).combined_score ??
+			Number.NEGATIVE_INFINITY,
 	}));
 
 	scored.sort((a, b) => b.combinedScore - a.combinedScore);

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -33,7 +33,12 @@ import {
 } from "./db.js";
 import { buildFilterClauses } from "./filters.js";
 import { readCodememConfigFile } from "./observer-config.js";
-import { buildMemoryPack, buildMemoryPackAsync } from "./pack.js";
+import {
+	buildMemoryPack,
+	buildMemoryPackAsync,
+	buildMemoryPackTrace,
+	buildMemoryPackTraceAsync,
+} from "./pack.js";
 import * as schema from "./schema.js";
 import {
 	type ExplainOptions,
@@ -49,6 +54,7 @@ import type {
 	MemoryItemResponse,
 	MemoryResult,
 	PackResponse,
+	PackTrace,
 	StoreStats,
 	TimelineItemResponse,
 } from "./types.js";
@@ -973,6 +979,15 @@ export class MemoryStore {
 		return buildMemoryPack(this, context, limit, tokenBudget ?? null, filters);
 	}
 
+	buildMemoryPackTrace(
+		context: string,
+		limit?: number,
+		tokenBudget?: number | null,
+		filters?: MemoryFilters,
+	): PackTrace {
+		return buildMemoryPackTrace(this, context, limit, tokenBudget ?? null, filters);
+	}
+
 	/**
 	 * Build a memory pack with semantic candidate merging.
 	 *
@@ -987,6 +1002,15 @@ export class MemoryStore {
 		filters?: MemoryFilters,
 	): Promise<PackResponse> {
 		return buildMemoryPackAsync(this, context, limit, tokenBudget ?? null, filters);
+	}
+
+	async buildMemoryPackTraceAsync(
+		context: string,
+		limit?: number,
+		tokenBudget?: number | null,
+		filters?: MemoryFilters,
+	): Promise<PackTrace> {
+		return buildMemoryPackTraceAsync(this, context, limit, tokenBudget ?? null, filters);
 	}
 
 	// Raw event helpers

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -73,6 +73,76 @@ export interface Artifact {
 	metadata_json: string | null;
 }
 
+export type PackTraceMode = "default" | "task" | "recall";
+
+export type PackTraceDisposition = "selected" | "dropped" | "deduped" | "trimmed";
+
+export type PackTraceSection = "summary" | "timeline" | "observations";
+
+export type PackTraceCandidateScores = {
+	base_score: number | null;
+	combined_score: number | null;
+	recency: number;
+	kind_bonus: number;
+	quality_boost: number;
+	working_set_overlap: number;
+	query_path_overlap: number;
+	personal_bias: number;
+	shared_trust_penalty: number;
+	recap_penalty: number;
+	tasklike_penalty: number;
+	text_overlap: number;
+	tag_overlap: number;
+};
+
+export type PackTraceCandidate = {
+	id: number;
+	rank: number;
+	kind: string;
+	title: string;
+	preview: string;
+	scores: PackTraceCandidateScores;
+	reasons: string[];
+	disposition: PackTraceDisposition;
+	section: PackTraceSection | null;
+};
+
+export type PackTrace = {
+	version: 1;
+	inputs: {
+		query: string;
+		project: string | null;
+		working_set_files: string[];
+		token_budget: number | null;
+		limit: number;
+	};
+	mode: {
+		selected: PackTraceMode;
+		reasons: string[];
+	};
+	retrieval: {
+		candidate_count: number;
+		candidates: PackTraceCandidate[];
+	};
+	assembly: {
+		deduped_ids: number[];
+		collapsed_groups: Array<{
+			kept: number;
+			dropped: number[];
+			support_count: number;
+		}>;
+		trimmed_ids: number[];
+		trim_reasons: string[];
+		sections: Record<PackTraceSection, number[]>;
+	};
+	output: {
+		estimated_tokens: number;
+		truncated: boolean;
+		section_counts: Record<PackTraceSection, number>;
+		pack_text: string;
+	};
+};
+
 // ---------------------------------------------------------------------------
 // Usage tracking
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Add the core `PackTrace` contract and instrument pack building so retrieval, dedupe, trim, and final pack assembly can be inspected without mutating pack usage metrics. This gives the CLI and viewer a canonical diagnostic object for understanding why a memory pack looked the way it did.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `pnpm exec vitest run packages/core/src/pack.test.ts`
- `pnpm exec tsc --noEmit -p packages/core/tsconfig.json`
- `pnpm run tsc`
- `pnpm build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
