### PR TITLE
fix(ui): pairing Copy button styling + team-sync overview copy direction

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -174,7 +174,7 @@ function PairingDisclosure({ contentHost, open, onOpenChange }: PairingDisclosur
 			<div className="peer-title">
 				<strong>Pairing command</strong>
 				<div className="peer-actions">
-					<button id="pairingCopy" type="button">
+					<button className="settings-button" id="pairingCopy" type="button">
 						Copy command
 					</button>
 				</div>

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -423,7 +423,7 @@ export function renderTeamSync() {
 		detail:
 			presenceStatus === "posted"
 				? actionableCount > 0
-					? `Team ${teamLabel}. Start with the highest-priority item below, then review people and devices.`
+					? `Team ${teamLabel}. Work through Needs attention above, then review people and devices.`
 					: `Team ${teamLabel}. Nothing urgent is blocking sync right now.`
 				: presenceStatus === "not_enrolled"
 					? `Team ${teamLabel}. Enroll this device first, then return here to review the rest of the team.`


### PR DESCRIPTION
## Description

Two small UX fixes flagged during release review:

1. `sync-disclosure.tsx`: the "Copy command" button in the pairing card rendered as an unstyled native button because it was missing the `.settings-button` class. Everything else in the disclosure used the styled pill treatment, so the bare chrome stood out.
2. `team-sync` overview: `statusSummary.detail` said "Start with the highest-priority item below, then review people and devices." But the Overview block sits at the bottom of the card and the Needs Attention items are above it, so "below" had nothing to point at. Switch to "Work through Needs attention above, then review people and devices." so the pointer matches the layout.

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)