### PR TITLE
feat(viewer): add memory forget action

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -738,6 +738,68 @@
         flex-shrink: 0;
       }
 
+      .feed-menu-panel {
+        min-width: 180px;
+        padding: 6px;
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--border);
+        background: var(--surface-1);
+        box-shadow: var(--shadow-md);
+        z-index: 24;
+      }
+      .feed-menu-trigger {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 30px;
+        height: 30px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-pill);
+        background: transparent;
+        color: var(--text-tertiary);
+        font-family: var(--font-sans);
+        font-size: 18px;
+        line-height: 1;
+        cursor: pointer;
+        transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+      }
+      .feed-menu-trigger:hover,
+      .feed-menu-trigger[data-state="open"] {
+        background: var(--surface-2);
+        color: var(--text-primary);
+        border-color: var(--border-hover);
+      }
+      .feed-menu-trigger:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .feed-menu-item {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        min-height: 36px;
+        padding: 8px 10px;
+        border-radius: var(--radius-md);
+        color: var(--text-primary);
+        font-size: 13px;
+        cursor: pointer;
+        user-select: none;
+        outline: none;
+      }
+      .feed-menu-item[data-highlighted] {
+        background: var(--surface-2);
+      }
+      .feed-menu-item[data-disabled] {
+        color: var(--text-tertiary);
+        cursor: default;
+      }
+      .feed-menu-item.danger {
+        color: var(--accent-warm);
+      }
+      .feed-menu-item.danger[data-highlighted] {
+        background: rgba(212, 100, 46, 0.1);
+      }
+
       .feed-title {
         font-weight: 600;
         font-size: 15px;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
 		"typecheck": "tsc -p tsconfig.json --noEmit"
 	},
 	"dependencies": {
+		"@radix-ui/react-dropdown-menu": "^2.1.16",
 		"@radix-ui/react-collapsible": "^1.1.12",
 		"@radix-ui/react-dialog": "^1.1.15",
 		"@radix-ui/react-select": "^2.2.6",

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -201,6 +201,17 @@ export async function updateMemoryVisibility(
 	return payload;
 }
 
+export async function forgetMemory(memoryId: number): Promise<{ status?: string }> {
+	const resp = await fetch("/api/memories/forget", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ memory_id: memoryId }),
+	});
+	const { text, payload } = await readJsonPayload<{ status?: string }>(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
+}
+
 export async function loadSummaries(project: string): Promise<PaginatedResponse> {
 	return loadSummariesPage(project);
 }

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -1,5 +1,6 @@
 /* Feed tab — memory feed rendering, filtering, search. */
 
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { type ComponentChildren, Fragment, h, render } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import * as api from "../lib/api";
@@ -15,6 +16,7 @@ import {
 } from "../lib/format";
 import { showGlobalNotice } from "../lib/notice";
 import { setFeedScopeFilter, setFeedTypeFilter, state } from "../lib/state";
+import { openSyncConfirmDialog } from "./sync/sync-dialogs";
 
 /* ── Types ───────────────────────────────────────────────── */
 
@@ -255,6 +257,64 @@ function replaceFeedItem(updatedItem: FeedItem) {
 	const key = itemKey(updatedItem);
 	state.lastFeedItems = (state.lastFeedItems as FeedItem[]).map((item) =>
 		itemKey(item) === key ? updatedItem : item,
+	);
+}
+
+function removeFeedItem(memoryId: number) {
+	const removedKeys = new Set<string>();
+	const keepItem = (item: FeedItem) => {
+		const itemMemoryId = Number(item.id || item.memory_id || 0);
+		const keep = itemMemoryId !== memoryId;
+		if (!keep) removedKeys.add(itemKey(item));
+		return keep;
+	};
+	state.lastFeedItems = (state.lastFeedItems as FeedItem[]).filter(keepItem);
+	if (Array.isArray(state.pendingFeedItems)) {
+		state.pendingFeedItems = (state.pendingFeedItems as FeedItem[]).filter(keepItem);
+	}
+	for (const key of removedKeys) {
+		state.newItemKeys.delete(key);
+		state.itemViewState.delete(key);
+		for (const expandKey of Array.from(state.itemExpandState.keys())) {
+			if (expandKey.startsWith(`${key}:`)) state.itemExpandState.delete(expandKey);
+		}
+	}
+}
+
+function FeedItemMenu({
+	disabled,
+	onForget,
+	title,
+}: {
+	disabled: boolean;
+	onForget: () => void;
+	title: string;
+}) {
+	return h(
+		DropdownMenu.Root,
+		null,
+		h(
+			DropdownMenu.Trigger,
+			{ asChild: true },
+			h(
+				"button",
+				{ "aria-label": `Actions for ${title}`, className: "feed-menu-trigger", type: "button" },
+				"⋯",
+			),
+		),
+		h(
+			DropdownMenu.Portal,
+			null,
+			h(
+				DropdownMenu.Content,
+				{ align: "end", className: "feed-menu-panel", side: "bottom", sideOffset: 4 },
+				h(
+					DropdownMenu.Item,
+					{ className: "feed-menu-item danger", disabled, onSelect: () => onForget() },
+					disabled ? "Forgetting…" : "Forget memory",
+				),
+			),
+		),
 	);
 }
 
@@ -670,6 +730,7 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 		visibility === "shared" ? "shared" : "private",
 	);
 	const [savingVisibility, setSavingVisibility] = useState(false);
+	const [deletingMemory, setDeletingMemory] = useState(false);
 	const summarySections = summaryObj ? renderSummarySections(summaryObj) : [];
 
 	useEffect(() => {
@@ -753,6 +814,35 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 		}
 	}
 
+	async function forgetMemory() {
+		const confirmed = await openSyncConfirmDialog({
+			autoFocusAction: "cancel",
+			title: `Forget ${displayTitle}?`,
+			description:
+				"This removes the memory from active results. The underlying record remains soft-deleted for audit and sync safety.",
+			confirmLabel: "Forget memory",
+			cancelLabel: "Keep memory",
+			tone: "danger",
+		});
+		if (!confirmed) return;
+
+		setDeletingMemory(true);
+		try {
+			await api.forgetMemory(memoryId);
+			removeFeedItem(memoryId);
+			updateFeedView(true);
+			await loadFeedData();
+			showGlobalNotice("Memory forgotten and removed from the active feed.");
+		} catch (error) {
+			showGlobalNotice(
+				error instanceof Error ? error.message : "Failed to forget memory.",
+				"warning",
+			);
+		} finally {
+			setDeletingMemory(false);
+		}
+	}
+
 	return h(
 		"div",
 		{
@@ -786,6 +876,13 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 						})
 					: null,
 				h("div", { className: "small feed-age", title: formatDate(createdAtRaw) }, relative),
+				Boolean(item.owned_by_self) && memoryId > 0
+					? h(FeedItemMenu, {
+							disabled: deletingMemory,
+							onForget: () => void forgetMemory(),
+							title: String(displayTitle || "memory"),
+						})
+					: null,
 			),
 		),
 		h(

--- a/packages/ui/src/tabs/sync/sync-dialogs.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs.tsx
@@ -6,6 +6,7 @@ type DialogTone = "default" | "danger";
 
 type ConfirmDialogRequest = {
 	kind: "confirm";
+	autoFocusAction?: "cancel" | "confirm";
 	cancelLabel?: string;
 	confirmLabel?: string;
 	description: string;
@@ -106,9 +107,21 @@ function SyncDialogHost() {
 	};
 
 	const handleOpenAutoFocus = (event: Event) => {
-		const primary = document.querySelector<HTMLElement>(
+		const legacyPrimary = document.querySelector<HTMLElement>(
 			'#syncDialog [data-sync-primary-action="true"]',
 		);
+		if (request?.kind === "input" && legacyPrimary) {
+			event.preventDefault();
+			legacyPrimary.focus();
+			return;
+		}
+		const preferredAction =
+			request?.kind === "confirm" ? (request.autoFocusAction ?? "confirm") : "confirm";
+		const selector =
+			preferredAction === "cancel"
+				? '#syncDialog [data-sync-dialog-action="cancel"]'
+				: '#syncDialog [data-sync-dialog-action="confirm"]';
+		const primary = document.querySelector<HTMLElement>(selector);
 		if (!primary) return;
 		event.preventDefault();
 		primary.focus();
@@ -237,6 +250,7 @@ function SyncDialogBody({
 				<div className="sync-dialog-actions">
 					<button
 						className="settings-button"
+						data-sync-dialog-action="cancel"
 						onClick={() => resolveCurrentDialog(request.kind === "confirm" ? false : null)}
 						type="button"
 					>
@@ -246,7 +260,7 @@ function SyncDialogBody({
 						<button
 							autoFocus
 							className={`settings-button ${dialogToneClassName(request.kind === "confirm" ? request.tone : undefined)}`}
-							data-sync-primary-action="true"
+							data-sync-dialog-action="confirm"
 							onClick={submit}
 							type="button"
 						>

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -62,9 +62,9 @@ function insertTestMemory(
 		createdAt?: string;
 		active?: boolean;
 	},
-) {
+): number {
 	const now = options.createdAt ?? new Date().toISOString();
-	store.db
+	const result = store.db
 		.prepare(
 			`INSERT INTO memory_items (
 				session_id, kind, title, subtitle, body_text, confidence, tags_text, active,
@@ -90,6 +90,7 @@ function insertTestMemory(
 			String(options.metadata?.source ?? "test"),
 			`${options.kind}-${options.title}-${now}`,
 		);
+	return Number(result.lastInsertRowid);
 }
 
 /** Create a test Hono app backed by a fresh in-memory DB. */
@@ -365,16 +366,205 @@ describe("viewer-server", () => {
 
 				const mineRes = await app.request("/api/observations?scope=mine");
 				expect(mineRes.status).toBe(200);
-				const mineItems = ((await mineRes.json()) as { items: Array<{ title: string }> }).items;
+				const mineItems = (
+					(await mineRes.json()) as { items: Array<{ title: string; owned_by_self?: boolean }> }
+				).items;
 				expect(mineItems.map((item) => item.title)).toEqual(["Mine"]);
+				expect(mineItems[0]?.owned_by_self).toBe(true);
 
 				const theirsRes = await app.request("/api/observations?scope=theirs");
 				expect(theirsRes.status).toBe(200);
-				const theirsItems = ((await theirsRes.json()) as { items: Array<{ title: string }> }).items;
+				const theirsItems = (
+					(await theirsRes.json()) as { items: Array<{ title: string; owned_by_self?: boolean }> }
+				).items;
 				expect(theirsItems.map((item) => item.title).sort()).toEqual([
 					"Null owned fields",
 					"Theirs",
 				]);
+				expect(theirsItems.every((item) => item.owned_by_self === false)).toBe(true);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("forgets an owned memory via the viewer API", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "bugfix",
+					title: "Owned memory",
+				});
+
+				const forgetRes = await app.request("/api/memories/forget", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId }),
+				});
+				expect(forgetRes.status).toBe(200);
+				expect(await forgetRes.json()).toEqual({ status: "ok" });
+
+				const observationsRes = await app.request("/api/observations");
+				expect(observationsRes.status).toBe(200);
+				const observations = (
+					(await observationsRes.json()) as { items: Array<{ id?: number; title: string }> }
+				).items;
+				expect(observations.map((item) => item.title)).not.toContain("Owned memory");
+
+				const row = store.db
+					.prepare("SELECT active, deleted_at FROM memory_items WHERE id = ?")
+					.get(memoryId) as { active: number; deleted_at: string | null };
+				expect(row.active).toBe(0);
+				expect(row.deleted_at).toBeTruthy();
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("treats repeated forget requests as a no-op success", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "change",
+					title: "Already forgotten",
+				});
+
+				const firstRes = await app.request("/api/memories/forget", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId }),
+				});
+				expect(firstRes.status).toBe(200);
+
+				const rowAfterFirstForget = store.db
+					.prepare("SELECT rev, deleted_at FROM memory_items WHERE id = ?")
+					.get(memoryId) as { rev: number; deleted_at: string | null };
+
+				const secondRes = await app.request("/api/memories/forget", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId }),
+				});
+				expect(secondRes.status).toBe(200);
+				expect(await secondRes.json()).toEqual({ status: "ok" });
+
+				const rowAfterSecondForget = store.db
+					.prepare("SELECT rev, deleted_at FROM memory_items WHERE id = ?")
+					.get(memoryId) as { rev: number; deleted_at: string | null };
+				expect(rowAfterSecondForget.rev).toBe(rowAfterFirstForget.rev);
+				expect(rowAfterSecondForget.deleted_at).toBe(rowAfterFirstForget.deleted_at);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects forgetting a memory not owned by this device", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "feature",
+					title: "Peer memory",
+					actorId: "peer:other",
+					originDeviceId: "peer-device-002",
+				});
+
+				const forgetRes = await app.request("/api/memories/forget", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId }),
+				});
+				expect(forgetRes.status).toBe(403);
+				const body = (await forgetRes.json()) as { error: string };
+				expect(body.error).toBe("memory not owned by this device");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("treats metadata-only local provenance as owned for forget requests", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "decision",
+					title: "Metadata-owned memory",
+					actorId: null,
+					originDeviceId: null,
+					metadata: {
+						actor_id: "local:test-device-001",
+						origin_device_id: "test-device-001",
+					},
+				});
+
+				const forgetRes = await app.request("/api/memories/forget", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId }),
+				});
+				expect(forgetRes.status).toBe(200);
+				expect(await forgetRes.json()).toEqual({ status: "ok" });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("validates forget requests", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const invalidIdRes = await app.request("/api/memories/forget", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: "abc" }),
+				});
+				expect(invalidIdRes.status).toBe(400);
+				expect(await invalidIdRes.json()).toEqual({ error: "memory_id must be int" });
+
+				const missingRes = await app.request("/api/memories/forget", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: 99999 }),
+				});
+				expect(missingRes.status).toBe(404);
+				expect(await missingRes.json()).toEqual({ error: "memory not found" });
 			} finally {
 				cleanup();
 			}

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -18,6 +18,63 @@ import { queryInt } from "../helpers.js";
 
 type StoreFactory = () => MemoryStore;
 
+type OwnershipContext = {
+	actorId: string;
+	claimedPeerIds: Set<string>;
+	deviceId: string;
+	legacyActorIds: Set<string>;
+};
+
+function cleanOwnershipValue(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed ? trimmed : null;
+}
+
+function buildOwnershipContext(store: MemoryStore): OwnershipContext {
+	const claimedPeerIds = new Set(store.sameActorPeerIds());
+	return {
+		actorId: store.actorId,
+		claimedPeerIds,
+		deviceId: store.deviceId,
+		legacyActorIds: new Set(Array.from(claimedPeerIds, (peerId) => `legacy-sync:${peerId}`)),
+	};
+}
+
+function memoryOwnedBySelf(
+	row: Record<string, unknown>,
+	ownership: OwnershipContext,
+	metadata = fromJson((row.metadata_json as string) ?? null),
+): boolean {
+	const meta = metadata as Record<string, unknown>;
+	const actorId = cleanOwnershipValue(row.actor_id) ?? cleanOwnershipValue(meta.actor_id);
+	if (actorId === ownership.actorId) return true;
+
+	const deviceId =
+		cleanOwnershipValue(row.origin_device_id) ?? cleanOwnershipValue(meta.origin_device_id);
+	if (deviceId === ownership.deviceId) return true;
+	if (deviceId && ownership.claimedPeerIds.has(deviceId)) return true;
+	if (actorId && ownership.legacyActorIds.has(actorId)) return true;
+
+	return false;
+}
+
+function serializeMemoryRow(
+	ownership: OwnershipContext,
+	row: Record<string, unknown>,
+): Record<string, unknown> {
+	const metadata = fromJson((row.metadata_json as string) ?? null);
+	const item = {
+		...row,
+		kind: canonicalMemoryKind((row.kind as string | null | undefined) ?? null, row.metadata_json),
+		metadata_json: metadata,
+	};
+	return {
+		...item,
+		owned_by_self: memoryOwnedBySelf(row, ownership, metadata),
+	};
+}
+
 /**
  * Attach session project/cwd fields to memory items.
  */
@@ -113,11 +170,8 @@ function queryMemoryPage(
 		)
 		.all(...filterResult.params, options.limit + 1, options.offset) as Record<string, unknown>[];
 
-	return rows.map((row) => ({
-		...row,
-		kind: canonicalMemoryKind((row.kind as string | null | undefined) ?? null, row.metadata_json),
-		metadata_json: fromJson((row.metadata_json as string) ?? null),
-	}));
+	const ownership = buildOwnershipContext(store);
+	return rows.map((row) => serializeMemoryRow(ownership, row));
 }
 
 function isSummaryLikeMemory(item: Record<string, unknown>): boolean {
@@ -471,6 +525,50 @@ export function memoryRoutes(getStore: StoreFactory) {
 			const msg = err instanceof Error ? err.message : String(err);
 			if (msg.includes("not found")) return c.json({ error: msg }, 404);
 			if (msg.includes("not owned")) return c.json({ error: msg }, 403);
+			return c.json({ error: msg }, 400);
+		}
+	});
+
+	// POST /api/memories/forget
+	app.post("/api/memories/forget", async (c) => {
+		const store = getStore();
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid JSON" }, 400);
+		}
+		const memoryId = parseStrictInteger(
+			typeof body.memory_id === "string" ? body.memory_id : String(body.memory_id ?? ""),
+		);
+		if (memoryId == null || memoryId <= 0) {
+			return c.json({ error: "memory_id must be int" }, 400);
+		}
+
+		const row = drizzle(store.db, { schema })
+			.select()
+			.from(schema.memoryItems)
+			.where(eq(schema.memoryItems.id, memoryId))
+			.get();
+		if (!row) {
+			return c.json({ error: "memory not found" }, 404);
+		}
+		const ownership = buildOwnershipContext(store);
+		if (!memoryOwnedBySelf(row, ownership)) {
+			return c.json({ error: "memory not owned by this device" }, 403);
+		}
+		if (Number(row.active ?? 1) === 0 || row.deleted_at != null) {
+			return c.json({ status: "ok" });
+		}
+
+		try {
+			store.forget(memoryId);
+			return c.json({ status: "ok" });
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (msg.includes("not found")) return c.json({ error: msg }, 404);
+			if (msg.includes("not owned")) return c.json({ error: msg }, 403);
+			if (msg.includes("sync_rebootstrap_in_progress")) return c.json({ error: msg }, 409);
 			return c.json({ error: msg }, 400);
 		}
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1518,6 +1521,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -1547,6 +1563,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popper@1.2.8':
@@ -1590,6 +1619,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4376,6 +4418,18 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@radix-ui/react-dropdown-menu@2.1.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@radix-ui/react-focus-guards@1.1.3(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -4392,6 +4446,29 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(react@19.2.4)
       react: 19.2.4
+
+  '@radix-ui/react-menu@2.1.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(react@19.2.4)
 
   '@radix-ui/react-popper@1.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -4425,6 +4502,20 @@ snapshots:
   '@radix-ui/react-primitive@2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@radix-ui/react-roving-focus@1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 


### PR DESCRIPTION
## Description
Add a viewer-side memory forget flow by exposing the existing soft-delete behavior through the feed UI.

- add a viewer API route for forgetting owned memories and return `owned_by_self` in feed items
- add a Radix dropdown action on feed cards with a confirmation dialog that defaults focus to cancel for destructive actions
- update viewer tests for forget behavior, ownership checks, and idempotent repeated forget requests

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Tests pass locally (`pytest`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional validation:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/ui/src/tabs/feed.test.ts`
- `pnpm build`

## Checklist

- [ ] Code follows project style (`ruff check` and `ruff format` pass)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
