### PR TITLE
refactor(sync): share visibility predicates across core and server

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -465,6 +465,8 @@ export {
 	recordReplicationOp,
 	setReplicationCursor,
 	setSyncResetState,
+	syncProjectAllowedByFilters,
+	syncVisibilityAllowed,
 } from "./sync-replication.js";
 export { SyncRetentionRunner } from "./sync-retention-runner.js";
 export { deriveTags, fileTags, normalizeTag } from "./tags.js";

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -14,6 +14,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import { fromJson, fromJsonStrict, toJson, toJsonNullable } from "./db.js";
 import { readCodememConfigFile } from "./observer-config.js";
+import { projectBasename } from "./project.js";
 import { clearMemoryRefs, populateMemoryRefs } from "./ref-populate.js";
 import * as schema from "./schema.js";
 import { deriveTags } from "./tags.js";
@@ -1228,15 +1229,6 @@ function parseJsonList(valuesJson: string | null | undefined): string[] {
 	}
 }
 
-function projectBasename(value: string | null | undefined): string {
-	const raw = String(value ?? "")
-		.trim()
-		.replaceAll("\\", "/");
-	if (!raw) return "";
-	const parts = raw.split("/").filter(Boolean);
-	return parts.length > 0 ? (parts[parts.length - 1] ?? "") : "";
-}
-
 function effectiveSyncProjectFilters(
 	db: Database,
 	peerDeviceId: string | null,
@@ -1283,15 +1275,26 @@ function syncProjectAllowed(
 	peerDeviceId: string | null,
 ): boolean {
 	const { include, exclude } = effectiveSyncProjectFilters(db, peerDeviceId);
-	const projectName = String(project ?? "").trim();
-	const basename = projectBasename(projectName);
-
-	if (exclude.some((item) => item === projectName || item === basename)) return false;
-	if (include.length === 0) return true;
-	return include.some((item) => item === projectName || item === basename);
+	return syncProjectAllowedByFilters(project, { include, exclude });
 }
 
-function syncVisibilityAllowed(payload: Record<string, unknown> | null): boolean {
+export function syncProjectAllowedByFilters(
+	projectValue: string | null,
+	filters: { include: string[]; exclude: string[] },
+): boolean {
+	const value = String(projectValue ?? "").trim();
+	const valueBase = projectBasename(value);
+	for (const blocked of filters.exclude) {
+		if (blocked === value || blocked === valueBase) return false;
+	}
+	if (filters.include.length === 0) return true;
+	for (const allowed of filters.include) {
+		if (allowed === value || allowed === valueBase) return true;
+	}
+	return false;
+}
+
+export function syncVisibilityAllowed(payload: Record<string, unknown> | null): boolean {
 	if (!payload) return false;
 	let visibility = String(payload.visibility ?? "")
 		.trim()

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -41,6 +41,8 @@ import {
 	requestJson,
 	runSyncPass,
 	schema,
+	syncProjectAllowedByFilters,
+	syncVisibilityAllowed,
 	verifySignature,
 } from "@codemem/core";
 import { and, count, desc, eq, max, ne } from "drizzle-orm";
@@ -342,15 +344,6 @@ async function authorizeBootstrapGrantRequest(
 	const cutoff = new Date(Date.now() - DEFAULT_TIME_WINDOW_S * 2 * 1000).toISOString();
 	cleanupNonces(store.db, cutoff);
 	return { ok: true, reason: "ok", deviceId };
-}
-
-function projectBasename(value: string | null | undefined): string {
-	const project = String(value ?? "")
-		.trim()
-		.replaceAll("\\", "/");
-	if (!project) return "";
-	const parts = project.split("/").filter(Boolean);
-	return parts.length > 0 ? (parts[parts.length - 1] ?? "") : "";
 }
 
 function parseJsonList(value: unknown): string[] {
@@ -686,61 +679,6 @@ async function acceptDiscoveredPeer(
 	return result;
 }
 
-function isSharedVisibility(payload: Record<string, unknown> | null): boolean {
-	if (!payload) return false;
-	let visibility = String(payload.visibility ?? "")
-		.trim()
-		.toLowerCase();
-	const metadata =
-		payload.metadata_json &&
-		typeof payload.metadata_json === "object" &&
-		!Array.isArray(payload.metadata_json)
-			? (payload.metadata_json as Record<string, unknown>)
-			: {};
-	const metadataVisibility = String(metadata.visibility ?? "")
-		.trim()
-		.toLowerCase();
-	if (!visibility && metadataVisibility) visibility = metadataVisibility;
-	if (!visibility) {
-		let workspaceKind = String(payload.workspace_kind ?? "")
-			.trim()
-			.toLowerCase();
-		let workspaceId = String(payload.workspace_id ?? "")
-			.trim()
-			.toLowerCase();
-		if (!workspaceKind)
-			workspaceKind = String(metadata.workspace_kind ?? "")
-				.trim()
-				.toLowerCase();
-		if (!workspaceId)
-			workspaceId = String(metadata.workspace_id ?? "")
-				.trim()
-				.toLowerCase();
-		if (workspaceKind === "shared" || workspaceId.startsWith("shared:")) {
-			visibility = "shared";
-		} else {
-			return true;
-		}
-	}
-	return visibility === "shared";
-}
-
-function projectAllowed(
-	projectValue: string | null,
-	filters: { include: string[]; exclude: string[] },
-): boolean {
-	const value = String(projectValue ?? "").trim();
-	const valueBase = projectBasename(value);
-	for (const blocked of filters.exclude) {
-		if (blocked === value || blocked === valueBase) return false;
-	}
-	if (filters.include.length === 0) return true;
-	for (const allowed of filters.include) {
-		if (allowed === value || allowed === valueBase) return true;
-	}
-	return false;
-}
-
 function filterOpsForPeer(
 	store: MemoryStore,
 	peerDeviceId: string,
@@ -756,12 +694,12 @@ function filterOpsForPeer(
 			continue;
 		}
 		const payload = parseOpPayload(op);
-		if (!allowPrivate && !isSharedVisibility(payload)) {
+		if (!allowPrivate && !syncVisibilityAllowed(payload)) {
 			skipped++;
 			continue;
 		}
 		const project = payload && typeof payload.project === "string" ? payload.project : null;
-		if (!projectAllowed(project, filters)) {
+		if (!syncProjectAllowedByFilters(project, filters)) {
 			skipped++;
 			continue;
 		}


### PR DESCRIPTION
## Description
<!-- Briefly describe what this PR changes and why -->

Extracts the shared sync visibility and project-filter predicates into `@codemem/core` and reuses them in the viewer-server sync route so core/server filtering cannot drift apart.

## Type of Change
<!-- Mark the relevant option(s) with an \"x\" -->

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
<!-- Describe how you tested these changes -->

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
<!-- Mark completed items with an \"x\" -->

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced