### PR TITLE
refactor(ui): extract feed/trace.ts — TraceCandidateGroup for inspector panel

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -611,44 +611,7 @@ function feedMetaText(visibleCount: number): string {
 	return `${visibleCount} items${filterLabel}${scopeLabel}${queryLabel}${filteredLabel}${moreLabel}`;
 }
 
-function TraceCandidateGroup({
-	label,
-	candidates,
-}: {
-	label: string;
-	candidates: api.PackTraceCandidate[];
-}) {
-	if (candidates.length === 0) return null;
-	return h(
-		"div",
-		{ className: "trace-group" },
-		h("div", { className: "section-meta" }, label),
-		h(
-			"div",
-			{ className: "feed-list" },
-			candidates.map((candidate) =>
-				h(
-					"div",
-					{ className: "feed-card", key: `${label}:${candidate.id}` },
-					h("div", { className: "feed-card-header" }, [
-						h("div", { className: "feed-card-title" }, `${candidate.rank}. ${candidate.title}`),
-						h(
-							"div",
-							{ className: "feed-card-meta" },
-							`#${candidate.id} · ${candidate.kind}${candidate.section ? ` · ${candidate.section}` : ""}`,
-						),
-					]),
-					h("div", { className: "feed-card-body" }, [
-						h("div", null, candidate.preview || "No preview available."),
-						candidate.reasons.length
-							? h("div", { className: "section-meta" }, `Reasons: ${candidate.reasons.join(", ")}`)
-							: null,
-					]),
-				),
-			),
-		),
-	);
-}
+import { TraceCandidateGroup } from "./feed/trace";
 
 function ContextInspectorPanel({ open }: { open: boolean }) {
 	const [inspectorQuery, setInspectorQuery] = useState(() => String(state.feedQuery || ""));

--- a/packages/ui/src/tabs/feed/trace.ts
+++ b/packages/ui/src/tabs/feed/trace.ts
@@ -1,0 +1,44 @@
+/* Feed context-inspector trace candidate group — renders a labeled batch
+ * of PackTraceCandidates for the inspector panel. */
+
+import { h } from "preact";
+import type * as api from "../../lib/api";
+
+export function TraceCandidateGroup({
+	label,
+	candidates,
+}: {
+	label: string;
+	candidates: api.PackTraceCandidate[];
+}) {
+	if (candidates.length === 0) return null;
+	return h(
+		"div",
+		{ className: "trace-group" },
+		h("div", { className: "section-meta" }, label),
+		h(
+			"div",
+			{ className: "feed-list" },
+			candidates.map((candidate) =>
+				h(
+					"div",
+					{ className: "feed-card", key: `${label}:${candidate.id}` },
+					h("div", { className: "feed-card-header" }, [
+						h("div", { className: "feed-card-title" }, `${candidate.rank}. ${candidate.title}`),
+						h(
+							"div",
+							{ className: "feed-card-meta" },
+							`#${candidate.id} · ${candidate.kind}${candidate.section ? ` · ${candidate.section}` : ""}`,
+						),
+					]),
+					h("div", { className: "feed-card-body" }, [
+						h("div", null, candidate.preview || "No preview available."),
+						candidate.reasons.length
+							? h("div", { className: "section-meta" }, `Reasons: ${candidate.reasons.join(", ")}`)
+							: null,
+					]),
+				),
+			),
+		),
+	);
+}


### PR DESCRIPTION
## Description

Stacked on top of #847. Move \`TraceCandidateGroup\` (used by the context-inspector panel) into its own module. Pure component.

- New file \`packages/ui/src/tabs/feed/trace.ts\`
- \`feed.ts\` shrinks by ~38 LOC

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced