### PR TITLE
docs(ui): clarify default-on tier routing behavior

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,7 +234,10 @@ The observer turns raw session transcripts into typed, structured memories. It's
 - `claude_sidecar` executes observer prompts through local Claude runtime auth and bypasses provider API-key client initialization.
 - `claude_sidecar` command launch is configurable with `claude_command` / `CODEMEM_CLAUDE_COMMAND` (JSON argv; default `["claude"]`).
 - Runtime defaults: `api_http` uses `gpt-5.1-codex-mini`; `claude_sidecar` uses `claude-4.5-haiku` unless explicitly overridden.
+- For capability-safe paths, tier routing can default on without an explicit user toggle. Current safe classes are OpenAI/Anthropic over `api_http` and Claude subscription usage over `claude_sidecar`.
+- OpenAI `api_http` observer calls are Responses-first by default unless the user explicitly overrides transport behavior.
 - If a configured `observer_model` is not available in Claude CLI, codemem retries once with Claude's default model.
+- When a tier-selected path cannot honor the requested runtime/provider/model combination, codemem records the requested-versus-actual details plus a visible fallback reason rather than silently masking the downgrade.
 - Supported auth sources are `auto`, `env`, `file`, `command`, `none`.
 - `observer_auth_command` is argv data and must be a JSON string array when passed via env (`CODEMEM_OBSERVER_AUTH_COMMAND`).
 - Header templating supports `${auth.token}`, `${auth.type}`, `${auth.source}`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -28,6 +28,10 @@
 - Connection/auth settings map to `claude_command`, `observer_runtime`, `observer_provider`, `observer_model`, `observer_base_url`, `observer_auth_source`, `observer_auth_file`, `observer_auth_command`, `observer_auth_timeout_ms`, `observer_auth_cache_ttl_s`, and `observer_headers`.
 - Processing settings include `raw_events_sweeper_interval_s` plus tiered observer routing controls for `observer_tier_routing_enabled`, `observer_simple_model`, `observer_simple_temperature`, `observer_rich_model`, `observer_rich_temperature`, `observer_rich_openai_use_responses`, `observer_rich_reasoning_effort`, `observer_rich_reasoning_summary`, and `observer_rich_max_output_tokens`.
 - When tiered routing is enabled, the Processing tab becomes the primary place for model selection; the Connection tab's base `observer_model` acts as a fallback rather than a competing primary control.
+- When you have not made an explicit routing choice, codemem may enable tiered routing automatically for capability-safe paths such as OpenAI/Anthropic over `api_http` and Claude subscription usage over `claude_sidecar`.
+- Explicit config still wins. If you set routing or transport values yourself, codemem honors them instead of replacing them with built-in defaults.
+- For OpenAI `api_http` paths, codemem now treats Responses as the default transport instead of chat-completions-style behavior.
+- If a selected tier path cannot honor the requested settings, codemem records the requested versus actual provider/model/runtime details and surfaces a visible fallback reason.
 - Sync settings can also be updated here (`sync_enabled`, `sync_host`, `sync_port`, `sync_interval_s`, `sync_mdns`).
 - Environment variables still override file values.
 - Config resolution supports JSON and JSONC with this precedence:
@@ -42,8 +46,9 @@
 - `claude_command` controls how `claude_sidecar` invokes Claude CLI (default `["claude"]`).
   - Wrapper example: `"claude_command": ["wrapper", "claude", "--"]`
 - Default model selection:
-  - `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
-  - `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.
+- `api_http`: `gpt-5.1-codex-mini` unless `observer_model` is set.
+- `claude_sidecar`: `claude-4.5-haiku` unless `observer_model` is set.
+- Tier routing may pick different simple/rich models automatically when the current runtime/provider path is marked capability-safe.
 - Anthropic direct API calls use Anthropic's direct model IDs. codemem translates the common shorthand `claude-4.5-haiku` to `claude-haiku-4-5`; if you want a fixed snapshot, set a versioned model like `claude-haiku-4-5-20251001` directly.
 - If a configured `observer_model` is unsupported by Claude CLI, codemem retries once with Claude's default model.
 - Supported auth sources: `auto`, `env`, `file`, `command`, `none`.
@@ -55,6 +60,7 @@
 - Queue settings include `raw_events_sweeper_interval_s` (seconds), which controls background pending-event drain cadence.
 - Tiered routing settings live in the Processing tab. The basic view exposes the tier-routing toggle plus simple/rich model choices, while advanced controls reveal the extra rich-tier tuning knobs.
 - To avoid overlapping primary controls, the Connection tab reframes `observer_model` as a fallback whenever tiered routing is enabled.
+- Rich-tier OpenAI transport tuning remains visible in Processing, but OpenAI API paths are Responses-first by default.
 
 Example command-token gateway config:
 

--- a/packages/ui/src/tabs/settings/components/ProcessingPanel.tsx
+++ b/packages/ui/src/tabs/settings/components/ProcessingPanel.tsx
@@ -59,7 +59,8 @@ export function ProcessingPanel({
 				<div className="small">{getTieredRoutingHelperText()}</div>
 				<SettingsHint hidden={!showTieredRouting || hiddenUnlessAdvanced()}>
 					These advanced routing values are only useful when you are tuning model cost, latency, or
-					output quality for a known workload.
+					output quality for a known workload. If a selected path cannot honor the requested tier
+					settings, codemem falls back visibly instead of silently pretending it worked.
 				</SettingsHint>
 				<Field hidden={!showTieredRouting}>
 					<div className="field-label">
@@ -67,7 +68,7 @@ export function ProcessingPanel({
 						<button
 							aria-label="About simple tier model"
 							className="help-icon"
-							data-tooltip="Used for lighter replay batches. Leave blank to keep codemem's routing defaults or base observer fallback."
+							data-tooltip="Used for lighter replay batches. Leave blank to keep codemem's routing defaults. Explicit simple-tier values override the built-in defaults."
 							type="button"
 						>
 							?
@@ -87,7 +88,7 @@ export function ProcessingPanel({
 						<button
 							aria-label="About rich tier model"
 							className="help-icon"
-							data-tooltip="Used for larger or more complex replay batches. Leave blank to keep codemem's rich-tier defaults."
+							data-tooltip="Used for larger or more complex replay batches. Leave blank to keep codemem's rich-tier defaults. Explicit rich-tier values override the built-in defaults."
 							type="button"
 						>
 							?
@@ -109,6 +110,10 @@ export function ProcessingPanel({
 					label="Use OpenAI Responses API for rich tier"
 					onCheckedChange={onSwitchInput("observerRichOpenAIUseResponses")}
 				/>
+				<div className="small" hidden={!showTieredRouting}>
+					On: rich-tier OpenAI requests use the Responses API (reasoning + longer output). Turn off
+					if your OpenAI account or proxy only supports chat/completions.
+				</div>
 				<Field
 					className="field settings-advanced"
 					hidden={!showTieredRouting || hiddenUnlessAdvanced()}

--- a/packages/ui/src/tabs/settings/data/model-accessors.ts
+++ b/packages/ui/src/tabs/settings/data/model-accessors.ts
@@ -26,9 +26,9 @@ export function getObserverModelHint(
 
 export function getTieredRoutingHelperText(values: SettingsFormState): string {
 	if (!values.observerTierRoutingEnabled) {
-		return "Off: codemem uses the base observer settings from the Connection tab for all batches.";
+		return "Off: codemem uses the base observer settings from the Connection tab for all batches. Explicit user settings always win over built-in routing defaults.";
 	}
-	return "On: codemem can route simpler batches to a lighter model and richer batches to a higher-quality configuration.";
+	return "On: codemem routes simpler batches to a lighter model and richer batches to a higher-quality configuration. Rich-tier OpenAI requests default to the Responses transport, and Claude sidecar runtimes route both tiers through the local Claude CLI.";
 }
 
 export function getObserverModelLabel(values: SettingsFormState): string {
@@ -37,13 +37,13 @@ export function getObserverModelLabel(values: SettingsFormState): string {
 
 export function getObserverModelTooltip(values: SettingsFormState): string {
 	return values.observerTierRoutingEnabled
-		? "Tiered routing is enabled, so Processing controls the simple/rich models. This base model is only a fallback."
+		? "Tiered routing is enabled, so Processing controls the simple/rich models. This base model is only a fallback, and explicit settings override built-in defaults."
 		: "Leave blank to use a recommended model for your selected mode/provider.";
 }
 
 export function getObserverModelDescription(values: SettingsFormState): string {
 	return values.observerTierRoutingEnabled
-		? "Tiered routing is active. Use this only as a fallback while the Processing tab owns simple/rich model selection."
+		? "Tiered routing is active. Use this only as a fallback while the Processing tab owns simple/rich model selection and explicit tier settings override built-in defaults."
 		: "Default: `gpt-5.1-codex-mini` for Direct API; `claude-4.5-haiku` for Local Claude session.";
 }
 


### PR DESCRIPTION
## Description
Updates the user-facing contract to match the stacked runtime work. The settings copy and docs now explain capability-safe default-on routing, explicit-setting precedence, OpenAI Responses-first behavior, and visible fallback semantics for requested-versus-actual routing.

## Type of Change
- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran:
- `pnpm run tsc`

## Checklist
- [ ] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced