### PR TITLE
feat(sync): generate vectors after inbound replication apply

### DIFF
--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -1,7 +1,9 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as syncAuth from "./sync-auth.js";
 import * as syncBootstrap from "./sync-bootstrap.js";
 import * as syncHttpClient from "./sync-http-client.js";
+import * as syncIdentity from "./sync-identity.js";
 import {
 	consecutiveConnectivityFailures,
 	cursorAdvances,
@@ -13,6 +15,7 @@ import {
 } from "./sync-pass.js";
 import * as syncReplication from "./sync-replication.js";
 import { initTestSchema } from "./test-utils.js";
+import * as vectors from "./vectors.js";
 
 // ---------------------------------------------------------------------------
 // Schema helper — adds sync tables not in base test schema
@@ -20,7 +23,7 @@ import { initTestSchema } from "./test-utils.js";
 
 function addSyncTables(db: InstanceType<typeof Database>): void {
 	db.exec(`
-		CREATE TABLE IF NOT EXISTS sync_peers (
+			CREATE TABLE IF NOT EXISTS sync_peers (
 			peer_device_id TEXT PRIMARY KEY,
 			name TEXT,
 			pinned_fingerprint TEXT,
@@ -47,19 +50,26 @@ function addSyncTables(db: InstanceType<typeof Database>): void {
 			error TEXT
 		);
 
-		CREATE TABLE IF NOT EXISTS replication_ops (
-			op_id TEXT PRIMARY KEY,
-			entity_type TEXT NOT NULL,
+			CREATE TABLE IF NOT EXISTS replication_ops (
+				op_id TEXT PRIMARY KEY,
+				entity_type TEXT NOT NULL,
 			entity_id TEXT NOT NULL,
 			op_type TEXT NOT NULL,
 			payload_json TEXT,
 			clock_rev INTEGER NOT NULL,
 			clock_updated_at TEXT NOT NULL,
 			clock_device_id TEXT NOT NULL,
-			device_id TEXT NOT NULL,
-			created_at TEXT NOT NULL
-		);
-	`);
+				device_id TEXT NOT NULL,
+				created_at TEXT NOT NULL
+			);
+
+			CREATE TABLE IF NOT EXISTS replication_cursors (
+				peer_device_id TEXT PRIMARY KEY,
+				last_applied_cursor TEXT,
+				last_acked_cursor TEXT,
+				updated_at TEXT
+			);
+		`);
 }
 
 // ---------------------------------------------------------------------------
@@ -106,6 +116,7 @@ describe("syncOnce", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		db.close();
 	});
 
@@ -137,6 +148,87 @@ describe("syncOnce", () => {
 		expect(result.ok).toBe(false);
 		// Either "device identity unavailable" or "no dialable peer addresses"
 		expect(result.error).toBeTruthy();
+	});
+
+	it("runs best-effort vector maintenance after applying incremental inbound ops", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "abc123", new Date().toISOString());
+		db.prepare(
+			"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+		).run("peer-1", "2025-12-31T00:00:00Z|local-op-0", null, new Date().toISOString());
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		const maintainSpy = vi
+			.spyOn(vectors, "maintainVectorsForReplicationApply")
+			.mockResolvedValue({ deleted: 0, inserted: 0, errors: ["embedding unavailable"] });
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "abc123",
+					protocol_version: "2",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-1",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-1",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [
+						{
+							op_id: "remote-op-1",
+							entity_type: "memory_item",
+							entity_id: "key:sync-pass-1",
+							op_type: "upsert",
+							payload_json: JSON.stringify({
+								kind: "discovery",
+								title: "Remote title",
+								body_text: "Remote body",
+								active: 1,
+								created_at: "2026-01-01T00:00:00Z",
+								updated_at: "2026-01-01T00:00:00Z",
+							}),
+							clock_rev: 1,
+							clock_updated_at: "2026-01-01T00:00:00Z",
+							clock_device_id: "dev-remote",
+							device_id: "dev-remote",
+							created_at: "2026-01-01T00:00:00Z",
+						},
+					],
+					next_cursor: "2026-01-01T00:00:00Z|remote-op-1",
+					skipped: 0,
+				},
+			]);
+
+		const result = await syncOnce(db, "peer-1", ["http://127.0.0.1:9090"]);
+
+		if (!result.ok) {
+			throw new Error(`syncOnce failed: ${result.error ?? "unknown error"}`);
+		}
+		expect(result.ok).toBe(true);
+		expect(result.opsIn).toBe(1);
+		expect(maintainSpy).toHaveBeenCalledOnce();
+		expect(maintainSpy).toHaveBeenCalledWith(db, {
+			upsertMemoryIds: [expect.any(Number)],
+			deleteMemoryIds: [],
+		});
+		expect(syncReplication.getReplicationCursor(db, "peer-1")[0]).toBe(
+			"2026-01-01T00:00:00Z|remote-op-1",
+		);
 	});
 });
 

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -27,6 +27,7 @@ import {
 	setReplicationCursor,
 } from "./sync-replication.js";
 import type { ReplicationOp, SyncResetRequired } from "./types.js";
+import { maintainVectorsForReplicationApply } from "./vectors.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -620,6 +621,7 @@ export async function syncOnce(
 				setReplicationCursor(db, peerDeviceId, { lastApplied: inboundCursorCandidate });
 				lastApplied = inboundCursorCandidate;
 			}
+			await maintainVectorsForReplicationApply(db, applied.vectorWork);
 
 			// -- 5. Push local ops to peer --
 			const [outboundWindow, outboundCursor] = loadLocalOpsSince(db, lastAcked, deviceId, limit);

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1589,6 +1589,8 @@ describe("applyReplicationOps", () => {
 		expect(mem).toBeDefined();
 		expect(mem.title).toBe("Remote memory");
 		expect(mem.rev).toBe(1);
+		expect(result.vectorWork.upsertMemoryIds).toEqual([Number(mem.id)]);
+		expect(result.vectorWork.deleteMemoryIds).toEqual([]);
 	});
 
 	it("updates existing memory when op clock is newer", () => {
@@ -1629,6 +1631,7 @@ describe("applyReplicationOps", () => {
 			.get("key:test-1") as Record<string, unknown>;
 		expect(mem.title).toBe("Updated title");
 		expect(mem.rev).toBe(2);
+		expect(result.vectorWork.upsertMemoryIds).toEqual([Number(mem.id)]);
 	});
 
 	it("counts conflict when existing memory has newer clock", () => {
@@ -1682,6 +1685,15 @@ describe("applyReplicationOps", () => {
 			.get("key:del-1") as { active: number; deleted_at: string | null };
 		expect(mem.active).toBe(0);
 		expect(mem.deleted_at).not.toBeNull();
+		const memoryId = Number(
+			(
+				db.prepare("SELECT id FROM memory_items WHERE import_key = ?").get("key:del-1") as {
+					id: number;
+				}
+			).id,
+		);
+		expect(result.vectorWork.upsertMemoryIds).toEqual([]);
+		expect(result.vectorWork.deleteMemoryIds).toEqual([memoryId]);
 	});
 
 	it("records applied ops in replication_ops table", () => {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -1437,6 +1437,12 @@ export interface ApplyResult {
 	skipped: number;
 	conflicts: number;
 	errors: string[];
+	vectorWork: ReplicationVectorWork;
+}
+
+export interface ReplicationVectorWork {
+	upsertMemoryIds: number[];
+	deleteMemoryIds: number[];
 }
 
 const LEGACY_IMPORT_KEY_OLD_RE = /^legacy:memory_item:(.+)$/;
@@ -1725,7 +1731,25 @@ export function applyReplicationOps(
 	localDeviceId: string,
 ): ApplyResult {
 	const d = drizzle(db, { schema });
-	const result: ApplyResult = { applied: 0, skipped: 0, conflicts: 0, errors: [] };
+	const result: ApplyResult = {
+		applied: 0,
+		skipped: 0,
+		conflicts: 0,
+		errors: [],
+		vectorWork: { upsertMemoryIds: [], deleteMemoryIds: [] },
+	};
+	const upsertMemoryIds = new Set<number>();
+	const deleteMemoryIds = new Set<number>();
+	const queueVectorUpsert = (memoryId: number): void => {
+		if (!Number.isInteger(memoryId) || memoryId <= 0) return;
+		deleteMemoryIds.delete(memoryId);
+		upsertMemoryIds.add(memoryId);
+	};
+	const queueVectorDelete = (memoryId: number): void => {
+		if (!Number.isInteger(memoryId) || memoryId <= 0) return;
+		upsertMemoryIds.delete(memoryId);
+		deleteMemoryIds.add(memoryId);
+	};
 
 	const applyAll = db.transaction(() => {
 		for (const op of ops) {
@@ -1780,6 +1804,9 @@ export function applyReplicationOps(
 						const payload = parseMemoryPayload(op, result.errors);
 						if (!payload) continue;
 						const metaObj = mergePayloadMetadata(payload.metadata_json, op.clock_device_id);
+						const shouldDeleteVectors =
+							payload.deleted_at != null ||
+							(payload.active != null && Number(payload.active) === 0);
 
 						d.update(schema.memoryItems)
 							.set({
@@ -1812,6 +1839,8 @@ export function applyReplicationOps(
 							})
 							.where(eq(schema.memoryItems.import_key, importKey))
 							.run();
+						if (shouldDeleteVectors) queueVectorDelete(Number(memRow.id));
+						else queueVectorUpsert(Number(memRow.id));
 					} else {
 						// Insert new memory item — skip if malformed
 						const payload = parseMemoryPayload(op, result.errors);
@@ -1827,8 +1856,8 @@ export function applyReplicationOps(
 							replicatedProject,
 						);
 						const metaObj = mergePayloadMetadata(payload.metadata_json, op.clock_device_id);
-
-						d.insert(schema.memoryItems)
+						const insertedRows = d
+							.insert(schema.memoryItems)
 							.values({
 								session_id: sessionId,
 								kind: payload.kind ?? "discovery",
@@ -1860,7 +1889,14 @@ export function applyReplicationOps(
 								user_prompt_id: payload.user_prompt_id,
 								prompt_number: payload.prompt_number,
 							})
-							.run();
+							.returning({ id: schema.memoryItems.id })
+							.all();
+						const insertedId = Number(insertedRows[0]?.id ?? 0);
+						if (payload.deleted_at != null || Number(payload.active ?? 1) === 0) {
+							queueVectorDelete(insertedId);
+						} else {
+							queueVectorUpsert(insertedId);
+						}
 					}
 				} else if (op.op_type === "delete") {
 					const importKey = op.entity_id;
@@ -1899,6 +1935,7 @@ export function applyReplicationOps(
 							})
 							.where(eq(schema.memoryItems.id, existingForDelete.id))
 							.run();
+						queueVectorDelete(Number(existingForDelete.id));
 					}
 					// If import_key not found, record the op as a tombstone for future resolution
 				} else {
@@ -1917,6 +1954,10 @@ export function applyReplicationOps(
 	});
 
 	applyAll();
+	result.vectorWork = {
+		upsertMemoryIds: [...upsertMemoryIds],
+		deleteMemoryIds: [...deleteMemoryIds],
+	};
 	return result;
 }
 

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -11,6 +11,7 @@ import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import {
 	backfillVectors,
+	maintainVectorsForReplicationApply,
 	resolveSemanticSearchModel,
 	semanticSearch,
 	storeVectors,
@@ -104,6 +105,95 @@ describe("vectors", () => {
 			chunk_index: 0,
 			model: "test-model",
 		});
+	});
+
+	it("runs best-effort replication vector maintenance without throwing on embedding failures", async () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'feature', 'Sync title', 'Sync body', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, now, now);
+		const memoryId = Number(info.lastInsertRowid);
+
+		vi.mocked(embeddings.embedTexts).mockRejectedValue(new Error("embedding unavailable"));
+
+		const result = await maintainVectorsForReplicationApply(db, {
+			upsertMemoryIds: [memoryId],
+			deleteMemoryIds: [],
+		});
+
+		expect(result.inserted).toBe(0);
+		expect(result.errors).toEqual(["backfill vectors failed: embedding unavailable"]);
+		expect(db.prepare("SELECT COUNT(*) AS c FROM memory_vectors").get()).toMatchObject({ c: 0 });
+	});
+
+	it("deletes vector rows for replicated tombstones", async () => {
+		const vector = new Float32Array(384);
+		db.exec(`
+			INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model)
+			VALUES (
+				vec_f32('${JSON.stringify(Array.from(vector))}'),
+				321,
+				0,
+				'delete-hash',
+				'test-model'
+			)
+		`);
+
+		const result = await maintainVectorsForReplicationApply(db, {
+			upsertMemoryIds: [],
+			deleteMemoryIds: [321],
+		});
+
+		expect(result.deleted).toBe(1);
+		expect(result.errors).toEqual([]);
+		expect(
+			db.prepare("SELECT COUNT(*) AS c FROM memory_vectors WHERE memory_id = ?").get(321),
+		).toMatchObject({ c: 0 });
+	});
+
+	it("refreshes same-model vectors for replicated content updates", async () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'feature', 'Fresh title', 'Fresh body', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, now, now);
+		const memoryId = Number(info.lastInsertRowid);
+
+		const staleVector = new Float32Array(384);
+		db.exec(`
+			INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model)
+			VALUES (
+				vec_f32('${JSON.stringify(Array.from(staleVector))}'),
+				${memoryId},
+				0,
+				'stale-hash',
+				'test-model'
+			)
+		`);
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+
+		const result = await maintainVectorsForReplicationApply(db, {
+			upsertMemoryIds: [memoryId],
+			deleteMemoryIds: [],
+		});
+
+		expect(result.errors).toEqual([]);
+		const rows = db
+			.prepare(
+				"SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ? ORDER BY chunk_index",
+			)
+			.all(memoryId, "test-model") as Array<{ content_hash: string }>;
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.content_hash).not.toBe("stale-hash");
 	});
 
 	it("keeps stale-model vectors until a migration cutover removes them", async () => {

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -21,6 +21,7 @@ import {
 } from "./embeddings.js";
 import { getMaintenanceJob } from "./maintenance-jobs.js";
 import { projectClause } from "./project.js";
+import type { ReplicationVectorWork } from "./sync-replication.js";
 
 const VECTOR_MODEL_MIGRATION_JOB = "vector_model_migration";
 
@@ -143,6 +144,94 @@ export interface BackfillVectorsOptions {
 	activeOnly?: boolean;
 	dryRun?: boolean;
 	memoryIds?: number[] | null;
+}
+
+export interface ReplicationVectorMaintenanceResult {
+	deleted: number;
+	inserted: number;
+	errors: string[];
+}
+
+function uniqueMemoryIds(memoryIds: number[]): number[] {
+	return [...new Set(memoryIds.filter((memoryId) => Number.isInteger(memoryId) && memoryId > 0))];
+}
+
+function deleteVectorsForMemoryIds(db: Database, memoryIds: number[]): number {
+	if (!tableExists(db, "memory_vectors") || memoryIds.length === 0) return 0;
+	const placeholders = memoryIds.map(() => "?").join(", ");
+	const result = db
+		.prepare(`DELETE FROM memory_vectors WHERE memory_id IN (${placeholders})`)
+		.run(...memoryIds);
+	return result.changes;
+}
+
+function pruneStaleCurrentModelVectors(db: Database, memoryIds: number[], model: string): number {
+	if (memoryIds.length === 0) return 0;
+	const placeholders = memoryIds.map(() => "?").join(", ");
+	const rows = db
+		.prepare(
+			`SELECT id, title, body_text FROM memory_items WHERE id IN (${placeholders}) ORDER BY id ASC`,
+		)
+		.all(...memoryIds) as MemoryTextRow[];
+	let deleted = 0;
+
+	for (const row of rows) {
+		const expectedHashes = chunkHashes(memoryText(row.title, row.body_text));
+		if (expectedHashes.length === 0) {
+			deleted += db
+				.prepare("DELETE FROM memory_vectors WHERE memory_id = ? AND model = ?")
+				.run(row.id, model).changes;
+			continue;
+		}
+		const hashPlaceholders = expectedHashes.map(() => "?").join(", ");
+		deleted += db
+			.prepare(
+				`DELETE FROM memory_vectors
+				 WHERE memory_id = ?
+				   AND model = ?
+				   AND content_hash NOT IN (${hashPlaceholders})`,
+			)
+			.run(row.id, model, ...expectedHashes).changes;
+	}
+
+	return deleted;
+}
+
+export async function maintainVectorsForReplicationApply(
+	db: Database,
+	work: ReplicationVectorWork,
+): Promise<ReplicationVectorMaintenanceResult> {
+	const result: ReplicationVectorMaintenanceResult = { deleted: 0, inserted: 0, errors: [] };
+	const deleteMemoryIds = uniqueMemoryIds(work.deleteMemoryIds);
+	const upsertMemoryIds = uniqueMemoryIds(work.upsertMemoryIds);
+
+	if (!tableExists(db, "memory_vectors")) {
+		return result;
+	}
+
+	try {
+		result.deleted += deleteVectorsForMemoryIds(db, deleteMemoryIds);
+	} catch (error) {
+		result.errors.push(
+			`delete vectors failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	if (upsertMemoryIds.length === 0) return result;
+
+	try {
+		const backfill = await backfillVectors(db, { memoryIds: upsertMemoryIds });
+		result.inserted = backfill.inserted;
+		if (backfill.checked > 0) {
+			result.deleted += pruneStaleCurrentModelVectors(db, upsertMemoryIds, resolveEmbeddingModel());
+		}
+	} catch (error) {
+		result.errors.push(
+			`backfill vectors failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	return result;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Automatically trigger best-effort vector maintenance after incremental inbound sync apply so synced memories become semantically searchable without manual backfill, while keeping sync correctness independent from embedding success.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/sync-replication.test.ts packages/core/src/sync-pass.test.ts packages/core/src/vectors.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] TypeScript build passes (`pnpm exec tsc --build`)

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
