### PR TITLE
sync: align device actions with existing button styles

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -342,7 +342,12 @@ function SyncPeerCard({
 				</div>
 
 				<div className="peer-actions">
-					<button type="button" disabled={!primaryAddress || syncBusy} onClick={() => void sync()}>
+					<button
+						type="button"
+						className="settings-button"
+						disabled={!primaryAddress || syncBusy}
+						onClick={() => void sync()}
+					>
 						{syncBusy ? "Syncing…" : "Sync now"}
 					</button>
 					<TextInput
@@ -357,10 +362,20 @@ function SyncPeerCard({
 							setRenameValue(event.currentTarget.value)
 						}
 					/>
-					<button type="button" disabled={renameBusy} onClick={() => void rename()}>
+					<button
+						type="button"
+						className="settings-button"
+						disabled={renameBusy}
+						onClick={() => void rename()}
+					>
 						{renameLabel}
 					</button>
-					<button type="button" disabled={removeBusy} onClick={() => void remove()}>
+					<button
+						type="button"
+						className="settings-button danger"
+						disabled={removeBusy}
+						onClick={() => void remove()}
+					>
 						{removeLabel}
 					</button>
 				</div>

--- a/packages/ui/src/tabs/sync/peer-scope-collapsible.tsx
+++ b/packages/ui/src/tabs/sync/peer-scope-collapsible.tsx
@@ -41,7 +41,9 @@ export function PeerScopeCollapsible({
 	return (
 		<Collapsible.Root open={open} onOpenChange={setOpen}>
 			<Collapsible.Trigger asChild>
-				<button type="button">{open ? "Hide sharing scope" : "Show sharing scope"}</button>
+				<button type="button" className="settings-button">
+					{open ? "Hide sharing scope" : "Show sharing scope"}
+				</button>
 			</Collapsible.Trigger>
 			{contentHost ? createPortal(content, contentHost) : null}
 		</Collapsible.Root>


### PR DESCRIPTION
## Description
Aligns the peer action buttons and sharing-scope toggle with the existing styled button treatment used elsewhere in the Sync surface. This keeps device actions visually consistent instead of mixing in one-off button styling.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
