### PR TITLE
feat(core,cli): add retroactive dedup and narrative backfill commands

### DIFF
--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { initDatabase } from "@codemem/core";
+import { describe, expect, it, vi } from "vitest";
 import { dbCommand } from "./db.js";
 
 describe("db command", () => {
@@ -33,5 +37,44 @@ describe("db command", () => {
 		expect(pruneMemLongs).toContain("--kinds");
 		expect(pruneMemLongs).toContain("--dry-run");
 		expect(pruneMemLongs).toContain("--json");
+	});
+
+	it("registers dedup-memories and backfill-narrative subcommands", () => {
+		const dedup = dbCommand.commands.find((command) => command.name() === "dedup-memories");
+		const narrative = dbCommand.commands.find((command) => command.name() === "backfill-narrative");
+		expect(dedup).toBeDefined();
+		expect(narrative).toBeDefined();
+
+		const dedupLongs = dedup?.options.map((option) => option.long) ?? [];
+		expect(dedupLongs).toContain("--window");
+		expect(dedupLongs).toContain("--limit");
+		expect(dedupLongs).toContain("--dry-run");
+		expect(dedupLongs).toContain("--json");
+
+		const narrativeLongs = narrative?.options.map((option) => option.long) ?? [];
+		expect(narrativeLongs).toContain("--limit");
+		expect(narrativeLongs).toContain("--dry-run");
+		expect(narrativeLongs).toContain("--json");
+	});
+
+	it("rejects invalid dedup window input", async () => {
+		const dedup = dbCommand.commands.find((command) => command.name() === "dedup-memories");
+		expect(dedup).toBeDefined();
+		if (!dedup) throw new Error("expected dedup-memories command");
+
+		const dbPath = join(mkdtempSync(join(tmpdir(), "codemem-db-cmd-")), "test.sqlite");
+		initDatabase(dbPath);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const originalExitCode = process.exitCode;
+		process.exitCode = undefined;
+		try {
+			await dedup.parseAsync(["node", "dedup-memories", "--db-path", dbPath, "--window", "foo"], {
+				from: "node",
+			});
+			expect(process.exitCode).toBe(1);
+		} finally {
+			process.exitCode = originalExitCode;
+			errorSpy.mockRestore();
+		}
 	});
 });

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -1,10 +1,12 @@
 import { statSync } from "node:fs";
 import * as p from "@clack/prompts";
 import {
+	backfillNarrativeFromBody,
 	backfillTagsText,
 	connect,
 	deactivateLowSignalMemories,
 	deactivateLowSignalObservations,
+	dedupNearDuplicateMemories,
 	getRawEventStatus,
 	initDatabase,
 	MemoryStore,
@@ -635,3 +637,103 @@ pruneMemCmd.action(
 	},
 );
 dbCommand.addCommand(pruneMemCmd);
+
+// --- db dedup-memories ---
+const dedupCmd = new Command("dedup-memories")
+	.configureHelp(helpStyle)
+	.description(
+		"Deactivate near-duplicate memories (cross-session, same normalized title within time window)",
+	)
+	.option("--window <ms>", "max time gap in milliseconds between duplicates (default: 3600000)")
+	.option("--limit <n>", "max pairs to check")
+	.option("--dry-run", "preview deactivations without writing");
+addDbOption(dedupCmd);
+addJsonOption(dedupCmd);
+dedupCmd.action(
+	(
+		opts: DbOpts &
+			JsonOpts & {
+				window?: string;
+				limit?: string;
+				dryRun?: boolean;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const windowMs = parseOptionalPositiveInt(opts.window);
+			const limit = parseOptionalPositiveInt(opts.limit);
+			const result = dedupNearDuplicateMemories(store.db, {
+				windowMs,
+				limit,
+				dryRun: opts.dryRun === true,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			const action = opts.dryRun ? "Would deactivate" : "Deactivated";
+			p.intro("codemem db dedup-memories");
+			if (result.pairs.length > 0 && result.pairs.length <= 20) {
+				for (const pair of result.pairs) {
+					p.log.info(
+						`${action} [${pair.deactivated_id}] (kept [${pair.kept_id}]): ${pair.title.slice(0, 80)}`,
+					);
+				}
+			}
+			p.outro(`${action} ${result.deactivated} duplicates from ${result.checked} pairs`);
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);
+dbCommand.addCommand(dedupCmd);
+
+// --- db backfill-narrative ---
+const backfillNarrativeCmd = new Command("backfill-narrative")
+	.configureHelp(helpStyle)
+	.description(
+		"Extract narrative from session_summary body_text (## Completed / ## Learned sections)",
+	)
+	.option("--limit <n>", "max memories to check")
+	.option("--dry-run", "preview updates without writing");
+addDbOption(backfillNarrativeCmd);
+addJsonOption(backfillNarrativeCmd);
+backfillNarrativeCmd.action(
+	(
+		opts: DbOpts &
+			JsonOpts & {
+				limit?: string;
+				dryRun?: boolean;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = parseOptionalPositiveInt(opts.limit);
+			const result = backfillNarrativeFromBody(store.db, {
+				limit,
+				dryRun: opts.dryRun === true,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			const action = opts.dryRun ? "Would update" : "Updated";
+			p.intro("codemem db backfill-narrative");
+			p.log.success(`${action} ${result.updated} memories (skipped ${result.skipped})`);
+			p.outro(`Checked ${result.checked} memories`);
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);
+dbCommand.addCommand(backfillNarrativeCmd);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -227,10 +227,13 @@ export type {
 	ReliabilityMetrics,
 } from "./maintenance.js";
 export {
+	backfillNarrativeFromBody,
 	backfillTagsText,
 	compareMemoryRoleReports,
 	deactivateLowSignalMemories,
 	deactivateLowSignalObservations,
+	dedupNearDuplicateMemories,
+	extractNarrativeFromBody,
 	getMemoryRoleReport,
 	getRawEventRelinkPlan,
 	getRawEventRelinkReport,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -5,10 +5,13 @@ import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import {
 	applyRawEventRelinkPlan,
+	backfillNarrativeFromBody,
 	backfillTagsText,
 	compareMemoryRoleReports,
 	deactivateLowSignalMemories,
 	deactivateLowSignalObservations,
+	dedupNearDuplicateMemories,
+	extractNarrativeFromBody,
 	getMemoryRoleReport,
 	getRawEventRelinkPlan,
 	getRawEventRelinkReport,
@@ -882,6 +885,290 @@ describe("maintenance", () => {
 			]);
 		} finally {
 			verify.close();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Retroactive near-duplicate deactivation
+// ---------------------------------------------------------------------------
+
+describe("dedupNearDuplicateMemories", () => {
+	function seedMemory(
+		db: Database,
+		sessionId: number,
+		title: string,
+		confidence: number,
+		createdAt: string,
+	): number {
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'discovery', ?, 'body', ?, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, title, confidence, createdAt, createdAt);
+		return Number(info.lastInsertRowid);
+	}
+
+	it("deactivates the lower-confidence duplicate within the time window", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const s1 = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const s2 = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:30:00Z", "test").lastInsertRowid,
+			);
+			const id1 = seedMemory(db, s1, "Sync orchestrator ported", 0.8, "2026-01-01T00:00:00Z");
+			const id2 = seedMemory(db, s2, "Sync orchestrator ported", 0.5, "2026-01-01T00:30:00Z");
+
+			const result = dedupNearDuplicateMemories(db);
+
+			expect(result.deactivated).toBe(1);
+			expect(result.pairs[0]).toMatchObject({ kept_id: id1, deactivated_id: id2 });
+			const active = (db.prepare("SELECT active FROM memory_items WHERE id = ?").get(id2) as any)
+				.active;
+			expect(active).toBe(0);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("does not deactivate pairs outside the time window", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const s1 = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const s2 = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T06:00:00Z", "test").lastInsertRowid,
+			);
+			seedMemory(db, s1, "Same title here", 0.8, "2026-01-01T00:00:00Z");
+			seedMemory(db, s2, "Same title here", 0.5, "2026-01-01T06:00:00Z");
+
+			const result = dedupNearDuplicateMemories(db, { windowMs: 3_600_000 });
+
+			expect(result.deactivated).toBe(0);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("keeps the more recent memory on confidence tie", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const s1 = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const s2 = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:10:00Z", "test").lastInsertRowid,
+			);
+			const id1 = seedMemory(db, s1, "Equal confidence pair", 0.7, "2026-01-01T00:00:00Z");
+			const id2 = seedMemory(db, s2, "Equal confidence pair", 0.7, "2026-01-01T00:10:00Z");
+
+			const result = dedupNearDuplicateMemories(db);
+
+			expect(result.deactivated).toBe(1);
+			expect(result.pairs[0]).toMatchObject({ kept_id: id2, deactivated_id: id1 });
+		} finally {
+			db.close();
+		}
+	});
+
+	it("respects dry-run mode", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const s1 = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const s2 = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:05:00Z", "test").lastInsertRowid,
+			);
+			const id2 = seedMemory(db, s1, "Dry run test", 0.5, "2026-01-01T00:00:00Z");
+			seedMemory(db, s2, "Dry run test", 0.8, "2026-01-01T00:05:00Z");
+
+			const result = dedupNearDuplicateMemories(db, { dryRun: true });
+
+			expect(result.deactivated).toBe(1);
+			const active = (db.prepare("SELECT active FROM memory_items WHERE id = ?").get(id2) as any)
+				.active;
+			expect(active).toBe(1); // Not actually deactivated
+		} finally {
+			db.close();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Heuristic narrative extraction
+// ---------------------------------------------------------------------------
+
+describe("extractNarrativeFromBody", () => {
+	it("extracts Completed and Learned sections", () => {
+		const body = `## Request
+Do something important.
+
+## Completed
+Built the widget and integrated it.
+
+## Learned
+Widgets need careful alignment.`;
+
+		const result = extractNarrativeFromBody(body);
+		expect(result).toBe("Built the widget and integrated it.\n\nWidgets need careful alignment.");
+	});
+
+	it("extracts only Completed when Learned is absent", () => {
+		const body = `## Request
+Fix the bug.
+
+## Completed
+Fixed the null pointer in the parser.`;
+
+		expect(extractNarrativeFromBody(body)).toBe("Fixed the null pointer in the parser.");
+	});
+
+	it("returns null when no structured sections exist", () => {
+		expect(extractNarrativeFromBody("Just a plain body with no headers.")).toBeNull();
+	});
+
+	it("returns null for empty body", () => {
+		expect(extractNarrativeFromBody("")).toBeNull();
+	});
+});
+
+describe("backfillNarrativeFromBody", () => {
+	function seedSummary(db: Database, sessionId: number, title: string, body: string): number {
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'session_summary', ?, ?, 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, title, body, now, now);
+		return Number(info.lastInsertRowid);
+	}
+
+	it("populates narrative from structured body_text", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedSummary(
+				db,
+				sessionId,
+				"Summary title",
+				"## Request\nDo stuff\n\n## Completed\nDid the stuff.\n\n## Learned\nStuff is easy.",
+			);
+
+			const result = backfillNarrativeFromBody(db);
+
+			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0 });
+			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as any;
+			expect(row.narrative).toBe("Did the stuff.\n\nStuff is easy.");
+		} finally {
+			db.close();
+		}
+	});
+
+	it("skips memories without structured sections", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			seedSummary(db, sessionId, "Plain summary", "Just a plain text body.");
+
+			const result = backfillNarrativeFromBody(db);
+
+			expect(result).toMatchObject({ checked: 1, updated: 0, skipped: 1 });
+		} finally {
+			db.close();
+		}
+	});
+
+	it("does not overwrite existing narrative", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedSummary(
+				db,
+				sessionId,
+				"Has narrative",
+				"## Request\nStuff\n\n## Completed\nDone.",
+			);
+			db.prepare("UPDATE memory_items SET narrative = ? WHERE id = ?").run(
+				"Existing narrative",
+				id,
+			);
+
+			const result = backfillNarrativeFromBody(db);
+
+			expect(result.checked).toBe(0); // Already has narrative, not selected
+			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as any;
+			expect(row.narrative).toBe("Existing narrative");
+		} finally {
+			db.close();
+		}
+	});
+
+	it("respects dry-run mode", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedSummary(
+				db,
+				sessionId,
+				"Dry run narrative",
+				"## Request\nDo\n\n## Completed\nDone.\n\n## Learned\nLearned stuff.",
+			);
+
+			const result = backfillNarrativeFromBody(db, { dryRun: true });
+
+			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0 });
+			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as any;
+			expect(row.narrative).toBeNull(); // Not actually written
+		} finally {
+			db.close();
 		}
 	});
 });

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -2084,3 +2084,203 @@ export function deactivateLowSignalMemories(
 
 	return { checked, deactivated: ids.length };
 }
+
+// ---------------------------------------------------------------------------
+// Retroactive near-duplicate deactivation
+// ---------------------------------------------------------------------------
+
+export interface DedupNearDuplicatesResult {
+	checked: number;
+	deactivated: number;
+	pairs: Array<{ kept_id: number; deactivated_id: number; title: string }>;
+}
+
+export interface DedupNearDuplicatesOptions {
+	/** Max time gap in milliseconds between duplicate candidates (default: 1 hour). */
+	windowMs?: number;
+	limit?: number | null;
+	dryRun?: boolean;
+}
+
+/**
+ * Find and deactivate near-duplicate memories: cross-session pairs with
+ * identical normalized titles created within a configurable time window.
+ *
+ * Keeps the higher-confidence member (ties: most recent). Does not delete
+ * rows — only sets `active = 0`.
+ */
+export function dedupNearDuplicateMemories(
+	db: Database,
+	opts: DedupNearDuplicatesOptions = {},
+): DedupNearDuplicatesResult {
+	const windowMs = opts.windowMs ?? 3_600_000; // 1 hour
+	const windowSeconds = windowMs / 1000;
+	const limitClause = opts.limit != null && opts.limit > 0 ? `LIMIT ${Number(opts.limit)}` : "";
+
+	// Find cross-session pairs with identical normalized titles within the time window.
+	// Self-join ordered so a.id < b.id to avoid duplicate pair reporting.
+	const pairRows = db
+		.prepare(
+			`SELECT
+				a.id AS id_a, a.session_id AS session_a, a.confidence AS conf_a, a.created_at AS created_a,
+				b.id AS id_b, b.session_id AS session_b, b.confidence AS conf_b, b.created_at AS created_b,
+				a.title AS title
+			 FROM memory_items a
+			 JOIN memory_items b
+			   ON LOWER(TRIM(a.title)) = LOWER(TRIM(b.title))
+			   AND a.id < b.id
+			   AND a.session_id != b.session_id
+			   AND a.active = 1
+			   AND b.active = 1
+			   AND ABS(JULIANDAY(a.created_at) - JULIANDAY(b.created_at)) * 86400 <= ?
+			 ORDER BY a.created_at DESC
+			 ${limitClause}`,
+		)
+		.all(windowSeconds) as Array<{
+		id_a: number;
+		session_a: number;
+		conf_a: number;
+		created_a: string;
+		id_b: number;
+		session_b: number;
+		conf_b: number;
+		created_b: string;
+		title: string;
+	}>;
+
+	const checked = pairRows.length;
+	const toDeactivate: number[] = [];
+	const pairs: DedupNearDuplicatesResult["pairs"] = [];
+
+	for (const row of pairRows) {
+		// Keep higher confidence; on tie, keep the more recent one.
+		let keepId: number;
+		let dropId: number;
+		if (row.conf_a > row.conf_b) {
+			keepId = row.id_a;
+			dropId = row.id_b;
+		} else if (row.conf_b > row.conf_a) {
+			keepId = row.id_b;
+			dropId = row.id_a;
+		} else {
+			// Equal confidence — keep the more recent one
+			keepId = row.created_a > row.created_b ? row.id_a : row.id_b;
+			dropId = keepId === row.id_a ? row.id_b : row.id_a;
+		}
+		if (!toDeactivate.includes(dropId)) {
+			toDeactivate.push(dropId);
+			pairs.push({ kept_id: keepId, deactivated_id: dropId, title: row.title });
+		}
+	}
+
+	if (toDeactivate.length === 0 || opts.dryRun === true) {
+		return { checked, deactivated: toDeactivate.length, pairs };
+	}
+
+	const now = new Date().toISOString();
+	const chunkSize = 200;
+	for (let start = 0; start < toDeactivate.length; start += chunkSize) {
+		const chunk = toDeactivate.slice(start, start + chunkSize);
+		const placeholders = chunk.map(() => "?").join(",");
+		db.prepare(
+			`UPDATE memory_items SET active = 0, updated_at = ? WHERE id IN (${placeholders})`,
+		).run(now, ...chunk);
+	}
+
+	return { checked, deactivated: toDeactivate.length, pairs };
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic narrative extraction from session_summary body_text
+// ---------------------------------------------------------------------------
+
+export interface BackfillNarrativeResult {
+	checked: number;
+	updated: number;
+	skipped: number;
+}
+
+export interface BackfillNarrativeOptions {
+	limit?: number | null;
+	dryRun?: boolean;
+}
+
+/**
+ * Extract a narrative from the structured `## Completed` / `## Learned`
+ * sections found in session_summary body_text. Returns null if the body
+ * doesn't match the expected structure.
+ */
+export function extractNarrativeFromBody(bodyText: string): string | null {
+	// Match sections like "## Completed\n...\n\n## Learned\n..."
+	const sections: string[] = [];
+
+	const completedMatch = bodyText.match(/##\s*Completed\s*\n([\s\S]*?)(?=\n##\s|\n*$)/);
+	if (completedMatch?.[1]?.trim()) {
+		sections.push(completedMatch[1].trim());
+	}
+
+	const learnedMatch = bodyText.match(/##\s*Learned\s*\n([\s\S]*?)(?=\n##\s|\n*$)/);
+	if (learnedMatch?.[1]?.trim()) {
+		sections.push(learnedMatch[1].trim());
+	}
+
+	if (sections.length === 0) return null;
+	return sections.join("\n\n");
+}
+
+/**
+ * Backfill narrative for session_summary memories that have structured
+ * body_text with `## Completed` / `## Learned` sections but no narrative.
+ *
+ * Only touches session_summary kind. Does not overwrite existing narratives.
+ */
+export function backfillNarrativeFromBody(
+	db: Database,
+	opts: BackfillNarrativeOptions = {},
+): BackfillNarrativeResult {
+	const limitClause = opts.limit != null && opts.limit > 0 ? `LIMIT ${Number(opts.limit)}` : "";
+
+	const rows = db
+		.prepare(
+			`SELECT id, body_text
+			 FROM memory_items
+			 WHERE kind = 'session_summary'
+			   AND active = 1
+			   AND (narrative IS NULL OR LENGTH(narrative) = 0)
+			   AND body_text IS NOT NULL
+			   AND LENGTH(body_text) > 0
+			 ORDER BY created_at ASC
+			 ${limitClause}`,
+		)
+		.all() as Array<{ id: number; body_text: string }>;
+
+	let checked = 0;
+	let updated = 0;
+	let skipped = 0;
+	const updates: Array<{ id: number; narrative: string }> = [];
+
+	for (const row of rows) {
+		checked++;
+		const narrative = extractNarrativeFromBody(row.body_text);
+		if (!narrative) {
+			skipped++;
+			continue;
+		}
+		updates.push({ id: row.id, narrative });
+		updated++;
+	}
+
+	if (updates.length > 0 && opts.dryRun !== true) {
+		const now = new Date().toISOString();
+		const updateStmt = db.prepare(
+			"UPDATE memory_items SET narrative = ?, updated_at = ? WHERE id = ?",
+		);
+		db.transaction(() => {
+			for (const update of updates) {
+				updateStmt.run(update.narrative, now, update.id);
+			}
+		})();
+	}
+
+	return { checked, updated, skipped };
+}

--- a/packages/viewer-server/static/app.js
+++ b/packages/viewer-server/static/app.js
@@ -13781,7 +13781,7 @@ For more information, see https://radix-ui.com/primitives/docs/components/${titl
 		try {
 			const runtime = await loadRuntimeInfo();
 			if (!runtime?.version) return;
-			setRuntimeLabel(runtime.version, "4e209f5");
+			setRuntimeLabel(runtime.version, "72edfec");
 		} catch {}
 	}
 	var lastAnnouncedRefreshState = null;


### PR DESCRIPTION
## Description

Two new retroactive maintenance commands for cleaning up existing memory data:

### `codemem db dedup-memories`
Find cross-session pairs with identical normalized titles created within a configurable time window (default: 1 hour) and deactivate the lower-confidence member. On confidence tie, keeps the more recent memory.

Based on the empirical analysis of the existing DB (1,668 near-duplicate cross-session pairs, 202 within 30 minutes).

### `codemem db backfill-narrative`
Extract narrative from `session_summary` body_text that follows the structured `## Request` / `## Completed` / `## Learned` format. Populates the `narrative` column from the Completed + Learned sections. Does not overwrite existing narratives.

Covers 4,045 session summaries that currently lack structured narrative content.

### Options (both commands)
- `--dry-run` — preview without writing
- `--limit <n>` — cap on items to process
- `--json` — structured output
- `--window <ms>` — dedup time window (dedup-memories only)

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Typecheck clean
- [x] 1067 tests pass (12 new)
- [x] Dedup: within window, outside window, confidence tie, dry-run
- [x] Narrative: structured extraction, missing sections, existing narrative preserved, dry-run
- [x] Unit tests for `extractNarrativeFromBody` parser

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced