### PR TITLE
feat(core): add workspace-level secret_scanner config block

### DIFF
--- a/packages/core/src/secret-scanner.test.ts
+++ b/packages/core/src/secret-scanner.test.ts
@@ -353,6 +353,90 @@ describe("redactMemoryFields", () => {
 	});
 });
 
+describe("loadScannerOptionsFromConfig", () => {
+	it("returns empty options for missing or malformed config", async () => {
+		const { loadScannerOptionsFromConfig } = await import("./secret-scanner.js");
+		expect(loadScannerOptionsFromConfig(null)).toEqual({});
+		expect(loadScannerOptionsFromConfig({})).toEqual({});
+		expect(loadScannerOptionsFromConfig({ secret_scanner: "not-an-object" })).toEqual({});
+		expect(loadScannerOptionsFromConfig({ secret_scanner: [] })).toEqual({});
+	});
+
+	it("loads workspace rules with regex compilation and entropy floor", async () => {
+		const { loadScannerOptionsFromConfig, SecretScanner } = await import("./secret-scanner.js");
+		const opts = loadScannerOptionsFromConfig({
+			secret_scanner: {
+				rules: [
+					{
+						kind: "internal_acme_token",
+						pattern: "\\bACME-[A-Z0-9]{10}\\b",
+						minEntropy: 2.0,
+					},
+				],
+			},
+		});
+		expect(opts.rules).toHaveLength(1);
+		const scanner = new SecretScanner(opts);
+		const r = scanner.scan("internal: ACME-AB12CD34EF and clean text");
+		expect(r.redacted).toContain("[REDACTED:internal_acme_token]");
+	});
+
+	it("drops malformed rule entries silently", async () => {
+		const { loadScannerOptionsFromConfig } = await import("./secret-scanner.js");
+		const opts = loadScannerOptionsFromConfig({
+			secret_scanner: {
+				rules: [
+					{ kind: "ok", pattern: "\\bok\\b" },
+					{ kind: "missing_pattern" },
+					{ pattern: "\\bnope\\b" },
+					{ kind: "bad_regex", pattern: "[unterminated" },
+					"not-an-object",
+					42,
+				],
+			},
+		});
+		expect(opts.rules).toHaveLength(1);
+		expect(opts.rules?.[0]?.kind).toBe("ok");
+	});
+
+	it("loads allowlist with literal strings and regex literals", async () => {
+		const { loadScannerOptionsFromConfig, SecretScanner } = await import("./secret-scanner.js");
+		const opts = loadScannerOptionsFromConfig({
+			secret_scanner: {
+				allowlist: ["AKIAFAKEFIXTURE0001", "/^test-fixture-.*$/i", "", 42 as unknown as string],
+			},
+		});
+		expect(opts.allowlist).toHaveLength(2);
+		const scanner = new SecretScanner(opts);
+		// Literal allowlist entry
+		expect(scanner.scan("creds: AKIAFAKEFIXTURE0001 in env").redacted).toContain(
+			"AKIAFAKEFIXTURE0001",
+		);
+	});
+
+	it("strips g and y flags from parsed allowlist regex literals", async () => {
+		const { loadScannerOptionsFromConfig, SecretScanner } = await import("./secret-scanner.js");
+		const opts = loadScannerOptionsFromConfig({
+			secret_scanner: {
+				allowlist: ["/^AKIAFAKEFIXTURE\\d{4}$/g", "/^anchored$/y"],
+			},
+		});
+		expect(opts.allowlist).toHaveLength(2);
+		for (const entry of opts.allowlist ?? []) {
+			expect(entry).toBeInstanceOf(RegExp);
+			const re = entry as RegExp;
+			expect(re.global).toBe(false);
+			expect(re.sticky).toBe(false);
+		}
+		// Behavior is stable across repeated allowlist tests.
+		const scanner = new SecretScanner(opts);
+		const fixture = "AKIAFAKEFIXTURE0001";
+		for (let i = 0; i < 4; i++) {
+			expect(scanner.scan(`creds: ${fixture} in env`).redacted).toContain(fixture);
+		}
+	});
+});
+
 describe("DEFAULT_RULES", () => {
 	it("exposes a non-empty rule set", () => {
 		expect(DEFAULT_RULES.length).toBeGreaterThan(5);

--- a/packages/core/src/secret-scanner.ts
+++ b/packages/core/src/secret-scanner.ts
@@ -287,6 +287,105 @@ function aggregateMap(map: Map<string, number>): ScanDetection[] {
 	return Array.from(map.entries()).map(([kind, count]) => ({ kind, count }));
 }
 
+/**
+ * Build `ScannerOptions` from a parsed codemem config object's
+ * `secret_scanner` block. Workspace-scoped rule overrides and an allowlist
+ * for known-safe matches are accepted under a single config key so a team
+ * can tighten or loosen the default policy without forking codemem.
+ *
+ * Expected shape (all keys optional):
+ * ```jsonc
+ * {
+ *   "secret_scanner": {
+ *     "rules": [
+ *       { "kind": "internal_token", "pattern": "\\bACME-[A-Z0-9]{10}\\b", "flags": "g", "minEntropy": 3.0 }
+ *     ],
+ *     "allowlist": [
+ *       "AKIAFAKEFIXTURE0001",     // string entries match by exact equality
+ *       "/^test-fixture-.*$/i"     // strings of the form /pattern/flags become regexes
+ *     ]
+ *   }
+ * }
+ * ```
+ *
+ * Malformed entries are silently dropped — config errors should never block
+ * a workspace from opening.
+ */
+export function loadScannerOptionsFromConfig(
+	config: Record<string, unknown> | null | undefined,
+): ScannerOptions {
+	const empty: ScannerOptions = {};
+	if (!config || typeof config !== "object") return empty;
+	const block = (config as { secret_scanner?: unknown }).secret_scanner;
+	if (!block || typeof block !== "object" || Array.isArray(block)) return empty;
+	const out: ScannerOptions = {};
+
+	const rawRules = (block as { rules?: unknown }).rules;
+	if (Array.isArray(rawRules)) {
+		const rules: SecretRule[] = [];
+		for (const entry of rawRules) {
+			if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+			const e = entry as Record<string, unknown>;
+			if (typeof e.kind !== "string" || typeof e.pattern !== "string") continue;
+			const flagsRaw = typeof e.flags === "string" ? e.flags : "g";
+			const flags = flagsRaw.includes("g") ? flagsRaw : `${flagsRaw}g`;
+			let pattern: RegExp;
+			try {
+				pattern = new RegExp(e.pattern, flags);
+			} catch {
+				continue;
+			}
+			const rule: SecretRule = { kind: e.kind, pattern };
+			if (typeof e.minEntropy === "number" && Number.isFinite(e.minEntropy)) {
+				rule.minEntropy = e.minEntropy;
+			}
+			if (
+				typeof e.redactGroup === "number" &&
+				Number.isInteger(e.redactGroup) &&
+				e.redactGroup > 0
+			) {
+				rule.redactGroup = e.redactGroup;
+			}
+			rules.push(rule);
+		}
+		if (rules.length > 0) out.rules = rules;
+	}
+
+	const rawAllowlist = (block as { allowlist?: unknown }).allowlist;
+	if (Array.isArray(rawAllowlist)) {
+		const allowlist: Array<string | RegExp> = [];
+		for (const entry of rawAllowlist) {
+			if (typeof entry !== "string" || entry.length === 0) continue;
+			// Strings of the form /pattern/flags are parsed as regex; everything
+			// else is treated as a literal.
+			const re = parseRegexLiteral(entry);
+			allowlist.push(re ?? entry);
+		}
+		if (allowlist.length > 0) out.allowlist = allowlist;
+	}
+
+	return out;
+}
+
+function parseRegexLiteral(value: string): RegExp | null {
+	if (value.length < 2 || value[0] !== "/") return null;
+	const lastSlash = value.lastIndexOf("/");
+	if (lastSlash <= 0) return null;
+	const pattern = value.slice(1, lastSlash);
+	const flags = value.slice(lastSlash + 1);
+	if (!/^[gimsuy]*$/.test(flags)) return null;
+	// Allowlist regexes are tested via RegExp.test which is stateful when `g`
+	// or `y` is set. Strip those flags up front so a configured /^foo/g
+	// behaves the same as /^foo/ — the runtime guard in isAllowlisted is
+	// belt-and-suspenders, this is the suspenders.
+	const safeFlags = flags.replace(/[gy]/g, "");
+	try {
+		return new RegExp(pattern, safeFlags);
+	} catch {
+		return null;
+	}
+}
+
 /** Merge multiple detection lists into a single per-kind summary. */
 export function mergeDetections(...lists: ScanDetection[][]): ScanDetection[] {
 	const merged = new Map<string, number>();

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -172,6 +172,36 @@ describe("MemoryStore", () => {
 			expect(row?.tags_text).not.toContain(pat);
 		});
 
+		it("applies workspace-config secret_scanner rules to local writes", () => {
+			store.close();
+			writeFileSync(
+				process.env.CODEMEM_CONFIG as string,
+				JSON.stringify({
+					secret_scanner: {
+						rules: [{ kind: "internal_acme_token", pattern: "\\bACME-[A-Z0-9]{10}\\b" }],
+						allowlist: ["AKIAFAKEFIXTURE0001"],
+					},
+				}),
+			);
+			store = new MemoryStore(dbPath);
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(
+				sessionId,
+				"discovery",
+				"workspace title with ACME-AB12CD34EF token",
+				"Body has AKIAFAKEFIXTURE0001 fixture and AKIAIOSFODNN7EXAMPLE real",
+			);
+			const row = store.get(memId);
+			// Workspace rule fires
+			expect(row?.title).toContain("[REDACTED:internal_acme_token]");
+			expect(row?.title).not.toContain("ACME-AB12CD34EF");
+			// Allowlist entry passes through
+			expect(row?.body_text).toContain("AKIAFAKEFIXTURE0001");
+			// Default rules still active for everything else
+			expect(row?.body_text).toContain("[REDACTED:aws_access_key_id]");
+			expect(row?.body_text).not.toContain("AKIAIOSFODNN7EXAMPLE");
+		});
+
 		it("never persists original secrets to the replication_ops payload", () => {
 			const sessionId = insertTestSession(store.db);
 			const pat = "ghp_abcdefghijklmnopqrstuvwxyz0123456789";

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -47,7 +47,12 @@ import {
 	search as searchFn,
 	timeline as timelineFn,
 } from "./search.js";
-import { mergeDetections, type ScanDetection, SecretScanner } from "./secret-scanner.js";
+import {
+	loadScannerOptionsFromConfig,
+	mergeDetections,
+	type ScanDetection,
+	SecretScanner,
+} from "./secret-scanner.js";
 import { recordReplicationOp } from "./sync-replication.js";
 import type {
 	ExplainResponse,
@@ -233,7 +238,12 @@ export class MemoryStore {
 			this.db.close();
 			throw err;
 		}
-		this.scanner = new SecretScanner();
+
+		// Read config once and use it for both actor identity and scanner
+		// rule overrides. Workspace-scoped rules and allowlist live under the
+		// `secret_scanner` block (see loadScannerOptionsFromConfig).
+		const config = readCodememConfigFile();
+		this.scanner = new SecretScanner(loadScannerOptionsFromConfig(config));
 
 		// Resolve device ID: env var → sync_device table → stable "local" fallback.
 		// Python uses exactly this order and fallback.
@@ -258,7 +268,6 @@ export class MemoryStore {
 
 		// Resolve actor identity — matches Python load_config() precedence:
 		// config file, then env override, then local fallbacks.
-		const config = readCodememConfigFile();
 		const configActorId = Object.hasOwn(process.env, "CODEMEM_ACTOR_ID")
 			? cleanStr(process.env.CODEMEM_ACTOR_ID)
 			: (cleanStr(config.actor_id) ?? null);


### PR DESCRIPTION
## Description

Workspace config now drives `MemoryStore.scanner` construction so teams can add org-specific patterns and known-safe fixtures without forking codemem.

Schema (all keys optional):

\`\`\`jsonc
{
  "secret_scanner": {
    "rules": [
      { "kind": "internal_token",
        "pattern": "\\\\bACME-[A-Z0-9]{10}\\\\b",
        "flags": "g",
        "minEntropy": 3.0 }
    ],
    "allowlist": [
      "AKIAFAKEFIXTURE0001",
      "/^test-fixture-.*$/i"
    ]
  }
}
\`\`\`

Allowlist entries: plain strings match by exact equality; strings shaped `/pattern/flags` become regexes (tested via `RegExp.test`, partial unless anchored). The parser strips `g` and `y` flags from regex literals before compiling so allowlist matching is stateless even on caller-supplied flags. Malformed rule entries are silently dropped — config errors should never block a workspace from opening.

`MemoryStore` reads `codemem` config once and uses it for both actor identity and scanner rules.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

`secret-scanner.test.ts` adds tests for missing/malformed config (returns empty options), workspace rule compilation with `minEntropy`, malformed rule entries silently dropped, allowlist literal/regex parsing, and stripping `g`/`y` flags from parsed regex literals (with stable repeat-call behavior). `store.test.ts` adds an end-to-end test asserting workspace rules fire on local writes, allowlist passes through, and default rules still active for everything else.

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — JSDoc on `loadScannerOptionsFromConfig` documents the schema with worked example
- [x] No new warnings introduced