### PR TITLE
refactor(ui): extract feed/menu.ts — FeedItemMenu dropdown

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -1,6 +1,5 @@
 /* Feed tab — memory feed rendering, filtering, search. */
 
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { type ComponentChildren, Fragment, h, render } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
 import { Chip } from "../components/primitives/chip";
@@ -149,42 +148,7 @@ function removeFeedItem(memoryId: number) {
 	}
 }
 
-function FeedItemMenu({
-	disabled,
-	onForget,
-	title,
-}: {
-	disabled: boolean;
-	onForget: () => void;
-	title: string;
-}) {
-	return h(
-		DropdownMenu.Root,
-		null,
-		h(
-			DropdownMenu.Trigger,
-			{ asChild: true },
-			h(
-				"button",
-				{ "aria-label": `Actions for ${title}`, className: "feed-menu-trigger", type: "button" },
-				"⋯",
-			),
-		),
-		h(
-			DropdownMenu.Portal,
-			null,
-			h(
-				DropdownMenu.Content,
-				{ align: "end", className: "feed-menu-panel", side: "bottom", sideOffset: 4 },
-				h(
-					DropdownMenu.Item,
-					{ className: "feed-menu-item danger", disabled, onSelect: () => onForget() },
-					disabled ? "Forgetting…" : "Forget memory",
-				),
-			),
-		),
-	);
-}
+import { FeedItemMenu } from "./feed/menu";
 
 /* ── Summary object extraction ───────────────────────────── */
 

--- a/packages/ui/src/tabs/feed/menu.ts
+++ b/packages/ui/src/tabs/feed/menu.ts
@@ -1,0 +1,41 @@
+/* Feed item action menu — "Forget memory" dropdown. */
+
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { h } from "preact";
+
+export function FeedItemMenu({
+	disabled,
+	onForget,
+	title,
+}: {
+	disabled: boolean;
+	onForget: () => void;
+	title: string;
+}) {
+	return h(
+		DropdownMenu.Root,
+		null,
+		h(
+			DropdownMenu.Trigger,
+			{ asChild: true },
+			h(
+				"button",
+				{ "aria-label": `Actions for ${title}`, className: "feed-menu-trigger", type: "button" },
+				"⋯",
+			),
+		),
+		h(
+			DropdownMenu.Portal,
+			null,
+			h(
+				DropdownMenu.Content,
+				{ align: "end", className: "feed-menu-panel", side: "bottom", sideOffset: 4 },
+				h(
+					DropdownMenu.Item,
+					{ className: "feed-menu-item danger", disabled, onSelect: () => onForget() },
+					disabled ? "Forgetting…" : "Forget memory",
+				),
+			),
+		),
+	);
+}


### PR DESCRIPTION
## Description

Stacked on top of #845. Move the \`FeedItemMenu\` Radix dropdown component into its own file. Pure component, no state. Drops the now-unused \`@radix-ui/react-dropdown-menu\` import from \`feed.ts\`.

- New file \`packages/ui/src/tabs/feed/menu.ts\`
- \`feed.ts\` shrinks by ~35 LOC

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced