### PR TITLE
fix(ui): gate coordinator admin tab by local admin readiness

### DIFF
--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -11,7 +11,15 @@ declare const __CODEMEM_GIT_COMMIT__: string;
 
 import * as api from "./lib/api";
 import { $, $select } from "./lib/dom";
-import { initState, setActiveTab, state, type TabId } from "./lib/state";
+import {
+	ALL_TAB_IDS,
+	getVisibleTabs,
+	initState,
+	resolveAccessibleTab,
+	setActiveTab,
+	state,
+	type TabId,
+} from "./lib/state";
 import { getTheme, initThemeSelect, setTheme } from "./lib/theme";
 
 import { initCoordinatorAdminTab, loadCoordinatorAdminData } from "./tabs/coordinator-admin";
@@ -175,29 +183,32 @@ document.addEventListener("visibilitychange", () => {
 
 /* ── Tab routing ─────────────────────────────────────────── */
 
-const TAB_IDS: TabId[] = ["feed", "health", "sync", "coordinator-admin"];
+function renderTabs(activeTab: TabId) {
+	const visibleTabs = new Set(getVisibleTabs(state.lastCoordinatorAdminStatus));
+	ALL_TAB_IDS.forEach((id) => {
+		const panel = $(`tab-${id}`);
+		if (panel) panel.hidden = id !== activeTab || !visibleTabs.has(id);
+	});
+
+	ALL_TAB_IDS.forEach((id) => {
+		const btn = $(`tabBtn-${id}`);
+		if (!btn) return;
+		btn.hidden = !visibleTabs.has(id);
+		btn.classList.toggle("active", id === activeTab && visibleTabs.has(id));
+	});
+}
 
 function switchTab(tab: TabId) {
-	setActiveTab(tab);
-
-	// Toggle tab panels
-	TAB_IDS.forEach((id) => {
-		const panel = $(`tab-${id}`);
-		if (panel) panel.hidden = id !== tab;
-	});
-
-	// Toggle tab buttons
-	TAB_IDS.forEach((id) => {
-		const btn = $(`tabBtn-${id}`);
-		if (btn) btn.classList.toggle("active", id === tab);
-	});
+	const nextTab = resolveAccessibleTab(tab, state.lastCoordinatorAdminStatus);
+	setActiveTab(nextTab);
+	renderTabs(nextTab);
 
 	// Refresh data for active tab
 	refresh();
 }
 
 function initTabs() {
-	TAB_IDS.forEach((id) => {
+	ALL_TAB_IDS.forEach((id) => {
 		const btn = $(`tabBtn-${id}`);
 		btn?.addEventListener("click", () => switchTab(id));
 	});
@@ -205,7 +216,7 @@ function initTabs() {
 	// Listen for hash changes (back/forward navigation)
 	window.addEventListener("hashchange", () => {
 		const hash = window.location.hash.replace("#", "") as TabId;
-		if (TAB_IDS.includes(hash) && hash !== state.activeTab) {
+		if (ALL_TAB_IDS.includes(hash) && hash !== state.activeTab) {
 			switchTab(hash);
 		}
 	});
@@ -263,18 +274,52 @@ async function doRefresh() {
 	try {
 		setRefreshStatus("refreshing");
 
+		let refreshTab = state.activeTab;
+		if (refreshTab === "coordinator-admin") {
+			try {
+				const status = await api.loadCoordinatorAdminStatus();
+				state.lastCoordinatorAdminStatus =
+					status && typeof status === "object"
+						? (status as typeof state.lastCoordinatorAdminStatus)
+						: null;
+			} catch {
+				state.lastCoordinatorAdminStatus = null;
+			}
+			refreshTab = state.activeTab;
+			refreshTab = resolveAccessibleTab(refreshTab, state.lastCoordinatorAdminStatus);
+			if (refreshTab !== state.activeTab) {
+				setActiveTab(refreshTab);
+				renderTabs(refreshTab);
+			}
+		}
+
 		// Always load health data (for the header health dot) and config
 		const promises: Promise<unknown>[] = [loadHealthData(), loadConfigData()];
+		if (refreshTab === "feed") {
+			promises.push(
+				api
+					.loadCoordinatorAdminStatus()
+					.then((status) => {
+						state.lastCoordinatorAdminStatus =
+							status && typeof status === "object"
+								? (status as typeof state.lastCoordinatorAdminStatus)
+								: null;
+					})
+					.catch(() => {
+						state.lastCoordinatorAdminStatus = null;
+					}),
+			);
+		}
 
 		// Load tab-specific data
-		if (state.activeTab === "feed") {
+		if (refreshTab === "feed") {
 			promises.push(loadFeedData());
 		}
 		// Sync data is needed by both Sync tab and Health tab (health cards derive sync state)
-		if (state.activeTab === "sync" || state.activeTab === "health") {
+		if (refreshTab === "sync" || refreshTab === "health") {
 			promises.push(loadSyncData());
 		}
-		if (state.activeTab === "coordinator-admin") {
+		if (refreshTab === "coordinator-admin") {
 			promises.push(loadCoordinatorAdminData());
 		}
 
@@ -284,6 +329,11 @@ async function doRefresh() {
 		}
 
 		await Promise.all(promises);
+		const nextTab = resolveAccessibleTab(state.activeTab, state.lastCoordinatorAdminStatus);
+		if (nextTab !== state.activeTab) {
+			setActiveTab(nextTab);
+		}
+		renderTabs(state.activeTab);
 		setRefreshStatus("idle");
 	} catch {
 		const ready = await isViewerReady();

--- a/packages/ui/src/lib/state.test.ts
+++ b/packages/ui/src/lib/state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	type CachedCoordinatorAdminStatus,
+	getVisibleTabs,
+	resolveAccessibleTab,
+	shouldShowCoordinatorAdminTab,
+} from "./state";
+
+describe("Coordinator Admin tab gating", () => {
+	it("keeps the tab visible while admin status is still unknown", () => {
+		expect(shouldShowCoordinatorAdminTab(null)).toBe(true);
+		expect(getVisibleTabs(null)).toContain("coordinator-admin");
+	});
+
+	it("hides the tab when the admin secret is missing", () => {
+		const status: CachedCoordinatorAdminStatus = {
+			has_admin_secret: false,
+			readiness: "partial",
+		};
+
+		expect(shouldShowCoordinatorAdminTab(status)).toBe(false);
+		expect(getVisibleTabs(status)).not.toContain("coordinator-admin");
+	});
+
+	it("keeps the tab visible when the admin secret is configured", () => {
+		const status: CachedCoordinatorAdminStatus = {
+			has_admin_secret: true,
+			readiness: "ready",
+		};
+
+		expect(shouldShowCoordinatorAdminTab(status)).toBe(true);
+		expect(getVisibleTabs(status)).toContain("coordinator-admin");
+	});
+
+	it("falls back to sync when the current tab becomes inaccessible", () => {
+		const status: CachedCoordinatorAdminStatus = {
+			has_admin_secret: false,
+			readiness: "partial",
+		};
+
+		expect(resolveAccessibleTab("coordinator-admin", status)).toBe("sync");
+		expect(resolveAccessibleTab("feed", status)).toBe("feed");
+	});
+});

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -4,6 +4,7 @@ import type { UiSyncViewModel } from "../tabs/sync/view-model";
 
 export type RefreshState = "idle" | "refreshing" | "paused" | "error";
 export type TabId = "feed" | "health" | "sync" | "coordinator-admin";
+export const ALL_TAB_IDS: TabId[] = ["feed", "health", "sync", "coordinator-admin"];
 
 /* ── Cached server payload shapes ─────────────────────────── */
 
@@ -262,22 +263,44 @@ export const state = {
 	syncPairingOpen: false,
 };
 
+export function shouldShowCoordinatorAdminTab(
+	status: CachedCoordinatorAdminStatus | null | undefined,
+): boolean {
+	if (!status) return true;
+	return status.has_admin_secret === true;
+}
+
+export function getVisibleTabs(status: CachedCoordinatorAdminStatus | null | undefined): TabId[] {
+	return shouldShowCoordinatorAdminTab(status)
+		? [...ALL_TAB_IDS]
+		: ALL_TAB_IDS.filter((tabId) => tabId !== "coordinator-admin");
+}
+
+export function resolveAccessibleTab(
+	tab: TabId,
+	status: CachedCoordinatorAdminStatus | null | undefined,
+): TabId {
+	return getVisibleTabs(status).includes(tab) ? tab : "sync";
+}
+
 /* ── Persistence helpers ───────────────────────────────────── */
 
 export function getActiveTab(): TabId {
 	const hash = window.location.hash.replace("#", "") as TabId;
-	if (["feed", "health", "sync", "coordinator-admin"].includes(hash)) return hash;
+	if (ALL_TAB_IDS.includes(hash))
+		return resolveAccessibleTab(hash, state.lastCoordinatorAdminStatus);
 	const saved = localStorage.getItem(TAB_KEY);
-	if (saved && ["feed", "health", "sync", "coordinator-admin"].includes(saved)) {
-		return saved as TabId;
+	if (saved && ALL_TAB_IDS.includes(saved as TabId)) {
+		return resolveAccessibleTab(saved as TabId, state.lastCoordinatorAdminStatus);
 	}
 	return "feed";
 }
 
 export function setActiveTab(tab: TabId) {
-	state.activeTab = tab;
-	window.location.hash = tab;
-	localStorage.setItem(TAB_KEY, tab);
+	const nextTab = resolveAccessibleTab(tab, state.lastCoordinatorAdminStatus);
+	state.activeTab = nextTab;
+	window.location.hash = nextTab;
+	localStorage.setItem(TAB_KEY, nextTab);
 }
 
 export function getFeedTypeFilter(): FeedFilter {


### PR DESCRIPTION
## Description
Gates the Coordinator Admin tab on local admin readiness so the viewer stops advertising a non-actionable admin destination when no local coordinator admin secret is configured. The UI now hides the tab once status is known and falls back to the Sync tab if a saved or deep-linked Coordinator Admin route becomes inaccessible.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm exec vitest run packages/ui/src/lib/state.test.ts packages/ui/src/tabs/sync/index.test.ts packages/ui/src/tabs/sync/view-model.test.ts`
- [x] `pnpm run tsc`

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced