### PR TITLE
fix(core): memoize peer ownership sets in memoryOwnedBySelf

### DIFF
--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -967,6 +967,66 @@ describe("MemoryStore", () => {
 				}),
 			).toBe(true);
 		});
+
+		it("does not re-query sync_peers on every call when invoked in a hot loop", () => {
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+				)
+				.run("peer-cache-1", store.actorId, 1, "2026-01-01T00:00:00Z");
+
+			// First call seeds the cache. Subsequent calls hit the cache and
+			// must not re-issue SELECTs against sync_peers — the previous
+			// implementation issued two per call which blocked the libuv
+			// event loop on large stores.
+			expect(
+				store.memoryOwnedBySelf({
+					origin_device_id: "peer-cache-1",
+					metadata: {},
+				}),
+			).toBe(true);
+
+			const spy = vi.spyOn(store, "sameActorPeerIds");
+			try {
+				for (let index = 0; index < 50; index += 1) {
+					store.memoryOwnedBySelf({
+						origin_device_id: "peer-cache-1",
+						metadata: {},
+					});
+				}
+				expect(spy).not.toHaveBeenCalled();
+			} finally {
+				spy.mockRestore();
+			}
+		});
+
+		it("invalidateOwnershipCache forces the next call to re-query sync_peers", () => {
+			// Prime the cache without any peers configured so isolated callers
+			// see "not owned" first.
+			expect(
+				store.memoryOwnedBySelf({
+					origin_device_id: "peer-cache-2",
+					metadata: {},
+				}),
+			).toBe(false);
+
+			// Add a claimed peer after the cache was seeded; without
+			// invalidation the cached negative result would survive its TTL.
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+				)
+				.run("peer-cache-2", store.actorId, 1, "2026-01-01T00:00:00Z");
+
+			store.invalidateOwnershipCache();
+
+			expect(
+				store.memoryOwnedBySelf({
+					origin_device_id: "peer-cache-2",
+					metadata: {},
+				}),
+			).toBe(true);
+		});
 	});
 
 	describe("forget", () => {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -219,6 +219,19 @@ export class MemoryStore {
 	 */
 	scanner: SecretScanner;
 	private readonly pendingVectorWrites = new Set<Promise<void>>();
+	// Ownership predicate cache for memoryOwnedBySelf. Recomputed once per
+	// OWNERSHIP_CACHE_TTL_MS instead of issuing two fresh sqlite SELECTs on
+	// every call. Hot search paths (search.ts:866, 879 + per-item rankers
+	// at 353, 496) can fan a single search out to thousands of ownership
+	// checks; without the cache that fan-out blocks the libuv event loop.
+	// Mutations to sync_peers happen via low-frequency UI/admin flows, so
+	// a short TTL keeps perceived staleness below interaction thresholds.
+	private _ownershipCache: {
+		actorIds: Set<string>;
+		deviceIds: Set<string>;
+		expiresAt: number;
+	} | null = null;
+	private static readonly OWNERSHIP_CACHE_TTL_MS = 5000;
 
 	/** Lazy Drizzle ORM wrapper — shares the same better-sqlite3 connection. */
 	private _drizzle: ReturnType<typeof drizzle> | null = null;
@@ -850,13 +863,44 @@ export class MemoryStore {
 		const deviceId = cleanStr(rec.origin_device_id) ?? cleanStr(meta.origin_device_id);
 		if (deviceId === this.deviceId) return true;
 
-		const claimedPeers = new Set(this.sameActorPeerIds());
-		if (deviceId && claimedPeers.has(deviceId)) return true;
-
-		const legacyActorIds = new Set(this.claimedSameActorLegacyActorIds());
-		if (actorId && legacyActorIds.has(actorId)) return true;
+		const sets = this.ownershipSets();
+		if (deviceId && sets.deviceIds.has(deviceId)) return true;
+		if (actorId && sets.actorIds.has(actorId)) return true;
 
 		return false;
+	}
+
+	/**
+	 * Return the (cached) sets of peer device ids and legacy actor ids this
+	 * store treats as "owned by self" for memory ranking. Recomputed every
+	 * OWNERSHIP_CACHE_TTL_MS to bound staleness on peer rename/identity
+	 * changes without forcing every UI mutation site to plumb invalidation
+	 * hooks.
+	 */
+	private ownershipSets(): { actorIds: Set<string>; deviceIds: Set<string> } {
+		const now = Date.now();
+		if (this._ownershipCache && this._ownershipCache.expiresAt > now) {
+			return this._ownershipCache;
+		}
+		const peerIds = this.sameActorPeerIds();
+		const deviceIds = new Set(peerIds);
+		const actorIds = new Set(peerIds.map((peerId) => `legacy-sync:${peerId}`));
+		this._ownershipCache = {
+			actorIds,
+			deviceIds,
+			expiresAt: now + MemoryStore.OWNERSHIP_CACHE_TTL_MS,
+		};
+		return this._ownershipCache;
+	}
+
+	/**
+	 * Drop the ownership cache. Callers that just mutated sync_peers in a
+	 * way that affects ownership (claim, identity change, rename, delete)
+	 * can call this to force the next memoryOwnedBySelf check to refresh.
+	 * Optional — the cache also expires on its own TTL.
+	 */
+	invalidateOwnershipCache(): void {
+		this._ownershipCache = null;
 	}
 
 	// forget


### PR DESCRIPTION
## Description

`memoryOwnedBySelf` issued two fresh sqlite SELECTs against `sync_peers` on every call. The hot search loop at `packages/core/src/search.ts:866` invokes it inside an `Array.filter`, plus per-item ranker callsites at lines 353 and 496. On a 2.6GB store with 18k memories the per-call fan-out blocked the libuv event loop for seconds at a time and left the viewer's HTTP server pegged at 100% CPU and unresponsive.

Caches the owned actor and device sets on the `MemoryStore` with a 5s TTL plus an explicit `invalidateOwnershipCache()` escape hatch. Hot search paths drop from O(results) sqlite SELECTs to O(1).

- Added cache + TTL on `MemoryStore`
- Added `invalidateOwnershipCache()` for callers that need stronger freshness after a mutation
- Two regression tests: hot-loop spy that asserts zero re-queries across 50 calls, and explicit cache-invalidation behavior

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1760 tests)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced