### PR TITLE
refactor(ui): extract feed/filter.ts — filterByType/filterByQuery/computeSignature

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -12,7 +12,6 @@ import {
 	formatFileList,
 	formatRelativeTime,
 	formatTagLabel,
-	normalize,
 	parseJsonArray,
 } from "../lib/format";
 import { showGlobalNotice } from "../lib/notice";
@@ -28,7 +27,6 @@ import {
 	feedScopeLabel,
 	isLowSignalObservation,
 	itemKey,
-	itemSignature,
 	mergeFeedItems,
 	mergeMetadata,
 	mergeRefreshFeedItems,
@@ -593,39 +591,7 @@ function FeedList({ items, loadingText }: { items: FeedItem[]; loadingText?: str
 
 /* ── Filtering ───────────────────────────────────────────── */
 
-function filterByType(items: FeedItem[]): FeedItem[] {
-	if (state.feedTypeFilter === "observations")
-		return items.filter((i) => !isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
-	if (state.feedTypeFilter === "summaries")
-		return items.filter((i) => isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
-	return items;
-}
-
-function filterByQuery(items: FeedItem[]): FeedItem[] {
-	const query = normalize(state.feedQuery);
-	if (!query) return items;
-	return items.filter((item) => {
-		const hay = [
-			normalize(item?.title),
-			normalize(item?.body_text),
-			normalize(item?.kind),
-			parseJsonArray(item?.tags || [])
-				.map((t) => normalize(t))
-				.join(" "),
-			normalize(item?.project),
-		]
-			.join(" ")
-			.trim();
-		return hay.includes(query);
-	});
-}
-
-function computeSignature(items: FeedItem[]): string {
-	const parts = items.map(
-		(i) => `${itemSignature(i)}:${i.kind || ""}:${i.created_at_utc || i.created_at || ""}`,
-	);
-	return `${state.feedTypeFilter}|${state.feedScopeFilter}|${state.currentProject}|${normalize(state.feedQuery)}|${parts.join("|")}`;
-}
+import { computeSignature, filterByQuery, filterByType } from "./feed/filter";
 
 async function loadMoreFeedPage() {
 	if (loadMoreInFlight || !hasMorePages()) return;

--- a/packages/ui/src/tabs/feed/filter.ts
+++ b/packages/ui/src/tabs/feed/filter.ts
@@ -1,0 +1,43 @@
+/* Feed filtering — by-type / by-query / signature helpers.
+ * Reads the feed-tab globals from lib/state directly so callers can stay
+ * declarative. */
+
+import { normalize, parseJsonArray } from "../../lib/format";
+import { state } from "../../lib/state";
+import { itemSignature, mergeMetadata } from "./helpers";
+import { isSummaryLikeItem } from "./summary-extract";
+import type { FeedItem } from "./types";
+
+export function filterByType(items: FeedItem[]): FeedItem[] {
+	if (state.feedTypeFilter === "observations")
+		return items.filter((i) => !isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
+	if (state.feedTypeFilter === "summaries")
+		return items.filter((i) => isSummaryLikeItem(i, mergeMetadata(i?.metadata_json)));
+	return items;
+}
+
+export function filterByQuery(items: FeedItem[]): FeedItem[] {
+	const query = normalize(state.feedQuery);
+	if (!query) return items;
+	return items.filter((item) => {
+		const hay = [
+			normalize(item?.title),
+			normalize(item?.body_text),
+			normalize(item?.kind),
+			parseJsonArray(item?.tags || [])
+				.map((t) => normalize(t))
+				.join(" "),
+			normalize(item?.project),
+		]
+			.join(" ")
+			.trim();
+		return hay.includes(query);
+	});
+}
+
+export function computeSignature(items: FeedItem[]): string {
+	const parts = items.map(
+		(i) => `${itemSignature(i)}:${i.kind || ""}:${i.created_at_utc || i.created_at || ""}`,
+	);
+	return `${state.feedTypeFilter}|${state.feedScopeFilter}|${state.currentProject}|${normalize(state.feedQuery)}|${parts.join("|")}`;
+}


### PR DESCRIPTION
## Description

Stacked on top of #844. Move three pure filtering helpers — \`filterByType\`, \`filterByQuery\`, \`computeSignature\` — into \`feed/filter.ts\`. They read the feed-tab state from \`lib/state\` directly (same as the current inline implementation) so no API change. Drops now-unused \`normalize\` and \`itemSignature\` imports from \`feed.ts\`.

- New file \`packages/ui/src/tabs/feed/filter.ts\`
- \`feed.ts\` shrinks by ~35 LOC

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced