### PR TITLE
feat(sync): make incremental op batch size configurable

### DIFF
--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { readCoordinatorSyncConfig } from "./coordinator-runtime.js";
+
+describe("readCoordinatorSyncConfig.syncOpsLimit", () => {
+	afterEach(() => {
+		delete process.env.CODEMEM_SYNC_OPS_LIMIT;
+	});
+
+	it("defaults to 500 when neither config nor env supplies a value", () => {
+		const config = readCoordinatorSyncConfig({});
+		expect(config.syncOpsLimit).toBe(500);
+	});
+
+	it("reads the value from the sync_ops_limit config key", () => {
+		const config = readCoordinatorSyncConfig({ sync_ops_limit: "250" });
+		expect(config.syncOpsLimit).toBe(250);
+	});
+
+	it("honors the CODEMEM_SYNC_OPS_LIMIT env var over config", () => {
+		process.env.CODEMEM_SYNC_OPS_LIMIT = "750";
+		const config = readCoordinatorSyncConfig({ sync_ops_limit: "250" });
+		expect(config.syncOpsLimit).toBe(750);
+	});
+
+	it("clamps values above the server cap of 1000", () => {
+		const config = readCoordinatorSyncConfig({ sync_ops_limit: "10000" });
+		expect(config.syncOpsLimit).toBe(1000);
+	});
+
+	it("clamps values below 1 up to 1", () => {
+		const config = readCoordinatorSyncConfig({ sync_ops_limit: "0" });
+		expect(config.syncOpsLimit).toBe(1);
+	});
+
+	it("falls back to the default when the config value is not an integer", () => {
+		const config = readCoordinatorSyncConfig({ sync_ops_limit: "not-a-number" });
+		expect(config.syncOpsLimit).toBe(500);
+	});
+});

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -62,6 +62,7 @@ export interface CoordinatorSyncConfig {
 	syncRetentionMaxOpsPerPass: number;
 	syncProjectsInclude: string[];
 	syncProjectsExclude: string[];
+	syncOpsLimit: number;
 	syncCoordinatorUrl: string;
 	syncCoordinatorGroup: string;
 	syncCoordinatorGroups: string[];
@@ -120,6 +121,7 @@ export function readCoordinatorSyncConfig(config?: ConfigRecord): CoordinatorSyn
 		syncRetentionMaxOpsPerPass: Math.max(1, parseIntOr(raw.sync_retention_max_ops_per_pass, 5000)),
 		syncProjectsInclude: parseStringList(raw.sync_projects_include),
 		syncProjectsExclude: parseStringList(raw.sync_projects_exclude),
+		syncOpsLimit: Math.max(1, Math.min(1000, parseIntOr(raw.sync_ops_limit, 500))),
 		syncCoordinatorUrl: clean(raw.sync_coordinator_url),
 		syncCoordinatorGroup,
 		syncCoordinatorGroups:

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -228,6 +228,7 @@ export const CODEMEM_CONFIG_ENV_OVERRIDES: Record<string, string> = {
 	sync_retention_max_ops_per_pass: "CODEMEM_SYNC_RETENTION_MAX_OPS_PER_PASS",
 	sync_projects_include: "CODEMEM_SYNC_PROJECTS_INCLUDE",
 	sync_projects_exclude: "CODEMEM_SYNC_PROJECTS_EXCLUDE",
+	sync_ops_limit: "CODEMEM_SYNC_OPS_LIMIT",
 	raw_events_sweeper_interval_s: "CODEMEM_RAW_EVENTS_SWEEPER_INTERVAL_S",
 };
 

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -126,6 +126,27 @@ describe("syncDaemonTick", () => {
 		expect(results[0].ok).toBe(true);
 		expect(runSyncPass).toHaveBeenCalledTimes(1);
 	});
+
+	it("threads syncOpsLimit from coordinator config into runSyncPass", async () => {
+		const { runSyncPass } = await import("./sync-pass.js");
+		const { readCoordinatorSyncConfig } = await import("./coordinator-runtime.js");
+		vi.mocked(readCoordinatorSyncConfig).mockReturnValue({
+			syncOpsLimit: 750,
+		} as unknown as ReturnType<typeof readCoordinatorSyncConfig>);
+
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "fp1", now);
+
+		await syncDaemonTick(db, "/tmp/keys");
+
+		expect(runSyncPass).toHaveBeenCalledWith(
+			db,
+			"peer-1",
+			expect.objectContaining({ limit: 750, keysDir: "/tmp/keys" }),
+		);
+	});
 });
 
 describe("refreshCoordinatorPresenceForDaemon", () => {

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -14,6 +14,7 @@ import {
 	readCoordinatorSyncConfig,
 	registerCoordinatorPresence,
 } from "./coordinator-runtime.js";
+
 import type { Database } from "./db.js";
 import { connect as connectDb, resolveDbPath } from "./db.js";
 import * as schema from "./schema.js";
@@ -158,6 +159,8 @@ export async function syncDaemonTick(
 		return [];
 	}
 
+	const opsLimit = readCoordinatorSyncConfig().syncOpsLimit;
+
 	syncPassPreflight(db);
 
 	const results: SyncTickResult[] = [];
@@ -178,7 +181,7 @@ export async function syncDaemonTick(
 			continue;
 		}
 
-		const result = await runSyncPass(db, peerDeviceId, { keysDir });
+		const result = await runSyncPass(db, peerDeviceId, { keysDir, limit: opsLimit });
 		results.push({
 			ok: result.ok,
 			error: result.error,

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -38,8 +38,14 @@ import { bestEffortMaintainVectorsForSyncFallback } from "./vectors.js";
 /** Default max body size for sync POST requests (1 MiB). */
 const MAX_SYNC_BODY_BYTES = 1_048_576;
 
-/** Default op fetch/push limit per round. */
-const DEFAULT_LIMIT = 200;
+/**
+ * Default op fetch/push limit per round.
+ *
+ * The server caps this at 1000 per request (see viewer-server /v1/ops).
+ * Callers can override via SyncPassOptions.limit; the sync daemon resolves
+ * it from the sync_ops_limit config key / CODEMEM_SYNC_OPS_LIMIT env var.
+ */
+const DEFAULT_LIMIT = 500;
 
 /** Elevated page size for initial bootstrap of never-synced peers. */
 const BOOTSTRAP_PAGE_SIZE = 2000;


### PR DESCRIPTION
## Description

Raise the per-tick incremental sync op fetch/push limit from 200 to 500 and expose it as a configurable knob (`sync_ops_limit` / `CODEMEM_SYNC_OPS_LIMIT`), clamped to the server cap of 1000. The daemon reads the value from `CoordinatorSyncConfig` and threads it through `SyncPassOptions.limit` to `runSyncPass`.

Fast bootstrap for never-synced peers already uses `BOOTSTRAP_PAGE_SIZE = 2000`; this is the remaining half of codemem-lxt4 — the incremental 200/interval drag for peers with very large backlogs (23k+ memories).

Closes codemem-lxt4.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, affected tests)
- [x] Added/updated tests (new \`coordinator-runtime.test.ts\` plus a \`syncDaemonTick\` pass-through test)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (config reader + daemon comments)
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)