### PR TITLE
fix(core): bootstrap schema in connect

### DIFF
--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdtempSync, readdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import BetterSqlite3 from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Database } from "./db.js";
 import {
@@ -74,6 +75,43 @@ describe("connect", () => {
 
 	it("expands ~/ paths like Python", () => {
 		expect(resolveDbPath("~/codemem-test.sqlite")).toBe(join(homedir(), "codemem-test.sqlite"));
+	});
+
+	it("bootstraps the schema on a fresh database path", () => {
+		db = connect(join(tmpDir, "fresh.sqlite"));
+
+		expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+		expect(tableExists(db, "memory_items")).toBe(true);
+		expect(tableExists(db, "sessions")).toBe(true);
+		expect(() => assertSchemaReady(db)).not.toThrow();
+	});
+
+	it("bootstraps the schema on an empty existing database file", () => {
+		const dbPath = join(tmpDir, "empty.sqlite");
+		writeFileSync(dbPath, "");
+
+		db = connect(dbPath);
+
+		expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+		expect(tableExists(db, "memory_items")).toBe(true);
+		expect(() => assertSchemaReady(db)).not.toThrow();
+	});
+
+	it("reopens an initialized database without clobbering existing data", () => {
+		const dbPath = join(tmpDir, "reopen.sqlite");
+		db = connect(dbPath);
+		db.exec("CREATE TABLE connect_reopen_guard (id INTEGER PRIMARY KEY, label TEXT NOT NULL)");
+		db.prepare("INSERT INTO connect_reopen_guard(label) VALUES (?)").run("still here");
+		db.close();
+
+		db = connect(dbPath);
+
+		expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+		expect(
+			db.prepare("SELECT label FROM connect_reopen_guard WHERE id = 1").get() as
+				| { label: string }
+				| undefined,
+		).toEqual({ label: "still here" });
 	});
 });
 
@@ -159,7 +197,7 @@ describe("loadSqliteVec", () => {
 
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
-		db = connect(join(tmpDir, "test.sqlite"));
+		db = new BetterSqlite3(join(tmpDir, "test.sqlite"));
 	});
 
 	afterEach(() => {
@@ -204,8 +242,8 @@ describe("getSchemaVersion", () => {
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
-	it("returns 0 for a fresh database", () => {
-		expect(getSchemaVersion(db)).toBe(0);
+	it("returns the bootstrapped version for a fresh database", () => {
+		expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
 	});
 
 	it("returns the version after it is set", () => {
@@ -229,25 +267,15 @@ describe("assertSchemaReady", () => {
 	});
 
 	it("throws for uninitialized schema (version 0)", () => {
-		expect(() => assertSchemaReady(db)).toThrow(/not initialized/);
+		const uninitialized = new BetterSqlite3(join(tmpDir, "uninitialized.sqlite"));
+		try {
+			expect(() => assertSchemaReady(uninitialized)).toThrow(/not initialized/);
+		} finally {
+			uninitialized.close();
+		}
 	});
 
 	it("passes for the current schema version with required tables", () => {
-		db.pragma(`user_version = ${SCHEMA_VERSION}`);
-		// Create all required tables + FTS5 index
-		db.exec(
-			"CREATE TABLE memory_items (id INTEGER PRIMARY KEY, title TEXT, body_text TEXT, tags_text TEXT)",
-		);
-		db.exec("CREATE TABLE sessions (id INTEGER PRIMARY KEY)");
-		db.exec("CREATE TABLE artifacts (id INTEGER PRIMARY KEY)");
-		db.exec("CREATE TABLE raw_events (id INTEGER PRIMARY KEY)");
-		db.exec(
-			"CREATE TABLE raw_event_sessions (source TEXT, stream_id TEXT, PRIMARY KEY (source, stream_id))",
-		);
-		db.exec("CREATE TABLE usage_events (id INTEGER PRIMARY KEY)");
-		db.exec(
-			"CREATE VIRTUAL TABLE memory_fts USING fts5(title, body_text, tags_text, content='memory_items', content_rowid='id')",
-		);
 		expect(() => assertSchemaReady(db)).not.toThrow();
 	});
 
@@ -258,26 +286,17 @@ describe("assertSchemaReady", () => {
 
 	it("warns but continues for a newer schema version", () => {
 		db.pragma(`user_version = ${SCHEMA_VERSION + 1}`);
-		// Create all required tables + FTS5 index
-		db.exec(
-			"CREATE TABLE memory_items (id INTEGER PRIMARY KEY, title TEXT, body_text TEXT, tags_text TEXT)",
-		);
-		db.exec("CREATE TABLE sessions (id INTEGER PRIMARY KEY)");
-		db.exec("CREATE TABLE artifacts (id INTEGER PRIMARY KEY)");
-		db.exec("CREATE TABLE raw_events (id INTEGER PRIMARY KEY)");
-		db.exec(
-			"CREATE TABLE raw_event_sessions (source TEXT, stream_id TEXT, PRIMARY KEY (source, stream_id))",
-		);
-		db.exec("CREATE TABLE usage_events (id INTEGER PRIMARY KEY)");
-		db.exec(
-			"CREATE VIRTUAL TABLE memory_fts USING fts5(title, body_text, tags_text, content='memory_items', content_rowid='id')",
-		);
 		expect(() => assertSchemaReady(db)).not.toThrow();
 	});
 
 	it("throws when required tables are missing", () => {
-		db.pragma(`user_version = ${SCHEMA_VERSION}`);
-		expect(() => assertSchemaReady(db)).toThrow(/Required tables missing/);
+		const missingTables = new BetterSqlite3(join(tmpDir, "missing-tables.sqlite"));
+		try {
+			missingTables.pragma(`user_version = ${SCHEMA_VERSION}`);
+			expect(() => assertSchemaReady(missingTables)).toThrow(/Required tables missing/);
+		} finally {
+			missingTables.close();
+		}
 	});
 });
 
@@ -311,7 +330,7 @@ describe("ensureAdditiveSchemaCompatibility", () => {
 
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
-		db = connect(join(tmpDir, "test.sqlite"));
+		db = new BetterSqlite3(join(tmpDir, "test.sqlite"));
 	});
 
 	afterEach(() => {
@@ -425,7 +444,7 @@ describe("ensurePlannerStats", () => {
 
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
-		db = connect(join(tmpDir, "test.sqlite"));
+		db = new BetterSqlite3(join(tmpDir, "test.sqlite"));
 	});
 
 	afterEach(() => {

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -5,7 +5,7 @@
  * path migration) and the schema-version introspection helpers
  * (`getSchemaVersion`, `assertSchemaReady`, `ensureAdditiveSchemaCompatibility`,
  * `ensurePlannerStats`). Schema bootstrap DDL lives in `schema-bootstrap.ts`;
- * `MemoryStore` auto-invokes it on first construction against a fresh DB.
+ * `connect()` now enforces the fresh-database bootstrap invariant.
  */
 
 import {
@@ -26,6 +26,7 @@ import type { Database as DatabaseType } from "better-sqlite3";
 import Database from "better-sqlite3";
 import * as sqliteVec from "sqlite-vec";
 import { expandUserPath } from "./observer-config.js";
+import { ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 
 // Re-export the Database type for consumers
 export type { DatabaseType as Database };
@@ -190,10 +191,8 @@ export function migrateLegacyDbPath(dbPath: string): void {
  * Open a better-sqlite3 connection with the standard codemem pragmas.
  *
  * Migrates legacy DB paths if needed, creates parent directories,
- * sets WAL mode, busy timeout, foreign keys. Does not create or migrate the
- * schema — callers are responsible for bootstrapping (either via
- * `MemoryStore`, which auto-bootstraps fresh files, or via `initDatabase` /
- * `bootstrapSchema` for offline tooling).
+ * sets WAL mode, busy timeout, foreign keys, and bootstraps the schema when
+ * opening a brand-new or otherwise uninitialized writable database.
  */
 export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 	migrateLegacyDbPath(dbPath);
@@ -212,6 +211,7 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 	}
 
 	db.pragma("synchronous = NORMAL");
+	ensureSchemaBootstrapped(db);
 
 	return db;
 }

--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -122,9 +122,9 @@ export function bootstrapSchema(db: Database): void {
 
 /**
  * Run `bootstrapSchema` on a database only if it's still at the unbootstrapped
- * state (`user_version === 0`). Safe to call from any entry point that opens
- * a raw `connect()` handle and then issues queries expecting the schema to be
- * in place. Idempotent: already-initialized databases are left untouched.
+ * state (`user_version === 0`). `connect()` now calls this by default for
+ * writable handles, but explicit callers may still use it directly. Idempotent:
+ * already-initialized databases are left untouched.
  */
 export function ensureSchemaBootstrapped(db: Database): void {
 	if (getSchemaVersion(db) === 0) {

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1087,7 +1087,7 @@ describe("MemoryStore constructor auto-bootstrap", () => {
 
 	it("bootstraps schema when constructed against an empty existing file", () => {
 		const dbPath = join(tmpDir, "empty.sqlite");
-		// Touch an empty file so connect() opens it as an uninitialized DB.
+		// Touch an empty file so connect() has to bootstrap an existing empty DB.
 		writeFileSync(dbPath, "");
 		const store = new MemoryStore(dbPath);
 		try {


### PR DESCRIPTION
## Description
Move schema bootstrap into `connect()` so fresh or empty databases are safe for raw callers by default instead of relying on scattered `ensureSchemaBootstrapped()` call-site guards.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm exec vitest run --project core packages/core/src/db.test.ts packages/core/src/maintenance.test.ts packages/core/src/coordinator-actions.test.ts packages/core/src/sync-retention-runner.test.ts packages/core/src/dedup-key-backfill.test.ts packages/core/src/vector-migration.test.ts packages/core/src/extraction-replay.test.ts packages/core/src/extraction-eval.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] TypeScript build passes (`pnpm --filter @codemem/core run typecheck`)

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
