### PR TITLE
feat(core): backfill historical SessionContext via maintenance_jobs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,10 +41,11 @@ flowchart LR
 3. Claude hook ingestion posts to `POST /api/claude-hooks` first and falls back to `codemem claude-hook-ingest` direct enqueue when the local viewer API is unavailable.
 4. The viewer/store persists raw events and queues durable flush batches.
 5. Idle and sweeper workers claim batches and run them through ingest.
-6. Ingest builds a transcript from user prompts and assistant messages, then hands it to the observer.
-7. The observer returns typed observations and an optional session summary as XML.
-8. Ingest writes artifacts (transcript, context snapshots), observations, and summaries to SQLite.
-9. The viewer, MCP server, and CLI all read from the same SQLite database.
+6. Before building session context, raw events are passed through `normalizeEventsForSessionContext` (in `ingest-transcript.ts`) which projects adapter-enveloped events (`_adapter` schema v1.0) into the flat `user_prompt` / `tool.execute.after` shapes that `buildSessionContext` scans. This is critical for Claude Code hook events which always arrive wrapped in the adapter envelope.
+7. Ingest builds a transcript from user prompts and assistant messages, then hands it to the observer.
+8. The observer returns typed observations and an optional session summary as XML.
+9. Ingest writes artifacts (transcript, context snapshots), observations, and summaries to SQLite.
+10. The viewer, MCP server, and CLI all read from the same SQLite database.
 
 ## Adapter support matrix and rollout
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -6,6 +6,7 @@ import * as p from "@clack/prompts";
 import {
 	DedupKeyBackfillRunner,
 	hasPendingDedupKeyBackfill,
+	hasPendingSessionContextBackfill,
 	initDatabase,
 	isEmbeddingDisabled,
 	type MemoryStore,
@@ -16,6 +17,7 @@ import {
 	readCoordinatorSyncConfig,
 	resolveDbPath,
 	runSyncDaemon,
+	SessionContextBackfillRunner,
 	SyncRetentionRunner,
 	VectorModelMigrationRunner,
 } from "@codemem/core";
@@ -413,6 +415,9 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	const dedupKeyBackfillRunner = new DedupKeyBackfillRunner({
 		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
 	});
+	const sessionContextBackfillRunner = new SessionContextBackfillRunner({
+		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
+	});
 	const syncRuntimeStatus: {
 		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
 		detail: string | null;
@@ -475,6 +480,10 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			if (hasPendingDedupKeyBackfill(store.db)) {
 				dedupKeyBackfillRunner.start();
 				p.log.step("Dedup-key maintenance runner started");
+			}
+			if (hasPendingSessionContextBackfill(store.db)) {
+				sessionContextBackfillRunner.start();
+				p.log.step("Session-context backfill runner started");
 			}
 			if (syncConfig.syncRetentionEnabled) {
 				retentionRunner.start();
@@ -550,6 +559,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		syncAbort.abort();
 		retentionAbort.abort();
 		await sweeper.stop();
+		await sessionContextBackfillRunner.stop();
 		await dedupKeyBackfillRunner.stop();
 		await vectorMigrationRunner.stop();
 		await retentionRunner.stop();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -355,6 +355,12 @@ export {
 	search,
 	timeline,
 } from "./search.js";
+export {
+	hasPendingSessionContextBackfill,
+	runSessionContextBackfillPass,
+	SESSION_CONTEXT_BACKFILL_JOB,
+	SessionContextBackfillRunner,
+} from "./session-context-backfill.js";
 export { MemoryStore } from "./store.js";
 export { canonicalMemoryKind, getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
 export type {

--- a/packages/core/src/session-context-backfill.test.ts
+++ b/packages/core/src/session-context-backfill.test.ts
@@ -1,0 +1,378 @@
+import Database from "better-sqlite3";
+import { beforeEach, describe, expect, it } from "vitest";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
+import {
+	hasPendingSessionContextBackfill,
+	runSessionContextBackfillPass,
+	SESSION_CONTEXT_BACKFILL_JOB,
+} from "./session-context-backfill.js";
+import { initTestSchema } from "./test-utils.js";
+
+interface SessionContextPayload {
+	flusher?: string;
+	source?: string;
+	streamId?: string;
+	opencodeSessionId?: string;
+	firstPrompt?: string;
+	promptCount?: number;
+	toolCount?: number;
+	durationMs?: number;
+	filesRead?: string[];
+	filesModified?: string[];
+}
+
+function insertRawEventSession(db: Database, source: string, streamId: string, now: string): void {
+	db.prepare(
+		`INSERT INTO raw_event_sessions(
+			source, stream_id, opencode_session_id, updated_at,
+			last_received_event_seq, last_flushed_event_seq
+		) VALUES (?, ?, ?, ?, 0, -1)`,
+	).run(source, streamId, streamId, now);
+}
+
+function insertRawEvent(
+	db: Database,
+	source: string,
+	streamId: string,
+	eventSeq: number,
+	eventId: string,
+	eventType: string,
+	payload: Record<string, unknown>,
+	tsWallMs: number,
+): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO raw_events(
+			source, stream_id, opencode_session_id, event_id, event_seq,
+			event_type, ts_wall_ms, payload_json, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		source,
+		streamId,
+		streamId,
+		eventId,
+		eventSeq,
+		eventType,
+		tsWallMs,
+		JSON.stringify(payload),
+		now,
+	);
+}
+
+function insertSessionRow(
+	db: Database,
+	source: string | null,
+	streamId: string | null,
+	sessionContext: SessionContextPayload | null,
+): number {
+	const now = new Date().toISOString();
+	const metadata = sessionContext == null ? {} : { session_context: sessionContext };
+	const info = db
+		.prepare(
+			`INSERT INTO sessions(started_at, cwd, project, user, tool_version, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(now, "/tmp/test", "test-project", "test-user", "raw_events", JSON.stringify(metadata));
+	const sessionId = Number(info.lastInsertRowid);
+	if (source && streamId) {
+		db.prepare(
+			`INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at)
+			 VALUES (?, ?, ?, ?, ?)`,
+		).run(source, streamId, streamId, sessionId, now);
+	}
+	return sessionId;
+}
+
+function readSessionContext(db: Database, sessionId: number): SessionContextPayload {
+	const row = db.prepare("SELECT metadata_json FROM sessions WHERE id = ?").get(sessionId) as
+		| { metadata_json: string | null }
+		| undefined;
+	if (!row?.metadata_json) return {};
+	const parsed = JSON.parse(row.metadata_json) as { session_context?: SessionContextPayload };
+	return parsed.session_context ?? {};
+}
+
+describe("session-context backfill maintenance", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	it("rebuilds session_context for a pre-fix raw-event session", async () => {
+		const source = "claude";
+		const streamId = "ses-prefix";
+		const now = new Date().toISOString();
+		insertRawEventSession(db, source, streamId, now);
+		insertRawEvent(
+			db,
+			source,
+			streamId,
+			1,
+			"evt-1",
+			"claude.hook",
+			{
+				type: "claude.hook",
+				_adapter: {
+					schema_version: "1.0",
+					source,
+					session_id: streamId,
+					event_id: "evt-1",
+					event_type: "prompt",
+					ts: "2026-03-04T10:00:00Z",
+					payload: { text: "Investigate the flush bug" },
+				},
+			},
+			Date.parse("2026-03-04T10:00:00Z"),
+		);
+		insertRawEvent(
+			db,
+			source,
+			streamId,
+			2,
+			"evt-2",
+			"claude.hook",
+			{
+				type: "claude.hook",
+				_adapter: {
+					schema_version: "1.0",
+					source,
+					session_id: streamId,
+					event_id: "evt-2",
+					event_type: "tool_result",
+					ts: "2026-03-04T10:00:05Z",
+					payload: {
+						tool_name: "Edit",
+						status: "ok",
+						tool_input: { file_path: "/tmp/repo/src/flush.ts" },
+					},
+					meta: { original_event_type: "tool.execute.after" },
+				},
+			},
+			Date.parse("2026-03-04T10:00:05Z"),
+		);
+
+		// Seed a pre-fix session: flusher=raw_events but derived fields are empty
+		// because buildSessionContext ran on the un-normalized Claude Code envelope.
+		const sessionId = insertSessionRow(db, source, streamId, {
+			flusher: "raw_events",
+			source,
+			streamId,
+			opencodeSessionId: streamId,
+			promptCount: 0,
+			toolCount: 0,
+			durationMs: 0,
+			filesRead: [],
+			filesModified: [],
+		});
+
+		expect(hasPendingSessionContextBackfill(db)).toBe(true);
+
+		const hasMore = await runSessionContextBackfillPass(db, { batchSize: 10 });
+		expect(hasMore).toBe(false);
+
+		const rebuilt = readSessionContext(db, sessionId);
+		expect(rebuilt.promptCount).toBe(1);
+		expect(rebuilt.toolCount).toBe(1);
+		expect(rebuilt.firstPrompt).toBe("Investigate the flush bug");
+		expect(rebuilt.filesModified).toEqual(["/tmp/repo/src/flush.ts"]);
+		// Preserved identity fields.
+		expect(rebuilt.flusher).toBe("raw_events");
+		expect(rebuilt.source).toBe(source);
+		expect(rebuilt.streamId).toBe(streamId);
+		expect(rebuilt.opencodeSessionId).toBe(streamId);
+
+		const job = getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB);
+		expect(job).toMatchObject({
+			status: "completed",
+			progress: { current: 1, total: 1, unit: "items" },
+		});
+		expect(job?.metadata).toMatchObject({
+			rewritten_sessions: 1,
+			processed_sessions: 1,
+			unchanged_sessions: 0,
+		});
+	});
+
+	it("is idempotent: second run after a rewrite is a no-op", async () => {
+		const source = "opencode";
+		const streamId = "ses-idempotent";
+		const now = new Date().toISOString();
+		insertRawEventSession(db, source, streamId, now);
+		insertRawEvent(
+			db,
+			source,
+			streamId,
+			1,
+			"evt-1",
+			"user_prompt",
+			{ type: "user_prompt", prompt_text: "Ship the fix" },
+			1_700_000_000_000,
+		);
+		insertRawEvent(
+			db,
+			source,
+			streamId,
+			2,
+			"evt-2",
+			"tool.execute.after",
+			{
+				type: "tool.execute.after",
+				tool: "edit",
+				args: { filePath: "/repo/src/a.ts" },
+			},
+			1_700_000_001_000,
+		);
+
+		const sessionId = insertSessionRow(db, source, streamId, {
+			flusher: "raw_events",
+			source,
+			streamId,
+			opencodeSessionId: streamId,
+			promptCount: 0,
+			toolCount: 0,
+			filesModified: [],
+			filesRead: [],
+		});
+
+		await runSessionContextBackfillPass(db, { batchSize: 10 });
+		const afterFirst = readSessionContext(db, sessionId);
+		expect(afterFirst.promptCount).toBe(1);
+		expect(afterFirst.toolCount).toBe(1);
+
+		// Capture metadata_json to detect any write on the second run.
+		const metadataBefore = db
+			.prepare("SELECT metadata_json FROM sessions WHERE id = ?")
+			.get(sessionId) as { metadata_json: string };
+
+		const hasMore = await runSessionContextBackfillPass(db, { batchSize: 10 });
+		expect(hasMore).toBe(false);
+
+		const metadataAfter = db
+			.prepare("SELECT metadata_json FROM sessions WHERE id = ?")
+			.get(sessionId) as { metadata_json: string };
+		expect(metadataAfter.metadata_json).toBe(metadataBefore.metadata_json);
+
+		const job = getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB);
+		expect(job?.status).toBe("completed");
+		expect(job?.metadata).toMatchObject({
+			unchanged_sessions: 1,
+			rewritten_sessions: 0,
+		});
+	});
+
+	it("skips a raw-event session that has no raw events and records the skip", async () => {
+		const source = "opencode";
+		const streamId = "ses-no-events";
+		insertSessionRow(db, source, streamId, {
+			flusher: "raw_events",
+			source,
+			streamId,
+			opencodeSessionId: streamId,
+			promptCount: 0,
+			toolCount: 0,
+		});
+
+		const hasMore = await runSessionContextBackfillPass(db, { batchSize: 10 });
+		expect(hasMore).toBe(false);
+
+		const job = getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB);
+		expect(job?.status).toBe("completed");
+		expect(job?.metadata).toMatchObject({
+			skipped_no_events: 1,
+			rewritten_sessions: 0,
+			processed_sessions: 1,
+		});
+	});
+
+	it("skips a raw-event session that is missing its opencode_sessions bridge row", async () => {
+		const source = "opencode";
+		const streamId = "ses-no-bridge";
+		const now = new Date().toISOString();
+		insertRawEventSession(db, source, streamId, now);
+		insertRawEvent(
+			db,
+			source,
+			streamId,
+			1,
+			"evt-1",
+			"user_prompt",
+			{ type: "user_prompt", prompt_text: "Hello" },
+			1_700_000_000_000,
+		);
+		// Session row with raw_events flusher marker but no opencode_sessions row.
+		insertSessionRow(db, null, null, {
+			flusher: "raw_events",
+			source,
+			streamId,
+			opencodeSessionId: streamId,
+		});
+
+		const hasMore = await runSessionContextBackfillPass(db, { batchSize: 10 });
+		expect(hasMore).toBe(false);
+
+		const job = getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB);
+		expect(job?.status).toBe("completed");
+		expect(job?.metadata).toMatchObject({
+			skipped_no_bridge: 1,
+			rewritten_sessions: 0,
+		});
+	});
+
+	it("ignores sessions not flushed via raw_events", async () => {
+		// Non-raw-events session should not be enqueued at all.
+		insertSessionRow(db, null, null, null);
+		expect(hasPendingSessionContextBackfill(db)).toBe(false);
+		const hasMore = await runSessionContextBackfillPass(db, { batchSize: 10 });
+		expect(hasMore).toBe(false);
+		expect(getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB)).toBeNull();
+	});
+
+	it("processes multiple candidates across batches and reports progress", async () => {
+		const source = "opencode";
+		for (let i = 1; i <= 3; i++) {
+			const streamId = `ses-multi-${i}`;
+			const now = new Date().toISOString();
+			insertRawEventSession(db, source, streamId, now);
+			insertRawEvent(
+				db,
+				source,
+				streamId,
+				1,
+				`evt-${i}-1`,
+				"user_prompt",
+				{ type: "user_prompt", prompt_text: `prompt ${i}` },
+				1_700_000_000_000 + i * 1000,
+			);
+			insertSessionRow(db, source, streamId, {
+				flusher: "raw_events",
+				source,
+				streamId,
+				opencodeSessionId: streamId,
+				promptCount: 0,
+				toolCount: 0,
+			});
+		}
+
+		// First pass processes 2, leaves 1 remaining.
+		const firstHasMore = await runSessionContextBackfillPass(db, { batchSize: 2 });
+		expect(firstHasMore).toBe(true);
+		const runningJob = getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB);
+		expect(runningJob?.status).toBe("running");
+		expect(runningJob?.metadata).toMatchObject({
+			processed_sessions: 2,
+			rewritten_sessions: 2,
+			total_candidates: 3,
+		});
+
+		const secondHasMore = await runSessionContextBackfillPass(db, { batchSize: 2 });
+		expect(secondHasMore).toBe(false);
+		const completedJob = getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB);
+		expect(completedJob?.status).toBe("completed");
+		expect(completedJob?.metadata).toMatchObject({
+			processed_sessions: 3,
+			rewritten_sessions: 3,
+		});
+	});
+});

--- a/packages/core/src/session-context-backfill.ts
+++ b/packages/core/src/session-context-backfill.ts
@@ -1,0 +1,433 @@
+/**
+ * Session context backfill — maintenance job that re-derives and persists
+ * `session_context` on historical `sessions` rows whose raw events were
+ * processed before the session-context extraction fixes landed.
+ *
+ * The write-side fix now normalizes raw events (Claude Code hook envelopes
+ * and OpenCode `apply_patch` tool payloads) before running
+ * `buildSessionContext`. This module applies the same rebuild retroactively:
+ * it walks raw-event-backed sessions, reloads their raw events, runs them
+ * through `normalizeEventsForSessionContext` + `buildSessionContext`, and
+ * rewrites `sessions.metadata_json.session_context` when the rebuild produces
+ * different content-derived fields (promptCount, toolCount, durationMs,
+ * firstPrompt, filesRead, filesModified).
+ *
+ * The job is idempotent: a second pass after the rebuild lands is a no-op
+ * because the rebuilt context will match the persisted one.
+ */
+
+import type { Database as SqliteDatabase } from "better-sqlite3";
+import { connect, resolveDbPath } from "./db.js";
+import { normalizeEventsForSessionContext } from "./ingest-transcript.js";
+import type { SessionContext } from "./ingest-types.js";
+import {
+	completeMaintenanceJob,
+	failMaintenanceJob,
+	getMaintenanceJob,
+	startMaintenanceJob,
+	updateMaintenanceJob,
+} from "./maintenance-jobs.js";
+import { buildSessionContext } from "./raw-event-flush.js";
+
+export const SESSION_CONTEXT_BACKFILL_JOB = "session_context_backfill";
+
+type SessionContextBackfillMetadata = {
+	last_cursor_id?: number;
+	total_candidates?: number;
+	processed_sessions?: number;
+	rewritten_sessions?: number;
+	skipped_no_events?: number;
+	skipped_no_bridge?: number;
+	unchanged_sessions?: number;
+};
+
+export interface SessionContextBackfillRunnerOptions {
+	batchSize?: number;
+	intervalMs?: number;
+	dbPath?: string;
+	signal?: AbortSignal;
+}
+
+interface CandidateSessionRow {
+	id: number;
+	metadata_json: string | null;
+	source: string | null;
+	stream_id: string | null;
+}
+
+interface RawEventRow {
+	event_seq: number;
+	event_type: string;
+	ts_wall_ms: number | null;
+	ts_mono_ms: number | null;
+	payload_json: string;
+	event_id: string | null;
+}
+
+/**
+ * Fields that `buildSessionContext` derives from raw events. Only these are
+ * compared and overwritten during backfill; identity/tracking fields on the
+ * persisted context (source, streamId, opencodeSessionId, flusher, flushBatch)
+ * are preserved as-is.
+ */
+const DERIVED_FIELDS = [
+	"firstPrompt",
+	"promptCount",
+	"toolCount",
+	"durationMs",
+	"filesModified",
+	"filesRead",
+] as const;
+
+function countCandidateSessions(db: SqliteDatabase): number {
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS c FROM sessions
+			 WHERE json_extract(metadata_json, '$.session_context.flusher') = 'raw_events'`,
+		)
+		.get() as { c?: number } | undefined;
+	return Number(row?.c ?? 0);
+}
+
+function selectCandidateBatch(
+	db: SqliteDatabase,
+	afterId: number,
+	batchSize: number,
+): CandidateSessionRow[] {
+	return db
+		.prepare(
+			`SELECT
+				s.id AS id,
+				s.metadata_json AS metadata_json,
+				os.source AS source,
+				os.stream_id AS stream_id
+			 FROM sessions s
+			 LEFT JOIN (
+				SELECT session_id, source, stream_id
+				FROM opencode_sessions
+				GROUP BY session_id
+			 ) os ON os.session_id = s.id
+			 WHERE s.id > ?
+			   AND json_extract(s.metadata_json, '$.session_context.flusher') = 'raw_events'
+			 ORDER BY s.id ASC
+			 LIMIT ?`,
+		)
+		.all(afterId, batchSize) as CandidateSessionRow[];
+}
+
+function loadRawEventsForStream(
+	db: SqliteDatabase,
+	source: string,
+	streamId: string,
+): Record<string, unknown>[] {
+	const rows = db
+		.prepare(
+			`SELECT event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, event_id
+			 FROM raw_events
+			 WHERE source = ? AND stream_id = ?
+			 ORDER BY event_seq ASC`,
+		)
+		.all(source, streamId) as RawEventRow[];
+	return rows.map<Record<string, unknown>>((row) => {
+		const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
+		payload.type = payload.type || row.event_type;
+		payload.timestamp_wall_ms = row.ts_wall_ms;
+		payload.timestamp_mono_ms = row.ts_mono_ms;
+		payload.event_seq = row.event_seq;
+		payload.event_id = row.event_id;
+		return payload;
+	});
+}
+
+function parseSessionMetadata(value: string | null): Record<string, unknown> {
+	if (!value) return {};
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+	} catch {
+		// Fall through — malformed metadata_json is treated as empty.
+	}
+	return {};
+}
+
+function normalizeDerived(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return [...value].sort();
+	}
+	return value ?? null;
+}
+
+function derivedFieldsDiffer(existing: Record<string, unknown>, rebuilt: SessionContext): boolean {
+	for (const field of DERIVED_FIELDS) {
+		const a = normalizeDerived(existing[field]);
+		const b = normalizeDerived((rebuilt as Record<string, unknown>)[field]);
+		if (JSON.stringify(a) !== JSON.stringify(b)) return true;
+	}
+	return false;
+}
+
+function mergeDerivedFields(
+	existing: Record<string, unknown>,
+	rebuilt: SessionContext,
+): Record<string, unknown> {
+	const next = { ...existing };
+	for (const field of DERIVED_FIELDS) {
+		const rebuiltValue = (rebuilt as Record<string, unknown>)[field];
+		if (rebuiltValue === undefined) {
+			delete next[field];
+		} else {
+			next[field] = rebuiltValue;
+		}
+	}
+	return next;
+}
+
+interface BatchResult {
+	processed: number;
+	rewritten: number;
+	skippedNoEvents: number;
+	skippedNoBridge: number;
+	unchanged: number;
+	lastCursorId: number;
+	exhausted: boolean;
+}
+
+function processCandidateBatch(
+	db: SqliteDatabase,
+	candidates: CandidateSessionRow[],
+	batchSize: number,
+): BatchResult {
+	let rewritten = 0;
+	let skippedNoEvents = 0;
+	let skippedNoBridge = 0;
+	let unchanged = 0;
+	let lastCursorId = candidates.at(-1)?.id ?? 0;
+
+	const updateStmt = db.prepare("UPDATE sessions SET metadata_json = ? WHERE id = ?");
+
+	for (const row of candidates) {
+		lastCursorId = row.id;
+		if (!row.source || !row.stream_id) {
+			skippedNoBridge += 1;
+			continue;
+		}
+		const events = loadRawEventsForStream(db, row.source, row.stream_id);
+		if (events.length === 0) {
+			skippedNoEvents += 1;
+			continue;
+		}
+		const normalized = normalizeEventsForSessionContext(events);
+		const rebuilt = buildSessionContext(normalized);
+		const metadata = parseSessionMetadata(row.metadata_json);
+		const existingContextValue = metadata.session_context;
+		const existingContext =
+			existingContextValue && typeof existingContextValue === "object"
+				? (existingContextValue as Record<string, unknown>)
+				: {};
+		if (!derivedFieldsDiffer(existingContext, rebuilt)) {
+			unchanged += 1;
+			continue;
+		}
+		const mergedContext = mergeDerivedFields(existingContext, rebuilt);
+		const nextMetadata = { ...metadata, session_context: mergedContext };
+		updateStmt.run(JSON.stringify(nextMetadata), row.id);
+		rewritten += 1;
+	}
+
+	return {
+		processed: candidates.length,
+		rewritten,
+		skippedNoEvents,
+		skippedNoBridge,
+		unchanged,
+		lastCursorId,
+		exhausted: candidates.length < batchSize,
+	};
+}
+
+export function hasPendingSessionContextBackfill(db: SqliteDatabase): boolean {
+	const job = getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB);
+	if (job?.status === "completed") return false;
+	return countCandidateSessions(db) > 0;
+}
+
+export async function runSessionContextBackfillPass(
+	db: SqliteDatabase,
+	options: { batchSize?: number } = {},
+): Promise<boolean> {
+	const batchSize = Math.max(1, options.batchSize ?? 100);
+	const existingJob = getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB);
+	const existingMetadata = (existingJob?.metadata ?? {}) as SessionContextBackfillMetadata;
+
+	const isFreshRun =
+		!existingJob || existingJob.status === "completed" || existingJob.status === "failed";
+
+	const lastCursorId = isFreshRun ? 0 : Number(existingMetadata.last_cursor_id ?? 0);
+	const totalCandidates = isFreshRun
+		? countCandidateSessions(db)
+		: Number(existingMetadata.total_candidates ?? countCandidateSessions(db));
+
+	if (isFreshRun && totalCandidates <= 0) {
+		return false;
+	}
+
+	if (isFreshRun) {
+		startMaintenanceJob(db, {
+			kind: SESSION_CONTEXT_BACKFILL_JOB,
+			title: "Backfilling session context",
+			message: `Rebuilding session_context for ${totalCandidates} raw-event sessions`,
+			progressTotal: totalCandidates,
+			metadata: {
+				last_cursor_id: 0,
+				total_candidates: totalCandidates,
+				processed_sessions: 0,
+				rewritten_sessions: 0,
+				skipped_no_events: 0,
+				skipped_no_bridge: 0,
+				unchanged_sessions: 0,
+			},
+		});
+	}
+
+	const candidates = selectCandidateBatch(db, lastCursorId, batchSize);
+	if (candidates.length === 0) {
+		const metadata = (getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB)?.metadata ??
+			{}) as SessionContextBackfillMetadata;
+		completeMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB, {
+			message: summarizeCompletion(metadata),
+			progressCurrent: Number(metadata.processed_sessions ?? 0),
+			progressTotal: Number(metadata.total_candidates ?? metadata.processed_sessions ?? 0),
+			metadata: {
+				...metadata,
+				last_cursor_id: lastCursorId,
+			},
+		});
+		return false;
+	}
+
+	const batchResult = processCandidateBatch(db, candidates, batchSize);
+	const metadataBefore = (getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB)?.metadata ??
+		{}) as SessionContextBackfillMetadata;
+	const processedSessions = Number(metadataBefore.processed_sessions ?? 0) + batchResult.processed;
+	const rewrittenSessions = Number(metadataBefore.rewritten_sessions ?? 0) + batchResult.rewritten;
+	const skippedNoEvents =
+		Number(metadataBefore.skipped_no_events ?? 0) + batchResult.skippedNoEvents;
+	const skippedNoBridge =
+		Number(metadataBefore.skipped_no_bridge ?? 0) + batchResult.skippedNoBridge;
+	const unchangedSessions = Number(metadataBefore.unchanged_sessions ?? 0) + batchResult.unchanged;
+	const nextMetadata: SessionContextBackfillMetadata = {
+		last_cursor_id: batchResult.lastCursorId,
+		total_candidates: Number(metadataBefore.total_candidates ?? totalCandidates),
+		processed_sessions: processedSessions,
+		rewritten_sessions: rewrittenSessions,
+		skipped_no_events: skippedNoEvents,
+		skipped_no_bridge: skippedNoBridge,
+		unchanged_sessions: unchangedSessions,
+	};
+
+	if (batchResult.exhausted) {
+		completeMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB, {
+			message: summarizeCompletion(nextMetadata),
+			progressCurrent: processedSessions,
+			progressTotal: Number(nextMetadata.total_candidates ?? processedSessions),
+			metadata: nextMetadata,
+		});
+		return false;
+	}
+
+	updateMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB, {
+		status: "running",
+		message: `Rebuilt session_context for ${rewrittenSessions} of ${processedSessions} scanned sessions`,
+		progressCurrent: processedSessions,
+		progressTotal: Number(nextMetadata.total_candidates ?? processedSessions),
+		metadata: nextMetadata,
+	});
+	return true;
+}
+
+function summarizeCompletion(metadata: SessionContextBackfillMetadata): string {
+	const rewritten = Number(metadata.rewritten_sessions ?? 0);
+	const processed = Number(metadata.processed_sessions ?? 0);
+	const skipped = Number(metadata.skipped_no_events ?? 0) + Number(metadata.skipped_no_bridge ?? 0);
+	if (processed === 0) {
+		return "No raw-event sessions required session_context backfill";
+	}
+	if (rewritten === 0) {
+		return `Scanned ${processed} sessions, no session_context rewrite required`;
+	}
+	const skipSuffix = skipped > 0 ? ` (${skipped} skipped)` : "";
+	return `Rebuilt session_context for ${rewritten} of ${processed} sessions${skipSuffix}`;
+}
+
+export class SessionContextBackfillRunner {
+	private readonly dbPath: string;
+	private readonly signal?: AbortSignal;
+	private readonly batchSize: number;
+	private readonly intervalMs: number;
+	private active = false;
+	private timer: ReturnType<typeof setTimeout> | null = null;
+	private currentRun: Promise<void> | null = null;
+
+	constructor(options: SessionContextBackfillRunnerOptions = {}) {
+		this.dbPath = resolveDbPath(options.dbPath);
+		this.signal = options.signal;
+		this.batchSize = Math.max(1, options.batchSize ?? 100);
+		this.intervalMs = Math.max(1000, options.intervalMs ?? 5000);
+	}
+
+	start(): void {
+		if (this.active) return;
+		this.active = true;
+		this.schedule(100);
+	}
+
+	async stop(): Promise<void> {
+		this.active = false;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+		if (this.currentRun) await this.currentRun;
+	}
+
+	private schedule(delayMs: number): void {
+		if (!this.active || this.signal?.aborted) return;
+		this.timer = setTimeout(() => {
+			this.timer = null;
+			this.currentRun = this.runOnce()
+				.catch((err) => {
+					console.error("Session-context backfill runner tick failed:", err);
+				})
+				.finally(() => {
+					this.currentRun = null;
+					this.schedule(this.intervalMs);
+				});
+		}, delayMs);
+		if (typeof this.timer === "object" && "unref" in this.timer) this.timer.unref();
+	}
+
+	private async runOnce(): Promise<void> {
+		if (!this.active || this.signal?.aborted) return;
+		let db: SqliteDatabase | null = null;
+		try {
+			db = connect(this.dbPath) as SqliteDatabase;
+			const hasMoreWork = await runSessionContextBackfillPass(db, { batchSize: this.batchSize });
+			if (!hasMoreWork) {
+				this.active = false;
+			}
+		} catch (error) {
+			if (db) {
+				failMaintenanceJob(
+					db,
+					SESSION_CONTEXT_BACKFILL_JOB,
+					error instanceof Error ? error.message : String(error),
+				);
+			}
+			console.warn("Session-context backfill runner failed", error);
+		} finally {
+			db?.close();
+		}
+	}
+}


### PR DESCRIPTION
## Description

Adds a `session_context_backfill` maintenance job that rebuilds `SessionContext` on historical `sessions` rows whose raw events were flushed before the recent session-context extraction fixes landed.

The write-side fixes (Claude Code hook envelope normalization and OpenCode `apply_patch` path extraction) are already in place up the stack. This change reuses the same `normalizeEventsForSessionContext` + `buildSessionContext` helpers retroactively: it scans sessions with `metadata_json.session_context.flusher = 'raw_events'`, reloads each session's raw events via the `opencode_sessions` bridge, rebuilds the derived fields (`promptCount`, `toolCount`, `durationMs`, `firstPrompt`, `filesRead`, `filesModified`), and rewrites `metadata_json` only when the rebuild differs from what was persisted.

The handler follows the singleton-job pattern used by `DedupKeyBackfillRunner` and `VectorModelMigrationRunner`: one `maintenance_jobs` row keyed by `session_context_backfill`, a cursor (`last_cursor_id`) and counters carried in metadata, and a small background runner wired into `codemem serve` startup/shutdown alongside the other maintenance runners. Identity fields (`source`, `streamId`, `opencodeSessionId`, `flusher`, `flushBatch`) are preserved; only the content-derived fields are overwritten. Sessions with missing raw events or a missing bridge row are counted as skips, not rewritten.

This PR is stacked on #717 and closes the historical-data half of the session-context extraction story.

## Type of Change

- [x] Feature (new functionality)

## Testing

- [x] `pnpm run tsc`
- [x] `pnpm run lint`
- [x] `pnpm run test` (1254 passing, including 6 new tests in `session-context-backfill.test.ts`)
- [x] Added unit tests covering: pre-fix Claude Code session rebuild, idempotent re-run, missing raw events skip, missing bridge row skip, non-raw-events sessions ignored, multi-batch progress tracking

## Checklist

- [x] Code follows project style (`biome check` passes)
- [x] Self-review completed
- [x] Documentation updated (if needed) - no user-facing docs impacted
- [x] No new warnings introduced