### PR TITLE
feat: add scope membership revocation semantics

### DIFF
--- a/packages/core/src/coordinator-api.test.ts
+++ b/packages/core/src/coordinator-api.test.ts
@@ -1035,6 +1035,21 @@ describe("createCoordinatorApp dependency injection", () => {
 			})),
 			listScopes: vi.fn(async () => [scope]),
 			revokeScopeMembership: vi.fn(async () => true),
+			listScopeMemberships: vi.fn(async () => [
+				{
+					scope_id: "scope-acme",
+					device_id: "device-a",
+					role: "member",
+					status: "revoked",
+					membership_epoch: 5,
+					coordinator_id: "coord-a",
+					group_id: "g1",
+					manifest_issuer_device_id: null,
+					manifest_hash: "hash-revoke",
+					signed_manifest_json: null,
+					updated_at: "2026-03-28T00:00:00Z",
+				},
+			]),
 		});
 		const app = createCoordinatorApp({
 			storeFactory: () => store,
@@ -1059,6 +1074,15 @@ describe("createCoordinatorApp dependency injection", () => {
 			ok: true,
 			scope_id: "scope-acme",
 			device_id: "device-a",
+			revocation: {
+				scope_id: "scope-acme",
+				device_id: "device-a",
+				membership_epoch: 5,
+				prevents_future_sync: true,
+				deletes_already_copied_data: false,
+				message:
+					"Revocation prevents future sync only; it does not remove data already copied to the revoked device.",
+			},
 		});
 		expect(store.revokeScopeMembership).toHaveBeenCalledWith({
 			scopeId: "scope-acme",
@@ -1066,6 +1090,139 @@ describe("createCoordinatorApp dependency injection", () => {
 			membershipEpoch: 5,
 			manifestHash: "hash-revoke",
 			signedManifestJson: null,
+		});
+		expect(store.listScopeMemberships).toHaveBeenCalledWith("scope-acme", true);
+	});
+
+	it("does not fail a persisted revoke when response enrichment cannot reload it", async () => {
+		const scope: CoordinatorScope = {
+			scope_id: "scope-acme",
+			label: "Acme Work",
+			kind: "team",
+			authority_type: "coordinator",
+			coordinator_id: "coord-a",
+			group_id: "g1",
+			manifest_issuer_device_id: null,
+			membership_epoch: 3,
+			manifest_hash: null,
+			status: "active",
+			created_at: "2026-03-28T00:00:00Z",
+			updated_at: "2026-03-28T00:00:00Z",
+		};
+		const store = createMockStore({
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Acme",
+				archived_at: null,
+				created_at: "2026-03-28T00:00:00Z",
+			})),
+			listScopes: vi.fn(async () => [scope]),
+			revokeScopeMembership: vi.fn(async () => true),
+			listScopeMemberships: vi.fn(async () => {
+				throw new Error("temporarily locked");
+			}),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+		});
+
+		const res = await app.request("/v1/admin/groups/g1/scopes/scope-acme/members/device-a/revoke", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-Codemem-Coordinator-Admin": "test-secret",
+			},
+			body: JSON.stringify({ membership_epoch: 5 }),
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({
+			revocation: {
+				membership_epoch: 5,
+				prevents_future_sync: true,
+				deletes_already_copied_data: false,
+			},
+		});
+		expect(store.revokeScopeMembership).toHaveBeenCalledWith({
+			scopeId: "scope-acme",
+			deviceId: "device-a",
+			membershipEpoch: 5,
+			manifestHash: null,
+			signedManifestJson: null,
+		});
+		expect(store.listScopeMemberships).toHaveBeenCalledWith("scope-acme", true);
+	});
+
+	it("reports persisted revoke epoch when request omits membership_epoch", async () => {
+		const scope: CoordinatorScope = {
+			scope_id: "scope-acme",
+			label: "Acme Work",
+			kind: "team",
+			authority_type: "coordinator",
+			coordinator_id: "coord-a",
+			group_id: "g1",
+			manifest_issuer_device_id: null,
+			membership_epoch: 3,
+			manifest_hash: null,
+			status: "active",
+			created_at: "2026-03-28T00:00:00Z",
+			updated_at: "2026-03-28T00:00:00Z",
+		};
+		const store = createMockStore({
+			getGroup: vi.fn(async () => ({
+				group_id: "g1",
+				display_name: "Acme",
+				archived_at: null,
+				created_at: "2026-03-28T00:00:00Z",
+			})),
+			listScopes: vi.fn(async () => [scope]),
+			revokeScopeMembership: vi.fn(async () => true),
+			listScopeMemberships: vi.fn(async () => [
+				{
+					scope_id: "scope-acme",
+					device_id: "device-a",
+					role: "member",
+					status: "revoked",
+					membership_epoch: 4,
+					coordinator_id: "coord-a",
+					group_id: "g1",
+					manifest_issuer_device_id: null,
+					manifest_hash: null,
+					signed_manifest_json: null,
+					updated_at: "2026-03-28T00:00:00Z",
+				},
+			]),
+		});
+		const app = createCoordinatorApp({
+			storeFactory: () => store,
+			runtime: {
+				adminSecret: () => "test-secret",
+				now: () => "2026-03-28T00:00:00Z",
+			},
+			requestVerifier: allowRequest,
+		});
+
+		const res = await app.request("/v1/admin/groups/g1/scopes/scope-acme/members/device-a/revoke", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-Codemem-Coordinator-Admin": "test-secret",
+			},
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({
+			revocation: {
+				membership_epoch: 4,
+				prevents_future_sync: true,
+				deletes_already_copied_data: false,
+			},
 		});
 	});
 });

--- a/packages/core/src/coordinator-api.ts
+++ b/packages/core/src/coordinator-api.ts
@@ -13,12 +13,14 @@ import type {
 	CoordinatorBootstrapGrantVerification,
 	CoordinatorEnrollment,
 	CoordinatorScope,
+	CoordinatorScopeMembership,
 	CoordinatorStore,
 } from "./coordinator-store-contract.js";
 import {
 	createInMemoryRequestRateLimiter,
 	type InMemoryRequestRateLimiter,
 } from "./request-rate-limit.js";
+import { explainScopeMembershipRevocation } from "./scope-membership-semantics.js";
 import { DEFAULT_TIME_WINDOW_S } from "./sync-auth-constants.js";
 import { fingerprintPublicKey } from "./sync-fingerprint.js";
 
@@ -920,7 +922,24 @@ export function createCoordinatorApp(
 				signedManifestJson: optionalString(data, "signed_manifest_json"),
 			});
 			if (!ok) return c.json({ error: "membership_not_found" }, 404);
-			return c.json({ ok: true, scope_id: scopeId, device_id: deviceId });
+			let revokedMembership: CoordinatorScopeMembership | undefined;
+			try {
+				revokedMembership = (await store.listScopeMemberships(scopeId, true)).find(
+					(membership) => membership.device_id === deviceId,
+				);
+			} catch {
+				revokedMembership = undefined;
+			}
+			return c.json({
+				ok: true,
+				scope_id: scopeId,
+				device_id: deviceId,
+				revocation: explainScopeMembershipRevocation({
+					scopeId,
+					deviceId,
+					membershipEpoch: revokedMembership?.membership_epoch ?? membershipEpoch,
+				}),
+			});
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
 		} finally {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -423,6 +423,15 @@ export {
 	upsertCachedScopeMemberships,
 } from "./scope-membership-cache.js";
 export type {
+	ScopeMembershipEpochStatus,
+	ScopeMembershipRevocationNotice,
+} from "./scope-membership-semantics.js";
+export {
+	explainScopeMembershipRevocation,
+	SCOPE_MEMBERSHIP_REVOCATION_LIMITATION,
+	scopeMembershipEpochStatus,
+} from "./scope-membership-semantics.js";
+export type {
 	CanonicalWorkspaceIdentity,
 	ResolveProjectScopeInput,
 	ScopeMapping,

--- a/packages/core/src/scope-membership-cache.test.ts
+++ b/packages/core/src/scope-membership-cache.test.ts
@@ -331,6 +331,81 @@ describe("scope membership cache", () => {
 		});
 	});
 
+	it("allows regrant only when the membership epoch advances", async () => {
+		const local = setup();
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async () => [scope({ membership_epoch: 9 })],
+				listMemberships: async () => [membership({ membership_epoch: 8, status: "revoked" })],
+			},
+		});
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now(1)),
+			fetchers: {
+				listScopes: async () => [scope({ membership_epoch: 9 })],
+				listMemberships: async () => [membership({ membership_epoch: 9, status: "active" })],
+			},
+		});
+
+		expect(
+			getCachedScopeAuthorization(local, {
+				deviceId: "device-a",
+				scopeId: "scope-acme",
+				now: new Date(now(2)),
+			}),
+		).toMatchObject({ authorized: true, state: "authorized" });
+	});
+
+	it("detects stale membership epochs without listing the scope as authorized", async () => {
+		const local = setup();
+		await refreshScopeMembershipCache(local, {
+			groupIds: ["team-a"],
+			coordinatorId: "coord-a",
+			now: new Date(now()),
+			fetchers: {
+				listScopes: async () => [scope({ membership_epoch: 5 })],
+				listMemberships: async () => [membership({ membership_epoch: 3 })],
+			},
+		});
+
+		expect(
+			getCachedScopeAuthorization(local, {
+				deviceId: "device-a",
+				scopeId: "scope-acme",
+			}),
+		).toMatchObject({
+			authorized: false,
+			state: "stale_epoch",
+			epoch: { membership_epoch: 3, required_epoch: 5, stale: true },
+		});
+		expect(listCachedScopesForDevice(local, "device-a").memberships).toEqual([]);
+	});
+
+	it("includes revocation limitation payloads for revoked memberships", () => {
+		const local = setup();
+		upsertCachedScopeMemberships(local, [membership({ membership_epoch: 8, status: "revoked" })]);
+
+		const authorization = getCachedScopeAuthorization(local, {
+			deviceId: "device-a",
+			scopeId: "scope-acme",
+		});
+
+		expect(authorization.revocation).toEqual({
+			scope_id: "scope-acme",
+			device_id: "device-a",
+			membership_epoch: 8,
+			prevents_future_sync: true,
+			deletes_already_copied_data: false,
+			message:
+				"Revocation prevents future sync only; it does not remove data already copied to the revoked device.",
+		});
+	});
+
 	it("does not authorize active memberships when scope metadata is missing", () => {
 		const local = setup();
 		upsertCachedScopeMemberships(local, [membership()]);

--- a/packages/core/src/scope-membership-cache.ts
+++ b/packages/core/src/scope-membership-cache.ts
@@ -9,6 +9,12 @@ import {
 } from "./coordinator-runtime.js";
 import type { CoordinatorScope, CoordinatorScopeMembership } from "./coordinator-store-contract.js";
 import type { Database } from "./db.js";
+import {
+	explainScopeMembershipRevocation,
+	type ScopeMembershipEpochStatus,
+	type ScopeMembershipRevocationNotice,
+	scopeMembershipEpochStatus,
+} from "./scope-membership-semantics.js";
 import { buildBaseUrl } from "./sync-http-client.js";
 
 export const DEFAULT_SCOPE_MEMBERSHIP_CACHE_MAX_AGE_MS = 60_000;
@@ -19,6 +25,7 @@ export type ScopeMembershipAuthorizationState =
 	| "authorized"
 	| "not_authorized"
 	| "revoked"
+	| "stale_epoch"
 	| "scope_unknown"
 	| "scope_inactive";
 
@@ -51,6 +58,8 @@ export interface CachedScopeAuthorization {
 	authorized: boolean;
 	state: ScopeMembershipAuthorizationState;
 	freshness: ScopeMembershipCacheFreshness;
+	epoch: ScopeMembershipEpochStatus;
+	revocation: ScopeMembershipRevocationNotice | null;
 	membership: CoordinatorScopeMembership | null;
 	scope: CoordinatorScope | null;
 	cacheStates: ScopeMembershipCacheState[];
@@ -617,7 +626,7 @@ export function listCachedScopesForDevice(
 	const rows = db
 		.prepare(
 			`${joinedMembershipSelect(
-				`WHERE sm.device_id = ? AND sm.status = 'active' AND rs.scope_id IS NOT NULL AND rs.status = 'active'${authorityFilter}`,
+				`WHERE sm.device_id = ? AND sm.status = 'active' AND rs.scope_id IS NOT NULL AND rs.status = 'active' AND sm.membership_epoch >= rs.membership_epoch${authorityFilter}`,
 			)} ORDER BY sm.scope_id ASC`,
 		)
 		.all(...params) as JoinedMembershipRow[];
@@ -660,6 +669,10 @@ export function getCachedScopeAuthorization(
 	);
 	const cacheStates = loadCacheStates(db, authority);
 	const currentFreshness = freshness(cacheStates, input);
+	const epoch = scopeMembershipEpochStatus({
+		membershipEpoch: membership?.membership_epoch ?? null,
+		requiredEpoch: scope?.membership_epoch ?? null,
+	});
 	if (!membership) {
 		return {
 			deviceId,
@@ -667,6 +680,8 @@ export function getCachedScopeAuthorization(
 			authorized: false,
 			state: "not_authorized",
 			freshness: currentFreshness,
+			epoch,
+			revocation: null,
 			membership: null,
 			scope,
 			cacheStates,
@@ -679,6 +694,12 @@ export function getCachedScopeAuthorization(
 			authorized: false,
 			state: "revoked",
 			freshness: currentFreshness,
+			epoch,
+			revocation: explainScopeMembershipRevocation({
+				scopeId,
+				deviceId,
+				membershipEpoch: membership.membership_epoch,
+			}),
 			membership,
 			scope,
 			cacheStates,
@@ -691,6 +712,8 @@ export function getCachedScopeAuthorization(
 			authorized: false,
 			state: "scope_inactive",
 			freshness: currentFreshness,
+			epoch,
+			revocation: null,
 			membership,
 			scope,
 			cacheStates,
@@ -703,8 +726,24 @@ export function getCachedScopeAuthorization(
 			authorized: false,
 			state: "scope_unknown",
 			freshness: currentFreshness,
+			epoch,
+			revocation: null,
 			membership,
 			scope: null,
+			cacheStates,
+		};
+	}
+	if (epoch.stale) {
+		return {
+			deviceId,
+			scopeId,
+			authorized: false,
+			state: "stale_epoch",
+			freshness: currentFreshness,
+			epoch,
+			revocation: null,
+			membership,
+			scope,
 			cacheStates,
 		};
 	}
@@ -714,6 +753,8 @@ export function getCachedScopeAuthorization(
 		authorized: membership.status === "active",
 		state: membership.status === "active" ? "authorized" : "not_authorized",
 		freshness: currentFreshness,
+		epoch,
+		revocation: null,
 		membership,
 		scope,
 		cacheStates,

--- a/packages/core/src/scope-membership-semantics.test.ts
+++ b/packages/core/src/scope-membership-semantics.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+	explainScopeMembershipRevocation,
+	scopeMembershipEpochStatus,
+} from "./scope-membership-semantics.js";
+
+describe("scope membership semantics", () => {
+	it("classifies stale, current, and unknown membership epochs", () => {
+		expect(scopeMembershipEpochStatus({ membershipEpoch: 2, requiredEpoch: 3 })).toEqual({
+			membership_epoch: 2,
+			required_epoch: 3,
+			stale: true,
+			reason: "stale_epoch",
+		});
+		expect(scopeMembershipEpochStatus({ membershipEpoch: 3, requiredEpoch: 3 })).toEqual({
+			membership_epoch: 3,
+			required_epoch: 3,
+			stale: false,
+			reason: "current",
+		});
+		expect(scopeMembershipEpochStatus({ membershipEpoch: null, requiredEpoch: 3 })).toEqual({
+			membership_epoch: null,
+			required_epoch: 3,
+			stale: false,
+			reason: "unknown_epoch",
+		});
+	});
+
+	it("explains revocation limits without promising remote deletion", () => {
+		expect(
+			explainScopeMembershipRevocation({
+				scopeId: "scope-acme",
+				deviceId: "device-a",
+				membershipEpoch: 4,
+			}),
+		).toEqual({
+			scope_id: "scope-acme",
+			device_id: "device-a",
+			membership_epoch: 4,
+			prevents_future_sync: true,
+			deletes_already_copied_data: false,
+			message:
+				"Revocation prevents future sync only; it does not remove data already copied to the revoked device.",
+		});
+	});
+});

--- a/packages/core/src/scope-membership-semantics.ts
+++ b/packages/core/src/scope-membership-semantics.ts
@@ -1,0 +1,57 @@
+export const SCOPE_MEMBERSHIP_REVOCATION_LIMITATION =
+	"Revocation prevents future sync only; it does not remove data already copied to the revoked device.";
+
+export interface ScopeMembershipRevocationNotice {
+	scope_id: string;
+	device_id: string;
+	membership_epoch: number | null;
+	prevents_future_sync: true;
+	deletes_already_copied_data: false;
+	message: string;
+}
+
+export interface ScopeMembershipEpochStatus {
+	membership_epoch: number | null;
+	required_epoch: number | null;
+	stale: boolean;
+	reason: "current" | "stale_epoch" | "unknown_epoch";
+}
+
+export function scopeMembershipEpochStatus(input: {
+	membershipEpoch?: number | null;
+	requiredEpoch?: number | null;
+}): ScopeMembershipEpochStatus {
+	const membershipEpoch = Number.isFinite(input.membershipEpoch)
+		? Number(input.membershipEpoch)
+		: null;
+	const requiredEpoch = Number.isFinite(input.requiredEpoch) ? Number(input.requiredEpoch) : null;
+	if (membershipEpoch == null || requiredEpoch == null) {
+		return {
+			membership_epoch: membershipEpoch,
+			required_epoch: requiredEpoch,
+			stale: false,
+			reason: "unknown_epoch",
+		};
+	}
+	return {
+		membership_epoch: membershipEpoch,
+		required_epoch: requiredEpoch,
+		stale: membershipEpoch < requiredEpoch,
+		reason: membershipEpoch < requiredEpoch ? "stale_epoch" : "current",
+	};
+}
+
+export function explainScopeMembershipRevocation(input: {
+	scopeId: string;
+	deviceId: string;
+	membershipEpoch?: number | null;
+}): ScopeMembershipRevocationNotice {
+	return {
+		scope_id: input.scopeId,
+		device_id: input.deviceId,
+		membership_epoch: Number.isFinite(input.membershipEpoch) ? Number(input.membershipEpoch) : null,
+		prevents_future_sync: true,
+		deletes_already_copied_data: false,
+		message: SCOPE_MEMBERSHIP_REVOCATION_LIMITATION,
+	};
+}


### PR DESCRIPTION
## Description
Adds shared membership epoch/revocation semantics, stale-epoch detection in the local cache, and revocation limitation payloads for coordinator admin responses. Revoked/stale memberships are excluded from authorized cache lookups while regrant requires an advanced epoch.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional targeted validation: `pnpm exec vitest run packages/core/src/scope-membership-semantics.test.ts packages/core/src/scope-membership-cache.test.ts packages/core/src/coordinator-api.test.ts packages/core/src/sync-daemon.test.ts packages/core/src/db.test.ts`.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed) — this follows the existing Sharing domain design; broader user docs remain for rollout/docs beads.
- [x] No new warnings introduced