### PR TITLE
chore(release): prepare 0.25.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.25.0"
+    "version": "0.25.1"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 .pytest_cache/
 .coverage
 coverage.xml
+.envrc
 *.egg-info/
 .eggs/
 build/

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.25.0";
+const PINNED_BACKEND_VERSION = "0.25.1";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.25.0");
+		expect(VERSION).toBe("0.25.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.25.0";
+export const VERSION = "0.25.1";
 
 export * as Api from "./api-types.js";
 export type { CreateBetterSqliteCoordinatorAppOptions } from "./better-sqlite-coordinator-runtime.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.25.0";
+const PINNED_BACKEND_VERSION = "0.25.1";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/static/app.js
+++ b/packages/viewer-server/static/app.js
@@ -13781,7 +13781,7 @@ For more information, see https://radix-ui.com/primitives/docs/components/${titl
 		try {
 			const runtime = await loadRuntimeInfo();
 			if (!runtime?.version) return;
-			setRuntimeLabel(runtime.version, "9e29ee2");
+			setRuntimeLabel(runtime.version, "7219f5e");
 		} catch {}
 	}
 	var lastAnnouncedRefreshState = null;

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description

Prepare the `0.25.1` release on top of the automatic injection hotfix.

This stack PR bumps the shared package/plugin version metadata and refreshes the built viewer asset so the release branch is ready to merge and tag once the hotfix is approved.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation performed:
- `pnpm run release:version -- set 0.25.1`
- `pnpm install`
- `pnpm build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced

## Notes

- Base PR: #678
- This PR is versioning/artifact-only and should merge after the hotfix lands.
