### PR TITLE
feat: add scope reassignment tombstones

### DIFF
--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -6,6 +6,7 @@ import { connect, tableExists } from "./db.js";
 import { buildFilterClauses, buildFilterClausesWithContext } from "./filters.js";
 import { MemoryStore } from "./store.js";
 import { setSyncDaemonPhase } from "./sync-daemon.js";
+import { loadReplicationOpsSince } from "./sync-replication.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import * as vectors from "./vectors.js";
 
@@ -277,6 +278,76 @@ describe("MemoryStore", () => {
 				.get(memory.import_key) as { scope_id: string | null; payload_json: string };
 			expect(op.scope_id).toBe("acme-work");
 			expect(JSON.parse(op.payload_json).scope_id).toBe("acme-work");
+		});
+
+		it("reassigns memory scope with an old-scope tombstone and new-scope upsert", () => {
+			const sessionId = insertTestSession(store.db);
+			store.db
+				.prepare(
+					`INSERT INTO replication_scopes(
+						scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+					 ) VALUES (?, ?, 'team', 'local', 0, 'active', ?, ?)`,
+				)
+				.run("acme-work", "Acme Work", "2026-05-01T00:00:00Z", "2026-05-01T00:00:00Z");
+
+			const memId = store.remember(sessionId, "feature", "Scoped reassignment", "Feature body");
+			const before = store.db
+				.prepare("SELECT import_key, scope_id, rev FROM memory_items WHERE id = ?")
+				.get(memId) as { import_key: string; scope_id: string | null; rev: number };
+			expect(before.scope_id).toBe("local-default");
+
+			const updated = store.reassignMemoryScope(memId, "acme-work");
+
+			expect(updated.scope_id).toBe("acme-work");
+			expect(updated.rev).toBe(before.rev + 2);
+			expect(updated.metadata_json).toMatchObject({
+				last_scope_reassignment: {
+					old_scope_id: "local-default",
+					new_scope_id: "acme-work",
+				},
+			});
+			const ops = store.db
+				.prepare(`SELECT op_id, op_type, clock_rev, scope_id, payload_json, created_at
+					 FROM replication_ops
+					 WHERE entity_id = ?
+					 ORDER BY clock_rev ASC, op_type ASC`)
+				.all(before.import_key) as Array<{
+				op_id: string;
+				op_type: string;
+				clock_rev: number;
+				scope_id: string | null;
+				payload_json: string | null;
+				created_at: string;
+			}>;
+
+			expect(ops).toHaveLength(3);
+			expect(ops[0]).toEqual(
+				expect.objectContaining({ op_type: "upsert", clock_rev: 1, scope_id: "local-default" }),
+			);
+			expect(ops[1]).toEqual(
+				expect.objectContaining({ op_type: "delete", clock_rev: 2, scope_id: "local-default" }),
+			);
+			expect(ops[1]?.payload_json).toBeNull();
+			expect(ops[2]).toEqual(
+				expect.objectContaining({ op_type: "upsert", clock_rev: 3, scope_id: "acme-work" }),
+			);
+			expect(JSON.parse(ops[2]?.payload_json ?? "{}").scope_id).toBe("acme-work");
+
+			const reassignmentStreamOps = ops
+				.filter((op) => op.clock_rev > before.rev)
+				.sort((a, b) => a.created_at.localeCompare(b.created_at) || a.op_id.localeCompare(b.op_id));
+			expect(reassignmentStreamOps).toHaveLength(2);
+			expect(reassignmentStreamOps.map((op) => op.op_type)).toEqual(["delete", "upsert"]);
+			const [deleteStreamOp, upsertStreamOp] = reassignmentStreamOps;
+			if (!deleteStreamOp || !upsertStreamOp) throw new Error("expected reassignment pair");
+			expect(deleteStreamOp.created_at).toBe(upsertStreamOp.created_at);
+			expect(deleteStreamOp.op_id < upsertStreamOp.op_id).toBe(true);
+			const [sameTimestampOps] = loadReplicationOpsSince(
+				store.db,
+				`${deleteStreamOp.created_at}|zzzzzzzz`,
+				10,
+			);
+			expect(sameTimestampOps.map((op) => op.op_type)).toEqual(["delete", "upsert"]);
 		});
 
 		it("generates an import_key when not provided", () => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -41,7 +41,7 @@ import { populateMemoryRefs } from "./ref-populate.js";
 import type { RefQueryOptions, RefQueryResult } from "./ref-queries.js";
 import { findByConcept as findByConceptFn, findByFile as findByFileFn } from "./ref-queries.js";
 import * as schema from "./schema.js";
-import { resolveSessionScopeId } from "./scope-stamping.js";
+import { ensureMemoryScopeId, resolveSessionScopeId } from "./scope-stamping.js";
 import {
 	type ExplainOptions,
 	explain as explainFn,
@@ -1154,6 +1154,110 @@ export class MemoryStore {
 				if (!updated) {
 					throw new Error("memory not found after update");
 				}
+				return updated;
+			})
+			.immediate();
+	}
+
+	// reassignMemoryScope
+
+	/**
+	 * Move an active, locally owned memory to another Sharing domain.
+	 *
+	 * Scope assignment is effectively immutable once a memory may have replicated,
+	 * so this is not a bare `scope_id` update. The transaction emits an old-scope
+	 * delete/tombstone op followed by a new-scope upsert op with a newer Lamport
+	 * revision. Old-scope recipients learn to stop syncing the memory, while
+	 * already-copied data on those devices may still remain outside this store.
+	 */
+	reassignMemoryScope(memoryId: number, newScopeId: string): MemoryItemResponse {
+		const cleanedScopeId = newScopeId.trim();
+		if (!cleanedScopeId) throw new Error("scope_id must be a non-empty string");
+
+		return this.db
+			.transaction(() => {
+				const row = this.d
+					.select()
+					.from(schema.memoryItems)
+					.where(and(eq(schema.memoryItems.id, memoryId), eq(schema.memoryItems.active, 1)))
+					.get() as MemoryItem | undefined;
+				if (!row) throw new Error("memory not found");
+				if (!this.memoryOwnedBySelf(row)) throw new Error("memory not owned by this device");
+
+				const targetScope = this.d
+					.select({ scope_id: schema.replicationScopes.scope_id })
+					.from(schema.replicationScopes)
+					.where(
+						and(
+							eq(schema.replicationScopes.scope_id, cleanedScopeId),
+							eq(schema.replicationScopes.status, "active"),
+						),
+					)
+					.get();
+				if (!targetScope) throw new Error(`scope not found or inactive: ${cleanedScopeId}`);
+
+				const oldScopeId = ensureMemoryScopeId(this.db, memoryId);
+				if (!oldScopeId) throw new Error("memory scope could not be resolved");
+				if (oldScopeId === cleanedScopeId) {
+					const current = this.get(memoryId);
+					if (!current) throw new Error("memory not found after scope check");
+					return current;
+				}
+
+				// Block shared-memory scope moves while sync requires attention.
+				this.assertSharedMutationAllowed(row.visibility);
+
+				const now = nowIso();
+				const reassignmentOpPrefix = `~scope-reassign:${randomUUID()}`;
+				const oldRev = row.rev ?? 0;
+				const tombstoneRev = oldRev + 1;
+				const upsertRev = oldRev + 2;
+				const meta = fromJson(row.metadata_json);
+				meta.clock_device_id = this.deviceId;
+				meta.last_scope_reassignment = {
+					old_scope_id: oldScopeId,
+					new_scope_id: cleanedScopeId,
+					reassigned_at: now,
+					warning:
+						"Already-copied data may remain on devices that previously received the old scope.",
+				};
+
+				this.d
+					.update(schema.memoryItems)
+					.set({
+						scope_id: cleanedScopeId,
+						updated_at: now,
+						metadata_json: toJson(meta),
+						rev: upsertRev,
+					})
+					.where(eq(schema.memoryItems.id, memoryId))
+					.run();
+
+				recordReplicationOp(this.db, {
+					memoryId,
+					opType: "delete",
+					deviceId: this.deviceId,
+					scopeId: oldScopeId,
+					clockRev: tombstoneRev,
+					clockUpdatedAt: now,
+					clockDeviceId: this.deviceId,
+					createdAt: now,
+					opId: `${reassignmentOpPrefix}:0-delete`,
+				});
+				recordReplicationOp(this.db, {
+					memoryId,
+					opType: "upsert",
+					deviceId: this.deviceId,
+					scopeId: cleanedScopeId,
+					clockRev: upsertRev,
+					clockUpdatedAt: now,
+					clockDeviceId: this.deviceId,
+					createdAt: now,
+					opId: `${reassignmentOpPrefix}:1-upsert`,
+				});
+
+				const updated = this.get(memoryId);
+				if (!updated) throw new Error("memory not found after scope reassignment");
 				return updated;
 			})
 			.immediate();

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -1991,6 +1991,60 @@ describe("applyReplicationOps", () => {
 		expect(recordedOp.scope_id).toBe("acme-work");
 	});
 
+	it("uses inbound delete clock device metadata for later Lamport tie-breaks", () => {
+		const sessionId = insertTestSession(db);
+		db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, created_at, updated_at, import_key, rev, active, metadata_json, scope_id
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Local old title",
+			"Local old body",
+			"2026-01-01T00:00:00Z",
+			"2026-01-01T00:00:00Z",
+			"key:test-1",
+			1,
+			1,
+			toJson({ clock_device_id: "a-local" }),
+			"local-default",
+		);
+
+		const deleteOp = makeReplicationOp({
+			op_id: "delete-lamport-op",
+			op_type: "delete",
+			payload_json: null,
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			clock_device_id: "z-delete-device",
+		});
+		const staleTieUpsert = makeReplicationOp({
+			op_id: "stale-tie-upsert-op",
+			clock_rev: 2,
+			clock_updated_at: "2026-01-02T00:00:00Z",
+			clock_device_id: "m-upsert-device",
+			payload_json: toJson({
+				kind: "discovery",
+				title: "Should not resurrect",
+				body_text: "Remote body",
+				active: 1,
+			}),
+		});
+
+		const deleteResult = applyReplicationOps(db, [deleteOp], "dev-local");
+		const tieResult = applyReplicationOps(db, [staleTieUpsert], "dev-local");
+
+		expect(deleteResult.applied).toBe(1);
+		expect(tieResult.conflicts).toBe(1);
+		const mem = db
+			.prepare("SELECT title, active, metadata_json FROM memory_items WHERE import_key = ?")
+			.get(deleteOp.entity_id) as { title: string; active: number; metadata_json: string };
+		expect(mem.title).toBe("Local old title");
+		expect(mem.active).toBe(0);
+		expect(JSON.parse(mem.metadata_json).clock_device_id).toBe("z-delete-device");
+	});
+
 	it("populates ref tables when inserting a new memory with files and concepts", () => {
 		const op = makeReplicationOp({
 			payload_json: toJson({

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -552,11 +552,17 @@ export function recordReplicationOp(
 		opType: "upsert" | "delete";
 		deviceId: string;
 		payload?: Record<string, unknown>;
+		scopeId?: string | null;
+		clockRev?: number;
+		clockUpdatedAt?: string;
+		clockDeviceId?: string;
+		createdAt?: string;
+		opId?: string;
 	},
 ): string {
 	const d = drizzle(db, { schema });
-	const opId = randomUUID();
-	const now = new Date().toISOString();
+	const opId = opts.opId ?? randomUUID();
+	const now = opts.createdAt ?? new Date().toISOString();
 
 	// Read the full memory row — typed via Drizzle schema
 	const row = d
@@ -565,17 +571,20 @@ export function recordReplicationOp(
 		.where(eq(schema.memoryItems.id, opts.memoryId))
 		.get();
 
-	const rev = Number(row?.rev ?? 0);
-	const updatedAt = row?.updated_at ?? now;
+	const rev = opts.clockRev ?? Number(row?.rev ?? 0);
+	const updatedAt = opts.clockUpdatedAt ?? row?.updated_at ?? now;
 	const entityId = row?.import_key ?? String(opts.memoryId);
 	const metadata = fromJson(row?.metadata_json);
 	// Backfill missing memory scope before emitting an op so storage, op row,
 	// and payload all carry the same authoritative local scope.
-	const scopeId = row ? ensureMemoryScopeId(db, opts.memoryId) : null;
+	const scopeId =
+		opts.scopeId !== undefined ? opts.scopeId : row ? ensureMemoryScopeId(db, opts.memoryId) : null;
 	const clockDeviceId =
-		typeof metadata.clock_device_id === "string" && metadata.clock_device_id.trim().length > 0
-			? metadata.clock_device_id
-			: opts.deviceId;
+		typeof opts.clockDeviceId === "string" && opts.clockDeviceId.trim().length > 0
+			? opts.clockDeviceId.trim()
+			: typeof metadata.clock_device_id === "string" && metadata.clock_device_id.trim().length > 0
+				? metadata.clock_device_id
+				: opts.deviceId;
 
 	// Resolve session project so peers can reconstruct the project association.
 	const sessionProject = row?.session_id
@@ -2018,12 +2027,15 @@ export function applyReplicationOps(
 							continue;
 						}
 						const now = new Date().toISOString();
+						const deleteMetadata = fromJson(existingForDelete.metadata_json);
+						deleteMetadata.clock_device_id = op.clock_device_id;
 						d.update(schema.memoryItems)
 							.set({
 								active: 0,
 								deleted_at: sql`COALESCE(${schema.memoryItems.deleted_at}, ${now})`,
 								rev: op.clock_rev,
 								updated_at: op.clock_updated_at,
+								metadata_json: toJson(deleteMetadata),
 								scope_id: sql`COALESCE(${opScopeId}, ${schema.memoryItems.scope_id})`,
 							})
 							.where(eq(schema.memoryItems.id, existingForDelete.id))


### PR DESCRIPTION
## Description
Adds `MemoryStore.reassignMemoryScope()` so moving a memory between Sharing domains emits an old-scope tombstone plus a new-scope upsert instead of mutating scope silently. Also pins deterministic paired-op stream ordering and preserves inbound delete clock-device metadata for correct Lamport tie-breaks.

This remains Phase 1 scope metadata behavior: no generic sync/retrieval scope enforcement is introduced.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran:
- `pnpm exec vitest run packages/core/src/store.test.ts packages/core/src/sync-replication.test.ts`
- `pnpm run tsc`
- `pnpm run lint`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced