### PR TITLE
feat(core,cli): backfill legacy memory dedup keys

### DIFF
--- a/packages/cli/src/commands/db.test.ts
+++ b/packages/cli/src/commands/db.test.ts
@@ -39,13 +39,17 @@ describe("db command", () => {
 		expect(pruneMemLongs).toContain("--json");
 	});
 
-	it("registers dedup-memories, backfill-narrative, and ai-backfill-structured subcommands", () => {
+	it("registers dedup-memories, backfill-dedup-keys, backfill-narrative, and ai-backfill-structured subcommands", () => {
 		const dedup = dbCommand.commands.find((command) => command.name() === "dedup-memories");
+		const dedupKeys = dbCommand.commands.find(
+			(command) => command.name() === "backfill-dedup-keys",
+		);
 		const narrative = dbCommand.commands.find((command) => command.name() === "backfill-narrative");
 		const aiStructured = dbCommand.commands.find(
 			(command) => command.name() === "ai-backfill-structured",
 		);
 		expect(dedup).toBeDefined();
+		expect(dedupKeys).toBeDefined();
 		expect(narrative).toBeDefined();
 		expect(aiStructured).toBeDefined();
 
@@ -54,6 +58,11 @@ describe("db command", () => {
 		expect(dedupLongs).toContain("--limit");
 		expect(dedupLongs).toContain("--dry-run");
 		expect(dedupLongs).toContain("--json");
+
+		const dedupKeysLongs = dedupKeys?.options.map((option) => option.long) ?? [];
+		expect(dedupKeysLongs).toContain("--limit");
+		expect(dedupKeysLongs).toContain("--dry-run");
+		expect(dedupKeysLongs).toContain("--json");
 
 		const narrativeLongs = narrative?.options.map((option) => option.long) ?? [];
 		expect(narrativeLongs).toContain("--limit");

--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -2,6 +2,7 @@ import { statSync } from "node:fs";
 import * as p from "@clack/prompts";
 import {
 	aiBackfillStructuredContent,
+	backfillMemoryDedupKeys,
 	backfillNarrativeFromBody,
 	backfillTagsText,
 	connect,
@@ -693,6 +694,48 @@ dedupCmd.action(
 	},
 );
 dbCommand.addCommand(dedupCmd);
+
+const backfillDedupKeysCmd = new Command("backfill-dedup-keys")
+	.configureHelp(helpStyle)
+	.description("Populate missing memory_items.dedup_key values for legacy rows")
+	.option("--limit <n>", "max memories to check")
+	.option("--dry-run", "preview updates without writing");
+addDbOption(backfillDedupKeysCmd);
+addJsonOption(backfillDedupKeysCmd);
+backfillDedupKeysCmd.action(
+	(
+		opts: DbOpts &
+			JsonOpts & {
+				limit?: string;
+				dryRun?: boolean;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = parseOptionalPositiveInt(opts.limit);
+			const result = backfillMemoryDedupKeys(store.db, {
+				limit,
+				dryRun: opts.dryRun === true,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			const action = opts.dryRun ? "Would update" : "Updated";
+			p.intro("codemem db backfill-dedup-keys");
+			p.log.success(`${action} ${result.updated} memories (skipped ${result.skipped})`);
+			p.outro(`Checked ${result.checked} memories`);
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);
+dbCommand.addCommand(backfillDedupKeysCmd);
 
 // --- db backfill-narrative ---
 const backfillNarrativeCmd = new Command("backfill-narrative")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,6 +228,7 @@ export type {
 } from "./maintenance.js";
 export {
 	aiBackfillStructuredContent,
+	backfillMemoryDedupKeys,
 	backfillNarrativeFromBody,
 	backfillTagsText,
 	compareMemoryRoleReports,

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
 	aiBackfillStructuredContent,
 	applyRawEventRelinkPlan,
+	backfillMemoryDedupKeys,
 	backfillNarrativeFromBody,
 	backfillTagsText,
 	compareMemoryRoleReports,
@@ -934,8 +935,10 @@ describe("dedupNearDuplicateMemories", () => {
 
 			expect(result.deactivated).toBe(1);
 			expect(result.pairs[0]).toMatchObject({ kept_id: id1, deactivated_id: id2 });
-			const active = (db.prepare("SELECT active FROM memory_items WHERE id = ?").get(id2) as any)
-				.active;
+			const row = db.prepare("SELECT active FROM memory_items WHERE id = ?").get(id2) as {
+				active: number;
+			};
+			const active = row.active;
 			expect(active).toBe(0);
 		} finally {
 			db.close();
@@ -1013,8 +1016,10 @@ describe("dedupNearDuplicateMemories", () => {
 			const result = dedupNearDuplicateMemories(db, { dryRun: true });
 
 			expect(result.deactivated).toBe(1);
-			const active = (db.prepare("SELECT active FROM memory_items WHERE id = ?").get(id2) as any)
-				.active;
+			const row = db.prepare("SELECT active FROM memory_items WHERE id = ?").get(id2) as {
+				active: number;
+			};
+			const active = row.active;
 			expect(active).toBe(1); // Not actually deactivated
 		} finally {
 			db.close();
@@ -1092,7 +1097,9 @@ describe("backfillNarrativeFromBody", () => {
 			const result = backfillNarrativeFromBody(db);
 
 			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0 });
-			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as any;
+			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as {
+				narrative: string | null;
+			};
 			expect(row.narrative).toBe("Did the stuff.\n\nStuff is easy.");
 		} finally {
 			db.close();
@@ -1141,7 +1148,9 @@ describe("backfillNarrativeFromBody", () => {
 			const result = backfillNarrativeFromBody(db);
 
 			expect(result.checked).toBe(0); // Already has narrative, not selected
-			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as any;
+			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as {
+				narrative: string | null;
+			};
 			expect(row.narrative).toBe("Existing narrative");
 		} finally {
 			db.close();
@@ -1167,8 +1176,147 @@ describe("backfillNarrativeFromBody", () => {
 			const result = backfillNarrativeFromBody(db, { dryRun: true });
 
 			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0 });
-			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as any;
+			const row = db.prepare("SELECT narrative FROM memory_items WHERE id = ?").get(id) as {
+				narrative: string | null;
+			};
 			expect(row.narrative).toBeNull(); // Not actually written
+		} finally {
+			db.close();
+		}
+	});
+});
+
+describe("backfillMemoryDedupKeys", () => {
+	function seedMemoryWithoutDedupKey(
+		db: Database,
+		sessionId: number,
+		title: string,
+		dedupKey: string | null = null,
+	): number {
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+				 workspace_id, dedup_key)
+				 VALUES (?, 'discovery', ?, 'Body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', 'shared:default', ?)`,
+			)
+			.run(sessionId, title, now, now, dedupKey);
+		return Number(info.lastInsertRowid);
+	}
+
+	it("populates missing dedup_key values for legacy rows", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemoryWithoutDedupKey(db, sessionId, "PR #123 Sync pass orchestrator ported");
+
+			const result = backfillMemoryDedupKeys(db);
+
+			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0 });
+			const row = db.prepare("SELECT dedup_key FROM memory_items WHERE id = ?").get(id) as {
+				dedup_key: string | null;
+			};
+			expect(row.dedup_key).toBeTruthy();
+		} finally {
+			db.close();
+		}
+	});
+
+	it("uses a fallback key when normalization strips the title", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemoryWithoutDedupKey(db, sessionId, "PR #123");
+
+			const result = backfillMemoryDedupKeys(db);
+
+			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0 });
+			const row = db.prepare("SELECT dedup_key FROM memory_items WHERE id = ?").get(id) as {
+				dedup_key: string | null;
+			};
+			expect(row.dedup_key).toBeTruthy();
+		} finally {
+			db.close();
+		}
+	});
+
+	it("skips conflicting active legacy duplicates instead of aborting the backfill", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const idA = seedMemoryWithoutDedupKey(db, sessionId, "PR #88 duplicate title");
+			const idB = seedMemoryWithoutDedupKey(db, sessionId, "PR #88 duplicate title");
+
+			const result = backfillMemoryDedupKeys(db);
+
+			expect(result).toMatchObject({ checked: 2, updated: 1, skipped: 1 });
+			const rows = db
+				.prepare("SELECT id, dedup_key FROM memory_items WHERE id IN (?, ?) ORDER BY id ASC")
+				.all(idA, idB) as Array<{ id: number; dedup_key: string | null }>;
+			expect(rows.filter((row) => row.dedup_key !== null)).toHaveLength(1);
+			expect(rows.filter((row) => row.dedup_key === null)).toHaveLength(1);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("does not overwrite existing dedup_key values", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemoryWithoutDedupKey(db, sessionId, "Existing key", "already-set");
+
+			const result = backfillMemoryDedupKeys(db);
+
+			expect(result).toMatchObject({ checked: 0, updated: 0, skipped: 0 });
+			const row = db.prepare("SELECT dedup_key FROM memory_items WHERE id = ?").get(id) as {
+				dedup_key: string | null;
+			};
+			expect(row.dedup_key).toBe("already-set");
+		} finally {
+			db.close();
+		}
+	});
+
+	it("respects dry-run mode", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemoryWithoutDedupKey(db, sessionId, "Dry run title");
+
+			const result = backfillMemoryDedupKeys(db, { dryRun: true });
+
+			expect(result).toMatchObject({ checked: 1, updated: 1, skipped: 0 });
+			const row = db.prepare("SELECT dedup_key FROM memory_items WHERE id = ?").get(id) as {
+				dedup_key: string | null;
+			};
+			expect(row.dedup_key).toBeNull();
 		} finally {
 			db.close();
 		}

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -17,6 +17,7 @@ import {
 	startMaintenanceJob,
 	updateMaintenanceJob,
 } from "./maintenance-jobs.js";
+import { buildMemoryDedupKey } from "./memory-dedup.js";
 import { loadObserverConfig, ObserverClient } from "./observer-client.js";
 import { buildMemoryPack } from "./pack.js";
 import { projectClause } from "./project.js";
@@ -2212,6 +2213,17 @@ export interface BackfillNarrativeOptions {
 	dryRun?: boolean;
 }
 
+export interface BackfillDedupKeysResult {
+	checked: number;
+	updated: number;
+	skipped: number;
+}
+
+export interface BackfillDedupKeysOptions {
+	limit?: number | null;
+	dryRun?: boolean;
+}
+
 /**
  * Extract a narrative from the structured `## Completed` / `## Learned`
  * sections found in session_summary body_text. Returns null if the body
@@ -2285,6 +2297,98 @@ export function backfillNarrativeFromBody(
 		db.transaction(() => {
 			for (const update of updates) {
 				updateStmt.run(update.narrative, now, update.id);
+			}
+		})();
+	}
+
+	return { checked, updated, skipped };
+}
+
+export function backfillMemoryDedupKeys(
+	db: Database,
+	opts: BackfillDedupKeysOptions = {},
+): BackfillDedupKeysResult {
+	const limitClause = opts.limit != null && opts.limit > 0 ? `LIMIT ${Number(opts.limit)}` : "";
+	const rows = db
+		.prepare(
+			`SELECT id, title, session_id, kind, visibility, workspace_id, active
+			 FROM memory_items
+			 WHERE dedup_key IS NULL
+			 ORDER BY created_at ASC, id ASC
+			 ${limitClause}`,
+		)
+		.all() as Array<{
+		id: number;
+		title: string;
+		session_id: number;
+		kind: string;
+		visibility: string | null;
+		workspace_id: string | null;
+		active: number;
+	}>;
+
+	let checked = 0;
+	let updated = 0;
+	let skipped = 0;
+	const updates: Array<{ id: number; dedupKey: string }> = [];
+	const seenActiveScopes = new Set<string>();
+	const hasActiveConflict = db.prepare(
+		`SELECT 1 AS ok
+		 FROM memory_items
+		 WHERE id != ?
+		   AND active = 1
+		   AND session_id = ?
+		   AND kind = ?
+		   AND visibility IS ?
+		   AND workspace_id IS ?
+		   AND dedup_key = ?
+		 LIMIT 1`,
+	);
+
+	for (const row of rows) {
+		checked++;
+		const dedupKey = buildMemoryDedupKey(row.title);
+		if (!dedupKey) {
+			skipped++;
+			continue;
+		}
+
+		const activeScopeKey = [
+			row.session_id,
+			row.kind,
+			row.visibility ?? "",
+			row.workspace_id ?? "",
+			dedupKey,
+		].join("\u001f");
+		if (
+			row.active === 1 &&
+			(seenActiveScopes.has(activeScopeKey) ||
+				hasActiveConflict.get(
+					row.id,
+					row.session_id,
+					row.kind,
+					row.visibility,
+					row.workspace_id,
+					dedupKey,
+				))
+		) {
+			skipped++;
+			continue;
+		}
+
+		updates.push({ id: row.id, dedupKey });
+		if (row.active === 1) seenActiveScopes.add(activeScopeKey);
+		updated++;
+	}
+
+	if (updates.length > 0 && opts.dryRun !== true) {
+		const now = new Date().toISOString();
+		const updateStmt = db.prepare(
+			"UPDATE memory_items SET dedup_key = ?, updated_at = ? WHERE id = ?",
+		);
+		db.transaction(() => {
+			for (const update of updates) {
+				updateStmt.run(update.dedupKey, now, update.id);
 			}
 		})();
 	}

--- a/packages/core/src/memory-dedup.ts
+++ b/packages/core/src/memory-dedup.ts
@@ -1,0 +1,19 @@
+import { createHash } from "node:crypto";
+
+export function normalizeMemoryDedupTitle(title: string): string {
+	return title
+		.toLowerCase()
+		.replace(/\b(?:pr|pull\s+request|issue)\s*#?\d+\b/gi, " ")
+		.replace(/^\s*#\d+\s*/g, " ")
+		.replace(/^[\s\p{P}]+|[\s\p{P}]+$/gu, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+export function buildMemoryDedupKey(title: string): string | null {
+	const normalized = normalizeMemoryDedupTitle(title);
+	const fallback = title.toLowerCase().replace(/\s+/g, " ").trim();
+	const keySource = normalized || fallback;
+	if (!keySource) return null;
+	return createHash("sha256").update(keySource).digest("hex");
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -12,7 +12,7 @@
  * memory_owned_by_self check.
  */
 
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { statSync } from "node:fs";
 import { and, desc, eq, gt, inArray, isNotNull, lt, lte, or, type SQL, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -32,6 +32,7 @@ import {
 	toJsonNullable,
 } from "./db.js";
 import { buildFilterClauses } from "./filters.js";
+import { buildMemoryDedupKey, normalizeMemoryDedupTitle } from "./memory-dedup.js";
 import { readCodememConfigFile } from "./observer-config.js";
 import {
 	buildMemoryPack,
@@ -158,30 +159,11 @@ const DEFAULT_CROSS_SESSION_DEDUP_WINDOW_MS = 3_600_000;
 const CROSS_SESSION_DEDUP_WINDOW_ENV = "CODEMEM_MEMORY_CROSS_SESSION_DEDUP_WINDOW_MS";
 const MAX_CROSS_SESSION_DEDUP_WINDOW_MS = 8_640_000_000_000_000;
 
-function normalizeMemoryDedupTitle(title: string): string {
-	return title
-		.toLowerCase()
-		.replace(/\b(?:pr|pull\s+request|issue)\s*#?\d+\b/gi, " ")
-		.replace(/^\s*#\d+\s*/g, " ")
-		.replace(/^[\s\p{P}]+|[\s\p{P}]+$/gu, "")
-		.replace(/\s+/g, " ")
-		.trim();
-}
-
-function buildMemoryDedupKey(title: string): string | null {
-	const normalized = normalizeMemoryDedupTitle(title);
-	const fallback = title.toLowerCase().replace(/\s+/g, " ").trim();
-	const keySource = normalized || fallback;
-	if (!keySource) return null;
-	return createHash("sha256").update(keySource).digest("hex");
-}
-
 function getMemoryDedupMatchText(title: string): string | null {
 	const normalized = normalizeMemoryDedupTitle(title);
 	const fallback = title.toLowerCase().replace(/\s+/g, " ").trim();
 	return normalized || fallback || null;
 }
-
 function resolveCrossSessionDedupWindowMs(): number {
 	const raw = process.env[CROSS_SESSION_DEDUP_WINDOW_ENV]?.trim();
 	if (!raw) return DEFAULT_CROSS_SESSION_DEDUP_WINDOW_MS;


### PR DESCRIPTION
## Description
- Add a shared memory dedup helper module so ingestion and maintenance use the same title normalization and key generation logic.
- Add a legacy `dedup_key` backfill maintenance path plus a `codemem db backfill-dedup-keys` CLI command for existing databases.
- Add focused core and CLI coverage for legacy-row backfill, skipped empty-normalization rows, dry-run behavior, and command registration.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pnpm --filter @codemem/core exec vitest run src/maintenance.test.ts src/store.test.ts src/db.test.ts src/test-schema.generated.test.ts` and `pnpm exec vitest run packages/cli/src/commands/db.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm exec biome check` and `pnpm run tsc` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced