### PR TITLE
chore(lint): burn down any in packages/ui/src/lib/state.ts

### DIFF
--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -1,7 +1,159 @@
 /* Global application state — shared across tabs. */
 
+import type { UiSyncViewModel } from "../tabs/sync/view-model";
+
 export type RefreshState = "idle" | "refreshing" | "paused" | "error";
 export type TabId = "feed" | "health" | "sync";
+
+/* ── Cached server payload shapes ─────────────────────────── */
+
+/**
+ * Minimal interfaces covering the fields UI code actually reads from the
+ * viewer API responses that get cached in `state`. All fields are optional
+ * and shapes are open (additional fields from the server are just ignored).
+ * When the UI starts reading a new field, add it here.
+ */
+
+export interface UsageTotals {
+	tokens_read?: number;
+	tokens_saved?: number;
+	work_investment_tokens?: number;
+}
+
+export interface RecentPack {
+	created_at?: string;
+	tokens_read?: number;
+	tokens_saved?: number;
+	metadata_json?: {
+		exact_duplicates_collapsed?: number;
+		exact_dedupe_enabled?: boolean;
+	};
+}
+
+export interface CachedStatsPayload {
+	identity?: { actor_id?: string };
+	database?: {
+		path?: string;
+		size_bytes?: number;
+		active_memory_items?: number;
+		vector_coverage?: number;
+		tags_coverage?: number;
+	};
+	usage?: { totals?: UsageTotals };
+	reliability?: {
+		counts?: { errored_batches?: number };
+		rates?: {
+			flush_success_rate?: number;
+			dropped_event_rate?: number;
+		};
+	};
+	maintenance_jobs?: unknown[];
+}
+
+export interface CachedUsagePayload {
+	totals_global?: UsageTotals;
+	totals?: UsageTotals;
+	totals_filtered?: UsageTotals | null;
+	events?: unknown[];
+	recent_packs?: RecentPack[];
+}
+
+export interface CachedRawEventsPayload {
+	pending?: number;
+	sessions?: number;
+	events?: unknown;
+}
+
+export interface CachedSyncStatus {
+	daemon_state?: string;
+	enabled?: boolean;
+	last_sync_at?: string;
+	last_sync_at_utc?: string;
+	presence_status?: string;
+	attentionItems?: unknown[];
+	summary?: unknown;
+	discovered_devices?: unknown[];
+	paired_peer_count?: number;
+}
+
+export interface SyncActor {
+	actor_id?: string;
+	display_name?: string;
+	actor_display_name?: string;
+	is_local?: boolean;
+}
+
+export interface SyncPeerStatus {
+	peer_state?: string;
+	sync_status?: string;
+	ping_status?: string;
+	fresh?: boolean;
+}
+
+export interface SyncPeer {
+	peer_device_id?: string;
+	peer_name?: string;
+	name?: string;
+	display_name?: string;
+	actor_id?: string;
+	fingerprint?: string;
+	addresses?: unknown[];
+	claimed_local_actor?: boolean;
+	private_count?: number;
+	shareable_count?: number;
+	scope_label?: string;
+	status?: SyncPeerStatus;
+	last_error?: string;
+}
+
+export interface SyncSharingReviewRow {
+	actor_display_name?: string;
+	actor_id?: string;
+	peer_name?: string;
+	peer_device_id?: string;
+	private_count?: number;
+	scope_label?: string;
+	shareable_count?: number;
+}
+
+export interface DiscoveredDevice {
+	device_id?: string;
+	display_name?: string;
+	fingerprint?: string;
+	groups?: string[];
+	stale?: boolean;
+	addresses?: string[];
+	needs_local_approval?: boolean;
+	waiting_for_peer_approval?: boolean;
+}
+
+export interface CachedSyncCoordinator {
+	configured?: boolean;
+	groups?: unknown[];
+	coordinator_url?: string;
+	discovered_devices?: DiscoveredDevice[];
+	presence_status?: string;
+	paired_peer_count?: number;
+}
+
+export interface CachedTeamInvite {
+	encoded?: string;
+	warnings?: string[];
+}
+
+export interface CachedTeamJoin {
+	status?: string;
+}
+
+export interface CachedPairingPayload {
+	name?: string;
+}
+
+export interface CachedSyncJoinRequest {
+	display_name?: string;
+	device_id?: string;
+	request_id?: string;
+}
 
 const TAB_KEY = "codemem-tab";
 const FEED_FILTER_KEY = "codemem-feed-filter";
@@ -35,10 +187,10 @@ export const state = {
 	feedTypeFilter: "all" as FeedFilter,
 	feedScopeFilter: "all" as FeedScope,
 	feedQuery: "",
-	lastFeedItems: [] as any[],
+	lastFeedItems: [] as unknown[],
 	lastFeedFilteredCount: 0,
 	lastFeedSignature: "",
-	pendingFeedItems: null as any[] | null,
+	pendingFeedItems: null as unknown[] | null,
 
 	/* Feed item view state */
 	itemViewState: new Map<string, string>(),
@@ -46,28 +198,28 @@ export const state = {
 	newItemKeys: new Set<string>(),
 
 	/* Cached payloads */
-	lastStatsPayload: null as any,
-	lastUsagePayload: null as any,
-	lastRawEventsPayload: null as any,
-	lastSyncStatus: null as any,
-	lastSyncActors: [] as any[],
-	lastSyncPeers: [] as any[],
-	pendingAcceptedSyncPeers: [] as any[],
-	lastSyncSharingReview: [] as any[],
-	lastSyncCoordinator: null as any,
-	lastSyncJoinRequests: [] as any[],
-	lastTeamInvite: null as any,
-	lastTeamJoin: null as any,
+	lastStatsPayload: null as CachedStatsPayload | null,
+	lastUsagePayload: null as CachedUsagePayload | null,
+	lastRawEventsPayload: null as CachedRawEventsPayload | null,
+	lastSyncStatus: null as CachedSyncStatus | null,
+	lastSyncActors: [] as SyncActor[],
+	lastSyncPeers: [] as SyncPeer[],
+	pendingAcceptedSyncPeers: [] as SyncPeer[],
+	lastSyncSharingReview: [] as SyncSharingReviewRow[],
+	lastSyncCoordinator: null as CachedSyncCoordinator | null,
+	lastSyncJoinRequests: [] as CachedSyncJoinRequest[],
+	lastTeamInvite: null as CachedTeamInvite | null,
+	lastTeamJoin: null as CachedTeamJoin | null,
 	syncJoinFlowFeedback: null as { message: string; tone: "success" | "warning" } | null,
 	syncPeerFeedbackById: new Map<string, { message: string; tone: "success" | "warning" }>(),
 	syncPeersSectionFeedback: null as { message: string; tone: "success" | "warning" } | null,
 	syncJoinRequestsFeedback: null as { message: string; tone: "success" | "warning" } | null,
 	syncDiscoveredFeedback: null as { message: string; tone: "success" | "warning" } | null,
-	lastSyncAttempts: [] as any[],
-	lastSyncLegacyDevices: [] as any[],
-	lastSyncViewModel: null as any,
+	lastSyncAttempts: [] as unknown[],
+	lastSyncLegacyDevices: [] as unknown[],
+	lastSyncViewModel: null as UiSyncViewModel | null,
 	lastSyncDuplicatePersonDecisions: {} as Record<string, string>,
-	pairingPayloadRaw: null as any,
+	pairingPayloadRaw: null as CachedPairingPayload | null,
 	pairingCommandRaw: "",
 
 	/* Config */

--- a/packages/ui/src/tabs/sync/helpers.test.ts
+++ b/packages/ui/src/tabs/sync/helpers.test.ts
@@ -38,6 +38,8 @@ describe("buildActorSelectOptions", () => {
 		];
 		state.lastSyncPeers = [];
 		state.lastSyncViewModel = {
+			summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
+			attentionItems: [],
 			duplicatePeople: [
 				{
 					displayName: "Adam",
@@ -61,6 +63,8 @@ describe("buildActorSelectOptions", () => {
 		];
 		state.lastSyncPeers = [];
 		state.lastSyncViewModel = {
+			summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
+			attentionItems: [],
 			duplicatePeople: [
 				{
 					displayName: "Adam",
@@ -80,7 +84,11 @@ describe("buildActorSelectOptions", () => {
 	it("keeps an explicit unassigned choice in the option list", () => {
 		state.lastSyncActors = [{ actor_id: "actor-local", display_name: "Adam", is_local: true }];
 		state.lastSyncPeers = [];
-		state.lastSyncViewModel = { duplicatePeople: [] };
+		state.lastSyncViewModel = {
+			summary: { connectedDeviceCount: 0, seenOnTeamCount: 0, offlineTeamDeviceCount: 0 },
+			attentionItems: [],
+			duplicatePeople: [],
+		};
 
 		expect(buildActorSelectOptions()).toEqual([
 			{ value: "", label: "No person assigned" },


### PR DESCRIPTION
## Summary

Burns down all 18 `noExplicitAny` biome warnings in
`packages/ui/src/lib/state.ts`, dropping the repo-wide count from
103 → 85.

Replaces the \`null as any\` / \`[] as any[]\` cached state fields with
concrete interfaces covering the fields the UI actually reads from the
viewer API responses it caches.

## Interfaces added

Each interface only declares the fields currently consumed. Shapes are
open (all optional) so the server can evolve without breaking the UI —
when the UI starts reading a new field, add it here.

- \`UsageTotals\` — \`tokens_read\` / \`tokens_saved\` /
  \`work_investment_tokens\`
- \`RecentPack\` — pack row in \`lastUsagePayload.recent_packs\`
- \`CachedStatsPayload\` — \`identity\`, \`database\`, \`usage\`,
  \`reliability\`, \`maintenance_jobs\`
- \`CachedUsagePayload\` — \`totals_global\` / \`totals\` /
  \`totals_filtered\` / \`events\` / \`recent_packs\`
- \`CachedRawEventsPayload\` — \`pending\` / \`sessions\` / \`events\`
- \`CachedSyncStatus\` — \`daemon_state\`, \`enabled\`,
  \`last_sync_at(_utc)\`, \`presence_status\`, \`summary\`, etc.
- \`SyncActor\` — \`actor_id\`, \`display_name\`,
  \`actor_display_name\`, \`is_local\`
- \`SyncPeerStatus\` + \`SyncPeer\` — \`peer_device_id\`, \`peer_name\`,
  \`status.peer_state\`, \`last_error\`, \`scope_label\`, etc.
- \`SyncSharingReviewRow\` — fields consumed by the sharing review
  panel
- \`DiscoveredDevice\` + \`CachedSyncCoordinator\` — \`device_id\`,
  \`groups\`, \`stale\`, \`addresses\`, plus \`presence_status\` /
  \`paired_peer_count\`
- \`CachedTeamInvite\` / \`CachedTeamJoin\` / \`CachedPairingPayload\` /
  \`CachedSyncJoinRequest\` — small response shapes for mutation flows

\`lastSyncViewModel\` is now typed directly as
\`UiSyncViewModel | null\`, reusing the existing derived-view-model
type from \`tabs/sync/view-model.ts\`.

## Test fixtures

\`packages/ui/src/tabs/sync/helpers.test.ts\` — the three inline
\`lastSyncViewModel\` fixtures now include the full
\`UiSyncViewModel\` shape (\`summary\`, \`attentionItems\`,
\`duplicatePeople\`) so they match the tightened type.

## Zero call-site rewrites

No consumer of these state fields needed edits. The interfaces were
built by walking the tsc errors emitted after the initial
\`any → unknown\` swap and adding exactly the fields being read — the
resulting shapes accepted every existing usage, including the
\`state.lastX || {}\` fallback pattern in health.ts.

## Type of Change

- [x] Non-breaking change (internal cleanup / lint burn-down)

## Testing

- [x] \`pnpm exec tsc --build\` — clean
- [x] \`pnpm run test\` — 1190 passed across the workspace
- [x] \`pnpm exec biome check packages\` — 85 warnings (was 103, -18)
- [x] \`pnpm exec biome check packages/ui/src/lib/state.ts\` — clean

## Checklist

- [x] No new \`any\` introduced
- [x] Runtime behavior unchanged — all fallbacks/reads hit the same
  fields; only the static types narrowed
- [x] No private refs / internal hostnames in code or commit message
- [x] Stacked on #692 (api.ts burn-down)