### PR TITLE
feat: log inject pack success metrics from Claude hook

### DIFF
--- a/packages/cli/src/commands/claude-hook-ingest-spool.ts
+++ b/packages/cli/src/commands/claude-hook-ingest-spool.ts
@@ -18,7 +18,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { logHookFailure } from "./claude-hook-plugin-log.js";
+import { logHookEvent } from "./claude-hook-plugin-log.js";
 
 const DEFAULT_LOCK_TTL_S = 300;
 const DEFAULT_LOCK_GRACE_S = 2;
@@ -268,7 +268,7 @@ export function spoolPayload(payload: Record<string, unknown>): boolean {
 	try {
 		mkdirSync(dir, { recursive: true });
 	} catch {
-		logHookFailure("codemem claude-hook-ingest failed to create spool dir");
+		logHookEvent("codemem claude-hook-ingest failed to create spool dir");
 		return false;
 	}
 
@@ -278,7 +278,7 @@ export function spoolPayload(payload: Record<string, unknown>): boolean {
 	try {
 		writeFileSync(tmpPath, payloadText, { encoding: "utf8" });
 	} catch {
-		logHookFailure("codemem claude-hook-ingest failed to allocate spool temp file");
+		logHookEvent("codemem claude-hook-ingest failed to allocate spool temp file");
 		return false;
 	}
 
@@ -292,10 +292,10 @@ export function spoolPayload(payload: Record<string, unknown>): boolean {
 		} catch {
 			// best-effort
 		}
-		logHookFailure("codemem claude-hook-ingest failed to spool payload");
+		logHookEvent("codemem claude-hook-ingest failed to spool payload");
 		return false;
 	}
-	logHookFailure(`codemem claude-hook-ingest spooled payload: ${finalPath}`);
+	logHookEvent(`codemem claude-hook-ingest spooled payload: ${finalPath}`);
 	return true;
 }
 
@@ -337,7 +337,7 @@ export function recoverStaleTmpSpool(ttlSeconds: number): void {
 		const recoveredPath = join(dir, recoveredName);
 		try {
 			renameSync(tmpPath, recoveredPath);
-			logHookFailure(
+			logHookEvent(
 				`codemem claude-hook-ingest recovered stale temp spool payload: ${recoveredPath}`,
 			);
 		} catch {
@@ -357,7 +357,7 @@ function quarantineSpoolEntry(dir: string, name: string, reason: string): void {
 	const quarantineName = `.bad-${reason}-${Date.now()}-${randomInt(1000, 10000)}-${name}`;
 	try {
 		renameSync(sourcePath, join(dir, quarantineName));
-		logHookFailure(
+		logHookEvent(
 			`codemem claude-hook-ingest quarantined corrupt spool payload (${reason}): ${quarantineName}`,
 		);
 	} catch {
@@ -365,9 +365,7 @@ function quarantineSpoolEntry(dir: string, name: string, reason: string): void {
 		// entry must not stay in the active queue.
 		try {
 			unlinkSync(sourcePath);
-			logHookFailure(
-				`codemem claude-hook-ingest dropped corrupt spool payload (${reason}): ${name}`,
-			);
+			logHookEvent(`codemem claude-hook-ingest dropped corrupt spool payload (${reason}): ${name}`);
 		} catch {
 			// best-effort
 		}
@@ -420,7 +418,7 @@ export async function drainSpool(handler: SpoolHandler): Promise<SpoolDrainResul
 		} catch {
 			// Genuine I/O failure — leave the file alone so the next drain
 			// can retry, and surface the failure to the plugin log.
-			logHookFailure(`codemem claude-hook-ingest failed to read spooled payload: ${path}`);
+			logHookEvent(`codemem claude-hook-ingest failed to read spooled payload: ${path}`);
 			result.failed++;
 			continue;
 		}
@@ -456,7 +454,7 @@ export async function drainSpool(handler: SpoolHandler): Promise<SpoolDrainResul
 				// best-effort
 			}
 		} else {
-			logHookFailure(`codemem claude-hook-ingest failed processing spooled payload: ${path}`);
+			logHookEvent(`codemem claude-hook-ingest failed processing spooled payload: ${path}`);
 			result.failed++;
 		}
 	}

--- a/packages/cli/src/commands/claude-hook-ingest.ts
+++ b/packages/cli/src/commands/claude-hook-ingest.ts
@@ -36,7 +36,7 @@ import {
 	spoolPayload,
 	withClaudeHookIngestLock,
 } from "./claude-hook-ingest-spool.js";
-import { logHookFailure } from "./claude-hook-plugin-log.js";
+import { logHookEvent } from "./claude-hook-plugin-log.js";
 import { trackHookSessionState } from "./claude-hook-session-state.js";
 
 type IngestVia = "http" | "direct" | "spool" | "spool_lock_busy";
@@ -97,16 +97,16 @@ async function tryHttpIngest(
 		try {
 			body = await res.json();
 		} catch {
-			logHookFailure("codemem claude-hook-ingest HTTP accepted with invalid response body");
+			logHookEvent("codemem claude-hook-ingest HTTP accepted with invalid response body");
 			return { ok: false, inserted: 0, skipped: 0 };
 		}
 		if (body == null || typeof body !== "object" || Array.isArray(body)) {
-			logHookFailure("codemem claude-hook-ingest HTTP accepted with invalid response type");
+			logHookEvent("codemem claude-hook-ingest HTTP accepted with invalid response type");
 			return { ok: false, inserted: 0, skipped: 0 };
 		}
 		const obj = body as Record<string, unknown>;
 		if (typeof obj.inserted !== "number" || typeof obj.skipped !== "number") {
-			logHookFailure("codemem claude-hook-ingest HTTP accepted with unexpected response body");
+			logHookEvent("codemem claude-hook-ingest HTTP accepted with unexpected response body");
 			return { ok: false, inserted: 0, skipped: 0 };
 		}
 		return { ok: true, inserted: obj.inserted, skipped: obj.skipped };
@@ -226,7 +226,7 @@ async function flushBoundaryRawEvents(
 	try {
 		observer = new ObserverClient();
 	} catch (err) {
-		logHookFailure(
+		logHookEvent(
 			`codemem claude-hook-ingest boundary flush observer init failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
 		return;
@@ -236,7 +236,7 @@ async function flushBoundaryRawEvents(
 	try {
 		store = new MemoryStore(dbPath);
 	} catch (err) {
-		logHookFailure(
+		logHookEvent(
 			`codemem claude-hook-ingest boundary flush store init failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
 		return;
@@ -256,7 +256,7 @@ async function flushBoundaryRawEvents(
 			},
 		);
 	} catch (err) {
-		logHookFailure(
+		logHookEvent(
 			`codemem claude-hook-ingest boundary flush raw events failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
 	} finally {
@@ -304,7 +304,7 @@ export async function ingestClaudeHookPayload(
 		try {
 			return { ok: true, result: directIngest(queued, getDbPath()) };
 		} catch (err) {
-			logHookFailure(
+			logHookEvent(
 				`codemem claude-hook-ingest direct fallback failed: ${err instanceof Error ? err.message : String(err)}`,
 			);
 			return { ok: false };
@@ -321,14 +321,14 @@ export async function ingestClaudeHookPayload(
 		try {
 			directIngest(payload, getDbPath());
 		} catch (err) {
-			logHookFailure(
+			logHookEvent(
 				`codemem claude-hook-ingest boundary flush direct write failed: ${err instanceof Error ? err.message : String(err)}`,
 			);
 		}
 		try {
 			await boundaryFlush(payload, getDbPath());
 		} catch (err) {
-			logHookFailure(
+			logHookEvent(
 				`codemem claude-hook-ingest boundary flush failed: ${err instanceof Error ? err.message : String(err)}`,
 			);
 		}
@@ -357,7 +357,7 @@ export async function ingestClaudeHookPayload(
 				// Another invocation is already draining; nothing to do.
 				return;
 			}
-			logHookFailure(
+			logHookEvent(
 				`codemem claude-hook-ingest backlog drain failed: ${err instanceof Error ? err.message : String(err)}`,
 			);
 		}
@@ -404,13 +404,13 @@ export async function ingestClaudeHookPayload(
 				return { inserted: 0, skipped: 0, via: "spool" as const };
 			}
 
-			logHookFailure("codemem claude-hook-ingest failed: fallback and spool failed");
+			logHookEvent("codemem claude-hook-ingest failed: fallback and spool failed");
 			throw new Error("claude-hook-ingest: fallback and spool both failed");
 		});
 	} catch (err) {
 		if (!(err instanceof LockBusyError)) throw err;
 
-		logHookFailure("codemem claude-hook-ingest lock busy; trying unlocked fallback");
+		logHookEvent("codemem claude-hook-ingest lock busy; trying unlocked fallback");
 		const direct = tryDirectFallback(payload);
 		if (direct.ok) {
 			return { ...direct.result, via: "direct" };
@@ -418,7 +418,7 @@ export async function ingestClaudeHookPayload(
 		if (spoolPayload(payload)) {
 			return { inserted: 0, skipped: 0, via: "spool_lock_busy" };
 		}
-		logHookFailure("codemem claude-hook-ingest failed: unlocked fallback and spool failed");
+		logHookEvent("codemem claude-hook-ingest failed: unlocked fallback and spool failed");
 		throw err;
 	}
 }

--- a/packages/cli/src/commands/claude-hook-inject.contract.test.ts
+++ b/packages/cli/src/commands/claude-hook-inject.contract.test.ts
@@ -274,23 +274,28 @@ describe("claude-hook-inject contract fixtures", () => {
 		}
 
 		try {
+			const toPack = (text: string) => ({
+				packText: text,
+				items: text ? 1 : 0,
+				packTokens: text ? text.length : 0,
+			});
 			const buildLocalPack = deps?.buildLocalPack
 				? async (
 						context: string,
 						project: string | null,
 						dbPath: string,
-						workingSetPaths?: string[],
+						workingSetPaths: string[] = [],
 					) => {
 						const result = deps.buildLocalPack?.(context, project, dbPath, workingSetPaths);
-						return await Promise.resolve(result ?? "");
+						return toPack(await Promise.resolve(result ?? ""));
 					}
-				: async () => "";
+				: async () => toPack("");
 			const httpPack = deps?.httpPack
 				? async (context: string, project: string | null, maxTimeMs?: number) => {
 						const result = deps.httpPack?.(context, project, maxTimeMs);
-						return await Promise.resolve(result ?? "");
+						return toPack(await Promise.resolve(result ?? ""));
 					}
-				: async () => "";
+				: async () => toPack("");
 
 			const result = await buildClaudeHookInjection(
 				payload,

--- a/packages/cli/src/commands/claude-hook-inject.test.ts
+++ b/packages/cli/src/commands/claude-hook-inject.test.ts
@@ -1,9 +1,19 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildClaudeHookInjection, claudeHookInjectCommand } from "./claude-hook-inject.js";
+import {
+	buildClaudeHookInjection,
+	claudeHookInjectCommand,
+	type PackResult,
+} from "./claude-hook-inject.js";
 import { saveSessionState, statePathForSession } from "./claude-hook-session-state.js";
+
+const pack = (packText: string, items = 0, packTokens = 0): PackResult => ({
+	packText,
+	items,
+	packTokens,
+});
 
 describe("claude-hook-inject command", () => {
 	let stateDir: string;
@@ -55,7 +65,7 @@ describe("claude-hook-inject command", () => {
 					expect(project).toBe("codemem");
 					expect(dbPath).toBe("/tmp/test.sqlite");
 					expect(workingSetPaths).toEqual([]);
-					return "## Summary\n[1] (decision) Auth fix";
+					return pack("## Summary\n[1] (decision) Auth fix", 1, 42);
 				},
 				httpPack: async () => {
 					throw new Error("http fallback should not run");
@@ -97,7 +107,7 @@ describe("claude-hook-inject command", () => {
 						expect(context).toBe("continue sync work codemem");
 						expect(project).toBe("codemem");
 						expect(maxTimeMs).toBe(7000);
-						return "## Timeline\n[4] (feature) Sync continuation";
+						return pack("## Timeline\n[4] (feature) Sync continuation", 1, 53);
 					},
 					resolveDb: () => "/tmp/test.sqlite",
 				},
@@ -181,8 +191,8 @@ describe("claude-hook-inject command", () => {
 				},
 				{},
 				{
-					buildLocalPack: async () => "12345678901234567890",
-					httpPack: async () => "",
+					buildLocalPack: async () => pack("12345678901234567890"),
+					httpPack: async () => pack(""),
 					resolveDb: () => "/tmp/test.sqlite",
 				},
 			);
@@ -215,8 +225,8 @@ describe("claude-hook-inject command", () => {
 			},
 			{},
 			{
-				buildLocalPack: async () => "Remember to run targeted tests.",
-				httpPack: async () => "",
+				buildLocalPack: async () => pack("Remember to run targeted tests."),
+				httpPack: async () => pack(""),
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
@@ -238,8 +248,8 @@ describe("claude-hook-inject command", () => {
 			},
 			{},
 			{
-				buildLocalPack: async () => "## Summary\nmemory pack",
-				httpPack: async () => "",
+				buildLocalPack: async () => pack("## Summary\nmemory pack"),
+				httpPack: async () => pack(""),
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
@@ -281,7 +291,7 @@ describe("claude-hook-inject command", () => {
 						"packages/cli/src/b.ts",
 						"packages/cli/src/c.ts",
 					]);
-					return "## Memory pack";
+					return pack("## Memory pack");
 				},
 				httpPack: async () => {
 					throw new Error("http fallback should not run");
@@ -309,8 +319,8 @@ describe("claude-hook-inject command", () => {
 				},
 				{},
 				{
-					buildLocalPack: async () => "memory_one memory_two memory_three memory_four",
-					httpPack: async () => "",
+					buildLocalPack: async () => pack("memory_one memory_two memory_three memory_four"),
+					httpPack: async () => pack(""),
 					resolveDb: () => "/tmp/test.sqlite",
 				},
 			);
@@ -384,14 +394,115 @@ describe("claude-hook-inject command", () => {
 					// equal post-normalization).
 					expect(context).not.toContain("\n");
 					expect(context).toBe("fix the auth callback flow codemem");
-					return "## Pack";
+					return pack("## Pack");
 				},
-				httpPack: async () => "",
+				httpPack: async () => pack(""),
 				resolveDb: () => "/tmp/test.sqlite",
 			},
 		);
 
 		expect(result.hookSpecificOutput?.additionalContext).toBe("## Pack");
+	});
+
+	it("logs inject.pack.ok with metrics on local pack success", async () => {
+		await buildClaudeHookInjection(
+			{
+				hook_event_name: "UserPromptSubmit",
+				session_id: "sess-metrics",
+				prompt: "ship the feature",
+				cwd: "/tmp/codemem",
+				project: "codemem",
+			},
+			{},
+			{
+				buildLocalPack: async () => pack("## Summary\nmemory pack body", 4, 137),
+				httpPack: async () => {
+					throw new Error("http fallback should not run");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		const log = readFileSync(pluginLogPath, "utf8");
+		const line = log.trim().split("\n").pop() ?? "";
+		expect(line).toContain("inject.pack.ok");
+		expect(line).toContain("source=claude");
+		expect(line).toContain("origin=local");
+		expect(line).toContain("items=4");
+		expect(line).toContain("pack_tokens=137");
+		expect(line).toContain('project="codemem"');
+		expect(line).toContain("empty=false");
+		expect(line).toMatch(/query_len=\d+/);
+	});
+
+	it("logs origin=http when local pack fails and http fallback succeeds", async () => {
+		const originalFallback = process.env.CODEMEM_INJECT_HTTP_FALLBACK;
+		process.env.CODEMEM_INJECT_HTTP_FALLBACK = "1";
+		try {
+			await buildClaudeHookInjection(
+				{
+					hook_event_name: "UserPromptSubmit",
+					session_id: "sess-http-origin",
+					prompt: "fallback path",
+					cwd: "/tmp/codemem",
+				},
+				{},
+				{
+					buildLocalPack: async () => {
+						throw new Error("local pack failed");
+					},
+					httpPack: async () => pack("## Timeline\nfallback pack", 2, 64),
+					resolveDb: () => "/tmp/test.sqlite",
+				},
+			);
+
+			const log = readFileSync(pluginLogPath, "utf8");
+			const okLine =
+				log
+					.trim()
+					.split("\n")
+					.reverse()
+					.find((l) => l.includes("inject.pack.ok")) ?? "";
+			expect(okLine).toContain("origin=http");
+			expect(okLine).toContain("items=2");
+			expect(okLine).toContain("pack_tokens=64");
+			expect(okLine).toContain("empty=false");
+		} finally {
+			if (originalFallback === undefined) delete process.env.CODEMEM_INJECT_HTTP_FALLBACK;
+			else process.env.CODEMEM_INJECT_HTTP_FALLBACK = originalFallback;
+		}
+	});
+
+	it("logs inject.pack.ok with empty=true when no pack is produced", async () => {
+		const originalFallback = process.env.CODEMEM_INJECT_HTTP_FALLBACK;
+		process.env.CODEMEM_INJECT_HTTP_FALLBACK = "0";
+		try {
+			await buildClaudeHookInjection(
+				{
+					hook_event_name: "UserPromptSubmit",
+					session_id: "sess-empty",
+					prompt: "no memories yet",
+					cwd: "/tmp/codemem",
+				},
+				{},
+				{
+					buildLocalPack: async () => pack(""),
+					httpPack: async () => {
+						throw new Error("http fallback disabled");
+					},
+					resolveDb: () => "/tmp/test.sqlite",
+				},
+			);
+
+			const log = readFileSync(pluginLogPath, "utf8");
+			const line = log.trim().split("\n").pop() ?? "";
+			expect(line).toContain("inject.pack.ok");
+			expect(line).toContain("empty=true");
+			expect(line).toContain("items=0");
+		} finally {
+			if (originalFallback === undefined) delete process.env.CODEMEM_INJECT_HTTP_FALLBACK;
+			else process.env.CODEMEM_INJECT_HTTP_FALLBACK = originalFallback;
+		}
 	});
 
 	it("returns continue without additionalContext when all generation paths fail", async () => {
@@ -409,7 +520,7 @@ describe("claude-hook-inject command", () => {
 					buildLocalPack: async () => {
 						throw new Error("local pack failed");
 					},
-					httpPack: async () => "",
+					httpPack: async () => pack(""),
 					resolveDb: () => "/tmp/test.sqlite",
 				},
 			);

--- a/packages/cli/src/commands/claude-hook-inject.ts
+++ b/packages/cli/src/commands/claude-hook-inject.ts
@@ -2,7 +2,7 @@ import { MemoryStore, resolveDbPath, resolveHookProject } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
 import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
-import { logHookFailure } from "./claude-hook-plugin-log.js";
+import { logHookEvent } from "./claude-hook-plugin-log.js";
 import {
 	buildInjectQuery,
 	normalizePromptText,
@@ -27,8 +27,18 @@ const HOOK_EVENT_NAME = "UserPromptSubmit" as const;
 
 type InjectOpts = DbOpts;
 
+export type PackResult = {
+	packText: string;
+	items: number;
+	packTokens: number;
+};
+
+const EMPTY_PACK: PackResult = { packText: "", items: 0, packTokens: 0 };
+
 type HttpPackResponse = {
 	pack_text?: string;
+	items?: unknown;
+	metrics?: { pack_tokens?: unknown };
 };
 
 type InjectDeps = {
@@ -114,7 +124,7 @@ async function buildLocalPack(
 	project: string | null,
 	dbPath: string,
 	workingSetPaths: string[] = [],
-): Promise<string> {
+): Promise<PackResult> {
 	const store = new MemoryStore(dbPath);
 	try {
 		const limit = parsePositiveInt(process.env.CODEMEM_INJECT_LIMIT, 8);
@@ -127,7 +137,12 @@ async function buildLocalPack(
 			filters.working_set_paths = workingSetPaths;
 		}
 		const pack = await store.buildMemoryPackAsync(context, limit, budget, filters);
-		return String(pack.pack_text ?? "").trim();
+		const packText = String(pack.pack_text ?? "").trim();
+		const items = Array.isArray(pack.items) ? pack.items.length : 0;
+		const packTokens = Number.isFinite(Number(pack.metrics?.pack_tokens))
+			? Number(pack.metrics.pack_tokens)
+			: 0;
+		return { packText, items, packTokens };
 	} finally {
 		store.close();
 	}
@@ -137,7 +152,8 @@ async function tryHttpPack(
 	context: string,
 	project: string | null,
 	maxTimeMs = DEFAULT_HTTP_MAX_TIME_S * 1000,
-): Promise<string> {
+): Promise<PackResult> {
+	const empty: PackResult = { packText: "", items: 0, packTokens: 0 };
 	const host = process.env.CODEMEM_VIEWER_HOST || DEFAULT_VIEWER_HOST;
 	const port = parsePositiveInt(process.env.CODEMEM_VIEWER_PORT, DEFAULT_VIEWER_PORT);
 	const url = new URL(`http://${host}:${port}/api/pack`);
@@ -156,12 +172,17 @@ async function tryHttpPack(
 	try {
 		const res = await fetch(url, { signal: controller.signal });
 		if (!res.ok) {
-			return "";
+			return empty;
 		}
 		const body = (await res.json()) as HttpPackResponse;
-		return String(body.pack_text ?? "").trim();
+		const packText = String(body.pack_text ?? "").trim();
+		const items = Array.isArray(body.items) ? body.items.length : 0;
+		const packTokens = Number.isFinite(Number(body.metrics?.pack_tokens))
+			? Number(body.metrics?.pack_tokens)
+			: 0;
+		return { packText, items, packTokens };
 	} catch {
-		return "";
+		return empty;
 	} finally {
 		clearTimeout(timeout);
 	}
@@ -206,26 +227,48 @@ export async function buildClaudeHookInjection(
 	const httpMaxTimeMs =
 		parsePositiveInt(process.env.CODEMEM_INJECT_HTTP_MAX_TIME_S, DEFAULT_HTTP_MAX_TIME_S) * 1000;
 
-	let additionalContext = "";
+	let pack: PackResult = EMPTY_PACK;
+	let origin: "local" | "http" | "none" = "none";
 	try {
 		const dbPath = resolveDb(resolveDbOpt(opts));
-		additionalContext = await buildPack(query, project, dbPath, workingSetPaths);
+		pack = await buildPack(query, project, dbPath, workingSetPaths);
+		if (pack.packText) {
+			origin = "local";
+		}
 	} catch (err) {
-		additionalContext = "";
-		logHookFailure(
+		logHookEvent(
 			`codemem claude-hook-inject local pack failed: ${err instanceof Error ? err.message : String(err)}`,
 		);
 	}
 
-	if (!additionalContext && envNotDisabled(process.env.CODEMEM_INJECT_HTTP_FALLBACK || "1")) {
-		// tryHttpPack swallows its own network errors and returns "" on
-		// failure; don't wrap it here so tests that throw from a stub mock
-		// still surface as failures (the existing
-		// "should not run" assertions rely on this).
-		additionalContext = await httpPack(query, project, httpMaxTimeMs);
+	if (!pack.packText && envNotDisabled(process.env.CODEMEM_INJECT_HTTP_FALLBACK || "1")) {
+		// tryHttpPack swallows its own network errors and returns an empty
+		// result on failure; don't wrap it here so tests that throw from a
+		// stub mock still surface as failures (the existing "should not run"
+		// assertions rely on this).
+		pack = await httpPack(query, project, httpMaxTimeMs);
+		if (pack.packText) {
+			origin = "http";
+		}
 	}
 
-	return continueResult(truncateAdditionalContext(additionalContext, maxChars));
+	// `empty` reflects retrieval, not post-truncation delivery, so the metric
+	// stays load-bearing for measuring whether the pipeline is producing
+	// memory candidates at all.
+	const fields = [
+		"inject.pack.ok",
+		"source=claude",
+		`origin=${origin}`,
+		`items=${pack.items}`,
+		`pack_tokens=${pack.packTokens}`,
+		`query_len=${query.length}`,
+		`empty=${pack.packText ? "false" : "true"}`,
+	];
+	if (project) {
+		fields.push(`project=${JSON.stringify(project)}`);
+	}
+	logHookEvent(fields.join(" "));
+	return continueResult(truncateAdditionalContext(pack.packText, maxChars));
 }
 
 const claudeHookInjectCmd = new Command("claude-hook-inject")

--- a/packages/cli/src/commands/claude-hook-plugin-log.test.ts
+++ b/packages/cli/src/commands/claude-hook-plugin-log.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { logHookFailure, pluginLogPath } from "./claude-hook-plugin-log.js";
+import { logHookEvent, pluginLogPath } from "./claude-hook-plugin-log.js";
 
 function slashPath(value: string): string {
 	return value.replace(/\\/g, "/");
@@ -54,13 +54,13 @@ describe("claude-hook-plugin-log", () => {
 		});
 	});
 
-	describe("logHookFailure", () => {
+	describe("logHookEvent", () => {
 		it("appends a timestamped line to the configured log path", () => {
 			const target = join(baseDir, "logs", "plugin.log");
 			process.env.CODEMEM_PLUGIN_LOG_PATH = target;
 
-			logHookFailure("first failure");
-			logHookFailure("second failure");
+			logHookEvent("first failure");
+			logHookEvent("second failure");
 
 			expect(existsSync(target)).toBe(true);
 			const content = readFileSync(target, "utf8");
@@ -73,7 +73,7 @@ describe("claude-hook-plugin-log", () => {
 		it("creates parent directories on first write", () => {
 			const target = join(baseDir, "deep", "nested", "plugin.log");
 			process.env.CODEMEM_PLUGIN_LOG_PATH = target;
-			logHookFailure("nested write");
+			logHookEvent("nested write");
 			expect(existsSync(target)).toBe(true);
 		});
 
@@ -83,7 +83,7 @@ describe("claude-hook-plugin-log", () => {
 			const blocker = join(baseDir, "blocker");
 			writeFileSync(blocker, "not a dir", "utf8");
 			process.env.CODEMEM_PLUGIN_LOG_PATH = join(blocker, "plugin.log");
-			expect(() => logHookFailure("should not throw")).not.toThrow();
+			expect(() => logHookEvent("should not throw")).not.toThrow();
 		});
 	});
 });

--- a/packages/cli/src/commands/claude-hook-plugin-log.ts
+++ b/packages/cli/src/commands/claude-hook-plugin-log.ts
@@ -1,7 +1,7 @@
 /**
- * Append-only plugin failure log used by both `claude-hook-inject` and
- * `claude-hook-ingest` to record errors that don't justify crashing the
- * hook command itself.
+ * Append-only plugin event log used by `claude-hook-inject` and
+ * `claude-hook-ingest` to record successes (e.g. `inject.pack.ok ...`) and
+ * errors that don't justify crashing the hook command itself.
  *
  * Behavior:
  * - Default log path is `~/.codemem/plugin.log`.
@@ -38,7 +38,7 @@ export function pluginLogPath(): string {
  * filesystem error is swallowed so a logging failure can never bubble up
  * into a Claude hook crash.
  */
-export function logHookFailure(message: string): void {
+export function logHookEvent(message: string): void {
 	const path = pluginLogPath();
 	try {
 		mkdirSync(dirname(path), { recursive: true });

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -1537,17 +1537,17 @@ export const OpencodeMemPlugin = async ({
       return "";
     }
     const metrics = parsePackMetrics(result.stdout);
-    if (debug) {
-      const itemCount = Number.isFinite(Number(metrics?.items))
-        ? Number(metrics.items)
-        : 0;
-      const packTokens = Number.isFinite(Number(metrics?.pack_tokens))
-        ? Number(metrics.pack_tokens)
-        : 0;
-      await logLine(
-        `inject.pack.ok query_len=${query ? query.length : 0} items=${itemCount} pack_tokens=${packTokens}`
-      );
-    }
+    // The pack JSON exposes the item count as `total_items`; `metrics.items`
+    // does not exist on that payload, so reading it would always log 0.
+    const itemCount = Number.isFinite(Number(metrics?.total_items))
+      ? Number(metrics.total_items)
+      : 0;
+    const packTokens = Number.isFinite(Number(metrics?.pack_tokens))
+      ? Number(metrics.pack_tokens)
+      : 0;
+    await logLine(
+      `inject.pack.ok source=opencode items=${itemCount} pack_tokens=${packTokens} query_len=${query ? query.length : 0}`
+    );
     if (metrics) {
       return {
         text: `[codemem context]\n${packText}`,


### PR DESCRIPTION
## Description

Adds a single-line `inject.pack.ok` event to `~/.codemem/plugin.log` per Claude `UserPromptSubmit` invocation, mirroring the line the OpenCode plugin already emits. The line carries `source`, `origin` (local|http|none), `items`, `pack_tokens`, `query_len`, `empty`, and (when set) `project`, so pack-injection frequency and HTTP-fallback usage are measurable across both surfaces.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Local pack and HTTP fallback are now typed (\`PackResult\`); test stubs use a small \`pack(text, items, tokens)\` helper. Two new tests cover \`origin=local\`, \`origin=http\`, and \`empty=true\` shapes. \`logHookFailure\` was renamed to \`logHookEvent\` since it now writes successes too; callers updated.

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced