### PR TITLE
fix(sync): return usable pairing addresses from viewer

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2491,6 +2491,48 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("returns pairing payload addresses that the CLI accept flow can use", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_host: "127.0.0.1",
+					sync_port: 7337,
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				const res = await app.request("/api/sync/pairing?includeDiagnostics=1");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					device_id: string;
+					fingerprint: string;
+					public_key: string | null;
+					addresses: string[];
+				};
+				expect(body.device_id).toBeTruthy();
+				expect(body.fingerprint).toBeTruthy();
+				expect(body.public_key).toBeTruthy();
+				expect(body.addresses).toEqual(["127.0.0.1:7337"]);
+			} finally {
+				cleanup();
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
 		it("skips coordinator join request lookup unless includeJoinRequests=1", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
@@ -4671,8 +4713,10 @@ describe("viewer-server", () => {
 		it("reports coordinator admin readiness states", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevAdminSecret = process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
 			try {
 				process.env.CODEMEM_CONFIG = configPath;
+				delete process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
 				writeFileSync(configPath, JSON.stringify({}));
 				const { app, cleanup } = createTestApp();
 				try {
@@ -4735,6 +4779,8 @@ describe("viewer-server", () => {
 			} finally {
 				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
 				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevAdminSecret == null) delete process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET;
+				else process.env.CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET = prevAdminSecret;
 			}
 		});
 

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -5,6 +5,7 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import net from "node:net";
+import { networkInterfaces } from "node:os";
 import { dirname, join } from "node:path";
 import type {
 	CoordinatorBootstrapGrantVerification,
@@ -109,6 +110,31 @@ function coordinatorAdminStatusPayload(config = readCoordinatorSyncConfig()) {
 		has_admin_secret: hasAdminSecret,
 		has_groups: hasGroups,
 	};
+}
+
+function pairingAdvertiseAddresses(config = readCoordinatorSyncConfig()): string[] {
+	const advertise = String(config.syncAdvertise || "auto")
+		.trim()
+		.toLowerCase();
+	if (advertise && advertise !== "auto" && advertise !== "default") {
+		return mergeAddresses(
+			[],
+			String(config.syncAdvertise || "")
+				.split(",")
+				.map((item) => item.trim())
+				.filter(Boolean),
+		);
+	}
+	if (config.syncHost && config.syncHost !== "0.0.0.0") {
+		return [`${config.syncHost}:${config.syncPort}`];
+	}
+	const addresses = Object.values(networkInterfaces())
+		.flatMap((entries) => entries ?? [])
+		.filter((entry) => !entry.internal)
+		.map((entry) => entry.address)
+		.filter((address) => address && address !== "127.0.0.1" && address !== "::1")
+		.map((address) => `${address}:${config.syncPort}`);
+	return [...new Set(addresses)];
 }
 
 function resolveCoordinatorAdminGroup(
@@ -1549,6 +1575,7 @@ export function syncRoutes(
 					pairing_filter_hint: PAIRING_FILTER_HINT,
 				});
 			}
+			const config = readCoordinatorSyncConfig();
 			const d = drizzle(store.db, { schema });
 			const deviceRow = d
 				.select({
@@ -1594,7 +1621,7 @@ export function syncRoutes(
 				fingerprint,
 				public_key: publicKey ?? null,
 				pairing_filter_hint: PAIRING_FILTER_HINT,
-				addresses: [],
+				addresses: pairingAdvertiseAddresses(config),
 			});
 		}
 	});


### PR DESCRIPTION
## Description
Fixes the viewer pairing command path so `/api/sync/pairing` returns usable advertise addresses instead of an empty list. Without addresses, the UI-generated pairing payload was rejected by the CLI accept flow and onboarding fell back to manual recovery.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm exec vitest run packages/viewer-server/src/index.test.ts`
- [x] `pnpm run tsc`

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced