### PR TITLE
feat(core,cli): automate dedup-key backfill maintenance

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -4,6 +4,8 @@ import net from "node:net";
 import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import {
+	DedupKeyBackfillRunner,
+	hasPendingDedupKeyBackfill,
 	initDatabase,
 	isEmbeddingDisabled,
 	type MemoryStore,
@@ -408,6 +410,9 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	const vectorMigrationRunner = new VectorModelMigrationRunner({
 		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
 	});
+	const dedupKeyBackfillRunner = new DedupKeyBackfillRunner({
+		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
+	});
 	const syncRuntimeStatus: {
 		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
 		detail: string | null;
@@ -466,6 +471,10 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			if (!isEmbeddingDisabled()) {
 				vectorMigrationRunner.start();
 				p.log.step("Vector maintenance runner started");
+			}
+			if (hasPendingDedupKeyBackfill(store.db)) {
+				dedupKeyBackfillRunner.start();
+				p.log.step("Dedup-key maintenance runner started");
 			}
 			if (syncConfig.syncRetentionEnabled) {
 				retentionRunner.start();
@@ -541,6 +550,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		syncAbort.abort();
 		retentionAbort.abort();
 		await sweeper.stop();
+		await dedupKeyBackfillRunner.stop();
 		await vectorMigrationRunner.stop();
 		await retentionRunner.stop();
 

--- a/packages/core/src/dedup-key-backfill.test.ts
+++ b/packages/core/src/dedup-key-backfill.test.ts
@@ -1,0 +1,94 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import {
+	DEDUP_KEY_BACKFILL_JOB,
+	hasPendingDedupKeyBackfill,
+	runDedupKeyBackfillPass,
+} from "./dedup-key-backfill.js";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+
+function seedMemoryWithoutDedupKey(
+	db: Database,
+	sessionId: number,
+	title: string,
+	active = 1,
+): number {
+	const now = new Date().toISOString();
+	const info = db
+		.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+			 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+			 workspace_id, dedup_key)
+			 VALUES (?, 'discovery', ?, 'Body', 0.5, '', ?, ?, ?, '{}', 1, 'shared', 'shared:default', NULL)`,
+		)
+		.run(sessionId, title, active, now, now);
+	return Number(info.lastInsertRowid);
+}
+
+describe("dedup-key backfill maintenance", () => {
+	it("runs once for duplicate scopes, then stops when only skipped rows remain", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			seedMemoryWithoutDedupKey(db, sessionId, "PR #88 duplicate title");
+			seedMemoryWithoutDedupKey(db, sessionId, "PR #88 duplicate title");
+
+			expect(hasPendingDedupKeyBackfill(db)).toBe(true);
+			await runDedupKeyBackfillPass(db, { batchSize: 10 });
+
+			const job = getMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB);
+			expect(job).toMatchObject({
+				status: "completed",
+				progress: { current: 1, total: 1, unit: "items" },
+			});
+			expect(job?.metadata).toMatchObject({ remaining_backfillable: 0, skipped_rows: 1 });
+			expect(hasPendingDedupKeyBackfill(db)).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("tracks progress and completes when backfillable rows are exhausted", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			seedMemoryWithoutDedupKey(db, sessionId, "Legacy title one");
+			seedMemoryWithoutDedupKey(db, sessionId, "Legacy title two");
+			seedMemoryWithoutDedupKey(db, sessionId, "Legacy title three");
+
+			expect(hasPendingDedupKeyBackfill(db)).toBe(true);
+
+			await runDedupKeyBackfillPass(db, { batchSize: 2 });
+
+			const runningJob = getMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB);
+			expect(runningJob).toMatchObject({
+				status: "running",
+				progress: { current: 2, total: 3, unit: "items" },
+			});
+			expect(runningJob?.metadata).toMatchObject({
+				processed_updates: 2,
+				remaining_backfillable: 1,
+				total_backfillable: 3,
+			});
+
+			await runDedupKeyBackfillPass(db, { batchSize: 2 });
+
+			const completedJob = getMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB);
+			expect(completedJob).toMatchObject({
+				status: "completed",
+				progress: { current: 3, total: 3, unit: "items" },
+			});
+			expect(completedJob?.metadata).toMatchObject({
+				processed_updates: 3,
+				remaining_backfillable: 0,
+				total_backfillable: 3,
+			});
+			expect(hasPendingDedupKeyBackfill(db)).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/core/src/dedup-key-backfill.ts
+++ b/packages/core/src/dedup-key-backfill.ts
@@ -1,0 +1,218 @@
+import type { Database as SqliteDatabase } from "better-sqlite3";
+import { connect, resolveDbPath } from "./db.js";
+import { applyMemoryDedupKeyUpdates, planMemoryDedupKeys } from "./maintenance.js";
+import {
+	completeMaintenanceJob,
+	failMaintenanceJob,
+	getMaintenanceJob,
+	startMaintenanceJob,
+	updateMaintenanceJob,
+} from "./maintenance-jobs.js";
+
+export const DEDUP_KEY_BACKFILL_JOB = "memory_dedup_key_backfill";
+
+type DedupKeyBackfillMetadata = {
+	total_backfillable?: number;
+	processed_updates?: number;
+	remaining_backfillable?: number;
+	skipped_rows?: number;
+	checked_rows?: number;
+	last_batch_updated?: number;
+	last_cursor_id?: number;
+};
+
+export interface DedupKeyBackfillRunnerOptions {
+	batchSize?: number;
+	intervalMs?: number;
+	dbPath?: string;
+	signal?: AbortSignal;
+}
+
+export function hasPendingDedupKeyBackfill(db: SqliteDatabase): boolean {
+	return planMemoryDedupKeys(db, { updateLimit: 1 }).backfillable > 0;
+}
+
+function getExistingMetadata(db: SqliteDatabase): DedupKeyBackfillMetadata {
+	return (
+		((getMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB)?.metadata ?? {}) as DedupKeyBackfillMetadata) ??
+		{}
+	);
+}
+
+export async function runDedupKeyBackfillPass(
+	db: SqliteDatabase,
+	options: { batchSize?: number } = {},
+): Promise<boolean> {
+	const existingJob = getMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB);
+	const existingMetadata = getExistingMetadata(db);
+	const batchSize = Math.max(1, options.batchSize ?? 250);
+	const lastCursorId = Number(existingMetadata.last_cursor_id ?? 0);
+	const plan = planMemoryDedupKeys(db, {
+		rowLimit: batchSize,
+		updateLimit: batchSize,
+		afterId: lastCursorId,
+	});
+
+	if (plan.checked <= 0) {
+		if (existingJob && existingJob.status !== "completed") {
+			const processedUpdates = Number(existingMetadata.processed_updates ?? 0);
+			completeMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB, {
+				message:
+					Number(existingMetadata.skipped_rows ?? 0) > 0
+						? `No backfillable dedup keys remaining (${Number(existingMetadata.skipped_rows ?? 0)} skipped)`
+						: "Dedup-key backfill complete",
+				progressCurrent: processedUpdates,
+				progressTotal: Number(existingMetadata.total_backfillable ?? processedUpdates),
+				metadata: {
+					...existingMetadata,
+					remaining_backfillable: 0,
+					checked_rows: 0,
+					last_batch_updated: 0,
+					last_cursor_id: lastCursorId,
+				},
+			});
+		}
+		return false;
+	}
+
+	const processedBefore = Number(existingMetadata.processed_updates ?? 0);
+	let progressTotal = Number(existingMetadata.total_backfillable ?? 0);
+	const processedAfter = processedBefore + plan.updates.length;
+	const cumulativeSkipped = Number(existingMetadata.skipped_rows ?? 0) + plan.skipped;
+	const reachedEnd = plan.exhausted;
+	const remainingWork = !reachedEnd;
+
+	if (!existingJob || existingJob.status === "completed" || existingJob.status === "failed") {
+		const totalPlan = planMemoryDedupKeys(db, { updateLimit: 1 });
+		const initialTotal = totalPlan.backfillable;
+		startMaintenanceJob(db, {
+			kind: DEDUP_KEY_BACKFILL_JOB,
+			title: "Backfilling dedup keys",
+			message: `Backfilling ${initialTotal} legacy memories with dedup keys`,
+			progressTotal: initialTotal,
+			metadata: {
+				total_backfillable: initialTotal,
+				processed_updates: processedBefore,
+				remaining_backfillable: initialTotal,
+				skipped_rows: 0,
+				checked_rows: plan.checked,
+				last_batch_updated: 0,
+				last_cursor_id: 0,
+			},
+		});
+		progressTotal = initialTotal;
+	}
+
+	applyMemoryDedupKeyUpdates(db, plan.updates);
+
+	if (!remainingWork) {
+		const finalProgressTotal = Number(
+			getExistingMetadata(db).total_backfillable ?? progressTotal ?? processedAfter,
+		);
+		completeMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB, {
+			message:
+				cumulativeSkipped > 0
+					? `Dedup-key backfill complete (${cumulativeSkipped} skipped)`
+					: "Dedup-key backfill complete",
+			progressCurrent: processedAfter,
+			progressTotal: finalProgressTotal,
+			metadata: {
+				total_backfillable: finalProgressTotal,
+				processed_updates: processedAfter,
+				remaining_backfillable: 0,
+				skipped_rows: cumulativeSkipped,
+				checked_rows: plan.checked,
+				last_batch_updated: plan.updates.length,
+				last_cursor_id: plan.lastScannedId,
+			},
+		});
+		return false;
+	}
+
+	updateMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB, {
+		message: `Backfilled ${processedAfter} of ${progressTotal} legacy dedup keys`,
+		progressCurrent: processedAfter,
+		progressTotal,
+		metadata: {
+			total_backfillable: progressTotal,
+			processed_updates: processedAfter,
+			remaining_backfillable: Math.max(progressTotal - processedAfter, 0),
+			skipped_rows: cumulativeSkipped,
+			checked_rows: plan.checked,
+			last_batch_updated: plan.updates.length,
+			last_cursor_id: plan.lastScannedId,
+		},
+	});
+	return true;
+}
+
+export class DedupKeyBackfillRunner {
+	private readonly dbPath: string;
+	private readonly signal?: AbortSignal;
+	private readonly batchSize: number;
+	private readonly intervalMs: number;
+	private active = false;
+	private timer: ReturnType<typeof setTimeout> | null = null;
+	private currentRun: Promise<void> | null = null;
+
+	constructor(options: DedupKeyBackfillRunnerOptions = {}) {
+		this.dbPath = resolveDbPath(options.dbPath);
+		this.signal = options.signal;
+		this.batchSize = Math.max(1, options.batchSize ?? 250);
+		this.intervalMs = Math.max(1000, options.intervalMs ?? 5000);
+	}
+
+	start(): void {
+		if (this.active) return;
+		this.active = true;
+		this.schedule(100);
+	}
+
+	async stop(): Promise<void> {
+		this.active = false;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+		if (this.currentRun) await this.currentRun;
+	}
+
+	private schedule(delayMs: number): void {
+		if (!this.active || this.signal?.aborted) return;
+		this.timer = setTimeout(() => {
+			this.timer = null;
+			this.currentRun = this.runOnce()
+				.catch((err) => {
+					console.error("Dedup-key backfill runner tick failed:", err);
+				})
+				.finally(() => {
+					this.currentRun = null;
+					this.schedule(this.intervalMs);
+				});
+		}, delayMs);
+		if (typeof this.timer === "object" && "unref" in this.timer) this.timer.unref();
+	}
+
+	private async runOnce(): Promise<void> {
+		if (!this.active || this.signal?.aborted) return;
+		let db: SqliteDatabase | null = null;
+		try {
+			db = connect(this.dbPath) as SqliteDatabase;
+			const hasMoreWork = await runDedupKeyBackfillPass(db, { batchSize: this.batchSize });
+			if (!hasMoreWork) {
+				this.active = false;
+			}
+		} catch (error) {
+			if (db) {
+				failMaintenanceJob(
+					db,
+					DEDUP_KEY_BACKFILL_JOB,
+					error instanceof Error ? error.message : String(error),
+				);
+			}
+			console.warn("Dedup-key backfill runner failed", error);
+		} finally {
+			db?.close();
+		}
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,12 @@ export {
 	toJson,
 	toJsonNullable,
 } from "./db.js";
+export {
+	DEDUP_KEY_BACKFILL_JOB,
+	DedupKeyBackfillRunner,
+	hasPendingDedupKeyBackfill,
+	runDedupKeyBackfillPass,
+} from "./dedup-key-backfill.js";
 export type { EmbeddingClient } from "./embeddings.js";
 export {
 	_resetEmbeddingClient,

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -2219,10 +2219,33 @@ export interface BackfillDedupKeysResult {
 	skipped: number;
 }
 
+export interface BackfillDedupKeysPlan extends BackfillDedupKeysResult {
+	backfillable: number;
+	updates: Array<{ id: number; dedupKey: string }>;
+	lastScannedId: number;
+	exhausted: boolean;
+}
+
 export interface BackfillDedupKeysOptions {
 	limit?: number | null;
 	dryRun?: boolean;
 }
+
+interface BackfillDedupKeysPlanOptions {
+	rowLimit?: number | null;
+	updateLimit?: number | null;
+	afterId?: number | null;
+}
+
+type DedupKeyCandidateRow = {
+	id: number;
+	title: string;
+	session_id: number;
+	kind: string;
+	visibility: string | null;
+	workspace_id: string | null;
+	active: number;
+};
 
 /**
  * Extract a narrative from the structured `## Completed` / `## Learned`
@@ -2304,32 +2327,47 @@ export function backfillNarrativeFromBody(
 	return { checked, updated, skipped };
 }
 
-export function backfillMemoryDedupKeys(
+function selectDedupKeyCandidateRows(
 	db: Database,
-	opts: BackfillDedupKeysOptions = {},
-): BackfillDedupKeysResult {
-	const limitClause = opts.limit != null && opts.limit > 0 ? `LIMIT ${Number(opts.limit)}` : "";
-	const rows = db
+	options: { rowLimit: number | null | undefined; afterId: number | null | undefined },
+): DedupKeyCandidateRow[] {
+	const limitClause =
+		options.rowLimit != null && options.rowLimit > 0 ? `LIMIT ${Number(options.rowLimit)}` : "";
+	const afterId = options.afterId != null && options.afterId > 0 ? options.afterId : 0;
+	return db
 		.prepare(
 			`SELECT id, title, session_id, kind, visibility, workspace_id, active
 			 FROM memory_items
 			 WHERE dedup_key IS NULL
+			   AND id > ?
 			 ORDER BY created_at ASC, id ASC
 			 ${limitClause}`,
 		)
-		.all() as Array<{
-		id: number;
-		title: string;
-		session_id: number;
-		kind: string;
-		visibility: string | null;
-		workspace_id: string | null;
-		active: number;
-	}>;
+		.all(afterId) as DedupKeyCandidateRow[];
+}
+
+function buildDedupActiveScopeKey(row: DedupKeyCandidateRow, dedupKey: string): string {
+	return [row.session_id, row.kind, row.visibility ?? "", row.workspace_id ?? "", dedupKey].join(
+		"\u001f",
+	);
+}
+
+export function planMemoryDedupKeys(
+	db: Database,
+	options: BackfillDedupKeysPlanOptions = {},
+): BackfillDedupKeysPlan {
+	const rowLimit = options.rowLimit ?? null;
+	const rows = selectDedupKeyCandidateRows(db, {
+		rowLimit,
+		afterId: options.afterId ?? null,
+	});
+	const updateLimit =
+		options.updateLimit != null && options.updateLimit > 0 ? options.updateLimit : null;
 
 	let checked = 0;
 	let updated = 0;
 	let skipped = 0;
+	let backfillable = 0;
 	const updates: Array<{ id: number; dedupKey: string }> = [];
 	const seenActiveScopes = new Set<string>();
 	const hasActiveConflict = db.prepare(
@@ -2353,13 +2391,7 @@ export function backfillMemoryDedupKeys(
 			continue;
 		}
 
-		const activeScopeKey = [
-			row.session_id,
-			row.kind,
-			row.visibility ?? "",
-			row.workspace_id ?? "",
-			dedupKey,
-		].join("\u001f");
+		const activeScopeKey = buildDedupActiveScopeKey(row, dedupKey);
 		if (
 			row.active === 1 &&
 			(seenActiveScopes.has(activeScopeKey) ||
@@ -2376,24 +2408,50 @@ export function backfillMemoryDedupKeys(
 			continue;
 		}
 
-		updates.push({ id: row.id, dedupKey });
+		backfillable++;
+		if (updateLimit == null || updates.length < updateLimit) {
+			updates.push({ id: row.id, dedupKey });
+		}
 		if (row.active === 1) seenActiveScopes.add(activeScopeKey);
 		updated++;
 	}
 
-	if (updates.length > 0 && opts.dryRun !== true) {
-		const now = new Date().toISOString();
-		const updateStmt = db.prepare(
-			"UPDATE memory_items SET dedup_key = ?, updated_at = ? WHERE id = ?",
-		);
-		db.transaction(() => {
-			for (const update of updates) {
-				updateStmt.run(update.dedupKey, now, update.id);
-			}
-		})();
-	}
+	return {
+		checked,
+		updated,
+		skipped,
+		backfillable,
+		updates,
+		lastScannedId: rows.at(-1)?.id ?? options.afterId ?? 0,
+		exhausted: rowLimit == null || rows.length < rowLimit,
+	};
+}
 
-	return { checked, updated, skipped };
+export function applyMemoryDedupKeyUpdates(
+	db: Database,
+	updates: Array<{ id: number; dedupKey: string }>,
+): void {
+	if (updates.length <= 0) return;
+	const now = new Date().toISOString();
+	const updateStmt = db.prepare(
+		"UPDATE memory_items SET dedup_key = ?, updated_at = ? WHERE id = ?",
+	);
+	db.transaction(() => {
+		for (const update of updates) {
+			updateStmt.run(update.dedupKey, now, update.id);
+		}
+	})();
+}
+
+export function backfillMemoryDedupKeys(
+	db: Database,
+	opts: BackfillDedupKeysOptions = {},
+): BackfillDedupKeysResult {
+	const plan = planMemoryDedupKeys(db, { rowLimit: opts.limit ?? null });
+	if (opts.dryRun !== true) {
+		applyMemoryDedupKeyUpdates(db, plan.updates);
+	}
+	return { checked: plan.checked, updated: plan.updated, skipped: plan.skipped };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/viewer-server/static/app.js
+++ b/packages/viewer-server/static/app.js
@@ -13781,7 +13781,7 @@ For more information, see https://radix-ui.com/primitives/docs/components/${titl
 		try {
 			const runtime = await loadRuntimeInfo();
 			if (!runtime?.version) return;
-			setRuntimeLabel(runtime.version, "2bc14c4");
+			setRuntimeLabel(runtime.version, "878e5a1");
 		} catch {}
 	}
 	var lastAnnouncedRefreshState = null;


### PR DESCRIPTION
## Description
- Add an automatic dedup-key backfill maintenance runner for legacy memories.
- Only start the runner when backfillable `dedup_key IS NULL` rows remain, so permanently skipped rows do not retrigger maintenance forever.
- Stop the runner once the backlog is drained and expose progress through the existing maintenance job plumbing.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pnpm --filter @codemem/core exec vitest run src/dedup-key-backfill.test.ts src/maintenance.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm exec biome check` and `pnpm --filter @codemem/core exec tsc --noEmit` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced