### PR TITLE
fix(ui): stack feed meta above controls row so filter changes cannot reflow controls (codemem-drod followup)

### DIFF
--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -968,14 +968,12 @@
 
       .feed-controls {
         display: flex;
-        align-items: center;
-        gap: var(--sp-3);
-        flex-wrap: wrap;
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--sp-2);
         margin-bottom: var(--sp-4);
       }
       .feed-controls > .section-meta {
-        flex: 1 1 auto;
-        min-width: 0;
         margin-bottom: 0;
       }
 


### PR DESCRIPTION
## Description

PR #937's attempt to stabilize the feed controls row did not fix the reflow — screenshots showed the controls cluster still wrapping to a second row and flipping from right-aligned to left-aligned when switching "All" → "My memories" because the meta text length still determined whether the controls could fit on the same flex row.

Fix: decouple meta and controls into separate rows permanently by changing `.feed-controls` from a horizontal flex row into a column. Meta occupies row 1, the controls cluster occupies row 2 (with its existing `justify-content: flex-end` handling alignment). Meta text length now has no effect on controls position.

## Changes

- `.feed-controls`: `flex-direction: column; align-items: stretch`, smaller internal gap (`--sp-2` instead of `--sp-3`), drop `flex-wrap` (no longer needed at this level).
- `.feed-controls > .section-meta`: keep `margin-bottom: 0` override; drop the `flex: 1 1 auto; min-width: 0` that was only relevant to the horizontal layout.
- `.feed-controls-right` unchanged — still wraps internally on narrow viewports.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint` pass
- [x] `pnpm --filter @codemem/ui build` succeeds
- [x] Screenshots confirmed the prior fix failed; the stacked layout removes the variable that caused the reflow

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No new warnings introduced

Re-opens codemem-drod (or its followup equivalent).