### PR TITLE
feat(search): widen_project_when_weak cross-project retrieval fallback

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -880,6 +880,236 @@ describe("MemoryStore.search", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Integration tests: cross-project widening (widen_project_when_weak)
+// ---------------------------------------------------------------------------
+
+describe("MemoryStore.search cross-project widening", () => {
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-search-test-widen-"));
+		dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function insertProjectSession(project: string): number {
+		const now = new Date().toISOString();
+		return Number(
+			store.db
+				.prepare(
+					`INSERT INTO sessions (started_at, cwd, user, tool_version, project)
+					 VALUES (?, ?, ?, ?, ?)`,
+				)
+				.run(now, `/tmp/${project}`, "testuser", "test-1.0", project).lastInsertRowid,
+		);
+	}
+
+	function seedTwoProjects() {
+		const currentSessionId = insertProjectSession("codemem");
+		const otherSessionId = insertProjectSession("other-project");
+		// Only one weak match in the current project.
+		store.remember(
+			currentSessionId,
+			"discovery",
+			"Mentions authentication offhand",
+			"brief passing mention",
+			0.1,
+		);
+		// Several strong matches in the other project.
+		store.remember(
+			otherSessionId,
+			"decision",
+			"Authentication strategy decision",
+			"Chose OAuth for all services",
+			0.9,
+		);
+		store.remember(
+			otherSessionId,
+			"feature",
+			"Authentication module",
+			"Authentication flow details",
+			0.9,
+		);
+		store.remember(
+			otherSessionId,
+			"bugfix",
+			"Authentication token refresh",
+			"Fixed authentication refresh edge case",
+			0.9,
+		);
+		return { currentSessionId, otherSessionId };
+	}
+
+	it("does not widen across projects when widen_project_when_weak is disabled", () => {
+		seedTwoProjects();
+		const results = store.search("authentication", 10, { project: "codemem" });
+		expect(results).toHaveLength(1);
+		expect(results[0]?.metadata?.widened_from_project).toBeUndefined();
+	});
+
+	it("widens across projects when enabled and primary results are weak", () => {
+		seedTwoProjects();
+		const results = store.search("authentication", 10, {
+			project: "codemem",
+			widen_project_when_weak: true,
+		});
+		expect(results.length).toBeGreaterThan(1);
+		const widened = results.filter((r) => r.metadata?.widened_from_project === true);
+		expect(widened.length).toBeGreaterThan(0);
+		for (const item of widened) {
+			expect(item.metadata?.source_project).toBe("other-project");
+		}
+	});
+
+	it("preserves current-project-first ordering when widening activates", () => {
+		const { currentSessionId } = seedTwoProjects();
+		const results = store.search("authentication", 10, {
+			project: "codemem",
+			widen_project_when_weak: true,
+		});
+		const firstNonWidened = results.findIndex((r) => r.metadata?.widened_from_project !== true);
+		const firstWidened = results.findIndex((r) => r.metadata?.widened_from_project === true);
+		expect(firstNonWidened).toBeGreaterThanOrEqual(0);
+		expect(firstWidened).toBeGreaterThan(firstNonWidened);
+		expect(results[0]?.session_id).toBe(currentSessionId);
+	});
+
+	it("does not widen when primary-project results are strong enough", () => {
+		const currentSessionId = insertProjectSession("codemem");
+		const otherSessionId = insertProjectSession("other-project");
+		// Multiple strong primary-project matches.
+		for (let i = 0; i < 4; i++) {
+			store.remember(
+				currentSessionId,
+				"decision",
+				`Authentication decision ${i}`,
+				"authentication authentication authentication authentication",
+				0.9,
+			);
+		}
+		store.remember(
+			otherSessionId,
+			"decision",
+			"Other-project authentication",
+			"other authentication details",
+			0.9,
+		);
+		const results = store.search("authentication", 10, {
+			project: "codemem",
+			widen_project_when_weak: true,
+		});
+		const widened = results.filter((r) => r.metadata?.widened_from_project === true);
+		expect(widened).toHaveLength(0);
+	});
+
+	it("does not widen when the query names a file path", () => {
+		seedTwoProjects();
+		const results = store.search("authentication packages/auth/token.ts", 10, {
+			project: "codemem",
+			widen_project_when_weak: true,
+		});
+		const widened = results.filter((r) => r.metadata?.widened_from_project === true);
+		expect(widened).toHaveLength(0);
+	});
+
+	it("still widens when the query contains punctuation-only dots (not real paths)", () => {
+		seedTwoProjects();
+		const results = store.search("authentication v2.1", 10, {
+			project: "codemem",
+			widen_project_when_weak: true,
+		});
+		const widened = results.filter((r) => r.metadata?.widened_from_project === true);
+		expect(widened.length).toBeGreaterThan(0);
+	});
+
+	it("respects visibility filters during cross-project widening", () => {
+		const currentSessionId = insertProjectSession("codemem");
+		const otherSessionId = insertProjectSession("other-project");
+		store.remember(
+			currentSessionId,
+			"discovery",
+			"Weak current mention",
+			"vague authentication reference",
+			0.1,
+		);
+		const ts = new Date().toISOString();
+		store.db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'decision', 'Other private auth', 'private authentication decision', 0.9, '', 1, ?, ?, '{}', 1, 'private')`,
+			)
+			.run(otherSessionId, ts, ts);
+		store.db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility)
+				 VALUES (?, 'decision', 'Other shared auth', 'shared authentication decision', 0.9, '', 1, ?, ?, '{}', 1, 'shared')`,
+			)
+			.run(otherSessionId, ts, ts);
+
+		const results = store.search("authentication", 10, {
+			project: "codemem",
+			widen_project_when_weak: true,
+			include_visibility: ["shared"],
+		});
+		const widened = results.filter((r) => r.metadata?.widened_from_project === true);
+		expect(widened.length).toBeGreaterThan(0);
+		for (const item of widened) {
+			expect(item.title).not.toContain("private");
+		}
+	});
+
+	it("caps widened results at widen_project_max_results", () => {
+		const currentSessionId = insertProjectSession("codemem");
+		const otherSessionId = insertProjectSession("other-project");
+		store.remember(
+			currentSessionId,
+			"discovery",
+			"Weak current mention",
+			"vague authentication reference",
+			0.1,
+		);
+		for (let i = 0; i < 6; i++) {
+			store.remember(
+				otherSessionId,
+				"decision",
+				`Other authentication decision ${i}`,
+				"authentication authentication",
+				0.9,
+			);
+		}
+		const results = store.search("authentication", 10, {
+			project: "codemem",
+			widen_project_when_weak: true,
+			widen_project_max_results: 2,
+		});
+		const widened = results.filter((r) => r.metadata?.widened_from_project === true);
+		expect(widened).toHaveLength(2);
+	});
+
+	it("skips widening when no project filter is set", () => {
+		seedTwoProjects();
+		const results = store.search("authentication", 10, {
+			widen_project_when_weak: true,
+		});
+		for (const item of results) {
+			expect(item.metadata?.widened_from_project).toBeUndefined();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Integration tests: MemoryStore.timeline
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -81,6 +81,9 @@ const TRUST_BIAS_UNREVIEWED_PENALTY = 0.12;
 const WIDEN_SHARED_DEFAULT_MIN_PERSONAL_RESULTS = 3;
 const WIDEN_SHARED_DEFAULT_MIN_PERSONAL_SCORE = 0.0;
 const WIDEN_SHARED_MAX_SHARED_RESULTS = 2;
+const WIDEN_PROJECT_DEFAULT_MIN_RESULTS = 3;
+const WIDEN_PROJECT_DEFAULT_MIN_SCORE = 0.0;
+const WIDEN_PROJECT_DEFAULT_MAX_RESULTS = 3;
 const NON_SUMMARY_RECAP_PENALTY = 2.5;
 const NON_SUMMARY_OBSERVER_RECAP_PENALTY = 6.5;
 const NON_TASK_TASKLIKE_PENALTY = 0.35;
@@ -260,6 +263,78 @@ function sharedWideningFilters(filters: MemoryFilters | undefined): MemoryFilter
 		personal_first: false,
 		widen_shared_when_weak: false,
 	};
+}
+
+function widenProjectWhenWeakEnabled(filters: MemoryFilters | undefined): boolean {
+	if (!filters || filters.widen_project_when_weak === undefined) return false;
+	const value = filters.widen_project_when_weak;
+	if (typeof value === "string") {
+		const lowered = value.trim().toLowerCase();
+		if (["0", "false", "no", "off"].includes(lowered)) return false;
+		if (["1", "true", "yes", "on"].includes(lowered)) return true;
+	}
+	return Boolean(value);
+}
+
+function widenProjectMinResults(filters: MemoryFilters | undefined): number {
+	const value = filters?.widen_project_min_results;
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return WIDEN_PROJECT_DEFAULT_MIN_RESULTS;
+	}
+	return Math.max(1, Math.trunc(value));
+}
+
+function widenProjectMinScore(filters: MemoryFilters | undefined): number {
+	const value = filters?.widen_project_min_score;
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return WIDEN_PROJECT_DEFAULT_MIN_SCORE;
+	}
+	return Math.max(0, value);
+}
+
+function widenProjectMaxResults(filters: MemoryFilters | undefined): number {
+	const value = filters?.widen_project_max_results;
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return WIDEN_PROJECT_DEFAULT_MAX_RESULTS;
+	}
+	return Math.max(1, Math.trunc(value));
+}
+
+function queryBlocksProjectWidening(query: string): boolean {
+	// A query that names real paths (contains `/` in a token) is almost always
+	// scoped to the current project; cross-project broadening is noise, not help.
+	// `queryPathHints` is intentionally loose and also classifies plain-English
+	// tokens like "oauth v2.1" as hints via the `.` rule, so we filter down to
+	// tokens that actually look like directory paths before short-circuiting.
+	return queryPathHints(query).some((token) => token.includes("/"));
+}
+
+function projectWideningFilters(filters: MemoryFilters | undefined): MemoryFilters {
+	return {
+		...(filters ?? {}),
+		project: undefined,
+		widen_project_when_weak: false,
+		widen_shared_when_weak: false,
+	};
+}
+
+function markProjectWideningMetadata(store: StoreHandle, items: MemoryResult[]): MemoryResult[] {
+	if (items.length === 0) return items;
+	const sessionIds = new Set(
+		items.map((item) => item.session_id).filter((id): id is number => !!id),
+	);
+	const sessionProjects = loadSessionProjects(store, sessionIds);
+	return items.map((item) => {
+		const sourceProject = sessionProjects.get(item.session_id) ?? null;
+		return {
+			...item,
+			metadata: {
+				...(item.metadata ?? {}),
+				widened_from_project: true,
+				...(sourceProject ? { source_project: sourceProject } : {}),
+			},
+		};
+	});
 }
 
 function markWideningMetadata(items: MemoryResult[]): MemoryResult[] {
@@ -769,6 +844,16 @@ export function search(
 ): MemoryResult[] {
 	const effectiveQuery = sanitizeSearchQuery(query).clean_query;
 	const primary = searchOnce(store, effectiveQuery, limit, filters);
+	const withShared = applySharedWidening(store, primary, effectiveQuery, filters);
+	return applyProjectWidening(store, withShared, effectiveQuery, filters);
+}
+
+function applySharedWidening(
+	store: StoreHandle,
+	primary: MemoryResult[],
+	effectiveQuery: string,
+	filters: MemoryFilters | undefined,
+): MemoryResult[] {
 	if (
 		!widenSharedWhenWeakEnabled(filters) ||
 		!effectiveQuery ||
@@ -804,6 +889,58 @@ export function search(
 		if (addedShared >= WIDEN_SHARED_MAX_SHARED_RESULTS) break;
 	}
 	return combined;
+}
+
+function applyProjectWidening(
+	store: StoreHandle,
+	primary: MemoryResult[],
+	effectiveQuery: string,
+	filters: MemoryFilters | undefined,
+): MemoryResult[] {
+	const projectFilter = filters?.project?.trim();
+	if (!projectFilter) return primary;
+	if (
+		!widenProjectWhenWeakEnabled(filters) ||
+		!effectiveQuery ||
+		queryBlocksProjectWidening(effectiveQuery)
+	) {
+		return primary;
+	}
+
+	const primaryProjectResults = primary.filter(
+		(item) => item.metadata?.widened_from_project !== true,
+	);
+	const strongestPrimaryScore = primaryProjectResults[0]?.score ?? -Infinity;
+	const primaryStrongEnough =
+		primaryProjectResults.length >= widenProjectMinResults(filters) &&
+		strongestPrimaryScore >= widenProjectMinScore(filters);
+	if (primaryStrongEnough) return primary;
+
+	const maxToAdd = widenProjectMaxResults(filters);
+	const candidates = searchOnce(
+		store,
+		effectiveQuery,
+		maxToAdd * 4,
+		projectWideningFilters(filters),
+	);
+	const seen = new Set(primary.map((item) => item.id));
+	const candidateSessionIds = new Set(
+		candidates.map((item) => item.session_id).filter((id): id is number => !!id),
+	);
+	const candidateSessionProjects = loadSessionProjects(store, candidateSessionIds);
+
+	const foreign: MemoryResult[] = [];
+	for (const candidate of candidates) {
+		if (seen.has(candidate.id)) continue;
+		const sourceProject = candidateSessionProjects.get(candidate.session_id) ?? null;
+		if (sourceProject && projectMatchesFilter(projectFilter, sourceProject)) continue;
+		foreign.push(candidate);
+		seen.add(candidate.id);
+		if (foreign.length >= maxToAdd) break;
+	}
+	if (foreign.length === 0) return primary;
+
+	return [...primary, ...markProjectWideningMetadata(store, foreign)];
 }
 
 function searchOnce(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -645,6 +645,10 @@ export interface MemoryFilters {
 	widen_shared_when_weak?: boolean | string;
 	widen_shared_min_personal_results?: number;
 	widen_shared_min_personal_score?: number;
+	widen_project_when_weak?: boolean | string;
+	widen_project_min_results?: number;
+	widen_project_min_score?: number;
+	widen_project_max_results?: number;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Implements the retrieval-time cross-project fallback from \`docs/plans/2026-04-17-cross-project-fallback-retrieval.md\` (landed in PR #769). When \`widen_project_when_weak\` is set and the primary-project results are weak (fewer than \`widen_project_min_results\` or below \`widen_project_min_score\`), search runs a bounded second query with the project filter cleared, drops already-seen and same-project ids, and appends up to \`widen_project_max_results\` cross-project items below the primary results.

Off by default, so existing callers see no behavior change. Closes codemem-o56x.

## Type of Change
- [x] 🚀 Feature (new functionality)

## Changes
- Add \`widen_project_when_weak\`, \`widen_project_min_results\`, \`widen_project_min_score\`, and \`widen_project_max_results\` to \`MemoryFilters\`.
- Add helpers mirroring the existing \`widen_shared_when_weak\` pattern (\`widenProjectWhenWeakEnabled\`, \`projectWideningFilters\`, \`markProjectWideningMetadata\`).
- Split \`search()\` into primary + \`applySharedWidening\` + \`applyProjectWidening\` for clarity.
- Short-circuit project widening when the query names a file path (\`queryPathHints\` non-empty), since those queries are almost always scoped to the current project.
- Tag widened items with \`metadata.widened_from_project=true\` and \`metadata.source_project=<project>\`.
- Preserve visibility/ownership filters during widening; only \`project\` is cleared.

## Testing
- [x] \`pnpm exec vitest run packages/core/src/search.test.ts\` — 89 pass (8 new widening tests).
- [x] \`pnpm run tsc\` — passes.
- [x] \`pnpm run lint\` — passes.
- [x] \`pnpm run test\` — 1376 tests pass.

## Checklist
- [x] Self-review completed
- [x] No new warnings introduced