### PR TITLE
refactor(core): extract maintenance/status.ts + shared with-db helper

### DIFF
--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -1,5 +1,5 @@
 import { statSync } from "node:fs";
-import { and, eq, gt, gte, inArray, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import {
 	assertSchemaReady,
@@ -10,6 +10,7 @@ import {
 } from "./db.js";
 import { getInjectionEvalScenarioByPrompt } from "./eval-scenarios.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
+import { withDb } from "./maintenance/with-db.js";
 import {
 	completeMaintenanceJob,
 	ensureMaintenanceJobsSchema,
@@ -26,6 +27,8 @@ import * as schema from "./schema.js";
 import { bootstrapSchema } from "./schema-bootstrap.js";
 import { MemoryStore } from "./store.js";
 import { canonicalMemoryKind, getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
+
+export { getRawEventStatus, retryRawEventFailures } from "./maintenance/status.js";
 
 export type {
 	MemoryRole,
@@ -65,23 +68,11 @@ import type {
 	RawEventRelinkPlanOptions,
 	RawEventRelinkReport,
 	RawEventRelinkReportOptions,
-	RawEventStatusResult,
 } from "./maintenance/types.js";
 
 interface InferredMemoryRole {
 	role: MemoryRole;
 	reason: string;
-}
-
-function withDb<T>(dbPath: string | undefined, fn: (db: Database, resolvedPath: string) => T): T {
-	const resolvedPath = resolveDbPath(dbPath);
-	const db = connect(resolvedPath);
-	try {
-		assertSchemaReady(db);
-		return fn(db, resolvedPath);
-	} finally {
-		db.close();
-	}
 }
 
 function classifyProjectQuality(project: unknown): "normal" | "empty" | "garbage_like" {
@@ -1134,98 +1125,6 @@ export function vacuumDatabase(dbPath?: string): { path: string; sizeBytes: numb
 	});
 }
 
-export function getRawEventStatus(dbPath?: string, limit = 25): RawEventStatusResult {
-	return withDb(dbPath, (db) => {
-		const d = drizzle(db, { schema });
-		const maxEvents = d
-			.select({
-				source: schema.rawEvents.source,
-				stream_id: schema.rawEvents.stream_id,
-				max_seq: sql<number>`MAX(${schema.rawEvents.event_seq})`.as("max_seq"),
-			})
-			.from(schema.rawEvents)
-			.groupBy(schema.rawEvents.source, schema.rawEvents.stream_id)
-			.as("max_events");
-
-		const rows = d
-			.select({
-				source: schema.rawEventSessions.source,
-				stream_id: schema.rawEventSessions.stream_id,
-				opencode_session_id: schema.rawEventSessions.opencode_session_id,
-				cwd: schema.rawEventSessions.cwd,
-				project: schema.rawEventSessions.project,
-				started_at: schema.rawEventSessions.started_at,
-				last_seen_ts_wall_ms: schema.rawEventSessions.last_seen_ts_wall_ms,
-				last_received_event_seq: schema.rawEventSessions.last_received_event_seq,
-				last_flushed_event_seq: schema.rawEventSessions.last_flushed_event_seq,
-				updated_at: schema.rawEventSessions.updated_at,
-			})
-			.from(schema.rawEventSessions)
-			.innerJoin(
-				maxEvents,
-				and(
-					eq(maxEvents.source, schema.rawEventSessions.source),
-					eq(maxEvents.stream_id, schema.rawEventSessions.stream_id),
-				),
-			)
-			.where(gt(maxEvents.max_seq, schema.rawEventSessions.last_flushed_event_seq))
-			.orderBy(sql`${schema.rawEventSessions.updated_at} DESC`)
-			.limit(limit)
-			.all();
-
-		const items = rows.map((row) => {
-			const streamId = String(row.stream_id ?? row.opencode_session_id ?? "");
-			return {
-				source: String(row.source ?? "opencode"),
-				stream_id: streamId,
-				opencode_session_id:
-					row.opencode_session_id == null ? null : String(row.opencode_session_id),
-				cwd: row.cwd == null ? null : String(row.cwd),
-				project: row.project == null ? null : String(row.project),
-				started_at: row.started_at == null ? null : String(row.started_at),
-				last_seen_ts_wall_ms:
-					row.last_seen_ts_wall_ms == null ? null : Number(row.last_seen_ts_wall_ms),
-				last_received_event_seq: Number(row.last_received_event_seq ?? -1),
-				last_flushed_event_seq: Number(row.last_flushed_event_seq ?? -1),
-				updated_at: String(row.updated_at ?? ""),
-				session_stream_id: streamId,
-				session_id: streamId,
-			};
-		});
-
-		const totalsRow = d
-			.select({
-				sessions: sql<number>`COUNT(1)`,
-				pending: sql<
-					number | null
-				>`SUM(${maxEvents.max_seq} - ${schema.rawEventSessions.last_flushed_event_seq})`,
-			})
-			.from(schema.rawEventSessions)
-			.innerJoin(
-				maxEvents,
-				and(
-					eq(maxEvents.source, schema.rawEventSessions.source),
-					eq(maxEvents.stream_id, schema.rawEventSessions.stream_id),
-				),
-			)
-			.where(gt(maxEvents.max_seq, schema.rawEventSessions.last_flushed_event_seq))
-			.get();
-
-		return {
-			items,
-			totals: {
-				pending: Number(totalsRow?.pending ?? 0),
-				sessions: Number(totalsRow?.sessions ?? 0),
-			},
-			ingest: {
-				available: true,
-				mode: "stream_queue",
-				max_body_bytes: 2_000_000,
-			},
-		};
-	});
-}
-
 // ---------------------------------------------------------------------------
 // Reliability metrics
 // ---------------------------------------------------------------------------
@@ -1481,50 +1380,6 @@ export function rawEventsGate(
 // ---------------------------------------------------------------------------
 // Retry
 // ---------------------------------------------------------------------------
-
-export function retryRawEventFailures(dbPath?: string, limit = 25): { retried: number } {
-	return withDb(dbPath, (db) => {
-		const d = drizzle(db, { schema });
-		const now = new Date().toISOString();
-		return db.transaction(() => {
-			const candidateIds = d
-				.select({ id: schema.rawEventFlushBatches.id })
-				.from(schema.rawEventFlushBatches)
-				.where(inArray(schema.rawEventFlushBatches.status, ["failed", "error"]))
-				.orderBy(schema.rawEventFlushBatches.updated_at)
-				.limit(limit)
-				.all()
-				.map((row) => Number(row.id));
-
-			if (candidateIds.length === 0) return { retried: 0 };
-
-			const result = d
-				.update(schema.rawEventFlushBatches)
-				.set({
-					status: "pending",
-					updated_at: now,
-					error_message: null,
-					error_type: null,
-					observer_provider: null,
-					observer_model: null,
-					observer_runtime: null,
-					observer_auth_source: null,
-					observer_auth_type: null,
-					observer_error_code: null,
-					observer_error_message: null,
-				})
-				.where(
-					and(
-						inArray(schema.rawEventFlushBatches.id, candidateIds),
-						inArray(schema.rawEventFlushBatches.status, ["failed", "error"]),
-					),
-				)
-				.run();
-
-			return { retried: Number(result.changes ?? 0) };
-		})();
-	});
-}
 
 export interface BackfillTagsTextOptions {
 	limit?: number | null;

--- a/packages/core/src/maintenance/status.ts
+++ b/packages/core/src/maintenance/status.ts
@@ -1,0 +1,147 @@
+/* Raw-event status and retry helpers for the maintenance surface.
+ *
+ * Extracted verbatim from packages/core/src/maintenance.ts as part of
+ * the maintenance/ split (tracked under codemem-ug38).
+ */
+
+import { and, eq, gt, inArray, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "../schema.js";
+import type { RawEventStatusResult } from "./types.js";
+import { withDb } from "./with-db.js";
+
+export function getRawEventStatus(dbPath?: string, limit = 25): RawEventStatusResult {
+	return withDb(dbPath, (db) => {
+		const d = drizzle(db, { schema });
+		const maxEvents = d
+			.select({
+				source: schema.rawEvents.source,
+				stream_id: schema.rawEvents.stream_id,
+				max_seq: sql<number>`MAX(${schema.rawEvents.event_seq})`.as("max_seq"),
+			})
+			.from(schema.rawEvents)
+			.groupBy(schema.rawEvents.source, schema.rawEvents.stream_id)
+			.as("max_events");
+
+		const rows = d
+			.select({
+				source: schema.rawEventSessions.source,
+				stream_id: schema.rawEventSessions.stream_id,
+				opencode_session_id: schema.rawEventSessions.opencode_session_id,
+				cwd: schema.rawEventSessions.cwd,
+				project: schema.rawEventSessions.project,
+				started_at: schema.rawEventSessions.started_at,
+				last_seen_ts_wall_ms: schema.rawEventSessions.last_seen_ts_wall_ms,
+				last_received_event_seq: schema.rawEventSessions.last_received_event_seq,
+				last_flushed_event_seq: schema.rawEventSessions.last_flushed_event_seq,
+				updated_at: schema.rawEventSessions.updated_at,
+			})
+			.from(schema.rawEventSessions)
+			.innerJoin(
+				maxEvents,
+				and(
+					eq(maxEvents.source, schema.rawEventSessions.source),
+					eq(maxEvents.stream_id, schema.rawEventSessions.stream_id),
+				),
+			)
+			.where(gt(maxEvents.max_seq, schema.rawEventSessions.last_flushed_event_seq))
+			.orderBy(sql`${schema.rawEventSessions.updated_at} DESC`)
+			.limit(limit)
+			.all();
+
+		const items = rows.map((row) => {
+			const streamId = String(row.stream_id ?? row.opencode_session_id ?? "");
+			return {
+				source: String(row.source ?? "opencode"),
+				stream_id: streamId,
+				opencode_session_id:
+					row.opencode_session_id == null ? null : String(row.opencode_session_id),
+				cwd: row.cwd == null ? null : String(row.cwd),
+				project: row.project == null ? null : String(row.project),
+				started_at: row.started_at == null ? null : String(row.started_at),
+				last_seen_ts_wall_ms:
+					row.last_seen_ts_wall_ms == null ? null : Number(row.last_seen_ts_wall_ms),
+				last_received_event_seq: Number(row.last_received_event_seq ?? -1),
+				last_flushed_event_seq: Number(row.last_flushed_event_seq ?? -1),
+				updated_at: String(row.updated_at ?? ""),
+				session_stream_id: streamId,
+				session_id: streamId,
+			};
+		});
+
+		const totalsRow = d
+			.select({
+				sessions: sql<number>`COUNT(1)`,
+				pending: sql<
+					number | null
+				>`SUM(${maxEvents.max_seq} - ${schema.rawEventSessions.last_flushed_event_seq})`,
+			})
+			.from(schema.rawEventSessions)
+			.innerJoin(
+				maxEvents,
+				and(
+					eq(maxEvents.source, schema.rawEventSessions.source),
+					eq(maxEvents.stream_id, schema.rawEventSessions.stream_id),
+				),
+			)
+			.where(gt(maxEvents.max_seq, schema.rawEventSessions.last_flushed_event_seq))
+			.get();
+
+		return {
+			items,
+			totals: {
+				pending: Number(totalsRow?.pending ?? 0),
+				sessions: Number(totalsRow?.sessions ?? 0),
+			},
+			ingest: {
+				available: true,
+				mode: "stream_queue",
+				max_body_bytes: 2_000_000,
+			},
+		};
+	});
+}
+
+export function retryRawEventFailures(dbPath?: string, limit = 25): { retried: number } {
+	return withDb(dbPath, (db) => {
+		const d = drizzle(db, { schema });
+		const now = new Date().toISOString();
+		return db.transaction(() => {
+			const candidateIds = d
+				.select({ id: schema.rawEventFlushBatches.id })
+				.from(schema.rawEventFlushBatches)
+				.where(inArray(schema.rawEventFlushBatches.status, ["failed", "error"]))
+				.orderBy(schema.rawEventFlushBatches.updated_at)
+				.limit(limit)
+				.all()
+				.map((row) => Number(row.id));
+
+			if (candidateIds.length === 0) return { retried: 0 };
+
+			const result = d
+				.update(schema.rawEventFlushBatches)
+				.set({
+					status: "pending",
+					updated_at: now,
+					error_message: null,
+					error_type: null,
+					observer_provider: null,
+					observer_model: null,
+					observer_runtime: null,
+					observer_auth_source: null,
+					observer_auth_type: null,
+					observer_error_code: null,
+					observer_error_message: null,
+				})
+				.where(
+					and(
+						inArray(schema.rawEventFlushBatches.id, candidateIds),
+						inArray(schema.rawEventFlushBatches.status, ["failed", "error"]),
+					),
+				)
+				.run();
+
+			return { retried: Number(result.changes ?? 0) };
+		})();
+	});
+}

--- a/packages/core/src/maintenance/with-db.ts
+++ b/packages/core/src/maintenance/with-db.ts
@@ -1,0 +1,20 @@
+/* Shared withDb helper for maintenance job modules — resolves the dbPath,
+ * opens a connection, asserts the schema is ready, then runs the callback
+ * with guaranteed cleanup. Extracted from maintenance.ts as part of the
+ * maintenance/ split (tracked under codemem-ug38). */
+
+import { assertSchemaReady, connect, type Database, resolveDbPath } from "../db.js";
+
+export function withDb<T>(
+	dbPath: string | undefined,
+	fn: (db: Database, resolvedPath: string) => T,
+): T {
+	const resolvedPath = resolveDbPath(dbPath);
+	const db = connect(resolvedPath);
+	try {
+		assertSchemaReady(db);
+		return fn(db, resolvedPath);
+	} finally {
+		db.close();
+	}
+}


### PR DESCRIPTION
## Description

Stacked on #824. Second slice of the `maintenance/` split — moves two raw-event-surface functions out of `maintenance.ts` verbatim, plus the shared `withDb` helper so future slices can share it.

- New `maintenance/with-db.ts` — `withDb` utility (resolve path, open connection, assert schema, run callback, close), moved byte-for-byte from the original internal helper
- New `maintenance/status.ts` — `getRawEventStatus` (backlog status) and `retryRawEventFailures` (requeues failed flush batches), both self-contained once withDb is shared
- `maintenance.ts` re-exports `getRawEventStatus` + `retryRawEventFailures` from the new module so external callers (memory CLI, health tab, tests) stay on the same import path

Left out intentionally this slice:
- `rawEventsGate` — depends on `getReliabilityMetrics` which hasn't been extracted yet; will ride with the `reliability.ts` slice

- Mechanical copy only — function bodies byte-for-byte, no logic rewrite
- `maintenance.ts` drops 2602 → 2458 LOC (cumulative with #824: 2806 → 2458, −12%)

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
