### PR TITLE
docs: lock sharing-domain architecture

### DIFF
--- a/docs/plans/2026-04-30-seed-and-mesh-architecture-converged.md
+++ b/docs/plans/2026-04-30-seed-and-mesh-architecture-converged.md
@@ -1,0 +1,295 @@
+# Seed Peer & Mesh Architecture — Converged Position
+
+**Date:** 2026-04-30
+**Status:** accepted architecture direction
+**Boundary semantics:** see `2026-04-30-sharing-domain-scope-design.md` for the sharing-domain (`scope_id`) model that this architecture rests on
+**Historical option survey:** `2026-04-30-seed-and-mesh-architecture-research.md` (preserved for context; superseded where it conflicts with this doc or the scope design)
+
+## Authoritative invariants
+
+These invariants apply to all sharing/sync work in codemem and supersede any conflicting framing in older docs:
+
+1. **Sharing domain (`scope_id`) is the hard data boundary in Phase 2.** Once a deployment is in Phase 2, a memory may only replicate to a peer if (a) the memory has a non-null `scope_id` recognized by both sides, AND (b) the peer is currently authorized for that `scope_id` at the latest known membership epoch. Memories with no `scope_id` MUST NOT replicate in Phase 2 except via an explicitly configured per-peer legacy compatibility scope, which is a documented, audited exception to this invariant — not an exemption from it.
+2. **Project include/exclude only narrows.** Per-peer project filters can subtract from what a peer would otherwise receive. They never grant access to a scope the peer is not authorized for. Basename-style project matches are display-only and MUST NOT be used for any scope authorization decision.
+3. **Coordinator group is a discovery, admin, and membership container.** Group membership is not data access. Scope grants are an explicit, separate, audited admin action whose record is independent of group membership changes. There is no auto-grant from group enrollment.
+4. **Coordinator is never a data path.** It does not store, proxy, or relay memory payloads, and it is not a gateway in front of a backend.
+5. **Seed/anchor peers are deployment artifacts.** A peer with high uptime is still a peer. There is no special protocol role for "backbone" or "seed" devices.
+6. **Visibility gates eligibility, not authorization.** `visibility=shared` makes a memory eligible to leave the device; scope membership decides where it may go.
+7. **Revocation prevents future sync only and is enforced per op batch.** Already-replicated data on a revoked device is not magically erased. Outbound sync MUST re-validate scope membership against the local membership cache before each op batch is sent. Cache TTL for scope membership is at most 60 seconds; longer TTLs are a documented operator exception with a stated revocation-lag SLA.
+8. **Local-first.** Writes are durable locally before any replication; quorum writes are not a primitive.
+9. **`sync_peers.claimed_local_actor` is retracted in Phase 2.** Same-actor private sync is expressed exclusively as membership in a `personal:<actor_id>` scope whose membership manifest is signed by an actor-controlled key. The legacy boolean MUST NOT bypass scope or visibility checks once a deployment is in Phase 2; Phase 1→2 promotion fails closed if any `sync_peer` still asserts `claimed_local_actor=1` without a corresponding `personal:` scope grant.
+10. **Local-only scopes never escape the device that minted them.** Scopes with `authority_type='local'` (including all migration-created `local-default`, `legacy-shared-review`, and similar scopes) are not eligible for outbound replication in any phase. Their memories are local artifacts until an admin explicitly reassigns them to an authoritative scope.
+11. **Inbound `scope_id` is taken from the op row, not re-resolved.** The receiver does not re-run project→scope resolution on incoming ops. The sender's resolution at minting time is binding for that op's `scope_id`. The receiver's job is to verify sender authorization, receiver authorization, and scope/payload consistency at the latest known epoch.
+
+If a future change conflicts with one of these invariants, it must explicitly supersede the relevant invariant in a dated decision doc, not silently widen behavior.
+
+## Purpose of this document
+
+This doc captures the position the codemem team converged on after iterating through several architectural framings (centralized SQL, durable log, two-tier mesh with quorum). It is written to be self-contained so that an external reviewer (human or AI) can engage with it without reading the prior research doc — though that earlier doc records the alternatives we considered and rejected.
+
+Read this doc with a critical eye. The author intentionally wants pushback on the assumptions, the protocol surface, the implementation budget, and the framing. Productive disagreement is the point.
+
+## TL;DR
+
+codemem should be **Syncthing-shaped, with structured op-logs instead of file blocks and explicit multi-user/group membership instead of Syncthing's single-user-multi-device default**.
+
+The "central seed peer" we considered is reframed as a **deployment property, not a protocol primitive** — it is just an always-on peer in the swarm, exactly the way a BitTorrent seed is just a peer that holds the complete file. The protocol does not know that any peer is special.
+
+A separate "backbone" tier with quorum semantics, distinct from "joiner" peers, is rejected. So is a "coordinator-as-gateway" pattern that proxies data. The coordinator's job is the minimum required to bridge network boundaries: discovery and group membership. mDNS handles the LAN case (already implemented).
+
+The implementation work is intentionally bounded. The patterns we're adopting are well-established (Syncthing's BEP, BitTorrent's swarm model, Cassandra's anti-entropy, Dynamo's hinted handoff) and we are implementing them in TypeScript ourselves rather than depending on external services or new deployable infrastructure.
+
+## Reference architectures
+
+### Syncthing — the closest analogue
+
+Syncthing is a peer-to-peer file synchronization tool. Each device holds full local copies of "folders" it shares with other devices. Discovery is a mix of a global discovery server (HTTPS), local UDP broadcast (mDNS-equivalent), and relay servers for NAT traversal. Authentication is mutual TLS pinned to device IDs derived from public keys.
+
+Mapping codemem onto Syncthing:
+
+| Syncthing | codemem | Status |
+|---|---|---|
+| Device ID (cert pubkey hash) | Device key | Already exists |
+| Folder | Scope | To be added (additive schema) |
+| Folder shared with N devices | Scope with N members | To be added |
+| Global discovery server | Coordinator | Already exists (simplified role going forward) |
+| Local discovery (UDP broadcast) | mDNS | Already exists (`packages/core/src/sync-discovery.ts`) |
+| Relay servers | Optional, deferred | Not built |
+| Block Exchange Protocol over TLS | HTTP/2 + mTLS over `/v1/ops` and `/v1/snapshot` | Already exists |
+| Versioning | Lamport scalar clock + LWW + tombstones | Already exists |
+
+The two material differences from Syncthing:
+
+1. **Structured op-logs, not file blocks.** Sync exchanges discrete `replication_ops` keyed by `op_id` (UUID), not file chunks. Conflict resolution is LWW on Lamport-ordered ops, not Syncthing's file-versioning. The wire transport mechanics are otherwise the same shape.
+2. **Multi-user team membership.** Syncthing assumes "your devices, your folders." codemem scopes have multiple humans, each with multiple devices, with cryptographically authorized member lists. The coordinator publishes the authorized device-key set per scope; peers verify membership when serving sync requests. This is a layer above the peer protocol, not a change to it.
+
+### BitTorrent — the swarm intuition
+
+BitTorrent's central insight: **with enough peers in a swarm, data persists as long as somebody is online holding it.** A "seed" in BT terminology is a peer that has the complete file. Other peers ("leechers" while incomplete, "seeds" once they have everything) exchange chunks via direct connections, with trackers (or DHT) helping with discovery.
+
+For codemem this gives us the right mental model for durability:
+
+- Data lives in the swarm. Each peer that's a member of a scope holds that scope's data.
+- "Always-on peers" (whether $5 VPS or k8s deployment) are peers that don't go offline when humans close their laptops. They're in the swarm; they're not architecturally above it.
+- An organization that wants strong availability deploys "enough always-on peers that the swarm has good connectivity even when humans aren't online." This is a deployment policy. The protocol doesn't care.
+- If every always-on peer were to die, data would still exist on the laptops that produced it; the swarm degrades gracefully.
+
+### Why not Dynamo / Cassandra
+
+The earlier framing leaned on Dynamo's lineage (consistent hashing, sloppy quorum, hinted handoff, Merkle anti-entropy). Dynamo's model is a *fixed cluster of always-on nodes serving clients*. It does not fit codemem because:
+
+- codemem's nodes ARE the clients (laptops produce memories)
+- Membership is dynamic (humans come and go from teams)
+- Peers are intermittently online by design (laptops sleep)
+- We don't have a coordinator-elected leader for any partition
+
+Two patterns from the Dynamo lineage do still apply because they generalize:
+
+- **Anti-entropy via Merkle ranges** — the convergence engine when two peers meet
+- **Hinted handoff** — store-and-forward when the intended recipient is unreachable
+
+The pieces we explicitly drop: quorum write between peers, consistent-hash placement, SWIM membership protocol, cluster-wide failure detection. None of these fit a Syncthing-shaped peer-to-peer model.
+
+## The codemem architecture, stated plainly
+
+### Peers
+
+Every peer is the same. A peer:
+
+- Has a device key (public/private, already exists)
+- Has a local SQLite database (already exists)
+- Is a member of zero or more scopes
+- Holds full local copies of every scope it is a member of
+- Originates writes (memories extracted from coding sessions, observations, etc.)
+- Replicates with other reachable members of the same scope, eventually consistent
+
+There is no role distinction between "backbone," "joiner," "seed," or "coordinator-side." A peer is a peer. Some peers happen to be always-on; that is observable but not protocol-relevant.
+
+### Scopes
+
+A scope is the unit of sharing. Every memory and every replication op carries a `scope_id` (additive schema change). Scopes correspond to projects, teams, or workspaces — the user-facing concept TBD, but the underlying primitive is "set of device keys authorized to read/write this data."
+
+Scope membership is a set of device keys, published and managed via the coordinator (or, in coordinator-less deployments, configured directly between peers). Membership changes are themselves cryptographically signed events; peers cache the latest membership and verify it on incoming sync requests.
+
+### Discovery
+
+Three mechanisms, in priority order:
+
+1. **mDNS** — same-LAN peer discovery. Already implemented at `packages/core/src/sync-discovery.ts`. Gated by config or env var.
+2. **Coordinator** — cross-network discovery and group membership directory. Already exists in a richer form than needed; we will pare it back to: groups, members per group, presence (which device key is currently reachable, at what address). The coordinator never sees memory data.
+3. **Manual / configured addresses** — works when you know where a peer lives and don't need a discovery service. Already supported via `sync_peers` table.
+
+Future addition (deferred): **relay** for NAT-traversal cases where direct connection fails. Syncthing has a community relay pool; codemem could do the same, or have peers relay through any reachable mutual member.
+
+### Replication semantics
+
+Writes are local-first. A peer writes to its own SQLite immediately. The write is durable from that peer's perspective the moment SQLite returns.
+
+Sharing is best-effort fanout to reachable members of the same scope, with eventual convergence guaranteed by anti-entropy. Specifically:
+
+- After a local write, the peer attempts to push the new ops to currently-reachable members of the scope.
+- If a target member is unreachable, the ops are queued for later push (hinted handoff: "deliver this op to device X when X is reachable, OR when any other member of the scope can forward it").
+- Periodically, pairs of peers exchange Merkle summaries of their op-log per shared scope. On hash mismatch, they exchange the actual missing ops via the existing `/v1/ops` endpoint.
+- On cold start (new device joins a scope, or a peer has been offline for a long time), bootstrap via the existing paginated `/v1/snapshot` endpoint, then tail with cursor-based `/v1/ops`.
+
+There is no quorum requirement at the protocol level. Each peer's local copy is the authoritative version of the world it has seen so far. Convergence between peers is eventual, ordered by Lamport clock with LWW for conflicting writes to the same `entity_id`.
+
+### Coordinator role, minimized
+
+The coordinator is a phone book and a group registry. It does:
+
+- **Group / scope membership management** — which device keys are authorized members of which scopes
+- **Presence directory** — which device keys are currently reachable, at what addresses (TTL'd, peers refresh)
+- **Bootstrap / invite flow** — how a new device gets enrolled in a group (existing bootstrap-grant pattern, possibly simplified)
+- **(Optional, future)** NAT traversal hints (STUN-like: "I see your peer at this public address")
+- **(Optional, future)** Relay fallback when direct peer connection fails
+
+The coordinator does NOT:
+
+- Store memories or replication ops
+- Proxy data between peers
+- Act as an auth boundary in front of a backend
+- Make routing decisions about which peer holds which data
+- Serve as a single point of failure for data access (peers continue to sync directly with each other if the coordinator is offline, as long as they already know each other's addresses)
+
+The coordinator is treated as a necessary mechanism for crossing network boundaries (where mDNS doesn't reach), not a desirable architectural feature in its own right. In LAN-only deployments mDNS suffices and the coordinator can be skipped.
+
+## Deployment shapes
+
+### Solo
+
+One peer. Local SQLite. No coordinator. No replication. mDNS off. This is codemem today; the new architecture changes nothing for this user.
+
+### Two-laptop personal sync
+
+Two peers. Coordinator (or manual address config) for discovery. mDNS for same-LAN. Each laptop is a member of every scope it cares about. They sync directly via HTTP+mTLS. Anti-entropy converges them when both are online. Effectively Syncthing for memories.
+
+### Small team, single $5 VPS as always-on backstop
+
+N laptops + 1 always-on VPS. The VPS is a regular peer that happens to never sleep. It is a member of the team's shared scopes. Laptops push to it when they have new ops; laptops pull from it when they want to catch up. The VPS is not a server — it is a peer. The coordinator can run on the same VPS or separately.
+
+### Small team, no always-on peer
+
+N laptops only. Sync happens whenever any two members are online simultaneously. Data is preserved as long as at least one member is online holding the latest ops; degrades gracefully if everyone goes offline. Less convenient than having a backstop but works.
+
+### Org-scale (e.g., internal team deployment)
+
+N laptops + a small k8s deployment of, say, 3 always-on codemem instances. The 3 instances are regular peers, members of the team scopes. They participate in the swarm identically to laptops; the only difference is uptime. Each holds full local SQLite (PVC or emptyDir, depending on whether you want them to bootstrap from peers on restart vs. preserve across restarts). Laptops push to whichever of the 3 they reach first; the others pick up the ops via anti-entropy. If one pod dies, the other 2 still have the data; a replacement bootstraps from peers on startup and rejoins.
+
+There is no "internal HA quorum" mode. The 3 instances are 3 peers. The swarm-with-redundancy property comes from running multiple peers, not from a special multi-pod replication protocol.
+
+### Cross-org federation (future)
+
+Two organizations with their own deployed seeds, both holding membership in a shared scope. They replicate via the same protocol as any two laptops. Not a v1 concern; the door is open.
+
+## Implementation work
+
+### What already exists
+
+- SQLite store via better-sqlite3 + Drizzle (`packages/core/src/store.ts`, `schema.ts`)
+- Replication ops table with Lamport clock + tombstones + UUIDs (`schema.ts`)
+- HTTP sync endpoints: `/v1/ops` (cursor-based) and `/v1/snapshot` (paginated bootstrap)
+- Pull→apply→push sync pass (`packages/core/src/sync-pass.ts`)
+- mTLS-secured peer transport
+- Coordinator service with groups, enrolled devices, presence, bootstrap-grants
+- Cloudflare Worker variant of the coordinator (D1-backed)
+- mDNS discovery (`packages/core/src/sync-discovery.ts`)
+- Device key identity model
+
+### What needs to be added
+
+In rough dependency order:
+
+1. **Scope as first-class** (additive schema)
+   - Add `scope_id` to `memory_items` and `replication_ops`
+   - Plumb scope through write paths (coding-session observers tag memories with the scope they belong to)
+   - Plumb scope through read paths (queries filter by scopes the local user is a member of)
+   - Backfill existing memories with a default scope
+   - Estimate: significant ergonomic surface but mechanically straightforward
+
+2. **Membership semantics + auth at the wire**
+   - Coordinator publishes the authorized device-key set per scope (or scope-membership is signed by a group-admin device)
+   - Peers cache membership locally and verify on incoming sync requests (peer X requesting ops for scope Y must have a device key in Y's member set)
+   - Estimate: ~300 LOC across coordinator + peer auth check
+
+3. **Anti-entropy via Merkle ranges over the op-log**
+   - Compute Merkle summaries per scope over `op_id`-ordered ranges (cached, invalidated on new ops)
+   - New endpoint: `GET /v1/scope/{id}/merkle?range=...` returning hash triples
+   - Periodic background job: pick a peer, exchange Merkle for shared scopes, fetch missing ops via existing `/v1/ops`
+   - Estimate: ~400 LOC, the heaviest single piece
+
+4. **Hinted handoff**
+   - New table: `replication_hints` with target device key, scope, op references, expiry
+   - Background drainer: when a hint's target becomes reachable, deliver and clear; also try to forward through any reachable mutual scope-member
+   - Hint storage cap to prevent unbounded growth on long-offline targets
+   - Estimate: ~200 LOC
+
+5. **Coordinator pare-back**
+   - Strip bootstrap-grant complexity if it doesn't earn its keep in the simpler model
+   - Document the coordinator as "discovery + group membership + presence; never a data path"
+   - Estimate: refactor + delete; net code reduction likely
+
+Total budget: roughly 1000-1500 LOC of new TypeScript across `packages/core` and the coordinator, plus the scope-as-first-class ergonomic work which is harder to estimate.
+
+### Patterns we explicitly do not implement
+
+- Quorum write (Dynamo W+R>N) — wrong shape for intermittently-online peers
+- Consistent hashing for placement — wrong shape, membership = placement
+- SWIM gossip membership — wrong shape, no cluster
+- Coordinator-as-gateway — gone, coordinator is not a data path
+- libp2p — overkill, HTTP+mTLS is enough (Syncthing's BEP works the same way)
+- Internal HA quorum mode for multi-pod seeds — gone, a multi-pod seed is just 3 peers
+- New wire protocol — extensions to the existing HTTP API only
+
+## Claims this position is making
+
+For a reviewer to challenge:
+
+1. **Syncthing's model fits codemem's domain.** We are not a database, not a streaming platform, not a pubsub system. We are a peer-replicated structured-data store with team-scoped sharing. Syncthing is the closest existing thing.
+
+2. **Quorum is the wrong primitive for our writes.** Writers (laptops) are intermittently online. Requiring quorum acks before considering a write durable would block laptop writes during their normal operating mode. Local-immediate-durable + eventual-replication is the right semantics.
+
+3. **The coordinator should be minimal.** It exists to bridge network boundaries and provide group identity. Anything more (proxying data, gating reads, routing decisions) is an architectural mistake driven by deployment-shape thinking.
+
+4. **A "backbone" of always-on peers is a deployment artifact.** It does not require any special protocol mode. The codemem protocol treats a k8s pod identically to a laptop. The org-scale deployment property comes from running multiple peers, not from a different protocol.
+
+5. **HTTP+mTLS is sufficient transport.** libp2p, custom protocols, and other peer-to-peer stacks introduce complexity without buying us anything Syncthing doesn't already get from TLS+TCP.
+
+6. **The implementation budget is small (~1000-1500 LOC).** This depends on (4) and (5) being correct. If we needed quorum or libp2p the budget would be much larger.
+
+7. **No new deployable infrastructure is needed.** No NATS, no Postgres, no DHT bootstrap nodes, no relay pools (yet). Everything runs in the existing codemem process plus the existing coordinator.
+
+## Open questions worth challenging
+
+These are places where the position above might be wrong, or where reasonable alternatives exist:
+
+1. **Is membership signing done by the coordinator (centralized authority) or by group-admin device keys (federated authority)?** The latter is more decentralized and more Matrix-like; the former is simpler. Tradeoff: who can revoke a member, and how is revocation propagated?
+
+2. **What happens to a scope whose only member's laptop is permanently lost?** Without an always-on peer, that scope's data dies with the last living member. Is this acceptable, or does the design need to push users toward at least one always-on peer for any "important" scope?
+
+3. **Anti-entropy frequency and target selection.** Random pair selection is simple but inefficient at scale; biased toward "peers we haven't synced with recently" is better but more state to track.
+
+4. **Op-log compaction.** Long-lived scopes accumulate ops indefinitely. Do we periodically compact the op-log into a snapshot baseline, dropping old ops? If so, how do peers that have been offline for years catch up?
+
+5. **Conflict resolution beyond LWW.** LWW with Lamport ordering loses information when two peers concurrently edit the same memory. Is this acceptable for codemem's domain, or do we need richer CRDT semantics for some entity types?
+
+6. **Membership change propagation latency.** A member is revoked from a scope; how quickly does that revocation reach all current member peers, and what happens during the propagation window?
+
+7. **Should joiner UX include explicit "I just produced a write; is it shared yet?" feedback?** With eventual consistency this becomes "shared with these N members so far," which is honest but unfamiliar to users coming from synchronous-write systems.
+
+8. **Deployment ergonomics for "I want my data backed up but don't want to run my own server."** Is the answer "run a $5 VPS yourself," "join a community-run backup pool," "store an encrypted snapshot in object storage as a fallback," or something else?
+
+9. **Performance of Merkle anti-entropy at scale.** How many scopes can a single peer reasonably participate in before the periodic Merkle exchange becomes too costly?
+
+10. **Multi-org federation auth.** When two orgs share a scope, who is the trust root for membership? This is out of v1 scope but worth thinking about now to avoid painting ourselves in.
+
+## Things the prior research doc gets wrong
+
+For an external reviewer reading both docs together: the companion research doc (`2026-04-30-seed-and-mesh-architecture-research.md`) anchors on "two-tier mesh with quorum writes" framed in the Dynamo/Cassandra lineage. That framing was rejected during deliberation. Specifically:
+
+- The companion doc's "two-tier mesh: backbone vs joiner" section is wrong. There is no protocol-level distinction.
+- The companion doc's "scope ring + quorum write + hinted handoff + Merkle anti-entropy + SWIM heartbeats" pattern set is over-specified. Of those, only Merkle anti-entropy and hinted handoff survive in the converged design.
+- The companion doc's "coordinator-as-gateway" pattern is rejected. The coordinator is a phone book.
+- The companion doc's "Dynamo as reference architecture" is wrong; the right references are Syncthing and BitTorrent.
+
+The companion doc is preserved because the option survey (single-pod + Litestream, managed Postgres, JetStream log, mesh) is still useful for understanding what was considered and why each was rejected for the long-term default. But its prescriptive recommendations should be read through this doc.

--- a/docs/plans/2026-04-30-seed-and-mesh-architecture-research.md
+++ b/docs/plans/2026-04-30-seed-and-mesh-architecture-research.md
@@ -1,0 +1,181 @@
+# Seed Peer & Mesh Architecture Research
+
+**Date:** 2026-04-30
+**Status:** historical / option survey only
+**Superseded by:** `2026-04-30-seed-and-mesh-architecture-converged.md` (architecture) and `2026-04-30-sharing-domain-scope-design.md` (boundary semantics)
+
+> **Read this for context, not direction.** The Dynamo/Cassandra-style two-tier mesh, coordinator-as-gateway, quorum writes, and "stateless app pod" framings here have been rejected. The codemem direction is Syncthing-shaped peer-to-peer with sharing domain (`scope_id`) as the hard boundary. Preserve this doc for the option survey it contains, but do not implement from it. Where it conflicts with the converged or scope-design docs, those win.
+
+## Why this exists
+
+We want a notion of a **seed (or central) peer** in codemem that fits the existing distributed model without forcing adoption of a centralized SQL database (Postgres-class). Target deployment is Kubernetes with a strong preference for stateless, horizontally scaled application pods. Self-hosted only — managed third-party stores like Cloudflare D1 are out of scope as a long-term default.
+
+This document captures the architecture options surveyed, the decision frame, and the recommended direction.
+
+## Existing model — what we have to build on
+
+Established by inspecting `packages/core/src/store.ts`, `packages/core/src/schema.ts`, `packages/core/src/sync-pass.ts`, and `packages/cloudflare-coordinator-worker/`:
+
+- **Storage backend:** better-sqlite3 (single-file, synchronous), schema in Drizzle. Auto-bootstraps on first construct. Multi-writer aware via `device_id` / `origin_device_id`.
+- **Memory shape:** mutable records with `deleted_at` tombstones and `rev` counter. Identity via `entity_id` (would be the global key under replication).
+- **Sync protocol:** pull→apply→push of an append-only `replication_ops` log via HTTP (`/v1/ops`, `/v1/snapshot`). Lamport scalar clock (`clock_rev` + `clock_device_id`). Idempotent on apply by `op_id` (UUID).
+- **Snapshot bootstrap:** paginated `/v1/snapshot` for cold-start; falls back to this on cursor drift or generation mismatch.
+- **Coordinator:** registry + presence + bootstrap-grant authorization only. **Not** a sync relay or data plane. D1-backed in the Cloudflare worker variant; Hono-on-SQLite when self-hosted.
+- **Bootstrap grants:** the schema already models a `seed_device_id` → `worker_device_id` relation as a one-time authorization for snapshot pull. The "seed peer" concept exists in nascent form.
+
+**Key insight:** the op log + scalar Lamport clock + tombstone LWW is essentially a half-CRDT. It is already idempotent, mergeable, and source-agnostic. That makes most of the candidate architectures *additive* rather than *transformative* — we'd be choosing where the durable log lives, not redesigning sync.
+
+## Option survey
+
+Four architectures were evaluated.
+
+### Option A — Single-pod seed + Litestream → object storage
+
+One `replicas: 1` Deployment with `strategy: Recreate`, SQLite on PVC, Litestream sidecar continuously streaming WAL to MinIO/S3.
+
+| Pros | Cons |
+|---|---|
+| Smallest leap from current state | Single writer; no horizontal write scale |
+| Restore on pod loss is automatic | Failover takes seconds; RPO ≈ Litestream interval |
+| Closest match to existing `seed_device_id` design | Couples runtime to object store |
+| Workers stay stateless | Doesn't unlock partial replication for joiner peers |
+
+### Option B — Managed Postgres (RDS-class) backend
+
+Replace the seed pod's SQLite with managed Postgres. Drizzle already supports the dialect.
+
+| Pros | Cons |
+|---|---|
+| Boring, shippable in days | Tension with "no managed third-party store" preference |
+| Genuinely stateless seed pods | Bad fit for OSS users who don't want to run Postgres |
+| Multi-writer free, read replicas free | Forces dual-backend storage layer (SQLite default + Postgres opt-in) — maintenance tax forever |
+| Org-aligned where Postgres is the paved road | Doesn't help joiner peers (they still need local store) |
+| Backups/PITR/failover are platform's problem | New SPOF: seed pod is dead if it can't reach DB |
+| Debuggable by anyone | Doesn't unlock any new product capability |
+
+### Option C — Append-only durable log (NATS JetStream) + materialized SQLite views
+
+Pods are stateless workers. Source of truth is a JetStream stream of replication ops. Each pod has an ephemeral SQLite materialized from the stream.
+
+| Pros | Cons |
+|---|---|
+| Op log model maps directly onto JetStream | Adds NATS as an operational dependency |
+| Stateless workers, durable backbone | Stream schema evolution requires care |
+| Self-hostable, K8s-native via official Helm chart | Materialization startup latency |
+| Naturally supports multi-region via JetStream mirroring | More moving parts than necessary today |
+
+### Option D — Pure mesh (Cassandra/Dynamo-style with scope-based partial replication)
+
+Stateless Deployment of backbone pods with `emptyDir` SQLite. Pods discover each other via the coordinator, replicate at quorum, and rebuild from peers on pod loss. Joiner peers (humans on laptops) subscribe to the subset of scopes they're entitled to.
+
+| Pros | Cons |
+|---|---|
+| No external storage dependency | Real distributed-systems work — months not weeks |
+| K8s pods are true cattle (`emptyDir` is fine) | Hard problems: quorum-write, hinted handoff, cold-boot herd, scope rebalancing |
+| Survives any minority pod loss | Operational maturity has to be earned |
+| Unlocks partial replication for joiner peers | Failure modes are richer (partial partitions, divergence) |
+| Aligned with codemem's distributed character | Requires investment in anti-entropy tooling |
+| Horizontal write scale via scope sharding | Higher debugging complexity |
+
+## Comparison
+
+| Axis | A: single-pod + Litestream | B: managed Postgres | C: JetStream log | D: pure mesh |
+|---|---|---|---|---|
+| Time to ship | days | days | weeks | months |
+| Stateless seed pods | seed no, workers yes | yes | yes | yes |
+| New ops dep | object store | RDS-class DB | NATS cluster | none |
+| Self-hostable cleanly | yes | awkward | yes | yes |
+| Aligns with stated preferences | yes | partial | yes | yes |
+| Solves partial replication for joiners | no | no | partial | yes |
+| Survives arbitrary pod loss | yes (restore) | yes (managed HA) | yes (Raft) | yes (replication) |
+| Unlocks new capabilities | no | no | streaming consumers | partial replication, true horizontal scale |
+
+## Architectural insights that emerged
+
+These apply regardless of which backend wins; they are the load-bearing design ideas.
+
+### Coordinator-as-gateway is the seam
+
+The current coordinator is a registry only. Upgrading it to a **gateway** that proxies joiner traffic to the data plane lets the data plane evolve without breaking joiner clients:
+
+- Single auth/entitlement boundary
+- Topology hiding — joiners only know the coordinator URL
+- Backbone stays cluster-internal (no external exposure)
+- Backend swap is a server-side change, transparent to joiners
+- The gateway is itself stateless and horizontally scalable
+
+This is the abstraction that makes "ship the simple version now, swap to the ambitious version later" actually work.
+
+### Scope as a first-class replication unit
+
+Today every peer holds every memory. For mesh and for partial joiner replication, **scope** (likely `workspace_id`, possibly group/team) needs to be first-class:
+
+- Every op carries its scope
+- Pods advertise which scopes they host
+- Joiners subscribe to the scopes they're entitled to
+- New pod boots → coordinator assigns scopes → it pulls them from peers
+- Pod loss → coordinator reassigns → other pods backfill
+
+This is an additive schema/ergonomic change with high leverage. It is also a precondition for any of the more ambitious options actually being useful.
+
+### Two-tier mesh: backbone vs joiners
+
+Backbone pods (in-cluster, k8s deployment, `emptyDir`) do quorum writes and host scopes per a hash ring. Joiner peers (laptops, ephemeral agents) are read-mostly observers with cursors; their writes get forwarded into the backbone for durability. Joiners don't participate in quorum and don't need to be reachable from inside the cluster.
+
+This separation kills most of the P2P complexity that would otherwise come from treating laptops as full replication participants.
+
+### Building blocks worth stealing
+
+- **libp2p** for transport (discovery, encrypted streams, NAT traversal for joiners, pubsub)
+- **`memberlist` / SWIM** for backbone cluster membership
+- **Cassandra vnodes** for incremental scope rebalancing
+- **Matrix room model** for scope membership/entitlement (cryptographically self-describing groups, fits existing device key + group enrollment)
+- **Automerge-Repo's `Repo` + `DocumentId` interface design** as a reference for scope-keyed pluggable network/storage adapters
+
+### Hard problems we will own if we build the mesh
+
+1. **Quorum-on-write.** `emptyDir` + RF≥2 means writes must ack from ≥W pods before client sees success. ~5–10ms LAN latency. Acceptable for codemem workload.
+2. **Hinted handoff.** During pod loss, writes go to a non-hosting pod with a "deliver to X when it returns" hint. Without this, write availability tanks during rolling restarts.
+3. **Cold-boot thundering herd.** Multiple pods booting empty must coordinate so they don't all try to pull from each other. Need a "boot from one survivor before accepting writes" rule and a readiness gate based on "caught up on assigned scopes".
+4. **Scope rebalancing.** Scaling 3→5 pods redistributes scopes. Vnode trick (each pod owns many small ranges) keeps movement incremental.
+5. **Anti-entropy granularity.** Merkle ranges per scope. Cheap when most scopes are quiet; scales with active scope count, not total data.
+
+## Decision frame
+
+### Recommended direction
+
+**Long-term:** Option D (full mesh) is the architecture with the most product payoff and the strongest alignment with codemem's distributed character. It is the only option that:
+
+- Removes external state dependencies entirely
+- Treats k8s pods as true cattle
+- Unlocks scope-based partial replication for joiner peers
+- Provides a horizontal write-scale story
+
+It is also the most engineering work. That cost is acknowledged and accepted as the right investment.
+
+**Interim:** make the storage layer pluggable. Default to SQLite. Allow Postgres as an opt-in for environments that prefer managed durability. Keep the sync wire protocol stable across backends so the eventual mesh is a drop-in for the seed today.
+
+**The unifying abstraction is the coordinator-as-gateway.** Whatever backend the seed runs (single-pod + Litestream today, mesh tomorrow), joiners only ever talk to the gateway. That is the layer we should design carefully now even if we don't ship the mesh until later.
+
+### What's explicitly out of scope
+
+- **Cloudflare D1** as a default (managed third-party).
+- **Postgres as the only option** — pluggable yes, mandatory no.
+- **Pure-mesh joiners** — joiners stay read-mostly observers, not full quorum participants. The complexity of NAT traversal + flaky-laptop quorum is not worth it.
+
+## Decomposition for planning
+
+If we commit to the mesh direction, three concerns should be independently shippable:
+
+1. **Scope as a data-model concept.** Additive schema change adding a `scope_id` to ops and memories. No behavior change. Ships first; unblocks everything else.
+2. **Coordinator-as-gateway.** Wraps the existing seed (single pod today). Establishes the joiner-facing API and the backend interface. Lets us validate the abstraction without the mesh existing.
+3. **Backbone mesh.** RF, hash ring, quorum-write, hinted handoff, anti-entropy. Hard, bounded in surface area because joiners don't participate.
+
+Doing them in this order means each layer is shippable and useful before the next exists.
+
+## Next steps
+
+- Convert this research into a phased plan (epic + child tasks) for the mesh work.
+- Prototype the coordinator-as-gateway shape against the existing single-pod seed to validate the API surface before committing to mesh internals.
+- Spike on libp2p as the backbone transport vs. plain HTTP+gossip on top of the existing sync API.
+- Draft the `scope_id` schema migration and the entitlement model for joiners.

--- a/docs/plans/2026-04-30-sharing-domain-scope-design.md
+++ b/docs/plans/2026-04-30-sharing-domain-scope-design.md
@@ -1,0 +1,900 @@
+# Sharing Domain / Replication Scope Design
+
+**Date:** 2026-04-30  
+**Status:** design / pre-implementation  
+**Related:** `2026-04-30-seed-and-mesh-architecture-converged.md`, `2026-04-30-seed-and-mesh-architecture-research.md`, `2026-04-22-multi-team-coordinator-groups-design.md`, `2026-03-08-shared-memory-trust-state-semantics.md`
+
+When this document conflicts with `2026-04-30-seed-and-mesh-architecture-research.md`, the converged Syncthing-shaped position wins: no quorum backbone, no coordinator-as-gateway, no coordinator data path, and no special seed protocol role.
+
+## Authoritative invariants (mirror)
+
+These mirror the invariants in `2026-04-30-seed-and-mesh-architecture-converged.md` and govern all scope-related work. The converged doc holds the canonical wording; this list is for orientation:
+
+1. Sharing domain (`scope_id`) is the hard data boundary in Phase 2; legacy compatibility is an audited exception, not an exemption.
+2. Project include/exclude only narrows; basename matches are display-only.
+3. Coordinator group membership is not data access; scope grants are explicit and audited.
+4. Coordinator is never a data path.
+5. Seed/anchor peers are deployment artifacts, not protocol roles.
+6. Visibility gates eligibility; scope membership gates destination.
+7. Revocation prevents future sync; outbound MUST re-validate membership per op batch; default cache TTL ≤ 60 s.
+8. Local-first; no quorum primitive.
+9. `claimed_local_actor` is retracted in Phase 2; same-actor private sync moves to a signed `personal:<actor_id>` scope.
+10. Local-only scopes (`authority_type='local'`) never replicate outbound.
+11. Inbound `scope_id` is authoritative from the op row; receivers do not re-resolve.
+
+Any change that loosens one of these invariants must supersede it explicitly in a dated decision doc.
+
+## Decision summary
+
+codemem should introduce a first-class **replication scope** as the hard trust and data-sharing boundary. Internally this should be represented as `scope_id`. User-facing surfaces should call it a **Sharing domain** unless a narrower product label emerges.
+
+This separates concepts that are currently adjacent but overloaded:
+
+| Concept | Meaning | Enforcement role |
+|---|---|---|
+| Project / workspace | Where a memory came from | Classification and user navigation |
+| Replication scope / Sharing domain | The hard boundary that determines which devices may receive data | Primary sync authorization boundary |
+| Coordinator group / team | Discovery, enrollment, admin, and defaults | Membership and policy management container |
+| Peer project filters | Per-peer include/exclude narrowing | Secondary selection policy |
+| Visibility | Whether a memory is eligible to leave the local device at all | Sync eligibility gate |
+| Trust state | Provenance confidence | Descriptive metadata, not an auth gate |
+
+The invariant is:
+
+> **A memory may only replicate to a peer if the peer is authorized for the memory's `scope_id`. Project include/exclude filters can narrow that result, but they must never widen it.**
+
+## Problem
+
+codemem already has several scope-like ideas:
+
+- `memory_items.workspace_id` and `workspace_kind` describe origin/workspace context.
+- `memory_items.visibility` controls whether an item is private or shareable.
+- `sync_peers.projects_include_json` and `projects_exclude_json` control peer-level project selection.
+- Coordinator groups provide discovery/admin context and can seed default project filters.
+- Retrieval and MCP tools can filter by actor, visibility, workspace, and trust metadata.
+
+Those primitives work for the current peer-filter model, but they are not a strong enough boundary for mixed personal/work/team machines. A single codemem instance may contain memories for personal projects, employer work, OSS, and client projects. Some of those should never cross organizational boundaries even if a peer filter is broad or a coordinator group default is misconfigured.
+
+Peer project filters answer “what does this peer care about?” They should not be the root security model. The system needs a stable field on each memory and replication op that answers “which sharing boundary owns this data?”
+
+## Goals
+
+- Make the sharing boundary explicit, durable, and visible.
+- Keep local-first behavior: writes remain durable locally before replication.
+- Preserve the converged peer-to-peer architecture: no coordinator data path, no quorum backbone.
+- Support mixed personal/work machines safely.
+- Keep coordinator groups as discovery/admin containers, not data boundaries.
+- Preserve existing peer include/exclude filters as a compatibility and narrowing layer.
+- Provide a migration path that defaults existing data safely.
+- Create work tracks that can be implemented incrementally before anti-entropy or hinted handoff.
+- Keep scope metadata non-authoritative and mostly invisible until membership authority and enforcement exist.
+
+## Non-goals
+
+- No coordinator-as-gateway or coordinator-proxied memory payloads.
+- No quorum write semantics.
+- No libp2p or new transport stack.
+- No automatic deletion of data already copied to a revoked device.
+- No cryptographic payload encryption design in this document; that is related but separate work.
+- No immediate removal of existing project filters or workspace fields.
+- No cross-org federation implementation in the first scope release.
+
+## Terminology
+
+### Sharing domain
+
+The user-facing name for a replication scope. A sharing domain is the boundary a user understands: “Personal,” “Acme Work,” “Client A,” “OSS codemem.”
+
+### `scope_id`
+
+The internal stable identifier for a sharing domain. Every shareable memory and every replication op should eventually carry a `scope_id`.
+
+### Project mapping
+
+A local rule that maps an observed project/workspace to a default `scope_id`. Example: `/work/acme/*` maps to `acme-work`; `/Users/adam/personal/*` maps to `personal`.
+
+#### Canonical workspace identity
+
+Project mapping for any scope decision MUST use a canonical workspace identity. Basename-style names (e.g. `sessions.project = 'codemem'`) are display-only and never participate in scope resolution.
+
+The canonical identity is the first non-empty value from this ladder:
+
+1. `git_remote` (preferred when available — globally unique)
+2. `git_remote + ':' + git_branch` when branch-level scoping is needed (rare; opt-in per mapping)
+3. Absolute `cwd` from the session row, normalized (resolved symlinks, no trailing slash)
+4. `workspace_id` (when set by an external integration)
+5. The literal string `unmapped:<sha256-of-cwd-or-project>` if every signal above is missing
+
+The resolver records which signal was used so the UI can show "matched on git_remote" vs "matched on cwd" for debugging.
+
+Two projects with the same basename and different git remotes MUST resolve to different scopes. The resolver test suite includes this fixture explicitly.
+
+Basename-only matches are allowed only in:
+
+- the legacy peer compatibility filter (existing `sync_peers.projects_*` semantics, deprecated path);
+- display strings shown to users.
+
+Basename-only matches MUST NOT be used in:
+
+- outbound scope authorization;
+- inbound scope authorization;
+- snapshot/reset boundary decisions;
+- migration auto-promotion to a non-`legacy-shared-review` scope.
+
+During migration, any historical row whose only signal is a basename-style `sessions.project` falls into `legacy-shared-review` regardless of how the existing `sync_peers.projects_include_json` would have routed it.
+
+### Scope membership
+
+The set of device keys authorized to read/write data in a `scope_id`. Membership may be published by a coordinator in v1 and should be shaped so group-admin device signatures can be added later.
+
+### Peer policy
+
+A per-peer narrowing layer. It can restrict projects, possibly directions, and future sync preferences, but it cannot grant access to a scope the peer is not authorized for.
+
+## Conceptual model
+
+```mermaid
+flowchart TD
+    P[Project / workspace] -->|mapped locally| S[Sharing domain / scope_id]
+    S -->|authorizes| M[Scope members: device keys]
+    G[Coordinator group / team] -->|manages or suggests| S
+    G -->|discovers| D[Devices / peers]
+    D -->|explicit trust creates| R[Sync peer relationship]
+    R -->|narrows via include/exclude| P
+    MI[Memory item] -->|stamped with| S
+    MI -->|has| V[visibility]
+    MI -->|replicates only if all gates pass| PEER[Authorized peer]
+```
+
+## Enforcement model
+
+Outbound replication should evaluate gates in this order:
+
+1. **Scope gate** — the target peer must be a current authorized member of the memory/op `scope_id`.
+2. **Visibility gate** — the memory must be shareable. Existing `visibility=shared` semantics remain the baseline.
+3. **Peer project filter gate** — include/exclude project rules may narrow which memories the peer receives.
+4. **Direction/policy gate** — future role/direction/policy fields may narrow further.
+
+The important property is monotonic narrowing: each later gate can only remove data from the candidate set. No gate after the scope gate can add authorization.
+
+Inbound replication should also verify scope membership before applying ops:
+
+- The sending peer must be authorized for each op's `scope_id`.
+- The receiving peer must also be a member of that `scope_id`; otherwise it should reject or quarantine the op.
+- Legacy ops without `scope_id` are accepted only during migration under explicit compatibility rules.
+
+## Data model proposal
+
+### New local tables
+
+#### `replication_scopes`
+
+Local cache/config for sharing domains.
+
+```sql
+CREATE TABLE replication_scopes (
+  scope_id TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  kind TEXT NOT NULL DEFAULT 'user', -- personal | team | org | client | system | user
+  authority_type TEXT NOT NULL DEFAULT 'local', -- local | coordinator | signed_manifest
+  coordinator_id TEXT,
+  group_id TEXT,
+  manifest_issuer_device_id TEXT,
+  membership_epoch INTEGER NOT NULL DEFAULT 0,
+  manifest_hash TEXT,
+  status TEXT NOT NULL DEFAULT 'active', -- active | archived | revoked
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+```
+
+#### `project_scope_mappings`
+
+Local mapping from projects/workspaces to default sharing domains.
+
+```sql
+CREATE TABLE project_scope_mappings (
+  id INTEGER PRIMARY KEY,
+  workspace_identity TEXT,
+  project_pattern TEXT NOT NULL,
+  scope_id TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 0,
+  source TEXT NOT NULL DEFAULT 'user', -- user | coordinator_default | migration | inferred
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+```
+
+Rules should be deterministic: highest priority wins; ties break by most specific pattern, then newest update. Exact project IDs should be preferred over broad path globs where possible.
+
+Rows derived only from basename-style historical project data should default to review/suggestion status rather than silently authorizing sync into an organizational domain.
+
+#### `scope_memberships`
+
+Local cache of device membership by scope.
+
+```sql
+CREATE TABLE scope_memberships (
+  scope_id TEXT NOT NULL,
+  device_id TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'member', -- member | admin | observer
+  status TEXT NOT NULL DEFAULT 'active', -- active | revoked | pending
+  membership_epoch INTEGER NOT NULL DEFAULT 0,
+  coordinator_id TEXT,
+  group_id TEXT,
+  manifest_issuer_device_id TEXT,
+  manifest_hash TEXT,
+  signed_manifest_json TEXT,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (scope_id, device_id)
+);
+```
+
+The schema should leave room for signed manifests even if v1 starts with coordinator-issued membership.
+
+Use explicit `(coordinator_id, group_id)` fields instead of a generic authority reference. Group IDs can collide across coordinators, and future multi-coordinator support is already an intentional design constraint.
+
+### Existing table additions
+
+#### `memory_items`
+
+Add nullable first, then make required once all write paths are migrated:
+
+```sql
+ALTER TABLE memory_items ADD COLUMN scope_id TEXT;
+CREATE INDEX idx_memory_items_scope_visibility_created
+  ON memory_items(scope_id, visibility, created_at);
+```
+
+`workspace_id` remains origin/retrieval metadata. It should not become the authorization boundary.
+
+#### `replication_ops`
+
+Add nullable first:
+
+```sql
+ALTER TABLE replication_ops ADD COLUMN scope_id TEXT;
+CREATE INDEX idx_replication_ops_scope_created
+  ON replication_ops(scope_id, created_at, op_id);
+```
+
+For upsert ops, `scope_id` should match the payload memory's `scope_id`. For delete ops, `scope_id` is still required so tombstones are routed only inside the correct sharing domain.
+
+#### `sync_peers`
+
+Keep existing project include/exclude fields. Add a cached set of allowed scopes if needed for fast local filtering, or derive from `scope_memberships` by peer device id.
+
+Preferred v1: derive from `scope_memberships` to avoid duplicated truth. Add denormalized cache only if performance demands it.
+
+#### Sync state
+
+Scope-aware cursors need matching scope-aware reset and retention state. Current peer-level cursor and global reset state are too broad for independent sharing domains.
+
+V1 should introduce per-scope sync state shaped around:
+
+```text
+(peer_device_id, scope_id) -> cursor state
+scope_id -> snapshot generation, snapshot id, baseline cursor, retained floor cursor
+```
+
+Bootstrap reset must replace or rebuild only the requested scope. It must never delete or reset all shared memories on a mixed personal/work database.
+
+### Coordinator data
+
+Coordinator groups manage discovery, admin, and membership. Group membership is not data access. The coordinator's data model MUST keep group membership and scope membership in distinct tables and distinct admin actions.
+
+Rules for v1:
+
+- A coordinator group MAY suggest a default scope at enrollment time (UI suggestion only).
+- The coordinator MUST NOT auto-create a scope as a side effect of group creation.
+- The coordinator MUST NOT auto-grant any device to any scope as a side effect of joining a group.
+- Granting a device to a scope is a separate, explicit `addDeviceToScope(scope_id, device_id, role, authority)` admin action with its own audit log entry.
+- Revoking a device from a scope is a separate, explicit action with its own audit log entry.
+- A device may be in a group with zero scope grants, and a device may hold scope grants without being in a group (e.g. a personal-scope device).
+
+Coordinator additions in v1:
+
+- group-scoped list of suggested scopes (label + default project template; no membership)
+- per-scope device grants (separate from group enrollment)
+- signed or coordinator-issued membership manifests with monotonic per-scope epochs
+- audit log entries for every grant/revoke
+
+### Reset state migration path
+
+`sync_reset_state` and `sync_retention_state` are currently singletons in `packages/core/src/schema.ts`. Per-scope reset/retention is a structural change, not an additive one. The migration path is fixed:
+
+1. Introduce per-scope tables alongside the singletons:
+
+   ```sql
+   CREATE TABLE sync_reset_state_v2 (
+     scope_id TEXT PRIMARY KEY,
+     generation INTEGER NOT NULL,
+     snapshot_id TEXT NOT NULL,
+     baseline_cursor TEXT,
+     retained_floor_cursor TEXT,
+     updated_at TEXT NOT NULL
+   );
+   CREATE TABLE sync_retention_state_v2 (
+     scope_id TEXT PRIMARY KEY,
+     last_run_at TEXT,
+     last_duration_ms INTEGER,
+     last_deleted_ops INTEGER NOT NULL DEFAULT 0,
+     last_estimated_bytes_before INTEGER,
+     last_estimated_bytes_after INTEGER,
+     retained_floor_cursor TEXT,
+     last_error TEXT,
+     last_error_at TEXT
+   );
+   ```
+
+2. Seed exactly one row in each new table for `scope_id = 'local-default'` from the existing singleton row. Generation, snapshot_id, baseline_cursor, and retained_floor_cursor carry over verbatim.
+3. Existing peer cursors remain valid for `local-default`; they are not invalidated by the migration. There is no forced-resync stampede during Phase 1.
+4. New scopes start at `generation = 1` with no baseline cursor. Bootstrap of a new scope produces an initial baseline.
+5. The singleton tables are kept read-only for one release window for rollback. Phase 1 → Phase 2 promotion deletes them.
+6. `(peer_device_id, scope_id)` cursors are added to a new `replication_cursors_v2` table; existing per-peer cursors are migrated as the `local-default` cursor for that peer.
+7. Op streams that straddle the migration boundary remain valid because `local-default` retains the original generation and baseline; ops without `scope_id` resolve to `local-default` for routing under Phase 1 rules only.
+
+## Default behavior
+
+### New install
+
+Create a local-only default scope:
+
+- `scope_id`: `local-default` or generated stable local ID
+- label: `Local only`
+- default visibility: `private`
+- authority: `local`
+
+No memory should leave the device by default.
+
+### Enabling sync
+
+When a user pairs with a peer or joins a coordinator group, codemem should guide them to choose or create a sharing domain:
+
+- Personal devices: “Personal” domain.
+- Team coordinator group: “Team” domain suggested by coordinator.
+- Contractor/client case: separate client domain.
+
+The UI should make the resulting boundary visible: “Project X shares to Acme Work” or “Project X is local only.”
+
+### Unknown project
+
+If no mapping matches the current project, default to the safest configured scope:
+
+1. explicit user-selected current scope, if the session launched with one;
+2. project-specific mapping, if discovered during previous sessions;
+3. local-only default scope.
+
+Do not infer “current coordinator group” as the default sharing domain for unknown projects. That is the leak-prone path.
+
+### Existing databases
+
+Migration should create:
+
+- a local-only default scope;
+- a legacy shared scope for existing shared memories if needed;
+- mappings inferred from existing peer project filters only as suggestions, not as silent hard policy.
+
+Backfill rules:
+
+- `visibility=private` or personal visibility -> local-only scope.
+- `visibility=shared` with clear `workspace_id`/project and existing peer filters -> candidate shared scope, but mark source as `migration` and surface for review.
+- ambiguous shared rows -> `legacy-shared-review` or equivalent, not broad org scope.
+
+The migration should favor under-sharing over accidental cross-boundary sharing.
+
+Scope metadata added during migration is not authoritative until membership authority exists. Before that point it should be treated as classification metadata and used for diagnostics/review, not as a half-enforced security boundary.
+
+## Write path
+
+Every memory write path needs a scope resolver:
+
+1. Determine session project/workspace.
+2. Match project/workspace against `project_scope_mappings`.
+3. Apply explicit runtime/session override if present.
+4. Fall back to local-only scope.
+5. Stamp `memory_items.scope_id`.
+6. Record `replication_ops.scope_id` when materializing shared ops.
+
+Observer output should not choose the scope. Scope is local policy, not LLM output.
+
+Scope assignment is effectively immutable for a replicated memory. If a user moves a memory from one sharing domain to another after it may have replicated, the system applies an atomic reassignment op:
+
+- A new replication op type `reassign_scope` carries `(entity_id, old_scope_id, new_scope_id, clock_rev, clock_updated_at, clock_device_id)`.
+- Receivers that are members of `old_scope_id` AND `new_scope_id` apply the reassignment in place and update local indexes.
+- Receivers that are members of only `old_scope_id` apply a tombstone for the old scope and drop the memory.
+- Receivers that are members of only `new_scope_id` accept the memory as a new upsert if the originating sender is authorized for the new scope at the current epoch; otherwise the op is rejected with `scope_mismatch`.
+- Receivers in neither scope reject the op with `receiver_not_member`.
+- Lamport ordering applies as usual; out-of-order delivery is handled because both scopes' op streams are independent and the reassignment carries the canonical clock.
+
+The UI MUST warn before reassignment that previous recipients of the old scope may retain already-copied data and that reassignment is best-effort beyond the local device. Reassignment is logged in the audit trail with the actor, old/new scope, and timestamp.
+
+## Read and retrieval path
+
+Retrieval should filter by scopes visible to the local actor/device by default. Existing filters continue to work:
+
+- actor filters answer “whose memory?”
+- visibility filters answer “private/shared?”
+- workspace filters answer “where did it come from?”
+- scope filters answer “which sharing boundary?”
+
+MCP tools should gain scope-aware filters only after the store/search layer can enforce local membership by default. Tools must not expose memories from scopes the local actor/device is not allowed to read.
+
+This must be a store/search invariant across all retrieval paths, not a UI-only filter. Scope checks need to apply before ranking or packaging in:
+
+- FTS search;
+- sqlite-vec semantic search;
+- hybrid pack construction and prompt injection;
+- timeline/recent/search-index tools;
+- memory expansion and explain tools;
+- viewer APIs;
+- MCP tools.
+
+Vectors inherit the scope of their memory item. Raw events, transcripts, and artifacts remain local-only unless a future design explicitly makes them replicable.
+
+## Sync path
+
+### `/v1/ops`
+
+Requests should include requested scope(s), either as query params or a request field depending on the existing API shape. Responses should only include ops whose `scope_id` is mutually authorized.
+
+Cursor state should become scope-aware. A single peer-level cursor is too coarse once peers share multiple domains with different membership and retention histories.
+
+Possible cursor key:
+
+```text
+(peer_device_id, scope_id)
+```
+
+### `/v1/snapshot`
+
+Snapshot bootstrap should also be scope-aware. A peer joining `acme-work` should not receive a database-wide snapshot filtered only after scanning. The query should be bounded by `scope_id` first, then visibility/project filters.
+
+Snapshot generations, baselines, and retained floors should be tracked per scope so pruning or resetting one sharing domain does not force unrelated domains to resync.
+
+### Applying ops
+
+The receiver should reject ops when:
+
+- `scope_id` is missing after compatibility mode ends;
+- sender is not a member of the scope;
+- receiver is not a member of the scope;
+- membership epoch is stale relative to cached revocation data;
+- op payload `scope_id` and op row `scope_id` disagree.
+
+Rejected ops should be visible in sync diagnostics, not silently ignored.
+
+### Inbound `scope_id` is taken from the op row, not re-resolved
+
+On inbound, `scope_id` is taken from the op row only. The receiver does NOT re-run project→scope resolution against the payload's `project` field. The sender's resolution at minting time is binding for that op's `scope_id`. The receiver's job is:
+
+1. Verify the sender is authorized for the op's `scope_id` at the latest known epoch.
+2. Verify the receiver itself is authorized for the op's `scope_id`.
+3. Verify the op was minted by a sender authorized at minting time (clock_device_id consistency).
+4. Verify payload metadata does not contradict the op row (e.g. embedded `scope_id` in payload, if present, must match the op row's `scope_id`).
+
+Disagreement between op-row `scope_id` and embedded payload `scope_id` is a hard reject with `scope_mismatch`. Project field disagreement is logged but does not change scope routing; the op-row `scope_id` is authoritative.
+
+### Hinted handoff (deferred work) MUST verify membership at delivery time
+
+Hinted handoff is deferred until after the foundation tracks land, but its semantics are pinned now:
+
+- A hint stored on peer A targeting peer B is metadata only; the underlying op carries its own `scope_id` and authorization.
+- When peer C (or peer A) attempts to deliver the hint to peer B, C MUST re-validate B's membership in the op's `scope_id` at C's latest known epoch.
+- A hint stored when B was a member but delivered after B is revoked MUST be dropped, not forwarded. The drop is logged with `stale_epoch`.
+- Hinted handoff cannot route an op to a peer that is not a member of the op's scope at delivery time, regardless of any prior state.
+- Hint storage caps and TTLs apply per scope, not per peer, so a long-revoked peer cannot accumulate unbounded hints in a single scope.
+
+### Private same-actor sync
+
+Current sync has a `claimed_local_actor` path that allows private memory sync between devices owned by the same actor. In Phase 2 this bypass is retracted (Invariant 9). Private same-actor sync MUST go through a `personal:<actor_id>` scope whose membership manifest is signed by an actor-controlled key. The actor's own devices are the only members. An org/work scope cannot receive private memories merely because a peer claims the same actor.
+
+Phase 1 → Phase 2 promotion fails closed if any `sync_peer` row still asserts `claimed_local_actor=1` without a corresponding `personal:` scope grant for the same device. Operators are guided to migrate by issuing a `personal:<actor_id>` scope and granting the same-actor devices to it before promotion.
+
+## Legacy peer compatibility and rollout gates
+
+Scope enforcement cannot be turned on globally in one release. Older peers will not understand `scope_id`, and existing databases will not have scope membership populated. The rollout has explicit phases, signaled at the protocol level, with strict rules about when scope metadata becomes authoritative.
+
+### Protocol versioning
+
+- Add a sync protocol capability advertisement (request header or capability field) so peers can discover one another's scope support: `unsupported`, `aware`, `enforcing`.
+- A peer's stance is observable per session and recorded in `sync_attempts` for diagnostics.
+- Capability downgrade is allowed (a peer that supports enforcing may speak `aware` to a legacy peer); capability upgrade is not.
+
+### Three-state per-deployment posture
+
+Each deployment has one of:
+
+- **Phase 0 — pre-scope.** Build does not yet include scope schema. No scope behavior. Existing peer/project filters apply.
+- **Phase 1 — aware.** Scope schema and resolver exist; new local writes stamp `scope_id`; outbound sync still uses legacy filters; inbound ops accept missing/unknown `scope_id` for backward compatibility. Scope metadata is informational only.
+- **Phase 2 — enforcing.** Scope membership is authoritative; outbound and inbound sync gate on scope; legacy peers are accepted only with explicit allowlists per peer.
+
+The transition from Phase 1 to Phase 2 is the gate at `codemem-ov4g.8`. Scope metadata MUST NOT be used for security decisions before Phase 2.
+
+#### Phase state is derived, not configured
+
+Phase state MUST be a derived value, not a config flag an operator can flip independently of system state. The derivation is:
+
+```
+phase = 0 if no scope schema is present
+      = 1 if scope schema is present AND any precondition for Phase 2 is unmet
+      = 2 if all of:
+          - every active scope has a current signed or coordinator-issued
+            membership manifest with a non-stale epoch
+          - no `sync_peer` row has `claimed_local_actor=1` without a matching
+            `personal:<actor_id>` scope grant for the same device
+          - the deployment is configured to enforce (operator opt-in flag,
+            but only consulted when the structural preconditions are met)
+          - capability negotiation has been live for at least one full
+            release window
+```
+
+The UI banner that shows "Scope metadata is informational only — boundaries are not yet enforced" reads from the same derived value. There is no path to display Phase 2 in the UI while running Phase 1 enforcement code, or vice versa.
+
+Phase 2 promotion fails closed with a structured error listing the unmet preconditions; the operator cannot bypass.
+
+### Behavior toward legacy peers
+
+When a peer advertises `unsupported`:
+
+- It still receives only `visibility=shared` memories that pass existing project filters.
+- In Phase 2, it additionally receives only memories whose resolved `scope_id` matches a per-peer "legacy compatibility scope" the operator has explicitly configured.
+- The default is no legacy compatibility scope, which means a legacy peer receives nothing once enforcing.
+- It cannot send memories that the receiver would have rejected by scope; receivers in Phase 2 reject inbound legacy ops unless the sender is on the legacy compatibility allowlist for the receiver.
+- UI marks the peer with a "legacy" badge and explains what changes when enforcement is enabled.
+
+#### Legacy compatibility scope is bounded
+
+To prevent operators from using legacy compatibility as an unbounded leak primitive, the following constraints are mandatory:
+
+- A scope is a valid legacy compatibility target ONLY IF the legacy peer was already an authorized recipient of that data under pre-Phase-2 rules. Operationally that means the legacy peer's existing `sync_peers` row must show prior successful sync attempts overlapping the project pattern that resolves to that scope.
+- A legacy compatibility scope MUST NOT include any scope created by `migration` source (`legacy-shared-review`, `local-default`, etc.).
+- A legacy compatibility scope MUST NOT include any scope whose `authority_type` is `local` (Invariant 10).
+- Configuring or changing a legacy compatibility scope is a privileged admin action that emits an audit event with reason "legacy-compat-grant", actor identity, target peer, target scope, and prior-sync evidence summary.
+- The UI MUST display "This peer cannot prove scope membership; you are granting it access without cryptographic authorization" each time the operator opens the configuration screen.
+
+If any of these constraints fail, the deployment refuses to set the legacy compatibility scope and reports a structured reason code.
+
+### When scope metadata becomes authoritative
+
+Scope metadata is authoritative if and only if all of the following are true:
+
+1. The local deployment is in Phase 2.
+2. The local membership cache has a current epoch from coordinator or signed manifest authority for the scopes in question.
+3. The op's `scope_id` is present, non-empty, and recognized.
+4. Sender and receiver both pass scope membership checks at the current epoch.
+
+If any condition fails, the op is handled per Phase 1 rules and a diagnostic reason code is recorded. The system MUST NOT silently authorize sync based on partial scope information.
+
+### Backfill and review behavior
+
+Scope metadata added by migration is treated as classification metadata in Phase 1. It cannot promote a memory's reach beyond what existing peer filters and visibility already allowed. Migration biases toward under-sharing:
+
+- private/personal visibility -> local-only scope
+- shared with clear workspace + existing peer reach -> migration-tagged shared scope (visible in Sync UI as "Migrated" until reviewed)
+- ambiguous shared -> `legacy-shared-review` scope; not eligible for outbound sync until a human or admin reassigns
+
+Operators must perform a review pass before enabling Phase 2; the UI surfaces an explicit list of unreviewed memories.
+
+### Rollback
+
+Phase 2 -> Phase 1 rollback is supported per-deployment by config. Rollback does not retract data already sent; it stops further enforcement. Rollback past Phase 1 (removing scope metadata) is not supported in v1.
+
+### Diagnostics and warnings
+
+While Phase 1 is active and any UI surface displays scope information, that surface MUST also display "Scope metadata is informational only — boundaries are not yet enforced" or equivalent. Operators must not be allowed to mistake Phase 1 visibility for enforcement.
+
+### Rollout sequencing
+
+The rollout phases map to Beads gates:
+
+- Phase 0 -> Phase 1: enabled when `codemem-ov4g.2.4` lands and scope stamping is correct.
+- Phase 1 -> Phase 2: enabled only after `codemem-ov4g.8` review checkpoint passes; gates outbound/inbound enforcement, snapshot scoping, retrieval/MCP filtering.
+- Phase 2 -> docs/release: gated on `codemem-ov4g.9` review checkpoint.
+
+## Coordinator role
+
+The coordinator remains discovery, presence, invite/join flow, and membership publication. It should not store memory payloads or proxy sync data.
+
+Coordinator groups can manage sharing domains:
+
+- list scopes available in a group;
+- publish member device sets by scope;
+- provide default project templates for new peer enrollment;
+- publish signed or coordinator-issued membership epochs;
+- record revocations.
+
+The coordinator should not automatically convert group membership into full data access for every scope in the group. Admin flows should explicitly grant devices to scopes.
+
+## Revocation semantics
+
+Revocation prevents future sync; it cannot erase knowledge already replicated to a device.
+
+Required v1 behavior:
+
+- Membership has an epoch/version.
+- Peers reject requests from devices revoked in the latest known epoch.
+- Peers stop pushing new ops to revoked devices.
+- UI states that revocation does not remove already-copied local data from the revoked machine.
+
+Future encrypted-storage work can add key rotation so revoked devices cannot decrypt future payloads. That belongs with the e2e encryption design, not this base scope model.
+
+## UI and UX
+
+### User-facing language
+
+Prefer **Sharing domain** over “scope” in the UI.
+
+Examples:
+
+- “Local only”
+- “Personal”
+- “Acme Work”
+- “Client A”
+- “OSS codemem”
+
+### Project settings surface
+
+Users should be able to see and change:
+
+- project -> sharing domain mapping;
+- whether memories from this project default to private or shared;
+- which peers/devices are members of that domain;
+- whether there are broad patterns that could catch unknown projects.
+
+### Peer surface
+
+Peer rows should show:
+
+- authorized sharing domains;
+- project filter narrowing;
+- last sync per domain, eventually;
+- blocked/rejected sync caused by scope mismatch.
+
+### Coordinator/admin surface
+
+Group detail should show:
+
+- scopes managed by the group;
+- members per scope;
+- default project templates;
+- enrollment/revocation actions.
+
+### Mixed personal/work safety
+
+The product should assume mixed machines are normal. Useful guardrails:
+
+- Unknown projects default to local-only.
+- Work/org domains should never auto-include arbitrary paths.
+- Broad includes like `*` or home-directory roots should trigger warnings when attached to org domains.
+- UI should show the current project's sharing domain during sync setup and in settings.
+
+## Validation strategy
+
+### Unit tests
+
+- Scope resolver chooses explicit mapping before fallback.
+- Unknown project falls back to local-only.
+- Peer project filters cannot widen scope authorization.
+- Private visibility blocks sync even when scope membership allows it.
+- Private same-actor sync only works through an allowed personal scope, not through org scopes.
+- Inbound op is rejected when sender lacks scope membership.
+- Inbound op is rejected when op and payload scope disagree.
+- Scope reassignment emits old-scope tombstone plus new-scope upsert.
+
+### Integration tests
+
+- Two peers sharing one scope sync only that scope.
+- Two peers sharing two scopes maintain independent cursors.
+- Two scopes maintain independent snapshot/reset/retention boundaries.
+- Work peer never receives personal scope data from a mixed device.
+- Coordinator group can seed a project template without automatically granting all group data.
+- Revoked device no longer receives new ops.
+
+### E2E smoke
+
+- Configure personal + work projects on one machine.
+- Pair one work peer and one personal peer.
+- Create memories in both projects.
+- Verify each peer receives only its domain.
+- Verify MCP/search on each peer sees only locally authorized scopes by default.
+
+## Rollout plan
+
+### Phase 0 — Design lock
+
+- Accept this design or revise it.
+- Record the architecture invariant in the seed/mesh converged plan or an ADR.
+- File Beads work tracks before implementation starts.
+
+### Phase 1 — Schema and resolver foundation
+
+- Add tables and nullable `scope_id` columns.
+- Add project-to-scope resolver.
+- Add safe defaults and migration/backfill.
+- Keep existing sync behavior unchanged except for stamping scope metadata.
+- Keep scope metadata non-authoritative and mostly invisible until membership authority exists.
+
+### Phase 2 — Membership authority and local cache
+
+- Add coordinator/local scope membership model.
+- Cache memberships locally.
+- Add membership epochs and revocation records.
+- Keep group membership separate from scope grants.
+- Define legacy compatibility window for peers without `scope_id`.
+
+### Phase 3 — Sync enforcement
+
+- Add scope-aware outbound filtering.
+- Add scope-aware inbound validation.
+- Add scope-aware cursors and snapshot filtering.
+- Add per-scope reset and retention boundaries.
+- Preserve compatibility for legacy peers during an explicit transition window.
+
+### Phase 4 — UX and diagnostics
+
+- Add sharing-domain settings.
+- Show project/domain mapping.
+- Show peer authorized domains and project filters.
+- Add sync rejection diagnostics.
+
+### Phase 5 — Mesh readiness
+
+- Add per-scope anti-entropy inventory/digest.
+- Add per-scope hinted handoff if needed.
+- Add seed/anchor-peer deployment docs.
+
+## Work tracks
+
+### Track A — Architecture and compatibility
+
+- Finalize terminology and invariants.
+- Define legacy compatibility window for peers without `scope_id`.
+- Decide whether user-facing docs say “Sharing domain,” “Workspace boundary,” or another label.
+
+### Track B — Store/schema/migration
+
+- Add scope tables and indexes.
+- Backfill existing memories safely.
+- Define canonical workspace identity for project mapping.
+- Add project mapping resolver.
+- Add tests for fallback behavior.
+
+### Track C — Sync protocol and enforcement
+
+- Add `scope_id` to replication ops and payload checks.
+- Scope `/v1/ops` and `/v1/snapshot`.
+- Make cursors scope-aware.
+- Make reset, bootstrap, and retention boundaries scope-aware.
+- Add inbound rejection diagnostics.
+
+### Track D — Coordinator membership
+
+- Add scope membership APIs/data model.
+- Publish membership epochs.
+- Cache memberships locally.
+- Enforce revocation for future sync.
+
+### Track E — Retrieval/MCP/viewer safety
+
+- Filter retrieval by local authorized scopes by default.
+- Add explicit scope filters where useful.
+- Update MCP tools and viewer APIs.
+- Apply scope filtering to FTS, vector, pack, timeline, expansion, and explain paths.
+- Add UI language and mixed-boundary warnings.
+
+### Track F — Product docs and deployment
+
+- Document personal/work mixed-device setup.
+- Document seed/anchor peer deployment with scopes.
+- Document revocation limitations honestly.
+- Update coordinator discovery docs once membership APIs land.
+
+## Implementation readiness matrix
+
+This matrix is the north-star acceptance fixture for implementation agents. If any row fails, the feature is not ready to ship. Implementation tracks reference rows in this matrix as acceptance criteria; nothing here is aspirational copy.
+
+### Fixture: "Mixed Adam" device
+
+One mixed laptop ("Mixed Adam") with three projects and three peers, exercised end-to-end:
+
+| Project | Project pattern | Mapped scope | Default visibility |
+|---|---|---|---|
+| `personal/finance` | `personal/*` | `personal` | private |
+| `work/acme-api` | `work/acme/*` | `acme-work` | shared |
+| `oss/codemem` | `oss/codemem` | `oss-codemem` | shared |
+
+Sharing domains:
+
+| `scope_id` | Authority | Members | Notes |
+|---|---|---|---|
+| `personal` | local | Mixed Adam, personal peer | private same-actor sync allowed |
+| `acme-work` | coordinator group `acme-eng` | Mixed Adam, work peer | revocation tested mid-run |
+| `oss-codemem` | coordinator group `oss-codemem` | Mixed Adam, OSS peer | broad project include configured on OSS peer |
+| `legacy-shared-review` | local | none | populated by migration; not eligible for sync |
+
+Peers:
+
+- **personal-peer** — authorized scopes: `personal`. No project filter.
+- **work-peer** — authorized scopes: `acme-work`. Project filter: include `*` (intentionally broad to prove filters cannot widen authorization).
+- **oss-peer** — authorized scopes: `oss-codemem`. Project filter: include `oss/*`.
+- **legacy-peer** — `unsupported` capability. Default behavior: receives nothing once enforcing, unless explicit per-peer compatibility scope is set.
+- **malicious-peer** — adversarial fixture used to verify defensive behavior. Each test below MUST produce a specific reason code AND MUST NOT mutate the local DB.
+
+#### Hostile peer fixtures
+
+| Attack | Expected response | Reason code |
+|---|---|---|
+| Sends op with `scope_id=acme-work` but is not a member of `acme-work`. | Reject before apply. | `sender_not_member` |
+| Sends op whose payload `workspace_id` says `personal` but op `scope_id` says `acme-work` (receiver does not re-resolve; payload mismatch detected). | Reject before apply. | `scope_mismatch` |
+| Sends an op_id seen a year ago after being revoked. | Reject; revoked. | `stale_epoch` |
+| Claims `claimed_local_actor` for `actor_id=adam` while presenting a device key not in `personal:adam` scope. | Reject (Phase 2: `claimed_local_actor` is no longer a bypass). | `sender_not_member` |
+| `clock_rev=Number.MAX_SAFE_INTEGER` to force LWW domination. | Accept clock comparison logic but still gate on scope; if scope check fails, reject. | `sender_not_member` or `scope_mismatch` |
+| Sends an op for `local-default` scope. | Reject; local-only scopes never replicate. | `scope_mismatch` (per Invariant 10) |
+| Replays a snapshot for `acme-work` but local cache shows the snapshot generation has advanced. | Reject; reset required. | `boundary_mismatch` (existing) |
+| Sends a `reassign_scope` op to a scope the sender is not authorized for. | Reject. | `sender_not_member` |
+| Sends an inbound op with `scope_id` set but no membership manifest cached locally. | Reject in Phase 2; apply under Phase 1 informational rules. | `stale_epoch` |
+
+### Acceptance behaviors
+
+| Surface | Expected behavior | Mapped beads |
+|---|---|---|
+| Write classification | New memories stamp the mapped `scope_id`; unknown projects fall back to local-only and never to a coordinator-group scope. | ov4g.2.2, ov4g.2.4 |
+| Outbound sync | Each peer receives only memories from authorized domains. work-peer's broad include cannot leak `personal` or `oss-codemem` data. | ov4g.4.3 |
+| Inbound sync | Ops are rejected before mutation if sender/receiver membership, scope_id, or scope/payload consistency fail. Reason codes recorded. | ov4g.4.5 |
+| Snapshot bootstrap | A bootstrap for `acme-work` reads only `acme-work` memories and replaces only `acme-work` rows on the receiver. Mixed personal/work databases never see cross-scope deletes. | ov4g.4.4 |
+| Cursor/reset/retention | Each `(peer, scope)` pair has an independent cursor; each scope has its own snapshot generation, baseline cursor, and retained floor. Pruning `oss-codemem` does not affect `acme-work`. | ov4g.4.2 |
+| Private same-actor sync | private memories sync only through `personal`. work-peer cannot receive private memories even if it claims the same actor. | ov4g.4.3, ov4g.4.5 |
+| Retrieval/search | FTS, recent, timeline, expand, explain return only locally authorized scopes by default; explicit scope filters intersect with authorization. | ov4g.5.2 |
+| Vector/pack/injection | sqlite-vec candidates and pack construction exclude unauthorized scopes before ranking/merging; plugin context injection cannot reintroduce filtered memories. | ov4g.5.3 |
+| MCP tools | memory_search, timeline, pack, expand, recent, remember, forget enforce scope authorization; remember resolves scope safely. | ov4g.5.4 |
+| Viewer/CLI APIs | Memory list/search/detail/stats apply the same store-level scope filters; raw events/artifacts are not newly exposed across scopes. | ov4g.5.5 |
+| Coordinator admin | Adding Mixed Adam to coordinator group `acme-eng` does not by itself grant `oss-codemem` or `personal`. Scope grants are explicit; revocations propagate to local cache. | ov4g.3.2, ov4g.3.4 |
+| UI guardrails | Broad org-domain patterns warn; basename collisions require review; scope reassignment warns about already-copied data. Phase 1 surfaces show "informational only" copy. | ov4g.6.4 |
+| Legacy peer behavior | legacy-peer in Phase 2 receives nothing by default. Operator can opt in to a per-peer compatibility scope; UI marks the peer "legacy" with explanation. | ov4g.4.1, ov4g.6.2 |
+| Revocation | Revoking work-peer mid-run stops future ops to that peer within one membership-cache refresh; UI/docs state already-copied data is not erased. | ov4g.3.4 |
+| Diagnostics | Scope-related rejections produce reason codes (`missing_scope`, `sender_not_member`, `receiver_not_member`, `stale_epoch`, `scope_mismatch`, `visibility_filter`, `project_filter`) visible by peer/scope without payload exposure. | ov4g.4.5, ov4g.6.5 |
+| E2E smoke | A single test fixture (Mixed Adam + three peers + legacy-peer) exercises every row above and fails on the first leak. | ov4g.4.6, ov4g.5.6, ov4g.6.6 |
+
+### Rollout-phase acceptance
+
+| Phase transition | Required for green |
+|---|---|
+| Phase 0 -> Phase 1 | Schema present; resolver deterministic; backfill biased to under-sharing; new writes stamp scope_id; legacy peers unaffected. |
+| Phase 1 -> Phase 2 | All sync rows above pass; membership cache stable; revocation honored; review checkpoint `ov4g.8` signed off. |
+| Phase 2 -> release | Retrieval/MCP/UI rows pass; legacy-peer behavior explicit; docs updated; review checkpoint `ov4g.9` signed off. |
+
+## Beads implementation plan
+
+Epic: `codemem-ov4g`.
+
+Implementation tracks:
+
+- `codemem-ov4g.1` — architecture and compatibility contract.
+- `codemem-ov4g.2` — schema, migration, project resolver, and scope stamping.
+- `codemem-ov4g.3` — membership authority, coordinator publication, cache, and revocation.
+- `codemem-ov4g.4` — sync protocol/enforcement, per-scope state, and sync diagnostics.
+- `codemem-ov4g.5` — retrieval, MCP, viewer API, vector, and pack safety.
+- `codemem-ov4g.6` — UI, diagnostics, warnings, and end-to-end smoke.
+- `codemem-ov4g.7` — user/coordinator/deployment docs.
+
+Review gates:
+
+- `codemem-ov4g.8` — foundation review before sync/retrieval enforcement becomes authoritative.
+- `codemem-ov4g.9` — boundary enforcement review before docs/release closure.
+
+Agents should work the lowest ready bead, follow its dependencies, and avoid widening scope beyond that bead. If a bead reveals design drift, stop and update this plan or file a follow-up before coding around it.
+
+## Open questions
+
+1. Should default `scope_id` values be human-readable slugs, random IDs with labels, or both?
+2. How long should legacy peers without `scope_id` remain sync-compatible?
+3. How should the UI present scope reassignment warnings without making normal project cleanup feel scary?
+4. Should one coordinator group create one default scope automatically, or require explicit scope creation?
+5. What is the minimum UI needed before scope enforcement is safe to ship?
+6. How should export/import represent scope membership and project mappings?
+7. How does future encrypted memory storage rotate keys on revocation?
+
+## Recommended next step
+
+Treat this design as the scope semantics layer underneath the converged seed/mesh plan. Do not start anti-entropy, hinted handoff, or anchor-peer scaling work until Track B and Track C are at least partially implemented and validated.


### PR DESCRIPTION
## Description

Locks the sharing-domain architecture direction before implementation. Adds the converged seed/mesh plan, supporting research, and the detailed Sharing domain / `scope_id` design so the stack has explicit invariants and rollout gates.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes (N/A: docs-only)
- [x] Manually verified changes work as expected (reviewed rendered Markdown/source)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
