### PR TITLE
fix(sync): prefer last working coordinator address

### DIFF
--- a/packages/core/src/sync-discovery.ts
+++ b/packages/core/src/sync-discovery.ts
@@ -158,23 +158,27 @@ export function recordPeerSuccess(
 	peerDeviceId: string,
 	address: string | null,
 ): string[] {
-	const addresses = loadPeerAddresses(db, peerDeviceId);
 	const normalized = normalizeAddress(address ?? "");
-	let ordered = addresses;
-	if (normalized) {
-		const remaining = addresses.filter((item) => normalizeAddress(item) !== normalized);
-		ordered = [normalized, ...remaining];
+	const now = new Date().toISOString();
+	const promote = db.transaction((deviceId: string, promotedAddress: string, syncedAt: string) => {
+		const addresses = loadPeerAddresses(db, deviceId);
+		const remaining = promotedAddress
+			? addresses.filter((item) => normalizeAddress(item) !== promotedAddress)
+			: addresses;
+		const ordered = promotedAddress ? [promotedAddress, ...remaining] : addresses;
 		const d = drizzle(db, { schema });
 		d.update(schema.syncPeers)
 			.set({
 				addresses_json: JSON.stringify(ordered),
-				last_sync_at: new Date().toISOString(),
+				last_sync_at: syncedAt,
+				last_seen_at: syncedAt,
 				last_error: null,
 			})
-			.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
+			.where(eq(schema.syncPeers.peer_device_id, deviceId))
 			.run();
-	}
-	return ordered;
+		return ordered;
+	});
+	return promote.immediate(peerDeviceId, normalized, now);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -313,6 +313,68 @@ describe("syncOnce", () => {
 			expect.objectContaining({ upsertMemoryIds: [expect.any(Number)], deleteMemoryIds: [] }),
 		);
 	});
+
+	it("promotes the working address after falling back from an unreachable candidate", async () => {
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, addresses_json, created_at) VALUES (?, ?, ?, ?)",
+		).run(
+			"peer-1",
+			"abc123",
+			JSON.stringify(["http://10.0.0.9:9090", "http://100.64.0.5:9090"]),
+			new Date().toISOString(),
+		);
+		db.prepare(
+			"INSERT INTO replication_cursors (peer_device_id, last_applied_cursor, last_acked_cursor, updated_at) VALUES (?, ?, ?, ?)",
+		).run("peer-1", "2025-12-31T00:00:00Z|local-op-0", null, new Date().toISOString());
+		vi.spyOn(syncIdentity, "ensureDeviceIdentity").mockReturnValue([
+			"local-device-id",
+			"ed25519 AAAA",
+		]);
+		vi.spyOn(syncAuth, "buildAuthHeaders").mockReturnValue({});
+
+		vi.spyOn(syncHttpClient, "requestJson")
+			.mockRejectedValueOnce(new Error("network is unreachable"))
+			.mockResolvedValueOnce([
+				200,
+				{
+					fingerprint: "abc123",
+					protocol_version: "2",
+					sync_reset: {
+						generation: 1,
+						snapshot_id: "snap-1",
+						baseline_cursor: null,
+						retained_floor_cursor: null,
+					},
+				},
+			])
+			.mockResolvedValueOnce([
+				200,
+				{
+					reset_required: false,
+					generation: 1,
+					snapshot_id: "snap-1",
+					baseline_cursor: null,
+					retained_floor_cursor: null,
+					ops: [],
+					next_cursor: null,
+					skipped: 0,
+				},
+			]);
+
+		const result = await syncOnce(db, "peer-1", ["http://10.0.0.9:9090", "http://100.64.0.5:9090"]);
+
+		if (!result.ok) {
+			throw new Error(`syncOnce failed: ${result.error ?? "unknown error"}`);
+		}
+		expect(result.address).toBe("http://100.64.0.5:9090");
+		const row = db
+			.prepare("SELECT addresses_json FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as { addresses_json: string };
+		expect(JSON.parse(row.addresses_json)).toEqual([
+			"http://100.64.0.5:9090",
+			"http://10.0.0.9:9090",
+		]);
+	});
 });
 
 describe("syncPassPreflight", () => {

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -12,6 +12,7 @@ import type { Database } from "./db.js";
 import * as schema from "./schema.js";
 import { buildAuthHeaders } from "./sync-auth.js";
 import { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
+import { recordPeerSuccess } from "./sync-discovery.js";
 import { buildBaseUrl, requestJson } from "./sync-http-client.js";
 import { ensureDeviceIdentity } from "./sync-identity.js";
 import {
@@ -181,18 +182,6 @@ function recordSyncAttempt(
 			ops_out: options.opsOut ?? 0,
 			error: options.error ?? null,
 		})
-		.run();
-}
-
-/**
- * Update last_sync_at and clear last_error on successful sync.
- */
-function recordPeerSuccess(db: Database, peerDeviceId: string): void {
-	const d = drizzle(db, { schema });
-	const now = new Date().toISOString();
-	d.update(schema.syncPeers)
-		.set({ last_sync_at: now, last_seen_at: now, last_error: null })
-		.where(eq(schema.syncPeers.peer_device_id, peerDeviceId))
 		.run();
 }
 
@@ -458,7 +447,7 @@ export async function syncOnce(
 						if (!bootstrapResult.ok) {
 							throw new Error("initial bootstrap apply failed");
 						}
-						recordPeerSuccess(db, peerDeviceId);
+						recordPeerSuccess(db, peerDeviceId, baseUrl);
 						recordSyncAttempt(db, peerDeviceId, {
 							ok: true,
 							opsIn: bootstrapResult.applied,
@@ -569,7 +558,7 @@ export async function syncOnce(
 					if (!bootstrapResult.ok) {
 						throw new Error("bootstrap apply failed");
 					}
-					recordPeerSuccess(db, peerDeviceId);
+					recordPeerSuccess(db, peerDeviceId, baseUrl);
 					recordSyncAttempt(db, peerDeviceId, {
 						ok: true,
 						opsIn: bootstrapResult.applied,
@@ -655,7 +644,7 @@ export async function syncOnce(
 			}
 
 			// -- 6. Record success --
-			recordPeerSuccess(db, peerDeviceId);
+			recordPeerSuccess(db, peerDeviceId, baseUrl);
 			recordSyncAttempt(db, peerDeviceId, {
 				ok: true,
 				opsIn: applied.applied,


### PR DESCRIPTION
## Description
Makes coordinator-backed sync sticky to the last known working peer address while preserving fallback behavior. Successful syncs now promote the winning address to the front of the stored peer address list, so future syncs try that route first instead of repeatedly starting with stale or unroutable candidates.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] `pnpm exec vitest run packages/core/src/sync-pass.test.ts packages/core/src/sync-discovery.test.ts`
- [x] `pnpm run tsc`

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced