### PR TITLE
feat: stamp scope ids on memory writes

### DIFF
--- a/packages/core/src/export-import.test.ts
+++ b/packages/core/src/export-import.test.ts
@@ -136,6 +136,9 @@ describe("export/import", () => {
 				inactiveMemory: checkDb
 					.prepare("SELECT active, deleted_at FROM memory_items WHERE import_key = ?")
 					.get("memory-2") as { active: number; deleted_at: string | null },
+				memoryScopes: checkDb
+					.prepare("SELECT DISTINCT scope_id FROM memory_items ORDER BY scope_id")
+					.all() as Array<{ scope_id: string | null }>,
 			};
 			expect(counts).toEqual({
 				sessions: 1,
@@ -144,6 +147,7 @@ describe("export/import", () => {
 				summaries: 1,
 				project: "/tmp/remapped",
 				inactiveMemory: { active: 0, deleted_at: "2026-03-01T10:03:30Z" },
+				memoryScopes: [{ scope_id: "local-default" }],
 			});
 			// Original created_at_epoch values (1) from the source DB are preserved
 			expect(promptEpoch).toBe(1);

--- a/packages/core/src/export-import.ts
+++ b/packages/core/src/export-import.ts
@@ -12,6 +12,7 @@ import {
 import { expandUserPath } from "./observer-config.js";
 import { projectColumnClause, resolveProject as resolveProjectName } from "./project.js";
 import * as schema from "./schema.js";
+import { resolveSessionScopeId } from "./scope-stamping.js";
 
 type JsonObject = Record<string, unknown>;
 type MemoryInsert = typeof schema.memoryItems.$inferInsert;
@@ -346,12 +347,18 @@ function insertPrompt(d: DrizzleDb, row: JsonObject): number {
 	return id;
 }
 
-function insertMemory(d: DrizzleDb, row: JsonObject): number {
+function insertMemory(db: Database, d: DrizzleDb, row: JsonObject): number {
 	const now = nowIso();
 	const parsedActive = row.active == null ? 1 : Number(row.active);
 	const active = Number.isFinite(parsedActive) ? parsedActive : 1;
 	const deletedAt =
 		typeof row.deleted_at === "string" && row.deleted_at.trim().length > 0 ? row.deleted_at : null;
+	const workspaceId = row.workspace_id == null ? null : String(row.workspace_id);
+	// Imports are local writes: resolve against destination policy instead of preserving source scope.
+	const scopeId = resolveSessionScopeId(db, {
+		sessionId: Number(row.session_id),
+		workspaceId,
+	});
 	const values: MemoryInsert = {
 		session_id: Number(row.session_id),
 		kind: String(row.kind ?? "observation"),
@@ -367,7 +374,7 @@ function insertMemory(d: DrizzleDb, row: JsonObject): number {
 		actor_id: row.actor_id == null ? null : String(row.actor_id),
 		actor_display_name: row.actor_display_name == null ? null : String(row.actor_display_name),
 		visibility: row.visibility == null ? null : String(row.visibility),
-		workspace_id: row.workspace_id == null ? null : String(row.workspace_id),
+		workspace_id: workspaceId,
 		workspace_kind: row.workspace_kind == null ? null : String(row.workspace_kind),
 		origin_device_id: row.origin_device_id == null ? null : String(row.origin_device_id),
 		origin_source: row.origin_source == null ? null : String(row.origin_source),
@@ -382,6 +389,7 @@ function insertMemory(d: DrizzleDb, row: JsonObject): number {
 		deleted_at: deletedAt,
 		rev: Number(row.rev ?? 1),
 		import_key: String(row.import_key),
+		scope_id: scopeId,
 	};
 	const rows = d
 		.insert(schema.memoryItems)
@@ -561,7 +569,7 @@ export function importMemories(payload: ExportPayload, opts: ImportOptions = {})
 						? mergeSummaryMetadata(baseMetadata, memory.metadata_json ?? null)
 						: baseMetadata;
 
-				insertMemory(d, {
+				insertMemory(db, d, {
 					...memory,
 					session_id: newSessionId,
 					project,

--- a/packages/core/src/scope-stamping.ts
+++ b/packages/core/src/scope-stamping.ts
@@ -1,0 +1,110 @@
+import type { Database } from "./db.js";
+import {
+	LOCAL_DEFAULT_SCOPE_ID,
+	resolveProjectScope,
+	type ScopeMapping,
+} from "./scope-resolution.js";
+
+interface SessionScopeRow {
+	cwd: string | null;
+	project: string | null;
+	git_remote: string | null;
+	git_branch: string | null;
+}
+
+interface MemoryScopeRow extends SessionScopeRow {
+	id: number;
+	session_id: number;
+	workspace_id: string | null;
+	scope_id: string | null;
+}
+
+export interface ResolveSessionScopeOptions {
+	sessionId: number;
+	workspaceId?: string | null;
+	explicitScopeId?: string | null;
+	localDefaultScopeId?: string;
+}
+
+function clean(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function loadProjectScopeMappings(db: Database): ScopeMapping[] {
+	return db
+		.prepare(
+			`SELECT id, workspace_identity, project_pattern, scope_id, priority, source, updated_at
+			 FROM project_scope_mappings
+			 WHERE scope_id IS NOT NULL AND TRIM(scope_id) != ''
+			 ORDER BY priority DESC, id ASC`,
+		)
+		.all() as ScopeMapping[];
+}
+
+function loadSessionScopeRow(db: Database, sessionId: number): SessionScopeRow | null {
+	const row = db
+		.prepare("SELECT cwd, project, git_remote, git_branch FROM sessions WHERE id = ? LIMIT 1")
+		.get(sessionId) as SessionScopeRow | undefined;
+	return row ?? null;
+}
+
+export function resolveSessionScopeId(db: Database, options: ResolveSessionScopeOptions): string {
+	const session = loadSessionScopeRow(db, options.sessionId);
+	const result = resolveProjectScope({
+		gitRemote: session?.git_remote ?? null,
+		gitBranch: session?.git_branch ?? null,
+		cwd: session?.cwd ?? null,
+		project: session?.project ?? null,
+		workspaceId: options.workspaceId ?? null,
+		explicitScopeId: options.explicitScopeId ?? null,
+		localDefaultScopeId: options.localDefaultScopeId ?? LOCAL_DEFAULT_SCOPE_ID,
+		mappings: loadProjectScopeMappings(db),
+	});
+	return result.scopeId;
+}
+
+function loadMemoryScopeRow(db: Database, memoryId: number): MemoryScopeRow | null {
+	const row = db
+		.prepare(
+			`SELECT
+				mi.id,
+				mi.session_id,
+				mi.workspace_id,
+				mi.scope_id,
+				s.cwd,
+				s.project,
+				s.git_remote,
+				s.git_branch
+			 FROM memory_items mi
+			 LEFT JOIN sessions s ON s.id = mi.session_id
+			 WHERE mi.id = ?
+			 LIMIT 1`,
+		)
+		.get(memoryId) as MemoryScopeRow | undefined;
+	return row ?? null;
+}
+
+export function ensureMemoryScopeId(db: Database, memoryId: number): string | null {
+	const row = loadMemoryScopeRow(db, memoryId);
+	if (!row) return null;
+	const existingScopeId = clean(row.scope_id);
+	if (existingScopeId) return existingScopeId;
+
+	const result = resolveProjectScope({
+		gitRemote: row.git_remote,
+		gitBranch: row.git_branch,
+		cwd: row.cwd,
+		project: row.project,
+		workspaceId: row.workspace_id,
+		localDefaultScopeId: LOCAL_DEFAULT_SCOPE_ID,
+		mappings: loadProjectScopeMappings(db),
+	});
+	db.prepare(
+		`UPDATE memory_items
+		 SET scope_id = ?
+		 WHERE id = ?
+		   AND (scope_id IS NULL OR TRIM(scope_id) = '')`,
+	).run(result.scopeId, memoryId);
+	return result.scopeId;
+}

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -229,6 +229,56 @@ describe("MemoryStore", () => {
 			}
 		});
 
+		it("stamps local-default scope on new memory and replication op by default", () => {
+			const sessionId = insertTestSession(store.db);
+			const memId = store.remember(sessionId, "feature", "Scoped default", "Feature body");
+
+			const memory = store.db
+				.prepare("SELECT import_key, scope_id FROM memory_items WHERE id = ?")
+				.get(memId) as { import_key: string; scope_id: string | null };
+			expect(memory.scope_id).toBe("local-default");
+
+			const op = store.db
+				.prepare("SELECT scope_id, payload_json FROM replication_ops WHERE entity_id = ?")
+				.get(memory.import_key) as { scope_id: string | null; payload_json: string };
+			expect(op.scope_id).toBe("local-default");
+			expect(JSON.parse(op.payload_json).scope_id).toBe("local-default");
+		});
+
+		it("stamps mapped scope on new memory and replication op", () => {
+			const sessionId = insertTestSession(store.db);
+			store.db
+				.prepare("UPDATE sessions SET cwd = ?, project = ? WHERE id = ?")
+				.run("/work/acme/service", "service", sessionId);
+			store.db
+				.prepare(
+					`INSERT INTO project_scope_mappings(
+						workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+					 ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				)
+				.run(
+					"/work/acme/service",
+					"/work/acme/*",
+					"acme-work",
+					10,
+					"user",
+					"2026-05-01T00:00:00Z",
+					"2026-05-01T00:00:00Z",
+				);
+
+			const memId = store.remember(sessionId, "feature", "Scoped mapped", "Feature body");
+			const memory = store.db
+				.prepare("SELECT import_key, scope_id FROM memory_items WHERE id = ?")
+				.get(memId) as { import_key: string; scope_id: string | null };
+			expect(memory.scope_id).toBe("acme-work");
+
+			const op = store.db
+				.prepare("SELECT scope_id, payload_json FROM replication_ops WHERE entity_id = ?")
+				.get(memory.import_key) as { scope_id: string | null; payload_json: string };
+			expect(op.scope_id).toBe("acme-work");
+			expect(JSON.parse(op.payload_json).scope_id).toBe("acme-work");
+		});
+
 		it("generates an import_key when not provided", () => {
 			const sessionId = insertTestSession(store.db);
 			const memId = store.remember(sessionId, "discovery", "Title", "Body");
@@ -380,6 +430,47 @@ describe("MemoryStore", () => {
 			expect(count.count).toBe(1);
 		});
 
+		it("returns same-session duplicates when legacy scope is missing", () => {
+			const nullScopeSessionId = insertTestSession(store.db);
+			const nullScopeId = store.remember(
+				nullScopeSessionId,
+				"feature",
+				"Legacy null scope title",
+				"Original body",
+			);
+			store.db.prepare("UPDATE memory_items SET scope_id = NULL WHERE id = ?").run(nullScopeId);
+
+			const nullScopeDuplicateId = store.remember(
+				nullScopeSessionId,
+				"feature",
+				"Legacy null scope title",
+				"Duplicate body",
+			);
+
+			const emptyScopeSessionId = insertTestSession(store.db);
+			const emptyScopeId = store.remember(
+				emptyScopeSessionId,
+				"feature",
+				"Legacy empty scope title",
+				"Original body",
+			);
+			store.db.prepare("UPDATE memory_items SET scope_id = '' WHERE id = ?").run(emptyScopeId);
+
+			const emptyScopeDuplicateId = store.remember(
+				emptyScopeSessionId,
+				"feature",
+				"Legacy empty scope title",
+				"Duplicate body",
+			);
+
+			expect(nullScopeDuplicateId).toBe(nullScopeId);
+			expect(emptyScopeDuplicateId).toBe(emptyScopeId);
+			const count = store.db.prepare("SELECT COUNT(*) AS count FROM memory_items").get() as {
+				count: number;
+			};
+			expect(count.count).toBe(2);
+		});
+
 		it("logs same-session dedup hits when CODEMEM_DEBUG=1", () => {
 			process.env.CODEMEM_DEBUG = "1";
 			const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -437,6 +528,48 @@ describe("MemoryStore", () => {
 				count: number;
 			};
 			expect(count.count).toBe(1);
+		});
+
+		it("does not dedup duplicate titles across different scopes", () => {
+			const sessionA = insertTestSession(store.db);
+			const sessionB = insertTestSession(store.db);
+			store.db
+				.prepare("UPDATE sessions SET cwd = ?, project = ? WHERE id = ?")
+				.run("/work/acme/service", "service", sessionA);
+			store.db
+				.prepare("UPDATE sessions SET cwd = ?, project = ? WHERE id = ?")
+				.run("/oss/codemem", "codemem", sessionB);
+			store.db
+				.prepare(
+					`INSERT INTO project_scope_mappings(
+						workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+					 ) VALUES (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?)`,
+				)
+				.run(
+					"/work/acme/service",
+					"/work/acme/*",
+					"acme-work",
+					10,
+					"user",
+					"2026-05-01T00:00:00Z",
+					"2026-05-01T00:00:00Z",
+					"/oss/codemem",
+					"/oss/*",
+					"oss-codemem",
+					10,
+					"user",
+					"2026-05-01T00:00:00Z",
+					"2026-05-01T00:00:00Z",
+				);
+
+			const firstId = store.remember(sessionA, "discovery", "Shared title", "Original body", 0.9);
+			const secondId = store.remember(sessionB, "discovery", "Shared title", "Duplicate body", 0.5);
+
+			expect(secondId).not.toBe(firstId);
+			const scopes = store.db
+				.prepare("SELECT scope_id FROM memory_items ORDER BY id")
+				.all() as Array<{ scope_id: string | null }>;
+			expect(scopes).toEqual([{ scope_id: "acme-work" }, { scope_id: "oss-codemem" }]);
 		});
 
 		it("logs cross-session dedup hits when CODEMEM_DEBUG=1", () => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -41,6 +41,7 @@ import { populateMemoryRefs } from "./ref-populate.js";
 import type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
 import { findByConcept as findByConceptFn, findByFile as findByFileFn } from "./ref-queries.js";
 import * as schema from "./schema.js";
+import { resolveSessionScopeId } from "./scope-stamping.js";
 import {
 	type ExplainOptions,
 	explain as explainFn,
@@ -286,6 +287,7 @@ export class MemoryStore {
 		kind: string,
 		title: string,
 		dedupKey: string | null,
+		scopeId: string,
 		provenance: {
 			visibility: string;
 			workspace_id: string;
@@ -299,16 +301,24 @@ export class MemoryStore {
 		const sameSessionRows = this.db
 			.prepare(
 				`SELECT id, title
-				 FROM memory_items
-				 WHERE active = 1
+					 FROM memory_items
+					 WHERE active = 1
 				   AND session_id = ?
 				   AND kind = ?
 				   AND visibility = ?
 				   AND workspace_id = ?
+				   AND (scope_id = ? OR scope_id IS NULL OR TRIM(scope_id) = '')
 				   AND (dedup_key = ? OR dedup_key IS NULL)
 				 ORDER BY created_at DESC, id DESC`,
 			)
-			.all(sessionId, kind, provenance.visibility, provenance.workspace_id, dedupKey) as Array<{
+			.all(
+				sessionId,
+				kind,
+				provenance.visibility,
+				provenance.workspace_id,
+				scopeId,
+				dedupKey,
+			) as Array<{
 			id: number;
 			title: string;
 		}>;
@@ -328,12 +338,13 @@ export class MemoryStore {
 		const crossSessionRows = this.db
 			.prepare(
 				`SELECT id, title
-				 FROM memory_items
-				 WHERE active = 1
+					 FROM memory_items
+					 WHERE active = 1
 				   AND session_id != ?
 				   AND kind = ?
 				   AND visibility = ?
 				   AND workspace_id = ?
+				   AND scope_id = ?
 				   AND created_at >= ?
 				   AND (dedup_key = ? OR dedup_key IS NULL)
 				 ORDER BY confidence DESC, created_at DESC, id DESC`,
@@ -343,6 +354,7 @@ export class MemoryStore {
 				kind,
 				provenance.visibility,
 				provenance.workspace_id,
+				scopeId,
 				since,
 				dedupKey,
 			) as Array<{
@@ -616,12 +628,17 @@ export class MemoryStore {
 
 		// Resolve provenance fields
 		const provenance = this.resolveProvenance(metaPayload);
+		const scopeId = resolveSessionScopeId(this.db, {
+			sessionId,
+			workspaceId: provenance.workspace_id,
+		});
 
 		const existingHit = this.findExistingDuplicateMemory(
 			sessionId,
 			validKind,
 			safeTitle,
 			dedupKey,
+			scopeId,
 			provenance,
 			now,
 		);
@@ -669,6 +686,7 @@ export class MemoryStore {
 						rev: 1,
 						dedup_key: dedupKey,
 						import_key: importKey,
+						scope_id: scopeId,
 					})
 					.returning({ id: schema.memoryItems.id })
 					.all();
@@ -694,6 +712,7 @@ export class MemoryStore {
 				validKind,
 				safeTitle,
 				dedupKey,
+				scopeId,
 				provenance,
 				now,
 			);

--- a/packages/core/src/sync-bootstrap.test.ts
+++ b/packages/core/src/sync-bootstrap.test.ts
@@ -98,6 +98,18 @@ describe("applyBootstrapSnapshot", () => {
 		expect(newA.visibility).toBe("shared");
 	});
 
+	it("preserves snapshot payload scope_id on inserted memories", () => {
+		const items = [makeSnapshotItem("scoped-key", { payload: { scope_id: "acme-work" } })];
+
+		const result = applyBootstrapSnapshot(db, "peer-1", items, makeResetInfo());
+
+		expect(result.ok).toBe(true);
+		const scoped = db
+			.prepare("SELECT scope_id FROM memory_items WHERE import_key = 'scoped-key'")
+			.get() as Record<string, unknown>;
+		expect(scoped.scope_id).toBe("acme-work");
+	});
+
 	it("preserves private memories during bootstrap", () => {
 		const now = new Date().toISOString();
 		db.prepare(

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -317,6 +317,7 @@ export function applyBootstrapSnapshot(
 					user_prompt_id:
 						typeof payload.user_prompt_id === "number" ? payload.user_prompt_id : null,
 					prompt_number: typeof payload.prompt_number === "number" ? payload.prompt_number : null,
+					scope_id: typeof payload.scope_id === "string" ? payload.scope_id : null,
 				})
 				.run();
 			result.applied++;

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -250,6 +250,54 @@ describe("recordReplicationOp", () => {
 		expect(row.clock_device_id).toBe("dev-a");
 	});
 
+	it("stamps a missing memory scope before recording the replication op", () => {
+		const sessionId = insertTestSession(db);
+		db.prepare("UPDATE sessions SET cwd = ?, project = ? WHERE id = ?").run(
+			"/work/acme/service",
+			"service",
+			sessionId,
+		);
+		db.prepare(
+			`INSERT INTO project_scope_mappings(
+				workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			"/work/acme/service",
+			"/work/acme/*",
+			"acme-work",
+			10,
+			"user",
+			"2026-05-01T00:00:00Z",
+			"2026-05-01T00:00:00Z",
+		);
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(sessionId, "discovery", "Test", "body", now, now, "key:scope-stamp", 3, toJson({}));
+
+		const memId = (
+			db.prepare("SELECT id FROM memory_items WHERE import_key = ?").get("key:scope-stamp") as {
+				id: number;
+			}
+		).id;
+
+		const opId = recordReplicationOp(db, {
+			memoryId: memId,
+			opType: "delete",
+			deviceId: "dev-a",
+		});
+
+		const memory = db.prepare("SELECT scope_id FROM memory_items WHERE id = ?").get(memId) as {
+			scope_id: string | null;
+		};
+		expect(memory.scope_id).toBe("acme-work");
+		const op = db.prepare("SELECT scope_id FROM replication_ops WHERE op_id = ?").get(opId) as {
+			scope_id: string | null;
+		};
+		expect(op.scope_id).toBe("acme-work");
+	});
+
 	it("includes full memory payload in upsert ops and round-trips all columns", () => {
 		const sessionId = insertTestSession(db);
 		const now = new Date().toISOString();
@@ -1368,6 +1416,60 @@ describe("legacy key migration + replication backfill", () => {
 		expect(count.n).toBe(2);
 	});
 
+	it("stamps missing memory scope before backfilling replication ops", () => {
+		db.prepare(
+			"INSERT INTO sync_device(device_id, public_key, fingerprint, created_at) VALUES (?, ?, ?, ?)",
+		).run("dev-local", "pub", "fp", "2026-01-01T00:00:00Z");
+		const sessionId = insertTestSession(db);
+		db.prepare("UPDATE sessions SET cwd = ?, project = ? WHERE id = ?").run(
+			"/work/acme/service",
+			"service",
+			sessionId,
+		);
+		db.prepare(
+			`INSERT INTO project_scope_mappings(
+				workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			"/work/acme/service",
+			"/work/acme/*",
+			"acme-work",
+			10,
+			"user",
+			"2026-05-01T00:00:00Z",
+			"2026-05-01T00:00:00Z",
+		);
+		const now = "2026-01-02T00:00:00Z";
+		db.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, created_at, updated_at, import_key, rev, active, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"feature",
+			"Live row",
+			"live",
+			now,
+			now,
+			"key:missing-scope",
+			1,
+			1,
+			toJson({}),
+		);
+
+		const inserted = backfillReplicationOps(db, 10);
+
+		expect(inserted).toBe(1);
+		const memory = db
+			.prepare("SELECT scope_id FROM memory_items WHERE import_key = ?")
+			.get("key:missing-scope") as { scope_id: string | null };
+		expect(memory.scope_id).toBe("acme-work");
+		const op = db
+			.prepare("SELECT scope_id, payload_json FROM replication_ops WHERE entity_id = ?")
+			.get("key:missing-scope") as { scope_id: string | null; payload_json: string };
+		expect(op.scope_id).toBe("acme-work");
+		expect(JSON.parse(op.payload_json).scope_id).toBe("acme-work");
+	});
+
 	it("does not mint legacy:local import keys before device identity exists", () => {
 		const sessionId = insertTestSession(db);
 		const now = "2026-01-02T00:00:00Z";
@@ -1813,6 +1915,80 @@ describe("applyReplicationOps", () => {
 		expect(mem.title).not.toContain(pat);
 		expect(mem.title).toContain("[REDACTED:github_pat_classic]");
 		expect(mem.body_text).not.toContain(pat);
+	});
+
+	it("uses authoritative inbound op scope_id when updating existing memories", () => {
+		const sessionId = insertTestSession(db);
+		db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, created_at, updated_at, import_key, rev, metadata_json, scope_id
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Local old title",
+			"Local old body",
+			"2026-01-01T00:00:00Z",
+			"2026-01-01T00:00:00Z",
+			"key:test-1",
+			0,
+			toJson({ clock_device_id: "dev-local" }),
+			"local-default",
+		);
+		const op = makeReplicationOp({ scope_id: "acme-work", clock_rev: 2 });
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+
+		expect(result.applied).toBe(1);
+		const mem = db
+			.prepare("SELECT title, scope_id FROM memory_items WHERE import_key = ?")
+			.get(op.entity_id) as { title: string; scope_id: string | null };
+		expect(mem.title).toBe("Remote memory");
+		expect(mem.scope_id).toBe("acme-work");
+		const recordedOp = db
+			.prepare("SELECT scope_id FROM replication_ops WHERE op_id = ?")
+			.get(op.op_id) as { scope_id: string | null };
+		expect(recordedOp.scope_id).toBe("acme-work");
+	});
+
+	it("uses authoritative inbound op scope_id when deleting existing memories", () => {
+		const sessionId = insertTestSession(db);
+		db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, created_at, updated_at, import_key, rev, active, metadata_json, scope_id
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Local old title",
+			"Local old body",
+			"2026-01-01T00:00:00Z",
+			"2026-01-01T00:00:00Z",
+			"key:test-1",
+			0,
+			1,
+			toJson({ clock_device_id: "dev-local" }),
+			"local-default",
+		);
+		const op = makeReplicationOp({
+			op_type: "delete",
+			payload_json: null,
+			scope_id: "acme-work",
+			clock_rev: 2,
+		});
+
+		const result = applyReplicationOps(db, [op], "dev-local");
+
+		expect(result.applied).toBe(1);
+		const mem = db
+			.prepare("SELECT active, scope_id FROM memory_items WHERE import_key = ?")
+			.get(op.entity_id) as { active: number; scope_id: string | null };
+		expect(mem.active).toBe(0);
+		expect(mem.scope_id).toBe("acme-work");
+		const recordedOp = db
+			.prepare("SELECT scope_id FROM replication_ops WHERE op_id = ?")
+			.get(op.op_id) as { scope_id: string | null };
+		expect(recordedOp.scope_id).toBe("acme-work");
 	});
 
 	it("populates ref tables when inserting a new memory with files and concepts", () => {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -17,6 +17,7 @@ import { readCodememConfigFile } from "./observer-config.js";
 import { projectBasename } from "./project.js";
 import { clearMemoryRefs, populateMemoryRefs } from "./ref-populate.js";
 import * as schema from "./schema.js";
+import { ensureMemoryScopeId } from "./scope-stamping.js";
 import { redactMemoryFields, SecretScanner } from "./secret-scanner.js";
 import { deriveTags } from "./tags.js";
 import type {
@@ -568,7 +569,9 @@ export function recordReplicationOp(
 	const updatedAt = row?.updated_at ?? now;
 	const entityId = row?.import_key ?? String(opts.memoryId);
 	const metadata = fromJson(row?.metadata_json);
-	const scopeId = row?.scope_id ?? null;
+	// Backfill missing memory scope before emitting an op so storage, op row,
+	// and payload all carry the same authoritative local scope.
+	const scopeId = row ? ensureMemoryScopeId(db, opts.memoryId) : null;
 	const clockDeviceId =
 		typeof metadata.clock_device_id === "string" && metadata.clock_device_id.trim().length > 0
 			? metadata.clock_device_id
@@ -584,7 +587,7 @@ export function recordReplicationOp(
 		: null;
 
 	// Build payload from the memory row so peers can reconstruct the full item.
-	// Explicit payload override takes precedence (used by tests).
+	// Explicit payload override wins except for authoritative scope_id on upserts.
 	let payloadJson: string | null;
 	if (opts.payload) {
 		payloadJson = toJson(
@@ -1669,7 +1672,8 @@ export function backfillReplicationOps(db: Database, limit = 200): number {
 
 		const clockDeviceId = originDeviceId;
 		if (!clockDeviceId) continue;
-		const payload = buildPayloadFromMemoryRow(row);
+		const scopeId = ensureMemoryScopeId(db, rowId);
+		const payload = buildPayloadFromMemoryRow({ ...row, scope_id: scopeId });
 
 		d.insert(schema.replicationOps)
 			.values({
@@ -1683,7 +1687,7 @@ export function backfillReplicationOps(db: Database, limit = 200): number {
 				clock_device_id: clockDeviceId,
 				device_id: clockDeviceId,
 				created_at: now,
-				scope_id: row.scope_id ?? null,
+				scope_id: scopeId,
 			})
 			.onConflictDoNothing()
 			.run();


### PR DESCRIPTION
## Description

Stamps `scope_id` on new local memory writes and generated replication ops using destination-local resolver policy. Keeps op rows, payloads, bootstrap imports, and export/import writes aligned while avoiding sync authorization/enforcement changes in this phase.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected (reviewed default/mapped stamping, scope-aware dedup, bootstrap/import, and replication-op coverage)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
