### PR TITLE
feat(sync): unified paste-to-accept for team invites and device pairing

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-invite-join-panels.tsx
@@ -107,13 +107,14 @@ function JoinToggleRow({
 		<>
 			<div className="sync-action">
 				<div className="sync-action-text">
-					Join another team.
+					Accept an invite or pairing.
 					<span className="sync-action-command">
-						Paste an invite to join an additional team from this device.
+						Paste a team invite to join another team, or a pairing payload to connect another
+						device.
 					</span>
 				</div>
 				<button type="button" className="settings-button" onClick={onToggle}>
-					{joinPanelOpen ? "Hide join form" : "Join another team"}
+					{joinPanelOpen ? "Hide paste form" : "Paste invite or pairing"}
 				</button>
 			</div>
 			{joinPanel ? (
@@ -163,7 +164,8 @@ export function SyncInviteJoinPanels({
 						<div className="sync-action-text">
 							Join this device.
 							<span className="sync-action-command">
-								Paste an invite for this device below to join an existing team.
+								Paste a team invite or pairing payload below to join an existing team or connect
+								another of your devices.
 							</span>
 						</div>
 					</div>

--- a/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
+++ b/packages/ui/src/tabs/sync/team-sync/events/init-team-sync-events.ts
@@ -95,22 +95,37 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 		if (!syncJoinButton || !syncJoinInvite) return;
 		const inviteValue = syncJoinInvite.value.trim();
 		if (!inviteValue) {
-			markFieldError(syncJoinInvite, "Paste a team invite to join.");
+			markFieldError(syncJoinInvite, "Paste a team invite or pairing payload.");
 			return;
 		}
 		clearFieldError(syncJoinInvite);
 		syncJoinButton.disabled = true;
-		syncJoinButton.textContent = "Joining\u2026";
+		syncJoinButton.textContent = "Accepting\u2026";
 		try {
 			const result = await api.importCoordinatorInvite(inviteValue);
 			state.lastTeamJoin = result;
-			let feedback: SyncActionFeedback = {
-				message:
-					result.status === "pending"
-						? "Join request sent. Waiting for admin approval."
-						: "Joined the team.",
-				tone: "success",
-			};
+			const resultType =
+				typeof (result as { type?: unknown }).type === "string"
+					? ((result as { type: string }).type as "pair" | "team_join")
+					: "team_join";
+			let feedback: SyncActionFeedback;
+			if (resultType === "pair") {
+				const peerId = String((result as { peer_device_id?: unknown }).peer_device_id ?? "").trim();
+				feedback = {
+					message: peerId
+						? `Paired with device ${peerId.slice(0, 8)}. It will appear in People & devices.`
+						: "Paired the device. It will appear in People & devices.",
+					tone: "success",
+				};
+			} else {
+				feedback = {
+					message:
+						result.status === "pending"
+							? "Join request sent. Waiting for admin approval."
+							: "Joined the team.",
+					tone: "success",
+				};
+			}
 			state.syncJoinFlowFeedback = feedback;
 			setJoinFeedbackVisibility();
 			syncJoinInvite.value = "";
@@ -118,7 +133,10 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 				await loadSyncData();
 			} catch (error) {
 				feedback = {
-					message: friendlyError(error, "Joined the team, but this view has not refreshed yet."),
+					message: friendlyError(
+						error,
+						"Accepted the invite, but this view has not refreshed yet.",
+					),
 					tone: "warning",
 				};
 				state.syncJoinFlowFeedback = feedback;
@@ -128,7 +146,7 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 			state.syncJoinFlowFeedback = {
 				message: friendlyError(
 					error,
-					"Failed to import invite. Check that the invite is complete, current, and meant for this team, then try again.",
+					"Failed to accept. Check that the invite or pairing payload is complete and current, then try again.",
 				),
 				tone: "warning",
 			};
@@ -139,7 +157,7 @@ export function initTeamSyncEvents(refreshCallback: () => void, loadSyncData: ()
 		} finally {
 			if (syncJoinButton.disabled) {
 				syncJoinButton.disabled = false;
-				syncJoinButton.textContent = "Join team";
+				syncJoinButton.textContent = "Accept";
 			}
 		}
 	});

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3386,9 +3386,9 @@
             <h3 class="settings-group-title">Join a team</h3>
             <div class="section-meta">Have an invite? Paste it here.</div>
             <div class="actor-create-row" id="syncJoinPanel">
-              <label for="syncJoinInvite" class="sr-only">Team invite</label>
-              <textarea class="feed-search" id="syncJoinInvite" placeholder="Paste team invite or codemem:// link"></textarea>
-              <button class="settings-button" id="syncJoinButton">Join team</button>
+              <label for="syncJoinInvite" class="sr-only">Team invite or pairing payload</label>
+              <textarea class="feed-search" id="syncJoinInvite" placeholder="Paste a team invite or device pairing payload"></textarea>
+              <button class="settings-button" id="syncJoinButton">Accept</button>
             </div>
           </div>
           <div id="syncAdminSection">

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -4780,6 +4780,154 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("accepts a device pairing payload and writes the peer row", async () => {
+			const peerKeysDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-keys-"));
+			const peerDbDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-db-"));
+			const peerDbPath = join(peerDbDir, "peer.sqlite");
+			const peerDb = new Database(peerDbPath);
+			initTestSchema(peerDb);
+			const [peerDeviceId, peerFingerprint] = ensureDeviceIdentity(peerDb, {
+				keysDir: peerKeysDir,
+			});
+			const peerPublicKey = loadPublicKey(peerKeysDir) ?? "";
+			peerDb.close();
+			const pairingPayload = {
+				device_id: peerDeviceId,
+				fingerprint: peerFingerprint,
+				public_key: peerPublicKey,
+				addresses: ["http://10.10.10.10:7337"],
+			};
+			const invite = Buffer.from(JSON.stringify(pairingPayload), "utf8").toString("base64");
+
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const res = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite }),
+				});
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({
+					ok: true,
+					type: "pair",
+					peer_device_id: peerDeviceId,
+				});
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const row = store.db
+					.prepare(
+						"SELECT peer_device_id, pinned_fingerprint FROM sync_peers WHERE peer_device_id = ?",
+					)
+					.get(peerDeviceId) as
+					| { peer_device_id?: string; pinned_fingerprint?: string }
+					| undefined;
+				expect(row?.peer_device_id).toBe(peerDeviceId);
+				expect(row?.pinned_fingerprint).toBe(peerFingerprint);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("accepts a raw JSON pairing payload without base64 wrapping", async () => {
+			const peerKeysDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-keys-"));
+			const peerDbDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-db-"));
+			const peerDbPath = join(peerDbDir, "peer.sqlite");
+			const peerDb = new Database(peerDbPath);
+			initTestSchema(peerDb);
+			const [peerDeviceId, peerFingerprint] = ensureDeviceIdentity(peerDb, {
+				keysDir: peerKeysDir,
+			});
+			const peerPublicKey = loadPublicKey(peerKeysDir) ?? "";
+			peerDb.close();
+			const pairingJson = JSON.stringify({
+				device_id: peerDeviceId,
+				fingerprint: peerFingerprint,
+				public_key: peerPublicKey,
+				addresses: ["http://10.10.10.10:7337"],
+			});
+			const { app, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const res = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite: pairingJson }),
+				});
+				expect(res.status).toBe(200);
+				expect(await res.json()).toMatchObject({ type: "pair", peer_device_id: peerDeviceId });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("unwraps the shell pairing command and accepts the embedded payload", async () => {
+			const peerKeysDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-keys-"));
+			const peerDbDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-db-"));
+			const peerDbPath = join(peerDbDir, "peer.sqlite");
+			const peerDb = new Database(peerDbPath);
+			initTestSchema(peerDb);
+			const [peerDeviceId, peerFingerprint] = ensureDeviceIdentity(peerDb, {
+				keysDir: peerKeysDir,
+			});
+			const peerPublicKey = loadPublicKey(peerKeysDir) ?? "";
+			peerDb.close();
+			const pairingPayload = {
+				device_id: peerDeviceId,
+				fingerprint: peerFingerprint,
+				public_key: peerPublicKey,
+				addresses: ["http://10.10.10.10:7337"],
+			};
+			const b64 = Buffer.from(JSON.stringify(pairingPayload), "utf8").toString("base64");
+			const shellWrapper = `echo '${b64}' | base64 -d | codemem sync pair --accept-file -`;
+
+			const { app, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const res = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite: shellWrapper }),
+				});
+				expect(res.status).toBe(200);
+				expect(await res.json()).toMatchObject({ type: "pair", peer_device_id: peerDeviceId });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects a pairing payload whose fingerprint does not match its public key", async () => {
+			const peerKeysDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-keys-"));
+			const peerDbDir = mkdtempSync(join(tmpdir(), "codemem-pair-peer-db-"));
+			const peerDbPath = join(peerDbDir, "peer.sqlite");
+			const peerDb = new Database(peerDbPath);
+			initTestSchema(peerDb);
+			const [peerDeviceId] = ensureDeviceIdentity(peerDb, { keysDir: peerKeysDir });
+			const peerPublicKey = loadPublicKey(peerKeysDir) ?? "";
+			peerDb.close();
+			const tampered = {
+				device_id: peerDeviceId,
+				fingerprint: "ff".repeat(32), // wrong
+				public_key: peerPublicKey,
+				addresses: ["http://10.10.10.10:7337"],
+			};
+			const invite = Buffer.from(JSON.stringify(tampered), "utf8").toString("base64");
+			const { app, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const res = await app.request("/api/sync/invites/import", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ invite }),
+				});
+				expect(res.status).toBe(400);
+				expect(await res.json()).toEqual({ error: "Pairing payload fingerprint mismatch" });
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("reports coordinator admin readiness states", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -55,6 +55,7 @@ import {
 	schema,
 	syncProjectAllowedByFilters,
 	syncVisibilityAllowed,
+	updatePeerAddresses,
 	upsertCoordinatorGroupPreference,
 	verifySignature,
 } from "@codemem/core";
@@ -92,6 +93,81 @@ const SYNC_STALE_AFTER_SECONDS = 10 * 60;
 const SYNC_PROTOCOL_VERSION = "2";
 const LEGACY_SYNC_ACTOR_DISPLAY_NAME = "Legacy synced peer";
 const LEGACY_SHARED_WORKSPACE_ID = "shared:legacy";
+
+/**
+ * Attempt to decode a pasted string as a device-pairing payload.
+ *
+ * Returns:
+ *   - `{ kind: "pair", ... }` when the payload base64-decodes to JSON with
+ *     the expected pairing shape AND the fingerprint matches the public
+ *     key.
+ *   - `{ kind: "invalid-pair", error }` when the payload looked like a
+ *     pairing payload but failed validation — the caller should 400 this
+ *     rather than falling back to coordinator-invite handling.
+ *   - `null` when the string is not a pairing payload at all.
+ */
+function tryParsePairingPayload(value: string):
+	| {
+			kind: "pair";
+			device_id: string;
+			fingerprint: string;
+			public_key: string;
+			addresses: string[];
+	  }
+	| { kind: "invalid-pair"; error: string }
+	| null {
+	// Accept both shapes the CLI can emit:
+	//   - raw JSON (`codemem sync pair --payload-only`)
+	//   - base64-encoded JSON (the inner blob inside the shell pipe wrapper)
+	let parsed: Record<string, unknown>;
+	if (value.trimStart().startsWith("{")) {
+		try {
+			parsed = JSON.parse(value) as Record<string, unknown>;
+		} catch {
+			return null;
+		}
+	} else {
+		let decoded: string;
+		try {
+			decoded = Buffer.from(value, "base64").toString("utf8");
+		} catch {
+			return null;
+		}
+		if (!decoded?.trimStart().startsWith("{")) return null;
+		try {
+			parsed = JSON.parse(decoded) as Record<string, unknown>;
+		} catch {
+			return null;
+		}
+	}
+	const deviceId = String(parsed.device_id ?? "").trim();
+	const fingerprint = String(parsed.fingerprint ?? "").trim();
+	const publicKey = String(parsed.public_key ?? "").trim();
+	// If the JSON doesn't carry any of the pairing discriminators, treat
+	// it as a different kind of payload (e.g. a coordinator invite happened
+	// to be JSON-encoded directly). Let the caller keep trying.
+	if (!deviceId && !fingerprint && !publicKey) return null;
+	const rawAddresses = Array.isArray(parsed.addresses) ? parsed.addresses : [];
+	const addresses = rawAddresses
+		.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+		.map((item) => item.trim());
+	if (!deviceId || !fingerprint || !publicKey || addresses.length === 0) {
+		return {
+			kind: "invalid-pair",
+			error: "Pairing payload missing device_id, fingerprint, public_key, or addresses",
+		};
+	}
+	if (fingerprintPublicKey(publicKey) !== fingerprint) {
+		return { kind: "invalid-pair", error: "Pairing payload fingerprint mismatch" };
+	}
+	return {
+		kind: "pair",
+		device_id: deviceId,
+		fingerprint,
+		public_key: publicKey,
+		addresses,
+	};
+}
 
 type CoordinatorAdminReadiness = "not_configured" | "partial" | "ready";
 
@@ -2155,6 +2231,12 @@ export function syncRoutes(
 		}
 	});
 
+	// POST /api/sync/invites/import accepts both team invites (coordinator
+	// invite envelope or codemem:// link) and device-pairing payloads
+	// (base64 JSON with { device_id, fingerprint, public_key, addresses }).
+	// The server discriminates by decoding the pasted text — UI callers get
+	// one textarea for both flows. Response carries `type: "team_join"` or
+	// `type: "pair"` so the UI can render the right success message.
 	app.post("/api/sync/invites/import", async (c) => {
 		const store = getStore();
 		let body: Record<string, unknown>;
@@ -2163,11 +2245,43 @@ export function syncRoutes(
 		} catch {
 			return c.json({ error: "invalid json" }, 400);
 		}
-		const inviteValue = String(body.invite ?? "").trim();
-		if (!inviteValue) return c.json({ error: "invite required" }, 400);
+		const rawValue = String(body.invite ?? "").trim();
+		if (!rawValue) return c.json({ error: "invite required" }, 400);
+
+		// Users often paste the whole shell command emitted by the Pairing
+		// diagnostics disclosure (`echo '<b64>' | base64 -d | codemem sync
+		// pair --accept-file -`). Peel the base64 out if we see that shape.
+		const shellMatch = rawValue.match(
+			/echo\s+['"]([A-Za-z0-9+/=]+)['"]\s*\|\s*base64\s+-d\s*\|\s*codemem/,
+		);
+		const normalized = shellMatch?.[1]?.trim() || rawValue;
+
+		const pairingResult = tryParsePairingPayload(normalized);
+		if (pairingResult?.kind === "invalid-pair") {
+			return c.json({ error: pairingResult.error }, 400);
+		}
+		if (pairingResult?.kind === "pair") {
+			try {
+				updatePeerAddresses(store.db, pairingResult.device_id, pairingResult.addresses, {
+					pinnedFingerprint: pairingResult.fingerprint,
+					publicKey: pairingResult.public_key,
+				});
+				return c.json({
+					ok: true,
+					type: "pair",
+					peer_device_id: pairingResult.device_id,
+				});
+			} catch (error) {
+				return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+			}
+		}
+
 		try {
-			const result = await coordinatorImportInviteAction({ inviteValue, dbPath: store.dbPath });
-			return c.json(result);
+			const result = await coordinatorImportInviteAction({
+				inviteValue: rawValue,
+				dbPath: store.dbPath,
+			});
+			return c.json({ ...result, type: "team_join" });
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
 		}


### PR DESCRIPTION
## Description

One textarea on the Sync tab now accepts either a team invite (`codemem://join?...` link or raw coordinator-invite base64) or a device-pairing payload. The server route discriminates by decoding the pasted string — base64 → JSON with `{device_id, fingerprint, public_key, addresses}` is treated as a pairing payload and wired through `updatePeerAddresses`; everything else falls through to the existing coordinator-invite path. Shell-wrapped forms (`echo '<b64>' | base64 -d | codemem sync pair --accept-file -`) get unwrapped before decoding.

Response gains a `type: "team_join" | "pair"` discriminator so the UI can show a pair-specific success message. Textarea placeholder, section copy, and button label shift from team-only to "invite or pairing." `codemem://` was dropped from the placeholder (the parser still accepts it for back-compat).

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Three new server tests: happy-path pair, shell-wrapped pair accept, fingerprint mismatch → 400.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced