### PR TITLE
refactor(ui): extract feed/toggles.ts — FeedViewToggle, FeedToggle, TagChip leaf components

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -172,40 +172,7 @@ import {
 	renderSummarySections,
 } from "./feed/body-renderers";
 
-function FeedViewToggle({
-	modes,
-	active,
-	onSelect,
-}: {
-	modes: Array<{ id: ItemViewMode; label: string }>;
-	active: ItemViewMode;
-	onSelect: (mode: ItemViewMode) => void;
-}) {
-	if (modes.length <= 1) return null;
-	return h(
-		"div",
-		{ className: "feed-toggle" },
-		modes.map((mode) =>
-			h(
-				"button",
-				{
-					key: mode.id,
-					className: `toggle-button${mode.id === active ? " active" : ""}`,
-					"data-filter": mode.id,
-					onClick: () => onSelect(mode.id),
-					type: "button",
-				},
-				mode.label,
-			),
-		),
-	);
-}
-
-function TagChip({ tag }: { tag: unknown }) {
-	const display = formatTagLabel(tag);
-	if (!display) return null;
-	return h(Chip, { variant: "tag", title: String(tag) }, display);
-}
+import { FeedToggle, FeedViewToggle, TagChip } from "./feed/toggles";
 
 /* ── Feed item card renderer ─────────────────────────────── */
 
@@ -642,38 +609,6 @@ function feedMetaText(visibleCount: number): string {
 	const queryLabel = state.feedQuery.trim() ? ` · matching "${state.feedQuery.trim()}"` : "";
 	const moreLabel = hasMorePages() ? " · scroll for more" : "";
 	return `${visibleCount} items${filterLabel}${scopeLabel}${queryLabel}${filteredLabel}${moreLabel}`;
-}
-
-function FeedToggle({
-	id,
-	active,
-	options,
-	onSelect,
-}: {
-	id: string;
-	active: string;
-	options: Array<{ value: string; label: string }>;
-	onSelect: (value: string) => void;
-}) {
-	return h(
-		"div",
-		{ className: "feed-toggle", id },
-		options.map(({ value, label }) => {
-			const selected = value === active;
-			return h(
-				"button",
-				{
-					"aria-pressed": selected ? "true" : "false",
-					className: `toggle-button${selected ? " active" : ""}`,
-					"data-filter": value,
-					key: value,
-					onClick: () => onSelect(value),
-					type: "button",
-				},
-				label,
-			);
-		}),
-	);
 }
 
 function TraceCandidateGroup({

--- a/packages/ui/src/tabs/feed/toggles.ts
+++ b/packages/ui/src/tabs/feed/toggles.ts
@@ -1,0 +1,74 @@
+/* Feed toggle buttons + tag chip — tiny leaf components shared across
+ * the feed tab. */
+
+import { h } from "preact";
+import { Chip } from "../../components/primitives/chip";
+import { formatTagLabel } from "../../lib/format";
+import type { ItemViewMode } from "./types";
+
+export function FeedViewToggle({
+	modes,
+	active,
+	onSelect,
+}: {
+	modes: Array<{ id: ItemViewMode; label: string }>;
+	active: ItemViewMode;
+	onSelect: (mode: ItemViewMode) => void;
+}) {
+	if (modes.length <= 1) return null;
+	return h(
+		"div",
+		{ className: "feed-toggle" },
+		modes.map((mode) =>
+			h(
+				"button",
+				{
+					key: mode.id,
+					className: `toggle-button${mode.id === active ? " active" : ""}`,
+					"data-filter": mode.id,
+					onClick: () => onSelect(mode.id),
+					type: "button",
+				},
+				mode.label,
+			),
+		),
+	);
+}
+
+export function FeedToggle({
+	id,
+	active,
+	options,
+	onSelect,
+}: {
+	id: string;
+	active: string;
+	options: Array<{ value: string; label: string }>;
+	onSelect: (value: string) => void;
+}) {
+	return h(
+		"div",
+		{ className: "feed-toggle", id },
+		options.map(({ value, label }) => {
+			const selected = value === active;
+			return h(
+				"button",
+				{
+					"aria-pressed": selected ? "true" : "false",
+					className: `toggle-button${selected ? " active" : ""}`,
+					"data-filter": value,
+					key: value,
+					onClick: () => onSelect(value),
+					type: "button",
+				},
+				label,
+			);
+		}),
+	);
+}
+
+export function TagChip({ tag }: { tag: unknown }) {
+	const display = formatTagLabel(tag);
+	if (!display) return null;
+	return h(Chip, { variant: "tag", title: String(tag) }, display);
+}


### PR DESCRIPTION
## Description

Stacked on top of #846. Move three small leaf components — \`FeedViewToggle\`, \`FeedToggle\`, \`TagChip\` — into \`feed/toggles.ts\`. All three are pure stateless components with no external state access. \`feed.ts\` imports them.

- New file \`packages/ui/src/tabs/feed/toggles.ts\`
- \`feed.ts\` shrinks by ~65 LOC

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced