### PR TITLE
refactor(ui): extract settings/data/diff-payload.ts — changed-field filter for save flow

### DIFF
--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -66,8 +66,6 @@ import {
 	protectedConfigHelp,
 } from "./settings/data/model-accessors";
 import {
-	hasOwn,
-	isEqualValue,
 	loadAdvancedPreference,
 	mergeOverrideBaseline,
 	persistAdvancedPreference,
@@ -412,6 +410,7 @@ export function renderConfigModal(payload: unknown) {
 }
 
 import { collectSettingsPayload as collectSettingsPayloadRaw } from "./settings/data/collect-payload";
+import { diffSettingsPayload } from "./settings/data/diff-payload";
 
 function collectSettingsPayload(
 	options: { allowUntouchedParseErrors?: boolean } = {},
@@ -472,17 +471,12 @@ export async function saveSettings(startPolling: () => void, refreshCallback: ()
 
 	try {
 		const current = collectSettingsPayload({ allowUntouchedParseErrors: true });
-		const changed: Record<string, unknown> = {};
-		Object.entries(current).forEach(([key, value]) => {
-			if (isProtectedConfigKey(key)) {
-				return;
-			}
-			if (hasOwn(settingsEnvOverrides, key) && !settingsTouchedKeys.has(key)) {
-				return;
-			}
-			if (!isEqualValue(value, settingsBaseline[key])) {
-				changed[key] = value;
-			}
+		const changed = diffSettingsPayload({
+			current,
+			baseline: settingsBaseline,
+			envOverrides: settingsEnvOverrides,
+			touchedKeys: settingsTouchedKeys,
+			isProtected: isProtectedConfigKey,
 		});
 		if (Object.keys(changed).length === 0) {
 			updateRenderState({ isSaving: false, statusText: "No unsaved changes" });

--- a/packages/ui/src/tabs/settings/data/diff-payload.ts
+++ b/packages/ui/src/tabs/settings/data/diff-payload.ts
@@ -1,0 +1,26 @@
+/* Compute the subset of settings that actually changed versus the
+ * baseline — skipping protected keys and env-override-managed keys
+ * the user didn't touch. */
+
+import { hasOwn, isEqualValue } from "./value-helpers";
+
+export interface DiffSettingsPayloadInput {
+	current: Record<string, unknown>;
+	baseline: Record<string, unknown>;
+	envOverrides: Record<string, unknown>;
+	touchedKeys: Set<string>;
+	isProtected: (key: string) => boolean;
+}
+
+export function diffSettingsPayload(input: DiffSettingsPayloadInput): Record<string, unknown> {
+	const { current, baseline, envOverrides, touchedKeys, isProtected } = input;
+	const changed: Record<string, unknown> = {};
+	Object.entries(current).forEach(([key, value]) => {
+		if (isProtected(key)) return;
+		if (hasOwn(envOverrides, key) && !touchedKeys.has(key)) return;
+		if (!isEqualValue(value, baseline[key])) {
+			changed[key] = value;
+		}
+	});
+	return changed;
+}


### PR DESCRIPTION
## Description

Stacked on top of #867. Extract the "changed fields" filter from `saveSettings` into `settings/data/diff-payload.ts` as a pure reducer: given `current`, `baseline`, `envOverrides`, `touchedKeys`, and an `isProtected` predicate, returns just the keys the user actually changed.

`saveSettings` now just calls `diffSettingsPayload({ ... })` and its body shrinks to a straightforward happy-path. Also drops the now-unused `hasOwn` and `isEqualValue` imports from `settings.tsx`.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced