### PR TITLE
refactor(ui): extract feed/meta.ts — feedMetaText summary-line builder

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -23,7 +23,6 @@ export type { FeedItem, FeedItemMetadata } from "./feed/types";
 
 import {
 	authorLabel,
-	feedScopeLabel,
 	isLowSignalObservation,
 	itemKey,
 	mergeFeedItems,
@@ -574,23 +573,7 @@ function maybeLoadMoreFeedPage() {
 	void loadMoreFeedPage();
 }
 
-function feedMetaText(visibleCount: number): string {
-	const filterLabel =
-		state.feedTypeFilter === "observations"
-			? " · observations"
-			: state.feedTypeFilter === "summaries"
-				? " · session summaries"
-				: "";
-	const scopeLabel = feedScopeLabel(state.feedScopeFilter);
-	const filteredLabel =
-		!state.feedQuery.trim() && state.lastFeedFilteredCount
-			? ` · ${state.lastFeedFilteredCount} observations filtered`
-			: "";
-	const queryLabel = state.feedQuery.trim() ? ` · matching "${state.feedQuery.trim()}"` : "";
-	const moreLabel = hasMorePages() ? " · scroll for more" : "";
-	return `${visibleCount} items${filterLabel}${scopeLabel}${queryLabel}${filteredLabel}${moreLabel}`;
-}
-
+import { feedMetaText } from "./feed/meta";
 import { TraceCandidateGroup } from "./feed/trace";
 
 function ContextInspectorPanel({ open }: { open: boolean }) {
@@ -842,7 +825,7 @@ function FeedTabView({ items, loadingText }: { items: FeedItem[]; loadingText?: 
 			h(
 				"div",
 				{ className: "section-meta", id: "feedMeta" },
-				loadingText || feedMetaText(items.length),
+				loadingText || feedMetaText(items.length, hasMorePages()),
 			),
 			h(
 				"div",

--- a/packages/ui/src/tabs/feed/meta.ts
+++ b/packages/ui/src/tabs/feed/meta.ts
@@ -1,0 +1,21 @@
+/* Feed summary-line text — shows counts, scope, filters, "scroll for more". */
+
+import { state } from "../../lib/state";
+import { feedScopeLabel } from "./helpers";
+
+export function feedMetaText(visibleCount: number, hasMorePages: boolean): string {
+	const filterLabel =
+		state.feedTypeFilter === "observations"
+			? " · observations"
+			: state.feedTypeFilter === "summaries"
+				? " · session summaries"
+				: "";
+	const scopeLabel = feedScopeLabel(state.feedScopeFilter);
+	const filteredLabel =
+		!state.feedQuery.trim() && state.lastFeedFilteredCount
+			? ` · ${state.lastFeedFilteredCount} observations filtered`
+			: "";
+	const queryLabel = state.feedQuery.trim() ? ` · matching "${state.feedQuery.trim()}"` : "";
+	const moreLabel = hasMorePages ? " · scroll for more" : "";
+	return `${visibleCount} items${filterLabel}${scopeLabel}${queryLabel}${filteredLabel}${moreLabel}`;
+}


### PR DESCRIPTION
## Description

Stacked on top of #849. Move \`feedMetaText\` (the "N items · filter · scope · ..." summary line) into \`feed/meta.ts\`. Takes \`hasMorePages\` as a parameter so the new module stays free of pagination module state. Drops the now-unused \`feedScopeLabel\` import from \`feed.ts\` (it's only used inside the new module).

- New file \`packages/ui/src/tabs/feed/meta.ts\`
- \`feed.ts\` shrinks by ~15 LOC
- Same behavior: single callsite now passes \`hasMorePages()\` explicitly

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced