### PR TITLE
feat(workspace): add two-phase bootstrap attachment

### DIFF
--- a/docs/contracts/pre-provisioned-workspace-runtime-attachment.md
+++ b/docs/contracts/pre-provisioned-workspace-runtime-attachment.md
@@ -147,11 +147,68 @@ Minimum state model:
 - `pending`
 - `joining`
 - `joined`
+- `joined_pending_seed_trust`
 - `bootstrapping`
 - `bootstrapped`
 - `sync_verifying`
 - `ready`
 - `failed`
+
+## Two-phase worker attachment
+
+Workspace workers may need to emit their identity before the seed peer can safely trust them. The attachment contract therefore supports splitting worker setup into two orchestrator-friendly phases.
+
+### Phase 1: join-only
+
+Inputs:
+- coordinator URL and group
+- invite payload
+- seed peer identity and address
+- workspace config, DB, and keys paths
+
+Expected behavior:
+- initialize DB, config, keys, and local sync identity
+- import the coordinator invite
+- pin the seed peer locally as the bootstrap source
+- emit `identity.json`, `status.json`, and `summary.json`
+- stop before bootstrap
+
+Expected terminal state:
+- `state`: `joined_pending_seed_trust`
+- `readiness_result`: `pending_seed_trust`
+
+The orchestrator should now read the worker identity and grant trust on the seed peer.
+
+### Seed-side trust grant
+
+The seed peer must accept or pin the worker identity before serving bootstrap data. The public contract is intentionally generic: the orchestrator provides the worker device ID, fingerprint, public key, and reachable worker address to the seed peer's trust/pin operation.
+
+Expected outcome:
+- the seed peer has a trusted `sync_peers` entry for the worker
+- the worker can authenticate when requesting bootstrap or sync data
+
+### Phase 2: finish-bootstrap
+
+Inputs:
+- same workspace config, DB, and keys paths used during join-only
+- seed peer identity and address
+
+Expected behavior:
+- reuse the existing worker identity
+- pin or refresh the seed peer locally
+- bootstrap from the seed peer
+- run one sync verification pass
+- emit final `status.json` and `summary.json`
+
+Expected terminal state:
+- `state`: `ready`
+- `readiness_result`: `ready`
+
+### Full mode
+
+A full one-shot worker attachment is still valid when the seed peer already trusts the worker or the environment has an external trust automation layer. Full mode performs join, local seed pin, bootstrap, sync verification, and readiness publication in one run.
+
+Bootstrap force behavior must remain opt-in. Operators may expose an explicit override such as `CODEMEM_BOOTSTRAP_FORCE=1` for disposable workspaces, but the default path should preserve local dirty-state protection.
 
 ## Readiness contract
 
@@ -187,7 +244,7 @@ Recommended minimum artifacts:
 - sync verification result summary
 - failure detail if attachment fails
 
-Sensitive material such as private keys must never be copied into shared artifacts.
+Sensitive material such as private keys, coordinator admin secrets, invite tokens, and bootstrap tokens must never be copied into shared artifacts. Config snapshots should redact sensitive fields before publication.
 
 ## Cleanup contract
 

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,7 +1,13 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { connect, initTestSchema, MemoryStore, startMaintenanceJob } from "@codemem/core";
+import {
+	connect,
+	initTestSchema,
+	loadPublicKey,
+	MemoryStore,
+	startMaintenanceJob,
+} from "@codemem/core";
 import { describe, expect, it, vi } from "vitest";
 import { syncCommand } from "./sync.js";
 import {
@@ -210,6 +216,39 @@ describe("formatSyncAttempt", () => {
 		expect(listRequests?.registeredArguments[0]?.required).toBe(false);
 		expect(createInvite?.helpInformation()).toContain("[group]");
 		expect(listRequests?.helpInformation()).toContain("[group]");
+	});
+
+	it("initializes sync identity from CODEMEM_KEYS_DIR during sync enable", async () => {
+		const tmpDbDir = mkdtempSync(join(tmpdir(), "sync-enable-keys-dir-test-"));
+		const dbPath = join(tmpDbDir, "mem.sqlite");
+		const configPath = join(tmpDbDir, "codemem.json");
+		const keysDir = join(tmpDbDir, "keys");
+		const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			const enable = syncCommand.commands.find((command) => command.name() === "enable");
+			await enable?.parseAsync(["--db-path", dbPath, "--config", configPath, "--json"], {
+				from: "user",
+			});
+
+			const publicKey = loadPublicKey(keysDir);
+			expect(publicKey).toBeTruthy();
+			const store = new MemoryStore(dbPath);
+			try {
+				const row = store.db.prepare("SELECT public_key FROM sync_device LIMIT 1").get() as
+					| { public_key: string }
+					| undefined;
+				expect(row?.public_key).toBe(publicKey);
+			} finally {
+				store.close();
+			}
+		} finally {
+			logSpy.mockRestore();
+			if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+			else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			rmSync(tmpDbDir, { recursive: true, force: true });
+		}
 	});
 
 	it("registers peer repair subcommands", () => {

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -895,7 +895,8 @@ enableCmd.action(
 
 		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 		try {
-			const [deviceId, fingerprint] = ensureDeviceIdentity(store.db);
+			const keysDir = process.env.CODEMEM_KEYS_DIR?.trim() || undefined;
+			const [deviceId, fingerprint] = ensureDeviceIdentity(store.db, { keysDir });
 			const config = readCliConfig(opts.config);
 			config.sync_enabled = true;
 			if (effectiveHost) config.sync_host = effectiveHost;

--- a/scripts/templates/workspace-codemem-bootstrap.sh
+++ b/scripts/templates/workspace-codemem-bootstrap.sh
@@ -68,7 +68,7 @@ if [ "$CODEMEM_NODE_ROLE" = "worker-peer" ]; then
   require_var CODEMEM_SEED_PEER_PUBLIC_KEY "$CODEMEM_SEED_PEER_PUBLIC_KEY"
   require_var CODEMEM_SEED_PEER_ADDRESS "$CODEMEM_SEED_PEER_ADDRESS"
 
-  pnpm run codemem -- sync coordinator import-invite "$CODEMEM_INVITE" --db-path "$CODEMEM_DB" --keys-dir "$CODEMEM_KEYS_DIR" --config "$CODEMEM_CONFIG" --json
+  pnpm run codemem -- coordinator import-invite "$CODEMEM_INVITE" --db-path "$CODEMEM_DB" --keys-dir "$CODEMEM_KEYS_DIR" --config "$CODEMEM_CONFIG" --json
   pnpm run codemem -- sync enable --db-path "$CODEMEM_DB" --host "$CODEMEM_SYNC_HOST" --port "$CODEMEM_SYNC_PORT" --interval 5
   node --input-type=module -e "import Database from 'better-sqlite3'; const db = new Database(process.env.CODEMEM_DB); const now = new Date().toISOString(); const addrJson = JSON.stringify([process.env.CODEMEM_SEED_PEER_ADDRESS]); db.prepare(\"INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at, last_seen_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(peer_device_id) DO UPDATE SET pinned_fingerprint = excluded.pinned_fingerprint, public_key = excluded.public_key, addresses_json = excluded.addresses_json, last_seen_at = excluded.last_seen_at\").run(process.env.CODEMEM_SEED_PEER_DEVICE_ID, process.env.CODEMEM_SEED_PEER_FINGERPRINT, process.env.CODEMEM_SEED_PEER_PUBLIC_KEY, addrJson, now, now); db.close();"
   pnpm run codemem -- sync bootstrap --peer "$CODEMEM_SEED_PEER_DEVICE_ID" --db-path "$CODEMEM_DB" --keys-dir "$CODEMEM_KEYS_DIR" --json --force

--- a/scripts/workspace/pin-peer.ts
+++ b/scripts/workspace/pin-peer.ts
@@ -1,0 +1,55 @@
+import { connect } from "../../packages/core/src/db.ts";
+
+function parseArgs(argv: string[]) {
+	let dbPath = "";
+	let peerDeviceId = "";
+	let fingerprint = "";
+	let publicKey = "";
+	let address = "";
+	for (let index = 2; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--db-path") {
+			dbPath = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--peer-device-id") {
+			peerDeviceId = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--fingerprint") {
+			fingerprint = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--public-key") {
+			publicKey = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--address") {
+			address = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		}
+	}
+	if (!dbPath || !peerDeviceId || !fingerprint || !publicKey) {
+		throw new Error(
+			"--db-path, --peer-device-id, --fingerprint, and --public-key are required",
+		);
+	}
+	return { dbPath, peerDeviceId, fingerprint, publicKey, address };
+}
+
+const { dbPath, peerDeviceId, fingerprint, publicKey, address } = parseArgs(process.argv);
+const db = connect(dbPath);
+
+try {
+	const now = new Date().toISOString();
+	const addressesJson = JSON.stringify(address ? [address] : []);
+	db.prepare(
+		`INSERT INTO sync_peers(
+			peer_device_id, pinned_fingerprint, public_key, addresses_json, created_at, last_seen_at
+		 ) VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(peer_device_id) DO UPDATE SET
+			pinned_fingerprint = excluded.pinned_fingerprint,
+			public_key = excluded.public_key,
+			addresses_json = excluded.addresses_json,
+			last_seen_at = excluded.last_seen_at`,
+	).run(peerDeviceId, fingerprint, publicKey, addressesJson, now, now);
+	console.log(JSON.stringify({ ok: true, peer_device_id: peerDeviceId }, null, 2));
+} finally {
+	db.close();
+}

--- a/scripts/workspace/prove-workspace-codemem-bootstrap-local.sh
+++ b/scripts/workspace/prove-workspace-codemem-bootstrap-local.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+
+PROOF_ROOT="${CODEMEM_PROOF_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/codemem-workspace-proof.XXXXXX")}" 
+KEEP_PROOF_ROOT="${CODEMEM_KEEP_PROOF_ROOT:-0}"
+ADMIN_SECRET="${CODEMEM_PROOF_ADMIN_SECRET:-workspace-proof-secret}"
+GROUP_ID="${CODEMEM_PROOF_GROUP:-workspace-proof}"
+COORDINATOR_PORT="${CODEMEM_PROOF_COORDINATOR_PORT:-47347}"
+SEED_SYNC_PORT="${CODEMEM_PROOF_SEED_SYNC_PORT:-47337}"
+WORKER_SYNC_PORT="${CODEMEM_PROOF_WORKER_SYNC_PORT:-47338}"
+SEED_VIEWER_PORT="${CODEMEM_PROOF_SEED_VIEWER_PORT:-48388}"
+WORKER_VIEWER_PORT="${CODEMEM_PROOF_WORKER_VIEWER_PORT:-48389}"
+COORDINATOR_DB="$PROOF_ROOT/coordinator/coordinator.sqlite"
+COORDINATOR_LOG="$PROOF_ROOT/coordinator/coordinator.log"
+SEED_ROOT="$PROOF_ROOT/seed"
+WORKER_ROOT="$PROOF_ROOT/worker"
+MARKER_TITLE="workspace-proof-sync-marker"
+MARKER_BODY="host-workspace verified sync"
+MANUAL_BOOTSTRAP_JSON="$PROOF_ROOT/manual-bootstrap.json"
+WORKER_FINISH_SUMMARY="$PROOF_ROOT/worker-finish-summary.json"
+
+mkdir -p "$PROOF_ROOT/coordinator"
+
+stop_viewer() {
+	db_path="$1"
+	host="$2"
+	port="$3"
+	if [ -f "$db_path" ]; then
+		pnpm --dir "$repo_root" exec tsx --conditions source packages/cli/src/index.ts serve stop --db-path "$db_path" --host "$host" --port "$port" >/dev/null 2>&1 || true
+	fi
+}
+
+cleanup() {
+	stop_viewer "$WORKER_ROOT/mem.sqlite" 127.0.0.1 "$WORKER_VIEWER_PORT"
+	stop_viewer "$SEED_ROOT/mem.sqlite" 127.0.0.1 "$SEED_VIEWER_PORT"
+	if [ -n "${COORDINATOR_PID:-}" ]; then
+		kill "$COORDINATOR_PID" >/dev/null 2>&1 || true
+	fi
+	if [ "$KEEP_PROOF_ROOT" != "1" ]; then
+		rm -rf "$PROOF_ROOT"
+	fi
+}
+
+trap cleanup EXIT INT TERM
+
+codemem() {
+	env CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET="$ADMIN_SECRET" pnpm --dir "$repo_root" exec tsx --conditions source packages/cli/src/index.ts "$@"
+}
+
+wait_for_http() {
+	url="$1"
+	node --input-type=module -e "const url = process.argv[1]; for (let i = 0; i < 80; i += 1) { try { const res = await fetch(url); if (res.status >= 100) process.exit(0); } catch {} await new Promise((resolve) => setTimeout(resolve, 250)); } process.exit(1);" "$url"
+}
+
+read_json_field() {
+	file_path="$1"
+	field_name="$2"
+	python3 - <<'PY' "$file_path" "$field_name"
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+print(payload[sys.argv[2]])
+PY
+}
+
+pin_peer() {
+	db_path="$1"
+	peer_device_id="$2"
+	fingerprint="$3"
+	public_key="$4"
+	address="$5"
+	pnpm --dir "$repo_root" exec tsx --conditions source scripts/workspace/pin-peer.ts --db-path "$db_path" --peer-device-id "$peer_device_id" --fingerprint "$fingerprint" --public-key "$public_key" --address "$address" >/dev/null
+}
+
+CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET="$ADMIN_SECRET" pnpm --dir "$repo_root" exec tsx --conditions source packages/cli/src/index.ts coordinator serve --db-path "$COORDINATOR_DB" --host 127.0.0.1 --port "$COORDINATOR_PORT" > "$COORDINATOR_LOG" 2>&1 &
+COORDINATOR_PID=$!
+wait_for_http "http://127.0.0.1:$COORDINATOR_PORT/"
+
+codemem coordinator group-create "$GROUP_ID" --db-path "$COORDINATOR_DB" > "$PROOF_ROOT/group-create.txt" 2>&1
+
+CODEMEM_REPO_ROOT="$repo_root" \
+CODEMEM_WORKSPACE_SELECTOR="local-host-workspace" \
+CODEMEM_FLEET_NAME="workspace-proof" \
+CODEMEM_NODE_ID="seed-main" \
+CODEMEM_NODE_ROLE="seed-peer" \
+CODEMEM_COORDINATOR_URL="http://127.0.0.1:$COORDINATOR_PORT" \
+CODEMEM_COORDINATOR_GROUP="$GROUP_ID" \
+CODEMEM_COORDINATOR_ADMIN_SECRET="$ADMIN_SECRET" \
+CODEMEM_RUNTIME_ROOT="$SEED_ROOT" \
+CODEMEM_SYNC_HOST="127.0.0.1" \
+CODEMEM_SYNC_PORT="$SEED_SYNC_PORT" \
+CODEMEM_VIEWER_HOST="127.0.0.1" \
+CODEMEM_VIEWER_PORT="$SEED_VIEWER_PORT" \
+sh "$script_dir/workspace-codemem-bootstrap-local.sh" > "$PROOF_ROOT/seed-summary.json"
+
+SEED_IDENTITY="$SEED_ROOT/artifacts/identity.json"
+SEED_DEVICE_ID=$(read_json_field "$SEED_IDENTITY" device_id)
+SEED_FINGERPRINT=$(read_json_field "$SEED_IDENTITY" fingerprint)
+SEED_PUBLIC_KEY=$(read_json_field "$SEED_IDENTITY" public_key)
+
+codemem coordinator enroll-device "$GROUP_ID" "$SEED_DEVICE_ID" --fingerprint "$SEED_FINGERPRINT" --public-key "$SEED_PUBLIC_KEY" --db-path "$COORDINATOR_DB" --json > "$PROOF_ROOT/enroll-seed.json"
+codemem coordinator create-invite "$GROUP_ID" --policy auto_admit --coordinator-url "http://127.0.0.1:$COORDINATOR_PORT" --remote-url "http://127.0.0.1:$COORDINATOR_PORT" --admin-secret "$ADMIN_SECRET" --db-path "$COORDINATOR_DB" --json > "$PROOF_ROOT/create-invite.json"
+
+INVITE=$(python3 - <<'PY' "$PROOF_ROOT/create-invite.json"
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+print(payload["encoded"])
+PY
+)
+
+CODEMEM_REPO_ROOT="$repo_root" \
+CODEMEM_WORKSPACE_SELECTOR="local-host-workspace" \
+CODEMEM_FLEET_NAME="workspace-proof" \
+CODEMEM_NODE_ID="worker-main" \
+CODEMEM_NODE_ROLE="worker-peer" \
+CODEMEM_SWARM_ID="swarm-proof" \
+CODEMEM_COORDINATOR_URL="http://127.0.0.1:$COORDINATOR_PORT" \
+CODEMEM_COORDINATOR_GROUP="$GROUP_ID" \
+CODEMEM_COORDINATOR_ADMIN_SECRET="$ADMIN_SECRET" \
+CODEMEM_RUNTIME_ROOT="$WORKER_ROOT" \
+CODEMEM_SYNC_HOST="127.0.0.1" \
+CODEMEM_SYNC_PORT="$WORKER_SYNC_PORT" \
+CODEMEM_VIEWER_HOST="127.0.0.1" \
+CODEMEM_VIEWER_PORT="$WORKER_VIEWER_PORT" \
+CODEMEM_INVITE="$INVITE" \
+CODEMEM_SEED_PEER_DEVICE_ID="$SEED_DEVICE_ID" \
+CODEMEM_SEED_PEER_FINGERPRINT="$SEED_FINGERPRINT" \
+CODEMEM_SEED_PEER_PUBLIC_KEY="$SEED_PUBLIC_KEY" \
+CODEMEM_SEED_PEER_ADDRESS="127.0.0.1:$SEED_SYNC_PORT" \
+CODEMEM_BOOTSTRAP_PHASE="join-only" \
+sh "$script_dir/workspace-codemem-bootstrap-local.sh" > "$PROOF_ROOT/worker-initial-summary.json"
+
+WORKER_IDENTITY="$WORKER_ROOT/artifacts/identity.json"
+WORKER_DEVICE_ID=$(read_json_field "$WORKER_IDENTITY" device_id)
+WORKER_FINGERPRINT=$(read_json_field "$WORKER_IDENTITY" fingerprint)
+WORKER_PUBLIC_KEY=$(read_json_field "$WORKER_IDENTITY" public_key)
+
+pin_peer "$SEED_ROOT/mem.sqlite" "$WORKER_DEVICE_ID" "$WORKER_FINGERPRINT" "$WORKER_PUBLIC_KEY" "127.0.0.1:$WORKER_SYNC_PORT"
+pin_peer "$WORKER_ROOT/mem.sqlite" "$SEED_DEVICE_ID" "$SEED_FINGERPRINT" "$SEED_PUBLIC_KEY" "127.0.0.1:$SEED_SYNC_PORT"
+
+pnpm --dir "$repo_root" exec tsx --conditions source packages/cli/src/index.ts memory remember --db-path "$SEED_ROOT/mem.sqlite" --kind discovery --title "$MARKER_TITLE" --body "$MARKER_BODY" >/dev/null
+CODEMEM_REPO_ROOT="$repo_root" \
+CODEMEM_WORKSPACE_SELECTOR="local-host-workspace" \
+CODEMEM_FLEET_NAME="workspace-proof" \
+CODEMEM_NODE_ID="worker-main" \
+CODEMEM_NODE_ROLE="worker-peer" \
+CODEMEM_SWARM_ID="swarm-proof" \
+CODEMEM_COORDINATOR_URL="http://127.0.0.1:$COORDINATOR_PORT" \
+CODEMEM_COORDINATOR_GROUP="$GROUP_ID" \
+CODEMEM_COORDINATOR_ADMIN_SECRET="$ADMIN_SECRET" \
+CODEMEM_RUNTIME_ROOT="$WORKER_ROOT" \
+CODEMEM_SYNC_HOST="127.0.0.1" \
+CODEMEM_SYNC_PORT="$WORKER_SYNC_PORT" \
+CODEMEM_VIEWER_HOST="127.0.0.1" \
+CODEMEM_VIEWER_PORT="$WORKER_VIEWER_PORT" \
+CODEMEM_SEED_PEER_DEVICE_ID="$SEED_DEVICE_ID" \
+CODEMEM_SEED_PEER_FINGERPRINT="$SEED_FINGERPRINT" \
+CODEMEM_SEED_PEER_PUBLIC_KEY="$SEED_PUBLIC_KEY" \
+CODEMEM_SEED_PEER_ADDRESS="127.0.0.1:$SEED_SYNC_PORT" \
+CODEMEM_BOOTSTRAP_PHASE="finish-bootstrap" \
+sh "$script_dir/workspace-codemem-bootstrap-local.sh" > "$WORKER_FINISH_SUMMARY"
+CODEMEM_KEYS_DIR="$WORKER_ROOT/keys" pnpm --dir "$repo_root" exec tsx --conditions source packages/cli/src/index.ts sync once --db-path "$WORKER_ROOT/mem.sqlite" > "$PROOF_ROOT/worker-sync-once.txt" 2>&1
+pnpm --dir "$repo_root" exec tsx --conditions source packages/cli/src/index.ts search "$MARKER_TITLE" --db-path "$WORKER_ROOT/mem.sqlite" --all-projects --json > "$PROOF_ROOT/worker-search.json"
+
+python3 - "$PROOF_ROOT" "$SEED_IDENTITY" "$WORKER_IDENTITY" "$GROUP_ID" "$COORDINATOR_PORT" "$ADMIN_SECRET" "$PROOF_ROOT/worker-sync-once.txt" "$PROOF_ROOT/worker-search.json" "$WORKER_FINISH_SUMMARY" > "$PROOF_ROOT/proof-summary.json" <<'PY'
+import json, sys, urllib.request
+from pathlib import Path
+
+proof_root = Path(sys.argv[1])
+seed_identity = json.loads(Path(sys.argv[2]).read_text())
+worker_identity = json.loads(Path(sys.argv[3]).read_text())
+group_id = sys.argv[4]
+coordinator_port = sys.argv[5]
+admin_secret = sys.argv[6]
+sync_once_text = Path(sys.argv[7]).read_text()
+search_results = json.loads(Path(sys.argv[8]).read_text())
+worker_finish = json.loads(Path(sys.argv[9]).read_text())
+
+req = urllib.request.Request(
+    f"http://127.0.0.1:{coordinator_port}/v1/admin/devices?group_id={group_id}",
+    headers={"X-Codemem-Coordinator-Admin": admin_secret},
+)
+with urllib.request.urlopen(req) as response:
+    coordinator_devices = json.loads(response.read().decode("utf-8"))
+
+device_ids = {item.get("device_id") for item in coordinator_devices.get("items", [])}
+search_hit = any(item.get("title") == "workspace-proof-sync-marker" for item in search_results)
+sync_ok = f"{seed_identity['device_id']}: ok" in sync_once_text
+
+payload = {
+    "proof_root": str(proof_root),
+    "coordinator_url": f"http://127.0.0.1:{coordinator_port}",
+    "group_id": group_id,
+    "seed_identity": seed_identity,
+    "worker_identity": worker_identity,
+    "coordinator_join_verified": seed_identity["device_id"] in device_ids and worker_identity["device_id"] in device_ids,
+    "bootstrap_verified": worker_finish.get("readiness_result") == "ready",
+    "sync_once_verified": sync_ok,
+    "marker_memory_verified": search_hit,
+}
+print(json.dumps(payload, indent=2))
+PY
+
+cat "$PROOF_ROOT/proof-summary.json"

--- a/scripts/workspace/read-peer-identity.ts
+++ b/scripts/workspace/read-peer-identity.ts
@@ -1,0 +1,42 @@
+import { connect } from "../../packages/core/src/db.ts";
+import { ensureDeviceIdentity, loadPublicKey } from "../../packages/core/src/index.ts";
+
+function parseArgs(argv: string[]) {
+	let dbPath = "";
+	let keysDir = "";
+	for (let index = 2; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--db-path") {
+			dbPath = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		} else if (arg === "--keys-dir") {
+			keysDir = String(argv[index + 1] ?? "").trim();
+			index += 1;
+		}
+	}
+	if (!dbPath || !keysDir) {
+		throw new Error("--db-path and --keys-dir are required");
+	}
+	return { dbPath, keysDir };
+}
+
+const { dbPath, keysDir } = parseArgs(process.argv);
+const db = connect(dbPath);
+
+try {
+	const [deviceId, fingerprint] = ensureDeviceIdentity(db, { keysDir });
+	const publicKey = loadPublicKey(keysDir);
+	console.log(
+		JSON.stringify(
+			{
+				device_id: deviceId,
+				fingerprint,
+				public_key: publicKey,
+			},
+			null,
+			2,
+		),
+	);
+} finally {
+	db.close();
+}

--- a/scripts/workspace/workspace-codemem-bootstrap-local.sh
+++ b/scripts/workspace/workspace-codemem-bootstrap-local.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env sh
+set -eu
+
+# Concrete host-workspace bootstrap flow for attaching codemem to an existing
+# developer/agent workspace with a durable HOME directory and a repo checkout.
+
+require_var() {
+	name="$1"
+	value="$2"
+	if [ -z "$value" ]; then
+		printf '%s\n' "$name is required" >&2
+		exit 1
+	fi
+}
+
+script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+repo_root_default=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+
+CODEMEM_REPO_ROOT="${CODEMEM_REPO_ROOT:-$repo_root_default}"
+CODEMEM_WORKSPACE_SELECTOR="${CODEMEM_WORKSPACE_SELECTOR:-$(hostname)}"
+CODEMEM_FLEET_NAME="${CODEMEM_FLEET_NAME:-workspace-attachment}"
+CODEMEM_NODE_ID="${CODEMEM_NODE_ID:-${CODEMEM_WORKSPACE_SELECTOR}}"
+CODEMEM_NODE_ROLE="${CODEMEM_NODE_ROLE:-}"
+CODEMEM_SWARM_ID="${CODEMEM_SWARM_ID:-}"
+CODEMEM_COORDINATOR_GROUP="${CODEMEM_COORDINATOR_GROUP:-}"
+CODEMEM_COORDINATOR_URL="${CODEMEM_COORDINATOR_URL:-}"
+CODEMEM_COORDINATOR_ADMIN_SECRET="${CODEMEM_COORDINATOR_ADMIN_SECRET:-${CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET:-}}"
+CODEMEM_IDENTITY_POLICY="${CODEMEM_IDENTITY_POLICY:-}"
+CODEMEM_PERSISTENCE="${CODEMEM_PERSISTENCE:-}"
+CODEMEM_RUNTIME_ROOT="${CODEMEM_RUNTIME_ROOT:-}"
+CODEMEM_SYNC_HOST="${CODEMEM_SYNC_HOST:-127.0.0.1}"
+CODEMEM_SYNC_PORT="${CODEMEM_SYNC_PORT:-7337}"
+CODEMEM_SYNC_INTERVAL_S="${CODEMEM_SYNC_INTERVAL_S:-5}"
+CODEMEM_VIEWER_HOST="${CODEMEM_VIEWER_HOST:-127.0.0.1}"
+CODEMEM_VIEWER_PORT="${CODEMEM_VIEWER_PORT:-38888}"
+CODEMEM_START_VIEWER="${CODEMEM_START_VIEWER:-1}"
+CODEMEM_VIEWER_STATIC_DIR="${CODEMEM_VIEWER_STATIC_DIR:-}"
+CODEMEM_INVITE="${CODEMEM_INVITE:-}"
+CODEMEM_SEED_PEER_DEVICE_ID="${CODEMEM_SEED_PEER_DEVICE_ID:-}"
+CODEMEM_SEED_PEER_FINGERPRINT="${CODEMEM_SEED_PEER_FINGERPRINT:-}"
+CODEMEM_SEED_PEER_PUBLIC_KEY="${CODEMEM_SEED_PEER_PUBLIC_KEY:-}"
+CODEMEM_SEED_PEER_ADDRESS="${CODEMEM_SEED_PEER_ADDRESS:-}"
+CODEMEM_BOOTSTRAP_PHASE="${CODEMEM_BOOTSTRAP_PHASE:-full}"
+CODEMEM_BOOTSTRAP_FORCE="${CODEMEM_BOOTSTRAP_FORCE:-0}"
+
+require_var CODEMEM_NODE_ROLE "$CODEMEM_NODE_ROLE"
+require_var CODEMEM_COORDINATOR_URL "$CODEMEM_COORDINATOR_URL"
+require_var CODEMEM_COORDINATOR_GROUP "$CODEMEM_COORDINATOR_GROUP"
+
+case "$CODEMEM_BOOTSTRAP_PHASE" in
+full | join-only | finish-bootstrap) ;;
+*)
+	printf '%s\n' "Unsupported CODEMEM_BOOTSTRAP_PHASE: $CODEMEM_BOOTSTRAP_PHASE" >&2
+	exit 1
+	;;
+esac
+
+if [ -z "$CODEMEM_IDENTITY_POLICY" ]; then
+	if [ "$CODEMEM_NODE_ROLE" = "seed-peer" ]; then
+		CODEMEM_IDENTITY_POLICY="stable"
+	else
+		CODEMEM_IDENTITY_POLICY="ephemeral"
+	fi
+fi
+
+if [ -z "$CODEMEM_PERSISTENCE" ]; then
+	if [ "$CODEMEM_NODE_ROLE" = "seed-peer" ]; then
+		CODEMEM_PERSISTENCE="stable"
+	else
+		CODEMEM_PERSISTENCE="ephemeral"
+	fi
+fi
+
+if [ -z "$CODEMEM_RUNTIME_ROOT" ]; then
+	if [ "$CODEMEM_PERSISTENCE" = "stable" ]; then
+		CODEMEM_RUNTIME_ROOT="$HOME/.codemem/workspaces/stable/$CODEMEM_WORKSPACE_SELECTOR/$CODEMEM_FLEET_NAME/$CODEMEM_NODE_ID"
+	else
+		tmp_root="${TMPDIR:-/tmp}"
+		CODEMEM_RUNTIME_ROOT="${tmp_root%/}/codemem-workspaces/ephemeral/$CODEMEM_WORKSPACE_SELECTOR/$CODEMEM_FLEET_NAME/$CODEMEM_NODE_ID"
+	fi
+fi
+
+CODEMEM_DB="${CODEMEM_DB:-$CODEMEM_RUNTIME_ROOT/mem.sqlite}"
+CODEMEM_CONFIG="${CODEMEM_CONFIG:-$CODEMEM_RUNTIME_ROOT/config/codemem.json}"
+CODEMEM_KEYS_DIR="${CODEMEM_KEYS_DIR:-$CODEMEM_RUNTIME_ROOT/keys}"
+CODEMEM_ARTIFACTS_DIR="${CODEMEM_ARTIFACTS_DIR:-$CODEMEM_RUNTIME_ROOT/artifacts}"
+
+export CODEMEM_WORKSPACE_SELECTOR CODEMEM_FLEET_NAME CODEMEM_NODE_ID CODEMEM_NODE_ROLE
+export CODEMEM_SWARM_ID CODEMEM_IDENTITY_POLICY CODEMEM_PERSISTENCE CODEMEM_RUNTIME_ROOT
+export CODEMEM_DB CODEMEM_CONFIG CODEMEM_KEYS_DIR CODEMEM_ARTIFACTS_DIR
+export CODEMEM_COORDINATOR_URL CODEMEM_COORDINATOR_GROUP CODEMEM_COORDINATOR_ADMIN_SECRET
+export CODEMEM_SYNC_HOST CODEMEM_SYNC_PORT CODEMEM_SYNC_INTERVAL_S CODEMEM_BOOTSTRAP_PHASE
+export CODEMEM_BOOTSTRAP_FORCE
+
+mkdir -p "$CODEMEM_RUNTIME_ROOT"
+mkdir -p "$(dirname "$CODEMEM_DB")"
+mkdir -p "$(dirname "$CODEMEM_CONFIG")"
+mkdir -p "$CODEMEM_KEYS_DIR"
+mkdir -p "$CODEMEM_ARTIFACTS_DIR"
+
+status_file="$CODEMEM_ARTIFACTS_DIR/status.json"
+identity_file="$CODEMEM_ARTIFACTS_DIR/identity.json"
+config_snapshot="$CODEMEM_ARTIFACTS_DIR/config.snapshot.json"
+summary_file="$CODEMEM_ARTIFACTS_DIR/summary.json"
+
+write_status() {
+	state="$1"
+	detail="$2"
+	STATE="$state" DETAIL="$detail" python3 - <<'PY' >"$status_file"
+import json, os
+payload = {
+    "workspace_selector": os.environ["CODEMEM_WORKSPACE_SELECTOR"],
+    "fleet_name": os.environ["CODEMEM_FLEET_NAME"],
+    "swarm_id": os.environ.get("CODEMEM_SWARM_ID") or None,
+    "node_id": os.environ["CODEMEM_NODE_ID"],
+    "node_role": os.environ["CODEMEM_NODE_ROLE"],
+    "identity_policy": os.environ["CODEMEM_IDENTITY_POLICY"],
+    "persistence": os.environ["CODEMEM_PERSISTENCE"],
+    "runtime_root": os.environ["CODEMEM_RUNTIME_ROOT"],
+    "db_path": os.environ["CODEMEM_DB"],
+    "config_path": os.environ["CODEMEM_CONFIG"],
+    "keys_path": os.environ["CODEMEM_KEYS_DIR"],
+    "coordinator_url": os.environ["CODEMEM_COORDINATOR_URL"],
+    "coordinator_group": os.environ["CODEMEM_COORDINATOR_GROUP"],
+    "bootstrap_phase": os.environ["CODEMEM_BOOTSTRAP_PHASE"],
+    "state": os.environ["STATE"],
+    "detail": os.environ["DETAIL"],
+}
+print(json.dumps(payload, indent=2))
+PY
+}
+
+write_summary() {
+	state="$1"
+	readiness="$2"
+	bootstrap_source="$3"
+	failure_detail="$4"
+	STATE="$state" READINESS="$readiness" BOOTSTRAP_SOURCE="$bootstrap_source" FAILURE_DETAIL="$failure_detail" python3 - <<'PY' >"$summary_file"
+import json, os
+identity = None
+identity_path = os.environ["IDENTITY_FILE"]
+if os.path.exists(identity_path):
+    with open(identity_path, "r", encoding="utf-8") as handle:
+        identity = json.load(handle)
+payload = {
+    "workspace_selector": os.environ["CODEMEM_WORKSPACE_SELECTOR"],
+    "fleet_name": os.environ["CODEMEM_FLEET_NAME"],
+    "swarm_id": os.environ.get("CODEMEM_SWARM_ID") or None,
+    "node_id": os.environ["CODEMEM_NODE_ID"],
+    "node_role": os.environ["CODEMEM_NODE_ROLE"],
+    "state": os.environ["STATE"],
+    "device_identity": identity,
+    "coordinator_group": os.environ["CODEMEM_COORDINATOR_GROUP"],
+    "bootstrap_phase": os.environ["CODEMEM_BOOTSTRAP_PHASE"],
+    "bootstrap_source": os.environ["BOOTSTRAP_SOURCE"] or None,
+    "readiness_result": os.environ["READINESS"],
+    "artifact_dir": os.environ["CODEMEM_ARTIFACTS_DIR"],
+    "failure_detail": os.environ["FAILURE_DETAIL"] or None,
+}
+print(json.dumps(payload, indent=2))
+PY
+}
+
+codemem() {
+	env \
+		CODEMEM_DB="$CODEMEM_DB" \
+		CODEMEM_CONFIG="$CODEMEM_CONFIG" \
+		CODEMEM_KEYS_DIR="$CODEMEM_KEYS_DIR" \
+		CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET="$CODEMEM_COORDINATOR_ADMIN_SECRET" \
+		pnpm --dir "$CODEMEM_REPO_ROOT" exec tsx --conditions source packages/cli/src/index.ts "$@"
+}
+
+wait_for_http() {
+	url="$1"
+	node --input-type=module -e "const url = process.argv[1]; for (let i = 0; i < 80; i += 1) { try { const res = await fetch(url); if (res.status >= 100) process.exit(0); } catch {} await new Promise((resolve) => setTimeout(resolve, 250)); } process.exit(1);" "$url"
+}
+
+write_status pending "Preparing workspace attachment paths and config."
+
+python3 - <<'PY' >"$CODEMEM_CONFIG"
+import json, os
+payload = {
+    "sync_enabled": True,
+    "sync_host": os.environ["CODEMEM_SYNC_HOST"],
+    "sync_port": int(os.environ["CODEMEM_SYNC_PORT"]),
+    "sync_interval_s": int(os.environ["CODEMEM_SYNC_INTERVAL_S"]),
+    "sync_coordinator_url": os.environ["CODEMEM_COORDINATOR_URL"],
+    "sync_coordinator_group": os.environ["CODEMEM_COORDINATOR_GROUP"],
+}
+secret = os.environ.get("CODEMEM_COORDINATOR_ADMIN_SECRET", "").strip()
+if secret:
+    payload["sync_coordinator_admin_secret"] = secret
+print(json.dumps(payload, indent=2))
+PY
+python3 - <<'PY' >"$config_snapshot"
+import json, os
+with open(os.environ["CODEMEM_CONFIG"], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+if "sync_coordinator_admin_secret" in payload:
+    payload["sync_coordinator_admin_secret"] = "<redacted>"
+print(json.dumps(payload, indent=2))
+PY
+
+codemem db init --db-path "$CODEMEM_DB" >"$CODEMEM_ARTIFACTS_DIR/db-init.txt" 2>&1
+codemem sync enable --db-path "$CODEMEM_DB" --host "$CODEMEM_SYNC_HOST" --port "$CODEMEM_SYNC_PORT" --interval "$CODEMEM_SYNC_INTERVAL_S" >"$CODEMEM_ARTIFACTS_DIR/sync-enable.txt" 2>&1
+pnpm --dir "$CODEMEM_REPO_ROOT" exec tsx --conditions source scripts/workspace/read-peer-identity.ts --db-path "$CODEMEM_DB" --keys-dir "$CODEMEM_KEYS_DIR" >"$identity_file"
+
+if [ "$CODEMEM_START_VIEWER" = "1" ]; then
+	if [ -z "$CODEMEM_VIEWER_STATIC_DIR" ]; then
+		CODEMEM_VIEWER_STATIC_DIR="$CODEMEM_RUNTIME_ROOT/viewer-static"
+		mkdir -p "$CODEMEM_VIEWER_STATIC_DIR"
+		python3 - <<'PY' >"$CODEMEM_VIEWER_STATIC_DIR/index.html"
+print("<!doctype html><title>codemem workspace bootstrap</title>")
+PY
+	fi
+	export CODEMEM_VIEWER_STATIC_DIR
+	env CODEMEM_VIEWER_STATIC_DIR="$CODEMEM_VIEWER_STATIC_DIR" CODEMEM_DB="$CODEMEM_DB" CODEMEM_CONFIG="$CODEMEM_CONFIG" CODEMEM_KEYS_DIR="$CODEMEM_KEYS_DIR" CODEMEM_SYNC_COORDINATOR_ADMIN_SECRET="$CODEMEM_COORDINATOR_ADMIN_SECRET" pnpm --dir "$CODEMEM_REPO_ROOT" exec tsx --conditions source packages/cli/src/index.ts serve start --db-path "$CODEMEM_DB" --host "$CODEMEM_VIEWER_HOST" --port "$CODEMEM_VIEWER_PORT" >"$CODEMEM_ARTIFACTS_DIR/viewer-start.txt" 2>&1
+	wait_for_http "http://$CODEMEM_VIEWER_HOST:$CODEMEM_VIEWER_PORT/"
+fi
+
+if [ "$CODEMEM_NODE_ROLE" = "seed-peer" ]; then
+	write_status ready "Seed peer configured, identity initialized, and sync server activated."
+	IDENTITY_FILE="$identity_file" write_summary ready ready none ""
+	cat "$summary_file"
+	exit 0
+fi
+
+if [ "$CODEMEM_NODE_ROLE" != "worker-peer" ]; then
+	write_status failed "Unsupported node role."
+	IDENTITY_FILE="$identity_file" write_summary failed failed none "unsupported CODEMEM_NODE_ROLE"
+	cat "$summary_file"
+	exit 1
+fi
+
+require_var CODEMEM_SEED_PEER_DEVICE_ID "$CODEMEM_SEED_PEER_DEVICE_ID"
+require_var CODEMEM_SEED_PEER_FINGERPRINT "$CODEMEM_SEED_PEER_FINGERPRINT"
+require_var CODEMEM_SEED_PEER_PUBLIC_KEY "$CODEMEM_SEED_PEER_PUBLIC_KEY"
+require_var CODEMEM_SEED_PEER_ADDRESS "$CODEMEM_SEED_PEER_ADDRESS"
+
+if [ "$CODEMEM_BOOTSTRAP_PHASE" != "finish-bootstrap" ]; then
+	require_var CODEMEM_INVITE "$CODEMEM_INVITE"
+	write_status joining "Importing coordinator invite and checking admission result."
+	codemem coordinator import-invite "$CODEMEM_INVITE" --db-path "$CODEMEM_DB" --keys-dir "$CODEMEM_KEYS_DIR" --config "$CODEMEM_CONFIG" --json >"$CODEMEM_ARTIFACTS_DIR/import-invite.json" 2>&1
+
+	invite_status=$(
+		python3 - <<'PY'
+import json, os
+path = os.environ["CODEMEM_ARTIFACTS_DIR"] + "/import-invite.json"
+with open(path, "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+print(str(payload.get("status", "")))
+PY
+)
+
+	if [ "$invite_status" = "pending" ] || [ -z "$invite_status" ]; then
+		write_status failed "Worker is not admitted yet; approval-required invites need an external approval step before readiness."
+		IDENTITY_FILE="$identity_file" write_summary failed failed none "coordinator join did not complete"
+		cat "$summary_file"
+		exit 1
+	fi
+	write_status joined "Worker admitted to coordinator group."
+else
+	write_status joined "Using existing worker identity and coordinator admission."
+fi
+
+pnpm --dir "$CODEMEM_REPO_ROOT" exec tsx --conditions source scripts/workspace/pin-peer.ts --db-path "$CODEMEM_DB" --peer-device-id "$CODEMEM_SEED_PEER_DEVICE_ID" --fingerprint "$CODEMEM_SEED_PEER_FINGERPRINT" --public-key "$CODEMEM_SEED_PEER_PUBLIC_KEY" --address "$CODEMEM_SEED_PEER_ADDRESS" >"$CODEMEM_ARTIFACTS_DIR/pin-seed-peer.json"
+
+if [ "$CODEMEM_BOOTSTRAP_PHASE" = "join-only" ]; then
+	write_status joined_pending_seed_trust "Worker identity emitted; waiting for the seed peer to trust this worker before bootstrap."
+	IDENTITY_FILE="$identity_file" write_summary joined_pending_seed_trust pending_seed_trust "$CODEMEM_SEED_PEER_DEVICE_ID" "seed peer trust pending"
+	cat "$summary_file"
+	exit 0
+fi
+
+write_status bootstrapping "Bootstrapping local state from the seed peer."
+if [ "$CODEMEM_BOOTSTRAP_FORCE" = "1" ]; then
+	codemem sync bootstrap --peer "$CODEMEM_SEED_PEER_DEVICE_ID" --db-path "$CODEMEM_DB" --keys-dir "$CODEMEM_KEYS_DIR" --json --force >"$CODEMEM_ARTIFACTS_DIR/bootstrap.json" 2>&1
+else
+	codemem sync bootstrap --peer "$CODEMEM_SEED_PEER_DEVICE_ID" --db-path "$CODEMEM_DB" --keys-dir "$CODEMEM_KEYS_DIR" --json >"$CODEMEM_ARTIFACTS_DIR/bootstrap.json" 2>&1
+fi
+
+bootstrap_ok=$(
+	python3 - <<'PY'
+import json, os
+path = os.environ["CODEMEM_ARTIFACTS_DIR"] + "/bootstrap.json"
+with open(path, "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+print("true" if payload.get("ok") is True else "false")
+PY
+)
+
+if [ "$bootstrap_ok" != "true" ]; then
+	write_status failed "Bootstrap did not complete successfully."
+	IDENTITY_FILE="$identity_file" write_summary failed failed "$CODEMEM_SEED_PEER_DEVICE_ID" "bootstrap failed"
+	cat "$summary_file"
+	exit 1
+fi
+
+write_status sync_verifying "Running one sync pass against the seed peer."
+codemem sync once --db-path "$CODEMEM_DB" >"$CODEMEM_ARTIFACTS_DIR/sync-once.txt" 2>&1
+
+if ! grep -q "$CODEMEM_SEED_PEER_DEVICE_ID: ok" "$CODEMEM_ARTIFACTS_DIR/sync-once.txt"; then
+	write_status failed "Sync verification did not report success for the seed peer."
+	IDENTITY_FILE="$identity_file" write_summary failed failed "$CODEMEM_SEED_PEER_DEVICE_ID" "sync verification failed"
+	cat "$summary_file"
+	exit 1
+fi
+
+write_status ready "Coordinator join, bootstrap, and sync verification completed."
+IDENTITY_FILE="$identity_file" write_summary ready ready "$CODEMEM_SEED_PEER_DEVICE_ID" ""
+cat "$summary_file"


### PR DESCRIPTION
## Description
Adds a public-safe two-phase workspace bootstrap flow for pre-provisioned runtimes so private orchestrators can demo seed-peer memory attachment without embedding AirDev/AirChat-specific commands in OSS.

This PR also fixes the workspace proof harness so it is hermetic, JSON-safe, and uses workspace-scoped keys consistently during sync identity setup.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `pnpm exec vitest run packages/cli/src/commands/sync.test.ts`
- `pnpm run lint`
- `pnpm run tsc`
- `CODEMEM_KEEP_PROOF_ROOT=1 CODEMEM_PROOF_ROOT=.tmp/workspace-proof-two-phase-1 CODEMEM_PROOF_COORDINATOR_PORT=51347 CODEMEM_PROOF_SEED_SYNC_PORT=51337 CODEMEM_PROOF_WORKER_SYNC_PORT=51338 CODEMEM_PROOF_SEED_VIEWER_PORT=51388 CODEMEM_PROOF_WORKER_VIEWER_PORT=51389 sh scripts/workspace/prove-workspace-codemem-bootstrap-local.sh`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced