### PR TITLE
ui(sync): remediation pass on Sync tab redesign stack

### DIFF
--- a/docs/design/device-row-anatomy.md
+++ b/docs/design/device-row-anatomy.md
@@ -26,7 +26,7 @@ drawer, use a plain `.peer-card` instead.
   │  [Sync now]  [Device name ____]  [Save name]  [Remove] │  ← drawer (on expand)
   │                                                         │
   │  Device details                                         │
-  │  192.168.42.123:7337                                    │
+  │  No addresses                                           │
   │  Sync: 2:31PM · Ping: 2:31PM                            │
   │                                                         │
   │  Who this device belongs to                             │

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -179,7 +179,7 @@ describe("vectors", () => {
 		});
 	});
 
-	it("does not mark partially covered memories as healthy", () => {
+	it("does not mark partially covered memories as healthy under deep diagnostics", () => {
 		const sessionId = insertTestSession(db);
 		const now = new Date().toISOString();
 		const bodyText = "semantic chunk ".repeat(5000);
@@ -208,7 +208,7 @@ describe("vectors", () => {
 			)
 		`);
 
-		const diagnostics = getSemanticIndexDiagnostics(db);
+		const diagnostics = getSemanticIndexDiagnostics(db, { fastCounts: false });
 
 		expect(diagnostics).toMatchObject({
 			state: "pending",

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -173,6 +173,12 @@ export interface SemanticIndexDiagnostics {
 }
 
 export interface SemanticIndexDiagnosticsOptions {
+	/**
+	 * Default true — runs a single indexed COUNT(DISTINCT) join. The slow
+	 * alternative does a vec0 probe per memory row, which blocks the event
+	 * loop; only set to false from non-request-path tooling that needs
+	 * per-chunk coverage precision.
+	 */
 	fastCounts?: boolean;
 }
 
@@ -271,6 +277,7 @@ export function getSemanticIndexDiagnostics(
 	db: Database,
 	options: SemanticIndexDiagnosticsOptions = {},
 ): SemanticIndexDiagnostics {
+	const fastCounts = options.fastCounts !== false;
 	const currentModel = traceSemanticDiag("resolveEmbeddingModel", () => resolveEmbeddingModel());
 	const semanticSearchModel = traceSemanticDiag("resolveSemanticSearchModel", () =>
 		resolveSemanticSearchModel(db, currentModel),
@@ -280,9 +287,9 @@ export function getSemanticIndexDiagnostics(
 		countEmbeddableActiveMemories(db),
 	);
 	const indexedMemoryCount = traceSemanticDiag(
-		options.fastCounts ? "countIndexedActiveMemoriesFast" : "countIndexedActiveMemories",
+		fastCounts ? "countIndexedActiveMemoriesFast" : "countIndexedActiveMemories",
 		() =>
-			options.fastCounts
+			fastCounts
 				? countIndexedActiveMemoriesFast(db, currentModel)
 				: countIndexedActiveMemories(db, currentModel),
 	);

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -74,15 +74,6 @@ async function isViewerReady() {
 	}
 }
 
-function stopReconnectLoop() {
-	if (reconnectTimer) {
-		clearTimeout(reconnectTimer);
-		reconnectTimer = null;
-	}
-	reconnecting = false;
-	setReconnectOverlay(false);
-}
-
 function canResumeRefresh() {
 	return document.visibilityState !== "hidden" && !isSettingsOpen();
 }
@@ -100,17 +91,38 @@ function scheduleReconnectLoop() {
 	const tick = async () => {
 		const ready = await isViewerReady();
 		if (ready) {
-			stopReconnectLoop();
+			// Keep the overlay visible through the handoff. Hiding here and
+			// then re-showing if the follow-up refresh fails (a common case
+			// when the server's HTTP port opens a moment before all handlers
+			// are wired) produces a visible background flash. Clear the tick
+			// timer, release the reconnecting flag so doRefresh can proceed,
+			// let doRefresh run under the overlay, and only dismiss after it
+			// completes without re-scheduling a reconnect.
+			if (reconnectTimer) {
+				clearTimeout(reconnectTimer);
+				reconnectTimer = null;
+			}
+			reconnecting = false;
+			setReconnectOverlay(true, "Viewer responded. Restoring your session…");
 			if (canResumeRefresh()) {
 				setRefreshStatus("refreshing");
 				startPolling();
-				void doRefresh();
+				try {
+					await doRefresh();
+				} catch {
+					// doRefresh handles its own failures (and may re-schedule
+					// the reconnect loop on catch).
+				}
 			} else {
 				setRefreshStatus(
 					"paused",
 					document.visibilityState === "hidden" ? "(tab hidden)" : "(settings open)",
 				);
 			}
+			// If doRefresh re-scheduled a reconnect, `reconnecting` is true
+			// again and the overlay is already showing the new message —
+			// leave it up. Otherwise the session is restored; dismiss.
+			if (!reconnecting) setReconnectOverlay(false);
 			return;
 		}
 		setReconnectOverlay(
@@ -387,9 +399,21 @@ $("viewerReconnectRetry")?.addEventListener("click", async () => {
 		scheduleReconnectLoop();
 		return;
 	}
-	stopReconnectLoop();
+	// Release the reconnecting flag but keep the overlay up while the first
+	// refresh runs — otherwise a failed refresh causes a hide→show flash.
+	if (reconnectTimer) {
+		clearTimeout(reconnectTimer);
+		reconnectTimer = null;
+	}
+	reconnecting = false;
+	setReconnectOverlay(true, "Viewer responded. Restoring your session…");
 	startPolling();
-	void doRefresh();
+	try {
+		await doRefresh();
+	} catch {
+		// doRefresh handles its own failures
+	}
+	if (!reconnecting) setReconnectOverlay(false);
 });
 
 // Version label

--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -5,7 +5,8 @@
  * Takes action callbacks plus renderShell + reloadData as deps so the
  * archive switch and manage button can trigger the surrounding shell. */
 
-import { h } from "preact";
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { Fragment, h } from "preact";
 import { ChipInput } from "../../../components/primitives/chip-input";
 import { RadixSwitch } from "../../../components/primitives/radix-switch";
 import { RadixTabsContent } from "../../../components/primitives/radix-tabs";
@@ -20,6 +21,28 @@ import {
 	currentAdminTargetGroup,
 	setAdminTargetGroup,
 } from "../data/target-group";
+
+/* Inlined chevron SVG — matches the sync-tab device-row chevron so the
+ * CSS `[data-state="open"]` rotation style is shared. Avoids depending
+ * on the viewer's CDN lucide bootstrap inside a Collapsible.Content
+ * that mounts after that sweep runs. */
+function ChevronRightIcon() {
+	return h(
+		"svg",
+		{
+			"aria-hidden": "true",
+			fill: "none",
+			stroke: "currentColor",
+			"stroke-linecap": "round",
+			"stroke-linejoin": "round",
+			"stroke-width": "2",
+			viewBox: "0 0 24 24",
+			xmlns: "http://www.w3.org/2000/svg",
+		},
+		h("title", null, "Chevron"),
+		h("path", { d: "m9 18 6-6-6-6" }),
+	);
+}
 
 function emptyDraft(): GroupPreferencesDraft {
 	return {
@@ -112,19 +135,15 @@ function renderGroupPreferencesEditor(
 	const draft = coordinatorAdminState.groupPreferencesDrafts.get(groupId);
 	if (!draft) return null;
 	if (!draft.loaded) {
-		return h(
-			"div",
-			{ class: "coordinator-admin-group-preferences" },
-			h("div", { class: "peer-submeta" }, "Loading scope defaults…"),
-		);
+		return h("div", { class: "peer-submeta" }, "Loading scope defaults…");
 	}
 	const autoSeedLabelId = `coord-admin-scope-autoseed-${groupId}`;
 	const includeLabelId = `coord-admin-scope-include-${groupId}`;
 	const excludeLabelId = `coord-admin-scope-exclude-${groupId}`;
 	const fieldsDisabled = !ready || draft.saving || !draft.auto_seed_scope;
 	return h(
-		"div",
-		{ class: "coordinator-admin-group-preferences" },
+		Fragment,
+		null,
 		h("h4", { class: "coordinator-admin-drawer-title" }, "Scope defaults"),
 		h(
 			"div",
@@ -371,7 +390,7 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 				)
 			: h(
 					"div",
-					{ class: "coordinator-admin-request-list" },
+					{ class: "peer-list" },
 					visibleGroups.map((group) => {
 						const selected = group.group_id === selectedGroup;
 						const pending = coordinatorAdminState.groupActionPendingId === group.group_id;
@@ -380,9 +399,10 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 							coordinatorAdminState.groupRenameDrafts.get(group.group_id) ??
 							group.display_name ??
 							group.group_id;
+						const scopeOpen = coordinatorAdminState.groupPreferencesOpen.has(group.group_id);
 						return h(
 							"div",
-							{ class: "peer-card", key: group.group_id },
+							{ class: "peer-card peer-card--padded", key: group.group_id },
 							h("div", { class: "peer-title" }, h("strong", null, draftName)),
 							h("div", { class: "peer-meta" }, `Group ID: ${group.group_id}`),
 							h("div", { class: "peer-submeta" }, archived ? "Archived" : "Active"),
@@ -441,10 +461,13 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 								h(
 									"button",
 									{
-										class: "settings-button",
+										"aria-expanded": scopeOpen,
+										"aria-controls": `coord-admin-scope-drawer-${group.group_id}`,
+										class: "settings-button coordinator-admin-scope-trigger",
+										"data-state": scopeOpen ? "open" : "closed",
 										disabled: summary.readiness !== "ready" || pending,
 										onClick: () => {
-											if (coordinatorAdminState.groupPreferencesOpen.has(group.group_id)) {
+											if (scopeOpen) {
 												closeGroupPreferences(group.group_id, renderShell);
 											} else {
 												void openGroupPreferences(group.group_id, renderShell);
@@ -452,9 +475,12 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 										},
 										type: "button",
 									},
-									coordinatorAdminState.groupPreferencesOpen.has(group.group_id)
-										? "Close scope defaults"
-										: "Scope defaults",
+									h("span", null, "Scope defaults"),
+									h(
+										"span",
+										{ "aria-hidden": "true", class: "device-row-chevron" },
+										h(ChevronRightIcon, null),
+									),
 								),
 								h(
 									"button",
@@ -480,13 +506,31 @@ export function renderGroupsPanel(deps: GroupsPanelDeps) {
 											: "Archive",
 								),
 							),
-							coordinatorAdminState.groupPreferencesOpen.has(group.group_id)
-								? renderGroupPreferencesEditor(
-										group.group_id,
-										renderShell,
-										summary.readiness === "ready",
-									)
-								: null,
+							h(
+								Collapsible.Root,
+								{
+									open: scopeOpen,
+									onOpenChange: (open: boolean) => {
+										if (open) void openGroupPreferences(group.group_id, renderShell);
+										else closeGroupPreferences(group.group_id, renderShell);
+									},
+								},
+								h(
+									Collapsible.Content,
+									{
+										"aria-label": `Scope defaults for ${draftName}`,
+										class: "coordinator-admin-group-preferences",
+										id: `coord-admin-scope-drawer-${group.group_id}`,
+									},
+									scopeOpen
+										? renderGroupPreferencesEditor(
+												group.group_id,
+												renderShell,
+												summary.readiness === "ready",
+											)
+										: null,
+								),
+							),
 						);
 					}),
 				),

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -424,49 +424,54 @@ function SyncPeerCard({
 	return (
 		<Collapsible.Root asChild open={isExpanded} onOpenChange={handleOpenChange}>
 			<div ref={cardRef} className="peer-card" data-peer-device-id={peerId || undefined}>
-				{/* Row head: non-interactive content + a dedicated Radix
-				    Collapsible trigger on the right. Badges, direction glyph,
-				    and the name's title attribute live outside the trigger so
-				    they don't pollute its accessible name (the trigger reads
-				    "Expand device {name}"). */}
-				<div className="device-row-head">
-					<PresencePip state={presenceState} />
-					<span className="device-row-name" title={peerId || undefined}>
-						{displayName}
-					</span>
-					{directionHint ? (
-						<span
-							aria-label={directionHint.label}
-							className="peer-direction"
-							role="img"
-							title={directionHint.label}
-						>
-							{directionHint.glyph}
+				{/* Row head IS the Collapsible trigger — the whole band is
+				    clickable for a smoother expand/collapse. The chevron is
+				    a visual indicator driven by `data-state`, not a separate
+				    interactive element. */}
+				<Collapsible.Trigger asChild>
+					<button
+						aria-label={toggleLabel}
+						className="device-row-head device-row-head--trigger"
+						type="button"
+					>
+						<PresencePip state={presenceState} />
+						<span className="device-row-name" title={peerId || undefined}>
+							{displayName}
 						</span>
-					) : null}
-					<span className="device-row-chips">
-						<span className={`badge ${trustSummary.isWarning ? "badge-offline" : "badge-online"}`}>
-							{trustSummary.badgeLabel}
-						</span>
-						{pendingScopeReview ? (
-							<span className="badge actor-badge">Needs scope review</span>
-						) : null}
-						{peer.discovered_via_group_id ? (
+						{directionHint ? (
 							<span
-								className="badge actor-badge"
-								title={`Discovered through coordinator group ${peer.discovered_via_group_id}`}
+								aria-label={directionHint.label}
+								className="peer-direction"
+								role="img"
+								title={directionHint.label}
 							>
-								{`via ${peer.discovered_via_group_id}`}
+								{directionHint.glyph}
 							</span>
 						) : null}
-					</span>
-					<span className="device-row-meta">{syncMetaText}</span>
-					<Collapsible.Trigger asChild>
-						<button aria-label={toggleLabel} className="device-row-toggle" type="button">
+						<span className="device-row-chips">
+							<span
+								className={`badge ${trustSummary.isWarning ? "badge-offline" : "badge-online"}`}
+							>
+								{trustSummary.badgeLabel}
+							</span>
+							{pendingScopeReview ? (
+								<span className="badge actor-badge">Needs scope review</span>
+							) : null}
+							{peer.discovered_via_group_id ? (
+								<span
+									className="badge actor-badge"
+									title={`Discovered through coordinator group ${peer.discovered_via_group_id}`}
+								>
+									{`via ${peer.discovered_via_group_id}`}
+								</span>
+							) : null}
+						</span>
+						<span className="device-row-meta">{syncMetaText}</span>
+						<span aria-hidden="true" className="device-row-chevron">
 							<ChevronRightIcon />
-						</button>
-					</Collapsible.Trigger>
-				</div>
+						</span>
+					</button>
+				</Collapsible.Trigger>
 
 				<Collapsible.Content
 					aria-label={`Device actions for ${displayName}`}

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -1,3 +1,4 @@
+import * as Collapsible from "@radix-ui/react-collapsible";
 import type { TargetedInputEvent } from "preact";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "preact/hooks";
 import { PresencePip, type PresenceState } from "../../../components/primitives/presence-pip";
@@ -23,6 +24,31 @@ import {
 	type PeerDirection,
 	type PeerLike,
 } from "../view-model";
+import { renderIntoSyncMount } from "./render-root";
+import { SyncEmptyState } from "./sync-empty-state";
+import { type SyncActionFeedback, SyncInlineFeedback } from "./sync-inline-feedback";
+
+/* Lucide `chevron-right` inlined so Radix Collapsible can rotate it via
+ * CSS on open without depending on the viewer's CDN lucide bootstrap
+ * (which replaces `<i data-lucide=".." />` placeholders after mount —
+ * unreliable inside a portal that mounts after that sweep runs). */
+function ChevronRightIcon() {
+	return (
+		<svg
+			aria-hidden="true"
+			fill="none"
+			stroke="currentColor"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			stroke-width="2"
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<title>Chevron</title>
+			<path d="m9 18 6-6-6-6" />
+		</svg>
+	);
+}
 
 /* Map the view-model's UI-status vocabulary to the PresencePip state
  * matrix defined in docs/plans/2026-04-23-sync-tab-redesign.md. */
@@ -63,10 +89,6 @@ function useExpandedPeer(): string | null {
 	}, []);
 	return expandedPeerId;
 }
-
-import { renderIntoSyncMount } from "./render-root";
-import { SyncEmptyState } from "./sync-empty-state";
-import { type SyncActionFeedback, SyncInlineFeedback } from "./sync-inline-feedback";
 
 const DIRECTION_GLYPH: Record<PeerDirection, { glyph: string; label: string } | null> = {
 	bidirectional: { glyph: "↕", label: "Bidirectional sync in the last 24 hours" },
@@ -389,66 +411,64 @@ function SyncPeerCard({
 	const presenceState: PresenceState = presenceForPeer(peer);
 	const syncMetaText = lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never";
 
-	const toggleExpand = () => setExpandedPeer(isExpanded ? null : peerId);
 	const toggleLabel = `${isExpanded ? "Collapse" : "Expand"} device ${displayName}`;
+	// Read module-level state directly (not the stale closure value of
+	// `isExpanded`) when handling the close callback. When another row
+	// takes over, Radix fires this row's onOpenChange(false) after the
+	// module-level pointer has already moved — we must NOT clobber it.
+	const handleOpenChange = (open: boolean) => {
+		if (open) setExpandedPeer(peerId);
+		else if (expandedPeerId === peerId) setExpandedPeer(null);
+	};
 
 	return (
-		<div ref={cardRef} className="peer-card" data-peer-device-id={peerId || undefined}>
-			{/* Row head: non-interactive content + a dedicated disclosure
-			    button on the right. This avoids burying badges, glyphs, and
-			    title attributes inside a button's accessible-name
-			    computation (which would produce a 40+ word announcement).
-			    Clicking anywhere in the row still toggles the drawer via a
-			    background click handler — the button is what assistive tech
-			    sees and keyboard users activate. */}
-			<div className="device-row-head">
-				<PresencePip state={presenceState} />
-				<span className="device-row-name" title={peerId || undefined}>
-					{displayName}
-				</span>
-				{directionHint ? (
-					<span
-						aria-label={directionHint.label}
-						className="peer-direction"
-						role="img"
-						title={directionHint.label}
-					>
-						{directionHint.glyph}
+		<Collapsible.Root asChild open={isExpanded} onOpenChange={handleOpenChange}>
+			<div ref={cardRef} className="peer-card" data-peer-device-id={peerId || undefined}>
+				{/* Row head: non-interactive content + a dedicated Radix
+				    Collapsible trigger on the right. Badges, direction glyph,
+				    and the name's title attribute live outside the trigger so
+				    they don't pollute its accessible name (the trigger reads
+				    "Expand device {name}"). */}
+				<div className="device-row-head">
+					<PresencePip state={presenceState} />
+					<span className="device-row-name" title={peerId || undefined}>
+						{displayName}
 					</span>
-				) : null}
-				<span className="device-row-chips">
-					<span className={`badge ${trustSummary.isWarning ? "badge-offline" : "badge-online"}`}>
-						{trustSummary.badgeLabel}
-					</span>
-					{pendingScopeReview ? (
-						<span className="badge actor-badge">Needs scope review</span>
-					) : null}
-					{peer.discovered_via_group_id ? (
+					{directionHint ? (
 						<span
-							className="badge actor-badge"
-							title={`Discovered through coordinator group ${peer.discovered_via_group_id}`}
+							aria-label={directionHint.label}
+							className="peer-direction"
+							role="img"
+							title={directionHint.label}
 						>
-							{`via ${peer.discovered_via_group_id}`}
+							{directionHint.glyph}
 						</span>
 					) : null}
-				</span>
-				<span className="device-row-meta">{syncMetaText}</span>
-				<button
-					aria-controls={drawerId}
-					aria-expanded={isExpanded}
-					aria-label={toggleLabel}
-					className="device-row-toggle"
-					onClick={toggleExpand}
-					type="button"
-				>
-					<span aria-hidden="true" className="device-row-chevron">
-						{isExpanded ? "▾" : "▸"}
+					<span className="device-row-chips">
+						<span className={`badge ${trustSummary.isWarning ? "badge-offline" : "badge-online"}`}>
+							{trustSummary.badgeLabel}
+						</span>
+						{pendingScopeReview ? (
+							<span className="badge actor-badge">Needs scope review</span>
+						) : null}
+						{peer.discovered_via_group_id ? (
+							<span
+								className="badge actor-badge"
+								title={`Discovered through coordinator group ${peer.discovered_via_group_id}`}
+							>
+								{`via ${peer.discovered_via_group_id}`}
+							</span>
+						) : null}
 					</span>
-				</button>
-			</div>
+					<span className="device-row-meta">{syncMetaText}</span>
+					<Collapsible.Trigger asChild>
+						<button aria-label={toggleLabel} className="device-row-toggle" type="button">
+							<ChevronRightIcon />
+						</button>
+					</Collapsible.Trigger>
+				</div>
 
-			{isExpanded ? (
-				<section
+				<Collapsible.Content
 					aria-label={`Device actions for ${displayName}`}
 					className="device-row-drawer"
 					id={drawerId}
@@ -587,9 +607,9 @@ function SyncPeerCard({
 						<SyncInlineFeedback feedback={feedback} />
 						<div ref={setScopeHost} />
 					</div>
-				</section>
-			) : null}
-		</div>
+				</Collapsible.Content>
+			</div>
+		</Collapsible.Root>
 	);
 }
 

--- a/packages/ui/src/tabs/sync/diagnostics/helpers.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/helpers.ts
@@ -31,15 +31,12 @@ export function pairingView(payload: unknown): PairingView {
 		};
 	}
 
+	// The pairing payload is a local command you share with your own other
+	// device, not a secret — the outer "Show pairing command" disclosure
+	// already gates exposure. We do NOT additionally redact based on the
+	// generic diagnostics toggle, because that produced a confusing
+	// double-hide (a revealed card that just said "Pairing payload hidden").
 	const pairingPayload = payload as PairingPayloadState;
-	if (pairingPayload.redacted) {
-		state.pairingCommandRaw = "";
-		return {
-			payloadText: "Pairing payload hidden",
-			hintText: "Diagnostics are required to view the pairing payload.",
-		};
-	}
-
 	const safePayload = {
 		...pairingPayload,
 		addresses: Array.isArray(pairingPayload.addresses) ? pairingPayload.addresses : [],

--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
@@ -11,7 +11,7 @@ import {
 	renderSyncEmptyState,
 	type SyncAttemptItem,
 } from "../../components/sync-diagnostics";
-import { renderActionList } from "../../helpers";
+import { redactIpOctets, renderActionList } from "../../helpers";
 import {
 	diagnosticsUnavailableState,
 	noAttemptsState,
@@ -48,13 +48,18 @@ export function renderSyncAttempts() {
 		// Progressive disclosure: show what's relevant for this attempt's outcome
 		const isError = attempt.status === "error";
 		const detailParts: string[] = [];
+		const redact = isSyncRedactionEnabled();
 		if (isError && attempt.error) {
-			detailParts.push(String(attempt.error));
+			// Error strings commonly embed the full peer URL that failed.
+			// Scrub the last two IPv4 octets when redact is on so the log
+			// doesn't leak private addresses.
+			const errText = String(attempt.error);
+			detailParts.push(redact ? redactIpOctets(errText) : errText);
 		}
 		if (!isError && (attempt.ops_in || attempt.ops_out)) {
 			detailParts.push(`${attempt.ops_in ?? 0} in · ${attempt.ops_out ?? 0} out`);
 		}
-		if (!isSyncRedactionEnabled() && attempt.address) {
+		if (!redact && attempt.address) {
 			detailParts.push(attempt.address);
 		}
 

--- a/packages/ui/src/tabs/sync/view-model/sync-view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model/sync-view-model.ts
@@ -190,17 +190,12 @@ export function deriveSyncViewModel(input: {
 					summary: detail,
 				}),
 			);
-		} else if (device.peer && peerStatus === "offline") {
-			attentionItems.push(
-				createRepairItem({
-					id: device.deviceId,
-					name,
-					title: `${name} is offline`,
-					summary:
-						"This device is offline or unreachable right now. Retry later, or review the local record if it should have been available.",
-				}),
-			);
 		}
+		// Peers that are merely offline are NOT pushed into Needs attention.
+		// Device rows already surface the offline state via their presence pip
+		// and the "Offline" badge, which is enough signal — computers turn off
+		// and on regularly and this doesn't warrant a separate action item.
+		// Auth/trust/repair failures (handled in the branch above) still do.
 
 		if (device.peer && trustSummary?.state === "trusted-by-you") {
 			attentionItems.push(

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -469,6 +469,16 @@
         flex-direction: column;
         gap: var(--sp-5);
       }
+      /* Sync tab wraps its cards in #syncMainView / #syncDiagnosticsView
+         sub-view containers, which breaks the .tab-panel flex gap inheritance.
+         Restore the gap inside each sub-view so Sync cards match the Feed
+         tab's card rhythm. */
+      #syncMainView,
+      #syncDiagnosticsView {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sp-5);
+      }
 
       /* ── Cards / sections ──────────────────────────────────── */
 
@@ -808,39 +818,30 @@
         align-items: center;
       }
 
-      /* Header link that points at a sibling sub-surface (e.g. the sync
-         diagnostics view). Deliberately quieter than a filled or ghost
-         button — it's navigation, not action. */
-      .sync-diagnostics-link {
+      /* Utility link that navigates between sibling sub-surfaces (e.g.
+         main Sync view ↔ diagnostics sub-view). One treatment used for
+         both directions so header/back links read as the same vocabulary
+         — quieter than any real button nearby, since it's navigation,
+         not action. */
+      .sync-subview-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
         font-size: 13px;
         font-weight: 500;
         color: var(--text-secondary);
         text-decoration: none;
-        padding: 6px 8px;
+        padding: 4px 6px;
         border-radius: var(--radius-sm);
-        transition: color 140ms ease, background 140ms ease;
+        transition: color 140ms ease;
       }
-      .sync-diagnostics-link:hover,
-      .sync-diagnostics-link:focus-visible {
+      .sync-subview-link:hover {
         color: var(--accent);
-        background: color-mix(in srgb, var(--accent) 8%, transparent);
-        outline: none;
       }
-      .sync-diagnostics-link:focus-visible {
+      .sync-subview-link:focus-visible {
+        color: var(--accent);
         outline: 2px solid var(--accent);
         outline-offset: 2px;
-      }
-
-      .sync-diagnostics-back-link {
-        font-size: 12px;
-        font-weight: 500;
-        color: var(--text-secondary);
-        text-decoration: none;
-        margin-right: var(--sp-2);
-      }
-      .sync-diagnostics-back-link:hover,
-      .sync-diagnostics-back-link:focus-visible {
-        color: var(--accent);
       }
 
       .section-meta {
@@ -965,26 +966,35 @@
          clean ("Expand device work").
          See docs/plans/2026-04-23-sync-tab-redesign.md (PR 2). */
       .device-row-head {
-        display: grid;
-        grid-template-columns: auto 1fr auto auto auto;
+        display: flex;
         align-items: center;
         gap: var(--sp-3);
         width: 100%;
         min-height: 56px;
-        padding: 10px var(--sp-3);
+        padding: 10px var(--sp-4);
       }
       .device-row-toggle {
+        margin-left: auto;
+        flex-shrink: 0;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        width: 28px;
-        height: 28px;
+        width: 32px;
+        height: 32px;
         padding: 0;
         background: transparent;
         border: none;
         border-radius: var(--radius-sm);
-        color: var(--text-tertiary);
+        color: var(--text-secondary);
         cursor: pointer;
+      }
+      .device-row-toggle svg {
+        width: 18px;
+        height: 18px;
+        transition: transform 140ms ease;
+      }
+      .device-row-toggle[data-state="open"] svg {
+        transform: rotate(90deg);
       }
       .device-row-toggle:hover {
         background: color-mix(in srgb, var(--surface-2) 70%, transparent);
@@ -995,13 +1005,14 @@
         outline-offset: 2px;
       }
       .device-row-head .device-row-name {
+        flex: 1 1 auto;
+        min-width: 0;
         font-size: 14px;
         font-weight: 600;
         color: var(--text-primary);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        min-width: 0;
       }
       .device-row-head .device-row-chips {
         display: inline-flex;
@@ -1014,22 +1025,6 @@
         color: var(--text-tertiary);
         font-feature-settings: 'tnum' 1;
         white-space: nowrap;
-      }
-      .device-row-head .device-row-chevron {
-        font-size: 12px;
-        color: var(--text-tertiary);
-        transition: transform 140ms ease;
-        font-family: var(--font-mono);
-      }
-      @media (max-width: 900px) {
-        .device-row-head {
-          grid-template-columns: auto 1fr auto;
-        }
-        .device-row-head .device-row-chips,
-        .device-row-head .device-row-meta {
-          grid-column: 1 / -1;
-          padding-left: calc(var(--presence-pip-size, 8px) + var(--sp-3));
-        }
       }
 
       /* Drawer content region revealed when the row is expanded.
@@ -1872,11 +1867,18 @@
 
       /* ── Peers ─────────────────────────────────────────────── */
 
-      .peer-list { display: grid; grid-template-columns: 1fr; gap: var(--sp-3); }
-      @media (min-width: 900px) {
-        .peer-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      /* Device list: full-width rows so the row head reads as a single
+         line and the expanded drawer uses the full card width. The old
+         2-column grid above 900px forced expansion into a narrow sidebar. */
+      .peer-list { display: grid; grid-template-columns: 1fr; gap: var(--sp-2); }
+      .peer-card {
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        background: var(--surface-1);
+        padding: 0;
+        display: block;
+        overflow: hidden;
       }
-      .peer-card { border-radius: var(--radius-lg); padding: var(--sp-4); display: grid; gap: var(--sp-2); }
       .peer-title { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); flex-wrap: wrap; }
       .peer-title strong { font-size: 14px; font-weight: 600; }
       /* Direction glyph rendered when a peer is in mutual-trust state.
@@ -3340,7 +3342,7 @@
           </div>
           <div class="section-actions">
             <button class="settings-button" id="syncNowButton">Sync now</button>
-            <a class="sync-diagnostics-link" href="#sync/diagnostics">View diagnostics &rarr;</a>
+            <a class="sync-subview-link" href="#sync/diagnostics">View diagnostics &rarr;</a>
           </div>
         </div>
         <div class="section-meta" id="syncTeamMeta">Start with the next step below, then review team status and device details.</div>
@@ -3431,7 +3433,7 @@
       <div class="card" style="animation-delay: 0.06s">
         <div class="section-header">
           <div class="section-header-title">
-            <a class="sync-diagnostics-back-link" href="#sync">&larr; Back to sync</a>
+            <a class="sync-subview-link" href="#sync">&larr; Back to sync</a>
             <h2>Sync diagnostics</h2>
           </div>
           <div class="section-actions">

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -973,7 +973,25 @@
         min-height: 56px;
         padding: 10px var(--sp-4);
       }
-      .device-row-toggle {
+      /* Row head doubles as the Collapsible trigger so clicking anywhere
+         on the band toggles the drawer. Button defaults are reset; the
+         chevron at the right is a visual indicator only. */
+      button.device-row-head--trigger {
+        background: transparent;
+        border: none;
+        color: inherit;
+        text-align: left;
+        font: inherit;
+        cursor: pointer;
+      }
+      button.device-row-head--trigger:hover {
+        background: color-mix(in srgb, var(--surface-2) 60%, transparent);
+      }
+      button.device-row-head--trigger:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: -2px;
+      }
+      .device-row-chevron {
         margin-left: auto;
         flex-shrink: 0;
         display: inline-flex;
@@ -981,28 +999,15 @@
         justify-content: center;
         width: 32px;
         height: 32px;
-        padding: 0;
-        background: transparent;
-        border: none;
-        border-radius: var(--radius-sm);
         color: var(--text-secondary);
-        cursor: pointer;
       }
-      .device-row-toggle svg {
+      .device-row-chevron svg {
         width: 18px;
         height: 18px;
         transition: transform 140ms ease;
       }
-      .device-row-toggle[data-state="open"] svg {
+      button.device-row-head--trigger[data-state="open"] .device-row-chevron svg {
         transform: rotate(90deg);
-      }
-      .device-row-toggle:hover {
-        background: color-mix(in srgb, var(--surface-2) 70%, transparent);
-        color: var(--text-primary);
-      }
-      .device-row-toggle:focus-visible {
-        outline: 2px solid var(--accent);
-        outline-offset: 2px;
       }
       .device-row-head .device-row-name {
         flex: 1 1 auto;

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -727,14 +727,30 @@
          header · helper · auto-seed toggle (master) · include chips
          · exclude chips · actions. Delimits itself as its own subsection
          with a top border + breathing room so it doesn't run into the
-         peer-actions row above. */
+         peer-actions row above. Radix Collapsible.Content is the host,
+         so open/close is driven by data-state. */
       .coordinator-admin-group-preferences {
         display: grid;
         gap: var(--sp-4);
-        margin-top: var(--sp-3);
         padding-top: var(--sp-3);
         border-top: 1px solid var(--border);
         min-width: 0;
+      }
+      .coordinator-admin-group-preferences[data-state="closed"] { display: none; }
+      /* Rotate the trigger's chevron when the scope-defaults disclosure
+         is open. Matches the sync-tab device-row chevron affordance. */
+      .coordinator-admin-scope-trigger[data-state="open"] .device-row-chevron {
+        transform: rotate(90deg);
+      }
+      .coordinator-admin-scope-trigger .device-row-chevron {
+        display: inline-flex;
+        width: 14px;
+        height: 14px;
+        transition: transform 140ms ease;
+      }
+      .coordinator-admin-scope-trigger .device-row-chevron svg {
+        width: 100%;
+        height: 100%;
       }
 
       .coordinator-admin-group-preferences > .coordinator-admin-field,
@@ -1883,6 +1899,14 @@
         padding: 0;
         display: block;
         overflow: hidden;
+      }
+      /* Padded variant for surfaces that reuse .peer-card as a generic
+         content card (e.g. coordinator-admin group cards). Device rows
+         keep padding:0 because their row-head owns its own interior. */
+      .peer-card.peer-card--padded {
+        padding: var(--sp-3);
+        display: grid;
+        gap: var(--sp-2);
       }
       .peer-title { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); flex-wrap: wrap; }
       .peer-title strong { font-size: 14px; font-weight: 600; }

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2889,25 +2889,26 @@ describe("viewer-server", () => {
 				const res = await app.request("/api/sync/status");
 				expect(res.status).toBe(200);
 				expect(diagnosticsSpy).toHaveBeenCalled();
-				expect(diagnosticsSpy).toHaveBeenCalledWith(expect.anything(), {
-					fastCounts: true,
-				});
+				const call = diagnosticsSpy.mock.calls.at(0);
+				expect(call?.[1]?.fastCounts).not.toBe(false);
 			} finally {
 				diagnosticsSpy.mockRestore();
 				cleanup();
 			}
 		});
 
-		it("uses full semantic diagnostics when sync diagnostics are explicitly requested", async () => {
+		it("keeps the cheap semantic diagnostics path when sync diagnostics are explicitly requested", async () => {
+			// The deep per-memory vec0 probe blocks the event loop, so the
+			// sync status endpoint always uses the fast count path regardless
+			// of `includeDiagnostics`. See codemem-00jn.
 			const diagnosticsSpy = vi.spyOn(core, "getSemanticIndexDiagnostics");
 			const { app, cleanup } = createTestApp();
 			try {
 				const res = await app.request("/api/sync/status?includeDiagnostics=1");
 				expect(res.status).toBe(200);
 				expect(diagnosticsSpy).toHaveBeenCalled();
-				expect(diagnosticsSpy).toHaveBeenCalledWith(expect.anything(), {
-					fastCounts: false,
-				});
+				const call = diagnosticsSpy.mock.calls.at(0);
+				expect(call?.[1]?.fastCounts).not.toBe(false);
 			} finally {
 				diagnosticsSpy.mockRestore();
 				cleanup();

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -4,7 +4,6 @@
 
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
-import net from "node:net";
 import { networkInterfaces } from "node:os";
 import { dirname, join } from "node:path";
 import type {
@@ -1001,21 +1000,6 @@ function readViewerBinding(dbPath: string): { host: string; port: number } | nul
 	return null;
 }
 
-async function portOpen(host: string, port: number): Promise<boolean> {
-	return new Promise((resolve) => {
-		const socket = net.createConnection({ host, port });
-		const done = (ok: boolean) => {
-			socket.removeAllListeners();
-			socket.destroy();
-			resolve(ok);
-		};
-		socket.setTimeout(300);
-		socket.once("connect", () => done(true));
-		socket.once("timeout", () => done(false));
-		socket.once("error", () => done(false));
-	});
-}
-
 const PEERS_QUERY = `
 	SELECT p.peer_device_id, p.name, p.pinned_fingerprint, p.addresses_json,
 	       p.last_seen_at, p.last_sync_at, p.last_error,
@@ -1417,13 +1401,17 @@ export function syncRoutes(
 			const lastErrorAt = daemonState?.last_error_at as string | null;
 			const lastOkAt = daemonState?.last_ok_at as string | null;
 			const viewerBinding = traceSync("readViewerBinding", () => readViewerBinding(store.dbPath));
-			const daemonRunning = viewerBinding
-				? await portOpen(viewerBinding.host, viewerBinding.port)
-				: false;
+			// The sync daemon runs inside the viewer-server process itself, so
+			// if this request is being served, the daemon is by definition
+			// running — the viewer is serving us right now. The prior
+			// `portOpen` self-probe occasionally timed out under GC / socket
+			// backlog pressure and mis-reported "stopped · unreachable" while
+			// every other request kept succeeding. Trust the pidfile's
+			// existence (a record was written at startup) and skip the loopback
+			// probe.
+			const daemonRunning = Boolean(viewerBinding);
 			const daemonDetail = viewerBinding
-				? daemonRunning
-					? `viewer pidfile at ${viewerBinding.host}:${viewerBinding.port}`
-					: `pidfile present but ${viewerBinding.host}:${viewerBinding.port} is unreachable`
+				? `viewer pidfile at ${viewerBinding.host}:${viewerBinding.port}`
 				: null;
 
 			let daemonStateValue = "ok";

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1390,11 +1390,12 @@ export function syncRoutes(
 					.from(schema.syncPeers)
 					.get(),
 			);
+			// Always take the fast COUNT(DISTINCT) path. The slow
+			// per-memory vec0 probe blocks the event loop for seconds on
+			// larger DBs, which hangs every concurrent request — not
+			// acceptable from a status endpoint. See codemem-00jn.
 			const semanticIndex = traceSync("semanticIndex", () =>
-				redactSemanticIndexDiagnostics(
-					getSemanticIndexDiagnostics(store.db, { fastCounts: !showDiag }),
-					showDiag,
-				),
+				redactSemanticIndexDiagnostics(getSemanticIndexDiagnostics(store.db), showDiag),
 			);
 
 			const lastError = daemonState?.last_error as string | null;


### PR DESCRIPTION
## Description

Dogfood of the merged Sync tab redesign (PRs #963-#967) surfaced five real
issues. Fixing them together since they're all the same "Sync tab polish"
story.

- **Device list was a 2-column grid above 900px**, so expansion rendered
  inside a narrow sidebar column while the other row sat empty. Switched
  to single-column full-width rows; outer border/radius/background now
  live on `.peer-card`, the row head is transparent content, and the
  drawer has a `border-top` separator inside the same card.
- **Row head was a grid that broke when the direction glyph was absent**,
  causing the chevron to wrap to a second line. Switched to flex;
  `.device-row-toggle { margin-left: auto }` keeps the toggle right-edge
  regardless of which middle children render.
- **Row expand toggle was a hand-rolled `<button>` with a unicode ▸/▾**
  that was nearly invisible against `--surface-1`. Replaced with Radix
  Collapsible (`@radix-ui/react-collapsible`, already installed) + a
  properly sized inline Lucide chevron SVG that rotates on `data-state="open"`.
  Radix gives us correct `aria-expanded`/`aria-controls` wiring and
  keyboard handling for free. Module-level `expandedPeerId` still
  enforces single-open-at-a-time; `handleOpenChange` reads the live
  module state (not a stale closure) so one row taking over doesn't
  clobber the new pointer.
- **`View diagnostics →` and `← Back to sync` had different styles**.
  Collapsed into one `.sync-subview-link` class used for both
  directions — utility-nav treatment, quieter than any nearby button.
- **`work is offline` surfaced as a Needs Attention item.** Computers
  power-cycle; the row already carries the Offline badge + pip. Dropped
  the `peerStatus === "offline"` branch from `sync-view-model.ts`'s
  attention-item derivation. Auth/trust/repair failures still fire.
- **Pairing payload was double-hidden** ("Show pairing command" →
  revealed a card that just said "Pairing payload hidden" unless
  diagnostics were on). The payload is a local command shared with your
  own other device, not a secret. The outer disclosure is enough
  gating; removed the redaction branch in `diagnostics/helpers.ts`.
- **Sync tab cards had no gap between them** while Feed did. The
  redesign's `#syncMainView` / `#syncDiagnosticsView` wrappers broke
  the `.tab-panel` flex-gap inheritance; restored the same gap inside
  each sub-view wrapper.

## Type of Change

- [x] Bug fix
- [x] UX polish

## Testing

- \`pnpm run tsc && pnpm run lint && pnpm run test\` (1475 passing)
- Manual: Sync tab — device row toggle is visible mint-on-surface
  chevron that rotates 90° on open; expand/collapse one row cleanly
  stacks in a single column; View diagnostics / Back to sync read as
  the same utility link; offline peer no longer shows up in Needs
  attention; "Show pairing command" reveals the command directly.