### PR TITLE
chore(release): prepare 0.29.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.29.0"
+    "version": "0.29.1"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.29.0";
+const PINNED_BACKEND_VERSION = "0.29.1";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.29.0",
+	"version": "0.29.1",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.29.0",
+	"version": "0.29.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.29.0");
+		expect(VERSION).toBe("0.29.1");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.29.0";
+export const VERSION = "0.29.1";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.29.0",
+	"version": "0.29.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.29.0";
+const PINNED_BACKEND_VERSION = "0.29.1";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.29.0",
+	"version": "0.29.1",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.29.0",
+	"version": "0.29.1",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description

Bumps the codemem release stream to **0.29.1**. The only meaningful change since 0.29.0 is the first-run bootstrap fix in #982 — `npx -y codemem stats` against a fresh install was throwing `Database schema is not initialized` because not every entry point auto-bootstrapped.

Cut as a patch release because the user-facing impact is "every brand-new install hit this on the documented first command."

### Changes since 0.29.0

- #982 — `fix(core): auto-bootstrap fresh databases on first access`
  - `connect()` and `assertSchemaReady()` both auto-bootstrap empty writable DBs.
  - Bootstrap DDL is wrapped in an immediate transaction with a post-DDL table-existence check; partial bootstraps cannot stamp `user_version`.
  - Optional `sqlite-vec` virtual-table setup runs outside the core transaction so vec failures cannot abort the core schema.
  - Refuses to bootstrap unrelated SQLite databases (`user_version` 0 or nonzero) and skips WAL/synchronous pragma flips for them.
  - Skips bootstrap on readonly handles, preserving the clean `not initialized` error.
  - `codemem db init` against a foreign DB throws a distinct `Refusing to initialize ... non-codemem schema` error.
- #981 — `chore(deps): bump @opencode-ai/plugin from 1.14.22 to 1.14.28`
- #980 — `fix: improve experimental Windows support` (already in 0.29.0 cut window — verify)

### Files bumped (`pnpm run release:version -- set 0.29.1`)

- `packages/core/package.json`
- `packages/cli/package.json`
- `packages/opencode-plugin/package.json`
- `packages/mcp-server/package.json`
- `packages/viewer-server/package.json`
- `packages/core/src/index.ts` (`VERSION`)
- `packages/core/src/index.test.ts` (version assertion)
- `packages/cli/.opencode/plugins/codemem.js` (`PINNED_BACKEND_VERSION`)
- `packages/opencode-plugin/.opencode/plugins/codemem.js` (`PINNED_BACKEND_VERSION`)
- `plugins/claude/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

## Type of Change

- [x] 🔧 Maintenance (release version bump)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (the `VERSION` assertion in `packages/core/src/index.test.ts` was bumped by `release:version`)
- [x] Manually verified changes work as expected

Validation:

- `pnpm run release:version -- check` — `OK: release versions are aligned at 0.29.1`
- `pnpm run tsc` — clean
- `pnpm run lint` — clean
- `pnpm run test` (full workspace pre-bump on the same tree) — 84 files / 1490 tests passed
- `pnpm exec vitest run packages/core/src/index.test.ts` — passes against the new `VERSION = "0.29.1"`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — none required for a patch bump
- [x] No new warnings introduced

## Release follow-up

After merge:

```sh
git fetch origin main
git checkout main
git pull --ff-only
pnpm run release:preflight-tag
git tag -a v0.29.1 -m "v0.29.1" <merged-commit>
git push origin v0.29.1
```

Tag must be on the merged main commit, not this branch tip.
