### PR TITLE
feat(sync): report semantic-index catch-up status

### DIFF
--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { connect, initTestSchema, MemoryStore } from "@codemem/core";
+import { connect, initTestSchema, MemoryStore, startMaintenanceJob } from "@codemem/core";
 import { describe, expect, it, vi } from "vitest";
 import { syncCommand } from "./sync.js";
 import {
@@ -257,6 +257,45 @@ describe("formatSyncAttempt", () => {
 			store.close();
 			rmSync(tmpDbDir, { recursive: true, force: true });
 			process.exitCode = prevExitCode;
+		}
+	});
+
+	it("reports semantic-index diagnostics in sync status json output", async () => {
+		const tmpDbDir = mkdtempSync(join(tmpdir(), "sync-status-diagnostics-test-"));
+		const dbPath = join(tmpDbDir, "mem.sqlite");
+		const configPath = join(tmpDbDir, "config.json");
+		writeFileSync(configPath, JSON.stringify({ sync_enabled: true }, null, 2));
+		const rawDb = connect(dbPath);
+		initTestSchema(rawDb);
+		rawDb.close();
+		const store = new MemoryStore(dbPath);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			startMaintenanceJob(store.db, {
+				kind: "vector_model_migration",
+				title: "Re-indexing memories",
+				status: "pending",
+				message: "Queued vector catch-up for synced bootstrap data",
+				progressTotal: 4,
+				metadata: { processed_embeddable: 1, embeddable_total: 4 },
+			});
+
+			await syncCommand.parseAsync(
+				["status", "--db-path", dbPath, "--config", configPath, "--json"],
+				{ from: "user" },
+			);
+
+			expect(logSpy).toHaveBeenCalledTimes(1);
+			const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as Record<string, unknown>;
+			expect(payload.semantic_index).toMatchObject({
+				state: "pending",
+				pending_memory_count: 3,
+				maintenance_job: { status: "pending" },
+			});
+		} finally {
+			logSpy.mockRestore();
+			store.close();
+			rmSync(tmpDbDir, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -16,6 +16,7 @@ import {
 	ensureDeviceIdentity,
 	fetchAllSnapshotPages,
 	fingerprintPublicKey,
+	getSemanticIndexDiagnostics,
 	hasUnsyncedSharedMemoryChanges,
 	loadPublicKey,
 	MemoryStore,
@@ -777,6 +778,7 @@ statusCmd.action((opts: { db?: string; dbPath?: string; config?: string; json?: 
 			})
 			.from(schema.syncPeers)
 			.all();
+		const semanticIndex = getSemanticIndexDiagnostics(store.db);
 
 		if (opts.json) {
 			console.log(
@@ -786,6 +788,7 @@ statusCmd.action((opts: { db?: string; dbPath?: string; config?: string; json?: 
 						host: config.sync_host ?? "0.0.0.0",
 						port: config.sync_port ?? 7337,
 						interval_s: config.sync_interval_s ?? 120,
+						semantic_index: semanticIndex,
 						device_id: deviceRow?.device_id ?? null,
 						fingerprint: deviceRow?.fingerprint ?? null,
 						coordinator_url: config.sync_coordinator_url ?? null,
@@ -828,6 +831,15 @@ statusCmd.action((opts: { db?: string; dbPath?: string; config?: string; json?: 
 				);
 			}
 		}
+		p.log.info(
+			[
+				"Semantic index:",
+				`  State: ${semanticIndex.state}`,
+				`  Summary: ${semanticIndex.summary}`,
+				`  Coverage: ${semanticIndex.indexed_memory_count}/${semanticIndex.embeddable_memory_count}`,
+				`  Mode: ${semanticIndex.mode === "semantic" ? `semantic (${semanticIndex.semantic_search_model ?? semanticIndex.current_model})` : "keyword-only"}`,
+			].join("\n"),
+		);
 		p.outro(`${peers.length} peer(s)`);
 	} finally {
 		store.close();

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -530,11 +530,30 @@ export interface ApiSyncRetentionStatus {
 	last_error_at?: string | null;
 }
 
+export interface ApiSemanticIndexDiagnostics {
+	state: "healthy" | "pending" | "failed" | "degraded";
+	summary: string;
+	mode: "semantic" | "keyword_only";
+	current_model: string;
+	semantic_search_model: string | null;
+	embeddable_memory_count: number;
+	indexed_memory_count: number;
+	pending_memory_count: number;
+	maintenance_job: {
+		status: "pending" | "running" | "failed" | "completed" | "cancelled";
+		message: string | null;
+		error: string | null;
+		progress_current: number;
+		progress_total: number | null;
+	} | null;
+}
+
 /** Status block nested in sync status response. */
 export interface ApiSyncStatusBlock {
 	enabled: boolean;
 	interval_s: number;
 	retention: ApiSyncRetentionStatus;
+	semantic_index: ApiSemanticIndexDiagnostics;
 	peer_count: number;
 	last_sync_at: string | null;
 	daemon_state: ApiSyncDaemonState;
@@ -557,6 +576,7 @@ export interface ApiSyncStatusResponse {
 	enabled: boolean;
 	interval_s: number;
 	retention: ApiSyncRetentionStatus;
+	semantic_index: ApiSemanticIndexDiagnostics;
 	peer_count: number;
 	last_sync_at: string | null;
 	daemon_state: ApiSyncDaemonState;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -509,6 +509,12 @@ export {
 export type {
 	BackfillVectorsOptions,
 	BackfillVectorsResult,
+	SemanticIndexDiagnostics,
 	SemanticSearchResult,
 } from "./vectors.js";
-export { backfillVectors, semanticSearch, storeVectors } from "./vectors.js";
+export {
+	backfillVectors,
+	getSemanticIndexDiagnostics,
+	semanticSearch,
+	storeVectors,
+} from "./vectors.js";

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -11,6 +11,7 @@ import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import {
 	backfillVectors,
+	getSemanticIndexDiagnostics,
 	maintainVectorsForReplicationApply,
 	resolveSemanticSearchModel,
 	semanticSearch,
@@ -129,6 +130,186 @@ describe("vectors", () => {
 		expect(result.inserted).toBe(0);
 		expect(result.errors).toEqual(["backfill vectors failed: embedding unavailable"]);
 		expect(db.prepare("SELECT COUNT(*) AS c FROM memory_vectors").get()).toMatchObject({ c: 0 });
+	});
+
+	it("reports pending semantic-index catch-up from queued maintenance job state", () => {
+		startMaintenanceJob(db, {
+			kind: "vector_model_migration",
+			title: "Re-indexing memories",
+			status: "pending",
+			message: "Queued vector catch-up for synced bootstrap data",
+			progressTotal: 3,
+			metadata: {
+				trigger: "sync_bootstrap",
+				processed_embeddable: 1,
+				embeddable_total: 3,
+			},
+		});
+
+		const diagnostics = getSemanticIndexDiagnostics(db);
+
+		expect(diagnostics).toMatchObject({
+			state: "pending",
+			mode: "keyword_only",
+			pending_memory_count: 2,
+			maintenance_job: {
+				status: "pending",
+				message: "Queued vector catch-up for synced bootstrap data",
+			},
+		});
+	});
+
+	it("reports degraded keyword-only mode when embeddable memories have no current vectors", () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+			 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+			 VALUES (?, 'feature', 'Needs vectors', 'Still keyword only', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+		).run(sessionId, now, now);
+
+		const diagnostics = getSemanticIndexDiagnostics(db);
+
+		expect(diagnostics).toMatchObject({
+			state: "degraded",
+			mode: "keyword_only",
+			embeddable_memory_count: 1,
+			indexed_memory_count: 0,
+			pending_memory_count: 1,
+		});
+	});
+
+	it("does not mark partially covered memories as healthy", () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		const bodyText = "semantic chunk ".repeat(5000);
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'feature', 'Chunky memory', ?, 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, bodyText, now, now);
+		const memoryId = Number(info.lastInsertRowid);
+		const chunks = embeddings.chunkText(`Chunky memory\n${bodyText}`);
+		const firstChunk = chunks[0];
+		if (!firstChunk || chunks.length < 2) {
+			throw new Error("expected multi-chunk memory for partial coverage test");
+		}
+
+		db.exec(`
+			INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model)
+			VALUES (
+				vec_f32('${JSON.stringify(Array.from(new Float32Array(384)))}'),
+				${memoryId},
+				0,
+				'${embeddings.hashText(firstChunk)}',
+				'test-model'
+			)
+		`);
+
+		const diagnostics = getSemanticIndexDiagnostics(db);
+
+		expect(diagnostics).toMatchObject({
+			state: "pending",
+			embeddable_memory_count: 1,
+			indexed_memory_count: 0,
+			pending_memory_count: 1,
+		});
+	});
+
+	it("reports failed semantic-index catch-up from maintenance job state", () => {
+		startMaintenanceJob(db, {
+			kind: "vector_model_migration",
+			title: "Re-indexing memories",
+			status: "pending",
+			progressTotal: 2,
+		});
+		db.prepare(
+			"UPDATE maintenance_jobs SET status = 'failed', message = ?, error = ? WHERE kind = ?",
+		).run(
+			"Vector re-indexing is waiting for the embedding client",
+			"Embedding client unavailable",
+			"vector_model_migration",
+		);
+
+		const diagnostics = getSemanticIndexDiagnostics(db);
+
+		expect(diagnostics).toMatchObject({
+			state: "failed",
+			summary: "Embedding client unavailable",
+			maintenance_job: {
+				status: "failed",
+				error: "Embedding client unavailable",
+			},
+		});
+	});
+
+	it("falls back to live pending counts after a completed job when vectors go missing", () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+			 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+			 VALUES (?, 'feature', 'Needs vectors', 'Coverage regressed', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+		).run(sessionId, now, now);
+		startMaintenanceJob(db, {
+			kind: "vector_model_migration",
+			title: "Re-indexing memories",
+			status: "completed",
+			progressCurrent: 2,
+			progressTotal: 2,
+			metadata: {
+				embeddable_total: 2,
+				processed_embeddable: 2,
+			},
+		});
+
+		const diagnostics = getSemanticIndexDiagnostics(db);
+
+		expect(diagnostics).toMatchObject({
+			state: "degraded",
+			pending_memory_count: 1,
+			mode: "keyword_only",
+		});
+	});
+
+	it("forces keyword-only degraded diagnostics when embeddings are disabled", async () => {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'feature', 'Has vectors', 'But runtime embeddings are disabled', 0.5, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(sessionId, now, now);
+		const memoryId = Number(info.lastInsertRowid);
+		db.exec(`
+			INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model)
+			VALUES (
+				vec_f32('${JSON.stringify(Array.from(new Float32Array(384)))}'),
+				${memoryId},
+				0,
+				'${embeddings.hashText("Has vectors\nBut runtime embeddings are disabled")}',
+				'test-model'
+			)
+		`);
+		const previous = process.env.CODEMEM_EMBEDDING_DISABLED;
+		process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+
+		const diagnostics = getSemanticIndexDiagnostics(db);
+		if (previous === undefined) {
+			delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		} else {
+			process.env.CODEMEM_EMBEDDING_DISABLED = previous;
+		}
+
+		expect(diagnostics).toMatchObject({
+			state: "degraded",
+			mode: "keyword_only",
+			summary: "Embeddings are disabled; sync data is available in keyword-only mode",
+		});
 	});
 
 	it("deletes vector rows for replicated tombstones", async () => {

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -10,7 +10,7 @@
  */
 
 import type { Database } from "./db.js";
-import { tableExists } from "./db.js";
+import { isEmbeddingDisabled, tableExists } from "./db.js";
 import {
 	chunkText,
 	embedTexts,
@@ -150,6 +150,142 @@ export interface ReplicationVectorMaintenanceResult {
 	deleted: number;
 	inserted: number;
 	errors: string[];
+}
+
+export type SemanticIndexState = "healthy" | "pending" | "failed" | "degraded";
+
+export interface SemanticIndexDiagnostics {
+	state: SemanticIndexState;
+	summary: string;
+	mode: "semantic" | "keyword_only";
+	current_model: string;
+	semantic_search_model: string | null;
+	embeddable_memory_count: number;
+	indexed_memory_count: number;
+	pending_memory_count: number;
+	maintenance_job: {
+		status: "pending" | "running" | "failed" | "completed" | "cancelled";
+		message: string | null;
+		error: string | null;
+		progress_current: number;
+		progress_total: number | null;
+	} | null;
+}
+
+function countEmbeddableActiveMemories(db: Database): number {
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS c
+			 FROM memory_items
+			 WHERE active = 1
+			   AND TRIM(COALESCE(title, '') || COALESCE(body_text, '')) != ''`,
+		)
+		.get() as { c?: number } | undefined;
+	return Number(row?.c ?? 0);
+}
+
+function countIndexedActiveMemories(db: Database, model: string): number {
+	if (!tableExists(db, "memory_vectors")) return 0;
+	const rows = db
+		.prepare(
+			`SELECT id, title, body_text
+			 FROM memory_items
+			 WHERE active = 1
+			   AND TRIM(COALESCE(title, '') || COALESCE(body_text, '')) != ''
+			 ORDER BY id ASC`,
+		)
+		.all() as MemoryTextRow[];
+	return rows.filter((row) => memoryHasCompleteVectorCoverage(db, row, model)).length;
+}
+
+function resolvePendingMemoryCount(
+	fallbackPendingCount: number,
+	job: ReturnType<typeof getMaintenanceJob>,
+): number {
+	if (!(job?.status === "pending" || job?.status === "running" || job?.status === "failed")) {
+		return fallbackPendingCount;
+	}
+	const metadata = job?.metadata ?? {};
+	const total = Number(metadata.embeddable_total ?? job?.progress.total ?? Number.NaN);
+	const processed = Number(metadata.processed_embeddable ?? job?.progress.current ?? Number.NaN);
+	if (Number.isFinite(total) && Number.isFinite(processed)) {
+		return Math.max(total - processed, 0);
+	}
+	return fallbackPendingCount;
+}
+
+function summarizeSemanticIndexState(
+	state: SemanticIndexState,
+	counts: { embeddable: number; indexed: number; pending: number },
+	job: ReturnType<typeof getMaintenanceJob>,
+): string {
+	if (state === "failed") {
+		return job?.error ?? job?.message ?? "Semantic-index catch-up failed";
+	}
+	if (state === "degraded") {
+		if (isEmbeddingDisabled()) {
+			return "Embeddings are disabled; sync data is available in keyword-only mode";
+		}
+		return "Semantic-index coverage is unavailable; sync data is effectively running in keyword-only mode";
+	}
+	if (state === "pending") {
+		return job?.message ?? `${counts.pending} memory(s) still need semantic indexing`;
+	}
+	if (counts.embeddable === 0) {
+		return "No embeddable memories need semantic indexing";
+	}
+	return `Semantic index is current for ${counts.indexed} embeddable mem${counts.indexed === 1 ? "ory" : "ories"}`;
+}
+
+export function getSemanticIndexDiagnostics(db: Database): SemanticIndexDiagnostics {
+	const currentModel = resolveEmbeddingModel();
+	const semanticSearchModel = resolveSemanticSearchModel(db, currentModel);
+	const embeddingsDisabled = isEmbeddingDisabled();
+	const embeddableMemoryCount = countEmbeddableActiveMemories(db);
+	const indexedMemoryCount = countIndexedActiveMemories(db, currentModel);
+	const fallbackPendingCount = Math.max(embeddableMemoryCount - indexedMemoryCount, 0);
+	const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+	const pendingMemoryCount = resolvePendingMemoryCount(fallbackPendingCount, job);
+	const degraded = embeddableMemoryCount > 0 && (embeddingsDisabled || semanticSearchModel == null);
+	const activeCatchUp = job?.status === "pending" || job?.status === "running";
+	const state: SemanticIndexState =
+		job?.status === "failed"
+			? "failed"
+			: activeCatchUp
+				? "pending"
+				: degraded
+					? "degraded"
+					: pendingMemoryCount > 0
+						? "pending"
+						: "healthy";
+
+	return {
+		state,
+		summary: summarizeSemanticIndexState(
+			state,
+			{
+				embeddable: embeddableMemoryCount,
+				indexed: indexedMemoryCount,
+				pending: pendingMemoryCount,
+			},
+			job,
+		),
+		mode: embeddingsDisabled || !semanticSearchModel ? "keyword_only" : "semantic",
+		current_model: currentModel,
+		semantic_search_model: semanticSearchModel,
+		embeddable_memory_count: embeddableMemoryCount,
+		indexed_memory_count: indexedMemoryCount,
+		pending_memory_count: pendingMemoryCount,
+		maintenance_job: job
+			? {
+					status: job.status,
+					message: job.message,
+					error: job.error,
+					progress_current: job.progress.current,
+					progress_total: job.progress.total,
+				}
+			: null,
+	};
 }
 
 function uniqueMemoryIds(memoryIds: number[]): number[] {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2543,6 +2543,78 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("includes semantic-index diagnostics in sync status output", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/sync/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				startMaintenanceJob(store.db, {
+					kind: "vector_model_migration",
+					title: "Re-indexing memories",
+					status: "pending",
+					message: "Queued vector catch-up for synced bootstrap data",
+					progressTotal: 4,
+					metadata: {
+						trigger: "sync_bootstrap",
+						processed_embeddable: 1,
+						embeddable_total: 4,
+					},
+				});
+
+				const res = await app.request("/api/sync/status");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.semantic_index).toMatchObject({
+					state: "pending",
+					pending_memory_count: 3,
+					maintenance_job: { status: "pending" },
+				});
+				const status = body.status as Record<string, unknown>;
+				expect(status.semantic_index).toMatchObject({
+					state: "pending",
+					pending_memory_count: 3,
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("redacts semantic-index job details when diagnostics are disabled", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/sync/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				startMaintenanceJob(store.db, {
+					kind: "vector_model_migration",
+					title: "Re-indexing memories",
+					status: "pending",
+					message: "Queued vector catch-up for synced bootstrap data",
+					progressTotal: 4,
+					metadata: {
+						processed_embeddable: 1,
+						embeddable_total: 4,
+					},
+				});
+
+				const res = await app.request("/api/sync/status");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.semantic_index).toMatchObject({
+					state: "pending",
+					summary: "Semantic-index catch-up is pending",
+					maintenance_job: {
+						status: "pending",
+						message: null,
+						error: null,
+					},
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("includes retention telemetry in sync status output", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -11,6 +11,7 @@ import type {
 	MaintenanceJobSnapshot,
 	MemoryStore,
 	ReplicationOp,
+	SemanticIndexDiagnostics,
 } from "@codemem/core";
 import {
 	applyReplicationOps,
@@ -27,6 +28,7 @@ import {
 	ensureDeviceIdentity,
 	extractReplicationOps,
 	fingerprintPublicKey,
+	getSemanticIndexDiagnostics,
 	getSyncResetState,
 	listCoordinatorJoinRequests,
 	listMaintenanceJobs,
@@ -106,6 +108,32 @@ function summarizeMaintenanceJobs(
 				}
 			: {}),
 	}));
+}
+
+function redactSemanticIndexDiagnostics(
+	diagnostics: SemanticIndexDiagnostics,
+	showDiagnostics: boolean,
+): SemanticIndexDiagnostics {
+	if (showDiagnostics || !diagnostics.maintenance_job) {
+		return diagnostics;
+	}
+	const summary =
+		diagnostics.state === "pending"
+			? "Semantic-index catch-up is pending"
+			: diagnostics.state === "failed"
+				? "Semantic-index catch-up failed"
+				: diagnostics.state === "degraded"
+					? "Semantic index is running in degraded mode"
+					: diagnostics.summary;
+	return {
+		...diagnostics,
+		summary,
+		maintenance_job: {
+			...diagnostics.maintenance_job,
+			message: null,
+			error: null,
+		},
+	};
 }
 
 function syncKeysDir(): string | undefined {
@@ -1226,6 +1254,10 @@ export function syncRoutes(
 				.select({ last_sync_at: max(schema.syncPeers.last_sync_at) })
 				.from(schema.syncPeers)
 				.get();
+			const semanticIndex = redactSemanticIndexDiagnostics(
+				getSemanticIndexDiagnostics(store.db),
+				showDiag,
+			);
 
 			const lastError = daemonState?.last_error as string | null;
 			const lastErrorAt = daemonState?.last_error_at as string | null;
@@ -1280,6 +1312,7 @@ export function syncRoutes(
 					last_error: (retentionState?.last_error as string | null) ?? null,
 					last_error_at: (retentionState?.last_error_at as string | null) ?? null,
 				},
+				semantic_index: semanticIndex,
 				peer_count: Number(peerCountRow?.total ?? 0),
 				last_sync_at: lastSyncRow?.last_sync_at ?? null,
 				daemon_state: daemonStateValue,


### PR DESCRIPTION
## Description
Expose semantic-index catch-up diagnostics through core, API, and CLI status surfaces so operators can see whether synced memories are fully indexed, pending catch-up, failed, or effectively running in keyword-only mode.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/vectors.test.ts packages/viewer-server/src/index.test.ts packages/cli/src/commands/sync.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] TypeScript build passes (`pnpm exec tsc --build`)

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
