### PR TITLE
ui: abbreviate large token stats in health cards

### DIFF
--- a/packages/ui/src/lib/format.test.ts
+++ b/packages/ui/src/lib/format.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { formatTokenCount } from "./format";
+
+describe("formatTokenCount", () => {
+	it("keeps small values fully written out", () => {
+		expect(formatTokenCount(842)).toBe("842 tokens");
+	});
+
+	it("abbreviates thousands and millions with readable suffixes", () => {
+		expect(formatTokenCount(842_000)).toBe("842K tokens");
+		expect(formatTokenCount(2_106_527)).toBe("2.1M tokens");
+	});
+
+	it("abbreviates billions without falling back to raw comma groups", () => {
+		expect(formatTokenCount(2_106_527_459)).toBe("2.1B tokens");
+	});
+
+	it("promotes rounded counts into the next suffix tier", () => {
+		expect(formatTokenCount(999_950)).toBe("1M tokens");
+		expect(formatTokenCount(999_950_000)).toBe("1B tokens");
+	});
+});

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -73,6 +73,29 @@ export function formatReductionPercent(saved: unknown, read: unknown): string {
 	return `${Math.round(pct * 100)}%`;
 }
 
+export function formatTokenCount(value: unknown): string {
+	const num = Number(value || 0);
+	if (!Number.isFinite(num)) return "n/a";
+	const units = [
+		{ threshold: 1_000_000_000, suffix: "B" },
+		{ threshold: 1_000_000, suffix: "M" },
+		{ threshold: 1_000, suffix: "K" },
+	] as const;
+	let unitIndex = units.findIndex(({ threshold }) => Math.abs(num) >= threshold);
+	if (unitIndex === -1) return `${num.toLocaleString()} tokens`;
+	while (unitIndex >= 0) {
+		const { suffix, threshold } = units[unitIndex];
+		const scaled = num / threshold;
+		const roundedNumber = Number(scaled.toFixed(scaled >= 10 ? 0 : 1));
+		if (Math.abs(roundedNumber) < 1000 || unitIndex === 0) {
+			const roundedText = roundedNumber.toString().replace(/\.0$/, "");
+			return `${roundedText}${suffix} tokens`;
+		}
+		unitIndex -= 1;
+	}
+	return `${num.toLocaleString()} tokens`;
+}
+
 export function parsePercentValue(label: unknown): number | null {
 	const text = String(label || "").trim();
 	if (!text.endsWith("%")) return null;

--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -9,6 +9,7 @@ import {
 	formatPercent,
 	formatReductionPercent,
 	formatTimestamp,
+	formatTokenCount,
 	parsePercentValue,
 	secondsSince,
 	titleCase,
@@ -548,14 +549,14 @@ export function renderStats() {
 	const items: StatItem[] = [
 		{
 			label: isFiltered ? "Savings (project)" : "Savings",
-			value: Number(usage.tokens_saved || 0),
-			tooltip: `Tokens saved by reusing compressed memories${globalLineSaved}`,
+			value: formatTokenCount(usage.tokens_saved || 0),
+			tooltip: `Tokens saved by reusing compressed memories. Exact: ${Number(usage.tokens_saved || 0).toLocaleString()} saved${globalLineSaved}`,
 			icon: "trending-up",
 		},
 		{
 			label: isFiltered ? "Injected (project)" : "Injected",
-			value: Number(usage.tokens_read || 0),
-			tooltip: `Tokens injected into context (pack size)${globalLineRead}`,
+			value: formatTokenCount(usage.tokens_read || 0),
+			tooltip: `Tokens injected into context (pack size). Exact: ${Number(usage.tokens_read || 0).toLocaleString()} injected${globalLineRead}`,
 			icon: "book-open",
 		},
 		{
@@ -569,8 +570,8 @@ export function renderStats() {
 		},
 		{
 			label: isFiltered ? "Work investment (project)" : "Work investment",
-			value: Number(usage.work_investment_tokens || 0),
-			tooltip: `Token cost of unique discovery groups${globalLineWork}`,
+			value: formatTokenCount(usage.work_investment_tokens || 0),
+			tooltip: `Token cost of unique discovery groups. Exact: ${Number(usage.work_investment_tokens || 0).toLocaleString()} invested${globalLineWork}`,
 			icon: "pencil",
 		},
 		{ label: "Active memories", value: db.active_memory_items || 0, icon: "check-circle" },
@@ -646,12 +647,14 @@ export function renderSessionSummary() {
 	const items: StatItem[] = [
 		{
 			label: "Last pack savings",
-			value: latestPack ? `${savedTokens.toLocaleString()} (${reductionPercent})` : "n/a",
+			value: latestPack ? `${formatTokenCount(savedTokens)} (${reductionPercent})` : "n/a",
+			tooltip: latestPack ? `Exact: ${savedTokens.toLocaleString()} saved` : undefined,
 			icon: "trending-up",
 		},
 		{
 			label: "Last pack size",
-			value: latestPack ? packTokens.toLocaleString() : "n/a",
+			value: latestPack ? formatTokenCount(packTokens) : "n/a",
+			tooltip: latestPack ? `Exact: ${packTokens.toLocaleString()} injected` : undefined,
 			icon: "package",
 		},
 		{


### PR DESCRIPTION
## Description
Abbreviates very large token counts in Health cards into readable K/M/B units while preserving exact counts in tooltip detail. This keeps high-volume token stats scannable without losing precision.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
