### PR TITLE
sync: clarify ownership and assignment copy

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -32,9 +32,9 @@ type SyncActorsListProps = {
 
 function localActorNote(hiddenLocalDuplicateCount: number): string {
 	if (hiddenLocalDuplicateCount <= 0) {
-		return "Represents you across your devices.";
+		return "Represents you across your own devices.";
 	}
-	return `Represents you across your devices. ${hiddenLocalDuplicateCount} unresolved duplicate ${hiddenLocalDuplicateCount === 1 ? "entry is" : "entries are"} hidden until reviewed in Needs attention.`;
+	return `Represents you across your own devices. ${hiddenLocalDuplicateCount} unresolved duplicate ${hiddenLocalDuplicateCount === 1 ? "entry is" : "entries are"} hidden until reviewed in Needs attention.`;
 }
 
 function SyncActorRow({
@@ -53,7 +53,7 @@ function SyncActorRow({
 	const [renameBusy, setRenameBusy] = useState(false);
 	const [renameLabel, setRenameLabel] = useState("Rename");
 	const [mergeBusy, setMergeBusy] = useState(false);
-	const [mergeLabel, setMergeLabel] = useState("Combine into selected person");
+	const [mergeLabel, setMergeLabel] = useState("Merge into selected person");
 	const [mergeTargetId, setMergeTargetId] = useState("");
 	const [advancedOpen, setAdvancedOpen] = useState(false);
 
@@ -62,16 +62,16 @@ function SyncActorRow({
 		setRenameBusy(false);
 		setRenameLabel("Rename");
 		setMergeBusy(false);
-		setMergeLabel("Combine into selected person");
+		setMergeLabel("Merge into selected person");
 		setMergeTargetId("");
 		setAdvancedOpen(false);
 	}, [actorId, count, hiddenLocalDuplicateCount, label, mergeTargetKeys]);
 
 	const mergeNote = !mergeTargets.length
-		? "No people available to combine yet. Create another person or use You."
+		? "No other people are available yet. Create another person first if you need to merge duplicates."
 		: actorMergeNote(mergeTargetId, actorId);
 	const mergeOptions = [
-		{ label: "Combine into person", value: "" },
+		{ label: "Merge into person", value: "" },
 		...mergeTargets.map((target) => {
 			const targetId = String(target.actor_id || "");
 			return {
@@ -125,7 +125,7 @@ function SyncActorRow({
 			setMergeLabel("Retry merge");
 		} finally {
 			setMergeBusy(false);
-			if (ok) setMergeLabel("Combine into selected person");
+			if (ok) setMergeLabel("Merge into selected person");
 		}
 	}
 
@@ -150,7 +150,7 @@ function SyncActorRow({
 
 			<div className="actor-actions">
 				{actor.is_local ? (
-					<div className="peer-meta">Rename in config</div>
+					<div className="peer-meta">Rename yourself in config</div>
 				) : (
 					<>
 						<TextInput
@@ -177,22 +177,22 @@ function SyncActorRow({
 							disabled={renameBusy || mergeBusy}
 							onClick={() => setAdvancedOpen((open) => !open)}
 						>
-							{advancedOpen ? "Hide cleanup actions" : "Show cleanup actions"}
+							{advancedOpen ? "Hide duplicate cleanup" : "Show duplicate cleanup"}
 						</button>
 						{advancedOpen ? (
 							<>
 								<div className="peer-meta actor-merge-note">
-									Use these only when cleaning up duplicates or removing an unused person.
+									Use these only when cleaning up duplicate people or removing an unused person.
 								</div>
 								<div className="actor-merge-controls">
 									<RadixSelect
-										ariaLabel={`Combine ${label} into another person`}
+										ariaLabel={`Merge ${label} into another person`}
 										contentClassName="sync-radix-select-content sync-actor-select-content"
 										disabled={mergeBusy || mergeTargets.length === 0}
 										itemClassName="sync-radix-select-item"
 										onValueChange={setMergeTargetId}
 										options={mergeOptions}
-										placeholder="Combine into person"
+										placeholder="Merge into person"
 										triggerClassName="sync-radix-select-trigger sync-actor-select actor-merge-select"
 										value={mergeTargetId}
 										viewportClassName="sync-radix-select-viewport"

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -116,8 +116,8 @@ function SyncPeerCard({
 				.join(" · ")
 		: "No addresses";
 	const assignmentSummary = peer.actor_display_name
-		? `Assigned to ${peer.claimed_local_actor ? "You" : String(peer.actor_display_name)}`
-		: "No person assigned yet";
+		? `This device belongs to ${peer.claimed_local_actor ? "you" : String(peer.actor_display_name)}.`
+		: "This device is not assigned to anyone yet.";
 	const lastSyncAt = String(peerStatus.last_sync_at || peerStatus.last_sync_at_utc || "");
 	const lastPingAt = String(peerStatus.last_ping_at || peerStatus.last_ping_at_utc || "");
 	const scopeEditorOpen = openPeerScopeEditors.has(peerId);
@@ -136,7 +136,7 @@ function SyncPeerCard({
 	const [removeLabel, setRemoveLabel] = useState("Remove peer");
 	const [selectedActorId, setSelectedActorId] = useState(String(peer.actor_id || ""));
 	const [applyActorBusy, setApplyActorBusy] = useState(false);
-	const [applyActorLabel, setApplyActorLabel] = useState("Save person");
+	const [applyActorLabel, setApplyActorLabel] = useState("Save assignment");
 	const [saveScopeBusy, setSaveScopeBusy] = useState(false);
 	const [saveScopeLabel, setSaveScopeLabel] = useState("Save scope");
 	const [resetScopeBusy, setResetScopeBusy] = useState(false);
@@ -181,7 +181,7 @@ function SyncPeerCard({
 		setRemoveLabel("Remove peer");
 		setSelectedActorId(String(peer.actor_id || ""));
 		setApplyActorBusy(false);
-		setApplyActorLabel("Save person");
+		setApplyActorLabel("Save assignment");
 		setSaveScopeBusy(false);
 		setSaveScopeLabel("Save scope");
 		setResetScopeBusy(false);
@@ -282,7 +282,7 @@ function SyncPeerCard({
 			const nextFeedback = await onAssignActor(peerId, selectedActorId || null);
 			setFeedback(nextFeedback);
 			state.syncPeerFeedbackById.set(peerId, nextFeedback);
-			setApplyActorLabel("Save person");
+			setApplyActorLabel("Save assignment");
 		} catch {
 			setApplyActorLabel("Retry");
 		} finally {
@@ -399,7 +399,7 @@ function SyncPeerCard({
 					].join(" · ")}
 				</div>
 
-				<div className="peer-scope-summary">Person assignment</div>
+				<div className="peer-scope-summary">Who this device belongs to</div>
 				<div className="peer-meta">{assignmentSummary}</div>
 				<div className="peer-actor-row">
 					<div className="sync-radix-select-host sync-actor-select-host">
@@ -410,7 +410,7 @@ function SyncPeerCard({
 							itemClassName="sync-radix-select-item"
 							onValueChange={setSelectedActorId}
 							options={actorSelectOptions}
-							placeholder="No person assigned"
+							placeholder="No person assigned yet"
 							triggerClassName="sync-radix-select-trigger sync-actor-select"
 							value={selectedActorId}
 							viewportClassName="sync-radix-select-viewport"

--- a/packages/ui/src/tabs/sync/people.ts
+++ b/packages/ui/src/tabs/sync/people.ts
@@ -185,14 +185,14 @@ export function renderSyncPeers() {
 				await api.assignPeerActor(peerId, actorId);
 				await _loadSyncData();
 				return {
-					message: actorId ? "Device person updated." : "Device person cleared.",
+					message: actorId ? "Device assignment updated." : "Device assignment cleared.",
 					tone: "success",
 				} satisfies SyncActionFeedback;
 			} catch (error) {
 				return {
 					message: friendlyError(
 						error,
-						"Failed to update device person. The current assignment is unchanged.",
+						"Failed to update device assignment. The current assignment is unchanged.",
 					),
 					tone: "warning",
 				} satisfies SyncActionFeedback;


### PR DESCRIPTION
## Description
Clarifies people/device ownership wording so assignments read more naturally and use consistent “belongs to” / “assignment” language. This reduces the amount of mental translation needed when reading who a device belongs to and what merge actions mean.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
