### PR TITLE
feat(core,cli): migrate vectors in the background by model

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -15,6 +15,7 @@ import {
 	resolveDbPath,
 	runSyncDaemon,
 	SyncRetentionRunner,
+	VectorModelMigrationRunner,
 } from "@codemem/core";
 import { Command, Option } from "commander";
 import { helpStyle } from "../help-style.js";
@@ -404,6 +405,9 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
 		signal: retentionAbort.signal,
 	});
+	const vectorMigrationRunner = new VectorModelMigrationRunner({
+		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
+	});
 	const syncRuntimeStatus: {
 		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
 		detail: string | null;
@@ -459,6 +463,10 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			p.log.success(`Listening on http://${info.address}:${info.port}`);
 			p.log.info(`Database: ${preparedDb}`);
 			p.log.step("Raw event sweeper started");
+			if (!isEmbeddingDisabled()) {
+				vectorMigrationRunner.start();
+				p.log.step("Vector maintenance runner started");
+			}
 			if (syncConfig.syncRetentionEnabled) {
 				retentionRunner.start();
 				p.log.step("Retention maintenance runner started");
@@ -533,6 +541,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		syncAbort.abort();
 		retentionAbort.abort();
 		await sweeper.stop();
+		await vectorMigrationRunner.stop();
 		await retentionRunner.stop();
 
 		// Drain both listeners before closing the shared store.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,7 @@
 		"vitest": "catalog:"
 	},
 	"dependencies": {
+		"@xenova/transformers": "^2.17.2",
 		"better-sqlite3": "^12.8.0",
 		"drizzle-orm": "catalog:",
 		"hono": "catalog:",

--- a/packages/core/src/embeddings.ts
+++ b/packages/core/src/embeddings.ts
@@ -112,6 +112,11 @@ export function _resetEmbeddingClient(): void {
 	_client = undefined;
 }
 
+/** Return the configured embedding model label without loading the client. */
+export function resolveEmbeddingModel(): string {
+	return process.env.CODEMEM_EMBEDDING_MODEL || "Xenova/bge-small-en-v1.5";
+}
+
 /**
  * Get the shared embedding client, creating it lazily on first call.
  * Returns null when embeddings are disabled or the runtime is unavailable.
@@ -122,7 +127,7 @@ export async function getEmbeddingClient(): Promise<EmbeddingClient | null> {
 		_client = null;
 		return null;
 	}
-	const model = process.env.CODEMEM_EMBEDDING_MODEL || "BAAI/bge-small-en-v1.5";
+	const model = resolveEmbeddingModel();
 	try {
 		_client = await createTransformersClient(model);
 	} catch {
@@ -149,7 +154,7 @@ async function createTransformersClient(model: string): Promise<EmbeddingClient>
 	// Dynamic import so the package is optional at install time
 	const { pipeline } = await import("@xenova/transformers");
 	const extractor = await pipeline("feature-extraction", model, {
-		quantized: true,
+		quantized: false,
 	});
 
 	// Infer dimensions from a probe embedding

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -489,6 +489,11 @@ export type {
 	UsageEvent,
 	UserPrompt,
 } from "./types.js";
+export {
+	runVectorMigrationPass,
+	VECTOR_MODEL_MIGRATION_JOB,
+	VectorModelMigrationRunner,
+} from "./vector-migration.js";
 export type {
 	BackfillVectorsOptions,
 	BackfillVectorsResult,

--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -1,0 +1,146 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSqliteVec } from "./db.js";
+import * as embeddings from "./embeddings.js";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+import { runVectorMigrationPass, VECTOR_MODEL_MIGRATION_JOB } from "./vector-migration.js";
+import { resolveSemanticSearchModel } from "./vectors.js";
+
+vi.mock("./embeddings.js", async () => {
+	const actual = await vi.importActual<typeof import("./embeddings.js")>("./embeddings.js");
+	return {
+		...actual,
+		getEmbeddingClient: vi.fn(),
+		embedTexts: vi.fn(),
+		resolveEmbeddingModel: vi.fn(() => "test-model"),
+	};
+});
+
+function seedMemory(
+	db: Database,
+	id: number,
+	sessionId: number,
+	title: string,
+	body: string,
+): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO memory_items(id, session_id, kind, title, body_text, confidence,
+		 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+		 VALUES (?, ?, 'feature', ?, ?, 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+	).run(id, sessionId, title, body, now, now);
+}
+
+function seedVector(db: Database, memoryId: number, model: string): void {
+	const vector = new Float32Array(384);
+	db.exec(`
+		INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model)
+		VALUES (
+			vec_f32('${JSON.stringify(Array.from(vector))}'),
+			${memoryId},
+			0,
+			'hash-${memoryId}-${model}',
+			'${model}'
+		)
+	`);
+}
+
+describe("vector migration", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		db = new Database(":memory:");
+		initTestSchema(db);
+		loadSqliteVec(db);
+		db.exec(`
+			CREATE VIRTUAL TABLE memory_vectors USING vec0(
+				embedding float[384],
+				memory_id INTEGER,
+				chunk_index INTEGER,
+				content_hash TEXT,
+				model TEXT
+			)
+		`);
+		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValue({
+			model: "test-model",
+			dimensions: 384,
+			embed: vi.fn(),
+		});
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("disables semantic vector search while migration is in progress", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "One", "Body one");
+		seedMemory(db, 2, sessionId, "Two", "Body two");
+		seedVector(db, 1, "old-model");
+		seedVector(db, 2, "old-model");
+
+		await runVectorMigrationPass(db, { batchSize: 1 });
+
+		const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(job).toMatchObject({
+			status: "running",
+			progress: { current: 1, total: 2, unit: "items" },
+		});
+		expect(job?.metadata).toMatchObject({ source_model: "old-model", target_model: "test-model" });
+		expect(resolveSemanticSearchModel(db, "test-model")).toBeNull();
+
+		const models = db
+			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
+			.all() as Array<{ model: string; c: number }>;
+		expect(models).toEqual([
+			{ model: "old-model", c: 2 },
+			{ model: "test-model", c: 1 },
+		]);
+	});
+
+	it("cuts over to the new model and removes stale rows after full coverage", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "One", "Body one");
+		seedMemory(db, 2, sessionId, "Two", "Body two");
+		seedVector(db, 1, "old-model");
+		seedVector(db, 2, "old-model");
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(job).toMatchObject({
+			status: "completed",
+			progress: { current: 2, total: 2, unit: "items" },
+		});
+		expect(resolveSemanticSearchModel(db, "test-model")).toBe("test-model");
+
+		const models = db
+			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
+			.all() as Array<{ model: string; c: number }>;
+		expect(models).toEqual([{ model: "test-model", c: 2 }]);
+	});
+
+	it("treats non-embeddable active memories as already covered", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "One", "Body one");
+		seedMemory(db, 2, sessionId, "", "");
+		seedVector(db, 1, "old-model");
+		seedVector(db, 2, "old-model");
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(job).toMatchObject({
+			status: "completed",
+			progress: { current: 2, total: 2, unit: "items" },
+		});
+
+		const models = db
+			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
+			.all() as Array<{ model: string; c: number }>;
+		expect(models).toEqual([{ model: "test-model", c: 1 }]);
+	});
+});

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -1,0 +1,210 @@
+import type { Database as SqliteDatabase } from "better-sqlite3";
+import { connect, isEmbeddingDisabled, loadSqliteVec, resolveDbPath } from "./db.js";
+import { getEmbeddingClient } from "./embeddings.js";
+import {
+	completeMaintenanceJob,
+	failMaintenanceJob,
+	getMaintenanceJob,
+	startMaintenanceJob,
+	updateMaintenanceJob,
+} from "./maintenance-jobs.js";
+import { backfillVectors, memoryHasCompleteVectorCoverage } from "./vectors.js";
+
+export const VECTOR_MODEL_MIGRATION_JOB = "vector_model_migration";
+
+export interface VectorModelMigrationOptions {
+	batchSize?: number;
+	intervalMs?: number;
+	dbPath?: string;
+	signal?: AbortSignal;
+}
+
+function activeMemoryRows(
+	db: SqliteDatabase,
+): Array<{ id: number; title: string | null; body_text: string | null }> {
+	return db
+		.prepare(
+			"SELECT id, title, body_text FROM memory_items WHERE active = 1 ORDER BY created_at ASC",
+		)
+		.all() as Array<{ id: number; title: string | null; body_text: string | null }>;
+}
+
+function vectorModels(db: SqliteDatabase): Array<{ model: string; rows: number }> {
+	return db
+		.prepare(
+			"SELECT model, COUNT(*) AS rows FROM memory_vectors GROUP BY model ORDER BY rows DESC, model ASC",
+		)
+		.all() as Array<{ model: string; rows: number }>;
+}
+
+function modelCoverage(
+	db: SqliteDatabase,
+	targetModel: string,
+	batchSize: number,
+): { total: number; covered: number; nextBatchIds: number[] } {
+	const rows = activeMemoryRows(db);
+	let covered = 0;
+	const nextBatchIds: number[] = [];
+	for (const row of rows) {
+		const complete = memoryHasCompleteVectorCoverage(db, row, targetModel);
+		if (complete) {
+			covered++;
+			continue;
+		}
+		if (nextBatchIds.length < batchSize) nextBatchIds.push(row.id);
+	}
+	return { total: rows.length, covered, nextBatchIds };
+}
+
+function cleanupStaleModels(db: SqliteDatabase, targetModel: string): number {
+	const row = db
+		.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model != ?")
+		.get(targetModel) as { c?: number } | undefined;
+	const count = Number(row?.c ?? 0);
+	if (count > 0) {
+		db.prepare("DELETE FROM memory_vectors WHERE model != ?").run(targetModel);
+	}
+	return count;
+}
+
+function detectSourceModel(db: SqliteDatabase, targetModel: string): string | null {
+	const rows = vectorModels(db).filter((row) => row.model !== targetModel);
+	return rows[0]?.model ?? null;
+}
+
+export async function runVectorMigrationPass(
+	db: SqliteDatabase,
+	options: { batchSize?: number } = {},
+): Promise<void> {
+	if (isEmbeddingDisabled()) return;
+	const client = await getEmbeddingClient();
+	if (!client) return;
+	const targetModel = client.model;
+	const coverage = modelCoverage(db, targetModel, Math.max(1, options.batchSize ?? 50));
+	const total = coverage.total;
+	if (total <= 0) return;
+
+	const sourceModel = detectSourceModel(db, targetModel);
+	if (!sourceModel && coverage.covered >= total) {
+		return;
+	}
+
+	const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+	if (!job || job.status === "completed" || job.status === "failed") {
+		startMaintenanceJob(db, {
+			kind: VECTOR_MODEL_MIGRATION_JOB,
+			title: "Re-indexing memories",
+			message: sourceModel
+				? `Building ${targetModel} vectors while semantic search falls back to FTS-only`
+				: `Building ${targetModel} vectors`,
+			progressTotal: total,
+			metadata: {
+				source_model: sourceModel,
+				target_model: targetModel,
+			},
+		});
+	}
+
+	const batchIds = coverage.nextBatchIds;
+	if (batchIds.length > 0) {
+		await backfillVectors(db, { memoryIds: batchIds });
+	}
+
+	const nextCoverage = modelCoverage(db, targetModel, Math.max(1, options.batchSize ?? 50));
+	if (nextCoverage.covered >= total) {
+		db.transaction(() => {
+			const removed = cleanupStaleModels(db, targetModel);
+			completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+				message:
+					removed > 0
+						? `Finished re-indexing and removed ${removed} stale vector rows`
+						: "Finished re-indexing memories",
+				progressCurrent: total,
+				progressTotal: total,
+				metadata: {
+					source_model: sourceModel,
+					target_model: targetModel,
+					removed_stale_rows: removed,
+				},
+			});
+		})();
+		return;
+	}
+
+	updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+		message: `Re-indexed ${nextCoverage.covered} of ${total} memories (semantic search uses FTS-only until complete)`,
+		progressCurrent: nextCoverage.covered,
+		progressTotal: total,
+		metadata: {
+			source_model: sourceModel,
+			target_model: targetModel,
+		},
+	});
+}
+
+export class VectorModelMigrationRunner {
+	private readonly dbPath: string;
+	private readonly signal?: AbortSignal;
+	private readonly batchSize: number;
+	private readonly intervalMs: number;
+	private active = false;
+	private timer: ReturnType<typeof setTimeout> | null = null;
+	private currentRun: Promise<void> | null = null;
+
+	constructor(options: VectorModelMigrationOptions = {}) {
+		this.dbPath = resolveDbPath(options.dbPath);
+		this.signal = options.signal;
+		this.batchSize = Math.max(1, options.batchSize ?? 50);
+		this.intervalMs = Math.max(1000, options.intervalMs ?? 5000);
+	}
+
+	start(): void {
+		if (this.active) return;
+		this.active = true;
+		this.schedule(100);
+	}
+
+	async stop(): Promise<void> {
+		this.active = false;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+		if (this.currentRun) await this.currentRun;
+	}
+
+	private schedule(delayMs: number): void {
+		if (!this.active || this.signal?.aborted) return;
+		this.timer = setTimeout(() => {
+			this.timer = null;
+			this.currentRun = this.runOnce()
+				.catch(() => {})
+				.finally(() => {
+					this.currentRun = null;
+					this.schedule(this.intervalMs);
+				});
+		}, delayMs);
+		if (typeof this.timer === "object" && "unref" in this.timer) this.timer.unref();
+	}
+
+	private async runOnce(): Promise<void> {
+		if (!this.active || this.signal?.aborted) return;
+		let db: SqliteDatabase | null = null;
+		try {
+			db = connect(this.dbPath) as SqliteDatabase;
+			loadSqliteVec(db);
+			await runVectorMigrationPass(db, { batchSize: this.batchSize });
+		} catch (error) {
+			if (db) {
+				failMaintenanceJob(
+					db,
+					VECTOR_MODEL_MIGRATION_JOB,
+					error instanceof Error ? error.message : String(error),
+				);
+			}
+			console.warn("Vector migration runner failed", error);
+		} finally {
+			db?.close();
+		}
+	}
+}

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -2,8 +2,9 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadSqliteVec } from "./db.js";
 import * as embeddings from "./embeddings.js";
+import { startMaintenanceJob } from "./maintenance-jobs.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
-import { backfillVectors, storeVectors } from "./vectors.js";
+import { backfillVectors, semanticSearch, storeVectors } from "./vectors.js";
 
 vi.mock("./embeddings.js", async () => {
 	const actual = await vi.importActual<typeof import("./embeddings.js")>("./embeddings.js");
@@ -11,6 +12,7 @@ vi.mock("./embeddings.js", async () => {
 		...actual,
 		getEmbeddingClient: vi.fn(),
 		embedTexts: vi.fn(),
+		resolveEmbeddingModel: vi.fn(() => "test-model"),
 	};
 });
 
@@ -100,5 +102,57 @@ describe("vectors", () => {
 			chunk_index: 0,
 			model: "test-model",
 		});
+	});
+
+	it("keeps stale-model vectors until a migration cutover removes them", async () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'feature', 'Rebuild title', 'Rebuild body', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, now, now);
+		const memoryId = Number(info.lastInsertRowid);
+
+		// Seed a stale vector row using a different model label.
+		const staleVector = new Float32Array(384);
+		db.exec(`
+			INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model)
+			VALUES (
+				vec_f32('${JSON.stringify(Array.from(staleVector))}'),
+				${memoryId},
+				0,
+				'stale-hash',
+				'old-model'
+			)
+		`);
+
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+
+		const result = await backfillVectors(db, { memoryIds: [memoryId] });
+
+		expect(result).toMatchObject({ checked: 1, embedded: 1, inserted: 1 });
+		const models = db
+			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
+			.all() as Array<{ model: string; c: number }>;
+		expect(models).toEqual([
+			{ model: "old-model", c: 1 },
+			{ model: "test-model", c: 1 },
+		]);
+	});
+
+	it("skips query embedding when vector search is disabled during migration", async () => {
+		startMaintenanceJob(db, {
+			kind: "vector_model_migration",
+			title: "Re-indexing memories",
+			metadata: { source_model: "old-model", target_model: "test-model" },
+		});
+
+		const results = await semanticSearch(db, "query text");
+
+		expect(results).toEqual([]);
+		expect(embeddings.embedTexts).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -15,9 +15,69 @@ import {
 	embedTexts,
 	getEmbeddingClient,
 	hashText,
+	resolveEmbeddingModel,
 	serializeFloat32,
 } from "./embeddings.js";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
 import { projectClause } from "./project.js";
+
+const VECTOR_MODEL_MIGRATION_JOB = "vector_model_migration";
+
+type VectorModelCount = { model: string; rows: number };
+
+type MemoryTextRow = { id: number; title: string | null; body_text: string | null };
+
+function listVectorModelCounts(db: Database): VectorModelCount[] {
+	return db
+		.prepare(
+			"SELECT model, COUNT(*) AS rows FROM memory_vectors GROUP BY model ORDER BY rows DESC, model ASC",
+		)
+		.all() as VectorModelCount[];
+}
+
+export function resolveSemanticSearchModel(
+	db: Database,
+	currentModel = resolveEmbeddingModel(),
+): string | null {
+	const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+	const metadata = job?.metadata ?? {};
+	const sourceModel = typeof metadata.source_model === "string" ? metadata.source_model : null;
+	if (
+		(job?.status === "running" || job?.status === "pending" || job?.status === "failed") &&
+		sourceModel &&
+		sourceModel !== currentModel
+	) {
+		return null;
+	}
+	const rows = listVectorModelCounts(db);
+	if (rows.length === 0) return null;
+	if (rows.some((row) => row.model === currentModel)) return currentModel;
+	return null;
+}
+
+function chunkHashes(text: string): string[] {
+	return chunkText(text).map((chunk) => hashText(chunk));
+}
+
+function memoryText(title: string | null, bodyText: string | null): string {
+	return `${title ?? ""}\n${bodyText ?? ""}`.trim();
+}
+
+export function memoryHasCompleteVectorCoverage(
+	db: Database,
+	memory: MemoryTextRow,
+	model: string,
+): boolean {
+	const expectedHashes = chunkHashes(memoryText(memory.title, memory.body_text));
+	if (expectedHashes.length === 0) return true;
+	const existingRows = db
+		.prepare("SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ?")
+		.all(memory.id, model) as Array<{ content_hash: string | null }>;
+	const existingHashes = new Set(
+		existingRows.map((row) => row.content_hash).filter((hash): hash is string => hash != null),
+	);
+	return expectedHashes.every((hash) => existingHashes.has(hash));
+}
 
 function toSqlStringLiteral(value: string): string {
 	return `'${value.replaceAll("'", "''")}'`;
@@ -102,14 +162,23 @@ export async function storeVectors(
 	if (embeddings.length === 0) return;
 
 	const model = client.model;
+	const insertVectors = db.transaction(
+		(entries: Array<{ vector: Float32Array; chunkIndex: number; contentHash: string }>) => {
+			for (const entry of entries) {
+				insertMemoryVector(db, entry.vector, memoryId, entry.chunkIndex, entry.contentHash, model);
+			}
+		},
+	);
+	const entries: Array<{ vector: Float32Array; chunkIndex: number; contentHash: string }> = [];
 
 	for (let i = 0; i < chunks.length && i < embeddings.length; i++) {
 		const vector = embeddings[i];
 		const chunk = chunks[i];
 		if (!vector || vector.length === 0) continue;
 		if (!chunk) continue;
-		insertMemoryVector(db, vector, memoryId, i, hashText(chunk), model);
+		entries.push({ vector, chunkIndex: i, contentHash: hashText(chunk) });
 	}
+	if (entries.length > 0) insertVectors(entries);
 }
 
 // ---------------------------------------------------------------------------
@@ -173,7 +242,7 @@ export async function backfillVectors(
 
 	for (const row of rows) {
 		checked++;
-		const text = `${row.title ?? ""}\n${row.body_text ?? ""}`.trim();
+		const text = memoryText(row.title, row.body_text);
 		const chunks = chunkText(text);
 		if (chunks.length === 0) continue;
 
@@ -187,7 +256,8 @@ export async function backfillVectors(
 
 		const pendingChunks: string[] = [];
 		const pendingHashes: string[] = [];
-		for (const chunk of chunks) {
+		const pendingChunkIndexes: number[] = [];
+		for (const [chunkIndex, chunk] of chunks.entries()) {
 			const h = hashText(chunk);
 			if (existingHashes.has(h)) {
 				skipped++;
@@ -195,6 +265,7 @@ export async function backfillVectors(
 			}
 			pendingChunks.push(chunk);
 			pendingHashes.push(h);
+			pendingChunkIndexes.push(chunkIndex);
 		}
 
 		if (pendingChunks.length === 0) continue;
@@ -208,13 +279,26 @@ export async function backfillVectors(
 			continue;
 		}
 
+		const insertVectors = db.transaction(
+			(entries: Array<{ vector: Float32Array; chunkIndex: number; contentHash: string }>) => {
+				for (const entry of entries) {
+					insertMemoryVector(db, entry.vector, row.id, entry.chunkIndex, entry.contentHash, model);
+				}
+			},
+		);
+		const entries: Array<{ vector: Float32Array; chunkIndex: number; contentHash: string }> = [];
 		for (let i = 0; i < embeddings.length; i++) {
 			const vector = embeddings[i];
 			const contentHash = pendingHashes[i];
+			const chunkIndex = pendingChunkIndexes[i];
 			if (!vector || vector.length === 0) continue;
 			if (!contentHash) continue;
-			insertMemoryVector(db, vector, row.id, i, contentHash, model);
-			inserted++;
+			if (chunkIndex == null) continue;
+			entries.push({ vector, chunkIndex, contentHash });
+		}
+		if (entries.length > 0) {
+			insertVectors(entries);
+			inserted += entries.length;
 		}
 	}
 
@@ -257,6 +341,8 @@ export async function semanticSearch(
 	filters?: { project?: string | null } | null,
 ): Promise<SemanticSearchResult[]> {
 	if (query.trim().length < 3) return [];
+	const searchModel = resolveSemanticSearchModel(db, resolveEmbeddingModel());
+	if (!searchModel) return [];
 
 	const embeddings = await embedTexts([query]);
 	if (embeddings.length === 0) return [];
@@ -264,7 +350,7 @@ export async function semanticSearch(
 	const firstEmbedding = embeddings[0];
 	if (!firstEmbedding) return [];
 	const queryEmbedding = serializeFloat32(firstEmbedding);
-	const params: unknown[] = [queryEmbedding, limit];
+	const params: unknown[] = [queryEmbedding, limit, searchModel];
 	const whereClauses: string[] = ["memory_items.active = 1"];
 	let joinSessions = false;
 
@@ -287,6 +373,7 @@ export async function semanticSearch(
 		${joinClause}
 		WHERE memory_vectors.embedding MATCH ?
 		  AND k = ?
+		  AND memory_vectors.model = ?
 		  AND ${where}
 		ORDER BY memory_vectors.distance ASC
 	`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@xenova/transformers':
+        specifier: ^2.17.2
+        version: 2.17.2
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -1135,6 +1138,10 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@huggingface/jinja@0.2.2':
+    resolution: {integrity: sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==}
+    engines: {node: '>=18'}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1376,6 +1383,36 @@ packages:
     peerDependencies:
       preact: ^10.4.0 || ^11.0.0-0
       vite: '>=2.0.0'
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1955,6 +1992,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
@@ -1993,6 +2033,9 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
+  '@xenova/transformers@2.17.2':
+    resolution: {integrity: sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -2016,10 +2059,59 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   babel-plugin-transform-hook-names@1.0.2:
     resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
     peerDependencies:
       '@babel/core': ^7.12.10
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.6.0:
+    resolution: {integrity: sha512-2YkS7NuiJceSEbyEOdSNLE9tsGd+f4+f7C+Nik/MCk27SYdwIMPT/yRKvg++FZhQXgk0KWJKJyXX9RhVV0RGqA==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.8.7:
+    resolution: {integrity: sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.12.0:
+    resolution: {integrity: sha512-w28i8lkBgREV3rPXGbgK+BO66q+ZpKqRWrZLiCdmmUlLPrQ45CzkvRhN+7lnv00Gpi2zy5naRxnUFAxCECDm9g==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.0:
+    resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2084,6 +2176,20 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -2340,6 +2446,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -2369,6 +2478,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -2387,6 +2499,9 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  flatbuffers@1.12.0:
+    resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2433,6 +2548,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -2477,6 +2595,9 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -2590,6 +2711,9 @@ packages:
   limiter@3.0.0:
     resolution: {integrity: sha512-hev7DuXojsTFl2YwyzUJMDnZ/qBDd3yZQLSH3aD4tdL1cqfc3TMnoecEJtWFaQFdErZsKoFMBTxF/FBSkgDbEg==}
 
+  long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2650,6 +2774,9 @@ packages:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
 
+  node-addon-api@6.1.0:
+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+
   node-html-parser@6.1.13:
     resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
@@ -2680,6 +2807,19 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onnx-proto@4.0.4:
+    resolution: {integrity: sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==}
+
+  onnxruntime-common@1.14.0:
+    resolution: {integrity: sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==}
+
+  onnxruntime-node@1.14.0:
+    resolution: {integrity: sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.14.0:
+    resolution: {integrity: sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2717,6 +2857,9 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2728,6 +2871,10 @@ packages:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  protobufjs@6.11.4:
+    resolution: {integrity: sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==}
     hasBin: true
 
   proxy-addr@2.0.7:
@@ -2846,6 +2993,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sharp@0.32.6:
+    resolution: {integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==}
+    engines: {node: '>=14.15.0'}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2885,6 +3036,9 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -2946,6 +3100,9 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -2960,9 +3117,21 @@ packages:
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3774,6 +3943,8 @@ snapshots:
     dependencies:
       hono: 4.12.11
 
+  '@huggingface/jinja@0.2.2': {}
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -3991,6 +4162,29 @@ snapshots:
       vite: 8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4367,6 +4561,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/long@4.0.2': {}
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
@@ -4426,6 +4622,18 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@xenova/transformers@2.17.2':
+    dependencies:
+      '@huggingface/jinja': 0.2.2
+      onnxruntime-web: 1.14.0
+      sharp: 0.32.6
+    optionalDependencies:
+      onnxruntime-node: 1.14.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -4448,9 +4656,43 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  b4a@1.8.0: {}
+
   babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.6.0:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.12.0(bare-events@2.8.2)
+      bare-url: 2.4.0
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.8.7: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.8.7
+
+  bare-stream@2.12.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.0:
+    dependencies:
+      bare-path: 3.0.0
 
   base64-js@1.5.1: {}
 
@@ -4523,6 +4765,22 @@ snapshots:
   chownr@1.1.4: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
 
   commander@14.0.3: {}
 
@@ -4760,6 +5018,12 @@ snapshots:
 
   etag@1.8.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
@@ -4810,6 +5074,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
   fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
@@ -4828,6 +5094,8 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  flatbuffers@1.12.0: {}
 
   forwarded@0.2.0: {}
 
@@ -4870,6 +5138,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  guid-typescript@1.0.9: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.2:
@@ -4903,6 +5173,8 @@ snapshots:
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-arrayish@0.3.4: {}
 
   is-promise@4.0.0: {}
 
@@ -4975,6 +5247,8 @@ snapshots:
 
   limiter@3.0.0: {}
 
+  long@4.0.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5025,6 +5299,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-addon-api@6.1.0: {}
+
   node-html-parser@6.1.13:
     dependencies:
       css-select: 5.2.2
@@ -5052,6 +5328,26 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onnx-proto@4.0.4:
+    dependencies:
+      protobufjs: 6.11.4
+
+  onnxruntime-common@1.14.0: {}
+
+  onnxruntime-node@1.14.0:
+    dependencies:
+      onnxruntime-common: 1.14.0
+    optional: true
+
+  onnxruntime-web@1.14.0:
+    dependencies:
+      flatbuffers: 1.12.0
+      guid-typescript: 1.0.9
+      long: 4.0.0
+      onnx-proto: 4.0.4
+      onnxruntime-common: 1.14.0
+      platform: 1.3.6
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
@@ -5071,6 +5367,8 @@ snapshots:
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
+
+  platform@1.3.6: {}
 
   postcss@8.5.8:
     dependencies:
@@ -5094,6 +5392,22 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  protobufjs@6.11.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/long': 4.0.2
+      '@types/node': 25.5.0
+      long: 4.0.0
 
   proxy-addr@2.0.7:
     dependencies:
@@ -5263,6 +5577,21 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sharp@0.32.6:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      node-addon-api: 6.1.0
+      prebuild-install: 7.1.3
+      semver: 7.7.4
+      simple-get: 4.0.1
+      tar-fs: 3.1.2
+      tunnel-agent: 0.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
@@ -5342,6 +5671,10 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
+
   sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
@@ -5386,6 +5719,15 @@ snapshots:
 
   std-env@4.0.0: {}
 
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -5401,6 +5743,18 @@ snapshots:
       pump: 3.0.4
       tar-stream: 2.2.0
 
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.6.0
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -5408,6 +5762,30 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.6.0
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Description

Add a background vector model migration path and switch the embedding runtime to the Transformers.js-compatible Xenova BGE model.

This keeps semantic search pinned to the old vector model while the new model builds in the background, then cuts over only after full coverage is reached and removes stale rows. The viewer `serve` process now starts this migration runner automatically, so release upgrades can repair old vector corpora without blocking normal use.

### Changes
- switch embedding runtime to `Xenova/bge-small-en-v1.5`
- add background `VectorModelMigrationRunner`
- keep semantic search on the source model while migration is running
- complete migration by cutting over and deleting stale rows only after full coverage
- start the migration runner automatically in `codemem serve`
- focused tests for incremental progress and final cutover

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Typecheck clean (`pnpm run tsc`)
- [x] Focused tests pass (`vector-migration.test.ts`, `vectors.test.ts`, `embed.test.ts`)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced