### PR TITLE
feat(core): wire file-ref candidate sourcing into task and recall pack modes

### DIFF
--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -1357,3 +1357,80 @@ describe("buildMemoryPack cluster compression", () => {
 		expect(compressedCandidate?.disposition).toBe("compressed");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// File-ref candidate sourcing across retrieval modes
+// ---------------------------------------------------------------------------
+
+describe("buildMemoryPack file-ref candidates in task and recall modes", () => {
+	let tmpDir: string;
+	let store: MemoryStore;
+	let sessionId: number;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-pack-fileref-"));
+		const dbPath = join(tmpDir, "test.db");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		store = new MemoryStore(dbPath);
+		sessionId = insertTestSession(store.db);
+	});
+
+	afterEach(() => {
+		store.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("surfaces file-ref candidates in task mode", () => {
+		// Memory whose text has NO overlap with the task query
+		// but whose files_modified match the working_set_paths
+		store.remember(
+			sessionId,
+			"decision",
+			"Chose HMAC-SHA256 for token signing",
+			"Selected HMAC-SHA256 for performance and security balance.",
+			0.8,
+			["crypto", "tokens"],
+			{
+				files_modified: ["packages/core/src/auth.ts"],
+				concepts: ["authentication"],
+			},
+		);
+
+		// Task-like query that will trigger task mode
+		const pack = buildMemoryPack(store, "what should I do next", 10, null, {
+			working_set_paths: ["packages/core/src/auth.ts"],
+		});
+
+		expect(pack.metrics.mode).toBe("task");
+		const found = pack.items.some((item) => item.title.includes("HMAC-SHA256"));
+		expect(found).toBe(true);
+	});
+
+	it("surfaces file-ref candidates in recall mode", () => {
+		// Memory whose text has NO overlap with the recall query
+		// but whose files_modified match the working_set_paths
+		store.remember(
+			sessionId,
+			"decision",
+			"Chose HMAC-SHA256 for token signing",
+			"Selected HMAC-SHA256 for performance and security balance.",
+			0.8,
+			["crypto", "tokens"],
+			{
+				files_modified: ["packages/core/src/auth.ts"],
+				concepts: ["authentication"],
+			},
+		);
+
+		// Recall-like query that will trigger recall mode
+		const pack = buildMemoryPack(store, "what did I work on last time", 10, null, {
+			working_set_paths: ["packages/core/src/auth.ts"],
+		});
+
+		expect(pack.metrics.mode).toBe("recall");
+		const found = pack.items.some((item) => item.title.includes("HMAC-SHA256"));
+		expect(found).toBe(true);
+	});
+});

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -1072,6 +1072,32 @@ function mergeResults(
 	return { merged, ftsCount: ftsResults.length, semanticCount };
 }
 
+/**
+ * Merge candidates discovered via the file-ref index into an existing result
+ * set.  Returns the original array unchanged when no working-set paths are
+ * provided or no new candidates are found.
+ */
+function mergeFileRefCandidates(
+	store: StoreHandle,
+	results: MemoryResult[],
+	filters: MemoryFilters | undefined,
+	effectiveLimit: number,
+): MemoryResult[] {
+	const workingSetPaths = filters?.working_set_paths;
+	if (!workingSetPaths || !Array.isArray(workingSetPaths) || workingSetPaths.length === 0) {
+		return results;
+	}
+	const existingIds = new Set(results.map((r) => r.id));
+	const refCandidateIds = findCandidatesByFile(store.db, workingSetPaths, effectiveLimit);
+	const newIds = refCandidateIds.filter((id) => !existingIds.has(id));
+	if (newIds.length === 0) return results;
+	const refMemories = newIds
+		.map((id) => store.get(id))
+		.filter((m): m is NonNullable<typeof m> => m != null)
+		.map(toMemoryResult);
+	return [...results, ...refMemories];
+}
+
 function buildPackArtifacts(
 	store: StoreHandle,
 	context: string,
@@ -1110,6 +1136,7 @@ function buildPackArtifacts(
 			taskResults = merge.merged;
 			semanticCount = merge.semanticCount;
 		}
+		taskResults = mergeFileRefCandidates(store, taskResults, filters, effectiveLimit);
 		retrievalResults = [...taskResults];
 		if (taskResults.length === 0) {
 			fallbackUsed = true;
@@ -1172,6 +1199,7 @@ function buildPackArtifacts(
 			recallResults = merge.merged;
 			semanticCount = merge.semanticCount;
 		}
+		recallResults = mergeFileRefCandidates(store, recallResults, filters, effectiveLimit);
 		retrievalResults = [...recallResults];
 		results = prioritizeRecallResults(recallResults, effectiveLimit, preferSummary, context);
 		if (results.length === 0) {
@@ -1217,25 +1245,8 @@ function buildPackArtifacts(
 			ftsCount = results.length;
 			retrievalResults = [...ftsResults];
 		}
-		// Merge working-set candidates from file ref index
-		const workingSetPaths = filters?.working_set_paths;
-		if (workingSetPaths && Array.isArray(workingSetPaths) && workingSetPaths.length > 0) {
-			const existingIds = new Set(results.map((r) => r.id));
-			const refCandidateIds = findCandidatesByFile(
-				store.db,
-				workingSetPaths as string[],
-				effectiveLimit,
-			);
-			const newIds = refCandidateIds.filter((id) => !existingIds.has(id));
-			if (newIds.length > 0) {
-				const refMemories = newIds
-					.map((id) => store.get(id))
-					.filter((m): m is NonNullable<typeof m> => m != null)
-					.map(toMemoryResult);
-				results = [...results, ...refMemories];
-				results = prioritizeDefaultResults(results, effectiveLimit, context);
-			}
-		}
+		results = mergeFileRefCandidates(store, results, filters, effectiveLimit);
+		results = prioritizeDefaultResults(results, effectiveLimit, context);
 
 		if (results.length === 0) {
 			fallbackUsed = true;


### PR DESCRIPTION
## Description

Extract `mergeFileRefCandidates()` helper and wire file-ref candidate sourcing into all three pack builder modes (task, recall, default). Previously only default mode used the junction table index — task and recall modes missed file-relevant memories when FTS didn't match.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Tests verify task-mode and recall-mode queries surface file-ref candidates

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] No new warnings introduced