### PR TITLE
fix(sync): stop redacting the pairing payload

### DIFF
--- a/packages/ui/src/tabs/sync/diagnostics/helpers.test.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/helpers.test.ts
@@ -7,14 +7,7 @@ describe("pairingView", () => {
 		state.pairingCommandRaw = "";
 	});
 
-	it("returns a hidden-command message when the payload is redacted", () => {
-		const view = pairingView({ redacted: true, pairing_filter_hint: "sync_is_redacted" });
-		expect(view.payloadText).toBe("Pairing command hidden while sync redaction is on.");
-		expect(view.hintText).toMatch(/Settings → Device Sync/);
-		expect(state.pairingCommandRaw).toBe("");
-	});
-
-	it("builds a base64 copy command when the payload is not redacted", () => {
+	it("builds a base64 copy command when the payload is present", () => {
 		const view = pairingView({
 			device_id: "dev-a",
 			fingerprint: "fp",

--- a/packages/ui/src/tabs/sync/diagnostics/helpers.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/helpers.ts
@@ -33,18 +33,6 @@ export function pairingView(payload: unknown): PairingView {
 	}
 
 	const pairingPayload = payload as PairingPayloadState;
-	// Invariant: the pairing command is only constructed when the server
-	// returned a non-redacted payload. When sync redaction is on (the
-	// default) /api/sync/pairing strips device_id/fingerprint/public_key/
-	// addresses and returns { redacted: true }; turning that into a
-	// base64 command produces one the CLI accept path rejects. Surface
-	// the redaction state so the user can disable it and retry.
-	if (pairingPayload.redacted) {
-		return noPairingCommand(
-			"Pairing command hidden while sync redaction is on.",
-			"Turn off sync redaction in Settings → Device Sync to reveal the copyable pairing command for this device.",
-		);
-	}
 	const safePayload = {
 		...pairingPayload,
 		addresses: Array.isArray(pairingPayload.addresses) ? pairingPayload.addresses : [],

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -240,7 +240,10 @@ export function resetSyncLoadStateForTests() {
 
 export async function loadPairingData() {
 	try {
-		const payload = await api.loadPairing(!isSyncRedactionEnabled());
+		// Pairing payload is always returned in full — it's the actual
+		// command the user shares, not a diagnostic. The "Show pairing
+		// command" disclosure in the UI is the user-facing exposure gate.
+		const payload = await api.loadPairing();
 		state.pairingPayloadRaw = payload || null;
 		renderPairing();
 	} catch {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1682,16 +1682,16 @@ export function syncRoutes(
 	});
 
 	// GET /api/sync/pairing — uses ensureDeviceIdentity from core (fix #5 context)
+	//
+	// The pairing payload is not redacted by the generic diagnostics toggle:
+	// it is the actual command the user shares with their own other devices,
+	// and the UI already hides it inside a "Show pairing command" disclosure
+	// that they explicitly open. Redacting the payload here broke the
+	// happy-path pairing flow because the UI had nothing to render as the
+	// command when diagnostics were off.
 	app.get("/api/sync/pairing", (c) => {
 		const store = getStore();
 		{
-			const showDiag = queryBool(c.req.query("includeDiagnostics"));
-			if (!showDiag) {
-				return c.json({
-					redacted: true,
-					pairing_filter_hint: PAIRING_FILTER_HINT,
-				});
-			}
 			const config = readCoordinatorSyncConfig();
 			const d = drizzle(store.db, { schema });
 			const deviceRow = d


### PR DESCRIPTION
## Description

`/api/sync/pairing` used to return `{ redacted: true, pairing_filter_hint }` whenever the generic sync-redaction toggle was on, which is the default. The UI's "Show pairing command" disclosure is already the user-facing exposure gate, so server-side redaction only broke the happy-path pairing flow — the copy-me command was constructed from an empty payload and the CLI accept path rejected it.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced