### PR TITLE
feat(core): backfill historical duplicate session_summary rows on viewer startup (codemem-garf)

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -10,6 +10,7 @@ import {
 	hasPendingDedupKeyBackfill,
 	hasPendingRefBackfill,
 	hasPendingSessionContextBackfill,
+	hasPendingSummaryDedupBackfill,
 	initDatabase,
 	isEmbeddingDisabled,
 	type MemoryStore,
@@ -24,6 +25,8 @@ import {
 	runSyncDaemon,
 	SESSION_CONTEXT_BACKFILL_JOB,
 	SessionContextBackfillRunner,
+	SUMMARY_DEDUP_BACKFILL_JOB,
+	SummaryDedupBackfillRunner,
 	SyncRetentionRunner,
 	VectorModelMigrationRunner,
 } from "@codemem/core";
@@ -584,6 +587,17 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 				createRunner: () =>
 					new RefBackfillRunner({
 						dbPath,
+						signal: backfillAbort.signal,
+					}),
+			},
+			{
+				name: "Session-summary dedup",
+				kind: SUMMARY_DEDUP_BACKFILL_JOB,
+				isPending: hasPendingSummaryDedupBackfill,
+				createRunner: () =>
+					new SummaryDedupBackfillRunner({
+						dbPath,
+						deviceId: store.deviceId,
 						signal: backfillAbort.signal,
 					}),
 			},

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -376,6 +376,12 @@ export {
 	SessionContextBackfillRunner,
 } from "./session-context-backfill.js";
 export { MemoryStore } from "./store.js";
+export {
+	hasPendingSummaryDedupBackfill,
+	runSummaryDedupBackfillPass,
+	SUMMARY_DEDUP_BACKFILL_JOB,
+	SummaryDedupBackfillRunner,
+} from "./summary-dedup-backfill.js";
 export { canonicalMemoryKind, getSummaryMetadata, isSummaryLikeMemory } from "./summary-memory.js";
 export type {
 	BuildAuthHeadersOptions,

--- a/packages/core/src/summary-dedup-backfill.test.ts
+++ b/packages/core/src/summary-dedup-backfill.test.ts
@@ -1,0 +1,195 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
+import {
+	hasPendingSummaryDedupBackfill,
+	runSummaryDedupBackfillPass,
+	SUMMARY_DEDUP_BACKFILL_JOB,
+} from "./summary-dedup-backfill.js";
+import { initTestSchema, insertTestSession } from "./test-utils.js";
+
+function seedSummary(
+	db: Database.Database,
+	sessionId: number,
+	createdAt: string,
+	source: string | null = "observer_summary",
+	active = 1,
+): number {
+	const metadata = source === null ? "{}" : JSON.stringify({ source });
+	const info = db
+		.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+			 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+			 workspace_id)
+			 VALUES (?, 'session_summary', 'Session recap', '## Completed\n...', 0.8,
+			 '', ?, ?, ?, ?, 1, 'shared', 'shared:default')`,
+		)
+		.run(sessionId, active, createdAt, createdAt, metadata);
+	return Number(info.lastInsertRowid);
+}
+
+function getRow(db: Database.Database, id: number) {
+	return db.prepare("SELECT * FROM memory_items WHERE id = ?").get(id) as Record<
+		string,
+		unknown
+	> | null;
+}
+
+describe("summary-dedup backfill", () => {
+	it("no-ops when every session has at most one active observer summary", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionA = insertTestSession(db);
+			const sessionB = insertTestSession(db);
+			seedSummary(db, sessionA, "2026-04-10T10:00:00Z");
+			seedSummary(db, sessionB, "2026-04-10T11:00:00Z");
+
+			expect(hasPendingSummaryDedupBackfill(db)).toBe(false);
+			const hasMore = await runSummaryDedupBackfillPass(db);
+			expect(hasMore).toBe(false);
+			expect(getMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB)).toBeNull();
+		} finally {
+			db.close();
+		}
+	});
+
+	it("keeps the most-recent summary and supersedes the rest with audit metadata", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			const id1 = seedSummary(db, sessionId, "2026-04-10T10:00:00Z");
+			const id2 = seedSummary(db, sessionId, "2026-04-10T11:00:00Z");
+			const id3 = seedSummary(db, sessionId, "2026-04-10T12:00:00Z");
+
+			expect(hasPendingSummaryDedupBackfill(db)).toBe(true);
+			await runSummaryDedupBackfillPass(db, { deviceId: "test-device" });
+
+			const winner = getRow(db, id3);
+			const loser1 = getRow(db, id1);
+			const loser2 = getRow(db, id2);
+
+			expect(winner?.active).toBe(1);
+			expect(loser1?.active).toBe(0);
+			expect(loser2?.active).toBe(0);
+			expect(loser1?.deleted_at).toBeTruthy();
+
+			const loser1Meta = JSON.parse(String(loser1?.metadata_json || "{}"));
+			expect(loser1Meta.superseded_at).toBeTruthy();
+			expect(loser1Meta.superseded_by).toBe(id3);
+			expect(loser1Meta.clock_device_id).toBe("test-device");
+			expect(Number(loser1?.rev)).toBe(2);
+
+			expect(hasPendingSummaryDedupBackfill(db)).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("leaves non-observer summaries alone (only targets observer_summary source)", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			const manual1 = seedSummary(db, sessionId, "2026-04-10T10:00:00Z", null);
+			const manual2 = seedSummary(db, sessionId, "2026-04-10T11:00:00Z", "manual");
+
+			expect(hasPendingSummaryDedupBackfill(db)).toBe(false);
+			await runSummaryDedupBackfillPass(db);
+			expect(getRow(db, manual1)?.active).toBe(1);
+			expect(getRow(db, manual2)?.active).toBe(1);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("emits replication delete ops for superseded rows", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			const id1 = seedSummary(db, sessionId, "2026-04-10T10:00:00Z");
+			seedSummary(db, sessionId, "2026-04-10T12:00:00Z");
+
+			await runSummaryDedupBackfillPass(db, { deviceId: "test-device" });
+
+			const ops = db
+				.prepare(
+					"SELECT op_type, entity_id FROM replication_ops WHERE entity_type = 'memory_item' ORDER BY created_at",
+				)
+				.all() as Array<{ op_type: string; entity_id: string }>;
+			expect(ops.some((op) => op.op_type === "delete" && op.entity_id === String(id1))).toBe(true);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("restarts from session_id 0 after a prior run completed so late-arriving duplicates are caught", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionLate = insertTestSession(db);
+			const sessionEarly = insertTestSession(db);
+			// First, seed dupes only on the later session. Run to completion.
+			seedSummary(db, sessionLate, "2026-04-10T10:00:00Z");
+			seedSummary(db, sessionLate, "2026-04-10T11:00:00Z");
+			await runSummaryDedupBackfillPass(db);
+			expect(getMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB)?.status).toBe("completed");
+
+			// Now introduce dupes on an earlier session_id (simulating a later
+			// sync import resurfacing historical data).
+			seedSummary(db, sessionEarly, "2026-04-10T09:00:00Z");
+			seedSummary(db, sessionEarly, "2026-04-10T09:30:00Z");
+
+			expect(hasPendingSummaryDedupBackfill(db)).toBe(true);
+			const hasMore = await runSummaryDedupBackfillPass(db);
+			expect(hasMore).toBe(false);
+			expect(hasPendingSummaryDedupBackfill(db)).toBe(false);
+
+			const done = getMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB);
+			expect(done?.status).toBe("completed");
+			expect(done?.metadata).toMatchObject({ processed_sessions: 1, superseded_rows: 1 });
+		} finally {
+			db.close();
+		}
+	});
+
+	it("tracks progress across batches and completes when drained", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			for (let i = 0; i < 3; i += 1) {
+				const sessionId = insertTestSession(db);
+				seedSummary(db, sessionId, `2026-04-10T10:0${i}:00Z`);
+				seedSummary(db, sessionId, `2026-04-10T11:0${i}:00Z`);
+			}
+
+			await runSummaryDedupBackfillPass(db, { batchSize: 2 });
+			const mid = getMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB);
+			expect(mid).toMatchObject({
+				status: "running",
+				progress: { current: 2, total: 3, unit: "sessions" },
+			});
+			expect(mid?.metadata).toMatchObject({
+				processed_sessions: 2,
+				superseded_rows: 2,
+				total_sessions: 3,
+			});
+
+			await runSummaryDedupBackfillPass(db, { batchSize: 2 });
+			const done = getMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB);
+			expect(done).toMatchObject({
+				status: "completed",
+				progress: { current: 3, total: 3, unit: "sessions" },
+			});
+			expect(done?.metadata).toMatchObject({
+				processed_sessions: 3,
+				superseded_rows: 3,
+			});
+			expect(hasPendingSummaryDedupBackfill(db)).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+});

--- a/packages/core/src/summary-dedup-backfill.ts
+++ b/packages/core/src/summary-dedup-backfill.ts
@@ -1,0 +1,337 @@
+/**
+ * Historical cleanup for sessions that accumulated multiple active
+ * `session_summary` memories before the write-path guard in
+ * `ingest-pipeline.ts#supersedePriorObserverSummaries` landed.
+ *
+ * For each session with more than one active `observer_summary` row, keep
+ * the most recent one (by created_at, tie-break by id) and soft-delete the
+ * rest with `superseded_at` / `superseded_by` audit metadata + replication
+ * delete ops — matching the semantics the live write path now enforces
+ * on every flush.
+ *
+ * Only runs against rows where `metadata.source === "observer_summary"`.
+ * Manually-created or legacy-imported session summaries are left alone.
+ */
+
+import type { Database as SqliteDatabase } from "better-sqlite3";
+import { connect, fromJson, resolveDbPath, toJson } from "./db.js";
+import {
+	completeMaintenanceJob,
+	failMaintenanceJob,
+	getMaintenanceJob,
+	startMaintenanceJob,
+	updateMaintenanceJob,
+} from "./maintenance-jobs.js";
+import { recordReplicationOp } from "./sync-replication.js";
+
+export const SUMMARY_DEDUP_BACKFILL_JOB = "session_summary_dedup_backfill";
+
+type SummaryDedupBackfillMetadata = {
+	total_sessions?: number;
+	processed_sessions?: number;
+	superseded_rows?: number;
+	last_session_id?: number;
+};
+
+export interface SummaryDedupBackfillRunnerOptions {
+	batchSize?: number;
+	intervalMs?: number;
+	dbPath?: string;
+	signal?: AbortSignal;
+	deviceId?: string;
+}
+
+interface CandidateRow {
+	id: number;
+	rev: number | null;
+	metadata_json: string | null;
+	created_at: string;
+}
+
+interface SessionPlan {
+	session_id: number;
+	winner_id: number;
+	superseded: CandidateRow[];
+}
+
+function countPendingSessions(db: SqliteDatabase): number {
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS n FROM (
+				SELECT session_id
+				FROM memory_items
+				WHERE active = 1
+				  AND kind = 'session_summary'
+				  AND json_extract(metadata_json, '$.source') = 'observer_summary'
+				GROUP BY session_id
+				HAVING COUNT(*) > 1
+			)`,
+		)
+		.get() as { n: number } | undefined;
+	return Number(row?.n ?? 0);
+}
+
+export function hasPendingSummaryDedupBackfill(db: SqliteDatabase): boolean {
+	return countPendingSessions(db) > 0;
+}
+
+function getExistingMetadata(db: SqliteDatabase): SummaryDedupBackfillMetadata {
+	return (getMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB)?.metadata ??
+		{}) as SummaryDedupBackfillMetadata;
+}
+
+function planBatch(db: SqliteDatabase, afterSessionId: number, batchSize: number): SessionPlan[] {
+	const sessionRows = db
+		.prepare(
+			`SELECT session_id
+			 FROM memory_items
+			 WHERE active = 1
+			   AND kind = 'session_summary'
+			   AND json_extract(metadata_json, '$.source') = 'observer_summary'
+			   AND session_id > ?
+			 GROUP BY session_id
+			 HAVING COUNT(*) > 1
+			 ORDER BY session_id ASC
+			 LIMIT ?`,
+		)
+		.all(afterSessionId, batchSize) as Array<{ session_id: number }>;
+
+	if (sessionRows.length === 0) return [];
+
+	const rowStmt = db.prepare(
+		`SELECT id, rev, metadata_json, created_at
+		 FROM memory_items
+		 WHERE session_id = ?
+		   AND active = 1
+		   AND kind = 'session_summary'
+		   AND json_extract(metadata_json, '$.source') = 'observer_summary'
+		 ORDER BY created_at DESC, id DESC`,
+	);
+
+	const plans: SessionPlan[] = [];
+	for (const { session_id } of sessionRows) {
+		const rows = rowStmt.all(session_id) as CandidateRow[];
+		if (rows.length < 2) continue;
+		const [winner, ...rest] = rows;
+		if (!winner) continue;
+		plans.push({ session_id, winner_id: winner.id, superseded: rest });
+	}
+	return plans;
+}
+
+function applySessionPlan(db: SqliteDatabase, plan: SessionPlan, deviceId: string): number {
+	const now = new Date().toISOString();
+	const updateStmt = db.prepare(
+		`UPDATE memory_items
+		 SET active = 0,
+		     deleted_at = ?,
+		     updated_at = ?,
+		     metadata_json = ?,
+		     rev = ?
+		 WHERE id = ?`,
+	);
+
+	let superseded = 0;
+	for (const row of plan.superseded) {
+		const meta = fromJson(row.metadata_json);
+		meta.superseded_at = now;
+		meta.superseded_by = plan.winner_id;
+		meta.clock_device_id = deviceId;
+		updateStmt.run(now, now, toJson(meta), (row.rev ?? 0) + 1, row.id);
+		try {
+			recordReplicationOp(db, {
+				memoryId: row.id,
+				opType: "delete",
+				deviceId,
+			});
+		} catch {
+			// Replication-op recording is best-effort; continue with supersede.
+		}
+		superseded += 1;
+	}
+	return superseded;
+}
+
+export interface SummaryDedupBackfillPassOptions {
+	batchSize?: number;
+	deviceId?: string;
+}
+
+export async function runSummaryDedupBackfillPass(
+	db: SqliteDatabase,
+	options: SummaryDedupBackfillPassOptions = {},
+): Promise<boolean> {
+	const batchSize = Math.max(1, options.batchSize ?? 50);
+	const deviceId = options.deviceId ?? "local";
+	const existingJob = getMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB);
+	const existingMetadata = getExistingMetadata(db);
+	// A previous run can leave `last_session_id` at the highest seen id. If
+	// new duplicates later appear on older session_ids (e.g. via sync import),
+	// resuming from that cursor would silently skip them and leave the job
+	// pending forever while the runner exits. Restart the scan from 0 whenever
+	// we're beginning a fresh pass (no prior job, or it's in a terminal state).
+	const startingFresh =
+		!existingJob || existingJob.status === "completed" || existingJob.status === "failed";
+	const lastSessionId = startingFresh ? 0 : Number(existingMetadata.last_session_id ?? 0);
+
+	const plans = planBatch(db, lastSessionId, batchSize);
+	const processedBefore = startingFresh ? 0 : Number(existingMetadata.processed_sessions ?? 0);
+	const supersededBefore = startingFresh ? 0 : Number(existingMetadata.superseded_rows ?? 0);
+
+	if (plans.length === 0) {
+		if (existingJob && existingJob.status !== "completed") {
+			completeMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB, {
+				message:
+					supersededBefore > 0
+						? `Session-summary dedup complete (${supersededBefore} rows superseded)`
+						: "Session-summary dedup complete",
+				progressCurrent: processedBefore,
+				progressTotal: Number(existingMetadata.total_sessions ?? processedBefore),
+				metadata: {
+					...existingMetadata,
+					last_session_id: lastSessionId,
+				},
+			});
+		}
+		return false;
+	}
+
+	if (!existingJob || existingJob.status === "completed" || existingJob.status === "failed") {
+		const initialTotal = countPendingSessions(db);
+		startMaintenanceJob(db, {
+			kind: SUMMARY_DEDUP_BACKFILL_JOB,
+			title: "Deduplicating historical session summaries",
+			message: `Cleaning up ${initialTotal} sessions with duplicate observer summaries`,
+			progressTotal: initialTotal,
+			progressUnit: "sessions",
+			metadata: {
+				total_sessions: initialTotal,
+				processed_sessions: processedBefore,
+				superseded_rows: supersededBefore,
+				last_session_id: lastSessionId,
+			},
+		});
+	}
+
+	let supersededInBatch = 0;
+	let maxSessionId = lastSessionId;
+	const runTxn = db.transaction(() => {
+		for (const plan of plans) {
+			supersededInBatch += applySessionPlan(db, plan, deviceId);
+			if (plan.session_id > maxSessionId) maxSessionId = plan.session_id;
+		}
+	});
+	runTxn();
+
+	const processedAfter = processedBefore + plans.length;
+	const supersededAfter = supersededBefore + supersededInBatch;
+	const remaining = countPendingSessions(db);
+	const totalSessions = Math.max(
+		Number(existingMetadata.total_sessions ?? processedAfter),
+		processedAfter + remaining,
+	);
+
+	if (remaining === 0) {
+		completeMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB, {
+			message: `Session-summary dedup complete (${supersededAfter} rows superseded across ${processedAfter} sessions)`,
+			progressCurrent: processedAfter,
+			progressTotal: totalSessions,
+			metadata: {
+				total_sessions: totalSessions,
+				processed_sessions: processedAfter,
+				superseded_rows: supersededAfter,
+				last_session_id: maxSessionId,
+			},
+		});
+		return false;
+	}
+
+	updateMaintenanceJob(db, SUMMARY_DEDUP_BACKFILL_JOB, {
+		message: `Deduplicated ${processedAfter} of ${totalSessions} sessions (${supersededAfter} rows superseded)`,
+		progressCurrent: processedAfter,
+		progressTotal: totalSessions,
+		metadata: {
+			total_sessions: totalSessions,
+			processed_sessions: processedAfter,
+			superseded_rows: supersededAfter,
+			last_session_id: maxSessionId,
+		},
+	});
+	return true;
+}
+
+export class SummaryDedupBackfillRunner {
+	private readonly dbPath: string;
+	private readonly signal?: AbortSignal;
+	private readonly batchSize: number;
+	private readonly intervalMs: number;
+	private readonly deviceId?: string;
+	private active = false;
+	private timer: ReturnType<typeof setTimeout> | null = null;
+	private currentRun: Promise<void> | null = null;
+
+	constructor(options: SummaryDedupBackfillRunnerOptions = {}) {
+		this.dbPath = resolveDbPath(options.dbPath);
+		this.signal = options.signal;
+		this.batchSize = Math.max(1, options.batchSize ?? 50);
+		this.intervalMs = Math.max(1000, options.intervalMs ?? 5000);
+		this.deviceId = options.deviceId;
+	}
+
+	start(): void {
+		if (this.active) return;
+		this.active = true;
+		this.schedule(100);
+	}
+
+	async stop(): Promise<void> {
+		this.active = false;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+		if (this.currentRun) await this.currentRun;
+	}
+
+	private schedule(delayMs: number): void {
+		if (!this.active || this.signal?.aborted) return;
+		this.timer = setTimeout(() => {
+			this.timer = null;
+			this.currentRun = this.runOnce()
+				.catch((err) => {
+					console.error("Summary-dedup backfill runner tick failed:", err);
+				})
+				.finally(() => {
+					this.currentRun = null;
+					this.schedule(this.intervalMs);
+				});
+		}, delayMs);
+		if (typeof this.timer === "object" && "unref" in this.timer) this.timer.unref();
+	}
+
+	private async runOnce(): Promise<void> {
+		if (!this.active || this.signal?.aborted) return;
+		let db: SqliteDatabase | null = null;
+		try {
+			db = connect(this.dbPath) as SqliteDatabase;
+			const hasMoreWork = await runSummaryDedupBackfillPass(db, {
+				batchSize: this.batchSize,
+				deviceId: this.deviceId,
+			});
+			if (!hasMoreWork) {
+				this.active = false;
+			}
+		} catch (error) {
+			if (db) {
+				failMaintenanceJob(
+					db,
+					SUMMARY_DEDUP_BACKFILL_JOB,
+					error instanceof Error ? error.message : String(error),
+				);
+			}
+			console.warn("Summary-dedup backfill runner failed", error);
+		} finally {
+			db?.close();
+		}
+	}
+}


### PR DESCRIPTION
## Description

PR #799 added `supersedePriorObserverSummaries` to enforce "one active observer summary per session" at the write site, but that guard only fires when a new summary is written for that session. Closed sessions that stopped writing before #799 landed still hold every historical summary row active — e.g., local dogfood sessions with 300+ active `session_summary` rows each.

Post-#799 measurement confirmed steady-state is clean (9.2% summary ratio, zero sessions with multiple active summaries after Apr 19). The remaining problem is purely historical. This PR adds a one-time backfill that applies the existing supersede semantics retroactively: for each session with >1 active `observer_summary`, keep the most-recent row and soft-delete the rest with `superseded_at` / `superseded_by` / `clock_device_id` audit metadata plus a replication delete op so peers drop them too.

The backfill runs automatically on viewer startup via the same sequential coordinator that already handles dedup-key / session-context / ref backfills — no user action required. Manual and legacy-imported summaries (`metadata.source !== "observer_summary"`) are left untouched.

## Changes

- `packages/core/src/summary-dedup-backfill.ts` (new): plan/apply/pass functions, `hasPendingSummaryDedupBackfill` predicate, `SummaryDedupBackfillRunner` class. Mirrors the shape of `dedup-key-backfill.ts`.
- `packages/core/src/summary-dedup-backfill.test.ts` (new): 5 tests — no-op on clean DB, supersede-and-keep-winner, audit metadata correctness, replication-op emission, batched progress tracking.
- `packages/core/src/index.ts`: re-export the new job kind, predicate, pass, and runner.
- `packages/cli/src/commands/serve.ts`: add `Session-summary dedup` entry to the viewer's sequential backfill coordinator, wired to the store's `deviceId` so replication ops are attributed correctly.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint` pass
- [x] `pnpm run test` — 1450 tests pass, including the 5 new backfill tests
- [x] Covered: no-op (0 pending), one session with N summaries (keeps most-recent, supersedes rest), non-observer summaries ignored, replication delete ops emitted, batched progress tracking completes when drained

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No new warnings introduced

Closes codemem-garf.