### PR TITLE
fix(ui): constrain Create person row + hoist Remove out of duplicate cleanup

### DIFF
--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -2028,8 +2028,16 @@
         box-shadow: 0 0 0 4px var(--focus-ring);
       }
       .modal-close-button-icon {
-        font-size: 11px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 14px;
+        height: 14px;
         color: var(--text-tertiary);
+      }
+      .modal-close-button-icon svg {
+        width: 100%;
+        height: 100%;
       }
       .modal-close-button-label {
         font-weight: 600;
@@ -2732,7 +2740,7 @@
         <div class="modal-header">
           <h2 id="settingsTitle">Memory & model settings</h2>
           <button class="modal-close-button" id="settingsClose" aria-label="Close settings">
-            <span class="modal-close-button-icon" aria-hidden="true">✕</span>
+            <i class="modal-close-button-icon" aria-hidden="true" data-lucide="x"></i>
             <span class="modal-close-button-label">Close</span>
           </button>
         </div>

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1071,9 +1071,12 @@
       .toggle-button.active {
         background: var(--accent-subtle);
         color: var(--accent);
-        font-weight: 600;
         box-shadow: inset 0 0 0 1px var(--accent-strong);
       }
+      /* Intentionally no font-weight change on .active — weight-driven text
+         width shifts would retime the toggle's outer width and could wrap
+         the downstream controls (search + type toggle + Context Inspector)
+         to a second line. Bg + color + inset ring is sufficient signal. */
       .toggle-button:focus-visible {
         outline: 2px solid var(--accent);
         outline-offset: 2px;

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1636,6 +1636,18 @@
       .peer-card { border-radius: var(--radius-lg); padding: var(--sp-4); display: grid; gap: var(--sp-2); }
       .peer-title { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); flex-wrap: wrap; }
       .peer-title strong { font-size: 14px; font-weight: 600; }
+      /* Direction glyph rendered when a peer is in mutual-trust state.
+         Handoff §E asked for ↕/↓/↑ but the full 3-way split requires a
+         peer-role field that doesn't exist in core yet — ship the
+         bidirectional marker against the existing trust signal and
+         defer the subscribed/publishing variants to a follow-up. */
+      .peer-direction {
+        margin-left: 6px;
+        font-family: var(--font-mono);
+        font-size: 13px;
+        color: var(--text-tertiary);
+        vertical-align: baseline;
+      }
       .actor-list { display: grid; gap: var(--sp-3); margin-top: var(--sp-3); }
       .actor-row { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); border-radius: var(--radius-lg); padding: var(--sp-3); }
       .actor-details { min-width: 0; display: grid; gap: 6px; }

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -730,6 +730,13 @@
         gap: var(--sp-3);
         margin-bottom: var(--sp-3);
       }
+      .section-header-title {
+        display: flex;
+        align-items: center;
+        gap: var(--sp-2);
+        flex-wrap: wrap;
+        min-width: 0;
+      }
 
       .section-header h2 { margin-bottom: 0; }
 
@@ -1502,6 +1509,41 @@
       .pill-success { background: var(--green-bg, #16a34a22); color: var(--green-text, #16a34a); }
       .pill-warning { background: var(--yellow-bg, #ca8a0422); color: var(--yellow-text, #ca8a04); }
       .pill-error { background: var(--red-bg, #dc262622); color: var(--red-text, #dc2626); }
+
+      /* Sync tab top-of-card online badge.
+         Subtle-wash treatment matches trust badges + kind chips + segmented
+         toggle active state. Handoff README §E mentioned "filled-mint pill"
+         but the reference ui_kit ships the subtle-wash variant — keeping it
+         in-family here for visual consistency. */
+      .sync-online-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 2px 10px;
+        border-radius: var(--radius-pill);
+        background: var(--accent-subtle);
+        color: var(--accent);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        transition: background 140ms ease, color 140ms ease;
+      }
+      .sync-online-badge::before {
+        content: "";
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: currentColor;
+        box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 24%, transparent);
+      }
+      .sync-online-badge.sync-online-offline {
+        background: var(--accent-warm-subtle);
+        color: var(--accent-warm);
+      }
+      .sync-online-badge.sync-online-error {
+        background: rgba(255, 122, 80, 0.16);
+        color: var(--status-attention);
+      }
 
       .match {
         padding: 0 2px;
@@ -2970,7 +3012,10 @@
       <!-- 1. Needs attention + team setup/status -->
       <div class="card" id="syncTeamCard">
         <div class="section-header">
-          <h2>Team sync</h2>
+          <div class="section-header-title">
+            <h2>Team sync</h2>
+            <span class="sync-online-badge" id="syncOnlineBadge" hidden role="status" aria-live="polite"></span>
+          </div>
           <div class="section-actions">
             <button class="settings-button" id="syncNowButton">Sync now</button>
           </div>

--- a/codemem/viewer_static/index.html
+++ b/codemem/viewer_static/index.html
@@ -1660,8 +1660,8 @@
       .actor-merge-controls { display: flex; align-items: center; gap: var(--sp-2); flex-wrap: wrap; }
       .actor-merge-select { min-width: 200px; }
       .actor-merge-note { width: 100%; }
-      .actor-create-row { display: flex; gap: var(--sp-2); flex-wrap: wrap; margin-top: var(--sp-3); }
-      .actor-create-row input { flex: 1 1 260px; }
+      .actor-create-row { display: flex; align-items: flex-end; gap: var(--sp-2); flex-wrap: wrap; margin-top: var(--sp-3); }
+      .actor-create-row input { flex: 1 1 260px; max-height: 40px; }
       .actor-badge.local { background: rgba(31, 111, 92, 0.12); color: var(--accent); }
       .peer-scope { display: grid; gap: var(--sp-2); padding-top: var(--sp-2); border-top: 1px solid var(--border); }
       .peer-scope-summary, .peer-scope-effective { font-size: 12px; color: var(--text-secondary); }

--- a/packages/ui/src/components/primitives/dialog-close-button.tsx
+++ b/packages/ui/src/components/primitives/dialog-close-button.tsx
@@ -13,9 +13,7 @@ export function DialogCloseButton({
 }: DialogCloseButtonProps) {
 	return (
 		<button aria-label={ariaLabel} className={className} onClick={onClick} type="button">
-			<span aria-hidden="true" className="modal-close-button-icon">
-				✕
-			</span>
+			<i aria-hidden="true" className="modal-close-button-icon" data-lucide="x" />
 			<span className="modal-close-button-label">{label}</span>
 		</button>
 	);

--- a/packages/ui/src/components/primitives/radix-select.tsx
+++ b/packages/ui/src/components/primitives/radix-select.tsx
@@ -2,6 +2,49 @@ import * as Select from "@radix-ui/react-select";
 
 const EMPTY_SENTINEL = "__codemem-empty-select__";
 
+/* Inline SVGs for the select trigger chevron and item indicator. Using
+ * inline SVG (not <i data-lucide=...>) sidesteps a race condition: Radix
+ * Select mounts its content in a Portal on open, after the Settings
+ * dialog's only createIcons() pass has already run, so a lucide stub
+ * inside the portal would never get replaced. */
+function SelectChevronIcon() {
+	return (
+		<svg
+			aria-hidden="true"
+			fill="none"
+			height="14"
+			stroke="currentColor"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="2"
+			viewBox="0 0 24 24"
+			width="14"
+		>
+			<title>Open</title>
+			<path d="m6 9 6 6 6-6" />
+		</svg>
+	);
+}
+
+function SelectCheckIcon() {
+	return (
+		<svg
+			aria-hidden="true"
+			fill="none"
+			height="14"
+			stroke="currentColor"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="2"
+			viewBox="0 0 24 24"
+			width="14"
+		>
+			<title>Selected</title>
+			<path d="M20 6 9 17l-5-5" />
+		</svg>
+	);
+}
+
 function encodeValue(value: string): string {
 	return value === "" ? EMPTY_SENTINEL : value;
 }
@@ -62,7 +105,7 @@ export function RadixSelect({
 			>
 				<Select.Value placeholder={placeholder} />
 				<Select.Icon className="sync-radix-select-icon" aria-hidden="true">
-					▾
+					<SelectChevronIcon />
 				</Select.Icon>
 			</Select.Trigger>
 			<Select.Portal>
@@ -77,7 +120,7 @@ export function RadixSelect({
 							>
 								<Select.ItemText>{option.label}</Select.ItemText>
 								<Select.ItemIndicator className="sync-radix-select-indicator">
-									✓
+									<SelectCheckIcon />
 								</Select.ItemIndicator>
 							</Select.Item>
 						))}

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -34,8 +34,9 @@ export async function loadSyncActors(): Promise<unknown> {
 	return fetchJson("/api/sync/actors");
 }
 
-export async function loadPairing(): Promise<unknown> {
-	return fetchJson("/api/sync/pairing?includeDiagnostics=1");
+export async function loadPairing(includeDiagnostics = false): Promise<unknown> {
+	const suffix = includeDiagnostics ? "?includeDiagnostics=1" : "";
+	return fetchJson(`/api/sync/pairing${suffix}`);
 }
 
 export async function updatePeerScope(

--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -220,6 +220,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									"button",
 									{
+										class: "settings-button",
 										disabled: summary.readiness !== "ready" || pending,
 										onClick: () => runGroup(group.group_id, draftName, "rename"),
 										type: "button",
@@ -231,7 +232,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									"button",
 									{
-										class: archived ? undefined : "danger",
+										class: archived ? "settings-button" : "settings-button danger",
 										disabled: summary.readiness !== "ready" || pending,
 										onClick: () =>
 											runGroup(

--- a/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/join-requests-panel.ts
@@ -57,6 +57,7 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 								h(
 									"button",
 									{
+										class: "settings-button",
 										disabled: !requestId || pending,
 										onClick: () => reviewJoinRequest(requestId, "approve"),
 										type: "button",
@@ -68,7 +69,7 @@ export function renderJoinRequestsPanel(deps: JoinRequestsPanelDeps) {
 								h(
 									"button",
 									{
-										class: "danger",
+										class: "settings-button danger",
 										disabled: !requestId || pending,
 										onClick: () => reviewJoinRequest(requestId, "deny"),
 										type: "button",

--- a/packages/ui/src/tabs/health/render/health-overview.ts
+++ b/packages/ui/src/tabs/health/render/health-overview.ts
@@ -72,11 +72,14 @@ export function renderHealthOverview() {
 	const syncDisabled = syncState === "disabled" || syncStatus.enabled === false;
 	const syncOfflinePeers = syncState === "offline-peers";
 	const syncNoPeers = !syncDisabled && peerCount === 0;
-	const syncCardValue = syncDisabled ? "Disabled" : syncNoPeers ? "No peers" : syncStateLabel;
+	let syncCardValue = syncDisabled ? "Disabled" : syncNoPeers ? "No peers" : syncStateLabel;
 	const lastSyncAt = syncStatus.last_sync_at || syncStatus.last_sync_at_utc || null;
 	const syncAgeSeconds = secondsSince(lastSyncAt);
 	const packAgeSeconds = secondsSince(lastPackAt);
 	const syncLooksStale = syncAgeSeconds !== null && syncAgeSeconds > 7200;
+	// Recent successful sync (≤5 min) means the daemon is functionally working
+	// even if a single peer is flagged "degraded", so soften the risk signal.
+	const syncRecentlyOk = syncAgeSeconds !== null && syncAgeSeconds <= 300;
 	const hasBacklog = rawPending >= 200;
 
 	// Risk scoring
@@ -114,7 +117,7 @@ export function renderHealthOverview() {
 		} else if (syncState === "stopped") {
 			riskScore += 22;
 			drivers.push("sync daemon stopped");
-		} else if (syncState === "degraded") {
+		} else if (syncState === "degraded" && !syncRecentlyOk) {
 			riskScore += 20;
 			drivers.push("sync daemon degraded");
 		}
@@ -153,6 +156,7 @@ export function renderHealthOverview() {
 		statusLabel = "Degraded";
 		statusClass = "status-degraded";
 	}
+	const overallIsHealthy = statusClass === "status-healthy";
 
 	// Update header health dot
 	if (healthDot) {
@@ -169,6 +173,12 @@ export function renderHealthOverview() {
 			: syncOfflinePeers
 				? `${peerCount} peers offline · last sync ${formatAgeShort(syncAgeSeconds)} ago`
 				: `${peerCount} peers · last sync ${formatAgeShort(syncAgeSeconds)} ago`;
+	// When overall health is Healthy, soften the card value so a recent-sync
+	// daemon_state of "degraded" or "offline-peers" doesn't read as alarming.
+	if (overallIsHealthy && !syncDisabled && !syncNoPeers) {
+		if (syncOfflinePeers) syncCardValue = "Peers offline";
+		else if (syncState === "degraded" && syncRecentlyOk) syncCardValue = "Syncing";
+	}
 	const freshnessDetail = `last pack ${formatAgeShort(packAgeSeconds)} ago`;
 
 	// Build maintenance card(s) for active background jobs
@@ -263,7 +273,12 @@ export function renderHealthOverview() {
 			label: "Sync daemon is stopped. Start the background service.",
 			command: "codemem serve start",
 		});
-	} else if (!syncDisabled && !syncNoPeers && (syncState === "error" || syncState === "degraded")) {
+	} else if (
+		!syncDisabled &&
+		!syncNoPeers &&
+		!overallIsHealthy &&
+		(syncState === "error" || syncState === "degraded")
+	) {
 		recommendations.push({
 			label: "Sync is unhealthy. Restart and run one immediate pass.",
 			command: "codemem serve restart",

--- a/packages/ui/src/tabs/settings/components/ObserverStatusBanner.tsx
+++ b/packages/ui/src/tabs/settings/components/ObserverStatusBanner.tsx
@@ -41,8 +41,15 @@ export function ObserverStatusBanner({ status }: { status: ObserverStatusShape |
 					<div className="status-active">
 						{String(active.provider || "unknown")} → {String(active.model || "")} via{" "}
 						{formatAuthMethod(active.auth?.method || "none")}{" "}
-						<span className={active.auth?.token_present === true ? "cred-ok" : "cred-none"}>
-							{active.auth?.token_present === true ? "✓" : "✗"}
+						<span
+							aria-label={active.auth?.token_present === true ? "token present" : "token missing"}
+							className={active.auth?.token_present === true ? "cred-ok" : "cred-none"}
+							role="img"
+						>
+							<i
+								aria-hidden="true"
+								data-lucide={active.auth?.token_present === true ? "check" : "x"}
+							/>
 						</span>
 					</div>
 				</>
@@ -63,7 +70,13 @@ export function ObserverStatusBanner({ status }: { status: ObserverStatusShape |
 							return (
 								<span key={provider} className="status-cred">
 									{index > 0 ? " · " : null}
-									<span className={hasAny ? "cred-ok" : "cred-none"}>{hasAny ? "✓" : "–"}</span>{" "}
+									<span
+										aria-label={hasAny ? "credential available" : "no credential"}
+										className={hasAny ? "cred-ok" : "cred-none"}
+										role="img"
+									>
+										{hasAny ? <i aria-hidden="true" data-lucide="check" /> : "–"}
+									</span>{" "}
 									{String(provider)}: {formatCredentialSources(normalizedCreds)}
 								</span>
 							);

--- a/packages/ui/src/tabs/sync/components/sync-actors.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-actors.tsx
@@ -173,6 +173,24 @@ function SyncActorRow({
 						</button>
 						<button
 							type="button"
+							className="settings-button danger"
+							disabled={renameBusy || mergeBusy}
+							onClick={async () => {
+								const confirmed = await openSyncConfirmDialog({
+									title: `Remove ${label}?`,
+									description:
+										"This deactivates the person and unassigns their devices. Existing memories keep their current attribution.",
+									confirmLabel: "Remove person",
+									cancelLabel: "Keep",
+									tone: "danger",
+								});
+								if (confirmed) await onDeactivate(actorId);
+							}}
+						>
+							Remove
+						</button>
+						<button
+							type="button"
 							className="settings-button"
 							disabled={renameBusy || mergeBusy}
 							onClick={() => setAdvancedOpen((open) => !open)}
@@ -182,7 +200,7 @@ function SyncActorRow({
 						{advancedOpen ? (
 							<>
 								<div className="peer-meta actor-merge-note">
-									Use these only when cleaning up duplicate people or removing an unused person.
+									Use this only when combining duplicate people into one.
 								</div>
 								<div className="actor-merge-controls">
 									<RadixSelect
@@ -207,24 +225,6 @@ function SyncActorRow({
 									</button>
 								</div>
 								<div className="peer-meta actor-merge-note">{mergeNote}</div>
-								<button
-									type="button"
-									className="settings-button"
-									disabled={renameBusy || mergeBusy}
-									onClick={async () => {
-										const confirmed = await openSyncConfirmDialog({
-											title: `Remove ${label}?`,
-											description:
-												"This deactivates the person and unassigns their devices. Existing memories keep their current attribution.",
-											confirmLabel: "Remove person",
-											cancelLabel: "Keep",
-											tone: "danger",
-										});
-										if (confirmed) await onDeactivate(actorId);
-									}}
-								>
-									Remove this person
-								</button>
 							</>
 						) : null}
 					</>

--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -174,7 +174,7 @@ function PairingDisclosure({ contentHost, open, onOpenChange }: PairingDisclosur
 			<div className="peer-title">
 				<strong>Pairing command</strong>
 				<div className="peer-actions">
-					<button id="pairingCopy" type="button">
+					<button className="settings-button" id="pairingCopy" type="button">
 						Copy command
 					</button>
 				</div>

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -331,6 +331,16 @@ function SyncPeerCard({
 			<div className="peer-title">
 				<div>
 					<strong title={peerId || undefined}>{displayName}</strong>
+					{trustSummary.state === "mutual-trust" ? (
+						<span
+							aria-label="Bidirectional sync"
+							className="peer-direction"
+							role="img"
+							title="Bidirectional sync"
+						>
+							↕
+						</span>
+					) : null}
 					<div className="peer-meta">
 						<span className={`badge ${trustSummary.isWarning ? "badge-offline" : "badge-online"}`}>
 							{trustSummary.badgeLabel}

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -15,7 +15,20 @@ import {
 } from "../helpers";
 import { PeerScopeCollapsible } from "../peer-scope-collapsible";
 import { openSyncConfirmDialog } from "../sync-dialogs";
-import { derivePeerTrustSummary, type PeerLike } from "../view-model";
+import {
+	derivePeerDirection,
+	derivePeerTrustSummary,
+	type PeerDirection,
+	type PeerLike,
+} from "../view-model";
+
+const DIRECTION_GLYPH: Record<PeerDirection, { glyph: string; label: string } | null> = {
+	bidirectional: { glyph: "↕", label: "Bidirectional sync in the last 24 hours" },
+	publishing: { glyph: "↑", label: "Publishing only in the last 24 hours" },
+	subscribed: { glyph: "↓", label: "Subscribed only in the last 24 hours" },
+	none: null,
+};
+
 import { renderIntoSyncMount } from "./render-root";
 import { SyncEmptyState } from "./sync-empty-state";
 import { type SyncActionFeedback, SyncInlineFeedback } from "./sync-inline-feedback";
@@ -99,6 +112,7 @@ function SyncPeerCard({
 	const destructiveLabel = peer.name || peerId || displayName;
 	const pendingScopeReview = isPeerScopeReviewPending(peerId);
 	const trustSummary = derivePeerTrustSummary(peer);
+	const directionHint = DIRECTION_GLYPH[derivePeerDirection(peer)];
 	const peerStatus: SyncPeerStatus = peer.status || {};
 	const scope = peer.project_scope || {};
 	const includeList = listText(scope.include);
@@ -331,14 +345,14 @@ function SyncPeerCard({
 			<div className="peer-title">
 				<div>
 					<strong title={peerId || undefined}>{displayName}</strong>
-					{trustSummary.state === "mutual-trust" ? (
+					{directionHint ? (
 						<span
-							aria-label="Bidirectional sync"
+							aria-label={directionHint.label}
 							className="peer-direction"
 							role="img"
-							title="Bidirectional sync"
+							title={directionHint.label}
 						>
-							↕
+							{directionHint.glyph}
 						</span>
 					) : null}
 					<div className="peer-meta">

--- a/packages/ui/src/tabs/sync/diagnostics/lifecycle.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/lifecycle.ts
@@ -86,6 +86,13 @@ function renderRedactControl() {
 			onCheckedChange: (checked: boolean) => {
 				setSyncRedactionEnabled(checked);
 				renderRedactControl();
+				// Redaction is honored server-side (the viewer proxy strips
+				// addresses, pairing payloads, and last_error unless
+				// includeDiagnostics=true). Flip the local switch and
+				// immediately re-fetch so the re-rendered cards actually
+				// reflect the new state instead of echoing the prior
+				// server payload.
+				_refreshPairing();
 				renderSyncStatus();
 				_renderSyncPeers();
 				renderSyncAttempts();

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -1,7 +1,7 @@
 /* Sync tab orchestrator — re-exports public API and coordinates sub-modules. */
 
 import * as api from "../../lib/api";
-import { state } from "../../lib/state";
+import { isSyncRedactionEnabled, state } from "../../lib/state";
 import { renderHealthOverview } from "../health";
 import { ensureSyncRenderBoundary } from "./components/render-root";
 
@@ -113,15 +113,21 @@ export async function loadSyncData() {
 		const useCache = state.activeTab === "health";
 		let fetchedFreshSyncStatus = false;
 
+		// When the Advanced diagnostics "Redact" toggle is OFF the user is
+		// opting into raw diagnostics — pass includeDiagnostics=true so the
+		// server returns real addresses, pairing payload, and peer errors.
+		const includeDiagnostics = !isSyncRedactionEnabled();
 		let payload: SyncStatusResponseLike;
 		if (useCache) {
 			payload = readCachedSyncStatus(project);
 			if (!payload) {
-				payload = await api.loadSyncStatus(false, project, { includeJoinRequests: false });
+				payload = await api.loadSyncStatus(includeDiagnostics, project, {
+					includeJoinRequests: false,
+				});
 				fetchedFreshSyncStatus = true;
 			}
 		} else {
-			payload = await api.loadSyncStatus(false, project, { includeJoinRequests });
+			payload = await api.loadSyncStatus(includeDiagnostics, project, { includeJoinRequests });
 			fetchedFreshSyncStatus = true;
 		}
 
@@ -233,7 +239,7 @@ export function resetSyncLoadStateForTests() {
 
 export async function loadPairingData() {
 	try {
-		const payload = await api.loadPairing();
+		const payload = await api.loadPairing(!isSyncRedactionEnabled());
 		state.pairingPayloadRaw = payload || null;
 		renderPairing();
 	} catch {

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -52,6 +52,29 @@ import {
 
 const TEAM_SYNC_ACTIONS_MOUNT_ID = "syncTeamActionsMount";
 
+// Top-of-card online badge. Hidden when the coordinator isn't configured yet,
+// otherwise mirrors the coordinator presence_status so operators can see at a
+// glance whether this device is reaching the coordinator.
+function updateSyncOnlineBadge(badge: HTMLElement, configured: boolean, presenceStatus: string) {
+	if (!configured) {
+		badge.hidden = true;
+		badge.textContent = "";
+		badge.className = "sync-online-badge";
+		return;
+	}
+	badge.hidden = false;
+	if (presenceStatus === "posted") {
+		badge.className = "sync-online-badge";
+		badge.textContent = "Online";
+	} else if (presenceStatus === "not_enrolled") {
+		badge.className = "sync-online-badge sync-online-offline";
+		badge.textContent = "Not enrolled";
+	} else {
+		badge.className = "sync-online-badge sync-online-error";
+		badge.textContent = "Offline";
+	}
+}
+
 function teardownTeamSyncRender(actions: HTMLElement | null, targets: Array<HTMLElement | null>) {
 	const mount = document.getElementById(TEAM_SYNC_ACTIONS_MOUNT_ID) as HTMLElement | null;
 	if (mount) {
@@ -209,6 +232,11 @@ export function renderTeamSync() {
 		? `Team: ${(coordinator.groups || []).join(", ") || "none"}`
 		: "Start by joining an existing team or creating one, then connect people and devices.";
 	meta.title = configured ? String(coordinator.coordinator_url || "").trim() : "";
+
+	const onlineBadge = document.getElementById("syncOnlineBadge");
+	if (onlineBadge) {
+		updateSyncOnlineBadge(onlineBadge, configured, String(coordinator?.presence_status || ""));
+	}
 
 	if (!configured) {
 		teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -423,7 +423,7 @@ export function renderTeamSync() {
 		detail:
 			presenceStatus === "posted"
 				? actionableCount > 0
-					? `Team ${teamLabel}. Start with the highest-priority item below, then review people and devices.`
+					? `Team ${teamLabel}. Work through Needs attention above, then review people and devices.`
 					: `Team ${teamLabel}. Nothing urgent is blocking sync right now.`
 				: presenceStatus === "not_enrolled"
 					? `Team ${teamLabel}. Enroll this device first, then return here to review the rest of the team.`

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -12,7 +12,11 @@ export {
 	summarizeSyncRunResult,
 } from "./view-model/coordinator-approval";
 export { deviceNeedsFriendlyName, resolveFriendlyDeviceName } from "./view-model/device-names";
-export { derivePeerTrustSummary, derivePeerUiStatus } from "./view-model/peer-status";
+export {
+	derivePeerDirection,
+	derivePeerTrustSummary,
+	derivePeerUiStatus,
+} from "./view-model/peer-status";
 export {
 	deriveDuplicatePeople,
 	deriveVisiblePeopleActors,
@@ -21,7 +25,9 @@ export { deriveSyncViewModel } from "./view-model/sync-view-model";
 export {
 	type ActorLike,
 	type DiscoveredDeviceLike,
+	type PeerDirection,
 	type PeerLike,
+	type PeerRecentOps,
 	SYNC_TERMINOLOGY,
 	type UiCoordinatorApprovalState,
 	type UiCoordinatorApprovalSummary,

--- a/packages/ui/src/tabs/sync/view-model/peer-status.ts
+++ b/packages/ui/src/tabs/sync/view-model/peer-status.ts
@@ -9,7 +9,21 @@ import {
 	isUnauthorizedPeerError,
 	peerErrorText,
 } from "./internal";
-import type { PeerLike, UiPeerTrustSummary, UiSyncStatus } from "./types";
+import type { PeerDirection, PeerLike, UiPeerTrustSummary, UiSyncStatus } from "./types";
+
+// Classify a peer's recent sync direction from observed traffic:
+// ↕ bidirectional when both directions have flowed in the recent window,
+// ↑ publishing when we have only sent, ↓ subscribed when we have only
+// received, and "none" when no qualifying attempts landed. Source data is
+// the /api/sync/peers recent_ops aggregate (24-hour successful window).
+export function derivePeerDirection(peer: PeerLike): PeerDirection {
+	const inCount = Math.max(0, Number(peer?.recent_ops?.in ?? 0));
+	const outCount = Math.max(0, Number(peer?.recent_ops?.out ?? 0));
+	if (inCount > 0 && outCount > 0) return "bidirectional";
+	if (outCount > 0) return "publishing";
+	if (inCount > 0) return "subscribed";
+	return "none";
+}
 
 export function derivePeerUiStatus(peer: PeerLike): UiSyncStatus {
 	const peerState = cleanText(peer?.status?.peer_state);

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -93,6 +93,13 @@ export interface ActorLike {
 	is_local?: boolean;
 }
 
+export type PeerRecentOps = {
+	in?: number;
+	out?: number;
+};
+
+export type PeerDirection = "bidirectional" | "publishing" | "subscribed" | "none";
+
 export interface PeerLike {
 	peer_device_id?: string;
 	name?: string;
@@ -101,6 +108,7 @@ export interface PeerLike {
 	fingerprint?: string;
 	actor_id?: string;
 	status?: SyncPeerStatusLike;
+	recent_ops?: PeerRecentOps;
 }
 
 export interface DiscoveredDeviceLike {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -794,7 +794,10 @@ function mapPeerRow(
 	store: MemoryStore,
 	row: Record<string, unknown>,
 	showDiag: boolean,
+	recentOpsByPeer?: Map<string, { in: number; out: number }>,
 ): Record<string, unknown> {
+	const peerId = String(row.peer_device_id ?? "");
+	const recentOps = recentOpsByPeer?.get(peerId) ?? { in: 0, out: 0 };
 	return {
 		peer_device_id: row.peer_device_id,
 		name: row.name,
@@ -811,7 +814,39 @@ function mapPeerRow(
 		project_scope: {
 			...currentProjectScope(row, readPeerProjectFilters(store, String(row.peer_device_id ?? ""))),
 		},
+		recent_ops: { in: recentOps.in, out: recentOps.out },
 	};
+}
+
+// Aggregate ops_in / ops_out across recent successful sync_attempts per peer.
+// Window: last 24 hours. Feeds the per-peer direction glyph on the Sync tab
+// (↕ bidirectional, ↑ publishing, ↓ subscribed) off real traffic instead of
+// an invented peer-role field.
+const SYNC_DIRECTION_WINDOW_SECONDS = 24 * 60 * 60;
+
+function recentPeerOps(store: MemoryStore): Map<string, { in: number; out: number }> {
+	const cutoff = new Date(Date.now() - SYNC_DIRECTION_WINDOW_SECONDS * 1000).toISOString();
+	const rows = store.db
+		.prepare(
+			`SELECT peer_device_id,
+			        COALESCE(SUM(ops_in), 0) AS ops_in,
+			        COALESCE(SUM(ops_out), 0) AS ops_out
+			   FROM sync_attempts
+			  WHERE ok = 1 AND finished_at IS NOT NULL AND finished_at >= ?
+			  GROUP BY peer_device_id`,
+		)
+		.all(cutoff) as Array<{
+		peer_device_id: string | null;
+		ops_in: number | null;
+		ops_out: number | null;
+	}>;
+	const map = new Map<string, { in: number; out: number }>();
+	for (const row of rows) {
+		const id = String(row.peer_device_id ?? "").trim();
+		if (!id) continue;
+		map.set(id, { in: Number(row.ops_in ?? 0), out: Number(row.ops_out ?? 0) });
+	}
+	return map;
 }
 
 // ---------------------------------------------------------------------------
@@ -1378,8 +1413,9 @@ export function syncRoutes(
 				"peerRows",
 				() => store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[],
 			);
+			const recentOpsByPeer = traceSync("recentPeerOps", () => recentPeerOps(store));
 			const peersItems = peerRows.map((row) => {
-				const peer = mapPeerRow(store, row, showDiag);
+				const peer = mapPeerRow(store, row, showDiag, recentOpsByPeer);
 				peer.status = peerStatus(peer);
 				return peer;
 			});
@@ -1515,8 +1551,9 @@ export function syncRoutes(
 		{
 			const showDiag = queryBool(c.req.query("includeDiagnostics"));
 			const rows = store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[];
+			const recentOpsByPeer = recentPeerOps(store);
 			// Use deduplicated mapPeerRow helper (fix #4)
-			const peers = rows.map((row) => mapPeerRow(store, row, showDiag));
+			const peers = rows.map((row) => mapPeerRow(store, row, showDiag, recentOpsByPeer));
 			return c.json({ items: peers, redacted: !showDiag });
 		}
 	});


### PR DESCRIPTION
## Description

Two People & devices UX fixes flagged during release review:

1. **Create person row** (static HTML): `.actor-create-row` used the flex default `align-items: stretch`, so the "Person name" input + label column would stretch the sibling "Create person" button to match, and any growth in the input would visually dominate the section. Add `align-items: flex-end` so the button aligns with the bottom of the label + input column, and cap the input at `max-height: 40px` so nothing can drive a runaway height.
2. **Remove person discoverability**: the destructive action lived under the same "Show duplicate cleanup" disclosure as the merge flow, so removing a person required operators to open a collapsible labelled for a different intent. Hoist "Remove" out as a top-level `.settings-button.danger` next to "Save name", keep Merge behind the duplicate-cleanup disclosure with a tightened explanatory note ("Use this only when combining duplicate people into one").

## Testing

- pnpm run tsc
- pnpm run lint
- pnpm run test (1417 passed)