### PR TITLE
fix(core): trigger vector migration when memories have no vectors at all

### DIFF
--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -211,4 +211,24 @@ describe("vector migration", () => {
 			.all() as Array<{ model: string; c: number }>;
 		expect(models).toEqual([{ model: "test-model", c: 3 }]);
 	});
+
+	it("backfills memories that have no vectors at all (no source model)", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "One", "Body one");
+		seedMemory(db, 2, sessionId, "Two", "Body two");
+		// No vectors seeded at all — empty memory_vectors table
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(job).toMatchObject({
+			status: "completed",
+			progress: { current: 2, total: 2, unit: "items" },
+		});
+
+		const models = db
+			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
+			.all() as Array<{ model: string; c: number }>;
+		expect(models).toEqual([{ model: "test-model", c: 2 }]);
+	});
 });

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -110,13 +110,24 @@ export async function runVectorMigrationPass(
 	const targetModel = client.model;
 	const sourceModel = detectSourceModel(db, targetModel);
 	const existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
-	if (
-		!sourceModel &&
-		existingJob?.status !== "running" &&
-		existingJob?.status !== "pending" &&
-		existingJob?.status !== "failed"
-	) {
-		return;
+	const hasInFlightJob =
+		existingJob?.status === "running" ||
+		existingJob?.status === "pending" ||
+		existingJob?.status === "failed";
+	if (!sourceModel && !hasInFlightJob) {
+		// No stale model and no in-flight job — check if there are uncovered memories.
+		const targetCoverage = db
+			.prepare("SELECT COUNT(DISTINCT memory_id) AS c FROM memory_vectors WHERE model = ?")
+			.get(targetModel) as { c?: number } | undefined;
+		const activeCount = db
+			.prepare("SELECT COUNT(*) AS c FROM memory_items WHERE active = 1")
+			.get() as { c?: number } | undefined;
+		const covered = Number(targetCoverage?.c ?? 0);
+		const total = Number(activeCount?.c ?? 0);
+		if (total <= 0 || covered >= total) {
+			return;
+		}
+		// Memories exist without target vectors — proceed to backfill them.
 	}
 	// Use cached embeddable_total from an in-progress job to avoid a full table scan per tick.
 	// Only recompute when starting a fresh migration or when the job is terminal.


### PR DESCRIPTION
## Description

The migration runner bailed early when no stale source model was detected, which meant databases with zero vectors (e.g., after a manual wipe or first-time embedding enablement) never got backfilled automatically.

Now checks whether active memories exist without target-model coverage and proceeds to backfill them even when there is no stale model to migrate from.

Addresses reviewer comment #1 from PR #661.

### Changes
- `vector-migration.ts`: replace early-return with a coverage check — if memories exist without target vectors, proceed to backfill
- `vector-migration.test.ts`: add test for "no vectors at all" backfill scenario

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Typecheck clean (`pnpm run tsc`)
- [x] All 1055 tests pass
- [x] Lint clean on touched files
- [x] New test: "backfills memories that have no vectors at all (no source model)"

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced