### PR TITLE
feat: filter outbound ops by sharing-domain membership

### DIFF
--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -748,6 +748,7 @@ export async function syncOnce(
 				db,
 				outboundWindow,
 				peerDeviceId,
+				{ localDeviceId: deviceId },
 			);
 			const postUrl = `${baseUrl}/v1/ops`;
 			if (outboundOps.length > 0) {

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -851,18 +851,24 @@ describe("loadMemorySnapshotPageForPeer", () => {
 		);
 	}
 
-	function grantPersonalScope(scopeId: string, peerDeviceId: string) {
+	function grantScope(scopeId: string, deviceIds: string[], authorityType = "coordinator") {
 		const now = new Date().toISOString();
 		db.prepare(
 			`INSERT OR IGNORE INTO replication_scopes(
 				scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
-			 ) VALUES (?, ?, 'user', 'coordinator', 1, 'active', ?, ?)`,
-		).run(scopeId, scopeId, now, now);
-		db.prepare(
-			`INSERT OR REPLACE INTO scope_memberships(
-				scope_id, device_id, role, status, membership_epoch, updated_at
-			 ) VALUES (?, ?, 'member', 'active', 1, ?)`,
-		).run(scopeId, peerDeviceId, now);
+			 ) VALUES (?, ?, 'user', ?, 1, 'active', ?, ?)`,
+		).run(scopeId, scopeId, authorityType, now, now);
+		for (const deviceId of deviceIds) {
+			db.prepare(
+				`INSERT OR REPLACE INTO scope_memberships(
+					scope_id, device_id, role, status, membership_epoch, updated_at
+				 ) VALUES (?, ?, 'member', 'active', 1, ?)`,
+			).run(scopeId, deviceId, now);
+		}
+	}
+
+	function grantPersonalScope(scopeId: string, peerDeviceId: string) {
+		grantScope(scopeId, [peerDeviceId]);
 	}
 
 	function insertSessionWithProject(project: string): number {
@@ -1807,18 +1813,24 @@ describe("filterReplicationOpsForSyncWithStatus", () => {
 		};
 	}
 
-	function grantPersonalScope(scopeId: string, peerDeviceId: string) {
+	function grantScope(scopeId: string, deviceIds: string[], authorityType = "coordinator") {
 		const now = new Date().toISOString();
 		db.prepare(
 			`INSERT OR IGNORE INTO replication_scopes(
 				scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
-			 ) VALUES (?, ?, 'user', 'coordinator', 1, 'active', ?, ?)`,
-		).run(scopeId, scopeId, now, now);
-		db.prepare(
-			`INSERT OR REPLACE INTO scope_memberships(
-				scope_id, device_id, role, status, membership_epoch, updated_at
-			 ) VALUES (?, ?, 'member', 'active', 1, ?)`,
-		).run(scopeId, peerDeviceId, now);
+			 ) VALUES (?, ?, 'user', ?, 1, 'active', ?, ?)`,
+		).run(scopeId, scopeId, authorityType, now, now);
+		for (const deviceId of deviceIds) {
+			db.prepare(
+				`INSERT OR REPLACE INTO scope_memberships(
+					scope_id, device_id, role, status, membership_epoch, updated_at
+				 ) VALUES (?, ?, 'member', 'active', 1, ?)`,
+			).run(scopeId, deviceId, now);
+		}
+	}
+
+	function grantPersonalScope(scopeId: string, peerDeviceId: string) {
+		grantScope(scopeId, [peerDeviceId]);
 	}
 
 	it("filters by peer include scope and advances cursor past skipped ops", () => {
@@ -1852,6 +1864,89 @@ describe("filterReplicationOpsForSyncWithStatus", () => {
 		expect(nextOnly).toBe("2026-01-01T00:00:02Z|op-2");
 	});
 
+	it("applies scope membership before broad project filters", () => {
+		db.prepare(
+			"INSERT INTO sync_peers(peer_device_id, projects_include_json, projects_exclude_json, created_at) VALUES (?, ?, ?, ?)",
+		).run("peer-1", toJson(["proj-a"]), toJson([]), "2026-01-01T00:00:00Z");
+		grantScope("acme-work", ["local-device"]);
+		const scopedOp = makeOp({
+			op_id: "op-scoped",
+			payload_json: toJson({ project: "proj-a", scope_id: "acme-work", visibility: "shared" }),
+			scope_id: "acme-work",
+		});
+
+		const [blockedOps, blockedCursor, blockedMeta] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[scopedOp],
+			"peer-1",
+			{ localDeviceId: "local-device" },
+		);
+		expect(blockedOps).toEqual([]);
+		expect(blockedCursor).toBe("2026-01-01T00:00:00Z|op-scoped");
+		expect(blockedMeta).toMatchObject({ reason: "scope_filter", scope_id: "acme-work" });
+
+		grantScope("acme-work", ["local-device", "peer-1"]);
+		const [allowedOps, allowedCursor, allowedMeta] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[scopedOp],
+			"peer-1",
+			{ localDeviceId: "local-device" },
+		);
+		expect(allowedOps.map((op) => op.op_id)).toEqual(["op-scoped"]);
+		expect(allowedCursor).toBe("2026-01-01T00:00:00Z|op-scoped");
+		expect(allowedMeta).toBeNull();
+	});
+
+	it("never sends local-authority scopes outbound", () => {
+		grantScope("local-only", ["local-device", "peer-1"], "local");
+		const localOnlyOp = makeOp({
+			op_id: "op-local-only",
+			payload_json: toJson({ project: "proj-a", scope_id: "local-only", visibility: "shared" }),
+			scope_id: "local-only",
+		});
+		const defaultScopeOp = makeOp({
+			op_id: "op-local-default",
+			payload_json: toJson({
+				project: "proj-a",
+				scope_id: DEFAULT_SYNC_SCOPE_ID,
+				visibility: "shared",
+			}),
+			scope_id: DEFAULT_SYNC_SCOPE_ID,
+			created_at: "2026-01-01T00:00:01Z",
+		});
+
+		const [allowed, cursor, skipped] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[localOnlyOp, defaultScopeOp],
+			"peer-1",
+			{ localDeviceId: "local-device" },
+		);
+
+		expect(allowed).toEqual([]);
+		expect(cursor).toBe("2026-01-01T00:00:01Z|op-local-default");
+		expect(skipped).toMatchObject({ reason: "scope_filter", skipped_count: 2 });
+	});
+
+	it("requires the local device to remain a scope member before outbound sync", () => {
+		grantScope("acme-work", ["peer-1"]);
+		const scopedOp = makeOp({
+			op_id: "op-local-revoked",
+			payload_json: toJson({ project: "proj-a", scope_id: "acme-work", visibility: "shared" }),
+			scope_id: "acme-work",
+		});
+
+		const [allowed, cursor, skipped] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[scopedOp],
+			"peer-1",
+			{ localDeviceId: "local-device" },
+		);
+
+		expect(allowed).toEqual([]);
+		expect(cursor).toBe("2026-01-01T00:00:00Z|op-local-revoked");
+		expect(skipped?.reason).toBe("scope_filter");
+	});
+
 	it("requires a matching personal scope grant instead of a claimed local actor flag", () => {
 		db.prepare(
 			"INSERT INTO sync_peers(peer_device_id, projects_include_json, projects_exclude_json, claimed_local_actor, created_at) VALUES (?, ?, ?, ?, ?)",
@@ -1877,7 +1972,7 @@ describe("filterReplicationOpsForSyncWithStatus", () => {
 		);
 		expect(blockedOps).toEqual([]);
 		expect(blockedCursor).toBe("2026-01-01T00:00:00Z|op-private");
-		expect(blockedMeta?.reason).toBe("visibility_filter");
+		expect(blockedMeta?.reason).toBe("scope_filter");
 
 		db.prepare("UPDATE sync_peers SET claimed_local_actor = 1 WHERE peer_device_id = ?").run(
 			"peer-1",
@@ -1887,7 +1982,7 @@ describe("filterReplicationOpsForSyncWithStatus", () => {
 			filterReplicationOpsForSyncWithStatus(db, [privateOp], "peer-1");
 		expect(stillBlockedOps).toEqual([]);
 		expect(stillBlockedCursor).toBe("2026-01-01T00:00:00Z|op-private");
-		expect(stillBlockedMeta?.reason).toBe("visibility_filter");
+		expect(stillBlockedMeta?.reason).toBe("scope_filter");
 
 		grantPersonalScope("personal:actor-1", "peer-1");
 		db.prepare("UPDATE sync_peers SET claimed_local_actor = 0 WHERE peer_device_id = ?").run(
@@ -1901,6 +1996,34 @@ describe("filterReplicationOpsForSyncWithStatus", () => {
 		expect(allowedOps.map((op) => op.op_id)).toEqual(["op-private"]);
 		expect(allowedCursor).toBe("2026-01-01T00:00:00Z|op-private");
 		expect(allowedMeta).toBeNull();
+	});
+
+	it("does not let personal grants make private payloads leave through org scopes", () => {
+		grantScope("acme-work", ["local-device", "peer-1"]);
+		grantScope("personal:actor-1", ["local-device", "peer-1"]);
+		const privateOrgOp = makeOp({
+			op_id: "op-private-org",
+			payload_json: toJson({
+				actor_id: "actor-1",
+				project: "proj-a",
+				scope_id: "acme-work",
+				visibility: "private",
+				workspace_id: "personal:actor-1",
+				workspace_kind: "personal",
+			}),
+			scope_id: "acme-work",
+		});
+
+		const [allowed, cursor, skipped] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[privateOrgOp],
+			"peer-1",
+			{ localDeviceId: "local-device" },
+		);
+
+		expect(allowed).toEqual([]);
+		expect(cursor).toBe("2026-01-01T00:00:00Z|op-private-org");
+		expect(skipped?.reason).toBe("scope_filter");
 	});
 
 	it("requires a personal scope grant when visibility is missing but scope is personal", () => {
@@ -1923,7 +2046,7 @@ describe("filterReplicationOpsForSyncWithStatus", () => {
 		);
 		expect(blockedOps).toEqual([]);
 		expect(blockedCursor).toBe("2026-01-01T00:00:00Z|op-personal-no-visibility");
-		expect(blockedMeta?.reason).toBe("visibility_filter");
+		expect(blockedMeta?.reason).toBe("scope_filter");
 
 		grantPersonalScope("personal:actor-1", "peer-1");
 		const [allowedOps, allowedCursor, allowedMeta] = filterReplicationOpsForSyncWithStatus(
@@ -2013,7 +2136,7 @@ describe("filterReplicationOpsForSyncWithStatus", () => {
 		);
 		expect(blockedPersonal).toEqual([]);
 		expect(blockedCursor).toBe("2026-01-01T00:00:06Z|op-personal-del");
-		expect(blockedMeta?.reason).toBe("visibility_filter");
+		expect(blockedMeta?.reason).toBe("scope_filter");
 
 		grantPersonalScope("personal:actor-1", "peer-1");
 		const [allowedPersonal, allowedCursor, allowedMeta] = filterReplicationOpsForSyncWithStatus(
@@ -2024,6 +2147,53 @@ describe("filterReplicationOpsForSyncWithStatus", () => {
 		expect(allowedPersonal.map((op) => op.op_id)).toEqual(["op-personal-del"]);
 		expect(allowedCursor).toBe("2026-01-01T00:00:06Z|op-personal-del");
 		expect(allowedMeta).toBeNull();
+	});
+
+	it("applies project filters to null-payload deletes when local context exists", () => {
+		db.prepare(
+			"INSERT INTO sync_peers(peer_device_id, projects_include_json, projects_exclude_json, created_at) VALUES (?, ?, ?, ?)",
+		).run("peer-1", toJson(["allowed-project"]), toJson([]), "2026-01-01T00:00:00Z");
+		grantScope("acme-work", ["local-device", "peer-1"]);
+		const sessionId = insertTestSession(db);
+		db.prepare("UPDATE sessions SET project = ? WHERE id = ?").run("blocked-project", sessionId);
+		db.prepare(
+			`INSERT INTO memory_items(
+				session_id, kind, title, body_text, created_at, updated_at, import_key, rev,
+				active, visibility, metadata_json, scope_id
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			sessionId,
+			"discovery",
+			"Blocked delete target",
+			"Blocked delete target",
+			"2026-01-01T00:00:00Z",
+			"2026-01-01T00:00:00Z",
+			"blocked-delete-key",
+			1,
+			1,
+			"shared",
+			toJson({}),
+			"acme-work",
+		);
+		const deleteOp = makeOp({
+			op_id: "op-blocked-delete",
+			entity_id: "blocked-delete-key",
+			op_type: "delete",
+			payload_json: null,
+			created_at: "2026-01-01T00:00:05Z",
+			scope_id: "acme-work",
+		});
+
+		const [allowed, cursor, skipped] = filterReplicationOpsForSyncWithStatus(
+			db,
+			[deleteOp],
+			"peer-1",
+			{ localDeviceId: "local-device" },
+		);
+
+		expect(allowed).toEqual([]);
+		expect(cursor).toBe("2026-01-01T00:00:05Z|op-blocked-delete");
+		expect(skipped).toMatchObject({ reason: "project_filter", project: "blocked-project" });
 	});
 
 	it("respects CODEMEM_SYNC_PROJECTS_* env overrides", () => {

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -1754,14 +1754,140 @@ function parsePayload(payloadJson: string | null): Record<string, unknown> | nul
 }
 
 export interface FilterReplicationSkipped {
-	reason: "visibility_filter" | "project_filter";
+	reason: "scope_filter" | "visibility_filter" | "project_filter";
 	op_id: string;
 	created_at: string;
 	entity_type: string;
 	entity_id: string;
 	skipped_count: number;
 	project?: string | null;
+	scope_id?: string | null;
 	visibility?: string | null;
+}
+
+export interface FilterReplicationOpsForSyncOptions {
+	localDeviceId?: string | null;
+	applyScopeFilter?: boolean;
+}
+
+interface ExistingMemoryFilterContext {
+	payload: Record<string, unknown>;
+	project: string | null;
+	scopeId: string | null;
+}
+
+function addSkipped(
+	state: { count: number; first: FilterReplicationSkipped | null },
+	op: ReplicationOp,
+	skipped: Pick<FilterReplicationSkipped, "reason"> &
+		Partial<Omit<FilterReplicationSkipped, "reason" | "skipped_count">>,
+): void {
+	state.count += 1;
+	if (!state.first) {
+		state.first = {
+			...skipped,
+			op_id: op.op_id,
+			created_at: op.created_at,
+			entity_type: op.entity_type,
+			entity_id: op.entity_id,
+			skipped_count: 0,
+		};
+	}
+}
+
+function metadataRecord(payload: Record<string, unknown> | null): Record<string, unknown> {
+	const metadata = payload?.metadata_json;
+	if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return {};
+	return metadata as Record<string, unknown>;
+}
+
+function payloadScopeId(payload: Record<string, unknown> | null): string | null {
+	const metadata = metadataRecord(payload);
+	return cleanText(payload?.scope_id ?? metadata.scope_id);
+}
+
+function payloadContradictsOutboundScope(
+	op: Pick<ReplicationOp, "scope_id">,
+	payload: Record<string, unknown> | null,
+): boolean {
+	const opScopeId = cleanText(op.scope_id);
+	const explicitPayloadScopeId = payloadScopeId(payload);
+	if (explicitPayloadScopeId && explicitPayloadScopeId !== opScopeId) return true;
+	if (!opScopeId) return explicitPayloadScopeId != null;
+
+	const personalRequirement = personalScopeAuthorizationRequirement(op, payload);
+	return Boolean(
+		personalRequirement.required &&
+			personalRequirement.scopeId &&
+			personalRequirement.scopeId !== opScopeId,
+	);
+}
+
+function existingMemoryFilterContext(
+	db: Database,
+	importKey: string,
+): ExistingMemoryFilterContext | null {
+	const key = cleanText(importKey);
+	if (!key) return null;
+	const row = db
+		.prepare(
+			`SELECT
+				m.actor_id,
+				m.metadata_json,
+				m.scope_id,
+				m.visibility,
+				m.workspace_id,
+				m.workspace_kind,
+				s.project
+			 FROM memory_items m
+			 LEFT JOIN sessions s ON s.id = m.session_id
+			 WHERE m.import_key = ?
+			 LIMIT 1`,
+		)
+		.get(key) as
+		| {
+				actor_id: string | null;
+				metadata_json: string | null;
+				project: string | null;
+				scope_id: string | null;
+				visibility: string | null;
+				workspace_id: string | null;
+				workspace_kind: string | null;
+		  }
+		| undefined;
+	if (!row) return null;
+	return {
+		payload: {
+			actor_id: row.actor_id,
+			metadata_json: fromJson(row.metadata_json),
+			visibility: row.visibility,
+			workspace_id: row.workspace_id,
+			workspace_kind: row.workspace_kind,
+		},
+		project: cleanText(row.project),
+		scopeId: cleanText(row.scope_id),
+	};
+}
+
+function outboundScopeAllowed(
+	db: Database,
+	op: ReplicationOp,
+	payload: Record<string, unknown> | null,
+	peerDeviceId: string | null,
+	localDeviceId: string | null,
+): boolean {
+	if (payloadContradictsOutboundScope(op, payload)) return false;
+	const scopeId = cleanText(op.scope_id);
+	if (!scopeId) return true;
+	if (scopeId === DEFAULT_SYNC_SCOPE_ID) return false;
+	const peerId = cleanText(peerDeviceId);
+	if (!peerId) return false;
+	const peerAuth = getCachedScopeAuthorization(db, { deviceId: peerId, scopeId });
+	if (!peerAuth.authorized || peerAuth.scope?.authority_type === "local") return false;
+	const localId = cleanText(localDeviceId);
+	if (!localId) return true;
+	const localAuth = getCachedScopeAuthorization(db, { deviceId: localId, scopeId });
+	return localAuth.authorized && localAuth.scope?.authority_type !== "local";
 }
 
 /**
@@ -1775,30 +1901,60 @@ export function filterReplicationOpsForSyncWithStatus(
 	db: Database,
 	ops: ReplicationOp[],
 	peerDeviceId: string | null,
+	options: FilterReplicationOpsForSyncOptions = {},
 ): [ReplicationOp[], string | null, FilterReplicationSkipped | null] {
 	const allowed: ReplicationOp[] = [];
 	let nextCursor: string | null = null;
-	let skippedCount = 0;
-	let firstSkipped: FilterReplicationSkipped | null = null;
+	const skipped = { count: 0, first: null as FilterReplicationSkipped | null };
+	const applyScopeFilter = options.applyScopeFilter !== false;
 	for (const op of ops) {
 		if (op.entity_type === "memory_item") {
 			const payload = parsePayload(op.payload_json);
+			if (
+				applyScopeFilter &&
+				!outboundScopeAllowed(db, op, payload, peerDeviceId, options.localDeviceId ?? null)
+			) {
+				addSkipped(skipped, op, { reason: "scope_filter", scope_id: cleanText(op.scope_id) });
+				nextCursor = computeCursor(op.created_at, op.op_id);
+				continue;
+			}
 			if (op.op_type === "delete" && payload == null) {
+				const existing = existingMemoryFilterContext(db, op.entity_id);
+				if (existing) {
+					if (applyScopeFilter && existing.scopeId && existing.scopeId !== cleanText(op.scope_id)) {
+						addSkipped(skipped, op, { reason: "scope_filter", scope_id: cleanText(op.scope_id) });
+						nextCursor = computeCursor(op.created_at, op.op_id);
+						continue;
+					}
+					if (
+						(replicationOpRequiresPersonalScopeAuthorization(op, existing.payload) ||
+							!syncVisibilityAllowed(existing.payload)) &&
+						!peerCanSyncPrivateOpByPersonalScopeGrant(db, op, existing.payload, peerDeviceId)
+					) {
+						addSkipped(skipped, op, {
+							reason: "visibility_filter",
+							visibility:
+								typeof existing.payload.visibility === "string"
+									? String(existing.payload.visibility)
+									: null,
+						});
+						nextCursor = computeCursor(op.created_at, op.op_id);
+						continue;
+					}
+					if (!syncProjectAllowed(db, existing.project, peerDeviceId)) {
+						addSkipped(skipped, op, {
+							reason: "project_filter",
+							project: existing.project,
+						});
+						nextCursor = computeCursor(op.created_at, op.op_id);
+						continue;
+					}
+				}
 				if (
 					replicationOpRequiresPersonalScopeAuthorization(op, payload) &&
 					!peerCanSyncPrivateOpByPersonalScopeGrant(db, op, payload, peerDeviceId)
 				) {
-					skippedCount += 1;
-					if (!firstSkipped) {
-						firstSkipped = {
-							reason: "visibility_filter",
-							op_id: op.op_id,
-							created_at: op.created_at,
-							entity_type: op.entity_type,
-							entity_id: op.entity_id,
-							skipped_count: 0,
-						};
-					}
+					addSkipped(skipped, op, { reason: "visibility_filter" });
 					nextCursor = computeCursor(op.created_at, op.op_id);
 					continue;
 				}
@@ -1811,18 +1967,10 @@ export function filterReplicationOpsForSyncWithStatus(
 					!syncVisibilityAllowed(payload)) &&
 				!peerCanSyncPrivateOpByPersonalScopeGrant(db, op, payload, peerDeviceId)
 			) {
-				skippedCount += 1;
-				if (!firstSkipped) {
-					firstSkipped = {
-						reason: "visibility_filter",
-						op_id: op.op_id,
-						created_at: op.created_at,
-						entity_type: op.entity_type,
-						entity_id: op.entity_id,
-						visibility: typeof payload?.visibility === "string" ? String(payload.visibility) : null,
-						skipped_count: 0,
-					};
-				}
+				addSkipped(skipped, op, {
+					reason: "visibility_filter",
+					visibility: typeof payload?.visibility === "string" ? String(payload.visibility) : null,
+				});
 				nextCursor = computeCursor(op.created_at, op.op_id);
 				continue;
 			}
@@ -1832,18 +1980,7 @@ export function filterReplicationOpsForSyncWithStatus(
 					? payload.project.trim()
 					: null;
 			if (!syncProjectAllowed(db, project, peerDeviceId)) {
-				skippedCount += 1;
-				if (!firstSkipped) {
-					firstSkipped = {
-						reason: "project_filter",
-						op_id: op.op_id,
-						created_at: op.created_at,
-						entity_type: op.entity_type,
-						entity_id: op.entity_id,
-						project,
-						skipped_count: 0,
-					};
-				}
+				addSkipped(skipped, op, { reason: "project_filter", project });
 				nextCursor = computeCursor(op.created_at, op.op_id);
 				continue;
 			}
@@ -1853,19 +1990,25 @@ export function filterReplicationOpsForSyncWithStatus(
 		nextCursor = computeCursor(op.created_at, op.op_id);
 	}
 
-	if (firstSkipped) {
-		firstSkipped.skipped_count = skippedCount;
+	if (skipped.first) {
+		skipped.first.skipped_count = skipped.count;
 	}
 
-	return [allowed, nextCursor, firstSkipped];
+	return [allowed, nextCursor, skipped.first];
 }
 
 export function filterReplicationOpsForSync(
 	db: Database,
 	ops: ReplicationOp[],
 	peerDeviceId: string | null,
+	options: FilterReplicationOpsForSyncOptions = {},
 ): [ReplicationOp[], string | null] {
-	const [allowed, nextCursor] = filterReplicationOpsForSyncWithStatus(db, ops, peerDeviceId);
+	const [allowed, nextCursor] = filterReplicationOpsForSyncWithStatus(
+		db,
+		ops,
+		peerDeviceId,
+		options,
+	);
 	return [allowed, nextCursor];
 }
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2600,6 +2600,65 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("filters local-only outbound /v1/ops before project filters", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = "2026-01-01T00:00:00Z";
+				store.db
+					.prepare(
+						`INSERT OR REPLACE INTO sync_reset_state(
+							id, generation, snapshot_id, baseline_cursor, retained_floor_cursor, updated_at
+						 ) VALUES (1, ?, ?, ?, ?, ?)`,
+					)
+					.run(3, "snapshot-3", null, null, now);
+				store.db
+					.prepare(
+						`INSERT INTO replication_ops(
+							op_id, entity_type, entity_id, op_type, payload_json, clock_rev,
+							clock_updated_at, clock_device_id, device_id, created_at, scope_id
+						 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+					)
+					.run(
+						"local-default-outbound-op",
+						"memory_item",
+						"local-default-outbound-key",
+						"upsert",
+						JSON.stringify({
+							project: "proj-a",
+							scope_id: "local-default",
+							visibility: "shared",
+						}),
+						1,
+						now,
+						"test-device-001",
+						"test-device-001",
+						now,
+						"local-default",
+					);
+
+				const url = "http://localhost/v1/ops?since=&limit=50&generation=3&snapshot_id=snapshot-3";
+				peer = createAuthenticatedSyncPeer(store, { url });
+				store.db
+					.prepare("UPDATE sync_peers SET projects_include_json = ? WHERE peer_device_id = ?")
+					.run('["proj-a"]', peer.peerDeviceId);
+
+				const res = await syncApp.request(url, { headers: peer.headers });
+
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body.ops).toEqual([]);
+				expect(body.skipped).toBe(1);
+				expect(body.next_cursor).toBe("2026-01-01T00:00:00Z|local-default-outbound-op");
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
 		it("serves paginated memory bootstrap pages with tombstones", async () => {
 			const { syncApp, getStore, cleanup } = createTestApp();
 			const peerDir = mkdtempSync(join(tmpdir(), "codemem-sync-peer-test-"));
@@ -2845,6 +2904,72 @@ describe("viewer-server", () => {
 						.prepare("SELECT title, scope_id FROM memory_items WHERE import_key = ?")
 						.get("legacy-push-key"),
 				).toMatchObject({ title: "Legacy push title", scope_id: null });
+			} finally {
+				peer?.cleanup();
+				cleanup();
+			}
+		});
+
+		it("does not outbound-scope-filter scoped pushes from unsupported peers", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			let peer: ReturnType<typeof createAuthenticatedSyncPeer> | null = null;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const url = "http://localhost/v1/ops";
+				peer = createAuthenticatedSyncPeer(store, { url, method: "POST" });
+				const now = "2026-01-01T00:00:00Z";
+				const payload = {
+					sync_capability: "unsupported",
+					ops: [
+						{
+							op_id: "unsupported-scoped-push-op",
+							entity_type: "memory_item",
+							entity_id: "unsupported-scoped-push-key",
+							op_type: "upsert",
+							payload_json: JSON.stringify({
+								body_text: "Unsupported scoped push body",
+								created_at: now,
+								kind: "discovery",
+								scope_id: "local-default",
+								title: "Unsupported scoped push title",
+								updated_at: now,
+								visibility: "shared",
+							}),
+							clock_rev: 1,
+							clock_updated_at: now,
+							clock_device_id: peer.peerDeviceId,
+							device_id: peer.peerDeviceId,
+							created_at: now,
+							scope_id: "local-default",
+						},
+					],
+				};
+				const bodyText = JSON.stringify(payload);
+				const bodyBytes = Buffer.from(bodyText);
+				const headers = buildAuthHeaders({
+					deviceId: peer.peerDeviceId,
+					method: "POST",
+					url,
+					bodyBytes,
+					keysDir: peer.keysDir,
+				});
+
+				const res = await syncApp.request(url, {
+					method: "POST",
+					headers: { ...headers, "Content-Type": "application/json" },
+					body: bodyText,
+				});
+
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as Record<string, unknown>;
+				expect(body).toMatchObject({ applied: 1, skipped: 0, rejected: 0 });
+				expect(
+					store.db
+						.prepare("SELECT title, scope_id FROM memory_items WHERE import_key = ?")
+						.get("unsupported-scoped-push-key"),
+				).toMatchObject({ title: "Unsupported scoped push title", scope_id: "local-default" });
 			} finally {
 				peer?.cleanup();
 				cleanup();

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -45,6 +45,7 @@ import {
 	DEFAULT_TIME_WINDOW_S,
 	ensureDeviceIdentity,
 	extractReplicationOps,
+	filterReplicationOpsForSyncWithStatus,
 	fingerprintPublicKey,
 	getCoordinatorGroupPreference,
 	getSemanticIndexDiagnostics,
@@ -59,19 +60,15 @@ import {
 	negotiateSyncCapability,
 	normalizeSyncCapability,
 	parseSyncScopeRequest,
-	peerCanSyncPrivateOpByPersonalScopeGrant,
 	personalScopeGrantStatusForPeer,
 	readCoordinatorSyncConfig,
 	recordNonce,
 	rejectInboundScopeFailures,
-	replicationOpRequiresPersonalScopeAuthorization,
 	requestJson,
 	runSyncPass,
 	SYNC_SCOPE_QUERY_PARAM,
 	schema,
-	syncProjectAllowedByFilters,
 	syncScopeResetRequiredPayload,
-	syncVisibilityAllowed,
 	updatePeerAddresses,
 	upsertCoordinatorGroupPreference,
 	verifySignature,
@@ -725,69 +722,6 @@ function claimLegacyDeviceAsSelf(store: MemoryStore, originDeviceId: string): nu
 	return Number(result.changes ?? 0);
 }
 
-function parseOpPayload(op: { payload_json: string | null }): Record<string, unknown> | null {
-	if (!op.payload_json || !String(op.payload_json).trim()) return null;
-	try {
-		const parsed = JSON.parse(op.payload_json) as unknown;
-		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
-		return parsed as Record<string, unknown>;
-	} catch {
-		return null;
-	}
-}
-
-function parseMetadataObject(raw: string | null): Record<string, unknown> {
-	if (!raw?.trim()) return {};
-	try {
-		const parsed = JSON.parse(raw) as unknown;
-		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
-		return parsed as Record<string, unknown>;
-	} catch {
-		return {};
-	}
-}
-
-function lookupExistingMemoryFilterContext(
-	store: MemoryStore,
-	importKey: string,
-): { payload: Record<string, unknown>; project: string | null } | null {
-	const row = store.db
-		.prepare(
-			`SELECT
-				m.actor_id,
-				m.metadata_json,
-				m.visibility,
-				m.workspace_id,
-				m.workspace_kind,
-				s.project
-			 FROM memory_items m
-			 LEFT JOIN sessions s ON s.id = m.session_id
-			 WHERE m.import_key = ?
-			 LIMIT 1`,
-		)
-		.get(importKey) as
-		| {
-				actor_id: string | null;
-				metadata_json: string | null;
-				project: string | null;
-				visibility: string | null;
-				workspace_id: string | null;
-				workspace_kind: string | null;
-		  }
-		| undefined;
-	if (!row) return null;
-	return {
-		payload: {
-			actor_id: row.actor_id,
-			metadata_json: parseMetadataObject(row.metadata_json),
-			visibility: row.visibility,
-			workspace_id: row.workspace_id,
-			workspace_kind: row.workspace_kind,
-		},
-		project: typeof row.project === "string" && row.project.trim() ? row.project.trim() : null,
-	};
-}
-
 function redactCoordinatorStatus(
 	coordinator: Record<string, unknown>,
 	showDiag: boolean,
@@ -1048,61 +982,15 @@ async function acceptDiscoveredPeer(
 function filterOpsForPeer(
 	store: MemoryStore,
 	peerDeviceId: string,
+	localDeviceId: string | null,
 	ops: ReplicationOp[],
+	options: { applyScopeFilter?: boolean } = {},
 ): { allowed: ReplicationOp[]; skipped: number } {
-	const filters = readPeerProjectFilters(store, peerDeviceId);
-	const allowed: ReplicationOp[] = [];
-	let skipped = 0;
-	for (const op of ops) {
-		if (op.entity_type !== "memory_item") {
-			allowed.push(op);
-			continue;
-		}
-		const payload = parseOpPayload(op);
-		const requiresPersonalScope = replicationOpRequiresPersonalScopeAuthorization(op, payload);
-		if (op.op_type === "delete" && payload == null) {
-			const existing = lookupExistingMemoryFilterContext(store, op.entity_id);
-			if (!existing) {
-				if (requiresPersonalScope || filters.include.length > 0 || filters.exclude.length > 0) {
-					skipped++;
-					continue;
-				}
-				allowed.push(op);
-				continue;
-			}
-			const deleteRequiresPersonalScope = replicationOpRequiresPersonalScopeAuthorization(
-				op,
-				existing.payload,
-			);
-			if (
-				(deleteRequiresPersonalScope || !syncVisibilityAllowed(existing.payload)) &&
-				!peerCanSyncPrivateOpByPersonalScopeGrant(store.db, op, existing.payload, peerDeviceId)
-			) {
-				skipped++;
-				continue;
-			}
-			if (!syncProjectAllowedByFilters(existing.project, filters)) {
-				skipped++;
-				continue;
-			}
-			allowed.push(op);
-			continue;
-		}
-		if (
-			(requiresPersonalScope || !syncVisibilityAllowed(payload)) &&
-			!peerCanSyncPrivateOpByPersonalScopeGrant(store.db, op, payload, peerDeviceId)
-		) {
-			skipped++;
-			continue;
-		}
-		const project = payload && typeof payload.project === "string" ? payload.project : null;
-		if (!syncProjectAllowedByFilters(project, filters)) {
-			skipped++;
-			continue;
-		}
-		allowed.push(op);
-	}
-	return { allowed, skipped };
+	const [allowed, , skipped] = filterReplicationOpsForSyncWithStatus(store.db, ops, peerDeviceId, {
+		localDeviceId,
+		applyScopeFilter: options.applyScopeFilter,
+	});
+	return { allowed, skipped: skipped?.skipped_count ?? 0 };
 }
 
 // ---------------------------------------------------------------------------
@@ -1414,7 +1302,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				);
 			}
 			const { ops, nextCursor, boundary } = result;
-			const filtered = filterOpsForPeer(store, peerDeviceId, ops);
+			const filtered = filterOpsForPeer(store, peerDeviceId, localDeviceId, ops);
 			return c.json({
 				reset_required: false,
 				sync_capability: LOCAL_SYNC_CAPABILITY,
@@ -1598,7 +1486,12 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 			LOCAL_SYNC_CAPABILITY,
 			normalizeSyncCapability(body.sync_capability),
 		);
-		const filtered = filterOpsForPeer(store, peerDeviceId, normalizedOps);
+		// Inbound POSTs still use legacy visibility/project filters, but must not run
+		// the outbound scope gate. Unsupported peers deliberately bypass strict inbound
+		// scope rejection during rollout, so outbound filtering would silently drop data.
+		const filtered = filterOpsForPeer(store, peerDeviceId, localDeviceId, normalizedOps, {
+			applyScopeFilter: false,
+		});
 		// Scope validation runs against the full signed batch so bad scoped ops cannot
 		// evade fail-closed rejection by also tripping peer project filters.
 		const rejected = rejectInboundScopeFailures(store.db, normalizedOps, localDeviceId, {


### PR DESCRIPTION
## Description
Fixes the PR #1014 review finding where inbound POST `/v1/ops` reused the outbound Sharing-domain scope gate before applying peer pushes. Inbound pushes now keep legacy visibility/project filtering, but skip only the outbound scope gate so unsupported or mixed-version peers with scoped op metadata are not silently dropped with a 200 response.

Strict inbound scope rejection still runs against the full signed batch for non-legacy peers before any mutation.

## Type of Change
<!-- Mark the relevant option(s) with an "x" -->

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
<!-- Describe how you tested these changes -->

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Additional validation:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "does not outbound-scope-filter scoped pushes from unsupported peers"` failed before the fix and passed after it.
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "does not outbound-scope-filter scoped pushes from unsupported peers|filters pushed ops by peer project filters before applying|hard-rejects inbound scope failures"`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts`
- `pnpm exec vitest run packages/core/src/sync-replication.test.ts`
- `pnpm exec vitest run packages/core/src/sync-pass.test.ts`
- `pnpm run tsc && pnpm run lint && pnpm run test` (90 files, 1720 tests)
- Snyk Code scan from the repo root: 40 existing findings in unrelated tests/scripts; no touched-file findings from this change.
- CodeReviewer: no blockers.

## Checklist
<!-- Mark completed items with an "x" -->

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced