### PR TITLE
ui(sync): syncing-pip override, device-row skeleton, empty-state rewrite

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -387,7 +387,10 @@ function SyncPeerCard({
 	const currentExpandedId = useExpandedPeer();
 	const isExpanded = currentExpandedId === peerId && peerId !== "";
 	const drawerId = `device-drawer-${peerId || "unknown"}`;
-	const presenceState = presenceForPeer(peer);
+	// Override the derived presence with "syncing" while this device is
+	// actively being contacted via Sync now — per the loading-states
+	// vocabulary in docs/plans/2026-04-23-sync-tab-redesign.md.
+	const presenceState: PresenceState = syncBusy ? "syncing" : presenceForPeer(peer);
 	const syncMetaText = lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never";
 
 	return (
@@ -592,10 +595,10 @@ function SyncPeersList(props: SyncPeersListProps) {
 				<SyncEmptyState
 					detail={
 						syncDisabled
-							? "Turn on sync in Settings → Device Sync first, then use Show pairing command under Connect another device to connect another device."
-							: "Use Show pairing command under Connect another device, run the command on the other device, then come back here to name it and decide who it belongs to."
+							? "Turn on sync in Settings → Device Sync first. Then use Invite a teammate or Paste an invite above to connect another device."
+							: "Use Invite a teammate above to share a join code, or Paste an invite to enroll this device on an existing team."
 					}
-					title="No devices connected here yet."
+					title="No teammates yet"
 				/>
 			</>
 		);

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1054,6 +1054,60 @@
         gap: var(--sp-3);
       }
 
+      /* Device-row skeleton (shown during the initial sync load). Shape
+         matches the real row so layout doesn't shift when data arrives.
+         See docs/plans/2026-04-23-sync-tab-redesign.md (loading-states). */
+      .device-row-skeleton-list {
+        display: grid;
+        gap: var(--sp-2);
+      }
+      .device-row-skeleton {
+        display: flex;
+        align-items: center;
+        gap: var(--sp-3);
+        min-height: 56px;
+        padding: 10px var(--sp-3);
+        border-radius: var(--radius-lg);
+        border: 1px solid var(--border);
+        background: var(--surface-1);
+      }
+      .device-row-skeleton .skel-pip,
+      .device-row-skeleton .skel-name,
+      .device-row-skeleton .skel-chip {
+        display: inline-block;
+        border-radius: var(--radius-sm);
+        background: linear-gradient(90deg,
+          color-mix(in srgb, var(--surface-2) 82%, var(--surface-1)) 25%,
+          color-mix(in srgb, var(--surface-2) 60%, var(--surface-1)) 50%,
+          color-mix(in srgb, var(--surface-2) 82%, var(--surface-1)) 75%);
+        background-size: 200% 100%;
+        animation: device-skel-shimmer 1.5s ease-in-out infinite;
+      }
+      .device-row-skeleton .skel-pip {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+      }
+      .device-row-skeleton .skel-name {
+        flex: 1;
+        max-width: 180px;
+        height: 14px;
+      }
+      .device-row-skeleton .skel-chip {
+        width: 80px;
+        height: 18px;
+        border-radius: var(--radius-pill);
+      }
+      @keyframes device-skel-shimmer {
+        0%   { background-position: 200% 0; }
+        100% { background-position: -200% 0; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .device-row-skeleton .skel-pip,
+        .device-row-skeleton .skel-name,
+        .device-row-skeleton .skel-chip { animation: none; }
+      }
+
       .sync-redact-control {
         display: inline-flex;
         align-items: center;
@@ -3366,9 +3420,10 @@
 
         <h3 class="settings-group-title" style="margin-top: 20px">Devices</h3>
         <div class="peer-list" id="syncPeers"></div>
-        <div class="sync-skeleton" id="syncPeersSkeleton" role="status" aria-label="Loading devices">
-          <div class="sync-skeleton-block"></div>
-          <div class="sync-skeleton-block"></div>
+        <div class="device-row-skeleton-list" id="syncPeersSkeleton" role="status" aria-label="Loading devices" aria-busy="true">
+          <div class="device-row-skeleton"><span class="skel-pip"></span><span class="skel-name"></span><span class="skel-chip"></span></div>
+          <div class="device-row-skeleton"><span class="skel-pip"></span><span class="skel-name"></span><span class="skel-chip"></span></div>
+          <div class="device-row-skeleton"><span class="skel-pip"></span><span class="skel-name"></span><span class="skel-chip"></span></div>
         </div>
 
         <h3 class="settings-group-title" style="margin-top: 20px">Connect another device</h3>


### PR DESCRIPTION
## Description

PR 3 of the Sync tab redesign (plan:
docs/plans/2026-04-23-sync-tab-redesign.md). Wires the loading-states
vocabulary into the freshly-refactored device row:

- **Syncing-pip override.** While a device is actively being contacted
  via Sync now, its PresencePip swaps to the pulsing \`syncing\` state
  (1.2s ease-in-out). Resolves back to its derived state when the
  operation completes.
- **Device-row-shaped skeleton.** \`#syncPeersSkeleton\` now renders
  three shimmer rows that match the real row silhouette (pip · name
  block · chip block) so layout doesn't shift when data arrives.
  \`aria-busy="true"\` on the container; shimmer gated by
  \`prefers-reduced-motion\`.
- **Zero-devices empty-state rewrite.** Copy now points at the
  existing Invite / Paste-invite actions above rather than the legacy
  pairing-command flow. Title becomes "No teammates yet" to match the
  plan's language.

## Type of Change

- [x] UX redesign (plan-backed)

## Testing

- \`pnpm run tsc && pnpm run lint && pnpm run test\` (1475 passing)
- Manual (next step): click Sync now on a device row while its drawer
  is expanded; the pip pulses mint-green during the sync and settles
  back to its resolved color when done. On first load of the Sync tab,
  three skeleton rows show briefly instead of a generic block loader.

Stacked on #964. PR 4 wraps up the series with handoff anatomy pages.