### PR TITLE
sync: refine unavailable and retry guidance

### DIFF
--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -416,7 +416,7 @@ export function renderSyncDiagnosticsUnavailable() {
 	if (syncAttempts) renderSyncEmptyState(syncAttempts, unavailableAttemptsState());
 	if (syncMeta) {
 		syncMeta.textContent =
-			"Advanced diagnostics are unavailable right now. Refresh the page, or verify the local sync service before retrying.";
+			"Advanced diagnostics are unavailable right now. Refresh the page first. If that still fails, verify the local sync service and retry once it responds again.";
 	}
 	renderActionList(syncActions, []);
 }

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -93,13 +93,13 @@ export function renderSyncActorsUnavailable() {
 	setPeopleCreateControlsDisabled(true);
 	if (actorMeta) {
 		actorMeta.textContent =
-			"People controls are temporarily unavailable. Refresh this page to retry, but device status and sync health are still available below.";
+			"People controls are temporarily unavailable. Refresh this page to retry. Device status and sync health are still available below while this recovers.";
 	}
 	if (actorList) {
 		renderSyncEmptyState(actorList, {
 			title: "People unavailable right now.",
 			detail:
-				"Refresh this page to reload named people once the people endpoint is responding again.",
+				"Refresh this page to retry. When the people endpoint responds again, named people will reload here.",
 		});
 	}
 }
@@ -252,14 +252,14 @@ export function renderSyncPeopleUnavailable() {
 		renderSyncEmptyState(actorList, {
 			title: "People unavailable right now.",
 			detail:
-				"Refresh this page to reload named people once the local sync status endpoint is responding again.",
+				"Refresh this page to retry. Named people will reload here once the local sync status endpoint responds again.",
 		});
 	}
 	if (syncPeers) {
 		renderSyncEmptyState(syncPeers, {
 			title: "Devices unavailable right now.",
 			detail:
-				"Refresh this page to reload paired devices. When sync is reachable again, you can rename, assign, or pair devices here.",
+				"Refresh this page to retry. When sync is reachable again, paired devices will reload here so you can rename, assign, or re-pair them.",
 		});
 	}
 }


### PR DESCRIPTION
## Description
Refines Sync unavailable and retry guidance so recovery states tell users to refresh first, then verify the local service if the failure persists. This keeps fallback states actionable without pretending there is a more automated recovery path than exists.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
