### PR TITLE
fix(core): persist observer narratives for new memories

### DIFF
--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -530,6 +530,7 @@ describe("ingest() integration", () => {
 		expect(obs).toBeDefined();
 		expect(obs?.kind).toBe("discovery");
 		expect(obs?.body_text).toContain("race condition");
+		expect(obs?.narrative).toContain("race condition");
 
 		// Session should be ended
 		const session = store.db

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -561,6 +561,7 @@ export async function ingest(
 				});
 				const memoryId = store.remember(sessionId, kind, memoryTitle, bodyText, 0.5, tags, {
 					subtitle: obs.subtitle,
+					narrative: obs.narrative,
 					facts: obs.facts,
 					concepts: obs.concepts,
 					files_read: obs.filesRead,


### PR DESCRIPTION
## Description

Persist the observer-produced `narrative` field for new non-session-summary memories.

### Root cause
The ingest pipeline already built `body_text` from `obs.narrative` + facts, but it did **not** pass `narrative: obs.narrative` into `store.remember(...)`. Since `store.remember()` only populates the dedicated `memory_items.narrative` column from metadata, recent memories were being stored with:
- `facts` ✅
- `concepts` ✅
- `body_text` ✅
- `narrative` ❌

That meant the viewer/feed could not show a true Narrative view for new memories, even though the observer was generating narrative text.

### Fix
- pass `narrative: obs.narrative` into `store.remember(...)` for observation memories
- add a regression test proving a newly ingested observation persists narrative

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] `pnpm run test -- packages/core/src/ingest-pipeline.test.ts`
- [x] `pnpm exec tsc --build packages/core`
- [x] Regression assertion added: ingested observation memories now have `narrative`

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced