### PR TITLE
sync: clarify top-level team sync flow

### DIFF
--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -8,6 +8,7 @@ import { SyncInlineFeedback } from "./sync-inline-feedback";
 
 export interface TeamSyncStatusSummary {
 	badgeClassName: string;
+	detail: string | null;
 	headline: string | null;
 	presenceLabel: string;
 	metricsText: string;
@@ -268,7 +269,7 @@ function ActionContent(props: TeamSyncPanelProps) {
 
 	return (
 		<>
-			{showNextStepsLabel ? <SectionHeading label="Next steps" /> : null}
+			{showNextStepsLabel ? <SectionHeading label="Needs attention" /> : null}
 			{hasAttentionItems
 				? props.actionItems.map((item) => (
 						<AttentionRow key={item.id} item={item} onAction={props.onAttentionAction} />
@@ -302,7 +303,7 @@ function TeamActionsContent({ children }: { children?: ComponentChildren }) {
 	if (!children) return null;
 	return (
 		<>
-			<SectionHeading label="Keep the team moving" />
+			<SectionHeading label="Add devices & teammates" />
 			{children}
 		</>
 	);
@@ -317,13 +318,15 @@ function TeamStatusPortal({
 }) {
 	return createPortal(
 		<div className="sync-team-summary">
+			<SectionHeading label="Overview" />
 			<div className="sync-team-status-row">
-				<span className="sync-team-status-label">Team status</span>
+				<span className="sync-team-status-label">Current status</span>
 				<span className={statusSummary.badgeClassName}>{statusSummary.presenceLabel}</span>
 			</div>
 			{statusSummary.headline ? (
 				<div className="sync-team-headline">{statusSummary.headline}</div>
 			) : null}
+			{statusSummary.detail ? <div className="section-meta">{statusSummary.detail}</div> : null}
 			<div className="sync-team-metrics sync-team-metrics-secondary">
 				{statusSummary.metricsText}
 			</div>

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -564,6 +564,14 @@ export function renderTeamSync() {
 	const teamLabel = (coordinator.groups || []).join(", ") || "none";
 	const statusSummary: TeamSyncStatusSummary = {
 		badgeClassName: `pill ${presenceStatus === "posted" ? "pill-success" : presenceStatus === "not_enrolled" ? "pill-warning" : "pill-error"}`,
+		detail:
+			presenceStatus === "posted"
+				? actionableCount > 0
+					? `Team ${teamLabel}. Start with the highest-priority item below, then review people and devices.`
+					: `Team ${teamLabel}. Nothing urgent is blocking sync right now.`
+				: presenceStatus === "not_enrolled"
+					? `Team ${teamLabel}. Enroll this device first, then return here to review the rest of the team.`
+					: `Team ${teamLabel}. Fix the current sync issue first, then verify the rest of the team state.`,
 		headline:
 			presenceStatus === "posted"
 				? actionableCount > 0


### PR DESCRIPTION
## Description
Clarifies the top-level Team sync flow so the overview, urgent work, and add-device flows read in a more intentional order. This makes the Sync tab easier to scan before users drop into people and device maintenance.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
