### PR TITLE
refactor(viewer): drop unused --t-* semantic type ramp

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -117,19 +117,6 @@
         /* Typography */
         --font-sans: "Geist", system-ui, -apple-system, sans-serif;
         --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-
-        /* Semantic type ramp — 14px body */
-        --t-display: 600 24px/1.2  var(--font-sans);
-        --t-h1:      600 18px/1.3  var(--font-sans);
-        --t-h2:      600 16px/1.3  var(--font-sans);
-        --t-h3:      600 15px/1.35 var(--font-sans);
-        --t-body:    400 14px/1.55 var(--font-sans);
-        --t-body-sm: 400 13px/1.55 var(--font-sans);
-        --t-meta:    400 12px/1.4  var(--font-sans);
-        --t-micro:   500 11px/1.3  var(--font-mono);
-        --t-code:    400 13px/1.55 var(--font-mono);
-        --t-eyebrow: 500 11px/1.2  var(--font-mono);
-        --t-eyebrow-letter-spacing: 0.08em;
       }
 
       /* ── Light variant ─────────────────────────────────────── */


### PR DESCRIPTION
## Description

The `--t-display` / `--t-h1` / `--t-h2` / `--t-h3` / `--t-body` / `--t-body-sm` / `--t-meta` / `--t-micro` / `--t-code` / `--t-eyebrow` / `--t-eyebrow-letter-spacing` tokens added during Foundation were speculation — every heading in the viewer hardcodes `font-size` in its scoped rule (`.card h2 { font-size: 16px }`, `.stat .value { font-size: 20px }`, etc.). Nothing reads the ramp tokens, so they're pure rot.

Remove them. When a later component refactor gives us canonical `Heading` / `Text` primitives, we can reintroduce a ramp that the component owns centrally. Until then, scoped rules stay authoritative.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
