### PR TITLE
chore(lint): unexclude packages/ui from biome and burn down the mechanical backlog

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -57,11 +57,29 @@
 			"packages/**/src/**/*.js",
 			"packages/**/*.json",
 			"packages/**/vite.config.ts",
-			"!packages/ui",
 			"vitest.config.ts",
 			"tsconfig.base.json",
 			"tsconfig.json",
 			"biome.json"
 		]
-	}
+	},
+	"overrides": [
+		{
+			"includes": ["packages/ui/**"],
+			"linter": {
+				"rules": {
+					"a11y": {
+						"noAutofocus": "off",
+						"noLabelWithoutControl": "warn",
+						"noStaticElementInteractions": "warn",
+						"useKeyWithClickEvents": "warn",
+						"useSemanticElements": "warn"
+					},
+					"suspicious": {
+						"noExplicitAny": "warn"
+					}
+				}
+			}
+		}
+	]
 }

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -9,37 +9,37 @@
 
 declare const __CODEMEM_GIT_COMMIT__: string;
 
-import { $, $select } from './lib/dom';
-import { getTheme, setTheme, initThemeSelect } from './lib/theme';
-import { state, initState, setActiveTab, type TabId } from './lib/state';
-import * as api from './lib/api';
+import * as api from "./lib/api";
+import { $, $select } from "./lib/dom";
+import { initState, setActiveTab, state, type TabId } from "./lib/state";
+import { getTheme, initThemeSelect, setTheme } from "./lib/theme";
 
-import { initFeedTab, loadFeedData, updateFeedView } from './tabs/feed';
-import { initHealthTab, loadHealthData, renderHealthOverview } from './tabs/health';
-import { initSyncTab, loadSyncData, loadPairingData, renderSyncStatus, renderSyncPeers, renderSyncAttempts, renderPairing } from './tabs/sync';
-import { initSettings, loadConfigData, isSettingsOpen } from './tabs/settings';
+import { initFeedTab, loadFeedData, updateFeedView } from "./tabs/feed";
+import { initHealthTab, loadHealthData } from "./tabs/health";
+import { initSettings, isSettingsOpen, loadConfigData } from "./tabs/settings";
+import { initSyncTab, loadPairingData, loadSyncData } from "./tabs/sync";
 
 function setRuntimeLabel(version: string, commit: string | null) {
-  const el = $('runtimeLabel');
-  if (!el) return;
-  const label = commit ? `v${version} (${commit})` : `v${version}`;
-  el.textContent = label;
-  el.title = commit ? `codemem ${version} (${commit})` : `codemem ${version}`;
-  el.hidden = false;
+	const el = $("runtimeLabel");
+	if (!el) return;
+	const label = commit ? `v${version} (${commit})` : `v${version}`;
+	el.textContent = label;
+	el.title = commit ? `codemem ${version} (${commit})` : `codemem ${version}`;
+	el.hidden = false;
 }
 
 async function loadRuntimeLabel() {
-  try {
-    const runtime = await api.loadRuntimeInfo();
-    if (!runtime?.version) return;
-    const commit = __CODEMEM_GIT_COMMIT__ || null;
-    setRuntimeLabel(runtime.version, commit);
-  } catch {}
+	try {
+		const runtime = await api.loadRuntimeInfo();
+		if (!runtime?.version) return;
+		const commit = __CODEMEM_GIT_COMMIT__ || null;
+		setRuntimeLabel(runtime.version, commit);
+	} catch {}
 }
 
 /* ── Refresh status ──────────────────────────────────────── */
 
-type RefreshState = 'idle' | 'refreshing' | 'paused' | 'error';
+type RefreshState = "idle" | "refreshing" | "paused" | "error";
 let lastAnnouncedRefreshState: RefreshState | null = null;
 const RECONNECT_POLL_MS = 1500;
 
@@ -47,174 +47,197 @@ let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnecting = false;
 
 function setReconnectOverlay(open: boolean, detail?: string) {
-  const overlay = $('viewerReconnectOverlay');
-  const detailEl = $('viewerReconnectDetail');
-  if (!overlay || !detailEl) return;
-  overlay.hidden = !open;
-  detailEl.textContent = detail || 'Trying again automatically while the viewer comes back.';
+	const overlay = $("viewerReconnectOverlay");
+	const detailEl = $("viewerReconnectDetail");
+	if (!overlay || !detailEl) return;
+	overlay.hidden = !open;
+	detailEl.textContent = detail || "Trying again automatically while the viewer comes back.";
 }
 
 async function isViewerReady() {
-  try {
-    await api.pingViewerReady();
-    return true;
-  } catch {
-    return false;
-  }
+	try {
+		await api.pingViewerReady();
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 function stopReconnectLoop() {
-  if (reconnectTimer) {
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-  }
-  reconnecting = false;
-  setReconnectOverlay(false);
+	if (reconnectTimer) {
+		clearTimeout(reconnectTimer);
+		reconnectTimer = null;
+	}
+	reconnecting = false;
+	setReconnectOverlay(false);
 }
 
 function canResumeRefresh() {
-  return document.visibilityState !== 'hidden' && !isSettingsOpen();
+	return document.visibilityState !== "hidden" && !isSettingsOpen();
 }
 
 function scheduleReconnectLoop() {
-  if (reconnecting) return;
-  reconnecting = true;
-  stopPolling();
-  setRefreshStatus('error', '(reconnecting)');
-  setReconnectOverlay(true, 'The viewer server is restarting or temporarily unavailable. Trying again automatically…');
+	if (reconnecting) return;
+	reconnecting = true;
+	stopPolling();
+	setRefreshStatus("error", "(reconnecting)");
+	setReconnectOverlay(
+		true,
+		"The viewer server is restarting or temporarily unavailable. Trying again automatically…",
+	);
 
-  const tick = async () => {
-    const ready = await isViewerReady();
-    if (ready) {
-      stopReconnectLoop();
-      if (canResumeRefresh()) {
-        setRefreshStatus('refreshing');
-        startPolling();
-        void doRefresh();
-      } else {
-        setRefreshStatus('paused', document.visibilityState === 'hidden' ? '(tab hidden)' : '(settings open)');
-      }
-      return;
-    }
-    setReconnectOverlay(true, 'Still reconnecting… the viewer will recover automatically as soon as the server responds.');
-    reconnectTimer = setTimeout(tick, RECONNECT_POLL_MS);
-  };
+	const tick = async () => {
+		const ready = await isViewerReady();
+		if (ready) {
+			stopReconnectLoop();
+			if (canResumeRefresh()) {
+				setRefreshStatus("refreshing");
+				startPolling();
+				void doRefresh();
+			} else {
+				setRefreshStatus(
+					"paused",
+					document.visibilityState === "hidden" ? "(tab hidden)" : "(settings open)",
+				);
+			}
+			return;
+		}
+		setReconnectOverlay(
+			true,
+			"Still reconnecting… the viewer will recover automatically as soon as the server responds.",
+		);
+		reconnectTimer = setTimeout(tick, RECONNECT_POLL_MS);
+	};
 
-  reconnectTimer = setTimeout(tick, RECONNECT_POLL_MS);
+	reconnectTimer = setTimeout(tick, RECONNECT_POLL_MS);
 }
 
 function setRefreshStatus(rs: RefreshState, detail?: string) {
-  state.refreshState = rs;
-  const el = $('refreshStatus');
-  if (!el) return;
+	state.refreshState = rs;
+	const el = $("refreshStatus");
+	if (!el) return;
 
-  const announce = (msg: string) => {
-    const announcer = $('refreshAnnouncer');
-    if (!announcer || lastAnnouncedRefreshState === rs) return;
-    announcer.textContent = msg;
-    lastAnnouncedRefreshState = rs;
-  };
+	const announce = (msg: string) => {
+		const announcer = $("refreshAnnouncer");
+		if (!announcer || lastAnnouncedRefreshState === rs) return;
+		announcer.textContent = msg;
+		lastAnnouncedRefreshState = rs;
+	};
 
-  if (rs === 'refreshing') { el.textContent = "refreshing…"; return; }
-  if (rs === 'paused') { el.textContent = "paused"; announce('Auto refresh paused.'); return; }
-  if (rs === 'error' && detail === '(reconnecting)') {
-    el.textContent = 'reconnecting…';
-    announce('Viewer reconnecting.');
-    return;
-  }
-  if (rs === 'error') { el.textContent = "refresh failed"; announce('Refresh failed.'); return; }
-  const suffix = detail ? ` ${detail}` : '';
-  el.textContent = "updated " + new Date().toLocaleTimeString() + suffix;
-  lastAnnouncedRefreshState = null;
+	if (rs === "refreshing") {
+		el.textContent = "refreshing…";
+		return;
+	}
+	if (rs === "paused") {
+		el.textContent = "paused";
+		announce("Auto refresh paused.");
+		return;
+	}
+	if (rs === "error" && detail === "(reconnecting)") {
+		el.textContent = "reconnecting…";
+		announce("Viewer reconnecting.");
+		return;
+	}
+	if (rs === "error") {
+		el.textContent = "refresh failed";
+		announce("Refresh failed.");
+		return;
+	}
+	const suffix = detail ? ` ${detail}` : "";
+	el.textContent = `updated ${new Date().toLocaleTimeString()}${suffix}`;
+	lastAnnouncedRefreshState = null;
 }
 
 /* ── Polling ─────────────────────────────────────────────── */
 
 function stopPolling() {
-  if (state.refreshTimer) { clearInterval(state.refreshTimer); state.refreshTimer = null; }
+	if (state.refreshTimer) {
+		clearInterval(state.refreshTimer);
+		state.refreshTimer = null;
+	}
 }
 
 function startPolling() {
-  if (state.refreshTimer) return;
-  state.refreshTimer = setInterval(() => refresh(), 5000);
+	if (state.refreshTimer) return;
+	state.refreshTimer = setInterval(() => refresh(), 5000);
 }
 
-document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'hidden') {
-    stopPolling();
-    setRefreshStatus('paused', '(tab hidden)');
-  } else if (!isSettingsOpen() && !reconnecting) {
-    startPolling();
-    refresh();
-  }
+document.addEventListener("visibilitychange", () => {
+	if (document.visibilityState === "hidden") {
+		stopPolling();
+		setRefreshStatus("paused", "(tab hidden)");
+	} else if (!isSettingsOpen() && !reconnecting) {
+		startPolling();
+		refresh();
+	}
 });
 
 /* ── Tab routing ─────────────────────────────────────────── */
 
-const TAB_IDS: TabId[] = ['feed', 'health', 'sync'];
+const TAB_IDS: TabId[] = ["feed", "health", "sync"];
 
 function switchTab(tab: TabId) {
-  setActiveTab(tab);
+	setActiveTab(tab);
 
-  // Toggle tab panels
-  TAB_IDS.forEach((id) => {
-    const panel = $(`tab-${id}`);
-    if (panel) panel.hidden = id !== tab;
-  });
+	// Toggle tab panels
+	TAB_IDS.forEach((id) => {
+		const panel = $(`tab-${id}`);
+		if (panel) panel.hidden = id !== tab;
+	});
 
-  // Toggle tab buttons
-  TAB_IDS.forEach((id) => {
-    const btn = $(`tabBtn-${id}`);
-    if (btn) btn.classList.toggle('active', id === tab);
-  });
+	// Toggle tab buttons
+	TAB_IDS.forEach((id) => {
+		const btn = $(`tabBtn-${id}`);
+		if (btn) btn.classList.toggle("active", id === tab);
+	});
 
-  // Refresh data for active tab
-  refresh();
+	// Refresh data for active tab
+	refresh();
 }
 
 function initTabs() {
-  TAB_IDS.forEach((id) => {
-    const btn = $(`tabBtn-${id}`);
-    btn?.addEventListener('click', () => switchTab(id));
-  });
+	TAB_IDS.forEach((id) => {
+		const btn = $(`tabBtn-${id}`);
+		btn?.addEventListener("click", () => switchTab(id));
+	});
 
-  // Listen for hash changes (back/forward navigation)
-  window.addEventListener('hashchange', () => {
-    const hash = window.location.hash.replace('#', '') as TabId;
-    if (TAB_IDS.includes(hash) && hash !== state.activeTab) {
-      switchTab(hash);
-    }
-  });
+	// Listen for hash changes (back/forward navigation)
+	window.addEventListener("hashchange", () => {
+		const hash = window.location.hash.replace("#", "") as TabId;
+		if (TAB_IDS.includes(hash) && hash !== state.activeTab) {
+			switchTab(hash);
+		}
+	});
 
-  // Set initial tab
-  switchTab(state.activeTab);
+	// Set initial tab
+	switchTab(state.activeTab);
 }
 
 /* ── Project filter ──────────────────────────────────────── */
 
 async function loadProjects() {
-  try {
-    const projects = await api.loadProjects();
-    const projectFilter = $select('projectFilter');
-    if (!projectFilter) return;
-    projectFilter.textContent = '';
-    const allOpt = document.createElement('option');
-    allOpt.value = '';
-    allOpt.textContent = 'All Projects';
-    projectFilter.appendChild(allOpt);
-    projects.forEach((p) => {
-      const opt = document.createElement('option');
-      opt.value = p;
-      opt.textContent = p;
-      projectFilter.appendChild(opt);
-    });
-  } catch {}
+	try {
+		const projects = await api.loadProjects();
+		const projectFilter = $select("projectFilter");
+		if (!projectFilter) return;
+		projectFilter.textContent = "";
+		const allOpt = document.createElement("option");
+		allOpt.value = "";
+		allOpt.textContent = "All Projects";
+		projectFilter.appendChild(allOpt);
+		projects.forEach((p) => {
+			const opt = document.createElement("option");
+			opt.value = p;
+			opt.textContent = p;
+			projectFilter.appendChild(opt);
+		});
+	} catch {}
 }
 
-$select('projectFilter')?.addEventListener('change', () => {
-  state.currentProject = $select('projectFilter')?.value || '';
-  updateFeedView(true);
-  refresh();
+$select("projectFilter")?.addEventListener("change", () => {
+	state.currentProject = $select("projectFilter")?.value || "";
+	updateFeedView(true);
+	refresh();
 });
 
 /* ── Main refresh ────────────────────────────────────────── */
@@ -222,56 +245,56 @@ $select('projectFilter')?.addEventListener('change', () => {
 let refreshDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 async function refresh() {
-  if (reconnecting) return;
-  // Debounce rapid calls (tab switch + hash change + visibility)
-  if (refreshDebounceTimer) clearTimeout(refreshDebounceTimer);
-  refreshDebounceTimer = setTimeout(() => doRefresh(), 80);
+	if (reconnecting) return;
+	// Debounce rapid calls (tab switch + hash change + visibility)
+	if (refreshDebounceTimer) clearTimeout(refreshDebounceTimer);
+	refreshDebounceTimer = setTimeout(() => doRefresh(), 80);
 }
 
 async function doRefresh() {
-  if (reconnecting) return;
-  if (state.refreshInFlight) { state.refreshQueued = true; return; }
-  state.refreshInFlight = true;
+	if (reconnecting) return;
+	if (state.refreshInFlight) {
+		state.refreshQueued = true;
+		return;
+	}
+	state.refreshInFlight = true;
 
-  try {
-    setRefreshStatus('refreshing');
+	try {
+		setRefreshStatus("refreshing");
 
-    // Always load health data (for the header health dot) and config
-    const promises: Promise<any>[] = [
-      loadHealthData(),
-      loadConfigData(),
-    ];
+		// Always load health data (for the header health dot) and config
+		const promises: Promise<any>[] = [loadHealthData(), loadConfigData()];
 
-    // Load tab-specific data
-    if (state.activeTab === 'feed') {
-      promises.push(loadFeedData());
-    }
-    // Sync data is needed by both Sync tab and Health tab (health cards derive sync state)
-    if (state.activeTab === 'sync' || state.activeTab === 'health') {
-      promises.push(loadSyncData());
-    }
+		// Load tab-specific data
+		if (state.activeTab === "feed") {
+			promises.push(loadFeedData());
+		}
+		// Sync data is needed by both Sync tab and Health tab (health cards derive sync state)
+		if (state.activeTab === "sync" || state.activeTab === "health") {
+			promises.push(loadSyncData());
+		}
 
-    // Load pairing if open
-    if (state.syncPairingOpen) {
-      promises.push(loadPairingData());
-    }
+		// Load pairing if open
+		if (state.syncPairingOpen) {
+			promises.push(loadPairingData());
+		}
 
-    await Promise.all(promises);
-    setRefreshStatus('idle');
-  } catch {
-    const ready = await isViewerReady();
-    if (!ready) {
-      scheduleReconnectLoop();
-    } else {
-      setRefreshStatus('error');
-    }
-  } finally {
-    state.refreshInFlight = false;
-    if (state.refreshQueued && !reconnecting) {
-      state.refreshQueued = false;
-      doRefresh();
-    }
-  }
+		await Promise.all(promises);
+		setRefreshStatus("idle");
+	} catch {
+		const ready = await isViewerReady();
+		if (!ready) {
+			scheduleReconnectLoop();
+		} else {
+			setRefreshStatus("error");
+		}
+	} finally {
+		state.refreshInFlight = false;
+		if (state.refreshQueued && !reconnecting) {
+			state.refreshQueued = false;
+			doRefresh();
+		}
+	}
 }
 
 /* ── Boot ────────────────────────────────────────────────── */
@@ -279,7 +302,7 @@ async function doRefresh() {
 initState();
 
 // Theme
-initThemeSelect($select('themeSelect'));
+initThemeSelect($select("themeSelect"));
 setTheme(getTheme());
 
 // Tabs
@@ -294,16 +317,16 @@ initSettings(stopPolling, startPolling, () => refresh());
 // Projects
 loadProjects();
 
-$('viewerReconnectRetry')?.addEventListener('click', async () => {
-  setReconnectOverlay(true, 'Checking whether the viewer server is back…');
-  const ready = await isViewerReady();
-  if (!ready) {
-    scheduleReconnectLoop();
-    return;
-  }
-  stopReconnectLoop();
-  startPolling();
-  void doRefresh();
+$("viewerReconnectRetry")?.addEventListener("click", async () => {
+	setReconnectOverlay(true, "Checking whether the viewer server is back…");
+	const ready = await isViewerReady();
+	if (!ready) {
+		scheduleReconnectLoop();
+		return;
+	}
+	stopReconnectLoop();
+	startPolling();
+	void doRefresh();
 });
 
 // Version label

--- a/packages/ui/src/components/primitives/radix-dialog.tsx
+++ b/packages/ui/src/components/primitives/radix-dialog.tsx
@@ -1,78 +1,78 @@
-import * as Dialog from '@radix-ui/react-dialog';
-import type { ComponentChildren, ComponentProps } from 'preact';
-import { render } from 'preact';
+import * as Dialog from "@radix-ui/react-dialog";
+import type { ComponentChildren, ComponentProps } from "preact";
+import { render } from "preact";
 
 type DialogContentProps = ComponentProps<typeof Dialog.Content>;
 
 export type RadixDialogProps = {
-  ariaDescribedby?: string;
-  ariaLabelledby?: string;
-  children?: ComponentChildren;
-  contentClassName?: string;
-  contentId: string;
-  modal?: boolean;
-  onCloseAutoFocus?: DialogContentProps['onCloseAutoFocus'];
-  onEscapeKeyDown?: DialogContentProps['onEscapeKeyDown'];
-  onInteractOutside?: DialogContentProps['onInteractOutside'];
-  onOpenAutoFocus?: DialogContentProps['onOpenAutoFocus'];
-  onOpenChange: (open: boolean) => void;
-  open: boolean;
-  overlayClassName?: string;
-  overlayId: string;
-  slotId?: string;
+	ariaDescribedby?: string;
+	ariaLabelledby?: string;
+	children?: ComponentChildren;
+	contentClassName?: string;
+	contentId: string;
+	modal?: boolean;
+	onCloseAutoFocus?: DialogContentProps["onCloseAutoFocus"];
+	onEscapeKeyDown?: DialogContentProps["onEscapeKeyDown"];
+	onInteractOutside?: DialogContentProps["onInteractOutside"];
+	onOpenAutoFocus?: DialogContentProps["onOpenAutoFocus"];
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+	overlayClassName?: string;
+	overlayId: string;
+	slotId?: string;
 };
 
 export function RadixDialog({
-  ariaDescribedby,
-  ariaLabelledby,
-  children,
-  contentClassName,
-  contentId,
-  modal = true,
-  onCloseAutoFocus,
-  onEscapeKeyDown,
-  onInteractOutside,
-  onOpenAutoFocus,
-  onOpenChange,
-  open,
-  overlayClassName,
-  overlayId,
-  slotId,
+	ariaDescribedby,
+	ariaLabelledby,
+	children,
+	contentClassName,
+	contentId,
+	modal = true,
+	onCloseAutoFocus,
+	onEscapeKeyDown,
+	onInteractOutside,
+	onOpenAutoFocus,
+	onOpenChange,
+	open,
+	overlayClassName,
+	overlayId,
+	slotId,
 }: RadixDialogProps) {
-  return (
-    <Dialog.Root modal={modal} open={open} onOpenChange={onOpenChange}>
-      {open ? (
-        <Dialog.Portal>
-          <Dialog.Overlay asChild>
-            <div className={overlayClassName} id={overlayId} />
-          </Dialog.Overlay>
-          <Dialog.Content
-            aria-describedby={ariaDescribedby}
-            aria-labelledby={ariaLabelledby}
-            asChild
-            onCloseAutoFocus={onCloseAutoFocus}
-            onEscapeKeyDown={onEscapeKeyDown}
-            onInteractOutside={onInteractOutside}
-            onOpenAutoFocus={onOpenAutoFocus}
-          >
-            <div
-              className={contentClassName}
-              id={contentId}
-              onClick={(event) => {
-                if (event.target !== event.currentTarget) return;
-                onOpenChange(false);
-              }}
-              tabIndex={-1}
-            >
-              {children ?? (slotId ? <div id={slotId} /> : null)}
-            </div>
-          </Dialog.Content>
-        </Dialog.Portal>
-      ) : null}
-    </Dialog.Root>
-  );
+	return (
+		<Dialog.Root modal={modal} open={open} onOpenChange={onOpenChange}>
+			{open ? (
+				<Dialog.Portal>
+					<Dialog.Overlay asChild>
+						<div className={overlayClassName} id={overlayId} />
+					</Dialog.Overlay>
+					<Dialog.Content
+						aria-describedby={ariaDescribedby}
+						aria-labelledby={ariaLabelledby}
+						asChild
+						onCloseAutoFocus={onCloseAutoFocus}
+						onEscapeKeyDown={onEscapeKeyDown}
+						onInteractOutside={onInteractOutside}
+						onOpenAutoFocus={onOpenAutoFocus}
+					>
+						<div
+							className={contentClassName}
+							id={contentId}
+							onClick={(event) => {
+								if (event.target !== event.currentTarget) return;
+								onOpenChange(false);
+							}}
+							tabIndex={-1}
+						>
+							{children ?? (slotId ? <div id={slotId} /> : null)}
+						</div>
+					</Dialog.Content>
+				</Dialog.Portal>
+			) : null}
+		</Dialog.Root>
+	);
 }
 
 export function renderRadixDialog(mount: HTMLElement, props: RadixDialogProps) {
-  render(<RadixDialog {...props} />, mount);
+	render(<RadixDialog {...props} />, mount);
 }

--- a/packages/ui/src/components/primitives/radix-select.tsx
+++ b/packages/ui/src/components/primitives/radix-select.tsx
@@ -1,87 +1,89 @@
-import * as Select from '@radix-ui/react-select';
+import * as Select from "@radix-ui/react-select";
 
-const EMPTY_SENTINEL = '__codemem-empty-select__';
+const EMPTY_SENTINEL = "__codemem-empty-select__";
 
 function encodeValue(value: string): string {
-  return value === '' ? EMPTY_SENTINEL : value;
+	return value === "" ? EMPTY_SENTINEL : value;
 }
 
 function decodeValue(value: string): string {
-  return value === EMPTY_SENTINEL ? '' : value;
+	return value === EMPTY_SENTINEL ? "" : value;
 }
 
 export type RadixSelectOption = {
-  value: string;
-  label: string;
-  disabled?: boolean;
+	value: string;
+	label: string;
+	disabled?: boolean;
 };
 
 type RadixSelectProps = {
-  ariaLabel?: string;
-  className?: string;
-  contentClassName?: string;
-  disabled?: boolean;
-  id?: string;
-  itemClassName?: string;
-  onValueChange: (value: string) => void;
-  options: RadixSelectOption[];
-  placeholder?: string;
-  triggerClassName?: string;
-  value: string;
-  viewportClassName?: string;
+	ariaLabel?: string;
+	className?: string;
+	contentClassName?: string;
+	disabled?: boolean;
+	id?: string;
+	itemClassName?: string;
+	onValueChange: (value: string) => void;
+	options: RadixSelectOption[];
+	placeholder?: string;
+	triggerClassName?: string;
+	value: string;
+	viewportClassName?: string;
 };
 
 export function RadixSelect({
-  ariaLabel,
-  className,
-  contentClassName,
-  disabled = false,
-  id,
-  itemClassName,
-  onValueChange,
-  options,
-  placeholder,
-  triggerClassName,
-  value,
-  viewportClassName,
+	ariaLabel,
+	className,
+	contentClassName,
+	disabled = false,
+	id,
+	itemClassName,
+	onValueChange,
+	options,
+	placeholder,
+	triggerClassName,
+	value,
+	viewportClassName,
 }: RadixSelectProps) {
-  const encodedValue = value ? encodeValue(value) : undefined;
+	const encodedValue = value ? encodeValue(value) : undefined;
 
-  return (
-    <Select.Root
-      disabled={disabled}
-      onValueChange={(nextValue) => onValueChange(decodeValue(nextValue))}
-      value={encodedValue}
-    >
-      <Select.Trigger
-        aria-label={ariaLabel ?? placeholder}
-        className={triggerClassName ?? className}
-        data-value={value}
-        id={id}
-        type="button"
-      >
-        <Select.Value placeholder={placeholder} />
-        <Select.Icon className="sync-radix-select-icon" aria-hidden="true">
-          ▾
-        </Select.Icon>
-      </Select.Trigger>
-      <Select.Portal>
-        <Select.Content className={contentClassName} position="popper">
-          <Select.Viewport className={viewportClassName}>
-            {options.map((option) => (
-              <Select.Item
-                key={encodeValue(option.value)}
-                className={itemClassName}
-                disabled={option.disabled}
-                value={encodeValue(option.value)}
-              >
-                <Select.ItemText>{option.label}</Select.ItemText>
-                <Select.ItemIndicator className="sync-radix-select-indicator">✓</Select.ItemIndicator>
-              </Select.Item>
-            ))}
-          </Select.Viewport>
-        </Select.Content>
-      </Select.Portal>
-    </Select.Root>
-  );
+	return (
+		<Select.Root
+			disabled={disabled}
+			onValueChange={(nextValue) => onValueChange(decodeValue(nextValue))}
+			value={encodedValue}
+		>
+			<Select.Trigger
+				aria-label={ariaLabel ?? placeholder}
+				className={triggerClassName ?? className}
+				data-value={value}
+				id={id}
+				type="button"
+			>
+				<Select.Value placeholder={placeholder} />
+				<Select.Icon className="sync-radix-select-icon" aria-hidden="true">
+					▾
+				</Select.Icon>
+			</Select.Trigger>
+			<Select.Portal>
+				<Select.Content className={contentClassName} position="popper">
+					<Select.Viewport className={viewportClassName}>
+						{options.map((option) => (
+							<Select.Item
+								key={encodeValue(option.value)}
+								className={itemClassName}
+								disabled={option.disabled}
+								value={encodeValue(option.value)}
+							>
+								<Select.ItemText>{option.label}</Select.ItemText>
+								<Select.ItemIndicator className="sync-radix-select-indicator">
+									✓
+								</Select.ItemIndicator>
+							</Select.Item>
+						))}
+					</Select.Viewport>
+				</Select.Content>
+			</Select.Portal>
+		</Select.Root>
+	);
 }

--- a/packages/ui/src/components/primitives/radix-switch.tsx
+++ b/packages/ui/src/components/primitives/radix-switch.tsx
@@ -1,37 +1,37 @@
-import * as Switch from '@radix-ui/react-switch';
+import * as Switch from "@radix-ui/react-switch";
 
 type RadixSwitchProps = {
-  'aria-labelledby'?: string;
-  checked: boolean;
-  className?: string;
-  disabled?: boolean;
-  id?: string;
-  name?: string;
-  onCheckedChange: (checked: boolean) => void;
-  thumbClassName?: string;
+	"aria-labelledby"?: string;
+	checked: boolean;
+	className?: string;
+	disabled?: boolean;
+	id?: string;
+	name?: string;
+	onCheckedChange: (checked: boolean) => void;
+	thumbClassName?: string;
 };
 
 export function RadixSwitch({
-  'aria-labelledby': ariaLabelledBy,
-  checked,
-  className,
-  disabled = false,
-  id,
-  name,
-  onCheckedChange,
-  thumbClassName,
+	"aria-labelledby": ariaLabelledBy,
+	checked,
+	className,
+	disabled = false,
+	id,
+	name,
+	onCheckedChange,
+	thumbClassName,
 }: RadixSwitchProps) {
-  return (
-    <Switch.Root
-      aria-labelledby={ariaLabelledBy}
-      checked={checked}
-      className={className}
-      disabled={disabled}
-      id={id}
-      name={name}
-      onCheckedChange={onCheckedChange}
-    >
-      <Switch.Thumb className={thumbClassName} />
-    </Switch.Root>
-  );
+	return (
+		<Switch.Root
+			aria-labelledby={ariaLabelledBy}
+			checked={checked}
+			className={className}
+			disabled={disabled}
+			id={id}
+			name={name}
+			onCheckedChange={onCheckedChange}
+		>
+			<Switch.Thumb className={thumbClassName} />
+		</Switch.Root>
+	);
 }

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -1,463 +1,476 @@
 /* API fetch wrappers — thin layer over the viewer HTTP endpoints. */
 
 export interface SyncRunItem {
-  peer_device_id: string;
-  ok: boolean;
-  error?: string;
-  address?: string;
-  opsIn: number;
-  opsOut: number;
-  addressErrors: Array<{ address: string; error: string }>;
+	peer_device_id: string;
+	ok: boolean;
+	error?: string;
+	address?: string;
+	opsIn: number;
+	opsOut: number;
+	addressErrors: Array<{ address: string; error: string }>;
 }
 
 export interface SyncRunResponse {
-  items: SyncRunItem[];
+	items: SyncRunItem[];
 }
 
 export interface RuntimeInfo {
-  version: string;
+	version: string;
 }
 
 export interface PackTraceCandidate {
-  id: number;
-  rank: number;
-  kind: string;
-  title: string;
-  preview: string;
-  reasons: string[];
-  disposition: 'selected' | 'dropped' | 'deduped' | 'trimmed';
-  section: 'summary' | 'timeline' | 'observations' | null;
-  scores: {
-    base_score: number | null;
-    combined_score: number | null;
-    recency: number;
-    kind_bonus: number;
-    quality_boost: number;
-    working_set_overlap: number;
-    query_path_overlap: number;
-    personal_bias: number;
-    shared_trust_penalty: number;
-    recap_penalty: number;
-    tasklike_penalty: number;
-    text_overlap: number;
-    tag_overlap: number;
-  };
+	id: number;
+	rank: number;
+	kind: string;
+	title: string;
+	preview: string;
+	reasons: string[];
+	disposition: "selected" | "dropped" | "deduped" | "trimmed";
+	section: "summary" | "timeline" | "observations" | null;
+	scores: {
+		base_score: number | null;
+		combined_score: number | null;
+		recency: number;
+		kind_bonus: number;
+		quality_boost: number;
+		working_set_overlap: number;
+		query_path_overlap: number;
+		personal_bias: number;
+		shared_trust_penalty: number;
+		recap_penalty: number;
+		tasklike_penalty: number;
+		text_overlap: number;
+		tag_overlap: number;
+	};
 }
 
 export interface PackTrace {
-  version: 1;
-  inputs: {
-    query: string;
-    project: string | null;
-    working_set_files: string[];
-    token_budget: number | null;
-    limit: number;
-  };
-  mode: {
-    selected: 'default' | 'task' | 'recall';
-    reasons: string[];
-  };
-  retrieval: {
-    candidate_count: number;
-    candidates: PackTraceCandidate[];
-  };
-  assembly: {
-    deduped_ids: number[];
-    collapsed_groups: Array<{
-      kept: number;
-      dropped: number[];
-      support_count: number;
-    }>;
-    trimmed_ids: number[];
-    trim_reasons: string[];
-    sections: Record<'summary' | 'timeline' | 'observations', number[]>;
-  };
-  output: {
-    estimated_tokens: number;
-    truncated: boolean;
-    section_counts: Record<'summary' | 'timeline' | 'observations', number>;
-    pack_text: string;
-  };
+	version: 1;
+	inputs: {
+		query: string;
+		project: string | null;
+		working_set_files: string[];
+		token_budget: number | null;
+		limit: number;
+	};
+	mode: {
+		selected: "default" | "task" | "recall";
+		reasons: string[];
+	};
+	retrieval: {
+		candidate_count: number;
+		candidates: PackTraceCandidate[];
+	};
+	assembly: {
+		deduped_ids: number[];
+		collapsed_groups: Array<{
+			kept: number;
+			dropped: number[];
+			support_count: number;
+		}>;
+		trimmed_ids: number[];
+		trim_reasons: string[];
+		sections: Record<"summary" | "timeline" | "observations", number[]>;
+	};
+	output: {
+		estimated_tokens: number;
+		truncated: boolean;
+		section_counts: Record<"summary" | "timeline" | "observations", number>;
+		pack_text: string;
+	};
 }
 
 function payloadError(payload: unknown): string | undefined {
-  if (!payload || typeof payload !== 'object') return undefined;
-  const maybeError = (payload as { error?: unknown }).error;
-  return typeof maybeError === 'string' ? maybeError : undefined;
+	if (!payload || typeof payload !== "object") return undefined;
+	const maybeError = (payload as { error?: unknown }).error;
+	return typeof maybeError === "string" ? maybeError : undefined;
 }
 
 async function fetchJson<T = Record<string, unknown>>(url: string): Promise<T> {
-  const resp = await fetch(url);
-  if (!resp.ok) throw new Error(`${url}: ${resp.status} ${resp.statusText}`);
-  return resp.json() as Promise<T>;
+	const resp = await fetch(url);
+	if (!resp.ok) throw new Error(`${url}: ${resp.status} ${resp.statusText}`);
+	return resp.json() as Promise<T>;
 }
 
 export async function pingViewerReady(timeoutMs = 1200): Promise<void> {
-  const controller = new AbortController();
-  const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const resp = await fetch('/api/stats', {
-      cache: 'no-store',
-      signal: controller.signal,
-    });
-    if (!resp.ok) throw new Error(`/api/stats: ${resp.status} ${resp.statusText}`);
-  } finally {
-    window.clearTimeout(timeoutId);
-  }
+	const controller = new AbortController();
+	const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const resp = await fetch("/api/stats", {
+			cache: "no-store",
+			signal: controller.signal,
+		});
+		if (!resp.ok) throw new Error(`/api/stats: ${resp.status} ${resp.statusText}`);
+	} finally {
+		window.clearTimeout(timeoutId);
+	}
 }
 
 async function readJsonPayload<T = Record<string, unknown>>(
-  resp: Response,
+	resp: Response,
 ): Promise<{ text: string; payload: T }> {
-  const text = await resp.text();
-  try {
-    return { text, payload: (text ? JSON.parse(text) : {}) as T };
-  } catch {
-    return { text, payload: {} as T };
-  }
+	const text = await resp.text();
+	try {
+		return { text, payload: (text ? JSON.parse(text) : {}) as T };
+	} catch {
+		return { text, payload: {} as T };
+	}
 }
 
 export async function loadStats(): Promise<any> {
-  return fetchJson('/api/stats');
+	return fetchJson("/api/stats");
 }
 
 export async function loadRuntimeInfo(): Promise<RuntimeInfo> {
-  return fetchJson('/api/runtime');
+	return fetchJson("/api/runtime");
 }
 
 export async function loadUsage(project: string): Promise<any> {
-  return fetchJson(`/api/usage?project=${encodeURIComponent(project)}`);
+	return fetchJson(`/api/usage?project=${encodeURIComponent(project)}`);
 }
 
 export async function loadSession(project: string): Promise<any> {
-  return fetchJson(`/api/session?project=${encodeURIComponent(project)}`);
+	return fetchJson(`/api/session?project=${encodeURIComponent(project)}`);
 }
 
 export async function loadRawEvents(project: string): Promise<any> {
-  return fetchJson(`/api/raw-events?project=${encodeURIComponent(project)}`);
+	return fetchJson(`/api/raw-events?project=${encodeURIComponent(project)}`);
 }
 
 export async function loadMemories(project: string): Promise<any> {
-  return loadMemoriesPage(project);
+	return loadMemoriesPage(project);
 }
 
 function buildProjectParams(
-  project: string,
-  limit?: number,
-  offset?: number,
-  scope?: string,
+	project: string,
+	limit?: number,
+	offset?: number,
+	scope?: string,
 ): string {
-  const params = new URLSearchParams();
-  params.set('project', project || '');
-  if (typeof limit === 'number') params.set('limit', String(limit));
-  if (typeof offset === 'number') params.set('offset', String(offset));
-  if (scope) params.set('scope', scope);
-  return params.toString();
+	const params = new URLSearchParams();
+	params.set("project", project || "");
+	if (typeof limit === "number") params.set("limit", String(limit));
+	if (typeof offset === "number") params.set("offset", String(offset));
+	if (scope) params.set("scope", scope);
+	return params.toString();
 }
 
 export async function loadMemoriesPage(
-  project: string,
-  options?: { limit?: number; offset?: number; scope?: string },
+	project: string,
+	options?: { limit?: number; offset?: number; scope?: string },
 ): Promise<any> {
-  const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
-  return fetchJson(`/api/observations?${query}`);
+	const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
+	return fetchJson(`/api/observations?${query}`);
 }
 
-export async function updateMemoryVisibility(memoryId: number, visibility: 'private' | 'shared'): Promise<any> {
-  const resp = await fetch('/api/memories/visibility', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ memory_id: memoryId, visibility }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+export async function updateMemoryVisibility(
+	memoryId: number,
+	visibility: "private" | "shared",
+): Promise<any> {
+	const resp = await fetch("/api/memories/visibility", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ memory_id: memoryId, visibility }),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function loadSummaries(project: string): Promise<any> {
-  return loadSummariesPage(project);
+	return loadSummariesPage(project);
 }
 
 export async function loadSummariesPage(
-  project: string,
-  options?: { limit?: number; offset?: number; scope?: string },
+	project: string,
+	options?: { limit?: number; offset?: number; scope?: string },
 ): Promise<any> {
-  const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
-  return fetchJson(`/api/summaries?${query}`);
+	const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
+	return fetchJson(`/api/summaries?${query}`);
 }
 
 export async function tracePack(payload: {
-  context: string;
-  project?: string | null;
-  working_set_files?: string[];
-  token_budget?: number | null;
-  limit?: number;
+	context: string;
+	project?: string | null;
+	working_set_files?: string[];
+	token_budget?: number | null;
+	limit?: number;
 }): Promise<PackTrace> {
-  const resp = await fetch('/api/pack/trace', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  const { text, payload: data } = await readJsonPayload<PackTrace>(resp);
-  if (!resp.ok) throw new Error(payloadError(data) || text || 'request failed');
-  return data;
+	const resp = await fetch("/api/pack/trace", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+	const { text, payload: data } = await readJsonPayload<PackTrace>(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
 }
 
 export async function loadObserverStatus(): Promise<any> {
-  return fetchJson('/api/observer-status');
+	return fetchJson("/api/observer-status");
 }
 
 export async function loadConfig(): Promise<any> {
-  return fetchJson('/api/config');
+	return fetchJson("/api/config");
 }
 
 export async function saveConfig(payload: any): Promise<void> {
-  const resp = await fetch('/api/config', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  const text = await resp.text();
-  let parsed: any = null;
-  if (text) {
-    try {
-      parsed = JSON.parse(text);
-    } catch {}
-  }
-  if (!resp.ok) {
-    const message = parsed && typeof parsed.error === 'string' ? parsed.error : text || 'request failed';
-    throw new Error(message);
-  }
-  return parsed;
+	const resp = await fetch("/api/config", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+	const text = await resp.text();
+	let parsed: any = null;
+	if (text) {
+		try {
+			parsed = JSON.parse(text);
+		} catch {}
+	}
+	if (!resp.ok) {
+		const message =
+			parsed && typeof parsed.error === "string" ? parsed.error : text || "request failed";
+		throw new Error(message);
+	}
+	return parsed;
 }
 
 export async function loadSyncStatus(
-  includeDiagnostics: boolean,
-  project = '',
-  options?: { includeJoinRequests?: boolean },
+	includeDiagnostics: boolean,
+	project = "",
+	options?: { includeJoinRequests?: boolean },
 ): Promise<any> {
-  const params = new URLSearchParams();
-  if (includeDiagnostics) params.set('includeDiagnostics', '1');
-  if (project) params.set('project', project);
-  if (options?.includeJoinRequests) params.set('includeJoinRequests', '1');
-  const suffix = params.size ? `?${params.toString()}` : '';
-  return fetchJson(`/api/sync/status${suffix}`);
+	const params = new URLSearchParams();
+	if (includeDiagnostics) params.set("includeDiagnostics", "1");
+	if (project) params.set("project", project);
+	if (options?.includeJoinRequests) params.set("includeJoinRequests", "1");
+	const suffix = params.size ? `?${params.toString()}` : "";
+	return fetchJson(`/api/sync/status${suffix}`);
 }
 
 export async function createCoordinatorInvite(payload: {
-  group_id: string;
-  coordinator_url?: string;
-  policy: 'auto_admit' | 'approval_required';
-  ttl_hours: number;
+	group_id: string;
+	coordinator_url?: string;
+	policy: "auto_admit" | "approval_required";
+	ttl_hours: number;
 }): Promise<any> {
-  const resp = await fetch('/api/sync/invites/create', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  const { text, payload: data } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(data) || text || 'request failed');
-  return data;
+	const resp = await fetch("/api/sync/invites/create", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
 }
 
 export async function importCoordinatorInvite(invite: string): Promise<any> {
-  const resp = await fetch('/api/sync/invites/import', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ invite }),
-  });
-  const { text, payload: data } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(data) || text || 'request failed');
-  return data;
+	const resp = await fetch("/api/sync/invites/import", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ invite }),
+	});
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
 }
 
-export async function reviewJoinRequest(requestId: string, action: 'approve' | 'deny'): Promise<any> {
-  const resp = await fetch('/api/sync/join-requests/review', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ request_id: requestId, action }),
-  });
-  const { text, payload: data } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(data) || text || 'request failed');
-  return data;
+export async function reviewJoinRequest(
+	requestId: string,
+	action: "approve" | "deny",
+): Promise<any> {
+	const resp = await fetch("/api/sync/join-requests/review", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ request_id: requestId, action }),
+	});
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
 }
 
 export async function loadSyncActors(): Promise<any> {
-  return fetchJson('/api/sync/actors');
+	return fetchJson("/api/sync/actors");
 }
 
 export async function loadPairing(): Promise<any> {
-  return fetchJson('/api/sync/pairing?includeDiagnostics=1');
+	return fetchJson("/api/sync/pairing?includeDiagnostics=1");
 }
 
 export async function updatePeerScope(
-  peerDeviceId: string,
-  include: string[] | null,
-  exclude: string[] | null,
-  inheritGlobal = false,
+	peerDeviceId: string,
+	include: string[] | null,
+	exclude: string[] | null,
+	inheritGlobal = false,
 ): Promise<any> {
-  const resp = await fetch('/api/sync/peers/scope', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      peer_device_id: peerDeviceId,
-      include,
-      exclude,
-      inherit_global: inheritGlobal,
-    }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) {
-    throw new Error(payloadError(payload) || text || 'request failed');
-  }
-  return payload;
+	const resp = await fetch("/api/sync/peers/scope", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			peer_device_id: peerDeviceId,
+			include,
+			exclude,
+			inherit_global: inheritGlobal,
+		}),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) {
+		throw new Error(payloadError(payload) || text || "request failed");
+	}
+	return payload;
 }
 
-export async function updatePeerIdentity(peerDeviceId: string, claimedLocalActor: boolean): Promise<any> {
-  const resp = await fetch('/api/sync/peers/identity', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      peer_device_id: peerDeviceId,
-      claimed_local_actor: claimedLocalActor,
-    }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+export async function updatePeerIdentity(
+	peerDeviceId: string,
+	claimedLocalActor: boolean,
+): Promise<any> {
+	const resp = await fetch("/api/sync/peers/identity", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			peer_device_id: peerDeviceId,
+			claimed_local_actor: claimedLocalActor,
+		}),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function assignPeerActor(peerDeviceId: string, actorId: string | null): Promise<any> {
-  const resp = await fetch('/api/sync/peers/identity', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      peer_device_id: peerDeviceId,
-      actor_id: actorId,
-    }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+	const resp = await fetch("/api/sync/peers/identity", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			peer_device_id: peerDeviceId,
+			actor_id: actorId,
+		}),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function deletePeer(peerDeviceId: string): Promise<any> {
-  const resp = await fetch(`/api/sync/peers/${encodeURIComponent(peerDeviceId)}`, {
-    method: 'DELETE',
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+	const resp = await fetch(`/api/sync/peers/${encodeURIComponent(peerDeviceId)}`, {
+		method: "DELETE",
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function renamePeer(peerDeviceId: string, name: string): Promise<any> {
-  const resp = await fetch('/api/sync/peers/rename', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      peer_device_id: peerDeviceId,
-      name,
-    }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+	const resp = await fetch("/api/sync/peers/rename", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			peer_device_id: peerDeviceId,
+			name,
+		}),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
-export async function acceptDiscoveredPeer(peerDeviceId: string, fingerprint: string): Promise<any> {
-  const resp = await fetch('/api/sync/peers/accept-discovered', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      peer_device_id: peerDeviceId,
-      fingerprint,
-    }),
-  });
-  const text = await resp.text();
-  let payload: any = {};
-  try {
-    payload = text ? JSON.parse(text) : {};
-  } catch {
-    payload = {};
-  }
-  const detail = typeof payload?.detail === 'string' ? payload.detail : undefined;
-  if (!resp.ok) throw new Error(detail || payloadError(payload) || text || 'request failed');
-  return payload;
+export async function acceptDiscoveredPeer(
+	peerDeviceId: string,
+	fingerprint: string,
+): Promise<any> {
+	const resp = await fetch("/api/sync/peers/accept-discovered", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			peer_device_id: peerDeviceId,
+			fingerprint,
+		}),
+	});
+	const text = await resp.text();
+	let payload: any = {};
+	try {
+		payload = text ? JSON.parse(text) : {};
+	} catch {
+		payload = {};
+	}
+	const detail = typeof payload?.detail === "string" ? payload.detail : undefined;
+	if (!resp.ok) throw new Error(detail || payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function createActor(displayName: string): Promise<any> {
-  const resp = await fetch('/api/sync/actors', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ display_name: displayName }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+	const resp = await fetch("/api/sync/actors", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ display_name: displayName }),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function renameActor(actorId: string, displayName: string): Promise<any> {
-  const resp = await fetch('/api/sync/actors/rename', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ actor_id: actorId, display_name: displayName }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+	const resp = await fetch("/api/sync/actors/rename", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ actor_id: actorId, display_name: displayName }),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function mergeActor(primaryActorId: string, secondaryActorId: string): Promise<any> {
-  const resp = await fetch('/api/sync/actors/merge', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      primary_actor_id: primaryActorId,
-      secondary_actor_id: secondaryActorId,
-    }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+	const resp = await fetch("/api/sync/actors/merge", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({
+			primary_actor_id: primaryActorId,
+			secondary_actor_id: secondaryActorId,
+		}),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function deactivateActor(actorId: string): Promise<any> {
-  const resp = await fetch('/api/sync/actors/deactivate', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ actor_id: actorId }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+	const resp = await fetch("/api/sync/actors/deactivate", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ actor_id: actorId }),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function claimLegacyDeviceIdentity(originDeviceId: string): Promise<any> {
-  const resp = await fetch('/api/sync/legacy-devices/claim', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ origin_device_id: originDeviceId }),
-  });
-  const { text, payload } = await readJsonPayload(resp);
-  if (!resp.ok) throw new Error(payloadError(payload) || text || 'request failed');
-  return payload;
+	const resp = await fetch("/api/sync/legacy-devices/claim", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ origin_device_id: originDeviceId }),
+	});
+	const { text, payload } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
 }
 
 export async function loadProjects(): Promise<string[]> {
-  const payload = await fetchJson<{ projects?: string[] }>('/api/projects');
-  return payload.projects || [];
+	const payload = await fetchJson<{ projects?: string[] }>("/api/projects");
+	return payload.projects || [];
 }
 
 export async function triggerSync(address?: string): Promise<SyncRunResponse> {
-  const payload = address ? { address } : {};
-  const resp = await fetch('/api/sync/run', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  const { text, payload: body } = await readJsonPayload<SyncRunResponse>(resp);
-  if (!resp.ok) throw new Error(payloadError(body) || text || 'request failed');
-  if (!text) throw new Error('empty sync response');
-  if (!Array.isArray(body?.items)) throw new Error(text || 'invalid sync response');
-  return body;
+	const payload = address ? { address } : {};
+	const resp = await fetch("/api/sync/run", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+	const { text, payload: body } = await readJsonPayload<SyncRunResponse>(resp);
+	if (!resp.ok) throw new Error(payloadError(body) || text || "request failed");
+	if (!text) throw new Error("empty sync response");
+	if (!Array.isArray(body?.items)) throw new Error(text || "invalid sync response");
+	return body;
 }

--- a/packages/ui/src/lib/dom.ts
+++ b/packages/ui/src/lib/dom.ts
@@ -1,70 +1,70 @@
 /* DOM utility helpers — thin wrappers for vanilla element creation. */
 
 export function el(tag: string, className?: string | null, text?: any): HTMLElement {
-  const node = document.createElement(tag);
-  if (className) node.className = className;
-  if (text !== undefined && text !== null) node.textContent = String(text);
-  return node;
+	const node = document.createElement(tag);
+	if (className) node.className = className;
+	if (text !== undefined && text !== null) node.textContent = String(text);
+	return node;
 }
 
 export function $(id: string): HTMLElement | null {
-  return document.getElementById(id);
+	return document.getElementById(id);
 }
 
 export function $input(id: string): HTMLInputElement | null {
-  return document.getElementById(id) as HTMLInputElement | null;
+	return document.getElementById(id) as HTMLInputElement | null;
 }
 
 export function $select(id: string): HTMLSelectElement | null {
-  return document.getElementById(id) as HTMLSelectElement | null;
+	return document.getElementById(id) as HTMLSelectElement | null;
 }
 
 export function $button(id: string): HTMLButtonElement | null {
-  return document.getElementById(id) as HTMLButtonElement | null;
+	return document.getElementById(id) as HTMLButtonElement | null;
 }
 
 export function hide(element: HTMLElement | null) {
-  if (element) element.hidden = true;
+	if (element) element.hidden = true;
 }
 
 export function show(element: HTMLElement | null) {
-  if (element) element.hidden = false;
+	if (element) element.hidden = false;
 }
 
 export function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
 }
 
 export function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function highlightText(text: string, query: string): string {
-  const q = query.trim();
-  if (!q) return escapeHtml(text);
-  const safe = escapeHtml(text);
-  try {
-    const re = new RegExp(`(${escapeRegExp(q)})`, 'ig');
-    return safe.replace(re, '<mark class="match">$1</mark>');
-  } catch {
-    return safe;
-  }
+	const q = query.trim();
+	if (!q) return escapeHtml(text);
+	const safe = escapeHtml(text);
+	try {
+		const re = new RegExp(`(${escapeRegExp(q)})`, "ig");
+		return safe.replace(re, '<mark class="match">$1</mark>');
+	} catch {
+		return safe;
+	}
 }
 
 export async function copyToClipboard(text: string, button: HTMLButtonElement) {
-  const prev = button.textContent;
-  try {
-    await navigator.clipboard.writeText(text);
-    button.textContent = 'Copied';
-  } catch {
-    button.textContent = 'Copy failed';
-  }
-  setTimeout(() => {
-    button.textContent = prev || 'Copy';
-  }, 1200);
+	const prev = button.textContent;
+	try {
+		await navigator.clipboard.writeText(text);
+		button.textContent = "Copied";
+	} catch {
+		button.textContent = "Copy failed";
+	}
+	setTimeout(() => {
+		button.textContent = prev || "Copy";
+	}, 1200);
 }

--- a/packages/ui/src/lib/form.ts
+++ b/packages/ui/src/lib/form.ts
@@ -1,39 +1,41 @@
 /* Form validation and async-action helpers. */
 
 export function shakeField(input: HTMLElement): void {
-  input.classList.add('sync-shake');
-  input.addEventListener('animationend', () => input.classList.remove('sync-shake'), { once: true });
+	input.classList.add("sync-shake");
+	input.addEventListener("animationend", () => input.classList.remove("sync-shake"), {
+		once: true,
+	});
 }
 
 export function markFieldError(
-  input: HTMLInputElement | HTMLTextAreaElement,
-  message: string,
+	input: HTMLInputElement | HTMLTextAreaElement,
+	message: string,
 ): boolean {
-  input.classList.add('sync-field-error');
-  const existing = input.parentElement?.querySelector('.sync-field-hint');
-  if (existing) existing.remove();
-  const hint = document.createElement('div');
-  hint.className = 'sync-field-hint';
-  hint.textContent = message;
-  input.insertAdjacentElement('afterend', hint);
-  shakeField(input);
-  input.addEventListener('input', () => clearFieldError(input), { once: true });
-  return false;
+	input.classList.add("sync-field-error");
+	const existing = input.parentElement?.querySelector(".sync-field-hint");
+	if (existing) existing.remove();
+	const hint = document.createElement("div");
+	hint.className = "sync-field-hint";
+	hint.textContent = message;
+	input.insertAdjacentElement("afterend", hint);
+	shakeField(input);
+	input.addEventListener("input", () => clearFieldError(input), { once: true });
+	return false;
 }
 
 export function clearFieldError(input: HTMLInputElement | HTMLTextAreaElement): void {
-  input.classList.remove('sync-field-error');
-  const hint = input.parentElement?.querySelector('.sync-field-hint');
-  if (hint) hint.remove();
+	input.classList.remove("sync-field-error");
+	const hint = input.parentElement?.querySelector(".sync-field-hint");
+	if (hint) hint.remove();
 }
 
 export function friendlyError(error: unknown, fallback: string): string {
-  if (error instanceof Error) {
-    const msg = error.message;
-    if (msg.includes('fetch') || msg.includes('network') || msg.includes('Failed to fetch')) {
-      return 'Network error \u2014 check your connection and try again.';
-    }
-    return msg;
-  }
-  return fallback;
+	if (error instanceof Error) {
+		const msg = error.message;
+		if (msg.includes("fetch") || msg.includes("network") || msg.includes("Failed to fetch")) {
+			return "Network error \u2014 check your connection and try again.";
+		}
+		return msg;
+	}
+	return fallback;
 }

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -1,131 +1,134 @@
 /* Formatting utilities — dates, numbers, text normalization. */
 
 export function formatDate(value: any): string {
-  if (!value) return 'n/a';
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+	if (!value) return "n/a";
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
 }
 
 export function formatTimestamp(value: any): string {
-  if (!value) return 'never';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return String(value);
-  return date.toLocaleString();
+	if (!value) return "never";
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return String(value);
+	return date.toLocaleString();
 }
 
 export function formatRelativeTime(value: any): string {
-  if (!value) return 'n/a';
-  const date = new Date(value);
-  const ms = date.getTime();
-  if (Number.isNaN(ms)) return String(value);
-  const diff = Date.now() - ms;
-  const seconds = Math.round(diff / 1000);
-  if (seconds < 10) return 'just now';
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  if (days < 14) return `${days}d ago`;
-  return date.toLocaleDateString();
+	if (!value) return "n/a";
+	const date = new Date(value);
+	const ms = date.getTime();
+	if (Number.isNaN(ms)) return String(value);
+	const diff = Date.now() - ms;
+	const seconds = Math.round(diff / 1000);
+	if (seconds < 10) return "just now";
+	if (seconds < 60) return `${seconds}s ago`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.round(hours / 24);
+	if (days < 14) return `${days}d ago`;
+	return date.toLocaleDateString();
 }
 
 export function secondsSince(value: any): number | null {
-  if (!value) return null;
-  const ts = new Date(value).getTime();
-  if (!Number.isFinite(ts)) return null;
-  const delta = Math.floor((Date.now() - ts) / 1e3);
-  return delta >= 0 ? delta : 0;
+	if (!value) return null;
+	const ts = new Date(value).getTime();
+	if (!Number.isFinite(ts)) return null;
+	const delta = Math.floor((Date.now() - ts) / 1e3);
+	return delta >= 0 ? delta : 0;
 }
 
 export function formatAgeShort(seconds: number | null): string {
-  if (seconds === null || seconds === undefined) return 'n/a';
-  if (seconds < 60) return `${seconds}s`;
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
-  return `${Math.floor(seconds / 86400)}d`;
+	if (seconds === null || seconds === undefined) return "n/a";
+	if (seconds < 60) return `${seconds}s`;
+	if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+	if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+	return `${Math.floor(seconds / 86400)}d`;
 }
 
 export function formatPercent(value: any): string {
-  const num = Number(value);
-  if (!Number.isFinite(num)) return 'n/a';
-  return `${Math.round(num * 100)}%`;
+	const num = Number(value);
+	if (!Number.isFinite(num)) return "n/a";
+	return `${Math.round(num * 100)}%`;
 }
 
 export function formatMultiplier(saved: any, read: any): string {
-  const savedNum = Number(saved || 0);
-  const readNum = Number(read || 0);
-  if (!Number.isFinite(savedNum) || !Number.isFinite(readNum) || readNum <= 0) return 'n/a';
-  const factor = (savedNum + readNum) / readNum;
-  if (!Number.isFinite(factor) || factor <= 0) return 'n/a';
-  return `${factor.toFixed(factor >= 10 ? 0 : 1)}x`;
+	const savedNum = Number(saved || 0);
+	const readNum = Number(read || 0);
+	if (!Number.isFinite(savedNum) || !Number.isFinite(readNum) || readNum <= 0) return "n/a";
+	const factor = (savedNum + readNum) / readNum;
+	if (!Number.isFinite(factor) || factor <= 0) return "n/a";
+	return `${factor.toFixed(factor >= 10 ? 0 : 1)}x`;
 }
 
 export function formatReductionPercent(saved: any, read: any): string {
-  const savedNum = Number(saved || 0);
-  const readNum = Number(read || 0);
-  if (!Number.isFinite(savedNum) || !Number.isFinite(readNum)) return 'n/a';
-  const total = savedNum + readNum;
-  if (total <= 0) return 'n/a';
-  const pct = savedNum / total;
-  if (!Number.isFinite(pct)) return 'n/a';
-  return `${Math.round(pct * 100)}%`;
+	const savedNum = Number(saved || 0);
+	const readNum = Number(read || 0);
+	if (!Number.isFinite(savedNum) || !Number.isFinite(readNum)) return "n/a";
+	const total = savedNum + readNum;
+	if (total <= 0) return "n/a";
+	const pct = savedNum / total;
+	if (!Number.isFinite(pct)) return "n/a";
+	return `${Math.round(pct * 100)}%`;
 }
 
 export function parsePercentValue(label: any): number | null {
-  const text = String(label || '').trim();
-  if (!text.endsWith('%')) return null;
-  const raw = Number(text.replace('%', ''));
-  if (!Number.isFinite(raw)) return null;
-  return raw;
+	const text = String(label || "").trim();
+	if (!text.endsWith("%")) return null;
+	const raw = Number(text.replace("%", ""));
+	if (!Number.isFinite(raw)) return null;
+	return raw;
 }
 
 export function normalize(text: any): string {
-  return String(text || '').replace(/\s+/g, ' ').trim().toLowerCase();
+	return String(text || "")
+		.replace(/\s+/g, " ")
+		.trim()
+		.toLowerCase();
 }
 
 export function parseJsonArray(value: any): any[] {
-  if (!value) return [];
-  if (Array.isArray(value)) return value;
-  if (typeof value === 'string') {
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  }
-  return [];
+	if (!value) return [];
+	if (Array.isArray(value)) return value;
+	if (typeof value === "string") {
+		try {
+			const parsed = JSON.parse(value);
+			return Array.isArray(parsed) ? parsed : [];
+		} catch {
+			return [];
+		}
+	}
+	return [];
 }
 
 export function titleCase(value: any): string {
-  const text = String(value || '').trim();
-  if (!text) return 'Unknown';
-  return text.charAt(0).toUpperCase() + text.slice(1);
+	const text = String(value || "").trim();
+	if (!text) return "Unknown";
+	return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
 export function toTitleLabel(value: string): string {
-  return value
-    .replace(/_/g, ' ')
-    .split(' ')
-    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
-    .join(' ')
-    .trim();
+	return value
+		.replace(/_/g, " ")
+		.split(" ")
+		.map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+		.join(" ")
+		.trim();
 }
 
 export function formatFileList(files: any[], limit = 2): string {
-  if (!files.length) return '';
-  const trimmed = files.map((f) => String(f).trim()).filter(Boolean);
-  const slice = trimmed.slice(0, limit);
-  const suffix = trimmed.length > limit ? ` +${trimmed.length - limit}` : '';
-  return `${slice.join(', ')}${suffix}`.trim();
+	if (!files.length) return "";
+	const trimmed = files.map((f) => String(f).trim()).filter(Boolean);
+	const slice = trimmed.slice(0, limit);
+	const suffix = trimmed.length > limit ? ` +${trimmed.length - limit}` : "";
+	return `${slice.join(", ")}${suffix}`.trim();
 }
 
 export function formatTagLabel(tag: any): string {
-  if (!tag) return '';
-  const trimmed = String(tag).trim();
-  const colonIndex = trimmed.indexOf(':');
-  if (colonIndex === -1) return trimmed;
-  return trimmed.slice(0, colonIndex).trim();
+	if (!tag) return "";
+	const trimmed = String(tag).trim();
+	const colonIndex = trimmed.indexOf(":");
+	if (colonIndex === -1) return trimmed;
+	return trimmed.slice(0, colonIndex).trim();
 }

--- a/packages/ui/src/lib/notice.ts
+++ b/packages/ui/src/lib/notice.ts
@@ -1,46 +1,46 @@
-import { $ } from './dom';
-import { state } from './state';
+import { $ } from "./dom";
+import { state } from "./state";
 
 let hideAbort: AbortController | null = null;
 
 export function hideGlobalNotice() {
-  const notice = $('globalNotice');
-  if (!notice) return;
-  if (state.noticeTimer) {
-    clearTimeout(state.noticeTimer);
-    state.noticeTimer = null;
-  }
-  // Cancel any previous hide listener before registering a new one
-  if (hideAbort) hideAbort.abort();
-  hideAbort = new AbortController();
-  notice.classList.add('hiding');
-  notice.addEventListener(
-    'animationend',
-    () => {
-      hideAbort = null;
-      notice.hidden = true;
-      notice.textContent = '';
-      notice.classList.remove('success', 'warning', 'hiding');
-    },
-    { once: true, signal: hideAbort.signal },
-  );
+	const notice = $("globalNotice");
+	if (!notice) return;
+	if (state.noticeTimer) {
+		clearTimeout(state.noticeTimer);
+		state.noticeTimer = null;
+	}
+	// Cancel any previous hide listener before registering a new one
+	if (hideAbort) hideAbort.abort();
+	hideAbort = new AbortController();
+	notice.classList.add("hiding");
+	notice.addEventListener(
+		"animationend",
+		() => {
+			hideAbort = null;
+			notice.hidden = true;
+			notice.textContent = "";
+			notice.classList.remove("success", "warning", "hiding");
+		},
+		{ once: true, signal: hideAbort.signal },
+	);
 }
 
-export function showGlobalNotice(message: string, type: 'success' | 'warning' = 'success') {
-  const notice = $('globalNotice');
-  if (!notice || !message) return;
-  // Cancel any in-progress hide animation so it can't kill this notice
-  if (hideAbort) {
-    hideAbort.abort();
-    hideAbort = null;
-  }
-  notice.classList.remove('hiding');
-  notice.textContent = message;
-  notice.classList.remove('success', 'warning');
-  notice.classList.add(type === 'warning' ? 'warning' : 'success');
-  notice.hidden = false;
-  if (state.noticeTimer) clearTimeout(state.noticeTimer);
-  state.noticeTimer = setTimeout(() => {
-    hideGlobalNotice();
-  }, 12_000);
+export function showGlobalNotice(message: string, type: "success" | "warning" = "success") {
+	const notice = $("globalNotice");
+	if (!notice || !message) return;
+	// Cancel any in-progress hide animation so it can't kill this notice
+	if (hideAbort) {
+		hideAbort.abort();
+		hideAbort = null;
+	}
+	notice.classList.remove("hiding");
+	notice.textContent = message;
+	notice.classList.remove("success", "warning");
+	notice.classList.add(type === "warning" ? "warning" : "success");
+	notice.hidden = false;
+	if (state.noticeTimer) clearTimeout(state.noticeTimer);
+	state.noticeTimer = setTimeout(() => {
+		hideGlobalNotice();
+	}, 12_000);
 }

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -1,166 +1,168 @@
 /* Global application state — shared across tabs. */
 
-export type RefreshState = 'idle' | 'refreshing' | 'paused' | 'error';
-export type TabId = 'feed' | 'health' | 'sync';
+export type RefreshState = "idle" | "refreshing" | "paused" | "error";
+export type TabId = "feed" | "health" | "sync";
 
-const TAB_KEY = 'codemem-tab';
-const FEED_FILTER_KEY = 'codemem-feed-filter';
-const FEED_SCOPE_KEY = 'codemem-feed-scope';
-const DETAILS_OPEN_KEY = 'codemem-details-open';
-const SYNC_DIAGNOSTICS_KEY = 'codemem-sync-diagnostics';
-const SYNC_PAIRING_KEY = 'codemem-sync-pairing';
-const SYNC_REDACT_KEY = 'codemem-sync-redact';
+const TAB_KEY = "codemem-tab";
+const FEED_FILTER_KEY = "codemem-feed-filter";
+const FEED_SCOPE_KEY = "codemem-feed-scope";
+const DETAILS_OPEN_KEY = "codemem-details-open";
+const SYNC_DIAGNOSTICS_KEY = "codemem-sync-diagnostics";
+const SYNC_PAIRING_KEY = "codemem-sync-pairing";
+const SYNC_REDACT_KEY = "codemem-sync-redact";
 
-export const FEED_FILTERS = ['all', 'observations', 'summaries'] as const;
+export const FEED_FILTERS = ["all", "observations", "summaries"] as const;
 export type FeedFilter = (typeof FEED_FILTERS)[number];
-export const FEED_SCOPES = ['all', 'mine', 'theirs'] as const;
+export const FEED_SCOPES = ["all", "mine", "theirs"] as const;
 export type FeedScope = (typeof FEED_SCOPES)[number];
 
 /* ── Mutable application state ─────────────────────────────── */
 
 export const state = {
-  /* Tab */
-  activeTab: 'feed' as TabId,
+	/* Tab */
+	activeTab: "feed" as TabId,
 
-  /* Project filter */
-  currentProject: '',
+	/* Project filter */
+	currentProject: "",
 
-  /* Refresh */
-  refreshState: 'idle' as RefreshState,
-  refreshInFlight: false,
-  refreshQueued: false,
-  refreshTimer: null as ReturnType<typeof setInterval> | null,
+	/* Refresh */
+	refreshState: "idle" as RefreshState,
+	refreshInFlight: false,
+	refreshQueued: false,
+	refreshTimer: null as ReturnType<typeof setInterval> | null,
 
-  /* Feed */
-  feedTypeFilter: 'all' as FeedFilter,
-  feedScopeFilter: 'all' as FeedScope,
-  feedQuery: '',
-  lastFeedItems: [] as any[],
-  lastFeedFilteredCount: 0,
-  lastFeedSignature: '',
-  pendingFeedItems: null as any[] | null,
+	/* Feed */
+	feedTypeFilter: "all" as FeedFilter,
+	feedScopeFilter: "all" as FeedScope,
+	feedQuery: "",
+	lastFeedItems: [] as any[],
+	lastFeedFilteredCount: 0,
+	lastFeedSignature: "",
+	pendingFeedItems: null as any[] | null,
 
-  /* Feed item view state */
-  itemViewState: new Map<string, string>(),
-  itemExpandState: new Map<string, boolean>(),
-  newItemKeys: new Set<string>(),
+	/* Feed item view state */
+	itemViewState: new Map<string, string>(),
+	itemExpandState: new Map<string, boolean>(),
+	newItemKeys: new Set<string>(),
 
-  /* Cached payloads */
-  lastStatsPayload: null as any,
-  lastUsagePayload: null as any,
-  lastRawEventsPayload: null as any,
-  lastSyncStatus: null as any,
-  lastSyncActors: [] as any[],
-  lastSyncPeers: [] as any[],
-  pendingAcceptedSyncPeers: [] as any[],
-  lastSyncSharingReview: [] as any[],
-  lastSyncCoordinator: null as any,
-  lastSyncJoinRequests: [] as any[],
-  lastTeamInvite: null as any,
-  lastTeamJoin: null as any,
-  syncJoinFlowFeedback: null as { message: string; tone: 'success' | 'warning' } | null,
-  syncPeerFeedbackById: new Map<string, { message: string; tone: 'success' | 'warning' }>(),
-  syncPeersSectionFeedback: null as { message: string; tone: 'success' | 'warning' } | null,
-  syncJoinRequestsFeedback: null as { message: string; tone: 'success' | 'warning' } | null,
-  syncDiscoveredFeedback: null as { message: string; tone: 'success' | 'warning' } | null,
-  lastSyncAttempts: [] as any[],
-  lastSyncLegacyDevices: [] as any[],
-  lastSyncViewModel: null as any,
-  lastSyncDuplicatePersonDecisions: {} as Record<string, string>,
-  pairingPayloadRaw: null as any,
-  pairingCommandRaw: '',
+	/* Cached payloads */
+	lastStatsPayload: null as any,
+	lastUsagePayload: null as any,
+	lastRawEventsPayload: null as any,
+	lastSyncStatus: null as any,
+	lastSyncActors: [] as any[],
+	lastSyncPeers: [] as any[],
+	pendingAcceptedSyncPeers: [] as any[],
+	lastSyncSharingReview: [] as any[],
+	lastSyncCoordinator: null as any,
+	lastSyncJoinRequests: [] as any[],
+	lastTeamInvite: null as any,
+	lastTeamJoin: null as any,
+	syncJoinFlowFeedback: null as { message: string; tone: "success" | "warning" } | null,
+	syncPeerFeedbackById: new Map<string, { message: string; tone: "success" | "warning" }>(),
+	syncPeersSectionFeedback: null as { message: string; tone: "success" | "warning" } | null,
+	syncJoinRequestsFeedback: null as { message: string; tone: "success" | "warning" } | null,
+	syncDiscoveredFeedback: null as { message: string; tone: "success" | "warning" } | null,
+	lastSyncAttempts: [] as any[],
+	lastSyncLegacyDevices: [] as any[],
+	lastSyncViewModel: null as any,
+	lastSyncDuplicatePersonDecisions: {} as Record<string, string>,
+	pairingPayloadRaw: null as any,
+	pairingCommandRaw: "",
 
-  /* Config */
-  configDefaults: {} as Record<string, any>,
-  configPath: '',
-  settingsDirty: false,
-  noticeTimer: null as ReturnType<typeof setTimeout> | null,
+	/* Config */
+	configDefaults: {} as Record<string, any>,
+	configPath: "",
+	settingsDirty: false,
+	noticeTimer: null as ReturnType<typeof setTimeout> | null,
 
-  /* Sync UI toggles */
-  syncDiagnosticsOpen: false,
-  syncPairingOpen: false,
+	/* Sync UI toggles */
+	syncDiagnosticsOpen: false,
+	syncPairingOpen: false,
 };
 
 /* ── Persistence helpers ───────────────────────────────────── */
 
 export function getActiveTab(): TabId {
-  const hash = window.location.hash.replace('#', '') as TabId;
-  if (['feed', 'health', 'sync'].includes(hash)) return hash;
-  const saved = localStorage.getItem(TAB_KEY);
-  if (saved && ['feed', 'health', 'sync'].includes(saved)) return saved as TabId;
-  return 'feed';
+	const hash = window.location.hash.replace("#", "") as TabId;
+	if (["feed", "health", "sync"].includes(hash)) return hash;
+	const saved = localStorage.getItem(TAB_KEY);
+	if (saved && ["feed", "health", "sync"].includes(saved)) return saved as TabId;
+	return "feed";
 }
 
 export function setActiveTab(tab: TabId) {
-  state.activeTab = tab;
-  window.location.hash = tab;
-  localStorage.setItem(TAB_KEY, tab);
+	state.activeTab = tab;
+	window.location.hash = tab;
+	localStorage.setItem(TAB_KEY, tab);
 }
 
 export function getFeedTypeFilter(): FeedFilter {
-  const saved = localStorage.getItem(FEED_FILTER_KEY) || 'all';
-  return FEED_FILTERS.includes(saved as FeedFilter) ? (saved as FeedFilter) : 'all';
+	const saved = localStorage.getItem(FEED_FILTER_KEY) || "all";
+	return FEED_FILTERS.includes(saved as FeedFilter) ? (saved as FeedFilter) : "all";
 }
 
 export function getFeedScopeFilter(): FeedScope {
-  const saved = localStorage.getItem(FEED_SCOPE_KEY) || 'all';
-  return FEED_SCOPES.includes(saved as FeedScope) ? (saved as FeedScope) : 'all';
+	const saved = localStorage.getItem(FEED_SCOPE_KEY) || "all";
+	return FEED_SCOPES.includes(saved as FeedScope) ? (saved as FeedScope) : "all";
 }
 
 export function setFeedTypeFilter(value: string) {
-  state.feedTypeFilter = FEED_FILTERS.includes(value as FeedFilter) ? (value as FeedFilter) : 'all';
-  localStorage.setItem(FEED_FILTER_KEY, state.feedTypeFilter);
+	state.feedTypeFilter = FEED_FILTERS.includes(value as FeedFilter) ? (value as FeedFilter) : "all";
+	localStorage.setItem(FEED_FILTER_KEY, state.feedTypeFilter);
 }
 
 export function setFeedScopeFilter(value: string) {
-  state.feedScopeFilter = FEED_SCOPES.includes(value as FeedScope) ? (value as FeedScope) : 'all';
-  localStorage.setItem(FEED_SCOPE_KEY, state.feedScopeFilter);
+	state.feedScopeFilter = FEED_SCOPES.includes(value as FeedScope) ? (value as FeedScope) : "all";
+	localStorage.setItem(FEED_SCOPE_KEY, state.feedScopeFilter);
 }
 
 export function isSyncDiagnosticsOpen(): boolean {
-  return localStorage.getItem(SYNC_DIAGNOSTICS_KEY) === '1';
+	return localStorage.getItem(SYNC_DIAGNOSTICS_KEY) === "1";
 }
 
 export function setSyncDiagnosticsOpen(open: boolean) {
-  state.syncDiagnosticsOpen = open;
-  localStorage.setItem(SYNC_DIAGNOSTICS_KEY, open ? '1' : '0');
+	state.syncDiagnosticsOpen = open;
+	localStorage.setItem(SYNC_DIAGNOSTICS_KEY, open ? "1" : "0");
 }
 
 export function isSyncPairingOpen(): boolean {
-  return state.syncPairingOpen;
+	return state.syncPairingOpen;
 }
 
 export function setSyncPairingOpen(open: boolean) {
-  state.syncPairingOpen = open;
-  try { localStorage.setItem(SYNC_PAIRING_KEY, open ? '1' : '0'); } catch {}
+	state.syncPairingOpen = open;
+	try {
+		localStorage.setItem(SYNC_PAIRING_KEY, open ? "1" : "0");
+	} catch {}
 }
 
 export function isSyncRedactionEnabled(): boolean {
-  return localStorage.getItem(SYNC_REDACT_KEY) !== '0';
+	return localStorage.getItem(SYNC_REDACT_KEY) !== "0";
 }
 
 export function setSyncRedactionEnabled(enabled: boolean) {
-  localStorage.setItem(SYNC_REDACT_KEY, enabled ? '1' : '0');
+	localStorage.setItem(SYNC_REDACT_KEY, enabled ? "1" : "0");
 }
 
 export function isDetailsOpen(): boolean {
-  return localStorage.getItem(DETAILS_OPEN_KEY) === '1';
+	return localStorage.getItem(DETAILS_OPEN_KEY) === "1";
 }
 
 export function setDetailsOpen(open: boolean) {
-  localStorage.setItem(DETAILS_OPEN_KEY, open ? '1' : '0');
+	localStorage.setItem(DETAILS_OPEN_KEY, open ? "1" : "0");
 }
 
 /* ── Init from storage ─────────────────────────────────────── */
 
 export function initState() {
-  state.activeTab = getActiveTab();
-  state.feedTypeFilter = getFeedTypeFilter();
-  state.feedScopeFilter = getFeedScopeFilter();
-  state.syncDiagnosticsOpen = isSyncDiagnosticsOpen();
-  try {
-    state.syncPairingOpen = localStorage.getItem(SYNC_PAIRING_KEY) === '1';
-  } catch {
-    state.syncPairingOpen = false;
-  }
+	state.activeTab = getActiveTab();
+	state.feedTypeFilter = getFeedTypeFilter();
+	state.feedScopeFilter = getFeedScopeFilter();
+	state.syncDiagnosticsOpen = isSyncDiagnosticsOpen();
+	try {
+		state.syncPairingOpen = localStorage.getItem(SYNC_PAIRING_KEY) === "1";
+	} catch {
+		state.syncPairingOpen = false;
+	}
 }

--- a/packages/ui/src/lib/theme.ts
+++ b/packages/ui/src/lib/theme.ts
@@ -1,54 +1,54 @@
 /* Theme management — light/dark/variant switching. */
 
 export type ThemeOption = {
-  id: string;
-  label: string;
-  mode: 'light' | 'dark';
+	id: string;
+	label: string;
+	mode: "light" | "dark";
 };
 
 export const THEME_OPTIONS: ThemeOption[] = [
-  { id: 'light', label: 'Light', mode: 'light' },
-  { id: 'dark', label: 'Dark', mode: 'dark' },
+	{ id: "light", label: "Light", mode: "light" },
+	{ id: "dark", label: "Dark", mode: "dark" },
 ];
 
-const THEME_STORAGE_KEY = 'codemem-theme';
+const THEME_STORAGE_KEY = "codemem-theme";
 
 function resolveTheme(themeId: string): ThemeOption {
-  const exact = THEME_OPTIONS.find((t) => t.id === themeId);
-  if (exact) return exact;
-  const fallback = themeId.startsWith('dark') ? 'dark' : 'light';
-  return THEME_OPTIONS.find((t) => t.id === fallback) || THEME_OPTIONS[0];
+	const exact = THEME_OPTIONS.find((t) => t.id === themeId);
+	if (exact) return exact;
+	const fallback = themeId.startsWith("dark") ? "dark" : "light";
+	return THEME_OPTIONS.find((t) => t.id === fallback) || THEME_OPTIONS[0];
 }
 
 export function getTheme(): string {
-  const saved = localStorage.getItem(THEME_STORAGE_KEY);
-  if (saved) return resolveTheme(saved).id;
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+	const saved = localStorage.getItem(THEME_STORAGE_KEY);
+	if (saved) return resolveTheme(saved).id;
+	return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
 export function setTheme(theme: string) {
-  const selected = resolveTheme(theme);
-  document.documentElement.setAttribute('data-theme', selected.mode);
-  document.documentElement.setAttribute('data-color-mode', selected.mode);
-  if (selected.id === selected.mode) {
-    document.documentElement.removeAttribute('data-theme-variant');
-  } else {
-    document.documentElement.setAttribute('data-theme-variant', selected.id);
-  }
-  localStorage.setItem(THEME_STORAGE_KEY, selected.id);
+	const selected = resolveTheme(theme);
+	document.documentElement.setAttribute("data-theme", selected.mode);
+	document.documentElement.setAttribute("data-color-mode", selected.mode);
+	if (selected.id === selected.mode) {
+		document.documentElement.removeAttribute("data-theme-variant");
+	} else {
+		document.documentElement.setAttribute("data-theme-variant", selected.id);
+	}
+	localStorage.setItem(THEME_STORAGE_KEY, selected.id);
 }
 
 export function initThemeSelect(select: HTMLSelectElement | null) {
-  if (!select) return;
-  select.textContent = '';
-  THEME_OPTIONS.forEach((theme) => {
-    const option = document.createElement('option');
-    option.value = theme.id;
-    option.textContent = theme.label;
-    select.appendChild(option);
-  });
-  select.value = getTheme();
-  select.addEventListener('change', () => {
-    setTheme(select.value || 'dark');
-  });
+	if (!select) return;
+	select.textContent = "";
+	THEME_OPTIONS.forEach((theme) => {
+		const option = document.createElement("option");
+		option.value = theme.id;
+		option.textContent = theme.label;
+		select.appendChild(option);
+	});
+	select.value = getTheme();
+	select.addEventListener("change", () => {
+		setTheme(select.value || "dark");
+	});
 }

--- a/packages/ui/src/tabs/feed.test.ts
+++ b/packages/ui/src/tabs/feed.test.ts
@@ -1,59 +1,59 @@
-import { describe, expect, it } from 'vitest';
-import { observationViewData } from './feed';
+import { describe, expect, it } from "vitest";
+import { observationViewData } from "./feed";
 
-describe('observationViewData', () => {
-  it('uses subtitle as summary and narrative as full text when both exist', () => {
-    const data = observationViewData({
-      subtitle: 'Short skim line',
-      narrative: 'Longer narrative explaining the change in detail.',
-      body_text: 'Legacy body text fallback',
-      facts: ['One fact'],
-      metadata_json: {},
-    });
+describe("observationViewData", () => {
+	it("uses subtitle as summary and narrative as full text when both exist", () => {
+		const data = observationViewData({
+			subtitle: "Short skim line",
+			narrative: "Longer narrative explaining the change in detail.",
+			body_text: "Legacy body text fallback",
+			facts: ["One fact"],
+			metadata_json: {},
+		});
 
-    expect(data.summary).toBe('Short skim line');
-    expect(data.narrative).toBe('Longer narrative explaining the change in detail.');
-    expect(data.hasSummary).toBe(true);
-    expect(data.hasNarrative).toBe(true);
-  });
+		expect(data.summary).toBe("Short skim line");
+		expect(data.narrative).toBe("Longer narrative explaining the change in detail.");
+		expect(data.hasSummary).toBe(true);
+		expect(data.hasNarrative).toBe(true);
+	});
 
-  it('falls back to body_text as legacy narrative when structured narrative is missing', () => {
-    const data = observationViewData({
-      subtitle: null,
-      narrative: null,
-      body_text: 'Legacy body text still available as the full observation detail.',
-      facts: [],
-      metadata_json: {},
-    });
+	it("falls back to body_text as legacy narrative when structured narrative is missing", () => {
+		const data = observationViewData({
+			subtitle: null,
+			narrative: null,
+			body_text: "Legacy body text still available as the full observation detail.",
+			facts: [],
+			metadata_json: {},
+		});
 
-    expect(data.summary).toBe('');
-    expect(data.narrative).toBe('Legacy body text still available as the full observation detail.');
-    expect(data.hasSummary).toBe(false);
-    expect(data.hasNarrative).toBe(true);
-  });
+		expect(data.summary).toBe("");
+		expect(data.narrative).toBe("Legacy body text still available as the full observation detail.");
+		expect(data.hasSummary).toBe(false);
+		expect(data.hasNarrative).toBe(true);
+	});
 
-  it('does not treat identical subtitle and narrative as distinct narrative mode', () => {
-    const data = observationViewData({
-      subtitle: 'Same text',
-      narrative: 'Same text',
-      body_text: 'Same text',
-      facts: [],
-      metadata_json: {},
-    });
+	it("does not treat identical subtitle and narrative as distinct narrative mode", () => {
+		const data = observationViewData({
+			subtitle: "Same text",
+			narrative: "Same text",
+			body_text: "Same text",
+			facts: [],
+			metadata_json: {},
+		});
 
-    expect(data.hasSummary).toBe(true);
-    expect(data.hasNarrative).toBe(false);
-  });
+		expect(data.hasSummary).toBe(true);
+		expect(data.hasNarrative).toBe(false);
+	});
 
-  it('derives sentence facts from full narrative before skim summary', () => {
-    const data = observationViewData({
-      subtitle: 'Short skim line',
-      narrative: 'First full detail sentence. Second full detail sentence.',
-      body_text: 'Legacy body text fallback',
-      facts: [],
-      metadata_json: {},
-    });
+	it("derives sentence facts from full narrative before skim summary", () => {
+		const data = observationViewData({
+			subtitle: "Short skim line",
+			narrative: "First full detail sentence. Second full detail sentence.",
+			body_text: "Legacy body text fallback",
+			facts: [],
+			metadata_json: {},
+		});
 
-    expect(data.facts).toEqual(['First full detail sentence.', 'Second full detail sentence.']);
-  });
+		expect(data.facts).toEqual(["First full detail sentence.", "Second full detail sentence."]);
+	});
 });

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -1,83 +1,97 @@
 /* Feed tab — memory feed rendering, filtering, search. */
 
-import { Fragment, h, render, type ComponentChildren } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
-import { highlightText } from '../lib/dom';
+import { type ComponentChildren, Fragment, h, render } from "preact";
+import { useEffect, useState } from "preact/hooks";
+import * as api from "../lib/api";
+import { highlightText } from "../lib/dom";
 import {
-  formatDate,
-  formatFileList,
-  formatRelativeTime,
-  formatTagLabel,
-  normalize,
-  parseJsonArray,
-  toTitleLabel,
-} from '../lib/format';
-import { state, setFeedScopeFilter, setFeedTypeFilter } from '../lib/state';
-import * as api from '../lib/api';
-import { showGlobalNotice } from '../lib/notice';
+	formatDate,
+	formatFileList,
+	formatRelativeTime,
+	formatTagLabel,
+	normalize,
+	parseJsonArray,
+	toTitleLabel,
+} from "../lib/format";
+import { showGlobalNotice } from "../lib/notice";
+import { setFeedScopeFilter, setFeedTypeFilter, state } from "../lib/state";
 
 /* ── Helpers ─────────────────────────────────────────────── */
 
 function mergeMetadata(metadata: any): any {
-  if (!metadata || typeof metadata !== 'object') return {};
-  const importMeta = metadata.import_metadata;
-  if (importMeta && typeof importMeta === 'object') {
-    return { ...importMeta, ...metadata };
-  }
-  return metadata;
+	if (!metadata || typeof metadata !== "object") return {};
+	const importMeta = metadata.import_metadata;
+	if (importMeta && typeof importMeta === "object") {
+		return { ...importMeta, ...metadata };
+	}
+	return metadata;
 }
 
 function extractFactsFromBody(text: any): string[] {
-  if (!text) return [];
-  const lines = String(text).split('\n').map((l) => l.trim()).filter(Boolean);
-  const bullets = lines.filter((l) => /^[-*\u2022]\s+/.test(l) || /^\d+\./.test(l));
-  if (!bullets.length) return [];
-  return bullets.map((l) => l.replace(/^[-*\u2022]\s+/, '').replace(/^\d+\.\s+/, ''));
+	if (!text) return [];
+	const lines = String(text)
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean);
+	const bullets = lines.filter((l) => /^[-*\u2022]\s+/.test(l) || /^\d+\./.test(l));
+	if (!bullets.length) return [];
+	return bullets.map((l) => l.replace(/^[-*\u2022]\s+/, "").replace(/^\d+\.\s+/, ""));
 }
 
 function sentenceFacts(text: string, limit = 6): string[] {
-  const raw = String(text || '').trim();
-  if (!raw) return [];
-  const collapsed = raw.replace(/\s+/g, ' ').trim();
-  const parts = collapsed.split(/(?<=[.!?])\s+/).map((p) => p.trim()).filter(Boolean);
-  const facts: string[] = [];
-  for (const part of parts) {
-    if (part.length < 18) continue;
-    facts.push(part);
-    if (facts.length >= limit) break;
-  }
-  return facts;
+	const raw = String(text || "").trim();
+	if (!raw) return [];
+	const collapsed = raw.replace(/\s+/g, " ").trim();
+	const parts = collapsed
+		.split(/(?<=[.!?])\s+/)
+		.map((p) => p.trim())
+		.filter(Boolean);
+	const facts: string[] = [];
+	for (const part of parts) {
+		if (part.length < 18) continue;
+		facts.push(part);
+		if (facts.length >= limit) break;
+	}
+	return facts;
 }
 
 function isLowSignalObservation(item: any): boolean {
-  const title = normalize(item.title);
-  const body = normalize(item.body_text);
-  if (!title && !body) return true;
-  const combined = body || title;
-  if (combined.length < 10) return true;
-  if (title && body && title === body && combined.length < 40) return true;
-  const lead = title.charAt(0);
-  if ((lead === '\u2514' || lead === '\u203a') && combined.length < 40) return true;
-  if (title.startsWith('list ') && combined.length < 20) return true;
-  if (combined === 'ls' || combined === 'list ls') return true;
-  return false;
+	const title = normalize(item.title);
+	const body = normalize(item.body_text);
+	if (!title && !body) return true;
+	const combined = body || title;
+	if (combined.length < 10) return true;
+	if (title && body && title === body && combined.length < 40) return true;
+	const lead = title.charAt(0);
+	if ((lead === "\u2514" || lead === "\u203a") && combined.length < 40) return true;
+	if (title.startsWith("list ") && combined.length < 20) return true;
+	if (combined === "ls" || combined === "list ls") return true;
+	return false;
 }
 
 function itemSignature(item: any): string {
-  return String(item.id ?? item.memory_id ?? item.observation_id ?? item.session_id ?? item.created_at_utc ?? item.created_at ?? '');
+	return String(
+		item.id ??
+			item.memory_id ??
+			item.observation_id ??
+			item.session_id ??
+			item.created_at_utc ??
+			item.created_at ??
+			"",
+	);
 }
 
 function itemKey(item: any): string {
-  return `${String(item.kind || '').toLowerCase()}:${itemSignature(item)}`;
+	return `${String(item.kind || "").toLowerCase()}:${itemSignature(item)}`;
 }
 
-type ItemViewMode = 'summary' | 'facts' | 'narrative';
+type ItemViewMode = "summary" | "facts" | "narrative";
 
 const OBSERVATION_PAGE_SIZE = 20;
 const SUMMARY_PAGE_SIZE = 50;
 const FEED_SCROLL_THRESHOLD_PX = 560;
 
-let lastFeedProject = '';
+let lastFeedProject = "";
 let observationOffset = 0;
 let summaryOffset = 0;
 let observationHasMore = true;
@@ -85,1091 +99,1321 @@ let summaryHasMore = true;
 let loadMoreInFlight = false;
 let feedScrollHandlerBound = false;
 let feedProjectGeneration = 0;
-let lastFeedScope = 'all';
+let lastFeedScope = "all";
 
 function markFeedMount(mount: HTMLElement) {
-  mount.dataset.feedRenderRoot = 'preact';
+	mount.dataset.feedRenderRoot = "preact";
 }
 
 function ensureFeedRenderBoundary() {
-  const feedTab = document.getElementById('tab-feed');
-  if (!feedTab) return;
-  feedTab.dataset.feedRenderBoundary = 'preact-hybrid';
+	const feedTab = document.getElementById("tab-feed");
+	if (!feedTab) return;
+	feedTab.dataset.feedRenderBoundary = "preact-hybrid";
 }
 
 function renderIntoFeedMount(mount: HTMLElement, content: ComponentChildren) {
-  markFeedMount(mount);
-  render(content, mount);
+	markFeedMount(mount);
+	render(content, mount);
 }
 
 function feedScopeLabel(scope: string): string {
-  if (scope === 'mine') return ' · my memories';
-  if (scope === 'theirs') return ' · other people';
-  return '';
+	if (scope === "mine") return " · my memories";
+	if (scope === "theirs") return " · other people";
+	return "";
 }
 
-function ProvenanceChip({ label, variant = '' }: { label: string; variant?: string }) {
-  return h('span', { className: `provenance-chip ${variant}`.trim() }, label);
+function ProvenanceChip({ label, variant = "" }: { label: string; variant?: string }) {
+	return h("span", { className: `provenance-chip ${variant}`.trim() }, label);
 }
 
 function trustStateLabel(trustState: string): string {
-  if (trustState === 'legacy_unknown') return 'legacy provenance';
-  if (trustState === 'unreviewed') return 'unreviewed';
-  return trustState.replace(/_/g, ' ');
+	if (trustState === "legacy_unknown") return "legacy provenance";
+	if (trustState === "unreviewed") return "unreviewed";
+	return trustState.replace(/_/g, " ");
 }
 
 function authorLabel(item: any): string {
-  if (item?.owned_by_self === true) return 'You';
-  const actorId = String(item.actor_id || '').trim();
-  const actorName = String(item.actor_display_name || '').trim();
-  if (actorId && actorId === state.lastStatsPayload?.identity?.actor_id) return 'You';
-  return actorName || actorId || 'Unknown author';
+	if (item?.owned_by_self === true) return "You";
+	const actorId = String(item.actor_id || "").trim();
+	const actorName = String(item.actor_display_name || "").trim();
+	if (actorId && actorId === state.lastStatsPayload?.identity?.actor_id) return "You";
+	return actorName || actorId || "Unknown author";
 }
 
 function resetPagination(project: string) {
-  lastFeedProject = project;
-  lastFeedScope = state.feedScopeFilter;
-  feedProjectGeneration += 1;
-  observationOffset = 0;
-  summaryOffset = 0;
-  observationHasMore = true;
-  summaryHasMore = true;
-  state.lastFeedItems = [];
-  state.pendingFeedItems = null;
-  state.lastFeedFilteredCount = 0;
-  state.lastFeedSignature = '';
-  state.newItemKeys.clear();
-  state.itemViewState.clear();
-  state.itemExpandState.clear();
+	lastFeedProject = project;
+	lastFeedScope = state.feedScopeFilter;
+	feedProjectGeneration += 1;
+	observationOffset = 0;
+	summaryOffset = 0;
+	observationHasMore = true;
+	summaryHasMore = true;
+	state.lastFeedItems = [];
+	state.pendingFeedItems = null;
+	state.lastFeedFilteredCount = 0;
+	state.lastFeedSignature = "";
+	state.newItemKeys.clear();
+	state.itemViewState.clear();
+	state.itemExpandState.clear();
 }
 
 function isNearFeedBottom(): boolean {
-  const root = document.documentElement;
-  const height = Math.max(root.scrollHeight, document.body.scrollHeight);
-  return window.innerHeight + window.scrollY >= height - FEED_SCROLL_THRESHOLD_PX;
+	const root = document.documentElement;
+	const height = Math.max(root.scrollHeight, document.body.scrollHeight);
+	return window.innerHeight + window.scrollY >= height - FEED_SCROLL_THRESHOLD_PX;
 }
 
 function pageHasMore(payload: any, count: number, limit: number): boolean {
-  const value = payload?.pagination?.has_more;
-  if (typeof value === 'boolean') return value;
-  return count >= limit;
+	const value = payload?.pagination?.has_more;
+	if (typeof value === "boolean") return value;
+	return count >= limit;
 }
 
 function pageNextOffset(payload: any, count: number): number {
-  const value = payload?.pagination?.next_offset;
-  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) return value;
-  return count;
+	const value = payload?.pagination?.next_offset;
+	if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value;
+	return count;
 }
 
 function hasMorePages(): boolean {
-  return observationHasMore || summaryHasMore;
+	return observationHasMore || summaryHasMore;
 }
 
 function mergeFeedItems(currentItems: any[], incomingItems: any[]): any[] {
-  const byKey = new Map<string, any>();
-  currentItems.forEach((item) => byKey.set(itemKey(item), item));
-  incomingItems.forEach((item) => byKey.set(itemKey(item), item));
-  return Array.from(byKey.values()).sort((a, b) => {
-    return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
-  });
+	const byKey = new Map<string, any>();
+	currentItems.forEach((item) => {
+		byKey.set(itemKey(item), item);
+	});
+	incomingItems.forEach((item) => {
+		byKey.set(itemKey(item), item);
+	});
+	return Array.from(byKey.values()).sort((a, b) => {
+		return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
+	});
 }
 
 function mergeRefreshFeedItems(currentItems: any[], firstPageItems: any[]): any[] {
-  const firstPageKeys = new Set(firstPageItems.map(itemKey));
-  const olderItems = currentItems.filter((item) => !firstPageKeys.has(itemKey(item)));
-  return mergeFeedItems(olderItems, firstPageItems);
+	const firstPageKeys = new Set(firstPageItems.map(itemKey));
+	const olderItems = currentItems.filter((item) => !firstPageKeys.has(itemKey(item)));
+	return mergeFeedItems(olderItems, firstPageItems);
 }
 
 function replaceFeedItem(updatedItem: any) {
-  const key = itemKey(updatedItem);
-  state.lastFeedItems = state.lastFeedItems.map((item) => (itemKey(item) === key ? updatedItem : item));
+	const key = itemKey(updatedItem);
+	state.lastFeedItems = state.lastFeedItems.map((item) =>
+		itemKey(item) === key ? updatedItem : item,
+	);
 }
 
 /* ── Summary object extraction ───────────────────────────── */
 
 function getSummaryObject(item: any): Record<string, any> | null {
-  const preferredKeys = ['request', 'outcome', 'plan', 'completed', 'learned', 'investigated', 'next', 'next_steps', 'notes'];
-  const looksLikeSummary = (v: any) => {
-    if (!v || typeof v !== 'object' || Array.isArray(v)) return false;
-    return preferredKeys.some((k) => typeof v[k] === 'string' && v[k].trim().length > 0);
-  };
-  if (item?.summary && typeof item.summary === 'object' && !Array.isArray(item.summary)) return item.summary;
-  if (item?.summary?.summary && typeof item.summary.summary === 'object') return item.summary.summary;
-  const metadata = item?.metadata_json;
-  if (looksLikeSummary(metadata)) return metadata;
-  if (looksLikeSummary(metadata?.summary)) return metadata.summary;
-  const bodyText = String(item?.body_text || '').trim();
-  if (bodyText.includes('## ')) {
-    const headingMap: Record<string, string> = {
-      request: 'request',
-      completed: 'completed',
-      learned: 'learned',
-      investigated: 'investigated',
-      'next steps': 'next_steps',
-      notes: 'notes',
-    };
-    const parsed: Record<string, string> = {};
-    const sectionRe = /(?:^|\n)##\s+([^\n]+)\n([\s\S]*?)(?=\n##\s+|$)/g;
-    for (let match = sectionRe.exec(bodyText); match; match = sectionRe.exec(bodyText)) {
-      const rawLabel = String(match[1] || '').trim().toLowerCase();
-      const key = headingMap[rawLabel];
-      const content = String(match[2] || '').trim();
-      if (key && content) parsed[key] = content;
-    }
-    if (looksLikeSummary(parsed)) return parsed;
-  }
-  return null;
+	const preferredKeys = [
+		"request",
+		"outcome",
+		"plan",
+		"completed",
+		"learned",
+		"investigated",
+		"next",
+		"next_steps",
+		"notes",
+	];
+	const looksLikeSummary = (v: any) => {
+		if (!v || typeof v !== "object" || Array.isArray(v)) return false;
+		return preferredKeys.some((k) => typeof v[k] === "string" && v[k].trim().length > 0);
+	};
+	if (item?.summary && typeof item.summary === "object" && !Array.isArray(item.summary))
+		return item.summary;
+	if (item?.summary?.summary && typeof item.summary.summary === "object")
+		return item.summary.summary;
+	const metadata = item?.metadata_json;
+	if (looksLikeSummary(metadata)) return metadata;
+	if (looksLikeSummary(metadata?.summary)) return metadata.summary;
+	const bodyText = String(item?.body_text || "").trim();
+	if (bodyText.includes("## ")) {
+		const headingMap: Record<string, string> = {
+			request: "request",
+			completed: "completed",
+			learned: "learned",
+			investigated: "investigated",
+			"next steps": "next_steps",
+			notes: "notes",
+		};
+		const parsed: Record<string, string> = {};
+		const sectionRe = /(?:^|\n)##\s+([^\n]+)\n([\s\S]*?)(?=\n##\s+|$)/g;
+		for (let match = sectionRe.exec(bodyText); match; match = sectionRe.exec(bodyText)) {
+			const rawLabel = String(match[1] || "")
+				.trim()
+				.toLowerCase();
+			const key = headingMap[rawLabel];
+			const content = String(match[2] || "").trim();
+			if (key && content) parsed[key] = content;
+		}
+		if (looksLikeSummary(parsed)) return parsed;
+	}
+	return null;
 }
 
 function isSummaryLikeItem(item: any, metadata: any): boolean {
-  const kindValue = String(item?.kind || '').toLowerCase();
-  if (kindValue === 'session_summary') return true;
-  if (metadata?.is_summary === true) return true;
-  const source = String(metadata?.source || '').trim().toLowerCase();
-  return source === 'observer_summary';
+	const kindValue = String(item?.kind || "").toLowerCase();
+	if (kindValue === "session_summary") return true;
+	if (metadata?.is_summary === true) return true;
+	const source = String(metadata?.source || "")
+		.trim()
+		.toLowerCase();
+	return source === "observer_summary";
 }
 
 function canonicalKind(item: any, metadata: any): string {
-  const kindValue = String(item?.kind || '').trim().toLowerCase();
-  return isSummaryLikeItem(item, metadata) ? 'session_summary' : (kindValue || 'change');
+	const kindValue = String(item?.kind || "")
+		.trim()
+		.toLowerCase();
+	return isSummaryLikeItem(item, metadata) ? "session_summary" : kindValue || "change";
 }
 
-function getFactsList(item: any): string[] {
-  const summary = getSummaryObject(item);
-  if (summary) {
-    const preferred = ['request', 'outcome', 'plan', 'completed', 'learned', 'investigated', 'next', 'next_steps', 'notes'];
-    const keys = Object.keys(summary);
-    const remaining = keys.filter((k) => !preferred.includes(k)).sort();
-    const ordered = [...preferred.filter((k) => keys.includes(k)), ...remaining];
-    const facts: string[] = [];
-    ordered.forEach((key) => {
-      const content = String(summary[key] || '').trim();
-      if (!content) return;
-      const bullets = extractFactsFromBody(content);
-      if (bullets.length) {
-        bullets.forEach((b) => facts.push(`${toTitleLabel(key)}: ${b}`.trim()));
-        return;
-      }
-      facts.push(`${toTitleLabel(key)}: ${content}`.trim());
-    });
-    return facts;
-  }
-  return extractFactsFromBody(String(item?.body_text || ''));
+function _getFactsList(item: any): string[] {
+	const summary = getSummaryObject(item);
+	if (summary) {
+		const preferred = [
+			"request",
+			"outcome",
+			"plan",
+			"completed",
+			"learned",
+			"investigated",
+			"next",
+			"next_steps",
+			"notes",
+		];
+		const keys = Object.keys(summary);
+		const remaining = keys.filter((k) => !preferred.includes(k)).sort();
+		const ordered = [...preferred.filter((k) => keys.includes(k)), ...remaining];
+		const facts: string[] = [];
+		ordered.forEach((key) => {
+			const content = String(summary[key] || "").trim();
+			if (!content) return;
+			const bullets = extractFactsFromBody(content);
+			if (bullets.length) {
+				bullets.forEach((b) => {
+					facts.push(`${toTitleLabel(key)}: ${b}`.trim());
+				});
+				return;
+			}
+			facts.push(`${toTitleLabel(key)}: ${content}`.trim());
+		});
+		return facts;
+	}
+	return extractFactsFromBody(String(item?.body_text || ""));
 }
 
 /* ── Observation view helpers ────────────────────────────── */
 
 export function observationViewData(item: any) {
-  const metadata = mergeMetadata(item?.metadata_json);
-  const summary = String(item?.subtitle || metadata?.subtitle || '').trim();
-  const narrative = String(item?.narrative || metadata?.narrative || item?.body_text || '').trim();
-  const normSummary = normalize(summary);
-  const normNarrative = normalize(narrative);
-  const narrativeDistinct = Boolean(narrative) && normNarrative !== normSummary;
-  const explicitFacts = parseJsonArray(item?.facts || metadata?.facts || []);
-  const fallbackFacts = explicitFacts.length ? explicitFacts : extractFactsFromBody(narrative || summary);
-  const derivedFacts = fallbackFacts.length ? fallbackFacts : sentenceFacts(narrative || summary);
-  return { summary, narrative, facts: derivedFacts, hasSummary: Boolean(summary), hasFacts: derivedFacts.length > 0, hasNarrative: narrativeDistinct };
+	const metadata = mergeMetadata(item?.metadata_json);
+	const summary = String(item?.subtitle || metadata?.subtitle || "").trim();
+	const narrative = String(item?.narrative || metadata?.narrative || item?.body_text || "").trim();
+	const normSummary = normalize(summary);
+	const normNarrative = normalize(narrative);
+	const narrativeDistinct = Boolean(narrative) && normNarrative !== normSummary;
+	const explicitFacts = parseJsonArray(item?.facts || metadata?.facts || []);
+	const fallbackFacts = explicitFacts.length
+		? explicitFacts
+		: extractFactsFromBody(narrative || summary);
+	const derivedFacts = fallbackFacts.length ? fallbackFacts : sentenceFacts(narrative || summary);
+	return {
+		summary,
+		narrative,
+		facts: derivedFacts,
+		hasSummary: Boolean(summary),
+		hasFacts: derivedFacts.length > 0,
+		hasNarrative: narrativeDistinct,
+	};
 }
 
-function observationViewModes(data: { hasSummary: boolean; hasFacts: boolean; hasNarrative: boolean }): Array<{ id: ItemViewMode; label: string }> {
-  const modes: Array<{ id: ItemViewMode; label: string }> = [];
-  if (data.hasSummary) modes.push({ id: 'summary', label: 'Summary' });
-  if (data.hasFacts) modes.push({ id: 'facts', label: 'Facts' });
-  if (data.hasNarrative) modes.push({ id: 'narrative', label: 'Narrative' });
-  return modes;
+function observationViewModes(data: {
+	hasSummary: boolean;
+	hasFacts: boolean;
+	hasNarrative: boolean;
+}): Array<{ id: ItemViewMode; label: string }> {
+	const modes: Array<{ id: ItemViewMode; label: string }> = [];
+	if (data.hasSummary) modes.push({ id: "summary", label: "Summary" });
+	if (data.hasFacts) modes.push({ id: "facts", label: "Facts" });
+	if (data.hasNarrative) modes.push({ id: "narrative", label: "Narrative" });
+	return modes;
 }
 
-function defaultObservationView(data: { hasSummary: boolean; hasFacts: boolean; hasNarrative: boolean }): ItemViewMode {
-  if (data.hasSummary) return 'summary';
-  if (data.hasFacts) return 'facts';
-  return 'narrative';
+function defaultObservationView(data: {
+	hasSummary: boolean;
+	hasFacts: boolean;
+	hasNarrative: boolean;
+}): ItemViewMode {
+	if (data.hasSummary) return "summary";
+	if (data.hasFacts) return "facts";
+	return "narrative";
 }
 
-function shouldClampBody(mode: ItemViewMode, data: { summary: string; narrative: string }): boolean {
-  if (mode === 'facts') return false;
-  if (mode === 'summary') return data.summary.length > 260;
-  return data.narrative.length > 320;
+function shouldClampBody(
+	mode: ItemViewMode,
+	data: { summary: string; narrative: string },
+): boolean {
+	if (mode === "facts") return false;
+	if (mode === "summary") return data.summary.length > 260;
+	return data.narrative.length > 320;
 }
 
 function clampClass(mode: ItemViewMode): string[] {
-  return mode === 'summary' ? ['clamp', 'clamp-3'] : ['clamp', 'clamp-5'];
+	return mode === "summary" ? ["clamp", "clamp-3"] : ["clamp", "clamp-5"];
 }
 
 function isSafeHref(value: string): boolean {
-  const href = String(value || '').trim();
-  if (!href) return false;
-  if (href.startsWith('#') || href.startsWith('/')) return true;
-  const lower = href.toLowerCase();
-  return lower.startsWith('http://') || lower.startsWith('https://') || lower.startsWith('mailto:');
+	const href = String(value || "").trim();
+	if (!href) return false;
+	if (href.startsWith("#") || href.startsWith("/")) return true;
+	const lower = href.toLowerCase();
+	return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("mailto:");
 }
 
 function sanitizeHtml(html: string): string {
-  const template = document.createElement('template');
-  template.innerHTML = String(html || '');
-  const allowedTags = new Set(['p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'blockquote', 'a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr']);
+	const template = document.createElement("template");
+	template.innerHTML = String(html || "");
+	const allowedTags = new Set([
+		"p",
+		"br",
+		"strong",
+		"em",
+		"code",
+		"pre",
+		"ul",
+		"ol",
+		"li",
+		"blockquote",
+		"a",
+		"h1",
+		"h2",
+		"h3",
+		"h4",
+		"h5",
+		"h6",
+		"hr",
+	]);
 
-  template.content.querySelectorAll('script, iframe, object, embed, link, style').forEach((node) => {
-    node.remove();
-  });
+	template.content
+		.querySelectorAll("script, iframe, object, embed, link, style")
+		.forEach((node) => {
+			node.remove();
+		});
 
-  template.content.querySelectorAll('*').forEach((node) => {
-    const tag = node.tagName.toLowerCase();
-    if (!allowedTags.has(tag)) {
-      node.replaceWith(document.createTextNode(node.textContent || ''));
-      return;
-    }
+	template.content.querySelectorAll("*").forEach((node) => {
+		const tag = node.tagName.toLowerCase();
+		if (!allowedTags.has(tag)) {
+			node.replaceWith(document.createTextNode(node.textContent || ""));
+			return;
+		}
 
-    const allowedAttrs = tag === 'a' ? new Set(['href', 'title']) : new Set<string>();
-    for (const attr of Array.from(node.attributes)) {
-      const name = attr.name.toLowerCase();
-      if (!allowedAttrs.has(name)) {
-        node.removeAttribute(attr.name);
-      }
-    }
+		const allowedAttrs = tag === "a" ? new Set(["href", "title"]) : new Set<string>();
+		for (const attr of Array.from(node.attributes)) {
+			const name = attr.name.toLowerCase();
+			if (!allowedAttrs.has(name)) {
+				node.removeAttribute(attr.name);
+			}
+		}
 
-    if (tag === 'a') {
-      const href = node.getAttribute('href') || '';
-      if (!isSafeHref(href)) {
-        node.removeAttribute('href');
-      } else {
-        node.setAttribute('rel', 'noopener noreferrer');
-        node.setAttribute('target', '_blank');
-      }
-    }
-  });
+		if (tag === "a") {
+			const href = node.getAttribute("href") || "";
+			if (!isSafeHref(href)) {
+				node.removeAttribute("href");
+			} else {
+				node.setAttribute("rel", "noopener noreferrer");
+				node.setAttribute("target", "_blank");
+			}
+		}
+	});
 
-  return template.innerHTML;
+	return template.innerHTML;
 }
 
 function renderMarkdownSafe(value: string): string {
-  const source = String(value || '');
-  try {
-    const rawHtml = (globalThis as any).marked.parse(source);
-    return sanitizeHtml(rawHtml);
-  } catch {
-    const escaped = source
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
-    return escaped;
-  }
+	const source = String(value || "");
+	try {
+		const rawHtml = (globalThis as any).marked.parse(source);
+		return sanitizeHtml(rawHtml);
+	} catch {
+		const escaped = source.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+		return escaped;
+	}
 }
 
 /* ── Rendering functions ─────────────────────────────────── */
 
 function renderSummarySections(summary: Record<string, any>) {
-  const preferred = ['request', 'outcome', 'plan', 'completed', 'learned', 'investigated', 'next', 'next_steps', 'notes'];
-  const keys = Object.keys(summary);
-  const ordered = preferred.filter((k) => keys.includes(k));
-  return ordered
-    .map((key) => {
-      const content = String(summary[key] || '').trim();
-      if (!content) return null;
-      return h(
-        'div',
-        { className: 'summary-section', key },
-        h('div', { className: 'summary-section-label' }, toTitleLabel(key)),
-        h('div', {
-          className: 'summary-section-content',
-          dangerouslySetInnerHTML: { __html: renderMarkdownSafe(content) },
-        }),
-      );
-    })
-    .filter(Boolean);
+	const preferred = [
+		"request",
+		"outcome",
+		"plan",
+		"completed",
+		"learned",
+		"investigated",
+		"next",
+		"next_steps",
+		"notes",
+	];
+	const keys = Object.keys(summary);
+	const ordered = preferred.filter((k) => keys.includes(k));
+	return ordered
+		.map((key) => {
+			const content = String(summary[key] || "").trim();
+			if (!content) return null;
+			return h(
+				"div",
+				{ className: "summary-section", key },
+				h("div", { className: "summary-section-label" }, toTitleLabel(key)),
+				h("div", {
+					className: "summary-section-content",
+					dangerouslySetInnerHTML: { __html: renderMarkdownSafe(content) },
+				}),
+			);
+		})
+		.filter(Boolean);
 }
 
 function renderFactsContent(facts: string[]) {
-  const trimmed = facts.map((f) => String(f || '').trim()).filter(Boolean);
-  if (!trimmed.length) return null;
-  const labeledFacts = trimmed.every((f) => /.+?:\s+.+/.test(f));
-  if (labeledFacts) {
-    const rows = trimmed
-      .map((fact, index) => {
-        const splitAt = fact.indexOf(':');
-        const labelText = fact.slice(0, splitAt).trim();
-        const contentText = fact.slice(splitAt + 1).trim();
-        if (!labelText || !contentText) return null;
-        return h(
-          'div',
-          { className: 'summary-section', key: `${labelText}-${index}` },
-          h('div', { className: 'summary-section-label' }, labelText),
-          h('div', {
-            className: 'summary-section-content',
-            dangerouslySetInnerHTML: { __html: renderMarkdownSafe(contentText) },
-          }),
-        );
-      })
-      .filter(Boolean);
-    if (rows.length) return h('div', { className: 'feed-body facts' }, rows);
-  }
-  return h(
-    'div',
-    { className: 'feed-body' },
-    h(
-      'ul',
-      null,
-      trimmed.map((fact, index) => h('li', { key: `${fact}-${index}` }, fact)),
-    ),
-  );
+	const trimmed = facts.map((f) => String(f || "").trim()).filter(Boolean);
+	if (!trimmed.length) return null;
+	const labeledFacts = trimmed.every((f) => /.+?:\s+.+/.test(f));
+	if (labeledFacts) {
+		const rows = trimmed
+			.map((fact, index) => {
+				const splitAt = fact.indexOf(":");
+				const labelText = fact.slice(0, splitAt).trim();
+				const contentText = fact.slice(splitAt + 1).trim();
+				if (!labelText || !contentText) return null;
+				return h(
+					"div",
+					{ className: "summary-section", key: `${labelText}-${index}` },
+					h("div", { className: "summary-section-label" }, labelText),
+					h("div", {
+						className: "summary-section-content",
+						dangerouslySetInnerHTML: { __html: renderMarkdownSafe(contentText) },
+					}),
+				);
+			})
+			.filter(Boolean);
+		if (rows.length) return h("div", { className: "feed-body facts" }, rows);
+	}
+	return h(
+		"div",
+		{ className: "feed-body" },
+		h(
+			"ul",
+			null,
+			trimmed.map((fact, index) => h("li", { key: `${fact}-${index}` }, fact)),
+		),
+	);
 }
 
-function renderNarrativeContent(narrative: string, className = 'feed-body') {
-  const content = String(narrative || '').trim();
-  if (!content) return null;
-  return h('div', {
-    className,
-    dangerouslySetInnerHTML: { __html: renderMarkdownSafe(content) },
-  });
+function renderNarrativeContent(narrative: string, className = "feed-body") {
+	const content = String(narrative || "").trim();
+	if (!content) return null;
+	return h("div", {
+		className,
+		dangerouslySetInnerHTML: { __html: renderMarkdownSafe(content) },
+	});
 }
 
 function FeedViewToggle({
-  modes,
-  active,
-  onSelect,
+	modes,
+	active,
+	onSelect,
 }: {
-  modes: Array<{ id: ItemViewMode; label: string }>;
-  active: ItemViewMode;
-  onSelect: (mode: ItemViewMode) => void;
+	modes: Array<{ id: ItemViewMode; label: string }>;
+	active: ItemViewMode;
+	onSelect: (mode: ItemViewMode) => void;
 }) {
-  if (modes.length <= 1) return null;
-  return h(
-    'div',
-    { className: 'feed-toggle' },
-    modes.map((mode) =>
-      h(
-        'button',
-        {
-          key: mode.id,
-          className: `toggle-button${mode.id === active ? ' active' : ''}`,
-          'data-filter': mode.id,
-          onClick: () => onSelect(mode.id),
-          type: 'button',
-        },
-        mode.label,
-      ),
-    ),
-  );
+	if (modes.length <= 1) return null;
+	return h(
+		"div",
+		{ className: "feed-toggle" },
+		modes.map((mode) =>
+			h(
+				"button",
+				{
+					key: mode.id,
+					className: `toggle-button${mode.id === active ? " active" : ""}`,
+					"data-filter": mode.id,
+					onClick: () => onSelect(mode.id),
+					type: "button",
+				},
+				mode.label,
+			),
+		),
+	);
 }
 
 function TagChip({ tag }: { tag: any }) {
-  const display = formatTagLabel(tag);
-  if (!display) return null;
-  return h('span', { className: 'tag-chip', title: String(tag) }, display);
+	const display = formatTagLabel(tag);
+	if (!display) return null;
+	return h("span", { className: "tag-chip", title: String(tag) }, display);
 }
 
 /* ── Feed item card renderer ─────────────────────────────── */
 
 function FeedItemCard({ item }: { item: any }) {
-  const metadata = mergeMetadata(item?.metadata_json);
-  const isSessionSummary = isSummaryLikeItem(item, metadata);
-  const displayKindValue = canonicalKind(item, metadata);
-  const rowKey = itemKey(item);
-  const defaultTitle = item.title || '(untitled)';
-  const displayTitle = isSessionSummary && metadata?.request ? metadata.request : defaultTitle;
-  const createdAtRaw = item.created_at || item.created_at_utc;
-  const relative = formatRelativeTime(createdAtRaw);
-  const tags = parseJsonArray(item.tags || []);
-  const files = parseJsonArray(item.files || []);
-  const project = item.project || '';
-  const actor = authorLabel(item);
-  const visibility = String(item.visibility || metadata?.visibility || 'private').trim();
-  const workspaceKind = String(item.workspace_kind || metadata?.workspace_kind || '').trim();
-  const originSource = String(item.origin_source || metadata?.origin_source || '').trim();
-  const originDeviceId = String(item.origin_device_id || metadata?.origin_device_id || '').trim();
-  const trustState = String(item.trust_state || metadata?.trust_state || '').trim();
-  const tagContent = tags.length ? ` · ${tags.map((t: any) => formatTagLabel(t)).join(', ')}` : '';
-  const fileContent = files.length ? ` · ${formatFileList(files)}` : '';
-  const memoryId = Number(item.id || 0);
-  const [isNew, setIsNew] = useState(state.newItemKeys.has(rowKey));
-  const summaryObj = isSessionSummary ? getSummaryObject({ ...item, metadata_json: metadata }) : null;
-  const observationData = !isSessionSummary ? observationViewData({ ...item, metadata_json: metadata }) : null;
-  const modes = observationData ? observationViewModes(observationData) : [];
-  const fallbackMode = observationData ? defaultObservationView(observationData) : 'summary';
-  const storedMode = state.itemViewState.get(rowKey) as ItemViewMode | undefined;
-  const initialMode = observationData && storedMode && modes.some((mode) => mode.id === storedMode)
-    ? storedMode
-    : (fallbackMode as ItemViewMode);
-  const [activeMode, setActiveMode] = useState<ItemViewMode>(initialMode);
-  const activeExpandKey = `${rowKey}:${activeMode}`;
-  const [expanded, setExpanded] = useState(state.itemExpandState.get(activeExpandKey) === true);
-  const [selectedVisibility, setSelectedVisibility] = useState<'private' | 'shared'>(
-    visibility === 'shared' ? 'shared' : 'private',
-  );
-  const [savingVisibility, setSavingVisibility] = useState(false);
-  const summarySections = summaryObj ? renderSummarySections(summaryObj) : [];
+	const metadata = mergeMetadata(item?.metadata_json);
+	const isSessionSummary = isSummaryLikeItem(item, metadata);
+	const displayKindValue = canonicalKind(item, metadata);
+	const rowKey = itemKey(item);
+	const defaultTitle = item.title || "(untitled)";
+	const displayTitle = isSessionSummary && metadata?.request ? metadata.request : defaultTitle;
+	const createdAtRaw = item.created_at || item.created_at_utc;
+	const relative = formatRelativeTime(createdAtRaw);
+	const tags = parseJsonArray(item.tags || []);
+	const files = parseJsonArray(item.files || []);
+	const project = item.project || "";
+	const actor = authorLabel(item);
+	const visibility = String(item.visibility || metadata?.visibility || "private").trim();
+	const workspaceKind = String(item.workspace_kind || metadata?.workspace_kind || "").trim();
+	const originSource = String(item.origin_source || metadata?.origin_source || "").trim();
+	const originDeviceId = String(item.origin_device_id || metadata?.origin_device_id || "").trim();
+	const trustState = String(item.trust_state || metadata?.trust_state || "").trim();
+	const tagContent = tags.length ? ` · ${tags.map((t: any) => formatTagLabel(t)).join(", ")}` : "";
+	const fileContent = files.length ? ` · ${formatFileList(files)}` : "";
+	const memoryId = Number(item.id || 0);
+	const [isNew, setIsNew] = useState(state.newItemKeys.has(rowKey));
+	const summaryObj = isSessionSummary
+		? getSummaryObject({ ...item, metadata_json: metadata })
+		: null;
+	const observationData = !isSessionSummary
+		? observationViewData({ ...item, metadata_json: metadata })
+		: null;
+	const modes = observationData ? observationViewModes(observationData) : [];
+	const fallbackMode = observationData ? defaultObservationView(observationData) : "summary";
+	const storedMode = state.itemViewState.get(rowKey) as ItemViewMode | undefined;
+	const initialMode =
+		observationData && storedMode && modes.some((mode) => mode.id === storedMode)
+			? storedMode
+			: (fallbackMode as ItemViewMode);
+	const [activeMode, setActiveMode] = useState<ItemViewMode>(initialMode);
+	const activeExpandKey = `${rowKey}:${activeMode}`;
+	const [expanded, setExpanded] = useState(state.itemExpandState.get(activeExpandKey) === true);
+	const [selectedVisibility, setSelectedVisibility] = useState<"private" | "shared">(
+		visibility === "shared" ? "shared" : "private",
+	);
+	const [savingVisibility, setSavingVisibility] = useState(false);
+	const summarySections = summaryObj ? renderSummarySections(summaryObj) : [];
 
-  useEffect(() => {
-    if (!observationData) return;
-    if (modes.some((mode) => mode.id === activeMode)) return;
-    setActiveMode(fallbackMode as ItemViewMode);
-  }, [activeMode, fallbackMode, modes, observationData]);
+	useEffect(() => {
+		if (!observationData) return;
+		if (modes.some((mode) => mode.id === activeMode)) return;
+		setActiveMode(fallbackMode as ItemViewMode);
+	}, [activeMode, fallbackMode, modes, observationData]);
 
-  useEffect(() => {
-    state.itemViewState.set(rowKey, activeMode);
-  }, [activeMode, rowKey]);
+	useEffect(() => {
+		state.itemViewState.set(rowKey, activeMode);
+	}, [activeMode, rowKey]);
 
-  useEffect(() => {
-    const nextExpandKey = `${rowKey}:${activeMode}`;
-    setExpanded(state.itemExpandState.get(nextExpandKey) === true);
-  }, [activeMode, rowKey]);
+	useEffect(() => {
+		const nextExpandKey = `${rowKey}:${activeMode}`;
+		setExpanded(state.itemExpandState.get(nextExpandKey) === true);
+	}, [activeMode, rowKey]);
 
-  useEffect(() => {
-    setSelectedVisibility(visibility === 'shared' ? 'shared' : 'private');
-  }, [visibility]);
+	useEffect(() => {
+		setSelectedVisibility(visibility === "shared" ? "shared" : "private");
+	}, [visibility]);
 
-  useEffect(() => {
-    if (!isNew) return;
-    const timer = window.setTimeout(() => {
-      state.newItemKeys.delete(rowKey);
-      setIsNew(false);
-    }, 700);
-    return () => window.clearTimeout(timer);
-  }, [isNew, rowKey]);
+	useEffect(() => {
+		if (!isNew) return;
+		const timer = window.setTimeout(() => {
+			state.newItemKeys.delete(rowKey);
+			setIsNew(false);
+		}, 700);
+		return () => window.clearTimeout(timer);
+	}, [isNew, rowKey]);
 
-  const currentVisibility = selectedVisibility;
-  const visibilityNote = currentVisibility === 'shared'
-    ? 'This memory can sync to peers allowed by your project filters.'
-    : 'This memory stays local unless the peer is assigned to your local actor.';
+	const currentVisibility = selectedVisibility;
+	const visibilityNote =
+		currentVisibility === "shared"
+			? "This memory can sync to peers allowed by your project filters."
+			: "This memory stays local unless the peer is assigned to your local actor.";
 
-  const canClamp = Boolean(observationData) && shouldClampBody(activeMode, observationData);
-  const bodyClassName = [
-    activeMode === 'facts' ? 'feed-body facts' : 'feed-body',
-    canClamp && !expanded ? clampClass(activeMode).join(' ') : '',
-  ].filter(Boolean).join(' ');
+	const canClamp = Boolean(observationData) && shouldClampBody(activeMode, observationData);
+	const bodyClassName = [
+		activeMode === "facts" ? "feed-body facts" : "feed-body",
+		canClamp && !expanded ? clampClass(activeMode).join(" ") : "",
+	]
+		.filter(Boolean)
+		.join(" ");
 
-  const bodyContent = isSessionSummary
-    ? summarySections.length
-      ? h('div', { className: 'feed-body facts' }, summarySections)
-      : renderNarrativeContent(String(item.body_text || '')) || h('div', { className: 'feed-body' })
-    : observationData
-      ? (activeMode === 'facts'
-          ? renderFactsContent(observationData.facts) || h('div', { className: bodyClassName })
-          : renderNarrativeContent(
-              activeMode === 'narrative' ? observationData.narrative : observationData.summary,
-              bodyClassName,
-            ) || h('div', { className: bodyClassName }))
-      : h('div', { className: 'feed-body' });
+	const bodyContent = isSessionSummary
+		? summarySections.length
+			? h("div", { className: "feed-body facts" }, summarySections)
+			: renderNarrativeContent(String(item.body_text || "")) || h("div", { className: "feed-body" })
+		: observationData
+			? activeMode === "facts"
+				? renderFactsContent(observationData.facts) || h("div", { className: bodyClassName })
+				: renderNarrativeContent(
+						activeMode === "narrative" ? observationData.narrative : observationData.summary,
+						bodyClassName,
+					) || h("div", { className: bodyClassName })
+			: h("div", { className: "feed-body" });
 
-  async function saveVisibility(nextVisibility: 'private' | 'shared') {
-    const previousVisibility = currentVisibility;
-    setSelectedVisibility(nextVisibility);
-    setSavingVisibility(true);
-    try {
-      const payload = await api.updateMemoryVisibility(memoryId, nextVisibility);
-      if (payload?.item) {
-        replaceFeedItem(payload.item);
-        updateFeedView(true);
-      }
-      showGlobalNotice(nextVisibility === 'shared' ? 'Memory will now sync as shared context.' : 'Memory is private again.');
-    } catch (error) {
-      setSelectedVisibility(previousVisibility);
-      showGlobalNotice(error instanceof Error ? error.message : 'Failed to save visibility.', 'warning');
-    } finally {
-      setSavingVisibility(false);
-    }
-  }
+	async function saveVisibility(nextVisibility: "private" | "shared") {
+		const previousVisibility = currentVisibility;
+		setSelectedVisibility(nextVisibility);
+		setSavingVisibility(true);
+		try {
+			const payload = await api.updateMemoryVisibility(memoryId, nextVisibility);
+			if (payload?.item) {
+				replaceFeedItem(payload.item);
+				updateFeedView(true);
+			}
+			showGlobalNotice(
+				nextVisibility === "shared"
+					? "Memory will now sync as shared context."
+					: "Memory is private again.",
+			);
+		} catch (error) {
+			setSelectedVisibility(previousVisibility);
+			showGlobalNotice(
+				error instanceof Error ? error.message : "Failed to save visibility.",
+				"warning",
+			);
+		} finally {
+			setSavingVisibility(false);
+		}
+	}
 
-  return h(
-    'div',
-    {
-      className: `feed-item ${displayKindValue}${isNew ? ' new-item' : ''}`.trim(),
-      'data-key': rowKey,
-    },
-    h(
-      'div',
-      { className: 'feed-card-header' },
-      h(
-        'div',
-        { className: 'feed-header' },
-        h('span', { className: `kind-pill ${displayKindValue}`.trim() }, displayKindValue.replace(/_/g, ' ')),
-        h('div', {
-          className: 'feed-title title',
-          dangerouslySetInnerHTML: { __html: highlightText(displayTitle, state.feedQuery) },
-        }),
-      ),
-      h(
-        'div',
-        { className: 'feed-actions' },
-        observationData
-          ? h(FeedViewToggle, {
-              active: activeMode,
-              modes,
-              onSelect: (mode) => setActiveMode(mode),
-            })
-          : null,
-        h('div', { className: 'small feed-age', title: formatDate(createdAtRaw) }, relative),
-      ),
-    ),
-    h(
-      'div',
-      { className: 'feed-provenance' },
-      h(ProvenanceChip, { label: actor, variant: actor === 'You' ? 'mine' : 'author' }),
-      h(ProvenanceChip, { label: visibility || 'private', variant: visibility || 'private' }),
-      workspaceKind && workspaceKind !== visibility ? h(ProvenanceChip, { label: workspaceKind, variant: 'workspace' }) : null,
-      originSource ? h(ProvenanceChip, { label: originSource, variant: 'source' }) : null,
-      originDeviceId && actor !== 'You' ? h(ProvenanceChip, { label: originDeviceId, variant: 'device' }) : null,
-      trustState && trustState !== 'trusted' ? h(ProvenanceChip, { label: trustStateLabel(trustState), variant: 'trust' }) : null,
-    ),
-    h('div', { className: 'feed-meta' }, `${project ? `Project: ${project}` : 'Project: n/a'}${tagContent}${fileContent}`),
-    bodyContent,
-    h(
-      'div',
-      { className: 'feed-footer' },
-      h(
-        'div',
-        { className: 'feed-footer-left' },
-        files.length
-          ? h(
-              'div',
-              { className: 'feed-files' },
-              files.map((file: any, index: number) => h('span', { className: 'feed-file', key: `${file}-${index}` }, file)),
-            )
-          : null,
-        tags.length
-          ? h(
-              'div',
-              { className: 'feed-tags' },
-              tags.map((tag: any, index: number) => h(TagChip, { key: `${String(tag)}-${index}`, tag })),
-            )
-          : null,
-        Boolean(item.owned_by_self) && memoryId > 0
-          ? h(
-              'div',
-              { className: 'feed-visibility-controls' },
-              h(
-                'select',
-                {
-                  'aria-label': `Visibility for ${String(item.title || 'memory')}`,
-                  className: 'feed-visibility-select',
-                  disabled: savingVisibility,
-                  onChange: (event) => {
-                    const nextValue = String((event.currentTarget as HTMLSelectElement).value) === 'shared' ? 'shared' : 'private';
-                    void saveVisibility(nextValue);
-                  },
-                  value: currentVisibility,
-                },
-                h('option', { value: 'private' }, 'Only me'),
-                h('option', { value: 'shared' }, 'Share with peers'),
-              ),
-              h('div', { className: 'feed-visibility-note' }, visibilityNote),
-            )
-          : null,
-      ),
-      h(
-        'div',
-        { className: 'feed-footer-right' },
-        canClamp
-          ? h(
-              'button',
-              {
-                className: 'feed-expand',
-                onClick: () => {
-                  const nextValue = !expanded;
-                  state.itemExpandState.set(activeExpandKey, nextValue);
-                  setExpanded(nextValue);
-                },
-                type: 'button',
-              },
-              expanded ? 'Collapse' : 'Expand',
-            )
-          : null,
-      ),
-    ),
-  );
+	return h(
+		"div",
+		{
+			className: `feed-item ${displayKindValue}${isNew ? " new-item" : ""}`.trim(),
+			"data-key": rowKey,
+		},
+		h(
+			"div",
+			{ className: "feed-card-header" },
+			h(
+				"div",
+				{ className: "feed-header" },
+				h(
+					"span",
+					{ className: `kind-pill ${displayKindValue}`.trim() },
+					displayKindValue.replace(/_/g, " "),
+				),
+				h("div", {
+					className: "feed-title title",
+					dangerouslySetInnerHTML: { __html: highlightText(displayTitle, state.feedQuery) },
+				}),
+			),
+			h(
+				"div",
+				{ className: "feed-actions" },
+				observationData
+					? h(FeedViewToggle, {
+							active: activeMode,
+							modes,
+							onSelect: (mode) => setActiveMode(mode),
+						})
+					: null,
+				h("div", { className: "small feed-age", title: formatDate(createdAtRaw) }, relative),
+			),
+		),
+		h(
+			"div",
+			{ className: "feed-provenance" },
+			h(ProvenanceChip, { label: actor, variant: actor === "You" ? "mine" : "author" }),
+			h(ProvenanceChip, { label: visibility || "private", variant: visibility || "private" }),
+			workspaceKind && workspaceKind !== visibility
+				? h(ProvenanceChip, { label: workspaceKind, variant: "workspace" })
+				: null,
+			originSource ? h(ProvenanceChip, { label: originSource, variant: "source" }) : null,
+			originDeviceId && actor !== "You"
+				? h(ProvenanceChip, { label: originDeviceId, variant: "device" })
+				: null,
+			trustState && trustState !== "trusted"
+				? h(ProvenanceChip, { label: trustStateLabel(trustState), variant: "trust" })
+				: null,
+		),
+		h(
+			"div",
+			{ className: "feed-meta" },
+			`${project ? `Project: ${project}` : "Project: n/a"}${tagContent}${fileContent}`,
+		),
+		bodyContent,
+		h(
+			"div",
+			{ className: "feed-footer" },
+			h(
+				"div",
+				{ className: "feed-footer-left" },
+				files.length
+					? h(
+							"div",
+							{ className: "feed-files" },
+							files.map((file: any, index: number) =>
+								h("span", { className: "feed-file", key: `${file}-${index}` }, file),
+							),
+						)
+					: null,
+				tags.length
+					? h(
+							"div",
+							{ className: "feed-tags" },
+							tags.map((tag: any, index: number) =>
+								h(TagChip, { key: `${String(tag)}-${index}`, tag }),
+							),
+						)
+					: null,
+				Boolean(item.owned_by_self) && memoryId > 0
+					? h(
+							"div",
+							{ className: "feed-visibility-controls" },
+							h(
+								"select",
+								{
+									"aria-label": `Visibility for ${String(item.title || "memory")}`,
+									className: "feed-visibility-select",
+									disabled: savingVisibility,
+									onChange: (event) => {
+										const nextValue =
+											String((event.currentTarget as HTMLSelectElement).value) === "shared"
+												? "shared"
+												: "private";
+										void saveVisibility(nextValue);
+									},
+									value: currentVisibility,
+								},
+								h("option", { value: "private" }, "Only me"),
+								h("option", { value: "shared" }, "Share with peers"),
+							),
+							h("div", { className: "feed-visibility-note" }, visibilityNote),
+						)
+					: null,
+			),
+			h(
+				"div",
+				{ className: "feed-footer-right" },
+				canClamp
+					? h(
+							"button",
+							{
+								className: "feed-expand",
+								onClick: () => {
+									const nextValue = !expanded;
+									state.itemExpandState.set(activeExpandKey, nextValue);
+									setExpanded(nextValue);
+								},
+								type: "button",
+							},
+							expanded ? "Collapse" : "Expand",
+						)
+					: null,
+			),
+		),
+	);
 }
 
 function FeedList({ items, loadingText }: { items: any[]; loadingText?: string }) {
-  if (loadingText) {
-    return h('div', { className: 'small' }, loadingText);
-  }
-  if (!items.length) {
-    return h('div', { className: 'small' }, 'No memories yet.');
-  }
-  return h(
-    Fragment,
-    null,
-    items.map((item) => h(FeedItemCard, { item, key: itemKey(item) })),
-  );
+	if (loadingText) {
+		return h("div", { className: "small" }, loadingText);
+	}
+	if (!items.length) {
+		return h("div", { className: "small" }, "No memories yet.");
+	}
+	return h(
+		Fragment,
+		null,
+		items.map((item) => h(FeedItemCard, { item, key: itemKey(item) })),
+	);
 }
 
 /* ── Filtering ───────────────────────────────────────────── */
 
 function filterByType(items: any[]): any[] {
-  if (state.feedTypeFilter === 'observations') return items.filter((i) => !isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
-  if (state.feedTypeFilter === 'summaries') return items.filter((i) => isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
-  return items;
+	if (state.feedTypeFilter === "observations")
+		return items.filter((i) => !isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
+	if (state.feedTypeFilter === "summaries")
+		return items.filter((i) => isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
+	return items;
 }
 
 function filterByQuery(items: any[]): any[] {
-  const query = normalize(state.feedQuery);
-  if (!query) return items;
-  return items.filter((item) => {
-    const hay = [normalize(item?.title), normalize(item?.body_text), normalize(item?.kind), parseJsonArray(item?.tags || []).map((t: any) => normalize(t)).join(' '), normalize(item?.project)].join(' ').trim();
-    return hay.includes(query);
-  });
+	const query = normalize(state.feedQuery);
+	if (!query) return items;
+	return items.filter((item) => {
+		const hay = [
+			normalize(item?.title),
+			normalize(item?.body_text),
+			normalize(item?.kind),
+			parseJsonArray(item?.tags || [])
+				.map((t: any) => normalize(t))
+				.join(" "),
+			normalize(item?.project),
+		]
+			.join(" ")
+			.trim();
+		return hay.includes(query);
+	});
 }
 
 function computeSignature(items: any[]): string {
-  const parts = items.map((i) => `${itemSignature(i)}:${i.kind || ''}:${i.created_at_utc || i.created_at || ''}`);
-  return `${state.feedTypeFilter}|${state.feedScopeFilter}|${state.currentProject}|${normalize(state.feedQuery)}|${parts.join('|')}`;
+	const parts = items.map(
+		(i) => `${itemSignature(i)}:${i.kind || ""}:${i.created_at_utc || i.created_at || ""}`,
+	);
+	return `${state.feedTypeFilter}|${state.feedScopeFilter}|${state.currentProject}|${normalize(state.feedQuery)}|${parts.join("|")}`;
 }
 
 function countNewItems(nextItems: any[], currentItems: any[]): number {
-  const seen = new Set(currentItems.map(itemKey));
-  return nextItems.filter((i) => !seen.has(itemKey(i))).length;
+	const seen = new Set(currentItems.map(itemKey));
+	return nextItems.filter((i) => !seen.has(itemKey(i))).length;
 }
 
 async function loadMoreFeedPage() {
-  if (loadMoreInFlight || !hasMorePages()) return;
-  const requestProject = state.currentProject || '';
-  const requestGeneration = feedProjectGeneration;
-  const startObservationOffset = observationOffset;
-  const startSummaryOffset = summaryOffset;
-  loadMoreInFlight = true;
-  try {
-    const [observations, summaries] = await Promise.all([
-      observationHasMore
-        ? api.loadMemoriesPage(requestProject, {
-            limit: OBSERVATION_PAGE_SIZE,
-            offset: startObservationOffset,
-            scope: state.feedScopeFilter,
-          })
-        : Promise.resolve({ items: [], pagination: { has_more: false, next_offset: startObservationOffset } }),
-      summaryHasMore
-        ? api.loadSummariesPage(requestProject, {
-            limit: SUMMARY_PAGE_SIZE,
-            offset: startSummaryOffset,
-            scope: state.feedScopeFilter,
-          })
-        : Promise.resolve({ items: [], pagination: { has_more: false, next_offset: startSummaryOffset } }),
-    ]);
+	if (loadMoreInFlight || !hasMorePages()) return;
+	const requestProject = state.currentProject || "";
+	const requestGeneration = feedProjectGeneration;
+	const startObservationOffset = observationOffset;
+	const startSummaryOffset = summaryOffset;
+	loadMoreInFlight = true;
+	try {
+		const [observations, summaries] = await Promise.all([
+			observationHasMore
+				? api.loadMemoriesPage(requestProject, {
+						limit: OBSERVATION_PAGE_SIZE,
+						offset: startObservationOffset,
+						scope: state.feedScopeFilter,
+					})
+				: Promise.resolve({
+						items: [],
+						pagination: { has_more: false, next_offset: startObservationOffset },
+					}),
+			summaryHasMore
+				? api.loadSummariesPage(requestProject, {
+						limit: SUMMARY_PAGE_SIZE,
+						offset: startSummaryOffset,
+						scope: state.feedScopeFilter,
+					})
+				: Promise.resolve({
+						items: [],
+						pagination: { has_more: false, next_offset: startSummaryOffset },
+					}),
+		]);
 
-    if (requestGeneration !== feedProjectGeneration || requestProject !== (state.currentProject || '')) {
-      return;
-    }
+		if (
+			requestGeneration !== feedProjectGeneration ||
+			requestProject !== (state.currentProject || "")
+		) {
+			return;
+		}
 
-    const summaryItems = summaries.items || [];
-    const observationItems = observations.items || [];
-    const filtered = observationItems.filter((i: any) => !isLowSignalObservation(i));
-    state.lastFeedFilteredCount += observationItems.length - filtered.length;
+		const summaryItems = summaries.items || [];
+		const observationItems = observations.items || [];
+		const filtered = observationItems.filter((i: any) => !isLowSignalObservation(i));
+		state.lastFeedFilteredCount += observationItems.length - filtered.length;
 
-    summaryHasMore = pageHasMore(summaries, summaryItems.length, SUMMARY_PAGE_SIZE);
-    observationHasMore = pageHasMore(observations, observationItems.length, OBSERVATION_PAGE_SIZE);
-    summaryOffset = pageNextOffset(summaries, startSummaryOffset + summaryItems.length);
-    observationOffset = pageNextOffset(observations, startObservationOffset + observationItems.length);
+		summaryHasMore = pageHasMore(summaries, summaryItems.length, SUMMARY_PAGE_SIZE);
+		observationHasMore = pageHasMore(observations, observationItems.length, OBSERVATION_PAGE_SIZE);
+		summaryOffset = pageNextOffset(summaries, startSummaryOffset + summaryItems.length);
+		observationOffset = pageNextOffset(
+			observations,
+			startObservationOffset + observationItems.length,
+		);
 
-    const incoming = [...summaryItems, ...filtered];
-    const feedItems = mergeFeedItems(state.lastFeedItems, incoming);
-    const newCount = countNewItems(feedItems, state.lastFeedItems);
-    if (newCount) {
-      const seen = new Set(state.lastFeedItems.map(itemKey));
-      feedItems.forEach((item: any) => {
-        if (!seen.has(itemKey(item))) state.newItemKeys.add(itemKey(item));
-      });
-    }
+		const incoming = [...summaryItems, ...filtered];
+		const feedItems = mergeFeedItems(state.lastFeedItems, incoming);
+		const newCount = countNewItems(feedItems, state.lastFeedItems);
+		if (newCount) {
+			const seen = new Set(state.lastFeedItems.map(itemKey));
+			feedItems.forEach((item: any) => {
+				if (!seen.has(itemKey(item))) state.newItemKeys.add(itemKey(item));
+			});
+		}
 
-    state.lastFeedItems = feedItems;
-    updateFeedView();
-  } finally {
-    loadMoreInFlight = false;
-  }
+		state.lastFeedItems = feedItems;
+		updateFeedView();
+	} finally {
+		loadMoreInFlight = false;
+	}
 }
 
 function maybeLoadMoreFeedPage() {
-  if (state.activeTab !== 'feed') return;
-  if (!hasMorePages()) return;
-  if (!isNearFeedBottom()) return;
-  void loadMoreFeedPage();
+	if (state.activeTab !== "feed") return;
+	if (!hasMorePages()) return;
+	if (!isNearFeedBottom()) return;
+	void loadMoreFeedPage();
 }
 
 function feedMetaText(visibleCount: number): string {
-  const filterLabel = state.feedTypeFilter === 'observations' ? ' · observations' : state.feedTypeFilter === 'summaries' ? ' · session summaries' : '';
-  const scopeLabel = feedScopeLabel(state.feedScopeFilter);
-  const filteredLabel = !state.feedQuery.trim() && state.lastFeedFilteredCount ? ` · ${state.lastFeedFilteredCount} observations filtered` : '';
-  const queryLabel = state.feedQuery.trim() ? ` · matching "${state.feedQuery.trim()}"` : '';
-  const moreLabel = hasMorePages() ? ' · scroll for more' : '';
-  return `${visibleCount} items${filterLabel}${scopeLabel}${queryLabel}${filteredLabel}${moreLabel}`;
+	const filterLabel =
+		state.feedTypeFilter === "observations"
+			? " · observations"
+			: state.feedTypeFilter === "summaries"
+				? " · session summaries"
+				: "";
+	const scopeLabel = feedScopeLabel(state.feedScopeFilter);
+	const filteredLabel =
+		!state.feedQuery.trim() && state.lastFeedFilteredCount
+			? ` · ${state.lastFeedFilteredCount} observations filtered`
+			: "";
+	const queryLabel = state.feedQuery.trim() ? ` · matching "${state.feedQuery.trim()}"` : "";
+	const moreLabel = hasMorePages() ? " · scroll for more" : "";
+	return `${visibleCount} items${filterLabel}${scopeLabel}${queryLabel}${filteredLabel}${moreLabel}`;
 }
 
 function FeedToggle({
-  id,
-  active,
-  options,
-  onSelect,
+	id,
+	active,
+	options,
+	onSelect,
 }: {
-  id: string;
-  active: string;
-  options: Array<{ value: string; label: string }>;
-  onSelect: (value: string) => void;
+	id: string;
+	active: string;
+	options: Array<{ value: string; label: string }>;
+	onSelect: (value: string) => void;
 }) {
-  return h(
-    'div',
-    { className: 'feed-toggle', id },
-    options.map(({ value, label }) => {
-      const selected = value === active;
-      return h(
-        'button',
-        {
-          'aria-pressed': selected ? 'true' : 'false',
-          className: `toggle-button${selected ? ' active' : ''}`,
-          'data-filter': value,
-          key: value,
-          onClick: () => onSelect(value),
-          type: 'button',
-        },
-        label,
-      );
-    }),
-  );
+	return h(
+		"div",
+		{ className: "feed-toggle", id },
+		options.map(({ value, label }) => {
+			const selected = value === active;
+			return h(
+				"button",
+				{
+					"aria-pressed": selected ? "true" : "false",
+					className: `toggle-button${selected ? " active" : ""}`,
+					"data-filter": value,
+					key: value,
+					onClick: () => onSelect(value),
+					type: "button",
+				},
+				label,
+			);
+		}),
+	);
 }
 
 function TraceCandidateGroup({
-  label,
-  candidates,
+	label,
+	candidates,
 }: {
-  label: string;
-  candidates: api.PackTraceCandidate[];
+	label: string;
+	candidates: api.PackTraceCandidate[];
 }) {
-  if (candidates.length === 0) return null;
-  return h(
-    'div',
-    { className: 'trace-group' },
-    h('div', { className: 'section-meta' }, label),
-    h(
-      'div',
-      { className: 'feed-list' },
-      candidates.map((candidate) =>
-        h(
-          'div',
-          { className: 'feed-card', key: `${label}:${candidate.id}` },
-          h('div', { className: 'feed-card-header' }, [
-            h('div', { className: 'feed-card-title' }, `${candidate.rank}. ${candidate.title}`),
-            h('div', { className: 'feed-card-meta' }, `#${candidate.id} · ${candidate.kind}${candidate.section ? ` · ${candidate.section}` : ''}`),
-          ]),
-          h('div', { className: 'feed-card-body' }, [
-            h('div', null, candidate.preview || 'No preview available.'),
-            candidate.reasons.length
-              ? h('div', { className: 'section-meta' }, `Reasons: ${candidate.reasons.join(', ')}`)
-              : null,
-          ]),
-        ),
-      ),
-    ),
-  );
+	if (candidates.length === 0) return null;
+	return h(
+		"div",
+		{ className: "trace-group" },
+		h("div", { className: "section-meta" }, label),
+		h(
+			"div",
+			{ className: "feed-list" },
+			candidates.map((candidate) =>
+				h(
+					"div",
+					{ className: "feed-card", key: `${label}:${candidate.id}` },
+					h("div", { className: "feed-card-header" }, [
+						h("div", { className: "feed-card-title" }, `${candidate.rank}. ${candidate.title}`),
+						h(
+							"div",
+							{ className: "feed-card-meta" },
+							`#${candidate.id} · ${candidate.kind}${candidate.section ? ` · ${candidate.section}` : ""}`,
+						),
+					]),
+					h("div", { className: "feed-card-body" }, [
+						h("div", null, candidate.preview || "No preview available."),
+						candidate.reasons.length
+							? h("div", { className: "section-meta" }, `Reasons: ${candidate.reasons.join(", ")}`)
+							: null,
+					]),
+				),
+			),
+		),
+	);
 }
 
 function ContextInspectorPanel() {
-  const [open, setOpen] = useState(false);
-  const [workingSetText, setWorkingSetText] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
-  const [errorContextKey, setErrorContextKey] = useState('');
-  const [trace, setTrace] = useState<api.PackTrace | null>(null);
-  const currentQuery = String(state.feedQuery || '').trim();
-  const currentProject = state.currentProject || null;
-  const currentContextKey = JSON.stringify([currentProject, currentQuery]);
-  const visibleTrace =
-    trace && trace.inputs.query === currentQuery && trace.inputs.project === currentProject ? trace : null;
-  const visibleError = error && errorContextKey === currentContextKey ? error : '';
+	const [open, setOpen] = useState(false);
+	const [workingSetText, setWorkingSetText] = useState("");
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState("");
+	const [errorContextKey, setErrorContextKey] = useState("");
+	const [trace, setTrace] = useState<api.PackTrace | null>(null);
+	const currentQuery = String(state.feedQuery || "").trim();
+	const currentProject = state.currentProject || null;
+	const currentContextKey = JSON.stringify([currentProject, currentQuery]);
+	const visibleTrace =
+		trace && trace.inputs.query === currentQuery && trace.inputs.project === currentProject
+			? trace
+			: null;
+	const visibleError = error && errorContextKey === currentContextKey ? error : "";
 
-  useEffect(() => {
-    setError('');
-    setErrorContextKey('');
-    setTrace((currentTrace) => {
-      if (!currentTrace) return null;
-      if (currentTrace.inputs.query !== currentQuery || currentTrace.inputs.project !== currentProject) {
-        return null;
-      }
-      return currentTrace;
-    });
-  }, [currentProject, currentQuery]);
+	useEffect(() => {
+		setError("");
+		setErrorContextKey("");
+		setTrace((currentTrace) => {
+			if (!currentTrace) return null;
+			if (
+				currentTrace.inputs.query !== currentQuery ||
+				currentTrace.inputs.project !== currentProject
+			) {
+				return null;
+			}
+			return currentTrace;
+		});
+	}, [currentProject, currentQuery]);
 
-  const runTrace = async () => {
-    const context = currentQuery;
-    const project = currentProject;
-    const contextKey = JSON.stringify([project, context]);
-    if (!context) {
-      setError('Enter a query to inspect.');
-      setErrorContextKey(contextKey);
-      setTrace(null);
-      return;
-    }
-    setLoading(true);
-    setError('');
-    setErrorContextKey('');
-    try {
-      const workingSetFiles = workingSetText
-        .split(/\n|,/)
-        .map((value) => value.trim())
-        .filter(Boolean);
-      const nextTrace = await api.tracePack({
-        context,
-        project,
-        working_set_files: workingSetFiles,
-      });
-      if (String(state.feedQuery || '').trim() !== context || (state.currentProject || null) !== project) {
-        return;
-      }
-      setTrace(nextTrace);
-    } catch (err) {
-      if (String(state.feedQuery || '').trim() !== context || (state.currentProject || null) !== project) {
-        return;
-      }
-      setError(err instanceof Error ? err.message : String(err));
-      setErrorContextKey(contextKey);
-      setTrace(null);
-    } finally {
-      setLoading(false);
-    }
-  };
+	const runTrace = async () => {
+		const context = currentQuery;
+		const project = currentProject;
+		const contextKey = JSON.stringify([project, context]);
+		if (!context) {
+			setError("Enter a query to inspect.");
+			setErrorContextKey(contextKey);
+			setTrace(null);
+			return;
+		}
+		setLoading(true);
+		setError("");
+		setErrorContextKey("");
+		try {
+			const workingSetFiles = workingSetText
+				.split(/\n|,/)
+				.map((value) => value.trim())
+				.filter(Boolean);
+			const nextTrace = await api.tracePack({
+				context,
+				project,
+				working_set_files: workingSetFiles,
+			});
+			if (
+				String(state.feedQuery || "").trim() !== context ||
+				(state.currentProject || null) !== project
+			) {
+				return;
+			}
+			setTrace(nextTrace);
+		} catch (err) {
+			if (
+				String(state.feedQuery || "").trim() !== context ||
+				(state.currentProject || null) !== project
+			) {
+				return;
+			}
+			setError(err instanceof Error ? err.message : String(err));
+			setErrorContextKey(contextKey);
+			setTrace(null);
+		} finally {
+			setLoading(false);
+		}
+	};
 
-  const selected = visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === 'selected') || [];
-  const dropped = visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === 'dropped') || [];
-  const deduped = visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === 'deduped') || [];
-  const trimmed = visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === 'trimmed') || [];
+	const selected =
+		visibleTrace?.retrieval.candidates.filter(
+			(candidate) => candidate.disposition === "selected",
+		) || [];
+	const dropped =
+		visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === "dropped") ||
+		[];
+	const deduped =
+		visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === "deduped") ||
+		[];
+	const trimmed =
+		visibleTrace?.retrieval.candidates.filter((candidate) => candidate.disposition === "trimmed") ||
+		[];
 
-  return h(
-    'div',
-    { className: 'feed-inspector' },
-    h(
-      'button',
-        {
-          className: 'toggle-button',
-          onClick: () => setOpen(!open),
-          type: 'button',
-        },
-      open ? 'Hide Context Inspector' : 'Open Context Inspector',
-    ),
-    open
-      ? h('div', { className: 'feed-card', style: 'margin-top:12px;' }, [
-          h('div', { className: 'feed-card-header' }, [
-            h('div', { className: 'feed-card-title' }, 'Context Inspector'),
-            h('div', { className: 'feed-card-meta' }, 'Tracing the current Search query'),
-          ]),
-          h('div', { className: 'feed-card-body' }, [
-            h('input', {
-              className: 'feed-search',
-              onInput: (event) => {
-                state.feedQuery = String((event.currentTarget as HTMLInputElement).value || '');
-                setTrace(null);
-                setError('');
-                setErrorContextKey('');
-                updateFeedView();
-              },
-              placeholder: 'Trace a pack query…',
-              value: state.feedQuery,
-            }),
-            h('textarea', {
-              onInput: (event) => setWorkingSetText(String((event.currentTarget as HTMLTextAreaElement).value || '')),
-              placeholder: 'Optional working-set files, one per line',
-              rows: 3,
-              style: 'margin-top:8px; width:100%;',
-              value: workingSetText,
-            }),
-            h(
-              'div',
-              { style: 'display:flex; gap:8px; margin-top:8px; align-items:center;' },
-              h(
-                'button',
-                { className: 'toggle-button active', disabled: loading, onClick: () => void runTrace(), type: 'button' },
-                loading ? 'Tracing…' : 'Run trace',
-              ),
-              visibleTrace
-                ? h('span', { className: 'section-meta' }, `mode=${visibleTrace.mode.selected} · candidates=${visibleTrace.retrieval.candidate_count} · tokens=${visibleTrace.output.estimated_tokens}`)
-                : null,
-            ),
-            trace && !visibleTrace
-              ? h('div', { className: 'section-meta', style: 'margin-top:8px;' }, 'Search context changed. Run trace again for the current query and project.')
-              : null,
-            visibleError ? h('div', { className: 'section-meta', style: 'margin-top:8px; color:#d96c6c;' }, visibleError) : null,
-          ]),
-          visibleTrace
-            ? h(Fragment, null, [
-                h(TraceCandidateGroup, { label: 'Selected', candidates: selected }),
-                h(TraceCandidateGroup, { label: 'Dropped', candidates: dropped }),
-                h(TraceCandidateGroup, { label: 'Deduped', candidates: deduped }),
-                h(TraceCandidateGroup, { label: 'Trimmed', candidates: trimmed }),
-                h('div', { className: 'feed-card-body' }, [
-                  visibleTrace.assembly.collapsed_groups.length
-                    ? h(
-                        'div',
-                        { className: 'section-meta' },
-                        `Collapsed duplicates: ${visibleTrace.assembly.collapsed_groups
-                          .map((group) => `kept #${group.kept} from [${group.dropped.join(', ')}]`)
-                          .join(' · ')}`,
-                      )
-                    : null,
-                  visibleTrace.assembly.trim_reasons.length
-                    ? h('div', { className: 'section-meta' }, `Trim reasons: ${visibleTrace.assembly.trim_reasons.join(', ')}`)
-                    : null,
-                  h('div', { className: 'section-meta' }, 'Final pack'),
-                  h('pre', { style: 'white-space:pre-wrap; overflow:auto;' }, visibleTrace.output.pack_text),
-                ]),
-              ])
-            : null,
-        ])
-      : null,
-  );
+	return h(
+		"div",
+		{ className: "feed-inspector" },
+		h(
+			"button",
+			{
+				className: "toggle-button",
+				onClick: () => setOpen(!open),
+				type: "button",
+			},
+			open ? "Hide Context Inspector" : "Open Context Inspector",
+		),
+		open
+			? h("div", { className: "feed-card", style: "margin-top:12px;" }, [
+					h("div", { className: "feed-card-header" }, [
+						h("div", { className: "feed-card-title" }, "Context Inspector"),
+						h("div", { className: "feed-card-meta" }, "Tracing the current Search query"),
+					]),
+					h("div", { className: "feed-card-body" }, [
+						h("input", {
+							className: "feed-search",
+							onInput: (event) => {
+								state.feedQuery = String((event.currentTarget as HTMLInputElement).value || "");
+								setTrace(null);
+								setError("");
+								setErrorContextKey("");
+								updateFeedView();
+							},
+							placeholder: "Trace a pack query…",
+							value: state.feedQuery,
+						}),
+						h("textarea", {
+							onInput: (event) =>
+								setWorkingSetText(String((event.currentTarget as HTMLTextAreaElement).value || "")),
+							placeholder: "Optional working-set files, one per line",
+							rows: 3,
+							style: "margin-top:8px; width:100%;",
+							value: workingSetText,
+						}),
+						h(
+							"div",
+							{ style: "display:flex; gap:8px; margin-top:8px; align-items:center;" },
+							h(
+								"button",
+								{
+									className: "toggle-button active",
+									disabled: loading,
+									onClick: () => void runTrace(),
+									type: "button",
+								},
+								loading ? "Tracing…" : "Run trace",
+							),
+							visibleTrace
+								? h(
+										"span",
+										{ className: "section-meta" },
+										`mode=${visibleTrace.mode.selected} · candidates=${visibleTrace.retrieval.candidate_count} · tokens=${visibleTrace.output.estimated_tokens}`,
+									)
+								: null,
+						),
+						trace && !visibleTrace
+							? h(
+									"div",
+									{ className: "section-meta", style: "margin-top:8px;" },
+									"Search context changed. Run trace again for the current query and project.",
+								)
+							: null,
+						visibleError
+							? h(
+									"div",
+									{ className: "section-meta", style: "margin-top:8px; color:#d96c6c;" },
+									visibleError,
+								)
+							: null,
+					]),
+					visibleTrace
+						? h(Fragment, null, [
+								h(TraceCandidateGroup, { label: "Selected", candidates: selected }),
+								h(TraceCandidateGroup, { label: "Dropped", candidates: dropped }),
+								h(TraceCandidateGroup, { label: "Deduped", candidates: deduped }),
+								h(TraceCandidateGroup, { label: "Trimmed", candidates: trimmed }),
+								h("div", { className: "feed-card-body" }, [
+									visibleTrace.assembly.collapsed_groups.length
+										? h(
+												"div",
+												{ className: "section-meta" },
+												`Collapsed duplicates: ${visibleTrace.assembly.collapsed_groups
+													.map((group) => `kept #${group.kept} from [${group.dropped.join(", ")}]`)
+													.join(" · ")}`,
+											)
+										: null,
+									visibleTrace.assembly.trim_reasons.length
+										? h(
+												"div",
+												{ className: "section-meta" },
+												`Trim reasons: ${visibleTrace.assembly.trim_reasons.join(", ")}`,
+											)
+										: null,
+									h("div", { className: "section-meta" }, "Final pack"),
+									h(
+										"pre",
+										{ style: "white-space:pre-wrap; overflow:auto;" },
+										visibleTrace.output.pack_text,
+									),
+								]),
+							])
+						: null,
+				])
+			: null,
+	);
 }
 
 function FeedTabView({ items, loadingText }: { items: any[]; loadingText?: string }) {
-  return h(
-    Fragment,
-    null,
-    h(
-      'div',
-      { className: 'feed-controls' },
-      h('div', { className: 'section-meta', id: 'feedMeta' }, loadingText || feedMetaText(items.length)),
-      h(
-        'div',
-        { className: 'feed-controls-right' },
-        h('input', {
-          className: 'feed-search',
-          id: 'feedSearch',
-          onInput: (event) => {
-            state.feedQuery = String((event.currentTarget as HTMLInputElement).value || '');
-            updateFeedView();
-          },
-          placeholder: 'Search title, body, tags…',
-          value: state.feedQuery,
-        }),
-        h(ContextInspectorPanel, {}),
-        h(FeedToggle, {
-          active: state.feedScopeFilter,
-          id: 'feedScopeToggle',
-          onSelect: (value) => {
-            if (value === state.feedScopeFilter) return;
-            setFeedScopeFilter(value);
-            void loadFeedData();
-          },
-          options: [
-            { value: 'all', label: 'All' },
-            { value: 'mine', label: 'My memories' },
-            { value: 'theirs', label: 'Other people' },
-          ],
-        }),
-        h(FeedToggle, {
-          active: state.feedTypeFilter,
-          id: 'feedTypeToggle',
-          onSelect: (value) => {
-            if (value === state.feedTypeFilter) return;
-            setFeedTypeFilter(value);
-            updateFeedView();
-          },
-          options: [
-            { value: 'all', label: 'All' },
-            { value: 'observations', label: 'Observations' },
-            { value: 'summaries', label: 'Summaries' },
-          ],
-        }),
-      ),
-    ),
-    h('div', { className: 'feed-list', id: 'feedList' }, h(FeedList, { items, loadingText })),
-  );
+	return h(
+		Fragment,
+		null,
+		h(
+			"div",
+			{ className: "feed-controls" },
+			h(
+				"div",
+				{ className: "section-meta", id: "feedMeta" },
+				loadingText || feedMetaText(items.length),
+			),
+			h(
+				"div",
+				{ className: "feed-controls-right" },
+				h("input", {
+					className: "feed-search",
+					id: "feedSearch",
+					onInput: (event) => {
+						state.feedQuery = String((event.currentTarget as HTMLInputElement).value || "");
+						updateFeedView();
+					},
+					placeholder: "Search title, body, tags…",
+					value: state.feedQuery,
+				}),
+				h(ContextInspectorPanel, {}),
+				h(FeedToggle, {
+					active: state.feedScopeFilter,
+					id: "feedScopeToggle",
+					onSelect: (value) => {
+						if (value === state.feedScopeFilter) return;
+						setFeedScopeFilter(value);
+						void loadFeedData();
+					},
+					options: [
+						{ value: "all", label: "All" },
+						{ value: "mine", label: "My memories" },
+						{ value: "theirs", label: "Other people" },
+					],
+				}),
+				h(FeedToggle, {
+					active: state.feedTypeFilter,
+					id: "feedTypeToggle",
+					onSelect: (value) => {
+						if (value === state.feedTypeFilter) return;
+						setFeedTypeFilter(value);
+						updateFeedView();
+					},
+					options: [
+						{ value: "all", label: "All" },
+						{ value: "observations", label: "Observations" },
+						{ value: "summaries", label: "Summaries" },
+					],
+				}),
+			),
+		),
+		h("div", { className: "feed-list", id: "feedList" }, h(FeedList, { items, loadingText })),
+	);
 }
 
 function renderFeedTab(items: any[], options?: { loadingText?: string }) {
-  const feedTab = document.getElementById('tab-feed');
-  if (!feedTab) return false;
-  renderIntoFeedMount(feedTab, h(FeedTabView, { items, loadingText: options?.loadingText }));
-  if (typeof (globalThis as any).lucide !== 'undefined' && !options?.loadingText) {
-    (globalThis as any).lucide.createIcons();
-  }
-  return true;
+	const feedTab = document.getElementById("tab-feed");
+	if (!feedTab) return false;
+	renderIntoFeedMount(feedTab, h(FeedTabView, { items, loadingText: options?.loadingText }));
+	if (typeof (globalThis as any).lucide !== "undefined" && !options?.loadingText) {
+		(globalThis as any).lucide.createIcons();
+	}
+	return true;
 }
 
 function renderProjectSwitchLoadingState() {
-  renderFeedTab([], { loadingText: 'Loading selected project...' });
+	renderFeedTab([], { loadingText: "Loading selected project..." });
 }
 
 /* ── Public API ──────────────────────────────────────────── */
 
 export function initFeedTab() {
-  ensureFeedRenderBoundary();
-  renderFeedTab(state.lastFeedItems, state.lastFeedItems.length || state.lastFeedSignature ? undefined : { loadingText: 'Loading memories…' });
+	ensureFeedRenderBoundary();
+	renderFeedTab(
+		state.lastFeedItems,
+		state.lastFeedItems.length || state.lastFeedSignature
+			? undefined
+			: { loadingText: "Loading memories…" },
+	);
 
-  if (!feedScrollHandlerBound) {
-    window.addEventListener('scroll', () => {
-      maybeLoadMoreFeedPage();
-    }, { passive: true });
-    feedScrollHandlerBound = true;
-  }
+	if (!feedScrollHandlerBound) {
+		window.addEventListener(
+			"scroll",
+			() => {
+				maybeLoadMoreFeedPage();
+			},
+			{ passive: true },
+		);
+		feedScrollHandlerBound = true;
+	}
 }
 
 export function updateFeedTypeToggle() {
-  updateFeedView(true);
+	updateFeedView(true);
 }
 
 export function updateFeedScopeToggle() {
-  updateFeedView(true);
+	updateFeedView(true);
 }
 
 export function updateFeedView(force = false) {
-  const feedTab = document.getElementById('tab-feed');
-  if (!feedTab) return;
+	const feedTab = document.getElementById("tab-feed");
+	if (!feedTab) return;
 
-  const scrollY = window.scrollY;
-  const byType = filterByType(state.lastFeedItems);
-  const visible = filterByQuery(byType);
+	const scrollY = window.scrollY;
+	const byType = filterByType(state.lastFeedItems);
+	const visible = filterByQuery(byType);
 
-  const sig = computeSignature(visible);
-  const changed = force || sig !== state.lastFeedSignature;
-  state.lastFeedSignature = sig;
+	const sig = computeSignature(visible);
+	const changed = force || sig !== state.lastFeedSignature;
+	state.lastFeedSignature = sig;
 
-  if (changed) {
-    renderFeedTab(visible);
-  }
+	if (changed) {
+		renderFeedTab(visible);
+	}
 
-  window.scrollTo({ top: scrollY });
-  maybeLoadMoreFeedPage();
+	window.scrollTo({ top: scrollY });
+	maybeLoadMoreFeedPage();
 }
 
 export async function loadFeedData() {
-  const project = state.currentProject || '';
-  const scopeChanged = state.feedScopeFilter !== lastFeedScope;
-  if (project !== lastFeedProject || scopeChanged) {
-    resetPagination(project);
-    renderProjectSwitchLoadingState();
-  }
-  const requestGeneration = feedProjectGeneration;
+	const project = state.currentProject || "";
+	const scopeChanged = state.feedScopeFilter !== lastFeedScope;
+	if (project !== lastFeedProject || scopeChanged) {
+		resetPagination(project);
+		renderProjectSwitchLoadingState();
+	}
+	const requestGeneration = feedProjectGeneration;
 
-  const observationsLimit = OBSERVATION_PAGE_SIZE;
-  const summariesLimit = SUMMARY_PAGE_SIZE;
+	const observationsLimit = OBSERVATION_PAGE_SIZE;
+	const summariesLimit = SUMMARY_PAGE_SIZE;
 
-  const [observations, summaries] = await Promise.all([
-    api.loadMemoriesPage(project, { limit: observationsLimit, offset: 0, scope: state.feedScopeFilter }),
-    api.loadSummariesPage(project, { limit: summariesLimit, offset: 0, scope: state.feedScopeFilter }),
-  ]);
+	const [observations, summaries] = await Promise.all([
+		api.loadMemoriesPage(project, {
+			limit: observationsLimit,
+			offset: 0,
+			scope: state.feedScopeFilter,
+		}),
+		api.loadSummariesPage(project, {
+			limit: summariesLimit,
+			offset: 0,
+			scope: state.feedScopeFilter,
+		}),
+	]);
 
-  if (requestGeneration !== feedProjectGeneration || project !== (state.currentProject || '')) {
-    return;
-  }
+	if (requestGeneration !== feedProjectGeneration || project !== (state.currentProject || "")) {
+		return;
+	}
 
-  const summaryItems = summaries.items || [];
-  const observationItems = observations.items || [];
-  const filtered = observationItems.filter((i: any) => !isLowSignalObservation(i));
-  const filteredCount = observationItems.length - filtered.length;
-  const firstPageFeedItems = [...summaryItems, ...filtered].sort((a, b) => {
-    return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
-  });
-  const feedItems = mergeRefreshFeedItems(state.lastFeedItems, firstPageFeedItems);
+	const summaryItems = summaries.items || [];
+	const observationItems = observations.items || [];
+	const filtered = observationItems.filter((i: any) => !isLowSignalObservation(i));
+	const filteredCount = observationItems.length - filtered.length;
+	const firstPageFeedItems = [...summaryItems, ...filtered].sort((a, b) => {
+		return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
+	});
+	const feedItems = mergeRefreshFeedItems(state.lastFeedItems, firstPageFeedItems);
 
-  const newCount = countNewItems(feedItems, state.lastFeedItems);
-  if (newCount) {
-    const seen = new Set(state.lastFeedItems.map(itemKey));
-    feedItems.forEach((item: any) => {
-      if (!seen.has(itemKey(item))) state.newItemKeys.add(itemKey(item));
-    });
-  }
+	const newCount = countNewItems(feedItems, state.lastFeedItems);
+	if (newCount) {
+		const seen = new Set(state.lastFeedItems.map(itemKey));
+		feedItems.forEach((item: any) => {
+			if (!seen.has(itemKey(item))) state.newItemKeys.add(itemKey(item));
+		});
+	}
 
-  state.pendingFeedItems = null;
-  state.lastFeedItems = feedItems;
-  state.lastFeedFilteredCount = Math.max(state.lastFeedFilteredCount, filteredCount);
-  summaryHasMore = pageHasMore(summaries, summaryItems.length, summariesLimit);
-  observationHasMore = pageHasMore(observations, observationItems.length, observationsLimit);
-  summaryOffset = Math.max(summaryOffset, pageNextOffset(summaries, summaryItems.length));
-  observationOffset = Math.max(observationOffset, pageNextOffset(observations, observationItems.length));
-  lastFeedScope = state.feedScopeFilter;
-  updateFeedView();
+	state.pendingFeedItems = null;
+	state.lastFeedItems = feedItems;
+	state.lastFeedFilteredCount = Math.max(state.lastFeedFilteredCount, filteredCount);
+	summaryHasMore = pageHasMore(summaries, summaryItems.length, summariesLimit);
+	observationHasMore = pageHasMore(observations, observationItems.length, observationsLimit);
+	summaryOffset = Math.max(summaryOffset, pageNextOffset(summaries, summaryItems.length));
+	observationOffset = Math.max(
+		observationOffset,
+		pageNextOffset(observations, observationItems.length),
+	);
+	lastFeedScope = state.feedScopeFilter;
+	updateFeedView();
 }

--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -1,496 +1,697 @@
 /* Health tab — system health, stats, session overview. */
 
-import { Fragment, h, render } from 'preact';
-import { copyToClipboard } from '../lib/dom';
+import { Fragment, h, render } from "preact";
+import * as api from "../lib/api";
+import { copyToClipboard } from "../lib/dom";
 import {
-  formatAgeShort,
-  formatMultiplier,
-  formatPercent,
-  formatReductionPercent,
-  formatTimestamp,
-  parsePercentValue,
-  secondsSince,
-  titleCase,
-} from '../lib/format';
-import { state, isDetailsOpen, setDetailsOpen } from '../lib/state';
-import * as api from '../lib/api';
-import { updateFeedView } from './feed';
+	formatAgeShort,
+	formatMultiplier,
+	formatPercent,
+	formatReductionPercent,
+	formatTimestamp,
+	parsePercentValue,
+	secondsSince,
+	titleCase,
+} from "../lib/format";
+import { state } from "../lib/state";
+import { updateFeedView } from "./feed";
 
 type HealthAction = {
-  label: string;
-  command: string;
-  /** If set, show an actionable button that triggers this async function. */
-  action?: () => Promise<void>;
-  actionLabel?: string;
+	label: string;
+	command: string;
+	/** If set, show an actionable button that triggers this async function. */
+	action?: () => Promise<void>;
+	actionLabel?: string;
 };
 
 /* ── Health card builder ─────────────────────────────────── */
 
 type HealthCardInput = {
-  label: string;
-  value: string;
-  detail?: string;
-  icon?: string;
-  className?: string;
-  title?: string;
+	label: string;
+	value: string;
+	detail?: string;
+	icon?: string;
+	className?: string;
+	title?: string;
 };
 
 type HealthActionRowProps = {
-  item: HealthAction;
+	item: HealthAction;
 };
 
 type StatItem = {
-  label: string;
-  value: string | number | null | undefined;
-  icon: string;
-  tooltip?: string;
+	label: string;
+	value: string | number | null | undefined;
+	icon: string;
+	tooltip?: string;
 };
 
 type UsageEvent = {
-  event?: string;
-  count?: number;
+	event?: string;
+	count?: number;
 };
 
 type LucideRuntime = {
-  createIcons: () => void;
+	createIcons: () => void;
 };
 
 function buildHealthCard(input: HealthCardInput): HealthCardInput {
-  return input;
+	return input;
 }
 
 function HealthCard({ label, value, detail, icon, className, title }: HealthCardInput) {
-  return (
-    h(
-      'div',
-      {
-        class: `stat${className ? ` ${className}` : ''}`,
-        title,
-        style: title ? 'cursor: help;' : undefined,
-      },
-      icon
-        ? h('i', {
-            'data-lucide': icon,
-            class: 'stat-icon',
-          })
-        : null,
-      h(
-        'div',
-        { class: 'stat-content' },
-        h('div', { class: 'value' }, value),
-        h('div', { class: 'label' }, label),
-        detail ? h('div', { class: 'small' }, detail) : null,
-      ),
-    )
-  );
+	return h(
+		"div",
+		{
+			class: `stat${className ? ` ${className}` : ""}`,
+			title,
+			style: title ? "cursor: help;" : undefined,
+		},
+		icon
+			? h("i", {
+					"data-lucide": icon,
+					class: "stat-icon",
+				})
+			: null,
+		h(
+			"div",
+			{ class: "stat-content" },
+			h("div", { class: "value" }, value),
+			h("div", { class: "label" }, label),
+			detail ? h("div", { class: "small" }, detail) : null,
+		),
+	);
 }
 
 function HealthActionRow({ item }: HealthActionRowProps) {
-  let actionButton: HTMLButtonElement | null = null;
-  let copyButton: HTMLButtonElement | null = null;
-  const actionLabel = item.actionLabel || 'Run';
+	let actionButton: HTMLButtonElement | null = null;
+	let copyButton: HTMLButtonElement | null = null;
+	const actionLabel = item.actionLabel || "Run";
 
-  async function handleAction() {
-    if (!item.action || !actionButton) return;
-    actionButton.disabled = true;
-    actionButton.textContent = 'Running…';
-    try {
-      await item.action();
-    } catch {}
-    actionButton.disabled = false;
-    actionButton.textContent = actionLabel;
-  }
+	async function handleAction() {
+		if (!item.action || !actionButton) return;
+		actionButton.disabled = true;
+		actionButton.textContent = "Running…";
+		try {
+			await item.action();
+		} catch {}
+		actionButton.disabled = false;
+		actionButton.textContent = actionLabel;
+	}
 
-  function handleCopy() {
-    if (!item.command || !copyButton) return;
-    copyToClipboard(item.command, copyButton);
-  }
+	function handleCopy() {
+		if (!item.command || !copyButton) return;
+		copyToClipboard(item.command, copyButton);
+	}
 
-  return h(
-    'div',
-    { class: 'health-action' },
-    h(
-      'div',
-      { class: 'health-action-text' },
-      item.label,
-      item.command ? h('span', { class: 'health-action-command' }, item.command) : null,
-    ),
-    h(
-      'div',
-      { class: 'health-action-buttons' },
-      item.action
-        ? h(
-            'button',
-            {
-              class: 'settings-button',
-              onClick: handleAction,
-              ref: (node: HTMLButtonElement | null) => {
-                actionButton = node;
-              },
-            },
-            actionLabel,
-          )
-        : null,
-      item.command
-        ? h(
-            'button',
-            {
-              class: 'settings-button health-action-copy',
-              onClick: handleCopy,
-              ref: (node: HTMLButtonElement | null) => {
-                copyButton = node;
-              },
-            },
-            'Copy',
-          )
-        : null,
-    ),
-  );
+	return h(
+		"div",
+		{ class: "health-action" },
+		h(
+			"div",
+			{ class: "health-action-text" },
+			item.label,
+			item.command ? h("span", { class: "health-action-command" }, item.command) : null,
+		),
+		h(
+			"div",
+			{ class: "health-action-buttons" },
+			item.action
+				? h(
+						"button",
+						{
+							class: "settings-button",
+							onClick: handleAction,
+							ref: (node: HTMLButtonElement | null) => {
+								actionButton = node;
+							},
+						},
+						actionLabel,
+					)
+				: null,
+			item.command
+				? h(
+						"button",
+						{
+							class: "settings-button health-action-copy",
+							onClick: handleCopy,
+							ref: (node: HTMLButtonElement | null) => {
+								copyButton = node;
+							},
+						},
+						"Copy",
+					)
+				: null,
+		),
+	);
 }
 
-function formatStatValue(value: StatItem['value']): string {
-  if (typeof value === 'number') return value.toLocaleString();
-  if (value == null) return 'n/a';
-  return String(value);
+function formatStatValue(value: StatItem["value"]): string {
+	if (typeof value === "number") return value.toLocaleString();
+	if (value == null) return "n/a";
+	return String(value);
 }
 
 function StatBlock({ label, value, icon, tooltip }: StatItem) {
-  return h(
-    'div',
-    {
-      class: 'stat',
-      title: tooltip,
-      style: tooltip ? 'cursor: help;' : undefined,
-    },
-    h('i', {
-      'data-lucide': icon,
-      class: 'stat-icon',
-    }),
-    h(
-      'div',
-      { class: 'stat-content' },
-      h('div', { class: 'value' }, formatStatValue(value)),
-      h('div', { class: 'label' }, label),
-    ),
-  );
+	return h(
+		"div",
+		{
+			class: "stat",
+			title: tooltip,
+			style: tooltip ? "cursor: help;" : undefined,
+		},
+		h("i", {
+			"data-lucide": icon,
+			class: "stat-icon",
+		}),
+		h(
+			"div",
+			{ class: "stat-content" },
+			h("div", { class: "value" }, formatStatValue(value)),
+			h("div", { class: "label" }, label),
+		),
+	);
 }
 
 function renderStatBlocks(container: HTMLElement | null, items: StatItem[]) {
-  if (!container) return;
-  render(
-    h(Fragment, null, items.map((item) => h(StatBlock, { ...item, key: `${item.label}-${item.icon}` }))),
-    container,
-  );
+	if (!container) return;
+	render(
+		h(
+			Fragment,
+			null,
+			items.map((item) => h(StatBlock, { ...item, key: `${item.label}-${item.icon}` })),
+		),
+		container,
+	);
 }
 
 function renderText(container: HTMLElement | null, value: string) {
-  if (!container) return;
-  render(h(Fragment, null, value), container);
+	if (!container) return;
+	render(h(Fragment, null, value), container);
 }
 
 function renderIcons() {
-  const lucide = (globalThis as typeof globalThis & { lucide?: LucideRuntime }).lucide;
-  if (lucide && typeof lucide.createIcons === 'function') lucide.createIcons();
+	const lucide = (globalThis as typeof globalThis & { lucide?: LucideRuntime }).lucide;
+	if (lucide && typeof lucide.createIcons === "function") lucide.createIcons();
 }
 
 function renderHealthCards(container: HTMLElement | null, cards: HealthCardInput[]) {
-  if (!container) return;
-  render(
-    h(
-      Fragment,
-      null,
-      cards.map((card) => h(HealthCard, { ...card, key: `${card.label}-${card.value}` })),
-    ),
-    container,
-  );
+	if (!container) return;
+	render(
+		h(
+			Fragment,
+			null,
+			cards.map((card) => h(HealthCard, { ...card, key: `${card.label}-${card.value}` })),
+		),
+		container,
+	);
 }
 
 function renderActionList(container: HTMLElement | null, actions: HealthAction[]) {
-  if (!container) return;
-  if (!actions.length) {
-    container.hidden = true;
-    render(null, container);
-    return;
-  }
+	if (!container) return;
+	if (!actions.length) {
+		container.hidden = true;
+		render(null, container);
+		return;
+	}
 
-  container.hidden = false;
-  render(
-    h(
-      Fragment,
-      null,
-      actions
-        .slice(0, 3)
-        .map((item, index) => h(HealthActionRow, { item, key: `${item.label}-${index}` })),
-    ),
-    container,
-  );
+	container.hidden = false;
+	render(
+		h(
+			Fragment,
+			null,
+			actions
+				.slice(0, 3)
+				.map((item, index) => h(HealthActionRow, { item, key: `${item.label}-${index}` })),
+		),
+		container,
+	);
 }
 
 /* ── Health overview renderer ────────────────────────────── */
 
 export function renderHealthOverview() {
-  const healthGrid = document.getElementById('healthGrid');
-  const healthMeta = document.getElementById('healthMeta');
-  const healthActions = document.getElementById('healthActions');
-  const healthDot = document.getElementById('healthDot');
-  if (!healthGrid || !healthMeta) return;
+	const healthGrid = document.getElementById("healthGrid");
+	const healthMeta = document.getElementById("healthMeta");
+	const healthActions = document.getElementById("healthActions");
+	const healthDot = document.getElementById("healthDot");
+	if (!healthGrid || !healthMeta) return;
 
-  const stats = state.lastStatsPayload || {};
-  const usagePayload = state.lastUsagePayload || {};
-  const raw = state.lastRawEventsPayload && typeof state.lastRawEventsPayload === 'object' ? state.lastRawEventsPayload : {};
-  const syncStatus = state.lastSyncStatus || {};
-  const maintenanceJobs: Array<{
-    kind?: string;
-    title?: string;
-    status?: string;
-    message?: string | null;
-    error?: string | null;
-    progress?: { current?: number; total?: number | null; unit?: string };
-  }> = Array.isArray(stats.maintenance_jobs) ? stats.maintenance_jobs : [];
-  const reliability = stats.reliability || {};
-  const counts = reliability.counts || {};
-  const rates = reliability.rates || {};
-  const dbStats = stats.database || {};
-  const totals = usagePayload.totals_filtered || usagePayload.totals || usagePayload.totals_global || stats.usage?.totals || {};
-  const recentPacks = Array.isArray(usagePayload.recent_packs) ? usagePayload.recent_packs : [];
-  const lastPackAt = recentPacks.length ? recentPacks[0]?.created_at : null;
-  const latestPackMeta = recentPacks.length ? (recentPacks[0]?.metadata_json || {}) : {};
-  const latestPackDeduped = Number(latestPackMeta?.exact_duplicates_collapsed || 0);
-  const rawPending = Number(raw.pending || 0);
-  const erroredBatches = Number(counts.errored_batches || 0);
-  const flushSuccessRate = Number(rates.flush_success_rate ?? 1);
-  const droppedRate = Number(rates.dropped_event_rate || 0);
-  const reductionLabel = formatReductionPercent(totals.tokens_saved, totals.tokens_read);
-  const reductionPercent = parsePercentValue(reductionLabel);
-  const tagCoverage = Number(dbStats.tags_coverage || 0);
-  const syncState = String(syncStatus.daemon_state || 'unknown');
-  const syncStateLabel =
-    syncState === 'offline-peers'
-      ? 'Offline peers'
-      : syncState === 'needs_attention'
-        ? 'Needs attention'
-        : syncState === 'rebootstrapping'
-          ? 'Rebootstrapping'
-          : titleCase(syncState);
-  const peerCount = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers.length : 0;
-  const syncDisabled = syncState === 'disabled' || syncStatus.enabled === false;
-  const syncOfflinePeers = syncState === 'offline-peers';
-  const syncNoPeers = !syncDisabled && peerCount === 0;
-  const syncCardValue = syncDisabled ? 'Disabled' : syncNoPeers ? 'No peers' : syncStateLabel;
-  const lastSyncAt = syncStatus.last_sync_at || syncStatus.last_sync_at_utc || null;
-  const syncAgeSeconds = secondsSince(lastSyncAt);
-  const packAgeSeconds = secondsSince(lastPackAt);
-  const syncLooksStale = syncAgeSeconds !== null && syncAgeSeconds > 7200;
-  const hasBacklog = rawPending >= 200;
+	const stats = state.lastStatsPayload || {};
+	const usagePayload = state.lastUsagePayload || {};
+	const raw =
+		state.lastRawEventsPayload && typeof state.lastRawEventsPayload === "object"
+			? state.lastRawEventsPayload
+			: {};
+	const syncStatus = state.lastSyncStatus || {};
+	const maintenanceJobs: Array<{
+		kind?: string;
+		title?: string;
+		status?: string;
+		message?: string | null;
+		error?: string | null;
+		progress?: { current?: number; total?: number | null; unit?: string };
+	}> = Array.isArray(stats.maintenance_jobs) ? stats.maintenance_jobs : [];
+	const reliability = stats.reliability || {};
+	const counts = reliability.counts || {};
+	const rates = reliability.rates || {};
+	const dbStats = stats.database || {};
+	const totals =
+		usagePayload.totals_filtered ||
+		usagePayload.totals ||
+		usagePayload.totals_global ||
+		stats.usage?.totals ||
+		{};
+	const recentPacks = Array.isArray(usagePayload.recent_packs) ? usagePayload.recent_packs : [];
+	const lastPackAt = recentPacks.length ? recentPacks[0]?.created_at : null;
+	const latestPackMeta = recentPacks.length ? recentPacks[0]?.metadata_json || {} : {};
+	const latestPackDeduped = Number(latestPackMeta?.exact_duplicates_collapsed || 0);
+	const rawPending = Number(raw.pending || 0);
+	const erroredBatches = Number(counts.errored_batches || 0);
+	const flushSuccessRate = Number(rates.flush_success_rate ?? 1);
+	const droppedRate = Number(rates.dropped_event_rate || 0);
+	const reductionLabel = formatReductionPercent(totals.tokens_saved, totals.tokens_read);
+	const reductionPercent = parsePercentValue(reductionLabel);
+	const tagCoverage = Number(dbStats.tags_coverage || 0);
+	const syncState = String(syncStatus.daemon_state || "unknown");
+	const syncStateLabel =
+		syncState === "offline-peers"
+			? "Offline peers"
+			: syncState === "needs_attention"
+				? "Needs attention"
+				: syncState === "rebootstrapping"
+					? "Rebootstrapping"
+					: titleCase(syncState);
+	const peerCount = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers.length : 0;
+	const syncDisabled = syncState === "disabled" || syncStatus.enabled === false;
+	const syncOfflinePeers = syncState === "offline-peers";
+	const syncNoPeers = !syncDisabled && peerCount === 0;
+	const syncCardValue = syncDisabled ? "Disabled" : syncNoPeers ? "No peers" : syncStateLabel;
+	const lastSyncAt = syncStatus.last_sync_at || syncStatus.last_sync_at_utc || null;
+	const syncAgeSeconds = secondsSince(lastSyncAt);
+	const packAgeSeconds = secondsSince(lastPackAt);
+	const syncLooksStale = syncAgeSeconds !== null && syncAgeSeconds > 7200;
+	const hasBacklog = rawPending >= 200;
 
-  // Risk scoring
-  let riskScore = 0;
-  const drivers: string[] = [];
-  if (rawPending >= 1000) { riskScore += 40; drivers.push('high raw-event backlog'); }
-  else if (rawPending >= 200) { riskScore += 24; drivers.push('growing raw-event backlog'); }
-  if (erroredBatches > 0 && rawPending >= 200) { riskScore += erroredBatches >= 5 ? 10 : 6; drivers.push('batch errors during backlog pressure'); }
-  if (flushSuccessRate < 0.95) { riskScore += 20; drivers.push('lower flush success'); }
-  if (droppedRate > 0.02) { riskScore += 24; drivers.push('high dropped-event rate'); }
-  else if (droppedRate > 0.005) { riskScore += 10; drivers.push('non-trivial dropped-event rate'); }
-  if (!syncDisabled && !syncNoPeers) {
-    if (syncState === 'error') { riskScore += 36; drivers.push('sync daemon reports errors'); }
-    else if (syncState === 'needs_attention') { riskScore += 40; drivers.push('sync needs manual attention'); }
-    else if (syncState === 'stopped') { riskScore += 22; drivers.push('sync daemon stopped'); }
-    else if (syncState === 'degraded') { riskScore += 20; drivers.push('sync daemon degraded'); }
-    if (syncOfflinePeers) { riskScore += 4; drivers.push('all peers currently offline'); if (syncLooksStale) { riskScore += 4; drivers.push('offline peers and sync not recent'); } }
-    else { if (syncLooksStale) { riskScore += 26; drivers.push('sync looks stale'); } else if (syncAgeSeconds !== null && syncAgeSeconds > 1800) { riskScore += 12; drivers.push('sync not recent'); } }
-  }
-  if (reductionPercent !== null && reductionPercent < 10) { riskScore += 8; drivers.push('low retrieval reduction'); }
-  if (packAgeSeconds !== null && packAgeSeconds > 86400) { riskScore += 12; drivers.push('memory pack activity is old'); }
+	// Risk scoring
+	let riskScore = 0;
+	const drivers: string[] = [];
+	if (rawPending >= 1000) {
+		riskScore += 40;
+		drivers.push("high raw-event backlog");
+	} else if (rawPending >= 200) {
+		riskScore += 24;
+		drivers.push("growing raw-event backlog");
+	}
+	if (erroredBatches > 0 && rawPending >= 200) {
+		riskScore += erroredBatches >= 5 ? 10 : 6;
+		drivers.push("batch errors during backlog pressure");
+	}
+	if (flushSuccessRate < 0.95) {
+		riskScore += 20;
+		drivers.push("lower flush success");
+	}
+	if (droppedRate > 0.02) {
+		riskScore += 24;
+		drivers.push("high dropped-event rate");
+	} else if (droppedRate > 0.005) {
+		riskScore += 10;
+		drivers.push("non-trivial dropped-event rate");
+	}
+	if (!syncDisabled && !syncNoPeers) {
+		if (syncState === "error") {
+			riskScore += 36;
+			drivers.push("sync daemon reports errors");
+		} else if (syncState === "needs_attention") {
+			riskScore += 40;
+			drivers.push("sync needs manual attention");
+		} else if (syncState === "stopped") {
+			riskScore += 22;
+			drivers.push("sync daemon stopped");
+		} else if (syncState === "degraded") {
+			riskScore += 20;
+			drivers.push("sync daemon degraded");
+		}
+		if (syncOfflinePeers) {
+			riskScore += 4;
+			drivers.push("all peers currently offline");
+			if (syncLooksStale) {
+				riskScore += 4;
+				drivers.push("offline peers and sync not recent");
+			}
+		} else {
+			if (syncLooksStale) {
+				riskScore += 26;
+				drivers.push("sync looks stale");
+			} else if (syncAgeSeconds !== null && syncAgeSeconds > 1800) {
+				riskScore += 12;
+				drivers.push("sync not recent");
+			}
+		}
+	}
+	if (reductionPercent !== null && reductionPercent < 10) {
+		riskScore += 8;
+		drivers.push("low retrieval reduction");
+	}
+	if (packAgeSeconds !== null && packAgeSeconds > 86400) {
+		riskScore += 12;
+		drivers.push("memory pack activity is old");
+	}
 
-  let statusLabel = 'Healthy';
-  let statusClass = 'status-healthy';
-  if (riskScore >= 60) { statusLabel = 'Attention'; statusClass = 'status-attention'; }
-  else if (riskScore >= 25) { statusLabel = 'Degraded'; statusClass = 'status-degraded'; }
+	let statusLabel = "Healthy";
+	let statusClass = "status-healthy";
+	if (riskScore >= 60) {
+		statusLabel = "Attention";
+		statusClass = "status-attention";
+	} else if (riskScore >= 25) {
+		statusLabel = "Degraded";
+		statusClass = "status-degraded";
+	}
 
-  // Update header health dot
-  if (healthDot) {
-    healthDot.className = `health-dot ${statusClass}`;
-    healthDot.title = statusLabel;
-  }
+	// Update header health dot
+	if (healthDot) {
+		healthDot.className = `health-dot ${statusClass}`;
+		healthDot.title = statusLabel;
+	}
 
-  const retrievalDetail = `${Number(totals.tokens_saved || 0).toLocaleString()} saved tokens · ${latestPackDeduped.toLocaleString()} deduped in latest pack`;
-  const pipelineDetail = rawPending > 0 ? 'Queue is actively draining' : 'Queue is clear';
-  const syncDetail = syncDisabled ? 'Sync disabled' : syncNoPeers ? 'No peers configured'
-    : syncOfflinePeers ? `${peerCount} peers offline · last sync ${formatAgeShort(syncAgeSeconds)} ago`
-    : `${peerCount} peers · last sync ${formatAgeShort(syncAgeSeconds)} ago`;
-  const freshnessDetail = `last pack ${formatAgeShort(packAgeSeconds)} ago`;
+	const retrievalDetail = `${Number(totals.tokens_saved || 0).toLocaleString()} saved tokens · ${latestPackDeduped.toLocaleString()} deduped in latest pack`;
+	const pipelineDetail = rawPending > 0 ? "Queue is actively draining" : "Queue is clear";
+	const syncDetail = syncDisabled
+		? "Sync disabled"
+		: syncNoPeers
+			? "No peers configured"
+			: syncOfflinePeers
+				? `${peerCount} peers offline · last sync ${formatAgeShort(syncAgeSeconds)} ago`
+				: `${peerCount} peers · last sync ${formatAgeShort(syncAgeSeconds)} ago`;
+	const freshnessDetail = `last pack ${formatAgeShort(packAgeSeconds)} ago`;
 
-  // Build maintenance card(s) for active background jobs
-  const maintenanceCards: HealthCardInput[] = maintenanceJobs.map((job) => {
-    const current = Number(job.progress?.current || 0);
-    const total = typeof job.progress?.total === 'number' ? job.progress.total : null;
-    const unit = String(job.progress?.unit || 'items');
-    const pct = total && total > 0 ? ` (${Math.round(100 * current / total)}%)` : '';
-    const progress = total && total > 0 ? `${current.toLocaleString()}/${total.toLocaleString()} ${unit}${pct}` : `${current.toLocaleString()} ${unit}`;
-    const isFailed = job.status === 'failed';
-    const detail = isFailed ? String(job.error || 'unknown error').trim() : undefined;
-    return buildHealthCard({
-      label: String(job.title || job.kind || 'Background maintenance'),
-      value: isFailed ? 'Failed' : progress,
-      detail,
-      icon: isFailed ? 'alert-triangle' : 'loader',
-      className: isFailed ? 'status-attention' : undefined,
-      title: isFailed ? `Error: ${job.error || 'unknown'}` : `${String(job.title || 'Maintenance')} in progress`,
-    });
-  });
+	// Build maintenance card(s) for active background jobs
+	const maintenanceCards: HealthCardInput[] = maintenanceJobs.map((job) => {
+		const current = Number(job.progress?.current || 0);
+		const total = typeof job.progress?.total === "number" ? job.progress.total : null;
+		const unit = String(job.progress?.unit || "items");
+		const pct = total && total > 0 ? ` (${Math.round((100 * current) / total)}%)` : "";
+		const progress =
+			total && total > 0
+				? `${current.toLocaleString()}/${total.toLocaleString()} ${unit}${pct}`
+				: `${current.toLocaleString()} ${unit}`;
+		const isFailed = job.status === "failed";
+		const detail = isFailed ? String(job.error || "unknown error").trim() : undefined;
+		return buildHealthCard({
+			label: String(job.title || job.kind || "Background maintenance"),
+			value: isFailed ? "Failed" : progress,
+			detail,
+			icon: isFailed ? "alert-triangle" : "loader",
+			className: isFailed ? "status-attention" : undefined,
+			title: isFailed
+				? `Error: ${job.error || "unknown"}`
+				: `${String(job.title || "Maintenance")} in progress`,
+		});
+	});
 
-  const cards = [
-    buildHealthCard({ label: 'Overall health', value: statusLabel, detail: `Weighted score ${riskScore}`, icon: 'heart-pulse', className: `health-primary ${statusClass}`, title: drivers.length ? `Main signals: ${drivers.join(', ')}` : 'No major risk signals detected' }),
-    ...maintenanceCards,
-    buildHealthCard({ label: 'Pipeline health', value: `${rawPending.toLocaleString()} pending`, detail: pipelineDetail, icon: 'workflow', title: 'Raw-event queue pressure and flush reliability' }),
-    buildHealthCard({ label: 'Retrieval impact', value: reductionLabel, detail: retrievalDetail, icon: 'sparkles', title: 'Reduction from memory reuse across recent usage' }),
-    buildHealthCard({ label: 'Sync health', value: syncCardValue, detail: syncDetail, icon: 'refresh-cw', title: 'Daemon state and sync recency' }),
-    buildHealthCard({ label: 'Data freshness', value: formatAgeShort(packAgeSeconds), detail: freshnessDetail, icon: 'clock-3', title: 'Recency of last memory pack activity' }),
-  ];
-  renderHealthCards(healthGrid, cards);
+	const cards = [
+		buildHealthCard({
+			label: "Overall health",
+			value: statusLabel,
+			detail: `Weighted score ${riskScore}`,
+			icon: "heart-pulse",
+			className: `health-primary ${statusClass}`,
+			title: drivers.length
+				? `Main signals: ${drivers.join(", ")}`
+				: "No major risk signals detected",
+		}),
+		...maintenanceCards,
+		buildHealthCard({
+			label: "Pipeline health",
+			value: `${rawPending.toLocaleString()} pending`,
+			detail: pipelineDetail,
+			icon: "workflow",
+			title: "Raw-event queue pressure and flush reliability",
+		}),
+		buildHealthCard({
+			label: "Retrieval impact",
+			value: reductionLabel,
+			detail: retrievalDetail,
+			icon: "sparkles",
+			title: "Reduction from memory reuse across recent usage",
+		}),
+		buildHealthCard({
+			label: "Sync health",
+			value: syncCardValue,
+			detail: syncDetail,
+			icon: "refresh-cw",
+			title: "Daemon state and sync recency",
+		}),
+		buildHealthCard({
+			label: "Data freshness",
+			value: formatAgeShort(packAgeSeconds),
+			detail: freshnessDetail,
+			icon: "clock-3",
+			title: "Recency of last memory pack activity",
+		}),
+	];
+	renderHealthCards(healthGrid, cards);
 
-  // Recommendations
-  const triggerSync = async () => {
-    await api.triggerSync();
-  };
-  const recommendations: HealthAction[] = [];
-  if (hasBacklog) {
-    recommendations.push({ label: 'Pipeline needs attention. Check queue health first.', command: 'codemem db raw-events-status' });
-    recommendations.push({ label: 'Then retry failed batches for impacted sessions.', command: 'codemem db raw-events-retry <opencode_session_id>' });
-  } else if (syncState === 'stopped') {
-    recommendations.push({ label: 'Sync daemon is stopped. Start the background service.', command: 'codemem sync start' });
-  } else if (!syncDisabled && !syncNoPeers && (syncState === 'error' || syncState === 'degraded')) {
-    recommendations.push({ label: 'Sync is unhealthy. Restart and run one immediate pass.', command: 'codemem sync restart', action: triggerSync, actionLabel: 'Sync now' });
-    recommendations.push({ label: 'Then run doctor to see root cause details.', command: 'codemem sync doctor' });
-  } else if (!syncDisabled && !syncNoPeers && syncLooksStale) {
-    recommendations.push({ label: 'Sync is stale. Run one immediate sync pass.', command: 'codemem sync once', action: triggerSync, actionLabel: 'Sync now' });
-  }
-  if (tagCoverage > 0 && tagCoverage < 0.7 && recommendations.length < 2) {
-    recommendations.push({ label: 'Tag coverage is low. Preview backfill impact.', command: 'codemem db backfill-tags --dry-run' });
-  }
-  renderActionList(healthActions, recommendations);
+	// Recommendations
+	const triggerSync = async () => {
+		await api.triggerSync();
+	};
+	const recommendations: HealthAction[] = [];
+	if (hasBacklog) {
+		recommendations.push({
+			label: "Pipeline needs attention. Check queue health first.",
+			command: "codemem db raw-events-status",
+		});
+		recommendations.push({
+			label: "Then retry failed batches for impacted sessions.",
+			command: "codemem db raw-events-retry <opencode_session_id>",
+		});
+	} else if (syncState === "stopped") {
+		recommendations.push({
+			label: "Sync daemon is stopped. Start the background service.",
+			command: "codemem sync start",
+		});
+	} else if (!syncDisabled && !syncNoPeers && (syncState === "error" || syncState === "degraded")) {
+		recommendations.push({
+			label: "Sync is unhealthy. Restart and run one immediate pass.",
+			command: "codemem sync restart",
+			action: triggerSync,
+			actionLabel: "Sync now",
+		});
+		recommendations.push({
+			label: "Then run doctor to see root cause details.",
+			command: "codemem sync doctor",
+		});
+	} else if (!syncDisabled && !syncNoPeers && syncLooksStale) {
+		recommendations.push({
+			label: "Sync is stale. Run one immediate sync pass.",
+			command: "codemem sync once",
+			action: triggerSync,
+			actionLabel: "Sync now",
+		});
+	}
+	if (tagCoverage > 0 && tagCoverage < 0.7 && recommendations.length < 2) {
+		recommendations.push({
+			label: "Tag coverage is low. Preview backfill impact.",
+			command: "codemem db backfill-tags --dry-run",
+		});
+	}
+	renderActionList(healthActions, recommendations);
 
-  healthMeta.textContent = drivers.length
-    ? `Why this status: ${drivers.join(', ')}.`
-    : 'Healthy right now. Diagnostics stay available if you want details.';
+	healthMeta.textContent = drivers.length
+		? `Why this status: ${drivers.join(", ")}.`
+		: "Healthy right now. Diagnostics stay available if you want details.";
 
-  renderIcons();
+	renderIcons();
 }
 
 /* ── Stats renderer ──────────────────────────────────────── */
 
 export function renderStats() {
-  const statsGrid = document.getElementById('statsGrid');
-  const metaLine = document.getElementById('metaLine');
-  if (!statsGrid) return;
+	const statsGrid = document.getElementById("statsGrid");
+	const metaLine = document.getElementById("metaLine");
+	if (!statsGrid) return;
 
-  const stats = state.lastStatsPayload || {};
-  const usagePayload = state.lastUsagePayload || {};
-  const raw = state.lastRawEventsPayload && typeof state.lastRawEventsPayload === 'object' ? state.lastRawEventsPayload : {};
-  const db = stats.database || {};
-  const project = state.currentProject;
-  const totalsGlobal = usagePayload?.totals_global || usagePayload?.totals || stats.usage?.totals || {};
-  const totalsFiltered = usagePayload?.totals_filtered || null;
-  const isFiltered = !!(project && totalsFiltered);
-  const usage = isFiltered ? totalsFiltered : totalsGlobal;
-  const rawSessions = Number(raw.sessions || 0);
-  const rawPending = Number(raw.pending || 0);
+	const stats = state.lastStatsPayload || {};
+	const usagePayload = state.lastUsagePayload || {};
+	const raw =
+		state.lastRawEventsPayload && typeof state.lastRawEventsPayload === "object"
+			? state.lastRawEventsPayload
+			: {};
+	const db = stats.database || {};
+	const project = state.currentProject;
+	const totalsGlobal =
+		usagePayload?.totals_global || usagePayload?.totals || stats.usage?.totals || {};
+	const totalsFiltered = usagePayload?.totals_filtered || null;
+	const isFiltered = !!(project && totalsFiltered);
+	const usage = isFiltered ? totalsFiltered : totalsGlobal;
+	const rawSessions = Number(raw.sessions || 0);
+	const rawPending = Number(raw.pending || 0);
 
-  const globalLineWork = isFiltered ? `\nGlobal: ${Number(totalsGlobal.work_investment_tokens || 0).toLocaleString()} invested` : '';
-  const globalLineRead = isFiltered ? `\nGlobal: ${Number(totalsGlobal.tokens_read || 0).toLocaleString()} read` : '';
-  const globalLineSaved = isFiltered ? `\nGlobal: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved` : '';
+	const globalLineWork = isFiltered
+		? `\nGlobal: ${Number(totalsGlobal.work_investment_tokens || 0).toLocaleString()} invested`
+		: "";
+	const globalLineRead = isFiltered
+		? `\nGlobal: ${Number(totalsGlobal.tokens_read || 0).toLocaleString()} read`
+		: "";
+	const globalLineSaved = isFiltered
+		? `\nGlobal: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved`
+		: "";
 
-  const items: StatItem[] = [
-    { label: isFiltered ? 'Savings (project)' : 'Savings', value: Number(usage.tokens_saved || 0), tooltip: 'Tokens saved by reusing compressed memories' + globalLineSaved, icon: 'trending-up' },
-    { label: isFiltered ? 'Injected (project)' : 'Injected', value: Number(usage.tokens_read || 0), tooltip: 'Tokens injected into context (pack size)' + globalLineRead, icon: 'book-open' },
-    { label: isFiltered ? 'Reduction (project)' : 'Reduction', value: formatReductionPercent(usage.tokens_saved, usage.tokens_read), tooltip: `Percent reduction from reuse. Factor: ${formatMultiplier(usage.tokens_saved, usage.tokens_read)}.` + globalLineRead + globalLineSaved, icon: 'percent' },
-    { label: isFiltered ? 'Work investment (project)' : 'Work investment', value: Number(usage.work_investment_tokens || 0), tooltip: 'Token cost of unique discovery groups' + globalLineWork, icon: 'pencil' },
-    { label: 'Active memories', value: db.active_memory_items || 0, icon: 'check-circle' },
-    { label: 'Embedding coverage', value: formatPercent(db.vector_coverage), tooltip: 'Share of active memories with embeddings', icon: 'layers' },
-    { label: 'Tag coverage', value: formatPercent(db.tags_coverage), tooltip: 'Share of active memories with tags', icon: 'tag' },
-  ];
-  if (rawPending > 0) items.push({ label: 'Raw events pending', value: rawPending, tooltip: 'Pending raw events waiting to be flushed', icon: 'activity' });
-  else if (rawSessions > 0) items.push({ label: 'Raw sessions', value: rawSessions, tooltip: 'Sessions with pending raw events', icon: 'inbox' });
+	const items: StatItem[] = [
+		{
+			label: isFiltered ? "Savings (project)" : "Savings",
+			value: Number(usage.tokens_saved || 0),
+			tooltip: `Tokens saved by reusing compressed memories${globalLineSaved}`,
+			icon: "trending-up",
+		},
+		{
+			label: isFiltered ? "Injected (project)" : "Injected",
+			value: Number(usage.tokens_read || 0),
+			tooltip: `Tokens injected into context (pack size)${globalLineRead}`,
+			icon: "book-open",
+		},
+		{
+			label: isFiltered ? "Reduction (project)" : "Reduction",
+			value: formatReductionPercent(usage.tokens_saved, usage.tokens_read),
+			tooltip:
+				`Percent reduction from reuse. Factor: ${formatMultiplier(usage.tokens_saved, usage.tokens_read)}.` +
+				globalLineRead +
+				globalLineSaved,
+			icon: "percent",
+		},
+		{
+			label: isFiltered ? "Work investment (project)" : "Work investment",
+			value: Number(usage.work_investment_tokens || 0),
+			tooltip: `Token cost of unique discovery groups${globalLineWork}`,
+			icon: "pencil",
+		},
+		{ label: "Active memories", value: db.active_memory_items || 0, icon: "check-circle" },
+		{
+			label: "Embedding coverage",
+			value: formatPercent(db.vector_coverage),
+			tooltip: "Share of active memories with embeddings",
+			icon: "layers",
+		},
+		{
+			label: "Tag coverage",
+			value: formatPercent(db.tags_coverage),
+			tooltip: "Share of active memories with tags",
+			icon: "tag",
+		},
+	];
+	if (rawPending > 0)
+		items.push({
+			label: "Raw events pending",
+			value: rawPending,
+			tooltip: "Pending raw events waiting to be flushed",
+			icon: "activity",
+		});
+	else if (rawSessions > 0)
+		items.push({
+			label: "Raw sessions",
+			value: rawSessions,
+			tooltip: "Sessions with pending raw events",
+			icon: "inbox",
+		});
 
-  renderStatBlocks(statsGrid, items);
+	renderStatBlocks(statsGrid, items);
 
-  if (metaLine) {
-    const projectSuffix = project ? ` · project: ${project}` : '';
-    renderText(metaLine, `DB: ${db.path || 'unknown'} · ${Math.round((db.size_bytes || 0) / 1024)} KB${projectSuffix}`);
-  }
-  renderIcons();
+	if (metaLine) {
+		const projectSuffix = project ? ` · project: ${project}` : "";
+		renderText(
+			metaLine,
+			`DB: ${db.path || "unknown"} · ${Math.round((db.size_bytes || 0) / 1024)} KB${projectSuffix}`,
+		);
+	}
+	renderIcons();
 }
 
 /* ── Session summary renderer ────────────────────────────── */
 
 export function renderSessionSummary() {
-  const sessionGrid = document.getElementById('sessionGrid');
-  const sessionMeta = document.getElementById('sessionMeta');
-  if (!sessionGrid || !sessionMeta) return;
+	const sessionGrid = document.getElementById("sessionGrid");
+	const sessionMeta = document.getElementById("sessionMeta");
+	if (!sessionGrid || !sessionMeta) return;
 
-  const usagePayload = state.lastUsagePayload || {};
-  const project = state.currentProject;
-  const totalsGlobal = usagePayload?.totals_global || usagePayload?.totals || {};
-  const totalsFiltered = usagePayload?.totals_filtered || null;
-  const isFiltered = !!(project && totalsFiltered);
+	const usagePayload = state.lastUsagePayload || {};
+	const project = state.currentProject;
+	const _totalsGlobal = usagePayload?.totals_global || usagePayload?.totals || {};
+	const totalsFiltered = usagePayload?.totals_filtered || null;
+	const isFiltered = !!(project && totalsFiltered);
 
-  const events: UsageEvent[] = Array.isArray(usagePayload?.events) ? usagePayload.events : [];
-  const packEvent = events.find((event) => event.event === 'pack') || null;
-  const recentPacks = Array.isArray(usagePayload?.recent_packs) ? usagePayload.recent_packs : [];
-  const latestPack = recentPacks.length ? recentPacks[0] : null;
-  const latestPackMeta = latestPack?.metadata_json || {};
-  const lastPackAt = latestPack?.created_at || '';
-  const packCount = Number(packEvent?.count || 0);
-  const packTokens = Number(latestPack?.tokens_read || 0);
-  const savedTokens = Number(latestPack?.tokens_saved || 0);
-  const dedupedCount = Number(latestPackMeta?.exact_duplicates_collapsed || 0);
-  const dedupeEnabled = !!latestPackMeta?.exact_dedupe_enabled;
-  const reductionPercent = formatReductionPercent(savedTokens, packTokens);
+	const events: UsageEvent[] = Array.isArray(usagePayload?.events) ? usagePayload.events : [];
+	const packEvent = events.find((event) => event.event === "pack") || null;
+	const recentPacks = Array.isArray(usagePayload?.recent_packs) ? usagePayload.recent_packs : [];
+	const latestPack = recentPacks.length ? recentPacks[0] : null;
+	const latestPackMeta = latestPack?.metadata_json || {};
+	const lastPackAt = latestPack?.created_at || "";
+	const packCount = Number(packEvent?.count || 0);
+	const packTokens = Number(latestPack?.tokens_read || 0);
+	const savedTokens = Number(latestPack?.tokens_saved || 0);
+	const dedupedCount = Number(latestPackMeta?.exact_duplicates_collapsed || 0);
+	const dedupeEnabled = !!latestPackMeta?.exact_dedupe_enabled;
+	const reductionPercent = formatReductionPercent(savedTokens, packTokens);
 
-  const packLine = packCount ? `${packCount} packs` : 'No packs yet';
-  const lastPackLine = lastPackAt ? `Last pack: ${formatTimestamp(lastPackAt)}` : '';
-  const scopeLabel = isFiltered ? 'Project' : 'All projects';
-  const items: StatItem[] = [
-    { label: 'Last pack savings', value: latestPack ? `${savedTokens.toLocaleString()} (${reductionPercent})` : 'n/a', icon: 'trending-up' },
-    { label: 'Last pack size', value: latestPack ? packTokens.toLocaleString() : 'n/a', icon: 'package' },
-    { label: 'Last pack deduped', value: latestPack ? dedupedCount.toLocaleString() : 'n/a', icon: 'copy-check' },
-    { label: 'Exact dedupe', value: latestPack ? (dedupeEnabled ? 'On' : 'Off') : 'n/a', icon: 'shield-check' },
-    { label: 'Packs', value: packCount || 0, icon: 'archive' },
-  ];
+	const packLine = packCount ? `${packCount} packs` : "No packs yet";
+	const lastPackLine = lastPackAt ? `Last pack: ${formatTimestamp(lastPackAt)}` : "";
+	const scopeLabel = isFiltered ? "Project" : "All projects";
+	const items: StatItem[] = [
+		{
+			label: "Last pack savings",
+			value: latestPack ? `${savedTokens.toLocaleString()} (${reductionPercent})` : "n/a",
+			icon: "trending-up",
+		},
+		{
+			label: "Last pack size",
+			value: latestPack ? packTokens.toLocaleString() : "n/a",
+			icon: "package",
+		},
+		{
+			label: "Last pack deduped",
+			value: latestPack ? dedupedCount.toLocaleString() : "n/a",
+			icon: "copy-check",
+		},
+		{
+			label: "Exact dedupe",
+			value: latestPack ? (dedupeEnabled ? "On" : "Off") : "n/a",
+			icon: "shield-check",
+		},
+		{ label: "Packs", value: packCount || 0, icon: "archive" },
+	];
 
-  renderText(sessionMeta, [scopeLabel, packLine, lastPackLine].filter(Boolean).join(' · '));
-  renderStatBlocks(sessionGrid, items);
+	renderText(sessionMeta, [scopeLabel, packLine, lastPackLine].filter(Boolean).join(" · "));
+	renderStatBlocks(sessionGrid, items);
 
-  renderIcons();
+	renderIcons();
 }
 
 /* ── Data loading ────────────────────────────────────────── */
 
 export async function loadHealthData() {
-  const previousActorId = state.lastStatsPayload?.identity?.actor_id || null;
-  const [statsPayload, usagePayload, sessionsPayload, rawEventsPayload] = await Promise.all([
-    api.loadStats(),
-    api.loadUsage(state.currentProject),
-    api.loadSession(state.currentProject),
-    api.loadRawEvents(state.currentProject),
-  ]);
+	const previousActorId = state.lastStatsPayload?.identity?.actor_id || null;
+	const [statsPayload, usagePayload, _sessionsPayload, rawEventsPayload] = await Promise.all([
+		api.loadStats(),
+		api.loadUsage(state.currentProject),
+		api.loadSession(state.currentProject),
+		api.loadRawEvents(state.currentProject),
+	]);
 
-  state.lastStatsPayload = statsPayload || {};
-  state.lastUsagePayload = usagePayload || {};
-  state.lastRawEventsPayload = rawEventsPayload || {};
-  const nextActorId = state.lastStatsPayload?.identity?.actor_id || null;
+	state.lastStatsPayload = statsPayload || {};
+	state.lastUsagePayload = usagePayload || {};
+	state.lastRawEventsPayload = rawEventsPayload || {};
+	const nextActorId = state.lastStatsPayload?.identity?.actor_id || null;
 
-  renderStats();
-  renderSessionSummary();
-  renderHealthOverview();
-  if (state.activeTab === 'feed' && previousActorId !== nextActorId) {
-    updateFeedView(true);
-  }
+	renderStats();
+	renderSessionSummary();
+	renderHealthOverview();
+	if (state.activeTab === "feed" && previousActorId !== nextActorId) {
+		updateFeedView(true);
+	}
 }
 
 /* ── Init ────────────────────────────────────────────────── */
 
 export function initHealthTab() {
-  // No special init needed beyond data loading.
+	// No special init needed beyond data loading.
 }

--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -1,17 +1,17 @@
 /* Settings modal — observer config, sync settings. */
 
-import { render, type ComponentChildren, type JSX } from 'preact';
-import { createPortal } from 'preact/compat';
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
-import { $, $button } from '../lib/dom';
-import { showGlobalNotice } from '../lib/notice';
-import { state } from '../lib/state';
-import { RadixDialog } from '../components/primitives/radix-dialog';
-import * as api from '../lib/api';
+import { type ComponentChildren, type JSX, render } from "preact";
+import { createPortal } from "preact/compat";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
+import { RadixDialog } from "../components/primitives/radix-dialog";
+import * as api from "../lib/api";
+import { $, $button } from "../lib/dom";
+import { showGlobalNotice } from "../lib/notice";
+import { state } from "../lib/state";
 
 let settingsOpen = false;
 let previouslyFocused: HTMLElement | null = null;
-let settingsActiveTab = 'observer';
+let settingsActiveTab = "observer";
 let settingsBaseline: Record<string, unknown> = {};
 let settingsEnvOverrides: Record<string, unknown> = {};
 let settingsTouchedKeys = new Set<string>();
@@ -19,1643 +19,2001 @@ let settingsShellMounted = false;
 let settingsProtectedKeys = new Set<string>();
 let settingsStartPolling: (() => void) | null = null;
 let settingsRefresh: (() => void) | null = null;
-const SETTINGS_ADVANCED_KEY = 'codemem-settings-advanced';
+const SETTINGS_ADVANCED_KEY = "codemem-settings-advanced";
 let settingsShowAdvanced = loadAdvancedPreference();
 
-const DEFAULT_OPENAI_MODEL = 'gpt-5.1-codex-mini';
-const DEFAULT_ANTHROPIC_MODEL = 'claude-4.5-haiku';
+const DEFAULT_OPENAI_MODEL = "gpt-5.1-codex-mini";
+const DEFAULT_ANTHROPIC_MODEL = "claude-4.5-haiku";
 
-type SettingsTabId = 'observer' | 'queue' | 'sync';
+type SettingsTabId = "observer" | "queue" | "sync";
 
 type SettingsFormState = {
-  claudeCommand: string;
-  observerProvider: string;
-  observerModel: string;
-  observerTierRoutingEnabled: boolean;
-  observerSimpleModel: string;
-  observerSimpleTemperature: string;
-  observerRichModel: string;
-  observerRichTemperature: string;
-  observerRichOpenAIUseResponses: boolean;
-  observerRichReasoningEffort: string;
-  observerRichReasoningSummary: string;
-  observerRichMaxOutputTokens: string;
-  observerRuntime: string;
-  observerAuthSource: string;
-  observerAuthFile: string;
-  observerAuthCommand: string;
-  observerAuthTimeoutMs: string;
-  observerAuthCacheTtlS: string;
-  observerHeaders: string;
-  observerMaxChars: string;
-  packObservationLimit: string;
-  packSessionLimit: string;
-  rawEventsSweeperIntervalS: string;
-  syncEnabled: boolean;
-  syncHost: string;
-  syncPort: string;
-  syncInterval: string;
-  syncMdns: boolean;
-  syncCoordinatorUrl: string;
-  syncCoordinatorGroup: string;
-  syncCoordinatorTimeout: string;
-  syncCoordinatorPresenceTtl: string;
+	claudeCommand: string;
+	observerProvider: string;
+	observerModel: string;
+	observerTierRoutingEnabled: boolean;
+	observerSimpleModel: string;
+	observerSimpleTemperature: string;
+	observerRichModel: string;
+	observerRichTemperature: string;
+	observerRichOpenAIUseResponses: boolean;
+	observerRichReasoningEffort: string;
+	observerRichReasoningSummary: string;
+	observerRichMaxOutputTokens: string;
+	observerRuntime: string;
+	observerAuthSource: string;
+	observerAuthFile: string;
+	observerAuthCommand: string;
+	observerAuthTimeoutMs: string;
+	observerAuthCacheTtlS: string;
+	observerHeaders: string;
+	observerMaxChars: string;
+	packObservationLimit: string;
+	packSessionLimit: string;
+	rawEventsSweeperIntervalS: string;
+	syncEnabled: boolean;
+	syncHost: string;
+	syncPort: string;
+	syncInterval: string;
+	syncMdns: boolean;
+	syncCoordinatorUrl: string;
+	syncCoordinatorGroup: string;
+	syncCoordinatorTimeout: string;
+	syncCoordinatorPresenceTtl: string;
 };
 
 type SettingsRenderState = {
-  effectiveText: string;
-  isSaving: boolean;
-  observerStatus: unknown;
-  overridesVisible: boolean;
-  pathText: string;
-  providers: string[];
-  statusText: string;
-  values: SettingsFormState;
+	effectiveText: string;
+	isSaving: boolean;
+	observerStatus: unknown;
+	overridesVisible: boolean;
+	pathText: string;
+	providers: string[];
+	statusText: string;
+	values: SettingsFormState;
 };
 
 type SettingsTooltipState = {
-  anchor: HTMLElement | null;
-  content: string;
-  visible: boolean;
+	anchor: HTMLElement | null;
+	content: string;
+	visible: boolean;
 };
 
 type SettingsController = {
-  hideTooltip: () => void;
-  setActiveTab: (tab: SettingsTabId) => void;
-  setDirty: (dirty: boolean) => void;
-  setOpen: (open: boolean) => void;
-  setRenderState: (patch: Partial<SettingsRenderState>) => void;
-  setShowAdvanced: (show: boolean) => void;
+	hideTooltip: () => void;
+	setActiveTab: (tab: SettingsTabId) => void;
+	setDirty: (dirty: boolean) => void;
+	setOpen: (open: boolean) => void;
+	setRenderState: (patch: Partial<SettingsRenderState>) => void;
+	setShowAdvanced: (show: boolean) => void;
 };
 
 let settingsController: SettingsController | null = null;
 
 const INPUT_TO_CONFIG_KEY: Record<keyof SettingsFormState, string> = {
-  claudeCommand: 'claude_command',
-  observerProvider: 'observer_provider',
-  observerModel: 'observer_model',
-  observerTierRoutingEnabled: 'observer_tier_routing_enabled',
-  observerSimpleModel: 'observer_simple_model',
-  observerSimpleTemperature: 'observer_simple_temperature',
-  observerRichModel: 'observer_rich_model',
-  observerRichTemperature: 'observer_rich_temperature',
-  observerRichOpenAIUseResponses: 'observer_rich_openai_use_responses',
-  observerRichReasoningEffort: 'observer_rich_reasoning_effort',
-  observerRichReasoningSummary: 'observer_rich_reasoning_summary',
-  observerRichMaxOutputTokens: 'observer_rich_max_output_tokens',
-  observerRuntime: 'observer_runtime',
-  observerAuthSource: 'observer_auth_source',
-  observerAuthFile: 'observer_auth_file',
-  observerAuthCommand: 'observer_auth_command',
-  observerAuthTimeoutMs: 'observer_auth_timeout_ms',
-  observerAuthCacheTtlS: 'observer_auth_cache_ttl_s',
-  observerHeaders: 'observer_headers',
-  observerMaxChars: 'observer_max_chars',
-  packObservationLimit: 'pack_observation_limit',
-  packSessionLimit: 'pack_session_limit',
-  rawEventsSweeperIntervalS: 'raw_events_sweeper_interval_s',
-  syncEnabled: 'sync_enabled',
-  syncHost: 'sync_host',
-  syncPort: 'sync_port',
-  syncInterval: 'sync_interval_s',
-  syncMdns: 'sync_mdns',
-  syncCoordinatorUrl: 'sync_coordinator_url',
-  syncCoordinatorGroup: 'sync_coordinator_group',
-  syncCoordinatorTimeout: 'sync_coordinator_timeout_s',
-  syncCoordinatorPresenceTtl: 'sync_coordinator_presence_ttl_s',
+	claudeCommand: "claude_command",
+	observerProvider: "observer_provider",
+	observerModel: "observer_model",
+	observerTierRoutingEnabled: "observer_tier_routing_enabled",
+	observerSimpleModel: "observer_simple_model",
+	observerSimpleTemperature: "observer_simple_temperature",
+	observerRichModel: "observer_rich_model",
+	observerRichTemperature: "observer_rich_temperature",
+	observerRichOpenAIUseResponses: "observer_rich_openai_use_responses",
+	observerRichReasoningEffort: "observer_rich_reasoning_effort",
+	observerRichReasoningSummary: "observer_rich_reasoning_summary",
+	observerRichMaxOutputTokens: "observer_rich_max_output_tokens",
+	observerRuntime: "observer_runtime",
+	observerAuthSource: "observer_auth_source",
+	observerAuthFile: "observer_auth_file",
+	observerAuthCommand: "observer_auth_command",
+	observerAuthTimeoutMs: "observer_auth_timeout_ms",
+	observerAuthCacheTtlS: "observer_auth_cache_ttl_s",
+	observerHeaders: "observer_headers",
+	observerMaxChars: "observer_max_chars",
+	packObservationLimit: "pack_observation_limit",
+	packSessionLimit: "pack_session_limit",
+	rawEventsSweeperIntervalS: "raw_events_sweeper_interval_s",
+	syncEnabled: "sync_enabled",
+	syncHost: "sync_host",
+	syncPort: "sync_port",
+	syncInterval: "sync_interval_s",
+	syncMdns: "sync_mdns",
+	syncCoordinatorUrl: "sync_coordinator_url",
+	syncCoordinatorGroup: "sync_coordinator_group",
+	syncCoordinatorTimeout: "sync_coordinator_timeout_s",
+	syncCoordinatorPresenceTtl: "sync_coordinator_presence_ttl_s",
 };
 
 const PROTECTED_VIEWER_CONFIG_KEYS = new Set([
-  'claude_command',
-  'observer_base_url',
-  'observer_auth_file',
-  'observer_auth_command',
-  'observer_headers',
-  'sync_coordinator_url',
+	"claude_command",
+	"observer_base_url",
+	"observer_auth_file",
+	"observer_auth_command",
+	"observer_headers",
+	"sync_coordinator_url",
 ]);
 
 const EMPTY_FORM_STATE: SettingsFormState = {
-  claudeCommand: '',
-  observerProvider: '',
-  observerModel: '',
-  observerTierRoutingEnabled: false,
-  observerSimpleModel: '',
-  observerSimpleTemperature: '',
-  observerRichModel: '',
-  observerRichTemperature: '',
-  observerRichOpenAIUseResponses: false,
-  observerRichReasoningEffort: '',
-  observerRichReasoningSummary: '',
-  observerRichMaxOutputTokens: '',
-  observerRuntime: 'api_http',
-  observerAuthSource: 'auto',
-  observerAuthFile: '',
-  observerAuthCommand: '',
-  observerAuthTimeoutMs: '',
-  observerAuthCacheTtlS: '',
-  observerHeaders: '',
-  observerMaxChars: '',
-  packObservationLimit: '',
-  packSessionLimit: '',
-  rawEventsSweeperIntervalS: '',
-  syncEnabled: false,
-  syncHost: '',
-  syncPort: '',
-  syncInterval: '',
-  syncMdns: false,
-  syncCoordinatorUrl: '',
-  syncCoordinatorGroup: '',
-  syncCoordinatorTimeout: '',
-  syncCoordinatorPresenceTtl: '',
+	claudeCommand: "",
+	observerProvider: "",
+	observerModel: "",
+	observerTierRoutingEnabled: false,
+	observerSimpleModel: "",
+	observerSimpleTemperature: "",
+	observerRichModel: "",
+	observerRichTemperature: "",
+	observerRichOpenAIUseResponses: false,
+	observerRichReasoningEffort: "",
+	observerRichReasoningSummary: "",
+	observerRichMaxOutputTokens: "",
+	observerRuntime: "api_http",
+	observerAuthSource: "auto",
+	observerAuthFile: "",
+	observerAuthCommand: "",
+	observerAuthTimeoutMs: "",
+	observerAuthCacheTtlS: "",
+	observerHeaders: "",
+	observerMaxChars: "",
+	packObservationLimit: "",
+	packSessionLimit: "",
+	rawEventsSweeperIntervalS: "",
+	syncEnabled: false,
+	syncHost: "",
+	syncPort: "",
+	syncInterval: "",
+	syncMdns: false,
+	syncCoordinatorUrl: "",
+	syncCoordinatorGroup: "",
+	syncCoordinatorTimeout: "",
+	syncCoordinatorPresenceTtl: "",
 };
 
 let settingsRenderState: SettingsRenderState = {
-  effectiveText: '',
-  isSaving: false,
-  observerStatus: null,
-  overridesVisible: false,
-  pathText: 'Config path: n/a',
-  providers: [],
-  statusText: 'Ready',
-  values: { ...EMPTY_FORM_STATE },
+	effectiveText: "",
+	isSaving: false,
+	observerStatus: null,
+	overridesVisible: false,
+	pathText: "Config path: n/a",
+	providers: [],
+	statusText: "Ready",
+	values: { ...EMPTY_FORM_STATE },
 };
 
 function loadAdvancedPreference(): boolean {
-  try {
-    return globalThis.localStorage?.getItem(SETTINGS_ADVANCED_KEY) === '1';
-  } catch {
-    return false;
-  }
+	try {
+		return globalThis.localStorage?.getItem(SETTINGS_ADVANCED_KEY) === "1";
+	} catch {
+		return false;
+	}
 }
 
 function persistAdvancedPreference(show: boolean) {
-  try {
-    globalThis.localStorage?.setItem(SETTINGS_ADVANCED_KEY, show ? '1' : '0');
-  } catch {}
+	try {
+		globalThis.localStorage?.setItem(SETTINGS_ADVANCED_KEY, show ? "1" : "0");
+	} catch {}
 }
 
 function hasOwn(obj: unknown, key: string): boolean {
-  return typeof obj === 'object' && obj !== null && Object.prototype.hasOwnProperty.call(obj, key);
+	return typeof obj === "object" && obj !== null && Object.hasOwn(obj, key);
 }
 
 function effectiveOrConfigured(config: any, effective: any, key: string): any {
-  if (hasOwn(effective, key)) return effective[key];
-  if (hasOwn(config, key)) return config[key];
-  return undefined;
+	if (hasOwn(effective, key)) return effective[key];
+	if (hasOwn(config, key)) return config[key];
+	return undefined;
 }
 
 function asInputString(value: unknown): string {
-  if (value === undefined || value === null) return '';
-  return String(value);
+	if (value === undefined || value === null) return "";
+	return String(value);
 }
 
 function asBooleanValue(value: unknown): boolean {
-  if (typeof value === 'boolean') return value;
-  if (typeof value === 'number') return value !== 0;
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase();
-    if (!normalized) return false;
-    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
-    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
-  }
-  return Boolean(value);
+	if (typeof value === "boolean") return value;
+	if (typeof value === "number") return value !== 0;
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (!normalized) return false;
+		if (["0", "false", "no", "off"].includes(normalized)) return false;
+		if (["1", "true", "yes", "on"].includes(normalized)) return true;
+	}
+	return Boolean(value);
 }
 
 function toProviderList(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
 }
 
 function isEqualValue(left: unknown, right: unknown): boolean {
-  if (left === right) return true;
-  return JSON.stringify(left) === JSON.stringify(right);
+	if (left === right) return true;
+	return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function normalizeTextValue(value: string): string {
-  const trimmed = value.trim();
-  return trimmed === '' ? '' : trimmed;
+	const trimmed = value.trim();
+	return trimmed === "" ? "" : trimmed;
 }
 
-function inferObserverModel(runtime: string, provider: string, configuredModel: string): { model: string; source: string } {
-  if (configuredModel) return { model: configuredModel, source: 'Configured' };
-  if (runtime === 'claude_sidecar') {
-    return { model: DEFAULT_ANTHROPIC_MODEL, source: 'Recommended (local Claude session)' };
-  }
-  if (provider === 'anthropic') {
-    return { model: DEFAULT_ANTHROPIC_MODEL, source: 'Recommended (Anthropic provider)' };
-  }
-  if (provider === 'opencode') {
-    return { model: 'opencode/gpt-5.1-codex-mini', source: 'Recommended (OpenCode Zen provider)' };
-  }
-  if (provider && provider !== 'openai') {
-    return { model: 'provider default', source: 'Recommended (provider default)' };
-  }
-  return { model: DEFAULT_OPENAI_MODEL, source: 'Recommended (direct API)' };
+function inferObserverModel(
+	runtime: string,
+	provider: string,
+	configuredModel: string,
+): { model: string; source: string } {
+	if (configuredModel) return { model: configuredModel, source: "Configured" };
+	if (runtime === "claude_sidecar") {
+		return { model: DEFAULT_ANTHROPIC_MODEL, source: "Recommended (local Claude session)" };
+	}
+	if (provider === "anthropic") {
+		return { model: DEFAULT_ANTHROPIC_MODEL, source: "Recommended (Anthropic provider)" };
+	}
+	if (provider === "opencode") {
+		return { model: "opencode/gpt-5.1-codex-mini", source: "Recommended (OpenCode Zen provider)" };
+	}
+	if (provider && provider !== "openai") {
+		return { model: "provider default", source: "Recommended (provider default)" };
+	}
+	return { model: DEFAULT_OPENAI_MODEL, source: "Recommended (direct API)" };
 }
 
 function configuredValueForKey(config: any, key: string): unknown {
-  switch (key) {
-    case 'claude_command': {
-      const value = config?.claude_command;
-      if (!Array.isArray(value)) return [];
-      const normalized: string[] = [];
-      value.forEach((item) => {
-        if (typeof item !== 'string') return;
-        const token = item.trim();
-        if (token) normalized.push(token);
-      });
-      return normalized;
-    }
-    case 'observer_provider':
-    case 'observer_model':
-    case 'observer_simple_model':
-    case 'observer_rich_model':
-    case 'observer_rich_reasoning_effort':
-    case 'observer_rich_reasoning_summary':
-    case 'observer_auth_file':
-    case 'sync_host':
-    case 'sync_coordinator_url':
-    case 'sync_coordinator_group':
-      return normalizeTextValue(asInputString(config?.[key]));
-    case 'observer_runtime':
-      return normalizeTextValue(asInputString(config?.observer_runtime));
-    case 'observer_auth_source':
-      return normalizeTextValue(asInputString(config?.observer_auth_source));
-    case 'observer_auth_command': {
-      const value = config?.observer_auth_command;
-      if (!Array.isArray(value)) return [];
-      return value.filter((item) => typeof item === 'string');
-    }
-    case 'observer_headers': {
-      const value = config?.observer_headers;
-      if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-      const headers: Record<string, string> = {};
-      Object.entries(value as Record<string, unknown>).forEach(([header, headerValue]) => {
-        if (typeof header === 'string' && header.trim() && typeof headerValue === 'string') {
-          headers[header.trim()] = headerValue;
-        }
-      });
-      return headers;
-    }
-    case 'observer_auth_timeout_ms':
-    case 'observer_max_chars':
-    case 'observer_simple_temperature':
-    case 'observer_rich_temperature':
-    case 'observer_rich_max_output_tokens':
-    case 'pack_observation_limit':
-    case 'pack_session_limit':
-    case 'raw_events_sweeper_interval_s':
-    case 'sync_port':
-    case 'sync_interval_s': {
-      if (!hasOwn(config, key)) return '';
-      const parsed = Number(config[key]);
-      return Number.isFinite(parsed) && parsed !== 0 ? parsed : '';
-    }
-    case 'sync_coordinator_timeout_s':
-    case 'sync_coordinator_presence_ttl_s': {
-      if (!hasOwn(config, key)) return '';
-      const parsed = Number(config[key]);
-      return Number.isFinite(parsed) && parsed > 0 ? parsed : '';
-    }
-    case 'observer_auth_cache_ttl_s': {
-      if (!hasOwn(config, key)) return '';
-      const parsed = Number(config[key]);
-      return Number.isFinite(parsed) ? parsed : '';
-    }
-    case 'sync_enabled':
-    case 'sync_mdns':
-    case 'observer_tier_routing_enabled':
-    case 'observer_rich_openai_use_responses':
-      return asBooleanValue(config?.[key]);
-    default:
-      return hasOwn(config, key) ? config[key] : '';
-  }
+	switch (key) {
+		case "claude_command": {
+			const value = config?.claude_command;
+			if (!Array.isArray(value)) return [];
+			const normalized: string[] = [];
+			value.forEach((item) => {
+				if (typeof item !== "string") return;
+				const token = item.trim();
+				if (token) normalized.push(token);
+			});
+			return normalized;
+		}
+		case "observer_provider":
+		case "observer_model":
+		case "observer_simple_model":
+		case "observer_rich_model":
+		case "observer_rich_reasoning_effort":
+		case "observer_rich_reasoning_summary":
+		case "observer_auth_file":
+		case "sync_host":
+		case "sync_coordinator_url":
+		case "sync_coordinator_group":
+			return normalizeTextValue(asInputString(config?.[key]));
+		case "observer_runtime":
+			return normalizeTextValue(asInputString(config?.observer_runtime));
+		case "observer_auth_source":
+			return normalizeTextValue(asInputString(config?.observer_auth_source));
+		case "observer_auth_command": {
+			const value = config?.observer_auth_command;
+			if (!Array.isArray(value)) return [];
+			return value.filter((item) => typeof item === "string");
+		}
+		case "observer_headers": {
+			const value = config?.observer_headers;
+			if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+			const headers: Record<string, string> = {};
+			Object.entries(value as Record<string, unknown>).forEach(([header, headerValue]) => {
+				if (typeof header === "string" && header.trim() && typeof headerValue === "string") {
+					headers[header.trim()] = headerValue;
+				}
+			});
+			return headers;
+		}
+		case "observer_auth_timeout_ms":
+		case "observer_max_chars":
+		case "observer_simple_temperature":
+		case "observer_rich_temperature":
+		case "observer_rich_max_output_tokens":
+		case "pack_observation_limit":
+		case "pack_session_limit":
+		case "raw_events_sweeper_interval_s":
+		case "sync_port":
+		case "sync_interval_s": {
+			if (!hasOwn(config, key)) return "";
+			const parsed = Number(config[key]);
+			return Number.isFinite(parsed) && parsed !== 0 ? parsed : "";
+		}
+		case "sync_coordinator_timeout_s":
+		case "sync_coordinator_presence_ttl_s": {
+			if (!hasOwn(config, key)) return "";
+			const parsed = Number(config[key]);
+			return Number.isFinite(parsed) && parsed > 0 ? parsed : "";
+		}
+		case "observer_auth_cache_ttl_s": {
+			if (!hasOwn(config, key)) return "";
+			const parsed = Number(config[key]);
+			return Number.isFinite(parsed) ? parsed : "";
+		}
+		case "sync_enabled":
+		case "sync_mdns":
+		case "observer_tier_routing_enabled":
+		case "observer_rich_openai_use_responses":
+			return asBooleanValue(config?.[key]);
+		default:
+			return hasOwn(config, key) ? config[key] : "";
+	}
 }
 
 function mergeOverrideBaseline(
-  baseline: Record<string, unknown>,
-  config: any,
-  envOverrides: Record<string, unknown>,
+	baseline: Record<string, unknown>,
+	config: any,
+	envOverrides: Record<string, unknown>,
 ): Record<string, unknown> {
-  const next = { ...baseline };
-  Object.keys(envOverrides).forEach((key) => {
-    if (hasOwn(next, key)) {
-      next[key] = configuredValueForKey(config, key);
-    }
-  });
-  return next;
+	const next = { ...baseline };
+	Object.keys(envOverrides).forEach((key) => {
+		if (hasOwn(next, key)) {
+			next[key] = configuredValueForKey(config, key);
+		}
+	});
+	return next;
 }
 
 function getObserverModelHint(): string {
-  const values = settingsRenderState.values;
-  if (values.observerTierRoutingEnabled) {
-    return 'Tiered routing is enabled: simple/rich model selection now lives in Processing.';
-  }
-  const inferred = inferObserverModel(
-    values.observerRuntime.trim() || 'api_http',
-    values.observerProvider.trim(),
-    normalizeTextValue(values.observerModel),
-  );
-  const overrideActive = ['observer_model', 'observer_provider', 'observer_runtime'].some(
-    (key) => hasOwn(settingsEnvOverrides, key),
-  );
-  const source = overrideActive ? 'Env override' : inferred.source;
-  return `${source}: ${inferred.model}`;
+	const values = settingsRenderState.values;
+	if (values.observerTierRoutingEnabled) {
+		return "Tiered routing is enabled: simple/rich model selection now lives in Processing.";
+	}
+	const inferred = inferObserverModel(
+		values.observerRuntime.trim() || "api_http",
+		values.observerProvider.trim(),
+		normalizeTextValue(values.observerModel),
+	);
+	const overrideActive = ["observer_model", "observer_provider", "observer_runtime"].some((key) =>
+		hasOwn(settingsEnvOverrides, key),
+	);
+	const source = overrideActive ? "Env override" : inferred.source;
+	return `${source}: ${inferred.model}`;
 }
 
 function getTieredRoutingHelperText(): string {
-  if (!settingsRenderState.values.observerTierRoutingEnabled) {
-    return 'Off: codemem uses the base observer settings from the Connection tab for all batches.';
-  }
-  return 'On: codemem can route simpler batches to a lighter model and richer batches to a higher-quality configuration.';
+	if (!settingsRenderState.values.observerTierRoutingEnabled) {
+		return "Off: codemem uses the base observer settings from the Connection tab for all batches.";
+	}
+	return "On: codemem can route simpler batches to a lighter model and richer batches to a higher-quality configuration.";
 }
 
 function getObserverModelLabel(): string {
-  return settingsRenderState.values.observerTierRoutingEnabled ? 'Base model fallback' : 'Model';
+	return settingsRenderState.values.observerTierRoutingEnabled ? "Base model fallback" : "Model";
 }
 
 function getObserverModelTooltip(): string {
-  return settingsRenderState.values.observerTierRoutingEnabled
-    ? 'Tiered routing is enabled, so Processing controls the simple/rich models. This base model is only a fallback.'
-    : 'Leave blank to use a recommended model for your selected mode/provider.';
+	return settingsRenderState.values.observerTierRoutingEnabled
+		? "Tiered routing is enabled, so Processing controls the simple/rich models. This base model is only a fallback."
+		: "Leave blank to use a recommended model for your selected mode/provider.";
 }
 
 function getObserverModelDescription(): string {
-  return settingsRenderState.values.observerTierRoutingEnabled
-    ? 'Tiered routing is active. Use this only as a fallback while the Processing tab owns simple/rich model selection.'
-    : 'Default: `gpt-5.1-codex-mini` for Direct API; `claude-4.5-haiku` for Local Claude session.';
+	return settingsRenderState.values.observerTierRoutingEnabled
+		? "Tiered routing is active. Use this only as a fallback while the Processing tab owns simple/rich model selection."
+		: "Default: `gpt-5.1-codex-mini` for Direct API; `claude-4.5-haiku` for Local Claude session.";
 }
 
 function positionHelpTooltipElement(el: HTMLElement, anchor: HTMLElement) {
-  const rect = anchor.getBoundingClientRect();
-  const margin = 8;
-  const gap = 8;
-  const width = el.offsetWidth;
-  const height = el.offsetHeight;
+	const rect = anchor.getBoundingClientRect();
+	const margin = 8;
+	const gap = 8;
+	const width = el.offsetWidth;
+	const height = el.offsetHeight;
 
-  let left = rect.left + rect.width / 2 - width / 2;
-  left = Math.max(margin, Math.min(left, globalThis.innerWidth - width - margin));
+	let left = rect.left + rect.width / 2 - width / 2;
+	left = Math.max(margin, Math.min(left, globalThis.innerWidth - width - margin));
 
-  let top = rect.bottom + gap;
-  if (top + height > globalThis.innerHeight - margin) {
-    top = rect.top - height - gap;
-  }
-  top = Math.max(margin, top);
+	let top = rect.bottom + gap;
+	if (top + height > globalThis.innerHeight - margin) {
+		top = rect.top - height - gap;
+	}
+	top = Math.max(margin, top);
 
-  el.style.left = `${Math.round(left)}px`;
-  el.style.top = `${Math.round(top)}px`;
+	el.style.left = `${Math.round(left)}px`;
+	el.style.top = `${Math.round(top)}px`;
 }
 
 function hideHelpTooltip() {
-  settingsController?.hideTooltip();
+	settingsController?.hideTooltip();
 }
 
 function helpButtonFromTarget(target: EventTarget | null): HTMLElement | null {
-  if (!(target instanceof Element)) return null;
-  return target.closest('.help-icon[data-tooltip]') as HTMLElement | null;
+	if (!(target instanceof Element)) return null;
+	return target.closest(".help-icon[data-tooltip]") as HTMLElement | null;
 }
 
 function markFieldTouched(inputId: keyof SettingsFormState) {
-  const key = INPUT_TO_CONFIG_KEY[inputId];
-  if (!key) return;
-  settingsTouchedKeys.add(key);
+	const key = INPUT_TO_CONFIG_KEY[inputId];
+	if (!key) return;
+	settingsTouchedKeys.add(key);
 }
 
 function getFocusableNodes(container: HTMLElement | null): HTMLElement[] {
-  if (!container) return [];
-  const selector = [
-    'button:not([disabled])',
-    'input:not([disabled])',
-    'select:not([disabled])',
-    'textarea:not([disabled])',
-    '[href]',
-    '[tabindex]:not([tabindex="-1"])',
-  ].join(',');
-  return Array.from(container.querySelectorAll(selector)).filter((node) => {
-    const el = node as HTMLElement;
-    return !el.hidden && el.offsetParent !== null;
-  }) as HTMLElement[];
+	if (!container) return [];
+	const selector = [
+		"button:not([disabled])",
+		"input:not([disabled])",
+		"select:not([disabled])",
+		"textarea:not([disabled])",
+		"[href]",
+		'[tabindex]:not([tabindex="-1"])',
+	].join(",");
+	return Array.from(container.querySelectorAll(selector)).filter((node) => {
+		const el = node as HTMLElement;
+		return !el.hidden && el.offsetParent !== null;
+	}) as HTMLElement[];
 }
 
 function focusSettingsDialog() {
-  const modal = $('settingsModal');
-  const focusable = getFocusableNodes(modal as HTMLElement | null);
-  const firstFocusable = focusable[0];
-  (firstFocusable || (modal as HTMLElement | null))?.focus();
+	const modal = $("settingsModal");
+	const focusable = getFocusableNodes(modal as HTMLElement | null);
+	const firstFocusable = focusable[0];
+	(firstFocusable || (modal as HTMLElement | null))?.focus();
 }
 
 function updateRenderState(patch: Partial<SettingsRenderState>) {
-  if (settingsController) {
-    settingsController.setRenderState(patch);
-    return;
-  }
-  settingsRenderState = {
-    ...settingsRenderState,
-    ...patch,
-  };
+	if (settingsController) {
+		settingsController.setRenderState(patch);
+		return;
+	}
+	settingsRenderState = {
+		...settingsRenderState,
+		...patch,
+	};
 }
 
 function updateFormState(patch: Partial<SettingsFormState>) {
-  updateRenderState({
-    values: {
-      ...settingsRenderState.values,
-      ...patch,
-    },
-  });
+	updateRenderState({
+		values: {
+			...settingsRenderState.values,
+			...patch,
+		},
+	});
 }
 
 function renderSettingsShell() {
-  const mount = $('settingsDialogMount');
-  if (!mount) return;
-  render(<SettingsDialogShell />, mount);
+	const mount = $("settingsDialogMount");
+	if (!mount) return;
+	render(<SettingsDialogShell />, mount);
 }
 
 function ensureSettingsShell() {
-  const mount = $('settingsDialogMount');
-  if (!mount) return;
-  if (settingsShellMounted) return;
-  renderSettingsShell();
-  settingsShellMounted = true;
+	const mount = $("settingsDialogMount");
+	if (!mount) return;
+	if (settingsShellMounted) return;
+	renderSettingsShell();
+	settingsShellMounted = true;
 }
 
 function SettingsDialogShell() {
-  const [open, setOpen] = useState(settingsOpen);
-  const [activeTab, setActiveTabState] = useState<SettingsTabId>(
-    ['observer', 'queue', 'sync'].includes(settingsActiveTab) ? (settingsActiveTab as SettingsTabId) : 'observer',
-  );
-  const [dirty, setDirtyState] = useState(state.settingsDirty);
-  const [renderState, setRenderStateState] = useState(settingsRenderState);
-  const [showAdvanced, setShowAdvancedState] = useState(settingsShowAdvanced);
-  const [tooltip, setTooltip] = useState<SettingsTooltipState>({
-    anchor: null,
-    content: '',
-    visible: false,
-  });
-  const tooltipRef = useRef<HTMLDivElement | null>(null);
+	const [open, setOpen] = useState(settingsOpen);
+	const [activeTab, setActiveTabState] = useState<SettingsTabId>(
+		["observer", "queue", "sync"].includes(settingsActiveTab)
+			? (settingsActiveTab as SettingsTabId)
+			: "observer",
+	);
+	const [dirty, setDirtyState] = useState(state.settingsDirty);
+	const [renderState, setRenderStateState] = useState(settingsRenderState);
+	const [showAdvanced, setShowAdvancedState] = useState(settingsShowAdvanced);
+	const [tooltip, setTooltip] = useState<SettingsTooltipState>({
+		anchor: null,
+		content: "",
+		visible: false,
+	});
+	const tooltipRef = useRef<HTMLDivElement | null>(null);
 
-  settingsOpen = open;
-  settingsActiveTab = activeTab;
-  state.settingsDirty = dirty;
-  settingsRenderState = renderState;
-  settingsShowAdvanced = showAdvanced;
+	settingsOpen = open;
+	settingsActiveTab = activeTab;
+	state.settingsDirty = dirty;
+	settingsRenderState = renderState;
+	settingsShowAdvanced = showAdvanced;
 
-  useEffect(() => {
-    settingsController = {
-      hideTooltip: () => {
-        setTooltip({ anchor: null, content: '', visible: false });
-      },
-      setActiveTab: (tab) => {
-        const nextTab = ['observer', 'queue', 'sync'].includes(tab) ? tab : 'observer';
-        settingsActiveTab = nextTab;
-        setActiveTabState(nextTab);
-      },
-      setDirty: (nextDirty) => {
-        state.settingsDirty = nextDirty;
-        setDirtyState(nextDirty);
-      },
-      setOpen: (nextOpen) => {
-        settingsOpen = nextOpen;
-        setOpen(nextOpen);
-      },
-      setRenderState: (patch) => {
-        const nextState = {
-          ...settingsRenderState,
-          ...patch,
-        };
-        settingsRenderState = nextState;
-        setRenderStateState(nextState);
-      },
-      setShowAdvanced: (nextShowAdvanced) => {
-        settingsShowAdvanced = nextShowAdvanced;
-        persistAdvancedPreference(nextShowAdvanced);
-        setShowAdvancedState(nextShowAdvanced);
-      },
-    };
+	useEffect(() => {
+		settingsController = {
+			hideTooltip: () => {
+				setTooltip({ anchor: null, content: "", visible: false });
+			},
+			setActiveTab: (tab) => {
+				const nextTab = ["observer", "queue", "sync"].includes(tab) ? tab : "observer";
+				settingsActiveTab = nextTab;
+				setActiveTabState(nextTab);
+			},
+			setDirty: (nextDirty) => {
+				state.settingsDirty = nextDirty;
+				setDirtyState(nextDirty);
+			},
+			setOpen: (nextOpen) => {
+				settingsOpen = nextOpen;
+				setOpen(nextOpen);
+			},
+			setRenderState: (patch) => {
+				const nextState = {
+					...settingsRenderState,
+					...patch,
+				};
+				settingsRenderState = nextState;
+				setRenderStateState(nextState);
+			},
+			setShowAdvanced: (nextShowAdvanced) => {
+				settingsShowAdvanced = nextShowAdvanced;
+				persistAdvancedPreference(nextShowAdvanced);
+				setShowAdvancedState(nextShowAdvanced);
+			},
+		};
 
-    return () => {
-      if (settingsController) {
-        settingsController = null;
-      }
-    };
-  }, []);
+		return () => {
+			if (settingsController) {
+				settingsController = null;
+			}
+		};
+	}, []);
 
-  useEffect(() => {
-    const showTooltip = (anchor: HTMLElement) => {
-      const content = anchor.dataset.tooltip?.trim();
-      if (!content) return;
-      setTooltip({ anchor, content, visible: true });
-    };
+	useEffect(() => {
+		const showTooltip = (anchor: HTMLElement) => {
+			const content = anchor.dataset.tooltip?.trim();
+			if (!content) return;
+			setTooltip({ anchor, content, visible: true });
+		};
 
-    const hideTooltip = () => {
-      setTooltip((current) => {
-        if (!current.visible && !current.anchor && !current.content) return current;
-        return { anchor: null, content: '', visible: false };
-      });
-    };
+		const hideTooltip = () => {
+			setTooltip((current) => {
+				if (!current.visible && !current.anchor && !current.content) return current;
+				return { anchor: null, content: "", visible: false };
+			});
+		};
 
-    const onPointerOver = (event: Event) => {
-      const button = helpButtonFromTarget(event.target);
-      if (!button) return;
-      showTooltip(button);
-    };
+		const onPointerOver = (event: Event) => {
+			const button = helpButtonFromTarget(event.target);
+			if (!button) return;
+			showTooltip(button);
+		};
 
-    const onPointerOut = (event: Event) => {
-      const button = helpButtonFromTarget(event.target);
-      if (!button) return;
-      const related = (event as PointerEvent).relatedTarget;
-      if (related instanceof Element && button.contains(related)) return;
-      hideTooltip();
-    };
+		const onPointerOut = (event: Event) => {
+			const button = helpButtonFromTarget(event.target);
+			if (!button) return;
+			const related = (event as PointerEvent).relatedTarget;
+			if (related instanceof Element && button.contains(related)) return;
+			hideTooltip();
+		};
 
-    const onFocusIn = (event: Event) => {
-      const button = helpButtonFromTarget(event.target);
-      if (!button) return;
-      showTooltip(button);
-    };
+		const onFocusIn = (event: Event) => {
+			const button = helpButtonFromTarget(event.target);
+			if (!button) return;
+			showTooltip(button);
+		};
 
-    const onFocusOut = (event: Event) => {
-      const button = helpButtonFromTarget(event.target);
-      if (!button) return;
-      hideTooltip();
-    };
+		const onFocusOut = (event: Event) => {
+			const button = helpButtonFromTarget(event.target);
+			if (!button) return;
+			hideTooltip();
+		};
 
-    const onClick = (event: Event) => {
-      const button = helpButtonFromTarget(event.target);
-      if (!button) return;
-      event.preventDefault();
-      setTooltip((current) => {
-        if (current.anchor === button && current.visible) {
-          return { anchor: null, content: '', visible: false };
-        }
-        const content = button.dataset.tooltip?.trim() || '';
-        if (!content) return current;
-        return { anchor: button, content, visible: true };
-      });
-    };
+		const onClick = (event: Event) => {
+			const button = helpButtonFromTarget(event.target);
+			if (!button) return;
+			event.preventDefault();
+			setTooltip((current) => {
+				if (current.anchor === button && current.visible) {
+					return { anchor: null, content: "", visible: false };
+				}
+				const content = button.dataset.tooltip?.trim() || "";
+				if (!content) return current;
+				return { anchor: button, content, visible: true };
+			});
+		};
 
-    document.addEventListener('pointerover', onPointerOver);
-    document.addEventListener('pointerout', onPointerOut);
-    document.addEventListener('focusin', onFocusIn);
-    document.addEventListener('focusout', onFocusOut);
-    document.addEventListener('click', onClick);
+		document.addEventListener("pointerover", onPointerOver);
+		document.addEventListener("pointerout", onPointerOut);
+		document.addEventListener("focusin", onFocusIn);
+		document.addEventListener("focusout", onFocusOut);
+		document.addEventListener("click", onClick);
 
-    return () => {
-      document.removeEventListener('pointerover', onPointerOver);
-      document.removeEventListener('pointerout', onPointerOut);
-      document.removeEventListener('focusin', onFocusIn);
-      document.removeEventListener('focusout', onFocusOut);
-      document.removeEventListener('click', onClick);
-    };
-  }, []);
+		return () => {
+			document.removeEventListener("pointerover", onPointerOver);
+			document.removeEventListener("pointerout", onPointerOut);
+			document.removeEventListener("focusin", onFocusIn);
+			document.removeEventListener("focusout", onFocusOut);
+			document.removeEventListener("click", onClick);
+		};
+	}, []);
 
-  useLayoutEffect(() => {
-    if (!tooltip.visible || !tooltip.anchor || !tooltipRef.current) return;
-    const frame = requestAnimationFrame(() => {
-      if (tooltipRef.current && tooltip.anchor) {
-        positionHelpTooltipElement(tooltipRef.current, tooltip.anchor);
-      }
-    });
-    return () => {
-      cancelAnimationFrame(frame);
-    };
-  }, [tooltip.anchor, tooltip.content, tooltip.visible]);
+	useLayoutEffect(() => {
+		if (!tooltip.visible || !tooltip.anchor || !tooltipRef.current) return;
+		const frame = requestAnimationFrame(() => {
+			if (tooltipRef.current && tooltip.anchor) {
+				positionHelpTooltipElement(tooltipRef.current, tooltip.anchor);
+			}
+		});
+		return () => {
+			cancelAnimationFrame(frame);
+		};
+	}, [tooltip.anchor, tooltip.content, tooltip.visible]);
 
-  useEffect(() => {
-    if (!tooltip.visible || !tooltip.anchor) return;
-    const reposition = () => {
-      if (tooltipRef.current && tooltip.anchor) {
-        positionHelpTooltipElement(tooltipRef.current, tooltip.anchor);
-      }
-    };
-    globalThis.addEventListener('resize', reposition);
-    document.addEventListener('scroll', reposition, true);
-    return () => {
-      globalThis.removeEventListener('resize', reposition);
-      document.removeEventListener('scroll', reposition, true);
-    };
-  }, [tooltip.anchor, tooltip.visible]);
+	useEffect(() => {
+		if (!tooltip.visible || !tooltip.anchor) return;
+		const reposition = () => {
+			if (tooltipRef.current && tooltip.anchor) {
+				positionHelpTooltipElement(tooltipRef.current, tooltip.anchor);
+			}
+		};
+		globalThis.addEventListener("resize", reposition);
+		document.addEventListener("scroll", reposition, true);
+		return () => {
+			globalThis.removeEventListener("resize", reposition);
+			document.removeEventListener("scroll", reposition, true);
+		};
+	}, [tooltip.anchor, tooltip.visible]);
 
-  const tooltipPortal = useMemo(() => {
-    if (typeof document === 'undefined') return null;
-    return createPortal(
-      <div
-        className={`help-tooltip${tooltip.visible ? ' visible' : ''}`}
-        hidden={!tooltip.visible}
-        ref={tooltipRef}
-      >
-        {tooltip.content}
-      </div>,
-      document.body,
-    );
-  }, [tooltip.content, tooltip.visible]);
+	const tooltipPortal = useMemo(() => {
+		if (typeof document === "undefined") return null;
+		return createPortal(
+			<div
+				className={`help-tooltip${tooltip.visible ? " visible" : ""}`}
+				hidden={!tooltip.visible}
+				ref={tooltipRef}
+			>
+				{tooltip.content}
+			</div>,
+			document.body,
+		);
+	}, [tooltip.content, tooltip.visible]);
 
-  const close = useCallback(() => {
-    if (settingsStartPolling && settingsRefresh) {
-      closeSettings(settingsStartPolling, settingsRefresh);
-    }
-  }, []);
+	const close = useCallback(() => {
+		if (settingsStartPolling && settingsRefresh) {
+			closeSettings(settingsStartPolling, settingsRefresh);
+		}
+	}, []);
 
-  return (
-    <>
-      <RadixDialog
-        ariaDescribedby="settingsDescription"
-        ariaLabelledby="settingsTitle"
-        contentClassName="modal"
-        contentId="settingsModal"
-        onCloseAutoFocus={(event) => {
-          event.preventDefault();
-        }}
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-          focusSettingsDialog();
-        }}
-        onOpenChange={(nextOpen) => {
-          if (nextOpen) {
-            setOpen(true);
-            return;
-          }
-          close();
-        }}
-        open={open}
-        overlayClassName="modal-backdrop"
-        overlayId="settingsBackdrop"
-      >
-        <SettingsDialogContent />
-      </RadixDialog>
-      {tooltipPortal}
-    </>
-  );
+	return (
+		<>
+			<RadixDialog
+				ariaDescribedby="settingsDescription"
+				ariaLabelledby="settingsTitle"
+				contentClassName="modal"
+				contentId="settingsModal"
+				onCloseAutoFocus={(event) => {
+					event.preventDefault();
+				}}
+				onOpenAutoFocus={(event) => {
+					event.preventDefault();
+					focusSettingsDialog();
+				}}
+				onOpenChange={(nextOpen) => {
+					if (nextOpen) {
+						setOpen(true);
+						return;
+					}
+					close();
+				}}
+				open={open}
+				overlayClassName="modal-backdrop"
+				overlayId="settingsBackdrop"
+			>
+				<SettingsDialogContent />
+			</RadixDialog>
+			{tooltipPortal}
+		</>
+	);
 }
 
 export function isSettingsOpen(): boolean {
-  return settingsOpen;
+	return settingsOpen;
 }
 
 function formatSettingsKey(key: string): string {
-  return String(key || '').replace(/_/g, ' ');
+	return String(key || "").replace(/_/g, " ");
 }
 
 function joinPhrases(values: string[]): string {
-  const items = values.filter((value) => typeof value === 'string' && value.trim());
-  if (items.length === 0) return '';
-  if (items.length === 1) return items[0];
-  if (items.length === 2) return `${items[0]} and ${items[1]}`;
-  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+	const items = values.filter((value) => typeof value === "string" && value.trim());
+	if (items.length === 0) return "";
+	if (items.length === 1) return items[0];
+	if (items.length === 2) return `${items[0]} and ${items[1]}`;
+	return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
 }
 
-function buildSettingsNotice(payload: any): { message: string; type: 'success' | 'warning' } {
-  const effects = payload?.effects && typeof payload.effects === 'object' ? payload.effects : {};
-  const hotReloaded = Array.isArray(effects.hot_reloaded_keys)
-    ? effects.hot_reloaded_keys.map(formatSettingsKey)
-    : [];
-  const liveApplied = Array.isArray(effects.live_applied_keys)
-    ? effects.live_applied_keys.map(formatSettingsKey)
-    : [];
-  const restartRequired = Array.isArray(effects.restart_required_keys)
-    ? effects.restart_required_keys.map(formatSettingsKey)
-    : [];
-  const warnings = Array.isArray(effects.warnings)
-    ? effects.warnings.filter(
-        (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0,
-      )
-    : [];
-  const manualActions = Array.isArray(effects.manual_actions) ? effects.manual_actions : [];
-  const sync = effects.sync && typeof effects.sync === 'object' ? effects.sync : {};
-  const lines: string[] = [];
+function buildSettingsNotice(payload: any): { message: string; type: "success" | "warning" } {
+	const effects = payload?.effects && typeof payload.effects === "object" ? payload.effects : {};
+	const hotReloaded = Array.isArray(effects.hot_reloaded_keys)
+		? effects.hot_reloaded_keys.map(formatSettingsKey)
+		: [];
+	const liveApplied = Array.isArray(effects.live_applied_keys)
+		? effects.live_applied_keys.map(formatSettingsKey)
+		: [];
+	const restartRequired = Array.isArray(effects.restart_required_keys)
+		? effects.restart_required_keys.map(formatSettingsKey)
+		: [];
+	const warnings = Array.isArray(effects.warnings)
+		? effects.warnings.filter(
+				(value: unknown): value is string => typeof value === "string" && value.trim().length > 0,
+			)
+		: [];
+	const manualActions = Array.isArray(effects.manual_actions) ? effects.manual_actions : [];
+	const sync = effects.sync && typeof effects.sync === "object" ? effects.sync : {};
+	const lines: string[] = [];
 
-  if (hotReloaded.length) {
-    lines.push(`Applied now: ${joinPhrases(hotReloaded)}.`);
-  }
-  if (liveApplied.length) {
-    lines.push(`Live settings updated: ${joinPhrases(liveApplied)}.`);
-  }
-  if (sync.attempted && typeof sync.message === 'string' && sync.message) {
-    lines.push(`Sync: ${sync.message}.`);
-  } else if (
-    Array.isArray(sync.affected_keys) &&
-    sync.affected_keys.length &&
-    typeof sync.reason === 'string' &&
-    sync.reason
-  ) {
-    lines.push(`Sync: ${sync.reason}.`);
-  }
-  if (restartRequired.length) {
-    lines.push(`Restart required for ${joinPhrases(restartRequired)}. Run: codemem serve restart`);
-  }
-  warnings.forEach((warning) => {
-    lines.push(warning);
-  });
-  manualActions.forEach((action) => {
-    if (action && typeof action.command === 'string' && action.command.trim()) {
-      lines.push(`If needed: ${action.command}.`);
-    }
-  });
-  if (!lines.length) {
-    lines.push('Saved.');
-  }
+	if (hotReloaded.length) {
+		lines.push(`Applied now: ${joinPhrases(hotReloaded)}.`);
+	}
+	if (liveApplied.length) {
+		lines.push(`Live settings updated: ${joinPhrases(liveApplied)}.`);
+	}
+	if (sync.attempted && typeof sync.message === "string" && sync.message) {
+		lines.push(`Sync: ${sync.message}.`);
+	} else if (
+		Array.isArray(sync.affected_keys) &&
+		sync.affected_keys.length &&
+		typeof sync.reason === "string" &&
+		sync.reason
+	) {
+		lines.push(`Sync: ${sync.reason}.`);
+	}
+	if (restartRequired.length) {
+		lines.push(`Restart required for ${joinPhrases(restartRequired)}. Run: codemem serve restart`);
+	}
+	warnings.forEach((warning) => {
+		lines.push(warning);
+	});
+	manualActions.forEach((action) => {
+		if (action && typeof action.command === "string" && action.command.trim()) {
+			lines.push(`If needed: ${action.command}.`);
+		}
+	});
+	if (!lines.length) {
+		lines.push("Saved.");
+	}
 
-  const hasWarning = restartRequired.length > 0 || warnings.length > 0 || sync.ok === false;
-  return { message: lines.join(' '), type: hasWarning ? 'warning' : 'success' };
+	const hasWarning = restartRequired.length > 0 || warnings.length > 0 || sync.ok === false;
+	return { message: lines.join(" "), type: hasWarning ? "warning" : "success" };
 }
 
 function isProtectedConfigKey(key: string): boolean {
-  return settingsProtectedKeys.has(key) || PROTECTED_VIEWER_CONFIG_KEYS.has(key);
+	return settingsProtectedKeys.has(key) || PROTECTED_VIEWER_CONFIG_KEYS.has(key);
 }
 
 function protectedConfigHelp(key: string): string {
-  return `${key} is read-only in the viewer for security. Edit the config file or environment instead.`;
+	return `${key} is read-only in the viewer for security. Edit the config file or environment instead.`;
 }
 
 function formStateFromPayload(payload: any): SettingsFormState {
-  const config = payload.config || {};
-  const effective = payload.effective || {};
-  const observerHeadersValue = effectiveOrConfigured(config, effective, 'observer_headers');
-  const observerHeaders =
-    observerHeadersValue && typeof observerHeadersValue === 'object' && !Array.isArray(observerHeadersValue)
-      ? Object.fromEntries(
-          Object.entries(observerHeadersValue as Record<string, unknown>).filter(
-            ([key, value]) => typeof key === 'string' && key.trim() && typeof value === 'string',
-          ),
-        )
-      : {};
-  const claudeCommandValue = effectiveOrConfigured(config, effective, 'claude_command');
-  const claudeCommand = Array.isArray(claudeCommandValue)
-    ? claudeCommandValue.filter((item): item is string => typeof item === 'string')
-    : [];
-  const authCommandValue = effectiveOrConfigured(config, effective, 'observer_auth_command');
-  const authCommand = Array.isArray(authCommandValue)
-    ? authCommandValue.filter((item): item is string => typeof item === 'string')
-    : [];
+	const config = payload.config || {};
+	const effective = payload.effective || {};
+	const observerHeadersValue = effectiveOrConfigured(config, effective, "observer_headers");
+	const observerHeaders =
+		observerHeadersValue &&
+		typeof observerHeadersValue === "object" &&
+		!Array.isArray(observerHeadersValue)
+			? Object.fromEntries(
+					Object.entries(observerHeadersValue as Record<string, unknown>).filter(
+						([key, value]) => typeof key === "string" && key.trim() && typeof value === "string",
+					),
+				)
+			: {};
+	const claudeCommandValue = effectiveOrConfigured(config, effective, "claude_command");
+	const claudeCommand = Array.isArray(claudeCommandValue)
+		? claudeCommandValue.filter((item): item is string => typeof item === "string")
+		: [];
+	const authCommandValue = effectiveOrConfigured(config, effective, "observer_auth_command");
+	const authCommand = Array.isArray(authCommandValue)
+		? authCommandValue.filter((item): item is string => typeof item === "string")
+		: [];
 
-  return {
-    claudeCommand: claudeCommand.length ? JSON.stringify(claudeCommand, null, 2) : '',
-    observerProvider: asInputString(effectiveOrConfigured(config, effective, 'observer_provider')),
-    observerModel: asInputString(effectiveOrConfigured(config, effective, 'observer_model')),
-    observerTierRoutingEnabled: asBooleanValue(
-      effectiveOrConfigured(config, effective, 'observer_tier_routing_enabled'),
-    ),
-    observerSimpleModel: asInputString(
-      effectiveOrConfigured(config, effective, 'observer_simple_model'),
-    ),
-    observerSimpleTemperature: asInputString(
-      effectiveOrConfigured(config, effective, 'observer_simple_temperature'),
-    ),
-    observerRichModel: asInputString(effectiveOrConfigured(config, effective, 'observer_rich_model')),
-    observerRichTemperature: asInputString(
-      effectiveOrConfigured(config, effective, 'observer_rich_temperature'),
-    ),
-    observerRichOpenAIUseResponses: asBooleanValue(
-      effectiveOrConfigured(config, effective, 'observer_rich_openai_use_responses'),
-    ),
-    observerRichReasoningEffort: asInputString(
-      effectiveOrConfigured(config, effective, 'observer_rich_reasoning_effort'),
-    ),
-    observerRichReasoningSummary: asInputString(
-      effectiveOrConfigured(config, effective, 'observer_rich_reasoning_summary'),
-    ),
-    observerRichMaxOutputTokens: asInputString(
-      effectiveOrConfigured(config, effective, 'observer_rich_max_output_tokens'),
-    ),
-    observerRuntime: asInputString(effectiveOrConfigured(config, effective, 'observer_runtime')) || 'api_http',
-    observerAuthSource:
-      asInputString(effectiveOrConfigured(config, effective, 'observer_auth_source')) || 'auto',
-    observerAuthFile: asInputString(effectiveOrConfigured(config, effective, 'observer_auth_file')),
-    observerAuthCommand: authCommand.length ? JSON.stringify(authCommand, null, 2) : '',
-    observerAuthTimeoutMs: asInputString(
-      effectiveOrConfigured(config, effective, 'observer_auth_timeout_ms'),
-    ),
-    observerAuthCacheTtlS: asInputString(
-      effectiveOrConfigured(config, effective, 'observer_auth_cache_ttl_s'),
-    ),
-    observerHeaders: Object.keys(observerHeaders).length ? JSON.stringify(observerHeaders, null, 2) : '',
-    observerMaxChars: asInputString(effectiveOrConfigured(config, effective, 'observer_max_chars')),
-    packObservationLimit: asInputString(
-      effectiveOrConfigured(config, effective, 'pack_observation_limit'),
-    ),
-    packSessionLimit: asInputString(effectiveOrConfigured(config, effective, 'pack_session_limit')),
-    rawEventsSweeperIntervalS: asInputString(
-      effectiveOrConfigured(config, effective, 'raw_events_sweeper_interval_s'),
-    ),
-    syncEnabled: asBooleanValue(effectiveOrConfigured(config, effective, 'sync_enabled')),
-    syncHost: asInputString(effectiveOrConfigured(config, effective, 'sync_host')),
-    syncPort: asInputString(effectiveOrConfigured(config, effective, 'sync_port')),
-    syncInterval: asInputString(effectiveOrConfigured(config, effective, 'sync_interval_s')),
-    syncMdns: asBooleanValue(effectiveOrConfigured(config, effective, 'sync_mdns')),
-    syncCoordinatorUrl: asInputString(effectiveOrConfigured(config, effective, 'sync_coordinator_url')),
-    syncCoordinatorGroup: asInputString(
-      effectiveOrConfigured(config, effective, 'sync_coordinator_group'),
-    ),
-    syncCoordinatorTimeout: asInputString(
-      effectiveOrConfigured(config, effective, 'sync_coordinator_timeout_s'),
-    ),
-    syncCoordinatorPresenceTtl: asInputString(
-      effectiveOrConfigured(config, effective, 'sync_coordinator_presence_ttl_s'),
-    ),
-  };
+	return {
+		claudeCommand: claudeCommand.length ? JSON.stringify(claudeCommand, null, 2) : "",
+		observerProvider: asInputString(effectiveOrConfigured(config, effective, "observer_provider")),
+		observerModel: asInputString(effectiveOrConfigured(config, effective, "observer_model")),
+		observerTierRoutingEnabled: asBooleanValue(
+			effectiveOrConfigured(config, effective, "observer_tier_routing_enabled"),
+		),
+		observerSimpleModel: asInputString(
+			effectiveOrConfigured(config, effective, "observer_simple_model"),
+		),
+		observerSimpleTemperature: asInputString(
+			effectiveOrConfigured(config, effective, "observer_simple_temperature"),
+		),
+		observerRichModel: asInputString(
+			effectiveOrConfigured(config, effective, "observer_rich_model"),
+		),
+		observerRichTemperature: asInputString(
+			effectiveOrConfigured(config, effective, "observer_rich_temperature"),
+		),
+		observerRichOpenAIUseResponses: asBooleanValue(
+			effectiveOrConfigured(config, effective, "observer_rich_openai_use_responses"),
+		),
+		observerRichReasoningEffort: asInputString(
+			effectiveOrConfigured(config, effective, "observer_rich_reasoning_effort"),
+		),
+		observerRichReasoningSummary: asInputString(
+			effectiveOrConfigured(config, effective, "observer_rich_reasoning_summary"),
+		),
+		observerRichMaxOutputTokens: asInputString(
+			effectiveOrConfigured(config, effective, "observer_rich_max_output_tokens"),
+		),
+		observerRuntime:
+			asInputString(effectiveOrConfigured(config, effective, "observer_runtime")) || "api_http",
+		observerAuthSource:
+			asInputString(effectiveOrConfigured(config, effective, "observer_auth_source")) || "auto",
+		observerAuthFile: asInputString(effectiveOrConfigured(config, effective, "observer_auth_file")),
+		observerAuthCommand: authCommand.length ? JSON.stringify(authCommand, null, 2) : "",
+		observerAuthTimeoutMs: asInputString(
+			effectiveOrConfigured(config, effective, "observer_auth_timeout_ms"),
+		),
+		observerAuthCacheTtlS: asInputString(
+			effectiveOrConfigured(config, effective, "observer_auth_cache_ttl_s"),
+		),
+		observerHeaders: Object.keys(observerHeaders).length
+			? JSON.stringify(observerHeaders, null, 2)
+			: "",
+		observerMaxChars: asInputString(effectiveOrConfigured(config, effective, "observer_max_chars")),
+		packObservationLimit: asInputString(
+			effectiveOrConfigured(config, effective, "pack_observation_limit"),
+		),
+		packSessionLimit: asInputString(effectiveOrConfigured(config, effective, "pack_session_limit")),
+		rawEventsSweeperIntervalS: asInputString(
+			effectiveOrConfigured(config, effective, "raw_events_sweeper_interval_s"),
+		),
+		syncEnabled: asBooleanValue(effectiveOrConfigured(config, effective, "sync_enabled")),
+		syncHost: asInputString(effectiveOrConfigured(config, effective, "sync_host")),
+		syncPort: asInputString(effectiveOrConfigured(config, effective, "sync_port")),
+		syncInterval: asInputString(effectiveOrConfigured(config, effective, "sync_interval_s")),
+		syncMdns: asBooleanValue(effectiveOrConfigured(config, effective, "sync_mdns")),
+		syncCoordinatorUrl: asInputString(
+			effectiveOrConfigured(config, effective, "sync_coordinator_url"),
+		),
+		syncCoordinatorGroup: asInputString(
+			effectiveOrConfigured(config, effective, "sync_coordinator_group"),
+		),
+		syncCoordinatorTimeout: asInputString(
+			effectiveOrConfigured(config, effective, "sync_coordinator_timeout_s"),
+		),
+		syncCoordinatorPresenceTtl: asInputString(
+			effectiveOrConfigured(config, effective, "sync_coordinator_presence_ttl_s"),
+		),
+	};
 }
 
 export function renderConfigModal(payload: any) {
-  if (!payload || typeof payload !== 'object') return;
-  const defaults = payload.defaults || {};
-  const config = payload.config || {};
-  const envOverrides =
-    payload.env_overrides && typeof payload.env_overrides === 'object' ? payload.env_overrides : {};
-  const protectedKeys = Array.isArray(payload.protected_keys)
-    ? payload.protected_keys.filter(
-        (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0,
-      )
-    : [];
-  const values = formStateFromPayload(payload);
+	if (!payload || typeof payload !== "object") return;
+	const defaults = payload.defaults || {};
+	const config = payload.config || {};
+	const envOverrides =
+		payload.env_overrides && typeof payload.env_overrides === "object" ? payload.env_overrides : {};
+	const protectedKeys = Array.isArray(payload.protected_keys)
+		? payload.protected_keys.filter(
+				(value: unknown): value is string => typeof value === "string" && value.trim().length > 0,
+			)
+		: [];
+	const values = formStateFromPayload(payload);
 
-  settingsEnvOverrides = envOverrides;
-  settingsProtectedKeys = new Set(protectedKeys);
-  state.configDefaults = defaults;
-  state.configPath = payload.path || '';
+	settingsEnvOverrides = envOverrides;
+	settingsProtectedKeys = new Set(protectedKeys);
+	state.configDefaults = defaults;
+	state.configPath = payload.path || "";
 
-  updateRenderState({
-    effectiveText:
-      Object.keys(envOverrides).length > 0 ? 'Some fields are managed by environment settings.' : '',
-    overridesVisible: Object.keys(envOverrides).length > 0,
-    pathText: state.configPath ? `Config path: ${state.configPath}` : 'Config path: n/a',
-    providers: toProviderList(payload.providers),
-    statusText: 'Ready',
-    values,
-  });
+	updateRenderState({
+		effectiveText:
+			Object.keys(envOverrides).length > 0
+				? "Some fields are managed by environment settings."
+				: "",
+		overridesVisible: Object.keys(envOverrides).length > 0,
+		pathText: state.configPath ? `Config path: ${state.configPath}` : "Config path: n/a",
+		providers: toProviderList(payload.providers),
+		statusText: "Ready",
+		values,
+	});
 
-  settingsTouchedKeys = new Set<string>();
-  try {
-    const baseline = collectSettingsPayload({ allowUntouchedParseErrors: true });
-    settingsBaseline = mergeOverrideBaseline(baseline, config, envOverrides);
-  } catch {
-    settingsBaseline = {};
-  }
+	settingsTouchedKeys = new Set<string>();
+	try {
+		const baseline = collectSettingsPayload({ allowUntouchedParseErrors: true });
+		settingsBaseline = mergeOverrideBaseline(baseline, config, envOverrides);
+	} catch {
+		settingsBaseline = {};
+	}
 
-  setDirty(false);
+	setDirty(false);
 }
 
-function parseCommandArgv(raw: string, options: { label: string; normalize?: boolean; requireNonEmpty?: boolean }): string[] {
-  const text = raw.trim();
-  if (!text) return [];
-  const parsed = JSON.parse(text);
-  if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== 'string')) {
-    throw new Error(`${options.label} must be a JSON string array`);
-  }
-  if (!options.normalize && !options.requireNonEmpty) {
-    return parsed;
-  }
-  const values = options.normalize ? parsed.map((item) => item.trim()) : parsed;
-  if (options.requireNonEmpty && values.some((item) => item.trim() === '')) {
-    throw new Error(`${options.label} cannot contain empty command tokens`);
-  }
-  return values;
+function parseCommandArgv(
+	raw: string,
+	options: { label: string; normalize?: boolean; requireNonEmpty?: boolean },
+): string[] {
+	const text = raw.trim();
+	if (!text) return [];
+	const parsed = JSON.parse(text);
+	if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+		throw new Error(`${options.label} must be a JSON string array`);
+	}
+	if (!options.normalize && !options.requireNonEmpty) {
+		return parsed;
+	}
+	const values = options.normalize ? parsed.map((item) => item.trim()) : parsed;
+	if (options.requireNonEmpty && values.some((item) => item.trim() === "")) {
+		throw new Error(`${options.label} cannot contain empty command tokens`);
+	}
+	return values;
 }
 
 function parseObserverHeaders(raw: string): Record<string, string> {
-  const text = raw.trim();
-  if (!text) return {};
-  const parsed = JSON.parse(text);
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error('observer headers must be a JSON object');
-  }
-  const headers: Record<string, string> = {};
-  for (const [key, value] of Object.entries(parsed)) {
-    if (typeof key !== 'string' || !key.trim() || typeof value !== 'string') {
-      throw new Error('observer headers must map string keys to string values');
-    }
-    headers[key.trim()] = value;
-  }
-  return headers;
+	const text = raw.trim();
+	if (!text) return {};
+	const parsed = JSON.parse(text);
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("observer headers must be a JSON object");
+	}
+	const headers: Record<string, string> = {};
+	for (const [key, value] of Object.entries(parsed)) {
+		if (typeof key !== "string" || !key.trim() || typeof value !== "string") {
+			throw new Error("observer headers must map string keys to string values");
+		}
+		headers[key.trim()] = value;
+	}
+	return headers;
 }
 
-function collectSettingsPayload(options: { allowUntouchedParseErrors?: boolean } = {}): Record<string, unknown> {
-  const allowUntouchedParseErrors = options.allowUntouchedParseErrors === true;
-  const values = settingsRenderState.values;
-  let claudeCommand: string[] = [];
-  try {
-    claudeCommand = parseCommandArgv(values.claudeCommand, {
-      label: 'claude command',
-      normalize: true,
-      requireNonEmpty: true,
-    });
-  } catch (error) {
-    if (!allowUntouchedParseErrors || settingsTouchedKeys.has('claude_command')) {
-      throw error;
-    }
-    const baseline = settingsBaseline.claude_command;
-    claudeCommand = Array.isArray(baseline)
-      ? baseline
-          .filter((item): item is string => typeof item === 'string')
-          .map((item) => item.trim())
-          .filter((item) => item.length > 0)
-      : [];
-  }
+function collectSettingsPayload(
+	options: { allowUntouchedParseErrors?: boolean } = {},
+): Record<string, unknown> {
+	const allowUntouchedParseErrors = options.allowUntouchedParseErrors === true;
+	const values = settingsRenderState.values;
+	let claudeCommand: string[] = [];
+	try {
+		claudeCommand = parseCommandArgv(values.claudeCommand, {
+			label: "claude command",
+			normalize: true,
+			requireNonEmpty: true,
+		});
+	} catch (error) {
+		if (!allowUntouchedParseErrors || settingsTouchedKeys.has("claude_command")) {
+			throw error;
+		}
+		const baseline = settingsBaseline.claude_command;
+		claudeCommand = Array.isArray(baseline)
+			? baseline
+					.filter((item): item is string => typeof item === "string")
+					.map((item) => item.trim())
+					.filter((item) => item.length > 0)
+			: [];
+	}
 
-  let authCommand: string[] = [];
-  try {
-    authCommand = parseCommandArgv(values.observerAuthCommand, { label: 'observer auth command' });
-  } catch (error) {
-    if (!allowUntouchedParseErrors || settingsTouchedKeys.has('observer_auth_command')) {
-      throw error;
-    }
-    const baseline = settingsBaseline.observer_auth_command;
-    authCommand = Array.isArray(baseline)
-      ? baseline.filter((item): item is string => typeof item === 'string')
-      : [];
-  }
+	let authCommand: string[] = [];
+	try {
+		authCommand = parseCommandArgv(values.observerAuthCommand, { label: "observer auth command" });
+	} catch (error) {
+		if (!allowUntouchedParseErrors || settingsTouchedKeys.has("observer_auth_command")) {
+			throw error;
+		}
+		const baseline = settingsBaseline.observer_auth_command;
+		authCommand = Array.isArray(baseline)
+			? baseline.filter((item): item is string => typeof item === "string")
+			: [];
+	}
 
-  let headers: Record<string, string> = {};
-  try {
-    headers = parseObserverHeaders(values.observerHeaders);
-  } catch (error) {
-    if (!allowUntouchedParseErrors || settingsTouchedKeys.has('observer_headers')) {
-      throw error;
-    }
-    const baseline = settingsBaseline.observer_headers;
-    if (baseline && typeof baseline === 'object' && !Array.isArray(baseline)) {
-      Object.entries(baseline as Record<string, unknown>).forEach(([key, value]) => {
-        if (typeof key === 'string' && key.trim() && typeof value === 'string') {
-          headers[key] = value;
-        }
-      });
-    }
-  }
+	let headers: Record<string, string> = {};
+	try {
+		headers = parseObserverHeaders(values.observerHeaders);
+	} catch (error) {
+		if (!allowUntouchedParseErrors || settingsTouchedKeys.has("observer_headers")) {
+			throw error;
+		}
+		const baseline = settingsBaseline.observer_headers;
+		if (baseline && typeof baseline === "object" && !Array.isArray(baseline)) {
+			Object.entries(baseline as Record<string, unknown>).forEach(([key, value]) => {
+				if (typeof key === "string" && key.trim() && typeof value === "string") {
+					headers[key] = value;
+				}
+			});
+		}
+	}
 
-  const authCacheTtlInput = values.observerAuthCacheTtlS.trim();
-  const simpleTemperatureInput = values.observerSimpleTemperature.trim();
-  const richTemperatureInput = values.observerRichTemperature.trim();
-  const richMaxOutputTokensInput = values.observerRichMaxOutputTokens.trim();
-  const sweeperIntervalInput = values.rawEventsSweeperIntervalS.trim();
-  const authCacheTtl = authCacheTtlInput === '' ? '' : Number(authCacheTtlInput);
-  const simpleTemperature = simpleTemperatureInput === '' ? '' : Number(simpleTemperatureInput);
-  const richTemperature = richTemperatureInput === '' ? '' : Number(richTemperatureInput);
-  const richMaxOutputTokens = richMaxOutputTokensInput === '' ? '' : Number(richMaxOutputTokensInput);
-  const sweeperIntervalNum = Number(sweeperIntervalInput);
-  const sweeperInterval = sweeperIntervalInput === '' ? '' : sweeperIntervalNum;
+	const authCacheTtlInput = values.observerAuthCacheTtlS.trim();
+	const simpleTemperatureInput = values.observerSimpleTemperature.trim();
+	const richTemperatureInput = values.observerRichTemperature.trim();
+	const richMaxOutputTokensInput = values.observerRichMaxOutputTokens.trim();
+	const sweeperIntervalInput = values.rawEventsSweeperIntervalS.trim();
+	const authCacheTtl = authCacheTtlInput === "" ? "" : Number(authCacheTtlInput);
+	const simpleTemperature = simpleTemperatureInput === "" ? "" : Number(simpleTemperatureInput);
+	const richTemperature = richTemperatureInput === "" ? "" : Number(richTemperatureInput);
+	const richMaxOutputTokens =
+		richMaxOutputTokensInput === "" ? "" : Number(richMaxOutputTokensInput);
+	const sweeperIntervalNum = Number(sweeperIntervalInput);
+	const sweeperInterval = sweeperIntervalInput === "" ? "" : sweeperIntervalNum;
 
-  if (authCacheTtlInput !== '' && !Number.isFinite(authCacheTtl)) {
-    throw new Error('observer auth cache ttl must be a number');
-  }
-  if (
-    simpleTemperatureInput !== '' &&
-    (typeof simpleTemperature !== 'number' || !Number.isFinite(simpleTemperature) || simpleTemperature < 0)
-  ) {
-    throw new Error('simple tier temperature must be a non-negative number');
-  }
-  if (
-    richTemperatureInput !== '' &&
-    (typeof richTemperature !== 'number' || !Number.isFinite(richTemperature) || richTemperature < 0)
-  ) {
-    throw new Error('rich tier temperature must be a non-negative number');
-  }
-  if (
-    richMaxOutputTokensInput !== '' &&
-    (
-      typeof richMaxOutputTokens !== 'number' ||
-      !Number.isFinite(richMaxOutputTokens) ||
-      richMaxOutputTokens <= 0 ||
-      !Number.isInteger(richMaxOutputTokens)
-    )
-  ) {
-    throw new Error('rich tier max output tokens must be a positive integer');
-  }
-  if (sweeperIntervalInput !== '' && (!Number.isFinite(sweeperIntervalNum) || sweeperIntervalNum <= 0)) {
-    throw new Error('raw-event sweeper interval must be a positive number');
-  }
+	if (authCacheTtlInput !== "" && !Number.isFinite(authCacheTtl)) {
+		throw new Error("observer auth cache ttl must be a number");
+	}
+	if (
+		simpleTemperatureInput !== "" &&
+		(typeof simpleTemperature !== "number" ||
+			!Number.isFinite(simpleTemperature) ||
+			simpleTemperature < 0)
+	) {
+		throw new Error("simple tier temperature must be a non-negative number");
+	}
+	if (
+		richTemperatureInput !== "" &&
+		(typeof richTemperature !== "number" ||
+			!Number.isFinite(richTemperature) ||
+			richTemperature < 0)
+	) {
+		throw new Error("rich tier temperature must be a non-negative number");
+	}
+	if (
+		richMaxOutputTokensInput !== "" &&
+		(typeof richMaxOutputTokens !== "number" ||
+			!Number.isFinite(richMaxOutputTokens) ||
+			richMaxOutputTokens <= 0 ||
+			!Number.isInteger(richMaxOutputTokens))
+	) {
+		throw new Error("rich tier max output tokens must be a positive integer");
+	}
+	if (
+		sweeperIntervalInput !== "" &&
+		(!Number.isFinite(sweeperIntervalNum) || sweeperIntervalNum <= 0)
+	) {
+		throw new Error("raw-event sweeper interval must be a positive number");
+	}
 
-  return {
-    claude_command: claudeCommand,
-    observer_provider: normalizeTextValue(values.observerProvider),
-    observer_model: normalizeTextValue(values.observerModel),
-    observer_tier_routing_enabled: values.observerTierRoutingEnabled,
-    observer_simple_model: normalizeTextValue(values.observerSimpleModel),
-    observer_simple_temperature: simpleTemperature,
-    observer_rich_model: normalizeTextValue(values.observerRichModel),
-    observer_rich_temperature: richTemperature,
-    observer_rich_openai_use_responses: values.observerRichOpenAIUseResponses,
-    observer_rich_reasoning_effort: normalizeTextValue(values.observerRichReasoningEffort),
-    observer_rich_reasoning_summary: normalizeTextValue(values.observerRichReasoningSummary),
-    observer_rich_max_output_tokens: richMaxOutputTokens,
-    observer_runtime: normalizeTextValue(values.observerRuntime || 'api_http') || 'api_http',
-    observer_auth_source: normalizeTextValue(values.observerAuthSource || 'auto') || 'auto',
-    observer_auth_file: normalizeTextValue(values.observerAuthFile),
-    observer_auth_command: authCommand,
-    observer_auth_timeout_ms: Number(values.observerAuthTimeoutMs || 0) || '',
-    observer_auth_cache_ttl_s: authCacheTtl,
-    observer_headers: headers,
-    observer_max_chars: Number(values.observerMaxChars || 0) || '',
-    pack_observation_limit: Number(values.packObservationLimit || 0) || '',
-    pack_session_limit: Number(values.packSessionLimit || 0) || '',
-    raw_events_sweeper_interval_s: sweeperInterval,
-    sync_enabled: values.syncEnabled,
-    sync_host: normalizeTextValue(values.syncHost),
-    sync_port: Number(values.syncPort || 0) || '',
-    sync_interval_s: Number(values.syncInterval || 0) || '',
-    sync_mdns: values.syncMdns,
-    sync_coordinator_url: normalizeTextValue(values.syncCoordinatorUrl),
-    sync_coordinator_group: normalizeTextValue(values.syncCoordinatorGroup),
-    sync_coordinator_timeout_s: Number(values.syncCoordinatorTimeout || 0) || '',
-    sync_coordinator_presence_ttl_s: Number(values.syncCoordinatorPresenceTtl || 0) || '',
-  };
+	return {
+		claude_command: claudeCommand,
+		observer_provider: normalizeTextValue(values.observerProvider),
+		observer_model: normalizeTextValue(values.observerModel),
+		observer_tier_routing_enabled: values.observerTierRoutingEnabled,
+		observer_simple_model: normalizeTextValue(values.observerSimpleModel),
+		observer_simple_temperature: simpleTemperature,
+		observer_rich_model: normalizeTextValue(values.observerRichModel),
+		observer_rich_temperature: richTemperature,
+		observer_rich_openai_use_responses: values.observerRichOpenAIUseResponses,
+		observer_rich_reasoning_effort: normalizeTextValue(values.observerRichReasoningEffort),
+		observer_rich_reasoning_summary: normalizeTextValue(values.observerRichReasoningSummary),
+		observer_rich_max_output_tokens: richMaxOutputTokens,
+		observer_runtime: normalizeTextValue(values.observerRuntime || "api_http") || "api_http",
+		observer_auth_source: normalizeTextValue(values.observerAuthSource || "auto") || "auto",
+		observer_auth_file: normalizeTextValue(values.observerAuthFile),
+		observer_auth_command: authCommand,
+		observer_auth_timeout_ms: Number(values.observerAuthTimeoutMs || 0) || "",
+		observer_auth_cache_ttl_s: authCacheTtl,
+		observer_headers: headers,
+		observer_max_chars: Number(values.observerMaxChars || 0) || "",
+		pack_observation_limit: Number(values.packObservationLimit || 0) || "",
+		pack_session_limit: Number(values.packSessionLimit || 0) || "",
+		raw_events_sweeper_interval_s: sweeperInterval,
+		sync_enabled: values.syncEnabled,
+		sync_host: normalizeTextValue(values.syncHost),
+		sync_port: Number(values.syncPort || 0) || "",
+		sync_interval_s: Number(values.syncInterval || 0) || "",
+		sync_mdns: values.syncMdns,
+		sync_coordinator_url: normalizeTextValue(values.syncCoordinatorUrl),
+		sync_coordinator_group: normalizeTextValue(values.syncCoordinatorGroup),
+		sync_coordinator_timeout_s: Number(values.syncCoordinatorTimeout || 0) || "",
+		sync_coordinator_presence_ttl_s: Number(values.syncCoordinatorPresenceTtl || 0) || "",
+	};
 }
 
 function setSettingsTab(tab: string) {
-  const nextTab = ['observer', 'queue', 'sync'].includes(tab) ? (tab as SettingsTabId) : 'observer';
-  settingsActiveTab = nextTab;
-  settingsController?.setActiveTab(nextTab);
+	const nextTab = ["observer", "queue", "sync"].includes(tab) ? (tab as SettingsTabId) : "observer";
+	settingsActiveTab = nextTab;
+	settingsController?.setActiveTab(nextTab);
 }
 
 function setDirty(dirty: boolean, rerender = true) {
-  state.settingsDirty = dirty;
-  if (rerender) settingsController?.setDirty(dirty);
+	state.settingsDirty = dirty;
+	if (rerender) settingsController?.setDirty(dirty);
 }
 
 export function openSettings(stopPolling: () => void) {
-  if (!settingsShellMounted) {
-    ensureSettingsShell();
-  }
-  settingsOpen = true;
-  previouslyFocused = document.activeElement as HTMLElement | null;
-  stopPolling();
-  settingsController?.setOpen(true);
+	if (!settingsShellMounted) {
+		ensureSettingsShell();
+	}
+	settingsOpen = true;
+	previouslyFocused = document.activeElement as HTMLElement | null;
+	stopPolling();
+	settingsController?.setOpen(true);
 }
 
 export function closeSettings(startPolling: () => void, refreshCallback: () => void) {
-  if (state.settingsDirty) {
-    if (!globalThis.confirm('Discard unsaved changes?')) {
-      settingsController?.setOpen(true);
-      return;
-    }
-  }
-  settingsOpen = false;
-  settingsController?.setOpen(false);
-  hideHelpTooltip();
-  const restoreTarget =
-    previouslyFocused && typeof previouslyFocused.focus === 'function'
-      ? previouslyFocused
-      : $button('settingsButton');
-  restoreTarget?.focus();
-  previouslyFocused = null;
-  settingsTouchedKeys = new Set<string>();
-  startPolling();
-  refreshCallback();
+	if (state.settingsDirty) {
+		if (!globalThis.confirm("Discard unsaved changes?")) {
+			settingsController?.setOpen(true);
+			return;
+		}
+	}
+	settingsOpen = false;
+	settingsController?.setOpen(false);
+	hideHelpTooltip();
+	const restoreTarget =
+		previouslyFocused && typeof previouslyFocused.focus === "function"
+			? previouslyFocused
+			: $button("settingsButton");
+	restoreTarget?.focus();
+	previouslyFocused = null;
+	settingsTouchedKeys = new Set<string>();
+	startPolling();
+	refreshCallback();
 }
 
 export async function saveSettings(startPolling: () => void, refreshCallback: () => void) {
-  if (settingsRenderState.isSaving) return;
-  updateRenderState({ isSaving: true, statusText: 'Saving...' });
+	if (settingsRenderState.isSaving) return;
+	updateRenderState({ isSaving: true, statusText: "Saving..." });
 
-  try {
-    const current = collectSettingsPayload({ allowUntouchedParseErrors: true });
-    const changed: Record<string, unknown> = {};
-    Object.entries(current).forEach(([key, value]) => {
-      if (isProtectedConfigKey(key)) {
-        return;
-      }
-      if (hasOwn(settingsEnvOverrides, key) && !settingsTouchedKeys.has(key)) {
-        return;
-      }
-      if (!isEqualValue(value, settingsBaseline[key])) {
-        changed[key] = value;
-      }
-    });
-    if (Object.keys(changed).length === 0) {
-      updateRenderState({ isSaving: false, statusText: 'No changes' });
-      setDirty(false);
-      closeSettings(startPolling, refreshCallback);
-      return;
-    }
+	try {
+		const current = collectSettingsPayload({ allowUntouchedParseErrors: true });
+		const changed: Record<string, unknown> = {};
+		Object.entries(current).forEach(([key, value]) => {
+			if (isProtectedConfigKey(key)) {
+				return;
+			}
+			if (hasOwn(settingsEnvOverrides, key) && !settingsTouchedKeys.has(key)) {
+				return;
+			}
+			if (!isEqualValue(value, settingsBaseline[key])) {
+				changed[key] = value;
+			}
+		});
+		if (Object.keys(changed).length === 0) {
+			updateRenderState({ isSaving: false, statusText: "No changes" });
+			setDirty(false);
+			closeSettings(startPolling, refreshCallback);
+			return;
+		}
 
-    const result = await api.saveConfig(changed);
-    const notice = buildSettingsNotice(result);
-    updateRenderState({ isSaving: false, statusText: 'Saved' });
-    setDirty(false);
-    closeSettings(startPolling, refreshCallback);
-    showGlobalNotice(notice.message, notice.type);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'unknown error';
-    updateRenderState({ isSaving: false, statusText: `Save failed: ${message}` });
-  }
+		const result = await api.saveConfig(changed);
+		const notice = buildSettingsNotice(result);
+		updateRenderState({ isSaving: false, statusText: "Saved" });
+		setDirty(false);
+		closeSettings(startPolling, refreshCallback);
+		showGlobalNotice(notice.message, notice.type);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "unknown error";
+		updateRenderState({ isSaving: false, statusText: `Save failed: ${message}` });
+	}
 }
 
 function formatAuthMethod(method: string): string {
-  switch (method) {
-    case 'anthropic_consumer':
-      return 'OAuth (Claude Max/Pro)';
-    case 'codex_consumer':
-      return 'OAuth (ChatGPT subscription)';
-    case 'sdk_client':
-      return 'API key';
-    case 'claude_sidecar':
-      return 'Local Claude session';
-    case 'opencode_run':
-      return 'OpenCode sidecar';
-    default:
-      return method || 'none';
-  }
+	switch (method) {
+		case "anthropic_consumer":
+			return "OAuth (Claude Max/Pro)";
+		case "codex_consumer":
+			return "OAuth (ChatGPT subscription)";
+		case "sdk_client":
+			return "API key";
+		case "claude_sidecar":
+			return "Local Claude session";
+		case "opencode_run":
+			return "OpenCode sidecar";
+		default:
+			return method || "none";
+	}
 }
 
 function formatCredentialSources(creds: Record<string, boolean>): string {
-  const parts: string[] = [];
-  if (creds.oauth) parts.push('OAuth');
-  if (creds.api_key) parts.push('API key');
-  if (creds.env_var) parts.push('env var');
-  return parts.length ? parts.join(', ') : 'none';
+	const parts: string[] = [];
+	if (creds.oauth) parts.push("OAuth");
+	if (creds.api_key) parts.push("API key");
+	if (creds.env_var) parts.push("env var");
+	return parts.length ? parts.join(", ") : "none";
 }
 
 function formatFailureTimestamp(value: unknown): string {
-  if (typeof value !== 'string' || !value.trim()) return 'Unknown time';
-  const ts = new Date(value);
-  if (Number.isNaN(ts.getTime())) return value;
-  return ts.toLocaleString();
+	if (typeof value !== "string" || !value.trim()) return "Unknown time";
+	const ts = new Date(value);
+	if (Number.isNaN(ts.getTime())) return value;
+	return ts.toLocaleString();
 }
 
 function renderObserverStatusBanner(status: any) {
-  updateRenderState({ observerStatus: status && typeof status === 'object' ? status : null });
+	updateRenderState({ observerStatus: status && typeof status === "object" ? status : null });
 }
 
 export async function loadConfigData() {
-  if (settingsOpen) return;
-  try {
-    const [payload, status] = await Promise.all([api.loadConfig(), api.loadObserverStatus().catch(() => null)]);
-    renderConfigModal(payload);
-    renderObserverStatusBanner(status);
-  } catch {}
+	if (settingsOpen) return;
+	try {
+		const [payload, status] = await Promise.all([
+			api.loadConfig(),
+			api.loadObserverStatus().catch(() => null),
+		]);
+		renderConfigModal(payload);
+		renderObserverStatusBanner(status);
+	} catch {}
 }
 
 function updateField<K extends keyof SettingsFormState>(field: K, value: SettingsFormState[K]) {
-  markFieldTouched(field);
-  updateFormState({ [field]: value } as Partial<SettingsFormState>);
-  setDirty(true);
+	markFieldTouched(field);
+	updateFormState({ [field]: value } as Partial<SettingsFormState>);
+	setDirty(true);
 }
 
 function onTextInput<K extends keyof SettingsFormState>(field: K) {
-  return (event: JSX.TargetedEvent<HTMLInputElement | HTMLTextAreaElement, Event>) => {
-    updateField(field, event.currentTarget.value as SettingsFormState[K]);
-  };
+	return (event: JSX.TargetedEvent<HTMLInputElement | HTMLTextAreaElement, Event>) => {
+		updateField(field, event.currentTarget.value as SettingsFormState[K]);
+	};
 }
 
 function onSelectInput<K extends keyof SettingsFormState>(field: K) {
-  return (event: JSX.TargetedEvent<HTMLSelectElement, Event>) => {
-    updateField(field, event.currentTarget.value as SettingsFormState[K]);
-  };
+	return (event: JSX.TargetedEvent<HTMLSelectElement, Event>) => {
+		updateField(field, event.currentTarget.value as SettingsFormState[K]);
+	};
 }
 
 function onCheckboxInput<K extends keyof SettingsFormState>(field: K) {
-  return (event: JSX.TargetedEvent<HTMLInputElement, Event>) => {
-    updateField(field, event.currentTarget.checked as SettingsFormState[K]);
-  };
+	return (event: JSX.TargetedEvent<HTMLInputElement, Event>) => {
+		updateField(field, event.currentTarget.checked as SettingsFormState[K]);
+	};
 }
 
 function onAdvancedToggle(event: JSX.TargetedEvent<HTMLInputElement, Event>) {
-  const checked = event.currentTarget.checked;
-  settingsShowAdvanced = checked;
-  settingsController?.setShowAdvanced(checked);
+	const checked = event.currentTarget.checked;
+	settingsShowAdvanced = checked;
+	settingsController?.setShowAdvanced(checked);
 }
 
 function tabButtonClass(tab: SettingsTabId): string {
-  return `settings-tab${settingsActiveTab === tab ? ' active' : ''}`;
+	return `settings-tab${settingsActiveTab === tab ? " active" : ""}`;
 }
 
 function panelClass(tab: SettingsTabId): string {
-  return `settings-panel${settingsActiveTab === tab ? ' active' : ''}`;
+	return `settings-panel${settingsActiveTab === tab ? " active" : ""}`;
 }
 
 function hiddenUnlessAdvanced(): boolean {
-  return !settingsShowAdvanced;
+	return !settingsShowAdvanced;
 }
 
 function ObserverStatusBanner() {
-  const status = settingsRenderState.observerStatus as Record<string, any> | null;
-  if (!status) {
-    return <div id="observerStatusBanner" className="observer-status-banner" hidden />;
-  }
+	const status = settingsRenderState.observerStatus as Record<string, any> | null;
+	if (!status) {
+		return <div id="observerStatusBanner" className="observer-status-banner" hidden />;
+	}
 
-  const active = status.active;
-  const available = status.available_credentials || {};
-  const failure = status.latest_failure;
-  const credentialEntries = Object.entries(available).filter(([, creds]) => creds && typeof creds === 'object');
+	const active = status.active;
+	const available = status.available_credentials || {};
+	const failure = status.latest_failure;
+	const credentialEntries = Object.entries(available).filter(
+		([, creds]) => creds && typeof creds === "object",
+	);
 
-  return (
-    <div id="observerStatusBanner" className="observer-status-banner">
-      {active ? (
-        <>
-          <div className="status-label">Active observer</div>
-          <div className="status-active">
-            {String(active.provider || 'unknown')} → {String(active.model || '')} via{' '}
-            {formatAuthMethod(active.auth?.method || 'none')}{' '}
-            <span className={active.auth?.token_present === true ? 'cred-ok' : 'cred-none'}>
-              {active.auth?.token_present === true ? '✓' : '✗'}
-            </span>
-          </div>
-        </>
-      ) : (
-        <>
-          <div className="status-label">Observer status</div>
-          <div className="status-active">Not yet initialized (waiting for first session)</div>
-        </>
-      )}
+	return (
+		<div id="observerStatusBanner" className="observer-status-banner">
+			{active ? (
+				<>
+					<div className="status-label">Active observer</div>
+					<div className="status-active">
+						{String(active.provider || "unknown")} → {String(active.model || "")} via{" "}
+						{formatAuthMethod(active.auth?.method || "none")}{" "}
+						<span className={active.auth?.token_present === true ? "cred-ok" : "cred-none"}>
+							{active.auth?.token_present === true ? "✓" : "✗"}
+						</span>
+					</div>
+				</>
+			) : (
+				<>
+					<div className="status-label">Observer status</div>
+					<div className="status-active">Not yet initialized (waiting for first session)</div>
+				</>
+			)}
 
-      {credentialEntries.length ? (
-        <>
-          <div className="status-label">Available credentials</div>
-          <div>
-            {credentialEntries.map(([provider, creds], index) => {
-              const normalizedCreds = creds as Record<string, boolean>;
-              const hasAny = Object.values(normalizedCreds).some(Boolean);
-              return (
-                <span key={provider} className="status-cred">
-                  {index > 0 ? ' · ' : null}
-                  <span className={hasAny ? 'cred-ok' : 'cred-none'}>{hasAny ? '✓' : '–'}</span>{' '}
-                  {String(provider)}: {formatCredentialSources(normalizedCreds)}
-                </span>
-              );
-            })}
-          </div>
-        </>
-      ) : null}
+			{credentialEntries.length ? (
+				<>
+					<div className="status-label">Available credentials</div>
+					<div>
+						{credentialEntries.map(([provider, creds], index) => {
+							const normalizedCreds = creds as Record<string, boolean>;
+							const hasAny = Object.values(normalizedCreds).some(Boolean);
+							return (
+								<span key={provider} className="status-cred">
+									{index > 0 ? " · " : null}
+									<span className={hasAny ? "cred-ok" : "cred-none"}>{hasAny ? "✓" : "–"}</span>{" "}
+									{String(provider)}: {formatCredentialSources(normalizedCreds)}
+								</span>
+							);
+						})}
+					</div>
+				</>
+			) : null}
 
-      {failure && typeof failure === 'object' ? (
-        <>
-          <div className="status-label">Latest processing issue</div>
-          <div className="status-issue">
-            <div className="status-issue-message">
-              {typeof failure.error_message === 'string' && failure.error_message.trim()
-                ? failure.error_message.trim()
-                : 'Raw-event processing failed.'}
-            </div>
-            <div className="status-issue-meta">
-              {[
-                [
-                  typeof failure.observer_provider === 'string' ? failure.observer_provider.trim() : '',
-                  typeof failure.observer_model === 'string' && failure.observer_model.trim()
-                    ? `→ ${failure.observer_model.trim()}`
-                    : '',
-                  typeof failure.observer_runtime === 'string' && failure.observer_runtime.trim()
-                    ? `(${failure.observer_runtime.trim()})`
-                    : '',
-                ]
-                  .filter(Boolean)
-                  .join(' ')
-                  .replace(/\s+/g, ' ')
-                  .trim(),
-                `Last failure ${formatFailureTimestamp(failure.updated_at)}`,
-                typeof failure.attempt_count === 'number' && Number.isFinite(failure.attempt_count)
-                  ? `Attempts ${failure.attempt_count}`
-                  : '',
-              ]
-                .filter(Boolean)
-                .join(' · ')}
-            </div>
-            {typeof failure.impact === 'string' && failure.impact.trim() ? (
-              <div className="status-issue-impact">{failure.impact.trim()}</div>
-            ) : null}
-          </div>
-        </>
-      ) : null}
-    </div>
-  );
+			{failure && typeof failure === "object" ? (
+				<>
+					<div className="status-label">Latest processing issue</div>
+					<div className="status-issue">
+						<div className="status-issue-message">
+							{typeof failure.error_message === "string" && failure.error_message.trim()
+								? failure.error_message.trim()
+								: "Raw-event processing failed."}
+						</div>
+						<div className="status-issue-meta">
+							{[
+								[
+									typeof failure.observer_provider === "string"
+										? failure.observer_provider.trim()
+										: "",
+									typeof failure.observer_model === "string" && failure.observer_model.trim()
+										? `→ ${failure.observer_model.trim()}`
+										: "",
+									typeof failure.observer_runtime === "string" && failure.observer_runtime.trim()
+										? `(${failure.observer_runtime.trim()})`
+										: "",
+								]
+									.filter(Boolean)
+									.join(" ")
+									.replace(/\s+/g, " ")
+									.trim(),
+								`Last failure ${formatFailureTimestamp(failure.updated_at)}`,
+								typeof failure.attempt_count === "number" && Number.isFinite(failure.attempt_count)
+									? `Attempts ${failure.attempt_count}`
+									: "",
+							]
+								.filter(Boolean)
+								.join(" · ")}
+						</div>
+						{typeof failure.impact === "string" && failure.impact.trim() ? (
+							<div className="status-issue-impact">{failure.impact.trim()}</div>
+						) : null}
+					</div>
+				</>
+			) : null}
+		</div>
+	);
 }
 
 function Field({
-  children,
-  className = 'field',
-  hidden = false,
-  id,
+	children,
+	className = "field",
+	hidden = false,
+	id,
 }: {
-  children: ComponentChildren;
-  className?: string;
-  hidden?: boolean;
-  id?: string;
+	children: ComponentChildren;
+	className?: string;
+	hidden?: boolean;
+	id?: string;
 }) {
-  return (
-    <div className={className} hidden={hidden} id={id}>
-      {children}
-    </div>
-  );
+	return (
+		<div className={className} hidden={hidden} id={id}>
+			{children}
+		</div>
+	);
 }
 
 function SettingsDialogContent() {
-  const values = settingsRenderState.values;
-  const observerMaxCharsDefault = state.configDefaults?.observer_max_chars || '';
-  const showAuthFile = values.observerAuthSource === 'file';
-  const showAuthCommand = values.observerAuthSource === 'command';
-  const showTieredRouting = values.observerTierRoutingEnabled;
+	const values = settingsRenderState.values;
+	const observerMaxCharsDefault = state.configDefaults?.observer_max_chars || "";
+	const showAuthFile = values.observerAuthSource === "file";
+	const showAuthCommand = values.observerAuthSource === "command";
+	const showTieredRouting = values.observerTierRoutingEnabled;
 
-  return (
-    <div className="modal-card">
-      <div className="modal-header">
-        <h2 id="settingsTitle">Memory & model settings</h2>
-        <button
-          aria-label="Close settings"
-          className="modal-close"
-          id="settingsClose"
-          onClick={() => {
-            if (settingsStartPolling && settingsRefresh) {
-              closeSettings(settingsStartPolling, settingsRefresh);
-            }
-          }}
-          type="button"
-        >
-          close
-        </button>
-      </div>
-      <div className="modal-body">
-        <div className="small" id="settingsDescription">
-          Configure connection, authentication, processing, and sync behavior.
-        </div>
-        <div aria-label="Settings sections" className="settings-tabs" role="tablist">
-          <button
-            aria-selected={settingsActiveTab === 'observer' ? 'true' : 'false'}
-            className={tabButtonClass('observer')}
-            data-settings-tab="observer"
-            id="settingsTabObserver"
-            onClick={() => setSettingsTab('observer')}
-            role="tab"
-            type="button"
-          >
-            Connection
-          </button>
-          <button
-            aria-selected={settingsActiveTab === 'queue' ? 'true' : 'false'}
-            className={tabButtonClass('queue')}
-            data-settings-tab="queue"
-            id="settingsTabQueue"
-            onClick={() => setSettingsTab('queue')}
-            role="tab"
-            type="button"
-          >
-            Processing
-          </button>
-          <button
-            aria-selected={settingsActiveTab === 'sync' ? 'true' : 'false'}
-            className={tabButtonClass('sync')}
-            data-settings-tab="sync"
-            id="settingsTabSync"
-            onClick={() => setSettingsTab('sync')}
-            role="tab"
-            type="button"
-          >
-            Device Sync
-          </button>
-        </div>
-        <div className="settings-advanced-toolbar field-checkbox">
-          <input
-            checked={settingsShowAdvanced}
-            className="cm-checkbox"
-            id="settingsAdvancedToggle"
-            onChange={onAdvancedToggle}
-            type="checkbox"
-          />
-          <label htmlFor="settingsAdvancedToggle">Show advanced controls</label>
-          <button
-            aria-label="About advanced controls"
-            className="help-icon"
-            data-tooltip="Advanced controls include JSON fields, tuning values, and network overrides."
-            type="button"
-          >
-            ?
-          </button>
-        </div>
+	return (
+		<div className="modal-card">
+			<div className="modal-header">
+				<h2 id="settingsTitle">Memory & model settings</h2>
+				<button
+					aria-label="Close settings"
+					className="modal-close"
+					id="settingsClose"
+					onClick={() => {
+						if (settingsStartPolling && settingsRefresh) {
+							closeSettings(settingsStartPolling, settingsRefresh);
+						}
+					}}
+					type="button"
+				>
+					close
+				</button>
+			</div>
+			<div className="modal-body">
+				<div className="small" id="settingsDescription">
+					Configure connection, authentication, processing, and sync behavior.
+				</div>
+				<div aria-label="Settings sections" className="settings-tabs" role="tablist">
+					<button
+						aria-selected={settingsActiveTab === "observer" ? "true" : "false"}
+						className={tabButtonClass("observer")}
+						data-settings-tab="observer"
+						id="settingsTabObserver"
+						onClick={() => setSettingsTab("observer")}
+						role="tab"
+						type="button"
+					>
+						Connection
+					</button>
+					<button
+						aria-selected={settingsActiveTab === "queue" ? "true" : "false"}
+						className={tabButtonClass("queue")}
+						data-settings-tab="queue"
+						id="settingsTabQueue"
+						onClick={() => setSettingsTab("queue")}
+						role="tab"
+						type="button"
+					>
+						Processing
+					</button>
+					<button
+						aria-selected={settingsActiveTab === "sync" ? "true" : "false"}
+						className={tabButtonClass("sync")}
+						data-settings-tab="sync"
+						id="settingsTabSync"
+						onClick={() => setSettingsTab("sync")}
+						role="tab"
+						type="button"
+					>
+						Device Sync
+					</button>
+				</div>
+				<div className="settings-advanced-toolbar field-checkbox">
+					<input
+						checked={settingsShowAdvanced}
+						className="cm-checkbox"
+						id="settingsAdvancedToggle"
+						onChange={onAdvancedToggle}
+						type="checkbox"
+					/>
+					<label htmlFor="settingsAdvancedToggle">Show advanced controls</label>
+					<button
+						aria-label="About advanced controls"
+						className="help-icon"
+						data-tooltip="Advanced controls include JSON fields, tuning values, and network overrides."
+						type="button"
+					>
+						?
+					</button>
+				</div>
 
-        <div className={panelClass('observer')} data-settings-panel="observer" hidden={settingsActiveTab !== 'observer'} id="settingsPanelObserver">
-          <ObserverStatusBanner />
-          <div className="settings-group">
-            <h3 className="settings-group-title">Connection</h3>
-            <Field>
-              <div className="field-label">
-                <label htmlFor="observerProvider">Model provider</label>
-                <button aria-label="About model provider" className="help-icon" data-tooltip="Choose where model requests are sent. Use auto for recommended defaults." type="button">?</button>
-              </div>
-              <select id="observerProvider" onChange={onSelectInput('observerProvider')} value={values.observerProvider}>
-                <option value="">auto (default)</option>
-                {Array.from(new Set(settingsRenderState.providers.concat(values.observerProvider ? [values.observerProvider] : [])))
-                  .sort((left, right) => left.localeCompare(right))
-                  .map((provider) => (
-                    <option key={provider} value={provider}>
-                      {provider}
-                    </option>
-                  ))}
-              </select>
-              <div className="small">`auto` uses recommended defaults for the selected connection mode.</div>
-            </Field>
-            <Field>
-              <div className="field-label">
-                <label htmlFor="observerModel">{getObserverModelLabel()}</label>
-                <button aria-label="About model defaults" className="help-icon" data-tooltip={getObserverModelTooltip()} type="button">?</button>
-              </div>
-              <input id="observerModel" onInput={onTextInput('observerModel')} placeholder="leave empty for default" value={values.observerModel} />
-              <div className="small">{getObserverModelDescription()}</div>
-              <div className="small" id="observerModelHint">{getObserverModelHint()}</div>
-            </Field>
-            <Field>
-              <div className="field-label">
-                <label htmlFor="observerRuntime">Connection mode</label>
-                <button aria-label="About connection mode" className="help-icon" data-tooltip="Direct API uses provider credentials. Local Claude session uses local Claude runtime auth." type="button">?</button>
-              </div>
-              <select id="observerRuntime" onChange={onSelectInput('observerRuntime')} value={values.observerRuntime}>
-                <option value="api_http">Direct API (default)</option>
-                <option value="claude_sidecar">Local Claude session</option>
-              </select>
-              <div className="small">Switch between provider API credentials and local Claude session auth.</div>
-            </Field>
-            <Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-              <label htmlFor="claudeCommand">Claude command (JSON argv)</label>
-              <textarea disabled id="claudeCommand" placeholder='["claude"]' rows={2} value={values.claudeCommand} />
-              <div className="small">{protectedConfigHelp('claude_command')}</div>
-            </Field>
-            <Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-              <label htmlFor="observerMaxChars">Request size limit (chars)</label>
-              <input id="observerMaxChars" min="1" onInput={onTextInput('observerMaxChars')} type="number" value={values.observerMaxChars} />
-              <div className="small" id="observerMaxCharsHint">{observerMaxCharsDefault ? `Default: ${observerMaxCharsDefault}` : ''}</div>
-            </Field>
-          </div>
+				<div
+					className={panelClass("observer")}
+					data-settings-panel="observer"
+					hidden={settingsActiveTab !== "observer"}
+					id="settingsPanelObserver"
+				>
+					<ObserverStatusBanner />
+					<div className="settings-group">
+						<h3 className="settings-group-title">Connection</h3>
+						<Field>
+							<div className="field-label">
+								<label htmlFor="observerProvider">Model provider</label>
+								<button
+									aria-label="About model provider"
+									className="help-icon"
+									data-tooltip="Choose where model requests are sent. Use auto for recommended defaults."
+									type="button"
+								>
+									?
+								</button>
+							</div>
+							<select
+								id="observerProvider"
+								onChange={onSelectInput("observerProvider")}
+								value={values.observerProvider}
+							>
+								<option value="">auto (default)</option>
+								{Array.from(
+									new Set(
+										settingsRenderState.providers.concat(
+											values.observerProvider ? [values.observerProvider] : [],
+										),
+									),
+								)
+									.sort((left, right) => left.localeCompare(right))
+									.map((provider) => (
+										<option key={provider} value={provider}>
+											{provider}
+										</option>
+									))}
+							</select>
+							<div className="small">
+								`auto` uses recommended defaults for the selected connection mode.
+							</div>
+						</Field>
+						<Field>
+							<div className="field-label">
+								<label htmlFor="observerModel">{getObserverModelLabel()}</label>
+								<button
+									aria-label="About model defaults"
+									className="help-icon"
+									data-tooltip={getObserverModelTooltip()}
+									type="button"
+								>
+									?
+								</button>
+							</div>
+							<input
+								id="observerModel"
+								onInput={onTextInput("observerModel")}
+								placeholder="leave empty for default"
+								value={values.observerModel}
+							/>
+							<div className="small">{getObserverModelDescription()}</div>
+							<div className="small" id="observerModelHint">
+								{getObserverModelHint()}
+							</div>
+						</Field>
+						<Field>
+							<div className="field-label">
+								<label htmlFor="observerRuntime">Connection mode</label>
+								<button
+									aria-label="About connection mode"
+									className="help-icon"
+									data-tooltip="Direct API uses provider credentials. Local Claude session uses local Claude runtime auth."
+									type="button"
+								>
+									?
+								</button>
+							</div>
+							<select
+								id="observerRuntime"
+								onChange={onSelectInput("observerRuntime")}
+								value={values.observerRuntime}
+							>
+								<option value="api_http">Direct API (default)</option>
+								<option value="claude_sidecar">Local Claude session</option>
+							</select>
+							<div className="small">
+								Switch between provider API credentials and local Claude session auth.
+							</div>
+						</Field>
+						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="claudeCommand">Claude command (JSON argv)</label>
+							<textarea
+								disabled
+								id="claudeCommand"
+								placeholder='["claude"]'
+								rows={2}
+								value={values.claudeCommand}
+							/>
+							<div className="small">{protectedConfigHelp("claude_command")}</div>
+						</Field>
+						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="observerMaxChars">Request size limit (chars)</label>
+							<input
+								id="observerMaxChars"
+								min="1"
+								onInput={onTextInput("observerMaxChars")}
+								type="number"
+								value={values.observerMaxChars}
+							/>
+							<div className="small" id="observerMaxCharsHint">
+								{observerMaxCharsDefault ? `Default: ${observerMaxCharsDefault}` : ""}
+							</div>
+						</Field>
+					</div>
 
-          <div className="settings-group">
-            <h3 className="settings-group-title">Authentication</h3>
-            <Field>
-              <div className="field-label">
-                <label htmlFor="observerAuthSource">Authentication method</label>
-                <button aria-label="About authentication method" className="help-icon" data-tooltip="Choose how credentials are resolved: environment, file, command, or none." type="button">?</button>
-              </div>
-              <select id="observerAuthSource" onChange={onSelectInput('observerAuthSource')} value={values.observerAuthSource}>
-                <option value="auto">auto (default)</option>
-                <option value="env">env</option>
-                <option value="file">file</option>
-                <option value="command">command</option>
-                <option value="none">none</option>
-              </select>
-              <div className="small">Use `auto` unless you need a specific token source.</div>
-            </Field>
-            <Field hidden={!showAuthFile} id="observerAuthFileField">
-              <label htmlFor="observerAuthFile">Token file path</label>
-              <input disabled id="observerAuthFile" placeholder="~/.codemem/work-token.txt" value={values.observerAuthFile} />
-              <div className="small">{protectedConfigHelp('observer_auth_file')}</div>
-            </Field>
-            <Field hidden={!showAuthCommand} id="observerAuthCommandField">
-              <div className="field-label">
-                <label htmlFor="observerAuthCommand">Token command</label>
-                <button aria-label="About token command" className="help-icon" data-tooltip="Runs this command and uses stdout as the token. JSON argv only, no shell parsing." type="button">?</button>
-              </div>
-              <textarea disabled id="observerAuthCommand" placeholder='["iap-auth", "--audience", "gateway"]' rows={3} value={values.observerAuthCommand} />
-              <div className="small">{protectedConfigHelp('observer_auth_command')}</div>
-            </Field>
-            <div className="small" hidden={!showAuthCommand} id="observerAuthCommandNote">
-              Command format: JSON string array, e.g. `["iap-auth", "--audience", "gateway"]`.
-            </div>
-            <Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-              <label htmlFor="observerAuthTimeoutMs">Token command timeout (ms)</label>
-              <input id="observerAuthTimeoutMs" min="1" onInput={onTextInput('observerAuthTimeoutMs')} type="number" value={values.observerAuthTimeoutMs} />
-            </Field>
-            <Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-              <label htmlFor="observerAuthCacheTtlS">Token cache time (s)</label>
-              <input id="observerAuthCacheTtlS" min="0" onInput={onTextInput('observerAuthCacheTtlS')} type="number" value={values.observerAuthCacheTtlS} />
-            </Field>
-            <Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-              <div className="field-label">
-                <label htmlFor="observerHeaders">Request headers (JSON)</label>
-                <button aria-label="About request headers" className="help-icon" data-tooltip={'Optional extra headers. Supports templates like ${auth.token}, ${auth.type}, ${auth.source}.'} type="button">?</button>
-              </div>
-              <textarea disabled id="observerHeaders" placeholder='{"Authorization":"Bearer ${auth.token}"}' rows={4} value={values.observerHeaders} />
-              <div className="small">{protectedConfigHelp('observer_headers')}</div>
-            </Field>
-          </div>
-        </div>
+					<div className="settings-group">
+						<h3 className="settings-group-title">Authentication</h3>
+						<Field>
+							<div className="field-label">
+								<label htmlFor="observerAuthSource">Authentication method</label>
+								<button
+									aria-label="About authentication method"
+									className="help-icon"
+									data-tooltip="Choose how credentials are resolved: environment, file, command, or none."
+									type="button"
+								>
+									?
+								</button>
+							</div>
+							<select
+								id="observerAuthSource"
+								onChange={onSelectInput("observerAuthSource")}
+								value={values.observerAuthSource}
+							>
+								<option value="auto">auto (default)</option>
+								<option value="env">env</option>
+								<option value="file">file</option>
+								<option value="command">command</option>
+								<option value="none">none</option>
+							</select>
+							<div className="small">Use `auto` unless you need a specific token source.</div>
+						</Field>
+						<Field hidden={!showAuthFile} id="observerAuthFileField">
+							<label htmlFor="observerAuthFile">Token file path</label>
+							<input
+								disabled
+								id="observerAuthFile"
+								placeholder="~/.codemem/work-token.txt"
+								value={values.observerAuthFile}
+							/>
+							<div className="small">{protectedConfigHelp("observer_auth_file")}</div>
+						</Field>
+						<Field hidden={!showAuthCommand} id="observerAuthCommandField">
+							<div className="field-label">
+								<label htmlFor="observerAuthCommand">Token command</label>
+								<button
+									aria-label="About token command"
+									className="help-icon"
+									data-tooltip="Runs this command and uses stdout as the token. JSON argv only, no shell parsing."
+									type="button"
+								>
+									?
+								</button>
+							</div>
+							<textarea
+								disabled
+								id="observerAuthCommand"
+								placeholder='["iap-auth", "--audience", "gateway"]'
+								rows={3}
+								value={values.observerAuthCommand}
+							/>
+							<div className="small">{protectedConfigHelp("observer_auth_command")}</div>
+						</Field>
+						<div className="small" hidden={!showAuthCommand} id="observerAuthCommandNote">
+							Command format: JSON string array, e.g. `["iap-auth", "--audience", "gateway"]`.
+						</div>
+						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="observerAuthTimeoutMs">Token command timeout (ms)</label>
+							<input
+								id="observerAuthTimeoutMs"
+								min="1"
+								onInput={onTextInput("observerAuthTimeoutMs")}
+								type="number"
+								value={values.observerAuthTimeoutMs}
+							/>
+						</Field>
+						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="observerAuthCacheTtlS">Token cache time (s)</label>
+							<input
+								id="observerAuthCacheTtlS"
+								min="0"
+								onInput={onTextInput("observerAuthCacheTtlS")}
+								type="number"
+								value={values.observerAuthCacheTtlS}
+							/>
+						</Field>
+						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<div className="field-label">
+								<label htmlFor="observerHeaders">Request headers (JSON)</label>
+								<button
+									aria-label="About request headers"
+									className="help-icon"
+									data-tooltip={
+										// biome-ignore lint/suspicious/noTemplateCurlyInString: literal documentation text describing the template placeholder syntax users can use in header values
+										"Optional extra headers. Supports templates like ${auth.token}, ${auth.type}, ${auth.source}."
+									}
+									type="button"
+								>
+									?
+								</button>
+							</div>
+							<textarea
+								disabled
+								id="observerHeaders"
+								placeholder='{"Authorization":"Bearer ${auth.token}"}'
+								rows={4}
+								value={values.observerHeaders}
+							/>
+							<div className="small">{protectedConfigHelp("observer_headers")}</div>
+						</Field>
+					</div>
+				</div>
 
-        <div className={panelClass('queue')} data-settings-panel="queue" hidden={settingsActiveTab !== 'queue'} id="settingsPanelQueue">
-          <div className="settings-group">
-            <h3 className="settings-group-title">Processing</h3>
-            <Field>
-              <div className="field-label">
-                <label htmlFor="rawEventsSweeperIntervalS">Background processing interval (seconds)</label>
-                <button aria-label="About background processing interval" className="help-icon" data-tooltip="How often codemem checks for queued events to process in the background." type="button">?</button>
-              </div>
-              <input id="rawEventsSweeperIntervalS" min="1" onInput={onTextInput('rawEventsSweeperIntervalS')} type="number" value={values.rawEventsSweeperIntervalS} />
-              <div className="small">How often background flush checks pending raw events.</div>
-            </Field>
-          </div>
-          <div className="settings-group">
-            <h3 className="settings-group-title">Tiered observer routing</h3>
-            <div className="field field-checkbox">
-              <input checked={values.observerTierRoutingEnabled} className="cm-checkbox" id="observerTierRoutingEnabled" onChange={onCheckboxInput('observerTierRoutingEnabled')} type="checkbox" />
-              <label htmlFor="observerTierRoutingEnabled">Enable tiered routing</label>
-            </div>
-            <div className="small">{getTieredRoutingHelperText()}</div>
-            <Field hidden={!showTieredRouting}>
-              <div className="field-label">
-                <label htmlFor="observerSimpleModel">Simple tier model</label>
-                <button aria-label="About simple tier model" className="help-icon" data-tooltip="Used for lighter replay batches. Leave blank to keep codemem's routing defaults or base observer fallback." type="button">?</button>
-              </div>
-              <input id="observerSimpleModel" onInput={onTextInput('observerSimpleModel')} placeholder="leave empty for default" value={values.observerSimpleModel} />
-              <div className="small">Used when a batch falls below rich-routing thresholds.</div>
-            </Field>
-            <Field hidden={!showTieredRouting}>
-              <div className="field-label">
-                <label htmlFor="observerRichModel">Rich tier model</label>
-                <button aria-label="About rich tier model" className="help-icon" data-tooltip="Used for larger or more complex replay batches. Leave blank to keep codemem's rich-tier defaults." type="button">?</button>
-              </div>
-              <input id="observerRichModel" onInput={onTextInput('observerRichModel')} placeholder="leave empty for default" value={values.observerRichModel} />
-              <div className="small">Used when routing detects a richer replay batch.</div>
-            </Field>
-            <Field className="field field-checkbox" hidden={!showTieredRouting}>
-              <input checked={values.observerRichOpenAIUseResponses} className="cm-checkbox" id="observerRichOpenAIUseResponses" onChange={onCheckboxInput('observerRichOpenAIUseResponses')} type="checkbox" />
-              <label htmlFor="observerRichOpenAIUseResponses">Use OpenAI Responses API for rich tier</label>
-            </Field>
-            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
-              <label htmlFor="observerSimpleTemperature">Simple tier temperature</label>
-              <input id="observerSimpleTemperature" min="0" onInput={onTextInput('observerSimpleTemperature')} step="0.1" type="number" value={values.observerSimpleTemperature} />
-            </Field>
-            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
-              <label htmlFor="observerRichTemperature">Rich tier temperature</label>
-              <input id="observerRichTemperature" min="0" onInput={onTextInput('observerRichTemperature')} step="0.1" type="number" value={values.observerRichTemperature} />
-            </Field>
-            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
-              <label htmlFor="observerRichReasoningEffort">Rich tier reasoning effort</label>
-              <input id="observerRichReasoningEffort" onInput={onTextInput('observerRichReasoningEffort')} placeholder="leave empty for default" value={values.observerRichReasoningEffort} />
-            </Field>
-            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
-              <label htmlFor="observerRichReasoningSummary">Rich tier reasoning summary</label>
-              <input id="observerRichReasoningSummary" onInput={onTextInput('observerRichReasoningSummary')} placeholder="leave empty for default" value={values.observerRichReasoningSummary} />
-            </Field>
-            <Field className="field settings-advanced" hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
-              <label htmlFor="observerRichMaxOutputTokens">Rich tier max output tokens</label>
-              <input id="observerRichMaxOutputTokens" min="1" onInput={onTextInput('observerRichMaxOutputTokens')} step="1" type="number" value={values.observerRichMaxOutputTokens} />
-            </Field>
-          </div>
-          <div className="settings-group settings-advanced" hidden={hiddenUnlessAdvanced()}>
-            <h3 className="settings-group-title">Context Pack Limits</h3>
-            <Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-              <label htmlFor="packObservationLimit">Observation limit</label>
-              <input id="packObservationLimit" min="1" onInput={onTextInput('packObservationLimit')} type="number" value={values.packObservationLimit} />
-              <div className="small">Default number of observations to include in a pack.</div>
-            </Field>
-            <Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-              <label htmlFor="packSessionLimit">Session summary limit</label>
-              <input id="packSessionLimit" min="1" onInput={onTextInput('packSessionLimit')} type="number" value={values.packSessionLimit} />
-              <div className="small">Default number of session summaries to include in a pack.</div>
-            </Field>
-          </div>
-        </div>
+				<div
+					className={panelClass("queue")}
+					data-settings-panel="queue"
+					hidden={settingsActiveTab !== "queue"}
+					id="settingsPanelQueue"
+				>
+					<div className="settings-group">
+						<h3 className="settings-group-title">Processing</h3>
+						<Field>
+							<div className="field-label">
+								<label htmlFor="rawEventsSweeperIntervalS">
+									Background processing interval (seconds)
+								</label>
+								<button
+									aria-label="About background processing interval"
+									className="help-icon"
+									data-tooltip="How often codemem checks for queued events to process in the background."
+									type="button"
+								>
+									?
+								</button>
+							</div>
+							<input
+								id="rawEventsSweeperIntervalS"
+								min="1"
+								onInput={onTextInput("rawEventsSweeperIntervalS")}
+								type="number"
+								value={values.rawEventsSweeperIntervalS}
+							/>
+							<div className="small">How often background flush checks pending raw events.</div>
+						</Field>
+					</div>
+					<div className="settings-group">
+						<h3 className="settings-group-title">Tiered observer routing</h3>
+						<div className="field field-checkbox">
+							<input
+								checked={values.observerTierRoutingEnabled}
+								className="cm-checkbox"
+								id="observerTierRoutingEnabled"
+								onChange={onCheckboxInput("observerTierRoutingEnabled")}
+								type="checkbox"
+							/>
+							<label htmlFor="observerTierRoutingEnabled">Enable tiered routing</label>
+						</div>
+						<div className="small">{getTieredRoutingHelperText()}</div>
+						<Field hidden={!showTieredRouting}>
+							<div className="field-label">
+								<label htmlFor="observerSimpleModel">Simple tier model</label>
+								<button
+									aria-label="About simple tier model"
+									className="help-icon"
+									data-tooltip="Used for lighter replay batches. Leave blank to keep codemem's routing defaults or base observer fallback."
+									type="button"
+								>
+									?
+								</button>
+							</div>
+							<input
+								id="observerSimpleModel"
+								onInput={onTextInput("observerSimpleModel")}
+								placeholder="leave empty for default"
+								value={values.observerSimpleModel}
+							/>
+							<div className="small">Used when a batch falls below rich-routing thresholds.</div>
+						</Field>
+						<Field hidden={!showTieredRouting}>
+							<div className="field-label">
+								<label htmlFor="observerRichModel">Rich tier model</label>
+								<button
+									aria-label="About rich tier model"
+									className="help-icon"
+									data-tooltip="Used for larger or more complex replay batches. Leave blank to keep codemem's rich-tier defaults."
+									type="button"
+								>
+									?
+								</button>
+							</div>
+							<input
+								id="observerRichModel"
+								onInput={onTextInput("observerRichModel")}
+								placeholder="leave empty for default"
+								value={values.observerRichModel}
+							/>
+							<div className="small">Used when routing detects a richer replay batch.</div>
+						</Field>
+						<Field className="field field-checkbox" hidden={!showTieredRouting}>
+							<input
+								checked={values.observerRichOpenAIUseResponses}
+								className="cm-checkbox"
+								id="observerRichOpenAIUseResponses"
+								onChange={onCheckboxInput("observerRichOpenAIUseResponses")}
+								type="checkbox"
+							/>
+							<label htmlFor="observerRichOpenAIUseResponses">
+								Use OpenAI Responses API for rich tier
+							</label>
+						</Field>
+						<Field
+							className="field settings-advanced"
+							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+						>
+							<label htmlFor="observerSimpleTemperature">Simple tier temperature</label>
+							<input
+								id="observerSimpleTemperature"
+								min="0"
+								onInput={onTextInput("observerSimpleTemperature")}
+								step="0.1"
+								type="number"
+								value={values.observerSimpleTemperature}
+							/>
+						</Field>
+						<Field
+							className="field settings-advanced"
+							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+						>
+							<label htmlFor="observerRichTemperature">Rich tier temperature</label>
+							<input
+								id="observerRichTemperature"
+								min="0"
+								onInput={onTextInput("observerRichTemperature")}
+								step="0.1"
+								type="number"
+								value={values.observerRichTemperature}
+							/>
+						</Field>
+						<Field
+							className="field settings-advanced"
+							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+						>
+							<label htmlFor="observerRichReasoningEffort">Rich tier reasoning effort</label>
+							<input
+								id="observerRichReasoningEffort"
+								onInput={onTextInput("observerRichReasoningEffort")}
+								placeholder="leave empty for default"
+								value={values.observerRichReasoningEffort}
+							/>
+						</Field>
+						<Field
+							className="field settings-advanced"
+							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+						>
+							<label htmlFor="observerRichReasoningSummary">Rich tier reasoning summary</label>
+							<input
+								id="observerRichReasoningSummary"
+								onInput={onTextInput("observerRichReasoningSummary")}
+								placeholder="leave empty for default"
+								value={values.observerRichReasoningSummary}
+							/>
+						</Field>
+						<Field
+							className="field settings-advanced"
+							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+						>
+							<label htmlFor="observerRichMaxOutputTokens">Rich tier max output tokens</label>
+							<input
+								id="observerRichMaxOutputTokens"
+								min="1"
+								onInput={onTextInput("observerRichMaxOutputTokens")}
+								step="1"
+								type="number"
+								value={values.observerRichMaxOutputTokens}
+							/>
+						</Field>
+					</div>
+					<div className="settings-group settings-advanced" hidden={hiddenUnlessAdvanced()}>
+						<h3 className="settings-group-title">Context Pack Limits</h3>
+						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="packObservationLimit">Observation limit</label>
+							<input
+								id="packObservationLimit"
+								min="1"
+								onInput={onTextInput("packObservationLimit")}
+								type="number"
+								value={values.packObservationLimit}
+							/>
+							<div className="small">Default number of observations to include in a pack.</div>
+						</Field>
+						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="packSessionLimit">Session summary limit</label>
+							<input
+								id="packSessionLimit"
+								min="1"
+								onInput={onTextInput("packSessionLimit")}
+								type="number"
+								value={values.packSessionLimit}
+							/>
+							<div className="small">Default number of session summaries to include in a pack.</div>
+						</Field>
+					</div>
+				</div>
 
-        <div className={panelClass('sync')} data-settings-panel="sync" hidden={settingsActiveTab !== 'sync'} id="settingsPanelSync">
-          <div className="settings-group">
-            <h3 className="settings-group-title">Device Sync</h3>
-            <div className="field field-checkbox"><input checked={values.syncEnabled} className="cm-checkbox" id="syncEnabled" onChange={onCheckboxInput('syncEnabled')} type="checkbox" /><label htmlFor="syncEnabled">Enable sync</label></div>
-            <div className="field"><label htmlFor="syncInterval">Sync interval (seconds)</label><input id="syncInterval" min="10" onInput={onTextInput('syncInterval')} type="number" value={values.syncInterval} /></div>
-            <div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}><label htmlFor="syncHost">Sync host</label><input id="syncHost" onInput={onTextInput('syncHost')} placeholder="127.0.0.1" value={values.syncHost} /></div>
-            <div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}><label htmlFor="syncPort">Sync port</label><input id="syncPort" min="1" onInput={onTextInput('syncPort')} type="number" value={values.syncPort} /></div>
-            <div className="field field-checkbox settings-advanced" hidden={hiddenUnlessAdvanced()}><input checked={values.syncMdns} className="cm-checkbox" id="syncMdns" onChange={onCheckboxInput('syncMdns')} type="checkbox" /><label htmlFor="syncMdns">Enable mDNS discovery</label></div>
-            <div className="field">
-              <label htmlFor="syncCoordinatorUrl">Coordinator URL</label>
-              <input disabled id="syncCoordinatorUrl" placeholder="https://coord.example.com" value={values.syncCoordinatorUrl} />
-              <div className="small">{protectedConfigHelp('sync_coordinator_url')}</div>
-            </div>
-            <div className="field">
-              <label htmlFor="syncCoordinatorGroup">Coordinator group</label>
-              <input id="syncCoordinatorGroup" onInput={onTextInput('syncCoordinatorGroup')} placeholder="nerdworld" value={values.syncCoordinatorGroup} />
-              <div className="small">Discovery namespace for peers using the same coordinator.</div>
-            </div>
-            <div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-              <label htmlFor="syncCoordinatorTimeout">Coordinator timeout (seconds)</label>
-              <input id="syncCoordinatorTimeout" min="1" onInput={onTextInput('syncCoordinatorTimeout')} type="number" value={values.syncCoordinatorTimeout} />
-            </div>
-            <div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-              <label htmlFor="syncCoordinatorPresenceTtl">Presence TTL (seconds)</label>
-              <input id="syncCoordinatorPresenceTtl" min="1" onInput={onTextInput('syncCoordinatorPresenceTtl')} type="number" value={values.syncCoordinatorPresenceTtl} />
-            </div>
-          </div>
-        </div>
+				<div
+					className={panelClass("sync")}
+					data-settings-panel="sync"
+					hidden={settingsActiveTab !== "sync"}
+					id="settingsPanelSync"
+				>
+					<div className="settings-group">
+						<h3 className="settings-group-title">Device Sync</h3>
+						<div className="field field-checkbox">
+							<input
+								checked={values.syncEnabled}
+								className="cm-checkbox"
+								id="syncEnabled"
+								onChange={onCheckboxInput("syncEnabled")}
+								type="checkbox"
+							/>
+							<label htmlFor="syncEnabled">Enable sync</label>
+						</div>
+						<div className="field">
+							<label htmlFor="syncInterval">Sync interval (seconds)</label>
+							<input
+								id="syncInterval"
+								min="10"
+								onInput={onTextInput("syncInterval")}
+								type="number"
+								value={values.syncInterval}
+							/>
+						</div>
+						<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="syncHost">Sync host</label>
+							<input
+								id="syncHost"
+								onInput={onTextInput("syncHost")}
+								placeholder="127.0.0.1"
+								value={values.syncHost}
+							/>
+						</div>
+						<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="syncPort">Sync port</label>
+							<input
+								id="syncPort"
+								min="1"
+								onInput={onTextInput("syncPort")}
+								type="number"
+								value={values.syncPort}
+							/>
+						</div>
+						<div className="field field-checkbox settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<input
+								checked={values.syncMdns}
+								className="cm-checkbox"
+								id="syncMdns"
+								onChange={onCheckboxInput("syncMdns")}
+								type="checkbox"
+							/>
+							<label htmlFor="syncMdns">Enable mDNS discovery</label>
+						</div>
+						<div className="field">
+							<label htmlFor="syncCoordinatorUrl">Coordinator URL</label>
+							<input
+								disabled
+								id="syncCoordinatorUrl"
+								placeholder="https://coord.example.com"
+								value={values.syncCoordinatorUrl}
+							/>
+							<div className="small">{protectedConfigHelp("sync_coordinator_url")}</div>
+						</div>
+						<div className="field">
+							<label htmlFor="syncCoordinatorGroup">Coordinator group</label>
+							<input
+								id="syncCoordinatorGroup"
+								onInput={onTextInput("syncCoordinatorGroup")}
+								placeholder="nerdworld"
+								value={values.syncCoordinatorGroup}
+							/>
+							<div className="small">Discovery namespace for peers using the same coordinator.</div>
+						</div>
+						<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="syncCoordinatorTimeout">Coordinator timeout (seconds)</label>
+							<input
+								id="syncCoordinatorTimeout"
+								min="1"
+								onInput={onTextInput("syncCoordinatorTimeout")}
+								type="number"
+								value={values.syncCoordinatorTimeout}
+							/>
+						</div>
+						<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<label htmlFor="syncCoordinatorPresenceTtl">Presence TTL (seconds)</label>
+							<input
+								id="syncCoordinatorPresenceTtl"
+								min="1"
+								onInput={onTextInput("syncCoordinatorPresenceTtl")}
+								type="number"
+								value={values.syncCoordinatorPresenceTtl}
+							/>
+						</div>
+					</div>
+				</div>
 
-        <div className="small mono" id="settingsPath">{settingsRenderState.pathText}</div>
-        <div className="small" id="settingsEffective">{settingsRenderState.effectiveText}</div>
-        <div className="settings-note" hidden={!settingsRenderState.overridesVisible} id="settingsOverrides">
-          Some values are controlled outside this screen and take priority.
-        </div>
-      </div>
-      <div className="modal-footer">
-        <div className="small" id="settingsStatus">{settingsRenderState.statusText}</div>
-        <button
-          className="settings-save"
-          disabled={!state.settingsDirty || settingsRenderState.isSaving}
-          id="settingsSave"
-          onClick={() => {
-            if (settingsStartPolling && settingsRefresh) {
-              void saveSettings(settingsStartPolling, settingsRefresh);
-            }
-          }}
-          type="button"
-        >
-          Save
-        </button>
-      </div>
-    </div>
-  );
+				<div className="small mono" id="settingsPath">
+					{settingsRenderState.pathText}
+				</div>
+				<div className="small" id="settingsEffective">
+					{settingsRenderState.effectiveText}
+				</div>
+				<div
+					className="settings-note"
+					hidden={!settingsRenderState.overridesVisible}
+					id="settingsOverrides"
+				>
+					Some values are controlled outside this screen and take priority.
+				</div>
+			</div>
+			<div className="modal-footer">
+				<div className="small" id="settingsStatus">
+					{settingsRenderState.statusText}
+				</div>
+				<button
+					className="settings-save"
+					disabled={!state.settingsDirty || settingsRenderState.isSaving}
+					id="settingsSave"
+					onClick={() => {
+						if (settingsStartPolling && settingsRefresh) {
+							void saveSettings(settingsStartPolling, settingsRefresh);
+						}
+					}}
+					type="button"
+				>
+					Save
+				</button>
+			</div>
+		</div>
+	);
 }
 
-export function initSettings(stopPolling: () => void, startPolling: () => void, refreshCallback: () => void) {
-  settingsStartPolling = startPolling;
-  settingsRefresh = refreshCallback;
-  ensureSettingsShell();
+export function initSettings(
+	stopPolling: () => void,
+	startPolling: () => void,
+	refreshCallback: () => void,
+) {
+	settingsStartPolling = startPolling;
+	settingsRefresh = refreshCallback;
+	ensureSettingsShell();
 
-  const settingsButton = $button('settingsButton');
-  settingsButton?.addEventListener('click', () => openSettings(stopPolling));
+	const settingsButton = $button("settingsButton");
+	settingsButton?.addEventListener("click", () => openSettings(stopPolling));
 }

--- a/packages/ui/src/tabs/sync/components/render-root.tsx
+++ b/packages/ui/src/tabs/sync/components/render-root.tsx
@@ -1,21 +1,21 @@
-import { render, type ComponentChildren } from 'preact';
+import { type ComponentChildren, render } from "preact";
 
 function markMount(mount: HTMLElement) {
-  mount.dataset.syncRenderRoot = 'preact';
+	mount.dataset.syncRenderRoot = "preact";
 }
 
 export function ensureSyncRenderBoundary() {
-  const syncTab = document.getElementById('tab-sync');
-  if (!syncTab) return;
-  syncTab.dataset.syncRenderBoundary = 'preact-hybrid';
+	const syncTab = document.getElementById("tab-sync");
+	if (!syncTab) return;
+	syncTab.dataset.syncRenderBoundary = "preact-hybrid";
 }
 
 export function renderIntoSyncMount(mount: HTMLElement, content: ComponentChildren) {
-  markMount(mount);
-  render(content, mount);
+	markMount(mount);
+	render(content, mount);
 }
 
 export function clearSyncMount(mount: HTMLElement) {
-  if (mount.dataset.syncRenderRoot !== 'preact') return;
-  render(null, mount);
+	if (mount.dataset.syncRenderRoot !== "preact") return;
+	render(null, mount);
 }

--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -1,221 +1,250 @@
-import type { TargetedInputEvent } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
-import { renderIntoSyncMount } from './render-root';
-import { openSyncConfirmDialog } from '../sync-dialogs';
+import type { TargetedInputEvent } from "preact";
+import { useEffect, useState } from "preact/hooks";
 import {
-  actorDisplayLabel,
-  actorLabel,
-  actorMergeNote,
-  assignedActorCount,
-  mergeTargetActors,
-} from '../helpers';
-import type { ActorLike } from '../view-model';
+	actorDisplayLabel,
+	actorLabel,
+	actorMergeNote,
+	assignedActorCount,
+	mergeTargetActors,
+} from "../helpers";
+import { openSyncConfirmDialog } from "../sync-dialogs";
+import type { ActorLike } from "../view-model";
+import { renderIntoSyncMount } from "./render-root";
 
 type SyncActorRowProps = {
-  actor: ActorLike;
-  hiddenLocalDuplicateCount: number;
-  onRename: (actorId: string, displayName: string) => Promise<void>;
-  onMerge: (primaryActorId: string, secondaryActorId: string) => Promise<void>;
-  onDeactivate: (actorId: string) => Promise<void>;
+	actor: ActorLike;
+	hiddenLocalDuplicateCount: number;
+	onRename: (actorId: string, displayName: string) => Promise<void>;
+	onMerge: (primaryActorId: string, secondaryActorId: string) => Promise<void>;
+	onDeactivate: (actorId: string) => Promise<void>;
 };
 
 type SyncActorsListProps = {
-  actors: ActorLike[];
-  hiddenLocalDuplicateCount: number;
-  onRename: (actorId: string, displayName: string) => Promise<void>;
-  onMerge: (primaryActorId: string, secondaryActorId: string) => Promise<void>;
-  onDeactivate: (actorId: string) => Promise<void>;
+	actors: ActorLike[];
+	hiddenLocalDuplicateCount: number;
+	onRename: (actorId: string, displayName: string) => Promise<void>;
+	onMerge: (primaryActorId: string, secondaryActorId: string) => Promise<void>;
+	onDeactivate: (actorId: string) => Promise<void>;
 };
 
 function localActorNote(hiddenLocalDuplicateCount: number): string {
-  if (hiddenLocalDuplicateCount <= 0) {
-    return 'Represents you across your devices.';
-  }
-  return `Represents you across your devices. ${hiddenLocalDuplicateCount} unresolved duplicate ${hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden until reviewed in Needs attention.`;
+	if (hiddenLocalDuplicateCount <= 0) {
+		return "Represents you across your devices.";
+	}
+	return `Represents you across your devices. ${hiddenLocalDuplicateCount} unresolved duplicate ${hiddenLocalDuplicateCount === 1 ? "entry is" : "entries are"} hidden until reviewed in Needs attention.`;
 }
 
-function SyncActorRow({ actor, hiddenLocalDuplicateCount, onRename, onMerge, onDeactivate }: SyncActorRowProps) {
-  const actorId = String(actor.actor_id || '');
-  const label = actorLabel(actor);
-  const count = assignedActorCount(actorId);
-  const mergeTargets = mergeTargetActors(actorId);
-  const mergeTargetKeys = mergeTargets.map((target) => String(target.actor_id || '')).join('|');
-  const [name, setName] = useState(label);
-  const [renameBusy, setRenameBusy] = useState(false);
-  const [renameLabel, setRenameLabel] = useState('Rename');
-  const [mergeBusy, setMergeBusy] = useState(false);
-  const [mergeLabel, setMergeLabel] = useState('Combine into selected person');
-  const [mergeTargetId, setMergeTargetId] = useState('');
+function SyncActorRow({
+	actor,
+	hiddenLocalDuplicateCount,
+	onRename,
+	onMerge,
+	onDeactivate,
+}: SyncActorRowProps) {
+	const actorId = String(actor.actor_id || "");
+	const label = actorLabel(actor);
+	const count = assignedActorCount(actorId);
+	const mergeTargets = mergeTargetActors(actorId);
+	const mergeTargetKeys = mergeTargets.map((target) => String(target.actor_id || "")).join("|");
+	const [name, setName] = useState(label);
+	const [renameBusy, setRenameBusy] = useState(false);
+	const [renameLabel, setRenameLabel] = useState("Rename");
+	const [mergeBusy, setMergeBusy] = useState(false);
+	const [mergeLabel, setMergeLabel] = useState("Combine into selected person");
+	const [mergeTargetId, setMergeTargetId] = useState("");
 
-  useEffect(() => {
-    setName(label);
-    setRenameBusy(false);
-    setRenameLabel('Rename');
-    setMergeBusy(false);
-    setMergeLabel('Combine into selected person');
-    setMergeTargetId('');
-  }, [actorId, count, hiddenLocalDuplicateCount, label, mergeTargetKeys]);
+	useEffect(() => {
+		setName(label);
+		setRenameBusy(false);
+		setRenameLabel("Rename");
+		setMergeBusy(false);
+		setMergeLabel("Combine into selected person");
+		setMergeTargetId("");
+	}, [actorId, count, hiddenLocalDuplicateCount, label, mergeTargetKeys]);
 
-  const mergeNote = !mergeTargets.length
-    ? 'No people available to combine yet. Create another person or use You.'
-    : actorMergeNote(mergeTargetId, actorId);
+	const mergeNote = !mergeTargets.length
+		? "No people available to combine yet. Create another person or use You."
+		: actorMergeNote(mergeTargetId, actorId);
 
-  async function rename() {
-    const nextName = name.trim();
-    if (!nextName) return;
-    setRenameBusy(true);
-    setRenameLabel('Saving…');
-    let ok = false;
-    try {
-      await onRename(actorId, nextName);
-      ok = true;
-    } catch {
-      setRenameLabel('Retry rename');
-    } finally {
-      setRenameBusy(false);
-      if (ok) setRenameLabel('Rename');
-    }
-  }
+	async function rename() {
+		const nextName = name.trim();
+		if (!nextName) return;
+		setRenameBusy(true);
+		setRenameLabel("Saving…");
+		let ok = false;
+		try {
+			await onRename(actorId, nextName);
+			ok = true;
+		} catch {
+			setRenameLabel("Retry rename");
+		} finally {
+			setRenameBusy(false);
+			if (ok) setRenameLabel("Rename");
+		}
+	}
 
-  async function merge() {
-    if (!mergeTargetId) return;
-    const target = mergeTargets.find((candidate) => String(candidate.actor_id || '') === mergeTargetId);
-    if (!target) return;
-    const confirmed = await openSyncConfirmDialog({
-      title: `Combine ${label} into ${actorLabel(target)}?`,
-      description: 'Assigned devices move now, but older memories keep their current stamped provenance for now.',
-      confirmLabel: 'Combine people',
-      cancelLabel: 'Keep separate',
-      tone: 'danger',
-    });
-    if (!confirmed) {
-      return;
-    }
-    setMergeBusy(true);
-    setMergeLabel('Merging…');
-    let ok = false;
-    try {
-      await onMerge(mergeTargetId, actorId);
-      ok = true;
-    } catch {
-      setMergeLabel('Retry merge');
-    } finally {
-      setMergeBusy(false);
-      if (ok) setMergeLabel('Combine into selected person');
-    }
-  }
+	async function merge() {
+		if (!mergeTargetId) return;
+		const target = mergeTargets.find(
+			(candidate) => String(candidate.actor_id || "") === mergeTargetId,
+		);
+		if (!target) return;
+		const confirmed = await openSyncConfirmDialog({
+			title: `Combine ${label} into ${actorLabel(target)}?`,
+			description:
+				"Assigned devices move now, but older memories keep their current stamped provenance for now.",
+			confirmLabel: "Combine people",
+			cancelLabel: "Keep separate",
+			tone: "danger",
+		});
+		if (!confirmed) {
+			return;
+		}
+		setMergeBusy(true);
+		setMergeLabel("Merging…");
+		let ok = false;
+		try {
+			await onMerge(mergeTargetId, actorId);
+			ok = true;
+		} catch {
+			setMergeLabel("Retry merge");
+		} finally {
+			setMergeBusy(false);
+			if (ok) setMergeLabel("Combine into selected person");
+		}
+	}
 
-  return (
-    <div className="actor-row">
-      <div className="actor-details">
-        <div className="actor-title">
-          <strong>{actorDisplayLabel(actor)}</strong>
-          <span
-            className={`badge actor-badge${actor.is_local ? ' local' : ''}`}
-            title={actor.is_local ? localActorNote(hiddenLocalDuplicateCount) : undefined}
-          >
-            {actor.is_local ? 'You' : `${count} device${count === 1 ? '' : 's'}`}
-          </span>
-        </div>
-        {!actor.is_local ? <div className="peer-meta">{count} assigned device{count === 1 ? '' : 's'}</div> : null}
-      </div>
+	return (
+		<div className="actor-row">
+			<div className="actor-details">
+				<div className="actor-title">
+					<strong>{actorDisplayLabel(actor)}</strong>
+					<span
+						className={`badge actor-badge${actor.is_local ? " local" : ""}`}
+						title={actor.is_local ? localActorNote(hiddenLocalDuplicateCount) : undefined}
+					>
+						{actor.is_local ? "You" : `${count} device${count === 1 ? "" : "s"}`}
+					</span>
+				</div>
+				{!actor.is_local ? (
+					<div className="peer-meta">
+						{count} assigned device{count === 1 ? "" : "s"}
+					</div>
+				) : null}
+			</div>
 
-      <div className="actor-actions">
-        {actor.is_local ? (
-          <div className="peer-meta">Rename in config</div>
-        ) : (
-          <>
-            <input
-              aria-label={`Rename ${label}`}
-              className="peer-scope-input actor-name-input"
-              disabled={renameBusy || mergeBusy}
-              value={name}
-              onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
-                setName(event.currentTarget.value)
-              }
-            />
-            <button className="settings-button" disabled={renameBusy || mergeBusy} onClick={() => void rename()}>
-              {renameLabel}
-            </button>
-            <div className="actor-merge-controls">
-              <select
-                aria-label={`Combine ${label} into another person`}
-                className="sync-actor-select actor-merge-select"
-                disabled={mergeBusy}
-                value={mergeTargetId}
-                onChange={(event) => setMergeTargetId(event.currentTarget.value)}
-              >
-                <option value="">Combine into person</option>
-                {mergeTargets.map((target) => {
-                  const targetId = String(target.actor_id || '');
-                  return (
-                    <option key={targetId} value={targetId}>
-                      {target.is_local ? actorDisplayLabel(target) : actorLabel(target)}
-                    </option>
-                  );
-                })}
-              </select>
-              <button
-                className="settings-button"
-                disabled={mergeBusy || mergeTargets.length === 0}
-                onClick={() => void merge()}
-              >
-                {mergeLabel}
-              </button>
-            </div>
-            <div className="peer-meta actor-merge-note">{mergeNote}</div>
-            <button
-              className="settings-button"
-              disabled={renameBusy || mergeBusy}
-              onClick={async () => {
-                const confirmed = await openSyncConfirmDialog({
-                  title: `Remove ${label}?`,
-                  description: 'This deactivates the person and unassigns their devices. Existing memories keep their current attribution.',
-                  confirmLabel: 'Remove person',
-                  cancelLabel: 'Keep',
-                  tone: 'danger',
-                });
-                if (confirmed) await onDeactivate(actorId);
-              }}
-            >
-              Remove person
-            </button>
-          </>
-        )}
-      </div>
-    </div>
-  );
+			<div className="actor-actions">
+				{actor.is_local ? (
+					<div className="peer-meta">Rename in config</div>
+				) : (
+					<>
+						<input
+							aria-label={`Rename ${label}`}
+							className="peer-scope-input actor-name-input"
+							disabled={renameBusy || mergeBusy}
+							value={name}
+							onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
+								setName(event.currentTarget.value)
+							}
+						/>
+						<button
+							type="button"
+							className="settings-button"
+							disabled={renameBusy || mergeBusy}
+							onClick={() => void rename()}
+						>
+							{renameLabel}
+						</button>
+						<div className="actor-merge-controls">
+							<select
+								aria-label={`Combine ${label} into another person`}
+								className="sync-actor-select actor-merge-select"
+								disabled={mergeBusy}
+								value={mergeTargetId}
+								onChange={(event) => setMergeTargetId(event.currentTarget.value)}
+							>
+								<option value="">Combine into person</option>
+								{mergeTargets.map((target) => {
+									const targetId = String(target.actor_id || "");
+									return (
+										<option key={targetId} value={targetId}>
+											{target.is_local ? actorDisplayLabel(target) : actorLabel(target)}
+										</option>
+									);
+								})}
+							</select>
+							<button
+								type="button"
+								className="settings-button"
+								disabled={mergeBusy || mergeTargets.length === 0}
+								onClick={() => void merge()}
+							>
+								{mergeLabel}
+							</button>
+						</div>
+						<div className="peer-meta actor-merge-note">{mergeNote}</div>
+						<button
+							type="button"
+							className="settings-button"
+							disabled={renameBusy || mergeBusy}
+							onClick={async () => {
+								const confirmed = await openSyncConfirmDialog({
+									title: `Remove ${label}?`,
+									description:
+										"This deactivates the person and unassigns their devices. Existing memories keep their current attribution.",
+									confirmLabel: "Remove person",
+									cancelLabel: "Keep",
+									tone: "danger",
+								});
+								if (confirmed) await onDeactivate(actorId);
+							}}
+						>
+							Remove person
+						</button>
+					</>
+				)}
+			</div>
+		</div>
+	);
 }
 
-function SyncActorsList({ actors, hiddenLocalDuplicateCount, onRename, onMerge, onDeactivate }: SyncActorsListProps) {
-  if (!actors.length) {
-    return (
-      <div className="sync-empty-state">
-        <strong>No people yet.</strong>
-        <span>Create a named person here, then assign each device below to keep sync ownership readable.</span>
-      </div>
-    );
-  }
+function SyncActorsList({
+	actors,
+	hiddenLocalDuplicateCount,
+	onRename,
+	onMerge,
+	onDeactivate,
+}: SyncActorsListProps) {
+	if (!actors.length) {
+		return (
+			<div className="sync-empty-state">
+				<strong>No people yet.</strong>
+				<span>
+					Create a named person here, then assign each device below to keep sync ownership readable.
+				</span>
+			</div>
+		);
+	}
 
-  return (
-    <>
-      {actors.map((actor) => {
-        const actorId = String(actor.actor_id || actor.display_name || actor.is_local || '');
-        return (
-          <SyncActorRow
-            key={actorId}
-            actor={actor}
-            hiddenLocalDuplicateCount={hiddenLocalDuplicateCount}
-            onRename={onRename}
-            onMerge={onMerge}
-            onDeactivate={onDeactivate}
-          />
-        );
-      })}
-    </>
-  );
+	return (
+		<>
+			{actors.map((actor) => {
+				const actorId = String(actor.actor_id || actor.display_name || actor.is_local || "");
+				return (
+					<SyncActorRow
+						key={actorId}
+						actor={actor}
+						hiddenLocalDuplicateCount={hiddenLocalDuplicateCount}
+						onRename={onRename}
+						onMerge={onMerge}
+						onDeactivate={onDeactivate}
+					/>
+				);
+			})}
+		</>
+	);
 }
 
 export function renderSyncActorsList(mount: HTMLElement, props: SyncActorsListProps) {
-  renderIntoSyncMount(mount, <SyncActorsList {...props} />);
+	renderIntoSyncMount(mount, <SyncActorsList {...props} />);
 }

--- a/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
@@ -1,101 +1,103 @@
-import { Fragment } from 'preact';
-import { clearSyncMount, renderIntoSyncMount } from './render-root';
+import { Fragment } from "preact";
+import { clearSyncMount, renderIntoSyncMount } from "./render-root";
 
 export type SyncStatItem = {
-  label: string;
-  value: number | string;
+	label: string;
+	value: number | string;
 };
 
 export type SyncAttemptItem = {
-  status: string;
-  peerLabel: string;
-  detail: string;
-  startedAt: string;
+	status: string;
+	peerLabel: string;
+	detail: string;
+	startedAt: string;
 };
 
 export type PairingView = {
-  payloadText: string;
-  hintText: string;
+	payloadText: string;
+	hintText: string;
 };
 
 export type SyncEmptyStateView = {
-  title: string;
-  detail: string;
+	title: string;
+	detail: string;
 };
 
 function DiagnosticsGrid({ items }: { items: SyncStatItem[] }) {
-  return (
-    <Fragment>
-      {items.map((item, index) => (
-        <div class="stat" key={`${item.label}-${index}`}>
-          <div class="stat-content">
-            <div class="value">{item.value}</div>
-            <div class="label">{item.label}</div>
-          </div>
-        </div>
-      ))}
-    </Fragment>
-  );
+	return (
+		<Fragment>
+			{items.map((item, index) => (
+				<div class="stat" key={`${item.label}-${index}`}>
+					<div class="stat-content">
+						<div class="value">{item.value}</div>
+						<div class="label">{item.label}</div>
+					</div>
+				</div>
+			))}
+		</Fragment>
+	);
 }
 
 function AttemptsList({ attempts }: { attempts: SyncAttemptItem[] }) {
-  return (
-    <Fragment>
-      {attempts.map((attempt, index) => (
-        <div class="diag-line" key={`${attempt.startedAt}-${attempt.peerLabel}-${index}`}>
-          <div class="left">
-            <div>{attempt.peerLabel} — {attempt.status}</div>
-            {attempt.detail ? <div class="small">{attempt.detail}</div> : null}
-          </div>
-          <div class="right">{attempt.startedAt}</div>
-        </div>
-      ))}
-    </Fragment>
-  );
+	return (
+		<Fragment>
+			{attempts.map((attempt, index) => (
+				<div class="diag-line" key={`${attempt.startedAt}-${attempt.peerLabel}-${index}`}>
+					<div class="left">
+						<div>
+							{attempt.peerLabel} — {attempt.status}
+						</div>
+						{attempt.detail ? <div class="small">{attempt.detail}</div> : null}
+					</div>
+					<div class="right">{attempt.startedAt}</div>
+				</div>
+			))}
+		</Fragment>
+	);
 }
 
 function PairingText({ text }: { text: string }) {
-  return <Fragment>{text}</Fragment>;
+	return <Fragment>{text}</Fragment>;
 }
 
 function SyncEmptyState({ title, detail }: SyncEmptyStateView) {
-  return (
-    <div class="sync-empty-state">
-      <strong>{title}</strong>
-      <span>{detail}</span>
-    </div>
-  );
+	return (
+		<div class="sync-empty-state">
+			<strong>{title}</strong>
+			<span>{detail}</span>
+		</div>
+	);
 }
 
 export function renderDiagnosticsGrid(mount: HTMLElement, items: SyncStatItem[]) {
-  if (!items.length) {
-    clearSyncMount(mount);
-    return;
-  }
+	if (!items.length) {
+		clearSyncMount(mount);
+		return;
+	}
 
-  renderIntoSyncMount(mount, <DiagnosticsGrid items={items} />);
+	renderIntoSyncMount(mount, <DiagnosticsGrid items={items} />);
 }
 
 export function renderAttemptsList(mount: HTMLElement, attempts: SyncAttemptItem[]) {
-  if (!attempts.length) {
-    clearSyncMount(mount);
-    return;
-  }
+	if (!attempts.length) {
+		clearSyncMount(mount);
+		return;
+	}
 
-  renderIntoSyncMount(mount, <AttemptsList attempts={attempts} />);
+	renderIntoSyncMount(mount, <AttemptsList attempts={attempts} />);
 }
 
 export function renderSyncEmptyState(mount: HTMLElement, view: SyncEmptyStateView) {
-  renderIntoSyncMount(mount, <SyncEmptyState {...view} />);
+	renderIntoSyncMount(mount, <SyncEmptyState {...view} />);
 }
 
 export function renderPairingView(
-  payloadMount: HTMLElement,
-  hintMount: HTMLElement | null,
-  view: PairingView,
+	payloadMount: HTMLElement,
+	hintMount: HTMLElement | null,
+	view: PairingView,
 ) {
-  renderIntoSyncMount(payloadMount, <PairingText text={view.payloadText} />);
-  if (hintMount) {
-    renderIntoSyncMount(hintMount, <PairingText text={view.hintText} />);
-  }
+	renderIntoSyncMount(payloadMount, <PairingText text={view.payloadText} />);
+	if (hintMount) {
+		renderIntoSyncMount(hintMount, <PairingText text={view.hintText} />);
+	}
 }

--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -1,178 +1,176 @@
-import * as Collapsible from '@radix-ui/react-collapsible';
-import type { ComponentChildren } from 'preact';
-import { createPortal } from 'preact/compat';
-import { useLayoutEffect, useRef } from 'preact/hooks';
-import { renderIntoSyncMount } from './render-root';
+import * as Collapsible from "@radix-ui/react-collapsible";
+import type { ComponentChildren } from "preact";
+import { createPortal } from "preact/compat";
+import { useLayoutEffect, useRef } from "preact/hooks";
+import { renderIntoSyncMount } from "./render-root";
 
 type SyncDisclosureProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  triggerId: string;
-  triggerClassName: string;
-  closedLabel: string;
-  openLabel: string;
-  contentId: string;
-  contentClassName?: string;
-  contentHost?: HTMLElement | null;
-  children: ComponentChildren;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	triggerId: string;
+	triggerClassName: string;
+	closedLabel: string;
+	openLabel: string;
+	contentId: string;
+	contentClassName?: string;
+	contentHost?: HTMLElement | null;
+	children: ComponentChildren;
 };
 
 function SyncDisclosure({
-  open,
-  onOpenChange,
-  triggerId,
-  triggerClassName,
-  closedLabel,
-  openLabel,
-  contentId,
-  contentClassName,
-  contentHost = null,
-  children,
+	open,
+	onOpenChange,
+	triggerId,
+	triggerClassName,
+	closedLabel,
+	openLabel,
+	contentId,
+	contentClassName,
+	contentHost = null,
+	children,
 }: SyncDisclosureProps) {
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const contentRef = useRef<HTMLDivElement | null>(null);
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
+	const contentRef = useRef<HTMLDivElement | null>(null);
 
-  useLayoutEffect(() => {
-    if (triggerRef.current) {
-      triggerRef.current.id = triggerId;
-      triggerRef.current.setAttribute('aria-controls', contentId);
-    }
-    if (contentRef.current) {
-      contentRef.current.id = contentId;
-    }
-  }, [contentId, triggerId, open]);
+	useLayoutEffect(() => {
+		if (triggerRef.current) {
+			triggerRef.current.id = triggerId;
+			triggerRef.current.setAttribute("aria-controls", contentId);
+		}
+		if (contentRef.current) {
+			contentRef.current.id = contentId;
+		}
+	}, [contentId, triggerId, open]);
 
-  const content = (
-    <Collapsible.Content asChild>
-      <div ref={contentRef} id={contentId} className={contentClassName} hidden={!open}>
-        {children}
-      </div>
-    </Collapsible.Content>
-  );
+	const content = (
+		<Collapsible.Content asChild>
+			<div ref={contentRef} id={contentId} className={contentClassName} hidden={!open}>
+				{children}
+			</div>
+		</Collapsible.Content>
+	);
 
-  return (
-    <Collapsible.Root open={open} onOpenChange={onOpenChange}>
-      <Collapsible.Trigger asChild>
-        <button
-          ref={triggerRef}
-          type="button"
-          className={triggerClassName}
-          id={triggerId}
-          aria-controls={contentId}
-        >
-          {open ? openLabel : closedLabel}
-        </button>
-      </Collapsible.Trigger>
-      {contentHost ? createPortal(content, contentHost) : content}
-    </Collapsible.Root>
-  );
+	return (
+		<Collapsible.Root open={open} onOpenChange={onOpenChange}>
+			<Collapsible.Trigger asChild>
+				<button
+					ref={triggerRef}
+					type="button"
+					className={triggerClassName}
+					id={triggerId}
+					aria-controls={contentId}
+				>
+					{open ? openLabel : closedLabel}
+				</button>
+			</Collapsible.Trigger>
+			{contentHost ? createPortal(content, contentHost) : content}
+		</Collapsible.Root>
+	);
 }
 
 type TeamSetupDisclosureProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
 };
 
 function TeamSetupDisclosure({ open, onOpenChange }: TeamSetupDisclosureProps) {
-  return (
-    <SyncDisclosure
-      open={open}
-      onOpenChange={onOpenChange}
-      triggerId="syncToggleAdmin"
-      triggerClassName="sync-toggle-admin"
-      closedLabel="Set up a new team instead…"
-      openLabel="Hide team setup"
-      contentId="syncInvitePanel"
-    >
-      <h3 className="settings-group-title" style={{ marginTop: '12px' }}>
-        Create a team
-      </h3>
-      <div className="section-meta">Generate an invite to share with teammates.</div>
-      <div className="actor-create-row">
-        <label htmlFor="syncInviteGroup" className="sr-only">
-          Team name
-        </label>
-        <input className="peer-scope-input" id="syncInviteGroup" placeholder="Team name (e.g. my-team)" />
-        <label htmlFor="syncInvitePolicy" className="sr-only">
-          Join policy
-        </label>
-        <div className="sync-radix-select-host sync-actor-select-host" id="syncInvitePolicyMount" />
-        <div className="sync-ttl-group">
-          <label htmlFor="syncInviteTtl">Expires in</label>
-          <input
-            className="peer-scope-input"
-            defaultValue="24"
-            id="syncInviteTtl"
-            min="1"
-            style={{ width: '64px' }}
-            type="number"
-          />
-          <label>hours</label>
-        </div>
-        <button className="settings-button" id="syncCreateInviteButton" type="button">
-          Create invite
-        </button>
-      </div>
-      <label htmlFor="syncInviteOutput" className="sr-only">
-        Generated invite
-      </label>
-      <textarea
-        className="feed-search"
-        id="syncInviteOutput"
-        placeholder="Invite will appear here"
-        readOnly
-        hidden
-      />
-      <div className="peer-meta" id="syncInviteWarnings" hidden />
-    </SyncDisclosure>
-  );
+	return (
+		<SyncDisclosure
+			open={open}
+			onOpenChange={onOpenChange}
+			triggerId="syncToggleAdmin"
+			triggerClassName="sync-toggle-admin"
+			closedLabel="Set up a new team instead…"
+			openLabel="Hide team setup"
+			contentId="syncInvitePanel"
+		>
+			<h3 className="settings-group-title" style={{ marginTop: "12px" }}>
+				Create a team
+			</h3>
+			<div className="section-meta">Generate an invite to share with teammates.</div>
+			<div className="actor-create-row">
+				<label htmlFor="syncInviteGroup" className="sr-only">
+					Team name
+				</label>
+				<input
+					className="peer-scope-input"
+					id="syncInviteGroup"
+					placeholder="Team name (e.g. my-team)"
+				/>
+				<label htmlFor="syncInvitePolicy" className="sr-only">
+					Join policy
+				</label>
+				<div className="sync-radix-select-host sync-actor-select-host" id="syncInvitePolicyMount" />
+				<div className="sync-ttl-group">
+					<label htmlFor="syncInviteTtl">Expires in</label>
+					<input
+						className="peer-scope-input"
+						defaultValue="24"
+						id="syncInviteTtl"
+						min="1"
+						style={{ width: "64px" }}
+						type="number"
+					/>
+					<label>hours</label>
+				</div>
+				<button className="settings-button" id="syncCreateInviteButton" type="button">
+					Create invite
+				</button>
+			</div>
+			<label htmlFor="syncInviteOutput" className="sr-only">
+				Generated invite
+			</label>
+			<textarea
+				className="feed-search"
+				id="syncInviteOutput"
+				placeholder="Invite will appear here"
+				readOnly
+				hidden
+			/>
+			<div className="peer-meta" id="syncInviteWarnings" hidden />
+		</SyncDisclosure>
+	);
 }
 
 type PairingDisclosureProps = {
-  contentHost: HTMLElement | null;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+	contentHost: HTMLElement | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
 };
 
 function PairingDisclosure({ contentHost, open, onOpenChange }: PairingDisclosureProps) {
-  return (
-    <SyncDisclosure
-      open={open}
-      onOpenChange={onOpenChange}
-      triggerId="syncPairingToggle"
-      triggerClassName="settings-button"
-      closedLabel="Show pairing"
-      openLabel="Hide pairing"
-      contentId="syncPairing"
-      contentClassName="pairing-card"
-      contentHost={contentHost}
-    >
-      <div className="peer-title">
-        <strong>Pairing command</strong>
-        <div className="peer-actions">
-          <button id="pairingCopy" type="button">
-            Copy command
-          </button>
-        </div>
-      </div>
-      <div className="pairing-body">
-        <pre id="pairingPayload" style={{ userSelect: 'all' }} />
-      </div>
-      <div className="peer-meta" id="pairingHint" />
-    </SyncDisclosure>
-  );
+	return (
+		<SyncDisclosure
+			open={open}
+			onOpenChange={onOpenChange}
+			triggerId="syncPairingToggle"
+			triggerClassName="settings-button"
+			closedLabel="Show pairing"
+			openLabel="Hide pairing"
+			contentId="syncPairing"
+			contentClassName="pairing-card"
+			contentHost={contentHost}
+		>
+			<div className="peer-title">
+				<strong>Pairing command</strong>
+				<div className="peer-actions">
+					<button id="pairingCopy" type="button">
+						Copy command
+					</button>
+				</div>
+			</div>
+			<div className="pairing-body">
+				<pre id="pairingPayload" style={{ userSelect: "all" }} />
+			</div>
+			<div className="peer-meta" id="pairingHint" />
+		</SyncDisclosure>
+	);
 }
 
-export function renderTeamSetupDisclosure(
-  mount: HTMLElement,
-  props: TeamSetupDisclosureProps,
-) {
-  renderIntoSyncMount(mount, <TeamSetupDisclosure {...props} />);
+export function renderTeamSetupDisclosure(mount: HTMLElement, props: TeamSetupDisclosureProps) {
+	renderIntoSyncMount(mount, <TeamSetupDisclosure {...props} />);
 }
 
-export function renderPairingDisclosure(
-  mount: HTMLElement,
-  props: PairingDisclosureProps,
-) {
-  renderIntoSyncMount(mount, <PairingDisclosure {...props} />);
+export function renderPairingDisclosure(mount: HTMLElement, props: PairingDisclosureProps) {
+	renderIntoSyncMount(mount, <PairingDisclosure {...props} />);
 }

--- a/packages/ui/src/tabs/sync/components/sync-inline-feedback.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-inline-feedback.tsx
@@ -1,17 +1,17 @@
 export type SyncActionFeedback = {
-  message: string;
-  tone: 'success' | 'warning';
+	message: string;
+	tone: "success" | "warning";
 };
 
 export function SyncInlineFeedback({ feedback }: { feedback: SyncActionFeedback | null }) {
-  if (!feedback?.message) return null;
-  return (
-    <div
-      className={`sync-inline-feedback ${feedback.tone}`}
-      role={feedback.tone === 'warning' ? 'alert' : 'status'}
-      aria-live={feedback.tone === 'warning' ? 'assertive' : 'polite'}
-    >
-      {feedback.message}
-    </div>
-  );
+	if (!feedback?.message) return null;
+	return (
+		<div
+			className={`sync-inline-feedback ${feedback.tone}`}
+			role={feedback.tone === "warning" ? "alert" : "status"}
+			aria-live={feedback.tone === "warning" ? "assertive" : "polite"}
+		>
+			{feedback.message}
+		</div>
+	);
 }

--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -1,142 +1,153 @@
-import { copyToClipboard } from '../../../lib/dom';
-import { useLayoutEffect, useRef } from 'preact/hooks';
+import { useLayoutEffect, useRef } from "preact/hooks";
+import { copyToClipboard } from "../../../lib/dom";
 
 type ExistingElementSlotProps = {
-  element: HTMLElement | null;
-  hidden?: boolean;
-  restoreParent?: HTMLElement | null;
+	element: HTMLElement | null;
+	hidden?: boolean;
+	restoreParent?: HTMLElement | null;
 };
 
 function ExistingElementSlot({
-  element,
-  hidden = false,
-  restoreParent = null,
+	element,
+	hidden = false,
+	restoreParent = null,
 }: ExistingElementSlotProps) {
-  const hostRef = useRef<HTMLDivElement | null>(null);
+	const hostRef = useRef<HTMLDivElement | null>(null);
 
-  useLayoutEffect(() => {
-    if (!element) return;
-    element.hidden = hidden;
-  }, [element, hidden]);
+	useLayoutEffect(() => {
+		if (!element) return;
+		element.hidden = hidden;
+	}, [element, hidden]);
 
-  useLayoutEffect(() => {
-    const host = hostRef.current;
-    if (!host || !element) return;
-    if (element.parentElement !== host) host.appendChild(element);
-    return () => {
-      if (!restoreParent || element.parentElement !== host) return;
-      restoreParent.appendChild(element);
-    };
-  }, [element, restoreParent]);
+	useLayoutEffect(() => {
+		const host = hostRef.current;
+		if (!host || !element) return;
+		if (element.parentElement !== host) host.appendChild(element);
+		return () => {
+			if (!restoreParent || element.parentElement !== host) return;
+			restoreParent.appendChild(element);
+		};
+	}, [element, restoreParent]);
 
-  return <div ref={hostRef} />;
+	return <div ref={hostRef} />;
 }
 
 function InviteToggleRow({
-  invitePanel,
-  invitePanelOpen,
-  inviteRestoreParent,
-  onToggle,
+	invitePanel,
+	invitePanelOpen,
+	inviteRestoreParent,
+	onToggle,
 }: {
-  invitePanel: HTMLElement | null;
-  invitePanelOpen: boolean;
-  inviteRestoreParent: HTMLElement | null;
-  onToggle: () => void;
+	invitePanel: HTMLElement | null;
+	invitePanelOpen: boolean;
+	inviteRestoreParent: HTMLElement | null;
+	onToggle: () => void;
 }) {
-  return (
-    <>
-      <div className="sync-action">
-        <div className="sync-action-text">
-          Add another teammate.
-          <span className="sync-action-command">Generate an invite when you are ready to bring another device into this team.</span>
-        </div>
-        <button type="button" className="settings-button" onClick={onToggle}>
-          {invitePanelOpen ? 'Hide invite form' : 'Invite a teammate'}
-        </button>
-      </div>
-      {invitePanel ? (
-        <ExistingElementSlot
-          element={invitePanel}
-          hidden={!invitePanelOpen}
-          restoreParent={inviteRestoreParent}
-        />
-      ) : null}
-    </>
-  );
+	return (
+		<>
+			<div className="sync-action">
+				<div className="sync-action-text">
+					Add another teammate.
+					<span className="sync-action-command">
+						Generate an invite when you are ready to bring another device into this team.
+					</span>
+				</div>
+				<button type="button" className="settings-button" onClick={onToggle}>
+					{invitePanelOpen ? "Hide invite form" : "Invite a teammate"}
+				</button>
+			</div>
+			{invitePanel ? (
+				<ExistingElementSlot
+					element={invitePanel}
+					hidden={!invitePanelOpen}
+					restoreParent={inviteRestoreParent}
+				/>
+			) : null}
+		</>
+	);
 }
 
 function PairingCopyRow() {
-  return (
-    <div className="sync-action">
-      <div className="sync-action-text">
-        Pair another device.
-        <span className="sync-action-command">Use the pairing command in Advanced diagnostics when you are ready to connect one.</span>
-      </div>
-      <button
-        type="button"
-        className="settings-button sync-action-copy"
-        onClick={(event) =>
-          copyToClipboard('codemem sync pair --payload-only', event.currentTarget as HTMLButtonElement)
-        }
-      >
-        Copy
-      </button>
-    </div>
-  );
+	return (
+		<div className="sync-action">
+			<div className="sync-action-text">
+				Pair another device.
+				<span className="sync-action-command">
+					Use the pairing command in Advanced diagnostics when you are ready to connect one.
+				</span>
+			</div>
+			<button
+				type="button"
+				className="settings-button sync-action-copy"
+				onClick={(event) =>
+					copyToClipboard(
+						"codemem sync pair --payload-only",
+						event.currentTarget as HTMLButtonElement,
+					)
+				}
+			>
+				Copy
+			</button>
+		</div>
+	);
 }
 
 export type SyncInviteJoinPanelsProps = {
-  invitePanel: HTMLElement | null;
-  invitePanelOpen: boolean;
-  inviteRestoreParent: HTMLElement | null;
-  joinPanel: HTMLElement | null;
-  joinRestoreParent: HTMLElement | null;
-  onToggleInvitePanel: () => void;
-  pairedPeerCount: number;
-  presenceStatus: string;
+	invitePanel: HTMLElement | null;
+	invitePanelOpen: boolean;
+	inviteRestoreParent: HTMLElement | null;
+	joinPanel: HTMLElement | null;
+	joinRestoreParent: HTMLElement | null;
+	onToggleInvitePanel: () => void;
+	pairedPeerCount: number;
+	presenceStatus: string;
 };
 
 export function SyncInviteJoinPanels({
-  invitePanel,
-  invitePanelOpen,
-  inviteRestoreParent,
-  joinPanel,
-  joinRestoreParent,
-  onToggleInvitePanel,
-  pairedPeerCount,
-  presenceStatus,
+	invitePanel,
+	invitePanelOpen,
+	inviteRestoreParent,
+	joinPanel,
+	joinRestoreParent,
+	onToggleInvitePanel,
+	pairedPeerCount,
+	presenceStatus,
 }: SyncInviteJoinPanelsProps) {
-  const showInviteActions = presenceStatus !== 'not_enrolled';
+	const showInviteActions = presenceStatus !== "not_enrolled";
 
-  return (
-    <>
-      {presenceStatus === 'not_enrolled' ? (
-        <>
-          {joinPanel ? (
-            <ExistingElementSlot element={joinPanel} hidden={false} restoreParent={joinRestoreParent} />
-          ) : null}
-          <div className="peer-meta" id="syncJoinFeedback" hidden />
-          <div className="sync-action">
-            <div className="sync-action-text">
-              This device is not on the team yet.
-              <span className="sync-action-command">
-                Import an invite or ask an admin to enroll it first.
-              </span>
-            </div>
-          </div>
-        </>
-      ) : null}
+	return (
+		<>
+			{presenceStatus === "not_enrolled" ? (
+				<>
+					{joinPanel ? (
+						<ExistingElementSlot
+							element={joinPanel}
+							hidden={false}
+							restoreParent={joinRestoreParent}
+						/>
+					) : null}
+					<div className="peer-meta" id="syncJoinFeedback" hidden />
+					<div className="sync-action">
+						<div className="sync-action-text">
+							This device is not on the team yet.
+							<span className="sync-action-command">
+								Import an invite or ask an admin to enroll it first.
+							</span>
+						</div>
+					</div>
+				</>
+			) : null}
 
-      {showInviteActions ? (
-        <InviteToggleRow
-          invitePanel={invitePanel}
-          invitePanelOpen={invitePanelOpen}
-          inviteRestoreParent={inviteRestoreParent}
-          onToggle={onToggleInvitePanel}
-        />
-      ) : null}
+			{showInviteActions ? (
+				<InviteToggleRow
+					invitePanel={invitePanel}
+					invitePanelOpen={invitePanelOpen}
+					inviteRestoreParent={inviteRestoreParent}
+					onToggle={onToggleInvitePanel}
+				/>
+			) : null}
 
-      {!pairedPeerCount && presenceStatus === 'posted' ? <PairingCopyRow /> : null}
-    </>
-  );
+			{!pairedPeerCount && presenceStatus === "posted" ? <PairingCopyRow /> : null}
+		</>
+	);
 }

--- a/packages/ui/src/tabs/sync/components/sync-legacy-claims.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-legacy-claims.tsx
@@ -1,77 +1,77 @@
-import { Fragment } from 'preact';
-import { clearSyncMount, renderIntoSyncMount } from './render-root';
-import { formatTimestamp } from '../../../lib/format';
-import { RadixSelect, type RadixSelectOption } from '../../../components/primitives/radix-select';
+import { Fragment } from "preact";
+import { RadixSelect, type RadixSelectOption } from "../../../components/primitives/radix-select";
+import { formatTimestamp } from "../../../lib/format";
+import { clearSyncMount, renderIntoSyncMount } from "./render-root";
 
 type LegacyDeviceClaim = {
-  origin_device_id?: string;
-  memory_count?: number;
-  last_seen_at?: string;
+	origin_device_id?: string;
+	memory_count?: number;
+	last_seen_at?: string;
 };
 
 function validDevices(devices: LegacyDeviceClaim[]): LegacyDeviceClaim[] {
-  return devices.filter((device) => String(device.origin_device_id || '').trim());
+	return devices.filter((device) => String(device.origin_device_id || "").trim());
 }
 
 function metaText(devices: LegacyDeviceClaim[]): string {
-  const withLastSeen = devices.find((device) => String(device.last_seen_at || '').trim());
-  if (withLastSeen?.last_seen_at) {
-    return `Detected from older synced memories. Latest memory: ${formatTimestamp(String(withLastSeen.last_seen_at).trim())}`;
-  }
-  return 'Detected from older synced memories not yet attached to a current device.';
+	const withLastSeen = devices.find((device) => String(device.last_seen_at || "").trim());
+	if (withLastSeen?.last_seen_at) {
+		return `Detected from older synced memories. Latest memory: ${formatTimestamp(String(withLastSeen.last_seen_at).trim())}`;
+	}
+	return "Detected from older synced memories not yet attached to a current device.";
 }
 
 function LegacyClaimMeta({ devices }: { devices: LegacyDeviceClaim[] }) {
-  return <Fragment>{metaText(devices)}</Fragment>;
+	return <Fragment>{metaText(devices)}</Fragment>;
 }
 
 function option(device: LegacyDeviceClaim): RadixSelectOption {
-  const deviceId = String(device.origin_device_id || '').trim();
-  const count = Number(device.memory_count || 0);
-  return {
-    label: count > 0 ? `${deviceId} (${count} memories)` : deviceId,
-    value: deviceId,
-  };
+	const deviceId = String(device.origin_device_id || "").trim();
+	const count = Number(device.memory_count || 0);
+	return {
+		label: count > 0 ? `${deviceId} (${count} memories)` : deviceId,
+		value: deviceId,
+	};
 }
 
 export function renderLegacyClaimsSlice(input: {
-  panel: HTMLElement;
-  mount: HTMLElement;
-  meta: HTMLElement;
-  devices: LegacyDeviceClaim[];
-  value: string;
-  onValueChange: (value: string) => void;
+	panel: HTMLElement;
+	mount: HTMLElement;
+	meta: HTMLElement;
+	devices: LegacyDeviceClaim[];
+	value: string;
+	onValueChange: (value: string) => void;
 }) {
-  const devices = validDevices(input.devices);
-  if (!devices.length) {
-    input.panel.hidden = true;
-    input.onValueChange('');
-    clearSyncMount(input.mount);
-    clearSyncMount(input.meta);
-    return;
-  }
+	const devices = validDevices(input.devices);
+	if (!devices.length) {
+		input.panel.hidden = true;
+		input.onValueChange("");
+		clearSyncMount(input.mount);
+		clearSyncMount(input.meta);
+		return;
+	}
 
-  const options = devices.map(option);
-  const nextValue = options.some((item) => item.value === input.value)
-    ? input.value
-    : options[0]?.value || '';
+	const options = devices.map(option);
+	const nextValue = options.some((item) => item.value === input.value)
+		? input.value
+		: options[0]?.value || "";
 
-  if (nextValue !== input.value) input.onValueChange(nextValue);
+	if (nextValue !== input.value) input.onValueChange(nextValue);
 
-  input.panel.hidden = false;
-  renderIntoSyncMount(
-    input.mount,
-    <RadixSelect
-      ariaLabel="Legacy device"
-      contentClassName="sync-radix-select-content sync-legacy-select-content"
-      id="syncLegacyDeviceSelect"
-      itemClassName="sync-radix-select-item"
-      onValueChange={input.onValueChange}
-      options={options}
-      triggerClassName="sync-radix-select-trigger sync-legacy-select"
-      value={nextValue}
-      viewportClassName="sync-radix-select-viewport"
-    />,
-  );
-  renderIntoSyncMount(input.meta, <LegacyClaimMeta devices={devices} />);
+	input.panel.hidden = false;
+	renderIntoSyncMount(
+		input.mount,
+		<RadixSelect
+			ariaLabel="Legacy device"
+			contentClassName="sync-radix-select-content sync-legacy-select-content"
+			id="syncLegacyDeviceSelect"
+			itemClassName="sync-radix-select-item"
+			onValueChange={input.onValueChange}
+			options={options}
+			triggerClassName="sync-radix-select-trigger sync-legacy-select"
+			value={nextValue}
+			viewportClassName="sync-radix-select-viewport"
+		/>,
+	);
+	renderIntoSyncMount(input.meta, <LegacyClaimMeta devices={devices} />);
 }

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -1,448 +1,479 @@
-import type { TargetedInputEvent } from 'preact';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks';
-import { RadixSelect, type RadixSelectOption } from '../../../components/primitives/radix-select';
-import { formatTimestamp } from '../../../lib/format';
-import { showGlobalNotice } from '../../../lib/notice';
-import { state, isSyncRedactionEnabled } from '../../../lib/state';
-import { openSyncConfirmDialog } from '../sync-dialogs';
-import { PeerScopeCollapsible } from '../peer-scope-collapsible';
+import type { TargetedInputEvent } from "preact";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
+import { RadixSelect } from "../../../components/primitives/radix-select";
+import { formatTimestamp } from "../../../lib/format";
+import { isSyncRedactionEnabled, state } from "../../../lib/state";
 import {
-  actorDisplayLabel,
-  buildActorSelectOptions,
-  consumePeerScopeReviewRequest,
-  createChipEditor,
-  isPeerScopeReviewPending,
-  openPeerScopeEditors,
-  pickPrimaryAddress,
-  redactAddress,
-} from '../helpers';
-import { derivePeerTrustSummary, summarizeSyncRunResult, type PeerLike } from '../view-model';
-import { renderIntoSyncMount } from './render-root';
-import { SyncInlineFeedback, type SyncActionFeedback } from './sync-inline-feedback';
+	buildActorSelectOptions,
+	consumePeerScopeReviewRequest,
+	createChipEditor,
+	isPeerScopeReviewPending,
+	openPeerScopeEditors,
+	pickPrimaryAddress,
+	redactAddress,
+} from "../helpers";
+import { PeerScopeCollapsible } from "../peer-scope-collapsible";
+import { openSyncConfirmDialog } from "../sync-dialogs";
+import { derivePeerTrustSummary, type PeerLike } from "../view-model";
+import { renderIntoSyncMount } from "./render-root";
+import { type SyncActionFeedback, SyncInlineFeedback } from "./sync-inline-feedback";
 
 type PeerScopeLike = {
-  include?: string[];
-  exclude?: string[];
-  effective_include?: string[];
-  effective_exclude?: string[];
-  inherits_global?: boolean;
+	include?: string[];
+	exclude?: string[];
+	effective_include?: string[];
+	effective_exclude?: string[];
+	inherits_global?: boolean;
 };
 
 type SyncPeer = PeerLike & {
-  actor_display_name?: string;
-  addresses?: unknown[];
-  claimed_local_actor?: boolean;
-  project_scope?: PeerScopeLike;
+	actor_display_name?: string;
+	addresses?: unknown[];
+	claimed_local_actor?: boolean;
+	project_scope?: PeerScopeLike;
 };
 
-type SyncPeerStatus = NonNullable<SyncPeer['status']> & {
-  last_ping_at?: string;
-  last_ping_at_utc?: string;
-  last_sync_at?: string;
-  last_sync_at_utc?: string;
+type SyncPeerStatus = NonNullable<SyncPeer["status"]> & {
+	last_ping_at?: string;
+	last_ping_at_utc?: string;
+	last_sync_at?: string;
+	last_sync_at_utc?: string;
 };
 
 type SyncPeerCardProps = {
-  peer: SyncPeer;
-  onAssignActor: (peerId: string, actorId: string | null) => Promise<SyncActionFeedback>;
-  onRemove: (peerId: string, label: string) => Promise<SyncActionFeedback>;
-  onRename: (peerId: string, name: string) => Promise<SyncActionFeedback>;
-  onResetScope: (peerId: string) => Promise<SyncActionFeedback>;
-  onSaveScope: (peerId: string, include: string[], exclude: string[]) => Promise<SyncActionFeedback>;
-  onSync: (peer: SyncPeer, address: string | undefined) => Promise<SyncActionFeedback | null>;
+	peer: SyncPeer;
+	onAssignActor: (peerId: string, actorId: string | null) => Promise<SyncActionFeedback>;
+	onRemove: (peerId: string, label: string) => Promise<SyncActionFeedback>;
+	onRename: (peerId: string, name: string) => Promise<SyncActionFeedback>;
+	onResetScope: (peerId: string) => Promise<SyncActionFeedback>;
+	onSaveScope: (
+		peerId: string,
+		include: string[],
+		exclude: string[],
+	) => Promise<SyncActionFeedback>;
+	onSync: (peer: SyncPeer, address: string | undefined) => Promise<SyncActionFeedback | null>;
 };
 
-type SyncPeersListProps = Omit<SyncPeerCardProps, 'peer'> & {
-  peers: SyncPeer[];
+type SyncPeersListProps = Omit<SyncPeerCardProps, "peer"> & {
+	peers: SyncPeer[];
 };
 
 function listText(value: unknown): string[] {
-  return Array.isArray(value) ? value.map((item) => String(item || '').trim()).filter(Boolean) : [];
+	return Array.isArray(value) ? value.map((item) => String(item || "").trim()).filter(Boolean) : [];
 }
 
-function summaryText(prefix: string, values: string[], emptyLabel: string): string {
-  return `${prefix}: ${values.join(', ') || emptyLabel}`;
+function _summaryText(prefix: string, values: string[], emptyLabel: string): string {
+	return `${prefix}: ${values.join(", ") || emptyLabel}`;
 }
 
 function ExistingElementSlot({ element }: { element: HTMLElement }) {
-  const hostRef = useRef<HTMLDivElement | null>(null);
+	const hostRef = useRef<HTMLDivElement | null>(null);
 
-  useLayoutEffect(() => {
-    const host = hostRef.current;
-    if (!host) return;
-    if (element.parentElement !== host) host.appendChild(element);
-    return () => {
-      if (element.parentElement === host) {
-        host.removeChild(element);
-      }
-    };
-  }, [element]);
+	useLayoutEffect(() => {
+		const host = hostRef.current;
+		if (!host) return;
+		if (element.parentElement !== host) host.appendChild(element);
+		return () => {
+			if (element.parentElement === host) {
+				host.removeChild(element);
+			}
+		};
+	}, [element]);
 
-  return <div ref={hostRef} />;
+	return <div ref={hostRef} />;
 }
 
 function SyncPeerCard({
-  peer,
-  onAssignActor,
-  onRemove,
-  onRename,
-  onResetScope,
-  onSaveScope,
-  onSync,
+	peer,
+	onAssignActor,
+	onRemove,
+	onRename,
+	onResetScope,
+	onSaveScope,
+	onSync,
 }: SyncPeerCardProps) {
-  const peerId = String(peer.peer_device_id || '');
-  const displayName = peer.name || (peerId ? peerId.slice(0, 8) : 'unknown');
-  const destructiveLabel = peer.name || peerId || displayName;
-  const pendingScopeReview = isPeerScopeReviewPending(peerId);
-  const trustSummary = derivePeerTrustSummary(peer);
-  const peerStatus: SyncPeerStatus = peer.status || {};
-  const scope = peer.project_scope || {};
-  const includeList = listText(scope.include);
-  const excludeList = listText(scope.exclude);
-  const effectiveInclude = listText(scope.effective_include);
-  const effectiveExclude = listText(scope.effective_exclude);
-  const inheritsGlobal = Boolean(scope.inherits_global);
-  const primaryAddress = pickPrimaryAddress(peer.addresses);
-  const peerAddresses = Array.isArray(peer.addresses)
-    ? Array.from(new Set(peer.addresses.filter(Boolean).map((value) => String(value))))
-    : [];
-  const addressLine = peerAddresses.length
-    ? peerAddresses.map((address) => (isSyncRedactionEnabled() ? redactAddress(address) : address)).join(' · ')
-    : 'No addresses';
-  const lastSyncAt = String(peerStatus.last_sync_at || peerStatus.last_sync_at_utc || '');
-  const lastPingAt = String(peerStatus.last_ping_at || peerStatus.last_ping_at_utc || '');
-  const scopeEditorOpen = openPeerScopeEditors.has(peerId);
-  const scopeReviewRequested = consumePeerScopeReviewRequest(peerId);
-  const cardRef = useRef<HTMLDivElement | null>(null);
-  const [scopeHost, setScopeHost] = useState<HTMLDivElement | null>(null);
+	const peerId = String(peer.peer_device_id || "");
+	const displayName = peer.name || (peerId ? peerId.slice(0, 8) : "unknown");
+	const destructiveLabel = peer.name || peerId || displayName;
+	const pendingScopeReview = isPeerScopeReviewPending(peerId);
+	const trustSummary = derivePeerTrustSummary(peer);
+	const peerStatus: SyncPeerStatus = peer.status || {};
+	const scope = peer.project_scope || {};
+	const includeList = listText(scope.include);
+	const excludeList = listText(scope.exclude);
+	const _effectiveInclude = listText(scope.effective_include);
+	const _effectiveExclude = listText(scope.effective_exclude);
+	const _inheritsGlobal = Boolean(scope.inherits_global);
+	const primaryAddress = pickPrimaryAddress(peer.addresses);
+	const peerAddresses = Array.isArray(peer.addresses)
+		? Array.from(new Set(peer.addresses.filter(Boolean).map((value) => String(value))))
+		: [];
+	const addressLine = peerAddresses.length
+		? peerAddresses
+				.map((address) => (isSyncRedactionEnabled() ? redactAddress(address) : address))
+				.join(" · ")
+		: "No addresses";
+	const lastSyncAt = String(peerStatus.last_sync_at || peerStatus.last_sync_at_utc || "");
+	const lastPingAt = String(peerStatus.last_ping_at || peerStatus.last_ping_at_utc || "");
+	const scopeEditorOpen = openPeerScopeEditors.has(peerId);
+	const scopeReviewRequested = consumePeerScopeReviewRequest(peerId);
+	const cardRef = useRef<HTMLDivElement | null>(null);
+	const [scopeHost, setScopeHost] = useState<HTMLDivElement | null>(null);
 
-  const [renameValue, setRenameValue] = useState(displayName);
-  const [feedback, setFeedback] = useState<SyncActionFeedback | null>(() => state.syncPeerFeedbackById.get(peerId) ?? null);
-  const [renameBusy, setRenameBusy] = useState(false);
-  const [renameLabel, setRenameLabel] = useState('Save name');
-  const [syncBusy, setSyncBusy] = useState(false);
-  const [removeBusy, setRemoveBusy] = useState(false);
-  const [removeLabel, setRemoveLabel] = useState('Remove peer');
-  const [selectedActorId, setSelectedActorId] = useState(String(peer.actor_id || ''));
-  const [applyActorBusy, setApplyActorBusy] = useState(false);
-  const [applyActorLabel, setApplyActorLabel] = useState('Save person');
-  const [saveScopeBusy, setSaveScopeBusy] = useState(false);
-  const [saveScopeLabel, setSaveScopeLabel] = useState('Save scope');
-  const [resetScopeBusy, setResetScopeBusy] = useState(false);
-  const [resetScopeLabel, setResetScopeLabel] = useState('Reset to global scope');
-  const actorSelectOptions = useMemo(() => {
-    const options = buildActorSelectOptions(selectedActorId);
-    const hasSelected = options.some((option) => option.value === selectedActorId);
-    if (selectedActorId && !hasSelected) {
-      options.push({
-        value: selectedActorId,
-        label: peer.claimed_local_actor ? 'You' : String(peer.actor_display_name || 'Current assignment'),
-      });
-    }
-    return options;
-  }, [peer.actor_display_name, peer.claimed_local_actor, selectedActorId, state.lastSyncActors, state.lastSyncPeers, state.lastSyncViewModel]);
+	const [renameValue, setRenameValue] = useState(displayName);
+	const [feedback, setFeedback] = useState<SyncActionFeedback | null>(
+		() => state.syncPeerFeedbackById.get(peerId) ?? null,
+	);
+	const [renameBusy, setRenameBusy] = useState(false);
+	const [renameLabel, setRenameLabel] = useState("Save name");
+	const [syncBusy, setSyncBusy] = useState(false);
+	const [removeBusy, setRemoveBusy] = useState(false);
+	const [removeLabel, setRemoveLabel] = useState("Remove peer");
+	const [selectedActorId, setSelectedActorId] = useState(String(peer.actor_id || ""));
+	const [applyActorBusy, setApplyActorBusy] = useState(false);
+	const [applyActorLabel, setApplyActorLabel] = useState("Save person");
+	const [saveScopeBusy, setSaveScopeBusy] = useState(false);
+	const [saveScopeLabel, setSaveScopeLabel] = useState("Save scope");
+	const [resetScopeBusy, setResetScopeBusy] = useState(false);
+	const [resetScopeLabel, setResetScopeLabel] = useState("Reset to global scope");
+	const actorSelectOptions = useMemo(() => {
+		const options = buildActorSelectOptions(selectedActorId);
+		const hasSelected = options.some((option) => option.value === selectedActorId);
+		if (selectedActorId && !hasSelected) {
+			options.push({
+				value: selectedActorId,
+				label: peer.claimed_local_actor
+					? "You"
+					: String(peer.actor_display_name || "Current assignment"),
+			});
+		}
+		return options;
+	}, [
+		peer.actor_display_name,
+		peer.claimed_local_actor,
+		selectedActorId,
+		state.lastSyncActors,
+		state.lastSyncPeers,
+		state.lastSyncViewModel,
+	]);
 
-  const includeEditor = useMemo(
-    () => createChipEditor(includeList, 'Add included project', 'All projects'),
-    [peerId, includeList.join('|')],
-  );
-  const excludeEditor = useMemo(
-    () => createChipEditor(excludeList, 'Add excluded project', 'No exclusions'),
-    [peerId, excludeList.join('|')],
-  );
+	const includeEditor = useMemo(
+		() => createChipEditor(includeList, "Add included project", "All projects"),
+		[peerId, includeList.join("|")],
+	);
+	const excludeEditor = useMemo(
+		() => createChipEditor(excludeList, "Add excluded project", "No exclusions"),
+		[peerId, excludeList.join("|")],
+	);
 
-  useEffect(() => {
-    setRenameValue(displayName);
-    setFeedback(state.syncPeerFeedbackById.get(peerId) ?? null);
-    setRenameBusy(false);
-    setRenameLabel('Save name');
-    setSyncBusy(false);
-    setRemoveBusy(false);
-    setRemoveLabel('Remove peer');
-    setSelectedActorId(String(peer.actor_id || ''));
-    setApplyActorBusy(false);
-    setApplyActorLabel('Save person');
-    setSaveScopeBusy(false);
-    setSaveScopeLabel('Save scope');
-    setResetScopeBusy(false);
-    setResetScopeLabel('Reset to global scope');
-  }, [displayName, peer.actor_id, peerId, includeList.join('|'), excludeList.join('|')]);
+	useEffect(() => {
+		setRenameValue(displayName);
+		setFeedback(state.syncPeerFeedbackById.get(peerId) ?? null);
+		setRenameBusy(false);
+		setRenameLabel("Save name");
+		setSyncBusy(false);
+		setRemoveBusy(false);
+		setRemoveLabel("Remove peer");
+		setSelectedActorId(String(peer.actor_id || ""));
+		setApplyActorBusy(false);
+		setApplyActorLabel("Save person");
+		setSaveScopeBusy(false);
+		setSaveScopeLabel("Save scope");
+		setResetScopeBusy(false);
+		setResetScopeLabel("Reset to global scope");
+	}, [displayName, peer.actor_id, peerId, includeList.join("|"), excludeList.join("|")]);
 
-  useEffect(() => {
-    if (!scopeReviewRequested || !cardRef.current) return;
-    queueMicrotask(() =>
-      cardRef.current?.scrollIntoView({
-        block: 'center',
-        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
-      }),
-    );
-  }, [scopeReviewRequested]);
+	useEffect(() => {
+		if (!scopeReviewRequested || !cardRef.current) return;
+		queueMicrotask(() =>
+			cardRef.current?.scrollIntoView({
+				block: "center",
+				behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+			}),
+		);
+	}, [scopeReviewRequested]);
 
-  async function rename() {
-    if (!peerId) return;
-    const nextName = renameValue.trim();
-    if (!nextName) {
-      const warning = { message: 'Enter a friendly name for this device.', tone: 'warning' } satisfies SyncActionFeedback;
-      setFeedback(warning);
-      state.syncPeerFeedbackById.set(peerId, warning);
-      const input = document.querySelector(`[data-device-name-input="${CSS.escape(peerId)}"]`) as
-        | HTMLInputElement
-        | null;
-      input?.focus();
-      return;
-    }
-    setRenameBusy(true);
-    setRenameLabel('Saving…');
-    try {
-      const nextFeedback = await onRename(peerId, nextName);
-      setFeedback(nextFeedback);
-      state.syncPeerFeedbackById.set(peerId, nextFeedback);
-      setRenameLabel('Save name');
-    } catch {
-      setRenameLabel('Retry');
-    } finally {
-      setRenameBusy(false);
-    }
-  }
+	async function rename() {
+		if (!peerId) return;
+		const nextName = renameValue.trim();
+		if (!nextName) {
+			const warning = {
+				message: "Enter a friendly name for this device.",
+				tone: "warning",
+			} satisfies SyncActionFeedback;
+			setFeedback(warning);
+			state.syncPeerFeedbackById.set(peerId, warning);
+			const input = document.querySelector(
+				`[data-device-name-input="${CSS.escape(peerId)}"]`,
+			) as HTMLInputElement | null;
+			input?.focus();
+			return;
+		}
+		setRenameBusy(true);
+		setRenameLabel("Saving…");
+		try {
+			const nextFeedback = await onRename(peerId, nextName);
+			setFeedback(nextFeedback);
+			state.syncPeerFeedbackById.set(peerId, nextFeedback);
+			setRenameLabel("Save name");
+		} catch {
+			setRenameLabel("Retry");
+		} finally {
+			setRenameBusy(false);
+		}
+	}
 
-  async function sync() {
-    if (!primaryAddress) return;
-    if (pendingScopeReview) {
-      const proceed = await openSyncConfirmDialog({
-        title: `Sync ${displayName} before scope review?`,
-        description: 'This manual sync will use the current effective scope until you finish reviewing and saving the device scope.',
-        confirmLabel: 'Sync anyway',
-        cancelLabel: 'Review scope first',
-      });
-      if (!proceed) return;
-    }
-    setSyncBusy(true);
-    try {
-      const nextFeedback = await onSync(peer, primaryAddress);
-      setFeedback(nextFeedback);
-      if (nextFeedback) state.syncPeerFeedbackById.set(peerId, nextFeedback);
-    } finally {
-      setSyncBusy(false);
-    }
-  }
+	async function sync() {
+		if (!primaryAddress) return;
+		if (pendingScopeReview) {
+			const proceed = await openSyncConfirmDialog({
+				title: `Sync ${displayName} before scope review?`,
+				description:
+					"This manual sync will use the current effective scope until you finish reviewing and saving the device scope.",
+				confirmLabel: "Sync anyway",
+				cancelLabel: "Review scope first",
+			});
+			if (!proceed) return;
+		}
+		setSyncBusy(true);
+		try {
+			const nextFeedback = await onSync(peer, primaryAddress);
+			setFeedback(nextFeedback);
+			if (nextFeedback) state.syncPeerFeedbackById.set(peerId, nextFeedback);
+		} finally {
+			setSyncBusy(false);
+		}
+	}
 
-  async function remove() {
-    if (!peerId) return;
-    const confirmed = await openSyncConfirmDialog({
-      title: `Remove peer ${destructiveLabel}?`,
-      description: 'This deletes the local sync peer entry on this device.',
-      confirmLabel: 'Remove peer',
-      cancelLabel: 'Keep peer',
-      tone: 'danger',
-    });
-    if (!confirmed) return;
-    setRemoveBusy(true);
-    setRemoveLabel('Removing…');
-    let ok = false;
-    try {
-      await onRemove(peerId, destructiveLabel);
-      ok = true;
-    } catch {
-      setRemoveLabel('Retry remove');
-    } finally {
-      setRemoveBusy(false);
-      if (ok) setRemoveLabel('Remove peer');
-    }
-  }
+	async function remove() {
+		if (!peerId) return;
+		const confirmed = await openSyncConfirmDialog({
+			title: `Remove peer ${destructiveLabel}?`,
+			description: "This deletes the local sync peer entry on this device.",
+			confirmLabel: "Remove peer",
+			cancelLabel: "Keep peer",
+			tone: "danger",
+		});
+		if (!confirmed) return;
+		setRemoveBusy(true);
+		setRemoveLabel("Removing…");
+		let ok = false;
+		try {
+			await onRemove(peerId, destructiveLabel);
+			ok = true;
+		} catch {
+			setRemoveLabel("Retry remove");
+		} finally {
+			setRemoveBusy(false);
+			if (ok) setRemoveLabel("Remove peer");
+		}
+	}
 
-  async function savePerson() {
-    if (!peerId) return;
-    setApplyActorBusy(true);
-    setApplyActorLabel('Saving…');
-    try {
-      const nextFeedback = await onAssignActor(peerId, selectedActorId || null);
-      setFeedback(nextFeedback);
-      state.syncPeerFeedbackById.set(peerId, nextFeedback);
-      setApplyActorLabel('Save person');
-    } catch {
-      setApplyActorLabel('Retry');
-    } finally {
-      setApplyActorBusy(false);
-    }
-  }
+	async function savePerson() {
+		if (!peerId) return;
+		setApplyActorBusy(true);
+		setApplyActorLabel("Saving…");
+		try {
+			const nextFeedback = await onAssignActor(peerId, selectedActorId || null);
+			setFeedback(nextFeedback);
+			state.syncPeerFeedbackById.set(peerId, nextFeedback);
+			setApplyActorLabel("Save person");
+		} catch {
+			setApplyActorLabel("Retry");
+		} finally {
+			setApplyActorBusy(false);
+		}
+	}
 
-  async function saveScope() {
-    if (!peerId) return;
-    setSaveScopeBusy(true);
-    setSaveScopeLabel('Saving…');
-    try {
-      const nextFeedback = await onSaveScope(peerId, includeEditor.values(), excludeEditor.values());
-      setFeedback(nextFeedback);
-      state.syncPeerFeedbackById.set(peerId, nextFeedback);
-      setSaveScopeLabel('Save scope');
-    } catch {
-      setSaveScopeLabel('Retry');
-    } finally {
-      setSaveScopeBusy(false);
-    }
-  }
+	async function saveScope() {
+		if (!peerId) return;
+		setSaveScopeBusy(true);
+		setSaveScopeLabel("Saving…");
+		try {
+			const nextFeedback = await onSaveScope(
+				peerId,
+				includeEditor.values(),
+				excludeEditor.values(),
+			);
+			setFeedback(nextFeedback);
+			state.syncPeerFeedbackById.set(peerId, nextFeedback);
+			setSaveScopeLabel("Save scope");
+		} catch {
+			setSaveScopeLabel("Retry");
+		} finally {
+			setSaveScopeBusy(false);
+		}
+	}
 
-  async function resetScope() {
-    if (!peerId) return;
-    setResetScopeBusy(true);
-    setResetScopeLabel('Resetting…');
-    try {
-      const nextFeedback = await onResetScope(peerId);
-      setFeedback(nextFeedback);
-      state.syncPeerFeedbackById.set(peerId, nextFeedback);
-      setResetScopeLabel('Reset to global scope');
-    } catch {
-      setResetScopeLabel('Retry');
-    } finally {
-      setResetScopeBusy(false);
-    }
-  }
+	async function resetScope() {
+		if (!peerId) return;
+		setResetScopeBusy(true);
+		setResetScopeLabel("Resetting…");
+		try {
+			const nextFeedback = await onResetScope(peerId);
+			setFeedback(nextFeedback);
+			state.syncPeerFeedbackById.set(peerId, nextFeedback);
+			setResetScopeLabel("Reset to global scope");
+		} catch {
+			setResetScopeLabel("Retry");
+		} finally {
+			setResetScopeBusy(false);
+		}
+	}
 
-  return (
-    <div ref={cardRef} className="peer-card" data-peer-device-id={peerId || undefined}>
-      <div className="peer-title">
-        <strong title={peerId || undefined}>
-          {displayName}{' '}
-          <span className={`badge ${trustSummary.isWarning ? 'badge-offline' : 'badge-online'}`}>
-            {trustSummary.badgeLabel}
-          </span>
-          {pendingScopeReview ? <span className="badge actor-badge">Needs scope review</span> : null}
-        </strong>
+	return (
+		<div ref={cardRef} className="peer-card" data-peer-device-id={peerId || undefined}>
+			<div className="peer-title">
+				<strong title={peerId || undefined}>
+					{displayName}{" "}
+					<span className={`badge ${trustSummary.isWarning ? "badge-offline" : "badge-online"}`}>
+						{trustSummary.badgeLabel}
+					</span>
+					{pendingScopeReview ? (
+						<span className="badge actor-badge">Needs scope review</span>
+					) : null}
+				</strong>
 
-        <div className="peer-actions">
-          <input
-            aria-label={`Friendly name for ${displayName}`}
-            className="peer-scope-input"
-            data-device-name-input={peerId || undefined}
-            disabled={renameBusy}
-            placeholder="Friendly device name"
-            value={renameValue}
-            onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
-              setRenameValue(event.currentTarget.value)
-            }
-          />
-          <button disabled={renameBusy} onClick={() => void rename()}>
-            {renameLabel}
-          </button>
-          <button disabled={!primaryAddress || syncBusy} onClick={() => void sync()}>
-            {syncBusy ? 'Syncing…' : 'Sync now'}
-          </button>
-          <button disabled={removeBusy} onClick={() => void remove()}>
-            {removeLabel}
-          </button>
-          <PeerScopeCollapsible
-            contentHost={scopeHost}
-            initialOpen={scopeEditorOpen}
-            onOpenChange={(open) => {
-              if (open) openPeerScopeEditors.add(peerId);
-              else openPeerScopeEditors.delete(peerId);
-            }}
-          >
-            <div>
-              <div className="peer-scope-row">
-                <ExistingElementSlot element={includeEditor.element} />
-                <ExistingElementSlot element={excludeEditor.element} />
-              </div>
-              <div className="peer-scope-actions">
-                <button
-                  type="button"
-                  className="settings-button"
-                  disabled={saveScopeBusy}
-                  onClick={() => void saveScope()}
-                >
-                  {saveScopeLabel}
-                </button>
-                <button
-                  type="button"
-                  className="settings-button"
-                  disabled={resetScopeBusy}
-                  onClick={() => void resetScope()}
-                >
-                  {resetScopeLabel}
-                </button>
-              </div>
-            </div>
-          </PeerScopeCollapsible>
-        </div>
-      </div>
+				<div className="peer-actions">
+					<input
+						aria-label={`Friendly name for ${displayName}`}
+						className="peer-scope-input"
+						data-device-name-input={peerId || undefined}
+						disabled={renameBusy}
+						placeholder="Friendly device name"
+						value={renameValue}
+						onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
+							setRenameValue(event.currentTarget.value)
+						}
+					/>
+					<button type="button" disabled={renameBusy} onClick={() => void rename()}>
+						{renameLabel}
+					</button>
+					<button type="button" disabled={!primaryAddress || syncBusy} onClick={() => void sync()}>
+						{syncBusy ? "Syncing…" : "Sync now"}
+					</button>
+					<button type="button" disabled={removeBusy} onClick={() => void remove()}>
+						{removeLabel}
+					</button>
+					<PeerScopeCollapsible
+						contentHost={scopeHost}
+						initialOpen={scopeEditorOpen}
+						onOpenChange={(open) => {
+							if (open) openPeerScopeEditors.add(peerId);
+							else openPeerScopeEditors.delete(peerId);
+						}}
+					>
+						<div>
+							<div className="peer-scope-row">
+								<ExistingElementSlot element={includeEditor.element} />
+								<ExistingElementSlot element={excludeEditor.element} />
+							</div>
+							<div className="peer-scope-actions">
+								<button
+									type="button"
+									className="settings-button"
+									disabled={saveScopeBusy}
+									onClick={() => void saveScope()}
+								>
+									{saveScopeLabel}
+								</button>
+								<button
+									type="button"
+									className="settings-button"
+									disabled={resetScopeBusy}
+									onClick={() => void resetScope()}
+								>
+									{resetScopeLabel}
+								</button>
+							</div>
+						</div>
+					</PeerScopeCollapsible>
+				</div>
+			</div>
 
-      <div className="peer-addresses">{addressLine}</div>
-      <div className="peer-meta">
-        {[lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : 'Sync: never', lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : 'Ping: never'].join(' · ')}
-      </div>
+			<div className="peer-addresses">{addressLine}</div>
+			<div className="peer-meta">
+				{[
+					lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never",
+					lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : "Ping: never",
+				].join(" · ")}
+			</div>
 
-      <div className="peer-scope">
-        {scopeReviewRequested ? (
-          <div className="peer-meta">
-            Review this device&apos;s sharing scope now.
-          </div>
-        ) : pendingScopeReview ? (
-          <div className="peer-meta">Scope review still pending.</div>
-        ) : null}
+			<div className="peer-scope">
+				{scopeReviewRequested ? (
+					<div className="peer-meta">Review this device&apos;s sharing scope now.</div>
+				) : pendingScopeReview ? (
+					<div className="peer-meta">Scope review still pending.</div>
+				) : null}
 
-        <div className="peer-scope-summary">Assigned person</div>
-        <div className="peer-meta">
-          {peer.actor_display_name
-            ? `Assigned to ${peer.claimed_local_actor ? 'You' : String(peer.actor_display_name)}`
-            : 'Unassigned person'}
-        </div>
-        <div className="peer-actor-row">
-          <div className="sync-radix-select-host sync-actor-select-host">
-            <RadixSelect
-              ariaLabel={`Assigned person for ${displayName}`}
-              contentClassName="sync-radix-select-content sync-actor-select-content"
-              disabled={applyActorBusy}
-              itemClassName="sync-radix-select-item"
-              onValueChange={setSelectedActorId}
-              options={actorSelectOptions}
-              placeholder="No person assigned"
-              triggerClassName="sync-radix-select-trigger sync-actor-select"
-              value={selectedActorId}
-              viewportClassName="sync-radix-select-viewport"
-            />
-          </div>
-          <button className="settings-button" disabled={applyActorBusy} onClick={() => void savePerson()}>
-            {applyActorLabel}
-          </button>
-        </div>
-        <SyncInlineFeedback feedback={feedback} />
-        <div ref={setScopeHost} />
-      </div>
-    </div>
-  );
+				<div className="peer-scope-summary">Assigned person</div>
+				<div className="peer-meta">
+					{peer.actor_display_name
+						? `Assigned to ${peer.claimed_local_actor ? "You" : String(peer.actor_display_name)}`
+						: "Unassigned person"}
+				</div>
+				<div className="peer-actor-row">
+					<div className="sync-radix-select-host sync-actor-select-host">
+						<RadixSelect
+							ariaLabel={`Assigned person for ${displayName}`}
+							contentClassName="sync-radix-select-content sync-actor-select-content"
+							disabled={applyActorBusy}
+							itemClassName="sync-radix-select-item"
+							onValueChange={setSelectedActorId}
+							options={actorSelectOptions}
+							placeholder="No person assigned"
+							triggerClassName="sync-radix-select-trigger sync-actor-select"
+							value={selectedActorId}
+							viewportClassName="sync-radix-select-viewport"
+						/>
+					</div>
+					<button
+						type="button"
+						className="settings-button"
+						disabled={applyActorBusy}
+						onClick={() => void savePerson()}
+					>
+						{applyActorLabel}
+					</button>
+				</div>
+				<SyncInlineFeedback feedback={feedback} />
+				<div ref={setScopeHost} />
+			</div>
+		</div>
+	);
 }
 
 function SyncPeersList(props: SyncPeersListProps) {
-  const sectionFeedback = state.syncPeersSectionFeedback;
-  const syncStatus = state.lastSyncStatus as { daemon_state?: string; enabled?: boolean } | null;
-  const syncDisabled = syncStatus?.daemon_state === 'disabled' || syncStatus?.enabled === false;
-  if (!props.peers.length) {
-    return (
-      <>
-        <SyncInlineFeedback feedback={sectionFeedback} />
-        <div className="sync-empty-state">
-          <strong>No paired devices yet.</strong>
-          <span>
-            {syncDisabled
-              ? 'Turn on sync in Settings → Device Sync first, then use Show pairing in Advanced diagnostics to connect another device.'
-              : 'Use the Show pairing control in Advanced diagnostics, run the command on the other device, then come back here to name and assign it.'}
-          </span>
-        </div>
-      </>
-    );
-  }
+	const sectionFeedback = state.syncPeersSectionFeedback;
+	const syncStatus = state.lastSyncStatus as { daemon_state?: string; enabled?: boolean } | null;
+	const syncDisabled = syncStatus?.daemon_state === "disabled" || syncStatus?.enabled === false;
+	if (!props.peers.length) {
+		return (
+			<>
+				<SyncInlineFeedback feedback={sectionFeedback} />
+				<div className="sync-empty-state">
+					<strong>No paired devices yet.</strong>
+					<span>
+						{syncDisabled
+							? "Turn on sync in Settings → Device Sync first, then use Show pairing in Advanced diagnostics to connect another device."
+							: "Use the Show pairing control in Advanced diagnostics, run the command on the other device, then come back here to name and assign it."}
+					</span>
+				</div>
+			</>
+		);
+	}
 
-  return (
-    <>
-      <SyncInlineFeedback feedback={sectionFeedback} />
-      {props.peers.map((peer) => {
-        const peerId = String(peer.peer_device_id || peer.name || 'unknown-peer');
-        return <SyncPeerCard key={peerId} peer={peer} {...props} />;
-      })}
-    </>
-  );
+	return (
+		<>
+			<SyncInlineFeedback feedback={sectionFeedback} />
+			{props.peers.map((peer) => {
+				const peerId = String(peer.peer_device_id || peer.name || "unknown-peer");
+				return <SyncPeerCard key={peerId} peer={peer} {...props} />;
+			})}
+		</>
+	);
 }
 
 export function renderSyncPeersList(mount: HTMLElement, props: SyncPeersListProps) {
-  renderIntoSyncMount(mount, <SyncPeersList {...props} />);
+	renderIntoSyncMount(mount, <SyncPeersList {...props} />);
 }

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
@@ -1,54 +1,55 @@
 export interface SyncSharingReviewItem {
-  actorDisplayName: string;
-  actorId: string;
-  peerName: string;
-  privateCount: number;
-  scopeLabel: string;
-  shareableCount: number;
+	actorDisplayName: string;
+	actorId: string;
+	peerName: string;
+	privateCount: number;
+	scopeLabel: string;
+	shareableCount: number;
 }
 
 type SyncSharingReviewProps = {
-  items: SyncSharingReviewItem[];
-  onReview: () => void;
+	items: SyncSharingReviewItem[];
+	onReview: () => void;
 };
 
 function SharingReviewRow({
-  item,
-  onReview,
+	item,
+	onReview,
 }: {
-  item: SyncSharingReviewItem;
-  onReview: () => void;
+	item: SyncSharingReviewItem;
+	onReview: () => void;
 }) {
-  return (
-    <div className="actor-row">
-      <div className="actor-details">
-        <div className="actor-title">
-          <strong>{item.peerName}</strong>
-          <span className="badge actor-badge">person: {item.actorDisplayName || item.actorId}</span>
-        </div>
-        <div className="peer-meta">
-          {item.shareableCount} share by default · {item.privateCount} marked Only me · {item.scopeLabel}
-        </div>
-      </div>
-      <div className="actor-actions">
-        <button type="button" className="settings-button" onClick={onReview}>
-          Review my memories in Feed
-        </button>
-      </div>
-    </div>
-  );
+	return (
+		<div className="actor-row">
+			<div className="actor-details">
+				<div className="actor-title">
+					<strong>{item.peerName}</strong>
+					<span className="badge actor-badge">person: {item.actorDisplayName || item.actorId}</span>
+				</div>
+				<div className="peer-meta">
+					{item.shareableCount} share by default · {item.privateCount} marked Only me ·{" "}
+					{item.scopeLabel}
+				</div>
+			</div>
+			<div className="actor-actions">
+				<button type="button" className="settings-button" onClick={onReview}>
+					Review my memories in Feed
+				</button>
+			</div>
+		</div>
+	);
 }
 
 export function SyncSharingReview({ items, onReview }: SyncSharingReviewProps) {
-  return (
-    <>
-      {items.map((item) => (
-        <SharingReviewRow
-          key={`${item.peerName}:${item.actorId}:${item.scopeLabel}`}
-          item={item}
-          onReview={onReview}
-        />
-      ))}
-    </>
-  );
+	return (
+		<>
+			{items.map((item) => (
+				<SharingReviewRow
+					key={`${item.peerName}:${item.actorId}:${item.scopeLabel}`}
+					item={item}
+					onReview={onReview}
+				/>
+			))}
+		</>
+	);
 }

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -1,300 +1,301 @@
-import { createPortal } from 'preact/compat';
-import type { ComponentChildren } from 'preact';
-import { useState } from 'preact/hooks';
-import { state } from '../../../lib/state';
-import type { UiSyncAttentionItem } from '../view-model';
-import type { SyncActionFeedback } from './sync-inline-feedback';
-import { SyncInlineFeedback } from './sync-inline-feedback';
+import type { ComponentChildren } from "preact";
+import { createPortal } from "preact/compat";
+import { useState } from "preact/hooks";
+import { state } from "../../../lib/state";
+import type { UiSyncAttentionItem } from "../view-model";
+import type { SyncActionFeedback } from "./sync-inline-feedback";
+import { SyncInlineFeedback } from "./sync-inline-feedback";
 
 export interface TeamSyncStatusSummary {
-  badgeClassName: string;
-  headline: string | null;
-  presenceLabel: string;
-  metricsText: string;
+	badgeClassName: string;
+	headline: string | null;
+	presenceLabel: string;
+	metricsText: string;
 }
 
 export interface TeamSyncDiscoveredRow {
-  actionMessage: string | null;
-  actionLabel: string | null;
-  approvalBadgeLabel: string | null;
-  availabilityLabel: string;
-  deviceId: string;
-  displayName: string;
-  displayTitle: string | null;
-  fingerprint: string;
-  mode: 'accept' | 'ambiguous' | 'conflict' | 'none' | 'paired' | 'scope-pending' | 'stale';
-  note: string;
-  pairedMessage: string | null;
-  connectionLabel: string;
+	actionMessage: string | null;
+	actionLabel: string | null;
+	approvalBadgeLabel: string | null;
+	availabilityLabel: string;
+	deviceId: string;
+	displayName: string;
+	displayTitle: string | null;
+	fingerprint: string;
+	mode: "accept" | "ambiguous" | "conflict" | "none" | "paired" | "scope-pending" | "stale";
+	note: string;
+	pairedMessage: string | null;
+	connectionLabel: string;
 }
 
 export interface TeamSyncPendingJoinRequest {
-  displayName: string;
-  requestId: string;
+	displayName: string;
+	requestId: string;
 }
 
 type TeamSyncPanelProps = {
-  actionItems: UiSyncAttentionItem[];
-  actionableCount: number;
-  children?: ComponentChildren;
-  discoveredListMount: HTMLElement | null;
-  discoveredRows: TeamSyncDiscoveredRow[];
-  joinRequestsMount: HTMLElement | null;
-  listMount: HTMLElement;
-  onApproveJoinRequest: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
-  onAttentionAction: (item: UiSyncAttentionItem) => Promise<void>;
-  onDenyJoinRequest: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
-  onInspectConflict: (row: TeamSyncDiscoveredRow) => void;
-  onRemoveConflict: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
-  onReviewDiscoveredDevice: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
-  pendingJoinRequests: TeamSyncPendingJoinRequest[];
-  presenceStatus: string;
-  statusSummary: TeamSyncStatusSummary;
+	actionItems: UiSyncAttentionItem[];
+	actionableCount: number;
+	children?: ComponentChildren;
+	discoveredListMount: HTMLElement | null;
+	discoveredRows: TeamSyncDiscoveredRow[];
+	joinRequestsMount: HTMLElement | null;
+	listMount: HTMLElement;
+	onApproveJoinRequest: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
+	onAttentionAction: (item: UiSyncAttentionItem) => Promise<void>;
+	onDenyJoinRequest: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
+	onInspectConflict: (row: TeamSyncDiscoveredRow) => void;
+	onRemoveConflict: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
+	onReviewDiscoveredDevice: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
+	pendingJoinRequests: TeamSyncPendingJoinRequest[];
+	presenceStatus: string;
+	statusSummary: TeamSyncStatusSummary;
 };
 
-function SectionHeading({
-  count,
-  label,
-}: {
-  count?: number;
-  label: string;
-}) {
-  return (
-    <div className="sync-section-heading">
-      <div className="sync-action-text sync-section-label">{label}</div>
-      {count ? <span className="badge actor-badge sync-section-count">{count}</span> : null}
-    </div>
-  );
+function SectionHeading({ count, label }: { count?: number; label: string }) {
+	return (
+		<div className="sync-section-heading">
+			<div className="sync-action-text sync-section-label">{label}</div>
+			{count ? <span className="badge actor-badge sync-section-count">{count}</span> : null}
+		</div>
+	);
 }
 
 function AttentionRow({
-  item,
-  onAction,
+	item,
+	onAction,
 }: {
-  item: UiSyncAttentionItem;
-  onAction: (item: UiSyncAttentionItem) => Promise<void>;
+	item: UiSyncAttentionItem;
+	onAction: (item: UiSyncAttentionItem) => Promise<void>;
 }) {
-  const [busy, setBusy] = useState(false);
+	const [busy, setBusy] = useState(false);
 
-  return (
-    <div className="sync-action">
-      <div className="sync-action-text">
-        {item.title}
-        <span className="sync-action-command">{item.summary}</span>
-      </div>
-      <button
-        type="button"
-        className="settings-button"
-        disabled={busy}
-        onClick={async () => {
-          setBusy(true);
-          try {
-            await onAction(item);
-          } finally {
-            setBusy(false);
-          }
-        }}
-      >
-        {item.actionLabel || 'Review'}
-      </button>
-    </div>
-  );
+	return (
+		<div className="sync-action">
+			<div className="sync-action-text">
+				{item.title}
+				<span className="sync-action-command">{item.summary}</span>
+			</div>
+			<button
+				type="button"
+				className="settings-button"
+				disabled={busy}
+				onClick={async () => {
+					setBusy(true);
+					try {
+						await onAction(item);
+					} finally {
+						setBusy(false);
+					}
+				}}
+			>
+				{item.actionLabel || "Review"}
+			</button>
+		</div>
+	);
 }
 
-
 function PendingJoinRequestRow({
-  request,
-  onApprove,
-  onDeny,
+	request,
+	onApprove,
+	onDeny,
 }: {
-  request: TeamSyncPendingJoinRequest;
-  onApprove: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
-  onDeny: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
+	request: TeamSyncPendingJoinRequest;
+	onApprove: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
+	onDeny: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
 }) {
-  const [busyAction, setBusyAction] = useState<'approve' | 'deny' | null>(null);
-  const [feedback, setFeedback] = useState<SyncActionFeedback | null>(null);
-  const [approveLabel, setApproveLabel] = useState('Approve');
-  const [denyLabel, setDenyLabel] = useState('Deny');
+	const [busyAction, setBusyAction] = useState<"approve" | "deny" | null>(null);
+	const [feedback, setFeedback] = useState<SyncActionFeedback | null>(null);
+	const [approveLabel, setApproveLabel] = useState("Approve");
+	const [denyLabel, setDenyLabel] = useState("Deny");
 
-  return (
-    <div className="actor-row">
-      <div className="actor-details">
-        <div className="actor-title" title={request.requestId || undefined}>{request.displayName}</div>
-      </div>
-      <div className="actor-actions">
-        <button
-          type="button"
-          className="settings-button"
-          disabled={busyAction !== null}
-          onClick={async () => {
-            setBusyAction('approve');
-            setApproveLabel('Approving…');
-            try {
-              setFeedback((await onApprove(request)) || null);
-              setApproveLabel('Approve');
-            } catch {
-              setApproveLabel('Retry');
-            } finally {
-              setBusyAction(null);
-            }
-          }}
-        >
-          {approveLabel}
-        </button>
-        <button
-          type="button"
-          className="settings-button"
-          disabled={busyAction !== null}
-          onClick={async () => {
-            setBusyAction('deny');
-            setDenyLabel('Denying…');
-            try {
-              setFeedback((await onDeny(request)) || null);
-              setDenyLabel('Deny');
-            } catch {
-              setDenyLabel('Retry');
-            } finally {
-              setBusyAction(null);
-            }
-          }}
-        >
-          {denyLabel}
-        </button>
-      </div>
-      <SyncInlineFeedback feedback={feedback} />
-    </div>
-  );
+	return (
+		<div className="actor-row">
+			<div className="actor-details">
+				<div className="actor-title" title={request.requestId || undefined}>
+					{request.displayName}
+				</div>
+			</div>
+			<div className="actor-actions">
+				<button
+					type="button"
+					className="settings-button"
+					disabled={busyAction !== null}
+					onClick={async () => {
+						setBusyAction("approve");
+						setApproveLabel("Approving…");
+						try {
+							setFeedback((await onApprove(request)) || null);
+							setApproveLabel("Approve");
+						} catch {
+							setApproveLabel("Retry");
+						} finally {
+							setBusyAction(null);
+						}
+					}}
+				>
+					{approveLabel}
+				</button>
+				<button
+					type="button"
+					className="settings-button"
+					disabled={busyAction !== null}
+					onClick={async () => {
+						setBusyAction("deny");
+						setDenyLabel("Denying…");
+						try {
+							setFeedback((await onDeny(request)) || null);
+							setDenyLabel("Deny");
+						} catch {
+							setDenyLabel("Retry");
+						} finally {
+							setBusyAction(null);
+						}
+					}}
+				>
+					{denyLabel}
+				</button>
+			</div>
+			<SyncInlineFeedback feedback={feedback} />
+		</div>
+	);
 }
 
 function DiscoveredDeviceRow({
-  row,
-  onInspectConflict,
-  onRemoveConflict,
-  onReview,
+	row,
+	onInspectConflict,
+	onRemoveConflict,
+	onReview,
 }: {
-  row: TeamSyncDiscoveredRow;
-  onInspectConflict: (row: TeamSyncDiscoveredRow) => void;
-  onRemoveConflict: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
-  onReview: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
+	row: TeamSyncDiscoveredRow;
+	onInspectConflict: (row: TeamSyncDiscoveredRow) => void;
+	onRemoveConflict: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
+	onReview: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
 }) {
-  const [busy, setBusy] = useState<'remove' | 'review' | null>(null);
-  const [feedback, setFeedback] = useState<SyncActionFeedback | null>(null);
-  const [reviewLabel, setReviewLabel] = useState(row.actionLabel || 'Review device');
-  const [removeLabel, setRemoveLabel] = useState('Remove broken device record');
+	const [busy, setBusy] = useState<"remove" | "review" | null>(null);
+	const [feedback, setFeedback] = useState<SyncActionFeedback | null>(null);
+	const [reviewLabel, setReviewLabel] = useState(row.actionLabel || "Review device");
+	const [removeLabel, setRemoveLabel] = useState("Remove broken device record");
 
-  return (
-    <div className="actor-row" data-discovered-device-id={row.deviceId}>
-      <div className="actor-details">
-        <div className="actor-title">
-          <strong title={row.displayTitle || undefined}>{row.displayName}</strong>
-          <span className={`badge actor-badge${row.availabilityLabel === 'Offline' ? '' : ' local'}`}>
-            {row.availabilityLabel}
-          </span>
-          <span className="badge actor-badge">{row.connectionLabel}</span>
-          {row.approvalBadgeLabel ? (
-            <span className="badge actor-badge">{row.approvalBadgeLabel}</span>
-          ) : null}
-        </div>
-        <div className="peer-meta">{row.note}</div>
-      </div>
-      <div className="actor-actions">
-        {row.mode === 'accept' ? (
-          <button
-            type="button"
-            className="settings-button"
-            disabled={busy !== null}
-              onClick={async () => {
-                setBusy('review');
-                setReviewLabel('Reviewing…');
-                try {
-                  setFeedback((await onReview(row)) || null);
-                  setReviewLabel(row.actionLabel || 'Review device');
-                } catch {
-                  setReviewLabel('Retry');
-                } finally {
-                  setBusy(null);
-                }
-            }}
-          >
-            {reviewLabel}
-          </button>
-        ) : null}
-        {(row.mode === 'stale' || row.mode === 'ambiguous' || row.mode === 'scope-pending') && row.actionMessage ? (
-          <div className="peer-meta">{row.actionMessage}</div>
-        ) : null}
-        {row.mode === 'paired' && row.pairedMessage ? (
-          <div className="peer-meta">{row.pairedMessage}</div>
-        ) : null}
-        {row.mode === 'conflict' ? (
-          <>
-            <button
-              type="button"
-              className="settings-button"
-              disabled={busy !== null}
-              onClick={() => onInspectConflict(row)}
-            >
-              Open device details
-            </button>
-            <button
-              type="button"
-              className="settings-button"
-              disabled={busy !== null}
-              onClick={async () => {
-                setBusy('remove');
-                setRemoveLabel('Removing…');
-                try {
-                  setFeedback((await onRemoveConflict(row)) || null);
-                  setRemoveLabel('Remove broken device record');
-                } catch {
-                  setRemoveLabel('Retry');
-                } finally {
-                  setBusy(null);
-                }
-              }}
-            >
-              {removeLabel}
-            </button>
-          </>
-        ) : null}
-      </div>
-      <SyncInlineFeedback feedback={feedback} />
-    </div>
-  );
+	return (
+		<div className="actor-row" data-discovered-device-id={row.deviceId}>
+			<div className="actor-details">
+				<div className="actor-title">
+					<strong title={row.displayTitle || undefined}>{row.displayName}</strong>
+					<span
+						className={`badge actor-badge${row.availabilityLabel === "Offline" ? "" : " local"}`}
+					>
+						{row.availabilityLabel}
+					</span>
+					<span className="badge actor-badge">{row.connectionLabel}</span>
+					{row.approvalBadgeLabel ? (
+						<span className="badge actor-badge">{row.approvalBadgeLabel}</span>
+					) : null}
+				</div>
+				<div className="peer-meta">{row.note}</div>
+			</div>
+			<div className="actor-actions">
+				{row.mode === "accept" ? (
+					<button
+						type="button"
+						className="settings-button"
+						disabled={busy !== null}
+						onClick={async () => {
+							setBusy("review");
+							setReviewLabel("Reviewing…");
+							try {
+								setFeedback((await onReview(row)) || null);
+								setReviewLabel(row.actionLabel || "Review device");
+							} catch {
+								setReviewLabel("Retry");
+							} finally {
+								setBusy(null);
+							}
+						}}
+					>
+						{reviewLabel}
+					</button>
+				) : null}
+				{(row.mode === "stale" || row.mode === "ambiguous" || row.mode === "scope-pending") &&
+				row.actionMessage ? (
+					<div className="peer-meta">{row.actionMessage}</div>
+				) : null}
+				{row.mode === "paired" && row.pairedMessage ? (
+					<div className="peer-meta">{row.pairedMessage}</div>
+				) : null}
+				{row.mode === "conflict" ? (
+					<>
+						<button
+							type="button"
+							className="settings-button"
+							disabled={busy !== null}
+							onClick={() => onInspectConflict(row)}
+						>
+							Open device details
+						</button>
+						<button
+							type="button"
+							className="settings-button"
+							disabled={busy !== null}
+							onClick={async () => {
+								setBusy("remove");
+								setRemoveLabel("Removing…");
+								try {
+									setFeedback((await onRemoveConflict(row)) || null);
+									setRemoveLabel("Remove broken device record");
+								} catch {
+									setRemoveLabel("Retry");
+								} finally {
+									setBusy(null);
+								}
+							}}
+						>
+							{removeLabel}
+						</button>
+					</>
+				) : null}
+			</div>
+			<SyncInlineFeedback feedback={feedback} />
+		</div>
+	);
 }
 
 function ActionContent(props: TeamSyncPanelProps) {
-  const hasAttentionItems = props.actionItems.length > 0;
-  const hasOtherActionableWork = props.actionableCount > props.actionItems.length;
-  const showNextStepsLabel = hasAttentionItems || hasOtherActionableWork || props.presenceStatus !== 'posted';
+	const hasAttentionItems = props.actionItems.length > 0;
+	const hasOtherActionableWork = props.actionableCount > props.actionItems.length;
+	const showNextStepsLabel =
+		hasAttentionItems || hasOtherActionableWork || props.presenceStatus !== "posted";
 
-  return (
-    <>
-      {showNextStepsLabel ? <SectionHeading label="Next steps" /> : null}
-      {hasAttentionItems
-        ? props.actionItems.map((item) => (
-            <AttentionRow key={item.id} item={item} onAction={props.onAttentionAction} />
-          ))
-        : null}
-      {!hasAttentionItems && !hasOtherActionableWork && props.presenceStatus === 'posted' ? (
-        <div className="sync-action">
-          <div className="sync-action-text">Everything is healthy.</div>
-        </div>
-      ) : null}
-      {!hasAttentionItems && hasOtherActionableWork && props.presenceStatus === 'posted' ? (
-        <div className="sync-action">
-          <div className="sync-action-text">Review the team items below when you are ready.</div>
-        </div>
-      ) : null}
-      {!hasAttentionItems && props.presenceStatus === 'not_enrolled' ? (
-        <div className="sync-action">
-          <div className="sync-action-text">
-            This device needs team enrollment
-            <span className="sync-action-command">Import an invite or ask an admin to enroll it.</span>
-          </div>
-        </div>
-      ) : null}
-    </>
-  );
+	return (
+		<>
+			{showNextStepsLabel ? <SectionHeading label="Next steps" /> : null}
+			{hasAttentionItems
+				? props.actionItems.map((item) => (
+						<AttentionRow key={item.id} item={item} onAction={props.onAttentionAction} />
+					))
+				: null}
+			{!hasAttentionItems && !hasOtherActionableWork && props.presenceStatus === "posted" ? (
+				<div className="sync-action">
+					<div className="sync-action-text">Everything is healthy.</div>
+				</div>
+			) : null}
+			{!hasAttentionItems && hasOtherActionableWork && props.presenceStatus === "posted" ? (
+				<div className="sync-action">
+					<div className="sync-action-text">Review the team items below when you are ready.</div>
+				</div>
+			) : null}
+			{!hasAttentionItems && props.presenceStatus === "not_enrolled" ? (
+				<div className="sync-action">
+					<div className="sync-action-text">
+						This device needs team enrollment
+						<span className="sync-action-command">
+							Import an invite or ask an admin to enroll it.
+						</span>
+					</div>
+				</div>
+			) : null}
+		</>
+	);
 }
 
 function TeamActionsContent({ children }: { children?: ComponentChildren }) {
@@ -308,105 +309,109 @@ function TeamActionsContent({ children }: { children?: ComponentChildren }) {
 }
 
 function TeamStatusPortal({
-  mount,
-  statusSummary,
+	mount,
+	statusSummary,
 }: {
-  mount: HTMLElement;
-  statusSummary: TeamSyncStatusSummary;
+	mount: HTMLElement;
+	statusSummary: TeamSyncStatusSummary;
 }) {
-  return createPortal(
-    <div className="sync-team-summary">
-      <div className="sync-team-status-row">
-        <span className="sync-team-status-label">Team status</span>
-        <span className={statusSummary.badgeClassName}>{statusSummary.presenceLabel}</span>
-      </div>
-      {statusSummary.headline ? <div className="sync-team-headline">{statusSummary.headline}</div> : null}
-      <div className="sync-team-metrics sync-team-metrics-secondary">{statusSummary.metricsText}</div>
-    </div>,
-    mount,
-  );
+	return createPortal(
+		<div className="sync-team-summary">
+			<div className="sync-team-status-row">
+				<span className="sync-team-status-label">Team status</span>
+				<span className={statusSummary.badgeClassName}>{statusSummary.presenceLabel}</span>
+			</div>
+			{statusSummary.headline ? (
+				<div className="sync-team-headline">{statusSummary.headline}</div>
+			) : null}
+			<div className="sync-team-metrics sync-team-metrics-secondary">
+				{statusSummary.metricsText}
+			</div>
+		</div>,
+		mount,
+	);
 }
 
 function DiscoveredPortal({
-  mount,
-  rows,
-  onInspectConflict,
-  onRemoveConflict,
-  onReview,
+	mount,
+	rows,
+	onInspectConflict,
+	onRemoveConflict,
+	onReview,
 }: {
-  mount: HTMLElement | null;
-  rows: TeamSyncDiscoveredRow[];
-  onInspectConflict: (row: TeamSyncDiscoveredRow) => void;
-  onRemoveConflict: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
-  onReview: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
+	mount: HTMLElement | null;
+	rows: TeamSyncDiscoveredRow[];
+	onInspectConflict: (row: TeamSyncDiscoveredRow) => void;
+	onRemoveConflict: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
+	onReview: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
 }) {
-  if (!mount || (!rows.length && !state.syncDiscoveredFeedback)) return null;
-  return createPortal(
-    <>
-      <SectionHeading count={rows.length || undefined} label="Devices seen on team" />
-      <SyncInlineFeedback feedback={state.syncDiscoveredFeedback} />
-      {rows.map((row) => (
-        <DiscoveredDeviceRow
-          key={row.deviceId}
-          row={row}
-          onInspectConflict={onInspectConflict}
-          onRemoveConflict={onRemoveConflict}
-          onReview={onReview}
-        />
-      ))}
-    </>,
-    mount,
-  );
+	if (!mount || (!rows.length && !state.syncDiscoveredFeedback)) return null;
+	return createPortal(
+		<>
+			<SectionHeading count={rows.length || undefined} label="Devices seen on team" />
+			<SyncInlineFeedback feedback={state.syncDiscoveredFeedback} />
+			{rows.map((row) => (
+				<DiscoveredDeviceRow
+					key={row.deviceId}
+					row={row}
+					onInspectConflict={onInspectConflict}
+					onRemoveConflict={onRemoveConflict}
+					onReview={onReview}
+				/>
+			))}
+		</>,
+		mount,
+	);
 }
 
 function PendingRequestsPortal({
-  mount,
-  requests,
-  onApprove,
-  onDeny,
+	mount,
+	requests,
+	onApprove,
+	onDeny,
 }: {
-  mount: HTMLElement | null;
-  requests: TeamSyncPendingJoinRequest[];
-  onApprove: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
-  onDeny: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
+	mount: HTMLElement | null;
+	requests: TeamSyncPendingJoinRequest[];
+	onApprove: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
+	onDeny: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
 }) {
-  if (!mount || (!requests.length && !state.syncJoinRequestsFeedback)) return null;
-  return createPortal(
-    <>
-      <SectionHeading count={requests.length || undefined} label="Pending join requests" />
-      <SyncInlineFeedback feedback={state.syncJoinRequestsFeedback} />
-      {requests.map((request) => (
-        <PendingJoinRequestRow
-          key={request.requestId}
-          request={request}
-          onApprove={onApprove}
-          onDeny={onDeny}
-        />
-      ))}
-    </>,
-    mount,
-  );
+	if (!mount || (!requests.length && !state.syncJoinRequestsFeedback)) return null;
+	return createPortal(
+		<>
+			<SectionHeading count={requests.length || undefined} label="Pending join requests" />
+			<SyncInlineFeedback feedback={state.syncJoinRequestsFeedback} />
+			{requests.map((request) => (
+				<PendingJoinRequestRow
+					key={request.requestId}
+					request={request}
+					onApprove={onApprove}
+					onDeny={onDeny}
+				/>
+			))}
+		</>,
+		mount,
+	);
 }
 
 export function TeamSyncPanel(props: TeamSyncPanelProps) {
-  return (
-    <>
-      <ActionContent {...props} />
-      <TeamActionsContent>{props.children}</TeamActionsContent>
-      <TeamStatusPortal mount={props.listMount} statusSummary={props.statusSummary} />
-      <PendingRequestsPortal
-        mount={props.joinRequestsMount}
-        requests={props.pendingJoinRequests}
-        onApprove={props.onApproveJoinRequest}
-        onDeny={props.onDenyJoinRequest}
-      />
-      <DiscoveredPortal
-        mount={props.discoveredListMount}
-        rows={props.discoveredRows}
-        onInspectConflict={props.onInspectConflict}
-        onRemoveConflict={props.onRemoveConflict}
-        onReview={props.onReviewDiscoveredDevice}
-      />
-    </>
-  );
+	return (
+		<>
+			<ActionContent {...props} />
+			<TeamActionsContent>{props.children}</TeamActionsContent>
+			<TeamStatusPortal mount={props.listMount} statusSummary={props.statusSummary} />
+			<PendingRequestsPortal
+				mount={props.joinRequestsMount}
+				requests={props.pendingJoinRequests}
+				onApprove={props.onApproveJoinRequest}
+				onDeny={props.onDenyJoinRequest}
+			/>
+			<DiscoveredPortal
+				mount={props.discoveredListMount}
+				rows={props.discoveredRows}
+				onInspectConflict={props.onInspectConflict}
+				onRemoveConflict={props.onRemoveConflict}
+				onReview={props.onReviewDiscoveredDevice}
+			/>
+		</>
+	);
 }

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -1,476 +1,488 @@
 /* Diagnostics card — sync status grid, attempts log, pairing. */
 
-import { h } from 'preact';
-import { RadixSwitch } from '../../components/primitives/radix-switch';
-import { copyToClipboard } from '../../lib/dom';
-import { formatAgeShort, formatTimestamp, secondsSince, titleCase } from '../../lib/format';
-import { state, setSyncPairingOpen, isSyncRedactionEnabled, setSyncRedactionEnabled } from '../../lib/state';
-import { renderIntoSyncMount } from './components/render-root';
-import { renderPairingDisclosure } from './components/sync-disclosure';
+import { h } from "preact";
+import { RadixSwitch } from "../../components/primitives/radix-switch";
+import { copyToClipboard } from "../../lib/dom";
+import { formatAgeShort, formatTimestamp, secondsSince, titleCase } from "../../lib/format";
 import {
-  renderAttemptsList,
-  renderDiagnosticsGrid,
-  renderPairingView,
-  renderSyncEmptyState,
-  type PairingView,
-  type SyncAttemptItem,
-  type SyncStatItem,
-} from './components/sync-diagnostics';
-import { redactAddress, renderActionList, hideSkeleton } from './helpers';
+	isSyncRedactionEnabled,
+	setSyncPairingOpen,
+	setSyncRedactionEnabled,
+	state,
+} from "../../lib/state";
+import { renderIntoSyncMount } from "./components/render-root";
+import {
+	type PairingView,
+	renderAttemptsList,
+	renderDiagnosticsGrid,
+	renderPairingView,
+	renderSyncEmptyState,
+	type SyncAttemptItem,
+	type SyncStatItem,
+} from "./components/sync-diagnostics";
+import { renderPairingDisclosure } from "./components/sync-disclosure";
+import { hideSkeleton, renderActionList } from "./helpers";
 
 type SyncRetention = {
-  enabled?: boolean;
-  last_deleted_ops?: number | string;
-  last_error?: string;
-  last_run_at?: string | null;
+	enabled?: boolean;
+	last_deleted_ops?: number | string;
+	last_error?: string;
+	last_run_at?: string | null;
 };
 
 type SyncPayloadState = {
-  seconds_since_last?: number;
+	seconds_since_last?: number;
 };
 
 type PingPayloadState = SyncPayloadState & {
-  last_ping_at?: string | null;
+	last_ping_at?: string | null;
 };
 
 type SyncStatusState = {
 	daemon_detail?: string;
-  daemon_state?: string;
-  enabled?: boolean;
-  last_ping_at?: string | null;
-  last_ping_error?: string;
-  last_sync_at?: string | null;
-  last_sync_at_utc?: string | null;
-  last_sync_error?: string;
-  pending?: number | string;
-  peers?: Record<string, unknown>;
-  ping?: PingPayloadState;
-  retention?: SyncRetention;
-  sync?: SyncPayloadState;
+	daemon_state?: string;
+	enabled?: boolean;
+	last_ping_at?: string | null;
+	last_ping_error?: string;
+	last_sync_at?: string | null;
+	last_sync_at_utc?: string | null;
+	last_sync_error?: string;
+	pending?: number | string;
+	peers?: Record<string, unknown>;
+	ping?: PingPayloadState;
+	retention?: SyncRetention;
+	sync?: SyncPayloadState;
 };
 
 type SyncAttemptState = {
-  address?: string;
-  error?: string;
-  finished_at?: string;
-  ops_in?: number;
-  ops_out?: number;
-  peer_device_id?: string;
-  started_at?: string;
-  started_at_utc?: string;
-  status?: string;
+	address?: string;
+	error?: string;
+	finished_at?: string;
+	ops_in?: number;
+	ops_out?: number;
+	peer_device_id?: string;
+	started_at?: string;
+	started_at_utc?: string;
+	status?: string;
 };
 
 type PairingPayloadState = Record<string, unknown> & {
-  addresses?: unknown[];
-  redacted?: boolean;
+	addresses?: unknown[];
+	redacted?: boolean;
 };
 
-
-
-const SYNC_REDACT_MOUNT_ID = 'syncRedactMount';
-const SYNC_REDACT_LABEL_ID = 'syncRedactLabel';
+const SYNC_REDACT_MOUNT_ID = "syncRedactMount";
+const SYNC_REDACT_LABEL_ID = "syncRedactLabel";
 
 function newestPeerPing(peers: Record<string, unknown> | null | undefined): string | null {
-  const timestamps = Object.values(peers || {})
-    .map((peer) => {
-      if (!peer || typeof peer !== 'object') return '';
-      return String((peer as { last_ping_at?: string | null }).last_ping_at || '').trim();
-    })
-    .filter(Boolean)
-    .sort();
-  return timestamps.length ? timestamps[timestamps.length - 1]! : null;
+	const timestamps = Object.values(peers || {})
+		.map((peer) => {
+			if (!peer || typeof peer !== "object") return "";
+			return String((peer as { last_ping_at?: string | null }).last_ping_at || "").trim();
+		})
+		.filter(Boolean)
+		.sort();
+	return timestamps[timestamps.length - 1] ?? null;
 }
 
 /* ── Import render functions needed for redact toggle ────── */
 // These are set by the index module to avoid circular imports.
 let _renderSyncPeers: () => void = () => {};
 export function setRenderSyncPeers(fn: () => void) {
-  _renderSyncPeers = fn;
+	_renderSyncPeers = fn;
 }
 
 let _refreshPairing: () => void = () => {};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+	return typeof value === "object" && value !== null;
 }
 
 function pairingView(payload: unknown): PairingView {
-  if (!isRecord(payload)) {
-    state.pairingCommandRaw = '';
-    return {
-      payloadText: 'Pairing not available',
-      hintText: 'Enable sync and retry.',
-    };
-  }
+	if (!isRecord(payload)) {
+		state.pairingCommandRaw = "";
+		return {
+			payloadText: "Pairing not available",
+			hintText: "Enable sync and retry.",
+		};
+	}
 
-  const pairingPayload = payload as PairingPayloadState;
-  if (pairingPayload.redacted) {
-    state.pairingCommandRaw = '';
-    return {
-      payloadText: 'Pairing payload hidden',
-      hintText: 'Diagnostics are required to view the pairing payload.',
-    };
-  }
+	const pairingPayload = payload as PairingPayloadState;
+	if (pairingPayload.redacted) {
+		state.pairingCommandRaw = "";
+		return {
+			payloadText: "Pairing payload hidden",
+			hintText: "Diagnostics are required to view the pairing payload.",
+		};
+	}
 
-  const safePayload = {
-    ...pairingPayload,
-    addresses: Array.isArray(pairingPayload.addresses) ? pairingPayload.addresses : [],
-  };
-  const compact = JSON.stringify(safePayload);
-  const b64 = btoa(compact);
-  const command = `echo '${b64}' | base64 -d | codemem sync pair --accept-file -`;
-  state.pairingCommandRaw = command;
-  return {
-    payloadText: command,
-    hintText:
-      'Copy this command and run it on the other device. Use --include/--exclude to control which projects sync.',
-  };
+	const safePayload = {
+		...pairingPayload,
+		addresses: Array.isArray(pairingPayload.addresses) ? pairingPayload.addresses : [],
+	};
+	const compact = JSON.stringify(safePayload);
+	const b64 = btoa(compact);
+	const command = `echo '${b64}' | base64 -d | codemem sync pair --accept-file -`;
+	state.pairingCommandRaw = command;
+	return {
+		payloadText: command,
+		hintText:
+			"Copy this command and run it on the other device. Use --include/--exclude to control which projects sync.",
+	};
 }
 
 function diagnosticsLoadingState() {
-  return {
-    title: 'Diagnostics still loading.',
-    detail: 'Wait a moment for local sync status. If it stays blank, refresh the page or check whether sync is enabled on this device.',
-  };
+	return {
+		title: "Diagnostics still loading.",
+		detail:
+			"Wait a moment for local sync status. If it stays blank, refresh the page or check whether sync is enabled on this device.",
+	};
 }
 
 function diagnosticsUnavailableState() {
-  return {
-    title: 'Diagnostics unavailable right now.',
-    detail: 'The viewer could not load sync status. Refresh this page, or check that the local codemem sync service is reachable before retrying.',
-  };
+	return {
+		title: "Diagnostics unavailable right now.",
+		detail:
+			"The viewer could not load sync status. Refresh this page, or check that the local codemem sync service is reachable before retrying.",
+	};
 }
 
 function noAttemptsState() {
-  const syncStatus = state.lastSyncStatus as { daemon_state?: string; enabled?: boolean } | null;
-  const syncDisabled = syncStatus?.daemon_state === 'disabled' || syncStatus?.enabled === false;
-  return {
-    title: 'No recent sync attempts yet.',
-    detail: syncDisabled
-      ? 'Turn on sync in Settings → Device Sync first. Recent attempts will appear here after this device can actually run sync work.'
-      : 'Trigger a sync pass or pair another device to generate activity here when you need low-level troubleshooting.',
-  };
+	const syncStatus = state.lastSyncStatus as { daemon_state?: string; enabled?: boolean } | null;
+	const syncDisabled = syncStatus?.daemon_state === "disabled" || syncStatus?.enabled === false;
+	return {
+		title: "No recent sync attempts yet.",
+		detail: syncDisabled
+			? "Turn on sync in Settings → Device Sync first. Recent attempts will appear here after this device can actually run sync work."
+			: "Trigger a sync pass or pair another device to generate activity here when you need low-level troubleshooting.",
+	};
 }
 
 function unavailableAttemptsState() {
-  return {
-    title: 'Recent attempts unavailable right now.',
-    detail: 'Attempt history could not be loaded because sync diagnostics failed. Refresh the page after local sync status is reachable again.',
-  };
+	return {
+		title: "Recent attempts unavailable right now.",
+		detail:
+			"Attempt history could not be loaded because sync diagnostics failed. Refresh the page after local sync status is reachable again.",
+	};
 }
 
 /* ── Sync status renderer ────────────────────────────────── */
 
 export function renderSyncStatus() {
-  const syncStatusGrid = document.getElementById('syncStatusGrid');
-  const syncMeta = document.getElementById('syncMeta');
-  const syncActions = document.getElementById('syncActions');
-  if (!syncStatusGrid) return;
+	const syncStatusGrid = document.getElementById("syncStatusGrid");
+	const syncMeta = document.getElementById("syncMeta");
+	const syncActions = document.getElementById("syncActions");
+	if (!syncStatusGrid) return;
 
-  hideSkeleton('syncDiagSkeleton');
+	hideSkeleton("syncDiagSkeleton");
 
-  const status = state.lastSyncStatus as SyncStatusState | null;
-  if (!status) {
-    renderSyncEmptyState(syncStatusGrid, diagnosticsLoadingState());
-    renderActionList(syncActions, []);
-    if (syncMeta) syncMeta.textContent = 'Loading advanced sync diagnostics…';
-    return;
-  }
+	const status = state.lastSyncStatus as SyncStatusState | null;
+	if (!status) {
+		renderSyncEmptyState(syncStatusGrid, diagnosticsLoadingState());
+		renderActionList(syncActions, []);
+		if (syncMeta) syncMeta.textContent = "Loading advanced sync diagnostics…";
+		return;
+	}
 
-  const peers = status.peers || {};
-  const pingPayload = status.ping || {};
-  const syncPayload = status.sync || {};
-  const lastSync = status.last_sync_at || status.last_sync_at_utc || null;
-  const lastPing = pingPayload.last_ping_at || status.last_ping_at || newestPeerPing(peers) || null;
-  const syncError = status.last_sync_error || '';
-  const pingError = status.last_ping_error || '';
-  const pending = Number(status.pending || 0);
-  const daemonDetail = String(status.daemon_detail || '');
-  const daemonState = String(status.daemon_state || 'unknown');
-  const retention = status.retention || {};
-  const retentionEnabled = retention.enabled === true;
-  const retentionDeleted = Number(retention.last_deleted_ops || 0);
-  const retentionLastRunAt = retention.last_run_at || null;
-  const retentionLastError = String(retention.last_error || '');
-  const daemonStateLabel =
-    daemonState === 'offline-peers'
-      ? 'Offline peers'
-      : daemonState === 'needs_attention'
-        ? 'Needs attention'
-        : daemonState === 'rebootstrapping'
-          ? 'Rebootstrapping'
-          : titleCase(daemonState);
-  const syncDisabled = daemonState === 'disabled' || status.enabled === false;
-  const peerCount = Object.keys(peers).length;
-  const syncNoPeers = !syncDisabled && peerCount === 0;
+	const peers = status.peers || {};
+	const pingPayload = status.ping || {};
+	const syncPayload = status.sync || {};
+	const lastSync = status.last_sync_at || status.last_sync_at_utc || null;
+	const lastPing = pingPayload.last_ping_at || status.last_ping_at || newestPeerPing(peers) || null;
+	const syncError = status.last_sync_error || "";
+	const pingError = status.last_ping_error || "";
+	const pending = Number(status.pending || 0);
+	const daemonDetail = String(status.daemon_detail || "");
+	const daemonState = String(status.daemon_state || "unknown");
+	const retention = status.retention || {};
+	const retentionEnabled = retention.enabled === true;
+	const retentionDeleted = Number(retention.last_deleted_ops || 0);
+	const retentionLastRunAt = retention.last_run_at || null;
+	const retentionLastError = String(retention.last_error || "");
+	const daemonStateLabel =
+		daemonState === "offline-peers"
+			? "Offline peers"
+			: daemonState === "needs_attention"
+				? "Needs attention"
+				: daemonState === "rebootstrapping"
+					? "Rebootstrapping"
+					: titleCase(daemonState);
+	const syncDisabled = daemonState === "disabled" || status.enabled === false;
+	const peerCount = Object.keys(peers).length;
+	const syncNoPeers = !syncDisabled && peerCount === 0;
 
-  if (syncMeta) {
-    const parts = syncDisabled
-      ? [
-          'Advanced sync is off on this device',
-          'Turn on sync in Settings → Device Sync when you want pairing payloads, peer status, and recent attempt details here',
-        ]
-      : syncNoPeers
-        ? [
-            'Advanced sync is ready but idle',
-            'Use Show pairing to connect another device, then this panel will start showing live peer status and recent attempts',
-          ]
-        : [
-            `Advanced state: ${daemonStateLabel}`,
-            `Peers: ${peerCount}`,
-            lastSync ? `Last sync: ${formatAgeShort(secondsSince(lastSync))} ago` : 'Last sync: never',
-          ];
-    if (daemonState === 'offline-peers') {
-      parts.push('All peers are currently offline; sync will resume automatically');
-    }
-    if (daemonDetail && daemonState === 'stopped') {
-      parts.push(`Detail: ${daemonDetail}`);
-    }
-    if (daemonDetail && (daemonState === 'needs_attention' || daemonState === 'rebootstrapping')) {
-      parts.push(`Detail: ${daemonDetail}`);
-    }
-    if (retentionEnabled) {
-      parts.push(
-        retentionLastRunAt
-          ? `Retention last ran ${formatAgeShort(secondsSince(retentionLastRunAt))} ago (approx oldest-first)`
-          : 'Retention enabled',
-      );
-    }
+	if (syncMeta) {
+		const parts = syncDisabled
+			? [
+					"Advanced sync is off on this device",
+					"Turn on sync in Settings → Device Sync when you want pairing payloads, peer status, and recent attempt details here",
+				]
+			: syncNoPeers
+				? [
+						"Advanced sync is ready but idle",
+						"Use Show pairing to connect another device, then this panel will start showing live peer status and recent attempts",
+					]
+				: [
+						`Advanced state: ${daemonStateLabel}`,
+						`Peers: ${peerCount}`,
+						lastSync
+							? `Last sync: ${formatAgeShort(secondsSince(lastSync))} ago`
+							: "Last sync: never",
+					];
+		if (daemonState === "offline-peers") {
+			parts.push("All peers are currently offline; sync will resume automatically");
+		}
+		if (daemonDetail && daemonState === "stopped") {
+			parts.push(`Detail: ${daemonDetail}`);
+		}
+		if (daemonDetail && (daemonState === "needs_attention" || daemonState === "rebootstrapping")) {
+			parts.push(`Detail: ${daemonDetail}`);
+		}
+		if (retentionEnabled) {
+			parts.push(
+				retentionLastRunAt
+					? `Retention last ran ${formatAgeShort(secondsSince(retentionLastRunAt))} ago (approx oldest-first)`
+					: "Retention enabled",
+			);
+		}
 
-    syncMeta.textContent = parts.join(' · ');
-  }
+		syncMeta.textContent = parts.join(" · ");
+	}
 
-  const items: SyncStatItem[] = syncDisabled
-    ? [
-        { label: 'State', value: 'Disabled' },
-        { label: 'Mode', value: 'Optional' },
-        { label: 'Pending events', value: pending },
-        { label: 'Last sync', value: 'Not running' },
-      ]
-    : syncNoPeers
-      ? [
-          { label: 'State', value: 'No peers' },
-          { label: 'Mode', value: 'Ready to pair' },
-          { label: 'Pending events', value: pending },
-          { label: 'Last sync', value: 'Waiting for first peer' },
-        ]
-      : [
-          { label: 'State', value: daemonStateLabel },
-          { label: 'Pending events', value: pending },
-          {
-            label: 'Last sync',
-            value: lastSync ? `${formatAgeShort(secondsSince(lastSync))} ago` : 'never',
-          },
-          {
-            label: 'Last peer ping',
-            value: lastPing ? `${formatAgeShort(secondsSince(lastPing))} ago` : 'never',
-          },
-          {
-            label: 'Retention',
-            value: retentionEnabled
-              ? retentionLastRunAt
-                ? `${retentionDeleted.toLocaleString()} ops last run (approx)`
-                : 'Enabled'
-              : 'Disabled',
-          },
-        ];
+	const items: SyncStatItem[] = syncDisabled
+		? [
+				{ label: "State", value: "Disabled" },
+				{ label: "Mode", value: "Optional" },
+				{ label: "Pending events", value: pending },
+				{ label: "Last sync", value: "Not running" },
+			]
+		: syncNoPeers
+			? [
+					{ label: "State", value: "No peers" },
+					{ label: "Mode", value: "Ready to pair" },
+					{ label: "Pending events", value: pending },
+					{ label: "Last sync", value: "Waiting for first peer" },
+				]
+			: [
+					{ label: "State", value: daemonStateLabel },
+					{ label: "Pending events", value: pending },
+					{
+						label: "Last sync",
+						value: lastSync ? `${formatAgeShort(secondsSince(lastSync))} ago` : "never",
+					},
+					{
+						label: "Last peer ping",
+						value: lastPing ? `${formatAgeShort(secondsSince(lastPing))} ago` : "never",
+					},
+					{
+						label: "Retention",
+						value: retentionEnabled
+							? retentionLastRunAt
+								? `${retentionDeleted.toLocaleString()} ops last run (approx)`
+								: "Enabled"
+							: "Disabled",
+					},
+				];
 
-  if (!syncDisabled && !syncNoPeers && (syncError || pingError)) {
-    items.push({
-      label: [syncError, pingError].filter(Boolean).join(' · '),
-      value: 'Errors',
-    });
-  }
+	if (!syncDisabled && !syncNoPeers && (syncError || pingError)) {
+		items.push({
+			label: [syncError, pingError].filter(Boolean).join(" · "),
+			value: "Errors",
+		});
+	}
 
-  if (!syncDisabled && !syncNoPeers && syncPayload.seconds_since_last) {
-    items.push({
-      label: 'Since last sync',
-      value: `${syncPayload.seconds_since_last}s`,
-    });
-  }
+	if (!syncDisabled && !syncNoPeers && syncPayload.seconds_since_last) {
+		items.push({
+			label: "Since last sync",
+			value: `${syncPayload.seconds_since_last}s`,
+		});
+	}
 
-  if (!syncDisabled && !syncNoPeers && pingPayload.seconds_since_last) {
-    items.push({
-      label: 'Since last peer ping',
-      value: `${pingPayload.seconds_since_last}s`,
-    });
-  }
+	if (!syncDisabled && !syncNoPeers && pingPayload.seconds_since_last) {
+		items.push({
+			label: "Since last peer ping",
+			value: `${pingPayload.seconds_since_last}s`,
+		});
+	}
 
-  if (!syncDisabled && retentionEnabled && retentionLastError) {
-    items.push({
-      label: retentionLastError,
-      value: 'Retention',
-    });
-  }
+	if (!syncDisabled && retentionEnabled && retentionLastError) {
+		items.push({
+			label: retentionLastError,
+			value: "Retention",
+		});
+	}
 
-  renderDiagnosticsGrid(syncStatusGrid, items);
+	renderDiagnosticsGrid(syncStatusGrid, items);
 
-  const actions: Array<{ label: string; command: string }> = [];
-  if (syncNoPeers) {
-    /* no action */
-  } else if (daemonState === 'offline-peers') {
-    /* informational */
-  } else if (daemonState === 'stopped') {
-    actions.push({ label: 'Sync daemon is stopped. Start it.', command: 'codemem sync start' });
-    actions.push({ label: 'Run one sync pass now.', command: 'codemem sync once' });
-  } else if (daemonState === 'needs_attention') {
-    actions.push({
-      label: 'Sync needs manual attention before reset can continue.',
-      command: 'codemem sync doctor',
-    });
-  } else if (daemonState === 'rebootstrapping') {
-    actions.push({ label: 'Sync is rebuilding state in the background.', command: 'codemem sync status' });
-  } else if (syncError || pingError || daemonState === 'error') {
-    actions.push({
-      label: 'Sync reports errors. Restart now.',
-      command: 'codemem sync restart && codemem sync once',
-    });
-    actions.push({
-      label: 'Run doctor for the root cause.',
-      command: 'codemem sync doctor',
-    });
-  } else if (!syncDisabled && !syncNoPeers && pending > 0) {
-    actions.push({
-      label: 'Pending sync work detected. Run one pass now.',
-      command: 'codemem sync once',
-    });
-  }
-  renderActionList(syncActions, actions);
+	const actions: Array<{ label: string; command: string }> = [];
+	if (syncNoPeers) {
+		/* no action */
+	} else if (daemonState === "offline-peers") {
+		/* informational */
+	} else if (daemonState === "stopped") {
+		actions.push({ label: "Sync daemon is stopped. Start it.", command: "codemem sync start" });
+		actions.push({ label: "Run one sync pass now.", command: "codemem sync once" });
+	} else if (daemonState === "needs_attention") {
+		actions.push({
+			label: "Sync needs manual attention before reset can continue.",
+			command: "codemem sync doctor",
+		});
+	} else if (daemonState === "rebootstrapping") {
+		actions.push({
+			label: "Sync is rebuilding state in the background.",
+			command: "codemem sync status",
+		});
+	} else if (syncError || pingError || daemonState === "error") {
+		actions.push({
+			label: "Sync reports errors. Restart now.",
+			command: "codemem sync restart && codemem sync once",
+		});
+		actions.push({
+			label: "Run doctor for the root cause.",
+			command: "codemem sync doctor",
+		});
+	} else if (!syncDisabled && !syncNoPeers && pending > 0) {
+		actions.push({
+			label: "Pending sync work detected. Run one pass now.",
+			command: "codemem sync once",
+		});
+	}
+	renderActionList(syncActions, actions);
 }
 
 /* ── Attempts renderer ───────────────────────────────────── */
 
 export function renderSyncAttempts() {
-  const syncAttempts = document.getElementById('syncAttempts');
-  if (!syncAttempts) return;
+	const syncAttempts = document.getElementById("syncAttempts");
+	if (!syncAttempts) return;
 
-  const attempts = state.lastSyncAttempts as SyncAttemptState[];
-  if (!Array.isArray(attempts) || !attempts.length) {
-    renderSyncEmptyState(syncAttempts, noAttemptsState());
-    return;
-  }
+	const attempts = state.lastSyncAttempts as SyncAttemptState[];
+	if (!Array.isArray(attempts) || !attempts.length) {
+		renderSyncEmptyState(syncAttempts, noAttemptsState());
+		return;
+	}
 
-  const items: SyncAttemptItem[] = attempts.slice(0, 5).map((attempt) => {
-    const time = attempt.started_at || attempt.started_at_utc || '';
-    const peerId = String(attempt.peer_device_id || '').trim();
-    const matchedPeer = Array.isArray(state.lastSyncPeers)
-      ? state.lastSyncPeers.find((p: any) => String(p?.peer_device_id || '') === peerId)
-      : null;
-    const peerName = String(matchedPeer?.name || '').trim();
-    const peerLabel = peerName || (peerId ? peerId.slice(0, 8) : 'unknown');
+	const items: SyncAttemptItem[] = attempts.slice(0, 5).map((attempt) => {
+		const time = attempt.started_at || attempt.started_at_utc || "";
+		const peerId = String(attempt.peer_device_id || "").trim();
+		const matchedPeer = Array.isArray(state.lastSyncPeers)
+			? state.lastSyncPeers.find((p: any) => String(p?.peer_device_id || "") === peerId)
+			: null;
+		const peerName = String(matchedPeer?.name || "").trim();
+		const peerLabel = peerName || (peerId ? peerId.slice(0, 8) : "unknown");
 
-    // Progressive disclosure: show what's relevant for this attempt's outcome
-    const isError = attempt.status === 'error';
-    const detailParts: string[] = [];
-    if (isError && attempt.error) {
-      detailParts.push(String(attempt.error));
-    }
-    if (!isError && (attempt.ops_in || attempt.ops_out)) {
-      detailParts.push(`${attempt.ops_in ?? 0} in · ${attempt.ops_out ?? 0} out`);
-    }
-    if (!isSyncRedactionEnabled() && attempt.address) {
-      detailParts.push(attempt.address);
-    }
+		// Progressive disclosure: show what's relevant for this attempt's outcome
+		const isError = attempt.status === "error";
+		const detailParts: string[] = [];
+		if (isError && attempt.error) {
+			detailParts.push(String(attempt.error));
+		}
+		if (!isError && (attempt.ops_in || attempt.ops_out)) {
+			detailParts.push(`${attempt.ops_in ?? 0} in · ${attempt.ops_out ?? 0} out`);
+		}
+		if (!isSyncRedactionEnabled() && attempt.address) {
+			detailParts.push(attempt.address);
+		}
 
-    return {
-      status: attempt.status || 'unknown',
-      peerLabel,
-      detail: detailParts.join(' · '),
-      startedAt: time ? formatTimestamp(time) : '',
-    };
-  });
+		return {
+			status: attempt.status || "unknown",
+			peerLabel,
+			detail: detailParts.join(" · "),
+			startedAt: time ? formatTimestamp(time) : "",
+		};
+	});
 
-  renderAttemptsList(syncAttempts, items);
+	renderAttemptsList(syncAttempts, items);
 }
 
 export function renderSyncDiagnosticsUnavailable() {
-  const syncStatusGrid = document.getElementById('syncStatusGrid');
-  const syncAttempts = document.getElementById('syncAttempts');
-  const syncMeta = document.getElementById('syncMeta');
-  const syncActions = document.getElementById('syncActions');
-  if (syncStatusGrid) renderSyncEmptyState(syncStatusGrid, diagnosticsUnavailableState());
-  if (syncAttempts) renderSyncEmptyState(syncAttempts, unavailableAttemptsState());
-  if (syncMeta) {
-    syncMeta.textContent =
-      'Advanced diagnostics are unavailable right now. Refresh the page, or verify the local sync service before retrying.';
-  }
-  renderActionList(syncActions, []);
+	const syncStatusGrid = document.getElementById("syncStatusGrid");
+	const syncAttempts = document.getElementById("syncAttempts");
+	const syncMeta = document.getElementById("syncMeta");
+	const syncActions = document.getElementById("syncActions");
+	if (syncStatusGrid) renderSyncEmptyState(syncStatusGrid, diagnosticsUnavailableState());
+	if (syncAttempts) renderSyncEmptyState(syncAttempts, unavailableAttemptsState());
+	if (syncMeta) {
+		syncMeta.textContent =
+			"Advanced diagnostics are unavailable right now. Refresh the page, or verify the local sync service before retrying.";
+	}
+	renderActionList(syncActions, []);
 }
 
 /* ── Pairing renderer ────────────────────────────────────── */
 
 function renderPairingCollapsible() {
-  const mount = document.getElementById('syncPairingDisclosureMount') as HTMLElement | null;
-  const contentHost = document.getElementById('syncPairingPanelMount') as HTMLElement | null;
-  if (!mount || !contentHost) return;
+	const mount = document.getElementById("syncPairingDisclosureMount") as HTMLElement | null;
+	const contentHost = document.getElementById("syncPairingPanelMount") as HTMLElement | null;
+	if (!mount || !contentHost) return;
 
-  renderPairingDisclosure(mount, {
-    contentHost,
-    open: state.syncPairingOpen,
-    onOpenChange: (open) => {
-      setSyncPairingOpen(open);
-      renderPairingCollapsible();
-      if (open) {
-        const pairingPayloadEl = document.getElementById('pairingPayload');
-        const pairingHint = document.getElementById('pairingHint');
-        if (pairingPayloadEl) {
-          renderPairingView(pairingPayloadEl, pairingHint, {
-            payloadText: 'Loading…',
-            hintText: 'Fetching pairing payload…',
-          });
-        }
-      }
-      _refreshPairing();
-    },
-  });
+	renderPairingDisclosure(mount, {
+		contentHost,
+		open: state.syncPairingOpen,
+		onOpenChange: (open) => {
+			setSyncPairingOpen(open);
+			renderPairingCollapsible();
+			if (open) {
+				const pairingPayloadEl = document.getElementById("pairingPayload");
+				const pairingHint = document.getElementById("pairingHint");
+				if (pairingPayloadEl) {
+					renderPairingView(pairingPayloadEl, pairingHint, {
+						payloadText: "Loading…",
+						hintText: "Fetching pairing payload…",
+					});
+				}
+			}
+			_refreshPairing();
+		},
+	});
 
-  const pairingCopy = document.getElementById('pairingCopy') as HTMLButtonElement | null;
-  if (pairingCopy) {
-    pairingCopy.onclick = async () => {
-      const text = state.pairingCommandRaw || document.getElementById('pairingPayload')?.textContent || '';
-      if (text) await copyToClipboard(text, pairingCopy);
-    };
-  }
+	const pairingCopy = document.getElementById("pairingCopy") as HTMLButtonElement | null;
+	if (pairingCopy) {
+		pairingCopy.onclick = async () => {
+			const text =
+				state.pairingCommandRaw || document.getElementById("pairingPayload")?.textContent || "";
+			if (text) await copyToClipboard(text, pairingCopy);
+		};
+	}
 }
 
 export function renderPairing() {
-  renderPairingCollapsible();
-  const pairingPayloadEl = document.getElementById('pairingPayload');
-  const pairingHint = document.getElementById('pairingHint');
-  if (!pairingPayloadEl) return;
+	renderPairingCollapsible();
+	const pairingPayloadEl = document.getElementById("pairingPayload");
+	const pairingHint = document.getElementById("pairingHint");
+	if (!pairingPayloadEl) return;
 
-  renderPairingView(pairingPayloadEl, pairingHint, pairingView(state.pairingPayloadRaw));
+	renderPairingView(pairingPayloadEl, pairingHint, pairingView(state.pairingPayloadRaw));
 }
 
 function renderRedactControl() {
-  const mount = document.getElementById(SYNC_REDACT_MOUNT_ID) as HTMLElement | null;
-  if (!mount) return;
+	const mount = document.getElementById(SYNC_REDACT_MOUNT_ID) as HTMLElement | null;
+	if (!mount) return;
 
-  renderIntoSyncMount(
-    mount,
-    h(RadixSwitch, {
-      'aria-labelledby': SYNC_REDACT_LABEL_ID,
-      checked: isSyncRedactionEnabled(),
-      className: 'sync-redact-switch',
-      id: 'syncRedact',
-      onCheckedChange: (checked: boolean) => {
-        setSyncRedactionEnabled(checked);
-        renderRedactControl();
-        renderSyncStatus();
-        _renderSyncPeers();
-        renderSyncAttempts();
-        renderPairing();
-      },
-      thumbClassName: 'sync-redact-switch-thumb',
-    }),
-  );
+	renderIntoSyncMount(
+		mount,
+		h(RadixSwitch, {
+			"aria-labelledby": SYNC_REDACT_LABEL_ID,
+			checked: isSyncRedactionEnabled(),
+			className: "sync-redact-switch",
+			id: "syncRedact",
+			onCheckedChange: (checked: boolean) => {
+				setSyncRedactionEnabled(checked);
+				renderRedactControl();
+				renderSyncStatus();
+				_renderSyncPeers();
+				renderSyncAttempts();
+				renderPairing();
+			},
+			thumbClassName: "sync-redact-switch-thumb",
+		}),
+	);
 }
 
 /* ── Event wiring ────────────────────────────────────────── */
 
 export function initDiagnosticsEvents(refreshCallback: () => void) {
-  _refreshPairing = refreshCallback;
-  renderPairingCollapsible();
-  renderRedactControl();
+	_refreshPairing = refreshCallback;
+	renderPairingCollapsible();
+	renderRedactControl();
 }

--- a/packages/ui/src/tabs/sync/helpers.test.ts
+++ b/packages/ui/src/tabs/sync/helpers.test.ts
@@ -1,88 +1,90 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from "vitest";
 
-import { state } from '../../lib/state';
-import { actorDisplayLabel, assignmentNote, buildActorSelectOptions } from './helpers';
+import { state } from "../../lib/state";
+import { actorDisplayLabel, assignmentNote, buildActorSelectOptions } from "./helpers";
 
 const originalActors = state.lastSyncActors;
 const originalPeers = state.lastSyncPeers;
 const originalViewModel = state.lastSyncViewModel;
 
 afterEach(() => {
-  state.lastSyncActors = originalActors;
-  state.lastSyncPeers = originalPeers;
-  state.lastSyncViewModel = originalViewModel;
+	state.lastSyncActors = originalActors;
+	state.lastSyncPeers = originalPeers;
+	state.lastSyncViewModel = originalViewModel;
 });
 
-describe('actorDisplayLabel', () => {
-  it('labels the local actor as You', () => {
-    expect(actorDisplayLabel({ actor_id: 'actor-local', display_name: 'Adam', is_local: true })).toBe('You');
-  });
+describe("actorDisplayLabel", () => {
+	it("labels the local actor as You", () => {
+		expect(
+			actorDisplayLabel({ actor_id: "actor-local", display_name: "Adam", is_local: true }),
+		).toBe("You");
+	});
 });
 
-describe('assignmentNote', () => {
-  it('describes local assignment as identity across devices', () => {
-    state.lastSyncActors = [{ actor_id: 'actor-local', display_name: 'Adam', is_local: true }];
+describe("assignmentNote", () => {
+	it("describes local assignment as identity across devices", () => {
+		state.lastSyncActors = [{ actor_id: "actor-local", display_name: "Adam", is_local: true }];
 
-    expect(assignmentNote('actor-local')).toContain('identity across your devices');
-  });
+		expect(assignmentNote("actor-local")).toContain("identity across your devices");
+	});
 });
 
-describe('buildActorSelectOptions', () => {
-  it('keeps You available while hiding unresolved duplicate people elsewhere', () => {
-    state.lastSyncActors = [
-      { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
-      { actor_id: 'actor-shadow', display_name: 'Adam', is_local: false },
-      { actor_id: 'actor-other', display_name: 'Pat', is_local: false },
-    ];
-    state.lastSyncPeers = [];
-    state.lastSyncViewModel = {
-      duplicatePeople: [
-        {
-          displayName: 'Adam',
-          actorIds: ['actor-local', 'actor-shadow'],
-          includesLocal: true,
-        },
-      ],
-    };
+describe("buildActorSelectOptions", () => {
+	it("keeps You available while hiding unresolved duplicate people elsewhere", () => {
+		state.lastSyncActors = [
+			{ actor_id: "actor-local", display_name: "Adam", is_local: true },
+			{ actor_id: "actor-shadow", display_name: "Adam", is_local: false },
+			{ actor_id: "actor-other", display_name: "Pat", is_local: false },
+		];
+		state.lastSyncPeers = [];
+		state.lastSyncViewModel = {
+			duplicatePeople: [
+				{
+					displayName: "Adam",
+					actorIds: ["actor-local", "actor-shadow"],
+					includesLocal: true,
+				},
+			],
+		};
 
-    expect(buildActorSelectOptions()).toEqual([
-      { value: '', label: 'No person assigned' },
-      { value: 'actor-local', label: 'You' },
-      { value: 'actor-other', label: 'Pat' },
-    ]);
-  });
+		expect(buildActorSelectOptions()).toEqual([
+			{ value: "", label: "No person assigned" },
+			{ value: "actor-local", label: "You" },
+			{ value: "actor-other", label: "Pat" },
+		]);
+	});
 
-  it('preserves a selected hidden actor so the control never renders blank', () => {
-    state.lastSyncActors = [
-      { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
-      { actor_id: 'actor-shadow', display_name: 'Adam', is_local: false },
-    ];
-    state.lastSyncPeers = [];
-    state.lastSyncViewModel = {
-      duplicatePeople: [
-        {
-          displayName: 'Adam',
-          actorIds: ['actor-local', 'actor-shadow'],
-          includesLocal: true,
-        },
-      ],
-    };
+	it("preserves a selected hidden actor so the control never renders blank", () => {
+		state.lastSyncActors = [
+			{ actor_id: "actor-local", display_name: "Adam", is_local: true },
+			{ actor_id: "actor-shadow", display_name: "Adam", is_local: false },
+		];
+		state.lastSyncPeers = [];
+		state.lastSyncViewModel = {
+			duplicatePeople: [
+				{
+					displayName: "Adam",
+					actorIds: ["actor-local", "actor-shadow"],
+					includesLocal: true,
+				},
+			],
+		};
 
-    expect(buildActorSelectOptions('actor-shadow')).toEqual([
-      { value: '', label: 'No person assigned' },
-      { value: 'actor-local', label: 'You' },
-      { value: 'actor-shadow', label: 'Adam' },
-    ]);
-  });
+		expect(buildActorSelectOptions("actor-shadow")).toEqual([
+			{ value: "", label: "No person assigned" },
+			{ value: "actor-local", label: "You" },
+			{ value: "actor-shadow", label: "Adam" },
+		]);
+	});
 
-  it('keeps an explicit unassigned choice in the option list', () => {
-    state.lastSyncActors = [{ actor_id: 'actor-local', display_name: 'Adam', is_local: true }];
-    state.lastSyncPeers = [];
-    state.lastSyncViewModel = { duplicatePeople: [] };
+	it("keeps an explicit unassigned choice in the option list", () => {
+		state.lastSyncActors = [{ actor_id: "actor-local", display_name: "Adam", is_local: true }];
+		state.lastSyncPeers = [];
+		state.lastSyncViewModel = { duplicatePeople: [] };
 
-    expect(buildActorSelectOptions()).toEqual([
-      { value: '', label: 'No person assigned' },
-      { value: 'actor-local', label: 'You' },
-    ]);
-  });
+		expect(buildActorSelectOptions()).toEqual([
+			{ value: "", label: "No person assigned" },
+			{ value: "actor-local", label: "You" },
+		]);
+	});
 });

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -1,301 +1,311 @@
 /* Shared helpers for the Sync tab sub-modules. */
 
-import { el, copyToClipboard } from '../../lib/dom';
-import { state } from '../../lib/state';
-import { deriveVisiblePeopleActors } from './view-model';
-import type { RadixSelectOption } from '../../components/primitives/radix-select';
+import type { RadixSelectOption } from "../../components/primitives/radix-select";
+import { copyToClipboard, el } from "../../lib/dom";
+import { state } from "../../lib/state";
+import { deriveVisiblePeopleActors } from "./view-model";
 
 /* ── Skeleton helpers ────────────────────────────────────── */
 
 export function hideSkeleton(id: string): void {
-  const skeleton = document.getElementById(id);
-  if (skeleton) skeleton.remove();
+	const skeleton = document.getElementById(id);
+	if (skeleton) skeleton.remove();
 }
 
 /* ── Module-level UI state ───────────────────────────────── */
 
 export let adminSetupExpanded = false;
 export function setAdminSetupExpanded(v: boolean) {
-  adminSetupExpanded = v;
+	adminSetupExpanded = v;
 }
 
 export let teamInvitePanelOpen = false;
 export function setTeamInvitePanelOpen(v: boolean) {
-  teamInvitePanelOpen = v;
+	teamInvitePanelOpen = v;
 }
 
 export const openPeerScopeEditors = new Set<string>();
 const pendingPeerScopeReviewIds = new Set<string>();
 const freshPeerScopeReviewIds = new Set<string>();
-const DUPLICATE_PERSON_DECISIONS_KEY = 'codemem-sync-duplicate-person-decisions';
+const DUPLICATE_PERSON_DECISIONS_KEY = "codemem-sync-duplicate-person-decisions";
 
-export type DuplicatePersonDecision = 'different-people';
+export type DuplicatePersonDecision = "different-people";
 
 export function requestPeerScopeReview(peerDeviceId: string) {
-  const value = String(peerDeviceId || '').trim();
-  if (!value) return;
-  pendingPeerScopeReviewIds.add(value);
-  freshPeerScopeReviewIds.add(value);
-  openPeerScopeEditors.add(value);
+	const value = String(peerDeviceId || "").trim();
+	if (!value) return;
+	pendingPeerScopeReviewIds.add(value);
+	freshPeerScopeReviewIds.add(value);
+	openPeerScopeEditors.add(value);
 }
 
 export function isPeerScopeReviewPending(peerDeviceId: string): boolean {
-  const value = String(peerDeviceId || '').trim();
-  return Boolean(value) && pendingPeerScopeReviewIds.has(value);
+	const value = String(peerDeviceId || "").trim();
+	return Boolean(value) && pendingPeerScopeReviewIds.has(value);
 }
 
 export function clearPeerScopeReview(peerDeviceId: string) {
-  const value = String(peerDeviceId || '').trim();
-  if (!value) return;
-  pendingPeerScopeReviewIds.delete(value);
+	const value = String(peerDeviceId || "").trim();
+	if (!value) return;
+	pendingPeerScopeReviewIds.delete(value);
 }
 
 export function consumePeerScopeReviewRequest(peerDeviceId: string): boolean {
-  const value = String(peerDeviceId || '').trim();
-  if (!value || !freshPeerScopeReviewIds.has(value)) return false;
-  freshPeerScopeReviewIds.delete(value);
-  return true;
+	const value = String(peerDeviceId || "").trim();
+	if (!value || !freshPeerScopeReviewIds.has(value)) return false;
+	freshPeerScopeReviewIds.delete(value);
+	return true;
 }
 
 function readDuplicatePersonDecisionStore(): Record<string, DuplicatePersonDecision> {
-  try {
-    const raw = localStorage.getItem(DUPLICATE_PERSON_DECISIONS_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw);
-    return parsed && typeof parsed === 'object' ? parsed : {};
-  } catch {
-    return {};
-  }
+	try {
+		const raw = localStorage.getItem(DUPLICATE_PERSON_DECISIONS_KEY);
+		if (!raw) return {};
+		const parsed = JSON.parse(raw);
+		return parsed && typeof parsed === "object" ? parsed : {};
+	} catch {
+		return {};
+	}
 }
 
 function writeDuplicatePersonDecisionStore(value: Record<string, DuplicatePersonDecision>) {
-  try {
-    localStorage.setItem(DUPLICATE_PERSON_DECISIONS_KEY, JSON.stringify(value));
-  } catch {}
+	try {
+		localStorage.setItem(DUPLICATE_PERSON_DECISIONS_KEY, JSON.stringify(value));
+	} catch {}
 }
 
 export function duplicatePersonDecisionKey(actorIds: string[]): string {
-  return [...actorIds].map((value) => String(value || '').trim()).filter(Boolean).sort().join('::');
+	return [...actorIds]
+		.map((value) => String(value || "").trim())
+		.filter(Boolean)
+		.sort()
+		.join("::");
 }
 
 export function readDuplicatePersonDecisions(): Record<string, DuplicatePersonDecision> {
-  return readDuplicatePersonDecisionStore();
+	return readDuplicatePersonDecisionStore();
 }
 
 export function saveDuplicatePersonDecision(actorIds: string[], decision: DuplicatePersonDecision) {
-  const key = duplicatePersonDecisionKey(actorIds);
-  if (!key) return;
-  const next = readDuplicatePersonDecisionStore();
-  next[key] = decision;
-  writeDuplicatePersonDecisionStore(next);
+	const key = duplicatePersonDecisionKey(actorIds);
+	if (!key) return;
+	const next = readDuplicatePersonDecisionStore();
+	next[key] = decision;
+	writeDuplicatePersonDecisionStore(next);
 }
 
 export function clearDuplicatePersonDecision(actorIds: string[]) {
-  const key = duplicatePersonDecisionKey(actorIds);
-  if (!key) return;
-  const next = readDuplicatePersonDecisionStore();
-  delete next[key];
-  writeDuplicatePersonDecisionStore(next);
+	const key = duplicatePersonDecisionKey(actorIds);
+	if (!key) return;
+	const next = readDuplicatePersonDecisionStore();
+	delete next[key];
+	writeDuplicatePersonDecisionStore(next);
 }
 
 /* ── Text helpers ────────────────────────────────────────── */
 
 /** Redact the last two octets of IPv4 addresses. */
 export function redactIpOctets(text: string): string {
-  return text.replace(/\b(\d{1,3}\.\d{1,3})\.\d{1,3}\.\d{1,3}\b/g, '$1.#.#');
+	return text.replace(/\b(\d{1,3}\.\d{1,3})\.\d{1,3}\.\d{1,3}\b/g, "$1.#.#");
 }
 
 export function redactAddress(address: any): string {
-  const raw = String(address || '');
-  if (!raw) return '';
-  return redactIpOctets(raw);
+	const raw = String(address || "");
+	if (!raw) return "";
+	return redactIpOctets(raw);
 }
 
 export function pickPrimaryAddress(addresses: unknown): string {
-  if (!Array.isArray(addresses)) return '';
-  const unique = Array.from(new Set(addresses.filter(Boolean)));
-  return typeof unique[0] === 'string' ? unique[0] : '';
+	if (!Array.isArray(addresses)) return "";
+	const unique = Array.from(new Set(addresses.filter(Boolean)));
+	return typeof unique[0] === "string" ? unique[0] : "";
 }
 
 export function parseScopeList(value: string): string[] {
-  return value
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean);
+	return value
+		.split(",")
+		.map((item) => item.trim())
+		.filter(Boolean);
 }
 
 /* ── Actor helpers ───────────────────────────────────────── */
 
 export function actorLabel(actor: any): string {
-  if (!actor || typeof actor !== 'object') return 'Unknown person';
-  const displayName = String(actor.display_name || '').trim();
-  if (!displayName) return String(actor.actor_id || 'Unknown person');
-  return displayName;
+	if (!actor || typeof actor !== "object") return "Unknown person";
+	const displayName = String(actor.display_name || "").trim();
+	if (!displayName) return String(actor.actor_id || "Unknown person");
+	return displayName;
 }
 
 export function actorDisplayLabel(actor: any): string {
-  if (!actor || typeof actor !== 'object') return 'Unknown person';
-  return actor.is_local ? 'You' : actorLabel(actor);
+	if (!actor || typeof actor !== "object") return "Unknown person";
+	return actor.is_local ? "You" : actorLabel(actor);
 }
 
 export function assignedActorCount(actorId: string): number {
-  const peers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
-  return peers.filter((peer) => String(peer?.actor_id || '') === actorId).length;
+	const peers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
+	return peers.filter((peer) => String(peer?.actor_id || "") === actorId).length;
 }
 
 export function assignmentNote(actorId: string): string {
-  if (!actorId) return 'Unassigned devices keep legacy fallback attribution until you choose a person.';
-  const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
-  const actor = actors.find((item) => String(item?.actor_id || '') === actorId);
-  if (actor?.is_local) {
-    return 'Assigning this device to you keeps it in your identity across your devices, including private sync.';
-  }
-  return 'This person receives memories from allowed projects by default. Use Only me on a memory when it should stay local.';
+	if (!actorId)
+		return "Unassigned devices keep legacy fallback attribution until you choose a person.";
+	const actors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
+	const actor = actors.find((item) => String(item?.actor_id || "") === actorId);
+	if (actor?.is_local) {
+		return "Assigning this device to you keeps it in your identity across your devices, including private sync.";
+	}
+	return "This person receives memories from allowed projects by default. Use Only me on a memory when it should stay local.";
 }
 
 export function visibleSyncActors() {
-  return deriveVisiblePeopleActors({
-    actors: state.lastSyncActors,
-    peers: state.lastSyncPeers,
-    duplicatePeople: state.lastSyncViewModel?.duplicatePeople,
-  }).visibleActors;
+	return deriveVisiblePeopleActors({
+		actors: state.lastSyncActors,
+		peers: state.lastSyncPeers,
+		duplicatePeople: state.lastSyncViewModel?.duplicatePeople,
+	}).visibleActors;
 }
 
-export function buildActorSelectOptions(selectedActorId = ''): RadixSelectOption[] {
-  const options: RadixSelectOption[] = [{ value: '', label: 'No person assigned' }];
-  const visibleActors = visibleSyncActors();
-  const allActors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
-  const selectedActor = allActors.find((actor) => String(actor?.actor_id || '') === selectedActorId);
-  const actors = selectedActor && !visibleActors.some((actor) => String(actor?.actor_id || '') === selectedActorId)
-    ? [...visibleActors, selectedActor]
-    : visibleActors;
+export function buildActorSelectOptions(selectedActorId = ""): RadixSelectOption[] {
+	const options: RadixSelectOption[] = [{ value: "", label: "No person assigned" }];
+	const visibleActors = visibleSyncActors();
+	const allActors = Array.isArray(state.lastSyncActors) ? state.lastSyncActors : [];
+	const selectedActor = allActors.find(
+		(actor) => String(actor?.actor_id || "") === selectedActorId,
+	);
+	const actors =
+		selectedActor &&
+		!visibleActors.some((actor) => String(actor?.actor_id || "") === selectedActorId)
+			? [...visibleActors, selectedActor]
+			: visibleActors;
 
-  actors.forEach((actor) => {
-    const actorId = String(actor?.actor_id || '').trim();
-    if (!actorId) return;
-    options.push({ value: actorId, label: actorDisplayLabel(actor) });
-  });
+	actors.forEach((actor) => {
+		const actorId = String(actor?.actor_id || "").trim();
+		if (!actorId) return;
+		options.push({ value: actorId, label: actorDisplayLabel(actor) });
+	});
 
-  return options.filter(
-    (option, index, all) => index === all.findIndex((candidate) => candidate.value === option.value),
-  );
+	return options.filter(
+		(option, index, all) =>
+			index === all.findIndex((candidate) => candidate.value === option.value),
+	);
 }
 
 export function buildActorOptions(selectedActorId: string): HTMLOptionElement[] {
-  const options: HTMLOptionElement[] = [];
-  const unassigned = document.createElement('option');
-  unassigned.value = '';
-  unassigned.textContent = 'No person assigned';
-  options.push(unassigned);
+	const options: HTMLOptionElement[] = [];
+	const unassigned = document.createElement("option");
+	unassigned.value = "";
+	unassigned.textContent = "No person assigned";
+	options.push(unassigned);
 
-  buildActorSelectOptions(selectedActorId)
-    .filter((option) => option.value)
-    .forEach((selectOption) => {
-    const option = document.createElement('option');
-    option.value = selectOption.value;
-    option.textContent = selectOption.label;
-    option.selected = option.value === selectedActorId;
-    options.push(option);
-  });
-  if (!selectedActorId) options[0].selected = true;
-  return options;
+	buildActorSelectOptions(selectedActorId)
+		.filter((option) => option.value)
+		.forEach((selectOption) => {
+			const option = document.createElement("option");
+			option.value = selectOption.value;
+			option.textContent = selectOption.label;
+			option.selected = option.value === selectedActorId;
+			options.push(option);
+		});
+	if (!selectedActorId) options[0].selected = true;
+	return options;
 }
 
 export function mergeTargetActors(actorId: string): any[] {
-  const actors = visibleSyncActors();
-  return actors.filter((actor) => String(actor?.actor_id || '') !== actorId);
+	const actors = visibleSyncActors();
+	return actors.filter((actor) => String(actor?.actor_id || "") !== actorId);
 }
 
 export function actorMergeNote(targetActorId: string, secondaryActorId: string): string {
-  const target = mergeTargetActors(secondaryActorId).find(
-    (actor) => String(actor?.actor_id || '') === targetActorId,
-  );
-  if (!targetActorId || !target) {
-    return 'Choose which person should keep these devices.';
-  }
-  return `Merge into ${actorDisplayLabel(target)}. Assigned devices move now; existing memories keep their current provenance.`;
+	const target = mergeTargetActors(secondaryActorId).find(
+		(actor) => String(actor?.actor_id || "") === targetActorId,
+	);
+	if (!targetActorId || !target) {
+		return "Choose which person should keep these devices.";
+	}
+	return `Merge into ${actorDisplayLabel(target)}. Assigned devices move now; existing memories keep their current provenance.`;
 }
 
 /* ── Chip editor component ───────────────────────────────── */
 
 export function createChipEditor(initialValues: string[], placeholder: string, emptyLabel: string) {
-  let values = [...initialValues];
-  const container = el('div', 'peer-scope-editor');
-  const chips = el('div', 'peer-scope-chips');
-  const input = el('input', 'peer-scope-input') as HTMLInputElement;
-  input.placeholder = placeholder;
+	let values = [...initialValues];
+	const container = el("div", "peer-scope-editor");
+	const chips = el("div", "peer-scope-chips");
+	const input = el("input", "peer-scope-input") as HTMLInputElement;
+	input.placeholder = placeholder;
 
-  const syncChips = () => {
-    chips.textContent = '';
-    if (!values.length) {
-      chips.appendChild(el('span', 'peer-scope-chip empty', emptyLabel));
-      return;
-    }
-    values.forEach((value, index) => {
-      const chip = el('span', 'peer-scope-chip');
-      const label = el('span', null, value);
-      const remove = el('button', 'peer-scope-chip-remove', 'x') as HTMLButtonElement;
-      remove.type = 'button';
-      remove.setAttribute('aria-label', `Remove ${value}`);
-      remove.addEventListener('click', () => {
-        values = values.filter((_, currentIndex) => currentIndex !== index);
-        syncChips();
-      });
-      chip.append(label, remove);
-      chips.appendChild(chip);
-    });
-  };
+	const syncChips = () => {
+		chips.textContent = "";
+		if (!values.length) {
+			chips.appendChild(el("span", "peer-scope-chip empty", emptyLabel));
+			return;
+		}
+		values.forEach((value, index) => {
+			const chip = el("span", "peer-scope-chip");
+			const label = el("span", null, value);
+			const remove = el("button", "peer-scope-chip-remove", "x") as HTMLButtonElement;
+			remove.type = "button";
+			remove.setAttribute("aria-label", `Remove ${value}`);
+			remove.addEventListener("click", () => {
+				values = values.filter((_, currentIndex) => currentIndex !== index);
+				syncChips();
+			});
+			chip.append(label, remove);
+			chips.appendChild(chip);
+		});
+	};
 
-  const commitInput = () => {
-    const incoming = parseScopeList(input.value);
-    if (incoming.length) {
-      values = Array.from(new Set([...values, ...incoming]));
-      input.value = '';
-      syncChips();
-    }
-  };
+	const commitInput = () => {
+		const incoming = parseScopeList(input.value);
+		if (incoming.length) {
+			values = Array.from(new Set([...values, ...incoming]));
+			input.value = "";
+			syncChips();
+		}
+	};
 
-  input.addEventListener('keydown', (event) => {
-    if (event.key === 'Enter' || event.key === ',') {
-      event.preventDefault();
-      commitInput();
-    }
-    if (event.key === 'Backspace' && !input.value && values.length) {
-      values = values.slice(0, -1);
-      syncChips();
-    }
-  });
-  input.addEventListener('blur', commitInput);
+	input.addEventListener("keydown", (event) => {
+		if (event.key === "Enter" || event.key === ",") {
+			event.preventDefault();
+			commitInput();
+		}
+		if (event.key === "Backspace" && !input.value && values.length) {
+			values = values.slice(0, -1);
+			syncChips();
+		}
+	});
+	input.addEventListener("blur", commitInput);
 
-  syncChips();
-  container.append(chips, input);
-  return {
-    element: container,
-    values: () => [...values],
-  };
+	syncChips();
+	container.append(chips, input);
+	return {
+		element: container,
+		values: () => [...values],
+	};
 }
 
 /* ── Action list renderer ────────────────────────────────── */
 
 export function renderActionList(
-  container: HTMLElement | null,
-  actions: Array<{ label: string; command: string }>,
+	container: HTMLElement | null,
+	actions: Array<{ label: string; command: string }>,
 ) {
-  if (!container) return;
-  container.textContent = '';
-  if (!actions.length) {
-    container.hidden = true;
-    return;
-  }
-  container.hidden = false;
-  actions.slice(0, 2).forEach((item) => {
-    const row = el('div', 'sync-action');
-    const textWrap = el('div', 'sync-action-text');
-    textWrap.textContent = item.label;
-    textWrap.appendChild(el('span', 'sync-action-command', item.command));
-    const btn = el('button', 'settings-button sync-action-copy', 'Copy') as HTMLButtonElement;
-    btn.addEventListener('click', () => copyToClipboard(item.command, btn));
-    row.append(textWrap, btn);
-    container.appendChild(row);
-  });
+	if (!container) return;
+	container.textContent = "";
+	if (!actions.length) {
+		container.hidden = true;
+		return;
+	}
+	container.hidden = false;
+	actions.slice(0, 2).forEach((item) => {
+		const row = el("div", "sync-action");
+		const textWrap = el("div", "sync-action-text");
+		textWrap.textContent = item.label;
+		textWrap.appendChild(el("span", "sync-action-command", item.command));
+		const btn = el("button", "settings-button sync-action-copy", "Copy") as HTMLButtonElement;
+		btn.addEventListener("click", () => copyToClipboard(item.command, btn));
+		row.append(textWrap, btn);
+		container.appendChild(row);
+	});
 }

--- a/packages/ui/src/tabs/sync/index.test.ts
+++ b/packages/ui/src/tabs/sync/index.test.ts
@@ -1,122 +1,132 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock('../../lib/api', () => ({
-  loadSyncStatus: vi.fn(),
-  loadSyncActors: vi.fn(),
+vi.mock("../../lib/api", () => ({
+	loadSyncStatus: vi.fn(),
+	loadSyncActors: vi.fn(),
 }));
 
-vi.mock('../health', () => ({ renderHealthOverview: vi.fn() }));
-vi.mock('./diagnostics', () => ({
-  renderSyncStatus: vi.fn(),
-  renderSyncAttempts: vi.fn(),
-  renderPairing: vi.fn(),
-  initDiagnosticsEvents: vi.fn(),
-  setRenderSyncPeers: vi.fn(),
+vi.mock("../health", () => ({ renderHealthOverview: vi.fn() }));
+vi.mock("./diagnostics", () => ({
+	renderSyncStatus: vi.fn(),
+	renderSyncAttempts: vi.fn(),
+	renderPairing: vi.fn(),
+	initDiagnosticsEvents: vi.fn(),
+	setRenderSyncPeers: vi.fn(),
 }));
-vi.mock('./team-sync', () => ({
-  renderTeamSync: vi.fn(),
-  renderSyncSharingReview: vi.fn(),
-  initTeamSyncEvents: vi.fn(),
-  setLoadSyncData: vi.fn(),
+vi.mock("./team-sync", () => ({
+	renderTeamSync: vi.fn(),
+	renderSyncSharingReview: vi.fn(),
+	initTeamSyncEvents: vi.fn(),
+	setLoadSyncData: vi.fn(),
 }));
-vi.mock('./people', () => ({
-  renderSyncActors: vi.fn(),
-  renderSyncPeers: vi.fn(),
-  renderLegacyDeviceClaims: vi.fn(),
-  initPeopleEvents: vi.fn(),
-  setLoadSyncData: vi.fn(),
+vi.mock("./people", () => ({
+	renderSyncActors: vi.fn(),
+	renderSyncPeers: vi.fn(),
+	renderLegacyDeviceClaims: vi.fn(),
+	initPeopleEvents: vi.fn(),
+	setLoadSyncData: vi.fn(),
 }));
-vi.mock('./components/render-root', () => ({ ensureSyncRenderBoundary: vi.fn() }));
-vi.mock('./sync-dialogs', () => ({ ensureSyncDialogHost: vi.fn() }));
-vi.mock('./helpers', () => ({
-  hideSkeleton: vi.fn(),
-  readDuplicatePersonDecisions: vi.fn(() => ({})),
+vi.mock("./components/render-root", () => ({ ensureSyncRenderBoundary: vi.fn() }));
+vi.mock("./sync-dialogs", () => ({ ensureSyncDialogHost: vi.fn() }));
+vi.mock("./helpers", () => ({
+	hideSkeleton: vi.fn(),
+	readDuplicatePersonDecisions: vi.fn(() => ({})),
 }));
 
 type Deferred<T> = {
-  promise: Promise<T>;
-  resolve: (value: T) => void;
-  reject: (error?: unknown) => void;
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (error?: unknown) => void;
 };
 
 function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  let reject!: (error?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
+	let resolve!: (value: T) => void;
+	let reject!: (error?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
 }
 
-describe('loadSyncData', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    const { state } = await import('../../lib/state');
-    const { resetSyncLoadStateForTests } = await import('./index');
-    resetSyncLoadStateForTests();
-    state.activeTab = 'sync';
-    state.currentProject = '';
-    state.lastSyncPeers = [];
-    state.pendingAcceptedSyncPeers = [];
-    state.lastSyncActors = [];
-    state.lastSyncCoordinator = null;
-    state.lastSyncViewModel = null;
-  });
+describe("loadSyncData", () => {
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const { state } = await import("../../lib/state");
+		const { resetSyncLoadStateForTests } = await import("./index");
+		resetSyncLoadStateForTests();
+		state.activeTab = "sync";
+		state.currentProject = "";
+		state.lastSyncPeers = [];
+		state.pendingAcceptedSyncPeers = [];
+		state.lastSyncActors = [];
+		state.lastSyncCoordinator = null;
+		state.lastSyncViewModel = null;
+	});
 
-  it('ignores stale out-of-order sync payloads from older refreshes', async () => {
-    const api = await import('../../lib/api');
-    const { state } = await import('../../lib/state');
-    const { loadSyncData } = await import('./index');
+	it("ignores stale out-of-order sync payloads from older refreshes", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
 
-    const first = deferred<{ peers: Array<{ peer_device_id: string }>; sharing_review: []; attempts: []; legacy_devices: [] }>();
-    const second = deferred<{ peers: Array<{ peer_device_id: string }>; sharing_review: []; attempts: []; legacy_devices: [] }>();
+		const first = deferred<{
+			peers: Array<{ peer_device_id: string }>;
+			sharing_review: [];
+			attempts: [];
+			legacy_devices: [];
+		}>();
+		const second = deferred<{
+			peers: Array<{ peer_device_id: string }>;
+			sharing_review: [];
+			attempts: [];
+			legacy_devices: [];
+		}>();
 
-    vi.mocked(api.loadSyncStatus)
-      .mockReturnValueOnce(first.promise as never)
-      .mockReturnValueOnce(second.promise as never);
-    vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadSyncStatus)
+			.mockReturnValueOnce(first.promise as never)
+			.mockReturnValueOnce(second.promise as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
 
-    const firstLoad = loadSyncData();
-    const secondLoad = loadSyncData();
+		const firstLoad = loadSyncData();
+		const secondLoad = loadSyncData();
 
-    second.resolve({
-      peers: [{ peer_device_id: 'peer-new' }],
-      sharing_review: [],
-      attempts: [],
-      legacy_devices: [],
-    });
-    await secondLoad;
-    expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(['peer-new']);
+		second.resolve({
+			peers: [{ peer_device_id: "peer-new" }],
+			sharing_review: [],
+			attempts: [],
+			legacy_devices: [],
+		});
+		await secondLoad;
+		expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(["peer-new"]);
 
-    first.resolve({
-      peers: [{ peer_device_id: 'peer-old' }],
-      sharing_review: [],
-      attempts: [],
-      legacy_devices: [],
-    });
-    await firstLoad;
-    expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(['peer-new']);
-  });
+		first.resolve({
+			peers: [{ peer_device_id: "peer-old" }],
+			sharing_review: [],
+			attempts: [],
+			legacy_devices: [],
+		});
+		await firstLoad;
+		expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(["peer-new"]);
+	});
 
-  it('does not extend the health-tab cache ttl on cache hits', async () => {
-    const api = await import('../../lib/api');
-    const { state } = await import('../../lib/state');
-    const { loadSyncData } = await import('./index');
+	it("does not extend the health-tab cache ttl on cache hits", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadSyncData } = await import("./index");
 
-    state.activeTab = 'health';
+		state.activeTab = "health";
 
-    vi.mocked(api.loadSyncStatus).mockResolvedValue({
-      peers: [{ peer_device_id: 'peer-cached' }],
-      sharing_review: [],
-      attempts: [],
-      legacy_devices: [],
-    } as never);
-    vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({
+			peers: [{ peer_device_id: "peer-cached" }],
+			sharing_review: [],
+			attempts: [],
+			legacy_devices: [],
+		} as never);
+		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
 
-    await loadSyncData();
-    await loadSyncData();
+		await loadSyncData();
+		await loadSyncData();
 
-    expect(api.loadSyncStatus).toHaveBeenCalledTimes(1);
-  });
+		expect(api.loadSyncStatus).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -1,217 +1,242 @@
 /* Sync tab orchestrator — re-exports public API and coordinates sub-modules. */
 
-import * as api from '../../lib/api';
-import { state } from '../../lib/state';
-import { renderHealthOverview } from '../health';
-import { deriveSyncViewModel } from './view-model';
+import * as api from "../../lib/api";
+import { state } from "../../lib/state";
+import { renderHealthOverview } from "../health";
+import { ensureSyncRenderBoundary } from "./components/render-root";
 
-import { renderSyncStatus, renderSyncAttempts, renderPairing, renderSyncDiagnosticsUnavailable, initDiagnosticsEvents, setRenderSyncPeers } from './diagnostics';
-import { renderTeamSync, renderSyncSharingReview, initTeamSyncEvents, setLoadSyncData as setTeamSyncLoadData } from './team-sync';
-import { renderSyncActors, renderSyncPeers, renderLegacyDeviceClaims, renderSyncActorsUnavailable, renderSyncPeopleUnavailable, initPeopleEvents, setLoadSyncData as setPeopleLoadData } from './people';
-import { ensureSyncRenderBoundary } from './components/render-root';
-import { ensureSyncDialogHost } from './sync-dialogs';
-import { hideSkeleton, readDuplicatePersonDecisions } from './helpers';
+import {
+	initDiagnosticsEvents,
+	renderPairing,
+	renderSyncAttempts,
+	renderSyncDiagnosticsUnavailable,
+	renderSyncStatus,
+	setRenderSyncPeers,
+} from "./diagnostics";
+import { hideSkeleton, readDuplicatePersonDecisions } from "./helpers";
+import {
+	initPeopleEvents,
+	renderLegacyDeviceClaims,
+	renderSyncActors,
+	renderSyncActorsUnavailable,
+	renderSyncPeers,
+	renderSyncPeopleUnavailable,
+	setLoadSyncData as setPeopleLoadData,
+} from "./people";
+import { ensureSyncDialogHost } from "./sync-dialogs";
+import {
+	initTeamSyncEvents,
+	renderSyncSharingReview,
+	renderTeamSync,
+	setLoadSyncData as setTeamSyncLoadData,
+} from "./team-sync";
+import { deriveSyncViewModel } from "./view-model";
 
 /* ── Re-exports consumed by app.ts ───────────────────────── */
 
-export { renderSyncStatus, renderSyncAttempts, renderPairing } from './diagnostics';
-export { renderSyncPeers } from './people';
+export { renderPairing, renderSyncAttempts, renderSyncStatus } from "./diagnostics";
+export { renderSyncPeers } from "./people";
 
 /* ── Data loading ────────────────────────────────────────── */
 
-let lastSyncHash = '';
+let lastSyncHash = "";
 type SyncStatusResponseLike = {
-  status?: Record<string, unknown> | null;
-  peers?: Array<{ peer_device_id?: string }>;
-  coordinator?: Record<string, unknown> | null;
-  join_requests?: unknown[];
-  sharing_review?: unknown[];
-  attempts?: unknown[];
-  legacy_devices?: unknown[];
+	status?: Record<string, unknown> | null;
+	peers?: Array<{ peer_device_id?: string }>;
+	coordinator?: Record<string, unknown> | null;
+	join_requests?: unknown[];
+	sharing_review?: unknown[];
+	attempts?: unknown[];
+	legacy_devices?: unknown[];
 };
 
 type SyncActorListResponseLike = {
-  items?: unknown[];
+	items?: unknown[];
 };
 
 type SyncPeerSummaryLike = {
-  peer_device_id?: string;
+	peer_device_id?: string;
 };
 
-let cachedSyncStatus: { key: string; expiresAtMs: number; payload: SyncStatusResponseLike } | null = null;
+let cachedSyncStatus: { key: string; expiresAtMs: number; payload: SyncStatusResponseLike } | null =
+	null;
 let latestSyncLoadRequestId = 0;
 
 const HEALTH_SYNC_STATUS_CACHE_TTL_MS = 15_000;
 
 function syncStatusCacheKey(project: string): string {
-  return `project:${project || ''}|includeJoinRequests:false`;
+	return `project:${project || ""}|includeJoinRequests:false`;
 }
 
 function readCachedSyncStatus(project: string): SyncStatusResponseLike | null {
-  const key = syncStatusCacheKey(project);
-  if (!cachedSyncStatus) return null;
-  if (cachedSyncStatus.key !== key) return null;
-  if (Date.now() >= cachedSyncStatus.expiresAtMs) return null;
-  return cachedSyncStatus.payload;
+	const key = syncStatusCacheKey(project);
+	if (!cachedSyncStatus) return null;
+	if (cachedSyncStatus.key !== key) return null;
+	if (Date.now() >= cachedSyncStatus.expiresAtMs) return null;
+	return cachedSyncStatus.payload;
 }
 
 function writeCachedSyncStatus(project: string, payload: SyncStatusResponseLike): void {
-  cachedSyncStatus = {
-    key: syncStatusCacheKey(project),
-    expiresAtMs: Date.now() + HEALTH_SYNC_STATUS_CACHE_TTL_MS,
-    payload,
-  };
+	cachedSyncStatus = {
+		key: syncStatusCacheKey(project),
+		expiresAtMs: Date.now() + HEALTH_SYNC_STATUS_CACHE_TTL_MS,
+		payload,
+	};
 }
 
 function normalizeSyncStatusForCache(payload: SyncStatusResponseLike): SyncStatusResponseLike {
-  if (!payload || typeof payload !== 'object') return payload;
-  return {
-    ...payload,
-    join_requests: [],
-  };
+	if (!payload || typeof payload !== "object") return payload;
+	return {
+		...payload,
+		join_requests: [],
+	};
 }
 
 function hideStaleSyncSecondarySections() {
-  const sharingReview = document.getElementById('syncSharingReview');
-  const sharingReviewList = document.getElementById('syncSharingReviewList');
-  const sharingReviewMeta = document.getElementById('syncSharingReviewMeta');
-  const legacyClaims = document.getElementById('syncLegacyClaims');
-  const legacyClaimsMeta = document.getElementById('syncLegacyClaimsMeta');
-  if (sharingReview) sharingReview.hidden = true;
-  if (sharingReviewList) sharingReviewList.textContent = '';
-  if (sharingReviewMeta) sharingReviewMeta.textContent = '';
-  if (legacyClaims) legacyClaims.hidden = true;
-  if (legacyClaimsMeta) legacyClaimsMeta.textContent = '';
+	const sharingReview = document.getElementById("syncSharingReview");
+	const sharingReviewList = document.getElementById("syncSharingReviewList");
+	const sharingReviewMeta = document.getElementById("syncSharingReviewMeta");
+	const legacyClaims = document.getElementById("syncLegacyClaims");
+	const legacyClaimsMeta = document.getElementById("syncLegacyClaimsMeta");
+	if (sharingReview) sharingReview.hidden = true;
+	if (sharingReviewList) sharingReviewList.textContent = "";
+	if (sharingReviewMeta) sharingReviewMeta.textContent = "";
+	if (legacyClaims) legacyClaims.hidden = true;
+	if (legacyClaimsMeta) legacyClaimsMeta.textContent = "";
 }
 
 export async function loadSyncData() {
-  const requestId = ++latestSyncLoadRequestId;
-  try {
-    const project = state.currentProject || '';
-    const includeJoinRequests = state.activeTab === 'sync';
-    const useCache = state.activeTab === 'health';
-    let fetchedFreshSyncStatus = false;
+	const requestId = ++latestSyncLoadRequestId;
+	try {
+		const project = state.currentProject || "";
+		const includeJoinRequests = state.activeTab === "sync";
+		const useCache = state.activeTab === "health";
+		let fetchedFreshSyncStatus = false;
 
-    let payload: SyncStatusResponseLike;
-    if (useCache) {
-      payload = readCachedSyncStatus(project);
-      if (!payload) {
-        payload = await api.loadSyncStatus(true, project, { includeJoinRequests: false });
-        fetchedFreshSyncStatus = true;
-      }
-    } else {
-      payload = await api.loadSyncStatus(true, project, { includeJoinRequests });
-      fetchedFreshSyncStatus = true;
-    }
+		let payload: SyncStatusResponseLike;
+		if (useCache) {
+			payload = readCachedSyncStatus(project);
+			if (!payload) {
+				payload = await api.loadSyncStatus(true, project, { includeJoinRequests: false });
+				fetchedFreshSyncStatus = true;
+			}
+		} else {
+			payload = await api.loadSyncStatus(true, project, { includeJoinRequests });
+			fetchedFreshSyncStatus = true;
+		}
 
-    let actorsPayload: SyncActorListResponseLike | null = null;
-    let actorLoadError = false;
-    const duplicatePersonDecisions = readDuplicatePersonDecisions();
-    try {
-      actorsPayload = await api.loadSyncActors();
-    } catch {
-      actorLoadError = true;
-    }
+		let actorsPayload: SyncActorListResponseLike | null = null;
+		let actorLoadError = false;
+		const duplicatePersonDecisions = readDuplicatePersonDecisions();
+		try {
+			actorsPayload = await api.loadSyncActors();
+		} catch {
+			actorLoadError = true;
+		}
 
-    if (requestId !== latestSyncLoadRequestId) return;
+		if (requestId !== latestSyncLoadRequestId) return;
 
-    if (fetchedFreshSyncStatus) {
-      writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
-    }
+		if (fetchedFreshSyncStatus) {
+			writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
+		}
 
-    // Skip re-render if data hasn't changed since last poll
-    const hash = JSON.stringify([payload, actorsPayload, duplicatePersonDecisions]);
-    if (hash === lastSyncHash) return;
-    lastSyncHash = hash;
+		// Skip re-render if data hasn't changed since last poll
+		const hash = JSON.stringify([payload, actorsPayload, duplicatePersonDecisions]);
+		if (hash === lastSyncHash) return;
+		lastSyncHash = hash;
 
-    const statusPayload =
-      payload.status && typeof payload.status === 'object' ? payload.status : null;
-    if (statusPayload) state.lastSyncStatus = statusPayload;
-    if (Array.isArray(actorsPayload?.items)) {
-      state.lastSyncActors = actorsPayload.items;
-    } else {
-      state.lastSyncActors = [];
-    }
-    const payloadPeers = Array.isArray(payload.peers) ? payload.peers : [];
-    const realPeerIds = new Set(payloadPeers.map((peer: SyncPeerSummaryLike) => String(peer?.peer_device_id || '').trim()).filter(Boolean));
-    const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
-      ? state.pendingAcceptedSyncPeers.filter((peer: SyncPeerSummaryLike) => {
-          const peerId = String(peer?.peer_device_id || '').trim();
-          return peerId && !realPeerIds.has(peerId);
-        })
-      : [];
-    state.pendingAcceptedSyncPeers = pendingPeers;
-    state.lastSyncPeers = [...payloadPeers, ...pendingPeers];
-    state.lastSyncSharingReview = payload.sharing_review || [];
-    state.lastSyncCoordinator = payload.coordinator || null;
-    if (Array.isArray(payload.join_requests)) {
-      state.lastSyncJoinRequests = payload.join_requests;
-    }
-    state.lastSyncAttempts = payload.attempts || [];
-    state.lastSyncLegacyDevices = payload.legacy_devices || [];
-    state.lastSyncDuplicatePersonDecisions = duplicatePersonDecisions;
-    state.lastSyncViewModel = deriveSyncViewModel({
-      actors: state.lastSyncActors,
-      peers: state.lastSyncPeers,
-      coordinator: state.lastSyncCoordinator,
-      duplicatePersonDecisions: state.lastSyncDuplicatePersonDecisions,
-    });
-    renderSyncStatus();
-    renderTeamSync();
-    renderSyncActors();
-    renderSyncSharingReview();
-    renderSyncPeers();
-    renderLegacyDeviceClaims();
-    renderSyncAttempts();
-    // Re-render health indicators since they consume sync state (health dot, etc.)
-    renderHealthOverview();
-    if (actorLoadError) {
-      renderSyncActorsUnavailable();
-    }
-  } catch {
-    if (requestId !== latestSyncLoadRequestId) return;
-    lastSyncHash = '';
-    // Clear all skeletons so the error state is visible, not masked by loading placeholders
-    hideSkeleton('syncTeamSkeleton');
-    hideSkeleton('syncActorsSkeleton');
-    hideSkeleton('syncPeersSkeleton');
-    hideSkeleton('syncDiagSkeleton');
-    hideStaleSyncSecondarySections();
-    renderSyncPeopleUnavailable();
-    renderSyncDiagnosticsUnavailable();
-  }
+		const statusPayload =
+			payload.status && typeof payload.status === "object" ? payload.status : null;
+		if (statusPayload) state.lastSyncStatus = statusPayload;
+		if (Array.isArray(actorsPayload?.items)) {
+			state.lastSyncActors = actorsPayload.items;
+		} else {
+			state.lastSyncActors = [];
+		}
+		const payloadPeers = Array.isArray(payload.peers) ? payload.peers : [];
+		const realPeerIds = new Set(
+			payloadPeers
+				.map((peer: SyncPeerSummaryLike) => String(peer?.peer_device_id || "").trim())
+				.filter(Boolean),
+		);
+		const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
+			? state.pendingAcceptedSyncPeers.filter((peer: SyncPeerSummaryLike) => {
+					const peerId = String(peer?.peer_device_id || "").trim();
+					return peerId && !realPeerIds.has(peerId);
+				})
+			: [];
+		state.pendingAcceptedSyncPeers = pendingPeers;
+		state.lastSyncPeers = [...payloadPeers, ...pendingPeers];
+		state.lastSyncSharingReview = payload.sharing_review || [];
+		state.lastSyncCoordinator = payload.coordinator || null;
+		if (Array.isArray(payload.join_requests)) {
+			state.lastSyncJoinRequests = payload.join_requests;
+		}
+		state.lastSyncAttempts = payload.attempts || [];
+		state.lastSyncLegacyDevices = payload.legacy_devices || [];
+		state.lastSyncDuplicatePersonDecisions = duplicatePersonDecisions;
+		state.lastSyncViewModel = deriveSyncViewModel({
+			actors: state.lastSyncActors,
+			peers: state.lastSyncPeers,
+			coordinator: state.lastSyncCoordinator,
+			duplicatePersonDecisions: state.lastSyncDuplicatePersonDecisions,
+		});
+		renderSyncStatus();
+		renderTeamSync();
+		renderSyncActors();
+		renderSyncSharingReview();
+		renderSyncPeers();
+		renderLegacyDeviceClaims();
+		renderSyncAttempts();
+		// Re-render health indicators since they consume sync state (health dot, etc.)
+		renderHealthOverview();
+		if (actorLoadError) {
+			renderSyncActorsUnavailable();
+		}
+	} catch {
+		if (requestId !== latestSyncLoadRequestId) return;
+		lastSyncHash = "";
+		// Clear all skeletons so the error state is visible, not masked by loading placeholders
+		hideSkeleton("syncTeamSkeleton");
+		hideSkeleton("syncActorsSkeleton");
+		hideSkeleton("syncPeersSkeleton");
+		hideSkeleton("syncDiagSkeleton");
+		hideStaleSyncSecondarySections();
+		renderSyncPeopleUnavailable();
+		renderSyncDiagnosticsUnavailable();
+	}
 }
 
 export function resetSyncLoadStateForTests() {
-  lastSyncHash = '';
-  cachedSyncStatus = null;
-  latestSyncLoadRequestId = 0;
+	lastSyncHash = "";
+	cachedSyncStatus = null;
+	latestSyncLoadRequestId = 0;
 }
 
 export async function loadPairingData() {
-  try {
-    const payload = await api.loadPairing();
-    state.pairingPayloadRaw = payload || null;
-    renderPairing();
-  } catch {
-    state.pairingPayloadRaw = null;
-    renderPairing();
-  }
+	try {
+		const payload = await api.loadPairing();
+		state.pairingPayloadRaw = payload || null;
+		renderPairing();
+	} catch {
+		state.pairingPayloadRaw = null;
+		renderPairing();
+	}
 }
 
 /* ── Init ────────────────────────────────────────────────── */
 
 export function initSyncTab(refreshCallback: () => void) {
-  ensureSyncRenderBoundary();
-  ensureSyncDialogHost();
-  // Wire cross-module callbacks to avoid circular imports
-  setTeamSyncLoadData(loadSyncData);
-  setPeopleLoadData(loadSyncData);
-  setRenderSyncPeers(renderSyncPeers);
+	ensureSyncRenderBoundary();
+	ensureSyncDialogHost();
+	// Wire cross-module callbacks to avoid circular imports
+	setTeamSyncLoadData(loadSyncData);
+	setPeopleLoadData(loadSyncData);
+	setRenderSyncPeers(renderSyncPeers);
 
-  initTeamSyncEvents(refreshCallback, loadSyncData);
-  initPeopleEvents(loadSyncData);
-  initDiagnosticsEvents(refreshCallback);
-  // loadSyncData() is NOT called here — app.ts refresh() handles the initial load
-  // to avoid duplicate requests and state races at startup.
+	initTeamSyncEvents(refreshCallback, loadSyncData);
+	initPeopleEvents(loadSyncData);
+	initDiagnosticsEvents(refreshCallback);
+	// loadSyncData() is NOT called here — app.ts refresh() handles the initial load
+	// to avoid duplicate requests and state races at startup.
 }

--- a/packages/ui/src/tabs/sync/peer-scope-collapsible.tsx
+++ b/packages/ui/src/tabs/sync/peer-scope-collapsible.tsx
@@ -1,60 +1,57 @@
-import * as Collapsible from '@radix-ui/react-collapsible';
-import type { ComponentChildren } from 'preact';
-import { createPortal } from 'preact/compat';
-import { useEffect, useLayoutEffect, useState } from 'preact/hooks';
-import { renderIntoSyncMount } from './components/render-root';
+import * as Collapsible from "@radix-ui/react-collapsible";
+import type { ComponentChildren } from "preact";
+import { createPortal } from "preact/compat";
+import { useEffect, useLayoutEffect, useState } from "preact/hooks";
+import { renderIntoSyncMount } from "./components/render-root";
 
 export type PeerScopeCollapsibleProps = {
-  contentHost: HTMLElement | null;
-  initialOpen: boolean;
-  onOpenChange: (open: boolean) => void;
-  children: ComponentChildren;
+	contentHost: HTMLElement | null;
+	initialOpen: boolean;
+	onOpenChange: (open: boolean) => void;
+	children: ComponentChildren;
 };
 
 export function PeerScopeCollapsible({
-  contentHost,
-  initialOpen,
-  onOpenChange,
-  children,
+	contentHost,
+	initialOpen,
+	onOpenChange,
+	children,
 }: PeerScopeCollapsibleProps) {
-  const [open, setOpen] = useState(initialOpen);
+	const [open, setOpen] = useState(initialOpen);
 
-  useEffect(() => {
-    setOpen(initialOpen);
-  }, [initialOpen]);
+	useEffect(() => {
+		setOpen(initialOpen);
+	}, [initialOpen]);
 
-  useLayoutEffect(() => {
-    onOpenChange(open);
-  }, [onOpenChange, open]);
+	useLayoutEffect(() => {
+		onOpenChange(open);
+	}, [onOpenChange, open]);
 
-  const content = (
-    <Collapsible.Content
-      forceMount
-      className={`peer-scope-editor-wrap${open ? '' : ' collapsed'}`}
-      hidden={!open}
-      inert={!open}
-    >
-      <ScopeEditorContent>{children}</ScopeEditorContent>
-    </Collapsible.Content>
-  );
+	const content = (
+		<Collapsible.Content
+			forceMount
+			className={`peer-scope-editor-wrap${open ? "" : " collapsed"}`}
+			hidden={!open}
+			inert={!open}
+		>
+			<ScopeEditorContent>{children}</ScopeEditorContent>
+		</Collapsible.Content>
+	);
 
-  return (
-    <Collapsible.Root open={open} onOpenChange={setOpen}>
-      <Collapsible.Trigger asChild>
-        <button type="button">{open ? 'Hide scope editor' : 'Edit scope'}</button>
-      </Collapsible.Trigger>
-      {contentHost ? createPortal(content, contentHost) : null}
-    </Collapsible.Root>
-  );
+	return (
+		<Collapsible.Root open={open} onOpenChange={setOpen}>
+			<Collapsible.Trigger asChild>
+				<button type="button">{open ? "Hide scope editor" : "Edit scope"}</button>
+			</Collapsible.Trigger>
+			{contentHost ? createPortal(content, contentHost) : null}
+		</Collapsible.Root>
+	);
 }
 
 function ScopeEditorContent({ children }: { children: ComponentChildren }) {
-  return <div>{children}</div>;
+	return <div>{children}</div>;
 }
 
-export function renderPeerScopeCollapsible(
-  mount: HTMLElement,
-  props: PeerScopeCollapsibleProps,
-) {
-  renderIntoSyncMount(mount, <PeerScopeCollapsible {...props} />);
+export function renderPeerScopeCollapsible(mount: HTMLElement, props: PeerScopeCollapsibleProps) {
+	renderIntoSyncMount(mount, <PeerScopeCollapsible {...props} />);
 }

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -1,329 +1,359 @@
 /* People card — people, devices, sharing review, legacy device claims. */
 
-import { state } from '../../lib/state';
-import * as api from '../../lib/api';
-import { showGlobalNotice } from '../../lib/notice';
-import { markFieldError, clearFieldError, friendlyError } from '../../lib/form';
+import * as api from "../../lib/api";
+import { clearFieldError, friendlyError, markFieldError } from "../../lib/form";
+import { showGlobalNotice } from "../../lib/notice";
+import { state } from "../../lib/state";
+import { renderSyncActorsList } from "./components/sync-actors";
+import { renderSyncEmptyState } from "./components/sync-diagnostics";
+import type { SyncActionFeedback } from "./components/sync-inline-feedback";
+import { renderLegacyClaimsSlice } from "./components/sync-legacy-claims";
+import { renderSyncPeersList } from "./components/sync-peers";
+import { clearPeerScopeReview, hideSkeleton, isPeerScopeReviewPending } from "./helpers";
+import { openSyncConfirmDialog } from "./sync-dialogs";
 import {
-  summarizeSyncRunResult,
-  deriveVisiblePeopleActors,
-  type VisiblePeopleResult,
-} from './view-model';
-import {
-  clearPeerScopeReview,
-  isPeerScopeReviewPending,
-  hideSkeleton,
-} from './helpers';
-import { openSyncConfirmDialog } from './sync-dialogs';
-import { renderSyncActorsList } from './components/sync-actors';
-import { renderSyncPeersList } from './components/sync-peers';
-import { renderSyncEmptyState } from './components/sync-diagnostics';
-import { renderLegacyClaimsSlice } from './components/sync-legacy-claims';
-import type { SyncActionFeedback } from './components/sync-inline-feedback';
+	deriveVisiblePeopleActors,
+	summarizeSyncRunResult,
+	type VisiblePeopleResult,
+} from "./view-model";
 
 /* ── loadSyncData callback (set by index module) ─────────── */
 
 let _loadSyncData: () => Promise<void> = async () => {};
-let legacyDeviceValue = '';
+let legacyDeviceValue = "";
 
 function setPeopleCreateControlsDisabled(disabled: boolean) {
-  const createButton = document.getElementById('syncActorCreateButton') as HTMLButtonElement | null;
-  const createInput = document.getElementById('syncActorCreateInput') as HTMLInputElement | null;
-  if (createButton) createButton.disabled = disabled;
-  if (createInput) createInput.disabled = disabled;
+	const createButton = document.getElementById("syncActorCreateButton") as HTMLButtonElement | null;
+	const createInput = document.getElementById("syncActorCreateInput") as HTMLInputElement | null;
+	if (createButton) createButton.disabled = disabled;
+	if (createInput) createInput.disabled = disabled;
 }
 
 export function setLoadSyncData(fn: () => Promise<void>) {
-  _loadSyncData = fn;
+	_loadSyncData = fn;
 }
 
 /* ── Actors renderer ─────────────────────────────────────── */
 
 export function renderSyncActors() {
-  const actorList = document.getElementById('syncActorsList');
-  const actorMeta = document.getElementById('syncActorsMeta');
-  if (!actorList) return;
-  hideSkeleton('syncActorsSkeleton');
-  setPeopleCreateControlsDisabled(false);
+	const actorList = document.getElementById("syncActorsList");
+	const actorMeta = document.getElementById("syncActorsMeta");
+	if (!actorList) return;
+	hideSkeleton("syncActorsSkeleton");
+	setPeopleCreateControlsDisabled(false);
 
-  const actorVisibility: VisiblePeopleResult = deriveVisiblePeopleActors({
-    actors: state.lastSyncActors,
-    peers: state.lastSyncPeers,
-    duplicatePeople: state.lastSyncViewModel?.duplicatePeople,
-  });
-  const actors = actorVisibility.visibleActors;
-  if (actorMeta) {
-    actorMeta.textContent = actors.length
-      ? 'Manage people here, then assign devices below.'
-      : 'No named people yet. Create a person here, then assign devices below so sync ownership is easier to review.';
-    if (actorVisibility.hiddenLocalDuplicateCount > 0) {
-      actorMeta.textContent += ` ${actorVisibility.hiddenLocalDuplicateCount} unresolved duplicate ${actorVisibility.hiddenLocalDuplicateCount === 1 ? 'entry is' : 'entries are'} hidden here until reviewed in Needs attention.`;
-    }
-  }
+	const actorVisibility: VisiblePeopleResult = deriveVisiblePeopleActors({
+		actors: state.lastSyncActors,
+		peers: state.lastSyncPeers,
+		duplicatePeople: state.lastSyncViewModel?.duplicatePeople,
+	});
+	const actors = actorVisibility.visibleActors;
+	if (actorMeta) {
+		actorMeta.textContent = actors.length
+			? "Manage people here, then assign devices below."
+			: "No named people yet. Create a person here, then assign devices below so sync ownership is easier to review.";
+		if (actorVisibility.hiddenLocalDuplicateCount > 0) {
+			actorMeta.textContent += ` ${actorVisibility.hiddenLocalDuplicateCount} unresolved duplicate ${actorVisibility.hiddenLocalDuplicateCount === 1 ? "entry is" : "entries are"} hidden here until reviewed in Needs attention.`;
+		}
+	}
 
-  renderSyncActorsList(actorList, {
-    actors,
-    hiddenLocalDuplicateCount: actorVisibility.hiddenLocalDuplicateCount,
-    onRename: async (actorId, nextName) => {
-      await api.renameActor(actorId, nextName);
-      await _loadSyncData();
-    },
-    onMerge: async (primaryActorId, secondaryActorId) => {
-      try {
-        await api.mergeActor(primaryActorId, secondaryActorId);
-        showGlobalNotice('People combined. Assigned devices moved to the selected person.');
-        await _loadSyncData();
-      } catch (error) {
-        showGlobalNotice(friendlyError(error, 'Failed to combine people.'), 'warning');
-        throw error;
-      }
-    },
-    onDeactivate: async (actorId) => {
-      try {
-        await api.deactivateActor(actorId);
-        showGlobalNotice('Person removed. Assigned devices have been unassigned.');
-        await _loadSyncData();
-      } catch (error) {
-        showGlobalNotice(friendlyError(error, 'Failed to remove person.'), 'warning');
-        throw error;
-      }
-    },
-  });
+	renderSyncActorsList(actorList, {
+		actors,
+		hiddenLocalDuplicateCount: actorVisibility.hiddenLocalDuplicateCount,
+		onRename: async (actorId, nextName) => {
+			await api.renameActor(actorId, nextName);
+			await _loadSyncData();
+		},
+		onMerge: async (primaryActorId, secondaryActorId) => {
+			try {
+				await api.mergeActor(primaryActorId, secondaryActorId);
+				showGlobalNotice("People combined. Assigned devices moved to the selected person.");
+				await _loadSyncData();
+			} catch (error) {
+				showGlobalNotice(friendlyError(error, "Failed to combine people."), "warning");
+				throw error;
+			}
+		},
+		onDeactivate: async (actorId) => {
+			try {
+				await api.deactivateActor(actorId);
+				showGlobalNotice("Person removed. Assigned devices have been unassigned.");
+				await _loadSyncData();
+			} catch (error) {
+				showGlobalNotice(friendlyError(error, "Failed to remove person."), "warning");
+				throw error;
+			}
+		},
+	});
 }
 
 export function renderSyncActorsUnavailable() {
-  const actorList = document.getElementById('syncActorsList');
-  const actorMeta = document.getElementById('syncActorsMeta');
-  setPeopleCreateControlsDisabled(true);
-  if (actorMeta) {
-    actorMeta.textContent =
-      'People controls are temporarily unavailable. Refresh this page to retry, but device status and sync health are still available below.';
-  }
-  if (actorList) {
-    renderSyncEmptyState(actorList, {
-      title: 'People unavailable right now.',
-      detail: 'Refresh this page to reload named people once the people endpoint is responding again.',
-    });
-  }
+	const actorList = document.getElementById("syncActorsList");
+	const actorMeta = document.getElementById("syncActorsMeta");
+	setPeopleCreateControlsDisabled(true);
+	if (actorMeta) {
+		actorMeta.textContent =
+			"People controls are temporarily unavailable. Refresh this page to retry, but device status and sync health are still available below.";
+	}
+	if (actorList) {
+		renderSyncEmptyState(actorList, {
+			title: "People unavailable right now.",
+			detail:
+				"Refresh this page to reload named people once the people endpoint is responding again.",
+		});
+	}
 }
 
 /* ── Devices renderer ────────────────────────────────────── */
 
 export function renderSyncPeers() {
-  const syncPeers = document.getElementById('syncPeers');
-  if (!syncPeers) return;
-  hideSkeleton('syncPeersSkeleton');
-  const peers = state.lastSyncPeers;
-  renderSyncPeersList(syncPeers, {
-    peers: Array.isArray(peers) ? peers : [],
-    onRename: async (peerId, nextName) => {
-      try {
-        await api.renamePeer(peerId, nextName);
-        await _loadSyncData();
-        return { message: 'Device name saved.', tone: 'success' } satisfies SyncActionFeedback;
-      } catch (error) {
-        return { message: friendlyError(error, 'Failed to save device name.'), tone: 'warning' } satisfies SyncActionFeedback;
-      }
-    },
-    onSync: async (peer, address) => {
-      try {
-        const result = await api.triggerSync(address);
-        const summary = summarizeSyncRunResult(result);
-        const peerId = String(peer?.peer_device_id || '');
-        let feedback: SyncActionFeedback | null;
-        if (!summary.ok) {
-          feedback = { message: summary.message, tone: 'warning' };
-        } else if (peerId && isPeerScopeReviewPending(peerId)) {
-          const displayName = peer?.name || (peerId ? peerId.slice(0, 8) : 'unknown');
-          feedback = {
-            message: `Triggered sync for ${displayName}. Review scope in this card if you want tighter sharing rules.`,
-            tone: 'warning',
-          };
-        } else {
-          feedback = { message: summary.message, tone: 'success' };
-        }
-        try {
-          await _loadSyncData();
-        } catch {
-          feedback = {
-            message:
-              'Sync started, but this view has not refreshed yet. Refresh the page or use Sync now again before retrying.',
-            tone: 'warning',
-          };
-        }
-        return feedback;
-      } catch (error) {
-        return { message: friendlyError(error, 'Failed to trigger sync.'), tone: 'warning' } satisfies SyncActionFeedback;
-      }
-    },
-    onRemove: async (peerId, label) => {
-      try {
-        await api.deletePeer(peerId);
-        const feedback = { message: `Removed peer ${label}.`, tone: 'success' } satisfies SyncActionFeedback;
-        state.syncPeerFeedbackById.delete(peerId);
-        state.syncPeersSectionFeedback = feedback;
-        await _loadSyncData();
-        return feedback;
-      } catch (error) {
-        return {
-          message: friendlyError(error, 'Failed to remove peer. The local peer entry is still here.'),
-          tone: 'warning',
-        } satisfies SyncActionFeedback;
-      }
-    },
-    onAssignActor: async (peerId, actorId) => {
-      try {
-        await api.assignPeerActor(peerId, actorId);
-        await _loadSyncData();
-        return { message: actorId ? 'Device person updated.' : 'Device person cleared.', tone: 'success' } satisfies SyncActionFeedback;
-      } catch (error) {
-        return {
-          message: friendlyError(error, 'Failed to update device person. The current assignment is unchanged.'),
-          tone: 'warning',
-        } satisfies SyncActionFeedback;
-      }
-    },
-    onSaveScope: async (peerId, include, exclude) => {
-      try {
-        await api.updatePeerScope(peerId, include, exclude);
-        clearPeerScopeReview(peerId);
-        await _loadSyncData();
-        return { message: 'Device sync scope saved.', tone: 'success' } satisfies SyncActionFeedback;
-      } catch (error) {
-        return {
-          message: friendlyError(error, 'Failed to save device scope. The current sharing rules are still active.'),
-          tone: 'warning',
-        } satisfies SyncActionFeedback;
-      }
-    },
-    onResetScope: async (peerId) => {
-      try {
-        await api.updatePeerScope(peerId, null, null, true);
-        clearPeerScopeReview(peerId);
-        await _loadSyncData();
-        return { message: 'Device sync scope reset to global defaults.', tone: 'success' } satisfies SyncActionFeedback;
-      } catch (error) {
-        return {
-          message: friendlyError(error, 'Failed to reset device scope. The current sharing rules are still active.'),
-          tone: 'warning',
-        } satisfies SyncActionFeedback;
-      }
-    },
-  });
+	const syncPeers = document.getElementById("syncPeers");
+	if (!syncPeers) return;
+	hideSkeleton("syncPeersSkeleton");
+	const peers = state.lastSyncPeers;
+	renderSyncPeersList(syncPeers, {
+		peers: Array.isArray(peers) ? peers : [],
+		onRename: async (peerId, nextName) => {
+			try {
+				await api.renamePeer(peerId, nextName);
+				await _loadSyncData();
+				return { message: "Device name saved.", tone: "success" } satisfies SyncActionFeedback;
+			} catch (error) {
+				return {
+					message: friendlyError(error, "Failed to save device name."),
+					tone: "warning",
+				} satisfies SyncActionFeedback;
+			}
+		},
+		onSync: async (peer, address) => {
+			try {
+				const result = await api.triggerSync(address);
+				const summary = summarizeSyncRunResult(result);
+				const peerId = String(peer?.peer_device_id || "");
+				let feedback: SyncActionFeedback | null;
+				if (!summary.ok) {
+					feedback = { message: summary.message, tone: "warning" };
+				} else if (peerId && isPeerScopeReviewPending(peerId)) {
+					const displayName = peer?.name || (peerId ? peerId.slice(0, 8) : "unknown");
+					feedback = {
+						message: `Triggered sync for ${displayName}. Review scope in this card if you want tighter sharing rules.`,
+						tone: "warning",
+					};
+				} else {
+					feedback = { message: summary.message, tone: "success" };
+				}
+				try {
+					await _loadSyncData();
+				} catch {
+					feedback = {
+						message:
+							"Sync started, but this view has not refreshed yet. Refresh the page or use Sync now again before retrying.",
+						tone: "warning",
+					};
+				}
+				return feedback;
+			} catch (error) {
+				return {
+					message: friendlyError(error, "Failed to trigger sync."),
+					tone: "warning",
+				} satisfies SyncActionFeedback;
+			}
+		},
+		onRemove: async (peerId, label) => {
+			try {
+				await api.deletePeer(peerId);
+				const feedback = {
+					message: `Removed peer ${label}.`,
+					tone: "success",
+				} satisfies SyncActionFeedback;
+				state.syncPeerFeedbackById.delete(peerId);
+				state.syncPeersSectionFeedback = feedback;
+				await _loadSyncData();
+				return feedback;
+			} catch (error) {
+				return {
+					message: friendlyError(
+						error,
+						"Failed to remove peer. The local peer entry is still here.",
+					),
+					tone: "warning",
+				} satisfies SyncActionFeedback;
+			}
+		},
+		onAssignActor: async (peerId, actorId) => {
+			try {
+				await api.assignPeerActor(peerId, actorId);
+				await _loadSyncData();
+				return {
+					message: actorId ? "Device person updated." : "Device person cleared.",
+					tone: "success",
+				} satisfies SyncActionFeedback;
+			} catch (error) {
+				return {
+					message: friendlyError(
+						error,
+						"Failed to update device person. The current assignment is unchanged.",
+					),
+					tone: "warning",
+				} satisfies SyncActionFeedback;
+			}
+		},
+		onSaveScope: async (peerId, include, exclude) => {
+			try {
+				await api.updatePeerScope(peerId, include, exclude);
+				clearPeerScopeReview(peerId);
+				await _loadSyncData();
+				return {
+					message: "Device sync scope saved.",
+					tone: "success",
+				} satisfies SyncActionFeedback;
+			} catch (error) {
+				return {
+					message: friendlyError(
+						error,
+						"Failed to save device scope. The current sharing rules are still active.",
+					),
+					tone: "warning",
+				} satisfies SyncActionFeedback;
+			}
+		},
+		onResetScope: async (peerId) => {
+			try {
+				await api.updatePeerScope(peerId, null, null, true);
+				clearPeerScopeReview(peerId);
+				await _loadSyncData();
+				return {
+					message: "Device sync scope reset to global defaults.",
+					tone: "success",
+				} satisfies SyncActionFeedback;
+			} catch (error) {
+				return {
+					message: friendlyError(
+						error,
+						"Failed to reset device scope. The current sharing rules are still active.",
+					),
+					tone: "warning",
+				} satisfies SyncActionFeedback;
+			}
+		},
+	});
 }
 
 export function renderSyncPeopleUnavailable() {
-  const actorList = document.getElementById('syncActorsList');
-  const actorMeta = document.getElementById('syncActorsMeta');
-  const syncPeers = document.getElementById('syncPeers');
-  setPeopleCreateControlsDisabled(true);
-  if (actorMeta) {
-    actorMeta.textContent =
-      'People and device details are unavailable right now. Refresh this page to retry once local sync status is reachable again.';
-  }
-  if (actorList) {
-    renderSyncEmptyState(actorList, {
-      title: 'People unavailable right now.',
-      detail: 'Refresh this page to reload named people once the local sync status endpoint is responding again.',
-    });
-  }
-  if (syncPeers) {
-    renderSyncEmptyState(syncPeers, {
-      title: 'Devices unavailable right now.',
-      detail: 'Refresh this page to reload paired devices. When sync is reachable again, you can rename, assign, or pair devices here.',
-    });
-  }
+	const actorList = document.getElementById("syncActorsList");
+	const actorMeta = document.getElementById("syncActorsMeta");
+	const syncPeers = document.getElementById("syncPeers");
+	setPeopleCreateControlsDisabled(true);
+	if (actorMeta) {
+		actorMeta.textContent =
+			"People and device details are unavailable right now. Refresh this page to retry once local sync status is reachable again.";
+	}
+	if (actorList) {
+		renderSyncEmptyState(actorList, {
+			title: "People unavailable right now.",
+			detail:
+				"Refresh this page to reload named people once the local sync status endpoint is responding again.",
+		});
+	}
+	if (syncPeers) {
+		renderSyncEmptyState(syncPeers, {
+			title: "Devices unavailable right now.",
+			detail:
+				"Refresh this page to reload paired devices. When sync is reachable again, you can rename, assign, or pair devices here.",
+		});
+	}
 }
 
 /* ── Legacy device claims renderer ───────────────────────── */
 
 export function renderLegacyDeviceClaims() {
-  const panel = document.getElementById('syncLegacyClaims');
-  const mount = document.getElementById('syncLegacyDeviceSelectMount') as HTMLElement | null;
-  const meta = document.getElementById('syncLegacyClaimsMeta');
-  if (!panel || !mount || !meta) return;
+	const panel = document.getElementById("syncLegacyClaims");
+	const mount = document.getElementById("syncLegacyDeviceSelectMount") as HTMLElement | null;
+	const meta = document.getElementById("syncLegacyClaimsMeta");
+	if (!panel || !mount || !meta) return;
 
-  const devices = Array.isArray(state.lastSyncLegacyDevices) ? state.lastSyncLegacyDevices : [];
-  renderLegacyClaimsSlice({
-    devices,
-    meta,
-    mount,
-    onValueChange: (value) => {
-      if (value === legacyDeviceValue) return;
-      legacyDeviceValue = value;
-      renderLegacyDeviceClaims();
-    },
-    panel,
-    value: legacyDeviceValue,
-  });
+	const devices = Array.isArray(state.lastSyncLegacyDevices) ? state.lastSyncLegacyDevices : [];
+	renderLegacyClaimsSlice({
+		devices,
+		meta,
+		mount,
+		onValueChange: (value) => {
+			if (value === legacyDeviceValue) return;
+			legacyDeviceValue = value;
+			renderLegacyDeviceClaims();
+		},
+		panel,
+		value: legacyDeviceValue,
+	});
 }
 
 /* ── Event wiring ────────────────────────────────────────── */
 
 export function initPeopleEvents(loadSyncData: () => Promise<void>) {
-  const syncActorCreateButton = document.getElementById(
-    'syncActorCreateButton',
-  ) as HTMLButtonElement | null;
-  const syncActorCreateInput = document.getElementById(
-    'syncActorCreateInput',
-  ) as HTMLInputElement | null;
-  const syncLegacyClaimButton = document.getElementById(
-    'syncLegacyClaimButton',
-  ) as HTMLButtonElement | null;
+	const syncActorCreateButton = document.getElementById(
+		"syncActorCreateButton",
+	) as HTMLButtonElement | null;
+	const syncActorCreateInput = document.getElementById(
+		"syncActorCreateInput",
+	) as HTMLInputElement | null;
+	const syncLegacyClaimButton = document.getElementById(
+		"syncLegacyClaimButton",
+	) as HTMLButtonElement | null;
 
-  syncActorCreateButton?.addEventListener('click', async () => {
-    if (!syncActorCreateButton || !syncActorCreateInput) return;
-    const displayName = String(syncActorCreateInput.value || '').trim();
-    if (!displayName) {
-      markFieldError(syncActorCreateInput, 'Enter a name for the person.');
-      return;
-    }
-    clearFieldError(syncActorCreateInput);
-    syncActorCreateButton.disabled = true;
-    syncActorCreateInput.disabled = true;
-    syncActorCreateButton.textContent = 'Creating\u2026';
-    try {
-      await api.createActor(displayName);
-      showGlobalNotice('Person created.');
-      syncActorCreateInput.value = '';
-      await loadSyncData();
-    } catch (error) {
-      showGlobalNotice(friendlyError(error, 'Failed to create person.'), 'warning');
-      syncActorCreateButton.textContent = 'Retry';
-      syncActorCreateButton.disabled = false;
-      syncActorCreateInput.disabled = false;
-      return;
-    }
-    syncActorCreateButton.textContent = 'Create person';
-    syncActorCreateButton.disabled = false;
-    syncActorCreateInput.disabled = false;
-  });
+	syncActorCreateButton?.addEventListener("click", async () => {
+		if (!syncActorCreateButton || !syncActorCreateInput) return;
+		const displayName = String(syncActorCreateInput.value || "").trim();
+		if (!displayName) {
+			markFieldError(syncActorCreateInput, "Enter a name for the person.");
+			return;
+		}
+		clearFieldError(syncActorCreateInput);
+		syncActorCreateButton.disabled = true;
+		syncActorCreateInput.disabled = true;
+		syncActorCreateButton.textContent = "Creating\u2026";
+		try {
+			await api.createActor(displayName);
+			showGlobalNotice("Person created.");
+			syncActorCreateInput.value = "";
+			await loadSyncData();
+		} catch (error) {
+			showGlobalNotice(friendlyError(error, "Failed to create person."), "warning");
+			syncActorCreateButton.textContent = "Retry";
+			syncActorCreateButton.disabled = false;
+			syncActorCreateInput.disabled = false;
+			return;
+		}
+		syncActorCreateButton.textContent = "Create person";
+		syncActorCreateButton.disabled = false;
+		syncActorCreateInput.disabled = false;
+	});
 
-  syncLegacyClaimButton?.addEventListener('click', async () => {
-    const originDeviceId = String(legacyDeviceValue || '').trim();
-    if (!originDeviceId || !syncLegacyClaimButton) return;
-    const confirmed = await openSyncConfirmDialog({
-      title: `Attach history from ${originDeviceId}?`,
-      description: 'This updates legacy provenance so the older device history is attached to you on this device.',
-      confirmLabel: 'Attach history',
-      cancelLabel: 'Cancel',
-      tone: 'danger',
-    });
-    if (!confirmed) return;
-    syncLegacyClaimButton.disabled = true;
-    const originalText = syncLegacyClaimButton.textContent || 'Attach device history';
-    syncLegacyClaimButton.textContent = 'Attaching\u2026';
-    try {
-      await api.claimLegacyDeviceIdentity(originDeviceId);
-      showGlobalNotice('Old device history attached to you.');
-      await loadSyncData();
-    } catch (error) {
-      showGlobalNotice(friendlyError(error, 'Failed to attach old device history.'), 'warning');
-      syncLegacyClaimButton.textContent = 'Retry';
-      syncLegacyClaimButton.disabled = false;
-      return;
-    }
-    syncLegacyClaimButton.textContent = originalText;
-    syncLegacyClaimButton.disabled = false;
-  });
+	syncLegacyClaimButton?.addEventListener("click", async () => {
+		const originDeviceId = String(legacyDeviceValue || "").trim();
+		if (!originDeviceId || !syncLegacyClaimButton) return;
+		const confirmed = await openSyncConfirmDialog({
+			title: `Attach history from ${originDeviceId}?`,
+			description:
+				"This updates legacy provenance so the older device history is attached to you on this device.",
+			confirmLabel: "Attach history",
+			cancelLabel: "Cancel",
+			tone: "danger",
+		});
+		if (!confirmed) return;
+		syncLegacyClaimButton.disabled = true;
+		const originalText = syncLegacyClaimButton.textContent || "Attach device history";
+		syncLegacyClaimButton.textContent = "Attaching\u2026";
+		try {
+			await api.claimLegacyDeviceIdentity(originDeviceId);
+			showGlobalNotice("Old device history attached to you.");
+			await loadSyncData();
+		} catch (error) {
+			showGlobalNotice(friendlyError(error, "Failed to attach old device history."), "warning");
+			syncLegacyClaimButton.textContent = "Retry";
+			syncLegacyClaimButton.disabled = false;
+			return;
+		}
+		syncLegacyClaimButton.textContent = originalText;
+		syncLegacyClaimButton.disabled = false;
+	});
 }

--- a/packages/ui/src/tabs/sync/sync-dialogs.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs.tsx
@@ -1,45 +1,45 @@
-import { render } from 'preact';
-import { useEffect, useMemo, useState } from 'preact/hooks';
-import { RadixDialog } from '../../components/primitives/radix-dialog';
+import { render } from "preact";
+import { useEffect, useMemo, useState } from "preact/hooks";
+import { RadixDialog } from "../../components/primitives/radix-dialog";
 
-type DialogTone = 'default' | 'danger';
+type DialogTone = "default" | "danger";
 
 type ConfirmDialogRequest = {
-  kind: 'confirm';
-  cancelLabel?: string;
-  confirmLabel?: string;
-  description: string;
-  tone?: DialogTone;
-  title: string;
+	kind: "confirm";
+	cancelLabel?: string;
+	confirmLabel?: string;
+	description: string;
+	tone?: DialogTone;
+	title: string;
 };
 
 type InputDialogRequest = {
-  kind: 'input';
-  cancelLabel?: string;
-  confirmLabel?: string;
-  description: string;
-  initialValue?: string;
-  placeholder?: string;
-  title: string;
-  validate?: (value: string) => string | null;
+	kind: "input";
+	cancelLabel?: string;
+	confirmLabel?: string;
+	description: string;
+	initialValue?: string;
+	placeholder?: string;
+	title: string;
+	validate?: (value: string) => string | null;
 };
 
 export type DuplicatePersonActorOption = {
-  actorId: string;
-  isLocal?: boolean;
-  label: string;
+	actorId: string;
+	isLocal?: boolean;
+	label: string;
 };
 
 type DuplicatePersonDialogResult =
-  | { action: 'cancel' }
-  | { action: 'different-people' }
-  | { action: 'merge'; primaryActorId: string; secondaryActorId: string };
+	| { action: "cancel" }
+	| { action: "different-people" }
+	| { action: "merge"; primaryActorId: string; secondaryActorId: string };
 
 type DuplicatePersonDialogRequest = {
-  actors: DuplicatePersonActorOption[];
-  kind: 'duplicate-person';
-  summary: string;
-  title: string;
+	actors: DuplicatePersonActorOption[];
+	kind: "duplicate-person";
+	summary: string;
+	title: string;
 };
 
 type SyncDialogRequest = ConfirmDialogRequest | InputDialogRequest | DuplicatePersonDialogRequest;
@@ -51,300 +51,388 @@ let resolveDialog: ((value: SyncDialogResult) => void) | null = null;
 let setHostRequest: ((request: SyncDialogRequest | null) => void) | null = null;
 
 function fallbackResult(request: SyncDialogRequest | null): SyncDialogResult {
-  if (!request) return null;
-  if (request.kind === 'confirm') return false;
-  if (request.kind === 'input') return null;
-  return { action: 'cancel' };
+	if (!request) return null;
+	if (request.kind === "confirm") return false;
+	if (request.kind === "input") return null;
+	return { action: "cancel" };
 }
 
-function ensureDialogAvailable(requestKind: SyncDialogRequest['kind']): boolean {
-  if (!currentRequest || !resolveDialog) return true;
-  console.warn(`Ignored sync ${requestKind} dialog request because another sync dialog is already open.`);
-  return false;
+function ensureDialogAvailable(requestKind: SyncDialogRequest["kind"]): boolean {
+	if (!currentRequest || !resolveDialog) return true;
+	console.warn(
+		`Ignored sync ${requestKind} dialog request because another sync dialog is already open.`,
+	);
+	return false;
 }
 
 function setRequest(nextRequest: SyncDialogRequest | null) {
-  currentRequest = nextRequest;
-  setHostRequest?.(nextRequest);
+	currentRequest = nextRequest;
+	setHostRequest?.(nextRequest);
 }
 
 function resolveCurrentDialog(value: SyncDialogResult) {
-  const resolver = resolveDialog;
-  resolveDialog = null;
-  setRequest(null);
-  resolver?.(value);
+	const resolver = resolveDialog;
+	resolveDialog = null;
+	setRequest(null);
+	resolver?.(value);
 }
 
 function dialogToneClassName(tone: DialogTone | undefined) {
-  return tone === 'danger' ? 'sync-dialog-confirm danger' : 'sync-dialog-confirm';
+	return tone === "danger" ? "sync-dialog-confirm danger" : "sync-dialog-confirm";
 }
 
 function SyncDialogHost() {
-  const [request, setDialogState] = useState<SyncDialogRequest | null>(currentRequest);
+	const [request, setDialogState] = useState<SyncDialogRequest | null>(currentRequest);
 
-  useEffect(() => {
-    setHostRequest = setDialogState;
-    return () => {
-      if (setHostRequest === setDialogState) setHostRequest = null;
-    };
-  }, []);
+	useEffect(() => {
+		setHostRequest = setDialogState;
+		return () => {
+			if (setHostRequest === setDialogState) setHostRequest = null;
+		};
+	}, []);
 
-  const open = Boolean(request);
-  const titleId = useMemo(() => `sync-dialog-title-${request?.kind || 'none'}`, [request?.kind]);
-  const descriptionId = useMemo(() => `sync-dialog-description-${request?.kind || 'none'}`, [request?.kind]);
+	const open = Boolean(request);
+	const titleId = useMemo(() => `sync-dialog-title-${request?.kind || "none"}`, [request?.kind]);
+	const descriptionId = useMemo(
+		() => `sync-dialog-description-${request?.kind || "none"}`,
+		[request?.kind],
+	);
 
-  if (!request) return null;
+	if (!request) return null;
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (nextOpen) return;
-    resolveCurrentDialog(request?.kind === 'confirm' ? false : null);
-  };
+	const handleOpenChange = (nextOpen: boolean) => {
+		if (nextOpen) return;
+		resolveCurrentDialog(request?.kind === "confirm" ? false : null);
+	};
 
-  const handleOpenAutoFocus = (event: Event) => {
-    const primary = document.querySelector<HTMLElement>('#syncDialog [data-sync-primary-action="true"]');
-    if (!primary) return;
-    event.preventDefault();
-    primary.focus();
-  };
+	const handleOpenAutoFocus = (event: Event) => {
+		const primary = document.querySelector<HTMLElement>(
+			'#syncDialog [data-sync-primary-action="true"]',
+		);
+		if (!primary) return;
+		event.preventDefault();
+		primary.focus();
+	};
 
-  const body = request ? <SyncDialogBody descriptionId={descriptionId} request={request} titleId={titleId} /> : null;
+	const body = request ? (
+		<SyncDialogBody descriptionId={descriptionId} request={request} titleId={titleId} />
+	) : null;
 
-  return (
-    <RadixDialog
-      ariaDescribedby={descriptionId}
-      ariaLabelledby={titleId}
-      contentClassName="modal"
-      contentId="syncDialog"
-      onOpenAutoFocus={handleOpenAutoFocus}
-      onOpenChange={handleOpenChange}
-      open={open}
-      overlayClassName="modal-backdrop"
-      overlayId="syncDialogBackdrop"
-    >
-      {body}
-    </RadixDialog>
-  );
+	return (
+		<RadixDialog
+			ariaDescribedby={descriptionId}
+			ariaLabelledby={titleId}
+			contentClassName="modal"
+			contentId="syncDialog"
+			onOpenAutoFocus={handleOpenAutoFocus}
+			onOpenChange={handleOpenChange}
+			open={open}
+			overlayClassName="modal-backdrop"
+			overlayId="syncDialogBackdrop"
+		>
+			{body}
+		</RadixDialog>
+	);
 }
 
 function SyncDialogBody({
-  descriptionId,
-  request,
-  titleId,
+	descriptionId,
+	request,
+	titleId,
 }: {
-  descriptionId: string;
-  request: SyncDialogRequest;
-  titleId: string;
+	descriptionId: string;
+	request: SyncDialogRequest;
+	titleId: string;
 }) {
-  const [inputValue, setInputValue] = useState(request.kind === 'input' ? request.initialValue || '' : '');
-  const [errorText, setErrorText] = useState<string | null>(null);
-  const supportsLabels = request.kind !== 'duplicate-person';
-  const inputErrorId = 'syncDialogInputError';
+	const [inputValue, setInputValue] = useState(
+		request.kind === "input" ? request.initialValue || "" : "",
+	);
+	const [errorText, setErrorText] = useState<string | null>(null);
+	const supportsLabels = request.kind !== "duplicate-person";
+	const inputErrorId = "syncDialogInputError";
 
-  useEffect(() => {
-    if (request.kind === 'input') {
-      setInputValue(request.initialValue || '');
-      setErrorText(null);
-    }
-  }, [request]);
+	useEffect(() => {
+		if (request.kind === "input") {
+			setInputValue(request.initialValue || "");
+			setErrorText(null);
+		}
+	}, [request]);
 
-  const cancelLabel = supportsLabels ? request.cancelLabel || 'Cancel' : 'Cancel';
-  const confirmLabel = supportsLabels ? request.confirmLabel || (request.kind === 'confirm' ? 'Confirm' : 'Save') : 'Confirm';
+	const cancelLabel = supportsLabels ? request.cancelLabel || "Cancel" : "Cancel";
+	const confirmLabel = supportsLabels
+		? request.confirmLabel || (request.kind === "confirm" ? "Confirm" : "Save")
+		: "Confirm";
 
-  const submit = () => {
-    if (request.kind === 'confirm') {
-      resolveCurrentDialog(true);
-      return;
-    }
-    if (request.kind === 'duplicate-person') return;
-    const trimmed = inputValue.trim();
-    const validation = request.validate?.(trimmed) || null;
-    if (validation) {
-      setErrorText(validation);
-      return;
-    }
-    resolveCurrentDialog(trimmed);
-  };
+	const submit = () => {
+		if (request.kind === "confirm") {
+			resolveCurrentDialog(true);
+			return;
+		}
+		if (request.kind === "duplicate-person") return;
+		const trimmed = inputValue.trim();
+		const validation = request.validate?.(trimmed) || null;
+		if (validation) {
+			setErrorText(validation);
+			return;
+		}
+		resolveCurrentDialog(trimmed);
+	};
 
-  return (
-    <div className="modal-card sync-dialog-card">
-      <div className="modal-header">
-        <h2 id={titleId}>{request.title}</h2>
-        <button className="modal-close" onClick={() => resolveCurrentDialog(request.kind === 'confirm' ? false : null)} type="button">
-          close
-        </button>
-      </div>
-      <div className="modal-body">
-        {request.kind !== 'duplicate-person' ? <div className="small" id={descriptionId}>{request.description}</div> : null}
-        {request.kind === 'duplicate-person' ? <div className="small" id={descriptionId}>{request.summary}</div> : null}
-        {request.kind === 'input' ? (
-          <div className="field">
-            <input
-              aria-describedby={errorText ? `${descriptionId} ${inputErrorId}` : descriptionId}
-              autoFocus
-              className={errorText ? 'sync-dialog-input sync-field-error' : 'sync-dialog-input'}
-              data-sync-primary-action="true"
-              onInput={(event) => {
-                setInputValue(event.currentTarget.value);
-                if (errorText) setErrorText(null);
-              }}
-              onKeyDown={(event) => {
-                if (event.key !== 'Enter') return;
-                event.preventDefault();
-                submit();
-              }}
-              placeholder={request.placeholder}
-              type="text"
-              value={inputValue}
-            />
-            {errorText ? <div className="sync-field-hint" id={inputErrorId}>{errorText}</div> : null}
-          </div>
-        ) : null}
-        {request.kind === 'duplicate-person' ? <DuplicatePersonDialogContent descriptionId={descriptionId} request={request} /> : null}
-      </div>
-      <div className="modal-footer">
-        <div className="small" />
-        <div className="sync-dialog-actions">
-          <button className="settings-button" onClick={() => resolveCurrentDialog(request.kind === 'confirm' ? false : null)} type="button">
-            {cancelLabel}
-          </button>
-          {request.kind !== 'duplicate-person' ? (
-            <button autoFocus className={`settings-button ${dialogToneClassName(request.kind === 'confirm' ? request.tone : undefined)}`} data-sync-primary-action="true" onClick={submit} type="button">
-              {confirmLabel}
-            </button>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  );
+	return (
+		<div className="modal-card sync-dialog-card">
+			<div className="modal-header">
+				<h2 id={titleId}>{request.title}</h2>
+				<button
+					className="modal-close"
+					onClick={() => resolveCurrentDialog(request.kind === "confirm" ? false : null)}
+					type="button"
+				>
+					close
+				</button>
+			</div>
+			<div className="modal-body">
+				{request.kind !== "duplicate-person" ? (
+					<div className="small" id={descriptionId}>
+						{request.description}
+					</div>
+				) : null}
+				{request.kind === "duplicate-person" ? (
+					<div className="small" id={descriptionId}>
+						{request.summary}
+					</div>
+				) : null}
+				{request.kind === "input" ? (
+					<div className="field">
+						<input
+							aria-describedby={errorText ? `${descriptionId} ${inputErrorId}` : descriptionId}
+							autoFocus
+							className={errorText ? "sync-dialog-input sync-field-error" : "sync-dialog-input"}
+							data-sync-primary-action="true"
+							onInput={(event) => {
+								setInputValue(event.currentTarget.value);
+								if (errorText) setErrorText(null);
+							}}
+							onKeyDown={(event) => {
+								if (event.key !== "Enter") return;
+								event.preventDefault();
+								submit();
+							}}
+							placeholder={request.placeholder}
+							type="text"
+							value={inputValue}
+						/>
+						{errorText ? (
+							<div className="sync-field-hint" id={inputErrorId}>
+								{errorText}
+							</div>
+						) : null}
+					</div>
+				) : null}
+				{request.kind === "duplicate-person" ? (
+					<DuplicatePersonDialogContent descriptionId={descriptionId} request={request} />
+				) : null}
+			</div>
+			<div className="modal-footer">
+				<div className="small" />
+				<div className="sync-dialog-actions">
+					<button
+						className="settings-button"
+						onClick={() => resolveCurrentDialog(request.kind === "confirm" ? false : null)}
+						type="button"
+					>
+						{cancelLabel}
+					</button>
+					{request.kind !== "duplicate-person" ? (
+						<button
+							autoFocus
+							className={`settings-button ${dialogToneClassName(request.kind === "confirm" ? request.tone : undefined)}`}
+							data-sync-primary-action="true"
+							onClick={submit}
+							type="button"
+						>
+							{confirmLabel}
+						</button>
+					) : null}
+				</div>
+			</div>
+		</div>
+	);
 }
 
 function DuplicatePersonDialogContent({
-  descriptionId,
-  request,
+	descriptionId,
+	request,
 }: {
-  descriptionId: string;
-  request: DuplicatePersonDialogRequest;
+	descriptionId: string;
+	request: DuplicatePersonDialogRequest;
 }) {
-  const [step, setStep] = useState<'choice' | 'merge'>('choice');
-  const defaultPrimary = request.actors.find((actor) => actor.isLocal)?.actorId || request.actors[0]?.actorId || '';
-  const [primaryActorId, setPrimaryActorId] = useState(defaultPrimary);
-  const [secondaryActorId, setSecondaryActorId] = useState('');
+	const [step, setStep] = useState<"choice" | "merge">("choice");
+	const defaultPrimary =
+		request.actors.find((actor) => actor.isLocal)?.actorId || request.actors[0]?.actorId || "";
+	const [primaryActorId, setPrimaryActorId] = useState(defaultPrimary);
+	const [secondaryActorId, setSecondaryActorId] = useState("");
 
-  useEffect(() => {
-    setStep('choice');
-    const nextPrimaryActorId = request.actors.find((actor) => actor.isLocal)?.actorId || request.actors[0]?.actorId || '';
-    const nextSecondaryActorId = request.actors.find((actor) => actor.actorId !== nextPrimaryActorId)?.actorId || '';
-    setPrimaryActorId(nextPrimaryActorId);
-    setSecondaryActorId(nextSecondaryActorId);
-  }, [request]);
+	useEffect(() => {
+		setStep("choice");
+		const nextPrimaryActorId =
+			request.actors.find((actor) => actor.isLocal)?.actorId || request.actors[0]?.actorId || "";
+		const nextSecondaryActorId =
+			request.actors.find((actor) => actor.actorId !== nextPrimaryActorId)?.actorId || "";
+		setPrimaryActorId(nextPrimaryActorId);
+		setSecondaryActorId(nextSecondaryActorId);
+	}, [request]);
 
-  const primary = request.actors.find((actor) => actor.actorId === primaryActorId) || request.actors[0];
-  const mergeCandidates = request.actors.filter((actor) => actor.actorId !== primaryActorId);
-  const secondary = mergeCandidates.find((actor) => actor.actorId === secondaryActorId) || mergeCandidates[0];
+	const primary =
+		request.actors.find((actor) => actor.actorId === primaryActorId) || request.actors[0];
+	const mergeCandidates = request.actors.filter((actor) => actor.actorId !== primaryActorId);
+	const secondary =
+		mergeCandidates.find((actor) => actor.actorId === secondaryActorId) || mergeCandidates[0];
 
-  return step === 'choice' ? (
-    <div className="sync-dialog-stack">
-      <div className="sync-dialog-choice-list" role="list">
-        <button autoFocus className="settings-button" data-sync-primary-action="true" onClick={() => setStep('merge')} type="button">These are both me</button>
-        <button className="settings-button" onClick={() => resolveCurrentDialog({ action: 'different-people' })} type="button">These are different people</button>
-        <button className="settings-button" onClick={() => resolveCurrentDialog({ action: 'cancel' })} type="button">Decide later</button>
-      </div>
-    </div>
-  ) : (
-    <div className="sync-dialog-stack">
-      <div className="small" id={descriptionId}>Choose which person should remain after combining these duplicates.</div>
-      <div className="sync-dialog-radio-list" role="radiogroup" aria-describedby={descriptionId} aria-label="Person to keep after combining duplicates">
-        {request.actors.map((actor) => (
-          <label className="sync-dialog-radio-option" key={actor.actorId}>
-            <input
-              autoFocus={primaryActorId === actor.actorId}
-              checked={primaryActorId === actor.actorId}
-              data-sync-primary-action={primaryActorId === actor.actorId ? 'true' : undefined}
-              name="syncDuplicatePrimaryActor"
-              onChange={() => setPrimaryActorId(actor.actorId)}
-              type="radio"
-              value={actor.actorId}
-            />
-            <span>{actor.label}{actor.isLocal ? ' (You)' : ''}</span>
-          </label>
-        ))}
-      </div>
-      <div className="field">
-        <label className="small" htmlFor="syncDuplicateSecondaryActor">Person to combine into the selected record</label>
-        <select
-          className="sync-dialog-input"
-          data-sync-primary-action="true"
-          id="syncDuplicateSecondaryActor"
-          value={secondary?.actorId || ''}
-          onChange={(event) => setSecondaryActorId(event.currentTarget.value)}
-        >
-          {mergeCandidates.map((actor) => (
-            <option key={actor.actorId} value={actor.actorId}>
-              {actor.label}{actor.isLocal ? ' (You)' : ''}
-            </option>
-          ))}
-        </select>
-      </div>
-      <div className="sync-dialog-actions">
-        <button className="settings-button" onClick={() => setStep('choice')} type="button">Back</button>
-        <button
-          className="settings-button"
-          disabled={!primary?.actorId || !secondary?.actorId}
-          onClick={() => {
-            if (!primary?.actorId || !secondary?.actorId) return;
-            resolveCurrentDialog({
-              action: 'merge',
-              primaryActorId: primary.actorId,
-              secondaryActorId: secondary.actorId,
-            });
-          }}
-          type="button"
-        >
-          Combine people
-        </button>
-      </div>
-    </div>
-  );
+	return step === "choice" ? (
+		<div className="sync-dialog-stack">
+			<div className="sync-dialog-choice-list" role="list">
+				<button
+					autoFocus
+					className="settings-button"
+					data-sync-primary-action="true"
+					onClick={() => setStep("merge")}
+					type="button"
+				>
+					These are both me
+				</button>
+				<button
+					className="settings-button"
+					onClick={() => resolveCurrentDialog({ action: "different-people" })}
+					type="button"
+				>
+					These are different people
+				</button>
+				<button
+					className="settings-button"
+					onClick={() => resolveCurrentDialog({ action: "cancel" })}
+					type="button"
+				>
+					Decide later
+				</button>
+			</div>
+		</div>
+	) : (
+		<div className="sync-dialog-stack">
+			<div className="small" id={descriptionId}>
+				Choose which person should remain after combining these duplicates.
+			</div>
+			<div
+				className="sync-dialog-radio-list"
+				role="radiogroup"
+				aria-describedby={descriptionId}
+				aria-label="Person to keep after combining duplicates"
+			>
+				{request.actors.map((actor) => (
+					<label className="sync-dialog-radio-option" key={actor.actorId}>
+						<input
+							autoFocus={primaryActorId === actor.actorId}
+							checked={primaryActorId === actor.actorId}
+							data-sync-primary-action={primaryActorId === actor.actorId ? "true" : undefined}
+							name="syncDuplicatePrimaryActor"
+							onChange={() => setPrimaryActorId(actor.actorId)}
+							type="radio"
+							value={actor.actorId}
+						/>
+						<span>
+							{actor.label}
+							{actor.isLocal ? " (You)" : ""}
+						</span>
+					</label>
+				))}
+			</div>
+			<div className="field">
+				<label className="small" htmlFor="syncDuplicateSecondaryActor">
+					Person to combine into the selected record
+				</label>
+				<select
+					className="sync-dialog-input"
+					data-sync-primary-action="true"
+					id="syncDuplicateSecondaryActor"
+					value={secondary?.actorId || ""}
+					onChange={(event) => setSecondaryActorId(event.currentTarget.value)}
+				>
+					{mergeCandidates.map((actor) => (
+						<option key={actor.actorId} value={actor.actorId}>
+							{actor.label}
+							{actor.isLocal ? " (You)" : ""}
+						</option>
+					))}
+				</select>
+			</div>
+			<div className="sync-dialog-actions">
+				<button className="settings-button" onClick={() => setStep("choice")} type="button">
+					Back
+				</button>
+				<button
+					className="settings-button"
+					disabled={!primary?.actorId || !secondary?.actorId}
+					onClick={() => {
+						if (!primary?.actorId || !secondary?.actorId) return;
+						resolveCurrentDialog({
+							action: "merge",
+							primaryActorId: primary.actorId,
+							secondaryActorId: secondary.actorId,
+						});
+					}}
+					type="button"
+				>
+					Combine people
+				</button>
+			</div>
+		</div>
+	);
 }
 
 export function ensureSyncDialogHost() {
-  if (dialogMount && dialogMount.isConnected) return;
-  dialogMount = document.getElementById('syncDialogMount') as HTMLElement | null;
-  if (!dialogMount) {
-    dialogMount = document.createElement('div');
-    dialogMount.id = 'syncDialogMount';
-    document.body.appendChild(dialogMount);
-  }
-  render(<SyncDialogHost />, dialogMount);
+	if (dialogMount?.isConnected) return;
+	dialogMount = document.getElementById("syncDialogMount") as HTMLElement | null;
+	if (!dialogMount) {
+		dialogMount = document.createElement("div");
+		dialogMount.id = "syncDialogMount";
+		document.body.appendChild(dialogMount);
+	}
+	render(<SyncDialogHost />, dialogMount);
 }
 
-export function openSyncConfirmDialog(request: Omit<ConfirmDialogRequest, 'kind'>): Promise<boolean> {
-  ensureSyncDialogHost();
-  if (!ensureDialogAvailable('confirm')) return Promise.resolve(false);
-  return new Promise<boolean>((resolve) => {
-    resolveDialog = (value) => resolve(Boolean(value));
-    setRequest({ kind: 'confirm', ...request });
-  });
+export function openSyncConfirmDialog(
+	request: Omit<ConfirmDialogRequest, "kind">,
+): Promise<boolean> {
+	ensureSyncDialogHost();
+	if (!ensureDialogAvailable("confirm")) return Promise.resolve(false);
+	return new Promise<boolean>((resolve) => {
+		resolveDialog = (value) => resolve(Boolean(value));
+		setRequest({ kind: "confirm", ...request });
+	});
 }
 
-export function openSyncInputDialog(request: Omit<InputDialogRequest, 'kind'>): Promise<string | null> {
-  ensureSyncDialogHost();
-  if (!ensureDialogAvailable('input')) return Promise.resolve(null);
-  return new Promise<string | null>((resolve) => {
-    resolveDialog = (value) => resolve(typeof value === 'string' ? value : null);
-    setRequest({ kind: 'input', ...request });
-  });
+export function openSyncInputDialog(
+	request: Omit<InputDialogRequest, "kind">,
+): Promise<string | null> {
+	ensureSyncDialogHost();
+	if (!ensureDialogAvailable("input")) return Promise.resolve(null);
+	return new Promise<string | null>((resolve) => {
+		resolveDialog = (value) => resolve(typeof value === "string" ? value : null);
+		setRequest({ kind: "input", ...request });
+	});
 }
 
 export function openDuplicatePersonDialog(
-  request: Omit<DuplicatePersonDialogRequest, 'kind'>,
+	request: Omit<DuplicatePersonDialogRequest, "kind">,
 ): Promise<DuplicatePersonDialogResult> {
-  ensureSyncDialogHost();
-  if (!ensureDialogAvailable('duplicate-person')) {
-    return Promise.resolve(fallbackResult({ kind: 'duplicate-person', ...request }) as DuplicatePersonDialogResult);
-  }
-  return new Promise<DuplicatePersonDialogResult>((resolve) => {
-    resolveDialog = (value) => resolve((value as DuplicatePersonDialogResult) || { action: 'cancel' });
-    setRequest({ kind: 'duplicate-person', ...request });
-  });
+	ensureSyncDialogHost();
+	if (!ensureDialogAvailable("duplicate-person")) {
+		return Promise.resolve(
+			fallbackResult({ kind: "duplicate-person", ...request }) as DuplicatePersonDialogResult,
+		);
+	}
+	return new Promise<DuplicatePersonDialogResult>((resolve) => {
+		resolveDialog = (value) =>
+			resolve((value as DuplicatePersonDialogResult) || { action: "cancel" });
+		setRequest({ kind: "duplicate-person", ...request });
+	});
 }

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -1,189 +1,204 @@
 /* Team sync card — coordinator onboarding, invites, join requests. */
 
-import { h } from 'preact';
-import { state, setFeedScopeFilter, isSyncRedactionEnabled } from '../../lib/state';
-import * as api from '../../lib/api';
-import { showGlobalNotice } from '../../lib/notice';
-import { markFieldError, clearFieldError, friendlyError } from '../../lib/form';
+import { h } from "preact";
+import { RadixSelect, type RadixSelectOption } from "../../components/primitives/radix-select";
+import * as api from "../../lib/api";
+import { clearFieldError, friendlyError, markFieldError } from "../../lib/form";
+import { showGlobalNotice } from "../../lib/notice";
+import { isSyncRedactionEnabled, setFeedScopeFilter, state } from "../../lib/state";
+import { clearSyncMount, renderIntoSyncMount } from "./components/render-root";
+import { renderTeamSetupDisclosure } from "./components/sync-disclosure";
+import type { SyncActionFeedback } from "./components/sync-inline-feedback";
+import { SyncInviteJoinPanels } from "./components/sync-invite-join-panels";
+import { SyncSharingReview, type SyncSharingReviewItem } from "./components/sync-sharing-review";
 import {
-  adminSetupExpanded,
-  setAdminSetupExpanded,
-  teamInvitePanelOpen,
-  setTeamInvitePanelOpen,
-  hideSkeleton,
-  isPeerScopeReviewPending,
-  redactAddress,
-  requestPeerScopeReview,
-  clearDuplicatePersonDecision,
-  saveDuplicatePersonDecision,
-} from './helpers';
-import { clearSyncMount, renderIntoSyncMount } from './components/render-root';
-import { renderTeamSetupDisclosure } from './components/sync-disclosure';
-import { SyncInviteJoinPanels } from './components/sync-invite-join-panels';
-import type { SyncActionFeedback } from './components/sync-inline-feedback';
-import { SyncSharingReview, type SyncSharingReviewItem } from './components/sync-sharing-review';
+	type TeamSyncDiscoveredRow,
+	TeamSyncPanel,
+	type TeamSyncPendingJoinRequest,
+	type TeamSyncStatusSummary,
+} from "./components/team-sync-panel";
 import {
-  TeamSyncPanel,
-  type TeamSyncDiscoveredRow,
-  type TeamSyncPendingJoinRequest,
-  type TeamSyncStatusSummary,
-} from './components/team-sync-panel';
-import { openDuplicatePersonDialog, openSyncConfirmDialog, openSyncInputDialog } from './sync-dialogs';
+	adminSetupExpanded,
+	clearDuplicatePersonDecision,
+	hideSkeleton,
+	isPeerScopeReviewPending,
+	redactAddress,
+	requestPeerScopeReview,
+	saveDuplicatePersonDecision,
+	setAdminSetupExpanded,
+	setTeamInvitePanelOpen,
+	teamInvitePanelOpen,
+} from "./helpers";
 import {
-  deriveCoordinatorApprovalSummary,
-  resolveFriendlyDeviceName,
-  SYNC_TERMINOLOGY,
-  summarizeSyncRunResult,
-} from './view-model';
-import { RadixSelect, type RadixSelectOption } from '../../components/primitives/radix-select';
+	openDuplicatePersonDialog,
+	openSyncConfirmDialog,
+	openSyncInputDialog,
+} from "./sync-dialogs";
+import {
+	deriveCoordinatorApprovalSummary,
+	resolveFriendlyDeviceName,
+	SYNC_TERMINOLOGY,
+	summarizeSyncRunResult,
+} from "./view-model";
 
-const TEAM_SYNC_ACTIONS_MOUNT_ID = 'syncTeamActionsMount';
+const TEAM_SYNC_ACTIONS_MOUNT_ID = "syncTeamActionsMount";
 const INVITE_POLICY_OPTIONS: RadixSelectOption[] = [
-  { value: 'auto_admit', label: 'Auto-admit' },
-  { value: 'approval_required', label: 'Approval required' },
+	{ value: "auto_admit", label: "Auto-admit" },
+	{ value: "approval_required", label: "Approval required" },
 ];
 
-let invitePolicyValue: 'auto_admit' | 'approval_required' = 'auto_admit';
+let invitePolicyValue: "auto_admit" | "approval_required" = "auto_admit";
 
 function renderAdminSetupDisclosure() {
-  const mount = document.getElementById('syncAdminDisclosureMount') as HTMLElement | null;
-  if (!mount) return;
-  renderTeamSetupDisclosure(mount, {
-    open: adminSetupExpanded,
-    onOpenChange: (open) => {
-      setAdminSetupExpanded(open);
-      renderAdminSetupDisclosure();
-      renderInvitePolicySelect();
-      setInviteOutputVisibility();
-    },
-  });
+	const mount = document.getElementById("syncAdminDisclosureMount") as HTMLElement | null;
+	if (!mount) return;
+	renderTeamSetupDisclosure(mount, {
+		open: adminSetupExpanded,
+		onOpenChange: (open) => {
+			setAdminSetupExpanded(open);
+			renderAdminSetupDisclosure();
+			renderInvitePolicySelect();
+			setInviteOutputVisibility();
+		},
+	});
 }
 
 /* ── DOM placement helpers ───────────────────────────────── */
 
 function ensureInvitePanelInAdminSection() {
-  // Team setup disclosure now renders in-place through Radix collapsible.
+	// Team setup disclosure now renders in-place through Radix collapsible.
 }
 
 function ensureJoinPanelInSetupSection() {
-  const joinPanel = document.getElementById('syncJoinPanel');
-  const joinSection = document.getElementById('syncJoinSection');
-  if (!joinPanel || !joinSection) return;
-  if (joinPanel.parentElement !== joinSection) joinSection.appendChild(joinPanel);
+	const joinPanel = document.getElementById("syncJoinPanel");
+	const joinSection = document.getElementById("syncJoinSection");
+	if (!joinPanel || !joinSection) return;
+	if (joinPanel.parentElement !== joinSection) joinSection.appendChild(joinPanel);
 }
 
 function setInviteOutputVisibility() {
-  const syncInviteOutput = document.getElementById('syncInviteOutput') as HTMLTextAreaElement | null;
-  const syncInviteWarnings = document.getElementById('syncInviteWarnings') as HTMLDivElement | null;
-  if (!syncInviteOutput) return;
-  const encoded = String(state.lastTeamInvite?.encoded || '').trim();
-  syncInviteOutput.value = encoded;
-  syncInviteOutput.hidden = !encoded;
-  if (syncInviteWarnings) {
-    const warnings = Array.isArray(state.lastTeamInvite?.warnings) ? state.lastTeamInvite.warnings : [];
-    syncInviteWarnings.textContent = warnings.join(' · ');
-    syncInviteWarnings.hidden = warnings.length === 0;
-  }
+	const syncInviteOutput = document.getElementById(
+		"syncInviteOutput",
+	) as HTMLTextAreaElement | null;
+	const syncInviteWarnings = document.getElementById("syncInviteWarnings") as HTMLDivElement | null;
+	if (!syncInviteOutput) return;
+	const encoded = String(state.lastTeamInvite?.encoded || "").trim();
+	syncInviteOutput.value = encoded;
+	syncInviteOutput.hidden = !encoded;
+	if (syncInviteWarnings) {
+		const warnings = Array.isArray(state.lastTeamInvite?.warnings)
+			? state.lastTeamInvite.warnings
+			: [];
+		syncInviteWarnings.textContent = warnings.join(" · ");
+		syncInviteWarnings.hidden = warnings.length === 0;
+	}
 }
 
 function setJoinFeedbackVisibility() {
-  const syncJoinFeedback = document.getElementById('syncJoinFeedback') as HTMLDivElement | null;
-  if (!syncJoinFeedback) return;
-  const feedback = state.syncJoinFlowFeedback;
-  syncJoinFeedback.textContent = feedback?.message || '';
-  syncJoinFeedback.hidden = !feedback?.message;
-  syncJoinFeedback.setAttribute('role', feedback?.tone === 'warning' ? 'alert' : 'status');
-  syncJoinFeedback.setAttribute('aria-live', feedback?.tone === 'warning' ? 'assertive' : 'polite');
-  syncJoinFeedback.className = `peer-meta${feedback ? ` ${feedback.tone === 'warning' ? 'sync-inline-feedback warning' : 'sync-inline-feedback success'}` : ''}`;
+	const syncJoinFeedback = document.getElementById("syncJoinFeedback") as HTMLDivElement | null;
+	if (!syncJoinFeedback) return;
+	const feedback = state.syncJoinFlowFeedback;
+	syncJoinFeedback.textContent = feedback?.message || "";
+	syncJoinFeedback.hidden = !feedback?.message;
+	syncJoinFeedback.setAttribute("role", feedback?.tone === "warning" ? "alert" : "status");
+	syncJoinFeedback.setAttribute("aria-live", feedback?.tone === "warning" ? "assertive" : "polite");
+	syncJoinFeedback.className = `peer-meta${feedback ? ` ${feedback.tone === "warning" ? "sync-inline-feedback warning" : "sync-inline-feedback success"}` : ""}`;
 }
 
 function clearContent(node: HTMLElement | null) {
-  if (node) node.textContent = '';
+	if (node) node.textContent = "";
 }
 
 function pulseAttentionTarget(target: HTMLElement | null) {
-  if (!(target instanceof HTMLElement)) return;
-  target.classList.remove('sync-attention-target');
-  void target.offsetWidth;
-  target.classList.add('sync-attention-target');
-  window.setTimeout(() => target.classList.remove('sync-attention-target'), 900);
+	if (!(target instanceof HTMLElement)) return;
+	target.classList.remove("sync-attention-target");
+	void target.offsetWidth;
+	target.classList.add("sync-attention-target");
+	window.setTimeout(() => target.classList.remove("sync-attention-target"), 900);
 }
 
 function prefersReducedMotion(): boolean {
-  return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	return (
+		typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
+	);
 }
 
 function syncScrollBehavior(): ScrollBehavior {
-  return prefersReducedMotion() ? 'auto' : 'smooth';
+	return prefersReducedMotion() ? "auto" : "smooth";
 }
 
 function renderInvitePolicySelect() {
-  const mount = document.getElementById('syncInvitePolicyMount') as HTMLElement | null;
-  if (!mount) return;
-  renderIntoSyncMount(
-    mount,
-    h(RadixSelect, {
-      ariaLabel: 'Join policy',
-      contentClassName: 'sync-radix-select-content sync-actor-select-content',
-      id: 'syncInvitePolicy',
-      itemClassName: 'sync-radix-select-item',
-      onValueChange: (value) => {
-        const nextValue = value === 'approval_required' ? 'approval_required' : 'auto_admit';
-        if (nextValue === invitePolicyValue) return;
-        invitePolicyValue = nextValue;
-        renderInvitePolicySelect();
-      },
-      options: INVITE_POLICY_OPTIONS,
-      triggerClassName: 'sync-radix-select-trigger sync-actor-select',
-      value: invitePolicyValue,
-      viewportClassName: 'sync-radix-select-viewport',
-    }),
-  );
+	const mount = document.getElementById("syncInvitePolicyMount") as HTMLElement | null;
+	if (!mount) return;
+	renderIntoSyncMount(
+		mount,
+		h(RadixSelect, {
+			ariaLabel: "Join policy",
+			contentClassName: "sync-radix-select-content sync-actor-select-content",
+			id: "syncInvitePolicy",
+			itemClassName: "sync-radix-select-item",
+			onValueChange: (value) => {
+				const nextValue = value === "approval_required" ? "approval_required" : "auto_admit";
+				if (nextValue === invitePolicyValue) return;
+				invitePolicyValue = nextValue;
+				renderInvitePolicySelect();
+			},
+			options: INVITE_POLICY_OPTIONS,
+			triggerClassName: "sync-radix-select-trigger sync-actor-select",
+			value: invitePolicyValue,
+			viewportClassName: "sync-radix-select-viewport",
+		}),
+	);
 }
 
 function teardownTeamSyncRender(actions: HTMLElement | null, targets: Array<HTMLElement | null>) {
-  const mount = document.getElementById(TEAM_SYNC_ACTIONS_MOUNT_ID) as HTMLElement | null;
-  if (mount) {
-    clearSyncMount(mount);
-    mount.remove();
-  }
-  clearContent(actions);
-  targets.forEach((target) => clearContent(target));
+	const mount = document.getElementById(TEAM_SYNC_ACTIONS_MOUNT_ID) as HTMLElement | null;
+	if (mount) {
+		clearSyncMount(mount);
+		mount.remove();
+	}
+	clearContent(actions);
+	targets.forEach((target) => {
+		clearContent(target);
+	});
 }
 
 /* ── Sharing review renderer ─────────────────────────────── */
 
 function openFeedSharingReview() {
-  setFeedScopeFilter('mine');
-  state.feedQuery = '';
-  window.location.hash = 'feed';
+	setFeedScopeFilter("mine");
+	state.feedQuery = "";
+	window.location.hash = "feed";
 }
 
 export function renderSyncSharingReview() {
-  const panel = document.getElementById('syncSharingReview');
-  const meta = document.getElementById('syncSharingReviewMeta');
-  const list = document.getElementById('syncSharingReviewList') as HTMLElement | null;
-  if (!panel || !meta || !list) return;
-  const items = Array.isArray(state.lastSyncSharingReview) ? state.lastSyncSharingReview : [];
-  if (!items.length) {
-    clearSyncMount(list);
-    panel.hidden = true;
-    return;
-  }
-  panel.hidden = false;
-  const scopeLabel = state.currentProject
-    ? `current project (${state.currentProject})`
-    : 'all allowed projects';
-  meta.textContent = `Teammates receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
-  const reviewItems: SyncSharingReviewItem[] = items.map((item) => ({
-    actorDisplayName: String(item.actor_display_name || item.actor_id || 'unknown'),
-    actorId: String(item.actor_id || 'unknown'),
-    peerName: String(item.peer_name || item.peer_device_id || 'Device'),
-    privateCount: Number(item.private_count || 0),
-    scopeLabel: String(item.scope_label || 'All allowed projects'),
-    shareableCount: Number(item.shareable_count || 0),
-  }));
-  renderIntoSyncMount(list, h(SyncSharingReview, { items: reviewItems, onReview: openFeedSharingReview }));
+	const panel = document.getElementById("syncSharingReview");
+	const meta = document.getElementById("syncSharingReviewMeta");
+	const list = document.getElementById("syncSharingReviewList") as HTMLElement | null;
+	if (!panel || !meta || !list) return;
+	const items = Array.isArray(state.lastSyncSharingReview) ? state.lastSyncSharingReview : [];
+	if (!items.length) {
+		clearSyncMount(list);
+		panel.hidden = true;
+		return;
+	}
+	panel.hidden = false;
+	const scopeLabel = state.currentProject
+		? `current project (${state.currentProject})`
+		: "all allowed projects";
+	meta.textContent = `Teammates receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
+	const reviewItems: SyncSharingReviewItem[] = items.map((item) => ({
+		actorDisplayName: String(item.actor_display_name || item.actor_id || "unknown"),
+		actorId: String(item.actor_id || "unknown"),
+		peerName: String(item.peer_name || item.peer_device_id || "Device"),
+		privateCount: Number(item.private_count || 0),
+		scopeLabel: String(item.scope_label || "All allowed projects"),
+		shareableCount: Number(item.shareable_count || 0),
+	}));
+	renderIntoSyncMount(
+		list,
+		h(SyncSharingReview, { items: reviewItems, onReview: openFeedSharingReview }),
+	);
 }
 
 /* ── Team sync renderer ──────────────────────────────────── */
@@ -191,657 +206,734 @@ export function renderSyncSharingReview() {
 // loadSyncData is set by the index module after both are loaded.
 let _loadSyncData: () => Promise<void> = async () => {};
 export function setLoadSyncData(fn: () => Promise<void>) {
-  _loadSyncData = fn;
+	_loadSyncData = fn;
 }
 
 export function renderTeamSync() {
-  const meta = document.getElementById('syncTeamMeta');
-  const setupPanel = document.getElementById('syncSetupPanel');
-  const list = document.getElementById('syncTeamStatus');
-  const listHeading = list?.previousElementSibling as HTMLElement | null;
-  const actions = document.getElementById('syncTeamActions');
-  if (!meta || !setupPanel || !list || !actions) return;
+	const meta = document.getElementById("syncTeamMeta");
+	const setupPanel = document.getElementById("syncSetupPanel");
+	const list = document.getElementById("syncTeamStatus");
+	const listHeading = list?.previousElementSibling as HTMLElement | null;
+	const actions = document.getElementById("syncTeamActions");
+	if (!meta || !setupPanel || !list || !actions) return;
 
-  renderAdminSetupDisclosure();
-  renderInvitePolicySelect();
-  setInviteOutputVisibility();
-  setJoinFeedbackVisibility();
+	renderAdminSetupDisclosure();
+	renderInvitePolicySelect();
+	setInviteOutputVisibility();
+	setJoinFeedbackVisibility();
 
-  const invitePanel = document.getElementById('syncInvitePanel');
-  const inviteRestoreParent = document.getElementById('syncAdminSection');
-  const joinPanel = document.getElementById('syncJoinPanel');
-  const joinRestoreParent = document.getElementById('syncJoinSection');
-  const joinRequests = document.getElementById('syncJoinRequests');
-  const discoveredPanel = document.getElementById('syncCoordinatorDiscovered');
-  const discoveredMeta = document.getElementById('syncCoordinatorDiscoveredMeta');
-  const discoveredList = document.getElementById('syncCoordinatorDiscoveredList');
+	const invitePanel = document.getElementById("syncInvitePanel");
+	const inviteRestoreParent = document.getElementById("syncAdminSection");
+	const joinPanel = document.getElementById("syncJoinPanel");
+	const joinRestoreParent = document.getElementById("syncJoinSection");
+	const joinRequests = document.getElementById("syncJoinRequests");
+	const discoveredPanel = document.getElementById("syncCoordinatorDiscovered");
+	const discoveredMeta = document.getElementById("syncCoordinatorDiscoveredMeta");
+	const discoveredList = document.getElementById("syncCoordinatorDiscoveredList");
 
-  hideSkeleton('syncTeamSkeleton');
-  ensureInvitePanelInAdminSection();
-  ensureJoinPanelInSetupSection();
+	hideSkeleton("syncTeamSkeleton");
+	ensureInvitePanelInAdminSection();
+	ensureJoinPanelInSetupSection();
 
-  const coordinator = state.lastSyncCoordinator;
-  const syncView = state.lastSyncViewModel || {
-    summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
-    duplicatePeople: [],
-    attentionItems: [],
-  };
+	const coordinator = state.lastSyncCoordinator;
+	const syncView = state.lastSyncViewModel || {
+		summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
+		duplicatePeople: [],
+		attentionItems: [],
+	};
 
-  const focusAttentionTarget = (item: { kind?: string; deviceId?: string }) => {
-    if (item.kind === 'possible-duplicate-person') {
-      const actorList = document.getElementById('syncActorsList');
-      if (actorList instanceof HTMLElement) {
-        actorList.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
-        pulseAttentionTarget(actorList);
-      }
-      return;
-    }
-    const deviceId = String(item.deviceId || '').trim();
-    if (!deviceId) return;
-    if (item.kind === 'name-device') {
-      const renameInput = document.querySelector(`[data-device-name-input="${CSS.escape(deviceId)}"]`);
-      if (renameInput instanceof HTMLInputElement) {
-        renameInput.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
-        renameInput.focus();
-        renameInput.select();
-        pulseAttentionTarget(renameInput);
-        return;
-      }
-    }
-    const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(deviceId)}"]`);
-    if (peerCard instanceof HTMLElement) {
-      peerCard.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
-      pulseAttentionTarget(peerCard);
-      return;
-    }
-    const discoveredRow = document.querySelector(`[data-discovered-device-id="${CSS.escape(deviceId)}"]`);
-    if (discoveredRow instanceof HTMLElement) {
-      discoveredRow.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
-      pulseAttentionTarget(discoveredRow);
-    }
-  };
+	const focusAttentionTarget = (item: { kind?: string; deviceId?: string }) => {
+		if (item.kind === "possible-duplicate-person") {
+			const actorList = document.getElementById("syncActorsList");
+			if (actorList instanceof HTMLElement) {
+				actorList.scrollIntoView({ block: "center", behavior: syncScrollBehavior() });
+				pulseAttentionTarget(actorList);
+			}
+			return;
+		}
+		const deviceId = String(item.deviceId || "").trim();
+		if (!deviceId) return;
+		if (item.kind === "name-device") {
+			const renameInput = document.querySelector(
+				`[data-device-name-input="${CSS.escape(deviceId)}"]`,
+			);
+			if (renameInput instanceof HTMLInputElement) {
+				renameInput.scrollIntoView({ block: "center", behavior: syncScrollBehavior() });
+				renameInput.focus();
+				renameInput.select();
+				pulseAttentionTarget(renameInput);
+				return;
+			}
+		}
+		const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(deviceId)}"]`);
+		if (peerCard instanceof HTMLElement) {
+			peerCard.scrollIntoView({ block: "center", behavior: syncScrollBehavior() });
+			pulseAttentionTarget(peerCard);
+			return;
+		}
+		const discoveredRow = document.querySelector(
+			`[data-discovered-device-id="${CSS.escape(deviceId)}"]`,
+		);
+		if (discoveredRow instanceof HTMLElement) {
+			discoveredRow.scrollIntoView({ block: "center", behavior: syncScrollBehavior() });
+			pulseAttentionTarget(discoveredRow);
+		}
+	};
 
-  const reviewDuplicatePeople = async (item: { actorIds?: unknown[]; title: string }) => {
-    const actorIds = Array.isArray(item.actorIds)
-      ? item.actorIds.map((value: unknown) => String(value || '').trim()).filter(Boolean)
-      : [];
-    const actors = (Array.isArray(state.lastSyncActors) ? state.lastSyncActors : []).filter((actor) =>
-      actorIds.includes(String(actor?.actor_id || '').trim()),
-    );
-    if (actors.length < 2) {
-      showGlobalNotice('This duplicate review is outdated. Refresh the card and review the remaining people entries.', 'warning');
-      return;
-    }
-    const result = await openDuplicatePersonDialog({
-      title: 'Review possible duplicate people',
-      summary: item.title.replace(/^Possible duplicate person:\s*/, ''),
-      actors: actors.map((actor) => ({
-        actorId: String(actor?.actor_id || ''),
-        label: String(actor?.display_name || actor?.actor_id || 'Unknown person'),
-        isLocal: Boolean(actor?.is_local),
-      })),
-    });
-    if (result.action === 'different-people') {
-      saveDuplicatePersonDecision(actorIds, 'different-people');
-      showGlobalNotice('Okay. I will keep these people separate on this device.');
-      await _loadSyncData();
-      return;
-    }
-    if (result.action !== 'merge') return;
-    const primary = actors.find((actor) => String(actor?.actor_id || '') === result.primaryActorId);
-    const secondary = actors.find((actor) => String(actor?.actor_id || '') === result.secondaryActorId);
-    if (!primary?.actor_id || !secondary?.actor_id) {
-      showGlobalNotice('Could not determine which people to combine. Refresh People & devices and try the review again.', 'warning');
-      return;
-    }
-    try {
-      await api.mergeActor(String(primary.actor_id), String(secondary.actor_id));
-      clearDuplicatePersonDecision(actorIds);
-      showGlobalNotice(`Combined duplicate people into ${String(primary.display_name || primary.actor_id)}.`);
-      await _loadSyncData();
-    } catch (error) {
-      try {
-        await _loadSyncData();
-      } catch {}
-      showGlobalNotice(friendlyError(error, 'Failed to combine these people.'), 'warning');
-    }
-  };
+	const reviewDuplicatePeople = async (item: { actorIds?: unknown[]; title: string }) => {
+		const actorIds = Array.isArray(item.actorIds)
+			? item.actorIds.map((value: unknown) => String(value || "").trim()).filter(Boolean)
+			: [];
+		const actors = (Array.isArray(state.lastSyncActors) ? state.lastSyncActors : []).filter(
+			(actor) => actorIds.includes(String(actor?.actor_id || "").trim()),
+		);
+		if (actors.length < 2) {
+			showGlobalNotice(
+				"This duplicate review is outdated. Refresh the card and review the remaining people entries.",
+				"warning",
+			);
+			return;
+		}
+		const result = await openDuplicatePersonDialog({
+			title: "Review possible duplicate people",
+			summary: item.title.replace(/^Possible duplicate person:\s*/, ""),
+			actors: actors.map((actor) => ({
+				actorId: String(actor?.actor_id || ""),
+				label: String(actor?.display_name || actor?.actor_id || "Unknown person"),
+				isLocal: Boolean(actor?.is_local),
+			})),
+		});
+		if (result.action === "different-people") {
+			saveDuplicatePersonDecision(actorIds, "different-people");
+			showGlobalNotice("Okay. I will keep these people separate on this device.");
+			await _loadSyncData();
+			return;
+		}
+		if (result.action !== "merge") return;
+		const primary = actors.find((actor) => String(actor?.actor_id || "") === result.primaryActorId);
+		const secondary = actors.find(
+			(actor) => String(actor?.actor_id || "") === result.secondaryActorId,
+		);
+		if (!primary?.actor_id || !secondary?.actor_id) {
+			showGlobalNotice(
+				"Could not determine which people to combine. Refresh People & devices and try the review again.",
+				"warning",
+			);
+			return;
+		}
+		try {
+			await api.mergeActor(String(primary.actor_id), String(secondary.actor_id));
+			clearDuplicatePersonDecision(actorIds);
+			showGlobalNotice(
+				`Combined duplicate people into ${String(primary.display_name || primary.actor_id)}.`,
+			);
+			await _loadSyncData();
+		} catch (error) {
+			try {
+				await _loadSyncData();
+			} catch {}
+			showGlobalNotice(friendlyError(error, "Failed to combine these people."), "warning");
+		}
+	};
 
-  const reviewDiscoveredDeviceName = async (suggestedName: string) => {
-    return await openSyncInputDialog({
-      title: 'Review device',
-      description: 'Choose a friendly name for this device before connecting it on this machine.',
-      initialValue: suggestedName,
-      placeholder: 'Desk Mini',
-      confirmLabel: 'Connect device',
-      cancelLabel: 'Cancel',
-      validate: (nextValue) => (nextValue.trim() ? null : 'Enter a device name to connect this device.'),
-    });
-  };
+	const reviewDiscoveredDeviceName = async (suggestedName: string) => {
+		return await openSyncInputDialog({
+			title: "Review device",
+			description: "Choose a friendly name for this device before connecting it on this machine.",
+			initialValue: suggestedName,
+			placeholder: "Desk Mini",
+			confirmLabel: "Connect device",
+			cancelLabel: "Cancel",
+			validate: (nextValue) =>
+				nextValue.trim() ? null : "Enter a device name to connect this device.",
+		});
+	};
 
-  const configured = Boolean(coordinator && coordinator.configured);
-  meta.textContent = configured
-    ? `Team: ${(coordinator.groups || []).join(', ') || 'none'}`
-    : 'Start by joining an existing team or creating one, then connect people and devices.';
-  meta.title = configured ? String(coordinator.coordinator_url || '').trim() : '';
+	const configured = Boolean(coordinator?.configured);
+	meta.textContent = configured
+		? `Team: ${(coordinator.groups || []).join(", ") || "none"}`
+		: "Start by joining an existing team or creating one, then connect people and devices.";
+	meta.title = configured ? String(coordinator.coordinator_url || "").trim() : "";
 
-  if (!configured) {
-    teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
-    setupPanel.hidden = false;
-    list.hidden = true;
-    if (listHeading) listHeading.hidden = true;
-    actions.hidden = true;
-    if (joinRequests) joinRequests.hidden = true;
-    if (discoveredPanel) discoveredPanel.hidden = true;
-    return;
-  }
+	if (!configured) {
+		teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
+		setupPanel.hidden = false;
+		list.hidden = true;
+		if (listHeading) listHeading.hidden = true;
+		actions.hidden = true;
+		if (joinRequests) joinRequests.hidden = true;
+		if (discoveredPanel) discoveredPanel.hidden = true;
+		return;
+	}
 
-  setupPanel.hidden = true;
-  list.hidden = false;
-  if (listHeading) listHeading.hidden = false;
-  actions.hidden = false;
+	setupPanel.hidden = true;
+	list.hidden = false;
+	if (listHeading) listHeading.hidden = false;
+	actions.hidden = false;
 
-  const presenceStatus = String(coordinator.presence_status || '');
-  const presenceLabel =
-    presenceStatus === 'posted'
-      ? 'Connected'
-      : presenceStatus === 'not_enrolled'
-        ? 'Needs enrollment'
-        : 'Connection error';
-  const localPeers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
-  const attentionItems = Array.isArray(syncView.attentionItems) ? syncView.attentionItems : [];
-  const connectedCount = Number(syncView.summary?.connectedDeviceCount || 0);
-  const seenOnTeamCount = Number(syncView.summary?.seenOnTeamCount || 0);
-  const offlineTeamDeviceCount = Number(syncView.summary?.offlineTeamDeviceCount || 0);
-  const metricParts = [`Connected ${connectedCount}`, `Team ${seenOnTeamCount}`];
-  if (offlineTeamDeviceCount > 0) {
-    metricParts.push(`Offline ${offlineTeamDeviceCount}`);
-  }
+	const presenceStatus = String(coordinator.presence_status || "");
+	const presenceLabel =
+		presenceStatus === "posted"
+			? "Connected"
+			: presenceStatus === "not_enrolled"
+				? "Needs enrollment"
+				: "Connection error";
+	const localPeers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
+	const attentionItems = Array.isArray(syncView.attentionItems) ? syncView.attentionItems : [];
+	const connectedCount = Number(syncView.summary?.connectedDeviceCount || 0);
+	const seenOnTeamCount = Number(syncView.summary?.seenOnTeamCount || 0);
+	const offlineTeamDeviceCount = Number(syncView.summary?.offlineTeamDeviceCount || 0);
+	const metricParts = [`Connected ${connectedCount}`, `Team ${seenOnTeamCount}`];
+	if (offlineTeamDeviceCount > 0) {
+		metricParts.push(`Offline ${offlineTeamDeviceCount}`);
+	}
 
-  const discoveredDevices = Array.isArray(coordinator.discovered_devices)
-    ? coordinator.discovered_devices
-    : [];
-  const discoveredRows: TeamSyncDiscoveredRow[] = discoveredDevices.map((device) => {
-    const deviceId = String(device.device_id || '').trim();
-    const rawCoordinatorName = String(device.display_name || '').trim();
-    const displayName =
-      resolveFriendlyDeviceName({ coordinatorName: rawCoordinatorName, deviceId }) ||
-      'Discovered device';
-    const displayTitle = deviceId && displayName !== deviceId ? deviceId : null;
-    const fingerprint = String(device.fingerprint || '').trim();
-    const groupIds = Array.isArray(device.groups)
-      ? device.groups.map((value) => String(value || '').trim()).filter(Boolean)
-      : [];
-    const hasAmbiguousCoordinatorGroup = groupIds.length > 1;
-    const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || '') === deviceId);
-    const approvalSummary = deriveCoordinatorApprovalSummary({
-      device,
-      pairedLocally: Boolean(pairedPeer),
-    });
-    const pairedFingerprint = String(pairedPeer?.fingerprint || '').trim();
-    const hasConflict =
-      Boolean(pairedPeer) &&
-      Boolean(fingerprint) &&
-      Boolean(pairedFingerprint) &&
-      pairedFingerprint !== fingerprint;
-    const canAccept =
-      Boolean(deviceId) &&
-      Boolean(fingerprint) &&
-      !pairedPeer &&
-      !device.stale &&
-      !hasAmbiguousCoordinatorGroup;
-    const addresses = Array.isArray(device.addresses) ? device.addresses : [];
-    const addressLabel = addresses.length
-      ? addresses
-          .map((address) =>
-            isSyncRedactionEnabled() ? redactAddress(String(address || '')) : String(address || ''),
-          )
-          .filter(Boolean)
-          .join(' · ')
-      : 'No fresh addresses';
-    const noteParts = [addressLabel];
-    if (!addresses.length && displayTitle) noteParts.push(`device id: ${deviceId}`);
-    let actionMessage: string | null = null;
-    let mode: TeamSyncDiscoveredRow['mode'] = canAccept ? 'accept' : 'none';
-    let pairedMessage: string | null = null;
+	const discoveredDevices = Array.isArray(coordinator.discovered_devices)
+		? coordinator.discovered_devices
+		: [];
+	const discoveredRows: TeamSyncDiscoveredRow[] = discoveredDevices.map((device) => {
+		const deviceId = String(device.device_id || "").trim();
+		const rawCoordinatorName = String(device.display_name || "").trim();
+		const displayName =
+			resolveFriendlyDeviceName({ coordinatorName: rawCoordinatorName, deviceId }) ||
+			"Discovered device";
+		const displayTitle = deviceId && displayName !== deviceId ? deviceId : null;
+		const fingerprint = String(device.fingerprint || "").trim();
+		const groupIds = Array.isArray(device.groups)
+			? device.groups.map((value) => String(value || "").trim()).filter(Boolean)
+			: [];
+		const hasAmbiguousCoordinatorGroup = groupIds.length > 1;
+		const pairedPeer = localPeers.find((peer) => String(peer?.peer_device_id || "") === deviceId);
+		const approvalSummary = deriveCoordinatorApprovalSummary({
+			device,
+			pairedLocally: Boolean(pairedPeer),
+		});
+		const pairedFingerprint = String(pairedPeer?.fingerprint || "").trim();
+		const hasConflict =
+			Boolean(pairedPeer) &&
+			Boolean(fingerprint) &&
+			Boolean(pairedFingerprint) &&
+			pairedFingerprint !== fingerprint;
+		const canAccept =
+			Boolean(deviceId) &&
+			Boolean(fingerprint) &&
+			!pairedPeer &&
+			!device.stale &&
+			!hasAmbiguousCoordinatorGroup;
+		const addresses = Array.isArray(device.addresses) ? device.addresses : [];
+		const addressLabel = addresses.length
+			? addresses
+					.map((address) =>
+						isSyncRedactionEnabled() ? redactAddress(String(address || "")) : String(address || ""),
+					)
+					.filter(Boolean)
+					.join(" · ")
+			: "No fresh addresses";
+		const noteParts = [addressLabel];
+		if (!addresses.length && displayTitle) noteParts.push(`device id: ${deviceId}`);
+		let actionMessage: string | null = null;
+		let mode: TeamSyncDiscoveredRow["mode"] = canAccept ? "accept" : "none";
+		let pairedMessage: string | null = null;
 
-    if (hasConflict) {
-      mode = 'conflict';
-    } else if (hasAmbiguousCoordinatorGroup) {
-      actionMessage = 'This device appears in multiple coordinator groups. Review team setup first or ask an admin to clean up the duplicate enrollment before approving it here.';
-      mode = 'ambiguous';
-    } else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
-      actionMessage = `Finish this device's scope review in People & devices before you sync it.`;
-      mode = 'scope-pending';
-    } else if (pairedPeer?.last_error) {
-      noteParts.push(`error: ${String(pairedPeer.last_error)}`);
-      mode = 'paired';
-    } else if (pairedPeer?.status?.peer_state) {
-      noteParts.push(`status: ${String(pairedPeer.status.peer_state)}`);
-      mode = 'paired';
-    } else if (!pairedPeer && device.stale) {
-      actionMessage = 'Wait for a fresh coordinator presence update, then review this device again here.';
-      mode = 'stale';
-    } else if (pairedPeer) {
-      mode = 'paired';
-    }
-    if (mode === 'paired') {
-      pairedMessage =
-        approvalSummary.state === 'waiting-for-other-device'
-          ? approvalSummary.description || 'Waiting on the other device.'
-          : String(pairedPeer?.last_error || '').toLowerCase().includes('401') &&
-              String(pairedPeer?.last_error || '').toLowerCase().includes('unauthorized')
-            ? 'Waiting for the other device to trust this one before sync can work.'
-            : null;
-    }
+		if (hasConflict) {
+			mode = "conflict";
+		} else if (hasAmbiguousCoordinatorGroup) {
+			actionMessage =
+				"This device appears in multiple coordinator groups. Review team setup first or ask an admin to clean up the duplicate enrollment before approving it here.";
+			mode = "ambiguous";
+		} else if (pairedPeer && isPeerScopeReviewPending(deviceId)) {
+			actionMessage = `Finish this device's scope review in People & devices before you sync it.`;
+			mode = "scope-pending";
+		} else if (pairedPeer?.last_error) {
+			noteParts.push(`error: ${String(pairedPeer.last_error)}`);
+			mode = "paired";
+		} else if (pairedPeer?.status?.peer_state) {
+			noteParts.push(`status: ${String(pairedPeer.status.peer_state)}`);
+			mode = "paired";
+		} else if (!pairedPeer && device.stale) {
+			actionMessage =
+				"Wait for a fresh coordinator presence update, then review this device again here.";
+			mode = "stale";
+		} else if (pairedPeer) {
+			mode = "paired";
+		}
+		if (mode === "paired") {
+			pairedMessage =
+				approvalSummary.state === "waiting-for-other-device"
+					? approvalSummary.description || "Waiting on the other device."
+					: String(pairedPeer?.last_error || "")
+								.toLowerCase()
+								.includes("401") &&
+							String(pairedPeer?.last_error || "")
+								.toLowerCase()
+								.includes("unauthorized")
+						? "Waiting for the other device to trust this one before sync can work."
+						: null;
+		}
 
-    return {
-      actionMessage,
-      actionLabel: approvalSummary.actionLabel || 'Review device',
-      approvalBadgeLabel: approvalSummary.badgeLabel,
-      availabilityLabel: device.stale ? 'Offline' : 'Available',
-      connectionLabel: hasConflict
-        ? SYNC_TERMINOLOGY.conflicts
-        : pairedPeer
-          ? SYNC_TERMINOLOGY.pairedLocally
-          : 'Not connected on this device',
-      deviceId,
-      displayName,
-      displayTitle,
-      fingerprint,
-      mode,
-      note: noteParts.join(' · '),
-      pairedMessage,
-    };
-  });
+		return {
+			actionMessage,
+			actionLabel: approvalSummary.actionLabel || "Review device",
+			approvalBadgeLabel: approvalSummary.badgeLabel,
+			availabilityLabel: device.stale ? "Offline" : "Available",
+			connectionLabel: hasConflict
+				? SYNC_TERMINOLOGY.conflicts
+				: pairedPeer
+					? SYNC_TERMINOLOGY.pairedLocally
+					: "Not connected on this device",
+			deviceId,
+			displayName,
+			displayTitle,
+			fingerprint,
+			mode,
+			note: noteParts.join(" · "),
+			pairedMessage,
+		};
+	});
 
-  const pending = Array.isArray(state.lastSyncJoinRequests) ? state.lastSyncJoinRequests : [];
-  const pendingJoinRequests: TeamSyncPendingJoinRequest[] = pending.map((request) => ({
-    displayName: String(request.display_name || request.device_id || 'Pending device'),
-    requestId: String(request.request_id || ''),
-  }));
-  const visibleDiscoveredRows = discoveredRows.filter(
-    (row) => row.mode !== 'paired' && row.mode !== 'none' && row.mode !== 'scope-pending',
-  );
-  // Count actionable items from the unfiltered list so scope-pending devices
-  // still contribute to the attention count even though they are hidden from
-  // the discovered section (they already appear in the devices section).
-  const discoveredActionableCount = discoveredRows.filter(
-    (row) => row.mode === 'accept' || row.mode === 'scope-pending',
-  ).length;
-  const actionableCount = attentionItems.length + pendingJoinRequests.length + discoveredActionableCount;
-  const attentionParts: string[] = [];
-  if (attentionItems.length > 0) {
-    const repairItems = attentionItems.filter((item) => item.kind === 'device-needs-repair');
-    const nameItems = attentionItems.filter((item) => item.kind === 'name-device');
-    const reviewItems = attentionItems.filter((item) => item.kind === 'review-team-device');
-    const duplicateItems = attentionItems.filter((item) => item.kind === 'possible-duplicate-person');
-    if (repairItems.length > 0) attentionParts.push(`${repairItems.length} device${repairItems.length === 1 ? '' : 's'} to repair`);
-    if (nameItems.length > 0) attentionParts.push(`${nameItems.length} device${nameItems.length === 1 ? '' : 's'} to name`);
-    if (reviewItems.length > 0) attentionParts.push(`${reviewItems.length} device${reviewItems.length === 1 ? '' : 's'} to review`);
-    if (duplicateItems.length > 0) attentionParts.push(`${duplicateItems.length} possible duplicate${duplicateItems.length === 1 ? '' : 's'}`);
-  }
-  if (pendingJoinRequests.length > 0) attentionParts.push(`${pendingJoinRequests.length} join request${pendingJoinRequests.length === 1 ? '' : 's'} to review`);
-  if (discoveredActionableCount > 0) attentionParts.push(`${discoveredActionableCount} discovered device${discoveredActionableCount === 1 ? '' : 's'}`);
-  const attentionDetail = attentionParts.join(', ');
-  const teamLabel = (coordinator.groups || []).join(', ') || 'none';
-  const statusSummary: TeamSyncStatusSummary = {
-    badgeClassName: `pill ${presenceStatus === 'posted' ? 'pill-success' : presenceStatus === 'not_enrolled' ? 'pill-warning' : 'pill-error'}`,
-    headline:
-      presenceStatus === 'posted'
-        ? actionableCount > 0
-          ? attentionDetail
-          : 'Everything is healthy'
-        : presenceStatus === 'not_enrolled'
-          ? 'This device is not enrolled in the team yet'
-          : 'Sync needs attention',
-    metricsText: metricParts.join(' · '),
-    presenceLabel,
-  };
-  meta.textContent =
-    presenceStatus === 'posted'
-      ? actionableCount > 0
-        ? `Team: ${teamLabel}. Start with the next step below, then scan the current team status.`
-        : `Team: ${teamLabel}. Team status and device details are below.`
-      : presenceStatus === 'not_enrolled'
-        ? `Team: ${teamLabel}. Enroll this device first, then return here to review the rest of the team.`
-        : `Team: ${teamLabel}. Fix the current sync issue first, then use the rest of this card to verify the team state.`;
+	const pending = Array.isArray(state.lastSyncJoinRequests) ? state.lastSyncJoinRequests : [];
+	const pendingJoinRequests: TeamSyncPendingJoinRequest[] = pending.map((request) => ({
+		displayName: String(request.display_name || request.device_id || "Pending device"),
+		requestId: String(request.request_id || ""),
+	}));
+	const visibleDiscoveredRows = discoveredRows.filter(
+		(row) => row.mode !== "paired" && row.mode !== "none" && row.mode !== "scope-pending",
+	);
+	// Count actionable items from the unfiltered list so scope-pending devices
+	// still contribute to the attention count even though they are hidden from
+	// the discovered section (they already appear in the devices section).
+	const discoveredActionableCount = discoveredRows.filter(
+		(row) => row.mode === "accept" || row.mode === "scope-pending",
+	).length;
+	const actionableCount =
+		attentionItems.length + pendingJoinRequests.length + discoveredActionableCount;
+	const attentionParts: string[] = [];
+	if (attentionItems.length > 0) {
+		const repairItems = attentionItems.filter((item) => item.kind === "device-needs-repair");
+		const nameItems = attentionItems.filter((item) => item.kind === "name-device");
+		const reviewItems = attentionItems.filter((item) => item.kind === "review-team-device");
+		const duplicateItems = attentionItems.filter(
+			(item) => item.kind === "possible-duplicate-person",
+		);
+		if (repairItems.length > 0)
+			attentionParts.push(
+				`${repairItems.length} device${repairItems.length === 1 ? "" : "s"} to repair`,
+			);
+		if (nameItems.length > 0)
+			attentionParts.push(`${nameItems.length} device${nameItems.length === 1 ? "" : "s"} to name`);
+		if (reviewItems.length > 0)
+			attentionParts.push(
+				`${reviewItems.length} device${reviewItems.length === 1 ? "" : "s"} to review`,
+			);
+		if (duplicateItems.length > 0)
+			attentionParts.push(
+				`${duplicateItems.length} possible duplicate${duplicateItems.length === 1 ? "" : "s"}`,
+			);
+	}
+	if (pendingJoinRequests.length > 0)
+		attentionParts.push(
+			`${pendingJoinRequests.length} join request${pendingJoinRequests.length === 1 ? "" : "s"} to review`,
+		);
+	if (discoveredActionableCount > 0)
+		attentionParts.push(
+			`${discoveredActionableCount} discovered device${discoveredActionableCount === 1 ? "" : "s"}`,
+		);
+	const attentionDetail = attentionParts.join(", ");
+	const teamLabel = (coordinator.groups || []).join(", ") || "none";
+	const statusSummary: TeamSyncStatusSummary = {
+		badgeClassName: `pill ${presenceStatus === "posted" ? "pill-success" : presenceStatus === "not_enrolled" ? "pill-warning" : "pill-error"}`,
+		headline:
+			presenceStatus === "posted"
+				? actionableCount > 0
+					? attentionDetail
+					: "Everything is healthy"
+				: presenceStatus === "not_enrolled"
+					? "This device is not enrolled in the team yet"
+					: "Sync needs attention",
+		metricsText: metricParts.join(" · "),
+		presenceLabel,
+	};
+	meta.textContent =
+		presenceStatus === "posted"
+			? actionableCount > 0
+				? `Team: ${teamLabel}. Start with the next step below, then scan the current team status.`
+				: `Team: ${teamLabel}. Team status and device details are below.`
+			: presenceStatus === "not_enrolled"
+				? `Team: ${teamLabel}. Enroll this device first, then return here to review the rest of the team.`
+				: `Team: ${teamLabel}. Fix the current sync issue first, then use the rest of this card to verify the team state.`;
 
-  if (discoveredPanel) {
-    discoveredPanel.hidden = visibleDiscoveredRows.length === 0 && !state.syncDiscoveredFeedback;
-  }
-  if (discoveredMeta) {
-    discoveredMeta.textContent = visibleDiscoveredRows.length
-      ? 'Review anything here that still needs trust, repair, or approval.'
-      : '';
-  }
-  if (joinRequests) {
-    joinRequests.hidden = pendingJoinRequests.length === 0 && !state.syncJoinRequestsFeedback;
-  }
+	if (discoveredPanel) {
+		discoveredPanel.hidden = visibleDiscoveredRows.length === 0 && !state.syncDiscoveredFeedback;
+	}
+	if (discoveredMeta) {
+		discoveredMeta.textContent = visibleDiscoveredRows.length
+			? "Review anything here that still needs trust, repair, or approval."
+			: "";
+	}
+	if (joinRequests) {
+		joinRequests.hidden = pendingJoinRequests.length === 0 && !state.syncJoinRequestsFeedback;
+	}
 
-  teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
-  const actionMount = document.createElement('div');
-  actionMount.id = TEAM_SYNC_ACTIONS_MOUNT_ID;
-  actions.appendChild(actionMount);
+	teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
+	const actionMount = document.createElement("div");
+	actionMount.id = TEAM_SYNC_ACTIONS_MOUNT_ID;
+	actions.appendChild(actionMount);
 
-  renderIntoSyncMount(
-    actionMount,
-    h(TeamSyncPanel, {
-      actionItems: attentionItems,
-      actionableCount,
-      children: h(SyncInviteJoinPanels, {
-        invitePanel,
-        invitePanelOpen: teamInvitePanelOpen,
-        inviteRestoreParent,
-        joinPanel,
-        joinRestoreParent,
-        onToggleInvitePanel: () => {
-          if (!invitePanel) return;
-          setTeamInvitePanelOpen(!teamInvitePanelOpen);
-          renderTeamSync();
-        },
-        pairedPeerCount: Number(coordinator.paired_peer_count || 0),
-        presenceStatus,
-      }),
-      discoveredListMount: discoveredList,
-      discoveredRows: visibleDiscoveredRows,
-      joinRequestsMount: joinRequests,
-      listMount: list,
-      onApproveJoinRequest: async (request) => {
-        try {
-          await api.reviewJoinRequest(request.requestId, 'approve');
-          const feedback = { message: `Approved ${request.displayName}. They can now sync with the team.`, tone: 'success' } satisfies SyncActionFeedback;
-          state.syncJoinRequestsFeedback = feedback;
-          await _loadSyncData();
-          return feedback;
-        } catch (error) {
-          return {
-            message: friendlyError(error, 'Failed to approve join request. Keep it pending and try again after the coordinator refreshes.'),
-            tone: 'warning',
-          } satisfies SyncActionFeedback;
-        }
-      },
-      onAttentionAction: async (item) => {
-        if (item.kind === 'possible-duplicate-person') {
-          await reviewDuplicatePeople(item);
-          return;
-        }
-        focusAttentionTarget(item);
-      },
-      onDenyJoinRequest: async (request) => {
-        const confirmed = await openSyncConfirmDialog({
-          title: `Deny join request from ${request.displayName}?`,
-          description: 'They will need a new invite to try joining this team again.',
-          confirmLabel: 'Deny request',
-          cancelLabel: 'Keep request pending',
-          tone: 'danger',
-        });
-        if (!confirmed) return null;
-        try {
-          await api.reviewJoinRequest(request.requestId, 'deny');
-          const feedback = { message: `Denied join request from ${request.displayName}.`, tone: 'success' } satisfies SyncActionFeedback;
-          state.syncJoinRequestsFeedback = feedback;
-          await _loadSyncData();
-          return feedback;
-        } catch (error) {
-          return {
-            message: friendlyError(error, 'Failed to deny join request. Leave it pending for now, then retry after the coordinator refreshes.'),
-            tone: 'warning',
-          } satisfies SyncActionFeedback;
-        }
-      },
-      onInspectConflict: (row) => {
-        const peerCard = document.querySelector(`[data-peer-device-id="${CSS.escape(row.deviceId)}"]`);
-        if (peerCard instanceof HTMLElement) {
-          peerCard.scrollIntoView({ block: 'center', behavior: syncScrollBehavior() });
-          showGlobalNotice(`Opened the conflicting local device record for ${row.displayName}.`, 'warning');
-          return;
-        }
-        showGlobalNotice(
-          'The conflicting local device record is not visible yet. Scroll to People & devices and try again.',
-          'warning',
-        );
-      },
-      onRemoveConflict: async (row) => {
-        const confirmed = await openSyncConfirmDialog({
-          title: `Remove ${row.displayName}?`,
-          description: 'This deletes the broken local device record. You can review this device again after the screen refreshes.',
-          confirmLabel: 'Remove device record',
-          cancelLabel: 'Keep device record',
-          tone: 'danger',
-        });
-        if (!confirmed) return null;
-        try {
-          await api.deletePeer(row.deviceId);
-          const feedback = {
-            message: `Removed the broken local device record for ${row.displayName}. If it is still available, review it again from Next steps or Devices seen on team.`,
-            tone: 'success',
-          } satisfies SyncActionFeedback;
-          state.syncDiscoveredFeedback = feedback;
-          await _loadSyncData();
-          return feedback;
-        } catch (error) {
-          return {
-            message: friendlyError(error, 'Failed to remove the broken local device record. The old local record is still present in People & devices.'),
-            tone: 'warning',
-          } satisfies SyncActionFeedback;
-        }
-      },
-      onReviewDiscoveredDevice: async (row) => {
-        try {
-          const reviewedName = await reviewDiscoveredDeviceName(row.displayName);
-          if (!reviewedName) return null;
-          const result = await api.acceptDiscoveredPeer(row.deviceId, row.fingerprint);
-          const optimisticName = String(result?.name || row.displayName || '').trim() || row.displayName;
-          const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
-            ? state.pendingAcceptedSyncPeers.filter(
-                (peer) => String(peer?.peer_device_id || '').trim() !== row.deviceId,
-              )
-            : [];
-          state.pendingAcceptedSyncPeers = [
-            ...pendingPeers,
-            {
-              peer_device_id: row.deviceId,
-              name: optimisticName,
-              fingerprint: row.fingerprint,
-              addresses: [],
-              claimed_local_actor: false,
-              status: { peer_state: 'degraded' },
-              last_error: 'Waiting for the other device to approve this one.',
-            },
-          ];
-          requestPeerScopeReview(row.deviceId);
-          let feedback: SyncActionFeedback = {
-            message:
-              row.approvalBadgeLabel === 'Needs your approval'
-                ? `Approved ${row.displayName} on this device. Two-way trust should be ready once both devices refresh.`
-                : `Step 1 complete on this device for ${row.displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
-            tone: 'success',
-          };
-          try {
-            if (reviewedName.trim() !== optimisticName.trim()) {
-              await api.renamePeer(row.deviceId, reviewedName.trim());
-              state.pendingAcceptedSyncPeers = state.pendingAcceptedSyncPeers.map((peer) =>
-                String(peer?.peer_device_id || '').trim() === row.deviceId
-                  ? { ...peer, name: reviewedName.trim() }
-                  : peer,
-              );
-              feedback = { message: `Connected ${reviewedName.trim()} and saved its name.`, tone: 'success' };
-            }
-          } catch (error) {
-            feedback = { message: friendlyError(error, 'Device connected, but naming did not finish.'), tone: 'warning' };
-          }
-          state.syncDiscoveredFeedback = feedback;
-          try {
-            await _loadSyncData();
-          } catch (error) {
-            feedback = {
-              message: friendlyError(error, 'Device connected, but the screen did not refresh yet. Refresh this page before trying the next step.'),
-              tone: 'warning',
-            };
-            state.syncDiscoveredFeedback = feedback;
-          }
-          return feedback;
-        } catch (error) {
-          return {
-            message: friendlyError(error, 'Failed to review this device. Wait for a fresh presence update and try again.'),
-            tone: 'warning',
-          } satisfies SyncActionFeedback;
-        }
-      },
-      pendingJoinRequests,
-      presenceStatus,
-      statusSummary,
-    }),
-  );
+	renderIntoSyncMount(
+		actionMount,
+		h(TeamSyncPanel, {
+			actionItems: attentionItems,
+			actionableCount,
+			children: h(SyncInviteJoinPanels, {
+				invitePanel,
+				invitePanelOpen: teamInvitePanelOpen,
+				inviteRestoreParent,
+				joinPanel,
+				joinRestoreParent,
+				onToggleInvitePanel: () => {
+					if (!invitePanel) return;
+					setTeamInvitePanelOpen(!teamInvitePanelOpen);
+					renderTeamSync();
+				},
+				pairedPeerCount: Number(coordinator.paired_peer_count || 0),
+				presenceStatus,
+			}),
+			discoveredListMount: discoveredList,
+			discoveredRows: visibleDiscoveredRows,
+			joinRequestsMount: joinRequests,
+			listMount: list,
+			onApproveJoinRequest: async (request) => {
+				try {
+					await api.reviewJoinRequest(request.requestId, "approve");
+					const feedback = {
+						message: `Approved ${request.displayName}. They can now sync with the team.`,
+						tone: "success",
+					} satisfies SyncActionFeedback;
+					state.syncJoinRequestsFeedback = feedback;
+					await _loadSyncData();
+					return feedback;
+				} catch (error) {
+					return {
+						message: friendlyError(
+							error,
+							"Failed to approve join request. Keep it pending and try again after the coordinator refreshes.",
+						),
+						tone: "warning",
+					} satisfies SyncActionFeedback;
+				}
+			},
+			onAttentionAction: async (item) => {
+				if (item.kind === "possible-duplicate-person") {
+					await reviewDuplicatePeople(item);
+					return;
+				}
+				focusAttentionTarget(item);
+			},
+			onDenyJoinRequest: async (request) => {
+				const confirmed = await openSyncConfirmDialog({
+					title: `Deny join request from ${request.displayName}?`,
+					description: "They will need a new invite to try joining this team again.",
+					confirmLabel: "Deny request",
+					cancelLabel: "Keep request pending",
+					tone: "danger",
+				});
+				if (!confirmed) return null;
+				try {
+					await api.reviewJoinRequest(request.requestId, "deny");
+					const feedback = {
+						message: `Denied join request from ${request.displayName}.`,
+						tone: "success",
+					} satisfies SyncActionFeedback;
+					state.syncJoinRequestsFeedback = feedback;
+					await _loadSyncData();
+					return feedback;
+				} catch (error) {
+					return {
+						message: friendlyError(
+							error,
+							"Failed to deny join request. Leave it pending for now, then retry after the coordinator refreshes.",
+						),
+						tone: "warning",
+					} satisfies SyncActionFeedback;
+				}
+			},
+			onInspectConflict: (row) => {
+				const peerCard = document.querySelector(
+					`[data-peer-device-id="${CSS.escape(row.deviceId)}"]`,
+				);
+				if (peerCard instanceof HTMLElement) {
+					peerCard.scrollIntoView({ block: "center", behavior: syncScrollBehavior() });
+					showGlobalNotice(
+						`Opened the conflicting local device record for ${row.displayName}.`,
+						"warning",
+					);
+					return;
+				}
+				showGlobalNotice(
+					"The conflicting local device record is not visible yet. Scroll to People & devices and try again.",
+					"warning",
+				);
+			},
+			onRemoveConflict: async (row) => {
+				const confirmed = await openSyncConfirmDialog({
+					title: `Remove ${row.displayName}?`,
+					description:
+						"This deletes the broken local device record. You can review this device again after the screen refreshes.",
+					confirmLabel: "Remove device record",
+					cancelLabel: "Keep device record",
+					tone: "danger",
+				});
+				if (!confirmed) return null;
+				try {
+					await api.deletePeer(row.deviceId);
+					const feedback = {
+						message: `Removed the broken local device record for ${row.displayName}. If it is still available, review it again from Next steps or Devices seen on team.`,
+						tone: "success",
+					} satisfies SyncActionFeedback;
+					state.syncDiscoveredFeedback = feedback;
+					await _loadSyncData();
+					return feedback;
+				} catch (error) {
+					return {
+						message: friendlyError(
+							error,
+							"Failed to remove the broken local device record. The old local record is still present in People & devices.",
+						),
+						tone: "warning",
+					} satisfies SyncActionFeedback;
+				}
+			},
+			onReviewDiscoveredDevice: async (row) => {
+				try {
+					const reviewedName = await reviewDiscoveredDeviceName(row.displayName);
+					if (!reviewedName) return null;
+					const result = await api.acceptDiscoveredPeer(row.deviceId, row.fingerprint);
+					const optimisticName =
+						String(result?.name || row.displayName || "").trim() || row.displayName;
+					const pendingPeers = Array.isArray(state.pendingAcceptedSyncPeers)
+						? state.pendingAcceptedSyncPeers.filter(
+								(peer) => String(peer?.peer_device_id || "").trim() !== row.deviceId,
+							)
+						: [];
+					state.pendingAcceptedSyncPeers = [
+						...pendingPeers,
+						{
+							peer_device_id: row.deviceId,
+							name: optimisticName,
+							fingerprint: row.fingerprint,
+							addresses: [],
+							claimed_local_actor: false,
+							status: { peer_state: "degraded" },
+							last_error: "Waiting for the other device to approve this one.",
+						},
+					];
+					requestPeerScopeReview(row.deviceId);
+					let feedback: SyncActionFeedback = {
+						message:
+							row.approvalBadgeLabel === "Needs your approval"
+								? `Approved ${row.displayName} on this device. Two-way trust should be ready once both devices refresh.`
+								: `Step 1 complete on this device for ${row.displayName}. Finish onboarding on the other device so both sides trust each other for sync.`,
+						tone: "success",
+					};
+					try {
+						if (reviewedName.trim() !== optimisticName.trim()) {
+							await api.renamePeer(row.deviceId, reviewedName.trim());
+							state.pendingAcceptedSyncPeers = state.pendingAcceptedSyncPeers.map((peer) =>
+								String(peer?.peer_device_id || "").trim() === row.deviceId
+									? { ...peer, name: reviewedName.trim() }
+									: peer,
+							);
+							feedback = {
+								message: `Connected ${reviewedName.trim()} and saved its name.`,
+								tone: "success",
+							};
+						}
+					} catch (error) {
+						feedback = {
+							message: friendlyError(error, "Device connected, but naming did not finish."),
+							tone: "warning",
+						};
+					}
+					state.syncDiscoveredFeedback = feedback;
+					try {
+						await _loadSyncData();
+					} catch (error) {
+						feedback = {
+							message: friendlyError(
+								error,
+								"Device connected, but the screen did not refresh yet. Refresh this page before trying the next step.",
+							),
+							tone: "warning",
+						};
+						state.syncDiscoveredFeedback = feedback;
+					}
+					return feedback;
+				} catch (error) {
+					return {
+						message: friendlyError(
+							error,
+							"Failed to review this device. Wait for a fresh presence update and try again.",
+						),
+						tone: "warning",
+					} satisfies SyncActionFeedback;
+				}
+			},
+			pendingJoinRequests,
+			presenceStatus,
+			statusSummary,
+		}),
+	);
 }
 
 /* ── Event wiring ────────────────────────────────────────── */
 
-export function initTeamSyncEvents(
-  refreshCallback: () => void,
-  loadSyncData: () => Promise<void>,
-) {
-  renderAdminSetupDisclosure();
-  renderInvitePolicySelect();
+export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: () => Promise<void>) {
+	renderAdminSetupDisclosure();
+	renderInvitePolicySelect();
 
-  const syncNowButton = document.getElementById('syncNowButton') as HTMLButtonElement | null;
-  const syncCreateInviteButton = document.getElementById(
-    'syncCreateInviteButton',
-  ) as HTMLButtonElement | null;
-  const syncInviteGroup = document.getElementById('syncInviteGroup') as HTMLInputElement | null;
-  const syncInviteTtl = document.getElementById('syncInviteTtl') as HTMLInputElement | null;
-  const syncInviteOutput = document.getElementById(
-    'syncInviteOutput',
-  ) as HTMLTextAreaElement | null;
-  const syncJoinButton = document.getElementById('syncJoinButton') as HTMLButtonElement | null;
-  const syncJoinInvite = document.getElementById('syncJoinInvite') as HTMLTextAreaElement | null;
+	const syncNowButton = document.getElementById("syncNowButton") as HTMLButtonElement | null;
+	const syncCreateInviteButton = document.getElementById(
+		"syncCreateInviteButton",
+	) as HTMLButtonElement | null;
+	const syncInviteGroup = document.getElementById("syncInviteGroup") as HTMLInputElement | null;
+	const syncInviteTtl = document.getElementById("syncInviteTtl") as HTMLInputElement | null;
+	const syncInviteOutput = document.getElementById(
+		"syncInviteOutput",
+	) as HTMLTextAreaElement | null;
+	const syncJoinButton = document.getElementById("syncJoinButton") as HTMLButtonElement | null;
+	const syncJoinInvite = document.getElementById("syncJoinInvite") as HTMLTextAreaElement | null;
 
-  syncCreateInviteButton?.addEventListener('click', async () => {
-    if (
-      !syncCreateInviteButton ||
-      !syncInviteGroup ||
-      !syncInviteTtl ||
-      !syncInviteOutput
-    )
-      return;
-    const groupName = syncInviteGroup.value.trim();
-    const ttlValue = Number(syncInviteTtl.value);
-    let valid = true;
-    if (!groupName) {
-      valid = markFieldError(syncInviteGroup, 'Team name is required.');
-    } else {
-      clearFieldError(syncInviteGroup);
-    }
-    if (!ttlValue || ttlValue < 1) {
-      valid = markFieldError(syncInviteTtl, 'Must be at least 1 hour.');
-    } else {
-      clearFieldError(syncInviteTtl);
-    }
-    if (!valid) return;
-    syncCreateInviteButton.disabled = true;
-    syncCreateInviteButton.textContent = 'Creating\u2026';
-    try {
-      const result = await api.createCoordinatorInvite({
-        group_id: groupName,
-        policy: invitePolicyValue,
-        ttl_hours: ttlValue || 24,
-      });
-      state.lastTeamInvite = result;
-      setInviteOutputVisibility();
-      syncInviteOutput.value = String(result.encoded || '');
-      syncInviteOutput.hidden = false;
-      syncInviteOutput.focus();
-      syncInviteOutput.select();
-      const warnings = Array.isArray(result.warnings) ? result.warnings : [];
-      showGlobalNotice(
-        warnings.length
-          ? `Invite created. Copy it above and review ${warnings.length === 1 ? '1 warning' : `${warnings.length} warnings`}.`
-          : 'Invite created. Copy the text above and share it with your teammate.',
-        warnings.length ? 'warning' : 'success',
-      );
-    } catch (error) {
-      showGlobalNotice(
-        friendlyError(error, 'Failed to create invite. Check the team name, invite lifetime, and coordinator reachability, then try again.'),
-        'warning',
-      );
-      syncCreateInviteButton.textContent = 'Retry';
-      syncCreateInviteButton.disabled = false;
-      return;
-    } finally {
-      if (syncCreateInviteButton.disabled) {
-        syncCreateInviteButton.disabled = false;
-        syncCreateInviteButton.textContent = 'Create invite';
-      }
-    }
-  });
+	syncCreateInviteButton?.addEventListener("click", async () => {
+		if (!syncCreateInviteButton || !syncInviteGroup || !syncInviteTtl || !syncInviteOutput) return;
+		const groupName = syncInviteGroup.value.trim();
+		const ttlValue = Number(syncInviteTtl.value);
+		let valid = true;
+		if (!groupName) {
+			valid = markFieldError(syncInviteGroup, "Team name is required.");
+		} else {
+			clearFieldError(syncInviteGroup);
+		}
+		if (!ttlValue || ttlValue < 1) {
+			valid = markFieldError(syncInviteTtl, "Must be at least 1 hour.");
+		} else {
+			clearFieldError(syncInviteTtl);
+		}
+		if (!valid) return;
+		syncCreateInviteButton.disabled = true;
+		syncCreateInviteButton.textContent = "Creating\u2026";
+		try {
+			const result = await api.createCoordinatorInvite({
+				group_id: groupName,
+				policy: invitePolicyValue,
+				ttl_hours: ttlValue || 24,
+			});
+			state.lastTeamInvite = result;
+			setInviteOutputVisibility();
+			syncInviteOutput.value = String(result.encoded || "");
+			syncInviteOutput.hidden = false;
+			syncInviteOutput.focus();
+			syncInviteOutput.select();
+			const warnings = Array.isArray(result.warnings) ? result.warnings : [];
+			showGlobalNotice(
+				warnings.length
+					? `Invite created. Copy it above and review ${warnings.length === 1 ? "1 warning" : `${warnings.length} warnings`}.`
+					: "Invite created. Copy the text above and share it with your teammate.",
+				warnings.length ? "warning" : "success",
+			);
+		} catch (error) {
+			showGlobalNotice(
+				friendlyError(
+					error,
+					"Failed to create invite. Check the team name, invite lifetime, and coordinator reachability, then try again.",
+				),
+				"warning",
+			);
+			syncCreateInviteButton.textContent = "Retry";
+			syncCreateInviteButton.disabled = false;
+			return;
+		} finally {
+			if (syncCreateInviteButton.disabled) {
+				syncCreateInviteButton.disabled = false;
+				syncCreateInviteButton.textContent = "Create invite";
+			}
+		}
+	});
 
-  syncJoinButton?.addEventListener('click', async () => {
-    if (!syncJoinButton || !syncJoinInvite) return;
-    const inviteValue = syncJoinInvite.value.trim();
-    if (!inviteValue) {
-      markFieldError(syncJoinInvite, 'Paste a team invite to join.');
-      return;
-    }
-    clearFieldError(syncJoinInvite);
-    syncJoinButton.disabled = true;
-    syncJoinButton.textContent = 'Joining\u2026';
-    try {
-      const result = await api.importCoordinatorInvite(inviteValue);
-      state.lastTeamJoin = result;
-      let feedback: SyncActionFeedback = {
-        message: result.status === 'pending' ? 'Join request sent. Waiting for admin approval.' : 'Joined the team.',
-        tone: 'success',
-      };
-      state.syncJoinFlowFeedback = feedback;
-      setJoinFeedbackVisibility();
-      syncJoinInvite.value = '';
-      try {
-        await loadSyncData();
-      } catch (error) {
-        feedback = {
-          message: friendlyError(error, 'Joined the team, but this view has not refreshed yet.'),
-          tone: 'warning',
-        };
-        state.syncJoinFlowFeedback = feedback;
-        setJoinFeedbackVisibility();
-      }
-    } catch (error) {
-      state.syncJoinFlowFeedback = {
-        message: friendlyError(error, 'Failed to import invite. Check that the invite is complete, current, and meant for this team, then try again.'),
-        tone: 'warning',
-      };
-      setJoinFeedbackVisibility();
-      syncJoinButton.textContent = 'Retry';
-      syncJoinButton.disabled = false;
-      return;
-    } finally {
-      if (syncJoinButton.disabled) {
-        syncJoinButton.disabled = false;
-        syncJoinButton.textContent = 'Join team';
-      }
-    }
-  });
+	syncJoinButton?.addEventListener("click", async () => {
+		if (!syncJoinButton || !syncJoinInvite) return;
+		const inviteValue = syncJoinInvite.value.trim();
+		if (!inviteValue) {
+			markFieldError(syncJoinInvite, "Paste a team invite to join.");
+			return;
+		}
+		clearFieldError(syncJoinInvite);
+		syncJoinButton.disabled = true;
+		syncJoinButton.textContent = "Joining\u2026";
+		try {
+			const result = await api.importCoordinatorInvite(inviteValue);
+			state.lastTeamJoin = result;
+			let feedback: SyncActionFeedback = {
+				message:
+					result.status === "pending"
+						? "Join request sent. Waiting for admin approval."
+						: "Joined the team.",
+				tone: "success",
+			};
+			state.syncJoinFlowFeedback = feedback;
+			setJoinFeedbackVisibility();
+			syncJoinInvite.value = "";
+			try {
+				await loadSyncData();
+			} catch (error) {
+				feedback = {
+					message: friendlyError(error, "Joined the team, but this view has not refreshed yet."),
+					tone: "warning",
+				};
+				state.syncJoinFlowFeedback = feedback;
+				setJoinFeedbackVisibility();
+			}
+		} catch (error) {
+			state.syncJoinFlowFeedback = {
+				message: friendlyError(
+					error,
+					"Failed to import invite. Check that the invite is complete, current, and meant for this team, then try again.",
+				),
+				tone: "warning",
+			};
+			setJoinFeedbackVisibility();
+			syncJoinButton.textContent = "Retry";
+			syncJoinButton.disabled = false;
+			return;
+		} finally {
+			if (syncJoinButton.disabled) {
+				syncJoinButton.disabled = false;
+				syncJoinButton.textContent = "Join team";
+			}
+		}
+	});
 
-  syncNowButton?.addEventListener('click', async () => {
-    if (!syncNowButton) return;
-    syncNowButton.disabled = true;
-    syncNowButton.textContent = 'Syncing\u2026';
-    try {
-      const result = await api.triggerSync();
-      const summary = summarizeSyncRunResult(result);
-      showGlobalNotice(summary.message, summary.warning ? 'warning' : undefined);
-    } catch (error) {
-      showGlobalNotice(
-        friendlyError(error, 'Failed to start sync. Retry once, then run codemem sync doctor if the problem keeps coming back.'),
-        'warning',
-      );
-      syncNowButton.textContent = 'Retry';
-      syncNowButton.disabled = false;
-      return;
-    }
-    syncNowButton.disabled = false;
-    syncNowButton.textContent = 'Sync now';
-    refreshCallback();
-  });
+	syncNowButton?.addEventListener("click", async () => {
+		if (!syncNowButton) return;
+		syncNowButton.disabled = true;
+		syncNowButton.textContent = "Syncing\u2026";
+		try {
+			const result = await api.triggerSync();
+			const summary = summarizeSyncRunResult(result);
+			showGlobalNotice(summary.message, summary.warning ? "warning" : undefined);
+		} catch (error) {
+			showGlobalNotice(
+				friendlyError(
+					error,
+					"Failed to start sync. Retry once, then run codemem sync doctor if the problem keeps coming back.",
+				),
+				"warning",
+			);
+			syncNowButton.textContent = "Retry";
+			syncNowButton.disabled = false;
+			return;
+		}
+		syncNowButton.disabled = false;
+		syncNowButton.textContent = "Sync now";
+		refreshCallback();
+	});
 }

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -1,327 +1,352 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 
 import {
-  deriveCoordinatorApprovalSummary,
-  deriveDuplicatePeople,
-  derivePeerTrustSummary,
-  derivePeerUiStatus,
-  deriveSyncViewModel,
-  deriveVisiblePeopleActors,
-  deviceNeedsFriendlyName,
-  resolveFriendlyDeviceName,
-  summarizeSyncRunResult,
-} from './view-model';
+	deriveCoordinatorApprovalSummary,
+	deriveDuplicatePeople,
+	derivePeerTrustSummary,
+	derivePeerUiStatus,
+	deriveSyncViewModel,
+	deriveVisiblePeopleActors,
+	deviceNeedsFriendlyName,
+	resolveFriendlyDeviceName,
+	summarizeSyncRunResult,
+} from "./view-model";
 
-describe('resolveFriendlyDeviceName', () => {
-  it('prefers the explicit local name first', () => {
-    expect(
-      resolveFriendlyDeviceName({
-        localName: 'Work MacBook',
-        coordinatorName: 'Adam laptop',
-        deviceId: '12345678-1234-1234-1234-123456789abc',
-      }),
-    ).toBe('Work MacBook');
-  });
+describe("resolveFriendlyDeviceName", () => {
+	it("prefers the explicit local name first", () => {
+		expect(
+			resolveFriendlyDeviceName({
+				localName: "Work MacBook",
+				coordinatorName: "Adam laptop",
+				deviceId: "12345678-1234-1234-1234-123456789abc",
+			}),
+		).toBe("Work MacBook");
+	});
 
-  it('falls back to coordinator display name before raw device ids', () => {
-    expect(
-      resolveFriendlyDeviceName({
-        localName: '',
-        coordinatorName: 'Desk Mini',
-        deviceId: '12345678-1234-1234-1234-123456789abc',
-      }),
-    ).toBe('Desk Mini');
-  });
+	it("falls back to coordinator display name before raw device ids", () => {
+		expect(
+			resolveFriendlyDeviceName({
+				localName: "",
+				coordinatorName: "Desk Mini",
+				deviceId: "12345678-1234-1234-1234-123456789abc",
+			}),
+		).toBe("Desk Mini");
+	});
 
-  it('uses a short fallback when nothing friendly exists', () => {
-    expect(
-      resolveFriendlyDeviceName({
-        deviceId: '12345678-1234-1234-1234-123456789abc',
-      }),
-    ).toBe('12345678');
-  });
+	it("uses a short fallback when nothing friendly exists", () => {
+		expect(
+			resolveFriendlyDeviceName({
+				deviceId: "12345678-1234-1234-1234-123456789abc",
+			}),
+		).toBe("12345678");
+	});
 });
 
-describe('deviceNeedsFriendlyName', () => {
-  it('requires naming when no local or coordinator name exists', () => {
-    expect(
-      deviceNeedsFriendlyName({ deviceId: '12345678-1234-1234-1234-123456789abc' }),
-    ).toBe(true);
-  });
+describe("deviceNeedsFriendlyName", () => {
+	it("requires naming when no local or coordinator name exists", () => {
+		expect(deviceNeedsFriendlyName({ deviceId: "12345678-1234-1234-1234-123456789abc" })).toBe(
+			true,
+		);
+	});
 
-  it('does not require naming when a friendly label already exists', () => {
-    expect(
-      deviceNeedsFriendlyName({
-        localName: 'Work MacBook',
-        deviceId: '12345678-1234-1234-1234-123456789abc',
-      }),
-    ).toBe(false);
-  });
+	it("does not require naming when a friendly label already exists", () => {
+		expect(
+			deviceNeedsFriendlyName({
+				localName: "Work MacBook",
+				deviceId: "12345678-1234-1234-1234-123456789abc",
+			}),
+		).toBe(false);
+	});
 });
 
-describe('derivePeerUiStatus', () => {
-  it('flags peers with explicit errors as needs-repair', () => {
-    expect(derivePeerUiStatus({ has_error: true, status: { peer_state: 'online' } })).toBe('needs-repair');
-  });
+describe("derivePeerUiStatus", () => {
+	it("flags peers with explicit errors as needs-repair", () => {
+		expect(derivePeerUiStatus({ has_error: true, status: { peer_state: "online" } })).toBe(
+			"needs-repair",
+		);
+	});
 
-  it('maps stale peers to offline', () => {
-    expect(derivePeerUiStatus({ status: { peer_state: 'stale' } })).toBe('offline');
-  });
+	it("maps stale peers to offline", () => {
+		expect(derivePeerUiStatus({ status: { peer_state: "stale" } })).toBe("offline");
+	});
 });
 
-describe('derivePeerTrustSummary', () => {
-  it('prioritizes current offline state over stale unauthorized history', () => {
-    expect(
-      derivePeerTrustSummary({
-        last_error: 'peer status failed (401: unauthorized)',
-        status: { peer_state: 'offline' },
-        has_error: false,
-      }).state,
-    ).toBe('offline');
-  });
+describe("derivePeerTrustSummary", () => {
+	it("prioritizes current offline state over stale unauthorized history", () => {
+		expect(
+			derivePeerTrustSummary({
+				last_error: "peer status failed (401: unauthorized)",
+				status: { peer_state: "offline" },
+				has_error: false,
+			}).state,
+		).toBe("offline");
+	});
 
-  it('surfaces one-way trust when the remote device rejects us with unauthorized', () => {
-    expect(
-      derivePeerTrustSummary({
-        last_error: 'peer status failed (401: unauthorized)',
-        status: { peer_state: 'degraded' },
-        has_error: true,
-      }),
-    ).toEqual({
-      state: 'trusted-by-you',
-      badgeLabel: 'Waiting for other device',
-      description:
-        'You accepted this device, but the other device still needs to trust this one before sync can work.',
-      isWarning: true,
-    });
-  });
+	it("surfaces one-way trust when the remote device rejects us with unauthorized", () => {
+		expect(
+			derivePeerTrustSummary({
+				last_error: "peer status failed (401: unauthorized)",
+				status: { peer_state: "degraded" },
+				has_error: true,
+			}),
+		).toEqual({
+			state: "trusted-by-you",
+			badgeLabel: "Waiting for other device",
+			description:
+				"You accepted this device, but the other device still needs to trust this one before sync can work.",
+			isWarning: true,
+		});
+	});
 
-  it('surfaces two-way trust once sync or ping succeeds', () => {
-    expect(derivePeerTrustSummary({ status: { sync_status: 'ok', peer_state: 'online' } }).state).toBe(
-      'mutual-trust',
-    );
-  });
+	it("surfaces two-way trust once sync or ping succeeds", () => {
+		expect(
+			derivePeerTrustSummary({ status: { sync_status: "ok", peer_state: "online" } }).state,
+		).toBe("mutual-trust");
+	});
 });
 
-describe('deriveCoordinatorApprovalSummary', () => {
-  it('flags coordinator devices that need approval on this device', () => {
-    expect(
-      deriveCoordinatorApprovalSummary({
-        device: { device_id: 'peer-a', needs_local_approval: true },
-        pairedLocally: false,
-      }),
-    ).toEqual({
-      state: 'needs-your-approval',
-      badgeLabel: 'Needs your approval',
-      description:
-        'Another device already trusted this one. Approve it on this device to finish reciprocal onboarding.',
-      actionLabel: 'Approve on this device',
-    });
-  });
+describe("deriveCoordinatorApprovalSummary", () => {
+	it("flags coordinator devices that need approval on this device", () => {
+		expect(
+			deriveCoordinatorApprovalSummary({
+				device: { device_id: "peer-a", needs_local_approval: true },
+				pairedLocally: false,
+			}),
+		).toEqual({
+			state: "needs-your-approval",
+			badgeLabel: "Needs your approval",
+			description:
+				"Another device already trusted this one. Approve it on this device to finish reciprocal onboarding.",
+			actionLabel: "Approve on this device",
+		});
+	});
 
-  it('flags coordinator devices that are still waiting on the other device', () => {
-    expect(
-      deriveCoordinatorApprovalSummary({
-        device: { device_id: 'peer-a', waiting_for_peer_approval: true },
-        pairedLocally: true,
-      }),
-    ).toEqual({
-      state: 'waiting-for-other-device',
-      badgeLabel: 'Waiting on other device',
-      description:
-        'You already trusted this device here. The other device still needs to approve this one before sync can work both ways.',
-      actionLabel: null,
-    });
-  });
+	it("flags coordinator devices that are still waiting on the other device", () => {
+		expect(
+			deriveCoordinatorApprovalSummary({
+				device: { device_id: "peer-a", waiting_for_peer_approval: true },
+				pairedLocally: true,
+			}),
+		).toEqual({
+			state: "waiting-for-other-device",
+			badgeLabel: "Waiting on other device",
+			description:
+				"You already trusted this device here. The other device still needs to approve this one before sync can work both ways.",
+			actionLabel: null,
+		});
+	});
 });
 
-describe('summarizeSyncRunResult', () => {
-  it('summarizes mixed failures without pretending they are all one-way trust', () => {
-    expect(
-      summarizeSyncRunResult({
-        items: [
-          { peer_device_id: 'a', ok: false, error: 'peer status failed (401: unauthorized)', opsIn: 0, opsOut: 0, addressErrors: [] },
-          { peer_device_id: 'b', ok: false, error: 'connection refused', opsIn: 0, opsOut: 0, addressErrors: [] },
-          { peer_device_id: 'c', ok: true, opsIn: 2, opsOut: 1, addressErrors: [] },
-        ],
-      }),
-    ).toEqual({
-      ok: false,
-      message: '2 of 3 device sync attempts failed. Review device details for the specific errors.',
-      warning: true,
-    });
-  });
+describe("summarizeSyncRunResult", () => {
+	it("summarizes mixed failures without pretending they are all one-way trust", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "a",
+						ok: false,
+						error: "peer status failed (401: unauthorized)",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+					{
+						peer_device_id: "b",
+						ok: false,
+						error: "connection refused",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+					{ peer_device_id: "c", ok: true, opsIn: 2, opsOut: 1, addressErrors: [] },
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message: "2 of 3 device sync attempts failed. Review device details for the specific errors.",
+			warning: true,
+		});
+	});
 
-  it('turns unauthorized sync failures into a directional trust message', () => {
-    expect(
-      summarizeSyncRunResult({
-        items: [{ peer_device_id: 'peer-a', ok: false, error: 'all addresses failed | http://x: peer status failed (401: unauthorized)', opsIn: 0, opsOut: 0, addressErrors: [] }],
-      }),
-    ).toEqual({
-      ok: false,
-      message:
-        'This device trusts the peer, but the other device still needs to trust this one before sync can work.',
-      warning: true,
-    });
-  });
+	it("turns unauthorized sync failures into a directional trust message", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: false,
+						error: "all addresses failed | http://x: peer status failed (401: unauthorized)",
+						opsIn: 0,
+						opsOut: 0,
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: false,
+			message:
+				"This device trusts the peer, but the other device still needs to trust this one before sync can work.",
+			warning: true,
+		});
+	});
 });
 
-describe('deriveDuplicatePeople', () => {
-  it('groups duplicate display names and preserves local involvement', () => {
-    expect(
-      deriveDuplicatePeople([
-        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
-        { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
-        { actor_id: 'actor-other', display_name: 'Pat', is_local: false },
-      ]),
-    ).toEqual([
-      {
-        displayName: 'Adam',
-        actorIds: ['actor-local', 'actor-remote'],
-        includesLocal: true,
-      },
-    ]);
-  });
+describe("deriveDuplicatePeople", () => {
+	it("groups duplicate display names and preserves local involvement", () => {
+		expect(
+			deriveDuplicatePeople([
+				{ actor_id: "actor-local", display_name: "Adam", is_local: true },
+				{ actor_id: "actor-remote", display_name: "Adam", is_local: false },
+				{ actor_id: "actor-other", display_name: "Pat", is_local: false },
+			]),
+		).toEqual([
+			{
+				displayName: "Adam",
+				actorIds: ["actor-local", "actor-remote"],
+				includesLocal: true,
+			},
+		]);
+	});
 });
 
-describe('deriveVisiblePeopleActors', () => {
-  it('hides unresolved zero-device duplicates of the local person from the people list', () => {
-    expect(
-      deriveVisiblePeopleActors({
-        actors: [
-          { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
-          { actor_id: 'actor-shadow', display_name: 'Adam', is_local: false },
-          { actor_id: 'actor-other', display_name: 'Pat', is_local: false },
-        ],
-        peers: [],
-        duplicatePeople: [
-          {
-            displayName: 'Adam',
-            actorIds: ['actor-local', 'actor-shadow'],
-            includesLocal: true,
-          },
-        ],
-      }),
-    ).toEqual({
-      visibleActors: [
-        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
-        { actor_id: 'actor-other', display_name: 'Pat', is_local: false },
-      ],
-      hiddenLocalDuplicateCount: 1,
-    });
-  });
+describe("deriveVisiblePeopleActors", () => {
+	it("hides unresolved zero-device duplicates of the local person from the people list", () => {
+		expect(
+			deriveVisiblePeopleActors({
+				actors: [
+					{ actor_id: "actor-local", display_name: "Adam", is_local: true },
+					{ actor_id: "actor-shadow", display_name: "Adam", is_local: false },
+					{ actor_id: "actor-other", display_name: "Pat", is_local: false },
+				],
+				peers: [],
+				duplicatePeople: [
+					{
+						displayName: "Adam",
+						actorIds: ["actor-local", "actor-shadow"],
+						includesLocal: true,
+					},
+				],
+			}),
+		).toEqual({
+			visibleActors: [
+				{ actor_id: "actor-local", display_name: "Adam", is_local: true },
+				{ actor_id: "actor-other", display_name: "Pat", is_local: false },
+			],
+			hiddenLocalDuplicateCount: 1,
+		});
+	});
 
-  it('keeps duplicate rows visible when the non-local duplicate already owns devices', () => {
-    expect(
-      deriveVisiblePeopleActors({
-        actors: [
-          { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
-          { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
-        ],
-        peers: [{ actor_id: 'actor-remote' }],
-        duplicatePeople: [
-          {
-            displayName: 'Adam',
-            actorIds: ['actor-local', 'actor-remote'],
-            includesLocal: true,
-          },
-        ],
-      }),
-    ).toEqual({
-      visibleActors: [
-        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
-        { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
-      ],
-      hiddenLocalDuplicateCount: 0,
-    });
-  });
+	it("keeps duplicate rows visible when the non-local duplicate already owns devices", () => {
+		expect(
+			deriveVisiblePeopleActors({
+				actors: [
+					{ actor_id: "actor-local", display_name: "Adam", is_local: true },
+					{ actor_id: "actor-remote", display_name: "Adam", is_local: false },
+				],
+				peers: [{ actor_id: "actor-remote" }],
+				duplicatePeople: [
+					{
+						displayName: "Adam",
+						actorIds: ["actor-local", "actor-remote"],
+						includesLocal: true,
+					},
+				],
+			}),
+		).toEqual({
+			visibleActors: [
+				{ actor_id: "actor-local", display_name: "Adam", is_local: true },
+				{ actor_id: "actor-remote", display_name: "Adam", is_local: false },
+			],
+			hiddenLocalDuplicateCount: 0,
+		});
+	});
 });
 
-describe('deriveSyncViewModel', () => {
-  it('creates attention items for duplicates, repairs, reviewable devices, and naming gaps', () => {
-    const view = deriveSyncViewModel({
-      actors: [
-        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
-        { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
-      ],
-      peers: [
-        {
-          peer_device_id: 'peer-1',
-          name: '',
-          has_error: true,
-          last_error: 'all addresses failed',
-          status: { peer_state: 'degraded' },
-          fingerprint: 'fp-old',
-        },
-      ],
-      coordinator: {
-        discovered_devices: [
-          {
-            device_id: 'peer-1',
-            display_name: '',
-            stale: false,
-            fingerprint: 'fp-new',
-          },
-          {
-            device_id: 'peer-2',
-            display_name: 'Desk Mini',
-            stale: false,
-            fingerprint: 'fp-2',
-          },
-        ],
-      },
-    });
+describe("deriveSyncViewModel", () => {
+	it("creates attention items for duplicates, repairs, reviewable devices, and naming gaps", () => {
+		const view = deriveSyncViewModel({
+			actors: [
+				{ actor_id: "actor-local", display_name: "Adam", is_local: true },
+				{ actor_id: "actor-remote", display_name: "Adam", is_local: false },
+			],
+			peers: [
+				{
+					peer_device_id: "peer-1",
+					name: "",
+					has_error: true,
+					last_error: "all addresses failed",
+					status: { peer_state: "degraded" },
+					fingerprint: "fp-old",
+				},
+			],
+			coordinator: {
+				discovered_devices: [
+					{
+						device_id: "peer-1",
+						display_name: "",
+						stale: false,
+						fingerprint: "fp-new",
+					},
+					{
+						device_id: "peer-2",
+						display_name: "Desk Mini",
+						stale: false,
+						fingerprint: "fp-2",
+					},
+				],
+			},
+		});
 
-    expect(view.summary).toEqual({
-      connectedDeviceCount: 0,
-      seenOnTeamCount: 2,
-      offlineTeamDeviceCount: 0,
-    });
-    expect(view.attentionItems.map((item) => item.kind)).toEqual([
-      'possible-duplicate-person',
-      'device-needs-repair',
-    ]);
-  });
+		expect(view.summary).toEqual({
+			connectedDeviceCount: 0,
+			seenOnTeamCount: 2,
+			offlineTeamDeviceCount: 0,
+		});
+		expect(view.attentionItems.map((item) => item.kind)).toEqual([
+			"possible-duplicate-person",
+			"device-needs-repair",
+		]);
+	});
 
-  it('hides duplicate-person attention when the user already marked them as different people', () => {
-    const view = deriveSyncViewModel({
-      actors: [
-        { actor_id: 'actor-local', display_name: 'Adam', is_local: true },
-        { actor_id: 'actor-remote', display_name: 'Adam', is_local: false },
-      ],
-      duplicatePersonDecisions: {
-        'actor-local::actor-remote': 'different-people',
-      },
-    });
+	it("hides duplicate-person attention when the user already marked them as different people", () => {
+		const view = deriveSyncViewModel({
+			actors: [
+				{ actor_id: "actor-local", display_name: "Adam", is_local: true },
+				{ actor_id: "actor-remote", display_name: "Adam", is_local: false },
+			],
+			duplicatePersonDecisions: {
+				"actor-local::actor-remote": "different-people",
+			},
+		});
 
-    expect(view.duplicatePeople).toEqual([]);
-    expect(view.attentionItems).toEqual([]);
-  });
+		expect(view.duplicatePeople).toEqual([]);
+		expect(view.attentionItems).toEqual([]);
+	});
 
-  it('does not count a stale coordinator record as offline when the paired peer is actively connected', () => {
-    const view = deriveSyncViewModel({
-      peers: [
-        {
-          peer_device_id: 'peer-1',
-          status: { peer_state: 'online', fresh: true, sync_status: 'ok' },
-        },
-      ],
-      coordinator: {
-        discovered_devices: [
-          {
-            device_id: 'peer-1',
-            display_name: 'Desk Mini',
-            stale: true,
-            fingerprint: 'fp-1',
-          },
-        ],
-      },
-    });
+	it("does not count a stale coordinator record as offline when the paired peer is actively connected", () => {
+		const view = deriveSyncViewModel({
+			peers: [
+				{
+					peer_device_id: "peer-1",
+					status: { peer_state: "online", fresh: true, sync_status: "ok" },
+				},
+			],
+			coordinator: {
+				discovered_devices: [
+					{
+						device_id: "peer-1",
+						display_name: "Desk Mini",
+						stale: true,
+						fingerprint: "fp-1",
+					},
+				],
+			},
+		});
 
-    expect(view.summary).toEqual({
-      connectedDeviceCount: 1,
-      seenOnTeamCount: 1,
-      offlineTeamDeviceCount: 0,
-    });
-  });
+		expect(view.summary).toEqual({
+			connectedDeviceCount: 1,
+			seenOnTeamCount: 1,
+			offlineTeamDeviceCount: 0,
+		});
+	});
 });

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -1,545 +1,593 @@
 /* Derived sync view-model helpers. Keep these pure so UX logic is testable. */
 
 export const SYNC_TERMINOLOGY = {
-  actor: 'person',
-  actors: 'people',
-  actorAssignment: 'person assignment',
-  localActor: 'you',
-  peer: 'device',
-  peers: 'devices',
-  pairedLocally: 'Connected on this device',
-  discovered: 'Seen on team',
-  conflicts: 'Needs repair',
+	actor: "person",
+	actors: "people",
+	actorAssignment: "person assignment",
+	localActor: "you",
+	peer: "device",
+	peers: "devices",
+	pairedLocally: "Connected on this device",
+	discovered: "Seen on team",
+	conflicts: "Needs repair",
 } as const;
 
-export type UiSyncStatus = 'connected' | 'available' | 'needs-repair' | 'offline' | 'waiting';
-export type UiTrustState = 'available' | 'trusted-by-you' | 'mutual-trust' | 'needs-repair' | 'offline';
-export type UiCoordinatorApprovalState = 'none' | 'needs-your-approval' | 'waiting-for-other-device';
+export type UiSyncStatus = "connected" | "available" | "needs-repair" | "offline" | "waiting";
+export type UiTrustState =
+	| "available"
+	| "trusted-by-you"
+	| "mutual-trust"
+	| "needs-repair"
+	| "offline";
+export type UiCoordinatorApprovalState =
+	| "none"
+	| "needs-your-approval"
+	| "waiting-for-other-device";
 
 interface SyncPeerStatusLike {
-  peer_state?: string;
-  sync_status?: string;
-  ping_status?: string;
-  fresh?: boolean;
+	peer_state?: string;
+	sync_status?: string;
+	ping_status?: string;
+	fresh?: boolean;
 }
 
 export interface UiSyncRunItem {
-  peer_device_id: string;
-  ok: boolean;
-  error?: string;
-  address?: string;
-  opsIn: number;
-  opsOut: number;
-  addressErrors: Array<{ address: string; error: string }>;
+	peer_device_id: string;
+	ok: boolean;
+	error?: string;
+	address?: string;
+	opsIn: number;
+	opsOut: number;
+	addressErrors: Array<{ address: string; error: string }>;
 }
 
 export interface UiSyncRunResponse {
-  items: UiSyncRunItem[];
+	items: UiSyncRunItem[];
 }
 
 export interface UiSyncAttentionItem {
-  id: string;
-  kind: 'possible-duplicate-person' | 'device-needs-repair' | 'review-team-device' | 'name-device';
-  priority: number;
-  title: string;
-  summary: string;
-  actionLabel: string;
-  deviceId?: string;
-  actorIds?: string[];
+	id: string;
+	kind: "possible-duplicate-person" | "device-needs-repair" | "review-team-device" | "name-device";
+	priority: number;
+	title: string;
+	summary: string;
+	actionLabel: string;
+	deviceId?: string;
+	actorIds?: string[];
 }
 
 export interface UiDuplicatePersonCandidate {
-  displayName: string;
-  actorIds: string[];
-  includesLocal: boolean;
+	displayName: string;
+	actorIds: string[];
+	includesLocal: boolean;
 }
 
 export interface UiSyncViewModel {
-  summary: {
-    connectedDeviceCount: number;
-    seenOnTeamCount: number;
-    offlineTeamDeviceCount: number;
-  };
-  duplicatePeople: UiDuplicatePersonCandidate[];
-  attentionItems: UiSyncAttentionItem[];
+	summary: {
+		connectedDeviceCount: number;
+		seenOnTeamCount: number;
+		offlineTeamDeviceCount: number;
+	};
+	duplicatePeople: UiDuplicatePersonCandidate[];
+	attentionItems: UiSyncAttentionItem[];
 }
 
 export interface UiPeerTrustSummary {
-  state: UiTrustState;
-  badgeLabel: string;
-  description: string;
-  isWarning: boolean;
+	state: UiTrustState;
+	badgeLabel: string;
+	description: string;
+	isWarning: boolean;
 }
 
 export interface VisiblePeopleResult {
-  visibleActors: ActorLike[];
-  hiddenLocalDuplicateCount: number;
+	visibleActors: ActorLike[];
+	hiddenLocalDuplicateCount: number;
 }
 
 export interface ActorLike {
-  actor_id?: string;
-  display_name?: string;
-  is_local?: boolean;
+	actor_id?: string;
+	display_name?: string;
+	is_local?: boolean;
 }
 
 export interface PeerLike {
-  peer_device_id?: string;
-  name?: string;
-  has_error?: boolean;
-  last_error?: string;
-  fingerprint?: string;
-  actor_id?: string;
-  status?: SyncPeerStatusLike;
+	peer_device_id?: string;
+	name?: string;
+	has_error?: boolean;
+	last_error?: string;
+	fingerprint?: string;
+	actor_id?: string;
+	status?: SyncPeerStatusLike;
 }
 
 export interface DiscoveredDeviceLike {
-  device_id?: string;
-  display_name?: string;
-  stale?: boolean;
-  fingerprint?: string;
-  groups?: string[];
-  needs_local_approval?: boolean;
-  waiting_for_peer_approval?: boolean;
+	device_id?: string;
+	display_name?: string;
+	stale?: boolean;
+	fingerprint?: string;
+	groups?: string[];
+	needs_local_approval?: boolean;
+	waiting_for_peer_approval?: boolean;
 }
 
 export interface UiCoordinatorApprovalSummary {
-  state: UiCoordinatorApprovalState;
-  badgeLabel: string | null;
-  description: string | null;
-  actionLabel: string | null;
+	state: UiCoordinatorApprovalState;
+	badgeLabel: string | null;
+	description: string | null;
+	actionLabel: string | null;
 }
 
 interface MergedDevice {
-  deviceId: string;
-  localName: string;
-  coordinatorName: string;
-  peer: PeerLike | null;
-  discovered: DiscoveredDeviceLike | null;
+	deviceId: string;
+	localName: string;
+	coordinatorName: string;
+	peer: PeerLike | null;
+	discovered: DiscoveredDeviceLike | null;
 }
 
 function cleanText(value: unknown): string {
-  return String(value ?? '').trim();
+	return String(value ?? "").trim();
 }
 
 function normalizeDisplayName(value: unknown): string {
-  return cleanText(value).replace(/\s+/g, ' ').toLowerCase();
+	return cleanText(value).replace(/\s+/g, " ").toLowerCase();
 }
 
-function looksLikeDeviceId(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(value);
+function _looksLikeDeviceId(value: string): boolean {
+	return /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(value);
 }
 
 function friendlyDeviceFallback(deviceId: string): string {
-  const cleanId = cleanText(deviceId);
-  return cleanId ? cleanId.slice(0, 8) : 'Unnamed device';
+	const cleanId = cleanText(deviceId);
+	return cleanId ? cleanId.slice(0, 8) : "Unnamed device";
 }
 
 export function resolveFriendlyDeviceName(input: {
-  localName?: unknown;
-  coordinatorName?: unknown;
-  deviceId?: unknown;
+	localName?: unknown;
+	coordinatorName?: unknown;
+	deviceId?: unknown;
 }): string {
-  const localName = cleanText(input.localName);
-  if (localName) return localName;
-  const coordinatorName = cleanText(input.coordinatorName);
-  if (coordinatorName) return coordinatorName;
-  return friendlyDeviceFallback(cleanText(input.deviceId));
+	const localName = cleanText(input.localName);
+	if (localName) return localName;
+	const coordinatorName = cleanText(input.coordinatorName);
+	if (coordinatorName) return coordinatorName;
+	return friendlyDeviceFallback(cleanText(input.deviceId));
 }
 
 export function deviceNeedsFriendlyName(input: {
-  localName?: unknown;
-  coordinatorName?: unknown;
-  deviceId?: unknown;
+	localName?: unknown;
+	coordinatorName?: unknown;
+	deviceId?: unknown;
 }): boolean {
-  const localName = cleanText(input.localName);
-  const coordinatorName = cleanText(input.coordinatorName);
-  if (localName || coordinatorName) return false;
-  return Boolean(cleanText(input.deviceId));
+	const localName = cleanText(input.localName);
+	const coordinatorName = cleanText(input.coordinatorName);
+	if (localName || coordinatorName) return false;
+	return Boolean(cleanText(input.deviceId));
 }
 
 export function derivePeerUiStatus(peer: PeerLike): UiSyncStatus {
-  const peerState = cleanText(peer?.status?.peer_state);
-  if (peer?.has_error || peerState === 'degraded') return 'needs-repair';
-  if (peerState === 'online') return 'connected';
-  if (peerState === 'offline' || peerState === 'stale') return 'offline';
-  if (peer?.status?.fresh) return 'connected';
-  return 'waiting';
+	const peerState = cleanText(peer?.status?.peer_state);
+	if (peer?.has_error || peerState === "degraded") return "needs-repair";
+	if (peerState === "online") return "connected";
+	if (peerState === "offline" || peerState === "stale") return "offline";
+	if (peer?.status?.fresh) return "connected";
+	return "waiting";
 }
 
 function isOfflineTeamDevice(device: MergedDevice): boolean {
-  if (!device.discovered?.stale) return false;
-  return device.peer ? derivePeerUiStatus(device.peer) !== 'connected' : true;
+	if (!device.discovered?.stale) return false;
+	return device.peer ? derivePeerUiStatus(device.peer) !== "connected" : true;
 }
 
 function peerErrorText(peer: PeerLike): string {
-  return cleanText(peer?.last_error).toLowerCase();
+	return cleanText(peer?.last_error).toLowerCase();
 }
 
 export function derivePeerTrustSummary(peer: PeerLike): UiPeerTrustSummary {
-  const peerStatus = peer?.status || {};
-  const peerState = cleanText(peerStatus.peer_state);
-  const lastError = peerErrorText(peer);
-  const syncOk = cleanText(peerStatus.sync_status) === 'ok' || cleanText(peerStatus.ping_status) === 'ok';
-  if (peerState === 'offline' || peerState === 'stale') {
-    return {
-      state: 'offline',
-      badgeLabel: 'Offline',
-      description: 'This device is known locally, but it is not reachable right now.',
-      isWarning: true,
-    };
-  }
-  if (lastError.includes('401') && lastError.includes('unauthorized')) {
-    return {
-      state: 'trusted-by-you',
-      badgeLabel: 'Waiting for other device',
-      description:
-        'You accepted this device, but the other device still needs to trust this one before sync can work.',
-      isWarning: true,
-    };
-  }
-  if (syncOk || peerState === 'online') {
-    return {
-      state: 'mutual-trust',
-      badgeLabel: 'Two-way trust',
-      description: 'Both devices trust each other and sync can run in both directions.',
-      isWarning: false,
-    };
-  }
-  if (peer?.has_error || peerState === 'degraded') {
-    return {
-      state: 'needs-repair',
-      badgeLabel: 'Needs repair',
-      description: 'This device has a sync problem that needs review before trust can be relied on.',
-      isWarning: true,
-    };
-  }
-  return {
-    state: 'trusted-by-you',
-    badgeLabel: 'Trusted on this device',
-    description:
-      'This device is trusted locally. Finish onboarding on the other device if sync is still blocked.',
-    isWarning: false,
-  };
+	const peerStatus = peer?.status || {};
+	const peerState = cleanText(peerStatus.peer_state);
+	const lastError = peerErrorText(peer);
+	const syncOk =
+		cleanText(peerStatus.sync_status) === "ok" || cleanText(peerStatus.ping_status) === "ok";
+	if (peerState === "offline" || peerState === "stale") {
+		return {
+			state: "offline",
+			badgeLabel: "Offline",
+			description: "This device is known locally, but it is not reachable right now.",
+			isWarning: true,
+		};
+	}
+	if (lastError.includes("401") && lastError.includes("unauthorized")) {
+		return {
+			state: "trusted-by-you",
+			badgeLabel: "Waiting for other device",
+			description:
+				"You accepted this device, but the other device still needs to trust this one before sync can work.",
+			isWarning: true,
+		};
+	}
+	if (syncOk || peerState === "online") {
+		return {
+			state: "mutual-trust",
+			badgeLabel: "Two-way trust",
+			description: "Both devices trust each other and sync can run in both directions.",
+			isWarning: false,
+		};
+	}
+	if (peer?.has_error || peerState === "degraded") {
+		return {
+			state: "needs-repair",
+			badgeLabel: "Needs repair",
+			description:
+				"This device has a sync problem that needs review before trust can be relied on.",
+			isWarning: true,
+		};
+	}
+	return {
+		state: "trusted-by-you",
+		badgeLabel: "Trusted on this device",
+		description:
+			"This device is trusted locally. Finish onboarding on the other device if sync is still blocked.",
+		isWarning: false,
+	};
 }
 
 export function deriveCoordinatorApprovalSummary(input: {
-  device: DiscoveredDeviceLike;
-  pairedLocally?: boolean;
+	device: DiscoveredDeviceLike;
+	pairedLocally?: boolean;
 }): UiCoordinatorApprovalSummary {
-  if (Boolean(input.device?.needs_local_approval) && !input.pairedLocally) {
-    return {
-      state: 'needs-your-approval',
-      badgeLabel: 'Needs your approval',
-      description:
-        'Another device already trusted this one. Approve it on this device to finish reciprocal onboarding.',
-      actionLabel: 'Approve on this device',
-    };
-  }
-  if (Boolean(input.device?.waiting_for_peer_approval)) {
-    return {
-      state: 'waiting-for-other-device',
-      badgeLabel: 'Waiting on other device',
-      description:
-        'You already trusted this device here. The other device still needs to approve this one before sync can work both ways.',
-      actionLabel: null,
-    };
-  }
-  return {
-    state: 'none',
-    badgeLabel: null,
-    description: null,
-    actionLabel: null,
-  };
+	if (Boolean(input.device?.needs_local_approval) && !input.pairedLocally) {
+		return {
+			state: "needs-your-approval",
+			badgeLabel: "Needs your approval",
+			description:
+				"Another device already trusted this one. Approve it on this device to finish reciprocal onboarding.",
+			actionLabel: "Approve on this device",
+		};
+	}
+	if (input.device?.waiting_for_peer_approval) {
+		return {
+			state: "waiting-for-other-device",
+			badgeLabel: "Waiting on other device",
+			description:
+				"You already trusted this device here. The other device still needs to approve this one before sync can work both ways.",
+			actionLabel: null,
+		};
+	}
+	return {
+		state: "none",
+		badgeLabel: null,
+		description: null,
+		actionLabel: null,
+	};
 }
 
-export function summarizeSyncRunResult(payload: UiSyncRunResponse): { ok: boolean; message: string; warning: boolean } {
-  const items = Array.isArray(payload?.items) ? payload.items : [];
-  if (!items.length) {
-    return { ok: true, message: 'Sync pass completed with no eligible devices.', warning: false };
-  }
-  const failedItems = items.filter((item) => item && item.ok === false);
-  if (!failedItems.length) {
-    return {
-      ok: true,
-      message: `Sync pass finished for ${items.length} device${items.length === 1 ? '' : 's'}.`,
-      warning: false,
-    };
-  }
-  const unauthorizedFailures = failedItems.filter((item) => cleanText(item.error).toLowerCase().includes('401') && cleanText(item.error).toLowerCase().includes('unauthorized'));
-  if (unauthorizedFailures.length === failedItems.length) {
-    return {
-      ok: false,
-      message:
-        'This device trusts the peer, but the other device still needs to trust this one before sync can work.',
-      warning: true,
-    };
-  }
-  if (failedItems.length < items.length) {
-    return {
-      ok: false,
-      message: `${failedItems.length} of ${items.length} device sync attempts failed. Review device details for the specific errors.`,
-      warning: true,
-    };
-  }
-  const error = cleanText(failedItems[0]?.error);
-  return {
-    ok: false,
-    message: error || 'Sync failed for at least one device.',
-    warning: true,
-  };
+export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
+	ok: boolean;
+	message: string;
+	warning: boolean;
+} {
+	const items = Array.isArray(payload?.items) ? payload.items : [];
+	if (!items.length) {
+		return { ok: true, message: "Sync pass completed with no eligible devices.", warning: false };
+	}
+	const failedItems = items.filter((item) => item && item.ok === false);
+	if (!failedItems.length) {
+		return {
+			ok: true,
+			message: `Sync pass finished for ${items.length} device${items.length === 1 ? "" : "s"}.`,
+			warning: false,
+		};
+	}
+	const unauthorizedFailures = failedItems.filter(
+		(item) =>
+			cleanText(item.error).toLowerCase().includes("401") &&
+			cleanText(item.error).toLowerCase().includes("unauthorized"),
+	);
+	if (unauthorizedFailures.length === failedItems.length) {
+		return {
+			ok: false,
+			message:
+				"This device trusts the peer, but the other device still needs to trust this one before sync can work.",
+			warning: true,
+		};
+	}
+	if (failedItems.length < items.length) {
+		return {
+			ok: false,
+			message: `${failedItems.length} of ${items.length} device sync attempts failed. Review device details for the specific errors.`,
+			warning: true,
+		};
+	}
+	const error = cleanText(failedItems[0]?.error);
+	return {
+		ok: false,
+		message: error || "Sync failed for at least one device.",
+		warning: true,
+	};
 }
 
 export function deriveDuplicatePeople(actors: ActorLike[]): UiDuplicatePersonCandidate[] {
-  const groups = new Map<string, UiDuplicatePersonCandidate>();
-  (Array.isArray(actors) ? actors : []).forEach((actor) => {
-    const displayName = cleanText(actor?.display_name);
-    const actorId = cleanText(actor?.actor_id);
-    const normalized = normalizeDisplayName(displayName);
-    if (!displayName || !actorId || !normalized) return;
-    const current = groups.get(normalized) ?? {
-      displayName,
-      actorIds: [],
-      includesLocal: false,
-    };
-    current.actorIds = [...current.actorIds, actorId];
-    current.includesLocal = current.includesLocal || Boolean(actor?.is_local);
-    groups.set(normalized, current);
-  });
-  return [...groups.values()]
-    .filter((item) => item.actorIds.length > 1)
-    .sort((a, b) => a.displayName.localeCompare(b.displayName));
+	const groups = new Map<string, UiDuplicatePersonCandidate>();
+	(Array.isArray(actors) ? actors : []).forEach((actor) => {
+		const displayName = cleanText(actor?.display_name);
+		const actorId = cleanText(actor?.actor_id);
+		const normalized = normalizeDisplayName(displayName);
+		if (!displayName || !actorId || !normalized) return;
+		const current = groups.get(normalized) ?? {
+			displayName,
+			actorIds: [],
+			includesLocal: false,
+		};
+		current.actorIds = [...current.actorIds, actorId];
+		current.includesLocal = current.includesLocal || Boolean(actor?.is_local);
+		groups.set(normalized, current);
+	});
+	return [...groups.values()]
+		.filter((item) => item.actorIds.length > 1)
+		.sort((a, b) => a.displayName.localeCompare(b.displayName));
 }
 
 export function deriveVisiblePeopleActors(input: {
-  actors?: ActorLike[];
-  peers?: PeerLike[];
-  duplicatePeople?: UiDuplicatePersonCandidate[];
+	actors?: ActorLike[];
+	peers?: PeerLike[];
+	duplicatePeople?: UiDuplicatePersonCandidate[];
 }): VisiblePeopleResult {
-  const actors = Array.isArray(input.actors) ? input.actors : [];
-  const peers = Array.isArray(input.peers) ? input.peers : [];
-  const duplicatePeople = Array.isArray(input.duplicatePeople) ? input.duplicatePeople : [];
-  const assignedCounts = new Map<string, number>();
-  peers.forEach((peer) => {
-    const actorId = cleanText(peer?.actor_id);
-    if (!actorId) return;
-    assignedCounts.set(actorId, (assignedCounts.get(actorId) ?? 0) + 1);
-  });
+	const actors = Array.isArray(input.actors) ? input.actors : [];
+	const peers = Array.isArray(input.peers) ? input.peers : [];
+	const duplicatePeople = Array.isArray(input.duplicatePeople) ? input.duplicatePeople : [];
+	const assignedCounts = new Map<string, number>();
+	peers.forEach((peer) => {
+		const actorId = cleanText(peer?.actor_id);
+		if (!actorId) return;
+		assignedCounts.set(actorId, (assignedCounts.get(actorId) ?? 0) + 1);
+	});
 
-  const hiddenIds = new Set<string>();
-  duplicatePeople.forEach((candidate) => {
-    if (!candidate.includesLocal) return;
-    candidate.actorIds.forEach((actorId) => {
-      const actor = actors.find((item) => cleanText(item?.actor_id) === actorId);
-      if (!actor || actor.is_local) return;
-      if ((assignedCounts.get(actorId) ?? 0) > 0) return;
-      hiddenIds.add(actorId);
-    });
-  });
+	const hiddenIds = new Set<string>();
+	duplicatePeople.forEach((candidate) => {
+		if (!candidate.includesLocal) return;
+		candidate.actorIds.forEach((actorId) => {
+			const actor = actors.find((item) => cleanText(item?.actor_id) === actorId);
+			if (!actor || actor.is_local) return;
+			if ((assignedCounts.get(actorId) ?? 0) > 0) return;
+			hiddenIds.add(actorId);
+		});
+	});
 
-  return {
-    visibleActors: actors.filter((actor) => !hiddenIds.has(cleanText(actor?.actor_id))),
-    hiddenLocalDuplicateCount: hiddenIds.size,
-  };
+	return {
+		visibleActors: actors.filter((actor) => !hiddenIds.has(cleanText(actor?.actor_id))),
+		hiddenLocalDuplicateCount: hiddenIds.size,
+	};
 }
 
-function createRepairItem(device: { id: string; name: string; summary: string }): UiSyncAttentionItem {
-  return {
-    id: `repair:${device.id}`,
-    kind: 'device-needs-repair',
-    priority: 10,
-    title: `${device.name} needs repair`,
-    summary: device.summary,
-    actionLabel: 'Open device',
-    deviceId: device.id,
-  };
+function createRepairItem(device: {
+	id: string;
+	name: string;
+	summary: string;
+}): UiSyncAttentionItem {
+	return {
+		id: `repair:${device.id}`,
+		kind: "device-needs-repair",
+		priority: 10,
+		title: `${device.name} needs repair`,
+		summary: device.summary,
+		actionLabel: "Open device",
+		deviceId: device.id,
+	};
 }
 
-function createReviewItem(device: { id: string; name: string; summary: string; key?: string }): UiSyncAttentionItem {
-  return {
-    id: `review:${device.id}:${device.key || 'default'}`,
-    kind: 'review-team-device',
-    priority: 20,
-    title: `${device.name} is available to review`,
-    summary: device.summary,
-    actionLabel: 'Open device',
-    deviceId: device.id,
-  };
+function createReviewItem(device: {
+	id: string;
+	name: string;
+	summary: string;
+	key?: string;
+}): UiSyncAttentionItem {
+	return {
+		id: `review:${device.id}:${device.key || "default"}`,
+		kind: "review-team-device",
+		priority: 20,
+		title: `${device.name} is available to review`,
+		summary: device.summary,
+		actionLabel: "Open device",
+		deviceId: device.id,
+	};
 }
 
-function createNamingItem(device: { id: string; name: string; summary: string }): UiSyncAttentionItem {
-  return {
-    id: `name:${device.id}`,
-    kind: 'name-device',
-    priority: 30,
-    title: `Name ${device.name}`,
-    summary: device.summary,
-    actionLabel: 'Go to name field',
-    deviceId: device.id,
-  };
+function createNamingItem(device: {
+	id: string;
+	name: string;
+	summary: string;
+}): UiSyncAttentionItem {
+	return {
+		id: `name:${device.id}`,
+		kind: "name-device",
+		priority: 30,
+		title: `Name ${device.name}`,
+		summary: device.summary,
+		actionLabel: "Go to name field",
+		deviceId: device.id,
+	};
 }
 
-function mergeDevices(peers: PeerLike[], discoveredDevices: DiscoveredDeviceLike[]): MergedDevice[] {
-  const devices = new Map<string, MergedDevice>();
-  const getOrCreate = (deviceId: string): MergedDevice => {
-    const current = devices.get(deviceId) ?? {
-      deviceId,
-      localName: '',
-      coordinatorName: '',
-      peer: null,
-      discovered: null,
-    };
-    devices.set(deviceId, current);
-    return current;
-  };
+function mergeDevices(
+	peers: PeerLike[],
+	discoveredDevices: DiscoveredDeviceLike[],
+): MergedDevice[] {
+	const devices = new Map<string, MergedDevice>();
+	const getOrCreate = (deviceId: string): MergedDevice => {
+		const current = devices.get(deviceId) ?? {
+			deviceId,
+			localName: "",
+			coordinatorName: "",
+			peer: null,
+			discovered: null,
+		};
+		devices.set(deviceId, current);
+		return current;
+	};
 
-  peers.forEach((peer) => {
-    const deviceId = cleanText(peer?.peer_device_id);
-    if (!deviceId) return;
-    const current = getOrCreate(deviceId);
-    current.peer = peer;
-    current.localName = cleanText(peer?.name);
-  });
+	peers.forEach((peer) => {
+		const deviceId = cleanText(peer?.peer_device_id);
+		if (!deviceId) return;
+		const current = getOrCreate(deviceId);
+		current.peer = peer;
+		current.localName = cleanText(peer?.name);
+	});
 
-  discoveredDevices.forEach((device) => {
-    const deviceId = cleanText(device?.device_id);
-    if (!deviceId) return;
-    const current = getOrCreate(deviceId);
-    current.discovered = device;
-    current.coordinatorName = cleanText(device?.display_name);
-  });
+	discoveredDevices.forEach((device) => {
+		const deviceId = cleanText(device?.device_id);
+		if (!deviceId) return;
+		const current = getOrCreate(deviceId);
+		current.discovered = device;
+		current.coordinatorName = cleanText(device?.display_name);
+	});
 
-  return [...devices.values()];
+	return [...devices.values()];
 }
 
 export function deriveSyncViewModel(input: {
-  actors?: ActorLike[];
-  peers?: PeerLike[];
-  coordinator?: { discovered_devices?: DiscoveredDeviceLike[] };
-  duplicatePersonDecisions?: Record<string, string>;
+	actors?: ActorLike[];
+	peers?: PeerLike[];
+	coordinator?: { discovered_devices?: DiscoveredDeviceLike[] };
+	duplicatePersonDecisions?: Record<string, string>;
 }): UiSyncViewModel {
-  const actors = Array.isArray(input.actors) ? input.actors : [];
-  const peers = Array.isArray(input.peers) ? input.peers : [];
-  const discoveredDevices = Array.isArray(input.coordinator?.discovered_devices)
-    ? input.coordinator.discovered_devices
-    : [];
-  const mergedDevices = mergeDevices(peers, discoveredDevices);
-  const duplicateDecisions = input.duplicatePersonDecisions ?? {};
-  const duplicatePeople = deriveDuplicatePeople(actors).filter(
-    (candidate) => !duplicateDecisions[[...candidate.actorIds].sort().join('::')],
-  );
-  const attentionItems: UiSyncAttentionItem[] = [];
+	const actors = Array.isArray(input.actors) ? input.actors : [];
+	const peers = Array.isArray(input.peers) ? input.peers : [];
+	const discoveredDevices = Array.isArray(input.coordinator?.discovered_devices)
+		? input.coordinator.discovered_devices
+		: [];
+	const mergedDevices = mergeDevices(peers, discoveredDevices);
+	const duplicateDecisions = input.duplicatePersonDecisions ?? {};
+	const duplicatePeople = deriveDuplicatePeople(actors).filter(
+		(candidate) => !duplicateDecisions[[...candidate.actorIds].sort().join("::")],
+	);
+	const attentionItems: UiSyncAttentionItem[] = [];
 
-  duplicatePeople.forEach((candidate) => {
-    attentionItems.push({
-      id: `duplicate:${candidate.actorIds.join(':')}`,
-      kind: 'possible-duplicate-person',
-      priority: candidate.includesLocal ? 5 : 15,
-      title: `Possible duplicate person: ${candidate.displayName}`,
-      summary: candidate.includesLocal
-        ? 'At least one entry is marked as you. Confirm whether these records represent the same person.'
-        : 'Multiple people share this name. Confirm whether they should stay separate or be combined.',
-      actionLabel: 'Go to people',
-      actorIds: candidate.actorIds,
-    });
-  });
+	duplicatePeople.forEach((candidate) => {
+		attentionItems.push({
+			id: `duplicate:${candidate.actorIds.join(":")}`,
+			kind: "possible-duplicate-person",
+			priority: candidate.includesLocal ? 5 : 15,
+			title: `Possible duplicate person: ${candidate.displayName}`,
+			summary: candidate.includesLocal
+				? "At least one entry is marked as you. Confirm whether these records represent the same person."
+				: "Multiple people share this name. Confirm whether they should stay separate or be combined.",
+			actionLabel: "Go to people",
+			actorIds: candidate.actorIds,
+		});
+	});
 
-  mergedDevices.forEach((device) => {
-    const name = resolveFriendlyDeviceName({
-      localName: device.localName,
-      coordinatorName: device.coordinatorName,
-      deviceId: device.deviceId,
-    });
-    const peerStatus = device.peer ? derivePeerUiStatus(device.peer) : 'waiting';
-    const trustSummary = device.peer ? derivePeerTrustSummary(device.peer) : null;
-    const discoveredFingerprint = cleanText(device.discovered?.fingerprint);
-    const peerFingerprint = cleanText(device.peer?.fingerprint);
-    const hasConflict = Boolean(device.peer) && Boolean(discoveredFingerprint) && Boolean(peerFingerprint) && discoveredFingerprint !== peerFingerprint;
+	mergedDevices.forEach((device) => {
+		const name = resolveFriendlyDeviceName({
+			localName: device.localName,
+			coordinatorName: device.coordinatorName,
+			deviceId: device.deviceId,
+		});
+		const peerStatus = device.peer ? derivePeerUiStatus(device.peer) : "waiting";
+		const trustSummary = device.peer ? derivePeerTrustSummary(device.peer) : null;
+		const discoveredFingerprint = cleanText(device.discovered?.fingerprint);
+		const peerFingerprint = cleanText(device.peer?.fingerprint);
+		const hasConflict =
+			Boolean(device.peer) &&
+			Boolean(discoveredFingerprint) &&
+			Boolean(peerFingerprint) &&
+			discoveredFingerprint !== peerFingerprint;
 
-    if (hasConflict) {
-      attentionItems.push(
-        createRepairItem({
-          id: device.deviceId,
-          name,
-          summary: 'This device identity changed. Repair or remove the older local record before reconnecting it.',
-        }),
-      );
-      return;
-    }
+		if (hasConflict) {
+			attentionItems.push(
+				createRepairItem({
+					id: device.deviceId,
+					name,
+					summary:
+						"This device identity changed. Repair or remove the older local record before reconnecting it.",
+				}),
+			);
+			return;
+		}
 
-    if (device.peer && peerStatus === 'needs-repair') {
-      const detail = trustSummary?.state === 'trusted-by-you'
-        ? trustSummary.description
-        : cleanText(device.peer?.last_error) || 'Sync health is degraded or broken.';
-      attentionItems.push(createRepairItem({ id: device.deviceId, name, summary: detail }));
-    } else if (device.peer && peerStatus === 'offline') {
-      attentionItems.push(
-        createRepairItem({
-          id: device.deviceId,
-          name,
-          summary: 'This device is offline or stale. Review it before re-pairing or retrying sync.',
-        }),
-      );
-    }
+		if (device.peer && peerStatus === "needs-repair") {
+			const detail =
+				trustSummary?.state === "trusted-by-you"
+					? trustSummary.description
+					: cleanText(device.peer?.last_error) || "Sync health is degraded or broken.";
+			attentionItems.push(createRepairItem({ id: device.deviceId, name, summary: detail }));
+		} else if (device.peer && peerStatus === "offline") {
+			attentionItems.push(
+				createRepairItem({
+					id: device.deviceId,
+					name,
+					summary: "This device is offline or stale. Review it before re-pairing or retrying sync.",
+				}),
+			);
+		}
 
-    if (device.peer && trustSummary?.state === 'trusted-by-you') {
-      attentionItems.push(
-        createReviewItem({
-          id: device.deviceId,
-          key: 'other-device-trust',
-          name,
-          summary:
-            'You accepted this device. Finish onboarding on the other device so it trusts this one too.',
-        }),
-      );
-    }
+		if (device.peer && trustSummary?.state === "trusted-by-you") {
+			attentionItems.push(
+				createReviewItem({
+					id: device.deviceId,
+					key: "other-device-trust",
+					name,
+					summary:
+						"You accepted this device. Finish onboarding on the other device so it trusts this one too.",
+				}),
+			);
+		}
 
-    if (!device.peer && device.discovered?.stale) {
-      attentionItems.push(
-        createReviewItem({
-          id: device.deviceId,
-          key: 'stale-discovery',
-          name,
-          summary: 'This device is no longer advertising fresh coordinator presence. Wait for it to check in again before connecting it here.',
-        }),
-      );
-    }
+		if (!device.peer && device.discovered?.stale) {
+			attentionItems.push(
+				createReviewItem({
+					id: device.deviceId,
+					key: "stale-discovery",
+					name,
+					summary:
+						"This device is no longer advertising fresh coordinator presence. Wait for it to check in again before connecting it here.",
+				}),
+			);
+		}
 
-    if (!device.peer && Array.isArray(device.discovered?.groups) && device.discovered.groups.length > 1) {
-      attentionItems.push(
-        createReviewItem({
-          id: device.deviceId,
-          key: 'ambiguous-groups',
-          name,
-          summary: 'This device appears in multiple coordinator groups. Review the team setup before approving it here.',
-        }),
-      );
-    }
+		if (
+			!device.peer &&
+			Array.isArray(device.discovered?.groups) &&
+			device.discovered.groups.length > 1
+		) {
+			attentionItems.push(
+				createReviewItem({
+					id: device.deviceId,
+					key: "ambiguous-groups",
+					name,
+					summary:
+						"This device appears in multiple coordinator groups. Review the team setup before approving it here.",
+				}),
+			);
+		}
 
-    if (
-      device.peer &&
-      deviceNeedsFriendlyName({
-        localName: device.localName,
-        coordinatorName: device.coordinatorName,
-        deviceId: device.deviceId,
-      })
-    ) {
-      attentionItems.push(
-        createNamingItem({
-          id: device.deviceId,
-          name,
-          summary: 'Give this device a friendly name so it is easier to recognize later.',
-        }),
-      );
-    }
-  });
+		if (
+			device.peer &&
+			deviceNeedsFriendlyName({
+				localName: device.localName,
+				coordinatorName: device.coordinatorName,
+				deviceId: device.deviceId,
+			})
+		) {
+			attentionItems.push(
+				createNamingItem({
+					id: device.deviceId,
+					name,
+					summary: "Give this device a friendly name so it is easier to recognize later.",
+				}),
+			);
+		}
+	});
 
-  return {
-    summary: {
-      connectedDeviceCount: peers.filter((peer) => derivePeerUiStatus(peer) === 'connected').length,
-      seenOnTeamCount: discoveredDevices.length,
-      offlineTeamDeviceCount: mergedDevices.filter((device) => isOfflineTeamDevice(device)).length,
-    },
-    duplicatePeople,
-    attentionItems: attentionItems.sort((a, b) => a.priority - b.priority || a.title.localeCompare(b.title)),
-  };
+	return {
+		summary: {
+			connectedDeviceCount: peers.filter((peer) => derivePeerUiStatus(peer) === "connected").length,
+			seenOnTeamCount: discoveredDevices.length,
+			offlineTeamDeviceCount: mergedDevices.filter((device) => isOfflineTeamDevice(device)).length,
+		},
+		duplicatePeople,
+		attentionItems: attentionItems.sort(
+			(a, b) => a.priority - b.priority || a.title.localeCompare(b.title),
+		),
+	};
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
-		"target": "ES2020",
-		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"target": "ES2022",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
 		"jsx": "react-jsx",
 		"jsxImportSource": "preact",
 		"module": "ESNext",

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -6,7 +6,12 @@ import type { OutputChunk, OutputOptions } from "rollup";
 import { defineConfig } from "vite";
 
 function isOutputChunk(value: unknown): value is OutputChunk {
-	return Boolean(value) && typeof value === "object" && "type" in value && (value as { type?: string }).type === "chunk";
+	return (
+		Boolean(value) &&
+		typeof value === "object" &&
+		"type" in value &&
+		(value as { type?: string }).type === "chunk"
+	);
 }
 
 function resolveGitCommit(): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		{ "path": "packages/cloudflare-coordinator-worker" },
 		{ "path": "packages/mcp-server" },
 		{ "path": "packages/viewer-server" },
-		{ "path": "packages/cli" }
+		{ "path": "packages/cli" },
+		{ "path": "packages/ui" }
 	]
 }


### PR DESCRIPTION
## Description

Reintroduces \`packages/ui\` to the biome lint scope (it was previously excluded via \`!packages/ui\` in \`files.includes\`) and sweeps the mechanical + a11y backlog that had accumulated while the package was unchecked. The stubborn remainder — the 133 \`noExplicitAny\` backlog and four deeper a11y rules that need real component refactors — lands under a per-path \`warn\` override so they stay visible as a burn-down baseline without failing CI.

Stacked on top of #688.

Refs: codemem-kwdx (same housekeeping tracker; this is the UI-specific burn-down sweep).

## Baseline

When I first unexcluded \`packages/ui\` the count was **224 errors + 7 infos** across 39 files:

| Count | Rule | Disposition |
|---:|---|---|
| **133** | \`suspicious/noExplicitAny\` | Overridden to warn for \`packages/ui\` — burn down in follow-ups |
| 8 | \`correctness/noUnusedImports\` | Fixed |
| 8 | \`correctness/noUnusedVariables\` | Fixed |
| 7 | \`a11y/useButtonType\` | Fixed (added \`type="button"\`) |
| 5 | \`style/useTemplate\` | Fixed (string concat → template literal) |
| 4 | \`suspicious/useIterableCallbackReturn\` | Fixed (wrap forEach body in braces for void return) |
| 4 | \`a11y/noAutofocus\` | Overridden to **off** — dialog primary-action focus is intentional |
| 2 | \`complexity/useOptionalChain\` | Fixed |
| 1 | \`a11y/useSemanticElements\` | Overridden to warn — needs real component refactor |
| 1 | \`a11y/useKeyWithClickEvents\` | Overridden to warn — needs real component refactor |
| 1 | \`a11y/noStaticElementInteractions\` | Overridden to warn — needs real component refactor |
| 1 | \`a11y/noLabelWithoutControl\` | Overridden to warn — needs real component refactor |
| 1 | \`suspicious/noTemplateCurlyInString\` | Fixed (inline \`biome-ignore\` with reason on literal doc string) |
| 1 | \`style/noNonNullAssertion\` | Fixed (swapped for \`?? null\`) |
| 1 | \`complexity/noExtraBooleanCast\` | Fixed |
| 1 | \`suspicious/noPrototypeBuiltins\` | Fixed |

## What's in the diff

### Large formatter pass

A \`biome check --write\` pass (no \`--unsafe\`) reformatted the entire package against our current biome formatter config. The diff is large (~9k lines) because \`packages/ui\` had never been run through biome before. No semantic changes — formatter-only.

### Mechanical sweeps (safe + reviewed-unsafe)

Biome's \`--unsafe\` pass handled the bulk of the mechanical fixes: unused imports/vars deleted, \`forEach((x) => map.set(...))\` wrapped in braces for void return, \`"a" + b\` → \`\\\`a\${b}\\\`\`, \`x && x.y\` → \`x?.y\`. I reviewed the diff to confirm nothing load-bearing was removed.

### Manual fixes

- **\`useButtonType\` (7)**: manually added \`type="button"\` in \`sync-actors.tsx\` (×3) and \`sync-peers.tsx\` (×4) so forms in those components don't accidentally submit.
- **\`useIterableCallbackReturn\` (4)**: manually wrapped expression-bodied arrow callbacks that returned \`Map.set\` / \`Array.push\` values — \`feed.ts\` (×3) and \`team-sync.ts\` (×1).
- **\`noNonNullAssertion\` (1)**: \`diagnostics.ts\` had \`timestamps[timestamps.length - 1]!\` after a sort — swapped for \`?? null\` which matches the function's \`string | null\` return type naturally.
- **\`noTemplateCurlyInString\` (1)**: the observer-headers help tooltip in \`settings.tsx\` contains literal documentation text describing the template placeholder syntax users can type in header values. Added a per-line \`biome-ignore\` directly above the string literal with an explicit reason.
- **\`noAutofocus\` (4) revert** in \`sync-dialogs.tsx\`: biome's \`--unsafe\` pass stripped \`autoFocus\` from four dialog primary-action elements (confirm button, merge choice, primary actor radio, rename input). Those autofocuses are intentional — dialog primary-action focus is load-bearing for the "press Enter to confirm" keyboard flow. Reverted the file and turned \`a11y/noAutofocus\` **off** for \`packages/ui\` via a per-path override so biome won't regress this pattern again.

### Per-path overrides (burn-down ratchet) in \`biome.json\`

\`\`\`json
"overrides": [
    {
        "includes": ["packages/ui/**"],
        "linter": {
            "rules": {
                "a11y": {
                    "noAutofocus": "off",
                    "noLabelWithoutControl": "warn",
                    "noStaticElementInteractions": "warn",
                    "useKeyWithClickEvents": "warn",
                    "useSemanticElements": "warn"
                },
                "suspicious": {
                    "noExplicitAny": "warn"
                }
            }
        }
    }
]
\`\`\`

- \`noAutofocus\` is **off** — dialog pattern is legitimate, don't warn about it.
- Everything else is **warn** — visible but non-blocking. CI no longer fails on these rules for UI code, but they're still tracked in biome output as a burn-down baseline. New code that introduces more violations gets flagged immediately.

## Result

- **0 errors** (was 224)
- **137 warnings** (133 \`noExplicitAny\` + 4 deeper a11y rules) — all under the \`packages/ui\` override, all expected, all tracked

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (\`pnpm run test\` — 1190 passed across the workspace)
- [x] Added/updated tests for changes — N/A, lint cleanup
- [x] Manually verified changes work as expected (\`pnpm exec biome check packages\` exit 0; \`pnpm run tsc\` clean)

## Checklist

- [x] Code follows project style (\`biome check\` passes with 0 errors)
- [x] Self-review completed
- [x] Documentation updated (if needed) — N/A
- [x] No new warnings introduced (the 137 warnings are the deferred backlog, not new drift)

## Follow-ups

Two tracks remain:

1. **Burn down the 133 \`noExplicitAny\` in \`packages/ui\`** — dominant patterns are DOM event handlers (\`any\` on \`event.currentTarget\`), fetch response shapes, and untyped third-party lib payloads (Chart.js, Radix, etc.). Each can be typed correctly with modest effort but the total is a multi-PR project.
2. **Address the four deeper a11y warnings** (\`useSemanticElements\`, \`useKeyWithClickEvents\`, \`noStaticElementInteractions\`, \`noLabelWithoutControl\`). These are real UX/a11y improvements that deserve per-component review — keyboard handlers on click-only elements, swapping div roles for semantic tags, pairing labels with inputs. Not suitable for a mechanical sweep.

## Stacking

Depends on #688 (lint cleanup + rule promotion). Won't conflict with #687 (0.25.3 release) — different files, different concerns.