### PR TITLE
refactor(ui): extract feed/pagination.ts — pure page helpers + page-size constants

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -37,13 +37,17 @@ import {
 	sentenceFacts,
 	trustStateLabel,
 } from "./feed/helpers";
+import {
+	countNewItems,
+	isNearFeedBottom,
+	OBSERVATION_PAGE_SIZE,
+	pageHasMore,
+	pageNextOffset,
+	SUMMARY_PAGE_SIZE,
+} from "./feed/pagination";
 import type { FeedItem, FeedItemMetadata, FeedSummary, ItemViewMode } from "./feed/types";
 
-/* ── Constants + module state ─────────────────────────────── */
-
-const OBSERVATION_PAGE_SIZE = 20;
-const SUMMARY_PAGE_SIZE = 50;
-const FEED_SCROLL_THRESHOLD_PX = 560;
+/* ── Module state ─────────────────────────────────────────── */
 
 let lastFeedProject = "";
 let observationOffset = 0;
@@ -92,24 +96,6 @@ function resetPagination(project: string) {
 	state.newItemKeys.clear();
 	state.itemViewState.clear();
 	state.itemExpandState.clear();
-}
-
-function isNearFeedBottom(): boolean {
-	const root = document.documentElement;
-	const height = Math.max(root.scrollHeight, document.body.scrollHeight);
-	return window.innerHeight + window.scrollY >= height - FEED_SCROLL_THRESHOLD_PX;
-}
-
-function pageHasMore(payload: api.PaginatedResponse, count: number, limit: number): boolean {
-	const value = payload.pagination?.has_more;
-	if (typeof value === "boolean") return value;
-	return count >= limit;
-}
-
-function pageNextOffset(payload: api.PaginatedResponse, count: number): number {
-	const value = payload.pagination?.next_offset;
-	if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value;
-	return count;
 }
 
 function hasMorePages(): boolean {
@@ -979,11 +965,6 @@ function computeSignature(items: FeedItem[]): string {
 		(i) => `${itemSignature(i)}:${i.kind || ""}:${i.created_at_utc || i.created_at || ""}`,
 	);
 	return `${state.feedTypeFilter}|${state.feedScopeFilter}|${state.currentProject}|${normalize(state.feedQuery)}|${parts.join("|")}`;
-}
-
-function countNewItems(nextItems: FeedItem[], currentItems: FeedItem[]): number {
-	const seen = new Set(currentItems.map(itemKey));
-	return nextItems.filter((i) => !seen.has(itemKey(i))).length;
 }
 
 async function loadMoreFeedPage() {

--- a/packages/ui/src/tabs/feed/pagination.ts
+++ b/packages/ui/src/tabs/feed/pagination.ts
@@ -1,0 +1,32 @@
+/* Feed pagination — pure helpers + page-size constants. */
+
+import type * as api from "../../lib/api";
+import { itemKey } from "./helpers";
+import type { FeedItem } from "./types";
+
+export const OBSERVATION_PAGE_SIZE = 20;
+export const SUMMARY_PAGE_SIZE = 50;
+export const FEED_SCROLL_THRESHOLD_PX = 560;
+
+export function isNearFeedBottom(): boolean {
+	const root = document.documentElement;
+	const height = Math.max(root.scrollHeight, document.body.scrollHeight);
+	return window.innerHeight + window.scrollY >= height - FEED_SCROLL_THRESHOLD_PX;
+}
+
+export function pageHasMore(payload: api.PaginatedResponse, count: number, limit: number): boolean {
+	const value = payload.pagination?.has_more;
+	if (typeof value === "boolean") return value;
+	return count >= limit;
+}
+
+export function pageNextOffset(payload: api.PaginatedResponse, count: number): number {
+	const value = payload.pagination?.next_offset;
+	if (typeof value === "number" && Number.isFinite(value) && value >= 0) return value;
+	return count;
+}
+
+export function countNewItems(nextItems: FeedItem[], currentItems: FeedItem[]): number {
+	const seen = new Set(currentItems.map(itemKey));
+	return nextItems.filter((i) => !seen.has(itemKey(i))).length;
+}


### PR DESCRIPTION
## Description

Continue the `feed/` split by extracting pagination plumbing — page-size constants and 4 pure helpers (`isNearFeedBottom`, `pageHasMore`, `pageNextOffset`, `countNewItems`) — from `feed.ts` into `feed/pagination.ts`. Stateful pieces (module lets, `resetPagination`, `loadMoreFeedPage`, `maybeLoadMoreFeedPage`, `hasMorePages`) stay in `feed.ts` for a later slice.

- New file `packages/ui/src/tabs/feed/pagination.ts` holds constants + pure functions verbatim
- `feed.ts` imports them; no behavior change
- feed.ts shrinks by ~19 LOC net

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed (pure-function extractions only; no stateful bits moved)

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced