### PR TITLE
feat(viewer): finish :focus-visible coverage with halos on button-family rules

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1170,6 +1170,7 @@
       .feed-menu-trigger:focus-visible {
         outline: 2px solid var(--accent);
         outline-offset: 2px;
+        box-shadow: 0 0 0 4px var(--focus-ring);
       }
       .feed-menu-item {
         display: flex;
@@ -1351,6 +1352,11 @@
         transition: background 140ms ease, color 140ms ease;
       }
       .feed-expand:hover { background: var(--accent-subtle); color: var(--accent); }
+      .feed-expand:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+        box-shadow: 0 0 0 4px var(--focus-ring);
+      }
 
       .feed-tags { display: flex; flex-wrap: wrap; gap: 6px; }
       /* File paths render as compact pill-tags in their own row — the actual
@@ -1909,6 +1915,7 @@
       .modal-close-button:focus-visible {
         outline: 2px solid var(--accent);
         outline-offset: 2px;
+        box-shadow: 0 0 0 4px var(--focus-ring);
       }
       .modal-close-button-icon {
         font-size: 11px;


### PR DESCRIPTION
## Description

Focus-management audit fallout after the design migration.

- `.feed-expand` had no focus rule at all (keyboard users tabbed through invisible)
- `.feed-menu-trigger` had `:focus-visible` but no halo
- `.modal-close-button` same

All three now carry the standard pattern: 2px accent outline, 2px offset, 4px accent-ring halo — matches `.settings-button` and `.icon-button`.

Form controls (`.project-filter`, `.feed-inspector-files`, `.sync-legacy-select`, `.sync-actor-select`, `.sync-dialog-input`, `.settings-select-trigger`) kept on `:focus` rather than `:focus-visible` — inputs and selects want the ring to appear on click too, not only on keyboard tabbing, because the ring doubles as a cursor-is-here cue.

Reduced-motion audit: cursor-blink on `.feed-empty-state::after` falls under the global `prefers-reduced-motion` rule. Verified inert.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
