### PR TITLE
feat: cache local scope memberships

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -643,6 +643,16 @@ export function ensureAdditiveSchemaCompatibility(db: DatabaseType): void {
 				ON scope_memberships(scope_id, status);
 			CREATE INDEX IF NOT EXISTS idx_scope_memberships_authority_group
 				ON scope_memberships(coordinator_id, group_id);
+
+			CREATE TABLE IF NOT EXISTS scope_membership_cache_state (
+				coordinator_id TEXT NOT NULL,
+				group_id TEXT NOT NULL,
+				last_refresh_at TEXT NOT NULL,
+				last_success_at TEXT,
+				last_error TEXT,
+				updated_at TEXT NOT NULL,
+				PRIMARY KEY (coordinator_id, group_id)
+			);
 		`);
 	} catch {
 		// Keep compatibility shim fail-open for optional additive scope metadata.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -401,6 +401,28 @@ export {
 	ScopeBackfillRunner,
 } from "./scope-backfill.js";
 export type {
+	CachedDeviceScopeMemberships,
+	CachedScopeAuthorization,
+	CachedScopeMembership,
+	RefreshScopeMembershipCacheGroupResult,
+	RefreshScopeMembershipCacheOptions,
+	RefreshScopeMembershipCacheResult,
+	ScopeMembershipAuthorizationState,
+	ScopeMembershipCacheAuthority,
+	ScopeMembershipCacheFetchers,
+	ScopeMembershipCacheFreshness,
+	ScopeMembershipCacheState,
+} from "./scope-membership-cache.js";
+export {
+	DEFAULT_SCOPE_MEMBERSHIP_CACHE_MAX_AGE_MS,
+	ensureScopeMembershipCacheStateTable,
+	getCachedScopeAuthorization,
+	listCachedScopesForDevice,
+	refreshConfiguredScopeMembershipCache,
+	refreshScopeMembershipCache,
+	upsertCachedScopeMemberships,
+} from "./scope-membership-cache.js";
+export type {
 	CanonicalWorkspaceIdentity,
 	ResolveProjectScopeInput,
 	ScopeMapping,

--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -96,6 +96,16 @@ CREATE TABLE IF NOT EXISTS coordinator_group_preferences (
 	updated_at TEXT NOT NULL,
 	PRIMARY KEY (coordinator_id, group_id)
 );
+
+CREATE TABLE IF NOT EXISTS scope_membership_cache_state (
+	coordinator_id TEXT NOT NULL,
+	group_id TEXT NOT NULL,
+	last_refresh_at TEXT NOT NULL,
+	last_success_at TEXT,
+	last_error TEXT,
+	updated_at TEXT NOT NULL,
+	PRIMARY KEY (coordinator_id, group_id)
+);
 `;
 
 /**

--- a/packages/core/src/scope-membership-cache.test.ts
+++ b/packages/core/src/scope-membership-cache.test.ts
@@ -1,0 +1,378 @@
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CoordinatorScope, CoordinatorScopeMembership } from "./coordinator-store-contract.js";
+import type { Database as CoreDatabase } from "./db.js";
+import {
+	getCachedScopeAuthorization,
+	listCachedScopesForDevice,
+	refreshScopeMembershipCache,
+	upsertCachedScopeMemberships,
+} from "./scope-membership-cache.js";
+import { initTestSchema } from "./test-utils.js";
+
+function now(offsetMs = 0): string {
+	return new Date(Date.UTC(2026, 4, 1, 12, 0, 0, offsetMs)).toISOString();
+}
+
+function scope(overrides: Partial<CoordinatorScope> = {}): CoordinatorScope {
+	return {
+		scope_id: "scope-acme",
+		label: "Acme Work",
+		kind: "team",
+		authority_type: "coordinator",
+		coordinator_id: "coord-a",
+		group_id: "team-a",
+		manifest_issuer_device_id: null,
+		membership_epoch: 3,
+		manifest_hash: "hash-scope",
+		status: "active",
+		created_at: now(),
+		updated_at: now(),
+		...overrides,
+	};
+}
+
+function membership(
+	overrides: Partial<CoordinatorScopeMembership> = {},
+): CoordinatorScopeMembership {
+	return {
+		scope_id: "scope-acme",
+		device_id: "device-a",
+		role: "member",
+		status: "active",
+		membership_epoch: 3,
+		coordinator_id: "coord-a",
+		group_id: "team-a",
+		manifest_issuer_device_id: null,
+		manifest_hash: "hash-member",
+		signed_manifest_json: null,
+		updated_at: now(),
+		...overrides,
+	};
+}
+
+describe("scope membership cache", () => {
+	let db: CoreDatabase | null = null;
+
+	afterEach(() => {
+		db?.close();
+		db = null;
+	});
+
+	function setup(): CoreDatabase {
+		db = new Database(":memory:");
+		initTestSchema(db);
+		return db;
+	}
+
+	it("caches coordinator scopes and active memberships for deterministic device lookups", async () => {
+		const local = setup();
+		const result = await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async () => [scope()],
+				listMemberships: async () => [membership()],
+			},
+		});
+
+		expect(result).toMatchObject({ status: "refreshed", coordinatorId: "coord-a" });
+		const cached = listCachedScopesForDevice(local, "device-a", {
+			now: new Date(now(1)),
+			authority: { coordinatorId: "coord-a", groupId: "team-a" },
+		});
+		expect(cached.freshness).toBe("fresh");
+		expect(cached.memberships).toEqual([
+			expect.objectContaining({
+				scope_id: "scope-acme",
+				device_id: "device-a",
+				status: "active",
+				scope: expect.objectContaining({ label: "Acme Work" }),
+			}),
+		]);
+	});
+
+	it("keeps cached authorization visible as stale when coordinator refresh fails", async () => {
+		const local = setup();
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async () => [scope()],
+				listMemberships: async () => [membership()],
+			},
+		});
+
+		const stale = await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now(2)),
+			fetchers: {
+				listScopes: async () => {
+					throw new Error("coordinator offline");
+				},
+				listMemberships: async () => [],
+			},
+		});
+
+		expect(stale.status).toBe("stale");
+		const cached = listCachedScopesForDevice(local, "device-a", {
+			now: new Date(now(3)),
+			authority: { coordinatorId: "coord-a", groupId: "team-a" },
+		});
+		expect(cached.freshness).toBe("stale");
+		expect(cached.memberships).toHaveLength(1);
+
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now(4)),
+			fetchers: {
+				listScopes: async () => [scope()],
+				listMemberships: async () => [membership()],
+			},
+		});
+
+		expect(
+			listCachedScopesForDevice(local, "device-a", {
+				now: new Date(now(5)),
+				authority: { coordinatorId: "coord-a", groupId: "team-a" },
+			}).freshness,
+		).toBe("fresh");
+	});
+
+	it("filters device lookups by requested coordinator and group authority", async () => {
+		const local = setup();
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a", "team-b"],
+			coordinatorId: "coord-a",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async (groupId) => [
+					scope({
+						scope_id: groupId === "team-a" ? "scope-acme" : "scope-oss",
+						group_id: groupId,
+					}),
+				],
+				listMemberships: async (groupId, scopeId) => [
+					membership({ group_id: groupId, scope_id: scopeId }),
+				],
+			},
+		});
+
+		const teamA = listCachedScopesForDevice(local, "device-a", {
+			authority: { coordinatorId: "coord-a", groupId: "team-a" },
+		});
+		const teamB = listCachedScopesForDevice(local, "device-a", {
+			authority: { coordinatorId: "coord-a", groupId: "team-b" },
+		});
+
+		expect(teamA.memberships.map((item) => item.scope_id)).toEqual(["scope-acme"]);
+		expect(teamB.memberships.map((item) => item.scope_id)).toEqual(["scope-oss"]);
+	});
+
+	it("normalizes missing coordinator authority from refreshed remote payloads", async () => {
+		const local = setup();
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "https://coord.example",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async () => [scope({ coordinator_id: null, group_id: null })],
+				listMemberships: async () => [membership({ coordinator_id: null, group_id: null })],
+			},
+		});
+
+		const authorization = getCachedScopeAuthorization(local, {
+			deviceId: "device-a",
+			scopeId: "scope-acme",
+			now: new Date(now(1)),
+		});
+		expect(authorization).toMatchObject({ authorized: true, freshness: "fresh" });
+		expect(authorization.membership).toMatchObject({
+			coordinator_id: "https://coord.example",
+			group_id: "team-a",
+		});
+	});
+
+	it("distinguishes fresh no-authorization from stale unknown authorization", async () => {
+		const local = setup();
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async () => [scope()],
+				listMemberships: async () => [],
+			},
+		});
+
+		const freshMiss = getCachedScopeAuthorization(local, {
+			deviceId: "device-a",
+			scopeId: "scope-acme",
+			now: new Date(now(1)),
+			authority: { coordinatorId: "coord-a", groupId: "team-a" },
+		});
+		expect(freshMiss).toMatchObject({
+			authorized: false,
+			state: "not_authorized",
+			freshness: "fresh",
+		});
+
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now(2)),
+			fetchers: {
+				listScopes: async () => {
+					throw new Error("coordinator offline");
+				},
+				listMemberships: async () => [],
+			},
+		});
+
+		const staleMiss = getCachedScopeAuthorization(local, {
+			deviceId: "device-a",
+			scopeId: "scope-acme",
+			now: new Date(now(3)),
+			authority: { coordinatorId: "coord-a", groupId: "team-a" },
+		});
+		expect(staleMiss).toMatchObject({
+			authorized: false,
+			state: "not_authorized",
+			freshness: "stale",
+		});
+	});
+
+	it("reconciles removed memberships on a successful authoritative refresh", async () => {
+		const local = setup();
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async () => [scope()],
+				listMemberships: async () => [membership()],
+			},
+		});
+		expect(
+			getCachedScopeAuthorization(local, {
+				deviceId: "device-a",
+				scopeId: "scope-acme",
+				now: new Date(now(1)),
+			}).authorized,
+		).toBe(true);
+
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now(2)),
+			fetchers: {
+				listScopes: async () => [scope({ membership_epoch: 4 })],
+				listMemberships: async () => [],
+			},
+		});
+
+		expect(
+			getCachedScopeAuthorization(local, {
+				deviceId: "device-a",
+				scopeId: "scope-acme",
+				now: new Date(now(3)),
+			}),
+		).toMatchObject({ authorized: false, state: "revoked", freshness: "fresh" });
+	});
+
+	it("reconciles omitted scopes on a successful authoritative refresh", async () => {
+		const local = setup();
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async () => [scope()],
+				listMemberships: async () => [membership()],
+			},
+		});
+
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now(1)),
+			fetchers: {
+				listScopes: async () => [],
+				listMemberships: async () => [],
+			},
+		});
+
+		expect(
+			getCachedScopeAuthorization(local, {
+				deviceId: "device-a",
+				scopeId: "scope-acme",
+				now: new Date(now(2)),
+			}),
+		).toMatchObject({ authorized: false, state: "revoked", freshness: "fresh" });
+		expect(listCachedScopesForDevice(local, "device-a").memberships).toEqual([]);
+	});
+
+	it("does not let stale active grants resurrect revoked memberships", () => {
+		const local = setup();
+		upsertCachedScopeMemberships(local, [membership({ membership_epoch: 8, status: "revoked" })]);
+		upsertCachedScopeMemberships(local, [membership({ membership_epoch: 7, status: "active" })]);
+
+		const authorization = getCachedScopeAuthorization(local, {
+			deviceId: "device-a",
+			scopeId: "scope-acme",
+		});
+		expect(authorization).toMatchObject({
+			authorized: false,
+			state: "revoked",
+		});
+	});
+
+	it("does not authorize active memberships when scope metadata is missing", () => {
+		const local = setup();
+		upsertCachedScopeMemberships(local, [membership()]);
+
+		const authorization = getCachedScopeAuthorization(local, {
+			deviceId: "device-a",
+			scopeId: "scope-acme",
+		});
+
+		expect(authorization).toMatchObject({
+			authorized: false,
+			state: "scope_unknown",
+			freshness: "unknown",
+			scope: null,
+		});
+		expect(listCachedScopesForDevice(local, "device-a").memberships).toEqual([]);
+	});
+
+	it("does not authorize a membership from a different requested authority", async () => {
+		const local = setup();
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-b"],
+			coordinatorId: "coord-b",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async () => [scope({ coordinator_id: "coord-b", group_id: "team-b" })],
+				listMemberships: async () => [
+					membership({ coordinator_id: "coord-b", group_id: "team-b" }),
+				],
+			},
+		});
+
+		const authorization = getCachedScopeAuthorization(local, {
+			deviceId: "device-a",
+			scopeId: "scope-acme",
+			authority: { coordinatorId: "coord-a", groupId: "team-a" },
+		});
+
+		expect(authorization).toMatchObject({
+			authorized: false,
+			state: "not_authorized",
+			scope: null,
+		});
+	});
+});

--- a/packages/core/src/scope-membership-cache.ts
+++ b/packages/core/src/scope-membership-cache.ts
@@ -1,0 +1,721 @@
+import {
+	coordinatorListScopeMembershipsAction,
+	coordinatorListScopesAction,
+} from "./coordinator-actions.js";
+import {
+	type CoordinatorSyncConfig,
+	coordinatorEnabled,
+	readCoordinatorSyncConfig,
+} from "./coordinator-runtime.js";
+import type { CoordinatorScope, CoordinatorScopeMembership } from "./coordinator-store-contract.js";
+import type { Database } from "./db.js";
+import { buildBaseUrl } from "./sync-http-client.js";
+
+export const DEFAULT_SCOPE_MEMBERSHIP_CACHE_MAX_AGE_MS = 60_000;
+
+export type ScopeMembershipCacheFreshness = "fresh" | "stale" | "unknown";
+
+export type ScopeMembershipAuthorizationState =
+	| "authorized"
+	| "not_authorized"
+	| "revoked"
+	| "scope_unknown"
+	| "scope_inactive";
+
+export interface ScopeMembershipCacheAuthority {
+	coordinatorId: string;
+	groupId: string;
+}
+
+export interface ScopeMembershipCacheState extends ScopeMembershipCacheAuthority {
+	last_refresh_at: string;
+	last_success_at: string | null;
+	last_error: string | null;
+	updated_at: string;
+}
+
+export interface CachedScopeMembership extends CoordinatorScopeMembership {
+	scope: CoordinatorScope | null;
+}
+
+export interface CachedDeviceScopeMemberships {
+	deviceId: string;
+	freshness: ScopeMembershipCacheFreshness;
+	memberships: CachedScopeMembership[];
+	cacheStates: ScopeMembershipCacheState[];
+}
+
+export interface CachedScopeAuthorization {
+	deviceId: string;
+	scopeId: string;
+	authorized: boolean;
+	state: ScopeMembershipAuthorizationState;
+	freshness: ScopeMembershipCacheFreshness;
+	membership: CoordinatorScopeMembership | null;
+	scope: CoordinatorScope | null;
+	cacheStates: ScopeMembershipCacheState[];
+}
+
+export interface ScopeMembershipCacheFetchers {
+	listScopes(groupId: string): Promise<CoordinatorScope[]>;
+	listMemberships(groupId: string, scopeId: string): Promise<CoordinatorScopeMembership[]>;
+}
+
+export interface RefreshScopeMembershipCacheOptions {
+	groupIds: string[];
+	coordinatorId?: string | null;
+	remoteUrl?: string | null;
+	adminSecret?: string | null;
+	now?: Date;
+	fetchers?: ScopeMembershipCacheFetchers;
+}
+
+export interface RefreshScopeMembershipCacheGroupResult {
+	groupId: string;
+	status: "refreshed" | "stale";
+	scopeCount: number;
+	membershipCount: number;
+	error: string | null;
+}
+
+export interface RefreshScopeMembershipCacheResult {
+	status: "refreshed" | "partial" | "stale" | "skipped";
+	coordinatorId: string | null;
+	groups: RefreshScopeMembershipCacheGroupResult[];
+}
+
+interface ScopeMembershipCacheLookupOptions {
+	now?: Date;
+	maxAgeMs?: number;
+	authority?: ScopeMembershipCacheAuthority | null;
+}
+
+interface JoinedMembershipRow extends CoordinatorScopeMembership {
+	scope_label: string | null;
+	scope_kind: string | null;
+	scope_authority_type: string | null;
+	scope_coordinator_id: string | null;
+	scope_group_id: string | null;
+	scope_manifest_issuer_device_id: string | null;
+	scope_membership_epoch: number | null;
+	scope_manifest_hash: string | null;
+	scope_status: string | null;
+	scope_created_at: string | null;
+	scope_updated_at: string | null;
+}
+
+function clean(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function nowIso(now?: Date): string {
+	return (now ?? new Date()).toISOString();
+}
+
+function groupIds(input: string[]): string[] {
+	return [...new Set(input.map((item) => item.trim()).filter(Boolean))].toSorted();
+}
+
+function authorityId(remoteUrl: string | null | undefined): string {
+	const remote = clean(remoteUrl);
+	if (!remote) return "local";
+	try {
+		return buildBaseUrl(remote);
+	} catch {
+		return remote;
+	}
+}
+
+function errorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	return String(error ?? "unknown");
+}
+
+export function ensureScopeMembershipCacheStateTable(db: Database): void {
+	db.exec(`
+		CREATE TABLE IF NOT EXISTS scope_membership_cache_state (
+			coordinator_id TEXT NOT NULL,
+			group_id TEXT NOT NULL,
+			last_refresh_at TEXT NOT NULL,
+			last_success_at TEXT,
+			last_error TEXT,
+			updated_at TEXT NOT NULL,
+			PRIMARY KEY (coordinator_id, group_id)
+		)
+	`);
+}
+
+function defaultFetchers(opts: RefreshScopeMembershipCacheOptions): ScopeMembershipCacheFetchers {
+	return {
+		listScopes: (groupId) =>
+			coordinatorListScopesAction({
+				groupId,
+				includeInactive: true,
+				remoteUrl: opts.remoteUrl ?? null,
+				adminSecret: opts.adminSecret ?? null,
+			}),
+		listMemberships: (groupId, scopeId) =>
+			coordinatorListScopeMembershipsAction({
+				groupId,
+				scopeId,
+				includeRevoked: true,
+				remoteUrl: opts.remoteUrl ?? null,
+				adminSecret: opts.adminSecret ?? null,
+			}),
+	};
+}
+
+function upsertScope(db: Database, scope: CoordinatorScope): void {
+	db.prepare(
+		`INSERT INTO replication_scopes(
+			scope_id, label, kind, authority_type, coordinator_id, group_id,
+			manifest_issuer_device_id, membership_epoch, manifest_hash, status, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(scope_id) DO UPDATE SET
+			label = excluded.label,
+			kind = excluded.kind,
+			authority_type = excluded.authority_type,
+			coordinator_id = excluded.coordinator_id,
+			group_id = excluded.group_id,
+			manifest_issuer_device_id = excluded.manifest_issuer_device_id,
+			membership_epoch = excluded.membership_epoch,
+			manifest_hash = excluded.manifest_hash,
+			status = excluded.status,
+			updated_at = excluded.updated_at
+		WHERE excluded.membership_epoch >= replication_scopes.membership_epoch`,
+	).run(
+		scope.scope_id,
+		scope.label,
+		scope.kind,
+		scope.authority_type,
+		scope.coordinator_id,
+		scope.group_id,
+		scope.manifest_issuer_device_id,
+		scope.membership_epoch,
+		scope.manifest_hash,
+		scope.status,
+		scope.created_at,
+		scope.updated_at,
+	);
+}
+
+function scopeWithAuthority(
+	scope: CoordinatorScope,
+	authority: ScopeMembershipCacheAuthority,
+): CoordinatorScope {
+	return {
+		...scope,
+		coordinator_id: clean(scope.coordinator_id) ?? authority.coordinatorId,
+		group_id: clean(scope.group_id) ?? authority.groupId,
+	};
+}
+
+function membershipWithAuthority(
+	membership: CoordinatorScopeMembership,
+	scope: CoordinatorScope,
+	authority: ScopeMembershipCacheAuthority,
+): CoordinatorScopeMembership {
+	return {
+		...membership,
+		coordinator_id:
+			clean(membership.coordinator_id) ?? clean(scope.coordinator_id) ?? authority.coordinatorId,
+		group_id: clean(membership.group_id) ?? clean(scope.group_id) ?? authority.groupId,
+	};
+}
+
+function placeholders(count: number): string {
+	return Array.from({ length: count }, () => "?").join(", ");
+}
+
+function reconcileScopeMembershipSnapshot(
+	db: Database,
+	scope: CoordinatorScope,
+	memberships: CoordinatorScopeMembership[],
+	authority: ScopeMembershipCacheAuthority,
+	timestamp: string,
+): void {
+	const deviceIds = memberships.map((membership) => membership.device_id);
+	const deviceFilter =
+		deviceIds.length > 0 ? `AND device_id NOT IN (${placeholders(deviceIds.length)})` : "";
+	db.prepare(
+		`UPDATE scope_memberships
+		 SET status = 'revoked',
+			 membership_epoch = CASE WHEN membership_epoch > ? THEN membership_epoch ELSE ? END,
+			 coordinator_id = COALESCE(coordinator_id, ?),
+			 group_id = COALESCE(group_id, ?),
+			 updated_at = ?
+		 WHERE scope_id = ?
+			 AND COALESCE(coordinator_id, ?) = ?
+			 AND COALESCE(group_id, ?) = ?
+			 AND status != 'revoked'
+			 ${deviceFilter}`,
+	).run(
+		scope.membership_epoch,
+		scope.membership_epoch,
+		authority.coordinatorId,
+		authority.groupId,
+		timestamp,
+		scope.scope_id,
+		authority.coordinatorId,
+		authority.coordinatorId,
+		authority.groupId,
+		authority.groupId,
+		...deviceIds,
+	);
+}
+
+function reconcileGroupScopeSnapshot(
+	db: Database,
+	authority: ScopeMembershipCacheAuthority,
+	scopes: CoordinatorScope[],
+	timestamp: string,
+): void {
+	const scopeIds = scopes.map((scope) => scope.scope_id);
+	const scopeFilter =
+		scopeIds.length > 0 ? `AND scope_id NOT IN (${placeholders(scopeIds.length)})` : "";
+	const missing = db
+		.prepare(
+			`SELECT scope_id
+			 FROM replication_scopes
+			 WHERE coordinator_id = ?
+				 AND group_id = ?
+				 ${scopeFilter}`,
+		)
+		.all(authority.coordinatorId, authority.groupId, ...scopeIds) as Array<{ scope_id: string }>;
+	if (missing.length === 0) return;
+	const missingScopeIds = missing.map((row) => row.scope_id);
+	db.prepare(
+		`UPDATE replication_scopes
+		 SET status = 'archived', updated_at = ?
+		 WHERE coordinator_id = ?
+			 AND group_id = ?
+			 AND scope_id IN (${placeholders(missingScopeIds.length)})`,
+	).run(timestamp, authority.coordinatorId, authority.groupId, ...missingScopeIds);
+	db.prepare(
+		`UPDATE scope_memberships
+		 SET status = 'revoked', updated_at = ?
+		 WHERE COALESCE(coordinator_id, ?) = ?
+			 AND COALESCE(group_id, ?) = ?
+			 AND scope_id IN (${placeholders(missingScopeIds.length)})
+			 AND status != 'revoked'`,
+	).run(
+		timestamp,
+		authority.coordinatorId,
+		authority.coordinatorId,
+		authority.groupId,
+		authority.groupId,
+		...missingScopeIds,
+	);
+}
+
+export function upsertCachedScopeMemberships(
+	db: Database,
+	memberships: CoordinatorScopeMembership[],
+): number {
+	const insert = db.prepare(
+		`INSERT INTO scope_memberships(
+			scope_id, device_id, role, status, membership_epoch, coordinator_id, group_id,
+			manifest_issuer_device_id, manifest_hash, signed_manifest_json, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(scope_id, device_id) DO UPDATE SET
+			role = excluded.role,
+			status = excluded.status,
+			membership_epoch = excluded.membership_epoch,
+			coordinator_id = excluded.coordinator_id,
+			group_id = excluded.group_id,
+			manifest_issuer_device_id = excluded.manifest_issuer_device_id,
+			manifest_hash = excluded.manifest_hash,
+			signed_manifest_json = excluded.signed_manifest_json,
+			updated_at = excluded.updated_at
+		WHERE excluded.membership_epoch > scope_memberships.membership_epoch
+			OR (
+				excluded.membership_epoch = scope_memberships.membership_epoch
+				AND scope_memberships.status != 'revoked'
+			)`,
+	);
+	let count = 0;
+	db.transaction(() => {
+		for (const membership of memberships) {
+			insert.run(
+				membership.scope_id,
+				membership.device_id,
+				membership.role,
+				membership.status,
+				membership.membership_epoch,
+				membership.coordinator_id,
+				membership.group_id,
+				membership.manifest_issuer_device_id,
+				membership.manifest_hash,
+				membership.signed_manifest_json,
+				membership.updated_at,
+			);
+			count += 1;
+		}
+	})();
+	return count;
+}
+
+function recordRefreshState(
+	db: Database,
+	input: ScopeMembershipCacheAuthority & { ok: boolean; error?: string | null; now: string },
+): void {
+	ensureScopeMembershipCacheStateTable(db);
+	db.prepare(
+		`INSERT INTO scope_membership_cache_state(
+			coordinator_id, group_id, last_refresh_at, last_success_at, last_error, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(coordinator_id, group_id) DO UPDATE SET
+			last_refresh_at = excluded.last_refresh_at,
+			last_success_at = COALESCE(excluded.last_success_at, scope_membership_cache_state.last_success_at),
+			last_error = excluded.last_error,
+			updated_at = excluded.updated_at`,
+	).run(
+		input.coordinatorId,
+		input.groupId,
+		input.now,
+		input.ok ? input.now : null,
+		input.ok ? null : (input.error ?? "unknown"),
+		input.now,
+	);
+}
+
+function loadCacheStates(
+	db: Database,
+	authority?: ScopeMembershipCacheAuthority | null,
+): ScopeMembershipCacheState[] {
+	ensureScopeMembershipCacheStateTable(db);
+	if (authority) {
+		return db
+			.prepare(
+				`SELECT coordinator_id, group_id, last_refresh_at, last_success_at, last_error, updated_at
+				 FROM scope_membership_cache_state
+				 WHERE coordinator_id = ? AND group_id = ?`,
+			)
+			.all(authority.coordinatorId, authority.groupId) as ScopeMembershipCacheState[];
+	}
+	return db
+		.prepare(
+			`SELECT coordinator_id, group_id, last_refresh_at, last_success_at, last_error, updated_at
+			 FROM scope_membership_cache_state
+			 ORDER BY coordinator_id ASC, group_id ASC`,
+		)
+		.all() as ScopeMembershipCacheState[];
+}
+
+function freshness(
+	states: ScopeMembershipCacheState[],
+	options: { now?: Date; maxAgeMs?: number },
+): ScopeMembershipCacheFreshness {
+	if (states.length === 0) return "unknown";
+	if (states.some((state) => clean(state.last_error) != null)) return "stale";
+	const maxAgeMs = options.maxAgeMs ?? DEFAULT_SCOPE_MEMBERSHIP_CACHE_MAX_AGE_MS;
+	const nowMs = (options.now ?? new Date()).getTime();
+	return states.some((state) => {
+		const refreshedAt = Date.parse(state.last_success_at ?? "");
+		return !Number.isFinite(refreshedAt) || nowMs - refreshedAt > maxAgeMs;
+	})
+		? "stale"
+		: "fresh";
+}
+
+function scopeFromJoinedRow(row: JoinedMembershipRow): CoordinatorScope | null {
+	if (!row.scope_label || !row.scope_kind || !row.scope_authority_type) return null;
+	return {
+		scope_id: row.scope_id,
+		label: row.scope_label,
+		kind: row.scope_kind,
+		authority_type: row.scope_authority_type,
+		coordinator_id: row.scope_coordinator_id,
+		group_id: row.scope_group_id,
+		manifest_issuer_device_id: row.scope_manifest_issuer_device_id,
+		membership_epoch: row.scope_membership_epoch ?? row.membership_epoch,
+		manifest_hash: row.scope_manifest_hash,
+		status: row.scope_status ?? "active",
+		created_at: row.scope_created_at ?? row.updated_at,
+		updated_at: row.scope_updated_at ?? row.updated_at,
+	};
+}
+
+function loadScope(
+	db: Database,
+	scopeId: string,
+	authority?: ScopeMembershipCacheAuthority | null,
+): CoordinatorScope | null {
+	const authorityFilter = authority ? " AND coordinator_id = ? AND group_id = ?" : "";
+	const params = authority ? [scopeId, authority.coordinatorId, authority.groupId] : [scopeId];
+	const row = db
+		.prepare(
+			`SELECT scope_id, label, kind, authority_type, coordinator_id, group_id,
+				manifest_issuer_device_id, membership_epoch, manifest_hash, status, created_at, updated_at
+			 FROM replication_scopes
+			 WHERE scope_id = ?${authorityFilter}
+			 LIMIT 1`,
+		)
+		.get(...params) as CoordinatorScope | undefined;
+	return row ?? null;
+}
+
+function membershipFromJoinedRow(row: JoinedMembershipRow): CoordinatorScopeMembership {
+	return {
+		scope_id: row.scope_id,
+		device_id: row.device_id,
+		role: row.role,
+		status: row.status,
+		membership_epoch: row.membership_epoch,
+		coordinator_id: row.coordinator_id,
+		group_id: row.group_id,
+		manifest_issuer_device_id: row.manifest_issuer_device_id,
+		manifest_hash: row.manifest_hash,
+		signed_manifest_json: row.signed_manifest_json,
+		updated_at: row.updated_at,
+	};
+}
+
+function joinedMembershipSelect(whereSql: string): string {
+	return `SELECT
+		sm.scope_id,
+		sm.device_id,
+		sm.role,
+		sm.status,
+		sm.membership_epoch,
+		sm.coordinator_id,
+		sm.group_id,
+		sm.manifest_issuer_device_id,
+		sm.manifest_hash,
+		sm.signed_manifest_json,
+		sm.updated_at,
+		rs.label AS scope_label,
+		rs.kind AS scope_kind,
+		rs.authority_type AS scope_authority_type,
+		rs.coordinator_id AS scope_coordinator_id,
+		rs.group_id AS scope_group_id,
+		rs.manifest_issuer_device_id AS scope_manifest_issuer_device_id,
+		rs.membership_epoch AS scope_membership_epoch,
+		rs.manifest_hash AS scope_manifest_hash,
+		rs.status AS scope_status,
+		rs.created_at AS scope_created_at,
+		rs.updated_at AS scope_updated_at
+	FROM scope_memberships sm
+	LEFT JOIN replication_scopes rs ON rs.scope_id = sm.scope_id
+	${whereSql}`;
+}
+
+function authorityFromMembership(
+	membership: CoordinatorScopeMembership | null,
+	fallback?: ScopeMembershipCacheAuthority | null,
+): ScopeMembershipCacheAuthority | null {
+	const coordinatorId = clean(membership?.coordinator_id) ?? fallback?.coordinatorId;
+	const groupId = clean(membership?.group_id) ?? fallback?.groupId;
+	return coordinatorId && groupId ? { coordinatorId, groupId } : null;
+}
+
+function authorityFromScope(scope: CoordinatorScope | null): ScopeMembershipCacheAuthority | null {
+	const coordinatorId = clean(scope?.coordinator_id);
+	const groupId = clean(scope?.group_id);
+	return coordinatorId && groupId ? { coordinatorId, groupId } : null;
+}
+
+export async function refreshScopeMembershipCache(
+	db: Database,
+	opts: RefreshScopeMembershipCacheOptions,
+): Promise<RefreshScopeMembershipCacheResult> {
+	const groups = groupIds(opts.groupIds);
+	if (groups.length === 0) return { status: "skipped", coordinatorId: null, groups: [] };
+	const coordinatorId = clean(opts.coordinatorId) ?? authorityId(opts.remoteUrl);
+	const authorityForGroup = (groupId: string): ScopeMembershipCacheAuthority => ({
+		coordinatorId,
+		groupId,
+	});
+	const fetchers = opts.fetchers ?? defaultFetchers(opts);
+	const timestamp = nowIso(opts.now);
+	const results: RefreshScopeMembershipCacheGroupResult[] = [];
+
+	for (const groupId of groups) {
+		try {
+			const authority = authorityForGroup(groupId);
+			const scopes = (await fetchers.listScopes(groupId)).map((scope) =>
+				scopeWithAuthority(scope, authority),
+			);
+			const membershipBatches: Array<{
+				scope: CoordinatorScope;
+				memberships: CoordinatorScopeMembership[];
+			}> = [];
+			for (const scope of scopes) {
+				const memberships = (await fetchers.listMemberships(groupId, scope.scope_id)).map(
+					(membership) => membershipWithAuthority(membership, scope, authority),
+				);
+				membershipBatches.push({ scope, memberships });
+			}
+			db.transaction(() => {
+				for (const scope of scopes) upsertScope(db, scope);
+				for (const batch of membershipBatches) {
+					upsertCachedScopeMemberships(db, batch.memberships);
+					reconcileScopeMembershipSnapshot(
+						db,
+						batch.scope,
+						batch.memberships,
+						authority,
+						timestamp,
+					);
+				}
+				reconcileGroupScopeSnapshot(db, authority, scopes, timestamp);
+				recordRefreshState(db, { coordinatorId, groupId, ok: true, now: timestamp });
+			})();
+			const membershipCount = membershipBatches.reduce(
+				(count, batch) => count + batch.memberships.length,
+				0,
+			);
+			results.push({
+				groupId,
+				status: "refreshed",
+				scopeCount: scopes.length,
+				membershipCount,
+				error: null,
+			});
+		} catch (error) {
+			const message = errorMessage(error);
+			recordRefreshState(db, { coordinatorId, groupId, ok: false, error: message, now: timestamp });
+			results.push({ groupId, status: "stale", scopeCount: 0, membershipCount: 0, error: message });
+		}
+	}
+
+	const refreshed = results.filter((result) => result.status === "refreshed").length;
+	const status = refreshed === results.length ? "refreshed" : refreshed === 0 ? "stale" : "partial";
+	return { status, coordinatorId, groups: results };
+}
+
+export async function refreshConfiguredScopeMembershipCache(
+	db: Database,
+	config?: CoordinatorSyncConfig,
+): Promise<RefreshScopeMembershipCacheResult> {
+	const syncConfig = config ?? readCoordinatorSyncConfig();
+	if (!coordinatorEnabled(syncConfig) || !syncConfig.syncCoordinatorAdminSecret) {
+		return { status: "skipped", coordinatorId: null, groups: [] };
+	}
+	return refreshScopeMembershipCache(db, {
+		groupIds: syncConfig.syncCoordinatorGroups,
+		coordinatorId: authorityId(syncConfig.syncCoordinatorUrl),
+		remoteUrl: syncConfig.syncCoordinatorUrl,
+		adminSecret: syncConfig.syncCoordinatorAdminSecret,
+	});
+}
+
+export function listCachedScopesForDevice(
+	db: Database,
+	deviceId: string,
+	opts: ScopeMembershipCacheLookupOptions = {},
+): CachedDeviceScopeMemberships {
+	const cleanDeviceId = clean(deviceId);
+	if (!cleanDeviceId) throw new Error("device_id is required.");
+	ensureScopeMembershipCacheStateTable(db);
+	const params: string[] = [cleanDeviceId];
+	const authorityFilter = opts.authority
+		? " AND COALESCE(sm.coordinator_id, rs.coordinator_id) = ? AND COALESCE(sm.group_id, rs.group_id) = ?"
+		: "";
+	if (opts.authority) params.push(opts.authority.coordinatorId, opts.authority.groupId);
+	const rows = db
+		.prepare(
+			`${joinedMembershipSelect(
+				`WHERE sm.device_id = ? AND sm.status = 'active' AND rs.scope_id IS NOT NULL AND rs.status = 'active'${authorityFilter}`,
+			)} ORDER BY sm.scope_id ASC`,
+		)
+		.all(...params) as JoinedMembershipRow[];
+	const cacheStates = loadCacheStates(db, opts.authority ?? null);
+	return {
+		deviceId: cleanDeviceId,
+		freshness: freshness(cacheStates, opts),
+		memberships: rows.map((row) => ({
+			...membershipFromJoinedRow(row),
+			scope: scopeFromJoinedRow(row),
+		})),
+		cacheStates,
+	};
+}
+
+export function getCachedScopeAuthorization(
+	db: Database,
+	input: { deviceId: string; scopeId: string } & ScopeMembershipCacheLookupOptions,
+): CachedScopeAuthorization {
+	const deviceId = clean(input.deviceId);
+	const scopeId = clean(input.scopeId);
+	if (!deviceId || !scopeId) throw new Error("device_id and scope_id are required.");
+	ensureScopeMembershipCacheStateTable(db);
+	const authorityFilter = input.authority
+		? " AND COALESCE(sm.coordinator_id, rs.coordinator_id) = ? AND COALESCE(sm.group_id, rs.group_id) = ?"
+		: "";
+	const params = input.authority
+		? [deviceId, scopeId, input.authority.coordinatorId, input.authority.groupId]
+		: [deviceId, scopeId];
+	const row = db
+		.prepare(
+			`${joinedMembershipSelect(`WHERE sm.device_id = ? AND sm.scope_id = ?${authorityFilter} LIMIT 1`)}`,
+		)
+		.get(...params) as JoinedMembershipRow | undefined;
+	const membership = row ? membershipFromJoinedRow(row) : null;
+	const scope = row ? scopeFromJoinedRow(row) : loadScope(db, scopeId, input.authority ?? null);
+	const authority = authorityFromMembership(
+		membership,
+		input.authority ?? authorityFromScope(scope),
+	);
+	const cacheStates = loadCacheStates(db, authority);
+	const currentFreshness = freshness(cacheStates, input);
+	if (!membership) {
+		return {
+			deviceId,
+			scopeId,
+			authorized: false,
+			state: "not_authorized",
+			freshness: currentFreshness,
+			membership: null,
+			scope,
+			cacheStates,
+		};
+	}
+	if (membership.status === "revoked") {
+		return {
+			deviceId,
+			scopeId,
+			authorized: false,
+			state: "revoked",
+			freshness: currentFreshness,
+			membership,
+			scope,
+			cacheStates,
+		};
+	}
+	if (scope?.status && scope.status !== "active") {
+		return {
+			deviceId,
+			scopeId,
+			authorized: false,
+			state: "scope_inactive",
+			freshness: currentFreshness,
+			membership,
+			scope,
+			cacheStates,
+		};
+	}
+	if (!scope) {
+		return {
+			deviceId,
+			scopeId,
+			authorized: false,
+			state: "scope_unknown",
+			freshness: currentFreshness,
+			membership,
+			scope: null,
+			cacheStates,
+		};
+	}
+	return {
+		deviceId,
+		scopeId,
+		authorized: membership.status === "active",
+		state: membership.status === "active" ? "authorized" : "not_authorized",
+		freshness: currentFreshness,
+		membership,
+		scope,
+		cacheStates,
+	};
+}

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -23,6 +23,14 @@ vi.mock("./coordinator-runtime.js", () => ({
 	registerCoordinatorPresence: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock("./scope-membership-cache.js", () => ({
+	refreshConfiguredScopeMembershipCache: vi.fn().mockResolvedValue({
+		status: "skipped",
+		coordinatorId: null,
+		groups: [],
+	}),
+}));
+
 // Mock sync-pass to avoid needing real keys/network
 vi.mock("./sync-pass.js", () => ({
 	syncPassPreflight: vi.fn(),
@@ -167,19 +175,23 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 		const { coordinatorEnabled, registerCoordinatorPresence } = await import(
 			"./coordinator-runtime.js"
 		);
+		const { refreshConfiguredScopeMembershipCache } = await import("./scope-membership-cache.js");
 		vi.mocked(coordinatorEnabled).mockReturnValue(false);
 
 		expect(await refreshCoordinatorPresenceForDaemon(db, ":memory:")).toBe(false);
 		expect(registerCoordinatorPresence).not.toHaveBeenCalled();
+		expect(refreshConfiguredScopeMembershipCache).not.toHaveBeenCalled();
 	});
 
-	it("posts coordinator presence with the daemon db and keys context when enabled", async () => {
+	it("posts coordinator presence and refreshes scope membership cache when enabled", async () => {
 		const { coordinatorEnabled, readCoordinatorSyncConfig, registerCoordinatorPresence } =
 			await import("./coordinator-runtime.js");
+		const { refreshConfiguredScopeMembershipCache } = await import("./scope-membership-cache.js");
 		vi.mocked(coordinatorEnabled).mockReturnValue(true);
 		vi.mocked(readCoordinatorSyncConfig).mockReturnValue({
 			syncCoordinatorUrl: "http://coord",
 			syncCoordinatorGroups: ["team"],
+			syncCoordinatorAdminSecret: "secret",
 		} as never);
 
 		expect(await refreshCoordinatorPresenceForDaemon(db, ":memory:", "/tmp/keys")).toBe(true);
@@ -190,6 +202,14 @@ describe("refreshCoordinatorPresenceForDaemon", () => {
 				syncCoordinatorGroups: ["team"],
 			}),
 			{ keysDir: "/tmp/keys" },
+		);
+		expect(refreshConfiguredScopeMembershipCache).toHaveBeenCalledWith(
+			db,
+			expect.objectContaining({
+				syncCoordinatorUrl: "http://coord",
+				syncCoordinatorGroups: ["team"],
+				syncCoordinatorAdminSecret: "secret",
+			}),
 		);
 	});
 

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -18,6 +18,7 @@ import {
 import type { Database } from "./db.js";
 import { connect as connectDb, ensureAdditiveSchemaCompatibility, resolveDbPath } from "./db.js";
 import * as schema from "./schema.js";
+import { refreshConfiguredScopeMembershipCache } from "./scope-membership-cache.js";
 import type { SecretScanner } from "./secret-scanner.js";
 import { advertiseMdns, mdnsEnabled } from "./sync-discovery.js";
 import { ensureDeviceIdentity } from "./sync-identity.js";
@@ -130,6 +131,7 @@ export async function refreshCoordinatorPresenceForDaemon(
 	const config = readCoordinatorSyncConfig();
 	if (!coordinatorEnabled(config)) return false;
 	await registerCoordinatorPresence({ db, dbPath }, config, { keysDir });
+	await refreshConfiguredScopeMembershipCache(db, config);
 	return true;
 }
 


### PR DESCRIPTION
## Description
Adds a local Sharing domain membership cache with deterministic lookup helpers for device/scope authorization and freshness state. The sync daemon refreshes the cache from configured coordinator admin metadata when available, preserves stale cached data during coordinator downtime, and reconciles removed grants/scopes after successful authoritative refreshes.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional targeted validation: `pnpm exec vitest run packages/core/src/scope-membership-cache.test.ts packages/core/src/sync-daemon.test.ts packages/core/src/db.test.ts`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed) — implementation follows the existing Sharing domain design plan; user-facing docs remain for later rollout beads.
- [x] No new warnings introduced