### PR TITLE
feat(viewer): feed-item newPulse mount animation with reduced-motion fallback

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -2619,7 +2619,20 @@
         50% { transform: scale(1.3); opacity: 0.5; }
       }
 
-      /* newPulse deferred to codemem-gi99 (feed-item mount animation, v2). */
+      /* newPulse: fresh feed items pulse their kind-banner bottom border
+         from accent-strong to transparent once on mount. The class is
+         applied by feed.ts only while state.newItemKeys holds the item's
+         key (700ms useEffect then clears it). Skipped entirely under
+         prefers-reduced-motion so the ambient accessibility pass still
+         applies. */
+      @media (prefers-reduced-motion: no-preference) {
+        @keyframes newPulse {
+          0%   { box-shadow: 0 0 0 0 var(--accent-strong); }
+          30%  { box-shadow: 0 0 0 6px var(--accent-subtle); }
+          100% { box-shadow: 0 0 0 0 transparent; }
+        }
+        .feed-item.new-item { animation: newPulse 420ms ease-out 1; }
+      }
 
       /* ── Responsive ────────────────────────────────────────── */
 

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -897,12 +897,10 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 				),
 			)
 		: null;
-	void isNew;
-
 	return h(
 		"article",
 		{
-			className: `feed-item ${displayKindValue}`.trim(),
+			className: `feed-item ${displayKindValue}${isNew ? " new-item" : ""}`.trim(),
 			"data-key": rowKey,
 		},
 		h(

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -1183,13 +1183,8 @@ async function loadMoreFeedPage() {
 
 		const incoming = [...summaryItems, ...filtered];
 		const feedItems = mergeFeedItems(state.lastFeedItems as FeedItem[], incoming);
-		const newCount = countNewItems(feedItems, state.lastFeedItems as FeedItem[]);
-		if (newCount) {
-			const seen = new Set((state.lastFeedItems as FeedItem[]).map(itemKey));
-			feedItems.forEach((item) => {
-				if (!seen.has(itemKey(item))) state.newItemKeys.add(itemKey(item));
-			});
-		}
+		// Pagination loads OLDER items, not fresh arrivals — skip the newPulse
+		// bookkeeping so scrolling doesn't flash historical cards.
 
 		state.lastFeedItems = feedItems;
 		updateFeedView();
@@ -1707,9 +1702,13 @@ export async function loadFeedData() {
 	});
 	const feedItems = mergeRefreshFeedItems(state.lastFeedItems as FeedItem[], firstPageFeedItems);
 
-	const newCount = countNewItems(feedItems, state.lastFeedItems as FeedItem[]);
-	if (newCount) {
-		const seen = new Set((state.lastFeedItems as FeedItem[]).map(itemKey));
+	// Only flag newPulse on genuine incremental arrivals. First-time load has
+	// an empty lastFeedItems and every row "looks new" — skip that case so we
+	// don't bulk-pulse the whole feed on open/tab-switch/project-switch.
+	const previousItems = state.lastFeedItems as FeedItem[];
+	const newCount = countNewItems(feedItems, previousItems);
+	if (newCount && previousItems.length > 0) {
+		const seen = new Set(previousItems.map(itemKey));
 		feedItems.forEach((item) => {
 			if (!seen.has(itemKey(item))) state.newItemKeys.add(itemKey(item));
 		});


### PR DESCRIPTION
## Description

Third v2-polish follow-up from the viewer design migration. Fresh feed items now pulse a brief mint halo on mount — the item's `box-shadow` flashes from `var(--accent-strong)` through `var(--accent-subtle)` to transparent over 420ms. Keyed off the `isNew` flag that `feed.ts` already tracks via `state.newItemKeys` (set on fresh arrivals, cleared by a 700ms `useEffect` after mount), so the pulse runs exactly once per newly-landed item.

- `.new-item` class + `newPulse` keyframe live inside a `@media (prefers-reduced-motion: no-preference)` block — users who've opted out of motion get no animation at all
- The 700ms cleanup effect that removes the item from `state.newItemKeys` stays unchanged
- Banner pattern from the feed-item refresh (#803) is unaffected — the pulse is a box-shadow on the outer `.feed-item`, not a border-color flash

Closes `codemem-gi99`.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
