### PR TITLE
feat(core): scan AI/maintenance writers for secrets

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -534,6 +534,7 @@ backfillTagsCmd.action(
 				project,
 				activeOnly: !opts.inactive,
 				dryRun: opts.dryRun === true,
+				scanner: store.scanner,
 			});
 
 			if (opts.json) {
@@ -761,6 +762,7 @@ backfillNarrativeCmd.action(
 			const result = backfillNarrativeFromBody(store.db, {
 				limit,
 				dryRun: opts.dryRun === true,
+				scanner: store.scanner,
 			});
 
 			if (opts.json) {
@@ -816,6 +818,7 @@ aiBackfillStructuredCmd.action(
 				kinds,
 				overwrite: opts.overwrite === true,
 				dryRun: opts.dryRun === true,
+				scanner: store.scanner,
 			});
 
 			if (opts.json) {

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -1437,6 +1437,48 @@ describe("aiBackfillStructuredContent", () => {
 		}
 	});
 
+	it("redacts secrets in AI-generated narrative, facts, and concepts before persisting", async () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const id = seedMemory(
+				db,
+				sessionId,
+				"change",
+				"Memory with secret-shaped AI output",
+				"Original body.",
+			);
+
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const observer = makeObserver(
+				JSON.stringify({
+					narrative: `AI summary mentions ${pat} verbatim.`,
+					facts: [`fact A references ${pat}`, "harmless fact"],
+					concepts: ["what-changed"],
+				}),
+			);
+
+			const result = await aiBackfillStructuredContent(db, { observer });
+			expect(result).toMatchObject({ updated: 1 });
+
+			const row = db.prepare("SELECT narrative, facts FROM memory_items WHERE id = ?").get(id) as {
+				narrative: string | null;
+				facts: string | null;
+			};
+			expect(row.narrative ?? "").not.toContain(pat);
+			expect(row.narrative ?? "").toContain("[REDACTED:github_pat_classic]");
+			expect(row.facts ?? "").not.toContain(pat);
+			expect(row.facts ?? "").toContain("[REDACTED:github_pat_classic]");
+		} finally {
+			db.close();
+		}
+	});
+
 	it("preserves existing structured fields by default", async () => {
 		const db = new Database(":memory:");
 		try {

--- a/packages/core/src/maintenance/ai-structured.ts
+++ b/packages/core/src/maintenance/ai-structured.ts
@@ -9,6 +9,7 @@ import {
 	updateMaintenanceJob,
 } from "../maintenance-jobs.js";
 import { loadObserverConfig, ObserverClient } from "../observer-client.js";
+import { SecretScanner } from "../secret-scanner.js";
 import { isSummaryLikeMemory } from "../summary-memory.js";
 
 const AI_BACKFILL_KINDS = [
@@ -71,6 +72,13 @@ export interface AIBackfillStructuredContentOptions {
 	dryRun?: boolean;
 	overwrite?: boolean;
 	observer?: StructuredBackfillObserver;
+	/**
+	 * Secret scanner used to redact AI-generated narrative/facts/concepts
+	 * before they are written back to memory_items. The summarizer can launder
+	 * a secret past pattern-based detection on the source or invent new
+	 * secret-shaped strings, so output must be re-scanned independent of input.
+	 */
+	scanner?: SecretScanner;
 }
 
 interface ParsedStructuredBackfill {
@@ -289,6 +297,7 @@ export async function aiBackfillStructuredContent(
 	);
 
 	const observer = opts.observer ?? createStructuredBackfillObserver();
+	const scanner = opts.scanner ?? new SecretScanner();
 	const total = eligibleRows.length;
 	startMaintenanceJob(db, {
 		kind: AI_BACKFILL_JOB_KIND,
@@ -337,6 +346,16 @@ export async function aiBackfillStructuredContent(
 					response.usedStructuredOutputs && response.parsed
 						? parseStructuredBackfillResponse(JSON.stringify(response.parsed))
 						: parseStructuredBackfillResponse(response.raw);
+
+				// Redact AI output before adoption. Source content was already
+				// scanned at write time, but the model can paraphrase past pattern
+				// detection or invent secret-shaped strings, so output is its own
+				// scan surface.
+				if (parsed.narrative != null) {
+					parsed.narrative = scanner.scan(parsed.narrative).redacted;
+				}
+				parsed.facts = parsed.facts.map((f) => scanner.scan(f).redacted);
+				parsed.concepts = parsed.concepts.map((c) => scanner.scan(c).redacted);
 
 				const nextNarrative =
 					row.narrative?.trim() && !opts.overwrite ? row.narrative : parsed.narrative;

--- a/packages/core/src/maintenance/backfill-narrative.ts
+++ b/packages/core/src/maintenance/backfill-narrative.ts
@@ -2,6 +2,7 @@
  */
 
 import type { Database } from "../db.js";
+import { SecretScanner } from "../secret-scanner.js";
 import { extractNarrativeFromBody } from "./narrative-extract.js";
 
 export interface BackfillNarrativeResult {
@@ -13,6 +14,12 @@ export interface BackfillNarrativeResult {
 export interface BackfillNarrativeOptions {
 	limit?: number | null;
 	dryRun?: boolean;
+	/**
+	 * Secret scanner used to redact extracted narrative before persistence.
+	 * Source body_text on legacy rows pre-dates the scanner, so the extracted
+	 * narrative cannot be assumed redaction-derivative.
+	 */
+	scanner?: SecretScanner;
 }
 
 /**
@@ -41,6 +48,7 @@ export function backfillNarrativeFromBody(
 		)
 		.all() as Array<{ id: number; body_text: string }>;
 
+	const scanner = opts.scanner ?? new SecretScanner();
 	let checked = 0;
 	let updated = 0;
 	let skipped = 0;
@@ -48,11 +56,12 @@ export function backfillNarrativeFromBody(
 
 	for (const row of rows) {
 		checked++;
-		const narrative = extractNarrativeFromBody(row.body_text);
-		if (!narrative) {
+		const extracted = extractNarrativeFromBody(row.body_text);
+		if (!extracted) {
 			skipped++;
 			continue;
 		}
+		const narrative = scanner.scan(extracted).redacted;
 		updates.push({ id: row.id, narrative });
 		updated++;
 	}

--- a/packages/core/src/maintenance/backfill-tags.ts
+++ b/packages/core/src/maintenance/backfill-tags.ts
@@ -3,6 +3,7 @@
 
 import type { Database } from "../db.js";
 import { projectClause } from "../project.js";
+import { SecretScanner } from "../secret-scanner.js";
 import { deriveTags, parseJsonStringList } from "./tag-helpers.js";
 
 export interface BackfillTagsTextOptions {
@@ -12,6 +13,16 @@ export interface BackfillTagsTextOptions {
 	activeOnly?: boolean;
 	dryRun?: boolean;
 	memoryIds?: number[] | null;
+	/**
+	 * Secret scanner used to redact derived tag values before persistence.
+	 * Tags derive from kind/title/concepts/files which are persisted columns —
+	 * but legacy rows pre-date the scanner so we cannot trust those columns to
+	 * be redacted-derivative. Caveat: `deriveTags` lowercases tags before this
+	 * scan runs, so case-sensitive rules (AWS AKIA*, Google AIza*, JWT eyJ*)
+	 * won't fire on legacy-derived tags. Catching the long tail there is the
+	 * job of the retroactive sweep (codemem-vb2s).
+	 */
+	scanner?: SecretScanner;
 }
 
 export interface BackfillTagsTextResult {
@@ -78,6 +89,7 @@ export function backfillTagsText(
 		files_modified: string | null;
 	}>;
 
+	const scanner = opts.scanner ?? new SecretScanner();
 	let checked = 0;
 	let updated = 0;
 	let skipped = 0;
@@ -96,7 +108,8 @@ export function backfillTagsText(
 			filesRead: parseJsonStringList(row.files_read),
 			filesModified: parseJsonStringList(row.files_modified),
 		});
-		const tagsText = tags.join(" ");
+		const safeTags = tags.map((t) => scanner.scan(t).redacted);
+		const tagsText = safeTags.join(" ");
 		if (!tagsText) {
 			skipped += 1;
 			continue;


### PR DESCRIPTION
## Description

Three direct `memory_items` writers bypassed `MemoryStore.remember` and therefore the foundation scanner: `aiBackfillStructuredContent` (writes AI-generated narrative / facts / concepts), `backfillNarrativeFromBody` (extracts narrative from body_text), and `backfillTagsText` (derives tags from kind / title / concepts / files). Each now accepts an optional `SecretScanner` and redacts derived output before persistence.

The summarization-output goal of this work is satisfied transitively: session_summary writes flow through `store.remember` in `ingest-pipeline.ts`, which is already scanned by the foundation in #988. Confirmed `summary-memory.ts` and `raw-event-flush.ts` contain no direct `memory_items` writes.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

`maintenance.test.ts` adds a test that mocks the AI observer to return narrative + facts containing a GitHub PAT and asserts both columns persist as `[REDACTED:github_pat_classic]`. The narrative-extract and tags-derive paths inherit the scanner via the same shared `MemoryStore.scanner` instance.

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — JSDoc notes on the new `scanner` option in each maintenance writer; backfill-tags caveats `deriveTags`'s lowercase normalization vs case-sensitive default rules
- [x] No new warnings introduced