### PR TITLE
refactor(ui): extract feed/skeleton.ts — FeedSkeletonItem placeholder component

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -45,6 +45,7 @@ import {
 	SUMMARY_PAGE_SIZE,
 } from "./feed/pagination";
 import { renderMarkdownSafe } from "./feed/sanitize";
+import { FeedSkeletonItem } from "./feed/skeleton";
 import type { FeedItem, FeedItemMetadata, FeedSummary, ItemViewMode } from "./feed/types";
 
 /* ── Module state ─────────────────────────────────────────── */
@@ -732,35 +733,6 @@ function FeedItemCard({ item }: { item: FeedItem }) {
 				),
 			),
 			filesRow,
-		),
-	);
-}
-
-function FeedSkeletonItem({ index }: { index: number }) {
-	// Alternate widths across the skeleton set so the stack doesn't look
-	// mechanically repeated. Three variants is enough to read as "loading."
-	const bodyWidths = [
-		["w-85", "w-65"],
-		["w-85", "w-40"],
-		["w-65", "w-85"],
-	];
-	const [first, second] = bodyWidths[index % bodyWidths.length];
-	return h(
-		"div",
-		{ className: "feed-skeleton-item", "aria-hidden": "true" },
-		h("div", { className: "feed-skeleton-banner" }),
-		h(
-			"div",
-			{ className: "feed-skeleton-body" },
-			h("div", { className: `feed-skeleton-line ${first}` }),
-			h("div", { className: `feed-skeleton-line ${second}` }),
-			h(
-				"div",
-				{ className: "feed-skeleton-footer" },
-				h("div", { className: "feed-skeleton-chip w-36" }),
-				h("div", { className: "feed-skeleton-chip w-56" }),
-				h("div", { className: "feed-skeleton-chip" }),
-			),
 		),
 	);
 }

--- a/packages/ui/src/tabs/feed/skeleton.ts
+++ b/packages/ui/src/tabs/feed/skeleton.ts
@@ -1,0 +1,32 @@
+/* Feed loading-state skeleton — placeholder cards shown while items load. */
+
+import { h } from "preact";
+
+export function FeedSkeletonItem({ index }: { index: number }) {
+	// Alternate widths across the skeleton set so the stack doesn't look
+	// mechanically repeated. Three variants is enough to read as "loading."
+	const bodyWidths = [
+		["w-85", "w-65"],
+		["w-85", "w-40"],
+		["w-65", "w-85"],
+	];
+	const [first, second] = bodyWidths[index % bodyWidths.length];
+	return h(
+		"div",
+		{ className: "feed-skeleton-item", "aria-hidden": "true" },
+		h("div", { className: "feed-skeleton-banner" }),
+		h(
+			"div",
+			{ className: "feed-skeleton-body" },
+			h("div", { className: `feed-skeleton-line ${first}` }),
+			h("div", { className: `feed-skeleton-line ${second}` }),
+			h(
+				"div",
+				{ className: "feed-skeleton-footer" },
+				h("div", { className: "feed-skeleton-chip w-36" }),
+				h("div", { className: "feed-skeleton-chip w-56" }),
+				h("div", { className: "feed-skeleton-chip" }),
+			),
+		),
+	);
+}


### PR DESCRIPTION
## Description

Stacked on top of #841. Move the \`FeedSkeletonItem\` placeholder component into its own file. Self-contained (only depends on preact \`h\`), so the extraction is trivial. \`feed.ts\` imports it and nothing else changes.

- New file \`packages/ui/src/tabs/feed/skeleton.ts\`
- \`feed.ts\` shrinks by ~30 LOC

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced