### PR TITLE
refactor(ui): extract settings/data/model-accessors.ts — observer model + advanced/protected helpers

### DIFF
--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -55,57 +55,34 @@ let settingsRenderState: SettingsRenderState = {
 };
 
 import { SettingsHint } from "./settings/components/SettingsHint";
-
+import {
+	getObserverModelDescription as getObserverModelDescriptionRaw,
+	getObserverModelHint as getObserverModelHintRaw,
+	getObserverModelLabel as getObserverModelLabelRaw,
+	getObserverModelTooltip as getObserverModelTooltipRaw,
+	getTieredRoutingHelperText as getTieredRoutingHelperTextRaw,
+	hiddenUnlessAdvanced as hiddenUnlessAdvancedRaw,
+	isProtectedConfigKey as isProtectedConfigKeyRaw,
+	protectedConfigHelp,
+} from "./settings/data/model-accessors";
 import {
 	hasOwn,
-	inferObserverModel,
 	isEqualValue,
 	loadAdvancedPreference,
 	mergeOverrideBaseline,
-	normalizeTextValue,
 	persistAdvancedPreference,
 	toProviderList,
 } from "./settings/data/value-helpers";
 
-function getObserverModelHint(): string {
-	const values = settingsRenderState.values;
-	if (values.observerTierRoutingEnabled) {
-		return "Tiered routing is enabled: simple/rich model selection now lives in Processing.";
-	}
-	const inferred = inferObserverModel(
-		values.observerRuntime.trim() || "api_http",
-		values.observerProvider.trim(),
-		normalizeTextValue(values.observerModel),
-	);
-	const overrideActive = ["observer_model", "observer_provider", "observer_runtime"].some((key) =>
-		hasOwn(settingsEnvOverrides, key),
-	);
-	const source = overrideActive ? "Env override" : inferred.source;
-	return `${source}: ${inferred.model}`;
-}
-
-function getTieredRoutingHelperText(): string {
-	if (!settingsRenderState.values.observerTierRoutingEnabled) {
-		return "Off: codemem uses the base observer settings from the Connection tab for all batches.";
-	}
-	return "On: codemem can route simpler batches to a lighter model and richer batches to a higher-quality configuration.";
-}
-
-function getObserverModelLabel(): string {
-	return settingsRenderState.values.observerTierRoutingEnabled ? "Base model fallback" : "Model";
-}
-
-function getObserverModelTooltip(): string {
-	return settingsRenderState.values.observerTierRoutingEnabled
-		? "Tiered routing is enabled, so Processing controls the simple/rich models. This base model is only a fallback."
-		: "Leave blank to use a recommended model for your selected mode/provider.";
-}
-
-function getObserverModelDescription(): string {
-	return settingsRenderState.values.observerTierRoutingEnabled
-		? "Tiered routing is active. Use this only as a fallback while the Processing tab owns simple/rich model selection."
-		: "Default: `gpt-5.1-codex-mini` for Direct API; `claude-4.5-haiku` for Local Claude session.";
-}
+const getObserverModelHint = (): string =>
+	getObserverModelHintRaw(settingsRenderState.values, settingsEnvOverrides);
+const getTieredRoutingHelperText = (): string =>
+	getTieredRoutingHelperTextRaw(settingsRenderState.values);
+const getObserverModelLabel = (): string => getObserverModelLabelRaw(settingsRenderState.values);
+const getObserverModelTooltip = (): string =>
+	getObserverModelTooltipRaw(settingsRenderState.values);
+const getObserverModelDescription = (): string =>
+	getObserverModelDescriptionRaw(settingsRenderState.values);
 
 import {
 	focusSettingsDialog,
@@ -387,13 +364,8 @@ export function isSettingsOpen(): boolean {
 
 import { buildSettingsNotice } from "./settings/data/notice";
 
-function isProtectedConfigKey(key: string): boolean {
-	return settingsProtectedKeys.has(key) || PROTECTED_VIEWER_CONFIG_KEYS.has(key);
-}
-
-function protectedConfigHelp(key: string): string {
-	return `${key} is read-only in the viewer for security. Edit the config file or environment instead.`;
-}
+const isProtectedConfigKey = (key: string): boolean =>
+	isProtectedConfigKeyRaw(key, settingsProtectedKeys, PROTECTED_VIEWER_CONFIG_KEYS);
 
 import { type ConfigPayload, formStateFromPayload } from "./settings/data/form-state";
 
@@ -581,9 +553,7 @@ function onAdvancedToggle(checked: boolean) {
 
 import { SettingsSwitchRow } from "./settings/components/SettingsSwitchRow";
 
-function hiddenUnlessAdvanced(): boolean {
-	return !settingsShowAdvanced;
-}
+const hiddenUnlessAdvanced = (): boolean => hiddenUnlessAdvancedRaw(settingsShowAdvanced);
 
 import {
 	ObserverStatusBanner as ObserverStatusBannerComponent,

--- a/packages/ui/src/tabs/settings/data/model-accessors.ts
+++ b/packages/ui/src/tabs/settings/data/model-accessors.ts
@@ -1,0 +1,64 @@
+/* Pure accessors for the Observer tab's dynamic labels, tooltips, and
+ * descriptions. Take the form values + environment overrides as input
+ * so the extracted panel can call them without module-state access. */
+
+import type { SettingsFormState } from "./types";
+import { hasOwn, inferObserverModel, normalizeTextValue } from "./value-helpers";
+
+export function getObserverModelHint(
+	values: SettingsFormState,
+	envOverrides: Record<string, unknown>,
+): string {
+	if (values.observerTierRoutingEnabled) {
+		return "Tiered routing is enabled: simple/rich model selection now lives in Processing.";
+	}
+	const inferred = inferObserverModel(
+		values.observerRuntime.trim() || "api_http",
+		values.observerProvider.trim(),
+		normalizeTextValue(values.observerModel),
+	);
+	const overrideActive = ["observer_model", "observer_provider", "observer_runtime"].some((key) =>
+		hasOwn(envOverrides, key),
+	);
+	const source = overrideActive ? "Env override" : inferred.source;
+	return `${source}: ${inferred.model}`;
+}
+
+export function getTieredRoutingHelperText(values: SettingsFormState): string {
+	if (!values.observerTierRoutingEnabled) {
+		return "Off: codemem uses the base observer settings from the Connection tab for all batches.";
+	}
+	return "On: codemem can route simpler batches to a lighter model and richer batches to a higher-quality configuration.";
+}
+
+export function getObserverModelLabel(values: SettingsFormState): string {
+	return values.observerTierRoutingEnabled ? "Base model fallback" : "Model";
+}
+
+export function getObserverModelTooltip(values: SettingsFormState): string {
+	return values.observerTierRoutingEnabled
+		? "Tiered routing is enabled, so Processing controls the simple/rich models. This base model is only a fallback."
+		: "Leave blank to use a recommended model for your selected mode/provider.";
+}
+
+export function getObserverModelDescription(values: SettingsFormState): string {
+	return values.observerTierRoutingEnabled
+		? "Tiered routing is active. Use this only as a fallback while the Processing tab owns simple/rich model selection."
+		: "Default: `gpt-5.1-codex-mini` for Direct API; `claude-4.5-haiku` for Local Claude session.";
+}
+
+export function hiddenUnlessAdvanced(showAdvanced: boolean): boolean {
+	return !showAdvanced;
+}
+
+export function isProtectedConfigKey(
+	key: string,
+	protectedKeys: Set<string>,
+	viewerProtectedKeys: Set<string>,
+): boolean {
+	return protectedKeys.has(key) || viewerProtectedKeys.has(key);
+}
+
+export function protectedConfigHelp(key: string): string {
+	return `${key} is read-only in the viewer for security. Edit the config file or environment instead.`;
+}


### PR DESCRIPTION
## Description

Stacked on top of #866. Move 8 pure accessor/predicate helpers into `settings/data/model-accessors.ts`:

- `getObserverModelHint`, `getTieredRoutingHelperText`, `getObserverModelLabel`, `getObserverModelTooltip`, `getObserverModelDescription` — model-label/hint computations that take `SettingsFormState` (and, for the hint, env overrides) as parameters instead of reading module state.
- `hiddenUnlessAdvanced(showAdvanced)` — parameterized by the flag.
- `isProtectedConfigKey(key, protectedKeys, viewerProtectedKeys)` — parameterized by the two sets.
- `protectedConfigHelp(key)` — already pure, moves with the family.

`settings.tsx` keeps thin one-line wrappers that pre-bind the current module state, so the panels keep calling the short names through the existing `panelProps` bundle unchanged.

Shrinks from ~740 → ~710 LOC.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced