### PR TITLE
chore(release): prepare 0.25.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.25.1"
+    "version": "0.25.2"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.25.1";
+const PINNED_BACKEND_VERSION = "0.25.2";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.25.1",
+	"version": "0.25.2",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.25.1",
+	"version": "0.25.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.25.1");
+		expect(VERSION).toBe("0.25.2");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.25.1";
+export const VERSION = "0.25.2";
 
 export * as Api from "./api-types.js";
 export type { CreateBetterSqliteCoordinatorAppOptions } from "./better-sqlite-coordinator-runtime.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.25.1",
+	"version": "0.25.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.25.1";
+const PINNED_BACKEND_VERSION = "0.25.2";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.25.1",
+	"version": "0.25.2",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.25.1",
+	"version": "0.25.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/viewer-server/static/app.js
+++ b/packages/viewer-server/static/app.js
@@ -13781,7 +13781,7 @@ For more information, see https://radix-ui.com/primitives/docs/components/${titl
 		try {
 			const runtime = await loadRuntimeInfo();
 			if (!runtime?.version) return;
-			setRuntimeLabel(runtime.version, "7219f5e");
+			setRuntimeLabel(runtime.version, "cc98f42");
 		} catch {}
 	}
 	var lastAnnouncedRefreshState = null;

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description

Cuts the **0.25.2** release. Ships the Claude hook parity stack that just landed on main:

- #680 fix(cli): restore Claude hook memory injection (the `hookSpecificOutput.hookEventName` hotfix)
- #681 feat(cli): port Claude hook session-state tracking to TS
- #682 feat(cli): port Claude hook ingest durability layer to TS
- #683 test(cli): add Claude hook output contract fixtures

Refs: codemem-mr2j.

## Version bumps (0.25.1 → 0.25.2)

| Path | Change |
|---|---|
| \`packages/core/package.json\` | version bump |
| \`packages/cli/package.json\` | version bump |
| \`packages/mcp-server/package.json\` | version bump |
| \`packages/viewer-server/package.json\` | version bump |
| \`packages/opencode-plugin/package.json\` | version bump |
| \`packages/core/src/index.ts\` | \`VERSION\` constant |
| \`packages/core/src/index.test.ts\` | matching assertion |
| \`packages/cli/.opencode/plugins/codemem.js\` | \`PINNED_BACKEND_VERSION\` |
| \`packages/opencode-plugin/.opencode/plugins/codemem.js\` | \`PINNED_BACKEND_VERSION\` |
| \`.claude-plugin/marketplace.json\` | metadata version + codemem plugin entry version (MCP args remain unpinned) |
| \`plugins/claude/.claude-plugin/plugin.json\` | metadata version (MCP args remain unpinned) |

## Regen

- \`pnpm install\` — lockfile already up to date (workspace-internal version bumps).
- \`pnpm build\` — viewer static asset hash refreshed from \`7219f5e\` to \`cc98f42\` to match the current main commit.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (\`pnpm run test\` — 1190 passed across the workspace)
- [x] Added/updated tests for changes (the version-string assertion in \`packages/core/src/index.test.ts\`)
- [x] Manually verified changes work as expected (\`pnpm run tsc\` clean; \`pnpm build\` successful for all packages)

## Checklist

- [x] Code follows project style (\`biome check\` clean on touched files; release diff is purely version strings + regenerated viewer asset)
- [x] Self-review completed
- [x] Documentation updated (if needed) — N/A for a version-bump release
- [x] No new warnings introduced

## Post-merge tag flow

After this PR squash-merges to \`main\`:

1. \`git checkout main && git pull --rebase\`
2. \`git status --short --branch\` — must be clean
3. \`git show --stat --summary HEAD\` — confirm the version bumps + viewer asset are present
4. \`git tag v0.25.2 && git push origin v0.25.2\` (tag the merge commit on \`main\`, NEVER the release branch)
5. The Release workflow will trigger on the \`v*\` tag and publish the GitHub Release artifacts