### PR TITLE
feat(cli): add pack trace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ For architecture details, see [docs/architecture.md](docs/architecture.md).
 | | `codemem recent` | Recent memories |
 | | `codemem search <query>` | Search memories |
 | | `codemem pack <context>` | Build a context-aware memory pack |
+| | `codemem pack trace <context>` | Inspect retrieval and pack assembly for a manual query |
 | | `codemem embed` | Backfill semantic embeddings |
 | **Memory** | `codemem memory show <id>` | Print a memory item as JSON |
 | | `codemem memory forget <id>` | Deactivate a memory item |

--- a/packages/cli/src/commands/pack-shared.test.ts
+++ b/packages/cli/src/commands/pack-shared.test.ts
@@ -1,5 +1,11 @@
+import { Command } from "commander";
 import { describe, expect, it } from "vitest";
-import { buildPackRequestOptions, collectWorkingSetFile } from "./pack-shared.js";
+import {
+	addPackRequestOptions,
+	buildPackRequestOptions,
+	collectWorkingSetFile,
+	PackUsageError,
+} from "./pack-shared.js";
 
 describe("collectWorkingSetFile", () => {
 	it("appends paths in order", () => {
@@ -73,5 +79,23 @@ describe("buildPackRequestOptions", () => {
 				working_set_paths: ["src/a.ts", "src/b.ts"],
 			},
 		});
+	});
+
+	it("rejects invalid numeric inputs instead of silently coercing them", () => {
+		expect(() => buildPackRequestOptions({ limit: "nope" })).toThrow(PackUsageError);
+		expect(() => buildPackRequestOptions({ tokenBudget: "bad" })).toThrow(PackUsageError);
+	});
+});
+
+describe("addPackRequestOptions", () => {
+	it("attaches the shared pack flags to a command", () => {
+		const command = addPackRequestOptions(new Command("pack-test"));
+		const longs = command.options.map((option) => option.long);
+		expect(longs).toContain("--limit");
+		expect(longs).toContain("--budget");
+		expect(longs).toContain("--token-budget");
+		expect(longs).toContain("--working-set-file");
+		expect(longs).toContain("--project");
+		expect(longs).toContain("--all-projects");
 	});
 });

--- a/packages/cli/src/commands/pack-shared.ts
+++ b/packages/cli/src/commands/pack-shared.ts
@@ -1,4 +1,5 @@
 import { resolveProject } from "@codemem/core";
+import type { Command } from "commander";
 
 export type PackFilters = { project?: string; working_set_paths?: string[] };
 
@@ -8,8 +9,30 @@ export type PackRequestOptions = {
 	filters: PackFilters;
 };
 
+export class PackUsageError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "PackUsageError";
+	}
+}
+
 export function collectWorkingSetFile(value: string, previous: string[]): string[] {
 	return [...previous, value];
+}
+
+export function addPackRequestOptions(command: Command): Command {
+	return command
+		.option("-n, --limit <n>", "max items", "10")
+		.option("--budget <tokens>", "token budget")
+		.option("--token-budget <tokens>", "token budget")
+		.option(
+			"--working-set-file <path>",
+			"recently modified file path used as ranking hint",
+			collectWorkingSetFile,
+			[],
+		)
+		.option("--project <project>", "project identifier (defaults to git repo root)")
+		.option("--all-projects", "search across all projects");
 }
 
 export function buildPackRequestOptions(
@@ -27,9 +50,9 @@ export function buildPackRequestOptions(
 		resolveProjectFn?: typeof resolveProject;
 	} = {},
 ): PackRequestOptions {
-	const limit = Number.parseInt(opts.limit ?? "10", 10) || 10;
+	const limit = parsePositiveInt(opts.limit ?? "10", "limit");
 	const budgetRaw = opts.tokenBudget ?? opts.budget;
-	const budget = budgetRaw ? Number.parseInt(budgetRaw, 10) : undefined;
+	const budget = budgetRaw ? parseNonNegativeInt(budgetRaw, "token budget") : undefined;
 	const filters: PackFilters = {};
 
 	if (!opts.allProjects) {
@@ -47,4 +70,26 @@ export function buildPackRequestOptions(
 	}
 
 	return { limit, budget, filters };
+}
+
+function parsePositiveInt(value: string, label: string): number {
+	if (!/^\d+$/.test(value.trim())) {
+		throw new PackUsageError(`${label} must be a positive integer`);
+	}
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed < 1) {
+		throw new PackUsageError(`${label} must be a positive integer`);
+	}
+	return parsed;
+}
+
+function parseNonNegativeInt(value: string, label: string): number {
+	if (!/^\d+$/.test(value.trim())) {
+		throw new PackUsageError(`${label} must be a non-negative integer`);
+	}
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) {
+		throw new PackUsageError(`${label} must be a non-negative integer`);
+	}
+	return parsed;
 }

--- a/packages/cli/src/commands/pack.test.ts
+++ b/packages/cli/src/commands/pack.test.ts
@@ -1,0 +1,308 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const buildMemoryPackAsync = vi.fn();
+const buildMemoryPackTraceAsync = vi.fn();
+const closeStore = vi.fn();
+const storePaths: Array<string | undefined> = [];
+
+vi.mock("@codemem/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@codemem/core")>();
+	return {
+		...actual,
+		MemoryStore: class {
+			constructor(dbPath?: string) {
+				storePaths.push(dbPath);
+			}
+			buildMemoryPackAsync = buildMemoryPackAsync;
+			buildMemoryPackTraceAsync = buildMemoryPackTraceAsync;
+			close = closeStore;
+		},
+		resolveDbPath: (value?: string) => value,
+	};
+});
+
+import { packCommand, renderPackTrace } from "./pack.js";
+
+afterEach(() => {
+	buildMemoryPackAsync.mockReset();
+	buildMemoryPackTraceAsync.mockReset();
+	closeStore.mockReset();
+	storePaths.length = 0;
+	process.exitCode = 0;
+	vi.restoreAllMocks();
+});
+
+async function parsePackCommand(args: string[]): Promise<void> {
+	const root = new Command("codemem");
+	root.enablePositionalOptions();
+	root.addCommand(packCommand);
+	await root.parseAsync(["pack", ...args], { from: "user" });
+}
+
+async function parseTraceCommand(args: string[]): Promise<void> {
+	const trace = packCommand.commands.find((command) => command.name() === "trace");
+	if (!trace) throw new Error("trace command missing");
+	await trace.parseAsync(args, { from: "user" });
+}
+
+describe("pack command", () => {
+	it("registers trace as a pack subcommand with shared options", () => {
+		const trace = packCommand.commands.find((command) => command.name() === "trace");
+		expect(trace).toBeDefined();
+		expect(trace?.registeredArguments[0]?.required).toBe(true);
+		expect(trace?.registeredArguments[0]?.name()).toBe("context");
+		const longs = trace?.options.map((option) => option.long) ?? [];
+		expect(longs).toContain("--db-path");
+		expect(longs).toContain("--json");
+		expect(longs).toContain("--working-set-file");
+		expect(longs).toContain("--project");
+		expect(longs).toContain("--all-projects");
+	});
+
+	it("renders grouped human-readable trace text", () => {
+		const rendered = renderPackTrace({
+			version: 1,
+			inputs: {
+				query: "continue viewer health work",
+				project: "codemem",
+				working_set_files: ["packages/ui/src/app.ts"],
+				token_budget: 1800,
+				limit: 10,
+			},
+			mode: {
+				selected: "task",
+				reasons: ["query matched task hints", "working set present"],
+			},
+			retrieval: {
+				candidate_count: 2,
+				candidates: [
+					{
+						id: 101,
+						rank: 1,
+						kind: "decision",
+						title: "Keep Search as the inspector entry point",
+						preview: "Search is the first manual query surface.",
+						scores: {
+							base_score: 1.2,
+							combined_score: 2.4,
+							recency: 0.9,
+							kind_bonus: 0.2,
+							quality_boost: 0.1,
+							working_set_overlap: 0.16,
+							query_path_overlap: 0,
+							personal_bias: 0,
+							shared_trust_penalty: 0,
+							recap_penalty: 0,
+							tasklike_penalty: 0,
+							text_overlap: 2,
+							tag_overlap: 1,
+						},
+						reasons: ["matched query terms", "selected for summary"],
+						disposition: "selected",
+						section: "summary",
+					},
+					{
+						id: 102,
+						rank: 2,
+						kind: "feature",
+						title: "Viewer Inspector follow-on",
+						preview: "Manual query inspection follows the CLI trace.",
+						scores: {
+							base_score: 0.8,
+							combined_score: 1.4,
+							recency: 0.8,
+							kind_bonus: 0.18,
+							quality_boost: 0.08,
+							working_set_overlap: 0,
+							query_path_overlap: 0,
+							personal_bias: 0,
+							shared_trust_penalty: 0,
+							recap_penalty: 0,
+							tasklike_penalty: 0,
+							text_overlap: 1,
+							tag_overlap: 0,
+						},
+						reasons: ["not selected for final pack"],
+						disposition: "dropped",
+						section: null,
+					},
+				],
+			},
+			assembly: {
+				deduped_ids: [],
+				collapsed_groups: [],
+				trimmed_ids: [],
+				trim_reasons: [],
+				sections: {
+					summary: [101],
+					timeline: [],
+					observations: [],
+				},
+			},
+			output: {
+				estimated_tokens: 42,
+				truncated: false,
+				section_counts: {
+					summary: 1,
+					timeline: 0,
+					observations: 0,
+				},
+				pack_text: "## Summary\n[101] (decision) Keep Search as the inspector entry point",
+			},
+		});
+
+		expect(rendered).toContain("Pack trace");
+		expect(rendered).toContain("Mode reasons: query matched task hints, working set present");
+		expect(rendered).toContain("Selected");
+		expect(rendered).toContain("Dropped");
+		expect(rendered).toContain("truncated: no");
+		expect(rendered).toContain("Final pack");
+		expect(rendered).toContain("## Summary");
+	});
+
+	it("supports the commander command path with json output", async () => {
+		buildMemoryPackTraceAsync.mockResolvedValue({
+			version: 1,
+			inputs: {
+				query: "continue viewer health work",
+				project: "codemem",
+				working_set_files: [],
+				token_budget: null,
+				limit: 10,
+			},
+			mode: { selected: "task", reasons: ["query matched task hints"] },
+			retrieval: { candidate_count: 0, candidates: [] },
+			assembly: {
+				deduped_ids: [],
+				collapsed_groups: [],
+				trimmed_ids: [],
+				trim_reasons: [],
+				sections: { summary: [], timeline: [], observations: [] },
+			},
+			output: {
+				estimated_tokens: 0,
+				truncated: false,
+				section_counts: { summary: 0, timeline: 0, observations: 0 },
+				pack_text: "",
+			},
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseTraceCommand(["continue viewer health work", "--json"]);
+
+		const output = logSpy.mock.calls.at(-1)?.[0];
+		expect(typeof output).toBe("string");
+		expect(JSON.parse(String(output))).toMatchObject({
+			version: 1,
+			mode: { selected: "task" },
+		});
+	});
+
+	it("emits structured json errors for trace failures", async () => {
+		buildMemoryPackTraceAsync.mockRejectedValue(new Error("trace blew up"));
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parseTraceCommand(["continue viewer health work", "--json"]);
+
+		const output = logSpy.mock.calls.at(-1)?.[0];
+		expect(JSON.parse(String(output))).toEqual({
+			error: "pack_trace_failed",
+			message: "trace blew up",
+		});
+		expect(process.exitCode).toBe(1);
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+
+	it("emits structured usage errors for invalid numeric json input", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parseTraceCommand(["continue viewer health work", "--json", "--limit", "nope"]);
+
+		const output = logSpy.mock.calls.at(-1)?.[0];
+		expect(JSON.parse(String(output))).toEqual({
+			error: "usage_error",
+			message: "limit must be a positive integer",
+		});
+		expect(process.exitCode).toBe(2);
+		expect(errorSpy).not.toHaveBeenCalled();
+		expect(buildMemoryPackTraceAsync).not.toHaveBeenCalled();
+	});
+
+	it("dispatches the nested pack trace commander path", async () => {
+		buildMemoryPackTraceAsync.mockResolvedValue({
+			version: 1,
+			inputs: {
+				query: "continue viewer health work",
+				project: null,
+				working_set_files: [],
+				token_budget: null,
+				limit: 10,
+			},
+			mode: { selected: "task", reasons: ["query matched task hints"] },
+			retrieval: { candidate_count: 0, candidates: [] },
+			assembly: {
+				deduped_ids: [],
+				collapsed_groups: [],
+				trimmed_ids: [],
+				trim_reasons: [],
+				sections: { summary: [], timeline: [], observations: [] },
+			},
+			output: {
+				estimated_tokens: 0,
+				truncated: false,
+				section_counts: { summary: 0, timeline: 0, observations: 0 },
+				pack_text: "",
+			},
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parsePackCommand(["trace", "continue viewer health work"]);
+
+		expect(buildMemoryPackTraceAsync).toHaveBeenCalledTimes(1);
+		expect(String(logSpy.mock.calls.at(-1)?.[0] ?? "")).toContain("Pack trace");
+	});
+
+	it("routes trace flags to the trace subcommand after the positional context", async () => {
+		buildMemoryPackTraceAsync.mockResolvedValue({
+			version: 1,
+			inputs: {
+				query: "continue viewer health work",
+				project: null,
+				working_set_files: [],
+				token_budget: null,
+				limit: 10,
+			},
+			mode: { selected: "task", reasons: ["query matched task hints"] },
+			retrieval: { candidate_count: 0, candidates: [] },
+			assembly: {
+				deduped_ids: [],
+				collapsed_groups: [],
+				trimmed_ids: [],
+				trim_reasons: [],
+				sections: { summary: [], timeline: [], observations: [] },
+			},
+			output: {
+				estimated_tokens: 0,
+				truncated: false,
+				section_counts: { summary: 0, timeline: 0, observations: 0 },
+				pack_text: "",
+			},
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parsePackCommand([
+			"trace",
+			"continue viewer health work",
+			"--json",
+			"--db-path",
+			"/tmp/codemem-test.sqlite",
+		]);
+
+		expect(buildMemoryPackTraceAsync).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({ version: 1 });
+		expect(storePaths.at(-1)).toBe("/tmp/codemem-test.sqlite");
+	});
+});

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -1,4 +1,5 @@
 import * as p from "@clack/prompts";
+import type { PackTrace } from "@codemem/core";
 import { MemoryStore, resolveDbPath } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
@@ -6,79 +7,185 @@ import {
 	addDbOption,
 	addJsonOption,
 	type DbOpts,
+	emitJsonError,
 	type JsonOpts,
 	resolveDbOpt,
 } from "../shared-options.js";
-import { buildPackRequestOptions, collectWorkingSetFile } from "./pack-shared.js";
+import { addPackRequestOptions, buildPackRequestOptions, PackUsageError } from "./pack-shared.js";
 
-const packCmd = new Command("pack")
-	.configureHelp(helpStyle)
-	.description("Build a context-aware memory pack")
-	.argument("<context>", "context string to search for")
-	.option("-n, --limit <n>", "max items", "10")
-	.option("--budget <tokens>", "token budget")
-	.option("--token-budget <tokens>", "token budget")
-	.option(
-		"--working-set-file <path>",
-		"recently modified file path used as ranking hint",
-		collectWorkingSetFile,
-		[],
-	)
-	.option("--project <project>", "project identifier (defaults to git repo root)")
-	.option("--all-projects", "search across all projects");
+type PackCommandOptions = DbOpts &
+	JsonOpts & {
+		limit: string;
+		budget?: string;
+		tokenBudget?: string;
+		workingSetFile?: string[];
+		project?: string;
+		allProjects?: boolean;
+	};
+
+function describeCandidate(candidate: PackTrace["retrieval"]["candidates"][number]): string[] {
+	const scoreParts = [
+		candidate.scores.combined_score != null
+			? `combined=${candidate.scores.combined_score.toFixed(2)}`
+			: null,
+		candidate.scores.base_score != null ? `base=${candidate.scores.base_score.toFixed(2)}` : null,
+		candidate.scores.text_overlap > 0 ? `text=${candidate.scores.text_overlap}` : null,
+		candidate.scores.tag_overlap > 0 ? `tag=${candidate.scores.tag_overlap}` : null,
+		candidate.scores.working_set_overlap > 0
+			? `working_set=${candidate.scores.working_set_overlap.toFixed(2)}`
+			: null,
+	]
+		.filter(Boolean)
+		.join(" ");
+
+	const lines = [`${candidate.rank}. [${candidate.id}] (${candidate.kind}) ${candidate.title}`];
+	if (candidate.section) lines.push(`   - section: ${candidate.section}`);
+	if (candidate.reasons.length > 0) lines.push(`   - reasons: ${candidate.reasons.join(", ")}`);
+	if (scoreParts) lines.push(`   - scores: ${scoreParts}`);
+	if (candidate.preview) lines.push(`   - preview: ${candidate.preview}`);
+	return lines;
+}
+
+export function renderPackTrace(trace: PackTrace): string {
+	const workingSet =
+		trace.inputs.working_set_files.length > 0
+			? trace.inputs.working_set_files.join(", ")
+			: "(none)";
+	const lines = [
+		"Pack trace",
+		`- Query: ${trace.inputs.query}`,
+		`- Project: ${trace.inputs.project ?? "(default)"}`,
+		`- Working set: ${workingSet}`,
+		`- Mode: ${trace.mode.selected}`,
+		`- Mode reasons: ${trace.mode.reasons.join(", ") || "(none)"}`,
+		`- Token budget: ${trace.inputs.token_budget ?? "(none)"}`,
+		"",
+	];
+
+	for (const disposition of ["selected", "dropped", "deduped", "trimmed"] as const) {
+		const group = trace.retrieval.candidates.filter(
+			(candidate) => candidate.disposition === disposition,
+		);
+		if (group.length === 0) continue;
+		lines.push(disposition.charAt(0).toUpperCase() + disposition.slice(1));
+		for (const candidate of group) {
+			lines.push(...describeCandidate(candidate));
+		}
+		lines.push("");
+	}
+
+	lines.push("Assembly");
+	lines.push(`- deduped ids: ${trace.assembly.deduped_ids.join(", ") || "(none)"}`);
+	lines.push(`- trimmed ids: ${trace.assembly.trimmed_ids.join(", ") || "(none)"}`);
+	lines.push(`- trim reasons: ${trace.assembly.trim_reasons.join(", ") || "(none)"}`);
+	lines.push(
+		`- section counts: summary=${trace.output.section_counts.summary} timeline=${trace.output.section_counts.timeline} observations=${trace.output.section_counts.observations}`,
+	);
+	lines.push(`- estimated tokens: ${trace.output.estimated_tokens}`);
+	lines.push(`- truncated: ${trace.output.truncated ? "yes" : "no"}`);
+	lines.push("");
+	lines.push("Final pack");
+	lines.push(trace.output.pack_text);
+	return lines.join("\n");
+}
+
+async function withStore(
+	opts: PackCommandOptions,
+	errorCode: string,
+	run: (store: MemoryStore) => Promise<void>,
+): Promise<void> {
+	let store: MemoryStore | null = null;
+	try {
+		store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		await run(store);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		const usageError = error instanceof PackUsageError;
+		if (opts.json) {
+			emitJsonError(usageError ? "usage_error" : errorCode, message, usageError ? 2 : 1);
+			return;
+		}
+		p.log.error(message);
+		process.exitCode = usageError ? 2 : 1;
+	} finally {
+		store?.close();
+	}
+}
+
+async function packAction(context: string, opts: PackCommandOptions): Promise<void> {
+	await withStore(opts, "pack_failed", async (store) => {
+		const { limit, budget, filters } = buildPackRequestOptions(opts, {
+			envProject: process.env.CODEMEM_PROJECT,
+		});
+		const result = await store.buildMemoryPackAsync(context, limit, budget, filters);
+
+		if (opts.json) {
+			console.log(JSON.stringify(result, null, 2));
+			return;
+		}
+
+		p.intro(`Memory pack for "${context}"`);
+
+		if (result.items.length === 0) {
+			p.log.warn("No relevant memories found.");
+			p.outro("done");
+			return;
+		}
+
+		const metrics = result.metrics;
+		p.log.info(
+			`${metrics.total_items} items, ~${metrics.pack_tokens} tokens` +
+				(metrics.fallback_used ? " (fallback)" : "") +
+				`  [fts:${metrics.sources.fts} sem:${metrics.sources.semantic} fuzzy:${metrics.sources.fuzzy}]`,
+		);
+
+		for (const item of result.items) {
+			p.log.step(`#${item.id}  ${item.kind}  ${item.title}`);
+		}
+
+		p.note(result.pack_text, "pack_text");
+		p.outro("done");
+	});
+}
+
+async function traceAction(context: string, opts: PackCommandOptions): Promise<void> {
+	await withStore(opts, "pack_trace_failed", async (store) => {
+		const { limit, budget, filters } = buildPackRequestOptions(opts, {
+			envProject: process.env.CODEMEM_PROJECT,
+		});
+		const trace = await store.buildMemoryPackTraceAsync(context, limit, budget, filters);
+
+		if (opts.json) {
+			console.log(JSON.stringify(trace, null, 2));
+			return;
+		}
+
+		console.log(renderPackTrace(trace));
+	});
+}
+
+const packCmd = addPackRequestOptions(
+	new Command("pack")
+		.enablePositionalOptions()
+		.configureHelp(helpStyle)
+		.description("Build a context-aware memory pack")
+		.argument("<context>", "context string to search for"),
+);
 
 addDbOption(packCmd);
 addJsonOption(packCmd);
+packCmd.action(packAction);
 
-export const packCommand = packCmd.action(
-	async (
-		context: string,
-		opts: DbOpts &
-			JsonOpts & {
-				limit: string;
-				budget?: string;
-				tokenBudget?: string;
-				workingSetFile?: string[];
-				project?: string;
-				allProjects?: boolean;
-			},
-	) => {
-		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
-		try {
-			const { limit, budget, filters } = buildPackRequestOptions(opts, {
-				envProject: process.env.CODEMEM_PROJECT,
-			});
-			const result = await store.buildMemoryPackAsync(context, limit, budget, filters);
-
-			if (opts.json) {
-				console.log(JSON.stringify(result, null, 2));
-				return;
-			}
-
-			p.intro(`Memory pack for "${context}"`);
-
-			if (result.items.length === 0) {
-				p.log.warn("No relevant memories found.");
-				p.outro("done");
-				return;
-			}
-
-			const m = result.metrics;
-			p.log.info(
-				`${m.total_items} items, ~${m.pack_tokens} tokens` +
-					(m.fallback_used ? " (fallback)" : "") +
-					`  [fts:${m.sources.fts} sem:${m.sources.semantic} fuzzy:${m.sources.fuzzy}]`,
-			);
-
-			for (const item of result.items) {
-				p.log.step(`#${item.id}  ${item.kind}  ${item.title}`);
-			}
-
-			p.note(result.pack_text, "pack_text");
-
-			p.outro("done");
-		} finally {
-			store.close();
-		}
-	},
+const traceCmd = addPackRequestOptions(
+	new Command("trace")
+		.configureHelp(helpStyle)
+		.description("Trace retrieval and assembly for a memory pack")
+		.argument("<context>", "context string to trace"),
 );
+
+addDbOption(traceCmd);
+addJsonOption(traceCmd);
+traceCmd.action(traceAction);
+packCmd.addCommand(traceCmd);
+
+export const packCommand = packCmd;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -97,6 +97,7 @@ const program = new Command();
 program
 	.name("codemem")
 	.description("codemem — persistent memory for AI coding agents")
+	.enablePositionalOptions()
 	.option("--install-completion", "install shell completion")
 	.option("--show-completion", "show shell completion install guidance")
 	.version(VERSION)


### PR DESCRIPTION
## Description
Add `codemem pack trace <context>` on top of the new core `PackTrace` API, with human-readable diagnostics by default and canonical JSON output for automation. The command now enforces structured JSON error handling for runtime and usage failures so it follows the CLI contract instead of falling over like an amateur hour debug flag.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `pnpm exec vitest run packages/cli/src/commands/pack.test.ts packages/cli/src/commands/pack-shared.test.ts`
- `pnpm exec tsc --noEmit -p packages/cli/tsconfig.json`
- `pnpm run tsc`
- `pnpm build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
