### PR TITLE
chore(trace): expose sanitized retrieval queries

### DIFF
--- a/packages/cli/src/commands/pack.test.ts
+++ b/packages/cli/src/commands/pack.test.ts
@@ -65,6 +65,7 @@ describe("pack command", () => {
 			version: 1,
 			inputs: {
 				query: "continue viewer health work",
+				sanitized_query: "viewer health work",
 				project: "codemem",
 				working_set_files: ["packages/ui/src/app.ts"],
 				token_budget: 1800,
@@ -156,6 +157,7 @@ describe("pack command", () => {
 		});
 
 		expect(rendered).toContain("Pack trace");
+		expect(rendered).toContain("Sanitized query: viewer health work");
 		expect(rendered).toContain("Mode reasons: query matched task hints, working set present");
 		expect(rendered).toContain("Selected");
 		expect(rendered).toContain("Dropped");

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -56,6 +56,7 @@ export function renderPackTrace(trace: PackTrace): string {
 	const lines = [
 		"Pack trace",
 		`- Query: ${trace.inputs.query}`,
+		...(trace.inputs.sanitized_query ? [`- Sanitized query: ${trace.inputs.sanitized_query}`] : []),
 		`- Project: ${trace.inputs.project ?? "(default)"}`,
 		`- Working set: ${workingSet}`,
 		`- Mode: ${trace.mode.selected}`,

--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -301,6 +301,7 @@ describe("buildMemoryPack", () => {
 
 		expect(trace.version).toBe(1);
 		expect(trace.inputs.query).toBe("continue viewer health work");
+		expect(trace.inputs).not.toHaveProperty("sanitized_query");
 		expect(trace.mode.selected).toBe(pack.metrics.mode);
 		expect(trace.output.pack_text).toBe(pack.pack_text);
 		expect(trace.output.estimated_tokens).toBe(pack.metrics.pack_tokens);
@@ -319,6 +320,29 @@ describe("buildMemoryPack", () => {
 				}),
 			}),
 		);
+	});
+
+	it("records sanitized_query in pack trace for contaminated inputs", () => {
+		store.remember(
+			sessionId,
+			"decision",
+			"Use PostgreSQL JSONB",
+			"Chose PostgreSQL because JSONB support simplified auth metadata storage",
+			0.9,
+		);
+
+		const trace = buildMemoryPackTrace(
+			store,
+			[
+				"You are a retrieval assistant.",
+				"Output only XML.",
+				"What did we decide about PostgreSQL JSONB support?",
+			].join("\n"),
+			10,
+		);
+
+		expect(trace.inputs.query).toContain("You are a retrieval assistant.");
+		expect(trace.inputs.sanitized_query).toBe("What did we decide about PostgreSQL JSONB support?");
 	});
 
 	it("marks deduped and trimmed candidates in pack trace", () => {

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -1122,7 +1122,8 @@ function buildPackArtifacts(
 	},
 ): PackArtifacts {
 	const effectiveLimit = Math.max(1, Math.trunc(limit));
-	const retrievalContext = sanitizeSearchQuery(context).clean_query;
+	const sanitized = sanitizeSearchQuery(context);
+	const retrievalContext = sanitized.clean_query;
 	let fallbackUsed = false;
 	let ftsCount = 0;
 	let semanticCount = 0;
@@ -1708,6 +1709,7 @@ function buildPackArtifacts(
 		version: 1,
 		inputs: {
 			query: context,
+			...(sanitized.was_sanitized ? { sanitized_query: retrievalContext } : {}),
 			project: filters?.project ?? null,
 			working_set_files: [...(filters?.working_set_paths ?? [])],
 			token_budget: tokenBudget,

--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -1150,9 +1150,23 @@ describe("MemoryStore.explain", () => {
 		seedMemories();
 		const result = store.explain("database");
 		expect(result.metadata).toHaveProperty("query", "database");
+		expect(result.metadata).not.toHaveProperty("sanitized_query");
 		expect(result.metadata).toHaveProperty("requested_ids_count", 0);
 		expect(typeof result.metadata.returned_items_count).toBe("number");
 		expect(result.metadata.include_pack_context).toBe(false);
+	});
+
+	it("reports sanitized_query in explain metadata for contaminated queries", () => {
+		seedMemories();
+		const result = store.explain(
+			[
+				"You are a memory retrieval assistant.",
+				"Output only JSON.",
+				"What did we decide about PostgreSQL?",
+			].join("\n"),
+		);
+		expect(result.metadata.query).toContain("You are a memory retrieval assistant.");
+		expect(result.metadata.sanitized_query).toBe("What did we decide about PostgreSQL?");
 	});
 
 	it("includes pack_context when includePackContext option is enabled", () => {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1207,6 +1207,8 @@ export function explain(
 ): ExplainResponse {
 	const includePackContext = options?.includePackContext ?? false;
 	const normalizedQuery = (query ?? "").trim();
+	const sanitized = normalizedQuery ? sanitizeSearchQuery(normalizedQuery) : null;
+	const sanitizedQuery = sanitized?.clean_query ?? "";
 	const { ordered: orderedIds, invalid: invalidIds } = dedupeOrderedIds(ids ?? []);
 
 	const errors: ExplainError[] = [];
@@ -1285,8 +1287,8 @@ export function explain(
 	}
 
 	// Tokenize query for term matching
-	const queryTokens = normalizedQuery
-		? (normalizedQuery.match(/[A-Za-z0-9_]+/g) ?? []).map((t) => t.toLowerCase())
+	const queryTokens = sanitizedQuery
+		? (sanitizedQuery.match(/[A-Za-z0-9_]+/g) ?? []).map((t) => t.toLowerCase())
 		: [];
 
 	const sessionProjects = loadSessionProjects(
@@ -1341,6 +1343,7 @@ export function explain(
 		errors,
 		metadata: {
 			query: normalizedQuery || null,
+			...(sanitized?.was_sanitized ? { sanitized_query: sanitized.clean_query } : {}),
 			project: filters?.project ?? null,
 			requested_ids_count: orderedIds.length,
 			returned_items_count: itemsPayload.length,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -112,6 +112,7 @@ export type PackTrace = {
 	version: 1;
 	inputs: {
 		query: string;
+		sanitized_query?: string;
 		project: string | null;
 		working_set_files: string[];
 		token_budget: number | null;
@@ -522,6 +523,7 @@ export interface ExplainResponse {
 	errors: ExplainError[];
 	metadata: {
 		query: string | null;
+		sanitized_query?: string;
 		project: string | null;
 		requested_ids_count: number;
 		returned_items_count: number;

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -72,6 +72,7 @@ export interface PackTrace {
 	version: 1;
 	inputs: {
 		query: string;
+		sanitized_query?: string;
 		project: string | null;
 		working_set_files: string[];
 		token_budget: number | null;


### PR DESCRIPTION
## Description
This PR exposes the sanitized retrieval query in explain metadata and pack traces so debugging shows what retrieval actually used after normalization. It makes the new sanitizer behavior observable without changing the user-facing query text.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran targeted validation:
- `pnpm run tsc`
- `pnpm exec biome check packages/core/src/types.ts packages/core/src/search.ts packages/core/src/search.test.ts packages/core/src/pack.ts packages/core/src/pack.test.ts packages/cli/src/commands/pack.test.ts`
- `pnpm exec vitest run packages/core/src/search.test.ts packages/core/src/pack.test.ts packages/cli/src/commands/pack.test.ts`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced