### PR TITLE
fix(core): bootstrap vector schema on fresh DBs

### DIFF
--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -94,10 +94,14 @@ CREATE VIRTUAL TABLE IF NOT EXISTS memory_vectors USING vec0(
  */
 export function ensureVectorSchema(db: Database): void {
 	if (isEmbeddingDisabled()) return;
-	if (!isSqliteVecLoaded(db)) {
-		loadSqliteVec(db);
+	try {
+		if (!isSqliteVecLoaded(db)) {
+			loadSqliteVec(db);
+		}
+		db.exec(MEMORY_VECTORS_DDL);
+	} catch {
+		return;
 	}
-	db.exec(MEMORY_VECTORS_DDL);
 }
 
 function isSqliteVecLoaded(db: Database): boolean {

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { connect } from "./db.js";
+import { connect, tableExists } from "./db.js";
 import { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
 import { MemoryStore } from "./store.js";
 import { setSyncDaemonPhase } from "./sync-daemon.js";
@@ -1062,6 +1062,7 @@ describe("MemoryStore constructor auto-bootstrap", () => {
 			const stats = store.stats();
 			expect(stats.database.memory_items).toBe(0);
 			expect(stats.database.sessions).toBe(0);
+			expect(tableExists(store.db, "memory_vectors")).toBe(true);
 
 			// Real query-path coverage: exercising `recent` / `recentByKinds`
 			// hits memory_items + FTS/provenance joins that assertSchemaReady

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -3,8 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as dbModule from "./db.js";
 import * as embeddings from "./embeddings.js";
 import { startMaintenanceJob } from "./maintenance-jobs.js";
+import { ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import {
@@ -155,6 +157,20 @@ describe("vectors", () => {
 		expect(results).toEqual([]);
 		expect(embeddings.embedTexts).not.toHaveBeenCalled();
 	});
+
+	it("returns empty results on a freshly bootstrapped database with no vectors", async () => {
+		const freshDb = new Database(":memory:");
+		try {
+			initTestSchema(freshDb);
+
+			const results = await semanticSearch(freshDb, "query text");
+
+			expect(results).toEqual([]);
+			expect(embeddings.embedTexts).not.toHaveBeenCalled();
+		} finally {
+			freshDb.close();
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -242,6 +258,23 @@ describe("memory_vectors bootstrap on fresh databases", () => {
 			expect(resolveSemanticSearchModel(store.db, "test-model")).toBe("test-model");
 		} finally {
 			store.close();
+		}
+	});
+
+	it("bootstraps the core schema even when sqlite-vec cannot load", () => {
+		const scratch = new Database(":memory:");
+		const loadSpy = vi.spyOn(dbModule, "loadSqliteVec").mockImplementation(() => {
+			throw new Error("vec unavailable");
+		});
+
+		try {
+			expect(() => ensureSchemaBootstrapped(scratch)).not.toThrow();
+			expect(() => scratch.prepare("SELECT COUNT(*) AS c FROM memory_items").get()).not.toThrow();
+			expect(() => resolveSemanticSearchModel(scratch, "test-model")).not.toThrow();
+			expect(resolveSemanticSearchModel(scratch, "test-model")).toBeNull();
+		} finally {
+			loadSpy.mockRestore();
+			scratch.close();
 		}
 	});
 });

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Database } from "./db.js";
+import { tableExists } from "./db.js";
 import {
 	chunkText,
 	embedTexts,
@@ -28,11 +29,18 @@ type VectorModelCount = { model: string; rows: number };
 type MemoryTextRow = { id: number; title: string | null; body_text: string | null };
 
 function listVectorModelCounts(db: Database): VectorModelCount[] {
-	return db
-		.prepare(
-			"SELECT model, COUNT(*) AS rows FROM memory_vectors GROUP BY model ORDER BY rows DESC, model ASC",
-		)
-		.all() as VectorModelCount[];
+	if (!tableExists(db, "memory_vectors")) {
+		return [];
+	}
+	try {
+		return db
+			.prepare(
+				"SELECT model, COUNT(*) AS rows FROM memory_vectors GROUP BY model ORDER BY rows DESC, model ASC",
+			)
+			.all() as VectorModelCount[];
+	} catch {
+		return [];
+	}
 }
 
 export function resolveSemanticSearchModel(


### PR DESCRIPTION
## Description
Fix fresh-database bootstrap so sqlite-vec schema is created as part of normal schema bootstrap, and make semantic-search model resolution fail closed when the vector table is unavailable.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/vectors.test.ts packages/core/src/vector-migration.test.ts packages/core/src/store.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] TypeScript build passes (`pnpm exec tsc --build`)

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
