### PR TITLE
feat(sync): skip sync attempts for coordinator peers with expired presence

### DIFF
--- a/docs/plans/2026-04-12-coordinator-admin-ui-design.md
+++ b/docs/plans/2026-04-12-coordinator-admin-ui-design.md
@@ -1,0 +1,316 @@
+# Coordinator Admin UI in Viewer
+
+**Status:** Design  
+**Date:** 2026-04-12
+
+## Problem
+
+Coordinator-backed discovery now has working building blocks for invites, join review, and device administration, but the operator experience is still split awkwardly across CLI, setup docs, and overloaded Sync UI.
+
+Today:
+
+- the Sync tab already carries too much cognitive load
+- the common `Invite teammate` action is convenient there, but advanced coordinator administration does not belong in the same surface
+- remote/Cloudflare coordinator admin requires an explicit admin secret, which makes “just click the invite button” unreliable unless configuration is complete
+- the current product model needs to preserve a clear distinction between coordinator-backed discovery and actual direct sync relationships
+
+The result is a product surface that technically works but does not communicate the boundary between:
+
+- everyday sync and peer management
+- operator-only remote coordinator administration
+
+## Goal
+
+Design a viewer-hosted **Coordinator Admin** experience that:
+
+- keeps the browser away from the raw admin secret
+- keeps Sync focused on peer/discovery/sync status
+- preserves `Invite teammate` as a convenient common action in Sync
+- makes advanced coordinator administration available in a dedicated top-level tab
+- supports a first useful slice now, while leaving room for richer groups/teams management later
+
+## Product framing
+
+The coordinator remains:
+
+- a discovery/admin service
+- not the direct memory transport path
+
+Direct peer sync remains separate and continues to work for:
+
+- manually paired peers
+- uncoordinated peers
+- coordinator-discovered peers that are later accepted for direct sync
+
+Coordinator membership should **not** mean “start syncing with everyone in the group.”
+
+## Key decisions
+
+### 1. New top-level tab
+
+Add a new top-level viewer tab named **Coordinator Admin**.
+
+Reasoning:
+
+- Sync is already overloaded
+- operator/admin concepts deserve a separate mental model
+- a dedicated tab scales better to groups/teams and multi-coordinator futures
+
+### 2. Keep invite affordance in Sync
+
+Keep `Invite teammate` in Sync because it is a common action and is useful close to everyday collaboration surfaces.
+
+If admin configuration is missing:
+
+- the action remains visible
+- it is disabled
+- it shows a short setup explanation
+
+### 3. Viewer-server owns the admin secret boundary
+
+The browser must not call the remote coordinator with the admin secret directly.
+
+Instead:
+
+- browser calls viewer-server
+- viewer-server reads local coordinator URL/admin-secret config
+- viewer-server proxies remote admin actions to the coordinator
+
+### 4. New route namespace
+
+Use a dedicated route namespace:
+
+- `/api/coordinator/admin/...`
+
+Reasoning:
+
+- clear boundary between coordinator admin and other viewer APIs
+- leaves room for future non-admin coordinator routes
+- avoids turning `/api/admin` into a vague dumping ground
+
+### 5. New surfaces use Radix UI
+
+All new UI in the Coordinator Admin tab should use Radix UI-based primitives and existing project patterns.
+
+## Information architecture
+
+### Sync tab
+
+Sync continues to own:
+
+- direct peer status
+- coordinator-backed discovery visibility
+- suggested peers
+- actual sync relationship state
+- `Invite teammate` as the common action
+
+Sync does **not** become the home for advanced remote coordinator administration.
+
+### Coordinator Admin tab
+
+The new top-level tab becomes the operator console for the currently configured coordinator target.
+
+#### v1 sections
+
+1. **Overview / setup state**
+   - configured coordinator URL
+   - configured group/team context
+   - admin capability present/missing
+   - setup guidance when not ready
+
+2. **Invites**
+   - create invite
+   - choose join policy (`auto_admit` / `approval_required`)
+   - show invite payload and warnings
+
+3. **Join requests**
+   - list pending join requests
+   - approve / deny
+   - show inline action feedback
+
+4. **Enrolled devices**
+   - list devices
+   - rename
+   - disable
+   - remove
+
+#### Later sections
+
+5. **Groups / teams browser**
+   - browse groups
+   - switch active group context
+   - eventually create/manage groups if the product model settles there
+
+6. **Coordinator diagnostics**
+   - remote admin readiness
+   - invite/join/admin failure details
+   - future bootstrap grant or diagnostics views
+
+## Security and config boundary
+
+### Required local configuration for admin mode
+
+- `sync_coordinator_url`
+- admin secret available to viewer-server (for example via env/config)
+
+### UI readiness states
+
+1. **Not configured**
+   - no coordinator target
+   - show setup guidance only
+
+2. **Partial**
+   - coordinator target exists
+   - admin secret missing
+   - allow read-only setup messaging, disable admin mutations
+
+3. **Ready**
+   - coordinator target + admin secret available
+   - full admin UI enabled
+
+## API boundary sketch
+
+### Read routes
+
+- `GET /api/coordinator/admin/status`
+- `GET /api/coordinator/admin/join-requests`
+- `GET /api/coordinator/admin/devices`
+- later: `GET /api/coordinator/admin/groups`
+
+### Mutation routes
+
+- `POST /api/coordinator/admin/invites`
+- `POST /api/coordinator/admin/join-requests/:id/approve`
+- `POST /api/coordinator/admin/join-requests/:id/deny`
+- `POST /api/coordinator/admin/devices/:id/rename`
+- `POST /api/coordinator/admin/devices/:id/disable`
+- `POST /api/coordinator/admin/devices/:id/remove`
+
+These should reuse existing coordinator action helpers wherever possible rather than inventing a parallel coordinator client.
+
+## Error handling
+
+The UI must distinguish between:
+
+- missing local setup
+- missing admin secret
+- remote admin auth failure
+- remote worker unreachable
+- malformed or stale invite/join/device state
+- success with warnings
+
+This design explicitly avoids “button did nothing” failure modes.
+
+## Implementation slices
+
+### Slice 0 — boundary + status plumbing
+
+Build the viewer-server coordinator admin proxy surface and normalized readiness/status payloads.
+
+Deliverables:
+
+- `/api/coordinator/admin/...` route shell
+- readiness state payload
+- normalized remote admin errors
+
+### Slice 1 — Coordinator Admin tab shell
+
+Build the new top-level tab and setup/empty-state experience.
+
+Deliverables:
+
+- tab in the viewer nav
+- Radix-based shell and sections
+- setup/readiness state rendering
+
+### Slice 1a — Sync invite gating cleanup
+
+Keep `Invite teammate` in Sync, but make it honest.
+
+Deliverables:
+
+- visible but disabled invite affordance when admin config is missing
+- short setup explanation
+- clear handoff to Coordinator Admin
+
+### Slice 2 — useful v1 admin surface
+
+Build the first actually useful admin operations.
+
+Deliverables:
+
+- invite creation panel
+- pending join request review panel
+- enrolled devices management panel
+
+This is the planned first release-quality slice.
+
+### Slice 3 — groups/teams browser
+
+Add group browsing and deeper coordinator management only after the shell and v1 admin actions are stable.
+
+### Slice 4 — multi-coordinator / multi-team future
+
+Support multiple coordinators or team contexts only after the product model is clearer.
+
+This should build on, not block, slices 0–3.
+
+## Bead graph
+
+### Epic
+
+- **Coordinator Admin UI in Viewer**
+
+### Child beads
+
+1. **viewer-server coordinator admin proxy routes**  
+   Blocks all later slices.
+
+2. **Coordinator Admin tab shell and readiness states**  
+   Depends on proxy routes.
+
+3. **Sync invite gating and handoff cleanup**  
+   Depends on proxy/status readiness; can land in parallel with the tab shell.
+
+4. **Coordinator Admin invites panel**  
+   Depends on tab shell.
+
+5. **Coordinator Admin join request review panel**  
+   Depends on tab shell.
+
+6. **Coordinator Admin enrolled devices panel**  
+   Depends on tab shell.
+
+7. **Coordinator Admin groups/teams browser**  
+   Depends on invites + join requests + devices panel.
+
+8. **Multi-coordinator / multi-team follow-on**  
+   Depends on groups/teams browser and product-model clarification work.
+
+## Relationship to existing coordinator work
+
+This design does not replace the existing product-model questions tracked in:
+
+- `codemem-cbfk` — clarify coordinator groups vs manual peer pairing
+- `codemem-low6` — auto-peer devices discovered in coordinator groups
+
+Instead, it creates an operator-facing admin surface that can ship independently of those deeper model decisions.
+
+## Non-goals for first implementation
+
+- no admin UI hosted inside the coordinator Worker itself
+- no browser-side storage or direct use of the admin secret
+- no relay/proxy transport through the coordinator
+- no automatic “join group means start syncing” behavior
+- no required multi-coordinator support in v1
+
+## Success criteria
+
+This design is successful when:
+
+1. Sync stays focused on everyday peer/discovery/sync workflows.
+2. Advanced coordinator operations move into a dedicated top-level tab.
+3. The browser never needs the raw admin secret.
+4. The common invite action remains convenient but no longer fails opaquely.
+5. We can stop after the v1/B slice and still have a coherent product surface.
+6. The architecture still leaves room for groups/teams and multi-coordinator futures.

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -1,6 +1,7 @@
 import { networkInterfaces } from "node:os";
 import { mergeAddresses } from "./address-utils.js";
 import type { CoordinatorReciprocalApproval } from "./coordinator-store-contract.js";
+import type { Database } from "./db.js";
 import { getCodememEnvOverrides, readCodememConfigFile } from "./observer-config.js";
 import type { MemoryStore } from "./store.js";
 import { buildAuthHeaders } from "./sync-auth.js";
@@ -199,11 +200,12 @@ export async function registerCoordinatorPresence(
 }
 
 export async function lookupCoordinatorPeers(
-	store: MemoryStore,
+	store: PresenceStoreLike,
 	config: CoordinatorSyncConfig,
+	options?: { keysDir?: string },
 ): Promise<Record<string, unknown>[]> {
 	if (!coordinatorEnabled(config)) return [];
-	const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+	const keysDir = options?.keysDir ?? (process.env.CODEMEM_KEYS_DIR?.trim() || undefined);
 	const [deviceId] = ensureDeviceIdentity(store.db, { keysDir });
 	const baseUrl = buildBaseUrl(config.syncCoordinatorUrl);
 	const merged = new Map<string, Record<string, unknown>>();
@@ -264,6 +266,46 @@ export async function lookupCoordinatorPeers(
 		}
 	}
 	return [...merged.values()];
+}
+
+/**
+ * Fetch the set of coordinator peer device IDs whose presence has expired.
+ *
+ * Returns an empty set when the coordinator is disabled or the lookup fails.
+ * Intended as a best-effort preflight for the sync daemon — failures degrade
+ * gracefully to the existing reactive shouldSkipOfflinePeer backoff.
+ */
+export async function fetchCoordinatorStalePeers(
+	db: Database,
+	dbPath: string,
+	keysDir?: string,
+): Promise<Set<string>> {
+	const config = readCoordinatorSyncConfig();
+	if (!coordinatorEnabled(config)) return new Set();
+	try {
+		const peers = await lookupCoordinatorPeers({ db, dbPath }, config, { keysDir });
+		// A device may appear under multiple fingerprints (key rotation, multi-group).
+		// Only mark a device stale if ALL its entries are stale.
+		const freshDevices = new Set<string>();
+		const staleDevices = new Set<string>();
+		for (const peer of peers) {
+			const deviceId = clean(peer.device_id);
+			if (!deviceId) continue;
+			if (peer.stale) {
+				staleDevices.add(deviceId);
+			} else {
+				freshDevices.add(deviceId);
+			}
+		}
+		// Remove any device that has at least one fresh entry
+		for (const deviceId of freshDevices) {
+			staleDevices.delete(deviceId);
+		}
+		return staleDevices;
+	} catch {
+		// Best-effort: if coordinator lookup fails, skip the optimization.
+		return new Set();
+	}
 }
 
 export async function listCoordinatorReciprocalApprovals(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export {
 	coordinatorEnabled,
 	coordinatorStatusSnapshot,
 	createCoordinatorReciprocalApproval,
+	fetchCoordinatorStalePeers,
 	listCoordinatorJoinRequests,
 	listCoordinatorReciprocalApprovals,
 	lookupCoordinatorPeers,

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -17,6 +17,7 @@ import { initTestSchema } from "./test-utils.js";
 
 vi.mock("./coordinator-runtime.js", () => ({
 	coordinatorEnabled: vi.fn().mockReturnValue(false),
+	fetchCoordinatorStalePeers: vi.fn().mockResolvedValue(new Set()),
 	readCoordinatorSyncConfig: vi.fn().mockReturnValue({}),
 	registerCoordinatorPresence: vi.fn().mockResolvedValue(null),
 }));
@@ -89,6 +90,41 @@ describe("syncDaemonTick", () => {
 		expect(results).toHaveLength(1);
 		expect(results[0].skipped).toBe(true);
 		expect(results[0].reason).toContain("backoff");
+	});
+
+	it("skips peers with expired coordinator presence", async () => {
+		const { runSyncPass, shouldSkipOfflinePeer } = await import("./sync-pass.js");
+		vi.mocked(shouldSkipOfflinePeer).mockReturnValue(false);
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "fp1", now);
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-2", "fp2", now);
+
+		const stalePeers = new Set(["peer-1"]);
+		const results = await syncDaemonTick(db, undefined, stalePeers);
+		expect(results).toHaveLength(2);
+		expect(results[0].skipped).toBe(true);
+		expect(results[0].reason).toContain("coordinator presence expired");
+		expect(results[1].ok).toBe(true);
+		expect(runSyncPass).toHaveBeenCalledTimes(1);
+		expect(runSyncPass).toHaveBeenCalledWith(db, "peer-2", expect.anything());
+	});
+
+	it("syncs all peers when stalePeers set is empty", async () => {
+		const { runSyncPass, shouldSkipOfflinePeer } = await import("./sync-pass.js");
+		vi.mocked(shouldSkipOfflinePeer).mockReturnValue(false);
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "fp1", now);
+
+		const results = await syncDaemonTick(db, undefined, new Set());
+		expect(results).toHaveLength(1);
+		expect(results[0].ok).toBe(true);
+		expect(runSyncPass).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -10,6 +10,7 @@ import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import {
 	coordinatorEnabled,
+	fetchCoordinatorStalePeers,
 	readCoordinatorSyncConfig,
 	registerCoordinatorPresence,
 } from "./coordinator-runtime.js";
@@ -137,9 +138,14 @@ export async function refreshCoordinatorPresenceForDaemon(
 /**
  * Run one sync tick: iterate over all enabled peers and sync each.
  *
- * Returns per-peer results. Peers in backoff are skipped.
+ * Returns per-peer results. Peers in backoff or with expired coordinator
+ * presence are skipped.
  */
-export async function syncDaemonTick(db: Database, keysDir?: string): Promise<SyncTickResult[]> {
+export async function syncDaemonTick(
+	db: Database,
+	keysDir?: string,
+	stalePeers?: Set<string>,
+): Promise<SyncTickResult[]> {
 	const d = drizzle(db, { schema });
 	const rows = d
 		.select({ peer_device_id: schema.syncPeers.peer_device_id })
@@ -157,6 +163,15 @@ export async function syncDaemonTick(db: Database, keysDir?: string): Promise<Sy
 	const results: SyncTickResult[] = [];
 	for (const row of rows) {
 		const peerDeviceId = row.peer_device_id;
+
+		if (stalePeers?.has(peerDeviceId)) {
+			results.push({
+				ok: false,
+				skipped: true,
+				reason: "peer offline (coordinator presence expired)",
+			});
+			continue;
+		}
 
 		if (shouldSkipOfflinePeer(db, peerDeviceId)) {
 			results.push({ ok: false, skipped: true, reason: "peer offline (backoff)" });
@@ -269,7 +284,10 @@ export async function runTickOnce(dbPath: string, keysDir?: string): Promise<voi
 			// Coordinator discovery is a supplemental surface. Keep direct peer sync running
 			// even when heartbeat posting fails for this tick.
 		}
-		const results = await syncDaemonTick(db, keysDir);
+		// Best-effort: skip peers the coordinator reports as offline.
+		// Returns empty set when coordinator is disabled or lookup fails.
+		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, keysDir);
+		const results = await syncDaemonTick(db, keysDir, stalePeers);
 		const needsAttention = results.some((r) => !r.ok && r.error?.includes("needs_attention"));
 		if (needsAttention) {
 			setSyncDaemonPhase(db, "needs_attention");


### PR DESCRIPTION
## Description
The sync daemon now queries coordinator peer presence before iterating peers. Peers the coordinator reports as stale (presence expired) are skipped without attempting a connection, avoiding wasted network calls, timeouts, and backoff churn. Falls back gracefully to existing reactive backoff for non-coordinator peers or when the coordinator is unreachable.

Also includes the coordinator admin UI design spec document.

Closes codemem-4ys8

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced