### PR TITLE
fix(viewer): keep maintenance cards in stable order

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -17,6 +17,7 @@ import {
 	loadPublicKey,
 	MemoryStore,
 	startMaintenanceJob,
+	updateMaintenanceJob,
 	VERSION,
 } from "@codemem/core";
 import Database from "better-sqlite3";
@@ -200,6 +201,40 @@ describe("viewer-server", () => {
 				expect(db).toHaveProperty("path");
 				expect(db).toHaveProperty("sessions");
 				expect(db).toHaveProperty("memory_items");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("keeps active maintenance jobs in stable started order", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+
+				startMaintenanceJob(store.db, {
+					kind: "job-a",
+					title: "Job A",
+					message: "A",
+					progressTotal: 10,
+				});
+				startMaintenanceJob(store.db, {
+					kind: "job-b",
+					title: "Job B",
+					message: "B",
+					progressTotal: 10,
+				});
+				updateMaintenanceJob(store.db, "job-b", {
+					message: "B updated",
+					progressCurrent: 5,
+				});
+
+				const res = await app.request("/api/stats");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				const jobs = body.maintenance_jobs as Array<Record<string, unknown>>;
+				expect(jobs.map((job) => job.kind)).toEqual(["job-a", "job-b"]);
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -7,6 +7,25 @@
 import { listMaintenanceJobs, type MemoryStore, VERSION } from "@codemem/core";
 import { Hono } from "hono";
 
+function maintenanceJobSortKey(job: {
+	started_at: string | null;
+	updated_at: string;
+	kind: string;
+}): [string, string] {
+	return [job.started_at ?? job.updated_at, job.kind];
+}
+
+function sortActiveMaintenanceJobs<
+	T extends { started_at: string | null; updated_at: string; kind: string },
+>(jobs: T[]): T[] {
+	return [...jobs].sort((a, b) => {
+		const [aTime, aKind] = maintenanceJobSortKey(a);
+		const [bTime, bKind] = maintenanceJobSortKey(b);
+		if (aTime !== bTime) return aTime.localeCompare(bTime);
+		return aKind.localeCompare(bKind);
+	});
+}
+
 /**
  * Create stats routes. The store factory is called per-request to get a
  * fresh connection (matching the Python viewer pattern).
@@ -26,18 +45,18 @@ export function statsRoutes(getStore: () => MemoryStore) {
 	app.get("/api/stats", (c) => {
 		const store = getStore();
 		const jobs = listMaintenanceJobs(store.db);
-		const activeJobs = jobs
-			.filter(
+		const activeJobs = sortActiveMaintenanceJobs(
+			jobs.filter(
 				(job) => job.status === "pending" || job.status === "running" || job.status === "failed",
-			)
-			.map((job) => ({
-				kind: job.kind,
-				title: job.title,
-				status: job.status,
-				message: job.message,
-				progress: job.progress,
-				error: job.error,
-			}));
+			),
+		).map((job) => ({
+			kind: job.kind,
+			title: job.title,
+			status: job.status,
+			message: job.message,
+			progress: job.progress,
+			error: job.error,
+		}));
 		return c.json({
 			...store.stats(),
 			viewer_pid: process.pid,

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -76,25 +76,36 @@ const SYNC_PROTOCOL_VERSION = "2";
 const LEGACY_SYNC_ACTOR_DISPLAY_NAME = "Legacy synced peer";
 const LEGACY_SHARED_WORKSPACE_ID = "shared:legacy";
 
+function sortActiveMaintenanceJobs<
+	T extends { started_at: string | null; updated_at: string; kind: string },
+>(jobs: T[]): T[] {
+	return [...jobs].sort((a, b) => {
+		const aTime = a.started_at ?? a.updated_at;
+		const bTime = b.started_at ?? b.updated_at;
+		if (aTime !== bTime) return aTime.localeCompare(bTime);
+		return a.kind.localeCompare(b.kind);
+	});
+}
+
 function summarizeMaintenanceJobs(
 	jobs: MaintenanceJobSnapshot[],
 	showDiagnostics: boolean,
 ): Array<Record<string, unknown>> {
-	return jobs
-		.filter((job) => ["pending", "running", "failed"].includes(String(job.status ?? "")))
-		.map((job) => ({
-			kind: job.kind,
-			title: job.title,
-			status: job.status,
-			progress: job.progress,
-			...(showDiagnostics
-				? {
-						message: job.message,
-						error: job.error,
-						metadata: job.metadata,
-					}
-				: {}),
-		}));
+	return sortActiveMaintenanceJobs(
+		jobs.filter((job) => ["pending", "running", "failed"].includes(String(job.status ?? ""))),
+	).map((job) => ({
+		kind: job.kind,
+		title: job.title,
+		status: job.status,
+		progress: job.progress,
+		...(showDiagnostics
+			? {
+					message: job.message,
+					error: job.error,
+					metadata: job.metadata,
+				}
+			: {}),
+	}));
 }
 
 function syncKeysDir(): string | undefined {


### PR DESCRIPTION
## Description
- Keep active maintenance jobs in a stable API order so Health maintenance cards do not swap positions whenever progress updates bump `updated_at`.
- Sort active maintenance jobs by start time and kind in both stats and sync API responses.
- Add a regression test for stable maintenance ordering in `/api/stats`.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [x] Tests pass locally (`pnpm exec vitest run packages/viewer-server/src/index.test.ts -t "keeps active maintenance jobs in stable started order"`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
- [x] Code follows project style (`pnpm exec biome check` and `pnpm run tsc` pass)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced