### PR TITLE
test: cover coordinator scope membership contracts

### DIFF
--- a/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
+++ b/packages/cloudflare-coordinator-worker/test/worker.integration.test.ts
@@ -210,6 +210,7 @@ describe("workers vitest + local D1 validation", () => {
 			.run();
 
 		const device = createIdentity();
+		const observer = createIdentity();
 		const adminHeaders = {
 			"content-type": "application/json",
 			"X-Codemem-Coordinator-Admin": "test-secret",
@@ -227,6 +228,18 @@ describe("workers vitest + local D1 validation", () => {
 			}),
 		});
 		expect(enrollRes.status).toBe(200);
+		const enrollObserverRes = await exports.default.fetch("https://example.com/v1/admin/devices", {
+			method: "POST",
+			headers: adminHeaders,
+			body: JSON.stringify({
+				group_id: "g1",
+				device_id: observer.deviceId,
+				fingerprint: observer.fingerprint,
+				public_key: observer.publicKey,
+				display_name: "Observer Device",
+			}),
+		});
+		expect(enrollObserverRes.status).toBe(200);
 
 		const createScopeRes = await exports.default.fetch(
 			"https://example.com/v1/admin/groups/g1/scopes",
@@ -326,6 +339,54 @@ describe("workers vitest + local D1 validation", () => {
 			scope_id: "scope-a",
 			device_id: device.deviceId,
 		});
+
+		const revokedDevicePresenceBody = JSON.stringify({
+			group_id: "g1",
+			fingerprint: device.fingerprint,
+			addresses: ["http://10.0.0.7:7337"],
+			ttl_s: 180,
+		});
+		const revokedDevicePresenceRes = await exports.default.fetch("https://example.com/v1/presence", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				...signHeaders(
+					device,
+					"POST",
+					"https://example.com/v1/presence",
+					revokedDevicePresenceBody,
+				),
+			},
+			body: revokedDevicePresenceBody,
+		});
+		expect(revokedDevicePresenceRes.status).toBe(200);
+
+		const peersAfterRevokeRes = await exports.default.fetch(
+			"https://example.com/v1/peers?group_id=g1",
+			{
+				method: "GET",
+				headers: signHeaders(observer, "GET", "https://example.com/v1/peers?group_id=g1", ""),
+			},
+		);
+		expect(peersAfterRevokeRes.status).toBe(200);
+		const peersAfterRevokeJson = (await peersAfterRevokeRes.json()) as {
+			items: CoordinatorPeerRecord[];
+		};
+		expect(peersAfterRevokeJson.items).toEqual([
+			expect.objectContaining({
+				device_id: device.deviceId,
+				fingerprint: device.fingerprint,
+				stale: false,
+				addresses: ["http://10.0.0.7:7337"],
+			}),
+		]);
+
+		const activeMembersAfterRevokeRes = await exports.default.fetch(
+			"https://example.com/v1/admin/groups/g1/scopes/scope-a/members",
+			{ headers: { "X-Codemem-Coordinator-Admin": "test-secret" } },
+		);
+		expect(activeMembersAfterRevokeRes.status).toBe(200);
+		expect(await activeMembersAfterRevokeRes.json()).toMatchObject({ items: [] });
 
 		const revokedMembersRes = await exports.default.fetch(
 			"https://example.com/v1/admin/groups/g1/scopes/scope-a/members?include_revoked=1",

--- a/packages/core/src/coordinator-store-test-harness.ts
+++ b/packages/core/src/coordinator-store-test-harness.ts
@@ -202,6 +202,14 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 							groupId: "shared-group",
 						}),
 					).rejects.toThrow("membership coordinatorId must match the scope coordinatorId");
+					await expect(
+						store.grantScopeMembership({
+							scopeId: "scope-acme",
+							deviceId: "device-a",
+							coordinatorId: "coord-a",
+							groupId: "other-group",
+						}),
+					).rejects.toThrow("membership groupId must match the scope groupId");
 					expect(await store.listScopeMemberships("scope-acme")).toEqual([]);
 				});
 			});
@@ -379,6 +387,97 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 							membershipEpoch: 8,
 						}),
 					).rejects.toThrow("membershipEpoch must not move backwards");
+				});
+			});
+
+			it("keeps grants and revocations isolated per scope", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("group-a");
+					await store.enrollDevice("group-a", {
+						deviceId: "device-a",
+						fingerprint: "fp-a",
+						publicKey: "pk-a",
+					});
+					await store.createScope({
+						scopeId: "scope-acme",
+						label: "Acme Work",
+						groupId: "group-a",
+						membershipEpoch: 2,
+					});
+					await store.createScope({
+						scopeId: "scope-oss",
+						label: "OSS codemem",
+						groupId: "group-a",
+						membershipEpoch: 2,
+					});
+
+					await store.grantScopeMembership({ scopeId: "scope-acme", deviceId: "device-a" });
+					await store.grantScopeMembership({ scopeId: "scope-oss", deviceId: "device-a" });
+					expect(
+						await store.revokeScopeMembership({
+							scopeId: "scope-acme",
+							deviceId: "device-a",
+							membershipEpoch: 3,
+						}),
+					).toBe(true);
+
+					expect(await store.listScopeMemberships("scope-acme")).toEqual([]);
+					expect(await store.listScopeMemberships("scope-acme", true)).toEqual([
+						expect.objectContaining({
+							device_id: "device-a",
+							status: "revoked",
+							membership_epoch: 3,
+						}),
+					]);
+					expect(await store.listScopeMemberships("scope-oss")).toEqual([
+						expect.objectContaining({
+							device_id: "device-a",
+							status: "active",
+							membership_epoch: 2,
+						}),
+					]);
+				});
+			});
+
+			it("keeps group presence independent from scope revocation", async () => {
+				await withContext(async ({ store }) => {
+					await store.createGroup("group-a");
+					await store.enrollDevice("group-a", {
+						deviceId: "device-a",
+						fingerprint: "fp-a",
+						publicKey: "pk-a",
+					});
+					await store.enrollDevice("group-a", {
+						deviceId: "device-b",
+						fingerprint: "fp-b",
+						publicKey: "pk-b",
+					});
+					await store.createScope({
+						scopeId: "scope-acme",
+						label: "Acme Work",
+						groupId: "group-a",
+					});
+					await store.grantScopeMembership({ scopeId: "scope-acme", deviceId: "device-b" });
+					await store.upsertPresence({
+						groupId: "group-a",
+						deviceId: "device-b",
+						addresses: ["http://10.0.0.5:7337"],
+						ttlS: 300,
+					});
+
+					expect(
+						await store.revokeScopeMembership({ scopeId: "scope-acme", deviceId: "device-b" }),
+					).toBe(true);
+
+					expect(await store.listScopeMemberships("scope-acme")).toEqual([]);
+					expect(await store.listGroupPeers("group-a", "device-a")).toEqual([
+						expect.objectContaining({
+							device_id: "device-b",
+							fingerprint: "fp-b",
+							stale: false,
+							addresses: ["http://10.0.0.5:7337"],
+						}),
+					]);
 				});
 			});
 		});
@@ -912,6 +1011,14 @@ export function runCoordinatorStoreContract<TStore extends CoordinatorStore>(
 				await withContext(async ({ store }) => {
 					expect(await store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:00Z")).toBe(true);
 					expect(await store.recordNonce("d1", "nonce-1", "2026-03-28T00:00:01Z")).toBe(false);
+				});
+			});
+
+			it("scopes nonce replay checks by device", async () => {
+				await withContext(async ({ store }) => {
+					expect(await store.recordNonce("d1", "shared-nonce", "2026-03-28T00:00:00Z")).toBe(true);
+					expect(await store.recordNonce("d2", "shared-nonce", "2026-03-28T00:00:00Z")).toBe(true);
+					expect(await store.recordNonce("d1", "shared-nonce", "2026-03-28T00:00:01Z")).toBe(false);
 				});
 			});
 


### PR DESCRIPTION
## Description
Adds cross-runtime coordinator Sharing domain contract coverage so scope membership behavior stays consistent across SQLite, D1, and the Cloudflare worker route surface.

This locks group-vs-scope separation, per-scope revoke isolation, active-vs-revoked membership listing, group presence independence, and per-device nonce replay behavior.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional targeted checks:
- `pnpm exec vitest run packages/core/src/coordinator-store.test.ts packages/core/src/d1-coordinator-store.test.ts`
- `pnpm exec vitest run packages/core/src/coordinator-api.test.ts`
- `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced