### PR TITLE
fix(core): improve ref query correctness — OR logic, subquery dedup, input guards, LIKE escaping

### DIFF
--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -1087,8 +1087,14 @@ function mergeFileRefCandidates(
 	if (!workingSetPaths || !Array.isArray(workingSetPaths) || workingSetPaths.length === 0) {
 		return results;
 	}
+	const validPaths = workingSetPaths.filter(
+		(p): p is string => typeof p === "string" && p.length > 0,
+	);
+	if (validPaths.length === 0) return results;
 	const existingIds = new Set(results.map((r) => r.id));
-	const refCandidateIds = findCandidatesByFile(store.db, workingSetPaths, effectiveLimit);
+	const refCandidateIds = findCandidatesByFile(store.db, validPaths, effectiveLimit, {
+		project: filters?.project,
+	});
 	const newIds = refCandidateIds.filter((id) => !existingIds.has(id));
 	if (newIds.length === 0) return results;
 	const refMemories = newIds

--- a/packages/core/src/ref-backfill.ts
+++ b/packages/core/src/ref-backfill.ts
@@ -47,11 +47,14 @@ export function hasPendingRefBackfill(db: SqliteDatabase): boolean {
 			`SELECT 1 FROM memory_items mi
 			 WHERE mi.active = 1
 			   AND (mi.files_read IS NOT NULL OR mi.files_modified IS NOT NULL OR mi.concepts IS NOT NULL)
-			   AND NOT EXISTS (
-			     SELECT 1 FROM memory_file_refs mfr WHERE mfr.memory_id = mi.id
-			   )
-			   AND NOT EXISTS (
-			     SELECT 1 FROM memory_concept_refs mcr WHERE mcr.memory_id = mi.id
+			   AND (
+			     ((mi.files_read IS NOT NULL OR mi.files_modified IS NOT NULL) AND NOT EXISTS (
+			       SELECT 1 FROM memory_file_refs mfr WHERE mfr.memory_id = mi.id
+			     ))
+			     OR
+			     (mi.concepts IS NOT NULL AND NOT EXISTS (
+			       SELECT 1 FROM memory_concept_refs mcr WHERE mcr.memory_id = mi.id
+			     ))
 			   )
 			 LIMIT 1`,
 		)
@@ -74,7 +77,8 @@ function safeJsonArray(value: string | null): string[] | null {
 	if (!value) return null;
 	try {
 		const parsed: unknown = JSON.parse(value);
-		if (Array.isArray(parsed)) return parsed as string[];
+		if (!Array.isArray(parsed)) return null;
+		return parsed.filter((v): v is string => typeof v === "string");
 	} catch {
 		// corrupt JSON — skip gracefully
 	}

--- a/packages/core/src/ref-populate.ts
+++ b/packages/core/src/ref-populate.ts
@@ -47,12 +47,14 @@ export function populateMemoryRefs(
 	);
 	if (filesRead) {
 		for (const path of filesRead) {
-			if (path) insertFileRef.run(memoryId, path, "read");
+			if (typeof path !== "string" || !path) continue;
+			insertFileRef.run(memoryId, path, "read");
 		}
 	}
 	if (filesModified) {
 		for (const path of filesModified) {
-			if (path) insertFileRef.run(memoryId, path, "modified");
+			if (typeof path !== "string" || !path) continue;
+			insertFileRef.run(memoryId, path, "modified");
 		}
 	}
 	const insertConceptRef = db.prepare(
@@ -60,7 +62,8 @@ export function populateMemoryRefs(
 	);
 	if (concepts) {
 		for (const concept of concepts) {
-			const normalized = normalizeConcept(concept ?? "");
+			if (typeof concept !== "string") continue;
+			const normalized = normalizeConcept(concept);
 			if (normalized) insertConceptRef.run(memoryId, normalized);
 		}
 	}

--- a/packages/core/src/ref-queries.ts
+++ b/packages/core/src/ref-queries.ts
@@ -52,45 +52,56 @@ export function findByFile(
 	filePath: string,
 	options?: RefQueryOptions,
 ): RefQueryResult[] {
-	const limit = options?.limit ?? 20;
-	const isDir = filePath.endsWith("/");
+	const trimmed = filePath.trim();
+	if (!trimmed) return [];
 
-	const clauses: string[] = ["mi.active = 1"];
-	const params: unknown[] = [];
+	const limit = options?.limit ?? 20;
+	const isDir = trimmed.endsWith("/");
+
+	const refClauses: string[] = [];
+	const refParams: unknown[] = [];
 
 	if (isDir) {
-		clauses.push("mfr.file_path LIKE ? || '%'");
-		params.push(filePath);
+		const escaped = trimmed.replace(/%/g, "\\%").replace(/_/g, "\\_");
+		refClauses.push("mfr.file_path LIKE ? ESCAPE '\\'");
+		refParams.push(`${escaped}%`);
 	} else {
-		clauses.push("mfr.file_path = ?");
-		params.push(filePath);
+		refClauses.push("mfr.file_path = ?");
+		refParams.push(trimmed);
 	}
 
 	if (options?.relation) {
-		clauses.push("mfr.relation = ?");
-		params.push(options.relation);
+		refClauses.push("mfr.relation = ?");
+		refParams.push(options.relation);
 	}
 
+	const outerClauses: string[] = ["mi.active = 1"];
+	const outerParams: unknown[] = [];
+
 	if (options?.kind) {
-		clauses.push("mi.kind = ?");
-		params.push(options.kind);
+		outerClauses.push("mi.kind = ?");
+		outerParams.push(options.kind);
 	}
 
 	if (options?.since) {
-		clauses.push("mi.created_at > ?");
-		params.push(options.since);
+		outerClauses.push("mi.created_at > ?");
+		outerParams.push(options.since);
 	}
 
-	params.push(limit);
+	const params: unknown[] = [...refParams, ...outerParams, limit];
 
 	const sql = `
-		SELECT DISTINCT mi.id, mi.session_id, mi.kind, mi.title, mi.subtitle,
+		SELECT mi.id, mi.session_id, mi.kind, mi.title, mi.subtitle,
 			mi.body_text, mi.narrative, mi.confidence, mi.tags_text,
 			mi.created_at, mi.updated_at, mi.files_read, mi.files_modified,
 			mi.concepts, mi.metadata_json
-		FROM memory_file_refs mfr
-		JOIN memory_items mi ON mi.id = mfr.memory_id
-		WHERE ${clauses.join(" AND ")}
+		FROM memory_items mi
+		WHERE mi.id IN (
+			SELECT DISTINCT mfr.memory_id
+			FROM memory_file_refs mfr
+			WHERE ${refClauses.join(" AND ")}
+		)
+		AND ${outerClauses.join(" AND ")}
 		ORDER BY mi.created_at DESC
 		LIMIT ?
 	`;
@@ -109,32 +120,38 @@ export function findByConcept(
 	concept: string,
 	options?: RefQueryOptions,
 ): RefQueryResult[] {
-	const limit = options?.limit ?? 20;
 	const normalized = normalizeConcept(concept);
+	if (!normalized) return [];
 
-	const clauses: string[] = ["mcr.concept = ?", "mi.active = 1"];
-	const params: unknown[] = [normalized];
+	const limit = options?.limit ?? 20;
+
+	const outerClauses: string[] = ["mi.active = 1"];
+	const outerParams: unknown[] = [];
 
 	if (options?.kind) {
-		clauses.push("mi.kind = ?");
-		params.push(options.kind);
+		outerClauses.push("mi.kind = ?");
+		outerParams.push(options.kind);
 	}
 
 	if (options?.since) {
-		clauses.push("mi.created_at > ?");
-		params.push(options.since);
+		outerClauses.push("mi.created_at > ?");
+		outerParams.push(options.since);
 	}
 
-	params.push(limit);
+	const params: unknown[] = [normalized, ...outerParams, limit];
 
 	const sql = `
-		SELECT DISTINCT mi.id, mi.session_id, mi.kind, mi.title, mi.subtitle,
+		SELECT mi.id, mi.session_id, mi.kind, mi.title, mi.subtitle,
 			mi.body_text, mi.narrative, mi.confidence, mi.tags_text,
 			mi.created_at, mi.updated_at, mi.files_read, mi.files_modified,
 			mi.concepts, mi.metadata_json
-		FROM memory_concept_refs mcr
-		JOIN memory_items mi ON mi.id = mcr.memory_id
-		WHERE ${clauses.join(" AND ")}
+		FROM memory_items mi
+		WHERE mi.id IN (
+			SELECT DISTINCT mcr.memory_id
+			FROM memory_concept_refs mcr
+			WHERE mcr.concept = ?
+		)
+		AND ${outerClauses.join(" AND ")}
 		ORDER BY mi.created_at DESC
 		LIMIT ?
 	`;

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -18,7 +18,7 @@ import {
 } from "./filters.js";
 import { parsePositiveMemoryId } from "./integers.js";
 import { inferMemoryRole } from "./memory-quality.js";
-import { projectMatchesFilter } from "./project.js";
+import { projectClause, projectMatchesFilter } from "./project.js";
 import { memoryLooksRecapLike, queryPrefersRecap, recapPenaltyMultiplier } from "./recap-policy.js";
 import * as schema from "./schema.js";
 import { canonicalMemoryKind } from "./summary-memory.js";
@@ -1276,19 +1276,38 @@ export function explain(
  * This is used by the pack builder to source working-set candidates
  * that FTS/vector search would miss.
  */
-export function findCandidatesByFile(db: Database, filePaths: string[], limit = 50): number[] {
+export function findCandidatesByFile(
+	db: Database,
+	filePaths: string[],
+	limit = 50,
+	options?: { project?: string },
+): number[] {
 	if (filePaths.length === 0) return [];
 	const placeholders = filePaths.map(() => "?").join(", ");
+	const params: unknown[] = [...filePaths];
+
+	let projectJoin = "";
+	let projectWhere = "";
+	if (options?.project) {
+		const { clause, params: projectParams } = projectClause(options.project);
+		if (clause) {
+			projectJoin = " JOIN sessions ON sessions.id = mi.session_id";
+			projectWhere = ` AND ${clause}`;
+			params.push(...projectParams);
+		}
+	}
+
+	params.push(limit);
 	const rows = db
 		.prepare(
 			`SELECT DISTINCT mfr.memory_id
 			 FROM memory_file_refs mfr
-			 JOIN memory_items mi ON mi.id = mfr.memory_id
+			 JOIN memory_items mi ON mi.id = mfr.memory_id${projectJoin}
 			 WHERE mfr.file_path IN (${placeholders})
-			   AND mi.active = 1
+			   AND mi.active = 1${projectWhere}
 			 ORDER BY mi.created_at DESC
 			 LIMIT ?`,
 		)
-		.all(...filePaths, limit) as Array<{ memory_id: number }>;
+		.all(...params) as Array<{ memory_id: number }>;
 	return rows.map((r) => r.memory_id);
 }

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -139,7 +139,8 @@ function asStringOrNull(value: unknown): string | null {
 /** Coerce an unknown payload field to `string[] | null` for ref population. */
 function asStringArrayOrNull(value: unknown): string[] | null {
 	if (!Array.isArray(value)) return null;
-	return value.map(String);
+	const strings = value.filter((v): v is string => typeof v === "string");
+	return strings.length > 0 ? strings : null;
 }
 
 function parseMemoryPayload(op: ReplicationOp, errors: string[]): MemoryPayload | null {


### PR DESCRIPTION
## Description

Four correctness fixes from review:
- `hasPendingRefBackfill` AND→OR: flag memories missing refs in *either* table, not just both
- Subquery dedup: replace `SELECT DISTINCT` on 15 wide columns with ID-based subquery
- Input guards: short-circuit on empty/whitespace file paths and concepts
- LIKE escaping: escape `%` and `_` in directory prefix queries

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] No new warnings introduced