### PR TITLE
fix(core): sanitize contaminated retrieval queries

### DIFF
--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -247,6 +247,27 @@ describe("buildMemoryPack", () => {
 		expect(pack.context).toBe("my test context");
 	});
 
+	it("sanitizes prompt-prefixed context before pack retrieval", () => {
+		store.remember(
+			sessionId,
+			"decision",
+			"Use PostgreSQL JSONB",
+			"Chose PostgreSQL because JSONB support simplified auth metadata storage",
+			0.9,
+		);
+
+		const pack = buildMemoryPack(
+			store,
+			[
+				"You are a retrieval assistant.",
+				"Output only XML.",
+				"What did we decide about PostgreSQL JSONB support?",
+			].join("\n"),
+		);
+
+		expect(pack.items.some((item) => item.title === "Use PostgreSQL JSONB")).toBe(true);
+	});
+
 	it("builds a deterministic pack trace with pack parity", () => {
 		store.remember(
 			sessionId,
@@ -335,9 +356,10 @@ describe("buildMemoryPack", () => {
 
 		expect(collapsedGroup).toBeTruthy();
 		expect(collapsedGroup?.support_count).toBe(2);
-		expect(
-			[collapsedGroup?.kept, ...(collapsedGroup?.dropped ?? [])].sort((a, b) => a - b),
-		).toEqual([canonicalId, duplicateId].sort((a, b) => a - b));
+		const collapsedIds = [collapsedGroup?.kept ?? -1, ...(collapsedGroup?.dropped ?? [])];
+		expect(collapsedIds.sort((a, b) => a - b)).toEqual(
+			[canonicalId, duplicateId].sort((a, b) => a - b),
+		);
 		for (const droppedId of collapsedGroup?.dropped ?? []) {
 			expect(trace.assembly.deduped_ids).toContain(droppedId);
 		}

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -17,6 +17,7 @@
 import type { Database } from "./db.js";
 import { buildFilterClausesWithContext } from "./filters.js";
 import { projectBasename } from "./project.js";
+import { sanitizeSearchQuery } from "./query-sanitizer.js";
 import { memoryLooksRecapLike, queryPrefersRecap } from "./recap-policy.js";
 import type { StoreHandle } from "./search.js";
 import { findCandidatesByFile, rerankResults, scoreResult, search, timeline } from "./search.js";
@@ -1116,17 +1117,18 @@ function buildPackArtifacts(
 	},
 ): PackArtifacts {
 	const effectiveLimit = Math.max(1, Math.trunc(limit));
+	const retrievalContext = sanitizeSearchQuery(context).clean_query;
 	let fallbackUsed = false;
 	let ftsCount = 0;
 	let semanticCount = 0;
 	let retrievalResults: MemoryResult[] = [];
-	let retrievalQuery = context;
+	let retrievalQuery = retrievalContext;
 	let results: MemoryResult[];
-	const taskMode = queryLooksLikeTasks(context);
-	const recallMode = !taskMode && queryLooksLikeRecall(context);
+	const taskMode = queryLooksLikeTasks(retrievalContext);
+	const recallMode = !taskMode && queryLooksLikeRecall(retrievalContext);
 
 	if (taskMode) {
-		const taskQuery = `${context} ${TASK_HINT_QUERY}`.trim();
+		const taskQuery = `${retrievalContext} ${TASK_HINT_QUERY}`.trim();
 		retrievalQuery = taskQuery;
 		let taskResults = search(store, taskQuery, effectiveLimit, filters);
 		ftsCount = taskResults.length;
@@ -1160,11 +1162,11 @@ function buildPackArtifacts(
 						? actionableTaskResults
 						: taskResults,
 				effectiveLimit,
-				context,
+				retrievalContext,
 			);
 		}
 	} else if (recallMode) {
-		const recallQuery = context.trim().length > 0 ? context : RECALL_HINT_QUERY;
+		const recallQuery = retrievalContext.trim().length > 0 ? retrievalContext : RECALL_HINT_QUERY;
 		retrievalQuery = recallQuery;
 		const preferSummary = queryPrefersRecap(recallQuery);
 		const wantsTimeline = recallQueryWantsTimeline(recallQuery);
@@ -1207,7 +1209,12 @@ function buildPackArtifacts(
 		}
 		recallResults = mergeFileRefCandidates(store, recallResults, filters, effectiveLimit);
 		retrievalResults = [...recallResults];
-		results = prioritizeRecallResults(recallResults, effectiveLimit, preferSummary, context);
+		results = prioritizeRecallResults(
+			recallResults,
+			effectiveLimit,
+			preferSummary,
+			retrievalContext,
+		);
 		if (results.length === 0) {
 			fallbackUsed = true;
 			results = recallFallbackRecent(store, effectiveLimit, filters);
@@ -1232,27 +1239,27 @@ function buildPackArtifacts(
 			}
 		}
 	} else {
-		const ftsResults = search(store, context, effectiveLimit, filters);
+		const ftsResults = search(store, retrievalContext, effectiveLimit, filters);
 		if (semanticResults && semanticResults.length > 0) {
 			const merge = mergeResults(
 				store,
 				ftsResults,
 				semanticResults,
 				effectiveLimit,
-				context,
+				retrievalContext,
 				filters,
 			);
-			results = prioritizeDefaultResults(merge.merged, effectiveLimit, context);
+			results = prioritizeDefaultResults(merge.merged, effectiveLimit, retrievalContext);
 			ftsCount = merge.ftsCount;
 			semanticCount = merge.semanticCount;
 			retrievalResults = [...merge.merged];
 		} else {
-			results = prioritizeDefaultResults(ftsResults, effectiveLimit, context);
+			results = prioritizeDefaultResults(ftsResults, effectiveLimit, retrievalContext);
 			ftsCount = results.length;
 			retrievalResults = [...ftsResults];
 		}
 		results = mergeFileRefCandidates(store, results, filters, effectiveLimit);
-		results = prioritizeDefaultResults(results, effectiveLimit, context);
+		results = prioritizeDefaultResults(results, effectiveLimit, retrievalContext);
 
 		if (results.length === 0) {
 			fallbackUsed = true;
@@ -1265,11 +1272,11 @@ function buildPackArtifacts(
 	// Summary: prefer search match; only inject a global fallback when the user
 	// explicitly wants a summary or we're in non-recall mode.
 	const directSummaryMatches =
-		recallMode && !queryPrefersRecap(context)
+		recallMode && !queryPrefersRecap(retrievalContext)
 			? results.filter((item) => isNativeSessionSummaryMemory(item))
 			: results.filter(isSummaryLike);
 	let summaryItems = directSummaryMatches.slice(0, 1);
-	const allowGlobalSummaryFallback = !recallMode || queryPrefersRecap(context);
+	const allowGlobalSummaryFallback = !recallMode || queryPrefersRecap(retrievalContext);
 	if (summaryItems.length === 0 && allowGlobalSummaryFallback) {
 		const s = findLatestSummaryLike(store, filters);
 		if (s) {
@@ -1538,6 +1545,14 @@ function buildPackArtifacts(
 	}
 
 	const allItems = selectedItems.map((item) => toPackItem(item, dedupeState, clusterState));
+	const seenAllItemIds = new Set(allItemIds);
+	for (const item of allItems) {
+		for (const compressedId of item.compressed_ids ?? []) {
+			if (seenAllItemIds.has(compressedId)) continue;
+			seenAllItemIds.add(compressedId);
+			allItemIds.push(compressedId);
+		}
+	}
 
 	const { previousPackIds, previousPackTokens } = getPackDeltaBaseline(
 		store,
@@ -1788,8 +1803,9 @@ export async function buildMemoryPackAsync(
 ): Promise<PackResponse> {
 	// Run semantic search (returns [] when embeddings unavailable)
 	let semResults: MemoryResult[] = [];
+	const semanticQuery = sanitizeSearchQuery(context).clean_query;
 	try {
-		const raw = await semanticSearch(store.db, context, limit, {
+		const raw = await semanticSearch(store.db, semanticQuery, limit, {
 			project: filters?.project,
 		});
 		semResults = semanticMemoryResults(raw);
@@ -1813,8 +1829,9 @@ export async function buildMemoryPackTraceAsync(
 	renderOptions?: PackRenderOptions,
 ): Promise<PackTrace> {
 	let semResults: MemoryResult[] = [];
+	const semanticQuery = sanitizeSearchQuery(context).clean_query;
 	try {
-		const raw = await semanticSearch(store.db, context, limit, {
+		const raw = await semanticSearch(store.db, semanticQuery, limit, {
 			project: filters?.project,
 		});
 		semResults = semanticMemoryResults(raw);

--- a/packages/core/src/query-sanitizer.ts
+++ b/packages/core/src/query-sanitizer.ts
@@ -1,0 +1,167 @@
+const MAX_QUERY_LENGTH = 250;
+const MIN_QUERY_LENGTH = 10;
+const QUOTE_CHARS = new Set(["'", '"']);
+
+const SENTENCE_SPLIT_RE = /[.!?。！？\n]+/;
+const TRAILING_QUESTION_RE = /[?？]\s*["']?\s*$/;
+const INSTRUCTION_PREFIX_PATTERNS = [
+	/^you are\b/i,
+	/^output only\b/i,
+	/^at task start\b/i,
+	/^always emit\b/i,
+	/^focus on\b/i,
+	/^use outcome-focused\b/i,
+	/^<\/?(?:summary|observation|request|facts|fact|notes|system|instructions?)>/i,
+];
+
+export type SanitizedQueryMethod =
+	| "passthrough"
+	| "instruction_prefix_trim"
+	| "question_extraction"
+	| "tail_sentence"
+	| "tail_truncation";
+
+export interface SanitizedQuery {
+	clean_query: string;
+	was_sanitized: boolean;
+	method: SanitizedQueryMethod;
+	reasons: string[];
+}
+
+function stripWrappingQuotes(value: string): string {
+	let candidate = value.trim();
+	while (
+		candidate.length >= 2 &&
+		QUOTE_CHARS.has(candidate[0] ?? "") &&
+		candidate[0] === candidate[candidate.length - 1]
+	) {
+		candidate = candidate.slice(1, -1).trim();
+	}
+	if (QUOTE_CHARS.has(candidate[0] ?? "")) candidate = candidate.slice(1).trim();
+	if (QUOTE_CHARS.has(candidate[candidate.length - 1] ?? ""))
+		candidate = candidate.slice(0, -1).trim();
+	return candidate;
+}
+
+function splitSegments(value: string): string[] {
+	return value
+		.split(/\n+/)
+		.map((segment) => segment.trim())
+		.filter(Boolean);
+}
+
+function trimCandidate(value: string): string {
+	const candidate = stripWrappingQuotes(value);
+	if (candidate.length <= MAX_QUERY_LENGTH) return candidate;
+	const nested = candidate
+		.split(SENTENCE_SPLIT_RE)
+		.map((segment) => stripWrappingQuotes(segment))
+		.filter((segment) => segment.length >= MIN_QUERY_LENGTH && segment.length <= MAX_QUERY_LENGTH);
+	if (nested.length > 0)
+		return nested[nested.length - 1] ?? candidate.slice(-MAX_QUERY_LENGTH).trim();
+	return candidate.slice(-MAX_QUERY_LENGTH).trim();
+}
+
+function looksInstructionLike(segment: string): boolean {
+	const trimmed = segment.trim();
+	if (!trimmed) return false;
+	if (trimmed.length < MIN_QUERY_LENGTH) return false;
+	return INSTRUCTION_PREFIX_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+function looksContaminated(raw: string, segments: string[]): boolean {
+	if (raw.includes("<") || raw.includes(">")) return true;
+	if (looksInstructionLike(raw)) return true;
+	if (
+		raw.includes("Output only") ||
+		raw.includes("Never mention") ||
+		raw.includes("At task start")
+	) {
+		return true;
+	}
+	if (segments.some((segment) => looksInstructionLike(segment))) return true;
+	return false;
+}
+
+function extractQuestionSentence(raw: string): string | null {
+	const fragments = raw.match(/[^.!?。！？\n]+[.!?。！？]?/g) ?? [];
+	for (const fragment of [...fragments].reverse()) {
+		if (!fragment.includes("?") && !fragment.includes("？")) continue;
+		const candidate = trimCandidate(fragment);
+		if (candidate.length >= MIN_QUERY_LENGTH) return candidate;
+	}
+	return null;
+}
+
+function buildResult(
+	rawQuery: string,
+	cleanQuery: string,
+	method: SanitizedQueryMethod,
+	reasons: string[],
+): SanitizedQuery {
+	const finalQuery = cleanQuery.trim() || rawQuery.trim();
+	return {
+		clean_query: finalQuery,
+		was_sanitized: finalQuery !== rawQuery.trim(),
+		method: finalQuery === rawQuery.trim() ? "passthrough" : method,
+		reasons,
+	};
+}
+
+export function sanitizeSearchQuery(rawQuery: string): SanitizedQuery {
+	const raw = String(rawQuery ?? "").trim();
+	if (!raw) return buildResult("", "", "passthrough", []);
+
+	const segments = splitSegments(raw);
+	const contaminated = looksContaminated(raw, segments);
+	if (raw.length <= MAX_QUERY_LENGTH && !contaminated) {
+		return buildResult(raw, raw, "passthrough", []);
+	}
+
+	const reasons: string[] = [];
+
+	if (segments.length > 1 && looksInstructionLike(segments[0] ?? "")) {
+		const tail = segments.filter((segment, index) => index > 0 && !looksInstructionLike(segment));
+		const candidate = trimCandidate(tail[tail.length - 1] ?? "");
+		if (candidate.length >= MIN_QUERY_LENGTH) {
+			reasons.push("instruction_prefix");
+			return buildResult(raw, candidate, "instruction_prefix_trim", reasons);
+		}
+	}
+
+	const questionSentence = extractQuestionSentence(raw);
+	if (questionSentence) {
+		reasons.push("question_sentence");
+		return buildResult(raw, questionSentence, "question_extraction", reasons);
+	}
+
+	for (const segment of [...segments].reverse()) {
+		if (!TRAILING_QUESTION_RE.test(segment)) continue;
+		const candidate = trimCandidate(segment);
+		if (candidate.length >= MIN_QUERY_LENGTH) {
+			reasons.push("question_segment");
+			return buildResult(raw, candidate, "question_extraction", reasons);
+		}
+	}
+
+	if (!contaminated) {
+		return buildResult(raw, raw, "passthrough", reasons);
+	}
+
+	for (const segment of [...segments].reverse()) {
+		const candidate = trimCandidate(segment);
+		if (candidate.length < MIN_QUERY_LENGTH) continue;
+		if (candidate === raw && raw.length <= MAX_QUERY_LENGTH) continue;
+		if (looksInstructionLike(candidate)) continue;
+		reasons.push("tail_segment");
+		return buildResult(raw, candidate, "tail_sentence", reasons);
+	}
+
+	const truncated = trimCandidate(raw);
+	if (truncated.length >= MIN_QUERY_LENGTH && truncated !== raw) {
+		reasons.push("tail_truncation");
+		return buildResult(raw, truncated, "tail_truncation", reasons);
+	}
+
+	return buildResult(raw, raw, "passthrough", reasons);
+}

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connect } from "./db.js";
+import { sanitizeSearchQuery } from "./query-sanitizer.js";
 import { expandQuery, kindBonus, recencyScore, rerankResults } from "./search.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
@@ -74,6 +75,60 @@ describe("expandQuery", () => {
 		expect(expandQuery("sessionization summary emission")).toBe(
 			"sessionization OR summary OR emission",
 		);
+	});
+});
+
+describe("sanitizeSearchQuery", () => {
+	it("passes through short normal queries", () => {
+		const result = sanitizeSearchQuery("what did we decide about oauth");
+		expect(result.clean_query).toBe("what did we decide about oauth");
+		expect(result.was_sanitized).toBe(false);
+		expect(result.method).toBe("passthrough");
+	});
+
+	it("extracts the trailing question from prompt-contaminated queries", () => {
+		const result = sanitizeSearchQuery(
+			[
+				"You are a memory retrieval assistant.",
+				"Output only JSON.",
+				"Never mention policies.",
+				"",
+				"What did we decide about oauth token refresh?",
+			].join("\n"),
+		);
+		expect(result.clean_query).toBe("What did we decide about oauth token refresh?");
+		expect(result.was_sanitized).toBe(true);
+		expect(result.method).toBe("instruction_prefix_trim");
+	});
+
+	it("falls back to the last meaningful tail segment when no question exists", () => {
+		const result = sanitizeSearchQuery(
+			[
+				"<summary>",
+				"  <request>Inspect prior work</request>",
+				"</summary>",
+				"OAuth callback failure during token refresh",
+			].join("\n"),
+		);
+		expect(result.clean_query).toBe("OAuth callback failure during token refresh");
+		expect(result.was_sanitized).toBe(true);
+		expect(result.method).toBe("tail_sentence");
+	});
+
+	it("preserves legitimate multiline queries when no contamination markers exist", () => {
+		const result = sanitizeSearchQuery("oauth token refresh\nplease answer briefly");
+		expect(result.clean_query).toBe("oauth token refresh\nplease answer briefly");
+		expect(result.was_sanitized).toBe(false);
+		expect(result.method).toBe("passthrough");
+	});
+
+	it("extracts embedded questions from long one-line contaminated prompts", () => {
+		const result = sanitizeSearchQuery(
+			"You are a memory retrieval assistant. Output only JSON. Never mention policies. What did we decide about oauth token refresh?",
+		);
+		expect(result.clean_query).toBe("What did we decide about oauth token refresh?");
+		expect(result.was_sanitized).toBe(true);
+		expect(result.method).toBe("question_extraction");
 	});
 });
 
@@ -669,6 +724,18 @@ describe("MemoryStore.search", () => {
 		seedMemories();
 		const results = store.search("AND OR NOT");
 		expect(results).toEqual([]);
+	});
+
+	it("sanitizes prompt-prefixed queries before searching", () => {
+		seedMemories();
+		const results = store.search(
+			[
+				"You are a memory retrieval assistant.",
+				"Output only JSON.",
+				"What did we decide about PostgreSQL JSONB support?",
+			].join("\n"),
+		);
+		expect(results[0]?.title).toBe("Chose PostgreSQL over MySQL");
 	});
 
 	it("filters by multiple criteria combined (kind + visibility)", () => {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -19,6 +19,7 @@ import {
 import { parsePositiveMemoryId } from "./integers.js";
 import { inferMemoryRole } from "./memory-quality.js";
 import { projectClause, projectMatchesFilter } from "./project.js";
+import { sanitizeSearchQuery } from "./query-sanitizer.js";
 import { memoryLooksRecapLike, queryPrefersRecap, recapPenaltyMultiplier } from "./recap-policy.js";
 import * as schema from "./schema.js";
 import { canonicalMemoryKind } from "./summary-memory.js";
@@ -666,11 +667,12 @@ export function search(
 	limit = 10,
 	filters?: MemoryFilters,
 ): MemoryResult[] {
-	const primary = searchOnce(store, query, limit, filters);
+	const effectiveQuery = sanitizeSearchQuery(query).clean_query;
+	const primary = searchOnce(store, effectiveQuery, limit, filters);
 	if (
 		!widenSharedWhenWeakEnabled(filters) ||
-		!query ||
-		queryBlocksSharedWidening(query) ||
+		!effectiveQuery ||
+		queryBlocksSharedWidening(effectiveQuery) ||
 		filtersBlockSharedWidening(filters)
 	) {
 		return primary;
@@ -686,7 +688,7 @@ export function search(
 	const shared = markWideningMetadata(
 		searchOnce(
 			store,
-			query,
+			effectiveQuery,
 			WIDEN_SHARED_MAX_SHARED_RESULTS,
 			sharedWideningFilters(filters),
 		).filter((item) => !store.memoryOwnedBySelf(item)),


### PR DESCRIPTION
## Description
This PR hardens retrieval against prompt-contaminated queries by sanitizing obvious instruction prefixes before search and pack retrieval. It also preserves compressed-away IDs in pack outputs so representative items still carry their hidden related IDs for follow-up fetches.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran targeted validation:
- `pnpm run tsc`
- `pnpm exec biome check packages/core/src/query-sanitizer.ts packages/core/src/search.ts packages/core/src/pack.ts packages/core/src/search.test.ts packages/core/src/pack.test.ts`
- `pnpm exec vitest run packages/core/src/search.test.ts packages/core/src/pack.test.ts`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced