### PR TITLE
fix(ui): style coordinator-admin action buttons consistently

### DIFF
--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -220,6 +220,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									"button",
 									{
+										class: "settings-button",
 										disabled: summary.readiness !== "ready" || pending,
 										onClick: () => runGroup(group.group_id, draftName, "rename"),
 										type: "button",
@@ -231,7 +232,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									"button",
 									{
-										class: archived ? undefined : "danger",
+										class: archived ? "settings-button" : "settings-button danger",
 										disabled: summary.readiness !== "ready" || pending,
 										onClick: () =>
 											runGroup(

--- a/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
@@ -57,6 +57,7 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 								h(
 									"button",
 									{
+										class: "settings-button",
 										disabled: !requestId || pending,
 										onClick: () => reviewJoinRequest(requestId, "approve"),
 										type: "button",
@@ -68,7 +69,7 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 								h(
 									"button",
 									{
-										class: "danger",
+										class: "settings-button danger",
 										disabled: !requestId || pending,
 										onClick: () => reviewJoinRequest(requestId, "deny"),
 										type: "button",


### PR DESCRIPTION
## Description

Group Rename/Archive and join-request Approve/Deny buttons were missing the `.settings-button` base class, so they rendered as native chrome while the surrounding Manage / Disable / Remove buttons used the viewer's styled pill treatment. The inconsistency was visible in the Coordinator Admin → Groups panel where Rename appeared as a white native button next to a green Manage, and Archive showed warm text without the pill border.

Fix: add `.settings-button` (plus `danger` for destructive variants) to every action button in `groups-panel` and `join-requests-panel` so they match the treatment already applied in `devices-panel`.

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)