### PR TITLE
feat(observer): add per-tier provider overrides and Claude defaults

### DIFF
--- a/packages/core/src/extraction-tier-routing.test.ts
+++ b/packages/core/src/extraction-tier-routing.test.ts
@@ -3,6 +3,42 @@ import {
 	buildTieredObserverConfig,
 	decideExtractionReplayTier,
 } from "./extraction-tier-routing.js";
+import type { ObserverConfig } from "./observer-client.js";
+
+function baseConfig(overrides: Partial<ObserverConfig> = {}): ObserverConfig {
+	return {
+		observerProvider: "openai",
+		observerModel: "gpt-5.4-mini",
+		observerRuntime: null,
+		observerApiKey: null,
+		observerBaseUrl: null,
+		observerTemperature: 0.2,
+		observerTierRoutingEnabled: true,
+		observerSimpleProvider: null,
+		observerSimpleModel: "gpt-5.4-mini",
+		observerSimpleTemperature: 0.2,
+		observerRichProvider: null,
+		observerRichModel: "gpt-5.4",
+		observerRichTemperature: 0.2,
+		observerRichOpenAIUseResponses: undefined,
+		observerRichReasoningEffort: null,
+		observerRichReasoningSummary: null,
+		observerRichMaxOutputTokens: 12000,
+		observerOpenAIUseResponses: false,
+		observerReasoningEffort: null,
+		observerReasoningSummary: null,
+		observerMaxOutputTokens: 4000,
+		observerMaxChars: 12000,
+		observerMaxTokens: 4000,
+		observerHeaders: {},
+		observerAuthSource: "none",
+		observerAuthFile: null,
+		observerAuthCommand: [],
+		observerAuthTimeoutMs: 1500,
+		observerAuthCacheTtlS: 300,
+		...overrides,
+	};
+}
 
 describe("extraction tier routing", () => {
 	it("routes rich batches to the rich tier when thresholds are exceeded", () => {
@@ -45,38 +81,160 @@ describe("extraction tier routing", () => {
 			toolCount: 12,
 			transcriptLength: 2800,
 		});
+		const config = buildTieredObserverConfig(baseConfig(), decision);
+		expect(config.observerOpenAIUseResponses).toBe(true);
+	});
+
+	it("picks Claude rich defaults when base provider is anthropic", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
 		const config = buildTieredObserverConfig(
-			{
-				observerProvider: "openai",
-				observerModel: "gpt-5.4-mini",
-				observerRuntime: null,
-				observerApiKey: null,
-				observerBaseUrl: null,
-				observerTemperature: 0.2,
-				observerTierRoutingEnabled: true,
-				observerSimpleModel: "gpt-5.4-mini",
-				observerSimpleTemperature: 0.2,
-				observerRichModel: "gpt-5.4",
-				observerRichTemperature: 0.2,
-				observerRichOpenAIUseResponses: undefined,
-				observerRichReasoningEffort: null,
-				observerRichReasoningSummary: null,
-				observerRichMaxOutputTokens: 12000,
-				observerOpenAIUseResponses: false,
-				observerReasoningEffort: null,
-				observerReasoningSummary: null,
-				observerMaxOutputTokens: 4000,
-				observerMaxChars: 12000,
-				observerMaxTokens: 4000,
-				observerHeaders: {},
-				observerAuthSource: "none",
-				observerAuthFile: null,
-				observerAuthCommand: [],
-				observerAuthTimeoutMs: 1500,
-				observerAuthCacheTtlS: 300,
-			},
+			baseConfig({
+				observerProvider: "anthropic",
+				observerModel: "claude-haiku-4-5",
+				observerSimpleModel: null,
+				observerRichModel: null,
+			}),
 			decision,
 		);
-		expect(config.observerOpenAIUseResponses).toBe(true);
+		expect(config.observerProvider).toBe("anthropic");
+		expect(config.observerModel).toBe("claude-sonnet-4-6");
+		expect(config.observerOpenAIUseResponses).toBeUndefined();
+		expect(config.observerReasoningEffort).toBeNull();
+		expect(config.observerMaxOutputTokens).toBe(12000);
+	});
+
+	it("picks Claude simple defaults when base provider is anthropic", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 19001,
+			sessionId: 200001,
+			eventSpan: 12,
+			promptCount: 1,
+			toolCount: 1,
+			transcriptLength: 320,
+		});
+		const config = buildTieredObserverConfig(
+			baseConfig({
+				observerProvider: "anthropic",
+				observerModel: "claude-haiku-4-5",
+				observerSimpleModel: null,
+				observerRichModel: null,
+			}),
+			decision,
+		);
+		expect(config.observerProvider).toBe("anthropic");
+		expect(config.observerModel).toBe("claude-haiku-4-5");
+		expect(config.observerOpenAIUseResponses).toBeUndefined();
+	});
+
+	it("respects observerRichProvider override even when base provider is openai", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const config = buildTieredObserverConfig(
+			baseConfig({
+				observerRichProvider: "anthropic",
+				observerRichModel: null,
+			}),
+			decision,
+		);
+		expect(config.observerProvider).toBe("anthropic");
+		expect(config.observerModel).toBe("claude-sonnet-4-6");
+		expect(config.observerOpenAIUseResponses).toBeUndefined();
+	});
+
+	it("respects observerSimpleProvider override for simple tier only", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 19001,
+			sessionId: 200001,
+			eventSpan: 12,
+			promptCount: 1,
+			toolCount: 1,
+			transcriptLength: 320,
+		});
+		const config = buildTieredObserverConfig(
+			baseConfig({
+				observerSimpleProvider: "anthropic",
+				observerSimpleModel: null,
+			}),
+			decision,
+		);
+		expect(config.observerProvider).toBe("anthropic");
+		expect(config.observerModel).toBe("claude-haiku-4-5");
+	});
+
+	it("preserves unknown/custom provider and skips OpenAI/Claude defaults", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const config = buildTieredObserverConfig(
+			baseConfig({
+				observerProvider: "opencode",
+				observerModel: "custom-sonnet",
+				observerSimpleModel: null,
+				observerRichModel: null,
+			}),
+			decision,
+		);
+		expect(config.observerProvider).toBe("opencode");
+		expect(config.observerModel).toBe("custom-sonnet");
+		expect(config.observerOpenAIUseResponses).toBeUndefined();
+	});
+
+	it("honors rich tier override model under a custom provider", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const config = buildTieredObserverConfig(
+			baseConfig({
+				observerProvider: "opencode",
+				observerModel: "fallback-model",
+				observerRichModel: "rich-override",
+			}),
+			decision,
+		);
+		expect(config.observerProvider).toBe("opencode");
+		expect(config.observerModel).toBe("rich-override");
+	});
+
+	it("still honors explicit per-tier model overrides under anthropic provider", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const config = buildTieredObserverConfig(
+			baseConfig({
+				observerProvider: "anthropic",
+				observerRichModel: "claude-opus-4-6",
+			}),
+			decision,
+		);
+		expect(config.observerProvider).toBe("anthropic");
+		expect(config.observerModel).toBe("claude-opus-4-6");
 	});
 });

--- a/packages/core/src/extraction-tier-routing.ts
+++ b/packages/core/src/extraction-tier-routing.ts
@@ -31,53 +31,130 @@ export const RICH_TIER_DEFAULTS: Partial<ObserverConfig> = {
 	observerMaxOutputTokens: 12000,
 };
 
+export const SIMPLE_TIER_ANTHROPIC_DEFAULTS: Partial<ObserverConfig> = {
+	observerProvider: "anthropic",
+	observerModel: "claude-haiku-4-5",
+	observerTemperature: 0.2,
+};
+
+export const RICH_TIER_ANTHROPIC_DEFAULTS: Partial<ObserverConfig> = {
+	observerProvider: "anthropic",
+	observerModel: "claude-sonnet-4-6",
+	observerTemperature: 0.2,
+	observerMaxOutputTokens: 12000,
+};
+
+type KnownTierProvider = "openai" | "anthropic";
+
+function normalizeKnownProvider(value: string | null | undefined): KnownTierProvider | null {
+	if (!value) return null;
+	const lowered = value.toLowerCase();
+	if (lowered === "openai") return "openai";
+	if (lowered === "anthropic") return "anthropic";
+	return null;
+}
+
+function trimmedProvider(value: string | null | undefined): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function resolveSimpleTierDefaults(provider: KnownTierProvider): Partial<ObserverConfig> {
+	return provider === "anthropic" ? SIMPLE_TIER_ANTHROPIC_DEFAULTS : SIMPLE_TIER_DEFAULTS;
+}
+
+function resolveRichTierDefaults(provider: KnownTierProvider): Partial<ObserverConfig> {
+	return provider === "anthropic" ? RICH_TIER_ANTHROPIC_DEFAULTS : RICH_TIER_DEFAULTS;
+}
+
 export function buildTieredObserverConfig(
 	baseConfig: ObserverConfig,
 	decision: ExtractionReplayTierRoutingDecision,
 ): ObserverConfig {
 	if (decision.tier === "simple") {
+		const knownProvider =
+			normalizeKnownProvider(baseConfig.observerSimpleProvider) ??
+			normalizeKnownProvider(baseConfig.observerProvider);
+		if (knownProvider) {
+			const tierDefaults = resolveSimpleTierDefaults(knownProvider);
+			return {
+				...baseConfig,
+				observerProvider: knownProvider,
+				observerModel:
+					baseConfig.observerSimpleModel ?? tierDefaults.observerModel ?? baseConfig.observerModel,
+				observerTemperature:
+					baseConfig.observerSimpleTemperature ??
+					tierDefaults.observerTemperature ??
+					baseConfig.observerTemperature,
+				observerOpenAIUseResponses: knownProvider === "openai" ? false : undefined,
+				observerReasoningEffort: null,
+				observerReasoningSummary: null,
+				observerMaxOutputTokens: baseConfig.observerMaxTokens,
+			};
+		}
+		// Unknown/custom provider (e.g. opencode, bespoke gateway): preserve the
+		// base provider and only honor user-provided tier overrides. Do not apply
+		// OpenAI or Anthropic defaults.
+		const preservedProvider =
+			trimmedProvider(baseConfig.observerSimpleProvider) ?? baseConfig.observerProvider ?? null;
 		return {
 			...baseConfig,
-			observerProvider:
-				baseConfig.observerProvider ?? SIMPLE_TIER_DEFAULTS.observerProvider ?? null,
-			observerModel:
-				baseConfig.observerSimpleModel ??
-				SIMPLE_TIER_DEFAULTS.observerModel ??
-				baseConfig.observerModel,
-			observerTemperature:
-				baseConfig.observerSimpleTemperature ??
-				SIMPLE_TIER_DEFAULTS.observerTemperature ??
-				baseConfig.observerTemperature,
-			observerOpenAIUseResponses: false,
+			observerProvider: preservedProvider,
+			observerModel: baseConfig.observerSimpleModel ?? baseConfig.observerModel,
+			observerTemperature: baseConfig.observerSimpleTemperature ?? baseConfig.observerTemperature,
+			observerOpenAIUseResponses: undefined,
 			observerReasoningEffort: null,
 			observerReasoningSummary: null,
 			observerMaxOutputTokens: baseConfig.observerMaxTokens,
 		};
 	}
 
+	const knownProvider =
+		normalizeKnownProvider(baseConfig.observerRichProvider) ??
+		normalizeKnownProvider(baseConfig.observerProvider);
+	if (knownProvider) {
+		const tierDefaults = resolveRichTierDefaults(knownProvider);
+		const isOpenAI = knownProvider === "openai";
+		return {
+			...baseConfig,
+			observerProvider: knownProvider,
+			observerModel:
+				baseConfig.observerRichModel ?? tierDefaults.observerModel ?? baseConfig.observerModel,
+			observerTemperature:
+				baseConfig.observerRichTemperature ??
+				tierDefaults.observerTemperature ??
+				baseConfig.observerTemperature,
+			observerOpenAIUseResponses: isOpenAI
+				? baseConfig.observerRichOpenAIUseResponses === true
+					? true
+					: (tierDefaults.observerOpenAIUseResponses ?? false)
+				: undefined,
+			observerReasoningEffort: isOpenAI
+				? (baseConfig.observerRichReasoningEffort ?? tierDefaults.observerReasoningEffort ?? null)
+				: null,
+			observerReasoningSummary: isOpenAI
+				? (baseConfig.observerRichReasoningSummary ?? tierDefaults.observerReasoningSummary ?? null)
+				: null,
+			observerMaxOutputTokens:
+				baseConfig.observerRichMaxOutputTokens ??
+				tierDefaults.observerMaxOutputTokens ??
+				baseConfig.observerMaxTokens,
+		};
+	}
+	// Unknown/custom provider: preserve base provider and only honor explicit
+	// rich-tier overrides.
+	const preservedProvider =
+		trimmedProvider(baseConfig.observerRichProvider) ?? baseConfig.observerProvider ?? null;
 	return {
 		...baseConfig,
-		observerProvider: RICH_TIER_DEFAULTS.observerProvider ?? baseConfig.observerProvider,
-		observerModel:
-			baseConfig.observerRichModel ?? RICH_TIER_DEFAULTS.observerModel ?? baseConfig.observerModel,
-		observerTemperature:
-			baseConfig.observerRichTemperature ??
-			RICH_TIER_DEFAULTS.observerTemperature ??
-			baseConfig.observerTemperature,
-		observerOpenAIUseResponses:
-			baseConfig.observerRichOpenAIUseResponses === true
-				? true
-				: (RICH_TIER_DEFAULTS.observerOpenAIUseResponses ?? false),
-		observerReasoningEffort:
-			baseConfig.observerRichReasoningEffort ?? RICH_TIER_DEFAULTS.observerReasoningEffort ?? null,
-		observerReasoningSummary:
-			baseConfig.observerRichReasoningSummary ??
-			RICH_TIER_DEFAULTS.observerReasoningSummary ??
-			null,
-		observerMaxOutputTokens:
-			baseConfig.observerRichMaxOutputTokens ??
-			RICH_TIER_DEFAULTS.observerMaxOutputTokens ??
-			baseConfig.observerMaxTokens,
+		observerProvider: preservedProvider,
+		observerModel: baseConfig.observerRichModel ?? baseConfig.observerModel,
+		observerTemperature: baseConfig.observerRichTemperature ?? baseConfig.observerTemperature,
+		observerOpenAIUseResponses: undefined,
+		observerReasoningEffort: null,
+		observerReasoningSummary: null,
+		observerMaxOutputTokens: baseConfig.observerRichMaxOutputTokens ?? baseConfig.observerMaxTokens,
 	};
 }
 

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -252,6 +252,32 @@ describe("ObserverClient", () => {
 			expect(client.maxOutputTokens).toBe(12000);
 		});
 
+		it("round-trips per-tier provider overrides through toConfig", () => {
+			const client = new ObserverClient({
+				observerProvider: "openai",
+				observerModel: "gpt-5.4-mini",
+				observerRuntime: null,
+				observerApiKey: null,
+				observerBaseUrl: null,
+				observerTemperature: 0.2,
+				observerSimpleProvider: "anthropic",
+				observerRichProvider: "anthropic",
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "auto",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+			expect(client.simpleProvider).toBe("anthropic");
+			expect(client.richProvider).toBe("anthropic");
+			const config = client.toConfig();
+			expect(config.observerSimpleProvider).toBe("anthropic");
+			expect(config.observerRichProvider).toBe("anthropic");
+		});
+
 		it("preserves auth source details in toConfig", () => {
 			const client = new ObserverClient({
 				observerProvider: "openai",

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -82,8 +82,10 @@ export interface ObserverConfig {
 	observerBaseUrl: string | null;
 	observerTemperature?: number | null;
 	observerTierRoutingEnabled?: boolean;
+	observerSimpleProvider?: string | null;
 	observerSimpleModel?: string | null;
 	observerSimpleTemperature?: number | null;
+	observerRichProvider?: string | null;
 	observerRichModel?: string | null;
 	observerRichTemperature?: number | null;
 	observerRichOpenAIUseResponses?: boolean;
@@ -222,8 +224,10 @@ export function loadObserverConfig(): ObserverConfig {
 		observerBaseUrl: null,
 		observerTemperature: 0.2,
 		observerTierRoutingEnabled: false,
+		observerSimpleProvider: null,
 		observerSimpleModel: null,
 		observerSimpleTemperature: null,
+		observerRichProvider: null,
 		observerRichModel: null,
 		observerRichTemperature: null,
 		observerRichOpenAIUseResponses: false,
@@ -286,12 +290,16 @@ export function loadObserverConfig(): ObserverConfig {
 	if (data.observer_tier_routing_enabled != null) {
 		cfg.observerTierRoutingEnabled = data.observer_tier_routing_enabled === true;
 	}
+	if (typeof data.observer_simple_provider === "string")
+		cfg.observerSimpleProvider = data.observer_simple_provider;
 	if (typeof data.observer_simple_model === "string")
 		cfg.observerSimpleModel = data.observer_simple_model;
 	if (data.observer_simple_temperature != null) {
 		const n = Number(data.observer_simple_temperature);
 		cfg.observerSimpleTemperature = Number.isFinite(n) ? n : cfg.observerSimpleTemperature;
 	}
+	if (typeof data.observer_rich_provider === "string")
+		cfg.observerRichProvider = data.observer_rich_provider;
 	if (typeof data.observer_rich_model === "string")
 		cfg.observerRichModel = data.observer_rich_model;
 	if (data.observer_rich_temperature != null) {
@@ -350,11 +358,14 @@ export function loadObserverConfig(): ObserverConfig {
 			process.env.CODEMEM_OBSERVER_TIER_ROUTING_ENABLED === "1" ||
 			process.env.CODEMEM_OBSERVER_TIER_ROUTING_ENABLED === "true";
 	}
+	cfg.observerSimpleProvider =
+		process.env.CODEMEM_OBSERVER_SIMPLE_PROVIDER ?? cfg.observerSimpleProvider;
 	cfg.observerSimpleModel = process.env.CODEMEM_OBSERVER_SIMPLE_MODEL ?? cfg.observerSimpleModel;
 	if (process.env.CODEMEM_OBSERVER_SIMPLE_TEMPERATURE != null) {
 		const n = Number(process.env.CODEMEM_OBSERVER_SIMPLE_TEMPERATURE);
 		cfg.observerSimpleTemperature = Number.isFinite(n) ? n : cfg.observerSimpleTemperature;
 	}
+	cfg.observerRichProvider = process.env.CODEMEM_OBSERVER_RICH_PROVIDER ?? cfg.observerRichProvider;
 	cfg.observerRichModel = process.env.CODEMEM_OBSERVER_RICH_MODEL ?? cfg.observerRichModel;
 	if (process.env.CODEMEM_OBSERVER_RICH_TEMPERATURE != null) {
 		const n = Number(process.env.CODEMEM_OBSERVER_RICH_TEMPERATURE);
@@ -839,8 +850,10 @@ export class ObserverClient {
 	readonly runtime: string;
 	readonly temperature: number | null;
 	readonly tierRoutingEnabled: boolean;
+	readonly simpleProvider: string | null;
 	readonly simpleModel: string | null;
 	readonly simpleTemperature: number | null;
+	readonly richProvider: string | null;
 	readonly richModel: string | null;
 	readonly richTemperature: number | null;
 	readonly richOpenAIUseResponses: boolean;
@@ -948,6 +961,10 @@ export class ObserverClient {
 				? cfg.observerTemperature
 				: 0.2;
 		this.tierRoutingEnabled = cfg.observerTierRoutingEnabled === true;
+		this.simpleProvider =
+			typeof cfg.observerSimpleProvider === "string" && cfg.observerSimpleProvider.trim()
+				? cfg.observerSimpleProvider.trim()
+				: null;
 		this.simpleModel =
 			typeof cfg.observerSimpleModel === "string" && cfg.observerSimpleModel.trim()
 				? cfg.observerSimpleModel.trim()
@@ -956,6 +973,10 @@ export class ObserverClient {
 			typeof cfg.observerSimpleTemperature === "number" &&
 			Number.isFinite(cfg.observerSimpleTemperature)
 				? cfg.observerSimpleTemperature
+				: null;
+		this.richProvider =
+			typeof cfg.observerRichProvider === "string" && cfg.observerRichProvider.trim()
+				? cfg.observerRichProvider.trim()
 				: null;
 		this.richModel =
 			typeof cfg.observerRichModel === "string" && cfg.observerRichModel.trim()
@@ -1033,8 +1054,10 @@ export class ObserverClient {
 			observerBaseUrl: this._customBaseUrl,
 			observerTemperature: this.temperature,
 			observerTierRoutingEnabled: this.tierRoutingEnabled,
+			observerSimpleProvider: this.simpleProvider,
 			observerSimpleModel: this.simpleModel,
 			observerSimpleTemperature: this.simpleTemperature,
+			observerRichProvider: this.richProvider,
 			observerRichModel: this.richModel,
 			observerRichTemperature: this.richTemperature,
 			observerRichOpenAIUseResponses: this.richOpenAIUseResponses,


### PR DESCRIPTION
## Description
Tiered extraction routing previously hard-coded OpenAI provider and OpenAI model names (`gpt-5.4` / `gpt-5.4-mini`) as its defaults. Users who configured `observer_provider=anthropic` and left the per-tier model overrides empty would end up with `provider=anthropic` plus an OpenAI model name, silently breaking tiering on Claude.

This PR adds the minimum parity needed so default-on tiering is safe for Anthropic users without completing the full capability-matrix design in codemem-kkd9. Closes codemem-s7f5.

## Type of Change
- [x] 🚀 Feature (new functionality)

## Changes
- Add \`observer_simple_provider\` / \`observer_rich_provider\` config keys and matching \`CODEMEM_OBSERVER_SIMPLE_PROVIDER\` / \`CODEMEM_OBSERVER_RICH_PROVIDER\` env vars.
- Add \`SIMPLE_TIER_ANTHROPIC_DEFAULTS\` (\`claude-haiku-4-5\`) and \`RICH_TIER_ANTHROPIC_DEFAULTS\` (\`claude-sonnet-4-6\`).
- Teach \`buildTieredObserverConfig\` to resolve the effective tier provider (per-tier override → base \`observer_provider\` → openai) and pick provider-appropriate defaults when per-tier model overrides are absent.
- Suppress OpenAI-specific flags (Responses API, reasoning effort/summary) when the resolved tier provider is not OpenAI.

## Testing
- [x] \`pnpm exec vitest run packages/core/src/extraction-tier-routing.test.ts\` — 8 passed.
- [x] \`pnpm run tsc\` — passes.
- [x] \`pnpm run lint\` — passes.
- [x] \`pnpm run test\` — 1368 tests passed.

## Checklist
- [x] Self-review completed
- [x] No new warnings introduced