### PR TITLE
chore(core): remove bootstrap redundancy and harden sync fallback

### DIFF
--- a/packages/core/src/export-import.ts
+++ b/packages/core/src/export-import.ts
@@ -12,7 +12,6 @@ import {
 import { expandUserPath } from "./observer-config.js";
 import { projectColumnClause, resolveProject as resolveProjectName } from "./project.js";
 import * as schema from "./schema.js";
-import { ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 
 type JsonObject = Record<string, unknown>;
 type MemoryInsert = typeof schema.memoryItems.$inferInsert;
@@ -206,9 +205,6 @@ function fetchBySessionIds(
 export function exportMemories(opts: ExportOptions = {}): ExportPayload {
 	const db = connect(resolveDbPath(opts.dbPath));
 	try {
-		// Auto-bootstrap fresh databases so `codemem export-memories` does not
-		// crash on a brand-new install (empty export is a valid outcome).
-		ensureSchemaBootstrapped(db);
 		assertSchemaReady(db);
 		const resolvedProject = resolveExportProject(opts);
 		const filters: JsonObject = {};
@@ -443,9 +439,6 @@ export function importMemories(payload: ExportPayload, opts: ImportOptions = {})
 
 	const db = connect(resolveDbPath(opts.dbPath));
 	try {
-		// Auto-bootstrap fresh databases so restoring a backup into a fresh
-		// install works without an explicit `codemem db init` first.
-		ensureSchemaBootstrapped(db);
 		assertSchemaReady(db);
 		const d = drizzle(db, { schema });
 		return db.transaction(() => {

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -23,7 +23,7 @@ import { loadObserverConfig, ObserverClient } from "./observer-client.js";
 import { buildMemoryPack } from "./pack.js";
 import { projectClause } from "./project.js";
 import * as schema from "./schema.js";
-import { bootstrapSchema, ensureSchemaBootstrapped } from "./schema-bootstrap.js";
+import { bootstrapSchema } from "./schema-bootstrap.js";
 import { MemoryStore } from "./store.js";
 import { canonicalMemoryKind, getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
 
@@ -282,13 +282,6 @@ function withDb<T>(dbPath: string | undefined, fn: (db: Database, resolvedPath: 
 	const resolvedPath = resolveDbPath(dbPath);
 	const db = connect(resolvedPath);
 	try {
-		// Auto-bootstrap fresh databases before asserting readiness. This
-		// helper backs several exported maintenance functions that are hit
-		// from CLI commands (`db vacuum`, `db raw-events-status`,
-		// `db raw-events-retry`, `db raw-events-gate`, `memory roles`,
-		// `memory relink-report`), any of which a user can run before
-		// `codemem db init`.
-		ensureSchemaBootstrapped(db);
 		assertSchemaReady(db);
 		return fn(db, resolvedPath);
 	} finally {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -38,7 +38,6 @@ import {
 	buildMemoryPackTraceAsync,
 } from "./pack.js";
 import * as schema from "./schema.js";
-import { ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 import {
 	type ExplainOptions,
 	explain as explainFn,
@@ -216,12 +215,6 @@ export class MemoryStore {
 		this.db = connect(this.dbPath);
 		try {
 			loadSqliteVec(this.db);
-			// Auto-bootstrap fresh databases: if the file is empty or has no
-			// schema yet, run the full schema DDL before asserting readiness.
-			// This makes `new MemoryStore(...)` safe to call from any entry
-			// point (mcp-server, claude-hook-ingest, CLI commands) without a
-			// prior explicit `codemem db init`.
-			ensureSchemaBootstrapped(this.db);
 			assertSchemaReady(this.db);
 			ensureAdditiveSchemaCompatibility(this.db);
 			ensurePlannerStats(this.db);

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -16,7 +16,9 @@ import {
 } from "./sync-pass.js";
 import * as syncReplication from "./sync-replication.js";
 import { initTestSchema } from "./test-utils.js";
+import * as vectorMigration from "./vector-migration.js";
 import { VECTOR_MODEL_MIGRATION_JOB } from "./vector-migration.js";
+import * as vectors from "./vectors.js";
 
 // ---------------------------------------------------------------------------
 // Schema helper — adds sync tables not in base test schema
@@ -230,6 +232,85 @@ describe("syncOnce", () => {
 		});
 		expect(syncReplication.getReplicationCursor(db, "peer-1")[0]).toBe(
 			"2026-01-01T00:00:00Z|remote-op-1",
+		);
+	});
+
+	it("falls back to immediate vector maintenance when durable queueing throws", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "abc123", new Date().toISOString());
+		db.prepare(
+			"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+		).run("peer-1", "2025-12-31T00:00:00Z|local-op-0", null, new Date().toISOString());
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+		vi.spyOn(vectorMigration, "queueVectorBackfillForIncrementalSync").mockImplementation(() => {
+			throw new Error("queue write failed");
+		});
+		const fallbackSpy = vi
+			.spyOn(vectors, "bestEffortMaintainVectorsForSyncFallback")
+			.mockResolvedValue({ deleted: 0, inserted: 1, errors: [] });
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "abc123",
+					protocol_version: "2",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-1",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-1",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [
+						{
+							op_id: "remote-op-fallback",
+							entity_type: "memory_item",
+							entity_id: "key:sync-pass-fallback",
+							op_type: "upsert",
+							payload_json: JSON.stringify({
+								kind: "discovery",
+								title: "Remote title",
+								body_text: "Remote body",
+								active: 1,
+								created_at: "2026-01-01T00:00:00Z",
+								updated_at: "2026-01-01T00:00:00Z",
+							}),
+							clock_rev: 1,
+							clock_updated_at: "2026-01-01T00:00:00Z",
+							clock_device_id: "dev-remote",
+							device_id: "dev-remote",
+							created_at: "2026-01-01T00:00:00Z",
+						},
+					],
+					next_cursor: "2026-01-01T00:00:00Z|remote-op-fallback",
+					skipped: 0,
+				},
+			]);
+
+		const result = await syncOnce(db, "peer-1", ["http://127.0.0.1:9090"]);
+
+		if (!result.ok) {
+			throw new Error(`syncOnce failed: ${result.error ?? "unknown error"}`);
+		}
+		expect(result.ok).toBe(true);
+		expect(fallbackSpy).toHaveBeenCalledWith(
+			db,
+			expect.objectContaining({ upsertMemoryIds: [expect.any(Number)], deleteMemoryIds: [] }),
 		);
 	});
 });

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -28,6 +28,7 @@ import {
 } from "./sync-replication.js";
 import type { ReplicationOp, SyncResetRequired } from "./types.js";
 import { queueVectorBackfillForIncrementalSync } from "./vector-migration.js";
+import { bestEffortMaintainVectorsForSyncFallback } from "./vectors.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -615,7 +616,17 @@ export async function syncOnce(
 
 			// -- 3. Apply incoming ops to local entities --
 			const applied = applyReplicationOps(db, inboundOps, deviceId);
-			queueVectorBackfillForIncrementalSync(db, applied.vectorWork);
+			try {
+				queueVectorBackfillForIncrementalSync(db, applied.vectorWork);
+			} catch (queueError) {
+				const fallback = await bestEffortMaintainVectorsForSyncFallback(db, applied.vectorWork);
+				if (fallback.errors.length > 0) {
+					const details = fallback.errors.join("; ");
+					throw new Error(
+						`vector catch-up queue failed: ${queueError instanceof Error ? queueError.message : String(queueError)}; fallback failed: ${details}`,
+					);
+				}
+			}
 
 			const inboundCursorCandidate = inboundCursor || asOptionalCursor(getPayload.next_cursor);
 			if (cursorAdvances(lastApplied, inboundCursorCandidate)) {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -103,6 +103,9 @@ interface MemoryPayload {
 	user_prompt_id: number | null;
 	prompt_number: number | null;
 	deleted_at: string | null;
+	// Wire payloads use this as "sender explicitly included deleted_at" so we can
+	// distinguish a tombstone clear (`deleted_at: null`) from an omitted field.
+	// Row-derived payloads set it from current storage truth instead.
 	has_deleted_at: boolean;
 	rev: number;
 	import_key: string | null;

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -11,8 +11,8 @@ import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import {
 	backfillVectors,
+	bestEffortMaintainVectorsForSyncFallback,
 	getSemanticIndexDiagnostics,
-	maintainVectorsForReplicationApply,
 	resolveSemanticSearchModel,
 	semanticSearch,
 	storeVectors,
@@ -108,7 +108,7 @@ describe("vectors", () => {
 		});
 	});
 
-	it("runs best-effort replication vector maintenance without throwing on embedding failures", async () => {
+	it("runs best-effort sync fallback vector maintenance without throwing on embedding failures", async () => {
 		const sessionId = insertTestSession(db);
 		const now = new Date().toISOString();
 		const info = db
@@ -122,7 +122,7 @@ describe("vectors", () => {
 
 		vi.mocked(embeddings.embedTexts).mockRejectedValue(new Error("embedding unavailable"));
 
-		const result = await maintainVectorsForReplicationApply(db, {
+		const result = await bestEffortMaintainVectorsForSyncFallback(db, {
 			upsertMemoryIds: [memoryId],
 			deleteMemoryIds: [],
 		});
@@ -325,7 +325,7 @@ describe("vectors", () => {
 			)
 		`);
 
-		const result = await maintainVectorsForReplicationApply(db, {
+		const result = await bestEffortMaintainVectorsForSyncFallback(db, {
 			upsertMemoryIds: [],
 			deleteMemoryIds: [321],
 		});
@@ -362,7 +362,7 @@ describe("vectors", () => {
 		`);
 		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
 
-		const result = await maintainVectorsForReplicationApply(db, {
+		const result = await bestEffortMaintainVectorsForSyncFallback(db, {
 			upsertMemoryIds: [memoryId],
 			deleteMemoryIds: [],
 		});

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -337,7 +337,12 @@ export function pruneStaleCurrentModelVectors(
 	return deleted;
 }
 
-export async function maintainVectorsForReplicationApply(
+/**
+ * Fallback-only sync maintenance path used when durable incremental queueing
+ * fails after inbound replication has already been applied. New sync code
+ * should prefer queueVectorBackfillForIncrementalSync so work survives restart.
+ */
+export async function bestEffortMaintainVectorsForSyncFallback(
 	db: Database,
 	work: ReplicationVectorWork,
 ): Promise<ReplicationVectorMaintenanceResult> {


### PR DESCRIPTION
## Description
Remove now-redundant bootstrap calls after moving the invariant into `connect()`, and harden incremental sync vector catch-up so a durable-queueing failure falls back to immediate best-effort maintenance instead of silently stranding vectors.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Tests pass locally (`pnpm exec vitest run packages/core/src/sync-pass.test.ts packages/core/src/vector-migration.test.ts packages/core/src/vectors.test.ts packages/core/src/db.test.ts packages/core/src/store.test.ts packages/core/src/maintenance.test.ts`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected
- [x] TypeScript build passes (`pnpm --filter @codemem/core run typecheck`)

## Checklist

- [x] Code follows project style (staged-file Biome hook passed during `gt create`)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
