### PR TITLE
fix(vector-migration): fast-exit when corpus already covers target model (codemem-ad6m)

### DIFF
--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as embeddings from "./embeddings.js";
-import { getMaintenanceJob } from "./maintenance-jobs.js";
+import { getMaintenanceJob, startMaintenanceJob } from "./maintenance-jobs.js";
 import { applyBootstrapSnapshot } from "./sync-bootstrap.js";
 import { setSyncResetState } from "./sync-replication.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
@@ -210,6 +210,47 @@ describe("vector migration", () => {
 			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
 			.all() as Array<{ model: string; c: number }>;
 		expect(models).toEqual([{ model: "test-model", c: 3 }]);
+	});
+
+	it("completes an in-flight running job without re-embedding when corpus is already covered", async () => {
+		// Reproduces codemem-ad6m: sync-incremental trigger leaves the job in
+		// 'running' status after its queue drains; every memory is already
+		// covered by target-model vectors and no source model remains. The
+		// runner should fast-exit, marking the job completed, not re-embed
+		// the entire corpus.
+		const sessionId = insertTestSession(db);
+		seedMemory(db, 1, sessionId, "One", "Body one");
+		seedMemory(db, 2, sessionId, "Two", "Body two");
+		seedVector(db, 1, "test-model");
+		seedVector(db, 2, "test-model");
+		startMaintenanceJob(db, {
+			kind: VECTOR_MODEL_MIGRATION_JOB,
+			title: "Re-indexing memories",
+			status: "running",
+			message: "Queued sync vector catch-up complete",
+			progressCurrent: 2,
+			progressTotal: 2,
+			metadata: {
+				target_model: "test-model",
+				source_model: null,
+				last_cursor_id: 0,
+				processed_embeddable: 2,
+				embeddable_total: 2,
+				trigger: "sync_incremental",
+			},
+		});
+		const embedSpy = vi.mocked(embeddings.embedTexts);
+		const callsBefore = embedSpy.mock.calls.length;
+
+		await runVectorMigrationPass(db, { batchSize: 50 });
+
+		expect(embedSpy.mock.calls.length).toBe(callsBefore);
+		const job = getMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB);
+		expect(job).toMatchObject({ status: "completed" });
+		const models = db
+			.prepare("SELECT model, COUNT(*) AS c FROM memory_vectors GROUP BY model ORDER BY model")
+			.all() as Array<{ model: string; c: number }>;
+		expect(models).toEqual([{ model: "test-model", c: 2 }]);
 	});
 
 	it("resumes bootstrap-queued vector catch-up after restart", async () => {

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -239,10 +239,14 @@ function vectorModels(db: SqliteDatabase): Array<{ model: string; rows: number }
 }
 
 function countEmbeddableActiveMemories(db: SqliteDatabase): number {
-	return db
-		.prepare("SELECT id, title, body_text FROM memory_items WHERE active = 1")
-		.all()
-		.filter((row) => isEmbeddableMemory(row as MemoryRow)).length;
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS c FROM memory_items
+			 WHERE active = 1
+			   AND TRIM(COALESCE(title, '') || COALESCE(body_text, '')) != ''`,
+		)
+		.get() as { c?: number } | undefined;
+	return Number(row?.c ?? 0);
 }
 
 function selectNextMigrationBatch(
@@ -362,8 +366,21 @@ export async function runVectorMigrationPass(
 		existingJob?.status === "running" ||
 		existingJob?.status === "pending" ||
 		existingJob?.status === "failed";
-	if (!sourceModel && !hasInFlightJob) {
-		// No stale model and no in-flight job — check if any active memories lack target vectors.
+	// codemem-ad6m: when a sync-triggered job (bootstrap or incremental)
+	// drains its queued work, status can remain 'running' without the
+	// batch loop having anything to do. The previous logic fell through
+	// and re-embedded the entire corpus. Fast-exit for that specific
+	// case — but ONLY for sync-triggered jobs, since the `uncovered`
+	// SQL counts memories that have ANY target-model row (even a single
+	// chunk of a multi-chunk memory). Full-migration jobs (no trigger,
+	// or an older full-migration trigger) must keep falling through to
+	// the batch loop so backfillVectors can detect partial chunk
+	// coverage and repair it.
+	const existingJobTrigger = (existingJob?.metadata as MigrationMetadata | undefined)?.trigger;
+	const fromSyncTrigger =
+		existingJobTrigger === SYNC_INCREMENTAL_TRIGGER ||
+		existingJobTrigger === SYNC_BOOTSTRAP_TRIGGER;
+	if (!sourceModel && fromSyncTrigger && hasInFlightJob) {
 		const uncovered = db
 			.prepare(
 				`SELECT COUNT(*) AS c FROM memory_items
@@ -372,6 +389,20 @@ export async function runVectorMigrationPass(
 			)
 			.get(targetModel) as { c?: number } | undefined;
 		if (Number(uncovered?.c ?? 0) <= 0) {
+			const jobMeta = (existingJob?.metadata ?? {}) as MigrationMetadata;
+			const indexedTotal = countEmbeddableActiveMemories(db);
+			completeMaintenanceJob(db, VECTOR_MODEL_MIGRATION_JOB, {
+				message: "Finished re-indexing memories",
+				progressCurrent: indexedTotal,
+				progressTotal: indexedTotal,
+				metadata: {
+					...jobMeta,
+					source_model: null,
+					target_model: targetModel,
+					processed_embeddable: indexedTotal,
+					embeddable_total: indexedTotal,
+				},
+			});
 			return;
 		}
 	}


### PR DESCRIPTION
## Description
<!-- Briefly describe what this PR changes and why -->

## Type of Change
<!-- Mark the relevant option(s) with an "x" -->

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing
<!-- Describe how you tested these changes -->

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist
<!-- Mark completed items with an "x" -->

- [ ] Code follows project style (`pnpm run lint` passes for touched files)
- [ ] Self-review completed
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced
