### PR TITLE
fix(ui): keep sync dialogs open when clicking autocomplete suggestions

### DIFF
--- a/packages/ui/src/tabs/sync/sync-dialogs/components/sync-dialog-host.tsx
+++ b/packages/ui/src/tabs/sync/sync-dialogs/components/sync-dialog-host.tsx
@@ -40,6 +40,18 @@ export function SyncDialogHost() {
 		resolveCurrentDialog(request?.kind === "confirm" ? false : null);
 	};
 
+	const handleInteractOutside = (event: Event & { detail?: { originalEvent?: Event } }) => {
+		// The autocomplete suggestion list renders inside its own Radix Popover
+		// portal, so Radix treats clicks on options as "outside the dialog" and
+		// closes the modal. Block that when the click target is inside an
+		// autocomplete popover so picking a suggestion actually fills the input.
+		const originalTarget = (event.detail?.originalEvent as { target?: unknown } | undefined)
+			?.target;
+		if (originalTarget instanceof Element && originalTarget.closest(".autocomplete-popover")) {
+			event.preventDefault();
+		}
+	};
+
 	const handleOpenAutoFocus = (event: Event) => {
 		const legacyPrimary = document.querySelector<HTMLElement>(
 			'#syncDialog [data-sync-primary-action="true"]',
@@ -71,6 +83,7 @@ export function SyncDialogHost() {
 			ariaLabelledby={titleId}
 			contentClassName="modal"
 			contentId="syncDialog"
+			onInteractOutside={handleInteractOutside}
 			onOpenAutoFocus={handleOpenAutoFocus}
 			onOpenChange={handleOpenChange}
 			open={open}


### PR DESCRIPTION
## Description

The sync dialog host (used for \"Assign to project\" and other input prompts)
closes as soon as a user clicks a suggestion in the autocomplete popover. The
popover renders inside its own Radix Popover portal, so Radix's Dialog treats
the click as an outside-interaction and fires \`onOpenChange(false)\` before the
suggestion can commit, dropping the user's selection.

Add an \`onInteractOutside\` handler that \`preventDefault\`s when the original
event target is inside an \`.autocomplete-popover\`. Suggestions now fill the
input instead of dismissing the dialog.

## Type of Change

- [x] Bug fix

## Testing

- \`pnpm run tsc && pnpm run lint\`
- Manual: open Feed → kebab → Assign to project, click a suggested project,
  verify the input is populated and the dialog stays open.