### PR TITLE
refactor(core): extract maintenance/init-vacuum.ts — initDatabase + vacuumDatabase

### DIFF
--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -1,9 +1,8 @@
-import { statSync } from "node:fs";
-import { assertSchemaReady, connect, getSchemaVersion, resolveDbPath } from "./db.js";
-import { withDb } from "./maintenance/with-db.js";
-import { ensureMaintenanceJobsSchema } from "./maintenance-jobs.js";
-import { bootstrapSchema } from "./schema-bootstrap.js";
-
+export { initDatabase, vacuumDatabase } from "./maintenance/init-vacuum.js";
+export {
+	compareMemoryRoleReports,
+	getMemoryRoleReport,
+} from "./maintenance/memory-role-report.js";
 export {
 	applyRawEventRelinkPlan,
 	applyRawEventRelinkPlanWithDb,
@@ -31,38 +30,6 @@ export type {
 	RawEventStatusItem,
 	RawEventStatusResult,
 } from "./maintenance/types.js";
-
-import { applyRawEventRelinkPlanWithDb } from "./maintenance/relink.js";
-
-export {
-	compareMemoryRoleReports,
-	getMemoryRoleReport,
-} from "./maintenance/memory-role-report.js";
-
-export function initDatabase(dbPath?: string): { path: string; sizeBytes: number } {
-	const resolvedPath = resolveDbPath(dbPath);
-	const db = connect(resolvedPath);
-	try {
-		if (getSchemaVersion(db) === 0) {
-			bootstrapSchema(db);
-		}
-		assertSchemaReady(db);
-		ensureMaintenanceJobsSchema(db);
-		applyRawEventRelinkPlanWithDb(db);
-		const stats = statSync(resolvedPath);
-		return { path: resolvedPath, sizeBytes: stats.size };
-	} finally {
-		db.close();
-	}
-}
-
-export function vacuumDatabase(dbPath?: string): { path: string; sizeBytes: number } {
-	return withDb(dbPath, (db, resolvedPath) => {
-		db.exec("VACUUM");
-		const stats = statSync(resolvedPath);
-		return { path: resolvedPath, sizeBytes: stats.size };
-	});
-}
 
 // ---------------------------------------------------------------------------
 // Reliability metrics

--- a/packages/core/src/maintenance/init-vacuum.ts
+++ b/packages/core/src/maintenance/init-vacuum.ts
@@ -1,0 +1,37 @@
+/* Database init + vacuum — bootstrap schema, run relink, vacuum on demand.
+ *
+ * Extracted verbatim from packages/core/src/maintenance.ts as part of
+ * the maintenance/ split (tracked under codemem-ug38).
+ */
+
+import { statSync } from "node:fs";
+import { assertSchemaReady, connect, getSchemaVersion, resolveDbPath } from "../db.js";
+import { ensureMaintenanceJobsSchema } from "../maintenance-jobs.js";
+import { bootstrapSchema } from "../schema-bootstrap.js";
+import { applyRawEventRelinkPlanWithDb } from "./relink.js";
+import { withDb } from "./with-db.js";
+
+export function initDatabase(dbPath?: string): { path: string; sizeBytes: number } {
+	const resolvedPath = resolveDbPath(dbPath);
+	const db = connect(resolvedPath);
+	try {
+		if (getSchemaVersion(db) === 0) {
+			bootstrapSchema(db);
+		}
+		assertSchemaReady(db);
+		ensureMaintenanceJobsSchema(db);
+		applyRawEventRelinkPlanWithDb(db);
+		const stats = statSync(resolvedPath);
+		return { path: resolvedPath, sizeBytes: stats.size };
+	} finally {
+		db.close();
+	}
+}
+
+export function vacuumDatabase(dbPath?: string): { path: string; sizeBytes: number } {
+	return withDb(dbPath, (db, resolvedPath) => {
+		db.exec("VACUUM");
+		const stats = statSync(resolvedPath);
+		return { path: resolvedPath, sizeBytes: stats.size };
+	});
+}


### PR DESCRIPTION
## Description

Stacked on top of #852. Move \`initDatabase\` and \`vacuumDatabase\` into \`maintenance/init-vacuum.ts\`. \`initDatabase\` imports \`applyRawEventRelinkPlanWithDb\` from the earlier-extracted \`relink.ts\` module (which is why this comes after #852). \`maintenance.ts\` re-exports both.

After this slice \`maintenance.ts\` is **just re-exports** — about 100 lines of public-API surface only. Every implementation lives under \`maintenance/\`.

- New file \`packages/core/src/maintenance/init-vacuum.ts\`
- \`maintenance.ts\` shrinks to ~100 LOC (from ~130)

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced