### PR TITLE
feat(core,cli): add GPT-5.4 structured-content backfill

### DIFF
--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -39,11 +39,15 @@ describe("db command", () => {
 		expect(pruneMemLongs).toContain("--json");
 	});
 
-	it("registers dedup-memories and backfill-narrative subcommands", () => {
+	it("registers dedup-memories, backfill-narrative, and ai-backfill-structured subcommands", () => {
 		const dedup = dbCommand.commands.find((command) => command.name() === "dedup-memories");
 		const narrative = dbCommand.commands.find((command) => command.name() === "backfill-narrative");
+		const aiStructured = dbCommand.commands.find(
+			(command) => command.name() === "ai-backfill-structured",
+		);
 		expect(dedup).toBeDefined();
 		expect(narrative).toBeDefined();
+		expect(aiStructured).toBeDefined();
 
 		const dedupLongs = dedup?.options.map((option) => option.long) ?? [];
 		expect(dedupLongs).toContain("--window");
@@ -55,6 +59,13 @@ describe("db command", () => {
 		expect(narrativeLongs).toContain("--limit");
 		expect(narrativeLongs).toContain("--dry-run");
 		expect(narrativeLongs).toContain("--json");
+
+		const aiLongs = aiStructured?.options.map((option) => option.long) ?? [];
+		expect(aiLongs).toContain("--limit");
+		expect(aiLongs).toContain("--kinds");
+		expect(aiLongs).toContain("--overwrite");
+		expect(aiLongs).toContain("--dry-run");
+		expect(aiLongs).toContain("--json");
 	});
 
 	it("rejects invalid dedup window input", async () => {

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -1,6 +1,7 @@
 import { statSync } from "node:fs";
 import * as p from "@clack/prompts";
 import {
+	aiBackfillStructuredContent,
 	backfillNarrativeFromBody,
 	backfillTagsText,
 	connect,
@@ -737,3 +738,60 @@ backfillNarrativeCmd.action(
 	},
 );
 dbCommand.addCommand(backfillNarrativeCmd);
+
+// --- db ai-backfill-structured ---
+const aiBackfillStructuredCmd = new Command("ai-backfill-structured")
+	.configureHelp(helpStyle)
+	.description(
+		"Use GPT-5.4 to populate missing narrative/facts/concepts for older non-session-summary memories",
+	)
+	.option("--limit <n>", "max memories to check")
+	.option("--kinds <csv>", "comma-separated kinds to target")
+	.option(
+		"--overwrite",
+		"overwrite existing structured fields instead of only filling missing ones",
+	)
+	.option("--dry-run", "preview updates without writing");
+addDbOption(aiBackfillStructuredCmd);
+addJsonOption(aiBackfillStructuredCmd);
+aiBackfillStructuredCmd.action(
+	async (
+		opts: DbOpts &
+			JsonOpts & {
+				limit?: string;
+				kinds?: string;
+				overwrite?: boolean;
+				dryRun?: boolean;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = parseOptionalPositiveInt(opts.limit);
+			const kinds = parseKindsCsv(opts.kinds);
+			const result = await aiBackfillStructuredContent(store.db, {
+				limit,
+				kinds,
+				overwrite: opts.overwrite === true,
+				dryRun: opts.dryRun === true,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			const action = opts.dryRun ? "Would update" : "Updated";
+			p.intro("codemem db ai-backfill-structured");
+			p.log.success(
+				`${action} ${result.updated} memories (skipped ${result.skipped}, failed ${result.failed})`,
+			);
+			p.outro(`Checked ${result.checked} memories`);
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);
+dbCommand.addCommand(aiBackfillStructuredCmd);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -227,6 +227,7 @@ export type {
 	ReliabilityMetrics,
 } from "./maintenance.js";
 export {
+	aiBackfillStructuredContent,
 	backfillNarrativeFromBody,
 	backfillTagsText,
 	compareMemoryRoleReports,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import {
+	aiBackfillStructuredContent,
 	applyRawEventRelinkPlan,
 	backfillNarrativeFromBody,
 	backfillTagsText,
@@ -21,6 +22,7 @@ import {
 	retryRawEventFailures,
 	vacuumDatabase,
 } from "./maintenance.js";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
 import { initTestSchema } from "./test-utils.js";
 
 function createDbPath(name: string): string {
@@ -1167,6 +1169,340 @@ describe("backfillNarrativeFromBody", () => {
 			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0 });
 			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as any;
 			expect(row.narrative).toBeNull(); // Not actually written
+		} finally {
+			db.close();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AI structured-content backfill
+// ---------------------------------------------------------------------------
+
+describe("aiBackfillStructuredContent", () => {
+	function seedMemory(
+		db: Database,
+		sessionId: number,
+		kind: string,
+		title: string,
+		body: string,
+		narrative: string | null = null,
+		facts: string | null = null,
+		concepts: string | null = null,
+	): number {
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+				 narrative, facts, concepts)
+				 VALUES (?, ?, ?, ?, 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?, ?, ?)`,
+			)
+			.run(sessionId, kind, title, body, now, now, narrative, facts, concepts);
+		return Number(info.lastInsertRowid);
+	}
+
+	function makeObserver(raw: string) {
+		let parsed: Record<string, unknown> | null = null;
+		try {
+			parsed = JSON.parse(raw) as Record<string, unknown>;
+		} catch {
+			parsed = null;
+		}
+		return {
+			observe: async () => ({ raw, parsed: null, provider: "openai", model: "gpt-5.4" }),
+			observeStructuredJson: async () => ({
+				raw,
+				parsed,
+				provider: "openai",
+				model: "gpt-5.4",
+				usedStructuredOutputs: true,
+			}),
+			getStatus: () => ({
+				provider: "openai",
+				model: "gpt-5.4",
+				runtime: "responses_api",
+				auth: { source: "test", type: "api_direct" as const, hasToken: true },
+			}),
+		};
+	}
+
+	it("fills missing structured fields from observer output", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemory(
+				db,
+				sessionId,
+				"change",
+				"Added new widget",
+				"Implemented the widget and documented its behavior.",
+			);
+
+			const observer = makeObserver(
+				JSON.stringify({
+					narrative: "Implemented the new widget and documented its behavior.",
+					facts: ["The widget was implemented", "Documentation was updated"],
+					concepts: ["what-changed", "pattern"],
+				}),
+			);
+
+			const result = await aiBackfillStructuredContent(db, { observer });
+
+			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0, failed: 0 });
+			const row = db
+				.prepare("SELECT narrative, facts, concepts FROM memory_items WHERE id = ?")
+				.get(id) as { narrative: string | null; facts: string | null; concepts: string | null };
+			expect(row.narrative).toBe("Implemented the new widget and documented its behavior.");
+			expect(row.facts).toBe(
+				JSON.stringify(["The widget was implemented", "Documentation was updated"]),
+			);
+			expect(row.concepts).toBe(JSON.stringify(["what-changed", "pattern"]));
+		} finally {
+			db.close();
+		}
+	});
+
+	it("preserves existing structured fields by default", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemory(
+				db,
+				sessionId,
+				"discovery",
+				"Existing narrative",
+				"Observed something useful.",
+				"Already there",
+				JSON.stringify(["Existing fact"]),
+				null,
+			);
+
+			const observer = makeObserver(
+				JSON.stringify({
+					narrative: "New narrative",
+					facts: ["New fact"],
+					concepts: ["gotcha"],
+				}),
+			);
+
+			const result = await aiBackfillStructuredContent(db, { observer });
+
+			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0, failed: 0 });
+			const row = db
+				.prepare("SELECT narrative, facts, concepts FROM memory_items WHERE id = ?")
+				.get(id) as { narrative: string | null; facts: string | null; concepts: string | null };
+			expect(row.narrative).toBe("Already there");
+			expect(row.facts).toBe(JSON.stringify(["Existing fact"]));
+			expect(row.concepts).toBe(JSON.stringify(["gotcha"]));
+		} finally {
+			db.close();
+		}
+	});
+
+	it("overwrites existing fields when overwrite=true", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemory(
+				db,
+				sessionId,
+				"bugfix",
+				"Overwrite test",
+				"Fixed a bug.",
+				"Old narrative",
+				JSON.stringify(["Old fact"]),
+				JSON.stringify(["old-concept"]),
+			);
+
+			const observer = makeObserver(
+				JSON.stringify({
+					narrative: "New narrative.",
+					facts: ["New fact"],
+					concepts: ["problem-solution"],
+				}),
+			);
+
+			await aiBackfillStructuredContent(db, { observer, overwrite: true });
+
+			const row = db
+				.prepare("SELECT narrative, facts, concepts FROM memory_items WHERE id = ?")
+				.get(id) as { narrative: string | null; facts: string | null; concepts: string | null };
+			expect(row.narrative).toBe("New narrative.");
+			expect(row.facts).toBe(JSON.stringify(["New fact"]));
+			expect(row.concepts).toBe(JSON.stringify(["problem-solution"]));
+		} finally {
+			db.close();
+		}
+	});
+
+	it("counts invalid observer output as failed and completes the job", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			seedMemory(db, sessionId, "feature", "Bad JSON", "Body text");
+
+			const observer = makeObserver("not json at all");
+			const result = await aiBackfillStructuredContent(db, { observer });
+
+			expect(result).toMatchObject({ checked: 1, updated: 0, skipped: 0, failed: 1 });
+			const job = getMaintenanceJob(db, "ai_structured_backfill");
+			expect(job).toMatchObject({
+				status: "completed",
+				progress: { current: 1, total: 1, unit: "items" },
+			});
+			expect(job?.metadata).toMatchObject({ failed: 1 });
+		} finally {
+			db.close();
+		}
+	});
+
+	it("counts schema-invalid observer objects as failed instead of skipped", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			seedMemory(db, sessionId, "feature", "Schema invalid", "Body text");
+
+			const observer = makeObserver(JSON.stringify({ foo: "bar" }));
+			const result = await aiBackfillStructuredContent(db, { observer });
+
+			expect(result).toMatchObject({ checked: 1, updated: 0, skipped: 0, failed: 1 });
+		} finally {
+			db.close();
+		}
+	});
+
+	it("excludes summary-like legacy memories from AI backfill target set", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const now = new Date().toISOString();
+			db.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'change', 'Legacy recap', 'Summary body', 0.5, '', 1, ?, ?, ?, 1, 'shared')`,
+			).run(sessionId, now, now, JSON.stringify({ is_summary: true, source: "observer_summary" }));
+
+			const observer = makeObserver(
+				JSON.stringify({
+					narrative: "Should not be used.",
+					facts: ["Fact"],
+					concepts: ["what-changed"],
+				}),
+			);
+			const result = await aiBackfillStructuredContent(db, { observer });
+
+			expect(result).toMatchObject({ checked: 0, updated: 0, skipped: 0, failed: 0 });
+		} finally {
+			db.close();
+		}
+	});
+
+	it("sanitizes truncated narratives and filters unsupported concepts", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemory(
+				db,
+				sessionId,
+				"feature",
+				"Truncation test",
+				"Body text with enough context.",
+			);
+
+			const observer = makeObserver(
+				JSON.stringify({
+					narrative:
+						"Useful first sentence. Another complete sentence. And then an incomplete trailing clause",
+					facts: ["Concrete supported fact"],
+					concepts: ["what-changed", "unsupported-concept", "gotcha"],
+				}),
+			);
+
+			await aiBackfillStructuredContent(db, { observer, overwrite: true });
+
+			const row = db
+				.prepare("SELECT narrative, facts, concepts FROM memory_items WHERE id = ?")
+				.get(id) as { narrative: string | null; facts: string | null; concepts: string | null };
+			expect(row.narrative).toBe("Useful first sentence. Another complete sentence.");
+			expect(row.concepts).toBe(JSON.stringify(["what-changed", "gotcha"]));
+		} finally {
+			db.close();
+		}
+	});
+
+	it("respects dry-run mode", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemory(db, sessionId, "decision", "Dry run", "Decided a thing.");
+
+			const observer = makeObserver(
+				JSON.stringify({
+					narrative: "Made a decision.",
+					facts: ["Decision fact"],
+					concepts: ["trade-off"],
+				}),
+			);
+
+			const result = await aiBackfillStructuredContent(db, { observer, dryRun: true });
+
+			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0, failed: 0 });
+			expect(result.samples).toHaveLength(1);
+			expect(result.samples?.[0]).toMatchObject({
+				id,
+				kind: "decision",
+				title: "Dry run",
+				narrative: "Made a decision.",
+				facts: ["Decision fact"],
+				concepts: ["trade-off"],
+			});
+			const row = db
+				.prepare("SELECT narrative, facts, concepts FROM memory_items WHERE id = ?")
+				.get(id) as { narrative: string | null; facts: string | null; concepts: string | null };
+			expect(row.narrative).toBeNull();
+			expect(row.facts).toBeNull();
+			expect(row.concepts).toBeNull();
 		} finally {
 			db.close();
 		}

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -10,7 +10,14 @@ import {
 } from "./db.js";
 import { getInjectionEvalScenarioByPrompt } from "./eval-scenarios.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
-import { ensureMaintenanceJobsSchema } from "./maintenance-jobs.js";
+import {
+	completeMaintenanceJob,
+	ensureMaintenanceJobsSchema,
+	failMaintenanceJob,
+	startMaintenanceJob,
+	updateMaintenanceJob,
+} from "./maintenance-jobs.js";
+import { loadObserverConfig, ObserverClient } from "./observer-client.js";
 import { buildMemoryPack } from "./pack.js";
 import { projectClause } from "./project.js";
 import * as schema from "./schema.js";
@@ -2283,4 +2290,424 @@ export function backfillNarrativeFromBody(
 	}
 
 	return { checked, updated, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// AI structured-content backfill
+// ---------------------------------------------------------------------------
+
+const AI_BACKFILL_KINDS = [
+	"change",
+	"discovery",
+	"bugfix",
+	"feature",
+	"decision",
+	"exploration",
+	"refactor",
+] as const;
+
+const AI_BACKFILL_CONCEPTS = [
+	"how-it-works",
+	"why-it-exists",
+	"what-changed",
+	"problem-solution",
+	"gotcha",
+	"pattern",
+	"trade-off",
+] as const;
+const AI_BACKFILL_CONCEPT_SET = new Set<string>(AI_BACKFILL_CONCEPTS);
+
+const AI_BACKFILL_JOB_KIND = "ai_structured_backfill";
+const AI_BACKFILL_SCHEMA_NAME = "codemem_structured_memory_backfill";
+const AI_BACKFILL_SCHEMA: Record<string, unknown> = {
+	type: "object",
+	additionalProperties: false,
+	properties: {
+		narrative: { type: ["string", "null"] },
+		facts: { type: "array", items: { type: "string" } },
+		concepts: { type: "array", items: { type: "string", enum: [...AI_BACKFILL_CONCEPTS] } },
+	},
+	required: ["narrative", "facts", "concepts"],
+};
+
+type StructuredBackfillObserver = Pick<
+	ObserverClient,
+	"observe" | "observeStructuredJson" | "getStatus"
+>;
+
+export interface AIBackfillStructuredContentResult {
+	checked: number;
+	updated: number;
+	skipped: number;
+	failed: number;
+	samples?: Array<{
+		id: number;
+		kind: string;
+		title: string;
+		narrative: string | null;
+		facts: string[];
+		concepts: string[];
+	}>;
+}
+
+export interface AIBackfillStructuredContentOptions {
+	limit?: number | null;
+	kinds?: string[] | null;
+	dryRun?: boolean;
+	overwrite?: boolean;
+	observer?: StructuredBackfillObserver;
+}
+
+interface ParsedStructuredBackfill {
+	narrative: string | null;
+	facts: string[];
+	concepts: string[];
+}
+
+type StructuredBackfillRow = {
+	id: number;
+	kind: string;
+	title: string;
+	body_text: string;
+	metadata_json: string | null;
+	narrative: string | null;
+	facts: string | null;
+	concepts: string | null;
+};
+
+function createStructuredBackfillObserver(): StructuredBackfillObserver {
+	const base = loadObserverConfig();
+	return new ObserverClient({
+		...base,
+		observerProvider: "openai",
+		observerModel: "gpt-5.4",
+		observerTemperature: 0.2,
+		observerOpenAIUseResponses: true,
+		observerReasoningEffort: null,
+		observerReasoningSummary: null,
+		observerMaxOutputTokens: 4000,
+	});
+}
+
+function parseJsonArrayOfStrings(value: string | null): string[] {
+	if (!value) return [];
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (Array.isArray(parsed)) {
+			return parsed.filter((item): item is string => typeof item === "string");
+		}
+	} catch {
+		return [];
+	}
+	return [];
+}
+
+function hasCompleteStructuredContent(row: {
+	narrative: string | null;
+	facts: string | null;
+	concepts: string | null;
+}): boolean {
+	return (
+		!!row.narrative?.trim() &&
+		parseJsonArrayOfStrings(row.facts).length > 0 &&
+		parseJsonArrayOfStrings(row.concepts).length > 0
+	);
+}
+
+function buildStructuredBackfillPrompt(row: {
+	id: number;
+	kind: string;
+	title: string;
+	body_text: string;
+}): { system: string; user: string } {
+	const system = `You are converting older codemem memories into structured fields.
+
+<output_contract>
+- Output only valid JSON with exactly this shape:
+  {"narrative": string|null, "facts": string[], "concepts": string[]}
+- Do not add markdown fences or prose.
+- Use null / [] when evidence is missing.
+</output_contract>
+
+<field_rules>
+- narrative: 2-6 complete sentences, or 1-2 short paragraphs made of complete sentences.
+- narrative must end cleanly on a full sentence. Do not output a truncated clause.
+- facts: 2-8 source-grounded, self-contained statements. Prefer concrete details over generic purpose statements.
+- concepts: 2-5 values from this exact list only:
+  ["how-it-works", "why-it-exists", "what-changed", "problem-solution", "gotcha", "pattern", "trade-off"]
+</field_rules>
+
+<grounding_rules>
+- Use ONLY the evidence in the provided title, kind, and body_text.
+- Do not invent files, APIs, behavior, users, dates, or outcomes.
+- If the source is vague, be specific only where the text is specific.
+- If evidence is insufficient for a field, return null or [].
+</grounding_rules>
+
+<concept_rules>
+- Use "gotcha" only when the source clearly describes a pitfall, surprise, failure mode, or caveat.
+- Use "trade-off" only when the source clearly describes a comparison, compromise, or explicit design tension.
+- Prefer fewer concepts over weak concepts.
+</concept_rules>
+
+<verbosity_controls>
+- Keep the narrative concise and information-dense.
+- Avoid repetition between narrative and facts.
+</verbosity_controls>
+
+<verification_loop>
+- Before finalizing, verify: valid JSON, complete sentences in narrative, concepts only from the allowed list, and every claim grounded in the source.
+</verification_loop>`;
+
+	const user = `Memory ID: ${row.id}
+Kind: ${row.kind}
+Title: ${row.title}
+
+Body text:
+${row.body_text}`;
+
+	return { system, user };
+}
+
+function sanitizeNarrative(value: string | null): string | null {
+	if (!value) return null;
+	let text = value.trim();
+	text = text.replace(/^\[+/, "").replace(/\]+$/, "").trim();
+	if (!text) return null;
+
+	// If the model trails off without sentence punctuation, trim to the last
+	// complete sentence if possible. Otherwise reject it as likely truncated.
+	if (!/[.!?]["')\]]?\s*$/.test(text)) {
+		const lastSentenceEnd = Math.max(
+			text.lastIndexOf("."),
+			text.lastIndexOf("!"),
+			text.lastIndexOf("?"),
+		);
+		if (lastSentenceEnd >= 20) {
+			const before = text;
+			text = text.slice(0, lastSentenceEnd + 1).trim();
+			console.warn(
+				`[codemem] sanitizeNarrative trimmed: "${before.slice(-30)}" → "${text.slice(-30)}"`,
+			);
+		} else {
+			console.warn(`[codemem] sanitizeNarrative rejected: "${text.slice(0, 50)}"`);
+			return null;
+		}
+	}
+
+	return text.length > 0 ? text : null;
+}
+
+function parseStructuredBackfillResponse(raw: string | null): ParsedStructuredBackfill {
+	if (!raw) throw new Error("observer returned empty response");
+	const trimmed = raw.trim();
+	const cleaned = trimmed.startsWith("```")
+		? trimmed.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "")
+		: trimmed;
+	const parsed = JSON.parse(cleaned) as Record<string, unknown>;
+	if (
+		!Object.hasOwn(parsed, "narrative") ||
+		!Object.hasOwn(parsed, "facts") ||
+		!Object.hasOwn(parsed, "concepts")
+	) {
+		throw new Error("observer returned schema-invalid object");
+	}
+	if (
+		!(typeof parsed.narrative === "string" || parsed.narrative === null) ||
+		!Array.isArray(parsed.facts) ||
+		!Array.isArray(parsed.concepts)
+	) {
+		throw new Error("observer returned schema-invalid field types");
+	}
+	const narrative =
+		typeof parsed.narrative === "string" && parsed.narrative.trim()
+			? sanitizeNarrative(parsed.narrative)
+			: null;
+	const facts = Array.isArray(parsed.facts)
+		? parsed.facts.filter(
+				(item): item is string => typeof item === "string" && item.trim().length > 0,
+			)
+		: [];
+	const concepts = Array.isArray(parsed.concepts)
+		? parsed.concepts
+				.filter(
+					(item): item is string =>
+						typeof item === "string" &&
+						item.trim().length > 0 &&
+						AI_BACKFILL_CONCEPT_SET.has(item.trim().toLowerCase()),
+				)
+				.map((item) => item.trim().toLowerCase())
+		: [];
+	return { narrative, facts, concepts };
+}
+
+/**
+ * AI-powered backfill for older non-session-summary memories that still lack
+ * structured content (`narrative`, `facts`, `concepts`). Uses GPT-5.4 via the
+ * existing ObserverClient/OpenAI integration.
+ */
+export async function aiBackfillStructuredContent(
+	db: Database,
+	opts: AIBackfillStructuredContentOptions = {},
+): Promise<AIBackfillStructuredContentResult> {
+	const kinds = opts.kinds?.length ? opts.kinds : [...AI_BACKFILL_KINDS];
+	const placeholders = kinds.map(() => "?").join(",");
+	const limitClause = opts.limit != null && opts.limit > 0 ? `LIMIT ${Number(opts.limit)}` : "";
+	const structuredFilter = opts.overwrite
+		? "1=1"
+		: `(narrative IS NULL OR LENGTH(narrative) = 0 OR facts IS NULL OR LENGTH(facts) <= 2 OR concepts IS NULL OR LENGTH(concepts) <= 2)`;
+	const rows = db
+		.prepare(
+			`SELECT id, kind, title, body_text, metadata_json, narrative, facts, concepts
+			 FROM memory_items
+			 WHERE active = 1
+			   AND kind IN (${placeholders})
+			   AND body_text IS NOT NULL
+			   AND LENGTH(body_text) > 0
+			   AND ${structuredFilter}
+			 ORDER BY created_at ASC
+			 ${limitClause}`,
+		)
+		.all(...kinds) as StructuredBackfillRow[];
+	const eligibleRows = rows.filter(
+		(row) => !isSummaryLikeMemory({ kind: row.kind, metadata: row.metadata_json }),
+	);
+
+	const observer = opts.observer ?? createStructuredBackfillObserver();
+	const total = eligibleRows.length;
+	startMaintenanceJob(db, {
+		kind: AI_BACKFILL_JOB_KIND,
+		title: "Backfilling structured content",
+		message: `Preparing GPT-5.4 extraction for ${total} memories`,
+		progressTotal: total,
+		metadata: {
+			model: observer.getStatus().model,
+			provider: observer.getStatus().provider,
+			kinds,
+			overwrite: opts.overwrite === true,
+		},
+	});
+
+	let checked = 0;
+	let updated = 0;
+	let skipped = 0;
+	let failed = 0;
+	const samples: NonNullable<AIBackfillStructuredContentResult["samples"]> = [];
+	const updateStmt = db.prepare(
+		"UPDATE memory_items SET narrative = ?, facts = ?, concepts = ?, updated_at = ? WHERE id = ?",
+	);
+
+	try {
+		for (const row of eligibleRows) {
+			checked++;
+			if (!opts.overwrite && hasCompleteStructuredContent(row)) {
+				skipped++;
+				updateMaintenanceJob(db, AI_BACKFILL_JOB_KIND, {
+					message: `Skipped ${skipped} already-structured memories`,
+					progressCurrent: checked,
+					progressTotal: total,
+				});
+				continue;
+			}
+
+			try {
+				const prompt = buildStructuredBackfillPrompt(row);
+				const response = await observer.observeStructuredJson(
+					prompt.system,
+					prompt.user,
+					AI_BACKFILL_SCHEMA_NAME,
+					AI_BACKFILL_SCHEMA,
+				);
+				const parsed =
+					response.usedStructuredOutputs && response.parsed
+						? parseStructuredBackfillResponse(JSON.stringify(response.parsed))
+						: parseStructuredBackfillResponse(response.raw);
+
+				const nextNarrative =
+					row.narrative?.trim() && !opts.overwrite ? row.narrative : parsed.narrative;
+				const existingFacts = parseJsonArrayOfStrings(row.facts);
+				const nextFacts =
+					existingFacts.length > 0 && !opts.overwrite ? existingFacts : parsed.facts;
+				const existingConcepts = parseJsonArrayOfStrings(row.concepts);
+				const nextConcepts =
+					existingConcepts.length > 0 && !opts.overwrite ? existingConcepts : parsed.concepts;
+
+				const changed =
+					(nextNarrative ?? null) !== (row.narrative ?? null) ||
+					JSON.stringify(nextFacts) !== JSON.stringify(existingFacts) ||
+					JSON.stringify(nextConcepts) !== JSON.stringify(existingConcepts);
+
+				if (!changed) {
+					skipped++;
+				} else {
+					if (opts.dryRun && samples.length < 10) {
+						samples.push({
+							id: row.id,
+							kind: row.kind,
+							title: row.title,
+							narrative: nextNarrative,
+							facts: nextFacts,
+							concepts: nextConcepts,
+						});
+					}
+					if (!opts.dryRun) {
+						updateStmt.run(
+							nextNarrative,
+							JSON.stringify(nextFacts),
+							JSON.stringify(nextConcepts),
+							new Date().toISOString(),
+							row.id,
+						);
+					}
+					updated++;
+				}
+			} catch {
+				failed++;
+			}
+
+			updateMaintenanceJob(db, AI_BACKFILL_JOB_KIND, {
+				message: `Processed ${checked} of ${total} memories`,
+				progressCurrent: checked,
+				progressTotal: total,
+				metadata: {
+					model: observer.getStatus().model,
+					provider: observer.getStatus().provider,
+					kinds,
+					overwrite: opts.overwrite === true,
+					updated,
+					skipped,
+					failed,
+				},
+			});
+		}
+
+		completeMaintenanceJob(db, AI_BACKFILL_JOB_KIND, {
+			message: `Processed ${checked} memories: ${updated} updated, ${skipped} skipped, ${failed} failed`,
+			progressCurrent: checked,
+			progressTotal: total,
+			metadata: {
+				model: observer.getStatus().model,
+				provider: observer.getStatus().provider,
+				kinds,
+				overwrite: opts.overwrite === true,
+				updated,
+				skipped,
+				failed,
+			},
+		});
+	} catch (error) {
+		failMaintenanceJob(
+			db,
+			AI_BACKFILL_JOB_KIND,
+			error instanceof Error ? error.message : String(error),
+			{
+				message: `Failed after ${checked} memories`,
+				progressCurrent: checked,
+				progressTotal: total,
+			},
+		);
+		throw error;
+	}
+
+	return { checked, updated, skipped, failed, ...(opts.dryRun ? { samples } : {}) };
 }

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -107,6 +107,14 @@ export interface ObserverResponse {
 	model: string;
 }
 
+export interface ObserverStructuredJsonResponse {
+	raw: string | null;
+	parsed: Record<string, unknown> | null;
+	provider: string;
+	model: string;
+	usedStructuredOutputs: boolean;
+}
+
 export interface ObserverStatus {
 	provider: string;
 	model: string;
@@ -409,6 +417,27 @@ function buildAnthropicPayload(
 	};
 }
 
+function buildAnthropicStructuredPayload(
+	model: string,
+	systemPrompt: string,
+	userPrompt: string,
+	maxTokens: number,
+	schema: Record<string, unknown>,
+): Record<string, unknown> {
+	return {
+		model: normalizeAnthropicModel(model),
+		max_tokens: maxTokens,
+		system: systemPrompt,
+		messages: [{ role: "user", content: userPrompt }],
+		output_config: {
+			format: {
+				type: "json_schema",
+				schema,
+			},
+		},
+	};
+}
+
 function parseAnthropicResponse(body: Record<string, unknown>): string | null {
 	const content = body.content;
 	if (!Array.isArray(content)) {
@@ -535,6 +564,37 @@ function buildOpenAIResponsesPayload(
 		if (reasoningSummary) reasoning.summary = reasoningSummary;
 		payload.reasoning = reasoning;
 	}
+	return payload;
+}
+
+function buildOpenAIResponsesStructuredPayload(
+	model: string,
+	systemPrompt: string,
+	userPrompt: string,
+	maxOutputTokens: number,
+	reasoningEffort: string | null,
+	reasoningSummary: string | null,
+	temperature: number | null,
+	schemaName: string,
+	schema: Record<string, unknown>,
+): Record<string, unknown> {
+	const payload = buildOpenAIResponsesPayload(
+		model,
+		systemPrompt,
+		userPrompt,
+		maxOutputTokens,
+		reasoningEffort,
+		reasoningSummary,
+		temperature,
+	);
+	payload.text = {
+		format: {
+			type: "json_schema",
+			name: schemaName,
+			schema,
+			strict: true,
+		},
+	};
 	return payload;
 }
 
@@ -955,6 +1015,113 @@ export class ObserverClient {
 			}
 			throw err;
 		}
+	}
+
+	/**
+	 * Request structured JSON output when the current provider/runtime supports it.
+	 * Falls back to plain `observe()` + caller-side parsing for unsupported paths.
+	 */
+	async observeStructuredJson(
+		systemPrompt: string,
+		userPrompt: string,
+		schemaName: string,
+		schema: Record<string, unknown>,
+	): Promise<ObserverStructuredJsonResponse> {
+		if (this.provider === "openai" && this.openaiUseResponses && !this._codexAccess) {
+			if (!this.auth.token) {
+				this._initProvider(true);
+				if (!this.auth.token) {
+					return {
+						raw: null,
+						parsed: null,
+						provider: this.provider,
+						model: this.model,
+						usedStructuredOutputs: true,
+					};
+				}
+			}
+
+			let url: string;
+			if (this._customBaseUrl) {
+				url = `${this._customBaseUrl.replace(/\/+$/, "")}/responses`;
+			} else {
+				url = "https://api.openai.com/v1/responses";
+			}
+			const headers = buildOpenAIHeaders(this.auth.token ?? "");
+			const mergedHeaders = mergeHeadersCaseInsensitive(
+				headers,
+				renderObserverHeaders(this._observerHeaders, this.auth),
+			);
+			const payload = buildOpenAIResponsesStructuredPayload(
+				this.model,
+				systemPrompt,
+				userPrompt,
+				this.maxOutputTokens,
+				this.reasoningEffort,
+				this.reasoningSummary,
+				this.temperature,
+				schemaName,
+				schema,
+			);
+			const raw = await this._fetchJSON(url, mergedHeaders, payload, {
+				parseResponse: parseOpenAIResponsesResponse,
+				providerLabel: "OpenAI",
+			});
+			return {
+				raw,
+				parsed: raw ? tryParseJSON(raw) : null,
+				provider: this.provider,
+				model: this.model,
+				usedStructuredOutputs: true,
+			};
+		}
+
+		if (this.provider === "anthropic") {
+			// Anthropic OAuth consumer uses SSE streaming which may not support
+			// structured output_config reliably. Fall back to observe() for OAuth.
+			// Direct API key path supports non-streaming structured outputs.
+			if (!this._anthropicOAuthAccess) {
+				if (!this.auth.token) {
+					this._initProvider(true);
+				}
+				if (this.auth.token) {
+					const headers = buildAnthropicHeaders(this.auth.token, false);
+					const mergedHeaders = mergeHeadersCaseInsensitive(
+						headers,
+						renderObserverHeaders(this._observerHeaders, this.auth),
+					);
+					const raw = await this._fetchJSON(
+						resolveAnthropicEndpoint(),
+						mergedHeaders,
+						buildAnthropicStructuredPayload(
+							this.model,
+							systemPrompt,
+							userPrompt,
+							this.maxTokens,
+							schema,
+						),
+						{ parseResponse: parseAnthropicResponse, providerLabel: "Anthropic" },
+					);
+					return {
+						raw,
+						parsed: raw ? tryParseJSON(raw) : null,
+						provider: this.provider,
+						model: this.model,
+						usedStructuredOutputs: true,
+					};
+				}
+			}
+			// OAuth or no token — fall through to observe() fallback below
+		}
+
+		const fallback = await this.observe(systemPrompt, userPrompt);
+		return {
+			raw: fallback.raw,
+			parsed: fallback.parsed,
+			provider: fallback.provider,
+			model: fallback.model,
+			usedStructuredOutputs: false,
+		};
 	}
 
 	// -----------------------------------------------------------------------

--- a/packages/viewer-server/static/app.js
+++ b/packages/viewer-server/static/app.js
@@ -13781,7 +13781,7 @@ For more information, see https://radix-ui.com/primitives/docs/components/${titl
 		try {
 			const runtime = await loadRuntimeInfo();
 			if (!runtime?.version) return;
-			setRuntimeLabel(runtime.version, "72edfec");
+			setRuntimeLabel(runtime.version, "0b3b12e");
 		} catch {}
 	}
 	var lastAnnouncedRefreshState = null;


### PR DESCRIPTION
## Description

Add a one-time GPT-5.4 backfill for older non-session-summary memories that still only have freeform `body_text` and lack structured content.

### What it does
New command: `codemem db ai-backfill-structured`

Targets these kinds by default:
- `change`
- `discovery`
- `bugfix`
- `feature`
- `decision`
- `exploration`
- `refactor`

For each eligible memory, uses GPT-5.4 via the existing `ObserverClient` / OpenAI integration to extract:
- `narrative`
- `facts[]`
- `concepts[]`

### Behavior
- **default:** fill only missing fields; preserve existing structured content
- **optional:** `--overwrite` replaces existing fields
- supports `--limit`, `--kinds`, `--dry-run`, `--json`
- persists progress via `maintenance_jobs` as `ai_structured_backfill`

### Why
We already backfilled session summaries heuristically, but ~4.7k older `change`/`discovery`/`bugfix`/etc. memories still lack structured content. This brings them up to the same shape as newer observer-generated memories.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Typecheck clean (`pnpm exec tsc --build packages/core packages/cli`)
- [x] Focused tests pass (`maintenance.test.ts`, `db.test.ts`)
- [x] New tests cover:
  - fills missing fields
  - preserves existing fields by default
  - overwrite mode
  - invalid observer output counts as failed
  - dry-run mode
  - CLI registration for `db ai-backfill-structured`

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced in touched logic