### PR TITLE
fix(viewer): long-title forget modal, health-pip moves into logo, coordinator buttons themed

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -341,6 +341,7 @@
       }
 
       .logo {
+        position: relative;
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -371,15 +372,22 @@
         box-shadow: 0 0 10px var(--accent-subtle);
       }
 
+      /* Health pip — lives top-right of the logo square. Separate from the
+         brand dot in the wordmark so the two mint circles don't read as
+         twins. 2px surface-colored border cuts the pip from the logo bg. */
       .health-dot {
-        width: 8px;
-        height: 8px;
+        position: absolute;
+        top: -2px;
+        right: -2px;
+        width: 10px;
+        height: 10px;
         border-radius: 50%;
+        border: 2px solid var(--surface-0);
         flex-shrink: 0;
       }
-      .health-dot.status-healthy { background: var(--status-healthy); box-shadow: 0 0 0 3px var(--accent-subtle); }
-      .health-dot.status-degraded { background: var(--status-degraded); box-shadow: 0 0 0 3px var(--accent-warm-subtle); }
-      .health-dot.status-attention { background: var(--status-attention); box-shadow: 0 0 0 3px rgba(255, 122, 80, 0.18); animation: pulse 2.4s ease infinite; }
+      .health-dot.status-healthy { background: var(--status-healthy); }
+      .health-dot.status-degraded { background: var(--status-degraded); }
+      .health-dot.status-attention { background: var(--status-attention); animation: pulse 2.4s ease infinite; }
 
       .header-right {
         display: flex;
@@ -2556,9 +2564,9 @@
                 <rect x="5.5" y="5.5" width="13" height="13" rx="2.25" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-opacity="0.55" stroke-width="1.2"/>
                 <rect x="9" y="9" width="13" height="13" rx="2.25" fill="currentColor"/>
               </svg>
+              <span class="health-dot status-healthy" id="healthDot" title="Healthy"></span>
             </span>
             <span class="header-title">codemem<span class="brand-dot" aria-hidden="true"></span></span>
-            <span class="health-dot status-healthy" id="healthDot" title="Healthy"></span>
           </div>
           <span class="refresh-status" id="refreshStatus">refreshing…</span>
           <span class="sr-only" id="refreshAnnouncer" aria-live="polite"></span>

--- a/packages/ui/src/tabs/coordinator-admin.tsx
+++ b/packages/ui/src/tabs/coordinator-admin.tsx
@@ -821,6 +821,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 								h(
 									"button",
 									{
+										class: "settings-button",
 										disabled: !deviceId || pending || summary.readiness !== "ready",
 										onClick: () => void runDeviceAction(deviceId, groupId, displayName, "rename"),
 										type: "button",
@@ -831,7 +832,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 									? h(
 											"button",
 											{
-												class: "danger",
+												class: "settings-button danger",
 												disabled: !deviceId || pending || summary.readiness !== "ready",
 												onClick: () =>
 													void runDeviceAction(deviceId, groupId, displayName, "disable"),
@@ -842,6 +843,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 									: h(
 											"button",
 											{
+												class: "settings-button",
 												disabled: !deviceId || pending || summary.readiness !== "ready",
 												onClick: () =>
 													void runDeviceAction(deviceId, groupId, displayName, "enable"),
@@ -852,7 +854,7 @@ function renderDevicesPanel(summary: ReturnType<typeof coordinatorAdminSummary>)
 								h(
 									"button",
 									{
-										class: "danger",
+										class: "settings-button danger",
 										disabled: !deviceId || pending || summary.readiness !== "ready",
 										onClick: () => void runDeviceAction(deviceId, groupId, displayName, "remove"),
 										type: "button",

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -852,11 +852,13 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 	}
 
 	async function forgetMemory() {
+		const titleText = String(displayTitle || "this memory").trim();
+		const truncatedTitle =
+			titleText.length > 80 ? `${titleText.slice(0, 79).trimEnd()}…` : titleText;
 		const confirmed = await openSyncConfirmDialog({
 			autoFocusAction: "cancel",
-			title: `Forget ${displayTitle}?`,
-			description:
-				"This removes the memory from active results. The underlying record remains soft-deleted for audit and sync safety.",
+			title: "Forget this memory?",
+			description: `Forgetting "${truncatedTitle}". This removes the memory from active results. The underlying record remains soft-deleted for audit and sync safety.`,
 			confirmLabel: "Forget memory",
 			cancelLabel: "Keep memory",
 			tone: "danger",


### PR DESCRIPTION
## Description

Three review-fallout items from the local test pass.

- **Forget modal heading blew out at long titles.** Session-summary titles regularly run 200+ chars; rendering them inline with the 18px heading produced a 4-line modal heading with the Close button floating awkwardly. Swap to a static heading ("Forget this memory?") and fold the (truncated to 80ch + ellipsis) title into the description body
- **Twin-dots header.** Mint brand dot next to mint health dot read as two dots. Moved the health indicator into the top-right of the logo square as a 10×10 pip with a 2px `--surface-0` border (later reverted in the review-polish PR in favor of dropping the brand dot entirely)
- **Coordinator Admin device-row buttons** (Rename / Enable / Disable / Remove) were either class-less or only carried `danger`. Browser chrome bled through on Rename + Enable; only the danger-cascading rule styled Disable + Remove. All four now get `.settings-button` (plus `danger` where destructive)

Not part of the design migration proper; surfaced during the local test pass. Sync log wrap and overall-healthy-but-sync-degraded over-warning filed as separate bugs.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
