### PR TITLE
sync: clarify join invite and pairing flows

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -47,9 +47,9 @@ function InviteToggleRow({
 		<>
 			<div className="sync-action">
 				<div className="sync-action-text">
-					Add another teammate.
+					Invite a teammate.
 					<span className="sync-action-command">
-						Generate an invite when you are ready to bring another device into this team.
+						Generate an invite when you want someone else to join this team from their device.
 					</span>
 				</div>
 				<button type="button" className="settings-button" onClick={onToggle}>
@@ -73,7 +73,7 @@ function PairingCopyRow() {
 			<div className="sync-action-text">
 				Pair another device.
 				<span className="sync-action-command">
-					Use the pairing command in Advanced diagnostics when you are ready to connect one.
+					Use a pairing command when you want to connect another one of your own devices.
 				</span>
 			</div>
 			<button
@@ -119,6 +119,14 @@ export function SyncInviteJoinPanels({
 		<>
 			{presenceStatus === "not_enrolled" ? (
 				<>
+					<div className="sync-action">
+						<div className="sync-action-text">
+							Join this device.
+							<span className="sync-action-command">
+								Paste an invite for this device below to join an existing team.
+							</span>
+						</div>
+					</div>
 					{joinPanel ? (
 						<ExistingElementSlot
 							element={joinPanel}
@@ -131,7 +139,7 @@ export function SyncInviteJoinPanels({
 						<div className="sync-action-text">
 							This device is not on the team yet.
 							<span className="sync-action-command">
-								Import an invite or ask an admin to enroll it first.
+								Use Join this device above, or ask an admin to enroll it first.
 							</span>
 						</div>
 					</div>


### PR DESCRIPTION
## Description
Clarifies the join, invite, and pairing flows so each one describes a distinct onboarding task. This helps users tell whether they are enrolling the current device, inviting a teammate, or pairing one of their own devices.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
