### PR TITLE
chore(lint): burn down Record<string, any> in packages/ui (4 sites)

### DIFF
--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -71,7 +71,7 @@ export const state = {
 	pairingCommandRaw: "",
 
 	/* Config */
-	configDefaults: {} as Record<string, any>,
+	configDefaults: {} as Record<string, unknown>,
 	configPath: "",
 	settingsDirty: false,
 	noticeTimer: null as ReturnType<typeof setTimeout> | null,

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -207,7 +207,16 @@ function replaceFeedItem(updatedItem: any) {
 
 /* ── Summary object extraction ───────────────────────────── */
 
-function getSummaryObject(item: any): Record<string, any> | null {
+/**
+ * A feed summary object parsed from a memory item's metadata, body text,
+ * or adapter output. Keys are semantic sections (request / completed /
+ * learned / etc.) but the server has enough shape variance that values
+ * are typed as `unknown` — callers are expected to coerce via
+ * `String(v || "")` or a `typeof` narrowing before rendering.
+ */
+type FeedSummary = Record<string, unknown>;
+
+function getSummaryObject(item: any): FeedSummary | null {
 	const preferredKeys = [
 		"request",
 		"outcome",
@@ -219,9 +228,13 @@ function getSummaryObject(item: any): Record<string, any> | null {
 		"next_steps",
 		"notes",
 	];
-	const looksLikeSummary = (v: any) => {
+	const looksLikeSummary = (v: unknown): v is FeedSummary => {
 		if (!v || typeof v !== "object" || Array.isArray(v)) return false;
-		return preferredKeys.some((k) => typeof v[k] === "string" && v[k].trim().length > 0);
+		const obj = v as FeedSummary;
+		return preferredKeys.some((k) => {
+			const value = obj[k];
+			return typeof value === "string" && value.trim().length > 0;
+		});
 	};
 	if (item?.summary && typeof item.summary === "object" && !Array.isArray(item.summary))
 		return item.summary;
@@ -446,7 +459,7 @@ function renderMarkdownSafe(value: string): string {
 
 /* ── Rendering functions ─────────────────────────────────── */
 
-function renderSummarySections(summary: Record<string, any>) {
+function renderSummarySections(summary: FeedSummary) {
 	const preferred = [
 		"request",
 		"outcome",

--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -1255,8 +1255,29 @@ function hiddenUnlessAdvanced(): boolean {
 	return !settingsShowAdvanced;
 }
 
+type ObserverStatusShape = {
+	active?: {
+		provider?: string;
+		model?: string;
+		auth?: {
+			method?: string;
+			token_present?: boolean;
+		};
+	} | null;
+	available_credentials?: Record<string, Record<string, boolean>>;
+	latest_failure?: {
+		error_message?: string;
+		observer_provider?: string;
+		observer_model?: string;
+		observer_runtime?: string;
+		updated_at?: string;
+		attempt_count?: number;
+		impact?: string;
+	} | null;
+};
+
 function ObserverStatusBanner() {
-	const status = settingsRenderState.observerStatus as Record<string, any> | null;
+	const status = settingsRenderState.observerStatus as ObserverStatusShape | null;
 	if (!status) {
 		return <div id="observerStatusBanner" className="observer-status-banner" hidden />;
 	}


### PR DESCRIPTION
## Description

Replaces all **4 literal `Record<string, any>` usages** in `packages/ui` with properly-shaped types. First installment of the `packages/ui` `noExplicitAny` burn-down started in #689.

Stacked on top of #689.

## Sites

### `packages/ui/src/lib/state.ts:74`

\`configDefaults: {} as Record<string, any>\` → \`Record<string, unknown>\`.

The two call sites (\`state.configDefaults = defaults\` in \`settings.tsx\` and \`state.configDefaults?.observer_max_chars || ""\`) both continue to type-check because \`unknown\` is assignable from any source and the single-field read already runs through a \`|| ""\` fallback.

### \`packages/ui/src/tabs/feed.ts\` (2 sites)

Introduces a \`FeedSummary = Record<string, unknown>\` type alias near the summary extraction helpers and threads it through both \`getSummaryObject(item): FeedSummary | null\` and \`renderSummarySections(summary: FeedSummary)\`.

The \`looksLikeSummary\` predicate becomes a proper TypeScript type guard \`(v: unknown): v is FeedSummary\` so downstream callers get narrowing for free. Value access in the renderer was already wrapped in \`String(summary[key] || "").trim()\` so no runtime behavior changes.

### \`packages/ui/src/tabs/settings.tsx:1259\`

The observer status banner was casting the render state entry to \`Record<string, any>\` and then navigating \`status.active.provider\`, \`status.active.auth.method\`, \`status.available_credentials[…]\`, \`status.latest_failure.error_message\`, etc.

Introduces a local \`ObserverStatusShape\` type that names every field the banner actually reads:

\`\`\`ts
type ObserverStatusShape = {
    active?: {
        provider?: string;
        model?: string;
        auth?: { method?: string; token_present?: boolean };
    } | null;
    available_credentials?: Record<string, Record<string, boolean>>;
    latest_failure?: {
        error_message?: string;
        observer_provider?: string;
        observer_model?: string;
        observer_runtime?: string;
        updated_at?: string;
        attempt_count?: number;
        impact?: string;
    } | null;
};
\`\`\`

The existing \`typeof x === "string"\` defensive guards at the failure-rendering site are preserved — they're runtime checks against the server emitting an unexpected shape, which the type cast alone can't prevent.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (\`pnpm run test\` — 1190 passed across the workspace)
- [x] Added/updated tests for changes — N/A, pure type tightening, runtime behavior unchanged
- [x] Manually verified changes work as expected

- \`pnpm run tsc\` — clean (the type changes flowed through all call sites without needing any callers to narrow further)
- \`pnpm exec biome check packages\` — exit 0, **132 warnings** (was 137 on #689; 5 warnings resolved because one of the fixes cascaded to clear an adjacent \`any\` narrowing)

## Checklist

- [x] Code follows project style (\`biome check\` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed) — N/A
- [x] No new warnings introduced

## Remaining backlog

**128 \`noExplicitAny\` warnings still in \`packages/ui\`** across:

- DOM event handlers where \`event.currentTarget\` is typed as \`any\`
- Untyped third-party lib payloads (Chart.js, Radix primitive props)
- Internal \`any\` locals in the feed / settings rendering code
- Sync view-model shapes typed as \`any\` for historical reasons

Future PRs stacked on this one will chip away at those categories. The remaining work is typically ~10-30 fixes per PR depending on whether the fix is a simple type annotation or a deeper shape definition.

## Stacking

```
◉  #690  chore(lint): burn down Record<string, any> in packages/ui (4 sites)  ← this PR
◯  #689  chore(lint): unexclude packages/ui from biome and burn down the mechanical backlog
◯  #688  chore(lint): clean up biome warnings and promote rules to error
```

Parallel to #687 (0.25.3 release, no overlap).