### PR TITLE
feat(cli,viewer): add 'codemem maintenance status' + keep completed jobs briefly visible

### DIFF
--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -1,0 +1,120 @@
+/* `codemem maintenance` — inspect background backfill / migration jobs.
+ *
+ * Opens the local sqlite db directly (no viewer required) and reads the
+ * `maintenance_jobs` table, surfacing status, progress, and timestamps.
+ * Pairs with the viewer's /api/stats which only shows active + recently-
+ * completed jobs.
+ */
+
+import * as p from "@clack/prompts";
+import {
+	listMaintenanceJobs,
+	type MaintenanceJobSnapshot,
+	MemoryStore,
+	resolveDbPath,
+} from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+import {
+	addDbOption,
+	addJsonOption,
+	type DbOpts,
+	type JsonOpts,
+	resolveDbOpt,
+} from "../shared-options.js";
+
+const maintenanceCmd = new Command("maintenance")
+	.configureHelp(helpStyle)
+	.description("Inspect background maintenance / backfill jobs");
+
+const statusCmd = new Command("status")
+	.configureHelp(helpStyle)
+	.description("Print current status of all maintenance jobs");
+
+addDbOption(statusCmd);
+addJsonOption(statusCmd);
+
+statusCmd.action((opts: DbOpts & JsonOpts) => {
+	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+	try {
+		const jobs = listMaintenanceJobs(store.db);
+		if (opts.json) {
+			console.log(JSON.stringify({ jobs }, null, 2));
+			return;
+		}
+		printJobsTable(jobs);
+	} finally {
+		store.close();
+	}
+});
+
+maintenanceCmd.addCommand(statusCmd);
+
+export const maintenanceCommand = maintenanceCmd;
+
+function printJobsTable(jobs: MaintenanceJobSnapshot[]): void {
+	p.intro("codemem maintenance");
+	if (jobs.length === 0) {
+		p.log.info("No maintenance jobs recorded in this database.");
+		p.outro("done");
+		return;
+	}
+
+	// Sort: running first, then pending, then recently-finished, then older.
+	const statusRank: Record<string, number> = {
+		running: 0,
+		pending: 1,
+		failed: 2,
+		cancelled: 3,
+		completed: 4,
+	};
+	const sorted = [...jobs].sort((a, b) => {
+		const rankDiff = (statusRank[a.status] ?? 9) - (statusRank[b.status] ?? 9);
+		if (rankDiff !== 0) return rankDiff;
+		return b.updated_at.localeCompare(a.updated_at);
+	});
+
+	for (const job of sorted) {
+		const progress = formatProgress(job);
+		const when = job.finished_at
+			? `finished ${shortAge(job.finished_at)} ago`
+			: job.started_at
+				? `started ${shortAge(job.started_at)} ago`
+				: `updated ${shortAge(job.updated_at)} ago`;
+		const header = `${job.kind} · ${job.status}${progress ? ` · ${progress}` : ""} · ${when}`;
+		const body = [job.title, job.message, job.error ? `error: ${job.error}` : null]
+			.filter(Boolean)
+			.join("\n");
+		const logger =
+			job.status === "failed"
+				? p.log.error
+				: job.status === "completed"
+					? p.log.success
+					: p.log.step;
+		logger(`${header}\n${body}`);
+	}
+
+	p.outro("done");
+}
+
+function formatProgress(job: MaintenanceJobSnapshot): string | null {
+	const { current, total, unit } = job.progress;
+	if (!current && !total) return null;
+	const unitLabel = unit || "items";
+	if (total == null || total <= 0) return `${current.toLocaleString()} ${unitLabel}`;
+	const pct = Math.round((100 * current) / total);
+	return `${current.toLocaleString()}/${total.toLocaleString()} ${unitLabel} (${pct}%)`;
+}
+
+function shortAge(iso: string): string {
+	const parsed = Date.parse(iso);
+	if (!Number.isFinite(parsed)) return iso;
+	const seconds = Math.max(0, Math.round((Date.now() - parsed) / 1000));
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.round(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.round(minutes / 60);
+	if (hours < 48) return `${hours}h`;
+	const days = Math.round(hours / 24);
+	return `${days}d`;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import { embedCommand } from "./commands/embed.js";
 import { enqueueRawEventCommand } from "./commands/enqueue-raw-event.js";
 import { exportMemoriesCommand } from "./commands/export-memories.js";
 import { importMemoriesCommand } from "./commands/import-memories.js";
+import { maintenanceCommand } from "./commands/maintenance.js";
 import { mcpCommand } from "./commands/mcp.js";
 import {
 	forgetMemoryCommand,
@@ -177,6 +178,7 @@ program.addCommand(dbCommand);
 program.addCommand(exportMemoriesCommand);
 program.addCommand(importMemoriesCommand);
 program.addCommand(statsCommand);
+program.addCommand(maintenanceCommand);
 program.addCommand(embedCommand);
 program.addCommand(recentCommand);
 program.addCommand(searchCommand);

--- a/packages/ui/src/tabs/health/render/health-overview.ts
+++ b/packages/ui/src/tabs/health/render/health-overview.ts
@@ -192,17 +192,25 @@ export function renderHealthOverview() {
 				? `${current.toLocaleString()}/${total.toLocaleString()} ${unit}${pct}`
 				: `${current.toLocaleString()} ${unit}`;
 		const isFailed = job.status === "failed";
-		const detail = isFailed ? String(job.error || "unknown error").trim() : undefined;
+		const isCompleted = job.status === "completed";
+		const value = isFailed ? "Failed" : isCompleted ? "Complete" : progress;
+		const detail = isFailed
+			? String(job.error || "unknown error").trim()
+			: isCompleted
+				? progress
+				: undefined;
 		return buildHealthCard({
 			key: String(job.kind || job.title || "background-maintenance"),
 			label: String(job.title || job.kind || "Background maintenance"),
-			value: isFailed ? "Failed" : progress,
+			value,
 			detail,
-			icon: isFailed ? "alert-triangle" : "loader",
+			icon: isFailed ? "alert-triangle" : isCompleted ? "check-circle" : "loader",
 			className: isFailed ? "status-attention" : undefined,
 			title: isFailed
 				? `Error: ${job.error || "unknown"}`
-				: `${String(job.title || "Maintenance")} in progress`,
+				: isCompleted
+					? `${String(job.title || "Maintenance")} finished`
+					: `${String(job.title || "Maintenance")} in progress`,
 		});
 	});
 

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -42,25 +42,41 @@ export function statsRoutes(getStore: () => MemoryStore) {
 		}
 	};
 
+	// Keep completed jobs visible in /api/stats for a short window after
+	// finished_at so the health UI has a chance to render success confirmation
+	// for fast-completing backfills (often <1s). Failed jobs stay indefinitely.
+	const RECENTLY_COMPLETED_WINDOW_MS = 120_000;
+
 	app.get("/api/stats", (c) => {
 		const store = getStore();
 		const jobs = listMaintenanceJobs(store.db);
-		const activeJobs = sortActiveMaintenanceJobs(
-			jobs.filter(
-				(job) => job.status === "pending" || job.status === "running" || job.status === "failed",
-			),
+		const now = Date.now();
+		const surfacedJobs = sortActiveMaintenanceJobs(
+			jobs.filter((job) => {
+				if (job.status === "pending" || job.status === "running" || job.status === "failed") {
+					return true;
+				}
+				if (job.status === "completed" && job.finished_at) {
+					const finished = Date.parse(job.finished_at);
+					if (Number.isFinite(finished) && now - finished <= RECENTLY_COMPLETED_WINDOW_MS) {
+						return true;
+					}
+				}
+				return false;
+			}),
 		).map((job) => ({
 			kind: job.kind,
 			title: job.title,
 			status: job.status,
 			message: job.message,
 			progress: job.progress,
+			finished_at: job.finished_at,
 			error: job.error,
 		}));
 		return c.json({
 			...store.stats(),
 			viewer_pid: process.pid,
-			maintenance_jobs: activeJobs,
+			maintenance_jobs: surfacedJobs,
 		});
 	});
 


### PR DESCRIPTION
## Description

Adds two observability improvements for the background backfill / migration pipeline:

1. **`codemem maintenance status` CLI** — opens the db directly (no viewer required) and prints every row in `maintenance_jobs` with kind, status, progress, age, and completion message. Supports `--json` for structured output and `--db` / `--db-path` for custom paths. Sorts running → pending → failed → cancelled → completed so active work surfaces first.
2. **Viewer `/api/stats` keeps completed jobs briefly** — previously filtered to `pending/running/failed` only; now retains `completed` jobs for 120s after `finished_at`. The health-overview card renders a "Complete" value with a check-circle for those, so fast-completing backfills (often <1s) are visible in the UI instead of flashing past.

Net effect: users can reliably tell whether a backfill ran and finished, where before the "backfill started" CLI line was the only surface and easy to miss.

## Changes

- `packages/cli/src/commands/maintenance.ts` (new): `maintenance status` command with table + JSON output.
- `packages/cli/src/index.ts`: register command.
- `packages/viewer-server/src/routes/stats.ts`: keep recently-completed jobs, add `finished_at` to the response.
- `packages/ui/src/tabs/health/render/health-overview.ts`: render `completed` jobs with distinct value/icon.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint`, `pnpm run test` pass (1462 tests)
- [x] `pnpm run codemem maintenance status` and `--json` both render expected output against a real db
- [x] `pnpm --filter @codemem/ui build` succeeds

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced