### PR TITLE
refactor(ui): extract view-model/people-derivations.ts

### DIFF
--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -6,16 +6,15 @@ import {
 	summarizeSyncRunResult,
 } from "./view-model/coordinator-approval";
 import { deviceNeedsFriendlyName, resolveFriendlyDeviceName } from "./view-model/device-names";
-import { cleanText, normalizeDisplayName } from "./view-model/internal";
+import { cleanText } from "./view-model/internal";
 import { derivePeerTrustSummary, derivePeerUiStatus } from "./view-model/peer-status";
+import { deriveDuplicatePeople, deriveVisiblePeopleActors } from "./view-model/people-derivations";
 import type {
 	ActorLike,
 	DiscoveredDeviceLike,
 	PeerLike,
-	UiDuplicatePersonCandidate,
 	UiSyncAttentionItem,
 	UiSyncViewModel,
-	VisiblePeopleResult,
 } from "./view-model/types";
 
 export {
@@ -37,8 +36,10 @@ export {
 } from "./view-model/types";
 export {
 	deriveCoordinatorApprovalSummary,
+	deriveDuplicatePeople,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
+	deriveVisiblePeopleActors,
 	deviceNeedsFriendlyName,
 	resolveFriendlyDeviceName,
 	shouldShowCoordinatorReviewAction,
@@ -56,59 +57,6 @@ interface MergedDevice {
 function isOfflineTeamDevice(device: MergedDevice): boolean {
 	if (!device.discovered?.stale) return false;
 	return device.peer ? derivePeerUiStatus(device.peer) !== "connected" : true;
-}
-
-export function deriveDuplicatePeople(actors: ActorLike[]): UiDuplicatePersonCandidate[] {
-	const groups = new Map<string, UiDuplicatePersonCandidate>();
-	(Array.isArray(actors) ? actors : []).forEach((actor) => {
-		const displayName = cleanText(actor?.display_name);
-		const actorId = cleanText(actor?.actor_id);
-		const normalized = normalizeDisplayName(displayName);
-		if (!displayName || !actorId || !normalized) return;
-		const current = groups.get(normalized) ?? {
-			displayName,
-			actorIds: [],
-			includesLocal: false,
-		};
-		current.actorIds = [...current.actorIds, actorId];
-		current.includesLocal = current.includesLocal || Boolean(actor?.is_local);
-		groups.set(normalized, current);
-	});
-	return [...groups.values()]
-		.filter((item) => item.actorIds.length > 1)
-		.sort((a, b) => a.displayName.localeCompare(b.displayName));
-}
-
-export function deriveVisiblePeopleActors(input: {
-	actors?: ActorLike[];
-	peers?: PeerLike[];
-	duplicatePeople?: UiDuplicatePersonCandidate[];
-}): VisiblePeopleResult {
-	const actors = Array.isArray(input.actors) ? input.actors : [];
-	const peers = Array.isArray(input.peers) ? input.peers : [];
-	const duplicatePeople = Array.isArray(input.duplicatePeople) ? input.duplicatePeople : [];
-	const assignedCounts = new Map<string, number>();
-	peers.forEach((peer) => {
-		const actorId = cleanText(peer?.actor_id);
-		if (!actorId) return;
-		assignedCounts.set(actorId, (assignedCounts.get(actorId) ?? 0) + 1);
-	});
-
-	const hiddenIds = new Set<string>();
-	duplicatePeople.forEach((candidate) => {
-		if (!candidate.includesLocal) return;
-		candidate.actorIds.forEach((actorId) => {
-			const actor = actors.find((item) => cleanText(item?.actor_id) === actorId);
-			if (!actor || actor.is_local) return;
-			if ((assignedCounts.get(actorId) ?? 0) > 0) return;
-			hiddenIds.add(actorId);
-		});
-	});
-
-	return {
-		visibleActors: actors.filter((actor) => !hiddenIds.has(cleanText(actor?.actor_id))),
-		hiddenLocalDuplicateCount: hiddenIds.size,
-	};
 }
 
 function createRepairItem(device: {

--- a/packages/ui/src/tabs/sync/view-model/people-derivations.ts
+++ b/packages/ui/src/tabs/sync/view-model/people-derivations.ts
@@ -1,0 +1,60 @@
+/* People / actor derivations — detect duplicate-person candidates by
+ * normalised display-name collision, and compute the visible actor
+ * list that hides unassigned local duplicates so the People tab does
+ * not show two entries for the same teammate. */
+
+import { cleanText, normalizeDisplayName } from "./internal";
+import type { ActorLike, PeerLike, UiDuplicatePersonCandidate, VisiblePeopleResult } from "./types";
+
+export function deriveDuplicatePeople(actors: ActorLike[]): UiDuplicatePersonCandidate[] {
+	const groups = new Map<string, UiDuplicatePersonCandidate>();
+	(Array.isArray(actors) ? actors : []).forEach((actor) => {
+		const displayName = cleanText(actor?.display_name);
+		const actorId = cleanText(actor?.actor_id);
+		const normalized = normalizeDisplayName(displayName);
+		if (!displayName || !actorId || !normalized) return;
+		const current = groups.get(normalized) ?? {
+			displayName,
+			actorIds: [],
+			includesLocal: false,
+		};
+		current.actorIds = [...current.actorIds, actorId];
+		current.includesLocal = current.includesLocal || Boolean(actor?.is_local);
+		groups.set(normalized, current);
+	});
+	return [...groups.values()]
+		.filter((item) => item.actorIds.length > 1)
+		.sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+export function deriveVisiblePeopleActors(input: {
+	actors?: ActorLike[];
+	peers?: PeerLike[];
+	duplicatePeople?: UiDuplicatePersonCandidate[];
+}): VisiblePeopleResult {
+	const actors = Array.isArray(input.actors) ? input.actors : [];
+	const peers = Array.isArray(input.peers) ? input.peers : [];
+	const duplicatePeople = Array.isArray(input.duplicatePeople) ? input.duplicatePeople : [];
+	const assignedCounts = new Map<string, number>();
+	peers.forEach((peer) => {
+		const actorId = cleanText(peer?.actor_id);
+		if (!actorId) return;
+		assignedCounts.set(actorId, (assignedCounts.get(actorId) ?? 0) + 1);
+	});
+
+	const hiddenIds = new Set<string>();
+	duplicatePeople.forEach((candidate) => {
+		if (!candidate.includesLocal) return;
+		candidate.actorIds.forEach((actorId) => {
+			const actor = actors.find((item) => cleanText(item?.actor_id) === actorId);
+			if (!actor || actor.is_local) return;
+			if ((assignedCounts.get(actorId) ?? 0) > 0) return;
+			hiddenIds.add(actorId);
+		});
+	});
+
+	return {
+		visibleActors: actors.filter((actor) => !hiddenIds.has(cleanText(actor?.actor_id))),
+		hiddenLocalDuplicateCount: hiddenIds.size,
+	};
+}


### PR DESCRIPTION
## Description

Fifth slice of the view-model.ts decomposition. Move deriveDuplicatePeople and deriveVisiblePeopleActors into view-model/people-derivations.ts. These share the cleanText + normalizeDisplayName helpers from the internal module and define the display rules for people/actors in the People tab. The barrel re-exports both so helpers.ts and people.ts stay on the same import path.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — identical duplicate detection + visible list rules
- [x] view-model.ts now 304 LOC (from 356)