### PR TITLE
feat(ui): clickable project picker for sharing-scope include/exclude

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
 		"@radix-ui/react-switch": "^1.2.6",
 		"@radix-ui/react-tabs": "^1.1.13",
 		"@radix-ui/react-toast": "^1.2.15",
+		"@radix-ui/react-toggle-group": "^1.1.11",
 		"@radix-ui/react-tooltip": "^1.2.8",
 		"preact": "^10.27.2",
 		"tslib": "^2.8.1"

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -28,7 +28,12 @@ import { initCoordinatorAdminTab, loadCoordinatorAdminData } from "./tabs/coordi
 import { initFeedTab, loadFeedData, updateFeedView } from "./tabs/feed";
 import { initHealthTab, loadHealthData } from "./tabs/health";
 import { initSettings, isSettingsOpen, loadConfigData } from "./tabs/settings";
-import { initSyncTab, loadPairingData, loadSyncData } from "./tabs/sync";
+import {
+	initSyncTab,
+	invalidateSyncPeerScopeCache,
+	loadPairingData,
+	loadSyncData,
+} from "./tabs/sync";
 
 function setRuntimeLabel(version: string, commit: string | null) {
 	const el = $("runtimeLabel");
@@ -246,6 +251,11 @@ function initTabs() {
 async function loadProjects() {
 	try {
 		const projects = await api.loadProjects();
+		state.knownProjects = projects;
+		// The Sync peer-scope picker caches these as clickable chips; its
+		// render is otherwise deduped on an unrelated payload hash, so tell
+		// it to invalidate. No-op when Sync hasn't loaded yet.
+		invalidateSyncPeerScopeCache();
 		const projectFilter = $select("projectFilter");
 		if (!projectFilter) return;
 		projectFilter.textContent = "";

--- a/packages/ui/src/components/primitives/project-scope-picker.tsx
+++ b/packages/ui/src/components/primitives/project-scope-picker.tsx
@@ -1,0 +1,248 @@
+/* Project-scope picker — selected projects show as removable chips;
+ * a Radix Popover trigger opens a search-filterable project list for
+ * adding more. Typing a name that doesn't match any existing project
+ * turns the last list row into `+ Create "foo"` so free-text entry
+ * folds into the same surface. Used by any include/exclude scope list
+ * (peer sharing scope, coordinator-admin group scope defaults). */
+
+import * as Popover from "@radix-ui/react-popover";
+import type { JSX } from "preact";
+import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+
+export interface ProjectScopePickerProps {
+	values: string[];
+	onValuesChange: (next: string[]) => void;
+	availableProjects: string[];
+	placeholder?: string;
+	emptyLabel?: string;
+	disabled?: boolean;
+	"aria-labelledby"?: string;
+}
+
+function normalize(value: string): string {
+	return value.trim();
+}
+
+export function ProjectScopePicker({
+	values,
+	onValuesChange,
+	availableProjects,
+	placeholder,
+	emptyLabel,
+	disabled,
+	"aria-labelledby": ariaLabelledby,
+}: ProjectScopePickerProps) {
+	const [open, setOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const [activeIndex, setActiveIndex] = useState(0);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	// Stable, de-duplicated, sorted pool of known + already-selected projects.
+	// Already-selected values stay in the list so users can uncheck them
+	// without hunting through the chip row above.
+	const allKnown = useMemo(() => {
+		const seen = new Set<string>();
+		const out: string[] = [];
+		for (const item of [...availableProjects, ...values]) {
+			const trimmed = normalize(item);
+			if (!trimmed || seen.has(trimmed)) continue;
+			seen.add(trimmed);
+			out.push(trimmed);
+		}
+		return out.sort((a, b) => a.localeCompare(b));
+	}, [availableProjects, values]);
+
+	const trimmedQuery = normalize(query);
+	const loweredQuery = trimmedQuery.toLowerCase();
+	const filtered = useMemo(() => {
+		if (!loweredQuery) return allKnown;
+		return allKnown.filter((project) => project.toLowerCase().includes(loweredQuery));
+	}, [allKnown, loweredQuery]);
+
+	const exactMatchExists = trimmedQuery
+		? allKnown.some((project) => project.toLowerCase() === loweredQuery)
+		: false;
+	const showCreateRow = Boolean(trimmedQuery) && !exactMatchExists;
+	const rowCount = filtered.length + (showCreateRow ? 1 : 0);
+
+	useEffect(() => {
+		if (activeIndex >= rowCount) {
+			setActiveIndex(Math.max(0, rowCount - 1));
+		}
+	}, [rowCount, activeIndex]);
+
+	useEffect(() => {
+		if (!open) return;
+		// Radix focuses the content root by default; shift focus to the
+		// search input on the next tick so typing-to-filter works.
+		const raf = requestAnimationFrame(() => inputRef.current?.focus());
+		return () => cancelAnimationFrame(raf);
+	}, [open]);
+
+	const toggleProject = (project: string) => {
+		const exists = values.includes(project);
+		if (exists) {
+			onValuesChange(values.filter((value) => value !== project));
+		} else {
+			onValuesChange(Array.from(new Set([...values, project])));
+		}
+	};
+
+	const createProject = (project: string) => {
+		const trimmed = normalize(project);
+		if (!trimmed) return;
+		onValuesChange(Array.from(new Set([...values, trimmed])));
+		setQuery("");
+		setActiveIndex(0);
+	};
+
+	const activateRow = (index: number) => {
+		if (index < filtered.length) {
+			const project = filtered[index];
+			if (project) toggleProject(project);
+			return;
+		}
+		if (showCreateRow) createProject(trimmedQuery);
+	};
+
+	const handleSearchKeyDown: JSX.KeyboardEventHandler<HTMLInputElement> = (event) => {
+		if (event.key === "ArrowDown") {
+			event.preventDefault();
+			setActiveIndex((prev) => Math.min(rowCount - 1, prev + 1));
+			return;
+		}
+		if (event.key === "ArrowUp") {
+			event.preventDefault();
+			setActiveIndex((prev) => Math.max(0, prev - 1));
+			return;
+		}
+		if (event.key === "Enter") {
+			event.preventDefault();
+			activateRow(activeIndex);
+			return;
+		}
+	};
+
+	const removeValue = (value: string) => {
+		onValuesChange(values.filter((existing) => existing !== value));
+	};
+
+	return (
+		<div class="project-scope-picker">
+			<ul aria-labelledby={ariaLabelledby} class="project-scope-picker-selected">
+				{values.length === 0 ? (
+					<li class="project-scope-picker-selected-empty">
+						{emptyLabel || "No projects selected."}
+					</li>
+				) : (
+					values.map((value) => (
+						<li class="project-scope-picker-selected-chip" key={value}>
+							<span>{value}</span>
+							{!disabled ? (
+								<button
+									aria-label={`Remove ${value}`}
+									class="project-scope-picker-selected-remove"
+									onClick={() => removeValue(value)}
+									type="button"
+								>
+									×
+								</button>
+							) : null}
+						</li>
+					))
+				)}
+			</ul>
+			<Popover.Root
+				onOpenChange={(next) => {
+					setOpen(next);
+					if (!next) {
+						setQuery("");
+						setActiveIndex(0);
+					}
+				}}
+				open={open}
+			>
+				<Popover.Trigger asChild>
+					<button
+						class="project-scope-picker-trigger settings-button"
+						disabled={disabled}
+						type="button"
+					>
+						<span aria-hidden="true">+</span>
+						<span>{placeholder || "Add project"}</span>
+					</button>
+				</Popover.Trigger>
+				<Popover.Portal>
+					<Popover.Content align="start" class="project-scope-picker-popover" sideOffset={6}>
+						<input
+							aria-label="Search projects"
+							class="project-scope-picker-search"
+							onInput={(event) => {
+								setQuery(event.currentTarget.value);
+								setActiveIndex(0);
+							}}
+							onKeyDown={handleSearchKeyDown}
+							placeholder="Search or create…"
+							ref={inputRef}
+							type="text"
+							value={query}
+						/>
+						<div class="project-scope-picker-results" role="listbox">
+							{filtered.length === 0 && !showCreateRow ? (
+								<div class="project-scope-picker-empty-row">
+									No projects yet. Type a name to create one.
+								</div>
+							) : null}
+							{filtered.map((project, index) => {
+								const selected = values.includes(project);
+								const active = index === activeIndex;
+								return (
+									<button
+										aria-selected={selected}
+										class={
+											active
+												? "project-scope-picker-row project-scope-picker-row--active"
+												: "project-scope-picker-row"
+										}
+										key={project}
+										onClick={() => {
+											setActiveIndex(index);
+											toggleProject(project);
+										}}
+										onMouseEnter={() => setActiveIndex(index)}
+										role="option"
+										type="button"
+									>
+										<span class="project-scope-picker-row-check" aria-hidden="true">
+											{selected ? "✓" : ""}
+										</span>
+										<span class="project-scope-picker-row-label">{project}</span>
+									</button>
+								);
+							})}
+							{showCreateRow ? (
+								<button
+									aria-selected={false}
+									class={
+										activeIndex === filtered.length
+											? "project-scope-picker-row project-scope-picker-row--create project-scope-picker-row--active"
+											: "project-scope-picker-row project-scope-picker-row--create"
+									}
+									onClick={() => createProject(trimmedQuery)}
+									onMouseEnter={() => setActiveIndex(filtered.length)}
+									role="option"
+									type="button"
+								>
+									<span class="project-scope-picker-row-check" aria-hidden="true">
+										+
+									</span>
+									<span class="project-scope-picker-row-label">{`Create "${trimmedQuery}"`}</span>
+								</button>
+							) : null}
+						</div>
+					</Popover.Content>
+				</Popover.Portal>
+			</Popover.Root>
+		</div>
+	);
+}

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -234,6 +234,12 @@ export const state = {
 	lastSyncCoordinator: null as CachedSyncCoordinator | null,
 	lastCoordinatorAdminStatus: null as CachedCoordinatorAdminStatus | null,
 	coordinatorAdminTargetGroup: "",
+	/**
+	 * Project names cached from the most recent /api/projects fetch.
+	 * Populated on app boot; reused by the Sync peer-scope picker to render
+	 * clickable project chips without re-fetching per render.
+	 */
+	knownProjects: [] as string[],
 	lastCoordinatorAdminGroups: [] as CachedCoordinatorAdminGroup[],
 	lastCoordinatorAdminJoinRequests: [] as CachedSyncJoinRequest[],
 	lastCoordinatorAdminDevices: [] as CachedCoordinatorAdminDevice[],

--- a/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
+++ b/packages/ui/src/tabs/coordinator-admin/components/groups-panel.ts
@@ -7,7 +7,7 @@
 
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { Fragment, h } from "preact";
-import { ChipInput } from "../../../components/primitives/chip-input";
+import { ProjectScopePicker } from "../../../components/primitives/project-scope-picker";
 import { RadixSwitch } from "../../../components/primitives/radix-switch";
 import { RadixTabsContent } from "../../../components/primitives/radix-tabs";
 import { TextInput } from "../../../components/primitives/text-input";
@@ -177,10 +177,11 @@ function renderGroupPreferencesEditor(
 			"div",
 			{ class: "coordinator-admin-field" },
 			h("span", { id: includeLabelId }, "Include projects"),
-			h(ChipInput, {
+			h(ProjectScopePicker, {
 				"aria-labelledby": includeLabelId,
+				availableProjects: coordinatorAdminState.availableProjects,
 				disabled: fieldsDisabled,
-				emptyLabel: "All projects allowed",
+				emptyLabel: "All projects allowed.",
 				onValuesChange: (next: string[]) => {
 					const current = coordinatorAdminState.groupPreferencesDrafts.get(groupId) ?? draft;
 					coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
@@ -189,23 +190,24 @@ function renderGroupPreferencesEditor(
 					});
 					renderShell();
 				},
-				placeholder: "Type a project name and press Enter",
+				placeholder: "Add project",
 				values: draft.projects_include,
 			}),
 			h(
 				"span",
 				{ class: "peer-submeta" },
-				"Exact project names. Leave empty to allow every project.",
+				"Leave empty to allow every project. Type to search or create a new name.",
 			),
 		),
 		h(
 			"div",
 			{ class: "coordinator-admin-field" },
 			h("span", { id: excludeLabelId }, "Exclude projects"),
-			h(ChipInput, {
+			h(ProjectScopePicker, {
 				"aria-labelledby": excludeLabelId,
+				availableProjects: coordinatorAdminState.availableProjects,
 				disabled: fieldsDisabled,
-				emptyLabel: "Nothing excluded",
+				emptyLabel: "Nothing excluded.",
 				onValuesChange: (next: string[]) => {
 					const current = coordinatorAdminState.groupPreferencesDrafts.get(groupId) ?? draft;
 					coordinatorAdminState.groupPreferencesDrafts.set(groupId, {
@@ -214,7 +216,7 @@ function renderGroupPreferencesEditor(
 					});
 					renderShell();
 				},
-				placeholder: "Type a project name and press Enter",
+				placeholder: "Add project",
 				values: draft.projects_exclude,
 			}),
 		),

--- a/packages/ui/src/tabs/coordinator-admin/data/state.ts
+++ b/packages/ui/src/tabs/coordinator-admin/data/state.ts
@@ -38,6 +38,12 @@ export interface CoordinatorAdminState {
 	deviceRenameDrafts: Map<string, string>;
 	groupPreferencesOpen: Set<string>;
 	groupPreferencesDrafts: Map<string, GroupPreferencesDraft>;
+	/**
+	 * Cached list of project names from /api/projects so the scope-defaults
+	 * ProjectScopePicker can render them as clickable chips without
+	 * re-fetching per keystroke.
+	 */
+	availableProjects: string[];
 }
 
 export const ADMIN_TARGET_GROUP_KEY = "codemem-coordinator-admin-target-group";
@@ -61,4 +67,5 @@ export const coordinatorAdminState: CoordinatorAdminState = {
 	deviceRenameDrafts: new Map<string, string>(),
 	groupPreferencesOpen: new Set<string>(),
 	groupPreferencesDrafts: new Map<string, GroupPreferencesDraft>(),
+	availableProjects: [],
 };

--- a/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
+++ b/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
@@ -245,6 +245,12 @@ export async function loadCoordinatorAdminData() {
 			state.lastCoordinatorAdminDevices = [];
 			coordinatorAdminState.deviceRenameDrafts.clear();
 		}
+		try {
+			coordinatorAdminState.availableProjects = await api.loadProjects();
+		} catch {
+			// Non-fatal — picker falls back to free-text entry.
+			coordinatorAdminState.availableProjects = [];
+		}
 	} else {
 		state.lastCoordinatorAdminGroups = [];
 		coordinatorAdminState.groupRenameDrafts.clear();

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -236,12 +236,12 @@ function SyncPeerCard({
 	]);
 
 	const includeEditor = useMemo(
-		() => createChipEditor(includeList, "Add included project", "All projects"),
-		[peerId, includeList.join("|")],
+		() => createChipEditor(includeList, "Add project", "All projects", state.knownProjects),
+		[peerId, includeList.join("|"), state.knownProjects.join("|")],
 	);
 	const excludeEditor = useMemo(
-		() => createChipEditor(excludeList, "Add excluded project", "No exclusions"),
-		[peerId, excludeList.join("|")],
+		() => createChipEditor(excludeList, "Add project", "No exclusions", state.knownProjects),
+		[peerId, excludeList.join("|"), state.knownProjects.join("|")],
 	);
 
 	useEffect(() => {

--- a/packages/ui/src/tabs/sync/helpers.ts
+++ b/packages/ui/src/tabs/sync/helpers.ts
@@ -233,57 +233,244 @@ export function actorMergeNote(targetActorId: string, secondaryActorId: string):
 
 /* ── Chip editor component ───────────────────────────────── */
 
-export function createChipEditor(initialValues: string[], placeholder: string, emptyLabel: string) {
+export function createChipEditor(
+	initialValues: string[],
+	placeholder: string,
+	emptyLabel: string,
+	availableProjects: string[] = [],
+) {
 	let values = [...initialValues];
-	const container = el("div", "peer-scope-editor");
-	const chips = el("div", "peer-scope-chips");
-	const input = el("input", "peer-scope-input") as HTMLInputElement;
-	input.placeholder = placeholder;
+	let query = "";
+	let activeIndex = 0;
+	let popoverOpen = false;
 
-	const syncChips = () => {
-		chips.textContent = "";
-		if (!values.length) {
-			chips.appendChild(el("span", "peer-scope-chip empty", emptyLabel));
+	const container = el("div", "project-scope-picker");
+	const selectedList = el("ul", "project-scope-picker-selected");
+	const trigger = el("button", "project-scope-picker-trigger settings-button") as HTMLButtonElement;
+	trigger.type = "button";
+	const triggerLabel = el("span", null, placeholder || "Add project");
+	const triggerPlus = el("span", null, "+");
+	triggerPlus.setAttribute("aria-hidden", "true");
+	trigger.append(triggerPlus, triggerLabel);
+	trigger.setAttribute("aria-haspopup", "listbox");
+	trigger.setAttribute("aria-expanded", "false");
+
+	const popover = el("div", "project-scope-picker-popover project-scope-picker-popover--inline");
+	popover.hidden = true;
+	const search = el("input", "project-scope-picker-search") as HTMLInputElement;
+	search.type = "text";
+	search.placeholder = "Search or create…";
+	search.setAttribute("aria-label", "Search projects");
+	const results = el("div", "project-scope-picker-results");
+	results.setAttribute("role", "listbox");
+	popover.append(search, results);
+
+	const knownPool = () => {
+		const seen = new Set<string>();
+		const out: string[] = [];
+		for (const item of [...availableProjects, ...values]) {
+			const trimmed = item.trim();
+			if (!trimmed || seen.has(trimmed)) continue;
+			seen.add(trimmed);
+			out.push(trimmed);
+		}
+		return out.sort((a, b) => a.localeCompare(b));
+	};
+
+	const filteredRows = () => {
+		const all = knownPool();
+		const q = query.trim().toLowerCase();
+		if (!q) return all;
+		return all.filter((project) => project.toLowerCase().includes(q));
+	};
+
+	const shouldShowCreateRow = () => {
+		const q = query.trim();
+		if (!q) return false;
+		return !knownPool().some((project) => project.toLowerCase() === q.toLowerCase());
+	};
+
+	const toggleValue = (project: string) => {
+		if (values.includes(project)) {
+			values = values.filter((value) => value !== project);
+		} else {
+			values = Array.from(new Set([...values, project]));
+		}
+		renderSelected();
+		renderResults();
+	};
+
+	const createFromQuery = () => {
+		const trimmed = query.trim();
+		if (!trimmed) return;
+		values = Array.from(new Set([...values, trimmed]));
+		query = "";
+		search.value = "";
+		activeIndex = 0;
+		renderSelected();
+		renderResults();
+	};
+
+	const activateRow = (index: number) => {
+		const rows = filteredRows();
+		if (index < rows.length) {
+			const project = rows[index];
+			if (project) toggleValue(project);
 			return;
 		}
-		values.forEach((value, index) => {
-			const chip = el("span", "peer-scope-chip");
+		if (shouldShowCreateRow()) createFromQuery();
+	};
+
+	const renderSelected = () => {
+		selectedList.textContent = "";
+		if (!values.length) {
+			const note = el("li", "project-scope-picker-selected-empty", emptyLabel);
+			selectedList.appendChild(note);
+			return;
+		}
+		values.forEach((value) => {
+			const chip = el("li", "project-scope-picker-selected-chip");
 			const label = el("span", null, value);
-			const remove = el("button", "peer-scope-chip-remove", "x") as HTMLButtonElement;
+			const remove = el("button", "project-scope-picker-selected-remove", "×") as HTMLButtonElement;
 			remove.type = "button";
 			remove.setAttribute("aria-label", `Remove ${value}`);
 			remove.addEventListener("click", () => {
-				values = values.filter((_, currentIndex) => currentIndex !== index);
-				syncChips();
+				values = values.filter((existing) => existing !== value);
+				renderSelected();
+				renderResults();
 			});
 			chip.append(label, remove);
-			chips.appendChild(chip);
+			selectedList.appendChild(chip);
 		});
 	};
 
-	const commitInput = () => {
-		const incoming = parseScopeList(input.value);
-		if (incoming.length) {
-			values = Array.from(new Set([...values, ...incoming]));
-			input.value = "";
-			syncChips();
+	const renderResults = () => {
+		results.textContent = "";
+		const rows = filteredRows();
+		const withCreate = shouldShowCreateRow();
+		const rowCount = rows.length + (withCreate ? 1 : 0);
+		if (activeIndex >= rowCount) activeIndex = Math.max(0, rowCount - 1);
+		if (!rows.length && !withCreate) {
+			const empty = el(
+				"div",
+				"project-scope-picker-empty-row",
+				"No projects yet. Type a name to create one.",
+			);
+			results.appendChild(empty);
+			return;
+		}
+		rows.forEach((project, index) => {
+			const selected = values.includes(project);
+			const active = index === activeIndex;
+			const row = el(
+				"button",
+				active
+					? "project-scope-picker-row project-scope-picker-row--active"
+					: "project-scope-picker-row",
+			) as HTMLButtonElement;
+			row.type = "button";
+			row.setAttribute("role", "option");
+			row.setAttribute("aria-selected", selected ? "true" : "false");
+			const check = el("span", "project-scope-picker-row-check", selected ? "✓" : "");
+			check.setAttribute("aria-hidden", "true");
+			const labelEl = el("span", "project-scope-picker-row-label", project);
+			row.append(check, labelEl);
+			row.addEventListener("click", () => {
+				activeIndex = index;
+				toggleValue(project);
+			});
+			row.addEventListener("mouseenter", () => {
+				activeIndex = index;
+				renderResults();
+			});
+			results.appendChild(row);
+		});
+		if (withCreate) {
+			const index = rows.length;
+			const active = index === activeIndex;
+			const row = el(
+				"button",
+				active
+					? "project-scope-picker-row project-scope-picker-row--create project-scope-picker-row--active"
+					: "project-scope-picker-row project-scope-picker-row--create",
+			) as HTMLButtonElement;
+			row.type = "button";
+			row.setAttribute("role", "option");
+			const check = el("span", "project-scope-picker-row-check", "+");
+			check.setAttribute("aria-hidden", "true");
+			const labelEl = el("span", "project-scope-picker-row-label", `Create "${query.trim()}"`);
+			row.append(check, labelEl);
+			row.addEventListener("click", () => createFromQuery());
+			row.addEventListener("mouseenter", () => {
+				activeIndex = index;
+				renderResults();
+			});
+			results.appendChild(row);
 		}
 	};
 
-	input.addEventListener("keydown", (event) => {
-		if (event.key === "Enter" || event.key === ",") {
-			event.preventDefault();
-			commitInput();
+	const setOpen = (next: boolean) => {
+		popoverOpen = next;
+		popover.hidden = !next;
+		trigger.setAttribute("aria-expanded", next ? "true" : "false");
+		if (next) {
+			query = "";
+			search.value = "";
+			activeIndex = 0;
+			renderResults();
+			// Defer focus so the element is laid out before we focus it.
+			requestAnimationFrame(() => search.focus());
 		}
-		if (event.key === "Backspace" && !input.value && values.length) {
-			values = values.slice(0, -1);
-			syncChips();
+	};
+
+	trigger.addEventListener("click", (event) => {
+		event.stopPropagation();
+		setOpen(!popoverOpen);
+	});
+
+	search.addEventListener("input", () => {
+		query = search.value;
+		activeIndex = 0;
+		renderResults();
+	});
+	search.addEventListener("keydown", (event) => {
+		const rowCount = filteredRows().length + (shouldShowCreateRow() ? 1 : 0);
+		if (event.key === "ArrowDown") {
+			event.preventDefault();
+			activeIndex = Math.min(rowCount - 1, activeIndex + 1);
+			renderResults();
+			return;
+		}
+		if (event.key === "ArrowUp") {
+			event.preventDefault();
+			activeIndex = Math.max(0, activeIndex - 1);
+			renderResults();
+			return;
+		}
+		if (event.key === "Enter") {
+			event.preventDefault();
+			activateRow(activeIndex);
+			return;
+		}
+		if (event.key === "Escape") {
+			event.preventDefault();
+			setOpen(false);
 		}
 	});
-	input.addEventListener("blur", commitInput);
 
-	syncChips();
-	container.append(chips, input);
+	const onDocumentClick = (event: MouseEvent) => {
+		if (!popoverOpen) return;
+		const target = event.target as Node | null;
+		if (!target) return;
+		if (container.contains(target)) return;
+		setOpen(false);
+	};
+	document.addEventListener("click", onDocumentClick);
+
+	container.append(selectedList, trigger, popover);
+	renderSelected();
+	renderResults();
+
 	return {
 		element: container,
 		values: () => [...values],

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -232,6 +232,20 @@ export async function loadSyncData() {
 	}
 }
 
+/**
+ * Called after `/api/projects` resolves (see app.ts loadProjects) so the
+ * Sync peer-scope picker rerenders with the freshly-cached project names.
+ * Without this, loadSyncData's dedup hash would skip the next render when
+ * the underlying sync payload hasn't changed, leaving the scope picker's
+ * clickable project list stuck on whatever was cached at first paint.
+ */
+export function invalidateSyncPeerScopeCache() {
+	lastSyncHash = "";
+	// Re-render immediately if we already have sync data; otherwise the
+	// next loadSyncData tick will hydrate the picker naturally.
+	if (state.lastSyncPeers?.length) renderSyncPeers();
+}
+
 export function resetSyncLoadStateForTests() {
 	lastSyncHash = "";
 	cachedSyncStatus = null;

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1942,6 +1942,157 @@
       .peer-scope-chips { display: flex; flex-wrap: wrap; gap: 6px; min-height: 32px; align-items: flex-start; padding: 8px 10px; margin: 0; list-style: none; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); }
       .peer-scope-chip { padding: 4px 8px; background: rgba(43, 122, 176, 0.12); color: var(--accent); font-size: 12px; }
       .peer-scope-chip.empty { background: transparent; color: var(--text-tertiary); border-style: dashed; border-color: var(--border); }
+
+      /* ProjectScopePicker — selected chips on top, an "Add project"
+         button below that opens a Radix Popover with a searchable list.
+         Typing an unmatched name turns the last row into
+         `+ Create "foo"` so free-text entry folds into the same
+         surface. Used by coordinator-admin scope defaults and Sync
+         peer-scope drawers. */
+      .project-scope-picker {
+        display: grid;
+        gap: var(--sp-2);
+        position: relative;
+      }
+      .project-scope-picker-selected {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        padding: 8px 10px;
+        margin: 0;
+        min-height: 36px;
+        list-style: none;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface-2);
+        align-items: center;
+      }
+      .project-scope-picker-selected-empty {
+        font-size: 12px;
+        color: var(--text-tertiary);
+      }
+      .project-scope-picker-selected-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 4px 4px 10px;
+        background: rgba(43, 122, 176, 0.16);
+        border: 1px solid color-mix(in srgb, var(--accent) 48%, var(--border));
+        border-radius: var(--radius-pill);
+        color: var(--accent);
+        font-size: 12px;
+      }
+      .project-scope-picker-selected-remove {
+        appearance: none;
+        border: none;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        padding: 0 4px;
+        font: inherit;
+        font-size: 14px;
+        line-height: 1;
+        opacity: 0.7;
+      }
+      .project-scope-picker-selected-remove:hover { opacity: 1; }
+      .project-scope-picker-trigger {
+        justify-self: start;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        font-size: 12px;
+      }
+      .project-scope-picker-popover {
+        width: min(360px, 100%);
+        max-height: 280px;
+        display: grid;
+        grid-template-rows: auto 1fr;
+        gap: 4px;
+        padding: 6px;
+        background: var(--surface-1);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        box-shadow: var(--shadow-lg, 0 10px 15px -3px rgba(0, 0, 0, 0.3));
+        z-index: 50;
+      }
+      /* Vanilla-DOM popover (peer-scope) anchors inline under its trigger;
+         the Preact ToggleGroup version portals via Radix. Both share the
+         rest of the styling. */
+      .project-scope-picker-popover--inline {
+        position: absolute;
+        left: 0;
+        right: auto;
+        top: 100%;
+        margin-top: 6px;
+      }
+      .project-scope-picker-search {
+        appearance: none;
+        width: 100%;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--surface-2);
+        color: var(--text-primary);
+        padding: 6px 10px;
+        font: inherit;
+        font-size: 13px;
+      }
+      .project-scope-picker-search:focus {
+        outline: 2px solid var(--accent);
+        outline-offset: 1px;
+      }
+      .project-scope-picker-results {
+        margin: 0;
+        padding: 4px 0;
+        list-style: none;
+        max-height: 220px;
+        overflow-y: auto;
+        display: grid;
+        gap: 2px;
+      }
+      .project-scope-picker-empty-row {
+        padding: 8px 10px;
+        font-size: 12px;
+        color: var(--text-tertiary);
+      }
+      .project-scope-picker-row {
+        appearance: none;
+        border: none;
+        background: transparent;
+        width: 100%;
+        text-align: left;
+        font: inherit;
+        display: grid;
+        grid-template-columns: 16px 1fr;
+        gap: 6px;
+        align-items: center;
+        padding: 6px 10px;
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        color: var(--text-secondary);
+        font-size: 13px;
+      }
+      .project-scope-picker-row:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: -2px;
+      }
+      .project-scope-picker-row--active {
+        background: color-mix(in srgb, var(--accent) 10%, transparent);
+        color: var(--text-primary);
+      }
+      .project-scope-picker-row[aria-selected="true"] {
+        color: var(--accent);
+      }
+      .project-scope-picker-row-check {
+        display: inline-block;
+        width: 16px;
+        text-align: center;
+        font-size: 12px;
+        color: var(--accent);
+      }
+      .project-scope-picker-row--create .project-scope-picker-row-check {
+        color: var(--text-tertiary);
+      }
       /* PresencePip — atomic health indicator.
          See docs/plans/2026-04-23-sync-tab-redesign.md (loading-states). */
       .presence-pip {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       '@radix-ui/react-toast':
         specifier: ^1.2.15
         version: 1.2.15(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.11
+        version: 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1836,6 +1839,32 @@ packages:
 
   '@radix-ui/react-toast@1.2.15':
     resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5069,6 +5098,26 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(react@19.2.4)
       '@radix-ui/react-visually-hidden': 1.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@radix-ui/react-toggle-group@1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@radix-ui/react-toggle@1.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 


### PR DESCRIPTION
## Description

Previous revision of this PR rendered every known project as a clickable ToggleGroup chip, which got visually loud at 20+ projects (double that for include + exclude).

Redesigned as: selected chips at top (each with an `×` to remove) + a single `[+ Add project]` button that opens a Radix Popover with a searchable list. Typing an unmatched name turns the last row into `+ Create "foo"` so free-text entry folds into the same surface. Scales cleanly past 50 projects; at-rest state only shows what's selected, not the whole pool.

- `packages/ui/src/components/primitives/project-scope-picker.tsx` — Preact component built on `@radix-ui/react-popover`. Full keyboard support (ArrowUp/Down/Enter/Escape) via the search input.
- `packages/ui/src/tabs/sync/helpers.ts` — vanilla-DOM equivalent for the peer-scope drawer uses the same selected-chips + popover pattern; buttons not lis for the result rows.
- Both Coordinator Admin group defaults and Sync peer-scope drawer wire in via `state.knownProjects` (populated by the existing `loadProjects()` on app boot) and `coordinatorAdminState.availableProjects` (populated by the existing admin-status fetch).
- Shared CSS covers the selected chips row, the popover chrome, the search input, and list rows (with selected/active/create states).

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

UI primitive swap only; no unit test added. Full suite 1483/1483.

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced