### PR TITLE
refactor(ui): standardize settings on shared Radix primitives

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1423,7 +1423,38 @@
       }
       .modal-header { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); }
       .modal-header h2 { margin: 0; font-size: 18px; }
-      .modal-close { border: none; background: transparent; color: var(--text-tertiary); cursor: pointer; font-size: 12px; font-family: var(--font-sans); }
+      .modal-close-button {
+        border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+        background: color-mix(in srgb, var(--surface-0) 78%, transparent);
+        color: var(--text-secondary);
+        border-radius: var(--radius-pill);
+        min-height: 30px;
+        padding: 0 10px;
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        cursor: pointer;
+        font-family: var(--font-sans);
+        font-size: 12px;
+        transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+      }
+      .modal-close-button:hover {
+        border-color: var(--border-hover);
+        background: color-mix(in srgb, var(--surface-0) 92%, var(--control-hover-bg));
+        color: var(--text-primary);
+      }
+      .modal-close-button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .modal-close-button-icon {
+        font-size: 11px;
+        color: var(--text-tertiary);
+      }
+      .modal-close-button-label {
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
       .modal-body { display: flex; flex-direction: column; gap: var(--sp-3); flex: 1; min-height: 0; overflow-y: auto; padding-right: 6px; }
       .modal-footer { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); flex-shrink: 0; padding-top: var(--sp-2); border-top: 1px solid var(--border); }
       @keyframes noticeSlideIn {
@@ -1528,13 +1559,15 @@
         cursor: pointer;
       }
       .settings-tab:hover { border-color: var(--border-hover); }
-      .settings-tab.active {
+      .settings-tab.active,
+      .settings-tab[data-state="active"] {
         border-color: var(--control-hover-border);
         color: var(--accent);
         background: var(--accent-subtle);
       }
-      .settings-panel { display: none; flex-direction: column; gap: var(--sp-3); }
-      .settings-panel.active { display: flex; }
+      .settings-panel { display: flex; flex-direction: column; gap: var(--sp-3); }
+      .settings-panel[data-state="inactive"] { display: none; }
+      .settings-panel[hidden] { display: none; }
       .observer-status-banner {
         display: flex;
         flex-direction: column;
@@ -1673,6 +1706,56 @@
 
       .field { display: flex; flex-direction: column; gap: 6px; font-size: 13px; }
       .field input:not([type="checkbox"]), .field select, .field textarea { padding: var(--sp-2) var(--sp-3); border-radius: var(--radius-sm); border: 1px solid var(--border); background: var(--input-bg); font-family: var(--font-sans); font-size: 13px; color: var(--text-primary); }
+      .settings-select-trigger {
+        display: inline-flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        width: 100%;
+        padding: var(--sp-2) var(--sp-3);
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--input-bg);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 13px;
+        text-align: left;
+      }
+      .settings-select-trigger:hover { border-color: var(--border-hover); }
+      .settings-select-trigger:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px var(--focus-ring);
+      }
+      .settings-select-content {
+        z-index: 30;
+        min-width: var(--radix-select-trigger-width);
+        overflow: hidden;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-1);
+        box-shadow: var(--shadow-lg);
+      }
+      .settings-select-viewport { padding: 6px; }
+      .settings-select-item {
+        min-height: 36px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 8px 12px;
+        border-radius: var(--radius-sm);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 13px;
+        cursor: pointer;
+        user-select: none;
+      }
+      .settings-select-item[data-highlighted] {
+        outline: none;
+        background: var(--accent-subtle);
+        color: var(--accent);
+      }
       .field-checkbox { flex-direction: row; align-items: center; gap: 8px; }
       .field-checkbox input[type="checkbox"] { width: 14px; height: 14px; margin: 0; }
       .field-checkbox label { margin: 0; }
@@ -1757,6 +1840,59 @@
         display: flex;
         flex-direction: column;
         gap: var(--sp-2);
+      }
+      .sync-dialog-radio-list {
+        display: grid;
+        gap: var(--sp-2);
+      }
+      .sync-dialog-radio-option {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 12px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-1) 86%, var(--surface-0));
+        cursor: pointer;
+        transition: border-color 0.15s ease, background 0.15s ease;
+      }
+      .sync-dialog-radio-option:hover {
+        border-color: var(--border-hover);
+        background: color-mix(in srgb, var(--surface-1) 94%, var(--surface-0));
+      }
+      .sync-dialog-radio-option:has(button[data-state="checked"]) {
+        border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+        background: color-mix(in srgb, var(--accent-subtle) 68%, var(--surface-1));
+      }
+      .sync-dialog-radio-option button {
+        width: 18px;
+        height: 18px;
+        border-radius: 999px;
+        border: 1px solid color-mix(in srgb, var(--text-tertiary) 42%, var(--border));
+        background: var(--surface-0);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        flex: 0 0 auto;
+      }
+      .sync-dialog-radio-option button:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .sync-dialog-radio-option button[data-state="checked"] {
+        border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
+        background: color-mix(in srgb, var(--accent-subtle) 82%, var(--surface-0));
+      }
+      .sync-dialog-radio-indicator {
+        width: 8px;
+        height: 8px;
+        border-radius: 999px;
+        background: var(--accent);
+      }
+      .sync-dialog-radio-label {
+        color: var(--text-primary);
+        font-size: 13px;
       }
       .settings-save:disabled { opacity: 0.6; cursor: not-allowed; }
       .settings-note { color: var(--text-tertiary); font-size: 12px; }
@@ -1876,14 +2012,17 @@
       <div class="modal-card">
         <div class="modal-header">
           <h2 id="settingsTitle">Memory & model settings</h2>
-          <button class="modal-close" id="settingsClose" aria-label="Close settings">close</button>
+          <button class="modal-close-button" id="settingsClose" aria-label="Close settings">
+            <span class="modal-close-button-icon" aria-hidden="true">✕</span>
+            <span class="modal-close-button-label">Close</span>
+          </button>
         </div>
         <div class="modal-body">
           <div class="small" id="settingsDescription">Configure connection, authentication, processing, and sync behavior.</div>
           <div class="settings-tabs" role="tablist" aria-label="Settings sections">
-            <button class="settings-tab active" id="settingsTabObserver" data-settings-tab="observer" role="tab" aria-selected="true">Connection</button>
-            <button class="settings-tab" id="settingsTabQueue" data-settings-tab="queue" role="tab" aria-selected="false">Processing</button>
-            <button class="settings-tab" id="settingsTabSync" data-settings-tab="sync" role="tab" aria-selected="false">Device Sync</button>
+            <button class="settings-tab" id="settingsTabObserver" data-settings-tab="observer" role="tab" aria-selected="true" data-state="active">Connection</button>
+            <button class="settings-tab" id="settingsTabQueue" data-settings-tab="queue" role="tab" aria-selected="false" data-state="inactive">Processing</button>
+            <button class="settings-tab" id="settingsTabSync" data-settings-tab="sync" role="tab" aria-selected="false" data-state="inactive">Device Sync</button>
           </div>
           <div class="settings-advanced-toolbar field-checkbox">
             <input class="cm-checkbox" id="settingsAdvancedToggle" type="checkbox" />
@@ -1891,7 +2030,7 @@
             <button class="help-icon" type="button" data-tooltip="Advanced controls include JSON fields, tuning values, and network overrides." aria-label="About advanced controls">?</button>
           </div>
 
-          <div class="settings-panel active" id="settingsPanelObserver" data-settings-panel="observer">
+          <div class="settings-panel" id="settingsPanelObserver" data-settings-panel="observer" data-state="active">
             <div id="observerStatusBanner" class="observer-status-banner" hidden></div>
             <div class="settings-group">
               <h3 class="settings-group-title">Connection</h3>
@@ -1986,7 +2125,7 @@
             </div>
           </div>
 
-          <div class="settings-panel" id="settingsPanelQueue" data-settings-panel="queue">
+          <div class="settings-panel" id="settingsPanelQueue" data-settings-panel="queue" data-state="inactive" hidden>
             <div class="settings-group">
               <h3 class="settings-group-title">Processing</h3>
               <div class="field">
@@ -2013,7 +2152,7 @@
             </div>
           </div>
 
-          <div class="settings-panel" id="settingsPanelSync" data-settings-panel="sync">
+          <div class="settings-panel" id="settingsPanelSync" data-settings-panel="sync" data-state="inactive" hidden>
             <div class="settings-group">
               <h3 class="settings-group-title">Device Sync</h3>
               <div class="field field-checkbox"><input class="cm-checkbox" id="syncEnabled" type="checkbox" /><label for="syncEnabled">Enable sync</label></div>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,20 +7,24 @@
 		"dev": "vite",
 		"build": "vite build --mode production && node ./scripts/stage-viewer-static.mjs",
 		"build:watch": "vite build --watch --mode development",
+		"test": "pnpm exec vitest run",
 		"typecheck": "tsc -p tsconfig.json --noEmit"
 	},
 	"dependencies": {
-		"@radix-ui/react-dropdown-menu": "^2.1.16",
+		"@preact/signals": "^2.5.1",
 		"@radix-ui/react-collapsible": "^1.1.12",
 		"@radix-ui/react-dialog": "^1.1.15",
+		"@radix-ui/react-dropdown-menu": "^2.1.16",
+		"@radix-ui/react-radio-group": "^1.3.8",
 		"@radix-ui/react-select": "^2.2.6",
 		"@radix-ui/react-switch": "^1.2.6",
-		"@preact/signals": "^2.5.1",
+		"@radix-ui/react-tabs": "^1.1.13",
 		"preact": "^10.27.2",
 		"tslib": "^2.8.1"
 	},
 	"devDependencies": {
 		"@preact/preset-vite": "^2.10.2",
+		"jsdom": "^27.0.1",
 		"typescript": "catalog:",
 		"vite": "catalog:"
 	}

--- a/packages/ui/src/components/primitives/dialog-close-button.tsx
+++ b/packages/ui/src/components/primitives/dialog-close-button.tsx
@@ -1,0 +1,22 @@
+type DialogCloseButtonProps = {
+	ariaLabel: string;
+	className?: string;
+	onClick: () => void;
+	label?: string;
+};
+
+export function DialogCloseButton({
+	ariaLabel,
+	className = "modal-close-button",
+	onClick,
+	label = "Close",
+}: DialogCloseButtonProps) {
+	return (
+		<button aria-label={ariaLabel} className={className} onClick={onClick} type="button">
+			<span aria-hidden="true" className="modal-close-button-icon">
+				✕
+			</span>
+			<span className="modal-close-button-label">{label}</span>
+		</button>
+	);
+}

--- a/packages/ui/src/components/primitives/radix-radio-group.tsx
+++ b/packages/ui/src/components/primitives/radix-radio-group.tsx
@@ -1,0 +1,68 @@
+import * as RadioGroup from "@radix-ui/react-radio-group";
+import type { ComponentChildren } from "preact";
+
+export type RadixRadioOption = {
+	disabled?: boolean;
+	label: ComponentChildren;
+	value: string;
+};
+
+type RadixRadioGroupProps = {
+	ariaDescribedby?: string;
+	ariaLabel?: string;
+	autoFocusValue?: string;
+	indicatorClassName?: string;
+	itemClassName?: string;
+	itemLabelClassName?: string;
+	name?: string;
+	onValueChange: (value: string) => void;
+	options: RadixRadioOption[];
+	rootClassName?: string;
+	value: string;
+};
+
+export function RadixRadioGroup({
+	ariaDescribedby,
+	ariaLabel,
+	autoFocusValue,
+	indicatorClassName,
+	itemClassName,
+	itemLabelClassName,
+	name,
+	onValueChange,
+	options,
+	rootClassName,
+	value,
+}: RadixRadioGroupProps) {
+	return (
+		<RadioGroup.Root
+			aria-describedby={ariaDescribedby}
+			aria-label={ariaLabel}
+			className={rootClassName}
+			name={name}
+			onValueChange={onValueChange}
+			value={value}
+		>
+			{options.map((option, index) => {
+				const inputId = `radio-option-input-${index}`;
+				const labelId = `radio-option-label-${index}`;
+				return (
+					<label className={itemClassName} htmlFor={inputId} key={option.value}>
+						<RadioGroup.Item
+							id={inputId}
+							aria-labelledby={labelId}
+							autoFocus={autoFocusValue === option.value}
+							disabled={option.disabled}
+							value={option.value}
+						>
+							<RadioGroup.Indicator className={indicatorClassName} />
+						</RadioGroup.Item>
+						<span className={itemLabelClassName} id={labelId}>
+							{option.label}
+						</span>
+					</label>
+				);
+			})}
+		</RadioGroup.Root>
+	);
+}

--- a/packages/ui/src/components/primitives/radix-select.tsx
+++ b/packages/ui/src/components/primitives/radix-select.tsx
@@ -54,7 +54,7 @@ export function RadixSelect({
 			value={encodedValue}
 		>
 			<Select.Trigger
-				aria-label={ariaLabel ?? placeholder}
+				aria-label={ariaLabel}
 				className={triggerClassName ?? className}
 				data-value={value}
 				id={id}

--- a/packages/ui/src/components/primitives/radix-tabs.tsx
+++ b/packages/ui/src/components/primitives/radix-tabs.tsx
@@ -1,0 +1,66 @@
+import * as Tabs from "@radix-ui/react-tabs";
+import type { ComponentChildren } from "preact";
+
+export type RadixTabOption = {
+	disabled?: boolean;
+	label: string;
+	value: string;
+};
+
+type RadixTabsProps = {
+	ariaLabel?: string;
+	children?: ComponentChildren;
+	listClassName?: string;
+	onValueChange: (value: string) => void;
+	tabs: RadixTabOption[];
+	triggerClassName?: string;
+	value: string;
+};
+
+type RadixTabsContentProps = {
+	children?: ComponentChildren;
+	className?: string;
+	forceMount?: boolean;
+	value: string;
+};
+
+export function RadixTabs({
+	ariaLabel,
+	children,
+	listClassName,
+	onValueChange,
+	tabs,
+	triggerClassName,
+	value,
+}: RadixTabsProps) {
+	return (
+		<Tabs.Root onValueChange={onValueChange} value={value}>
+			<Tabs.List aria-label={ariaLabel} className={listClassName}>
+				{tabs.map((tab) => (
+					<Tabs.Trigger
+						className={triggerClassName}
+						disabled={tab.disabled}
+						key={tab.value}
+						value={tab.value}
+					>
+						{tab.label}
+					</Tabs.Trigger>
+				))}
+			</Tabs.List>
+			{children}
+		</Tabs.Root>
+	);
+}
+
+export function RadixTabsContent({
+	children,
+	className,
+	forceMount = false,
+	value,
+}: RadixTabsContentProps) {
+	return (
+		<Tabs.Content className={className} forceMount={forceMount ? true : undefined} value={value}>
+			{children}
+		</Tabs.Content>
+	);
+}

--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -3,7 +3,14 @@
 import { type ComponentChildren, type JSX, render } from "preact";
 import { createPortal } from "preact/compat";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
+import { DialogCloseButton } from "../components/primitives/dialog-close-button";
 import { RadixDialog } from "../components/primitives/radix-dialog";
+import { RadixSelect } from "../components/primitives/radix-select";
+import {
+	type RadixTabOption,
+	RadixTabs,
+	RadixTabsContent,
+} from "../components/primitives/radix-tabs";
 import * as api from "../lib/api";
 import { $, $button } from "../lib/dom";
 import { showGlobalNotice } from "../lib/notice";
@@ -24,6 +31,12 @@ let settingsShowAdvanced = loadAdvancedPreference();
 
 const DEFAULT_OPENAI_MODEL = "gpt-5.1-codex-mini";
 const DEFAULT_ANTHROPIC_MODEL = "claude-4.5-haiku";
+
+const SETTINGS_TABS: RadixTabOption[] = [
+	{ value: "observer", label: "Connection" },
+	{ value: "queue", label: "Processing" },
+	{ value: "sync", label: "Device Sync" },
+];
 
 type SettingsTabId = "observer" | "queue" | "sync";
 
@@ -1259,9 +1272,9 @@ function onTextInput<K extends keyof SettingsFormState>(field: K) {
 	};
 }
 
-function onSelectInput<K extends keyof SettingsFormState>(field: K) {
-	return (event: JSX.TargetedEvent<HTMLSelectElement, Event>) => {
-		updateField(field, event.currentTarget.value as SettingsFormState[K]);
+function onSelectValueChange<K extends keyof SettingsFormState>(field: K) {
+	return (value: string) => {
+		updateField(field, value as SettingsFormState[K]);
 	};
 }
 
@@ -1275,14 +1288,6 @@ function onAdvancedToggle(event: JSX.TargetedEvent<HTMLInputElement, Event>) {
 	const checked = event.currentTarget.checked;
 	settingsShowAdvanced = checked;
 	settingsController?.setShowAdvanced(checked);
-}
-
-function tabButtonClass(tab: SettingsTabId): string {
-	return `settings-tab${settingsActiveTab === tab ? " active" : ""}`;
-}
-
-function panelClass(tab: SettingsTabId): string {
-	return `settings-panel${settingsActiveTab === tab ? " active" : ""}`;
 }
 
 function hiddenUnlessAdvanced(): boolean {
@@ -1430,63 +1435,33 @@ function SettingsDialogContent() {
 	const showAuthFile = values.observerAuthSource === "file";
 	const showAuthCommand = values.observerAuthSource === "command";
 	const showTieredRouting = values.observerTierRoutingEnabled;
+	const providerOptions = Array.from(
+		new Set(
+			settingsRenderState.providers.concat(
+				values.observerProvider ? [values.observerProvider] : [],
+			),
+		),
+	)
+		.sort((left, right) => left.localeCompare(right))
+		.map((provider) => ({ label: provider, value: provider }));
 
 	return (
 		<div className="modal-card">
 			<div className="modal-header">
 				<h2 id="settingsTitle">Memory & model settings</h2>
-				<button
-					aria-label="Close settings"
-					className="modal-close"
-					id="settingsClose"
+				<DialogCloseButton
+					ariaLabel="Close settings"
+					className="modal-close-button"
 					onClick={() => {
 						if (settingsStartPolling && settingsRefresh) {
 							closeSettings(settingsStartPolling, settingsRefresh);
 						}
 					}}
-					type="button"
-				>
-					close
-				</button>
+				/>
 			</div>
 			<div className="modal-body">
 				<div className="small" id="settingsDescription">
 					Configure connection, authentication, processing, and sync behavior.
-				</div>
-				<div aria-label="Settings sections" className="settings-tabs" role="tablist">
-					<button
-						aria-selected={settingsActiveTab === "observer" ? "true" : "false"}
-						className={tabButtonClass("observer")}
-						data-settings-tab="observer"
-						id="settingsTabObserver"
-						onClick={() => setSettingsTab("observer")}
-						role="tab"
-						type="button"
-					>
-						Connection
-					</button>
-					<button
-						aria-selected={settingsActiveTab === "queue" ? "true" : "false"}
-						className={tabButtonClass("queue")}
-						data-settings-tab="queue"
-						id="settingsTabQueue"
-						onClick={() => setSettingsTab("queue")}
-						role="tab"
-						type="button"
-					>
-						Processing
-					</button>
-					<button
-						aria-selected={settingsActiveTab === "sync" ? "true" : "false"}
-						className={tabButtonClass("sync")}
-						data-settings-tab="sync"
-						id="settingsTabSync"
-						onClick={() => setSettingsTab("sync")}
-						role="tab"
-						type="button"
-					>
-						Device Sync
-					</button>
 				</div>
 				<div className="settings-advanced-toolbar field-checkbox">
 					<input
@@ -1507,522 +1482,527 @@ function SettingsDialogContent() {
 					</button>
 				</div>
 
-				<div
-					className={panelClass("observer")}
-					data-settings-panel="observer"
-					hidden={settingsActiveTab !== "observer"}
-					id="settingsPanelObserver"
+				<RadixTabs
+					ariaLabel="Settings sections"
+					listClassName="settings-tabs"
+					onValueChange={setSettingsTab}
+					tabs={SETTINGS_TABS}
+					triggerClassName="settings-tab"
+					value={settingsActiveTab}
 				>
-					<ObserverStatusBanner />
-					<div className="settings-group">
-						<h3 className="settings-group-title">Connection</h3>
-						<Field>
-							<div className="field-label">
-								<label htmlFor="observerProvider">Model provider</label>
-								<button
-									aria-label="About model provider"
-									className="help-icon"
-									data-tooltip="Choose where model requests are sent. Use auto for recommended defaults."
-									type="button"
-								>
-									?
-								</button>
-							</div>
-							<select
-								id="observerProvider"
-								onChange={onSelectInput("observerProvider")}
-								value={values.observerProvider}
-							>
-								<option value="">auto (default)</option>
-								{Array.from(
-									new Set(
-										settingsRenderState.providers.concat(
-											values.observerProvider ? [values.observerProvider] : [],
-										),
-									),
-								)
-									.sort((left, right) => left.localeCompare(right))
-									.map((provider) => (
-										<option key={provider} value={provider}>
-											{provider}
-										</option>
-									))}
-							</select>
-							<div className="small">
-								`auto` uses recommended defaults for the selected connection mode.
-							</div>
-						</Field>
-						<Field>
-							<div className="field-label">
-								<label htmlFor="observerModel">{getObserverModelLabel()}</label>
-								<button
-									aria-label="About model defaults"
-									className="help-icon"
-									data-tooltip={getObserverModelTooltip()}
-									type="button"
-								>
-									?
-								</button>
-							</div>
-							<input
-								id="observerModel"
-								onInput={onTextInput("observerModel")}
-								placeholder="leave empty for default"
-								value={values.observerModel}
-							/>
-							<div className="small">{getObserverModelDescription()}</div>
-							<div className="small" id="observerModelHint">
-								{getObserverModelHint()}
-							</div>
-						</Field>
-						<Field>
-							<div className="field-label">
-								<label htmlFor="observerRuntime">Connection mode</label>
-								<button
-									aria-label="About connection mode"
-									className="help-icon"
-									data-tooltip="Direct API uses provider credentials. Local Claude session uses local Claude runtime auth."
-									type="button"
-								>
-									?
-								</button>
-							</div>
-							<select
-								id="observerRuntime"
-								onChange={onSelectInput("observerRuntime")}
-								value={values.observerRuntime}
-							>
-								<option value="api_http">Direct API (default)</option>
-								<option value="claude_sidecar">Local Claude session</option>
-							</select>
-							<div className="small">
-								Switch between provider API credentials and local Claude session auth.
-							</div>
-						</Field>
-						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="claudeCommand">Claude command (JSON argv)</label>
-							<textarea
-								disabled
-								id="claudeCommand"
-								placeholder='["claude"]'
-								rows={2}
-								value={values.claudeCommand}
-							/>
-							<div className="small">{protectedConfigHelp("claude_command")}</div>
-						</Field>
-						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="observerMaxChars">Request size limit (chars)</label>
-							<input
-								id="observerMaxChars"
-								min="1"
-								onInput={onTextInput("observerMaxChars")}
-								type="number"
-								value={values.observerMaxChars}
-							/>
-							<div className="small" id="observerMaxCharsHint">
-								{observerMaxCharsDefault ? `Default: ${observerMaxCharsDefault}` : ""}
-							</div>
-						</Field>
-					</div>
-
-					<div className="settings-group">
-						<h3 className="settings-group-title">Authentication</h3>
-						<Field>
-							<div className="field-label">
-								<label htmlFor="observerAuthSource">Authentication method</label>
-								<button
-									aria-label="About authentication method"
-									className="help-icon"
-									data-tooltip="Choose how credentials are resolved: environment, file, command, or none."
-									type="button"
-								>
-									?
-								</button>
-							</div>
-							<select
-								id="observerAuthSource"
-								onChange={onSelectInput("observerAuthSource")}
-								value={values.observerAuthSource}
-							>
-								<option value="auto">auto (default)</option>
-								<option value="env">env</option>
-								<option value="file">file</option>
-								<option value="command">command</option>
-								<option value="none">none</option>
-							</select>
-							<div className="small">Use `auto` unless you need a specific token source.</div>
-						</Field>
-						<Field hidden={!showAuthFile} id="observerAuthFileField">
-							<label htmlFor="observerAuthFile">Token file path</label>
-							<input
-								disabled
-								id="observerAuthFile"
-								placeholder="~/.codemem/work-token.txt"
-								value={values.observerAuthFile}
-							/>
-							<div className="small">{protectedConfigHelp("observer_auth_file")}</div>
-						</Field>
-						<Field hidden={!showAuthCommand} id="observerAuthCommandField">
-							<div className="field-label">
-								<label htmlFor="observerAuthCommand">Token command</label>
-								<button
-									aria-label="About token command"
-									className="help-icon"
-									data-tooltip="Runs this command and uses stdout as the token. JSON argv only, no shell parsing."
-									type="button"
-								>
-									?
-								</button>
-							</div>
-							<textarea
-								disabled
-								id="observerAuthCommand"
-								placeholder='["iap-auth", "--audience", "gateway"]'
-								rows={3}
-								value={values.observerAuthCommand}
-							/>
-							<div className="small">{protectedConfigHelp("observer_auth_command")}</div>
-						</Field>
-						<div className="small" hidden={!showAuthCommand} id="observerAuthCommandNote">
-							Command format: JSON string array, e.g. `["iap-auth", "--audience", "gateway"]`.
+					<RadixTabsContent className="settings-panel" forceMount value="observer">
+						<ObserverStatusBanner />
+						<div className="settings-group">
+							<h3 className="settings-group-title">Connection</h3>
+							<Field>
+								<div className="field-label">
+									<label htmlFor="observerProvider">Model provider</label>
+									<button
+										aria-label="About model provider"
+										className="help-icon"
+										data-tooltip="Choose where model requests are sent. Use auto for recommended defaults."
+										type="button"
+									>
+										?
+									</button>
+								</div>
+								<RadixSelect
+									ariaLabel="Model provider"
+									contentClassName="settings-select-content"
+									id="observerProvider"
+									itemClassName="settings-select-item"
+									onValueChange={onSelectValueChange("observerProvider")}
+									options={[{ label: "auto (default)", value: "" }, ...providerOptions]}
+									placeholder="auto (default)"
+									triggerClassName="settings-select-trigger"
+									value={values.observerProvider}
+									viewportClassName="settings-select-viewport"
+								/>
+								<div className="small">
+									`auto` uses recommended defaults for the selected connection mode.
+								</div>
+							</Field>
+							<Field>
+								<div className="field-label">
+									<label htmlFor="observerModel">{getObserverModelLabel()}</label>
+									<button
+										aria-label="About model defaults"
+										className="help-icon"
+										data-tooltip={getObserverModelTooltip()}
+										type="button"
+									>
+										?
+									</button>
+								</div>
+								<input
+									id="observerModel"
+									onInput={onTextInput("observerModel")}
+									placeholder="leave empty for default"
+									value={values.observerModel}
+								/>
+								<div className="small">{getObserverModelDescription()}</div>
+								<div className="small" id="observerModelHint">
+									{getObserverModelHint()}
+								</div>
+							</Field>
+							<Field>
+								<div className="field-label">
+									<label htmlFor="observerRuntime">Connection mode</label>
+									<button
+										aria-label="About connection mode"
+										className="help-icon"
+										data-tooltip="Direct API uses provider credentials. Local Claude session uses local Claude runtime auth."
+										type="button"
+									>
+										?
+									</button>
+								</div>
+								<RadixSelect
+									ariaLabel="Connection mode"
+									contentClassName="settings-select-content"
+									id="observerRuntime"
+									itemClassName="settings-select-item"
+									onValueChange={onSelectValueChange("observerRuntime")}
+									options={[
+										{ label: "Direct API (default)", value: "api_http" },
+										{ label: "Local Claude session", value: "claude_sidecar" },
+									]}
+									triggerClassName="settings-select-trigger"
+									value={values.observerRuntime}
+									viewportClassName="settings-select-viewport"
+								/>
+								<div className="small">
+									Switch between provider API credentials and local Claude session auth.
+								</div>
+							</Field>
+							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="claudeCommand">Claude command (JSON argv)</label>
+								<textarea
+									disabled
+									id="claudeCommand"
+									placeholder='["claude"]'
+									rows={2}
+									value={values.claudeCommand}
+								/>
+								<div className="small">{protectedConfigHelp("claude_command")}</div>
+							</Field>
+							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="observerMaxChars">Request size limit (chars)</label>
+								<input
+									id="observerMaxChars"
+									min="1"
+									onInput={onTextInput("observerMaxChars")}
+									type="number"
+									value={values.observerMaxChars}
+								/>
+								<div className="small" id="observerMaxCharsHint">
+									{observerMaxCharsDefault ? `Default: ${observerMaxCharsDefault}` : ""}
+								</div>
+							</Field>
 						</div>
-						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="observerAuthTimeoutMs">Token command timeout (ms)</label>
-							<input
-								id="observerAuthTimeoutMs"
-								min="1"
-								onInput={onTextInput("observerAuthTimeoutMs")}
-								type="number"
-								value={values.observerAuthTimeoutMs}
-							/>
-						</Field>
-						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="observerAuthCacheTtlS">Token cache time (s)</label>
-							<input
-								id="observerAuthCacheTtlS"
-								min="0"
-								onInput={onTextInput("observerAuthCacheTtlS")}
-								type="number"
-								value={values.observerAuthCacheTtlS}
-							/>
-						</Field>
-						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<div className="field-label">
-								<label htmlFor="observerHeaders">Request headers (JSON)</label>
-								<button
-									aria-label="About request headers"
-									className="help-icon"
-									data-tooltip={
-										// biome-ignore lint/suspicious/noTemplateCurlyInString: literal documentation text describing the template placeholder syntax users can use in header values
-										"Optional extra headers. Supports templates like ${auth.token}, ${auth.type}, ${auth.source}."
-									}
-									type="button"
-								>
-									?
-								</button>
-							</div>
-							<textarea
-								disabled
-								id="observerHeaders"
-								placeholder='{"Authorization":"Bearer ${auth.token}"}'
-								rows={4}
-								value={values.observerHeaders}
-							/>
-							<div className="small">{protectedConfigHelp("observer_headers")}</div>
-						</Field>
-					</div>
-				</div>
 
-				<div
-					className={panelClass("queue")}
-					data-settings-panel="queue"
-					hidden={settingsActiveTab !== "queue"}
-					id="settingsPanelQueue"
-				>
-					<div className="settings-group">
-						<h3 className="settings-group-title">Processing</h3>
-						<Field>
-							<div className="field-label">
-								<label htmlFor="rawEventsSweeperIntervalS">
-									Background processing interval (seconds)
+						<div className="settings-group">
+							<h3 className="settings-group-title">Authentication</h3>
+							<Field>
+								<div className="field-label">
+									<label htmlFor="observerAuthSource">Authentication method</label>
+									<button
+										aria-label="About authentication method"
+										className="help-icon"
+										data-tooltip="Choose how credentials are resolved: environment, file, command, or none."
+										type="button"
+									>
+										?
+									</button>
+								</div>
+								<RadixSelect
+									ariaLabel="Authentication method"
+									contentClassName="settings-select-content"
+									id="observerAuthSource"
+									itemClassName="settings-select-item"
+									onValueChange={onSelectValueChange("observerAuthSource")}
+									options={[
+										{ label: "auto (default)", value: "auto" },
+										{ label: "env", value: "env" },
+										{ label: "file", value: "file" },
+										{ label: "command", value: "command" },
+										{ label: "none", value: "none" },
+									]}
+									triggerClassName="settings-select-trigger"
+									value={values.observerAuthSource}
+									viewportClassName="settings-select-viewport"
+								/>
+								<div className="small">Use `auto` unless you need a specific token source.</div>
+							</Field>
+							<Field hidden={!showAuthFile} id="observerAuthFileField">
+								<label htmlFor="observerAuthFile">Token file path</label>
+								<input
+									disabled
+									id="observerAuthFile"
+									placeholder="~/.codemem/work-token.txt"
+									value={values.observerAuthFile}
+								/>
+								<div className="small">{protectedConfigHelp("observer_auth_file")}</div>
+							</Field>
+							<Field hidden={!showAuthCommand} id="observerAuthCommandField">
+								<div className="field-label">
+									<label htmlFor="observerAuthCommand">Token command</label>
+									<button
+										aria-label="About token command"
+										className="help-icon"
+										data-tooltip="Runs this command and uses stdout as the token. JSON argv only, no shell parsing."
+										type="button"
+									>
+										?
+									</button>
+								</div>
+								<textarea
+									disabled
+									id="observerAuthCommand"
+									placeholder='["iap-auth", "--audience", "gateway"]'
+									rows={3}
+									value={values.observerAuthCommand}
+								/>
+								<div className="small">{protectedConfigHelp("observer_auth_command")}</div>
+							</Field>
+							<div className="small" hidden={!showAuthCommand} id="observerAuthCommandNote">
+								Command format: JSON string array, e.g. `["iap-auth", "--audience", "gateway"]`.
+							</div>
+							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="observerAuthTimeoutMs">Token command timeout (ms)</label>
+								<input
+									id="observerAuthTimeoutMs"
+									min="1"
+									onInput={onTextInput("observerAuthTimeoutMs")}
+									type="number"
+									value={values.observerAuthTimeoutMs}
+								/>
+							</Field>
+							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="observerAuthCacheTtlS">Token cache time (s)</label>
+								<input
+									id="observerAuthCacheTtlS"
+									min="0"
+									onInput={onTextInput("observerAuthCacheTtlS")}
+									type="number"
+									value={values.observerAuthCacheTtlS}
+								/>
+							</Field>
+							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<div className="field-label">
+									<label htmlFor="observerHeaders">Request headers (JSON)</label>
+									<button
+										aria-label="About request headers"
+										className="help-icon"
+										data-tooltip={
+											// biome-ignore lint/suspicious/noTemplateCurlyInString: literal documentation text describing the template placeholder syntax users can use in header values
+											"Optional extra headers. Supports templates like ${auth.token}, ${auth.type}, ${auth.source}."
+										}
+										type="button"
+									>
+										?
+									</button>
+								</div>
+								<textarea
+									disabled
+									id="observerHeaders"
+									placeholder='{"Authorization":"Bearer ${auth.token}"}'
+									rows={4}
+									value={values.observerHeaders}
+								/>
+								<div className="small">{protectedConfigHelp("observer_headers")}</div>
+							</Field>
+						</div>
+					</RadixTabsContent>
+
+					<RadixTabsContent className="settings-panel" forceMount value="queue">
+						<div className="settings-group">
+							<h3 className="settings-group-title">Processing</h3>
+							<Field>
+								<div className="field-label">
+									<label htmlFor="rawEventsSweeperIntervalS">
+										Background processing interval (seconds)
+									</label>
+									<button
+										aria-label="About background processing interval"
+										className="help-icon"
+										data-tooltip="How often codemem checks for queued events to process in the background."
+										type="button"
+									>
+										?
+									</button>
+								</div>
+								<input
+									id="rawEventsSweeperIntervalS"
+									min="1"
+									onInput={onTextInput("rawEventsSweeperIntervalS")}
+									type="number"
+									value={values.rawEventsSweeperIntervalS}
+								/>
+								<div className="small">How often background flush checks pending raw events.</div>
+							</Field>
+						</div>
+						<div className="settings-group">
+							<h3 className="settings-group-title">Tiered observer routing</h3>
+							<div className="field field-checkbox">
+								<input
+									checked={values.observerTierRoutingEnabled}
+									className="cm-checkbox"
+									id="observerTierRoutingEnabled"
+									onChange={onCheckboxInput("observerTierRoutingEnabled")}
+									type="checkbox"
+								/>
+								<label htmlFor="observerTierRoutingEnabled">Enable tiered routing</label>
+							</div>
+							<div className="small">{getTieredRoutingHelperText()}</div>
+							<Field hidden={!showTieredRouting}>
+								<div className="field-label">
+									<label htmlFor="observerSimpleModel">Simple tier model</label>
+									<button
+										aria-label="About simple tier model"
+										className="help-icon"
+										data-tooltip="Used for lighter replay batches. Leave blank to keep codemem's routing defaults or base observer fallback."
+										type="button"
+									>
+										?
+									</button>
+								</div>
+								<input
+									id="observerSimpleModel"
+									onInput={onTextInput("observerSimpleModel")}
+									placeholder="leave empty for default"
+									value={values.observerSimpleModel}
+								/>
+								<div className="small">Used when a batch falls below rich-routing thresholds.</div>
+							</Field>
+							<Field hidden={!showTieredRouting}>
+								<div className="field-label">
+									<label htmlFor="observerRichModel">Rich tier model</label>
+									<button
+										aria-label="About rich tier model"
+										className="help-icon"
+										data-tooltip="Used for larger or more complex replay batches. Leave blank to keep codemem's rich-tier defaults."
+										type="button"
+									>
+										?
+									</button>
+								</div>
+								<input
+									id="observerRichModel"
+									onInput={onTextInput("observerRichModel")}
+									placeholder="leave empty for default"
+									value={values.observerRichModel}
+								/>
+								<div className="small">Used when routing detects a richer replay batch.</div>
+							</Field>
+							<Field className="field field-checkbox" hidden={!showTieredRouting}>
+								<input
+									checked={values.observerRichOpenAIUseResponses}
+									className="cm-checkbox"
+									id="observerRichOpenAIUseResponses"
+									onChange={onCheckboxInput("observerRichOpenAIUseResponses")}
+									type="checkbox"
+								/>
+								<label htmlFor="observerRichOpenAIUseResponses">
+									Use OpenAI Responses API for rich tier
 								</label>
-								<button
-									aria-label="About background processing interval"
-									className="help-icon"
-									data-tooltip="How often codemem checks for queued events to process in the background."
-									type="button"
-								>
-									?
-								</button>
-							</div>
-							<input
-								id="rawEventsSweeperIntervalS"
-								min="1"
-								onInput={onTextInput("rawEventsSweeperIntervalS")}
-								type="number"
-								value={values.rawEventsSweeperIntervalS}
-							/>
-							<div className="small">How often background flush checks pending raw events.</div>
-						</Field>
-					</div>
-					<div className="settings-group">
-						<h3 className="settings-group-title">Tiered observer routing</h3>
-						<div className="field field-checkbox">
-							<input
-								checked={values.observerTierRoutingEnabled}
-								className="cm-checkbox"
-								id="observerTierRoutingEnabled"
-								onChange={onCheckboxInput("observerTierRoutingEnabled")}
-								type="checkbox"
-							/>
-							<label htmlFor="observerTierRoutingEnabled">Enable tiered routing</label>
+							</Field>
+							<Field
+								className="field settings-advanced"
+								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+							>
+								<label htmlFor="observerSimpleTemperature">Simple tier temperature</label>
+								<input
+									id="observerSimpleTemperature"
+									min="0"
+									onInput={onTextInput("observerSimpleTemperature")}
+									step="0.1"
+									type="number"
+									value={values.observerSimpleTemperature}
+								/>
+							</Field>
+							<Field
+								className="field settings-advanced"
+								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+							>
+								<label htmlFor="observerRichTemperature">Rich tier temperature</label>
+								<input
+									id="observerRichTemperature"
+									min="0"
+									onInput={onTextInput("observerRichTemperature")}
+									step="0.1"
+									type="number"
+									value={values.observerRichTemperature}
+								/>
+							</Field>
+							<Field
+								className="field settings-advanced"
+								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+							>
+								<label htmlFor="observerRichReasoningEffort">Rich tier reasoning effort</label>
+								<input
+									id="observerRichReasoningEffort"
+									onInput={onTextInput("observerRichReasoningEffort")}
+									placeholder="leave empty for default"
+									value={values.observerRichReasoningEffort}
+								/>
+							</Field>
+							<Field
+								className="field settings-advanced"
+								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+							>
+								<label htmlFor="observerRichReasoningSummary">Rich tier reasoning summary</label>
+								<input
+									id="observerRichReasoningSummary"
+									onInput={onTextInput("observerRichReasoningSummary")}
+									placeholder="leave empty for default"
+									value={values.observerRichReasoningSummary}
+								/>
+							</Field>
+							<Field
+								className="field settings-advanced"
+								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
+							>
+								<label htmlFor="observerRichMaxOutputTokens">Rich tier max output tokens</label>
+								<input
+									id="observerRichMaxOutputTokens"
+									min="1"
+									onInput={onTextInput("observerRichMaxOutputTokens")}
+									step="1"
+									type="number"
+									value={values.observerRichMaxOutputTokens}
+								/>
+							</Field>
 						</div>
-						<div className="small">{getTieredRoutingHelperText()}</div>
-						<Field hidden={!showTieredRouting}>
-							<div className="field-label">
-								<label htmlFor="observerSimpleModel">Simple tier model</label>
-								<button
-									aria-label="About simple tier model"
-									className="help-icon"
-									data-tooltip="Used for lighter replay batches. Leave blank to keep codemem's routing defaults or base observer fallback."
-									type="button"
-								>
-									?
-								</button>
-							</div>
-							<input
-								id="observerSimpleModel"
-								onInput={onTextInput("observerSimpleModel")}
-								placeholder="leave empty for default"
-								value={values.observerSimpleModel}
-							/>
-							<div className="small">Used when a batch falls below rich-routing thresholds.</div>
-						</Field>
-						<Field hidden={!showTieredRouting}>
-							<div className="field-label">
-								<label htmlFor="observerRichModel">Rich tier model</label>
-								<button
-									aria-label="About rich tier model"
-									className="help-icon"
-									data-tooltip="Used for larger or more complex replay batches. Leave blank to keep codemem's rich-tier defaults."
-									type="button"
-								>
-									?
-								</button>
-							</div>
-							<input
-								id="observerRichModel"
-								onInput={onTextInput("observerRichModel")}
-								placeholder="leave empty for default"
-								value={values.observerRichModel}
-							/>
-							<div className="small">Used when routing detects a richer replay batch.</div>
-						</Field>
-						<Field className="field field-checkbox" hidden={!showTieredRouting}>
-							<input
-								checked={values.observerRichOpenAIUseResponses}
-								className="cm-checkbox"
-								id="observerRichOpenAIUseResponses"
-								onChange={onCheckboxInput("observerRichOpenAIUseResponses")}
-								type="checkbox"
-							/>
-							<label htmlFor="observerRichOpenAIUseResponses">
-								Use OpenAI Responses API for rich tier
-							</label>
-						</Field>
-						<Field
-							className="field settings-advanced"
-							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
-						>
-							<label htmlFor="observerSimpleTemperature">Simple tier temperature</label>
-							<input
-								id="observerSimpleTemperature"
-								min="0"
-								onInput={onTextInput("observerSimpleTemperature")}
-								step="0.1"
-								type="number"
-								value={values.observerSimpleTemperature}
-							/>
-						</Field>
-						<Field
-							className="field settings-advanced"
-							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
-						>
-							<label htmlFor="observerRichTemperature">Rich tier temperature</label>
-							<input
-								id="observerRichTemperature"
-								min="0"
-								onInput={onTextInput("observerRichTemperature")}
-								step="0.1"
-								type="number"
-								value={values.observerRichTemperature}
-							/>
-						</Field>
-						<Field
-							className="field settings-advanced"
-							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
-						>
-							<label htmlFor="observerRichReasoningEffort">Rich tier reasoning effort</label>
-							<input
-								id="observerRichReasoningEffort"
-								onInput={onTextInput("observerRichReasoningEffort")}
-								placeholder="leave empty for default"
-								value={values.observerRichReasoningEffort}
-							/>
-						</Field>
-						<Field
-							className="field settings-advanced"
-							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
-						>
-							<label htmlFor="observerRichReasoningSummary">Rich tier reasoning summary</label>
-							<input
-								id="observerRichReasoningSummary"
-								onInput={onTextInput("observerRichReasoningSummary")}
-								placeholder="leave empty for default"
-								value={values.observerRichReasoningSummary}
-							/>
-						</Field>
-						<Field
-							className="field settings-advanced"
-							hidden={!showTieredRouting || hiddenUnlessAdvanced()}
-						>
-							<label htmlFor="observerRichMaxOutputTokens">Rich tier max output tokens</label>
-							<input
-								id="observerRichMaxOutputTokens"
-								min="1"
-								onInput={onTextInput("observerRichMaxOutputTokens")}
-								step="1"
-								type="number"
-								value={values.observerRichMaxOutputTokens}
-							/>
-						</Field>
-					</div>
-					<div className="settings-group settings-advanced" hidden={hiddenUnlessAdvanced()}>
-						<h3 className="settings-group-title">Context Pack Limits</h3>
-						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="packObservationLimit">Observation limit</label>
-							<input
-								id="packObservationLimit"
-								min="1"
-								onInput={onTextInput("packObservationLimit")}
-								type="number"
-								value={values.packObservationLimit}
-							/>
-							<div className="small">Default number of observations to include in a pack.</div>
-						</Field>
-						<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="packSessionLimit">Session summary limit</label>
-							<input
-								id="packSessionLimit"
-								min="1"
-								onInput={onTextInput("packSessionLimit")}
-								type="number"
-								value={values.packSessionLimit}
-							/>
-							<div className="small">Default number of session summaries to include in a pack.</div>
-						</Field>
-					</div>
-				</div>
+						<div className="settings-group settings-advanced" hidden={hiddenUnlessAdvanced()}>
+							<h3 className="settings-group-title">Context Pack Limits</h3>
+							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="packObservationLimit">Observation limit</label>
+								<input
+									id="packObservationLimit"
+									min="1"
+									onInput={onTextInput("packObservationLimit")}
+									type="number"
+									value={values.packObservationLimit}
+								/>
+								<div className="small">Default number of observations to include in a pack.</div>
+							</Field>
+							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="packSessionLimit">Session summary limit</label>
+								<input
+									id="packSessionLimit"
+									min="1"
+									onInput={onTextInput("packSessionLimit")}
+									type="number"
+									value={values.packSessionLimit}
+								/>
+								<div className="small">
+									Default number of session summaries to include in a pack.
+								</div>
+							</Field>
+						</div>
+					</RadixTabsContent>
 
-				<div
-					className={panelClass("sync")}
-					data-settings-panel="sync"
-					hidden={settingsActiveTab !== "sync"}
-					id="settingsPanelSync"
-				>
-					<div className="settings-group">
-						<h3 className="settings-group-title">Device Sync</h3>
-						<div className="field field-checkbox">
-							<input
-								checked={values.syncEnabled}
-								className="cm-checkbox"
-								id="syncEnabled"
-								onChange={onCheckboxInput("syncEnabled")}
-								type="checkbox"
-							/>
-							<label htmlFor="syncEnabled">Enable sync</label>
+					<RadixTabsContent className="settings-panel" forceMount value="sync">
+						<div className="settings-group">
+							<h3 className="settings-group-title">Device Sync</h3>
+							<div className="field field-checkbox">
+								<input
+									checked={values.syncEnabled}
+									className="cm-checkbox"
+									id="syncEnabled"
+									onChange={onCheckboxInput("syncEnabled")}
+									type="checkbox"
+								/>
+								<label htmlFor="syncEnabled">Enable sync</label>
+							</div>
+							<div className="field">
+								<label htmlFor="syncInterval">Sync interval (seconds)</label>
+								<input
+									id="syncInterval"
+									min="10"
+									onInput={onTextInput("syncInterval")}
+									type="number"
+									value={values.syncInterval}
+								/>
+							</div>
+							<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="syncHost">Sync host</label>
+								<input
+									id="syncHost"
+									onInput={onTextInput("syncHost")}
+									placeholder="127.0.0.1"
+									value={values.syncHost}
+								/>
+							</div>
+							<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="syncPort">Sync port</label>
+								<input
+									id="syncPort"
+									min="1"
+									onInput={onTextInput("syncPort")}
+									type="number"
+									value={values.syncPort}
+								/>
+							</div>
+							<div
+								className="field field-checkbox settings-advanced"
+								hidden={hiddenUnlessAdvanced()}
+							>
+								<input
+									checked={values.syncMdns}
+									className="cm-checkbox"
+									id="syncMdns"
+									onChange={onCheckboxInput("syncMdns")}
+									type="checkbox"
+								/>
+								<label htmlFor="syncMdns">Enable mDNS discovery</label>
+							</div>
+							<div className="field">
+								<label htmlFor="syncCoordinatorUrl">Coordinator URL</label>
+								<input
+									disabled
+									id="syncCoordinatorUrl"
+									placeholder="https://coord.example.com"
+									value={values.syncCoordinatorUrl}
+								/>
+								<div className="small">{protectedConfigHelp("sync_coordinator_url")}</div>
+							</div>
+							<div className="field">
+								<label htmlFor="syncCoordinatorGroup">Coordinator group</label>
+								<input
+									id="syncCoordinatorGroup"
+									onInput={onTextInput("syncCoordinatorGroup")}
+									placeholder="nerdworld"
+									value={values.syncCoordinatorGroup}
+								/>
+								<div className="small">
+									Discovery namespace for peers using the same coordinator.
+								</div>
+							</div>
+							<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="syncCoordinatorTimeout">Coordinator timeout (seconds)</label>
+								<input
+									id="syncCoordinatorTimeout"
+									min="1"
+									onInput={onTextInput("syncCoordinatorTimeout")}
+									type="number"
+									value={values.syncCoordinatorTimeout}
+								/>
+							</div>
+							<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
+								<label htmlFor="syncCoordinatorPresenceTtl">Presence TTL (seconds)</label>
+								<input
+									id="syncCoordinatorPresenceTtl"
+									min="1"
+									onInput={onTextInput("syncCoordinatorPresenceTtl")}
+									type="number"
+									value={values.syncCoordinatorPresenceTtl}
+								/>
+							</div>
 						</div>
-						<div className="field">
-							<label htmlFor="syncInterval">Sync interval (seconds)</label>
-							<input
-								id="syncInterval"
-								min="10"
-								onInput={onTextInput("syncInterval")}
-								type="number"
-								value={values.syncInterval}
-							/>
-						</div>
-						<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="syncHost">Sync host</label>
-							<input
-								id="syncHost"
-								onInput={onTextInput("syncHost")}
-								placeholder="127.0.0.1"
-								value={values.syncHost}
-							/>
-						</div>
-						<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="syncPort">Sync port</label>
-							<input
-								id="syncPort"
-								min="1"
-								onInput={onTextInput("syncPort")}
-								type="number"
-								value={values.syncPort}
-							/>
-						</div>
-						<div className="field field-checkbox settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<input
-								checked={values.syncMdns}
-								className="cm-checkbox"
-								id="syncMdns"
-								onChange={onCheckboxInput("syncMdns")}
-								type="checkbox"
-							/>
-							<label htmlFor="syncMdns">Enable mDNS discovery</label>
-						</div>
-						<div className="field">
-							<label htmlFor="syncCoordinatorUrl">Coordinator URL</label>
-							<input
-								disabled
-								id="syncCoordinatorUrl"
-								placeholder="https://coord.example.com"
-								value={values.syncCoordinatorUrl}
-							/>
-							<div className="small">{protectedConfigHelp("sync_coordinator_url")}</div>
-						</div>
-						<div className="field">
-							<label htmlFor="syncCoordinatorGroup">Coordinator group</label>
-							<input
-								id="syncCoordinatorGroup"
-								onInput={onTextInput("syncCoordinatorGroup")}
-								placeholder="nerdworld"
-								value={values.syncCoordinatorGroup}
-							/>
-							<div className="small">Discovery namespace for peers using the same coordinator.</div>
-						</div>
-						<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="syncCoordinatorTimeout">Coordinator timeout (seconds)</label>
-							<input
-								id="syncCoordinatorTimeout"
-								min="1"
-								onInput={onTextInput("syncCoordinatorTimeout")}
-								type="number"
-								value={values.syncCoordinatorTimeout}
-							/>
-						</div>
-						<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
-							<label htmlFor="syncCoordinatorPresenceTtl">Presence TTL (seconds)</label>
-							<input
-								id="syncCoordinatorPresenceTtl"
-								min="1"
-								onInput={onTextInput("syncCoordinatorPresenceTtl")}
-								type="number"
-								value={values.syncCoordinatorPresenceTtl}
-							/>
-						</div>
-					</div>
-				</div>
+					</RadixTabsContent>
+				</RadixTabs>
 
 				<div className="small mono" id="settingsPath">
 					{settingsRenderState.pathText}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@25.5.0)(jsdom@27.4.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cli:
     dependencies:
@@ -110,7 +110,7 @@ importers:
         version: 8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@25.5.0)(jsdom@27.4.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/cloudflare-coordinator-worker:
     dependencies:
@@ -120,7 +120,7 @@ importers:
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.13.5
-        version: 0.13.5(@cloudflare/workers-types@4.20260317.1)(@vitest/runner@4.1.2)(@vitest/snapshot@4.1.2)(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 0.13.5(@cloudflare/workers-types@4.20260317.1)(@vitest/runner@4.1.2)(@vitest/snapshot@4.1.2)(vitest@4.1.2(@types/node@25.5.0)(jsdom@27.4.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)))
       '@cloudflare/workers-types':
         specifier: ^4.20260317.1
         version: 4.20260317.1
@@ -138,7 +138,7 @@ importers:
         version: 8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@25.5.0)(jsdom@27.4.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
         specifier: ^4.41.0
         version: 4.78.0(@cloudflare/workers-types@4.20260317.1)
@@ -175,7 +175,7 @@ importers:
         version: 8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@25.5.0)(jsdom@27.4.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mcp-server:
     dependencies:
@@ -200,7 +200,7 @@ importers:
         version: 8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@25.5.0)(jsdom@27.4.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/opencode-plugin:
     dependencies:
@@ -222,12 +222,18 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-switch':
         specifier: ^1.2.6
         version: 1.2.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       preact:
         specifier: ^10.27.2
         version: 10.29.0
@@ -238,6 +244,9 @@ importers:
       '@preact/preset-vite':
         specifier: ^2.10.2
         version: 2.10.5(@babel/core@7.29.0)(preact@10.29.0)(rollup@4.59.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+      jsdom:
+        specifier: ^27.0.1
+        version: 27.4.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -283,9 +292,21 @@ importers:
         version: 8.0.5(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@22.19.15)(vite@8.0.5(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.2(@types/node@22.19.15)(jsdom@27.4.0)(vite@8.0.5(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -499,6 +520,42 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1120,6 +1177,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -1630,6 +1696,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -1667,6 +1746,19 @@ packages:
 
   '@radix-ui/react-switch@1.2.6':
     resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2088,6 +2180,10 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2184,6 +2280,9 @@ packages:
   better-sqlite3@12.8.0:
     resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -2300,9 +2399,21 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+    engines: {node: '>=20'}
+
+  data-urls@6.0.1:
+    resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
+    engines: {node: '>=20'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2312,6 +2423,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -2463,6 +2577,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   environment@1.1.0:
@@ -2656,9 +2774,21 @@ packages:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -2693,6 +2823,9 @@ packages:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -2704,6 +2837,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@27.4.0:
+    resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2821,6 +2963,10 @@ packages:
   long@4.0.0:
     resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
 
+  lru-cache@11.3.3:
+    resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2830,6 +2976,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2936,6 +3085,9 @@ packages:
   onnxruntime-web@1.14.0:
     resolution: {integrity: sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2998,6 +3150,10 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -3091,6 +3247,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3264,6 +3424,9 @@ packages:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -3298,9 +3461,24 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3455,6 +3633,26 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3499,6 +3697,25 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -3531,6 +3748,26 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@acemir/cssom@0.9.31': {}
+
+  '@asamuzakjp/css-color@4.1.2':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.3.3
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.3
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3713,14 +3950,14 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260317.1
 
-  '@cloudflare/vitest-pool-workers@0.13.5(@cloudflare/workers-types@4.20260317.1)(@vitest/runner@4.1.2)(@vitest/snapshot@4.1.2)(vitest@4.1.2(@types/node@25.5.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)))':
+  '@cloudflare/vitest-pool-workers@0.13.5(@cloudflare/workers-types@4.20260317.1)(@vitest/runner@4.1.2)(@vitest/snapshot@4.1.2)(vitest@4.1.2(@types/node@25.5.0)(jsdom@27.4.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)))':
     dependencies:
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.3
       miniflare: 4.20260317.3
-      vitest: 4.1.2(@types/node@25.5.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.2(@types/node@25.5.0)(jsdom@27.4.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
       wrangler: 4.78.0(@cloudflare/workers-types@4.20260317.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -3748,6 +3985,30 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -4076,6 +4337,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.4':
     optional: true
+
+  '@exodus/bytes@1.15.0': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -4505,6 +4768,21 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@radix-ui/react-radio-group@1.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@radix-ui/react-roving-focus@1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4559,6 +4837,19 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
       '@radix-ui/react-use-previous': 1.1.1(react@19.2.4)
       '@radix-ui/react-use-size': 1.1.1(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@radix-ui/react-tabs@1.1.13(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
@@ -4847,6 +5138,8 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  agent-base@7.1.4: {}
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -4918,6 +5211,10 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bindings@1.5.0:
     dependencies:
@@ -5042,11 +5339,30 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@6.2.2: {}
+
+  cssstyle@5.3.7:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.3.3
+
+  data-urls@6.0.1:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 15.1.0
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -5110,6 +5426,8 @@ snapshots:
       once: 1.4.0
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   environment@1.1.0: {}
 
@@ -5387,6 +5705,12 @@ snapshots:
 
   hono@4.12.8: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -5394,6 +5718,20 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -5417,6 +5755,8 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.5.0
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
@@ -5424,6 +5764,34 @@ snapshots:
   jose@6.2.1: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@27.4.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@exodus/bytes': 1.15.0
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -5516,6 +5884,8 @@ snapshots:
 
   long@4.0.0: {}
 
+  lru-cache@11.3.3: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -5525,6 +5895,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -5621,6 +5993,10 @@ snapshots:
       onnxruntime-common: 1.14.0
       platform: 1.3.6
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
@@ -5691,6 +6067,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+
+  punycode@2.3.1: {}
 
   qs@6.15.0:
     dependencies:
@@ -5823,6 +6201,10 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -6045,6 +6427,8 @@ snapshots:
 
   supports-color@10.2.2: {}
 
+  symbol-tree@3.2.4: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -6107,7 +6491,21 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1: {}
 
@@ -6201,7 +6599,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.2(@types/node@22.19.15)(vite@8.0.5(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.2(@types/node@22.19.15)(jsdom@27.4.0)(vite@8.0.5(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@8.0.5(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
@@ -6225,10 +6623,11 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
+      jsdom: 27.4.0
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.2(@types/node@25.5.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.2(@types/node@25.5.0)(jsdom@27.4.0)(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
       '@vitest/mocker': 4.1.2(vite@8.0.5(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
@@ -6252,8 +6651,24 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.0
+      jsdom: 27.4.0
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
 
   which@2.0.2:
     dependencies:
@@ -6298,6 +6713,12 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.0: {}
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Description
Standardize the viewer settings surface on shared Radix-backed primitives instead of the previous ad hoc mix. This adds reusable tabs/radio/dismiss primitives, migrates the settings modal to shared tabs/selects, and normalizes the close affordance so the UI stops feeling half-migrated.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Targeted validation:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm exec biome check packages/ui/src/components/primitives/dialog-close-button.tsx packages/ui/src/components/primitives/radix-radio-group.tsx packages/ui/src/components/primitives/radix-select.tsx packages/ui/src/components/primitives/radix-tabs.tsx packages/ui/src/tabs/settings.tsx packages/ui/package.json`
- `pnpm --filter @codemem/ui build`

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced