### PR TITLE
feat: surface scope-rejection diagnostics in sync API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -554,7 +554,11 @@ export type {
 	ApplyReplicationOpsOptions,
 	ApplyResult,
 	InboundScopeRejection,
+	InboundScopeRejectionPeerSummary,
 	InboundScopeRejectionReason,
+	InboundScopeRejectionRecord,
+	InboundScopeRejectionSummaryOptions,
+	ListInboundScopeRejectionsOptions,
 } from "./sync-replication.js";
 export {
 	applyReplicationOps,
@@ -570,6 +574,7 @@ export {
 	getSyncResetState,
 	hasUnsyncedSharedMemoryChanges,
 	isNewerClock,
+	listInboundScopeRejections,
 	loadMemorySnapshotPageForPeer,
 	loadReplicationOpsForPeer,
 	loadReplicationOpsSince,
@@ -584,6 +589,7 @@ export {
 	replicationOpRequiresPersonalScopeAuthorization,
 	setReplicationCursor,
 	setSyncResetState,
+	summarizeInboundScopeRejections,
 	syncProjectAllowedByFilters,
 	syncVisibilityAllowed,
 } from "./sync-replication.js";

--- a/packages/core/src/sync-replication.test.ts
+++ b/packages/core/src/sync-replication.test.ts
@@ -16,6 +16,7 @@ import {
 	getSyncResetState,
 	hasUnsyncedSharedMemoryChanges,
 	isNewerClock,
+	listInboundScopeRejections,
 	loadMemorySnapshotPageForPeer,
 	loadReplicationOpsForPeer,
 	loadReplicationOpsSince,
@@ -26,6 +27,7 @@ import {
 	recordReplicationOp,
 	setReplicationCursor,
 	setSyncResetState,
+	summarizeInboundScopeRejections,
 } from "./sync-replication.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import type { ReplicationOp } from "./types.js";
@@ -3458,5 +3460,134 @@ describe("bootstrap snapshot round-trip parity", () => {
 		expect(applied.narrative).toBe("Bootstrap narrative");
 		expect(applied.user_prompt_id).toBe(99);
 		expect(applied.prompt_number).toBe(3);
+	});
+});
+
+describe("inbound scope rejection diagnostics", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	function insertRejection(
+		peerDeviceId: string | null,
+		reason: string,
+		opts: {
+			opId?: string;
+			scopeId?: string | null;
+			createdAt?: string;
+			entityId?: string;
+		} = {},
+	): void {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS sync_scope_rejections (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				peer_device_id TEXT,
+				op_id TEXT NOT NULL,
+				entity_type TEXT NOT NULL,
+				entity_id TEXT NOT NULL,
+				scope_id TEXT,
+				reason TEXT NOT NULL,
+				created_at TEXT NOT NULL
+			);
+		`);
+		db.prepare(
+			`INSERT INTO sync_scope_rejections(
+				peer_device_id, op_id, entity_type, entity_id, scope_id, reason, created_at
+			 ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		).run(
+			peerDeviceId,
+			opts.opId ?? `op-${Math.random().toString(36).slice(2, 8)}`,
+			"memory_item",
+			opts.entityId ?? "key:test",
+			opts.scopeId ?? "acme-work",
+			reason,
+			opts.createdAt ?? "2026-01-02T00:00:00Z",
+		);
+	}
+
+	it("returns an empty summary when the rejection log table does not exist", () => {
+		expect(summarizeInboundScopeRejections(db)).toEqual([]);
+		expect(listInboundScopeRejections(db)).toEqual([]);
+	});
+
+	it("groups rejection counts by peer and reason", () => {
+		insertRejection("dev-remote-a", "missing_scope", { createdAt: "2026-01-02T00:00:00Z" });
+		insertRejection("dev-remote-a", "missing_scope", { createdAt: "2026-01-02T00:00:01Z" });
+		insertRejection("dev-remote-a", "stale_epoch", { createdAt: "2026-01-02T00:00:02Z" });
+		insertRejection("dev-remote-b", "scope_mismatch", { createdAt: "2026-01-02T00:00:03Z" });
+
+		const summaries = summarizeInboundScopeRejections(db);
+		const byPeer = new Map(summaries.map((entry) => [entry.peer_device_id, entry]));
+
+		expect(byPeer.get("dev-remote-a")).toEqual({
+			peer_device_id: "dev-remote-a",
+			total: 3,
+			by_reason: { missing_scope: 2, stale_epoch: 1 },
+			last_at: "2026-01-02T00:00:02Z",
+		});
+		expect(byPeer.get("dev-remote-b")).toEqual({
+			peer_device_id: "dev-remote-b",
+			total: 1,
+			by_reason: { scope_mismatch: 1 },
+			last_at: "2026-01-02T00:00:03Z",
+		});
+	});
+
+	it("filters rejections by peer and time window", () => {
+		insertRejection("dev-remote-a", "missing_scope", { createdAt: "2026-01-01T00:00:00Z" });
+		insertRejection("dev-remote-a", "stale_epoch", { createdAt: "2026-01-03T00:00:00Z" });
+		insertRejection("dev-remote-b", "stale_epoch", { createdAt: "2026-01-03T00:00:00Z" });
+
+		const recent = summarizeInboundScopeRejections(db, {
+			sinceIso: "2026-01-02T00:00:00Z",
+			peerDeviceId: "dev-remote-a",
+		});
+		expect(recent).toEqual([
+			{
+				peer_device_id: "dev-remote-a",
+				total: 1,
+				by_reason: { stale_epoch: 1 },
+				last_at: "2026-01-03T00:00:00Z",
+			},
+		]);
+	});
+
+	it("lists rejection records newest-first without exposing payloads", () => {
+		insertRejection("dev-remote", "missing_scope", {
+			opId: "op-old",
+			scopeId: null,
+			createdAt: "2026-01-02T00:00:00Z",
+		});
+		insertRejection("dev-remote", "stale_epoch", {
+			opId: "op-new",
+			scopeId: "acme-work",
+			createdAt: "2026-01-03T00:00:00Z",
+		});
+
+		const records = listInboundScopeRejections(db, { peerDeviceId: "dev-remote", limit: 10 });
+		expect(records.map((r) => r.op_id)).toEqual(["op-new", "op-old"]);
+		for (const record of records) {
+			expect(record).not.toHaveProperty("payload_json");
+			expect(record.peer_device_id).toBe("dev-remote");
+		}
+	});
+
+	it("clamps the list limit to a sensible maximum", () => {
+		for (let i = 0; i < 10; i++) {
+			insertRejection("dev-remote", "missing_scope", {
+				opId: `op-${i}`,
+				createdAt: `2026-01-02T00:00:${String(i).padStart(2, "0")}Z`,
+			});
+		}
+		expect(listInboundScopeRejections(db, { limit: 3 })).toHaveLength(3);
+		expect(listInboundScopeRejections(db, { limit: 0 })).toHaveLength(1);
+		expect(listInboundScopeRejections(db, { limit: 10_000 }).length).toBeLessThanOrEqual(500);
 	});
 });

--- a/packages/core/src/sync-replication.ts
+++ b/packages/core/src/sync-replication.ts
@@ -2266,6 +2266,163 @@ export function rejectInboundScopeFailures(
 	return result;
 }
 
+/** Aggregate counts of recorded inbound-scope rejections per peer device. */
+export interface InboundScopeRejectionPeerSummary {
+	peer_device_id: string | null;
+	total: number;
+	by_reason: Partial<Record<InboundScopeRejectionReason, number>>;
+	last_at: string | null;
+}
+
+export interface InboundScopeRejectionSummaryOptions {
+	/** ISO timestamp; rejections older than this are ignored. */
+	sinceIso?: string;
+	/** Optional: only summarize rejections recorded for this peer. */
+	peerDeviceId?: string | null;
+}
+
+/**
+ * Read-only summary of recorded inbound-scope rejections grouped by peer.
+ * Pure aggregate over the rejection log — never reads payloads (the log
+ * does not store any). Used by the sync API to render reason-code
+ * breakdowns without exposing op contents.
+ */
+export function summarizeInboundScopeRejections(
+	db: Database,
+	options: InboundScopeRejectionSummaryOptions = {},
+): InboundScopeRejectionPeerSummary[] {
+	if (!syncScopeRejectionsTableExists(db)) return [];
+	const params: unknown[] = [];
+	const filters: string[] = [];
+	if (options.sinceIso) {
+		filters.push(`created_at >= ?`);
+		params.push(options.sinceIso);
+	}
+	if (options.peerDeviceId !== undefined) {
+		const id = cleanText(options.peerDeviceId);
+		if (id === null) {
+			filters.push(`peer_device_id IS NULL`);
+		} else {
+			filters.push(`peer_device_id = ?`);
+			params.push(id);
+		}
+	}
+	const where = filters.length ? `WHERE ${filters.join(" AND ")}` : "";
+	const rows = db
+		.prepare(
+			`SELECT peer_device_id, reason, COUNT(*) AS count, MAX(created_at) AS last_at
+			   FROM sync_scope_rejections
+			   ${where}
+			  GROUP BY peer_device_id, reason`,
+		)
+		.all(...params) as Array<{
+		peer_device_id: string | null;
+		reason: string;
+		count: number;
+		last_at: string | null;
+	}>;
+
+	const summaries = new Map<string, InboundScopeRejectionPeerSummary>();
+	for (const row of rows) {
+		const key = row.peer_device_id ?? "";
+		let entry = summaries.get(key);
+		if (!entry) {
+			entry = {
+				peer_device_id: row.peer_device_id ?? null,
+				total: 0,
+				by_reason: {},
+				last_at: null,
+			};
+			summaries.set(key, entry);
+		}
+		const reason = row.reason as InboundScopeRejectionReason;
+		const count = Number(row.count ?? 0);
+		entry.by_reason[reason] = (entry.by_reason[reason] ?? 0) + count;
+		entry.total += count;
+		if (row.last_at && (!entry.last_at || row.last_at > entry.last_at)) {
+			entry.last_at = row.last_at;
+		}
+	}
+	return Array.from(summaries.values());
+}
+
+export interface InboundScopeRejectionRecord extends InboundScopeRejection {
+	id: number;
+	created_at: string;
+}
+
+export interface ListInboundScopeRejectionsOptions {
+	peerDeviceId?: string | null;
+	sinceIso?: string;
+	limit?: number;
+}
+
+/**
+ * List recently recorded inbound-scope rejections (newest first). Each row
+ * is metadata only — op id, entity ref, scope id, reason, timestamp — and
+ * never includes op payloads (the log does not store them).
+ */
+export function listInboundScopeRejections(
+	db: Database,
+	options: ListInboundScopeRejectionsOptions = {},
+): InboundScopeRejectionRecord[] {
+	if (!syncScopeRejectionsTableExists(db)) return [];
+	const params: unknown[] = [];
+	const filters: string[] = [];
+	if (options.sinceIso) {
+		filters.push(`created_at >= ?`);
+		params.push(options.sinceIso);
+	}
+	if (options.peerDeviceId !== undefined) {
+		const id = cleanText(options.peerDeviceId);
+		if (id === null) {
+			filters.push(`peer_device_id IS NULL`);
+		} else {
+			filters.push(`peer_device_id = ?`);
+			params.push(id);
+		}
+	}
+	const where = filters.length ? `WHERE ${filters.join(" AND ")}` : "";
+	const limit = Math.max(1, Math.min(options.limit ?? 100, 500));
+	const rows = db
+		.prepare(
+			`SELECT id, peer_device_id, op_id, entity_type, entity_id, scope_id, reason, created_at
+			   FROM sync_scope_rejections
+			   ${where}
+			  ORDER BY created_at DESC, id DESC
+			  LIMIT ?`,
+		)
+		.all(...params, limit) as Array<{
+		id: number;
+		peer_device_id: string | null;
+		op_id: string;
+		entity_type: string;
+		entity_id: string;
+		scope_id: string | null;
+		reason: string;
+		created_at: string;
+	}>;
+	return rows.map((row) => ({
+		id: Number(row.id),
+		peer_device_id: row.peer_device_id ?? null,
+		op_id: row.op_id,
+		entity_type: row.entity_type,
+		entity_id: row.entity_id,
+		scope_id: row.scope_id ?? null,
+		reason: row.reason as InboundScopeRejectionReason,
+		created_at: row.created_at,
+	}));
+}
+
+function syncScopeRejectionsTableExists(db: Database): boolean {
+	const row = db
+		.prepare(
+			`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sync_scope_rejections' LIMIT 1`,
+		)
+		.get();
+	return Boolean(row);
+}
+
 const LEGACY_IMPORT_KEY_OLD_RE = /^legacy:memory_item:(.+)$/;
 
 /**

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -19,10 +19,12 @@ import { PeerScopeCollapsible } from "../peer-scope-collapsible";
 import { openSyncConfirmDialog } from "../sync-dialogs";
 import {
 	derivePeerDirection,
+	derivePeerScopeRejectionsView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
 	type PeerDirection,
 	type PeerLike,
+	type PeerScopeRejectionsSummary,
 } from "../view-model";
 import { renderIntoSyncMount } from "./render-root";
 import { SyncEmptyState } from "./sync-empty-state";
@@ -110,6 +112,7 @@ type SyncPeer = PeerLike & {
 	addresses?: unknown[];
 	claimed_local_actor?: boolean;
 	project_scope?: PeerScopeLike;
+	scope_rejections?: PeerScopeRejectionsSummary;
 	discovered_via_coordinator_id?: string | null;
 	discovered_via_group_id?: string | null;
 };
@@ -176,6 +179,7 @@ function SyncPeerCard({
 	const trustSummary = derivePeerTrustSummary(peer);
 	const directionHint = DIRECTION_GLYPH[derivePeerDirection(peer)];
 	const peerStatus: SyncPeerStatus = peer.status || {};
+	const scopeRejections = derivePeerScopeRejectionsView(peer);
 	const scope = peer.project_scope || {};
 	const includeList = listText(scope.include);
 	const excludeList = listText(scope.exclude);
@@ -457,6 +461,14 @@ function SyncPeerCard({
 							{pendingScopeReview ? (
 								<span className="badge actor-badge">Needs scope review</span>
 							) : null}
+							{scopeRejections.badgeLabel ? (
+								<span
+									className="badge badge-offline"
+									title="Inbound ops rejected by the sharing-domain scope gate. Expand for reason codes."
+								>
+									{scopeRejections.badgeLabel}
+								</span>
+							) : null}
 							{peer.discovered_via_group_id ? (
 								<span
 									className="badge actor-badge"
@@ -543,6 +555,34 @@ function SyncPeerCard({
 								lastPingAt ? `Ping: ${formatTimestamp(lastPingAt)}` : "Ping: never",
 							].join(" · ")}
 						</div>
+
+						{scopeRejections.total > 0 ? (
+							<div
+								className="peer-scope-rejections"
+								data-peer-rejection-count={scopeRejections.total}
+							>
+								<div className="peer-scope-summary">Sharing-rule rejections (24h)</div>
+								<div className="peer-meta">
+									Inbound ops the local fail-closed gate refused. Diagnostics never expose op
+									payloads.
+								</div>
+								<ul className="peer-scope-rejections-list">
+									{scopeRejections.reasons.map((entry) => (
+										<li key={entry.reason}>
+											<span className="peer-scope-rejection-label">{entry.label}</span>
+											<span className="peer-scope-rejection-count">
+												{entry.count.toLocaleString()}
+											</span>
+										</li>
+									))}
+								</ul>
+								{scopeRejections.lastAt ? (
+									<div className="peer-meta">
+										Last rejected {formatTimestamp(scopeRejections.lastAt)}
+									</div>
+								) : null}
+							</div>
+						) : null}
 
 						<div className="peer-scope-summary">Who this device belongs to</div>
 						<div className="peer-meta">{assignmentSummary}</div>

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	deriveCoordinatorApprovalSummary,
 	deriveDuplicatePeople,
+	derivePeerScopeRejectionsView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
 	deriveSyncViewModel,
@@ -136,6 +137,43 @@ describe("derivePeerTrustSummary", () => {
 		expect(
 			derivePeerTrustSummary({ status: { sync_status: "ok", peer_state: "online" } }).state,
 		).toBe("mutual-trust");
+	});
+});
+
+describe("derivePeerScopeRejectionsView", () => {
+	it("returns an empty view when nothing has been rejected", () => {
+		expect(derivePeerScopeRejectionsView({}).total).toBe(0);
+		expect(derivePeerScopeRejectionsView({}).badgeLabel).toBeNull();
+		expect(
+			derivePeerScopeRejectionsView({
+				scope_rejections: { total: 0, by_reason: {} },
+			}).total,
+		).toBe(0);
+	});
+
+	it("renders human-readable labels and orders reasons by count desc", () => {
+		const view = derivePeerScopeRejectionsView({
+			scope_rejections: {
+				total: 4,
+				by_reason: { missing_scope: 1, stale_epoch: 3 },
+				last_at: "2026-05-03T00:00:00Z",
+			},
+		});
+		expect(view.total).toBe(4);
+		expect(view.badgeLabel).toBe("4 sync rejections");
+		expect(view.reasons.map((entry) => [entry.reason, entry.count])).toEqual([
+			["stale_epoch", 3],
+			["missing_scope", 1],
+		]);
+		expect(view.reasons[0]?.label).toBe("Stale or revoked membership");
+		expect(view.lastAt).toBe("2026-05-03T00:00:00Z");
+	});
+
+	it("uses singular badge label when there is exactly one rejection", () => {
+		const view = derivePeerScopeRejectionsView({
+			scope_rejections: { total: 1, by_reason: { missing_scope: 1 } },
+		});
+		expect(view.badgeLabel).toBe("1 sync rejection");
 	});
 });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -14,8 +14,10 @@ export {
 export { deviceNeedsFriendlyName, resolveFriendlyDeviceName } from "./view-model/device-names";
 export {
 	derivePeerDirection,
+	derivePeerScopeRejectionsView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
+	type PeerScopeRejectionsView,
 } from "./view-model/peer-status";
 export {
 	deriveDuplicatePeople,
@@ -28,6 +30,8 @@ export {
 	type PeerDirection,
 	type PeerLike,
 	type PeerRecentOps,
+	type PeerScopeRejectionReason,
+	type PeerScopeRejectionsSummary,
 	SYNC_TERMINOLOGY,
 	type UiCoordinatorApprovalState,
 	type UiCoordinatorApprovalSummary,

--- a/packages/ui/src/tabs/sync/view-model/peer-status.ts
+++ b/packages/ui/src/tabs/sync/view-model/peer-status.ts
@@ -9,7 +9,13 @@ import {
 	isUnauthorizedPeerError,
 	peerErrorText,
 } from "./internal";
-import type { PeerDirection, PeerLike, UiPeerTrustSummary, UiSyncStatus } from "./types";
+import type {
+	PeerDirection,
+	PeerLike,
+	PeerScopeRejectionReason,
+	UiPeerTrustSummary,
+	UiSyncStatus,
+} from "./types";
 
 // Classify a peer's recent sync direction from observed traffic:
 // ↕ bidirectional when both directions have flowed in the recent window,
@@ -92,5 +98,52 @@ export function derivePeerTrustSummary(peer: PeerLike): UiPeerTrustSummary {
 		description:
 			"This device is already trusted here. Finish setup on the other device before sync can run both ways.",
 		isWarning: false,
+	};
+}
+
+const SCOPE_REJECTION_REASON_LABELS: Record<PeerScopeRejectionReason, string> = {
+	missing_scope: "Missing scope id",
+	sender_not_member: "Sender not a scope member",
+	receiver_not_member: "Receiver not a scope member",
+	stale_epoch: "Stale or revoked membership",
+	scope_mismatch: "Scope mismatch",
+};
+
+export interface PeerScopeRejectionsView {
+	total: number;
+	badgeLabel: string | null;
+	reasons: Array<{ reason: PeerScopeRejectionReason; label: string; count: number }>;
+	lastAt: string | null;
+}
+
+/**
+ * Translate the per-peer scope-rejection summary returned by /api/sync/peers
+ * into a UI-ready view. Returns total=0 when nothing has been rejected, in
+ * which case the row should not display a rejection badge or detail block.
+ */
+export function derivePeerScopeRejectionsView(peer: PeerLike): PeerScopeRejectionsView {
+	const summary = peer?.scope_rejections;
+	const total = Math.max(0, Number(summary?.total ?? 0));
+	if (!summary || total === 0) {
+		return { total: 0, badgeLabel: null, reasons: [], lastAt: null };
+	}
+	const reasons: Array<{ reason: PeerScopeRejectionReason; label: string; count: number }> = [];
+	for (const [reason, count] of Object.entries(summary.by_reason ?? {})) {
+		const numeric = Math.max(0, Number(count ?? 0));
+		if (numeric === 0) continue;
+		const key = reason as PeerScopeRejectionReason;
+		reasons.push({
+			reason: key,
+			label: SCOPE_REJECTION_REASON_LABELS[key] ?? reason,
+			count: numeric,
+		});
+	}
+	reasons.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+	const badgeLabel = total === 1 ? "1 sync rejection" : `${total.toLocaleString()} sync rejections`;
+	return {
+		total,
+		badgeLabel,
+		reasons,
+		lastAt: summary.last_at ?? null,
 	};
 }

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -100,6 +100,19 @@ export type PeerRecentOps = {
 
 export type PeerDirection = "bidirectional" | "publishing" | "subscribed" | "none";
 
+export type PeerScopeRejectionReason =
+	| "missing_scope"
+	| "sender_not_member"
+	| "receiver_not_member"
+	| "stale_epoch"
+	| "scope_mismatch";
+
+export interface PeerScopeRejectionsSummary {
+	total?: number;
+	by_reason?: Partial<Record<PeerScopeRejectionReason, number>>;
+	last_at?: string | null;
+}
+
 export interface PeerLike {
 	peer_device_id?: string;
 	name?: string;
@@ -109,6 +122,7 @@ export interface PeerLike {
 	actor_id?: string;
 	status?: SyncPeerStatusLike;
 	recent_ops?: PeerRecentOps;
+	scope_rejections?: PeerScopeRejectionsSummary;
 }
 
 export interface DiscoveredDeviceLike {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -1687,6 +1687,166 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("surfaces inbound scope-rejection summary per peer", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				const _warmup = await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db
+					.prepare(
+						`INSERT INTO sync_peers (
+							peer_device_id, name, claimed_local_actor, created_at
+						) VALUES (?, ?, 0, ?)`,
+					)
+					.run("peer-rej", "Peer Rej", new Date().toISOString());
+				store.db.exec(`
+					CREATE TABLE IF NOT EXISTS sync_scope_rejections (
+						id INTEGER PRIMARY KEY AUTOINCREMENT,
+						peer_device_id TEXT,
+						op_id TEXT NOT NULL,
+						entity_type TEXT NOT NULL,
+						entity_id TEXT NOT NULL,
+						scope_id TEXT,
+						reason TEXT NOT NULL,
+						created_at TEXT NOT NULL
+					);
+				`);
+				const recent = new Date().toISOString();
+				const insert = store.db.prepare(
+					`INSERT INTO sync_scope_rejections(
+						peer_device_id, op_id, entity_type, entity_id, scope_id, reason, created_at
+					 ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				);
+				insert.run(
+					"peer-rej",
+					"op-1",
+					"memory_item",
+					"key:a",
+					"acme-work",
+					"missing_scope",
+					recent,
+				);
+				insert.run(
+					"peer-rej",
+					"op-2",
+					"memory_item",
+					"key:b",
+					"acme-work",
+					"missing_scope",
+					recent,
+				);
+				insert.run("peer-rej", "op-3", "memory_item", "key:c", "acme-work", "stale_epoch", recent);
+
+				const res = await app.request("/api/sync/peers");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					items: Array<{
+						peer_device_id: string;
+						scope_rejections: {
+							total: number;
+							by_reason: Record<string, number>;
+							last_at: string | null;
+						};
+					}>;
+				};
+				const peer = body.items.find((p) => p.peer_device_id === "peer-rej");
+				expect(peer?.scope_rejections.total).toBe(3);
+				expect(peer?.scope_rejections.by_reason).toEqual({
+					missing_scope: 2,
+					stale_epoch: 1,
+				});
+				expect(peer?.scope_rejections.last_at).toBe(recent);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("returns scope-rejection records for a peer without exposing payloads", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				const _warmup = await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				store.db.exec(`
+					CREATE TABLE IF NOT EXISTS sync_scope_rejections (
+						id INTEGER PRIMARY KEY AUTOINCREMENT,
+						peer_device_id TEXT,
+						op_id TEXT NOT NULL,
+						entity_type TEXT NOT NULL,
+						entity_id TEXT NOT NULL,
+						scope_id TEXT,
+						reason TEXT NOT NULL,
+						created_at TEXT NOT NULL
+					);
+				`);
+				const insert = store.db.prepare(
+					`INSERT INTO sync_scope_rejections(
+						peer_device_id, op_id, entity_type, entity_id, scope_id, reason, created_at
+					 ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				);
+				const now = new Date().toISOString();
+				insert.run("peer-x", "op-old", "memory_item", "key:1", "acme", "missing_scope", now);
+				insert.run("peer-x", "op-new", "memory_item", "key:2", "acme", "stale_epoch", now);
+				insert.run("peer-y", "op-other", "memory_item", "key:3", "other", "scope_mismatch", now);
+
+				const res = await app.request("/api/sync/peers/peer-x/scope-rejections");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					peer_device_id: string;
+					summary: { total: number; by_reason: Record<string, number> };
+					items: Array<Record<string, unknown>>;
+				};
+				expect(body.peer_device_id).toBe("peer-x");
+				expect(body.summary.total).toBe(2);
+				expect(body.summary.by_reason).toEqual({
+					missing_scope: 1,
+					stale_epoch: 1,
+				});
+				expect(body.items).toHaveLength(2);
+				for (const item of body.items) {
+					expect(item).not.toHaveProperty("payload_json");
+					expect(item.peer_device_id).toBe("peer-x");
+				}
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("rejects scope-rejections lookup with missing peer id", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const res = await app.request("/api/sync/peers/%20/scope-rejections");
+				expect(res.status).toBe(400);
+				const body = (await res.json()) as { error: string };
+				expect(body.error).toBe("missing_peer_device_id");
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("clamps absurd sinceMinutes values instead of throwing on Date overflow", async () => {
+			const { app, cleanup } = createTestApp();
+			try {
+				const _warmup = await app.request("/api/stats");
+				// Number.MAX_SAFE_INTEGER minutes would push the computed
+				// timestamp past the JS Date range and make toISOString()
+				// throw RangeError → 500. The handler must clamp first.
+				const res = await app.request(
+					`/api/sync/peers/peer-x/scope-rejections?sinceMinutes=${Number.MAX_SAFE_INTEGER}`,
+				);
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					summary: { total: number };
+					items: unknown[];
+				};
+				expect(body.summary.total).toBe(0);
+				expect(body.items).toEqual([]);
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("treats naive sync timestamps as UTC", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -50,8 +50,10 @@ import {
 	getCoordinatorGroupPreference,
 	getSemanticIndexDiagnostics,
 	getSyncResetState,
+	type InboundScopeRejectionPeerSummary,
 	LOCAL_SYNC_CAPABILITY,
 	listCoordinatorJoinRequests,
+	listInboundScopeRejections,
 	listMaintenanceJobs,
 	loadMemorySnapshotPageForPeer,
 	loadReplicationOpsForPeer,
@@ -68,6 +70,7 @@ import {
 	runSyncPass,
 	SYNC_SCOPE_QUERY_PARAM,
 	schema,
+	summarizeInboundScopeRejections,
 	syncScopeResetRequiredPayload,
 	updatePeerAddresses,
 	upsertCoordinatorGroupPreference,
@@ -1023,9 +1026,11 @@ function mapPeerRow(
 	row: Record<string, unknown>,
 	showDiag: boolean,
 	recentOpsByPeer?: Map<string, { in: number; out: number }>,
+	scopeRejectionsByPeer?: Map<string, InboundScopeRejectionPeerSummary>,
 ): Record<string, unknown> {
 	const peerId = String(row.peer_device_id ?? "");
 	const recentOps = recentOpsByPeer?.get(peerId) ?? { in: 0, out: 0 };
+	const scopeRejections = scopeRejectionsByPeer?.get(peerId);
 	return {
 		peer_device_id: row.peer_device_id,
 		name: row.name,
@@ -1044,6 +1049,11 @@ function mapPeerRow(
 			...currentProjectScope(row, readPeerProjectFilters(store, String(row.peer_device_id ?? ""))),
 		},
 		recent_ops: { in: recentOps.in, out: recentOps.out },
+		scope_rejections: {
+			total: scopeRejections?.total ?? 0,
+			by_reason: scopeRejections?.by_reason ?? {},
+			last_at: scopeRejections?.last_at ?? null,
+		},
 		discovered_via_coordinator_id:
 			typeof row.discovered_via_coordinator_id === "string"
 				? row.discovered_via_coordinator_id
@@ -1051,6 +1061,22 @@ function mapPeerRow(
 		discovered_via_group_id:
 			typeof row.discovered_via_group_id === "string" ? row.discovered_via_group_id : null,
 	};
+}
+
+const SYNC_SCOPE_REJECTION_WINDOW_SECONDS = 24 * 60 * 60;
+
+function recentScopeRejectionsByPeer(
+	store: MemoryStore,
+): Map<string, InboundScopeRejectionPeerSummary> {
+	const cutoff = new Date(Date.now() - SYNC_SCOPE_REJECTION_WINDOW_SECONDS * 1000).toISOString();
+	const summaries = summarizeInboundScopeRejections(store.db, { sinceIso: cutoff });
+	const map = new Map<string, InboundScopeRejectionPeerSummary>();
+	for (const summary of summaries) {
+		const id = String(summary.peer_device_id ?? "").trim();
+		if (!id) continue;
+		map.set(id, summary);
+	}
+	return map;
 }
 
 // Aggregate ops_in / ops_out across recent successful sync_attempts per peer.
@@ -1710,8 +1736,11 @@ export function syncRoutes(
 				() => store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[],
 			);
 			const recentOpsByPeer = traceSync("recentPeerOps", () => recentPeerOps(store));
+			const scopeRejectionsByPeer = traceSync("recentScopeRejectionsByPeer", () =>
+				recentScopeRejectionsByPeer(store),
+			);
 			const peersItems = peerRows.map((row) => {
-				const peer = mapPeerRow(store, row, showDiag, recentOpsByPeer);
+				const peer = mapPeerRow(store, row, showDiag, recentOpsByPeer, scopeRejectionsByPeer);
 				peer.status = peerStatus(peer);
 				return peer;
 			});
@@ -1851,10 +1880,55 @@ export function syncRoutes(
 			const showDiag = queryBool(c.req.query("includeDiagnostics"));
 			const rows = store.db.prepare(PEERS_QUERY).all() as Record<string, unknown>[];
 			const recentOpsByPeer = recentPeerOps(store);
+			const scopeRejectionsByPeer = recentScopeRejectionsByPeer(store);
 			// Use deduplicated mapPeerRow helper (fix #4)
-			const peers = rows.map((row) => mapPeerRow(store, row, showDiag, recentOpsByPeer));
+			const peers = rows.map((row) =>
+				mapPeerRow(store, row, showDiag, recentOpsByPeer, scopeRejectionsByPeer),
+			);
 			return c.json({ items: peers, redacted: !showDiag });
 		}
+	});
+
+	// GET /api/sync/peers/:peer_device_id/scope-rejections
+	//
+	// Recent scope-rejection records produced by the inbound fail-closed gate.
+	// Each row is metadata only — op id, entity ref, scope id, reason code,
+	// timestamp. The rejection log never stores op payloads, so this endpoint
+	// can never leak inbound payload contents regardless of diagnostics state.
+	app.get("/api/sync/peers/:peer_device_id/scope-rejections", (c) => {
+		const store = getStore();
+		const peerDeviceId = String(c.req.param("peer_device_id") || "").trim();
+		if (!peerDeviceId) return c.json({ error: "missing_peer_device_id" }, 400);
+		const limit = queryInt(c.req.query("limit"), 100);
+		if (limit <= 0) return c.json({ error: "invalid_limit" }, 400);
+		const sinceMinutesRaw = queryInt(c.req.query("sinceMinutes"), 24 * 60);
+		// Cap at ~10 years so a hostile or fat-fingered query cannot push the
+		// computed timestamp past the Date range and turn toISOString() into
+		// a 500. Anything older than 10 years is effectively "all rejections".
+		const SINCE_MINUTES_MAX = 10 * 365 * 24 * 60;
+		const sinceMinutes = Math.min(Math.max(sinceMinutesRaw, 0), SINCE_MINUTES_MAX);
+		const sinceIso =
+			sinceMinutes > 0 ? new Date(Date.now() - sinceMinutes * 60_000).toISOString() : undefined;
+		const records = listInboundScopeRejections(store.db, {
+			peerDeviceId,
+			sinceIso,
+			limit,
+		});
+		const summaries = summarizeInboundScopeRejections(store.db, {
+			peerDeviceId,
+			sinceIso,
+		});
+		const summary = summaries[0] ?? {
+			peer_device_id: peerDeviceId,
+			total: 0,
+			by_reason: {},
+			last_at: null,
+		};
+		return c.json({
+			peer_device_id: peerDeviceId,
+			summary,
+			items: records,
+		});
 	});
 
 	// GET /api/sync/actors


### PR DESCRIPTION
## Description

Read from the `sync_scope_rejections` log produced by the inbound fail-closed gate and expose reason-code summaries per peer plus a recent-rejections list — without touching the gate itself. Toggling diagnostics on or off has no effect on the underlying rejection enforcement.

- Core: `summarizeInboundScopeRejections` and `listInboundScopeRejections` aggregate the rejection log (metadata only — the log never stores op payloads)
- Viewer-server: `/api/sync/peers` items now include `scope_rejections: { total, by_reason, last_at }` over a 24h window; new `GET /api/sync/peers/:peer_device_id/scope-rejections` returns recent rejection records
- UI: `derivePeerScopeRejectionsView` renders a peer-card badge plus a "Sharing-rule rejections (24h)" drawer block listing reasons by count

## Type of Change

- [x] 🚀 Feature (new functionality)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes — core helper aggregation, viewer-server endpoint shape, UI view-model derivation
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced