### PR TITLE
feat(viewer): add coordinator admin group management

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -436,33 +436,68 @@
         gap: var(--sp-5);
       }
 
-      .coordinator-admin-hero,
+      .coordinator-admin-header,
       .coordinator-admin-sections {
         display: grid;
         gap: var(--sp-3);
       }
 
-      .coordinator-admin-meta-grid {
+      .coordinator-admin-summary-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
         gap: var(--sp-3);
       }
 
-      .coordinator-admin-meta-grid div {
+      .coordinator-admin-summary-card {
         border: 1px solid var(--border);
         border-radius: var(--radius-md);
         padding: var(--sp-3);
         background: var(--surface-0);
+        display: grid;
+        gap: 6px;
       }
 
-      .coordinator-admin-meta-grid dt {
-        color: var(--text-tertiary);
-        font-size: 12px;
-        margin-bottom: var(--sp-1);
+      .coordinator-admin-summary-card strong {
+        font-size: 16px;
+        line-height: 1.3;
       }
 
-      .coordinator-admin-meta-grid dd {
-        font-weight: 600;
+      .coordinator-admin-inline-warning {
+        border: 1px solid rgba(240, 180, 41, 0.28);
+        background: rgba(240, 180, 41, 0.08);
+        border-radius: var(--radius-md);
+        padding: var(--sp-3);
+      }
+
+      .coordinator-admin-inline-meta {
+        margin-top: -4px;
+      }
+
+      .coordinator-admin-context-line {
+        padding-top: var(--sp-2);
+        border-top: 1px solid var(--border);
+      }
+
+      .coordinator-admin-groups-context {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: var(--sp-3);
+      }
+
+      .coordinator-admin-context-pair {
+        display: grid;
+        gap: 4px;
+        min-width: 0;
+        padding: var(--sp-2) 0;
+      }
+
+      .coordinator-admin-context-pair strong {
+        font-size: 16px;
+        line-height: 1.2;
+      }
+
+      .coordinator-admin-context-counts strong {
+        white-space: nowrap;
       }
 
       .coordinator-admin-tabs-list {
@@ -499,7 +534,8 @@
       }
 
       .coordinator-admin-panel h3 {
-        font-size: 15px;
+        font-size: 18px;
+        line-height: 1.25;
         margin: 0;
       }
 
@@ -526,6 +562,89 @@
 
       .coordinator-admin-warning-list {
         color: var(--status-attention);
+      }
+
+      .coordinator-admin-groups-toolbar {
+        justify-content: flex-start;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      .coordinator-admin-primary-actions,
+      .coordinator-admin-secondary-actions {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .coordinator-admin-inline-filter {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .coordinator-admin-inline-filter .section-meta {
+        line-height: 1;
+        margin: 0;
+      }
+
+      .coordinator-admin-switch {
+        width: 34px;
+        height: 20px;
+        border: 1px solid color-mix(in srgb, var(--text-tertiary) 42%, var(--control-border));
+        border-radius: var(--radius-pill);
+        background: color-mix(in srgb, var(--surface-1) 82%, var(--surface-0));
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-tertiary) 8%, transparent);
+        cursor: pointer;
+        flex-shrink: 0;
+        padding: 1px;
+        transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      .coordinator-admin-switch:hover {
+        border-color: color-mix(in srgb, var(--accent) 38%, var(--control-hover-border));
+      }
+
+      .coordinator-admin-switch:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .coordinator-admin-switch[data-state="checked"] {
+        background: color-mix(in srgb, var(--accent) 18%, var(--surface-1));
+        border-color: color-mix(in srgb, var(--accent) 54%, var(--control-hover-border));
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
+      }
+
+      .coordinator-admin-switch:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+
+      .coordinator-admin-switch-thumb {
+        display: block;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        background: color-mix(in srgb, var(--surface-0) 88%, white);
+        border: 1px solid color-mix(in srgb, var(--text-tertiary) 24%, transparent);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+        transition: transform 0.15s ease, background 0.15s ease;
+        transform: translateX(0);
+      }
+
+      .coordinator-admin-switch[data-state="checked"] .coordinator-admin-switch-thumb {
+        transform: translateX(14px);
+        background: color-mix(in srgb, var(--accent) 88%, white);
+        border-color: color-mix(in srgb, var(--accent) 42%, transparent);
+      }
+
+      .coordinator-admin-count-copy {
+        margin-left: 2px;
+      }
+
+      .coordinator-admin-empty-state {
+        padding: var(--sp-3) 0 var(--sp-1);
       }
 
       .coordinator-admin-list {
@@ -1180,6 +1299,8 @@
       .peer-actions { display: flex; gap: 6px; }
       .peer-actions button { border: 1px solid var(--border); background: transparent; border-radius: var(--radius-pill); padding: 5px 10px; min-width: 28px; min-height: 28px; display: inline-flex; align-items: center; justify-content: center; font-family: var(--font-sans); font-size: 12px; cursor: pointer; color: var(--text-secondary); }
       .peer-actions button:hover { border-color: var(--border-hover); background: var(--surface-2); }
+      .peer-actions button.danger { color: var(--accent-warm); border-color: color-mix(in srgb, var(--accent-warm) 36%, var(--border)); }
+      .peer-actions button.danger:hover { background: var(--accent-warm-subtle); border-color: var(--accent-warm); }
       .peer-card,
       .actor-row,
       .peer-scope-input,

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -698,7 +698,8 @@ export function createCoordinatorApp(
 		try {
 			const ok = await store.renameDevice(groupId, deviceId, displayName);
 			if (!ok) return c.json({ error: "device_not_found" }, 404);
-			return c.json({ ok: true });
+			const device = await store.getEnrollment(groupId, deviceId);
+			return c.json({ ok: true, device });
 		} finally {
 			await store.close();
 		}

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -286,6 +286,66 @@ export async function loadCoordinatorAdminStatus(): Promise<unknown> {
 	return fetchJson("/api/coordinator/admin/status");
 }
 
+export async function loadCoordinatorAdminGroups(): Promise<unknown> {
+	return fetchJson("/api/coordinator/admin/groups");
+}
+
+export async function loadCoordinatorAdminGroupsFiltered(
+	includeArchived: boolean,
+): Promise<unknown> {
+	const suffix = includeArchived ? "?include_archived=1" : "";
+	return fetchJson(`/api/coordinator/admin/groups${suffix}`);
+}
+
+export async function createCoordinatorAdminGroup(payload: {
+	group_id: string;
+	display_name?: string | null;
+}): Promise<unknown> {
+	const resp = await fetch("/api/coordinator/admin/groups", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}
+
+export async function renameCoordinatorAdminGroup(
+	groupId: string,
+	displayName: string,
+): Promise<unknown> {
+	const resp = await fetch(`/api/coordinator/admin/groups/${encodeURIComponent(groupId)}/rename`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ display_name: displayName }),
+	});
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}
+
+export async function archiveCoordinatorAdminGroup(groupId: string): Promise<unknown> {
+	const resp = await fetch(`/api/coordinator/admin/groups/${encodeURIComponent(groupId)}/archive`, {
+		method: "POST",
+	});
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}
+
+export async function unarchiveCoordinatorAdminGroup(groupId: string): Promise<unknown> {
+	const resp = await fetch(
+		`/api/coordinator/admin/groups/${encodeURIComponent(groupId)}/unarchive`,
+		{
+			method: "POST",
+		},
+	);
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}
+
 export async function loadCoordinatorAdminJoinRequests(groupId?: string | null): Promise<unknown> {
 	const params = new URLSearchParams();
 	if (groupId) params.set("group_id", groupId);

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -153,6 +153,13 @@ export interface CachedCoordinatorAdminDevice {
 	fingerprint?: string;
 }
 
+export interface CachedCoordinatorAdminGroup {
+	group_id?: string;
+	display_name?: string | null;
+	archived_at?: string | null;
+	created_at?: string;
+}
+
 export interface CachedTeamInvite {
 	encoded?: string;
 	warnings?: string[];
@@ -225,6 +232,8 @@ export const state = {
 	lastSyncSharingReview: [] as SyncSharingReviewRow[],
 	lastSyncCoordinator: null as CachedSyncCoordinator | null,
 	lastCoordinatorAdminStatus: null as CachedCoordinatorAdminStatus | null,
+	coordinatorAdminTargetGroup: "",
+	lastCoordinatorAdminGroups: [] as CachedCoordinatorAdminGroup[],
 	lastCoordinatorAdminJoinRequests: [] as CachedSyncJoinRequest[],
 	lastCoordinatorAdminDevices: [] as CachedCoordinatorAdminDevice[],
 	lastSyncJoinRequests: [] as CachedSyncJoinRequest[],

--- a/packages/ui/src/tabs/coordinator-admin.tsx
+++ b/packages/ui/src/tabs/coordinator-admin.tsx
@@ -1,23 +1,110 @@
 import { h, render } from "preact";
 import { RadixSelect } from "../components/primitives/radix-select";
+import { RadixSwitch } from "../components/primitives/radix-switch";
 import { RadixTabs, RadixTabsContent } from "../components/primitives/radix-tabs";
 import * as api from "../lib/api";
+import { copyToClipboard } from "../lib/dom";
 import { showGlobalNotice } from "../lib/notice";
 import { state } from "../lib/state";
 import { openSyncConfirmDialog } from "./sync/sync-dialogs";
 
-type AdminSection = "overview" | "invites" | "join-requests" | "devices";
+type AdminSection = "groups" | "invites" | "join-requests" | "devices";
 
-let activeSection: AdminSection = "overview";
+let activeSection: AdminSection = "groups";
 let inviteGroup = "";
 let inviteTtlHours = "24";
 let invitePolicy: "auto_admit" | "approval_required" = "auto_admit";
 let invitePending = false;
+let showArchivedGroups = false;
+let createGroupId = "";
+let createGroupDisplayName = "";
+let groupActionPendingId = "";
+let groupActionPendingKind: "create" | "rename" | "archive" | "unarchive" | "" = "";
 let joinReviewPendingId = "";
 let joinReviewPendingAction: "approve" | "deny" | "" = "";
 let deviceActionPendingId = "";
 let deviceActionPendingKind: "rename" | "disable" | "remove" | "" = "";
+const groupRenameDrafts = new Map<string, string>();
 const deviceRenameDrafts = new Map<string, string>();
+const ADMIN_TARGET_GROUP_KEY = "codemem-coordinator-admin-target-group";
+
+function adminTargetStorageKey(coordinatorUrl: string | null | undefined): string {
+	return `${ADMIN_TARGET_GROUP_KEY}:${String(coordinatorUrl || "").trim()}`;
+}
+
+function readStoredAdminTargetGroup(coordinatorUrl: string | null | undefined): string {
+	try {
+		return localStorage.getItem(adminTargetStorageKey(coordinatorUrl)) || "";
+	} catch {
+		return "";
+	}
+}
+
+function writeStoredAdminTargetGroup(coordinatorUrl: string | null | undefined, groupId: string) {
+	try {
+		localStorage.setItem(adminTargetStorageKey(coordinatorUrl), groupId);
+	} catch {
+		// ignore storage errors
+	}
+}
+
+function currentAdminTargetGroup(): string {
+	return String(state.coordinatorAdminTargetGroup || "").trim();
+}
+
+function setAdminTargetGroup(groupId: string) {
+	state.coordinatorAdminTargetGroup = groupId;
+	writeStoredAdminTargetGroup(state.lastCoordinatorAdminStatus?.coordinator_url || null, groupId);
+}
+
+function availableCoordinatorGroups(): Array<{
+	group_id: string;
+	display_name: string | null;
+	archived_at: string | null;
+}> {
+	const groups = Array.isArray(state.lastCoordinatorAdminGroups)
+		? state.lastCoordinatorAdminGroups
+		: [];
+	return groups
+		.map((group) => ({
+			archived_at: group.archived_at ?? null,
+			display_name: group.display_name ?? null,
+			group_id: String(group.group_id || "").trim(),
+		}))
+		.filter((group) => group.group_id);
+}
+
+function reconcileGroupRenameDrafts() {
+	const next = new Map<string, string>();
+	for (const group of availableCoordinatorGroups()) {
+		next.set(group.group_id, group.display_name || group.group_id);
+	}
+	groupRenameDrafts.clear();
+	for (const [groupId, name] of next.entries()) {
+		groupRenameDrafts.set(groupId, name);
+	}
+}
+
+function currentAdminTargetGroupRecord() {
+	const target = currentAdminTargetGroup();
+	return availableCoordinatorGroups().find((group) => group.group_id === target) || null;
+}
+
+function resolveAdminTargetGroup() {
+	const status = state.lastCoordinatorAdminStatus;
+	const groups = availableCoordinatorGroups();
+	const configured = String(status?.active_group || "").trim();
+	const stored = readStoredAdminTargetGroup(status?.coordinator_url || null);
+	const current = currentAdminTargetGroup();
+	const availableIds = new Set(groups.map((group) => group.group_id));
+	const candidate = current || stored || configured || groups[0]?.group_id || "";
+	const resolved =
+		candidate && (availableIds.size === 0 || availableIds.has(candidate))
+			? candidate
+			: configured || groups[0]?.group_id || "";
+	setAdminTargetGroup(resolved);
+	return resolved;
+}
 
 function reconcileDeviceRenameDrafts() {
 	const next = new Map<string, string>();
@@ -70,10 +157,86 @@ function coordinatorAdminSummary() {
 	};
 }
 
+async function createGroupFromAdminPanel() {
+	if (groupActionPendingKind) return;
+	const groupId = createGroupId.trim();
+	if (!groupId) {
+		showGlobalNotice("Enter a group id before creating a group.", "warning");
+		return;
+	}
+	groupActionPendingKind = "create";
+	renderShell();
+	try {
+		await api.createCoordinatorAdminGroup({
+			group_id: groupId,
+			display_name: createGroupDisplayName.trim() || null,
+		});
+		createGroupId = "";
+		createGroupDisplayName = "";
+		showGlobalNotice("Group created.", "success");
+		await loadCoordinatorAdminData();
+	} catch (error) {
+		showGlobalNotice(error instanceof Error ? error.message : "Failed to create group.", "warning");
+	} finally {
+		groupActionPendingKind = "";
+		renderShell();
+	}
+}
+
+async function runGroupAction(
+	groupId: string,
+	displayName: string,
+	kind: "rename" | "archive" | "unarchive",
+) {
+	if (!groupId || groupActionPendingId) return;
+	if (
+		(kind === "archive" || kind === "unarchive") &&
+		!(await openSyncConfirmDialog({
+			title: `${kind === "archive" ? "Archive" : "Unarchive"} ${displayName || groupId}?`,
+			description:
+				kind === "archive"
+					? "Archived groups stay visible and restorable, but they stop being operational for new invites and joins."
+					: "This group will become operational again for invites and coordinator-backed joins.",
+			confirmLabel: kind === "archive" ? "Archive group" : "Unarchive group",
+			cancelLabel: kind === "archive" ? "Keep group active" : "Keep group archived",
+			tone: "danger",
+		}))
+	) {
+		return;
+	}
+	groupActionPendingId = groupId;
+	groupActionPendingKind = kind;
+	renderShell();
+	try {
+		if (kind === "rename") {
+			await api.renameCoordinatorAdminGroup(groupId, displayName);
+			showGlobalNotice("Group renamed.", "success");
+		}
+		if (kind === "archive") {
+			await api.archiveCoordinatorAdminGroup(groupId);
+			showGlobalNotice("Group archived.", "success");
+		}
+		if (kind === "unarchive") {
+			await api.unarchiveCoordinatorAdminGroup(groupId);
+			showGlobalNotice("Group unarchived.", "success");
+		}
+		await loadCoordinatorAdminData();
+	} catch (error) {
+		showGlobalNotice(
+			error instanceof Error ? error.message : `Failed to ${kind} group.`,
+			"warning",
+		);
+	} finally {
+		groupActionPendingId = "";
+		groupActionPendingKind = "";
+		renderShell();
+	}
+}
+
 async function createInviteFromAdminPanel() {
 	if (invitePending) return;
 	const status = state.lastCoordinatorAdminStatus;
-	const defaultGroup = String(status?.active_group || "").trim();
+	const defaultGroup = currentAdminTargetGroup() || String(status?.active_group || "").trim();
 	const groupId = inviteGroup.trim() || defaultGroup;
 	const ttlHours = Number(inviteTtlHours);
 	if (!groupId) {
@@ -112,8 +275,7 @@ async function createInviteFromAdminPanel() {
 
 function renderInvitesPanel(summary: ReturnType<typeof coordinatorAdminSummary>) {
 	const status = state.lastCoordinatorAdminStatus;
-	const groups = Array.isArray(status?.groups) ? status.groups.filter(Boolean) : [];
-	const activeGroup = String(status?.active_group || "").trim();
+	const activeGroup = currentAdminTargetGroup() || String(status?.active_group || "").trim();
 	const effectiveGroup = inviteGroup.trim() || activeGroup;
 	const output = String(state.lastTeamInvite?.encoded || "").trim();
 	const warnings = Array.isArray(state.lastTeamInvite?.warnings)
@@ -121,7 +283,7 @@ function renderInvitesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 		: [];
 	return h(
 		RadixTabsContent,
-		{ className: "coordinator-admin-panel", forceMount: true, value: "invites" },
+		{ className: "coordinator-admin-panel", value: "invites" },
 		h("h3", null, "Create teammate invite"),
 		h(
 			"p",
@@ -203,9 +365,6 @@ function renderInvitesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 			),
 			effectiveGroup ? h("span", { class: "peer-submeta" }, `Using group ${effectiveGroup}`) : null,
 		),
-		groups.length
-			? h("p", { class: "peer-submeta" }, `Available groups: ${groups.join(", ")}`)
-			: null,
 		output
 			? h(
 					"label",
@@ -216,11 +375,229 @@ function renderInvitesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 						readOnly: true,
 						value: output,
 					}),
+					h(
+						"button",
+						{
+							class: "settings-button sync-action-copy",
+							type: "button",
+							onClick: (event: MouseEvent) =>
+								copyToClipboard(output, event.currentTarget as HTMLButtonElement),
+						},
+						"Copy",
+					),
 				)
 			: null,
 		warnings?.length
 			? h("div", { class: "peer-meta coordinator-admin-warning-list" }, warnings.join(" · "))
 			: null,
+	);
+}
+
+function renderGroupsPanel(summary: ReturnType<typeof coordinatorAdminSummary>) {
+	const configuredGroup = String(state.lastCoordinatorAdminStatus?.active_group || "").trim();
+	const selectedGroup = currentAdminTargetGroup();
+	const groups = availableCoordinatorGroups();
+	const activeGroups = groups.filter((group) => !group.archived_at);
+	const archivedGroups = groups.filter((group) => group.archived_at);
+	const visibleGroups = showArchivedGroups ? groups : activeGroups;
+	const targetExists = selectedGroup
+		? groups.some((group) => group.group_id === selectedGroup)
+		: false;
+	const countParts = [`${activeGroups.length} active`];
+	if (archivedGroups.length) countParts.push(`${archivedGroups.length} archived`);
+	return h(
+		RadixTabsContent,
+		{ className: "coordinator-admin-panel", value: "groups" },
+		h("h3", null, "Groups"),
+		h(
+			"p",
+			{ class: "peer-submeta" },
+			selectedGroup
+				? `Managing ${selectedGroup}${configuredGroup && configuredGroup !== selectedGroup ? ` · this node uses ${configuredGroup} for discovery` : ""}`
+				: configuredGroup
+					? `This node uses ${configuredGroup} for discovery. Select a group below to manage it.`
+					: "No group selected yet. Create one or select an existing group to manage.",
+		),
+		groups.length ? h("p", { class: "peer-submeta" }, countParts.join(" · ")) : null,
+		!targetExists && selectedGroup
+			? h(
+					"div",
+					{ class: "peer-meta coordinator-admin-inline-warning" },
+					`The selected admin target group (${selectedGroup}) is configured locally but does not exist in the coordinator yet. Create it below or switch to another group once one exists.`,
+				)
+			: null,
+		h(
+			"div",
+			{ class: "coordinator-admin-form-grid" },
+			h(
+				"label",
+				{ class: "coordinator-admin-field" },
+				h("span", null, "New group id"),
+				h("input", {
+					class: "peer-scope-input",
+					disabled: summary.readiness !== "ready" || groupActionPendingKind === "create",
+					onInput: (event) => {
+						createGroupId = String((event.currentTarget as HTMLInputElement).value || "");
+					},
+					placeholder: "team-alpha",
+					value: createGroupId,
+				}),
+			),
+			h(
+				"label",
+				{ class: "coordinator-admin-field" },
+				h("span", null, "Display name"),
+				h("input", {
+					class: "peer-scope-input",
+					disabled: summary.readiness !== "ready" || groupActionPendingKind === "create",
+					onInput: (event) => {
+						createGroupDisplayName = String((event.currentTarget as HTMLInputElement).value || "");
+					},
+					placeholder: "Team Alpha",
+					value: createGroupDisplayName,
+				}),
+			),
+		),
+		h(
+			"div",
+			{ class: "section-actions coordinator-admin-groups-toolbar" },
+			h(
+				"div",
+				{ class: "coordinator-admin-primary-actions" },
+				h(
+					"button",
+					{
+						class: "settings-button",
+						disabled: summary.readiness !== "ready" || groupActionPendingKind === "create",
+						onClick: () => void createGroupFromAdminPanel(),
+						type: "button",
+					},
+					groupActionPendingKind === "create" ? "Creating…" : "Create group",
+				),
+			),
+			h(
+				"div",
+				{ class: "coordinator-admin-secondary-actions" },
+				h(
+					"label",
+					{ class: "coordinator-admin-inline-filter" },
+					h(
+						"span",
+						{ class: "section-meta", id: "coordinatorAdminShowArchivedLabel" },
+						"Show archived",
+					),
+					h(RadixSwitch, {
+						"aria-labelledby": "coordinatorAdminShowArchivedLabel",
+						checked: showArchivedGroups,
+						className: "coordinator-admin-switch",
+						disabled: summary.readiness !== "ready",
+						onCheckedChange: (checked) => {
+							showArchivedGroups = checked;
+							renderShell();
+						},
+						thumbClassName: "coordinator-admin-switch-thumb",
+					}),
+				),
+			),
+		),
+		!visibleGroups.length
+			? h(
+					"div",
+					{ class: "peer-meta coordinator-admin-empty-state" },
+					summary.readiness === "ready"
+						? showArchivedGroups
+							? "No coordinator groups are available yet."
+							: "No active groups yet. Create one to get started."
+						: "Group browsing will appear here once setup is complete.",
+				)
+			: h(
+					"div",
+					{ class: "coordinator-admin-request-list" },
+					visibleGroups.map((group) => {
+						const selected = group.group_id === selectedGroup;
+						const pending = groupActionPendingId === group.group_id;
+						const archived = Boolean(group.archived_at);
+						const draftName =
+							groupRenameDrafts.get(group.group_id) ?? group.display_name ?? group.group_id;
+						return h(
+							"div",
+							{ class: "peer-card", key: group.group_id },
+							h("div", { class: "peer-title" }, h("strong", null, draftName)),
+							h("div", { class: "peer-meta" }, `Group ID: ${group.group_id}`),
+							h("div", { class: "peer-submeta" }, archived ? "Archived" : "Active"),
+							configuredGroup === group.group_id
+								? h(
+										"div",
+										{ class: "peer-submeta" },
+										"This node is configured to use this group for coordinator-backed discovery.",
+									)
+								: null,
+							h(
+								"label",
+								{ class: "coordinator-admin-field" },
+								h("span", null, "Display name"),
+								h("input", {
+									class: "peer-scope-input",
+									disabled: summary.readiness !== "ready" || pending,
+									onInput: (event) => {
+										groupRenameDrafts.set(
+											group.group_id,
+											String((event.currentTarget as HTMLInputElement).value || ""),
+										);
+									},
+									value: draftName,
+								}),
+							),
+							h(
+								"div",
+								{ class: "peer-actions" },
+								h(
+									"button",
+									{
+										class: "settings-button",
+										disabled: summary.readiness !== "ready" || selected,
+										onClick: () => {
+											setAdminTargetGroup(group.group_id);
+											void loadCoordinatorAdminData();
+										},
+										type: "button",
+									},
+									selected ? "Managing" : "Manage",
+								),
+								h(
+									"button",
+									{
+										disabled: summary.readiness !== "ready" || pending,
+										onClick: () => void runGroupAction(group.group_id, draftName, "rename"),
+										type: "button",
+									},
+									pending && groupActionPendingKind === "rename" ? "Renaming…" : "Rename",
+								),
+								h(
+									"button",
+									{
+										class: archived ? undefined : "danger",
+										disabled: summary.readiness !== "ready" || pending,
+										onClick: () =>
+											void runGroupAction(
+												group.group_id,
+												group.display_name || group.group_id,
+												archived ? "unarchive" : "archive",
+											),
+										type: "button",
+									},
+									pending && groupActionPendingKind === (archived ? "unarchive" : "archive")
+										? archived
+											? "Restoring…"
+											: "Archiving…"
+										: archived
+											? "Unarchive"
+											: "Archive",
+								),
+							),
+						);
+					}),
+				),
 	);
 }
 
@@ -252,7 +629,7 @@ function renderJoinRequestsPanel(summary: ReturnType<typeof coordinatorAdminSumm
 		: [];
 	return h(
 		RadixTabsContent,
-		{ className: "coordinator-admin-panel", forceMount: true, value: "join-requests" },
+		{ className: "coordinator-admin-panel", value: "join-requests" },
 		h("h3", null, "Pending join requests"),
 		h(
 			"p",
@@ -297,6 +674,7 @@ function renderJoinRequestsPanel(summary: ReturnType<typeof coordinatorAdminSumm
 								h(
 									"button",
 									{
+										class: "danger",
 										disabled: !requestId || pending,
 										onClick: () => void reviewJoinRequestFromAdminPanel(requestId, "deny"),
 										type: "button",
@@ -370,7 +748,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 		: [];
 	return h(
 		RadixTabsContent,
-		{ className: "coordinator-admin-panel", forceMount: true, value: "devices" },
+		{ className: "coordinator-admin-panel", value: "devices" },
 		h("h3", null, "Enrolled devices"),
 		h(
 			"p",
@@ -441,6 +819,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 								h(
 									"button",
 									{
+										class: "danger",
 										disabled: !deviceId || pending || summary.readiness !== "ready" || !enabled,
 										onClick: () => void runDeviceAction(deviceId, groupId, displayName, "disable"),
 										type: "button",
@@ -450,6 +829,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 								h(
 									"button",
 									{
+										class: "danger",
 										disabled: !deviceId || pending || summary.readiness !== "ready",
 										onClick: () => void runDeviceAction(deviceId, groupId, displayName, "remove"),
 										type: "button",
@@ -468,19 +848,40 @@ function renderShell() {
 	if (!mount) return;
 	const status = state.lastCoordinatorAdminStatus;
 	const summary = coordinatorAdminSummary();
-	const groups = Array.isArray(status?.groups) ? status.groups.filter(Boolean) : [];
 	const coordinatorUrl = String(status?.coordinator_url || "").trim();
 	const activeGroup = String(status?.active_group || "").trim();
-	const invitesEnabled = summary.readiness === "ready";
+	const targetGroupRecord = currentAdminTargetGroupRecord();
+	const targetArchived = Boolean(targetGroupRecord?.archived_at);
+	const groupsEnabled = summary.readiness === "ready";
+	const invitesEnabled = summary.readiness === "ready" && !targetArchived;
 	const joinRequestsEnabled = summary.readiness === "ready";
 	const devicesEnabled = summary.readiness === "ready";
+	const targetGroup = currentAdminTargetGroup();
+	const activeGroupCount = availableCoordinatorGroups().filter(
+		(group) => !group.archived_at,
+	).length;
+	const archivedGroupCount = availableCoordinatorGroups().filter(
+		(group) => group.archived_at,
+	).length;
+	const joinRequestCount = Array.isArray(state.lastCoordinatorAdminJoinRequests)
+		? state.lastCoordinatorAdminJoinRequests.length
+		: 0;
+	const deviceCount = Array.isArray(state.lastCoordinatorAdminDevices)
+		? state.lastCoordinatorAdminDevices.length
+		: 0;
+	const headerMessage =
+		summary.readiness !== "ready"
+			? summary.detail
+			: targetArchived
+				? "The selected admin target group is archived. Restore it or switch groups before creating invites."
+				: "";
 	if (
-		activeSection !== "overview" &&
-		((activeSection === "invites" && !invitesEnabled) ||
-			(activeSection === "join-requests" && !joinRequestsEnabled) ||
-			(activeSection === "devices" && !devicesEnabled))
+		(activeSection === "invites" && !invitesEnabled) ||
+		(activeSection === "groups" && !groupsEnabled) ||
+		(activeSection === "join-requests" && !joinRequestsEnabled) ||
+		(activeSection === "devices" && !devicesEnabled)
 	) {
-		activeSection = "overview";
+		activeSection = summary.readiness === "ready" ? "groups" : "invites";
 	}
 
 	render(
@@ -489,30 +890,49 @@ function renderShell() {
 			{ class: "coordinator-admin-shell" },
 			h(
 				"div",
-				{ class: "card coordinator-admin-hero" },
+				{ class: "card coordinator-admin-header" },
 				h("div", { class: "section-header" }, h("h2", null, "Coordinator Admin")),
-				h("p", { class: "peer-meta" }, summary.title),
-				h("p", { class: "peer-submeta" }, summary.detail),
 				h(
-					"dl",
-					{ class: "coordinator-admin-meta-grid" },
-					h("div", null, h("dt", null, "Readiness"), h("dd", null, summary.readiness)),
+					"div",
+					{ class: "coordinator-admin-summary-grid" },
 					h(
 						"div",
-						null,
-						h("dt", null, "Coordinator URL"),
-						h("dd", null, coordinatorUrl || "Not configured"),
+						{ class: "coordinator-admin-summary-card" },
+						h("span", { class: "section-meta" }, "Admin target"),
+						h("strong", null, targetGroup || "None selected"),
 					),
-					h("div", null, h("dt", null, "Active group"), h("dd", null, activeGroup || "None")),
 					h(
 						"div",
-						null,
-						h("dt", null, "Admin secret"),
-						h("dd", null, status?.has_admin_secret ? "Available locally" : "Missing"),
+						{ class: "coordinator-admin-summary-card" },
+						h("span", { class: "section-meta" }, "Node discovery group"),
+						h("strong", null, activeGroup || "None"),
+					),
+					h(
+						"div",
+						{ class: "coordinator-admin-summary-card" },
+						h("span", { class: "section-meta" }, "Groups"),
+						h(
+							"strong",
+							null,
+							`${activeGroupCount} active${archivedGroupCount ? ` · ${archivedGroupCount} archived` : ""}`,
+						),
+					),
+					h(
+						"div",
+						{ class: "coordinator-admin-summary-card" },
+						h("span", { class: "section-meta" }, "Selected group activity"),
+						h("strong", null, `${joinRequestCount} join requests · ${deviceCount} devices`),
 					),
 				),
-				groups.length
-					? h("p", { class: "peer-submeta" }, `Configured groups: ${groups.join(", ")}`)
+				headerMessage
+					? h("div", { class: "peer-meta coordinator-admin-inline-warning" }, headerMessage)
+					: null,
+				coordinatorUrl
+					? h(
+							"div",
+							{ class: "section-meta coordinator-admin-inline-meta" },
+							`Coordinator: ${coordinatorUrl}`,
+						)
 					: null,
 			),
 			h(
@@ -524,11 +944,11 @@ function renderShell() {
 						ariaLabel: "Coordinator admin sections",
 						listClassName: "coordinator-admin-tabs-list",
 						onValueChange: (value) => {
-							activeSection = (value as AdminSection) || "overview";
+							activeSection = (value as AdminSection) || "groups";
 							renderShell();
 						},
 						tabs: [
-							{ value: "overview", label: "Overview" },
+							{ value: "groups", label: "Groups", disabled: !groupsEnabled },
 							{ value: "invites", label: "Invites", disabled: !invitesEnabled },
 							{ value: "join-requests", label: "Join requests", disabled: !joinRequestsEnabled },
 							{ value: "devices", label: "Devices", disabled: !devicesEnabled },
@@ -536,21 +956,19 @@ function renderShell() {
 						triggerClassName: "coordinator-admin-tab-trigger",
 						value: activeSection,
 					},
-					h(
-						RadixTabsContent,
-						{ className: "coordinator-admin-panel", forceMount: true, value: "overview" },
-						h("h3", null, "What lives here"),
-						h(
-							"ul",
-							{ class: "coordinator-admin-list" },
-							h("li", null, "Create teammate invites with clear policy choices."),
-							h("li", null, "Review and approve or deny pending join requests."),
-							h("li", null, "Manage enrolled devices without mixing admin state into Sync."),
-						),
-					),
+					renderGroupsPanel(summary),
 					renderInvitesPanel(summary),
 					renderJoinRequestsPanel(summary),
 					renderDevicesPanel(summary),
+				),
+				h(
+					"div",
+					{ class: "section-meta coordinator-admin-context-line" },
+					targetArchived
+						? `Selected group ${targetGroup || "—"} is archived. Switch or restore it to enable invite operations.`
+						: targetGroup
+							? `Actions below apply to ${targetGroup}.`
+							: "Select a group to start managing coordinator state.",
 				),
 			),
 		),
@@ -575,9 +993,24 @@ export async function loadCoordinatorAdminData() {
 		return;
 	}
 	const activeGroup = String(state.lastCoordinatorAdminStatus?.active_group || "").trim();
+	resolveAdminTargetGroup();
 	if (state.lastCoordinatorAdminStatus?.readiness === "ready") {
 		try {
-			const payload = (await api.loadCoordinatorAdminJoinRequests(activeGroup)) as {
+			const groupsPayload = (await api.loadCoordinatorAdminGroupsFiltered(showArchivedGroups)) as {
+				items?: typeof state.lastCoordinatorAdminGroups;
+			};
+			state.lastCoordinatorAdminGroups = Array.isArray(groupsPayload?.items)
+				? groupsPayload.items
+				: [];
+			reconcileGroupRenameDrafts();
+			resolveAdminTargetGroup();
+		} catch {
+			state.lastCoordinatorAdminGroups = [];
+			groupRenameDrafts.clear();
+		}
+		const targetGroup = currentAdminTargetGroup();
+		try {
+			const payload = (await api.loadCoordinatorAdminJoinRequests(targetGroup || activeGroup)) as {
 				items?: typeof state.lastCoordinatorAdminJoinRequests;
 			};
 			state.lastCoordinatorAdminJoinRequests = Array.isArray(payload?.items) ? payload.items : [];
@@ -585,7 +1018,10 @@ export async function loadCoordinatorAdminData() {
 			state.lastCoordinatorAdminJoinRequests = [];
 		}
 		try {
-			const devicesPayload = (await api.loadCoordinatorAdminDevices(activeGroup, true)) as {
+			const devicesPayload = (await api.loadCoordinatorAdminDevices(
+				targetGroup || activeGroup,
+				true,
+			)) as {
 				items?: typeof state.lastCoordinatorAdminDevices;
 			};
 			state.lastCoordinatorAdminDevices = Array.isArray(devicesPayload?.items)
@@ -597,6 +1033,8 @@ export async function loadCoordinatorAdminData() {
 			deviceRenameDrafts.clear();
 		}
 	} else {
+		state.lastCoordinatorAdminGroups = [];
+		groupRenameDrafts.clear();
 		state.lastCoordinatorAdminJoinRequests = [];
 		state.lastCoordinatorAdminDevices = [];
 		deviceRenameDrafts.clear();

--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -1973,7 +1973,7 @@ function SettingsDialogContent() {
 								<input
 									id="syncCoordinatorGroup"
 									onInput={onTextInput("syncCoordinatorGroup")}
-									placeholder="nerdworld"
+									placeholder="team-alpha"
 									value={values.syncCoordinatorGroup}
 								/>
 								<div className="small">

--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -43,7 +43,7 @@ function SyncDisclosure({
 	}, [contentId, triggerId, open]);
 
 	const content = (
-		<Collapsible.Content asChild>
+		<Collapsible.Content forceMount asChild>
 			<div ref={contentRef} id={contentId} className={contentClassName} hidden={!open}>
 				{children}
 			</div>


### PR DESCRIPTION
## Description
Reworks Coordinator Admin so Groups becomes the primary management surface, removes the low-signal Overview tab, separates admin target group from the node's discovery group, and adds real group management UX for create, rename, archive, show archived, and unarchive flows.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced