### PR TITLE
fix(core): wrap remember() in transaction and populate refs on replication apply

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -347,6 +347,7 @@ export {
 	RefBackfillRunner,
 	runRefBackfillPass,
 } from "./ref-backfill.js";
+export { clearMemoryRefs, normalizeConcept, populateMemoryRefs } from "./ref-populate.js";
 export type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
 export { findByConcept, findByFile } from "./ref-queries.js";
 export type { MaintenanceJob, NewMaintenanceJob } from "./schema.js";

--- a/packages/core/src/ref-backfill.ts
+++ b/packages/core/src/ref-backfill.ts
@@ -18,6 +18,7 @@ import {
 	startMaintenanceJob,
 	updateMaintenanceJob,
 } from "./maintenance-jobs.js";
+import { normalizeConcept } from "./ref-populate.js";
 
 export const REF_BACKFILL_JOB = "memory_ref_backfill";
 
@@ -171,7 +172,7 @@ export async function runRefBackfillPass(
 			}
 			if (concepts) {
 				for (const concept of concepts) {
-					const normalized = concept?.trim().toLowerCase();
+					const normalized = normalizeConcept(concept ?? "");
 					if (normalized) insertConceptRef.run(row.id, normalized);
 				}
 			}

--- a/packages/core/src/ref-populate.ts
+++ b/packages/core/src/ref-populate.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared helpers for populating the `memory_file_refs` and
+ * `memory_concept_refs` junction tables from the denormalized JSON arrays
+ * stored on `memory_items` rows.
+ *
+ * Used at write time in `MemoryStore.remember()`, during replication apply,
+ * and by the ref-backfill maintenance job.
+ */
+
+import type { Database as SqliteDatabase } from "better-sqlite3";
+
+/**
+ * Normalize a concept string for storage/lookup: trim whitespace and
+ * lowercase. Shared across write, backfill, and query paths so the
+ * normalization rule lives in exactly one place.
+ */
+export function normalizeConcept(concept: string): string {
+	return concept.trim().toLowerCase();
+}
+
+/**
+ * Delete all existing ref rows for a memory. Used before re-populating on
+ * updates where the files/concepts may have changed.
+ */
+export function clearMemoryRefs(db: SqliteDatabase, memoryId: number): void {
+	db.prepare("DELETE FROM memory_file_refs WHERE memory_id = ?").run(memoryId);
+	db.prepare("DELETE FROM memory_concept_refs WHERE memory_id = ?").run(memoryId);
+}
+
+/**
+ * Populate `memory_file_refs` and `memory_concept_refs` junction-table rows
+ * for a single memory item. Uses `INSERT OR IGNORE` so calling this on an
+ * already-populated memory is a safe no-op.
+ *
+ * Callers are responsible for running this inside a transaction when
+ * atomicity with the parent insert/update is required.
+ */
+export function populateMemoryRefs(
+	db: SqliteDatabase,
+	memoryId: number,
+	filesRead: string[] | null,
+	filesModified: string[] | null,
+	concepts: string[] | null,
+): void {
+	const insertFileRef = db.prepare(
+		"INSERT OR IGNORE INTO memory_file_refs (memory_id, file_path, relation) VALUES (?, ?, ?)",
+	);
+	if (filesRead) {
+		for (const path of filesRead) {
+			if (path) insertFileRef.run(memoryId, path, "read");
+		}
+	}
+	if (filesModified) {
+		for (const path of filesModified) {
+			if (path) insertFileRef.run(memoryId, path, "modified");
+		}
+	}
+	const insertConceptRef = db.prepare(
+		"INSERT OR IGNORE INTO memory_concept_refs (memory_id, concept) VALUES (?, ?)",
+	);
+	if (concepts) {
+		for (const concept of concepts) {
+			const normalized = normalizeConcept(concept ?? "");
+			if (normalized) insertConceptRef.run(memoryId, normalized);
+		}
+	}
+}

--- a/packages/core/src/ref-queries.ts
+++ b/packages/core/src/ref-queries.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Database } from "./db.js";
+import { normalizeConcept } from "./ref-populate.js";
 
 export interface RefQueryOptions {
 	/** Filter by memory kind (e.g. "decision", "bugfix") */
@@ -109,7 +110,7 @@ export function findByConcept(
 	options?: RefQueryOptions,
 ): RefQueryResult[] {
 	const limit = options?.limit ?? 20;
-	const normalized = concept.trim().toLowerCase();
+	const normalized = normalizeConcept(concept);
 
 	const clauses: string[] = ["mcr.concept = ?", "mi.active = 1"];
 	const params: unknown[] = [normalized];

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -581,6 +581,25 @@ describe("MemoryStore", () => {
 				expect(conceptRefs).toHaveLength(0);
 			}
 		});
+
+		it("rolls back memory_items insert when ref population fails", () => {
+			const sessionId = insertTestSession(store.db);
+
+			// Sabotage the memory_file_refs table so INSERT OR IGNORE still throws
+			store.db.exec("DROP TABLE memory_file_refs");
+
+			expect(() =>
+				store.remember(sessionId, "discovery", "Rollback test", "Body", 0.5, [], {
+					files_read: ["src/oops.ts"],
+				}),
+			).toThrow();
+
+			// The memory_items insert should have been rolled back
+			const row = store.db
+				.prepare("SELECT id FROM memory_items WHERE title = ?")
+				.get("Rollback test");
+			expect(row).toBeUndefined();
+		});
 	});
 
 	// -- forget --------------------------------------------------------------

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -37,6 +37,7 @@ import {
 	buildMemoryPackTrace,
 	buildMemoryPackTraceAsync,
 } from "./pack.js";
+import { populateMemoryRefs } from "./ref-populate.js";
 import type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
 import { findByConcept as findByConceptFn, findByFile as findByFileFn } from "./ref-queries.js";
 import * as schema from "./schema.js";
@@ -591,44 +592,60 @@ export class MemoryStore {
 		// Block shared-memory writes while sync requires attention.
 		this.assertSharedMutationAllowed(provenance.visibility);
 
-		let insertedRows: Array<{ id: number }>;
+		let memoryId: number;
 		try {
-			insertedRows = this.d
-				.insert(schema.memoryItems)
-				.values({
-					session_id: sessionId,
-					kind: validKind,
-					title,
-					subtitle,
-					body_text: bodyText,
-					confidence,
-					tags_text: tagsText,
-					active: 1,
-					created_at: now,
-					updated_at: now,
-					metadata_json: toJson(metaPayload),
-					actor_id: provenance.actor_id,
-					actor_display_name: provenance.actor_display_name,
-					visibility: provenance.visibility,
-					workspace_id: provenance.workspace_id,
-					workspace_kind: provenance.workspace_kind,
-					origin_device_id: provenance.origin_device_id,
-					origin_source: provenance.origin_source,
-					trust_state: provenance.trust_state,
-					narrative,
-					facts: toJsonNullable(facts),
-					concepts: toJsonNullable(concepts),
-					files_read: toJsonNullable(filesRead),
-					files_modified: toJsonNullable(filesModified),
-					prompt_number: promptNumber,
-					user_prompt_id: userPromptId,
-					deleted_at: null,
-					rev: 1,
-					dedup_key: dedupKey,
-					import_key: importKey,
-				})
-				.returning({ id: schema.memoryItems.id })
-				.all();
+			memoryId = this.db.transaction(() => {
+				const insertedRows = this.d
+					.insert(schema.memoryItems)
+					.values({
+						session_id: sessionId,
+						kind: validKind,
+						title,
+						subtitle,
+						body_text: bodyText,
+						confidence,
+						tags_text: tagsText,
+						active: 1,
+						created_at: now,
+						updated_at: now,
+						metadata_json: toJson(metaPayload),
+						actor_id: provenance.actor_id,
+						actor_display_name: provenance.actor_display_name,
+						visibility: provenance.visibility,
+						workspace_id: provenance.workspace_id,
+						workspace_kind: provenance.workspace_kind,
+						origin_device_id: provenance.origin_device_id,
+						origin_source: provenance.origin_source,
+						trust_state: provenance.trust_state,
+						narrative,
+						facts: toJsonNullable(facts),
+						concepts: toJsonNullable(concepts),
+						files_read: toJsonNullable(filesRead),
+						files_modified: toJsonNullable(filesModified),
+						prompt_number: promptNumber,
+						user_prompt_id: userPromptId,
+						deleted_at: null,
+						rev: 1,
+						dedup_key: dedupKey,
+						import_key: importKey,
+					})
+					.returning({ id: schema.memoryItems.id })
+					.all();
+
+				const id = insertedRows[0]?.id;
+				if (id == null) throw new Error("memory insert returned no id");
+
+				populateMemoryRefs(this.db, id, filesRead, filesModified, concepts);
+
+				// Record replication op for sync propagation (non-fatal)
+				try {
+					recordReplicationOp(this.db, { memoryId: id, opType: "upsert", deviceId: this.deviceId });
+				} catch {
+					// Non-fatal — don't block memory creation
+				}
+
+				return id;
+			})();
 		} catch (error) {
 			if (!isSameSessionDedupConstraintError(error)) throw error;
 			const existingSameSessionHit = this.findExistingDuplicateMemory(
@@ -646,53 +663,9 @@ export class MemoryStore {
 			throw error;
 		}
 
-		const memoryId = insertedRows[0]?.id;
-		if (memoryId == null) throw new Error("memory insert returned no id");
-
-		this.populateMemoryRefs(memoryId, filesRead, filesModified, concepts);
-
-		// Record replication op for sync propagation
-		try {
-			recordReplicationOp(this.db, { memoryId, opType: "upsert", deviceId: this.deviceId });
-		} catch {
-			// Non-fatal — don't block memory creation
-		}
-
 		this.enqueueVectorWrite(memoryId, title, bodyText);
 
 		return memoryId;
-	}
-
-	// junction-table denormalization
-
-	private populateMemoryRefs(
-		memoryId: number,
-		filesRead: string[] | null,
-		filesModified: string[] | null,
-		concepts: string[] | null,
-	): void {
-		const insertFileRef = this.db.prepare(
-			"INSERT OR IGNORE INTO memory_file_refs (memory_id, file_path, relation) VALUES (?, ?, ?)",
-		);
-		if (filesRead) {
-			for (const path of filesRead) {
-				if (path) insertFileRef.run(memoryId, path, "read");
-			}
-		}
-		if (filesModified) {
-			for (const path of filesModified) {
-				if (path) insertFileRef.run(memoryId, path, "modified");
-			}
-		}
-		const insertConceptRef = this.db.prepare(
-			"INSERT OR IGNORE INTO memory_concept_refs (memory_id, concept) VALUES (?, ?)",
-		);
-		if (concepts) {
-			for (const concept of concepts) {
-				const normalized = concept?.trim().toLowerCase();
-				if (normalized) insertConceptRef.run(memoryId, normalized);
-			}
-		}
 	}
 
 	// provenance resolution

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1593,6 +1593,115 @@ describe("applyReplicationOps", () => {
 		expect(result.vectorWork.deleteMemoryIds).toEqual([]);
 	});
 
+	it("populates ref tables when inserting a new memory with files and concepts", () => {
+		const op = makeReplicationOp({
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Remote with refs",
+				body_text: "Remote body",
+				files_read: ["src/auth.ts", "src/config.ts"],
+				files_modified: ["src/auth.ts"],
+				concepts: ["Auth", " security "],
+			}),
+		});
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+
+		const mem = db
+			.prepare("SELECT id FROM memory_items WHERE import_key = ?")
+			.get("key:test-1") as { id: number };
+
+		const fileRefs = db
+			.prepare("SELECT * FROM memory_file_refs WHERE memory_id = ? ORDER BY file_path, relation")
+			.all(mem.id) as Array<{ memory_id: number; file_path: string; relation: string }>;
+
+		expect(fileRefs).toHaveLength(3);
+		expect(fileRefs).toContainEqual({
+			memory_id: mem.id,
+			file_path: "src/auth.ts",
+			relation: "read",
+		});
+		expect(fileRefs).toContainEqual({
+			memory_id: mem.id,
+			file_path: "src/config.ts",
+			relation: "read",
+		});
+		expect(fileRefs).toContainEqual({
+			memory_id: mem.id,
+			file_path: "src/auth.ts",
+			relation: "modified",
+		});
+
+		const conceptRefs = db
+			.prepare("SELECT * FROM memory_concept_refs WHERE memory_id = ? ORDER BY concept")
+			.all(mem.id) as Array<{ memory_id: number; concept: string }>;
+
+		expect(conceptRefs).toHaveLength(2);
+		expect(conceptRefs).toContainEqual({ memory_id: mem.id, concept: "auth" });
+		expect(conceptRefs).toContainEqual({ memory_id: mem.id, concept: "security" });
+	});
+
+	it("repopulates ref tables when updating existing memory with new files/concepts", () => {
+		// Insert initial memory with some refs
+		const insertOp = makeReplicationOp({
+			entity_id: "key:update-refs",
+			clock_rev: 1,
+			clock_updated_at: "2026-01-01T00:00:00Z",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Refs update test",
+				body_text: "Body",
+				files_read: ["src/old.ts"],
+				concepts: ["old-concept"],
+			}),
+		});
+		applyReplicationOps(db, [insertOp], "dev-local");
+
+		const mem = db
+			.prepare("SELECT id FROM memory_items WHERE import_key = ?")
+			.get("key:update-refs") as { id: number };
+
+		// Verify initial refs
+		let fileRefs = db
+			.prepare("SELECT file_path FROM memory_file_refs WHERE memory_id = ?")
+			.all(mem.id) as Array<{ file_path: string }>;
+		expect(fileRefs).toHaveLength(1);
+		expect(fileRefs[0]?.file_path).toBe("src/old.ts");
+
+		// Update with new files/concepts
+		const updateOp = makeReplicationOp({
+			op_id: `op-update-${Date.now()}`,
+			entity_id: "key:update-refs",
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Refs update test",
+				body_text: "Body",
+				files_read: ["src/new.ts"],
+				files_modified: ["src/new.ts"],
+				concepts: ["new-concept"],
+			}),
+		});
+		applyReplicationOps(db, [updateOp], "dev-local");
+
+		// Old refs should be gone, new refs should be present
+		fileRefs = db
+			.prepare(
+				"SELECT file_path, relation FROM memory_file_refs WHERE memory_id = ? ORDER BY file_path, relation",
+			)
+			.all(mem.id) as Array<{ file_path: string; relation: string }>;
+		expect(fileRefs).toHaveLength(2);
+		expect(fileRefs).toContainEqual({ file_path: "src/new.ts", relation: "read" });
+		expect(fileRefs).toContainEqual({ file_path: "src/new.ts", relation: "modified" });
+
+		const conceptRefs = db
+			.prepare("SELECT concept FROM memory_concept_refs WHERE memory_id = ?")
+			.all(mem.id) as Array<{ concept: string }>;
+		expect(conceptRefs).toHaveLength(1);
+		expect(conceptRefs[0]?.concept).toBe("new-concept");
+	});
+
 	it("updates existing memory when op clock is newer", () => {
 		// Insert initial memory
 		const sessionId = insertTestSession(db);

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -14,6 +14,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import { fromJson, fromJsonStrict, toJson, toJsonNullable } from "./db.js";
 import { readCodememConfigFile } from "./observer-config.js";
+import { clearMemoryRefs, populateMemoryRefs } from "./ref-populate.js";
 import * as schema from "./schema.js";
 import { deriveTags } from "./tags.js";
 import type {
@@ -133,6 +134,12 @@ function asNumberOrNull(value: unknown): number | null {
 function asStringOrNull(value: unknown): string | null {
 	if (value == null) return null;
 	return String(value);
+}
+
+/** Coerce an unknown payload field to `string[] | null` for ref population. */
+function asStringArrayOrNull(value: unknown): string[] | null {
+	if (!Array.isArray(value)) return null;
+	return value.map(String);
 }
 
 function parseMemoryPayload(op: ReplicationOp, errors: string[]): MemoryPayload | null {
@@ -1870,6 +1877,15 @@ export function applyReplicationOps(
 							})
 							.where(eq(schema.memoryItems.import_key, importKey))
 							.run();
+						// Re-populate junction tables with updated file/concept refs
+						clearMemoryRefs(db, Number(memRow.id));
+						populateMemoryRefs(
+							db,
+							Number(memRow.id),
+							asStringArrayOrNull(payload.files_read),
+							asStringArrayOrNull(payload.files_modified),
+							asStringArrayOrNull(payload.concepts),
+						);
 						if (shouldDeleteVectors) queueVectorDelete(Number(memRow.id));
 						else if (shouldQueueVectorUpsert) queueVectorUpsert(Number(memRow.id));
 					} else {
@@ -1923,6 +1939,14 @@ export function applyReplicationOps(
 							.returning({ id: schema.memoryItems.id })
 							.all();
 						const insertedId = Number(insertedRows[0]?.id ?? 0);
+						// Populate junction tables for the new memory
+						populateMemoryRefs(
+							db,
+							insertedId,
+							asStringArrayOrNull(payload.files_read),
+							asStringArrayOrNull(payload.files_modified),
+							asStringArrayOrNull(payload.concepts),
+						);
 						if (payload.deleted_at != null || Number(payload.active ?? 1) === 0) {
 							queueVectorDelete(insertedId);
 						} else {


### PR DESCRIPTION
## Description

Three related fixes:
- Wrap `remember()` insert + ref population + replication op in a single transaction so partial writes can't occur
- Populate junction table refs during replication apply (both insert and update paths) so synced memories are indexed
- Extract shared `populateMemoryRefs()` and `normalizeConcept()` into `ref-populate.ts` to eliminate duplication

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Tests verify transaction rollback, replication insert refs, and replication update ref replacement

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] No new warnings introduced