### PR TITLE
feat(viewer): add coordinator admin join review

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -286,6 +286,28 @@ export async function loadCoordinatorAdminStatus(): Promise<unknown> {
 	return fetchJson("/api/coordinator/admin/status");
 }
 
+export async function loadCoordinatorAdminJoinRequests(groupId?: string | null): Promise<unknown> {
+	const params = new URLSearchParams();
+	if (groupId) params.set("group_id", groupId);
+	const suffix = params.size ? `?${params.toString()}` : "";
+	return fetchJson(`/api/coordinator/admin/join-requests${suffix}`);
+}
+
+export async function reviewCoordinatorAdminJoinRequest(
+	requestId: string,
+	action: "approve" | "deny",
+): Promise<unknown> {
+	const resp = await fetch(
+		`/api/coordinator/admin/join-requests/${encodeURIComponent(requestId)}/${action}`,
+		{
+			method: "POST",
+		},
+	);
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}
+
 export async function createCoordinatorInvite(payload: {
 	group_id: string;
 	coordinator_url?: string;

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -217,6 +217,7 @@ export const state = {
 	lastSyncSharingReview: [] as SyncSharingReviewRow[],
 	lastSyncCoordinator: null as CachedSyncCoordinator | null,
 	lastCoordinatorAdminStatus: null as CachedCoordinatorAdminStatus | null,
+	lastCoordinatorAdminJoinRequests: [] as CachedSyncJoinRequest[],
 	lastSyncJoinRequests: [] as CachedSyncJoinRequest[],
 	lastTeamInvite: null as CachedTeamInvite | null,
 	lastTeamJoin: null as CachedTeamJoin | null,

--- a/packages/ui/src/tabs/coordinator-admin.tsx
+++ b/packages/ui/src/tabs/coordinator-admin.tsx
@@ -12,6 +12,8 @@ let inviteGroup = "";
 let inviteTtlHours = "24";
 let invitePolicy: "auto_admit" | "approval_required" = "auto_admit";
 let invitePending = false;
+let joinReviewPendingId = "";
+let joinReviewPendingAction: "approve" | "deny" | "" = "";
 
 function coordinatorAdminSummary() {
 	const status = state.lastCoordinatorAdminStatus;
@@ -202,6 +204,92 @@ function renderInvitesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 	);
 }
 
+async function reviewJoinRequestFromAdminPanel(requestId: string, action: "approve" | "deny") {
+	if (joinReviewPendingId) return;
+	joinReviewPendingId = requestId;
+	joinReviewPendingAction = action;
+	renderShell();
+	try {
+		await api.reviewCoordinatorAdminJoinRequest(requestId, action);
+		showGlobalNotice(
+			action === "approve" ? "Join request approved." : "Join request denied.",
+			"success",
+		);
+		await loadCoordinatorAdminData();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Failed to review join request.";
+		showGlobalNotice(message, "warning");
+	} finally {
+		joinReviewPendingId = "";
+		joinReviewPendingAction = "";
+		renderShell();
+	}
+}
+
+function renderJoinRequestsPanel(summary: ReturnType<typeof coordinatorAdminSummary>) {
+	const items = Array.isArray(state.lastCoordinatorAdminJoinRequests)
+		? state.lastCoordinatorAdminJoinRequests
+		: [];
+	return h(
+		RadixTabsContent,
+		{ className: "coordinator-admin-panel", forceMount: true, value: "join-requests" },
+		h("h3", null, "Pending join requests"),
+		h(
+			"p",
+			{ class: "peer-submeta" },
+			summary.readiness === "ready"
+				? "Approve or deny teammate join requests from the dedicated operator surface instead of burying them in Sync."
+				: "Finish setup first. Join request review stays disabled until coordinator admin is ready.",
+		),
+		!items.length
+			? h(
+					"div",
+					{ class: "peer-meta" },
+					summary.readiness === "ready"
+						? "No pending join requests right now."
+						: "Join request review will appear here once setup is complete.",
+				)
+			: h(
+					"div",
+					{ class: "coordinator-admin-request-list" },
+					items.map((item) => {
+						const requestId = String(item.request_id || "").trim();
+						const deviceId = String(item.device_id || "unknown-device");
+						const displayName = String(item.display_name || deviceId);
+						const pending = joinReviewPendingId === requestId;
+						return h(
+							"div",
+							{ class: "peer-card", key: requestId || deviceId },
+							h("div", { class: "peer-title" }, h("strong", null, displayName)),
+							h("div", { class: "peer-meta" }, `Device: ${deviceId}`),
+							h(
+								"div",
+								{ class: "peer-actions" },
+								h(
+									"button",
+									{
+										disabled: !requestId || pending,
+										onClick: () => void reviewJoinRequestFromAdminPanel(requestId, "approve"),
+										type: "button",
+									},
+									pending && joinReviewPendingAction === "approve" ? "Approving…" : "Approve",
+								),
+								h(
+									"button",
+									{
+										disabled: !requestId || pending,
+										onClick: () => void reviewJoinRequestFromAdminPanel(requestId, "deny"),
+										type: "button",
+									},
+									pending && joinReviewPendingAction === "deny" ? "Denying…" : "Deny",
+								),
+							),
+						);
+					}),
+				),
+	);
+}
+
 function renderShell() {
 	const mount = document.getElementById("coordinatorAdminMount");
 	if (!mount) return;
@@ -211,11 +299,11 @@ function renderShell() {
 	const coordinatorUrl = String(status?.coordinator_url || "").trim();
 	const activeGroup = String(status?.active_group || "").trim();
 	const invitesEnabled = summary.readiness === "ready";
+	const joinRequestsEnabled = summary.readiness === "ready";
 	if (
 		activeSection !== "overview" &&
-		!invitesEnabled &&
-		activeSection !== "join-requests" &&
-		activeSection !== "devices"
+		((activeSection === "invites" && !invitesEnabled) ||
+			(activeSection === "join-requests" && !joinRequestsEnabled))
 	) {
 		activeSection = "overview";
 	}
@@ -267,7 +355,7 @@ function renderShell() {
 						tabs: [
 							{ value: "overview", label: "Overview" },
 							{ value: "invites", label: "Invites", disabled: !invitesEnabled },
-							{ value: "join-requests", label: "Join requests", disabled: true },
+							{ value: "join-requests", label: "Join requests", disabled: !joinRequestsEnabled },
 							{ value: "devices", label: "Devices", disabled: true },
 						],
 						triggerClassName: "coordinator-admin-tab-trigger",
@@ -286,16 +374,7 @@ function renderShell() {
 						),
 					),
 					renderInvitesPanel(summary),
-					h(
-						RadixTabsContent,
-						{ className: "coordinator-admin-panel", forceMount: true, value: "join-requests" },
-						h("h3", null, "Join request tools land in the next slice"),
-						h(
-							"p",
-							{ class: "peer-submeta" },
-							"This shell is intentionally separating the operator control plane before the review workflow lands.",
-						),
-					),
+					renderJoinRequestsPanel(summary),
 					h(
 						RadixTabsContent,
 						{ className: "coordinator-admin-panel", forceMount: true, value: "devices" },
@@ -321,8 +400,18 @@ export async function loadCoordinatorAdminData() {
 	try {
 		state.lastCoordinatorAdminStatus =
 			(await api.loadCoordinatorAdminStatus()) as typeof state.lastCoordinatorAdminStatus;
+		const activeGroup = String(state.lastCoordinatorAdminStatus?.active_group || "").trim();
+		if (state.lastCoordinatorAdminStatus?.readiness === "ready") {
+			const payload = (await api.loadCoordinatorAdminJoinRequests(activeGroup)) as {
+				items?: typeof state.lastCoordinatorAdminJoinRequests;
+			};
+			state.lastCoordinatorAdminJoinRequests = Array.isArray(payload?.items) ? payload.items : [];
+		} else {
+			state.lastCoordinatorAdminJoinRequests = [];
+		}
 	} catch {
 		state.lastCoordinatorAdminStatus = null;
+		state.lastCoordinatorAdminJoinRequests = [];
 	}
 	renderShell();
 }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -4846,6 +4846,52 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("reviews coordinator join requests through the admin route", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/join-requests/approve")) {
+					return new Response(
+						JSON.stringify({ request: { request_id: "req-1", status: "approved" } }),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const res = await app.request("/api/coordinator/admin/join-requests/req-1/approve", {
+						method: "POST",
+					});
+					expect(res.status).toBe(200);
+					expect(await res.json()).toMatchObject({
+						ok: true,
+						request: { request_id: "req-1", status: "approved" },
+						status: expect.objectContaining({ readiness: "ready" }),
+					});
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
 		it("lists coordinator devices through the admin route", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -2122,6 +2122,66 @@ export function syncRoutes(
 		}
 	});
 
+	app.post("/api/coordinator/admin/join-requests/:request_id/approve", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const requestId = String(c.req.param("request_id") ?? "").trim();
+		if (!requestId) return c.json({ error: "request_id required", status }, 400);
+		try {
+			const result = await coordinatorReviewJoinRequestAction({
+				requestId,
+				approve: true,
+				reviewedBy: null,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!result) return c.json({ error: "join request not found", status }, 404);
+			return c.json({ ok: true, request: result, status });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return c.json(
+				{ error: message, status },
+				message.includes("request_not_found") || message.includes("not found") ? 404 : 400,
+			);
+		}
+	});
+
+	app.post("/api/coordinator/admin/join-requests/:request_id/deny", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const requestId = String(c.req.param("request_id") ?? "").trim();
+		if (!requestId) return c.json({ error: "request_id required", status }, 400);
+		try {
+			const result = await coordinatorReviewJoinRequestAction({
+				requestId,
+				approve: false,
+				reviewedBy: null,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!result) return c.json({ error: "join request not found", status }, 404);
+			return c.json({ ok: true, request: result, status });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return c.json(
+				{ error: message, status },
+				message.includes("request_not_found") || message.includes("not found") ? 404 : 400,
+			);
+		}
+	});
+
 	app.get("/api/coordinator/admin/devices", async (c) => {
 		const config = readCoordinatorSyncConfig();
 		const status = coordinatorAdminStatusPayload(config);


### PR DESCRIPTION
## Description
Adds the Coordinator Admin join request review panel and dedicated approve/deny routes so coordinator membership review happens in the operator surface instead of the Sync tab.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced