### PR TITLE
feat(ui): sync-tab via-group chip for coordinator-discovered peers

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -46,6 +46,8 @@ type SyncPeer = PeerLike & {
 	addresses?: unknown[];
 	claimed_local_actor?: boolean;
 	project_scope?: PeerScopeLike;
+	discovered_via_coordinator_id?: string | null;
+	discovered_via_group_id?: string | null;
 };
 
 type SyncPeerStatus = NonNullable<SyncPeer["status"]> & {
@@ -361,6 +363,14 @@ function SyncPeerCard({
 						</span>
 						{pendingScopeReview ? (
 							<span className="badge actor-badge">Needs scope review</span>
+						) : null}
+						{peer.discovered_via_group_id ? (
+							<span
+								className="badge actor-badge"
+								title={`Discovered through coordinator group ${peer.discovered_via_group_id}`}
+							>
+								{`via ${peer.discovered_via_group_id}`}
+							</span>
 						) : null}
 					</div>
 				</div>

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -899,6 +899,12 @@ function mapPeerRow(
 			...currentProjectScope(row, readPeerProjectFilters(store, String(row.peer_device_id ?? ""))),
 		},
 		recent_ops: { in: recentOps.in, out: recentOps.out },
+		discovered_via_coordinator_id:
+			typeof row.discovered_via_coordinator_id === "string"
+				? row.discovered_via_coordinator_id
+				: null,
+		discovered_via_group_id:
+			typeof row.discovered_via_group_id === "string" ? row.discovered_via_group_id : null,
 	};
 }
 


### PR DESCRIPTION
## Description

Fourth and final slice of the multi-team coordinator groups epic. Adds a `via {group}` chip to Sync-tab peer rows when the peer was discovered through a coordinator group. Manually-paired peers show no chip. Sync stays focused on everyday peer/sync work — this is the only visible change on that tab.

## Changes

- `packages/viewer-server/src/routes/sync.ts`: `mapPeerRow` now surfaces `discovered_via_coordinator_id` + `discovered_via_group_id` on the API response.
- `packages/ui/src/tabs/sync/components/sync-peers.tsx`: `SyncPeer` type extended with the two new optional fields. Peer card renders a small `via <group>` badge next to the existing trust / scope-review badges when `discovered_via_group_id` is set.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1469 tests pass
- [x] `pnpm --filter @codemem/ui build` succeeds
- [x] Manually verified: pre-upgrade peers still render normally; post-slice-1 enrollments get the chip

## Checklist

- [x] Code follows project style
- [x] Self-review completed