### PR TITLE
refactor(viewer): extract Chip primitive and route feed.ts kind/tag/provenance through it

### DIFF
--- a/packages/ui/src/components/primitives/chip.tsx
+++ b/packages/ui/src/components/primitives/chip.tsx
@@ -1,0 +1,40 @@
+import type { ComponentChildren } from "preact";
+
+export type ChipVariant = "kind" | "provenance" | "tag" | "badge" | "scope";
+
+interface ChipProps {
+	variant: ChipVariant;
+	/**
+	 * Tone sub-class appended to the base variant (e.g. `feature` / `mine` /
+	 * `online`). Optional — provenance/kind chips default to their neutral
+	 * styling when absent.
+	 */
+	tone?: string;
+	title?: string;
+	children?: ComponentChildren;
+}
+
+const VARIANT_CLASS: Record<ChipVariant, string> = {
+	kind: "kind-chip",
+	provenance: "provenance-chip",
+	tag: "tag-chip",
+	badge: "badge",
+	scope: "peer-scope-chip",
+};
+
+/**
+ * Canonical pill-shaped label. Renders `<span>` with the existing variant
+ * class (`kind-chip`, `provenance-chip`, `tag-chip`, `badge`, `peer-scope-chip`)
+ * — CSS is owned by the viewer stylesheet so output is identical to
+ * hand-written spans. One component so future chips don't each grow their
+ * own className concatenation.
+ */
+export function Chip({ variant, tone, title, children }: ChipProps) {
+	const base = VARIANT_CLASS[variant];
+	const className = tone ? `${base} ${tone}` : base;
+	return (
+		<span className={className} title={title}>
+			{children}
+		</span>
+	);
+}

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -3,6 +3,7 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { type ComponentChildren, Fragment, h, render } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
+import { Chip } from "../components/primitives/chip";
 import * as api from "../lib/api";
 import { highlightText } from "../lib/dom";
 import {
@@ -178,7 +179,7 @@ function feedScopeLabel(scope: string): string {
 }
 
 function ProvenanceChip({ label, variant = "" }: { label: string; variant?: string }) {
-	return h("span", { className: `provenance-chip ${variant}`.trim() }, label);
+	return h(Chip, { variant: "provenance", tone: variant || undefined }, label);
 }
 
 function trustStateLabel(trustState: string): string {
@@ -706,7 +707,7 @@ function FeedViewToggle({
 function TagChip({ tag }: { tag: unknown }) {
 	const display = formatTagLabel(tag);
 	if (!display) return null;
-	return h("span", { className: "tag-chip", title: String(tag) }, display);
+	return h(Chip, { variant: "tag", title: String(tag) }, display);
 }
 
 /* ── Feed item card renderer ─────────────────────────────── */
@@ -903,7 +904,7 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 		h(
 			"div",
 			{ className: "feed-kind-banner" },
-			h("span", { className: `kind-chip ${displayKindValue}`.trim() }, kindChipLabel),
+			h(Chip, { variant: "kind", tone: displayKindValue }, kindChipLabel),
 		),
 		h(
 			"div",


### PR DESCRIPTION
## Description

Fourth sub-commit of `codemem-h6rd`. Introduces the first Preact primitive from the component-architecture consolidation plan and routes the three feed-card chip renders through it.

New component: `packages/ui/src/components/primitives/chip.tsx` exposing `<Chip variant="kind|provenance|tag|badge|scope" tone="..." />`. Output HTML is byte-identical to the hand-written spans — `Chip` just stamps the existing CSS class names (`kind-chip`, `provenance-chip`, `tag-chip`, `badge`, `peer-scope-chip`) with the optional tone sub-class appended. CSS stays authoritative in the viewer stylesheet.

Callsites migrated in `packages/ui/src/tabs/feed.ts`:
- `ProvenanceChip` local wrapper → delegates to `<Chip variant="provenance" tone={...}>`
- `TagChip` local wrapper → delegates to `<Chip variant="tag">`
- Inline kind-chip span (feed banner) → `<Chip variant="kind" tone={displayKindValue}>`

Out of scope: `sync/helpers.ts` chip renders use the DOM builder (`el()`) rather than JSX — not idiomatic for this primitive, so left as-is. Button primitive deferred because the 39 button callsites with varying disabled/async/label states need live visual review before migrating.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
