### PR TITLE
feat(viewer): add coordinator admin invites panel

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -503,6 +503,31 @@
         margin: 0;
       }
 
+      .coordinator-admin-form-grid {
+        display: grid;
+        gap: var(--sp-3);
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      }
+
+      .coordinator-admin-field {
+        display: grid;
+        gap: var(--sp-2);
+      }
+
+      .coordinator-admin-field > span {
+        font-size: 12px;
+        color: var(--text-secondary);
+        font-weight: 600;
+      }
+
+      .coordinator-admin-output {
+        min-height: 108px;
+      }
+
+      .coordinator-admin-warning-list {
+        color: var(--status-attention);
+      }
+
       .coordinator-admin-list {
         padding-left: var(--sp-4);
         display: grid;

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -292,7 +292,7 @@ export async function createCoordinatorInvite(payload: {
 	policy: "auto_admit" | "approval_required";
 	ttl_hours: number;
 }): Promise<CoordinatorInviteResult> {
-	const resp = await fetch("/api/sync/invites/create", {
+	const resp = await fetch("/api/coordinator/admin/invites", {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(payload),

--- a/packages/ui/src/tabs/coordinator-admin.tsx
+++ b/packages/ui/src/tabs/coordinator-admin.tsx
@@ -1,11 +1,17 @@
 import { h, render } from "preact";
+import { RadixSelect } from "../components/primitives/radix-select";
 import { RadixTabs, RadixTabsContent } from "../components/primitives/radix-tabs";
 import * as api from "../lib/api";
+import { showGlobalNotice } from "../lib/notice";
 import { state } from "../lib/state";
 
 type AdminSection = "overview" | "invites" | "join-requests" | "devices";
 
 let activeSection: AdminSection = "overview";
+let inviteGroup = "";
+let inviteTtlHours = "24";
+let invitePolicy: "auto_admit" | "approval_required" = "auto_admit";
+let invitePending = false;
 
 function coordinatorAdminSummary() {
 	const status = state.lastCoordinatorAdminStatus;
@@ -42,6 +48,160 @@ function coordinatorAdminSummary() {
 	};
 }
 
+async function createInviteFromAdminPanel() {
+	if (invitePending) return;
+	const status = state.lastCoordinatorAdminStatus;
+	const defaultGroup = String(status?.active_group || "").trim();
+	const groupId = inviteGroup.trim() || defaultGroup;
+	const ttlHours = Number(inviteTtlHours);
+	if (!groupId) {
+		showGlobalNotice("Choose a coordinator group before creating an invite.", "warning");
+		return;
+	}
+	if (!Number.isFinite(ttlHours) || ttlHours < 1) {
+		showGlobalNotice("Invite lifetime must be at least 1 hour.", "warning");
+		return;
+	}
+	invitePending = true;
+	renderShell();
+	try {
+		const result = await api.createCoordinatorInvite({
+			group_id: groupId,
+			policy: invitePolicy,
+			ttl_hours: ttlHours,
+		});
+		state.lastTeamInvite = result;
+		inviteGroup = groupId;
+		const warnings = Array.isArray(result.warnings) ? result.warnings : [];
+		showGlobalNotice(
+			warnings.length
+				? `Invite created. Review ${warnings.length === 1 ? "the warning" : `${warnings.length} warnings`} before sharing it.`
+				: "Invite created. Copy it from Coordinator Admin and share it with your teammate.",
+			warnings.length ? "warning" : "success",
+		);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to create invite.";
+		showGlobalNotice(message, "warning");
+	} finally {
+		invitePending = false;
+		renderShell();
+	}
+}
+
+function renderInvitesPanel(summary: ReturnType<typeof coordinatorAdminSummary>) {
+	const status = state.lastCoordinatorAdminStatus;
+	const groups = Array.isArray(status?.groups) ? status.groups.filter(Boolean) : [];
+	const activeGroup = String(status?.active_group || "").trim();
+	const effectiveGroup = inviteGroup.trim() || activeGroup;
+	const output = String(state.lastTeamInvite?.encoded || "").trim();
+	const warnings = Array.isArray(state.lastTeamInvite?.warnings)
+		? state.lastTeamInvite?.warnings
+		: [];
+	return h(
+		RadixTabsContent,
+		{ className: "coordinator-admin-panel", forceMount: true, value: "invites" },
+		h("h3", null, "Create teammate invite"),
+		h(
+			"p",
+			{ class: "peer-submeta" },
+			summary.readiness === "ready"
+				? "Generate a coordinator-backed invite from the same operator surface that will later handle join requests and device administration."
+				: "Finish setup first. Invite creation stays disabled until the local coordinator admin configuration is ready.",
+		),
+		h(
+			"div",
+			{ class: "coordinator-admin-form-grid" },
+			h(
+				"label",
+				{ class: "coordinator-admin-field" },
+				h("span", null, "Group"),
+				h("input", {
+					class: "peer-scope-input",
+					disabled: summary.readiness !== "ready",
+					onInput: (event) => {
+						inviteGroup = String((event.currentTarget as HTMLInputElement).value || "");
+					},
+					placeholder: activeGroup || "team-alpha",
+					value: inviteGroup,
+				}),
+			),
+			h(
+				"label",
+				{ class: "coordinator-admin-field" },
+				h("span", null, "Join policy"),
+				h(RadixSelect, {
+					ariaLabel: "Invite join policy",
+					contentClassName: "sync-radix-select-content sync-actor-select-content",
+					disabled: summary.readiness !== "ready",
+					id: "coordinatorAdminInvitePolicy",
+					itemClassName: "sync-radix-select-item",
+					onValueChange: (value) => {
+						invitePolicy = value === "approval_required" ? "approval_required" : "auto_admit";
+						renderShell();
+					},
+					options: [
+						{ value: "auto_admit", label: "Auto-admit" },
+						{ value: "approval_required", label: "Approval required" },
+					],
+					triggerClassName: "sync-radix-select-trigger sync-actor-select",
+					value: invitePolicy,
+					viewportClassName: "sync-radix-select-viewport",
+				}),
+			),
+			h(
+				"label",
+				{ class: "coordinator-admin-field" },
+				h("span", null, "Expires in (hours)"),
+				h("input", {
+					class: "peer-scope-input",
+					disabled: summary.readiness !== "ready",
+					min: "1",
+					onInput: (event) => {
+						inviteTtlHours = String((event.currentTarget as HTMLInputElement).value || "");
+					},
+					type: "number",
+					value: inviteTtlHours,
+				}),
+			),
+		),
+		h(
+			"div",
+			{ class: "section-actions" },
+			h(
+				"button",
+				{
+					class: "settings-button",
+					disabled: summary.readiness !== "ready" || invitePending,
+					onClick: () => {
+						void createInviteFromAdminPanel();
+					},
+					type: "button",
+				},
+				invitePending ? "Creating…" : "Create invite",
+			),
+			effectiveGroup ? h("span", { class: "peer-submeta" }, `Using group ${effectiveGroup}`) : null,
+		),
+		groups.length
+			? h("p", { class: "peer-submeta" }, `Available groups: ${groups.join(", ")}`)
+			: null,
+		output
+			? h(
+					"label",
+					{ class: "coordinator-admin-field" },
+					h("span", null, "Generated invite"),
+					h("textarea", {
+						class: "feed-search coordinator-admin-output",
+						readOnly: true,
+						value: output,
+					}),
+				)
+			: null,
+		warnings?.length
+			? h("div", { class: "peer-meta coordinator-admin-warning-list" }, warnings.join(" · "))
+			: null,
+	);
+}
+
 function renderShell() {
 	const mount = document.getElementById("coordinatorAdminMount");
 	if (!mount) return;
@@ -50,8 +210,15 @@ function renderShell() {
 	const groups = Array.isArray(status?.groups) ? status.groups.filter(Boolean) : [];
 	const coordinatorUrl = String(status?.coordinator_url || "").trim();
 	const activeGroup = String(status?.active_group || "").trim();
-
-	const disabledTabs = summary.readiness !== "ready";
+	const invitesEnabled = summary.readiness === "ready";
+	if (
+		activeSection !== "overview" &&
+		!invitesEnabled &&
+		activeSection !== "join-requests" &&
+		activeSection !== "devices"
+	) {
+		activeSection = "overview";
+	}
 
 	render(
 		h(
@@ -99,9 +266,9 @@ function renderShell() {
 						},
 						tabs: [
 							{ value: "overview", label: "Overview" },
-							{ value: "invites", label: "Invites", disabled: disabledTabs },
-							{ value: "join-requests", label: "Join requests", disabled: disabledTabs },
-							{ value: "devices", label: "Devices", disabled: disabledTabs },
+							{ value: "invites", label: "Invites", disabled: !invitesEnabled },
+							{ value: "join-requests", label: "Join requests", disabled: true },
+							{ value: "devices", label: "Devices", disabled: true },
 						],
 						triggerClassName: "coordinator-admin-tab-trigger",
 						value: activeSection,
@@ -118,22 +285,25 @@ function renderShell() {
 							h("li", null, "Manage enrolled devices without mixing admin state into Sync."),
 						),
 					),
-					["invites", "join-requests", "devices"].map((section) =>
+					renderInvitesPanel(summary),
+					h(
+						RadixTabsContent,
+						{ className: "coordinator-admin-panel", forceMount: true, value: "join-requests" },
+						h("h3", null, "Join request tools land in the next slice"),
 						h(
-							RadixTabsContent,
-							{ className: "coordinator-admin-panel", forceMount: true, value: section },
-							h(
-								"h3",
-								null,
-								`${section === "join-requests" ? "Join request" : section.slice(0, 1).toUpperCase() + section.slice(1)} tools land in the next slice`,
-							),
-							h(
-								"p",
-								{ class: "peer-submeta" },
-								summary.readiness === "ready"
-									? "This shell is intentionally keeping the operator boundary and readiness UX honest before the real admin workflows land."
-									: "Finish setup first. This panel stays disabled until the local coordinator admin configuration is ready.",
-							),
+							"p",
+							{ class: "peer-submeta" },
+							"This shell is intentionally separating the operator control plane before the review workflow lands.",
+						),
+					),
+					h(
+						RadixTabsContent,
+						{ className: "coordinator-admin-panel", forceMount: true, value: "devices" },
+						h("h3", null, "Device admin tools land in the next slice"),
+						h(
+							"p",
+							{ class: "peer-submeta" },
+							"Device management will live here once the tab shell and invite workflow settle.",
 						),
 					),
 				),

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -4409,6 +4409,55 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("creates coordinator invites through the coordinator admin route", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/invites")) {
+					return new Response(
+						JSON.stringify({
+							encoded: "invite-blob",
+							link: "https://example.test/invite",
+							payload: { group_id: "team-a" },
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_coordinator_url: "https://coord.example.test",
+					sync_coordinator_group: "team-a",
+					sync_coordinator_admin_secret: "secret",
+				}),
+			);
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/coordinator/admin/invites", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ policy: "auto_admit", ttl_hours: 24 }),
+				});
+				expect(res.status).toBe(200);
+				expect(await res.json()).toMatchObject({
+					encoded: "invite-blob",
+					group_id: "team-a",
+					status: expect.objectContaining({ readiness: "ready", active_group: "team-a" }),
+				});
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+			}
+		});
+
 		it("returns invite warnings for private-looking coordinator URLs", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -2053,6 +2053,51 @@ export function syncRoutes(
 		return c.json(status);
 	});
 
+	app.post("/api/coordinator/admin/invites", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json", status }, 400);
+		}
+		const groupId = resolveCoordinatorAdminGroup(String(body.group_id ?? "").trim(), status);
+		const coordinatorUrl = body.coordinator_url == null ? null : String(body.coordinator_url ?? "");
+		const policy = String(body.policy ?? "auto_admit").trim();
+		const ttlHours = Number.parseInt(String(body.ttl_hours ?? 24), 10);
+		if (!groupId) return c.json({ error: "group_id required", status }, 400);
+		if (body.coordinator_url != null && typeof body.coordinator_url !== "string") {
+			return c.json({ error: "coordinator_url must be string", status }, 400);
+		}
+		if (!["auto_admit", "approval_required"].includes(policy)) {
+			return c.json({ error: "policy must be auto_admit or approval_required", status }, 400);
+		}
+		if (!Number.isFinite(ttlHours)) {
+			return c.json({ error: "ttl_hours must be int", status }, 400);
+		}
+		try {
+			const result = await coordinatorCreateInviteAction({
+				groupId,
+				coordinatorUrl,
+				policy,
+				ttlHours,
+				createdBy: null,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			return c.json({ ...result, status });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
+		}
+	});
+
 	app.get("/api/coordinator/admin/join-requests", async (c) => {
 		const config = readCoordinatorSyncConfig();
 		const status = coordinatorAdminStatusPayload(config);


### PR DESCRIPTION
## Description
Adds the Coordinator Admin invites panel and routes invite creation through the dedicated coordinator admin API so common invite generation lives in the new operator surface without exposing the admin secret to the browser.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced