### PR TITLE
chore(core): instrument ingestion dedup hits

### DIFF
--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -24,17 +24,20 @@ describe("MemoryStore", () => {
 	let prevActorId: string | undefined;
 	let prevActorDisplayName: string | undefined;
 	let prevCrossSessionDedupWindowMs: string | undefined;
+	let prevCodememDebug: string | undefined;
 
 	beforeEach(() => {
 		prevCodememConfig = process.env.CODEMEM_CONFIG;
 		prevActorId = process.env.CODEMEM_ACTOR_ID;
 		prevActorDisplayName = process.env.CODEMEM_ACTOR_DISPLAY_NAME;
 		prevCrossSessionDedupWindowMs = process.env.CODEMEM_MEMORY_CROSS_SESSION_DEDUP_WINDOW_MS;
+		prevCodememDebug = process.env.CODEMEM_DEBUG;
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-store-test-"));
 		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
 		delete process.env.CODEMEM_ACTOR_ID;
 		delete process.env.CODEMEM_ACTOR_DISPLAY_NAME;
 		delete process.env.CODEMEM_MEMORY_CROSS_SESSION_DEDUP_WINDOW_MS;
+		delete process.env.CODEMEM_DEBUG;
 		dbPath = join(tmpDir, "test.sqlite");
 		// Pre-create the schema so MemoryStore constructor's assertSchemaReady passes
 		const setupDb = connect(dbPath);
@@ -57,6 +60,8 @@ describe("MemoryStore", () => {
 		} else {
 			process.env.CODEMEM_MEMORY_CROSS_SESSION_DEDUP_WINDOW_MS = prevCrossSessionDedupWindowMs;
 		}
+		if (prevCodememDebug === undefined) delete process.env.CODEMEM_DEBUG;
+		else process.env.CODEMEM_DEBUG = prevCodememDebug;
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
@@ -284,6 +289,28 @@ describe("MemoryStore", () => {
 			expect(count.count).toBe(1);
 		});
 
+		it("logs same-session dedup hits when CODEMEM_DEBUG=1", () => {
+			process.env.CODEMEM_DEBUG = "1";
+			const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+			try {
+				const sessionId = insertTestSession(store.db);
+				const firstId = store.remember(sessionId, "feature", "Same session title", "Original body");
+				const duplicateId = store.remember(
+					sessionId,
+					"feature",
+					"Same session title",
+					"Duplicate body",
+				);
+
+				expect(duplicateId).toBe(firstId);
+				expect(stderrSpy).toHaveBeenCalledWith(
+					expect.stringContaining("[codemem] memory dedup hit scope=same_session"),
+				);
+			} finally {
+				stderrSpy.mockRestore();
+			}
+		});
+
 		it("returns the existing id for same-session duplicates when normalization strips the title", () => {
 			const sessionId = insertTestSession(store.db);
 			const firstId = store.remember(sessionId, "feature", "PR #77", "Original body");
@@ -319,6 +346,36 @@ describe("MemoryStore", () => {
 				count: number;
 			};
 			expect(count.count).toBe(1);
+		});
+
+		it("logs cross-session dedup hits when CODEMEM_DEBUG=1", () => {
+			process.env.CODEMEM_DEBUG = "1";
+			const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+			try {
+				const sessionA = insertTestSession(store.db);
+				const sessionB = insertTestSession(store.db);
+				const firstId = store.remember(
+					sessionA,
+					"discovery",
+					"Cross session title",
+					"Original body",
+					0.9,
+				);
+				const duplicateId = store.remember(
+					sessionB,
+					"discovery",
+					"Cross session title",
+					"Duplicate body",
+					0.5,
+				);
+
+				expect(duplicateId).toBe(firstId);
+				expect(stderrSpy).toHaveBeenCalledWith(
+					expect.stringContaining("[codemem] memory dedup hit scope=cross_session"),
+				);
+			} finally {
+				stderrSpy.mockRestore();
+			}
 		});
 
 		it("inserts a new row for cross-session duplicates outside the dedup window", () => {
@@ -442,6 +499,19 @@ describe("MemoryStore", () => {
 			expect(duplicateId).toBe(firstId);
 			const row = store.get(firstId);
 			expect(row?.body_text).toBe("First body");
+		});
+
+		it("does not log dedup hits by default", () => {
+			const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+			try {
+				const sessionId = insertTestSession(store.db);
+				store.remember(sessionId, "feature", "Silent dedup title", "Original body");
+				store.remember(sessionId, "feature", "Silent dedup title", "Duplicate body");
+
+				expect(stderrSpy).not.toHaveBeenCalled();
+			} finally {
+				stderrSpy.mockRestore();
+			}
 		});
 	});
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -158,6 +158,12 @@ const LEGACY_SHARED_WORKSPACE_ID = "shared:legacy";
 const DEFAULT_CROSS_SESSION_DEDUP_WINDOW_MS = 3_600_000;
 const CROSS_SESSION_DEDUP_WINDOW_ENV = "CODEMEM_MEMORY_CROSS_SESSION_DEDUP_WINDOW_MS";
 const MAX_CROSS_SESSION_DEDUP_WINDOW_MS = 8_640_000_000_000_000;
+const CODEMEM_DEBUG_ENV = "CODEMEM_DEBUG";
+
+type DedupHit = {
+	id: number;
+	scope: "same_session" | "cross_session";
+};
 
 function getMemoryDedupMatchText(title: string): string | null {
 	const normalized = normalizeMemoryDedupTitle(title);
@@ -267,7 +273,7 @@ export class MemoryStore {
 			workspace_id: string;
 		},
 		now: string,
-	): number | null {
+	): DedupHit | null {
 		if (!dedupKey) return null;
 		const matchTitle = getMemoryDedupMatchText(title);
 		if (!matchTitle) return null;
@@ -289,7 +295,9 @@ export class MemoryStore {
 			title: string;
 		}>;
 		for (const row of sameSessionRows) {
-			if (getMemoryDedupMatchText(row.title) === matchTitle) return row.id;
+			if (getMemoryDedupMatchText(row.title) === matchTitle) {
+				return { id: row.id, scope: "same_session" };
+			}
 		}
 
 		// Cross-session matching is intentionally best-effort. We want to avoid
@@ -324,9 +332,18 @@ export class MemoryStore {
 			title: string;
 		}>;
 		for (const row of crossSessionRows) {
-			if (getMemoryDedupMatchText(row.title) === matchTitle) return row.id;
+			if (getMemoryDedupMatchText(row.title) === matchTitle) {
+				return { id: row.id, scope: "cross_session" };
+			}
 		}
 		return null;
+	}
+
+	private logDedupHit(hit: DedupHit, kind: string, title: string): void {
+		if (process.env[CODEMEM_DEBUG_ENV] !== "1") return;
+		process.stderr.write(
+			`[codemem] memory dedup hit scope=${hit.scope} existing_id=${hit.id} kind=${kind} title=${JSON.stringify(title)}\n`,
+		);
 	}
 
 	/**
@@ -559,7 +576,7 @@ export class MemoryStore {
 		// Resolve provenance fields
 		const provenance = this.resolveProvenance(metaPayload);
 
-		const existingId = this.findExistingDuplicateMemory(
+		const existingHit = this.findExistingDuplicateMemory(
 			sessionId,
 			validKind,
 			title,
@@ -567,7 +584,10 @@ export class MemoryStore {
 			provenance,
 			now,
 		);
-		if (existingId != null) return existingId;
+		if (existingHit != null) {
+			this.logDedupHit(existingHit, validKind, title);
+			return existingHit.id;
+		}
 
 		// Block shared-memory writes while sync requires attention.
 		this.assertSharedMutationAllowed(provenance.visibility);
@@ -612,7 +632,7 @@ export class MemoryStore {
 				.all();
 		} catch (error) {
 			if (!isSameSessionDedupConstraintError(error)) throw error;
-			const existingSameSessionId = this.findExistingDuplicateMemory(
+			const existingSameSessionHit = this.findExistingDuplicateMemory(
 				sessionId,
 				validKind,
 				title,
@@ -620,7 +640,10 @@ export class MemoryStore {
 				provenance,
 				now,
 			);
-			if (existingSameSessionId != null) return existingSameSessionId;
+			if (existingSameSessionHit != null) {
+				this.logDedupHit(existingSameSessionHit, validKind, title);
+				return existingSameSessionHit.id;
+			}
 			throw error;
 		}
 

--- a/packages/viewer-server/static/app.js
+++ b/packages/viewer-server/static/app.js
@@ -13781,7 +13781,7 @@ For more information, see https://radix-ui.com/primitives/docs/components/${titl
 		try {
 			const runtime = await loadRuntimeInfo();
 			if (!runtime?.version) return;
-			setRuntimeLabel(runtime.version, "9b37b4d");
+			setRuntimeLabel(runtime.version, "2bc14c4");
 		} catch {}
 	}
 	var lastAnnouncedRefreshState = null;


### PR DESCRIPTION
## Description
- Add debug-gated instrumentation for ingestion-time dedup hits in `MemoryStore.remember`.
- Distinguish same-session vs cross-session dedup reuse and emit a compact debug log only when `CODEMEM_DEBUG=1`.
- Add targeted tests for same-session logging, cross-session logging, and the default silent path.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pnpm --filter @codemem/core exec vitest run src/store.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm exec biome check` and `pnpm --filter @codemem/core exec tsc --noEmit` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced