### PR TITLE
feed: improve scanability and empty states

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1078,9 +1078,26 @@
         overflow-wrap: anywhere;
         word-break: break-word;
       }
+      .feed-card-subtitle {
+        width: 100%;
+        color: var(--text-tertiary);
+      }
       .feed-meta {
         color: var(--text-tertiary);
         font-size: 12px;
+      }
+      .feed-empty-state {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: var(--sp-3);
+        border: 1px dashed var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface-0);
+        color: var(--text-secondary);
+      }
+      .feed-empty-state strong {
+        color: var(--text-primary);
       }
 
       .feed-provenance {

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -789,6 +789,9 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 		currentVisibility === "shared"
 			? "This memory can sync to peers allowed by your project filters."
 			: "This memory stays local unless the peer is assigned to your local actor.";
+	const secondaryMeta = [project ? `Project ${project}` : "No project", relative]
+		.filter(Boolean)
+		.join(" · ");
 
 	const canClamp = Boolean(observationData) && shouldClampBody(activeMode, observationData);
 	const bodyClassName = [
@@ -887,6 +890,7 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 					className: "feed-title title",
 					dangerouslySetInnerHTML: { __html: highlightText(displayTitle, state.feedQuery) },
 				}),
+				h("div", { className: "feed-card-subtitle small" }, secondaryMeta),
 			),
 			h(
 				"div",
@@ -927,7 +931,7 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 		h(
 			"div",
 			{ className: "feed-meta" },
-			`${project ? `Project: ${project}` : "Project: n/a"}${tagContent}${fileContent}`,
+			`${tagContent}${fileContent}` || "No tags or files attached.",
 		),
 		bodyContent,
 		h(
@@ -1007,10 +1011,25 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 
 function FeedList({ items, loadingText }: { items: FeedItem[]; loadingText?: string }) {
 	if (loadingText) {
-		return h("div", { className: "small" }, loadingText);
+		return h("div", { className: "small feed-empty-state" }, loadingText);
 	}
 	if (!items.length) {
-		return h("div", { className: "small" }, "No memories yet.");
+		const hasFilters =
+			Boolean(state.feedQuery.trim()) ||
+			state.feedTypeFilter !== "all" ||
+			state.feedScopeFilter !== "all";
+		return h(
+			"div",
+			{ className: "small feed-empty-state" },
+			h("strong", null, hasFilters ? "No memories match the current filters." : "No memories yet."),
+			h(
+				"div",
+				null,
+				hasFilters
+					? "Try clearing filters, changing the scope, or using a broader search."
+					: "Memories and session summaries will appear here once codemem has something worth keeping.",
+			),
+		);
 	}
 	return h(
 		Fragment,


### PR DESCRIPTION
## Description
Improves Feed scanability by separating the title from secondary project/time metadata, reducing duplicate meta noise, and giving loading/empty states a clearer visual treatment. This makes cards easier to skim and zero states less abrupt.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm exec biome check ...`, targeted vitest runs)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
