### PR TITLE
refactor(ui): extract coordinator-admin/data/summary.ts — pure readiness-banner reducer

### DIFF
--- a/packages/ui/src/tabs/coordinator-admin.tsx
+++ b/packages/ui/src/tabs/coordinator-admin.tsx
@@ -9,6 +9,7 @@ import { copyToClipboard } from "../lib/dom";
 import { showGlobalNotice } from "../lib/notice";
 import { state } from "../lib/state";
 import { type AdminSection, coordinatorAdminState } from "./coordinator-admin/data/state";
+import { coordinatorAdminSummary } from "./coordinator-admin/data/summary";
 import {
 	availableCoordinatorGroups,
 	currentAdminTargetGroup,
@@ -19,41 +20,6 @@ import {
 	setAdminTargetGroup,
 } from "./coordinator-admin/data/target-group";
 import { openSyncConfirmDialog } from "./sync/sync-dialogs";
-
-function coordinatorAdminSummary() {
-	const status = state.lastCoordinatorAdminStatus;
-	if (!status) {
-		return {
-			readiness: "partial",
-			title: "Checking coordinator admin readiness…",
-			detail: "Loading local coordinator admin configuration from the viewer server.",
-		};
-	}
-	if (status.readiness === "ready") {
-		return {
-			readiness: "ready",
-			title: "Coordinator admin is ready",
-			detail:
-				"This viewer can use the local admin configuration to manage invites, join requests, and enrolled devices without exposing the admin secret to the browser.",
-		};
-	}
-	if (status.readiness === "partial") {
-		return {
-			readiness: "partial",
-			title: "Coordinator admin setup is incomplete",
-			detail:
-				status.has_admin_secret === false
-					? "Set a coordinator admin secret for the viewer server before using invite and device admin actions."
-					: "Finish configuring the coordinator target and group before using admin actions.",
-		};
-	}
-	return {
-		readiness: "not_configured",
-		title: "Coordinator admin is not configured",
-		detail:
-			"Set a coordinator URL, group, and admin secret locally to enable remote coordinator administration from this viewer.",
-	};
-}
 
 async function createGroupFromAdminPanel() {
 	if (coordinatorAdminState.groupActionPendingKind) return;

--- a/packages/ui/src/tabs/coordinator-admin/data/summary.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/summary.ts
@@ -1,0 +1,48 @@
+/* Coordinator-admin readiness summary — derives the banner copy from
+ * the latest viewer /coordinator-admin/status response. Pure: reads
+ * `state.lastCoordinatorAdminStatus` and returns a display-ready shape. */
+
+import { state } from "../../../lib/state";
+
+export type CoordinatorAdminReadiness = "ready" | "partial" | "not_configured";
+
+export interface CoordinatorAdminSummary {
+	readiness: CoordinatorAdminReadiness;
+	title: string;
+	detail: string;
+}
+
+export function coordinatorAdminSummary(): CoordinatorAdminSummary {
+	const status = state.lastCoordinatorAdminStatus;
+	if (!status) {
+		return {
+			readiness: "partial",
+			title: "Checking coordinator admin readiness…",
+			detail: "Loading local coordinator admin configuration from the viewer server.",
+		};
+	}
+	if (status.readiness === "ready") {
+		return {
+			readiness: "ready",
+			title: "Coordinator admin is ready",
+			detail:
+				"This viewer can use the local admin configuration to manage invites, join requests, and enrolled devices without exposing the admin secret to the browser.",
+		};
+	}
+	if (status.readiness === "partial") {
+		return {
+			readiness: "partial",
+			title: "Coordinator admin setup is incomplete",
+			detail:
+				status.has_admin_secret === false
+					? "Set a coordinator admin secret for the viewer server before using invite and device admin actions."
+					: "Finish configuring the coordinator target and group before using admin actions.",
+		};
+	}
+	return {
+		readiness: "not_configured",
+		title: "Coordinator admin is not configured",
+		detail:
+			"Set a coordinator URL, group, and admin secret locally to enable remote coordinator administration from this viewer.",
+	};
+}


### PR DESCRIPTION
## Description

Stacked on top of #879. Move `coordinatorAdminSummary` (the readiness-banner reducer) into `coordinator-admin/data/summary.ts`. Pure: reads `state.lastCoordinatorAdminStatus`, returns `{readiness, title, detail}`.

Also exports `CoordinatorAdminReadiness` + `CoordinatorAdminSummary` types so panel components can type their `summary` prop instead of relying on `ReturnType<typeof ...>` inference across files.

Shrinks `coordinator-admin.tsx` from ~1000 → ~965 LOC.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1417 passing)
- [x] Self-review completed

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No docs impact
- [x] No new warnings introduced