### PR TITLE
feat(mcp,cli): expose compact pack mode to consumers

### DIFF
--- a/packages/cli/src/commands/pack-shared.ts
+++ b/packages/cli/src/commands/pack-shared.ts
@@ -1,3 +1,4 @@
+import type { PackRenderOptions } from "@codemem/core";
 import { resolveProject } from "@codemem/core";
 import type { Command } from "commander";
 
@@ -7,6 +8,7 @@ export type PackRequestOptions = {
 	limit: number;
 	budget: number | undefined;
 	filters: PackFilters;
+	renderOptions?: PackRenderOptions;
 };
 
 export class PackUsageError extends Error {
@@ -32,7 +34,9 @@ export function addPackRequestOptions(command: Command): Command {
 			[],
 		)
 		.option("--project <project>", "project identifier (defaults to git repo root)")
-		.option("--all-projects", "search across all projects");
+		.option("--all-projects", "search across all projects")
+		.option("--compact", "render a scannable index with full detail only for top N items")
+		.option("--compact-detail <n>", "items to show in full detail in compact mode (default 3)");
 }
 
 export function buildPackRequestOptions(
@@ -43,6 +47,8 @@ export function buildPackRequestOptions(
 		workingSetFile?: string[];
 		project?: string;
 		allProjects?: boolean;
+		compact?: boolean;
+		compactDetail?: string;
 	},
 	ctx: {
 		cwd?: string;
@@ -69,7 +75,18 @@ export function buildPackRequestOptions(
 		filters.working_set_paths = opts.workingSetFile;
 	}
 
-	return { limit, budget, filters };
+	let renderOptions: PackRenderOptions | undefined;
+	if (opts.compact || opts.compactDetail != null) {
+		renderOptions = { compact: true };
+		if (opts.compactDetail != null) {
+			renderOptions.compactDetailCount = parseNonNegativeInt(
+				opts.compactDetail,
+				"compact detail count",
+			);
+		}
+	}
+
+	return { limit, budget, filters, renderOptions };
 }
 
 function parsePositiveInt(value: string, label: string): number {

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -21,6 +21,8 @@ type PackCommandOptions = DbOpts &
 		workingSetFile?: string[];
 		project?: string;
 		allProjects?: boolean;
+		compact?: boolean;
+		compactDetail?: string;
 	};
 
 function describeCandidate(candidate: PackTrace["retrieval"]["candidates"][number]): string[] {
@@ -114,10 +116,10 @@ async function withStore(
 
 async function packAction(context: string, opts: PackCommandOptions): Promise<void> {
 	await withStore(opts, "pack_failed", async (store) => {
-		const { limit, budget, filters } = buildPackRequestOptions(opts, {
+		const { limit, budget, filters, renderOptions } = buildPackRequestOptions(opts, {
 			envProject: process.env.CODEMEM_PROJECT,
 		});
-		const result = await store.buildMemoryPackAsync(context, limit, budget, filters);
+		const result = await store.buildMemoryPackAsync(context, limit, budget, filters, renderOptions);
 
 		if (opts.json) {
 			console.log(JSON.stringify(result, null, 2));
@@ -150,10 +152,16 @@ async function packAction(context: string, opts: PackCommandOptions): Promise<vo
 
 async function traceAction(context: string, opts: PackCommandOptions): Promise<void> {
 	await withStore(opts, "pack_trace_failed", async (store) => {
-		const { limit, budget, filters } = buildPackRequestOptions(opts, {
+		const { limit, budget, filters, renderOptions } = buildPackRequestOptions(opts, {
 			envProject: process.env.CODEMEM_PROJECT,
 		});
-		const trace = await store.buildMemoryPackTraceAsync(context, limit, budget, filters);
+		const trace = await store.buildMemoryPackTraceAsync(
+			context,
+			limit,
+			budget,
+			filters,
+			renderOptions,
+		);
 
 		if (opts.json) {
 			console.log(JSON.stringify(trace, null, 2));

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -440,16 +440,34 @@ async function main() {
 		{
 			context: z.string().describe("Context description to search for"),
 			limit: z.number().int().min(1).max(50).optional().describe("Max items to include"),
+			compact: z
+				.boolean()
+				.optional()
+				.describe(
+					"When true, render a scannable index of all items with full detail only for the top N (default 3). Saves tokens when broad overview matters more than per-item detail.",
+				),
+			compact_detail_count: z
+				.number()
+				.int()
+				.min(0)
+				.max(50)
+				.optional()
+				.describe("Number of items to show in full detail in compact mode (default 3)"),
 			...filterSchema,
 		},
 		async (args) => {
 			try {
 				const filters = buildFilters(args);
+				const renderOptions =
+					args.compact || args.compact_detail_count != null
+						? { compact: args.compact ?? true, compactDetailCount: args.compact_detail_count }
+						: undefined;
 				const result = await store.buildMemoryPackAsync(
 					args.context,
 					args.limit ?? undefined,
 					null,
 					filters,
+					renderOptions,
 				);
 				return jsonContent(result);
 			} catch (err) {


### PR DESCRIPTION
## Description

Expose the compact pack rendering mode to MCP and CLI consumers.

**Part 2 of 3** in the Phase A pack usefulness stack ([design doc](docs/plans/2026-04-08-pack-usefulness-roadmap.md), bead: codemem-wp2k).

### MCP: `memory_pack` tool
- `compact` (boolean, optional): render scannable index with full detail only for top N
- `compact_detail_count` (int, optional): items to show in full detail (default 3)

### CLI: `codemem pack`
- `--compact`: enable compact rendering
- `--compact-detail <n>`: set detail count

### Changes
- `packages/mcp-server/src/index.ts`: add compact params to `memory_pack` tool schema
- `packages/cli/src/commands/pack-shared.ts`: add `--compact`/`--compact-detail` options, return `renderOptions` from builder
- `packages/cli/src/commands/pack.ts`: thread `renderOptions` to store methods

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Tests pass locally (`pnpm run test` — 1036 pass)
- [x] Typecheck clean (`pnpm run tsc`)

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [x] No new warnings introduced