### PR TITLE
feat(ui): finish Radix migration for settings and sync text controls

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1956,7 +1956,7 @@
       .settings-advanced-toolbar {
         display: flex;
         align-items: center;
-        gap: 8px;
+        gap: 10px;
         padding: var(--sp-2) var(--sp-3);
         border: 1px solid var(--border);
         border-radius: var(--radius-sm);
@@ -2027,6 +2027,62 @@
       .field-checkbox { flex-direction: row; align-items: center; gap: 8px; }
       .field-checkbox input[type="checkbox"] { width: 14px; height: 14px; margin: 0; }
       .field-checkbox label { margin: 0; }
+      .settings-switch-row {
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-start;
+        gap: 10px;
+        flex: 0 1 auto;
+      }
+      .settings-switch-copy {
+        color: var(--text-primary);
+        line-height: 1.35;
+        cursor: pointer;
+      }
+      .settings-switch {
+        width: 34px;
+        height: 20px;
+        border: 1px solid color-mix(in srgb, var(--text-tertiary) 42%, var(--control-border));
+        border-radius: var(--radius-pill);
+        background: color-mix(in srgb, var(--surface-1) 82%, var(--surface-0));
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-tertiary) 8%, transparent);
+        cursor: pointer;
+        flex-shrink: 0;
+        padding: 1px;
+        transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+      }
+      .settings-switch:hover {
+        border-color: color-mix(in srgb, var(--accent) 38%, var(--control-hover-border));
+      }
+      .settings-switch:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .settings-switch[data-state="checked"] {
+        background: color-mix(in srgb, var(--accent) 18%, var(--surface-1));
+        border-color: color-mix(in srgb, var(--accent) 54%, var(--control-hover-border));
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
+      }
+      .settings-switch:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+      .settings-switch-thumb {
+        display: block;
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        background: color-mix(in srgb, var(--surface-0) 88%, white);
+        border: 1px solid color-mix(in srgb, var(--text-tertiary) 24%, transparent);
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+        transition: transform 0.15s ease, background 0.15s ease;
+        transform: translateX(0);
+      }
+      .settings-switch[data-state="checked"] .settings-switch-thumb {
+        transform: translateX(14px);
+        background: color-mix(in srgb, var(--accent) 88%, white);
+        border-color: color-mix(in srgb, var(--accent) 42%, transparent);
+      }
       .cm-checkbox {
         appearance: none;
         width: 16px;

--- a/packages/ui/src/components/primitives/primitives.test.tsx
+++ b/packages/ui/src/components/primitives/primitives.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 let selectOnValueChange: ((value: string) => void) | undefined;
 let tabsOnValueChange: ((value: string) => void) | undefined;
 let radioOnValueChange: ((value: string) => void) | undefined;
+let switchOnCheckedChange: ((checked: boolean) => void) | undefined;
 
 type MockChildrenProps = {
 	children?: ComponentChild;
@@ -88,10 +89,31 @@ vi.mock("@radix-ui/react-radio-group", () => ({
 	Indicator: ({ children, ...props }: MockChildrenProps) => <span {...props}>{children}</span>,
 }));
 
+vi.mock("@radix-ui/react-switch", () => ({
+	Root: ({ children, checked, onCheckedChange, ...props }: MockChildrenProps) => {
+		switchOnCheckedChange = onCheckedChange as ((checked: boolean) => void) | undefined;
+		return (
+			<button
+				{...props}
+				aria-checked={checked ? "true" : "false"}
+				onClick={() => switchOnCheckedChange?.(!checked)}
+				role="switch"
+				type="button"
+			>
+				{children}
+			</button>
+		);
+	},
+	Thumb: ({ children, ...props }: MockChildrenProps) => <span {...props}>{children}</span>,
+}));
+
 import { DialogCloseButton } from "./dialog-close-button";
 import { RadixRadioGroup } from "./radix-radio-group";
 import { RadixSelect } from "./radix-select";
+import { RadixSwitch } from "./radix-switch";
 import { RadixTabs } from "./radix-tabs";
+import { TextArea } from "./text-area";
+import { TextInput } from "./text-input";
 
 let mount: HTMLDivElement | null = null;
 
@@ -115,6 +137,7 @@ afterEach(() => {
 	selectOnValueChange = undefined;
 	tabsOnValueChange = undefined;
 	radioOnValueChange = undefined;
+	switchOnCheckedChange = undefined;
 	document.body.innerHTML = "";
 });
 
@@ -226,5 +249,104 @@ describe("RadixRadioGroup", () => {
 		});
 
 		expect(onValueChange).toHaveBeenCalledWith("sam");
+	});
+});
+
+describe("RadixSwitch", () => {
+	it("reports checked changes through the shared switch primitive", () => {
+		const onCheckedChange = vi.fn();
+		const root = renderIntoDocument(
+			<RadixSwitch
+				aria-labelledby="settingsAdvancedToggleLabel"
+				checked={false}
+				id="settingsAdvancedToggle"
+				onCheckedChange={onCheckedChange}
+			/>,
+		);
+
+		const button = root.querySelector('[role="switch"]');
+		expect(button?.getAttribute("aria-labelledby")).toBe("settingsAdvancedToggleLabel");
+		expect(button?.getAttribute("id")).toBe("settingsAdvancedToggle");
+
+		act(() => {
+			switchOnCheckedChange?.(true);
+		});
+
+		expect(onCheckedChange).toHaveBeenCalledWith(true);
+	});
+
+	it("supports label-driven toggle behavior with a real label association", () => {
+		const onCheckedChange = vi.fn();
+		const root = renderIntoDocument(
+			<>
+				<label htmlFor="settingsAdvancedToggle" id="settingsAdvancedToggleLabel">
+					Show advanced controls
+				</label>
+				<RadixSwitch
+					aria-labelledby="settingsAdvancedToggleLabel"
+					checked={false}
+					id="settingsAdvancedToggle"
+					onCheckedChange={onCheckedChange}
+				/>
+			</>,
+		);
+
+		const label = Array.from(root.querySelectorAll("label")).find((item) =>
+			item.textContent?.includes("Show advanced controls"),
+		);
+		expect(label).toBeTruthy();
+
+		act(() => {
+			label?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+		});
+
+		expect(onCheckedChange).toHaveBeenCalledWith(true);
+	});
+});
+
+describe("TextInput", () => {
+	it("preserves accessible naming and input events", () => {
+		const onInput = vi.fn();
+		const root = renderIntoDocument(
+			<>
+				<label htmlFor="observerModel">Observer model</label>
+				<TextInput
+					id="observerModel"
+					onInput={onInput}
+					placeholder="leave empty for default"
+					value=""
+				/>
+			</>,
+		);
+
+		const input = root.querySelector("input");
+		expect(input?.getAttribute("id")).toBe("observerModel");
+		expect(input?.getAttribute("placeholder")).toBe("leave empty for default");
+
+		act(() => {
+			if (input) {
+				input.value = "gpt-5.1-mini";
+				input.dispatchEvent(new Event("input", { bubbles: true }));
+			}
+		});
+
+		expect(onInput).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("TextArea", () => {
+	it("preserves textarea props for read-only and sizing behavior", () => {
+		const root = renderIntoDocument(
+			<>
+				<label htmlFor="syncInviteOutput">Generated invite</label>
+				<TextArea id="syncInviteOutput" readOnly rows={3} value="invite-token" />
+			</>,
+		);
+
+		const textarea = root.querySelector("textarea");
+		expect(textarea?.getAttribute("id")).toBe("syncInviteOutput");
+		expect(textarea?.readOnly).toBe(true);
+		expect(textarea?.getAttribute("rows")).toBe("3");
+		expect(textarea?.value).toBe("invite-token");
 	});
 });

--- a/packages/ui/src/components/primitives/text-area.tsx
+++ b/packages/ui/src/components/primitives/text-area.tsx
@@ -1,0 +1,7 @@
+import type { JSX } from "preact";
+
+export type TextAreaProps = JSX.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export function TextArea(props: TextAreaProps) {
+	return <textarea {...props} />;
+}

--- a/packages/ui/src/components/primitives/text-input.tsx
+++ b/packages/ui/src/components/primitives/text-input.tsx
@@ -1,0 +1,7 @@
+import type { JSX } from "preact";
+
+export type TextInputProps = JSX.InputHTMLAttributes<HTMLInputElement>;
+
+export function TextInput(props: TextInputProps) {
+	return <input {...props} />;
+}

--- a/packages/ui/src/tabs/coordinator-admin.tsx
+++ b/packages/ui/src/tabs/coordinator-admin.tsx
@@ -2,6 +2,8 @@ import { h, render } from "preact";
 import { RadixSelect } from "../components/primitives/radix-select";
 import { RadixSwitch } from "../components/primitives/radix-switch";
 import { RadixTabs, RadixTabsContent } from "../components/primitives/radix-tabs";
+import { TextArea } from "../components/primitives/text-area";
+import { TextInput } from "../components/primitives/text-input";
 import * as api from "../lib/api";
 import { copyToClipboard } from "../lib/dom";
 import { showGlobalNotice } from "../lib/notice";
@@ -299,13 +301,14 @@ function renderInvitesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 				"label",
 				{ class: "coordinator-admin-field" },
 				h("span", null, "Group"),
-				h("input", {
+				h(TextInput, {
 					class: "peer-scope-input",
 					disabled: summary.readiness !== "ready",
 					onInput: (event) => {
 						inviteGroup = String((event.currentTarget as HTMLInputElement).value || "");
 					},
 					placeholder: activeGroup || "team-alpha",
+					type: "text",
 					value: inviteGroup,
 				}),
 			),
@@ -336,7 +339,7 @@ function renderInvitesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 				"label",
 				{ class: "coordinator-admin-field" },
 				h("span", null, "Expires in (hours)"),
-				h("input", {
+				h(TextInput, {
 					class: "peer-scope-input",
 					disabled: summary.readiness !== "ready",
 					min: "1",
@@ -370,7 +373,7 @@ function renderInvitesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 					"label",
 					{ class: "coordinator-admin-field" },
 					h("span", null, "Generated invite"),
-					h("textarea", {
+					h(TextArea, {
 						class: "feed-search coordinator-admin-output",
 						readOnly: true,
 						value: output,
@@ -433,13 +436,14 @@ function renderGroupsPanel(summary: ReturnType<typeof coordinatorAdminSummary>) 
 				"label",
 				{ class: "coordinator-admin-field" },
 				h("span", null, "New group id"),
-				h("input", {
+				h(TextInput, {
 					class: "peer-scope-input",
 					disabled: summary.readiness !== "ready" || groupActionPendingKind === "create",
 					onInput: (event) => {
 						createGroupId = String((event.currentTarget as HTMLInputElement).value || "");
 					},
 					placeholder: "team-alpha",
+					type: "text",
 					value: createGroupId,
 				}),
 			),
@@ -447,13 +451,14 @@ function renderGroupsPanel(summary: ReturnType<typeof coordinatorAdminSummary>) 
 				"label",
 				{ class: "coordinator-admin-field" },
 				h("span", null, "Display name"),
-				h("input", {
+				h(TextInput, {
 					class: "peer-scope-input",
 					disabled: summary.readiness !== "ready" || groupActionPendingKind === "create",
 					onInput: (event) => {
 						createGroupDisplayName = String((event.currentTarget as HTMLInputElement).value || "");
 					},
 					placeholder: "Team Alpha",
+					type: "text",
 					value: createGroupDisplayName,
 				}),
 			),
@@ -536,7 +541,7 @@ function renderGroupsPanel(summary: ReturnType<typeof coordinatorAdminSummary>) 
 								"label",
 								{ class: "coordinator-admin-field" },
 								h("span", null, "Display name"),
-								h("input", {
+								h(TextInput, {
 									class: "peer-scope-input",
 									disabled: summary.readiness !== "ready" || pending,
 									onInput: (event) => {
@@ -545,6 +550,7 @@ function renderGroupsPanel(summary: ReturnType<typeof coordinatorAdminSummary>) 
 											String((event.currentTarget as HTMLInputElement).value || ""),
 										);
 									},
+									type: "text",
 									value: draftName,
 								}),
 							),
@@ -791,7 +797,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 									"label",
 									{ class: "coordinator-admin-field" },
 									h("span", null, "Display name"),
-									h("input", {
+									h(TextInput, {
 										class: "peer-scope-input",
 										disabled: summary.readiness !== "ready" || pending,
 										onInput: (event) => {
@@ -800,6 +806,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 												String((event.currentTarget as HTMLInputElement).value || ""),
 											);
 										},
+										type: "text",
 										value: draft,
 									}),
 								),

--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -27,6 +27,7 @@ type HealthAction = {
 /* ── Health card builder ─────────────────────────────────── */
 
 type HealthCardInput = {
+	key?: string;
 	label: string;
 	value: string;
 	detail?: string;
@@ -201,7 +202,7 @@ function renderHealthCards(container: HTMLElement | null, cards: HealthCardInput
 		h(
 			Fragment,
 			null,
-			cards.map((card) => h(HealthCard, { ...card, key: `${card.label}-${card.value}` })),
+			cards.map((card) => h(HealthCard, { ...card, key: card.key ?? card.label })),
 		),
 		container,
 	);
@@ -398,6 +399,7 @@ export function renderHealthOverview() {
 		const isFailed = job.status === "failed";
 		const detail = isFailed ? String(job.error || "unknown error").trim() : undefined;
 		return buildHealthCard({
+			key: String(job.kind || job.title || "background-maintenance"),
 			label: String(job.title || job.kind || "Background maintenance"),
 			value: isFailed ? "Failed" : progress,
 			detail,
@@ -411,6 +413,7 @@ export function renderHealthOverview() {
 
 	const cards = [
 		buildHealthCard({
+			key: "overall-health",
 			label: "Overall health",
 			value: statusLabel,
 			detail: `Weighted score ${riskScore}`,
@@ -422,6 +425,7 @@ export function renderHealthOverview() {
 		}),
 		...maintenanceCards,
 		buildHealthCard({
+			key: "pipeline-health",
 			label: "Pipeline health",
 			value: `${rawPending.toLocaleString()} pending`,
 			detail: pipelineDetail,
@@ -429,6 +433,7 @@ export function renderHealthOverview() {
 			title: "Raw-event queue pressure and flush reliability",
 		}),
 		buildHealthCard({
+			key: "retrieval-impact",
 			label: "Retrieval impact",
 			value: reductionLabel,
 			detail: retrievalDetail,
@@ -436,6 +441,7 @@ export function renderHealthOverview() {
 			title: "Reduction from memory reuse across recent usage",
 		}),
 		buildHealthCard({
+			key: "sync-health",
 			label: "Sync health",
 			value: syncCardValue,
 			detail: syncDetail,
@@ -443,6 +449,7 @@ export function renderHealthOverview() {
 			title: "Daemon state and sync recency",
 		}),
 		buildHealthCard({
+			key: "data-freshness",
 			label: "Data freshness",
 			value: formatAgeShort(packAgeSeconds),
 			detail: freshnessDetail,

--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -6,11 +6,14 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { DialogCloseButton } from "../components/primitives/dialog-close-button";
 import { RadixDialog } from "../components/primitives/radix-dialog";
 import { RadixSelect } from "../components/primitives/radix-select";
+import { RadixSwitch } from "../components/primitives/radix-switch";
 import {
 	type RadixTabOption,
 	RadixTabs,
 	RadixTabsContent,
 } from "../components/primitives/radix-tabs";
+import { TextArea } from "../components/primitives/text-area";
+import { TextInput } from "../components/primitives/text-input";
 import * as api from "../lib/api";
 import { $, $button } from "../lib/dom";
 import { showGlobalNotice } from "../lib/notice";
@@ -1278,16 +1281,60 @@ function onSelectValueChange<K extends keyof SettingsFormState>(field: K) {
 	};
 }
 
-function onCheckboxInput<K extends keyof SettingsFormState>(field: K) {
-	return (event: JSX.TargetedEvent<HTMLInputElement, Event>) => {
-		updateField(field, event.currentTarget.checked as SettingsFormState[K]);
+function onSwitchInput<K extends keyof SettingsFormState>(field: K) {
+	return (checked: boolean) => {
+		updateField(field, checked as SettingsFormState[K]);
 	};
 }
 
-function onAdvancedToggle(event: JSX.TargetedEvent<HTMLInputElement, Event>) {
-	const checked = event.currentTarget.checked;
+function onAdvancedToggle(checked: boolean) {
 	settingsShowAdvanced = checked;
 	settingsController?.setShowAdvanced(checked);
+}
+
+type SettingsSwitchRowProps = {
+	checked: boolean;
+	disabled?: boolean;
+	hidden?: boolean;
+	id: string;
+	label: string;
+	onCheckedChange: (checked: boolean) => void;
+	className?: string;
+};
+
+function SettingsSwitchRow({
+	checked,
+	className,
+	disabled = false,
+	hidden = false,
+	id,
+	label,
+	onCheckedChange,
+}: SettingsSwitchRowProps) {
+	const labelId = `${id}Label`;
+	return (
+		<div
+			className={
+				className
+					? `field-checkbox settings-switch-row ${className}`
+					: "field-checkbox settings-switch-row"
+			}
+			hidden={hidden}
+		>
+			<label className="settings-switch-copy" htmlFor={id} id={labelId}>
+				{label}
+			</label>
+			<RadixSwitch
+				aria-labelledby={labelId}
+				checked={checked}
+				className="settings-switch"
+				disabled={disabled}
+				id={id}
+				onCheckedChange={onCheckedChange}
+				thumbClassName="settings-switch-thumb"
+			/>
+		</div>
+	);
 }
 
 function hiddenUnlessAdvanced(): boolean {
@@ -1463,15 +1510,13 @@ function SettingsDialogContent() {
 				<div className="small" id="settingsDescription">
 					Configure connection, authentication, processing, and sync behavior.
 				</div>
-				<div className="settings-advanced-toolbar field-checkbox">
-					<input
+				<div className="settings-advanced-toolbar">
+					<SettingsSwitchRow
 						checked={settingsShowAdvanced}
-						className="cm-checkbox"
 						id="settingsAdvancedToggle"
-						onChange={onAdvancedToggle}
-						type="checkbox"
+						label="Show advanced controls"
+						onCheckedChange={onAdvancedToggle}
 					/>
-					<label htmlFor="settingsAdvancedToggle">Show advanced controls</label>
 					<button
 						aria-label="About advanced controls"
 						className="help-icon"
@@ -1534,7 +1579,7 @@ function SettingsDialogContent() {
 										?
 									</button>
 								</div>
-								<input
+								<TextInput
 									id="observerModel"
 									onInput={onTextInput("observerModel")}
 									placeholder="leave empty for default"
@@ -1577,7 +1622,7 @@ function SettingsDialogContent() {
 							</Field>
 							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="claudeCommand">Claude command (JSON argv)</label>
-								<textarea
+								<TextArea
 									disabled
 									id="claudeCommand"
 									placeholder='["claude"]'
@@ -1588,7 +1633,7 @@ function SettingsDialogContent() {
 							</Field>
 							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="observerMaxChars">Request size limit (chars)</label>
-								<input
+								<TextInput
 									id="observerMaxChars"
 									min="1"
 									onInput={onTextInput("observerMaxChars")}
@@ -1636,7 +1681,7 @@ function SettingsDialogContent() {
 							</Field>
 							<Field hidden={!showAuthFile} id="observerAuthFileField">
 								<label htmlFor="observerAuthFile">Token file path</label>
-								<input
+								<TextInput
 									disabled
 									id="observerAuthFile"
 									placeholder="~/.codemem/work-token.txt"
@@ -1656,7 +1701,7 @@ function SettingsDialogContent() {
 										?
 									</button>
 								</div>
-								<textarea
+								<TextArea
 									disabled
 									id="observerAuthCommand"
 									placeholder='["iap-auth", "--audience", "gateway"]'
@@ -1670,7 +1715,7 @@ function SettingsDialogContent() {
 							</div>
 							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="observerAuthTimeoutMs">Token command timeout (ms)</label>
-								<input
+								<TextInput
 									id="observerAuthTimeoutMs"
 									min="1"
 									onInput={onTextInput("observerAuthTimeoutMs")}
@@ -1680,7 +1725,7 @@ function SettingsDialogContent() {
 							</Field>
 							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="observerAuthCacheTtlS">Token cache time (s)</label>
-								<input
+								<TextInput
 									id="observerAuthCacheTtlS"
 									min="0"
 									onInput={onTextInput("observerAuthCacheTtlS")}
@@ -1703,7 +1748,7 @@ function SettingsDialogContent() {
 										?
 									</button>
 								</div>
-								<textarea
+								<TextArea
 									disabled
 									id="observerHeaders"
 									placeholder='{"Authorization":"Bearer ${auth.token}"}'
@@ -1732,7 +1777,7 @@ function SettingsDialogContent() {
 										?
 									</button>
 								</div>
-								<input
+								<TextInput
 									id="rawEventsSweeperIntervalS"
 									min="1"
 									onInput={onTextInput("rawEventsSweeperIntervalS")}
@@ -1744,16 +1789,13 @@ function SettingsDialogContent() {
 						</div>
 						<div className="settings-group">
 							<h3 className="settings-group-title">Tiered observer routing</h3>
-							<div className="field field-checkbox">
-								<input
-									checked={values.observerTierRoutingEnabled}
-									className="cm-checkbox"
-									id="observerTierRoutingEnabled"
-									onChange={onCheckboxInput("observerTierRoutingEnabled")}
-									type="checkbox"
-								/>
-								<label htmlFor="observerTierRoutingEnabled">Enable tiered routing</label>
-							</div>
+							<SettingsSwitchRow
+								checked={values.observerTierRoutingEnabled}
+								className="field"
+								id="observerTierRoutingEnabled"
+								label="Enable tiered routing"
+								onCheckedChange={onSwitchInput("observerTierRoutingEnabled")}
+							/>
 							<div className="small">{getTieredRoutingHelperText()}</div>
 							<Field hidden={!showTieredRouting}>
 								<div className="field-label">
@@ -1767,7 +1809,7 @@ function SettingsDialogContent() {
 										?
 									</button>
 								</div>
-								<input
+								<TextInput
 									id="observerSimpleModel"
 									onInput={onTextInput("observerSimpleModel")}
 									placeholder="leave empty for default"
@@ -1787,7 +1829,7 @@ function SettingsDialogContent() {
 										?
 									</button>
 								</div>
-								<input
+								<TextInput
 									id="observerRichModel"
 									onInput={onTextInput("observerRichModel")}
 									placeholder="leave empty for default"
@@ -1795,24 +1837,20 @@ function SettingsDialogContent() {
 								/>
 								<div className="small">Used when routing detects a richer replay batch.</div>
 							</Field>
-							<Field className="field field-checkbox" hidden={!showTieredRouting}>
-								<input
-									checked={values.observerRichOpenAIUseResponses}
-									className="cm-checkbox"
-									id="observerRichOpenAIUseResponses"
-									onChange={onCheckboxInput("observerRichOpenAIUseResponses")}
-									type="checkbox"
-								/>
-								<label htmlFor="observerRichOpenAIUseResponses">
-									Use OpenAI Responses API for rich tier
-								</label>
-							</Field>
+							<SettingsSwitchRow
+								checked={values.observerRichOpenAIUseResponses}
+								className="field"
+								hidden={!showTieredRouting}
+								id="observerRichOpenAIUseResponses"
+								label="Use OpenAI Responses API for rich tier"
+								onCheckedChange={onSwitchInput("observerRichOpenAIUseResponses")}
+							/>
 							<Field
 								className="field settings-advanced"
 								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
 							>
 								<label htmlFor="observerSimpleTemperature">Simple tier temperature</label>
-								<input
+								<TextInput
 									id="observerSimpleTemperature"
 									min="0"
 									onInput={onTextInput("observerSimpleTemperature")}
@@ -1826,7 +1864,7 @@ function SettingsDialogContent() {
 								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
 							>
 								<label htmlFor="observerRichTemperature">Rich tier temperature</label>
-								<input
+								<TextInput
 									id="observerRichTemperature"
 									min="0"
 									onInput={onTextInput("observerRichTemperature")}
@@ -1840,7 +1878,7 @@ function SettingsDialogContent() {
 								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
 							>
 								<label htmlFor="observerRichReasoningEffort">Rich tier reasoning effort</label>
-								<input
+								<TextInput
 									id="observerRichReasoningEffort"
 									onInput={onTextInput("observerRichReasoningEffort")}
 									placeholder="leave empty for default"
@@ -1852,7 +1890,7 @@ function SettingsDialogContent() {
 								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
 							>
 								<label htmlFor="observerRichReasoningSummary">Rich tier reasoning summary</label>
-								<input
+								<TextInput
 									id="observerRichReasoningSummary"
 									onInput={onTextInput("observerRichReasoningSummary")}
 									placeholder="leave empty for default"
@@ -1864,7 +1902,7 @@ function SettingsDialogContent() {
 								hidden={!showTieredRouting || hiddenUnlessAdvanced()}
 							>
 								<label htmlFor="observerRichMaxOutputTokens">Rich tier max output tokens</label>
-								<input
+								<TextInput
 									id="observerRichMaxOutputTokens"
 									min="1"
 									onInput={onTextInput("observerRichMaxOutputTokens")}
@@ -1878,7 +1916,7 @@ function SettingsDialogContent() {
 							<h3 className="settings-group-title">Context Pack Limits</h3>
 							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="packObservationLimit">Observation limit</label>
-								<input
+								<TextInput
 									id="packObservationLimit"
 									min="1"
 									onInput={onTextInput("packObservationLimit")}
@@ -1889,7 +1927,7 @@ function SettingsDialogContent() {
 							</Field>
 							<Field className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="packSessionLimit">Session summary limit</label>
-								<input
+								<TextInput
 									id="packSessionLimit"
 									min="1"
 									onInput={onTextInput("packSessionLimit")}
@@ -1906,19 +1944,16 @@ function SettingsDialogContent() {
 					<RadixTabsContent className="settings-panel" forceMount value="sync">
 						<div className="settings-group">
 							<h3 className="settings-group-title">Device Sync</h3>
-							<div className="field field-checkbox">
-								<input
-									checked={values.syncEnabled}
-									className="cm-checkbox"
-									id="syncEnabled"
-									onChange={onCheckboxInput("syncEnabled")}
-									type="checkbox"
-								/>
-								<label htmlFor="syncEnabled">Enable sync</label>
-							</div>
+							<SettingsSwitchRow
+								checked={values.syncEnabled}
+								className="field"
+								id="syncEnabled"
+								label="Enable sync"
+								onCheckedChange={onSwitchInput("syncEnabled")}
+							/>
 							<div className="field">
 								<label htmlFor="syncInterval">Sync interval (seconds)</label>
-								<input
+								<TextInput
 									id="syncInterval"
 									min="10"
 									onInput={onTextInput("syncInterval")}
@@ -1928,7 +1963,7 @@ function SettingsDialogContent() {
 							</div>
 							<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="syncHost">Sync host</label>
-								<input
+								<TextInput
 									id="syncHost"
 									onInput={onTextInput("syncHost")}
 									placeholder="127.0.0.1"
@@ -1937,7 +1972,7 @@ function SettingsDialogContent() {
 							</div>
 							<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="syncPort">Sync port</label>
-								<input
+								<TextInput
 									id="syncPort"
 									min="1"
 									onInput={onTextInput("syncPort")}
@@ -1945,22 +1980,17 @@ function SettingsDialogContent() {
 									value={values.syncPort}
 								/>
 							</div>
-							<div
-								className="field field-checkbox settings-advanced"
+							<SettingsSwitchRow
+								checked={values.syncMdns}
+								className="field settings-advanced"
 								hidden={hiddenUnlessAdvanced()}
-							>
-								<input
-									checked={values.syncMdns}
-									className="cm-checkbox"
-									id="syncMdns"
-									onChange={onCheckboxInput("syncMdns")}
-									type="checkbox"
-								/>
-								<label htmlFor="syncMdns">Enable mDNS discovery</label>
-							</div>
+								id="syncMdns"
+								label="Enable mDNS discovery"
+								onCheckedChange={onSwitchInput("syncMdns")}
+							/>
 							<div className="field">
 								<label htmlFor="syncCoordinatorUrl">Coordinator URL</label>
-								<input
+								<TextInput
 									disabled
 									id="syncCoordinatorUrl"
 									placeholder="https://coord.example.com"
@@ -1970,7 +2000,7 @@ function SettingsDialogContent() {
 							</div>
 							<div className="field">
 								<label htmlFor="syncCoordinatorGroup">Coordinator group</label>
-								<input
+								<TextInput
 									id="syncCoordinatorGroup"
 									onInput={onTextInput("syncCoordinatorGroup")}
 									placeholder="team-alpha"
@@ -1982,7 +2012,7 @@ function SettingsDialogContent() {
 							</div>
 							<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="syncCoordinatorTimeout">Coordinator timeout (seconds)</label>
-								<input
+								<TextInput
 									id="syncCoordinatorTimeout"
 									min="1"
 									onInput={onTextInput("syncCoordinatorTimeout")}
@@ -1992,7 +2022,7 @@ function SettingsDialogContent() {
 							</div>
 							<div className="field settings-advanced" hidden={hiddenUnlessAdvanced()}>
 								<label htmlFor="syncCoordinatorPresenceTtl">Presence TTL (seconds)</label>
-								<input
+								<TextInput
 									id="syncCoordinatorPresenceTtl"
 									min="1"
 									onInput={onTextInput("syncCoordinatorPresenceTtl")}

--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -1,6 +1,7 @@
 import type { TargetedInputEvent } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import { RadixSelect } from "../../../components/primitives/radix-select";
+import { TextInput } from "../../../components/primitives/text-input";
 import {
 	actorDisplayLabel,
 	actorLabel,
@@ -149,10 +150,11 @@ function SyncActorRow({
 					<div className="peer-meta">Rename in config</div>
 				) : (
 					<>
-						<input
+						<TextInput
 							aria-label={`Rename ${label}`}
 							className="peer-scope-input actor-name-input"
 							disabled={renameBusy || mergeBusy}
+							type="text"
 							value={name}
 							onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
 								setName(event.currentTarget.value)

--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -2,6 +2,8 @@ import * as Collapsible from "@radix-ui/react-collapsible";
 import type { ComponentChildren } from "preact";
 import { createPortal } from "preact/compat";
 import { useLayoutEffect, useRef } from "preact/hooks";
+import { TextArea } from "../../../components/primitives/text-area";
+import { TextInput } from "../../../components/primitives/text-input";
 import { renderIntoSyncMount } from "./render-root";
 
 type SyncDisclosureProps = {
@@ -92,10 +94,11 @@ function TeamSetupDisclosure({ open, onOpenChange }: TeamSetupDisclosureProps) {
 				<label htmlFor="syncInviteGroup" className="sr-only">
 					Team name
 				</label>
-				<input
+				<TextInput
 					className="peer-scope-input"
 					id="syncInviteGroup"
 					placeholder="Team name (e.g. my-team)"
+					type="text"
 				/>
 				<label htmlFor="syncInvitePolicy" className="sr-only">
 					Join policy
@@ -103,7 +106,7 @@ function TeamSetupDisclosure({ open, onOpenChange }: TeamSetupDisclosureProps) {
 				<div className="sync-radix-select-host sync-actor-select-host" id="syncInvitePolicyMount" />
 				<div className="sync-ttl-group">
 					<label htmlFor="syncInviteTtl">Expires in</label>
-					<input
+					<TextInput
 						className="peer-scope-input"
 						defaultValue="24"
 						id="syncInviteTtl"
@@ -120,7 +123,7 @@ function TeamSetupDisclosure({ open, onOpenChange }: TeamSetupDisclosureProps) {
 			<label htmlFor="syncInviteOutput" className="sr-only">
 				Generated invite
 			</label>
-			<textarea
+			<TextArea
 				className="feed-search"
 				id="syncInviteOutput"
 				placeholder="Invite will appear here"

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -1,6 +1,7 @@
 import type { TargetedInputEvent } from "preact";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
 import { RadixSelect } from "../../../components/primitives/radix-select";
+import { TextInput } from "../../../components/primitives/text-input";
 import { formatTimestamp } from "../../../lib/format";
 import { isSyncRedactionEnabled, state } from "../../../lib/state";
 import {
@@ -335,12 +336,13 @@ function SyncPeerCard({
 				</strong>
 
 				<div className="peer-actions">
-					<input
+					<TextInput
 						aria-label={`Friendly name for ${displayName}`}
 						className="peer-scope-input"
 						data-device-name-input={peerId || undefined}
 						disabled={renameBusy}
 						placeholder="Friendly device name"
+						type="text"
 						value={renameValue}
 						onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
 							setRenameValue(event.currentTarget.value)

--- a/packages/ui/src/tabs/sync/sync-dialogs.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs.tsx
@@ -4,6 +4,7 @@ import { DialogCloseButton } from "../../components/primitives/dialog-close-butt
 import { RadixDialog } from "../../components/primitives/radix-dialog";
 import { RadixRadioGroup } from "../../components/primitives/radix-radio-group";
 import { RadixSelect } from "../../components/primitives/radix-select";
+import { TextInput } from "../../components/primitives/text-input";
 
 type DialogTone = "default" | "danger";
 
@@ -216,7 +217,7 @@ function SyncDialogBody({
 				) : null}
 				{request.kind === "input" ? (
 					<div className="field">
-						<input
+						<TextInput
 							aria-describedby={errorText ? `${descriptionId} ${inputErrorId}` : descriptionId}
 							autoFocus
 							className={errorText ? "sync-dialog-input sync-field-error" : "sync-dialog-input"}


### PR DESCRIPTION
## Description
This PR finishes the remaining Radix-aligned UI control migration for settings and sync-adjacent text surfaces. It migrates the remaining settings toggles to the shared switch primitive, adds shared text input and textarea primitives, and replaces the remaining native text-entry controls in settings, coordinator-admin, and sync flows with those shared primitives while preserving existing ids, handlers, and native text-entry behavior.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran validation:
- `pnpm exec vitest run packages/ui/src/components/primitives/primitives.test.tsx`
- `pnpm --filter @codemem/ui test`
- `pnpm --filter @codemem/ui build`
- `pnpm run tsc`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced