### PR TITLE
ui(sync): carve Advanced diagnostics into #sync/diagnostics sub-view, remove Overview card

### DIFF
--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -285,7 +285,10 @@ export function resolveAccessibleTab(
 /* ── Persistence helpers ───────────────────────────────────── */
 
 export function getActiveTab(): TabId {
-	const hash = window.location.hash.replace("#", "") as TabId;
+	// Strip an optional sub-view segment after `/` so hashes like
+	// `#sync/diagnostics` still resolve to the parent tab (`sync`). Sub-view
+	// state is owned per-tab (e.g. sync/sync-view-controller.ts).
+	const hash = window.location.hash.replace(/^#/, "").split("/")[0] as TabId;
 	if (ALL_TAB_IDS.includes(hash))
 		return resolveAccessibleTab(hash, state.lastCoordinatorAdminStatus);
 	const saved = localStorage.getItem(TAB_KEY);

--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -6,14 +6,6 @@ import type { UiSyncAttentionItem } from "../view-model";
 import type { SyncActionFeedback } from "./sync-inline-feedback";
 import { SyncInlineFeedback } from "./sync-inline-feedback";
 
-export interface TeamSyncStatusSummary {
-	badgeClassName: string;
-	detail: string | null;
-	headline: string | null;
-	presenceLabel: string;
-	metricsText: string;
-}
-
 export interface TeamSyncDiscoveredRow {
 	actionMessage: string | null;
 	actionLabel: string | null;
@@ -41,7 +33,11 @@ type TeamSyncPanelProps = {
 	discoveredListMount: HTMLElement | null;
 	discoveredRows: TeamSyncDiscoveredRow[];
 	joinRequestsMount: HTMLElement | null;
-	listMount: HTMLElement;
+	// Unused since the Team-status Overview card was removed (Q3 in
+	// docs/plans/2026-04-23-sync-tab-redesign.md). Still accepted because
+	// render-team-sync.ts looks up the legacy DOM node for backward
+	// compatibility with the teardown path.
+	listMount: HTMLElement | null;
 	onApproveJoinRequest: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
 	onAttentionAction: (item: UiSyncAttentionItem) => Promise<void>;
 	onDenyJoinRequest: (request: TeamSyncPendingJoinRequest) => Promise<SyncActionFeedback | null>;
@@ -50,7 +46,6 @@ type TeamSyncPanelProps = {
 	onReviewDiscoveredDevice: (row: TeamSyncDiscoveredRow) => Promise<SyncActionFeedback | null>;
 	pendingJoinRequests: TeamSyncPendingJoinRequest[];
 	presenceStatus: string;
-	statusSummary: TeamSyncStatusSummary;
 };
 
 function SectionHeading({ count, label }: { count?: number; label: string }) {
@@ -326,32 +321,6 @@ function TeamActionsContent({ children }: { children?: ComponentChildren }) {
 	);
 }
 
-function TeamStatusPortal({
-	mount,
-	statusSummary,
-}: {
-	mount: HTMLElement;
-	statusSummary: TeamSyncStatusSummary;
-}) {
-	return createPortal(
-		<div className="sync-team-summary">
-			<SectionHeading label="Overview" />
-			<div className="sync-team-status-row">
-				<span className="sync-team-status-label">Current status</span>
-				<span className={statusSummary.badgeClassName}>{statusSummary.presenceLabel}</span>
-			</div>
-			{statusSummary.headline ? (
-				<div className="sync-team-headline">{statusSummary.headline}</div>
-			) : null}
-			{statusSummary.detail ? <div className="section-meta">{statusSummary.detail}</div> : null}
-			<div className="sync-team-metrics sync-team-metrics-secondary">
-				{statusSummary.metricsText}
-			</div>
-		</div>,
-		mount,
-	);
-}
-
 function DiscoveredPortal({
 	mount,
 	rows,
@@ -421,11 +390,15 @@ function PendingRequestsPortal({
 }
 
 export function TeamSyncPanel(props: TeamSyncPanelProps) {
+	// The Team status > Overview portal is intentionally NOT rendered here:
+	// its data is already surfaced by the header presence chip ("Online"
+	// / "Offline") and the "Needs attention" section above. See
+	// docs/plans/2026-04-23-sync-tab-redesign.md (Q3). Status summary props
+	// stay on the panel so the header chip derivation still works.
 	return (
 		<>
 			<ActionContent {...props} />
 			<TeamActionsContent>{props.children}</TeamActionsContent>
-			<TeamStatusPortal mount={props.listMount} statusSummary={props.statusSummary} />
 			<PendingRequestsPortal
 				mount={props.joinRequestsMount}
 				requests={props.pendingJoinRequests}

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -24,6 +24,7 @@ import {
 	setLoadSyncData as setPeopleLoadData,
 } from "./people";
 import { ensureSyncDialogHost } from "./sync-dialogs";
+import { applySyncSubView, ensureSyncSubViewListener } from "./sync-view-controller";
 import {
 	initTeamSyncEvents,
 	renderSyncSharingReview,
@@ -261,6 +262,11 @@ export function initSyncTab(refreshCallback: () => void) {
 	initTeamSyncEvents(refreshCallback, loadSyncData);
 	initPeopleEvents(loadSyncData);
 	initDiagnosticsEvents(refreshCallback);
+
+	// Apply the current #sync vs #sync/diagnostics sub-view and keep it in
+	// sync with future hash changes. See docs/plans/2026-04-23-sync-tab-redesign.md.
+	applySyncSubView();
+	ensureSyncSubViewListener();
 	// loadSyncData() is NOT called here — app.ts refresh() handles the initial load
 	// to avoid duplicate requests and state races at startup.
 }

--- a/packages/ui/src/tabs/sync/sync-view-controller.ts
+++ b/packages/ui/src/tabs/sync/sync-view-controller.ts
@@ -1,0 +1,44 @@
+/* Sync tab sub-view controller.
+ *
+ * The Sync tab hosts two sibling regions inside #tab-sync:
+ *   - #syncMainView          (everything except diagnostics)
+ *   - #syncDiagnosticsView   (the advanced diagnostics card)
+ *
+ * Users switch between them via the URL hash:
+ *   #sync              -> main view
+ *   #sync/diagnostics  -> diagnostics view
+ *
+ * Keeping the toggle here (not in lib/state.ts's tab router) avoids
+ * churning ALL_TAB_IDS and keeps #sync as a single top-level tab in the
+ * nav. See docs/plans/2026-04-23-sync-tab-redesign.md (Q1).
+ */
+
+export type SyncSubView = "main" | "diagnostics";
+
+export function getSyncSubView(): SyncSubView {
+	const hash = window.location.hash.replace(/^#/, "");
+	return hash === "sync/diagnostics" ? "diagnostics" : "main";
+}
+
+export function applySyncSubView(view: SyncSubView = getSyncSubView()): void {
+	const main = document.getElementById("syncMainView");
+	const diag = document.getElementById("syncDiagnosticsView");
+	if (!main || !diag) return;
+	if (view === "diagnostics") {
+		main.hidden = true;
+		diag.hidden = false;
+	} else {
+		main.hidden = false;
+		diag.hidden = true;
+	}
+}
+
+let listenerAttached = false;
+
+export function ensureSyncSubViewListener(): void {
+	if (listenerAttached) return;
+	listenerAttached = true;
+	window.addEventListener("hashchange", () => {
+		applySyncSubView();
+	});
+}

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -16,7 +16,6 @@ import {
 	type TeamSyncDiscoveredRow,
 	TeamSyncPanel,
 	type TeamSyncPendingJoinRequest,
-	type TeamSyncStatusSummary,
 } from "../../components/team-sync-panel";
 import {
 	clearDuplicatePersonDecision,
@@ -92,10 +91,13 @@ function teardownTeamSyncRender(actions: HTMLElement | null, targets: Array<HTML
 export function renderTeamSync() {
 	const meta = document.getElementById("syncTeamMeta");
 	const setupPanel = document.getElementById("syncSetupPanel");
+	// The #syncTeamStatus list + its "Team status" heading are removed with
+	// the overview-card kill (Q3 in the redesign plan). Keep lookups tolerant
+	// for any lingering embedded markup.
 	const list = document.getElementById("syncTeamStatus");
 	const listHeading = list?.previousElementSibling as HTMLElement | null;
 	const actions = document.getElementById("syncTeamActions");
-	if (!meta || !setupPanel || !list || !actions) return;
+	if (!meta || !setupPanel || !actions) return;
 
 	renderAdminSetupDisclosure();
 	renderInvitePolicySelect();
@@ -243,7 +245,7 @@ export function renderTeamSync() {
 	if (!configured) {
 		teardownTeamSyncRender(actions, [list, joinRequests, discoveredList]);
 		setupPanel.hidden = false;
-		list.hidden = true;
+		if (list) list.hidden = true;
 		if (listHeading) listHeading.hidden = true;
 		actions.hidden = true;
 		if (joinRequests) joinRequests.hidden = true;
@@ -252,26 +254,13 @@ export function renderTeamSync() {
 	}
 
 	setupPanel.hidden = true;
-	list.hidden = false;
+	if (list) list.hidden = false;
 	if (listHeading) listHeading.hidden = false;
 	actions.hidden = false;
 
 	const presenceStatus = String(coordinator.presence_status || "");
-	const presenceLabel =
-		presenceStatus === "posted"
-			? "Connected"
-			: presenceStatus === "not_enrolled"
-				? "Needs enrollment"
-				: "Connection error";
 	const localPeers = Array.isArray(state.lastSyncPeers) ? state.lastSyncPeers : [];
 	const attentionItems = Array.isArray(syncView.attentionItems) ? syncView.attentionItems : [];
-	const connectedCount = Number(syncView.summary?.connectedDeviceCount || 0);
-	const seenOnTeamCount = Number(syncView.summary?.seenOnTeamCount || 0);
-	const offlineTeamDeviceCount = Number(syncView.summary?.offlineTeamDeviceCount || 0);
-	const metricParts = [`Connected ${connectedCount}`, `Team ${seenOnTeamCount}`];
-	if (offlineTeamDeviceCount > 0) {
-		metricParts.push(`Offline ${offlineTeamDeviceCount}`);
-	}
 
 	const discoveredDevices = Array.isArray(coordinator.discovered_devices)
 		? coordinator.discovered_devices
@@ -387,60 +376,7 @@ export function renderTeamSync() {
 	).length;
 	const actionableCount =
 		attentionItems.length + pendingJoinRequests.length + discoveredActionableCount;
-	const attentionParts: string[] = [];
-	if (attentionItems.length > 0) {
-		const repairItems = attentionItems.filter((item) => item.kind === "device-needs-repair");
-		const nameItems = attentionItems.filter((item) => item.kind === "name-device");
-		const reviewItems = attentionItems.filter((item) => item.kind === "review-team-device");
-		const duplicateItems = attentionItems.filter(
-			(item) => item.kind === "possible-duplicate-person",
-		);
-		if (repairItems.length > 0)
-			attentionParts.push(
-				`${repairItems.length} device issue${repairItems.length === 1 ? "" : "s"} to review`,
-			);
-		if (nameItems.length > 0)
-			attentionParts.push(`${nameItems.length} device${nameItems.length === 1 ? "" : "s"} to name`);
-		if (reviewItems.length > 0)
-			attentionParts.push(
-				`${reviewItems.length} device${reviewItems.length === 1 ? "" : "s"} to review`,
-			);
-		if (duplicateItems.length > 0)
-			attentionParts.push(
-				`${duplicateItems.length} possible duplicate${duplicateItems.length === 1 ? "" : "s"}`,
-			);
-	}
-	if (pendingJoinRequests.length > 0)
-		attentionParts.push(
-			`${pendingJoinRequests.length} join request${pendingJoinRequests.length === 1 ? "" : "s"} to review`,
-		);
-	if (discoveredActionableCount > 0)
-		attentionParts.push(
-			`${discoveredActionableCount} discovered device${discoveredActionableCount === 1 ? "" : "s"}`,
-		);
-	const attentionDetail = attentionParts.join(", ");
 	const teamLabel = (coordinator.groups || []).join(", ") || "none";
-	const statusSummary: TeamSyncStatusSummary = {
-		badgeClassName: `pill ${presenceStatus === "posted" ? "pill-success" : presenceStatus === "not_enrolled" ? "pill-warning" : "pill-error"}`,
-		detail:
-			presenceStatus === "posted"
-				? actionableCount > 0
-					? `Team ${teamLabel}. Work through Needs attention above, then review people and devices.`
-					: `Team ${teamLabel}. Nothing urgent is blocking sync right now.`
-				: presenceStatus === "not_enrolled"
-					? `Team ${teamLabel}. Enroll this device first, then return here to review the rest of the team.`
-					: `Team ${teamLabel}. Fix the current sync issue first, then verify the rest of the team state.`,
-		headline:
-			presenceStatus === "posted"
-				? actionableCount > 0
-					? attentionDetail
-					: "Everything is healthy"
-				: presenceStatus === "not_enrolled"
-					? "This device is not enrolled in the team yet"
-					: "Sync needs attention",
-		metricsText: metricParts.join(" · "),
-		presenceLabel,
-	};
 	meta.textContent =
 		presenceStatus === "posted"
 			? actionableCount > 0
@@ -628,7 +564,6 @@ export function renderTeamSync() {
 			},
 			pendingJoinRequests,
 			presenceStatus,
-			statusSummary,
 		}),
 	);
 }

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -808,6 +808,41 @@
         align-items: center;
       }
 
+      /* Header link that points at a sibling sub-surface (e.g. the sync
+         diagnostics view). Deliberately quieter than a filled or ghost
+         button — it's navigation, not action. */
+      .sync-diagnostics-link {
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--text-secondary);
+        text-decoration: none;
+        padding: 6px 8px;
+        border-radius: var(--radius-sm);
+        transition: color 140ms ease, background 140ms ease;
+      }
+      .sync-diagnostics-link:hover,
+      .sync-diagnostics-link:focus-visible {
+        color: var(--accent);
+        background: color-mix(in srgb, var(--accent) 8%, transparent);
+        outline: none;
+      }
+      .sync-diagnostics-link:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .sync-diagnostics-back-link {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--text-secondary);
+        text-decoration: none;
+        margin-right: var(--sp-2);
+      }
+      .sync-diagnostics-back-link:hover,
+      .sync-diagnostics-back-link:focus-visible {
+        color: var(--accent);
+      }
+
       .section-meta {
         color: var(--text-tertiary);
         font-size: 12px;
@@ -3124,6 +3159,10 @@
     <!-- ── Tab: Sync ───────────────────────────────────────── -->
     <div class="tab-panel" id="tab-sync" hidden>
 
+      <!-- Sub-view: main Sync surface. Toggled by syncViewController
+           based on #sync vs #sync/diagnostics in the URL hash. -->
+      <div id="syncMainView">
+
       <!-- 1. Needs attention + team setup/status -->
       <div class="card" id="syncTeamCard">
         <div class="section-header">
@@ -3133,6 +3172,7 @@
           </div>
           <div class="section-actions">
             <button class="settings-button" id="syncNowButton">Sync now</button>
+            <a class="sync-diagnostics-link" href="#sync/diagnostics">View diagnostics &rarr;</a>
           </div>
         </div>
         <div class="section-meta" id="syncTeamMeta">Start with the next step below, then review team status and device details.</div>
@@ -3156,8 +3196,6 @@
             <div id="syncAdminDisclosureMount" style="display: contents"></div>
           </div>
         </div>
-        <h3 class="settings-group-title" style="margin-top: 20px">Team status</h3>
-        <div class="actor-list" id="syncTeamStatus" aria-live="polite"></div>
         <div class="actor-list" id="syncJoinRequests"></div>
         <div id="syncCoordinatorDiscovered" hidden>
           <h3 class="settings-group-title" style="margin-top: 20px">Devices seen on team</h3>
@@ -3216,10 +3254,17 @@
         </div>
       </div>
 
-      <!-- 3. Advanced diagnostics — status, attempts -->
+      </div><!-- /#syncMainView -->
+
+      <!-- Sub-view: Advanced diagnostics. Reached via #sync/diagnostics;
+           shown by syncViewController when that hash is active. -->
+      <div id="syncDiagnosticsView" hidden>
       <div class="card" style="animation-delay: 0.06s">
         <div class="section-header">
-          <h2>Advanced diagnostics</h2>
+          <div class="section-header-title">
+            <a class="sync-diagnostics-back-link" href="#sync">&larr; Back to sync</a>
+            <h2>Sync diagnostics</h2>
+          </div>
           <div class="section-actions">
             <label class="small sync-redact-control">
               <span id="syncRedactMount"></span>
@@ -3227,7 +3272,7 @@
             </label>
           </div>
         </div>
-        <div class="section-meta" id="syncMeta">Use this section for sync debugging and recent attempt details.</div>
+        <div class="section-meta" id="syncMeta">Use this surface for sync debugging and recent attempt details.</div>
         <div class="sync-skeleton" id="syncDiagSkeleton" role="status" aria-label="Loading diagnostics">
           <div class="sync-skeleton-line long"></div>
           <div class="sync-skeleton-line medium"></div>
@@ -3236,9 +3281,10 @@
         <div class="sync-actions" id="syncActions"></div>
         <div class="grid-2" id="syncStatusGrid"></div>
 
-        <h3 class="settings-group-title" style="margin-top: 20px">Recent sync attempts (advanced)</h3>
+        <h3 class="settings-group-title" style="margin-top: 20px">Recent sync attempts</h3>
         <div class="attempts-list" id="syncAttempts"></div>
       </div>
+      </div><!-- /#syncDiagnosticsView -->
     </div>
 
     <div class="tab-panel" id="tab-coordinator-admin" hidden>


### PR DESCRIPTION
## Description

PR 1 of the Sync tab redesign (plan:
docs/plans/2026-04-23-sync-tab-redesign.md). Two cuts that together
deliver the biggest single density win the plan targets:

- **Advanced diagnostics moves to a sub-view** at #sync/diagnostics. The
  Sync tab now has two sibling regions inside \`#tab-sync\`:
  \`#syncMainView\` and \`#syncDiagnosticsView\`, toggled by a new
  \`sync-view-controller.ts\` that reads the URL hash. A "View
  diagnostics →" link in the Sync tab header navigates there; a
  "← Back to sync" link above the diagnostics card returns to the main
  view. The tab router in \`state.ts\` was taught to strip the
  \`/diagnostics\` segment before matching so \`#sync/diagnostics\` still
  activates the sync tab.
- **Team status > Overview card removed.** The portal + the
  statusSummary derivation in render-team-sync.ts are gone; the presence
  signal lives in the header chip and the Needs attention section above.

PRs 2-4 continue the redesign: DeviceRow + DeviceDetailDrawer (2),
PresencePip state matrix + skeletons + empty states (3), handoff
anatomy pages (4).

## Type of Change

- [x] UX redesign (plan-backed)

## Testing

- \`pnpm run tsc && pnpm run lint && pnpm run test\` (1475 passing, 385
  files linted)
- Manual (next step): Sync tab header shows "View diagnostics →", clicking
  it swaps in the diagnostics sub-view; back link returns to main. Team
  status Overview card no longer renders.