### PR TITLE
feat(core): make OpenAI observer routing Responses-first

### DIFF
--- a/packages/core/src/extraction-tier-routing.test.ts
+++ b/packages/core/src/extraction-tier-routing.test.ts
@@ -73,6 +73,19 @@ describe("extraction tier routing", () => {
 		expect(decision.observer.observerTemperature).toBe(0.2);
 	});
 
+	it("uses Responses defaults for the simple OpenAI tier when transport is not explicitly set", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 19001,
+			sessionId: 200001,
+			eventSpan: 12,
+			promptCount: 1,
+			toolCount: 1,
+			transcriptLength: 320,
+		});
+		const config = buildTieredObserverConfig(baseConfig(), decision);
+		expect(config.observerOpenAIUseResponses).toBe(true);
+	});
+
 	it("uses rich Responses defaults when rich-specific flag is unset", () => {
 		const decision = decideExtractionReplayTier({
 			batchId: 18503,
@@ -308,5 +321,24 @@ describe("extraction tier routing", () => {
 		);
 		expect(selection.observer.observerOpenAIUseResponses).toBe(false);
 		expect(selection.metadata.fallbackApplied).toBe(false);
+	});
+
+	it("honors explicit false for simple OpenAI Responses usage", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 19001,
+			sessionId: 200001,
+			eventSpan: 12,
+			promptCount: 1,
+			toolCount: 1,
+			transcriptLength: 320,
+		});
+		const selection = buildTieredObserverSelection(
+			baseConfig({
+				observerOpenAIUseResponses: false,
+				observerExplicitConfigKeys: ["observerOpenAIUseResponses"],
+			}),
+			decision,
+		);
+		expect(selection.observer.observerOpenAIUseResponses).toBe(false);
 	});
 });

--- a/packages/core/src/extraction-tier-routing.ts
+++ b/packages/core/src/extraction-tier-routing.ts
@@ -122,6 +122,7 @@ export function buildTieredObserverSelection(
 			normalizeKnownProvider(baseConfig.observerProvider);
 		if (knownProvider) {
 			const tierDefaults = resolveSimpleTierDefaults(knownProvider);
+			const hasExplicitBaseResponsesSetting = explicitConfigKeys.has("observerOpenAIUseResponses");
 			const observer = {
 				...baseConfig,
 				observerProvider: knownProvider,
@@ -131,7 +132,12 @@ export function buildTieredObserverSelection(
 					baseConfig.observerSimpleTemperature ??
 					tierDefaults.observerTemperature ??
 					baseConfig.observerTemperature,
-				observerOpenAIUseResponses: knownProvider === "openai" ? false : undefined,
+				observerOpenAIUseResponses:
+					knownProvider === "openai"
+						? hasExplicitBaseResponsesSetting
+							? baseConfig.observerOpenAIUseResponses === true
+							: true
+						: undefined,
 				observerReasoningEffort: null,
 				observerReasoningSummary: null,
 				observerMaxOutputTokens: baseConfig.observerMaxTokens,
@@ -174,6 +180,7 @@ export function buildTieredObserverSelection(
 	if (knownProvider) {
 		const tierDefaults = resolveRichTierDefaults(knownProvider);
 		const isOpenAI = knownProvider === "openai";
+		const hasExplicitBaseResponsesSetting = explicitConfigKeys.has("observerOpenAIUseResponses");
 		const hasExplicitRichResponsesSetting = explicitConfigKeys.has(
 			"observerRichOpenAIUseResponses",
 		);
@@ -193,7 +200,9 @@ export function buildTieredObserverSelection(
 			observerOpenAIUseResponses: isOpenAI
 				? hasExplicitRichResponsesSetting
 					? baseConfig.observerRichOpenAIUseResponses === true
-					: (tierDefaults.observerOpenAIUseResponses ?? false)
+					: hasExplicitBaseResponsesSetting
+						? baseConfig.observerOpenAIUseResponses === true
+						: (tierDefaults.observerOpenAIUseResponses ?? false)
 				: undefined,
 			observerReasoningEffort: isOpenAI
 				? (baseConfig.observerRichReasoningEffort ?? tierDefaults.observerReasoningEffort ?? null)

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -26,6 +26,10 @@ describe("loadObserverConfig", () => {
 		"CODEMEM_OBSERVER_RICH_REASONING_EFFORT",
 		"CODEMEM_OBSERVER_RICH_REASONING_SUMMARY",
 		"CODEMEM_OBSERVER_RICH_MAX_OUTPUT_TOKENS",
+		"CODEMEM_OBSERVER_OPENAI_USE_RESPONSES",
+		"CODEMEM_OBSERVER_REASONING_EFFORT",
+		"CODEMEM_OBSERVER_REASONING_SUMMARY",
+		"CODEMEM_OBSERVER_MAX_OUTPUT_TOKENS",
 		"CODEMEM_OBSERVER_AUTH_SOURCE",
 		"CODEMEM_OBSERVER_AUTH_FILE",
 		"CODEMEM_OBSERVER_AUTH_COMMAND",
@@ -173,6 +177,38 @@ describe("loadObserverConfig", () => {
 		} finally {
 			rmSync(tmpDir, { recursive: true, force: true });
 		}
+	});
+
+	it("populates observerOpenAIUseResponses when set via config file", () => {
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-config-test-"));
+		const configPath = join(tmpDir, "config.json");
+		writeFileSync(
+			configPath,
+			JSON.stringify({
+				observer_provider: "openai",
+				observer_openai_use_responses: true,
+			}),
+		);
+		try {
+			process.env.CODEMEM_CONFIG = configPath;
+			const cfg = loadObserverConfig();
+			expect(cfg.observerOpenAIUseResponses).toBe(true);
+			expect(cfg.observerExplicitConfigKeys).toEqual(
+				expect.arrayContaining(["observerOpenAIUseResponses"]),
+			);
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("populates observerOpenAIUseResponses when set via env var", () => {
+		process.env.CODEMEM_OBSERVER_OPENAI_USE_RESPONSES = "true";
+		process.env.CODEMEM_CONFIG = "/tmp/codemem-test-nonexistent/config.json";
+		const cfg = loadObserverConfig();
+		expect(cfg.observerOpenAIUseResponses).toBe(true);
+		expect(cfg.observerExplicitConfigKeys).toEqual(
+			expect.arrayContaining(["observerOpenAIUseResponses"]),
+		);
 	});
 });
 
@@ -372,6 +408,48 @@ describe("ObserverClient", () => {
 			expect(client.reasoningEffort).toBe("low");
 			expect(client.reasoningSummary).toBe("auto");
 			expect(client.maxOutputTokens).toBe(12000);
+		});
+
+		it("defaults OpenAI api_http clients to Responses when transport is not explicitly set", () => {
+			const client = new ObserverClient({
+				observerProvider: "openai",
+				observerModel: "gpt-5.4-mini",
+				observerRuntime: "api_http",
+				observerApiKey: "sk-test-key",
+				observerBaseUrl: null,
+				observerTemperature: 0.2,
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "auto",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+			expect(client.openaiUseResponses).toBe(true);
+		});
+
+		it("honors explicit false for OpenAI api_http Responses usage", () => {
+			const client = new ObserverClient({
+				observerProvider: "openai",
+				observerModel: "gpt-5.4-mini",
+				observerRuntime: "api_http",
+				observerApiKey: "sk-test-key",
+				observerBaseUrl: null,
+				observerTemperature: 0.2,
+				observerOpenAIUseResponses: false,
+				observerExplicitConfigKeys: ["observerOpenAIUseResponses"],
+				observerMaxChars: 12_000,
+				observerMaxTokens: 4_000,
+				observerHeaders: {},
+				observerAuthSource: "auto",
+				observerAuthFile: null,
+				observerAuthCommand: [],
+				observerAuthTimeoutMs: 1500,
+				observerAuthCacheTtlS: 300,
+			});
+			expect(client.openaiUseResponses).toBe(false);
 		});
 
 		it("round-trips per-tier provider overrides through toConfig", () => {
@@ -791,18 +869,62 @@ describe("ObserverClient.observe()", () => {
 		expect(result.provider).toBe("anthropic");
 	});
 
-	it("calls OpenAI endpoint with correct format", async () => {
+	it("routes OpenAI to chat/completions when user explicitly disables Responses", async () => {
+		let capturedUrl: string | undefined;
+
+		globalThis.fetch = (async (input: string | URL | Request, _init?: RequestInit) => {
+			capturedUrl = String(input);
+			return new Response(
+				JSON.stringify({
+					choices: [{ message: { content: "chat completions response" } }],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			);
+		}) as typeof globalThis.fetch;
+
+		const client = new ObserverClient({
+			observerProvider: "openai",
+			observerModel: "gpt-5.4-mini",
+			observerRuntime: "api_http",
+			observerApiKey: "sk-openai-test-key",
+			observerBaseUrl: null,
+			observerOpenAIUseResponses: false,
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "auto",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+			observerExplicitConfigKeys: ["observerOpenAIUseResponses"],
+		});
+		const result = await client.observe("system", "user");
+
+		expect(capturedUrl).toContain("/chat/completions");
+		expect(capturedUrl).not.toContain("/responses");
+		expect(result.raw).toBe("chat completions response");
+	});
+
+	it("calls OpenAI Responses endpoint by default", async () => {
 		let capturedUrl: string | undefined;
 		let capturedHeaders: Record<string, string> | undefined;
+		let capturedBody: Record<string, unknown> | undefined;
 
 		globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
 			capturedUrl = String(input);
 			capturedHeaders = Object.fromEntries(
 				Object.entries((init?.headers as Record<string, string>) ?? {}),
 			);
+			capturedBody = JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>;
 			return new Response(
 				JSON.stringify({
-					choices: [{ message: { content: "openai response text" } }],
+					output: [
+						{
+							type: "message",
+							content: [{ type: "output_text", text: "openai response text" }],
+						},
+					],
 				}),
 				{ status: 200, headers: { "content-type": "application/json" } },
 			);
@@ -812,7 +934,9 @@ describe("ObserverClient.observe()", () => {
 		const result = await client.observe("system", "user");
 
 		expect(capturedUrl).toContain("openai.com");
+		expect(capturedUrl).toContain("/responses");
 		expect(capturedHeaders?.authorization).toBe("Bearer sk-openai-test-key");
+		expect(capturedBody?.input).toBeDefined();
 		expect(result.raw).toBe("openai response text");
 		expect(result.provider).toBe("openai");
 	});
@@ -894,7 +1018,12 @@ describe("ObserverClient.observe()", () => {
 			capturedBody = JSON.parse(init?.body as string) as Record<string, unknown>;
 			return new Response(
 				JSON.stringify({
-					choices: [{ message: { content: "ok" } }],
+					output: [
+						{
+							type: "message",
+							content: [{ type: "output_text", text: "ok" }],
+						},
+					],
 				}),
 				{ status: 200, headers: { "content-type": "application/json" } },
 			);
@@ -920,11 +1049,12 @@ describe("ObserverClient.observe()", () => {
 		const longUser = "u".repeat(500);
 		await client.observe(longSystem, longUser);
 
-		// The messages should be truncated — system to 100 chars, user to remaining budget
-		const messages = capturedBody?.messages as Array<{ content: string }>;
-		expect(messages).toBeDefined();
-		const systemMsg = messages.find((m: Record<string, unknown>) => m.role === "system");
-		expect(systemMsg?.content.length).toBeLessThanOrEqual(100);
+		const input = capturedBody?.input as Array<Record<string, unknown>>;
+		expect(input).toBeDefined();
+		const systemMsg = input.find((m: Record<string, unknown>) => m.role === "developer");
+		const systemText = ((systemMsg?.content as Array<Record<string, unknown>> | undefined)?.[0]
+			?.text ?? "") as string;
+		expect(systemText.length).toBeLessThanOrEqual(100);
 	});
 
 	it("retries once on auth error", async () => {

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -370,6 +370,10 @@ export function loadObserverConfig(): ObserverConfig {
 		observerRichReasoningEffort: null,
 		observerRichReasoningSummary: null,
 		observerRichMaxOutputTokens: null,
+		observerOpenAIUseResponses: undefined,
+		observerReasoningEffort: null,
+		observerReasoningSummary: null,
+		observerMaxOutputTokens: null,
 		observerMaxChars: 12_000,
 		observerMaxTokens: 4_000,
 		observerHeaders: {},
@@ -455,6 +459,19 @@ export function loadObserverConfig(): ObserverConfig {
 		const n = Number(data.observer_rich_max_output_tokens);
 		cfg.observerRichMaxOutputTokens = Number.isFinite(n) ? n : cfg.observerRichMaxOutputTokens;
 	}
+	if (data.observer_openai_use_responses != null) {
+		cfg.observerOpenAIUseResponses = data.observer_openai_use_responses === true;
+	}
+	if (typeof data.observer_reasoning_effort === "string") {
+		cfg.observerReasoningEffort = data.observer_reasoning_effort;
+	}
+	if (typeof data.observer_reasoning_summary === "string") {
+		cfg.observerReasoningSummary = data.observer_reasoning_summary;
+	}
+	if (data.observer_max_output_tokens != null) {
+		const n = Number(data.observer_max_output_tokens);
+		cfg.observerMaxOutputTokens = Number.isFinite(n) ? n : cfg.observerMaxOutputTokens;
+	}
 	cfg.observerMaxChars = parseIntSafe(data.observer_max_chars, cfg.observerMaxChars);
 	cfg.observerMaxTokens = parseIntSafe(data.observer_max_tokens, cfg.observerMaxTokens);
 	if (typeof data.observer_auth_source === "string")
@@ -519,6 +536,19 @@ export function loadObserverConfig(): ObserverConfig {
 	if (process.env.CODEMEM_OBSERVER_RICH_MAX_OUTPUT_TOKENS != null) {
 		const n = Number(process.env.CODEMEM_OBSERVER_RICH_MAX_OUTPUT_TOKENS);
 		cfg.observerRichMaxOutputTokens = Number.isFinite(n) ? n : cfg.observerRichMaxOutputTokens;
+	}
+	if (process.env.CODEMEM_OBSERVER_OPENAI_USE_RESPONSES != null) {
+		cfg.observerOpenAIUseResponses =
+			process.env.CODEMEM_OBSERVER_OPENAI_USE_RESPONSES === "1" ||
+			process.env.CODEMEM_OBSERVER_OPENAI_USE_RESPONSES === "true";
+	}
+	cfg.observerReasoningEffort =
+		process.env.CODEMEM_OBSERVER_REASONING_EFFORT ?? cfg.observerReasoningEffort;
+	cfg.observerReasoningSummary =
+		process.env.CODEMEM_OBSERVER_REASONING_SUMMARY ?? cfg.observerReasoningSummary;
+	if (process.env.CODEMEM_OBSERVER_MAX_OUTPUT_TOKENS != null) {
+		const n = Number(process.env.CODEMEM_OBSERVER_MAX_OUTPUT_TOKENS);
+		cfg.observerMaxOutputTokens = Number.isFinite(n) ? n : cfg.observerMaxOutputTokens;
 	}
 	cfg.observerAuthSource = process.env.CODEMEM_OBSERVER_AUTH_SOURCE ?? cfg.observerAuthSource;
 	cfg.observerAuthFile = process.env.CODEMEM_OBSERVER_AUTH_FILE ?? cfg.observerAuthFile;
@@ -1148,7 +1178,9 @@ export class ObserverClient {
 			Number.isFinite(cfg.observerRichMaxOutputTokens)
 				? cfg.observerRichMaxOutputTokens
 				: null;
-		this.openaiUseResponses = cfg.observerOpenAIUseResponses === true;
+		this.openaiUseResponses = explicitConfigKeys.has("observerOpenAIUseResponses")
+			? cfg.observerOpenAIUseResponses === true
+			: this.provider === "openai" && this.runtime === "api_http";
 		this.reasoningEffort =
 			typeof cfg.observerReasoningEffort === "string" && cfg.observerReasoningEffort.trim()
 				? cfg.observerReasoningEffort.trim()


### PR DESCRIPTION
## Description
Makes OpenAI `api_http` observer routing Responses-first by default. This aligns both routing defaults and the observer client with the approved design while still honoring explicit `observerOpenAIUseResponses: false` / rich-tier overrides when users set them intentionally.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran:
- `pnpm exec vitest run packages/core/src/extraction-tier-routing.test.ts packages/core/src/observer-client.test.ts packages/core/src/ingest-pipeline.test.ts`
- `pnpm run tsc`

## Checklist
- [ ] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced