### PR TITLE
refactor(ui): extract SettingsDialogShell into settings/components/

### DIFF
--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -1,13 +1,12 @@
 /* Settings modal — observer config, sync settings. */
 
 import { render } from "preact";
-import { useCallback, useEffect, useState } from "preact/hooks";
-import { RadixDialog } from "../components/primitives/radix-dialog";
 import * as api from "../lib/api";
 import { $, $button } from "../lib/dom";
 import { showGlobalNotice } from "../lib/notice";
 import { state } from "../lib/state";
 
+import { SettingsDialogShell } from "./settings/components/SettingsDialogShell";
 import { SettingsModalContent } from "./settings/components/SettingsModalContent";
 import { PROTECTED_VIEWER_CONFIG_KEYS } from "./settings/data/constants";
 import { createSettingsEventHandlers } from "./settings/data/event-handlers";
@@ -28,11 +27,7 @@ import type {
 	SettingsRenderState,
 	SettingsTabId,
 } from "./settings/data/types";
-import {
-	mergeOverrideBaseline,
-	persistAdvancedPreference,
-	toProviderList,
-} from "./settings/data/value-helpers";
+import { mergeOverrideBaseline, toProviderList } from "./settings/data/value-helpers";
 
 const getObserverModelHint = (): string =>
 	getObserverModelHintRaw(settingsState.renderState.values, settingsState.envOverrides);
@@ -44,9 +39,6 @@ const getObserverModelTooltip = (): string =>
 	getObserverModelTooltipRaw(settingsState.renderState.values);
 const getObserverModelDescription = (): string =>
 	getObserverModelDescriptionRaw(settingsState.renderState.values);
-
-import { focusSettingsDialog } from "./settings/data/dom";
-import { useHelpTooltip } from "./settings/hooks/use-help-tooltip";
 
 function hideHelpTooltip() {
 	settingsState.controller?.hideTooltip();
@@ -75,7 +67,7 @@ function updateFormState(patch: Partial<SettingsFormState>) {
 function renderSettingsShell() {
 	const mount = $("settingsDialogMount");
 	if (!mount) return;
-	render(<SettingsDialogShell />, mount);
+	render(<SettingsDialogShellBound />, mount);
 	// Lucide icon replacement happens in the shell's open-state effect — the
 	// Dialog renders children only while open, so createIcons() here would
 	// no-op against the unmounted tree.
@@ -89,110 +81,8 @@ function ensureSettingsShell() {
 	settingsState.shellMounted = true;
 }
 
-function SettingsDialogShell() {
-	const [open, setOpen] = useState(settingsState.open);
-	const [activeTab, setActiveTabState] = useState<SettingsTabId>(
-		["observer", "queue", "sync"].includes(settingsState.activeTab)
-			? (settingsState.activeTab as SettingsTabId)
-			: "observer",
-	);
-	const [dirty, setDirtyState] = useState(state.settingsDirty);
-	const [renderState, setRenderStateState] = useState(settingsState.renderState);
-	const [showAdvanced, setShowAdvancedState] = useState(settingsState.showAdvanced);
-	const { tooltipPortal, setTooltip } = useHelpTooltip();
-
-	settingsState.open = open;
-	settingsState.activeTab = activeTab;
-	state.settingsDirty = dirty;
-	settingsState.renderState = renderState;
-	settingsState.showAdvanced = showAdvanced;
-
-	useEffect(() => {
-		settingsState.controller = {
-			hideTooltip: () => {
-				setTooltip({ anchor: null, content: "", visible: false });
-			},
-			setActiveTab: (tab) => {
-				const nextTab = ["observer", "queue", "sync"].includes(tab) ? tab : "observer";
-				settingsState.activeTab = nextTab;
-				setActiveTabState(nextTab);
-			},
-			setDirty: (nextDirty) => {
-				state.settingsDirty = nextDirty;
-				setDirtyState(nextDirty);
-			},
-			setOpen: (nextOpen) => {
-				settingsState.open = nextOpen;
-				setOpen(nextOpen);
-			},
-			setRenderState: (patch) => {
-				const nextState = {
-					...settingsState.renderState,
-					...patch,
-				};
-				settingsState.renderState = nextState;
-				setRenderStateState(nextState);
-			},
-			setShowAdvanced: (nextShowAdvanced) => {
-				settingsState.showAdvanced = nextShowAdvanced;
-				persistAdvancedPreference(nextShowAdvanced);
-				setShowAdvancedState(nextShowAdvanced);
-			},
-		};
-
-		return () => {
-			if (settingsState.controller) {
-				settingsState.controller = null;
-			}
-		};
-	}, []);
-
-	// Radix Dialog mounts its children only while `open` is true, so any
-	// <i data-lucide="..."> stubs inside the dialog need a createIcons pass
-	// every time the modal opens. Running it on the shell mount (before the
-	// children exist) is a no-op for those nodes.
-	useEffect(() => {
-		if (!open) return;
-		const lucide = (globalThis as { lucide?: { createIcons?: () => void } }).lucide;
-		lucide?.createIcons?.();
-	}, [open]);
-
-	const close = useCallback(() => {
-		if (settingsState.startPolling && settingsState.refresh) {
-			closeSettings(settingsState.startPolling, settingsState.refresh);
-		}
-	}, []);
-
-	return (
-		<>
-			<RadixDialog
-				ariaDescribedby="settingsDescription"
-				ariaLabelledby="settingsTitle"
-				contentClassName="modal"
-				contentId="settingsModal"
-				onCloseAutoFocus={(event) => {
-					event.preventDefault();
-				}}
-				onOpenAutoFocus={(event) => {
-					event.preventDefault();
-					focusSettingsDialog();
-				}}
-				onOpenChange={(nextOpen) => {
-					if (nextOpen) {
-						setOpen(true);
-						return;
-					}
-					close();
-				}}
-				open={open}
-				overlayClassName="modal-backdrop"
-				overlayId="settingsBackdrop"
-			>
-				<SettingsDialogContent />
-			</RadixDialog>
-			{tooltipPortal}
-		</>
-	);
+function SettingsDialogShellBound() {
+	return <SettingsDialogShell DialogContent={SettingsDialogContent} onClose={closeSettings} />;
 }
 
 export function isSettingsOpen(): boolean {

--- a/packages/ui/src/tabs/settings/components/SettingsDialogShell.tsx
+++ b/packages/ui/src/tabs/settings/components/SettingsDialogShell.tsx
@@ -1,0 +1,120 @@
+import type { JSX } from "preact";
+import { useCallback, useEffect, useState } from "preact/hooks";
+import { RadixDialog } from "../../../components/primitives/radix-dialog";
+import { state } from "../../../lib/state";
+import { focusSettingsDialog } from "../data/dom";
+import { settingsState } from "../data/state";
+import type { SettingsTabId } from "../data/types";
+import { persistAdvancedPreference } from "../data/value-helpers";
+import { useHelpTooltip } from "../hooks/use-help-tooltip";
+
+export interface SettingsDialogShellProps {
+	DialogContent: () => JSX.Element;
+	onClose: (startPolling: () => void, refresh: () => void) => void;
+}
+
+export function SettingsDialogShell({ DialogContent, onClose }: SettingsDialogShellProps) {
+	const [open, setOpen] = useState(settingsState.open);
+	const [activeTab, setActiveTabState] = useState<SettingsTabId>(
+		["observer", "queue", "sync"].includes(settingsState.activeTab)
+			? (settingsState.activeTab as SettingsTabId)
+			: "observer",
+	);
+	const [dirty, setDirtyState] = useState(state.settingsDirty);
+	const [renderState, setRenderStateState] = useState(settingsState.renderState);
+	const [showAdvanced, setShowAdvancedState] = useState(settingsState.showAdvanced);
+	const { tooltipPortal, setTooltip } = useHelpTooltip();
+
+	settingsState.open = open;
+	settingsState.activeTab = activeTab;
+	state.settingsDirty = dirty;
+	settingsState.renderState = renderState;
+	settingsState.showAdvanced = showAdvanced;
+
+	useEffect(() => {
+		settingsState.controller = {
+			hideTooltip: () => {
+				setTooltip({ anchor: null, content: "", visible: false });
+			},
+			setActiveTab: (tab) => {
+				const nextTab = ["observer", "queue", "sync"].includes(tab) ? tab : "observer";
+				settingsState.activeTab = nextTab;
+				setActiveTabState(nextTab);
+			},
+			setDirty: (nextDirty) => {
+				state.settingsDirty = nextDirty;
+				setDirtyState(nextDirty);
+			},
+			setOpen: (nextOpen) => {
+				settingsState.open = nextOpen;
+				setOpen(nextOpen);
+			},
+			setRenderState: (patch) => {
+				const nextState = {
+					...settingsState.renderState,
+					...patch,
+				};
+				settingsState.renderState = nextState;
+				setRenderStateState(nextState);
+			},
+			setShowAdvanced: (nextShowAdvanced) => {
+				settingsState.showAdvanced = nextShowAdvanced;
+				persistAdvancedPreference(nextShowAdvanced);
+				setShowAdvancedState(nextShowAdvanced);
+			},
+		};
+
+		return () => {
+			if (settingsState.controller) {
+				settingsState.controller = null;
+			}
+		};
+	}, []);
+
+	// Radix Dialog mounts its children only while `open` is true, so any
+	// <i data-lucide="..."> stubs inside the dialog need a createIcons pass
+	// every time the modal opens. Running it on the shell mount (before the
+	// children exist) is a no-op for those nodes.
+	useEffect(() => {
+		if (!open) return;
+		const lucide = (globalThis as { lucide?: { createIcons?: () => void } }).lucide;
+		lucide?.createIcons?.();
+	}, [open]);
+
+	const close = useCallback(() => {
+		if (settingsState.startPolling && settingsState.refresh) {
+			onClose(settingsState.startPolling, settingsState.refresh);
+		}
+	}, [onClose]);
+
+	return (
+		<>
+			<RadixDialog
+				ariaDescribedby="settingsDescription"
+				ariaLabelledby="settingsTitle"
+				contentClassName="modal"
+				contentId="settingsModal"
+				onCloseAutoFocus={(event) => {
+					event.preventDefault();
+				}}
+				onOpenAutoFocus={(event) => {
+					event.preventDefault();
+					focusSettingsDialog();
+				}}
+				onOpenChange={(nextOpen) => {
+					if (nextOpen) {
+						setOpen(true);
+						return;
+					}
+					close();
+				}}
+				open={open}
+				overlayClassName="modal-backdrop"
+				overlayId="settingsBackdrop"
+			>
+				<DialogContent />
+			</RadixDialog>
+			{tooltipPortal}
+		</>
+	);
+}


### PR DESCRIPTION
## Description

Stacked on top of #872. With the module state now on `settingsState`, `SettingsDialogShell` can finally live outside `settings.tsx`.

- New `settings/components/SettingsDialogShell.tsx` owns the Radix Dialog frame, the bidirectional module-state ↔ `useState` sync, `settingsController` registration, the lucide createIcons trigger, and the tooltip-portal mount.
- Takes two props — `DialogContent: () => JSX.Element` and `onClose: (startPolling, refresh) => void` — so it doesn't need to import back into `settings.tsx`.
- `settings.tsx` keeps a tiny `SettingsDialogShellBound` wrapper that binds `SettingsDialogContent` + `closeSettings`, and `renderSettingsShell` now renders that wrapper.

Drops `useCallback`, `useEffect`, `useState`, `RadixDialog`, `focusSettingsDialog`, `useHelpTooltip`, `persistAdvancedPreference` imports from `settings.tsx`.

Shrinks from ~450 → ~340 LOC.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced