### PR TITLE
refactor(viewer): extract shared .surface base for bordered card family

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -472,9 +472,22 @@
 
       /* ── Cards / sections ──────────────────────────────────── */
 
-      .card {
+      /* Every bordered-surface component (card, stat tile, peer card,
+         actor row, modal card) shares the same tinted-inset background
+         + 1px translucent border. Pull it into one selector group so
+         each variant only declares radius, padding, shadow, and layout.
+         Markup unchanged — each class works standalone. */
+      .surface,
+      .card,
+      .stat,
+      .peer-card,
+      .actor-row,
+      .modal-card {
         background: var(--surface-1);
         border: 1px solid var(--border);
+      }
+
+      .card {
         border-radius: var(--radius-xl);
         padding: var(--sp-5);
         box-shadow: var(--shadow-md);
@@ -749,10 +762,8 @@
       /* ── Stat cards ────────────────────────────────────────── */
 
       .stat {
-        border: 1px solid var(--border);
         border-radius: var(--radius-lg);
         padding: var(--sp-4);
-        background: var(--surface-1);
         display: flex;
         align-items: center;
         gap: var(--sp-3);
@@ -1563,11 +1574,11 @@
       @media (min-width: 900px) {
         .peer-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       }
-      .peer-card { border: 1px solid var(--border); border-radius: var(--radius-lg); padding: var(--sp-4); background: var(--surface-1); display: grid; gap: var(--sp-2); }
+      .peer-card { border-radius: var(--radius-lg); padding: var(--sp-4); display: grid; gap: var(--sp-2); }
       .peer-title { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); flex-wrap: wrap; }
       .peer-title strong { font-size: 14px; font-weight: 600; }
       .actor-list { display: grid; gap: var(--sp-3); margin-top: var(--sp-3); }
-      .actor-row { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); border: 1px solid var(--border); border-radius: var(--radius-lg); padding: var(--sp-3); background: var(--surface-1); }
+      .actor-row { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); border-radius: var(--radius-lg); padding: var(--sp-3); }
       .actor-details { min-width: 0; display: grid; gap: 6px; }
       .actor-title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
       .actor-actions { display: flex; align-items: center; gap: var(--sp-2); flex-wrap: wrap; justify-content: flex-end; }
@@ -1935,8 +1946,6 @@
 
       .modal-card {
         width: min(520px, 100%);
-        background: var(--surface-1);
-        border: 1px solid var(--border);
         border-radius: var(--radius-xl);
         box-shadow: var(--shadow-lg);
         padding: var(--sp-5);


### PR DESCRIPTION
## Description

Third sub-commit of `codemem-h6rd` (component-architecture consolidation). Every bordered-surface component in the viewer (`.card`, `.stat`, `.peer-card`, `.actor-row`, `.modal-card`) re-declared `background: var(--surface-1)` and `border: 1px solid var(--border)` from scratch. Pulled both into a single selector group so each variant only declares the layout-specific bits — `border-radius`, `padding`, `box-shadow`, and `display` / flex / grid behavior.

- Adds a bare `.surface` base class (currently unused in markup) for new bordered-card callsites to reach for instead of re-declaring the surface + border pair
- Markup unchanged — each variant class works standalone
- Same computed styles, ~10 LOC lighter

Third and likely final CSS-side sub-commit of Phase 2. Further consolidation (Button/Chip/Card as Preact components with real variant props) needs markup changes that are better done under live visual review, not pure CSS refactor.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
