### PR TITLE
fix(ui): rework scope-defaults drawer — chip inputs, master toggle, accurate semantics

### DIFF
--- a/packages/ui/src/components/primitives/chip-input.tsx
+++ b/packages/ui/src/components/primitives/chip-input.tsx
@@ -1,0 +1,96 @@
+/* Preact chip input — type + Enter (or comma) to add, Backspace to remove
+ * the last chip when the input is empty, × to remove a specific chip.
+ * Reuses the existing `.peer-scope-*` CSS from the Sync tab so the visual
+ * language stays consistent. Free-text, no validation beyond trimming. */
+
+import type { JSX } from "preact";
+import { useRef } from "preact/hooks";
+
+export interface ChipInputProps {
+	values: string[];
+	onValuesChange: (next: string[]) => void;
+	placeholder?: string;
+	emptyLabel?: string;
+	disabled?: boolean;
+	"aria-labelledby"?: string;
+}
+
+function parseIncoming(raw: string): string[] {
+	return raw
+		.split(",")
+		.map((item) => item.trim())
+		.filter((item) => item.length > 0);
+}
+
+export function ChipInput({
+	values,
+	onValuesChange,
+	placeholder,
+	emptyLabel,
+	disabled,
+	"aria-labelledby": ariaLabelledby,
+}: ChipInputProps) {
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	const commit = () => {
+		const input = inputRef.current;
+		if (!input) return;
+		const incoming = parseIncoming(input.value);
+		if (!incoming.length) return;
+		const next = Array.from(new Set([...values, ...incoming]));
+		onValuesChange(next);
+		input.value = "";
+	};
+
+	const removeAt = (index: number) => {
+		const next = values.filter((_, i) => i !== index);
+		onValuesChange(next);
+	};
+
+	const handleKeyDown: JSX.KeyboardEventHandler<HTMLInputElement> = (event) => {
+		if (event.key === "Enter" || event.key === ",") {
+			event.preventDefault();
+			commit();
+			return;
+		}
+		if (event.key === "Backspace" && !event.currentTarget.value && values.length > 0) {
+			event.preventDefault();
+			removeAt(values.length - 1);
+		}
+	};
+
+	return (
+		<div class="peer-scope-editor">
+			<ul class="peer-scope-chips">
+				{values.length === 0 && emptyLabel ? (
+					<li class="peer-scope-chip empty">{emptyLabel}</li>
+				) : null}
+				{values.map((value, index) => (
+					<li class="peer-scope-chip" key={`${value}::${index}`}>
+						<span>{value}</span>
+						{!disabled ? (
+							<button
+								aria-label={`Remove ${value}`}
+								class="peer-scope-chip-remove"
+								onClick={() => removeAt(index)}
+								type="button"
+							>
+								×
+							</button>
+						) : null}
+					</li>
+				))}
+			</ul>
+			<input
+				aria-labelledby={ariaLabelledby}
+				class="peer-scope-input"
+				disabled={disabled}
+				onBlur={commit}
+				onKeyDown={handleKeyDown}
+				placeholder={placeholder}
+				ref={inputRef}
+				type="text"
+			/>
+		</div>
+	);
+}

--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -6,6 +6,7 @@
  * archive switch and manage button can trigger the surrounding shell. */
 
 import { h } from "preact";
+import { ChipInput } from "../../../components/primitives/chip-input";
 import { RadixSwitch } from "../../../components/primitives/radix-switch";
 import { RadixTabsContent } from "../../../components/primitives/radix-tabs";
 import { TextInput } from "../../../components/primitives/text-input";
@@ -22,25 +23,13 @@ import {
 
 function emptyDraft(): GroupPreferencesDraft {
 	return {
-		projects_include: "",
-		projects_exclude: "",
+		projects_include: [],
+		projects_exclude: [],
 		auto_seed_scope: true,
 		loaded: false,
 		saving: false,
 		error: "",
 	};
-}
-
-function listToText(list: string[] | null): string {
-	return Array.isArray(list) ? list.join(", ") : "";
-}
-
-function textToList(text: string): string[] | null {
-	const items = text
-		.split(",")
-		.map((item) => item.trim())
-		.filter((item) => item.length > 0);
-	return items.length === 0 ? null : items;
 }
 
 async function openGroupPreferences(groupId: string, renderShell: () => void): Promise<void> {
@@ -51,8 +40,8 @@ async function openGroupPreferences(groupId: string, renderShell: () => void): P
 	try {
 		const prefs = await api.loadCoordinatorGroupPreferences(groupId);
 		coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
-			projects_include: listToText(prefs.projects_include),
-			projects_exclude: listToText(prefs.projects_exclude),
+			projects_include: Array.isArray(prefs.projects_include) ? [...prefs.projects_include] : [],
+			projects_exclude: Array.isArray(prefs.projects_exclude) ? [...prefs.projects_exclude] : [],
 			auto_seed_scope: prefs.auto_seed_scope,
 			loaded: true,
 			saving: false,
@@ -81,11 +70,12 @@ async function saveGroupPreferences(groupId: string, renderShell: () => void): P
 	// kick off a parallel save. The Save button is disabled on `draft.saving`,
 	// but a pre-render double-click can otherwise slip through.
 	if (initial.saving) return;
-	// Snapshot the payload to send BEFORE awaiting, so typing during the save
-	// doesn't alter what gets persisted this round.
+	// Snapshot the payload to send BEFORE awaiting, so chip edits during the
+	// save don't alter what gets persisted this round. Empty arrays serialize
+	// as `null` at the API layer; the store treats that as "no filter".
 	const payload = {
-		projects_include: textToList(initial.projects_include),
-		projects_exclude: textToList(initial.projects_exclude),
+		projects_include: initial.projects_include.length > 0 ? [...initial.projects_include] : null,
+		projects_exclude: initial.projects_exclude.length > 0 ? [...initial.projects_exclude] : null,
 		auto_seed_scope: initial.auto_seed_scope,
 	};
 	coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
@@ -128,64 +118,30 @@ function renderGroupPreferencesEditor(
 			h("div", { class: "peer-submeta" }, "Loading scope defaults…"),
 		);
 	}
+	const autoSeedLabelId = `coord-admin-scope-autoseed-${groupId}`;
+	const includeLabelId = `coord-admin-scope-include-${groupId}`;
+	const excludeLabelId = `coord-admin-scope-exclude-${groupId}`;
+	const fieldsDisabled = !ready || draft.saving || !draft.auto_seed_scope;
 	return h(
 		"div",
 		{ class: "coordinator-admin-group-preferences" },
+		h("h4", { class: "coordinator-admin-drawer-title" }, "Scope defaults"),
 		h(
 			"div",
 			{ class: "peer-submeta" },
-			"New peers discovered through this team will default to this scope. Existing peers are not changed.",
+			"When enabled, new peers enrolled through this team start with the project filters below. Existing peers are unchanged.",
 		),
+		// Master toggle first — the include/exclude chips are only meaningful
+		// when auto-seed is on, so the form reads top-down from decision
+		// (toggle) to config (chips).
 		h(
 			"label",
-			{ class: "coordinator-admin-field" },
-			h("span", null, "Include projects (comma-separated)"),
-			h(TextInput, {
-				class: "peer-scope-input",
-				disabled: !ready || draft.saving,
-				onInput: (event) => {
-					// Read the LATEST draft from the shared map rather than the
-					// one captured at render time — text inputs don't re-render
-					// between keystrokes, so `draft` here would otherwise stomp
-					// other fields' edits with stale values.
-					const current = coordinatorAdminState.groupPreferencesDrafts.get(groupId) ?? draft;
-					const next = String((event.currentTarget as HTMLInputElement).value || "");
-					coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
-						...current,
-						projects_include: next,
-					});
-				},
-				placeholder: "e.g. work/*, shared-work-coworker/*",
-				type: "text",
-				value: draft.projects_include,
-			}),
-		),
-		h(
-			"label",
-			{ class: "coordinator-admin-field" },
-			h("span", null, "Exclude projects (comma-separated)"),
-			h(TextInput, {
-				class: "peer-scope-input",
-				disabled: !ready || draft.saving,
-				onInput: (event) => {
-					const current = coordinatorAdminState.groupPreferencesDrafts.get(groupId) ?? draft;
-					const next = String((event.currentTarget as HTMLInputElement).value || "");
-					coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
-						...current,
-						projects_exclude: next,
-					});
-				},
-				placeholder: "",
-				type: "text",
-				value: draft.projects_exclude,
-			}),
-		),
-		h(
-			"label",
-			{ class: "coordinator-admin-field coordinator-admin-switch" },
-			h("span", null, "Auto-seed scope on new peers"),
+			{ class: "coordinator-admin-inline-filter" },
+			h("span", { class: "section-meta", id: autoSeedLabelId }, "Auto-seed scope on new peers"),
 			h(RadixSwitch, {
+				"aria-labelledby": autoSeedLabelId,
 				checked: draft.auto_seed_scope,
+				className: "coordinator-admin-switch",
 				disabled: !ready || draft.saving,
 				onCheckedChange: (checked: boolean) => {
 					const current = coordinatorAdminState.groupPreferencesDrafts.get(groupId) ?? draft;
@@ -195,6 +151,52 @@ function renderGroupPreferencesEditor(
 					});
 					renderShell();
 				},
+				thumbClassName: "coordinator-admin-switch-thumb",
+			}),
+		),
+		h(
+			"div",
+			{ class: "coordinator-admin-field" },
+			h("span", { id: includeLabelId }, "Include projects"),
+			h(ChipInput, {
+				"aria-labelledby": includeLabelId,
+				disabled: fieldsDisabled,
+				emptyLabel: "All projects allowed",
+				onValuesChange: (next: string[]) => {
+					const current = coordinatorAdminState.groupPreferencesDrafts.get(groupId) ?? draft;
+					coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
+						...current,
+						projects_include: next,
+					});
+					renderShell();
+				},
+				placeholder: "Type a project name and press Enter",
+				values: draft.projects_include,
+			}),
+			h(
+				"span",
+				{ class: "peer-submeta" },
+				"Exact project names. Leave empty to allow every project.",
+			),
+		),
+		h(
+			"div",
+			{ class: "coordinator-admin-field" },
+			h("span", { id: excludeLabelId }, "Exclude projects"),
+			h(ChipInput, {
+				"aria-labelledby": excludeLabelId,
+				disabled: fieldsDisabled,
+				emptyLabel: "Nothing excluded",
+				onValuesChange: (next: string[]) => {
+					const current = coordinatorAdminState.groupPreferencesDrafts.get(groupId) ?? draft;
+					coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
+						...current,
+						projects_exclude: next,
+					});
+					renderShell();
+				},
+				placeholder: "Type a project name and press Enter",
+				values: draft.projects_exclude,
 			}),
 		),
 		draft.error ? h("div", { class: "peer-submeta coordinator-admin-error" }, draft.error) : null,

--- a/packages/ui/src/tabs/coordinator-admin/data/state.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/state.ts
@@ -11,8 +11,8 @@ export type DeviceActionKind = "rename" | "disable" | "enable" | "remove" | "";
 export type InvitePolicy = "auto_admit" | "approval_required";
 
 export interface GroupPreferencesDraft {
-	projects_include: string;
-	projects_exclude: string;
+	projects_include: string[];
+	projects_exclude: string[];
 	auto_seed_scope: boolean;
 	loaded: boolean;
 	saving: boolean;

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -713,6 +713,68 @@
         margin-left: 2px;
       }
 
+      /* Scope-defaults drawer inside a group card. Reads top-down:
+         header · helper · auto-seed toggle (master) · include chips
+         · exclude chips · actions. Delimits itself as its own subsection
+         with a top border + breathing room so it doesn't run into the
+         peer-actions row above. */
+      .coordinator-admin-group-preferences {
+        display: grid;
+        gap: var(--sp-4);
+        margin-top: var(--sp-3);
+        padding-top: var(--sp-3);
+        border-top: 1px solid var(--border);
+        min-width: 0;
+      }
+
+      .coordinator-admin-group-preferences > .coordinator-admin-field,
+      .coordinator-admin-group-preferences > .coordinator-admin-inline-filter {
+        min-width: 0;
+      }
+
+      .coordinator-admin-drawer-title {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin: 0;
+        letter-spacing: 0.01em;
+      }
+
+      /* Tighten the helper text directly under the drawer title so they
+         read as one intro block, then let the sp-4 gap separate that
+         block from the toggle. */
+      .coordinator-admin-group-preferences > .coordinator-admin-drawer-title + .peer-submeta {
+        margin-top: calc(-1 * var(--sp-3));
+      }
+
+      /* Help text that lives INSIDE a chip field (e.g. "Exact names,
+         leave empty to allow all") — looser than the row gap, tighter
+         than the inter-section gap. */
+      .coordinator-admin-group-preferences .coordinator-admin-field > .peer-submeta {
+        margin-top: calc(-1 * var(--sp-1));
+      }
+
+      /* Dim the chip editor when auto-seed is off so it visually reads
+         as "configuration that isn't currently applied" rather than
+         "broken input". */
+      .coordinator-admin-group-preferences .peer-scope-input:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+
+      /* Separate the action row (Save / Cancel) from the last field with
+         an explicit gap + top border so the terminating region reads as
+         distinct from the form controls above. */
+      .coordinator-admin-group-preferences > .peer-actions {
+        margin-top: var(--sp-1);
+        padding-top: var(--sp-3);
+        border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+      }
+
+      .coordinator-admin-group-preferences > .coordinator-admin-inline-filter {
+        gap: var(--sp-3);
+      }
+
       .coordinator-admin-empty-state {
         padding: var(--sp-3) 0 var(--sp-1);
       }
@@ -1670,7 +1732,7 @@
       .peer-actor-row { display: flex; align-items: center; gap: var(--sp-2); flex-wrap: wrap; }
       .peer-scope-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-2); }
       .peer-scope-editor { display: grid; gap: 8px; }
-      .peer-scope-chips { display: flex; flex-wrap: wrap; gap: 6px; min-height: 32px; align-items: flex-start; padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); }
+      .peer-scope-chips { display: flex; flex-wrap: wrap; gap: 6px; min-height: 32px; align-items: flex-start; padding: 8px 10px; margin: 0; list-style: none; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); }
       .peer-scope-chip { padding: 4px 8px; background: rgba(43, 122, 176, 0.12); color: var(--accent); font-size: 12px; }
       .peer-scope-chip.empty { background: transparent; color: var(--text-tertiary); border-style: dashed; border-color: var(--border); }
       .peer-scope-chip-remove { border: none; background: transparent; color: inherit; cursor: pointer; padding: 0; font: inherit; opacity: 0.75; }


### PR DESCRIPTION
## Description

The first pass of this PR fixed two local bugs (switch-track class applied
to the wrapping label, and missing drawer hierarchy). Dogfooding surfaced
three more issues that this revision addresses:

- **Globbing doesn't exist.** Scope matching in \`store.ts:2262\` is exact
  string equality against the full project name OR its basename. The old
  placeholder \`work/*, shared-work-coworker/*\` was misleading. The form
  now uses per-chip entries with real names as examples.
- **Free-text inputs were inconsistent with Sync-tab chip UX.** Replaced
  the comma-separated \`<input>\`s with a new Preact \`ChipInput\` primitive
  that reuses the existing \`.peer-scope-*\` styles. Type + Enter (or
  comma) to add, × or Backspace to remove.
- **Auto-seed is the master switch, not a sibling field.** Empty
  include/exclude with auto-seed on = "allow all, exclude nothing";
  auto-seed off = filters saved but not applied. Form now reads top-down
  from decision (toggle) to config (chips). When auto-seed is off, chip
  inputs are disabled but the configured values are preserved.

Also keeps the drawer-as-subsection layout, the proper switch class
wiring, and adds a new \`ChipInput\` primitive at
\`packages/ui/src/components/primitives/chip-input.tsx\` reusing existing
\`.peer-scope-*\` CSS from the Sync tab.

## Type of Change

- [x] Bug fix
- [x] UX improvement

## Testing

- \`pnpm run tsc && pnpm run lint && pnpm run test\` (1475 passing)
- Manual: Coordinator Admin → Groups → Scope defaults. Toggle is first.
  Chip inputs show "All projects allowed" / "Nothing excluded" when empty,
  dim when auto-seed is off, accept Enter/comma to commit.