### PR TITLE
fix(core): stop dedup-key backfill from announcing 'pending' after completion

### DIFF
--- a/packages/core/src/dedup-key-backfill.test.ts
+++ b/packages/core/src/dedup-key-backfill.test.ts
@@ -50,6 +50,50 @@ describe("dedup-key backfill maintenance", () => {
 		}
 	});
 
+	it("re-processes rows inserted after completion by resetting the cursor on terminal state", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = insertTestSession(db);
+			seedMemoryWithoutDedupKey(db, sessionId, "Initial title");
+			await runDedupKeyBackfillPass(db, { batchSize: 10 });
+			expect(getMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB)?.status).toBe("completed");
+
+			// Simulate a replicated or bootstrap-snapshot row landing AFTER
+			// the prior pass marked itself completed. Previously the pass
+			// would resume from last_cursor_id (past this row's id) and
+			// never touch it, while the predicate kept reporting pending —
+			// the "backfill announced every startup" symptom reported by
+			// the user.
+			db.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+				 workspace_id, dedup_key)
+				 VALUES (?, 'discovery', 'Replicated row with no dedup_key', 'Body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', 'shared:default', NULL)`,
+			).run(sessionId, "2026-04-22T00:00:00Z", "2026-04-22T00:00:00Z");
+			const newRowId = Number(
+				(
+					db.prepare("SELECT MAX(id) AS id FROM memory_items WHERE dedup_key IS NULL").get() as {
+						id: number;
+					}
+				).id,
+			);
+
+			expect(hasPendingDedupKeyBackfill(db)).toBe(true);
+
+			// Re-running the pass must re-scan from id=0 (cursor reset on
+			// terminal state) and write a dedup_key for the replicated row.
+			await runDedupKeyBackfillPass(db, { batchSize: 10 });
+			const row = db.prepare("SELECT dedup_key FROM memory_items WHERE id = ?").get(newRowId) as {
+				dedup_key: string | null;
+			};
+			expect(row.dedup_key).toBeTruthy();
+			expect(hasPendingDedupKeyBackfill(db)).toBe(false);
+		} finally {
+			db.close();
+		}
+	});
+
 	it("tracks progress and completes when backfillable rows are exhausted", async () => {
 		const db = new Database(":memory:");
 		try {

--- a/packages/core/src/dedup-key-backfill.ts
+++ b/packages/core/src/dedup-key-backfill.ts
@@ -29,6 +29,12 @@ export interface DedupKeyBackfillRunnerOptions {
 }
 
 export function hasPendingDedupKeyBackfill(db: SqliteDatabase): boolean {
+	// Work-driven predicate: kept this way so replicated / bootstrapped rows
+	// inserted after a prior completion (applyReplicationOps and
+	// applyBootstrapSnapshot don't set dedup_key) do get picked up on the
+	// next `serve start`. The "announces pending every startup" symptom is
+	// fixed by resetting the cursor in runDedupKeyBackfillPass when the
+	// prior job is in a terminal state — see that function.
 	return planMemoryDedupKeys(db, { updateLimit: 1 }).backfillable > 0;
 }
 
@@ -44,7 +50,14 @@ export async function runDedupKeyBackfillPass(
 	const existingJob = getMaintenanceJob(db, DEDUP_KEY_BACKFILL_JOB);
 	const existingMetadata = getExistingMetadata(db);
 	const batchSize = Math.max(1, options.batchSize ?? 250);
-	const lastCursorId = Number(existingMetadata.last_cursor_id ?? 0);
+	// Reset the cursor when the prior job is in a terminal state so rows
+	// inserted after that completion (e.g. from replication or bootstrap
+	// snapshots, which don't populate dedup_key) are picked up on the next
+	// pass. Without this reset the pass resumes past them forever and the
+	// `backfillable > 0` predicate keeps re-triggering the coordinator.
+	const startingFresh =
+		!existingJob || existingJob.status === "completed" || existingJob.status === "failed";
+	const lastCursorId = startingFresh ? 0 : Number(existingMetadata.last_cursor_id ?? 0);
 	const plan = planMemoryDedupKeys(db, {
 		rowLimit: batchSize,
 		updateLimit: batchSize,
@@ -73,10 +86,12 @@ export async function runDedupKeyBackfillPass(
 		return false;
 	}
 
-	const processedBefore = Number(existingMetadata.processed_updates ?? 0);
-	let progressTotal = Number(existingMetadata.total_backfillable ?? 0);
+	const processedBefore = startingFresh ? 0 : Number(existingMetadata.processed_updates ?? 0);
+	let progressTotal = startingFresh ? 0 : Number(existingMetadata.total_backfillable ?? 0);
 	const processedAfter = processedBefore + plan.updates.length;
-	const cumulativeSkipped = Number(existingMetadata.skipped_rows ?? 0) + plan.skipped;
+	const cumulativeSkipped = startingFresh
+		? plan.skipped
+		: Number(existingMetadata.skipped_rows ?? 0) + plan.skipped;
 	const reachedEnd = plan.exhausted;
 	const remainingWork = !reachedEnd;
 

--- a/packages/core/src/summary-dedup-backfill.ts
+++ b/packages/core/src/summary-dedup-backfill.ts
@@ -72,6 +72,11 @@ function countPendingSessions(db: SqliteDatabase): number {
 }
 
 export function hasPendingSummaryDedupBackfill(db: SqliteDatabase): boolean {
+	// Intentionally work-driven, not status-gated: this backfill is a
+	// continuous cleanup — sync can bring in new observer summaries that
+	// raise a session's active-summary count above 1 long after the initial
+	// job row was marked completed. Announcing and re-running on the next
+	// viewer start is the intended behavior in that case.
 	return countPendingSessions(db) > 0;
 }
 


### PR DESCRIPTION
## Description

The dedup-key backfill announced "1 backfill job(s) pending — starting sequential runners" on every `codemem serve start`, even though the job row was marked `completed`. Root cause: `hasPendingDedupKeyBackfill` re-scans the memory_items table from id=0 every call (`planMemoryDedupKeys({ updateLimit: 1 }).backfillable > 0`). Meanwhile `runDedupKeyBackfillPass` resumed from `last_cursor_id` at the end of the table, so any rows before that cursor — including newly-replicated rows that `applyReplicationOps` and `applyBootstrapSnapshot` insert without a `dedup_key` — stayed untouched. The predicate kept reporting pending, the pass did nothing, and the coordinator looped.

Fix: keep the predicate work-driven (so post-completion replicated inserts *do* trigger a new pass), but reset the pass's cursor to 0 when the prior job is in a terminal state (completed / failed / missing). That way a fresh pass re-scans from the beginning and actually writes dedup_keys for rows the previous cursor moved past.

## Changes

- `packages/core/src/dedup-key-backfill.ts`: when `existingJob.status` is completed / failed / missing, treat the pass as a fresh start — reset `lastCursorId` to 0 and re-zero the `processed_updates` / `skipped_rows` accumulators.
- Regression test: seed a row after a successful completion, assert the predicate re-fires AND the next pass writes a dedup_key for it.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint`, `pnpm run test` pass (1462 tests)
- [x] New regression test covers the "replicated row lands after completion" case
- [x] Predicate/pass cursor-reset pattern matches the one in `summary-dedup-backfill.ts`

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced