### PR TITLE
refactor(ui): start health.ts split — move shared types to health/types.ts

### DIFF
--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -19,46 +19,16 @@ import {
 } from "../lib/format";
 import { state } from "../lib/state";
 import { updateFeedView } from "./feed";
-
-type HealthAction = {
-	label: string;
-	command: string;
-	/** If set, show an actionable button that triggers this async function. */
-	action?: () => Promise<void>;
-	actionLabel?: string;
-};
+import type {
+	HealthAction,
+	HealthActionRowProps,
+	HealthCardInput,
+	LucideRuntime,
+	StatItem,
+	UsageEvent,
+} from "./health/types";
 
 /* ── Health card builder ─────────────────────────────────── */
-
-type HealthCardInput = {
-	key?: string;
-	label: string;
-	value: string;
-	detail?: string;
-	icon?: string;
-	className?: string;
-	title?: string;
-};
-
-type HealthActionRowProps = {
-	item: HealthAction;
-};
-
-type StatItem = {
-	label: string;
-	value: string | number | null | undefined;
-	icon: string;
-	tooltip?: string;
-};
-
-type UsageEvent = {
-	event?: string;
-	count?: number;
-};
-
-type LucideRuntime = {
-	createIcons: () => void;
-};
 
 function buildHealthCard(input: HealthCardInput): HealthCardInput {
 	return input;

--- a/packages/ui/src/tabs/health/types.ts
+++ b/packages/ui/src/tabs/health/types.ts
@@ -1,0 +1,42 @@
+/* Shared types for the Health tab — card inputs, stat rows, action
+ * recommendations, and the Lucide runtime shape used by renderIcons.
+ * Kept in one module so the component + renderer slices can agree on
+ * shapes without bouncing through the barrel. */
+
+export type HealthAction = {
+	label: string;
+	command: string;
+	/** If set, show an actionable button that triggers this async function. */
+	action?: () => Promise<void>;
+	actionLabel?: string;
+};
+
+export type HealthCardInput = {
+	key?: string;
+	label: string;
+	value: string;
+	detail?: string;
+	icon?: string;
+	className?: string;
+	title?: string;
+};
+
+export type HealthActionRowProps = {
+	item: HealthAction;
+};
+
+export type StatItem = {
+	label: string;
+	value: string | number | null | undefined;
+	icon: string;
+	tooltip?: string;
+};
+
+export type UsageEvent = {
+	event?: string;
+	count?: number;
+};
+
+export type LucideRuntime = {
+	createIcons: () => void;
+};


### PR DESCRIPTION
## Description

First slice of the 708-LOC health.ts decomposition. Hoist the shared type definitions (HealthAction, HealthCardInput, HealthActionRowProps, StatItem, UsageEvent, LucideRuntime) into a dedicated types module so the component + renderer slices can agree on shapes without bouncing back through the barrel.

Same pattern used on the settings, coordinator-admin, and team-sync splits.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — pure type move
- [x] health.ts public API unchanged