### PR TITLE
fix(core): bootstrap on fresh DBs in remaining raw connect() call sites

### DIFF
--- a/packages/core/src/export-import.ts
+++ b/packages/core/src/export-import.ts
@@ -12,6 +12,7 @@ import {
 import { expandUserPath } from "./observer-config.js";
 import { projectColumnClause, resolveProject as resolveProjectName } from "./project.js";
 import * as schema from "./schema.js";
+import { ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 
 type JsonObject = Record<string, unknown>;
 type MemoryInsert = typeof schema.memoryItems.$inferInsert;
@@ -205,6 +206,9 @@ function fetchBySessionIds(
 export function exportMemories(opts: ExportOptions = {}): ExportPayload {
 	const db = connect(resolveDbPath(opts.dbPath));
 	try {
+		// Auto-bootstrap fresh databases so `codemem export-memories` does not
+		// crash on a brand-new install (empty export is a valid outcome).
+		ensureSchemaBootstrapped(db);
 		assertSchemaReady(db);
 		const resolvedProject = resolveExportProject(opts);
 		const filters: JsonObject = {};
@@ -439,6 +443,9 @@ export function importMemories(payload: ExportPayload, opts: ImportOptions = {})
 
 	const db = connect(resolveDbPath(opts.dbPath));
 	try {
+		// Auto-bootstrap fresh databases so restoring a backup into a fresh
+		// install works without an explicit `codemem db init` first.
+		ensureSchemaBootstrapped(db);
 		assertSchemaReady(db);
 		const d = drizzle(db, { schema });
 		return db.transaction(() => {

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -22,7 +22,7 @@ import { loadObserverConfig, ObserverClient } from "./observer-client.js";
 import { buildMemoryPack } from "./pack.js";
 import { projectClause } from "./project.js";
 import * as schema from "./schema.js";
-import { bootstrapSchema } from "./schema-bootstrap.js";
+import { bootstrapSchema, ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 import { MemoryStore } from "./store.js";
 import { canonicalMemoryKind, getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
 
@@ -281,6 +281,13 @@ function withDb<T>(dbPath: string | undefined, fn: (db: Database, resolvedPath: 
 	const resolvedPath = resolveDbPath(dbPath);
 	const db = connect(resolvedPath);
 	try {
+		// Auto-bootstrap fresh databases before asserting readiness. This
+		// helper backs several exported maintenance functions that are hit
+		// from CLI commands (`db vacuum`, `db raw-events-status`,
+		// `db raw-events-retry`, `db raw-events-gate`, `memory roles`,
+		// `memory relink-report`), any of which a user can run before
+		// `codemem db init`.
+		ensureSchemaBootstrapped(db);
 		assertSchemaReady(db);
 		return fn(db, resolvedPath);
 	} finally {


### PR DESCRIPTION
## Description

Follow-up audit to #699. That PR auto-bootstrapped `MemoryStore` and
`directEnqueue` but left other raw `connect()` call sites reachable
from CLI commands that a user can hit against a fresh database before
running `codemem db init`.

Audited all nine runtime raw `connect()` call sites. Three needed
fixes (added `ensureSchemaBootstrapped(db)` after `connect()`):

- `exportMemories` — `codemem export-memories` on a fresh DB
- `importMemories` — `codemem import-memories` into a fresh install
- `withDb` helper in `maintenance.ts` — single fix covers `db vacuum`,
  `db raw-events-status`, `db raw-events-retry`, `db raw-events-gate`,
  `memory roles`, `memory relink-report`, `memory relink-apply`

Six sites verified safe without changes:
`SyncRetentionRunner` / `VectorModelMigrationRunner` /
`DedupKeyBackfillRunner` (only instantiated from `codemem serve`,
which pre-inits), `coordinator-actions.ts` (already calls
`initDatabase` inline), `extraction-eval` + `extraction-replay`
(dev eval surfaces on pre-populated batches), and `initDatabase`
itself (canonical bootstrap).

## Type of Change

- [x] 🐛 Bug fix

## Testing

- [x] `pnpm run tsc` — clean
- [x] `pnpm exec biome check packages` — clean
- [x] `pnpm run test` — 1194 passed

## Checklist

- [x] Closes codemem-ue7v
- [x] Follow-up to #699
- [x] No behavior change on the happy path (already-initialized DBs)