### PR TITLE
feat(coordinator-admin): wire up device enable end-to-end

### DIFF
--- a/packages/core/src/coordinator-actions.test.ts
+++ b/packages/core/src/coordinator-actions.test.ts
@@ -6,6 +6,7 @@ import {
 	coordinatorCreateGroupAction,
 	coordinatorCreateInviteAction,
 	coordinatorDisableDeviceAction,
+	coordinatorEnableDeviceAction,
 	coordinatorEnrollDeviceAction,
 	coordinatorListDevicesAction,
 	coordinatorListGroupsAction,
@@ -115,6 +116,32 @@ describe("coordinator local admin actions", () => {
 				enabled: 0,
 			}),
 		);
+	});
+
+	it("re-enables a disabled device", async () => {
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		await coordinatorEnrollDeviceAction({
+			groupId: "team-a",
+			deviceId: "device-1",
+			fingerprint: "fp-1",
+			publicKey: "pk-1",
+			dbPath,
+		});
+		await coordinatorDisableDeviceAction({ groupId: "team-a", deviceId: "device-1", dbPath });
+		expect(await coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([]);
+		expect(
+			await coordinatorEnableDeviceAction({ groupId: "team-a", deviceId: "device-1", dbPath }),
+		).toBe(true);
+		expect(await coordinatorListDevicesAction({ groupId: "team-a", dbPath })).toEqual([
+			expect.objectContaining({ device_id: "device-1", enabled: 1 }),
+		]);
+	});
+
+	it("returns false when enabling a missing device", async () => {
+		await coordinatorCreateGroupAction({ groupId: "team-a", dbPath });
+		expect(
+			await coordinatorEnableDeviceAction({ groupId: "team-a", deviceId: "missing", dbPath }),
+		).toBe(false);
 	});
 
 	it("rejects enrollment into a missing group", async () => {

--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -494,6 +494,47 @@ export async function coordinatorDisableDeviceAction(opts: {
 	}
 }
 
+export async function coordinatorEnableDeviceAction(opts: {
+	groupId: string;
+	deviceId: string;
+	dbPath?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+}): Promise<boolean> {
+	const groupId = String(opts.groupId ?? "").trim();
+	const deviceId = String(opts.deviceId ?? "").trim();
+	if (!groupId || !deviceId) throw new Error("group_id and device_id are required.");
+	const remote = opts.remoteUrl ?? coordinatorRemoteTarget().remoteUrl;
+	const adminSecret = opts.adminSecret ?? coordinatorRemoteTarget().adminSecret;
+	if (remote) {
+		if (!adminSecret) throw new Error("Admin secret required.");
+		try {
+			await remoteRequest(
+				"POST",
+				`${remote.replace(/\/+$/, "")}/v1/admin/devices/enable`,
+				adminSecret,
+				{ group_id: groupId, device_id: deviceId },
+			);
+		} catch (error) {
+			if (
+				error instanceof Error &&
+				error.message.includes("(404)") &&
+				error.message.includes("device_not_found")
+			) {
+				return false;
+			}
+			throw error;
+		}
+		return true;
+	}
+	const store = new BetterSqliteCoordinatorStore(opts.dbPath ?? DEFAULT_COORDINATOR_DB_PATH);
+	try {
+		return await store.setDeviceEnabled(groupId, deviceId, true);
+	} finally {
+		await store.close();
+	}
+}
+
 export async function coordinatorRemoveDeviceAction(opts: {
 	groupId: string;
 	deviceId: string;

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -738,6 +738,39 @@ export function createCoordinatorApp(
 		}
 	});
 
+	// POST /v1/admin/devices/enable
+	app.post("/v1/admin/devices/enable", async (c) => {
+		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);
+		if (!adminAuth.ok)
+			return rateLimitedResponse(c, c.req.path, false) ?? c.json({ error: adminAuth.error }, 401);
+		const limited = rateLimitedResponse(c, "admin", true);
+		if (limited) return limited;
+
+		const raw = await readRequestBytes(c);
+		if (raw == null) return c.json({ error: "body_too_large" }, 413);
+
+		const data = parseJsonObject(raw);
+		if (!data) {
+			return c.json({ error: "invalid_json" }, 400);
+		}
+
+		const groupId = String(data.group_id ?? "").trim();
+		const deviceId = String(data.device_id ?? "").trim();
+
+		if (!groupId || !deviceId) {
+			return c.json({ error: "group_id_and_device_id_required" }, 400);
+		}
+
+		const store = createStore();
+		try {
+			const ok = await store.setDeviceEnabled(groupId, deviceId, true);
+			if (!ok) return c.json({ error: "device_not_found" }, 404);
+			return c.json({ ok: true });
+		} finally {
+			await store.close();
+		}
+	});
+
 	// POST /v1/admin/devices/remove
 	app.post("/v1/admin/devices/remove", async (c) => {
 		const adminAuth = authorizeAdmin(c.req.header(ADMIN_HEADER), runtime);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export {
 	coordinatorCreateGroupAction,
 	coordinatorCreateInviteAction,
 	coordinatorDisableDeviceAction,
+	coordinatorEnableDeviceAction,
 	coordinatorEnrollDeviceAction,
 	coordinatorImportInviteAction,
 	coordinatorListBootstrapGrantsAction,

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -411,6 +411,19 @@ export async function disableCoordinatorAdminDevice(
 	return data;
 }
 
+export async function enableCoordinatorAdminDevice(
+	deviceId: string,
+	groupId: string,
+): Promise<unknown> {
+	const resp = await fetch(
+		`/api/coordinator/admin/devices/${encodeURIComponent(deviceId)}/enable?group_id=${encodeURIComponent(groupId)}`,
+		{ method: "POST" },
+	);
+	const { text, payload: data } = await readJsonPayload(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}
+
 export async function removeCoordinatorAdminDevice(
 	deviceId: string,
 	groupId: string,

--- a/packages/ui/src/tabs/coordinator-admin.tsx
+++ b/packages/ui/src/tabs/coordinator-admin.tsx
@@ -25,7 +25,7 @@ let groupActionPendingKind: "create" | "rename" | "archive" | "unarchive" | "" =
 let joinReviewPendingId = "";
 let joinReviewPendingAction: "approve" | "deny" | "" = "";
 let deviceActionPendingId = "";
-let deviceActionPendingKind: "rename" | "disable" | "remove" | "" = "";
+let deviceActionPendingKind: "rename" | "disable" | "enable" | "remove" | "" = "";
 const groupRenameDrafts = new Map<string, string>();
 const deviceRenameDrafts = new Map<string, string>();
 const ADMIN_TARGET_GROUP_KEY = "codemem-coordinator-admin-target-group";
@@ -698,7 +698,7 @@ async function runDeviceAction(
 	deviceId: string,
 	groupId: string,
 	displayName: string,
-	kind: "rename" | "disable" | "remove",
+	kind: "rename" | "disable" | "enable" | "remove",
 ) {
 	if (!deviceId || deviceActionPendingId) return;
 	if (
@@ -707,7 +707,7 @@ async function runDeviceAction(
 			title: `${kind === "disable" ? "Disable" : "Remove"} ${displayName || deviceId}?`,
 			description:
 				kind === "disable"
-					? "This device will stay enrolled but can no longer participate until you re-enable it from a future admin flow."
+					? "This device will stay enrolled but can no longer participate until you re-enable it."
 					: "This removes the enrolled device record from the coordinator. The teammate would need a fresh invite or re-enrollment path to come back.",
 			confirmLabel: kind === "disable" ? "Disable device" : "Remove device",
 			cancelLabel: kind === "disable" ? "Keep device enabled" : "Keep device enrolled",
@@ -732,6 +732,10 @@ async function runDeviceAction(
 		if (kind === "disable") {
 			await api.disableCoordinatorAdminDevice(deviceId, groupId);
 			showGlobalNotice("Device disabled.", "success");
+		}
+		if (kind === "enable") {
+			await api.enableCoordinatorAdminDevice(deviceId, groupId);
+			showGlobalNotice("Device enabled.", "success");
 		}
 		if (kind === "remove") {
 			await api.removeCoordinatorAdminDevice(deviceId, groupId);
@@ -760,7 +764,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 			"p",
 			{ class: "peer-submeta" },
 			summary.readiness === "ready"
-				? "Rename, disable, or remove enrolled devices from the operator surface without confusing this with direct sync state."
+				? "Rename, disable, re-enable, or remove enrolled devices from the operator surface without confusing this with direct sync state."
 				: "Finish setup first. Device administration stays disabled until coordinator admin is ready.",
 		),
 		!items.length
@@ -823,16 +827,28 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 									},
 									pending && deviceActionPendingKind === "rename" ? "Renaming…" : "Rename",
 								),
-								h(
-									"button",
-									{
-										class: "danger",
-										disabled: !deviceId || pending || summary.readiness !== "ready" || !enabled,
-										onClick: () => void runDeviceAction(deviceId, groupId, displayName, "disable"),
-										type: "button",
-									},
-									pending && deviceActionPendingKind === "disable" ? "Disabling…" : "Disable",
-								),
+								enabled
+									? h(
+											"button",
+											{
+												class: "danger",
+												disabled: !deviceId || pending || summary.readiness !== "ready",
+												onClick: () =>
+													void runDeviceAction(deviceId, groupId, displayName, "disable"),
+												type: "button",
+											},
+											pending && deviceActionPendingKind === "disable" ? "Disabling…" : "Disable",
+										)
+									: h(
+											"button",
+											{
+												disabled: !deviceId || pending || summary.readiness !== "ready",
+												onClick: () =>
+													void runDeviceAction(deviceId, groupId, displayName, "enable"),
+												type: "button",
+											},
+											pending && deviceActionPendingKind === "enable" ? "Enabling…" : "Enable",
+										),
 								h(
 									"button",
 									{

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5081,6 +5081,9 @@ describe("viewer-server", () => {
 				if (url.includes("/v1/admin/devices/disable")) {
 					return new Response(JSON.stringify({ ok: true }), { status: 200 });
 				}
+				if (url.includes("/v1/admin/devices/enable")) {
+					return new Response(JSON.stringify({ ok: true }), { status: 200 });
+				}
 				if (url.includes("/v1/admin/devices/remove")) {
 					return new Response(JSON.stringify({ ok: true }), { status: 200 });
 				}
@@ -5116,6 +5119,12 @@ describe("viewer-server", () => {
 					});
 					expect(disabled.status).toBe(200);
 					expect(await disabled.json()).toMatchObject({ ok: true, device_id: "device-1" });
+
+					const enabled = await app.request("/api/coordinator/admin/devices/device-1/enable", {
+						method: "POST",
+					});
+					expect(enabled.status).toBe(200);
+					expect(await enabled.json()).toMatchObject({ ok: true, device_id: "device-1" });
 
 					const removed = await app.request("/api/coordinator/admin/devices/device-1/remove", {
 						method: "POST",

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -22,6 +22,7 @@ import {
 	coordinatorCreateGroupAction,
 	coordinatorCreateInviteAction,
 	coordinatorDisableDeviceAction,
+	coordinatorEnableDeviceAction,
 	coordinatorImportInviteAction,
 	coordinatorListBootstrapGrantsAction,
 	coordinatorListDevicesAction,
@@ -2401,6 +2402,33 @@ export function syncRoutes(
 		if (!groupId) return c.json({ error: "group_id required", status }, 400);
 		try {
 			const ok = await coordinatorDisableDeviceAction({
+				groupId,
+				deviceId,
+				remoteUrl: config.syncCoordinatorUrl || null,
+				adminSecret: config.syncCoordinatorAdminSecret || null,
+			});
+			if (!ok) return c.json({ error: "device_not_found", status }, 404);
+			return c.json({ ok: true, device_id: deviceId, status });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error), status }, 400);
+		}
+	});
+
+	app.post("/api/coordinator/admin/devices/:device_id/enable", async (c) => {
+		const config = readCoordinatorSyncConfig();
+		const status = coordinatorAdminStatusPayload(config);
+		if (status.readiness === "not_configured") {
+			return c.json({ error: "coordinator_not_configured", status }, 400);
+		}
+		if (!status.has_admin_secret) {
+			return c.json({ error: "coordinator_admin_secret_missing", status }, 400);
+		}
+		const deviceId = String(c.req.param("device_id") ?? "").trim();
+		if (!deviceId) return c.json({ error: "device_id required", status }, 400);
+		const groupId = resolveCoordinatorAdminGroup(c.req.query("group_id"), status);
+		if (!groupId) return c.json({ error: "group_id required", status }, 400);
+		try {
+			const ok = await coordinatorEnableDeviceAction({
 				groupId,
 				deviceId,
 				remoteUrl: config.syncCoordinatorUrl || null,


### PR DESCRIPTION
## Description
\`setDeviceEnabled\` already supports \`enabled=true\` in the coordinator store, but the rest of the stack was disable-only: no \`/v1/admin/devices/enable\` route, no \`coordinatorEnableDeviceAction\`, no viewer-server proxy, no UI button. Disable therefore looked permanent and was styled as a destructive action.

This PR wires enable up symmetrically across every layer. Closes codemem-57yy.

## Type of Change
- [x] 🚀 Feature (new functionality)

## Changes
- **Coordinator API** (\`packages/core/src/coordinator-api.ts\`): add \`POST /v1/admin/devices/enable\` mirroring the disable route.
- **Coordinator action** (\`packages/core/src/coordinator-actions.ts\`): add \`coordinatorEnableDeviceAction\` with the same local/remote dispatch and 404 handling as the disable action.
- **Core index export** (\`packages/core/src/index.ts\`): re-export the new action.
- **Viewer-server proxy** (\`packages/viewer-server/src/routes/sync.ts\`): add \`POST /api/coordinator/admin/devices/:device_id/enable\` proxy route.
- **UI api wrapper** (\`packages/ui/src/lib/api.ts\`): add \`enableCoordinatorAdminDevice\`.
- **Coordinator Admin UI** (\`packages/ui/src/tabs/coordinator-admin.tsx\`): render a non-destructive **Enable** button in place of **Disable** when a device is already disabled. No confirm dialog for enable (non-destructive).

## Testing
- [x] \`packages/core/src/coordinator-actions.test.ts\`: new cases for re-enabling a disabled device and for enabling a missing device.
- [x] \`packages/viewer-server/src/index.test.ts\`: extended admin-route integration test with the enable proxy call.
- [x] \`pnpm run tsc\` — passes.
- [x] \`pnpm run lint\` — passes.
- [x] \`pnpm run test\` — 1378 tests pass.
- [x] \`pnpm --filter @codemem/ui build\` — clean build.

## Checklist
- [x] Self-review completed
- [x] No new warnings introduced