### PR TITLE
feat(core): restore cross-platform mDNS peer discovery via bonjour-service

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -20,6 +20,7 @@ import {
 	hasUnsyncedSharedMemoryChanges,
 	loadPublicKey,
 	MemoryStore,
+	mdnsEnabled,
 	readCodememConfigFile,
 	readCodememConfigFileAtPath,
 	readCoordinatorSyncConfig,
@@ -687,12 +688,21 @@ doctorCmd.action(
 				if (!pinned || !hasKey) issues.push(`peer ${peer.peer_device_id} not pinned`);
 			}
 
+			const mdnsActive = mdnsEnabled();
+			const mdnsSource = process.env.CODEMEM_SYNC_MDNS ? "env" : config.sync_mdns ? "config" : null;
+			const mdnsLabel = mdnsActive
+				? mdnsSource === "env"
+					? "enabled (env)"
+					: "enabled (config)"
+				: "disabled";
+
 			if (opts.json) {
 				console.log(
 					JSON.stringify({
 						enabled: config.sync_enabled === true,
 						listen: `${syncHost}:${syncPort}`,
-						mdns: process.env.CODEMEM_SYNC_MDNS ? "env-configured" : "default/off",
+						mdns: mdnsLabel,
+						mdns_source: mdnsSource,
 						daemon: reachable ? "running" : "not running",
 						identity: device?.device_id ?? null,
 						daemon_error: daemonState?.last_error ?? null,
@@ -707,7 +717,7 @@ doctorCmd.action(
 			console.log("Sync doctor");
 			console.log(`- Enabled: ${config.sync_enabled === true}`);
 			console.log(`- Listen: ${syncHost}:${syncPort}`);
-			console.log(`- mDNS: ${process.env.CODEMEM_SYNC_MDNS ? "env-configured" : "default/off"}`);
+			console.log(`- mDNS: ${mdnsLabel}`);
 			console.log(`- Daemon: ${reachable ? "running" : "not running"}`);
 
 			if (!device) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
 	"dependencies": {
 		"@xenova/transformers": "^2.17.2",
 		"better-sqlite3": "^12.8.0",
+		"bonjour-service": "^1.3.0",
 		"drizzle-orm": "catalog:",
 		"hono": "catalog:",
 		"limiter": "catalog:",

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -54,6 +54,7 @@ export interface CoordinatorSyncConfig {
 	syncPort: number;
 	syncIntervalS: number;
 	syncAdvertise: string;
+	syncMdns: boolean;
 	syncRetentionEnabled: boolean;
 	syncRetentionMaxAgeDays: number;
 	syncRetentionMaxSizeMb: number;
@@ -113,6 +114,7 @@ export function readCoordinatorSyncConfig(config?: ConfigRecord): CoordinatorSyn
 		syncPort: parseIntOr(raw.sync_port, 7337),
 		syncIntervalS: parseIntOr(raw.sync_interval_s, 120),
 		syncAdvertise: clean(raw.sync_advertise) || "auto",
+		syncMdns: parseBoolOr(raw.sync_mdns, false),
 		syncRetentionEnabled: parseBoolOr(raw.sync_retention_enabled, false),
 		syncRetentionMaxAgeDays: Math.max(1, parseIntOr(raw.sync_retention_max_age_days, 30)),
 		syncRetentionMaxSizeMb: Math.max(1, parseIntOr(raw.sync_retention_max_size_mb, 512)),

--- a/packages/core/src/sync-discovery.test.ts
+++ b/packages/core/src/sync-discovery.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -259,27 +262,50 @@ describe("recordPeerSuccess", () => {
 // ---------------------------------------------------------------------------
 
 describe("mdnsEnabled", () => {
-	afterEach(() => {
-		vi.unstubAllEnvs();
+	let tmpDir: string;
+	let configPath: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-mdns-test-"));
+		configPath = join(tmpDir, "config.json");
+		vi.stubEnv("CODEMEM_CONFIG", configPath);
 	});
 
-	it("returns false when env var is not set", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns false with no env and no config", () => {
 		vi.stubEnv("CODEMEM_SYNC_MDNS", "");
 		expect(mdnsEnabled()).toBe(false);
 	});
 
-	it("returns true when env var is '1'", () => {
+	it("env '1' wins over missing config", () => {
 		vi.stubEnv("CODEMEM_SYNC_MDNS", "1");
 		expect(mdnsEnabled()).toBe(true);
 	});
 
-	it("returns true when env var is 'true'", () => {
+	it("env 'true' wins over missing config", () => {
 		vi.stubEnv("CODEMEM_SYNC_MDNS", "true");
 		expect(mdnsEnabled()).toBe(true);
 	});
 
-	it("returns false for other values", () => {
+	it("env '0' explicitly disables even if config says enabled", () => {
+		writeFileSync(configPath, JSON.stringify({ sync_mdns: true }));
 		vi.stubEnv("CODEMEM_SYNC_MDNS", "0");
+		expect(mdnsEnabled()).toBe(false);
+	});
+
+	it("config sync_mdns=true enables when env is unset", () => {
+		writeFileSync(configPath, JSON.stringify({ sync_mdns: true }));
+		vi.stubEnv("CODEMEM_SYNC_MDNS", "");
+		expect(mdnsEnabled()).toBe(true);
+	});
+
+	it("config sync_mdns=false keeps it disabled when env is unset", () => {
+		writeFileSync(configPath, JSON.stringify({ sync_mdns: false }));
+		vi.stubEnv("CODEMEM_SYNC_MDNS", "");
 		expect(mdnsEnabled()).toBe(false);
 	});
 });
@@ -335,13 +361,21 @@ describe("mdnsAddressesForPeer", () => {
 });
 
 describe("mDNS runtime hooks", () => {
-	afterEach(() => {
-		vi.unstubAllEnvs();
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-mdns-runtime-"));
+		vi.stubEnv("CODEMEM_CONFIG", join(tmpDir, "config.json"));
 	});
 
-	it("returns no entries and no-op close when mDNS is disabled", () => {
-		vi.stubEnv("CODEMEM_SYNC_MDNS", "");
-		expect(discoverPeersViaMdns()).toEqual([]);
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("returns no entries and no-op close when mDNS is disabled", async () => {
+		vi.stubEnv("CODEMEM_SYNC_MDNS", "0");
+		await expect(discoverPeersViaMdns()).resolves.toEqual([]);
 		expect(() => advertiseMdns("dev-local", 7337).close()).not.toThrow();
 	});
 });

--- a/packages/core/src/sync-discovery.ts
+++ b/packages/core/src/sync-discovery.ts
@@ -2,15 +2,18 @@
  * Peer discovery and address management for the codemem sync system.
  *
  * Handles address normalization, deduplication, peer address storage,
- * and mDNS stubs. Ported from codemem/sync/discovery.py.
+ * and cross-platform mDNS advertise/discover via `bonjour-service`.
  */
 
-import { execFileSync, spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { mergeAddresses, normalizeAddress } from "./address-utils.js";
+import { readCoordinatorSyncConfig } from "./coordinator-runtime.js";
 import type { Database } from "./db.js";
 import * as schema from "./schema.js";
+
+const requireFromHere = createRequire(import.meta.url);
 
 // Re-export for consumers that import from sync-discovery
 export { addressDedupeKey, mergeAddresses, normalizeAddress } from "./address-utils.js";
@@ -219,7 +222,7 @@ export function setPeerLocalActorClaim(db: Database, peerDeviceId: string, claim
 }
 
 // ---------------------------------------------------------------------------
-// mDNS stubs (Phase 1)
+// mDNS peer discovery (cross-platform via bonjour-service)
 // ---------------------------------------------------------------------------
 
 export interface MdnsEntry {
@@ -230,144 +233,214 @@ export interface MdnsEntry {
 	properties?: Record<string, string | Uint8Array>;
 }
 
-function commandAvailable(command: string): boolean {
+const MDNS_SERVICE_TYPE = "codemem"; // advertises as _codemem._tcp.local.
+
+/**
+ * Returns true when mDNS discovery should be active on this device.
+ *
+ * Reads the merged codemem config (so the Settings UI toggle is
+ * authoritative) with an env-var override (`CODEMEM_SYNC_MDNS`) for
+ * one-off runs. Previously env-only, which silently ignored the UI
+ * toggle.
+ */
+export function mdnsEnabled(): boolean {
+	const envValue = process.env.CODEMEM_SYNC_MDNS;
+	if (envValue) return envValue === "1" || envValue.toLowerCase() === "true";
 	try {
-		execFileSync("which", [command], { stdio: "pipe" });
-		return true;
+		return readCoordinatorSyncConfig().syncMdns;
 	} catch {
 		return false;
 	}
 }
 
-function runDnsSd(args: string[], timeoutMs = 1200): string {
-	try {
-		return execFileSync("dns-sd", args, {
-			encoding: "utf8",
-			stdio: ["ignore", "pipe", "pipe"],
-			timeout: timeoutMs,
-		});
-	} catch (err) {
-		if (err && typeof err === "object") {
-			const e = err as { stdout?: string | Buffer; stderr?: string | Buffer };
-			const out = [e.stdout, e.stderr]
-				.map((part) => {
-					if (typeof part === "string") return part;
-					if (part instanceof Buffer) return part.toString("utf8");
-					return "";
-				})
-				.filter(Boolean)
-				.join("\n");
-			return out;
-		}
-		return "";
-	}
-}
-
-function discoverServiceNamesDnsSd(): string[] {
-	const output = runDnsSd(["-B", "_codemem._tcp", "local."], 1200);
-	if (!output) return [];
-	const names = new Set<string>();
-	for (const line of output.split(/\r?\n/)) {
-		if (!line.includes("Add")) continue;
-		let name = "";
-		const columnMatch = line.match(/\bAdd\b.*\slocal\.\s+_codemem\._tcp\.\s+(.+)$/);
-		if (columnMatch) {
-			name = String(columnMatch[1] ?? "").trim();
-		} else {
-			const legacyMatch = line.match(/\sAdd\s+\S+\s+\S+\s+\S+\s+(.+)\._codemem\._tcp\./);
-			if (legacyMatch) name = String(legacyMatch[1] ?? "").trim();
-		}
-		if (name) names.add(name);
-	}
-	return [...names];
-}
-
-function resolveServiceDnsSd(name: string): MdnsEntry | null {
-	const output = runDnsSd(["-L", name, "_codemem._tcp", "local."], 1200);
-	if (!output) return null;
-
-	const hostPortMatch = output.match(/can be reached at\s+([^:\s]+)\.?:(\d+)/i);
-	const host = hostPortMatch?.[1] ? String(hostPortMatch[1]).trim() : "";
-	const port = hostPortMatch?.[2] ? Number.parseInt(String(hostPortMatch[2]), 10) : 0;
-
-	const txtDeviceIdMatch = output.match(/device_id=([^\s"',]+)/i);
-	const deviceId = txtDeviceIdMatch?.[1] ? String(txtDeviceIdMatch[1]).trim() : "";
-
-	if (!host || !port || Number.isNaN(port)) return null;
-	const properties: Record<string, string> = {};
-	if (deviceId) properties.device_id = deviceId;
-
-	return {
-		name,
-		host,
-		port,
-		properties,
+// Lazy-import `bonjour-service` so users who disable embeddings or run
+// in environments where the multicast socket can't bind don't pay the
+// startup cost. Returns null when the module isn't available.
+interface BonjourLike {
+	publish: (opts: { name: string; type: string; port: number; txt?: Record<string, string> }) => {
+		stop: (cb?: () => void) => void;
 	};
+	find: (
+		opts: { type: string },
+		onUp?: (svc: {
+			name: string;
+			host?: string;
+			fqdn?: string;
+			port: number;
+			addresses?: string[];
+			txt?: Record<string, string>;
+		}) => void,
+	) => { stop: () => void };
+	destroy: () => void;
+}
+
+type BonjourCtor = new (
+	opts?: Record<string, unknown>,
+	errorCallback?: (err: Error) => void,
+) => BonjourLike;
+
+function loadBonjour(): BonjourLike | null {
+	try {
+		const mod = requireFromHere("bonjour-service") as {
+			Bonjour?: BonjourCtor;
+			default?: BonjourCtor;
+		};
+		const Ctor = mod.Bonjour ?? mod.default;
+		if (!Ctor) return null;
+		// Pass an error callback so mDNS runtime errors (bind failures on
+		// restricted containers, interface churn, multicast blocked) stay
+		// contained instead of propagating as uncaught exceptions and
+		// taking down the sync/viewer process. Degrades to no-op on error.
+		return new Ctor(undefined, (err: Error) => {
+			console.warn("[codemem] mDNS runtime error (non-fatal):", err?.message ?? err);
+		});
+	} catch {
+		return null;
+	}
+}
+
+// Shared Bonjour instance: advertise + discover reuse a single multicast
+// socket, refcounted across callers. This avoids churn where each call would
+// otherwise spin up a fresh bind-release cycle and race its own publish/find
+// against destroy(). The instance is lazily created on first acquire and torn
+// down when the last caller releases.
+let sharedInstance: BonjourLike | null = null;
+let sharedRefcount = 0;
+
+function acquireBonjour(): BonjourLike | null {
+	if (sharedInstance) {
+		sharedRefcount += 1;
+		return sharedInstance;
+	}
+	const instance = loadBonjour();
+	if (!instance) return null;
+	sharedInstance = instance;
+	sharedRefcount = 1;
+	return sharedInstance;
+}
+
+function releaseBonjour(): void {
+	if (!sharedInstance) return;
+	sharedRefcount = Math.max(0, sharedRefcount - 1);
+	if (sharedRefcount > 0) return;
+	const instance = sharedInstance;
+	sharedInstance = null;
+	try {
+		instance.destroy();
+	} catch {
+		// best effort
+	}
 }
 
 /**
- * Check if mDNS discovery is enabled via the CODEMEM_SYNC_MDNS env var.
+ * Internal: reset shared instance state. Exposed for tests only.
  */
-export function mdnsEnabled(): boolean {
-	const value = process.env.CODEMEM_SYNC_MDNS;
-	if (!value) return false;
-	return value === "1" || value.toLowerCase() === "true";
+export function __resetMdnsForTests(): void {
+	if (sharedInstance) {
+		try {
+			sharedInstance.destroy();
+		} catch {
+			// best effort
+		}
+	}
+	sharedInstance = null;
+	sharedRefcount = 0;
 }
 
 /**
- * Advertise this device via mDNS.
+ * Advertise this device as a codemem sync peer via mDNS.
  *
- * Phase 1 stub: logs the intent and returns a no-op closer.
- * Real implementation will use dns-sd (macOS) or bonjour-service (Linux).
+ * Returns a closer that tears down the advertisement. No-op when mDNS
+ * is disabled, when `bonjour-service` failed to load, or when the
+ * multicast socket cannot bind.
  */
-export function advertiseMdns(_deviceId: string, _port: number): { close(): void } {
+export function advertiseMdns(deviceId: string, port: number): { close(): void } {
 	if (!mdnsEnabled()) return { close() {} };
-	if (process.platform !== "darwin") return { close() {} };
-	if (!commandAvailable("dns-sd")) return { close() {} };
+	if (!deviceId || !port || !Number.isFinite(port)) return { close() {} };
 
-	const serviceName = `codemem-${_deviceId.slice(0, 12)}`;
-	const child = spawn(
-		"dns-sd",
-		["-R", serviceName, "_codemem._tcp", "local.", String(_port), `device_id=${_deviceId}`],
-		{
-			stdio: "ignore",
-			detached: false,
-		},
-	);
+	const bonjour = acquireBonjour();
+	if (!bonjour) return { close() {} };
 
+	let advertisement: { stop: (cb?: () => void) => void } | null = null;
+	try {
+		advertisement = bonjour.publish({
+			name: `codemem-${deviceId.slice(0, 12)}`,
+			type: MDNS_SERVICE_TYPE,
+			port,
+			txt: { device_id: deviceId },
+		});
+	} catch {
+		releaseBonjour();
+		return { close() {} };
+	}
+
+	let closed = false;
 	return {
 		close() {
-			if (!child.killed) {
-				try {
-					child.kill("SIGTERM");
-				} catch {
-					// best effort
-				}
+			if (closed) return;
+			closed = true;
+			const release = () => releaseBonjour();
+			try {
+				// Wait for publish to acknowledge the stop before releasing the
+				// shared instance so the unpublish actually reaches the wire.
+				advertisement?.stop(() => release());
+			} catch {
+				release();
 			}
 		},
 	};
 }
 
 /**
- * Discover peers via mDNS.
- *
- * Phase 1 stub: returns an empty array.
- * Real implementation will use dns-sd (macOS) or bonjour-service (Linux).
+ * Discover codemem sync peers via mDNS. Blocks up to `timeoutMs` (default
+ * 1500) collecting `_codemem._tcp.local.` responders, then returns the
+ * entries it saw. No-op / empty array when mDNS is disabled or the
+ * module couldn't load.
  */
-export function discoverPeersViaMdns(): MdnsEntry[] {
+export async function discoverPeersViaMdns(timeoutMs = 1500): Promise<MdnsEntry[]> {
 	if (!mdnsEnabled()) return [];
-	if (process.platform !== "darwin") return [];
-	if (!commandAvailable("dns-sd")) return [];
 
-	const names = discoverServiceNamesDnsSd();
-	if (names.length === 0) return [];
+	const bonjour = acquireBonjour();
+	if (!bonjour) return [];
 
-	const entries: MdnsEntry[] = [];
-	for (const name of names) {
-		const resolved = resolveServiceDnsSd(name);
-		if (resolved) entries.push(resolved);
+	const found: MdnsEntry[] = [];
+	const seen = new Set<string>();
+	// Ignore late `onUp` callbacks that fire after the timeout elapses — the
+	// browser's `stop()` is best-effort and can race in-flight dispatches.
+	let acceptingResults = true;
+	let browser: { stop: () => void } | null = null;
+	try {
+		browser = bonjour.find({ type: MDNS_SERVICE_TYPE }, (svc) => {
+			if (!acceptingResults) return;
+			const key = `${svc.name}|${svc.host ?? svc.fqdn ?? ""}|${svc.port}`;
+			if (seen.has(key)) return;
+			seen.add(key);
+			const addresses = Array.isArray(svc.addresses) ? svc.addresses : [];
+			const ipv4 = addresses.find((addr) => addr && /^[\d.]+$/.test(addr));
+			const properties: Record<string, string> = {};
+			const rawTxt = svc.txt ?? {};
+			for (const [key, value] of Object.entries(rawTxt)) {
+				properties[key] = String(value);
+			}
+			found.push({
+				name: svc.name,
+				host: (svc.host || svc.fqdn || "").replace(/\.$/, ""),
+				port: svc.port,
+				address: ipv4,
+				properties,
+			});
+		});
+		await new Promise<void>((resolve) => setTimeout(resolve, Math.max(100, timeoutMs)));
+	} finally {
+		acceptingResults = false;
+		try {
+			browser?.stop();
+		} catch {
+			// best effort
+		}
+		releaseBonjour();
 	}
-	return entries;
+	return found;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
+      bonjour-service:
+        specifier: ^1.3.0
+        version: 1.3.0
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
@@ -1401,6 +1404,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@leichtgewicht/ip-codec@2.0.5':
+    resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -2381,6 +2387,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  bonjour-service@1.3.0:
+    resolution: {integrity: sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -2529,6 +2538,10 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dns-packet@5.6.1:
+    resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
+    engines: {node: '>=6'}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -3126,6 +3139,10 @@ packages:
   msgpackr@1.11.10:
     resolution: {integrity: sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==}
 
+  multicast-dns@7.2.5:
+    resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
+    hasBin: true
+
   multipasta@0.2.7:
     resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
 
@@ -3563,6 +3580,9 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  thunky@1.1.0:
+    resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4628,6 +4648,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@leichtgewicht/ip-codec@2.0.5': {}
+
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.12(hono@4.12.11)
@@ -5458,6 +5480,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bonjour-service@1.3.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      multicast-dns: 7.2.5
+
   boolbase@1.0.0: {}
 
   browserslist@4.28.1:
@@ -5591,6 +5618,10 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
+
+  dns-packet@5.6.1:
+    dependencies:
+      '@leichtgewicht/ip-codec': 2.0.5
 
   dom-serializer@2.0.0:
     dependencies:
@@ -6185,6 +6216,11 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
+  multicast-dns@7.2.5:
+    dependencies:
+      dns-packet: 5.6.1
+      thunky: 1.1.0
+
   multipasta@0.2.7: {}
 
   nanoid@3.3.11: {}
@@ -6743,6 +6779,8 @@ snapshots:
       b4a: 1.8.0
     transitivePeerDependencies:
       - react-native-b4a
+
+  thunky@1.1.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## Description

Restores end-to-end mDNS peer discovery for codemem sync. Prior to this the TS runtime carried Phase 1 stubs plus a macOS-only `dns-sd` shell-out path — Linux/Windows users had no mDNS at all, and even on macOS the Settings UI toggle had no effect because `mdnsEnabled()` and `codemem sync doctor` read only `process.env.CODEMEM_SYNC_MDNS`, ignoring the saved `sync_mdns` config value.

## Changes

- **`packages/core/src/sync-discovery.ts`** — replace the `execFileSync("dns-sd", ...)` + spawn implementation with `bonjour-service` (pure JS, no native addon, advertises + browses `_codemem._tcp.local.`). Works on macOS, Linux, and Windows with no external daemons. `advertiseMdns` publishes `codemem-<deviceId prefix>` with a `device_id` TXT record; `discoverPeersViaMdns` returns `{ name, host, port, address, properties }` for every responder seen during a 1.5s browse window (tunable). Lazy-loads the module via `createRequire(import.meta.url)` so the code still runs cleanly if the dep is missing.
- **`mdnsEnabled()`** now reads the merged coordinator config first (`readCoordinatorSyncConfig().syncMdns`), with the env var still acting as an explicit override. Settings UI toggles are now authoritative.
- **`packages/core/src/coordinator-runtime.ts`** — `CoordinatorSyncConfig` gains `syncMdns: boolean`, populated via the same env-override mechanism other sync fields already use.
- **`packages/cli/src/commands/sync.ts`** (`sync doctor`) — prints the actual state of mDNS using `mdnsEnabled()` plus a source label (`enabled (config)` / `enabled (env)` / `disabled`). The old output could claim `default/off` even when the UI said enabled.
- **`packages/core/package.json`** — adds `bonjour-service` (pure JS; no native compilation, no install scripts, clean under `ignore-scripts=true`).

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] `pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1464 tests pass
- [x] New unit tests cover `mdnsEnabled()` matrix: missing env + config, env='1'/'true' win, env='0' explicitly disables even when config says enabled, config `sync_mdns=true` enables when env unset, config `sync_mdns=false` keeps it off.
- [x] Runtime hooks test: `discoverPeersViaMdns()` returns `[]` and `advertiseMdns()` no-ops cleanly when disabled.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced