### PR TITLE
sync: polish action labels and decision copy

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -105,10 +105,10 @@ function SyncActorRow({
 		);
 		if (!target) return;
 		const confirmed = await openSyncConfirmDialog({
-			title: `Combine ${label} into ${actorLabel(target)}?`,
+			title: `Merge ${label} into ${actorLabel(target)}?`,
 			description:
 				"Assigned devices move now, but older memories keep their current stamped provenance for now.",
-			confirmLabel: "Combine people",
+			confirmLabel: "Merge people",
 			cancelLabel: "Keep separate",
 			tone: "danger",
 		});
@@ -223,7 +223,7 @@ function SyncActorRow({
 										if (confirmed) await onDeactivate(actorId);
 									}}
 								>
-									Remove person
+									Remove this person
 								</button>
 							</>
 						) : null}

--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -73,7 +73,7 @@ function PairingCopyRow() {
 			<div className="sync-action-text">
 				Pair another device.
 				<span className="sync-action-command">
-					Use a pairing command when you want to connect another one of your own devices.
+					Copy a pairing command when you want to connect another one of your own devices.
 				</span>
 			</div>
 			<button
@@ -86,7 +86,7 @@ function PairingCopyRow() {
 					)
 				}
 			>
-				Copy
+				Copy pairing command
 			</button>
 		</div>
 	);

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -133,7 +133,7 @@ function SyncPeerCard({
 	const [renameLabel, setRenameLabel] = useState("Save name");
 	const [syncBusy, setSyncBusy] = useState(false);
 	const [removeBusy, setRemoveBusy] = useState(false);
-	const [removeLabel, setRemoveLabel] = useState("Remove peer");
+	const [removeLabel, setRemoveLabel] = useState("Remove device");
 	const [selectedActorId, setSelectedActorId] = useState(String(peer.actor_id || ""));
 	const [applyActorBusy, setApplyActorBusy] = useState(false);
 	const [applyActorLabel, setApplyActorLabel] = useState("Save assignment");
@@ -178,7 +178,7 @@ function SyncPeerCard({
 		setRenameLabel("Save name");
 		setSyncBusy(false);
 		setRemoveBusy(false);
-		setRemoveLabel("Remove peer");
+		setRemoveLabel("Remove device");
 		setSelectedActorId(String(peer.actor_id || ""));
 		setApplyActorBusy(false);
 		setApplyActorLabel("Save assignment");
@@ -253,10 +253,10 @@ function SyncPeerCard({
 	async function remove() {
 		if (!peerId) return;
 		const confirmed = await openSyncConfirmDialog({
-			title: `Remove peer ${destructiveLabel}?`,
-			description: "This deletes the local sync peer entry on this device.",
-			confirmLabel: "Remove peer",
-			cancelLabel: "Keep peer",
+			title: `Remove device ${destructiveLabel}?`,
+			description: "This removes the local record for this paired device on this machine.",
+			confirmLabel: "Remove device",
+			cancelLabel: "Keep device",
 			tone: "danger",
 		});
 		if (!confirmed) return;
@@ -270,7 +270,7 @@ function SyncPeerCard({
 			setRemoveLabel("Retry remove");
 		} finally {
 			setRemoveBusy(false);
-			if (ok) setRemoveLabel("Remove peer");
+			if (ok) setRemoveLabel("Remove device");
 		}
 	}
 
@@ -482,7 +482,7 @@ function SyncPeersList(props: SyncPeersListProps) {
 					detail={
 						syncDisabled
 							? "Turn on sync in Settings → Device Sync first, then use Show pairing in Advanced diagnostics to connect another device."
-							: "Use Show pairing in Advanced diagnostics, run the command on the other device, then come back here to name and assign it."
+							: "Use Show pairing in Advanced diagnostics, run the command on the other device, then come back here to name it and decide who it belongs to."
 					}
 					title="No devices connected here yet."
 				/>


### PR DESCRIPTION
## Description
Polishes Sync action labels and decision copy so destructive actions, pairing prompts, and merge/remove wording are more explicit. This makes the safest next action easier to understand without changing the underlying workflows.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
