### PR TITLE
refactor(ui): extract feed/view.ts — FeedList + FeedTabView with ops prop DI

### DIFF
--- a/packages/ui/src/tabs/feed.ts
+++ b/packages/ui/src/tabs/feed.ts
@@ -1,9 +1,8 @@
 /* Feed tab — memory feed rendering, filtering, search. */
 
-import { Fragment, h } from "preact";
-import { useState } from "preact/hooks";
+import { h } from "preact";
 import * as api from "../lib/api";
-import { setFeedScopeFilter, setFeedTypeFilter, state } from "../lib/state";
+import { state } from "../lib/state";
 
 /* ── Types ───────────────────────────────────────────────── */
 
@@ -23,7 +22,6 @@ import {
 	pageNextOffset,
 	SUMMARY_PAGE_SIZE,
 } from "./feed/pagination";
-import { FeedSkeletonItem } from "./feed/skeleton";
 import type { FeedItem } from "./feed/types";
 
 /* ── Module state ─────────────────────────────────────────── */
@@ -97,54 +95,7 @@ function removeFeedItem(memoryId: number) {
 
 export { observationViewData } from "./feed/observation-view";
 
-import { FeedItemCard } from "./feed/card";
-import { FeedToggle } from "./feed/toggles";
-
-function FeedList({ items, loadingText }: { items: FeedItem[]; loadingText?: string }) {
-	if (loadingText) {
-		return h(
-			"div",
-			{
-				className: "feed-skeleton",
-				role: "status",
-				"aria-label": loadingText,
-			},
-			[0, 1, 2, 3].map((i) => h(FeedSkeletonItem, { index: i, key: `skeleton-${i}` })),
-		);
-	}
-	if (!items.length) {
-		const hasFilters =
-			Boolean(state.feedQuery.trim()) ||
-			state.feedTypeFilter !== "all" ||
-			state.feedScopeFilter !== "all";
-		return h(
-			"div",
-			{ className: "small feed-empty-state" },
-			h("strong", null, hasFilters ? "No memories match the current filters." : "No memories yet."),
-			h(
-				"div",
-				null,
-				hasFilters
-					? "Try clearing filters, changing the scope, or using a broader search."
-					: "Memories and session summaries will appear here once codemem has something worth keeping.",
-			),
-		);
-	}
-	return h(
-		Fragment,
-		null,
-		items.map((item) =>
-			h(FeedItemCard, {
-				item,
-				key: itemKey(item),
-				onReplace: replaceFeedItem,
-				onRemove: removeFeedItem,
-				onViewRefresh: () => updateFeedView(true),
-				onReload: loadFeedData,
-			}),
-		),
-	);
-}
+import { FeedTabView, type FeedViewOps } from "./feed/view";
 
 /* ── Filtering ───────────────────────────────────────────── */
 
@@ -220,85 +171,21 @@ function maybeLoadMoreFeedPage() {
 	void loadMoreFeedPage();
 }
 
-import { ContextInspectorPanel } from "./feed/inspector";
-import { feedMetaText } from "./feed/meta";
-
-function FeedTabView({ items, loadingText }: { items: FeedItem[]; loadingText?: string }) {
-	const [inspectorOpen, setInspectorOpen] = useState(false);
-	return h(
-		Fragment,
-		null,
-		h(
-			"div",
-			{ className: "feed-controls" },
-			h(
-				"div",
-				{ className: "section-meta", id: "feedMeta" },
-				loadingText || feedMetaText(items.length, hasMorePages()),
-			),
-			h(
-				"div",
-				{ className: "feed-controls-right" },
-				h("input", {
-					className: "feed-search",
-					id: "feedSearch",
-					onInput: (event) => {
-						state.feedQuery = String((event.currentTarget as HTMLInputElement).value || "");
-						updateFeedView();
-					},
-					placeholder: "Search title, body, tags…",
-					value: state.feedQuery,
-				}),
-				h(FeedToggle, {
-					active: state.feedScopeFilter,
-					id: "feedScopeToggle",
-					onSelect: (value) => {
-						if (value === state.feedScopeFilter) return;
-						setFeedScopeFilter(value);
-						void loadFeedData();
-					},
-					options: [
-						{ value: "all", label: "All" },
-						{ value: "mine", label: "My memories" },
-						{ value: "theirs", label: "Other people" },
-					],
-				}),
-				h(FeedToggle, {
-					active: state.feedTypeFilter,
-					id: "feedTypeToggle",
-					onSelect: (value) => {
-						if (value === state.feedTypeFilter) return;
-						setFeedTypeFilter(value);
-						updateFeedView();
-					},
-					options: [
-						{ value: "all", label: "All" },
-						{ value: "observations", label: "Observations" },
-						{ value: "summaries", label: "Summaries" },
-					],
-				}),
-				h(
-					"button",
-					{
-						"aria-controls": "contextInspectorPanel",
-						"aria-expanded": inspectorOpen,
-						className: "settings-button feed-inspector-button",
-						onClick: () => setInspectorOpen((current) => !current),
-						type: "button",
-					},
-					inspectorOpen ? "Hide Context Inspector" : "Context Inspector",
-				),
-			),
-		),
-		h(ContextInspectorPanel, { open: inspectorOpen }),
-		h("div", { className: "feed-list", id: "feedList" }, h(FeedList, { items, loadingText })),
-	);
-}
+const feedOps: FeedViewOps = {
+	replaceFeedItem,
+	removeFeedItem,
+	updateFeedView: (force?: boolean) => updateFeedView(force),
+	loadFeedData: () => loadFeedData(),
+	hasMorePages,
+};
 
 function renderFeedTab(items: FeedItem[], options?: { loadingText?: string }) {
 	const feedTab = document.getElementById("tab-feed");
 	if (!feedTab) return false;
-	renderIntoFeedMount(feedTab, h(FeedTabView, { items, loadingText: options?.loadingText }));
+	renderIntoFeedMount(
+		feedTab,
+		h(FeedTabView, { items, loadingText: options?.loadingText, ops: feedOps }),
+	);
 	const globalLucide = (globalThis as { lucide?: { createIcons: () => void } }).lucide;
 	if (globalLucide && !options?.loadingText) {
 		globalLucide.createIcons();

--- a/packages/ui/src/tabs/feed/view.ts
+++ b/packages/ui/src/tabs/feed/view.ts
@@ -1,0 +1,156 @@
+/* Feed tab view — top-level layout for controls row, inspector panel,
+ * and the list of feed items. Receives state mutators + view-refresh
+ * callbacks as props to avoid circular imports with feed.ts. */
+
+import { Fragment, h } from "preact";
+import { useState } from "preact/hooks";
+import { setFeedScopeFilter, setFeedTypeFilter, state } from "../../lib/state";
+import { FeedItemCard } from "./card";
+import { itemKey } from "./helpers";
+import { ContextInspectorPanel } from "./inspector";
+import { feedMetaText } from "./meta";
+import { FeedSkeletonItem } from "./skeleton";
+import { FeedToggle } from "./toggles";
+import type { FeedItem } from "./types";
+
+export interface FeedViewOps {
+	replaceFeedItem: (item: FeedItem) => void;
+	removeFeedItem: (memoryId: number) => void;
+	updateFeedView: (force?: boolean) => void;
+	loadFeedData: () => Promise<void>;
+	hasMorePages: () => boolean;
+}
+
+export function FeedList({
+	items,
+	loadingText,
+	ops,
+}: {
+	items: FeedItem[];
+	loadingText?: string;
+	ops: FeedViewOps;
+}) {
+	if (loadingText) {
+		return h(
+			"div",
+			{
+				className: "feed-skeleton",
+				role: "status",
+				"aria-label": loadingText,
+			},
+			[0, 1, 2, 3].map((i) => h(FeedSkeletonItem, { index: i, key: `skeleton-${i}` })),
+		);
+	}
+	if (!items.length) {
+		const hasFilters =
+			Boolean(state.feedQuery.trim()) ||
+			state.feedTypeFilter !== "all" ||
+			state.feedScopeFilter !== "all";
+		return h(
+			"div",
+			{ className: "small feed-empty-state" },
+			h("strong", null, hasFilters ? "No memories match the current filters." : "No memories yet."),
+			h(
+				"div",
+				null,
+				hasFilters
+					? "Try clearing filters, changing the scope, or using a broader search."
+					: "Memories and session summaries will appear here once codemem has something worth keeping.",
+			),
+		);
+	}
+	return h(
+		Fragment,
+		null,
+		items.map((item) =>
+			h(FeedItemCard, {
+				item,
+				key: itemKey(item),
+				onReplace: ops.replaceFeedItem,
+				onRemove: ops.removeFeedItem,
+				onViewRefresh: () => ops.updateFeedView(true),
+				onReload: ops.loadFeedData,
+			}),
+		),
+	);
+}
+
+export function FeedTabView({
+	items,
+	loadingText,
+	ops,
+}: {
+	items: FeedItem[];
+	loadingText?: string;
+	ops: FeedViewOps;
+}) {
+	const [inspectorOpen, setInspectorOpen] = useState(false);
+	return h(
+		Fragment,
+		null,
+		h(
+			"div",
+			{ className: "feed-controls" },
+			h(
+				"div",
+				{ className: "section-meta", id: "feedMeta" },
+				loadingText || feedMetaText(items.length, ops.hasMorePages()),
+			),
+			h(
+				"div",
+				{ className: "feed-controls-right" },
+				h("input", {
+					className: "feed-search",
+					id: "feedSearch",
+					onInput: (event) => {
+						state.feedQuery = String((event.currentTarget as HTMLInputElement).value || "");
+						ops.updateFeedView();
+					},
+					placeholder: "Search title, body, tags…",
+					value: state.feedQuery,
+				}),
+				h(FeedToggle, {
+					active: state.feedScopeFilter,
+					id: "feedScopeToggle",
+					onSelect: (value) => {
+						if (value === state.feedScopeFilter) return;
+						setFeedScopeFilter(value);
+						void ops.loadFeedData();
+					},
+					options: [
+						{ value: "all", label: "All" },
+						{ value: "mine", label: "My memories" },
+						{ value: "theirs", label: "Other people" },
+					],
+				}),
+				h(FeedToggle, {
+					active: state.feedTypeFilter,
+					id: "feedTypeToggle",
+					onSelect: (value) => {
+						if (value === state.feedTypeFilter) return;
+						setFeedTypeFilter(value);
+						ops.updateFeedView();
+					},
+					options: [
+						{ value: "all", label: "All" },
+						{ value: "observations", label: "Observations" },
+						{ value: "summaries", label: "Summaries" },
+					],
+				}),
+				h(
+					"button",
+					{
+						"aria-controls": "contextInspectorPanel",
+						"aria-expanded": inspectorOpen,
+						className: "settings-button feed-inspector-button",
+						onClick: () => setInspectorOpen((current) => !current),
+						type: "button",
+					},
+					inspectorOpen ? "Hide Context Inspector" : "Context Inspector",
+				),
+			),
+		),
+		h(ContextInspectorPanel, { open: inspectorOpen }),
+		h("div", { className: "feed-list", id: "feedList" }, h(FeedList, { items, loadingText, ops })),
+	);
+}


### PR DESCRIPTION
## Description

Stacked on top of #856. Move \`FeedList\` and \`FeedTabView\` (the top-level layout + list renderer) into \`feed/view.ts\`. Both take an \`ops\` prop — a bundle of state mutators (\`replaceFeedItem\`, \`removeFeedItem\`) and callbacks (\`updateFeedView\`, \`loadFeedData\`, \`hasMorePages\`) — so they can run without pulling in feed.ts's module state (which would be circular).

\`feed.ts\`'s \`renderFeedTab\` now builds a single \`feedOps\` bundle once and passes it through. This finishes the major feed-side extractions — what remains in \`feed.ts\` is just the render boundary (pagination state, \`loadFeedData\`, \`loadMoreFeedPage\`, view scheduling, and the public \`initFeedTab\` / \`updateFeedView\` / \`updateFeedTypeToggle\` / \`updateFeedScopeToggle\` API).

- New file \`packages/ui/src/tabs/feed/view.ts\` (~155 LOC)
- \`feed.ts\` shrinks from ~425 LOC to ~315 LOC; drops Fragment, useState, setFeedScopeFilter, setFeedTypeFilter imports that moved with the view

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced