### PR TITLE
chore(release): bump to 0.28.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.28.0"
+    "version": "0.28.1"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.28.0";
+const PINNED_BACKEND_VERSION = "0.28.1";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.28.0",
+	"version": "0.28.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.28.0",
+	"version": "0.28.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.28.0");
+		expect(VERSION).toBe("0.28.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.28.0";
+export const VERSION = "0.28.1";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.28.0",
+	"version": "0.28.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.28.0";
+const PINNED_BACKEND_VERSION = "0.28.1";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.28.0",
+	"version": "0.28.1",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.28.0",
+	"version": "0.28.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description

Release 0.28.1 — patch release bundling recent UI stabilization, historical data cleanup, the TypeScript 6 / Hono 2 toolchain bump, and Snyk code findings.

## Highlights

### UI / UX
- Feed controls no longer shift horizontally when switching between "All" / "My memories" / "Other people" (#937 + #944). Meta text now sits on its own row above the controls cluster so its length can never reflow the controls.
- Pairing disclosure promoted out of the Advanced diagnostics card into the People & devices card as a first-class "Connect another device" affordance (#938).

### Core
- One-time historical backfill of duplicate observer session summaries (#939). Sessions that accumulated many active `session_summary` rows before the write-path guard landed (PR #799) are now cleaned up automatically on viewer startup via the sequential backfill coordinator — keeping the most recent summary per session and soft-deleting the rest with `superseded_at` / `superseded_by` audit metadata and replication delete ops.

### Dependencies / security
- TypeScript 5.9 → 6.0, @hono/node-server 1.19 → 2.0, plus minor bumps on Biome, hono, vite, vitest, and @modelcontextprotocol/sdk to resolve upstream advisories (#942).
- Snyk code findings across tooling resolved (#943).

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint` pass
- [x] `pnpm run test` — 1452 tests pass
- [x] `pnpm run release:version check` confirms all 11 version locations aligned at 0.28.1

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No new warnings introduced