### PR TITLE
feat: define scope-aware sync protocol contract

### DIFF
--- a/docs/plans/2026-04-30-sharing-domain-scope-design.md
+++ b/docs/plans/2026-04-30-sharing-domain-scope-design.md
@@ -452,6 +452,19 @@ Snapshot bootstrap should also be scope-aware. A peer joining `acme-work` should
 
 Snapshot generations, baselines, and retained floors should be tracked per scope so pruning or resetting one sharing domain does not force unrelated domains to resync.
 
+### Compatibility contract locked by `codemem-ov4g.4.1`
+
+Until per-scope cursors and scope-limited snapshots land, the wire protocol reserves `scope_id` without serving scoped data from the legacy singleton stream:
+
+- Omitted `scope_id` means legacy compatibility mode. The peer uses the current singleton reset boundary and existing visibility/project filters. Responses include `scope_id: null` so aware peers can distinguish this from a scoped stream.
+- `GET /v1/ops` uses `scope_id` as a query parameter.
+- `POST /v1/ops` may carry `scope_id` in the JSON body alongside `ops`.
+- `GET /v1/snapshot` uses `scope_id` as a query parameter.
+- Present but empty `scope_id` returns HTTP 409 with `error: "reset_required"`, `reset_required: true`, `reason: "missing_scope"`, the current reset boundary, and `sync_capability: "aware"`.
+- Present non-empty `scope_id` returns HTTP 409 with `reason: "unsupported_scope"` until later `ov4g.4` work adds per-scope cursor/reset/snapshot state and scope-bounded queries.
+- Servers MUST NOT silently ignore an explicit `scope_id`; that would let a caller believe it received a bounded Sharing domain stream when it actually received the legacy unscoped stream.
+- This compatibility slice does not add membership enforcement. Phase 1 still treats `scope_id` metadata as informational and preserves legacy peers that omit `scope_id`.
+
 ### Applying ops
 
 The receiver should reject ops when:

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -809,12 +809,15 @@ export interface ApiSyncNowResponse {
 export interface ApiSyncOpsRequestQuery {
 	since: string | null;
 	limit: number;
+	scope_id?: string | null;
 	generation: number;
 	snapshot_id: string;
 	baseline_cursor: string | null;
 }
 
 export interface ApiSyncResetBoundary {
+	/** Null means the peer used the legacy unscoped compatibility request shape. */
+	scope_id: string | null;
 	generation: number;
 	snapshot_id: string;
 	baseline_cursor: string | null;
@@ -841,7 +844,12 @@ export interface ApiSyncOpsResetRequiredResponse extends ApiSyncResetBoundary {
 	error: "reset_required";
 	reset_required: true;
 	sync_capability: SyncCapability;
-	reason: "stale_cursor" | "generation_mismatch" | "boundary_mismatch";
+	reason:
+		| "stale_cursor"
+		| "generation_mismatch"
+		| "boundary_mismatch"
+		| "missing_scope"
+		| "unsupported_scope";
 }
 
 export type ApiSyncOpsResponse = ApiSyncOpsIncrementalResponse | ApiSyncOpsResetRequiredResponse;
@@ -849,6 +857,7 @@ export type ApiSyncOpsResponse = ApiSyncOpsIncrementalResponse | ApiSyncOpsReset
 export interface ApiSyncMemorySnapshotPageRequestQuery {
 	limit: number;
 	page_token: string | null;
+	scope_id?: string | null;
 	generation: number;
 	snapshot_id: string;
 	baseline_cursor: string | null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -578,6 +578,17 @@ export {
 	syncVisibilityAllowed,
 } from "./sync-replication.js";
 export { SyncRetentionRunner } from "./sync-retention-runner.js";
+export type {
+	SyncScopeRequest,
+	SyncScopeRequestMode,
+	SyncScopeResetReason,
+} from "./sync-scope-protocol.js";
+export {
+	addSyncScopeToBoundary,
+	parseSyncScopeRequest,
+	SYNC_SCOPE_QUERY_PARAM,
+	syncScopeResetRequiredPayload,
+} from "./sync-scope-protocol.js";
 export { deriveTags, fileTags, normalizeTag } from "./tags.js";
 // Test utilities (exported for consumer packages like viewer-server)
 export { initTestSchema, insertTestSession } from "./test-utils.js";

--- a/packages/core/src/sync-bootstrap.test.ts
+++ b/packages/core/src/sync-bootstrap.test.ts
@@ -259,6 +259,7 @@ describe("fetchAllSnapshotPages", () => {
 		const prevFetch = globalThis.fetch;
 		try {
 			globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+				expect(String(_input)).toContain("scope_id=acme-work");
 				expect(init?.headers).toMatchObject({
 					"X-Codemem-Bootstrap-Grant": "grant-1",
 					[SYNC_CAPABILITY_HEADER]: "aware",
@@ -280,7 +281,7 @@ describe("fetchAllSnapshotPages", () => {
 
 			const result = await fetchAllSnapshotPages(
 				"http://peer.example.test:47337",
-				makeResetInfo(),
+				makeResetInfo({ scope_id: "acme-work" }),
 				deviceId,
 				{ keysDir, bootstrapGrantId: "grant-1" },
 			);

--- a/packages/core/src/sync-bootstrap.ts
+++ b/packages/core/src/sync-bootstrap.ts
@@ -87,6 +87,9 @@ export async function fetchAllSnapshotPages(
 		if (resetInfo.baseline_cursor) {
 			params.set("baseline_cursor", resetInfo.baseline_cursor);
 		}
+		if (resetInfo.scope_id) {
+			params.set("scope_id", resetInfo.scope_id);
+		}
 		if (pageToken) {
 			params.set("page_token", pageToken);
 		}

--- a/packages/core/src/sync-pass.test.ts
+++ b/packages/core/src/sync-pass.test.ts
@@ -795,7 +795,13 @@ describe("syncOnce auto-bootstrap", () => {
 	it("triggers bootstrap for empty local state with no cursor", async () => {
 		seedPeer();
 
-		vi.spyOn(syncHttpClient, "requestJson").mockResolvedValue([200, statusPayload]);
+		vi.spyOn(syncHttpClient, "requestJson").mockResolvedValue([
+			200,
+			{
+				...statusPayload,
+				sync_reset: { ...statusPayload.sync_reset, scope_id: "acme-work" },
+			},
+		]);
 		vi.spyOn(syncBootstrap, "fetchAllSnapshotPages").mockResolvedValue({
 			items: [],
 			generation: 1,
@@ -817,6 +823,7 @@ describe("syncOnce auto-bootstrap", () => {
 
 		// Verify the elevated page size was used
 		const fetchCall = vi.mocked(syncBootstrap.fetchAllSnapshotPages).mock.calls[0];
+		expect(fetchCall?.[1]).toMatchObject({ scope_id: "acme-work" });
 		expect(fetchCall?.[3]?.pageSize).toBe(2000);
 	});
 

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -143,6 +143,7 @@ function asOptionalCursor(value: unknown): string | null {
 }
 
 function parsePeerResetBoundary(payload: Record<string, unknown> | null): {
+	scope_id: string | null;
 	generation: number;
 	snapshot_id: string;
 	baseline_cursor: string | null;
@@ -157,6 +158,7 @@ function parsePeerResetBoundary(payload: Record<string, unknown> | null): {
 	}
 	const baseline = asOptionalCursor(boundary.baseline_cursor);
 	return {
+		scope_id: asOptionalCursor(boundary.scope_id),
 		generation: Number(boundary.generation),
 		snapshot_id: boundary.snapshot_id.trim(),
 		baseline_cursor: baseline,
@@ -489,6 +491,7 @@ export async function syncOnce(
 				if (localSharedCount === 0) {
 					try {
 						const resetInfo = {
+							scope_id: peerResetBoundary.scope_id,
 							generation: peerResetBoundary.generation,
 							snapshot_id: peerResetBoundary.snapshot_id,
 							baseline_cursor: peerResetBoundary.baseline_cursor ?? null,
@@ -587,12 +590,17 @@ export async function syncOnce(
 			});
 			if (getStatus === 409 && getPayload?.reset_required === true) {
 				const dirtyLocal = hasUnsyncedSharedMemoryChanges(db);
+				const resetReason =
+					getPayload.reason === "generation_mismatch" ||
+					getPayload.reason === "boundary_mismatch" ||
+					getPayload.reason === "missing_scope" ||
+					getPayload.reason === "unsupported_scope"
+						? getPayload.reason
+						: "stale_cursor";
 				const resetRequired: SyncResult["resetRequired"] = {
 					reset_required: true,
-					reason:
-						getPayload.reason === "generation_mismatch" || getPayload.reason === "boundary_mismatch"
-							? getPayload.reason
-							: "stale_cursor",
+					reason: resetReason,
+					scope_id: typeof getPayload.scope_id === "string" ? getPayload.scope_id : null,
 					generation: Number(getPayload.generation ?? 1),
 					snapshot_id: String(getPayload.snapshot_id ?? ""),
 					baseline_cursor:

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -29,6 +29,7 @@ import type {
 } from "./types.js";
 
 export interface SyncResetBoundary {
+	scope_id?: string | null;
 	generation: number;
 	snapshot_id: string;
 	baseline_cursor: string | null;
@@ -37,7 +38,12 @@ export interface SyncResetBoundary {
 
 export interface SyncResetRequired extends SyncResetBoundary {
 	reset_required: true;
-	reason: "stale_cursor" | "generation_mismatch" | "boundary_mismatch";
+	reason:
+		| "stale_cursor"
+		| "generation_mismatch"
+		| "boundary_mismatch"
+		| "missing_scope"
+		| "unsupported_scope";
 }
 
 export interface LoadReplicationOpsForPeerOptions {

--- a/packages/core/src/sync-scope-protocol.test.ts
+++ b/packages/core/src/sync-scope-protocol.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+	addSyncScopeToBoundary,
+	parseSyncScopeRequest,
+	syncScopeResetRequiredPayload,
+} from "./sync-scope-protocol.js";
+
+describe("sync scope protocol compatibility", () => {
+	it("treats omitted scope_id as legacy compatibility mode", () => {
+		expect(parseSyncScopeRequest(undefined, false)).toEqual({
+			ok: true,
+			mode: "legacy",
+			scope_id: null,
+		});
+	});
+
+	it("returns missing_scope when scope_id is present but empty", () => {
+		expect(parseSyncScopeRequest("  ", true)).toEqual({ ok: false, reason: "missing_scope" });
+	});
+
+	it("returns unsupported_scope for explicit scoped requests until per-scope sync lands", () => {
+		expect(parseSyncScopeRequest("acme-work", true)).toEqual({
+			ok: false,
+			reason: "unsupported_scope",
+		});
+	});
+
+	it("adds legacy scope shape to reset boundaries", () => {
+		expect(
+			addSyncScopeToBoundary(
+				{
+					generation: 2,
+					snapshot_id: "snapshot-2",
+					baseline_cursor: null,
+					retained_floor_cursor: "2026-01-01T00:00:00Z|floor",
+				},
+				null,
+			),
+		).toEqual({
+			generation: 2,
+			snapshot_id: "snapshot-2",
+			baseline_cursor: null,
+			retained_floor_cursor: "2026-01-01T00:00:00Z|floor",
+			scope_id: null,
+		});
+	});
+
+	it("builds reset_required payloads for scope protocol errors", () => {
+		expect(
+			syncScopeResetRequiredPayload(
+				{
+					generation: 3,
+					snapshot_id: "snapshot-3",
+					baseline_cursor: "2026-01-01T00:00:01Z|base",
+					retained_floor_cursor: null,
+				},
+				"unsupported_scope",
+				"aware",
+			),
+		).toEqual({
+			error: "reset_required",
+			reset_required: true,
+			sync_capability: "aware",
+			reason: "unsupported_scope",
+			generation: 3,
+			snapshot_id: "snapshot-3",
+			baseline_cursor: "2026-01-01T00:00:01Z|base",
+			retained_floor_cursor: null,
+			scope_id: null,
+		});
+	});
+});

--- a/packages/core/src/sync-scope-protocol.ts
+++ b/packages/core/src/sync-scope-protocol.ts
@@ -1,0 +1,69 @@
+import type { SyncCapability } from "./sync-capability.js";
+
+export const SYNC_SCOPE_QUERY_PARAM = "scope_id";
+
+export type SyncScopeRequestMode = "legacy" | "scoped";
+export type SyncScopeResetReason = "missing_scope" | "unsupported_scope";
+
+export interface SyncScopeRequestOk {
+	ok: true;
+	mode: SyncScopeRequestMode;
+	scope_id: string | null;
+}
+
+export interface SyncScopeRequestError {
+	ok: false;
+	reason: SyncScopeResetReason;
+}
+
+export type SyncScopeRequest = SyncScopeRequestOk | SyncScopeRequestError;
+
+export interface SyncResetBoundaryShape {
+	generation: number;
+	snapshot_id: string;
+	baseline_cursor: string | null;
+	retained_floor_cursor: string | null;
+}
+
+export function parseSyncScopeRequest(value: unknown, provided: boolean): SyncScopeRequest {
+	if (!provided) {
+		return { ok: true, mode: "legacy", scope_id: null };
+	}
+
+	const scopeId = typeof value === "string" ? value.trim() : "";
+	if (!scopeId) {
+		return { ok: false, reason: "missing_scope" };
+	}
+
+	// ov4g.4.1 reserves the parameter and fails closed for explicit scoped
+	// requests. Per-scope cursors/snapshots land in later ov4g.4 slices; until
+	// then, silently ignoring a requested scope would be worse than refusing it.
+	return { ok: false, reason: "unsupported_scope" };
+}
+
+export function addSyncScopeToBoundary<T extends SyncResetBoundaryShape>(
+	boundary: T,
+	scopeId: string | null,
+): T & { scope_id: string | null } {
+	return { ...boundary, scope_id: scopeId };
+}
+
+export function syncScopeResetRequiredPayload(
+	boundary: SyncResetBoundaryShape,
+	reason: SyncScopeResetReason,
+	syncCapability: SyncCapability,
+): SyncResetBoundaryShape & {
+	error: "reset_required";
+	reset_required: true;
+	sync_capability: SyncCapability;
+	reason: SyncScopeResetReason;
+	scope_id: string | null;
+} {
+	return {
+		error: "reset_required",
+		reset_required: true,
+		sync_capability: syncCapability,
+		reason,
+		...addSyncScopeToBoundary(boundary, null),
+	};
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -408,6 +408,7 @@ export interface SyncResetState {
 }
 
 export interface SyncResetBoundary {
+	scope_id?: string | null;
 	generation: number;
 	snapshot_id: string;
 	baseline_cursor: string | null;
@@ -416,7 +417,13 @@ export interface SyncResetBoundary {
 
 export interface SyncResetRequired extends SyncResetBoundary {
 	reset_required: true;
-	reason: "stale_cursor" | "generation_mismatch" | "boundary_mismatch" | "initial_bootstrap";
+	reason:
+		| "stale_cursor"
+		| "generation_mismatch"
+		| "boundary_mismatch"
+		| "initial_bootstrap"
+		| "missing_scope"
+		| "unsupported_scope";
 }
 
 export interface SyncDirtyLocalState {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -143,6 +143,52 @@ function createTestApp(opts?: {
 	};
 }
 
+function createAuthenticatedSyncPeer(
+	store: MemoryStore,
+	input: {
+		url: string;
+		method?: "GET" | "POST";
+		bodyBytes?: Buffer;
+	},
+): { headers: Record<string, string>; cleanup: () => void } {
+	const peerDir = mkdtempSync(join(tmpdir(), "codemem-sync-peer-test-"));
+	const peerDb = connect(join(peerDir, "peer.sqlite"));
+	const peerKeysDir = join(peerDir, "keys");
+	try {
+		initTestSchema(peerDb);
+		const [peerDeviceId] = ensureDeviceIdentity(peerDb, { keysDir: peerKeysDir });
+		const peerPublicKey = loadPublicKey(peerKeysDir);
+		if (!peerPublicKey) throw new Error("peer public key missing");
+		const peerFingerprint = peerDb.prepare("SELECT fingerprint FROM sync_device LIMIT 1").get() as
+			| { fingerprint: string }
+			| undefined;
+		if (!peerFingerprint?.fingerprint) throw new Error("peer fingerprint missing");
+		store.db
+			.prepare(
+				`INSERT INTO sync_peers(peer_device_id, pinned_fingerprint, public_key, created_at)
+				 VALUES (?, ?, ?, ?)`,
+			)
+			.run(peerDeviceId, peerFingerprint.fingerprint, peerPublicKey, new Date().toISOString());
+		return {
+			headers: buildAuthHeaders({
+				deviceId: peerDeviceId,
+				method: input.method ?? "GET",
+				url: input.url,
+				bodyBytes: input.bodyBytes ?? Buffer.alloc(0),
+				keysDir: peerKeysDir,
+			}),
+			cleanup: () => {
+				peerDb.close();
+				rmSync(peerDir, { recursive: true, force: true });
+			},
+		};
+	} catch (err) {
+		peerDb.close();
+		rmSync(peerDir, { recursive: true, force: true });
+		throw err;
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1825,6 +1871,7 @@ describe("viewer-server", () => {
 					const body = (await res.json()) as Record<string, unknown>;
 					expect(body.protocol_version).toBe("2");
 					expect(body.sync_capability).toBe("aware");
+					expect(body.sync_reset).toMatchObject({ scope_id: null });
 				} finally {
 					peerDb.close();
 				}
@@ -2225,6 +2272,249 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("returns reset_required when GET /v1/ops receives an empty scope_id", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const url = "http://localhost/v1/ops?scope_id=&limit=50";
+				peer = createAuthenticatedSyncPeer(store, { url });
+
+				const res = await syncApp.request(url, { headers: peer.headers });
+
+				expect(res.status).toBe(409);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({
+					error: "reset_required",
+					reset_required: true,
+					sync_capability: "aware",
+					reason: "missing_scope",
+					scope_id: null,
+				});
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("returns reset_required when GET /v1/ops receives an unsupported scope_id", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const url = "http://localhost/v1/ops?scope_id=acme-work&limit=50";
+				peer = createAuthenticatedSyncPeer(store, { url });
+
+				const res = await syncApp.request(url, { headers: peer.headers });
+
+				expect(res.status).toBe(409);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({
+					error: "reset_required",
+					reset_required: true,
+					sync_capability: "aware",
+					reason: "unsupported_scope",
+					scope_id: null,
+				});
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("returns reset_required when GET /v1/snapshot receives an unsupported scope_id", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const url = "http://localhost/v1/snapshot?scope_id=acme-work&generation=1&snapshot_id=test";
+				peer = createAuthenticatedSyncPeer(store, { url });
+
+				const res = await syncApp.request(url, { headers: peer.headers });
+
+				expect(res.status).toBe(409);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({
+					error: "reset_required",
+					reset_required: true,
+					sync_capability: "aware",
+					reason: "unsupported_scope",
+					scope_id: null,
+				});
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("returns reset_required when GET /v1/snapshot receives an empty scope_id", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const url = "http://localhost/v1/snapshot?scope_id=&generation=1&snapshot_id=test";
+				peer = createAuthenticatedSyncPeer(store, { url });
+
+				const res = await syncApp.request(url, { headers: peer.headers });
+
+				expect(res.status).toBe(409);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({
+					error: "reset_required",
+					reset_required: true,
+					sync_capability: "aware",
+					reason: "missing_scope",
+					scope_id: null,
+				});
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("returns reset_required when POST /v1/ops receives an unsupported body scope_id", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const url = "http://localhost/v1/ops";
+				const bodyText = JSON.stringify({ ops: [], scope_id: "acme-work" });
+				const bodyBytes = Buffer.from(bodyText);
+				peer = createAuthenticatedSyncPeer(store, { url, method: "POST", bodyBytes });
+
+				const res = await syncApp.request(url, {
+					method: "POST",
+					headers: { ...peer.headers, "Content-Type": "application/json" },
+					body: bodyText,
+				});
+
+				expect(res.status).toBe(409);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({
+					error: "reset_required",
+					reset_required: true,
+					sync_capability: "aware",
+					reason: "unsupported_scope",
+					scope_id: null,
+				});
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("returns reset_required for unsupported POST scope_id before missing ops validation", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const url = "http://localhost/v1/ops";
+				const bodyText = JSON.stringify({ scope_id: "acme-work" });
+				const bodyBytes = Buffer.from(bodyText);
+				peer = createAuthenticatedSyncPeer(store, { url, method: "POST", bodyBytes });
+
+				const res = await syncApp.request(url, {
+					method: "POST",
+					headers: { ...peer.headers, "Content-Type": "application/json" },
+					body: bodyText,
+				});
+
+				expect(res.status).toBe(409);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({
+					error: "reset_required",
+					reset_required: true,
+					sync_capability: "aware",
+					reason: "unsupported_scope",
+					scope_id: null,
+				});
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("returns reset_required for empty POST scope_id before missing ops validation", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const url = "http://localhost/v1/ops";
+				const bodyText = JSON.stringify({ scope_id: "" });
+				const bodyBytes = Buffer.from(bodyText);
+				peer = createAuthenticatedSyncPeer(store, { url, method: "POST", bodyBytes });
+
+				const res = await syncApp.request(url, {
+					method: "POST",
+					headers: { ...peer.headers, "Content-Type": "application/json" },
+					body: bodyText,
+				});
+
+				expect(res.status).toBe(409);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({
+					error: "reset_required",
+					reset_required: true,
+					sync_capability: "aware",
+					reason: "missing_scope",
+					scope_id: null,
+				});
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("returns reset_required for unsupported POST scope_id before oversized ops validation", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const url = "http://localhost/v1/ops";
+				const bodyText = JSON.stringify({
+					scope_id: "acme-work",
+					ops: Array.from({ length: 2001 }, () => null),
+				});
+				const bodyBytes = Buffer.from(bodyText);
+				peer = createAuthenticatedSyncPeer(store, { url, method: "POST", bodyBytes });
+
+				const res = await syncApp.request(url, {
+					method: "POST",
+					headers: { ...peer.headers, "Content-Type": "application/json" },
+					body: bodyText,
+				});
+
+				expect(res.status).toBe(409);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({
+					error: "reset_required",
+					reset_required: true,
+					sync_capability: "aware",
+					reason: "unsupported_scope",
+					scope_id: null,
+				});
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
 		it("advertises capability on incremental /v1/ops responses", async () => {
 			const { syncApp, getStore, cleanup } = createTestApp();
 			const peerDir = mkdtempSync(join(tmpdir(), "codemem-sync-peer-test-"));
@@ -2275,6 +2565,7 @@ describe("viewer-server", () => {
 					const body = (await res.json()) as Record<string, unknown>;
 					expect(body.reset_required).toBe(false);
 					expect(body.sync_capability).toBe("aware");
+					expect(body.scope_id).toBeNull();
 					expect(body.ops).toEqual([]);
 				} finally {
 					peerDb.close();
@@ -2377,6 +2668,7 @@ describe("viewer-server", () => {
 					expect(body.generation).toBe(11);
 					expect(body.snapshot_id).toBe("snapshot-11");
 					expect(body.sync_capability).toBe("aware");
+					expect(body.scope_id).toBeNull();
 					const items = body.items as Array<Record<string, unknown>>;
 					expect(items.map((item) => item.entity_id)).toEqual(["key-a", "key-b"]);
 					expect(items[1]?.op_type).toBe("delete");
@@ -2461,6 +2753,7 @@ describe("viewer-server", () => {
 					expect(res.status).toBe(200);
 					const body = (await res.json()) as Record<string, unknown>;
 					expect(body.sync_capability).toBe("aware");
+					expect(body.scope_id).toBeNull();
 				} finally {
 					peerDb.close();
 				}

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -14,6 +14,7 @@ import type {
 	SemanticIndexDiagnostics,
 } from "@codemem/core";
 import {
+	addSyncScopeToBoundary,
 	applyReplicationOps,
 	buildBaseUrl,
 	cleanupNonces,
@@ -55,12 +56,15 @@ import {
 	loadReplicationOpsForPeer,
 	lookupCoordinatorPeers,
 	mergeAddresses,
+	parseSyncScopeRequest,
 	readCoordinatorSyncConfig,
 	recordNonce,
 	requestJson,
 	runSyncPass,
+	SYNC_SCOPE_QUERY_PARAM,
 	schema,
 	syncProjectAllowedByFilters,
+	syncScopeResetRequiredPayload,
 	syncVisibilityAllowed,
 	updatePeerAddresses,
 	upsertCoordinatorGroupPreference,
@@ -1247,7 +1251,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 					device_id: deviceId,
 					protocol_version: SYNC_PROTOCOL_VERSION,
 					fingerprint,
-					sync_reset: syncReset,
+					sync_reset: addSyncScopeToBoundary(syncReset, null),
 					sync_capability: LOCAL_SYNC_CAPABILITY,
 				});
 			} catch {
@@ -1269,6 +1273,18 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		const peerDeviceId = auth.deviceId;
 
 		try {
+			const rawScopeId = c.req.query(SYNC_SCOPE_QUERY_PARAM);
+			const scopeRequest = parseSyncScopeRequest(rawScopeId, rawScopeId !== undefined);
+			if (!scopeRequest.ok) {
+				return c.json(
+					syncScopeResetRequiredPayload(
+						getSyncResetState(store.db),
+						scopeRequest.reason,
+						LOCAL_SYNC_CAPABILITY,
+					),
+					409,
+				);
+			}
 			const since = c.req.query("since") ?? null;
 			const rawLimit = Number.parseInt(c.req.query("limit") ?? "200", 10);
 			const rawGeneration = c.req.query("generation");
@@ -1293,7 +1309,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 					{
 						error: "reset_required",
 						sync_capability: LOCAL_SYNC_CAPABILITY,
-						...result.reset,
+						...addSyncScopeToBoundary(result.reset, scopeRequest.scope_id),
 					},
 					409,
 				);
@@ -1303,6 +1319,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			return c.json({
 				reset_required: false,
 				sync_capability: LOCAL_SYNC_CAPABILITY,
+				scope_id: scopeRequest.scope_id,
 				generation: boundary.generation,
 				snapshot_id: boundary.snapshot_id,
 				baseline_cursor: boundary.baseline_cursor,
@@ -1357,6 +1374,18 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			if (limited) return limited;
 
 			try {
+				const rawScopeId = c.req.query(SYNC_SCOPE_QUERY_PARAM);
+				const scopeRequest = parseSyncScopeRequest(rawScopeId, rawScopeId !== undefined);
+				if (!scopeRequest.ok) {
+					return c.json(
+						syncScopeResetRequiredPayload(
+							getSyncResetState(store.db),
+							scopeRequest.reason,
+							LOCAL_SYNC_CAPABILITY,
+						),
+						409,
+					);
+				}
 				const rawGeneration = c.req.query("generation");
 				const generation =
 					rawGeneration != null && rawGeneration.trim().length > 0
@@ -1386,6 +1415,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				});
 
 				return c.json({
+					scope_id: scopeRequest.scope_id,
 					generation: result.boundary.generation,
 					snapshot_id: result.boundary.snapshot_id,
 					baseline_cursor: result.boundary.baseline_cursor,
@@ -1433,6 +1463,17 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			return c.json({ error: "invalid_json" }, 400);
 		}
 
+		const scopeRequest = parseSyncScopeRequest(body.scope_id, Object.hasOwn(body, "scope_id"));
+		if (!scopeRequest.ok) {
+			return c.json(
+				syncScopeResetRequiredPayload(
+					getSyncResetState(store.db),
+					scopeRequest.reason,
+					LOCAL_SYNC_CAPABILITY,
+				),
+				409,
+			);
+		}
 		if (!Array.isArray(body.ops)) {
 			return c.json({ error: "invalid_ops" }, 400);
 		}
@@ -1465,6 +1506,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		return c.json({
 			...result,
 			sync_capability: LOCAL_SYNC_CAPABILITY,
+			scope_id: scopeRequest.scope_id,
 			skipped: result.skipped + filteredInbound.skipped,
 		});
 	});


### PR DESCRIPTION
## Description
Defines the minimal scope-aware sync protocol contract before enforcement: `scope_id` is reserved on sync endpoints, omitted `scope_id` remains legacy-compatible, explicit empty/unsupported scoped requests fail closed with `reset_required`, and reset/snapshot metadata carries `scope_id` through client bootstrap.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation run:
- `pnpm exec vitest run packages/core/src/sync-scope-protocol.test.ts packages/core/src/sync-bootstrap.test.ts packages/core/src/sync-pass.test.ts packages/core/src/sync-replication.test.ts packages/viewer-server/src/index.test.ts`
- `pnpm run tsc`
- `pnpm run lint`
- `pnpm run test`
- CodeReviewer re-review: no blockers

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced