### PR TITLE
refactor(ui): extract feed/summary-extract.ts — summary object parsing + classifiers

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -26,7 +26,6 @@ export type { FeedItem, FeedItemMetadata } from "./feed/types";
 
 import {
 	authorLabel,
-	extractFactsFromBody,
 	feedScopeLabel,
 	isLowSignalObservation,
 	itemKey,
@@ -46,7 +45,7 @@ import {
 } from "./feed/pagination";
 import { renderMarkdownSafe } from "./feed/sanitize";
 import { FeedSkeletonItem } from "./feed/skeleton";
-import type { FeedItem, FeedItemMetadata, FeedSummary, ItemViewMode } from "./feed/types";
+import type { FeedItem, FeedSummary, ItemViewMode } from "./feed/types";
 
 /* ── Module state ─────────────────────────────────────────── */
 
@@ -193,118 +192,7 @@ function FeedItemMenu({
 
 /* ── Summary object extraction ───────────────────────────── */
 
-/**
- * A feed summary object parsed from a memory item's metadata, body text,
- * or adapter output. Keys are semantic sections (request / completed /
- * learned / etc.) but the server has enough shape variance that values
- * are typed as `unknown` — callers are expected to coerce via
- * `String(v || "")` or a `typeof` narrowing before rendering.
- */
-function getSummaryObject(item: FeedItem): FeedSummary | null {
-	const preferredKeys = [
-		"request",
-		"outcome",
-		"plan",
-		"completed",
-		"learned",
-		"investigated",
-		"next",
-		"next_steps",
-		"notes",
-	];
-	const looksLikeSummary = (v: unknown): v is FeedSummary => {
-		if (!v || typeof v !== "object" || Array.isArray(v)) return false;
-		const obj = v as FeedSummary;
-		return preferredKeys.some((k) => {
-			const value = obj[k];
-			return typeof value === "string" && value.trim().length > 0;
-		});
-	};
-	const rawSummary = item?.summary;
-	if (rawSummary && typeof rawSummary === "object" && !Array.isArray(rawSummary)) {
-		const nestedSummary = (rawSummary as { summary?: unknown }).summary;
-		if (looksLikeSummary(rawSummary)) return rawSummary;
-		if (looksLikeSummary(nestedSummary)) return nestedSummary;
-	}
-	const metadata = item?.metadata_json;
-	if (looksLikeSummary(metadata)) return metadata;
-	if (metadata && looksLikeSummary(metadata.summary)) return metadata.summary;
-	const bodyText = String(item?.body_text || "").trim();
-	if (bodyText.includes("## ")) {
-		const headingMap: Record<string, string> = {
-			request: "request",
-			completed: "completed",
-			learned: "learned",
-			investigated: "investigated",
-			"next steps": "next_steps",
-			notes: "notes",
-		};
-		const parsed: Record<string, string> = {};
-		const sectionRe = /(?:^|\n)##\s+([^\n]+)\n([\s\S]*?)(?=\n##\s+|$)/g;
-		for (let match = sectionRe.exec(bodyText); match; match = sectionRe.exec(bodyText)) {
-			const rawLabel = String(match[1] || "")
-				.trim()
-				.toLowerCase();
-			const key = headingMap[rawLabel];
-			const content = String(match[2] || "").trim();
-			if (key && content) parsed[key] = content;
-		}
-		if (looksLikeSummary(parsed)) return parsed;
-	}
-	return null;
-}
-
-function isSummaryLikeItem(item: FeedItem, metadata: FeedItemMetadata): boolean {
-	const kindValue = String(item?.kind || "").toLowerCase();
-	if (kindValue === "session_summary") return true;
-	if (metadata?.is_summary === true) return true;
-	const source = String(metadata?.source || "")
-		.trim()
-		.toLowerCase();
-	return source === "observer_summary";
-}
-
-function canonicalKind(item: FeedItem, metadata: FeedItemMetadata): string {
-	const kindValue = String(item?.kind || "")
-		.trim()
-		.toLowerCase();
-	return isSummaryLikeItem(item, metadata) ? "session_summary" : kindValue || "change";
-}
-
-function _getFactsList(item: FeedItem): string[] {
-	const summary = getSummaryObject(item);
-	if (summary) {
-		const preferred = [
-			"request",
-			"outcome",
-			"plan",
-			"completed",
-			"learned",
-			"investigated",
-			"next",
-			"next_steps",
-			"notes",
-		];
-		const keys = Object.keys(summary);
-		const remaining = keys.filter((k) => !preferred.includes(k)).sort();
-		const ordered = [...preferred.filter((k) => keys.includes(k)), ...remaining];
-		const facts: string[] = [];
-		ordered.forEach((key) => {
-			const content = String(summary[key] || "").trim();
-			if (!content) return;
-			const bullets = extractFactsFromBody(content);
-			if (bullets.length) {
-				bullets.forEach((b) => {
-					facts.push(`${toTitleLabel(key)}: ${b}`.trim());
-				});
-				return;
-			}
-			facts.push(`${toTitleLabel(key)}: ${content}`.trim());
-		});
-		return facts;
-	}
-	return extractFactsFromBody(String(item?.body_text || ""));
-}
+import { canonicalKind, getSummaryObject, isSummaryLikeItem } from "./feed/summary-extract";
 
 export { observationViewData } from "./feed/observation-view";
 

--- a/packages/ui/src/tabs/feed/summary-extract.ts
+++ b/packages/ui/src/tabs/feed/summary-extract.ts
@@ -1,0 +1,119 @@
+/* Feed summary extraction — parse a FeedItem's metadata/body/adapter-output
+ * into a normalized FeedSummary object and classify it as summary-like. */
+
+import { toTitleLabel } from "../../lib/format";
+import { extractFactsFromBody } from "./helpers";
+import type { FeedItem, FeedItemMetadata, FeedSummary } from "./types";
+
+/**
+ * A feed summary object parsed from a memory item's metadata, body text,
+ * or adapter output. Keys are semantic sections (request / completed /
+ * learned / etc.) but the server has enough shape variance that values
+ * are typed as `unknown` — callers are expected to coerce via
+ * `String(v || "")` or a `typeof` narrowing before rendering.
+ */
+export function getSummaryObject(item: FeedItem): FeedSummary | null {
+	const preferredKeys = [
+		"request",
+		"outcome",
+		"plan",
+		"completed",
+		"learned",
+		"investigated",
+		"next",
+		"next_steps",
+		"notes",
+	];
+	const looksLikeSummary = (v: unknown): v is FeedSummary => {
+		if (!v || typeof v !== "object" || Array.isArray(v)) return false;
+		const obj = v as FeedSummary;
+		return preferredKeys.some((k) => {
+			const value = obj[k];
+			return typeof value === "string" && value.trim().length > 0;
+		});
+	};
+	const rawSummary = item?.summary;
+	if (rawSummary && typeof rawSummary === "object" && !Array.isArray(rawSummary)) {
+		const nestedSummary = (rawSummary as { summary?: unknown }).summary;
+		if (looksLikeSummary(rawSummary)) return rawSummary;
+		if (looksLikeSummary(nestedSummary)) return nestedSummary;
+	}
+	const metadata = item?.metadata_json;
+	if (looksLikeSummary(metadata)) return metadata;
+	if (metadata && looksLikeSummary(metadata.summary)) return metadata.summary;
+	const bodyText = String(item?.body_text || "").trim();
+	if (bodyText.includes("## ")) {
+		const headingMap: Record<string, string> = {
+			request: "request",
+			completed: "completed",
+			learned: "learned",
+			investigated: "investigated",
+			"next steps": "next_steps",
+			notes: "notes",
+		};
+		const parsed: Record<string, string> = {};
+		const sectionRe = /(?:^|\n)##\s+([^\n]+)\n([\s\S]*?)(?=\n##\s+|$)/g;
+		for (let match = sectionRe.exec(bodyText); match; match = sectionRe.exec(bodyText)) {
+			const rawLabel = String(match[1] || "")
+				.trim()
+				.toLowerCase();
+			const key = headingMap[rawLabel];
+			const content = String(match[2] || "").trim();
+			if (key && content) parsed[key] = content;
+		}
+		if (looksLikeSummary(parsed)) return parsed;
+	}
+	return null;
+}
+
+export function isSummaryLikeItem(item: FeedItem, metadata: FeedItemMetadata): boolean {
+	const kindValue = String(item?.kind || "").toLowerCase();
+	if (kindValue === "session_summary") return true;
+	if (metadata?.is_summary === true) return true;
+	const source = String(metadata?.source || "")
+		.trim()
+		.toLowerCase();
+	return source === "observer_summary";
+}
+
+export function canonicalKind(item: FeedItem, metadata: FeedItemMetadata): string {
+	const kindValue = String(item?.kind || "")
+		.trim()
+		.toLowerCase();
+	return isSummaryLikeItem(item, metadata) ? "session_summary" : kindValue || "change";
+}
+
+export function _getFactsList(item: FeedItem): string[] {
+	const summary = getSummaryObject(item);
+	if (summary) {
+		const preferred = [
+			"request",
+			"outcome",
+			"plan",
+			"completed",
+			"learned",
+			"investigated",
+			"next",
+			"next_steps",
+			"notes",
+		];
+		const keys = Object.keys(summary);
+		const remaining = keys.filter((k) => !preferred.includes(k)).sort();
+		const ordered = [...preferred.filter((k) => keys.includes(k)), ...remaining];
+		const facts: string[] = [];
+		ordered.forEach((key) => {
+			const content = String(summary[key] || "").trim();
+			if (!content) return;
+			const bullets = extractFactsFromBody(content);
+			if (bullets.length) {
+				bullets.forEach((b) => {
+					facts.push(`${toTitleLabel(key)}: ${b}`.trim());
+				});
+				return;
+			}
+			facts.push(`${toTitleLabel(key)}: ${content}`.trim());
+		});
+		return facts;
+	}
+	return extractFactsFromBody(String(item?.body_text || ""));
+}


### PR DESCRIPTION
## Description

Stacked on top of #842. Move four pure summary/classification helpers — \`getSummaryObject\`, \`isSummaryLikeItem\`, \`canonicalKind\`, \`_getFactsList\` — into \`feed/summary-extract.ts\`. \`feed.ts\` imports the three actually-called ones and drops the now-unused \`FeedItemMetadata\` / \`extractFactsFromBody\` imports.

- New file \`packages/ui/src/tabs/feed/summary-extract.ts\`
- \`feed.ts\` shrinks by ~115 LOC

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced