### PR TITLE
feat(viewer): add coordinator admin device actions

### DIFF
--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -227,8 +227,8 @@ export async function coordinatorListDevicesAction(opts: {
 }): Promise<CoordinatorEnrollment[]> {
 	const groupId = String(opts.groupId ?? "").trim();
 	if (!groupId) throw new Error("Group id required.");
-	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
-	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	const remote = opts.remoteUrl ?? null;
+	const adminSecret = opts.adminSecret ?? null;
 	if (remote) {
 		if (!adminSecret) throw new Error("Admin secret required.");
 		const payload = await remoteRequest(
@@ -255,12 +255,39 @@ export async function coordinatorRenameDeviceAction(opts: {
 	deviceId: string;
 	displayName: string;
 	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
 }): Promise<CoordinatorEnrollment | null> {
 	const groupId = String(opts.groupId ?? "").trim();
 	const deviceId = String(opts.deviceId ?? "").trim();
 	const displayName = String(opts.displayName ?? "").trim();
 	if (!groupId || !deviceId || !displayName) {
 		throw new Error("group_id, device_id, and display_name are required.");
+	}
+	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		let payload: Record<string, unknown> | null;
+		try {
+			payload = await remoteRequest(
+				"POST",
+				`${remote.replace(/\/+$/, "")}/v1/admin/devices/rename`,
+				adminSecret,
+				{ group_id: groupId, device_id: deviceId, display_name: displayName },
+			);
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				error.message.includes("(404)") &&
+				error.message.includes("device_not_found")
+			) {
+				return null;
+			}
+			throw error;
+		}
+		const device = payload?.device;
+		return device && typeof device === "object" ? (device as CoordinatorEnrollment) : null;
 	}
 	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
@@ -279,10 +306,35 @@ export async function coordinatorDisableDeviceAction(opts: {
 	groupId: string;
 	deviceId: string;
 	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
 }): Promise<boolean> {
 	const groupId = String(opts.groupId ?? "").trim();
 	const deviceId = String(opts.deviceId ?? "").trim();
 	if (!groupId || !deviceId) throw new Error("group_id and device_id are required.");
+	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		try {
+			await remoteRequest(
+				"POST",
+				`${remote.replace(/\/+$/, "")}/v1/admin/devices/disable`,
+				adminSecret,
+				{ group_id: groupId, device_id: deviceId },
+			);
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				error.message.includes("(404)") &&
+				error.message.includes("device_not_found")
+			) {
+				return false;
+			}
+			throw error;
+		}
+		return true;
+	}
 	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
 		return await store.setDeviceEnabled(groupId, deviceId, false);
@@ -295,10 +347,35 @@ export async function coordinatorRemoveDeviceAction(opts: {
 	groupId: string;
 	deviceId: string;
 	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
 }): Promise<boolean> {
 	const groupId = String(opts.groupId ?? "").trim();
 	const deviceId = String(opts.deviceId ?? "").trim();
 	if (!groupId || !deviceId) throw new Error("group_id and device_id are required.");
+	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		try {
+			await remoteRequest(
+				"POST",
+				`${remote.replace(/\/+$/, "")}/v1/admin/devices/remove`,
+				adminSecret,
+				{ group_id: groupId, device_id: deviceId },
+			);
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				error.message.includes("(404)") &&
+				error.message.includes("device_not_found")
+			) {
+				return false;
+			}
+			throw error;
+		}
+		return true;
+	}
 	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
 		return await store.removeDevice(groupId, deviceId);

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -293,12 +293,69 @@ export async function loadCoordinatorAdminJoinRequests(groupId?: string | null):
 	return fetchJson(`/api/coordinator/admin/join-requests${suffix}`);
 }
 
+export async function loadCoordinatorAdminDevices(
+	groupId?: string | null,
+	includeDisabled = true,
+): Promise<unknown> {
+	const params = new URLSearchParams();
+	if (groupId) params.set("group_id", groupId);
+	if (includeDisabled) params.set("include_disabled", "1");
+	const suffix = params.size ? `?${params.toString()}` : "";
+	return fetchJson(`/api/coordinator/admin/devices${suffix}`);
+}
+
 export async function reviewCoordinatorAdminJoinRequest(
 	requestId: string,
 	action: "approve" | "deny",
 ): Promise<unknown> {
 	const resp = await fetch(
 		`/api/coordinator/admin/join-requests/${encodeURIComponent(requestId)}/${action}`,
+		{
+			method: "POST",
+		},
+	);
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}
+
+export async function renameCoordinatorAdminDevice(
+	deviceId: string,
+	groupId: string,
+	displayName: string,
+): Promise<unknown> {
+	const resp = await fetch(
+		`/api/coordinator/admin/devices/${encodeURIComponent(deviceId)}/rename`,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ group_id: groupId, display_name: displayName }),
+		},
+	);
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}
+
+export async function disableCoordinatorAdminDevice(
+	deviceId: string,
+	groupId: string,
+): Promise<unknown> {
+	const resp = await fetch(
+		`/api/coordinator/admin/devices/${encodeURIComponent(deviceId)}/disable?group_id=${encodeURIComponent(groupId)}`,
+		{ method: "POST" },
+	);
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}
+
+export async function removeCoordinatorAdminDevice(
+	deviceId: string,
+	groupId: string,
+): Promise<unknown> {
+	const resp = await fetch(
+		`/api/coordinator/admin/devices/${encodeURIComponent(deviceId)}/remove?group_id=${encodeURIComponent(groupId)}`,
 		{
 			method: "POST",
 		},
@@ -331,20 +388,6 @@ export async function importCoordinatorInvite(invite: string): Promise<ImportInv
 		body: JSON.stringify({ invite }),
 	});
 	const { text, payload: data } = await readJsonPayload<ImportInviteResult>(resp);
-	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
-	return data;
-}
-
-export async function reviewJoinRequest(
-	requestId: string,
-	action: "approve" | "deny",
-): Promise<unknown> {
-	const resp = await fetch("/api/sync/join-requests/review", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ request_id: requestId, action }),
-	});
-	const { text, payload: data } = await readJsonPayload(resp);
 	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
 	return data;
 }

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -145,6 +145,14 @@ export interface CachedCoordinatorAdminStatus {
 	has_groups?: boolean;
 }
 
+export interface CachedCoordinatorAdminDevice {
+	device_id?: string;
+	group_id?: string;
+	display_name?: string | null;
+	enabled?: number | boolean;
+	fingerprint?: string;
+}
+
 export interface CachedTeamInvite {
 	encoded?: string;
 	warnings?: string[];
@@ -218,6 +226,7 @@ export const state = {
 	lastSyncCoordinator: null as CachedSyncCoordinator | null,
 	lastCoordinatorAdminStatus: null as CachedCoordinatorAdminStatus | null,
 	lastCoordinatorAdminJoinRequests: [] as CachedSyncJoinRequest[],
+	lastCoordinatorAdminDevices: [] as CachedCoordinatorAdminDevice[],
 	lastSyncJoinRequests: [] as CachedSyncJoinRequest[],
 	lastTeamInvite: null as CachedTeamInvite | null,
 	lastTeamJoin: null as CachedTeamJoin | null,

--- a/packages/ui/src/tabs/coordinator-admin.tsx
+++ b/packages/ui/src/tabs/coordinator-admin.tsx
@@ -4,6 +4,7 @@ import { RadixTabs, RadixTabsContent } from "../components/primitives/radix-tabs
 import * as api from "../lib/api";
 import { showGlobalNotice } from "../lib/notice";
 import { state } from "../lib/state";
+import { openSyncConfirmDialog } from "./sync/sync-dialogs";
 
 type AdminSection = "overview" | "invites" | "join-requests" | "devices";
 
@@ -14,6 +15,25 @@ let invitePolicy: "auto_admit" | "approval_required" = "auto_admit";
 let invitePending = false;
 let joinReviewPendingId = "";
 let joinReviewPendingAction: "approve" | "deny" | "" = "";
+let deviceActionPendingId = "";
+let deviceActionPendingKind: "rename" | "disable" | "remove" | "" = "";
+const deviceRenameDrafts = new Map<string, string>();
+
+function reconcileDeviceRenameDrafts() {
+	const next = new Map<string, string>();
+	const items = Array.isArray(state.lastCoordinatorAdminDevices)
+		? state.lastCoordinatorAdminDevices
+		: [];
+	for (const item of items) {
+		const deviceId = String(item.device_id || "").trim();
+		if (!deviceId) continue;
+		next.set(deviceId, String(item.display_name || ""));
+	}
+	deviceRenameDrafts.clear();
+	for (const [deviceId, name] of next.entries()) {
+		deviceRenameDrafts.set(deviceId, name);
+	}
+}
 
 function coordinatorAdminSummary() {
 	const status = state.lastCoordinatorAdminStatus;
@@ -290,6 +310,159 @@ function renderJoinRequestsPanel(summary: ReturnType<typeof coordinatorAdminSumm
 	);
 }
 
+async function runDeviceAction(
+	deviceId: string,
+	groupId: string,
+	displayName: string,
+	kind: "rename" | "disable" | "remove",
+) {
+	if (!deviceId || deviceActionPendingId) return;
+	if (
+		(kind === "disable" || kind === "remove") &&
+		!(await openSyncConfirmDialog({
+			title: `${kind === "disable" ? "Disable" : "Remove"} ${displayName || deviceId}?`,
+			description:
+				kind === "disable"
+					? "This device will stay enrolled but can no longer participate until you re-enable it from a future admin flow."
+					: "This removes the enrolled device record from the coordinator. The teammate would need a fresh invite or re-enrollment path to come back.",
+			confirmLabel: kind === "disable" ? "Disable device" : "Remove device",
+			cancelLabel: kind === "disable" ? "Keep device enabled" : "Keep device enrolled",
+			tone: "danger",
+		}))
+	) {
+		return;
+	}
+	deviceActionPendingId = deviceId;
+	deviceActionPendingKind = kind;
+	renderShell();
+	try {
+		if (kind === "rename") {
+			const nextName = String(deviceRenameDrafts.get(deviceId) || "").trim();
+			if (!nextName) {
+				showGlobalNotice("Enter a device name before renaming it.", "warning");
+				return;
+			}
+			await api.renameCoordinatorAdminDevice(deviceId, groupId, nextName);
+			showGlobalNotice("Device renamed.", "success");
+		}
+		if (kind === "disable") {
+			await api.disableCoordinatorAdminDevice(deviceId, groupId);
+			showGlobalNotice("Device disabled.", "success");
+		}
+		if (kind === "remove") {
+			await api.removeCoordinatorAdminDevice(deviceId, groupId);
+			showGlobalNotice("Device removed.", "success");
+		}
+		await loadCoordinatorAdminData();
+	} catch (error) {
+		const message = error instanceof Error ? error.message : `Failed to ${kind} device.`;
+		showGlobalNotice(message, "warning");
+	} finally {
+		deviceActionPendingId = "";
+		deviceActionPendingKind = "";
+		renderShell();
+	}
+}
+
+function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>) {
+	const items = Array.isArray(state.lastCoordinatorAdminDevices)
+		? state.lastCoordinatorAdminDevices
+		: [];
+	return h(
+		RadixTabsContent,
+		{ className: "coordinator-admin-panel", forceMount: true, value: "devices" },
+		h("h3", null, "Enrolled devices"),
+		h(
+			"p",
+			{ class: "peer-submeta" },
+			summary.readiness === "ready"
+				? "Rename, disable, or remove enrolled devices from the operator surface without confusing this with direct sync state."
+				: "Finish setup first. Device administration stays disabled until coordinator admin is ready.",
+		),
+		!items.length
+			? h(
+					"div",
+					{ class: "peer-meta" },
+					summary.readiness === "ready"
+						? "No enrolled devices found for the active coordinator group."
+						: "Device administration will appear here once setup is complete.",
+				)
+			: h(
+					"div",
+					{ class: "coordinator-admin-request-list" },
+					items.map((item) => {
+						const deviceId = String(item.device_id || "").trim();
+						const groupId = String(
+							item.group_id || state.lastCoordinatorAdminStatus?.active_group || "",
+						).trim();
+						const displayName = String(item.display_name || deviceId || "Unnamed device");
+						const pending = deviceActionPendingId === deviceId;
+						const draft = deviceRenameDrafts.get(deviceId) ?? String(item.display_name || "");
+						const enabled = item.enabled !== false && item.enabled !== 0;
+						return h(
+							"div",
+							{ class: "peer-card", key: deviceId || String(item.fingerprint || "unknown") },
+							h("div", { class: "peer-title" }, h("strong", null, draft || displayName)),
+							h("div", { class: "peer-meta" }, `Device: ${deviceId || "unknown"}`),
+							groupId ? h("div", { class: "peer-submeta" }, `Group: ${groupId}`) : null,
+							h("div", { class: "peer-submeta" }, enabled ? "Enabled" : "Disabled"),
+							h(
+								"div",
+								{ class: "coordinator-admin-form-grid" },
+								h(
+									"label",
+									{ class: "coordinator-admin-field" },
+									h("span", null, "Display name"),
+									h("input", {
+										class: "peer-scope-input",
+										disabled: summary.readiness !== "ready" || pending,
+										onInput: (event) => {
+											deviceRenameDrafts.set(
+												deviceId,
+												String((event.currentTarget as HTMLInputElement).value || ""),
+											);
+										},
+										value: draft,
+									}),
+								),
+							),
+							h(
+								"div",
+								{ class: "peer-actions" },
+								h(
+									"button",
+									{
+										disabled: !deviceId || pending || summary.readiness !== "ready",
+										onClick: () => void runDeviceAction(deviceId, groupId, displayName, "rename"),
+										type: "button",
+									},
+									pending && deviceActionPendingKind === "rename" ? "Renaming…" : "Rename",
+								),
+								h(
+									"button",
+									{
+										disabled: !deviceId || pending || summary.readiness !== "ready" || !enabled,
+										onClick: () => void runDeviceAction(deviceId, groupId, displayName, "disable"),
+										type: "button",
+									},
+									pending && deviceActionPendingKind === "disable" ? "Disabling…" : "Disable",
+								),
+								h(
+									"button",
+									{
+										disabled: !deviceId || pending || summary.readiness !== "ready",
+										onClick: () => void runDeviceAction(deviceId, groupId, displayName, "remove"),
+										type: "button",
+									},
+									pending && deviceActionPendingKind === "remove" ? "Removing…" : "Remove",
+								),
+							),
+						);
+					}),
+				),
+	);
+}
+
 function renderShell() {
 	const mount = document.getElementById("coordinatorAdminMount");
 	if (!mount) return;
@@ -300,10 +473,12 @@ function renderShell() {
 	const activeGroup = String(status?.active_group || "").trim();
 	const invitesEnabled = summary.readiness === "ready";
 	const joinRequestsEnabled = summary.readiness === "ready";
+	const devicesEnabled = summary.readiness === "ready";
 	if (
 		activeSection !== "overview" &&
 		((activeSection === "invites" && !invitesEnabled) ||
-			(activeSection === "join-requests" && !joinRequestsEnabled))
+			(activeSection === "join-requests" && !joinRequestsEnabled) ||
+			(activeSection === "devices" && !devicesEnabled))
 	) {
 		activeSection = "overview";
 	}
@@ -356,7 +531,7 @@ function renderShell() {
 							{ value: "overview", label: "Overview" },
 							{ value: "invites", label: "Invites", disabled: !invitesEnabled },
 							{ value: "join-requests", label: "Join requests", disabled: !joinRequestsEnabled },
-							{ value: "devices", label: "Devices", disabled: true },
+							{ value: "devices", label: "Devices", disabled: !devicesEnabled },
 						],
 						triggerClassName: "coordinator-admin-tab-trigger",
 						value: activeSection,
@@ -375,16 +550,7 @@ function renderShell() {
 					),
 					renderInvitesPanel(summary),
 					renderJoinRequestsPanel(summary),
-					h(
-						RadixTabsContent,
-						{ className: "coordinator-admin-panel", forceMount: true, value: "devices" },
-						h("h3", null, "Device admin tools land in the next slice"),
-						h(
-							"p",
-							{ class: "peer-submeta" },
-							"Device management will live here once the tab shell and invite workflow settle.",
-						),
-					),
+					renderDevicesPanel(summary),
 				),
 			),
 		),
@@ -400,18 +566,40 @@ export async function loadCoordinatorAdminData() {
 	try {
 		state.lastCoordinatorAdminStatus =
 			(await api.loadCoordinatorAdminStatus()) as typeof state.lastCoordinatorAdminStatus;
-		const activeGroup = String(state.lastCoordinatorAdminStatus?.active_group || "").trim();
-		if (state.lastCoordinatorAdminStatus?.readiness === "ready") {
+	} catch {
+		state.lastCoordinatorAdminStatus = null;
+		state.lastCoordinatorAdminJoinRequests = [];
+		state.lastCoordinatorAdminDevices = [];
+		deviceRenameDrafts.clear();
+		renderShell();
+		return;
+	}
+	const activeGroup = String(state.lastCoordinatorAdminStatus?.active_group || "").trim();
+	if (state.lastCoordinatorAdminStatus?.readiness === "ready") {
+		try {
 			const payload = (await api.loadCoordinatorAdminJoinRequests(activeGroup)) as {
 				items?: typeof state.lastCoordinatorAdminJoinRequests;
 			};
 			state.lastCoordinatorAdminJoinRequests = Array.isArray(payload?.items) ? payload.items : [];
-		} else {
+		} catch {
 			state.lastCoordinatorAdminJoinRequests = [];
 		}
-	} catch {
-		state.lastCoordinatorAdminStatus = null;
+		try {
+			const devicesPayload = (await api.loadCoordinatorAdminDevices(activeGroup, true)) as {
+				items?: typeof state.lastCoordinatorAdminDevices;
+			};
+			state.lastCoordinatorAdminDevices = Array.isArray(devicesPayload?.items)
+				? devicesPayload.items
+				: [];
+			reconcileDeviceRenameDrafts();
+		} catch {
+			state.lastCoordinatorAdminDevices = [];
+			deviceRenameDrafts.clear();
+		}
+	} else {
 		state.lastCoordinatorAdminJoinRequests = [];
+		state.lastCoordinatorAdminDevices = [];
+		deviceRenameDrafts.clear();
 	}
 	renderShell();
 }

--- a/packages/ui/src/tabs/sync/index.test.ts
+++ b/packages/ui/src/tabs/sync/index.test.ts
@@ -99,10 +99,10 @@ describe("loadSyncData", () => {
 		await secondLoad;
 		expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(["peer-new"]);
 		expect(api.loadSyncStatus).toHaveBeenNthCalledWith(1, false, "", {
-			includeJoinRequests: true,
+			includeJoinRequests: false,
 		});
 		expect(api.loadSyncStatus).toHaveBeenNthCalledWith(2, false, "", {
-			includeJoinRequests: true,
+			includeJoinRequests: false,
 		});
 
 		first.resolve({

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -109,7 +109,7 @@ export async function loadSyncData() {
 	const requestId = ++latestSyncLoadRequestId;
 	try {
 		const project = state.currentProject || "";
-		const includeJoinRequests = state.activeTab === "sync";
+		const includeJoinRequests = false;
 		const useCache = state.activeTab === "health";
 		let fetchedFreshSyncStatus = false;
 
@@ -185,9 +185,7 @@ export async function loadSyncData() {
 			coordinatorAdminStatus && typeof coordinatorAdminStatus === "object"
 				? coordinatorAdminStatus
 				: null;
-		if (Array.isArray(payload.join_requests)) {
-			state.lastSyncJoinRequests = payload.join_requests;
-		}
+		state.lastSyncJoinRequests = Array.isArray(payload.join_requests) ? payload.join_requests : [];
 		state.lastSyncAttempts = payload.attempts || [];
 		state.lastSyncLegacyDevices = payload.legacy_devices || [];
 		state.lastSyncDuplicatePersonDecisions = duplicatePersonDecisions;

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -517,11 +517,7 @@ export function renderTeamSync() {
 		};
 	});
 
-	const pending = Array.isArray(state.lastSyncJoinRequests) ? state.lastSyncJoinRequests : [];
-	const pendingJoinRequests: TeamSyncPendingJoinRequest[] = pending.map((request) => ({
-		displayName: String(request.display_name || request.device_id || "Pending device"),
-		requestId: String(request.request_id || ""),
-	}));
+	const pendingJoinRequests: TeamSyncPendingJoinRequest[] = [];
 	const visibleDiscoveredRows = discoveredRows.filter(
 		(row) => row.mode !== "paired" && row.mode !== "none" && row.mode !== "scope-pending",
 	);
@@ -628,26 +624,7 @@ export function renderTeamSync() {
 			discoveredRows: visibleDiscoveredRows,
 			joinRequestsMount: joinRequests,
 			listMount: list,
-			onApproveJoinRequest: async (request) => {
-				try {
-					await api.reviewJoinRequest(request.requestId, "approve");
-					const feedback = {
-						message: `Approved ${request.displayName}. They can now sync with the team.`,
-						tone: "success",
-					} satisfies SyncActionFeedback;
-					state.syncJoinRequestsFeedback = feedback;
-					await _loadSyncData();
-					return feedback;
-				} catch (error) {
-					return {
-						message: friendlyError(
-							error,
-							"Failed to approve join request. Keep it pending and try again after the coordinator refreshes.",
-						),
-						tone: "warning",
-					} satisfies SyncActionFeedback;
-				}
-			},
+			onApproveJoinRequest: async () => null,
 			onAttentionAction: async (item) => {
 				if (item.kind === "possible-duplicate-person") {
 					await reviewDuplicatePeople(item);
@@ -655,34 +632,7 @@ export function renderTeamSync() {
 				}
 				focusAttentionTarget(item);
 			},
-			onDenyJoinRequest: async (request) => {
-				const confirmed = await openSyncConfirmDialog({
-					title: `Deny join request from ${request.displayName}?`,
-					description: "They will need a new invite to try joining this team again.",
-					confirmLabel: "Deny request",
-					cancelLabel: "Keep request pending",
-					tone: "danger",
-				});
-				if (!confirmed) return null;
-				try {
-					await api.reviewJoinRequest(request.requestId, "deny");
-					const feedback = {
-						message: `Denied join request from ${request.displayName}.`,
-						tone: "success",
-					} satisfies SyncActionFeedback;
-					state.syncJoinRequestsFeedback = feedback;
-					await _loadSyncData();
-					return feedback;
-				} catch (error) {
-					return {
-						message: friendlyError(
-							error,
-							"Failed to deny join request. Leave it pending for now, then retry after the coordinator refreshes.",
-						),
-						tone: "warning",
-					} satisfies SyncActionFeedback;
-				}
-			},
+			onDenyJoinRequest: async () => null,
 			onInspectConflict: (row) => {
 				const peerCard = document.querySelector(
 					`[data-peer-device-id="${CSS.escape(row.deviceId)}"]`,

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -4668,68 +4668,6 @@ describe("viewer-server", () => {
 			}
 		});
 
-		it("reviews join requests through the viewer route", async () => {
-			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
-			const prevConfig = process.env.CODEMEM_CONFIG;
-			const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-				const url = String(input);
-				const requestBody = init?.body
-					? JSON.parse(new TextDecoder().decode(init.body as ArrayBufferView))
-					: {};
-				if (url.includes("/v1/admin/join-requests/approve") && requestBody.request_id === "req-1") {
-					return new Response(
-						JSON.stringify({ request: { request_id: "req-1", status: "approved" } }),
-						{ status: 200 },
-					);
-				}
-				if (
-					url.includes("/v1/admin/join-requests/approve") &&
-					requestBody.request_id === "missing"
-				) {
-					return new Response(JSON.stringify({ error: "request_not_found" }), { status: 404 });
-				}
-				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
-			});
-			const prevFetch = globalThis.fetch;
-			globalThis.fetch = fetchMock as typeof fetch;
-			process.env.CODEMEM_CONFIG = configPath;
-			writeFileSync(
-				configPath,
-				JSON.stringify({
-					sync_coordinator_url: "https://coord.example.test",
-					sync_coordinator_admin_secret: "secret",
-				}),
-			);
-			const { app, cleanup } = createTestApp();
-			try {
-				const res = await app.request("/api/sync/join-requests/review", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ request_id: "req-1", action: "approve" }),
-				});
-				expect(res.status).toBe(200);
-				const body = (await res.json()) as {
-					ok: boolean;
-					request: { request_id: string; status: string };
-				};
-				expect(body.ok).toBe(true);
-				expect(body.request.request_id).toBe("req-1");
-				expect(body.request.status).toBe("approved");
-
-				const missing = await app.request("/api/sync/join-requests/review", {
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ request_id: "missing", action: "approve" }),
-				});
-				expect(missing.status).toBe(404);
-			} finally {
-				cleanup();
-				globalThis.fetch = prevFetch;
-				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
-				else process.env.CODEMEM_CONFIG = prevConfig;
-			}
-		});
-
 		it("reports coordinator admin readiness states", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;
@@ -4928,6 +4866,73 @@ describe("viewer-server", () => {
 						items: [expect.objectContaining({ device_id: "device-1", display_name: "Laptop" })],
 						status: expect.objectContaining({ readiness: "ready" }),
 					});
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
+		it("runs coordinator device admin actions through the admin routes", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/devices/rename")) {
+					return new Response(
+						JSON.stringify({
+							device: { device_id: "device-1", group_id: "team-a", display_name: "Renamed" },
+						}),
+						{ status: 200 },
+					);
+				}
+				if (url.includes("/v1/admin/devices/disable")) {
+					return new Response(JSON.stringify({ ok: true }), { status: 200 });
+				}
+				if (url.includes("/v1/admin/devices/remove")) {
+					return new Response(JSON.stringify({ ok: true }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const renamed = await app.request("/api/coordinator/admin/devices/device-1/rename", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ display_name: "Renamed" }),
+					});
+					expect(renamed.status).toBe(200);
+					expect(await renamed.json()).toMatchObject({
+						ok: true,
+						device: expect.objectContaining({ device_id: "device-1", display_name: "Renamed" }),
+					});
+
+					const disabled = await app.request("/api/coordinator/admin/devices/device-1/disable", {
+						method: "POST",
+					});
+					expect(disabled.status).toBe(200);
+					expect(await disabled.json()).toMatchObject({ ok: true, device_id: "device-1" });
+
+					const removed = await app.request("/api/coordinator/admin/devices/device-1/remove", {
+						method: "POST",
+					});
+					expect(removed.status).toBe(200);
+					expect(await removed.json()).toMatchObject({ ok: true, device_id: "device-1" });
 				} finally {
 					cleanup();
 				}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -18,10 +18,13 @@ import {
 	buildBaseUrl,
 	cleanupNonces,
 	coordinatorCreateInviteAction,
+	coordinatorDisableDeviceAction,
 	coordinatorImportInviteAction,
 	coordinatorListBootstrapGrantsAction,
 	coordinatorListDevicesAction,
 	coordinatorListJoinRequestsAction,
+	coordinatorRemoveDeviceAction,
+	coordinatorRenameDeviceAction,
 	coordinatorReviewJoinRequestAction,
 	coordinatorRevokeBootstrapGrantAction,
 	coordinatorStatusSnapshot,
@@ -110,6 +113,12 @@ function resolveCoordinatorAdminGroup(
 	const explicit = String(requestedGroup ?? "").trim();
 	if (explicit) return explicit;
 	return status.active_group;
+}
+
+function parseInviteTtlHours(value: unknown): number | null {
+	const ttlHours = Number(String(value ?? 24));
+	if (!Number.isInteger(ttlHours) || ttlHours < 1) return null;
+	return ttlHours;
 }
 
 function sortActiveMaintenanceJobs<
@@ -1971,7 +1980,7 @@ export function syncRoutes(
 		const groupId = String(body.group_id ?? "").trim();
 		const coordinatorUrl = body.coordinator_url == null ? null : String(body.coordinator_url ?? "");
 		const policy = String(body.policy ?? "auto_admit").trim();
-		const ttlHours = Number.parseInt(String(body.ttl_hours ?? 24), 10);
+		const ttlHours = parseInviteTtlHours(body.ttl_hours);
 		if (!groupId) return c.json({ error: "group_id required" }, 400);
 		if (body.coordinator_url != null && typeof body.coordinator_url !== "string") {
 			return c.json({ error: "coordinator_url must be string" }, 400);
@@ -1979,7 +1988,7 @@ export function syncRoutes(
 		if (!["auto_admit", "approval_required"].includes(policy)) {
 			return c.json({ error: "policy must be auto_admit or approval_required" }, 400);
 		}
-		if (!Number.isFinite(ttlHours)) return c.json({ error: "ttl_hours must be int" }, 400);
+		if (ttlHours == null) return c.json({ error: "ttl_hours must be an integer >= 1" }, 400);
 		try {
 			const config = readCoordinatorSyncConfig();
 			const result = await coordinatorCreateInviteAction({
@@ -2015,39 +2024,6 @@ export function syncRoutes(
 		}
 	});
 
-	app.post("/api/sync/join-requests/review", async (c) => {
-		let body: Record<string, unknown>;
-		try {
-			body = await c.req.json<Record<string, unknown>>();
-		} catch {
-			return c.json({ error: "invalid json" }, 400);
-		}
-		const requestId = String(body.request_id ?? "").trim();
-		const action = String(body.action ?? "").trim();
-		if (!requestId) return c.json({ error: "request_id required" }, 400);
-		if (!["approve", "deny"].includes(action)) {
-			return c.json({ error: "action must be approve or deny" }, 400);
-		}
-		try {
-			const config = readCoordinatorSyncConfig();
-			const result = await coordinatorReviewJoinRequestAction({
-				requestId,
-				approve: action === "approve",
-				reviewedBy: null,
-				remoteUrl: config.syncCoordinatorUrl || null,
-				adminSecret: config.syncCoordinatorAdminSecret || null,
-			});
-			if (!result) return c.json({ error: "join request not found" }, 404);
-			return c.json({ ok: true, request: result });
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			return c.json(
-				{ error: message },
-				message.includes("request_not_found") || message.includes("not found") ? 404 : 400,
-			);
-		}
-	});
-
 	app.get("/api/coordinator/admin/status", async (c) => {
 		const status = coordinatorAdminStatusPayload();
 		return c.json(status);
@@ -2071,7 +2047,7 @@ export function syncRoutes(
 		const groupId = resolveCoordinatorAdminGroup(String(body.group_id ?? "").trim(), status);
 		const coordinatorUrl = body.coordinator_url == null ? null : String(body.coordinator_url ?? "");
 		const policy = String(body.policy ?? "auto_admit").trim();
-		const ttlHours = Number.parseInt(String(body.ttl_hours ?? 24), 10);
+		const ttlHours = parseInviteTtlHours(body.ttl_hours);
 		if (!groupId) return c.json({ error: "group_id required", status }, 400);
 		if (body.coordinator_url != null && typeof body.coordinator_url !== "string") {
 			return c.json({ error: "coordinator_url must be string", status }, 400);
@@ -2079,8 +2055,8 @@ export function syncRoutes(
 		if (!["auto_admit", "approval_required"].includes(policy)) {
 			return c.json({ error: "policy must be auto_admit or approval_required", status }, 400);
 		}
-		if (!Number.isFinite(ttlHours)) {
-			return c.json({ error: "ttl_hours must be int", status }, 400);
+		if (ttlHours == null) {
+			return c.json({ error: "ttl_hours must be an integer >= 1", status }, 400);
 		}
 		try {
 			const result = await coordinatorCreateInviteAction({
@@ -2204,6 +2180,96 @@ export function syncRoutes(
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "unknown";
 			return c.json({ error: message, status }, 502);
+		}
+	});
+
+	app.post("/api/coordinator/admin/devices/:device_id/rename", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const deviceId = String(c.req.param("device_id") ?? "").trim();
+		if (!deviceId) return c.json({ error: "device_id required", status }, 400);
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json", status }, 400);
+		}
+		const groupId = resolveCoordinatorAdminGroup(String(body.group_id ?? "").trim(), status);
+		const displayName = String(body.display_name ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id required", status }, 400);
+		if (!displayName) return c.json({ error: "display_name required", status }, 400);
+		try {
+			const device = await coordinatorRenameDeviceAction({
+				groupId,
+				deviceId,
+				displayName,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!device) return c.json({ error: "device_not_found", status }, 404);
+			return c.json({ ok: true, device, status });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
+		}
+	});
+
+	app.post("/api/coordinator/admin/devices/:device_id/disable", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const deviceId = String(c.req.param("device_id") ?? "").trim();
+		if (!deviceId) return c.json({ error: "device_id required", status }, 400);
+		const groupId = resolveCoordinatorAdminGroup(c.req.query("group_id"), status);
+		if (!groupId) return c.json({ error: "group_id required", status }, 400);
+		try {
+			const ok = await coordinatorDisableDeviceAction({
+				groupId,
+				deviceId,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!ok) return c.json({ error: "device_not_found", status }, 404);
+			return c.json({ ok: true, device_id: deviceId, status });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
+		}
+	});
+
+	app.post("/api/coordinator/admin/devices/:device_id/remove", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const deviceId = String(c.req.param("device_id") ?? "").trim();
+		if (!deviceId) return c.json({ error: "device_id required", status }, 400);
+		const groupId = resolveCoordinatorAdminGroup(c.req.query("group_id"), status);
+		if (!groupId) return c.json({ error: "group_id required", status }, 400);
+		try {
+			const ok = await coordinatorRemoveDeviceAction({
+				groupId,
+				deviceId,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!ok) return c.json({ error: "device_not_found", status }, 404);
+			return c.json({ ok: true, device_id: deviceId, status });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
 		}
 	});
 


### PR DESCRIPTION
## Description
Adds enrolled device management in Coordinator Admin, including list, rename, disable, and remove flows with confirmation and explicit group-aware routing.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced