### PR TITLE
chore(release): prepare 0.29.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.28.1"
+    "version": "0.29.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.28.1",
+      "version": "0.29.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.28.1";
+const PINNED_BACKEND_VERSION = "0.29.0";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.28.1",
+	"version": "0.29.0",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.28.1",
+	"version": "0.29.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.28.1");
+		expect(VERSION).toBe("0.29.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.28.1";
+export const VERSION = "0.29.0";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.28.1",
+	"version": "0.29.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.28.1";
+const PINNED_BACKEND_VERSION = "0.29.0";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.28.1",
+	"version": "0.29.0",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.28.1",
+	"version": "0.29.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description

Release prep for 0.29.0. Bumps the 11 coordinated version markers via `node scripts/release-version.mjs set 0.29.0`.

Headline changes since v0.28.1:

- **Multi-team coordinator groups** — one device can join additional teams on the same coordinator, coordinator admin gains group-level scope defaults, and the Sync tab surfaces peers discovered through each coordinator group.
- **Sync tab redesign** — Advanced diagnostics carved into a `#sync/diagnostics` sub-route, compact device rows with click-to-expand detail drawers, padded-card primitives across Sync / Coordinator Admin.
- **Vector-migration reliability** — fast-exit when the corpus already covers the target model (no more 9-hour 29k re-embed loops), idle-cadence backoff with wake-on-queued-work, cooperative `AbortSignal` shutdown.
- **Sync pairing flow** — server stops redacting the pairing payload so the copy-me command works under default redaction, one paste textarea accepts both team invites and pairing payloads, team devices become explicit pair candidates, and sharing-scope include/exclude uses a popover-combobox project picker.

Also quietly fixes the Sync status endpoint vec0 main-thread stall that could wedge the viewer under 0.28.1.

## Type of Change

- [x] 🔧 Maintenance (refactor, chore, CI, etc.)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Version-only bump; `node scripts/release-version.mjs check` passes with all 11 markers aligned at 0.29.0. Full suite 1483/1483.

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced

## Release procedure reminder

Merge this PR last (after #977 and #978), then tag \`v0.29.0\` from **main** per \`AGENTS.md\` — never from the release branch tip.