### PR TITLE
docs(plans): add scoped retrieval and sync vector designs

### DIFF
--- a/docs/plans/2026-04-11-scoped-memory-retrieval-design.md
+++ b/docs/plans/2026-04-11-scoped-memory-retrieval-design.md
@@ -1,0 +1,550 @@
+# Scoped Memory Retrieval Design
+
+**Status:** Draft
+**Date:** 2026-04-11
+**Related docs:**
+- `docs/plans/2026-04-07-memory-quality-model.md`
+- `docs/plans/2026-04-07-recap-policy.md`
+- `docs/plans/2026-03-12-adaptive-widening-personal-to-shared-retrieval.md`
+- `docs/plans/2026-03-01-memory-explain-contract.md`
+**Primary bead:** TBD
+
+## Purpose
+
+Define how codemem should represent and retrieve memories that operate at
+different scopes:
+
+- **project-scoped** memory tied to one repository or codebase
+- **personal-scoped** memory tied to a specific user's working preferences
+- **general-scoped** memory that captures a reusable lesson across projects
+
+The goal is not just to add a `scope` field. The goal is to make retrieval more
+reliable by ensuring the system can answer three different questions without
+mixing them together:
+
+1. what rules or facts apply to **this project**?
+2. how does **this user** usually prefer to work?
+3. what **generalizable lesson** is relevant here?
+
+## Problem
+
+Current memory retrieval largely assumes that durable memories live in one pool
+and can be ranked mostly by textual relevance plus a small set of heuristics.
+
+That breaks down once we want to preserve lessons such as:
+
+- project-specific release or workflow rules
+- user-specific working preferences
+- cross-project debugging or tooling lessons
+
+If these all live in one flat ranking pool, the system will eventually produce
+bad retrieval behavior such as:
+
+- a broad general lesson outranking a concrete project rule
+- a user preference being treated like a universal truth
+- noisy cross-project material polluting project-local injection
+- useful general lessons being under-ranked because they lack exact project terms
+
+In short:
+
+> scope-free memory storage leads to scope-confused retrieval
+
+## Core Principle
+
+Memory retrieval should be **scope-aware, applicability-aware, and precedence-aware**.
+
+That means:
+
+- memories should declare or infer **what scope they belong to**
+- retrieval should evaluate **when a memory applies**, not just whether it shares words
+- ranking should enforce **scope precedence** so local truth beats generic truth
+
+## Goals
+
+1. represent project, personal, and general memory explicitly
+2. retrieve candidates per scope rather than from one flat pool
+3. add lightweight applicability metadata so retrieval can reason about when a
+   memory matters
+4. preserve project-local rules as stronger than user preferences, and user
+   preferences as stronger than generic lessons
+5. support cross-project durable lessons without letting them dominate unrelated work
+6. create a design that can be implemented incrementally without reworking the
+   entire memory system at once
+
+## Non-goals
+
+This design does **not** try to:
+
+- solve memory authoring UX completely
+- build a full ontology or knowledge graph first
+- infer perfect applicability from raw text alone
+- make every memory manually annotated with detailed rules
+- replace existing search/rerank logic in one step
+
+## Scope Model
+
+### 1. Project scope
+
+Project-scoped memory is true because of this repository, architecture, or local
+workflow contract.
+
+Examples:
+
+- codemem uses Graphite stack workflow in this repo
+- codemem release procedure requires branch/PR/tag ordering
+- codemem recap policy demotes recap-like material in default injection
+- sync visibility semantics for this project
+
+#### Retrieval posture
+
+- highest default precedence when the active project matches
+- should dominate personal and general memories for local workflow or system behavior
+
+### 2. Personal scope
+
+Personal-scoped memory reflects a user's stable preferences across projects.
+
+Examples:
+
+- prefers terse PR bodies that still satisfy the template
+- prefers stacked PRs when tooling supports them
+- prefers direct execution over plan-only responses
+
+#### Retrieval posture
+
+- second precedence after project scope
+- should never override explicit project policy
+- useful when tailoring style, workflow, or defaults
+
+### 3. General scope
+
+General-scoped memory captures reusable lessons that apply across many projects.
+
+Examples:
+
+- optional extensions should fail closed during schema bootstrap
+- in stacked PR workflows, submit the full stack or descendants may remain stale
+- task-intent retrieval should not demote procedural memories
+
+#### Retrieval posture
+
+- lowest precedence of the three scopes
+- should contribute when topical or operational pattern matches exist
+- should not override specific project-local evidence when that exists
+
+## Scope Classification Rules
+
+### Project if
+
+- the memory depends on repo-local architecture, naming, or workflow
+- the memory references project-specific behavior that could be wrong elsewhere
+- the memory is effectively a local rule or contract
+
+### Personal if
+
+- the memory expresses a user preference rather than a repository requirement
+- it should follow the user across projects
+- another contributor in the same project could reasonably prefer differently
+
+### General if
+
+- the memory describes a reusable lesson, pitfall, or debugging heuristic
+- it remains useful when rewritten without project-specific baggage
+- it would still be valid in many unrelated repositories
+
+## Proposed Schema
+
+This schema should be treated as a logical design target, not necessarily the
+exact first database migration.
+
+```ts
+type MemoryScope = "project" | "personal" | "general";
+type MemoryShareability = "private" | "team" | "public-safe";
+
+interface ScopedMemoryMetadata {
+  scope: MemoryScope;
+  owner?: string;
+  project?: string;
+
+  applicability?: {
+    activities?: string[];
+    intents?: string[];
+    tools?: string[];
+    domains?: string[];
+    repo_patterns?: string[];
+    excludes?: string[];
+  };
+
+  precedence?: number;
+  confidence?: number;
+  shareability?: MemoryShareability;
+
+  source?: {
+    type: "observed" | "user-stated" | "derived" | "imported";
+    reference?: string;
+  };
+}
+```
+
+### Minimal first slice
+
+If we want the smallest useful implementation, we can start with:
+
+- `scope`
+- `owner`
+- `project`
+- `applicability.activities`
+- `applicability.intents`
+- `applicability.tools`
+- `applicability.domains`
+- `precedence`
+- `confidence`
+- `shareability`
+
+## Applicability Metadata
+
+Scope alone is not enough. A general memory can still be wrong for the current
+turn, and a project memory can still be irrelevant to the immediate request.
+
+Applicability metadata should remain lightweight and operational rather than
+trying to encode deep world knowledge.
+
+### Recommended applicability dimensions
+
+#### Activities
+
+What the agent is doing right now.
+
+Examples:
+
+- `implementation`
+- `debugging`
+- `review`
+- `release`
+- `docs`
+- `stacked-pr`
+
+#### Intents
+
+What kind of question or request is being answered.
+
+Examples:
+
+- `what-next`
+- `fix-failure`
+- `implement`
+- `plan`
+- `explain`
+- `recap`
+
+#### Tools
+
+Concrete tooling or platforms mentioned or inferred.
+
+Examples:
+
+- `git`
+- `graphite`
+- `sqlite`
+- `cloudflare`
+- `vitest`
+
+#### Domains
+
+Topical domain or subsystem categories.
+
+Examples:
+
+- `retrieval`
+- `sync`
+- `ui`
+- `schema`
+- `release`
+- `memory-quality`
+
+#### Repository patterns
+
+Useful structural contexts.
+
+Examples:
+
+- `monorepo`
+- `stacked-pr`
+- `migration`
+- `optional-extension`
+
+#### Excludes
+
+Simple negative constraints for obvious non-applicability.
+
+Examples:
+
+- `single-branch-workflow`
+- `docs-only`
+- `explicit-recap`
+- `unrelated-project`
+
+## How Applicability Should Be Produced
+
+We should not require fully manual metadata authoring for every memory.
+
+Use three sources of truth:
+
+### 1. Explicit metadata
+
+Used for high-value curated memories or imported policy docs.
+
+Good for:
+
+- project rules
+- user preferences
+- intentionally authored general lessons
+
+### 2. Derived metadata
+
+Inferred from memory text, kind, surrounding context, or source event.
+
+Good for:
+
+- tool mentions
+- likely domain labels
+- likely activity or intent class
+- whether the memory behaves like a rule, preference, or lesson
+
+### 3. Observed usefulness signals
+
+Learned from retrieval behavior over time.
+
+Good for:
+
+- which memories repeatedly help in similar contexts
+- which memories get retrieved but ignored
+- which memories correlate with successful outcomes or fewer retries
+
+## Retrieval Algorithm
+
+The retrieval design should not query one flat memory pool.
+
+### Step 1: infer current context
+
+Build a lightweight context object for the current turn.
+
+Example:
+
+```json
+{
+  "project": "codemem",
+  "user": "adam",
+  "activity": "implementation",
+  "intent": "what-next",
+  "tools": ["git", "graphite"],
+  "domains": ["retrieval", "memory-quality"]
+}
+```
+
+### Step 2: retrieve candidates by scope bucket
+
+Retrieve separately from:
+
+- matching project memories
+- matching personal memories for the active user
+- matching general memories
+
+This can still use hybrid search, but candidates should remain tagged by scope.
+
+### Step 3: score applicability within each bucket
+
+Boost for:
+
+- matching activity
+- matching intent
+- matching tools
+- matching domains
+- matching repo patterns
+
+Demote or suppress for:
+
+- explicit excludes
+- mismatched project/user scope
+- contradictory context
+
+### Step 4: merge with scope precedence
+
+Recommended default priority:
+
+- project: `300`
+- personal: `200`
+- general: `100`
+
+Then compute something like:
+
+```ts
+finalScore =
+  retrievalScore +
+  applicabilityScore +
+  scopePriority +
+  confidenceWeight -
+  contradictionPenalty;
+```
+
+### Step 5: dedupe and diversity cap
+
+Do not return several nearly identical memories that all encode the same lesson.
+
+Prefer:
+
+- one project rule
+- one personal preference
+- one or two general lessons
+
+instead of many adjacent copies of the same idea.
+
+## Precedence Rules
+
+### Rule 1 — project beats personal
+
+A project-scoped workflow rule must beat a user preference when they conflict.
+
+### Rule 2 — personal beats general
+
+A user preference should beat a generic lesson when choosing style or defaults.
+
+### Rule 3 — general only wins when specific scopes do not apply
+
+General lessons should fill gaps, not overwrite local truth.
+
+### Rule 4 — explicit applicability beats weak textual similarity
+
+A memory with a clear activity/intent/tool match should outrank a fuzzier lexical
+match with the wrong scope.
+
+## Reliability Requirements
+
+The system should be designed against several predictable failure modes.
+
+### Failure mode 1 — generic pollution
+
+A broad general lesson matches many turns and contaminates project-local retrieval.
+
+#### Mitigations
+
+- scope-bucket retrieval
+- strong precedence
+- excludes
+- result diversity caps
+
+### Failure mode 2 — useful general memory never appears
+
+A transferable lesson is phrased differently and misses exact keyword matching.
+
+#### Mitigations
+
+- semantic retrieval within the general bucket
+- derived tool/domain tags
+- reinforcement from observed usefulness
+
+### Failure mode 3 — personal preference looks like universal policy
+
+A user habit is shown without its scope label and treated as system truth.
+
+#### Mitigations
+
+- preserve scope in metadata and explain output
+- rank personal below project
+- never strip scope during explanation/debugging
+
+### Failure mode 4 — stale applicability metadata
+
+Memories continue to rank as if they still apply even after workflows drift.
+
+#### Mitigations
+
+- track usefulness over time
+- allow superseding or replacement links
+- decay low-confidence inferred applicability
+
+## Relationship to Existing Retrieval Work
+
+This design should extend, not replace, recent retrieval policy work.
+
+### Memory quality model
+
+The memory quality model already distinguishes durable, recap, ephemeral, and
+general/cross-project value classes. Scope design complements that model by
+adding **where a memory should apply**, not just **how durable it is**.
+
+### Recap policy
+
+Recap policy already uses explicit retrieval modes such as default injection vs
+explicit recap. Scope-aware retrieval should follow the same pattern: a relevant
+scope and a relevant mode should both matter.
+
+### Adaptive widening
+
+Existing personal-to-shared widening logic shows that retrieval already benefits
+from searching in ordered tiers rather than a single undifferentiated pool. This
+proposal generalizes that idea to project/personal/general memory scopes.
+
+## First Implementation Slices
+
+### Slice 1 — explicit scope metadata and bucketed retrieval
+
+Add:
+
+- scope field
+- owner/project fields where relevant
+- fixed precedence between project, personal, general
+
+Do not solve full applicability inference yet.
+
+### Slice 2 — lightweight applicability tags
+
+Add small tag families:
+
+- activities
+- intents
+- tools
+- domains
+
+Use direct matching and simple boosts.
+
+### Slice 3 — usefulness reinforcement
+
+Track:
+
+- retrieval frequency in matching contexts
+- whether the memory was surfaced into final context
+- whether it was later reinforced or ignored
+
+### Slice 4 — memory explain/debug support
+
+Extend explain/debug output to show:
+
+- scope bucket
+- applicability matches
+- precedence contribution
+- suppression reasons
+
+## Open Questions
+
+1. should personal-scoped memories live in the same store with metadata labels,
+   or in a separate user-profile layer?
+2. how much explicit authoring do we want before we rely on derived tags?
+3. should general memories be retrieved by default, or only when project/personal
+   buckets are weak?
+4. how should we represent superseded general lessons without deleting useful history?
+5. do we want separate write-time policy for promoting a memory from project to
+   general scope after repeated reuse?
+
+## Recommendation
+
+Start small:
+
+1. add **scope**
+2. retrieve by **scope buckets**
+3. merge with **fixed precedence**
+4. add a small set of **applicability tags**
+5. instrument **memory explain** before adding heavier inference
+
+That gives us a reliable foundation for scoped retrieval without prematurely
+building a full graph or policy engine.

--- a/docs/plans/2026-04-11-sync-vector-handling-design.md
+++ b/docs/plans/2026-04-11-sync-vector-handling-design.md
@@ -1,0 +1,404 @@
+# Sync Vector Handling Design
+
+**Status:** Draft
+**Date:** 2026-04-11
+**Related docs:**
+- `docs/architecture.md`
+- `docs/plans/2026-03-15-embedding-packaging.md`
+- `docs/plans/2026-03-15-db-coexistence-contract.md`
+- `docs/plans/2026-04-01-fast-peer-bootstrap-design.md`
+**Primary bead:** TBD
+
+## Purpose
+
+Define how codemem should maintain semantic-search coverage for memories received
+through sync.
+
+Today, sync replicates `memory_items` payloads but not `memory_vectors`, and the
+receiver-side replication apply path does not automatically generate vectors for
+inbound memories. That leaves a gap where synced memories exist locally but are
+not available to semantic search unless vectors are generated some other way.
+
+This document proposes the product and implementation direction for closing that
+gap.
+
+## Problem
+
+The current sync story is asymmetrical:
+
+- **durable memory data** is transferred via replication ops and bootstrap snapshots
+- **vector index data** is local and derived
+
+That is not inherently wrong. The issue is that the receiver currently does not
+reliably rebuild the derived index on arrival.
+
+As a result:
+
+- synced memories may be searchable by keyword/FTS but not by semantic search
+- bootstrap can leave a large peer with little or no vector coverage locally
+- users would have to rely on manual backfill (`codemem embed`) to repair coverage
+
+That is not an acceptable default product story.
+
+## Current State
+
+### What sync transfers
+
+Replication ops and snapshot/bootstrap carry full `memory_items` payloads and
+related synced entity data.
+
+Evidence:
+
+- `packages/core/src/sync-replication.test.ts` verifies that upsert ops carry the
+  full memory payload and round-trip all replicated columns
+- `packages/core/src/sync-replication.ts` applies inbound memory upserts by
+  inserting or updating `memory_items`
+
+### What sync does not transfer
+
+Sync does not currently replicate `memory_vectors` rows as part of memory-item
+ replication payloads.
+
+### What the receiver currently does not do
+
+`applyReplicationOps()` does not call `storeVectors()`, queue vector writes, or
+schedule a targeted vector backfill for newly inserted or updated inbound
+memories.
+
+### Existing vector posture
+
+The existing architecture already treats vectors as derived/local index data:
+
+- `docs/architecture.md` describes `memory_vectors` as a local sqlite-vec table
+  written on create or backfill
+- `docs/plans/2026-03-15-db-coexistence-contract.md` explicitly says vec/embedding
+  sync is application-level and that vectors can be regenerated
+- `docs/plans/2026-03-15-embedding-packaging.md` notes that different runtimes may
+  produce slightly different vectors, but each runtime remains internally consistent
+
+This means the missing piece is not conceptual permission to regenerate. The
+missing piece is doing it automatically on receive.
+
+## Product Requirement
+
+Users should not need to run periodic manual embedding backfills just to make
+synced memories semantically searchable.
+
+Operationally, we need one of two guarantees:
+
+1. sync transfers vectors along with memory data, or
+2. the receiver automatically generates vectors for inbound synced memories
+
+## Options
+
+### Option A — Transfer vectors through sync
+
+Replicate `memory_vectors` rows as part of snapshot/bootstrap and incremental op
+application.
+
+#### Pros
+
+- receiver gets semantic-search coverage immediately
+- no re-embedding cost on arrival
+- useful for large bootstrap where embedding generation would take time
+
+#### Cons
+
+- vectors are derived data, so replication payloads get heavier
+- transfers embed model/version assumptions into sync payload semantics
+- mixed-runtime/model compatibility becomes more complex
+- stale vector cleanup and migration semantics now need to propagate over sync
+- vectors may need to be re-generated locally anyway if model policy changes
+
+#### Assessment
+
+Possible, but it makes the sync protocol carry more derived-index concerns than
+it does today.
+
+### Option B — Generate vectors automatically on receive
+
+Keep sync replication focused on durable memory rows, but trigger receiver-side
+vector generation whenever inbound memories are inserted or materially updated.
+
+#### Pros
+
+- keeps replication payloads smaller and simpler
+- preserves the current conceptual model that vectors are local derived index data
+- avoids cross-peer transport of model-specific vector blobs
+- works even if sender and receiver embedding runtimes differ slightly
+- stale vectors remain a local maintenance concern, which already fits current design
+
+#### Cons
+
+- semantic coverage is not instantaneous if model download or embedding work is slow
+- bootstrap may need a background reindex pass for large imports
+- receivers without embedding capability will still degrade to keyword-only search
+
+#### Assessment
+
+This matches the current architecture better and is the recommended default.
+
+## Recommendation
+
+**Choose Option B: generate vectors automatically on receive.**
+
+Rationale:
+
+1. vectors are already treated as derived/local index data
+2. replication today is designed around durable memory payloads, not search indexes
+3. model differences across runtimes already exist and are acceptable when each
+   node embeds consistently with itself
+4. local regeneration is simpler than teaching sync how to replicate and manage
+   vector-table lifecycle
+
+In short:
+
+> sync should transfer durable memory state; each receiver should build the local
+> semantic index automatically.
+
+This does mean that **fresh-peer bootstrap semantic readiness may lag behind data
+readiness**. That tradeoff is acceptable if the system makes the lag automatic,
+resumable, and visible rather than requiring operator intervention.
+
+## Design
+
+### Rule 1 — Inbound memory upserts should queue vector work
+
+When `applyReplicationOps()` inserts or updates a `memory_item`, the receiver
+should determine whether vector work is needed for that memory.
+
+At minimum:
+
+- new memory inserted by sync → queue vector generation
+- existing memory updated with changed title/body → queue vector regeneration
+- delete/tombstone or inactive memory → remove or invalidate existing vector rows
+
+### Rule 2 — Vector generation should not block sync correctness
+
+Inbound replication should continue to treat vector generation as non-fatal.
+
+If embeddings are unavailable because:
+
+- sqlite-vec cannot load
+- the embedding model is not downloaded yet
+- the embedding runtime throws
+
+then sync should still apply the memory row successfully and record that vector
+coverage is pending or skipped.
+
+### Rule 3 — Large bootstrap should batch receiver-side reindexing
+
+For large bootstrap/snapshot applies, vector generation should not happen as a
+fully synchronous per-memory cost inside the hottest apply loop.
+
+Instead:
+
+- collect affected memory IDs during apply
+- run a batched receiver-side vector pass after the transaction commits
+- allow this work to continue in the background if necessary
+
+Bootstrap should therefore be understood as two-stage readiness:
+
+1. **data-ready** — memory rows are present and sync state is correct
+2. **semantic-ready** — local vector coverage has caught up
+
+The design goal is not to hide this distinction. The design goal is to make the
+second stage automatic and reliable.
+
+### Rule 4 — Re-embedding should be content-aware
+
+Only regenerate vectors when the embeddable content changed.
+
+Likely triggers:
+
+- `title` changed
+- `body_text` changed
+- current vector model missing for the memory
+
+Non-triggers:
+
+- provenance-only metadata updates
+- visibility/trust changes without content changes
+
+### Rule 5 — Receiver should tolerate zero-vector mode
+
+If a node cannot embed at all, synced memories should still work through FTS and
+other retrieval paths. The system should degrade gracefully rather than treating
+missing vectors as sync failure.
+
+## Proposed Implementation Shape
+
+### A. Collect vector work during apply
+
+Extend `applyReplicationOps()` to track a small side list such as:
+
+```ts
+interface ReplicationVectorWork {
+  upsertIds: number[];
+  deleteIds: number[];
+}
+```
+
+That list should be built while processing inbound memory-item ops.
+
+### B. Return vector work from apply path
+
+Instead of hiding all side effects inside `ApplyResult`, return or expose enough
+information for the caller to enqueue follow-up vector maintenance.
+
+Example direction:
+
+```ts
+interface ApplyResult {
+  applied: number;
+  skipped: number;
+  conflicts: number;
+  errors: string[];
+  vector_work?: {
+    upsert_memory_ids: number[];
+    delete_memory_ids: number[];
+  };
+}
+```
+
+### C. Add a receiver-side vector maintenance helper
+
+Introduce a small helper that:
+
+- deletes stale vector rows for deleted/inactive memories
+- runs `backfillVectors()` or targeted `storeVectors()` for changed inbound rows
+- handles missing embeddings non-fatally
+
+This should likely live near `vectors.ts` or `sync-replication.ts`, but remain a
+separate focused function rather than bloating `applyReplicationOps()`.
+
+### D. Use two execution modes
+
+#### Incremental sync
+
+For normal inbound op batches:
+
+- collect changed memory IDs
+- after transaction commit, run a small targeted vector-maintenance pass
+
+#### Bootstrap / snapshot apply
+
+For large bootstrap applies:
+
+- collect changed memory IDs across the snapshot
+- perform batched vector backfill after apply
+- report progress through existing maintenance job or sync diagnostics surfaces if needed
+
+### E. Persist pending vector work across restarts
+
+Receiver-side vector generation for synced memories should not live only in
+process memory.
+
+We should maintain a durable pending-work mechanism so that:
+
+- a large bootstrap can resume after restart
+- temporary embedding/runtime failures do not lose the backlog
+- diagnostics can report actual semantic-index lag
+
+This can take the form of:
+
+- a dedicated queue table, or
+- a maintenance job state plus resumable memory-id cursor ranges
+
+Exact shape is an implementation detail, but durable recovery is part of the
+reliability requirement.
+
+## Why not do vector writes inline in the transaction?
+
+Because that couples sync correctness to the slowest and least reliable part of
+the embedding pipeline.
+
+Inline writes would create bad failure modes:
+
+- model download delays block sync apply
+- embedding failures cause partial or slow replication behavior
+- large bootstrap becomes much more expensive in the critical path
+
+The better separation is:
+
+- **transactional sync apply** for durable memory state
+- **post-commit best-effort vector maintenance** for local semantic index state
+
+## Deletion and stale-vector policy
+
+Receiver-side vector maintenance must handle deletions as well as inserts.
+
+When an inbound delete/tombstone wins:
+
+- keep the tombstone semantics for `memory_items`
+- remove vector rows for that memory locally if present
+
+When an inbound upsert replaces content:
+
+- old model/content-hash rows should not remain the active effective index for
+  that memory under the current target model
+
+This should align with the existing vector migration and stale-row cleanup logic.
+
+## User Experience
+
+### Desired behavior
+
+- a newly synced memory becomes keyword-searchable immediately
+- semantic search coverage appears automatically shortly after receipt
+- large peer bootstrap may take time to finish embedding, but does not require
+  manual operator intervention
+- if embeddings are unavailable, codemem still works and makes the degraded state visible
+
+For bootstrap specifically, the user experience should be:
+
+- sync completes without requiring embeddings to succeed inline
+- the node is usable immediately for exact/FTS retrieval
+- semantic indexing continues automatically until coverage catches up
+- restart does not discard indexing progress or pending work
+
+### Diagnostics
+
+We should consider surfacing:
+
+- inbound memories pending embedding after sync
+- receiver-side vector maintenance failures
+- whether the local node is running without embeddings
+
+This can likely piggyback on existing maintenance job or sync diagnostics UI.
+
+## Validation Requirements
+
+At minimum, implementation should add tests for:
+
+1. inbound sync upsert inserts memory row and schedules or performs vector work
+2. inbound sync update with changed content regenerates vectors
+3. inbound metadata-only update does not re-embed unnecessarily
+4. inbound delete removes or invalidates vector rows
+5. embedding failure during receive does not fail `applyReplicationOps()`
+6. bootstrap path eventually yields local vector coverage for received memories
+
+## Open Questions
+
+1. should receiver-side vector work be tracked as a dedicated maintenance job, or
+   remain an internal best-effort queue?
+2. for very large bootstrap, should we chunk vector backfill by snapshot page,
+   by fixed memory count, or by time budget?
+3. should sync diagnostics report semantic-index lag explicitly?
+4. do we want a small persisted queue of pending vector work so restarts do not
+   lose the backlog?
+5. should sender-side vector transfer ever be added as an optimization later,
+   even if receiver-side generation is the default contract?
+
+## Recommendation Summary
+
+The immediate contract should be:
+
+- sync transfers durable memory rows
+- receivers automatically build local vectors for inbound memories
+- vector generation is post-commit and non-fatal
+- bootstrap batches vector work instead of requiring manual backfill
+- pending vector work survives restart and reports progress/lag
+
+That gives codemem a usable semantic-search story for sync without bloating the
+replication protocol around derived index data.


### PR DESCRIPTION
## Description
Add two planning docs to clarify the next retrieval and sync directions before more implementation work lands: a scoped memory retrieval design and a reliability-first sync vector handling design.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
