### PR TITLE
chore(lint): burn down any in packages/ui tail files

### DIFF
--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -263,7 +263,7 @@ async function doRefresh() {
 		setRefreshStatus("refreshing");
 
 		// Always load health data (for the header health dot) and config
-		const promises: Promise<any>[] = [loadHealthData(), loadConfigData()];
+		const promises: Promise<unknown>[] = [loadHealthData(), loadConfigData()];
 
 		// Load tab-specific data
 		if (state.activeTab === "feed") {

--- a/packages/ui/src/lib/dom.ts
+++ b/packages/ui/src/lib/dom.ts
@@ -1,6 +1,6 @@
 /* DOM utility helpers — thin wrappers for vanilla element creation. */
 
-export function el(tag: string, className?: string | null, text?: any): HTMLElement {
+export function el(tag: string, className?: string | null, text?: unknown): HTMLElement {
 	const node = document.createElement(tag);
 	if (className) node.className = className;
 	if (text !== undefined && text !== null) node.textContent = String(text);

--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -198,9 +198,9 @@ function hasOwn(obj: unknown, key: string): boolean {
 	return typeof obj === "object" && obj !== null && Object.hasOwn(obj, key);
 }
 
-function effectiveOrConfigured(config: any, effective: any, key: string): any {
-	if (hasOwn(effective, key)) return effective[key];
-	if (hasOwn(config, key)) return config[key];
+function effectiveOrConfigured(config: unknown, effective: unknown, key: string): unknown {
+	if (hasOwn(effective, key)) return (effective as Record<string, unknown>)[key];
+	if (hasOwn(config, key)) return (config as Record<string, unknown>)[key];
 	return undefined;
 }
 
@@ -257,10 +257,11 @@ function inferObserverModel(
 	return { model: DEFAULT_OPENAI_MODEL, source: "Recommended (direct API)" };
 }
 
-function configuredValueForKey(config: any, key: string): unknown {
+function configuredValueForKey(config: unknown, key: string): unknown {
+	const cfg = (config ?? {}) as Record<string, unknown>;
 	switch (key) {
 		case "claude_command": {
-			const value = config?.claude_command;
+			const value = cfg.claude_command;
 			if (!Array.isArray(value)) return [];
 			const normalized: string[] = [];
 			value.forEach((item) => {
@@ -280,18 +281,18 @@ function configuredValueForKey(config: any, key: string): unknown {
 		case "sync_host":
 		case "sync_coordinator_url":
 		case "sync_coordinator_group":
-			return normalizeTextValue(asInputString(config?.[key]));
+			return normalizeTextValue(asInputString(cfg[key]));
 		case "observer_runtime":
-			return normalizeTextValue(asInputString(config?.observer_runtime));
+			return normalizeTextValue(asInputString(cfg.observer_runtime));
 		case "observer_auth_source":
-			return normalizeTextValue(asInputString(config?.observer_auth_source));
+			return normalizeTextValue(asInputString(cfg.observer_auth_source));
 		case "observer_auth_command": {
-			const value = config?.observer_auth_command;
+			const value = cfg.observer_auth_command;
 			if (!Array.isArray(value)) return [];
 			return value.filter((item) => typeof item === "string");
 		}
 		case "observer_headers": {
-			const value = config?.observer_headers;
+			const value = cfg.observer_headers;
 			if (!value || typeof value !== "object" || Array.isArray(value)) return {};
 			const headers: Record<string, string> = {};
 			Object.entries(value as Record<string, unknown>).forEach(([header, headerValue]) => {
@@ -311,34 +312,34 @@ function configuredValueForKey(config: any, key: string): unknown {
 		case "raw_events_sweeper_interval_s":
 		case "sync_port":
 		case "sync_interval_s": {
-			if (!hasOwn(config, key)) return "";
-			const parsed = Number(config[key]);
+			if (!hasOwn(cfg, key)) return "";
+			const parsed = Number(cfg[key]);
 			return Number.isFinite(parsed) && parsed !== 0 ? parsed : "";
 		}
 		case "sync_coordinator_timeout_s":
 		case "sync_coordinator_presence_ttl_s": {
-			if (!hasOwn(config, key)) return "";
-			const parsed = Number(config[key]);
+			if (!hasOwn(cfg, key)) return "";
+			const parsed = Number(cfg[key]);
 			return Number.isFinite(parsed) && parsed > 0 ? parsed : "";
 		}
 		case "observer_auth_cache_ttl_s": {
-			if (!hasOwn(config, key)) return "";
-			const parsed = Number(config[key]);
+			if (!hasOwn(cfg, key)) return "";
+			const parsed = Number(cfg[key]);
 			return Number.isFinite(parsed) ? parsed : "";
 		}
 		case "sync_enabled":
 		case "sync_mdns":
 		case "observer_tier_routing_enabled":
 		case "observer_rich_openai_use_responses":
-			return asBooleanValue(config?.[key]);
+			return asBooleanValue(cfg[key]);
 		default:
-			return hasOwn(config, key) ? config[key] : "";
+			return hasOwn(cfg, key) ? cfg[key] : "";
 	}
 }
 
 function mergeOverrideBaseline(
 	baseline: Record<string, unknown>,
-	config: any,
+	config: unknown,
 	envOverrides: Record<string, unknown>,
 ): Record<string, unknown> {
 	const next = { ...baseline };
@@ -709,23 +710,42 @@ function joinPhrases(values: string[]): string {
 	return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
 }
 
-function buildSettingsNotice(payload: any): { message: string; type: "success" | "warning" } {
-	const effects = payload?.effects && typeof payload.effects === "object" ? payload.effects : {};
+interface SettingsSaveEffects {
+	hot_reloaded_keys?: unknown;
+	live_applied_keys?: unknown;
+	restart_required_keys?: unknown;
+	warnings?: unknown;
+	manual_actions?: unknown;
+	sync?: {
+		attempted?: boolean;
+		message?: string;
+		reason?: string;
+		affected_keys?: unknown;
+		ok?: boolean;
+	};
+}
+
+function buildSettingsNotice(payload: unknown): { message: string; type: "success" | "warning" } {
+	const raw = (payload as { effects?: SettingsSaveEffects } | null | undefined)?.effects;
+	const effects: SettingsSaveEffects =
+		raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
 	const hotReloaded = Array.isArray(effects.hot_reloaded_keys)
-		? effects.hot_reloaded_keys.map(formatSettingsKey)
+		? effects.hot_reloaded_keys.map((key) => formatSettingsKey(String(key)))
 		: [];
 	const liveApplied = Array.isArray(effects.live_applied_keys)
-		? effects.live_applied_keys.map(formatSettingsKey)
+		? effects.live_applied_keys.map((key) => formatSettingsKey(String(key)))
 		: [];
 	const restartRequired = Array.isArray(effects.restart_required_keys)
-		? effects.restart_required_keys.map(formatSettingsKey)
+		? effects.restart_required_keys.map((key) => formatSettingsKey(String(key)))
 		: [];
 	const warnings = Array.isArray(effects.warnings)
 		? effects.warnings.filter(
-				(value: unknown): value is string => typeof value === "string" && value.trim().length > 0,
+				(value): value is string => typeof value === "string" && value.trim().length > 0,
 			)
 		: [];
-	const manualActions = Array.isArray(effects.manual_actions) ? effects.manual_actions : [];
+	const manualActions: Array<{ command?: string }> = Array.isArray(effects.manual_actions)
+		? (effects.manual_actions as Array<{ command?: string }>)
+		: [];
 	const sync = effects.sync && typeof effects.sync === "object" ? effects.sync : {};
 	const lines: string[] = [];
 
@@ -772,7 +792,17 @@ function protectedConfigHelp(key: string): string {
 	return `${key} is read-only in the viewer for security. Edit the config file or environment instead.`;
 }
 
-function formStateFromPayload(payload: any): SettingsFormState {
+interface ConfigPayload {
+	config?: Record<string, unknown>;
+	effective?: Record<string, unknown>;
+	defaults?: Record<string, unknown>;
+	env_overrides?: Record<string, unknown>;
+	protected_keys?: unknown;
+	providers?: unknown;
+	path?: string;
+}
+
+function formStateFromPayload(payload: ConfigPayload): SettingsFormState {
 	const config = payload.config || {};
 	const effective = payload.effective || {};
 	const observerHeadersValue = effectiveOrConfigured(config, effective, "observer_headers");
@@ -869,23 +899,24 @@ function formStateFromPayload(payload: any): SettingsFormState {
 	};
 }
 
-export function renderConfigModal(payload: any) {
+export function renderConfigModal(payload: unknown) {
 	if (!payload || typeof payload !== "object") return;
-	const defaults = payload.defaults || {};
-	const config = payload.config || {};
+	const data = payload as ConfigPayload;
+	const defaults = data.defaults || {};
+	const config = data.config || {};
 	const envOverrides =
-		payload.env_overrides && typeof payload.env_overrides === "object" ? payload.env_overrides : {};
-	const protectedKeys = Array.isArray(payload.protected_keys)
-		? payload.protected_keys.filter(
-				(value: unknown): value is string => typeof value === "string" && value.trim().length > 0,
+		data.env_overrides && typeof data.env_overrides === "object" ? data.env_overrides : {};
+	const protectedKeys = Array.isArray(data.protected_keys)
+		? data.protected_keys.filter(
+				(value): value is string => typeof value === "string" && value.trim().length > 0,
 			)
 		: [];
-	const values = formStateFromPayload(payload);
+	const values = formStateFromPayload(data);
 
 	settingsEnvOverrides = envOverrides;
 	settingsProtectedKeys = new Set(protectedKeys);
 	state.configDefaults = defaults;
-	state.configPath = payload.path || "";
+	state.configPath = data.path || "";
 
 	updateRenderState({
 		effectiveText:
@@ -894,7 +925,7 @@ export function renderConfigModal(payload: any) {
 				: "",
 		overridesVisible: Object.keys(envOverrides).length > 0,
 		pathText: state.configPath ? `Config path: ${state.configPath}` : "Config path: n/a",
-		providers: toProviderList(payload.providers),
+		providers: toProviderList(data.providers),
 		statusText: "Ready",
 		values,
 	});
@@ -1197,8 +1228,11 @@ function formatFailureTimestamp(value: unknown): string {
 	return ts.toLocaleString();
 }
 
-function renderObserverStatusBanner(status: any) {
-	updateRenderState({ observerStatus: status && typeof status === "object" ? status : null });
+function renderObserverStatusBanner(status: unknown) {
+	updateRenderState({
+		observerStatus:
+			status && typeof status === "object" ? (status as Record<string, unknown>) : null,
+	});
 }
 
 export async function loadConfigData() {

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -366,7 +366,7 @@ export function renderSyncAttempts() {
 		const time = attempt.started_at || attempt.started_at_utc || "";
 		const peerId = String(attempt.peer_device_id || "").trim();
 		const matchedPeer = Array.isArray(state.lastSyncPeers)
-			? state.lastSyncPeers.find((p: any) => String(p?.peer_device_id || "") === peerId)
+			? state.lastSyncPeers.find((p) => String(p?.peer_device_id || "") === peerId)
 			: null;
 		const peerName = String(matchedPeer?.name || "").trim();
 		const peerLabel = peerName || (peerId ? peerId.slice(0, 8) : "unknown");

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -2,7 +2,7 @@
 
 import type { RadixSelectOption } from "../../components/primitives/radix-select";
 import { copyToClipboard, el } from "../../lib/dom";
-import { state } from "../../lib/state";
+import { type SyncActor, state } from "../../lib/state";
 import { deriveVisiblePeopleActors } from "./view-model";
 
 /* ── Skeleton helpers ────────────────────────────────────── */
@@ -109,7 +109,7 @@ export function redactIpOctets(text: string): string {
 	return text.replace(/\b(\d{1,3}\.\d{1,3})\.\d{1,3}\.\d{1,3}\b/g, "$1.#.#");
 }
 
-export function redactAddress(address: any): string {
+export function redactAddress(address: unknown): string {
 	const raw = String(address || "");
 	if (!raw) return "";
 	return redactIpOctets(raw);
@@ -130,14 +130,14 @@ export function parseScopeList(value: string): string[] {
 
 /* ── Actor helpers ───────────────────────────────────────── */
 
-export function actorLabel(actor: any): string {
+export function actorLabel(actor: SyncActor | null | undefined): string {
 	if (!actor || typeof actor !== "object") return "Unknown person";
 	const displayName = String(actor.display_name || "").trim();
 	if (!displayName) return String(actor.actor_id || "Unknown person");
 	return displayName;
 }
 
-export function actorDisplayLabel(actor: any): string {
+export function actorDisplayLabel(actor: SyncActor | null | undefined): string {
 	if (!actor || typeof actor !== "object") return "Unknown person";
 	return actor.is_local ? "You" : actorLabel(actor);
 }
@@ -211,7 +211,7 @@ export function buildActorOptions(selectedActorId: string): HTMLOptionElement[] 
 	return options;
 }
 
-export function mergeTargetActors(actorId: string): any[] {
+export function mergeTargetActors(actorId: string): SyncActor[] {
 	const actors = visibleSyncActors();
 	return actors.filter((actor) => String(actor?.actor_id || "") !== actorId);
 }


### PR DESCRIPTION
## Summary

Burns down the remaining 16 \`noExplicitAny\` warnings in the tail of
\`packages/ui\`: \`settings.tsx\` (9), \`sync/helpers.ts\` (4),
\`lib/dom.ts\` (1), \`sync/diagnostics.ts\` (1), \`app.ts\` (1). Drops
repo-wide warnings 20 → 4.

After this PR the only warnings left are four a11y rule violations
that need real component refactors
(\`noStaticElementInteractions\`, \`useKeyWithClickEvents\`,
\`noLabelWithoutControl\`, \`useSemanticElements\`). Those will be
tackled in a follow-up PR.

## settings.tsx

- \`effectiveOrConfigured(config: any, effective: any, key): any\` →
  \`(config: unknown, effective: unknown, key): unknown\`. Field
  access now goes through a narrow
  \`(x as Record<string, unknown>)[key]\` cast inside the guarded
  branch.
- \`configuredValueForKey(config: any, key)\` → \`config: unknown\`.
  The body captures \`config\` into a local
  \`cfg: Record<string, unknown>\` once, replacing the \`config?.foo\`
  / \`config?.[key]\` chains.
- \`mergeOverrideBaseline(..., config: any, ...)\` →
  \`config: unknown\` (same call pattern — it only forwards into
  \`configuredValueForKey\`).
- \`buildSettingsNotice(payload: any)\` → \`payload: unknown\`.
  Introduces a local \`SettingsSaveEffects\` interface covering
  \`hot_reloaded_keys\`, \`live_applied_keys\`,
  \`restart_required_keys\`, \`warnings\`, \`manual_actions\`, and
  \`sync\` (with its nested shape). The \`manual_actions\` list is
  typed as \`Array<{ command?: string }>\`.
- \`formStateFromPayload(payload: any)\` → takes a new inline
  \`ConfigPayload\` interface (\`config\`, \`effective\`, \`defaults\`,
  \`env_overrides\`, \`protected_keys\`, \`providers\`, \`path\`). The
  same interface is reused by \`renderConfigModal(payload: unknown)\`,
  which gains a narrowing cast.
- \`renderObserverStatusBanner(status: any)\` → \`status: unknown\`,
  with the \`Record<string, unknown>\` cast happening inside the
  truthy branch.

## sync/helpers.ts

- Imports the new \`SyncActor\` type from \`lib/state\`.
- \`actorLabel(actor: any)\` / \`actorDisplayLabel(actor: any)\` /
  \`mergeTargetActors(): any[]\` → use
  \`SyncActor | null | undefined\` / \`SyncActor[]\`.
- \`redactAddress(address: any)\` → \`address: unknown\`.

## sync/diagnostics.ts

- \`state.lastSyncPeers.find((p: any) => ...)\` — removes the
  explicit \`any\` annotation; the callback parameter now inherits the
  \`SyncPeer\` element type from the typed state field.

## lib/dom.ts

- \`el(tag, className, text?: any)\` → \`text?: unknown\`. The helper
  already coerces via \`String(text)\`.

## app.ts

- \`Promise<any>[]\` for the parallel refresh promise list →
  \`Promise<unknown>[]\`. All the loaders called here now return
  \`unknown\` or a concrete type, so no callers read through this
  array.

## Type of Change

- [x] Non-breaking change (internal cleanup / lint burn-down)

## Testing

- [x] \`pnpm exec tsc --build\` — clean
- [x] \`pnpm run test\` — 1190 passed across the workspace
- [x] \`pnpm exec biome check packages\` — 4 warnings remaining, all
  a11y (tracked for follow-up)

## Checklist

- [x] No new \`any\` introduced (\`noExplicitAny\` now hits zero in
  the whole workspace)
- [x] No runtime or behavior changes
- [x] No private refs / internal hostnames in code or commit message
- [x] Stacked on #695 (feed.ts burn-down)