### PR TITLE
feat(search): widen retrieval with indexed file and concept refs

### DIFF
--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -1349,6 +1349,22 @@ describe("buildMemoryPack cluster compression", () => {
 		expect(found).toBe(true);
 	});
 
+	it("surfaces memories via concept ref widening when FTS misses them", () => {
+		store.remember(
+			sessionId,
+			"decision",
+			"Chose HMAC-SHA256 for token signing",
+			"Selected HMAC-SHA256 for performance and security balance.",
+			0.8,
+			["crypto", "tokens"],
+			{ concepts: ["authentication"] },
+		);
+
+		const pack = buildMemoryPack(store, "authentication", 10);
+		const found = pack.items.some((item) => item.title.includes("HMAC-SHA256"));
+		expect(found).toBe(true);
+	});
+
 	it("reports compressed clusters in pack trace and marks compressed candidates", () => {
 		const idA = store.remember(
 			sessionId,

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -19,8 +19,9 @@ import { buildFilterClausesWithContext } from "./filters.js";
 import { projectBasename } from "./project.js";
 import { sanitizeSearchQuery } from "./query-sanitizer.js";
 import { memoryLooksRecapLike, queryPrefersRecap } from "./recap-policy.js";
+import { findByFile } from "./ref-queries.js";
 import type { StoreHandle } from "./search.js";
-import { findCandidatesByFile, rerankResults, scoreResult, search, timeline } from "./search.js";
+import { rerankResults, scoreResult, search, timeline } from "./search.js";
 import {
 	canonicalMemoryKind,
 	getSummaryMetadata,
@@ -1093,9 +1094,13 @@ function mergeFileRefCandidates(
 	);
 	if (validPaths.length === 0) return results;
 	const existingIds = new Set(results.map((r) => r.id));
-	const refCandidateIds = findCandidatesByFile(store.db, validPaths, effectiveLimit, {
-		project: filters?.project,
-	});
+	const refCandidateIds = validPaths.flatMap((path) =>
+		findByFile(store.db, path, {
+			limit: effectiveLimit,
+			project: filters?.project,
+			relation: "modified",
+		}).map((row) => row.id),
+	);
 	const newIds = refCandidateIds.filter((id) => !existingIds.has(id));
 	if (newIds.length === 0) return results;
 	const refMemories = newIds

--- a/packages/core/src/ref-queries.ts
+++ b/packages/core/src/ref-queries.ts
@@ -10,11 +10,14 @@
  */
 
 import type { Database } from "./db.js";
+import { projectClause } from "./project.js";
 import { normalizeConcept } from "./ref-populate.js";
 
 export interface RefQueryOptions {
 	/** Filter by memory kind (e.g. "decision", "bugfix") */
 	kind?: string;
+	/** Filter by session project using projectClause matching */
+	project?: string;
 	/** Filter file refs by relation type */
 	relation?: "read" | "modified";
 	/** Max results to return. Default 20. */
@@ -77,6 +80,16 @@ export function findByFile(
 
 	const outerClauses: string[] = ["mi.active = 1"];
 	const outerParams: unknown[] = [];
+	let joinClause = "";
+
+	if (options?.project) {
+		const { clause, params } = projectClause(options.project);
+		if (clause) {
+			joinClause = " JOIN sessions ON sessions.id = mi.session_id";
+			outerClauses.push(clause);
+			outerParams.push(...params);
+		}
+	}
 
 	if (options?.kind) {
 		outerClauses.push("mi.kind = ?");
@@ -95,7 +108,7 @@ export function findByFile(
 			mi.body_text, mi.narrative, mi.confidence, mi.tags_text,
 			mi.created_at, mi.updated_at, mi.files_read, mi.files_modified,
 			mi.concepts, mi.metadata_json
-		FROM memory_items mi
+		FROM memory_items mi${joinClause}
 		WHERE mi.id IN (
 			SELECT DISTINCT mfr.memory_id
 			FROM memory_file_refs mfr
@@ -127,6 +140,16 @@ export function findByConcept(
 
 	const outerClauses: string[] = ["mi.active = 1"];
 	const outerParams: unknown[] = [];
+	let joinClause = "";
+
+	if (options?.project) {
+		const { clause, params } = projectClause(options.project);
+		if (clause) {
+			joinClause = " JOIN sessions ON sessions.id = mi.session_id";
+			outerClauses.push(clause);
+			outerParams.push(...params);
+		}
+	}
 
 	if (options?.kind) {
 		outerClauses.push("mi.kind = ?");
@@ -145,7 +168,7 @@ export function findByConcept(
 			mi.body_text, mi.narrative, mi.confidence, mi.tags_text,
 			mi.created_at, mi.updated_at, mi.files_read, mi.files_modified,
 			mi.concepts, mi.metadata_json
-		FROM memory_items mi
+		FROM memory_items mi${joinClause}
 		WHERE mi.id IN (
 			SELECT DISTINCT mcr.memory_id
 			FROM memory_concept_refs mcr

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -726,6 +726,84 @@ describe("MemoryStore.search", () => {
 		expect(results).toEqual([]);
 	});
 
+	it("widens candidates via file refs when query names a touched file", () => {
+		const sessionId = insertTestSession(store.db);
+		store.remember(
+			sessionId,
+			"discovery",
+			"Database migration note",
+			"General migration cleanup.",
+			0.2,
+		);
+		store.remember(
+			sessionId,
+			"decision",
+			"Chose HMAC-SHA256 for token signing",
+			"Selected HMAC-SHA256 for performance and security balance.",
+			0.8,
+			[],
+			{ files_modified: ["packages/core/src/auth.ts"] },
+		);
+
+		const results = store.search("what decisions affected packages/core/src/auth.ts", 10);
+		expect(results[0]?.title).toContain("HMAC-SHA256");
+	});
+
+	it("preserves case-sensitive file hints for indexed lookup", () => {
+		const sessionId = insertTestSession(store.db);
+		store.remember(
+			sessionId,
+			"decision",
+			"Updated AuthDialog flow",
+			"Adjusted the AuthDialog token handoff.",
+			0.8,
+			[],
+			{ files_modified: ["packages/ui/src/AuthDialog.tsx"] },
+		);
+
+		const results = store.search("what changed in packages/ui/src/AuthDialog.tsx", 10);
+		expect(results[0]?.title).toContain("AuthDialog");
+	});
+
+	it("widens candidates via concept refs when FTS misses the concept term", () => {
+		const sessionId = insertTestSession(store.db);
+		store.remember(
+			sessionId,
+			"discovery",
+			"Authentication rollout note",
+			"General rollout chores.",
+			0.2,
+		);
+		store.remember(
+			sessionId,
+			"decision",
+			"Chose HMAC-SHA256 for token signing",
+			"Selected HMAC-SHA256 for performance and security balance.",
+			0.8,
+			[],
+			{ concepts: ["authentication"] },
+		);
+
+		const results = store.search("authentication", 10);
+		expect(results[0]?.title).toContain("HMAC-SHA256");
+	});
+
+	it("does not widen concept candidates for broad multi-token queries", () => {
+		const sessionId = insertTestSession(store.db);
+		store.remember(
+			sessionId,
+			"decision",
+			"Release policy update",
+			"Unrelated body text that should not match broad natural language queries.",
+			0.8,
+			[],
+			{ concepts: ["retention"] },
+		);
+
+		const results = store.search("was fix retention", 10);
+		expect(results.some((item) => item.title.includes("Release policy update"))).toBe(false);
+	});
+
 	it("sanitizes prompt-prefixed queries before searching", () => {
 		seedMemories();
 		const results = store.search(

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -18,9 +18,10 @@ import {
 } from "./filters.js";
 import { parsePositiveMemoryId } from "./integers.js";
 import { inferMemoryRole } from "./memory-quality.js";
-import { projectClause, projectMatchesFilter } from "./project.js";
+import { projectMatchesFilter } from "./project.js";
 import { sanitizeSearchQuery } from "./query-sanitizer.js";
 import { memoryLooksRecapLike, queryPrefersRecap, recapPenaltyMultiplier } from "./recap-policy.js";
+import { findByConcept, findByFile } from "./ref-queries.js";
 import * as schema from "./schema.js";
 import { canonicalMemoryKind } from "./summary-memory.js";
 import type {
@@ -508,14 +509,32 @@ function memoryFilesTouched(item: MemoryResult): string[] {
 
 function queryPathHints(query: string): string[] {
 	const rawTokens = query.match(/[A-Za-z0-9_./-]+/g) ?? [];
-	const normalized = rawTokens
-		.map((token) => canonicalPath(token))
+	const paths = rawTokens
+		.map((token) => token.trim())
 		.filter((token) => token.includes("/") || token.includes("."));
-	return [...new Set(normalized)];
+	return [...new Set(paths)];
+}
+
+function queryConceptHints(query: string): string[] {
+	const rawTokens = query.match(/[A-Za-z0-9_./-]+/g) ?? [];
+	const contentTokens = rawTokens
+		.map((token) => token.trim().toLowerCase())
+		.filter(
+			(token) =>
+				token.length > 2 &&
+				!token.includes("/") &&
+				!token.includes(".") &&
+				!FTS5_OPERATORS.has(token) &&
+				!SEARCH_QUERY_STOP_WORDS.has(token),
+		);
+	const uniqueTokens = [...new Set(contentTokens)];
+	return uniqueTokens.length === 1 ? uniqueTokens : [];
 }
 
 function queryPathOverlapBoost(item: MemoryResult, query: string): number {
-	const hintedPaths = queryPathHints(query);
+	const hintedPaths = queryPathHints(query)
+		.map((path) => canonicalPath(path))
+		.filter(Boolean);
 	if (hintedPaths.length === 0) return 0.0;
 	const itemPaths = memoryFilesTouched(item);
 	if (itemPaths.length === 0) return 0.0;
@@ -535,6 +554,87 @@ function queryPathOverlapBoost(item: MemoryResult, query: string): number {
 	}
 	const boost = directHits * 0.18 + basenameHits * 0.06;
 	return Math.min(0.18, boost);
+}
+
+function rowToMemoryResult(
+	row: Record<string, unknown>,
+	preserveFilteredKind: boolean,
+): MemoryResult {
+	const metadata: Record<string, unknown> = {
+		...fromJson(row.metadata_json as string | null),
+	};
+	for (const key of [
+		"actor_id",
+		"actor_display_name",
+		"visibility",
+		"workspace_id",
+		"workspace_kind",
+		"origin_device_id",
+		"origin_source",
+		"trust_state",
+	] as const) {
+		const value = row[key];
+		if (value != null) metadata[key] = value;
+	}
+
+	for (const key of ["files_modified", "files_read", "concepts"] as const) {
+		const raw = row[key];
+		if (typeof raw !== "string") continue;
+		try {
+			const parsed: unknown = JSON.parse(raw);
+			if (Array.isArray(parsed)) metadata[key] ??= parsed;
+		} catch {
+			// not valid JSON — ignore
+		}
+	}
+
+	return {
+		id: row.id as number,
+		kind: preserveFilteredKind
+			? (row.kind as string)
+			: canonicalMemoryKind(row.kind as string, metadata),
+		title: row.title as string,
+		body_text: row.body_text as string,
+		confidence: row.confidence as number,
+		created_at: row.created_at as string,
+		updated_at: row.updated_at as string,
+		tags_text: (row.tags_text as string) ?? "",
+		score: Number(row.score ?? 0),
+		session_id: row.session_id as number,
+		metadata,
+		narrative: (row.narrative as string | null) ?? null,
+		facts: (row.facts as string | null) ?? null,
+	};
+}
+
+function fetchResultsByIds(
+	store: StoreHandle,
+	ids: number[],
+	filters: MemoryFilters | undefined,
+	preserveFilteredKind: boolean,
+): MemoryResult[] {
+	if (ids.length === 0) return [];
+	const placeholders = ids.map(() => "?").join(", ");
+	const params: unknown[] = [...ids];
+	const whereClauses = [`memory_items.id IN (${placeholders})`, "memory_items.active = 1"];
+	const filterResult = buildFilterClausesWithContext(filters, {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+	});
+	whereClauses.push(...filterResult.clauses);
+	params.push(...filterResult.params);
+	const joinClause = filterResult.joinSessions
+		? "JOIN sessions ON sessions.id = memory_items.session_id"
+		: "";
+	const rows = store.db
+		.prepare(
+			`SELECT memory_items.*, 0 AS score
+			 FROM memory_items
+			 ${joinClause}
+			 WHERE ${whereClauses.join(" AND ")}`,
+		)
+		.all(...params) as Record<string, unknown>[];
+	return rows.map((row) => rowToMemoryResult(row, preserveFilteredKind));
 }
 
 /**
@@ -750,57 +850,36 @@ function searchOnce(
 
 	const rows = store.db.prepare(sql).all(...params) as Record<string, unknown>[];
 	const preserveFilteredKind = typeof filters?.kind === "string" && filters.kind.trim().length > 0;
-
-	const results: MemoryResult[] = rows.map((row) => {
-		const metadata: Record<string, unknown> = {
-			...fromJson(row.metadata_json as string | null),
-		};
-		for (const key of [
-			"actor_id",
-			"actor_display_name",
-			"visibility",
-			"workspace_id",
-			"workspace_kind",
-			"origin_device_id",
-			"origin_source",
-			"trust_state",
-		] as const) {
-			const value = row[key];
-			if (value != null) metadata[key] = value;
-		}
-
-		// Propagate files_modified into metadata when stored as a JSON array
-		if (row.files_modified && typeof row.files_modified === "string") {
-			try {
-				const parsed: unknown = JSON.parse(row.files_modified as string);
-				if (Array.isArray(parsed)) {
-					metadata.files_modified ??= parsed;
-				}
-			} catch {
-				// not valid JSON — ignore
-			}
-		}
-
-		return {
-			id: row.id as number,
-			kind: preserveFilteredKind
-				? (row.kind as string)
-				: canonicalMemoryKind(row.kind as string, metadata),
-			title: row.title as string,
-			body_text: row.body_text as string,
-			confidence: row.confidence as number,
-			created_at: row.created_at as string,
-			updated_at: row.updated_at as string,
-			tags_text: (row.tags_text as string) ?? "",
-			score: Number(row.score),
-			session_id: row.session_id as number,
-			metadata,
-			narrative: (row.narrative as string | null) ?? null,
-			facts: (row.facts as string | null) ?? null,
-		};
+	const results = rows.map((row) => rowToMemoryResult(row, preserveFilteredKind));
+	const indexedCandidateIds = [
+		...queryPathHints(query).flatMap((path) =>
+			findByFile(store.db, path, {
+				limit: queryLimit,
+				project: filters?.project,
+				relation: "modified",
+			}).map((row) => row.id),
+		),
+		...queryConceptHints(query).flatMap((concept) =>
+			findByConcept(store.db, concept, {
+				limit: queryLimit,
+				project: filters?.project,
+				since: filters?.since,
+				kind: filters?.kind,
+			}).map((row) => row.id),
+		),
+	];
+	const seenIds = new Set(results.map((item) => item.id));
+	const newIds = indexedCandidateIds.filter((id) => {
+		if (seenIds.has(id)) return false;
+		seenIds.add(id);
+		return true;
 	});
+	const widened =
+		newIds.length > 0
+			? [...results, ...fetchResultsByIds(store, newIds, filters, preserveFilteredKind)]
+			: results;
 
-	return rerankResults(store, results, effectiveLimit, filters, query);
+	return rerankResults(store, widened, effectiveLimit, filters, query);
 }
 
 /**
@@ -1278,38 +1357,3 @@ export function explain(
  * This is used by the pack builder to source working-set candidates
  * that FTS/vector search would miss.
  */
-export function findCandidatesByFile(
-	db: Database,
-	filePaths: string[],
-	limit = 50,
-	options?: { project?: string },
-): number[] {
-	if (filePaths.length === 0) return [];
-	const placeholders = filePaths.map(() => "?").join(", ");
-	const params: unknown[] = [...filePaths];
-
-	let projectJoin = "";
-	let projectWhere = "";
-	if (options?.project) {
-		const { clause, params: projectParams } = projectClause(options.project);
-		if (clause) {
-			projectJoin = " JOIN sessions ON sessions.id = mi.session_id";
-			projectWhere = ` AND ${clause}`;
-			params.push(...projectParams);
-		}
-	}
-
-	params.push(limit);
-	const rows = db
-		.prepare(
-			`SELECT DISTINCT mfr.memory_id
-			 FROM memory_file_refs mfr
-			 JOIN memory_items mi ON mi.id = mfr.memory_id${projectJoin}
-			 WHERE mfr.file_path IN (${placeholders})
-			   AND mi.active = 1${projectWhere}
-			 ORDER BY mi.created_at DESC
-			 LIMIT ?`,
-		)
-		.all(...params) as Array<{ memory_id: number }>;
-	return rows.map((r) => r.memory_id);
-}


### PR DESCRIPTION
## Description
This PR keeps baseline retrieval intact while widening candidate discovery through indexed file and concept refs before reranking. The goal is better recall for memories whose text does not match the query directly, without turning auxiliary indexes into a gating layer.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran targeted validation:
- `pnpm run tsc`
- `pnpm exec biome check packages/core/src/search.ts packages/core/src/search.test.ts packages/core/src/pack.test.ts`
- `pnpm exec vitest run packages/core/src/search.test.ts packages/core/src/pack.test.ts`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced