### PR TITLE
chore(ts): bump server-side TypeScript target to ES2024

### DIFF
--- a/packages/cloudflare-coordinator-worker/tsconfig.json
+++ b/packages/cloudflare-coordinator-worker/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist",
-		"lib": ["ES2022", "DOM"],
+		"lib": ["ES2024", "DOM"],
 		"types": ["@cloudflare/workers-types"]
 	},
 	"include": ["src"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"compilerOptions": {
-		"target": "ES2022",
+		"target": "ES2024",
 		"module": "Node16",
 		"moduleResolution": "Node16",
 		"baseUrl": ".",
@@ -11,7 +11,7 @@
 				"packages/core/src/internal/cloudflare-coordinator.ts"
 			]
 		},
-		"lib": ["ES2022"],
+		"lib": ["ES2024"],
 		"strict": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
## Description

Raises \`tsconfig.base.json\` target and lib from \`ES2022\` to \`ES2024\` for all the packages that extend it (\`core\`, \`cli\`, \`mcp-server\`, \`viewer-server\`, \`cloudflare-coordinator-worker\`). \`packages/ui\` stays at \`ES2022\` — it's a standalone config that targets browsers, not Node, so its safe baseline is different.

Stacked on top of #690.

## Why

The workspace requires Node \`>=24\` (current LTS) across every server-side package. Node 24 has full support for ES2024, which includes a pile of APIs that would be actively useful in future work:

- \`Promise.withResolvers()\` — eliminates the "defer object" pattern
- \`Object.groupBy()\` / \`Map.groupBy()\` — replaces manual \`reduce\` chains when bucketing arrays
- \`Array.fromAsync()\` — collect async iterables in one call
- \`Atomics.waitAsync()\` — non-blocking shared-memory sync
- RegExp \`v\` flag — set-notation character classes

Previously these APIs were available at runtime but **not in the TS type system**, because \`lib: ES2022\` told the compiler they didn't exist yet. This bump unblocks using them without forcing adoption anywhere.

## Why not ES2025

Node 24 supports ~95% of ES2025 (Set methods, Iterator helpers, \`Promise.try\`, \`RegExp.escape\`, JSON module import attributes, \`Float16Array\`), but several features are still feature-flagged or landed in very recent Node 24 patch releases. Validating every ES2025 API across the deployment surface isn't worth the effort today for features that are mostly niche utilities. **Revisit when Node 26 lands and ES2025 is fully baselined.**

## Why \`packages/ui\` stays at ES2022

The viewer is served as a static bundle to a developer's browser, not to Node. The safe browser baseline is independent of Node 24. ES2022 covers ~96% of browsers and unblocks the biome autofixes that assume ES2022 (e.g. \`Object.hasOwn\`). Bumping UI to ES2024 would cut browser coverage to ~85% without a corresponding benefit.

## Changes

| File | Change |
|---|---|
| \`tsconfig.base.json\` | \`target: "ES2022"\` → \`"ES2024"\`, \`lib: ["ES2022"]\` → \`["ES2024"]\` |
| \`packages/cloudflare-coordinator-worker/tsconfig.json\` | \`lib: ["ES2022", "DOM"]\` → \`["ES2024", "DOM"]\` (the worker extends the base but overrides \`lib\` to pull in \`DOM\` for worker globals; bumping the override keeps it in sync) |

The worker's Cloudflare compatibility date is \`2026-03-28\`, which uses a V8 with full ES2023 and most ES2024 support, so the worker runtime is safe.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (\`pnpm run test\` — 1190 passed across the workspace)
- [x] Added/updated tests for changes — N/A, pure TS config change with no current usage
- [x] Manually verified changes work as expected

- \`pnpm exec tsc --build --force\` — clean rebuild of all 6 TS projects with the new target
- \`pnpm exec biome check packages\` — exit 0, 132 warnings (the expected packages/ui burn-down baseline from #689 + #690)

**No runtime or behavior changes.** This PR only enables new APIs for future use; it doesn't add any current usage of ES2024 features.

## Checklist

- [x] Code follows project style (\`biome check\` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed) — N/A
- [x] No new warnings introduced

## Stack

```
◉  #691  chore(ts): bump server-side TypeScript target to ES2024  ← this PR
◯  #690  chore(lint): burn down Record<string, any> in packages/ui
◯  #689  chore(lint): unexclude packages/ui from biome and burn down the mechanical backlog
│ ◯  #687  chore(release): prepare 0.25.3                       (parallel on main)
◯─┘  main
```