### PR TITLE
feat(viewer): stat tiles with tabular numerals and uppercase tracked labels

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -723,7 +723,7 @@
 
       .grid-2 {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         gap: var(--sp-3);
       }
 
@@ -737,12 +737,13 @@
 
       .stat {
         border: 1px solid var(--border);
-        border-radius: var(--radius-md);
-        padding: var(--sp-3);
-        background: var(--surface-2);
+        border-radius: var(--radius-lg);
+        padding: var(--sp-4);
+        background: var(--surface-1);
         display: flex;
         align-items: center;
         gap: var(--sp-3);
+        box-shadow: var(--shadow-sm);
       }
 
       .stat-icon {
@@ -757,20 +758,26 @@
         display: flex;
         flex-direction: column;
         min-width: 0;
+        gap: 4px;
       }
 
       .stat .value {
+        font-family: var(--font-sans);
         font-weight: 600;
-        font-size: 16px;
-        color: var(--accent-cool);
-        line-height: 1.2;
+        font-size: 24px;
+        color: var(--text-primary);
+        line-height: 1.1;
+        letter-spacing: -0.01em;
         font-feature-settings: 'tnum' 1;
       }
 
       .stat .label {
         color: var(--text-tertiary);
-        font-size: 11px;
+        font-size: 12px;
+        font-weight: 500;
         line-height: 1.3;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
       }
 
       .health-primary {


### PR DESCRIPTION
## Description

Lift stat tiles to the hero-metric treatment from the design-handoff §6. Tiles now carry `--surface-1` with `--radius-lg` and a 16px pad, and the value reads first.

- Value: Geist 600 with tnum + `-0.01em` tracking, primary text color instead of accent-cool (later tuned to 20px in the follow-up polish PR)
- Label: 12px uppercase `0.08em` tracked tertiary (matches the eyebrow pattern used site-wide)
- Grid `minmax(200px, 1fr)` so four tiles lock at ~860px but collapse cleanly on narrow viewports
- Soft `--shadow-sm` for slight elevation
- Delta chip top-right deferred to a follow-up bead (API doesn't ship per-stat deltas yet)

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
