### PR TITLE
fix(sync): keep rejoined coordinator peers reviewable

### DIFF
--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -38,6 +38,7 @@ import {
 	deriveCoordinatorApprovalSummary,
 	resolveFriendlyDeviceName,
 	SYNC_TERMINOLOGY,
+	shouldShowCoordinatorReviewAction,
 	summarizeSyncRunResult,
 } from "./view-model";
 
@@ -440,12 +441,11 @@ export function renderTeamSync() {
 			Boolean(fingerprint) &&
 			Boolean(pairedFingerprint) &&
 			pairedFingerprint !== fingerprint;
-		const canAccept =
-			Boolean(deviceId) &&
-			Boolean(fingerprint) &&
-			!pairedPeer &&
-			!device.stale &&
-			!hasAmbiguousCoordinatorGroup;
+		const canAccept = shouldShowCoordinatorReviewAction({
+			device,
+			hasAmbiguousCoordinatorGroup,
+			pairedLocally: Boolean(pairedPeer),
+		});
 		const addresses = Array.isArray(device.addresses) ? device.addresses : [];
 		const addressLabel = addresses.length
 			? addresses
@@ -472,15 +472,15 @@ export function renderTeamSync() {
 			mode = "scope-pending";
 		} else if (pairedPeer?.last_error) {
 			noteParts.push(`error: ${String(pairedPeer.last_error)}`);
-			mode = "paired";
+			if (!canAccept) mode = "paired";
 		} else if (pairedPeer?.status?.peer_state) {
 			noteParts.push(`status: ${String(pairedPeer.status.peer_state)}`);
-			mode = "paired";
+			if (!canAccept) mode = "paired";
 		} else if (!pairedPeer && device.stale) {
 			actionMessage =
 				"Wait for a fresh coordinator presence update, then review this device again here.";
 			mode = "stale";
-		} else if (pairedPeer) {
+		} else if (pairedPeer && !canAccept) {
 			mode = "paired";
 		}
 		if (mode === "paired") {

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -9,6 +9,7 @@ import {
 	deriveVisiblePeopleActors,
 	deviceNeedsFriendlyName,
 	resolveFriendlyDeviceName,
+	shouldShowCoordinatorReviewAction,
 	summarizeSyncRunResult,
 } from "./view-model";
 
@@ -134,6 +135,49 @@ describe("deriveCoordinatorApprovalSummary", () => {
 				"You already trusted this device here. The other device still needs to approve this one before sync can work both ways.",
 			actionLabel: null,
 		});
+	});
+
+	it("still flags devices that need local approval after a prior local peer record exists", () => {
+		expect(
+			deriveCoordinatorApprovalSummary({
+				device: { device_id: "peer-a", needs_local_approval: true },
+				pairedLocally: true,
+			}),
+		).toEqual({
+			state: "needs-your-approval",
+			badgeLabel: "Needs your approval",
+			description:
+				"Another device already trusted this one. Approve it on this device to finish reciprocal onboarding.",
+			actionLabel: "Approve on this device",
+		});
+	});
+});
+
+describe("shouldShowCoordinatorReviewAction", () => {
+	it("keeps rejoined devices actionable when reciprocal local approval is still needed", () => {
+		expect(
+			shouldShowCoordinatorReviewAction({
+				device: {
+					device_id: "peer-a",
+					fingerprint: "fp-a",
+					needs_local_approval: true,
+				},
+				pairedLocally: true,
+			}),
+		).toBe(true);
+	});
+
+	it("keeps already-paired devices hidden when they are only waiting on the other side", () => {
+		expect(
+			shouldShowCoordinatorReviewAction({
+				device: {
+					device_id: "peer-a",
+					fingerprint: "fp-a",
+					waiting_for_peer_approval: true,
+				},
+				pairedLocally: true,
+			}),
+		).toBe(false);
 	});
 });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -236,7 +236,7 @@ export function deriveCoordinatorApprovalSummary(input: {
 	device: DiscoveredDeviceLike;
 	pairedLocally?: boolean;
 }): UiCoordinatorApprovalSummary {
-	if (Boolean(input.device?.needs_local_approval) && !input.pairedLocally) {
+	if (input.device?.needs_local_approval) {
 		return {
 			state: "needs-your-approval",
 			badgeLabel: "Needs your approval",
@@ -260,6 +260,20 @@ export function deriveCoordinatorApprovalSummary(input: {
 		description: null,
 		actionLabel: null,
 	};
+}
+
+export function shouldShowCoordinatorReviewAction(input: {
+	device: DiscoveredDeviceLike;
+	pairedLocally?: boolean;
+	hasAmbiguousCoordinatorGroup?: boolean;
+}): boolean {
+	const approvalSummary = deriveCoordinatorApprovalSummary(input);
+	const deviceId = cleanText(input.device?.device_id);
+	const fingerprint = cleanText(input.device?.fingerprint);
+	if (!deviceId || !fingerprint) return false;
+	if (Boolean(input.device?.stale) || Boolean(input.hasAmbiguousCoordinatorGroup)) return false;
+	if (!input.pairedLocally) return true;
+	return approvalSummary.state === "needs-your-approval";
 }
 
 export function summarizeSyncRunResult(payload: UiSyncRunResponse): {


### PR DESCRIPTION
## Description
Fixes the Sync discovered-device flow so coordinator peers that were previously known, removed, and later rejoined still surface the local reciprocal approval action instead of collapsing into a generic paired state.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts packages/ui/src/tabs/sync/index.test.ts`
- [x] `pnpm run tsc`

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced