### PR TITLE
feat: add safe scope backfill

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -9,6 +9,7 @@ import {
 	getMaintenanceJob,
 	hasPendingDedupKeyBackfill,
 	hasPendingRefBackfill,
+	hasPendingScopeBackfill,
 	hasPendingSessionContextBackfill,
 	hasPendingSummaryDedupBackfill,
 	initDatabase,
@@ -23,6 +24,8 @@ import {
 	readCoordinatorSyncConfig,
 	resolveDbPath,
 	runSyncDaemon,
+	SCOPE_BACKFILL_JOB,
+	ScopeBackfillRunner,
 	SESSION_CONTEXT_BACKFILL_JOB,
 	SessionContextBackfillRunner,
 	SUMMARY_DEDUP_BACKFILL_JOB,
@@ -566,6 +569,16 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	const backfillCoordinator = createSequentialBackfillCoordinator(
 		store,
 		[
+			{
+				name: "Sharing-domain",
+				kind: SCOPE_BACKFILL_JOB,
+				isPending: hasPendingScopeBackfill,
+				createRunner: () =>
+					new ScopeBackfillRunner({
+						dbPath,
+						signal: backfillAbort.signal,
+					}),
+			},
 			{
 				name: "Dedup-key",
 				kind: DEDUP_KEY_BACKFILL_JOB,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -370,6 +370,24 @@ export type { MaintenanceJob, NewMaintenanceJob } from "./schema.js";
 export * as schema from "./schema.js";
 export { bootstrapSchema, ensureSchemaBootstrapped } from "./schema-bootstrap.js";
 export type {
+	LegacyMemoryScopeClassification,
+	LegacyMemoryScopeInput,
+	ScopeBackfillOptions,
+	ScopeBackfillReason,
+	ScopeBackfillResult,
+	ScopeBackfillRunnerOptions,
+} from "./scope-backfill.js";
+export {
+	backfillScopeIds,
+	classifyLegacyMemoryScope,
+	ensureScopeBackfillScopes,
+	hasPendingScopeBackfill,
+	LEGACY_SHARED_REVIEW_SCOPE_ID,
+	runScopeBackfillPass,
+	SCOPE_BACKFILL_JOB,
+	ScopeBackfillRunner,
+} from "./scope-backfill.js";
+export type {
 	CanonicalWorkspaceIdentity,
 	ResolveProjectScopeInput,
 	ScopeMapping,

--- a/packages/core/src/scope-backfill.test.ts
+++ b/packages/core/src/scope-backfill.test.ts
@@ -1,0 +1,291 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toJson } from "./db.js";
+import {
+	backfillScopeIds,
+	classifyLegacyMemoryScope,
+	ensureScopeBackfillScopes,
+	hasPendingScopeBackfill,
+	LEGACY_SHARED_REVIEW_SCOPE_ID,
+	runScopeBackfillPass,
+} from "./scope-backfill.js";
+import { LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
+import { initTestSchema } from "./test-utils.js";
+
+function insertSession(
+	db: InstanceType<typeof Database>,
+	overrides: { project?: string | null; cwd?: string | null; gitRemote?: string | null } = {},
+): number {
+	const now = "2026-05-01T00:00:00Z";
+	const cwd = Object.hasOwn(overrides, "cwd") ? overrides.cwd : "/tmp/codemem-test";
+	const project = Object.hasOwn(overrides, "project") ? overrides.project : "codemem-test";
+	const gitRemote = Object.hasOwn(overrides, "gitRemote") ? overrides.gitRemote : null;
+	const result = db
+		.prepare(
+			`INSERT INTO sessions(started_at, cwd, project, git_remote, user, tool_version)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(now, cwd, project, gitRemote, "test-user", "test");
+	return Number(result.lastInsertRowid);
+}
+
+function insertMemory(
+	db: InstanceType<typeof Database>,
+	input: {
+		sessionId: number;
+		title: string;
+		visibility?: string | null;
+		workspaceKind?: string | null;
+		workspaceId?: string | null;
+		active?: number;
+		deletedAt?: string | null;
+		importKey?: string | null;
+		scopeId?: string | null;
+	},
+): number {
+	const now = "2026-05-01T00:00:00Z";
+	const result = db
+		.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, created_at, updated_at,
+				visibility, workspace_id, workspace_kind, active, deleted_at,
+				import_key, scope_id, metadata_json
+			 ) VALUES (?, 'discovery', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			input.sessionId,
+			input.title,
+			`${input.title} body`,
+			now,
+			now,
+			input.visibility ?? null,
+			input.workspaceId ?? null,
+			input.workspaceKind ?? null,
+			input.active ?? 1,
+			input.deletedAt ?? null,
+			input.importKey ?? null,
+			input.scopeId ?? null,
+			toJson({}),
+		);
+	return Number(result.lastInsertRowid);
+}
+
+function insertReplicationOp(
+	db: InstanceType<typeof Database>,
+	opId: string,
+	entityId: string,
+): void {
+	db.prepare(
+		`INSERT INTO replication_ops(
+			op_id, entity_type, entity_id, op_type, payload_json,
+			clock_rev, clock_updated_at, clock_device_id, device_id, created_at
+		 ) VALUES (?, 'memory_item', ?, 'upsert', NULL, 1, ?, 'dev-a', 'dev-a', ?)`,
+	).run(opId, entityId, "2026-05-01T00:00:00Z", "2026-05-01T00:00:00Z");
+}
+
+describe("scope backfill", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("classifies private and ambiguous legacy memories conservatively", () => {
+		expect(classifyLegacyMemoryScope({ visibility: "private" })).toEqual({
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+			reason: "private_or_personal",
+			needsReview: false,
+		});
+		expect(
+			classifyLegacyMemoryScope({
+				visibility: "shared",
+				project: "codemem",
+				workspaceId: "shared:default",
+			}),
+		).toEqual({
+			scopeId: LEGACY_SHARED_REVIEW_SCOPE_ID,
+			reason: "shared_ambiguous_review",
+			needsReview: true,
+		});
+		expect(
+			classifyLegacyMemoryScope({
+				visibility: "shared",
+				cwd: "/work/acme/service",
+				gitRemote: "https://example.com/acme/service.git",
+				workspaceId: "shared:team",
+			}),
+		).toEqual({
+			scopeId: LEGACY_SHARED_REVIEW_SCOPE_ID,
+			reason: "shared_with_canonical_workspace_review",
+			needsReview: true,
+		});
+	});
+
+	it("seeds required migration scopes idempotently", () => {
+		expect(ensureScopeBackfillScopes(db, "2026-05-01T00:00:00Z")).toBe(2);
+		expect(ensureScopeBackfillScopes(db, "2026-05-01T00:00:00Z")).toBe(0);
+
+		const rows = db
+			.prepare("SELECT scope_id, label, authority_type FROM replication_scopes ORDER BY scope_id")
+			.all() as Array<{ scope_id: string; label: string; authority_type: string }>;
+		expect(rows).toEqual([
+			{
+				scope_id: LEGACY_SHARED_REVIEW_SCOPE_ID,
+				label: "Legacy shared review",
+				authority_type: "local",
+			},
+			{ scope_id: LOCAL_DEFAULT_SCOPE_ID, label: "Local only", authority_type: "local" },
+		]);
+	});
+
+	it("backfills memories and existing replication ops without overwriting scopes", () => {
+		const privateSession = insertSession(db, { project: "personal", cwd: "/home/me/personal" });
+		const sharedSession = insertSession(db, {
+			project: "service",
+			cwd: "/work/acme/service",
+			gitRemote: "https://example.com/acme/service.git",
+		});
+		const ambiguousSession = insertSession(db, { project: "codemem", cwd: null });
+
+		const privateId = insertMemory(db, {
+			sessionId: privateSession,
+			title: "Private",
+			visibility: "private",
+			workspaceKind: "personal",
+			workspaceId: "personal:actor-1",
+			importKey: "key:private",
+		});
+		insertMemory(db, {
+			sessionId: sharedSession,
+			title: "Shared clear",
+			visibility: "shared",
+			workspaceKind: "shared",
+			workspaceId: "shared:team",
+			importKey: "key:shared",
+		});
+		insertMemory(db, {
+			sessionId: ambiguousSession,
+			title: "Shared ambiguous",
+			visibility: "shared",
+			workspaceKind: "shared",
+			workspaceId: "shared:default",
+			importKey: "key:ambiguous",
+		});
+		insertMemory(db, {
+			sessionId: sharedSession,
+			title: "Deleted shared",
+			visibility: "shared",
+			workspaceKind: "shared",
+			workspaceId: "shared:team",
+			active: 0,
+			deletedAt: "2026-05-01T00:00:00Z",
+			importKey: "key:deleted",
+		});
+		insertMemory(db, {
+			sessionId: sharedSession,
+			title: "Already scoped",
+			visibility: "shared",
+			workspaceKind: "shared",
+			workspaceId: "shared:team",
+			importKey: "key:custom",
+			scopeId: "custom-scope",
+		});
+
+		insertReplicationOp(db, "op-private", "key:private");
+		insertReplicationOp(db, "op-deleted", "key:deleted");
+		insertReplicationOp(db, "op-numeric", String(privateId));
+		insertReplicationOp(db, "op-missing", "key:missing");
+
+		expect(hasPendingScopeBackfill(db)).toBe(true);
+		const result = backfillScopeIds(db, { now: "2026-05-01T00:00:00Z" });
+
+		expect(result.seededScopes).toBe(2);
+		expect(result.checkedMemoryItems).toBe(4);
+		expect(result.updatedMemoryItems).toBe(4);
+		expect(result.checkedReplicationOps).toBe(3);
+		expect(result.updatedReplicationOps).toBe(3);
+		expect(result.skippedReplicationOps).toBe(0);
+
+		const memories = db
+			.prepare("SELECT import_key, scope_id FROM memory_items ORDER BY import_key")
+			.all() as Array<{ import_key: string; scope_id: string }>;
+		expect(memories).toEqual([
+			{ import_key: "key:ambiguous", scope_id: LEGACY_SHARED_REVIEW_SCOPE_ID },
+			{ import_key: "key:custom", scope_id: "custom-scope" },
+			{ import_key: "key:deleted", scope_id: LEGACY_SHARED_REVIEW_SCOPE_ID },
+			{ import_key: "key:private", scope_id: LOCAL_DEFAULT_SCOPE_ID },
+			{ import_key: "key:shared", scope_id: LEGACY_SHARED_REVIEW_SCOPE_ID },
+		]);
+
+		const ops = db
+			.prepare("SELECT op_id, scope_id FROM replication_ops ORDER BY op_id")
+			.all() as Array<{ op_id: string; scope_id: string | null }>;
+		expect(ops).toEqual([
+			{ op_id: "op-deleted", scope_id: LEGACY_SHARED_REVIEW_SCOPE_ID },
+			{ op_id: "op-missing", scope_id: null },
+			{ op_id: "op-numeric", scope_id: LOCAL_DEFAULT_SCOPE_ID },
+			{ op_id: "op-private", scope_id: LOCAL_DEFAULT_SCOPE_ID },
+		]);
+		expect(hasPendingScopeBackfill(db)).toBe(false);
+
+		const second = backfillScopeIds(db, { now: "2026-05-01T00:00:00Z" });
+		expect(second.seededScopes).toBe(0);
+		expect(second.updatedMemoryItems).toBe(0);
+		expect(second.updatedReplicationOps).toBe(0);
+	});
+
+	it("skips unmatchable ops when selecting limited replication-op batches", () => {
+		const sessionId = insertSession(db, { project: "codemem", cwd: null });
+		insertMemory(db, {
+			sessionId,
+			title: "Scoped memory",
+			visibility: "private",
+			workspaceKind: "personal",
+			workspaceId: "personal:actor-1",
+			importKey: "key:matchable",
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+		});
+		insertReplicationOp(db, "op-aaa-unmatched", "key:missing");
+		insertReplicationOp(db, "op-zzz-matchable", "key:matchable");
+
+		const result = backfillScopeIds(db, { memoryLimit: 10, replicationOpLimit: 1 });
+
+		expect(result.checkedReplicationOps).toBe(1);
+		expect(result.updatedReplicationOps).toBe(1);
+		expect(result.skippedReplicationOps).toBe(0);
+		expect(
+			(
+				db
+					.prepare("SELECT scope_id FROM replication_ops WHERE op_id = 'op-zzz-matchable'")
+					.get() as {
+					scope_id: string | null;
+				}
+			).scope_id,
+		).toBe(LOCAL_DEFAULT_SCOPE_ID);
+		expect(hasPendingScopeBackfill(db)).toBe(false);
+	});
+
+	it("runs as a maintenance pass and completes when no matching op work remains", async () => {
+		const sessionId = insertSession(db, { project: "personal", cwd: "/home/me/personal" });
+		insertMemory(db, {
+			sessionId,
+			title: "Private",
+			visibility: "private",
+			workspaceKind: "personal",
+			workspaceId: "personal:actor-1",
+			importKey: "key:private",
+		});
+		insertReplicationOp(db, "op-missing", "key:missing");
+
+		await expect(runScopeBackfillPass(db, { batchSize: 10 })).resolves.toBe(false);
+
+		const memory = db.prepare("SELECT scope_id FROM memory_items").get() as { scope_id: string };
+		expect(memory.scope_id).toBe(LOCAL_DEFAULT_SCOPE_ID);
+		expect(hasPendingScopeBackfill(db)).toBe(false);
+	});
+});

--- a/packages/core/src/scope-backfill.ts
+++ b/packages/core/src/scope-backfill.ts
@@ -1,0 +1,504 @@
+/**
+ * Safe scope backfill for legacy memories and replication ops.
+ *
+ * Phase 1 scope metadata is classification only. This backfill deliberately
+ * under-shares: private/personal memories go to the local-only scope, and
+ * legacy shared memories go to a review scope rather than an org/team scope.
+ */
+
+import type { Database as SqliteDatabase } from "better-sqlite3";
+import { connect, resolveDbPath } from "./db.js";
+import {
+	completeMaintenanceJob,
+	failMaintenanceJob,
+	getMaintenanceJob,
+	startMaintenanceJob,
+	updateMaintenanceJob,
+} from "./maintenance-jobs.js";
+import { LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
+
+export const LEGACY_SHARED_REVIEW_SCOPE_ID = "legacy-shared-review";
+export const SCOPE_BACKFILL_JOB = "scope_id_backfill";
+
+export type ScopeBackfillReason =
+	| "private_or_personal"
+	| "shared_with_canonical_workspace_review"
+	| "shared_ambiguous_review";
+
+export interface LegacyMemoryScopeInput {
+	visibility?: string | null;
+	workspaceKind?: string | null;
+	workspaceId?: string | null;
+	project?: string | null;
+	cwd?: string | null;
+	gitRemote?: string | null;
+}
+
+export interface LegacyMemoryScopeClassification {
+	scopeId: string;
+	reason: ScopeBackfillReason;
+	needsReview: boolean;
+}
+
+export interface ScopeBackfillResult {
+	seededScopes: number;
+	checkedMemoryItems: number;
+	updatedMemoryItems: number;
+	checkedReplicationOps: number;
+	updatedReplicationOps: number;
+	skippedReplicationOps: number;
+	remainingMemoryItems: number;
+	remainingReplicationOps: number;
+}
+
+export interface ScopeBackfillOptions {
+	memoryLimit?: number;
+	replicationOpLimit?: number;
+	now?: string;
+}
+
+export interface ScopeBackfillRunnerOptions {
+	batchSize?: number;
+	intervalMs?: number;
+	dbPath?: string;
+	signal?: AbortSignal;
+}
+
+type ScopeBackfillMetadata = {
+	seeded_scopes?: number;
+	processed_memories?: number;
+	updated_memories?: number;
+	processed_replication_ops?: number;
+	updated_replication_ops?: number;
+	skipped_replication_ops?: number;
+	remaining_memories?: number;
+	remaining_replication_ops?: number;
+};
+
+interface MemoryScopeCandidateRow {
+	id: number;
+	visibility: string | null;
+	workspace_id: string | null;
+	workspace_kind: string | null;
+	project: string | null;
+	cwd: string | null;
+	git_remote: string | null;
+}
+
+interface ReplicationOpScopeCandidateRow {
+	op_id: string;
+	entity_id: string;
+}
+
+function clean(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function hasCanonicalWorkspaceSignal(input: LegacyMemoryScopeInput): boolean {
+	if (clean(input.gitRemote)) return true;
+	if (clean(input.cwd)) return true;
+	const workspaceId = clean(input.workspaceId);
+	return workspaceId != null && workspaceId !== "shared:default";
+}
+
+export function classifyLegacyMemoryScope(
+	input: LegacyMemoryScopeInput,
+): LegacyMemoryScopeClassification {
+	const visibility = clean(input.visibility)?.toLowerCase() ?? null;
+	const workspaceKind = clean(input.workspaceKind)?.toLowerCase() ?? null;
+	const workspaceId = clean(input.workspaceId)?.toLowerCase() ?? null;
+
+	if (
+		visibility === "private" ||
+		visibility === "personal" ||
+		workspaceKind === "personal" ||
+		workspaceId?.startsWith("personal:")
+	) {
+		return {
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+			reason: "private_or_personal",
+			needsReview: false,
+		};
+	}
+
+	return {
+		scopeId: LEGACY_SHARED_REVIEW_SCOPE_ID,
+		reason: hasCanonicalWorkspaceSignal(input)
+			? "shared_with_canonical_workspace_review"
+			: "shared_ambiguous_review",
+		needsReview: true,
+	};
+}
+
+function countMissingRequiredScopes(db: SqliteDatabase): number {
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS n
+			 FROM (SELECT ? AS scope_id UNION ALL SELECT ? AS scope_id) required
+			 WHERE NOT EXISTS (
+				SELECT 1 FROM replication_scopes rs WHERE rs.scope_id = required.scope_id
+			 )`,
+		)
+		.get(LOCAL_DEFAULT_SCOPE_ID, LEGACY_SHARED_REVIEW_SCOPE_ID) as { n: number } | undefined;
+	return Number(row?.n ?? 0);
+}
+
+export function ensureScopeBackfillScopes(
+	db: SqliteDatabase,
+	now = new Date().toISOString(),
+): number {
+	const insert = db.prepare(
+		`INSERT OR IGNORE INTO replication_scopes(
+			scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+		 ) VALUES (?, ?, ?, 'local', 0, 'active', ?, ?)`,
+	);
+	return db.transaction(() => {
+		let inserted = 0;
+		inserted += Number(
+			insert.run(LOCAL_DEFAULT_SCOPE_ID, "Local only", "system", now, now).changes ?? 0,
+		);
+		inserted += Number(
+			insert.run(LEGACY_SHARED_REVIEW_SCOPE_ID, "Legacy shared review", "system", now, now)
+				.changes ?? 0,
+		);
+		return inserted;
+	})();
+}
+
+function countPendingMemoryScopes(db: SqliteDatabase): number {
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS n
+			 FROM memory_items
+			 WHERE scope_id IS NULL OR TRIM(scope_id) = ''`,
+		)
+		.get() as { n: number } | undefined;
+	return Number(row?.n ?? 0);
+}
+
+function countPendingReplicationOpScopes(db: SqliteDatabase): number {
+	const row = db
+		.prepare(
+			`SELECT COUNT(*) AS n
+			 FROM replication_ops ro
+			 WHERE ro.entity_type = 'memory_item'
+			   AND (ro.scope_id IS NULL OR TRIM(ro.scope_id) = '')
+			   AND EXISTS (
+				SELECT 1
+				FROM memory_items mi
+				WHERE (mi.import_key = ro.entity_id OR CAST(mi.id AS TEXT) = ro.entity_id)
+				  AND mi.scope_id IS NOT NULL
+				  AND TRIM(mi.scope_id) != ''
+			   )`,
+		)
+		.get() as { n: number } | undefined;
+	return Number(row?.n ?? 0);
+}
+
+function pendingWorkCount(db: SqliteDatabase): number {
+	return (
+		countMissingRequiredScopes(db) +
+		countPendingMemoryScopes(db) +
+		countPendingReplicationOpScopes(db)
+	);
+}
+
+export function hasPendingScopeBackfill(db: SqliteDatabase): boolean {
+	return pendingWorkCount(db) > 0;
+}
+
+function selectMemoryScopeCandidates(db: SqliteDatabase, limit: number): MemoryScopeCandidateRow[] {
+	return db
+		.prepare(
+			`SELECT
+				mi.id,
+				mi.visibility,
+				mi.workspace_id,
+				mi.workspace_kind,
+				s.project,
+				s.cwd,
+				s.git_remote
+			 FROM memory_items mi
+			 LEFT JOIN sessions s ON s.id = mi.session_id
+			 WHERE mi.scope_id IS NULL OR TRIM(mi.scope_id) = ''
+			 ORDER BY mi.id ASC
+			 LIMIT ?`,
+		)
+		.all(limit) as MemoryScopeCandidateRow[];
+}
+
+function selectReplicationOpScopeCandidates(
+	db: SqliteDatabase,
+	limit: number,
+): ReplicationOpScopeCandidateRow[] {
+	return db
+		.prepare(
+			`SELECT ro.op_id, ro.entity_id
+			 FROM replication_ops ro
+			 WHERE ro.entity_type = 'memory_item'
+			   AND (ro.scope_id IS NULL OR TRIM(ro.scope_id) = '')
+			   AND EXISTS (
+				SELECT 1
+				FROM memory_items mi
+				WHERE (mi.import_key = ro.entity_id OR CAST(mi.id AS TEXT) = ro.entity_id)
+				  AND mi.scope_id IS NOT NULL
+				  AND TRIM(mi.scope_id) != ''
+			   )
+			 ORDER BY ro.created_at ASC, ro.op_id ASC
+			 LIMIT ?`,
+		)
+		.all(limit) as ReplicationOpScopeCandidateRow[];
+}
+
+function lookupMemoryScopeForOp(db: SqliteDatabase, entityId: string): string | null {
+	const row = db
+		.prepare(
+			`SELECT scope_id
+			 FROM memory_items
+			 WHERE (import_key = ? OR CAST(id AS TEXT) = ?)
+			   AND scope_id IS NOT NULL
+			   AND TRIM(scope_id) != ''
+			 ORDER BY CASE WHEN import_key = ? THEN 0 ELSE 1 END, id ASC
+			 LIMIT 1`,
+		)
+		.get(entityId, entityId, entityId) as { scope_id: string | null } | undefined;
+	return clean(row?.scope_id);
+}
+
+export function backfillScopeIds(
+	db: SqliteDatabase,
+	options: ScopeBackfillOptions = {},
+): ScopeBackfillResult {
+	const memoryLimit = Math.max(1, options.memoryLimit ?? 250);
+	const replicationOpLimit = Math.max(1, options.replicationOpLimit ?? memoryLimit);
+	const seededScopes = ensureScopeBackfillScopes(db, options.now);
+	const memoryRows = selectMemoryScopeCandidates(db, memoryLimit);
+
+	const updateMemoryScope = db.prepare(
+		`UPDATE memory_items
+		 SET scope_id = ?
+		 WHERE id = ?
+		   AND (scope_id IS NULL OR TRIM(scope_id) = '')`,
+	);
+	const updateOpScope = db.prepare(
+		`UPDATE replication_ops
+		 SET scope_id = ?
+		 WHERE op_id = ?
+		   AND (scope_id IS NULL OR TRIM(scope_id) = '')`,
+	);
+
+	const apply = db.transaction(() => {
+		let updatedMemoryItems = 0;
+		let updatedReplicationOps = 0;
+		let skippedReplicationOps = 0;
+
+		for (const row of memoryRows) {
+			const classification = classifyLegacyMemoryScope({
+				visibility: row.visibility,
+				workspaceKind: row.workspace_kind,
+				workspaceId: row.workspace_id,
+				project: row.project,
+				cwd: row.cwd,
+				gitRemote: row.git_remote,
+			});
+			updatedMemoryItems += Number(
+				updateMemoryScope.run(classification.scopeId, row.id).changes ?? 0,
+			);
+		}
+
+		const opRows = selectReplicationOpScopeCandidates(db, replicationOpLimit);
+		for (const row of opRows) {
+			const scopeId = lookupMemoryScopeForOp(db, row.entity_id);
+			if (!scopeId) {
+				skippedReplicationOps += 1;
+				continue;
+			}
+			updatedReplicationOps += Number(updateOpScope.run(scopeId, row.op_id).changes ?? 0);
+		}
+
+		return {
+			checkedReplicationOps: opRows.length,
+			updatedMemoryItems,
+			updatedReplicationOps,
+			skippedReplicationOps,
+		};
+	});
+
+	const applied = apply();
+
+	return {
+		seededScopes,
+		checkedMemoryItems: memoryRows.length,
+		updatedMemoryItems: applied.updatedMemoryItems,
+		checkedReplicationOps: applied.checkedReplicationOps,
+		updatedReplicationOps: applied.updatedReplicationOps,
+		skippedReplicationOps: applied.skippedReplicationOps,
+		remainingMemoryItems: countPendingMemoryScopes(db),
+		remainingReplicationOps: countPendingReplicationOpScopes(db),
+	};
+}
+
+function getExistingMetadata(db: SqliteDatabase): ScopeBackfillMetadata {
+	return (getMaintenanceJob(db, SCOPE_BACKFILL_JOB)?.metadata ?? {}) as ScopeBackfillMetadata;
+}
+
+export async function runScopeBackfillPass(
+	db: SqliteDatabase,
+	options: { batchSize?: number } = {},
+): Promise<boolean> {
+	const batchSize = Math.max(1, options.batchSize ?? 250);
+	const existingJob = getMaintenanceJob(db, SCOPE_BACKFILL_JOB);
+	const existingMetadata = getExistingMetadata(db);
+	const startingFresh =
+		!existingJob || existingJob.status === "completed" || existingJob.status === "failed";
+	const totalBefore = pendingWorkCount(db);
+
+	if (totalBefore <= 0) {
+		if (existingJob && existingJob.status !== "completed") {
+			completeMaintenanceJob(db, SCOPE_BACKFILL_JOB, {
+				message: "Scope backfill complete",
+				progressCurrent: Number(existingMetadata.processed_memories ?? 0),
+				progressTotal: Number(existingMetadata.processed_memories ?? 0),
+				metadata: { ...existingMetadata, remaining_memories: 0, remaining_replication_ops: 0 },
+			});
+		}
+		return false;
+	}
+
+	if (startingFresh) {
+		startMaintenanceJob(db, {
+			kind: SCOPE_BACKFILL_JOB,
+			title: "Backfilling sharing domains",
+			message: `Backfilling ${totalBefore} legacy scope item(s)`,
+			progressTotal: totalBefore,
+			metadata: {
+				seeded_scopes: 0,
+				processed_memories: 0,
+				updated_memories: 0,
+				processed_replication_ops: 0,
+				updated_replication_ops: 0,
+				skipped_replication_ops: 0,
+				remaining_memories: countPendingMemoryScopes(db),
+				remaining_replication_ops: countPendingReplicationOpScopes(db),
+			},
+		});
+	}
+
+	const result = backfillScopeIds(db, {
+		memoryLimit: batchSize,
+		replicationOpLimit: batchSize,
+	});
+	const latestMetadata = startingFresh ? {} : existingMetadata;
+	const seededScopes = Number(latestMetadata.seeded_scopes ?? 0) + result.seededScopes;
+	const processedMemories =
+		Number(latestMetadata.processed_memories ?? 0) + result.checkedMemoryItems;
+	const updatedMemories = Number(latestMetadata.updated_memories ?? 0) + result.updatedMemoryItems;
+	const processedReplicationOps =
+		Number(latestMetadata.processed_replication_ops ?? 0) + result.checkedReplicationOps;
+	const updatedReplicationOps =
+		Number(latestMetadata.updated_replication_ops ?? 0) + result.updatedReplicationOps;
+	const skippedReplicationOps =
+		Number(latestMetadata.skipped_replication_ops ?? 0) + result.skippedReplicationOps;
+	const remaining = pendingWorkCount(db);
+	const progressCurrent = Math.max(totalBefore - remaining, 0);
+	const metadata: ScopeBackfillMetadata = {
+		seeded_scopes: seededScopes,
+		processed_memories: processedMemories,
+		updated_memories: updatedMemories,
+		processed_replication_ops: processedReplicationOps,
+		updated_replication_ops: updatedReplicationOps,
+		skipped_replication_ops: skippedReplicationOps,
+		remaining_memories: result.remainingMemoryItems,
+		remaining_replication_ops: result.remainingReplicationOps,
+	};
+
+	if (remaining <= 0) {
+		completeMaintenanceJob(db, SCOPE_BACKFILL_JOB, {
+			message: "Scope backfill complete",
+			progressCurrent: totalBefore,
+			progressTotal: totalBefore,
+			metadata,
+		});
+		return false;
+	}
+
+	updateMaintenanceJob(db, SCOPE_BACKFILL_JOB, {
+		message: `Backfilled sharing domains for ${progressCurrent} of ${totalBefore} item(s)`,
+		progressCurrent,
+		progressTotal: totalBefore,
+		metadata,
+	});
+	return true;
+}
+
+export class ScopeBackfillRunner {
+	private readonly dbPath: string;
+	private readonly signal?: AbortSignal;
+	private readonly batchSize: number;
+	private readonly intervalMs: number;
+	private active = false;
+	private timer: ReturnType<typeof setTimeout> | null = null;
+	private currentRun: Promise<void> | null = null;
+
+	constructor(options: ScopeBackfillRunnerOptions = {}) {
+		this.dbPath = resolveDbPath(options.dbPath);
+		this.signal = options.signal;
+		this.batchSize = Math.max(1, options.batchSize ?? 250);
+		this.intervalMs = Math.max(1000, options.intervalMs ?? 5000);
+	}
+
+	start(): void {
+		if (this.active) return;
+		this.active = true;
+		this.schedule(100);
+	}
+
+	async stop(): Promise<void> {
+		this.active = false;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+		if (this.currentRun) await this.currentRun;
+	}
+
+	private schedule(delayMs: number): void {
+		if (!this.active || this.signal?.aborted) return;
+		this.timer = setTimeout(() => {
+			this.timer = null;
+			this.currentRun = this.runOnce()
+				.catch((err) => {
+					console.error("Scope backfill runner tick failed:", err);
+				})
+				.finally(() => {
+					this.currentRun = null;
+					this.schedule(this.intervalMs);
+				});
+		}, delayMs);
+		if (typeof this.timer === "object" && "unref" in this.timer) this.timer.unref();
+	}
+
+	private async runOnce(): Promise<void> {
+		if (!this.active || this.signal?.aborted) return;
+		let db: SqliteDatabase | null = null;
+		try {
+			db = connect(this.dbPath) as SqliteDatabase;
+			const hasMoreWork = await runScopeBackfillPass(db, { batchSize: this.batchSize });
+			if (!hasMoreWork) {
+				this.active = false;
+			}
+		} catch (error) {
+			if (db) {
+				failMaintenanceJob(
+					db,
+					SCOPE_BACKFILL_JOB,
+					error instanceof Error ? error.message : String(error),
+				);
+			}
+			console.warn("Scope backfill runner failed", error);
+		} finally {
+			db?.close();
+		}
+	}
+}

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -45,6 +45,7 @@ function makeOp(id: string, payloadSize = 10): ReplicationOp {
 		clock_device_id: "dev-a",
 		device_id: "dev-a",
 		created_at: "2026-01-01T00:00:00Z",
+		scope_id: null,
 	};
 }
 
@@ -1424,6 +1425,7 @@ describe("filterReplicationOpsForSyncWithStatus", () => {
 			clock_device_id: "peer-1",
 			device_id: "peer-1",
 			created_at: "2026-01-01T00:00:00Z",
+			scope_id: null,
 			...overrides,
 		};
 	}
@@ -1576,6 +1578,7 @@ describe("applyReplicationOps", () => {
 			clock_device_id: "dev-remote",
 			device_id: "dev-remote",
 			created_at: "2026-01-01T00:00:00Z",
+			scope_id: null,
 			...overrides,
 		};
 	}
@@ -2316,6 +2319,7 @@ describe("replication payload round-trip parity", () => {
 			clock_device_id: "remote-device",
 			device_id: "remote-device",
 			created_at: op.created_at,
+			scope_id: op.scope_id,
 		};
 
 		const result = applyReplicationOps(db, [replicationOp], "target-device");


### PR DESCRIPTION
## Description

Adds deterministic safe backfill for legacy scope metadata. Existing private/personal memories go to `local-default`, shared/ambiguous legacy rows go to `legacy-shared-review`, and replication ops are backfilled from scoped memories without widening sync behavior.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (reviewed idempotent backfill and maintenance runner coverage)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
