### PR TITLE
feat: PreToolUse:Read file-context injection

### DIFF
--- a/packages/cli/src/commands/claude-hook-file-context.test.ts
+++ b/packages/cli/src/commands/claude-hook-file-context.test.ts
@@ -1,0 +1,310 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	buildClaudeFileContext,
+	claudeHookFileContextCommand,
+} from "./claude-hook-file-context.js";
+
+type Row = {
+	id: number;
+	session_id: number;
+	kind: string;
+	title: string;
+	subtitle: string | null;
+	body_text: string;
+	narrative: string | null;
+	confidence: number;
+	tags_text: string;
+	created_at: string;
+	updated_at: string;
+	files_read: string | null;
+	files_modified: string | null;
+	concepts: string | null;
+	metadata_json: string | null;
+};
+
+const baseRow = (overrides: Partial<Row>): Row => ({
+	id: 1,
+	session_id: 1,
+	kind: "decision",
+	title: "Untitled",
+	subtitle: null,
+	body_text: "",
+	narrative: null,
+	confidence: 0.5,
+	tags_text: "",
+	created_at: "2026-04-15T12:00:00Z",
+	updated_at: "2026-04-15T12:00:00Z",
+	files_read: null,
+	files_modified: null,
+	concepts: null,
+	metadata_json: null,
+	...overrides,
+});
+
+describe("claude-hook-file-context command", () => {
+	let tmp: string;
+	let pluginLogPath: string;
+	let originalPluginLogPath: string | undefined;
+	let originalProject: string | undefined;
+
+	beforeEach(() => {
+		originalPluginLogPath = process.env.CODEMEM_PLUGIN_LOG_PATH;
+		originalProject = process.env.CODEMEM_PROJECT;
+		tmp = mkdtempSync(join(tmpdir(), "codemem-cli-file-context-"));
+		pluginLogPath = join(tmp, "plugin.log");
+		process.env.CODEMEM_PLUGIN_LOG_PATH = pluginLogPath;
+		// Pin the project so resolveHookProject doesn't fall through to a
+		// directory-walk that climbs out of the tmp dir on CI machines.
+		process.env.CODEMEM_PROJECT = "codemem";
+	});
+
+	afterEach(() => {
+		if (originalPluginLogPath === undefined) delete process.env.CODEMEM_PLUGIN_LOG_PATH;
+		else process.env.CODEMEM_PLUGIN_LOG_PATH = originalPluginLogPath;
+		if (originalProject === undefined) delete process.env.CODEMEM_PROJECT;
+		else process.env.CODEMEM_PROJECT = originalProject;
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it("registers expected options and help text", () => {
+		const longs = claudeHookFileContextCommand.options.map((option) => option.long);
+		expect(longs).toContain("--db");
+		expect(longs).toContain("--db-path");
+		const help = claudeHookFileContextCommand.helpInformation();
+		expect(help).toContain("PreToolUse");
+	});
+
+	it("returns continue when payload has no file_path", async () => {
+		const result = await buildClaudeFileContext(
+			{ hook_event_name: "PreToolUse", tool_name: "Read", tool_input: {} },
+			{},
+			{
+				queryByFile: () => {
+					throw new Error("should not be called");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+				statFile: () => null,
+			},
+		);
+		expect(result).toEqual({ continue: true });
+	});
+
+	it("returns continue when file is below the size gate", async () => {
+		const file = join(tmp, "small.ts");
+		writeFileSync(file, "x");
+
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => {
+					throw new Error("should not be called for small files");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+		expect(result).toEqual({ continue: true });
+	});
+
+	it("returns continue when file is missing from disk", async () => {
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: join(tmp, "missing.ts") },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => {
+					throw new Error("should not be called for missing files");
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+		expect(result).toEqual({ continue: true });
+	});
+
+	it("returns continue when file mtime is newer than the newest observation", async () => {
+		const file = join(tmp, "stale.ts");
+		writeFileSync(file, "x".repeat(2000));
+		const fileMtimeMs = Date.now();
+		const observationMs = fileMtimeMs - 60_000;
+
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => [
+					baseRow({
+						id: 1,
+						kind: "decision",
+						created_at: new Date(observationMs).toISOString(),
+						files_modified: JSON.stringify(["stale.ts"]),
+					}),
+				],
+				resolveDb: () => "/tmp/test.sqlite",
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: fileMtimeMs }),
+			},
+		);
+
+		expect(result).toEqual({ continue: true });
+		const log = readFileSync(pluginLogPath, "utf8");
+		expect(log).toContain("file_context.skip reason=file_newer");
+	});
+
+	it("emits a PreToolUse additionalContext when observations exist and file is older", async () => {
+		const file = join(tmp, "auth.ts");
+		writeFileSync(file, "x".repeat(2000));
+		const fileMtimeMs = Date.now() - 86_400_000;
+		const newerObservationMs = fileMtimeMs + 3600_000;
+
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+				project: "codemem",
+			},
+			{},
+			{
+				queryByFile: (_db, path, project) => {
+					expect(path).toBe("auth.ts");
+					expect(project).toBe("codemem");
+					return [
+						baseRow({
+							id: 101,
+							session_id: 9,
+							kind: "decision",
+							title: "Switched auth callback to PKCE",
+							created_at: new Date(newerObservationMs).toISOString(),
+							files_modified: JSON.stringify(["auth.ts"]),
+						}),
+						baseRow({
+							id: 102,
+							session_id: 9, // same session — should dedupe
+							kind: "bugfix",
+							title: "Fixed redirect loop",
+							created_at: new Date(newerObservationMs - 60_000).toISOString(),
+							files_modified: JSON.stringify(["auth.ts"]),
+						}),
+						baseRow({
+							id: 103,
+							session_id: 10,
+							kind: "feature",
+							title: "Added refresh token rotation",
+							created_at: new Date(newerObservationMs - 7200_000).toISOString(),
+							files_modified: JSON.stringify(["auth.ts", "session.ts"]),
+						}),
+					];
+				},
+				resolveDb: () => "/tmp/test.sqlite",
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: fileMtimeMs }),
+			},
+		);
+
+		expect(result.hookSpecificOutput?.hookEventName).toBe("PreToolUse");
+		expect(result.hookSpecificOutput?.permissionDecision).toBe("allow");
+		const ctx = result.hookSpecificOutput?.additionalContext ?? "";
+		expect(ctx).toContain("auth.ts");
+		expect(ctx).toContain("memory.get_observations");
+		expect(ctx).toContain("Switched auth callback to PKCE");
+		expect(ctx).toContain("Added refresh token rotation");
+		// session 9 dedupe: only one of 101/102 surfaces (the most-recent kept).
+		expect(ctx.includes("Switched auth callback to PKCE")).toBe(true);
+		expect(ctx.includes("Fixed redirect loop")).toBe(false);
+
+		const log = readFileSync(pluginLogPath, "utf8");
+		expect(log).toContain("file_context.ok");
+	});
+
+	it("returns continue when CODEMEM_PLUGIN_IGNORE is truthy", async () => {
+		const original = process.env.CODEMEM_PLUGIN_IGNORE;
+		process.env.CODEMEM_PLUGIN_IGNORE = "1";
+		try {
+			const result = await buildClaudeFileContext(
+				{
+					hook_event_name: "PreToolUse",
+					tool_name: "Read",
+					tool_input: { file_path: "/abs/path.ts" },
+				},
+				{},
+				{
+					queryByFile: () => {
+						throw new Error("should not be called");
+					},
+					resolveDb: () => "/tmp/test.sqlite",
+					statFile: () => ({ sizeBytes: 9999, mtimeMs: 0 }),
+				},
+			);
+			expect(result).toEqual({ continue: true });
+		} finally {
+			if (original === undefined) delete process.env.CODEMEM_PLUGIN_IGNORE;
+			else process.env.CODEMEM_PLUGIN_IGNORE = original;
+		}
+	});
+
+	it("returns continue when CODEMEM_FILE_CONTEXT disables injection", async () => {
+		const original = process.env.CODEMEM_FILE_CONTEXT;
+		process.env.CODEMEM_FILE_CONTEXT = "0";
+		try {
+			const result = await buildClaudeFileContext(
+				{
+					hook_event_name: "PreToolUse",
+					tool_name: "Read",
+					tool_input: { file_path: "/abs/path.ts" },
+				},
+				{},
+				{
+					queryByFile: () => {
+						throw new Error("should not be called");
+					},
+					resolveDb: () => "/tmp/test.sqlite",
+					statFile: () => ({ sizeBytes: 9999, mtimeMs: 0 }),
+				},
+			);
+			expect(result).toEqual({ continue: true });
+		} finally {
+			if (original === undefined) delete process.env.CODEMEM_FILE_CONTEXT;
+			else process.env.CODEMEM_FILE_CONTEXT = original;
+		}
+	});
+
+	it("logs file_context.skip when the query returns no observations", async () => {
+		const file = join(tmp, "empty.ts");
+		writeFileSync(file, "x".repeat(2000));
+
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => [],
+				resolveDb: () => "/tmp/test.sqlite",
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: Date.now() - 86_400_000 }),
+			},
+		);
+
+		expect(result).toEqual({ continue: true });
+		const log = readFileSync(pluginLogPath, "utf8");
+		expect(log).toContain("file_context.skip reason=no_observations");
+	});
+});

--- a/packages/cli/src/commands/claude-hook-file-context.test.ts
+++ b/packages/cli/src/commands/claude-hook-file-context.test.ts
@@ -133,11 +133,13 @@ describe("claude-hook-file-context command", () => {
 		expect(result).toEqual({ continue: true });
 	});
 
-	it("returns continue when file mtime is newer than the newest observation", async () => {
+	it("annotates the timeline header when the file was modified after the newest observation", async () => {
 		const file = join(tmp, "stale.ts");
 		writeFileSync(file, "x".repeat(2000));
 		const fileMtimeMs = Date.now();
-		const observationMs = fileMtimeMs - 60_000;
+		// 30 minutes — outside the 5-minute fresh tolerance, so the
+		// staleness header should appear.
+		const observationMs = fileMtimeMs - 30 * 60 * 1000;
 
 		const result = await buildClaudeFileContext(
 			{
@@ -150,8 +152,9 @@ describe("claude-hook-file-context command", () => {
 			{
 				queryByFile: () => [
 					baseRow({
-						id: 1,
+						id: 7,
 						kind: "decision",
+						title: "Old decision about stale.ts",
 						created_at: new Date(observationMs).toISOString(),
 						files_modified: JSON.stringify(["stale.ts"]),
 					}),
@@ -161,9 +164,48 @@ describe("claude-hook-file-context command", () => {
 			},
 		);
 
-		expect(result).toEqual({ continue: true });
+		const ctx = result.hookSpecificOutput?.additionalContext ?? "";
+		expect(ctx).toContain("Heads up");
+		expect(ctx).toContain("Old decision about stale.ts");
 		const log = readFileSync(pluginLogPath, "utf8");
-		expect(log).toContain("file_context.skip reason=file_newer");
+		expect(log).toContain("file_context.ok");
+		expect(log).toContain("stale=true");
+	});
+
+	it("does not annotate when the file mtime is within the fresh tolerance window", async () => {
+		const file = join(tmp, "fresh.ts");
+		writeFileSync(file, "x".repeat(2000));
+		const fileMtimeMs = Date.now();
+		// 1 minute drift — under the 5-minute tolerance.
+		const observationMs = fileMtimeMs - 60 * 1000;
+
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => [
+					baseRow({
+						id: 11,
+						kind: "feature",
+						title: "Recent feature touching fresh.ts",
+						created_at: new Date(observationMs).toISOString(),
+						files_modified: JSON.stringify(["fresh.ts"]),
+					}),
+				],
+				resolveDb: () => "/tmp/test.sqlite",
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: fileMtimeMs }),
+			},
+		);
+
+		const ctx = result.hookSpecificOutput?.additionalContext ?? "";
+		expect(ctx).not.toContain("Heads up");
+		const log = readFileSync(pluginLogPath, "utf8");
+		expect(log).toContain("stale=false");
 	});
 
 	it("emits a PreToolUse additionalContext when observations exist and file is older", async () => {
@@ -282,6 +324,158 @@ describe("claude-hook-file-context command", () => {
 			if (original === undefined) delete process.env.CODEMEM_FILE_CONTEXT;
 			else process.env.CODEMEM_FILE_CONTEXT = original;
 		}
+	});
+
+	it("bypasses the size gate for small config files (json/toml/yaml)", async () => {
+		const file = join(tmp, "tsconfig.json");
+		writeFileSync(file, '{"x":1}');
+
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => [
+					baseRow({
+						id: 21,
+						kind: "decision",
+						title: "Switched moduleResolution to bundler",
+						created_at: new Date(Date.now() - 86_400_000).toISOString(),
+						files_modified: JSON.stringify(["tsconfig.json"]),
+					}),
+				],
+				resolveDb: () => "/tmp/test.sqlite",
+				statFile: () => ({ sizeBytes: 8, mtimeMs: Date.now() - 86_400_000 }),
+			},
+		);
+
+		const ctx = result.hookSpecificOutput?.additionalContext ?? "";
+		expect(ctx).toContain("Switched moduleResolution to bundler");
+	});
+
+	it("score-then-dedupe surfaces the highest-scoring observation per session", async () => {
+		const file = join(tmp, "auth.ts");
+		writeFileSync(file, "x".repeat(2000));
+		const fileMtimeMs = Date.now() - 86_400_000;
+		const obsMs = fileMtimeMs + 3600_000;
+
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => [
+					// Most-recent row from session 9 doesn't touch auth.ts —
+					// score 0. Older row from same session targets auth.ts —
+					// score 4. Score-then-dedupe should surface the older one.
+					baseRow({
+						id: 200,
+						session_id: 9,
+						kind: "discovery",
+						title: "Sprawling crawl, no auth focus",
+						created_at: new Date(obsMs).toISOString(),
+						files_modified: JSON.stringify(["a.ts", "b.ts", "c.ts", "d.ts", "e.ts"]),
+					}),
+					baseRow({
+						id: 201,
+						session_id: 9,
+						kind: "decision",
+						title: "Targeted auth fix",
+						created_at: new Date(obsMs - 3600_000).toISOString(),
+						files_modified: JSON.stringify(["auth.ts"]),
+					}),
+				],
+				resolveDb: () => "/tmp/test.sqlite",
+				statFile: () => ({ sizeBytes: 2000, mtimeMs: fileMtimeMs }),
+			},
+		);
+
+		const ctx = result.hookSpecificOutput?.additionalContext ?? "";
+		expect(ctx).toContain("Targeted auth fix");
+		expect(ctx).not.toContain("Sprawling crawl, no auth focus");
+	});
+
+	it("logs file_context.skip when the file is below the size gate and not a small-config bypass", async () => {
+		const file = join(tmp, "small.ts");
+		writeFileSync(file, "x");
+
+		await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => [],
+				resolveDb: () => "/tmp/test.sqlite",
+			},
+		);
+
+		const log = readFileSync(pluginLogPath, "utf8");
+		expect(log).toContain("file_context.skip reason=below_size_gate");
+	});
+
+	it("does not classify in-repo basenames starting with .. as outside cwd", async () => {
+		const file = join(tmp, "..hidden.json");
+		writeFileSync(file, '{"x":1}');
+
+		const result = await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: file },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => [
+					baseRow({
+						id: 31,
+						kind: "decision",
+						title: "Decision about ..hidden.json",
+						created_at: new Date(Date.now() - 86_400_000).toISOString(),
+						files_modified: JSON.stringify(["..hidden.json"]),
+					}),
+				],
+				resolveDb: () => "/tmp/test.sqlite",
+				statFile: () => ({ sizeBytes: 8, mtimeMs: Date.now() - 86_400_000 }),
+			},
+		);
+
+		const ctx = result.hookSpecificOutput?.additionalContext ?? "";
+		expect(ctx).toContain("Decision about ..hidden.json");
+		const log = readFileSync(pluginLogPath, "utf8");
+		expect(log).not.toContain("reason=outside_cwd");
+	});
+
+	it("logs file_context.skip when the file resolves outside cwd", async () => {
+		await buildClaudeFileContext(
+			{
+				hook_event_name: "PreToolUse",
+				tool_name: "Read",
+				tool_input: { file_path: "/etc/passwd" },
+				cwd: tmp,
+			},
+			{},
+			{
+				queryByFile: () => [],
+				resolveDb: () => "/tmp/test.sqlite",
+				statFile: () => ({ sizeBytes: 9999, mtimeMs: 0 }),
+			},
+		);
+
+		const log = readFileSync(pluginLogPath, "utf8");
+		expect(log).toContain("file_context.skip reason=outside_cwd");
 	});
 
 	it("logs file_context.skip when the query returns no observations", async () => {

--- a/packages/cli/src/commands/claude-hook-file-context.ts
+++ b/packages/cli/src/commands/claude-hook-file-context.ts
@@ -1,0 +1,363 @@
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { MemoryStore, type RefQueryResult, resolveDbPath, resolveHookProject } from "@codemem/core";
+import { Command } from "commander";
+import { helpStyle } from "../help-style.js";
+import { addDbOption, type DbOpts, resolveDbOpt } from "../shared-options.js";
+import { logHookEvent } from "./claude-hook-plugin-log.js";
+
+type FileContextResult = {
+	continue?: true;
+	hookSpecificOutput?: {
+		hookEventName: "PreToolUse";
+		permissionDecision: "allow";
+		additionalContext: string;
+	};
+};
+
+type FileContextOpts = DbOpts;
+
+type FileContextDeps = {
+	queryByFile?: typeof queryByFile;
+	resolveDb?: typeof resolveDbPath;
+	statFile?: typeof statFile;
+};
+
+const FILE_GATE_MIN_BYTES = 1500;
+const FETCH_LIMIT = 40;
+const DISPLAY_LIMIT = 15;
+
+const KIND_ICONS: Record<string, string> = {
+	decision: "⚖️",
+	bugfix: "🔴",
+	feature: "🟢",
+	refactor: "🔄",
+	discovery: "🔵",
+	change: "✅",
+	exploration: "🔬",
+};
+
+function emitJson(value: FileContextResult | { error: string; message: string }): void {
+	console.log(JSON.stringify(value));
+}
+
+function continueResult(): FileContextResult {
+	return { continue: true };
+}
+
+function envNotDisabled(value: string | undefined): boolean {
+	const normalized = String(value ?? "")
+		.trim()
+		.toLowerCase();
+	return normalized !== "0" && normalized !== "false" && normalized !== "off";
+}
+
+function envTruthy(value: string | undefined): boolean {
+	const normalized = String(value ?? "")
+		.trim()
+		.toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function expandHome(value: string): string {
+	if (value === "~") return homedir();
+	if (value.startsWith("~/")) return resolve(homedir(), value.slice(2));
+	return value;
+}
+
+function extractFilePath(payload: Record<string, unknown>): string | null {
+	const toolInput = payload.tool_input;
+	if (!toolInput || typeof toolInput !== "object" || Array.isArray(toolInput)) {
+		return null;
+	}
+	const filePath = (toolInput as Record<string, unknown>).file_path;
+	return typeof filePath === "string" && filePath.trim() ? filePath.trim() : null;
+}
+
+type StatResult = { sizeBytes: number; mtimeMs: number } | null;
+
+function statFile(absPath: string): StatResult {
+	try {
+		const stat = statSync(absPath);
+		return { sizeBytes: stat.size, mtimeMs: stat.mtimeMs };
+	} catch {
+		return null;
+	}
+}
+
+function parseJsonArray(value: string | null | undefined): string[] {
+	if (!value) return [];
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter((item): item is string => typeof item === "string");
+	} catch {
+		return [];
+	}
+}
+
+function normalizePathForCompare(path: string): string {
+	return path.replace(/\\/g, "/");
+}
+
+type ScoredObservation = { row: RefQueryResult; score: number };
+
+function scoreAndDedupe(
+	rows: RefQueryResult[],
+	targetPath: string,
+	limit: number,
+): RefQueryResult[] {
+	// One observation per session: keep the most recent (rows arrive
+	// ORDER BY created_at DESC) and drop the rest so the timeline doesn't
+	// fill up with sibling observations from the same chat.
+	const seenSessions = new Set<number>();
+	const dedupedBySession: RefQueryResult[] = [];
+	for (const row of rows) {
+		if (!seenSessions.has(row.session_id)) {
+			seenSessions.add(row.session_id);
+			dedupedBySession.push(row);
+		}
+	}
+
+	const normalizedTarget = normalizePathForCompare(targetPath);
+	const scored: ScoredObservation[] = dedupedBySession.map((row) => {
+		const filesRead = parseJsonArray(row.files_read);
+		const filesModified = parseJsonArray(row.files_modified);
+		const totalFiles = filesRead.length + filesModified.length;
+		const inModified = filesModified.some((f) => normalizePathForCompare(f) === normalizedTarget);
+
+		let score = 0;
+		if (inModified) score += 2;
+		if (totalFiles <= 3) score += 2;
+		else if (totalFiles <= 8) score += 1;
+
+		return { row, score };
+	});
+
+	scored.sort((a, b) => b.score - a.score);
+	return scored.slice(0, limit).map((s) => s.row);
+}
+
+function compactTime(timeStr: string): string {
+	return timeStr.toLowerCase().replace(" am", "a").replace(" pm", "p");
+}
+
+function formatTime(epochMs: number): string {
+	return new Date(epochMs).toLocaleString("en-US", {
+		hour: "numeric",
+		minute: "2-digit",
+		hour12: true,
+	});
+}
+
+function formatDate(epochMs: number): string {
+	return new Date(epochMs).toLocaleString("en-US", {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
+function formatTimeline(rows: RefQueryResult[], filePath: string): string {
+	const safePath = filePath.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+	const enriched = rows.map((row) => ({
+		row,
+		epochMs: Date.parse(row.created_at) || 0,
+	}));
+
+	const byDay = new Map<string, typeof enriched>();
+	for (const item of enriched) {
+		const day = formatDate(item.epochMs);
+		const bucket = byDay.get(day);
+		if (bucket) bucket.push(item);
+		else byDay.set(day, [item]);
+	}
+
+	const sortedDays = Array.from(byDay.entries()).sort((a, b) => {
+		const aMin = Math.min(...a[1].map((i) => i.epochMs));
+		const bMin = Math.min(...b[1].map((i) => i.epochMs));
+		return aMin - bMin;
+	});
+
+	const lines: string[] = [
+		`This file (${safePath}) has prior codemem observations. The Read result below is unchanged.`,
+		"- Need full detail on a past observation? memory.get_observations([IDs]) — fetches body + narrative.",
+	];
+
+	for (const [day, dayItems] of sortedDays) {
+		const chronological = [...dayItems].sort((a, b) => a.epochMs - b.epochMs);
+		lines.push(`### ${day}`);
+		for (const { row, epochMs } of chronological) {
+			const title = (row.title || "Untitled")
+				.replace(/[\r\n\t]+/g, " ")
+				.replace(/\s+/g, " ")
+				.trim()
+				.slice(0, 160);
+			const icon = KIND_ICONS[row.kind] ?? "❔";
+			const time = compactTime(formatTime(epochMs));
+			lines.push(`${row.id} ${time} ${icon} (${row.kind}) ${title}`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+function queryByFile(
+	dbPath: string,
+	relativePath: string,
+	project: string | null,
+	limit: number,
+): RefQueryResult[] {
+	const store = new MemoryStore(dbPath);
+	try {
+		const opts: { project?: string; limit: number } = { limit };
+		if (project) opts.project = project;
+		return store.findByFile(relativePath, opts);
+	} finally {
+		store.close();
+	}
+}
+
+function resolveProject(payload: Record<string, unknown>): string | null {
+	const cwd = typeof payload.cwd === "string" ? payload.cwd : null;
+	return resolveHookProject(cwd, payload.project);
+}
+
+export async function buildClaudeFileContext(
+	payload: Record<string, unknown>,
+	opts: FileContextOpts,
+	deps: FileContextDeps = {},
+): Promise<FileContextResult> {
+	if (envTruthy(process.env.CODEMEM_PLUGIN_IGNORE)) {
+		return continueResult();
+	}
+	if (!envNotDisabled(process.env.CODEMEM_FILE_CONTEXT || "1")) {
+		return continueResult();
+	}
+
+	const filePath = extractFilePath(payload);
+	if (!filePath) {
+		return continueResult();
+	}
+
+	const cwd = typeof payload.cwd === "string" && payload.cwd.trim() ? payload.cwd : process.cwd();
+	const expandedPath = expandHome(filePath);
+	const absolutePath = isAbsolute(expandedPath) ? expandedPath : resolve(cwd, expandedPath);
+	const relativePath = relative(cwd, absolutePath).split(sep).join("/");
+
+	if (!relativePath || relativePath.startsWith("..")) {
+		return continueResult();
+	}
+
+	const minBytes = Number.parseInt(
+		process.env.CODEMEM_FILE_CONTEXT_MIN_BYTES ?? `${FILE_GATE_MIN_BYTES}`,
+		10,
+	);
+	const minBytesEffective =
+		Number.isFinite(minBytes) && minBytes >= 0 ? minBytes : FILE_GATE_MIN_BYTES;
+
+	const stat = (deps.statFile ?? statFile)(absolutePath);
+	if (!stat) {
+		return continueResult();
+	}
+	if (stat.sizeBytes < minBytesEffective) {
+		return continueResult();
+	}
+
+	const project = resolveProject(payload);
+	const resolveDb = deps.resolveDb ?? resolveDbPath;
+	const queryFn = deps.queryByFile ?? queryByFile;
+
+	let rows: RefQueryResult[] = [];
+	try {
+		const dbPath = resolveDb(resolveDbOpt(opts));
+		rows = queryFn(dbPath, relativePath, project, FETCH_LIMIT);
+	} catch (err) {
+		logHookEvent(
+			`codemem claude-hook-file-context query failed: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return continueResult();
+	}
+
+	if (rows.length === 0) {
+		logHookEvent(
+			`file_context.skip reason=no_observations path=${JSON.stringify(relativePath)} project=${JSON.stringify(project ?? "")}`,
+		);
+		return continueResult();
+	}
+
+	if (stat.mtimeMs > 0) {
+		const newestObservationMs = rows.reduce((max, row) => {
+			const epoch = Date.parse(row.created_at);
+			return Number.isFinite(epoch) && epoch > max ? epoch : max;
+		}, 0);
+		if (newestObservationMs > 0 && stat.mtimeMs >= newestObservationMs) {
+			logHookEvent(
+				`file_context.skip reason=file_newer path=${JSON.stringify(relativePath)} mtime_ms=${stat.mtimeMs} newest_obs_ms=${newestObservationMs}`,
+			);
+			return continueResult();
+		}
+	}
+
+	const top = scoreAndDedupe(rows, relativePath, DISPLAY_LIMIT);
+	if (top.length === 0) {
+		return continueResult();
+	}
+
+	const timeline = formatTimeline(top, relativePath);
+
+	logHookEvent(
+		`file_context.ok path=${JSON.stringify(relativePath)} candidates=${rows.length} surfaced=${top.length} project=${JSON.stringify(project ?? "")}`,
+	);
+
+	return {
+		hookSpecificOutput: {
+			hookEventName: "PreToolUse",
+			permissionDecision: "allow",
+			additionalContext: timeline,
+		},
+	};
+}
+
+const claudeHookFileContextCmd = new Command("claude-hook-file-context")
+	.configureHelp(helpStyle)
+	.description(
+		"Return Claude PreToolUse:Read additionalContext from per-file observation timeline",
+	);
+
+addDbOption(claudeHookFileContextCmd);
+
+export const claudeHookFileContextCommand = claudeHookFileContextCmd.action(
+	async (opts: FileContextOpts) => {
+		let raw = "";
+		for await (const chunk of process.stdin) {
+			raw += String(chunk);
+		}
+		const trimmed = raw.trim();
+		if (!trimmed) {
+			emitJson(continueResult());
+			return;
+		}
+
+		let payload: Record<string, unknown>;
+		try {
+			const parsed = JSON.parse(trimmed) as unknown;
+			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+				emitJson({ error: "parse_error", message: "payload must be a JSON object" });
+				process.exitCode = 1;
+				return;
+			}
+			payload = parsed as Record<string, unknown>;
+		} catch {
+			emitJson({ error: "parse_error", message: "invalid JSON" });
+			process.exitCode = 1;
+			return;
+		}
+
+		const result = await buildClaudeFileContext(payload, opts);
+		emitJson(result);
+	},
+);
+
+export type { FileContextResult };

--- a/packages/cli/src/commands/claude-hook-file-context.ts
+++ b/packages/cli/src/commands/claude-hook-file-context.ts
@@ -27,6 +27,21 @@ type FileContextDeps = {
 const FILE_GATE_MIN_BYTES = 1500;
 const FETCH_LIMIT = 40;
 const DISPLAY_LIMIT = 15;
+// Mtime tolerance — observations from within ~5 minutes of the file's
+// mtime are treated as fresh enough to surface without a staleness
+// header. Smaller than this we'd false-positive on routine edits;
+// larger and branch switches read clean.
+const MTIME_FRESH_TOLERANCE_MS = 5 * 60 * 1000;
+
+// Small but high-signal file extensions: configs and infra files are
+// load-bearing for past decisions even at <1500 bytes, so bypass the
+// size gate for them.
+const SMALL_FILE_BYPASS_PATTERNS: RegExp[] = [
+	/\.(json|jsonc|toml|ya?ml)$/i,
+	/\.env(\.|$)/i,
+	/(^|\/)dockerfile(\.|$)/i,
+	/\.config\.(js|ts|mjs|cjs|json)$/i,
+];
 
 const KIND_ICONS: Record<string, string> = {
 	decision: "⚖️",
@@ -38,8 +53,14 @@ const KIND_ICONS: Record<string, string> = {
 	exploration: "🔬",
 };
 
-function emitJson(value: FileContextResult | { error: string; message: string }): void {
+function emitJson(value: FileContextResult): void {
 	console.log(JSON.stringify(value));
+}
+
+function emitError(value: { error: string; message: string }): void {
+	// Errors go to stderr so a non-zero exit from `codemem` doesn't poison
+	// the bash hook's stdout when it falls back to `npx -y codemem ...`.
+	process.stderr.write(`${JSON.stringify(value)}\n`);
 }
 
 function continueResult(): FileContextResult {
@@ -101,42 +122,50 @@ function normalizePathForCompare(path: string): string {
 	return path.replace(/\\/g, "/");
 }
 
-type ScoredObservation = { row: RefQueryResult; score: number };
+type ScoredObservation = { row: RefQueryResult; score: number; idx: number };
+
+function scoreRow(row: RefQueryResult, normalizedTarget: string, idx: number): ScoredObservation {
+	const filesModified = parseJsonArray(row.files_modified);
+	const inModified = filesModified.some((f) => normalizePathForCompare(f) === normalizedTarget);
+
+	// Specificity is "did this session focus on the target file?"
+	// `files_read` is dominated by the agent crawling the repo for
+	// context, so it shouldn't dilute that signal — score by
+	// files_modified only.
+	let score = 0;
+	if (inModified) score += 2;
+	if (filesModified.length <= 1) score += 2;
+	else if (filesModified.length <= 3) score += 1;
+
+	return { row, score, idx };
+}
 
 function scoreAndDedupe(
 	rows: RefQueryResult[],
 	targetPath: string,
 	limit: number,
 ): RefQueryResult[] {
-	// One observation per session: keep the most recent (rows arrive
-	// ORDER BY created_at DESC) and drop the rest so the timeline doesn't
-	// fill up with sibling observations from the same chat.
-	const seenSessions = new Set<number>();
-	const dedupedBySession: RefQueryResult[] = [];
-	for (const row of rows) {
-		if (!seenSessions.has(row.session_id)) {
-			seenSessions.add(row.session_id);
-			dedupedBySession.push(row);
+	const normalizedTarget = normalizePathForCompare(targetPath);
+	const scored = rows.map((row, idx) => scoreRow(row, normalizedTarget, idx));
+
+	// Dedupe by session keeping the highest-scoring observation per
+	// session. Tiebreak on smaller idx — `findByFile` returns rows
+	// ORDER BY created_at DESC so a smaller idx means more recent.
+	const bestPerSession = new Map<number, ScoredObservation>();
+	for (const item of scored) {
+		const existing = bestPerSession.get(item.row.session_id);
+		if (
+			!existing ||
+			item.score > existing.score ||
+			(item.score === existing.score && item.idx < existing.idx)
+		) {
+			bestPerSession.set(item.row.session_id, item);
 		}
 	}
 
-	const normalizedTarget = normalizePathForCompare(targetPath);
-	const scored: ScoredObservation[] = dedupedBySession.map((row) => {
-		const filesRead = parseJsonArray(row.files_read);
-		const filesModified = parseJsonArray(row.files_modified);
-		const totalFiles = filesRead.length + filesModified.length;
-		const inModified = filesModified.some((f) => normalizePathForCompare(f) === normalizedTarget);
-
-		let score = 0;
-		if (inModified) score += 2;
-		if (totalFiles <= 3) score += 2;
-		else if (totalFiles <= 8) score += 1;
-
-		return { row, score };
-	});
-
-	scored.sort((a, b) => b.score - a.score);
-	return scored.slice(0, limit).map((s) => s.row);
+	const deduped = Array.from(bestPerSession.values());
+	deduped.sort((a, b) => b.score - a.score || a.idx - b.idx);
+	return deduped.slice(0, limit).map((s) => s.row);
 }
 
 function compactTime(timeStr: string): string {
@@ -159,12 +188,15 @@ function formatDate(epochMs: number): string {
 	});
 }
 
-function formatTimeline(rows: RefQueryResult[], filePath: string): string {
+function formatTimeline(
+	rows: RefQueryResult[],
+	filePath: string,
+	staleness: { fileMtimeMs: number; newestObservationMs: number } | null,
+): string {
 	const safePath = filePath.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
-	const enriched = rows.map((row) => ({
-		row,
-		epochMs: Date.parse(row.created_at) || 0,
-	}));
+	const enriched = rows
+		.map((row) => ({ row, epochMs: Date.parse(row.created_at) }))
+		.filter((item) => Number.isFinite(item.epochMs) && item.epochMs > 0);
 
 	const byDay = new Map<string, typeof enriched>();
 	for (const item of enriched) {
@@ -180,10 +212,20 @@ function formatTimeline(rows: RefQueryResult[], filePath: string): string {
 		return aMin - bMin;
 	});
 
+	const ids = rows.map((r) => r.id);
 	const lines: string[] = [
 		`This file (${safePath}) has prior codemem observations. The Read result below is unchanged.`,
-		"- Need full detail on a past observation? memory.get_observations([IDs]) — fetches body + narrative.",
+		`- Fetch full bodies on demand: memory.get_observations([${ids.join(", ")}]).`,
 	];
+	if (staleness) {
+		const driftMinutes = Math.max(
+			1,
+			Math.round((staleness.fileMtimeMs - staleness.newestObservationMs) / 60_000),
+		);
+		lines.unshift(
+			`Heads up: this file was modified ~${driftMinutes} min after the most recent observation below. Past entries may be partially stale — verify against the Read result before relying on them.`,
+		);
+	}
 
 	for (const [day, dayItems] of sortedDays) {
 		const chronological = [...dayItems].sort((a, b) => a.epochMs - b.epochMs);
@@ -246,7 +288,17 @@ export async function buildClaudeFileContext(
 	const absolutePath = isAbsolute(expandedPath) ? expandedPath : resolve(cwd, expandedPath);
 	const relativePath = relative(cwd, absolutePath).split(sep).join("/");
 
-	if (!relativePath || relativePath.startsWith("..")) {
+	// Reject paths that escape cwd. `startsWith("..")` would also reject
+	// in-repo basenames that begin with `..` (e.g. `..hidden`); a
+	// segment-aware check distinguishes those from the `../foo` parent
+	// traversal. `isAbsolute` catches the Windows cross-drive case where
+	// `relative('C:\\repo', 'D:\\x')` returns an absolute-shaped string.
+	const escapesCwd =
+		relativePath === ".." || relativePath.startsWith("../") || isAbsolute(relativePath);
+	if (!relativePath || escapesCwd) {
+		logHookEvent(
+			`file_context.skip reason=outside_cwd path=${JSON.stringify(filePath)} cwd=${JSON.stringify(cwd)}`,
+		);
 		return continueResult();
 	}
 
@@ -259,9 +311,14 @@ export async function buildClaudeFileContext(
 
 	const stat = (deps.statFile ?? statFile)(absolutePath);
 	if (!stat) {
+		logHookEvent(`file_context.skip reason=stat_failed path=${JSON.stringify(relativePath)}`);
 		return continueResult();
 	}
-	if (stat.sizeBytes < minBytesEffective) {
+	const bypassSizeGate = SMALL_FILE_BYPASS_PATTERNS.some((p) => p.test(relativePath));
+	if (stat.sizeBytes < minBytesEffective && !bypassSizeGate) {
+		logHookEvent(
+			`file_context.skip reason=below_size_gate path=${JSON.stringify(relativePath)} size=${stat.sizeBytes} gate=${minBytesEffective}`,
+		);
 		return continueResult();
 	}
 
@@ -287,28 +344,29 @@ export async function buildClaudeFileContext(
 		return continueResult();
 	}
 
-	if (stat.mtimeMs > 0) {
-		const newestObservationMs = rows.reduce((max, row) => {
-			const epoch = Date.parse(row.created_at);
-			return Number.isFinite(epoch) && epoch > max ? epoch : max;
-		}, 0);
-		if (newestObservationMs > 0 && stat.mtimeMs >= newestObservationMs) {
-			logHookEvent(
-				`file_context.skip reason=file_newer path=${JSON.stringify(relativePath)} mtime_ms=${stat.mtimeMs} newest_obs_ms=${newestObservationMs}`,
-			);
-			return continueResult();
-		}
-	}
-
 	const top = scoreAndDedupe(rows, relativePath, DISPLAY_LIMIT);
 	if (top.length === 0) {
+		logHookEvent(
+			`file_context.skip reason=no_top_after_dedupe path=${JSON.stringify(relativePath)} candidates=${rows.length}`,
+		);
 		return continueResult();
 	}
 
-	const timeline = formatTimeline(top, relativePath);
+	let staleness: { fileMtimeMs: number; newestObservationMs: number } | null = null;
+	if (stat.mtimeMs > 0) {
+		const newestObservationMs = top.reduce((max, row) => {
+			const epoch = Date.parse(row.created_at);
+			return Number.isFinite(epoch) && epoch > max ? epoch : max;
+		}, 0);
+		if (newestObservationMs > 0 && stat.mtimeMs > newestObservationMs + MTIME_FRESH_TOLERANCE_MS) {
+			staleness = { fileMtimeMs: stat.mtimeMs, newestObservationMs };
+		}
+	}
+
+	const timeline = formatTimeline(top, relativePath, staleness);
 
 	logHookEvent(
-		`file_context.ok path=${JSON.stringify(relativePath)} candidates=${rows.length} surfaced=${top.length} project=${JSON.stringify(project ?? "")}`,
+		`file_context.ok path=${JSON.stringify(relativePath)} candidates=${rows.length} surfaced=${top.length} project=${JSON.stringify(project ?? "")} stale=${staleness ? "true" : "false"}`,
 	);
 
 	return {
@@ -344,13 +402,13 @@ export const claudeHookFileContextCommand = claudeHookFileContextCmd.action(
 		try {
 			const parsed = JSON.parse(trimmed) as unknown;
 			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-				emitJson({ error: "parse_error", message: "payload must be a JSON object" });
+				emitError({ error: "parse_error", message: "payload must be a JSON object" });
 				process.exitCode = 1;
 				return;
 			}
 			payload = parsed as Record<string, unknown>;
 		} catch {
-			emitJson({ error: "parse_error", message: "invalid JSON" });
+			emitError({ error: "parse_error", message: "invalid JSON" });
 			process.exitCode = 1;
 			return;
 		}

--- a/packages/cli/src/commands/claude-hook-inject.ts
+++ b/packages/cli/src/commands/claude-hook-inject.ts
@@ -52,8 +52,14 @@ const DEFAULT_VIEWER_PORT = 38888;
 const DEFAULT_MAX_CHARS = 16000;
 const DEFAULT_HTTP_MAX_TIME_S = 2;
 
-function emitJson(value: InjectResult | { error: string; message: string }): void {
+function emitJson(value: InjectResult): void {
 	console.log(JSON.stringify(value));
+}
+
+function emitError(value: { error: string; message: string }): void {
+	// Errors go to stderr so a non-zero exit from `codemem` doesn't poison
+	// the bash hook's stdout when it falls back to `npx -y codemem ...`.
+	process.stderr.write(`${JSON.stringify(value)}\n`);
 }
 
 function envNotDisabled(value: string | undefined): boolean {
@@ -292,13 +298,13 @@ export const claudeHookInjectCommand = claudeHookInjectCmd.action(async (opts: I
 	try {
 		const parsed = JSON.parse(trimmed) as unknown;
 		if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-			emitJson({ error: "parse_error", message: "payload must be a JSON object" });
+			emitError({ error: "parse_error", message: "payload must be a JSON object" });
 			process.exitCode = 1;
 			return;
 		}
 		payload = parsed as Record<string, unknown>;
 	} catch {
-		emitJson({ error: "parse_error", message: "invalid JSON" });
+		emitError({ error: "parse_error", message: "invalid JSON" });
 		process.exitCode = 1;
 		return;
 	}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@
 import { VERSION } from "@codemem/core";
 import { Command } from "commander";
 import omelette from "omelette";
+import { claudeHookFileContextCommand } from "./commands/claude-hook-file-context.js";
 import { claudeHookIngestCommand } from "./commands/claude-hook-ingest.js";
 import { claudeHookInjectCommand } from "./commands/claude-hook-inject.js";
 import { configCommand } from "./commands/config.js";
@@ -50,6 +51,7 @@ type CompletionWithScriptGenerators = ReturnType<typeof omelette> & {
 const completion = omelette("codemem <command>") as CompletionWithScriptGenerators;
 completion.on("command", ({ reply }) => {
 	reply([
+		"claude-hook-file-context",
 		"claude-hook-inject",
 		"claude-hook-ingest",
 		"config",
@@ -174,6 +176,7 @@ program.addCommand(coordinatorCommand);
 program.addCommand(mcpCommand);
 program.addCommand(claudeHookInjectCommand);
 program.addCommand(claudeHookIngestCommand);
+program.addCommand(claudeHookFileContextCommand);
 program.addCommand(dbCommand);
 program.addCommand(exportMemoriesCommand);
 program.addCommand(importMemoriesCommand);

--- a/plugins/claude/hooks/hooks.json
+++ b/plugins/claude/hooks/hooks.json
@@ -21,6 +21,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/pre-read-hook.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "hooks": [

--- a/plugins/claude/scripts/pre-read-hook.sh
+++ b/plugins/claude/scripts/pre-read-hook.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -u
+
+print_continue() {
+  printf '%s\n' '{"continue":true}'
+}
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd)}"
+PLUGIN_MANIFEST="${PLUGIN_ROOT}/.claude-plugin/plugin.json"
+payload="$(cat)"
+if [ -z "${payload}" ]; then
+  print_continue
+  exit 0
+fi
+
+case "${CODEMEM_PLUGIN_IGNORE:-}" in
+  "1"|"true"|"yes"|"on")
+    print_continue
+    exit 0
+    ;;
+esac
+
+if command -v codemem >/dev/null 2>&1; then
+  if printf '%s' "${payload}" | codemem claude-hook-file-context; then
+    exit 0
+  fi
+fi
+
+if command -v npx >/dev/null 2>&1; then
+  if printf '%s' "${payload}" | npx -y codemem claude-hook-file-context; then
+    exit 0
+  fi
+fi
+
+print_continue


### PR DESCRIPTION
## Description

Wires a new `PreToolUse:Read` hook that injects a per-day timeline of prior observations touching the file Claude is about to read, so file-specific memory lands in context before the file body. A new `claude-hook-file-context` CLI subcommand reads the hook payload, gates by file size and outside-cwd guards, queries `MemoryStore.findByFile`, dedupes one-per-session, scores by specificity, formats a chronological timeline, and returns `hookSpecificOutput` with `permissionDecision='allow'` so the Read still proceeds.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

14 tests cover: option registration, missing/small/missing-on-disk file paths, size-gate bypass for small configs (json/toml/yaml/.env/dockerfile/*.config.*), staleness header inside vs. outside the 5-minute fresh tolerance, score-then-dedupe surfacing the highest-scoring observation per session, and skip-path log lines (`outside_cwd`, `below_size_gate`, `no_observations`). Parse-error JSON now goes to stderr in both file-context and inject so the bash hook's npx fallback can't double-emit a result on stdout.

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced