### PR TITLE
fix(plugin): target explicit viewer bindings and reject cross-target runtime clashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,12 @@ Common overrides:
 |----------|---------|
 | `CODEMEM_DB` | SQLite database path |
 | `CODEMEM_INJECT_CONTEXT` | `0` to disable automatic context injection |
+| `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Host/port the plugin-managed viewer should start, probe, and restart |
 | `CODEMEM_VIEWER_AUTO` | `0` to disable auto-starting the viewer |
+
+Viewer note:
+
+- The plugin manages one explicit viewer target per runtime. If you run multiple viewers, give each one its own DB/runtime folder instead of sharing `viewer.pid` state next to the same SQLite file.
 
 The viewer includes a grouped Settings modal (`Connection`, `Processing`, `Device Sync`) with shell-agnostic labels and an advanced-controls toggle for technical fields.
 - Settings show effective values (configured or default) and only persist changed fields on save.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -89,6 +89,15 @@ If needed, restart viewer + plugin flow:
 codemem serve restart
 ```
 
+If you override the viewer bind, keep the plugin and viewer aligned on the same target:
+
+```bash
+set -lx CODEMEM_VIEWER_HOST 127.0.0.1
+set -lx CODEMEM_VIEWER_PORT 38892
+```
+
+The plugin now passes that explicit host/port through when it auto-starts, health-checks, stops, or restarts the viewer. Do not run multiple viewers against the same DB/runtime folder unless they intentionally share the same bind target; otherwise `viewer.pid` ownership becomes ambiguous.
+
 If compatibility toasts appear after restart, follow the runner-specific guidance in Compatibility guidance behavior below.
 
 ## Plugin tools exposed to the model
@@ -234,7 +243,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_RUNNER` | Override auto-detected runner: `codemem` (global), `npx`, `node` (repo/dev), or custom binary name. |
 | `CODEMEM_RUNNER_FROM` | Runner source override: npm package spec for `npx` (for example `codemem@0.20.0-alpha.7`), or repo/CLI entry path for `node`. |
 | `CODEMEM_VIEWER` | Set to `0`, `false`, or `off` to disable the viewer entirely. |
-| `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Customize the viewer host/port printed on startup. |
+| `CODEMEM_VIEWER_HOST`, `CODEMEM_VIEWER_PORT` | Explicit host/port the plugin-managed viewer should start, probe, stop, and restart. |
 | `CODEMEM_VIEWER_AUTO` | Set to `0`/`false`/`off` to disable auto-start (default on). |
 | `CODEMEM_VIEWER_AUTO_STOP` | Set to `0`/`false`/`off` to keep the viewer running after OpenCode exits (default on). |
 | `CODEMEM_PLUGIN_LOG` | Path for the plugin log file (set `1`/`true`/`yes` for `~/.codemem/plugin.log`; Claude hook failures are logged to this path by default). |

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -4,7 +4,9 @@ import net from "node:net";
 import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import {
-	connect,
+	DEDUP_KEY_BACKFILL_JOB,
+	DedupKeyBackfillRunner,
+	getMaintenanceJob,
 	hasPendingDedupKeyBackfill,
 	hasPendingRefBackfill,
 	hasPendingSessionContextBackfill,
@@ -13,14 +15,15 @@ import {
 	type MemoryStore,
 	ObserverClient,
 	RawEventSweeper,
+	REF_BACKFILL_JOB,
+	RefBackfillRunner,
 	readCodememConfigFile,
 	readCodememConfigFileAtPath,
 	readCoordinatorSyncConfig,
 	resolveDbPath,
-	runDedupKeyBackfillPass,
-	runRefBackfillPass,
-	runSessionContextBackfillPass,
 	runSyncDaemon,
+	SESSION_CONTEXT_BACKFILL_JOB,
+	SessionContextBackfillRunner,
 	SyncRetentionRunner,
 	VectorModelMigrationRunner,
 } from "@codemem/core";
@@ -164,6 +167,18 @@ function readViewerPidRecord(dbPath: string): ViewerPidRecord | null {
 		}
 	}
 	return null;
+}
+
+async function findRuntimeViewerConflict(
+	dbPath: string,
+	target: { host: string; port: number },
+): Promise<ViewerPidRecord | null> {
+	const record = readViewerPidRecord(dbPath);
+	if (!record) return null;
+	if (record.host === target.host && record.port === target.port) return null;
+	if (!isProcessRunning(record.pid)) return null;
+	if (!(await respondsLikeCodememViewer(record))) return null;
+	return record;
 }
 
 function isProcessRunning(pid: number): boolean {
@@ -362,71 +377,110 @@ async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promi
 	);
 }
 
-/**
- * Run backfill jobs one at a time using direct pass calls (not the timer-based
- * runners). Each job processes its full backlog before the next starts. This
- * prevents WAL lock contention when multiple backfills are pending.
- *
- * Yields to the event loop between passes so the HTTP server stays responsive.
- */
-async function sequenceBackfillRunners(
-	dbPath: string,
-	pending: {
-		dedupKey: boolean;
-		sessionContext: boolean;
-		ref: boolean;
-	},
+type ManagedBackfillRunner = {
+	start(): void;
+	stop(): Promise<void>;
+};
+
+type BackfillJobPlan = {
+	name: string;
+	kind: string;
+	isPending: (db: MemoryStore["db"]) => boolean;
+	createRunner: () => ManagedBackfillRunner;
+};
+
+function createSequentialBackfillCoordinator(
+	store: MemoryStore,
+	jobPlans: BackfillJobPlan[],
 	signal?: AbortSignal,
-): Promise<void> {
-	const jobs: Array<{
-		name: string;
-		run: (db: ReturnType<typeof connect>) => Promise<boolean>;
-	}> = [];
+): { start: () => void; stop: () => Promise<void> } {
+	const pollIntervalMs = 1000;
+	let activeRunner: ManagedBackfillRunner | null = null;
+	let activePlan: BackfillJobPlan | null = null;
+	let activePollTimer: ReturnType<typeof setTimeout> | null = null;
+	let nextJobIndex = 0;
+	let stopped = false;
 
-	if (pending.dedupKey) {
-		jobs.push({
-			name: "Dedup-key",
-			run: (db) => runDedupKeyBackfillPass(db, { batchSize: 10 }),
-		});
-	}
-	if (pending.sessionContext) {
-		jobs.push({
-			name: "Session-context",
-			run: (db) => runSessionContextBackfillPass(db, { batchSize: 10 }),
-		});
-	}
-	if (pending.ref) {
-		jobs.push({
-			name: "Ref",
-			run: (db) => runRefBackfillPass(db, { batchSize: 10 }),
-		});
-	}
+	const clearPollTimer = () => {
+		if (!activePollTimer) return;
+		clearTimeout(activePollTimer);
+		activePollTimer = null;
+	};
 
-	if (jobs.length === 0) return;
-
-	p.log.step(`${jobs.length} backfill job(s) pending — running sequentially`);
-	for (const job of jobs) {
-		if (signal?.aborted) break;
-		p.log.step(`${job.name} backfill started`);
-		// One connection per job (not per pass) to avoid repeated schema bootstrap.
-		const db = connect(dbPath);
-		try {
-			let moreWork = true;
-			while (moreWork && !signal?.aborted) {
-				moreWork = await job.run(db);
-				// Yield to the event loop so the HTTP server can handle requests
-				await new Promise((resolve) => setTimeout(resolve, 200));
-			}
-		} finally {
-			db.close();
+	const schedulePoll = (fn: () => void) => {
+		clearPollTimer();
+		activePollTimer = setTimeout(fn, pollIntervalMs);
+		if (typeof activePollTimer === "object" && "unref" in activePollTimer) {
+			activePollTimer.unref();
 		}
-		if (!signal?.aborted) {
-			p.log.step(`${job.name} backfill complete`);
+	};
+
+	const waitForCurrentJob = () => {
+		if (stopped || signal?.aborted || !activePlan || !activeRunner) return;
+		const job = getMaintenanceJob(store.db, activePlan.kind);
+		if (!activePlan.isPending(store.db)) {
+			const finishedPlan = activePlan;
+			const finishedRunner = activeRunner;
+			activePlan = null;
+			activeRunner = null;
+			void finishedRunner.stop().finally(() => {
+				if (!stopped && !signal?.aborted) {
+					p.log.step(`${finishedPlan.name} backfill complete`);
+					startNextJob();
+				}
+			});
+			return;
 		}
-	}
-	if (!signal?.aborted) {
+		if (job?.status === "failed") {
+			const failedPlan = activePlan;
+			const failedRunner = activeRunner;
+			activePlan = null;
+			activeRunner = null;
+			void failedRunner.stop().finally(() => {
+				if (!stopped && !signal?.aborted) {
+					p.log.warn(`${failedPlan.name} backfill failed and will be retried on a later startup`);
+					startNextJob();
+				}
+			});
+			return;
+		}
+		schedulePoll(waitForCurrentJob);
+	};
+
+	const startNextJob = () => {
+		clearPollTimer();
+		if (stopped || signal?.aborted) return;
+		while (nextJobIndex < jobPlans.length) {
+			const plan = jobPlans[nextJobIndex++];
+			if (!plan) continue;
+			if (!plan.isPending(store.db)) continue;
+			activePlan = plan;
+			activeRunner = plan.createRunner();
+			p.log.step(`${plan.name} backfill started`);
+			activeRunner.start();
+			schedulePoll(waitForCurrentJob);
+			return;
+		}
 		p.log.step("All backfill jobs complete");
-	}
+	};
+
+	return {
+		start: () => {
+			if (stopped || signal?.aborted) return;
+			const pendingCount = jobPlans.filter((plan) => plan.isPending(store.db)).length;
+			if (pendingCount === 0) return;
+			p.log.step(`${pendingCount} backfill job(s) pending — starting sequential runners`);
+			startNextJob();
+		},
+		stop: async () => {
+			stopped = true;
+			clearPollTimer();
+			const runner = activeRunner;
+			activeRunner = null;
+			activePlan = null;
+			if (runner) await runner.stop();
+		},
+	};
 }
 
 async function startForegroundViewer(invocation: ResolvedServeInvocation): Promise<void> {
@@ -476,15 +530,50 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		: readCodememConfigFile();
 	const syncConfig = readCoordinatorSyncConfig(config);
 	const syncEnabled = syncConfig.syncEnabled;
+	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
 	const retentionRunner = new SyncRetentionRunner({
-		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
+		dbPath,
 		signal: retentionAbort.signal,
 	});
 	const vectorMigrationRunner = new VectorModelMigrationRunner({
-		dbPath: resolveDbPath(invocation.dbPath ?? undefined),
+		dbPath,
 	});
-	// Backfill runners removed — sequenceBackfillRunners() now runs passes
-	// directly to avoid concurrent connections and WAL lock contention.
+	const backfillCoordinator = createSequentialBackfillCoordinator(
+		store,
+		[
+			{
+				name: "Dedup-key",
+				kind: DEDUP_KEY_BACKFILL_JOB,
+				isPending: hasPendingDedupKeyBackfill,
+				createRunner: () =>
+					new DedupKeyBackfillRunner({
+						dbPath,
+						signal: backfillAbort.signal,
+					}),
+			},
+			{
+				name: "Session-context",
+				kind: SESSION_CONTEXT_BACKFILL_JOB,
+				isPending: hasPendingSessionContextBackfill,
+				createRunner: () =>
+					new SessionContextBackfillRunner({
+						dbPath,
+						signal: backfillAbort.signal,
+					}),
+			},
+			{
+				name: "Ref",
+				kind: REF_BACKFILL_JOB,
+				isPending: hasPendingRefBackfill,
+				createRunner: () =>
+					new RefBackfillRunner({
+						dbPath,
+						signal: backfillAbort.signal,
+					}),
+			},
+		],
+		backfillAbort.signal,
+	);
 	const syncRuntimeStatus: {
 		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
 		detail: string | null;
@@ -500,7 +589,6 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		getSyncRuntimeStatus: () => syncRuntimeStatus,
 	};
 	const app = createApp(appOpts);
-	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
 	const pidPath = pidFilePath(dbPath);
 
 	// Sync protocol listener — separate port, network-accessible for peers.
@@ -544,23 +632,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 				vectorMigrationRunner.start();
 				p.log.step("Vector maintenance runner started");
 			}
-			// Sequence backfill jobs so only one batch-heavy job runs at a
-			// time.  On a large database (e.g. first boot after a schema upgrade)
-			// all three can have pending work; running them concurrently causes
-			// WAL lock contention that deadlocks the viewer.
-			void sequenceBackfillRunners(
-				resolveDbPath(invocation.dbPath ?? undefined),
-				{
-					dedupKey: hasPendingDedupKeyBackfill(store.db),
-					sessionContext: hasPendingSessionContextBackfill(store.db),
-					ref: hasPendingRefBackfill(store.db),
-				},
-				backfillAbort.signal,
-			).catch((err) => {
-				p.log.warn(
-					`Backfill sequencer failed: ${err instanceof Error ? err.message : String(err)}`,
-				);
-			});
+			backfillCoordinator.start();
 			if (syncConfig.syncRetentionEnabled) {
 				retentionRunner.start();
 				p.log.step("Retention maintenance runner started");
@@ -638,6 +710,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		await sweeper.stop();
 		await vectorMigrationRunner.stop();
 		await retentionRunner.stop();
+		await backfillCoordinator.stop();
 
 		// Drain both listeners before closing the shared store.
 		await new Promise<void>((resolve) => {
@@ -684,6 +757,21 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 
 async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<void> {
 	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
+	const runtimeConflict = await findRuntimeViewerConflict(dbPath, {
+		host: invocation.host,
+		port: invocation.port,
+	});
+	if (runtimeConflict) {
+		p.intro("codemem viewer");
+		p.log.error(
+			`Database runtime at ${dirname(dbPath)} is already managed by viewer ${runtimeConflict.host}:${runtimeConflict.port} (pid ${runtimeConflict.pid})`,
+		);
+		p.log.info(
+			"Use the matching --host/--port, stop the existing viewer first, or use a separate db/runtime folder for another viewer.",
+		);
+		process.exitCode = 1;
+		return;
+	}
 	if (invocation.mode === "stop" || invocation.mode === "restart") {
 		const result = await stopExistingViewer(dbPath, {
 			host: invocation.host,

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -168,6 +168,18 @@ function readViewerPidRecord(dbPath: string): ViewerPidRecord | null {
 	}
 	return null;
 }
+function normalizeViewerHost(host: string): string {
+	const normalized = host.trim().toLowerCase();
+	if (
+		normalized === "localhost" ||
+		normalized === "127.0.0.1" ||
+		normalized === "::1" ||
+		normalized === "[::1]"
+	) {
+		return "loopback";
+	}
+	return normalized;
+}
 
 async function findRuntimeViewerConflict(
 	dbPath: string,
@@ -175,7 +187,11 @@ async function findRuntimeViewerConflict(
 ): Promise<ViewerPidRecord | null> {
 	const record = readViewerPidRecord(dbPath);
 	if (!record) return null;
-	if (record.host === target.host && record.port === target.port) return null;
+	if (
+		normalizeViewerHost(record.host) === normalizeViewerHost(target.host) &&
+		record.port === target.port
+	)
+		return null;
 	if (!isProcessRunning(record.pid)) return null;
 	if (!(await respondsLikeCodememViewer(record))) return null;
 	return record;

--- a/packages/core/src/ref-backfill.test.ts
+++ b/packages/core/src/ref-backfill.test.ts
@@ -202,6 +202,32 @@ describe("ref backfill maintenance", () => {
 				db.prepare("SELECT COUNT(*) AS cnt FROM memory_file_refs").get() as { cnt: number }
 			).cnt;
 			expect(fileCount).toBe(0);
+			expect(hasPendingRefBackfill(db)).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("does not mark invalid or empty source arrays as pending forever", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			const now = new Date().toISOString();
+
+			db.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+				 workspace_id, dedup_key,
+				 files_read, files_modified, concepts)
+				 VALUES (?, 'discovery', 'Invalid memory', 'Body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', 'shared:default', NULL,
+				 ?, ?, ?)`,
+			).run(sessionId, now, now, "{not-json", JSON.stringify([]), JSON.stringify([]));
+
+			expect(hasPendingRefBackfill(db)).toBe(false);
+			const moreWork = await runRefBackfillPass(db, { batchSize: 10 });
+			expect(moreWork).toBe(false);
+			expect(getMaintenanceJob(db, REF_BACKFILL_JOB)).toBeNull();
 		} finally {
 			db.close();
 		}

--- a/packages/core/src/ref-backfill.ts
+++ b/packages/core/src/ref-backfill.ts
@@ -36,26 +36,34 @@ export interface RefBackfillRunnerOptions {
 	signal?: AbortSignal;
 }
 
-/**
- * Check if any active memory_items have non-null files/concepts columns.
- * This is a cheap existence check — it does NOT verify whether ref rows
- * already exist (the backfill itself uses INSERT OR IGNORE for that).
- */
+const REF_BACKFILL_PENDING_WHERE = `mi.active = 1
+	AND (
+	  (
+	    (
+	      (json_valid(mi.files_read) AND json_type(mi.files_read) = 'array' AND json_array_length(mi.files_read) > 0)
+	      OR
+	      (json_valid(mi.files_modified) AND json_type(mi.files_modified) = 'array' AND json_array_length(mi.files_modified) > 0)
+	    )
+	    AND NOT EXISTS (
+	      SELECT 1 FROM memory_file_refs mfr WHERE mfr.memory_id = mi.id
+	    )
+	  )
+	  OR
+	  (
+	    json_valid(mi.concepts)
+	    AND json_type(mi.concepts) = 'array'
+	    AND json_array_length(mi.concepts) > 0
+	    AND NOT EXISTS (
+	      SELECT 1 FROM memory_concept_refs mcr WHERE mcr.memory_id = mi.id
+	    )
+	  )
+	)`;
+
 export function hasPendingRefBackfill(db: SqliteDatabase): boolean {
 	const row = db
 		.prepare(
 			`SELECT 1 FROM memory_items mi
-			 WHERE mi.active = 1
-			   AND (mi.files_read IS NOT NULL OR mi.files_modified IS NOT NULL OR mi.concepts IS NOT NULL)
-			   AND (
-			     ((mi.files_read IS NOT NULL OR mi.files_modified IS NOT NULL) AND NOT EXISTS (
-			       SELECT 1 FROM memory_file_refs mfr WHERE mfr.memory_id = mi.id
-			     ))
-			     OR
-			     (mi.concepts IS NOT NULL AND NOT EXISTS (
-			       SELECT 1 FROM memory_concept_refs mcr WHERE mcr.memory_id = mi.id
-			     ))
-			   )
+			 WHERE ${REF_BACKFILL_PENDING_WHERE}
 			 LIMIT 1`,
 		)
 		.get();
@@ -98,9 +106,8 @@ export async function runRefBackfillPass(
 		.prepare(
 			`SELECT mi.id, mi.files_read, mi.files_modified, mi.concepts
 			 FROM memory_items mi
-			 WHERE mi.active = 1
-			   AND mi.id > ?
-			   AND (mi.files_read IS NOT NULL OR mi.files_modified IS NOT NULL OR mi.concepts IS NOT NULL)
+			 WHERE mi.id > ?
+			   AND ${REF_BACKFILL_PENDING_WHERE}
 			 ORDER BY mi.id ASC
 			 LIMIT ?`,
 		)
@@ -129,9 +136,8 @@ export async function runRefBackfillPass(
 	if (!existingJob || existingJob.status === "completed" || existingJob.status === "failed") {
 		const countRow = db
 			.prepare(
-				`SELECT COUNT(*) AS cnt FROM memory_items
-				 WHERE active = 1
-				   AND (files_read IS NOT NULL OR files_modified IS NOT NULL OR concepts IS NOT NULL)`,
+				`SELECT COUNT(*) AS cnt FROM memory_items mi
+				 WHERE ${REF_BACKFILL_PENDING_WHERE}`,
 			)
 			.get() as { cnt: number };
 		const initialTotal = countRow.cnt;

--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -462,6 +462,28 @@ describe("vector migration", () => {
 		expect(completedAfterDisable).toMatchObject({ status: "completed" });
 	});
 
+	it("returns early for completed current-model jobs without rescanning vectors", async () => {
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "One", "Body one");
+
+		await runVectorMigrationPass(db, { batchSize: 10 });
+		const completedJob = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(completedJob).toMatchObject({ status: "completed" });
+
+		const prepareSpy = vi.spyOn(db, "prepare");
+		prepareSpy.mockImplementation((sql: string) => {
+			if (sql.includes("SELECT model, COUNT(*) AS rows FROM memory_vectors")) {
+				throw new Error("unexpected vector model scan");
+			}
+			return Database.prototype.prepare.call(db, sql);
+		});
+
+		await expect(runVectorMigrationPass(db, { batchSize: 10 })).resolves.toBeUndefined();
+		expect(getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB)).toMatchObject({
+			status: "completed",
+		});
+	});
+
 	it("removes stale old-model rows when queued work has zero embeddable memories", async () => {
 		const sessionId = insertTestSession(db);
 		seedMemory(db, 1, sessionId, "", "");

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -325,6 +325,17 @@ export async function runVectorMigrationPass(
 	}
 	const targetModel = client.model;
 	const effectiveBatchSize = Math.max(1, options.batchSize ?? 50);
+	const existingMetadata = (existingJob?.metadata ?? {}) as MigrationMetadata;
+	const queuedSyncWorkCount =
+		metadataMemoryIds(existingMetadata.pending_upsert_memory_ids).length +
+		metadataMemoryIds(existingMetadata.pending_delete_memory_ids).length;
+	if (
+		existingJob?.status === "completed" &&
+		existingMetadata.target_model === targetModel &&
+		queuedSyncWorkCount === 0
+	) {
+		return;
+	}
 	if (existingJob) {
 		const queuedSyncWork = await runQueuedSyncVectorWork(
 			db,

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -176,6 +176,17 @@ export interface SemanticIndexDiagnosticsOptions {
 	fastCounts?: boolean;
 }
 
+function traceSemanticDiag<T>(label: string, fn: () => T): T {
+	if (process.env.CODEMEM_TRACE_SEMANTIC_DIAGNOSTICS !== "1") return fn();
+	const startedAt = Date.now();
+	console.warn(`[codemem semantic] ${label} start`);
+	try {
+		return fn();
+	} finally {
+		console.warn(`[codemem semantic] ${label} ${Date.now() - startedAt}ms`);
+	}
+}
+
 function countEmbeddableActiveMemories(db: Database): number {
 	const row = db
 		.prepare(
@@ -260,15 +271,25 @@ export function getSemanticIndexDiagnostics(
 	db: Database,
 	options: SemanticIndexDiagnosticsOptions = {},
 ): SemanticIndexDiagnostics {
-	const currentModel = resolveEmbeddingModel();
-	const semanticSearchModel = resolveSemanticSearchModel(db, currentModel);
-	const embeddingsDisabled = isEmbeddingDisabled();
-	const embeddableMemoryCount = countEmbeddableActiveMemories(db);
-	const indexedMemoryCount = options.fastCounts
-		? countIndexedActiveMemoriesFast(db, currentModel)
-		: countIndexedActiveMemories(db, currentModel);
+	const currentModel = traceSemanticDiag("resolveEmbeddingModel", () => resolveEmbeddingModel());
+	const semanticSearchModel = traceSemanticDiag("resolveSemanticSearchModel", () =>
+		resolveSemanticSearchModel(db, currentModel),
+	);
+	const embeddingsDisabled = traceSemanticDiag("isEmbeddingDisabled", () => isEmbeddingDisabled());
+	const embeddableMemoryCount = traceSemanticDiag("countEmbeddableActiveMemories", () =>
+		countEmbeddableActiveMemories(db),
+	);
+	const indexedMemoryCount = traceSemanticDiag(
+		options.fastCounts ? "countIndexedActiveMemoriesFast" : "countIndexedActiveMemories",
+		() =>
+			options.fastCounts
+				? countIndexedActiveMemoriesFast(db, currentModel)
+				: countIndexedActiveMemories(db, currentModel),
+	);
 	const fallbackPendingCount = Math.max(embeddableMemoryCount - indexedMemoryCount, 0);
-	const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+	const job = traceSemanticDiag("getMaintenanceJob", () =>
+		getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB),
+	);
 	const pendingMemoryCount = resolvePendingMemoryCount(fallbackPendingCount, job);
 	const degraded = embeddableMemoryCount > 0 && (embeddingsDisabled || semanticSearchModel == null);
 	const activeCatchUp = job?.status === "pending" || job?.status === "running";

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -172,6 +172,10 @@ export interface SemanticIndexDiagnostics {
 	} | null;
 }
 
+export interface SemanticIndexDiagnosticsOptions {
+	fastCounts?: boolean;
+}
+
 function countEmbeddableActiveMemories(db: Database): number {
 	const row = db
 		.prepare(
@@ -196,6 +200,21 @@ function countIndexedActiveMemories(db: Database, model: string): number {
 		)
 		.all() as MemoryTextRow[];
 	return rows.filter((row) => memoryHasCompleteVectorCoverage(db, row, model)).length;
+}
+
+function countIndexedActiveMemoriesFast(db: Database, model: string): number {
+	if (!tableExists(db, "memory_vectors")) return 0;
+	const row = db
+		.prepare(
+			`SELECT COUNT(DISTINCT mi.id) AS c
+			 FROM memory_items mi
+			 JOIN memory_vectors mv ON mv.memory_id = mi.id
+			 WHERE mi.active = 1
+			   AND mv.model = ?
+			   AND TRIM(COALESCE(mi.title, '') || COALESCE(mi.body_text, '')) != ''`,
+		)
+		.get(model) as { c?: number } | undefined;
+	return Number(row?.c ?? 0);
 }
 
 function resolvePendingMemoryCount(
@@ -237,12 +256,17 @@ function summarizeSemanticIndexState(
 	return `Semantic index is current for ${counts.indexed} embeddable mem${counts.indexed === 1 ? "ory" : "ories"}`;
 }
 
-export function getSemanticIndexDiagnostics(db: Database): SemanticIndexDiagnostics {
+export function getSemanticIndexDiagnostics(
+	db: Database,
+	options: SemanticIndexDiagnosticsOptions = {},
+): SemanticIndexDiagnostics {
 	const currentModel = resolveEmbeddingModel();
 	const semanticSearchModel = resolveSemanticSearchModel(db, currentModel);
 	const embeddingsDisabled = isEmbeddingDisabled();
 	const embeddableMemoryCount = countEmbeddableActiveMemories(db);
-	const indexedMemoryCount = countIndexedActiveMemories(db, currentModel);
+	const indexedMemoryCount = options.fastCounts
+		? countIndexedActiveMemoriesFast(db, currentModel)
+		: countIndexedActiveMemories(db, currentModel);
 	const fallbackPendingCount = Math.max(embeddableMemoryCount - indexedMemoryCount, 0);
 	const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
 	const pendingMemoryCount = resolvePendingMemoryCount(fallbackPendingCount, job);

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -703,6 +703,8 @@ export const OpencodeMemPlugin = async ({
   );
   const viewerHost = process.env.CODEMEM_VIEWER_HOST || "127.0.0.1";
   const viewerPort = process.env.CODEMEM_VIEWER_PORT || "38888";
+  const viewerDbPath = process.env.CODEMEM_DB || "";
+  const viewerConfigPath = process.env.CODEMEM_CONFIG || "";
   const commandTimeout = Number.parseInt(
     process.env.CODEMEM_PLUGIN_CMD_TIMEOUT || "20000",
     10
@@ -796,6 +798,17 @@ export const OpencodeMemPlugin = async ({
     }
     lastToastAtBySession.set(sessionID, now);
     return true;
+  };
+
+  const buildViewerCliArgs = (action) => {
+    const args = ["serve", action, "--host", viewerHost, "--port", viewerPort];
+    if (String(viewerDbPath || "").trim()) {
+      args.push("--db-path", viewerDbPath);
+    }
+    if (String(viewerConfigPath || "").trim()) {
+      args.push("--config", viewerConfigPath);
+    }
+    return args;
   };
 
   const emitRawEvent = async ({ sessionID, type, payload }) => {
@@ -1212,7 +1225,8 @@ export const OpencodeMemPlugin = async ({
       return;
     }
     viewerStarted = true;
-    const cmd = [runner, ...runnerArgs, "serve", "start"];
+    const viewerArgs = buildViewerCliArgs("start");
+    const cmd = [runner, ...runnerArgs, ...viewerArgs];
     logLine(`auto-starting viewer: ${cmd.join(" ")}`).catch(() => {});
     try {
       const child = nodeSpawn(cmd[0], cmd.slice(1), {
@@ -1304,7 +1318,7 @@ export const OpencodeMemPlugin = async ({
     if (!viewerEnabled || !viewerAutoStart || !viewerStarted) {
       return { attempted: false, ok: false };
     }
-    const restartResult = await runCli(["serve", "restart"]);
+    const restartResult = await runCli(buildViewerCliArgs("restart"));
     if (restartResult?.exitCode === 0) {
       await logLine("compat.auto_update_viewer_restart ok");
       return { attempted: true, ok: true };
@@ -1550,7 +1564,7 @@ export const OpencodeMemPlugin = async ({
     viewerStarted = false;
     stopHealthCheck();
     await logLine("viewer stop requested");
-    await runCli(["serve", "stop"]);
+    await runCli(buildViewerCliArgs("stop"));
   };
 
   const checkViewerHealth = async () => {
@@ -1581,7 +1595,7 @@ export const OpencodeMemPlugin = async ({
       healthLastRestartAttempt = Date.now();
       await logLine(`viewer.health restarting viewer after ${healthConsecutiveFailures} consecutive failures`);
       try {
-        const result = await runCli(["serve", "restart"]);
+        const result = await runCli(buildViewerCliArgs("restart"));
         const ok = result?.exitCode === 0;
         await logLine(`viewer.health restart ${ok ? "succeeded" : "failed"} (exit=${result?.exitCode ?? "unknown"})`);
         if (ok) {

--- a/packages/ui/src/tabs/sync/index.test.ts
+++ b/packages/ui/src/tabs/sync/index.test.ts
@@ -98,6 +98,12 @@ describe("loadSyncData", () => {
 		});
 		await secondLoad;
 		expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(["peer-new"]);
+		expect(api.loadSyncStatus).toHaveBeenNthCalledWith(1, false, "", {
+			includeJoinRequests: true,
+		});
+		expect(api.loadSyncStatus).toHaveBeenNthCalledWith(2, false, "", {
+			includeJoinRequests: true,
+		});
 
 		first.resolve({
 			peers: [{ peer_device_id: "peer-old" }],
@@ -128,5 +134,8 @@ describe("loadSyncData", () => {
 		await loadSyncData();
 
 		expect(api.loadSyncStatus).toHaveBeenCalledTimes(1);
+		expect(api.loadSyncStatus).toHaveBeenCalledWith(false, "", {
+			includeJoinRequests: false,
+		});
 	});
 });

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -117,11 +117,11 @@ export async function loadSyncData() {
 		if (useCache) {
 			payload = readCachedSyncStatus(project);
 			if (!payload) {
-				payload = await api.loadSyncStatus(true, project, { includeJoinRequests: false });
+				payload = await api.loadSyncStatus(false, project, { includeJoinRequests: false });
 				fetchedFreshSyncStatus = true;
 			}
 		} else {
-			payload = await api.loadSyncStatus(true, project, { includeJoinRequests });
+			payload = await api.loadSyncStatus(false, project, { includeJoinRequests });
 			fetchedFreshSyncStatus = true;
 		}
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2771,7 +2771,7 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("uses cheap semantic diagnostics for sync status requests", async () => {
+		it("uses cheap semantic diagnostics for non-diagnostic sync status requests", async () => {
 			const diagnosticsSpy = vi.spyOn(core, "getSemanticIndexDiagnostics");
 			const { app, cleanup } = createTestApp();
 			try {
@@ -2780,6 +2780,22 @@ describe("viewer-server", () => {
 				expect(diagnosticsSpy).toHaveBeenCalled();
 				expect(diagnosticsSpy).toHaveBeenCalledWith(expect.anything(), {
 					fastCounts: true,
+				});
+			} finally {
+				diagnosticsSpy.mockRestore();
+				cleanup();
+			}
+		});
+
+		it("uses full semantic diagnostics when sync diagnostics are explicitly requested", async () => {
+			const diagnosticsSpy = vi.spyOn(core, "getSemanticIndexDiagnostics");
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/status?includeDiagnostics=1");
+				expect(res.status).toBe(200);
+				expect(diagnosticsSpy).toHaveBeenCalled();
+				expect(diagnosticsSpy).toHaveBeenCalledWith(expect.anything(), {
+					fastCounts: false,
 				});
 			} finally {
 				diagnosticsSpy.mockRestore();

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -8,6 +8,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import * as core from "@codemem/core";
 import {
 	buildAuthHeaders,
 	connect,
@@ -2766,6 +2767,22 @@ describe("viewer-server", () => {
 					pending_memory_count: 3,
 				});
 			} finally {
+				cleanup();
+			}
+		});
+
+		it("uses cheap semantic diagnostics for sync status requests", async () => {
+			const diagnosticsSpy = vi.spyOn(core, "getSemanticIndexDiagnostics");
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/status");
+				expect(res.status).toBe(200);
+				expect(diagnosticsSpy).toHaveBeenCalled();
+				expect(diagnosticsSpy).toHaveBeenCalledWith(expect.anything(), {
+					fastCounts: true,
+				});
+			} finally {
+				diagnosticsSpy.mockRestore();
 				cleanup();
 			}
 		});

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1255,7 +1255,7 @@ export function syncRoutes(
 				.from(schema.syncPeers)
 				.get();
 			const semanticIndex = redactSemanticIndexDiagnostics(
-				getSemanticIndexDiagnostics(store.db, { fastCounts: true }),
+				getSemanticIndexDiagnostics(store.db, { fastCounts: !showDiag }),
 				showDiag,
 			);
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1204,30 +1204,42 @@ export function syncRoutes(
 	app.get("/api/sync/status", async (c) => {
 		const store = getStore();
 		{
+			const traceSync = <T>(label: string, fn: () => T): T => {
+				if (process.env.CODEMEM_TRACE_SYNC_STATUS !== "1") return fn();
+				const startedAt = Date.now();
+				console.warn(`[codemem sync-status] ${label} start`);
+				try {
+					return fn();
+				} finally {
+					console.warn(`[codemem sync-status] ${label} ${Date.now() - startedAt}ms`);
+				}
+			};
 			const showDiag = queryBool(c.req.query("includeDiagnostics"));
 			const includeJoinRequests = queryBool(c.req.query("includeJoinRequests"));
 			const project = c.req.query("project") || null;
-			const config = readCoordinatorSyncConfig();
-			const syncReset = getSyncResetState(store.db);
+			const config = traceSync("readCoordinatorSyncConfig", () => readCoordinatorSyncConfig());
+			const syncReset = traceSync("getSyncResetState", () => getSyncResetState(store.db));
 
 			const d = drizzle(store.db, { schema });
 
-			const deviceRow = d
-				.select({
-					device_id: schema.syncDevice.device_id,
-					fingerprint: schema.syncDevice.fingerprint,
-				})
-				.from(schema.syncDevice)
-				.limit(1)
-				.get();
+			const deviceRow = traceSync("deviceRow", () =>
+				d
+					.select({
+						device_id: schema.syncDevice.device_id,
+						fingerprint: schema.syncDevice.fingerprint,
+					})
+					.from(schema.syncDevice)
+					.limit(1)
+					.get(),
+			);
 
-			const daemonState = d
-				.select()
-				.from(schema.syncDaemonState)
-				.where(eq(schema.syncDaemonState.id, 1))
-				.get();
+			const daemonState = traceSync("daemonState", () =>
+				d.select().from(schema.syncDaemonState).where(eq(schema.syncDaemonState.id, 1)).get(),
+			);
 
-			const peerCountRow = d.select({ total: count() }).from(schema.syncPeers).get();
+			const peerCountRow = traceSync("peerCountRow", () =>
+				d.select({ total: count() }).from(schema.syncPeers).get(),
+			);
 			let retentionState:
 				| {
 						last_run_at?: string | null;
@@ -1241,28 +1253,34 @@ export function syncRoutes(
 				  }
 				| undefined;
 			try {
-				retentionState = d
-					.select()
-					.from(schema.syncRetentionState)
-					.where(eq(schema.syncRetentionState.id, 1))
-					.get();
+				retentionState = traceSync("retentionState", () =>
+					d
+						.select()
+						.from(schema.syncRetentionState)
+						.where(eq(schema.syncRetentionState.id, 1))
+						.get(),
+				);
 			} catch {
 				retentionState = undefined;
 			}
 
-			const lastSyncRow = d
-				.select({ last_sync_at: max(schema.syncPeers.last_sync_at) })
-				.from(schema.syncPeers)
-				.get();
-			const semanticIndex = redactSemanticIndexDiagnostics(
-				getSemanticIndexDiagnostics(store.db, { fastCounts: !showDiag }),
-				showDiag,
+			const lastSyncRow = traceSync("lastSyncRow", () =>
+				d
+					.select({ last_sync_at: max(schema.syncPeers.last_sync_at) })
+					.from(schema.syncPeers)
+					.get(),
+			);
+			const semanticIndex = traceSync("semanticIndex", () =>
+				redactSemanticIndexDiagnostics(
+					getSemanticIndexDiagnostics(store.db, { fastCounts: !showDiag }),
+					showDiag,
+				),
 			);
 
 			const lastError = daemonState?.last_error as string | null;
 			const lastErrorAt = daemonState?.last_error_at as string | null;
 			const lastOkAt = daemonState?.last_ok_at as string | null;
-			const viewerBinding = readViewerBinding(store.dbPath);
+			const viewerBinding = traceSync("readViewerBinding", () => readViewerBinding(store.dbPath));
 			const daemonRunning = viewerBinding
 				? await portOpen(viewerBinding.host, viewerBinding.port)
 				: false;
@@ -1345,7 +1363,10 @@ export function syncRoutes(
 			}
 
 			// Build peers list using deduplicated mapPeerRow
-			const peerRows = store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[];
+			const peerRows = traceSync(
+				"peerRows",
+				() => store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[],
+			);
 			const peersItems = peerRows.map((row) => {
 				const peer = mapPeerRow(store, row, showDiag);
 				peer.status = peerStatus(peer);
@@ -1358,24 +1379,31 @@ export function syncRoutes(
 			}
 
 			// Attempts
-			const attemptRows = d
-				.select({
-					peer_device_id: schema.syncAttempts.peer_device_id,
-					ok: schema.syncAttempts.ok,
-					error: schema.syncAttempts.error,
-					started_at: schema.syncAttempts.started_at,
-					finished_at: schema.syncAttempts.finished_at,
-					ops_in: schema.syncAttempts.ops_in,
-					ops_out: schema.syncAttempts.ops_out,
-				})
-				.from(schema.syncAttempts)
-				.orderBy(desc(schema.syncAttempts.finished_at))
-				.limit(25)
-				.all();
+			const attemptRows = traceSync("attemptRows", () =>
+				d
+					.select({
+						peer_device_id: schema.syncAttempts.peer_device_id,
+						ok: schema.syncAttempts.ok,
+						error: schema.syncAttempts.error,
+						started_at: schema.syncAttempts.started_at,
+						finished_at: schema.syncAttempts.finished_at,
+						ops_in: schema.syncAttempts.ops_in,
+						ops_out: schema.syncAttempts.ops_out,
+					})
+					.from(schema.syncAttempts)
+					.orderBy(desc(schema.syncAttempts.finished_at))
+					.limit(25)
+					.all(),
+			);
 			const peerAddressMap = new Map<string, string[]>();
-			const peerAddressRows = store.db
-				.prepare("SELECT peer_device_id, addresses_json FROM sync_peers")
-				.all() as Array<{ peer_device_id: string | null; addresses_json: string | null }>;
+			const peerAddressRows = traceSync(
+				"peerAddressRows",
+				() =>
+					store.db.prepare("SELECT peer_device_id, addresses_json FROM sync_peers").all() as Array<{
+						peer_device_id: string | null;
+						addresses_json: string | null;
+					}>,
+			);
 			peerAddressRows.forEach((peerRow) => {
 				const addrs = safeJsonList(peerRow.addresses_json as string | null);
 				if (addrs.length) peerAddressMap.set(String(peerRow.peer_device_id ?? ""), addrs);
@@ -1398,11 +1426,11 @@ export function syncRoutes(
 				sync: {},
 				ping: {},
 			};
-			const legacyDevices = store.claimableLegacyDeviceIds();
-			const sharingReview = store.sharingReviewSummary(project);
-			const coordinator = redactCoordinatorStatus(
-				await coordinatorStatusSnapshot(store, config),
-				showDiag,
+			const legacyDevices = traceSync("legacyDevices", () => store.claimableLegacyDeviceIds());
+			const sharingReview = traceSync("sharingReview", () => store.sharingReviewSummary(project));
+			const coordinatorSnapshot = await coordinatorStatusSnapshot(store, config);
+			const coordinator = traceSync("coordinator", () =>
+				redactCoordinatorStatus(coordinatorSnapshot, showDiag),
 			);
 			let joinRequests: Record<string, unknown>[] = [];
 			if (includeJoinRequests && showDiag && config.syncCoordinatorAdminSecret) {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1255,7 +1255,7 @@ export function syncRoutes(
 				.from(schema.syncPeers)
 				.get();
 			const semanticIndex = redactSemanticIndexDiagnostics(
-				getSemanticIndexDiagnostics(store.db),
+				getSemanticIndexDiagnostics(store.db, { fastCounts: true }),
 				showDiag,
 			);
 


### PR DESCRIPTION
## Description

This follow-up fix hardens viewer lifecycle targeting on top of the maintenance hotfix branch.

It does two things:
- makes the OpenCode plugin pass an explicit viewer target when it auto-starts, stops, health-checks, or restarts a viewer (`--host`, `--port`, plus DB/config context when available)
- makes `serve` refuse cross-target viewer management for the same DB/runtime path instead of stomping another viewer's runtime state

During debugging, this branch also fixed the remaining shipped regression in `/api/sync/status`: the route was doing a full semantic-index coverage audit on the request path, including per-memory vec lookups across the whole database. It now uses a cheap semantic-diagnostics mode for sync status so the viewer stays responsive on real upgraded databases.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this PR:
- `pnpm run tsc`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/core/src/vectors.test.ts packages/cli/src/commands/serve.test.ts`
- `node --check packages/opencode-plugin/.opencode/plugins/codemem.js`

Manual verification on the affected local DB:
- `GET /api/sync/status` returns `200`
- `GET /api/sync/status?includeDiagnostics=1` returns `200`
- `GET /api/stats` returns `200`
- viewer root `/` returns `200`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced