### PR TITLE
feat(viewer): drop brand dot, ~ home-dir collapse, dynamic byte suffix, softer stat size

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -341,7 +341,6 @@
       }
 
       .logo {
-        position: relative;
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -361,33 +360,15 @@
         white-space: nowrap;
       }
 
-      .brand-dot {
-        display: inline-block;
-        width: 6px;
-        height: 6px;
-        border-radius: 50%;
-        background: var(--accent);
-        margin-left: 3px;
-        vertical-align: baseline;
-        box-shadow: 0 0 10px var(--accent-subtle);
-      }
-
-      /* Health pip — lives top-right of the logo square. Separate from the
-         brand dot in the wordmark so the two mint circles don't read as
-         twins. 2px surface-colored border cuts the pip from the logo bg. */
       .health-dot {
-        position: absolute;
-        top: -2px;
-        right: -2px;
-        width: 10px;
-        height: 10px;
+        width: 8px;
+        height: 8px;
         border-radius: 50%;
-        border: 2px solid var(--surface-0);
         flex-shrink: 0;
       }
-      .health-dot.status-healthy { background: var(--status-healthy); }
-      .health-dot.status-degraded { background: var(--status-degraded); }
-      .health-dot.status-attention { background: var(--status-attention); animation: pulse 2.4s ease infinite; }
+      .health-dot.status-healthy { background: var(--status-healthy); box-shadow: 0 0 0 3px var(--accent-subtle); }
+      .health-dot.status-degraded { background: var(--status-degraded); box-shadow: 0 0 0 3px var(--accent-warm-subtle); }
+      .health-dot.status-attention { background: var(--status-attention); box-shadow: 0 0 0 3px rgba(255, 122, 80, 0.18); animation: pulse 2.4s ease infinite; }
 
       .header-right {
         display: flex;
@@ -796,9 +777,9 @@
       .stat .value {
         font-family: var(--font-sans);
         font-weight: 600;
-        font-size: 24px;
+        font-size: 20px;
         color: var(--text-primary);
-        line-height: 1.1;
+        line-height: 1.15;
         letter-spacing: -0.01em;
         font-feature-settings: 'tnum' 1;
       }
@@ -2576,9 +2557,9 @@
                 <rect x="5.5" y="5.5" width="13" height="13" rx="2.25" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-opacity="0.55" stroke-width="1.2"/>
                 <rect x="9" y="9" width="13" height="13" rx="2.25" fill="currentColor"/>
               </svg>
-              <span class="health-dot status-healthy" id="healthDot" title="Healthy"></span>
             </span>
-            <span class="header-title">codemem<span class="brand-dot" aria-hidden="true"></span></span>
+            <span class="header-title">codemem</span>
+            <span class="health-dot status-healthy" id="healthDot" title="Healthy"></span>
           </div>
           <span class="refresh-status" id="refreshStatus">refreshing…</span>
           <span class="sr-only" id="refreshAnnouncer" aria-live="polite"></span>

--- a/packages/ui/src/lib/format.test.ts
+++ b/packages/ui/src/lib/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatTokenCount } from "./format";
+import { collapseHome, formatBytes, formatTokenCount } from "./format";
 
 describe("formatTokenCount", () => {
 	it("keeps small values fully written out", () => {
@@ -20,5 +20,53 @@ describe("formatTokenCount", () => {
 		// Keep readable unit boundaries instead of surfacing awkward values like 1000K.
 		expect(formatTokenCount(999_950)).toBe("1M tokens");
 		expect(formatTokenCount(999_950_000)).toBe("1B tokens");
+	});
+});
+
+describe("collapseHome", () => {
+	it("replaces macOS user home with ~", () => {
+		expect(collapseHome("/Users/adam/workspace/codemem")).toBe("~/workspace/codemem");
+	});
+	it("replaces Linux user home with ~", () => {
+		expect(collapseHome("/home/adam/projects/db.sqlite")).toBe("~/projects/db.sqlite");
+	});
+	it("replaces Windows user home with ~", () => {
+		expect(collapseHome("C:\\Users\\adam\\codemem\\mem.sqlite")).toBe("~\\codemem\\mem.sqlite");
+	});
+	it("leaves non-home paths alone", () => {
+		expect(collapseHome("/var/run/codemem.sock")).toBe("/var/run/codemem.sock");
+	});
+	it("treats bare home dir as ~", () => {
+		expect(collapseHome("/Users/adam")).toBe("~");
+	});
+	it("returns empty string for nullish input", () => {
+		expect(collapseHome(null)).toBe("");
+		expect(collapseHome(undefined)).toBe("");
+	});
+});
+
+describe("formatBytes", () => {
+	it("shows raw bytes under 1024", () => {
+		expect(formatBytes(512)).toBe("512 B");
+		expect(formatBytes(0)).toBe("0 B");
+	});
+	it("scales through KB / MB / GB / TB", () => {
+		expect(formatBytes(2048)).toBe("2 KB");
+		expect(formatBytes(1.5 * 1024 * 1024)).toBe("1.5 MB");
+		expect(formatBytes(5 * 1024 * 1024 * 1024)).toBe("5 GB");
+		expect(formatBytes(3 * 1024 ** 4)).toBe("3 TB");
+	});
+	it("rounds to integer once the scaled value crosses 10", () => {
+		expect(formatBytes(15 * 1024 * 1024)).toBe("15 MB");
+	});
+	it("promotes to the next unit when rounding would hit 1024", () => {
+		// 1023.6 KB rounds to 1024 on its face; re-normalize to 1 MB so the
+		// magnitude always stays under the next unit boundary.
+		expect(formatBytes(Math.round(1023.6 * 1024))).toBe("1 MB");
+		expect(formatBytes(Math.round(1023.7 * 1024 * 1024))).toBe("1 GB");
+	});
+	it("returns n/a for invalid input", () => {
+		expect(formatBytes("not a number")).toBe("n/a");
+		expect(formatBytes(-5)).toBe("n/a");
 	});
 });

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -155,3 +155,41 @@ export function formatTagLabel(tag: unknown): string {
 	if (colonIndex === -1) return trimmed;
 	return trimmed.slice(0, colonIndex).trim();
 }
+
+/**
+ * Replace the user's home-directory prefix with `~` in a path string —
+ * `/Users/adam/workspace/foo` → `~/workspace/foo`, same for `/home/adam/…`
+ * and Windows `C:\Users\adam\…`. Leaves anything else untouched.
+ */
+export function collapseHome(path: unknown): string {
+	const text = String(path || "");
+	if (!text) return "";
+	return text
+		.replace(/^\/Users\/[^/]+(?=\/|$)/, "~")
+		.replace(/^\/home\/[^/]+(?=\/|$)/, "~")
+		.replace(/^[A-Z]:\\Users\\[^\\]+(?=\\|$)/, "~");
+}
+
+/**
+ * Format a byte count with the smallest suffix that keeps the number under
+ * 1024 units (binary convention to match filesystem reporting). 0-byte and
+ * non-finite inputs return a friendly fallback.
+ */
+export function formatBytes(value: unknown): string {
+	const num = Number(value || 0);
+	if (!Number.isFinite(num) || num < 0) return "n/a";
+	if (num < 1024) return `${num} B`;
+	const units = ["KB", "MB", "GB", "TB", "PB"];
+	const roundAt = (scaled: number) =>
+		scaled >= 10 ? Math.round(scaled) : Number(scaled.toFixed(1));
+	let scaled = num / 1024;
+	let unitIndex = 0;
+	// Promote to the next unit while the *rounded* value would hit 1024 — so
+	// inputs like 1023.6 KB become "1 MB", not "1024 KB".
+	while (unitIndex < units.length - 1 && roundAt(scaled) >= 1024) {
+		scaled /= 1024;
+		unitIndex += 1;
+	}
+	const text = String(roundAt(scaled)).replace(/\.0$/, "");
+	return `${text} ${units[unitIndex]}`;
+}

--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -4,7 +4,9 @@ import { Fragment, h, render } from "preact";
 import * as api from "../lib/api";
 import { copyToClipboard } from "../lib/dom";
 import {
+	collapseHome,
 	formatAgeShort,
+	formatBytes,
 	formatMultiplier,
 	formatPercent,
 	formatReductionPercent,
@@ -607,10 +609,8 @@ export function renderStats() {
 
 	if (metaLine) {
 		const projectSuffix = project ? ` · project: ${project}` : "";
-		renderText(
-			metaLine,
-			`DB: ${db.path || "unknown"} · ${Math.round((db.size_bytes || 0) / 1024)} KB${projectSuffix}`,
-		);
+		const dbPath = collapseHome(db.path || "unknown");
+		renderText(metaLine, `DB: ${dbPath} · ${formatBytes(db.size_bytes || 0)}${projectSuffix}`);
 	}
 	renderIcons();
 }


### PR DESCRIPTION
## Description

Four review-pass polishes in one commit: tighten the header, tame the stat tiles.

- **Drop the mint brand dot** after "codemem" in the wordmark and move the health pip back to its pre-migration slot beside the wordmark with the `--accent-subtle` glow restored. The brand dot was decorative; the logo square + Geist 600 wordmark already carry the brand. Keeping it only added a second mint circle competing with the health signal
- **Meta line: swap home-dir prefix for `~`** via a new `collapseHome` helper (handles `/Users/<user>`, `/home/<user>`, and `C:\Users\<user>`). Plus a new `formatBytes` helper that scales through B / KB / MB / GB / TB based on the value (binary convention to match filesystem reporting). Both land in `packages/ui/src/lib/format.ts` with 10 new tests
- **Stat tiles: value size 24px → 20px.** 24px made the Overview + Stats rows feel heavier than the surrounding cards; 20px keeps the number prominent without overpowering the label/detail stack. Line-height bumped to 1.15 so descenders don't clip

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
