### PR TITLE
fix(cli): treat Claude hook ingest skipped>0 as a benign no-op

### DIFF
--- a/packages/cli/src/commands/claude-hook-ingest.test.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.test.ts
@@ -216,27 +216,32 @@ describe("claude-hook-ingest command", () => {
 			expect(httpCallCount).toBe(1);
 		});
 
-		it("treats HTTP `skipped > 0` as a failure and falls through to direct ingest", async () => {
-			// The viewer accepted the HTTP payload but skipped it (e.g. dedup
-			// miss, malformed shape after parse). The durability layer must
-			// not silently call this a success — it has to fall through to
-			// the locked direct/spool path so the data is captured locally.
-			const directCalls: Array<Record<string, unknown>> = [];
+		it("treats HTTP `skipped > 0` (deterministic null envelope) as a successful no-op", async () => {
+			// The viewer only returns {inserted:0, skipped:1} when
+			// buildRawEventEnvelopeFromHook produces a null envelope — a
+			// deterministic decision for payloads like a Stop event with no
+			// assistant text. Retrying via the direct path would produce the
+			// same null envelope and the same skip, so the ingest command
+			// accepts this as a no-op success instead of triggering the
+			// durability fallback.
+			let directCalls = 0;
 			const result = await ingestClaudeHookPayload(
-				{ hook_event_name: "Stop", session_id: "sess-skipped" },
+				{ hook_event_name: "Stop", session_id: "sess-no-text" },
 				{ host: "127.0.0.1", port: 38888 },
 				{
-					httpIngest: async () => ({ ok: false, inserted: 0, skipped: 1 }),
-					directIngest: (payload) => {
-						directCalls.push(payload);
+					httpIngest: async () => ({ ok: true, inserted: 0, skipped: 1 }),
+					directIngest: () => {
+						directCalls++;
 						return { inserted: 1, skipped: 0 };
 					},
-					boundaryFlush: () => {},
+					boundaryFlush: () => {
+						throw new Error("boundary flush should not run for Stop without flush envs");
+					},
 					resolveDb: () => "/tmp/test.sqlite",
 				},
 			);
-			expect(result.via).toBe("direct");
-			expect(directCalls).toHaveLength(1);
+			expect(result).toEqual({ inserted: 0, skipped: 1, via: "http" });
+			expect(directCalls).toBe(0);
 		});
 
 		it("spools the payload when both HTTP and direct ingest fail", async () => {

--- a/packages/cli/src/commands/claude-hook-ingest.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.ts
@@ -61,11 +61,19 @@ function emitStructuredError(errorCode: string, message: string): void {
 
 /** Try to POST the hook payload to the running viewer server.
  *
- * Returns `ok: true` only when the viewer accepted the payload AND
- * actually inserted it. The viewer may legitimately accept a request
- * but report `skipped > 0` when the payload was deduped or otherwise
- * rejected after parse — those cases must trigger the locked
- * fallback so the durability layer can decide whether to spool.
+ * Returns `ok: true` whenever the viewer accepts the request and
+ * returns a well-shaped JSON body with numeric `inserted` / `skipped`
+ * fields. That includes the `{inserted: 0, skipped: 1}` response the
+ * viewer emits when the payload maps to a null envelope (Stop with no
+ * assistant text, UserPromptSubmit with empty prompt, etc.) — that
+ * determination is deterministic, so retrying via the direct fallback
+ * would produce the exact same null envelope and the same skip. We
+ * accept those as benign no-ops instead of triggering the durability
+ * dance pointlessly.
+ *
+ * If a future server change adds a new `skipped` reason that IS
+ * transient, we'll need a reason field in the response and updated
+ * client handling — not an unconditional fail-over.
  */
 async function tryHttpIngest(
 	payload: Record<string, unknown>,
@@ -99,10 +107,6 @@ async function tryHttpIngest(
 		if (typeof obj.inserted !== "number" || typeof obj.skipped !== "number") {
 			logHookFailure("codemem claude-hook-ingest HTTP accepted with unexpected response body");
 			return { ok: false, inserted: 0, skipped: 0 };
-		}
-		if (obj.skipped > 0) {
-			logHookFailure("codemem claude-hook-ingest HTTP accepted but skipped payload");
-			return { ok: false, inserted: obj.inserted, skipped: obj.skipped };
 		}
 		return { ok: true, inserted: obj.inserted, skipped: obj.skipped };
 	} catch {


### PR DESCRIPTION
## Description

Reverts the \`skipped > 0\` fail-over behavior that landed in #682 (Codex P1 fix). That fix was over-corrective: it treated \`{inserted:0, skipped:1}\` from \`/api/claude-hooks\` as a transient failure and triggered the full durability dance (lock → drain → second HTTP retry → direct fallback). But reading the viewer handler in \`packages/viewer-server/src/routes/raw-events.ts\`, the only way the endpoint returns \`skipped:1\` is when \`buildRawEventEnvelopeFromHook\` produces a null envelope — a deterministic decision that retrying via the direct path cannot change.

Refs: codemem-8as0.

## Symptom

Every \`Stop\` hook that fires before the assistant has produced reply text (common during interrupted generation, rapid tool-use, or \`stop_hook_active\` recursive stops) wrote **two** \`plugin.log\` entries 4ms apart — one from the first HTTP attempt, one from the second HTTP retry inside the locked fallback — plus pointless lock/drain/direct-fallback churn. No data loss, just noise and wasted work.

Reproduced in \`~/.codemem/plugin.log\` on the installed 0.25.2 CLI:

\`\`\`
2026-04-10T07:56:08.293Z codemem claude-hook-ingest HTTP accepted but skipped payload
2026-04-10T07:56:08.297Z codemem claude-hook-ingest HTTP accepted but skipped payload
\`\`\`

## Evidence

Four direct curl probes against the running 0.25.2 viewer confirm that \`skipped:1\` comes exclusively from the null-envelope branch:

| Payload | Response |
|---|---|
| \`Stop\` with no \`last_assistant_message\` | \`{inserted:0, skipped:1}\` |
| \`Stop\` with \`last_assistant_message\` | \`{inserted:1, skipped:0}\` |
| \`SessionStart\` | \`{inserted:1, skipped:0}\` |
| \`PostToolUse\` with \`tool_name\` | \`{inserted:1, skipped:0}\` |

The handler at \`packages/viewer-server/src/routes/raw-events.ts:384-432\` has exactly two return paths: \`{inserted:0, skipped:1}\` when \`envelope === null\`, and \`{inserted: inserted ? 1 : 0, skipped: 0}\` otherwise. There is no other code path that produces \`skipped > 0\`. Any real server error (JSON parse, body too large, invalid shape, internal crash) returns 4xx/5xx.

## Fix

- Remove the \`skipped > 0 → ok:false\` branch in \`tryHttpIngest\` (\`packages/cli/src/commands/claude-hook-ingest.ts\`). Return \`{ok:true, inserted, skipped}\` so the orchestrator accepts the benign no-op and returns \`via:"http"\` without triggering durability.
- Delete the \`"HTTP accepted but skipped payload"\` log line.
- Keep the strict response-shape validation (\`typeof\` checks for \`inserted\`/\`skipped\`). That part of #682 is still correct and still triggers the fallback when the viewer returns something unexpected.
- Flip the test \`treats HTTP \\\`skipped > 0\\\` as a failure and falls through to direct ingest\` to assert the no-op success shape. The mocked \`httpIngest\` now returns \`{ok:true, inserted:0, skipped:1}\` and the assertion is \`result === {inserted:0, skipped:1, via:"http"}\` with zero direct calls.

## Future guardrail

If a future server change adds a new \`skipped\` reason that IS transient, the server should include a reason field in the response and the client should fail over only on specific reasons — not on an unconditional \`skipped > 0\`. The updated docstring on \`tryHttpIngest\` notes this explicitly.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (\`pnpm --filter codemem test -- claude-hook\` — 174 tests pass)
- [x] Added/updated tests for changes (the flipped regression test)
- [x] Manually verified changes work as expected

End-to-end smoke against the rebuilt CLI with a sandboxed \`CODEMEM_PLUGIN_LOG_PATH\`:
\`\`\`
$ echo '{"hook_event_name":"Stop","session_id":"smoke","cwd":"/Users/adam/workspace/codemem"}' \\
  | node packages/cli/dist/index.js claude-hook-ingest
{"inserted":0,"skipped":1,"via":"http"}
\`\`\`
And the plugin log file is never created (zero noise).

## Checklist

- [x] Code follows project style (\`biome check\` clean on touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — updated the \`tryHttpIngest\` docstring to explain the new semantics
- [x] No new warnings introduced