### PR TITLE
test(core): extend pack eval fixtures and usefulness suite

### DIFF
--- a/packages/core/src/pack-eval-fixtures.ts
+++ b/packages/core/src/pack-eval-fixtures.ts
@@ -15,6 +15,8 @@ export type PackEvalCorpus = {
 		viewerHealthFeatureId: number;
 		workingSetPrimaryId: number;
 		workingSetDistractorId: number;
+		workingSetSharedFileStrongId: number;
+		workingSetSharedFileNoiseId: number;
 	};
 };
 
@@ -125,6 +127,27 @@ export function createPackEvalCorpus(store: MemoryStore): PackEvalCorpus {
 		undefined,
 		{ files_modified: ["packages/ui/src/tabs/feed.ts"] },
 	);
+	// Two memories touching the SAME file so retrieval must pick between them on
+	// signal rather than file-overlap alone. Kept on a distinct file
+	// (settings.ts) so they don't perturb the health.ts-focused tests above.
+	const workingSetSharedFileStrongId = store.remember(
+		currentSessionId,
+		"decision",
+		"Settings tab freshness rule",
+		"Decision to cap settings tab freshness diagnostics at 24h and surface stale peer counts inline",
+		0.92,
+		undefined,
+		{ files_modified: ["packages/ui/src/tabs/settings.ts"] },
+	);
+	const workingSetSharedFileNoiseId = store.remember(
+		olderSessionId,
+		"exploration",
+		"Settings tab drive-by tidy",
+		"Minor comment fix in the settings tab file, unrelated to any current work",
+		0.3,
+		undefined,
+		{ files_modified: ["packages/ui/src/tabs/settings.ts"] },
+	);
 
 	return {
 		currentSessionId,
@@ -140,6 +163,8 @@ export function createPackEvalCorpus(store: MemoryStore): PackEvalCorpus {
 			viewerHealthFeatureId,
 			workingSetPrimaryId,
 			workingSetDistractorId,
+			workingSetSharedFileStrongId,
+			workingSetSharedFileNoiseId,
 		},
 	};
 }

--- a/packages/core/src/pack.eval.test.ts
+++ b/packages/core/src/pack.eval.test.ts
@@ -95,6 +95,24 @@ describe("buildMemoryPack usefulness evals", () => {
 		expect(pack.pack_text.toLowerCase()).toContain("summary");
 	});
 
+	it("picks the stronger memory when multiple candidates share the same working-set file", () => {
+		const corpus = createPackEvalCorpus(store);
+
+		const pack = buildMemoryPack(store, "settings tab freshness decision", 10, null, {
+			working_set_paths: ["packages/ui/src/tabs/settings.ts"],
+		});
+
+		// Both fixture memories touch settings.ts; the strong durable decision
+		// should outrank the low-confidence drive-by exploration so file overlap
+		// alone cannot rescue noise.
+		const strongPos = pack.item_ids.indexOf(corpus.ids.workingSetSharedFileStrongId);
+		const noisePos = pack.item_ids.indexOf(corpus.ids.workingSetSharedFileNoiseId);
+		expect(strongPos).toBeGreaterThanOrEqual(0);
+		if (noisePos >= 0) {
+			expect(strongPos).toBeLessThan(noisePos);
+		}
+	});
+
 	it("boosts working-set overlaps ahead of distractors when semantic candidates tie", () => {
 		const corpus = createPackEvalCorpus(store);
 		const semanticResults: MemoryResult[] = [

--- a/packages/core/src/pack.eval.test.ts
+++ b/packages/core/src/pack.eval.test.ts
@@ -162,4 +162,38 @@ describe("buildMemoryPack usefulness evals", () => {
 			pack.item_ids.indexOf(corpus.ids.workingSetDistractorId),
 		);
 	});
+
+	it("never ranks low-confidence noise at position 1 across varied query phrasings", () => {
+		const corpus = createPackEvalCorpus(store);
+		const queries = [
+			"what did we decide about oauth",
+			"continue the viewer health work",
+			"summary of oauth",
+			"memory retrieval issues",
+			"sessionization summary emission",
+			"what should we do next about auth",
+		];
+
+		for (const query of queries) {
+			const pack = buildMemoryPack(store, query, 10);
+			expect(pack.item_ids[0], `noise ranked top-1 for query "${query}"`).not.toBe(
+				corpus.ids.workingSetSharedFileNoiseId,
+			);
+		}
+	});
+
+	it("combines task-mode ranking with working-set overlap", () => {
+		const corpus = createPackEvalCorpus(store);
+
+		const pack = buildMemoryPack(store, "what should we do next about auth", 10, null, {
+			working_set_paths: ["packages/ui/src/tabs/health.ts"],
+		});
+
+		// Task mode: the auth decision must still be top-1.
+		expect(pack.metrics.mode).toBe("task");
+		expect(pack.item_ids[0]).toBe(corpus.ids.authTaskDecisionId);
+		// Working-set overlap is a tiered signal — the health-tab memory should
+		// appear somewhere in the top N rather than trailing pure distractors.
+		expect(pack.item_ids.slice(0, 5)).toContain(corpus.ids.workingSetPrimaryId);
+	});
 });


### PR DESCRIPTION
## Description

Two related beads bundled into one PR because both commits extend \`packages/core/src/pack.eval.test.ts\` and \`pack-eval-fixtures.ts\`:

**codemem-5pdw** — extend fixture corpus: the existing corpus only covered distinct-file working-set scenarios (\`health.ts\` vs \`feed.ts\`). Adds two memories touching \`packages/ui/src/tabs/settings.ts\` — a high-confidence decision in the current session and a low-confidence drive-by exploration in the older session — so usefulness evals can verify that file overlap alone does not rescue low-signal memories. Plus an eval assertion showing the strong durable memory outranks the noise memory.

**codemem-5pbv** — extend usefulness eval suite: existing tests already cover recall / task / continuation / working-set. Adds two more tiered regression guards:
- Low-confidence noise is never ranked top-1 across recall / task / default / continuation query phrasings.
- Task-mode ranking and working-set overlap combine: the auth decision stays top-1 while the health-tab working-set memory still lands in the top 5.

Closes codemem-5pdw and codemem-5pbv.

## Type of Change

- [x] 🧪 Testing (test-only changes)

## Testing

- [x] \`pnpm exec vitest run packages/core/src/pack.eval.test.ts\` — 10 tests pass
- [x] \`pnpm exec vitest run packages/core/src/pack.test.ts\` — 67 tests pass (no regression from fixture expansion)
- [x] \`pnpm run tsc\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)