### PR TITLE
sync: standardize sync empty-state and attention copy

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -243,9 +243,9 @@ function SyncActorsList({
 	if (!actors.length) {
 		return (
 			<div className="sync-empty-state">
-				<strong>No people yet.</strong>
+				<strong>No people set up yet.</strong>
 				<span>
-					Create a named person here, then assign each device below to keep sync ownership readable.
+					Create a named person here, then assign devices below so team ownership stays readable.
 				</span>
 			</div>
 		);

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -461,11 +461,11 @@ function SyncPeersList(props: SyncPeersListProps) {
 			<>
 				<SyncInlineFeedback feedback={sectionFeedback} />
 				<div className="sync-empty-state">
-					<strong>No paired devices yet.</strong>
+					<strong>No devices connected here yet.</strong>
 					<span>
 						{syncDisabled
 							? "Turn on sync in Settings → Device Sync first, then use Show pairing in Advanced diagnostics to connect another device."
-							: "Use the Show pairing control in Advanced diagnostics, run the command on the other device, then come back here to name and assign it."}
+							: "Use Show pairing in Advanced diagnostics, run the command on the other device, then come back here to name and assign it."}
 					</span>
 				</div>
 			</>

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -284,12 +284,14 @@ function ActionContent(props: TeamSyncPanelProps) {
 				: null}
 			{!hasAttentionItems && !hasOtherActionableWork && props.presenceStatus === "posted" ? (
 				<div className="sync-action">
-					<div className="sync-action-text">Everything is healthy.</div>
+					<div className="sync-action-text">No urgent team work right now.</div>
 				</div>
 			) : null}
 			{!hasAttentionItems && hasOtherActionableWork && props.presenceStatus === "posted" ? (
 				<div className="sync-action">
-					<div className="sync-action-text">Review the team items below when you are ready.</div>
+					<div className="sync-action-text">
+						More team follow-up is listed below when you are ready.
+					</div>
 				</div>
 			) : null}
 			{!hasAttentionItems && props.presenceStatus === "not_enrolled" ? (


### PR DESCRIPTION
## Description
Standardizes the Sync tab empty-state and attention copy so “nothing urgent” and “nothing connected yet” states use a more consistent voice. This makes status changes feel less random across sections.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
