### PR TITLE
refactor(core): extract maintenance/backfill-tags.ts — tags_text backfill

### DIFF
--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -9,12 +9,10 @@ import {
 	resolveDbPath,
 } from "./db.js";
 import { getInjectionEvalScenarioByPrompt } from "./eval-scenarios.js";
-import { deriveTags, parseJsonStringList } from "./maintenance/tag-helpers.js";
 import { withDb } from "./maintenance/with-db.js";
 import { ensureMaintenanceJobsSchema } from "./maintenance-jobs.js";
 import { inferMemoryRole } from "./memory-quality.js";
 import { buildMemoryPack } from "./pack.js";
-import { projectClause } from "./project.js";
 import * as schema from "./schema.js";
 import { bootstrapSchema } from "./schema-bootstrap.js";
 import { MemoryStore } from "./store.js";
@@ -1128,117 +1126,11 @@ export { getReliabilityMetrics, rawEventsGate } from "./maintenance/reliability.
 // Retry
 // ---------------------------------------------------------------------------
 
-export interface BackfillTagsTextOptions {
-	limit?: number | null;
-	since?: string | null;
-	project?: string | null;
-	activeOnly?: boolean;
-	dryRun?: boolean;
-	memoryIds?: number[] | null;
-}
-
-export interface BackfillTagsTextResult {
-	checked: number;
-	updated: number;
-	skipped: number;
-}
-
-/**
- * Populate memory_items.tags_text for rows where it is empty.
- * Port of Python's backfill_tags_text() maintenance helper.
- */
-export function backfillTagsText(
-	db: Database,
-	opts: BackfillTagsTextOptions = {},
-): BackfillTagsTextResult {
-	const { limit, since, project, activeOnly = true, dryRun = false, memoryIds } = opts;
-
-	const params: unknown[] = [];
-	const whereClauses = ["(memory_items.tags_text IS NULL OR TRIM(memory_items.tags_text) = '')"];
-
-	if (activeOnly) whereClauses.push("memory_items.active = 1");
-	if (since) {
-		whereClauses.push("memory_items.created_at >= ?");
-		params.push(since);
-	}
-
-	let joinSessions = false;
-	if (project) {
-		const pc = projectClause(project);
-		if (pc.clause) {
-			whereClauses.push(pc.clause);
-			params.push(...pc.params);
-			joinSessions = true;
-		}
-	}
-
-	if (memoryIds && memoryIds.length > 0) {
-		const placeholders = memoryIds.map(() => "?").join(",");
-		whereClauses.push(`memory_items.id IN (${placeholders})`);
-		params.push(...memoryIds.map((id) => Number(id)));
-	}
-
-	const where = whereClauses.join(" AND ");
-	const joinClause = joinSessions ? "JOIN sessions ON sessions.id = memory_items.session_id" : "";
-	const limitClause = limit != null && limit > 0 ? "LIMIT ?" : "";
-	if (limit != null && limit > 0) params.push(limit);
-
-	const rows = db
-		.prepare(
-			`SELECT memory_items.id, memory_items.kind, memory_items.title,
-			        memory_items.concepts, memory_items.files_read, memory_items.files_modified
-			 FROM memory_items
-			 ${joinClause}
-			 WHERE ${where}
-			 ORDER BY memory_items.created_at ASC
-			 ${limitClause}`,
-		)
-		.all(...params) as Array<{
-		id: number;
-		kind: string | null;
-		title: string | null;
-		concepts: string | null;
-		files_read: string | null;
-		files_modified: string | null;
-	}>;
-
-	let checked = 0;
-	let updated = 0;
-	let skipped = 0;
-	const now = new Date().toISOString();
-	const updateStmt = db.prepare(
-		"UPDATE memory_items SET tags_text = ?, updated_at = ? WHERE id = ?",
-	);
-	const updates: Array<{ id: number; tagsText: string }> = [];
-
-	for (const row of rows) {
-		checked += 1;
-		const tags = deriveTags({
-			kind: String(row.kind ?? ""),
-			title: String(row.title ?? ""),
-			concepts: parseJsonStringList(row.concepts),
-			filesRead: parseJsonStringList(row.files_read),
-			filesModified: parseJsonStringList(row.files_modified),
-		});
-		const tagsText = tags.join(" ");
-		if (!tagsText) {
-			skipped += 1;
-			continue;
-		}
-		updates.push({ id: row.id, tagsText });
-		updated += 1;
-	}
-
-	if (!dryRun && updates.length > 0) {
-		db.transaction(() => {
-			for (const update of updates) {
-				updateStmt.run(update.tagsText, now, update.id);
-			}
-		})();
-	}
-
-	return { checked, updated, skipped };
-}
+export type {
+	BackfillTagsTextOptions,
+	BackfillTagsTextResult,
+} from "./maintenance/backfill-tags.js";
+export { backfillTagsText } from "./maintenance/backfill-tags.js";
 
 export type {
 	DeactivateLowSignalMemoriesOptions,

--- a/packages/core/src/maintenance/backfill-tags.ts
+++ b/packages/core/src/maintenance/backfill-tags.ts
@@ -1,0 +1,120 @@
+/* Tag-text backfill for memory_items.tags_text.
+ *
+ * Extracted verbatim from packages/core/src/maintenance.ts as part of
+ * the maintenance/ split (tracked under codemem-ug38).
+ */
+
+import type { Database } from "../db.js";
+import { projectClause } from "../project.js";
+import { deriveTags, parseJsonStringList } from "./tag-helpers.js";
+
+export interface BackfillTagsTextOptions {
+	limit?: number | null;
+	since?: string | null;
+	project?: string | null;
+	activeOnly?: boolean;
+	dryRun?: boolean;
+	memoryIds?: number[] | null;
+}
+
+export interface BackfillTagsTextResult {
+	checked: number;
+	updated: number;
+	skipped: number;
+}
+
+/**
+ * Populate memory_items.tags_text for rows where it is empty.
+ */
+export function backfillTagsText(
+	db: Database,
+	opts: BackfillTagsTextOptions = {},
+): BackfillTagsTextResult {
+	const { limit, since, project, activeOnly = true, dryRun = false, memoryIds } = opts;
+
+	const params: unknown[] = [];
+	const whereClauses = ["(memory_items.tags_text IS NULL OR TRIM(memory_items.tags_text) = '')"];
+
+	if (activeOnly) whereClauses.push("memory_items.active = 1");
+	if (since) {
+		whereClauses.push("memory_items.created_at >= ?");
+		params.push(since);
+	}
+
+	let joinSessions = false;
+	if (project) {
+		const pc = projectClause(project);
+		if (pc.clause) {
+			whereClauses.push(pc.clause);
+			params.push(...pc.params);
+			joinSessions = true;
+		}
+	}
+
+	if (memoryIds && memoryIds.length > 0) {
+		const placeholders = memoryIds.map(() => "?").join(",");
+		whereClauses.push(`memory_items.id IN (${placeholders})`);
+		params.push(...memoryIds.map((id) => Number(id)));
+	}
+
+	const where = whereClauses.join(" AND ");
+	const joinClause = joinSessions ? "JOIN sessions ON sessions.id = memory_items.session_id" : "";
+	const limitClause = limit != null && limit > 0 ? "LIMIT ?" : "";
+	if (limit != null && limit > 0) params.push(limit);
+
+	const rows = db
+		.prepare(
+			`SELECT memory_items.id, memory_items.kind, memory_items.title,
+			        memory_items.concepts, memory_items.files_read, memory_items.files_modified
+			 FROM memory_items
+			 ${joinClause}
+			 WHERE ${where}
+			 ORDER BY memory_items.created_at ASC
+			 ${limitClause}`,
+		)
+		.all(...params) as Array<{
+		id: number;
+		kind: string | null;
+		title: string | null;
+		concepts: string | null;
+		files_read: string | null;
+		files_modified: string | null;
+	}>;
+
+	let checked = 0;
+	let updated = 0;
+	let skipped = 0;
+	const now = new Date().toISOString();
+	const updateStmt = db.prepare(
+		"UPDATE memory_items SET tags_text = ?, updated_at = ? WHERE id = ?",
+	);
+	const updates: Array<{ id: number; tagsText: string }> = [];
+
+	for (const row of rows) {
+		checked += 1;
+		const tags = deriveTags({
+			kind: String(row.kind ?? ""),
+			title: String(row.title ?? ""),
+			concepts: parseJsonStringList(row.concepts),
+			filesRead: parseJsonStringList(row.files_read),
+			filesModified: parseJsonStringList(row.files_modified),
+		});
+		const tagsText = tags.join(" ");
+		if (!tagsText) {
+			skipped += 1;
+			continue;
+		}
+		updates.push({ id: row.id, tagsText });
+		updated += 1;
+	}
+
+	if (!dryRun && updates.length > 0) {
+		db.transaction(() => {
+			for (const update of updates) {
+				updateStmt.run(update.tagsText, now, update.id);
+			}
+		})();
+	}
+
+	return { checked, updated, skipped };
+}


### PR DESCRIPTION
## Description

Stacked on top of #839. Move \`backfillTagsText\` (plus its \`BackfillTagsTextOptions\` / \`BackfillTagsTextResult\` types) into \`maintenance/backfill-tags.ts\`. Depends on the already-extracted \`tag-helpers.ts\` plus \`projectClause\` from \`project.js\`. \`maintenance.ts\` re-exports the public names. Drops now-unused \`deriveTags\`, \`parseJsonStringList\`, and \`projectClause\` imports from \`maintenance.ts\`.

- New file \`packages/core/src/maintenance/backfill-tags.ts\`
- \`maintenance.ts\` shrinks by ~110 LOC

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced