### PR TITLE
feat: add project scope resolver

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -369,6 +369,20 @@ export { findByConcept, findByFile } from "./ref-queries.js";
 export type { MaintenanceJob, NewMaintenanceJob } from "./schema.js";
 export * as schema from "./schema.js";
 export { bootstrapSchema, ensureSchemaBootstrapped } from "./schema-bootstrap.js";
+export type {
+	CanonicalWorkspaceIdentity,
+	ResolveProjectScopeInput,
+	ScopeMapping,
+	ScopeResolution,
+	ScopeResolutionReason,
+	WorkspaceIdentityInput,
+	WorkspaceIdentitySource,
+} from "./scope-resolution.js";
+export {
+	canonicalWorkspaceIdentity,
+	LOCAL_DEFAULT_SCOPE_ID,
+	resolveProjectScope,
+} from "./scope-resolution.js";
 export type { StoreHandle } from "./search.js";
 export {
 	dedupeOrderedIds,

--- a/packages/core/src/scope-resolution.test.ts
+++ b/packages/core/src/scope-resolution.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+	canonicalWorkspaceIdentity,
+	LOCAL_DEFAULT_SCOPE_ID,
+	resolveProjectScope,
+	type ScopeMapping,
+} from "./scope-resolution.js";
+
+function mapping(input: Partial<ScopeMapping> & { scope_id: string }): ScopeMapping {
+	return {
+		project_pattern: input.project_pattern ?? "/work/*",
+		priority: input.priority ?? 0,
+		scope_id: input.scope_id,
+		updated_at: input.updated_at ?? "2026-04-30T00:00:00Z",
+		workspace_identity: input.workspace_identity ?? null,
+		id: input.id ?? null,
+		source: input.source ?? "user",
+	};
+}
+
+describe("canonicalWorkspaceIdentity", () => {
+	it("prefers git remote over cwd and display project", () => {
+		expect(
+			canonicalWorkspaceIdentity({
+				cwd: "/Users/adam/workspace/codemem",
+				gitRemote: " https://github.com/kunickiaj/codemem.git ",
+				project: "codemem",
+			}),
+		).toEqual({
+			displayProject: "codemem",
+			source: "git_remote",
+			value: "https://github.com/kunickiaj/codemem.git",
+		});
+	});
+
+	it("uses branch-scoped remote only when explicitly requested", () => {
+		expect(
+			canonicalWorkspaceIdentity({
+				branchScoped: true,
+				gitBranch: "feature/scope",
+				gitRemote: "https://github.com/kunickiaj/codemem.git",
+			}).value,
+		).toBe("https://github.com/kunickiaj/codemem.git:feature/scope");
+	});
+});
+
+describe("resolveProjectScope", () => {
+	it("uses an explicit runtime override before mappings", () => {
+		const result = resolveProjectScope({
+			explicitScopeId: "manual-scope",
+			gitRemote: "https://github.com/kunickiaj/codemem.git",
+			mappings: [
+				mapping({
+					scope_id: "repo-scope",
+					workspace_identity: "https://github.com/kunickiaj/codemem.git",
+				}),
+			],
+		});
+
+		expect(result).toMatchObject({
+			mapping: null,
+			reason: "explicit_override",
+			scopeId: "manual-scope",
+		});
+	});
+
+	it("uses exact canonical workspace identity before pattern mappings", () => {
+		const result = resolveProjectScope({
+			gitRemote: "https://github.com/kunickiaj/codemem.git",
+			mappings: [
+				mapping({ project_pattern: "https://github.com/kunickiaj/*", scope_id: "pattern-scope" }),
+				mapping({
+					scope_id: "exact-scope",
+					workspace_identity: "https://github.com/kunickiaj/codemem.git",
+				}),
+			],
+		});
+
+		expect(result).toMatchObject({
+			reason: "exact_mapping",
+			scopeId: "exact-scope",
+			workspaceIdentity: { source: "git_remote" },
+		});
+	});
+
+	it("normalizes exact workspace identity mappings", () => {
+		expect(
+			resolveProjectScope({
+				cwd: "/work/acme/service",
+				mappings: [mapping({ scope_id: "exact-cwd", workspace_identity: "/work/acme/service/" })],
+			}),
+		).toMatchObject({ reason: "exact_mapping", scopeId: "exact-cwd" });
+	});
+
+	it("uses highest priority deterministic pattern", () => {
+		const result = resolveProjectScope({
+			cwd: "/work/acme/service",
+			mappings: [
+				mapping({ project_pattern: "/work/acme/*", priority: 1, scope_id: "specific-low" }),
+				mapping({ project_pattern: "/work/*", priority: 10, scope_id: "broad-high" }),
+			],
+		});
+
+		expect(result).toMatchObject({
+			matchedPattern: "/work/*",
+			reason: "pattern_mapping",
+			scopeId: "broad-high",
+		});
+	});
+
+	it("breaks equal-priority ties by most specific pattern", () => {
+		const result = resolveProjectScope({
+			cwd: "/work/acme/service",
+			mappings: [
+				mapping({ project_pattern: "/work/*", priority: 5, scope_id: "broad" }),
+				mapping({ project_pattern: "/work/acme/*", priority: 5, scope_id: "specific" }),
+			],
+		});
+
+		expect(result).toMatchObject({
+			matchedPattern: "/work/acme/*",
+			scopeId: "specific",
+		});
+	});
+
+	it("keeps basename-colliding projects separate by git remote", () => {
+		const mappings = [
+			mapping({
+				scope_id: "work-codemem",
+				workspace_identity: "https://github.com/acme/codemem.git",
+			}),
+			mapping({
+				scope_id: "oss-codemem",
+				workspace_identity: "https://github.com/kunickiaj/codemem.git",
+			}),
+		];
+
+		expect(
+			resolveProjectScope({
+				gitRemote: "https://github.com/acme/codemem.git",
+				mappings,
+				project: "codemem",
+			}).scopeId,
+		).toBe("work-codemem");
+		expect(
+			resolveProjectScope({
+				gitRemote: "https://github.com/kunickiaj/codemem.git",
+				mappings,
+				project: "codemem",
+			}).scopeId,
+		).toBe("oss-codemem");
+	});
+
+	it("does not authorize org scopes from basename-only project data", () => {
+		const result = resolveProjectScope({
+			mappings: [mapping({ project_pattern: "codemem", scope_id: "org-codemem" })],
+			project: "codemem",
+		});
+
+		expect(result).toMatchObject({
+			reason: "local_default",
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+			workspaceIdentity: { source: "unmapped" },
+		});
+	});
+
+	it("does not authorize exact unmapped-hash mappings from basename-only project data", () => {
+		const unmapped = canonicalWorkspaceIdentity({ project: "codemem" });
+
+		expect(
+			resolveProjectScope({
+				mappings: [mapping({ scope_id: "org-codemem", workspace_identity: unmapped.value })],
+				project: "codemem",
+			}),
+		).toMatchObject({
+			reason: "local_default",
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+			workspaceIdentity: { source: "unmapped", value: unmapped.value },
+		});
+	});
+
+	it("falls back to local-only when no mapping matches", () => {
+		expect(
+			resolveProjectScope({
+				cwd: "/personal/unknown",
+				localDefaultScopeId: "local-only-custom",
+				mappings: [mapping({ project_pattern: "/work/*", scope_id: "work" })],
+			}),
+		).toMatchObject({ reason: "local_default", scopeId: "local-only-custom" });
+	});
+});

--- a/packages/core/src/scope-resolution.ts
+++ b/packages/core/src/scope-resolution.ts
@@ -1,0 +1,250 @@
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+
+export const LOCAL_DEFAULT_SCOPE_ID = "local-default";
+
+export type WorkspaceIdentitySource =
+	| "git_remote"
+	| "git_remote_branch"
+	| "cwd"
+	| "workspace_id"
+	| "unmapped";
+
+export interface WorkspaceIdentityInput {
+	gitRemote?: string | null;
+	gitBranch?: string | null;
+	cwd?: string | null;
+	workspaceId?: string | null;
+	project?: string | null;
+	branchScoped?: boolean;
+}
+
+export interface CanonicalWorkspaceIdentity {
+	value: string;
+	source: WorkspaceIdentitySource;
+	displayProject: string | null;
+}
+
+export interface ScopeMapping {
+	id?: number | null;
+	workspace_identity?: string | null;
+	project_pattern: string;
+	scope_id: string;
+	priority?: number | null;
+	updated_at?: string | null;
+	source?: string | null;
+}
+
+export type ScopeResolutionReason =
+	| "explicit_override"
+	| "exact_mapping"
+	| "pattern_mapping"
+	| "local_default";
+
+export interface ScopeResolution {
+	scopeId: string;
+	reason: ScopeResolutionReason;
+	workspaceIdentity: CanonicalWorkspaceIdentity;
+	mapping: ScopeMapping | null;
+	matchedPattern: string | null;
+}
+
+export interface ResolveProjectScopeInput extends WorkspaceIdentityInput {
+	explicitScopeId?: string | null;
+	mappings?: ScopeMapping[];
+	localDefaultScopeId?: string;
+}
+
+interface MappingCandidate {
+	mapping: ScopeMapping;
+	specificity: number;
+	matchedPattern: string | null;
+}
+
+function clean(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function normalizeSlash(value: string): string {
+	const normalized = value.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+	return normalized || value.trim();
+}
+
+function normalizeCwd(cwd: string): string {
+	// Callers should pass an already-realpathed session cwd when symlink
+	// resolution matters; this pure helper only normalizes path syntax.
+	return normalizeSlash(resolve(cwd));
+}
+
+function normalizeMappingIdentity(value: string | null | undefined): string | null {
+	const cleaned = clean(value);
+	return cleaned ? normalizeSlash(cleaned) : null;
+}
+
+function unmappedIdentity(input: WorkspaceIdentityInput): string {
+	const seed = [input.cwd, input.project, input.workspaceId]
+		.map((value) => clean(value))
+		.find((value): value is string => value != null);
+	const digest = createHash("sha256")
+		.update(seed ?? "unknown", "utf8")
+		.digest("hex");
+	return `unmapped:${digest}`;
+}
+
+export function canonicalWorkspaceIdentity(
+	input: WorkspaceIdentityInput,
+): CanonicalWorkspaceIdentity {
+	const gitRemote = clean(input.gitRemote);
+	const gitBranch = clean(input.gitBranch);
+	const cwd = clean(input.cwd);
+	const workspaceId = clean(input.workspaceId);
+	const project = clean(input.project);
+
+	if (gitRemote) {
+		const normalizedRemote = normalizeSlash(gitRemote);
+		if (input.branchScoped && gitBranch) {
+			return {
+				value: `${normalizedRemote}:${gitBranch}`,
+				source: "git_remote_branch",
+				displayProject: project,
+			};
+		}
+		return { value: normalizedRemote, source: "git_remote", displayProject: project };
+	}
+
+	if (cwd) {
+		return { value: normalizeCwd(cwd), source: "cwd", displayProject: project };
+	}
+
+	if (workspaceId) {
+		return { value: normalizeSlash(workspaceId), source: "workspace_id", displayProject: project };
+	}
+
+	return { value: unmappedIdentity(input), source: "unmapped", displayProject: project };
+}
+
+function isBasenameOnlyPattern(pattern: string): boolean {
+	return !/[\\/:]/.test(pattern);
+}
+
+function escapeRegex(value: string): string {
+	return value.replace(/[|\\{}()[\]^$+?.*]/g, "\\$&");
+}
+
+function patternSpecificity(pattern: string): number {
+	return pattern.replace(/[*?]/g, "").length;
+}
+
+function matchesPattern(identity: string, pattern: string): boolean {
+	const normalizedPattern = normalizeSlash(pattern);
+	if (!normalizedPattern || isBasenameOnlyPattern(normalizedPattern)) return false;
+	if (!/[*?]/.test(normalizedPattern)) return identity === normalizedPattern;
+	const regex = new RegExp(
+		`^${escapeRegex(normalizedPattern).replaceAll("\\*", ".*").replaceAll("\\?", ".")}$`,
+	);
+	return regex.test(identity);
+}
+
+function candidatePriority(candidate: MappingCandidate): number {
+	return candidate.mapping.priority ?? 0;
+}
+
+function candidateUpdatedAt(candidate: MappingCandidate): number {
+	const updatedAt = clean(candidate.mapping.updated_at);
+	if (!updatedAt) return 0;
+	const time = Date.parse(updatedAt);
+	return Number.isFinite(time) ? time : 0;
+}
+
+function compareCandidates(a: MappingCandidate, b: MappingCandidate): number {
+	return (
+		candidatePriority(b) - candidatePriority(a) ||
+		b.specificity - a.specificity ||
+		candidateUpdatedAt(b) - candidateUpdatedAt(a) ||
+		(b.mapping.id ?? 0) - (a.mapping.id ?? 0) ||
+		a.mapping.scope_id.localeCompare(b.mapping.scope_id)
+	);
+}
+
+function bestCandidate(candidates: MappingCandidate[]): MappingCandidate | null {
+	return candidates.toSorted(compareCandidates)[0] ?? null;
+}
+
+export function resolveProjectScope(input: ResolveProjectScopeInput): ScopeResolution {
+	const workspaceIdentity = canonicalWorkspaceIdentity(input);
+	const explicitScopeId = clean(input.explicitScopeId);
+	if (explicitScopeId) {
+		return {
+			scopeId: explicitScopeId,
+			reason: "explicit_override",
+			workspaceIdentity,
+			mapping: null,
+			matchedPattern: null,
+		};
+	}
+	if (workspaceIdentity.source === "unmapped") {
+		return {
+			scopeId: input.localDefaultScopeId ?? LOCAL_DEFAULT_SCOPE_ID,
+			reason: "local_default",
+			workspaceIdentity,
+			mapping: null,
+			matchedPattern: null,
+		};
+	}
+
+	const mappings = input.mappings ?? [];
+	const exact = bestCandidate(
+		mappings
+			.filter(
+				(mapping) =>
+					normalizeMappingIdentity(mapping.workspace_identity) === workspaceIdentity.value,
+			)
+			.map((mapping) => ({
+				mapping,
+				matchedPattern: null,
+				specificity: workspaceIdentity.value.length,
+			})),
+	);
+	if (exact) {
+		return {
+			scopeId: exact.mapping.scope_id,
+			reason: "exact_mapping",
+			workspaceIdentity,
+			mapping: exact.mapping,
+			matchedPattern: null,
+		};
+	}
+
+	const pattern = bestCandidate(
+		mappings.flatMap((mapping): MappingCandidate[] => {
+			if (clean(mapping.workspace_identity)) return [];
+			const projectPattern = clean(mapping.project_pattern);
+			if (!projectPattern || !matchesPattern(workspaceIdentity.value, projectPattern)) return [];
+			return [
+				{
+					mapping,
+					matchedPattern: normalizeSlash(projectPattern),
+					specificity: patternSpecificity(projectPattern),
+				},
+			];
+		}),
+	);
+	if (pattern) {
+		return {
+			scopeId: pattern.mapping.scope_id,
+			reason: "pattern_mapping",
+			workspaceIdentity,
+			mapping: pattern.mapping,
+			matchedPattern: pattern.matchedPattern,
+		};
+	}
+
+	return {
+		scopeId: input.localDefaultScopeId ?? LOCAL_DEFAULT_SCOPE_ID,
+		reason: "local_default",
+		workspaceIdentity,
+		mapping: null,
+		matchedPattern: null,
+	};
+}


### PR DESCRIPTION
## Description

Adds the pure project-to-scope resolver and canonical workspace identity logic. The resolver prefers explicit overrides and exact canonical mappings, rejects basename-only authorization, and falls back safely to `local-default` for unknown projects.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (reviewed resolver fixtures for priority, specificity, collisions, and fallback)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
