### PR TITLE
fix(cli): restore Claude hook memory injection

### DIFF
--- a/packages/cli/src/commands/claude-hook-inject.test.ts
+++ b/packages/cli/src/commands/claude-hook-inject.test.ts
@@ -38,6 +38,7 @@ describe("claude-hook-inject command", () => {
 		expect(result).toEqual({
 			continue: true,
 			hookSpecificOutput: {
+				hookEventName: "UserPromptSubmit",
 				additionalContext: "## Summary\n[1] (decision) Auth fix",
 			},
 		});
@@ -75,6 +76,7 @@ describe("claude-hook-inject command", () => {
 			expect(result).toEqual({
 				continue: true,
 				hookSpecificOutput: {
+					hookEventName: "UserPromptSubmit",
 					additionalContext: "## Timeline\n[4] (feature) Sync continuation",
 				},
 			});
@@ -158,6 +160,7 @@ describe("claude-hook-inject command", () => {
 			expect(result).toEqual({
 				continue: true,
 				hookSpecificOutput: {
+					hookEventName: "UserPromptSubmit",
 					additionalContext: "123456789012",
 				},
 			});
@@ -165,6 +168,54 @@ describe("claude-hook-inject command", () => {
 			if (originalMaxChars === undefined) delete process.env.CODEMEM_INJECT_MAX_CHARS;
 			else process.env.CODEMEM_INJECT_MAX_CHARS = originalMaxChars;
 		}
+	});
+
+	it("always emits UserPromptSubmit hookEventName even when payload carries a different hook_event_name", async () => {
+		// claude-hook-inject is wired exclusively to UserPromptSubmit and the
+		// hookSpecificOutput.additionalContext field is UserPromptSubmit-specific.
+		// Echoing a different event name would silently produce schema-invalid
+		// output, so the emitted event name must be hardcoded regardless of
+		// what the payload claims.
+		const result = await buildClaudeHookInjection(
+			{
+				hook_event_name: "SessionStart",
+				session_id: "sess-wrong-event",
+				prompt: "investigate flaky test",
+				cwd: "/tmp/codemem",
+			},
+			{},
+			{
+				buildLocalPack: async () => "Remember to run targeted tests.",
+				httpPack: async () => "",
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result.hookSpecificOutput?.hookEventName).toBe("UserPromptSubmit");
+		expect(result.hookSpecificOutput?.additionalContext).toContain(
+			"Remember to run targeted tests.",
+		);
+	});
+
+	it("emits UserPromptSubmit hookEventName when payload omits hook_event_name", async () => {
+		// Resilience to payload-shape drift: even if Claude Code stops sending
+		// hook_event_name on the inbound side, the emitted output stays valid.
+		const result = await buildClaudeHookInjection(
+			{
+				session_id: "sess-missing-event",
+				prompt: "plan retrieval improvements",
+				cwd: "/tmp/codemem",
+			},
+			{},
+			{
+				buildLocalPack: async () => "## Summary\nmemory pack",
+				httpPack: async () => "",
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result.hookSpecificOutput?.hookEventName).toBe("UserPromptSubmit");
+		expect(result.hookSpecificOutput?.additionalContext).toBe("## Summary\nmemory pack");
 	});
 
 	it("returns continue without additionalContext when all generation paths fail", async () => {

--- a/packages/cli/src/commands/claude-hook-inject.ts
+++ b/packages/cli/src/commands/claude-hook-inject.ts
@@ -6,9 +6,16 @@ import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
 type InjectResult = {
 	continue: true;
 	hookSpecificOutput?: {
+		hookEventName: "UserPromptSubmit";
 		additionalContext: string;
 	};
 };
+
+// claude-hook-inject is wired exclusively to UserPromptSubmit. The
+// hookSpecificOutput schema is event-specific (additionalContext is a
+// UserPromptSubmit-only field), so emitting any other event name would
+// produce invalid output regardless of what the payload claims.
+const HOOK_EVENT_NAME = "UserPromptSubmit" as const;
 
 type InjectOpts = DbOpts;
 
@@ -53,6 +60,7 @@ function continueResult(additionalContext?: string): InjectResult {
 	return {
 		continue: true,
 		hookSpecificOutput: {
+			hookEventName: HOOK_EVENT_NAME,
 			additionalContext,
 		},
 	};


### PR DESCRIPTION
## Description

Hotfix: `packages/cli/src/commands/claude-hook-inject.ts` was emitting `hookSpecificOutput` without the `hookEventName` field, which caused Claude Code's `UserPromptSubmit` hook JSON validation to fail and silently dropped the injected memory pack — the "codemem doesn't do anything in Claude Code" symptom.

`continueResult()` now hardcodes `hookEventName: "UserPromptSubmit"` whenever it emits `hookSpecificOutput`. The type is tightened to a literal so the field cannot drift back to a free-form string. The emitted event name is intentionally NOT read from the payload: `claude-hook-inject` is wired exclusively to `UserPromptSubmit` and the `additionalContext` field inside `hookSpecificOutput` is `UserPromptSubmit`-specific, so echoing a different event name from the payload would silently produce a *different* schema validation error than the one we're fixing.

First PR in a 4-PR Graphite stack. Refs: codemem-msd6.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (\`pnpm test\` — 1184 passed across the workspace)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Test changes in \`packages/cli/src/commands/claude-hook-inject.test.ts\`:
- Updated three existing shape-asserting tests to expect the new \`hookEventName\` field in their \`toEqual\` blocks.
- New invariance test: payload carries \`hook_event_name: "SessionStart"\`, asserts the emitted output is still \`"UserPromptSubmit"\`. This is the test that would have caught the original bug and would catch any future drift back to a payload-echo.
- New resilience test: payload omits \`hook_event_name\` entirely, asserts the output stays valid.

End-to-end smoke verification with the rebuilt CLI:
\`\`\`
echo '{"hook_event_name":"SessionStart","session_id":"smoke","prompt":"verify invariance","cwd":"/Users/adam/workspace/codemem","project":"codemem"}' \\
  | CODEMEM_INJECT_HTTP_FALLBACK=0 node packages/cli/dist/index.js claude-hook-inject
\`\`\`
→ \`continue: True, hookEventName: 'UserPromptSubmit', additionalContext(len): 2664\`

## Checklist

- [x] Code follows project style (\`biome check\` clean on touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — N/A
- [x] No new warnings introduced