### PR TITLE
perf(core): index memory_items.import_key + split OR-EXISTS in scope backfill

### DIFF
--- a/packages/core/src/schema-bootstrap.ts
+++ b/packages/core/src/schema-bootstrap.ts
@@ -58,6 +58,16 @@ CREATE INDEX IF NOT EXISTS idx_sync_scope_rejections_peer_created
 CREATE INDEX IF NOT EXISTS idx_sync_scope_rejections_scope_created
 	ON sync_scope_rejections(scope_id, created_at);
 
+-- import_key is the primary lookup key from replication_ops.entity_id back to
+-- the source memory. The scope-backfill runner's selectReplicationOpScopeCandidates
+-- query joins on it for every unstamped op; without this index a Pi 4 with
+-- ~17k memories and ~35k ops scans the full memory_items table on every batch
+-- tick. The partial WHERE clause keeps the index small (most rows have
+-- import_key set; the few that don't aren't searchable anyway).
+CREATE INDEX IF NOT EXISTS idx_memory_items_import_key
+	ON memory_items(import_key)
+	WHERE import_key IS NOT NULL;
+
 CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
 	title, body_text, tags_text,
 	content='memory_items',

--- a/packages/core/src/scope-backfill.test.ts
+++ b/packages/core/src/scope-backfill.test.ts
@@ -433,4 +433,46 @@ describe("scope backfill", () => {
 		await expect(runScopeBackfillPass(db, { batchSize: 10 })).resolves.toBe(false);
 		expect(hasPendingScopeBackfill(db)).toBe(false);
 	});
+
+	it("selectReplicationOpScopeCandidates rejects malformed entity_id integer false-positives", async () => {
+		// Reviewer-flagged regression for #1026: SQLite's CAST AS INTEGER
+		// is lenient — "123abc" casts to 123. Without a strict text-equality
+		// guard the index-friendly id-branch JOIN would treat such a row
+		// as a match for memory_items.id = 123, occupying batch slots that
+		// genuinely stampable ops need. Codemem doesn't write malformed
+		// entity_ids in normal operation, but a buggy peer could send one.
+		const sessionId = insertSession(db, { project: "p", cwd: "/x" });
+		const stampedId = insertMemory(db, {
+			sessionId,
+			title: "stamped",
+			workspaceId: "personal:actor-1",
+			workspaceKind: "personal",
+			importKey: "key:stamped",
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+		});
+
+		// Simulate a malformed entity_id whose lenient INTEGER cast
+		// happens to match a real memory's id: "<id>garbage" → <id>.
+		insertReplicationOp(db, "op-malformed", `${stampedId}garbage`);
+		// Real stampable op for the same memory via id form.
+		insertReplicationOp(db, "op-real", String(stampedId));
+
+		const result = backfillScopeIds(db, { memoryLimit: 10, replicationOpLimit: 10 });
+
+		// Only the real op should be selected and stamped; the malformed
+		// one stays unstamped (its scope_id remains NULL) so it never
+		// claims a batch slot in steady-state runs either.
+		expect(result.checkedReplicationOps).toBe(1);
+		expect(result.updatedReplicationOps).toBe(1);
+
+		const realOp = db
+			.prepare("SELECT scope_id FROM replication_ops WHERE op_id = ?")
+			.get("op-real") as { scope_id: string | null };
+		expect(realOp.scope_id).toBe(LOCAL_DEFAULT_SCOPE_ID);
+
+		const malformedOp = db
+			.prepare("SELECT scope_id FROM replication_ops WHERE op_id = ?")
+			.get("op-malformed") as { scope_id: string | null };
+		expect(malformedOp.scope_id).toBeNull();
+	});
 });

--- a/packages/core/src/scope-backfill.ts
+++ b/packages/core/src/scope-backfill.ts
@@ -330,20 +330,46 @@ function selectReplicationOpScopeCandidates(
 	db: SqliteDatabase,
 	limit: number,
 ): ReplicationOpScopeCandidateRow[] {
+	// Split the original `(import_key = entity_id OR CAST(id AS TEXT) = entity_id)`
+	// EXISTS into a UNION of two index-friendly INNER JOIN probes. The
+	// import_key branch hits idx_memory_items_import_key directly; the
+	// id branch hits the memory_items primary key after CAST. Without
+	// this split the planner sees the OR clause and degrades to a full
+	// scan of memory_items per replication_ops row, which is exactly
+	// what pegged Pi-class hardware on real-shape databases.
+	//
+	// Subtlety on the id branch: `mi.id = CAST(entity_id AS INTEGER)` is
+	// index-friendly but SQLite's INTEGER cast is lenient — strings like
+	// "123abc" or "  42 " cast to 123 / 42 and would produce false-
+	// positive matches that the old text-compare path filtered out.
+	// We pair the integer compare (for index access) with a strict
+	// text-equality check (`CAST(mi.id AS TEXT) = ro.entity_id`) that
+	// the planner only evaluates on the small post-join candidate set,
+	// preserving exact-match semantics. False positives would otherwise
+	// occupy the batch slot, then fail to stamp via lookupMemoryScopeForOp
+	// (which uses the original strict text-compare), starving real work.
 	return db
 		.prepare(
-			`SELECT ro.op_id, ro.entity_id
-			 FROM replication_ops ro
-			 WHERE ro.entity_type = 'memory_item'
-			   AND (ro.scope_id IS NULL OR TRIM(ro.scope_id) = '')
-			   AND EXISTS (
-				SELECT 1
-				FROM memory_items mi
-				WHERE (mi.import_key = ro.entity_id OR CAST(mi.id AS TEXT) = ro.entity_id)
+			`SELECT op_id, entity_id, created_at
+			 FROM (
+				SELECT ro.op_id, ro.entity_id, ro.created_at
+				FROM replication_ops ro
+				INNER JOIN memory_items mi ON mi.import_key = ro.entity_id
+				WHERE ro.entity_type = 'memory_item'
+				  AND (ro.scope_id IS NULL OR TRIM(ro.scope_id) = '')
 				  AND mi.scope_id IS NOT NULL
 				  AND TRIM(mi.scope_id) != ''
-			   )
-			 ORDER BY ro.created_at ASC, ro.op_id ASC
+				UNION
+				SELECT ro.op_id, ro.entity_id, ro.created_at
+				FROM replication_ops ro
+				INNER JOIN memory_items mi ON mi.id = CAST(ro.entity_id AS INTEGER)
+				WHERE ro.entity_type = 'memory_item'
+				  AND (ro.scope_id IS NULL OR TRIM(ro.scope_id) = '')
+				  AND mi.scope_id IS NOT NULL
+				  AND TRIM(mi.scope_id) != ''
+				  AND CAST(mi.id AS TEXT) = ro.entity_id
+			 )
+			 ORDER BY created_at ASC, op_id ASC
 			 LIMIT ?`,
 		)
 		.all(limit) as ReplicationOpScopeCandidateRow[];


### PR DESCRIPTION
## Description

Stacked on #1025. With the runner-tick `pendingWorkCount` call gone (#1025), the dominant remaining cost on Pi-class hardware is `selectReplicationOpScopeCandidates` inside `backfillScopeIds` itself. The query's `(import_key = entity_id OR CAST(id AS TEXT) = entity_id)` `OR`-on-keys clause defeats the planner; without an index on `memory_items.import_key` the inner query degrades to a full scan of `memory_items` per `replication_ops` row.

On a Pi 4 with 17,659 memories, 34,597 ops, 377 MB DB this is what kept CPU pegged in 5s bursts even after #1025.

Two changes:

- **New `idx_memory_items_import_key` partial index** in schema-bootstrap. Idempotent `CREATE INDEX IF NOT EXISTS`, runs on every startup so existing databases pick it up automatically. Partial `WHERE import_key IS NOT NULL` keeps the index small.
- **`selectReplicationOpScopeCandidates` rewritten as a `UNION` of two index-friendly `INNER JOIN` probes** — one keyed on `import_key`, one on `CAST(mi.id AS INTEGER)`. Each branch hits a single index instead of scanning `memory_items` per outer row.

Behavior unchanged on stable databases: same rows returned in same order, just without the per-row scan.

## Type of Change

- [x] ⚡ Performance fix

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1763 tests)
- [ ] Added/updated tests for changes (existing tests cover both branches: memory matched by `import_key` and by stringified id)
- [ ] Manually verified changes work as expected (waiting for Pi 4 dogfood after stack lands)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced