### PR TITLE
chore(lint): promote packages/ui biome rules back to error

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -69,14 +69,7 @@
 			"linter": {
 				"rules": {
 					"a11y": {
-						"noAutofocus": "off",
-						"noLabelWithoutControl": "warn",
-						"noStaticElementInteractions": "warn",
-						"useKeyWithClickEvents": "warn",
-						"useSemanticElements": "warn"
-					},
-					"suspicious": {
-						"noExplicitAny": "warn"
+						"noAutofocus": "off"
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

With the \`noExplicitAny\` + a11y burn-down stack complete and zero
warnings remaining in \`packages/ui\`, the per-path override in
\`biome.json\` that ratcheted these rules down to warnings is no
longer doing any work. This PR prunes it so the rules enforce as
errors in CI, locking in the burn-down.

## Rules promoted back to error (by removal)

All five of these now inherit \`error\` from the top-level config
instead of being downgraded to \`warn\` under the
\`packages/ui/**\` override:

- \`suspicious/noExplicitAny\` — zero sites after #692–#696.
- \`a11y/noLabelWithoutControl\` — fixed in #697
  (\`<label>hours</label>\` → \`<span>hours</span>\` in
  \`sync-disclosure.tsx\`).
- \`a11y/noStaticElementInteractions\` — fixed in #697 by adding an
  explicit \`role="dialog"\` on the \`Dialog.Content\` child div.
- \`a11y/useKeyWithClickEvents\` — #697 added a scoped
  \`biome-ignore\` at the one legitimate site (background-dismiss
  click in \`radix-dialog.tsx\`; keyboard close is handled by Radix's
  \`onEscapeKeyDown\`).
- \`a11y/useSemanticElements\` — fixed in #697 by converting the
  sync-dialog choice list from \`<div role="list">\` to
  \`<ul><li>\`.

## Rule kept off

\`a11y/noAutofocus\` stays disabled for \`packages/ui/**\`. Dialog
primary actions legitimately need \`autoFocus\` (it's the standard
behavior for modal confirm buttons, and was reverted once already
after biome's \`--unsafe\` autofix stripped it from
\`sync-dialogs.tsx\`). The dialog UX relies on it.

## Net effect

New \`any\` or a11y regressions in \`packages/ui\` are now caught as
CI errors instead of silent warnings. Zero code changes required;
config-only PR that finishes the burn-down ratchet.

## Type of Change

- [x] Non-breaking change (lint config tightening)

## Testing

- [x] \`pnpm exec biome check packages\` — zero warnings, zero
  errors (with the pruned override active)
- [x] \`pnpm exec tsc --build\` — clean

## Checklist

- [x] No code changes
- [x] Verified locally that the pruned override produces zero
  warnings across all 238 files
- [x] No private refs / internal hostnames in commit message
- [x] Stacked on #697 (a11y fixes)