### PR TITLE
refactor(ui): extract health/render/stats.ts — stats grid + meta line

### DIFF
--- a/packages/ui/src/tabs/health.ts
+++ b/packages/ui/src/tabs/health.ts
@@ -1,122 +1,15 @@
 /* Health tab — system health, stats, session overview. */
 
 import * as api from "../lib/api";
-import {
-	collapseHome,
-	formatBytes,
-	formatMultiplier,
-	formatPercent,
-	formatReductionPercent,
-	formatTimestamp,
-	formatTokenCount,
-} from "../lib/format";
+import { formatReductionPercent, formatTimestamp, formatTokenCount } from "../lib/format";
 import { state } from "../lib/state";
 import { updateFeedView } from "./feed";
 import { renderIcons, renderStatBlocks, renderText } from "./health/components";
 import { renderHealthOverview } from "./health/render/health-overview";
+import { renderStats } from "./health/render/stats";
 import type { StatItem, UsageEvent } from "./health/types";
 
-export { renderHealthOverview };
-
-/* ── Stats renderer ──────────────────────────────────────── */
-
-export function renderStats() {
-	const statsGrid = document.getElementById("statsGrid");
-	const metaLine = document.getElementById("metaLine");
-	if (!statsGrid) return;
-
-	const stats = state.lastStatsPayload || {};
-	const usagePayload = state.lastUsagePayload || {};
-	const raw =
-		state.lastRawEventsPayload && typeof state.lastRawEventsPayload === "object"
-			? state.lastRawEventsPayload
-			: {};
-	const db = stats.database || {};
-	const project = state.currentProject;
-	const totalsGlobal =
-		usagePayload?.totals_global || usagePayload?.totals || stats.usage?.totals || {};
-	const totalsFiltered = usagePayload?.totals_filtered || null;
-	const isFiltered = !!(project && totalsFiltered);
-	const usage = isFiltered ? totalsFiltered : totalsGlobal;
-	const rawSessions = Number(raw.sessions || 0);
-	const rawPending = Number(raw.pending || 0);
-
-	const globalLineWork = isFiltered
-		? `\nGlobal: ${Number(totalsGlobal.work_investment_tokens || 0).toLocaleString()} invested`
-		: "";
-	const globalLineRead = isFiltered
-		? `\nGlobal: ${Number(totalsGlobal.tokens_read || 0).toLocaleString()} read`
-		: "";
-	const globalLineSaved = isFiltered
-		? `\nGlobal: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved`
-		: "";
-
-	const items: StatItem[] = [
-		{
-			label: isFiltered ? "Savings (project)" : "Savings",
-			value: formatTokenCount(usage.tokens_saved || 0),
-			tooltip: `Tokens saved by reusing compressed memories. Exact: ${Number(usage.tokens_saved || 0).toLocaleString()} saved${globalLineSaved}`,
-			icon: "trending-up",
-		},
-		{
-			label: isFiltered ? "Injected (project)" : "Injected",
-			value: formatTokenCount(usage.tokens_read || 0),
-			tooltip: `Tokens injected into context (pack size). Exact: ${Number(usage.tokens_read || 0).toLocaleString()} injected${globalLineRead}`,
-			icon: "book-open",
-		},
-		{
-			label: isFiltered ? "Reduction (project)" : "Reduction",
-			value: formatReductionPercent(usage.tokens_saved, usage.tokens_read),
-			tooltip:
-				`Percent reduction from reuse. Factor: ${formatMultiplier(usage.tokens_saved, usage.tokens_read)}.` +
-				globalLineRead +
-				globalLineSaved,
-			icon: "percent",
-		},
-		{
-			label: isFiltered ? "Work investment (project)" : "Work investment",
-			value: formatTokenCount(usage.work_investment_tokens || 0),
-			tooltip: `Token cost of unique discovery groups. Exact: ${Number(usage.work_investment_tokens || 0).toLocaleString()} invested${globalLineWork}`,
-			icon: "pencil",
-		},
-		{ label: "Active memories", value: db.active_memory_items || 0, icon: "check-circle" },
-		{
-			label: "Embedding coverage",
-			value: formatPercent(db.vector_coverage),
-			tooltip: "Share of active memories with embeddings",
-			icon: "layers",
-		},
-		{
-			label: "Tag coverage",
-			value: formatPercent(db.tags_coverage),
-			tooltip: "Share of active memories with tags",
-			icon: "tag",
-		},
-	];
-	if (rawPending > 0)
-		items.push({
-			label: "Raw events pending",
-			value: rawPending,
-			tooltip: "Pending raw events waiting to be flushed",
-			icon: "activity",
-		});
-	else if (rawSessions > 0)
-		items.push({
-			label: "Raw sessions",
-			value: rawSessions,
-			tooltip: "Sessions with pending raw events",
-			icon: "inbox",
-		});
-
-	renderStatBlocks(statsGrid, items);
-
-	if (metaLine) {
-		const projectSuffix = project ? ` · project: ${project}` : "";
-		const dbPath = collapseHome(db.path || "unknown");
-		renderText(metaLine, `DB: ${dbPath} · ${formatBytes(db.size_bytes || 0)}${projectSuffix}`);
-	}
-	renderIcons();
-}
+export { renderHealthOverview, renderStats };
 
 /* ── Session summary renderer ────────────────────────────── */
 

--- a/packages/ui/src/tabs/health/render/stats.ts
+++ b/packages/ui/src/tabs/health/render/stats.ts
@@ -1,0 +1,114 @@
+/* Stats renderer for the Health tab — reads usage totals and database
+ * state off the global store, builds the StatItem grid (including
+ * project-filtered variants when a project is selected), and writes a
+ * meta line describing the database path and size. */
+
+import {
+	collapseHome,
+	formatBytes,
+	formatMultiplier,
+	formatPercent,
+	formatReductionPercent,
+	formatTokenCount,
+} from "../../../lib/format";
+import { state } from "../../../lib/state";
+import { renderIcons, renderStatBlocks, renderText } from "../components";
+import type { StatItem } from "../types";
+
+export function renderStats() {
+	const statsGrid = document.getElementById("statsGrid");
+	const metaLine = document.getElementById("metaLine");
+	if (!statsGrid) return;
+
+	const stats = state.lastStatsPayload || {};
+	const usagePayload = state.lastUsagePayload || {};
+	const raw =
+		state.lastRawEventsPayload && typeof state.lastRawEventsPayload === "object"
+			? state.lastRawEventsPayload
+			: {};
+	const db = stats.database || {};
+	const project = state.currentProject;
+	const totalsGlobal =
+		usagePayload?.totals_global || usagePayload?.totals || stats.usage?.totals || {};
+	const totalsFiltered = usagePayload?.totals_filtered || null;
+	const isFiltered = !!(project && totalsFiltered);
+	const usage = isFiltered ? totalsFiltered : totalsGlobal;
+	const rawSessions = Number(raw.sessions || 0);
+	const rawPending = Number(raw.pending || 0);
+
+	const globalLineWork = isFiltered
+		? `\nGlobal: ${Number(totalsGlobal.work_investment_tokens || 0).toLocaleString()} invested`
+		: "";
+	const globalLineRead = isFiltered
+		? `\nGlobal: ${Number(totalsGlobal.tokens_read || 0).toLocaleString()} read`
+		: "";
+	const globalLineSaved = isFiltered
+		? `\nGlobal: ${Number(totalsGlobal.tokens_saved || 0).toLocaleString()} saved`
+		: "";
+
+	const items: StatItem[] = [
+		{
+			label: isFiltered ? "Savings (project)" : "Savings",
+			value: formatTokenCount(usage.tokens_saved || 0),
+			tooltip: `Tokens saved by reusing compressed memories. Exact: ${Number(usage.tokens_saved || 0).toLocaleString()} saved${globalLineSaved}`,
+			icon: "trending-up",
+		},
+		{
+			label: isFiltered ? "Injected (project)" : "Injected",
+			value: formatTokenCount(usage.tokens_read || 0),
+			tooltip: `Tokens injected into context (pack size). Exact: ${Number(usage.tokens_read || 0).toLocaleString()} injected${globalLineRead}`,
+			icon: "book-open",
+		},
+		{
+			label: isFiltered ? "Reduction (project)" : "Reduction",
+			value: formatReductionPercent(usage.tokens_saved, usage.tokens_read),
+			tooltip:
+				`Percent reduction from reuse. Factor: ${formatMultiplier(usage.tokens_saved, usage.tokens_read)}.` +
+				globalLineRead +
+				globalLineSaved,
+			icon: "percent",
+		},
+		{
+			label: isFiltered ? "Work investment (project)" : "Work investment",
+			value: formatTokenCount(usage.work_investment_tokens || 0),
+			tooltip: `Token cost of unique discovery groups. Exact: ${Number(usage.work_investment_tokens || 0).toLocaleString()} invested${globalLineWork}`,
+			icon: "pencil",
+		},
+		{ label: "Active memories", value: db.active_memory_items || 0, icon: "check-circle" },
+		{
+			label: "Embedding coverage",
+			value: formatPercent(db.vector_coverage),
+			tooltip: "Share of active memories with embeddings",
+			icon: "layers",
+		},
+		{
+			label: "Tag coverage",
+			value: formatPercent(db.tags_coverage),
+			tooltip: "Share of active memories with tags",
+			icon: "tag",
+		},
+	];
+	if (rawPending > 0)
+		items.push({
+			label: "Raw events pending",
+			value: rawPending,
+			tooltip: "Pending raw events waiting to be flushed",
+			icon: "activity",
+		});
+	else if (rawSessions > 0)
+		items.push({
+			label: "Raw sessions",
+			value: rawSessions,
+			tooltip: "Sessions with pending raw events",
+			icon: "inbox",
+		});
+
+	renderStatBlocks(statsGrid, items);
+
+	if (metaLine) {
+		const projectSuffix = project ? ` · project: ${project}` : "";
+		const dbPath = collapseHome(db.path || "unknown");
+		renderText(metaLine, `DB: ${dbPath} · ${formatBytes(db.size_bytes || 0)}${projectSuffix}`);
+	}
+	renderIcons();
+}


### PR DESCRIPTION
## Description

Fourth slice of the health.ts decomposition. Move renderStats into health/render/stats.ts. The module owns the project-filtered stat grid (savings, injected tokens, reduction percent, work investment, active memories, embedding/tag coverage, raw event counters) plus the DB path + size meta line. The barrel re-exports renderStats so existing call sites stay on the same import path.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — identical stat grid and meta line
- [x] health.ts now 103 LOC (from 210)