### PR TITLE
chore(release): bump to 0.28.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.27.0"
+    "version": "0.28.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.27.0";
+const PINNED_BACKEND_VERSION = "0.28.0";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.27.0",
+	"version": "0.28.0",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.27.0",
+	"version": "0.28.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.27.0");
+		expect(VERSION).toBe("0.28.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.27.0";
+export const VERSION = "0.28.0";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.27.0",
+	"version": "0.28.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.27.0";
+const PINNED_BACKEND_VERSION = "0.28.0";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.27.0",
+	"version": "0.28.0",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.27.0",
+	"version": "0.28.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Summary

Release bump across the 11 version-managed locations (validated by `scripts/release-version.mjs check`).

## Headline changes since v0.27.0

### Features
- Direction glyph on Sync peer cards: ↕ / ↑ / ↓ derived from observed `ops_in` / `ops_out` in the last 24h. Server exposes `recent_ops` per peer via `/api/sync/status` and `/api/sync/peers`.
- Top-of-Sync online badge keyed to coordinator `presence_status`.
- Coordinator admin UI parent epic landed — invites, join-request review, device lifecycle, group CRUD.
- Cross-project fallback retrieval (`widen_project_when_weak`).
- Per-tier provider overrides and Claude defaults for the observer.
- Derived memory-role surfacing in retrieval diagnostics.
- Configurable incremental op batch size for sync.
- Viewer design-system adoption: Geist font stack, deep-ink tokens, sticky blurred header, 140ms transition audit, 4px-border feed banner, feed item pulse, stat tiles with tabular numerals, 2-col peer grid, terminal empty state, Radix Toast notices.
- Tooltip + close-button primitives adopted across modals.

### Fixes
- Health tab no longer fires aggressive "Sync unhealthy. Restart." CTA when overall health reads green (codemem-ne69).
- Advanced diagnostics Redact toggle now actually toggles — passes `includeDiagnostics` to `/api/sync/status` + `/api/sync/pairing` and refetches on flip.
- Unicode pictograms replaced with Lucide icons across primitives and the settings modal (codemem-6ljg).
- Coordinator-admin group Rename/Archive + join Approve/Deny buttons now use the styled pill treatment.
- Feed toggle active state no longer shifts toggle width.
- People & devices: Create person input capped; Remove hoisted out of the duplicate-cleanup disclosure.
- Pairing Copy button now styled; team-sync overview copy no longer contradicts its own layout.
- Observer session summaries: per-session supersede so multi-flush sessions don't stack redundant summaries.

### Refactors
- UI god-file decomposition shipped for `coordinator-admin.tsx` (1068→9), `team-sync.ts` (924→9), `health.ts` (708→9), `view-model.ts` (642→37), `api.ts` (662→65), `diagnostics.ts` (500→16), and `sync-dialogs.tsx` (460→74).
- Core `maintenance/` carve-out: ai-structured, backfill-narrative, backfill-tags, dedup-keys, dedup, and supporting helpers each split into focused modules.

## Type of Change

- [x] Release / version bump

## Testing

- `pnpm run tsc`
- `pnpm run lint`
- `pnpm run test` (1417 passed)
- `node scripts/release-version.mjs check` → aligned at 0.28.0

## Known issues deferred to 0.28.1

- Feed-tab controls-row reflow when filter selection changes — tracked as `codemem-drod`.

## Post-merge

Tag the merged main commit (not this branch tip) per repo convention:

```fish
pnpm run release:preflight-tag v0.28.0
git tag v0.28.0 <merged-main-sha>
git push origin v0.28.0
```