### PR TITLE
feat(viewer): sync peer cards in 2-col grid, tinted trust badges

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1410,8 +1410,8 @@
         font-size: 12px;
         font-weight: 600;
       }
-      .badge-online { background: rgba(26, 107, 86, 0.12); color: var(--accent); }
-      .badge-offline { background: rgba(182, 75, 47, 0.15); color: var(--accent-warm); }
+      .badge-online { background: var(--accent-subtle); color: var(--accent); border-color: var(--accent-strong); }
+      .badge-offline { background: var(--accent-warm-subtle); color: var(--accent-warm); border-color: rgba(255, 180, 84, 0.3); }
 
       .pill {
         display: inline-block;
@@ -1495,7 +1495,10 @@
 
       /* ── Peers ─────────────────────────────────────────────── */
 
-      .peer-list { display: grid; gap: var(--sp-3); }
+      .peer-list { display: grid; grid-template-columns: 1fr; gap: var(--sp-3); }
+      @media (min-width: 900px) {
+        .peer-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      }
       .peer-card { border: 1px solid var(--border); border-radius: var(--radius-lg); padding: var(--sp-4); background: var(--surface-1); display: grid; gap: var(--sp-2); }
       .peer-title { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); flex-wrap: wrap; }
       .peer-title strong { font-size: 14px; font-weight: 600; }
@@ -1829,8 +1832,8 @@
         border-color: var(--accent);
         box-shadow: 0 0 0 3px var(--focus-ring);
       }
-      .peer-meta { font-size: 13px; color: var(--text-tertiary); }
-      .peer-addresses { font-family: var(--font-mono); font-size: 12px; color: var(--text-secondary); opacity: 0.7; }
+      .peer-meta { font-size: 13px; color: var(--text-tertiary); font-feature-settings: 'tnum' 1; }
+      .peer-addresses { font-family: var(--font-mono); font-size: 12px; color: var(--text-tertiary); letter-spacing: 0.02em; }
       .attempts-list { margin-top: var(--sp-3); display: grid; gap: 6px; font-size: 13px; color: var(--text-tertiary); }
 
       /* ── Pairing ───────────────────────────────────────────── */


### PR DESCRIPTION
## Description

Sync peer cards go from a scrolling stack to paired devices.

- `.peer-list` grid: `1fr` under 900px, `repeat(2, minmax(0, 1fr))` above — the Sync tab reads as pairs
- `.badge-online` / `.badge-offline` shift to the `reference/ui_kit` pattern: subtle tinted wash keyed to accent / accent-warm with `accent-strong` border. Matches kind-chip + segmented-toggle so all three components read as one family
- `.peer-meta` picks up `font-feature-settings: 'tnum' 1` so live-refreshing timestamps don't jitter
- Address lines drop the `opacity: 0.7` hack for a direct `--text-tertiary` pairing

Direction glyphs (↕ ↓ ↑) and a top-of-tab online pill deferred — peer data model doesn't expose direction, and the card has no connectivity-signal source today.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
