### PR TITLE
fix(sync): skip re-embed for metadata-only updates

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -198,22 +198,26 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 	migrateLegacyDbPath(dbPath);
 	mkdirSync(dirname(dbPath), { recursive: true });
 	const db = new Database(dbPath);
+	try {
+		// Match Python's connect() pragmas exactly
+		db.pragma("foreign_keys = ON");
+		db.pragma("busy_timeout = 5000");
 
-	// Match Python's connect() pragmas exactly
-	db.pragma("foreign_keys = ON");
-	db.pragma("busy_timeout = 5000");
+		const journalMode = db.pragma("journal_mode = WAL", { simple: true }) as string;
+		if (journalMode.toLowerCase() !== "wal") {
+			console.warn(
+				`Failed to enable WAL mode (got ${journalMode}). Concurrent access may not work correctly.`,
+			);
+		}
 
-	const journalMode = db.pragma("journal_mode = WAL", { simple: true }) as string;
-	if (journalMode.toLowerCase() !== "wal") {
-		console.warn(
-			`Failed to enable WAL mode (got ${journalMode}). Concurrent access may not work correctly.`,
-		);
+		db.pragma("synchronous = NORMAL");
+		ensureSchemaBootstrapped(db);
+
+		return db;
+	} catch (error) {
+		db.close();
+		throw error;
 	}
-
-	db.pragma("synchronous = NORMAL");
-	ensureSchemaBootstrapped(db);
-
-	return db;
 }
 
 function hasPlannerStats(db: DatabaseType): boolean {

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1796,6 +1796,97 @@ describe("applyReplicationOps", () => {
 		expect(mem.title).toBe("Updated title");
 		expect(mem.tags_text).toBe("existing-tag");
 	});
+
+	it("does not queue vector re-embed for metadata-only updates", () => {
+		const sessionId = insertTestSession(db);
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, visibility, created_at, updated_at, import_key, rev, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Stable title",
+			"stable body",
+			"private",
+			"2026-01-01T00:00:00Z",
+			"2026-01-01T00:00:00Z",
+			"key:metadata-only",
+			1,
+			toJson({ clock_device_id: "dev-remote" }),
+		);
+
+		const op = makeReplicationOp({
+			entity_id: "key:metadata-only",
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Stable title",
+				body_text: "stable body",
+				visibility: "shared",
+				updated_at: "2026-01-02T00:00:00Z",
+			}),
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+		expect(result.vectorWork.upsertMemoryIds).toEqual([]);
+		expect(result.vectorWork.deleteMemoryIds).toEqual([]);
+
+		const mem = db
+			.prepare("SELECT visibility FROM memory_items WHERE import_key = ?")
+			.get("key:metadata-only") as { visibility: string };
+		expect(mem.visibility).toBe("shared");
+	});
+
+	it("queues vector re-embed when a metadata-only update reactivates a deleted memory", () => {
+		const sessionId = insertTestSession(db);
+		const deletedAt = "2026-01-01T00:00:00Z";
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, active, deleted_at, created_at, updated_at, import_key, rev, metadata_json)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.run(
+				sessionId,
+				"discovery",
+				"Stable title",
+				"stable body",
+				0,
+				deletedAt,
+				deletedAt,
+				deletedAt,
+				"key:undelete",
+				1,
+				toJson({ clock_device_id: "dev-remote" }),
+			);
+		const memoryId = Number(info.lastInsertRowid);
+
+		const op = makeReplicationOp({
+			entity_id: "key:undelete",
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Stable title",
+				body_text: "stable body",
+				active: 1,
+				deleted_at: null,
+				updated_at: "2026-01-02T00:00:00Z",
+			}),
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+		expect(result.vectorWork.upsertMemoryIds).toEqual([memoryId]);
+		expect(result.vectorWork.deleteMemoryIds).toEqual([]);
+
+		const mem = db
+			.prepare("SELECT active, deleted_at FROM memory_items WHERE import_key = ?")
+			.get("key:undelete") as { active: number; deleted_at: string | null };
+		expect(mem.active).toBe(1);
+		expect(mem.deleted_at).toBeNull();
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -103,9 +103,18 @@ interface MemoryPayload {
 	user_prompt_id: number | null;
 	prompt_number: number | null;
 	deleted_at: string | null;
+	has_deleted_at: boolean;
 	rev: number;
 	import_key: string | null;
 	project?: string | null;
+}
+
+function resolveReplicatedTextUpdate(
+	nextValue: string | null | undefined,
+	currentValue: string | null,
+): string {
+	if (nextValue == null) return currentValue ?? "";
+	return nextValue;
 }
 
 function asNumberOrNull(value: unknown): number | null {
@@ -167,6 +176,7 @@ function parseMemoryPayload(op: ReplicationOp, errors: string[]): MemoryPayload 
 		user_prompt_id: asNumberOrNull(raw.user_prompt_id),
 		prompt_number: asNumberOrNull(raw.prompt_number),
 		deleted_at: asStringOrNull(raw.deleted_at),
+		has_deleted_at: Object.hasOwn(raw, "deleted_at"),
 		rev: asNumberOrNull(raw.rev) ?? 0,
 		import_key: asStringOrNull(raw.import_key),
 		project: asStringOrNull(raw.project),
@@ -1709,6 +1719,7 @@ function buildPayloadFromMemoryRow(row: MemoryItemRow): MemoryPayload {
 		user_prompt_id: row.user_prompt_id ?? null,
 		prompt_number: row.prompt_number ?? null,
 		deleted_at: row.deleted_at ?? null,
+		has_deleted_at: row.deleted_at != null,
 		rev: row.rev ?? 0,
 		import_key: row.import_key ?? null,
 	};
@@ -1778,6 +1789,10 @@ export function applyReplicationOps(
 							id: schema.memoryItems.id,
 							rev: schema.memoryItems.rev,
 							updated_at: schema.memoryItems.updated_at,
+							title: schema.memoryItems.title,
+							body_text: schema.memoryItems.body_text,
+							active: schema.memoryItems.active,
+							deleted_at: schema.memoryItems.deleted_at,
 							metadata_json: schema.memoryItems.metadata_json,
 						})
 						.from(schema.memoryItems)
@@ -1804,9 +1819,22 @@ export function applyReplicationOps(
 						const payload = parseMemoryPayload(op, result.errors);
 						if (!payload) continue;
 						const metaObj = mergePayloadMetadata(payload.metadata_json, op.clock_device_id);
+						const nextTitle = resolveReplicatedTextUpdate(payload.title, memRow.title);
+						const nextBodyText = resolveReplicatedTextUpdate(payload.body_text, memRow.body_text);
+						const contentChanged =
+							nextTitle !== (memRow.title ?? "") || nextBodyText !== (memRow.body_text ?? "");
+						const wasInactive = Number(memRow.active ?? 1) === 0 || memRow.deleted_at != null;
+						const nextActive =
+							payload.active != null ? Number(payload.active) : Number(memRow.active ?? 1);
+						const nextDeletedAt = payload.has_deleted_at
+							? payload.deleted_at
+							: (memRow.deleted_at ?? null);
+						const becomesActive = nextActive !== 0 && nextDeletedAt == null;
 						const shouldDeleteVectors =
 							payload.deleted_at != null ||
 							(payload.active != null && Number(payload.active) === 0);
+						const shouldQueueVectorUpsert =
+							!shouldDeleteVectors && (contentChanged || (wasInactive && becomesActive));
 
 						d.update(schema.memoryItems)
 							.set({
@@ -1840,7 +1868,7 @@ export function applyReplicationOps(
 							.where(eq(schema.memoryItems.import_key, importKey))
 							.run();
 						if (shouldDeleteVectors) queueVectorDelete(Number(memRow.id));
-						else queueVectorUpsert(Number(memRow.id));
+						else if (shouldQueueVectorUpsert) queueVectorUpsert(Number(memRow.id));
 					} else {
 						// Insert new memory item — skip if malformed
 						const payload = parseMemoryPayload(op, result.errors);

--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -338,6 +338,65 @@ describe("vector migration", () => {
 		}
 	});
 
+	it("prunes stale current-model vectors while replaying queued incremental upserts", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "Incremental memory", "Fresh body");
+		db.exec(`
+			INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model)
+			VALUES (
+				vec_f32('${JSON.stringify(Array.from(new Float32Array(384)))}'),
+				1,
+				0,
+				'stale-current-hash',
+				'test-model'
+			)
+		`);
+
+		queueVectorBackfillForIncrementalSync(db, {
+			upsertMemoryIds: [1],
+			deleteMemoryIds: [],
+		});
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		const rows = db
+			.prepare(
+				"SELECT content_hash FROM memory_vectors WHERE memory_id = ? AND model = ? ORDER BY content_hash",
+			)
+			.all(1, "test-model") as Array<{ content_hash: string }>;
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.content_hash).not.toBe("stale-current-hash");
+	});
+
+	it("preserves newly queued incremental ids while replaying queued work", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "One", "Body one");
+		seedMemory(db, 2, sessionId, "Two", "Body two");
+		seedVector(db, 2, "test-model");
+
+		queueVectorBackfillForIncrementalSync(db, {
+			upsertMemoryIds: [1],
+			deleteMemoryIds: [],
+		});
+		vi.mocked(embeddings.embedTexts).mockImplementationOnce(async () => {
+			queueVectorBackfillForIncrementalSync(db, {
+				upsertMemoryIds: [],
+				deleteMemoryIds: [2],
+			});
+			return [new Float32Array(384)];
+		});
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+
+		const runningJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(runningJob).toMatchObject({
+			status: "running",
+			metadata: {
+				pending_delete_memory_ids: [2],
+			},
+		});
+	});
+
 	it("marks a queued bootstrap backfill as failed when the embedding client is unavailable", async () => {
 		setSyncResetState(db, {
 			generation: 1,

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -9,7 +9,7 @@ import {
 	updateMaintenanceJob,
 } from "./maintenance-jobs.js";
 import type { ReplicationVectorWork } from "./sync-replication.js";
-import { backfillVectors } from "./vectors.js";
+import { backfillVectors, pruneStaleCurrentModelVectors } from "./vectors.js";
 
 export const VECTOR_MODEL_MIGRATION_JOB = "vector_model_migration";
 const SYNC_BOOTSTRAP_TRIGGER = "sync_bootstrap";
@@ -75,6 +75,15 @@ function deleteVectorsForMemoryIds(db: SqliteDatabase, memoryIds: number[]): voi
 	db.prepare(`DELETE FROM memory_vectors WHERE memory_id IN (${placeholders})`).run(...memoryIds);
 }
 
+function sameQueuedSyncMemoryIds(a: MigrationMetadata, b: MigrationMetadata): boolean {
+	return (
+		JSON.stringify(metadataMemoryIds(a.pending_upsert_memory_ids)) ===
+			JSON.stringify(metadataMemoryIds(b.pending_upsert_memory_ids)) &&
+		JSON.stringify(metadataMemoryIds(a.pending_delete_memory_ids)) ===
+			JSON.stringify(metadataMemoryIds(b.pending_delete_memory_ids))
+	);
+}
+
 export function queueVectorBackfillForIncrementalSync(
 	db: SqliteDatabase,
 	work: ReplicationVectorWork,
@@ -128,6 +137,7 @@ export function queueVectorBackfillForIncrementalSync(
 async function runQueuedSyncVectorWork(
 	db: SqliteDatabase,
 	job: NonNullable<ReturnType<typeof getMaintenanceJob>>,
+	targetModel: string,
 	batchSize: number,
 ): Promise<{ completed: boolean; metadata: MigrationMetadata }> {
 	const metadata = (job.metadata ?? {}) as MigrationMetadata;
@@ -143,13 +153,25 @@ async function runQueuedSyncVectorWork(
 	const batchUpsertMemoryIds = pendingUpsertMemoryIds.slice(0, batchSize);
 	if (batchUpsertMemoryIds.length > 0) {
 		await backfillVectors(db, { memoryIds: batchUpsertMemoryIds });
+		pruneStaleCurrentModelVectors(db, batchUpsertMemoryIds, targetModel);
 	}
 
-	const nextMetadata: MigrationMetadata = {
+	const drainedMetadata: MigrationMetadata = {
 		...metadata,
 		pending_delete_memory_ids: [],
 		pending_upsert_memory_ids: pendingUpsertMemoryIds.slice(batchUpsertMemoryIds.length),
 	};
+	const latestJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+	const latestMetadata = ((latestJob?.metadata ?? {}) as MigrationMetadata) ?? {};
+	const nextMetadata = sameQueuedSyncMemoryIds(latestMetadata, metadata)
+		? drainedMetadata
+		: {
+				...latestMetadata,
+				...mergeQueuedSyncMemoryIds(latestMetadata, {
+					upsertMemoryIds: metadataMemoryIds(drainedMetadata.pending_upsert_memory_ids),
+					deleteMemoryIds: metadataMemoryIds(drainedMetadata.pending_delete_memory_ids),
+				}),
+			};
 	const remainingWorkCount =
 		metadataMemoryIds(nextMetadata.pending_delete_memory_ids).length +
 		metadataMemoryIds(nextMetadata.pending_upsert_memory_ids).length;
@@ -304,8 +326,22 @@ export async function runVectorMigrationPass(
 	const targetModel = client.model;
 	const effectiveBatchSize = Math.max(1, options.batchSize ?? 50);
 	if (existingJob) {
-		const queuedSyncWork = await runQueuedSyncVectorWork(db, existingJob, effectiveBatchSize);
+		const queuedSyncWork = await runQueuedSyncVectorWork(
+			db,
+			existingJob,
+			targetModel,
+			effectiveBatchSize,
+		);
 		if (queuedSyncWork.completed) {
+			return;
+		}
+		const queuedSyncRemainingWork =
+			metadataMemoryIds(queuedSyncWork.metadata.pending_delete_memory_ids).length +
+			metadataMemoryIds(queuedSyncWork.metadata.pending_upsert_memory_ids).length;
+		if (
+			(queuedSyncWork.metadata.trigger ?? SYNC_INCREMENTAL_TRIGGER) === SYNC_INCREMENTAL_TRIGGER &&
+			queuedSyncRemainingWork > 0
+		) {
 			return;
 		}
 		existingJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -301,7 +301,11 @@ function deleteVectorsForMemoryIds(db: Database, memoryIds: number[]): number {
 	return result.changes;
 }
 
-function pruneStaleCurrentModelVectors(db: Database, memoryIds: number[], model: string): number {
+export function pruneStaleCurrentModelVectors(
+	db: Database,
+	memoryIds: number[],
+	model: string,
+): number {
 	if (memoryIds.length === 0) return 0;
 	const placeholders = memoryIds.map(() => "?").join(", ");
 	const rows = db


### PR DESCRIPTION
## Description
Avoid queueing receiver-side vector re-embedding for metadata-only inbound sync updates by comparing effective title/body content before scheduling vector work.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/sync-replication.test.ts packages/core/src/sync-pass.test.ts packages/core/src/vector-migration.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] TypeScript build passes (`pnpm --filter @codemem/core run typecheck`)

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
