### PR TITLE
fix: improve experimental Windows support

### DIFF
--- a/packages/cli/src/commands/claude-hook-plugin-log.test.ts
+++ b/packages/cli/src/commands/claude-hook-plugin-log.test.ts
@@ -4,6 +4,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { logHookFailure, pluginLogPath } from "./claude-hook-plugin-log.js";
 
+function slashPath(value: string): string {
+	return value.replace(/\\/g, "/");
+}
+
 describe("claude-hook-plugin-log", () => {
 	let baseDir: string;
 	const savedEnv: Record<string, string | undefined> = {};
@@ -26,7 +30,7 @@ describe("claude-hook-plugin-log", () => {
 
 	describe("pluginLogPath", () => {
 		it("returns the expanded default when no env override is set", () => {
-			expect(pluginLogPath().endsWith("/.codemem/plugin.log")).toBe(true);
+			expect(slashPath(pluginLogPath()).endsWith("/.codemem/plugin.log")).toBe(true);
 		});
 
 		it("uses CODEMEM_PLUGIN_LOG_PATH when it points at a real path", () => {
@@ -38,7 +42,7 @@ describe("claude-hook-plugin-log", () => {
 		it("treats boolean-shaped CODEMEM_PLUGIN_LOG values as toggles, not paths", () => {
 			for (const value of ["1", "0", "true", "false", "yes", "no", "on", "off", ""]) {
 				process.env.CODEMEM_PLUGIN_LOG = value;
-				expect(pluginLogPath().endsWith("/.codemem/plugin.log")).toBe(true);
+				expect(slashPath(pluginLogPath()).endsWith("/.codemem/plugin.log")).toBe(true);
 			}
 		});
 

--- a/packages/cli/src/commands/claude-hook-plugin-log.ts
+++ b/packages/cli/src/commands/claude-hook-plugin-log.ts
@@ -18,8 +18,9 @@ import { dirname, join } from "node:path";
 const BOOLEAN_TOGGLE_VALUES = new Set(["", "0", "false", "off", "1", "true", "yes", "on", "no"]);
 
 function expandHome(value: string): string {
-	if (value === "~") return homedir();
-	if (value.startsWith("~/")) return join(homedir(), value.slice(2));
+	const home = process.env.HOME?.trim() || homedir();
+	if (value === "~") return home;
+	if (value.startsWith("~/")) return join(home, value.slice(2));
 	return value;
 }
 

--- a/packages/core/src/extraction-eval.test.ts
+++ b/packages/core/src/extraction-eval.test.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import {
@@ -8,7 +10,10 @@ import {
 import { initTestSchema } from "./test-utils.js";
 
 function createDbPath(name: string): string {
-	return `/tmp/codemem-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`;
+	return join(
+		tmpdir(),
+		`codemem-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+	);
 }
 
 describe("session extraction eval", () => {

--- a/packages/core/src/extraction-replay.test.ts
+++ b/packages/core/src/extraction-replay.test.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import { buildRawEventEnvelopeFromHook } from "./claude-hooks.js";
@@ -6,7 +8,10 @@ import type { ObserverClient } from "./observer-client.js";
 import { initTestSchema } from "./test-utils.js";
 
 function createDbPath(name: string): string {
-	return `/tmp/codemem-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`;
+	return join(
+		tmpdir(),
+		`codemem-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+	);
 }
 
 describe("extraction replay", () => {

--- a/packages/core/src/home.ts
+++ b/packages/core/src/home.ts
@@ -1,0 +1,5 @@
+import { homedir } from "node:os";
+
+export function codememHomeDir(): string {
+	return process.env.HOME?.trim() || homedir();
+}

--- a/packages/core/src/observer-auth.ts
+++ b/packages/core/src/observer-auth.ts
@@ -8,8 +8,9 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { arch, homedir, platform, release } from "node:os";
+import { arch, platform, release } from "node:os";
 import { join } from "node:path";
+import { codememHomeDir } from "./home.js";
 
 // Inline version to avoid circular import (index.ts re-exports from this module).
 // Keep in sync with the VERSION constant in index.ts.
@@ -49,7 +50,7 @@ function noAuth(): ObserverAuthMaterial {
 // ---------------------------------------------------------------------------
 
 function getOpenCodeAuthPath(): string {
-	return join(homedir(), ".local", "share", "opencode", "auth.json");
+	return join(codememHomeDir(), ".local", "share", "opencode", "auth.json");
 }
 
 /** Load the OpenCode OAuth token cache from `~/.local/share/opencode/auth.json`. */
@@ -208,7 +209,7 @@ export function runAuthCommand(command: string[], timeoutMs: number): string | n
 export function readAuthFile(filePath: string | null): string | null {
 	if (!filePath) return null;
 	// Expand ~ and $ENV_VAR
-	let resolved = filePath.replace(/^~/, homedir());
+	let resolved = filePath.replace(/^~/, codememHomeDir());
 	resolved = resolved.replace(
 		/\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
 		(match, braced, bare) => {

--- a/packages/core/src/observer-client.ts
+++ b/packages/core/src/observer-client.ts
@@ -11,9 +11,9 @@
 
 import { execFile } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { codememHomeDir } from "./home.js";
 
 import {
 	buildCodexHeaders,
@@ -387,11 +387,11 @@ export function loadObserverConfig(): ObserverConfig {
 	};
 
 	// Read config file
-	const configDir = join(homedir(), ".config", "codemem");
+	const configDir = join(codememHomeDir(), ".config", "codemem");
 	const envPath = process.env.CODEMEM_CONFIG;
 	let configPath: string | null = null;
 	if (envPath) {
-		configPath = envPath.replace(/^~/, homedir());
+		configPath = envPath.replace(/^~/, codememHomeDir());
 	} else {
 		const candidates = [join(configDir, "config.json"), join(configDir, "config.jsonc")];
 		configPath = candidates.find((p) => existsSync(p)) ?? null;

--- a/packages/core/src/observer-config.ts
+++ b/packages/core/src/observer-config.ts
@@ -7,8 +7,8 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
+import { codememHomeDir } from "./home.js";
 
 // ---------------------------------------------------------------------------
 // JSONC helpers
@@ -105,7 +105,7 @@ export function stripTrailingCommas(text: string): string {
 
 /** Load OpenCode config from `~/.config/opencode/opencode.json{c}`. */
 export function loadOpenCodeConfig(): Record<string, unknown> {
-	const configDir = join(homedir(), ".config", "opencode");
+	const configDir = join(codememHomeDir(), ".config", "opencode");
 	const candidates = [join(configDir, "opencode.json"), join(configDir, "opencode.jsonc")];
 
 	const configPath = candidates.find((p) => existsSync(p));
@@ -135,7 +135,7 @@ export function loadOpenCodeConfig(): Record<string, unknown> {
 
 /** Expand `~/...` paths like Python's `Path(...).expanduser()`. */
 export function expandUserPath(value: string): string {
-	return value.startsWith("~/") ? join(homedir(), value.slice(2)) : value;
+	return value.startsWith("~/") ? join(codememHomeDir(), value.slice(2)) : value;
 }
 
 function isSafeWorkspaceId(value: string): boolean {
@@ -147,14 +147,14 @@ export function getWorkspaceCodememConfigPath(workspaceId: string): string {
 	if (!trimmed || !isSafeWorkspaceId(trimmed)) {
 		throw new Error(`Invalid workspace id for config path: ${workspaceId}`);
 	}
-	return join(homedir(), ".codemem", "workspaces", trimmed, "config", "codemem.json");
+	return join(codememHomeDir(), ".codemem", "workspaces", trimmed, "config", "codemem.json");
 }
 
 export function getWorkspaceScopedCodememConfigPath(): string | null {
 	const runtimeRoot = process.env.CODEMEM_RUNTIME_ROOT?.trim();
 	if (runtimeRoot) {
 		const expandedRoot = expandUserPath(runtimeRoot);
-		if (expandedRoot.startsWith("/")) {
+		if (isAbsolute(expandedRoot)) {
 			return join(expandedRoot, "config", "codemem.json");
 		}
 		// Invalid/relative runtime root — fall through to workspace-id lookup
@@ -167,7 +167,7 @@ export function getWorkspaceScopedCodememConfigPath(): string | null {
 }
 
 function getLegacyCodememConfigPath(): string {
-	const configDir = join(homedir(), ".config", "codemem");
+	const configDir = join(codememHomeDir(), ".config", "codemem");
 	const candidates = [join(configDir, "config.json"), join(configDir, "config.jsonc")];
 	return candidates.find((p) => existsSync(p)) ?? join(configDir, "config.json");
 }
@@ -301,16 +301,16 @@ export function resolveCodememConfigPath(
 	const runtimeRoot = process.env.CODEMEM_RUNTIME_ROOT?.trim();
 	if (runtimeRoot) {
 		const expandedRoot = expandUserPath(runtimeRoot);
-		const isAbsolute = expandedRoot.startsWith("/");
+		const absolute = isAbsolute(expandedRoot);
 		const path = join(expandedRoot, "config", "codemem.json");
 		candidates.push({
 			path,
 			source: "env-runtime-root",
-			reason: isAbsolute
+			reason: absolute
 				? `CODEMEM_RUNTIME_ROOT='${runtimeRoot}'`
 				: `CODEMEM_RUNTIME_ROOT='${runtimeRoot}' is relative, not absolute`,
-			exists: isAbsolute ? existsSync(path) : false,
-			valid: isAbsolute,
+			exists: absolute ? existsSync(path) : false,
+			valid: absolute,
 		});
 	}
 
@@ -320,7 +320,7 @@ export function resolveCodememConfigPath(
 		const safe = isSafeWorkspaceId(workspaceId);
 		const path = safe
 			? getWorkspaceCodememConfigPath(workspaceId)
-			: join(homedir(), ".codemem", "workspaces", workspaceId, "config", "codemem.json");
+			: join(codememHomeDir(), ".codemem", "workspaces", workspaceId, "config", "codemem.json");
 		candidates.push({
 			path,
 			source: "env-workspace-id",
@@ -585,7 +585,7 @@ function resolveFilePlaceholder(value: string): string {
 	return value.replace(/\{file:([^}]+)\}/g, (match, rawPath: string) => {
 		const trimmed = rawPath.trim();
 		if (!trimmed) return match;
-		const resolved = expandEnvVars(trimmed).replace(/^~/, homedir());
+		const resolved = expandEnvVars(trimmed).replace(/^~/, codememHomeDir());
 		try {
 			return readFileSync(resolved, "utf-8").trim();
 		} catch {

--- a/packages/core/src/sync-identity.test.ts
+++ b/packages/core/src/sync-identity.test.ts
@@ -21,7 +21,11 @@ import { initTestSchema } from "./test-utils.js";
 
 function sshKeygenAvailable(): boolean {
 	try {
-		execFileSync("which", ["ssh-keygen"], { stdio: "pipe" });
+		if (process.platform === "win32") {
+			execFileSync("where.exe", ["ssh-keygen"], { stdio: "pipe" });
+		} else {
+			execFileSync("which", ["ssh-keygen"], { stdio: "pipe" });
+		}
 		return true;
 	} catch {
 		return false;
@@ -29,6 +33,10 @@ function sshKeygenAvailable(): boolean {
 }
 
 const HAS_SSH_KEYGEN = sshKeygenAvailable();
+
+function slashPath(value: string): string {
+	return value.replace(/\\/g, "/");
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -68,15 +76,15 @@ describe("sync-identity", () => {
 	describe("resolveKeyPaths", () => {
 		it("returns correct paths for custom dir", () => {
 			const [priv, pub] = resolveKeyPaths("/tmp/mykeys");
-			expect(priv).toBe("/tmp/mykeys/device.key");
-			expect(pub).toBe("/tmp/mykeys/device.key.pub");
+			expect(slashPath(priv)).toBe("/tmp/mykeys/device.key");
+			expect(slashPath(pub)).toBe("/tmp/mykeys/device.key.pub");
 		});
 
 		it("uses default dir when none provided", () => {
 			const [priv, pub] = resolveKeyPaths();
 			expect(priv).toContain("device.key");
 			expect(pub).toContain("device.key.pub");
-			expect(priv).toContain(".config/codemem/keys");
+			expect(slashPath(priv)).toContain(".config/codemem/keys");
 		});
 	});
 

--- a/packages/core/src/sync-identity.ts
+++ b/packages/core/src/sync-identity.ts
@@ -8,12 +8,12 @@
 import { execFileSync } from "node:child_process";
 import { createPrivateKey, createPublicKey, generateKeyPairSync, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import { connect as connectDb, resolveDbPath } from "./db.js";
+import { codememHomeDir } from "./home.js";
 import * as schema from "./schema.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 
@@ -23,10 +23,13 @@ export { fingerprintPublicKey } from "./sync-fingerprint.js";
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_KEYS_DIR = join(homedir(), ".config", "codemem", "keys");
 const PRIVATE_KEY_NAME = "device.key";
 const PUBLIC_KEY_NAME = "device.key.pub";
 const KEYCHAIN_SERVICE = "codemem-sync";
+
+function defaultKeysDir(): string {
+	return join(codememHomeDir(), ".config", "codemem", "keys");
+}
 
 // ---------------------------------------------------------------------------
 // Fingerprint
@@ -145,7 +148,7 @@ export function loadPrivateKeyKeychain(deviceId: string): Buffer | null {
 
 /** Resolve private and public key file paths. */
 export function resolveKeyPaths(keysDir?: string): [string, string] {
-	const dir = keysDir ?? DEFAULT_KEYS_DIR;
+	const dir = keysDir ?? defaultKeysDir();
 	return [join(dir, PRIVATE_KEY_NAME), join(dir, PUBLIC_KEY_NAME)];
 }
 
@@ -331,7 +334,7 @@ export function ensureDeviceIdentity(
 	db: Database,
 	options?: EnsureDeviceIdentityOptions,
 ): [string, string] {
-	const keysDir = options?.keysDir ?? DEFAULT_KEYS_DIR;
+	const keysDir = options?.keysDir ?? defaultKeysDir();
 	const [privatePath, publicPath] = resolveKeyPaths(keysDir);
 	warnKeychainLimitations();
 

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -916,6 +916,8 @@ describe("pruneReplicationOps", () => {
 	let db: InstanceType<typeof Database>;
 
 	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-25T00:00:00Z"));
 		db = new Database(":memory:");
 		initTestSchema(db);
 		setSyncResetState(db, {
@@ -928,6 +930,7 @@ describe("pruneReplicationOps", () => {
 
 	afterEach(() => {
 		db.close();
+		vi.useRealTimers();
 	});
 
 	function insertOp(opId: string, createdAt: string) {

--- a/packages/core/src/sync-retention-runner.test.ts
+++ b/packages/core/src/sync-retention-runner.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { connect } from "./db.js";
 import { runSyncRetentionPass } from "./sync-retention-runner.js";
 import { initTestSchema } from "./test-utils.js";
@@ -19,6 +19,8 @@ describe("runSyncRetentionPass", () => {
 	let db: ReturnType<typeof connect>;
 
 	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-25T00:00:00Z"));
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-sync-retention-test-"));
 		dbPath = join(tmpDir, "retention.sqlite");
 		db = connect(dbPath);
@@ -28,6 +30,7 @@ describe("runSyncRetentionPass", () => {
 	afterEach(() => {
 		db.close();
 		rmSync(tmpDir, { recursive: true, force: true });
+		vi.useRealTimers();
 	});
 
 	it("persists aggregated multi-pass pruning results", async () => {


### PR DESCRIPTION
## Summary
- Respect test-scoped `HOME` on Windows for codemem/opencode config, auth cache, plugin logs, and sync key paths.
- Make Windows test paths portable by using `tmpdir()`/`join()`, normalizing path-separator assertions, and using `where.exe` to detect `ssh-keygen`.
- Stabilize sync retention tests by pinning the date-sensitive retention clock.

## Windows Support Status
- Windows support remains experimental, but the current TypeScript CLI/plugin/MCP path is no longer blocked by the old Python `termios` issue.
- Verified on Windows with live plugin/MCP usage and local test runs; sqlite-vec native loading was separately smoke-tested.
- No extra `winget` install was needed here because `ssh-keygen.exe` was already available via Windows OpenSSH Client. If missing, install OpenSSH Client through Windows Optional Features / `Add-WindowsCapability`; Git for Windows can also provide `ssh-keygen`, but the test now detects the standard Windows OpenSSH install directly.

## Verification
- `pnpm.cmd run tsc`
- `pnpm.cmd run test` (`83 passed`, `1483 passed`, no skips)
- `pnpm.cmd exec biome check packages/core/src/home.ts packages/core/src/observer-config.ts packages/core/src/observer-auth.ts packages/core/src/observer-client.ts packages/core/src/sync-identity.ts packages/core/src/extraction-replay.test.ts packages/core/src/extraction-eval.test.ts packages/core/src/sync-replication.test.ts packages/core/src/sync-retention-runner.test.ts packages/core/src/sync-identity.test.ts packages/cli/src/commands/claude-hook-plugin-log.ts packages/cli/src/commands/claude-hook-plugin-log.test.ts`

## Notes
- Full `pnpm.cmd run lint` still reports repo-wide CRLF/LF formatting diagnostics across many untouched files on this Windows checkout. Touched files pass Biome directly.