### PR TITLE
fix(plugin): point Claude marketplace at latest stable (0.29.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.29.1"
+    "version": "0.29.4"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.29.1",
+      "version": "0.29.4",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.29.1",
+  "version": "0.29.4",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Summary

- Bumps `.claude-plugin/marketplace.json` and `plugins/claude/.claude-plugin/plugin.json` from `0.29.1` → `0.29.4` so the Claude Code marketplace listing reflects the latest stable release.
- Pure pointer bump on `main` — no package version changes elsewhere. The marketplace catalog is sourced from `main`, while package versions ride on the `release/0.29` and `release/0.30` lines.

## Why this was needed

The `release-version` script bumps these files as part of the standard release flow on the `release/*` branch, but those bumps never get forwarded back to `main`. Result: every release since 0.29.1 (so 0.29.2, 0.29.3, 0.29.4) has been invisible to `/plugin` users, who all see 0.29.1 as the "latest". Caught when an alpha tester ran `/plugin` after installing 0.29.4 and saw 0.29.1 still listed.

Follow-up: `scripts/release-version.mjs` should either land these bumps on `main` directly during release, or there should be a separate "publish marketplace" step. Tracked separately.

## Test plan

- [ ] CI green
- [ ] Reload Claude Code marketplace → `/plugin` shows codemem 0.29.4