### PR TITLE
feat(core): add capability-safe default-on tier routing defaults

### DIFF
--- a/docs/plans/2026-04-21-default-on-tiered-routing-design.md
+++ b/docs/plans/2026-04-21-default-on-tiered-routing-design.md
@@ -1,0 +1,239 @@
+# Default-on tiered routing design
+
+**Date:** 2026-04-21  
+**Status:** Approved design  
+**Bead:** `codemem-kkd9`
+
+## Problem
+
+codemem already has replay-driven tier routing and a partial live config surface, but
+ the runtime contract is still muddy in the places that matter for making it the
+ default:
+
+- provider versus runtime responsibility is mixed together
+- OpenAI transport behavior is split between Responses and legacy completions-style behavior
+- Claude sidecar compatibility is treated as uncertain even though Claude CLI can select a model explicitly
+- fallback behavior is underspecified, which makes default-on risky and hard to debug
+
+The result is a half-intentional matrix: rich OpenAI routing already prefers Responses,
+ simple OpenAI routing still forces the older path, and Anthropic plus Claude sidecar
+ support are only partly encoded in design language.
+
+## Goals
+
+- Make tiered routing default-on only where codemem has an explicit safe capability contract.
+- Treat access path and runtime as the primary routing capability axis, not just model vendor.
+- Respect explicit user settings over built-in defaults.
+- Make fallback behavior visible and deterministic.
+- Standardize OpenAI-capable API paths on Responses as the default transport.
+- Define the follow-up slices needed to implement and validate the policy.
+
+## Non-goals
+
+- No change to promotion thresholds in this design.
+- No attempt to keep legacy completions-style OpenAI transport as a recommended fallback path.
+- No speculative support promise for unknown custom providers that do not map cleanly to an explicit capability class.
+
+## Recommended approach
+
+Use **capability-safe default-on tier routing**.
+
+Defaults should only apply when the user has not made an explicit routing choice.
+ codemem should enable tiered routing by default only for provider/runtime paths with
+ an explicit capability mapping. Unknown or underspecified paths should remain
+ conservative until mapped.
+
+The key design decision is that the capability boundary is primarily the
+ **access path/runtime class**, not the vendor name alone.
+
+## Core decisions
+
+### 1. Explicit user settings always win
+
+Configuration precedence is:
+
+1. explicit user settings
+2. capability-safe built-in defaults
+3. base fallback behavior when a requested tier config cannot be honored
+
+This applies to:
+
+- `observer_tier_routing_enabled`
+- base `observer_provider`, `observer_model`, `observer_runtime`
+- tier-specific provider/model fields
+- tier-specific transport and tuning fields
+
+If the user explicitly disables tier routing, codemem leaves it off. If the user
+ explicitly enables it on an unusual path, codemem should honor that intent but still
+ surface any runtime downgrade clearly.
+
+### 2. Capability is determined by access path/runtime class
+
+The design should stop framing support as “OpenAI safe, Anthropic maybe.”
+
+The better rule is:
+
+- API-backed paths are eligible for default-on when codemem has an explicit provider/runtime mapping.
+- Claude subscription-backed Claude Code usage is its own runtime class and should be modeled through `claude_sidecar`.
+
+### 3. Claude sidecar is eligible for default-on tiering
+
+`claude_sidecar` is not a permanent exception. For Claude Code Pro/Max subscription
+ usage, sidecar is the required runtime path, but Claude CLI already supports
+ `--model`, which gives codemem the primitive it needs to choose different simple and
+ rich models intentionally.
+
+That makes `claude_sidecar` eligible for default-on tier routing as long as:
+
+- codemem can pass an explicit tier-selected model
+- the observer prompt/response contract remains reliable on sidecar
+- codemem records the actual selected tier/model/runtime for debugging
+
+### 4. OpenAI API paths should be Responses-first
+
+For OpenAI-capable `api_http` paths, codemem should treat **Responses** as the
+ default and preferred transport.
+
+Completions-style behavior should not remain a built-in legacy fallback in this
+ design. If older transport behavior still exists in code during migration, it should
+ be treated as implementation debt or explicit user override behavior, not as the
+ recommended default contract.
+
+## Capability matrix
+
+### Default-on when the user has not made an explicit choice
+
+#### `api_http`
+
+- **OpenAI API/models**
+  - supported
+  - tiered routing default-on
+  - Responses-first for simple and rich tiers
+
+- **Anthropic API/models**
+  - supported
+  - tiered routing default-on
+  - native Anthropic Messages path
+
+- **Compatible API-backed custom/provider gateway paths**
+  - eligible only when codemem can classify them into an explicit supported capability class
+  - do not assume universal safety for arbitrary custom providers
+
+#### `claude_sidecar`
+
+- **Claude Code Pro/Max subscription path via Claude CLI runtime**
+  - supported
+  - tiered routing default-on
+  - simple/rich model selection is performed via `claude --model ...`
+
+### Not default-on by default
+
+- unknown/custom paths without an explicit capability mapping
+- paths where codemem cannot confidently select a tier-specific model/runtime
+- paths where the actual runtime/model selection cannot be verified or recorded
+
+## Fallback and diagnostics contract
+
+Fallback should be **visible, deterministic, and narrow**.
+
+If tier routing is enabled but the selected path cannot honor the requested tier
+ config, codemem should:
+
+1. fall back to the base observer config
+2. persist what was requested versus what actually ran
+3. surface the fallback reason in diagnostics
+
+Fallback should **not** mean trying random alternate transports or providers until
+ something works. Pick one intended path. If that path is unsupported, degrade to the
+ known-safe base config and say so.
+
+### Required recorded metadata
+
+- requested tier
+- requested provider
+- requested runtime
+- requested model
+- actual provider
+- actual runtime
+- actual model
+- actual transport class
+- fallback applied: yes/no
+- fallback reason, when applicable
+- routing reasons from the richness decision
+
+### Example fallback reasons
+
+- unsupported tier override for runtime
+- unknown provider capability class
+- configured tier model unavailable
+- Claude sidecar rejected or did not recognize the requested model
+- provider-specific transport setting requested on an incompatible path
+
+## Transport policy by capability class
+
+### OpenAI over `api_http`
+
+- Responses is the default transport
+- tiered routing uses Responses for both tiers by default
+- no built-in legacy completions fallback in the intended product contract
+
+### Anthropic over `api_http`
+
+- use the native Anthropic Messages path
+- tier routing changes model choice, not transport family
+
+### Claude over `claude_sidecar`
+
+- use Claude CLI as the runtime transport
+- tier routing changes the `--model` selection
+
+## User-facing behavior
+
+When tier routing is enabled by built-in defaults, the UI and docs should describe it
+ as an automatic optimization that depends on the current provider/runtime path.
+
+When a fallback occurs, the system should not behave like nothing happened. The user
+ should be able to tell:
+
+- which tier codemem wanted
+- what actually ran
+- why codemem downgraded to the base config
+
+This is especially important for debugging sidecar/model availability issues and for
+ explaining why a configured rich-tier model was not actually used.
+
+## Rejected alternatives
+
+### Keep default-off until every path is perfect
+
+Rejected because the repo already has enough evidence to make explicit safe cells
+ default-on, and delaying all default behavior behind the weakest edge case slows the
+ useful path.
+
+### Universal default-on with broad silent fallback
+
+Rejected because it creates too much surprise and too much hidden complexity,
+ especially across custom providers and sidecar flows.
+
+### Continue treating OpenAI completions-style transport as a peer default
+
+Rejected because it preserves unnecessary transport bifurcation in the mainline
+ product contract while codemem already wants a clearer capability matrix and
+ Responses-first stance.
+
+## Implementation outline
+
+1. Encode the runtime/provider capability matrix in routing/config resolution.
+2. Make default-on decisions conditional on explicit-user-choice detection.
+3. Switch OpenAI-capable default transport behavior to Responses-first.
+4. Add Claude sidecar simple/rich model mapping and runtime reporting.
+5. Persist requested-versus-actual routing metadata plus fallback reason.
+6. Update tests for capability gating, transport choice, sidecar routing, and diagnostics.
+7. Update user-facing docs to explain automatic default-on behavior and visible fallback behavior.
+
+## Follow-up slices
+
+- capability matrix and config precedence implementation
+- OpenAI Responses-first cleanup
+- Claude sidecar tier-routing implementation and diagnostics
+- docs and settings copy refresh for the new default behavior

--- a/packages/core/src/extraction-tier-routing.test.ts
+++ b/packages/core/src/extraction-tier-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildTieredObserverConfig,
+	buildTieredObserverSelection,
 	decideExtractionReplayTier,
 } from "./extraction-tier-routing.js";
 import type { ObserverConfig } from "./observer-client.js";
@@ -236,5 +237,76 @@ describe("extraction tier routing", () => {
 		);
 		expect(config.observerProvider).toBe("anthropic");
 		expect(config.observerModel).toBe("claude-opus-4-6");
+	});
+
+	it("records requested routing metadata for a rich tier selection", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const selection = buildTieredObserverSelection(baseConfig(), decision);
+		expect(selection.metadata).toEqual(
+			expect.objectContaining({
+				requestedTier: "rich",
+				requestedProvider: "openai",
+				requestedModel: "gpt-5.4",
+				requestedRuntime: "api_http",
+				requestedOpenAIResponses: true,
+				fallbackApplied: false,
+				fallbackReason: null,
+			}),
+		);
+	});
+
+	it("marks incompatible provider-specific transport requests as a visible fallback", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const selection = buildTieredObserverSelection(
+			baseConfig({
+				observerProvider: "anthropic",
+				observerRichOpenAIUseResponses: true,
+				observerExplicitConfigKeys: ["observerRichOpenAIUseResponses"],
+			}),
+			decision,
+		);
+		expect(selection.metadata).toEqual(
+			expect.objectContaining({
+				requestedProvider: "anthropic",
+				requestedOpenAIResponses: true,
+				fallbackApplied: true,
+				fallbackReason: "provider-specific transport setting requested on an incompatible path",
+			}),
+		);
+		expect(selection.observer.observerOpenAIUseResponses).toBeUndefined();
+	});
+
+	it("honors explicit false for rich OpenAI Responses usage", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const selection = buildTieredObserverSelection(
+			baseConfig({
+				observerRichOpenAIUseResponses: false,
+				observerExplicitConfigKeys: ["observerRichOpenAIUseResponses"],
+			}),
+			decision,
+		);
+		expect(selection.observer.observerOpenAIUseResponses).toBe(false);
+		expect(selection.metadata.fallbackApplied).toBe(false);
 	});
 });

--- a/packages/core/src/extraction-tier-routing.ts
+++ b/packages/core/src/extraction-tier-routing.ts
@@ -15,6 +15,21 @@ export interface ExtractionReplayTierRoutingDecision {
 	observer: Partial<ObserverConfig>;
 }
 
+export interface TierRoutingApplicationMetadata {
+	requestedTier: "simple" | "rich";
+	requestedProvider: string | null;
+	requestedModel: string | null;
+	requestedRuntime: string | null;
+	requestedOpenAIResponses: boolean | null;
+	fallbackApplied: boolean;
+	fallbackReason: string | null;
+}
+
+export interface TieredObserverConfigSelection {
+	observer: ObserverConfig;
+	metadata: TierRoutingApplicationMetadata;
+}
+
 export const SIMPLE_TIER_DEFAULTS: Partial<ObserverConfig> = {
 	observerProvider: "openai",
 	observerModel: "gpt-5.4-mini",
@@ -68,17 +83,46 @@ function resolveRichTierDefaults(provider: KnownTierProvider): Partial<ObserverC
 	return provider === "anthropic" ? RICH_TIER_ANTHROPIC_DEFAULTS : RICH_TIER_DEFAULTS;
 }
 
-export function buildTieredObserverConfig(
+function normalizeRuntime(value: string | null | undefined): string {
+	return typeof value === "string" && value.trim().toLowerCase() === "claude_sidecar"
+		? "claude_sidecar"
+		: "api_http";
+}
+
+function nullIfUndefined<T>(value: T | undefined): T | null {
+	return value === undefined ? null : value;
+}
+
+function requestedMetadata(
+	decision: ExtractionReplayTierRoutingDecision,
+	config: ObserverConfig,
+	fallbackReason: string | null = null,
+): TierRoutingApplicationMetadata {
+	return {
+		requestedTier: decision.tier,
+		requestedProvider: config.observerProvider ?? null,
+		requestedModel: config.observerModel ?? null,
+		requestedRuntime: config.observerRuntime ?? null,
+		requestedOpenAIResponses: nullIfUndefined(config.observerOpenAIUseResponses),
+		fallbackApplied: fallbackReason != null,
+		fallbackReason,
+	};
+}
+
+export function buildTieredObserverSelection(
 	baseConfig: ObserverConfig,
 	decision: ExtractionReplayTierRoutingDecision,
-): ObserverConfig {
+): TieredObserverConfigSelection {
+	const normalizedRuntime = normalizeRuntime(baseConfig.observerRuntime);
+	const explicitConfigKeys = new Set(baseConfig.observerExplicitConfigKeys ?? []);
+
 	if (decision.tier === "simple") {
 		const knownProvider =
 			normalizeKnownProvider(baseConfig.observerSimpleProvider) ??
 			normalizeKnownProvider(baseConfig.observerProvider);
 		if (knownProvider) {
 			const tierDefaults = resolveSimpleTierDefaults(knownProvider);
-			return {
+			const observer = {
 				...baseConfig,
 				observerProvider: knownProvider,
 				observerModel:
@@ -92,13 +136,20 @@ export function buildTieredObserverConfig(
 				observerReasoningSummary: null,
 				observerMaxOutputTokens: baseConfig.observerMaxTokens,
 			};
+			return {
+				observer,
+				metadata: requestedMetadata(decision, {
+					...observer,
+					observerRuntime: normalizedRuntime,
+				}),
+			};
 		}
 		// Unknown/custom provider (e.g. opencode, bespoke gateway): preserve the
 		// base provider and only honor user-provided tier overrides. Do not apply
 		// OpenAI or Anthropic defaults.
 		const preservedProvider =
 			trimmedProvider(baseConfig.observerSimpleProvider) ?? baseConfig.observerProvider ?? null;
-		return {
+		const observer = {
 			...baseConfig,
 			observerProvider: preservedProvider,
 			observerModel: baseConfig.observerSimpleModel ?? baseConfig.observerModel,
@@ -108,6 +159,13 @@ export function buildTieredObserverConfig(
 			observerReasoningSummary: null,
 			observerMaxOutputTokens: baseConfig.observerMaxTokens,
 		};
+		return {
+			observer,
+			metadata: requestedMetadata(decision, {
+				...observer,
+				observerRuntime: normalizedRuntime,
+			}),
+		};
 	}
 
 	const knownProvider =
@@ -116,7 +174,14 @@ export function buildTieredObserverConfig(
 	if (knownProvider) {
 		const tierDefaults = resolveRichTierDefaults(knownProvider);
 		const isOpenAI = knownProvider === "openai";
-		return {
+		const hasExplicitRichResponsesSetting = explicitConfigKeys.has(
+			"observerRichOpenAIUseResponses",
+		);
+		const explicitResponsesRequested =
+			hasExplicitRichResponsesSetting &&
+			baseConfig.observerRichOpenAIUseResponses === true &&
+			!isOpenAI;
+		const observer = {
 			...baseConfig,
 			observerProvider: knownProvider,
 			observerModel:
@@ -126,8 +191,8 @@ export function buildTieredObserverConfig(
 				tierDefaults.observerTemperature ??
 				baseConfig.observerTemperature,
 			observerOpenAIUseResponses: isOpenAI
-				? baseConfig.observerRichOpenAIUseResponses === true
-					? true
+				? hasExplicitRichResponsesSetting
+					? baseConfig.observerRichOpenAIUseResponses === true
 					: (tierDefaults.observerOpenAIUseResponses ?? false)
 				: undefined,
 			observerReasoningEffort: isOpenAI
@@ -141,12 +206,29 @@ export function buildTieredObserverConfig(
 				tierDefaults.observerMaxOutputTokens ??
 				baseConfig.observerMaxTokens,
 		};
+		const requestedConfig: ObserverConfig = {
+			...observer,
+			observerRuntime: normalizedRuntime,
+			observerOpenAIUseResponses: explicitResponsesRequested
+				? true
+				: observer.observerOpenAIUseResponses,
+		};
+		return {
+			observer,
+			metadata: requestedMetadata(
+				decision,
+				requestedConfig,
+				explicitResponsesRequested
+					? "provider-specific transport setting requested on an incompatible path"
+					: null,
+			),
+		};
 	}
 	// Unknown/custom provider: preserve base provider and only honor explicit
 	// rich-tier overrides.
 	const preservedProvider =
 		trimmedProvider(baseConfig.observerRichProvider) ?? baseConfig.observerProvider ?? null;
-	return {
+	const observer = {
 		...baseConfig,
 		observerProvider: preservedProvider,
 		observerModel: baseConfig.observerRichModel ?? baseConfig.observerModel,
@@ -156,6 +238,20 @@ export function buildTieredObserverConfig(
 		observerReasoningSummary: null,
 		observerMaxOutputTokens: baseConfig.observerRichMaxOutputTokens ?? baseConfig.observerMaxTokens,
 	};
+	return {
+		observer,
+		metadata: requestedMetadata(decision, {
+			...observer,
+			observerRuntime: normalizedRuntime,
+		}),
+	};
+}
+
+export function buildTieredObserverConfig(
+	baseConfig: ObserverConfig,
+	decision: ExtractionReplayTierRoutingDecision,
+): ObserverConfig {
+	return buildTieredObserverSelection(baseConfig, decision).observer;
 }
 
 export function decideExtractionReplayTier(

--- a/packages/core/src/ingest-pipeline.test.ts
+++ b/packages/core/src/ingest-pipeline.test.ts
@@ -1241,17 +1241,29 @@ describe("ingest() integration", () => {
 		expect(memoryMeta).toEqual(
 			expect.objectContaining({
 				observer_tier: "rich",
+				observer_requested_provider: "openai",
+				observer_requested_model: "gpt-5.4",
+				observer_requested_runtime: "api_http",
 				observer_provider: "openai",
 				observer_model: "gpt-5.4",
+				observer_runtime: "api_http",
 				observer_openai_responses: true,
+				observer_fallback_applied: false,
+				observer_fallback_reason: null,
 			}),
 		);
 		expect(sessionMeta.post).toEqual(
 			expect.objectContaining({
 				observer_tier: "rich",
+				observer_requested_provider: "openai",
+				observer_requested_model: "gpt-5.4",
+				observer_requested_runtime: "api_http",
 				observer_provider: "openai",
 				observer_model: "gpt-5.4",
+				observer_runtime: "api_http",
 				observer_openai_responses: true,
+				observer_fallback_applied: false,
+				observer_fallback_reason: null,
 			}),
 		);
 	});

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -24,7 +24,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import { normalizeProjectLabel } from "./claude-hooks.js";
 import { fromJson, toJson } from "./db.js";
 import {
-	buildTieredObserverConfig,
+	buildTieredObserverSelection,
 	decideExtractionReplayTier,
 } from "./extraction-tier-routing.js";
 import {
@@ -479,6 +479,12 @@ export async function ingest(
 		let selectedObserver = options.observer;
 		let selectedTier: "simple" | "rich" | null = null;
 		let selectedTierReasons: string[] = [];
+		let requestedObserverProvider: string | null = null;
+		let requestedObserverModel: string | null = null;
+		let requestedObserverRuntime: string | null = null;
+		let requestedObserverOpenAIResponses: boolean | null = null;
+		let observerFallbackApplied = false;
+		let observerFallbackReason: string | null = null;
 		if (options.observer.tierRoutingEnabled) {
 			const flushBatchId =
 				sessionContext.flushBatch &&
@@ -496,7 +502,14 @@ export async function ingest(
 			});
 			selectedTier = decision.tier;
 			selectedTierReasons = decision.reasons;
-			const tierConfig = buildTieredObserverConfig(options.observer.toConfig(), decision);
+			const tierSelection = buildTieredObserverSelection(options.observer.toConfig(), decision);
+			const tierConfig = tierSelection.observer;
+			requestedObserverProvider = tierSelection.metadata.requestedProvider;
+			requestedObserverModel = tierSelection.metadata.requestedModel;
+			requestedObserverRuntime = tierSelection.metadata.requestedRuntime;
+			requestedObserverOpenAIResponses = tierSelection.metadata.requestedOpenAIResponses;
+			observerFallbackApplied = tierSelection.metadata.fallbackApplied;
+			observerFallbackReason = tierSelection.metadata.fallbackReason;
 			selectedObserver = options.createTierObserver
 				? options.createTierObserver(tierConfig)
 				: new ObserverClientImpl(tierConfig);
@@ -531,6 +544,7 @@ export async function ingest(
 		// ------------------------------------------------------------------
 		const rawText = response.raw;
 		const parsed = response.parsed;
+		const observerStatus = selectedObserver.getStatus();
 
 		const observationsToStore: typeof parsed.observations = [];
 		if (storeTyped && hasMeaningfulObservation(parsed.observations)) {
@@ -681,9 +695,16 @@ export async function ingest(
 					source: "observer",
 					observer_tier: selectedTier,
 					observer_tier_reasons: selectedTierReasons,
+					observer_requested_provider: requestedObserverProvider,
+					observer_requested_model: requestedObserverModel,
+					observer_requested_runtime: requestedObserverRuntime,
+					observer_requested_openai_responses: requestedObserverOpenAIResponses,
 					observer_provider: response.provider,
 					observer_model: response.model,
+					observer_runtime: observerStatus.runtime,
 					observer_openai_responses: selectedObserver.openaiUseResponses,
+					observer_fallback_applied: observerFallbackApplied,
+					observer_fallback_reason: observerFallbackReason,
 					flush_batch: flushBatchMetadata,
 				});
 				vectorWriteInputs.push({ memoryId, title: memoryTitle, bodyText });
@@ -727,9 +748,16 @@ export async function ingest(
 						session_class: sessionClass,
 						observer_tier: selectedTier,
 						observer_tier_reasons: selectedTierReasons,
+						observer_requested_provider: requestedObserverProvider,
+						observer_requested_model: requestedObserverModel,
+						observer_requested_runtime: requestedObserverRuntime,
+						observer_requested_openai_responses: requestedObserverOpenAIResponses,
 						observer_provider: response.provider,
 						observer_model: response.model,
+						observer_runtime: observerStatus.runtime,
 						observer_openai_responses: selectedObserver.openaiUseResponses,
+						observer_fallback_applied: observerFallbackApplied,
+						observer_fallback_reason: observerFallbackReason,
 						files_read: summary.filesRead,
 						files_modified: summary.filesModified,
 						source: "observer_summary",
@@ -762,9 +790,16 @@ export async function ingest(
 						summary_disposition: summaryDisposition,
 						observer_tier: selectedTier,
 						observer_tier_reasons: selectedTierReasons,
+						requested_provider: requestedObserverProvider,
+						requested_model: requestedObserverModel,
+						requested_runtime: requestedObserverRuntime,
+						requested_openai_responses: requestedObserverOpenAIResponses,
 						provider: response.provider,
 						model: response.model,
+						runtime: observerStatus.runtime,
 						openai_responses: selectedObserver.openaiUseResponses,
+						fallback_applied: observerFallbackApplied,
+						fallback_reason: observerFallbackReason,
 						session_usage_tokens: usageTokenTotal,
 					}),
 				})
@@ -787,9 +822,16 @@ export async function ingest(
 			summary_disposition: summaryDisposition,
 			observer_tier: selectedTier,
 			observer_tier_reasons: selectedTierReasons,
+			observer_requested_provider: requestedObserverProvider,
+			observer_requested_model: requestedObserverModel,
+			observer_requested_runtime: requestedObserverRuntime,
+			observer_requested_openai_responses: requestedObserverOpenAIResponses,
 			observer_provider: response.provider,
 			observer_model: response.model,
+			observer_runtime: observerStatus.runtime,
 			observer_openai_responses: selectedObserver.openaiUseResponses,
+			observer_fallback_applied: observerFallbackApplied,
+			observer_fallback_reason: observerFallbackReason,
 		});
 	} catch (err) {
 		// End session even on error

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -153,6 +153,27 @@ describe("loadObserverConfig", () => {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
 	});
+
+	it("records explicit config keys for user-set tier routing fields", () => {
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-config-test-"));
+		const configPath = join(tmpDir, "config.json");
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				observer_provider: "openai",
+				observer_tier_routing_enabled: false,
+			}),
+		);
+		try {
+			process.env.CODEMEM_CONFIG = configPath;
+			const cfg = loadObserverConfig();
+			expect(cfg.observerExplicitConfigKeys).toEqual(
+				expect.arrayContaining(["observerProvider", "observerTierRoutingEnabled"]),
+			);
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -161,6 +182,107 @@ describe("loadObserverConfig", () => {
 
 describe("ObserverClient", () => {
 	describe("constructor", () => {
+		it("defaults tier routing on for capability-safe api_http providers when not explicitly set", () => {
+			const client = new ObserverClient({
+				observerProvider: "openai",
+				observerModel: "gpt-5.4-mini",
+				observerRuntime: "api_http",
+				observerApiKey: null,
+				observerBaseUrl: null,
+				observerTemperature: 0.2,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "auto",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+			expect(client.tierRoutingEnabled).toBe(true);
+		});
+
+		it("keeps tier routing off when the user explicitly disables it", () => {
+			const client = new ObserverClient({
+				observerProvider: "openai",
+				observerModel: "gpt-5.4-mini",
+				observerRuntime: "api_http",
+				observerApiKey: null,
+				observerBaseUrl: null,
+				observerTemperature: 0.2,
+				observerTierRoutingEnabled: false,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "auto",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+			expect(client.tierRoutingEnabled).toBe(false);
+		});
+
+		it("keeps default tier routing off when a custom base URL is configured", () => {
+			const client = new ObserverClient({
+				observerProvider: "openai",
+				observerModel: "gpt-5.4-mini",
+				observerRuntime: "api_http",
+				observerApiKey: "test-key",
+				observerBaseUrl: "https://openai-proxy.example/v1",
+				observerTemperature: 0.2,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "none",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+			expect(client.tierRoutingEnabled).toBe(false);
+		});
+
+		it("keeps default tier routing off for unmapped api_http providers", () => {
+			const client = new ObserverClient({
+				observerProvider: "opencode",
+				observerModel: "opencode/gpt-5.4-mini",
+				observerRuntime: "api_http",
+				observerApiKey: "test-key",
+				observerBaseUrl: "https://gateway.example/v1",
+				observerTemperature: 0.2,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "none",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+			expect(client.tierRoutingEnabled).toBe(false);
+		});
+
+		it("keeps default tier routing off for claude_sidecar until sidecar tier routing lands", () => {
+			const client = new ObserverClient({
+				observerProvider: "anthropic",
+				observerModel: "claude-haiku-4-5",
+				observerRuntime: "claude_sidecar",
+				observerApiKey: null,
+				observerBaseUrl: null,
+				observerTemperature: 0.2,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "auto",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+			expect(client.tierRoutingEnabled).toBe(false);
+		});
+
 		it("defaults to openai provider and default model", () => {
 			const client = new ObserverClient({
 				observerProvider: null,

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -105,6 +105,7 @@ export interface ObserverConfig {
 	observerAuthTimeoutMs: number;
 	observerAuthCacheTtlS: number;
 	claudeCommand?: string[];
+	observerExplicitConfigKeys?: string[];
 }
 
 export interface ObserverResponse {
@@ -128,6 +129,141 @@ export interface ObserverStatus {
 	runtime: string;
 	auth: { source: string; type: string; hasToken: boolean };
 	lastError?: { code: string; message: string } | null;
+}
+
+interface ObserverConfigKeyMapping {
+	fileKey: string;
+	envKey: string;
+	normalizedKey: keyof ObserverConfig;
+}
+
+const OBSERVER_CONFIG_KEY_MAPPINGS: ObserverConfigKeyMapping[] = [
+	{
+		fileKey: "observer_tier_routing_enabled",
+		envKey: "CODEMEM_OBSERVER_TIER_ROUTING_ENABLED",
+		normalizedKey: "observerTierRoutingEnabled",
+	},
+	{
+		fileKey: "observer_provider",
+		envKey: "CODEMEM_OBSERVER_PROVIDER",
+		normalizedKey: "observerProvider",
+	},
+	{ fileKey: "observer_model", envKey: "CODEMEM_OBSERVER_MODEL", normalizedKey: "observerModel" },
+	{
+		fileKey: "observer_runtime",
+		envKey: "CODEMEM_OBSERVER_RUNTIME",
+		normalizedKey: "observerRuntime",
+	},
+	{
+		fileKey: "observer_simple_provider",
+		envKey: "CODEMEM_OBSERVER_SIMPLE_PROVIDER",
+		normalizedKey: "observerSimpleProvider",
+	},
+	{
+		fileKey: "observer_simple_model",
+		envKey: "CODEMEM_OBSERVER_SIMPLE_MODEL",
+		normalizedKey: "observerSimpleModel",
+	},
+	{
+		fileKey: "observer_simple_temperature",
+		envKey: "CODEMEM_OBSERVER_SIMPLE_TEMPERATURE",
+		normalizedKey: "observerSimpleTemperature",
+	},
+	{
+		fileKey: "observer_rich_provider",
+		envKey: "CODEMEM_OBSERVER_RICH_PROVIDER",
+		normalizedKey: "observerRichProvider",
+	},
+	{
+		fileKey: "observer_rich_model",
+		envKey: "CODEMEM_OBSERVER_RICH_MODEL",
+		normalizedKey: "observerRichModel",
+	},
+	{
+		fileKey: "observer_rich_temperature",
+		envKey: "CODEMEM_OBSERVER_RICH_TEMPERATURE",
+		normalizedKey: "observerRichTemperature",
+	},
+	{
+		fileKey: "observer_rich_openai_use_responses",
+		envKey: "CODEMEM_OBSERVER_RICH_OPENAI_USE_RESPONSES",
+		normalizedKey: "observerRichOpenAIUseResponses",
+	},
+	{
+		fileKey: "observer_rich_reasoning_effort",
+		envKey: "CODEMEM_OBSERVER_RICH_REASONING_EFFORT",
+		normalizedKey: "observerRichReasoningEffort",
+	},
+	{
+		fileKey: "observer_rich_reasoning_summary",
+		envKey: "CODEMEM_OBSERVER_RICH_REASONING_SUMMARY",
+		normalizedKey: "observerRichReasoningSummary",
+	},
+	{
+		fileKey: "observer_rich_max_output_tokens",
+		envKey: "CODEMEM_OBSERVER_RICH_MAX_OUTPUT_TOKENS",
+		normalizedKey: "observerRichMaxOutputTokens",
+	},
+	{
+		fileKey: "observer_openai_use_responses",
+		envKey: "CODEMEM_OBSERVER_OPENAI_USE_RESPONSES",
+		normalizedKey: "observerOpenAIUseResponses",
+	},
+	{
+		fileKey: "observer_reasoning_effort",
+		envKey: "CODEMEM_OBSERVER_REASONING_EFFORT",
+		normalizedKey: "observerReasoningEffort",
+	},
+	{
+		fileKey: "observer_reasoning_summary",
+		envKey: "CODEMEM_OBSERVER_REASONING_SUMMARY",
+		normalizedKey: "observerReasoningSummary",
+	},
+	{
+		fileKey: "observer_max_output_tokens",
+		envKey: "CODEMEM_OBSERVER_MAX_OUTPUT_TOKENS",
+		normalizedKey: "observerMaxOutputTokens",
+	},
+];
+
+function collectExplicitObserverConfigKeys(
+	data: Record<string, unknown>,
+	env: NodeJS.ProcessEnv,
+): string[] {
+	const keys = new Set<string>();
+	for (const { fileKey, envKey, normalizedKey } of OBSERVER_CONFIG_KEY_MAPPINGS) {
+		if (fileKey in data || env[envKey] != null) keys.add(normalizedKey);
+	}
+	return [...keys];
+}
+
+function resolveExplicitObserverConfigKeys(
+	cfg: ObserverConfig,
+	configWasProvided: boolean,
+): Set<string> {
+	if (Array.isArray(cfg.observerExplicitConfigKeys)) {
+		return new Set(cfg.observerExplicitConfigKeys);
+	}
+	if (!configWasProvided) return new Set();
+	return new Set(
+		Object.entries(cfg)
+			.filter(([, value]) => value !== undefined)
+			.map(([key]) => key),
+	);
+}
+
+function supportsDefaultTierRouting(
+	provider: string,
+	runtime: string,
+	hasCustomBaseUrl: boolean,
+): boolean {
+	if (runtime !== "api_http") return false;
+	if (provider !== "openai" && provider !== "anthropic") return false;
+	// A custom base URL may point at an OpenAI-compatible gateway that only
+	// implements chat/completions. Rich-tier defaults turn Responses on, so we
+	// cannot assume capability-safety without an explicit user opt-in.
+	if (hasCustomBaseUrl) return false;
+	return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -426,6 +562,8 @@ export function loadObserverConfig(): ObserverConfig {
 	) {
 		cfg.observerRuntime = "claude_sidecar";
 	}
+
+	cfg.observerExplicitConfigKeys = collectExplicitObserverConfigKeys(data, process.env);
 
 	return cfg;
 }
@@ -892,9 +1030,13 @@ export class ObserverClient {
 	// Error tracking
 	private _lastErrorCode: string | null = null;
 	private _lastErrorMessage: string | null = null;
+	private readonly _observerExplicitConfigKeys: string[];
 
 	constructor(config?: ObserverConfig) {
+		const configWasProvided = config !== undefined;
 		const cfg = config ?? loadObserverConfig();
+		const explicitConfigKeys = resolveExplicitObserverConfigKeys(cfg, configWasProvided);
+		this._observerExplicitConfigKeys = [...explicitConfigKeys];
 
 		const provider = (cfg.observerProvider ?? "").toLowerCase();
 		const model = (cfg.observerModel ?? "").trim();
@@ -960,7 +1102,11 @@ export class ObserverClient {
 			typeof cfg.observerTemperature === "number" && Number.isFinite(cfg.observerTemperature)
 				? cfg.observerTemperature
 				: 0.2;
-		this.tierRoutingEnabled = cfg.observerTierRoutingEnabled === true;
+		const hasCustomBaseUrl =
+			typeof cfg.observerBaseUrl === "string" && cfg.observerBaseUrl.trim().length > 0;
+		this.tierRoutingEnabled = explicitConfigKeys.has("observerTierRoutingEnabled")
+			? cfg.observerTierRoutingEnabled === true
+			: supportsDefaultTierRouting(this.provider, this.runtime, hasCustomBaseUrl);
 		this.simpleProvider =
 			typeof cfg.observerSimpleProvider === "string" && cfg.observerSimpleProvider.trim()
 				? cfg.observerSimpleProvider.trim()
@@ -1077,6 +1223,7 @@ export class ObserverClient {
 			observerAuthTimeoutMs: this.authTimeoutMs,
 			observerAuthCacheTtlS: this.authCacheTtlS,
 			claudeCommand: [...this._claudeCommand],
+			observerExplicitConfigKeys: [...this._observerExplicitConfigKeys],
 		};
 	}
 


### PR DESCRIPTION
## Description
Implements the first slice of the approved default-on tier routing design. This makes tier routing default on only for capability-safe paths, preserves explicit user overrides, and records requested-versus-actual routing metadata plus visible fallback reasons so later transport/runtime work has a clean contract.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran:
- `pnpm exec vitest run packages/core/src/extraction-tier-routing.test.ts packages/core/src/observer-client.test.ts packages/core/src/ingest-pipeline.test.ts`
- `pnpm run tsc`

## Checklist
- [ ] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced