### PR TITLE
sync: make re-pairing and offline states explicit

### DIFF
--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -476,12 +476,12 @@ export function renderHealthOverview() {
 	} else if (syncState === "stopped") {
 		recommendations.push({
 			label: "Sync daemon is stopped. Start the background service.",
-			command: "codemem sync start",
+			command: "codemem serve start",
 		});
 	} else if (!syncDisabled && !syncNoPeers && (syncState === "error" || syncState === "degraded")) {
 		recommendations.push({
 			label: "Sync is unhealthy. Restart and run one immediate pass.",
-			command: "codemem sync restart",
+			command: "codemem serve restart",
 			action: triggerSync,
 			actionLabel: "Sync now",
 		});

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -275,7 +275,7 @@ function ActionContent(props: TeamSyncPanelProps) {
 		<>
 			{showNextStepsLabel ? <SectionHeading label="Needs attention" /> : null}
 			{showNextStepsLabel ? (
-				<SectionNote>Start here when something needs review, repair, or approval.</SectionNote>
+				<SectionNote>Start here when something needs review, re-pairing, or approval.</SectionNote>
 			) : null}
 			{hasAttentionItems
 				? props.actionItems.map((item) => (
@@ -365,7 +365,8 @@ function DiscoveredPortal({
 		<>
 			<SectionHeading count={rows.length || undefined} label="Devices waiting for review" />
 			<SectionNote>
-				Review team devices here when they still need trust, repair, or approval on this machine.
+				Review team devices here when they still need trust, re-pairing, or approval on this
+				machine.
 			</SectionNote>
 			<SyncInlineFeedback feedback={state.syncDiscoveredFeedback} />
 			{rows.map((row) => (

--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -320,7 +320,7 @@ export function renderSyncStatus() {
 	} else if (daemonState === "offline-peers") {
 		/* informational */
 	} else if (daemonState === "stopped") {
-		actions.push({ label: "Sync daemon is stopped. Start it.", command: "codemem sync start" });
+		actions.push({ label: "Sync daemon is stopped. Start it.", command: "codemem serve start" });
 		actions.push({ label: "Run one sync pass now.", command: "codemem sync once" });
 	} else if (daemonState === "needs_attention") {
 		actions.push({
@@ -335,7 +335,7 @@ export function renderSyncStatus() {
 	} else if (syncError || pingError || daemonState === "error") {
 		actions.push({
 			label: "Sync reports errors. Restart now.",
-			command: "codemem sync restart && codemem sync once",
+			command: "codemem serve restart && codemem sync once",
 		});
 		actions.push({
 			label: "Run doctor for the root cause.",

--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -539,7 +539,7 @@ export function renderTeamSync() {
 		);
 		if (repairItems.length > 0)
 			attentionParts.push(
-				`${repairItems.length} device${repairItems.length === 1 ? "" : "s"} to repair`,
+				`${repairItems.length} device issue${repairItems.length === 1 ? "" : "s"} to review`,
 			);
 		if (nameItems.length > 0)
 			attentionParts.push(`${nameItems.length} device${nameItems.length === 1 ? "" : "s"} to name`);
@@ -597,7 +597,7 @@ export function renderTeamSync() {
 	}
 	if (discoveredMeta) {
 		discoveredMeta.textContent = visibleDiscoveredRows.length
-			? "Review anything here that still needs trust, repair, or approval."
+			? "Review anything here that still needs trust, follow-up, or approval."
 			: "";
 	}
 	if (joinRequests) {

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -61,10 +61,27 @@ describe("deviceNeedsFriendlyName", () => {
 });
 
 describe("derivePeerUiStatus", () => {
-	it("flags peers with explicit errors as needs-repair", () => {
+	it("flags unauthorized peers as needing re-pairing attention", () => {
+		expect(
+			derivePeerUiStatus({
+				has_error: true,
+				last_error: "peer status failed (401: unauthorized)",
+				status: { peer_state: "degraded" },
+			}),
+		).toBe("needs-repair");
+	});
+
+	it("treats timeout-heavy peers as offline instead of generic repair", () => {
 		expect(derivePeerUiStatus({ has_error: true, status: { peer_state: "online" } })).toBe(
 			"needs-repair",
 		);
+		expect(
+			derivePeerUiStatus({
+				has_error: true,
+				last_error: "all addresses failed | http://x: The operation was aborted due to timeout",
+				status: { peer_state: "degraded" },
+			}),
+		).toBe("offline");
 	});
 
 	it("maps stale peers to offline", () => {
@@ -83,7 +100,7 @@ describe("derivePeerTrustSummary", () => {
 		).toBe("offline");
 	});
 
-	it("surfaces one-way trust when the remote device rejects us with unauthorized", () => {
+	it("surfaces re-pairing guidance when the remote device rejects us with unauthorized", () => {
 		expect(
 			derivePeerTrustSummary({
 				last_error: "peer status failed (401: unauthorized)",
@@ -91,10 +108,26 @@ describe("derivePeerTrustSummary", () => {
 				has_error: true,
 			}),
 		).toEqual({
-			state: "trusted-by-you",
-			badgeLabel: "Waiting for other device",
+			state: "needs-repairing",
+			badgeLabel: "Needs re-pairing",
 			description:
-				"You accepted this device, but the other device still needs to trust this one before sync can work.",
+				"This device no longer trusts this one. Pair again from the other device, or remove this local record if it is no longer valid.",
+			isWarning: true,
+		});
+	});
+
+	it("treats timeout-heavy device errors as offline guidance", () => {
+		expect(
+			derivePeerTrustSummary({
+				last_error: "all addresses failed | http://x: The operation was aborted due to timeout",
+				status: { peer_state: "degraded" },
+				has_error: true,
+			}),
+		).toEqual({
+			state: "offline",
+			badgeLabel: "Offline",
+			description:
+				"This device is known locally, but it is not responding on its saved addresses right now.",
 			isWarning: true,
 		});
 	});
@@ -212,7 +245,7 @@ describe("summarizeSyncRunResult", () => {
 		});
 	});
 
-	it("turns unauthorized sync failures into a directional trust message", () => {
+	it("turns unauthorized sync failures into a re-pairing message", () => {
 		expect(
 			summarizeSyncRunResult({
 				items: [
@@ -229,7 +262,7 @@ describe("summarizeSyncRunResult", () => {
 		).toEqual({
 			ok: false,
 			message:
-				"This device trusts the peer, but the other device still needs to trust this one before sync can work.",
+				"This device no longer has two-way trust with the peer. Pair it again from the other device, or remove the stale local record.",
 			warning: true,
 		});
 	});
@@ -307,7 +340,7 @@ describe("deriveVisiblePeopleActors", () => {
 });
 
 describe("deriveSyncViewModel", () => {
-	it("creates attention items for duplicates, repairs, reviewable devices, and naming gaps", () => {
+	it("creates attention items for duplicates and device issues that need review", () => {
 		const view = deriveSyncViewModel({
 			actors: [
 				{ actor_id: "actor-local", display_name: "Adam", is_local: true },
@@ -350,6 +383,9 @@ describe("deriveSyncViewModel", () => {
 			"possible-duplicate-person",
 			"device-needs-repair",
 		]);
+		expect(view.attentionItems[1]).toMatchObject({
+			title: "peer-1 needs review",
+		});
 	});
 
 	it("hides duplicate-person attention when the user already marked them as different people", () => {

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -9,7 +9,7 @@ export const SYNC_TERMINOLOGY = {
 	peers: "devices",
 	pairedLocally: "Connected on this device",
 	discovered: "Seen on team",
-	conflicts: "Needs repair",
+	conflicts: "Needs review",
 } as const;
 
 export type UiSyncStatus = "connected" | "available" | "needs-repair" | "offline" | "waiting";
@@ -17,7 +17,8 @@ export type UiTrustState =
 	| "available"
 	| "trusted-by-you"
 	| "mutual-trust"
-	| "needs-repair"
+	| "needs-repairing"
+	| "needs-review"
 	| "offline";
 export type UiCoordinatorApprovalState =
 	| "none"
@@ -167,9 +168,12 @@ export function deviceNeedsFriendlyName(input: {
 
 export function derivePeerUiStatus(peer: PeerLike): UiSyncStatus {
 	const peerState = cleanText(peer?.status?.peer_state);
+	if (peerState === "offline" || peerState === "stale") return "offline";
+	const lastError = peerErrorText(peer);
+	if (isUnauthorizedPeerError(lastError)) return "needs-repair";
+	if (isConnectivityPeerError(lastError)) return "offline";
 	if (peer?.has_error || peerState === "degraded") return "needs-repair";
 	if (peerState === "online") return "connected";
-	if (peerState === "offline" || peerState === "stale") return "offline";
 	if (peer?.status?.fresh) return "connected";
 	return "waiting";
 }
@@ -181,6 +185,16 @@ function isOfflineTeamDevice(device: MergedDevice): boolean {
 
 function peerErrorText(peer: PeerLike): string {
 	return cleanText(peer?.last_error).toLowerCase();
+}
+
+function isUnauthorizedPeerError(errorText: string): boolean {
+	return errorText.includes("401") && errorText.includes("unauthorized");
+}
+
+function isConnectivityPeerError(errorText: string): boolean {
+	return ["timeout", "connection refused", "unreachable", "aborted", "all addresses failed"].some(
+		(fragment) => errorText.includes(fragment),
+	);
 }
 
 export function derivePeerTrustSummary(peer: PeerLike): UiPeerTrustSummary {
@@ -197,12 +211,21 @@ export function derivePeerTrustSummary(peer: PeerLike): UiPeerTrustSummary {
 			isWarning: true,
 		};
 	}
-	if (lastError.includes("401") && lastError.includes("unauthorized")) {
+	if (isUnauthorizedPeerError(lastError)) {
 		return {
-			state: "trusted-by-you",
-			badgeLabel: "Waiting for other device",
+			state: "needs-repairing",
+			badgeLabel: "Needs re-pairing",
 			description:
-				"You accepted this device, but the other device still needs to trust this one before sync can work.",
+				"This device no longer trusts this one. Pair again from the other device, or remove this local record if it is no longer valid.",
+			isWarning: true,
+		};
+	}
+	if (isConnectivityPeerError(lastError)) {
+		return {
+			state: "offline",
+			badgeLabel: "Offline",
+			description:
+				"This device is known locally, but it is not responding on its saved addresses right now.",
 			isWarning: true,
 		};
 	}
@@ -216,10 +239,9 @@ export function derivePeerTrustSummary(peer: PeerLike): UiPeerTrustSummary {
 	}
 	if (peer?.has_error || peerState === "degraded") {
 		return {
-			state: "needs-repair",
-			badgeLabel: "Needs repair",
-			description:
-				"This device has a sync problem that needs review before trust can be relied on.",
+			state: "needs-review",
+			badgeLabel: "Needs review",
+			description: "This device has a sync problem that needs review before you rely on it again.",
 			isWarning: true,
 		};
 	}
@@ -302,7 +324,7 @@ export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
 		return {
 			ok: false,
 			message:
-				"This device trusts the peer, but the other device still needs to trust this one before sync can work.",
+				"This device no longer has two-way trust with the peer. Pair it again from the other device, or remove the stale local record.",
 			warning: true,
 		};
 	}
@@ -378,12 +400,13 @@ function createRepairItem(device: {
 	id: string;
 	name: string;
 	summary: string;
+	title?: string;
 }): UiSyncAttentionItem {
 	return {
 		id: `repair:${device.id}`,
 		kind: "device-needs-repair",
 		priority: 10,
-		title: `${device.name} needs repair`,
+		title: device.title || `${device.name} needs attention`,
 		summary: device.summary,
 		actionLabel: "Open device",
 		deviceId: device.id,
@@ -512,8 +535,9 @@ export function deriveSyncViewModel(input: {
 				createRepairItem({
 					id: device.deviceId,
 					name,
+					title: `${name} needs review`,
 					summary:
-						"This device identity changed. Repair or remove the older local record before reconnecting it.",
+						"This device identity changed. Remove the older local record before reconnecting it.",
 				}),
 			);
 			return;
@@ -521,16 +545,26 @@ export function deriveSyncViewModel(input: {
 
 		if (device.peer && peerStatus === "needs-repair") {
 			const detail =
-				trustSummary?.state === "trusted-by-you"
-					? trustSummary.description
-					: cleanText(device.peer?.last_error) || "Sync health is degraded or broken.";
-			attentionItems.push(createRepairItem({ id: device.deviceId, name, summary: detail }));
+				trustSummary?.description || cleanText(device.peer?.last_error) || "Sync needs review.";
+			attentionItems.push(
+				createRepairItem({
+					id: device.deviceId,
+					name,
+					title:
+						trustSummary?.state === "needs-repairing"
+							? `${name} needs re-pairing`
+							: `${name} needs review`,
+					summary: detail,
+				}),
+			);
 		} else if (device.peer && peerStatus === "offline") {
 			attentionItems.push(
 				createRepairItem({
 					id: device.deviceId,
 					name,
-					summary: "This device is offline or stale. Review it before re-pairing or retrying sync.",
+					title: `${name} is offline`,
+					summary:
+						"This device is offline or unreachable right now. Retry later, or review the local record if it should have been available.",
 				}),
 			);
 		}


### PR DESCRIPTION
## Description
Replaces vague Sync repair language with clearer actionable states: unauthorized peers now read as re-pairing problems, timeout-heavy peers read as offline, and stale health guidance now points at the serve-managed daemon lifecycle. This makes failure states easier to act on without inventing an automated repair workflow that does not exist.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
