### PR TITLE
refactor(ui): extract createSettingsEventHandlers factory into data/event-handlers.ts

### DIFF
--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -1,6 +1,6 @@
 /* Settings modal — observer config, sync settings. */
 
-import { type JSX, render } from "preact";
+import { render } from "preact";
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { RadixDialog } from "../components/primitives/radix-dialog";
 import * as api from "../lib/api";
@@ -20,11 +20,8 @@ let settingsStartPolling: (() => void) | null = null;
 let settingsRefresh: (() => void) | null = null;
 
 import { SettingsModalContent } from "./settings/components/SettingsModalContent";
-import {
-	EMPTY_FORM_STATE,
-	INPUT_TO_CONFIG_KEY,
-	PROTECTED_VIEWER_CONFIG_KEYS,
-} from "./settings/data/constants";
+import { EMPTY_FORM_STATE, PROTECTED_VIEWER_CONFIG_KEYS } from "./settings/data/constants";
+import { createSettingsEventHandlers } from "./settings/data/event-handlers";
 import type {
 	SettingsController,
 	SettingsFormState,
@@ -79,12 +76,6 @@ import { useHelpTooltip } from "./settings/hooks/use-help-tooltip";
 
 function hideHelpTooltip() {
 	settingsController?.hideTooltip();
-}
-
-function markFieldTouched(inputId: keyof SettingsFormState) {
-	const key = INPUT_TO_CONFIG_KEY[inputId];
-	if (!key) return;
-	settingsTouchedKeys.add(key);
 }
 
 function updateRenderState(patch: Partial<SettingsRenderState>) {
@@ -390,29 +381,12 @@ export async function loadConfigData() {
 	} catch {}
 }
 
-function updateField<K extends keyof SettingsFormState>(field: K, value: SettingsFormState[K]) {
-	markFieldTouched(field);
-	updateFormState({ [field]: value } as Partial<SettingsFormState>);
-	setDirty(true);
-}
-
-function onTextInput<K extends keyof SettingsFormState>(field: K) {
-	return (event: JSX.TargetedEvent<HTMLInputElement | HTMLTextAreaElement, Event>) => {
-		updateField(field, event.currentTarget.value as SettingsFormState[K]);
-	};
-}
-
-function onSelectValueChange<K extends keyof SettingsFormState>(field: K) {
-	return (value: string) => {
-		updateField(field, value as SettingsFormState[K]);
-	};
-}
-
-function onSwitchInput<K extends keyof SettingsFormState>(field: K) {
-	return (checked: boolean) => {
-		updateField(field, checked as SettingsFormState[K]);
-	};
-}
+const { onTextInput, onSelectValueChange, onSwitchInput } = createSettingsEventHandlers({
+	getTouchedKeys: () => settingsTouchedKeys,
+	getValues: () => settingsRenderState.values,
+	updateFormState,
+	setDirty: (dirty) => setDirty(dirty),
+});
 
 function onAdvancedToggle(checked: boolean) {
 	settingsShowAdvanced = checked;

--- a/packages/ui/src/tabs/settings/data/event-handlers.ts
+++ b/packages/ui/src/tabs/settings/data/event-handlers.ts
@@ -1,0 +1,71 @@
+/* Factory for the settings form's input event handlers. Takes a deps
+ * object so the handlers don't need direct module-state access —
+ * settings.tsx passes in the touched-keys accessor, current-values getter,
+ * and dispatch callbacks and gets back the bound handlers. */
+
+import type { JSX } from "preact";
+import { INPUT_TO_CONFIG_KEY } from "./constants";
+import type { SettingsFormState } from "./types";
+
+export interface EventHandlerDeps {
+	// Accessor rather than a direct Set reference: settings.tsx
+	// reassigns `settingsTouchedKeys` in renderConfigModal/closeSettings,
+	// so a captured reference would go stale after the first reset.
+	getTouchedKeys: () => Set<string>;
+	getValues: () => SettingsFormState;
+	updateFormState: (patch: Partial<SettingsFormState>) => void;
+	setDirty: (dirty: boolean) => void;
+}
+
+export interface SettingsEventHandlers {
+	markFieldTouched: (inputId: keyof SettingsFormState) => void;
+	updateField: <K extends keyof SettingsFormState>(field: K, value: SettingsFormState[K]) => void;
+	onTextInput: <K extends keyof SettingsFormState>(
+		field: K,
+	) => (event: JSX.TargetedEvent<HTMLInputElement | HTMLTextAreaElement, Event>) => void;
+	onSelectValueChange: <K extends keyof SettingsFormState>(field: K) => (value: string) => void;
+	onSwitchInput: <K extends keyof SettingsFormState>(field: K) => (checked: boolean) => void;
+}
+
+export function createSettingsEventHandlers(deps: EventHandlerDeps): SettingsEventHandlers {
+	const markFieldTouched = (inputId: keyof SettingsFormState) => {
+		const key = INPUT_TO_CONFIG_KEY[inputId];
+		if (!key) return;
+		deps.getTouchedKeys().add(key);
+	};
+
+	const updateField = <K extends keyof SettingsFormState>(
+		field: K,
+		value: SettingsFormState[K],
+	) => {
+		markFieldTouched(field);
+		deps.updateFormState({ [field]: value } as Partial<SettingsFormState>);
+		deps.setDirty(true);
+	};
+
+	const onTextInput =
+		<K extends keyof SettingsFormState>(field: K) =>
+		(event: JSX.TargetedEvent<HTMLInputElement | HTMLTextAreaElement, Event>) => {
+			updateField(field, event.currentTarget.value as SettingsFormState[K]);
+		};
+
+	const onSelectValueChange =
+		<K extends keyof SettingsFormState>(field: K) =>
+		(value: string) => {
+			updateField(field, value as SettingsFormState[K]);
+		};
+
+	const onSwitchInput =
+		<K extends keyof SettingsFormState>(field: K) =>
+		(checked: boolean) => {
+			updateField(field, checked as SettingsFormState[K]);
+		};
+
+	return {
+		markFieldTouched,
+		updateField,
+		onTextInput,
+		onSelectValueChange,
+		onSwitchInput,
+	};
+}


### PR DESCRIPTION
## Description

Stacked on top of #870. Move the input-event handler family — `markFieldTouched`, `updateField`, `onTextInput`, `onSelectValueChange`, `onSwitchInput` — into a `createSettingsEventHandlers(deps)` factory under `settings/data/event-handlers.ts`. The factory takes a `deps` object holding the touched-keys set, a values getter, and the two dispatch callbacks, so the handlers have no direct module-state access.

`settings.tsx` instantiates the factory once at module scope and destructures the handlers. `onAdvancedToggle` stays behind because it writes `settingsShowAdvanced` and calls `settingsController` directly — it can move once the state-sync layer itself is extracted.

Shrinks from ~505 → ~480 LOC. Also drops the now-unused `INPUT_TO_CONFIG_KEY` and `JSX` imports from `settings.tsx` (they moved with the factory).

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced