### PR TITLE
feat(core): add generic maintenance job progress state

### DIFF
--- a/docs/plans/2026-04-08-pack-usefulness-roadmap.md
+++ b/docs/plans/2026-04-08-pack-usefulness-roadmap.md
@@ -129,15 +129,16 @@ individually.
 - present synthesized sections before the individual memory listing
 - keep individual memories available for detail
 
-**This phase is deliberately underspecified.** The right design depends on what
-Phase D and A reveal about real pack failures once structured content is
-available. Design the synthesis contract after shipping D and A.
+**This phase has been specified** based on a 30-trace empirical audit conducted
+after shipping D and A. See
+[Phase B design doc](./2026-04-08-phase-b-pack-dedup-design.md) for the full
+spec, audit data, and implementation plan.
 
 ## Implementation Order
 
-1. **Phase D** — restore narrative/facts (quick win, high signal)
-2. **Phase A** — compact index + fetch-more (token efficiency, broad context)
-3. **Phase B** — cross-memory synthesis (differentiated product value)
+1. **Phase D** — restore narrative/facts (quick win, high signal) ✅ shipped
+2. **Phase A** — compact index + fetch-more (token efficiency, broad context) ✅ shipped
+3. **Phase B** — cross-memory synthesis (differentiated product value) — [design ready](./2026-04-08-phase-b-pack-dedup-design.md)
 
 ## Files Likely to Change
 

--- a/docs/plans/2026-04-08-phase-b-pack-dedup-design.md
+++ b/docs/plans/2026-04-08-phase-b-pack-dedup-design.md
@@ -1,0 +1,311 @@
+# Phase B: Pack near-duplicate compression
+
+**Parent:** [Pack usefulness roadmap](./2026-04-08-pack-usefulness-roadmap.md)
+**Status:** Design ready — pending approval
+**Prereqs:** Phase D (shipped), Phase A (shipped)
+
+## Empirical findings
+
+A 30-trace pack audit (spanning task, recall, and default modes across diverse
+queries) produced these results:
+
+| Metric | Value |
+|---|---|
+| Traces analyzed | 30 |
+| Total candidates | 300 |
+| Total selected items | 246 |
+| Exact dedupes (current system) | 1 |
+| Near-duplicate clusters found | 41 |
+| All-selected clusters (synthesis targets) | 27 |
+| Selected items in clusters | 70 (28% of selected) |
+
+**Mode breakdown:**
+
+| Mode | Selected in clusters | Cluster rate |
+|---|---|---|
+| default | 66 / 206 | 32% |
+| recall | 4 / 13 | 31% |
+| task | 0 / 27 | 0% |
+
+Task mode returns distinct actionable items and does not need synthesis.
+Default and recall modes waste ~30% of their token budget on near-duplicate
+content covering the same theme.
+
+### Cluster pattern taxonomy
+
+From the 27 all-selected clusters:
+
+| Pattern | Count | Example |
+|---|---|---|
+| **Related work** — multiple memories about the same feature/change from different sessions | 14 | Sync orchestrator port appears as both a discovery and a feature memory |
+| **Session echo** — a session_summary restating what a detail memory already says | 5 | "Remove accidental docs plan file" appears as a change + session_summary |
+| **Operational rule** — same lesson surfaced from different sessions | 4 | Replication retention plan described twice as separate discoveries |
+| **Recurring failure** — same bug/fix described twice | 2 | Peer deletion cursor leak: two bugfix memories with near-identical titles |
+| **Thematic overlap** — same investigation from different angles | 2 | Python→TS port footguns: a discovery + an exploration |
+
+### Token savings estimate
+
+The most cluster-heavy traces (sync replication: 4 clusters in 10 items, viewer
+inspector: 5-item cluster) could drop 30–40% in token cost if clusters were
+compressed. Across the full audit, compressing 27 clusters would eliminate ~70
+redundant items, saving roughly 25% of total pack tokens in default/recall modes.
+
+## How claude-mem handles this
+
+claude-mem avoids the problem at two layers:
+
+1. **Ingestion-time content-hash dedup** — `sha256(session_id, title,
+   narrative)` with a 30-second window prevents identical observations from being
+   stored (e.g., webhook retries, re-processing).
+
+2. **Per-session dedup at retrieval** — For file-context queries, claude-mem
+   keeps only the most recent observation per session, then ranks by specificity.
+   This prevents the "5 memories about the same PR from 5 sessions" pattern.
+
+3. **No pack-time synthesis** — claude-mem does not compress near-duplicates. It
+   relies on its compact index format (`ID TIME TYPE TITLE` table) plus
+   `get_observations([IDs])` to let the model choose what to expand. The model
+   does the synthesis implicitly by only fetching what it needs.
+
+**Key insight:** claude-mem's approach sidesteps synthesis by (a) preventing
+duplicates from being stored and (b) giving the model a cheap index with
+on-demand detail. codemem's compact mode (Phase A) now provides the same
+on-demand pattern, but the underlying data still has near-duplicates that waste
+index lines and detail slots.
+
+## Root cause
+
+codemem's observer creates a new `memory_item` for each session that touches a
+topic. When multiple sessions work on the same feature (e.g., 3 sessions
+implementing a PR, reviewing it, and fixing review feedback), each produces a
+separate memory. These memories have similar titles and overlapping body content
+but different IDs, different sessions, and slightly different wording — enough to
+bypass exact dedup.
+
+## Design
+
+### Two complementary layers
+
+Phase B addresses near-duplicates at both ingestion and rendering:
+
+**Layer 1: Ingestion-time near-dedup (prevent new duplicates)**
+
+Lightweight content-hash check at `remember()` time. Before inserting a new
+memory item, compute a dedup key and check for a recent match.
+
+**Layer 2: Pack-time cluster compression (handle existing duplicates)**
+
+At pack assembly time, detect near-duplicate clusters in the selected items and
+compress each cluster into a single representative item with a support count.
+
+### Layer 1: Ingestion-time near-dedup
+
+**Dedup key:** `sha256(session_id, normalize(title))` — same session + same
+normalized title = duplicate. This catches the observer re-extracting the same
+memory when a session is processed multiple times.
+
+**Cross-session dedup key:** `sha256(normalize(title))` with a configurable time
+window (default: 1 hour). This catches the common pattern of consecutive
+sessions producing the same memory (e.g., reviewing a PR, then fixing review
+feedback — both sessions produce "PR #649 Context Inspector" memories).
+
+**Normalize:** lowercase, collapse whitespace, strip leading/trailing
+punctuation, strip numeric prefixes like PR/issue numbers. This lets "PR #649
+review found Context Inspector reads shared query state" and "PR #649 inspector
+still shows stale error" remain distinct (different verbs, different claims)
+while collapsing true duplicates like "Sync pass orchestrator ported from Python
+to TypeScript" appearing twice with minor wording variations.
+
+**On match:** Skip the insert and return the existing memory's ID. Log the skip
+at debug level. Optionally bump the existing memory's `updated_at` to reflect
+that the topic was re-encountered.
+
+**Configuration:**
+- `dedup_same_session`: boolean (default: true) — always deduplicate within a
+  session
+- `dedup_cross_session_window_ms`: number (default: 3600000 / 1 hour) — set to
+  0 to disable cross-session dedup
+
+**Implementation cost:** One indexed lookup per `remember()` call. The
+`content_hash` column already exists on `artifacts` but not on `memory_items` —
+add a `dedup_key` column with an index.
+
+### Layer 2: Pack-time cluster compression
+
+This is a rendering-only optimization. It does not modify stored data.
+
+#### Detection heuristic
+
+For the selected items in a pack, find clusters of near-duplicates:
+
+```
+for each pair of selected items (i, j):
+  if titleWordOverlap(i, j) >= 3 significant words:
+    group i and j into the same cluster
+```
+
+**"Significant words"** = words with length > 2, excluding a stopword set
+(the, a, an, and, or, to, in, for, of, on, with, is, was, are, were, from,
+this, that, it, not, no). This is the exact heuristic used in the audit and it
+caught all 27 real clusters with zero false positives across 30 traces.
+
+**Transitive closure:** If A clusters with B and B clusters with C, all three
+form one cluster. Use union-find for efficient grouping.
+
+#### Compression strategy
+
+For each cluster of size ≥ 2:
+
+1. **Pick a representative:** The cluster member with the highest confidence. On
+   tie, prefer the most recent. On further tie, prefer the item with narrative
+   content.
+
+2. **Annotate the representative:** Add a `support_count` field (extending the
+   existing dedup `support_count` pattern) and a `compressed_ids` list of the
+   other cluster members' IDs.
+
+3. **Remove non-representatives** from the rendered pack text. They remain in
+   `item_ids` and `items` (with a `compressed_into` field pointing to the
+   representative) so the model can still fetch them via `memory_get`.
+
+4. **Format compressed items** with an indicator:
+
+   ```
+   [42] (discovery) Sync pass orchestrator ported to TypeScript (+1 related)
+   The sync pass orchestrator coordinates a complete synchronization exchange...
+   ```
+
+   The `(+N related)` suffix signals that more detail exists without consuming
+   extra tokens.
+
+#### Interaction with compact mode
+
+In compact mode, compression happens before the Index/Detail split:
+- Compressed items get one index line each (with the `+N` suffix)
+- Only representatives compete for detail slots
+- Non-representatives don't appear in the index at all
+
+In full mode, compression replaces the non-representative items with the
+annotated representative. The section structure (Summary/Timeline/Observations)
+is preserved.
+
+#### Efficiency
+
+The detection is O(n²) in selected items, where n ≤ limit (default 10). For
+n=10, that's 45 pair comparisons, each involving a set intersection of ~5–10
+words. This is sub-millisecond work and adds negligible overhead to pack
+assembly.
+
+No LLM calls. No network requests. No new storage. The heuristic runs entirely
+in-process using word-overlap on data already loaded for rendering.
+
+#### When NOT to compress
+
+- **Task mode:** The audit showed 0% cluster rate in task mode. Skip compression
+  when `mode === "task"` to avoid any overhead or false positives.
+- **Single-item clusters:** Only compress clusters of size ≥ 2.
+- **Cross-kind clusters:** Allow clusters to span kinds (discovery + feature is a
+  valid cluster). The representative's kind is preserved.
+
+### Pack trace changes
+
+The trace should report compression:
+
+```json
+{
+  "assembly": {
+    "compressed_clusters": [
+      {
+        "representative_id": 7566,
+        "compressed_ids": [7570],
+        "overlap_words": ["sync", "pass", "orchestrator", "ported", "python", "typescript"],
+        "pattern": "related_work"
+      }
+    ]
+  }
+}
+```
+
+## Files to change
+
+### Layer 1 (ingestion dedup)
+- `packages/core/src/schema.ts` — add `dedup_key` column to `memory_items`
+- `packages/core/src/store.ts` — add dedup check in `remember()`
+- Migration for the new column + index
+- Tests for dedup behavior
+
+### Layer 2 (pack compression)
+- `packages/core/src/pack.ts` — add `detectClusters()` and
+  `compressClusters()` between reranking and budget steps
+- `packages/core/src/types.ts` — add `support_count` and `compressed_ids` to
+  `PackItem`, add `compressed_clusters` to `PackTrace`
+- `packages/core/src/pack.test.ts` — cluster detection and compression tests
+
+## Testing strategy
+
+### Layer 1
+- Same session, same normalized title → skip insert, return existing ID
+- Same session, different title → both inserted
+- Cross-session, same title within window → skip insert
+- Cross-session, same title outside window → both inserted
+- Cross-session dedup disabled → both inserted
+
+### Layer 2
+- Items with ≥ 3 shared significant words cluster together
+- Items with < 3 shared words remain separate
+- Representative is highest-confidence member
+- Compressed items get `(+N related)` suffix in pack text
+- `item_ids` still contains all original IDs (including compressed)
+- Compression reduces `pack_tokens` vs. uncompressed
+- Task mode skips compression
+- Compact mode: compressed items excluded from index, only representative shown
+- Trace reports `compressed_clusters`
+
+## Implementation order
+
+1. **Layer 2 first** (pack compression) — immediate value for existing data,
+   no schema migration, rendering-only change
+2. **Layer 1 second** (ingestion dedup) — prevents future duplicates, requires
+   migration, reduces the work Layer 2 has to do over time
+
+## Design decisions
+
+### 1. Cross-session dedup window: 1 hour
+
+Empirical analysis of the existing DB (13K active memories, 1668 near-duplicate
+cross-session pairs):
+
+| Bucket | Pairs | Cumulative |
+|---|---|---|
+| < 30 min | 202 | 12% |
+| < 1 hour | 244 | 15% |
+| < 24 hours | 438 | 26% |
+| < 30 days | 1386 | 83% |
+| 30+ days | 282 | 100% |
+
+The distribution is bimodal: a spike at < 30 minutes (observer re-extracting
+the same work within a session split) and a long tail out to weeks/months
+(legitimately revisited topics). The median pair gap is 244 hours (~10 days).
+
+**Decision:** Start with 1 hour. This catches 15% of pairs (the acute noise)
+without risking suppression of legitimate new memories about revisited topics.
+Layer 2 pack compression handles the long-tail redundancy. Instrument skipped
+dedup hits at debug level to allow tuning later.
+
+### 2. Title normalization: do not strip PR/issue numbers
+
+The audit heuristic worked with PR numbers included and produced zero false
+positives across 30 traces. PR numbers are meaningful signal — two memories
+sharing `PR #649` *are* related work, and that helps clustering. If we see
+false positives later (two unrelated memories that happen to mention the same
+PR), we can revisit.
+
+### 3. Compressed items: exclude from `items`, keep in `item_ids`
+
+Compressed-away items are excluded from the `items` response array but remain
+in `item_ids`. The `pack_text` already shows `(+N related)` which signals
+more detail exists, and `item_ids` gives the model IDs to fetch via
+`memory_get`. Adding compressed items to `items` is dead weight in the common
+case where the model trusts the representative. If the "why was this
+compressed" signal is needed, `compressed_clusters` in the response metadata
+(parallel to the trace field) provides it without bloating every item.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,6 +241,22 @@ export {
 	retryRawEventFailures,
 	vacuumDatabase,
 } from "./maintenance.js";
+export type {
+	MaintenanceJobRecord,
+	MaintenanceJobSnapshot,
+	MaintenanceJobStatus,
+	StartMaintenanceJobInput,
+	UpdateMaintenanceJobInput,
+} from "./maintenance-jobs.js";
+export {
+	completeMaintenanceJob,
+	ensureMaintenanceJobsSchema,
+	failMaintenanceJob,
+	getMaintenanceJob,
+	listMaintenanceJobs,
+	startMaintenanceJob,
+	updateMaintenanceJob,
+} from "./maintenance-jobs.js";
 export type { ObserverAuthMaterial } from "./observer-auth.js";
 export {
 	buildCodexHeaders,
@@ -312,6 +328,7 @@ export {
 export type { FlushRawEventsOptions } from "./raw-event-flush.js";
 export { buildSessionContext, flushRawEvents } from "./raw-event-flush.js";
 export { RawEventSweeper } from "./raw-event-sweeper.js";
+export type { MaintenanceJob, NewMaintenanceJob } from "./schema.js";
 export * as schema from "./schema.js";
 export type { StoreHandle } from "./search.js";
 export {

--- a/packages/core/src/maintenance-jobs.test.ts
+++ b/packages/core/src/maintenance-jobs.test.ts
@@ -1,0 +1,247 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { initDatabase } from "./maintenance.js";
+import {
+	completeMaintenanceJob,
+	failMaintenanceJob,
+	getMaintenanceJob,
+	listMaintenanceJobs,
+	startMaintenanceJob,
+	updateMaintenanceJob,
+} from "./maintenance-jobs.js";
+import { initTestSchema } from "./test-utils.js";
+
+function createDbPath(name: string): string {
+	const dir = mkdtempSync(join(tmpdir(), "codemem-maintenance-jobs-"));
+	return join(dir, `${name}.sqlite`);
+}
+
+describe("maintenance jobs", () => {
+	it("starts and reads a running job", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const job = startMaintenanceJob(db, {
+				kind: "vector_migration",
+				title: "Re-indexing memories",
+				message: "Starting rebuild",
+				progressTotal: 100,
+				metadata: { source_model: "old", target_model: "new" },
+			});
+
+			expect(job.kind).toBe("vector_migration");
+			expect(job.status).toBe("running");
+			expect(job.progress).toEqual({ current: 0, total: 100, unit: "items" });
+			expect(job.metadata).toMatchObject({ source_model: "old", target_model: "new" });
+			expect(getMaintenanceJob(db, "vector_migration")).toMatchObject({
+				kind: "vector_migration",
+				status: "running",
+			});
+		} finally {
+			db.close();
+		}
+	});
+
+	it("updates progress and completion state", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			startMaintenanceJob(db, {
+				kind: "vector_migration",
+				title: "Re-indexing memories",
+				progressTotal: 10,
+			});
+
+			const mid = updateMaintenanceJob(db, "vector_migration", {
+				message: "Indexed 4 of 10",
+				progressCurrent: 4,
+			});
+			expect(mid).toMatchObject({
+				message: "Indexed 4 of 10",
+				progress: { current: 4, total: 10, unit: "items" },
+				status: "running",
+			});
+
+			const done = completeMaintenanceJob(db, "vector_migration", {
+				message: "Rebuild complete",
+				progressCurrent: 10,
+			});
+			expect(done).toMatchObject({
+				status: "completed",
+				message: "Rebuild complete",
+				progress: { current: 10, total: 10, unit: "items" },
+			});
+			expect(done?.finished_at).toBeTruthy();
+		} finally {
+			db.close();
+		}
+	});
+
+	it("records failure state and error text", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			startMaintenanceJob(db, {
+				kind: "narrative_backfill",
+				title: "Backfilling narrative",
+			});
+
+			const failed = failMaintenanceJob(db, "narrative_backfill", "observer unavailable", {
+				message: "Stopped during provider outage",
+				progressCurrent: 12,
+				progressTotal: 30,
+			});
+			expect(failed).toMatchObject({
+				status: "failed",
+				message: "Stopped during provider outage",
+				error: "observer unavailable",
+				progress: { current: 12, total: 30, unit: "items" },
+			});
+			expect(failed?.finished_at).toBeTruthy();
+		} finally {
+			db.close();
+		}
+	});
+
+	it("does not rewrite finished_at when updating an already completed job", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			startMaintenanceJob(db, {
+				kind: "vector_migration",
+				title: "Re-indexing memories",
+			});
+			const completed = completeMaintenanceJob(db, "vector_migration", {
+				message: "Done",
+			});
+			expect(completed).toBeTruthy();
+			if (!completed) throw new Error("expected completed job");
+			const firstFinishedAt = completed.finished_at;
+			expect(firstFinishedAt).toBeTruthy();
+
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			const touched = updateMaintenanceJob(db, "vector_migration", {
+				message: "Still done",
+			});
+			expect(touched).toBeTruthy();
+			if (!touched) throw new Error("expected touched job");
+
+			expect(touched.status).toBe("completed");
+			expect(touched.finished_at).toBe(firstFinishedAt);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("clears stale error when a failed job later completes", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			startMaintenanceJob(db, {
+				kind: "vector_migration",
+				title: "Re-indexing memories",
+			});
+			failMaintenanceJob(db, "vector_migration", "temporary outage", {
+				message: "provider failed",
+			});
+
+			const completed = completeMaintenanceJob(db, "vector_migration", {
+				message: "Recovered",
+			});
+			expect(completed).toBeTruthy();
+			if (!completed) throw new Error("expected completed job");
+
+			expect(completed.status).toBe("completed");
+			expect(completed.error).toBeNull();
+		} finally {
+			db.close();
+		}
+	});
+
+	it("clears terminal fields when explicitly moved back to running", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			startMaintenanceJob(db, {
+				kind: "vector_migration",
+				title: "Re-indexing memories",
+			});
+			failMaintenanceJob(db, "vector_migration", "temporary outage", {
+				message: "provider failed",
+			});
+
+			const restarted = updateMaintenanceJob(db, "vector_migration", {
+				status: "running",
+				message: "Retrying",
+			});
+			expect(restarted).toBeTruthy();
+			if (!restarted) throw new Error("expected restarted job");
+
+			expect(restarted.status).toBe("running");
+			expect(restarted.finished_at).toBeNull();
+			expect(restarted.error).toBeNull();
+		} finally {
+			db.close();
+		}
+	});
+
+	it("supports explicitly clearing the message with null", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			startMaintenanceJob(db, {
+				kind: "vector_migration",
+				title: "Re-indexing memories",
+				message: "Starting rebuild",
+			});
+
+			const updated = updateMaintenanceJob(db, "vector_migration", {
+				message: null,
+			});
+			expect(updated).toBeTruthy();
+			if (!updated) throw new Error("expected updated job");
+
+			expect(updated.message).toBeNull();
+		} finally {
+			db.close();
+		}
+	});
+
+	it("lists jobs newest-first by updated_at", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			startMaintenanceJob(db, { kind: "one", title: "One" });
+			startMaintenanceJob(db, { kind: "two", title: "Two" });
+			updateMaintenanceJob(db, "one", { message: "recent touch" });
+
+			const jobs = listMaintenanceJobs(db);
+			expect(jobs.map((job) => job.kind)).toEqual(["one", "two"]);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("initDatabase ensures maintenance_jobs exists on existing schema-ready dbs", () => {
+		const dbPath = createDbPath("init-existing");
+		const db = new Database(dbPath);
+		try {
+			initTestSchema(db);
+			db.prepare("DROP TABLE maintenance_jobs").run();
+		} finally {
+			db.close();
+		}
+
+		initDatabase(dbPath);
+
+		const verify = new Database(dbPath, { readonly: true });
+		try {
+			expect(() => verify.prepare("SELECT 1 FROM maintenance_jobs LIMIT 1").get()).not.toThrow();
+		} finally {
+			verify.close();
+		}
+	});
+});

--- a/packages/core/src/maintenance-jobs.ts
+++ b/packages/core/src/maintenance-jobs.ts
@@ -1,0 +1,292 @@
+import type { Database } from "./db.js";
+
+export type MaintenanceJobStatus = "pending" | "running" | "completed" | "failed" | "cancelled";
+
+export interface MaintenanceJobRecord {
+	kind: string;
+	title: string;
+	status: MaintenanceJobStatus;
+	message: string | null;
+	progress_current: number;
+	progress_total: number | null;
+	progress_unit: string;
+	metadata_json: string | null;
+	started_at: string | null;
+	updated_at: string;
+	finished_at: string | null;
+	error: string | null;
+}
+
+export interface MaintenanceJobSnapshot {
+	kind: string;
+	title: string;
+	status: MaintenanceJobStatus;
+	message: string | null;
+	progress: {
+		current: number;
+		total: number | null;
+		unit: string;
+	};
+	metadata: Record<string, unknown> | null;
+	started_at: string | null;
+	updated_at: string;
+	finished_at: string | null;
+	error: string | null;
+}
+
+export interface StartMaintenanceJobInput {
+	kind: string;
+	title: string;
+	message?: string | null;
+	progressTotal?: number | null;
+	progressUnit?: string;
+	metadata?: Record<string, unknown> | null;
+	status?: "pending" | "running";
+}
+
+export interface UpdateMaintenanceJobInput {
+	message?: string | null;
+	progressCurrent?: number;
+	progressTotal?: number | null;
+	progressUnit?: string;
+	metadata?: Record<string, unknown> | null;
+	status?: MaintenanceJobStatus;
+}
+
+function ensureTable(db: Database): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS maintenance_jobs (
+			kind TEXT PRIMARY KEY,
+			title TEXT NOT NULL,
+			status TEXT NOT NULL,
+			message TEXT,
+			progress_current INTEGER NOT NULL DEFAULT 0,
+			progress_total INTEGER,
+			progress_unit TEXT NOT NULL DEFAULT 'items',
+			metadata_json TEXT,
+			started_at TEXT,
+			updated_at TEXT NOT NULL,
+			finished_at TEXT,
+			error TEXT
+		);
+		CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_status_updated
+			ON maintenance_jobs(status, updated_at);
+	`);
+}
+
+function parseMetadata(value: string | null): Record<string, unknown> | null {
+	if (!value) return null;
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+	} catch {
+		return null;
+	}
+	return null;
+}
+
+function isTerminalStatus(status: MaintenanceJobStatus): boolean {
+	return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+function resolveMessage(
+	input: UpdateMaintenanceJobInput,
+	existing: MaintenanceJobSnapshot,
+): string | null {
+	if (Object.hasOwn(input, "message")) {
+		return input.message ?? null;
+	}
+	return existing.message;
+}
+
+function resolveMetadataJson(
+	input: UpdateMaintenanceJobInput,
+	existing: MaintenanceJobSnapshot,
+): string | null {
+	if (Object.hasOwn(input, "metadata")) {
+		return input.metadata ? JSON.stringify(input.metadata) : null;
+	}
+	return existing.metadata ? JSON.stringify(existing.metadata) : null;
+}
+
+function toSnapshot(row: MaintenanceJobRecord | undefined): MaintenanceJobSnapshot | null {
+	if (!row) return null;
+	return {
+		kind: row.kind,
+		title: row.title,
+		status: row.status,
+		message: row.message,
+		progress: {
+			current: row.progress_current,
+			total: row.progress_total,
+			unit: row.progress_unit,
+		},
+		metadata: parseMetadata(row.metadata_json),
+		started_at: row.started_at,
+		updated_at: row.updated_at,
+		finished_at: row.finished_at,
+		error: row.error,
+	};
+}
+
+export function getMaintenanceJob(db: Database, kind: string): MaintenanceJobSnapshot | null {
+	ensureTable(db);
+	const row = db.prepare("SELECT * FROM maintenance_jobs WHERE kind = ?").get(kind) as
+		| MaintenanceJobRecord
+		| undefined;
+	return toSnapshot(row);
+}
+
+export function listMaintenanceJobs(db: Database): MaintenanceJobSnapshot[] {
+	ensureTable(db);
+	const rows = db
+		.prepare("SELECT * FROM maintenance_jobs ORDER BY updated_at DESC, kind ASC")
+		.all() as MaintenanceJobRecord[];
+	return rows
+		.map((row) => toSnapshot(row))
+		.filter((row): row is MaintenanceJobSnapshot => row != null);
+}
+
+export function startMaintenanceJob(
+	db: Database,
+	input: StartMaintenanceJobInput,
+): MaintenanceJobSnapshot {
+	ensureTable(db);
+	const now = new Date().toISOString();
+	const status = input.status ?? "running";
+	const metadataJson = input.metadata ? JSON.stringify(input.metadata) : null;
+	db.prepare(
+		`INSERT INTO maintenance_jobs(
+			kind, title, status, message, progress_current, progress_total,
+			progress_unit, metadata_json, started_at, updated_at, finished_at, error
+		) VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, NULL, NULL)
+		ON CONFLICT(kind) DO UPDATE SET
+			title = excluded.title,
+			status = excluded.status,
+			message = excluded.message,
+			progress_current = 0,
+			progress_total = excluded.progress_total,
+			progress_unit = excluded.progress_unit,
+			metadata_json = excluded.metadata_json,
+			started_at = excluded.started_at,
+			updated_at = excluded.updated_at,
+			finished_at = NULL,
+			error = NULL`,
+	).run(
+		input.kind,
+		input.title,
+		status,
+		input.message ?? null,
+		input.progressTotal ?? null,
+		input.progressUnit ?? "items",
+		metadataJson,
+		now,
+		now,
+	);
+	const job = getMaintenanceJob(db, input.kind);
+	if (!job) {
+		throw new Error(`Failed to start maintenance job: ${input.kind}`);
+	}
+	return job;
+}
+
+export function updateMaintenanceJob(
+	db: Database,
+	kind: string,
+	input: UpdateMaintenanceJobInput,
+): MaintenanceJobSnapshot | null {
+	ensureTable(db);
+	const existing = getMaintenanceJob(db, kind);
+	if (!existing) return null;
+	const now = new Date().toISOString();
+	const nextStatus = input.status ?? existing.status;
+	const transitioningToTerminal =
+		!isTerminalStatus(existing.status) && isTerminalStatus(nextStatus);
+	const transitioningToRunning = isTerminalStatus(existing.status) && !isTerminalStatus(nextStatus);
+	const finishedAt = transitioningToTerminal
+		? now
+		: transitioningToRunning
+			? null
+			: existing.finished_at;
+	const error =
+		nextStatus === "failed"
+			? existing.error
+			: nextStatus === "completed" || nextStatus === "cancelled" || transitioningToRunning
+				? null
+				: existing.error;
+	db.prepare(
+		`UPDATE maintenance_jobs
+		 SET status = ?,
+		     message = ?,
+		     progress_current = ?,
+		     progress_total = ?,
+		     progress_unit = ?,
+		     metadata_json = ?,
+		     updated_at = ?,
+		     finished_at = ?,
+		     error = ?
+		 WHERE kind = ?`,
+	).run(
+		nextStatus,
+		resolveMessage(input, existing),
+		input.progressCurrent ?? existing.progress.current,
+		input.progressTotal === undefined ? existing.progress.total : input.progressTotal,
+		input.progressUnit ?? existing.progress.unit,
+		resolveMetadataJson(input, existing),
+		now,
+		finishedAt,
+		error,
+		kind,
+	);
+	return getMaintenanceJob(db, kind);
+}
+
+export function completeMaintenanceJob(
+	db: Database,
+	kind: string,
+	input: Omit<UpdateMaintenanceJobInput, "status"> = {},
+): MaintenanceJobSnapshot | null {
+	return updateMaintenanceJob(db, kind, { ...input, status: "completed" });
+}
+
+export function failMaintenanceJob(
+	db: Database,
+	kind: string,
+	error: string,
+	input: Omit<UpdateMaintenanceJobInput, "status"> = {},
+): MaintenanceJobSnapshot | null {
+	ensureTable(db);
+	const existing = getMaintenanceJob(db, kind);
+	if (!existing) return null;
+	const now = new Date().toISOString();
+	db.prepare(
+		`UPDATE maintenance_jobs
+		 SET status = 'failed',
+		     message = ?,
+		     progress_current = ?,
+			 progress_total = ?,
+			 progress_unit = ?,
+			 metadata_json = ?,
+			 updated_at = ?,
+			 finished_at = ?,
+			 error = ?
+		 WHERE kind = ?`,
+	).run(
+		resolveMessage(input, existing),
+		input.progressCurrent ?? existing.progress.current,
+		input.progressTotal === undefined ? existing.progress.total : input.progressTotal,
+		input.progressUnit ?? existing.progress.unit,
+		resolveMetadataJson(input, existing),
+		now,
+		now,
+		error,
+		kind,
+	);
+	return getMaintenanceJob(db, kind);
+}
+
+export function ensureMaintenanceJobsSchema(db: Database): void {
+	ensureTable(db);
+}

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -10,6 +10,7 @@ import {
 } from "./db.js";
 import { getInjectionEvalScenarioByPrompt } from "./eval-scenarios.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
+import { ensureMaintenanceJobsSchema } from "./maintenance-jobs.js";
 import { buildMemoryPack } from "./pack.js";
 import { projectClause } from "./project.js";
 import * as schema from "./schema.js";
@@ -1382,6 +1383,7 @@ export function initDatabase(dbPath?: string): { path: string; sizeBytes: number
 			bootstrapSchema(db);
 		}
 		assertSchemaReady(db);
+		ensureMaintenanceJobsSchema(db);
 		applyRawEventRelinkPlanWithDb(db);
 		const stats = statSync(resolvedPath);
 		return { path: resolvedPath, sizeBytes: stats.size };

--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -17,6 +17,24 @@ CREATE TABLE IF NOT EXISTS sync_retention_state (
 	last_error_at TEXT
 );
 
+CREATE TABLE IF NOT EXISTS maintenance_jobs (
+	kind TEXT PRIMARY KEY,
+	title TEXT NOT NULL,
+	status TEXT NOT NULL,
+	message TEXT,
+	progress_current INTEGER NOT NULL DEFAULT 0,
+	progress_total INTEGER,
+	progress_unit TEXT NOT NULL DEFAULT 'items',
+	metadata_json TEXT,
+	started_at TEXT,
+	updated_at TEXT NOT NULL,
+	finished_at TEXT,
+	error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_status_updated
+	ON maintenance_jobs(status, updated_at);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
 	title, body_text, tags_text,
 	content='memory_items',

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -117,6 +117,28 @@ export const usageEvents = sqliteTable(
 export type UsageEvent = typeof usageEvents.$inferSelect;
 export type NewUsageEvent = typeof usageEvents.$inferInsert;
 
+export const maintenanceJobs = sqliteTable(
+	"maintenance_jobs",
+	{
+		kind: text("kind").primaryKey(),
+		title: text("title").notNull(),
+		status: text("status").notNull(),
+		message: text("message"),
+		progress_current: integer("progress_current").notNull().default(0),
+		progress_total: integer("progress_total"),
+		progress_unit: text("progress_unit").notNull().default("items"),
+		metadata_json: text("metadata_json"),
+		started_at: text("started_at"),
+		updated_at: text("updated_at").notNull(),
+		finished_at: text("finished_at"),
+		error: text("error"),
+	},
+	(table) => [index("idx_maintenance_jobs_status_updated").on(table.status, table.updated_at)],
+);
+
+export type MaintenanceJob = typeof maintenanceJobs.$inferSelect;
+export type NewMaintenanceJob = typeof maintenanceJobs.$inferInsert;
+
 export const rawEvents = sqliteTable(
 	"raw_events",
 	{


### PR DESCRIPTION
## Description

Add a reusable persisted maintenance job state table and helper API for long-running background tasks.

This introduces a generic `maintenance_jobs` surface that can track progress, messaging, completion, and failure for any future maintenance workflow (re-indexing, backfills, migrations, cleanup). It is intentionally generic so the viewer can show a single maintenance progress surface regardless of job kind.

### Changes
- `maintenance_jobs` schema + bootstrap creation
- helper API to start/update/complete/fail/list jobs
- `initDatabase()` ensures the table exists for existing DBs too
- focused tests for lifecycle, ordering, and init-time creation

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Typecheck clean (`pnpm run tsc`)
- [x] Focused tests pass (`packages/core/src/maintenance-jobs.test.ts`)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced