### PR TITLE
fix(cli): don't warn 'deprecated --foreground' when used with serve start subcommand

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -858,12 +858,18 @@ serveCmd.addOption(new Option("--restart", "restart background viewer").hideHelp
 export const serveCommand = serveCmd.action(
 	async (action: string | undefined, opts: LegacyServeOptions) => {
 		try {
-			// Emit deprecation warnings for legacy flags
-			if (opts.stop) emitDeprecationWarning("--stop", "codemem serve stop");
-			if (opts.restart) emitDeprecationWarning("--restart", "codemem serve restart");
-			if (opts.background) emitDeprecationWarning("--background", "codemem serve start");
-			if (opts.foreground)
-				emitDeprecationWarning("--foreground", "codemem serve start --foreground");
+			// Emit deprecation warnings only when the legacy bare-flag form is
+			// used (no lifecycle action). When an action is present (start,
+			// stop, restart) the flags are being consumed by the modern
+			// subcommand form — e.g. `codemem serve start --foreground` — and
+			// should not be flagged as deprecated.
+			if (action === undefined) {
+				if (opts.stop) emitDeprecationWarning("--stop", "codemem serve stop");
+				if (opts.restart) emitDeprecationWarning("--restart", "codemem serve restart");
+				if (opts.background) emitDeprecationWarning("--background", "codemem serve start");
+				if (opts.foreground)
+					emitDeprecationWarning("--foreground", "codemem serve start --foreground");
+			}
 
 			const normalizedAction =
 				action === undefined


### PR DESCRIPTION
## Description

Running `codemem serve start --foreground` emitted:

```
Warning: '--foreground' is deprecated, use 'codemem serve start --foreground' instead.
```

— literally telling the user to run the same invocation they just did. The legacy-flag deprecation warnings fired whenever `opts.foreground` / `opts.stop` / etc. were truthy, regardless of whether a subcommand action was present. So the modern form (`serve start --foreground`) and the legacy bare-flag form (`serve --foreground`) both tripped the warning.

## Changes

- `packages/cli/src/commands/serve.ts`: gate all four legacy-flag warnings (`--stop`, `--restart`, `--background`, `--foreground`) on `action === undefined`. When a lifecycle subcommand is present the flags are being consumed by the modern form and aren't deprecated.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint`, `pnpm run test` pass (1461 tests)
- [x] Manually verified `codemem serve start --foreground` no longer prints the deprecation line

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced