### PR TITLE
fix(core): pass workspace scanner through sync daemon to inbound apply

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -698,6 +698,11 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 						host: syncConfig.syncHost,
 						port: syncConfig.syncPort,
 						signal: syncAbort.signal,
+						// Foreground mode: hand the daemon the same workspace-aware
+						// scanner the local writes use, so workspace `secret_scanner`
+						// rules apply to inbound peer payloads instead of the daemon
+						// silently falling back to the built-in default ruleset.
+						scanner: store.scanner,
 						onPhaseChange: (phase) => {
 							if (phase === "running") {
 								syncRuntimeStatus.phase = null;

--- a/packages/core/src/sync-daemon.test.ts
+++ b/packages/core/src/sync-daemon.test.ts
@@ -156,6 +156,30 @@ describe("syncDaemonTick", () => {
 			expect.objectContaining({ limit: 750, keysDir: "/tmp/keys" }),
 		);
 	});
+
+	it("forwards the workspace scanner to runSyncPass so inbound peer apply uses workspace rules", async () => {
+		// Wiring regression: without this, the daemon path falls back to the
+		// built-in default scanner and the foreground viewer's workspace
+		// `secret_scanner` config block is silently skipped on inbound
+		// peer payloads. sync-pass.ts:syncOnce emits a one-shot warning
+		// "[codemem] sync apply running without explicit scanner" when no
+		// scanner is supplied; serve.ts now passes store.scanner through
+		// runSyncDaemon → runTickOnce → syncDaemonTick → runSyncPass.
+		const { runSyncPass } = await import("./sync-pass.js");
+		const now = new Date().toISOString();
+		db.prepare(
+			"INSERT INTO sync_peers (peer_device_id, pinned_fingerprint, created_at) VALUES (?, ?, ?)",
+		).run("peer-1", "fp1", now);
+
+		const fakeScanner = { scan: vi.fn() } as unknown as Parameters<typeof syncDaemonTick>[3];
+		await syncDaemonTick(db, "/tmp/keys", new Set(), fakeScanner);
+
+		expect(runSyncPass).toHaveBeenCalledWith(
+			db,
+			"peer-1",
+			expect.objectContaining({ scanner: fakeScanner }),
+		);
+	});
 });
 
 describe("refreshCoordinatorPresenceForDaemon", () => {

--- a/packages/core/src/sync-daemon.ts
+++ b/packages/core/src/sync-daemon.ts
@@ -36,6 +36,17 @@ export interface SyncDaemonOptions {
 	keysDir?: string;
 	signal?: AbortSignal;
 	onPhaseChange?: (phase: "starting" | "running" | "stopping") => void;
+	/**
+	 * Workspace-aware secret scanner. When provided, the daemon's inbound
+	 * peer apply path uses this scanner so any rules from the workspace
+	 * `secret_scanner` config block are applied to received payloads.
+	 * Without it, the apply path falls back to the built-in default
+	 * ruleset and emits a single "sync apply running without explicit
+	 * scanner" warning per process. Pass `store.scanner` from the viewer
+	 * (`packages/cli/src/commands/serve.ts`) so foreground deployments
+	 * stay in lockstep with local writes.
+	 */
+	scanner?: SecretScanner;
 }
 
 export interface SyncTickResult {
@@ -221,6 +232,7 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
 	const keysDir = options?.keysDir;
 	const signal = options?.signal;
 	const onPhaseChange = options?.onPhaseChange;
+	const scanner = options?.scanner;
 	onPhaseChange?.("starting");
 
 	// Ensure device identity
@@ -252,7 +264,7 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
 		const runTick = () => {
 			if (tickRunning) return; // Skip if previous tick still running
 			tickRunning = true;
-			runTickOnce(dbPath, keysDir).finally(() => {
+			runTickOnce(dbPath, keysDir, scanner).finally(() => {
 				tickRunning = false;
 				if (!firstTickCompleted) {
 					firstTickCompleted = true;
@@ -286,7 +298,11 @@ export async function runSyncDaemon(options?: SyncDaemonOptions): Promise<void> 
  *
  * Errors are caught and recorded in sync_daemon_state.
  */
-export async function runTickOnce(dbPath: string, keysDir?: string): Promise<void> {
+export async function runTickOnce(
+	dbPath: string,
+	keysDir?: string,
+	scanner?: SecretScanner,
+): Promise<void> {
 	const db = connectDb(dbPath);
 	try {
 		ensureAdditiveSchemaCompatibility(db);
@@ -299,7 +315,7 @@ export async function runTickOnce(dbPath: string, keysDir?: string): Promise<voi
 		// Best-effort: skip peers the coordinator reports as offline.
 		// Returns empty set when coordinator is disabled or lookup fails.
 		const stalePeers = await fetchCoordinatorStalePeers(db, dbPath, keysDir);
-		const results = await syncDaemonTick(db, keysDir, stalePeers);
+		const results = await syncDaemonTick(db, keysDir, stalePeers, scanner);
 		const needsAttention = results.some((r) => !r.ok && r.error?.includes("needs_attention"));
 		if (needsAttention) {
 			setSyncDaemonPhase(db, "needs_attention");


### PR DESCRIPTION
## Description

The viewer logs `[codemem] sync apply running without explicit scanner — workspace-level secret rules will not apply to inbound peer content` on every startup. The default scanner with built-in PAT/AWS rules still runs, but **workspace-level `secret_scanner` config blocks are silently skipped on payloads received from peers** — only local writes see the workspace rules.

Cause: `SyncDaemonOptions` / `runSyncDaemon` / `runTickOnce` / `syncDaemonTick` all carried the scanner shape internally, but `serve.ts` (the foreground viewer) never threaded its `store.scanner` through to `runSyncDaemon`. The 4th param of `syncDaemonTick` was a no-op for production deployments, and `syncOnce`'s one-shot warning fired exactly once per viewer process.

Plumbed the scanner end-to-end:

- `SyncDaemonOptions.scanner?: SecretScanner` — new optional field for backward compat with daemon-only deployments
- `runSyncDaemon` picks it up and passes to `runTickOnce`
- `runTickOnce` takes a 3rd `scanner` param and forwards to `syncDaemonTick` (which already accepted one and routed it into `runSyncPass`)
- `packages/cli/src/commands/serve.ts`: `runSyncDaemon({ ..., scanner: store.scanner })`, so foreground deployments stay in lockstep with local writes

Daemon-only deployments without a viewer process still get the default scanner + the one-shot warning — they need a separate fix (rebuild the scanner inside `runTickOnce` from `readCodememConfigFile().secret_scanner`) which isn't in scope here. The foreground case is the dominant deployment shape and the one that's been visibly emitting the warning.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test` — 1766 tests)
- [x] Added/updated tests for changes — new regression test in `sync-daemon.test.ts` asserts that when a scanner is passed into `syncDaemonTick`, `runSyncPass` receives it via its options object
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced