### PR TITLE
refactor(ui): start diagnostics.ts split — move types + redact constants to diagnostics/types.ts

### DIFF
--- a/packages/ui/src/tabs/sync/diagnostics.ts
+++ b/packages/ui/src/tabs/sync/diagnostics.ts
@@ -21,58 +21,14 @@ import {
 	type SyncStatItem,
 } from "./components/sync-diagnostics";
 import { renderPairingDisclosure } from "./components/sync-disclosure";
+import {
+	type PairingPayloadState,
+	SYNC_REDACT_LABEL_ID,
+	SYNC_REDACT_MOUNT_ID,
+	type SyncAttemptState,
+	type SyncStatusState,
+} from "./diagnostics/types";
 import { hideSkeleton, renderActionList } from "./helpers";
-
-type SyncRetention = {
-	enabled?: boolean;
-	last_deleted_ops?: number | string;
-	last_error?: string;
-	last_run_at?: string | null;
-};
-
-type SyncPayloadState = {
-	seconds_since_last?: number;
-};
-
-type PingPayloadState = SyncPayloadState & {
-	last_ping_at?: string | null;
-};
-
-type SyncStatusState = {
-	daemon_detail?: string;
-	daemon_state?: string;
-	enabled?: boolean;
-	last_ping_at?: string | null;
-	last_ping_error?: string;
-	last_sync_at?: string | null;
-	last_sync_at_utc?: string | null;
-	last_sync_error?: string;
-	pending?: number | string;
-	peers?: Record<string, unknown>;
-	ping?: PingPayloadState;
-	retention?: SyncRetention;
-	sync?: SyncPayloadState;
-};
-
-type SyncAttemptState = {
-	address?: string;
-	error?: string;
-	finished_at?: string;
-	ops_in?: number;
-	ops_out?: number;
-	peer_device_id?: string;
-	started_at?: string;
-	started_at_utc?: string;
-	status?: string;
-};
-
-type PairingPayloadState = Record<string, unknown> & {
-	addresses?: unknown[];
-	redacted?: boolean;
-};
-
-const SYNC_REDACT_MOUNT_ID = "syncRedactMount";
-const SYNC_REDACT_LABEL_ID = "syncRedactLabel";
 
 function newestPeerPing(peers: Record<string, unknown> | null | undefined): string | null {
 	const timestamps = Object.values(peers || {})

--- a/packages/ui/src/tabs/sync/diagnostics/types.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/types.ts
@@ -1,0 +1,54 @@
+/* Shared diagnostics types + DOM constants. The type aliases describe
+ * the shapes inside the viewer's /api/sync/status payload so the
+ * renderers can narrow it instead of reaching through `unknown`. */
+
+export type SyncRetention = {
+	enabled?: boolean;
+	last_deleted_ops?: number | string;
+	last_error?: string;
+	last_run_at?: string | null;
+};
+
+export type SyncPayloadState = {
+	seconds_since_last?: number;
+};
+
+export type PingPayloadState = SyncPayloadState & {
+	last_ping_at?: string | null;
+};
+
+export type SyncStatusState = {
+	daemon_detail?: string;
+	daemon_state?: string;
+	enabled?: boolean;
+	last_ping_at?: string | null;
+	last_ping_error?: string;
+	last_sync_at?: string | null;
+	last_sync_at_utc?: string | null;
+	last_sync_error?: string;
+	pending?: number | string;
+	peers?: Record<string, unknown>;
+	ping?: PingPayloadState;
+	retention?: SyncRetention;
+	sync?: SyncPayloadState;
+};
+
+export type SyncAttemptState = {
+	address?: string;
+	error?: string;
+	finished_at?: string;
+	ops_in?: number;
+	ops_out?: number;
+	peer_device_id?: string;
+	started_at?: string;
+	started_at_utc?: string;
+	status?: string;
+};
+
+export type PairingPayloadState = Record<string, unknown> & {
+	addresses?: unknown[];
+	redacted?: boolean;
+};
+
+export const SYNC_REDACT_MOUNT_ID = "syncRedactMount";
+export const SYNC_REDACT_LABEL_ID = "syncRedactLabel";


### PR DESCRIPTION
## Description

First slice of the 500-LOC diagnostics.ts decomposition. Hoist the narrow-unknown type aliases (SyncRetention, SyncPayloadState, PingPayloadState, SyncStatusState, SyncAttemptState, PairingPayloadState) plus the SYNC_REDACT_* DOM id constants into a dedicated types module. Unblocks the helper + renderer extractions that need the same shapes.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — pure type/const move