### PR TITLE
fix(core): auto-bootstrap fresh databases on first access

### DIFF
--- a/packages/cli/src/commands/stats.test.ts
+++ b/packages/cli/src/commands/stats.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, getSchemaVersion, SCHEMA_VERSION } from "@codemem/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { statsCommand } from "./stats.js";
+
+describe("stats command", () => {
+	let tmpDir: string;
+	let prevCodememConfig: string | undefined;
+
+	beforeEach(() => {
+		prevCodememConfig = process.env.CODEMEM_CONFIG;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-stats-command-"));
+		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
+	});
+
+	afterEach(() => {
+		if (prevCodememConfig === undefined) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = prevCodememConfig;
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("auto-initializes a fresh database before reporting stats", async () => {
+		const dbPath = join(tmpDir, "fresh.sqlite");
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			await statsCommand.parseAsync(["--db-path", dbPath, "--json"], { from: "user" });
+
+			const output = logSpy.mock.calls.at(-1)?.[0];
+			expect(typeof output).toBe("string");
+			const result = JSON.parse(String(output));
+			expect(result.database.path).toBe(dbPath);
+			expect(result.database.memory_items).toBe(0);
+
+			const db = connect(dbPath);
+			try {
+				expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+			} finally {
+				db.close();
+			}
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+});

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -31,7 +31,7 @@ function hasIndex(db: Database, name: string): boolean {
 
 describe("connect", () => {
 	let tmpDir: string;
-	let db: Database;
+	let db: Database | undefined;
 
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "codemem-test-"));
@@ -112,6 +112,52 @@ describe("connect", () => {
 				| { label: string }
 				| undefined,
 		).toEqual({ label: "still here" });
+	});
+
+	it("supports multiple handles racing the first-run bootstrap result", () => {
+		const dbPath = join(tmpDir, "multi-handle.sqlite");
+		const first = connect(dbPath);
+		const second = connect(dbPath);
+		try {
+			expect(getSchemaVersion(first)).toBe(SCHEMA_VERSION);
+			expect(getSchemaVersion(second)).toBe(SCHEMA_VERSION);
+			expect(tableExists(first, "memory_items")).toBe(true);
+			expect(tableExists(second, "memory_items")).toBe(true);
+			expect(() => assertSchemaReady(first)).not.toThrow();
+			expect(() => assertSchemaReady(second)).not.toThrow();
+		} finally {
+			first.close();
+			second.close();
+		}
+	});
+
+	it("does not bootstrap or switch unrelated non-empty databases to WAL", () => {
+		const dbPath = join(tmpDir, "unrelated.sqlite");
+		const unrelated = new BetterSqlite3(dbPath);
+		unrelated.exec("CREATE TABLE unrelated_data (id INTEGER PRIMARY KEY)");
+		unrelated.close();
+
+		db = connect(dbPath);
+
+		expect(getSchemaVersion(db)).toBe(0);
+		expect(tableExists(db, "memory_items")).toBe(false);
+		expect(tableExists(db, "unrelated_data")).toBe(true);
+		expect(existsSync(`${dbPath}-wal`)).toBe(false);
+	});
+
+	it("does not switch unrelated databases with nonzero user_version to WAL", () => {
+		const dbPath = join(tmpDir, "unrelated-versioned.sqlite");
+		const unrelated = new BetterSqlite3(dbPath);
+		unrelated.exec("CREATE TABLE unrelated_data (id INTEGER PRIMARY KEY)");
+		unrelated.pragma("user_version = 1");
+		unrelated.close();
+
+		db = connect(dbPath);
+
+		expect(getSchemaVersion(db)).toBe(1);
+		expect(tableExists(db, "memory_items")).toBe(false);
+		expect(tableExists(db, "unrelated_data")).toBe(true);
+		expect(existsSync(`${dbPath}-wal`)).toBe(false);
 	});
 });
 
@@ -266,12 +312,43 @@ describe("assertSchemaReady", () => {
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
-	it("throws for uninitialized schema (version 0)", () => {
+	it("bootstraps uninitialized writable schemas before asserting readiness", () => {
 		const uninitialized = new BetterSqlite3(join(tmpDir, "uninitialized.sqlite"));
 		try {
-			expect(() => assertSchemaReady(uninitialized)).toThrow(/not initialized/);
+			expect(getSchemaVersion(uninitialized)).toBe(0);
+			expect(() => assertSchemaReady(uninitialized)).not.toThrow();
+			expect(getSchemaVersion(uninitialized)).toBe(SCHEMA_VERSION);
+			expect(tableExists(uninitialized, "memory_items")).toBe(true);
 		} finally {
 			uninitialized.close();
+		}
+	});
+
+	it("does not bootstrap unrelated non-empty SQLite databases", () => {
+		const unrelated = new BetterSqlite3(join(tmpDir, "unrelated.sqlite"));
+		try {
+			unrelated.exec("CREATE TABLE unrelated_data (id INTEGER PRIMARY KEY)");
+			expect(getSchemaVersion(unrelated)).toBe(0);
+
+			expect(() => assertSchemaReady(unrelated)).toThrow(/not initialized/);
+			expect(tableExists(unrelated, "memory_items")).toBe(false);
+			expect(tableExists(unrelated, "unrelated_data")).toBe(true);
+		} finally {
+			unrelated.close();
+		}
+	});
+
+	it("does not try to bootstrap readonly uninitialized schemas", () => {
+		const dbPath = join(tmpDir, "readonly-uninitialized.sqlite");
+		const seed = new BetterSqlite3(dbPath);
+		seed.close();
+		const readonly = new BetterSqlite3(dbPath, { readonly: true });
+		try {
+			expect(getSchemaVersion(readonly)).toBe(0);
+			expect(() => assertSchemaReady(readonly)).toThrow(/not initialized/);
+			expect(() => assertSchemaReady(readonly)).not.toThrow(/readonly/i);
+		} finally {
+			readonly.close();
 		}
 	});
 

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -26,7 +26,7 @@ import type { Database as DatabaseType } from "better-sqlite3";
 import Database from "better-sqlite3";
 import * as sqliteVec from "sqlite-vec";
 import { expandUserPath } from "./observer-config.js";
-import { ensureSchemaBootstrapped } from "./schema-bootstrap.js";
+import { canAutoBootstrapSchema, ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 
 // Re-export the Database type for consumers
 export type { DatabaseType as Database };
@@ -51,6 +51,8 @@ const REQUIRED_TABLES = [
 	"raw_event_sessions",
 	"usage_events",
 ] as const;
+
+export const REQUIRED_BOOTSTRAPPED_TABLES = [...REQUIRED_TABLES, "memory_fts"] as const;
 
 /** Marker file written after the first successful TS access to a DB. */
 const TS_MARKER = ".codemem-ts-accessed";
@@ -202,6 +204,10 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 		// Match Python's connect() pragmas exactly
 		db.pragma("foreign_keys = ON");
 		db.pragma("busy_timeout = 5000");
+		const configureWal = canAutoBootstrapSchema(db) || hasBootstrappedCodememSchema(db);
+
+		ensureSchemaBootstrapped(db);
+		if (!configureWal) return db;
 
 		const journalMode = db.pragma("journal_mode = WAL", { simple: true }) as string;
 		if (journalMode.toLowerCase() !== "wal") {
@@ -211,13 +217,16 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 		}
 
 		db.pragma("synchronous = NORMAL");
-		ensureSchemaBootstrapped(db);
 
 		return db;
 	} catch (error) {
 		db.close();
 		throw error;
 	}
+}
+
+function hasBootstrappedCodememSchema(db: DatabaseType): boolean {
+	return REQUIRED_BOOTSTRAPPED_TABLES.every((table) => tableExists(db, table));
 }
 
 function hasPlannerStats(db: DatabaseType): boolean {
@@ -402,10 +411,16 @@ export function backupOnFirstAccess(dbPath: string): void {
 /**
  * Verify the database schema is initialized and compatible.
  *
+ * Empty writable first-run handles are bootstrapped here as a final safety net,
+ * even though `connect()` already does the same. A few lower-level maintenance
+ * and integration paths call this assertion after receiving an existing database
+ * handle, so keeping the bootstrap invariant here prevents one entry point from
+ * requiring a manual `codemem db init` while another works automatically.
+ *
  * Per the coexistence contract: TS tolerates additive newer schemas (Python may
  * have run migrations that add tables/columns the TS runtime doesn't know about).
  * TS only hard-fails if:
- *   - Schema is uninitialized (version 0)
+ *   - Schema is still uninitialized after a bootstrap attempt (version 0)
  *   - Schema is too old (below MIN_COMPATIBLE_SCHEMA)
  *   - Required tables are missing
  *   - FTS5 index is missing (needed for search)
@@ -414,6 +429,7 @@ export function backupOnFirstAccess(dbPath: string): void {
  * changes are assumed safe per the coexistence contract.
  */
 export function assertSchemaReady(db: DatabaseType): void {
+	ensureSchemaBootstrapped(db);
 	const version = getSchemaVersion(db);
 	if (version === 0) {
 		throw new Error(

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -130,6 +130,24 @@ describe("maintenance", { timeout: 15_000 }, () => {
 		}
 	});
 
+	it("does not initialize unrelated non-empty SQLite databases", () => {
+		const dbPath = createDbPath("unrelated-init");
+		const unrelated = new Database(dbPath);
+		unrelated.exec("CREATE TABLE unrelated_data (id INTEGER PRIMARY KEY)");
+		unrelated.close();
+
+		expect(() => initDatabase(dbPath)).toThrow(/Refusing to initialize .*non-codemem schema/);
+
+		const db = new Database(dbPath, { readonly: true });
+		try {
+			expect(() => db.prepare("SELECT 1 FROM memory_items LIMIT 1").get()).toThrow();
+			expect(() => db.prepare("SELECT 1 FROM unrelated_data LIMIT 1").get()).not.toThrow();
+			expect(db.pragma("user_version", { simple: true })).toBe(0);
+		} finally {
+			db.close();
+		}
+	});
+
 	it("reports max retry depth from raw_event_flush_batches.attempt_count", () => {
 		const dbPath = createDbPath("retry-depth");
 		seedMaintenanceDb(dbPath);

--- a/packages/core/src/maintenance/init-vacuum.ts
+++ b/packages/core/src/maintenance/init-vacuum.ts
@@ -4,7 +4,6 @@
 import { statSync } from "node:fs";
 import { assertSchemaReady, connect, getSchemaVersion, resolveDbPath } from "../db.js";
 import { ensureMaintenanceJobsSchema } from "../maintenance-jobs.js";
-import { bootstrapSchema } from "../schema-bootstrap.js";
 import { applyRawEventRelinkPlanWithDb } from "./relink.js";
 import { withDb } from "./with-db.js";
 
@@ -13,7 +12,10 @@ export function initDatabase(dbPath?: string): { path: string; sizeBytes: number
 	const db = connect(resolvedPath);
 	try {
 		if (getSchemaVersion(db) === 0) {
-			bootstrapSchema(db);
+			throw new Error(
+				`Refusing to initialize ${resolvedPath}: file exists and contains a non-codemem schema. ` +
+					"Choose a new --db-path or move the existing SQLite file before retrying.",
+			);
 		}
 		assertSchemaReady(db);
 		ensureMaintenanceJobsSchema(db);

--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -1,5 +1,11 @@
 import type { Database } from "./db.js";
-import { getSchemaVersion, isEmbeddingDisabled, loadSqliteVec, SCHEMA_VERSION } from "./db.js";
+import {
+	getSchemaVersion,
+	isEmbeddingDisabled,
+	loadSqliteVec,
+	REQUIRED_BOOTSTRAPPED_TABLES,
+	SCHEMA_VERSION,
+} from "./db.js";
 import { TEST_SCHEMA_BASE_DDL } from "./test-schema.generated.js";
 
 const SCHEMA_AUX_DDL = `
@@ -145,10 +151,42 @@ function isSqliteVecLoaded(db: Database): boolean {
 }
 
 export function bootstrapSchema(db: Database): void {
-	db.exec(TEST_SCHEMA_BASE_DDL);
-	db.exec(SCHEMA_AUX_DDL);
+	db.transaction(() => {
+		db.exec(TEST_SCHEMA_BASE_DDL);
+		db.exec(SCHEMA_AUX_DDL);
+		assertBootstrapTablesCreated(db);
+		db.pragma(`user_version = ${SCHEMA_VERSION}`);
+	}).immediate();
+
+	// sqlite-vec support is optional/best-effort. Keep it outside the core
+	// bootstrap transaction so an unavailable extension cannot produce a
+	// half-successful core schema, and cannot prevent first-run stats/setup.
 	ensureVectorSchema(db);
-	db.pragma(`user_version = ${SCHEMA_VERSION}`);
+}
+
+function assertBootstrapTablesCreated(db: Database): void {
+	const missing = REQUIRED_BOOTSTRAPPED_TABLES.filter((table) => !tableExists(db, table));
+	if (missing.length > 0) {
+		throw new Error(`Schema bootstrap failed; missing required tables: ${missing.join(", ")}`);
+	}
+}
+
+function isSafeEmptyDatabase(db: Database): boolean {
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS count
+			 FROM sqlite_master
+			 WHERE name NOT LIKE 'sqlite\\_%' ESCAPE '\\'`,
+		)
+		.get() as { count?: number } | undefined;
+	return (row?.count ?? 0) === 0;
+}
+
+function tableExists(db: Database, table: string): boolean {
+	const row = db
+		.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1")
+		.get(table);
+	return row !== undefined;
 }
 
 /**
@@ -158,7 +196,15 @@ export function bootstrapSchema(db: Database): void {
  * already-initialized databases are left untouched.
  */
 export function ensureSchemaBootstrapped(db: Database): void {
-	if (getSchemaVersion(db) === 0) {
+	if (!isReadonlyDatabase(db) && canAutoBootstrapSchema(db)) {
 		bootstrapSchema(db);
 	}
+}
+
+export function canAutoBootstrapSchema(db: Database): boolean {
+	return getSchemaVersion(db) === 0 && isSafeEmptyDatabase(db);
+}
+
+function isReadonlyDatabase(db: Database): boolean {
+	return (db as { readonly?: boolean }).readonly === true;
 }


### PR DESCRIPTION
## Description

A new user running `npx -y codemem stats` against a brand-new install hit:

```
Error: Database schema is not initialized. Initialize the SQLite database with the current TypeScript runtime before retrying.
```

We had previously fixed `MemoryStore.constructor()` to auto-bootstrap, but `assertSchemaReady()` and a few maintenance entry points still threw on the `user_version === 0` branch before any bootstrap attempt. Once `MemoryStore`'s constructor was bypassed (or the order of operations differed), first-run users hit the assertion.

This PR closes the regression and hardens the bootstrap path against unrelated databases:

- `connect()` auto-bootstraps writable empty databases.
- `assertSchemaReady()` mirrors the same safety net so callers that open raw `better-sqlite3` handles also auto-init empty DBs.
- Bootstrap DDL is wrapped in an immediate transaction with a post-DDL table-existence assertion, so a partial bootstrap can never stamp `user_version` to a half-built schema.
- Optional `sqlite-vec` virtual-table setup runs **outside** the core transaction. Vec failures (Alpine, musl, ARM, missing prebuilds) must not abort the core schema or leave the DB stamped at an inconsistent version.
- Refuse to bootstrap unrelated SQLite databases. The eligibility predicate requires `user_version === 0` **and** an empty `sqlite_master`, so a foreign DB at `--db-path` is left untouched (no codemem tables, no `user_version` bump). WAL/synchronous pragma flips are also gated on bootstrap eligibility, so we never leave WAL sidecars beside foreign files.
- `assertSchemaReady()` skips bootstrap on readonly handles, preserving the clean `not initialized` error instead of `SQLITE_READONLY`.
- `codemem db init` against a foreign DB now throws a distinct `Refusing to initialize <path>: file exists and contains a non-codemem schema.` instead of the generic schema-not-initialized error that motivated this PR in the first place.
- De-duplicated the required-bootstrapped-tables list (now exported from `db.ts`).

Also includes a small unrelated fix that surfaced when running the full suite: the sync-retention / replication prune tests use fixtures dated `2026-03-26`, which became older than the 30-day age cutoff once the wall clock crossed `2026-04-26`. Those tests now run under `vi.useFakeTimers()` pinned to `2026-04-01`. Pulled into this PR because the suite has to be green to merge.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)
- [x] 🔧 Maintenance (test fixture pinning)
- [x] 🧪 Testing (regression coverage)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation:

- `pnpm run tsc` — clean
- `pnpm run lint` — clean
- `pnpm run test` — 84 files / 1490 tests passed
- Manual: `CODEMEM_DB=.tmp/first-run-stats-post-ramsay.sqlite pnpm run codemem stats --json` against a fresh path returns the expected JSON and creates a DB at `SCHEMA_VERSION`.

New regression coverage:

- `db.test.ts` — `connect()` against unrelated SQLite DBs (`user_version` 0 and nonzero) leaves them untouched and does not write WAL sidecars; multiple sequential `connect()` handles all see the bootstrapped schema; `assertSchemaReady()` on a readonly empty DB throws `not initialized`, not a readonly error; `assertSchemaReady()` on an unrelated non-empty DB still throws and creates no codemem tables.
- `maintenance.test.ts` — `initDatabase()` against an unrelated non-empty DB throws the new `Refusing to initialize` error and leaves the file untouched.
- `stats.test.ts` (new) — `codemem stats --json` against a non-existent DB path produces stats output and the file ends up at `SCHEMA_VERSION`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — no user-facing doc changes; behavior matches what `README.md` already promises (auto-bootstrap on first access)
- [x] No new warnings introduced

## Notes for Reviewers

- The `assertSchemaReady()` side effect (auto-bootstrap) is intentional but a semantic shift; if you'd prefer it renamed to `ensureSchemaReady()` with the assertion-only variant kept, happy to do that as a follow-up.
- The atomic-bootstrap guarantee means partial bootstraps cannot recur in new installs. Pre-existing partially-bootstrapped DBs in the wild (if any) would still need manual cleanup or a future `db init --force`. Not addressing that here.
