### PR TITLE
refactor(ui): start sync-dialogs.tsx split — move request/result types to sync-dialogs/types.ts

### DIFF
--- a/packages/ui/src/tabs/sync/sync-dialogs.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs.tsx
@@ -5,50 +5,17 @@ import { RadixDialog } from "../../components/primitives/radix-dialog";
 import { RadixRadioGroup } from "../../components/primitives/radix-radio-group";
 import { RadixSelect } from "../../components/primitives/radix-select";
 import { TextInput } from "../../components/primitives/text-input";
+import type {
+	ConfirmDialogRequest,
+	DialogTone,
+	DuplicatePersonDialogRequest,
+	DuplicatePersonDialogResult,
+	InputDialogRequest,
+	SyncDialogRequest,
+	SyncDialogResult,
+} from "./sync-dialogs/types";
 
-type DialogTone = "default" | "danger";
-
-type ConfirmDialogRequest = {
-	kind: "confirm";
-	autoFocusAction?: "cancel" | "confirm";
-	cancelLabel?: string;
-	confirmLabel?: string;
-	description: string;
-	tone?: DialogTone;
-	title: string;
-};
-
-type InputDialogRequest = {
-	kind: "input";
-	cancelLabel?: string;
-	confirmLabel?: string;
-	description: string;
-	initialValue?: string;
-	placeholder?: string;
-	title: string;
-	validate?: (value: string) => string | null;
-};
-
-export type DuplicatePersonActorOption = {
-	actorId: string;
-	isLocal?: boolean;
-	label: string;
-};
-
-type DuplicatePersonDialogResult =
-	| { action: "cancel" }
-	| { action: "different-people" }
-	| { action: "merge"; primaryActorId: string; secondaryActorId: string };
-
-type DuplicatePersonDialogRequest = {
-	actors: DuplicatePersonActorOption[];
-	kind: "duplicate-person";
-	summary: string;
-	title: string;
-};
-
-type SyncDialogRequest = ConfirmDialogRequest | InputDialogRequest | DuplicatePersonDialogRequest;
-type SyncDialogResult = boolean | string | null | DuplicatePersonDialogResult;
+export type { DuplicatePersonActorOption } from "./sync-dialogs/types";
 
 let dialogMount: HTMLElement | null = null;
 let currentRequest: SyncDialogRequest | null = null;

--- a/packages/ui/src/tabs/sync/sync-dialogs/types.ts
+++ b/packages/ui/src/tabs/sync/sync-dialogs/types.ts
@@ -1,0 +1,53 @@
+/* Request/result shapes for the sync dialog queue. Each request is
+ * tagged by `kind` so the host can pick the right body renderer, and
+ * SyncDialogResult is the union of all possible resolver payloads
+ * (boolean for confirm, string|null for input, union for duplicate
+ * person flow). */
+
+export type DialogTone = "default" | "danger";
+
+export type ConfirmDialogRequest = {
+	kind: "confirm";
+	autoFocusAction?: "cancel" | "confirm";
+	cancelLabel?: string;
+	confirmLabel?: string;
+	description: string;
+	tone?: DialogTone;
+	title: string;
+};
+
+export type InputDialogRequest = {
+	kind: "input";
+	cancelLabel?: string;
+	confirmLabel?: string;
+	description: string;
+	initialValue?: string;
+	placeholder?: string;
+	title: string;
+	validate?: (value: string) => string | null;
+};
+
+export type DuplicatePersonActorOption = {
+	actorId: string;
+	isLocal?: boolean;
+	label: string;
+};
+
+export type DuplicatePersonDialogResult =
+	| { action: "cancel" }
+	| { action: "different-people" }
+	| { action: "merge"; primaryActorId: string; secondaryActorId: string };
+
+export type DuplicatePersonDialogRequest = {
+	actors: DuplicatePersonActorOption[];
+	kind: "duplicate-person";
+	summary: string;
+	title: string;
+};
+
+export type SyncDialogRequest =
+	| ConfirmDialogRequest
+	| InputDialogRequest
+	| DuplicatePersonDialogRequest;
+
+export type SyncDialogResult = boolean | string | null | DuplicatePersonDialogResult;


### PR DESCRIPTION
## Description

First slice of the 460-LOC sync-dialogs.tsx decomposition. Hoist the shared request/result type definitions (DialogTone, the three *DialogRequest variants, DuplicatePersonActorOption, DuplicatePersonDialogResult, SyncDialogRequest, SyncDialogResult) into a dedicated types module. sync-dialogs.tsx re-exports DuplicatePersonActorOption since team-sync.ts imports it for its own API.

## Type of Change

- [x] Refactor (no behavioral change)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] No behavioral change — pure type move