### PR TITLE
fix(ui): separate observation summary from full narrative in feed

### DIFF
--- a/packages/ui/src/tabs/feed.test.ts
+++ b/packages/ui/src/tabs/feed.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { observationViewData } from './feed';
+
+describe('observationViewData', () => {
+  it('uses subtitle as summary and narrative as full text when both exist', () => {
+    const data = observationViewData({
+      subtitle: 'Short skim line',
+      narrative: 'Longer narrative explaining the change in detail.',
+      body_text: 'Legacy body text fallback',
+      facts: ['One fact'],
+      metadata_json: {},
+    });
+
+    expect(data.summary).toBe('Short skim line');
+    expect(data.narrative).toBe('Longer narrative explaining the change in detail.');
+    expect(data.hasSummary).toBe(true);
+    expect(data.hasNarrative).toBe(true);
+  });
+
+  it('falls back to body_text as legacy narrative when structured narrative is missing', () => {
+    const data = observationViewData({
+      subtitle: null,
+      narrative: null,
+      body_text: 'Legacy body text still available as the full observation detail.',
+      facts: [],
+      metadata_json: {},
+    });
+
+    expect(data.summary).toBe('');
+    expect(data.narrative).toBe('Legacy body text still available as the full observation detail.');
+    expect(data.hasSummary).toBe(false);
+    expect(data.hasNarrative).toBe(true);
+  });
+
+  it('does not treat identical subtitle and narrative as distinct narrative mode', () => {
+    const data = observationViewData({
+      subtitle: 'Same text',
+      narrative: 'Same text',
+      body_text: 'Same text',
+      facts: [],
+      metadata_json: {},
+    });
+
+    expect(data.hasSummary).toBe(true);
+    expect(data.hasNarrative).toBe(false);
+  });
+
+  it('derives sentence facts from full narrative before skim summary', () => {
+    const data = observationViewData({
+      subtitle: 'Short skim line',
+      narrative: 'First full detail sentence. Second full detail sentence.',
+      body_text: 'Legacy body text fallback',
+      facts: [],
+      metadata_json: {},
+    });
+
+    expect(data.facts).toEqual(['First full detail sentence.', 'Second full detail sentence.']);
+  });
+});

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -259,16 +259,16 @@ function getFactsList(item: any): string[] {
 
 /* ── Observation view helpers ────────────────────────────── */
 
-function observationViewData(item: any) {
+export function observationViewData(item: any) {
   const metadata = mergeMetadata(item?.metadata_json);
-  const summary = String(item?.subtitle || item?.body_text || '').trim();
-  const narrative = String(item?.narrative || metadata?.narrative || '').trim();
+  const summary = String(item?.subtitle || metadata?.subtitle || '').trim();
+  const narrative = String(item?.narrative || metadata?.narrative || item?.body_text || '').trim();
   const normSummary = normalize(summary);
   const normNarrative = normalize(narrative);
   const narrativeDistinct = Boolean(narrative) && normNarrative !== normSummary;
   const explicitFacts = parseJsonArray(item?.facts || metadata?.facts || []);
-  const fallbackFacts = explicitFacts.length ? explicitFacts : extractFactsFromBody(summary || narrative);
-  const derivedFacts = fallbackFacts.length ? fallbackFacts : sentenceFacts(summary);
+  const fallbackFacts = explicitFacts.length ? explicitFacts : extractFactsFromBody(narrative || summary);
+  const derivedFacts = fallbackFacts.length ? fallbackFacts : sentenceFacts(narrative || summary);
   return { summary, narrative, facts: derivedFacts, hasSummary: Boolean(summary), hasFacts: derivedFacts.length > 0, hasNarrative: narrativeDistinct };
 }
 


### PR DESCRIPTION
## Description

Clarify observation rendering in the feed by separating the skim/summary field from the full narrative field.

### Before
For non-summary memories, the feed treated:
- `summary` = `subtitle || body_text`
- `narrative` = dedicated `narrative`

That made `body_text` implicitly serve as both the summary and the narrative fallback, muddying the distinction between fields.

### After
For non-summary memories, the feed now treats:
- `summary` = `subtitle` only (or metadata subtitle)
- `narrative` = dedicated `narrative`, falling back to `body_text` only as a legacy full-text fallback
- `facts` fallback = derived from narrative/body_text rather than the summary skim line

This keeps the model aligned with the intended data roles:
- `subtitle` = skim line
- `narrative` = full observation detail
- `body_text` = legacy/raw fallback

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] `pnpm exec tsc --build packages/ui`
- [x] New unit tests in `packages/ui/src/tabs/feed.test.ts`
- [x] Verified:
  - subtitle is summary and narrative is full text when both exist
  - body_text is only used as legacy narrative fallback
  - identical subtitle/narrative does not create a redundant narrative mode

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced