### PR TITLE
feat(cli): port Claude hook session-state tracking to TS

### DIFF
--- a/packages/cli/src/commands/claude-hook-ingest.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.ts
@@ -2,9 +2,9 @@
  * codemem claude-hook-ingest — read a single Claude Code hook payload
  * from stdin and enqueue it for processing.
  *
- * Ports codemem/commands/claude_hook_runtime_cmds.py with an HTTP-first
- * strategy: try POST /api/claude-hooks (viewer must be running), then
- * fall back to direct raw-event enqueue via the local store.
+ * HTTP-first strategy: POST to the running viewer's /api/claude-hooks
+ * endpoint, then fall back to direct raw-event enqueue via the local
+ * store when the viewer is unreachable.
  *
  * Usage (from Claude hooks config):
  *   echo '{"hook_event_name":"Stop","session_id":"...","last_assistant_message":"..."}' \
@@ -22,6 +22,7 @@ import {
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 import { addDbOption, addViewerHostOptions, type DbOpts, resolveDbOpt } from "../shared-options.js";
+import { trackHookSessionState } from "./claude-hook-session-state.js";
 
 type IngestResult = { inserted: number; skipped: number; via: "http" | "direct" };
 
@@ -166,6 +167,15 @@ export async function ingestClaudeHookPayload(
 	const httpIngest = deps.httpIngest ?? tryHttpIngest;
 	const directIngest = deps.directIngest ?? directEnqueue;
 	const resolveDb = deps.resolveDb ?? resolveDbPath;
+
+	// Update per-session state alongside ingestion so claude-hook-inject's
+	// retrieval query can draw on prompts/files seen on the ingest path.
+	// Failures must never crash the hook command.
+	try {
+		trackHookSessionState(payload);
+	} catch {
+		// best-effort
+	}
 
 	const port = typeof opts.port === "number" ? opts.port : Number.parseInt(opts.port, 10);
 	const httpResult = await httpIngest(payload, opts.host, port);

--- a/packages/cli/src/commands/claude-hook-inject.test.ts
+++ b/packages/cli/src/commands/claude-hook-inject.test.ts
@@ -1,7 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildClaudeHookInjection, claudeHookInjectCommand } from "./claude-hook-inject.js";
+import { saveSessionState, statePathForSession } from "./claude-hook-session-state.js";
 
 describe("claude-hook-inject command", () => {
+	let stateDir: string;
+	let originalContextDir: string | undefined;
+
+	beforeEach(() => {
+		originalContextDir = process.env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR;
+		stateDir = mkdtempSync(join(tmpdir(), "codemem-cli-inject-state-"));
+		process.env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR = stateDir;
+	});
+
+	afterEach(() => {
+		if (originalContextDir === undefined) delete process.env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR;
+		else process.env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR = originalContextDir;
+		rmSync(stateDir, { recursive: true, force: true });
+	});
+
 	it("registers expected options and help text", () => {
 		const longs = claudeHookInjectCommand.options.map((option) => option.long);
 		expect(longs).toContain("--db");
@@ -22,10 +41,13 @@ describe("claude-hook-inject command", () => {
 			},
 			{},
 			{
-				buildLocalPack: async (context, project, dbPath) => {
-					expect(context).toBe("fix auth callback");
+				buildLocalPack: async (context, project, dbPath, workingSetPaths) => {
+					// Rich query: first_prompt (just persisted) + project; current
+					// prompt is identical to first_prompt and is therefore skipped.
+					expect(context).toBe("fix auth callback codemem");
 					expect(project).toBe("codemem");
 					expect(dbPath).toBe("/tmp/test.sqlite");
+					expect(workingSetPaths).toEqual([]);
 					return "## Summary\n[1] (decision) Auth fix";
 				},
 				httpPack: async () => {
@@ -64,7 +86,8 @@ describe("claude-hook-inject command", () => {
 						throw new Error("local pack failed");
 					},
 					httpPack: async (context, project, maxTimeMs) => {
-						expect(context).toBe("continue sync work");
+						// HTTP fallback receives the same rich query as the local path.
+						expect(context).toBe("continue sync work codemem");
 						expect(project).toBe("codemem");
 						expect(maxTimeMs).toBe(7000);
 						return "## Timeline\n[4] (feature) Sync continuation";
@@ -161,7 +184,7 @@ describe("claude-hook-inject command", () => {
 				continue: true,
 				hookSpecificOutput: {
 					hookEventName: "UserPromptSubmit",
-					additionalContext: "123456789012",
+					additionalContext: "123456789012\n\n[pack truncated]",
 				},
 			});
 		} finally {
@@ -216,6 +239,152 @@ describe("claude-hook-inject command", () => {
 
 		expect(result.hookSpecificOutput?.hookEventName).toBe("UserPromptSubmit");
 		expect(result.hookSpecificOutput?.additionalContext).toBe("## Summary\nmemory pack");
+	});
+
+	it("enriches the retrieval query with prior session state and propagates working_set_paths", async () => {
+		// Pre-seed session state on disk so this prompt looks like the second
+		// turn of an existing session: prior first_prompt + prior modified files.
+		const sessionId = "sess-stateful";
+		saveSessionState(sessionId, {
+			first_prompt: "investigate flaky test",
+			last_prompt: "investigate flaky test",
+			files_modified: ["packages/cli/src/a.ts", "packages/cli/src/b.ts", "packages/cli/src/c.ts"],
+			updated_at: "2026-04-09T00:00:00Z",
+		});
+
+		const result = await buildClaudeHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: sessionId,
+				prompt: "now check the fixture",
+				cwd: "/tmp/codemem",
+				project: "codemem",
+			},
+			{},
+			{
+				buildLocalPack: async (context, project, _dbPath, workingSetPaths) => {
+					// Query weaves: original first_prompt + new prompt + project
+					// + recent file basenames (last 5 → all 3 here).
+					expect(context).toBe(
+						"investigate flaky test now check the fixture codemem a.ts b.ts c.ts",
+					);
+					expect(project).toBe("codemem");
+					expect(workingSetPaths).toEqual([
+						"packages/cli/src/a.ts",
+						"packages/cli/src/b.ts",
+						"packages/cli/src/c.ts",
+					]);
+					return "## Memory pack";
+				},
+				httpPack: async () => {
+					throw new Error("http fallback should not run");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result.hookSpecificOutput?.additionalContext).toBe("## Memory pack");
+		// State persists across the call: last_prompt now reflects the new prompt.
+		expect(statePathForSession(sessionId).startsWith(stateDir)).toBe(true);
+	});
+
+	it("appends [pack truncated] marker when additionalContext exceeds CODEMEM_INJECT_MAX_CHARS", async () => {
+		const originalMaxChars = process.env.CODEMEM_INJECT_MAX_CHARS;
+		// 22 cuts the source at "memory_one memory_two " (trailing space).
+		// trimEnd should drop the trailing space before appending the marker.
+		process.env.CODEMEM_INJECT_MAX_CHARS = "22";
+		try {
+			const result = await buildClaudeHookInjection(
+				{
+					hook_event_name: "UserPromptSubmit",
+					session_id: "sess-marker",
+					prompt: "any longer prompt",
+				},
+				{},
+				{
+					buildLocalPack: async () => "memory_one memory_two memory_three memory_four",
+					httpPack: async () => "",
+					resolveDb: () => "/tmp/test.sqlite",
+				},
+			);
+
+			const additionalContext = result.hookSpecificOutput?.additionalContext ?? "";
+			expect(additionalContext.endsWith("\n\n[pack truncated]")).toBe(true);
+			expect(additionalContext).toBe("memory_one memory_two\n\n[pack truncated]");
+		} finally {
+			if (originalMaxChars === undefined) delete process.env.CODEMEM_INJECT_MAX_CHARS;
+			else process.env.CODEMEM_INJECT_MAX_CHARS = originalMaxChars;
+		}
+	});
+
+	it("returns continue without injection when CODEMEM_PLUGIN_IGNORE is truthy", async () => {
+		const originalIgnore = process.env.CODEMEM_PLUGIN_IGNORE;
+		process.env.CODEMEM_PLUGIN_IGNORE = "1";
+		try {
+			const result = await buildClaudeHookInjection(
+				{
+					hook_event_name: "UserPromptSubmit",
+					session_id: "sess-ignored",
+					prompt: "should be ignored",
+				},
+				{},
+				{
+					buildLocalPack: async () => {
+						throw new Error("should not be called when plugin is ignored");
+					},
+					httpPack: async () => {
+						throw new Error("should not be called when plugin is ignored");
+					},
+					resolveDb: () => "/tmp/test.sqlite",
+				},
+			);
+			expect(result).toEqual({ continue: true });
+		} finally {
+			if (originalIgnore === undefined) delete process.env.CODEMEM_PLUGIN_IGNORE;
+			else process.env.CODEMEM_PLUGIN_IGNORE = originalIgnore;
+		}
+	});
+
+	it("normalizes multi-line prompts before composing the rich query", async () => {
+		// The session-state tracker stores first_prompt with newlines collapsed.
+		// extractInjectContext must do the same so the second-turn comparison
+		// `prompt !== first_prompt` works for multi-line prompts — otherwise
+		// the current prompt would be appended on every turn.
+		const sessionId = "sess-multiline";
+		// Pre-seed first_prompt as the canonical (collapsed) form.
+		saveSessionState(sessionId, {
+			first_prompt: "fix the auth callback flow",
+			last_prompt: "fix the auth callback flow",
+			files_modified: [],
+			updated_at: "2026-04-09T00:00:00Z",
+		});
+
+		const result = await buildClaudeHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: sessionId,
+				// Same words, but with newlines — the bug would treat this as
+				// a different prompt than the stored first_prompt.
+				prompt: "fix the auth\ncallback flow",
+				cwd: "/tmp/codemem",
+				project: "codemem",
+			},
+			{},
+			{
+				buildLocalPack: async (context) => {
+					// Newlines must be collapsed to spaces, AND the current
+					// prompt must dedupe against first_prompt (skipped because
+					// equal post-normalization).
+					expect(context).not.toContain("\n");
+					expect(context).toBe("fix the auth callback flow codemem");
+					return "## Pack";
+				},
+				httpPack: async () => "",
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		expect(result.hookSpecificOutput?.additionalContext).toBe("## Pack");
 	});
 
 	it("returns continue without additionalContext when all generation paths fail", async () => {

--- a/packages/cli/src/commands/claude-hook-inject.ts
+++ b/packages/cli/src/commands/claude-hook-inject.ts
@@ -2,6 +2,13 @@ import { MemoryStore, resolveDbPath, resolveHookProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
+import {
+	buildInjectQuery,
+	normalizePromptText,
+	type SessionState,
+	trackHookSessionState,
+	workingSetPathsFromState,
+} from "./claude-hook-session-state.js";
 
 type InjectResult = {
 	continue: true;
@@ -45,6 +52,13 @@ function envNotDisabled(value: string | undefined): boolean {
 	return normalized !== "0" && normalized !== "false" && normalized !== "off";
 }
 
+function envTruthy(value: string | undefined): boolean {
+	const normalized = String(value ?? "")
+		.trim()
+		.toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
 function parsePositiveInt(value: string | undefined, fallback: number): number {
 	const parsed = Number.parseInt(String(value ?? ""), 10);
 	if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -74,11 +88,18 @@ function truncateAdditionalContext(text: string, maxChars: number): string {
 	if (!Number.isFinite(maxChars) || maxChars <= 0 || normalized.length <= maxChars) {
 		return normalized;
 	}
-	return normalized.slice(0, maxChars);
+	// Strip trailing whitespace from the slice before appending the marker
+	// so the boundary stays readable in chat output.
+	return `${normalized.slice(0, maxChars).trimEnd()}\n\n[pack truncated]`;
 }
 
 function extractInjectContext(payload: Record<string, unknown>): string | null {
-	const prompt = String(payload.prompt ?? "").trim();
+	// Reuse the same normalization the session-state tracker applies so the
+	// `prompt !== first_prompt` comparison in buildInjectQuery is robust to
+	// multi-line prompts (otherwise a "fix\nauth" current prompt would never
+	// match a stored "fix auth" first_prompt and would be appended on every
+	// turn).
+	const prompt = normalizePromptText(payload.prompt);
 	return prompt || null;
 }
 
@@ -91,14 +112,18 @@ async function buildLocalPack(
 	context: string,
 	project: string | null,
 	dbPath: string,
+	workingSetPaths: string[] = [],
 ): Promise<string> {
 	const store = new MemoryStore(dbPath);
 	try {
 		const limit = parsePositiveInt(process.env.CODEMEM_INJECT_LIMIT, 8);
 		const budget = parsePositiveInt(process.env.CODEMEM_INJECT_TOKEN_BUDGET, 800);
-		const filters: { project?: string } = {};
+		const filters: { project?: string; working_set_paths?: string[] } = {};
 		if (project) {
 			filters.project = project;
+		}
+		if (workingSetPaths.length > 0) {
+			filters.working_set_paths = workingSetPaths;
 		}
 		const pack = await store.buildMemoryPackAsync(context, limit, budget, filters);
 		return String(pack.pack_text ?? "").trim();
@@ -146,12 +171,27 @@ export async function buildClaudeHookInjection(
 	opts: InjectOpts,
 	deps: InjectDeps = {},
 ): Promise<InjectResult> {
+	// Honor the global plugin-ignore kill switch first so users can disable
+	// every codemem hook side effect by exporting CODEMEM_PLUGIN_IGNORE=1
+	// without having to know which subcommand is wired to which hook.
+	if (envTruthy(process.env.CODEMEM_PLUGIN_IGNORE)) {
+		return continueResult();
+	}
 	if (!envNotDisabled(process.env.CODEMEM_INJECT_CONTEXT || "1")) {
 		return continueResult();
 	}
 
-	const context = extractInjectContext(payload);
-	if (!context) {
+	// Track session state before the prompt-presence check so SessionEnd /
+	// PostToolUse / SessionStart events still update the per-session store.
+	let state: SessionState | null = null;
+	try {
+		state = trackHookSessionState(payload);
+	} catch {
+		state = null;
+	}
+
+	const promptText = extractInjectContext(payload);
+	if (!promptText) {
 		return continueResult();
 	}
 
@@ -159,6 +199,8 @@ export async function buildClaudeHookInjection(
 	const httpPack = deps.httpPack ?? tryHttpPack;
 	const resolveDb = deps.resolveDb ?? resolveDbPath;
 	const project = resolveInjectProject(payload);
+	const query = buildInjectQuery({ prompt: promptText, project, state });
+	const workingSetPaths = workingSetPathsFromState(state);
 	const maxChars = parsePositiveInt(process.env.CODEMEM_INJECT_MAX_CHARS, DEFAULT_MAX_CHARS);
 	const httpMaxTimeMs =
 		parsePositiveInt(process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S, DEFAULT_HTTP_MAX_TIME_S) * 1000;
@@ -166,13 +208,13 @@ export async function buildClaudeHookInjection(
 	let additionalContext = "";
 	try {
 		const dbPath = resolveDb(resolveDbOpt(opts));
-		additionalContext = await buildPack(context, project, dbPath);
+		additionalContext = await buildPack(query, project, dbPath, workingSetPaths);
 	} catch {
 		additionalContext = "";
 	}
 
 	if (!additionalContext && envNotDisabled(process.env.CODEMEM_INJECT_HTTP_FALLBACK || "1")) {
-		additionalContext = await httpPack(context, project, httpMaxTimeMs);
+		additionalContext = await httpPack(query, project, httpMaxTimeMs);
 	}
 
 	return continueResult(truncateAdditionalContext(additionalContext, maxChars));

--- a/packages/cli/src/commands/claude-hook-session-state.test.ts
+++ b/packages/cli/src/commands/claude-hook-session-state.test.ts
@@ -1,0 +1,346 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	buildInjectQuery,
+	clearSessionState,
+	defaultSessionState,
+	extractModifiedPathsFromHook,
+	loadSessionState,
+	saveSessionState,
+	statePathForSession,
+	trackHookSessionState,
+	workingSetPathsFromState,
+} from "./claude-hook-session-state.js";
+
+describe("claude-hook-session-state", () => {
+	let stateDir: string;
+	let originalEnv: string | undefined;
+
+	beforeEach(() => {
+		originalEnv = process.env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR;
+		stateDir = mkdtempSync(join(tmpdir(), "codemem-cli-claude-hook-state-"));
+		process.env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR = stateDir;
+	});
+
+	afterEach(() => {
+		if (originalEnv === undefined) delete process.env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR;
+		else process.env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR = originalEnv;
+		rmSync(stateDir, { recursive: true, force: true });
+	});
+
+	describe("statePathForSession", () => {
+		it("derives a deterministic 16-char sha1 prefix per session id", () => {
+			const a = statePathForSession("session-A");
+			const b = statePathForSession("session-A");
+			const c = statePathForSession("session-B");
+			expect(a).toBe(b);
+			expect(a).not.toBe(c);
+			expect(a.startsWith(stateDir)).toBe(true);
+			expect(a.endsWith(".json")).toBe(true);
+		});
+	});
+
+	describe("loadSessionState", () => {
+		it("returns default state when no file exists", () => {
+			expect(loadSessionState("missing")).toEqual(defaultSessionState());
+		});
+
+		it("returns default state when file is malformed JSON", () => {
+			saveSessionState("ok", {
+				first_prompt: "kept",
+				last_prompt: "kept",
+				files_modified: [],
+				updated_at: "",
+			});
+			const path = statePathForSession("ok");
+			writeFileSync(path, "not-json", "utf8");
+			expect(loadSessionState("ok")).toEqual(defaultSessionState());
+		});
+
+		it("normalizes and caps fields when reading back", () => {
+			saveSessionState("normalize", {
+				first_prompt: "  first  ",
+				last_prompt: "  last  ",
+				files_modified: ["  a.ts  ", "", "b.ts"],
+				updated_at: "2026-04-09T00:00:00Z",
+			});
+			const loaded = loadSessionState("normalize");
+			expect(loaded.first_prompt).toBe("first");
+			expect(loaded.last_prompt).toBe("last");
+			expect(loaded.files_modified).toEqual(["a.ts", "b.ts"]);
+			expect(loaded.updated_at).toBe("2026-04-09T00:00:00Z");
+		});
+	});
+
+	describe("saveSessionState + clearSessionState", () => {
+		it("roundtrips state through disk", () => {
+			const original = {
+				first_prompt: "investigate flaky test",
+				last_prompt: "now check the fixture",
+				files_modified: ["packages/cli/src/foo.ts", "packages/cli/src/bar.ts"],
+				updated_at: "2026-04-09T01:00:00Z",
+			};
+			saveSessionState("rt", original);
+			const path = statePathForSession("rt");
+			expect(existsSync(path)).toBe(true);
+
+			const persisted = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+			expect(persisted.first_prompt).toBe(original.first_prompt);
+			expect(persisted.files_modified).toEqual(original.files_modified);
+
+			expect(loadSessionState("rt")).toEqual(original);
+		});
+
+		it("clear removes the state file", () => {
+			saveSessionState("clr", {
+				first_prompt: "x",
+				last_prompt: "x",
+				files_modified: [],
+				updated_at: "",
+			});
+			const path = statePathForSession("clr");
+			expect(existsSync(path)).toBe(true);
+			clearSessionState("clr");
+			expect(existsSync(path)).toBe(false);
+		});
+
+		it("clear is a no-op when the file does not exist", () => {
+			expect(() => clearSessionState("never-saved")).not.toThrow();
+		});
+	});
+
+	describe("extractModifiedPathsFromHook", () => {
+		it("returns paths for Edit/Write/MultiEdit/NotebookEdit tool inputs", () => {
+			expect(
+				extractModifiedPathsFromHook({
+					tool_name: "Edit",
+					tool_input: { filePath: "packages/cli/src/a.ts" },
+				}),
+			).toEqual(["packages/cli/src/a.ts"]);
+
+			expect(
+				extractModifiedPathsFromHook({
+					tool_name: "write",
+					tool_input: { file_path: "packages/cli/src/b.ts" },
+				}),
+			).toEqual(["packages/cli/src/b.ts"]);
+
+			expect(
+				extractModifiedPathsFromHook({
+					tool_name: "NotebookEdit",
+					tool_input: { path: "notebooks/c.ipynb" },
+				}),
+			).toEqual(["notebooks/c.ipynb"]);
+		});
+
+		it("falls back to apply_patch `patch` field when `patchText` is an empty string", () => {
+			// `??` would stop at the empty string and miss the real patch.
+			expect(
+				extractModifiedPathsFromHook({
+					tool_name: "apply_patch",
+					tool_input: {
+						patchText: "",
+						patch: "*** Add File: packages/cli/src/fallback.ts\n+content",
+					},
+				}),
+			).toEqual(["packages/cli/src/fallback.ts"]);
+		});
+
+		it("parses apply_patch patchText for Add/Update/Delete entries", () => {
+			const patch = [
+				"*** Begin Patch",
+				"*** Update File: packages/cli/src/x.ts",
+				"@@",
+				"-old",
+				"+new",
+				"*** Add File: packages/cli/src/y.ts",
+				"+brand new",
+				"*** Delete File: packages/cli/src/z.ts",
+				"*** End Patch",
+			].join("\n");
+
+			expect(
+				extractModifiedPathsFromHook({
+					tool_name: "apply_patch",
+					tool_input: { patchText: patch },
+				}),
+			).toEqual(["packages/cli/src/x.ts", "packages/cli/src/y.ts", "packages/cli/src/z.ts"]);
+		});
+
+		it("returns empty for non-mutating tools", () => {
+			expect(
+				extractModifiedPathsFromHook({
+					tool_name: "Read",
+					tool_input: { filePath: "packages/cli/src/a.ts" },
+				}),
+			).toEqual([]);
+		});
+
+		it("dedupes overlapping path keys preserving first-seen order", () => {
+			expect(
+				extractModifiedPathsFromHook({
+					tool_name: "edit",
+					tool_input: {
+						filePath: "shared.ts",
+						file_path: "shared.ts",
+						path: "other.ts",
+					},
+				}),
+			).toEqual(["shared.ts", "other.ts"]);
+		});
+	});
+
+	describe("trackHookSessionState", () => {
+		it("returns null when payload has no usable session id", () => {
+			expect(trackHookSessionState({ hook_event_name: "UserPromptSubmit" })).toBeNull();
+			expect(
+				trackHookSessionState({ session_id: "   ", hook_event_name: "UserPromptSubmit" }),
+			).toBeNull();
+		});
+
+		it("UserPromptSubmit sets first_prompt once and keeps tracking last_prompt", () => {
+			const sessionId = "track-1";
+			trackHookSessionState({
+				session_id: sessionId,
+				hook_event_name: "UserPromptSubmit",
+				prompt: "investigate flaky test",
+			});
+			let state = loadSessionState(sessionId);
+			expect(state.first_prompt).toBe("investigate flaky test");
+			expect(state.last_prompt).toBe("investigate flaky test");
+
+			trackHookSessionState({
+				session_id: sessionId,
+				hook_event_name: "UserPromptSubmit",
+				prompt: "now check the fixture",
+			});
+			state = loadSessionState(sessionId);
+			expect(state.first_prompt).toBe("investigate flaky test"); // unchanged
+			expect(state.last_prompt).toBe("now check the fixture");
+		});
+
+		it("PostToolUse appends modified files and dedupes across calls", () => {
+			const sessionId = "track-2";
+			trackHookSessionState({
+				session_id: sessionId,
+				hook_event_name: "PostToolUse",
+				tool_name: "edit",
+				tool_input: { filePath: "packages/cli/src/a.ts" },
+			});
+			trackHookSessionState({
+				session_id: sessionId,
+				hook_event_name: "PostToolUseFailure",
+				tool_name: "write",
+				tool_input: { file_path: "packages/cli/src/b.ts" },
+			});
+			trackHookSessionState({
+				session_id: sessionId,
+				hook_event_name: "PostToolUse",
+				tool_name: "edit",
+				tool_input: { filePath: "packages/cli/src/a.ts" }, // duplicate
+			});
+			const state = loadSessionState(sessionId);
+			expect(state.files_modified).toEqual(["packages/cli/src/a.ts", "packages/cli/src/b.ts"]);
+		});
+
+		it("SessionEnd clears the on-disk state", () => {
+			const sessionId = "track-3";
+			trackHookSessionState({
+				session_id: sessionId,
+				hook_event_name: "UserPromptSubmit",
+				prompt: "kick off work",
+			});
+			expect(existsSync(statePathForSession(sessionId))).toBe(true);
+
+			const result = trackHookSessionState({
+				session_id: sessionId,
+				hook_event_name: "SessionEnd",
+			});
+			expect(result).toBeNull();
+			expect(existsSync(statePathForSession(sessionId))).toBe(false);
+		});
+
+		it("returns loaded state without writing for unrelated events", () => {
+			const sessionId = "track-4";
+			const result = trackHookSessionState({
+				session_id: sessionId,
+				hook_event_name: "SessionStart",
+			});
+			expect(result).toEqual(defaultSessionState());
+			expect(existsSync(statePathForSession(sessionId))).toBe(false);
+		});
+	});
+
+	describe("buildInjectQuery", () => {
+		it("returns 'recent work' when nothing useful is available", () => {
+			expect(buildInjectQuery({ prompt: "", project: null, state: null })).toBe("recent work");
+		});
+
+		it("includes first_prompt + project + file basenames, skipping duplicate prompt", () => {
+			const state = {
+				first_prompt: "investigate flaky test",
+				last_prompt: "investigate flaky test",
+				files_modified: ["packages/cli/src/foo.ts", "packages/cli/src/bar.ts"],
+				updated_at: "",
+			};
+			const query = buildInjectQuery({
+				prompt: "investigate flaky test", // identical to first_prompt → skipped
+				project: "codemem",
+				state,
+			});
+			expect(query).toBe("investigate flaky test codemem foo.ts bar.ts");
+		});
+
+		it("includes the current prompt when it differs from first_prompt", () => {
+			const state = {
+				first_prompt: "kick off work",
+				last_prompt: "now check fixture",
+				files_modified: [],
+				updated_at: "",
+			};
+			const query = buildInjectQuery({
+				prompt: "now check fixture",
+				project: null,
+				state,
+			});
+			expect(query).toBe("kick off work now check fixture");
+		});
+
+		it("drops short current prompts (length <= 5) to avoid noise", () => {
+			const query = buildInjectQuery({
+				prompt: "fix",
+				project: "codemem",
+				state: defaultSessionState(),
+			});
+			expect(query).toBe("codemem");
+		});
+
+		it("caps the query at 500 characters", () => {
+			const query = buildInjectQuery({
+				prompt: "x".repeat(2000),
+				project: null,
+				state: defaultSessionState(),
+			});
+			expect(query.length).toBe(500);
+		});
+	});
+
+	describe("workingSetPathsFromState", () => {
+		it("returns the last 8 paths only", () => {
+			const files = Array.from({ length: 12 }, (_, i) => `f${i}.ts`);
+			const state = {
+				first_prompt: "",
+				last_prompt: "",
+				files_modified: files,
+				updated_at: "",
+			};
+			expect(workingSetPathsFromState(state)).toEqual(files.slice(-8));
+		});
+
+		it("returns an empty array when state is null", () => {
+			expect(workingSetPathsFromState(null)).toEqual([]);
+		});
+	});
+});

--- a/packages/cli/src/commands/claude-hook-session-state.ts
+++ b/packages/cli/src/commands/claude-hook-session-state.ts
@@ -1,0 +1,286 @@
+/**
+ * Session-state tracking for Claude Code hook commands.
+ *
+ * Persists per-session signal (first prompt, latest prompt, recently
+ * modified files) to disk so that retrieval inside `claude-hook-inject`
+ * can build a query richer than the bare current prompt and so that
+ * file-locality boosts can target files the user just edited.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type SessionState = {
+	first_prompt: string;
+	last_prompt: string;
+	files_modified: string[];
+	updated_at: string;
+};
+
+const MAX_FILES_MODIFIED = 64;
+const MAX_WORKING_SET_PATHS = 8;
+const MAX_QUERY_CHARS = 500;
+const MAX_QUERY_FILE_BASENAMES = 5;
+
+const MUTATING_TOOL_NAMES = new Set(["edit", "write", "multiedit", "notebookedit", "apply_patch"]);
+
+const APPLY_PATCH_PATH_PREFIXES = ["*** Add File: ", "*** Update File: ", "*** Delete File: "];
+
+export function defaultSessionState(): SessionState {
+	return {
+		first_prompt: "",
+		last_prompt: "",
+		files_modified: [],
+		updated_at: "",
+	};
+}
+
+function expandHome(value: string): string {
+	if (value === "~") return homedir();
+	if (value.startsWith("~/")) return join(homedir(), value.slice(2));
+	return value;
+}
+
+export function contextDir(): string {
+	const override = process.env.CODEMEM_CLAUDE_HOOK_CONTEXT_DIR;
+	return expandHome(override?.trim() ? override : "~/.codemem/claude-hook-context");
+}
+
+export function statePathForSession(sessionId: string): string {
+	const digest = createHash("sha1").update(sessionId).digest("hex").slice(0, 16);
+	return join(contextDir(), `${digest}.json`);
+}
+
+/**
+ * Normalize a prompt-shaped payload field: drop non-strings, trim
+ * leading/trailing whitespace, and collapse newlines to spaces so that
+ * prompts compared across the inject + ingest paths and across turns
+ * within a session use the same canonical form.
+ */
+export function normalizePromptText(value: unknown): string {
+	if (typeof value !== "string") return "";
+	return value.trim().replace(/\n/g, " ");
+}
+
+function normalizeStringList(value: unknown, cap: number): string[] {
+	if (!Array.isArray(value)) return [];
+	const out: string[] = [];
+	for (const item of value) {
+		if (typeof item !== "string") continue;
+		const trimmed = item.trim();
+		if (trimmed) out.push(trimmed);
+	}
+	return out.slice(0, cap);
+}
+
+export function loadSessionState(sessionId: string): SessionState {
+	const path = statePathForSession(sessionId);
+	if (!existsSync(path)) return defaultSessionState();
+	try {
+		const raw = readFileSync(path, "utf8");
+		const parsed: unknown = JSON.parse(raw);
+		if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return defaultSessionState();
+		}
+		const obj = parsed as Record<string, unknown>;
+		return {
+			first_prompt: typeof obj.first_prompt === "string" ? obj.first_prompt.trim() : "",
+			last_prompt: typeof obj.last_prompt === "string" ? obj.last_prompt.trim() : "",
+			files_modified: normalizeStringList(obj.files_modified, MAX_FILES_MODIFIED),
+			updated_at: typeof obj.updated_at === "string" ? obj.updated_at.trim() : "",
+		};
+	} catch {
+		return defaultSessionState();
+	}
+}
+
+function nowIso(): string {
+	return new Date().toISOString();
+}
+
+export function saveSessionState(sessionId: string, state: SessionState): void {
+	const dir = contextDir();
+	mkdirSync(dir, { recursive: true });
+	const path = statePathForSession(sessionId);
+	const tmpPath = `${path}.tmp`;
+	const payload = {
+		first_prompt: String(state.first_prompt ?? ""),
+		last_prompt: String(state.last_prompt ?? ""),
+		files_modified: normalizeStringList(state.files_modified, MAX_FILES_MODIFIED),
+		updated_at: String(state.updated_at ?? ""),
+	};
+	writeFileSync(tmpPath, JSON.stringify(payload), { encoding: "utf8" });
+	renameSync(tmpPath, path);
+}
+
+export function clearSessionState(sessionId: string): void {
+	const path = statePathForSession(sessionId);
+	try {
+		rmSync(path, { force: true });
+	} catch {
+		// best-effort: failure to clear an unreachable file is non-fatal
+	}
+}
+
+function extractApplyPatchPaths(patchText: string): string[] {
+	const out: string[] = [];
+	for (const line of patchText.split("\n")) {
+		for (const prefix of APPLY_PATCH_PATH_PREFIXES) {
+			if (line.startsWith(prefix)) {
+				const path = line.slice(prefix.length).trim();
+				if (path) out.push(path);
+			}
+		}
+	}
+	return out;
+}
+
+export function extractModifiedPathsFromHook(payload: Record<string, unknown>): string[] {
+	const toolName = String(payload.tool_name ?? "")
+		.trim()
+		.toLowerCase();
+	if (!MUTATING_TOOL_NAMES.has(toolName)) return [];
+
+	const toolInput = payload.tool_input;
+	if (toolInput == null || typeof toolInput !== "object" || Array.isArray(toolInput)) {
+		return [];
+	}
+	const obj = toolInput as Record<string, unknown>;
+
+	const collected: string[] = [];
+	for (const key of ["filePath", "file_path", "path"]) {
+		const value = obj[key];
+		if (typeof value === "string") {
+			const trimmed = value.trim();
+			if (trimmed) collected.push(trimmed);
+		}
+	}
+	if (toolName === "apply_patch") {
+		// `patchText` is the canonical key, but some agents send an empty
+		// `patchText` alongside the real patch in `patch`. Use a falsy
+		// fallback (not `??`) so an empty `patchText` doesn't shadow it.
+		const primary =
+			typeof obj.patchText === "string" && obj.patchText.trim() ? obj.patchText : null;
+		const patchText = primary ?? (typeof obj.patch === "string" ? obj.patch : null);
+		if (patchText?.trim()) {
+			collected.push(...extractApplyPatchPaths(patchText));
+		}
+	}
+
+	const seen = new Set<string>();
+	const ordered: string[] = [];
+	for (const path of collected) {
+		if (seen.has(path)) continue;
+		seen.add(path);
+		ordered.push(path);
+	}
+	return ordered;
+}
+
+/**
+ * Update the on-disk session state for a hook payload and return the
+ * resulting state. Returns null when the payload has no usable session_id
+ * or when SessionEnd just cleared the state. Failures are swallowed —
+ * hook commands must never crash on state I/O errors.
+ */
+export function trackHookSessionState(payload: Record<string, unknown>): SessionState | null {
+	const sessionRaw = payload.session_id;
+	if (typeof sessionRaw !== "string") return null;
+	const sessionId = sessionRaw.trim();
+	if (!sessionId) return null;
+
+	const hookEventName =
+		typeof payload.hook_event_name === "string" ? payload.hook_event_name.trim() : "";
+
+	if (hookEventName === "SessionEnd") {
+		clearSessionState(sessionId);
+		return null;
+	}
+
+	const state = loadSessionState(sessionId);
+	let changed = false;
+
+	if (hookEventName === "UserPromptSubmit") {
+		const prompt = normalizePromptText(payload.prompt);
+		if (prompt) {
+			if (!state.first_prompt) {
+				state.first_prompt = prompt;
+				changed = true;
+			}
+			if (state.last_prompt !== prompt) {
+				state.last_prompt = prompt;
+				changed = true;
+			}
+		}
+	} else if (hookEventName === "PostToolUse" || hookEventName === "PostToolUseFailure") {
+		const existing = state.files_modified.filter((path) => path.trim().length > 0);
+		const seen = new Set(existing);
+		for (const path of extractModifiedPathsFromHook(payload)) {
+			if (seen.has(path)) continue;
+			existing.push(path);
+			seen.add(path);
+			changed = true;
+		}
+		state.files_modified = existing.slice(-MAX_FILES_MODIFIED);
+	}
+
+	if (changed) {
+		state.updated_at = nowIso();
+		try {
+			saveSessionState(sessionId, state);
+		} catch {
+			// best-effort: dropping a state update is preferable to crashing the hook
+		}
+	}
+	return state;
+}
+
+function pathBasename(value: string): string {
+	const normalized = value.replace(/\\/g, "/").replace(/\/+$/, "");
+	if (!normalized) return "";
+	const parts = normalized.split("/");
+	return parts[parts.length - 1] ?? "";
+}
+
+/**
+ * Compose a retrieval query that combines the original session intent,
+ * the current prompt, the project, and recent modified file basenames.
+ * Caps the result at 500 characters.
+ */
+export function buildInjectQuery(args: {
+	prompt: string;
+	project: string | null;
+	state: SessionState | null;
+}): string {
+	const parts: string[] = [];
+	const firstPrompt = args.state ? normalizePromptText(args.state.first_prompt) : "";
+	const filesModified = args.state
+		? args.state.files_modified.filter((item) => item.trim().length > 0)
+		: [];
+
+	if (firstPrompt) parts.push(firstPrompt);
+	if (args.prompt && args.prompt !== firstPrompt && args.prompt.length > 5) {
+		parts.push(args.prompt);
+	}
+	if (args.project) parts.push(args.project);
+	if (filesModified.length > 0) {
+		const names = filesModified
+			.slice(-MAX_QUERY_FILE_BASENAMES)
+			.map(pathBasename)
+			.filter((name) => name.length > 0);
+		if (names.length > 0) parts.push(names.join(" "));
+	}
+
+	if (parts.length === 0) return "recent work";
+	const query = parts.join(" ");
+	return query.length > MAX_QUERY_CHARS ? query.slice(0, MAX_QUERY_CHARS) : query;
+}
+
+/** Return the working set paths (last N modified files) for pack filters. */
+export function workingSetPathsFromState(state: SessionState | null): string[] {
+	if (!state) return [];
+	const files = state.files_modified.filter((path) => path.trim().length > 0);
+	return files.slice(-MAX_WORKING_SET_PATHS);
+}


### PR DESCRIPTION
## Description

Adds per-session signal tracking to the TypeScript Claude hook commands so retrieval inside `claude-hook-inject` builds a query richer than the bare current prompt and applies file-locality boosts to the memory pack.

Stacked on top of #680. Second PR in a 4-PR Graphite stack. Refs: codemem-fkx1.

### New module: `packages/cli/src/commands/claude-hook-session-state.ts`

- `SessionState` type + default; state lives in `~/.codemem/claude-hook-context/<sha1(session_id)>.json` (env-overridable via `CODEMEM_CLAUDE_HOOK_CONTEXT_DIR` for tests).
- `loadSessionState` / `saveSessionState` (atomic via tmp+rename) / `clearSessionState` — all best-effort, a state I/O failure must never crash a Claude hook.
- `normalizePromptText(value)` collapses prompts to a canonical form (trim + newlines → spaces) shared by both the tracker and the inject command's query builder, so multi-line prompts compare consistently across turns.
- `trackHookSessionState(payload)` — UserPromptSubmit records `first_prompt` once + refreshes `last_prompt`; PostToolUse / PostToolUseFailure extracts paths from Edit / Write / MultiEdit / NotebookEdit / apply_patch tool inputs, dedupes, caps at 64; SessionEnd clears the state file. The apply_patch path uses a falsy fallback between `patchText` and `patch` so an empty `patchText` doesn't shadow the real patch in the `patch` field.
- `buildInjectQuery({prompt, project, state})` — composes `first_prompt` + current prompt (skipped if equal to first_prompt or shorter than 6 chars) + project + last 5 modified file basenames. Caps at 500 chars; falls back to \`"recent work"\` when nothing useful is available.
- `workingSetPathsFromState(state)` — last 8 modified files, fed into the pack \`working_set_paths\` filter.
- `extractModifiedPathsFromHook(payload)` — tool input path extraction including apply_patch parsing.

### Integration

- `claude-hook-inject.ts` honors `CODEMEM_PLUGIN_IGNORE` as a global kill switch before any other env check, calls `trackHookSessionState` before the prompt-presence check (so SessionEnd / PostToolUse events still update state even when there is no prompt to inject), feeds the rich query into `buildLocalPack` / `tryHttpPack`, and propagates `workingSetPaths` into the local pack filters. `extractInjectContext` reuses `normalizePromptText` so the rich query's prompt-vs-first_prompt comparison is robust to multi-line prompts.
- `buildLocalPack` signature gains an optional `workingSetPaths` argument that lands as `filters.working_set_paths`.
- `truncateAdditionalContext` now `trimEnd()`s the slice and appends \`\\n\\n[pack truncated]\` so the boundary is visible in chat output instead of a silent slice.
- `claude-hook-ingest.ts` also calls `trackHookSessionState` on every invocation (best-effort) so prompts and modified files seen on the ingest path feed the same store the inject path reads from.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (\`pnpm test\` — 1190 passed across the workspace)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

New \`claude-hook-session-state.test.ts\` covers:
- state-path derivation (deterministic sha1 prefix per session id)
- load defaults / malformed-JSON resilience
- save → load roundtrip with normalization
- clear behavior + no-op when missing
- modified-path extraction (Edit / Write / MultiEdit / NotebookEdit / apply_patch + dedupe across path keys + empty-patchText fallback)
- \`trackHookSessionState\` lifecycle (first_prompt persistence across turns, PostToolUse dedupe across calls, SessionEnd clear, unrelated-event load-only)
- \`buildInjectQuery\` composition + 500-char cap + 5-char short-prompt skip + \`"recent work"\` fallback
- \`workingSetPathsFromState\` slicing

\`claude-hook-inject.test.ts\` gains a per-test sandboxed state dir + plugin log path. Existing shape-asserting tests are updated to expect the rich query string in the pack mock and the new truncation marker. New tests cover:
- \`CODEMEM_PLUGIN_IGNORE\` short-circuit
- multi-line prompt normalization (regression test for the prompt-vs-first_prompt comparison)
- pre-seeded state → rich query weave + \`working_set_paths\` propagation
- truncation marker including \`trimEnd\` behavior

End-to-end verified with the rebuilt CLI: PostToolUse pre-seed + UserPromptSubmit + second-turn UserPromptSubmit shows \`first_prompt\` preserved across turns, \`last_prompt\` updated, \`files_modified\` persisted, and SessionEnd clears the state file.

## Checklist

- [x] Code follows project style (\`biome check\` clean on touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — N/A
- [x] No new warnings introduced