### PR TITLE
feat(viewer): feed loading skeleton matching the banner shape

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1066,6 +1066,60 @@
         gap: var(--sp-3);
       }
 
+      /* Feed loading skeleton — mirrors the banner / body / footer shape so
+         the transition into real content doesn't shift layout. Reuses the
+         sync-shimmer keyframe below. */
+      .feed-skeleton {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sp-3);
+      }
+      .feed-skeleton-item {
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-1);
+        overflow: hidden;
+        box-shadow: var(--shadow-sm);
+      }
+      .feed-skeleton-banner {
+        height: 28px;
+        background: linear-gradient(90deg, var(--surface-2) 25%, var(--surface-3) 50%, var(--surface-2) 75%);
+        background-size: 400px 100%;
+        animation: sync-shimmer 1.5s ease-in-out infinite;
+        border-bottom: 1px solid var(--border);
+      }
+      .feed-skeleton-body {
+        padding: var(--sp-4) var(--sp-5);
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .feed-skeleton-line {
+        height: 12px;
+        border-radius: 6px;
+        background: linear-gradient(90deg, var(--surface-2) 25%, var(--surface-3) 50%, var(--surface-2) 75%);
+        background-size: 400px 100%;
+        animation: sync-shimmer 1.5s ease-in-out infinite;
+      }
+      .feed-skeleton-line.w-85 { width: 85%; }
+      .feed-skeleton-line.w-65 { width: 65%; }
+      .feed-skeleton-line.w-40 { width: 40%; }
+      .feed-skeleton-footer {
+        display: flex;
+        gap: 8px;
+        padding-top: 4px;
+      }
+      .feed-skeleton-chip {
+        height: 18px;
+        width: 72px;
+        border-radius: var(--radius-pill);
+        background: linear-gradient(90deg, var(--surface-2) 25%, var(--surface-3) 50%, var(--surface-2) 75%);
+        background-size: 400px 100%;
+        animation: sync-shimmer 1.5s ease-in-out infinite;
+      }
+      .feed-skeleton-chip.w-36 { width: 36px; }
+      .feed-skeleton-chip.w-56 { width: 56px; }
+
       /* ── Feed items ────────────────────────────────────────── */
       /* Design-handoff clarification (2026-04-19): feed items render with
          a full-width top banner in the kind's tint, not a 4px left rail.

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -1014,9 +1014,46 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 	);
 }
 
+function FeedSkeletonItem({ index }: { index: number }) {
+	// Alternate widths across the skeleton set so the stack doesn't look
+	// mechanically repeated. Three variants is enough to read as "loading."
+	const bodyWidths = [
+		["w-85", "w-65"],
+		["w-85", "w-40"],
+		["w-65", "w-85"],
+	];
+	const [first, second] = bodyWidths[index % bodyWidths.length];
+	return h(
+		"div",
+		{ className: "feed-skeleton-item", "aria-hidden": "true" },
+		h("div", { className: "feed-skeleton-banner" }),
+		h(
+			"div",
+			{ className: "feed-skeleton-body" },
+			h("div", { className: `feed-skeleton-line ${first}` }),
+			h("div", { className: `feed-skeleton-line ${second}` }),
+			h(
+				"div",
+				{ className: "feed-skeleton-footer" },
+				h("div", { className: "feed-skeleton-chip w-36" }),
+				h("div", { className: "feed-skeleton-chip w-56" }),
+				h("div", { className: "feed-skeleton-chip" }),
+			),
+		),
+	);
+}
+
 function FeedList({ items, loadingText }: { items: FeedItem[]; loadingText?: string }) {
 	if (loadingText) {
-		return h("div", { className: "small feed-empty-state" }, loadingText);
+		return h(
+			"div",
+			{
+				className: "feed-skeleton",
+				role: "status",
+				"aria-label": loadingText,
+			},
+			[0, 1, 2, 3].map((i) => h(FeedSkeletonItem, { index: i, key: `skeleton-${i}` })),
+		);
 	}
 	if (!items.length) {
 		const hasFilters =


### PR DESCRIPTION
## Description

`FeedList` used to render "Loading…" plain text during pagination and initial load — the feed refresh window is the viewer's most perceptible latency, and a bare string made the tab feel dead while data travelled.

- `.feed-skeleton` stack of four `.feed-skeleton-item` cards: 28px banner strip + two body lines (widths rotate across 85% / 65% / 40%) + a footer row of three shimmer chips
- Outer shape mirrors the real feed item's banner → body → footer so the transition into real content doesn't shift layout
- Animation reuses the existing `@keyframes sync-shimmer` (1.5s ease-in-out infinite on a 400px gradient)
- Global `prefers-reduced-motion` rule already freezes it — no separate override needed
- Container `role="status"` + `aria-label` for SR; items `aria-hidden="true"` so the SR announces the loading state once, not N times

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
