### PR TITLE
feat(viewer): add Context Inspector

### DIFF
--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -213,6 +213,7 @@ async function loadProjects() {
 
 $select('projectFilter')?.addEventListener('change', () => {
   state.currentProject = $select('projectFilter')?.value || '';
+  updateFeedView(true);
   refresh();
 });
 

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -18,6 +18,68 @@ export interface RuntimeInfo {
   version: string;
 }
 
+export interface PackTraceCandidate {
+  id: number;
+  rank: number;
+  kind: string;
+  title: string;
+  preview: string;
+  reasons: string[];
+  disposition: 'selected' | 'dropped' | 'deduped' | 'trimmed';
+  section: 'summary' | 'timeline' | 'observations' | null;
+  scores: {
+    base_score: number | null;
+    combined_score: number | null;
+    recency: number;
+    kind_bonus: number;
+    quality_boost: number;
+    working_set_overlap: number;
+    query_path_overlap: number;
+    personal_bias: number;
+    shared_trust_penalty: number;
+    recap_penalty: number;
+    tasklike_penalty: number;
+    text_overlap: number;
+    tag_overlap: number;
+  };
+}
+
+export interface PackTrace {
+  version: 1;
+  inputs: {
+    query: string;
+    project: string | null;
+    working_set_files: string[];
+    token_budget: number | null;
+    limit: number;
+  };
+  mode: {
+    selected: 'default' | 'task' | 'recall';
+    reasons: string[];
+  };
+  retrieval: {
+    candidate_count: number;
+    candidates: PackTraceCandidate[];
+  };
+  assembly: {
+    deduped_ids: number[];
+    collapsed_groups: Array<{
+      kept: number;
+      dropped: number[];
+      support_count: number;
+    }>;
+    trimmed_ids: number[];
+    trim_reasons: string[];
+    sections: Record<'summary' | 'timeline' | 'observations', number[]>;
+  };
+  output: {
+    estimated_tokens: number;
+    truncated: boolean;
+    section_counts: Record<'summary' | 'timeline' | 'observations', number>;
+    pack_text: string;
+  };
+}
+
 function payloadError(payload: unknown): string | undefined {
   if (!payload || typeof payload !== 'object') return undefined;
   const maybeError = (payload as { error?: unknown }).error;
@@ -122,6 +184,23 @@ export async function loadSummariesPage(
 ): Promise<any> {
   const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
   return fetchJson(`/api/summaries?${query}`);
+}
+
+export async function tracePack(payload: {
+  context: string;
+  project?: string | null;
+  working_set_files?: string[];
+  token_budget?: number | null;
+  limit?: number;
+}): Promise<PackTrace> {
+  const resp = await fetch('/api/pack/trace', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const { text, payload: data } = await readJsonPayload<PackTrace>(resp);
+  if (!resp.ok) throw new Error(payloadError(data) || text || 'request failed');
+  return data;
 }
 
 export async function loadObserverStatus(): Promise<any> {

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -824,6 +824,195 @@ function FeedToggle({
   );
 }
 
+function TraceCandidateGroup({
+  label,
+  candidates,
+}: {
+  label: string;
+  candidates: api.PackTraceCandidate[];
+}) {
+  if (candidates.length === 0) return null;
+  return h(
+    'div',
+    { className: 'trace-group' },
+    h('div', { className: 'section-meta' }, label),
+    h(
+      'div',
+      { className: 'feed-list' },
+      candidates.map((candidate) =>
+        h(
+          'div',
+          { className: 'feed-card', key: `${label}:${candidate.id}` },
+          h('div', { className: 'feed-card-header' }, [
+            h('div', { className: 'feed-card-title' }, `${candidate.rank}. ${candidate.title}`),
+            h('div', { className: 'feed-card-meta' }, `#${candidate.id} · ${candidate.kind}${candidate.section ? ` · ${candidate.section}` : ''}`),
+          ]),
+          h('div', { className: 'feed-card-body' }, [
+            h('div', null, candidate.preview || 'No preview available.'),
+            candidate.reasons.length
+              ? h('div', { className: 'section-meta' }, `Reasons: ${candidate.reasons.join(', ')}`)
+              : null,
+          ]),
+        ),
+      ),
+    ),
+  );
+}
+
+function ContextInspectorPanel() {
+  const [open, setOpen] = useState(false);
+  const [workingSetText, setWorkingSetText] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [errorContextKey, setErrorContextKey] = useState('');
+  const [trace, setTrace] = useState<api.PackTrace | null>(null);
+  const currentQuery = String(state.feedQuery || '').trim();
+  const currentProject = state.currentProject || null;
+  const currentContextKey = JSON.stringify([currentProject, currentQuery]);
+  const visibleTrace =
+    trace && trace.inputs.query === currentQuery && trace.inputs.project === currentProject ? trace : null;
+  const visibleError = error && errorContextKey === currentContextKey ? error : '';
+
+  useEffect(() => {
+    setError('');
+    setErrorContextKey('');
+    setTrace((currentTrace) => {
+      if (!currentTrace) return null;
+      if (currentTrace.inputs.query !== currentQuery || currentTrace.inputs.project !== currentProject) {
+        return null;
+      }
+      return currentTrace;
+    });
+  }, [currentProject, currentQuery]);
+
+  const runTrace = async () => {
+    const context = currentQuery;
+    const project = currentProject;
+    const contextKey = JSON.stringify([project, context]);
+    if (!context) {
+      setError('Enter a query to inspect.');
+      setErrorContextKey(contextKey);
+      setTrace(null);
+      return;
+    }
+    setLoading(true);
+    setError('');
+    setErrorContextKey('');
+    try {
+      const workingSetFiles = workingSetText
+        .split(/\n|,/)
+        .map((value) => value.trim())
+        .filter(Boolean);
+      const nextTrace = await api.tracePack({
+        context,
+        project,
+        working_set_files: workingSetFiles,
+      });
+      if (String(state.feedQuery || '').trim() !== context || (state.currentProject || null) !== project) {
+        return;
+      }
+      setTrace(nextTrace);
+    } catch (err) {
+      if (String(state.feedQuery || '').trim() !== context || (state.currentProject || null) !== project) {
+        return;
+      }
+      setError(err instanceof Error ? err.message : String(err));
+      setErrorContextKey(contextKey);
+      setTrace(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const selected = visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === 'selected') || [];
+  const dropped = visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === 'dropped') || [];
+  const deduped = visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === 'deduped') || [];
+  const trimmed = visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === 'trimmed') || [];
+
+  return h(
+    'div',
+    { className: 'feed-inspector' },
+    h(
+      'button',
+        {
+          className: 'toggle-button',
+          onClick: () => setOpen(!open),
+          type: 'button',
+        },
+      open ? 'Hide Context Inspector' : 'Open Context Inspector',
+    ),
+    open
+      ? h('div', { className: 'feed-card', style: 'margin-top:12px;' }, [
+          h('div', { className: 'feed-card-header' }, [
+            h('div', { className: 'feed-card-title' }, 'Context Inspector'),
+            h('div', { className: 'feed-card-meta' }, 'Tracing the current Search query'),
+          ]),
+          h('div', { className: 'feed-card-body' }, [
+            h('input', {
+              className: 'feed-search',
+              onInput: (event) => {
+                state.feedQuery = String((event.currentTarget as HTMLInputElement).value || '');
+                setTrace(null);
+                setError('');
+                setErrorContextKey('');
+                updateFeedView();
+              },
+              placeholder: 'Trace a pack query…',
+              value: state.feedQuery,
+            }),
+            h('textarea', {
+              onInput: (event) => setWorkingSetText(String((event.currentTarget as HTMLTextAreaElement).value || '')),
+              placeholder: 'Optional working-set files, one per line',
+              rows: 3,
+              style: 'margin-top:8px; width:100%;',
+              value: workingSetText,
+            }),
+            h(
+              'div',
+              { style: 'display:flex; gap:8px; margin-top:8px; align-items:center;' },
+              h(
+                'button',
+                { className: 'toggle-button active', disabled: loading, onClick: () => void runTrace(), type: 'button' },
+                loading ? 'Tracing…' : 'Run trace',
+              ),
+              visibleTrace
+                ? h('span', { className: 'section-meta' }, `mode=${visibleTrace.mode.selected} · candidates=${visibleTrace.retrieval.candidate_count} · tokens=${visibleTrace.output.estimated_tokens}`)
+                : null,
+            ),
+            trace && !visibleTrace
+              ? h('div', { className: 'section-meta', style: 'margin-top:8px;' }, 'Search context changed. Run trace again for the current query and project.')
+              : null,
+            visibleError ? h('div', { className: 'section-meta', style: 'margin-top:8px; color:#d96c6c;' }, visibleError) : null,
+          ]),
+          visibleTrace
+            ? h(Fragment, null, [
+                h(TraceCandidateGroup, { label: 'Selected', candidates: selected }),
+                h(TraceCandidateGroup, { label: 'Dropped', candidates: dropped }),
+                h(TraceCandidateGroup, { label: 'Deduped', candidates: deduped }),
+                h(TraceCandidateGroup, { label: 'Trimmed', candidates: trimmed }),
+                h('div', { className: 'feed-card-body' }, [
+                  visibleTrace.assembly.collapsed_groups.length
+                    ? h(
+                        'div',
+                        { className: 'section-meta' },
+                        `Collapsed duplicates: ${visibleTrace.assembly.collapsed_groups
+                          .map((group) => `kept #${group.kept} from [${group.dropped.join(', ')}]`)
+                          .join(' · ')}`,
+                      )
+                    : null,
+                  visibleTrace.assembly.trim_reasons.length
+                    ? h('div', { className: 'section-meta' }, `Trim reasons: ${visibleTrace.assembly.trim_reasons.join(', ')}`)
+                    : null,
+                  h('div', { className: 'section-meta' }, 'Final pack'),
+                  h('pre', { style: 'white-space:pre-wrap; overflow:auto;' }, visibleTrace.output.pack_text),
+                ]),
+              ])
+            : null,
+        ])
+      : null,
+  );
+}
+
 function FeedTabView({ items, loadingText }: { items: any[]; loadingText?: string }) {
   return h(
     Fragment,
@@ -845,6 +1034,7 @@ function FeedTabView({ items, loadingText }: { items: any[]; loadingText?: strin
           placeholder: 'Search title, body, tags…',
           value: state.feedQuery,
         }),
+        h(ContextInspectorPanel, {}),
         h(FeedToggle, {
           active: state.feedScopeFilter,
           id: 'feedScopeToggle',

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -576,6 +576,152 @@ describe("viewer-server", () => {
 		});
 	});
 
+	describe("POST /api/pack/trace", () => {
+		it("uses async pack trace builder path", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+
+				const expected = {
+					version: 1 as const,
+					inputs: {
+						query: "semantic context",
+						project: "test-project",
+						working_set_files: ["packages/ui/src/app.ts"],
+						token_budget: null,
+						limit: 10,
+					},
+					mode: {
+						selected: "task" as const,
+						reasons: ["query matched task hints"],
+					},
+					retrieval: {
+						candidate_count: 0,
+						candidates: [],
+					},
+					assembly: {
+						deduped_ids: [],
+						collapsed_groups: [],
+						trimmed_ids: [],
+						trim_reasons: [],
+						sections: {
+							summary: [],
+							timeline: [],
+							observations: [],
+						},
+					},
+					output: {
+						estimated_tokens: 0,
+						truncated: false,
+						section_counts: {
+							summary: 0,
+							timeline: 0,
+							observations: 0,
+						},
+						pack_text: "",
+					},
+				};
+
+				const asyncSpy = vi.spyOn(store, "buildMemoryPackTraceAsync").mockResolvedValue(expected);
+
+				const res = await app.request("/api/pack/trace", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						context: "semantic context",
+						project: "test-project",
+						working_set_files: ["packages/ui/src/app.ts"],
+					}),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toEqual(expected);
+				expect(asyncSpy).toHaveBeenCalledTimes(1);
+				expect(asyncSpy).toHaveBeenCalledWith("semantic context", 10, null, {
+					project: "test-project",
+					working_set_paths: ["packages/ui/src/app.ts"],
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects invalid trace payloads", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const invalidJson = await app.request("/api/pack/trace", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: "{not-json",
+				});
+				expect(invalidJson.status).toBe(400);
+				expect(await invalidJson.json()).toEqual({ error: "invalid json body" });
+
+				const missingContext = await app.request("/api/pack/trace", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ project: "test-project" }),
+				});
+				expect(missingContext.status).toBe(400);
+				expect(await missingContext.json()).toEqual({ error: "context required" });
+
+				const nonStringContext = await app.request("/api/pack/trace", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ context: { bad: true } }),
+				});
+				expect(nonStringContext.status).toBe(400);
+				expect(await nonStringContext.json()).toEqual({ error: "context required" });
+
+				const badLimit = await app.request("/api/pack/trace", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ context: "semantic context", limit: 3.5 }),
+				});
+				expect(badLimit.status).toBe(400);
+				expect(await badLimit.json()).toEqual({ error: "limit must be a positive int" });
+
+				const badBudget = await app.request("/api/pack/trace", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ context: "semantic context", token_budget: 2.5 }),
+				});
+				expect(badBudget.status).toBe(400);
+				expect(await badBudget.json()).toEqual({ error: "token_budget must be int" });
+
+				const badWorkingSet = await app.request("/api/pack/trace", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						context: "semantic context",
+						working_set_files: "packages/ui/src/app.ts",
+					}),
+				});
+				expect(badWorkingSet.status).toBe(400);
+				expect(await badWorkingSet.json()).toEqual({
+					error: "working_set_files must be an array of strings",
+				});
+
+				const mixedWorkingSet = await app.request("/api/pack/trace", {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({
+						context: "semantic context",
+						working_set_files: ["packages/ui/src/app.ts", 123],
+					}),
+				});
+				expect(mixedWorkingSet.status).toBe(400);
+				expect(await mixedWorkingSet.json()).toEqual({
+					error: "working_set_files must be an array of strings",
+				});
+			} finally {
+				cleanup();
+			}
+		});
+	});
+
 	describe("GET /api/observer-status", () => {
 		it("returns live observer status and suppresses stale failures after success", async () => {
 			const { store, cleanup } = createTestStore();

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -351,6 +351,61 @@ export function memoryRoutes(getStore: StoreFactory) {
 		}
 	});
 
+	app.post("/api/pack/trace", async (c) => {
+		const store = getStore();
+		const parsed = await c.req.json().catch(() => Symbol.for("invalid-json"));
+		if (parsed === Symbol.for("invalid-json")) {
+			return c.json({ error: "invalid json body" }, 400);
+		}
+		const body = parsed as {
+			context?: unknown;
+			limit?: unknown;
+			token_budget?: unknown;
+			project?: unknown;
+			working_set_files?: unknown;
+		} | null;
+		const context = typeof body?.context === "string" ? body.context.trim() : "";
+		if (!context) {
+			return c.json({ error: "context required" }, 400);
+		}
+		const limit =
+			body?.limit == null
+				? 10
+				: typeof body.limit === "number" && Number.isInteger(body.limit) && body.limit >= 1
+					? body.limit
+					: null;
+		if (limit == null) {
+			return c.json({ error: "limit must be a positive int" }, 400);
+		}
+		let tokenBudget: number | null = null;
+		if (body?.token_budget != null) {
+			if (
+				typeof body.token_budget !== "number" ||
+				!Number.isInteger(body.token_budget) ||
+				body.token_budget < 0
+			) {
+				return c.json({ error: "token_budget must be int" }, 400);
+			}
+			tokenBudget = body.token_budget;
+		}
+		const project = typeof body?.project === "string" && body.project.trim() ? body.project : null;
+		if (body?.working_set_files != null && !Array.isArray(body.working_set_files)) {
+			return c.json({ error: "working_set_files must be an array of strings" }, 400);
+		}
+		if (
+			Array.isArray(body?.working_set_files) &&
+			body.working_set_files.some((value) => typeof value !== "string")
+		) {
+			return c.json({ error: "working_set_files must be an array of strings" }, 400);
+		}
+		const workingSetFiles = Array.isArray(body?.working_set_files) ? body.working_set_files : [];
+		const filters: { project?: string; working_set_paths?: string[] } = {};
+		if (project) filters.project = project;
+		if (workingSetFiles.length > 0) filters.working_set_paths = workingSetFiles;
+		const trace = await store.buildMemoryPackTraceAsync(context, limit, tokenBudget, filters);
+		return c.json(trace);
+	});
+
 	// GET /api/memory
 	app.get("/api/memory", (c) => {
 		const store = getStore();


### PR DESCRIPTION
## Description
Add a Search-entry Context Inspector backed by the canonical `PackTrace` JSON so retrieval candidates and final pack output can be inspected from the viewer. The route and UI were tightened to reject malformed payloads, expose collapse/trim rationale, and avoid stale query or project state leaking into the inspector after context changes or async races.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

- `pnpm exec vitest run packages/viewer-server/src/index.test.ts`
- `pnpm --filter @codemem/ui typecheck`
- `pnpm run tsc`
- `pnpm build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
