### PR TITLE
refactor(core): extract maintenance/low-signal.ts — low-signal memory deactivation

### DIFF
--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -9,7 +9,6 @@ import {
 	resolveDbPath,
 } from "./db.js";
 import { getInjectionEvalScenarioByPrompt } from "./eval-scenarios.js";
-import { isLowSignalObservation } from "./ingest-filters.js";
 import { deriveTags, parseJsonStringList } from "./maintenance/tag-helpers.js";
 import { withDb } from "./maintenance/with-db.js";
 import {
@@ -1249,105 +1248,14 @@ export function backfillTagsText(
 	return { checked, updated, skipped };
 }
 
-export interface DeactivateLowSignalResult {
-	checked: number;
-	deactivated: number;
-}
-
-export interface DeactivateLowSignalMemoriesOptions {
-	kinds?: string[] | null;
-	limit?: number | null;
-	dryRun?: boolean;
-}
-
-const DEFAULT_LOW_SIGNAL_KINDS = [
-	"observation",
-	"discovery",
-	"change",
-	"feature",
-	"bugfix",
-	"refactor",
-	"decision",
-	"note",
-	"entities",
-	"session_summary",
-];
-
-const OBSERVATION_EQUIVALENT_KINDS = [
-	"observation",
-	"bugfix",
-	"feature",
-	"refactor",
-	"change",
-	"discovery",
-	"decision",
-	"exploration",
-];
-
-/**
- * Deactivate low-signal observations only.
- */
-export function deactivateLowSignalObservations(
-	db: Database,
-	limit?: number | null,
-	dryRun = false,
-): DeactivateLowSignalResult {
-	return deactivateLowSignalMemories(db, {
-		kinds: OBSERVATION_EQUIVALENT_KINDS,
-		limit,
-		dryRun,
-	});
-}
-
-/**
- * Deactivate low-signal memories across selected kinds (does not delete rows).
- */
-export function deactivateLowSignalMemories(
-	db: Database,
-	opts: DeactivateLowSignalMemoriesOptions = {},
-): DeactivateLowSignalResult {
-	const selectedKinds =
-		opts.kinds?.map((kind) => kind.trim()).filter((kind) => kind.length > 0) ?? [];
-	const kinds = selectedKinds.length > 0 ? selectedKinds : DEFAULT_LOW_SIGNAL_KINDS;
-	const placeholders = kinds.map(() => "?").join(",");
-	const params: unknown[] = [...kinds];
-	let limitClause = "";
-	if (opts.limit != null && opts.limit > 0) {
-		limitClause = "LIMIT ?";
-		params.push(opts.limit);
-	}
-
-	const rows = db
-		.prepare(
-			`SELECT id, title, body_text
-			 FROM memory_items
-			 WHERE kind IN (${placeholders}) AND active = 1
-			 ORDER BY id DESC
-			 ${limitClause}`,
-		)
-		.all(...params) as Array<{ id: number; title: string | null; body_text: string | null }>;
-
-	const checked = rows.length;
-	const ids = rows
-		.filter((row) => isLowSignalObservation(row.body_text || row.title || ""))
-		.map((row) => Number(row.id));
-
-	if (ids.length === 0 || opts.dryRun === true) {
-		return { checked, deactivated: ids.length };
-	}
-
-	const now = new Date().toISOString();
-	const chunkSize = 200;
-	for (let start = 0; start < ids.length; start += chunkSize) {
-		const chunk = ids.slice(start, start + chunkSize);
-		const chunkPlaceholders = chunk.map(() => "?").join(",");
-		db.prepare(
-			`UPDATE memory_items SET active = 0, updated_at = ? WHERE id IN (${chunkPlaceholders})`,
-		).run(now, ...chunk);
-	}
-
-	return { checked, deactivated: ids.length };
-}
+export type {
+	DeactivateLowSignalMemoriesOptions,
+	DeactivateLowSignalResult,
+} from "./maintenance/low-signal.js";
+export {
+	deactivateLowSignalMemories,
+	deactivateLowSignalObservations,
+} from "./maintenance/low-signal.js";
 
 // ---------------------------------------------------------------------------
 // Retroactive near-duplicate deactivation

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -10,6 +10,7 @@ import {
 } from "./db.js";
 import { getInjectionEvalScenarioByPrompt } from "./eval-scenarios.js";
 import { isLowSignalObservation } from "./ingest-filters.js";
+import { deriveTags, parseJsonStringList } from "./maintenance/tag-helpers.js";
 import { withDb } from "./maintenance/with-db.js";
 import {
 	completeMaintenanceJob,
@@ -1149,87 +1150,6 @@ export interface BackfillTagsTextResult {
 	checked: number;
 	updated: number;
 	skipped: number;
-}
-
-function normalizeTag(value: string): string {
-	let normalized = value.trim().toLowerCase();
-	if (!normalized) return "";
-	normalized = normalized.replace(/[^a-z0-9_]+/g, "-");
-	normalized = normalized.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
-	if (!normalized) return "";
-	if (normalized.length > 40) normalized = normalized.slice(0, 40).replace(/-+$/g, "");
-	return normalized;
-}
-
-function fileTags(pathValue: string): string[] {
-	const raw = pathValue.trim();
-	if (!raw) return [];
-	const parts = raw.split(/[\\/]+/).filter((part) => part && part !== "." && part !== "..");
-	if (parts.length === 0) return [];
-	const tags: string[] = [];
-	const basename = normalizeTag(parts[parts.length - 1] ?? "");
-	if (basename) tags.push(basename);
-	if (parts.length >= 2) {
-		const parent = normalizeTag(parts[parts.length - 2] ?? "");
-		if (parent) tags.push(parent);
-	}
-	if (parts.length >= 3) {
-		const top = normalizeTag(parts[0] ?? "");
-		if (top) tags.push(top);
-	}
-	return tags;
-}
-
-function parseJsonStringList(value: string | null): string[] {
-	if (!value) return [];
-	try {
-		const parsed = JSON.parse(value) as unknown;
-		if (!Array.isArray(parsed)) return [];
-		return parsed
-			.map((item) => (typeof item === "string" ? item.trim() : ""))
-			.filter((item) => item.length > 0);
-	} catch {
-		return [];
-	}
-}
-
-function deriveTags(input: {
-	kind: string;
-	title: string;
-	concepts: string[];
-	filesRead: string[];
-	filesModified: string[];
-}): string[] {
-	const tags: string[] = [];
-	const kindTag = normalizeTag(input.kind);
-	if (kindTag) tags.push(kindTag);
-
-	for (const concept of input.concepts) {
-		const tag = normalizeTag(concept);
-		if (tag) tags.push(tag);
-	}
-
-	for (const filePath of [...input.filesRead, ...input.filesModified]) {
-		tags.push(...fileTags(filePath));
-	}
-
-	if (tags.length === 0 && input.title.trim()) {
-		const tokens = input.title.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
-		for (const token of tokens) {
-			const tag = normalizeTag(token);
-			if (tag) tags.push(tag);
-		}
-	}
-
-	const deduped: string[] = [];
-	const seen = new Set<string>();
-	for (const tag of tags) {
-		if (seen.has(tag)) continue;
-		seen.add(tag);
-		deduped.push(tag);
-		if (deduped.length >= 20) break;
-	}
-	return deduped;
 }
 
 /**

--- a/packages/core/src/maintenance/low-signal.ts
+++ b/packages/core/src/maintenance/low-signal.ts
@@ -1,0 +1,108 @@
+/* Low-signal memory deactivation for the maintenance surface.
+ *
+ * Extracted verbatim from packages/core/src/maintenance.ts as part of
+ * the maintenance/ split (tracked under codemem-ug38).
+ */
+
+import type { Database } from "../db.js";
+import { isLowSignalObservation } from "../ingest-filters.js";
+
+export interface DeactivateLowSignalResult {
+	checked: number;
+	deactivated: number;
+}
+
+export interface DeactivateLowSignalMemoriesOptions {
+	kinds?: string[] | null;
+	limit?: number | null;
+	dryRun?: boolean;
+}
+
+const DEFAULT_LOW_SIGNAL_KINDS = [
+	"observation",
+	"discovery",
+	"change",
+	"feature",
+	"bugfix",
+	"refactor",
+	"decision",
+	"note",
+	"entities",
+	"session_summary",
+];
+
+const OBSERVATION_EQUIVALENT_KINDS = [
+	"observation",
+	"bugfix",
+	"feature",
+	"refactor",
+	"change",
+	"discovery",
+	"decision",
+	"exploration",
+];
+
+/**
+ * Deactivate low-signal observations only.
+ */
+export function deactivateLowSignalObservations(
+	db: Database,
+	limit?: number | null,
+	dryRun = false,
+): DeactivateLowSignalResult {
+	return deactivateLowSignalMemories(db, {
+		kinds: OBSERVATION_EQUIVALENT_KINDS,
+		limit,
+		dryRun,
+	});
+}
+
+/**
+ * Deactivate low-signal memories across selected kinds (does not delete rows).
+ */
+export function deactivateLowSignalMemories(
+	db: Database,
+	opts: DeactivateLowSignalMemoriesOptions = {},
+): DeactivateLowSignalResult {
+	const selectedKinds =
+		opts.kinds?.map((kind) => kind.trim()).filter((kind) => kind.length > 0) ?? [];
+	const kinds = selectedKinds.length > 0 ? selectedKinds : DEFAULT_LOW_SIGNAL_KINDS;
+	const placeholders = kinds.map(() => "?").join(",");
+	const params: unknown[] = [...kinds];
+	let limitClause = "";
+	if (opts.limit != null && opts.limit > 0) {
+		limitClause = "LIMIT ?";
+		params.push(opts.limit);
+	}
+
+	const rows = db
+		.prepare(
+			`SELECT id, title, body_text
+			 FROM memory_items
+			 WHERE kind IN (${placeholders}) AND active = 1
+			 ORDER BY id DESC
+			 ${limitClause}`,
+		)
+		.all(...params) as Array<{ id: number; title: string | null; body_text: string | null }>;
+
+	const checked = rows.length;
+	const ids = rows
+		.filter((row) => isLowSignalObservation(row.body_text || row.title || ""))
+		.map((row) => Number(row.id));
+
+	if (ids.length === 0 || opts.dryRun === true) {
+		return { checked, deactivated: ids.length };
+	}
+
+	const now = new Date().toISOString();
+	const chunkSize = 200;
+	for (let start = 0; start < ids.length; start += chunkSize) {
+		const chunk = ids.slice(start, start + chunkSize);
+		const chunkPlaceholders = chunk.map(() => "?").join(",");
+		db.prepare(
+			`UPDATE memory_items SET active = 0, updated_at = ? WHERE id IN (${chunkPlaceholders})`,
+		).run(now, ...chunk);
+	}
+
+	return { checked, deactivated: ids.length };
+}

--- a/packages/core/src/maintenance/tag-helpers.ts
+++ b/packages/core/src/maintenance/tag-helpers.ts
@@ -1,0 +1,87 @@
+/* Tag-derivation helpers for the memory_items.tags_text backfill.
+ *
+ * Extracted verbatim from packages/core/src/maintenance.ts as part of
+ * the maintenance/ split (tracked under codemem-ug38). Pure — no db,
+ * no side effects.
+ */
+
+export function normalizeTag(value: string): string {
+	let normalized = value.trim().toLowerCase();
+	if (!normalized) return "";
+	normalized = normalized.replace(/[^a-z0-9_]+/g, "-");
+	normalized = normalized.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
+	if (!normalized) return "";
+	if (normalized.length > 40) normalized = normalized.slice(0, 40).replace(/-+$/g, "");
+	return normalized;
+}
+
+export function fileTags(pathValue: string): string[] {
+	const raw = pathValue.trim();
+	if (!raw) return [];
+	const parts = raw.split(/[\\/]+/).filter((part) => part && part !== "." && part !== "..");
+	if (parts.length === 0) return [];
+	const tags: string[] = [];
+	const basename = normalizeTag(parts[parts.length - 1] ?? "");
+	if (basename) tags.push(basename);
+	if (parts.length >= 2) {
+		const parent = normalizeTag(parts[parts.length - 2] ?? "");
+		if (parent) tags.push(parent);
+	}
+	if (parts.length >= 3) {
+		const top = normalizeTag(parts[0] ?? "");
+		if (top) tags.push(top);
+	}
+	return tags;
+}
+
+export function parseJsonStringList(value: string | null): string[] {
+	if (!value) return [];
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		return parsed
+			.map((item) => (typeof item === "string" ? item.trim() : ""))
+			.filter((item) => item.length > 0);
+	} catch {
+		return [];
+	}
+}
+
+export function deriveTags(input: {
+	kind: string;
+	title: string;
+	concepts: string[];
+	filesRead: string[];
+	filesModified: string[];
+}): string[] {
+	const tags: string[] = [];
+	const kindTag = normalizeTag(input.kind);
+	if (kindTag) tags.push(kindTag);
+
+	for (const concept of input.concepts) {
+		const tag = normalizeTag(concept);
+		if (tag) tags.push(tag);
+	}
+
+	for (const filePath of [...input.filesRead, ...input.filesModified]) {
+		tags.push(...fileTags(filePath));
+	}
+
+	if (tags.length === 0 && input.title.trim()) {
+		const tokens = input.title.toLowerCase().match(/[a-z0-9_]+/g) ?? [];
+		for (const token of tokens) {
+			const tag = normalizeTag(token);
+			if (tag) tags.push(tag);
+		}
+	}
+
+	const deduped: string[] = [];
+	const seen = new Set<string>();
+	for (const tag of tags) {
+		if (seen.has(tag)) continue;
+		seen.add(tag);
+		deduped.push(tag);
+		if (deduped.length >= 20) break;
+	}
+	return deduped;
+}


### PR DESCRIPTION
## Description

Continue the \`maintenance/\` split by moving low-signal memory deactivation — \`deactivateLowSignalObservations\`, \`deactivateLowSignalMemories\`, their result/options types, and the two kind-lists — into \`maintenance/low-signal.ts\`. Verbatim; \`maintenance.ts\` re-exports so the public surface is unchanged. \`isLowSignalObservation\` import is dropped from \`maintenance.ts\` since it's now only used inside the new module.

- New file \`packages/core/src/maintenance/low-signal.ts\`
- \`maintenance.ts\` shrinks by ~95 LOC
- No runtime behavior change

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced