### PR TITLE
feat(core): apply secret scanner to sync-receive payloads

### DIFF
--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -328,7 +328,10 @@ onceCmd.action(async (opts: { db?: string; dbPath?: string; peer?: string; json?
 			error?: string;
 		}> = [];
 		for (const row of rows) {
-			const result = await runSyncPass(store.db, row.peer_device_id, { keysDir });
+			const result = await runSyncPass(store.db, row.peer_device_id, {
+				keysDir,
+				scanner: store.scanner,
+			});
 			if (!result.ok) hadFailure = true;
 			results.push({
 				peer_device_id: row.peer_device_id,
@@ -1254,7 +1257,13 @@ bootstrapCmd.action(
 				pageSize,
 			});
 
-			const result = applyBootstrapSnapshot(store.db, peerDeviceId, items, resetInfo);
+			const result = applyBootstrapSnapshot(
+				store.db,
+				peerDeviceId,
+				items,
+				resetInfo,
+				store.scanner,
+			);
 
 			if (opts.json) {
 				console.log(

--- a/packages/core/src/secret-scanner.test.ts
+++ b/packages/core/src/secret-scanner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	DEFAULT_RULES,
 	mergeDetections,
+	redactMemoryFields,
 	type SecretRule,
 	SecretScanner,
 } from "./secret-scanner.js";
@@ -298,6 +299,57 @@ describe("mergeDetections", () => {
 		);
 		expect(merged.find((d) => d.kind === "jwt")?.count).toBe(4);
 		expect(merged.find((d) => d.kind === "github_pat_classic")?.count).toBe(2);
+	});
+});
+
+describe("redactMemoryFields", () => {
+	const scanner = new SecretScanner();
+
+	it("redacts string fields and array string entries in a memory payload shape", () => {
+		const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+		const awsId = "AKIAIOSFODNN7EXAMPLE";
+		const payload: Record<string, unknown> = {
+			title: `t ${pat}`,
+			subtitle: `s ${pat}`,
+			body_text: `b ${awsId}`,
+			narrative: `n ${pat}`,
+			tags_text: pat,
+			facts: [`fact ${pat}`, "clean"],
+			concepts: ["clean concept"],
+			metadata_json: { password: "supersecretvalue123", note: "harmless" },
+		};
+		const r = redactMemoryFields(payload, scanner);
+		expect(r.target.title).not.toContain(pat);
+		expect(r.target.subtitle).not.toContain(pat);
+		expect(r.target.body_text).not.toContain(awsId);
+		expect(r.target.narrative).not.toContain(pat);
+		expect(r.target.tags_text).not.toContain(pat);
+		expect((r.target.facts as string[])[0]).not.toContain(pat);
+		expect((r.target.facts as string[])[1]).toBe("clean");
+		expect((r.target.metadata_json as { password: string }).password).toBe(
+			"[REDACTED:context_secret]",
+		);
+		expect(r.detections.length).toBeGreaterThan(0);
+	});
+
+	it("ignores undefined and non-string optional fields without throwing", () => {
+		const payload = { other: "irrelevant" } as Record<string, unknown>;
+		expect(() => redactMemoryFields(payload, scanner)).not.toThrow();
+	});
+
+	it("redacts peer-supplied file path arrays", () => {
+		const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+		const payload: Record<string, unknown> = {
+			files_read: [`/tmp/${pat}.log`, "/clean/path"],
+			files_modified: [`relative/${pat}.txt`],
+		};
+		redactMemoryFields(payload, scanner);
+		const filesRead = payload.files_read as string[];
+		const filesModified = payload.files_modified as string[];
+		expect(filesRead[0]).not.toContain(pat);
+		expect(filesRead[0]).toContain("[REDACTED:github_pat_classic]");
+		expect(filesRead[1]).toBe("/clean/path");
+		expect(filesModified[0]).not.toContain(pat);
 	});
 });
 

--- a/packages/core/src/secret-scanner.ts
+++ b/packages/core/src/secret-scanner.ts
@@ -295,3 +295,100 @@ export function mergeDetections(...lists: ScanDetection[][]): ScanDetection[] {
 	}
 	return aggregateMap(merged);
 }
+
+/**
+ * Shape of a parsed inbound memory payload (sync-replication or sync-bootstrap).
+ * Any field that is `undefined` is left untouched. The struct is mutated in
+ * place by `redactMemoryFields` so callers can redact-then-insert without
+ * cloning.
+ */
+export interface MemoryFieldRedactionTarget {
+	title?: string | null;
+	subtitle?: string | null;
+	body_text?: string | null;
+	tags_text?: string | null;
+	narrative?: string | null;
+	facts?: unknown;
+	concepts?: unknown;
+	files_read?: unknown;
+	files_modified?: unknown;
+	metadata_json?: unknown;
+	/**
+	 * Peer-controlled identity strings persisted alongside content. They show
+	 * up in the viewer and exports verbatim, so a malicious peer could smuggle
+	 * a secret in a display name. Scanned for the same well-known patterns as
+	 * everything else; not subject to context_secret heuristics since they
+	 * legitimately contain free-form text.
+	 */
+	actor_display_name?: string | null;
+	origin_source?: string | null;
+}
+
+/**
+ * Redact secrets from a parsed inbound memory payload before persistence.
+ * Used by sync-receive (sync-replication.ts) and bootstrap-snapshot apply
+ * (sync-bootstrap.ts) so peer-shipped content goes through the same scanner
+ * as locally-authored writes. Mutates the target in place; returns the merged
+ * detection summary across all scanned fields.
+ */
+export function redactMemoryFields<T extends MemoryFieldRedactionTarget>(
+	target: T,
+	scanner: SecretScanner,
+): { target: T; detections: ScanDetection[] } {
+	const lists: ScanDetection[][] = [];
+
+	const scanStringField = (key: keyof MemoryFieldRedactionTarget): void => {
+		const value = (target as MemoryFieldRedactionTarget)[key];
+		if (typeof value === "string" && value.length > 0) {
+			const result = scanner.scan(value);
+			(target as MemoryFieldRedactionTarget)[key] = result.redacted;
+			lists.push(result.detections);
+		}
+	};
+	scanStringField("title");
+	scanStringField("subtitle");
+	scanStringField("body_text");
+	scanStringField("narrative");
+	scanStringField("actor_display_name");
+	scanStringField("origin_source");
+
+	// tags_text is a whitespace-joined string here. Local writes scan each tag
+	// individually before joining (store.ts), so to keep behavior consistent
+	// when peer payloads arrive pre-joined we split, scan-per-tag, and rejoin.
+	const rawTagsText = (target as MemoryFieldRedactionTarget).tags_text;
+	if (typeof rawTagsText === "string" && rawTagsText.length > 0) {
+		const parts = rawTagsText.split(/\s+/).filter(Boolean);
+		const scannedParts: string[] = [];
+		for (const part of parts) {
+			const result = scanner.scan(part);
+			scannedParts.push(result.redacted);
+			lists.push(result.detections);
+		}
+		(target as MemoryFieldRedactionTarget).tags_text = scannedParts.join(" ");
+	}
+
+	for (const key of ["facts", "concepts", "files_read", "files_modified"] as const) {
+		const value = (target as MemoryFieldRedactionTarget)[key];
+		if (Array.isArray(value)) {
+			const next: unknown[] = [];
+			for (const item of value) {
+				if (typeof item === "string") {
+					const result = scanner.scan(item);
+					next.push(result.redacted);
+					lists.push(result.detections);
+				} else {
+					next.push(item);
+				}
+			}
+			(target as MemoryFieldRedactionTarget)[key] = next;
+		}
+	}
+
+	if (target.metadata_json && typeof target.metadata_json === "object") {
+		const result = scanner.redactValue(target.metadata_json);
+		target.metadata_json = result.value;
+		lists.push(result.detections);
+	}
+
+	return { target, detections: mergeDetections(...lists) };
+}

--- a/packages/core/src/sync-bootstrap.test.ts
+++ b/packages/core/src/sync-bootstrap.test.ts
@@ -184,6 +184,44 @@ describe("applyBootstrapSnapshot", () => {
 		});
 	});
 
+	it("redacts secrets in inbound bootstrap snapshot items", () => {
+		const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+		const awsId = "AKIAIOSFODNN7EXAMPLE";
+		const items = [
+			makeSnapshotItem("secret-key", {
+				payload: {
+					title: `peer title ${pat}`,
+					body_text: `peer body ${awsId}`,
+					narrative: `peer narrative ${pat}`,
+					tags_text: pat,
+					metadata_json: { clock_device_id: "peer-dev", password: "supersecretvalue123" },
+				},
+			}),
+		];
+		const result = applyBootstrapSnapshot(db, "peer-1", items, makeResetInfo());
+		expect(result.ok).toBe(true);
+		expect(result.applied).toBe(1);
+		const mem = db
+			.prepare(
+				"SELECT title, body_text, narrative, tags_text, metadata_json FROM memory_items WHERE import_key = 'secret-key'",
+			)
+			.get() as {
+			title: string;
+			body_text: string;
+			narrative: string | null;
+			tags_text: string | null;
+			metadata_json: string | null;
+		};
+		expect(mem.title).not.toContain(pat);
+		expect(mem.title).toContain("[REDACTED:github_pat_classic]");
+		expect(mem.body_text).not.toContain(awsId);
+		expect(mem.body_text).toContain("[REDACTED:aws_access_key_id]");
+		expect(mem.narrative).not.toContain(pat);
+		expect(mem.tags_text ?? "").not.toContain(pat);
+		const meta = JSON.parse(mem.metadata_json ?? "{}");
+		expect(meta.password).toBe("[REDACTED:context_secret]");
+	});
+
 	it("applies empty snapshot (wipes shared, inserts nothing)", () => {
 		const now = new Date().toISOString();
 		db.prepare(

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -15,6 +15,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import { toJson } from "./db.js";
 import * as schema from "./schema.js";
+import { redactMemoryFields, SecretScanner } from "./secret-scanner.js";
 import { buildAuthHeaders } from "./sync-auth.js";
 import { requestJson } from "./sync-http-client.js";
 import { setReplicationCursor, setSyncResetState } from "./sync-replication.js";
@@ -222,8 +223,14 @@ export function applyBootstrapSnapshot(
 	peerDeviceId: string,
 	items: SyncMemorySnapshotItem[],
 	resetInfo: SyncResetRequired,
+	scanner?: SecretScanner,
 ): BootstrapResult {
 	const result: BootstrapResult = { ok: false, applied: 0, deleted: 0 };
+	// Bootstrap items are peer-authored content. Run them through the same
+	// scanner as locally-authored writes; without this, a single bootstrap
+	// from a misbehaving peer could re-populate the local store with secrets
+	// the peer emitted before they ran scanner-aware versions.
+	const activeScanner = scanner ?? new SecretScanner();
 
 	db.transaction(() => {
 		const d = drizzle(db, { schema });
@@ -253,6 +260,7 @@ export function applyBootstrapSnapshot(
 		for (const item of items) {
 			const payload = parseSnapshotPayload(item);
 			if (!payload) continue;
+			redactMemoryFields(payload, activeScanner);
 			const project =
 				typeof payload.project === "string" && payload.project.trim()
 					? payload.project.trim()

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -18,6 +18,7 @@ import {
 import type { Database } from "./db.js";
 import { connect as connectDb, resolveDbPath } from "./db.js";
 import * as schema from "./schema.js";
+import type { SecretScanner } from "./secret-scanner.js";
 import { advertiseMdns, mdnsEnabled } from "./sync-discovery.js";
 import { ensureDeviceIdentity } from "./sync-identity.js";
 import { runSyncPass, shouldSkipOfflinePeer, syncPassPreflight } from "./sync-pass.js";
@@ -146,6 +147,7 @@ export async function syncDaemonTick(
 	db: Database,
 	keysDir?: string,
 	stalePeers?: Set<string>,
+	scanner?: SecretScanner,
 ): Promise<SyncTickResult[]> {
 	const d = drizzle(db, { schema });
 	const rows = d
@@ -181,7 +183,11 @@ export async function syncDaemonTick(
 			continue;
 		}
 
-		const result = await runSyncPass(db, peerDeviceId, { keysDir, limit: opsLimit });
+		const result = await runSyncPass(db, peerDeviceId, {
+			keysDir,
+			limit: opsLimit,
+			scanner,
+		});
 		results.push({
 			ok: result.ok,
 			error: result.error,

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -10,6 +10,7 @@ import { and, desc, eq, gt, or } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import type { Database } from "./db.js";
 import * as schema from "./schema.js";
+import type { SecretScanner } from "./secret-scanner.js";
 import { buildAuthHeaders } from "./sync-auth.js";
 import { applyBootstrapSnapshot, fetchAllSnapshotPages } from "./sync-bootstrap.js";
 import { recordPeerSuccess } from "./sync-discovery.js";
@@ -37,6 +38,13 @@ import { bestEffortMaintainVectorsForSyncFallback } from "./vectors.js";
 
 /** Default max body size for sync POST requests (1 MiB). */
 const MAX_SYNC_BODY_BYTES = 1_048_576;
+
+/**
+ * One-shot warning latch so sync-apply paths log a single line per process if
+ * a caller forgot to thread the scanner through. Workspace-level rule overrides
+ * silently fail to apply to peer-shipped content otherwise.
+ */
+let syncOnceScannerWarned = false;
 
 /**
  * Default op fetch/push limit per round.
@@ -70,6 +78,13 @@ export interface SyncResult {
 export interface SyncPassOptions {
 	limit?: number;
 	keysDir?: string;
+	/**
+	 * Secret scanner used to redact peer-shipped content on apply. Callers that
+	 * own a `MemoryStore` should pass `store.scanner` so workspace-level rule
+	 * overrides apply uniformly to local writes and sync-receive. Omitting it
+	 * falls back to default rules only and prints a one-time warning.
+	 */
+	scanner?: SecretScanner;
 }
 
 // ---------------------------------------------------------------------------
@@ -331,6 +346,13 @@ export async function syncOnce(
 ): Promise<SyncResult> {
 	const limit = options?.limit ?? DEFAULT_LIMIT;
 	const keysDir = options?.keysDir;
+	const scanner = options?.scanner;
+	if (!scanner && !syncOnceScannerWarned) {
+		syncOnceScannerWarned = true;
+		process.stderr.write(
+			"[codemem] sync apply running without explicit scanner — workspace-level secret rules will not apply to inbound peer content\n",
+		);
+	}
 
 	// Look up pinned fingerprint
 	const d = drizzle(db, { schema });
@@ -449,7 +471,13 @@ export async function syncOnce(
 								addressErrors: [],
 							};
 						}
-						const bootstrapResult = applyBootstrapSnapshot(db, peerDeviceId, items, resetInfo);
+						const bootstrapResult = applyBootstrapSnapshot(
+							db,
+							peerDeviceId,
+							items,
+							resetInfo,
+							scanner,
+						);
 						if (!bootstrapResult.ok) {
 							throw new Error("initial bootstrap apply failed");
 						}
@@ -560,7 +588,13 @@ export async function syncOnce(
 						};
 					}
 
-					const bootstrapResult = applyBootstrapSnapshot(db, peerDeviceId, items, resetRequired);
+					const bootstrapResult = applyBootstrapSnapshot(
+						db,
+						peerDeviceId,
+						items,
+						resetRequired,
+						scanner,
+					);
 					if (!bootstrapResult.ok) {
 						throw new Error("bootstrap apply failed");
 					}
@@ -610,7 +644,7 @@ export async function syncOnce(
 			);
 
 			// -- 3. Apply incoming ops to local entities --
-			const applied = applyReplicationOps(db, inboundOps, deviceId);
+			const applied = applyReplicationOps(db, inboundOps, deviceId, scanner);
 			try {
 				queueVectorBackfillForIncrementalSync(db, applied.vectorWork);
 			} catch (queueError) {

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toJson } from "./db.js";
+import { SecretScanner } from "./secret-scanner.js";
 import {
 	applyReplicationOps,
 	backfillReplicationOps,
@@ -1594,6 +1595,117 @@ describe("applyReplicationOps", () => {
 		expect(mem.rev).toBe(1);
 		expect(result.vectorWork.upsertMemoryIds).toEqual([Number(mem.id)]);
 		expect(result.vectorWork.deleteMemoryIds).toEqual([]);
+	});
+
+	it("redacts secrets in inbound peer payloads on insert", () => {
+		const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+		const awsId = "AKIAIOSFODNN7EXAMPLE";
+		const op = makeReplicationOp({
+			payload_json: toJson({
+				kind: "discovery",
+				title: `peer title ${pat}`,
+				body_text: `peer body ${awsId}`,
+				narrative: `peer narrative ${pat}`,
+				tags_text: pat,
+				facts: [`fact contains ${pat}`],
+				concepts: ["clean"],
+				metadata_json: { password: "supersecretvalue123", note: "harmless" },
+			}),
+		});
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+		const mem = db
+			.prepare(
+				"SELECT title, body_text, narrative, tags_text, facts, metadata_json FROM memory_items WHERE import_key = ?",
+			)
+			.get("key:test-1") as {
+			title: string;
+			body_text: string;
+			narrative: string | null;
+			tags_text: string | null;
+			facts: string | null;
+			metadata_json: string | null;
+		};
+		expect(mem.title).not.toContain(pat);
+		expect(mem.title).toContain("[REDACTED:github_pat_classic]");
+		expect(mem.body_text).not.toContain(awsId);
+		expect(mem.body_text).toContain("[REDACTED:aws_access_key_id]");
+		expect(mem.narrative).not.toContain(pat);
+		expect(mem.tags_text ?? "").not.toContain(pat);
+		expect(mem.facts ?? "").not.toContain(pat);
+		const meta = JSON.parse(mem.metadata_json ?? "{}");
+		expect(meta.password).toBe("[REDACTED:context_secret]");
+		expect(meta.note).toBe("harmless");
+	});
+
+	it("applies a custom scanner's extra rules to inbound peer payloads", () => {
+		const op = makeReplicationOp({
+			payload_json: toJson({
+				kind: "discovery",
+				title: "internal token ACME-XYZ12 in title",
+				body_text: "ACME-XYZ12 in body",
+			}),
+		});
+		const customScanner = new SecretScanner({
+			rules: [{ kind: "internal_acme_token", pattern: /\bACME-[A-Z0-9]{5}\b/g }],
+		});
+		const result = applyReplicationOps(db, [op], "dev-local", customScanner);
+		expect(result.applied).toBe(1);
+		const mem = db
+			.prepare("SELECT title, body_text FROM memory_items WHERE import_key = ?")
+			.get("key:test-1") as { title: string; body_text: string };
+		expect(mem.title).toContain("[REDACTED:internal_acme_token]");
+		expect(mem.title).not.toContain("ACME-XYZ12");
+		expect(mem.body_text).toContain("[REDACTED:internal_acme_token]");
+	});
+
+	it("redacts peer-controlled actor_display_name and origin_source", () => {
+		const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+		const op = makeReplicationOp({
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Title",
+				body_text: "Body",
+				actor_display_name: `Peer ${pat}`,
+				origin_source: `tool ${pat}`,
+			}),
+		});
+		const result = applyReplicationOps(db, [op], "dev-local");
+		expect(result.applied).toBe(1);
+		const mem = db
+			.prepare("SELECT actor_display_name, origin_source FROM memory_items WHERE import_key = ?")
+			.get("key:test-1") as { actor_display_name: string | null; origin_source: string | null };
+		expect(mem.actor_display_name ?? "").not.toContain(pat);
+		expect(mem.actor_display_name ?? "").toContain("[REDACTED:github_pat_classic]");
+		expect(mem.origin_source ?? "").not.toContain(pat);
+	});
+
+	it("redacts secrets in inbound peer payloads on update of existing row", () => {
+		// Insert a baseline row
+		const baselineOp = makeReplicationOp({ op_id: "op-baseline" });
+		applyReplicationOps(db, [baselineOp], "dev-local");
+
+		// Replicate an update that contains a secret
+		const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+		const updateOp = makeReplicationOp({
+			op_id: "op-update",
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			payload_json: toJson({
+				kind: "discovery",
+				title: `updated ${pat}`,
+				body_text: `updated body ${pat}`,
+				updated_at: "2026-01-02T00:00:00Z",
+			}),
+		});
+		const result = applyReplicationOps(db, [updateOp], "dev-local");
+		expect(result.applied).toBe(1);
+		const mem = db
+			.prepare("SELECT title, body_text FROM memory_items WHERE import_key = ?")
+			.get("key:test-1") as { title: string; body_text: string };
+		expect(mem.title).not.toContain(pat);
+		expect(mem.title).toContain("[REDACTED:github_pat_classic]");
+		expect(mem.body_text).not.toContain(pat);
 	});
 
 	it("populates ref tables when inserting a new memory with files and concepts", () => {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -17,6 +17,7 @@ import { readCodememConfigFile } from "./observer-config.js";
 import { projectBasename } from "./project.js";
 import { clearMemoryRefs, populateMemoryRefs } from "./ref-populate.js";
 import * as schema from "./schema.js";
+import { redactMemoryFields, SecretScanner } from "./secret-scanner.js";
 import { deriveTags } from "./tags.js";
 import type {
 	ReplicationOp,
@@ -1754,8 +1755,14 @@ export function applyReplicationOps(
 	db: Database,
 	ops: ReplicationOp[],
 	localDeviceId: string,
+	scanner?: SecretScanner,
 ): ApplyResult {
 	const d = drizzle(db, { schema });
+	// Peer-shipped content goes through the same redaction policy as
+	// locally-authored writes. Callers that maintain their own scanner
+	// (typically a MemoryStore instance) should pass it so workspace-level
+	// rule overrides apply uniformly. Otherwise fall back to defaults.
+	const activeScanner = scanner ?? new SecretScanner();
 	const result: ApplyResult = {
 		applied: 0,
 		skipped: 0,
@@ -1832,6 +1839,7 @@ export function applyReplicationOps(
 						// Update existing row from payload — skip if malformed
 						const payload = parseMemoryPayload(op, result.errors);
 						if (!payload) continue;
+						redactMemoryFields(payload, activeScanner);
 						const metaObj = mergePayloadMetadata(payload.metadata_json, op.clock_device_id);
 						const nextTitle = resolveReplicatedTextUpdate(payload.title, memRow.title);
 						const nextBodyText = resolveReplicatedTextUpdate(payload.body_text, memRow.body_text);
@@ -1896,6 +1904,7 @@ export function applyReplicationOps(
 						// Insert new memory item — skip if malformed
 						const payload = parseMemoryPayload(op, result.errors);
 						if (!payload) continue;
+						redactMemoryFields(payload, activeScanner);
 						const replicatedProject =
 							typeof payload.project === "string" && payload.project.trim()
 								? payload.project.trim()

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1373,7 +1373,12 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		const [localDeviceId] = ensureDeviceIdentity(store.db, { keysDir: syncKeysDir() });
 
 		const filteredInbound = filterOpsForPeer(store, peerDeviceId, normalizedOps);
-		const result = applyReplicationOps(store.db, filteredInbound.allowed, localDeviceId);
+		const result = applyReplicationOps(
+			store.db,
+			filteredInbound.allowed,
+			localDeviceId,
+			store.scanner,
+		);
 		return c.json({
 			...result,
 			skipped: result.skipped + filteredInbound.skipped,
@@ -1885,7 +1890,7 @@ export function syncRoutes(
 		}
 		const items = [] as Array<Record<string, unknown>>;
 		for (const peerId of peerIds) {
-			const result = await runSyncPass(store.db, peerId);
+			const result = await runSyncPass(store.db, peerId, { scanner: store.scanner });
 			items.push({ peer_device_id: peerId, ...result });
 		}
 		return c.json({ items });


### PR DESCRIPTION
## Description

Wires the foundation scanner (#988) into both inbound sync paths so peer-shipped content is redacted before persistence. Without receive-side scanning, a peer running an older version (or no scanner at all) is a clean bypass.

`redactMemoryFields` mutates parsed inbound memory payloads (title / subtitle / body_text / narrative / tags_text / facts / concepts / files_read / files_modified / metadata_json / actor_display_name / origin_source) in place. `applyReplicationOps` and `applyBootstrapSnapshot` accept an optional `SecretScanner` and call the helper after their parser. `SyncPassOptions.scanner` is threaded through `runSyncPass` + `syncOnce` + `syncDaemonTick`, and the CLI bootstrap caller plus viewer-server sync route pass `store.scanner`. A one-time stderr warning fires when sync runs without an explicit scanner so workspace-rule gaps are visible instead of silent.

`tags_text` is split-scan-rejoin to match the per-tag scan semantics local writes use in `MemoryStore.remember`.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

Tests cover redact-on-insert and redact-on-update via `applyReplicationOps`, custom-scanner-rules-apply through the receive path, peer-controlled identity field redaction (actor_display_name, origin_source), peer-supplied file path arrays, and bootstrap-snapshot redaction.

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — JSDoc on `redactMemoryFields` and `SyncPassOptions.scanner`
- [x] No new warnings introduced