### PR TITLE
ui(sync): compact device rows with click-to-expand drawer + shared primitives

### DIFF
--- a/packages/ui/src/components/primitives/action-shelf.tsx
+++ b/packages/ui/src/components/primitives/action-shelf.tsx
@@ -1,0 +1,50 @@
+/* ActionShelf — list / region toolbar with one primary + N secondary buttons.
+ *
+ * Enforces the "at most one filled-primary button per line of sight" rule
+ * from docs/plans/2026-04-23-sync-tab-redesign.md (visual-hierarchy). Use
+ * this anywhere a region needs a title row with trailing actions (e.g. a
+ * devices list toolbar). Wraps below 900px when constrained.
+ */
+
+export interface ActionShelfAction {
+	label: string;
+	onClick: () => void | Promise<void>;
+	disabled?: boolean;
+	busy?: boolean;
+	"aria-label"?: string;
+}
+
+export interface ActionShelfProps {
+	primary?: ActionShelfAction;
+	secondary?: ActionShelfAction[];
+	align?: "start" | "end";
+}
+
+function ActionButton({ action, primary }: { action: ActionShelfAction; primary: boolean }) {
+	const busy = Boolean(action.busy);
+	return (
+		<button
+			aria-busy={busy}
+			aria-label={action["aria-label"]}
+			className={primary ? "settings-button sync-btn-primary" : "settings-button"}
+			disabled={action.disabled || busy}
+			onClick={() => {
+				void action.onClick();
+			}}
+			type="button"
+		>
+			{action.label}
+		</button>
+	);
+}
+
+export function ActionShelf({ primary, secondary, align = "end" }: ActionShelfProps) {
+	return (
+		<div className={`action-shelf action-shelf-align-${align}`} role="toolbar" aria-label="Actions">
+			{(secondary ?? []).map((action, index) => (
+				<ActionButton action={action} key={`secondary-${index}-${action.label}`} primary={false} />
+			))}
+			{primary ? <ActionButton action={primary} primary /> : null}
+		</div>
+	);
+}

--- a/packages/ui/src/components/primitives/presence-pip.tsx
+++ b/packages/ui/src/components/primitives/presence-pip.tsx
@@ -1,0 +1,37 @@
+/* PresencePip — atomic presence/health indicator.
+ *
+ * A small colored dot used in device rows, attention rows, and anywhere
+ * else we need a compact health signal. Color + pulse convey the state;
+ * an aria-label carries the semantic for assistive tech.
+ *
+ * See docs/plans/2026-04-23-sync-tab-redesign.md (loading-states section)
+ * for the full state matrix and color-source rationale. */
+
+export type PresenceState = "online" | "offline" | "degraded" | "attention" | "syncing" | "unknown";
+
+export interface PresencePipProps {
+	state: PresenceState;
+	size?: 6 | 8;
+	"aria-label"?: string;
+}
+
+const DEFAULT_LABEL: Record<PresenceState, string> = {
+	online: "Online",
+	offline: "Offline",
+	degraded: "Degraded",
+	attention: "Action required",
+	syncing: "Syncing",
+	unknown: "Status unknown",
+};
+
+export function PresencePip({ state, size = 8, "aria-label": ariaLabel }: PresencePipProps) {
+	const label = ariaLabel ?? DEFAULT_LABEL[state];
+	return (
+		<span
+			aria-label={label}
+			className={`presence-pip presence-pip--${state}`}
+			role="img"
+			style={`--presence-pip-size: ${size}px`}
+		/>
+	);
+}

--- a/packages/ui/src/components/primitives/trust-chip.tsx
+++ b/packages/ui/src/components/primitives/trust-chip.tsx
@@ -1,0 +1,41 @@
+/* TrustChip — typed chip wrapper for peer trust state.
+ *
+ * Maps a four-state trust model to the existing `Chip` primitive's
+ * scope-variant vocabulary with a tone derived from state. Keeps copy +
+ * tone decisions in one place so device rows, drawers, and future
+ * admin surfaces render trust identically.
+ *
+ * See docs/plans/2026-04-23-sync-tab-redesign.md for trust-state
+ * semantics and chip tone mappings. */
+
+import { Chip } from "./chip";
+
+export type TrustState = "two-way" | "you-trust-them" | "they-trust-you" | "not-trusted";
+
+export interface TrustChipProps {
+	state: TrustState;
+	compact?: boolean;
+}
+
+const LABELS: Record<TrustState, { long: string; short: string }> = {
+	"two-way": { long: "Two-way trust", short: "Mutual" },
+	"you-trust-them": { long: "You trust them", short: "You → them" },
+	"they-trust-you": { long: "They trust you", short: "Them → you" },
+	"not-trusted": { long: "Not trusted", short: "Not trusted" },
+};
+
+const TONES: Record<TrustState, "ok" | "pending" | "warn"> = {
+	"two-way": "ok",
+	"you-trust-them": "pending",
+	"they-trust-you": "pending",
+	"not-trusted": "warn",
+};
+
+export function TrustChip({ state, compact = false }: TrustChipProps) {
+	const label = compact ? LABELS[state].short : LABELS[state].long;
+	return (
+		<Chip variant="scope" tone={TONES[state]} title={LABELS[state].long}>
+			{label}
+		</Chip>
+	);
+}

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -1,5 +1,6 @@
 import type { TargetedInputEvent } from "preact";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
+import { PresencePip, type PresenceState } from "../../../components/primitives/presence-pip";
 import { RadixSelect } from "../../../components/primitives/radix-select";
 import { TextInput } from "../../../components/primitives/text-input";
 import { formatTimestamp } from "../../../lib/format";
@@ -18,9 +19,50 @@ import { openSyncConfirmDialog } from "../sync-dialogs";
 import {
 	derivePeerDirection,
 	derivePeerTrustSummary,
+	derivePeerUiStatus,
 	type PeerDirection,
 	type PeerLike,
 } from "../view-model";
+
+/* Map the view-model's UI-status vocabulary to the PresencePip state
+ * matrix defined in docs/plans/2026-04-23-sync-tab-redesign.md. */
+function presenceForPeer(peer: PeerLike): PresenceState {
+	switch (derivePeerUiStatus(peer)) {
+		case "connected":
+			return "online";
+		case "offline":
+			return "offline";
+		case "needs-repair":
+			return "attention";
+		default:
+			return "unknown";
+	}
+}
+
+/* Module-level expand state — only one device drawer open at a time.
+ * The row component subscribes via a tick counter in local state so
+ * React re-renders when the global pointer changes. */
+let expandedPeerId: string | null = null;
+let expandTickCounter = 0;
+const expandListeners = new Set<(tick: number) => void>();
+
+function setExpandedPeer(peerId: string | null): void {
+	if (expandedPeerId === peerId) return;
+	expandedPeerId = peerId;
+	expandTickCounter += 1;
+	for (const listener of expandListeners) listener(expandTickCounter);
+}
+
+function useExpandedPeer(): string | null {
+	const [, setTick] = useState(0);
+	useEffect(() => {
+		expandListeners.add(setTick);
+		return () => {
+			expandListeners.delete(setTick);
+		};
+	}, []);
+	return expandedPeerId;
+}
 
 const DIRECTION_GLYPH: Record<PeerDirection, { glyph: string; label: string } | null> = {
 	bidirectional: { glyph: "↕", label: "Bidirectional sync in the last 24 hours" },
@@ -342,173 +384,199 @@ function SyncPeerCard({
 		}
 	}
 
+	const currentExpandedId = useExpandedPeer();
+	const isExpanded = currentExpandedId === peerId && peerId !== "";
+	const drawerId = `device-drawer-${peerId || "unknown"}`;
+	const presenceState = presenceForPeer(peer);
+	const syncMetaText = lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never";
+
 	return (
 		<div ref={cardRef} className="peer-card" data-peer-device-id={peerId || undefined}>
-			<div className="peer-title">
-				<div>
-					<strong title={peerId || undefined}>{displayName}</strong>
-					{directionHint ? (
+			<button
+				aria-controls={drawerId}
+				aria-expanded={isExpanded}
+				className="device-row-head"
+				onClick={() => setExpandedPeer(isExpanded ? null : peerId)}
+				type="button"
+			>
+				<PresencePip state={presenceState} />
+				<span className="device-row-name" title={peerId || undefined}>
+					{displayName}
+				</span>
+				{directionHint ? (
+					<span
+						aria-label={directionHint.label}
+						className="peer-direction"
+						role="img"
+						title={directionHint.label}
+					>
+						{directionHint.glyph}
+					</span>
+				) : null}
+				<span className="device-row-chips">
+					<span className={`badge ${trustSummary.isWarning ? "badge-offline" : "badge-online"}`}>
+						{trustSummary.badgeLabel}
+					</span>
+					{pendingScopeReview ? (
+						<span className="badge actor-badge">Needs scope review</span>
+					) : null}
+					{peer.discovered_via_group_id ? (
 						<span
-							aria-label={directionHint.label}
-							className="peer-direction"
-							role="img"
-							title={directionHint.label}
+							className="badge actor-badge"
+							title={`Discovered through coordinator group ${peer.discovered_via_group_id}`}
 						>
-							{directionHint.glyph}
+							{`via ${peer.discovered_via_group_id}`}
 						</span>
 					) : null}
-					<div className="peer-meta">
-						<span className={`badge ${trustSummary.isWarning ? "badge-offline" : "badge-online"}`}>
-							{trustSummary.badgeLabel}
-						</span>
-						{pendingScopeReview ? (
-							<span className="badge actor-badge">Needs scope review</span>
-						) : null}
-						{peer.discovered_via_group_id ? (
-							<span
-								className="badge actor-badge"
-								title={`Discovered through coordinator group ${peer.discovered_via_group_id}`}
-							>
-								{`via ${peer.discovered_via_group_id}`}
-							</span>
-						) : null}
-					</div>
-				</div>
+				</span>
+				<span className="device-row-meta">{syncMetaText}</span>
+				<span aria-hidden="true" className="device-row-chevron">
+					{isExpanded ? "▾" : "▸"}
+				</span>
+			</button>
 
-				<div className="peer-actions">
-					<button
-						type="button"
-						className="settings-button"
-						disabled={!primaryAddress || syncBusy}
-						onClick={() => void sync()}
-					>
-						{syncBusy ? "Syncing…" : "Sync now"}
-					</button>
-					<div className="sync-labeled-field">
-						<label
-							className="sync-labeled-field-caption"
-							htmlFor={`device-name-${peerId || "unknown"}`}
-						>
-							Device name
-						</label>
-						<TextInput
-							aria-label={`Friendly name for ${displayName}`}
-							className="peer-scope-input"
-							data-device-name-input={peerId || undefined}
-							disabled={renameBusy}
-							id={`device-name-${peerId || "unknown"}`}
-							placeholder="Friendly device name"
-							type="text"
-							value={renameValue}
-							onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
-								setRenameValue(event.currentTarget.value)
-							}
-						/>
-					</div>
-					<button
-						type="button"
-						className="settings-button"
-						disabled={renameBusy}
-						onClick={() => void rename()}
-					>
-						{renameLabel}
-					</button>
-					<button
-						type="button"
-						className="settings-button danger"
-						disabled={removeBusy}
-						onClick={() => void remove()}
-					>
-						{removeLabel}
-					</button>
-				</div>
-			</div>
-
-			<div className="peer-scope">
-				{scopeReviewRequested ? (
-					<div className="peer-meta">
-						Review this device&apos;s sharing rules now if the defaults are too broad.
-					</div>
-				) : pendingScopeReview ? (
-					<div className="peer-meta">Sharing rule review is still pending for this device.</div>
-				) : null}
-
-				<div className="peer-scope-summary">Device details</div>
-				<div className="peer-addresses">{addressLine}</div>
-				<div className="peer-meta">
-					{[
-						lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never",
-						lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : "Ping: never",
-					].join(" · ")}
-				</div>
-
-				<div className="peer-scope-summary">Who this device belongs to</div>
-				<div className="peer-meta">{assignmentSummary}</div>
-				<div className="peer-actor-row">
-					<div className="sync-radix-select-host sync-actor-select-host">
-						<RadixSelect
-							ariaLabel={`Assigned person for ${displayName}`}
-							contentClassName="sync-radix-select-content sync-actor-select-content"
-							disabled={applyActorBusy}
-							itemClassName="sync-radix-select-item"
-							onValueChange={setSelectedActorId}
-							options={actorSelectOptions}
-							placeholder="No person assigned yet"
-							triggerClassName="sync-radix-select-trigger sync-actor-select"
-							value={selectedActorId}
-							viewportClassName="sync-radix-select-viewport"
-						/>
-					</div>
-					<button
-						type="button"
-						className="settings-button"
-						disabled={applyActorBusy}
-						onClick={() => void savePerson()}
-					>
-						{applyActorLabel}
-					</button>
-				</div>
-
-				<div className="peer-scope-summary">Advanced sharing scope</div>
-				<div className="peer-meta">
-					Review or tighten what this device can share when you need more than the global defaults.
-				</div>
-				<PeerScopeCollapsible
-					contentHost={scopeHost}
-					initialOpen={scopeEditorOpen}
-					onOpenChange={(open) => {
-						if (open) openPeerScopeEditors.add(peerId);
-						else openPeerScopeEditors.delete(peerId);
-					}}
+			{isExpanded ? (
+				<section
+					aria-label={`Device actions for ${displayName}`}
+					className="device-row-drawer"
+					id={drawerId}
 				>
-					<div>
-						<div className="peer-scope-row">
-							<ExistingElementSlot element={includeEditor.element} />
-							<ExistingElementSlot element={excludeEditor.element} />
-						</div>
-						<div className="peer-scope-actions">
-							<button
-								type="button"
-								className="settings-button"
-								disabled={saveScopeBusy}
-								onClick={() => void saveScope()}
+					<div className="peer-actions">
+						<button
+							type="button"
+							className="settings-button"
+							disabled={!primaryAddress || syncBusy}
+							onClick={() => void sync()}
+						>
+							{syncBusy ? "Syncing…" : "Sync now"}
+						</button>
+						<div className="sync-labeled-field">
+							<label
+								className="sync-labeled-field-caption"
+								htmlFor={`device-name-${peerId || "unknown"}`}
 							>
-								{saveScopeLabel}
-							</button>
-							<button
-								type="button"
-								className="settings-button"
-								disabled={resetScopeBusy}
-								onClick={() => void resetScope()}
-							>
-								{resetScopeLabel}
-							</button>
+								Device name
+							</label>
+							<TextInput
+								aria-label={`Friendly name for ${displayName}`}
+								className="peer-scope-input"
+								data-device-name-input={peerId || undefined}
+								disabled={renameBusy}
+								id={`device-name-${peerId || "unknown"}`}
+								placeholder="Friendly device name"
+								type="text"
+								value={renameValue}
+								onInput={(event: TargetedInputEvent<HTMLInputElement>) =>
+									setRenameValue(event.currentTarget.value)
+								}
+							/>
 						</div>
+						<button
+							type="button"
+							className="settings-button"
+							disabled={renameBusy}
+							onClick={() => void rename()}
+						>
+							{renameLabel}
+						</button>
+						<button
+							type="button"
+							className="settings-button danger"
+							disabled={removeBusy}
+							onClick={() => void remove()}
+						>
+							{removeLabel}
+						</button>
 					</div>
-				</PeerScopeCollapsible>
-				<SyncInlineFeedback feedback={feedback} />
-				<div ref={setScopeHost} />
-			</div>
+
+					<div className="peer-scope">
+						{scopeReviewRequested ? (
+							<div className="peer-meta">
+								Review this device&apos;s sharing rules now if the defaults are too broad.
+							</div>
+						) : pendingScopeReview ? (
+							<div className="peer-meta">Sharing rule review is still pending for this device.</div>
+						) : null}
+
+						<div className="peer-scope-summary">Device details</div>
+						<div className="peer-addresses">{addressLine}</div>
+						<div className="peer-meta">
+							{[
+								lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never",
+								lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : "Ping: never",
+							].join(" · ")}
+						</div>
+
+						<div className="peer-scope-summary">Who this device belongs to</div>
+						<div className="peer-meta">{assignmentSummary}</div>
+						<div className="peer-actor-row">
+							<div className="sync-radix-select-host sync-actor-select-host">
+								<RadixSelect
+									ariaLabel={`Assigned person for ${displayName}`}
+									contentClassName="sync-radix-select-content sync-actor-select-content"
+									disabled={applyActorBusy}
+									itemClassName="sync-radix-select-item"
+									onValueChange={setSelectedActorId}
+									options={actorSelectOptions}
+									placeholder="No person assigned yet"
+									triggerClassName="sync-radix-select-trigger sync-actor-select"
+									value={selectedActorId}
+									viewportClassName="sync-radix-select-viewport"
+								/>
+							</div>
+							<button
+								type="button"
+								className="settings-button"
+								disabled={applyActorBusy}
+								onClick={() => void savePerson()}
+							>
+								{applyActorLabel}
+							</button>
+						</div>
+
+						<div className="peer-scope-summary">Advanced sharing scope</div>
+						<div className="peer-meta">
+							Review or tighten what this device can share when you need more than the global
+							defaults.
+						</div>
+						<PeerScopeCollapsible
+							contentHost={scopeHost}
+							initialOpen={scopeEditorOpen}
+							onOpenChange={(open) => {
+								if (open) openPeerScopeEditors.add(peerId);
+								else openPeerScopeEditors.delete(peerId);
+							}}
+						>
+							<div>
+								<div className="peer-scope-row">
+									<ExistingElementSlot element={includeEditor.element} />
+									<ExistingElementSlot element={excludeEditor.element} />
+								</div>
+								<div className="peer-scope-actions">
+									<button
+										type="button"
+										className="settings-button"
+										disabled={saveScopeBusy}
+										onClick={() => void saveScope()}
+									>
+										{saveScopeLabel}
+									</button>
+									<button
+										type="button"
+										className="settings-button"
+										disabled={resetScopeBusy}
+										onClick={() => void resetScope()}
+									>
+										{resetScopeLabel}
+									</button>
+								</div>
+							</div>
+						</PeerScopeCollapsible>
+						<SyncInlineFeedback feedback={feedback} />
+						<div ref={setScopeHost} />
+					</div>
+				</section>
+			) : null}
 		</div>
 	);
 }

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -957,6 +957,103 @@
         box-shadow: 0 0 0 4px var(--focus-ring);
       }
 
+      /* Primary-filled variant: the only filled-accent button on its
+         line of sight. See docs/plans/2026-04-23-sync-tab-redesign.md. */
+      .settings-button.sync-btn-primary {
+        background: color-mix(in srgb, var(--accent) 88%, transparent);
+        border-color: color-mix(in srgb, var(--accent) 60%, var(--control-border));
+        color: var(--surface-0);
+        font-weight: 600;
+      }
+      .settings-button.sync-btn-primary:hover {
+        background: var(--accent);
+        border-color: var(--accent);
+      }
+
+      /* ActionShelf toolbar: trailing buttons right-aligned by default;
+         wraps to a new line when the row can't fit. */
+      .action-shelf {
+        display: flex;
+        gap: var(--sp-2);
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .action-shelf-align-end   { justify-content: flex-end; }
+      .action-shelf-align-start { justify-content: flex-start; }
+
+      /* Device-row compact header (the clickable band above the drawer).
+         See docs/plans/2026-04-23-sync-tab-redesign.md (PR 2). */
+      .device-row-head {
+        display: grid;
+        grid-template-columns: auto 1fr auto auto auto;
+        align-items: center;
+        gap: var(--sp-3);
+        width: 100%;
+        min-height: 56px;
+        padding: 10px var(--sp-3);
+        background: transparent;
+        border: none;
+        border-radius: var(--radius-lg);
+        cursor: pointer;
+        color: inherit;
+        text-align: left;
+        font: inherit;
+      }
+      .device-row-head:hover {
+        background: color-mix(in srgb, var(--surface-2) 60%, transparent);
+      }
+      .device-row-head:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      .device-row-head .device-row-name {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-primary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        min-width: 0;
+      }
+      .device-row-head .device-row-chips {
+        display: inline-flex;
+        gap: 6px;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+      .device-row-head .device-row-meta {
+        font-size: 12px;
+        color: var(--text-tertiary);
+        font-feature-settings: 'tnum' 1;
+        white-space: nowrap;
+      }
+      .device-row-head .device-row-chevron {
+        font-size: 12px;
+        color: var(--text-tertiary);
+        transition: transform 140ms ease;
+        font-family: var(--font-mono);
+      }
+      @media (max-width: 900px) {
+        .device-row-head {
+          grid-template-columns: auto 1fr auto;
+        }
+        .device-row-head .device-row-chips,
+        .device-row-head .device-row-meta {
+          grid-column: 1 / -1;
+          padding-left: calc(var(--presence-pip-size, 8px) + var(--sp-3));
+        }
+      }
+
+      /* Drawer content region revealed when the row is expanded.
+         Keeps the existing .peer-actions / .peer-scope styling intact —
+         this is just the outer wrapper + separator line. */
+      .device-row-drawer {
+        padding: var(--sp-3) var(--sp-4) var(--sp-4);
+        border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+        display: grid;
+        gap: var(--sp-3);
+      }
+
       .sync-redact-control {
         display: inline-flex;
         align-items: center;
@@ -1772,6 +1869,50 @@
       .peer-scope-chips { display: flex; flex-wrap: wrap; gap: 6px; min-height: 32px; align-items: flex-start; padding: 8px 10px; margin: 0; list-style: none; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); }
       .peer-scope-chip { padding: 4px 8px; background: rgba(43, 122, 176, 0.12); color: var(--accent); font-size: 12px; }
       .peer-scope-chip.empty { background: transparent; color: var(--text-tertiary); border-style: dashed; border-color: var(--border); }
+      /* Trust-state tones — see design_handoff_codemem_viewer/
+         reference/DESIGN_SYSTEM.md and docs/plans/2026-04-23-sync-tab-redesign.md */
+      .peer-scope-chip.ok {
+        background: color-mix(in srgb, var(--accent) 14%, transparent);
+        color: var(--accent);
+      }
+      .peer-scope-chip.pending {
+        background: color-mix(in srgb, var(--accent-cool, var(--accent)) 12%, transparent);
+        color: var(--accent-cool, var(--accent));
+      }
+      .peer-scope-chip.warn {
+        background: color-mix(in srgb, var(--accent-warm, var(--accent)) 16%, transparent);
+        color: var(--accent-warm, var(--accent));
+      }
+
+      /* PresencePip — atomic health indicator.
+         See docs/plans/2026-04-23-sync-tab-redesign.md (loading-states). */
+      .presence-pip {
+        display: inline-block;
+        width: var(--presence-pip-size, 8px);
+        height: var(--presence-pip-size, 8px);
+        border-radius: 50%;
+        flex-shrink: 0;
+        vertical-align: middle;
+      }
+      .presence-pip--online    { background: var(--accent); }
+      .presence-pip--offline   { background: var(--accent-warm, var(--accent)); }
+      .presence-pip--degraded  { background: var(--accent-warm, var(--accent)); }
+      .presence-pip--attention { background: var(--accent-warm-strong, var(--accent-warm, var(--accent))); animation: pip-attention 2.4s ease-in-out infinite; }
+      .presence-pip--syncing   { background: var(--accent); animation: pip-syncing 1.2s ease-in-out infinite; }
+      .presence-pip--unknown   { background: var(--text-tertiary); opacity: 0.6; }
+
+      @keyframes pip-attention {
+        0%, 100% { opacity: 0.6; transform: scale(1); }
+        50%      { opacity: 1;   transform: scale(1.15); }
+      }
+      @keyframes pip-syncing {
+        0%, 100% { opacity: 0.55; }
+        50%      { opacity: 1; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .presence-pip--attention,
+        .presence-pip--syncing { animation: none; opacity: 1; transform: none; }
+      }
       .peer-scope-chip-remove { border: none; background: transparent; color: inherit; cursor: pointer; padding: 0; font: inherit; opacity: 0.75; }
       .peer-scope-chip-remove:hover { opacity: 1; }
       .peer-scope-input { width: 100%; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--text-primary); padding: 8px 10px; font: inherit; }


### PR DESCRIPTION
## Description

PR 2 of the Sync tab redesign (plan:
docs/plans/2026-04-23-sync-tab-redesign.md). Changes how each device
is presented in the People & devices list:

- **Compact row header.** Every device now renders as a 56px
  clickable row: PresencePip · name · direction arrow · trust badge ·
  "Sync: {timestamp}" meta · chevron. Hover elevates, focus-visible
  draws a 2px accent outline.
- **Click-to-expand drawer.** Clicking a row expands an in-place
  drawer that carries the existing device-management surface
  (Sync now / rename / remove / ownership assignment / sharing
  scope). Only one row's drawer is open at a time; clicking another
  row collapses the previous one.
- **aria-expanded / aria-controls** on each row button, a `section`
  landmark for the drawer with a descriptive \`aria-label\`.
- **Shared primitives** added:
  - \`PresencePip\` (atom) with 6-state matrix (online / offline /
    degraded / attention / syncing / unknown), pulse animations
    gated by \`prefers-reduced-motion\`.
  - \`TrustChip\` (molecule wrapping Chip) for trust-state tone
    mapping. Not wired into the row yet — deferred to a follow-up
    so the existing trust badge render path stays intact.
  - \`ActionShelf\` (molecule) for toolbar-style primary +
    secondary buttons.
- **Primary-filled button variant** (\`settings-button.sync-btn-primary\`)
  for the "at most one filled-accent button per line of sight" rule.

## Type of Change

- [x] UX redesign (plan-backed)
- [x] New shared primitives (additive)

## Testing

- \`pnpm run tsc && pnpm run lint && pnpm run test\` (1475 passing)
- Manual (next step): Sync tab — click a device row; drawer expands
  inline. Click another row; previous collapses. All existing device
  actions (rename, sync, remove, scope, ownership) work unchanged.

Stacked on #963. PR 3 adds the loading-states vocabulary (skeletons,
empty state, pulse + pip wiring on Sync now). PR 4 is the handoff
anatomy pages.