### PR TITLE
fix(core): drop unsafe TTL cache from memoryOwnedBySelf

### DIFF
--- a/packages/core/src/search.test.ts
+++ b/packages/core/src/search.test.ts
@@ -200,6 +200,10 @@ describe("kindBonus", () => {
 // ---------------------------------------------------------------------------
 
 describe("rerankResults", () => {
+	const isOwnedByMockStore = (item: MemoryResult | Record<string, unknown>) => {
+		const metadata = (item as MemoryResult).metadata as Record<string, unknown> | undefined;
+		return metadata?.actor_id === "local:test-device";
+	};
 	const mockStore = {
 		db: {} as never,
 		actorId: "local:test-device",
@@ -207,10 +211,8 @@ describe("rerankResults", () => {
 		get: () => null,
 		recent: () => [],
 		recentByKinds: () => [],
-		memoryOwnedBySelf: (item: MemoryResult | Record<string, unknown>) => {
-			const metadata = (item as MemoryResult).metadata as Record<string, unknown> | undefined;
-			return metadata?.actor_id === "local:test-device";
-		},
+		memoryOwnedBySelf: isOwnedByMockStore,
+		buildOwnershipPredicate: () => isOwnedByMockStore,
 	};
 
 	function makeResult(overrides: Partial<MemoryResult>): MemoryResult {
@@ -575,6 +577,39 @@ describe("rerankResults", () => {
 			undefined,
 			"summarize memory retrieval issues",
 		);
+		expect(reranked[0]?.id).toBe(1);
+	});
+
+	it("falls back to memoryOwnedBySelf when buildOwnershipPredicate is not implemented", () => {
+		// Older `StoreHandle` implementers (e.g. external JS callers compiled
+		// against a prior interface) only ship `memoryOwnedBySelf`. Reranking
+		// must not crash with `TypeError: store.buildOwnershipPredicate is not
+		// a function` in that case.
+		const legacyStore = {
+			db: {} as never,
+			actorId: "local:test-device",
+			deviceId: "test-device",
+			get: () => null,
+			recent: () => [],
+			recentByKinds: () => [],
+			memoryOwnedBySelf: isOwnedByMockStore,
+			// buildOwnershipPredicate intentionally omitted.
+		};
+		const results = [
+			makeResult({ id: 1, score: 1.0, metadata: { actor_id: "local:test-device" } }),
+			makeResult({
+				id: 2,
+				score: 1.0,
+				metadata: { visibility: "shared", workspace_kind: "shared", trust_state: "unreviewed" },
+			}),
+		];
+		expect(() =>
+			rerankResults(legacyStore, results, 10, { personal_first: true, trust_bias: "soft" }),
+		).not.toThrow();
+		const reranked = rerankResults(legacyStore, results, 10, {
+			personal_first: true,
+			trust_bias: "soft",
+		});
 		expect(reranked[0]?.id).toBe(1);
 	});
 });

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -52,6 +52,9 @@ export interface StoreHandle {
 	readonly deviceId: string;
 	get(memoryId: number): MemoryItemResponse | null;
 	memoryOwnedBySelf(item: MemoryItem | MemoryResult | Record<string, unknown>): boolean;
+	buildOwnershipPredicate?(): (
+		item: MemoryItem | MemoryResult | Record<string, unknown>,
+	) => boolean;
 	recent(limit?: number, filters?: MemoryFilters | null, offset?: number): MemoryItemResponse[];
 	recentByKinds(
 		kinds: string[],
@@ -345,12 +348,12 @@ function markWideningMetadata(items: MemoryResult[]): MemoryResult[] {
 }
 
 function personalBias(
-	store: StoreHandle,
+	ownedByOwner: (item: MemoryResult) => boolean,
 	item: MemoryResult,
 	filters: MemoryFilters | undefined,
 ): number {
 	if (!personalFirstEnabled(filters)) return 0.0;
-	return store.memoryOwnedBySelf(item) ? PERSONAL_FIRST_BONUS : 0.0;
+	return ownedByOwner(item) ? PERSONAL_FIRST_BONUS : 0.0;
 }
 
 function searchQueryLooksTaskLike(query: string): boolean {
@@ -488,12 +491,12 @@ function itemLooksTaskLikeForSearch(item: MemoryResult): boolean {
 }
 
 function sharedTrustPenalty(
-	store: StoreHandle,
+	ownedByOwner: (item: MemoryResult) => boolean,
 	item: MemoryResult,
 	filters: MemoryFilters | undefined,
 ): number {
 	if (trustBiasMode(filters) !== "soft") return 0.0;
-	if (store.memoryOwnedBySelf(item)) return 0.0;
+	if (ownedByOwner(item)) return 0.0;
 	const metadata = item.metadata ?? {};
 	const visibility = String(metadata.visibility ?? "")
 		.trim()
@@ -749,13 +752,36 @@ function workingSetOverlapBoost(item: MemoryResult, workingSetPaths: string[]): 
 	return Math.min(0.32, boost);
 }
 
+/**
+ * Build an ownership predicate from `store`, falling back to a closure over
+ * `memoryOwnedBySelf` when the optional `buildOwnershipPredicate` method is
+ * not implemented. The fallback path preserves correctness for older
+ * `StoreHandle` implementers (e.g. external JS callers compiled against a
+ * prior version of this interface) at the cost of re-querying sync_peers
+ * per item.
+ */
+function ownershipPredicateFor(
+	store: StoreHandle,
+): (item: MemoryItem | MemoryResult | Record<string, unknown>) => boolean {
+	if (typeof store.buildOwnershipPredicate === "function") {
+		return store.buildOwnershipPredicate();
+	}
+	return (item) => store.memoryOwnedBySelf(item);
+}
+
 export function scoreResult(
 	store: StoreHandle,
 	item: MemoryResult,
 	filters?: MemoryFilters,
 	query = "",
 	referenceNow = new Date(),
+	ownedByOwner?: (item: MemoryResult) => boolean,
 ): PackTraceCandidateScores {
+	// Per-item rankers (personalBias / sharedTrustPenalty) check whether
+	// the result is owned by this device's actor. Building a fresh
+	// predicate here would re-query sync_peers per item; callers that
+	// already snapshotted the predicate (rerankResults) pass theirs in.
+	const ownership = ownedByOwner ?? ownershipPredicateFor(store);
 	const workingSetPaths = normalizeWorkingSetPaths(filters?.working_set_paths);
 	const preferSummary = queryPrefersRecap(query);
 	const taskLikeQuery = searchQueryLooksTaskLike(query);
@@ -765,8 +791,8 @@ export function scoreResult(
 	const roleAdjustment = roleAdjustmentForSearch(item, preferSummary, taskLikeQuery);
 	const workingSetOverlap = workingSetOverlapBoost(item, workingSetPaths);
 	const queryPathOverlap = queryPathOverlapBoost(item, query);
-	const personalBiasValue = personalBias(store, item, filters);
-	const sharedTrustPenaltyValue = sharedTrustPenalty(store, item, filters);
+	const personalBiasValue = personalBias(ownership, item, filters);
+	const sharedTrustPenaltyValue = sharedTrustPenalty(ownership, item, filters);
 	const recapPenalty = recapPenaltyForSearch(item, preferSummary);
 	const tasklikePenalty =
 		!taskLikeQuery && itemLooksTaskLikeForSearch(item) ? NON_TASK_TASKLIKE_PENALTY : 0.0;
@@ -816,11 +842,14 @@ export function rerankResults(
 	query = "",
 ): MemoryResult[] {
 	const referenceNow = new Date();
+	// Snapshot ownership once per rerank pass so per-item scoring does not
+	// re-query sync_peers for every candidate.
+	const ownedByOwner = ownershipPredicateFor(store);
 
 	const scored = results.map((item) => ({
 		item,
 		combinedScore:
-			scoreResult(store, item, filters, query, referenceNow).combined_score ??
+			scoreResult(store, item, filters, query, referenceNow, ownedByOwner).combined_score ??
 			Number.NEGATIVE_INFINITY,
 	}));
 
@@ -863,7 +892,10 @@ function applySharedWidening(
 		return primary;
 	}
 
-	const personalResults = primary.filter((item) => store.memoryOwnedBySelf(item));
+	// Snapshot ownership once for the two filter passes below; the predicate
+	// captures the current sync_peers state so per-result checks stay O(1).
+	const ownedByOwner = ownershipPredicateFor(store);
+	const personalResults = primary.filter((item) => ownedByOwner(item));
 	const strongestPersonalScore = personalResults[0]?.score ?? -Infinity;
 	const personalStrongEnough =
 		personalResults.length >= widenSharedMinPersonalResults(filters) &&
@@ -876,7 +908,7 @@ function applySharedWidening(
 			effectiveQuery,
 			WIDEN_SHARED_MAX_SHARED_RESULTS,
 			sharedWideningFilters(filters),
-		).filter((item) => !store.memoryOwnedBySelf(item)),
+		).filter((item) => !ownedByOwner(item)),
 	);
 	const seen = new Set(primary.map((item) => item.id));
 	const combined = [...primary];

--- a/packages/core/src/store.test.ts
+++ b/packages/core/src/store.test.ts
@@ -968,31 +968,54 @@ describe("MemoryStore", () => {
 			).toBe(true);
 		});
 
-		it("does not re-query sync_peers on every call when invoked in a hot loop", () => {
+		it("memoryOwnedBySelf reflects sync_peers changes immediately (no caching)", () => {
+			// Authorization-critical callers (forgetMemory, setMemoryVisibility,
+			// etc.) call memoryOwnedBySelf to decide whether a write is
+			// allowed. The result must reflect the latest sync_peers state
+			// on every call — caching here would mean an unclaimed peer's
+			// writes could still be authorized inside a stale window.
+			expect(
+				store.memoryOwnedBySelf({
+					origin_device_id: "peer-fresh",
+					metadata: {},
+				}),
+			).toBe(false);
+
 			store.db
 				.prepare(
 					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
 				)
-				.run("peer-cache-1", store.actorId, 1, "2026-01-01T00:00:00Z");
+				.run("peer-fresh", store.actorId, 1, "2026-01-01T00:00:00Z");
 
-			// First call seeds the cache. Subsequent calls hit the cache and
-			// must not re-issue SELECTs against sync_peers — the previous
-			// implementation issued two per call which blocked the libuv
-			// event loop on large stores.
 			expect(
 				store.memoryOwnedBySelf({
-					origin_device_id: "peer-cache-1",
+					origin_device_id: "peer-fresh",
 					metadata: {},
 				}),
 			).toBe(true);
 
+			store.db.prepare("DELETE FROM sync_peers WHERE peer_device_id = ?").run("peer-fresh");
+
+			expect(
+				store.memoryOwnedBySelf({
+					origin_device_id: "peer-fresh",
+					metadata: {},
+				}),
+			).toBe(false);
+		});
+
+		it("buildOwnershipPredicate snapshots sync_peers once for hot-loop callers", () => {
+			store.db
+				.prepare(
+					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
+				)
+				.run("peer-snapshot", store.actorId, 1, "2026-01-01T00:00:00Z");
+
+			const predicate = store.buildOwnershipPredicate();
 			const spy = vi.spyOn(store, "sameActorPeerIds");
 			try {
 				for (let index = 0; index < 50; index += 1) {
-					store.memoryOwnedBySelf({
-						origin_device_id: "peer-cache-1",
-						metadata: {},
-					});
+					predicate({ origin_device_id: "peer-snapshot", metadata: {} });
 				}
 				expect(spy).not.toHaveBeenCalled();
 			} finally {
@@ -1000,32 +1023,21 @@ describe("MemoryStore", () => {
 			}
 		});
 
-		it("invalidateOwnershipCache forces the next call to re-query sync_peers", () => {
-			// Prime the cache without any peers configured so isolated callers
-			// see "not owned" first.
-			expect(
-				store.memoryOwnedBySelf({
-					origin_device_id: "peer-cache-2",
-					metadata: {},
-				}),
-			).toBe(false);
+		it("buildOwnershipPredicate snapshot does not observe later peer changes", () => {
+			const predicate = store.buildOwnershipPredicate();
 
-			// Add a claimed peer after the cache was seeded; without
-			// invalidation the cached negative result would survive its TTL.
 			store.db
 				.prepare(
 					"INSERT INTO sync_peers(peer_device_id, actor_id, claimed_local_actor, created_at) VALUES (?, ?, ?, ?)",
 				)
-				.run("peer-cache-2", store.actorId, 1, "2026-01-01T00:00:00Z");
+				.run("peer-late", store.actorId, 1, "2026-01-01T00:00:00Z");
 
-			store.invalidateOwnershipCache();
-
-			expect(
-				store.memoryOwnedBySelf({
-					origin_device_id: "peer-cache-2",
-					metadata: {},
-				}),
-			).toBe(true);
+			// Frozen-snapshot semantics: each request rebuilds the predicate,
+			// so callers that hold one across requests intentionally trade
+			// freshness for the per-loop perf win. memoryOwnedBySelf remains
+			// the always-fresh path for write-side authorization.
+			expect(predicate({ origin_device_id: "peer-late", metadata: {} })).toBe(false);
+			expect(store.memoryOwnedBySelf({ origin_device_id: "peer-late", metadata: {} })).toBe(true);
 		});
 	});
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -219,19 +219,6 @@ export class MemoryStore {
 	 */
 	scanner: SecretScanner;
 	private readonly pendingVectorWrites = new Set<Promise<void>>();
-	// Ownership predicate cache for memoryOwnedBySelf. Recomputed once per
-	// OWNERSHIP_CACHE_TTL_MS instead of issuing two fresh sqlite SELECTs on
-	// every call. Hot search paths (search.ts:866, 879 + per-item rankers
-	// at 353, 496) can fan a single search out to thousands of ownership
-	// checks; without the cache that fan-out blocks the libuv event loop.
-	// Mutations to sync_peers happen via low-frequency UI/admin flows, so
-	// a short TTL keeps perceived staleness below interaction thresholds.
-	private _ownershipCache: {
-		actorIds: Set<string>;
-		deviceIds: Set<string>;
-		expiresAt: number;
-	} | null = null;
-	private static readonly OWNERSHIP_CACHE_TTL_MS = 5000;
 
 	/** Lazy Drizzle ORM wrapper — shares the same better-sqlite3 connection. */
 	private _drizzle: ReturnType<typeof drizzle> | null = null;
@@ -846,61 +833,47 @@ export class MemoryStore {
 	 * 3. actor_id in legacy sync actor ids → owned
 	 */
 	memoryOwnedBySelf(item: MemoryItem | MemoryResult | Record<string, unknown>): boolean {
-		const rec = item as Record<string, unknown>;
-		// Check top-level columns first (MemoryItem / DB row),
-		// then metadata dict (MemoryResult from search populates provenance there).
-		// For raw DB rows, metadata_json is a string — parse it so legacy rows
-		// whose actor_id/origin_device_id live inside metadata_json still pass
-		// ownership checks.
-		let meta = (rec.metadata ?? {}) as Record<string, unknown>;
-		if (!rec.metadata && typeof rec.metadata_json === "string") {
-			meta = fromJson(rec.metadata_json);
-		}
-
-		const actorId = cleanStr(rec.actor_id) ?? cleanStr(meta.actor_id);
-		if (actorId === this.actorId) return true;
-
-		const deviceId = cleanStr(rec.origin_device_id) ?? cleanStr(meta.origin_device_id);
-		if (deviceId === this.deviceId) return true;
-
-		const sets = this.ownershipSets();
-		if (deviceId && sets.deviceIds.has(deviceId)) return true;
-		if (actorId && sets.actorIds.has(actorId)) return true;
-
-		return false;
+		// Always re-reads sync_peers via sameActorPeerIds(). This method
+		// authorizes mutating APIs (forgetMemory / setMemoryVisibility /
+		// reassignMemoryScope etc.) so it must reflect peer claim changes
+		// the moment they land — no caching here. Callers that legitimately
+		// loop over many memories (search ranking, widening filters) should
+		// snapshot once via buildOwnershipPredicate() and reuse the closure.
+		return this.buildOwnershipPredicate()(item);
 	}
 
 	/**
-	 * Return the (cached) sets of peer device ids and legacy actor ids this
-	 * store treats as "owned by self" for memory ranking. Recomputed every
-	 * OWNERSHIP_CACHE_TTL_MS to bound staleness on peer rename/identity
-	 * changes without forcing every UI mutation site to plumb invalidation
-	 * hooks.
+	 * Snapshot the current ownership state into a fast inline predicate.
+	 *
+	 * Used to amortize the sync_peers SELECTs across hot loops in the
+	 * search ranker. The closure captures the actor + device + claimed-peer
+	 * sets at construction time and returns synchronous boolean checks
+	 * without touching sqlite. Because the snapshot is frozen, callers
+	 * should rebuild the predicate once per request — never share one
+	 * across requests where peer claims could change in between.
 	 */
-	private ownershipSets(): { actorIds: Set<string>; deviceIds: Set<string> } {
-		const now = Date.now();
-		if (this._ownershipCache && this._ownershipCache.expiresAt > now) {
-			return this._ownershipCache;
-		}
+	buildOwnershipPredicate(): (
+		item: MemoryItem | MemoryResult | Record<string, unknown>,
+	) => boolean {
 		const peerIds = this.sameActorPeerIds();
-		const deviceIds = new Set(peerIds);
-		const actorIds = new Set(peerIds.map((peerId) => `legacy-sync:${peerId}`));
-		this._ownershipCache = {
-			actorIds,
-			deviceIds,
-			expiresAt: now + MemoryStore.OWNERSHIP_CACHE_TTL_MS,
+		const claimedDeviceIds = new Set(peerIds);
+		const legacyActorIds = new Set(peerIds.map((peerId) => `legacy-sync:${peerId}`));
+		const ownerActorId = this.actorId;
+		const ownerDeviceId = this.deviceId;
+		return (item) => {
+			const rec = item as Record<string, unknown>;
+			let meta = (rec.metadata ?? {}) as Record<string, unknown>;
+			if (!rec.metadata && typeof rec.metadata_json === "string") {
+				meta = fromJson(rec.metadata_json);
+			}
+			const actorId = cleanStr(rec.actor_id) ?? cleanStr(meta.actor_id);
+			if (actorId === ownerActorId) return true;
+			const deviceId = cleanStr(rec.origin_device_id) ?? cleanStr(meta.origin_device_id);
+			if (deviceId === ownerDeviceId) return true;
+			if (deviceId && claimedDeviceIds.has(deviceId)) return true;
+			if (actorId && legacyActorIds.has(actorId)) return true;
+			return false;
 		};
-		return this._ownershipCache;
-	}
-
-	/**
-	 * Drop the ownership cache. Callers that just mutated sync_peers in a
-	 * way that affects ownership (claim, identity change, rename, delete)
-	 * can call this to force the next memoryOwnedBySelf check to refresh.
-	 * Optional — the cache also expires on its own TTL.
-	 */
-	invalidateOwnershipCache(): void {
-		this._ownershipCache = null;
 	}
 
 	// forget


### PR DESCRIPTION
## Description

Reviewer follow-up to #1020. The 5s-TTL cache introduced there makes `memoryOwnedBySelf` return stale ownership data for up to five seconds, but that method **also authorizes mutating APIs**: `forgetMemory`, `setMemoryVisibility`, `reassignMemoryScope`, and the matching write-path callers in `store.ts`. Because no production code calls `invalidateOwnershipCache()` after `sync_peers` changes, unclaiming or reassigning a peer doesn't take effect immediately and writes from a now-unowned peer can still be accepted during the TTL window.

This is live in **v0.29.3 on npm `latest`** and **v0.30.0-alpha.1** — a real auth-staleness window during peer-config flips. Worth back-porting to a `0.29.4` hotfix and including in the next 0.30 alpha.

Replace with two methods:

- `memoryOwnedBySelf` is now always-fresh — re-reads `sync_peers` every call by delegating to a one-shot `buildOwnershipPredicate()`. Write-path callers get exact, current ownership state.
- `buildOwnershipPredicate()` snapshots the peer state once and returns a fast inline closure. Search-side hot loops build one predicate per request and reuse it across all candidates, preserving the perf win from #1020 without the auth-staleness risk.

The snapshot is **frozen** at construction time, which is the right shape for a single-request ranker pass but wrong for write-path auth — hence the explicit method split.

Search ranker plumbing:

- `personalBias` and `sharedTrustPenalty` take a predicate parameter instead of the store handle.
- `scoreResult` accepts an optional predicate; `rerankResults` builds one once per pass and threads it through.
- `applySharedWidening` builds one predicate and uses it for both filter passes.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1766 tests)
- [x] Added/updated tests for changes:
  - `memoryOwnedBySelf` reflects `sync_peers` changes immediately (insert + delete cycles assert no caching)
  - `buildOwnershipPredicate` snapshots once for hot-loop callers (50 calls, zero re-queries via `sameActorPeerIds` spy)
  - `buildOwnershipPredicate` snapshot does not observe later peer changes (proves the frozen-snapshot semantic)
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced