### PR TITLE
feat(core): populate memory_file_refs and memory_concept_refs at write time

### DIFF
--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -513,6 +513,74 @@ describe("MemoryStore", () => {
 				stderrSpy.mockRestore();
 			}
 		});
+
+		it("populates memory_file_refs for files_read and files_modified", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "File refs test", "Body", 0.5, [], {
+				files_read: ["src/auth.ts", "src/config.ts"],
+				files_modified: ["src/auth.ts"],
+			});
+
+			const fileRefs = store.db
+				.prepare("SELECT * FROM memory_file_refs WHERE memory_id = ? ORDER BY file_path, relation")
+				.all(memId) as Array<{ memory_id: number; file_path: string; relation: string }>;
+
+			expect(fileRefs).toHaveLength(3);
+			expect(fileRefs).toContainEqual({
+				memory_id: memId,
+				file_path: "src/auth.ts",
+				relation: "read",
+			});
+			expect(fileRefs).toContainEqual({
+				memory_id: memId,
+				file_path: "src/config.ts",
+				relation: "read",
+			});
+			expect(fileRefs).toContainEqual({
+				memory_id: memId,
+				file_path: "src/auth.ts",
+				relation: "modified",
+			});
+		});
+
+		it("populates memory_concept_refs with normalized concepts", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Concept refs test", "Body", 0.5, [], {
+				concepts: ["Auth", "security", " oauth "],
+			});
+
+			const conceptRefs = store.db
+				.prepare("SELECT * FROM memory_concept_refs WHERE memory_id = ? ORDER BY concept")
+				.all(memId) as Array<{ memory_id: number; concept: string }>;
+
+			expect(conceptRefs).toHaveLength(3);
+			expect(conceptRefs).toContainEqual({ memory_id: memId, concept: "auth" });
+			expect(conceptRefs).toContainEqual({ memory_id: memId, concept: "security" });
+			expect(conceptRefs).toContainEqual({ memory_id: memId, concept: "oauth" });
+		});
+
+		it("creates no ref rows when files and concepts are null or empty", () => {
+			const sessionId = insertTestSession(store.db);
+			// No metadata at all
+			const memId1 = store.remember(sessionId, "discovery", "No refs test 1", "Body");
+			// Empty arrays
+			const memId2 = store.remember(sessionId, "discovery", "No refs test 2", "Body", 0.5, [], {
+				files_read: [],
+				files_modified: [],
+				concepts: [],
+			});
+
+			for (const memId of [memId1, memId2]) {
+				const fileRefs = store.db
+					.prepare("SELECT * FROM memory_file_refs WHERE memory_id = ?")
+					.all(memId);
+				const conceptRefs = store.db
+					.prepare("SELECT * FROM memory_concept_refs WHERE memory_id = ?")
+					.all(memId);
+				expect(fileRefs).toHaveLength(0);
+				expect(conceptRefs).toHaveLength(0);
+			}
+		});
 	});
 
 	// -- forget --------------------------------------------------------------

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -647,6 +647,8 @@ export class MemoryStore {
 		const memoryId = insertedRows[0]?.id;
 		if (memoryId == null) throw new Error("memory insert returned no id");
 
+		this.populateMemoryRefs(memoryId, filesRead, filesModified, concepts);
+
 		// Record replication op for sync propagation
 		try {
 			recordReplicationOp(this.db, { memoryId, opType: "upsert", deviceId: this.deviceId });
@@ -657,6 +659,38 @@ export class MemoryStore {
 		this.enqueueVectorWrite(memoryId, title, bodyText);
 
 		return memoryId;
+	}
+
+	// junction-table denormalization
+
+	private populateMemoryRefs(
+		memoryId: number,
+		filesRead: string[] | null,
+		filesModified: string[] | null,
+		concepts: string[] | null,
+	): void {
+		const insertFileRef = this.db.prepare(
+			"INSERT OR IGNORE INTO memory_file_refs (memory_id, file_path, relation) VALUES (?, ?, ?)",
+		);
+		if (filesRead) {
+			for (const path of filesRead) {
+				if (path) insertFileRef.run(memoryId, path, "read");
+			}
+		}
+		if (filesModified) {
+			for (const path of filesModified) {
+				if (path) insertFileRef.run(memoryId, path, "modified");
+			}
+		}
+		const insertConceptRef = this.db.prepare(
+			"INSERT OR IGNORE INTO memory_concept_refs (memory_id, concept) VALUES (?, ?)",
+		);
+		if (concepts) {
+			for (const concept of concepts) {
+				const normalized = concept?.trim().toLowerCase();
+				if (normalized) insertConceptRef.run(memoryId, normalized);
+			}
+		}
 	}
 
 	// provenance resolution


### PR DESCRIPTION
## Description

Populate `memory_file_refs` and `memory_concept_refs` at write time inside `store.remember()`. Concepts are normalized to `trim().toLowerCase()`. Uses `INSERT OR IGNORE` for idempotency against the composite primary keys.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Tests verify file refs with correct relations, concept normalization, and null/empty handling

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] No new warnings introduced