### PR TITLE
feat(core): add ref-backfill maintenance job for existing memory file/concept data

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -341,6 +341,12 @@ export {
 export type { FlushRawEventsOptions } from "./raw-event-flush.js";
 export { buildSessionContext, flushRawEvents } from "./raw-event-flush.js";
 export { RawEventSweeper } from "./raw-event-sweeper.js";
+export {
+	hasPendingRefBackfill,
+	REF_BACKFILL_JOB,
+	RefBackfillRunner,
+	runRefBackfillPass,
+} from "./ref-backfill.js";
 export type { MaintenanceJob, NewMaintenanceJob } from "./schema.js";
 export * as schema from "./schema.js";
 export { bootstrapSchema, ensureSchemaBootstrapped } from "./schema-bootstrap.js";

--- a/packages/core/src/ref-backfill.test.ts
+++ b/packages/core/src/ref-backfill.test.ts
@@ -1,0 +1,242 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
+import { hasPendingRefBackfill, REF_BACKFILL_JOB, runRefBackfillPass } from "./ref-backfill.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+
+/**
+ * Insert a "legacy" memory that has JSON arrays in the dedicated columns
+ * but no corresponding junction-table rows (simulates data written before
+ * the write-time ref population landed).
+ */
+function seedLegacyMemory(
+	db: Database,
+	sessionId: number,
+	opts: {
+		filesRead?: string[] | null;
+		filesModified?: string[] | null;
+		concepts?: string[] | null;
+	} = {},
+): number {
+	const now = new Date().toISOString();
+	const info = db
+		.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+			 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+			 workspace_id, dedup_key,
+			 files_read, files_modified, concepts)
+			 VALUES (?, 'discovery', 'Test memory', 'Body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', 'shared:default', NULL,
+			 ?, ?, ?)`,
+		)
+		.run(
+			sessionId,
+			now,
+			now,
+			opts.filesRead ? JSON.stringify(opts.filesRead) : null,
+			opts.filesModified ? JSON.stringify(opts.filesModified) : null,
+			opts.concepts ? JSON.stringify(opts.concepts) : null,
+		);
+	return Number(info.lastInsertRowid);
+}
+
+describe("ref backfill maintenance", () => {
+	it("populates file/concept refs for memories that have JSON data", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			const memId = seedLegacyMemory(db, sessionId, {
+				filesRead: ["/src/foo.ts", "/src/bar.ts"],
+				filesModified: ["/src/baz.ts"],
+				concepts: ["TypeScript", "Testing"],
+			});
+
+			expect(hasPendingRefBackfill(db)).toBe(true);
+			await runRefBackfillPass(db, { batchSize: 10 });
+
+			// File refs should be populated
+			const fileRefs = db
+				.prepare(
+					"SELECT file_path, relation FROM memory_file_refs WHERE memory_id = ? ORDER BY file_path",
+				)
+				.all(memId) as Array<{ file_path: string; relation: string }>;
+			expect(fileRefs).toEqual([
+				{ file_path: "/src/bar.ts", relation: "read" },
+				{ file_path: "/src/baz.ts", relation: "modified" },
+				{ file_path: "/src/foo.ts", relation: "read" },
+			]);
+
+			// Concept refs should be normalized to lowercase
+			const conceptRefs = db
+				.prepare("SELECT concept FROM memory_concept_refs WHERE memory_id = ? ORDER BY concept")
+				.all(memId) as Array<{ concept: string }>;
+			expect(conceptRefs).toEqual([{ concept: "testing" }, { concept: "typescript" }]);
+
+			expect(hasPendingRefBackfill(db)).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("is idempotent — second pass produces no errors or duplicate rows", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			seedLegacyMemory(db, sessionId, {
+				filesRead: ["/src/a.ts"],
+				concepts: ["Idempotency"],
+			});
+
+			await runRefBackfillPass(db, { batchSize: 10 });
+			const countAfterFirst = (
+				db.prepare("SELECT COUNT(*) AS cnt FROM memory_file_refs").get() as { cnt: number }
+			).cnt;
+
+			// Reset job so a second pass will re-process
+			db.prepare("DELETE FROM maintenance_jobs WHERE kind = ?").run(REF_BACKFILL_JOB);
+
+			// Second pass — INSERT OR IGNORE means no duplicates
+			await runRefBackfillPass(db, { batchSize: 10 });
+			const countAfterSecond = (
+				db.prepare("SELECT COUNT(*) AS cnt FROM memory_file_refs").get() as { cnt: number }
+			).cnt;
+
+			expect(countAfterSecond).toBe(countAfterFirst);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("respects batchSize — returns true when more work remains", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			seedLegacyMemory(db, sessionId, { filesRead: ["/a.ts"] });
+			seedLegacyMemory(db, sessionId, { filesRead: ["/b.ts"] });
+			seedLegacyMemory(db, sessionId, { filesRead: ["/c.ts"] });
+
+			// First pass: batchSize=2, should return true (more work)
+			const moreWork = await runRefBackfillPass(db, { batchSize: 2 });
+			expect(moreWork).toBe(true);
+
+			const runningJob = getMaintenanceJob(db, REF_BACKFILL_JOB);
+			expect(runningJob).toMatchObject({
+				status: "running",
+				progress: { current: 2, total: 3, unit: "items" },
+			});
+
+			// Second pass: processes remaining 1 row, should return false
+			const done = await runRefBackfillPass(db, { batchSize: 2 });
+			expect(done).toBe(false);
+
+			const completedJob = getMaintenanceJob(db, REF_BACKFILL_JOB);
+			expect(completedJob).toMatchObject({
+				status: "completed",
+				progress: { current: 3, total: 3, unit: "items" },
+			});
+		} finally {
+			db.close();
+		}
+	});
+
+	it("memories with null JSON arrays produce no ref rows", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			// Memory with all nulls — but we need at least one non-null to match
+			// the WHERE clause, so this memory won't be selected at all
+			seedLegacyMemory(db, sessionId, {
+				filesRead: null,
+				filesModified: null,
+				concepts: null,
+			});
+
+			const moreWork = await runRefBackfillPass(db, { batchSize: 10 });
+			expect(moreWork).toBe(false);
+
+			const fileCount = (
+				db.prepare("SELECT COUNT(*) AS cnt FROM memory_file_refs").get() as { cnt: number }
+			).cnt;
+			const conceptCount = (
+				db.prepare("SELECT COUNT(*) AS cnt FROM memory_concept_refs").get() as { cnt: number }
+			).cnt;
+			expect(fileCount).toBe(0);
+			expect(conceptCount).toBe(0);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("skips memories with corrupt/invalid JSON gracefully", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+
+			// Insert a memory with corrupt JSON directly
+			const now = new Date().toISOString();
+			db.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+				 workspace_id, dedup_key,
+				 files_read, files_modified, concepts)
+				 VALUES (?, 'discovery', 'Corrupt memory', 'Body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', 'shared:default', NULL,
+				 '{not-json', 'also broken', '["valid-concept"]')`,
+			).run(sessionId, now, now);
+
+			// Should not throw
+			const moreWork = await runRefBackfillPass(db, { batchSize: 10 });
+			expect(moreWork).toBe(false);
+
+			// The valid concept should still be inserted
+			const conceptCount = (
+				db.prepare("SELECT COUNT(*) AS cnt FROM memory_concept_refs").get() as { cnt: number }
+			).cnt;
+			expect(conceptCount).toBe(1);
+
+			// Corrupt file columns should produce no file refs
+			const fileCount = (
+				db.prepare("SELECT COUNT(*) AS cnt FROM memory_file_refs").get() as { cnt: number }
+			).cnt;
+			expect(fileCount).toBe(0);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("maintenance job transitions: created → running → completed", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			seedLegacyMemory(db, sessionId, { concepts: ["alpha"] });
+			seedLegacyMemory(db, sessionId, { concepts: ["beta"] });
+			seedLegacyMemory(db, sessionId, { concepts: ["gamma"] });
+
+			// First pass with batchSize=2 — creates job in running state
+			await runRefBackfillPass(db, { batchSize: 2 });
+			const runningJob = getMaintenanceJob(db, REF_BACKFILL_JOB);
+			expect(runningJob?.status).toBe("running");
+			expect(runningJob?.metadata).toMatchObject({
+				processed: 2,
+				remaining: 1,
+				total_backfillable: 3,
+			});
+
+			// Second pass — completes
+			await runRefBackfillPass(db, { batchSize: 2 });
+			const completedJob = getMaintenanceJob(db, REF_BACKFILL_JOB);
+			expect(completedJob?.status).toBe("completed");
+			expect(completedJob?.metadata).toMatchObject({
+				processed: 3,
+				remaining: 0,
+				total_backfillable: 3,
+			});
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/core/src/ref-backfill.ts
+++ b/packages/core/src/ref-backfill.ts
@@ -1,0 +1,288 @@
+/**
+ * Ref backfill — maintenance job that populates `memory_file_refs` and
+ * `memory_concept_refs` for existing `memory_items` that have JSON data in
+ * `files_read`/`files_modified`/`concepts` columns but were written before
+ * the junction tables existed.
+ *
+ * Uses `INSERT OR IGNORE` so the backfill is fully idempotent: memories that
+ * already have ref rows populated (e.g. written after the write-time
+ * population landed) simply have all their inserts ignored.
+ */
+
+import type { Database as SqliteDatabase } from "better-sqlite3";
+import { connect, resolveDbPath } from "./db.js";
+import {
+	completeMaintenanceJob,
+	failMaintenanceJob,
+	getMaintenanceJob,
+	startMaintenanceJob,
+	updateMaintenanceJob,
+} from "./maintenance-jobs.js";
+
+export const REF_BACKFILL_JOB = "memory_ref_backfill";
+
+type RefBackfillMetadata = {
+	total_backfillable?: number;
+	processed?: number;
+	remaining?: number;
+	last_cursor_id?: number;
+};
+
+export interface RefBackfillRunnerOptions {
+	batchSize?: number;
+	intervalMs?: number;
+	dbPath?: string;
+	signal?: AbortSignal;
+}
+
+/**
+ * Check if any active memory_items have non-null files/concepts columns.
+ * This is a cheap existence check — it does NOT verify whether ref rows
+ * already exist (the backfill itself uses INSERT OR IGNORE for that).
+ */
+export function hasPendingRefBackfill(db: SqliteDatabase): boolean {
+	const row = db
+		.prepare(
+			`SELECT 1 FROM memory_items mi
+			 WHERE mi.active = 1
+			   AND (mi.files_read IS NOT NULL OR mi.files_modified IS NOT NULL OR mi.concepts IS NOT NULL)
+			   AND NOT EXISTS (
+			     SELECT 1 FROM memory_file_refs mfr WHERE mfr.memory_id = mi.id
+			   )
+			   AND NOT EXISTS (
+			     SELECT 1 FROM memory_concept_refs mcr WHERE mcr.memory_id = mi.id
+			   )
+			 LIMIT 1`,
+		)
+		.get();
+	return row != null;
+}
+
+function getExistingMetadata(db: SqliteDatabase): RefBackfillMetadata {
+	return ((getMaintenanceJob(db, REF_BACKFILL_JOB)?.metadata ?? {}) as RefBackfillMetadata) ?? {};
+}
+
+interface BackfillRow {
+	id: number;
+	files_read: string | null;
+	files_modified: string | null;
+	concepts: string | null;
+}
+
+function safeJsonArray(value: string | null): string[] | null {
+	if (!value) return null;
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (Array.isArray(parsed)) return parsed as string[];
+	} catch {
+		// corrupt JSON — skip gracefully
+	}
+	return null;
+}
+
+export async function runRefBackfillPass(
+	db: SqliteDatabase,
+	options: { batchSize?: number } = {},
+): Promise<boolean> {
+	const existingJob = getMaintenanceJob(db, REF_BACKFILL_JOB);
+	const existingMetadata = getExistingMetadata(db);
+	const batchSize = Math.max(1, options.batchSize ?? 250);
+	const lastCursorId = Number(existingMetadata.last_cursor_id ?? 0);
+
+	const rows = db
+		.prepare(
+			`SELECT mi.id, mi.files_read, mi.files_modified, mi.concepts
+			 FROM memory_items mi
+			 WHERE mi.active = 1
+			   AND mi.id > ?
+			   AND (mi.files_read IS NOT NULL OR mi.files_modified IS NOT NULL OR mi.concepts IS NOT NULL)
+			 ORDER BY mi.id ASC
+			 LIMIT ?`,
+		)
+		.all(lastCursorId, batchSize) as BackfillRow[];
+
+	if (rows.length === 0) {
+		if (existingJob && existingJob.status !== "completed") {
+			const processed = Number(existingMetadata.processed ?? 0);
+			completeMaintenanceJob(db, REF_BACKFILL_JOB, {
+				message: "Ref backfill complete",
+				progressCurrent: processed,
+				progressTotal: Number(existingMetadata.total_backfillable ?? processed),
+				metadata: {
+					...existingMetadata,
+					remaining: 0,
+					last_cursor_id: lastCursorId,
+				},
+			});
+		}
+		return false;
+	}
+
+	const processedBefore = Number(existingMetadata.processed ?? 0);
+	let progressTotal = Number(existingMetadata.total_backfillable ?? 0);
+
+	if (!existingJob || existingJob.status === "completed" || existingJob.status === "failed") {
+		const countRow = db
+			.prepare(
+				`SELECT COUNT(*) AS cnt FROM memory_items
+				 WHERE active = 1
+				   AND (files_read IS NOT NULL OR files_modified IS NOT NULL OR concepts IS NOT NULL)`,
+			)
+			.get() as { cnt: number };
+		const initialTotal = countRow.cnt;
+		startMaintenanceJob(db, {
+			kind: REF_BACKFILL_JOB,
+			title: "Backfilling memory file/concept refs",
+			message: `Backfilling refs for ${initialTotal} memories`,
+			progressTotal: initialTotal,
+			metadata: {
+				total_backfillable: initialTotal,
+				processed: processedBefore,
+				remaining: initialTotal,
+				last_cursor_id: 0,
+			},
+		});
+		progressTotal = initialTotal;
+	}
+
+	// Insert refs for each row
+	const insertFileRef = db.prepare(
+		"INSERT OR IGNORE INTO memory_file_refs (memory_id, file_path, relation) VALUES (?, ?, ?)",
+	);
+	const insertConceptRef = db.prepare(
+		"INSERT OR IGNORE INTO memory_concept_refs (memory_id, concept) VALUES (?, ?)",
+	);
+
+	const insertAll = db.transaction(() => {
+		for (const row of rows) {
+			const filesRead = safeJsonArray(row.files_read);
+			const filesModified = safeJsonArray(row.files_modified);
+			const concepts = safeJsonArray(row.concepts);
+
+			if (filesRead) {
+				for (const path of filesRead) {
+					if (path) insertFileRef.run(row.id, path, "read");
+				}
+			}
+			if (filesModified) {
+				for (const path of filesModified) {
+					if (path) insertFileRef.run(row.id, path, "modified");
+				}
+			}
+			if (concepts) {
+				for (const concept of concepts) {
+					const normalized = concept?.trim().toLowerCase();
+					if (normalized) insertConceptRef.run(row.id, normalized);
+				}
+			}
+		}
+	});
+	insertAll();
+
+	const processedAfter = processedBefore + rows.length;
+	const exhausted = rows.length < batchSize;
+	// rows.length > 0 guaranteed by early return above
+	const newCursor = (rows[rows.length - 1] as BackfillRow).id;
+
+	if (exhausted) {
+		const finalProgressTotal = Number(
+			getExistingMetadata(db).total_backfillable ?? progressTotal ?? processedAfter,
+		);
+		completeMaintenanceJob(db, REF_BACKFILL_JOB, {
+			message: "Ref backfill complete",
+			progressCurrent: processedAfter,
+			progressTotal: finalProgressTotal,
+			metadata: {
+				total_backfillable: finalProgressTotal,
+				processed: processedAfter,
+				remaining: 0,
+				last_cursor_id: newCursor,
+			},
+		});
+		return false;
+	}
+
+	updateMaintenanceJob(db, REF_BACKFILL_JOB, {
+		message: `Backfilled refs for ${processedAfter} of ${progressTotal} memories`,
+		progressCurrent: processedAfter,
+		progressTotal,
+		metadata: {
+			total_backfillable: progressTotal,
+			processed: processedAfter,
+			remaining: Math.max(progressTotal - processedAfter, 0),
+			last_cursor_id: newCursor,
+		},
+	});
+	return true;
+}
+
+export class RefBackfillRunner {
+	private readonly dbPath: string;
+	private readonly signal?: AbortSignal;
+	private readonly batchSize: number;
+	private readonly intervalMs: number;
+	private active = false;
+	private timer: ReturnType<typeof setTimeout> | null = null;
+	private currentRun: Promise<void> | null = null;
+
+	constructor(options: RefBackfillRunnerOptions = {}) {
+		this.dbPath = resolveDbPath(options.dbPath);
+		this.signal = options.signal;
+		this.batchSize = Math.max(1, options.batchSize ?? 250);
+		this.intervalMs = Math.max(1000, options.intervalMs ?? 5000);
+	}
+
+	start(): void {
+		if (this.active) return;
+		this.active = true;
+		this.schedule(100);
+	}
+
+	async stop(): Promise<void> {
+		this.active = false;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+		if (this.currentRun) await this.currentRun;
+	}
+
+	private schedule(delayMs: number): void {
+		if (!this.active || this.signal?.aborted) return;
+		this.timer = setTimeout(() => {
+			this.timer = null;
+			this.currentRun = this.runOnce()
+				.catch((err) => {
+					console.error("Ref backfill runner tick failed:", err);
+				})
+				.finally(() => {
+					this.currentRun = null;
+					this.schedule(this.intervalMs);
+				});
+		}, delayMs);
+		if (typeof this.timer === "object" && "unref" in this.timer) this.timer.unref();
+	}
+
+	private async runOnce(): Promise<void> {
+		if (!this.active || this.signal?.aborted) return;
+		let db: SqliteDatabase | null = null;
+		try {
+			db = connect(this.dbPath) as SqliteDatabase;
+			const hasMoreWork = await runRefBackfillPass(db, { batchSize: this.batchSize });
+			if (!hasMoreWork) {
+				this.active = false;
+			}
+		} catch (error) {
+			if (db) {
+				failMaintenanceJob(
+					db,
+					REF_BACKFILL_JOB,
+					error instanceof Error ? error.message : String(error),
+				);
+			}
+			console.warn("Ref backfill runner failed", error);
+		} finally {
+			db?.close();
+		}
+	}
+}


### PR DESCRIPTION
## Description

Add a cursor-based backfill maintenance job that populates junction table refs for pre-existing memories. Follows the `DedupKeyBackfillRunner` pattern: batched processing, maintenance job tracking, timer-based runner class. Handles corrupt JSON gracefully.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] 6 tests covering backfill, idempotency, batching, null handling, corrupt JSON, and job lifecycle

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] No new warnings introduced