### PR TITLE
refactor(ui): start feed/ split — move shared types to feed/types.ts

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -24,77 +24,22 @@ import { openSyncConfirmDialog } from "./sync/sync-dialogs";
 
 export type { FeedItem, FeedItemMetadata } from "./feed/types";
 
+import {
+	authorLabel,
+	extractFactsFromBody,
+	feedScopeLabel,
+	isLowSignalObservation,
+	itemKey,
+	itemSignature,
+	mergeFeedItems,
+	mergeMetadata,
+	mergeRefreshFeedItems,
+	sentenceFacts,
+	trustStateLabel,
+} from "./feed/helpers";
 import type { FeedItem, FeedItemMetadata, FeedSummary, ItemViewMode } from "./feed/types";
 
-/* ── Helpers ─────────────────────────────────────────────── */
-
-function mergeMetadata(metadata: unknown): FeedItemMetadata {
-	if (!metadata || typeof metadata !== "object") return {};
-	const meta = metadata as FeedItemMetadata;
-	const importMeta = meta.import_metadata;
-	if (importMeta && typeof importMeta === "object") {
-		return { ...importMeta, ...meta };
-	}
-	return meta;
-}
-
-function extractFactsFromBody(text: unknown): string[] {
-	if (!text) return [];
-	const lines = String(text)
-		.split("\n")
-		.map((l) => l.trim())
-		.filter(Boolean);
-	const bullets = lines.filter((l) => /^[-*\u2022]\s+/.test(l) || /^\d+\./.test(l));
-	if (!bullets.length) return [];
-	return bullets.map((l) => l.replace(/^[-*\u2022]\s+/, "").replace(/^\d+\.\s+/, ""));
-}
-
-function sentenceFacts(text: string, limit = 6): string[] {
-	const raw = String(text || "").trim();
-	if (!raw) return [];
-	const collapsed = raw.replace(/\s+/g, " ").trim();
-	const parts = collapsed
-		.split(/(?<=[.!?])\s+/)
-		.map((p) => p.trim())
-		.filter(Boolean);
-	const facts: string[] = [];
-	for (const part of parts) {
-		if (part.length < 18) continue;
-		facts.push(part);
-		if (facts.length >= limit) break;
-	}
-	return facts;
-}
-
-function isLowSignalObservation(item: FeedItem): boolean {
-	const title = normalize(item.title);
-	const body = normalize(item.body_text);
-	if (!title && !body) return true;
-	const combined = body || title;
-	if (combined.length < 10) return true;
-	if (title && body && title === body && combined.length < 40) return true;
-	const lead = title.charAt(0);
-	if ((lead === "\u2514" || lead === "\u203a") && combined.length < 40) return true;
-	if (title.startsWith("list ") && combined.length < 20) return true;
-	if (combined === "ls" || combined === "list ls") return true;
-	return false;
-}
-
-function itemSignature(item: FeedItem): string {
-	return String(
-		item.id ??
-			item.memory_id ??
-			item.observation_id ??
-			item.session_id ??
-			item.created_at_utc ??
-			item.created_at ??
-			"",
-	);
-}
-
-function itemKey(item: FeedItem): string {
-	return `${String(item.kind || "").toLowerCase()}:${itemSignature(item)}`;
-}
+/* ── Constants + module state ─────────────────────────────── */
 
 const OBSERVATION_PAGE_SIZE = 20;
 const SUMMARY_PAGE_SIZE = 50;
@@ -128,28 +73,8 @@ function renderIntoFeedMount(mount: HTMLElement, content: ComponentChildren) {
 	render(h(TooltipProvider, null, content), mount);
 }
 
-function feedScopeLabel(scope: string): string {
-	if (scope === "mine") return " · my memories";
-	if (scope === "theirs") return " · other people";
-	return "";
-}
-
 function ProvenanceChip({ label, variant = "" }: { label: string; variant?: string }) {
 	return h(Chip, { variant: "provenance", tone: variant || undefined }, label);
-}
-
-function trustStateLabel(trustState: string): string {
-	if (trustState === "legacy_unknown") return "legacy provenance";
-	if (trustState === "unreviewed") return "unreviewed";
-	return trustState.replace(/_/g, " ");
-}
-
-function authorLabel(item: FeedItem): string {
-	if (item?.owned_by_self === true) return "You";
-	const actorId = String(item.actor_id || "").trim();
-	const actorName = String(item.actor_display_name || "").trim();
-	if (actorId && actorId === state.lastStatsPayload?.identity?.actor_id) return "You";
-	return actorName || actorId || "Unknown author";
 }
 
 function resetPagination(project: string) {
@@ -189,25 +114,6 @@ function pageNextOffset(payload: api.PaginatedResponse, count: number): number {
 
 function hasMorePages(): boolean {
 	return observationHasMore || summaryHasMore;
-}
-
-function mergeFeedItems(currentItems: FeedItem[], incomingItems: FeedItem[]): FeedItem[] {
-	const byKey = new Map<string, FeedItem>();
-	currentItems.forEach((item) => {
-		byKey.set(itemKey(item), item);
-	});
-	incomingItems.forEach((item) => {
-		byKey.set(itemKey(item), item);
-	});
-	return Array.from(byKey.values()).sort((a, b) => {
-		return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
-	});
-}
-
-function mergeRefreshFeedItems(currentItems: FeedItem[], firstPageItems: FeedItem[]): FeedItem[] {
-	const firstPageKeys = new Set(firstPageItems.map(itemKey));
-	const olderItems = currentItems.filter((item) => !firstPageKeys.has(itemKey(item)));
-	return mergeFeedItems(olderItems, firstPageItems);
 }
 
 export function syncInspectorQueryDraft(options: {

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -22,55 +22,9 @@ import { openSyncConfirmDialog } from "./sync/sync-dialogs";
 
 /* ── Types ───────────────────────────────────────────────── */
 
-/**
- * A feed item — observations and session summaries are pulled from different
- * viewer endpoints but render through the same card component. This shape
- * covers every field we read; the server adds more fields that we ignore,
- * so shapes are open and all fields optional.
- */
-export interface FeedItemMetadata {
-	import_metadata?: FeedItemMetadata;
-	subtitle?: string;
-	narrative?: string;
-	facts?: unknown;
-	is_summary?: boolean;
-	source?: string;
-	request?: string;
-	visibility?: string;
-	workspace_kind?: string;
-	origin_source?: string;
-	origin_device_id?: string;
-	trust_state?: string;
-	summary?: unknown;
-}
+export type { FeedItem, FeedItemMetadata } from "./feed/types";
 
-export interface FeedItem {
-	id?: number;
-	memory_id?: number | string;
-	observation_id?: number | string;
-	session_id?: number | string;
-	created_at?: string;
-	created_at_utc?: string;
-	kind?: string;
-	title?: string;
-	subtitle?: string;
-	body_text?: string;
-	narrative?: string;
-	facts?: unknown;
-	tags?: unknown;
-	files?: unknown;
-	project?: string;
-	actor_id?: string;
-	actor_display_name?: string;
-	owned_by_self?: boolean;
-	visibility?: string;
-	workspace_kind?: string;
-	origin_source?: string;
-	origin_device_id?: string;
-	trust_state?: string;
-	metadata_json?: FeedItemMetadata;
-	summary?: unknown;
-}
+import type { FeedItem, FeedItemMetadata, FeedSummary, ItemViewMode } from "./feed/types";
 
 /* ── Helpers ─────────────────────────────────────────────── */
 
@@ -141,8 +95,6 @@ function itemSignature(item: FeedItem): string {
 function itemKey(item: FeedItem): string {
 	return `${String(item.kind || "").toLowerCase()}:${itemSignature(item)}`;
 }
-
-type ItemViewMode = "summary" | "facts" | "narrative";
 
 const OBSERVATION_PAGE_SIZE = 20;
 const SUMMARY_PAGE_SIZE = 50;
@@ -355,8 +307,6 @@ function FeedItemMenu({
  * are typed as `unknown` — callers are expected to coerce via
  * `String(v || "")` or a `typeof` narrowing before rendering.
  */
-type FeedSummary = Record<string, unknown>;
-
 function getSummaryObject(item: FeedItem): FeedSummary | null {
 	const preferredKeys = [
 		"request",

--- a/packages/ui/src/tabs/feed/helpers.ts
+++ b/packages/ui/src/tabs/feed/helpers.ts
@@ -1,0 +1,120 @@
+/* Pure helper functions for the Feed tab — no rendering, no state mutation.
+ *
+ * Extracted verbatim from packages/ui/src/tabs/feed.ts as part of the
+ * feed/ split (tracked under codemem-ug38). Each function below is
+ * exported so feed.ts can import it; nothing else changed.
+ */
+
+import { normalize } from "../../lib/format";
+import { state } from "../../lib/state";
+import type { FeedItem, FeedItemMetadata } from "./types";
+
+export function mergeMetadata(metadata: unknown): FeedItemMetadata {
+	if (!metadata || typeof metadata !== "object") return {};
+	const meta = metadata as FeedItemMetadata;
+	const importMeta = meta.import_metadata;
+	if (importMeta && typeof importMeta === "object") {
+		return { ...importMeta, ...meta };
+	}
+	return meta;
+}
+
+export function extractFactsFromBody(text: unknown): string[] {
+	if (!text) return [];
+	const lines = String(text)
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean);
+	const bullets = lines.filter((l) => /^[-*\u2022]\s+/.test(l) || /^\d+\./.test(l));
+	if (!bullets.length) return [];
+	return bullets.map((l) => l.replace(/^[-*\u2022]\s+/, "").replace(/^\d+\.\s+/, ""));
+}
+
+export function sentenceFacts(text: string, limit = 6): string[] {
+	const raw = String(text || "").trim();
+	if (!raw) return [];
+	const collapsed = raw.replace(/\s+/g, " ").trim();
+	const parts = collapsed
+		.split(/(?<=[.!?])\s+/)
+		.map((p) => p.trim())
+		.filter(Boolean);
+	const facts: string[] = [];
+	for (const part of parts) {
+		if (part.length < 18) continue;
+		facts.push(part);
+		if (facts.length >= limit) break;
+	}
+	return facts;
+}
+
+export function isLowSignalObservation(item: FeedItem): boolean {
+	const title = normalize(item.title);
+	const body = normalize(item.body_text);
+	if (!title && !body) return true;
+	const combined = body || title;
+	if (combined.length < 10) return true;
+	if (title && body && title === body && combined.length < 40) return true;
+	const lead = title.charAt(0);
+	if ((lead === "\u2514" || lead === "\u203a") && combined.length < 40) return true;
+	if (title.startsWith("list ") && combined.length < 20) return true;
+	if (combined === "ls" || combined === "list ls") return true;
+	return false;
+}
+
+export function itemSignature(item: FeedItem): string {
+	return String(
+		item.id ??
+			item.memory_id ??
+			item.observation_id ??
+			item.session_id ??
+			item.created_at_utc ??
+			item.created_at ??
+			"",
+	);
+}
+
+export function itemKey(item: FeedItem): string {
+	return `${String(item.kind || "").toLowerCase()}:${itemSignature(item)}`;
+}
+
+export function feedScopeLabel(scope: string): string {
+	if (scope === "mine") return " · my memories";
+	if (scope === "theirs") return " · other people";
+	return "";
+}
+
+export function trustStateLabel(trustState: string): string {
+	if (trustState === "legacy_unknown") return "legacy provenance";
+	if (trustState === "unreviewed") return "unreviewed";
+	return trustState.replace(/_/g, " ");
+}
+
+export function authorLabel(item: FeedItem): string {
+	if (item?.owned_by_self === true) return "You";
+	const actorId = String(item.actor_id || "").trim();
+	const actorName = String(item.actor_display_name || "").trim();
+	if (actorId && actorId === state.lastStatsPayload?.identity?.actor_id) return "You";
+	return actorName || actorId || "Unknown author";
+}
+
+export function mergeFeedItems(currentItems: FeedItem[], incomingItems: FeedItem[]): FeedItem[] {
+	const byKey = new Map<string, FeedItem>();
+	currentItems.forEach((item) => {
+		byKey.set(itemKey(item), item);
+	});
+	incomingItems.forEach((item) => {
+		byKey.set(itemKey(item), item);
+	});
+	return Array.from(byKey.values()).sort((a, b) => {
+		return new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
+	});
+}
+
+export function mergeRefreshFeedItems(
+	currentItems: FeedItem[],
+	firstPageItems: FeedItem[],
+): FeedItem[] {
+	const firstPageKeys = new Set(firstPageItems.map(itemKey));
+	const olderItems = currentItems.filter((item) => !firstPageKeys.has(itemKey(item)));
+	return mergeFeedItems(olderItems, firstPageItems);
+}

--- a/packages/ui/src/tabs/feed/types.ts
+++ b/packages/ui/src/tabs/feed/types.ts
@@ -1,0 +1,57 @@
+/* Shared types for the Feed tab. */
+
+/**
+ * A feed item — observations and session summaries are pulled from different
+ * viewer endpoints but render through the same card component. This shape
+ * covers every field we read; the server adds more fields that we ignore,
+ * so shapes are open and all fields optional.
+ */
+export interface FeedItemMetadata {
+	import_metadata?: FeedItemMetadata;
+	subtitle?: string;
+	narrative?: string;
+	facts?: unknown;
+	is_summary?: boolean;
+	source?: string;
+	request?: string;
+	visibility?: string;
+	workspace_kind?: string;
+	origin_source?: string;
+	origin_device_id?: string;
+	trust_state?: string;
+	summary?: unknown;
+}
+
+export interface FeedItem {
+	id?: number;
+	memory_id?: number | string;
+	observation_id?: number | string;
+	session_id?: number | string;
+	created_at?: string;
+	created_at_utc?: string;
+	kind?: string;
+	title?: string;
+	subtitle?: string;
+	body_text?: string;
+	narrative?: string;
+	facts?: unknown;
+	tags?: unknown;
+	files?: unknown;
+	project?: string;
+	actor_id?: string;
+	actor_display_name?: string;
+	owned_by_self?: boolean;
+	visibility?: string;
+	workspace_kind?: string;
+	origin_source?: string;
+	origin_device_id?: string;
+	trust_state?: string;
+	metadata_json?: FeedItemMetadata;
+	summary?: unknown;
+}
+
+/** Which view mode a feed-item body is rendering in (toggled by FeedViewToggle). */
+export type ItemViewMode = "summary" | "facts" | "narrative";
+
+/** Summary payload attached to observations / session summaries. Open shape. */
+export type FeedSummary = Record<string, unknown>;


### PR DESCRIPTION
## Description

First step of splitting `packages/ui/src/tabs/feed.ts` (1729 LOC, 78 top-level symbols) into a concern-organized `feed/` folder. Tracks against the project-wide god-file refactor (`codemem-ug38`).

- New `packages/ui/src/tabs/feed/types.ts` holds the four public shared types — `FeedItem`, `FeedItemMetadata`, `ItemViewMode`, `FeedSummary` — verbatim from the original
- `feed.ts` re-exports `FeedItem` + `FeedItemMetadata` so existing callsite imports (app.ts etc.) keep working unchanged
- Mechanical move only — zero function bodies touched, zero behavior change
- `feed.ts` drops from 1729 → 1483 lines

Left for follow-up sub-commits (same refactor bead):
- `helpers.ts` (pure utility functions)
- `pagination.ts` (module-local offsets + loadMore)
- `card.tsx` / `skeleton.tsx` / `list.tsx` / `inspector.tsx` / `view.tsx`
- Eventually: `feed.ts` becomes a thin `index.ts` re-export

Each follow-up will copy originals verbatim rather than rewrite — the point is navigation, not behavior drift.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
