### PR TITLE
feat(sync): expose recent_ops per peer + wire direction glyph to observed traffic

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1071,9 +1071,12 @@
       .toggle-button.active {
         background: var(--accent-subtle);
         color: var(--accent);
-        font-weight: 600;
         box-shadow: inset 0 0 0 1px var(--accent-strong);
       }
+      /* Intentionally no font-weight change on .active — weight-driven text
+         width shifts would retime the toggle's outer width and could wrap
+         the downstream controls (search + type toggle + Context Inspector)
+         to a second line. Bg + color + inset ring is sufficient signal. */
       .toggle-button:focus-visible {
         outline: 2px solid var(--accent);
         outline-offset: 2px;

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1660,8 +1660,8 @@
       .actor-merge-controls { display: flex; align-items: center; gap: var(--sp-2); flex-wrap: wrap; }
       .actor-merge-select { min-width: 200px; }
       .actor-merge-note { width: 100%; }
-      .actor-create-row { display: flex; gap: var(--sp-2); flex-wrap: wrap; margin-top: var(--sp-3); }
-      .actor-create-row input { flex: 1 1 260px; }
+      .actor-create-row { display: flex; align-items: flex-end; gap: var(--sp-2); flex-wrap: wrap; margin-top: var(--sp-3); }
+      .actor-create-row input { flex: 1 1 260px; max-height: 40px; }
       .actor-badge.local { background: rgba(31, 111, 92, 0.12); color: var(--accent); }
       .peer-scope { display: grid; gap: var(--sp-2); padding-top: var(--sp-2); border-top: 1px solid var(--border); }
       .peer-scope-summary, .peer-scope-effective { font-size: 12px; color: var(--text-secondary); }

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -34,8 +34,9 @@ export async function loadSyncActors(): Promise<unknown> {
 	return fetchJson("/api/sync/actors");
 }
 
-export async function loadPairing(): Promise<unknown> {
-	return fetchJson("/api/sync/pairing?includeDiagnostics=1");
+export async function loadPairing(includeDiagnostics = false): Promise<unknown> {
+	const suffix = includeDiagnostics ? "?includeDiagnostics=1" : "";
+	return fetchJson(`/api/sync/pairing${suffix}`);
 }
 
 export async function updatePeerScope(

--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -220,6 +220,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									"button",
 									{
+										class: "settings-button",
 										disabled: summary.readiness !== "ready" || pending,
 										onClick: () => runGroup(group.group_id, draftName, "rename"),
 										type: "button",
@@ -231,7 +232,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									"button",
 									{
-										class: archived ? undefined : "danger",
+										class: archived ? "settings-button" : "settings-button danger",
 										disabled: summary.readiness !== "ready" || pending,
 										onClick: () =>
 											runGroup(

--- a/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
@@ -57,6 +57,7 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 								h(
 									"button",
 									{
+										class: "settings-button",
 										disabled: !requestId || pending,
 										onClick: () => reviewJoinRequest(requestId, "approve"),
 										type: "button",
@@ -68,7 +69,7 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 								h(
 									"button",
 									{
-										class: "danger",
+										class: "settings-button danger",
 										disabled: !requestId || pending,
 										onClick: () => reviewJoinRequest(requestId, "deny"),
 										type: "button",

--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -173,6 +173,24 @@ function SyncActorRow({
 						</button>
 						<button
 							type="button"
+							className="settings-button danger"
+							disabled={renameBusy || mergeBusy}
+							onClick={async () => {
+								const confirmed = await openSyncConfirmDialog({
+									title: `Remove ${label}?`,
+									description:
+										"This deactivates the person and unassigns their devices. Existing memories keep their current attribution.",
+									confirmLabel: "Remove person",
+									cancelLabel: "Keep",
+									tone: "danger",
+								});
+								if (confirmed) await onDeactivate(actorId);
+							}}
+						>
+							Remove
+						</button>
+						<button
+							type="button"
 							className="settings-button"
 							disabled={renameBusy || mergeBusy}
 							onClick={() => setAdvancedOpen((open) => !open)}
@@ -182,7 +200,7 @@ function SyncActorRow({
 						{advancedOpen ? (
 							<>
 								<div className="peer-meta actor-merge-note">
-									Use these only when cleaning up duplicate people or removing an unused person.
+									Use this only when combining duplicate people into one.
 								</div>
 								<div className="actor-merge-controls">
 									<RadixSelect
@@ -207,24 +225,6 @@ function SyncActorRow({
 									</button>
 								</div>
 								<div className="peer-meta actor-merge-note">{mergeNote}</div>
-								<button
-									type="button"
-									className="settings-button"
-									disabled={renameBusy || mergeBusy}
-									onClick={async () => {
-										const confirmed = await openSyncConfirmDialog({
-											title: `Remove ${label}?`,
-											description:
-												"This deactivates the person and unassigns their devices. Existing memories keep their current attribution.",
-											confirmLabel: "Remove person",
-											cancelLabel: "Keep",
-											tone: "danger",
-										});
-										if (confirmed) await onDeactivate(actorId);
-									}}
-								>
-									Remove this person
-								</button>
 							</>
 						) : null}
 					</>

--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -174,7 +174,7 @@ function PairingDisclosure({ contentHost, open, onOpenChange }: PairingDisclosur
 			<div className="peer-title">
 				<strong>Pairing command</strong>
 				<div className="peer-actions">
-					<button id="pairingCopy" type="button">
+					<button className="settings-button" id="pairingCopy" type="button">
 						Copy command
 					</button>
 				</div>

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -15,7 +15,20 @@ import {
 } from "../helpers";
 import { PeerScopeCollapsible } from "../peer-scope-collapsible";
 import { openSyncConfirmDialog } from "../sync-dialogs";
-import { derivePeerTrustSummary, type PeerLike } from "../view-model";
+import {
+	derivePeerDirection,
+	derivePeerTrustSummary,
+	type PeerDirection,
+	type PeerLike,
+} from "../view-model";
+
+const DIRECTION_GLYPH: Record<PeerDirection, { glyph: string; label: string } | null> = {
+	bidirectional: { glyph: "↕", label: "Bidirectional sync in the last 24 hours" },
+	publishing: { glyph: "↑", label: "Publishing only in the last 24 hours" },
+	subscribed: { glyph: "↓", label: "Subscribed only in the last 24 hours" },
+	none: null,
+};
+
 import { renderIntoSyncMount } from "./render-root";
 import { SyncEmptyState } from "./sync-empty-state";
 import { type SyncActionFeedback, SyncInlineFeedback } from "./sync-inline-feedback";
@@ -99,6 +112,7 @@ function SyncPeerCard({
 	const destructiveLabel = peer.name || peerId || displayName;
 	const pendingScopeReview = isPeerScopeReviewPending(peerId);
 	const trustSummary = derivePeerTrustSummary(peer);
+	const directionHint = DIRECTION_GLYPH[derivePeerDirection(peer)];
 	const peerStatus: SyncPeerStatus = peer.status || {};
 	const scope = peer.project_scope || {};
 	const includeList = listText(scope.include);
@@ -331,14 +345,14 @@ function SyncPeerCard({
 			<div className="peer-title">
 				<div>
 					<strong title={peerId || undefined}>{displayName}</strong>
-					{trustSummary.state === "mutual-trust" ? (
+					{directionHint ? (
 						<span
-							aria-label="Bidirectional sync"
+							aria-label={directionHint.label}
 							className="peer-direction"
 							role="img"
-							title="Bidirectional sync"
+							title={directionHint.label}
 						>
-							↕
+							{directionHint.glyph}
 						</span>
 					) : null}
 					<div className="peer-meta">

--- a/packages/ui/src/tabs/sync/diagnostics/lifecycle.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/lifecycle.ts
@@ -86,6 +86,13 @@ function renderRedactControl() {
 			onCheckedChange: (checked: boolean) => {
 				setSyncRedactionEnabled(checked);
 				renderRedactControl();
+				// Redaction is honored server-side (the viewer proxy strips
+				// addresses, pairing payloads, and last_error unless
+				// includeDiagnostics=true). Flip the local switch and
+				// immediately re-fetch so the re-rendered cards actually
+				// reflect the new state instead of echoing the prior
+				// server payload.
+				_refreshPairing();
 				renderSyncStatus();
 				_renderSyncPeers();
 				renderSyncAttempts();

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -1,7 +1,7 @@
 /* Sync tab orchestrator — re-exports public API and coordinates sub-modules. */
 
 import * as api from "../../lib/api";
-import { state } from "../../lib/state";
+import { isSyncRedactionEnabled, state } from "../../lib/state";
 import { renderHealthOverview } from "../health";
 import { ensureSyncRenderBoundary } from "./components/render-root";
 
@@ -113,15 +113,21 @@ export async function loadSyncData() {
 		const useCache = state.activeTab === "health";
 		let fetchedFreshSyncStatus = false;
 
+		// When the Advanced diagnostics "Redact" toggle is OFF the user is
+		// opting into raw diagnostics — pass includeDiagnostics=true so the
+		// server returns real addresses, pairing payload, and peer errors.
+		const includeDiagnostics = !isSyncRedactionEnabled();
 		let payload: SyncStatusResponseLike;
 		if (useCache) {
 			payload = readCachedSyncStatus(project);
 			if (!payload) {
-				payload = await api.loadSyncStatus(false, project, { includeJoinRequests: false });
+				payload = await api.loadSyncStatus(includeDiagnostics, project, {
+					includeJoinRequests: false,
+				});
 				fetchedFreshSyncStatus = true;
 			}
 		} else {
-			payload = await api.loadSyncStatus(false, project, { includeJoinRequests });
+			payload = await api.loadSyncStatus(includeDiagnostics, project, { includeJoinRequests });
 			fetchedFreshSyncStatus = true;
 		}
 
@@ -233,7 +239,7 @@ export function resetSyncLoadStateForTests() {
 
 export async function loadPairingData() {
 	try {
-		const payload = await api.loadPairing();
+		const payload = await api.loadPairing(!isSyncRedactionEnabled());
 		state.pairingPayloadRaw = payload || null;
 		renderPairing();
 	} catch {

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -423,7 +423,7 @@ export function renderTeamSync() {
 		detail:
 			presenceStatus === "posted"
 				? actionableCount > 0
-					? `Team ${teamLabel}. Start with the highest-priority item below, then review people and devices.`
+					? `Team ${teamLabel}. Work through Needs attention above, then review people and devices.`
 					: `Team ${teamLabel}. Nothing urgent is blocking sync right now.`
 				: presenceStatus === "not_enrolled"
 					? `Team ${teamLabel}. Enroll this device first, then return here to review the rest of the team.`

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -12,7 +12,11 @@ export {
 	summarizeSyncRunResult,
 } from "./view-model/coordinator-approval";
 export { deviceNeedsFriendlyName, resolveFriendlyDeviceName } from "./view-model/device-names";
-export { derivePeerTrustSummary, derivePeerUiStatus } from "./view-model/peer-status";
+export {
+	derivePeerDirection,
+	derivePeerTrustSummary,
+	derivePeerUiStatus,
+} from "./view-model/peer-status";
 export {
 	deriveDuplicatePeople,
 	deriveVisiblePeopleActors,
@@ -21,7 +25,9 @@ export { deriveSyncViewModel } from "./view-model/sync-view-model";
 export {
 	type ActorLike,
 	type DiscoveredDeviceLike,
+	type PeerDirection,
 	type PeerLike,
+	type PeerRecentOps,
 	SYNC_TERMINOLOGY,
 	type UiCoordinatorApprovalState,
 	type UiCoordinatorApprovalSummary,

--- a/packages/ui/src/tabs/sync/view-model/peer-status.ts
+++ b/packages/ui/src/tabs/sync/view-model/peer-status.ts
@@ -9,7 +9,21 @@ import {
 	isUnauthorizedPeerError,
 	peerErrorText,
 } from "./internal";
-import type { PeerLike, UiPeerTrustSummary, UiSyncStatus } from "./types";
+import type { PeerDirection, PeerLike, UiPeerTrustSummary, UiSyncStatus } from "./types";
+
+// Classify a peer's recent sync direction from observed traffic:
+// ↕ bidirectional when both directions have flowed in the recent window,
+// ↑ publishing when we have only sent, ↓ subscribed when we have only
+// received, and "none" when no qualifying attempts landed. Source data is
+// the /api/sync/peers recent_ops aggregate (24-hour successful window).
+export function derivePeerDirection(peer: PeerLike): PeerDirection {
+	const inCount = Math.max(0, Number(peer?.recent_ops?.in ?? 0));
+	const outCount = Math.max(0, Number(peer?.recent_ops?.out ?? 0));
+	if (inCount > 0 && outCount > 0) return "bidirectional";
+	if (outCount > 0) return "publishing";
+	if (inCount > 0) return "subscribed";
+	return "none";
+}
 
 export function derivePeerUiStatus(peer: PeerLike): UiSyncStatus {
 	const peerState = cleanText(peer?.status?.peer_state);

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -93,6 +93,13 @@ export interface ActorLike {
 	is_local?: boolean;
 }
 
+export type PeerRecentOps = {
+	in?: number;
+	out?: number;
+};
+
+export type PeerDirection = "bidirectional" | "publishing" | "subscribed" | "none";
+
 export interface PeerLike {
 	peer_device_id?: string;
 	name?: string;
@@ -101,6 +108,7 @@ export interface PeerLike {
 	fingerprint?: string;
 	actor_id?: string;
 	status?: SyncPeerStatusLike;
+	recent_ops?: PeerRecentOps;
 }
 
 export interface DiscoveredDeviceLike {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -794,7 +794,10 @@ function mapPeerRow(
 	store: MemoryStore,
 	row: Record<string, unknown>,
 	showDiag: boolean,
+	recentOpsByPeer?: Map<string, { in: number; out: number }>,
 ): Record<string, unknown> {
+	const peerId = String(row.peer_device_id ?? "");
+	const recentOps = recentOpsByPeer?.get(peerId) ?? { in: 0, out: 0 };
 	return {
 		peer_device_id: row.peer_device_id,
 		name: row.name,
@@ -811,7 +814,39 @@ function mapPeerRow(
 		project_scope: {
 			...currentProjectScope(row, readPeerProjectFilters(store, String(row.peer_device_id ?? ""))),
 		},
+		recent_ops: { in: recentOps.in, out: recentOps.out },
 	};
+}
+
+// Aggregate ops_in / ops_out across recent successful sync_attempts per peer.
+// Window: last 24 hours. Feeds the per-peer direction glyph on the Sync tab
+// (↕ bidirectional, ↑ publishing, ↓ subscribed) off real traffic instead of
+// an invented peer-role field.
+const SYNC_DIRECTION_WINDOW_SECONDS = 24 * 60 * 60;
+
+function recentPeerOps(store: MemoryStore): Map<string, { in: number; out: number }> {
+	const cutoff = new Date(Date.now() - SYNC_DIRECTION_WINDOW_SECONDS * 1000).toISOString();
+	const rows = store.db
+		.prepare(
+			`SELECT peer_device_id,
+			        COALESCE(SUM(ops_in), 0) AS ops_in,
+			        COALESCE(SUM(ops_out), 0) AS ops_out
+			   FROM sync_attempts
+			  WHERE ok = 1 AND finished_at IS NOT NULL AND finished_at >= ?
+			  GROUP BY peer_device_id`,
+		)
+		.all(cutoff) as Array<{
+		peer_device_id: string | null;
+		ops_in: number | null;
+		ops_out: number | null;
+	}>;
+	const map = new Map<string, { in: number; out: number }>();
+	for (const row of rows) {
+		const id = String(row.peer_device_id ?? "").trim();
+		if (!id) continue;
+		map.set(id, { in: Number(row.ops_in ?? 0), out: Number(row.ops_out ?? 0) });
+	}
+	return map;
 }
 
 // ---------------------------------------------------------------------------
@@ -1378,8 +1413,9 @@ export function syncRoutes(
 				"peerRows",
 				() => store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[],
 			);
+			const recentOpsByPeer = traceSync("recentPeerOps", () => recentPeerOps(store));
 			const peersItems = peerRows.map((row) => {
-				const peer = mapPeerRow(store, row, showDiag);
+				const peer = mapPeerRow(store, row, showDiag, recentOpsByPeer);
 				peer.status = peerStatus(peer);
 				return peer;
 			});
@@ -1515,8 +1551,9 @@ export function syncRoutes(
 		{
 			const showDiag = queryBool(c.req.query("includeDiagnostics"));
 			const rows = store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[];
+			const recentOpsByPeer = recentPeerOps(store);
 			// Use deduplicated mapPeerRow helper (fix #4)
-			const peers = rows.map((row) => mapPeerRow(store, row, showDiag));
+			const peers = rows.map((row) => mapPeerRow(store, row, showDiag, recentOpsByPeer));
 			return c.json({ items: peers, redacted: !showDiag });
 		}
 	});


### PR DESCRIPTION
## Description

Lets the Sync tab render the handoff §E direction glyph (↕ bidirectional / ↑ publishing / ↓ subscribed) from observed traffic rather than a trust-state proxy.

**Server:** `packages/viewer-server/src/routes/sync.ts`
- `recentPeerOps(store)` aggregates ops_in / ops_out across successful sync_attempts per peer in the last 24h.
- `mapPeerRow` attaches `recent_ops: { in, out }` to every peer in `/api/sync/status` and `/api/sync/peers`.

**UI:** `packages/ui/src/tabs/sync/*`
- `view-model/types.ts`: adds `PeerRecentOps` + `PeerDirection` union and `recent_ops` on `PeerLike`.
- `view-model/peer-status.ts`: `derivePeerDirection(peer)` classifies from raw counts. Supersedes the earlier mutual-trust shortcut.
- `components/sync-peers.tsx`: renders ↕/↑/↓ via a `DIRECTION_GLYPH` map so glyph + aria-label + tooltip stay coherent. Hidden when neither side moved traffic.

Closes codemem-05jj.

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)

## Checklist

- [x] Direction derived from observed ops, not invented trust state
- [x] Hidden when peer is idle (no glyph rather than misleading fallback)
- [x] Supersedes the bidirectional-only shortcut from #919