### PR TITLE
sync: improve disclosure focus flow

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -1,7 +1,7 @@
 import * as Collapsible from "@radix-ui/react-collapsible";
 import type { ComponentChildren } from "preact";
 import { createPortal } from "preact/compat";
-import { useLayoutEffect, useRef } from "preact/hooks";
+import { useEffect, useLayoutEffect, useRef } from "preact/hooks";
 import { TextArea } from "../../../components/primitives/text-area";
 import { TextInput } from "../../../components/primitives/text-input";
 import { renderIntoSyncMount } from "./render-root";
@@ -33,6 +33,7 @@ function SyncDisclosure({
 }: SyncDisclosureProps) {
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
 	const contentRef = useRef<HTMLDivElement | null>(null);
+	const openedRef = useRef(false);
 
 	useLayoutEffect(() => {
 		if (triggerRef.current) {
@@ -43,6 +44,21 @@ function SyncDisclosure({
 			contentRef.current.id = contentId;
 		}
 	}, [contentId, triggerId, open]);
+
+	useEffect(() => {
+		if (!open) {
+			openedRef.current = false;
+			return;
+		}
+		if (openedRef.current) return;
+		openedRef.current = true;
+		queueMicrotask(() => {
+			const firstFocusable = contentRef.current?.querySelector<HTMLElement>(
+				'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+			);
+			firstFocusable?.focus();
+		});
+	}, [open]);
 
 	const content = (
 		<Collapsible.Content forceMount asChild>

--- a/packages/ui/src/tabs/sync/peer-scope-collapsible.tsx
+++ b/packages/ui/src/tabs/sync/peer-scope-collapsible.tsx
@@ -1,7 +1,7 @@
 import * as Collapsible from "@radix-ui/react-collapsible";
 import type { ComponentChildren } from "preact";
 import { createPortal } from "preact/compat";
-import { useEffect, useLayoutEffect, useState } from "preact/hooks";
+import { useEffect, useLayoutEffect, useRef, useState } from "preact/hooks";
 import { renderIntoSyncMount } from "./components/render-root";
 
 export type PeerScopeCollapsibleProps = {
@@ -18,6 +18,7 @@ export function PeerScopeCollapsible({
 	children,
 }: PeerScopeCollapsibleProps) {
 	const [open, setOpen] = useState(initialOpen);
+	const contentRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
 		setOpen(initialOpen);
@@ -27,9 +28,20 @@ export function PeerScopeCollapsible({
 		onOpenChange(open);
 	}, [onOpenChange, open]);
 
+	useEffect(() => {
+		if (!open) return;
+		queueMicrotask(() => {
+			const firstFocusable = contentRef.current?.querySelector<HTMLElement>(
+				'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+			);
+			firstFocusable?.focus();
+		});
+	}, [open]);
+
 	const content = (
 		<Collapsible.Content
 			forceMount
+			ref={contentRef}
 			className={`peer-scope-editor-wrap${open ? "" : " collapsed"}`}
 			hidden={!open}
 			inert={!open}


### PR DESCRIPTION
## Description
Improves Sync disclosure focus flow so keyboard users land on the first newly revealed control instead of staying behind the opened panel. This makes the pairing, team setup, and sharing-scope disclosures easier to use without changing their behavior.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
