### PR TITLE
fix(core): supersede prior observer session summaries per session

### DIFF
--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -1311,3 +1311,167 @@ describe("cleanOrphanSessions", () => {
 		expect(cleaned).toBe(0);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// supersedePriorObserverSummaries
+// ---------------------------------------------------------------------------
+
+describe("supersedePriorObserverSummaries", () => {
+	let tmpDir: string;
+	let store: MemoryStore;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-supersede-test-"));
+		const dbPath = join(tmpDir, "test.sqlite");
+		const setupDb = connect(dbPath);
+		initTestSchema(setupDb);
+		setupDb.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	async function loadHelpers() {
+		const { supersedePriorObserverSummaries } = await import("./ingest-pipeline.js");
+		const { drizzle } = await import("drizzle-orm/better-sqlite3");
+		const schema = await import("./schema.js");
+		return {
+			supersede: supersedePriorObserverSummaries,
+			d: drizzle(store.db, { schema }),
+		};
+	}
+
+	function insertSession(): number {
+		const result = store.db
+			.prepare("INSERT INTO sessions (started_at, cwd) VALUES (?, ?)")
+			.run(new Date().toISOString(), "/tmp") as { lastInsertRowid: number };
+		return result.lastInsertRowid;
+	}
+
+	it("returns an empty list when no prior observer summaries exist", async () => {
+		const { supersede, d } = await loadHelpers();
+		const sessionId = insertSession();
+		const supersededIds = supersede(store, d, sessionId);
+		expect(supersededIds).toEqual([]);
+	});
+
+	it("soft-deletes prior active observer summaries for the session", async () => {
+		const { supersede, d } = await loadHelpers();
+		const sessionId = insertSession();
+
+		const oldA = store.remember(sessionId, "session_summary", "flush A", "body A", 0.3, undefined, {
+			source: "observer_summary",
+		});
+		const oldB = store.remember(sessionId, "session_summary", "flush B", "body B", 0.3, undefined, {
+			source: "observer_summary",
+		});
+
+		const supersededIds = supersede(store, d, sessionId);
+		expect(supersededIds.sort()).toEqual([oldA, oldB].sort());
+
+		const rows = store.db
+			.prepare(
+				"SELECT id, active, metadata_json FROM memory_items WHERE session_id = ? AND kind = 'session_summary' ORDER BY id ASC",
+			)
+			.all(sessionId) as Array<{ id: number; active: number; metadata_json: string }>;
+		expect(rows).toHaveLength(2);
+		expect(rows.every((r) => r.active === 0)).toBe(true);
+		for (const row of rows) {
+			const meta = JSON.parse(row.metadata_json ?? "{}");
+			expect(typeof meta.superseded_at).toBe("string");
+		}
+	});
+
+	it("does not touch summaries from other sources or other sessions", async () => {
+		const { supersede, d } = await loadHelpers();
+		const sessionId = insertSession();
+		const otherSessionId = insertSession();
+
+		const legacyId = store.remember(
+			sessionId,
+			"session_summary",
+			"legacy summary",
+			"legacy body",
+			0.3,
+			undefined,
+			{ source: "legacy_import" },
+		);
+		const otherSessionSummaryId = store.remember(
+			otherSessionId,
+			"session_summary",
+			"other session",
+			"other body",
+			0.3,
+			undefined,
+			{ source: "observer_summary" },
+		);
+
+		const supersededIds = supersede(store, d, sessionId);
+		expect(supersededIds).toEqual([]);
+
+		const legacyActive = store.db
+			.prepare("SELECT active FROM memory_items WHERE id = ?")
+			.get(legacyId) as { active: number };
+		const otherActive = store.db
+			.prepare("SELECT active FROM memory_items WHERE id = ?")
+			.get(otherSessionSummaryId) as { active: number };
+		expect(legacyActive.active).toBe(1);
+		expect(otherActive.active).toBe(1);
+	});
+
+	it("keeps the freshest content when a later flush repeats an earlier title", async () => {
+		// Reproduces the bug path the reviewer flagged: flush A, flush B, flush A
+		// again. If supersede ran after store.remember, the A-title dedupe would
+		// return the oldest A row and we would wipe out B, regressing to stale
+		// content. Running supersede first ensures the dedupe query sees no
+		// active matches so store.remember always inserts fresh.
+		const { supersede, d } = await loadHelpers();
+		const sessionId = insertSession();
+
+		// Flush 1
+		supersede(store, d, sessionId);
+		const rowA1 = store.remember(
+			sessionId,
+			"session_summary",
+			"flush A",
+			"body A1",
+			0.3,
+			undefined,
+			{ source: "observer_summary" },
+		);
+
+		// Flush 2 (different title)
+		supersede(store, d, sessionId);
+		const rowB = store.remember(sessionId, "session_summary", "flush B", "body B", 0.3, undefined, {
+			source: "observer_summary",
+		});
+
+		// Flush 3 (repeats title A with fresher body)
+		supersede(store, d, sessionId);
+		const rowA2 = store.remember(
+			sessionId,
+			"session_summary",
+			"flush A",
+			"body A2-fresh",
+			0.3,
+			undefined,
+			{ source: "observer_summary" },
+		);
+
+		// All three rows must be distinct inserts; the dedupe should not have
+		// reused rowA1's id because it was soft-deleted before flush 3.
+		expect(new Set([rowA1, rowB, rowA2]).size).toBe(3);
+
+		const activeRows = store.db
+			.prepare(
+				"SELECT id, body_text FROM memory_items WHERE session_id = ? AND kind = 'session_summary' AND active = 1",
+			)
+			.all(sessionId) as Array<{ id: number; body_text: string }>;
+		expect(activeRows).toHaveLength(1);
+		expect(activeRows[0]?.id).toBe(rowA2);
+		expect(activeRows[0]?.body_text).toBe("body A2-fresh");
+	});
+});

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -19,10 +19,10 @@
  * 12. End session
  */
 
-import { and, isNull, lt } from "drizzle-orm";
+import { and, eq, isNull, lt } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { normalizeProjectLabel } from "./claude-hooks.js";
-import { toJson } from "./db.js";
+import { fromJson, toJson } from "./db.js";
 import {
 	buildTieredObserverConfig,
 	decideExtractionReplayTier,
@@ -60,6 +60,7 @@ import { resolveProject } from "./project.js";
 import * as schema from "./schema.js";
 import { classifySessionForInjection, shouldSuppressSummaryOnlyOutput } from "./session-policy.js";
 import type { MemoryStore } from "./store.js";
+import { recordReplicationOp } from "./sync-replication.js";
 import { deriveTags } from "./tags.js";
 import { storeVectors } from "./vectors.js";
 
@@ -93,6 +94,115 @@ function normalizePath(path: string, repoRoot: string | null): string {
 
 function normalizePaths(paths: string[], repoRoot: string | null): string[] {
 	return paths.map((p) => normalizePath(p, repoRoot)).filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Session-summary emission guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Soft-delete prior active `session_summary` memories written by the observer
+ * for a session so each session holds at most one live observer summary.
+ *
+ * The observer pipeline writes a summary per flush batch. Long-running
+ * "durable" sessions therefore accumulate hundreds of per-flush summaries that
+ * crowd out typed observations and poison retrieval. This helper enforces the
+ * "one active observer summary per session" invariant by superseding earlier
+ * active rows whose `metadata.source === "observer_summary"`, leaving them
+ * soft-deleted for audit (with `superseded_at` metadata) and recording
+ * replication ops so peers drop the stale rows.
+ *
+ * Must be called *before* the new summary is persisted. If it ran afterward,
+ * `store.remember`'s title dedupe could return an existing stale summary's id
+ * rather than inserting a new row, and this helper would then treat that
+ * stale id as the replacement and wipe out newer summaries in the session.
+ * Running first ensures the dedupe query sees no prior active matches.
+ *
+ * Only `observer_summary` rows are touched; manually-created or
+ * legacy-imported session summaries are left alone.
+ *
+ * Returns the ids of the superseded rows so callers can backfill
+ * `superseded_by` once the new replacement id is known.
+ */
+export function supersedePriorObserverSummaries(
+	store: MemoryStore,
+	d: ReturnType<typeof drizzle>,
+	sessionId: number,
+): number[] {
+	const rows = d
+		.select({
+			id: schema.memoryItems.id,
+			rev: schema.memoryItems.rev,
+			metadata_json: schema.memoryItems.metadata_json,
+		})
+		.from(schema.memoryItems)
+		.where(
+			and(
+				eq(schema.memoryItems.session_id, sessionId),
+				eq(schema.memoryItems.kind, "session_summary"),
+				eq(schema.memoryItems.active, 1),
+			),
+		)
+		.all();
+
+	if (rows.length === 0) return [];
+
+	const now = new Date().toISOString();
+	const superseded: number[] = [];
+	for (const row of rows) {
+		const meta = fromJson(row.metadata_json);
+		if (meta.source !== "observer_summary") continue;
+		meta.superseded_at = now;
+		meta.clock_device_id = store.deviceId;
+		d.update(schema.memoryItems)
+			.set({
+				active: 0,
+				deleted_at: now,
+				updated_at: now,
+				metadata_json: toJson(meta),
+				rev: (row.rev ?? 0) + 1,
+			})
+			.where(eq(schema.memoryItems.id, row.id))
+			.run();
+		try {
+			recordReplicationOp(store.db, {
+				memoryId: row.id,
+				opType: "delete",
+				deviceId: store.deviceId,
+			});
+		} catch {
+			// Replication-op recording is best-effort; continue with supersede.
+		}
+		superseded.push(row.id);
+	}
+	return superseded;
+}
+
+/**
+ * Annotate rows superseded by `supersedePriorObserverSummaries` with the id of
+ * the replacement summary. Local audit only — no rev bump or replication op,
+ * since peers already learned of the soft-delete from the primary supersede.
+ */
+function markSupersededBy(
+	d: ReturnType<typeof drizzle>,
+	supersededIds: number[],
+	replacementId: number,
+): void {
+	if (supersededIds.length === 0) return;
+	for (const id of supersededIds) {
+		const row = d
+			.select({ metadata_json: schema.memoryItems.metadata_json })
+			.from(schema.memoryItems)
+			.where(eq(schema.memoryItems.id, id))
+			.get();
+		if (!row) continue;
+		const meta = fromJson(row.metadata_json);
+		meta.superseded_by = replacementId;
+		d.update(schema.memoryItems)
+			.set({ metadata_json: toJson(meta) })
+			.where(eq(schema.memoryItems.id, id))
+			.run();
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -591,6 +701,13 @@ export async function ingest(
 					filesRead: summary.filesRead,
 					filesModified: summary.filesModified,
 				});
+				// Enforce one live observer summary per session: supersede any
+				// prior active observer_summary rows for this session BEFORE the
+				// new row is persisted, otherwise `store.remember`'s title dedupe
+				// could return a stale prior summary's id instead of inserting.
+				// Long-running durable sessions would otherwise accumulate one
+				// summary per flush batch.
+				const supersededIds = supersedePriorObserverSummaries(store, d, sessionId);
 				const memoryId = store.remember(
 					sessionId,
 					"session_summary",
@@ -619,6 +736,7 @@ export async function ingest(
 						flush_batch: flushBatchMetadata,
 					},
 				);
+				markSupersededBy(d, supersededIds, memoryId);
 				vectorWriteInputs.push({ memoryId, title: summaryTitle, bodyText: body });
 			}
 


### PR DESCRIPTION
## Description

Post-fix measurement against the local codemem DB showed \`session_summary\` share of recent memories rose from 30% pre-fix to **53% post-fix** (PRs #715–718). Investigating session \`166756\` — a single ~24h codemem dev session — showed **353 \`session_summary\` memories** written across the day with metadata \`source = \"observer_summary\"\`, avg one every ~4 minutes, all classified as \`durable\`.

**Root cause**: \`ingest-pipeline.ts\` calls \`store.remember(\"session_summary\", ...)\` on every flush batch whose session passes \`shouldSuppressSummaryOnlyOutput\`. That guard only suppresses \`trivial_turn\` / \`micro_low_value\` sessions, so every flush of a durable session writes a brand-new summary row. There's no \"update existing summary for this session\" path — each flush appends.

## Fix

Before persisting a new observer session_summary, soft-delete any prior **active** \`session_summary\` rows for the same session whose \`metadata.source === \"observer_summary\"\`. Keep the superseded rows in place for audit (with \`superseded_at\` / \`superseded_by\` metadata) and emit a replication delete op so peers drop them too. Manually created or legacy-imported summaries are left untouched.

Net effect: the \"one live observer summary per session\" invariant is enforced at the write site. Long-running durable sessions now hold exactly 1 active summary at any point.

## Measurement reference

| Window | Total memories | session_summary | Share |
|---|---|---|---|
| Overall | 14,883 | 4,777 | 32.1% |
| Pre-fix (≤2026-04-11) | 13,631 | 4,113 | 30.2% |
| Post-fix (≥2026-04-12) | 1,252 | 664 | **53.0%** |
| Last 7 days | 1,446 | 749 | 51.8% |

With this fix, every flush beyond the first is a net zero to the active memory set (it supersedes + writes = active-count unchanged). The steady-state share should drop substantially.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] \`pnpm run tsc\` clean
- [x] \`pnpm --filter @codemem/core exec vitest run src/ingest-pipeline.test.ts\` — 62 tests pass (3 new covering no-prior, multiple-prior, and cross-session/cross-source cases)

## Follow-ups

- codemem-garf (per-session summary dedupe maintenance job) becomes a one-shot cleanup of the existing 141 offender sessions rather than an ongoing sweep.
- Re-measure after a few days of real traffic to confirm post-fix-new share drops below 30%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)