### PR TITLE
feat(viewer): add visible labels on sync device-rename and create-person inputs

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1605,7 +1605,19 @@
       .peer-scope-chip-remove:hover { opacity: 1; }
       .peer-scope-input { width: 100%; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--text-primary); padding: 8px 10px; font: inherit; }
       .peer-scope-actions { display: flex; gap: var(--sp-2); flex-wrap: wrap; }
-      .peer-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+      .peer-actions { display: flex; gap: 6px; flex-wrap: wrap; align-items: flex-end; }
+
+      /* Labeled input wrapper — keeps a small uppercase caption visible even
+         when the input has a value. Replaces aria-label-only inputs that
+         were glaring once the deep-ink palette raised contrast. */
+      .sync-labeled-field { display: flex; flex-direction: column; gap: 4px; min-width: 180px; flex: 1 1 220px; }
+      .sync-labeled-field-caption {
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--text-tertiary);
+      }
       .peer-actions button.danger { color: var(--accent-warm); border-color: color-mix(in srgb, var(--accent-warm) 36%, var(--border)); }
       .peer-actions button.danger:hover { background: var(--accent-warm-subtle); border-color: var(--accent-warm); }
       .peer-card,
@@ -2892,8 +2904,10 @@
         <h3 class="settings-group-title">People</h3>
         <div class="section-meta" id="syncActorsMeta">Create and rename people here. Assign each device below.</div>
         <div class="actor-create-row">
-          <label for="syncActorCreateInput" class="sr-only">Person name</label>
-          <input class="peer-scope-input" id="syncActorCreateInput" placeholder="Create a named person" />
+          <div class="sync-labeled-field">
+            <label for="syncActorCreateInput" class="sync-labeled-field-caption">Person name</label>
+            <input class="peer-scope-input" id="syncActorCreateInput" placeholder="e.g. Alex, backend team" />
+          </div>
           <button class="settings-button" id="syncActorCreateButton">Create person</button>
         </div>
         <div class="actor-list" id="syncActorsList"></div>

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -350,18 +350,27 @@ function SyncPeerCard({
 					>
 						{syncBusy ? "Syncing…" : "Sync now"}
 					</button>
-					<TextInput
-						aria-label={`Friendly name for ${displayName}`}
-						className="peer-scope-input"
-						data-device-name-input={peerId || undefined}
-						disabled={renameBusy}
-						placeholder="Friendly device name"
-						type="text"
-						value={renameValue}
-						onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
-							setRenameValue(event.currentTarget.value)
-						}
-					/>
+					<div className="sync-labeled-field">
+						<label
+							className="sync-labeled-field-caption"
+							htmlFor={`device-name-${peerId || "unknown"}`}
+						>
+							Device name
+						</label>
+						<TextInput
+							aria-label={`Friendly name for ${displayName}`}
+							className="peer-scope-input"
+							data-device-name-input={peerId || undefined}
+							disabled={renameBusy}
+							id={`device-name-${peerId || "unknown"}`}
+							placeholder="Friendly device name"
+							type="text"
+							value={renameValue}
+							onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
+								setRenameValue(event.currentTarget.value)
+							}
+						/>
+					</div>
 					<button
 						type="button"
 						className="settings-button"


### PR DESCRIPTION
## Description

Deep-ink palette raised contrast enough that inputs relying on `aria-label` + placeholder became hard to parse. Once populated ("pi4"), the field sat next to Save name / Remove device with no visible cue what it was — screen readers always had the label; humans didn't.

- New `.sync-labeled-field` wrapper pattern: column-flex, 4px gap, small uppercase-tracked tertiary caption above the input
- Matches the eyebrow-label pattern used on stat tiles (12px uppercase 0.08em), at 11px to feel supporting rather than primary
- Wired at the two callsites the review screenshots called out: device-rename input in peer cards ("Device name") and create-person row in the Sync actors section ("Person name", replaces the `.sr-only` label with a cleaner placeholder)
- Assignee RadixSelect already has the visible "Who this device belongs to" caption and actor-rename already shows "Display name" — not changed

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
