### PR TITLE
fix(core): populate filesModified from apply_patch tool events

### DIFF
--- a/packages/cli/src/commands/claude-hook-session-state.ts
+++ b/packages/cli/src/commands/claude-hook-session-state.ts
@@ -11,6 +11,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "@codemem/core";
 
 export type SessionState = {
 	first_prompt: string;
@@ -23,10 +24,6 @@ const MAX_FILES_MODIFIED = 64;
 const MAX_WORKING_SET_PATHS = 8;
 const MAX_QUERY_CHARS = 500;
 const MAX_QUERY_FILE_BASENAMES = 5;
-
-const MUTATING_TOOL_NAMES = new Set(["edit", "write", "multiedit", "notebookedit", "apply_patch"]);
-
-const APPLY_PATCH_PATH_PREFIXES = ["*** Add File: ", "*** Update File: ", "*** Delete File: "];
 
 export function defaultSessionState(): SessionState {
 	return {
@@ -122,19 +119,6 @@ export function clearSessionState(sessionId: string): void {
 	} catch {
 		// best-effort: failure to clear an unreachable file is non-fatal
 	}
-}
-
-function extractApplyPatchPaths(patchText: string): string[] {
-	const out: string[] = [];
-	for (const line of patchText.split("\n")) {
-		for (const prefix of APPLY_PATCH_PATH_PREFIXES) {
-			if (line.startsWith(prefix)) {
-				const path = line.slice(prefix.length).trim();
-				if (path) out.push(path);
-			}
-		}
-	}
-	return out;
 }
 
 export function extractModifiedPathsFromHook(payload: Record<string, unknown>): string[] {

--- a/packages/core/src/build-session-context.test.ts
+++ b/packages/core/src/build-session-context.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionContext } from "./raw-event-flush.js";
+
+describe("buildSessionContext — OpenCode file-mutation tools", () => {
+	it("extracts filesModified from apply_patch patchText (Add/Update/Delete)", () => {
+		const patchText = [
+			"*** Begin Patch",
+			"*** Add File: src/new.ts",
+			"+export const x = 1;",
+			"*** Update File: src/existing.ts",
+			"@@ -1,1 +1,1 @@",
+			"-export const y = 1;",
+			"+export const y = 2;",
+			"*** Delete File: src/old.ts",
+			"*** End Patch",
+		].join("\n");
+
+		const context = buildSessionContext([
+			{
+				type: "tool.execute.after",
+				tool: "apply_patch",
+				args: { patchText },
+				timestamp_wall_ms: 1_700_000_000_000,
+			},
+		]);
+
+		expect(context.filesModified).toEqual(["src/existing.ts", "src/new.ts", "src/old.ts"]);
+		expect(context.filesRead).toEqual([]);
+		expect(context.toolCount).toBe(1);
+	});
+
+	it("also accepts `patch` as an alternate patchText key", () => {
+		const patchText = "*** Begin Patch\n*** Add File: a.ts\n+x\n*** End Patch";
+		const context = buildSessionContext([
+			{
+				type: "tool.execute.after",
+				tool: "apply_patch",
+				args: { patch: patchText },
+				timestamp_wall_ms: 1,
+			},
+		]);
+		expect(context.filesModified).toEqual(["a.ts"]);
+	});
+
+	it("deduplicates paths across multiple apply_patch calls", () => {
+		const patchA = "*** Begin Patch\n*** Add File: shared.ts\n+1\n*** End Patch";
+		const patchB = "*** Begin Patch\n*** Update File: shared.ts\n+2\n*** End Patch";
+		const context = buildSessionContext([
+			{ type: "tool.execute.after", tool: "apply_patch", args: { patchText: patchA } },
+			{ type: "tool.execute.after", tool: "apply_patch", args: { patchText: patchB } },
+		]);
+		expect(context.filesModified).toEqual(["shared.ts"]);
+	});
+
+	it("treats write/edit tools identically to apply_patch for filesModified", () => {
+		const context = buildSessionContext([
+			{
+				type: "tool.execute.after",
+				tool: "write",
+				args: { filePath: "/repo/out.ts" },
+			},
+			{
+				type: "tool.execute.after",
+				tool: "edit",
+				args: { filePath: "/repo/existing.ts" },
+			},
+			{
+				type: "tool.execute.after",
+				tool: "apply_patch",
+				args: { patchText: "*** Begin Patch\n*** Add File: /repo/patched.ts\n+x\n*** End Patch" },
+			},
+		]);
+		expect(context.filesModified).toEqual([
+			"/repo/existing.ts",
+			"/repo/out.ts",
+			"/repo/patched.ts",
+		]);
+	});
+
+	it("recognizes Claude Code multiedit and notebookedit tools", () => {
+		const context = buildSessionContext([
+			{
+				type: "tool.execute.after",
+				tool: "multiedit",
+				args: { file_path: "/repo/m.ts" },
+			},
+			{
+				type: "tool.execute.after",
+				tool: "notebookedit",
+				args: { file_path: "/repo/n.ipynb" },
+			},
+		]);
+		expect(context.filesModified).toEqual(["/repo/m.ts", "/repo/n.ipynb"]);
+	});
+
+	it("ignores apply_patch events whose patchText has no file markers", () => {
+		const context = buildSessionContext([
+			{
+				type: "tool.execute.after",
+				tool: "apply_patch",
+				args: { patchText: "*** Begin Patch\n*** End Patch" },
+			},
+		]);
+		expect(context.filesModified).toEqual([]);
+	});
+});

--- a/packages/core/src/raw-event-flush.test.ts
+++ b/packages/core/src/raw-event-flush.test.ts
@@ -388,11 +388,127 @@ describe("flushRawEvents max retry", () => {
 				toolCount?: number;
 				firstPrompt?: string;
 				filesRead?: string[];
+				filesModified?: string[];
 			};
 		};
 		expect(meta.session_context?.promptCount).toBe(1);
 		expect(meta.session_context?.toolCount).toBe(2);
 		expect(meta.session_context?.firstPrompt).toBe("Investigate the flush bug");
 		expect(meta.session_context?.filesRead).toEqual(["/tmp/repo/src/flush.ts"]);
+		expect(meta.session_context?.filesModified).toEqual(["/tmp/repo/src/flush.ts"]);
+	});
+
+	it("populates filesModified from OpenCode apply_patch adapter events end-to-end", async () => {
+		const sessionId = "ses_opencode_apply_patch";
+		const patchText = [
+			"*** Begin Patch",
+			"*** Add File: /repo/src/new.ts",
+			"+export const created = 1;",
+			"*** Update File: /repo/src/existing.ts",
+			"@@ -1 +1 @@",
+			"-export const value = 1;",
+			"+export const value = 2;",
+			"*** End Patch",
+		].join("\n");
+
+		// Seed a PURE adapter-enveloped tool_result event — this is the shape
+		// OpenCode actually emits for apply_patch. No outer `tool` / `args` /
+		// `type: "tool.execute.after"` fields; the adapter envelope is the only
+		// thing that carries the tool name and patchText. This forces the flush
+		// path through `normalizeEventsForSessionContext` +
+		// `projectAdapterToolEvent` and proves the adapter projection populates
+		// `filesModified` via the `apply_patch` branch of `buildSessionContext`.
+		const adapterEvent = {
+			schema_version: "1.0",
+			source: "opencode",
+			session_id: sessionId,
+			event_id: "oc:apply_patch:1",
+			event_type: "tool_result",
+			ts: "2026-04-11T12:00:05Z",
+			ordering_confidence: "low",
+			payload: {
+				tool_name: "apply_patch",
+				status: "ok",
+				tool_input: { patchText },
+				tool_output:
+					"Success. Updated the following files:\nA /repo/src/new.ts\nU /repo/src/existing.ts",
+				error: null,
+			},
+			meta: { original_event_type: "tool.execute.after" },
+		};
+
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			eventId: "evt-prompt",
+			eventType: "user_prompt",
+			payload: {
+				type: "user_prompt",
+				prompt_text: "Ship the apply_patch fix",
+				timestamp: "2026-04-11T12:00:00Z",
+			},
+			tsWallMs: Date.parse("2026-04-11T12:00:00Z"),
+		});
+		store.recordRawEvent({
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			eventId: adapterEvent.event_id,
+			eventType: "tool.execute.after",
+			payload: { _adapter: adapterEvent },
+			tsWallMs: Date.parse(adapterEvent.ts),
+		});
+
+		const summaryResponder = {
+			observe: async () => ({
+				raw: `<summary>
+					<request>Ship the apply_patch fix</request>
+					<investigated>raw-event-flush session context</investigated>
+					<learned>apply_patch needs explicit handling</learned>
+					<completed>Added handling</completed>
+					<next_steps></next_steps>
+					<notes></notes>
+				</summary>`,
+				parsed: null,
+				provider: "test",
+				model: "test-model",
+			}),
+			getStatus: () => ({
+				provider: "test",
+				model: "test-model",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+			}),
+		};
+
+		const ingestOpts = { observer: summaryResponder } as unknown as IngestOptions;
+		const flushOpts = {
+			opencodeSessionId: sessionId,
+			source: "opencode",
+			cwd: "/repo",
+			project: "repo",
+			startedAt: "2026-04-11T12:00:00Z",
+			maxEvents: null,
+		};
+
+		const result = await flushRawEvents(store, ingestOpts, flushOpts);
+		expect(result.flushed).toBeGreaterThan(0);
+
+		const row = store.db
+			.prepare(
+				"SELECT metadata_json FROM sessions WHERE id = (SELECT session_id FROM opencode_sessions WHERE stream_id = ?)",
+			)
+			.get(sessionId) as { metadata_json: string } | undefined;
+		expect(row).toBeDefined();
+		const meta = JSON.parse(row?.metadata_json ?? "{}") as {
+			session_context?: {
+				filesModified?: string[];
+				toolCount?: number;
+			};
+		};
+		expect(meta.session_context?.filesModified).toEqual([
+			"/repo/src/existing.ts",
+			"/repo/src/new.ts",
+		]);
+		expect(meta.session_context?.toolCount).toBe(1);
 	});
 });

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -8,6 +8,7 @@
  * and updates flush state on success (or records failure details).
  */
 
+import { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";
 import { extractAdapterEvent, projectAdapterToolEvent } from "./ingest-events.js";
 import { type IngestOptions, ingest } from "./ingest-pipeline.js";
 import { normalizeAdapterEvents, normalizeEventsForSessionContext } from "./ingest-transcript.js";
@@ -114,12 +115,35 @@ export function buildSessionContext(events: Record<string, unknown>[]): SessionC
 		const args = e.args;
 		if (args == null || typeof args !== "object") continue;
 		const argsObj = args as Record<string, unknown>;
+
+		// OpenCode's primary file-mutation tool is `apply_patch`, which does not
+		// expose a `filePath` key — the paths live inside the `patchText` string
+		// using the standard `*** Add File: <path>` / `*** Update File: <path>` /
+		// `*** Delete File: <path>` markers. Extract those explicitly so the
+		// session context reflects writes from `apply_patch` sessions.
+		//
+		// `*** Delete File:` entries are also recorded as `filesModified` because
+		// session context tracks "files the session touched", not just writes —
+		// a deletion is a mutation and downstream session-aware surfaces (pack,
+		// injection) want to see deleted paths too.
+		if (tool === "apply_patch") {
+			const patchText = argsObj.patchText ?? argsObj.patch;
+			if (typeof patchText === "string" && patchText) {
+				for (const path of extractApplyPatchPaths(patchText)) {
+					filesModified.add(path);
+				}
+			}
+			continue;
+		}
+
 		// Support both OpenCode-style camelCase (`filePath`) and Claude Code-style
 		// snake_case (`file_path`) tool input keys. Claude Code hook payloads use
 		// `file_path` verbatim from the Claude Code schema.
 		const filePath = argsObj.filePath ?? argsObj.file_path ?? argsObj.path;
 		if (typeof filePath !== "string" || !filePath) continue;
-		if (tool === "write" || tool === "edit") filesModified.add(filePath);
+		if (MUTATING_TOOL_NAMES.has(tool)) {
+			filesModified.add(filePath);
+		}
 		if (tool === "read") filesRead.add(filePath);
 	}
 


### PR DESCRIPTION
## Description

`buildSessionContext` only recognized `write` and `edit` tools for populating
`filesModified`. This fix adds three improvements to the session-context
builder so that `filesModified` reflects all file-mutating tool usage:

1. **apply_patch path extraction.** OpenCode's primary file-mutation tool
   (`apply_patch`) does not expose a `filePath` key -- the paths live inside
   the `patchText` string using `*** Add File:` / `*** Update File:` /
   `*** Delete File:` markers. The new code parses those markers via the
   shared `extractApplyPatchPaths` helper from `packages/core/src/apply-patch.ts`
   (introduced in the parent PR). Delete-as-modified is intentional:
   `filesModified` tracks "files the session touched", and a deletion is a
   mutation.

2. **multiedit / notebookedit recognition.** Claude Code's `multiedit` and
   `notebookedit` tools were not in the mutation-tool list. Both are now
   recognized via the shared `MUTATING_TOOL_NAMES` set.

3. **Deduplicate `extractApplyPatchPaths` and `MUTATING_TOOL_NAMES`.**
   `packages/cli/src/commands/claude-hook-session-state.ts` had its own local
   copies of both. This PR removes them and imports from `@codemem/core`
   instead, closing the three-way duplication across the monorepo.

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] Maintenance (dedup shared helpers across packages)

## Testing

- [x] `pnpm run test` -- all 71 files / 1253 tests green.
- [x] Added E2E test seeding a pure adapter-enveloped `apply_patch` event
      (no redundant outer `tool` / `args` fields) and asserting
      `filesModified` is populated on the persisted session context.
- [x] Split pure-function `buildSessionContext` tests into
      `build-session-context.test.ts`; `extractApplyPatchPaths` unit tests
      co-located in `apply-patch.test.ts` (from parent PR).
- [x] `pnpm run tsc` and `pnpm run lint` clean.

## Checklist

- [x] Code follows project style (biome clean)
- [x] Self-review completed
- [ ] Documentation updated (not needed -- internal pipeline fix)
- [x] No new warnings introduced