### PR TITLE
refactor(ui): promote pairing out of Advanced diagnostics into People & devices (codemem-dmuj)

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-disclosure.tsx
@@ -165,8 +165,8 @@ function PairingDisclosure({ contentHost, open, onOpenChange }: PairingDisclosur
 			onOpenChange={onOpenChange}
 			triggerId="syncPairingToggle"
 			triggerClassName="settings-button"
-			closedLabel="Show pairing"
-			openLabel="Hide pairing"
+			closedLabel="Show pairing command"
+			openLabel="Hide pairing command"
 			contentId="syncPairing"
 			contentClassName="pairing-card"
 			contentHost={contentHost}

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -514,8 +514,8 @@ function SyncPeersList(props: SyncPeersListProps) {
 				<SyncEmptyState
 					detail={
 						syncDisabled
-							? "Turn on sync in Settings → Device Sync first, then use Show pairing in Advanced diagnostics to connect another device."
-							: "Use Show pairing in Advanced diagnostics, run the command on the other device, then come back here to name it and decide who it belongs to."
+							? "Turn on sync in Settings → Device Sync first, then use Show pairing command under Connect another device to connect another device."
+							: "Use Show pairing command under Connect another device, run the command on the other device, then come back here to name it and decide who it belongs to."
 					}
 					title="No devices connected here yet."
 				/>

--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-status.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-status.ts
@@ -67,7 +67,7 @@ export function renderSyncStatus() {
 			: syncNoPeers
 				? [
 						"Advanced sync is ready but idle",
-						"Use Show pairing to connect another device, then this panel will start showing live peer status and recent attempts",
+						"Use Show pairing command under People & devices to connect another device, then this panel will start showing live peer status and recent attempts",
 					]
 				: [
 						`Advanced state: ${daemonStateLabel}`,

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3096,6 +3096,13 @@
           <div class="sync-skeleton-block"></div>
         </div>
 
+        <h3 class="settings-group-title" style="margin-top: 20px">Connect another device</h3>
+        <div class="section-meta">Share this command on the new device to join it to the team.</div>
+        <div class="actor-create-row">
+          <div id="syncPairingDisclosureMount" style="display: contents"></div>
+        </div>
+        <div id="syncPairingPanelMount" style="display: contents"></div>
+
         <div id="syncSharingReview" hidden>
           <h3 class="settings-group-title" style="margin-top: 20px">What teammates will receive</h3>
           <div class="section-meta" id="syncSharingReviewMeta"></div>
@@ -3113,19 +3120,18 @@
         </div>
       </div>
 
-      <!-- 3. Advanced diagnostics — status, pairing, attempts -->
+      <!-- 3. Advanced diagnostics — status, attempts -->
       <div class="card" style="animation-delay: 0.06s">
         <div class="section-header">
           <h2>Advanced diagnostics</h2>
           <div class="section-actions">
-            <div id="syncPairingDisclosureMount" style="display: contents"></div>
             <label class="small sync-redact-control">
               <span id="syncRedactMount"></span>
               <span id="syncRedactLabel">Redact</span>
             </label>
           </div>
         </div>
-        <div class="section-meta" id="syncMeta">Use this section for sync debugging, pairing, and recent attempt details.</div>
+        <div class="section-meta" id="syncMeta">Use this section for sync debugging and recent attempt details.</div>
         <div class="sync-skeleton" id="syncDiagSkeleton" role="status" aria-label="Loading diagnostics">
           <div class="sync-skeleton-line long"></div>
           <div class="sync-skeleton-line medium"></div>
@@ -3133,8 +3139,6 @@
         </div>
         <div class="sync-actions" id="syncActions"></div>
         <div class="grid-2" id="syncStatusGrid"></div>
-
-        <div id="syncPairingPanelMount" style="display: contents"></div>
 
         <h3 class="settings-group-title" style="margin-top: 20px">Recent sync attempts (advanced)</h3>
         <div class="attempts-list" id="syncAttempts"></div>


### PR DESCRIPTION
## Description

Pairing is the primary way a fresh device joins an existing team, but it lived under the "Advanced diagnostics" collapsible alongside debug-only signals (redact toggle, recent sync attempts, daemon status grid). Operators had to dig through a debug panel to reach the main onboarding payload.

This moves the pairing disclosure + payload mount into the People & devices card as a first-class "Connect another device" affordance, right below the Devices list where a new device would be discovered. The Advanced diagnostics card stays focused on status/redact/attempts.

## Changes

- `packages/ui/static/index.html`: relocate `syncPairingDisclosureMount` + `syncPairingPanelMount` from the Advanced diagnostics card into the People & devices card under a new "Connect another device" group title. Removed pairing wording from the `syncMeta` copy.
- `packages/ui/src/tabs/sync/components/sync-disclosure.tsx`: clearer trigger labels ("Show pairing command" / "Hide pairing command").
- `packages/ui/src/tabs/sync/components/sync-peers.tsx` and `diagnostics/render/sync-status.ts`: update empty-state / idle-state copy to point at the new location.

Mount IDs are unchanged, so `diagnostics/lifecycle.ts` wiring (including the redact re-render hook that calls `renderPairing()`) keeps working without modification. `state.syncPairingOpen` persistence semantics are preserved.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint` pass
- [x] `pnpm exec vitest run packages/ui/src/tabs/sync` — 4 files, 35 tests pass
- [x] `pnpm --filter @codemem/ui build` succeeds
- [x] Manually verified: pairing disclosure toggles correctly in its new location; redact toggle still triggers pairing re-render

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No new warnings introduced

Closes codemem-dmuj. Stacked on #937.