### PR TITLE
refactor(ui): extract feed/body-renderers.ts — summary/facts/narrative renderers

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -14,7 +14,6 @@ import {
 	formatTagLabel,
 	normalize,
 	parseJsonArray,
-	toTitleLabel,
 } from "../lib/format";
 import { showGlobalNotice } from "../lib/notice";
 import { setFeedScopeFilter, setFeedTypeFilter, state } from "../lib/state";
@@ -43,9 +42,8 @@ import {
 	pageNextOffset,
 	SUMMARY_PAGE_SIZE,
 } from "./feed/pagination";
-import { renderMarkdownSafe } from "./feed/sanitize";
 import { FeedSkeletonItem } from "./feed/skeleton";
-import type { FeedItem, FeedSummary, ItemViewMode } from "./feed/types";
+import type { FeedItem, ItemViewMode } from "./feed/types";
 
 /* ── Module state ─────────────────────────────────────────── */
 
@@ -206,80 +204,11 @@ import {
 
 /* ── Rendering functions ─────────────────────────────────── */
 
-function renderSummarySections(summary: FeedSummary) {
-	const preferred = [
-		"request",
-		"outcome",
-		"plan",
-		"completed",
-		"learned",
-		"investigated",
-		"next",
-		"next_steps",
-		"notes",
-	];
-	const keys = Object.keys(summary);
-	const ordered = preferred.filter((k) => keys.includes(k));
-	return ordered
-		.map((key) => {
-			const content = String(summary[key] || "").trim();
-			if (!content) return null;
-			return h(
-				"div",
-				{ className: "summary-section", key },
-				h("div", { className: "summary-section-label" }, toTitleLabel(key)),
-				h("div", {
-					className: "summary-section-content",
-					dangerouslySetInnerHTML: { __html: renderMarkdownSafe(content) },
-				}),
-			);
-		})
-		.filter(Boolean);
-}
-
-function renderFactsContent(facts: unknown[]) {
-	const trimmed = facts.map((f) => String(f || "").trim()).filter(Boolean);
-	if (!trimmed.length) return null;
-	const labeledFacts = trimmed.every((f) => /.+?:\s+.+/.test(f));
-	if (labeledFacts) {
-		const rows = trimmed
-			.map((fact, index) => {
-				const splitAt = fact.indexOf(":");
-				const labelText = fact.slice(0, splitAt).trim();
-				const contentText = fact.slice(splitAt + 1).trim();
-				if (!labelText || !contentText) return null;
-				return h(
-					"div",
-					{ className: "summary-section", key: `${labelText}-${index}` },
-					h("div", { className: "summary-section-label" }, labelText),
-					h("div", {
-						className: "summary-section-content",
-						dangerouslySetInnerHTML: { __html: renderMarkdownSafe(contentText) },
-					}),
-				);
-			})
-			.filter(Boolean);
-		if (rows.length) return h("div", { className: "feed-body facts" }, rows);
-	}
-	return h(
-		"div",
-		{ className: "feed-body" },
-		h(
-			"ul",
-			null,
-			trimmed.map((fact, index) => h("li", { key: `${fact}-${index}` }, fact)),
-		),
-	);
-}
-
-function renderNarrativeContent(narrative: string, className = "feed-body") {
-	const content = String(narrative || "").trim();
-	if (!content) return null;
-	return h("div", {
-		className,
-		dangerouslySetInnerHTML: { __html: renderMarkdownSafe(content) },
-	});
-}
+import {
+	renderFactsContent,
+	renderNarrativeContent,
+	renderSummarySections,
+} from "./feed/body-renderers";
 
 function FeedViewToggle({
 	modes,

--- a/packages/ui/src/tabs/feed/body-renderers.ts
+++ b/packages/ui/src/tabs/feed/body-renderers.ts
@@ -1,0 +1,81 @@
+/* Feed body renderers — summary sections, facts lists, narrative blocks. */
+
+import { h } from "preact";
+import { toTitleLabel } from "../../lib/format";
+import { renderMarkdownSafe } from "./sanitize";
+import type { FeedSummary } from "./types";
+
+export function renderSummarySections(summary: FeedSummary) {
+	const preferred = [
+		"request",
+		"outcome",
+		"plan",
+		"completed",
+		"learned",
+		"investigated",
+		"next",
+		"next_steps",
+		"notes",
+	];
+	const keys = Object.keys(summary);
+	const ordered = preferred.filter((k) => keys.includes(k));
+	return ordered
+		.map((key) => {
+			const content = String(summary[key] || "").trim();
+			if (!content) return null;
+			return h(
+				"div",
+				{ className: "summary-section", key },
+				h("div", { className: "summary-section-label" }, toTitleLabel(key)),
+				h("div", {
+					className: "summary-section-content",
+					dangerouslySetInnerHTML: { __html: renderMarkdownSafe(content) },
+				}),
+			);
+		})
+		.filter(Boolean);
+}
+
+export function renderFactsContent(facts: unknown[]) {
+	const trimmed = facts.map((f) => String(f || "").trim()).filter(Boolean);
+	if (!trimmed.length) return null;
+	const labeledFacts = trimmed.every((f) => /.+?:\s+.+/.test(f));
+	if (labeledFacts) {
+		const rows = trimmed
+			.map((fact, index) => {
+				const splitAt = fact.indexOf(":");
+				const labelText = fact.slice(0, splitAt).trim();
+				const contentText = fact.slice(splitAt + 1).trim();
+				if (!labelText || !contentText) return null;
+				return h(
+					"div",
+					{ className: "summary-section", key: `${labelText}-${index}` },
+					h("div", { className: "summary-section-label" }, labelText),
+					h("div", {
+						className: "summary-section-content",
+						dangerouslySetInnerHTML: { __html: renderMarkdownSafe(contentText) },
+					}),
+				);
+			})
+			.filter(Boolean);
+		if (rows.length) return h("div", { className: "feed-body facts" }, rows);
+	}
+	return h(
+		"div",
+		{ className: "feed-body" },
+		h(
+			"ul",
+			null,
+			trimmed.map((fact, index) => h("li", { key: `${fact}-${index}` }, fact)),
+		),
+	);
+}
+
+export function renderNarrativeContent(narrative: string, className = "feed-body") {
+	const content = String(narrative || "").trim();
+	if (!content) return null;
+	return h("div", {
+		className,
+		dangerouslySetInnerHTML: { __html: renderMarkdownSafe(content) },
+	});
+}


### PR DESCRIPTION
## Description

Stacked on top of #843. Move the three feed body renderers — \`renderSummarySections\`, \`renderFactsContent\`, \`renderNarrativeContent\` — into \`feed/body-renderers.ts\`. They consume \`renderMarkdownSafe\` and \`toTitleLabel\`, both already modularized. \`feed.ts\` drops now-unused \`renderMarkdownSafe\`, \`toTitleLabel\`, and \`FeedSummary\` imports.

- New file \`packages/ui/src/tabs/feed/body-renderers.ts\`
- \`feed.ts\` shrinks by ~75 LOC

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced