### PR TITLE
refactor(ui): extract feed/sanitize.ts — HTML/Markdown sanitizer

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -45,6 +45,7 @@ import {
 	pageNextOffset,
 	SUMMARY_PAGE_SIZE,
 } from "./feed/pagination";
+import { renderMarkdownSafe } from "./feed/sanitize";
 import type { FeedItem, FeedItemMetadata, FeedSummary, ItemViewMode } from "./feed/types";
 
 /* ── Module state ─────────────────────────────────────────── */
@@ -362,86 +363,6 @@ function shouldClampBody(
 
 function clampClass(mode: ItemViewMode): string[] {
 	return mode === "summary" ? ["clamp", "clamp-3"] : ["clamp", "clamp-5"];
-}
-
-function isSafeHref(value: string): boolean {
-	const href = String(value || "").trim();
-	if (!href) return false;
-	if (href.startsWith("#") || href.startsWith("/")) return true;
-	const lower = href.toLowerCase();
-	return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("mailto:");
-}
-
-function sanitizeHtml(html: string): string {
-	const template = document.createElement("template");
-	template.innerHTML = String(html || "");
-	const allowedTags = new Set([
-		"p",
-		"br",
-		"strong",
-		"em",
-		"code",
-		"pre",
-		"ul",
-		"ol",
-		"li",
-		"blockquote",
-		"a",
-		"h1",
-		"h2",
-		"h3",
-		"h4",
-		"h5",
-		"h6",
-		"hr",
-	]);
-
-	template.content
-		.querySelectorAll("script, iframe, object, embed, link, style")
-		.forEach((node) => {
-			node.remove();
-		});
-
-	template.content.querySelectorAll("*").forEach((node) => {
-		const tag = node.tagName.toLowerCase();
-		if (!allowedTags.has(tag)) {
-			node.replaceWith(document.createTextNode(node.textContent || ""));
-			return;
-		}
-
-		const allowedAttrs = tag === "a" ? new Set(["href", "title"]) : new Set<string>();
-		for (const attr of Array.from(node.attributes)) {
-			const name = attr.name.toLowerCase();
-			if (!allowedAttrs.has(name)) {
-				node.removeAttribute(attr.name);
-			}
-		}
-
-		if (tag === "a") {
-			const href = node.getAttribute("href") || "";
-			if (!isSafeHref(href)) {
-				node.removeAttribute("href");
-			} else {
-				node.setAttribute("rel", "noopener noreferrer");
-				node.setAttribute("target", "_blank");
-			}
-		}
-	});
-
-	return template.innerHTML;
-}
-
-function renderMarkdownSafe(value: string): string {
-	const source = String(value || "");
-	try {
-		const globalMarked = (globalThis as { marked?: { parse: (src: string) => string } }).marked;
-		if (!globalMarked) throw new Error("marked is not available");
-		const rawHtml = globalMarked.parse(source);
-		return sanitizeHtml(rawHtml);
-	} catch {
-		const escaped = source.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-		return escaped;
-	}
 }
 
 /* ── Rendering functions ─────────────────────────────────── */

--- a/packages/ui/src/tabs/feed/sanitize.ts
+++ b/packages/ui/src/tabs/feed/sanitize.ts
@@ -1,0 +1,81 @@
+/* Feed sanitize — HTML/Markdown sanitizer + safe-href check. */
+
+export function isSafeHref(value: string): boolean {
+	const href = String(value || "").trim();
+	if (!href) return false;
+	if (href.startsWith("#") || href.startsWith("/")) return true;
+	const lower = href.toLowerCase();
+	return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("mailto:");
+}
+
+export function sanitizeHtml(html: string): string {
+	const template = document.createElement("template");
+	template.innerHTML = String(html || "");
+	const allowedTags = new Set([
+		"p",
+		"br",
+		"strong",
+		"em",
+		"code",
+		"pre",
+		"ul",
+		"ol",
+		"li",
+		"blockquote",
+		"a",
+		"h1",
+		"h2",
+		"h3",
+		"h4",
+		"h5",
+		"h6",
+		"hr",
+	]);
+
+	template.content
+		.querySelectorAll("script, iframe, object, embed, link, style")
+		.forEach((node) => {
+			node.remove();
+		});
+
+	template.content.querySelectorAll("*").forEach((node) => {
+		const tag = node.tagName.toLowerCase();
+		if (!allowedTags.has(tag)) {
+			node.replaceWith(document.createTextNode(node.textContent || ""));
+			return;
+		}
+
+		const allowedAttrs = tag === "a" ? new Set(["href", "title"]) : new Set<string>();
+		for (const attr of Array.from(node.attributes)) {
+			const name = attr.name.toLowerCase();
+			if (!allowedAttrs.has(name)) {
+				node.removeAttribute(attr.name);
+			}
+		}
+
+		if (tag === "a") {
+			const href = node.getAttribute("href") || "";
+			if (!isSafeHref(href)) {
+				node.removeAttribute("href");
+			} else {
+				node.setAttribute("rel", "noopener noreferrer");
+				node.setAttribute("target", "_blank");
+			}
+		}
+	});
+
+	return template.innerHTML;
+}
+
+export function renderMarkdownSafe(value: string): string {
+	const source = String(value || "");
+	try {
+		const globalMarked = (globalThis as { marked?: { parse: (src: string) => string } }).marked;
+		if (!globalMarked) throw new Error("marked is not available");
+		const rawHtml = globalMarked.parse(source);
+		return sanitizeHtml(rawHtml);
+	} catch {
+		const escaped = source.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+		return escaped;
+	}
+}


### PR DESCRIPTION
## Description

Continue the `feed/` split by extracting HTML/Markdown sanitization — `isSafeHref`, `sanitizeHtml`, `renderMarkdownSafe` — into `feed/sanitize.ts`. All three are fully self-contained (no state, no feed-specific imports), so the move is verbatim with no behavior change.

- New file `packages/ui/src/tabs/feed/sanitize.ts` exports the three sanitizer helpers
- `feed.ts` imports `renderMarkdownSafe` (the only sanitize function called at feed-tab callsites); `isSafeHref` and `sanitizeHtml` are used internally by the module and re-exported

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed (pure extraction; no semantic change)

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced