### PR TITLE
feat(cli): add db scan-secrets retroactive sweep

### DIFF
--- a/packages/cli/src/commands/db.ts
+++ b/packages/cli/src/commands/db.ts
@@ -18,6 +18,7 @@ import {
 	resolveDbPath,
 	resolveProject,
 	retryRawEventFailures,
+	scanSecretsRetroactive,
 	vacuumDatabase,
 } from "@codemem/core";
 import { Command } from "commander";
@@ -841,3 +842,54 @@ aiBackfillStructuredCmd.action(
 	},
 );
 dbCommand.addCommand(aiBackfillStructuredCmd);
+
+// --- db scan-secrets ---
+const scanSecretsCmd = new Command("scan-secrets")
+	.configureHelp(helpStyle)
+	.description("Sweep existing memories and redact any secrets found in stored content")
+	.option("--limit <n>", "max memories to scan in this run")
+	.option("--dry-run", "report detections without rewriting any rows");
+addDbOption(scanSecretsCmd);
+addJsonOption(scanSecretsCmd);
+scanSecretsCmd.action(
+	(
+		opts: DbOpts &
+			JsonOpts & {
+				limit?: string;
+				dryRun?: boolean;
+			},
+	) => {
+		const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
+		try {
+			const limit = parseOptionalPositiveInt(opts.limit);
+			const result = scanSecretsRetroactive(store.db, {
+				limit,
+				dryRun: opts.dryRun === true,
+				scanner: store.scanner,
+			});
+
+			if (opts.json) {
+				console.log(JSON.stringify(result, null, 2));
+				return;
+			}
+
+			const action = opts.dryRun ? "Would redact" : "Redacted";
+			p.intro("codemem db scan-secrets");
+			p.log.success(`${action} ${result.updated} of ${result.checked} memories`);
+			if (result.skippedOversized > 0) {
+				p.log.warn(`Skipped ${result.skippedOversized} oversized rows (above default 1 MiB cap)`);
+			}
+			if (result.detections.length > 0) {
+				const summary = result.detections.map((d) => `${d.kind}=${d.count}`).join(", ");
+				p.log.info(`Detections: ${summary}`);
+			}
+			p.outro("Re-run with no changes to confirm idempotency");
+		} catch (error) {
+			p.log.error(error instanceof Error ? error.message : String(error));
+			process.exitCode = 1;
+		} finally {
+			store.close();
+		}
+	},
+);
+dbCommand.addCommand(scanSecretsCmd);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -267,6 +267,7 @@ export {
 	initDatabase,
 	rawEventsGate,
 	retryRawEventFailures,
+	scanSecretsRetroactive,
 	vacuumDatabase,
 } from "./maintenance.js";
 export type {

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -21,6 +21,7 @@ import {
 	getReliabilityMetrics,
 	initDatabase,
 	retryRawEventFailures,
+	scanSecretsRetroactive,
 	vacuumDatabase,
 } from "./maintenance.js";
 import { getMaintenanceJob } from "./maintenance-jobs.js";
@@ -1714,6 +1715,348 @@ describe("aiBackfillStructuredContent", () => {
 			expect(row.narrative).toBeNull();
 			expect(row.facts).toBeNull();
 			expect(row.concepts).toBeNull();
+		} finally {
+			db.close();
+		}
+	});
+});
+
+describe("scanSecretsRetroactive", () => {
+	function seedLegacyRow(
+		db: Database,
+		sessionId: number,
+		title: string,
+		body: string,
+		extras: Partial<{
+			subtitle: string;
+			narrative: string;
+			tags_text: string;
+			facts: string;
+			concepts: string;
+			metadata_json: string;
+		}> = {},
+	): number {
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, subtitle, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+				 narrative, facts, concepts)
+				 VALUES (?, ?, ?, ?, ?, 0.5, ?, 1, ?, ?, ?, 1, 'shared', ?, ?, ?)`,
+			)
+			.run(
+				sessionId,
+				"discovery",
+				title,
+				extras.subtitle ?? null,
+				body,
+				extras.tags_text ?? "",
+				now,
+				now,
+				extras.metadata_json ?? "{}",
+				extras.narrative ?? null,
+				extras.facts ?? null,
+				extras.concepts ?? null,
+			);
+		return Number(info.lastInsertRowid);
+	}
+
+	it("redacts legacy unredacted memories in place", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const awsId = "AKIAIOSFODNN7EXAMPLE";
+			const id = seedLegacyRow(db, sessionId, `legacy ${pat}`, `body has ${awsId}`, {
+				narrative: `narrative has ${pat}`,
+				tags_text: `safe ${pat}`,
+				facts: JSON.stringify([`fact has ${pat}`, "clean"]),
+				metadata_json: JSON.stringify({ password: "supersecretvalue123", note: "fine" }),
+			});
+
+			const result = scanSecretsRetroactive(db);
+			expect(result.checked).toBe(1);
+			expect(result.updated).toBe(1);
+			expect(result.detections.length).toBeGreaterThan(0);
+
+			const row = db
+				.prepare(
+					"SELECT title, body_text, narrative, tags_text, facts, metadata_json FROM memory_items WHERE id = ?",
+				)
+				.get(id) as {
+				title: string;
+				body_text: string;
+				narrative: string | null;
+				tags_text: string | null;
+				facts: string | null;
+				metadata_json: string | null;
+			};
+			expect(row.title).not.toContain(pat);
+			expect(row.title).toContain("[REDACTED:github_pat_classic]");
+			expect(row.body_text).not.toContain(awsId);
+			expect(row.narrative).not.toContain(pat);
+			expect(row.tags_text ?? "").not.toContain(pat);
+			expect(row.facts ?? "").not.toContain(pat);
+			const meta = JSON.parse(row.metadata_json ?? "{}");
+			expect(meta.password).toBe("[REDACTED:context_secret]");
+			expect(meta.note).toBe("fine");
+		} finally {
+			db.close();
+		}
+	});
+
+	it("is idempotent — second run reports zero updates", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			seedLegacyRow(db, sessionId, "legacy ghp_abcdefghijklmnopqrstuvwxyz0123456789", "clean body");
+			const first = scanSecretsRetroactive(db);
+			expect(first.updated).toBe(1);
+			const second = scanSecretsRetroactive(db);
+			expect(second.checked).toBeGreaterThan(0);
+			expect(second.updated).toBe(0);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("dry-run reports detections without writing", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const id = seedLegacyRow(db, sessionId, `legacy ${pat}`, "clean body");
+			const result = scanSecretsRetroactive(db, { dryRun: true });
+			expect(result.updated).toBe(1);
+			expect(result.detections.find((d) => d.kind === "github_pat_classic")?.count).toBe(1);
+			const row = db.prepare("SELECT title FROM memory_items WHERE id = ?").get(id) as {
+				title: string;
+			};
+			expect(row.title).toContain(pat);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("skips rows over the size cap and reports them", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			seedLegacyRow(db, sessionId, "huge", `${"x".repeat(200)}${pat}`);
+			const result = scanSecretsRetroactive(db, { maxRowBytes: 100 });
+			expect(result.skippedOversized).toBe(1);
+			expect(result.updated).toBe(0);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("idempotent on dual-rule redactions (secret-context plus pattern match)", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			// "secret: ghp_..." triggers BOTH generic_assigned_secret and github_pat_classic.
+			const id = seedLegacyRow(
+				db,
+				sessionId,
+				"title",
+				"secret: ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+			);
+			const first = scanSecretsRetroactive(db);
+			expect(first.updated).toBe(1);
+			const firstBody = db.prepare("SELECT body_text FROM memory_items WHERE id = ?").get(id) as {
+				body_text: string;
+			};
+			expect(firstBody.body_text).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz0123456789");
+			const second = scanSecretsRetroactive(db);
+			expect(second.updated).toBe(0);
+			const secondBody = db.prepare("SELECT body_text FROM memory_items WHERE id = ?").get(id) as {
+				body_text: string;
+			};
+			expect(secondBody.body_text).toBe(firstBody.body_text);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("redacts actor_display_name and origin_source", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const now = new Date().toISOString();
+			const id = Number(
+				db
+					.prepare(
+						`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+						 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+						 actor_display_name, origin_source)
+						 VALUES (?, 'discovery', 'Title', 'Body', 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?, ?)`,
+					)
+					.run(sessionId, now, now, `peer ${pat}`, `tool ${pat}`).lastInsertRowid,
+			);
+			const result = scanSecretsRetroactive(db);
+			expect(result.updated).toBe(1);
+			const row = db
+				.prepare("SELECT actor_display_name, origin_source FROM memory_items WHERE id = ?")
+				.get(id) as { actor_display_name: string | null; origin_source: string | null };
+			expect(row.actor_display_name ?? "").not.toContain(pat);
+			expect(row.actor_display_name ?? "").toContain("[REDACTED:github_pat_classic]");
+			expect(row.origin_source ?? "").not.toContain(pat);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("refreshes memory_concept_refs after redacting concepts", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const conceptsRaw = JSON.stringify([`leaks ${pat}`, "clean"]);
+			const id = seedLegacyRow(db, sessionId, "Title", "Body", { concepts: conceptsRaw });
+			// Seed the junction table with the unredacted concept (mimic what
+			// would have happened if remember() had been called pre-scanner).
+			db.prepare("INSERT INTO memory_concept_refs (memory_id, concept) VALUES (?, ?), (?, ?)").run(
+				id,
+				`leaks ${pat}`.toLowerCase(),
+				id,
+				"clean",
+			);
+			const result = scanSecretsRetroactive(db);
+			expect(result.updated).toBe(1);
+			const refs = db
+				.prepare("SELECT concept FROM memory_concept_refs WHERE memory_id = ? ORDER BY concept")
+				.all(id) as Array<{ concept: string }>;
+			const all = refs.map((r) => r.concept).join("|");
+			expect(all).not.toContain(pat);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("redacts legacy file_read/file_modified arrays and refreshes memory_file_refs", () => {
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const filesRead = JSON.stringify([`/tmp/${pat}.log`, "/clean/path"]);
+			const filesModified = JSON.stringify([`/var/${pat}.tmp`]);
+			// Seed legacy memory and pre-scanner junction-table refs that contain
+			// the unredacted paths (mimics what populateMemoryRefs would have done
+			// pre-scanner deployment).
+			const now = new Date().toISOString();
+			const id = Number(
+				db
+					.prepare(
+						`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+						 tags_text, active, created_at, updated_at, metadata_json, rev, visibility,
+						 files_read, files_modified)
+						 VALUES (?, 'discovery', 'T', 'B', 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?, ?)`,
+					)
+					.run(sessionId, now, now, filesRead, filesModified).lastInsertRowid,
+			);
+			db.prepare(
+				"INSERT INTO memory_file_refs (memory_id, file_path, relation) VALUES (?, ?, 'read'), (?, ?, 'read'), (?, ?, 'modified')",
+			).run(id, `/tmp/${pat}.log`, id, "/clean/path", id, `/var/${pat}.tmp`);
+
+			const result = scanSecretsRetroactive(db);
+			expect(result.updated).toBe(1);
+
+			const row = db
+				.prepare("SELECT files_read, files_modified FROM memory_items WHERE id = ?")
+				.get(id) as { files_read: string; files_modified: string };
+			expect(row.files_read).not.toContain(pat);
+			expect(row.files_read).toContain("[REDACTED:github_pat_classic]");
+			expect(row.files_modified).not.toContain(pat);
+
+			const refs = db
+				.prepare("SELECT file_path FROM memory_file_refs WHERE memory_id = ?")
+				.all(id) as Array<{ file_path: string }>;
+			for (const r of refs) {
+				expect(r.file_path).not.toContain(pat);
+			}
+			expect(refs.some((r) => r.file_path === "/clean/path")).toBe(true);
+		} finally {
+			db.close();
+		}
+	});
+
+	it("rejects updates with a stale rev when a concurrent writer bumps rev mid-scan", async () => {
+		const { SecretScanner } = await import("./secret-scanner.js");
+		const db = new Database(":memory:");
+		try {
+			initTestSchema(db);
+			const sessionId = Number(
+				db
+					.prepare("INSERT INTO sessions(started_at, project) VALUES (?, ?)")
+					.run("2026-01-01T00:00:00Z", "test").lastInsertRowid,
+			);
+			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+			const id = seedLegacyRow(db, sessionId, `legacy ${pat}`, "Body");
+			// Inject a concurrent rev bump between the sweep's SELECT (which
+			// loaded rev=1) and its UPDATE. The first scan call happens on
+			// the title; we hijack it to bump rev in the DB so the UPDATE's
+			// WHERE rev=1 guard fails.
+			const racy = new SecretScanner();
+			const orig = racy.scan.bind(racy);
+			let bumped = false;
+			racy.scan = (text: string) => {
+				if (!bumped && text.includes(pat)) {
+					bumped = true;
+					db.prepare("UPDATE memory_items SET rev = rev + 1 WHERE id = ?").run(id);
+				}
+				return orig(text);
+			};
+			const result = scanSecretsRetroactive(db, { scanner: racy });
+			expect(result.updated).toBe(0);
+			expect(result.staleWrites).toBe(1);
+			const row = db.prepare("SELECT title FROM memory_items WHERE id = ?").get(id) as {
+				title: string;
+			};
+			// Original content survives because the rev guard rejected the write.
+			expect(row.title).toContain(pat);
 		} finally {
 			db.close();
 		}

--- a/packages/core/src/maintenance.ts
+++ b/packages/core/src/maintenance.ts
@@ -97,3 +97,8 @@ export type {
 	AIBackfillStructuredContentResult,
 } from "./maintenance/ai-structured.js";
 export { aiBackfillStructuredContent } from "./maintenance/ai-structured.js";
+export type {
+	ScanSecretsRetroactiveOptions,
+	ScanSecretsRetroactiveResult,
+} from "./maintenance/scan-secrets.js";
+export { scanSecretsRetroactive } from "./maintenance/scan-secrets.js";

--- a/packages/core/src/maintenance/scan-secrets.ts
+++ b/packages/core/src/maintenance/scan-secrets.ts
@@ -1,0 +1,360 @@
+/**
+ * Retroactive secret-scan sweep over already-stored memories.
+ *
+ * Day-one users of the scanner have an unscanned backlog: memories written
+ * before the scanner shipped retain whatever secret-shaped content was in
+ * their bodies, titles, narratives, etc. This sweep walks `memory_items`,
+ * scans every content-bearing column, writes redacted versions back, and
+ * refreshes junction tables (`memory_concept_refs`, `memory_file_refs`)
+ * derived from the redacted columns so they cannot retain stale unredacted
+ * concept strings.
+ *
+ * Idempotent — scanning an already-redacted string yields the same string
+ * (the `[REDACTED:<kind>]` markers do not match any default rule), so a
+ * second run is a no-op except for the work of reading rows.
+ *
+ * Concurrency — each row is updated in its own transaction with a
+ * `WHERE rev = ?` guard so a concurrent legitimate write that bumped `rev`
+ * is not silently clobbered. The local-only sweep does not bump `rev` or
+ * record a replication op; peers redact their own copies via the
+ * sync-receive scanner.
+ */
+
+import type { Database } from "../db.js";
+import { normalizeConcept } from "../ref-populate.js";
+import { mergeDetections, type ScanDetection, SecretScanner } from "../secret-scanner.js";
+
+export interface ScanSecretsRetroactiveOptions {
+	/** Max rows to scan in this run. Omit (or pass null/0) for "everything". */
+	limit?: number | null;
+	/** Preview redactions without writing. */
+	dryRun?: boolean;
+	/** Custom scanner. Defaults to a fresh `SecretScanner` with built-in rules. */
+	scanner?: SecretScanner;
+	/**
+	 * Per-row content length above which we skip and count rather than spend
+	 * scanner CPU on a single huge body. Default 1 MiB. Note: this is a CPU
+	 * cap, not a memory cap — the row's columns are already loaded into Node
+	 * before this check.
+	 */
+	maxRowBytes?: number;
+}
+
+export interface ScanSecretsRetroactiveResult {
+	checked: number;
+	updated: number;
+	skippedOversized: number;
+	staleWrites: number;
+	detections: ScanDetection[];
+}
+
+interface MemoryRow {
+	id: number;
+	rev: number;
+	title: string | null;
+	subtitle: string | null;
+	body_text: string | null;
+	narrative: string | null;
+	tags_text: string | null;
+	facts: string | null;
+	concepts: string | null;
+	files_read: string | null;
+	files_modified: string | null;
+	metadata_json: string | null;
+	actor_display_name: string | null;
+	origin_source: string | null;
+}
+
+const DEFAULT_MAX_ROW_BYTES = 1024 * 1024;
+
+function rowBytes(row: MemoryRow): number {
+	let total = 0;
+	for (const v of [
+		row.title,
+		row.subtitle,
+		row.body_text,
+		row.narrative,
+		row.tags_text,
+		row.facts,
+		row.concepts,
+		row.files_read,
+		row.files_modified,
+		row.metadata_json,
+		row.actor_display_name,
+		row.origin_source,
+	]) {
+		if (typeof v === "string") total += v.length;
+	}
+	return total;
+}
+
+function scanArrayJson(
+	json: string | null,
+	scanner: SecretScanner,
+): {
+	json: string | null;
+	detections: ScanDetection[];
+	changed: boolean;
+} {
+	if (json == null || json.length === 0) return { json, detections: [], changed: false };
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(json);
+	} catch {
+		return { json, detections: [], changed: false };
+	}
+	if (!Array.isArray(parsed)) return { json, detections: [], changed: false };
+	const lists: ScanDetection[][] = [];
+	const next: unknown[] = [];
+	let changed = false;
+	for (const item of parsed) {
+		if (typeof item === "string") {
+			const r = scanner.scan(item);
+			if (r.redacted !== item) changed = true;
+			lists.push(r.detections);
+			next.push(r.redacted);
+		} else {
+			next.push(item);
+		}
+	}
+	return {
+		json: changed ? JSON.stringify(next) : json,
+		detections: mergeDetections(...lists),
+		changed,
+	};
+}
+
+function scanMetadataJson(
+	json: string | null,
+	scanner: SecretScanner,
+): {
+	json: string | null;
+	detections: ScanDetection[];
+	changed: boolean;
+} {
+	if (json == null || json.length === 0) return { json, detections: [], changed: false };
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(json);
+	} catch {
+		return { json, detections: [], changed: false };
+	}
+	if (parsed === null || typeof parsed !== "object") {
+		return { json, detections: [], changed: false };
+	}
+	const r = scanner.redactValue(parsed);
+	const nextJson = JSON.stringify(r.value);
+	const changed = nextJson !== json;
+	return { json: changed ? nextJson : json, detections: r.detections, changed };
+}
+
+function scanTagsText(
+	text: string | null,
+	scanner: SecretScanner,
+): {
+	text: string | null;
+	detections: ScanDetection[];
+	changed: boolean;
+} {
+	if (text == null || text.length === 0) return { text, detections: [], changed: false };
+	const parts = text.split(/\s+/).filter(Boolean);
+	const lists: ScanDetection[][] = [];
+	const next: string[] = [];
+	let changed = false;
+	for (const part of parts) {
+		const r = scanner.scan(part);
+		if (r.redacted !== part) changed = true;
+		lists.push(r.detections);
+		next.push(r.redacted);
+	}
+	return {
+		text: changed ? next.join(" ") : text,
+		detections: mergeDetections(...lists),
+		changed,
+	};
+}
+
+function scanString(
+	value: string | null,
+	scanner: SecretScanner,
+): { value: string | null; detections: ScanDetection[]; changed: boolean } {
+	if (value == null || value.length === 0) {
+		return { value, detections: [], changed: false };
+	}
+	const r = scanner.scan(value);
+	return { value: r.redacted, detections: r.detections, changed: r.redacted !== value };
+}
+
+function asStringArray(json: string | null): string[] | null {
+	if (json == null || json.length === 0) return null;
+	try {
+		const parsed = JSON.parse(json);
+		if (!Array.isArray(parsed)) return null;
+		return parsed.filter((v): v is string => typeof v === "string");
+	} catch {
+		return null;
+	}
+}
+
+export function scanSecretsRetroactive(
+	db: Database,
+	opts: ScanSecretsRetroactiveOptions = {},
+): ScanSecretsRetroactiveResult {
+	const scanner = opts.scanner ?? new SecretScanner();
+	const dryRun = opts.dryRun === true;
+	const maxRowBytes = opts.maxRowBytes ?? DEFAULT_MAX_ROW_BYTES;
+	const hasLimit = typeof opts.limit === "number" && Number.isInteger(opts.limit) && opts.limit > 0;
+	const limitClause = hasLimit ? `LIMIT ${Number(opts.limit)}` : "";
+
+	const rows = db
+		.prepare(
+			`SELECT id, rev, title, subtitle, body_text, narrative, tags_text,
+			        facts, concepts, files_read, files_modified, metadata_json,
+			        actor_display_name, origin_source
+			 FROM memory_items
+			 ORDER BY id ASC
+			 ${limitClause}`,
+		)
+		.all() as MemoryRow[];
+
+	const updateStmt = db.prepare(
+		`UPDATE memory_items
+		 SET title = ?, subtitle = ?, body_text = ?, narrative = ?, tags_text = ?,
+		     facts = ?, concepts = ?, files_read = ?, files_modified = ?,
+		     metadata_json = ?, actor_display_name = ?, origin_source = ?,
+		     updated_at = ?
+		 WHERE id = ? AND rev = ?`,
+	);
+
+	const detectionLists: ScanDetection[][] = [];
+	let checked = 0;
+	let updated = 0;
+	let skippedOversized = 0;
+	let staleWrites = 0;
+
+	for (const row of rows) {
+		checked++;
+		if (rowBytes(row) > maxRowBytes) {
+			skippedOversized++;
+			continue;
+		}
+
+		const titleResult = scanString(row.title, scanner);
+		const subtitleResult = scanString(row.subtitle, scanner);
+		const bodyResult = scanString(row.body_text, scanner);
+		const narrativeResult = scanString(row.narrative, scanner);
+		const actorNameResult = scanString(row.actor_display_name, scanner);
+		const originSourceResult = scanString(row.origin_source, scanner);
+		const tagsResult = scanTagsText(row.tags_text, scanner);
+		const factsResult = scanArrayJson(row.facts, scanner);
+		const conceptsResult = scanArrayJson(row.concepts, scanner);
+		const filesReadResult = scanArrayJson(row.files_read, scanner);
+		const filesModifiedResult = scanArrayJson(row.files_modified, scanner);
+		const metaResult = scanMetadataJson(row.metadata_json, scanner);
+
+		const changed =
+			titleResult.changed ||
+			subtitleResult.changed ||
+			bodyResult.changed ||
+			narrativeResult.changed ||
+			actorNameResult.changed ||
+			originSourceResult.changed ||
+			tagsResult.changed ||
+			factsResult.changed ||
+			conceptsResult.changed ||
+			filesReadResult.changed ||
+			filesModifiedResult.changed ||
+			metaResult.changed;
+
+		if (!changed) continue;
+
+		detectionLists.push(
+			titleResult.detections,
+			subtitleResult.detections,
+			bodyResult.detections,
+			narrativeResult.detections,
+			actorNameResult.detections,
+			originSourceResult.detections,
+			tagsResult.detections,
+			factsResult.detections,
+			conceptsResult.detections,
+			filesReadResult.detections,
+			filesModifiedResult.detections,
+			metaResult.detections,
+		);
+
+		if (dryRun) {
+			updated++;
+			continue;
+		}
+
+		// Single-row transaction so a concurrent legitimate writer that bumped
+		// `rev` is not silently clobbered. Junction-table refresh is done in
+		// the same transaction so the row's stored columns and its derived
+		// indexes never disagree.
+		const ok = db.transaction(() => {
+			const result = updateStmt.run(
+				titleResult.value,
+				subtitleResult.value,
+				bodyResult.value,
+				narrativeResult.value,
+				tagsResult.text,
+				factsResult.json,
+				conceptsResult.json,
+				filesReadResult.json,
+				filesModifiedResult.json,
+				metaResult.json,
+				actorNameResult.value,
+				originSourceResult.value,
+				new Date().toISOString(),
+				row.id,
+				row.rev,
+			);
+			if (result.changes === 0) return false;
+			// Junction tables derive from concepts and files_read/files_modified
+			// and index the raw strings. If we redacted any of those columns,
+			// the junction tables still hold the unredacted form and act as a
+			// side-channel for queries / exports that read them.
+			if (conceptsResult.changed) {
+				db.prepare("DELETE FROM memory_concept_refs WHERE memory_id = ?").run(row.id);
+				const concepts = asStringArray(conceptsResult.json);
+				if (concepts) {
+					const insertStmt = db.prepare(
+						"INSERT OR IGNORE INTO memory_concept_refs (memory_id, concept) VALUES (?, ?)",
+					);
+					for (const concept of concepts) {
+						const normalized = normalizeConcept(concept);
+						if (normalized) insertStmt.run(row.id, normalized);
+					}
+				}
+			}
+			if (filesReadResult.changed || filesModifiedResult.changed) {
+				db.prepare("DELETE FROM memory_file_refs WHERE memory_id = ?").run(row.id);
+				const insertStmt = db.prepare(
+					"INSERT OR IGNORE INTO memory_file_refs (memory_id, file_path, relation) VALUES (?, ?, ?)",
+				);
+				for (const path of asStringArray(filesReadResult.json) ?? []) {
+					if (path) insertStmt.run(row.id, path, "read");
+				}
+				for (const path of asStringArray(filesModifiedResult.json) ?? []) {
+					if (path) insertStmt.run(row.id, path, "modified");
+				}
+			}
+			return true;
+		})();
+
+		if (ok) {
+			updated++;
+		} else {
+			staleWrites++;
+		}
+	}
+
+	return {
+		checked,
+		updated,
+		skippedOversized,
+		staleWrites,
+		detections: mergeDetections(...detectionLists),
+	};
+}


### PR DESCRIPTION
## Description

Adds `scanSecretsRetroactive` plus the `codemem db scan-secrets` CLI for the day-one backlog of memories written before the scanner shipped.

Walks `memory_items` in id order, scans every content-bearing column (title / subtitle / body_text / narrative / tags_text / facts / concepts / files_read / files_modified / metadata_json / actor_display_name / origin_source) and writes redacted versions back via single-row in-place UPDATE — never DELETE on the memory itself.

Concurrency: each row's UPDATE runs in its own transaction with a `WHERE rev = ?` guard so a concurrent legitimate write that bumped `rev` is not silently clobbered (counted as `staleWrites`). Junction-table refresh: both `memory_concept_refs` and `memory_file_refs` are rebuilt for the redacted memory when their source columns change, so neither index retains unredacted strings as a side-channel.

Idempotent — scanning `[REDACTED:<kind>]` markers is a no-op because the marker char class does not match any default rule. Per-row CPU cap (default 1 MiB) skips and counts oversized rows.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

Tests cover legacy redact, idempotency on dual-rule (secret-context + pattern), dry-run, oversize cap, `actor_display_name` / `origin_source` redaction, concept-junction refresh, file-path columns + `memory_file_refs` junction refresh, and a TOCTOU regression that uses a racy custom scanner to bump `rev` between SELECT and UPDATE — verifying the row is not clobbered and `staleWrites` is incremented.

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (`codemem db scan-secrets --dry-run` and `--json` output contains kind+count only)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — JSDoc on the new module; CLI subcommand has built-in help
- [x] No new warnings introduced