### PR TITLE
refactor(ui): extract settings/data/dom.ts — pure DOM helpers for tooltip + focus

### DIFF
--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -110,62 +110,20 @@ function getObserverModelDescription(): string {
 		: "Default: `gpt-5.1-codex-mini` for Direct API; `claude-4.5-haiku` for Local Claude session.";
 }
 
-function positionHelpTooltipElement(el: HTMLElement, anchor: HTMLElement) {
-	const rect = anchor.getBoundingClientRect();
-	const margin = 8;
-	const gap = 8;
-	const width = el.offsetWidth;
-	const height = el.offsetHeight;
-
-	let left = rect.left + rect.width / 2 - width / 2;
-	left = Math.max(margin, Math.min(left, globalThis.innerWidth - width - margin));
-
-	let top = rect.bottom + gap;
-	if (top + height > globalThis.innerHeight - margin) {
-		top = rect.top - height - gap;
-	}
-	top = Math.max(margin, top);
-
-	el.style.left = `${Math.round(left)}px`;
-	el.style.top = `${Math.round(top)}px`;
-}
+import {
+	focusSettingsDialog,
+	helpButtonFromTarget,
+	positionHelpTooltipElement,
+} from "./settings/data/dom";
 
 function hideHelpTooltip() {
 	settingsController?.hideTooltip();
-}
-
-function helpButtonFromTarget(target: EventTarget | null): HTMLElement | null {
-	if (!(target instanceof Element)) return null;
-	return target.closest(".help-icon[data-tooltip]") as HTMLElement | null;
 }
 
 function markFieldTouched(inputId: keyof SettingsFormState) {
 	const key = INPUT_TO_CONFIG_KEY[inputId];
 	if (!key) return;
 	settingsTouchedKeys.add(key);
-}
-
-function getFocusableNodes(container: HTMLElement | null): HTMLElement[] {
-	if (!container) return [];
-	const selector = [
-		"button:not([disabled])",
-		"input:not([disabled])",
-		"select:not([disabled])",
-		"textarea:not([disabled])",
-		"[href]",
-		'[tabindex]:not([tabindex="-1"])',
-	].join(",");
-	return Array.from(container.querySelectorAll(selector)).filter((node) => {
-		const el = node as HTMLElement;
-		return !el.hidden && el.offsetParent !== null;
-	}) as HTMLElement[];
-}
-
-function focusSettingsDialog() {
-	const modal = $("settingsModal");
-	const focusable = getFocusableNodes(modal as HTMLElement | null);
-	const firstFocusable = focusable[0];
-	(firstFocusable || (modal as HTMLElement | null))?.focus();
 }
 
 function updateRenderState(patch: Partial<SettingsRenderState>) {

--- a/packages/ui/src/tabs/settings/data/dom.ts
+++ b/packages/ui/src/tabs/settings/data/dom.ts
@@ -1,0 +1,53 @@
+/* Pure DOM helpers used by the settings modal — tooltip positioning,
+ * tooltip anchor lookup, focus-trap enumeration, and the initial focus
+ * handler for the opened dialog. */
+
+import { $ } from "../../../lib/dom";
+
+export function positionHelpTooltipElement(el: HTMLElement, anchor: HTMLElement) {
+	const rect = anchor.getBoundingClientRect();
+	const margin = 8;
+	const gap = 8;
+	const width = el.offsetWidth;
+	const height = el.offsetHeight;
+
+	let left = rect.left + rect.width / 2 - width / 2;
+	left = Math.max(margin, Math.min(left, globalThis.innerWidth - width - margin));
+
+	let top = rect.bottom + gap;
+	if (top + height > globalThis.innerHeight - margin) {
+		top = rect.top - height - gap;
+	}
+	top = Math.max(margin, top);
+
+	el.style.left = `${Math.round(left)}px`;
+	el.style.top = `${Math.round(top)}px`;
+}
+
+export function helpButtonFromTarget(target: EventTarget | null): HTMLElement | null {
+	if (!(target instanceof Element)) return null;
+	return target.closest(".help-icon[data-tooltip]") as HTMLElement | null;
+}
+
+export function getFocusableNodes(container: HTMLElement | null): HTMLElement[] {
+	if (!container) return [];
+	const selector = [
+		"button:not([disabled])",
+		"input:not([disabled])",
+		"select:not([disabled])",
+		"textarea:not([disabled])",
+		"[href]",
+		'[tabindex]:not([tabindex="-1"])',
+	].join(",");
+	return Array.from(container.querySelectorAll(selector)).filter((node) => {
+		const el = node as HTMLElement;
+		return !el.hidden && el.offsetParent !== null;
+	}) as HTMLElement[];
+}
+
+export function focusSettingsDialog() {
+	const modal = $("settingsModal");
+	const focusable = getFocusableNodes(modal as HTMLElement | null);
+	const firstFocusable = focusable[0];
+	(firstFocusable || (modal as HTMLElement | null))?.focus();
+}


### PR DESCRIPTION
## Description

Stacked on top of #862. Four more pure DOM helpers into `settings/data/dom.ts`:

- `positionHelpTooltipElement` — tooltip placement math
- `helpButtonFromTarget` — resolve an event target to its nearest `.help-icon[data-tooltip]` anchor
- `getFocusableNodes` — selector-based focusable scan
- `focusSettingsDialog` — initial-focus handler for the opened modal

None of them touch settings module state; `hideHelpTooltip` stays in `settings.tsx` because it dispatches through `settingsController`.

`settings.tsx` shrinks from ~1525 → ~1485 LOC.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced