### PR TITLE
fix(ui): stabilize feed controls position across filter selection (codemem-drod)

### DIFF
--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -969,10 +969,14 @@
       .feed-controls {
         display: flex;
         align-items: center;
-        justify-content: space-between;
         gap: var(--sp-3);
         flex-wrap: wrap;
         margin-bottom: var(--sp-4);
+      }
+      .feed-controls > .section-meta {
+        flex: 1 1 auto;
+        min-width: 0;
+        margin-bottom: 0;
       }
 
       .feed-controls-right {


### PR DESCRIPTION
## Description

Feed tab controls row shifted horizontally when the scope filter changed ("All" / "My memories" / "Other people") because `feedScopeLabel` returns an empty string for the "all" case, making the meta text shorter. The `.feed-controls` flex container used `justify-content: space-between`, so length changes in the left item rippled the right cluster's position — even after PR #922 stabilized individual toggle widths.

Fix: drop `space-between` and let the meta absorb slack with `flex: 1 1 auto`. The controls cluster stays pinned right regardless of meta length.

## Changes

- `.feed-controls`: remove `justify-content: space-between`
- `.feed-controls > .section-meta`: add `flex: 1 1 auto; min-width: 0; margin-bottom: 0`

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm exec vitest run packages/ui/src/tabs/feed.test.ts`)
- [x] `pnpm --filter @codemem/ui build` succeeds
- [x] Manually verified: controls row position no longer changes when toggling scope filter

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No new warnings introduced

Closes codemem-drod.