### PR TITLE
feat(viewer): add coordinator admin proxy routes

### DIFF
--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -222,9 +222,26 @@ export async function coordinatorListDevicesAction(opts: {
 	groupId: string;
 	includeDisabled?: boolean;
 	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
 }): Promise<CoordinatorEnrollment[]> {
 	const groupId = String(opts.groupId ?? "").trim();
 	if (!groupId) throw new Error("Group id required.");
+	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		const payload = await remoteRequest(
+			"GET",
+			`${remote.replace(/\/+$/, "")}/v1/admin/devices?group_id=${encodeURIComponent(groupId)}&include_disabled=${opts.includeDisabled ? "1" : "0"}`,
+			adminSecret,
+		);
+		return Array.isArray(payload?.items)
+			? payload.items.filter(
+					(row): row is CoordinatorEnrollment => Boolean(row) && typeof row === "object",
+				)
+			: [];
+	}
 	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
 		return await store.listEnrolledDevices(groupId, opts.includeDisabled === true);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -4681,6 +4681,168 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("reports coordinator admin readiness states", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(configPath, JSON.stringify({}));
+				const { app, cleanup } = createTestApp();
+				try {
+					const missing = await app.request("/api/coordinator/admin/status");
+					expect(missing.status).toBe(200);
+					expect(await missing.json()).toMatchObject({
+						readiness: "not_configured",
+						coordinator_url: null,
+						has_admin_secret: false,
+						has_groups: false,
+					});
+				} finally {
+					cleanup();
+				}
+
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+					}),
+				);
+				const { app: partialApp, cleanup: cleanupPartial } = createTestApp();
+				try {
+					const partial = await partialApp.request("/api/coordinator/admin/status");
+					expect(partial.status).toBe(200);
+					expect(await partial.json()).toMatchObject({
+						readiness: "partial",
+						coordinator_url: "https://coord.example.test",
+						active_group: "team-a",
+						has_admin_secret: false,
+						has_groups: true,
+					});
+				} finally {
+					cleanupPartial();
+				}
+
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				const { app: readyApp, cleanup: cleanupReady } = createTestApp();
+				try {
+					const ready = await readyApp.request("/api/coordinator/admin/status");
+					expect(ready.status).toBe(200);
+					expect(await ready.json()).toMatchObject({
+						readiness: "ready",
+						coordinator_url: "https://coord.example.test",
+						active_group: "team-a",
+						has_admin_secret: true,
+						has_groups: true,
+					});
+				} finally {
+					cleanupReady();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
+		it("lists coordinator join requests through the admin route", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/join-requests?group_id=team-a")) {
+					return new Response(
+						JSON.stringify({
+							items: [{ request_id: "req-1", group_id: "team-a", device_id: "device-1" }],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const res = await app.request("/api/coordinator/admin/join-requests");
+					expect(res.status).toBe(200);
+					expect(await res.json()).toMatchObject({
+						group_id: "team-a",
+						items: [expect.objectContaining({ request_id: "req-1" })],
+						status: expect.objectContaining({ readiness: "ready" }),
+					});
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
+		it("lists coordinator devices through the admin route", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/devices?group_id=team-a&include_disabled=1")) {
+					return new Response(
+						JSON.stringify({
+							items: [{ device_id: "device-1", group_id: "team-a", display_name: "Laptop" }],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const res = await app.request("/api/coordinator/admin/devices?include_disabled=1");
+					expect(res.status).toBe(200);
+					expect(await res.json()).toMatchObject({
+						group_id: "team-a",
+						items: [expect.objectContaining({ device_id: "device-1", display_name: "Laptop" })],
+						status: expect.objectContaining({ readiness: "ready" }),
+					});
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
 		it("deletes sync peers through the viewer route", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -20,6 +20,8 @@ import {
 	coordinatorCreateInviteAction,
 	coordinatorImportInviteAction,
 	coordinatorListBootstrapGrantsAction,
+	coordinatorListDevicesAction,
+	coordinatorListJoinRequestsAction,
 	coordinatorReviewJoinRequestAction,
 	coordinatorRevokeBootstrapGrantAction,
 	coordinatorStatusSnapshot,
@@ -79,6 +81,36 @@ const SYNC_STALE_AFTER_SECONDS = 10 * 60;
 const SYNC_PROTOCOL_VERSION = "2";
 const LEGACY_SYNC_ACTOR_DISPLAY_NAME = "Legacy synced peer";
 const LEGACY_SHARED_WORKSPACE_ID = "shared:legacy";
+
+type CoordinatorAdminReadiness = "not_configured" | "partial" | "ready";
+
+function coordinatorAdminStatusPayload(config = readCoordinatorSyncConfig()) {
+	const groups = config.syncCoordinatorGroups;
+	const activeGroup = groups[0] ?? null;
+	const hasUrl = Boolean(config.syncCoordinatorUrl);
+	const hasGroups = groups.length > 0;
+	const hasAdminSecret = Boolean(config.syncCoordinatorAdminSecret);
+	let readiness: CoordinatorAdminReadiness = "ready";
+	if (!hasUrl) readiness = "not_configured";
+	else if (!hasGroups || !hasAdminSecret) readiness = "partial";
+	return {
+		readiness,
+		coordinator_url: config.syncCoordinatorUrl || null,
+		groups,
+		active_group: activeGroup,
+		has_admin_secret: hasAdminSecret,
+		has_groups: hasGroups,
+	};
+}
+
+function resolveCoordinatorAdminGroup(
+	requestedGroup: string | null | undefined,
+	status: ReturnType<typeof coordinatorAdminStatusPayload>,
+): string | null {
+	const explicit = String(requestedGroup ?? "").trim();
+	if (explicit) return explicit;
+	return status.active_group;
+}
 
 function sortActiveMaintenanceJobs<
 	T extends { started_at: string | null; updated_at: string; kind: string },
@@ -2013,6 +2045,60 @@ export function syncRoutes(
 				{ error: message },
 				message.includes("request_not_found") || message.includes("not found") ? 404 : 400,
 			);
+		}
+	});
+
+	app.get("/api/coordinator/admin/status", async (c) => {
+		const status = coordinatorAdminStatusPayload();
+		return c.json(status);
+	});
+
+	app.get("/api/coordinator/admin/join-requests", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const groupId = resolveCoordinatorAdminGroup(c.req.query("group_id"), status);
+		if (!groupId) return c.json({ error: "group_id_required", status }, 400);
+		try {
+			const items = await coordinatorListJoinRequestsAction({
+				groupId,
+				remoteUrl: status.coordinator_url,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			return c.json({ items, group_id: groupId, status });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "unknown";
+			return c.json({ error: message, status }, 502);
+		}
+	});
+
+	app.get("/api/coordinator/admin/devices", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const groupId = resolveCoordinatorAdminGroup(c.req.query("group_id"), status);
+		if (!groupId) return c.json({ error: "group_id_required", status }, 400);
+		try {
+			const items = await coordinatorListDevicesAction({
+				groupId,
+				includeDisabled: queryBool(c.req.query("include_disabled")),
+				remoteUrl: status.coordinator_url,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			return c.json({ items, group_id: groupId, status });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "unknown";
+			return c.json({ error: message, status }, 502);
 		}
 	});
 


### PR DESCRIPTION
## Description
Adds the viewer-server `/api/coordinator/admin/*` proxy surface and readiness contract so coordinator admin state stays server-side and the browser never needs the raw admin secret.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced