### PR TITLE
feat(ui): top-of-sync online badge driven by coordinator presence_status

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -730,6 +730,13 @@
         gap: var(--sp-3);
         margin-bottom: var(--sp-3);
       }
+      .section-header-title {
+        display: flex;
+        align-items: center;
+        gap: var(--sp-2);
+        flex-wrap: wrap;
+        min-width: 0;
+      }
 
       .section-header h2 { margin-bottom: 0; }
 
@@ -1502,6 +1509,41 @@
       .pill-success { background: var(--green-bg, #16a34a22); color: var(--green-text, #16a34a); }
       .pill-warning { background: var(--yellow-bg, #ca8a0422); color: var(--yellow-text, #ca8a04); }
       .pill-error { background: var(--red-bg, #dc262622); color: var(--red-text, #dc2626); }
+
+      /* Sync tab top-of-card online badge.
+         Subtle-wash treatment matches trust badges + kind chips + segmented
+         toggle active state. Handoff README §E mentioned "filled-mint pill"
+         but the reference ui_kit ships the subtle-wash variant — keeping it
+         in-family here for visual consistency. */
+      .sync-online-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 2px 10px;
+        border-radius: var(--radius-pill);
+        background: var(--accent-subtle);
+        color: var(--accent);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        transition: background 140ms ease, color 140ms ease;
+      }
+      .sync-online-badge::before {
+        content: "";
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+        box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 24%, transparent);
+      }
+      .sync-online-badge.sync-online-offline {
+        background: var(--accent-warm-subtle);
+        color: var(--accent-warm);
+      }
+      .sync-online-badge.sync-online-error {
+        background: rgba(255, 122, 80, 0.16);
+        color: var(--status-attention);
+      }
 
       .match {
         padding: 0 2px;
@@ -2970,7 +3012,10 @@
       <!-- 1. Needs attention + team setup/status -->
       <div class="card" id="syncTeamCard">
         <div class="section-header">
-          <h2>Team sync</h2>
+          <div class="section-header-title">
+            <h2>Team sync</h2>
+            <span class="sync-online-badge" id="syncOnlineBadge" hidden role="status" aria-live="polite"></span>
+          </div>
           <div class="section-actions">
             <button class="settings-button" id="syncNowButton">Sync now</button>
           </div>

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -52,6 +52,29 @@ import {
 
 const TEAM_SYNC_ACTIONS_MOUNT_ID = "syncTeamActionsMount";
 
+// Top-of-card online badge. Hidden when the coordinator isn't configured yet,
+// otherwise mirrors the coordinator presence_status so operators can see at a
+// glance whether this device is reaching the coordinator.
+function updateSyncOnlineBadge(badge: HTMLElement, configured: boolean, presenceStatus: string) {
+	if (!configured) {
+		badge.hidden = true;
+		badge.textContent = "";
+		badge.className = "sync-online-badge";
+		return;
+	}
+	badge.hidden = false;
+	if (presenceStatus === "posted") {
+		badge.className = "sync-online-badge";
+		badge.textContent = "Online";
+	} else if (presenceStatus === "not_enrolled") {
+		badge.className = "sync-online-badge sync-online-offline";
+		badge.textContent = "Not enrolled";
+	} else {
+		badge.className = "sync-online-badge sync-online-error";
+		badge.textContent = "Offline";
+	}
+}
+
 function teardownTeamSyncRender(actions: HTMLElement | null, targets: Array<HTMLElement | null>) {
 	const mount = document.getElementById(TEAM_SYNC_ACTIONS_MOUNT_ID) as HTMLElement | null;
 	if (mount) {
@@ -209,6 +232,11 @@ export function renderTeamSync() {
 		? `Team: ${(coordinator.groups || []).join(", ") || "none"}`
 		: "Start by joining an existing team or creating one, then connect people and devices.";
 	meta.title = configured ? String(coordinator.coordinator_url || "").trim() : "";
+
+	const onlineBadge = document.getElementById("syncOnlineBadge");
+	if (onlineBadge) {
+		updateSyncOnlineBadge(onlineBadge, configured, String(coordinator?.presence_status || ""));
+	}
 
 	if (!configured) {
 		teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);


### PR DESCRIPTION
## Description

Adds a subtle-wash online badge at the top of the Sync tab's team card, next to the "Team sync" heading. The handoff README §E asked for this; bead codemem-i063 flagged it as blocked on a connectivity signal, but `state.lastSyncCoordinator.presence_status` already exposes exactly the signal needed.

**Behavior:**
- Hidden when the coordinator isn't configured (setup path stays clean).
- "Online" + mint subtle-wash when `presence_status === "posted"`.
- "Not enrolled" + warm subtle-wash when `presence_status === "not_enrolled"`.
- "Offline" + attention subtle-wash for any other error state.

Styling follows the `reference/ui_kit` "subtle-wash `.badge-online`" variant rather than the README prose "filled-mint pill", per the codemem-i063 bead recommendation to keep in-family with trust badges and kind chips. Leading 6px status dot inherits `currentColor` so dot, ring, and text stay coherent across all three states.

## Type of Change

- [x] Feature (non-breaking UI addition)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] Hidden when coordinator is not configured
- [x] Mirrors `presence_status` across posted / not_enrolled / error
- [x] `role="status" aria-live="polite"` so screen readers announce changes
- [x] Closes the online-badge half of codemem-i063