### PR TITLE
refactor(ui): start view-model.ts split — move shared types + terminology to view-model/types.ts

### DIFF
--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -1,122 +1,36 @@
 /* Derived sync view-model helpers. Keep these pure so UX logic is testable. */
 
-export const SYNC_TERMINOLOGY = {
-	actor: "person",
-	actors: "people",
-	actorAssignment: "person assignment",
-	localActor: "you",
-	peer: "device",
-	peers: "devices",
-	pairedLocally: "Connected on this device",
-	discovered: "Seen on team",
-	conflicts: "Needs review",
-} as const;
+import type {
+	ActorLike,
+	DiscoveredDeviceLike,
+	PeerLike,
+	UiCoordinatorApprovalSummary,
+	UiDuplicatePersonCandidate,
+	UiPeerTrustSummary,
+	UiSyncAttentionItem,
+	UiSyncRunResponse,
+	UiSyncStatus,
+	UiSyncViewModel,
+	VisiblePeopleResult,
+} from "./view-model/types";
 
-export type UiSyncStatus = "connected" | "available" | "needs-repair" | "offline" | "waiting";
-export type UiTrustState =
-	| "available"
-	| "trusted-by-you"
-	| "mutual-trust"
-	| "needs-repairing"
-	| "needs-review"
-	| "offline";
-export type UiCoordinatorApprovalState =
-	| "none"
-	| "needs-your-approval"
-	| "waiting-for-other-device";
-
-interface SyncPeerStatusLike {
-	peer_state?: string;
-	sync_status?: string;
-	ping_status?: string;
-	fresh?: boolean;
-}
-
-export interface UiSyncRunItem {
-	peer_device_id: string;
-	ok: boolean;
-	error?: string;
-	address?: string;
-	opsIn: number;
-	opsOut: number;
-	addressErrors: Array<{ address: string; error: string }>;
-}
-
-export interface UiSyncRunResponse {
-	items: UiSyncRunItem[];
-}
-
-export interface UiSyncAttentionItem {
-	id: string;
-	kind: "possible-duplicate-person" | "device-needs-repair" | "review-team-device" | "name-device";
-	priority: number;
-	title: string;
-	summary: string;
-	actionLabel: string;
-	deviceId?: string;
-	actorIds?: string[];
-}
-
-export interface UiDuplicatePersonCandidate {
-	displayName: string;
-	actorIds: string[];
-	includesLocal: boolean;
-}
-
-export interface UiSyncViewModel {
-	summary: {
-		connectedDeviceCount: number;
-		seenOnTeamCount: number;
-		offlineTeamDeviceCount: number;
-	};
-	duplicatePeople: UiDuplicatePersonCandidate[];
-	attentionItems: UiSyncAttentionItem[];
-}
-
-export interface UiPeerTrustSummary {
-	state: UiTrustState;
-	badgeLabel: string;
-	description: string;
-	isWarning: boolean;
-}
-
-export interface VisiblePeopleResult {
-	visibleActors: ActorLike[];
-	hiddenLocalDuplicateCount: number;
-}
-
-export interface ActorLike {
-	actor_id?: string;
-	display_name?: string;
-	is_local?: boolean;
-}
-
-export interface PeerLike {
-	peer_device_id?: string;
-	name?: string;
-	has_error?: boolean;
-	last_error?: string;
-	fingerprint?: string;
-	actor_id?: string;
-	status?: SyncPeerStatusLike;
-}
-
-export interface DiscoveredDeviceLike {
-	device_id?: string;
-	display_name?: string;
-	stale?: boolean;
-	fingerprint?: string;
-	groups?: string[];
-	needs_local_approval?: boolean;
-	waiting_for_peer_approval?: boolean;
-}
-
-export interface UiCoordinatorApprovalSummary {
-	state: UiCoordinatorApprovalState;
-	badgeLabel: string | null;
-	description: string | null;
-	actionLabel: string | null;
-}
+export {
+	type ActorLike,
+	type DiscoveredDeviceLike,
+	type PeerLike,
+	SYNC_TERMINOLOGY,
+	type UiCoordinatorApprovalState,
+	type UiCoordinatorApprovalSummary,
+	type UiDuplicatePersonCandidate,
+	type UiPeerTrustSummary,
+	type UiSyncAttentionItem,
+	type UiSyncRunItem,
+	type UiSyncRunResponse,
+	type UiSyncStatus,
+	type UiSyncViewModel,
+	type UiTrustState,
+	type VisiblePeopleResult,
+} from "./view-model/types";
 
 interface MergedDevice {
 	deviceId: string;

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -1,0 +1,121 @@
+/* Shared types and terminology for the sync view-model. Keeping
+ * SYNC_TERMINOLOGY alongside the types keeps the user-facing strings
+ * and the shapes that reference them colocated. */
+
+export const SYNC_TERMINOLOGY = {
+	actor: "person",
+	actors: "people",
+	actorAssignment: "person assignment",
+	localActor: "you",
+	peer: "device",
+	peers: "devices",
+	pairedLocally: "Connected on this device",
+	discovered: "Seen on team",
+	conflicts: "Needs review",
+} as const;
+
+export type UiSyncStatus = "connected" | "available" | "needs-repair" | "offline" | "waiting";
+export type UiTrustState =
+	| "available"
+	| "trusted-by-you"
+	| "mutual-trust"
+	| "needs-repairing"
+	| "needs-review"
+	| "offline";
+export type UiCoordinatorApprovalState =
+	| "none"
+	| "needs-your-approval"
+	| "waiting-for-other-device";
+
+export interface SyncPeerStatusLike {
+	peer_state?: string;
+	sync_status?: string;
+	ping_status?: string;
+	fresh?: boolean;
+}
+
+export interface UiSyncRunItem {
+	peer_device_id: string;
+	ok: boolean;
+	error?: string;
+	address?: string;
+	opsIn: number;
+	opsOut: number;
+	addressErrors: Array<{ address: string; error: string }>;
+}
+
+export interface UiSyncRunResponse {
+	items: UiSyncRunItem[];
+}
+
+export interface UiSyncAttentionItem {
+	id: string;
+	kind: "possible-duplicate-person" | "device-needs-repair" | "review-team-device" | "name-device";
+	priority: number;
+	title: string;
+	summary: string;
+	actionLabel: string;
+	deviceId?: string;
+	actorIds?: string[];
+}
+
+export interface UiDuplicatePersonCandidate {
+	displayName: string;
+	actorIds: string[];
+	includesLocal: boolean;
+}
+
+export interface UiSyncViewModel {
+	summary: {
+		connectedDeviceCount: number;
+		seenOnTeamCount: number;
+		offlineTeamDeviceCount: number;
+	};
+	duplicatePeople: UiDuplicatePersonCandidate[];
+	attentionItems: UiSyncAttentionItem[];
+}
+
+export interface UiPeerTrustSummary {
+	state: UiTrustState;
+	badgeLabel: string;
+	description: string;
+	isWarning: boolean;
+}
+
+export interface VisiblePeopleResult {
+	visibleActors: ActorLike[];
+	hiddenLocalDuplicateCount: number;
+}
+
+export interface ActorLike {
+	actor_id?: string;
+	display_name?: string;
+	is_local?: boolean;
+}
+
+export interface PeerLike {
+	peer_device_id?: string;
+	name?: string;
+	has_error?: boolean;
+	last_error?: string;
+	fingerprint?: string;
+	actor_id?: string;
+	status?: SyncPeerStatusLike;
+}
+
+export interface DiscoveredDeviceLike {
+	device_id?: string;
+	display_name?: string;
+	stale?: boolean;
+	fingerprint?: string;
+	groups?: string[];
+	needs_local_approval?: boolean;
+	waiting_for_peer_approval?: boolean;
+}
+
+export interface UiCoordinatorApprovalSummary {
+	state: UiCoordinatorApprovalState;
+	badgeLabel: string | null;
+	description: string | null;
+	actionLabel: string | null;
+}


### PR DESCRIPTION
## Description

First slice of the 642-LOC view-model.ts decomposition. Hoist the SYNC_TERMINOLOGY const and all exported type definitions (ActorLike, PeerLike, DiscoveredDeviceLike, Ui* interfaces, state unions, VisiblePeopleResult, SyncPeerStatusLike) into a dedicated types module. The view-model.ts barrel re-exports everything so existing call sites across the sync tabs and state.ts stay on the same import path.

Same pattern used on the settings, coordinator-admin, team-sync, and health splits.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — pure type + const move
- [x] view-model.ts public API unchanged — barrel re-exports identical names