### PR TITLE
refactor(ui): extract api/runtime.ts + stats.ts + memories.ts + config.ts, barrel the rest

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -1,7 +1,11 @@
-/* API fetch wrappers — thin layer over the viewer HTTP endpoints. */
+/* API fetch wrappers — barrel re-export of the split modules. The
+ * viewer HTTP endpoints were broken up into api/ (types.ts,
+ * internal.ts, runtime.ts, stats.ts, memories.ts, config.ts, sync.ts,
+ * coordinator-admin.ts) during the decomposition; this file now only
+ * keeps the public API stable for `import * as api from "../lib/api"`
+ * call sites. */
 
-import { buildProjectParams, fetchJson, payloadError, readJsonPayload } from "./api/internal";
-
+export { loadConfig, loadObserverStatus, saveConfig } from "./api/config";
 export {
 	archiveCoordinatorAdminGroup,
 	createCoordinatorAdminGroup,
@@ -19,7 +23,17 @@ export {
 	reviewCoordinatorAdminJoinRequest,
 	unarchiveCoordinatorAdminGroup,
 } from "./api/coordinator-admin";
-
+export {
+	forgetMemory,
+	loadMemories,
+	loadMemoriesPage,
+	loadSummaries,
+	loadSummariesPage,
+	tracePack,
+	updateMemoryVisibility,
+} from "./api/memories";
+export { loadProjects, loadRuntimeInfo, pingViewerReady } from "./api/runtime";
+export { loadRawEvents, loadSession, loadStats, loadUsage } from "./api/stats";
 export {
 	acceptDiscoveredPeer,
 	assignPeerActor,
@@ -38,9 +52,6 @@ export {
 	updatePeerIdentity,
 	updatePeerScope,
 } from "./api/sync";
-
-import type { PackTrace, PaginatedResponse, RuntimeInfo } from "./api/types";
-
 export type {
 	AcceptDiscoveredPeerResult,
 	CoordinatorInviteResult,
@@ -52,136 +63,3 @@ export type {
 	SyncRunItem,
 	SyncRunResponse,
 } from "./api/types";
-
-export async function pingViewerReady(timeoutMs = 1200): Promise<void> {
-	const controller = new AbortController();
-	const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
-	try {
-		const resp = await fetch("/api/stats", {
-			cache: "no-store",
-			signal: controller.signal,
-		});
-		if (!resp.ok) throw new Error(`/api/stats: ${resp.status} ${resp.statusText}`);
-	} finally {
-		window.clearTimeout(timeoutId);
-	}
-}
-
-export async function loadStats(): Promise<unknown> {
-	return fetchJson("/api/stats");
-}
-
-export async function loadRuntimeInfo(): Promise<RuntimeInfo> {
-	return fetchJson("/api/runtime");
-}
-
-export async function loadUsage(project: string): Promise<unknown> {
-	return fetchJson(`/api/usage?project=${encodeURIComponent(project)}`);
-}
-
-export async function loadSession(project: string): Promise<unknown> {
-	return fetchJson(`/api/session?project=${encodeURIComponent(project)}`);
-}
-
-export async function loadRawEvents(project: string): Promise<unknown> {
-	return fetchJson(`/api/raw-events?project=${encodeURIComponent(project)}`);
-}
-
-export async function loadMemories(project: string): Promise<PaginatedResponse> {
-	return loadMemoriesPage(project);
-}
-
-export async function loadMemoriesPage(
-	project: string,
-	options?: { limit?: number; offset?: number; scope?: string },
-): Promise<PaginatedResponse> {
-	const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
-	return fetchJson<PaginatedResponse>(`/api/observations?${query}`);
-}
-
-export async function updateMemoryVisibility(
-	memoryId: number,
-	visibility: "private" | "shared",
-): Promise<{ item?: unknown }> {
-	const resp = await fetch("/api/memories/visibility", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ memory_id: memoryId, visibility }),
-	});
-	const { text, payload } = await readJsonPayload<{ item?: unknown }>(resp);
-	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
-	return payload;
-}
-
-export async function forgetMemory(memoryId: number): Promise<{ status?: string }> {
-	const resp = await fetch("/api/memories/forget", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ memory_id: memoryId }),
-	});
-	const { text, payload } = await readJsonPayload<{ status?: string }>(resp);
-	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
-	return payload;
-}
-
-export async function loadSummaries(project: string): Promise<PaginatedResponse> {
-	return loadSummariesPage(project);
-}
-
-export async function loadSummariesPage(
-	project: string,
-	options?: { limit?: number; offset?: number; scope?: string },
-): Promise<PaginatedResponse> {
-	const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
-	return fetchJson<PaginatedResponse>(`/api/summaries?${query}`);
-}
-
-export async function tracePack(payload: {
-	context: string;
-	project?: string | null;
-	working_set_files?: string[];
-	token_budget?: number | null;
-	limit?: number;
-}): Promise<PackTrace> {
-	const resp = await fetch("/api/pack/trace", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(payload),
-	});
-	const { text, payload: data } = await readJsonPayload<PackTrace>(resp);
-	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
-	return data;
-}
-
-export async function loadObserverStatus(): Promise<unknown> {
-	return fetchJson("/api/observer-status");
-}
-
-export async function loadConfig(): Promise<unknown> {
-	return fetchJson("/api/config");
-}
-
-export async function saveConfig(payload: Record<string, unknown>): Promise<unknown> {
-	const resp = await fetch("/api/config", {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(payload),
-	});
-	const text = await resp.text();
-	let parsed: unknown = null;
-	if (text) {
-		try {
-			parsed = JSON.parse(text);
-		} catch {}
-	}
-	if (!resp.ok) {
-		const message = payloadError(parsed) || text || "request failed";
-		throw new Error(message);
-	}
-	return parsed;
-}
-
-export async function loadProjects(): Promise<string[]> {
-	const payload = await fetchJson<{ projects?: string[] }>("/api/projects");
-	return payload.projects || [];
-}

--- a/packages/ui/src/lib/api/config.ts
+++ b/packages/ui/src/lib/api/config.ts
@@ -1,0 +1,34 @@
+/* Observer/config endpoints — observer connectivity status, and the
+ * load/save cycle for the settings tab's editable config. saveConfig
+ * keeps its own JSON-parse fallback so partial failures still surface
+ * the raw response body as an error message. */
+
+import { fetchJson, payloadError } from "./internal";
+
+export async function loadObserverStatus(): Promise<unknown> {
+	return fetchJson("/api/observer-status");
+}
+
+export async function loadConfig(): Promise<unknown> {
+	return fetchJson("/api/config");
+}
+
+export async function saveConfig(payload: Record<string, unknown>): Promise<unknown> {
+	const resp = await fetch("/api/config", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+	const text = await resp.text();
+	let parsed: unknown = null;
+	if (text) {
+		try {
+			parsed = JSON.parse(text);
+		} catch {}
+	}
+	if (!resp.ok) {
+		const message = payloadError(parsed) || text || "request failed";
+		throw new Error(message);
+	}
+	return parsed;
+}

--- a/packages/ui/src/lib/api/memories.ts
+++ b/packages/ui/src/lib/api/memories.ts
@@ -1,0 +1,73 @@
+/* Memory + summary + pack-trace endpoints — paginated list fetches
+ * keyed off the current project, visibility toggles and forget
+ * actions on individual memories, and the pack-trace debug call used
+ * by the Inspector. */
+
+import { buildProjectParams, fetchJson, payloadError, readJsonPayload } from "./internal";
+import type { PackTrace, PaginatedResponse } from "./types";
+
+export async function loadMemories(project: string): Promise<PaginatedResponse> {
+	return loadMemoriesPage(project);
+}
+
+export async function loadMemoriesPage(
+	project: string,
+	options?: { limit?: number; offset?: number; scope?: string },
+): Promise<PaginatedResponse> {
+	const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
+	return fetchJson<PaginatedResponse>(`/api/observations?${query}`);
+}
+
+export async function updateMemoryVisibility(
+	memoryId: number,
+	visibility: "private" | "shared",
+): Promise<{ item?: unknown }> {
+	const resp = await fetch("/api/memories/visibility", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ memory_id: memoryId, visibility }),
+	});
+	const { text, payload } = await readJsonPayload<{ item?: unknown }>(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
+}
+
+export async function forgetMemory(memoryId: number): Promise<{ status?: string }> {
+	const resp = await fetch("/api/memories/forget", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ memory_id: memoryId }),
+	});
+	const { text, payload } = await readJsonPayload<{ status?: string }>(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
+}
+
+export async function loadSummaries(project: string): Promise<PaginatedResponse> {
+	return loadSummariesPage(project);
+}
+
+export async function loadSummariesPage(
+	project: string,
+	options?: { limit?: number; offset?: number; scope?: string },
+): Promise<PaginatedResponse> {
+	const query = buildProjectParams(project, options?.limit, options?.offset, options?.scope);
+	return fetchJson<PaginatedResponse>(`/api/summaries?${query}`);
+}
+
+export async function tracePack(payload: {
+	context: string;
+	project?: string | null;
+	working_set_files?: string[];
+	token_budget?: number | null;
+	limit?: number;
+}): Promise<PackTrace> {
+	const resp = await fetch("/api/pack/trace", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(payload),
+	});
+	const { text, payload: data } = await readJsonPayload<PackTrace>(resp);
+	if (!resp.ok) throw new Error(payloadError(data) || text || "request failed");
+	return data;
+}

--- a/packages/ui/src/lib/api/runtime.ts
+++ b/packages/ui/src/lib/api/runtime.ts
@@ -1,0 +1,29 @@
+/* Runtime-info endpoints — viewer readiness probe, build/version
+ * info, and project list. Kept separate from stats so the tiny
+ * readiness ping does not pull in the stats payload helpers. */
+
+import { fetchJson } from "./internal";
+import type { RuntimeInfo } from "./types";
+
+export async function pingViewerReady(timeoutMs = 1200): Promise<void> {
+	const controller = new AbortController();
+	const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const resp = await fetch("/api/stats", {
+			cache: "no-store",
+			signal: controller.signal,
+		});
+		if (!resp.ok) throw new Error(`/api/stats: ${resp.status} ${resp.statusText}`);
+	} finally {
+		window.clearTimeout(timeoutId);
+	}
+}
+
+export async function loadRuntimeInfo(): Promise<RuntimeInfo> {
+	return fetchJson("/api/runtime");
+}
+
+export async function loadProjects(): Promise<string[]> {
+	const payload = await fetchJson<{ projects?: string[] }>("/api/projects");
+	return payload.projects || [];
+}

--- a/packages/ui/src/lib/api/stats.ts
+++ b/packages/ui/src/lib/api/stats.ts
@@ -1,0 +1,21 @@
+/* Stats + usage endpoints consumed by the Health tab — raw pipeline
+ * state, per-project token usage, session summaries, and raw-event
+ * queue counters. All are simple GETs so the module stays thin. */
+
+import { fetchJson } from "./internal";
+
+export async function loadStats(): Promise<unknown> {
+	return fetchJson("/api/stats");
+}
+
+export async function loadUsage(project: string): Promise<unknown> {
+	return fetchJson(`/api/usage?project=${encodeURIComponent(project)}`);
+}
+
+export async function loadSession(project: string): Promise<unknown> {
+	return fetchJson(`/api/session?project=${encodeURIComponent(project)}`);
+}
+
+export async function loadRawEvents(project: string): Promise<unknown> {
+	return fetchJson(`/api/raw-events?project=${encodeURIComponent(project)}`);
+}


### PR DESCRIPTION
## Description

Final slice of the api.ts decomposition. The remaining endpoints split into four focused domain modules: runtime (readiness probe, runtime info, project list), stats (stats/usage/session/raw-event loaders), memories (memory + summary pagination, visibility toggle, forget, pack trace), and config (observer status, config load/save). api.ts becomes a thin barrel re-exporting every public function + type so existing `import * as api from "../lib/api"` call sites stay on the same path.

End state: api.ts is 65 LOC (from 662 originally); each request domain lives in its own module under api/.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — identical request shapes and response handling
- [x] Public API unchanged — all named functions + types still resolve through the barrel
- [x] `import * as api from "../lib/api"` consumers see the same surface