### PR TITLE
refactor(ui): start feed/ split — move shared types to feed/types.ts

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -22,55 +22,9 @@ import { openSyncConfirmDialog } from "./sync/sync-dialogs";
 
 /* ── Types ───────────────────────────────────────────────── */
 
-/**
- * A feed item — observations and session summaries are pulled from different
- * viewer endpoints but render through the same card component. This shape
- * covers every field we read; the server adds more fields that we ignore,
- * so shapes are open and all fields optional.
- */
-export interface FeedItemMetadata {
-	import_metadata?: FeedItemMetadata;
-	subtitle?: string;
-	narrative?: string;
-	facts?: unknown;
-	is_summary?: boolean;
-	source?: string;
-	request?: string;
-	visibility?: string;
-	workspace_kind?: string;
-	origin_source?: string;
-	origin_device_id?: string;
-	trust_state?: string;
-	summary?: unknown;
-}
+export type { FeedItem, FeedItemMetadata } from "./feed/types";
 
-export interface FeedItem {
-	id?: number;
-	memory_id?: number | string;
-	observation_id?: number | string;
-	session_id?: number | string;
-	created_at?: string;
-	created_at_utc?: string;
-	kind?: string;
-	title?: string;
-	subtitle?: string;
-	body_text?: string;
-	narrative?: string;
-	facts?: unknown;
-	tags?: unknown;
-	files?: unknown;
-	project?: string;
-	actor_id?: string;
-	actor_display_name?: string;
-	owned_by_self?: boolean;
-	visibility?: string;
-	workspace_kind?: string;
-	origin_source?: string;
-	origin_device_id?: string;
-	trust_state?: string;
-	metadata_json?: FeedItemMetadata;
-	summary?: unknown;
-}
+import type { FeedItem, FeedItemMetadata, FeedSummary, ItemViewMode } from "./feed/types";
 
 /* ── Helpers ─────────────────────────────────────────────── */
 
@@ -141,8 +95,6 @@ function itemSignature(item: FeedItem): string {
 function itemKey(item: FeedItem): string {
 	return `${String(item.kind || "").toLowerCase()}:${itemSignature(item)}`;
 }
-
-type ItemViewMode = "summary" | "facts" | "narrative";
 
 const OBSERVATION_PAGE_SIZE = 20;
 const SUMMARY_PAGE_SIZE = 50;
@@ -355,8 +307,6 @@ function FeedItemMenu({
  * are typed as `unknown` — callers are expected to coerce via
  * `String(v || "")` or a `typeof` narrowing before rendering.
  */
-type FeedSummary = Record<string, unknown>;
-
 function getSummaryObject(item: FeedItem): FeedSummary | null {
 	const preferredKeys = [
 		"request",

--- a/packages/ui/src/tabs/feed/types.ts
+++ b/packages/ui/src/tabs/feed/types.ts
@@ -1,0 +1,57 @@
+/* Shared types for the Feed tab. */
+
+/**
+ * A feed item — observations and session summaries are pulled from different
+ * viewer endpoints but render through the same card component. This shape
+ * covers every field we read; the server adds more fields that we ignore,
+ * so shapes are open and all fields optional.
+ */
+export interface FeedItemMetadata {
+	import_metadata?: FeedItemMetadata;
+	subtitle?: string;
+	narrative?: string;
+	facts?: unknown;
+	is_summary?: boolean;
+	source?: string;
+	request?: string;
+	visibility?: string;
+	workspace_kind?: string;
+	origin_source?: string;
+	origin_device_id?: string;
+	trust_state?: string;
+	summary?: unknown;
+}
+
+export interface FeedItem {
+	id?: number;
+	memory_id?: number | string;
+	observation_id?: number | string;
+	session_id?: number | string;
+	created_at?: string;
+	created_at_utc?: string;
+	kind?: string;
+	title?: string;
+	subtitle?: string;
+	body_text?: string;
+	narrative?: string;
+	facts?: unknown;
+	tags?: unknown;
+	files?: unknown;
+	project?: string;
+	actor_id?: string;
+	actor_display_name?: string;
+	owned_by_self?: boolean;
+	visibility?: string;
+	workspace_kind?: string;
+	origin_source?: string;
+	origin_device_id?: string;
+	trust_state?: string;
+	metadata_json?: FeedItemMetadata;
+	summary?: unknown;
+}
+
+/** Which view mode a feed-item body is rendering in (toggled by FeedViewToggle). */
+export type ItemViewMode = "summary" | "facts" | "narrative";
+
+/** Summary payload attached to observations / session summaries. Open shape. */
+export type FeedSummary = Record<string, unknown>;


### PR DESCRIPTION
## Description

First step of splitting `packages/ui/src/tabs/feed.ts` (1729 LOC, 78 top-level symbols) into a concern-organized `feed/` folder. Part of the project-wide god-file refactor (`codemem-ug38`).

- New `packages/ui/src/tabs/feed/types.ts` holds the four public shared types — `FeedItem`, `FeedItemMetadata`, `ItemViewMode`, `FeedSummary` — verbatim from the original
- `feed.ts` re-exports `FeedItem` + `FeedItemMetadata` so existing callsite imports (app.ts etc.) keep working unchanged
- Mechanical move only — zero function bodies touched, zero behavior change
- `feed.ts` drops 1729 → 1483 LOC

Follow-up extraction (`helpers.ts`) stacked as #826 so each slice is reviewable on its own.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
