### PR TITLE
docs(design): Sync tab redesign handoff anatomy pages

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,35 @@
+# codemem design patterns
+
+Documentation for design patterns that extend beyond a single component.
+These complement the broader codemem design handoff (lives separately)
+by documenting patterns this repo's UI introduces or refines.
+
+## Anatomy pages
+
+- [`device-row-anatomy.md`](./device-row-anatomy.md) — list-item
+  density pattern: compact row + click-to-expand drawer. Used by the
+  Sync tab's People & devices list.
+- [`action-shelf-anatomy.md`](./action-shelf-anatomy.md) — toolbar
+  layout and button-prominence rules ("at most one filled-primary per
+  line of sight").
+- [`attention-vocabulary-anatomy.md`](./attention-vocabulary-anatomy.md) —
+  offline / degraded / attention / syncing visual language. Pip sizes,
+  pulse timing, Gestalt pairing rules.
+- [`disclosure-region-anatomy.md`](./disclosure-region-anatomy.md) —
+  inline-expand vs. popover vs. modal decision table; focus
+  management; anti-patterns.
+
+All four landed with the 2026-04-23 Sync tab redesign; see
+[`docs/plans/2026-04-23-sync-tab-redesign.md`](../plans/2026-04-23-sync-tab-redesign.md)
+for the design history and PR sequence.
+
+## Scope
+
+These pages document **reusable patterns**, not component internals.
+When something here needs to become a shared primitive (e.g.
+`PresencePip` used on a second tab), the pattern description here
+stays stable even as the implementation evolves.
+
+Token values, color palettes, and typography scales remain in the
+design handoff's `colors_and_type.css` — these pages reference
+tokens but don't redefine them.

--- a/docs/design/action-shelf-anatomy.md
+++ b/docs/design/action-shelf-anatomy.md
@@ -1,0 +1,89 @@
+# Action-shelf anatomy
+
+> Toolbar pattern for placing 1–N actions at the top of a list or region.
+> Enforces the "at most one filled-primary button per line of sight"
+> rule so visual hierarchy stays intact when features accrete.
+
+## When to use
+
+- A list region needs a title + one or more list-level actions
+  ("Invite a teammate", "Join another team", "Create person").
+- A section region needs trailing utility controls that should read as
+  peer in importance but not compete with the primary action.
+
+If there's only one action and no sibling actions within the same
+region, a standalone `<button class="settings-button sync-btn-primary">`
+is fine — you don't need an ActionShelf wrapper.
+
+## Anatomy
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  People & devices                [Join another team] [Invite] │
+└────────────────────────────────────────────────────────────────┘
+   ↑                                       ↑              ↑
+   h2 section title                 secondary ghost   primary filled
+```
+
+Layout:
+
+- Region heading on the left. Uses the T1 section-title treatment
+  (16px / 600 / text-primary).
+- Actions on the right. Right-aligned at ≥ 900px; wraps to next line
+  below 900px.
+- Gap between actions: `var(--sp-2)` (8px).
+
+Button prominence rules:
+
+| Tier            | Class                                       | Count per shelf |
+|-----------------|---------------------------------------------|-----------------|
+| primary-filled  | `settings-button sync-btn-primary`          | **at most 1**   |
+| primary-ghost   | `settings-button` (accent on border/hover)  | 0–1 encouraged  |
+| secondary-ghost | `settings-button` (default neutral border)  | 0–N             |
+| text-link       | `sync-diagnostics-link` or similar          | 0–1, utility-only |
+
+If you find yourself wanting two filled-primary buttons in the same
+shelf, one of them is not actually primary — pick and demote the other.
+
+## Responsive behavior
+
+- ≥ 900px: title row + actions row side by side (`grid-template-columns:
+  1fr auto`).
+- < 900px: title and actions stack; shelf itself wraps with
+  `flex-wrap: wrap` if the actions row can't fit.
+
+If a shelf grows past 3 actions, consider collapsing the excess into a
+"More ▾" popover or splitting into two regions rather than letting the
+shelf grow unbounded.
+
+## Props (reference implementation)
+
+```ts
+interface ActionShelfAction {
+  label: string;
+  onClick: () => void | Promise<void>;
+  disabled?: boolean;
+  busy?: boolean;
+  "aria-label"?: string;
+}
+
+interface ActionShelfProps {
+  primary?: ActionShelfAction;       // at most one filled-accent button
+  secondary?: ActionShelfAction[];   // 0–N ghost buttons
+  align?: "start" | "end";           // default "end" for toolbars
+}
+```
+
+## Accessibility
+
+- Render as `<div role="toolbar" aria-label="...">`.
+- Each button uses plain `<button type="button">` with `aria-busy` when
+  the action is in flight.
+- Do not put the region `<h2>` inside the shelf; the shelf is siblings
+  to the heading so heading landmarks still work.
+
+## Related
+
+- `device-row-anatomy.md` — uses the action-shelf above the device list.
+- `disclosure-region-anatomy.md` — for shelves that need to toggle a
+  region rather than fire a one-shot action.

--- a/docs/design/attention-vocabulary-anatomy.md
+++ b/docs/design/attention-vocabulary-anatomy.md
@@ -1,0 +1,86 @@
+# Attention vocabulary
+
+> The offline / degraded / attention / syncing visual language. One
+> vocabulary across the product so an Attention row and the device row
+> it refers to read as the same thing.
+
+## States
+
+```
+state       color                        behavior      example copy
+─────────── ──────────────────────────── ───────────── ────────────────────────────
+online      --accent                     static        (no meta line shown)
+syncing     --accent                     pulse 1.2s    "Syncing now…"
+offline     --accent-warm                static        "Offline · last seen 4/14 2:29PM"
+degraded    --accent-warm                static        "Partial sync · peer status failed (401)"
+attention   --accent-warm-strong         pulse 2.4s    "Not trusted — accept invite on other device"
+unknown     --text-tertiary              static        "Not yet synced"
+```
+
+Principle: **color conveys the family, pulse conveys urgency.**
+
+- Healthy family (`--accent`): online static, syncing pulses because
+  something is actively in flight.
+- Warm family (`--accent-warm`): offline + degraded share this color;
+  both mean "not healthy but user action not required." Attention uses
+  the stronger warm variant AND pulses to signal "act on this."
+- Inert (`--text-tertiary`): genuinely unknown state (never synced yet,
+  state hasn't loaded). Deliberately low-contrast — it's not a warning.
+
+## Pip sizes
+
+| Size  | Token          | When to use                                 |
+|-------|----------------|---------------------------------------------|
+| 6px   | `--pip-size-sm`| In-row status where there's no label paired |
+| 8px   | `--pip-size-md`| Attention anchors, device-row primary pip   |
+
+Pip component: `PresencePip` at `packages/ui/src/components/primitives/
+presence-pip.tsx`.
+
+## Pulse timing
+
+```
+attention: 2.4s ease-in-out, opacity 0.60 → 1.00 → 0.60, scale 1 → 1.15 → 1
+syncing:   1.2s ease-in-out, opacity 0.55 → 1.00 → 0.55, no scale
+```
+
+Both animations are gated by `prefers-reduced-motion: reduce`. When
+reduced motion is active, the pip still changes color to convey state —
+the pulse is purely a secondary signal.
+
+## Gestalt pairing
+
+When an Attention row refers to a specific device, both rows show the
+same pip (size, color, pulse timing). This links them visually without
+duplicating copy.
+
+```
+┌─────────────────────────────────────────────────────┐
+│ ●  Work is offline              [Open device]      │  ← attention row, 8px warm pulse
+│    This device is offline right now. Retry later.   │
+└─────────────────────────────────────────────────────┘
+  …
+┌─────────────────────────────────────────────────────┐
+│ ●  Work                  [Offline]   Sync: 2:29PM ▸│  ← device row, same 8px warm pulse
+└─────────────────────────────────────────────────────┘
+```
+
+## Anti-patterns
+
+- **Don't color the row background.** Surfaces stay `--surface-1`; the
+  color signal lives in the pip, not the chrome.
+- **Don't invent new degraded-state colors.** Reuse `--accent-warm` and
+  `--accent-warm-strong` from the handoff; variation belongs in pulse,
+  not hue.
+- **Don't use red.** Red is reserved for destructive confirmation
+  dialogs (per the handoff voice — "Warnings are phrased as facts, not
+  alarms").
+- **Don't replace the pip with a text-only badge.** The pip's
+  advantage is that it compresses status into a glance without eating
+  horizontal space.
+
+## Related
+
+- `device-row-anatomy.md` — pip placement in a list row.
+- `disclosure-region-anatomy.md` — attention rows often link to a
+  device row which expands on click.

--- a/docs/design/device-row-anatomy.md
+++ b/docs/design/device-row-anatomy.md
@@ -1,0 +1,105 @@
+# Device-row anatomy
+
+> List-item density pattern for the Sync tab's People & devices list.
+> Scales to ~10 devices comfortably; expands in place to reveal per-row
+> detail without leaving the list.
+
+## When to use
+
+Any time you render a list of entities where each entity has:
+
+- A single-line primary identifier (device name, peer id, person name).
+- A compact health/status signal.
+- A small set of secondary status tags (trust, direction, provenance).
+- Per-entity actions that don't fit on a single line.
+
+If your list items only need a name + one or two chips with no detail
+drawer, use a plain `.peer-card` instead.
+
+## Anatomy
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ●  Work   ↕   [Two-way trust]   [via team-alpha]   Sync: 2:31PM ▸│  ← compact row
+└─────────────────────────────────────────────────────────────┘
+  ┌─────────────────────────────────────────────────────────┐
+  │  [Sync now]  [Device name ____]  [Save name]  [Remove] │  ← drawer (on expand)
+  │                                                         │
+  │  Device details                                         │
+  │  192.168.42.123:7337                                    │
+  │  Sync: 2:31PM · Ping: 2:31PM                            │
+  │                                                         │
+  │  Who this device belongs to                             │
+  │  This device belongs to you.                            │
+  │  [You ▾]  [Save assignment]                             │
+  │                                                         │
+  │  Advanced sharing scope ▸                               │
+  └─────────────────────────────────────────────────────────┘
+```
+
+Left to right in the compact row:
+
+1. **PresencePip** — 8px dot. Color + pulse convey state. See
+   `attention-vocabulary-anatomy.md`.
+2. **Name** — T3 row name (14px / 600 / text-primary). Truncates with
+   ellipsis on overflow.
+3. **Direction glyph** (optional) — ↑ / ↓ / ↕ for the last 24h direction.
+4. **Trust chip** — `.badge` today, will migrate to `TrustChip` primitive.
+5. **Provenance chips** (optional) — "via {group-id}", "Needs scope
+   review", etc. Each uses `.badge` styling.
+6. **Meta** — T5 (12px / 400 / text-tertiary). Sync timestamp.
+7. **Chevron** — ▸ collapsed / ▾ expanded. Decorative (aria-hidden).
+
+Row height: **56px minimum** (hits the 44px touch target with 10px
+top/bottom padding).
+
+## States
+
+| State        | Trigger                                       | Visual |
+|--------------|-----------------------------------------------|--------|
+| default      | row rendered, mouse away                      | transparent bg |
+| hover        | mouse over, not focused                       | `surface-2` 60% |
+| focus-visible| tab navigation                                | 2px accent outline |
+| expanded     | clicked or activated via keyboard             | drawer visible, chevron rotated |
+| attention    | owning device has pending user action         | pip pulses warm |
+| syncing      | device is actively being contacted            | pip pulses mint |
+
+Only **one row's drawer is open at a time.** Clicking a different row
+collapses the previous one. State lives at the render module level
+(e.g. `expandedPeerId` in `sync-peers.tsx`).
+
+## Accessibility
+
+- The row itself is a `<button aria-expanded aria-controls>` with the
+  full compact header as its clickable target.
+- The drawer is a `<section aria-label="Device actions for {name}">`.
+- Focus management: on expand, default browser focus handling is fine
+  (drawer sub-controls take focus when activated). On collapse, focus
+  returns to the row button.
+- Touch targets: row header ≥ 56px, all drawer buttons ≥ 28px (extended
+  by padding to meet 44px recommended minimum on touch devices).
+- `prefers-reduced-motion` disables pip pulse + hover transitions.
+
+## Props (reference implementation)
+
+```ts
+interface DeviceRowProps {
+  deviceId: string;
+  name: string;
+  trust: TrustState;                // see trust-chip tone mapping
+  presence: PresenceState;          // see attention-vocabulary
+  lastSyncAt?: string;              // ISO timestamp, shown as T5 meta
+  lastError?: string;               // degraded / offline detail
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  renderDrawer: () => VNode;        // lazy — only mounts when expanded
+}
+```
+
+## Related
+
+- `action-shelf-anatomy.md` — for the toolbar pattern used to place
+  list-level actions above the device row list.
+- `disclosure-region-anatomy.md` — for the expand mechanics generalized
+  beyond the device row.
+- `attention-vocabulary-anatomy.md` — for the pip state matrix.

--- a/docs/design/disclosure-region-anatomy.md
+++ b/docs/design/disclosure-region-anatomy.md
@@ -1,0 +1,86 @@
+# Disclosure-region anatomy
+
+> How to reveal detail for a row or section without navigating away or
+> opening a modal. The codemem viewer uses this pattern for device
+> rows, coordinator-group scope defaults, and advanced diagnostics
+> toggles.
+
+## Decision table — which disclosure pattern?
+
+| Situation                                        | Pattern             |
+|-------------------------------------------------|---------------------|
+| Row in a list needs per-row detail              | **Inline expand**   |
+| Secondary option that lives next to a control  | Collapsible disclosure (inline) |
+| Heavyweight workflow, user must focus on it    | Modal (`RadixDialog`) |
+| Short ephemeral actions (menu, tooltip)        | Popover (`RadixPopover`) |
+
+When in doubt, start with inline expand. It preserves context.
+
+## Inline expand (rows)
+
+Mechanics:
+
+- Row renders as `<button aria-expanded aria-controls>`.
+- Drawer renders as a sibling `<section aria-label>` inside the same
+  list-item `<li>` / `<div>`, conditionally mounted when expanded.
+- **Only one row open at a time.** State lives at the module level
+  (e.g. `let expandedPeerId: string | null`) with a small subscribe
+  hook so components re-render when the pointer changes.
+- Collapsing the previous row and expanding the new one happens
+  atomically via the setter.
+
+```
+.list
+├── .row (aria-expanded=false)           ← clickable header
+├── .row (aria-expanded=true)            ← clickable header
+│   └── <section> drawer contents
+└── .row (aria-expanded=false)
+```
+
+## Inline disclosure (sections)
+
+For sections that need a "hide/show more" affordance without list-item
+semantics, use a plain `<button aria-controls aria-expanded>` toggle
+next to a region that conditionally renders. Examples in the codebase:
+
+- "Advanced sharing scope" in the device detail drawer.
+- "Show archived" groups toggle in Coordinator Admin.
+- Coordinator Admin "Scope defaults" drawer inside each group card.
+
+Use `var(--sp-3)` gap between the toggle and its revealed region, and
+keep the region inside the same card when possible so proximity
+signals they belong together.
+
+## Focus management
+
+Rule of thumb: **don't fight the browser.**
+
+- On expand: default focus stays on the row button. Sub-controls take
+  focus when activated.
+- On collapse via button: focus stays on the row button.
+- On collapse via another row expanding: focus moves to the new row.
+- For keyboard users, `Tab` enters the drawer in DOM order. `Escape`
+  is NOT wired by default (inline expand is not modal; Escape should
+  not close it unless the user specifically requests it).
+
+## Animation
+
+Keep it boring. Inline expand should feel like "the list grew a row,"
+not "a panel slid in." Use a 140ms ease height transition on the
+drawer OR no transition at all if it's janky with variable content.
+The drawer exists inline in the DOM — tying animation to data load is
+fine; animating the drawer itself often isn't worth the complexity.
+
+## Anti-patterns
+
+- **Don't put a drawer inside a popover.** Popovers have positioning
+  and focus semantics that conflict with form controls.
+- **Don't nest drawers.** If you need a drawer-inside-a-drawer, you
+  probably want a modal for the inner one, or a separate route.
+- **Don't make the entire row a link.** A link leaves the page; an
+  expand toggle doesn't. Use the right semantics.
+
+## Related
+
+- `device-row-anatomy.md` — the canonical inline-expand example.
+- `action-shelf-anatomy.md` — for toolbars that open disclosures.


### PR DESCRIPTION
## Description

PR 4 (final) of the Sync tab redesign (plan:
docs/plans/2026-04-23-sync-tab-redesign.md). Ships four pattern
anatomy pages + a README index at docs/design/:

- \`device-row-anatomy.md\` — list-item density pattern (compact row +
  click-to-expand drawer). DOM structure, states, touch-target rules,
  accessibility wiring.
- \`action-shelf-anatomy.md\` — toolbar layout and button-prominence
  rules. "At most one filled-primary per line of sight" convention
  for the devices toolbar and any future sibling toolbars.
- \`attention-vocabulary-anatomy.md\` — the unified offline /
  degraded / attention / syncing visual language. Pip sizes, pulse
  timing, Gestalt pairing between attention rows and device rows.
- \`disclosure-region-anatomy.md\` — inline-expand vs. popover vs.
  modal decision table, focus-management guidance, anti-patterns.

These document the patterns introduced by PRs 1–3 so other tabs can
adopt the same vocabulary without re-deriving decisions.

## Type of Change

- [x] Documentation

## Testing

Docs-only change; no \`tsc\`/\`lint\`/\`test\` impact. Verified that
the four pages render correctly as markdown.

Stacked on #965. Completes the 4-PR Sync tab redesign series:
- #963 — diagnostics sub-view + Overview card removal
- #964 — device-row + drawer + primitives
- #965 — syncing-pip override + skeleton + empty state
- #966 — handoff anatomy pages (this PR)