### PR TITLE
refactor(ui): extract settings/data/state-ops.ts — controller dispatch helpers

### DIFF
--- a/packages/ui/src/tabs/settings.tsx
+++ b/packages/ui/src/tabs/settings.tsx
@@ -21,12 +21,7 @@ import {
 	protectedConfigHelp,
 } from "./settings/data/model-accessors";
 import { settingsState } from "./settings/data/state";
-import type {
-	SettingsFormState,
-	SettingsPanelProps,
-	SettingsRenderState,
-	SettingsTabId,
-} from "./settings/data/types";
+import type { SettingsPanelProps } from "./settings/data/types";
 import { mergeOverrideBaseline, toProviderList } from "./settings/data/value-helpers";
 
 const getObserverModelHint = (): string =>
@@ -40,29 +35,14 @@ const getObserverModelTooltip = (): string =>
 const getObserverModelDescription = (): string =>
 	getObserverModelDescriptionRaw(settingsState.renderState.values);
 
-function hideHelpTooltip() {
-	settingsState.controller?.hideTooltip();
-}
-
-function updateRenderState(patch: Partial<SettingsRenderState>) {
-	if (settingsState.controller) {
-		settingsState.controller.setRenderState(patch);
-		return;
-	}
-	settingsState.renderState = {
-		...settingsState.renderState,
-		...patch,
-	};
-}
-
-function updateFormState(patch: Partial<SettingsFormState>) {
-	updateRenderState({
-		values: {
-			...settingsState.renderState.values,
-			...patch,
-		},
-	});
-}
+import {
+	hideHelpTooltip,
+	onAdvancedToggle,
+	setDirty,
+	setSettingsTab,
+	updateFormState,
+	updateRenderState,
+} from "./settings/data/state-ops";
 
 function renderSettingsShell() {
 	const mount = $("settingsDialogMount");
@@ -150,17 +130,6 @@ function collectSettingsPayload(
 		baseline: settingsState.baseline,
 		allowUntouchedParseErrors: options.allowUntouchedParseErrors,
 	});
-}
-
-function setSettingsTab(tab: string) {
-	const nextTab = ["observer", "queue", "sync"].includes(tab) ? (tab as SettingsTabId) : "observer";
-	settingsState.activeTab = nextTab;
-	settingsState.controller?.setActiveTab(nextTab);
-}
-
-function setDirty(dirty: boolean, rerender = true) {
-	state.settingsDirty = dirty;
-	if (rerender) settingsState.controller?.setDirty(dirty);
 }
 
 export function openSettings(stopPolling: () => void) {
@@ -251,11 +220,6 @@ const { onTextInput, onSelectValueChange, onSwitchInput } = createSettingsEventH
 	updateFormState,
 	setDirty: (dirty) => setDirty(dirty),
 });
-
-function onAdvancedToggle(checked: boolean) {
-	settingsState.showAdvanced = checked;
-	settingsState.controller?.setShowAdvanced(checked);
-}
 
 const hiddenUnlessAdvanced = (): boolean => hiddenUnlessAdvancedRaw(settingsState.showAdvanced);
 

--- a/packages/ui/src/tabs/settings/data/state-ops.ts
+++ b/packages/ui/src/tabs/settings/data/state-ops.ts
@@ -1,0 +1,51 @@
+/* State mutation helpers that dispatch through `settingsState.controller`
+ * when the React shell is mounted, or update `settingsState` directly
+ * when it is not. All of these read/write `settingsState` — they live
+ * here rather than in settings.tsx so the lifecycle module, the modal
+ * shell, and future slices can share them without a circular import. */
+
+import { state } from "../../../lib/state";
+import { settingsState } from "./state";
+import type { SettingsFormState, SettingsRenderState, SettingsTabId } from "./types";
+
+export function hideHelpTooltip() {
+	settingsState.controller?.hideTooltip();
+}
+
+export function updateRenderState(patch: Partial<SettingsRenderState>) {
+	if (settingsState.controller) {
+		settingsState.controller.setRenderState(patch);
+		return;
+	}
+	settingsState.renderState = {
+		...settingsState.renderState,
+		...patch,
+	};
+}
+
+export function updateFormState(patch: Partial<SettingsFormState>) {
+	updateRenderState({
+		values: {
+			...settingsState.renderState.values,
+			...patch,
+		},
+	});
+}
+
+export function setSettingsTab(tab: string) {
+	const nextTab: SettingsTabId = ["observer", "queue", "sync"].includes(tab)
+		? (tab as SettingsTabId)
+		: "observer";
+	settingsState.activeTab = nextTab;
+	settingsState.controller?.setActiveTab(nextTab);
+}
+
+export function setDirty(dirty: boolean, rerender = true) {
+	state.settingsDirty = dirty;
+	if (rerender) settingsState.controller?.setDirty(dirty);
+}
+
+export function onAdvancedToggle(checked: boolean) {
+	settingsState.showAdvanced = checked;
+	settingsState.controller?.setShowAdvanced(checked);
+}


### PR DESCRIPTION
## Description

Stacked on top of #873. Move the six `settingsState`-dispatching helpers — `hideHelpTooltip`, `updateRenderState`, `updateFormState`, `setSettingsTab`, `setDirty`, `onAdvancedToggle` — into `settings/data/state-ops.ts`. They all read/write `settingsState` and route through `settingsState.controller` when the React shell is mounted.

With these in a shared module, the lifecycle entry points (`openSettings`, `closeSettings`, `saveSettings`, `loadConfigData`, `renderConfigModal`) can move out next without pulling back into `settings.tsx` for dispatch.

`settings.tsx` shrinks from ~340 → ~305 LOC. Drops now-unused `SettingsFormState`, `SettingsRenderState`, `SettingsTabId` imports.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced