### PR TITLE
fix(build): force declaration rebuilds after clean

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -18,7 +18,7 @@
 	],
 	"scripts": {
 		"clean": "rm -rf dist tsconfig.tsbuildinfo",
-		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist && pnpm exec tsc --build",
+		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist && pnpm exec tsc --build --force",
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -16,7 +16,7 @@
 	],
 	"scripts": {
 		"clean": "rm -rf dist tsconfig.tsbuildinfo",
-		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist && pnpm exec tsc --build",
+		"build": "pnpm exec vite build --ssr src/index.ts --outDir dist && pnpm exec tsc --build --force",
 		"typecheck": "pnpm exec tsc --noEmit"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Description
Force declaration rebuilds for `@codemem/mcp` and `@codemem/server` after clean builds so workspace typechecking stays deterministic. This fixes the stale incremental build state where `dist/` was gone but TypeScript still skipped declaration emission, leaving the CLI unable to resolve package typings.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

- `pnpm --filter @codemem/mcp clean && pnpm --filter @codemem/server clean && pnpm --filter @codemem/mcp build && pnpm --filter @codemem/server build`
- `pnpm run tsc`
- `pnpm build`

## Checklist

- [x] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
