### PR TITLE
fix(core): keep diagnostics endpoint healthy when sqlite-vec is unavailable

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -188,6 +188,49 @@ Optional (recommended for coworker sync): set a per-peer project filter at accep
 - Check `~/.codemem/plugin.log` for plugin errors.
 - Sync errors: `codemem sync status` shows the last error per peer.
 
+### sqlite-vec / `no such module: vec0`
+
+**Symptom:** API errors with `SqliteError: no such module: vec0`, or the viewer logs `sqlite-vec failed to load; retrying viewer startup with embeddings disabled` at startup.
+
+`memory_vectors` is a sqlite-vec virtual table backed by the `vec0` extension module. The module is shipped as a per-platform npm sub-package (`sqlite-vec-darwin-arm64`, `sqlite-vec-linux-arm64`, `sqlite-vec-linux-x64`, `sqlite-vec-windows-x64`, `sqlite-vec-darwin-x64`) and selected automatically by npm's `optionalDependencies` resolution. It usually just works, but a few install layouts can leave the right binary missing.
+
+Diagnose first:
+
+```fish
+# Confirm the architecture and the codemem install path
+uname -m
+which codemem
+ls (npm root -g)/codemem/node_modules/ | grep -i sqlite-vec
+```
+
+You should see both `sqlite-vec/` (the wrapper) and `sqlite-vec-<platform>/` (the prebuilt binary). If the platform-specific package is missing, that's the bug.
+
+Fixes, in order of preference:
+
+1. **Reinstall codemem with optional deps explicitly included.** npm sometimes drops `optionalDependencies` for global installs:
+   ```fish
+   npm install -g --include=optional codemem@latest
+   ```
+
+2. **Force-install the platform package alongside.** If reinstalling didn't help (sometimes happens with global installs across major Node upgrades), install the matching platform sub-package separately and link it into codemem's tree:
+   ```fish
+   # 64-bit Pi OS / generic Linux ARM64
+   npm install -g sqlite-vec-linux-arm64
+   ln -sfn (npm root -g)/sqlite-vec-linux-arm64 \
+           (npm root -g)/codemem/node_modules/sqlite-vec-linux-arm64
+   # then restart the viewer
+   ```
+   Substitute the right platform: `sqlite-vec-linux-arm` for 32-bit Pi OS (`uname -m` reports `armv7l`), `sqlite-vec-linux-x64` for x86_64 Linux.
+
+3. **Run with embeddings disabled.** Codemem degrades gracefully: keyword search via FTS5 keeps working, the viewer keeps loading, and the only feature you lose is semantic recall via vector similarity:
+   ```fish
+   set -Ux CODEMEM_EMBEDDING_DISABLED 1
+   # then restart the viewer
+   ```
+   Reverse with `set -e CODEMEM_EMBEDDING_DISABLED`.
+
+The viewer's startup retries automatically with embeddings disabled if the initial load fails (`sqlite-vec failed to load; retrying viewer startup with embeddings disabled` in the banner). If you see API errors with `no such module: vec0` AFTER that retry message, please file an issue — `getSemanticIndexDiagnostics` and other vec-touching code paths should be self-healing on a connection without `vec0`.
+
 ### Bootstrap grant failures
 
 **Symptom:** worker bootstrap fails with HTTP 401 / `bootstrap_grant_invalid`.

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -442,6 +442,56 @@ describe("vectors", () => {
 			freshDb.close();
 		}
 	});
+
+	it("getSemanticIndexDiagnostics survives a missing vec0 module without throwing", () => {
+		// Reproduces the Pi 4 / Linux ARM scenario: the memory_vectors
+		// virtual table is referenced from the diagnostics counter but
+		// the vec0 module is unavailable on the active connection.
+		// A JOIN against memory_vectors then crashes with `SQLITE_ERROR:
+		// no such module: vec0`. The diagnostics endpoint must treat
+		// that as "0 indexed" rather than 500 the route handler that
+		// called it.
+		//
+		// Simulate by constructing a connection where memory_vectors
+		// exists in the schema as a non-virtual table (so tableExists
+		// returns true) but no vec0 module is registered. The fast-path
+		// JOIN will throw "no such module" because better-sqlite3 plans
+		// the query against any matching table name.
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-vectors-vec-missing-"));
+		const dbPath = join(tmpDir, "test.sqlite");
+		try {
+			const stubDb = new Database(dbPath);
+			try {
+				initTestSchema(stubDb);
+				stubDb.exec(`
+					CREATE TABLE IF NOT EXISTS memory_vectors (
+						memory_id INTEGER PRIMARY KEY,
+						embedding BLOB,
+						model TEXT
+					);
+				`);
+				const originalPrepare = stubDb.prepare.bind(stubDb);
+				const prepareSpy = vi.spyOn(stubDb, "prepare").mockImplementation((sql: string) => {
+					if (sql.includes("memory_vectors")) {
+						throw new Error("SQLITE_ERROR: no such module: vec0");
+					}
+					return originalPrepare(sql);
+				});
+
+				try {
+					expect(() => getSemanticIndexDiagnostics(stubDb)).not.toThrow();
+					const diagnostics = getSemanticIndexDiagnostics(stubDb);
+					expect(diagnostics.indexed_memory_count).toBe(0);
+				} finally {
+					prepareSpy.mockRestore();
+				}
+			} finally {
+				stubDb.close();
+			}
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -211,33 +211,65 @@ function countEmbeddableActiveMemories(db: Database): number {
 	return Number(row?.c ?? 0);
 }
 
+/**
+ * `memory_vectors` is a sqlite-vec virtual table. Querying it requires the
+ * `vec0` module to be loaded into the active connection — a different
+ * concern from the table merely existing in the schema. On platforms where
+ * sqlite-vec failed to load (e.g. Linux ARM64 without the matching
+ * platform package), the table can persist from a previous run while the
+ * module is gone, so a JOIN crashes with `SQLITE_ERROR: no such module:
+ * vec0`. Diagnostic counters must treat that case as "0 indexed", same as
+ * the explicit `CODEMEM_EMBEDDING_DISABLED` path, instead of throwing.
+ */
+function isVecModuleMissingError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	const message = error.message ?? "";
+	return /no such module:\s*vec0/i.test(message);
+}
+
 function countIndexedActiveMemories(db: Database, model: string): number {
-	if (!tableExists(db, "memory_vectors")) return 0;
-	const rows = db
-		.prepare(
-			`SELECT id, title, body_text
-			 FROM memory_items
-			 WHERE active = 1
-			   AND TRIM(COALESCE(title, '') || COALESCE(body_text, '')) != ''
-			 ORDER BY id ASC`,
-		)
-		.all() as MemoryTextRow[];
-	return rows.filter((row) => memoryHasCompleteVectorCoverage(db, row, model)).length;
+	if (isEmbeddingDisabled() || !tableExists(db, "memory_vectors")) return 0;
+	let rows: MemoryTextRow[];
+	try {
+		rows = db
+			.prepare(
+				`SELECT id, title, body_text
+				 FROM memory_items
+				 WHERE active = 1
+				   AND TRIM(COALESCE(title, '') || COALESCE(body_text, '')) != ''
+				 ORDER BY id ASC`,
+			)
+			.all() as MemoryTextRow[];
+	} catch (error) {
+		if (isVecModuleMissingError(error)) return 0;
+		throw error;
+	}
+	try {
+		return rows.filter((row) => memoryHasCompleteVectorCoverage(db, row, model)).length;
+	} catch (error) {
+		if (isVecModuleMissingError(error)) return 0;
+		throw error;
+	}
 }
 
 function countIndexedActiveMemoriesFast(db: Database, model: string): number {
-	if (!tableExists(db, "memory_vectors")) return 0;
-	const row = db
-		.prepare(
-			`SELECT COUNT(DISTINCT mi.id) AS c
-			 FROM memory_items mi
-			 JOIN memory_vectors mv ON mv.memory_id = mi.id
-			 WHERE mi.active = 1
-			   AND mv.model = ?
-			   AND TRIM(COALESCE(mi.title, '') || COALESCE(mi.body_text, '')) != ''`,
-		)
-		.get(model) as { c?: number } | undefined;
-	return Number(row?.c ?? 0);
+	if (isEmbeddingDisabled() || !tableExists(db, "memory_vectors")) return 0;
+	try {
+		const row = db
+			.prepare(
+				`SELECT COUNT(DISTINCT mi.id) AS c
+				 FROM memory_items mi
+				 JOIN memory_vectors mv ON mv.memory_id = mi.id
+				 WHERE mi.active = 1
+				   AND mv.model = ?
+				   AND TRIM(COALESCE(mi.title, '') || COALESCE(mi.body_text, '')) != ''`,
+			)
+			.get(model) as { c?: number } | undefined;
+		return Number(row?.c ?? 0);
+	} catch (error) {
+		if (isVecModuleMissingError(error)) return 0;
+		throw error;
+	}
 }
 
 function resolvePendingMemoryCount(


### PR DESCRIPTION
## Description

The viewer's `/api/sync/status` route calls `getSemanticIndexDiagnostics`, which counts indexed memories by JOINing the `memory_vectors` virtual table. That virtual table is sqlite-vec's `vec0` module. On platforms where sqlite-vec is unavailable on the active connection — Pi 4 / Linux ARM64 deployments where the platform-specific package didn't install correctly, or any environment running with `CODEMEM_EMBEDDING_DISABLED=1` — the table can persist in the schema while `vec0` is gone. The JOIN then crashes with `SqliteError: no such module: vec0`, which becomes a 500 on the route handler. Symptom: the web UI's sync panel hangs/spins because `/api/sync/status` keeps erroring.

Two changes in `vectors.ts`:

- `countIndexedActiveMemories` / `countIndexedActiveMemoriesFast` now short-circuit when `isEmbeddingDisabled()` is true, matching the bootstrap path's contract.
- Both wrap their `memory_vectors`-touching prepare/get calls in a try/catch that swallows `no such module: vec0` and returns 0. Other SQLite errors still propagate so we don't mask real corruption.

New regression test in `vectors.test.ts` spies on `db.prepare` to throw `"no such module: vec0"` whenever the SQL touches `memory_vectors`, confirming `getSemanticIndexDiagnostics` no longer throws and reports `indexed_memory_count = 0`.

Adds a Troubleshooting subsection to `docs/user-guide.md` explaining the three install-time workarounds for this on Linux ARM64 plus the `CODEMEM_EMBEDDING_DISABLED=1` fallback.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1765 tests)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected (waiting for Pi 4 dogfood)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed) — new Troubleshooting subsection in `docs/user-guide.md`
- [x] No new warnings introduced