### PR TITLE
feat(ui): bidirectional direction glyph on mutual-trust peer cards

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1636,6 +1636,18 @@
       .peer-card { border-radius: var(--radius-lg); padding: var(--sp-4); display: grid; gap: var(--sp-2); }
       .peer-title { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); flex-wrap: wrap; }
       .peer-title strong { font-size: 14px; font-weight: 600; }
+      /* Direction glyph rendered when a peer is in mutual-trust state.
+         Handoff §E asked for ↕/↓/↑ but the full 3-way split requires a
+         peer-role field that doesn't exist in core yet — ship the
+         bidirectional marker against the existing trust signal and
+         defer the subscribed/publishing variants to a follow-up. */
+      .peer-direction {
+        margin-left: 6px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        color: var(--text-tertiary);
+        vertical-align: baseline;
+      }
       .actor-list { display: grid; gap: var(--sp-3); margin-top: var(--sp-3); }
       .actor-row { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); border-radius: var(--radius-lg); padding: var(--sp-3); }
       .actor-details { min-width: 0; display: grid; gap: 6px; }

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -331,6 +331,16 @@ function SyncPeerCard({
 			<div className="peer-title">
 				<div>
 					<strong title={peerId || undefined}>{displayName}</strong>
+					{trustSummary.state === "mutual-trust" ? (
+						<span
+							aria-label="Bidirectional sync"
+							className="peer-direction"
+							role="img"
+							title="Bidirectional sync"
+						>
+							↕
+						</span>
+					) : null}
 					<div className="peer-meta">
 						<span className={`badge ${trustSummary.isWarning ? "badge-offline" : "badge-online"}`}>
 							{trustSummary.badgeLabel}


### PR DESCRIPTION
## Description

Adds the ↕ glyph to peer cards whose `trustSummary.state === "mutual-trust"` — that's the one direction signal derivable from existing data without inventing a peer-role field.

The handoff §E asks for three glyphs (↕ bidirectional / ↓ subscribed / ↑ publishing), but only bidirectional maps cleanly to today's `derivePeerTrustSummary` output. ↓/↑ would need a per-peer role flag (who pulls vs who publishes) that the core schema and the `/api/sync/peers` payload don't carry yet. Defer those to a follow-up backed by a real data-model change.

## Type of Change

- [x] Feature (non-breaking UI addition)

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] `<span class="peer-direction" role="img" aria-label="Bidirectional sync">` so screen readers + hover tooltips both read the meaning in words
- [x] Mono font + text-tertiary color so the glyph reads as a quiet adornment, not a status pill
- [x] Only renders for mutual-trust state (no hard-coded glyph when the data isn't there)
- [x] Closes the "bidirectional direction marker" slice of codemem-i063