### PR TITLE
feat(core): add Claude sidecar tier routing support

### DIFF
--- a/packages/core/src/extraction-tier-routing.test.ts
+++ b/packages/core/src/extraction-tier-routing.test.ts
@@ -147,6 +147,50 @@ describe("extraction tier routing", () => {
 		expect(config.observerOpenAIUseResponses).toBeUndefined();
 	});
 
+	it("maps claude_sidecar simple tier routing onto Claude defaults", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 19001,
+			sessionId: 200001,
+			eventSpan: 12,
+			promptCount: 1,
+			toolCount: 1,
+			transcriptLength: 320,
+		});
+		const config = buildTieredObserverConfig(
+			baseConfig({
+				observerProvider: "openai",
+				observerRuntime: "claude_sidecar",
+				observerSimpleModel: null,
+			}),
+			decision,
+		);
+		expect(config.observerProvider).toBe("anthropic");
+		expect(config.observerModel).toBe("claude-haiku-4-5");
+		expect(config.observerRuntime).toBe("claude_sidecar");
+	});
+
+	it("maps claude_sidecar rich tier routing onto Claude defaults", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const config = buildTieredObserverConfig(
+			baseConfig({
+				observerProvider: "openai",
+				observerRuntime: "claude_sidecar",
+				observerRichModel: null,
+			}),
+			decision,
+		);
+		expect(config.observerProvider).toBe("anthropic");
+		expect(config.observerModel).toBe("claude-sonnet-4-6");
+		expect(config.observerRuntime).toBe("claude_sidecar");
+	});
+
 	it("respects observerRichProvider override even when base provider is openai", () => {
 		const decision = decideExtractionReplayTier({
 			batchId: 18503,
@@ -340,5 +384,49 @@ describe("extraction tier routing", () => {
 			decision,
 		);
 		expect(selection.observer.observerOpenAIUseResponses).toBe(false);
+	});
+
+	it("does not record fallback on claude_sidecar when provider was not explicitly requested", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const selection = buildTieredObserverSelection(
+			baseConfig({
+				observerProvider: "openai",
+				observerRuntime: "claude_sidecar",
+			}),
+			decision,
+		);
+		expect(selection.metadata.fallbackApplied).toBe(false);
+		expect(selection.metadata.fallbackReason).toBeNull();
+		expect(selection.observer.observerProvider).toBe("anthropic");
+	});
+
+	it("records a visible fallback when an incompatible provider is requested on claude_sidecar", () => {
+		const decision = decideExtractionReplayTier({
+			batchId: 18503,
+			sessionId: 166405,
+			eventSpan: 153,
+			promptCount: 4,
+			toolCount: 12,
+			transcriptLength: 2800,
+		});
+		const selection = buildTieredObserverSelection(
+			baseConfig({
+				observerProvider: "openai",
+				observerRuntime: "claude_sidecar",
+				observerExplicitConfigKeys: ["observerProvider"],
+			}),
+			decision,
+		);
+		expect(selection.metadata.requestedProvider).toBe("openai");
+		expect(selection.metadata.fallbackApplied).toBe(true);
+		expect(selection.metadata.fallbackReason).toBe("unsupported tier override for runtime");
+		expect(selection.observer.observerProvider).toBe("anthropic");
 	});
 });

--- a/packages/core/src/extraction-tier-routing.ts
+++ b/packages/core/src/extraction-tier-routing.ts
@@ -115,6 +115,64 @@ export function buildTieredObserverSelection(
 ): TieredObserverConfigSelection {
 	const normalizedRuntime = normalizeRuntime(baseConfig.observerRuntime);
 	const explicitConfigKeys = new Set(baseConfig.observerExplicitConfigKeys ?? []);
+	if (normalizedRuntime === "claude_sidecar") {
+		const sidecarProviderKey =
+			decision.tier === "simple" ? "observerSimpleProvider" : "observerRichProvider";
+		const hasExplicitProviderOverride =
+			explicitConfigKeys.has(sidecarProviderKey) || explicitConfigKeys.has("observerProvider");
+		const requestedProvider =
+			(sidecarProviderKey === "observerSimpleProvider"
+				? trimmedProvider(baseConfig.observerSimpleProvider)
+				: trimmedProvider(baseConfig.observerRichProvider)) ??
+			trimmedProvider(baseConfig.observerProvider);
+		const tierDefaults =
+			decision.tier === "simple" ? SIMPLE_TIER_ANTHROPIC_DEFAULTS : RICH_TIER_ANTHROPIC_DEFAULTS;
+		const observer = {
+			...baseConfig,
+			observerProvider: "anthropic",
+			observerModel:
+				decision.tier === "simple"
+					? (baseConfig.observerSimpleModel ??
+						tierDefaults.observerModel ??
+						baseConfig.observerModel)
+					: (baseConfig.observerRichModel ??
+						tierDefaults.observerModel ??
+						baseConfig.observerModel),
+			observerTemperature:
+				decision.tier === "simple"
+					? (baseConfig.observerSimpleTemperature ??
+						tierDefaults.observerTemperature ??
+						baseConfig.observerTemperature)
+					: (baseConfig.observerRichTemperature ??
+						tierDefaults.observerTemperature ??
+						baseConfig.observerTemperature),
+			observerOpenAIUseResponses: undefined,
+			observerReasoningEffort: null,
+			observerReasoningSummary: null,
+			observerMaxOutputTokens:
+				decision.tier === "simple"
+					? baseConfig.observerMaxTokens
+					: (baseConfig.observerRichMaxOutputTokens ??
+						tierDefaults.observerMaxOutputTokens ??
+						baseConfig.observerMaxTokens),
+		};
+		const fallbackReason =
+			hasExplicitProviderOverride && requestedProvider && requestedProvider !== "anthropic"
+				? "unsupported tier override for runtime"
+				: null;
+		return {
+			observer,
+			metadata: requestedMetadata(
+				decision,
+				{
+					...observer,
+					observerProvider: requestedProvider ?? observer.observerProvider,
+					observerRuntime: normalizedRuntime,
+				},
+				fallbackReason,
+			),
+		};
+	}
 
 	if (decision.tier === "simple") {
 		const knownProvider =

--- a/packages/core/src/observer-client.test.ts
+++ b/packages/core/src/observer-client.test.ts
@@ -2,7 +2,12 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { loadObserverConfig, ObserverClient } from "./observer-client.js";
+import {
+	isSidecarAuthError,
+	isSidecarModelError,
+	loadObserverConfig,
+	ObserverClient,
+} from "./observer-client.js";
 
 // ---------------------------------------------------------------------------
 // loadObserverConfig
@@ -299,7 +304,7 @@ describe("ObserverClient", () => {
 			expect(client.tierRoutingEnabled).toBe(false);
 		});
 
-		it("keeps default tier routing off for claude_sidecar until sidecar tier routing lands", () => {
+		it("defaults tier routing on for claude_sidecar", () => {
 			const client = new ObserverClient({
 				observerProvider: "anthropic",
 				observerModel: "claude-haiku-4-5",
@@ -316,7 +321,7 @@ describe("ObserverClient", () => {
 				observerAuthTimeoutMs: 1500,
 				observerAuthCacheTtlS: 300,
 			});
-			expect(client.tierRoutingEnabled).toBe(false);
+			expect(client.tierRoutingEnabled).toBe(true);
 		});
 
 		it("defaults to openai provider and default model", () => {
@@ -1154,5 +1159,203 @@ describe("ObserverClient.observe()", () => {
 
 		const result = await client.observe("system", "user");
 		expect(result.raw).toBeNull();
+	});
+
+	it("passes the selected sidecar model via --model", () => {
+		const client = new ObserverClient({
+			observerProvider: "anthropic",
+			observerModel: "claude-sonnet-4-6",
+			observerRuntime: "claude_sidecar",
+			observerApiKey: null,
+			observerBaseUrl: null,
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "auto",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+		});
+		const command = (
+			client as unknown as { _buildSidecarCommand: (prompt: string, useModel: boolean) => string[] }
+		)._buildSidecarCommand("prompt", true);
+		expect(command).toContain("--model");
+		expect(command).toContain("claude-sonnet-4-6");
+	});
+
+	it("leaves resolved model null when retry payload omits model", async () => {
+		const client = new ObserverClient({
+			observerProvider: "anthropic",
+			observerModel: "claude-sonnet-4-6",
+			observerRuntime: "claude_sidecar",
+			observerApiKey: null,
+			observerBaseUrl: null,
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "auto",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+		});
+		(
+			client as unknown as {
+				_invokeSidecar: (
+					prompt: string,
+					useModel: boolean,
+				) => Promise<{ output: string | null; error: string | null; reportedModel: string | null }>;
+			}
+		)._invokeSidecar = async (_prompt, useModel) => {
+			if (useModel) {
+				return { output: null, error: "Issue with the selected model", reportedModel: null };
+			}
+			return { output: "sidecar ok", error: null, reportedModel: null };
+		};
+
+		await client.observe("system", "user");
+		const status = client.getStatus();
+
+		expect(status.actualModel).toBeNull();
+		expect(status.modelFallbackApplied).toBe(true);
+	});
+
+	it("raises ObserverAuthError when the sidecar reports an auth failure", async () => {
+		const client = new ObserverClient({
+			observerProvider: "anthropic",
+			observerModel: "claude-sonnet-4-6",
+			observerRuntime: "claude_sidecar",
+			observerApiKey: null,
+			observerBaseUrl: null,
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "auto",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+		});
+		(
+			client as unknown as {
+				_invokeSidecar: (
+					prompt: string,
+					useModel: boolean,
+				) => Promise<{ output: string | null; error: string | null; reportedModel: string | null }>;
+			}
+		)._invokeSidecar = async () => ({
+			output: null,
+			error: "Not logged in. Please run `claude login`.",
+			reportedModel: null,
+		});
+
+		await expect(client.observe("system", "user")).rejects.toThrow(/not logged in/i);
+		expect(client.getStatus().lastError?.code).toBe("auth_failed");
+	});
+
+	it("returns null and records ENOENT when the claude binary is missing", async () => {
+		const client = new ObserverClient({
+			observerProvider: "anthropic",
+			observerModel: "claude-sonnet-4-6",
+			observerRuntime: "claude_sidecar",
+			observerApiKey: null,
+			observerBaseUrl: null,
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "auto",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+			claudeCommand: ["/nonexistent/claude-binary-that-does-not-exist"],
+		});
+		const result = await client.observe("system", "user");
+		expect(result.raw).toBeNull();
+	});
+
+	describe("sidecar error classifiers", () => {
+		it("matches model errors from known Claude CLI phrasings", () => {
+			expect(isSidecarModelError("Issue with the selected model")).toBe(true);
+			expect(isSidecarModelError("Run --model to pick a different model")).toBe(true);
+			expect(isSidecarModelError("model foo may not exist")).toBe(true);
+			expect(isSidecarModelError("the model may not exist; try another")).toBe(true);
+		});
+
+		it("does not misclassify unrelated errors as model errors", () => {
+			expect(isSidecarModelError("Not logged in")).toBe(false);
+			expect(isSidecarModelError("Connection timed out")).toBe(false);
+			expect(isSidecarModelError("")).toBe(false);
+		});
+
+		it("matches auth errors from known Claude CLI phrasings", () => {
+			expect(isSidecarAuthError("Not logged in. Please run `claude login`.")).toBe(true);
+			expect(isSidecarAuthError("Authentication failed")).toBe(true);
+			expect(isSidecarAuthError("Unauthorized")).toBe(true);
+			expect(isSidecarAuthError("Permission denied")).toBe(true);
+			expect(isSidecarAuthError("Please set ANTHROPIC_API_KEY")).toBe(true);
+			expect(isSidecarAuthError("Run /setup-token to authenticate")).toBe(true);
+		});
+
+		it("does not misclassify unrelated errors as auth errors", () => {
+			expect(isSidecarAuthError("Issue with the selected model")).toBe(false);
+			expect(isSidecarAuthError("Request failed with status 500")).toBe(false);
+			expect(isSidecarAuthError("")).toBe(false);
+		});
+	});
+
+	it("reports the actual sidecar model after retrying without --model", async () => {
+		const client = new ObserverClient({
+			observerProvider: "anthropic",
+			observerModel: "claude-sonnet-4-6",
+			observerRuntime: "claude_sidecar",
+			observerApiKey: null,
+			observerBaseUrl: null,
+			observerMaxChars: 12_000,
+			observerMaxTokens: 4_000,
+			observerHeaders: {},
+			observerAuthSource: "auto",
+			observerAuthFile: null,
+			observerAuthCommand: [],
+			observerAuthTimeoutMs: 1500,
+			observerAuthCacheTtlS: 300,
+		});
+		let calls = 0;
+		(
+			client as unknown as {
+				_invokeSidecar: (
+					prompt: string,
+					useModel: boolean,
+				) => Promise<{ output: string | null; error: string | null; reportedModel: string | null }>;
+			}
+		)._invokeSidecar = async (_prompt, useModel) => {
+			calls++;
+			if (useModel) {
+				return {
+					output: null,
+					error: "Issue with the selected model",
+					reportedModel: null,
+				};
+			}
+			return {
+				output: "sidecar ok",
+				error: null,
+				reportedModel: "claude-haiku-4-5",
+			};
+		};
+
+		const result = await client.observe("system", "user");
+		const status = client.getStatus();
+
+		expect(calls).toBe(2);
+		expect(result.raw).toBe("sidecar ok");
+		expect(result.model).toBe("claude-haiku-4-5");
+		expect(status.model).toBe("claude-haiku-4-5");
+		expect(status.actualModel).toBe("claude-haiku-4-5");
+		expect(status.modelFallbackApplied).toBe(true);
+		expect(status.modelFallbackReason).toBe(
+			"configured sidecar tier model unavailable; retried with default Claude model",
+		);
 	});
 });

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -128,6 +128,9 @@ export interface ObserverStatus {
 	model: string;
 	runtime: string;
 	auth: { source: string; type: string; hasToken: boolean };
+	actualModel?: string | null;
+	modelFallbackApplied?: boolean;
+	modelFallbackReason?: string | null;
 	lastError?: { code: string; message: string } | null;
 }
 
@@ -257,6 +260,7 @@ function supportsDefaultTierRouting(
 	runtime: string,
 	hasCustomBaseUrl: boolean,
 ): boolean {
+	if (runtime === "claude_sidecar") return true;
 	if (runtime !== "api_http") return false;
 	if (provider !== "openai" && provider !== "anthropic") return false;
 	// A custom base URL may point at an OpenAI-compatible gateway that only
@@ -264,6 +268,11 @@ function supportsDefaultTierRouting(
 	// cannot assume capability-safety without an explicit user opt-in.
 	if (hasCustomBaseUrl) return false;
 	return true;
+}
+
+function extractClaudeReportedModel(payload: Record<string, unknown>): string | null {
+	const model = payload.model;
+	return typeof model === "string" && model.trim() ? model.trim() : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -640,7 +649,7 @@ function extractClaudeResultPayload(output: string): Record<string, unknown> | n
  * Detect model-related errors from Claude CLI output.
  * Preserves the Python implementation's generous matching strategy.
  */
-function isSidecarModelError(message: string): boolean {
+export function isSidecarModelError(message: string): boolean {
 	const lowered = message.toLowerCase();
 	return (
 		lowered.includes("issue with the selected model") ||
@@ -653,7 +662,7 @@ function isSidecarModelError(message: string): boolean {
  * Detect auth-related errors from Claude CLI output.
  * Preserves the Python implementation's broad phrase matching.
  */
-function isSidecarAuthError(message: string): boolean {
+export function isSidecarAuthError(message: string): boolean {
 	const lowered = message.toLowerCase();
 	const checks = [
 		"not logged in",
@@ -1061,6 +1070,9 @@ export class ObserverClient {
 	private _lastErrorCode: string | null = null;
 	private _lastErrorMessage: string | null = null;
 	private readonly _observerExplicitConfigKeys: string[];
+	private _lastResolvedModel: string | null = null;
+	private _sidecarModelFallbackApplied = false;
+	private _sidecarModelFallbackReason: string | null = null;
 
 	constructor(config?: ObserverConfig) {
 		const configWasProvided = config !== undefined;
@@ -1126,6 +1138,7 @@ export class ObserverClient {
 		this._sidecarModel = model || DEFAULT_ANTHROPIC_MODEL;
 		if (this.runtime === "claude_sidecar") {
 			this.model = this._sidecarModel;
+			this._lastResolvedModel = this._sidecarModel;
 		}
 
 		this.temperature =
@@ -1220,6 +1233,18 @@ export class ObserverClient {
 		// Initialize provider client state — skip for claude_sidecar (no API key needed)
 		if (this.runtime !== "claude_sidecar") {
 			this._initProvider(false);
+		} else if (
+			cfg.observerAuthSource === "file" ||
+			cfg.observerAuthSource === "command" ||
+			cfg.observerAuthSource === "env"
+		) {
+			// The sidecar runtime authenticates through the local Claude CLI and
+			// does not consult observer_auth_source, so flag the mismatch to avoid
+			// silently ignoring user config.
+			console.warn(
+				`[codemem] observer_auth_source="${cfg.observerAuthSource}" is ignored when ` +
+					`observer_runtime="claude_sidecar"; the sidecar authenticates via the local Claude CLI.`,
+			);
 		}
 	}
 
@@ -1281,7 +1306,8 @@ export class ObserverClient {
 
 		const status: ObserverStatus = {
 			provider: this.provider,
-			model: this.model,
+			model:
+				this.runtime === "claude_sidecar" ? (this._lastResolvedModel ?? this.model) : this.model,
 			runtime,
 			auth: {
 				source: this.auth.source,
@@ -1289,6 +1315,11 @@ export class ObserverClient {
 				hasToken: !!this.auth.token,
 			},
 		};
+		if (this.runtime === "claude_sidecar") {
+			status.actualModel = this._lastResolvedModel;
+			status.modelFallbackApplied = this._sidecarModelFallbackApplied;
+			status.modelFallbackReason = this._sidecarModelFallbackReason;
+		}
 		if (this._lastErrorMessage) {
 			status.lastError = {
 				code: this._lastErrorCode ?? "observer_error",
@@ -1321,13 +1352,19 @@ export class ObserverClient {
 			userPrompt.length > userBudget ? userPrompt.slice(0, userBudget) : userPrompt;
 
 		try {
+			if (this.runtime === "claude_sidecar") {
+				this._lastResolvedModel = this._sidecarModel;
+				this._sidecarModelFallbackApplied = false;
+				this._sidecarModelFallbackReason = null;
+			}
 			const raw = await this._callOnce(clippedSystem, clippedUser);
 			if (raw) this._clearLastError();
 			return {
 				raw,
 				parsed: raw ? tryParseJSON(raw) : null,
 				provider: this.provider,
-				model: this.model,
+				model:
+					this.runtime === "claude_sidecar" ? (this._lastResolvedModel ?? this.model) : this.model,
 			};
 		} catch (err) {
 			if (err instanceof ObserverAuthError) {
@@ -1341,7 +1378,10 @@ export class ObserverClient {
 						raw,
 						parsed: raw ? tryParseJSON(raw) : null,
 						provider: this.provider,
-						model: this.model,
+						model:
+							this.runtime === "claude_sidecar"
+								? (this._lastResolvedModel ?? this.model)
+								: this.model,
 					};
 				} catch {
 					throw err; // re-throw original
@@ -1736,17 +1776,22 @@ export class ObserverClient {
 	private async _invokeSidecar(
 		prompt: string,
 		useModel: boolean,
-	): Promise<[string | null, string | null]> {
+	): Promise<{ output: string | null; error: string | null; reportedModel: string | null }> {
 		const cmd = this._buildSidecarCommand(prompt, useModel);
 		const executable = cmd[0] ?? "claude";
 		const args = cmd.slice(1);
-		const env = {
+		// Clear Claude-Code session markers so the spawned `claude` process starts
+		// fresh rather than inheriting the parent harness's session identity.
+		const env: NodeJS.ProcessEnv = {
 			...process.env,
 			CODEMEM_PLUGIN_IGNORE: "1",
 			CODEMEM_VIEWER: "0",
 			CODEMEM_VIEWER_AUTO: "0",
 			CODEMEM_VIEWER_AUTO_STOP: "0",
 		};
+		delete env.CLAUDE_CODE_ENTRYPOINT;
+		delete env.CLAUDE_CODE_SESSION;
+		delete env.CLAUDECODE;
 
 		const execFileAsync = promisify(execFile);
 		try {
@@ -1760,15 +1805,20 @@ export class ObserverClient {
 			if (payload !== null) {
 				const message = String(payload.result ?? "").trim();
 				const isError = Boolean(payload.is_error);
+				const reportedModel = extractClaudeReportedModel(payload);
 				if (isError) {
-					return [null, message || "claude sidecar returned an error"];
+					return {
+						output: null,
+						error: message || "claude sidecar returned an error",
+						reportedModel,
+					};
 				}
-				return [message || null, null];
+				return { output: message || null, error: null, reportedModel };
 			}
 
 			// No result payload found — treat non-empty stdout as raw output
 			const text = (stdout || "").trim();
-			return [text || null, null];
+			return { output: text || null, error: null, reportedModel: null };
 		} catch (err: unknown) {
 			const error = err as NodeJS.ErrnoException & {
 				killed?: boolean;
@@ -1782,13 +1832,31 @@ export class ObserverClient {
 				console.warn(
 					"[codemem] observer claude_sidecar unavailable: configured claude command not found",
 				);
-				return [null, "configured claude command not found"];
+				return {
+					output: null,
+					error: "configured claude command not found",
+					reportedModel: null,
+				};
 			}
 
-			// Timeout (killed by signal or timeout error)
-			if (error.killed || error.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
+			// stdout exceeded the configured buffer — distinct from a timeout.
+			if (error.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
+				console.warn("[codemem] observer claude_sidecar stdout exceeded buffer limit");
+				return {
+					output: null,
+					error: "claude sidecar output exceeded buffer limit",
+					reportedModel: null,
+				};
+			}
+
+			// Timeout (killed by signal after CLAUDE_SIDECAR_TIMEOUT_MS)
+			if (error.killed) {
 				console.warn("[codemem] observer claude_sidecar timed out");
-				return [null, "claude sidecar call timed out"];
+				return {
+					output: null,
+					error: "claude sidecar call timed out",
+					reportedModel: null,
+				};
 			}
 
 			// Non-zero exit — check for result payload in stdout first
@@ -1797,27 +1865,42 @@ export class ObserverClient {
 				if (payload !== null) {
 					const message = String(payload.result ?? "").trim();
 					const isError = Boolean(payload.is_error);
+					const reportedModel = extractClaudeReportedModel(payload);
 					if (isError) {
-						return [null, message || "claude sidecar returned an error"];
+						return {
+							output: null,
+							error: message || "claude sidecar returned an error",
+							reportedModel,
+						};
 					}
-					return [message || null, null];
+					return { output: message || null, error: null, reportedModel };
 				}
 			}
 
 			const message = (error.stderr || "").trim() || (error.stdout || "").trim() || String(err);
-			return [null, message];
+			return { output: null, error: message, reportedModel: null };
 		}
 	}
 
 	private async _callSidecar(systemPrompt: string, userPrompt: string): Promise<string | null> {
 		const prompt = `${systemPrompt}\n\n${userPrompt}`;
 
-		let [output, error] = await this._invokeSidecar(prompt, true);
+		let { output, error, reportedModel } = await this._invokeSidecar(prompt, true);
+		if (reportedModel) this._lastResolvedModel = reportedModel;
 		if (error && this._sidecarModel && isSidecarModelError(error)) {
 			console.warn(
 				`[codemem] observer claude_sidecar model unsupported; retrying with default model (model=${this._sidecarModel})`,
 			);
-			[output, error] = await this._invokeSidecar(prompt, false);
+			this._sidecarModelFallbackApplied = true;
+			this._sidecarModelFallbackReason =
+				"configured sidecar tier model unavailable; retried with default Claude model";
+			({ output, error, reportedModel } = await this._invokeSidecar(prompt, false));
+			// Only update the resolved-model marker when the sidecar actually
+			// reports one. If the retry payload omits the model, leave
+			// _lastResolvedModel unchanged (or null) rather than asserting a
+			// default — the sidecar's own default may differ per environment.
+			if (reportedModel) this._lastResolvedModel = reportedModel;
+			else this._lastResolvedModel = null;
 		}
 		if (error) {
 			if (isSidecarAuthError(error)) {


### PR DESCRIPTION
## Description
Adds the Claude sidecar slice of tier routing. This maps simple/rich tier selection onto explicit Claude CLI `--model` usage, enables default-on sidecar routing for that capability-safe runtime, and makes requested-vs-actual diagnostics honest when Claude falls back to its default model.

## Type of Change
- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran:
- `pnpm exec vitest run packages/core/src/extraction-tier-routing.test.ts packages/core/src/observer-client.test.ts packages/core/src/ingest-pipeline.test.ts`
- `pnpm run tsc`

## Checklist
- [ ] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced