### PR TITLE
refactor(ui): extract feed/mount.ts — render-boundary helpers + ProvenanceChip

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -1,9 +1,9 @@
 /* Feed tab — memory feed rendering, filtering, search. */
 
-import { type ComponentChildren, Fragment, h, render } from "preact";
+import { Fragment, h } from "preact";
 import { useEffect, useRef, useState } from "preact/hooks";
 import { Chip } from "../components/primitives/chip";
-import { Tooltip, TooltipProvider } from "../components/primitives/tooltip";
+import { Tooltip } from "../components/primitives/tooltip";
 import * as api from "../lib/api";
 import { highlightText } from "../lib/dom";
 import {
@@ -54,27 +54,7 @@ let feedScrollHandlerBound = false;
 let feedProjectGeneration = 0;
 let lastFeedScope = "all";
 
-function markFeedMount(mount: HTMLElement) {
-	mount.dataset.feedRenderRoot = "preact";
-}
-
-function ensureFeedRenderBoundary() {
-	const feedTab = document.getElementById("tab-feed");
-	if (!feedTab) return;
-	feedTab.dataset.feedRenderBoundary = "preact-hybrid";
-}
-
-function renderIntoFeedMount(mount: HTMLElement, content: ComponentChildren) {
-	markFeedMount(mount);
-	// Wrap every feed render in a TooltipProvider so adjacent feed-item
-	// tooltips share skipDelayDuration and don't each pay the full open
-	// delay when the user hovers from one card to the next.
-	render(h(TooltipProvider, null, content), mount);
-}
-
-function ProvenanceChip({ label, variant = "" }: { label: string; variant?: string }) {
-	return h(Chip, { variant: "provenance", tone: variant || undefined }, label);
-}
+import { ensureFeedRenderBoundary, ProvenanceChip, renderIntoFeedMount } from "./feed/mount";
 
 function resetPagination(project: string) {
 	lastFeedProject = project;

--- a/packages/ui/src/tabs/feed/mount.ts
+++ b/packages/ui/src/tabs/feed/mount.ts
@@ -1,0 +1,27 @@
+/* Feed render boundary helpers + the ProvenanceChip wrapper. */
+
+import { type ComponentChildren, h, render } from "preact";
+import { Chip } from "../../components/primitives/chip";
+import { TooltipProvider } from "../../components/primitives/tooltip";
+
+export function markFeedMount(mount: HTMLElement) {
+	mount.dataset.feedRenderRoot = "preact";
+}
+
+export function ensureFeedRenderBoundary() {
+	const feedTab = document.getElementById("tab-feed");
+	if (!feedTab) return;
+	feedTab.dataset.feedRenderBoundary = "preact-hybrid";
+}
+
+export function renderIntoFeedMount(mount: HTMLElement, content: ComponentChildren) {
+	markFeedMount(mount);
+	// Wrap every feed render in a TooltipProvider so adjacent feed-item
+	// tooltips share skipDelayDuration and don't each pay the full open
+	// delay when the user hovers from one card to the next.
+	render(h(TooltipProvider, null, content), mount);
+}
+
+export function ProvenanceChip({ label, variant = "" }: { label: string; variant?: string }) {
+	return h(Chip, { variant: "provenance", tone: variant || undefined }, label);
+}


### PR DESCRIPTION
## Description

Stacked on top of #848. Move the feed render-boundary helpers (\`markFeedMount\`, \`ensureFeedRenderBoundary\`, \`renderIntoFeedMount\`) plus the tiny \`ProvenanceChip\` wrapper into \`feed/mount.ts\`. Drops now-unused \`ComponentChildren\`, \`render\`, and \`TooltipProvider\` imports from \`feed.ts\`.

- New file \`packages/ui/src/tabs/feed/mount.ts\`
- \`feed.ts\` shrinks by ~20 LOC

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced