### PR TITLE
feat(sync): persist incremental vector catch-up across restart

### DIFF
--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -1,5 +1,6 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
 import * as syncAuth from "./sync-auth.js";
 import * as syncBootstrap from "./sync-bootstrap.js";
 import * as syncHttpClient from "./sync-http-client.js";
@@ -15,7 +16,7 @@ import {
 } from "./sync-pass.js";
 import * as syncReplication from "./sync-replication.js";
 import { initTestSchema } from "./test-utils.js";
-import * as vectors from "./vectors.js";
+import { VECTOR_MODEL_MIGRATION_JOB } from "./vector-migration.js";
 
 // ---------------------------------------------------------------------------
 // Schema helper — adds sync tables not in base test schema
@@ -150,7 +151,7 @@ describe("syncOnce", () => {
 		expect(result.error).toBeTruthy();
 	});
 
-	it("runs best-effort vector maintenance after applying incremental inbound ops", async () => {
+	it("queues durable vector catch-up after applying incremental inbound ops", async () => {
 		db.prepare(
 			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
 		).run("peer-1", "abc123", new Date().toISOString());
@@ -162,9 +163,6 @@ describe("syncOnce", () => {
 			"ed25519 AAAA",
 		]);
 		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
-		const maintainSpy = vi
-			.spyOn(vectors, "maintainVectorsForReplicationApply")
-			.mockResolvedValue({ deleted: 0, inserted: 0, errors: ["embedding unavailable"] });
 
 		vi.spyOn(syncHttpClient, "requestJson")
 			.mockResolvedValueOnce([
@@ -221,10 +219,14 @@ describe("syncOnce", () => {
 		}
 		expect(result.ok).toBe(true);
 		expect(result.opsIn).toBe(1);
-		expect(maintainSpy).toHaveBeenCalledOnce();
-		expect(maintainSpy).toHaveBeenCalledWith(db, {
-			upsertMemoryIds: [expect.any(Number)],
-			deleteMemoryIds: [],
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "pending",
+			message: "Queued vector catch-up for incremental sync data",
+			metadata: {
+				trigger: "sync_incremental",
+				pending_upsert_memory_ids: [expect.any(Number)],
+				pending_delete_memory_ids: [],
+			},
 		});
 		expect(syncReplication.getReplicationCursor(db, "peer-1")[0]).toBe(
 			"2026-01-01T00:00:00Z|remote-op-1",

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -27,7 +27,7 @@ import {
 	setReplicationCursor,
 } from "./sync-replication.js";
 import type { ReplicationOp, SyncResetRequired } from "./types.js";
-import { maintainVectorsForReplicationApply } from "./vectors.js";
+import { queueVectorBackfillForIncrementalSync } from "./vector-migration.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -615,13 +615,13 @@ export async function syncOnce(
 
 			// -- 3. Apply incoming ops to local entities --
 			const applied = applyReplicationOps(db, inboundOps, deviceId);
+			queueVectorBackfillForIncrementalSync(db, applied.vectorWork);
 
 			const inboundCursorCandidate = inboundCursor || asOptionalCursor(getPayload.next_cursor);
 			if (cursorAdvances(lastApplied, inboundCursorCandidate)) {
 				setReplicationCursor(db, peerDeviceId, { lastApplied: inboundCursorCandidate });
 				lastApplied = inboundCursorCandidate;
 			}
-			await maintainVectorsForReplicationApply(db, applied.vectorWork);
 
 			// -- 5. Push local ops to peer --
 			const [outboundWindow, outboundCursor] = loadLocalOpsSince(db, lastAcked, deviceId, limit);

--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -8,7 +8,11 @@ import { getMaintenanceJob } from "./maintenance-jobs.js";
 import { applyBootstrapSnapshot } from "./sync-bootstrap.js";
 import { setSyncResetState } from "./sync-replication.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
-import { runVectorMigrationPass, VECTOR_MODEL_MIGRATION_JOB } from "./vector-migration.js";
+import {
+	queueVectorBackfillForIncrementalSync,
+	runVectorMigrationPass,
+	VECTOR_MODEL_MIGRATION_JOB,
+} from "./vector-migration.js";
 import { resolveSemanticSearchModel } from "./vectors.js";
 
 vi.mock("./embeddings.js", async () => {
@@ -269,6 +273,59 @@ describe("vector migration", () => {
 			expect(completedJob).toMatchObject({
 				status: "completed",
 				progress: { current: 1, total: 1, unit: "items" },
+			});
+
+			const models = fileDb
+				.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
+				.all() as Array<{ model: string; c: number }>;
+			expect(models).toEqual([{ model: "test-model", c: 1 }]);
+		} finally {
+			fileDb?.close();
+			rmSync(dbDir, { recursive: true, force: true });
+		}
+	});
+
+	it("resumes incremental sync queued vector catch-up after restart", async () => {
+		const dbDir = mkdtempSync(join(tmpdir(), "codemem-vector-incremental-"));
+		const dbPath = join(dbDir, "restart-safe.sqlite");
+		let fileDb: Database | null = null;
+		try {
+			fileDb = new Database(dbPath);
+			initTestSchema(fileDb);
+			const sessionId = insertTestSession(fileDb);
+			seedMemory(fileDb, 1, sessionId, "Incremental memory", "Needs vectors after restart");
+
+			queueVectorBackfillForIncrementalSync(fileDb, {
+				upsertMemoryIds: [1],
+				deleteMemoryIds: [],
+			});
+
+			const pendingJob = getMaintenanceJob(fileDb, VECTOR_MODEL_MIGRATION_JOB);
+			expect(pendingJob).toMatchObject({
+				status: "pending",
+				message: "Queued vector catch-up for incremental sync data",
+				metadata: {
+					trigger: "sync_incremental",
+					pending_upsert_memory_ids: [1],
+					pending_delete_memory_ids: [],
+				},
+			});
+
+			fileDb.close();
+			fileDb = null;
+			fileDb = new Database(dbPath);
+			initTestSchema(fileDb);
+
+			await runVectorMigrationPass(fileDb, { batchSize: 10 });
+
+			const completedJob = getMaintenanceJob(fileDb, VECTOR_MODEL_MIGRATION_JOB);
+			expect(completedJob).toMatchObject({
+				status: "completed",
+				message: "Finished vector catch-up for incremental sync data",
+				metadata: {
+					pending_upsert_memory_ids: [],
+					pending_delete_memory_ids: [],
+				},
 			});
 
 			const models = fileDb

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -8,10 +8,12 @@ import {
 	startMaintenanceJob,
 	updateMaintenanceJob,
 } from "./maintenance-jobs.js";
+import type { ReplicationVectorWork } from "./sync-replication.js";
 import { backfillVectors } from "./vectors.js";
 
 export const VECTOR_MODEL_MIGRATION_JOB = "vector_model_migration";
 const SYNC_BOOTSTRAP_TRIGGER = "sync_bootstrap";
+const SYNC_INCREMENTAL_TRIGGER = "sync_incremental";
 
 export interface VectorModelMigrationOptions {
 	batchSize?: number;
@@ -30,7 +32,155 @@ type MigrationMetadata = {
 	embeddable_total?: number;
 	removed_stale_rows?: number;
 	trigger?: string | null;
+	pending_upsert_memory_ids?: number[];
+	pending_delete_memory_ids?: number[];
 };
+
+function uniquePositiveIds(memoryIds: number[]): number[] {
+	return [
+		...new Set(memoryIds.filter((memoryId) => Number.isInteger(memoryId) && memoryId > 0)),
+	].sort((a, b) => a - b);
+}
+
+function metadataMemoryIds(value: unknown): number[] {
+	if (!Array.isArray(value)) return [];
+	return uniquePositiveIds(value.filter((item): item is number => typeof item === "number"));
+}
+
+function mergeQueuedSyncMemoryIds(
+	metadata: MigrationMetadata,
+	work: ReplicationVectorWork,
+): Pick<MigrationMetadata, "pending_upsert_memory_ids" | "pending_delete_memory_ids"> {
+	const pendingUpsertMemoryIds = new Set(metadataMemoryIds(metadata.pending_upsert_memory_ids));
+	const pendingDeleteMemoryIds = new Set(metadataMemoryIds(metadata.pending_delete_memory_ids));
+
+	for (const memoryId of uniquePositiveIds(work.deleteMemoryIds)) {
+		pendingUpsertMemoryIds.delete(memoryId);
+		pendingDeleteMemoryIds.add(memoryId);
+	}
+	for (const memoryId of uniquePositiveIds(work.upsertMemoryIds)) {
+		pendingDeleteMemoryIds.delete(memoryId);
+		pendingUpsertMemoryIds.add(memoryId);
+	}
+
+	return {
+		pending_upsert_memory_ids: [...pendingUpsertMemoryIds],
+		pending_delete_memory_ids: [...pendingDeleteMemoryIds],
+	};
+}
+
+function deleteVectorsForMemoryIds(db: SqliteDatabase, memoryIds: number[]): void {
+	if (memoryIds.length === 0) return;
+	const placeholders = memoryIds.map(() => "?").join(", ");
+	db.prepare(`DELETE FROM memory_vectors WHERE memory_id IN (${placeholders})`).run(...memoryIds);
+}
+
+export function queueVectorBackfillForIncrementalSync(
+	db: SqliteDatabase,
+	work: ReplicationVectorWork,
+): void {
+	const queuedWork = mergeQueuedSyncMemoryIds({}, work);
+	if (
+		(queuedWork.pending_upsert_memory_ids?.length ?? 0) === 0 &&
+		(queuedWork.pending_delete_memory_ids?.length ?? 0) === 0
+	) {
+		return;
+	}
+
+	const existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+	const existingMetadata =
+		existingJob && existingJob.status !== "completed" && existingJob.status !== "cancelled"
+			? ((existingJob.metadata ?? {}) as MigrationMetadata)
+			: {};
+	const metadata: MigrationMetadata = {
+		...existingMetadata,
+		...mergeQueuedSyncMemoryIds(existingMetadata, work),
+		trigger: existingMetadata.trigger ?? SYNC_INCREMENTAL_TRIGGER,
+	};
+	const pendingWorkCount =
+		metadataMemoryIds(metadata.pending_upsert_memory_ids).length +
+		metadataMemoryIds(metadata.pending_delete_memory_ids).length;
+
+	if (!existingJob || existingJob.status === "completed" || existingJob.status === "cancelled") {
+		startMaintenanceJob(db, {
+			kind: VECTOR_MODEL_MIGRATION_JOB,
+			title: "Re-indexing memories",
+			status: "pending",
+			message: "Queued vector catch-up for incremental sync data",
+			progressTotal: null,
+			metadata,
+		});
+		return;
+	}
+
+	updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+		status: "pending",
+		message: "Queued vector catch-up for incremental sync data",
+		progressCurrent:
+			existingJob.status === "failed"
+				? 0
+				: Math.min(existingJob.progress.current, pendingWorkCount),
+		progressTotal: existingJob.progress.total,
+		metadata,
+	});
+}
+
+async function runQueuedSyncVectorWork(
+	db: SqliteDatabase,
+	job: NonNullable<ReturnType<typeof getMaintenanceJob>>,
+	batchSize: number,
+): Promise<{ completed: boolean; metadata: MigrationMetadata }> {
+	const metadata = (job.metadata ?? {}) as MigrationMetadata;
+	const pendingDeleteMemoryIds = metadataMemoryIds(metadata.pending_delete_memory_ids);
+	const pendingUpsertMemoryIds = metadataMemoryIds(metadata.pending_upsert_memory_ids);
+	if (pendingDeleteMemoryIds.length === 0 && pendingUpsertMemoryIds.length === 0) {
+		return { completed: false, metadata };
+	}
+
+	if (pendingDeleteMemoryIds.length > 0) {
+		deleteVectorsForMemoryIds(db, pendingDeleteMemoryIds);
+	}
+	const batchUpsertMemoryIds = pendingUpsertMemoryIds.slice(0, batchSize);
+	if (batchUpsertMemoryIds.length > 0) {
+		await backfillVectors(db, { memoryIds: batchUpsertMemoryIds });
+	}
+
+	const nextMetadata: MigrationMetadata = {
+		...metadata,
+		pending_delete_memory_ids: [],
+		pending_upsert_memory_ids: pendingUpsertMemoryIds.slice(batchUpsertMemoryIds.length),
+	};
+	const remainingWorkCount =
+		metadataMemoryIds(nextMetadata.pending_delete_memory_ids).length +
+		metadataMemoryIds(nextMetadata.pending_upsert_memory_ids).length;
+	const incrementalOnly =
+		(metadata.trigger ?? SYNC_INCREMENTAL_TRIGGER) === SYNC_INCREMENTAL_TRIGGER &&
+		!metadata.source_model &&
+		!metadata.last_cursor_id &&
+		metadata.embeddable_total == null;
+
+	if (remainingWorkCount === 0 && incrementalOnly) {
+		completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+			message: "Finished vector catch-up for incremental sync data",
+			progressCurrent: 0,
+			progressTotal: null,
+			metadata: nextMetadata,
+		});
+		return { completed: true, metadata: nextMetadata };
+	}
+
+	updateMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+		status: remainingWorkCount > 0 ? "running" : job.status,
+		message:
+			remainingWorkCount > 0
+				? `Queued vector catch-up has ${remainingWorkCount} memory change(s) remaining`
+				: job.message,
+		progressCurrent: 0,
+		progressTotal: null,
+		metadata: nextMetadata,
+	});
+	return { completed: false, metadata: nextMetadata };
+}
 
 export function queueVectorBackfillForSyncBootstrap(
 	db: SqliteDatabase,
@@ -132,7 +282,7 @@ export async function runVectorMigrationPass(
 	db: SqliteDatabase,
 	options: { batchSize?: number } = {},
 ): Promise<void> {
-	const existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+	let existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
 	const isInFlightJob = existingJob?.status === "running" || existingJob?.status === "pending";
 	if (isEmbeddingDisabled()) {
 		if (isInFlightJob) {
@@ -152,6 +302,14 @@ export async function runVectorMigrationPass(
 		return;
 	}
 	const targetModel = client.model;
+	const effectiveBatchSize = Math.max(1, options.batchSize ?? 50);
+	if (existingJob) {
+		const queuedSyncWork = await runQueuedSyncVectorWork(db, existingJob, effectiveBatchSize);
+		if (queuedSyncWork.completed) {
+			return;
+		}
+		existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+	}
 	const sourceModel = detectSourceModel(db, targetModel);
 	const hasInFlightJob =
 		existingJob?.status === "running" ||
@@ -232,7 +390,6 @@ export async function runVectorMigrationPass(
 		});
 	}
 
-	const effectiveBatchSize = Math.max(1, options.batchSize ?? 50);
 	const batchRows = selectNextMigrationBatch(db, metadata.last_cursor_id ?? 0, effectiveBatchSize);
 	const batchIds = batchRows.map((row) => row.id);
 	const embeddableInBatch = batchRows.filter(isEmbeddableMemory).length;


### PR DESCRIPTION
## Description
Persist incremental receive-side vector catch-up work through the existing maintenance job path so sync-applied memories can finish semantic indexing after restart instead of relying only on in-memory best effort.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/sync-pass.test.ts packages/core/src/vector-migration.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] TypeScript build passes (`pnpm exec tsc --build`)

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
