### PR TITLE
chore: strip extracted-verbatim banner noise from split modules

### DIFF
--- a/packages/core/src/maintenance/ai-structured.ts
+++ b/packages/core/src/maintenance/ai-structured.ts
@@ -1,7 +1,4 @@
 /* AI-powered structured-content backfill for older memories.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import type { Database } from "../db.js";

--- a/packages/core/src/maintenance/backfill-narrative.ts
+++ b/packages/core/src/maintenance/backfill-narrative.ts
@@ -1,7 +1,4 @@
 /* Narrative backfill for session_summary memories.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import type { Database } from "../db.js";

--- a/packages/core/src/maintenance/backfill-tags.ts
+++ b/packages/core/src/maintenance/backfill-tags.ts
@@ -1,7 +1,4 @@
 /* Tag-text backfill for memory_items.tags_text.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import type { Database } from "../db.js";

--- a/packages/core/src/maintenance/dedup-keys.ts
+++ b/packages/core/src/maintenance/dedup-keys.ts
@@ -1,7 +1,4 @@
 /* Dedup-key planning and backfill for memory_items.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import type { Database } from "../db.js";

--- a/packages/core/src/maintenance/dedup.ts
+++ b/packages/core/src/maintenance/dedup.ts
@@ -1,7 +1,4 @@
 /* Near-duplicate memory deactivation.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import type { Database } from "../db.js";

--- a/packages/core/src/maintenance/init-vacuum.ts
+++ b/packages/core/src/maintenance/init-vacuum.ts
@@ -1,7 +1,4 @@
 /* Database init + vacuum — bootstrap schema, run relink, vacuum on demand.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import { statSync } from "node:fs";

--- a/packages/core/src/maintenance/low-signal.ts
+++ b/packages/core/src/maintenance/low-signal.ts
@@ -1,7 +1,4 @@
 /* Low-signal memory deactivation for the maintenance surface.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import type { Database } from "../db.js";

--- a/packages/core/src/maintenance/memory-role-helpers.ts
+++ b/packages/core/src/maintenance/memory-role-helpers.ts
@@ -1,9 +1,4 @@
-/* Memory-role probe scoring + helper utilities.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38). Consumed by
- * getMemoryRoleReport and compareMemoryRoleReports.
- */
+/* Memory-role probe scoring + helper utilities. */
 
 import { getInjectionEvalScenarioByPrompt } from "../eval-scenarios.js";
 import { getSummaryMetadata } from "../summary-memory.js";

--- a/packages/core/src/maintenance/memory-role-report.ts
+++ b/packages/core/src/maintenance/memory-role-report.ts
@@ -1,8 +1,5 @@
 /* Memory-role reporting — builds the role/mapping/probe report used by
  * the CLI's `bd memory role-report` and related tooling.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import { getInjectionEvalScenarioByPrompt } from "../eval-scenarios.js";

--- a/packages/core/src/maintenance/narrative-extract.ts
+++ b/packages/core/src/maintenance/narrative-extract.ts
@@ -1,9 +1,4 @@
-/* Narrative extraction from session-summary body text.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38). Pure — no db,
- * no imports, no side effects.
- */
+/* Narrative extraction from session-summary body text. */
 
 export function extractNarrativeFromBody(bodyText: string): string | null {
 	// Match sections like "## Completed\n...\n\n## Learned\n..."

--- a/packages/core/src/maintenance/reliability.ts
+++ b/packages/core/src/maintenance/reliability.ts
@@ -1,7 +1,4 @@
 /* Reliability metrics + raw-events gate for the maintenance surface.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import { and, eq, gte, inArray, sql } from "drizzle-orm";

--- a/packages/core/src/maintenance/relink.ts
+++ b/packages/core/src/maintenance/relink.ts
@@ -1,8 +1,5 @@
 /* Raw-event relink — group/plan/apply helpers for canonicalizing
  * opencode session linkage.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import { inArray, sql } from "drizzle-orm";

--- a/packages/core/src/maintenance/status.ts
+++ b/packages/core/src/maintenance/status.ts
@@ -1,7 +1,4 @@
 /* Raw-event status and retry helpers for the maintenance surface.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38).
  */
 
 import { and, eq, gt, inArray, sql } from "drizzle-orm";

--- a/packages/core/src/maintenance/tag-helpers.ts
+++ b/packages/core/src/maintenance/tag-helpers.ts
@@ -1,9 +1,4 @@
-/* Tag-derivation helpers for the memory_items.tags_text backfill.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as part of
- * the maintenance/ split (tracked under codemem-ug38). Pure — no db,
- * no side effects.
- */
+/* Tag-derivation helpers for the memory_items.tags_text backfill. */
 
 export function normalizeTag(value: string): string {
 	let normalized = value.trim().toLowerCase();

--- a/packages/core/src/maintenance/types.ts
+++ b/packages/core/src/maintenance/types.ts
@@ -1,12 +1,4 @@
 /* Maintenance module shared types.
- *
- * Extracted verbatim from packages/core/src/maintenance.ts as the first
- * step of the maintenance/ split (tracked under codemem-ug38). Pure
- * interfaces + the MemoryRole string union — no runtime code, no
- * behavior change. Further exports (reliability metrics, tags-backfill,
- * low-signal, dedup, narrative, ai-structured) stay with their job
- * modules for now and will migrate alongside those functions in
- * follow-up sub-commits.
  */
 
 export interface RawEventStatusItem {

--- a/packages/core/src/maintenance/with-db.ts
+++ b/packages/core/src/maintenance/with-db.ts
@@ -1,7 +1,5 @@
-/* Shared withDb helper for maintenance job modules — resolves the dbPath,
- * opens a connection, asserts the schema is ready, then runs the callback
- * with guaranteed cleanup. Extracted from maintenance.ts as part of the
- * maintenance/ split (tracked under codemem-ug38). */
+/* Shared withDb helper — resolves the dbPath, opens a connection, asserts
+ * the schema is ready, then runs the callback with guaranteed cleanup. */
 
 import { assertSchemaReady, connect, type Database, resolveDbPath } from "../db.js";
 

--- a/packages/ui/src/tabs/feed/helpers.ts
+++ b/packages/ui/src/tabs/feed/helpers.ts
@@ -1,8 +1,4 @@
 /* Pure helper functions for the Feed tab — no rendering, no state mutation.
- *
- * Extracted verbatim from packages/ui/src/tabs/feed.ts as part of the
- * feed/ split (tracked under codemem-ug38). Each function below is
- * exported so feed.ts can import it; nothing else changed.
  */
 
 import { normalize } from "../../lib/format";


### PR DESCRIPTION
## Description

Stacked on top of #854. Cleanup-only pass: strip the "Extracted verbatim from packages/core/src/maintenance.ts as part of the maintenance/ split (tracked under codemem-ug38)" noise from the banner comments in every split module. Those sentences tracked history that belongs in commit messages / PR descriptions, not in the source file — they rot and add noise on every future read.

Files touched (banner edits only, no behavior change):
- \`packages/core/src/maintenance/\*.ts\` (16 files)
- \`packages/ui/src/tabs/feed/helpers.ts\`

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced