### PR TITLE
feat(viewer): replace hand-rolled globalNotice with Radix Toast

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -2020,36 +2020,87 @@
       }
       .modal-body { display: flex; flex-direction: column; gap: var(--sp-3); flex: 1; min-height: 0; overflow-y: auto; padding-right: 6px; }
       .modal-footer { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); flex-shrink: 0; padding-top: var(--sp-2); border-top: 1px solid var(--border); }
-      @keyframes noticeSlideIn {
-        from { transform: translateY(-12px); opacity: 0; }
-        to { transform: translateY(0); opacity: 1; }
+      /* ── Toast (Radix Toast-backed) ───────────────────────── */
+      /* Fixed viewport anchored bottom-right. Each toast is a surface-card
+         with a severity-tinted left accent keyed to .toast-{variant}. */
+      .toast-viewport {
+        position: fixed;
+        bottom: var(--sp-5);
+        right: var(--sp-5);
+        display: flex;
+        flex-direction: column;
+        gap: var(--sp-2);
+        width: min(380px, calc(100vw - var(--sp-5) * 2));
+        max-width: 100%;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        z-index: 80;
+        outline: none;
       }
-      @keyframes noticeSlideOut {
-        from { transform: translateY(0); opacity: 1; }
-        to { transform: translateY(-12px); opacity: 0; }
-      }
-      .app-notice {
-        margin: var(--sp-3) var(--sp-5) 0;
-        padding: var(--sp-3) var(--sp-4);
-        border: 1px solid var(--border);
-        border-radius: var(--radius-md);
+      .toast-root {
         background: var(--surface-1);
-        color: var(--text-secondary);
-        box-shadow: var(--shadow-sm);
-        animation: noticeSlideIn 0.25s ease both;
+        border: 1px solid var(--border);
+        border-left: 3px solid var(--accent);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-md);
+        padding: var(--sp-3) var(--sp-4);
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: var(--sp-3);
+        align-items: start;
+        color: var(--text-primary);
+        font-size: 13px;
+        line-height: 1.5;
       }
-      .app-notice.hiding {
-        animation: noticeSlideOut 0.2s ease both;
+      .toast-root[data-state="open"] { animation: toastSlideIn 160ms ease; }
+      .toast-root[data-state="closed"] { animation: toastFadeOut 140ms ease forwards; }
+      .toast-root[data-swipe="move"] { transform: translateX(var(--radix-toast-swipe-move-x)); }
+      .toast-root[data-swipe="cancel"] { transform: translateX(0); transition: transform 140ms ease; }
+      .toast-root[data-swipe="end"] { animation: toastSwipeOut 140ms ease forwards; }
+
+      .toast-success { border-left-color: var(--accent); }
+      .toast-info    { border-left-color: var(--accent-cool); }
+      .toast-warning { border-left-color: var(--accent-warm); }
+      .toast-error   { border-left-color: var(--status-attention); }
+
+      .toast-message { color: var(--text-primary); }
+
+      .toast-close {
+        border: 1px solid var(--border);
+        background: transparent;
+        color: var(--text-tertiary);
+        width: 24px;
+        height: 24px;
+        border-radius: var(--radius-pill);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 14px;
+        line-height: 1;
+        cursor: pointer;
+        transition: background-color 140ms ease, color 140ms ease;
+        padding: 0;
+        flex-shrink: 0;
       }
-      .app-notice.success {
-        border-color: rgba(26, 107, 86, 0.24);
-        background: rgba(26, 107, 86, 0.08);
-        color: var(--accent);
+      .toast-close:hover { background: var(--surface-2); color: var(--text-primary); }
+      .toast-close:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+        box-shadow: 0 0 0 4px var(--focus-ring);
       }
-      .app-notice.warning {
-        border-color: rgba(212, 100, 46, 0.28);
-        background: rgba(212, 100, 46, 0.1);
-        color: var(--accent-warm);
+
+      @keyframes toastSlideIn {
+        from { transform: translateX(calc(100% + var(--sp-5))); opacity: 0; }
+        to   { transform: translateX(0); opacity: 1; }
+      }
+      @keyframes toastFadeOut {
+        from { opacity: 1; }
+        to   { opacity: 0; }
+      }
+      @keyframes toastSwipeOut {
+        from { transform: translateX(var(--radix-toast-swipe-end-x)); }
+        to   { transform: translateX(calc(100% + var(--sp-5))); }
       }
       .viewer-reconnect-overlay {
         position: fixed;
@@ -2625,7 +2676,7 @@
       <button class="tab-btn" id="tabBtn-sync">Sync</button>
       <button class="tab-btn" id="tabBtn-coordinator-admin">Coordinator Admin</button>
     </nav>
-    <div class="app-notice" id="globalNotice" hidden aria-live="polite"></div>
+    <div id="toastRoot"></div>
     <div class="viewer-reconnect-overlay" id="viewerReconnectOverlay" hidden>
       <div class="viewer-reconnect-card" role="status" aria-live="assertive">
         <div class="viewer-reconnect-eyebrow">Viewer connection</div>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,6 +19,7 @@
 		"@radix-ui/react-select": "^2.2.6",
 		"@radix-ui/react-switch": "^1.2.6",
 		"@radix-ui/react-tabs": "^1.1.13",
+		"@radix-ui/react-toast": "^1.2.15",
 		"@radix-ui/react-tooltip": "^1.2.8",
 		"preact": "^10.27.2",
 		"tslib": "^2.8.1"

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -9,6 +9,7 @@
 
 declare const __CODEMEM_GIT_COMMIT__: string;
 
+import { mountToastHost } from "./components/primitives/toast";
 import * as api from "./lib/api";
 import { $, $button, $select } from "./lib/dom";
 import {
@@ -354,6 +355,10 @@ async function doRefresh() {
 /* ── Boot ────────────────────────────────────────────────── */
 
 initState();
+
+// Toast host — mount first so early notices (from tab init etc.) land.
+const toastRoot = document.getElementById("toastRoot");
+if (toastRoot) mountToastHost(toastRoot);
 
 // Theme
 initThemeToggle($button("themeToggle"));

--- a/packages/ui/src/components/primitives/toast.tsx
+++ b/packages/ui/src/components/primitives/toast.tsx
@@ -1,0 +1,85 @@
+import { signal } from "@preact/signals";
+import * as ToastPrimitive from "@radix-ui/react-toast";
+import { render } from "preact";
+
+export type ToastVariant = "success" | "warning" | "error" | "info";
+
+interface ToastItem {
+	id: number;
+	message: string;
+	variant: ToastVariant;
+	durationMs: number;
+}
+
+/** Queue of active toasts — rendered by <ToastHost>, mutated by pushToast. */
+const toasts = signal<ToastItem[]>([]);
+let nextId = 1;
+
+/**
+ * Imperative API preserved so callsites that used the old
+ * `showGlobalNotice(message, 'success' | 'warning')` helper don't have to
+ * know about React state. Queues the toast; ToastHost renders it.
+ */
+export function pushToast(
+	message: string,
+	variant: ToastVariant = "success",
+	durationMs = 8_000,
+): void {
+	if (!message) return;
+	const id = nextId++;
+	toasts.value = [...toasts.value, { id, message, variant, durationMs }];
+}
+
+/** Dismiss a specific toast (used by Radix onOpenChange). */
+function dismissToast(id: number) {
+	toasts.value = toasts.value.filter((t) => t.id !== id);
+}
+
+/** Dismiss all active toasts — rarely needed, exposed for completeness. */
+export function dismissAllToasts() {
+	toasts.value = [];
+}
+
+/**
+ * Mount once via `mountToastHost(document.body)`. Renders the Radix
+ * Provider + Viewport plus one Root per queued toast. Subscribes to the
+ * signal so any pushToast triggers a re-render.
+ */
+export function ToastHost() {
+	const items = toasts.value;
+	return (
+		<ToastPrimitive.Provider duration={8_000} swipeDirection="right">
+			{items.map((item) => (
+				<ToastPrimitive.Root
+					key={item.id}
+					className={`toast-root toast-${item.variant}`}
+					duration={item.durationMs}
+					onOpenChange={(open) => {
+						if (!open) dismissToast(item.id);
+					}}
+					// role + aria-live derived from variant: errors/warnings are
+					// 'alert' (interruptive), success/info are 'status' (polite).
+					type={
+						item.variant === "error" || item.variant === "warning" ? "foreground" : "background"
+					}
+				>
+					<ToastPrimitive.Description className="toast-message">
+						{item.message}
+					</ToastPrimitive.Description>
+					<ToastPrimitive.Close aria-label="Dismiss" className="toast-close">
+						×
+					</ToastPrimitive.Close>
+				</ToastPrimitive.Root>
+			))}
+			<ToastPrimitive.Viewport className="toast-viewport" />
+		</ToastPrimitive.Provider>
+	);
+}
+
+/**
+ * Attach the ToastHost to the given DOM element (usually document.body).
+ * Idempotent — calls render() which replaces any previous tree.
+ */
+export function mountToastHost(root: HTMLElement) {
+	render(<ToastHost />, root);
+}

--- a/packages/ui/src/lib/notice.ts
+++ b/packages/ui/src/lib/notice.ts
@@ -1,46 +1,15 @@
-import { $ } from "./dom";
-import { state } from "./state";
+import { dismissAllToasts, pushToast } from "../components/primitives/toast";
 
-let hideAbort: AbortController | null = null;
-
-export function hideGlobalNotice() {
-	const notice = $("globalNotice");
-	if (!notice) return;
-	if (state.noticeTimer) {
-		clearTimeout(state.noticeTimer);
-		state.noticeTimer = null;
-	}
-	// Cancel any previous hide listener before registering a new one
-	if (hideAbort) hideAbort.abort();
-	hideAbort = new AbortController();
-	notice.classList.add("hiding");
-	notice.addEventListener(
-		"animationend",
-		() => {
-			hideAbort = null;
-			notice.hidden = true;
-			notice.textContent = "";
-			notice.classList.remove("success", "warning", "hiding");
-		},
-		{ once: true, signal: hideAbort.signal },
-	);
+/**
+ * Legacy signature kept for callsite stability. Now delegates to the Radix
+ * Toast host (mounted once at app boot). Historically rendered via a static
+ * #globalNotice div; that markup is gone — ToastHost owns the UI.
+ */
+export function showGlobalNotice(message: string, type: "success" | "warning" = "success"): void {
+	pushToast(message, type);
 }
 
-export function showGlobalNotice(message: string, type: "success" | "warning" = "success") {
-	const notice = $("globalNotice");
-	if (!notice || !message) return;
-	// Cancel any in-progress hide animation so it can't kill this notice
-	if (hideAbort) {
-		hideAbort.abort();
-		hideAbort = null;
-	}
-	notice.classList.remove("hiding");
-	notice.textContent = message;
-	notice.classList.remove("success", "warning");
-	notice.classList.add(type === "warning" ? "warning" : "success");
-	notice.hidden = false;
-	if (state.noticeTimer) clearTimeout(state.noticeTimer);
-	state.noticeTimer = setTimeout(() => {
-		hideGlobalNotice();
-	}, 12_000);
+/** Back-compat: clears the entire toast queue. */
+export function hideGlobalNotice(): void {
+	dismissAllToasts();
 }

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -256,7 +256,6 @@ export const state = {
 	configDefaults: {} as Record<string, unknown>,
 	configPath: "",
 	settingsDirty: false,
-	noticeTimer: null as ReturnType<typeof setTimeout> | null,
 
 	/* Sync UI toggles */
 	syncDiagnosticsOpen: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.15
+        version: 1.2.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1792,6 +1795,19 @@ packages:
 
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4957,6 +4973,23 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-roving-focus': 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@radix-ui/react-toast@1.2.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 


### PR DESCRIPTION
## Description

Second of two Radix Primitive additions flagged during Phase 2 review (`codemem-b8i6`). Replaces the hand-rolled `#globalNotice` aria-live region + `.app-notice` CSS with `@radix-ui/react-toast` under a new `<ToastHost>` mount.

- New primitive: `packages/ui/src/components/primitives/toast.tsx` — signal-backed queue, `pushToast(message, variant, durationMs?)` imperative API, `ToastHost` renders `Provider + Viewport + one Root per queued item`, `mountToastHost(rootEl)` attaches once at boot
- Severity → Radix `type` mapping: `error`/`warning` → `foreground` (role=alert, interruptive), `success`/`info` → `background` (role=status)
- Styling: `.toast-viewport` fixed bottom-right, severity-tinted left accent per `.toast-{success|info|warning|error}` root, slide-in-from-right (160ms) + fade-out (140ms) + Radix swipe-to-dismiss wired through `data-swipe` transforms
- Callsite stability: `notice.ts` keeps `showGlobalNotice(message, type)` + `hideGlobalNotice()` signatures — they now delegate to `pushToast` / `dismissAllToasts`. All existing callers (forget-memory, sync peer ops, coordinator admin, settings save) unchanged
- Cleanup: `#globalNotice` + `.app-notice` + `@keyframes noticeSlide*` removed; replaced by a minimal `#toastRoot` mount div. `state.noticeTimer` dropped as dead field

Bundle: +55 kB gzipped across Tooltip (#818) + Toast combined. Real a11y upgrade for a pattern we were faking with an always-on live region.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
