### PR TITLE
fix(viewer): sync-diag row wraps body within column, timestamp flush-right

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1561,9 +1561,26 @@
       /* ── Diagnostics ───────────────────────────────────────── */
 
       .diag-list { margin-top: var(--sp-3); display: flex; flex-direction: column; gap: var(--sp-2); }
-      .diag-line { border: 1px solid var(--border); border-radius: var(--radius-md); padding: var(--sp-3); background: var(--surface-2); display: flex; justify-content: space-between; gap: var(--sp-3); }
+      /* Sync diagnostics row. Body wraps within its own column; timestamp
+         stays flush-right on the first line and doesn't shove the wrapped
+         body sideways. On narrow viewports the timestamp stacks under the
+         body so neither column has to compete with the other. */
+      .diag-line {
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--sp-3);
+        background: var(--surface-2);
+        display: grid;
+        grid-template-columns: 1fr auto;
+        align-items: baseline;
+        gap: var(--sp-3);
+      }
       .diag-line .left { min-width: 0; }
-      .diag-line .right { flex-shrink: 0; color: var(--text-tertiary); }
+      .diag-line .right { color: var(--text-tertiary); white-space: nowrap; }
+      @media (max-width: 600px) {
+        .diag-line { grid-template-columns: 1fr; }
+        .diag-line .right { font-size: 11px; }
+      }
 
       .diag-group { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: var(--sp-2) var(--sp-3); margin-top: var(--sp-3); background: var(--surface-2); }
       .diag-group summary { cursor: pointer; color: var(--text-tertiary); font-size: 13px; }


### PR DESCRIPTION
## Description

The Recent Sync Attempts diagnostics row used `display: flex; justify-content: space-between` which pinned the timestamp to the top-right corner while long error bodies (multi-address timeouts: `all addresses failed | http://... || http://...`) wrapped across multiple lines underneath. The result was a lopsided block with the timestamp floating high above lines 2–4 of the wrapped body.

Switch `.diag-line` to an explicit grid (`1fr auto`) with `align-items: baseline` so the timestamp sits on the body's first baseline and the body wraps within its own column without shoving the timestamp sideways. Under 600px viewport width, collapse to a single column so the timestamp stacks cleanly beneath the body.

Closes `codemem-4epj`.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
