### PR TITLE
feat(core): bootstrap memory_file_refs and memory_concept_refs tables (schema v7)

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -32,7 +32,7 @@ import { ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 export type { DatabaseType as Database };
 
 /** Current schema version this TS runtime was built against. */
-export const SCHEMA_VERSION = 6;
+export const SCHEMA_VERSION = 7;
 
 /**
  * Minimum schema version the TS runtime can operate with.

--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -59,6 +59,27 @@ CREATE TRIGGER memory_items_ad AFTER DELETE ON memory_items BEGIN
 	INSERT INTO memory_fts(memory_fts, rowid, title, body_text, tags_text)
 	VALUES('delete', old.id, old.title, old.body_text, old.tags_text);
 END;
+
+CREATE TABLE IF NOT EXISTS memory_file_refs (
+	memory_id INTEGER NOT NULL,
+	file_path TEXT NOT NULL,
+	relation TEXT NOT NULL,
+	PRIMARY KEY (memory_id, file_path, relation),
+	FOREIGN KEY (memory_id) REFERENCES memory_items(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_file_refs_path
+	ON memory_file_refs(file_path);
+
+CREATE TABLE IF NOT EXISTS memory_concept_refs (
+	memory_id INTEGER NOT NULL,
+	concept TEXT NOT NULL,
+	PRIMARY KEY (memory_id, concept),
+	FOREIGN KEY (memory_id) REFERENCES memory_items(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_concept_refs_concept
+	ON memory_concept_refs(concept);
 `;
 
 /**


### PR DESCRIPTION
## Description

Add `CREATE TABLE IF NOT EXISTS` DDL for the junction tables to `SCHEMA_AUX_DDL` in schema-bootstrap.ts and bump `SCHEMA_VERSION` from 6 to 7. Fresh databases get the tables on first bootstrap.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] No new warnings introduced