### PR TITLE
refactor(ui): extract team-sync/helpers/dom.ts — clearContent, pulseAttentionTarget, scroll behavior

### DIFF
--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -35,6 +35,7 @@ import {
 	openSyncInputDialog,
 } from "./sync-dialogs";
 import { setLoadSyncData as setLoadSyncDataImpl, teamSyncState } from "./team-sync/data/state";
+import { clearContent, pulseAttentionTarget, syncScrollBehavior } from "./team-sync/helpers/dom";
 import {
 	deriveCoordinatorApprovalSummary,
 	resolveFriendlyDeviceName,
@@ -128,28 +129,6 @@ function setJoinFeedbackVisibility() {
 	syncJoinFeedback.setAttribute("role", feedback?.tone === "warning" ? "alert" : "status");
 	syncJoinFeedback.setAttribute("aria-live", feedback?.tone === "warning" ? "assertive" : "polite");
 	syncJoinFeedback.className = `peer-meta${feedback ? ` ${feedback.tone === "warning" ? "sync-inline-feedback warning" : "sync-inline-feedback success"}` : ""}`;
-}
-
-function clearContent(node: HTMLElement | null) {
-	if (node) node.textContent = "";
-}
-
-function pulseAttentionTarget(target: HTMLElement | null) {
-	if (!(target instanceof HTMLElement)) return;
-	target.classList.remove("sync-attention-target");
-	void target.offsetWidth;
-	target.classList.add("sync-attention-target");
-	window.setTimeout(() => target.classList.remove("sync-attention-target"), 900);
-}
-
-function prefersReducedMotion(): boolean {
-	return (
-		typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
-	);
-}
-
-function syncScrollBehavior(): ScrollBehavior {
-	return prefersReducedMotion() ? "auto" : "smooth";
 }
 
 function renderInvitePolicySelect() {

--- a/packages/ui/src/tabs/sync/team-sync/helpers/dom.ts
+++ b/packages/ui/src/tabs/sync/team-sync/helpers/dom.ts
@@ -1,0 +1,25 @@
+/* DOM utilities shared by the team sync card — reduced-motion aware
+ * scroll behavior and the pulse-attention animation used to highlight
+ * the destination of an attention item's action. */
+
+export function clearContent(node: HTMLElement | null) {
+	if (node) node.textContent = "";
+}
+
+export function pulseAttentionTarget(target: HTMLElement | null) {
+	if (!(target instanceof HTMLElement)) return;
+	target.classList.remove("sync-attention-target");
+	void target.offsetWidth;
+	target.classList.add("sync-attention-target");
+	window.setTimeout(() => target.classList.remove("sync-attention-target"), 900);
+}
+
+export function prefersReducedMotion(): boolean {
+	return (
+		typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
+	);
+}
+
+export function syncScrollBehavior(): ScrollBehavior {
+	return prefersReducedMotion() ? "auto" : "smooth";
+}


### PR DESCRIPTION
## Description

Second slice of the team-sync.ts decomposition. Move the reduced-motion-aware scroll-behavior helper, the pulse animation helper, and the tiny clearContent utility off team-sync.ts into a shared helpers/dom module. These are needed by future slices that extract the attention-target focusing logic.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — identical animation and scroll semantics