### PR TITLE
refactor(core): extract maintenance/backfill-narrative.ts — session-summary narrative backfill

### DIFF
--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -1271,17 +1271,6 @@ export { dedupNearDuplicateMemories } from "./maintenance/dedup.js";
 // Heuristic narrative extraction from session_summary body_text
 // ---------------------------------------------------------------------------
 
-export interface BackfillNarrativeResult {
-	checked: number;
-	updated: number;
-	skipped: number;
-}
-
-export interface BackfillNarrativeOptions {
-	limit?: number | null;
-	dryRun?: boolean;
-}
-
 export interface BackfillDedupKeysResult {
 	checked: number;
 	updated: number;
@@ -1316,71 +1305,12 @@ type DedupKeyCandidateRow = {
 	active: number;
 };
 
-/**
- * Extract a narrative from the structured `## Completed` / `## Learned`
- * sections found in session_summary body_text. Returns null if the body
- * doesn't match the expected structure.
- */
+export type {
+	BackfillNarrativeOptions,
+	BackfillNarrativeResult,
+} from "./maintenance/backfill-narrative.js";
+export { backfillNarrativeFromBody } from "./maintenance/backfill-narrative.js";
 export { extractNarrativeFromBody } from "./maintenance/narrative-extract.js";
-
-import { extractNarrativeFromBody } from "./maintenance/narrative-extract.js";
-
-/**
- * Backfill narrative for session_summary memories that have structured
- * body_text with `## Completed` / `## Learned` sections but no narrative.
- *
- * Only touches session_summary kind. Does not overwrite existing narratives.
- */
-export function backfillNarrativeFromBody(
-	db: Database,
-	opts: BackfillNarrativeOptions = {},
-): BackfillNarrativeResult {
-	const limitClause = opts.limit != null && opts.limit > 0 ? `LIMIT ${Number(opts.limit)}` : "";
-
-	const rows = db
-		.prepare(
-			`SELECT id, body_text
-			 FROM memory_items
-			 WHERE kind = 'session_summary'
-			   AND active = 1
-			   AND (narrative IS NULL OR LENGTH(narrative) = 0)
-			   AND body_text IS NOT NULL
-			   AND LENGTH(body_text) > 0
-			 ORDER BY created_at ASC
-			 ${limitClause}`,
-		)
-		.all() as Array<{ id: number; body_text: string }>;
-
-	let checked = 0;
-	let updated = 0;
-	let skipped = 0;
-	const updates: Array<{ id: number; narrative: string }> = [];
-
-	for (const row of rows) {
-		checked++;
-		const narrative = extractNarrativeFromBody(row.body_text);
-		if (!narrative) {
-			skipped++;
-			continue;
-		}
-		updates.push({ id: row.id, narrative });
-		updated++;
-	}
-
-	if (updates.length > 0 && opts.dryRun !== true) {
-		const now = new Date().toISOString();
-		const updateStmt = db.prepare(
-			"UPDATE memory_items SET narrative = ?, updated_at = ? WHERE id = ?",
-		);
-		db.transaction(() => {
-			for (const update of updates) {
-				updateStmt.run(update.narrative, now, update.id);
-			}
-		})();
-	}
-
-	return { checked, updated, skipped };
-}
 
 function selectDedupKeyCandidateRows(
 	db: Database,

--- a/packages/core/src/maintenance/backfill-narrative.ts
+++ b/packages/core/src/maintenance/backfill-narrative.ts
@@ -1,0 +1,76 @@
+/* Narrative backfill for session_summary memories.
+ *
+ * Extracted verbatim from packages/core/src/maintenance.ts as part of
+ * the maintenance/ split (tracked under codemem-ug38).
+ */
+
+import type { Database } from "../db.js";
+import { extractNarrativeFromBody } from "./narrative-extract.js";
+
+export interface BackfillNarrativeResult {
+	checked: number;
+	updated: number;
+	skipped: number;
+}
+
+export interface BackfillNarrativeOptions {
+	limit?: number | null;
+	dryRun?: boolean;
+}
+
+/**
+ * Backfill narrative for session_summary memories that have structured
+ * body_text with `## Completed` / `## Learned` sections but no narrative.
+ *
+ * Only touches session_summary kind. Does not overwrite existing narratives.
+ */
+export function backfillNarrativeFromBody(
+	db: Database,
+	opts: BackfillNarrativeOptions = {},
+): BackfillNarrativeResult {
+	const limitClause = opts.limit != null && opts.limit > 0 ? `LIMIT ${Number(opts.limit)}` : "";
+
+	const rows = db
+		.prepare(
+			`SELECT id, body_text
+			 FROM memory_items
+			 WHERE kind = 'session_summary'
+			   AND active = 1
+			   AND (narrative IS NULL OR LENGTH(narrative) = 0)
+			   AND body_text IS NOT NULL
+			   AND LENGTH(body_text) > 0
+			 ORDER BY created_at ASC
+			 ${limitClause}`,
+		)
+		.all() as Array<{ id: number; body_text: string }>;
+
+	let checked = 0;
+	let updated = 0;
+	let skipped = 0;
+	const updates: Array<{ id: number; narrative: string }> = [];
+
+	for (const row of rows) {
+		checked++;
+		const narrative = extractNarrativeFromBody(row.body_text);
+		if (!narrative) {
+			skipped++;
+			continue;
+		}
+		updates.push({ id: row.id, narrative });
+		updated++;
+	}
+
+	if (updates.length > 0 && opts.dryRun !== true) {
+		const now = new Date().toISOString();
+		const updateStmt = db.prepare(
+			"UPDATE memory_items SET narrative = ?, updated_at = ? WHERE id = ?",
+		);
+		db.transaction(() => {
+			for (const update of updates) {
+				updateStmt.run(update.narrative, now, update.id);
+			}
+		})();
+	}
+
+	return { checked, updated, skipped };
+}


### PR DESCRIPTION
## Description

Stacked on top of #836. Move \`backfillNarrativeFromBody\` (plus its result/options types) into \`maintenance/backfill-narrative.ts\`. It depends on \`extractNarrativeFromBody\` from the earlier \`maintenance/narrative-extract.ts\` module, so the import stays local to the new file. \`maintenance.ts\` keeps re-exports; public surface unchanged.

- New file \`packages/core/src/maintenance/backfill-narrative.ts\`
- \`maintenance.ts\` shrinks by ~75 LOC
- No runtime behavior change

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced