### PR TITLE
fix(core): normalize Claude Code raw events before buildSessionContext

### DIFF
--- a/packages/core/src/apply-patch.test.ts
+++ b/packages/core/src/apply-patch.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";
+
+describe("MUTATING_TOOL_NAMES", () => {
+	it("includes OpenCode and Claude Code file-mutation tools", () => {
+		expect(MUTATING_TOOL_NAMES.has("edit")).toBe(true);
+		expect(MUTATING_TOOL_NAMES.has("write")).toBe(true);
+		expect(MUTATING_TOOL_NAMES.has("multiedit")).toBe(true);
+		expect(MUTATING_TOOL_NAMES.has("notebookedit")).toBe(true);
+		expect(MUTATING_TOOL_NAMES.has("apply_patch")).toBe(true);
+	});
+
+	it("does not include read/search tools", () => {
+		expect(MUTATING_TOOL_NAMES.has("read")).toBe(false);
+		expect(MUTATING_TOOL_NAMES.has("grep")).toBe(false);
+		expect(MUTATING_TOOL_NAMES.has("glob")).toBe(false);
+	});
+});
+
+describe("extractApplyPatchPaths", () => {
+	it("returns empty for empty input", () => {
+		expect(extractApplyPatchPaths("")).toEqual([]);
+	});
+
+	it("returns empty for completely non-patch input", () => {
+		expect(extractApplyPatchPaths("not a patch at all\njust prose")).toEqual([]);
+	});
+
+	it("extracts Add/Update/Delete paths in order", () => {
+		const patch = [
+			"*** Begin Patch",
+			"*** Add File: src/new.ts",
+			"+export const x = 1;",
+			"*** Update File: src/existing.ts",
+			"@@ -1 +1 @@",
+			"-export const y = 1;",
+			"+export const y = 2;",
+			"*** Delete File: src/old.ts",
+			"*** End Patch",
+		].join("\n");
+		expect(extractApplyPatchPaths(patch)).toEqual(["src/new.ts", "src/existing.ts", "src/old.ts"]);
+	});
+
+	it("preserves first-seen order and deduplicates repeats", () => {
+		const patch = [
+			"*** Begin Patch",
+			"*** Add File: z.ts",
+			"*** Update File: a.ts",
+			"*** Add File: z.ts",
+			"*** End Patch",
+		].join("\n");
+		expect(extractApplyPatchPaths(patch)).toEqual(["z.ts", "a.ts"]);
+	});
+
+	it("handles CRLF line endings", () => {
+		const patch = "*** Begin Patch\r\n*** Add File: win.ts\r\n+x\r\n*** End Patch\r\n";
+		expect(extractApplyPatchPaths(patch)).toEqual(["win.ts"]);
+	});
+
+	it("ignores non-matching marker-like lines", () => {
+		const patch = [
+			"*** Begin Patch",
+			"*** Add File: real.ts",
+			"+content",
+			"*** NOT A VALID MARKER: fake.ts",
+			"*** End Patch",
+		].join("\n");
+		expect(extractApplyPatchPaths(patch)).toEqual(["real.ts"]);
+	});
+
+	it("does not match marker lines with leading whitespace", () => {
+		// The patch format is strict: markers MUST start at column 0. A leading
+		// space means the line is part of diff context, not a real marker.
+		const patch = [
+			"*** Begin Patch",
+			" *** Add File: indented.ts",
+			"*** Add File: real.ts",
+			"*** End Patch",
+		].join("\n");
+		expect(extractApplyPatchPaths(patch)).toEqual(["real.ts"]);
+	});
+
+	it("returns empty when the patch has begin/end markers but no file entries", () => {
+		expect(extractApplyPatchPaths("*** Begin Patch\n*** End Patch")).toEqual([]);
+	});
+});

--- a/packages/core/src/apply-patch.ts
+++ b/packages/core/src/apply-patch.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared helpers for the `apply_patch` tool and Claude Code mutating tools.
+ *
+ * Both the CLI hook session-state tracker and the core raw-event flush path
+ * need to (a) recognize which tool names represent file-mutation tools and
+ * (b) parse paths out of an `apply_patch` patch text. Keeping one copy here
+ * avoids drift between the two code paths.
+ *
+ * Only Add/Update/Delete markers are supported, matching the plugin-side
+ * helper in `packages/opencode-plugin/.opencode/plugins/codemem.js`.
+ */
+
+/**
+ * Tool names (lowercased) that mutate files.
+ *
+ * `apply_patch` is the OpenCode primary mutation tool; `edit`, `write`,
+ * `multiedit`, and `notebookedit` are Claude Code's mutation tools. The
+ * tool name is compared after lowercasing the raw payload value.
+ */
+export const MUTATING_TOOL_NAMES = new Set<string>([
+	"edit",
+	"write",
+	"multiedit",
+	"notebookedit",
+	"apply_patch",
+]);
+
+/**
+ * Extract file paths mentioned in an `apply_patch` patchText.
+ *
+ * The `apply_patch` tool encodes paths inline using the
+ * `*** Add File: <path>` / `*** Update File: <path>` /
+ * `*** Delete File: <path>` markers rather than a dedicated `filePath` arg.
+ * This parser mirrors `extractApplyPatchPaths` in the OpenCode plugin so the
+ * plugin's live context tracking and the core session-context rebuild agree.
+ *
+ * Returns paths in first-seen order, deduplicated. Handles both LF and CRLF
+ * line endings. Silently ignores empty / non-patch input.
+ */
+export function extractApplyPatchPaths(patchText: string): string[] {
+	if (!patchText) return [];
+	const seen = new Set<string>();
+	const paths: string[] = [];
+	for (const rawLine of patchText.split(/\r?\n/)) {
+		const match = rawLine.match(/^\*\*\* (?:Update|Add|Delete) File: (.+)$/);
+		if (!match) continue;
+		const path = (match[1] ?? "").trim();
+		if (!path || seen.has(path)) continue;
+		seen.add(path);
+		paths.push(path);
+	}
+	return paths;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@
 export const VERSION = "0.25.3";
 
 export * as Api from "./api-types.js";
+export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";
 export type { CreateBetterSqliteCoordinatorAppOptions } from "./better-sqlite-coordinator-runtime.js";
 export { createBetterSqliteCoordinatorApp } from "./better-sqlite-coordinator-runtime.js";
 export type { ClaudeHookAdapterEvent, ClaudeHookRawEventEnvelope } from "./claude-hooks.js";
@@ -197,6 +198,7 @@ export {
 	firstSentence,
 	isTrivialRequest,
 	normalizeAdapterEvents,
+	normalizeEventsForSessionContext,
 	normalizeRequestText,
 	TRIVIAL_REQUESTS,
 } from "./ingest-transcript.js";

--- a/packages/core/src/ingest-transcript.ts
+++ b/packages/core/src/ingest-transcript.ts
@@ -5,6 +5,7 @@
  * from codemem/plugin_ingest.py.
  */
 
+import { extractAdapterEvent, projectAdapterToolEvent } from "./ingest-events.js";
 import { stripPrivate } from "./ingest-sanitize.js";
 import type { ParsedSummary } from "./ingest-types.js";
 
@@ -157,6 +158,60 @@ export function extractPrompts(
 		});
 	}
 	return prompts;
+}
+
+/**
+ * Normalize raw events (including adapter-enveloped Claude Code hook events)
+ * into the flat `user_prompt` / `tool.execute.after` shapes that
+ * buildSessionContext() scans for.
+ *
+ * Preserves `timestamp_wall_ms` on each resulting event so that durationMs
+ * continues to be computed correctly.
+ *
+ * This complements `normalizeAdapterEvents`, which targets the
+ * prompt/assistant side. `normalizeEventsForSessionContext` additionally
+ * projects adapter tool_result events into flat `tool.execute.after`
+ * entries via `projectAdapterToolEvent`, which is what
+ * `buildSessionContext` needs to count tools and extract file paths.
+ */
+export function normalizeEventsForSessionContext(
+	events: Record<string, unknown>[],
+): Record<string, unknown>[] {
+	const normalized: Record<string, unknown>[] = [];
+	for (const event of events) {
+		const wallMs = event.timestamp_wall_ms;
+		const adapter = extractAdapterEvent(event);
+		if (adapter) {
+			const adapterType = String(adapter.event_type ?? "");
+			if (adapterType === "prompt") {
+				const payload = adapter.payload as Record<string, unknown> | undefined;
+				const text = String(payload?.text ?? "").trim();
+				if (text) {
+					normalized.push({
+						type: "user_prompt",
+						prompt_text: text,
+						timestamp: adapter.ts ?? null,
+						timestamp_wall_ms: wallMs,
+					});
+					continue;
+				}
+			} else if (adapterType === "tool_result") {
+				const projected = projectAdapterToolEvent(adapter, event);
+				if (projected) {
+					projected.timestamp_wall_ms = wallMs;
+					normalized.push(projected);
+					continue;
+				}
+			}
+			// Other adapter event types (assistant, session_*, error, tool_call)
+			// are not relevant to buildSessionContext. Keep the original so that
+			// durationMs sees the wall timestamp.
+			normalized.push(event);
+			continue;
+		}
+		normalized.push(event);
+	}
+	return normalized;
 }
 
 /**

--- a/packages/core/src/raw-event-flush.test.ts
+++ b/packages/core/src/raw-event-flush.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildRawEventEnvelopeFromHook } from "./claude-hooks.js";
 import { connect } from "./db.js";
 import type { IngestOptions } from "./ingest-pipeline.js";
 import { flushRawEvents } from "./raw-event-flush.js";
@@ -284,5 +285,114 @@ describe("flushRawEvents max retry", () => {
 			)
 			.get() as { count: number };
 		expect(memorySessionCounts.count).toBe(1);
+	});
+
+	it("populates session context fields from Claude Code adapter-enveloped raw events", async () => {
+		const sessionId = "sess-claude-ctx";
+
+		// Seed Claude Code hook events via the same envelope path the viewer/CLI
+		// use. These produce `claude.hook` raw events with an `_adapter` payload.
+		const hookEvents: Record<string, unknown>[] = [
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: sessionId,
+				prompt: "Investigate the flush bug",
+				cwd: "/tmp/repo",
+				ts: "2026-03-04T10:00:00Z",
+			},
+			{
+				hook_event_name: "PostToolUse",
+				session_id: sessionId,
+				tool_use_id: "toolu_1",
+				tool_name: "Read",
+				tool_input: { file_path: "/tmp/repo/src/flush.ts" },
+				tool_response: "file contents",
+				cwd: "/tmp/repo",
+				ts: "2026-03-04T10:00:05Z",
+			},
+			{
+				hook_event_name: "PostToolUse",
+				session_id: sessionId,
+				tool_use_id: "toolu_2",
+				tool_name: "Edit",
+				tool_input: { file_path: "/tmp/repo/src/flush.ts" },
+				tool_response: "edited",
+				cwd: "/tmp/repo",
+				ts: "2026-03-04T10:00:10Z",
+			},
+		];
+
+		for (const hook of hookEvents) {
+			const envelope = buildRawEventEnvelopeFromHook(hook);
+			expect(envelope).not.toBeNull();
+			if (envelope == null) throw new Error("envelope");
+			store.recordRawEvent({
+				opencodeSessionId: envelope.opencode_session_id,
+				source: envelope.source,
+				eventId: envelope.event_id,
+				eventType: envelope.event_type,
+				payload: envelope.payload,
+				tsWallMs: envelope.ts_wall_ms,
+			});
+		}
+
+		const summaryResponder = {
+			observe: async () => ({
+				raw: `<summary>
+					<request>Investigate the flush bug</request>
+					<investigated>raw-event-flush.ts session context builder</investigated>
+					<learned>Claude Code events need normalization before scanning</learned>
+					<completed>Added normalization step</completed>
+					<next_steps>Add regression test</next_steps>
+					<notes></notes>
+				</summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const ingestOpts = { observer: summaryResponder } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "claude",
+			cwd: "/tmp/repo",
+			project: "repo",
+			startedAt: "2026-03-04T10:00:00Z",
+			maxEvents: null,
+		};
+
+		const result = await flushRawEvents(store, ingestOpts, flushOpts);
+		expect(result.flushed).toBeGreaterThan(0);
+		expect(result.updatedState).toBe(1);
+
+		// The persisted session metadata is the authoritative regression check:
+		// before the fix these fields were all absent because Claude Code raw
+		// events (type="claude.hook") never populated buildSessionContext's
+		// counts or path lists.
+		const row = store.db
+			.prepare(
+				"SELECT metadata_json FROM sessions WHERE id = (SELECT session_id FROM opencode_sessions WHERE stream_id = ?)",
+			)
+			.get(sessionId) as { metadata_json: string } | undefined;
+		expect(row).toBeDefined();
+		const meta = JSON.parse(row?.metadata_json ?? "{}") as {
+			session_context?: {
+				promptCount?: number;
+				toolCount?: number;
+				firstPrompt?: string;
+				filesRead?: string[];
+			};
+		};
+		expect(meta.session_context?.promptCount).toBe(1);
+		expect(meta.session_context?.toolCount).toBe(2);
+		expect(meta.session_context?.firstPrompt).toBe("Investigate the flush bug");
+		expect(meta.session_context?.filesRead).toEqual(["/tmp/repo/src/flush.ts"]);
 	});
 });

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -10,7 +10,7 @@
 
 import { extractAdapterEvent, projectAdapterToolEvent } from "./ingest-events.js";
 import { type IngestOptions, ingest } from "./ingest-pipeline.js";
-import { normalizeAdapterEvents } from "./ingest-transcript.js";
+import { normalizeAdapterEvents, normalizeEventsForSessionContext } from "./ingest-transcript.js";
 import type { IngestPayload, SessionContext } from "./ingest-types.js";
 import { ObserverAuthError } from "./observer-client.js";
 import type { MemoryStore } from "./store.js";
@@ -113,8 +113,11 @@ export function buildSessionContext(events: Record<string, unknown>[]): SessionC
 		const tool = String(e.tool ?? "").toLowerCase();
 		const args = e.args;
 		if (args == null || typeof args !== "object") continue;
-		const filePath =
-			(args as Record<string, unknown>).filePath ?? (args as Record<string, unknown>).path;
+		const argsObj = args as Record<string, unknown>;
+		// Support both OpenCode-style camelCase (`filePath`) and Claude Code-style
+		// snake_case (`file_path`) tool input keys. Claude Code hook payloads use
+		// `file_path` verbatim from the Claude Code schema.
+		const filePath = argsObj.filePath ?? argsObj.file_path ?? argsObj.path;
 		if (typeof filePath !== "string" || !filePath) continue;
 		if (tool === "write" || tool === "edit") filesModified.add(filePath);
 		if (tool === "read") filesRead.add(filePath);
@@ -283,8 +286,12 @@ export async function flushRawEvents(
 		return { flushed: 0, updatedState: 0 };
 	}
 
-	// Build session context
-	const sessionContext: SessionContext = buildSessionContext(events);
+	// Build session context. Claude Code raw events arrive as `claude.hook`
+	// with an adapter envelope; normalize them to the flat user_prompt /
+	// tool.execute.after shapes before scanning so promptCount, toolCount,
+	// firstPrompt, filesRead, and filesModified are populated correctly.
+	const normalizedForContext = normalizeEventsForSessionContext(events);
+	const sessionContext: SessionContext = buildSessionContext(normalizedForContext);
 	sessionContext.opencodeSessionId = opencodeSessionId;
 	sessionContext.source = source;
 	sessionContext.streamId = opencodeSessionId;


### PR DESCRIPTION
## Description

Claude Code hook events arrive as `claude.hook` raw events with an `_adapter`
envelope, so `buildSessionContext` — which scans for flat `user_prompt` /
`tool.execute.after` shapes — silently produced zero prompts, zero tools, no
`firstPrompt`, and an empty `filesRead` for the entire Claude Code ingestion
path. Downstream, `classifySessionForInjection` always fell through to
`"working"` and summary suppression became a no-op for Claude Code sessions.

## Changes

1. **Normalize adapter-enveloped events before `buildSessionContext`.** The new
   helper `normalizeEventsForSessionContext` lives in `ingest-transcript.ts`
   next to the existing `normalizeAdapterEvents` helper — both project
   `_adapter` envelopes into the flat shapes the transcript/context builders
   scan for. `raw-event-flush.ts` imports it from there. `timestamp_wall_ms` is
   preserved on each projected event so `durationMs` stays correct.

2. **Accept `file_path` alongside `filePath` / `path` in `buildSessionContext`.**
   Claude Code hook payloads use the snake_case `file_path` verbatim from the
   Claude Code schema, so the existing camelCase lookup dropped every file
   path. This is intentionally included in this PR because it is part of the
   same "Claude Code events populate SessionContext correctly" fix — same
   call site, same symptom.

3. **Extract the shared `apply-patch.ts` helper module.** Adds
   `packages/core/src/apply-patch.ts` exporting `extractApplyPatchPaths` and
   `MUTATING_TOOL_NAMES`. This module is consumed by the follow-up PR in the
   stack that deduplicates the two pre-existing TypeScript copies of this
   helper in `packages/core` and `packages/cli`. Co-located unit tests cover
   CRLF input, leading-whitespace marker rejection, empty / non-patch input,
   dedup, and ordering.

## Testing

- [x] `pnpm run test` — all 70 files / 1246 tests green.
- [x] Added a regression test that seeds Claude Code hook payloads via
      `buildRawEventEnvelopeFromHook`, runs them through `flushRawEvents` with
      a minimal summary responder, and asserts `promptCount`, `toolCount`,
      `firstPrompt`, and `filesRead` are populated on the persisted session
      context. (Substring assertions on the observer prompt were dropped —
      the persisted metadata is the real regression surface.)
- [x] `pnpm run tsc` and `pnpm run lint` clean.

## Type of Change

- [ ] Feature (new functionality)
- [x] Bug fix (fixes an issue)
- [ ] Documentation (docs-only change)
- [x] Maintenance (extracts shared helper module)
- [ ] Testing (test-only changes)

## Checklist

- [x] Code follows project style (biome clean)
- [x] Self-review completed
- [ ] Documentation updated (not needed — internal pipeline fix)
- [x] No new warnings introduced