### PR TITLE
fix(core): create memory_vectors virtual table during schema bootstrap

### DIFF
--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -1,5 +1,5 @@
 import type { Database } from "./db.js";
-import { getSchemaVersion, SCHEMA_VERSION } from "./db.js";
+import { getSchemaVersion, isEmbeddingDisabled, loadSqliteVec, SCHEMA_VERSION } from "./db.js";
 import { TEST_SCHEMA_BASE_DDL } from "./test-schema.generated.js";
 
 const SCHEMA_AUX_DDL = `
@@ -61,9 +61,58 @@ CREATE TRIGGER memory_items_ad AFTER DELETE ON memory_items BEGIN
 END;
 `;
 
+/**
+ * DDL for the sqlite-vec `memory_vectors` virtual table. Drizzle cannot model
+ * virtual tables driven by a loadable extension, so this lives alongside the
+ * other aux DDL and is executed through `ensureVectorSchema` (which first
+ * makes sure the `vec0` module is actually loaded on the connection).
+ *
+ * Columns mirror the Python `_ensure_vector_schema` helper in `codemem/db.py`.
+ * The embedding width (384) matches the default BAAI/bge-small-en-v1.5 model
+ * and the existing vectors tests; changing it requires rebuilding existing
+ * vector rows via the migration helper.
+ */
+const MEMORY_VECTORS_DDL = `
+CREATE VIRTUAL TABLE IF NOT EXISTS memory_vectors USING vec0(
+	embedding float[384],
+	memory_id INTEGER,
+	chunk_index INTEGER,
+	content_hash TEXT,
+	model TEXT
+);
+`;
+
+/**
+ * Create the `memory_vectors` sqlite-vec virtual table on `db` if it does not
+ * already exist. No-op when embeddings are disabled via
+ * `CODEMEM_EMBEDDING_DISABLED`, matching the Python backend's behavior.
+ *
+ * This function is safe to call from any bootstrap path — it probes for
+ * `vec_version()` first and only attempts to load the sqlite-vec extension if
+ * it is not already present on the connection. That avoids double-loading when
+ * callers (like `MemoryStore`) have already called `loadSqliteVec` directly.
+ */
+export function ensureVectorSchema(db: Database): void {
+	if (isEmbeddingDisabled()) return;
+	if (!isSqliteVecLoaded(db)) {
+		loadSqliteVec(db);
+	}
+	db.exec(MEMORY_VECTORS_DDL);
+}
+
+function isSqliteVecLoaded(db: Database): boolean {
+	try {
+		const row = db.prepare("SELECT vec_version() AS v").get() as { v?: string } | undefined;
+		return typeof row?.v === "string" && row.v.length > 0;
+	} catch {
+		return false;
+	}
+}
+
 export function bootstrapSchema(db: Database): void {
 	db.exec(TEST_SCHEMA_BASE_DDL);
 	db.exec(SCHEMA_AUX_DDL);
+	ensureVectorSchema(db);
 	db.pragma(`user_version = ${SCHEMA_VERSION}`);
 }
 

--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -1,6 +1,5 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadSqliteVec } from "./db.js";
 import * as embeddings from "./embeddings.js";
 import { getMaintenanceJob } from "./maintenance-jobs.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
@@ -52,17 +51,9 @@ describe("vector migration", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		db = new Database(":memory:");
+		// initTestSchema -> bootstrapSchema loads sqlite-vec and creates the
+		// memory_vectors virtual table as part of normal bootstrap.
 		initTestSchema(db);
-		loadSqliteVec(db);
-		db.exec(`
-			CREATE VIRTUAL TABLE memory_vectors USING vec0(
-				embedding float[384],
-				memory_id INTEGER,
-				chunk_index INTEGER,
-				content_hash TEXT,
-				model TEXT
-			)
-		`);
 		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValue({
 			model: "test-model",
 			dimensions: 384,

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -1,10 +1,18 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadSqliteVec } from "./db.js";
 import * as embeddings from "./embeddings.js";
 import { startMaintenanceJob } from "./maintenance-jobs.js";
+import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
-import { backfillVectors, semanticSearch, storeVectors } from "./vectors.js";
+import {
+	backfillVectors,
+	resolveSemanticSearchModel,
+	semanticSearch,
+	storeVectors,
+} from "./vectors.js";
 
 vi.mock("./embeddings.js", async () => {
 	const actual = await vi.importActual<typeof import("./embeddings.js")>("./embeddings.js");
@@ -22,17 +30,9 @@ describe("vectors", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		db = new Database(":memory:");
+		// initTestSchema -> bootstrapSchema loads sqlite-vec and creates the
+		// memory_vectors virtual table as part of normal bootstrap.
 		initTestSchema(db);
-		loadSqliteVec(db);
-		db.exec(`
-			CREATE VIRTUAL TABLE memory_vectors USING vec0(
-				embedding float[384],
-				memory_id INTEGER,
-				chunk_index INTEGER,
-				content_hash TEXT,
-				model TEXT
-			)
-		`);
 		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValue({
 			model: "test-model",
 			dimensions: 384,
@@ -154,5 +154,94 @@ describe("vectors", () => {
 
 		expect(results).toEqual([]);
 		expect(embeddings.embedTexts).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Fresh-database bootstrap coverage for memory_vectors.
+// Regression guard for codemem-yco1: bootstrapSchema must create the
+// sqlite-vec virtual table so the unguarded `resolveSemanticSearchModel`
+// query path does not throw on a freshly auto-bootstrapped DB.
+// ---------------------------------------------------------------------------
+
+describe("memory_vectors bootstrap on fresh databases", () => {
+	let tmpDir: string;
+	let prevCodememConfig: string | undefined;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		prevCodememConfig = process.env.CODEMEM_CONFIG;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-vec-bootstrap-test-"));
+		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
+		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValue({
+			model: "test-model",
+			dimensions: 384,
+			embed: vi.fn(async () => [new Float32Array(384)]),
+		});
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+	});
+
+	afterEach(() => {
+		if (prevCodememConfig === undefined) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevCodememConfig;
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("creates memory_vectors during initTestSchema on an in-memory DB", () => {
+		const scratch = new Database(":memory:");
+		try {
+			initTestSchema(scratch);
+			const row = scratch
+				.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_vectors'")
+				.get() as { name: string } | undefined;
+			expect(row?.name).toBe("memory_vectors");
+
+			// resolveSemanticSearchModel must not throw on an empty but
+			// bootstrapped DB — this is the unguarded path that previously
+			// blew up when memory_vectors was missing.
+			expect(() => resolveSemanticSearchModel(scratch, "test-model")).not.toThrow();
+			expect(resolveSemanticSearchModel(scratch, "test-model")).toBeNull();
+		} finally {
+			scratch.close();
+		}
+	});
+
+	it("creates memory_vectors via auto-bootstrap when constructing MemoryStore against a fresh path", async () => {
+		const dbPath = join(tmpDir, "vectors-fresh.sqlite");
+		// No pre-seeding — constructor discovers an uninitialized file and
+		// runs ensureSchemaBootstrapped, which must now create memory_vectors.
+		const store = new MemoryStore(dbPath);
+		try {
+			const tableRow = store.db
+				.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_vectors'")
+				.get() as { name: string } | undefined;
+			expect(tableRow?.name).toBe("memory_vectors");
+
+			// Unguarded model-resolution query must succeed on a fresh DB.
+			expect(() => resolveSemanticSearchModel(store.db, "test-model")).not.toThrow();
+
+			// Round-trip: remember → flushPendingVectorWrites → semanticSearch.
+			// With the mocked embedding client, storeVectors writes a vector row.
+			const sessionId = insertTestSession(store.db);
+			store.remember(
+				sessionId,
+				"discovery",
+				"vectors bootstrap smoke test",
+				"body text for semantic search round-trip",
+			);
+			await store.flushPendingVectorWrites();
+
+			const count = store.db
+				.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE model = ?")
+				.get("test-model") as { c: number };
+			expect(count.c).toBeGreaterThan(0);
+
+			// After a successful insert, resolveSemanticSearchModel should
+			// return the current model (this is the read path semanticSearch
+			// relies on before embedding the query).
+			expect(resolveSemanticSearchModel(store.db, "test-model")).toBe("test-model");
+		} finally {
+			store.close();
+		}
 	});
 });


### PR DESCRIPTION
## Description

Fresh SQLite files auto-bootstrapped via `MemoryStore` (PR #699) never
got the sqlite-vec `memory_vectors` virtual table. `bootstrapSchema`
ran the base DDL and stopped, so the first query touching
`memory_vectors` (e.g. `resolveSemanticSearchModel`) threw
`SQLITE_ERROR: no such table` on a brand-new install.

Add `ensureVectorSchema(db)` to `schema-bootstrap.ts`:

- no-op when `CODEMEM_EMBEDDING_DISABLED` is set
- probe `SELECT vec_version()` first and only call `loadSqliteVec` if
  the extension isn't already loaded (avoids double-loading when
  `MemoryStore` already loaded it)
- run `CREATE VIRTUAL TABLE IF NOT EXISTS memory_vectors USING vec0(...)`

Wire it into `bootstrapSchema` between `SCHEMA_AUX_DDL` and the
`user_version` pragma so every bootstrap path (initTestSchema, the
MemoryStore auto-bootstrap path, and any future raw callers) gets the
vec table. Drop now-redundant manual `loadSqliteVec` + `CREATE VIRTUAL
TABLE` from `vectors` / `vector-migration` test setups.

Closes codemem-yco1

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Tests pass locally (`pnpm run test` — 1196 passed / 68 files)
- [x] Added regression tests in `vectors.test.ts` for both fresh-db
  paths: in-memory `initTestSchema` and `MemoryStore` constructor
  against an uninitialized sqlite file, including a
  `remember` → `flushPendingVectorWrites` → `semanticSearch` round-trip
- [x] `pnpm run tsc`, `pnpm exec biome check packages`, `pnpm build`
  all clean

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed) — no docs change required
- [x] No new warnings introduced