### PR TITLE
feat(core): persist session class on typed observer memories

### DIFF
--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -611,6 +611,64 @@ describe("ingest() integration", () => {
 		);
 	});
 
+	it("persists session class on typed observer memories", async () => {
+		const typedObserver = {
+			observe: async () => ({
+				raw: `<observation>
+					<type>decision</type>
+					<title>Keep session class on typed memories</title>
+					<narrative>Typed memories should carry the same session class as the source session.</narrative>
+					<files_read>
+						<file>src/session-policy.ts</file>
+					</files_read>
+				</observation>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const payload = buildPayload({
+			events: [
+				{
+					type: "user_prompt",
+					prompt_text: "investigate session classification persistence",
+					prompt_number: 1,
+					timestamp: new Date().toISOString(),
+				},
+				{
+					type: "assistant_message",
+					assistant_text: "Tracked the policy gap.",
+					timestamp: new Date().toISOString(),
+				},
+			],
+			sessionContext: {
+				source: "opencode",
+				streamId: "test-stream-typed-session-class",
+				promptCount: 2,
+				toolCount: 3,
+				durationMs: 240_000,
+				filesRead: ["/tmp/repo/src/session-policy.ts"],
+			},
+		});
+
+		await ingest(payload, store, { observer: typedObserver } as unknown as IngestOptions);
+
+		const memory = store.db
+			.prepare(
+				"SELECT kind, metadata_json FROM memory_items WHERE json_extract(metadata_json, '$.source') = 'observer' ORDER BY id DESC LIMIT 1",
+			)
+			.get() as { kind: string; metadata_json: string };
+		expect(memory.kind).toBe("decision");
+		expect(JSON.parse(memory.metadata_json).session_class).toBe("working");
+	});
+
 	it("keeps summary-only output for longer sessions", async () => {
 		const summaryOnlyObserver = {
 			observe: async () => ({

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -567,6 +567,7 @@ export async function ingest(
 					files_read: obs.filesRead,
 					files_modified: obs.filesModified,
 					prompt_number: promptNumber,
+					session_class: sessionClass,
 					source: "observer",
 					observer_tier: selectedTier,
 					observer_tier_reasons: selectedTierReasons,


### PR DESCRIPTION
## Description
Persist `session_class` onto typed observer memory metadata so session classification is reusable outside summary-only paths and can feed later retrieval/injection work.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/ingest-pipeline.test.ts packages/core/src/session-policy.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] TypeScript build passes (`pnpm exec tsc --build`)

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
