### PR TITLE
refactor(ui): extract feed/observation-view.ts — view-mode selection helpers

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -45,6 +45,7 @@ import {
 	pageNextOffset,
 	SUMMARY_PAGE_SIZE,
 } from "./feed/pagination";
+import { renderMarkdownSafe } from "./feed/sanitize";
 import type { FeedItem, FeedItemMetadata, FeedSummary, ItemViewMode } from "./feed/types";
 
 /* ── Module state ─────────────────────────────────────────── */
@@ -362,86 +363,6 @@ function shouldClampBody(
 
 function clampClass(mode: ItemViewMode): string[] {
 	return mode === "summary" ? ["clamp", "clamp-3"] : ["clamp", "clamp-5"];
-}
-
-function isSafeHref(value: string): boolean {
-	const href = String(value || "").trim();
-	if (!href) return false;
-	if (href.startsWith("#") || href.startsWith("/")) return true;
-	const lower = href.toLowerCase();
-	return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("mailto:");
-}
-
-function sanitizeHtml(html: string): string {
-	const template = document.createElement("template");
-	template.innerHTML = String(html || "");
-	const allowedTags = new Set([
-		"p",
-		"br",
-		"strong",
-		"em",
-		"code",
-		"pre",
-		"ul",
-		"ol",
-		"li",
-		"blockquote",
-		"a",
-		"h1",
-		"h2",
-		"h3",
-		"h4",
-		"h5",
-		"h6",
-		"hr",
-	]);
-
-	template.content
-		.querySelectorAll("script, iframe, object, embed, link, style")
-		.forEach((node) => {
-			node.remove();
-		});
-
-	template.content.querySelectorAll("*").forEach((node) => {
-		const tag = node.tagName.toLowerCase();
-		if (!allowedTags.has(tag)) {
-			node.replaceWith(document.createTextNode(node.textContent || ""));
-			return;
-		}
-
-		const allowedAttrs = tag === "a" ? new Set(["href", "title"]) : new Set<string>();
-		for (const attr of Array.from(node.attributes)) {
-			const name = attr.name.toLowerCase();
-			if (!allowedAttrs.has(name)) {
-				node.removeAttribute(attr.name);
-			}
-		}
-
-		if (tag === "a") {
-			const href = node.getAttribute("href") || "";
-			if (!isSafeHref(href)) {
-				node.removeAttribute("href");
-			} else {
-				node.setAttribute("rel", "noopener noreferrer");
-				node.setAttribute("target", "_blank");
-			}
-		}
-	});
-
-	return template.innerHTML;
-}
-
-function renderMarkdownSafe(value: string): string {
-	const source = String(value || "");
-	try {
-		const globalMarked = (globalThis as { marked?: { parse: (src: string) => string } }).marked;
-		if (!globalMarked) throw new Error("marked is not available");
-		const rawHtml = globalMarked.parse(source);
-		return sanitizeHtml(rawHtml);
-	} catch {
-		const escaped = source.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-		return escaped;
-	}
 }
 
 /* ── Rendering functions ─────────────────────────────────── */

--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -34,7 +34,6 @@ import {
 	mergeFeedItems,
 	mergeMetadata,
 	mergeRefreshFeedItems,
-	sentenceFacts,
 	trustStateLabel,
 } from "./feed/helpers";
 import {
@@ -306,64 +305,15 @@ function _getFactsList(item: FeedItem): string[] {
 	return extractFactsFromBody(String(item?.body_text || ""));
 }
 
-/* ── Observation view helpers ────────────────────────────── */
+export { observationViewData } from "./feed/observation-view";
 
-export function observationViewData(item: FeedItem) {
-	const metadata = mergeMetadata(item?.metadata_json);
-	const summary = String(item?.subtitle || metadata?.subtitle || "").trim();
-	const narrative = String(item?.narrative || metadata?.narrative || item?.body_text || "").trim();
-	const normSummary = normalize(summary);
-	const normNarrative = normalize(narrative);
-	const narrativeDistinct = Boolean(narrative) && normNarrative !== normSummary;
-	const explicitFacts = parseJsonArray(item?.facts || metadata?.facts || []);
-	const fallbackFacts = explicitFacts.length
-		? explicitFacts
-		: extractFactsFromBody(narrative || summary);
-	const derivedFacts = fallbackFacts.length ? fallbackFacts : sentenceFacts(narrative || summary);
-	return {
-		summary,
-		narrative,
-		facts: derivedFacts,
-		hasSummary: Boolean(summary),
-		hasFacts: derivedFacts.length > 0,
-		hasNarrative: narrativeDistinct,
-	};
-}
-
-function observationViewModes(data: {
-	hasSummary: boolean;
-	hasFacts: boolean;
-	hasNarrative: boolean;
-}): Array<{ id: ItemViewMode; label: string }> {
-	const modes: Array<{ id: ItemViewMode; label: string }> = [];
-	if (data.hasSummary) modes.push({ id: "summary", label: "Summary" });
-	if (data.hasFacts) modes.push({ id: "facts", label: "Facts" });
-	if (data.hasNarrative) modes.push({ id: "narrative", label: "Narrative" });
-	return modes;
-}
-
-function defaultObservationView(data: {
-	hasSummary: boolean;
-	hasFacts: boolean;
-	hasNarrative: boolean;
-}): ItemViewMode {
-	if (data.hasSummary) return "summary";
-	if (data.hasFacts) return "facts";
-	return "narrative";
-}
-
-function shouldClampBody(
-	mode: ItemViewMode,
-	data: { summary: string; narrative: string },
-): boolean {
-	if (mode === "facts") return false;
-	if (mode === "summary") return data.summary.length > 260;
-	return data.narrative.length > 320;
-}
-
-function clampClass(mode: ItemViewMode): string[] {
-	return mode === "summary" ? ["clamp", "clamp-3"] : ["clamp", "clamp-5"];
-}
+import {
+	clampClass,
+	defaultObservationView,
+	observationViewData,
+	observationViewModes,
+	shouldClampBody,
+} from "./feed/observation-view";
 
 /* ── Rendering functions ─────────────────────────────────── */
 

--- a/packages/ui/src/tabs/feed/observation-view.ts
+++ b/packages/ui/src/tabs/feed/observation-view.ts
@@ -1,0 +1,63 @@
+/* Observation view-mode helpers — pure selection logic for toggling
+ * between "summary", "facts", and "narrative" presentations of a feed item. */
+
+import { normalize, parseJsonArray } from "../../lib/format";
+import { extractFactsFromBody, mergeMetadata, sentenceFacts } from "./helpers";
+import type { FeedItem, ItemViewMode } from "./types";
+
+export function observationViewData(item: FeedItem) {
+	const metadata = mergeMetadata(item?.metadata_json);
+	const summary = String(item?.subtitle || metadata?.subtitle || "").trim();
+	const narrative = String(item?.narrative || metadata?.narrative || item?.body_text || "").trim();
+	const normSummary = normalize(summary);
+	const normNarrative = normalize(narrative);
+	const narrativeDistinct = Boolean(narrative) && normNarrative !== normSummary;
+	const explicitFacts = parseJsonArray(item?.facts || metadata?.facts || []);
+	const fallbackFacts = explicitFacts.length
+		? explicitFacts
+		: extractFactsFromBody(narrative || summary);
+	const derivedFacts = fallbackFacts.length ? fallbackFacts : sentenceFacts(narrative || summary);
+	return {
+		summary,
+		narrative,
+		facts: derivedFacts,
+		hasSummary: Boolean(summary),
+		hasFacts: derivedFacts.length > 0,
+		hasNarrative: narrativeDistinct,
+	};
+}
+
+export function observationViewModes(data: {
+	hasSummary: boolean;
+	hasFacts: boolean;
+	hasNarrative: boolean;
+}): Array<{ id: ItemViewMode; label: string }> {
+	const modes: Array<{ id: ItemViewMode; label: string }> = [];
+	if (data.hasSummary) modes.push({ id: "summary", label: "Summary" });
+	if (data.hasFacts) modes.push({ id: "facts", label: "Facts" });
+	if (data.hasNarrative) modes.push({ id: "narrative", label: "Narrative" });
+	return modes;
+}
+
+export function defaultObservationView(data: {
+	hasSummary: boolean;
+	hasFacts: boolean;
+	hasNarrative: boolean;
+}): ItemViewMode {
+	if (data.hasSummary) return "summary";
+	if (data.hasFacts) return "facts";
+	return "narrative";
+}
+
+export function shouldClampBody(
+	mode: ItemViewMode,
+	data: { summary: string; narrative: string },
+): boolean {
+	if (mode === "facts") return false;
+	if (mode === "summary") return data.summary.length > 260;
+	return data.narrative.length > 320;
+}
+
+export function clampClass(mode: ItemViewMode): string[] {
+	return mode === "summary" ? ["clamp", "clamp-3"] : ["clamp", "clamp-5"];
+}

--- a/packages/ui/src/tabs/feed/sanitize.ts
+++ b/packages/ui/src/tabs/feed/sanitize.ts
@@ -1,0 +1,81 @@
+/* Feed sanitize — HTML/Markdown sanitizer + safe-href check. */
+
+export function isSafeHref(value: string): boolean {
+	const href = String(value || "").trim();
+	if (!href) return false;
+	if (href.startsWith("#") || href.startsWith("/")) return true;
+	const lower = href.toLowerCase();
+	return lower.startsWith("http://") || lower.startsWith("https://") || lower.startsWith("mailto:");
+}
+
+export function sanitizeHtml(html: string): string {
+	const template = document.createElement("template");
+	template.innerHTML = String(html || "");
+	const allowedTags = new Set([
+		"p",
+		"br",
+		"strong",
+		"em",
+		"code",
+		"pre",
+		"ul",
+		"ol",
+		"li",
+		"blockquote",
+		"a",
+		"h1",
+		"h2",
+		"h3",
+		"h4",
+		"h5",
+		"h6",
+		"hr",
+	]);
+
+	template.content
+		.querySelectorAll("script, iframe, object, embed, link, style")
+		.forEach((node) => {
+			node.remove();
+		});
+
+	template.content.querySelectorAll("*").forEach((node) => {
+		const tag = node.tagName.toLowerCase();
+		if (!allowedTags.has(tag)) {
+			node.replaceWith(document.createTextNode(node.textContent || ""));
+			return;
+		}
+
+		const allowedAttrs = tag === "a" ? new Set(["href", "title"]) : new Set<string>();
+		for (const attr of Array.from(node.attributes)) {
+			const name = attr.name.toLowerCase();
+			if (!allowedAttrs.has(name)) {
+				node.removeAttribute(attr.name);
+			}
+		}
+
+		if (tag === "a") {
+			const href = node.getAttribute("href") || "";
+			if (!isSafeHref(href)) {
+				node.removeAttribute("href");
+			} else {
+				node.setAttribute("rel", "noopener noreferrer");
+				node.setAttribute("target", "_blank");
+			}
+		}
+	});
+
+	return template.innerHTML;
+}
+
+export function renderMarkdownSafe(value: string): string {
+	const source = String(value || "");
+	try {
+		const globalMarked = (globalThis as { marked?: { parse: (src: string) => string } }).marked;
+		if (!globalMarked) throw new Error("marked is not available");
+		const rawHtml = globalMarked.parse(source);
+		return sanitizeHtml(rawHtml);
+	} catch {
+		const escaped = source.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+		return escaped;
+	}
+}


### PR DESCRIPTION
## Description

Continue the \`feed/\` split by moving the view-mode selection helpers — \`observationViewData\`, \`observationViewModes\`, \`defaultObservationView\`, \`shouldClampBody\`, \`clampClass\` — into \`feed/observation-view.ts\`. All five are pure; \`feed.ts\` keeps the \`observationViewData\` re-export since it's consumed by tests. Drops the now-unused \`sentenceFacts\` import from \`feed.ts\`.

- New file \`packages/ui/src/tabs/feed/observation-view.ts\`
- \`feed.ts\` shrinks by ~55 LOC
- No runtime behavior change; existing tests in \`feed.test.ts\` still cover \`observationViewData\`

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced