### PR TITLE
fix(core): auto-bootstrap fresh databases in MemoryStore constructor

### DIFF
--- a/packages/cli/src/commands/claude-hook-ingest.test.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.test.ts
@@ -154,6 +154,41 @@ describe("claude-hook-ingest command", () => {
 		}
 	});
 
+	it("direct enqueue bootstraps fresh databases on demand", () => {
+		// Fresh path without initTestSchema() — the failure mode Cowork sandbox
+		// VMs hit when the hook fires before the MCP server finishes its own
+		// MemoryStore construction. Without ensureSchemaBootstrapped this call
+		// would throw "no such table: raw_events".
+		const dir = mkdtempSync(join(tmpdir(), "codemem-cli-direct-bootstrap-"));
+		const dbPath = join(dir, "fresh.sqlite");
+		try {
+			const result = directEnqueue(
+				{
+					hook_event_name: "SessionStart",
+					session_id: "sess-fresh-bootstrap",
+					timestamp: "2026-01-01T00:00:00Z",
+					cwd: "/tmp/demo",
+				},
+				dbPath,
+			);
+			expect(result).toEqual({ inserted: 1, skipped: 0 });
+
+			// Re-open through a plain connect() and verify the raw event actually
+			// landed in the auto-bootstrapped schema.
+			const db = connect(dbPath);
+			try {
+				const rawCount = db.prepare("SELECT COUNT(*) AS c FROM raw_events").get() as {
+					c: number;
+				};
+				expect(rawCount.c).toBe(1);
+			} finally {
+				db.close();
+			}
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	describe("durability layer", () => {
 		it("drains spooled backlog on the HTTP-success path so a recovered viewer doesn't strand entries", async () => {
 			// Pre-seed a payload from a previous failed run.

--- a/packages/cli/src/commands/claude-hook-ingest.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.ts
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import {
 	buildRawEventEnvelopeFromHook,
 	connect,
+	ensureSchemaBootstrapped,
 	flushRawEvents,
 	loadSqliteVec,
 	MemoryStore,
@@ -131,6 +132,11 @@ export function directEnqueue(
 		} catch {
 			// sqlite-vec not available — non-fatal for raw event enqueue
 		}
+		// Auto-bootstrap fresh databases before touching raw_events. The MCP
+		// server's MemoryStore constructor normally bootstraps first, but
+		// hooks can race its startup (claude-hook-ingest is a separate CLI
+		// process) so we can't rely on that ordering.
+		ensureSchemaBootstrapped(db);
 		const strippedPayload = stripPrivateObj(envelope.payload) as Record<string, unknown>;
 		const existing = db
 			.prepare(

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,9 +1,11 @@
 /**
- * Database connection and schema initialization for the codemem TS backend.
+ * Database connection and schema primitives for the codemem store.
  *
- * Mirrors codemem/db.py — same pragmas, same WAL mode, same sqlite-vec loading.
- * During Phase 1 of the migration, Python owns DDL (schema migrations).
- * The TS runtime validates the schema version but does NOT run migrations.
+ * Owns the `connect()` helper (pragmas, WAL mode, sqlite-vec loading, legacy
+ * path migration) and the schema-version introspection helpers
+ * (`getSchemaVersion`, `assertSchemaReady`, `ensureAdditiveSchemaCompatibility`,
+ * `ensurePlannerStats`). Schema bootstrap DDL lives in `schema-bootstrap.ts`;
+ * `MemoryStore` auto-invokes it on first construction against a fresh DB.
  */
 
 import {
@@ -188,8 +190,10 @@ export function migrateLegacyDbPath(dbPath: string): void {
  * Open a better-sqlite3 connection with the standard codemem pragmas.
  *
  * Migrates legacy DB paths if needed, creates parent directories,
- * sets WAL mode, busy timeout, foreign keys.
- * Does NOT initialize or migrate the schema — during Phase 1, Python owns DDL.
+ * sets WAL mode, busy timeout, foreign keys. Does not create or migrate the
+ * schema — callers are responsible for bootstrapping (either via
+ * `MemoryStore`, which auto-bootstraps fresh files, or via `initDatabase` /
+ * `bootstrapSchema` for offline tooling).
  */
 export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 	migrateLegacyDbPath(dbPath);
@@ -263,10 +267,11 @@ export function isEmbeddingDisabled(): boolean {
 }
 
 /**
- * Read the schema user_version from the database.
+ * Read the schema `user_version` pragma from the database.
  *
- * During Phase 1, the TS runtime uses this to verify the schema is initialized
- * (by Python) before operating. It does NOT set or bump the version.
+ * Returns `0` for a freshly-created or empty file, which is the signal
+ * `MemoryStore` / `initDatabase` / `bootstrapSchema` use to decide whether to
+ * run the initial DDL.
  */
 export function getSchemaVersion(db: DatabaseType): number {
 	const row = db.pragma("user_version", { simple: true });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -341,6 +341,7 @@ export { buildSessionContext, flushRawEvents } from "./raw-event-flush.js";
 export { RawEventSweeper } from "./raw-event-sweeper.js";
 export type { MaintenanceJob, NewMaintenanceJob } from "./schema.js";
 export * as schema from "./schema.js";
+export { bootstrapSchema, ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 export type { StoreHandle } from "./search.js";
 export {
 	dedupeOrderedIds,

--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -1,5 +1,5 @@
 import type { Database } from "./db.js";
-import { SCHEMA_VERSION } from "./db.js";
+import { getSchemaVersion, SCHEMA_VERSION } from "./db.js";
 import { TEST_SCHEMA_BASE_DDL } from "./test-schema.generated.js";
 
 const SCHEMA_AUX_DDL = `
@@ -65,4 +65,16 @@ export function bootstrapSchema(db: Database): void {
 	db.exec(TEST_SCHEMA_BASE_DDL);
 	db.exec(SCHEMA_AUX_DDL);
 	db.pragma(`user_version = ${SCHEMA_VERSION}`);
+}
+
+/**
+ * Run `bootstrapSchema` on a database only if it's still at the unbootstrapped
+ * state (`user_version === 0`). Safe to call from any entry point that opens
+ * a raw `connect()` handle and then issues queries expecting the schema to be
+ * in place. Idempotent: already-initialized databases are left untouched.
+ */
+export function ensureSchemaBootstrapped(db: Database): void {
+	if (getSchemaVersion(db) === 0) {
+		bootstrapSchema(db);
+	}
 }

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1030,3 +1030,95 @@ describe("buildFilterClauses", () => {
 		expect(result.params).toEqual(["local:device-1", "device-1"]);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Fresh-database auto-bootstrap
+// ---------------------------------------------------------------------------
+
+describe("MemoryStore constructor auto-bootstrap", () => {
+	let tmpDir: string;
+	let prevCodememConfig: string | undefined;
+
+	beforeEach(() => {
+		prevCodememConfig = process.env.CODEMEM_CONFIG;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-bootstrap-test-"));
+		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
+	});
+
+	afterEach(() => {
+		if (prevCodememConfig === undefined) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevCodememConfig;
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("bootstraps schema when constructed against a path with no existing file", () => {
+		const dbPath = join(tmpDir, "fresh.sqlite");
+		// No pre-seeding — let the constructor discover an uninitialized DB.
+		// This mirrors the MCP server / claude-hook-ingest entry points hitting
+		// a fresh plugin install inside a wiped sandbox VM.
+		const store = new MemoryStore(dbPath);
+		try {
+			// If bootstrap worked, basic reads succeed and stats report an empty store.
+			const stats = store.stats();
+			expect(stats.database.memory_items).toBe(0);
+			expect(stats.database.sessions).toBe(0);
+
+			// Real query-path coverage: exercising `recent` / `recentByKinds`
+			// hits memory_items + FTS/provenance joins that assertSchemaReady
+			// alone doesn't catch if any table is missing.
+			expect(store.recent(10)).toEqual([]);
+			expect(store.recentByKinds(["discovery"])).toEqual([]);
+
+			// And a write-then-read round-trip through the same constructor-
+			// bootstrapped handle — the actual MCP-server hot path on fresh DBs.
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(
+				sessionId,
+				"discovery",
+				"post-bootstrap insert",
+				"written on an auto-bootstrapped DB",
+			);
+			expect(store.get(memId)?.title).toBe("post-bootstrap insert");
+		} finally {
+			store.close();
+		}
+	});
+
+	it("bootstraps schema when constructed against an empty existing file", () => {
+		const dbPath = join(tmpDir, "empty.sqlite");
+		// Touch an empty file so connect() opens it as an uninitialized DB.
+		writeFileSync(dbPath, "");
+		const store = new MemoryStore(dbPath);
+		try {
+			const stats = store.stats();
+			expect(stats.database.memory_items).toBe(0);
+			// Same query-path smoke test as the fresh-path case.
+			expect(store.recent(10)).toEqual([]);
+		} finally {
+			store.close();
+		}
+	});
+
+	it("does not re-bootstrap an already-initialized database", () => {
+		const dbPath = join(tmpDir, "existing.sqlite");
+		// First construction bootstraps.
+		const first = new MemoryStore(dbPath);
+		const sessionId = insertTestSession(first.db);
+		const memId = first.remember(
+			sessionId,
+			"discovery",
+			"persisted memory",
+			"should survive a second construction",
+		);
+		first.close();
+
+		// Second construction must not wipe or re-run bootstrap DDL destructively.
+		const second = new MemoryStore(dbPath);
+		try {
+			const fetched = second.get(memId);
+			expect(fetched?.title).toBe("persisted memory");
+		} finally {
+			second.close();
+		}
+	});
+});

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,15 +1,12 @@
 /**
- * MemoryStore — TypeScript port of codemem/store/_store.py (Phase 1 CRUD).
+ * MemoryStore — the main read/write surface for the codemem memory store.
  *
- * During Phase 1, Python owns DDL/schema. This TS runtime reads and writes data
- * but does NOT create or migrate tables. The assertSchemaReady() call verifies
- * the schema was initialized by Python before any operations.
- *
- * Methods ported: get, remember, forget, recent, recentByKinds, stats,
- * updateMemoryVisibility, close.
- *
- * NOT ported yet: pack, usage tracking, vectors, provenance resolution,
- * memory_owned_by_self check.
+ * Manages a better-sqlite3 connection to the on-disk database and exposes
+ * CRUD, search, pack, and sync helpers. Fresh databases are auto-bootstrapped
+ * on first construction: if the connected file has no schema (user_version 0),
+ * `bootstrapSchema` runs before `assertSchemaReady` so every CLI/MCP entry
+ * point gets a ready-to-use store without requiring an explicit
+ * `codemem db init` invocation first.
  */
 
 import { randomUUID } from "node:crypto";
@@ -41,6 +38,7 @@ import {
 	buildMemoryPackTraceAsync,
 } from "./pack.js";
 import * as schema from "./schema.js";
+import { ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 import {
 	type ExplainOptions,
 	explain as explainFn,
@@ -218,6 +216,12 @@ export class MemoryStore {
 		this.db = connect(this.dbPath);
 		try {
 			loadSqliteVec(this.db);
+			// Auto-bootstrap fresh databases: if the file is empty or has no
+			// schema yet, run the full schema DDL before asserting readiness.
+			// This makes `new MemoryStore(...)` safe to call from any entry
+			// point (mcp-server, claude-hook-ingest, CLI commands) without a
+			// prior explicit `codemem db init`.
+			ensureSchemaBootstrapped(this.db);
 			assertSchemaReady(this.db);
 			ensureAdditiveSchemaCompatibility(this.db);
 			ensurePlannerStats(this.db);


### PR DESCRIPTION
## Summary

Regression follow-up to #575. That PR taught \`codemem db init\` and
\`codemem serve start\` to auto-bootstrap a fresh SQLite file, but
didn't hoist the fix into the shared \`MemoryStore\` constructor or
the \`directEnqueue\` hook path. So every other entry point —
\`mcp-server\`, \`claude-hook-ingest\`, the CLI commands
(\`stats\`, \`search\`, \`recent\`, \`memory\`, \`embed\`, etc.) —
still called \`assertSchemaReady\` (or raw \`db.prepare("SELECT ... FROM raw_events")\`)
and threw on an uninitialized DB.

**User-visible symptom:** installing the plugin into a fresh
environment — notably a Claude Desktop / Cowork sandbox VM whose
\`~/.codemem\` is wiped on every session — produced an empty
\`mem.sqlite\` via \`connect()\` but then the very first MCP tool
call or hook invocation crashed because no schema existed. The user
had to run \`codemem db init\` manually before anything worked.

## Fix

Introduces a small \`ensureSchemaBootstrapped(db)\` helper in
\`schema-bootstrap.ts\`:

\`\`\`ts
export function ensureSchemaBootstrapped(db: Database): void {
    if (getSchemaVersion(db) === 0) {
        bootstrapSchema(db);
    }
}
\`\`\`

Exported from \`@codemem/core\`. Called from two places:

1. **\`MemoryStore\` constructor** (\`packages/core/src/store.ts\`) —
   runs right after \`loadSqliteVec\` and before
   \`assertSchemaReady\`. Matches the \`initDatabase()\` gate pattern
   exactly: a fresh file gets the full schema DDL, an
   already-initialized file is left alone. Idempotent with the
   existing \`db init\` / \`serve start\` paths.

2. **\`directEnqueue\`** (\`packages/cli/src/commands/claude-hook-ingest.ts\`) —
   runs right after \`loadSqliteVec\` and before the raw
   \`SELECT 1 FROM raw_events ...\` prepare. This closes the
   MCP-server-startup vs. hook-spawn race: the hook script is a
   separate CLI process and we can't rely on the MCP server having
   bootstrapped the DB first.

Every other entry point that touches the DB routes through
\`MemoryStore\` (mcp-server, claude-hook-inject's
\`buildLocalPack\`, \`flushBoundaryRawEvents\`, the read-only CLI
commands), so they all pick up the fix for free.

## Stale docstring cleanup

Four file-level or function-level comments across \`store.ts\` and
\`db.ts\` still claimed "During Phase 1, Python owns DDL / schema" —
relics of the original TS port. The TypeScript runtime has owned the
schema surface for a while now. Rewrote them to describe current
behavior (auto-bootstrap on fresh databases, callers responsible for
bootstrapping raw \`connect()\` handles).

## Tests

Added four focused tests covering the fresh-DB path:

1. **\`store.test.ts\` → bootstraps on a path with no existing file**
   — constructs directly, then exercises real query paths
   (\`recent\`, \`recentByKinds\`) and does a full write-then-read
   round-trip via \`insertTestSession\` + \`remember\` + \`get\`.
2. **\`store.test.ts\` → bootstraps on an empty zero-byte file** —
   the symptom from the Cowork VM diagnosis. Same query-path smoke
   test.
3. **\`store.test.ts\` → does not re-bootstrap an already-initialized
   database** — writes through the first instance, closes, reopens
   via a new \`MemoryStore\`, confirms the original row is still
   readable.
4. **\`claude-hook-ingest.test.ts\` → directEnqueue bootstraps fresh
   DBs on demand** — constructs a DB path without
   \`initTestSchema()\`, calls \`directEnqueue\` directly, asserts
   \`inserted: 1\` and verifies the raw event actually landed via a
   follow-up \`SELECT COUNT(*) FROM raw_events\`.

## Follow-ups filed (not in this PR)

Gordon Ramsay review surfaced three related issues that should be
separate PRs:

- **\`memory_vectors\` virtual table** is not created by
  \`bootstrapSchema\` (Drizzle can't model sqlite-vec virtual tables).
  \`listVectorModelCounts\` in \`vectors.ts\` does unguarded
  \`SELECT FROM memory_vectors\`, so semantic search throws on any
  freshly-bootstrapped DB. Pre-existing bug, now more likely to
  surface. Filed as a follow-up.
- **Raw \`connect()\` call-site audit** — \`sync-retention-runner\`,
  \`vector-migration\`, \`dedup-key-backfill\`, \`coordinator-actions\`,
  \`export-import\`, \`extraction-replay\`, \`extraction-eval\`. All
  maintenance/sync ops that normally run against an initialized DB,
  but worth confirming individually. Filed as a follow-up task.

(The directEnqueue fix Gordon flagged as a MUST is included in this
PR.)

## Type of Change

- [x] 🐛 Bug fix (fixes a regression introduced by the partial #575 fix)

## Testing

- [x] \`pnpm --filter @codemem/core exec vitest run src/store.test.ts\` —
  75 passed (3 new auto-bootstrap tests)
- [x] \`pnpm --filter codemem exec vitest run src/commands/claude-hook-ingest.test.ts\` —
  13 passed (1 new directEnqueue fresh-bootstrap test)
- [x] \`pnpm run test\` — 1194 passed across the workspace (was 1190)
- [x] \`pnpm exec tsc --build\` — clean
- [x] \`pnpm exec biome check packages\` — clean

## Checklist

- [x] Idempotent with existing \`db init\` / \`serve start\` paths
- [x] No concurrent-bootstrap race surface change (all DDL uses
  \`CREATE ... IF NOT EXISTS\`; SQLite \`busy_timeout\` handles
  serialization)
- [x] Tests exercise real query paths, not just constructor-level
  assertions
- [x] Closes the MCP-startup vs. hook-spawn race via the
  \`directEnqueue\` fix
- [x] No private refs / internal hostnames in code or commit message