### PR TITLE
feat(viewer): show background maintenance progress in sync diagnostics

### DIFF
--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -34,7 +34,8 @@ type PingPayloadState = SyncPayloadState & {
 };
 
 type SyncStatusState = {
-  daemon_detail?: string;
+	background_maintenance?: MaintenanceJobState[];
+	daemon_detail?: string;
   daemon_state?: string;
   enabled?: boolean;
   last_ping_at?: string | null;
@@ -64,6 +65,19 @@ type SyncAttemptState = {
 type PairingPayloadState = Record<string, unknown> & {
   addresses?: unknown[];
   redacted?: boolean;
+};
+
+type MaintenanceJobState = {
+  kind?: string;
+  title?: string;
+  status?: string;
+  message?: string | null;
+  error?: string | null;
+  progress?: {
+    current?: number;
+    total?: number | null;
+    unit?: string;
+  };
 };
 
 const SYNC_REDACT_MOUNT_ID = 'syncRedactMount';
@@ -169,6 +183,10 @@ export function renderSyncStatus() {
   hideSkeleton('syncDiagSkeleton');
 
   const status = state.lastSyncStatus as SyncStatusState | null;
+  const maintenanceJobs = Array.isArray(status?.background_maintenance)
+    ? (status.background_maintenance as MaintenanceJobState[])
+        .filter((job) => ['pending', 'running', 'failed'].includes(String(job?.status || '')))
+    : [];
   if (!status) {
     renderSyncEmptyState(syncStatusGrid, diagnosticsLoadingState());
     renderActionList(syncActions, []);
@@ -234,6 +252,27 @@ export function renderSyncStatus() {
           ? `Retention last ran ${formatAgeShort(secondsSince(retentionLastRunAt))} ago (approx oldest-first)`
           : 'Retention enabled',
       );
+    }
+    if (maintenanceJobs.length > 0) {
+      const maintenanceLabel = maintenanceJobs
+        .slice(0, 2)
+        .map((job) => {
+          const current = Number(job.progress?.current || 0);
+          const total = typeof job.progress?.total === 'number' ? job.progress?.total : null;
+          const unit = String(job.progress?.unit || 'items');
+          const progress = total && total > 0
+            ? `${current}/${total} ${unit}`
+            : current > 0
+              ? `${current} ${unit}`
+              : titleCase(String(job.status || 'running'));
+          const detail = String(job.error || job.message || '').trim();
+          if (detail) {
+            return `${String(job.title || job.kind || 'Background maintenance')}: ${progress} — ${detail}`;
+          }
+          return `${String(job.title || job.kind || 'Background maintenance')}: ${progress}`;
+        })
+        .join(' · ');
+      parts.push(`Maintenance: ${maintenanceLabel}`);
     }
     syncMeta.textContent = parts.join(' · ');
   }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -16,6 +16,7 @@ import {
 	insertTestSession,
 	loadPublicKey,
 	MemoryStore,
+	startMaintenanceJob,
 	VERSION,
 } from "@codemem/core";
 import Database from "better-sqlite3";
@@ -2433,6 +2434,68 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body.daemon_state).toBe("starting");
 				expect(body.daemon_detail).toBe("Running initial sync in background");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("includes detailed maintenance summaries only when diagnostics are enabled", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/sync/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				startMaintenanceJob(store.db, {
+					kind: "vector_model_migration",
+					title: "Re-indexing memories",
+					message: "Building new embeddings",
+					progressTotal: 10,
+					metadata: { source_model: "old-model", target_model: "new-model" },
+				});
+
+				const res = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				const status = body.status as Record<string, unknown>;
+				const jobs = status.background_maintenance as Array<Record<string, unknown>>;
+				expect(jobs).toHaveLength(1);
+				expect(jobs[0]).toMatchObject({
+					kind: "vector_model_migration",
+					title: "Re-indexing memories",
+					message: "Building new embeddings",
+					metadata: { source_model: "old-model", target_model: "new-model" },
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("redacts maintenance details when diagnostics are disabled", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/sync/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				startMaintenanceJob(store.db, {
+					kind: "vector_model_migration",
+					title: "Re-indexing memories",
+					message: "Building new embeddings",
+					progressTotal: 10,
+					metadata: { source_model: "old-model", target_model: "new-model" },
+				});
+
+				const res = await app.request("/api/sync/status");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				const status = body.status as Record<string, unknown>;
+				const jobs = status.background_maintenance as Array<Record<string, unknown>>;
+				expect(jobs).toHaveLength(1);
+				expect(jobs[0]).toMatchObject({
+					kind: "vector_model_migration",
+					title: "Re-indexing memories",
+				});
+				expect(jobs[0]).not.toHaveProperty("message");
+				expect(jobs[0]).not.toHaveProperty("metadata");
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -8,6 +8,7 @@ import net from "node:net";
 import { dirname, join } from "node:path";
 import type {
 	CoordinatorBootstrapGrantVerification,
+	MaintenanceJobSnapshot,
 	MemoryStore,
 	ReplicationOp,
 } from "@codemem/core";
@@ -28,6 +29,7 @@ import {
 	fingerprintPublicKey,
 	getSyncResetState,
 	listCoordinatorJoinRequests,
+	listMaintenanceJobs,
 	loadMemorySnapshotPageForPeer,
 	loadReplicationOpsForPeer,
 	lookupCoordinatorPeers,
@@ -73,6 +75,27 @@ const SYNC_STALE_AFTER_SECONDS = 10 * 60;
 const SYNC_PROTOCOL_VERSION = "2";
 const LEGACY_SYNC_ACTOR_DISPLAY_NAME = "Legacy synced peer";
 const LEGACY_SHARED_WORKSPACE_ID = "shared:legacy";
+
+function summarizeMaintenanceJobs(
+	jobs: MaintenanceJobSnapshot[],
+	showDiagnostics: boolean,
+): Array<Record<string, unknown>> {
+	return jobs
+		.filter((job) => ["pending", "running", "failed"].includes(String(job.status ?? "")))
+		.map((job) => ({
+			kind: job.kind,
+			title: job.title,
+			status: job.status,
+			progress: job.progress,
+			...(showDiagnostics
+				? {
+						message: job.message,
+						error: job.error,
+						metadata: job.metadata,
+					}
+				: {}),
+		}));
+}
 
 function syncKeysDir(): string | undefined {
 	return process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
@@ -1306,13 +1329,13 @@ export function syncRoutes(
 				.limit(25)
 				.all();
 			const peerAddressMap = new Map<string, string[]>();
-			store.db
+			const peerAddressRows = store.db
 				.prepare("SELECT peer_device_id, addresses_json FROM sync_peers")
-				.all()
-				.forEach((peerRow: any) => {
-					const addrs = safeJsonList(peerRow.addresses_json as string | null);
-					if (addrs.length) peerAddressMap.set(String(peerRow.peer_device_id ?? ""), addrs);
-				});
+				.all() as Array<{ peer_device_id: string | null; addresses_json: string | null }>;
+			peerAddressRows.forEach((peerRow) => {
+				const addrs = safeJsonList(peerRow.addresses_json as string | null);
+				if (addrs.length) peerAddressMap.set(String(peerRow.peer_device_id ?? ""), addrs);
+			});
 			const attemptsItems = attemptRows.map((row) => {
 				const addrs = showDiag ? peerAddressMap.get(String(row.peer_device_id ?? "")) : undefined;
 				return {
@@ -1325,6 +1348,7 @@ export function syncRoutes(
 
 			const statusBlock: Record<string, unknown> = {
 				...statusPayload,
+				background_maintenance: summarizeMaintenanceJobs(listMaintenanceJobs(store.db), showDiag),
 				peers: peersMap,
 				pending: 0,
 				sync: {},
@@ -1571,17 +1595,17 @@ export function syncRoutes(
 			if (!peerId) return c.json({ error: "unknown peer address" }, 404);
 			peerIds = [peerId];
 		} else if (requestedPeerId) {
-			peerIds = store.db
+			const requestedPeerRows = store.db
 				.prepare("SELECT peer_device_id FROM sync_peers WHERE peer_device_id = ?")
-				.all(requestedPeerId)
-				.map((row: any) => String(row.peer_device_id ?? "").trim())
+				.all(requestedPeerId) as Array<{ peer_device_id: string | null }>;
+			peerIds = requestedPeerRows
+				.map((row) => String(row.peer_device_id ?? "").trim())
 				.filter(Boolean);
 		} else {
-			peerIds = store.db
-				.prepare("SELECT peer_device_id FROM sync_peers")
-				.all()
-				.map((row: any) => String(row.peer_device_id ?? "").trim())
-				.filter(Boolean);
+			const allPeerRows = store.db.prepare("SELECT peer_device_id FROM sync_peers").all() as Array<{
+				peer_device_id: string | null;
+			}>;
+			peerIds = allPeerRows.map((row) => String(row.peer_device_id ?? "").trim()).filter(Boolean);
 		}
 		const items = [] as Array<Record<string, unknown>>;
 		for (const peerId of peerIds) {


### PR DESCRIPTION
## Description

Expose generic maintenance job progress in the viewer's sync diagnostics so users can see long-running background work without losing the existing diagnostics flow.

This uses the new `maintenance_jobs` state from the previous PR and surfaces it through the existing sync status payload. The UI shows active maintenance progress in the diagnostics metadata area using the job's title and progress counters, so future maintenance tasks can reuse the same surface without custom UI work.

### Changes
- include `maintenance` in `/api/sync/status`
- track the payload in UI state
- render active maintenance progress in sync diagnostics metadata

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Typecheck clean (`pnpm run tsc`)
- [x] Focused tests pass for dependent core behavior

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced