### PR TITLE
feat(viewer): add coordinator admin tab shell

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -431,6 +431,84 @@
         margin-bottom: var(--sp-3);
       }
 
+      .coordinator-admin-shell {
+        display: grid;
+        gap: var(--sp-5);
+      }
+
+      .coordinator-admin-hero,
+      .coordinator-admin-sections {
+        display: grid;
+        gap: var(--sp-3);
+      }
+
+      .coordinator-admin-meta-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: var(--sp-3);
+      }
+
+      .coordinator-admin-meta-grid div {
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--sp-3);
+        background: var(--surface-0);
+      }
+
+      .coordinator-admin-meta-grid dt {
+        color: var(--text-tertiary);
+        font-size: 12px;
+        margin-bottom: var(--sp-1);
+      }
+
+      .coordinator-admin-meta-grid dd {
+        font-weight: 600;
+      }
+
+      .coordinator-admin-tabs-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sp-2);
+      }
+
+      .coordinator-admin-tab-trigger {
+        border: 1px solid var(--border);
+        border-radius: var(--radius-pill);
+        background: var(--surface-0);
+        color: var(--text-secondary);
+        padding: var(--sp-2) var(--sp-3);
+        font: inherit;
+        cursor: pointer;
+      }
+
+      .coordinator-admin-tab-trigger[data-state="active"] {
+        background: var(--accent-subtle);
+        border-color: var(--control-border);
+        color: var(--accent);
+      }
+
+      .coordinator-admin-tab-trigger:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+
+      .coordinator-admin-panel {
+        display: grid;
+        gap: var(--sp-3);
+        padding-top: var(--sp-2);
+      }
+
+      .coordinator-admin-panel h3 {
+        font-size: 15px;
+        margin: 0;
+      }
+
+      .coordinator-admin-list {
+        padding-left: var(--sp-4);
+        display: grid;
+        gap: var(--sp-2);
+      }
+
       .section-header {
         display: flex;
         align-items: center;
@@ -1987,6 +2065,7 @@
       <button class="tab-btn active" id="tabBtn-feed">Feed</button>
       <button class="tab-btn" id="tabBtn-health">Health</button>
       <button class="tab-btn" id="tabBtn-sync">Sync</button>
+      <button class="tab-btn" id="tabBtn-coordinator-admin">Coordinator Admin</button>
     </nav>
     <div class="app-notice" id="globalNotice" hidden aria-live="polite"></div>
     <div class="viewer-reconnect-overlay" id="viewerReconnectOverlay" hidden>
@@ -2346,6 +2425,10 @@
         <h3 class="settings-group-title" style="margin-top: 20px">Recent sync attempts (advanced)</h3>
         <div class="attempts-list" id="syncAttempts"></div>
       </div>
+    </div>
+
+    <div class="tab-panel" id="tab-coordinator-admin" hidden>
+      <div id="coordinatorAdminMount"></div>
     </div>
 
     <script src="/assets/app.js"></script>

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -14,6 +14,7 @@ import { $, $select } from "./lib/dom";
 import { initState, setActiveTab, state, type TabId } from "./lib/state";
 import { getTheme, initThemeSelect, setTheme } from "./lib/theme";
 
+import { initCoordinatorAdminTab, loadCoordinatorAdminData } from "./tabs/coordinator-admin";
 import { initFeedTab, loadFeedData, updateFeedView } from "./tabs/feed";
 import { initHealthTab, loadHealthData } from "./tabs/health";
 import { initSettings, isSettingsOpen, loadConfigData } from "./tabs/settings";
@@ -174,7 +175,7 @@ document.addEventListener("visibilitychange", () => {
 
 /* ── Tab routing ─────────────────────────────────────────── */
 
-const TAB_IDS: TabId[] = ["feed", "health", "sync"];
+const TAB_IDS: TabId[] = ["feed", "health", "sync", "coordinator-admin"];
 
 function switchTab(tab: TabId) {
 	setActiveTab(tab);
@@ -273,6 +274,9 @@ async function doRefresh() {
 		if (state.activeTab === "sync" || state.activeTab === "health") {
 			promises.push(loadSyncData());
 		}
+		if (state.activeTab === "coordinator-admin") {
+			promises.push(loadCoordinatorAdminData());
+		}
 
 		// Load pairing if open
 		if (state.syncPairingOpen) {
@@ -312,6 +316,7 @@ initTabs();
 initFeedTab();
 initHealthTab();
 initSyncTab(() => refresh());
+initCoordinatorAdminTab();
 initSettings(stopPolling, startPolling, () => refresh());
 
 // Projects

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -282,6 +282,10 @@ export async function loadSyncStatus(
 	return fetchJson(`/api/sync/status${suffix}`);
 }
 
+export async function loadCoordinatorAdminStatus(): Promise<unknown> {
+	return fetchJson("/api/coordinator/admin/status");
+}
+
 export async function createCoordinatorInvite(payload: {
 	group_id: string;
 	coordinator_url?: string;

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -3,7 +3,7 @@
 import type { UiSyncViewModel } from "../tabs/sync/view-model";
 
 export type RefreshState = "idle" | "refreshing" | "paused" | "error";
-export type TabId = "feed" | "health" | "sync";
+export type TabId = "feed" | "health" | "sync" | "coordinator-admin";
 
 /* ── Cached server payload shapes ─────────────────────────── */
 
@@ -136,6 +136,15 @@ export interface CachedSyncCoordinator {
 	paired_peer_count?: number;
 }
 
+export interface CachedCoordinatorAdminStatus {
+	readiness?: "not_configured" | "partial" | "ready";
+	coordinator_url?: string | null;
+	groups?: string[];
+	active_group?: string | null;
+	has_admin_secret?: boolean;
+	has_groups?: boolean;
+}
+
 export interface CachedTeamInvite {
 	encoded?: string;
 	warnings?: string[];
@@ -207,6 +216,7 @@ export const state = {
 	pendingAcceptedSyncPeers: [] as SyncPeer[],
 	lastSyncSharingReview: [] as SyncSharingReviewRow[],
 	lastSyncCoordinator: null as CachedSyncCoordinator | null,
+	lastCoordinatorAdminStatus: null as CachedCoordinatorAdminStatus | null,
 	lastSyncJoinRequests: [] as CachedSyncJoinRequest[],
 	lastTeamInvite: null as CachedTeamInvite | null,
 	lastTeamJoin: null as CachedTeamJoin | null,
@@ -237,9 +247,11 @@ export const state = {
 
 export function getActiveTab(): TabId {
 	const hash = window.location.hash.replace("#", "") as TabId;
-	if (["feed", "health", "sync"].includes(hash)) return hash;
+	if (["feed", "health", "sync", "coordinator-admin"].includes(hash)) return hash;
 	const saved = localStorage.getItem(TAB_KEY);
-	if (saved && ["feed", "health", "sync"].includes(saved)) return saved as TabId;
+	if (saved && ["feed", "health", "sync", "coordinator-admin"].includes(saved)) {
+		return saved as TabId;
+	}
 	return "feed";
 }
 

--- a/packages/ui/src/tabs/coordinator-admin.tsx
+++ b/packages/ui/src/tabs/coordinator-admin.tsx
@@ -1,0 +1,158 @@
+import { h, render } from "preact";
+import { RadixTabs, RadixTabsContent } from "../components/primitives/radix-tabs";
+import * as api from "../lib/api";
+import { state } from "../lib/state";
+
+type AdminSection = "overview" | "invites" | "join-requests" | "devices";
+
+let activeSection: AdminSection = "overview";
+
+function coordinatorAdminSummary() {
+	const status = state.lastCoordinatorAdminStatus;
+	if (!status) {
+		return {
+			readiness: "partial",
+			title: "Checking coordinator admin readiness…",
+			detail: "Loading local coordinator admin configuration from the viewer server.",
+		};
+	}
+	if (status.readiness === "ready") {
+		return {
+			readiness: "ready",
+			title: "Coordinator admin is ready",
+			detail:
+				"This viewer can use the local admin configuration to manage invites, join requests, and enrolled devices without exposing the admin secret to the browser.",
+		};
+	}
+	if (status.readiness === "partial") {
+		return {
+			readiness: "partial",
+			title: "Coordinator admin setup is incomplete",
+			detail:
+				status.has_admin_secret === false
+					? "Set a coordinator admin secret for the viewer server before using invite and device admin actions."
+					: "Finish configuring the coordinator target and group before using admin actions.",
+		};
+	}
+	return {
+		readiness: "not_configured",
+		title: "Coordinator admin is not configured",
+		detail:
+			"Set a coordinator URL, group, and admin secret locally to enable remote coordinator administration from this viewer.",
+	};
+}
+
+function renderShell() {
+	const mount = document.getElementById("coordinatorAdminMount");
+	if (!mount) return;
+	const status = state.lastCoordinatorAdminStatus;
+	const summary = coordinatorAdminSummary();
+	const groups = Array.isArray(status?.groups) ? status.groups.filter(Boolean) : [];
+	const coordinatorUrl = String(status?.coordinator_url || "").trim();
+	const activeGroup = String(status?.active_group || "").trim();
+
+	const disabledTabs = summary.readiness !== "ready";
+
+	render(
+		h(
+			"div",
+			{ class: "coordinator-admin-shell" },
+			h(
+				"div",
+				{ class: "card coordinator-admin-hero" },
+				h("div", { class: "section-header" }, h("h2", null, "Coordinator Admin")),
+				h("p", { class: "peer-meta" }, summary.title),
+				h("p", { class: "peer-submeta" }, summary.detail),
+				h(
+					"dl",
+					{ class: "coordinator-admin-meta-grid" },
+					h("div", null, h("dt", null, "Readiness"), h("dd", null, summary.readiness)),
+					h(
+						"div",
+						null,
+						h("dt", null, "Coordinator URL"),
+						h("dd", null, coordinatorUrl || "Not configured"),
+					),
+					h("div", null, h("dt", null, "Active group"), h("dd", null, activeGroup || "None")),
+					h(
+						"div",
+						null,
+						h("dt", null, "Admin secret"),
+						h("dd", null, status?.has_admin_secret ? "Available locally" : "Missing"),
+					),
+				),
+				groups.length
+					? h("p", { class: "peer-submeta" }, `Configured groups: ${groups.join(", ")}`)
+					: null,
+			),
+			h(
+				"div",
+				{ class: "card coordinator-admin-sections" },
+				h(
+					RadixTabs,
+					{
+						ariaLabel: "Coordinator admin sections",
+						listClassName: "coordinator-admin-tabs-list",
+						onValueChange: (value) => {
+							activeSection = (value as AdminSection) || "overview";
+							renderShell();
+						},
+						tabs: [
+							{ value: "overview", label: "Overview" },
+							{ value: "invites", label: "Invites", disabled: disabledTabs },
+							{ value: "join-requests", label: "Join requests", disabled: disabledTabs },
+							{ value: "devices", label: "Devices", disabled: disabledTabs },
+						],
+						triggerClassName: "coordinator-admin-tab-trigger",
+						value: activeSection,
+					},
+					h(
+						RadixTabsContent,
+						{ className: "coordinator-admin-panel", forceMount: true, value: "overview" },
+						h("h3", null, "What lives here"),
+						h(
+							"ul",
+							{ class: "coordinator-admin-list" },
+							h("li", null, "Create teammate invites with clear policy choices."),
+							h("li", null, "Review and approve or deny pending join requests."),
+							h("li", null, "Manage enrolled devices without mixing admin state into Sync."),
+						),
+					),
+					["invites", "join-requests", "devices"].map((section) =>
+						h(
+							RadixTabsContent,
+							{ className: "coordinator-admin-panel", forceMount: true, value: section },
+							h(
+								"h3",
+								null,
+								`${section === "join-requests" ? "Join request" : section.slice(0, 1).toUpperCase() + section.slice(1)} tools land in the next slice`,
+							),
+							h(
+								"p",
+								{ class: "peer-submeta" },
+								summary.readiness === "ready"
+									? "This shell is intentionally keeping the operator boundary and readiness UX honest before the real admin workflows land."
+									: "Finish setup first. This panel stays disabled until the local coordinator admin configuration is ready.",
+							),
+						),
+					),
+				),
+			),
+		),
+		mount,
+	);
+}
+
+export function initCoordinatorAdminTab() {
+	renderShell();
+}
+
+export async function loadCoordinatorAdminData() {
+	try {
+		state.lastCoordinatorAdminStatus =
+			(await api.loadCoordinatorAdminStatus()) as typeof state.lastCoordinatorAdminStatus;
+	} catch {
+		state.lastCoordinatorAdminStatus = null;
+	}
+	renderShell();
+}

--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -127,6 +127,7 @@ function TeamSetupDisclosure({ open, onOpenChange }: TeamSetupDisclosureProps) {
 				readOnly
 				hidden
 			/>
+			<div className="peer-meta" id="syncInviteAdminHint" />
 			<div className="peer-meta" id="syncInviteWarnings" hidden />
 		</SyncDisclosure>
 	);

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -126,12 +126,19 @@ export async function loadSyncData() {
 		}
 
 		let actorsPayload: SyncActorListResponseLike | null = null;
+		let coordinatorAdminStatus: Record<string, unknown> | null = null;
 		let actorLoadError = false;
+		let coordinatorAdminLoadError = false;
 		const duplicatePersonDecisions = readDuplicatePersonDecisions();
 		try {
 			actorsPayload = await api.loadSyncActors();
 		} catch {
 			actorLoadError = true;
+		}
+		try {
+			coordinatorAdminStatus = (await api.loadCoordinatorAdminStatus()) as Record<string, unknown>;
+		} catch {
+			coordinatorAdminLoadError = true;
 		}
 
 		if (requestId !== latestSyncLoadRequestId) return;
@@ -141,7 +148,12 @@ export async function loadSyncData() {
 		}
 
 		// Skip re-render if data hasn't changed since last poll
-		const hash = JSON.stringify([payload, actorsPayload, duplicatePersonDecisions]);
+		const hash = JSON.stringify([
+			payload,
+			actorsPayload,
+			coordinatorAdminStatus,
+			duplicatePersonDecisions,
+		]);
 		if (hash === lastSyncHash) return;
 		lastSyncHash = hash;
 
@@ -169,6 +181,10 @@ export async function loadSyncData() {
 		state.lastSyncPeers = [...payloadPeers, ...pendingPeers];
 		state.lastSyncSharingReview = payload.sharing_review || [];
 		state.lastSyncCoordinator = payload.coordinator || null;
+		state.lastCoordinatorAdminStatus =
+			coordinatorAdminStatus && typeof coordinatorAdminStatus === "object"
+				? coordinatorAdminStatus
+				: null;
 		if (Array.isArray(payload.join_requests)) {
 			state.lastSyncJoinRequests = payload.join_requests;
 		}
@@ -192,6 +208,10 @@ export async function loadSyncData() {
 		renderHealthOverview();
 		if (actorLoadError) {
 			renderSyncActorsUnavailable();
+		}
+		if (coordinatorAdminLoadError) {
+			state.lastCoordinatorAdminStatus = null;
+			renderTeamSync();
 		}
 	} catch {
 		if (requestId !== latestSyncLoadRequestId) return;

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -49,6 +49,31 @@ const INVITE_POLICY_OPTIONS: RadixSelectOption[] = [
 
 let invitePolicyValue: "auto_admit" | "approval_required" = "auto_admit";
 
+function applySyncInviteReadinessState() {
+	const syncCreateInviteButton = document.getElementById(
+		"syncCreateInviteButton",
+	) as HTMLButtonElement | null;
+	const hint = document.getElementById("syncInviteAdminHint") as HTMLParagraphElement | null;
+	if (!syncCreateInviteButton || !hint) return;
+	const readiness = state.lastCoordinatorAdminStatus?.readiness;
+	const activeGroup = String(state.lastCoordinatorAdminStatus?.active_group || "").trim();
+	if (readiness === "ready") {
+		syncCreateInviteButton.disabled = false;
+		hint.hidden = false;
+		hint.textContent = activeGroup
+			? `Remote coordinator admin is ready for ${activeGroup}. Advanced admin tools now live in Coordinator Admin.`
+			: "Remote coordinator admin is ready. Advanced admin tools now live in Coordinator Admin.";
+		return;
+	}
+	const message =
+		readiness === "partial"
+			? "Finish coordinator admin setup before creating remote invites. Use Coordinator Admin to check what is missing."
+			: "Configure a coordinator URL, group, and admin secret before creating remote invites. Use Coordinator Admin to finish setup.";
+	syncCreateInviteButton.disabled = true;
+	hint.hidden = false;
+	hint.textContent = message;
+}
+
 function renderAdminSetupDisclosure() {
 	const mount = document.getElementById("syncAdminDisclosureMount") as HTMLElement | null;
 	if (!mount) return;
@@ -221,6 +246,7 @@ export function renderTeamSync() {
 	renderInvitePolicySelect();
 	setInviteOutputVisibility();
 	setJoinFeedbackVisibility();
+	applySyncInviteReadinessState();
 
 	const invitePanel = document.getElementById("syncInvitePanel");
 	const inviteRestoreParent = document.getElementById("syncAdminSection");
@@ -805,6 +831,7 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 
 	syncCreateInviteButton?.addEventListener("click", async () => {
 		if (!syncCreateInviteButton || !syncInviteGroup || !syncInviteTtl || !syncInviteOutput) return;
+		if (syncCreateInviteButton.disabled) return;
 		const groupName = syncInviteGroup.value.trim();
 		const ttlValue = Number(syncInviteTtl.value);
 		let valid = true;


### PR DESCRIPTION
## Description
Adds the top-level Coordinator Admin tab shell and readiness states, and keeps Invite teammate visible in Sync while disabling it with setup guidance when coordinator admin is not configured.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced