### PR TITLE
sync: extract shared sync empty-state UI

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -12,6 +12,7 @@ import {
 import { openSyncConfirmDialog } from "../sync-dialogs";
 import type { ActorLike } from "../view-model";
 import { renderIntoSyncMount } from "./render-root";
+import { SyncEmptyState } from "./sync-empty-state";
 
 type SyncActorRowProps = {
 	actor: ActorLike;
@@ -242,12 +243,10 @@ function SyncActorsList({
 }: SyncActorsListProps) {
 	if (!actors.length) {
 		return (
-			<div className="sync-empty-state">
-				<strong>No people set up yet.</strong>
-				<span>
-					Create a named person here, then assign devices below so team ownership stays readable.
-				</span>
-			</div>
+			<SyncEmptyState
+				detail="Create a named person here, then assign devices below so team ownership stays readable."
+				title="No people set up yet."
+			/>
 		);
 	}
 

--- a/packages/ui/src/tabs/sync/components/sync-empty-state.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-empty-state.tsx
@@ -1,0 +1,15 @@
+import type { ComponentChildren } from "preact";
+
+type SyncEmptyStateProps = {
+	title: ComponentChildren;
+	detail: ComponentChildren;
+};
+
+export function SyncEmptyState({ title, detail }: SyncEmptyStateProps) {
+	return (
+		<div className="sync-empty-state">
+			<strong>{title}</strong>
+			<span>{detail}</span>
+		</div>
+	);
+}

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -17,6 +17,7 @@ import { PeerScopeCollapsible } from "../peer-scope-collapsible";
 import { openSyncConfirmDialog } from "../sync-dialogs";
 import { derivePeerTrustSummary, type PeerLike } from "../view-model";
 import { renderIntoSyncMount } from "./render-root";
+import { SyncEmptyState } from "./sync-empty-state";
 import { type SyncActionFeedback, SyncInlineFeedback } from "./sync-inline-feedback";
 
 type PeerScopeLike = {
@@ -460,14 +461,14 @@ function SyncPeersList(props: SyncPeersListProps) {
 		return (
 			<>
 				<SyncInlineFeedback feedback={sectionFeedback} />
-				<div className="sync-empty-state">
-					<strong>No devices connected here yet.</strong>
-					<span>
-						{syncDisabled
+				<SyncEmptyState
+					detail={
+						syncDisabled
 							? "Turn on sync in Settings → Device Sync first, then use Show pairing in Advanced diagnostics to connect another device."
-							: "Use Show pairing in Advanced diagnostics, run the command on the other device, then come back here to name and assign it."}
-					</span>
-				</div>
+							: "Use Show pairing in Advanced diagnostics, run the command on the other device, then come back here to name and assign it."
+					}
+					title="No devices connected here yet."
+				/>
 			</>
 		);
 	}


### PR DESCRIPTION
## Description
Extracts the repeated Sync empty-state UI into a shared component after the copy and layout patterns stabilized. This keeps the people and device sections aligned without hiding their intent behind larger abstractions.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
