### PR TITLE
chore(release): prepare 0.27.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.26.2"
+    "version": "0.27.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.26.2",
+      "version": "0.27.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.26.2";
+const PINNED_BACKEND_VERSION = "0.27.0";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.26.2",
+	"version": "0.27.0",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.26.2",
+	"version": "0.27.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.26.2");
+		expect(VERSION).toBe("0.27.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.26.2";
+export const VERSION = "0.27.0";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.26.2",
+	"version": "0.27.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.26.2";
+const PINNED_BACKEND_VERSION = "0.27.0";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.26.2",
+	"version": "0.27.0",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.26.2",
+	"version": "0.27.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description
Prepare the `0.27.0` release by bumping managed package, plugin, and marketplace version metadata. This release is a feature release because `main` since `v0.26.2` includes wider retrieval coverage, better search/query handling, feed/context inspector stability fixes, several sync UX fixes, and the final Radix migration pass for settings and sync text controls.

Notable release-facing changes since `v0.26.2`:
- Widen retrieval with indexed file and concept refs, plus same-timestamp timeline neighbor inclusion for better search recall
- Sanitize contaminated retrieval queries and expose sanitized retrieval queries in tracing
- Stabilize feed context inspector query/layout behavior
- Improve sync behavior around coordinator address reuse, peer reviewability, pairing addresses, offline attempt history, and admin tab gating
- Finish Radix migration for settings and sync text controls

## Type of Change
<!-- Mark the relevant option(s) with an "x" -->

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing
<!-- Describe how you tested these changes -->

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run for this release prep branch:
- `pnpm run release:version -- check`
- `pnpm run test:release-version`
- `pnpm run check`

## Checklist
<!-- Mark completed items with an "x" -->

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced