### PR TITLE
feat(core): add write-time secret scanner foundation

### DIFF
--- a/packages/core/src/secret-scanner.test.ts
+++ b/packages/core/src/secret-scanner.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_RULES,
+	mergeDetections,
+	type SecretRule,
+	SecretScanner,
+} from "./secret-scanner.js";
+
+describe("SecretScanner", () => {
+	const scanner = new SecretScanner();
+
+	describe("scan — well-known secret patterns", () => {
+		it("redacts AWS access key IDs", () => {
+			const r = scanner.scan("aws creds: AKIAIOSFODNN7EXAMPLE in config");
+			expect(r.redacted).toBe("aws creds: [REDACTED:aws_access_key_id] in config");
+			expect(r.detections).toEqual([{ kind: "aws_access_key_id", count: 1 }]);
+		});
+
+		it("redacts AWS secret access keys with sufficient entropy", () => {
+			const secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+			const r = scanner.scan(`secret = ${secret}`);
+			expect(r.redacted).not.toContain(secret);
+			// Either aws_secret_access_key or generic_assigned_secret will catch it; both are wins.
+			expect(r.detections.length).toBeGreaterThan(0);
+		});
+
+		it("redacts JWTs", () => {
+			const jwt =
+				"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+			const r = scanner.scan(`auth header: Bearer ${jwt}`);
+			expect(r.redacted).toContain("[REDACTED:jwt]");
+			expect(r.redacted).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+			expect(r.detections.find((d) => d.kind === "jwt")?.count).toBe(1);
+		});
+
+		it("redacts classic GitHub PATs", () => {
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const r = scanner.scan(`token=${pat}`);
+			expect(r.redacted).toContain("[REDACTED:github_pat_classic]");
+			expect(r.redacted).not.toContain(pat);
+		});
+
+		it("redacts fine-grained GitHub PATs", () => {
+			const pat = `github_pat_${"a".repeat(82)}`;
+			const r = scanner.scan(`use ${pat} for the api`);
+			expect(r.redacted).toContain("[REDACTED:github_pat_finegrained]");
+			expect(r.redacted).not.toContain(pat);
+		});
+
+		it("redacts other GitHub token variants", () => {
+			const tokens = [
+				"gho_abcdefghijklmnopqrstuvwxyz0123456789",
+				"ghu_abcdefghijklmnopqrstuvwxyz0123456789",
+				"ghs_abcdefghijklmnopqrstuvwxyz0123456789",
+				"ghr_abcdefghijklmnopqrstuvwxyz0123456789",
+			];
+			for (const t of tokens) {
+				const r = scanner.scan(`x ${t} y`);
+				expect(r.redacted).not.toContain(t);
+			}
+		});
+
+		it("redacts PEM private key blocks", () => {
+			const pem = `-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----`;
+			const r = scanner.scan(`key file content:\n${pem}\nend`);
+			expect(r.redacted).toContain("[REDACTED:pem_private_key]");
+			expect(r.redacted).not.toContain("BEGIN RSA PRIVATE KEY");
+		});
+
+		it("redacts Slack tokens", () => {
+			const t = "xoxb-1234567890-abcdefghij";
+			const r = scanner.scan(`slack: ${t}`);
+			expect(r.redacted).toContain("[REDACTED:slack_token]");
+		});
+
+		it("redacts Google API keys", () => {
+			// 39 chars total: AIza + 35
+			const k = "AIzaSyA-BCDEFGHIJKLMNOPQRSTUVWXY0123456";
+			expect(k.length).toBe(39);
+			const r = scanner.scan(`gkey=${k}`);
+			expect(r.redacted).toContain("[REDACTED:google_api_key]");
+		});
+
+		it("redacts Stripe live and test keys", () => {
+			// Repetition-only suffixes so GitHub push-protection does not flag
+			// these as live Stripe keys; pattern still matches the rule.
+			const live = `sk_live_${"X".repeat(24)}`;
+			const test = `sk_test_${"X".repeat(24)}`;
+			expect(scanner.scan(live).redacted).toContain("[REDACTED:");
+			expect(scanner.scan(test).redacted).toContain("[REDACTED:");
+		});
+	});
+
+	describe("scan — generic high-entropy with assignment context", () => {
+		it("redacts the value after a secret-context prefix", () => {
+			const r = scanner.scan('API_KEY="aB3xZ9pQ7rT2vW8yE4nM6kL0sJ5hF1dG"');
+			expect(r.redacted).not.toContain("aB3xZ9pQ7rT2vW8yE4nM6kL0sJ5hF1dG");
+			expect(r.redacted).toMatch(/\[REDACTED:/);
+			expect(r.redacted).toContain("API_KEY=");
+		});
+
+		it("does not redact ordinary prose without secret context", () => {
+			const text = "The quick brown fox jumps over the lazy dog forty two times.";
+			const r = scanner.scan(text);
+			expect(r.redacted).toBe(text);
+			expect(r.detections).toEqual([]);
+		});
+
+		it("does not redact common low-entropy identifiers like UUIDs", () => {
+			const text = "session id 550e8400-e29b-41d4-a716-446655440000 is fine";
+			const r = scanner.scan(text);
+			expect(r.redacted).toBe(text);
+		});
+
+		it("does not redact git commit SHAs", () => {
+			const text = "fixed in commit a1b2c3d4e5f60718293a4b5c6d7e8f9012345678";
+			const r = scanner.scan(text);
+			expect(r.redacted).toBe(text);
+		});
+	});
+
+	describe("redactValue — recursive object walk", () => {
+		it("redacts strings inside nested objects and arrays", () => {
+			const input = {
+				body: "key=ghp_abcdefghijklmnopqrstuvwxyz0123456789 inline",
+				nested: {
+					token: "supersecretvalue1234",
+					note: "harmless",
+				},
+				arr: ["plain", "AKIAIOSFODNN7EXAMPLE"],
+			};
+			const r = scanner.redactValue(input);
+			const out = r.value as typeof input;
+			expect(out.body).toContain("[REDACTED:github_pat_classic]");
+			expect(out.nested.token).toBe("[REDACTED:context_secret]");
+			expect(out.nested.note).toBe("harmless");
+			expect(out.arr[0]).toBe("plain");
+			expect(out.arr[1]).toBe("[REDACTED:aws_access_key_id]");
+			expect(r.detections.find((d) => d.kind === "github_pat_classic")?.count).toBe(1);
+			expect(r.detections.find((d) => d.kind === "context_secret")?.count).toBe(1);
+			expect(r.detections.find((d) => d.kind === "aws_access_key_id")?.count).toBe(1);
+		});
+
+		it("treats secret-bearing key names as context for whole-value redaction", () => {
+			const input = { password: "hunter2-but-longer", other: "fine" };
+			const r = scanner.redactValue(input);
+			expect((r.value as typeof input).password).toBe("[REDACTED:context_secret]");
+			expect((r.value as typeof input).other).toBe("fine");
+		});
+
+		it("preserves URL values even under secret-bearing key names", () => {
+			const input = { auth: "https://example.com/auth/callback" };
+			const r = scanner.redactValue(input);
+			expect((r.value as typeof input).auth).toBe("https://example.com/auth/callback");
+		});
+
+		it("preserves non-string values unchanged", () => {
+			const input = { count: 42, flag: true, nope: null };
+			const r = scanner.redactValue(input);
+			expect(r.value).toEqual(input);
+			expect(r.detections).toEqual([]);
+		});
+	});
+
+	describe("allowlist", () => {
+		it("bypasses redaction for explicit literal matches", () => {
+			const fixture = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const s = new SecretScanner({ allowlist: [fixture] });
+			const r = s.scan(`token=${fixture}`);
+			expect(r.redacted).toContain(fixture);
+		});
+
+		it("bypasses redaction for allowlist regexes", () => {
+			const s = new SecretScanner({ allowlist: [/^AKIAFAKEFIXTURE/] });
+			const r = s.scan("creds: AKIAFAKEFIXTURE0001 in test");
+			expect(r.redacted).toContain("AKIAFAKEFIXTURE0001");
+		});
+
+		it("is stable across repeat calls when allowlist regex has g flag", () => {
+			const fixture = "AKIAFAKEFIXTURE0001";
+			const s = new SecretScanner({ allowlist: [/^AKIAFAKEFIXTURE\d{4}$/g] });
+			for (let i = 0; i < 4; i++) {
+				expect(s.scan(`creds: ${fixture} in test`).redacted).toContain(fixture);
+			}
+		});
+	});
+
+	describe("custom rules", () => {
+		it("merges additional rules with defaults", () => {
+			const extra: SecretRule = { kind: "internal_token", pattern: /\bACME-[A-Z0-9]{10}\b/g };
+			const s = new SecretScanner({ rules: [extra] });
+			const r = s.scan("internal: ACME-AB12CD34EF and aws AKIAIOSFODNN7EXAMPLE");
+			expect(r.redacted).toContain("[REDACTED:internal_token]");
+			expect(r.redacted).toContain("[REDACTED:aws_access_key_id]");
+		});
+	});
+
+	describe("rule precedence", () => {
+		it("classifies Anthropic keys as anthropic_api_key, not openai_api_key", () => {
+			const key = `sk-ant-api03-${"A".repeat(85)}aB1`;
+			const r = scanner.scan(`auth: ${key}`);
+			expect(r.redacted).toContain("[REDACTED:anthropic_api_key]");
+			expect(r.redacted).not.toContain("[REDACTED:openai_api_key]");
+		});
+
+		it("classifies OpenAI proj keys as openai_api_key", () => {
+			const key = "sk-proj-aB3xZ9pQ7rT2vW8yE4nM6kL0sJ5hF1dGcXvBnMxY8zRpQwErTy2";
+			const r = scanner.scan(`OPENAI_API_KEY=${key}`);
+			expect(r.redacted).toContain("[REDACTED:openai_api_key]");
+		});
+
+		it("does not flag low-entropy sk- prefixed identifiers as openai keys", () => {
+			// Internal SKU-like string with sk- prefix and 32+ chars but flat entropy
+			const r = scanner.scan("sku ref sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa fine");
+			expect(r.redacted).not.toContain("[REDACTED:openai_api_key]");
+		});
+	});
+
+	describe("non-plain objects and cycles in redactValue", () => {
+		it("returns Date instances unchanged instead of serializing to {}", () => {
+			const d = new Date("2026-01-01T00:00:00Z");
+			const r = scanner.redactValue({ when: d });
+			expect((r.value as { when: Date }).when).toBe(d);
+		});
+
+		it("returns Map / Set / RegExp / Buffer unchanged", () => {
+			const map = new Map([["k", "v"]]);
+			const set = new Set([1, 2, 3]);
+			const re = /foo/i;
+			const buf = Buffer.from("hello");
+			const r = scanner.redactValue({ map, set, re, buf });
+			const out = r.value as {
+				map: Map<string, string>;
+				set: Set<number>;
+				re: RegExp;
+				buf: Buffer;
+			};
+			expect(out.map).toBe(map);
+			expect(out.set).toBe(set);
+			expect(out.re).toBe(re);
+			expect(out.buf).toBe(buf);
+		});
+
+		it("survives a self-referential object without stack-overflowing", () => {
+			const obj: Record<string, unknown> = { name: "x" };
+			obj.self = obj;
+			expect(() => scanner.redactValue(obj)).not.toThrow();
+			const r = scanner.redactValue(obj);
+			expect(r.value).toBeDefined();
+		});
+
+		it("survives a cyclic array reference", () => {
+			const arr: unknown[] = ["a"];
+			arr.push(arr);
+			expect(() => scanner.redactValue(arr)).not.toThrow();
+		});
+	});
+
+	describe("edge cases", () => {
+		it("returns the original text when no rules match", () => {
+			const r = scanner.scan("nothing to see here");
+			expect(r.redacted).toBe("nothing to see here");
+			expect(r.detections).toEqual([]);
+		});
+
+		it("handles empty and non-string inputs gracefully", () => {
+			expect(scanner.scan("").redacted).toBe("");
+			// @ts-expect-error — guarding runtime use
+			expect(scanner.scan(null).redacted).toBe(null);
+		});
+
+		it("counts multiple detections of the same kind", () => {
+			const r = scanner.scan(
+				"ghp_abcdefghijklmnopqrstuvwxyz0123456789 and ghp_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			);
+			expect(r.detections.find((d) => d.kind === "github_pat_classic")?.count).toBe(2);
+		});
+
+		it("never includes the original matched value in detection records", () => {
+			const r = scanner.scan("ghp_abcdefghijklmnopqrstuvwxyz0123456789");
+			for (const d of r.detections) {
+				expect(d).toEqual({ kind: d.kind, count: d.count });
+				expect(JSON.stringify(d)).not.toContain("ghp_");
+			}
+		});
+	});
+});
+
+describe("mergeDetections", () => {
+	it("sums counts per kind across multiple lists", () => {
+		const merged = mergeDetections(
+			[
+				{ kind: "jwt", count: 1 },
+				{ kind: "github_pat_classic", count: 2 },
+			],
+			[{ kind: "jwt", count: 3 }],
+			[],
+		);
+		expect(merged.find((d) => d.kind === "jwt")?.count).toBe(4);
+		expect(merged.find((d) => d.kind === "github_pat_classic")?.count).toBe(2);
+	});
+});
+
+describe("DEFAULT_RULES", () => {
+	it("exposes a non-empty rule set", () => {
+		expect(DEFAULT_RULES.length).toBeGreaterThan(5);
+	});
+
+	it("every default rule is a global regex", () => {
+		for (const rule of DEFAULT_RULES) {
+			expect(rule.pattern.flags).toContain("g");
+		}
+	});
+});

--- a/packages/core/src/secret-scanner.ts
+++ b/packages/core/src/secret-scanner.ts
@@ -1,0 +1,297 @@
+/**
+ * Write-time secret scanner for the codemem store.
+ *
+ * Detects common secrets in memory write payloads (titles, bodies, narratives,
+ * structured fields, and free-form metadata) and replaces them with
+ * `[REDACTED:<kind>]` markers before persistence. There is no override flag:
+ * codemem has no legitimate use case for storing live secrets, so any escape
+ * hatch becomes the bypass that makes scanning theater.
+ *
+ * Scope of this foundation: the local-write chokepoint inside `MemoryStore.remember`.
+ * Other writers into `memory_items` (sync-replication apply, sync-bootstrap
+ * snapshot apply, AI/maintenance backfills of narrative/facts/concepts/tags)
+ * are NOT scanned by this module yet — they are addressed by dependent bd
+ * issues (codemem-hflk for sync-receive, codemem-tzrn for compaction/AI output,
+ * codemem-vb2s for retroactive sweep over already-stored content). Workspace-level
+ * rule overrides (codemem-ben8) and the test-fixture allowlist (codemem-jasn)
+ * plug in via `ScannerOptions` without changing this module's shape.
+ */
+
+export interface SecretRule {
+	/** Stable identifier surfaced in the redaction marker and detection log. */
+	kind: string;
+	/** Regex used to find candidate matches. Must be a global regex. */
+	pattern: RegExp;
+	/**
+	 * Optional minimum Shannon entropy (bits/char) the matched substring must
+	 * meet to be redacted. Filters out low-entropy false positives like
+	 * common words that happen to look like a secret.
+	 */
+	minEntropy?: number;
+	/**
+	 * If set, only the indicated capture group (1-based) is replaced. Useful
+	 * for context-aware rules where the match includes a known prefix that
+	 * should be preserved.
+	 */
+	redactGroup?: number;
+}
+
+export interface ScanDetection {
+	kind: string;
+	count: number;
+}
+
+export interface ScanResult {
+	redacted: string;
+	detections: ScanDetection[];
+}
+
+export interface ScannerOptions {
+	/** Additional rules merged with `DEFAULT_RULES`. */
+	rules?: SecretRule[];
+	/**
+	 * Strings or regexes that bypass redaction even when matched. NOTE: string
+	 * entries match by exact equality against the matched substring; regex
+	 * entries are tested with `RegExp.test()` (partial match by default; use
+	 * anchors for exact match).
+	 */
+	allowlist?: Array<string | RegExp>;
+}
+
+/** Field names whose string values should be treated as secret-bearing. */
+const SECRET_BEARING_KEY =
+	/^(?:secret|token|password|passwd|pwd|auth|bearer|credential|api[_-]?key|access[_-]?key|client[_-]?secret|private[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|bearer[_-]?token|api[_-]?token)$/i;
+
+/**
+ * Built-in default rules. Conservative: prefer well-known prefixes and
+ * structural patterns over raw entropy to keep the false-positive rate low.
+ *
+ * Rule precedence is order-dependent. More-specific rules MUST come before
+ * more-general ones — see the OpenAI rule, which uses a negative lookahead to
+ * avoid swallowing Anthropic keys regardless of order.
+ */
+export const DEFAULT_RULES: SecretRule[] = [
+	// AWS — both halves of an access key pair
+	{ kind: "aws_access_key_id", pattern: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g },
+	// AWS secret access key — 40 base64-ish chars; require entropy to filter FPs
+	{
+		kind: "aws_secret_access_key",
+		pattern: /(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])/g,
+		minEntropy: 4.5,
+	},
+
+	// GitHub token family
+	{ kind: "github_pat_classic", pattern: /\bghp_[A-Za-z0-9]{36}\b/g },
+	{ kind: "github_pat_finegrained", pattern: /\bgithub_pat_[A-Za-z0-9_]{82}\b/g },
+	{ kind: "github_oauth", pattern: /\bgho_[A-Za-z0-9]{36}\b/g },
+	{ kind: "github_user_token", pattern: /\bghu_[A-Za-z0-9]{36}\b/g },
+	{ kind: "github_server_token", pattern: /\bghs_[A-Za-z0-9]{36}\b/g },
+	{ kind: "github_refresh_token", pattern: /\bghr_[A-Za-z0-9]{36}\b/g },
+
+	// JWT — three base64url segments separated by dots, header begins with eyJ
+	{ kind: "jwt", pattern: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g },
+
+	// Common provider keys
+	{ kind: "google_api_key", pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g },
+	{ kind: "slack_token", pattern: /\bxox[abprs]-[A-Za-z0-9-]{10,}\b/g },
+	{ kind: "stripe_live_key", pattern: /\bsk_live_[0-9a-zA-Z]{24,}\b/g },
+	{ kind: "stripe_test_key", pattern: /\bsk_test_[0-9a-zA-Z]{24,}\b/g },
+	{ kind: "anthropic_api_key", pattern: /\bsk-ant-(?:api|admin)\d{2}-[A-Za-z0-9_-]{80,}\b/g },
+	// OpenAI keys: negative lookahead for `ant-` so Anthropic keys do not match here
+	// even if rule order changes. Entropy floor avoids false-positive on internal
+	// `sk-` prefixed identifiers that happen to be long enough.
+	{
+		kind: "openai_api_key",
+		pattern: /\bsk-(?!ant-)(?:proj-|svcacct-)?[A-Za-z0-9_-]{32,}\b/g,
+		minEntropy: 3.5,
+	},
+
+	// PEM-encoded private keys (RSA/EC/DSA/OpenSSH/PGP). Note: PGP MESSAGE
+	// blocks, SSH2 ENCRYPTED PRIVATE KEY, and PuTTY user-key files are NOT
+	// matched by this rule and remain a known gap (deferred backlog).
+	{
+		kind: "pem_private_key",
+		pattern:
+			/-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----[\s\S]+?-----END (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----/g,
+	},
+
+	// Context-aware generic secret: secret/token/password = "<value>"
+	// Only the captured value (group 1) is redacted; the prefix is preserved.
+	{
+		kind: "generic_assigned_secret",
+		pattern:
+			/\b(?:secret|token|password|passwd|pwd|auth|bearer|credential|api[_-]?key|access[_-]?key|client[_-]?secret|access[_-]?token|refresh[_-]?token|id[_-]?token|bearer[_-]?token|api[_-]?token)\s*[:=]\s*["']?([A-Za-z0-9+/=_.-]{20,})["']?/gi,
+		minEntropy: 3.5,
+		redactGroup: 1,
+	},
+];
+
+/** Shannon entropy in bits per character. */
+function shannonEntropy(text: string): number {
+	if (text.length === 0) return 0;
+	const freq = new Map<string, number>();
+	for (const ch of text) freq.set(ch, (freq.get(ch) ?? 0) + 1);
+	let h = 0;
+	for (const count of freq.values()) {
+		const p = count / text.length;
+		h -= p * Math.log2(p);
+	}
+	return h;
+}
+
+function ensureGlobal(re: RegExp): RegExp {
+	if (re.flags.includes("g")) return re;
+	return new RegExp(re.source, `${re.flags}g`);
+}
+
+function isAllowlisted(match: string, allowlist: Array<string | RegExp>): boolean {
+	for (const entry of allowlist) {
+		if (typeof entry === "string") {
+			if (entry === match) return true;
+		} else {
+			// `RegExp.test()` advances `lastIndex` on regexes with `g` or `y`
+			// flags, which would make repeated allowlist checks return
+			// alternating results. Reset before testing so the decision is
+			// stable across calls regardless of caller-supplied flags.
+			if (entry.global || entry.sticky) entry.lastIndex = 0;
+			if (entry.test(match)) return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Detect whether `value` is a "plain" object (`{}` literal or `Object.create(null)`),
+ * vs a class instance / built-in like Date, Map, Set, RegExp, Buffer, typed array.
+ * Plain objects are walked recursively; non-plain objects are returned as-is so
+ * we don't silently corrupt them by reconstructing as `{}`.
+ */
+function isPlainObject(value: object): boolean {
+	const proto = Object.getPrototypeOf(value);
+	return proto === null || proto === Object.prototype;
+}
+
+export class SecretScanner {
+	private readonly rules: SecretRule[];
+	private readonly allowlist: Array<string | RegExp>;
+
+	constructor(opts: ScannerOptions = {}) {
+		this.rules = [...DEFAULT_RULES, ...(opts.rules ?? [])];
+		this.allowlist = opts.allowlist ?? [];
+	}
+
+	/** Scan a single string. Returns the redacted form and per-kind detection counts. */
+	scan(text: string): ScanResult {
+		if (!text || typeof text !== "string") return { redacted: text, detections: [] };
+		let redacted = text;
+		const counts = new Map<string, number>();
+		for (const rule of this.rules) {
+			const re = ensureGlobal(rule.pattern);
+			redacted = redacted.replace(re, (...args) => {
+				// args = [match, ...groups, offset, fullString, groupsObj?]
+				const match = args[0] as string;
+				const target =
+					rule.redactGroup != null ? ((args[rule.redactGroup] as string | undefined) ?? "") : match;
+				if (!target) return match;
+				if (isAllowlisted(target, this.allowlist)) return match;
+				if (rule.minEntropy != null && shannonEntropy(target) < rule.minEntropy) return match;
+				counts.set(rule.kind, (counts.get(rule.kind) ?? 0) + 1);
+				const marker = `[REDACTED:${rule.kind}]`;
+				if (rule.redactGroup != null) {
+					return match.replace(target, marker);
+				}
+				return marker;
+			});
+		}
+		const detections = Array.from(counts.entries()).map(([kind, count]) => ({ kind, count }));
+		return { redacted, detections };
+	}
+
+	/**
+	 * Recursively walk a value, scanning every string. String values whose
+	 * containing key name matches a secret-bearing field are redacted whole if
+	 * non-trivial. Non-plain objects (Date, Map, Set, RegExp, Buffer, typed
+	 * arrays, class instances) are returned as-is to avoid silent corruption.
+	 * Cycles are detected via a `seen` set so misbehaving callers cannot
+	 * stack-overflow the scanner.
+	 */
+	redactValue(value: unknown, parentKey?: string): { value: unknown; detections: ScanDetection[] } {
+		return this.redactValueInternal(value, parentKey, new WeakSet());
+	}
+
+	private redactValueInternal(
+		value: unknown,
+		parentKey: string | undefined,
+		seen: WeakSet<object>,
+	): { value: unknown; detections: ScanDetection[] } {
+		if (typeof value === "string") {
+			if (parentKey && SECRET_BEARING_KEY.test(parentKey) && this.looksLikeSecretValue(value)) {
+				if (isAllowlisted(value, this.allowlist)) {
+					return { value, detections: [] };
+				}
+				return {
+					value: "[REDACTED:context_secret]",
+					detections: [{ kind: "context_secret", count: 1 }],
+				};
+			}
+			const result = this.scan(value);
+			return { value: result.redacted, detections: result.detections };
+		}
+		if (Array.isArray(value)) {
+			if (seen.has(value)) return { value, detections: [] };
+			seen.add(value);
+			const out: unknown[] = [];
+			const merged = new Map<string, number>();
+			for (const item of value) {
+				const r = this.redactValueInternal(item, parentKey, seen);
+				out.push(r.value);
+				for (const d of r.detections) merged.set(d.kind, (merged.get(d.kind) ?? 0) + d.count);
+			}
+			return { value: out, detections: aggregateMap(merged) };
+		}
+		if (value !== null && typeof value === "object") {
+			if (seen.has(value)) return { value, detections: [] };
+			if (!isPlainObject(value)) {
+				// Non-plain objects (Date, Map, Set, RegExp, Buffer, typed arrays,
+				// class instances) are returned unchanged. Walking them would
+				// silently strip prototype methods and corrupt state.
+				return { value, detections: [] };
+			}
+			seen.add(value);
+			const obj = value as Record<string, unknown>;
+			const out: Record<string, unknown> = {};
+			const merged = new Map<string, number>();
+			for (const [k, v] of Object.entries(obj)) {
+				const r = this.redactValueInternal(v, k, seen);
+				out[k] = r.value;
+				for (const d of r.detections) merged.set(d.kind, (merged.get(d.kind) ?? 0) + d.count);
+			}
+			return { value: out, detections: aggregateMap(merged) };
+		}
+		return { value, detections: [] };
+	}
+
+	private looksLikeSecretValue(text: string): boolean {
+		// Threshold of 8 chars filters obvious placeholders ("n/a", "true", short
+		// human values) while still catching anything long enough to plausibly
+		// be a secret. URL values get a free pass since auth callback URLs are
+		// commonly stored under "auth"-named keys.
+		if (text.length < 8) return false;
+		if (/^(?:https?|ftp|file):\/\//i.test(text)) return false;
+		if (/^(?:\[REDACTED:|<.*>|\{\{.*\}\}|null|undefined)$/i.test(text.trim())) return false;
+		return true;
+	}
+}
+
+function aggregateMap(map: Map<string, number>): ScanDetection[] {
+	return Array.from(map.entries()).map(([kind, count]) => ({ kind, count }));
+}
+
+/** Merge multiple detection lists into a single per-kind summary. */
+export function mergeDetections(...lists: ScanDetection[][]): ScanDetection[] {
+	const merged = new Map<string, number>();
+	for (const list of lists) {
+		for (const d of list) merged.set(d.kind, (merged.get(d.kind) ?? 0) + d.count);
+	}
+	return aggregateMap(merged);
+}

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -138,6 +138,67 @@ describe("MemoryStore", () => {
 			expect(row?.deleted_at).toBeNull();
 		});
 
+		it("redacts secrets in title, body, and metadata before persisting", () => {
+			const sessionId = insertTestSession(store.db);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const awsId = "AKIAIOSFODNN7EXAMPLE";
+			const memId = store.remember(
+				sessionId,
+				"discovery",
+				`Found token ${pat} in config`,
+				`Body has ${awsId} embedded`,
+				0.5,
+				undefined,
+				{ password: "supersecretvalue123", note: "harmless" },
+			);
+
+			const row = store.get(memId);
+			expect(row?.title).toContain("[REDACTED:github_pat_classic]");
+			expect(row?.title).not.toContain(pat);
+			expect(row?.body_text).toContain("[REDACTED:aws_access_key_id]");
+			expect(row?.body_text).not.toContain(awsId);
+			const meta = row?.metadata_json as Record<string, unknown>;
+			expect(meta.password).toBe("[REDACTED:context_secret]");
+			expect(meta.note).toBe("harmless");
+		});
+
+		it("redacts secrets in tags before persisting", () => {
+			const sessionId = insertTestSession(store.db);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const memId = store.remember(sessionId, "discovery", "Title", "Body", 0.5, ["safe-tag", pat]);
+			const row = store.get(memId);
+			expect(row?.tags_text).toContain("[REDACTED:github_pat_classic]");
+			expect(row?.tags_text).toContain("safe-tag");
+			expect(row?.tags_text).not.toContain(pat);
+		});
+
+		it("never persists original secrets to the replication_ops payload", () => {
+			const sessionId = insertTestSession(store.db);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const awsId = "AKIAIOSFODNN7EXAMPLE";
+			const memId = store.remember(
+				sessionId,
+				"discovery",
+				`title with ${pat}`,
+				`body with ${awsId}`,
+				0.5,
+				[pat],
+				{ password: "supersecretvalue123" },
+			);
+			expect(memId).toBeGreaterThan(0);
+
+			const ops = store.db
+				.prepare("SELECT payload_json FROM replication_ops WHERE entity_type = 'memory_item'")
+				.all() as Array<{ payload_json: string | null }>;
+			expect(ops.length).toBeGreaterThan(0);
+			for (const op of ops) {
+				const payload = op.payload_json ?? "";
+				expect(payload).not.toContain(pat);
+				expect(payload).not.toContain(awsId);
+				expect(payload).not.toContain("supersecretvalue123");
+			}
+		});
+
 		it("generates an import_key when not provided", () => {
 			const sessionId = insertTestSession(store.db);
 			const memId = store.remember(sessionId, "discovery", "Title", "Body");

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -47,6 +47,7 @@ import {
 	search as searchFn,
 	timeline as timelineFn,
 } from "./search.js";
+import { mergeDetections, type ScanDetection, SecretScanner } from "./secret-scanner.js";
 import { recordReplicationOp } from "./sync-replication.js";
 import type {
 	ExplainResponse,
@@ -204,6 +205,13 @@ export class MemoryStore {
 	readonly actorId: string;
 	readonly actorDisplayName: string;
 	readonly crossSessionDedupWindowMs: number;
+	/**
+	 * Per-store secret scanner. Lives on the instance (not as a module global)
+	 * so workspace-level rule overrides and allowlists can be wired without
+	 * coupling between stores in the same process. Mutable so tests and
+	 * follow-on issues (codemem-ben8, codemem-jasn) can swap it.
+	 */
+	scanner: SecretScanner;
 	private readonly pendingVectorWrites = new Set<Promise<void>>();
 
 	/** Lazy Drizzle ORM wrapper — shares the same better-sqlite3 connection. */
@@ -225,6 +233,7 @@ export class MemoryStore {
 			this.db.close();
 			throw err;
 		}
+		this.scanner = new SecretScanner();
 
 		// Resolve device ID: env var → sync_device table → stable "local" fallback.
 		// Python uses exactly this order and fallback.
@@ -551,9 +560,32 @@ export class MemoryStore {
 	): number {
 		const validKind = validateMemoryKind(kind);
 		const now = nowIso();
-		const tagsText = tags ? [...new Set(tags)].sort().join(" ") : "";
-		const metaPayload = { ...(metadata ?? {}) };
-		const dedupKey = buildMemoryDedupKey(title);
+
+		// Scan for secrets BEFORE any further processing. The redacted forms are
+		// what get deduped, embedded, and persisted; the originals never reach
+		// disk. There is no override flag — see secret-scanner.ts.
+		const scanner = this.scanner;
+		const titleScan = scanner.scan(title);
+		const bodyScan = scanner.scan(bodyText);
+		const safeTitle = titleScan.redacted;
+		const safeBody = bodyScan.redacted;
+
+		// Tags are written verbatim into tags_text and mirrored into the FTS
+		// index. Scan each one so a malformed caller can't use a tag as a
+		// scanner bypass.
+		const tagDetections: ScanDetection[] = [];
+		const safeTags = tags
+			? tags.map((t) => {
+					const r = scanner.scan(t);
+					tagDetections.push(...r.detections);
+					return r.redacted;
+				})
+			: undefined;
+		const tagsText = safeTags ? [...new Set(safeTags)].sort().join(" ") : "";
+
+		const metaScan = scanner.redactValue(metadata ?? {});
+		const metaPayload = { ...(metaScan.value as Record<string, unknown>) };
+		const dedupKey = buildMemoryDedupKey(safeTitle);
 
 		metaPayload.clock_device_id ??= this.deviceId;
 		const importKey = (metaPayload.import_key as string) || randomUUID();
@@ -579,13 +611,13 @@ export class MemoryStore {
 		const existingHit = this.findExistingDuplicateMemory(
 			sessionId,
 			validKind,
-			title,
+			safeTitle,
 			dedupKey,
 			provenance,
 			now,
 		);
 		if (existingHit != null) {
-			this.logDedupHit(existingHit, validKind, title);
+			this.logDedupHit(existingHit, validKind, safeTitle);
 			return existingHit.id;
 		}
 
@@ -600,9 +632,9 @@ export class MemoryStore {
 					.values({
 						session_id: sessionId,
 						kind: validKind,
-						title,
+						title: safeTitle,
 						subtitle,
-						body_text: bodyText,
+						body_text: safeBody,
 						confidence,
 						tags_text: tagsText,
 						active: 1,
@@ -651,21 +683,44 @@ export class MemoryStore {
 			const existingSameSessionHit = this.findExistingDuplicateMemory(
 				sessionId,
 				validKind,
-				title,
+				safeTitle,
 				dedupKey,
 				provenance,
 				now,
 			);
 			if (existingSameSessionHit != null) {
-				this.logDedupHit(existingSameSessionHit, validKind, title);
+				this.logDedupHit(existingSameSessionHit, validKind, safeTitle);
 				return existingSameSessionHit.id;
 			}
 			throw error;
 		}
 
-		this.enqueueVectorWrite(memoryId, title, bodyText);
+		this.enqueueVectorWrite(memoryId, safeTitle, safeBody);
+
+		const detections = mergeDetections(
+			titleScan.detections,
+			bodyScan.detections,
+			metaScan.detections,
+		);
+		if (detections.length > 0) {
+			this.logSecretRedactions(memoryId, validKind, detections);
+		}
 
 		return memoryId;
+	}
+
+	/**
+	 * Log secret-redaction events for observability. Records the kind and
+	 * count only — never the matched value. Gated on CODEMEM_DEBUG so normal
+	 * use stays quiet, but the call site always runs so test coverage and
+	 * future structured-logging hooks have a single chokepoint to grow into.
+	 */
+	private logSecretRedactions(memoryId: number, kind: string, detections: ScanDetection[]): void {
+		if (process.env[CODEMEM_DEBUG_ENV] !== "1") return;
+		const summary = detections.map((d) => `${d.kind}=${d.count}`).join(",");
+		process.stderr.write(
+			`[codemem] secret_scanner redacted memory_id=${memoryId} kind=${kind} detections=${summary}\n`,
+		);
 	}
 
 	// provenance resolution


### PR DESCRIPTION
## Description

Adds the write-time secret-scanner foundation that the rest of the stack (#989–#992) plugs into. Detects common secrets in memory write payloads (titles, bodies, narratives, structured fields, free-form metadata, tags) and replaces them with `[REDACTED:<kind>]` markers before persistence at the `MemoryStore.remember` chokepoint. Embeddings are derived only from post-redaction text and `replication_ops` payloads carry only redacted content.

Codemem has no legitimate use case for storing live secrets, so policy is strict redact with no override flag — any escape hatch becomes the bypass that makes scanning theater. `redactValue` recursively walks objects with non-plain-object guards (Date / Map / Set / RegExp / Buffer pass through unchanged) and cycle detection via `WeakSet`. The scanner instance lives on `MemoryStore` so workspace-config layers later in the stack plug in cleanly.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

Foundation tests cover every default rule (AWS / JWT / GitHub family / Slack / Google / Stripe / Anthropic / OpenAI / PEM / generic-context-secret), recursive object redaction, cycle and non-plain-object guards, rule precedence (Anthropic vs OpenAI), allowlist behavior including stateful-regex stability, tags scanned per-element, and a `replication_ops`-payload no-leak invariant.

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — JSDoc on the new module; no user-facing surface here, only internal infra
- [x] No new warnings introduced