### PR TITLE
feat(ui): add 'Assign to project' feed kebab action

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck": "pnpm run tsc",
     "check": "pnpm run tsc && pnpm run lint && pnpm run test",
     "codemem": "tsx --conditions source packages/cli/src/index.ts",
+    "dev": "pnpm --filter @codemem/ui run build:watch",
     "prepare": "husky",
     "release:version": "node scripts/release-version.mjs",
     "release:preflight-tag": "bash scripts/release-tag-preflight.sh"

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -1023,6 +1023,87 @@ describe("MemoryStore", () => {
 
 	// -- close ---------------------------------------------------------------
 
+	// -- moveMemoryProject ---------------------------------------------------
+
+	describe("moveMemoryProject", () => {
+		function sessionProject(db: MemoryStore["db"], sessionId: number): string | null {
+			const row = db.prepare("SELECT project FROM sessions WHERE id = ?").get(sessionId) as
+				| { project: string | null }
+				| undefined;
+			return row?.project ?? null;
+		}
+
+		it("updates the parent session's project to the trimmed value", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+
+			const result = store.moveMemoryProject(memId, "  new-project  ");
+			expect(result.project).toBe("new-project");
+			expect(result.session_id).toBe(sessionId);
+			expect(sessionProject(store.db, sessionId)).toBe("new-project");
+		});
+
+		it("reports the number of sibling memories that moved with the session", () => {
+			const sessionId = insertTestSession(store.db);
+			const memA = store.remember(sessionId, "discovery", "Title A", "Body");
+			store.remember(sessionId, "discovery", "Title B", "Body");
+			store.remember(sessionId, "discovery", "Title C", "Body");
+
+			const result = store.moveMemoryProject(memA, "other");
+			expect(result.moved_memory_count).toBe(3);
+		});
+
+		it("excludes inactive siblings from the moved_memory_count", () => {
+			const sessionId = insertTestSession(store.db);
+			const memA = store.remember(sessionId, "discovery", "Title A", "Body");
+			const memB = store.remember(sessionId, "discovery", "Title B", "Body");
+			store.forget(memB);
+
+			const result = store.moveMemoryProject(memA, "other");
+			expect(result.moved_memory_count).toBe(1);
+		});
+
+		it("throws when project is empty or whitespace", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+
+			expect(() => store.moveMemoryProject(memId, "")).toThrow(/non-empty/);
+			expect(() => store.moveMemoryProject(memId, "   ")).toThrow(/non-empty/);
+		});
+
+		it("throws when the memory is not found", () => {
+			expect(() => store.moveMemoryProject(99999, "anything")).toThrow(/memory not found/);
+		});
+
+		it("throws when the memory is inactive", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+			store.forget(memId);
+
+			expect(() => store.moveMemoryProject(memId, "new")).toThrow(/memory not found/);
+		});
+
+		it("recognizes self-ownership from metadata_json on legacy rows with null top-level columns", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "discovery", "Title", "Body");
+			// Simulate a legacy/imported row: clear top-level actor_id /
+			// origin_device_id, but stash the same values inside metadata_json.
+			store.db
+				.prepare(
+					`UPDATE memory_items
+					 SET actor_id = NULL,
+					     origin_device_id = NULL,
+					     metadata_json = ?
+					 WHERE id = ?`,
+				)
+				.run(JSON.stringify({ actor_id: store.actorId, origin_device_id: store.deviceId }), memId);
+
+			// Ownership check should succeed now that metadata_json is parsed.
+			const result = store.moveMemoryProject(memId, "legacy-move");
+			expect(result.project).toBe("legacy-move");
+		});
+	});
+
 	describe("close", () => {
 		it("closes the database connection", () => {
 			const sessionId = insertTestSession(store.db);

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -753,7 +753,13 @@ export class MemoryStore {
 		const rec = item as Record<string, unknown>;
 		// Check top-level columns first (MemoryItem / DB row),
 		// then metadata dict (MemoryResult from search populates provenance there).
-		const meta = (rec.metadata ?? {}) as Record<string, unknown>;
+		// For raw DB rows, metadata_json is a string — parse it so legacy rows
+		// whose actor_id/origin_device_id live inside metadata_json still pass
+		// ownership checks.
+		let meta = (rec.metadata ?? {}) as Record<string, unknown>;
+		if (!rec.metadata && typeof rec.metadata_json === "string") {
+			meta = fromJson(rec.metadata_json);
+		}
 
 		const actorId = cleanStr(rec.actor_id) ?? cleanStr(meta.actor_id);
 		if (actorId === this.actorId) return true;
@@ -1066,6 +1072,68 @@ export class MemoryStore {
 					throw new Error("memory not found after update");
 				}
 				return updated;
+			})
+			.immediate();
+	}
+
+	// moveMemoryProject
+
+	/**
+	 * Reassign a memory to a different project by mutating its parent
+	 * session's project column. Because project attribution is derived
+	 * from sessions.project via JOIN, every memory that shares the
+	 * session moves with it — the caller is responsible for warning the
+	 * user when the session holds more than one memory.
+	 *
+	 * Local-only mutation: the sessions table is not currently part of
+	 * the replication stream, so the move is not propagated to peers.
+	 *
+	 * Throws if the memory is not found, inactive, or not owned by this
+	 * device. Trims the project argument and rejects empty values.
+	 */
+	moveMemoryProject(
+		memoryId: number,
+		project: string,
+	): { session_id: number; project: string; moved_memory_count: number } {
+		const cleanedProject = project.trim();
+		if (!cleanedProject) {
+			throw new Error("project must be a non-empty string");
+		}
+
+		return this.db
+			.transaction(() => {
+				const row = this.d
+					.select()
+					.from(schema.memoryItems)
+					.where(and(eq(schema.memoryItems.id, memoryId), eq(schema.memoryItems.active, 1)))
+					.get() as MemoryItem | undefined;
+				if (!row) {
+					throw new Error("memory not found");
+				}
+				if (!this.memoryOwnedBySelf(row)) {
+					throw new Error("memory not owned by this device");
+				}
+
+				const sessionId = row.session_id;
+				this.d
+					.update(schema.sessions)
+					.set({ project: cleanedProject })
+					.where(eq(schema.sessions.id, sessionId))
+					.run();
+
+				const countRow = this.d
+					.select({ n: sql<number>`count(*)` })
+					.from(schema.memoryItems)
+					.where(
+						and(eq(schema.memoryItems.session_id, sessionId), eq(schema.memoryItems.active, 1)),
+					)
+					.get() as { n: number } | undefined;
+
+				return {
+					session_id: sessionId,
+					project: cleanedProject,
+					moved_memory_count: Number(countRow?.n ?? 1),
+				};
 			})
 			.immediate();
 	}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
 		"clean": "rm -rf ../viewer-server/static",
 		"dev": "vite",
 		"build": "vite build --mode production && node ./scripts/stage-viewer-static.mjs",
-		"build:watch": "vite build --watch --mode development",
+		"build:watch": "node ./scripts/stage-viewer-static.mjs && vite build --watch --mode development",
 		"test": "pnpm exec vitest run",
 		"typecheck": "tsc -p tsconfig.json --noEmit"
 	},
@@ -15,6 +15,7 @@
 		"@radix-ui/react-collapsible": "^1.1.12",
 		"@radix-ui/react-dialog": "^1.1.15",
 		"@radix-ui/react-dropdown-menu": "^2.1.16",
+		"@radix-ui/react-popover": "^1.1.15",
 		"@radix-ui/react-radio-group": "^1.3.8",
 		"@radix-ui/react-select": "^2.2.6",
 		"@radix-ui/react-switch": "^1.2.6",

--- a/packages/ui/src/components/primitives/autocomplete-input.tsx
+++ b/packages/ui/src/components/primitives/autocomplete-input.tsx
@@ -1,0 +1,175 @@
+/* Ant.design-style Autocomplete built on top of Radix Popover.
+ *
+ * Radix has no native autocomplete primitive (see
+ * radix-ui/primitives#1486). This wraps a plain <input> with a
+ * Popover-anchored filtered suggestion list, arrow-key navigation,
+ * Enter/Tab commit, Escape dismiss, and portal-safe positioning so it
+ * renders correctly inside modal dialogs with clipping parents.
+ *
+ * Free-text entry is always allowed — suggestions are purely
+ * accelerators, not an exclusive set. */
+
+import * as Popover from "@radix-ui/react-popover";
+import type { JSX, Ref } from "preact";
+import { forwardRef } from "preact/compat";
+import { useEffect, useImperativeHandle, useMemo, useRef, useState } from "preact/hooks";
+
+type InputAttrs = Omit<
+	JSX.InputHTMLAttributes<HTMLInputElement>,
+	"onChange" | "onInput" | "value" | "ref"
+>;
+
+export type AutocompleteInputProps = InputAttrs & {
+	value: string;
+	onValueChange: (value: string) => void;
+	suggestions: string[];
+	onSubmit?: () => void;
+	maxSuggestions?: number;
+};
+
+export const AutocompleteInput = forwardRef(function AutocompleteInput(
+	{
+		value,
+		onValueChange,
+		suggestions,
+		onSubmit,
+		maxSuggestions = 20,
+		onKeyDown,
+		onFocus,
+		onBlur,
+		className,
+		...inputProps
+	}: AutocompleteInputProps,
+	externalRef: Ref<HTMLInputElement>,
+) {
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	useImperativeHandle(externalRef, () => inputRef.current as HTMLInputElement, []);
+
+	const [open, setOpen] = useState(false);
+	const [activeIndex, setActiveIndex] = useState(-1);
+
+	const filtered = useMemo(() => {
+		const q = value.trim().toLowerCase();
+		const base = q ? suggestions.filter((s) => s.toLowerCase().includes(q)) : suggestions;
+		return base.slice(0, maxSuggestions);
+	}, [value, suggestions, maxSuggestions]);
+
+	useEffect(() => {
+		if (activeIndex >= filtered.length) setActiveIndex(filtered.length - 1);
+	}, [filtered.length, activeIndex]);
+
+	const shouldOpen = open && filtered.length > 0;
+
+	const commit = (selection: string) => {
+		onValueChange(selection);
+		setOpen(false);
+		setActiveIndex(-1);
+		inputRef.current?.focus();
+	};
+
+	const handleKeyDown: JSX.KeyboardEventHandler<HTMLInputElement> = (event) => {
+		if (event.key === "ArrowDown") {
+			event.preventDefault();
+			setOpen(true);
+			setActiveIndex((i) => (filtered.length === 0 ? -1 : Math.min(i + 1, filtered.length - 1)));
+			return;
+		}
+		if (event.key === "ArrowUp") {
+			event.preventDefault();
+			if (!open) setOpen(true);
+			setActiveIndex((i) => Math.max(i - 1, -1));
+			return;
+		}
+		if (event.key === "Escape" && shouldOpen) {
+			event.preventDefault();
+			setOpen(false);
+			setActiveIndex(-1);
+			return;
+		}
+		if ((event.key === "Tab" || event.key === "Enter") && activeIndex >= 0) {
+			const pick = filtered[activeIndex];
+			if (pick) {
+				event.preventDefault();
+				commit(pick);
+				return;
+			}
+		}
+		if (event.key === "Enter" && onSubmit) {
+			event.preventDefault();
+			onSubmit();
+			return;
+		}
+		onKeyDown?.(event);
+	};
+
+	return (
+		<Popover.Root open={shouldOpen} onOpenChange={setOpen}>
+			<Popover.Anchor asChild>
+				<input
+					{...inputProps}
+					ref={inputRef}
+					className={className}
+					value={value}
+					onInput={(event) => {
+						onValueChange((event.currentTarget as HTMLInputElement).value);
+						setOpen(true);
+						setActiveIndex(-1);
+					}}
+					onFocus={(event) => {
+						// Don't open on focus — only open once the user signals
+						// intent (types, or presses arrow-down). Opening on focus
+						// makes the dropdown appear immediately when the dialog
+						// mounts with autoFocus, which hides the input.
+						onFocus?.(event);
+					}}
+					onBlur={(event) => {
+						// Let click-on-option fire before closing.
+						window.setTimeout(() => setOpen(false), 120);
+						onBlur?.(event);
+					}}
+					onKeyDown={handleKeyDown}
+					role="combobox"
+					aria-autocomplete="list"
+					aria-expanded={shouldOpen}
+					aria-controls="autocompleteListbox"
+					aria-activedescendant={
+						activeIndex >= 0 ? `autocomplete-option-${activeIndex}` : undefined
+					}
+				/>
+			</Popover.Anchor>
+			<Popover.Portal>
+				<Popover.Content
+					align="start"
+					className="autocomplete-popover"
+					onOpenAutoFocus={(event) => event.preventDefault()}
+					onCloseAutoFocus={(event) => event.preventDefault()}
+					sideOffset={4}
+					style={{ width: "var(--radix-popover-trigger-width)" }}
+				>
+					<div className="autocomplete-listbox" id="autocompleteListbox" role="listbox">
+						{filtered.map((suggestion, index) => {
+							const active = index === activeIndex;
+							return (
+								<div
+									aria-selected={active}
+									className={active ? "autocomplete-option active" : "autocomplete-option"}
+									id={`autocomplete-option-${index}`}
+									key={suggestion}
+									onMouseDown={(event) => {
+										event.preventDefault();
+										commit(suggestion);
+									}}
+									onMouseEnter={() => setActiveIndex(index)}
+									role="option"
+									tabIndex={-1}
+								>
+									{suggestion}
+								</div>
+							);
+						})}
+					</div>
+				</Popover.Content>
+			</Popover.Portal>
+		</Popover.Root>
+	);
+});

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -29,6 +29,7 @@ export {
 	loadMemoriesPage,
 	loadSummaries,
 	loadSummariesPage,
+	moveMemoryProject,
 	tracePack,
 	updateMemoryVisibility,
 } from "./api/memories";

--- a/packages/ui/src/lib/api/memories.ts
+++ b/packages/ui/src/lib/api/memories.ts
@@ -32,6 +32,24 @@ export async function updateMemoryVisibility(
 	return payload;
 }
 
+export async function moveMemoryProject(
+	memoryId: number,
+	project: string,
+): Promise<{ session_id: number; project: string; moved_memory_count: number }> {
+	const resp = await fetch("/api/memories/project", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ memory_id: memoryId, project }),
+	});
+	const { text, payload } = await readJsonPayload<{
+		session_id: number;
+		project: string;
+		moved_memory_count: number;
+	}>(resp);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	return payload;
+}
+
 export async function forgetMemory(memoryId: number): Promise<{ status?: string }> {
 	const resp = await fetch("/api/memories/forget", {
 		method: "POST",

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../../lib/format";
 import { showGlobalNotice } from "../../../lib/notice";
 import { state } from "../../../lib/state";
-import { openSyncConfirmDialog } from "../../sync/sync-dialogs";
+import { openSyncConfirmDialog, openSyncInputDialog } from "../../sync/sync-dialogs";
 import {
 	renderFactsContent,
 	renderNarrativeContent,
@@ -91,6 +91,7 @@ export function FeedItemCard({
 	);
 	const [savingVisibility, setSavingVisibility] = useState(false);
 	const [deletingMemory, setDeletingMemory] = useState(false);
+	const [movingProject, setMovingProject] = useState(false);
 	const summarySections = summaryObj ? renderSummarySections(summaryObj) : [];
 
 	useEffect(() => {
@@ -188,6 +189,62 @@ export function FeedItemCard({
 		}
 	}
 
+	async function moveProject() {
+		const currentProject = String(item.project || "").trim();
+		const initialValue = currentProject;
+		const titleText = String(displayTitle || "this memory").trim();
+		const truncatedTitle =
+			titleText.length > 80 ? `${titleText.slice(0, 79).trimEnd()}…` : titleText;
+		const description = currentProject
+			? `Move "${truncatedTitle}" from "${currentProject}" to another project. Pick an existing project or type a new name. Every memory in the same session will be reassigned together.`
+			: `Assign a project to "${truncatedTitle}". Pick an existing project or type a new name. Every memory in the same session will be reassigned together.`;
+		let suggestions: string[] = [];
+		try {
+			const all = await api.loadProjects();
+			suggestions = all.filter((p) => p && p !== currentProject);
+		} catch {
+			// Non-fatal — fall back to free-text entry without suggestions.
+		}
+		const nextProject = await openSyncInputDialog({
+			title: "Assign to project",
+			description,
+			initialValue,
+			placeholder: "Pick one or type a new project name",
+			suggestions,
+			confirmLabel: "Move",
+			cancelLabel: "Cancel",
+			validate: (value) => {
+				const trimmed = value.trim();
+				if (!trimmed) return "Enter a project name.";
+				if (trimmed === currentProject) return "Already assigned to this project.";
+				return null;
+			},
+		});
+		if (nextProject == null) return;
+		const target = nextProject.trim();
+		if (!target || target === currentProject) return;
+
+		setMovingProject(true);
+		try {
+			const result = await api.moveMemoryProject(memoryId, target);
+			const count = Number(result.moved_memory_count || 1);
+			const label =
+				count > 1
+					? `Moved ${count} memories from this session to "${result.project}".`
+					: `Moved to "${result.project}".`;
+			showGlobalNotice(label);
+			await onReload();
+			onViewRefresh();
+		} catch (error) {
+			showGlobalNotice(
+				error instanceof Error ? error.message : "Failed to move memory.",
+				"warning",
+			);
+		} finally {
+			setMovingProject(false);
+		}
+	}
+
 	async function forgetMemory() {
 		const titleText = String(displayTitle || "this memory").trim();
 		const truncatedTitle =
@@ -272,7 +329,9 @@ export function FeedItemCard({
 					),
 					Boolean(item.owned_by_self) && memoryId > 0
 						? h(FeedItemMenu, {
+								assignProjectDisabled: movingProject,
 								disabled: deletingMemory,
+								onAssignProject: () => void moveProject(),
 								onForget: () => void forgetMemory(),
 								title: String(displayTitle || "memory"),
 							})

--- a/packages/ui/src/tabs/feed/components/FeedItemMenu.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemMenu.tsx
@@ -2,11 +2,15 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { h } from "preact";
 
 export function FeedItemMenu({
+	assignProjectDisabled,
 	disabled,
+	onAssignProject,
 	onForget,
 	title,
 }: {
+	assignProjectDisabled: boolean;
 	disabled: boolean;
+	onAssignProject: () => void;
 	onForget: () => void;
 	title: string;
 }) {
@@ -28,6 +32,15 @@ export function FeedItemMenu({
 			h(
 				DropdownMenu.Content,
 				{ align: "end", className: "feed-menu-panel", side: "bottom", sideOffset: 4 },
+				h(
+					DropdownMenu.Item,
+					{
+						className: "feed-menu-item",
+						disabled: assignProjectDisabled,
+						onSelect: () => onAssignProject(),
+					},
+					assignProjectDisabled ? "Moving…" : "Assign to project…",
+				),
 				h(
 					DropdownMenu.Item,
 					{ className: "feed-menu-item danger", disabled, onSelect: () => onForget() },

--- a/packages/ui/src/tabs/sync/sync-dialogs/components/sync-dialog-body.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs/components/sync-dialog-body.tsx
@@ -5,6 +5,7 @@
  * value does not resolve the outer dialog. */
 
 import { useEffect, useState } from "preact/hooks";
+import { AutocompleteInput } from "../../../../components/primitives/autocomplete-input";
 import { DialogCloseButton } from "../../../../components/primitives/dialog-close-button";
 import { TextInput } from "../../../../components/primitives/text-input";
 import { dialogToneClassName, resolveCurrentDialog } from "../internal";
@@ -76,24 +77,41 @@ export function SyncDialogBody({
 				) : null}
 				{request.kind === "input" ? (
 					<div className="field">
-						<TextInput
-							aria-describedby={errorText ? `${descriptionId} ${inputErrorId}` : descriptionId}
-							autoFocus
-							className={errorText ? "sync-dialog-input sync-field-error" : "sync-dialog-input"}
-							data-sync-primary-action="true"
-							onInput={(event) => {
-								setInputValue(event.currentTarget.value);
-								if (errorText) setErrorText(null);
-							}}
-							onKeyDown={(event) => {
-								if (event.key !== "Enter") return;
-								event.preventDefault();
-								submit();
-							}}
-							placeholder={request.placeholder}
-							type="text"
-							value={inputValue}
-						/>
+						{request.suggestions?.length ? (
+							<AutocompleteInput
+								aria-describedby={errorText ? `${descriptionId} ${inputErrorId}` : descriptionId}
+								autoFocus
+								className={errorText ? "sync-dialog-input sync-field-error" : "sync-dialog-input"}
+								data-sync-primary-action="true"
+								onSubmit={submit}
+								onValueChange={(value) => {
+									setInputValue(value);
+									if (errorText) setErrorText(null);
+								}}
+								placeholder={request.placeholder}
+								suggestions={request.suggestions}
+								value={inputValue}
+							/>
+						) : (
+							<TextInput
+								aria-describedby={errorText ? `${descriptionId} ${inputErrorId}` : descriptionId}
+								autoFocus
+								className={errorText ? "sync-dialog-input sync-field-error" : "sync-dialog-input"}
+								data-sync-primary-action="true"
+								onInput={(event) => {
+									setInputValue(event.currentTarget.value);
+									if (errorText) setErrorText(null);
+								}}
+								onKeyDown={(event) => {
+									if (event.key !== "Enter") return;
+									event.preventDefault();
+									submit();
+								}}
+								placeholder={request.placeholder}
+								type="text"
+								value={inputValue}
+							/>
+						)}
 						{errorText ? (
 							<div className="sync-field-hint" id={inputErrorId}>
 								{errorText}

--- a/packages/ui/src/tabs/sync/sync-dialogs/types.ts
+++ b/packages/ui/src/tabs/sync/sync-dialogs/types.ts
@@ -23,6 +23,7 @@ export type InputDialogRequest = {
 	description: string;
 	initialValue?: string;
 	placeholder?: string;
+	suggestions?: string[];
 	title: string;
 	validate?: (value: string) => string | null;
 };

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -2583,7 +2583,8 @@
         align-items: center;
       }
       .sync-dialog-input {
-        width: 100%;
+        width: calc(100% - 6px);
+        margin: 3px;
         padding: var(--sp-2) var(--sp-3);
         border-radius: var(--radius-sm);
         border: 1px solid var(--border);
@@ -2591,11 +2592,44 @@
         color: var(--text-primary);
         font-family: var(--font-sans);
         font-size: 13px;
+        box-sizing: border-box;
       }
       .sync-dialog-input:focus {
-        outline: none;
         border-color: var(--accent);
-        box-shadow: 0 0 0 3px var(--focus-ring);
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 1px;
+      }
+      .autocomplete-popover {
+        background: var(--surface-1, var(--bg-elevated));
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+        max-height: 260px;
+        overflow-y: auto;
+        padding: 4px;
+        z-index: 120;
+      }
+      .autocomplete-listbox {
+        display: flex;
+        flex-direction: column;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .autocomplete-option {
+        padding: 6px 10px;
+        border-radius: var(--radius-sm);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 13px;
+        cursor: pointer;
+        user-select: none;
+      }
+      .autocomplete-option:hover,
+      .autocomplete-option.active,
+      .autocomplete-option[aria-selected="true"] {
+        background: var(--surface-2, rgba(255, 255, 255, 0.06));
+        color: var(--accent);
       }
       .sync-dialog-confirm.danger {
         background: rgba(182, 75, 47, 0.12);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -388,6 +388,75 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("moves an owned memory to a new project via /api/memories/project", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Memory on wrong project",
+				});
+
+				const res = await app.request("/api/memories/project", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId, project: "new-project" }),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					session_id: number;
+					project: string;
+					moved_memory_count: number;
+				};
+				expect(body.project).toBe("new-project");
+				expect(body.session_id).toBe(sessionId);
+				expect(body.moved_memory_count).toBe(1);
+
+				const row = store.db
+					.prepare("SELECT project FROM sessions WHERE id = ?")
+					.get(sessionId) as { project: string };
+				expect(row.project).toBe("new-project");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects /api/memories/project with empty project", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const memoryId = insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Memory",
+				});
+
+				const res = await app.request("/api/memories/project", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Origin: "http://127.0.0.1:38888",
+					},
+					body: JSON.stringify({ memory_id: memoryId, project: "   " }),
+				});
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as { error?: string };
+				expect(body.error).toContain("project");
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("forgets an owned memory via the viewer API", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/memory.ts
+++ b/packages/viewer-server/src/routes/memory.ts
@@ -529,6 +529,36 @@ export function memoryRoutes(getStore: StoreFactory) {
 		}
 	});
 
+	// POST /api/memories/project
+	app.post("/api/memories/project", async (c) => {
+		const store = getStore();
+		let body: Record<string, unknown>;
+		try {
+			body = await c.req.json<Record<string, unknown>>();
+		} catch {
+			return c.json({ error: "invalid JSON" }, 400);
+		}
+		const memoryId = parseStrictInteger(
+			typeof body.memory_id === "string" ? body.memory_id : String(body.memory_id ?? ""),
+		);
+		if (memoryId == null || memoryId <= 0) {
+			return c.json({ error: "memory_id must be int" }, 400);
+		}
+		const project = String(body.project ?? "").trim();
+		if (!project) {
+			return c.json({ error: "project must be a non-empty string" }, 400);
+		}
+		try {
+			const result = store.moveMemoryProject(memoryId, project);
+			return c.json(result);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			if (msg.includes("not found")) return c.json({ error: msg }, 404);
+			if (msg.includes("not owned")) return c.json({ error: msg }, 403);
+			return c.json({ error: msg }, 400);
+		}
+	});
+
 	// POST /api/memories/forget
 	app.post("/api/memories/forget", async (c) => {
 		const store = getStore();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-radio-group':
         specifier: ^1.3.8
         version: 1.3.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1675,6 +1678,19 @@ packages:
 
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4872,6 +4888,26 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(react@19.2.4)
+
+  '@radix-ui/react-popover@1.1.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
       aria-hidden: 1.2.6
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)


### PR DESCRIPTION
## Description

Add an "Assign to project…" action to the feed item kebab menu, letting users reassign a memory to a different project (or assign a project to memories that have none) directly from the feed.

Opens a dialog pre-filled with the memory's current project (if any); on submit, mutates the memory's parent session's `project` column. The success toast surfaces how many sibling memories moved with it — project attribution is derived from `sessions.project` via JOIN, so the whole session moves together.

## Changes

- **Core**: new `MemoryStore.moveMemoryProject(memoryId, project)` — owner check, transactional session update, returns `{ session_id, project, moved_memory_count }`. Also hardens `memoryOwnedBySelf` to parse `metadata_json` when passed a raw DB row, so legacy/imported memories whose `actor_id`/`origin_device_id` live only in metadata still pass ownership (fix also covers `updateMemoryVisibility` and `forget`).
- **Viewer-server**: `POST /api/memories/project` endpoint with 400/403/404 handling.
- **UI**: new `AutocompleteInput` primitive built on `@radix-ui/react-popover` (ant.design-style anchored suggestion list with keyboard nav, portal-safe inside dialogs). The dialog uses it when `suggestions` is present, falls back to `TextInput` otherwise.
- **Dialog polish**: focus ring now uses `outline` + `outline-offset` with 3px input margin so it can't be clipped by `.modal-body`'s `overflow-y: auto`.
- **Kebab menu**: adds "Assign to project…" above "Forget memory", with a `movingProject` disabled state.

## Scope

**Local-only move.** The `sessions` table isn't part of the replication stream today, so project reassignment only applies on the device where it's performed. Multi-device propagation is a separate follow-up.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint` pass
- [x] `pnpm run test` — 1461 tests pass (6 new store tests including the legacy-row ownership regression, 2 new route tests)
- [x] `pnpm --filter @codemem/ui build` succeeds

## Checklist

- [x] Code follows project style (`pnpm run lint` passes)
- [x] Self-review completed
- [x] No new warnings introduced