### PR TITLE
refactor(ui): migrate sync flows to shared Radix controls

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -1,5 +1,6 @@
 import type { TargetedInputEvent } from "preact";
 import { useEffect, useState } from "preact/hooks";
+import { RadixSelect } from "../../../components/primitives/radix-select";
 import {
 	actorDisplayLabel,
 	actorLabel,
@@ -65,6 +66,16 @@ function SyncActorRow({
 	const mergeNote = !mergeTargets.length
 		? "No people available to combine yet. Create another person or use You."
 		: actorMergeNote(mergeTargetId, actorId);
+	const mergeOptions = [
+		{ label: "Combine into person", value: "" },
+		...mergeTargets.map((target) => {
+			const targetId = String(target.actor_id || "");
+			return {
+				label: target.is_local ? actorDisplayLabel(target) : actorLabel(target),
+				value: targetId,
+			};
+		}),
+	];
 
 	async function rename() {
 		const nextName = name.trim();
@@ -156,27 +167,22 @@ function SyncActorRow({
 							{renameLabel}
 						</button>
 						<div className="actor-merge-controls">
-							<select
-								aria-label={`Combine ${label} into another person`}
-								className="sync-actor-select actor-merge-select"
-								disabled={mergeBusy}
+							<RadixSelect
+								ariaLabel={`Combine ${label} into another person`}
+								contentClassName="sync-radix-select-content sync-actor-select-content"
+								disabled={mergeBusy || mergeTargets.length === 0}
+								itemClassName="sync-radix-select-item"
+								onValueChange={setMergeTargetId}
+								options={mergeOptions}
+								placeholder="Combine into person"
+								triggerClassName="sync-radix-select-trigger sync-actor-select actor-merge-select"
 								value={mergeTargetId}
-								onChange={(event) => setMergeTargetId(event.currentTarget.value)}
-							>
-								<option value="">Combine into person</option>
-								{mergeTargets.map((target) => {
-									const targetId = String(target.actor_id || "");
-									return (
-										<option key={targetId} value={targetId}>
-											{target.is_local ? actorDisplayLabel(target) : actorLabel(target)}
-										</option>
-									);
-								})}
-							</select>
+								viewportClassName="sync-radix-select-viewport"
+							/>
 							<button
 								type="button"
 								className="settings-button"
-								disabled={mergeBusy || mergeTargets.length === 0}
+								disabled={mergeBusy || mergeTargets.length === 0 || !mergeTargetId}
 								onClick={() => void merge()}
 							>
 								{mergeLabel}

--- a/packages/ui/src/tabs/sync/sync-dialogs.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs.tsx
@@ -1,6 +1,9 @@
 import { render } from "preact";
 import { useEffect, useMemo, useState } from "preact/hooks";
+import { DialogCloseButton } from "../../components/primitives/dialog-close-button";
 import { RadixDialog } from "../../components/primitives/radix-dialog";
+import { RadixRadioGroup } from "../../components/primitives/radix-radio-group";
+import { RadixSelect } from "../../components/primitives/radix-select";
 
 type DialogTone = "default" | "danger";
 
@@ -195,13 +198,10 @@ function SyncDialogBody({
 		<div className="modal-card sync-dialog-card">
 			<div className="modal-header">
 				<h2 id={titleId}>{request.title}</h2>
-				<button
-					className="modal-close"
+				<DialogCloseButton
+					ariaLabel={`Close ${request.title}`}
 					onClick={() => resolveCurrentDialog(request.kind === "confirm" ? false : null)}
-					type="button"
-				>
-					close
-				</button>
+				/>
 			</div>
 			<div className="modal-body">
 				{request.kind !== "duplicate-person" ? (
@@ -301,6 +301,19 @@ function DuplicatePersonDialogContent({
 	const mergeCandidates = request.actors.filter((actor) => actor.actorId !== primaryActorId);
 	const secondary =
 		mergeCandidates.find((actor) => actor.actorId === secondaryActorId) || mergeCandidates[0];
+	const primaryOptions = request.actors.map((actor) => ({
+		label: (
+			<>
+				{actor.label}
+				{actor.isLocal ? " (You)" : ""}
+			</>
+		),
+		value: actor.actorId,
+	}));
+	const mergeOptions = mergeCandidates.map((actor) => ({
+		label: `${actor.label}${actor.isLocal ? " (You)" : ""}`,
+		value: actor.actorId,
+	}));
 
 	return step === "choice" ? (
 		<div className="sync-dialog-stack">
@@ -341,48 +354,36 @@ function DuplicatePersonDialogContent({
 			<div className="small" id={descriptionId}>
 				Choose which person should remain after combining these duplicates.
 			</div>
-			<div
-				className="sync-dialog-radio-list"
-				role="radiogroup"
-				aria-describedby={descriptionId}
-				aria-label="Person to keep after combining duplicates"
-			>
-				{request.actors.map((actor) => (
-					<label className="sync-dialog-radio-option" key={actor.actorId}>
-						<input
-							autoFocus={primaryActorId === actor.actorId}
-							checked={primaryActorId === actor.actorId}
-							data-sync-primary-action={primaryActorId === actor.actorId ? "true" : undefined}
-							name="syncDuplicatePrimaryActor"
-							onChange={() => setPrimaryActorId(actor.actorId)}
-							type="radio"
-							value={actor.actorId}
-						/>
-						<span>
-							{actor.label}
-							{actor.isLocal ? " (You)" : ""}
-						</span>
-					</label>
-				))}
-			</div>
+			<RadixRadioGroup
+				ariaDescribedby={descriptionId}
+				ariaLabel="Person to keep after combining duplicates"
+				autoFocusValue={primaryActorId}
+				indicatorClassName="sync-dialog-radio-indicator"
+				itemClassName="sync-dialog-radio-option"
+				itemLabelClassName="sync-dialog-radio-label"
+				name="syncDuplicatePrimaryActor"
+				onValueChange={setPrimaryActorId}
+				options={primaryOptions}
+				rootClassName="sync-dialog-radio-list"
+				value={primaryActorId}
+			/>
 			<div className="field">
 				<label className="small" htmlFor="syncDuplicateSecondaryActor">
 					Person to combine into the selected record
 				</label>
-				<select
-					className="sync-dialog-input"
-					data-sync-primary-action="true"
+				<RadixSelect
+					ariaLabel="Person to combine into the selected record"
+					contentClassName="sync-radix-select-content sync-actor-select-content"
+					disabled={mergeOptions.length === 0}
 					id="syncDuplicateSecondaryActor"
+					itemClassName="sync-radix-select-item"
+					onValueChange={setSecondaryActorId}
+					options={mergeOptions}
+					placeholder="No merge target available"
+					triggerClassName="sync-radix-select-trigger sync-dialog-input"
 					value={secondary?.actorId || ""}
-					onChange={(event) => setSecondaryActorId(event.currentTarget.value)}
-				>
-					{mergeCandidates.map((actor) => (
-						<option key={actor.actorId} value={actor.actorId}>
-							{actor.label}
-							{actor.isLocal ? " (You)" : ""}
-						</option>
-					))}
-				</select>
+					viewportClassName="sync-radix-select-viewport"
+				/>
 			</div>
 			<div className="sync-dialog-actions">
 				<button className="settings-button" onClick={() => setStep("choice")} type="button">


### PR DESCRIPTION
## Description
Finish the sync-side migration onto the shared Radix interaction layer. This moves duplicate-person dialogs and actor merge flows off native/ad hoc controls so sync no longer lags behind settings in the migration.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Targeted validation:
- `pnpm --filter @codemem/ui typecheck`
- `pnpm exec biome check packages/ui/src/tabs/sync/components/sync-actors.tsx packages/ui/src/tabs/sync/sync-dialogs.tsx`
- `pnpm --filter @codemem/ui build`

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced