### PR TITLE
feat(sync): make team devices explicit pair-candidates with padded-card chrome

### DIFF
--- a/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
+++ b/packages/ui/src/tabs/sync/components/team-sync-panel.tsx
@@ -171,27 +171,24 @@ function DiscoveredDeviceRow({
 }) {
 	const [busy, setBusy] = useState<"remove" | "review" | null>(null);
 	const [feedback, setFeedback] = useState<SyncActionFeedback | null>(null);
-	const [reviewLabel, setReviewLabel] = useState(row.actionLabel || "Review device");
+	const defaultReviewLabel = row.actionLabel || "Pair with this device";
+	const [reviewLabel, setReviewLabel] = useState(defaultReviewLabel);
 	const [removeLabel, setRemoveLabel] = useState("Remove broken device record");
 
 	return (
-		<div className="actor-row" data-discovered-device-id={row.deviceId}>
-			<div className="actor-details">
-				<div className="actor-title">
-					<strong title={row.displayTitle || undefined}>{row.displayName}</strong>
-					<span
-						className={`badge actor-badge${row.availabilityLabel === "Offline" ? "" : " local"}`}
-					>
-						{row.availabilityLabel}
-					</span>
-					<span className="badge actor-badge">{row.connectionLabel}</span>
-					{row.approvalBadgeLabel ? (
-						<span className="badge actor-badge">{row.approvalBadgeLabel}</span>
-					) : null}
-				</div>
-				<div className="peer-meta">{row.note}</div>
+		<div className="peer-card peer-card--padded" data-discovered-device-id={row.deviceId}>
+			<div className="peer-title">
+				<strong title={row.displayTitle || undefined}>{row.displayName}</strong>
+				<span className={`badge actor-badge${row.availabilityLabel === "Offline" ? "" : " local"}`}>
+					{row.availabilityLabel}
+				</span>
+				<span className="badge actor-badge">{row.connectionLabel}</span>
+				{row.approvalBadgeLabel ? (
+					<span className="badge actor-badge">{row.approvalBadgeLabel}</span>
+				) : null}
 			</div>
-			<div className="actor-actions">
+			<div className="peer-meta">{row.note}</div>
+			<div className="peer-actions">
 				{row.mode === "accept" ? (
 					<button
 						type="button"
@@ -200,10 +197,10 @@ function DiscoveredDeviceRow({
 						disabled={busy !== null}
 						onClick={async () => {
 							setBusy("review");
-							setReviewLabel("Reviewing…");
+							setReviewLabel("Pairing…");
 							try {
 								setFeedback((await onReview(row)) || null);
-								setReviewLabel(row.actionLabel || "Review device");
+								setReviewLabel(row.actionLabel || defaultReviewLabel);
 							} catch {
 								setReviewLabel("Retry");
 							} finally {
@@ -234,7 +231,7 @@ function DiscoveredDeviceRow({
 						</button>
 						<button
 							type="button"
-							className="settings-button"
+							className="settings-button danger"
 							aria-label={`${removeLabel} for ${row.displayName}`}
 							disabled={busy !== null}
 							onClick={async () => {

--- a/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/render-team-sync.ts
@@ -215,14 +215,14 @@ export function renderTeamSync() {
 
 	const reviewDiscoveredDeviceName = async (suggestedName: string) => {
 		return await openSyncInputDialog({
-			title: "Review device",
-			description: "Choose a friendly name for this device before connecting it on this machine.",
+			title: "Pair with this device",
+			description: "Choose a friendly name for this device before pairing it on this machine.",
 			initialValue: suggestedName,
 			placeholder: "Desk Mini",
-			confirmLabel: "Connect device",
+			confirmLabel: "Pair",
 			cancelLabel: "Cancel",
 			validate: (nextValue) =>
-				nextValue.trim() ? null : "Enter a device name to connect this device.",
+				nextValue.trim() ? null : "Enter a device name to pair this device.",
 		});
 	};
 
@@ -337,7 +337,11 @@ export function renderTeamSync() {
 
 		return {
 			actionMessage,
-			actionLabel: approvalSummary.actionLabel || "Review device",
+			// Unpaired team devices get the direct "Pair with this device"
+			// affordance. Devices that already need explicit approval keep
+			// their approval-specific label (e.g. "Approve on this device").
+			actionLabel:
+				approvalSummary.actionLabel || (pairedPeer ? "Review device" : "Pair with this device"),
 			approvalBadgeLabel: approvalSummary.badgeLabel,
 			availabilityLabel: device.stale ? "Offline" : "Available",
 			connectionLabel: hasConflict
@@ -382,7 +386,7 @@ export function renderTeamSync() {
 	}
 	if (discoveredMeta) {
 		discoveredMeta.textContent = visibleDiscoveredRows.length
-			? "Review anything here that still needs trust, follow-up, or approval."
+			? "Pair with a teammate's device to see it appear in People & devices and start syncing."
 			: "";
 	}
 	if (joinRequests) {

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3397,9 +3397,9 @@
         </div>
         <div class="actor-list" id="syncJoinRequests"></div>
         <div id="syncCoordinatorDiscovered" hidden>
-          <h3 class="settings-group-title" style="margin-top: 20px">Devices seen on team</h3>
+          <h3 class="settings-group-title" style="margin-top: 20px">Team devices to pair</h3>
           <div class="section-meta" id="syncCoordinatorDiscoveredMeta"></div>
-          <div class="actor-list" id="syncCoordinatorDiscoveredList"></div>
+          <div class="peer-list" id="syncCoordinatorDiscoveredList"></div>
         </div>
       </div>
 


### PR DESCRIPTION
## Description

After joining a team, the coordinator already surfaces every other team member's device metadata (id, fingerprint, public key, addresses) as "discovered devices." The panel had been rendering that list in legacy `.actor-list` / `.actor-row` chrome with a bureaucratic "Review device" action.

- Panel title → **Team devices to pair** with action-oriented meta copy.
- Rows rebased onto `.peer-card` + `.peer-card--padded` with `.peer-title` + `.peer-actions`, matching the People & devices and coordinator-admin anatomy.
- Default row action **Pair with this device** (was "Review device"); approval-specific modes keep their explicit "Approve on this device" label.
- Pair-name modal retitled to "Pair with this device" / "Pair."

Uses the existing `/api/sync/peers/accept-discovered` endpoint — no backend wire changes.

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

UI-copy + styling change; no new unit tests. Existing 1482-test suite still green.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced