### PR TITLE
sync: improve screen reader announcements

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-empty-state.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-empty-state.tsx
@@ -7,7 +7,7 @@ type SyncEmptyStateProps = {
 
 export function SyncEmptyState({ title, detail }: SyncEmptyStateProps) {
 	return (
-		<div className="sync-empty-state">
+		<div className="sync-empty-state" role="status" aria-live="polite" aria-atomic="true">
 			<strong>{title}</strong>
 			<span>{detail}</span>
 		</div>

--- a/packages/ui/src/tabs/sync/components/sync-inline-feedback.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-inline-feedback.tsx
@@ -10,6 +10,7 @@ export function SyncInlineFeedback({ feedback }: { feedback: SyncActionFeedback 
 			className={`sync-inline-feedback ${feedback.tone}`}
 			role={feedback.tone === "warning" ? "alert" : "status"}
 			aria-live={feedback.tone === "warning" ? "assertive" : "polite"}
+			aria-atomic="true"
 		>
 			{feedback.message}
 		</div>

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -125,6 +125,7 @@ function PendingJoinRequestRow({
 				<button
 					type="button"
 					className="settings-button"
+					aria-label={`${approveLabel} join request from ${request.displayName}`}
 					disabled={busyAction !== null}
 					onClick={async () => {
 						setBusyAction("approve");
@@ -144,6 +145,7 @@ function PendingJoinRequestRow({
 				<button
 					type="button"
 					className="settings-button"
+					aria-label={`${denyLabel} join request from ${request.displayName}`}
 					disabled={busyAction !== null}
 					onClick={async () => {
 						setBusyAction("deny");
@@ -204,6 +206,7 @@ function DiscoveredDeviceRow({
 					<button
 						type="button"
 						className="settings-button"
+						aria-label={`${reviewLabel} for ${row.displayName}`}
 						disabled={busy !== null}
 						onClick={async () => {
 							setBusy("review");
@@ -233,6 +236,7 @@ function DiscoveredDeviceRow({
 						<button
 							type="button"
 							className="settings-button"
+							aria-label={`Open details for ${row.displayName}`}
 							disabled={busy !== null}
 							onClick={() => onInspectConflict(row)}
 						>
@@ -241,6 +245,7 @@ function DiscoveredDeviceRow({
 						<button
 							type="button"
 							className="settings-button"
+							aria-label={`${removeLabel} for ${row.displayName}`}
 							disabled={busy !== null}
 							onClick={async () => {
 								setBusy("remove");


### PR DESCRIPTION
## Description
Tightens Sync screen-reader behavior by making inline status announcements atomic and adding clearer labels for join-review and device-review actions. This improves spoken feedback and action clarity on the busiest Sync rows.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
