### PR TITLE
feat(sync): let a device join additional teams on the same coordinator

### DIFF
--- a/packages/core/src/coordinator-actions.ts
+++ b/packages/core/src/coordinator-actions.ts
@@ -675,6 +675,21 @@ export async function coordinatorImportInviteAction(opts: {
 	if (!coordinatorUrl) throw new Error("Invite is missing a coordinator URL.");
 	const config = readCodememConfigFile();
 	const displayName = String(config.actor_display_name ?? deviceId).trim() || deviceId;
+	// V1 of multi-team assumes one coordinator hosting multiple groups.
+	// If this device is already enrolled in a different coordinator, surface
+	// that as a hard error instead of silently overwriting the existing
+	// coordinator URL and orphaning the prior group memberships. Normalize
+	// trailing slashes before comparing so harmless formatting differences
+	// (e.g. `https://coord.example.com` vs. `…/`) don't reject valid same-
+	// coordinator invites.
+	const normalizeCoordinatorUrl = (value: string): string => value.trim().replace(/\/+$/, "");
+	const existingCoordinator = normalizeCoordinatorUrl(String(config.sync_coordinator_url ?? ""));
+	const incomingCoordinator = normalizeCoordinatorUrl(coordinatorUrl);
+	if (existingCoordinator && existingCoordinator !== incomingCoordinator) {
+		throw new Error(
+			`This device is already enrolled with coordinator ${existingCoordinator}. Multi-team joining is only supported across groups on the same coordinator.`,
+		);
+	}
 	let status = 0;
 	let response: Record<string, unknown> | null = null;
 	try {
@@ -701,13 +716,33 @@ export async function coordinatorImportInviteAction(opts: {
 	}
 	const nextConfig = readCodememConfigFile();
 	nextConfig.sync_coordinator_url = coordinatorUrl;
-	nextConfig.sync_coordinator_group = String(payload.group_id);
+	// Append the new group to sync_coordinator_groups (dedup) instead of
+	// overwriting sync_coordinator_group. The runtime reads both the plural
+	// and singular forms; we keep singular pointing at the first group for
+	// legacy compatibility.
+	const newGroupId = String(payload.group_id);
+	const existingGroups = (() => {
+		const plural = nextConfig.sync_coordinator_groups;
+		if (Array.isArray(plural)) return plural.map((g) => String(g).trim()).filter(Boolean);
+		if (typeof plural === "string") {
+			return plural
+				.split(",")
+				.map((g) => g.trim())
+				.filter(Boolean);
+		}
+		const singular = nextConfig.sync_coordinator_group;
+		return typeof singular === "string" && singular.trim() ? [singular.trim()] : [];
+	})();
+	const mergedGroups = Array.from(new Set([...existingGroups, newGroupId]));
+	nextConfig.sync_coordinator_groups = mergedGroups;
+	nextConfig.sync_coordinator_group = mergedGroups[0] ?? newGroupId;
 	const configPath = writeCodememConfigFile(nextConfig, opts.configPath ?? undefined);
 	return {
 		group_id: payload.group_id,
 		coordinator_url: payload.coordinator_url,
 		status: response?.status ?? null,
 		config_path: configPath,
+		groups: mergedGroups,
 	};
 }
 

--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -92,13 +92,50 @@ function PairingCopyRow() {
 	);
 }
 
+function JoinToggleRow({
+	joinPanel,
+	joinPanelOpen,
+	joinRestoreParent,
+	onToggle,
+}: {
+	joinPanel: HTMLElement | null;
+	joinPanelOpen: boolean;
+	joinRestoreParent: HTMLElement | null;
+	onToggle: () => void;
+}) {
+	return (
+		<>
+			<div className="sync-action">
+				<div className="sync-action-text">
+					Join another team.
+					<span className="sync-action-command">
+						Paste an invite to join an additional team from this device.
+					</span>
+				</div>
+				<button type="button" className="settings-button" onClick={onToggle}>
+					{joinPanelOpen ? "Hide join form" : "Join another team"}
+				</button>
+			</div>
+			{joinPanel ? (
+				<ExistingElementSlot
+					element={joinPanel}
+					hidden={!joinPanelOpen}
+					restoreParent={joinRestoreParent}
+				/>
+			) : null}
+		</>
+	);
+}
+
 export type SyncInviteJoinPanelsProps = {
 	invitePanel: HTMLElement | null;
 	invitePanelOpen: boolean;
 	inviteRestoreParent: HTMLElement | null;
 	joinPanel: HTMLElement | null;
+	joinPanelOpen: boolean;
 	joinRestoreParent: HTMLElement | null;
 	onToggleInvitePanel: () => void;
+	onToggleJoinPanel: () => void;
 	pairedPeerCount: number;
 	presenceStatus: string;
 };
@@ -108,16 +145,19 @@ export function SyncInviteJoinPanels({
 	invitePanelOpen,
 	inviteRestoreParent,
 	joinPanel,
+	joinPanelOpen,
 	joinRestoreParent,
 	onToggleInvitePanel,
+	onToggleJoinPanel,
 	pairedPeerCount,
 	presenceStatus,
 }: SyncInviteJoinPanelsProps) {
-	const showInviteActions = presenceStatus !== "not_enrolled";
+	const notEnrolled = presenceStatus === "not_enrolled";
+	const showInviteActions = !notEnrolled;
 
 	return (
 		<>
-			{presenceStatus === "not_enrolled" ? (
+			{notEnrolled ? (
 				<>
 					<div className="sync-action">
 						<div className="sync-action-text">
@@ -144,7 +184,23 @@ export function SyncInviteJoinPanels({
 						</div>
 					</div>
 				</>
-			) : null}
+			) : (
+				<>
+					<JoinToggleRow
+						joinPanel={joinPanel}
+						joinPanelOpen={joinPanelOpen}
+						joinRestoreParent={joinRestoreParent}
+						onToggle={onToggleJoinPanel}
+					/>
+					{/* The join handler writes into state.syncJoinFlowFeedback and
+					    calls setJoinFeedbackVisibility(); that helper exits early
+					    if #syncJoinFeedback is missing from the DOM, so we must
+					    keep the container mounted in this branch too. Otherwise
+					    enrolled users joining another team get no success / error
+					    / pending message after import. */}
+					<div className="peer-meta" id="syncJoinFeedback" hidden />
+				</>
+			)}
 
 			{showInviteActions ? (
 				<InviteToggleRow

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -24,6 +24,11 @@ export function setTeamInvitePanelOpen(v: boolean) {
 	teamInvitePanelOpen = v;
 }
 
+export let teamJoinPanelOpen = false;
+export function setTeamJoinPanelOpen(v: boolean) {
+	teamJoinPanelOpen = v;
+}
+
 export const openPeerScopeEditors = new Set<string>();
 const pendingPeerScopeReviewIds = new Set<string>();
 const freshPeerScopeReviewIds = new Set<string>();

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -26,7 +26,9 @@ import {
 	requestPeerScopeReview,
 	saveDuplicatePersonDecision,
 	setTeamInvitePanelOpen,
+	setTeamJoinPanelOpen,
 	teamInvitePanelOpen,
+	teamJoinPanelOpen,
 } from "../../helpers";
 import {
 	openDuplicatePersonDialog,
@@ -475,10 +477,16 @@ export function renderTeamSync() {
 				invitePanelOpen: teamInvitePanelOpen,
 				inviteRestoreParent,
 				joinPanel,
+				joinPanelOpen: teamJoinPanelOpen,
 				joinRestoreParent,
 				onToggleInvitePanel: () => {
 					if (!invitePanel) return;
 					setTeamInvitePanelOpen(!teamInvitePanelOpen);
+					renderTeamSync();
+				},
+				onToggleJoinPanel: () => {
+					if (!joinPanel) return;
+					setTeamJoinPanelOpen(!teamJoinPanelOpen);
 					renderTeamSync();
 				},
 				pairedPeerCount: Number(coordinator.paired_peer_count || 0),


### PR DESCRIPTION
## Description

The multi-team design says a device can belong to multiple coordinator
groups simultaneously, but the Sync tab hid the invite-paste box once the
device was enrolled in any group, and the backend \`sync/invites/import\`
action overwrote \`sync_coordinator_group\` on every import — silently
dropping the existing team.

- Sync tab now shows a "Join another team" toggle once enrolled. Collapsed
  by default to keep the paired-device list as the primary focus; expands
  to the same paste-invite panel the not-enrolled flow uses.
- \`coordinatorImportInviteAction\` now appends the new group id to
  \`sync_coordinator_groups\` (dedup) and leaves \`sync_coordinator_group\`
  pointing at the first group for legacy-reader compatibility.
- Importing an invite from a DIFFERENT coordinator URL now errors with
  "This device is already enrolled with coordinator <x>. Multi-team
  joining is only supported across groups on the same coordinator." per
  the v1 constraint in \`docs/plans/2026-04-22-multi-team-coordinator-groups-design.md\`.

## Type of Change

- [x] Feature (completes multi-team v1 join flow)

## Testing

- \`pnpm run tsc && pnpm run lint && pnpm run test\` (1475 passing)
- Manual (next step): Sync tab on an enrolled device → Join another team →
  paste an invite from a second group on the same coordinator → verify both
  groups appear in config and both tabs surface their peers.