### PR TITLE
feat(coordinator): add group lifecycle management

### DIFF
--- a/packages/cloudflare-coordinator-worker/migrations/0004_add_group_archival.sql
+++ b/packages/cloudflare-coordinator-worker/migrations/0004_add_group_archival.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups ADD COLUMN archived_at TEXT;

--- a/packages/cloudflare-coordinator-worker/schema.sql
+++ b/packages/cloudflare-coordinator-worker/schema.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS groups (
   group_id TEXT PRIMARY KEY,
   display_name TEXT,
+  archived_at TEXT,
   created_at TEXT NOT NULL
 );
 

--- a/packages/core/src/better-sqlite-coordinator-store.ts
+++ b/packages/core/src/better-sqlite-coordinator-store.ts
@@ -160,6 +160,7 @@ function initializeSchema(db: DatabaseType): void {
 		CREATE TABLE IF NOT EXISTS groups (
 			group_id TEXT PRIMARY KEY,
 			display_name TEXT,
+			archived_at TEXT,
 			created_at TEXT NOT NULL
 		);
 
@@ -238,6 +239,11 @@ function initializeSchema(db: DatabaseType): void {
 			revoked_at TEXT
 		);
 	`);
+	try {
+		db.prepare("ALTER TABLE groups ADD COLUMN archived_at TEXT").run();
+	} catch {
+		// already exists
+	}
 }
 
 export function connectCoordinator(path?: string): DatabaseType {
@@ -287,22 +293,52 @@ export class BetterSqliteCoordinatorStore implements CoordinatorStore {
 
 	async createGroup(groupId: string, displayName?: string | null): Promise<void> {
 		this.db
-			.prepare("INSERT OR IGNORE INTO groups(group_id, display_name, created_at) VALUES (?, ?, ?)")
+			.prepare(
+				"INSERT OR IGNORE INTO groups(group_id, display_name, archived_at, created_at) VALUES (?, ?, NULL, ?)",
+			)
 			.run(groupId, displayName ?? null, nowISO());
 	}
 
 	async getGroup(groupId: string): Promise<CoordinatorGroup | null> {
 		const row = this.db
-			.prepare("SELECT group_id, display_name, created_at FROM groups WHERE group_id = ?")
+			.prepare(
+				"SELECT group_id, display_name, archived_at, created_at FROM groups WHERE group_id = ?",
+			)
 			.get(groupId);
 		return row ? rowToRecord<CoordinatorGroup>(row) : null;
 	}
 
-	async listGroups(): Promise<CoordinatorGroup[]> {
+	async listGroups(includeArchived = false): Promise<CoordinatorGroup[]> {
+		const where = includeArchived ? "" : "WHERE archived_at IS NULL";
 		return this.db
-			.prepare("SELECT group_id, display_name, created_at FROM groups ORDER BY created_at ASC")
+			.prepare(
+				`SELECT group_id, display_name, archived_at, created_at FROM groups ${where} ORDER BY created_at ASC`,
+			)
 			.all()
 			.map((row) => rowToRecord<CoordinatorGroup>(row));
+	}
+
+	async renameGroup(groupId: string, displayName: string): Promise<boolean> {
+		const result = this.db
+			.prepare("UPDATE groups SET display_name = ? WHERE group_id = ?")
+			.run(displayName, groupId);
+		return result.changes > 0;
+	}
+
+	async archiveGroup(groupId: string, archivedAt = nowISO()): Promise<boolean> {
+		const result = this.db
+			.prepare("UPDATE groups SET archived_at = ? WHERE group_id = ? AND archived_at IS NULL")
+			.run(archivedAt, groupId);
+		return result.changes > 0;
+	}
+
+	async unarchiveGroup(groupId: string): Promise<boolean> {
+		const result = this.db
+			.prepare(
+				"UPDATE groups SET archived_at = NULL WHERE group_id = ? AND archived_at IS NOT NULL",
+			)
+			.run(groupId);
+		return result.changes > 0;
 	}
 
 	async enrollDevice(groupId: string, opts: CoordinatorEnrollDeviceInput): Promise<void> {

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -161,9 +161,26 @@ export async function coordinatorCreateGroupAction(opts: {
 	groupId: string;
 	displayName?: string | null;
 	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
 }): Promise<CoordinatorGroup> {
 	const groupId = String(opts.groupId ?? "").trim();
 	if (!groupId) throw new Error("Group id required.");
+	const remote = opts.remoteUrl ?? null;
+	const adminSecret = opts.adminSecret ?? null;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		const payload = await remoteRequest(
+			"POST",
+			`${remote.replace(/\/+$/, "")}/v1/admin/groups`,
+			adminSecret,
+			{ group_id: groupId, display_name: opts.displayName ?? null },
+		);
+		const group = payload?.group;
+		if (!group || typeof group !== "object")
+			throw new Error("Remote coordinator did not return group payload.");
+		return group as CoordinatorGroup;
+	}
 	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
 		await store.createGroup(groupId, opts.displayName ?? null);
@@ -175,12 +192,146 @@ export async function coordinatorCreateGroupAction(opts: {
 	}
 }
 
+export async function coordinatorRenameGroupAction(opts: {
+	groupId: string;
+	displayName: string;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<CoordinatorGroup | null> {
+	const groupId = String(opts.groupId ?? "").trim();
+	const displayName = String(opts.displayName ?? "").trim();
+	if (!groupId || !displayName) throw new Error("group_id and display_name are required.");
+	const remote = opts.remoteUrl ?? null;
+	const adminSecret = opts.adminSecret ?? null;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		let payload: Record<string, unknown> | null;
+		try {
+			payload = await remoteRequest(
+				"POST",
+				`${remote.replace(/\/+$/, "")}/v1/admin/groups/rename`,
+				adminSecret,
+				{ group_id: groupId, display_name: displayName },
+			);
+		} catch (error) {
+			if (error instanceof Error && error.message.includes("group_not_found")) return null;
+			throw error;
+		}
+		const group = payload?.group;
+		return group && typeof group === "object" ? (group as CoordinatorGroup) : null;
+	}
+	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		const ok = await store.renameGroup(groupId, displayName);
+		if (!ok) return null;
+		return await store.getGroup(groupId);
+	} finally {
+		await store.close();
+	}
+}
+
+export async function coordinatorArchiveGroupAction(opts: {
+	groupId: string;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<CoordinatorGroup | null> {
+	const groupId = String(opts.groupId ?? "").trim();
+	if (!groupId) throw new Error("Group id required.");
+	const remote = opts.remoteUrl ?? null;
+	const adminSecret = opts.adminSecret ?? null;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		let payload: Record<string, unknown> | null;
+		try {
+			payload = await remoteRequest(
+				"POST",
+				`${remote.replace(/\/+$/, "")}/v1/admin/groups/archive`,
+				adminSecret,
+				{ group_id: groupId },
+			);
+		} catch (error) {
+			if (error instanceof Error && error.message.includes("group_not_found_or_already_archived"))
+				return null;
+			throw error;
+		}
+		const group = payload?.group;
+		return group && typeof group === "object" ? (group as CoordinatorGroup) : null;
+	}
+	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		const ok = await store.archiveGroup(groupId);
+		if (!ok) return null;
+		return await store.getGroup(groupId);
+	} finally {
+		await store.close();
+	}
+}
+
+export async function coordinatorUnarchiveGroupAction(opts: {
+	groupId: string;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<CoordinatorGroup | null> {
+	const groupId = String(opts.groupId ?? "").trim();
+	if (!groupId) throw new Error("Group id required.");
+	const remote = opts.remoteUrl ?? null;
+	const adminSecret = opts.adminSecret ?? null;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		let payload: Record<string, unknown> | null;
+		try {
+			payload = await remoteRequest(
+				"POST",
+				`${remote.replace(/\/+$/, "")}/v1/admin/groups/unarchive`,
+				adminSecret,
+				{ group_id: groupId },
+			);
+		} catch (error) {
+			if (error instanceof Error && error.message.includes("group_not_found_or_not_archived"))
+				return null;
+			throw error;
+		}
+		const group = payload?.group;
+		return group && typeof group === "object" ? (group as CoordinatorGroup) : null;
+	}
+	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		const ok = await store.unarchiveGroup(groupId);
+		if (!ok) return null;
+		return await store.getGroup(groupId);
+	} finally {
+		await store.close();
+	}
+}
+
 export async function coordinatorListGroupsAction(opts?: {
 	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+	includeArchived?: boolean;
 }): Promise<CoordinatorGroup[]> {
+	const remote = opts?.remoteUrl ?? null;
+	const adminSecret = opts?.adminSecret ?? null;
+	const includeArchived = opts?.includeArchived === true;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		const payload = await remoteRequest(
+			"GET",
+			`${remote.replace(/\/+$/, "")}/v1/admin/groups${includeArchived ? "?include_archived=1" : ""}`,
+			adminSecret,
+		);
+		return Array.isArray(payload?.items)
+			? payload.items.filter(
+					(row): row is CoordinatorGroup => Boolean(row) && typeof row === "object",
+				)
+			: [];
+	}
 	const store = new BetterSqliteCoordinatorStore(opts?.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
 	try {
-		return await store.listGroups();
+		return await store.listGroups(includeArchived);
 	} finally {
 		await store.close();
 	}

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -521,6 +521,129 @@ export function createCoordinatorApp(
 		return c.json({ ok: true });
 	});
 
+	// GET /v1/admin/groups — list coordinator groups
+	app.get("/v1/admin/groups", async (c) => {
+		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
+
+		const includeArchived = ["1", "true", "yes"].includes(
+			(c.req.query("include_archived") ?? "0").trim().toLowerCase(),
+		);
+
+		const store = createStore();
+		try {
+			return c.json({ items: await store.listGroups(includeArchived) });
+		} finally {
+			await store.close();
+		}
+	});
+
+	app.post("/v1/admin/groups", async (c) => {
+		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
+
+		const raw = await readRequestBytes(c);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
+		const data = parseJsonObject(raw);
+		if (!data) return c.json({ error: "invalid_json" }, 400);
+
+		const groupId = String(data.group_id ?? "").trim();
+		const displayName = String(data.display_name ?? "").trim() || null;
+		if (!groupId) return c.json({ error: "group_id_required" }, 400);
+
+		const store = createStore();
+		try {
+			await store.createGroup(groupId, displayName);
+			return c.json({ ok: true, group: await store.getGroup(groupId) });
+		} finally {
+			await store.close();
+		}
+	});
+
+	app.post("/v1/admin/groups/rename", async (c) => {
+		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
+
+		const raw = await readRequestBytes(c);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
+		const data = parseJsonObject(raw);
+		if (!data) return c.json({ error: "invalid_json" }, 400);
+
+		const groupId = String(data.group_id ?? "").trim();
+		const displayName = String(data.display_name ?? "").trim();
+		if (!groupId || !displayName) {
+			return c.json({ error: "group_id_and_display_name_required" }, 400);
+		}
+
+		const store = createStore();
+		try {
+			const ok = await store.renameGroup(groupId, displayName);
+			if (!ok) return c.json({ error: "group_not_found" }, 404);
+			return c.json({ ok: true, group: await store.getGroup(groupId) });
+		} finally {
+			await store.close();
+		}
+	});
+
+	app.post("/v1/admin/groups/archive", async (c) => {
+		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
+
+		const raw = await readRequestBytes(c);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
+		const data = parseJsonObject(raw);
+		if (!data) return c.json({ error: "invalid_json" }, 400);
+
+		const groupId = String(data.group_id ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id_required" }, 400);
+
+		const store = createStore();
+		try {
+			const ok = await store.archiveGroup(groupId, runtime.now());
+			if (!ok) return c.json({ error: "group_not_found_or_already_archived" }, 404);
+			return c.json({ ok: true, group: await store.getGroup(groupId) });
+		} finally {
+			await store.close();
+		}
+	});
+
+	app.post("/v1/admin/groups/unarchive", async (c) => {
+		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
+
+		const raw = await readRequestBytes(c);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
+		const data = parseJsonObject(raw);
+		if (!data) return c.json({ error: "invalid_json" }, 400);
+
+		const groupId = String(data.group_id ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id_required" }, 400);
+
+		const store = createStore();
+		try {
+			const ok = await store.unarchiveGroup(groupId);
+			if (!ok) return c.json({ error: "group_not_found_or_not_archived" }, 404);
+			return c.json({ ok: true, group: await store.getGroup(groupId) });
+		} finally {
+			await store.close();
+		}
+	});
+
 	// GET /v1/admin/devices — list enrolled devices
 	app.get("/v1/admin/devices", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
@@ -676,6 +799,7 @@ export function createCoordinatorApp(
 		try {
 			const group = await store.getGroup(groupId);
 			if (!group) return c.json({ error: "group_not_found" }, 404);
+			if (group.archived_at) return c.json({ error: "group_archived" }, 409);
 
 			const invite = await store.createInvite({
 				groupId,
@@ -861,6 +985,9 @@ export function createCoordinatorApp(
 		try {
 			const invite = await store.getInviteByToken(token);
 			if (!invite) return c.json({ error: "invalid_token" }, 404);
+			const group = await store.getGroup(String(invite.group_id));
+			if (!group) return c.json({ error: "group_not_found" }, 404);
+			if (group.archived_at) return c.json({ error: "group_archived" }, 409);
 
 			if (invite.revoked_at) return c.json({ error: "revoked_token" }, 400);
 

--- a/packages/core/src/coordinator-store-contract.ts
+++ b/packages/core/src/coordinator-store-contract.ts
@@ -1,6 +1,7 @@
 export interface CoordinatorGroup {
 	group_id: string;
 	display_name: string | null;
+	archived_at: string | null;
 	created_at: string;
 }
 
@@ -154,7 +155,10 @@ export interface CoordinatorStore {
 	close(): Promise<void>;
 	createGroup(groupId: string, displayName?: string | null): Promise<void>;
 	getGroup(groupId: string): Promise<CoordinatorGroup | null>;
-	listGroups(): Promise<CoordinatorGroup[]>;
+	listGroups(includeArchived?: boolean): Promise<CoordinatorGroup[]>;
+	renameGroup(groupId: string, displayName: string): Promise<boolean>;
+	archiveGroup(groupId: string, archivedAt?: string): Promise<boolean>;
+	unarchiveGroup(groupId: string): Promise<boolean>;
 	enrollDevice(groupId: string, opts: CoordinatorEnrollDeviceInput): Promise<void>;
 	listEnrolledDevices(groupId: string, includeDisabled?: boolean): Promise<CoordinatorEnrollment[]>;
 	getEnrollment(groupId: string, deviceId: string): Promise<CoordinatorEnrollment | null>;

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -58,6 +58,33 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 					expect(await store.listGroups()).toHaveLength(2);
 				});
 			});
+
+			it("renames a group", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1", "Original");
+					expect(await store.renameGroup("g1", "Renamed")).toBe(true);
+					const group = await store.getGroup("g1");
+					expect(group?.display_name).toBe("Renamed");
+				});
+			});
+
+			it("archives and unarchives a group", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("g1", "Team Alpha");
+					expect(await store.archiveGroup("g1", "2026-04-14T00:00:00.000Z")).toBe(true);
+					expect(await store.listGroups()).toEqual([]);
+					expect(await store.listGroups(true)).toEqual([
+						expect.objectContaining({
+							group_id: "g1",
+							archived_at: "2026-04-14T00:00:00.000Z",
+						}),
+					]);
+					expect(await store.unarchiveGroup("g1")).toBe(true);
+					expect(await store.listGroups()).toEqual([
+						expect.objectContaining({ group_id: "g1", archived_at: null }),
+					]);
+				});
+			});
 		});
 
 		describe("devices", () => {

--- a/packages/core/src/d1-coordinator-store.ts
+++ b/packages/core/src/d1-coordinator-store.ts
@@ -191,7 +191,9 @@ export class D1CoordinatorStore implements CoordinatorStore {
 
 	async createGroup(_groupId: string, _displayName?: string | null): Promise<void> {
 		await this.db
-			.prepare("INSERT OR IGNORE INTO groups(group_id, display_name, created_at) VALUES (?, ?, ?)")
+			.prepare(
+				"INSERT OR IGNORE INTO groups(group_id, display_name, archived_at, created_at) VALUES (?, ?, NULL, ?)",
+			)
 			.bind(_groupId, _displayName ?? null, nowISO())
 			.run();
 	}
@@ -199,20 +201,55 @@ export class D1CoordinatorStore implements CoordinatorStore {
 	async getGroup(_groupId: string): Promise<CoordinatorGroup | null> {
 		const row = await firstRow<CoordinatorGroup>(
 			this.db
-				.prepare("SELECT group_id, display_name, created_at FROM groups WHERE group_id = ?")
+				.prepare(
+					"SELECT group_id, display_name, archived_at, created_at FROM groups WHERE group_id = ?",
+				)
 				.bind(_groupId),
 		);
 		return row ? rowToRecord<CoordinatorGroup>(row) : null;
 	}
 
-	async listGroups(): Promise<CoordinatorGroup[]> {
+	async listGroups(_includeArchived = false): Promise<CoordinatorGroup[]> {
+		const where = _includeArchived ? "" : "WHERE archived_at IS NULL";
 		return (
 			await allRows<CoordinatorGroup>(
 				this.db.prepare(
-					"SELECT group_id, display_name, created_at FROM groups ORDER BY created_at ASC",
+					`SELECT group_id, display_name, archived_at, created_at FROM groups ${where} ORDER BY created_at ASC`,
 				),
 			)
 		).map((row) => rowToRecord<CoordinatorGroup>(row));
+	}
+
+	async renameGroup(_groupId: string, _displayName: string): Promise<boolean> {
+		return (
+			(await runChanges(
+				this.db
+					.prepare("UPDATE groups SET display_name = ? WHERE group_id = ?")
+					.bind(_displayName, _groupId),
+			)) > 0
+		);
+	}
+
+	async archiveGroup(_groupId: string, _archivedAt = nowISO()): Promise<boolean> {
+		return (
+			(await runChanges(
+				this.db
+					.prepare("UPDATE groups SET archived_at = ? WHERE group_id = ? AND archived_at IS NULL")
+					.bind(_archivedAt, _groupId),
+			)) > 0
+		);
+	}
+
+	async unarchiveGroup(_groupId: string): Promise<boolean> {
+		return (
+			(await runChanges(
+				this.db
+					.prepare(
+						"UPDATE groups SET archived_at = NULL WHERE group_id = ? AND archived_at IS NOT NULL",
+					)
+					.bind(_groupId),
+			)) > 0
+		);
 	}
 
 	async enrollDevice(_groupId: string, _opts: CoordinatorEnrollDeviceInput): Promise<void> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
 	resolveHookProject,
 } from "./claude-hooks.js";
 export {
+	coordinatorArchiveGroupAction,
 	coordinatorCreateGroupAction,
 	coordinatorCreateInviteAction,
 	coordinatorDisableDeviceAction,
@@ -32,8 +33,10 @@ export {
 	coordinatorListJoinRequestsAction,
 	coordinatorRemoveDeviceAction,
 	coordinatorRenameDeviceAction,
+	coordinatorRenameGroupAction,
 	coordinatorReviewJoinRequestAction,
 	coordinatorRevokeBootstrapGrantAction,
+	coordinatorUnarchiveGroupAction,
 } from "./coordinator-actions.js";
 export type {
 	CoordinatorRequestVerifier,

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -4784,6 +4784,149 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("lists coordinator groups through the admin route", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.includes("/v1/admin/groups")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{ group_id: "team-a", display_name: "Team A" },
+								{ group_id: "nerdworld", display_name: "Nerdworld" },
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const res = await app.request("/api/coordinator/admin/groups");
+					expect(res.status).toBe(200);
+					expect(await res.json()).toMatchObject({
+						items: [
+							expect.objectContaining({ group_id: "team-a" }),
+							expect.objectContaining({ group_id: "nerdworld" }),
+						],
+						status: expect.objectContaining({ readiness: "ready" }),
+					});
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
+		it("runs coordinator group lifecycle actions through the admin routes", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (
+					url.includes("/v1/admin/groups") &&
+					!url.includes("rename") &&
+					!url.includes("archive") &&
+					!url.includes("unarchive")
+				) {
+					return new Response(
+						JSON.stringify({
+							group: { group_id: "team-a", display_name: "Team A", archived_at: null },
+						}),
+						{ status: 200 },
+					);
+				}
+				if (url.includes("/v1/admin/groups/rename")) {
+					return new Response(
+						JSON.stringify({
+							group: { group_id: "team-a", display_name: "Renamed", archived_at: null },
+						}),
+						{ status: 200 },
+					);
+				}
+				if (url.includes("/v1/admin/groups/archive")) {
+					return new Response(
+						JSON.stringify({
+							group: {
+								group_id: "team-a",
+								display_name: "Renamed",
+								archived_at: "2026-04-14T00:00:00Z",
+							},
+						}),
+						{ status: 200 },
+					);
+				}
+				if (url.includes("/v1/admin/groups/unarchive")) {
+					return new Response(
+						JSON.stringify({
+							group: { group_id: "team-a", display_name: "Renamed", archived_at: null },
+						}),
+						{ status: 200 },
+					);
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			try {
+				process.env.CODEMEM_CONFIG = configPath;
+				writeFileSync(
+					configPath,
+					JSON.stringify({
+						sync_coordinator_url: "https://coord.example.test",
+						sync_coordinator_group: "team-a",
+						sync_coordinator_admin_secret: "secret",
+					}),
+				);
+				globalThis.fetch = fetchMock as typeof fetch;
+				const { app, cleanup } = createTestApp();
+				try {
+					const created = await app.request("/api/coordinator/admin/groups", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ group_id: "team-a", display_name: "Team A" }),
+					});
+					expect(created.status).toBe(200);
+					const renamed = await app.request("/api/coordinator/admin/groups/team-a/rename", {
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ display_name: "Renamed" }),
+					});
+					expect(renamed.status).toBe(200);
+					const archived = await app.request("/api/coordinator/admin/groups/team-a/archive", {
+						method: "POST",
+					});
+					expect(archived.status).toBe(200);
+					const unarchived = await app.request("/api/coordinator/admin/groups/team-a/unarchive", {
+						method: "POST",
+					});
+					expect(unarchived.status).toBe(200);
+				} finally {
+					cleanup();
+				}
+			} finally {
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				globalThis.fetch = prevFetch;
+			}
+		});
+
 		it("reviews coordinator join requests through the admin route", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -17,17 +17,22 @@ import {
 	applyReplicationOps,
 	buildBaseUrl,
 	cleanupNonces,
+	coordinatorArchiveGroupAction,
+	coordinatorCreateGroupAction,
 	coordinatorCreateInviteAction,
 	coordinatorDisableDeviceAction,
 	coordinatorImportInviteAction,
 	coordinatorListBootstrapGrantsAction,
 	coordinatorListDevicesAction,
+	coordinatorListGroupsAction,
 	coordinatorListJoinRequestsAction,
 	coordinatorRemoveDeviceAction,
 	coordinatorRenameDeviceAction,
+	coordinatorRenameGroupAction,
 	coordinatorReviewJoinRequestAction,
 	coordinatorRevokeBootstrapGrantAction,
 	coordinatorStatusSnapshot,
+	coordinatorUnarchiveGroupAction,
 	createCoordinatorReciprocalApproval,
 	DEFAULT_TIME_WINDOW_S,
 	ensureDeviceIdentity,
@@ -2027,6 +2032,141 @@ export function syncRoutes(
 	app.get("/api/coordinator/admin/status", async (c) => {
 		const status = coordinatorAdminStatusPayload();
 		return c.json(status);
+	});
+
+	app.get("/api/coordinator/admin/groups", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const includeArchived = queryBool(c.req.query("include_archived"));
+		try {
+			const items = await coordinatorListGroupsAction({
+				includeArchived,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			return c.json({ items, status });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "unknown";
+			return c.json({ error: message, status }, 502);
+		}
+	});
+
+	app.post("/api/coordinator/admin/groups", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json", status }, 400);
+		}
+		const groupId = String(body.group_id ?? "").trim();
+		const displayName = String(body.display_name ?? "").trim() || null;
+		if (!groupId) return c.json({ error: "group_id required", status }, 400);
+		try {
+			const group = await coordinatorCreateGroupAction({
+				groupId,
+				displayName,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			return c.json({ ok: true, group, status });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
+		}
+	});
+
+	app.post("/api/coordinator/admin/groups/:group_id/rename", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const groupId = String(c.req.param("group_id") ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id required", status }, 400);
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid json", status }, 400);
+		}
+		const displayName = String(body.display_name ?? "").trim();
+		if (!displayName) return c.json({ error: "display_name required", status }, 400);
+		try {
+			const group = await coordinatorRenameGroupAction({
+				groupId,
+				displayName,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!group) return c.json({ error: "group_not_found", status }, 404);
+			return c.json({ ok: true, group, status });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
+		}
+	});
+
+	app.post("/api/coordinator/admin/groups/:group_id/archive", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const groupId = String(c.req.param("group_id") ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id required", status }, 400);
+		try {
+			const group = await coordinatorArchiveGroupAction({
+				groupId,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!group) return c.json({ error: "group_not_found_or_already_archived", status }, 404);
+			return c.json({ ok: true, group, status });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
+		}
+	});
+
+	app.post("/api/coordinator/admin/groups/:group_id/unarchive", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const groupId = String(c.req.param("group_id") ?? "").trim();
+		if (!groupId) return c.json({ error: "group_id required", status }, 400);
+		try {
+			const group = await coordinatorUnarchiveGroupAction({
+				groupId,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!group) return c.json({ error: "group_not_found_or_not_archived", status }, 404);
+			return c.json({ ok: true, group, status });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
+		}
 	});
 
 	app.post("/api/coordinator/admin/invites", async (c) => {


### PR DESCRIPTION
## Description
Adds coordinator group lifecycle support across the backend stack: archived groups, active-vs-archived listing, rename/archive/unarchive operations, archived-group enforcement for invites and joins, Cloudflare schema updates, and viewer-server proxy routes for the new admin lifecycle actions.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced