### PR TITLE
feed: simplify provenance and visibility language

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -788,8 +788,19 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 	const visibilityNote =
 		currentVisibility === "shared"
 			? "This memory can sync to peers allowed by your project filters."
-			: "This memory stays local unless the peer is assigned to your local actor.";
+			: "This memory stays on this device unless a matching local assignment allows it to sync.";
 	const secondaryMeta = [project ? `Project ${project}` : "No project", relative]
+		.filter(Boolean)
+		.join(" · ");
+	const provenanceDetails = [
+		workspaceKind && workspaceKind !== visibility ? `Workspace ${workspaceKind}` : "",
+		originSource ? `From ${originSource}` : "",
+		originDeviceId && actor !== "You" ? `Device ${originDeviceId}` : "",
+		trustState && trustState !== "trusted" ? trustStateLabel(trustState) : "",
+	]
+		.filter(Boolean)
+		.join(" · ");
+	const metaText = [`${tagContent}${fileContent}`.trim(), provenanceDetails]
 		.filter(Boolean)
 		.join(" · ");
 
@@ -917,21 +928,11 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 			{ className: "feed-provenance" },
 			h(ProvenanceChip, { label: actor, variant: actor === "You" ? "mine" : "author" }),
 			h(ProvenanceChip, { label: visibility || "private", variant: visibility || "private" }),
-			workspaceKind && workspaceKind !== visibility
-				? h(ProvenanceChip, { label: workspaceKind, variant: "workspace" })
-				: null,
-			originSource ? h(ProvenanceChip, { label: originSource, variant: "source" }) : null,
-			originDeviceId && actor !== "You"
-				? h(ProvenanceChip, { label: originDeviceId, variant: "device" })
-				: null,
-			trustState && trustState !== "trusted"
-				? h(ProvenanceChip, { label: trustStateLabel(trustState), variant: "trust" })
-				: null,
 		),
 		h(
 			"div",
 			{ className: "feed-meta" },
-			`${tagContent}${fileContent}` || "No tags or files attached.",
+			metaText || "No tags, files, or provenance details attached.",
 		),
 		bodyContent,
 		h(


### PR DESCRIPTION
## Description
Simplifies Feed provenance and visibility language by keeping the chip row focused on the primary identity/visibility signals and moving secondary provenance detail into quieter metadata text. This reduces chip noise without losing context.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm exec biome check ...`, targeted vitest runs)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
