### PR TITLE
feat(cli): wire ref-backfill runner into serve command

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -6,12 +6,14 @@ import * as p from "@clack/prompts";
 import {
 	DedupKeyBackfillRunner,
 	hasPendingDedupKeyBackfill,
+	hasPendingRefBackfill,
 	hasPendingSessionContextBackfill,
 	initDatabase,
 	isEmbeddingDisabled,
 	type MemoryStore,
 	ObserverClient,
 	RawEventSweeper,
+	RefBackfillRunner,
 	readCodememConfigFile,
 	readCodememConfigFileAtPath,
 	readCoordinatorSyncConfig,
@@ -418,6 +420,9 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	const sessionContextBackfillRunner = new SessionContextBackfillRunner({
 		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
 	});
+	const refBackfillRunner = new RefBackfillRunner({
+		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
+	});
 	const syncRuntimeStatus: {
 		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
 		detail: string | null;
@@ -484,6 +489,10 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			if (hasPendingSessionContextBackfill(store.db)) {
 				sessionContextBackfillRunner.start();
 				p.log.step("Session-context backfill runner started");
+			}
+			if (hasPendingRefBackfill(store.db)) {
+				refBackfillRunner.start();
+				p.log.step("Ref backfill runner started");
 			}
 			if (syncConfig.syncRetentionEnabled) {
 				retentionRunner.start();
@@ -560,6 +569,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		retentionAbort.abort();
 		await sweeper.stop();
 		await sessionContextBackfillRunner.stop();
+		await refBackfillRunner.stop();
 		await dedupKeyBackfillRunner.stop();
 		await vectorMigrationRunner.stop();
 		await retentionRunner.stop();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -347,6 +347,8 @@ export {
 	RefBackfillRunner,
 	runRefBackfillPass,
 } from "./ref-backfill.js";
+export type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
+export { findByConcept, findByFile } from "./ref-queries.js";
 export type { MaintenanceJob, NewMaintenanceJob } from "./schema.js";
 export * as schema from "./schema.js";
 export { bootstrapSchema, ensureSchemaBootstrapped } from "./schema-bootstrap.js";

--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -1299,6 +1299,34 @@ describe("buildMemoryPack cluster compression", () => {
 		expect(pack.items).toHaveLength(1);
 	});
 
+	it("surfaces memories via file ref index when FTS misses them", () => {
+		// Create a memory whose title/body have NO overlap with the query
+		// but whose files_modified match the working_set_paths
+		store.remember(
+			sessionId,
+			"decision",
+			"Chose HMAC-SHA256 for token signing",
+			"After evaluating options, selected HMAC-SHA256 for performance and security balance.",
+			0.8,
+			["crypto", "tokens"],
+			{
+				files_modified: ["packages/core/src/auth.ts"],
+				concepts: ["authentication"],
+			},
+		);
+
+		// Query something completely unrelated to the memory text
+		const pack = buildMemoryPack(store, "continue database migration work", 10, null, {
+			working_set_paths: ["packages/core/src/auth.ts"],
+		});
+
+		// The memory should appear because it modified a working-set file
+		expect(pack.item_ids.length).toBeGreaterThan(0);
+		// The decision about HMAC should be in the results
+		const found = pack.items.some((item) => item.title.includes("HMAC-SHA256"));
+		expect(found).toBe(true);
+	});
+
 	it("reports compressed clusters in pack trace and marks compressed candidates", () => {
 		const idA = store.remember(
 			sessionId,

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -19,7 +19,7 @@ import { buildFilterClausesWithContext } from "./filters.js";
 import { projectBasename } from "./project.js";
 import { memoryLooksRecapLike, queryPrefersRecap } from "./recap-policy.js";
 import type { StoreHandle } from "./search.js";
-import { rerankResults, scoreResult, search, timeline } from "./search.js";
+import { findCandidatesByFile, rerankResults, scoreResult, search, timeline } from "./search.js";
 import {
 	canonicalMemoryKind,
 	getSummaryMetadata,
@@ -1217,6 +1217,26 @@ function buildPackArtifacts(
 			ftsCount = results.length;
 			retrievalResults = [...ftsResults];
 		}
+		// Merge working-set candidates from file ref index
+		const workingSetPaths = filters?.working_set_paths;
+		if (workingSetPaths && Array.isArray(workingSetPaths) && workingSetPaths.length > 0) {
+			const existingIds = new Set(results.map((r) => r.id));
+			const refCandidateIds = findCandidatesByFile(
+				store.db,
+				workingSetPaths as string[],
+				effectiveLimit,
+			);
+			const newIds = refCandidateIds.filter((id) => !existingIds.has(id));
+			if (newIds.length > 0) {
+				const refMemories = newIds
+					.map((id) => store.get(id))
+					.filter((m): m is NonNullable<typeof m> => m != null)
+					.map(toMemoryResult);
+				results = [...results, ...refMemories];
+				results = prioritizeDefaultResults(results, effectiveLimit, context);
+			}
+		}
+
 		if (results.length === 0) {
 			fallbackUsed = true;
 			results = store.recent(effectiveLimit, filters ?? null).map(toMemoryResult);

--- a/packages/core/src/ref-queries.test.ts
+++ b/packages/core/src/ref-queries.test.ts
@@ -1,0 +1,293 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "./db.js";
+import { findByConcept, findByFile } from "./ref-queries.js";
+import { MemoryStore } from "./store.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+
+describe("ref-queries", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+	let sessionId: number;
+	let prevCodememConfig: string | undefined;
+	let prevActorId: string | undefined;
+	let prevActorDisplayName: string | undefined;
+
+	beforeEach(() => {
+		prevCodememConfig = process.env.CODEMEM_CONFIG;
+		prevActorId = process.env.CODEMEM_ACTOR_ID;
+		prevActorDisplayName = process.env.CODEMEM_ACTOR_DISPLAY_NAME;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-ref-queries-test-"));
+		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
+		delete process.env.CODEMEM_ACTOR_ID;
+		delete process.env.CODEMEM_ACTOR_DISPLAY_NAME;
+		dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+		sessionId = insertTestSession(store.db);
+	});
+
+	afterEach(() => {
+		store?.close();
+		if (prevCodememConfig === undefined) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevCodememConfig;
+		if (prevActorId === undefined) delete process.env.CODEMEM_ACTOR_ID;
+		else process.env.CODEMEM_ACTOR_ID = prevActorId;
+		if (prevActorDisplayName === undefined) delete process.env.CODEMEM_ACTOR_DISPLAY_NAME;
+		else process.env.CODEMEM_ACTOR_DISPLAY_NAME = prevActorDisplayName;
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// -- findByFile -----------------------------------------------------------
+
+	describe("findByFile", () => {
+		it("returns memories where the file appears in memory_file_refs", () => {
+			store.remember(sessionId, "discovery", "Auth module overview", "Body about auth", 0.8, [], {
+				files_read: ["src/auth.ts", "src/config.ts"],
+				files_modified: ["src/auth.ts"],
+			});
+			store.remember(sessionId, "bugfix", "Fixed config bug", "Body about config", 0.7, [], {
+				files_read: ["src/config.ts"],
+			});
+
+			const results = findByFile(store.db, "src/auth.ts");
+			expect(results).toHaveLength(1);
+			expect(results[0].title).toBe("Auth module overview");
+		});
+
+		it("filters by relation type", () => {
+			store.remember(sessionId, "discovery", "Auth read-only", "Body", 0.5, [], {
+				files_read: ["src/auth.ts"],
+			});
+			store.remember(sessionId, "change", "Auth modified", "Body", 0.5, [], {
+				files_modified: ["src/auth.ts"],
+			});
+
+			const readOnly = findByFile(store.db, "src/auth.ts", { relation: "read" });
+			expect(readOnly).toHaveLength(1);
+			expect(readOnly[0].title).toBe("Auth read-only");
+
+			const modifiedOnly = findByFile(store.db, "src/auth.ts", { relation: "modified" });
+			expect(modifiedOnly).toHaveLength(1);
+			expect(modifiedOnly[0].title).toBe("Auth modified");
+		});
+
+		it("filters by memory kind", () => {
+			store.remember(sessionId, "decision", "Auth decision", "Body", 0.8, [], {
+				files_read: ["src/auth.ts"],
+			});
+			store.remember(sessionId, "bugfix", "Auth bugfix", "Body", 0.6, [], {
+				files_read: ["src/auth.ts"],
+			});
+
+			const decisions = findByFile(store.db, "src/auth.ts", { kind: "decision" });
+			expect(decisions).toHaveLength(1);
+			expect(decisions[0].title).toBe("Auth decision");
+		});
+
+		it("matches directory prefix when filePath ends with /", () => {
+			store.remember(sessionId, "discovery", "Auth deep file", "Body", 0.5, [], {
+				files_read: ["src/auth/provider.ts", "src/auth/adapter.ts"],
+			});
+			store.remember(sessionId, "discovery", "Config file", "Body", 0.5, [], {
+				files_read: ["src/config.ts"],
+			});
+
+			const results = findByFile(store.db, "src/auth/");
+			expect(results).toHaveLength(1);
+			expect(results[0].title).toBe("Auth deep file");
+		});
+
+		it("returns results ordered by created_at DESC", () => {
+			// Create memories with different timestamps by inserting directly with offsets
+			const id1 = store.remember(sessionId, "discovery", "First created", "Body", 0.5, [], {
+				files_read: ["src/auth.ts"],
+			});
+			const id2 = store.remember(sessionId, "bugfix", "Second created", "Body", 0.5, [], {
+				files_read: ["src/auth.ts"],
+			});
+			// Manually push the second one's created_at later to guarantee ordering
+			store.db
+				.prepare("UPDATE memory_items SET created_at = '2099-01-01T00:00:00Z' WHERE id = ?")
+				.run(id2);
+			store.db
+				.prepare("UPDATE memory_items SET created_at = '2000-01-01T00:00:00Z' WHERE id = ?")
+				.run(id1);
+
+			const results = findByFile(store.db, "src/auth.ts");
+			expect(results).toHaveLength(2);
+			expect(results[0].title).toBe("Second created");
+			expect(results[1].title).toBe("First created");
+		});
+
+		it("respects the limit option", () => {
+			for (let i = 0; i < 5; i++) {
+				store.remember(sessionId, "discovery", `Memory ${i}`, "Body", 0.5, [], {
+					files_read: ["src/auth.ts"],
+				});
+			}
+
+			const results = findByFile(store.db, "src/auth.ts", { limit: 2 });
+			expect(results).toHaveLength(2);
+		});
+
+		it("excludes soft-deleted memories (active = 0)", () => {
+			const memId = store.remember(sessionId, "discovery", "Deleted memory", "Body", 0.5, [], {
+				files_read: ["src/auth.ts"],
+			});
+			store.db.prepare("UPDATE memory_items SET active = 0 WHERE id = ?").run(memId);
+
+			const results = findByFile(store.db, "src/auth.ts");
+			expect(results).toHaveLength(0);
+		});
+
+		it("filters by since timestamp", () => {
+			const id1 = store.remember(sessionId, "discovery", "Old memory", "Body", 0.5, [], {
+				files_read: ["src/auth.ts"],
+			});
+			const id2 = store.remember(sessionId, "bugfix", "New memory", "Body", 0.5, [], {
+				files_read: ["src/auth.ts"],
+			});
+			store.db
+				.prepare("UPDATE memory_items SET created_at = '2000-01-01T00:00:00Z' WHERE id = ?")
+				.run(id1);
+			store.db
+				.prepare("UPDATE memory_items SET created_at = '2099-01-01T00:00:00Z' WHERE id = ?")
+				.run(id2);
+
+			const results = findByFile(store.db, "src/auth.ts", { since: "2025-01-01T00:00:00Z" });
+			expect(results).toHaveLength(1);
+			expect(results[0].title).toBe("New memory");
+		});
+	});
+
+	// -- findByConcept --------------------------------------------------------
+
+	describe("findByConcept", () => {
+		it("returns memories with the given concept", () => {
+			store.remember(sessionId, "discovery", "Auth concepts", "Body about auth", 0.8, [], {
+				concepts: ["auth", "security"],
+			});
+			store.remember(sessionId, "bugfix", "Config concepts", "Body about config", 0.7, [], {
+				concepts: ["config"],
+			});
+
+			const results = findByConcept(store.db, "auth");
+			expect(results).toHaveLength(1);
+			expect(results[0].title).toBe("Auth concepts");
+		});
+
+		it("normalizes input to lowercase before querying", () => {
+			store.remember(sessionId, "discovery", "Auth uppercase", "Body", 0.5, [], {
+				concepts: ["auth"],
+			});
+
+			// Query with uppercase — should still match
+			const results = findByConcept(store.db, "Auth");
+			expect(results).toHaveLength(1);
+			expect(results[0].title).toBe("Auth uppercase");
+		});
+
+		it("filters by memory kind", () => {
+			store.remember(sessionId, "decision", "Auth decision", "Body", 0.8, [], {
+				concepts: ["auth"],
+			});
+			store.remember(sessionId, "bugfix", "Auth bugfix", "Body", 0.6, [], {
+				concepts: ["auth"],
+			});
+
+			const decisions = findByConcept(store.db, "auth", { kind: "decision" });
+			expect(decisions).toHaveLength(1);
+			expect(decisions[0].title).toBe("Auth decision");
+		});
+
+		it("returns results ordered by created_at DESC", () => {
+			const id1 = store.remember(sessionId, "discovery", "First concept", "Body", 0.5, [], {
+				concepts: ["auth"],
+			});
+			const id2 = store.remember(sessionId, "bugfix", "Second concept", "Body", 0.5, [], {
+				concepts: ["auth"],
+			});
+			store.db
+				.prepare("UPDATE memory_items SET created_at = '2099-01-01T00:00:00Z' WHERE id = ?")
+				.run(id2);
+			store.db
+				.prepare("UPDATE memory_items SET created_at = '2000-01-01T00:00:00Z' WHERE id = ?")
+				.run(id1);
+
+			const results = findByConcept(store.db, "auth");
+			expect(results).toHaveLength(2);
+			expect(results[0].title).toBe("Second concept");
+			expect(results[1].title).toBe("First concept");
+		});
+
+		it("respects the limit option", () => {
+			for (let i = 0; i < 5; i++) {
+				store.remember(sessionId, "discovery", `Concept memory ${i}`, "Body", 0.5, [], {
+					concepts: ["auth"],
+				});
+			}
+
+			const results = findByConcept(store.db, "auth", { limit: 2 });
+			expect(results).toHaveLength(2);
+		});
+
+		it("excludes soft-deleted memories (active = 0)", () => {
+			const memId = store.remember(sessionId, "discovery", "Deleted concept", "Body", 0.5, [], {
+				concepts: ["auth"],
+			});
+			store.db.prepare("UPDATE memory_items SET active = 0 WHERE id = ?").run(memId);
+
+			const results = findByConcept(store.db, "auth");
+			expect(results).toHaveLength(0);
+		});
+
+		it("filters by since timestamp", () => {
+			const id1 = store.remember(sessionId, "discovery", "Old concept", "Body", 0.5, [], {
+				concepts: ["auth"],
+			});
+			const id2 = store.remember(sessionId, "bugfix", "New concept", "Body", 0.5, [], {
+				concepts: ["auth"],
+			});
+			store.db
+				.prepare("UPDATE memory_items SET created_at = '2000-01-01T00:00:00Z' WHERE id = ?")
+				.run(id1);
+			store.db
+				.prepare("UPDATE memory_items SET created_at = '2099-01-01T00:00:00Z' WHERE id = ?")
+				.run(id2);
+
+			const results = findByConcept(store.db, "auth", { since: "2025-01-01T00:00:00Z" });
+			expect(results).toHaveLength(1);
+			expect(results[0].title).toBe("New concept");
+		});
+	});
+
+	// -- MemoryStore integration ----------------------------------------------
+
+	describe("MemoryStore integration", () => {
+		it("store.findByFile delegates to the ref-queries function", () => {
+			store.remember(sessionId, "discovery", "Store file test", "Body", 0.5, [], {
+				files_read: ["src/store.ts"],
+			});
+
+			const results = store.findByFile("src/store.ts");
+			expect(results).toHaveLength(1);
+			expect(results[0].title).toBe("Store file test");
+		});
+
+		it("store.findByConcept delegates to the ref-queries function", () => {
+			store.remember(sessionId, "discovery", "Store concept test", "Body", 0.5, [], {
+				concepts: ["store"],
+			});
+
+			const results = store.findByConcept("store");
+			expect(results).toHaveLength(1);
+			expect(results[0].title).toBe("Store concept test");
+		});
+	});
+});

--- a/packages/core/src/ref-queries.ts
+++ b/packages/core/src/ref-queries.ts
@@ -1,0 +1,142 @@
+/**
+ * Indexed query functions for finding memories by file path or concept.
+ *
+ * These use the `memory_file_refs` and `memory_concept_refs` junction tables
+ * (populated at write time) to efficiently answer questions like
+ * "what decisions affected auth.ts?" and "what do we know about auth?".
+ *
+ * Uses raw SQL with `db.prepare()` (not Drizzle) since these are JOIN queries
+ * with dynamic WHERE clauses — same pattern as search.ts.
+ */
+
+import type { Database } from "./db.js";
+
+export interface RefQueryOptions {
+	/** Filter by memory kind (e.g. "decision", "bugfix") */
+	kind?: string;
+	/** Filter file refs by relation type */
+	relation?: "read" | "modified";
+	/** Max results to return. Default 20. */
+	limit?: number;
+	/** Only return memories created after this ISO timestamp */
+	since?: string;
+}
+
+export interface RefQueryResult {
+	id: number;
+	session_id: number;
+	kind: string;
+	title: string;
+	subtitle: string | null;
+	body_text: string;
+	narrative: string | null;
+	confidence: number;
+	tags_text: string;
+	created_at: string;
+	updated_at: string;
+	files_read: string | null;
+	files_modified: string | null;
+	concepts: string | null;
+	metadata_json: string | null;
+}
+
+/**
+ * Find memories associated with a file path via the `memory_file_refs` index.
+ *
+ * If `filePath` ends with `/`, it is treated as a directory prefix and matches
+ * all files under that directory. Otherwise, it performs an exact match.
+ */
+export function findByFile(
+	db: Database,
+	filePath: string,
+	options?: RefQueryOptions,
+): RefQueryResult[] {
+	const limit = options?.limit ?? 20;
+	const isDir = filePath.endsWith("/");
+
+	const clauses: string[] = ["mi.active = 1"];
+	const params: unknown[] = [];
+
+	if (isDir) {
+		clauses.push("mfr.file_path LIKE ? || '%'");
+		params.push(filePath);
+	} else {
+		clauses.push("mfr.file_path = ?");
+		params.push(filePath);
+	}
+
+	if (options?.relation) {
+		clauses.push("mfr.relation = ?");
+		params.push(options.relation);
+	}
+
+	if (options?.kind) {
+		clauses.push("mi.kind = ?");
+		params.push(options.kind);
+	}
+
+	if (options?.since) {
+		clauses.push("mi.created_at > ?");
+		params.push(options.since);
+	}
+
+	params.push(limit);
+
+	const sql = `
+		SELECT DISTINCT mi.id, mi.session_id, mi.kind, mi.title, mi.subtitle,
+			mi.body_text, mi.narrative, mi.confidence, mi.tags_text,
+			mi.created_at, mi.updated_at, mi.files_read, mi.files_modified,
+			mi.concepts, mi.metadata_json
+		FROM memory_file_refs mfr
+		JOIN memory_items mi ON mi.id = mfr.memory_id
+		WHERE ${clauses.join(" AND ")}
+		ORDER BY mi.created_at DESC
+		LIMIT ?
+	`;
+
+	return db.prepare(sql).all(...params) as RefQueryResult[];
+}
+
+/**
+ * Find memories associated with a concept via the `memory_concept_refs` index.
+ *
+ * The input concept is normalized to `trim().toLowerCase()` before querying,
+ * matching the normalization applied at write time.
+ */
+export function findByConcept(
+	db: Database,
+	concept: string,
+	options?: RefQueryOptions,
+): RefQueryResult[] {
+	const limit = options?.limit ?? 20;
+	const normalized = concept.trim().toLowerCase();
+
+	const clauses: string[] = ["mcr.concept = ?", "mi.active = 1"];
+	const params: unknown[] = [normalized];
+
+	if (options?.kind) {
+		clauses.push("mi.kind = ?");
+		params.push(options.kind);
+	}
+
+	if (options?.since) {
+		clauses.push("mi.created_at > ?");
+		params.push(options.since);
+	}
+
+	params.push(limit);
+
+	const sql = `
+		SELECT DISTINCT mi.id, mi.session_id, mi.kind, mi.title, mi.subtitle,
+			mi.body_text, mi.narrative, mi.confidence, mi.tags_text,
+			mi.created_at, mi.updated_at, mi.files_read, mi.files_modified,
+			mi.concepts, mi.metadata_json
+		FROM memory_concept_refs mcr
+		JOIN memory_items mi ON mi.id = mcr.memory_id
+		WHERE ${clauses.join(" AND ")}
+		ORDER BY mi.created_at DESC
+		LIMIT ?
+	`;
+
+	return db.prepare(sql).all(...params) as RefQueryResult[];
+}

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1258,3 +1258,28 @@ export function explain(
 		},
 	};
 }
+
+/**
+ * Find memory IDs that touch any of the given file paths, using the
+ * memory_file_refs junction table index. Returns up to `limit` distinct
+ * memory IDs ordered by creation date (newest first).
+ *
+ * This is used by the pack builder to source working-set candidates
+ * that FTS/vector search would miss.
+ */
+export function findCandidatesByFile(db: Database, filePaths: string[], limit = 50): number[] {
+	if (filePaths.length === 0) return [];
+	const placeholders = filePaths.map(() => "?").join(", ");
+	const rows = db
+		.prepare(
+			`SELECT DISTINCT mfr.memory_id
+			 FROM memory_file_refs mfr
+			 JOIN memory_items mi ON mi.id = mfr.memory_id
+			 WHERE mfr.file_path IN (${placeholders})
+			   AND mi.active = 1
+			 ORDER BY mi.created_at DESC
+			 LIMIT ?`,
+		)
+		.all(...filePaths, limit) as Array<{ memory_id: number }>;
+	return rows.map((r) => r.memory_id);
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -37,6 +37,8 @@ import {
 	buildMemoryPackTrace,
 	buildMemoryPackTraceAsync,
 } from "./pack.js";
+import type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
+import { findByConcept as findByConceptFn, findByFile as findByFileFn } from "./ref-queries.js";
 import * as schema from "./schema.js";
 import {
 	type ExplainOptions,
@@ -2311,6 +2313,18 @@ export class MemoryStore {
 				String(a.peer_name ?? "").localeCompare(String(b.peer_name ?? "")) ||
 				String(a.peer_device_id ?? "").localeCompare(String(b.peer_device_id ?? "")),
 		);
+	}
+
+	// ref queries
+
+	/** Find memories associated with a file path via the junction table index. */
+	findByFile(filePath: string, options?: RefQueryOptions): RefQueryResult[] {
+		return findByFileFn(this.db, filePath, options);
+	}
+
+	/** Find memories associated with a concept via the junction table index. */
+	findByConcept(concept: string, options?: RefQueryOptions): RefQueryResult[] {
+		return findByConceptFn(this.db, concept, options);
 	}
 
 	// close


### PR DESCRIPTION
## Description

Wire `RefBackfillRunner` into the CLI serve command, following the same pattern as `DedupKeyBackfillRunner` and `SessionContextBackfillRunner`. Starts conditionally when pending backfill work exists.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] No new warnings introduced