### PR TITLE
fix(sync): clarify offline peer attempt history

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
@@ -38,9 +38,10 @@ function DiagnosticsGrid({ items }: { items: SyncStatItem[] }) {
 	);
 }
 
-function AttemptsList({ attempts }: { attempts: SyncAttemptItem[] }) {
+function AttemptsList({ attempts, note }: { attempts: SyncAttemptItem[]; note?: string }) {
 	return (
 		<Fragment>
+			{note ? <div class="small">{note}</div> : null}
 			{attempts.map((attempt, index) => (
 				<div class="diag-line" key={`${attempt.startedAt}-${attempt.peerLabel}-${index}`}>
 					<div class="left">
@@ -78,13 +79,13 @@ export function renderDiagnosticsGrid(mount: HTMLElement, items: SyncStatItem[])
 	renderIntoSyncMount(mount, <DiagnosticsGrid items={items} />);
 }
 
-export function renderAttemptsList(mount: HTMLElement, attempts: SyncAttemptItem[]) {
+export function renderAttemptsList(mount: HTMLElement, attempts: SyncAttemptItem[], note?: string) {
 	if (!attempts.length) {
 		clearSyncMount(mount);
 		return;
 	}
 
-	renderIntoSyncMount(mount, <AttemptsList attempts={attempts} />);
+	renderIntoSyncMount(mount, <AttemptsList attempts={attempts} note={note} />);
 }
 
 export function renderSyncEmptyState(mount: HTMLElement, view: SyncEmptyStateView) {

--- a/packages/ui/src/tabs/sync/diagnostics.test.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { syncAttemptsHistoryNote } from "./diagnostics";
+
+describe("syncAttemptsHistoryNote", () => {
+	it("explains that offline-peer attempts may be historical", () => {
+		expect(syncAttemptsHistoryNote("offline-peers", true)).toContain(
+			"before all peers went offline",
+		);
+	});
+
+	it("stays empty when there are no visible failures to explain", () => {
+		expect(syncAttemptsHistoryNote("offline-peers", false)).toBe("");
+	});
+
+	it("stays empty for other daemon states", () => {
+		expect(syncAttemptsHistoryNote("ok", true)).toBe("");
+		expect(syncAttemptsHistoryNote("stale", true)).toBe("");
+	});
+});

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -357,10 +357,16 @@ export function renderSyncAttempts() {
 	if (!syncAttempts) return;
 
 	const attempts = state.lastSyncAttempts as SyncAttemptState[];
+	const daemonState = String(state.lastSyncStatus?.daemon_state || "").trim();
 	if (!Array.isArray(attempts) || !attempts.length) {
 		renderSyncEmptyState(syncAttempts, noAttemptsState());
 		return;
 	}
+
+	const historyOnlyNote = syncAttemptsHistoryNote(
+		daemonState,
+		attempts.slice(0, 5).some((attempt) => attempt.status === "error"),
+	);
 
 	const items: SyncAttemptItem[] = attempts.slice(0, 5).map((attempt) => {
 		const time = attempt.started_at || attempt.started_at_utc || "";
@@ -392,7 +398,13 @@ export function renderSyncAttempts() {
 		};
 	});
 
-	renderAttemptsList(syncAttempts, items);
+	renderAttemptsList(syncAttempts, items, historyOnlyNote);
+}
+
+export function syncAttemptsHistoryNote(daemonState: string, hasVisibleErrors: boolean): string {
+	return daemonState === "offline-peers" && hasVisibleErrors
+		? "Some recent failures may have happened before all peers went offline. Sync will resume automatically when a peer becomes reachable."
+		: "";
 }
 
 export function renderSyncDiagnosticsUnavailable() {


### PR DESCRIPTION
## Description
Clarifies the Sync diagnostics attempts list when the daemon is already in `offline-peers` mode. Instead of making recent failed attempts look like active ongoing retries, the UI now explains that the visible failures may predate the current offline state and that sync will resume automatically when a peer becomes reachable.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm exec vitest run packages/ui/src/tabs/sync/diagnostics.test.ts packages/ui/src/lib/state.test.ts packages/ui/src/tabs/sync/index.test.ts packages/ui/src/tabs/sync/view-model.test.ts`
- [x] `pnpm run tsc`

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced