### PR TITLE
refactor(ui): extract view-model/internal.ts + view-model/device-names.ts

### DIFF
--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -1,5 +1,13 @@
 /* Derived sync view-model helpers. Keep these pure so UX logic is testable. */
 
+import { deviceNeedsFriendlyName, resolveFriendlyDeviceName } from "./view-model/device-names";
+import {
+	cleanText,
+	isConnectivityPeerError,
+	isUnauthorizedPeerError,
+	normalizeDisplayName,
+	peerErrorText,
+} from "./view-model/internal";
 import type {
 	ActorLike,
 	DiscoveredDeviceLike,
@@ -31,6 +39,7 @@ export {
 	type UiTrustState,
 	type VisiblePeopleResult,
 } from "./view-model/types";
+export { deviceNeedsFriendlyName, resolveFriendlyDeviceName };
 
 interface MergedDevice {
 	deviceId: string;
@@ -38,46 +47,6 @@ interface MergedDevice {
 	coordinatorName: string;
 	peer: PeerLike | null;
 	discovered: DiscoveredDeviceLike | null;
-}
-
-function cleanText(value: unknown): string {
-	return String(value ?? "").trim();
-}
-
-function normalizeDisplayName(value: unknown): string {
-	return cleanText(value).replace(/\s+/g, " ").toLowerCase();
-}
-
-function _looksLikeDeviceId(value: string): boolean {
-	return /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i.test(value);
-}
-
-function friendlyDeviceFallback(deviceId: string): string {
-	const cleanId = cleanText(deviceId);
-	return cleanId ? cleanId.slice(0, 8) : "Unnamed device";
-}
-
-export function resolveFriendlyDeviceName(input: {
-	localName?: unknown;
-	coordinatorName?: unknown;
-	deviceId?: unknown;
-}): string {
-	const localName = cleanText(input.localName);
-	if (localName) return localName;
-	const coordinatorName = cleanText(input.coordinatorName);
-	if (coordinatorName) return coordinatorName;
-	return friendlyDeviceFallback(cleanText(input.deviceId));
-}
-
-export function deviceNeedsFriendlyName(input: {
-	localName?: unknown;
-	coordinatorName?: unknown;
-	deviceId?: unknown;
-}): boolean {
-	const localName = cleanText(input.localName);
-	const coordinatorName = cleanText(input.coordinatorName);
-	if (localName || coordinatorName) return false;
-	return Boolean(cleanText(input.deviceId));
 }
 
 export function derivePeerUiStatus(peer: PeerLike): UiSyncStatus {
@@ -95,20 +64,6 @@ export function derivePeerUiStatus(peer: PeerLike): UiSyncStatus {
 function isOfflineTeamDevice(device: MergedDevice): boolean {
 	if (!device.discovered?.stale) return false;
 	return device.peer ? derivePeerUiStatus(device.peer) !== "connected" : true;
-}
-
-function peerErrorText(peer: PeerLike): string {
-	return cleanText(peer?.last_error).toLowerCase();
-}
-
-function isUnauthorizedPeerError(errorText: string): boolean {
-	return errorText.includes("401") && errorText.includes("unauthorized");
-}
-
-function isConnectivityPeerError(errorText: string): boolean {
-	return ["timeout", "connection refused", "unreachable", "aborted", "all addresses failed"].some(
-		(fragment) => errorText.includes(fragment),
-	);
 }
 
 export function derivePeerTrustSummary(peer: PeerLike): UiPeerTrustSummary {

--- a/packages/ui/src/tabs/sync/view-model/device-names.ts
+++ b/packages/ui/src/tabs/sync/view-model/device-names.ts
@@ -1,0 +1,29 @@
+/* Device-name derivations — resolve the friendly display string for a
+ * discovered device (prefer local rename, then coordinator display
+ * name, then a short id fallback) and detect the "id-only" case where
+ * the UI should prompt the operator to name the device. */
+
+import { cleanText, friendlyDeviceFallback } from "./internal";
+
+export function resolveFriendlyDeviceName(input: {
+	localName?: unknown;
+	coordinatorName?: unknown;
+	deviceId?: unknown;
+}): string {
+	const localName = cleanText(input.localName);
+	if (localName) return localName;
+	const coordinatorName = cleanText(input.coordinatorName);
+	if (coordinatorName) return coordinatorName;
+	return friendlyDeviceFallback(cleanText(input.deviceId));
+}
+
+export function deviceNeedsFriendlyName(input: {
+	localName?: unknown;
+	coordinatorName?: unknown;
+	deviceId?: unknown;
+}): boolean {
+	const localName = cleanText(input.localName);
+	const coordinatorName = cleanText(input.coordinatorName);
+	if (localName || coordinatorName) return false;
+	return Boolean(cleanText(input.deviceId));
+}

--- a/packages/ui/src/tabs/sync/view-model/internal.ts
+++ b/packages/ui/src/tabs/sync/view-model/internal.ts
@@ -1,0 +1,36 @@
+/* Internal helpers shared across the view-model modules. cleanText
+ * and normalizeDisplayName are the text normalizers used for diffing
+ * peer/actor names; friendlyDeviceFallback produces a short stable
+ * fallback when neither local nor coordinator names are available. The
+ * peer-error classifiers centralise the "is this message 401 /
+ * connectivity failure" checks used by the trust + UI status
+ * derivations. */
+
+import type { PeerLike } from "./types";
+
+export function cleanText(value: unknown): string {
+	return String(value ?? "").trim();
+}
+
+export function normalizeDisplayName(value: unknown): string {
+	return cleanText(value).replace(/\s+/g, " ").toLowerCase();
+}
+
+export function friendlyDeviceFallback(deviceId: string): string {
+	const cleanId = cleanText(deviceId);
+	return cleanId ? cleanId.slice(0, 8) : "Unnamed device";
+}
+
+export function peerErrorText(peer: PeerLike): string {
+	return cleanText(peer?.last_error).toLowerCase();
+}
+
+export function isUnauthorizedPeerError(errorText: string): boolean {
+	return errorText.includes("401") && errorText.includes("unauthorized");
+}
+
+export function isConnectivityPeerError(errorText: string): boolean {
+	return ["timeout", "connection refused", "unreachable", "aborted", "all addresses failed"].some(
+		(fragment) => errorText.includes(fragment),
+	);
+}


### PR DESCRIPTION
## Description

Second slice of the view-model.ts decomposition. Move the private text/peer-error helpers (cleanText, normalizeDisplayName, friendlyDeviceFallback, peerErrorText, isUnauthorizedPeerError, isConnectivityPeerError) into view-model/internal.ts, and the device-name derivations (resolveFriendlyDeviceName, deviceNeedsFriendlyName) into view-model/device-names.ts. Also drops the unused _looksLikeDeviceId dead helper.

The barrel re-exports the two device-name functions so call sites stay on the same import path.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — identical helper semantics
- [x] view-model.ts now 511 LOC (from 642)
- [x] Dead _looksLikeDeviceId helper removed (had a leading underscore and was never called)