### PR TITLE
fix(search): include same-timestamp timeline neighbors

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -976,6 +976,26 @@ describe("MemoryStore.timeline", () => {
 		expect(sessionIds.size).toBe(1);
 	});
 
+	it("includes same-timestamp neighbors using id tie-breaks", () => {
+		const sessionId = insertTestSession(store.db);
+		const ts = new Date("2025-01-01T00:00:00Z").toISOString();
+		const ids: number[] = [];
+		for (const title of ["First", "Second", "Third"]) {
+			const info = store.db
+				.prepare(
+					`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+					 tags_text, active, created_at, updated_at, metadata_json, rev)
+					 VALUES (?, 'feature', ?, 'body text', 0.5, '', 1, ?, ?, '{}', 1)`,
+				)
+				.run(sessionId, title, ts, ts);
+			ids.push(Number(info.lastInsertRowid));
+		}
+
+		const anchorId = ids[1] as number;
+		const results = store.timeline(null, anchorId, 1, 1);
+		expect(results.map((item) => item.id)).toEqual([ids[0], anchorId, ids[2]]);
+	});
+
 	it("parses metadata_json on each result", () => {
 		seedTimeline();
 		const results = store.timeline("Database");

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -961,11 +961,15 @@ function timelineAround(
 			`SELECT memory_items.*
 			 FROM memory_items
 			 ${joinClause}
-			 WHERE ${whereClause} AND memory_items.created_at < ?
-			 ORDER BY memory_items.created_at DESC
+			 WHERE ${whereClause}
+			   AND (
+					memory_items.created_at < ?
+					OR (memory_items.created_at = ? AND memory_items.id < ?)
+			   )
+			 ORDER BY memory_items.created_at DESC, memory_items.id DESC
 			 LIMIT ?`,
 		)
-		.all(...baseParams, anchorCreatedAt, depthBefore) as MemoryItem[];
+		.all(...baseParams, anchorCreatedAt, anchorCreatedAt, anchorId, depthBefore) as MemoryItem[];
 
 	// After: newer memories, ascending
 	const afterRows = store.db
@@ -973,11 +977,15 @@ function timelineAround(
 			`SELECT memory_items.*
 			 FROM memory_items
 			 ${joinClause}
-			 WHERE ${whereClause} AND memory_items.created_at > ?
-			 ORDER BY memory_items.created_at ASC
+			 WHERE ${whereClause}
+			   AND (
+					memory_items.created_at > ?
+					OR (memory_items.created_at = ? AND memory_items.id > ?)
+			   )
+			 ORDER BY memory_items.created_at ASC, memory_items.id ASC
 			 LIMIT ?`,
 		)
-		.all(...baseParams, anchorCreatedAt, depthAfter) as MemoryItem[];
+		.all(...baseParams, anchorCreatedAt, anchorCreatedAt, anchorId, depthAfter) as MemoryItem[];
 
 	// Re-fetch anchor row to get full columns (anchor from search may be partial)
 	const d = getDrizzle(store.db);


### PR DESCRIPTION
## Description
This PR fixes a flaky timeline/pack interaction caused by memories that share the same `created_at` timestamp. Timeline neighbor queries previously used strict timestamp comparisons only, which could drop same-timestamp siblings and make recall-mode pack composition intermittently miss compressed related IDs. The fix adds `id` tie-breaks to before/after timeline queries and covers the case with a regression test.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [ ] 🚀 Feature (new functionality)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran targeted validation:
- `pnpm exec vitest run packages/core/src/search.test.ts packages/core/src/pack.test.ts --pool forks --maxWorkers 1`
- `pnpm exec vitest run packages/core/src/search.test.ts`
- `pnpm exec vitest run packages/core/src/pack.test.ts`
- `pnpm exec biome check packages/core/src/search.ts packages/core/src/search.test.ts`
- `pnpm run tsc`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced