### PR TITLE
fix(deps): pin better-sqlite3 to 12.8.0 via pnpm override

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
       "esbuild",
       "sharp",
       "workerd"
-    ]
+    ],
+    "overrides": {
+      "better-sqlite3": "12.8.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ catalogs:
       specifier: ^4.1.5
       version: 4.1.5
 
+overrides:
+  better-sqlite3: 12.8.0
+
 importers:
 
   .:
@@ -88,7 +91,7 @@ importers:
         version: 14.0.3
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@4.20260503.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
+        version: 0.45.2(@cloudflare/workers-types@4.20260503.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
       omelette:
         specifier: ^0.4.17
         version: 0.4.17
@@ -2399,10 +2402,6 @@ packages:
     resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
-  better-sqlite3@12.9.0:
-    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
-
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -2612,7 +2611,7 @@ packages:
       '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
-      better-sqlite3: '>=7'
+      better-sqlite3: 12.8.0
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
@@ -5499,12 +5498,6 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
-  better-sqlite3@12.9.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-    optional: true
-
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
@@ -5708,12 +5701,6 @@ snapshots:
       '@cloudflare/workers-types': 4.20260503.1
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.8.0
-
-  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260503.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0):
-    optionalDependencies:
-      '@cloudflare/workers-types': 4.20260503.1
-      '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 12.9.0
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## Description

PR #1023's better-sqlite3 pin to `12.8.0` was first-party only — some transitive consumer (likely `@cloudflare/vitest-pool-workers` plus its bundled `workerd` types) still resolved 12.9.0 in CI. The workspace ended up with two copies of `drizzle-orm` keyed against different `better-sqlite3` SQL types, and CI tsc rejected every Drizzle call site in `packages/cli/src/commands/sync.ts` with TS2769 / TS2322 errors of the form `SQL<unknown>` is not assignable to `SQL<unknown>` — same name, different module resolution.

Adds a workspace-level `pnpm.overrides` entry forcing `better-sqlite3@12.8.0` throughout the dependency graph. Local `pnpm-lock.yaml` now shows a single resolution; tsc green from a clean install (verified by deleting `node_modules` and reinstalling).

- `package.json`: new `pnpm.overrides.better-sqlite3 = "12.8.0"`
- `pnpm-lock.yaml`: regenerated; only `better-sqlite3@12.8.0` resolves now

Revert the override when 12.9.x ships a Node v137 / darwin-arm64 prebuild and the dependency graph naturally aligns.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` from a clean install)
- [ ] Added/updated tests for changes (build/dependency-only fix)
- [x] Manually verified changes work as expected (clean `pnpm install` followed by full check passed)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced