### PR TITLE
refactor(ui): extract team-sync/render/sharing-review.ts

### DIFF
--- a/packages/ui/src/tabs/sync/team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync.ts
@@ -4,11 +4,10 @@ import { h } from "preact";
 import * as api from "../../lib/api";
 import { clearFieldError, friendlyError, markFieldError } from "../../lib/form";
 import { showGlobalNotice } from "../../lib/notice";
-import { isSyncRedactionEnabled, setFeedScopeFilter, state } from "../../lib/state";
+import { isSyncRedactionEnabled, state } from "../../lib/state";
 import { clearSyncMount, renderIntoSyncMount } from "./components/render-root";
 import type { SyncActionFeedback } from "./components/sync-inline-feedback";
 import { SyncInviteJoinPanels } from "./components/sync-invite-join-panels";
-import { SyncSharingReview, type SyncSharingReviewItem } from "./components/sync-sharing-review";
 import {
 	type TeamSyncDiscoveredRow,
 	TeamSyncPanel,
@@ -40,6 +39,7 @@ import {
 	setInviteOutputVisibility,
 	setJoinFeedbackVisibility,
 } from "./team-sync/helpers/invite-panel-dom";
+import { renderSyncSharingReview } from "./team-sync/render/sharing-review";
 import {
 	deriveCoordinatorApprovalSummary,
 	resolveFriendlyDeviceName,
@@ -62,43 +62,7 @@ function teardownTeamSyncRender(actions: HTMLElement | null, targets: Array<HTML
 	});
 }
 
-/* ── Sharing review renderer ─────────────────────────────── */
-
-function openFeedSharingReview() {
-	setFeedScopeFilter("mine");
-	state.feedQuery = "";
-	window.location.hash = "feed";
-}
-
-export function renderSyncSharingReview() {
-	const panel = document.getElementById("syncSharingReview");
-	const meta = document.getElementById("syncSharingReviewMeta");
-	const list = document.getElementById("syncSharingReviewList") as HTMLElement | null;
-	if (!panel || !meta || !list) return;
-	const items = Array.isArray(state.lastSyncSharingReview) ? state.lastSyncSharingReview : [];
-	if (!items.length) {
-		clearSyncMount(list);
-		panel.hidden = true;
-		return;
-	}
-	panel.hidden = false;
-	const scopeLabel = state.currentProject
-		? `current project (${state.currentProject})`
-		: "all allowed projects";
-	meta.textContent = `Teammates receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
-	const reviewItems: SyncSharingReviewItem[] = items.map((item) => ({
-		actorDisplayName: String(item.actor_display_name || item.actor_id || "unknown"),
-		actorId: String(item.actor_id || "unknown"),
-		peerName: String(item.peer_name || item.peer_device_id || "Device"),
-		privateCount: Number(item.private_count || 0),
-		scopeLabel: String(item.scope_label || "All allowed projects"),
-		shareableCount: Number(item.shareable_count || 0),
-	}));
-	renderIntoSyncMount(
-		list,
-		h(SyncSharingReview, { items: reviewItems, onReview: openFeedSharingReview }),
-	);
-}
+export { renderSyncSharingReview };
 
 /* ── Team sync renderer ──────────────────────────────────── */
 

--- a/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
@@ -1,0 +1,47 @@
+/* Sharing review renderer for the team-sync card — renders the
+ * "Teammates are receiving your memories" review surface and routes
+ * the "Review" CTA back to the Feed tab filtered by the current actor. */
+
+import { h } from "preact";
+import { setFeedScopeFilter, state } from "../../../../lib/state";
+import { clearSyncMount, renderIntoSyncMount } from "../../components/render-root";
+import {
+	SyncSharingReview,
+	type SyncSharingReviewItem,
+} from "../../components/sync-sharing-review";
+
+function openFeedSharingReview() {
+	setFeedScopeFilter("mine");
+	state.feedQuery = "";
+	window.location.hash = "feed";
+}
+
+export function renderSyncSharingReview() {
+	const panel = document.getElementById("syncSharingReview");
+	const meta = document.getElementById("syncSharingReviewMeta");
+	const list = document.getElementById("syncSharingReviewList") as HTMLElement | null;
+	if (!panel || !meta || !list) return;
+	const items = Array.isArray(state.lastSyncSharingReview) ? state.lastSyncSharingReview : [];
+	if (!items.length) {
+		clearSyncMount(list);
+		panel.hidden = true;
+		return;
+	}
+	panel.hidden = false;
+	const scopeLabel = state.currentProject
+		? `current project (${state.currentProject})`
+		: "all allowed projects";
+	meta.textContent = `Teammates receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
+	const reviewItems: SyncSharingReviewItem[] = items.map((item) => ({
+		actorDisplayName: String(item.actor_display_name || item.actor_id || "unknown"),
+		actorId: String(item.actor_id || "unknown"),
+		peerName: String(item.peer_name || item.peer_device_id || "Device"),
+		privateCount: Number(item.private_count || 0),
+		scopeLabel: String(item.scope_label || "All allowed projects"),
+		shareableCount: Number(item.shareable_count || 0),
+	}));
+	renderIntoSyncMount(
+		list,
+		h(SyncSharingReview, { items: reviewItems, onReview: openFeedSharingReview }),
+	);
+}


### PR DESCRIPTION
## Description

Fourth slice of the team-sync.ts decomposition. Move renderSyncSharingReview (and the private openFeedSharingReview helper it routes to) into its own module under team-sync/render/. team-sync.ts now re-exports the public entry so the call site in index.ts stays on the same import path.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — identical review surface
- [x] team-sync.ts now 757 LOC (from 924 when the stack started)