### PR TITLE
feat(viewer): feed item top banner, file pills below, terminal empty state

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -964,7 +964,7 @@
       .feed-search {
         min-width: 200px;
         flex: 1;
-        max-width: 400px;
+        max-width: 420px;
         padding: 8px var(--sp-3);
         border-radius: var(--radius-md);
         border: 1px solid var(--border);
@@ -973,7 +973,7 @@
         font-family: var(--font-sans);
         font-size: 13px;
         outline: none;
-        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+        transition: border-color 140ms ease, box-shadow 140ms ease;
       }
       .feed-search::placeholder { color: var(--text-tertiary); }
       .feed-search:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--focus-ring); }
@@ -1006,7 +1006,7 @@
         padding: 3px;
         border-radius: var(--radius-pill);
         border: 1px solid var(--border);
-        background: var(--surface-2);
+        background: color-mix(in srgb, var(--surface-0) 70%, transparent);
       }
 
       .toggle-button {
@@ -1015,16 +1015,21 @@
         color: var(--text-tertiary);
         font-family: var(--font-sans);
         font-size: 12px;
-        padding: 4px 10px;
+        padding: 4px 12px;
         border-radius: var(--radius-pill);
         cursor: pointer;
         display: inline-flex;
         align-items: center;
         gap: 5px;
-        transition: background 0.15s ease, color 0.15s ease;
+        transition: background-color 140ms ease, color 140ms ease, box-shadow 140ms ease;
       }
       .toggle-button:hover { background: var(--toggle-hover-bg); color: var(--text-primary); }
-      .toggle-button.active { background: var(--toggle-active-bg); color: var(--toggle-active-text); font-weight: 600; }
+      .toggle-button.active {
+        background: var(--accent-subtle);
+        color: var(--accent);
+        font-weight: 600;
+        box-shadow: inset 0 0 0 1px var(--accent-strong);
+      }
 
       .feed-list {
         display: flex;
@@ -1033,34 +1038,51 @@
       }
 
       /* ── Feed items ────────────────────────────────────────── */
+      /* Design-handoff clarification (2026-04-19): feed items render with
+         a full-width top banner in the kind's tint, not a 4px left rail.
+         Banner ~28px tall, --accent-subtle bg per kind, 1px accent-strong
+         bottom border; kind chip sits inset left inside the banner. */
 
       .feed-item {
         border: 1px solid var(--border);
-        border-left: 4px solid var(--accent);
-        border-radius: var(--radius-lg);
-        padding: var(--sp-4) var(--sp-5);
+        border-radius: var(--radius-md);
         background: var(--surface-1);
+        overflow: hidden;
         display: flex;
         flex-direction: column;
-        gap: var(--sp-2);
-        transition: transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+        box-shadow: var(--shadow-sm);
+        transition: transform 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
       }
       .feed-item:hover {
         transform: translateY(-1px);
-        box-shadow: var(--shadow-sm);
+        box-shadow: var(--shadow-md);
         border-color: var(--border-hover);
       }
-      .feed-item.new-item { animation: newPulse 420ms ease-out 1; }
 
-      /* Kind border colors */
-      .feed-item.feature { border-left-color: var(--accent); }
-      .feed-item.change { border-left-color: var(--accent-cool); }
-      .feed-item.bugfix { border-left-color: var(--accent-warm); }
-      .feed-item.refactor { border-left-color: #8b5cc6; }
-      .feed-item.discovery { border-left-color: #5e81ac; }
-      .feed-item.decision { border-left-color: #8fadbd; }
-      .feed-item.session_summary { border-left-color: #4696c8; }
-      .feed-item.exploration { border-left-color: var(--text-tertiary); }
+      /* Kind banner — defaults to mint (feature). Per-kind overrides below. */
+      .feed-kind-banner {
+        padding: 7px var(--sp-5);
+        background: var(--accent-subtle);
+        border-bottom: 1px solid var(--accent-strong);
+      }
+      .feed-item.change .feed-kind-banner { background: var(--accent-cool-subtle); border-bottom-color: rgba(134, 169, 255, 0.28); }
+      .feed-item.bugfix .feed-kind-banner { background: var(--accent-warm-subtle); border-bottom-color: rgba(255, 180, 84, 0.28); }
+      .feed-item.refactor .feed-kind-banner { background: var(--accent-violet-subtle); border-bottom-color: rgba(199, 155, 255, 0.28); }
+      .feed-item.discovery .feed-kind-banner { background: rgba(77, 212, 180, 0.12); border-bottom-color: rgba(77, 212, 180, 0.28); }
+      .feed-item.docs .feed-kind-banner { background: rgba(226, 192, 126, 0.12); border-bottom-color: rgba(226, 192, 126, 0.28); }
+      .feed-item.test .feed-kind-banner { background: rgba(158, 167, 183, 0.12); border-bottom-color: rgba(158, 167, 183, 0.28); }
+      /* Core emits 'decision' / 'exploration' / 'session_summary' too — preserve
+         neutral treatments so those items aren't unstyled. */
+      .feed-item.decision .feed-kind-banner { background: rgba(158, 167, 183, 0.12); border-bottom-color: rgba(158, 167, 183, 0.28); }
+      .feed-item.exploration .feed-kind-banner { background: rgba(140, 140, 140, 0.10); border-bottom-color: rgba(140, 140, 140, 0.24); }
+      .feed-item.session_summary .feed-kind-banner { background: rgba(134, 169, 255, 0.10); border-bottom-color: rgba(134, 169, 255, 0.24); }
+
+      .feed-card-body {
+        padding: var(--sp-4) var(--sp-5);
+        display: flex;
+        flex-direction: column;
+        gap: var(--sp-2);
+      }
 
       .feed-card-header {
         display: flex;
@@ -1167,18 +1189,41 @@
         color: var(--text-tertiary);
         font-size: 12px;
       }
+      /* Empty state renders as a terminal-output block — mono surface,
+         blinking mint cursor — to match the codemem "warm local journal"
+         voice and signal "this is a CLI-native tool." */
       .feed-empty-state {
         display: flex;
         flex-direction: column;
         gap: 6px;
-        padding: var(--sp-3);
-        border: 1px dashed var(--border);
-        border-radius: var(--radius-sm);
-        background: var(--surface-0);
+        padding: var(--sp-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-2);
         color: var(--text-secondary);
+        font-family: var(--font-mono);
+        font-size: 13px;
       }
       .feed-empty-state strong {
         color: var(--text-primary);
+        font-weight: 600;
+      }
+      .feed-empty-state::before {
+        content: "$ codemem feed";
+        display: block;
+        color: var(--accent);
+        font-weight: 500;
+        margin-bottom: 4px;
+      }
+      .feed-empty-state::after {
+        content: "_";
+        display: inline-block;
+        color: var(--accent);
+        animation: cursorBlink 1.1s steps(2, end) infinite;
+      }
+      @keyframes cursorBlink {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0; }
       }
 
       .feed-provenance {
@@ -1279,32 +1324,50 @@
       .feed-expand:hover { background: var(--accent-subtle); color: var(--accent); }
 
       .feed-tags { display: flex; flex-wrap: wrap; gap: 6px; }
-      .feed-files { display: flex; flex-wrap: wrap; gap: var(--sp-2); font-size: 10px; color: var(--text-tertiary); opacity: 0.85; }
-      .feed-file { white-space: nowrap; }
-      .feed-age { white-space: nowrap; }
+      /* File paths render as compact pill-tags in their own row — the actual
+         filename is informative and earns its horizontal space. */
+      .feed-files { display: flex; flex-wrap: wrap; gap: 6px; }
+      .feed-file {
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        background: var(--surface-2);
+        border: 1px solid var(--border);
+        font-family: var(--font-mono);
+        font-size: 11px;
+        color: var(--text-tertiary);
+        white-space: nowrap;
+      }
+      .feed-age { white-space: nowrap; font-family: var(--font-mono); font-size: 11px; color: var(--text-tertiary); letter-spacing: 0.02em; }
 
       /* ── Pills & badges ────────────────────────────────────── */
 
-      .kind-pill {
+      /* Kind chip — lives inside .feed-kind-banner. Tint + colored border
+         match the banner per kind so the chip reads as part of the strip. */
+      .kind-chip {
         display: inline-flex;
         align-items: center;
-        padding: 2px 8px;
+        gap: 6px;
+        padding: 2px 10px;
         border-radius: var(--radius-pill);
-        font-size: 11px;
-        font-weight: 500;
-        letter-spacing: 0.2px;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
         white-space: nowrap;
         background: var(--accent-subtle);
         color: var(--accent);
+        border: 1px solid var(--accent-strong);
       }
-      .kind-pill.feature { background: var(--accent-subtle); color: var(--accent); }
-      .kind-pill.change { background: var(--accent-cool-subtle); color: var(--accent-cool); }
-      .kind-pill.bugfix { background: var(--accent-warm-subtle); color: var(--accent-warm); }
-      .kind-pill.refactor { background: rgba(139, 92, 198, 0.12); color: #8b5cc6; }
-      .kind-pill.discovery { background: rgba(94, 129, 172, 0.12); color: #5e81ac; }
-      .kind-pill.decision { background: rgba(143, 173, 189, 0.12); color: #6b8fa3; }
-      .kind-pill.session_summary { background: rgba(70, 150, 200, 0.12); color: #4696c8; }
-      .kind-pill.exploration { background: rgba(140, 140, 140, 0.12); color: var(--text-tertiary); }
+      .kind-chip.change { background: var(--accent-cool-subtle); color: var(--accent-cool); border-color: rgba(134, 169, 255, 0.3); }
+      .kind-chip.bugfix { background: var(--accent-warm-subtle); color: var(--accent-warm); border-color: rgba(255, 180, 84, 0.3); }
+      .kind-chip.refactor { background: var(--accent-violet-subtle); color: var(--accent-violet); border-color: rgba(199, 155, 255, 0.3); }
+      .kind-chip.discovery { background: rgba(77, 212, 180, 0.12); color: #4dd4b4; border-color: rgba(77, 212, 180, 0.3); }
+      .kind-chip.docs { background: rgba(226, 192, 126, 0.12); color: #e2c07e; border-color: rgba(226, 192, 126, 0.3); }
+      .kind-chip.test { background: rgba(158, 167, 183, 0.14); color: #9ea7b7; border-color: rgba(158, 167, 183, 0.3); }
+      .kind-chip.decision { background: rgba(158, 167, 183, 0.14); color: #9ea7b7; border-color: rgba(158, 167, 183, 0.3); }
+      .kind-chip.exploration { background: rgba(140, 140, 140, 0.12); color: var(--text-tertiary); border-color: rgba(140, 140, 140, 0.28); }
+      .kind-chip.session_summary { background: rgba(134, 169, 255, 0.10); color: var(--accent-cool); border-color: rgba(134, 169, 255, 0.24); }
 
       .tag-chip {
         display: inline-flex;
@@ -2356,11 +2419,7 @@
         50% { transform: scale(1.3); opacity: 0.5; }
       }
 
-      @keyframes newPulse {
-        0% { box-shadow: 0 0 0 rgba(26, 107, 86, 0); }
-        40% { box-shadow: 0 0 0 3px var(--accent-subtle); }
-        100% { box-shadow: 0 0 0 rgba(26, 107, 86, 0); }
-      }
+      /* newPulse deferred to codemem-gi99 (feed-item mount animation, v2). */
 
       /* ── Responsive ────────────────────────────────────────── */
 

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -51,6 +51,12 @@
         --accent-cool-subtle:   rgba(134, 169, 255, 0.14);
         --accent-violet:        #c79bff;
         --accent-violet-subtle: rgba(199, 155, 255, 0.14);
+        --accent-steel:         #4dd4b4;
+        --accent-steel-subtle:  rgba(77, 212, 180, 0.14);
+        --accent-ochre:         #e2c07e;
+        --accent-ochre-subtle:  rgba(226, 192, 126, 0.14);
+        --accent-neutral:       #9ea7b7;
+        --accent-neutral-subtle: rgba(158, 167, 183, 0.14);
 
         /* Status */
         --status-healthy:   #7ef0c2;
@@ -154,6 +160,12 @@
         --accent-cool-subtle:   rgba(62, 95, 168, 0.10);
         --accent-violet:        #7f52c2;
         --accent-violet-subtle: rgba(127, 82, 194, 0.12);
+        --accent-steel:         #1a8a70;
+        --accent-steel-subtle:  rgba(26, 138, 112, 0.12);
+        --accent-ochre:         #b5832a;
+        --accent-ochre-subtle:  rgba(181, 131, 42, 0.12);
+        --accent-neutral:       #5d6a7c;
+        --accent-neutral-subtle: rgba(93, 106, 124, 0.10);
 
         /* Status */
         --status-healthy:   #0f8a68;
@@ -215,6 +227,12 @@
           --accent-cool-subtle:   rgba(62, 95, 168, 0.10);
           --accent-violet:        #7f52c2;
           --accent-violet-subtle: rgba(127, 82, 194, 0.12);
+          --accent-steel:         #1a8a70;
+          --accent-steel-subtle:  rgba(26, 138, 112, 0.12);
+          --accent-ochre:         #b5832a;
+          --accent-ochre-subtle:  rgba(181, 131, 42, 0.12);
+          --accent-neutral:       #5d6a7c;
+          --accent-neutral-subtle: rgba(93, 106, 124, 0.10);
 
           --status-healthy:   #0f8a68;
           --status-degraded:  #c97a1f;
@@ -1065,17 +1083,17 @@
         background: var(--accent-subtle);
         border-bottom: 1px solid var(--accent-strong);
       }
-      .feed-item.change .feed-kind-banner { background: var(--accent-cool-subtle); border-bottom-color: rgba(134, 169, 255, 0.28); }
-      .feed-item.bugfix .feed-kind-banner { background: var(--accent-warm-subtle); border-bottom-color: rgba(255, 180, 84, 0.28); }
-      .feed-item.refactor .feed-kind-banner { background: var(--accent-violet-subtle); border-bottom-color: rgba(199, 155, 255, 0.28); }
-      .feed-item.discovery .feed-kind-banner { background: rgba(77, 212, 180, 0.12); border-bottom-color: rgba(77, 212, 180, 0.28); }
-      .feed-item.docs .feed-kind-banner { background: rgba(226, 192, 126, 0.12); border-bottom-color: rgba(226, 192, 126, 0.28); }
-      .feed-item.test .feed-kind-banner { background: rgba(158, 167, 183, 0.12); border-bottom-color: rgba(158, 167, 183, 0.28); }
+      .feed-item.change .feed-kind-banner { background: var(--accent-cool-subtle); border-bottom-color: color-mix(in srgb, var(--accent-cool) 30%, transparent); }
+      .feed-item.bugfix .feed-kind-banner { background: var(--accent-warm-subtle); border-bottom-color: color-mix(in srgb, var(--accent-warm) 30%, transparent); }
+      .feed-item.refactor .feed-kind-banner { background: var(--accent-violet-subtle); border-bottom-color: color-mix(in srgb, var(--accent-violet) 30%, transparent); }
+      .feed-item.discovery .feed-kind-banner { background: var(--accent-steel-subtle); border-bottom-color: color-mix(in srgb, var(--accent-steel) 30%, transparent); }
+      .feed-item.docs .feed-kind-banner { background: var(--accent-ochre-subtle); border-bottom-color: color-mix(in srgb, var(--accent-ochre) 30%, transparent); }
+      .feed-item.test .feed-kind-banner { background: var(--accent-neutral-subtle); border-bottom-color: color-mix(in srgb, var(--accent-neutral) 30%, transparent); }
       /* Core emits 'decision' / 'exploration' / 'session_summary' too — preserve
          neutral treatments so those items aren't unstyled. */
-      .feed-item.decision .feed-kind-banner { background: rgba(158, 167, 183, 0.12); border-bottom-color: rgba(158, 167, 183, 0.28); }
-      .feed-item.exploration .feed-kind-banner { background: rgba(140, 140, 140, 0.10); border-bottom-color: rgba(140, 140, 140, 0.24); }
-      .feed-item.session_summary .feed-kind-banner { background: rgba(134, 169, 255, 0.10); border-bottom-color: rgba(134, 169, 255, 0.24); }
+      .feed-item.decision .feed-kind-banner { background: var(--accent-neutral-subtle); border-bottom-color: color-mix(in srgb, var(--accent-neutral) 30%, transparent); }
+      .feed-item.exploration .feed-kind-banner { background: color-mix(in srgb, var(--text-tertiary) 12%, transparent); border-bottom-color: color-mix(in srgb, var(--text-tertiary) 24%, transparent); }
+      .feed-item.session_summary .feed-kind-banner { background: color-mix(in srgb, var(--accent-cool) 10%, transparent); border-bottom-color: color-mix(in srgb, var(--accent-cool) 22%, transparent); }
 
       .feed-card-body {
         padding: var(--sp-4) var(--sp-5);
@@ -1359,15 +1377,15 @@
         color: var(--accent);
         border: 1px solid var(--accent-strong);
       }
-      .kind-chip.change { background: var(--accent-cool-subtle); color: var(--accent-cool); border-color: rgba(134, 169, 255, 0.3); }
-      .kind-chip.bugfix { background: var(--accent-warm-subtle); color: var(--accent-warm); border-color: rgba(255, 180, 84, 0.3); }
-      .kind-chip.refactor { background: var(--accent-violet-subtle); color: var(--accent-violet); border-color: rgba(199, 155, 255, 0.3); }
-      .kind-chip.discovery { background: rgba(77, 212, 180, 0.12); color: #4dd4b4; border-color: rgba(77, 212, 180, 0.3); }
-      .kind-chip.docs { background: rgba(226, 192, 126, 0.12); color: #e2c07e; border-color: rgba(226, 192, 126, 0.3); }
-      .kind-chip.test { background: rgba(158, 167, 183, 0.14); color: #9ea7b7; border-color: rgba(158, 167, 183, 0.3); }
-      .kind-chip.decision { background: rgba(158, 167, 183, 0.14); color: #9ea7b7; border-color: rgba(158, 167, 183, 0.3); }
-      .kind-chip.exploration { background: rgba(140, 140, 140, 0.12); color: var(--text-tertiary); border-color: rgba(140, 140, 140, 0.28); }
-      .kind-chip.session_summary { background: rgba(134, 169, 255, 0.10); color: var(--accent-cool); border-color: rgba(134, 169, 255, 0.24); }
+      .kind-chip.change { background: var(--accent-cool-subtle); color: var(--accent-cool); border-color: color-mix(in srgb, var(--accent-cool) 32%, transparent); }
+      .kind-chip.bugfix { background: var(--accent-warm-subtle); color: var(--accent-warm); border-color: color-mix(in srgb, var(--accent-warm) 32%, transparent); }
+      .kind-chip.refactor { background: var(--accent-violet-subtle); color: var(--accent-violet); border-color: color-mix(in srgb, var(--accent-violet) 32%, transparent); }
+      .kind-chip.discovery { background: var(--accent-steel-subtle); color: var(--accent-steel); border-color: color-mix(in srgb, var(--accent-steel) 32%, transparent); }
+      .kind-chip.docs { background: var(--accent-ochre-subtle); color: var(--accent-ochre); border-color: color-mix(in srgb, var(--accent-ochre) 32%, transparent); }
+      .kind-chip.test { background: var(--accent-neutral-subtle); color: var(--accent-neutral); border-color: color-mix(in srgb, var(--accent-neutral) 32%, transparent); }
+      .kind-chip.decision { background: var(--accent-neutral-subtle); color: var(--accent-neutral); border-color: color-mix(in srgb, var(--accent-neutral) 32%, transparent); }
+      .kind-chip.exploration { background: color-mix(in srgb, var(--text-tertiary) 12%, transparent); color: var(--text-tertiary); border-color: color-mix(in srgb, var(--text-tertiary) 28%, transparent); }
+      .kind-chip.session_summary { background: color-mix(in srgb, var(--accent-cool) 10%, transparent); color: var(--accent-cool); border-color: color-mix(in srgb, var(--accent-cool) 24%, transparent); }
 
       .tag-chip {
         display: inline-flex;

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -880,132 +880,136 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 		}
 	}
 
+	const kindChipLabel = displayKindValue.replace(/_/g, " ");
+	const filesRow = files.length
+		? h(
+				"div",
+				{ className: "feed-files" },
+				files.map((file, index) =>
+					h("span", { className: "feed-file", key: `${String(file)}-${index}` }, String(file)),
+				),
+			)
+		: null;
+	void isNew;
+
 	return h(
-		"div",
+		"article",
 		{
-			className: `feed-item ${displayKindValue}${isNew ? " new-item" : ""}`.trim(),
+			className: `feed-item ${displayKindValue}`.trim(),
 			"data-key": rowKey,
 		},
 		h(
 			"div",
-			{ className: "feed-card-header" },
+			{ className: "feed-kind-banner" },
+			h("span", { className: `kind-chip ${displayKindValue}`.trim() }, kindChipLabel),
+		),
+		h(
+			"div",
+			{ className: "feed-card-body" },
 			h(
 				"div",
-				{ className: "feed-header" },
+				{ className: "feed-card-header" },
 				h(
-					"span",
-					{ className: `kind-pill ${displayKindValue}`.trim() },
-					displayKindValue.replace(/_/g, " "),
+					"div",
+					{ className: "feed-header" },
+					h("div", {
+						className: "feed-title title",
+						dangerouslySetInnerHTML: { __html: highlightText(displayTitle, state.feedQuery) },
+					}),
+					h("div", { className: "feed-card-subtitle small" }, secondaryMeta),
 				),
-				h("div", {
-					className: "feed-title title",
-					dangerouslySetInnerHTML: { __html: highlightText(displayTitle, state.feedQuery) },
-				}),
-				h("div", { className: "feed-card-subtitle small" }, secondaryMeta),
+				h(
+					"div",
+					{ className: "feed-actions" },
+					observationData
+						? h(FeedViewToggle, {
+								active: activeMode,
+								modes,
+								onSelect: (mode) => setActiveMode(mode),
+							})
+						: null,
+					h("div", { className: "small feed-age", title: formatDate(createdAtRaw) }, relative),
+					Boolean(item.owned_by_self) && memoryId > 0
+						? h(FeedItemMenu, {
+								disabled: deletingMemory,
+								onForget: () => void forgetMemory(),
+								title: String(displayTitle || "memory"),
+							})
+						: null,
+				),
 			),
 			h(
 				"div",
-				{ className: "feed-actions" },
-				observationData
-					? h(FeedViewToggle, {
-							active: activeMode,
-							modes,
-							onSelect: (mode) => setActiveMode(mode),
-						})
-					: null,
-				h("div", { className: "small feed-age", title: formatDate(createdAtRaw) }, relative),
-				Boolean(item.owned_by_self) && memoryId > 0
-					? h(FeedItemMenu, {
-							disabled: deletingMemory,
-							onForget: () => void forgetMemory(),
-							title: String(displayTitle || "memory"),
-						})
-					: null,
+				{ className: "feed-provenance" },
+				h(ProvenanceChip, { label: actor, variant: actor === "You" ? "mine" : "author" }),
+				h(ProvenanceChip, { label: visibility || "private", variant: visibility || "private" }),
 			),
-		),
-		h(
-			"div",
-			{ className: "feed-provenance" },
-			h(ProvenanceChip, { label: actor, variant: actor === "You" ? "mine" : "author" }),
-			h(ProvenanceChip, { label: visibility || "private", variant: visibility || "private" }),
-		),
-		h(
-			"div",
-			{ className: "feed-meta" },
-			metaText || "No tags, files, or provenance details attached.",
-		),
-		bodyContent,
-		h(
-			"div",
-			{ className: "feed-footer" },
 			h(
 				"div",
-				{ className: "feed-footer-left" },
-				files.length
-					? h(
-							"div",
-							{ className: "feed-files" },
-							files.map((file, index) =>
+				{ className: "feed-meta" },
+				metaText || "No tags, files, or provenance details attached.",
+			),
+			bodyContent,
+			h(
+				"div",
+				{ className: "feed-footer" },
+				h(
+					"div",
+					{ className: "feed-footer-left" },
+					tags.length
+						? h(
+								"div",
+								{ className: "feed-tags" },
+								tags.map((tag, index) => h(TagChip, { key: `${String(tag)}-${index}`, tag })),
+							)
+						: null,
+					Boolean(item.owned_by_self) && memoryId > 0
+						? h(
+								"div",
+								{ className: "feed-visibility-controls" },
 								h(
-									"span",
-									{ className: "feed-file", key: `${String(file)}-${index}` },
-									String(file),
-								),
-							),
-						)
-					: null,
-				tags.length
-					? h(
-							"div",
-							{ className: "feed-tags" },
-							tags.map((tag, index) => h(TagChip, { key: `${String(tag)}-${index}`, tag })),
-						)
-					: null,
-				Boolean(item.owned_by_self) && memoryId > 0
-					? h(
-							"div",
-							{ className: "feed-visibility-controls" },
-							h(
-								"select",
-								{
-									"aria-label": `Visibility for ${String(item.title || "memory")}`,
-									className: "feed-visibility-select",
-									disabled: savingVisibility,
-									onChange: (event) => {
-										const nextValue =
-											String((event.currentTarget as HTMLSelectElement).value) === "shared"
-												? "shared"
-												: "private";
-										void saveVisibility(nextValue);
+									"select",
+									{
+										"aria-label": `Visibility for ${String(item.title || "memory")}`,
+										className: "feed-visibility-select",
+										disabled: savingVisibility,
+										onChange: (event) => {
+											const nextValue =
+												String((event.currentTarget as HTMLSelectElement).value) === "shared"
+													? "shared"
+													: "private";
+											void saveVisibility(nextValue);
+										},
+										value: currentVisibility,
 									},
-									value: currentVisibility,
+									h("option", { value: "private" }, "Only me"),
+									h("option", { value: "shared" }, "Share with peers"),
+								),
+								h("div", { className: "feed-visibility-note" }, visibilityNote),
+							)
+						: null,
+				),
+				h(
+					"div",
+					{ className: "feed-footer-right" },
+					canClamp
+						? h(
+								"button",
+								{
+									className: "feed-expand",
+									onClick: () => {
+										const nextValue = !expanded;
+										state.itemExpandState.set(activeExpandKey, nextValue);
+										setExpanded(nextValue);
+									},
+									type: "button",
 								},
-								h("option", { value: "private" }, "Only me"),
-								h("option", { value: "shared" }, "Share with peers"),
-							),
-							h("div", { className: "feed-visibility-note" }, visibilityNote),
-						)
-					: null,
+								expanded ? "Collapse" : "Expand",
+							)
+						: null,
+				),
 			),
-			h(
-				"div",
-				{ className: "feed-footer-right" },
-				canClamp
-					? h(
-							"button",
-							{
-								className: "feed-expand",
-								onClick: () => {
-									const nextValue = !expanded;
-									state.itemExpandState.set(activeExpandKey, nextValue);
-									setExpanded(nextValue);
-								},
-								type: "button",
-							},
-							expanded ? "Collapse" : "Expand",
-						)
-					: null,
-			),
+			filesRow,
 		),
 	);
 }


### PR DESCRIPTION
## Description

The canonical feed-item refresh. Drop the 4px left-rail pattern in favor of a full-width top banner tinted per memory kind — that's the design-agent-confirmed taxonomy cue.

- Top banner in the kind's `--accent-subtle` with an `accent-strong`-tinted bottom border
- Kind chip inset left inside the banner (renamed `kind-pill` → `kind-chip`, mono uppercase 0.08em)
- Card `overflow: hidden` + `--radius-md` so the banner inherits the rounded top; body content in a new `.feed-card-body` wrapper
- 7 canonical kinds styled (feature / bugfix / change / refactor / discovery / docs / test); decision / exploration / session_summary preserved with neutral treatments because the core store still emits those
- New `--accent-steel`, `--accent-ochre`, `--accent-neutral` (+ `-subtle`) tokens back the three previously-missing kinds across all three theme blocks; every kind rule resolves via `var()` + `color-mix` so there are no hardcoded hex values in the feed CSS
- File paths render as pill tags below the footer (not collapsed into a mono count — filenames carry real info)
- Terminal-output empty state (mono + blinking mint cursor, `$ codemem feed` prompt) for the CLI-native voice
- Segmented All/Mine/Theirs toggle active: `--accent-subtle` wash + `inset 0 0 0 1px var(--accent-strong)`
- `newPulse` mount animation deferred to a v2 follow-up

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
