### PR TITLE
refactor(core): extract maintenance/narrative-extract.ts — pure body-text parser

### DIFF
--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -1833,23 +1833,9 @@ type DedupKeyCandidateRow = {
  * sections found in session_summary body_text. Returns null if the body
  * doesn't match the expected structure.
  */
-export function extractNarrativeFromBody(bodyText: string): string | null {
-	// Match sections like "## Completed\n...\n\n## Learned\n..."
-	const sections: string[] = [];
+export { extractNarrativeFromBody } from "./maintenance/narrative-extract.js";
 
-	const completedMatch = bodyText.match(/##\s*Completed\s*\n([\s\S]*?)(?=\n##\s|\n*$)/);
-	if (completedMatch?.[1]?.trim()) {
-		sections.push(completedMatch[1].trim());
-	}
-
-	const learnedMatch = bodyText.match(/##\s*Learned\s*\n([\s\S]*?)(?=\n##\s|\n*$)/);
-	if (learnedMatch?.[1]?.trim()) {
-		sections.push(learnedMatch[1].trim());
-	}
-
-	if (sections.length === 0) return null;
-	return sections.join("\n\n");
-}
+import { extractNarrativeFromBody } from "./maintenance/narrative-extract.js";
 
 /**
  * Backfill narrative for session_summary memories that have structured

--- a/packages/core/src/maintenance/narrative-extract.ts
+++ b/packages/core/src/maintenance/narrative-extract.ts
@@ -1,0 +1,24 @@
+/* Narrative extraction from session-summary body text.
+ *
+ * Extracted verbatim from packages/core/src/maintenance.ts as part of
+ * the maintenance/ split (tracked under codemem-ug38). Pure — no db,
+ * no imports, no side effects.
+ */
+
+export function extractNarrativeFromBody(bodyText: string): string | null {
+	// Match sections like "## Completed\n...\n\n## Learned\n..."
+	const sections: string[] = [];
+
+	const completedMatch = bodyText.match(/##\s*Completed\s*\n([\s\S]*?)(?=\n##\s|\n*$)/);
+	if (completedMatch?.[1]?.trim()) {
+		sections.push(completedMatch[1].trim());
+	}
+
+	const learnedMatch = bodyText.match(/##\s*Learned\s*\n([\s\S]*?)(?=\n##\s|\n*$)/);
+	if (learnedMatch?.[1]?.trim()) {
+		sections.push(learnedMatch[1].trim());
+	}
+
+	if (sections.length === 0) return null;
+	return sections.join("\n\n");
+}


### PR DESCRIPTION
## Description

Small self-contained slice of the `maintenance/` split: move the pure `extractNarrativeFromBody` parser into its own module. No dependencies, no state, no db — just a regex-based section extractor. `maintenance.ts` keeps a re-export so the public surface is unchanged.

- New file `packages/core/src/maintenance/narrative-extract.ts`
- `maintenance.ts` re-exports from the new location

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced