### PR TITLE
feat(sync): persist bootstrap vector catch-up across restart

### DIFF
--- a/packages/core/src/sync-bootstrap.test.ts
+++ b/packages/core/src/sync-bootstrap.test.ts
@@ -4,11 +4,13 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { toJson } from "./db.js";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
 import { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
 import { ensureDeviceIdentity } from "./sync-identity.js";
 import { getSyncResetState, setSyncResetState } from "./sync-replication.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import type { SyncMemorySnapshotItem, SyncResetRequired } from "./types.js";
+import { VECTOR_MODEL_MIGRATION_JOB } from "./vector-migration.js";
 
 function makeResetInfo(overrides?: Partial<SyncResetRequired>): SyncResetRequired {
 	return {
@@ -156,6 +158,30 @@ describe("applyBootstrapSnapshot", () => {
 			.prepare("SELECT last_applied_cursor FROM replication_cursors WHERE peer_device_id = ?")
 			.get("peer-1") as { last_applied_cursor: string } | undefined;
 		expect(cursor?.last_applied_cursor).toBe("2026-01-01T00:00:05Z|base-op");
+	});
+
+	it("queues a persisted vector backfill job for bootstrap catch-up", () => {
+		const items = [
+			makeSnapshotItem("embeddable-key"),
+			makeSnapshotItem("blank-key", { payload: { title: "", body_text: "" } }),
+			makeSnapshotItem("deleted-key", { op_type: "delete" }),
+		];
+
+		applyBootstrapSnapshot(db, "peer-1", items, makeResetInfo());
+
+		const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(job).toMatchObject({
+			status: "pending",
+			title: "Re-indexing memories",
+			message: "Queued vector catch-up for synced bootstrap data",
+			progress: { current: 0, total: 1, unit: "items" },
+		});
+		expect(job?.metadata).toMatchObject({
+			last_cursor_id: 0,
+			processed_embeddable: 0,
+			embeddable_total: 1,
+			trigger: "sync_bootstrap",
+		});
 	});
 
 	it("applies empty snapshot (wipes shared, inserts nothing)", () => {

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -19,6 +19,7 @@ import { buildAuthHeaders } from "./sync-auth.js";
 import { requestJson } from "./sync-http-client.js";
 import { setReplicationCursor, setSyncResetState } from "./sync-replication.js";
 import type { SyncMemorySnapshotItem, SyncResetRequired } from "./types.js";
+import { queueVectorBackfillForSyncBootstrap } from "./vector-migration.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -161,6 +162,12 @@ function parseSnapshotPayload(item: SyncMemorySnapshotItem): Record<string, unkn
 	}
 }
 
+function isEmbeddableSnapshotPayload(payload: Record<string, unknown>): boolean {
+	const title = typeof payload.title === "string" ? payload.title : "";
+	const bodyText = typeof payload.body_text === "string" ? payload.body_text : "";
+	return `${title}\n${bodyText}`.trim().length > 0;
+}
+
 const bootstrapSessionCache = new Map<string, number>();
 
 function ensureSessionForBootstrap(
@@ -220,6 +227,7 @@ export function applyBootstrapSnapshot(
 
 	db.transaction(() => {
 		const d = drizzle(db, { schema });
+		let embeddableApplied = 0;
 
 		// 1. Delete all local sync-eligible memories that have been synced.
 		// - Only memories with import_key (i.e. previously synced) are deleted.
@@ -259,6 +267,9 @@ export function applyBootstrapSnapshot(
 			meta.clock_device_id = item.clock_device_id;
 
 			const isDeleted = item.op_type === "delete";
+			if (!isDeleted && isEmbeddableSnapshotPayload(payload)) {
+				embeddableApplied++;
+			}
 
 			d.insert(schema.memoryItems)
 				.values({
@@ -319,6 +330,8 @@ export function applyBootstrapSnapshot(
 			snapshot_id: resetInfo.snapshot_id,
 			baseline_cursor: resetInfo.baseline_cursor,
 		});
+
+		queueVectorBackfillForSyncBootstrap(db, { embeddableTotal: embeddableApplied });
 
 		result.ok = true;
 	}).immediate();

--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -1,7 +1,12 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as embeddings from "./embeddings.js";
 import { getMaintenanceJob } from "./maintenance-jobs.js";
+import { applyBootstrapSnapshot } from "./sync-bootstrap.js";
+import { setSyncResetState } from "./sync-replication.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import { runVectorMigrationPass, VECTOR_MODEL_MIGRATION_JOB } from "./vector-migration.js";
 import { resolveSemanticSearchModel } from "./vectors.js";
@@ -201,6 +206,167 @@ describe("vector migration", () => {
 			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
 			.all() as Array<{ model: string; c: number }>;
 		expect(models).toEqual([{ model: "test-model", c: 3 }]);
+	});
+
+	it("resumes bootstrap-queued vector catch-up after restart", async () => {
+		const dbDir = mkdtempSync(join(tmpdir(), "codemem-vector-bootstrap-"));
+		const dbPath = join(dbDir, "restart-safe.sqlite");
+		let fileDb: Database | null = null;
+		try {
+			fileDb = new Database(dbPath);
+			initTestSchema(fileDb);
+			setSyncResetState(fileDb, {
+				generation: 1,
+				snapshot_id: "snap-1",
+				baseline_cursor: null,
+			});
+			applyBootstrapSnapshot(
+				fileDb,
+				"peer-1",
+				[
+					{
+						entity_id: "bootstrap-1",
+						op_type: "upsert",
+						payload_json: JSON.stringify({
+							kind: "feature",
+							title: "Bootstrap memory",
+							body_text: "Needs vectors after restart",
+							visibility: "shared",
+							workspace_kind: "shared",
+							workspace_id: "shared:default",
+							created_at: "2026-01-01T00:00:01Z",
+							metadata_json: { clock_device_id: "peer-dev" },
+						}),
+						clock_rev: 1,
+						clock_updated_at: "2026-01-01T00:00:02Z",
+						clock_device_id: "peer-dev",
+					},
+				],
+				{
+					reset_required: true,
+					reason: "generation_mismatch",
+					generation: 2,
+					snapshot_id: "snap-2",
+					baseline_cursor: "2026-01-01T00:00:05Z|base-op",
+					retained_floor_cursor: null,
+				},
+			);
+
+			const pendingJob = getMaintenanceJob(fileDb, VECTOR_MODEL_MIGRATION_JOB);
+			expect(pendingJob).toMatchObject({
+				status: "pending",
+				progress: { current: 0, total: 1, unit: "items" },
+			});
+
+			fileDb.close();
+			fileDb = null;
+			fileDb = new Database(dbPath);
+			initTestSchema(fileDb);
+
+			await runVectorMigrationPass(fileDb, { batchSize: 10 });
+
+			const completedJob = getMaintenanceJob(fileDb, VECTOR_MODEL_MIGRATION_JOB);
+			expect(completedJob).toMatchObject({
+				status: "completed",
+				progress: { current: 1, total: 1, unit: "items" },
+			});
+
+			const models = fileDb
+				.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
+				.all() as Array<{ model: string; c: number }>;
+			expect(models).toEqual([{ model: "test-model", c: 1 }]);
+		} finally {
+			fileDb?.close();
+			rmSync(dbDir, { recursive: true, force: true });
+		}
+	});
+
+	it("marks a queued bootstrap backfill as failed when the embedding client is unavailable", async () => {
+		setSyncResetState(db, {
+			generation: 1,
+			snapshot_id: "snap-1",
+			baseline_cursor: null,
+		});
+		applyBootstrapSnapshot(
+			db,
+			"peer-1",
+			[
+				{
+					entity_id: "bootstrap-1",
+					op_type: "upsert",
+					payload_json: JSON.stringify({
+						kind: "feature",
+						title: "Bootstrap memory",
+						body_text: "Needs vectors later",
+						visibility: "shared",
+						workspace_kind: "shared",
+						workspace_id: "shared:default",
+						created_at: "2026-01-01T00:00:01Z",
+						metadata_json: { clock_device_id: "peer-dev" },
+					}),
+					clock_rev: 1,
+					clock_updated_at: "2026-01-01T00:00:02Z",
+					clock_device_id: "peer-dev",
+				},
+			],
+			{
+				reset_required: true,
+				reason: "generation_mismatch",
+				generation: 2,
+				snapshot_id: "snap-2",
+				baseline_cursor: "2026-01-01T00:00:05Z|base-op",
+				retained_floor_cursor: null,
+			},
+		);
+
+		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValueOnce(null);
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		const failedJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(failedJob).toMatchObject({
+			status: "failed",
+			message: "Vector re-indexing is waiting for the embedding client",
+			error: "Embedding client unavailable",
+		});
+	});
+
+	it("does not rewrite completed jobs when the embedding client is unavailable", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "One", "Body one");
+		seedVector(db, 1, "old-model");
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+		const completedBeforeDisable = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(completedBeforeDisable).toMatchObject({ status: "completed" });
+
+		vi.mocked(embeddings.getEmbeddingClient).mockResolvedValueOnce(null);
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		const completedAfterDisable = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(completedAfterDisable).toMatchObject({ status: "completed" });
+	});
+
+	it("removes stale old-model rows when queued work has zero embeddable memories", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "", "");
+		seedVector(db, 1, "old-model");
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(job).toMatchObject({
+			status: "completed",
+			metadata: {
+				source_model: "old-model",
+				target_model: "test-model",
+				removed_stale_rows: 1,
+			},
+		});
+
+		const models = db
+			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
+			.all() as Array<{ model: string; c: number }>;
+		expect(models).toEqual([]);
 	});
 
 	it("backfills memories that have no vectors at all (no source model)", async () => {

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -11,6 +11,7 @@ import {
 import { backfillVectors } from "./vectors.js";
 
 export const VECTOR_MODEL_MIGRATION_JOB = "vector_model_migration";
+const SYNC_BOOTSTRAP_TRIGGER = "sync_bootstrap";
 
 export interface VectorModelMigrationOptions {
 	batchSize?: number;
@@ -28,7 +29,34 @@ type MigrationMetadata = {
 	processed_embeddable?: number;
 	embeddable_total?: number;
 	removed_stale_rows?: number;
+	trigger?: string | null;
 };
+
+export function queueVectorBackfillForSyncBootstrap(
+	db: SqliteDatabase,
+	options: { embeddableTotal?: number | null } = {},
+): void {
+	const embeddableTotal =
+		typeof options.embeddableTotal === "number" && options.embeddableTotal >= 0
+			? options.embeddableTotal
+			: null;
+	const metadata: MigrationMetadata = {
+		last_cursor_id: 0,
+		processed_embeddable: 0,
+		trigger: SYNC_BOOTSTRAP_TRIGGER,
+	};
+	if (embeddableTotal != null) {
+		metadata.embeddable_total = embeddableTotal;
+	}
+	startMaintenanceJob(db, {
+		kind: VECTOR_MODEL_MIGRATION_JOB,
+		title: "Re-indexing memories",
+		status: "pending",
+		message: "Queued vector catch-up for synced bootstrap data",
+		progressTotal: embeddableTotal,
+		metadata,
+	});
+}
 
 function vectorModels(db: SqliteDatabase): Array<{ model: string; rows: number }> {
 	return db
@@ -104,12 +132,27 @@ export async function runVectorMigrationPass(
 	db: SqliteDatabase,
 	options: { batchSize?: number } = {},
 ): Promise<void> {
-	if (isEmbeddingDisabled()) return;
+	const existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+	const isInFlightJob = existingJob?.status === "running" || existingJob?.status === "pending";
+	if (isEmbeddingDisabled()) {
+		if (isInFlightJob) {
+			failMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, "Embeddings are disabled", {
+				message: "Vector re-indexing is waiting for embeddings to be enabled",
+			});
+		}
+		return;
+	}
 	const client = await getEmbeddingClient();
-	if (!client) return;
+	if (!client) {
+		if (isInFlightJob) {
+			failMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, "Embedding client unavailable", {
+				message: "Vector re-indexing is waiting for the embedding client",
+			});
+		}
+		return;
+	}
 	const targetModel = client.model;
 	const sourceModel = detectSourceModel(db, targetModel);
-	const existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
 	const hasInFlightJob =
 		existingJob?.status === "running" ||
 		existingJob?.status === "pending" ||
@@ -135,6 +178,20 @@ export async function runVectorMigrationPass(
 		isResumingJob && existingMeta.embeddable_total
 			? Number(existingMeta.embeddable_total)
 			: countEmbeddableActiveMemories(db);
+	if (embeddableTotal <= 0 && hasInFlightJob && !sourceModel) {
+		completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+			message: "No embeddable memories to re-index",
+			progressCurrent: 0,
+			progressTotal: 0,
+			metadata: {
+				...existingMeta,
+				last_cursor_id: 0,
+				processed_embeddable: 0,
+				embeddable_total: 0,
+			},
+		});
+		return;
+	}
 	if (sourceModel && embeddableTotal <= 0) {
 		const removed = cleanupStaleModels(db, targetModel);
 		startMaintenanceJob(db, {


### PR DESCRIPTION
## Description
Persist bootstrap-triggered vector catch-up work through the existing maintenance job path so large sync/bootstrap indexing can resume after restart instead of relying on in-memory best effort only.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/sync-bootstrap.test.ts packages/core/src/vector-migration.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] TypeScript build passes (`pnpm exec tsc --build`)

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
