### PR TITLE
test(cli): add manual injection contract coverage

### DIFF
--- a/packages/cli/src/commands/memory-inject.test.ts
+++ b/packages/cli/src/commands/memory-inject.test.ts
@@ -1,0 +1,114 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const buildMemoryPackAsync = vi.fn();
+const closeStore = vi.fn();
+const storePaths: Array<string | undefined> = [];
+
+vi.mock("@codemem/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@codemem/core")>();
+	return {
+		...actual,
+		MemoryStore: class {
+			constructor(dbPath?: string) {
+				storePaths.push(dbPath);
+			}
+			buildMemoryPackAsync = buildMemoryPackAsync;
+			close = closeStore;
+		},
+		resolveDbPath: (value?: string) => value,
+		resolveProject: (_cwd: string, override?: string | null) =>
+			override?.trim() || "default-project",
+	};
+});
+
+import { memoryCommand } from "./memory.js";
+
+afterEach(() => {
+	buildMemoryPackAsync.mockReset();
+	closeStore.mockReset();
+	storePaths.length = 0;
+	process.exitCode = 0;
+	vi.restoreAllMocks();
+});
+
+async function parseInjectCommand(args: string[]): Promise<void> {
+	const root = new Command("codemem");
+	root.enablePositionalOptions();
+	root.addCommand(memoryCommand);
+	await root.parseAsync(["memory", "inject", ...args], { from: "user" });
+}
+
+describe("memory inject command", () => {
+	it("prints raw pack text and forwards project and working-set flags", async () => {
+		buildMemoryPackAsync.mockResolvedValue({ pack_text: "RAW PACK BODY" });
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parseInjectCommand([
+			"continue viewer health work",
+			"--project",
+			"codemem",
+			"--working-set-file",
+			"packages/ui/src/app.ts",
+			"--token-budget",
+			"90",
+			"--db-path",
+			"/tmp/codemem-test.sqlite",
+		]);
+
+		expect(buildMemoryPackAsync).toHaveBeenCalledWith("continue viewer health work", 10, 90, {
+			project: "codemem",
+			working_set_paths: ["packages/ui/src/app.ts"],
+		});
+		expect(logSpy).toHaveBeenLastCalledWith("RAW PACK BODY");
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Warning: 'codemem memory inject' is deprecated, use 'codemem pack' instead.",
+		);
+		expect(storePaths.at(-1)).toBe("/tmp/codemem-test.sqlite");
+		expect(closeStore).toHaveBeenCalledTimes(1);
+	});
+
+	it("omits project filters for all-projects inject requests", async () => {
+		buildMemoryPackAsync.mockResolvedValue({ pack_text: "" });
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parseInjectCommand([
+			"continue viewer health work",
+			"--all-projects",
+			"--working-set-file",
+			"packages/ui/src/app.ts",
+		]);
+
+		expect(buildMemoryPackAsync).toHaveBeenCalledWith(
+			"continue viewer health work",
+			10,
+			undefined,
+			{ working_set_paths: ["packages/ui/src/app.ts"] },
+		);
+		expect(logSpy).toHaveBeenLastCalledWith("");
+	});
+
+	it("prints an empty string when inject returns no pack text", async () => {
+		buildMemoryPackAsync.mockResolvedValue({ pack_text: "" });
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parseInjectCommand(["continue viewer health work"]);
+
+		expect(logSpy).toHaveBeenLastCalledWith("");
+	});
+
+	it("closes the store when inject pack generation fails", async () => {
+		buildMemoryPackAsync.mockRejectedValue(new Error("inject failed"));
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parseInjectCommand(["continue viewer health work"]).catch(() => {});
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Warning: 'codemem memory inject' is deprecated, use 'codemem pack' instead.",
+		);
+		expect(closeStore).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/cli/src/commands/pack.test.ts
+++ b/packages/cli/src/commands/pack.test.ts
@@ -164,6 +164,108 @@ describe("pack command", () => {
 		expect(rendered).toContain("## Summary");
 	});
 
+	it("supports the main pack commander path with json output", async () => {
+		buildMemoryPackAsync.mockResolvedValue({
+			items: [{ id: 101, kind: "decision", title: "Keep Search", subtitle: null }],
+			metrics: {
+				total_items: 1,
+				pack_tokens: 42,
+				fallback_used: false,
+				sources: { fts: 1, semantic: 0, fuzzy: 0 },
+			},
+			pack_text: "## Summary\n[101] (decision) Keep Search",
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parsePackCommand([
+			"continue viewer health work",
+			"--json",
+			"--project",
+			"codemem",
+			"--working-set-file",
+			"packages/ui/src/app.ts",
+			"--token-budget",
+			"120",
+			"--compact",
+			"--compact-detail",
+			"2",
+		]);
+
+		expect(buildMemoryPackAsync).toHaveBeenCalledWith(
+			"continue viewer health work",
+			10,
+			120,
+			{ project: "codemem", working_set_paths: ["packages/ui/src/app.ts"] },
+			{ compact: true, compactDetailCount: 2 },
+		);
+		const output = logSpy.mock.calls.at(-1)?.[0];
+		expect(JSON.parse(String(output))).toMatchObject({
+			pack_text: "## Summary\n[101] (decision) Keep Search",
+			metrics: { total_items: 1 },
+		});
+	});
+
+	it("omits project filters for all-projects pack requests", async () => {
+		buildMemoryPackAsync.mockResolvedValue({
+			items: [],
+			metrics: {
+				total_items: 0,
+				pack_tokens: 0,
+				fallback_used: false,
+				sources: { fts: 0, semantic: 0, fuzzy: 0 },
+			},
+			pack_text: "",
+		});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parsePackCommand([
+			"continue viewer health work",
+			"--json",
+			"--all-projects",
+			"--working-set-file",
+			"packages/ui/src/app.ts",
+		]);
+
+		expect(buildMemoryPackAsync).toHaveBeenCalledWith(
+			"continue viewer health work",
+			10,
+			undefined,
+			{ working_set_paths: ["packages/ui/src/app.ts"] },
+			undefined,
+		);
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toMatchObject({ items: [] });
+	});
+
+	it("emits structured json errors for pack failures", async () => {
+		buildMemoryPackAsync.mockRejectedValue(new Error("pack blew up"));
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parsePackCommand(["continue viewer health work", "--json"]);
+
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toEqual({
+			error: "pack_failed",
+			message: "pack blew up",
+		});
+		expect(process.exitCode).toBe(1);
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+
+	it("emits structured usage errors for invalid main pack numeric input", async () => {
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await parsePackCommand(["continue viewer health work", "--json", "--limit", "nope"]);
+
+		expect(JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]))).toEqual({
+			error: "usage_error",
+			message: "limit must be a positive integer",
+		});
+		expect(process.exitCode).toBe(2);
+		expect(errorSpy).not.toHaveBeenCalled();
+		expect(buildMemoryPackAsync).not.toHaveBeenCalled();
+	});
+
 	it("supports the commander command path with json output", async () => {
 		buildMemoryPackTraceAsync.mockResolvedValue({
 			version: 1,


### PR DESCRIPTION
## Description
<!-- Briefly describe what this PR changes and why -->

Adds deterministic CLI/manual contract coverage for `codemem pack` and `codemem memory inject`, covering JSON/raw output shape, project and working-set flag plumbing, all-projects behavior, and failure/usage-error handling.

## Type of Change
<!-- Mark the relevant option(s) with an "x" -->

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
<!-- Describe how you tested these changes -->

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist
<!-- Mark completed items with an "x" -->

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced