### PR TITLE
fix(viewer): match header logo to the new gradient-M favicon

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -2552,11 +2552,9 @@
         <div class="header-left">
           <div class="header-brand">
             <span class="logo" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" shape-rendering="crispEdges" aria-hidden="true">
-                <path d="M3 8h13v13H3z" fill="none" stroke="currentColor" stroke-width="2.8" opacity="0.18"/>
-                <path d="M4.5 6.5h13v13h-13z" fill="none" stroke="currentColor" stroke-width="2.8" opacity="0.30"/>
-                <path d="M6 5h13v13H6z" fill="none" stroke="currentColor" stroke-width="2.8" opacity="0.56"/>
-                <path d="M7.5 3.5h13v13h-13z" fill="none" stroke="currentColor" stroke-width="2.8" opacity="0.82"/>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                <rect x="3.75" y="3.75" width="12" height="12" rx="2.25" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-opacity="0.55" stroke-width="1.2"/>
+                <rect x="8.25" y="8.25" width="12" height="12" rx="2.25" fill="currentColor"/>
               </svg>
             </span>
             <span class="header-title">codemem</span>


### PR DESCRIPTION
## Description

The Foundation PR shipped a new favicon (offset mint rounded squares from the design handoff) but the header logo still rendered the pre-migration stacked-square motif — four outlined squares at progressive opacity.

Replace with the two-rect composition from the favicon (back square outlined + 18% tint, front square solid) at a 24×24 viewBox. Keeps `currentColor` so light theme picks up the `--accent` evergreen without a separate SVG.

Now the chrome matches the favicon and the installable app icon.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
