### PR TITLE
fix(core): scope sqlite-vec semantic retrieval

### DIFF
--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -48,6 +48,65 @@ describe("buildMemoryPack", () => {
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
+	function insertCoordinatorScope(scopeId: string): void {
+		const now = new Date().toISOString();
+		store.db
+			.prepare(
+				`INSERT OR REPLACE INTO replication_scopes(
+					scope_id, label, kind, authority_type, coordinator_id, group_id,
+					membership_epoch, status, created_at, updated_at
+				 ) VALUES (?, ?, 'team', 'coordinator', 'coord-test', 'group-test', 0, 'active', ?, ?)`,
+			)
+			.run(scopeId, scopeId, now, now);
+	}
+
+	function grantScopeToLocalDevice(scopeId: string): void {
+		insertCoordinatorScope(scopeId);
+		store.db
+			.prepare(
+				`INSERT OR REPLACE INTO scope_memberships(
+					scope_id, device_id, role, status, membership_epoch,
+					coordinator_id, group_id, updated_at
+				 ) VALUES (?, ?, 'member', 'active', 0, 'coord-test', 'group-test', ?)`,
+			)
+			.run(scopeId, store.deviceId, new Date().toISOString());
+	}
+
+	function insertScopedMemory(scopeId: string, title: string, bodyText: string): number {
+		const now = new Date().toISOString();
+		const info = store.db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility, scope_id)
+				 VALUES (?, 'discovery', ?, ?, 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+			)
+			.run(sessionId, title, bodyText, now, now, scopeId);
+		return Number(info.lastInsertRowid);
+	}
+
+	function semanticCandidate(
+		id: number,
+		title: string,
+		bodyText: string,
+		score: number,
+	): MemoryResult {
+		return {
+			id,
+			kind: "discovery",
+			title,
+			body_text: bodyText,
+			confidence: 0.9,
+			created_at: "2026-01-01T00:00:00.000Z",
+			updated_at: "2026-01-01T00:00:00.000Z",
+			tags_text: "",
+			score,
+			session_id: sessionId,
+			metadata: {},
+			narrative: null,
+			facts: null,
+		};
+	}
+
 	it("returns items and pack_text for matching context", () => {
 		store.remember(sessionId, "discovery", "Found database issue", "The DB was slow", 0.8);
 		store.remember(sessionId, "bugfix", "Fixed database query", "Optimized the join", 0.9);
@@ -634,9 +693,27 @@ describe("buildMemoryPack", () => {
 	});
 
 	it("keeps working-set overlaps prioritized when semantic candidates are merged", () => {
+		const overlappingId = store.remember(
+			sessionId,
+			"feature",
+			"Overlapping file",
+			"Directly related to current file",
+			0.9,
+			undefined,
+			{ files_modified: ["src/important.ts"] },
+		);
+		const nonOverlappingId = store.remember(
+			sessionId,
+			"feature",
+			"Non-overlapping file",
+			"Not tied to working set",
+			0.9,
+			undefined,
+			{ files_modified: ["src/other.ts"] },
+		);
 		const semanticResults: MemoryResult[] = [
 			{
-				id: 1,
+				id: overlappingId,
 				kind: "feature",
 				title: "Overlapping file",
 				body_text: "Directly related to current file",
@@ -651,7 +728,7 @@ describe("buildMemoryPack", () => {
 				facts: null,
 			},
 			{
-				id: 2,
+				id: nonOverlappingId,
 				kind: "feature",
 				title: "Non-overlapping file",
 				body_text: "Not tied to working set",
@@ -676,7 +753,129 @@ describe("buildMemoryPack", () => {
 			semanticResults,
 		);
 
-		expect(pack.item_ids[0]).toBe(1);
+		expect(pack.item_ids[0]).toBe(overlappingId);
+	});
+
+	it("scopes caller-provided semantic candidates before pack merge", () => {
+		grantScopeToLocalDevice("authorized-team");
+		insertCoordinatorScope("unauthorized-team");
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Visible semantic pack note",
+			"visible semantic pack body",
+		);
+		const hiddenId = insertScopedMemory(
+			"unauthorized-team",
+			"Hidden semantic pack note",
+			"hidden semantic pack body",
+		);
+		const semanticResults: MemoryResult[] = [
+			{
+				id: hiddenId,
+				kind: "discovery",
+				title: "Hidden semantic pack note",
+				body_text: "hidden semantic pack body",
+				confidence: 0.9,
+				created_at: "2026-01-01T00:00:00.000Z",
+				updated_at: "2026-01-01T00:00:00.000Z",
+				tags_text: "",
+				score: 0.99,
+				session_id: sessionId,
+				metadata: {},
+				narrative: null,
+				facts: null,
+			},
+			{
+				id: visibleId,
+				kind: "discovery",
+				title: "Visible semantic pack note",
+				body_text: "visible semantic pack body",
+				confidence: 0.9,
+				created_at: "2026-01-01T00:00:00.000Z",
+				updated_at: "2026-01-01T00:00:00.000Z",
+				tags_text: "",
+				score: 0.5,
+				session_id: sessionId,
+				metadata: {},
+				narrative: null,
+				facts: null,
+			},
+		];
+
+		const pack = buildMemoryPack(store, "zzz_nomatch_zzz", 10, null, undefined, semanticResults);
+
+		expect(pack.item_ids).toContain(visibleId);
+		expect(pack.item_ids).not.toContain(hiddenId);
+		expect(pack.pack_text).toContain("Visible semantic pack note");
+		expect(pack.pack_text).not.toContain("Hidden semantic pack note");
+		expect(pack.metrics.sources.semantic).toBe(1);
+	});
+
+	it("keeps revalidating semantic candidates after hidden candidates fill the first chunk", () => {
+		grantScopeToLocalDevice("authorized-team");
+		insertCoordinatorScope("unauthorized-team");
+		const semanticResults: MemoryResult[] = [];
+		for (let i = 0; i < 205; i += 1) {
+			const hiddenId = insertScopedMemory(
+				"unauthorized-team",
+				`Hidden semantic pack note ${i}`,
+				"hidden semantic pack body",
+			);
+			semanticResults.push(
+				semanticCandidate(
+					hiddenId,
+					`Hidden semantic pack note ${i}`,
+					"hidden semantic pack body",
+					1,
+				),
+			);
+		}
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Visible semantic pack note after hidden chunk",
+			"visible semantic pack body",
+		);
+		semanticResults.push(
+			semanticCandidate(
+				visibleId,
+				"Visible semantic pack note after hidden chunk",
+				"visible semantic pack body",
+				0.5,
+			),
+		);
+
+		const pack = buildMemoryPack(store, "zzz_nomatch_zzz", 10, null, undefined, semanticResults);
+
+		expect(pack.item_ids).toContain(visibleId);
+		expect(pack.metrics.sources.semantic).toBe(1);
+	});
+
+	it("scopes latest summary fallback during pack assembly", () => {
+		grantScopeToLocalDevice("authorized-team");
+		insertCoordinatorScope("unauthorized-team");
+		const insertSummary = (scopeId: string, title: string, createdAt: string): number => {
+			const info = store.db
+				.prepare(
+					`INSERT INTO memory_items(
+						session_id, kind, title, body_text, confidence, tags_text, active,
+						created_at, updated_at, metadata_json, rev, visibility, scope_id
+					) VALUES (?, 'session_summary', ?, ?, 0.8, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+				)
+				.run(sessionId, title, `${title} body`, createdAt, createdAt, scopeId);
+			return Number(info.lastInsertRowid);
+		};
+		insertSummary("authorized-team", "Authorized fallback summary", "2026-01-01T00:00:00.000Z");
+		insertSummary("unauthorized-team", "Hidden fallback summary", "2026-01-03T00:00:00.000Z");
+		insertScopedMemory(
+			"authorized-team",
+			"Newest visible non-summary",
+			"visible fallback anchor body",
+		);
+
+		const pack = buildMemoryPack(store, "zzz_nomatch_zzz", 1);
+
+		expect(pack.pack_text).toContain("Authorized fallback summary");
+		expect(pack.pack_text).not.toContain("Hidden fallback summary");
 	});
 
 	it("keeps topical terms when using task mode", () => {

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -14,7 +14,7 @@
  * tracking, discovery-token work estimation.
  */
 
-import type { Database } from "./db.js";
+import { type Database, fromJson } from "./db.js";
 import { buildFilterClausesWithContext } from "./filters.js";
 import { inferMemoryRole } from "./memory-quality.js";
 import { projectBasename } from "./project.js";
@@ -68,6 +68,7 @@ const TASK_HINT_QUERY =
 
 const RECALL_HINT_QUERY = "session summary recap remember last time previous work";
 
+const MAX_SEMANTIC_REVALIDATION_IDS = 200;
 const TRACE_CANDIDATE_LIMIT = 20;
 const TRACE_PREVIEW_LIMIT = 160;
 
@@ -895,6 +896,7 @@ function findLatestSummaryLike(store: StoreHandle, filters?: MemoryFilters): Mem
 	const filterResult = buildFilterClausesWithContext(filters ?? null, {
 		actorId: store.actorId,
 		deviceId: store.deviceId,
+		enforceScopeVisibility: true,
 	});
 	const whereParts = [
 		"memory_items.active = 1",
@@ -1065,14 +1067,76 @@ function mergeResults(
 		const existing = seen.get(r.id);
 		if (!existing || r.score > existing.score) seen.set(r.id, r);
 	}
+	const scopedSemanticResults = scopeSemanticResults(store, semanticResults, filters);
 	let semanticCount = 0;
-	for (const r of semanticResults) {
+	for (const r of scopedSemanticResults) {
 		if (!seen.has(r.id)) semanticCount++;
 		const existing = seen.get(r.id);
 		if (!existing || r.score > existing.score) seen.set(r.id, r);
 	}
 	const merged = rerankResults(store, [...seen.values()], limit, filters, query);
 	return { merged, ftsCount: ftsResults.length, semanticCount };
+}
+
+function scopeSemanticResults(
+	store: StoreHandle,
+	semanticResults: MemoryResult[],
+	filters?: MemoryFilters,
+): MemoryResult[] {
+	if (semanticResults.length === 0) return [];
+	const originalById = new Map<number, MemoryResult>();
+	for (const item of semanticResults) {
+		if (!Number.isSafeInteger(item.id) || item.id <= 0) continue;
+		if (!originalById.has(item.id)) originalById.set(item.id, item);
+	}
+	const ids = [...originalById.keys()];
+	if (ids.length === 0) return [];
+
+	const filterResult = buildFilterClausesWithContext(filters ?? null, {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+		enforceScopeVisibility: true,
+	});
+	const joinClause = filterResult.joinSessions
+		? "JOIN sessions ON sessions.id = memory_items.session_id"
+		: "";
+	const scopedById = new Map<number, MemoryResult>();
+	for (let offset = 0; offset < ids.length; offset += MAX_SEMANTIC_REVALIDATION_IDS) {
+		const chunkIds = ids.slice(offset, offset + MAX_SEMANTIC_REVALIDATION_IDS);
+		const placeholders = chunkIds.map(() => "?").join(", ");
+		const rows = store.db
+			.prepare(
+				`SELECT memory_items.*
+				 FROM memory_items
+				 ${joinClause}
+				 WHERE ${["memory_items.active = 1", `memory_items.id IN (${placeholders})`, ...filterResult.clauses].join(" AND ")}`,
+			)
+			.all(...chunkIds, ...filterResult.params) as Array<Record<string, unknown>>;
+
+		for (const row of rows) {
+			const id = Number(row.id);
+			const original = originalById.get(id);
+			if (!original) continue;
+			const metadataJson = row.metadata_json == null ? null : String(row.metadata_json);
+			scopedById.set(id, {
+				id,
+				kind: canonicalMemoryKind(String(row.kind ?? "observation"), metadataJson),
+				title: String(row.title ?? ""),
+				body_text: String(row.body_text ?? ""),
+				confidence: Number(row.confidence ?? 0),
+				created_at: String(row.created_at ?? ""),
+				updated_at: String(row.updated_at ?? ""),
+				tags_text: String(row.tags_text ?? ""),
+				score: original.score,
+				session_id: Number(row.session_id),
+				metadata: fromJson(metadataJson),
+				narrative: row.narrative == null ? null : String(row.narrative),
+				facts: row.facts == null ? null : String(row.facts),
+			});
+		}
+	}
+
+	return ids.map((id) => scopedById.get(id)).filter((item): item is MemoryResult => !!item);
 }
 
 /**
@@ -1821,8 +1885,9 @@ export async function buildMemoryPackAsync(
 	let semResults: MemoryResult[] = [];
 	const semanticQuery = sanitizeSearchQuery(context).clean_query;
 	try {
-		const raw = await semanticSearch(store.db, semanticQuery, limit, {
-			project: filters?.project,
+		const raw = await semanticSearch(store.db, semanticQuery, limit, filters, {
+			actorId: store.actorId,
+			deviceId: store.deviceId,
 		});
 		semResults = semanticMemoryResults(raw);
 	} catch {
@@ -1847,8 +1912,9 @@ export async function buildMemoryPackTraceAsync(
 	let semResults: MemoryResult[] = [];
 	const semanticQuery = sanitizeSearchQuery(context).clean_query;
 	try {
-		const raw = await semanticSearch(store.db, semanticQuery, limit, {
-			project: filters?.project,
+		const raw = await semanticSearch(store.db, semanticQuery, limit, filters, {
+			actorId: store.actorId,
+			deviceId: store.deviceId,
 		});
 		semResults = semanticMemoryResults(raw);
 	} catch {

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -48,6 +48,53 @@ describe("vectors", () => {
 		db.close();
 	});
 
+	function insertCoordinatorScope(scopeId: string): void {
+		const now = new Date().toISOString();
+		db.prepare(
+			`INSERT OR REPLACE INTO replication_scopes(
+				scope_id, label, kind, authority_type, coordinator_id, group_id,
+				membership_epoch, status, created_at, updated_at
+			 ) VALUES (?, ?, 'team', 'coordinator', 'coord-test', 'group-test', 0, 'active', ?, ?)`,
+		).run(scopeId, scopeId, now, now);
+	}
+
+	function grantScopeToDevice(scopeId: string, deviceId: string): void {
+		insertCoordinatorScope(scopeId);
+		db.prepare(
+			`INSERT OR REPLACE INTO scope_memberships(
+				scope_id, device_id, role, status, membership_epoch,
+				coordinator_id, group_id, updated_at
+			 ) VALUES (?, ?, 'member', 'active', 0, 'coord-test', 'group-test', ?)`,
+		).run(scopeId, deviceId, new Date().toISOString());
+	}
+
+	function insertScopedMemory(scopeId: string, title: string, bodyText: string): number {
+		const sessionId = insertTestSession(db);
+		const now = new Date().toISOString();
+		const info = db
+			.prepare(
+				`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				 tags_text, active, created_at, updated_at, metadata_json, rev, visibility, scope_id)
+				 VALUES (?, 'discovery', ?, ?, 0.5, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+			)
+			.run(sessionId, title, bodyText, now, now, scopeId);
+		return Number(info.lastInsertRowid);
+	}
+
+	function insertTestVector(memoryId: number, value: number, contentHash: string): void {
+		const vector = new Float32Array(384).fill(value);
+		db.exec(`
+			INSERT INTO memory_vectors(embedding, memory_id, chunk_index, content_hash, model)
+			VALUES (
+				vec_f32('${JSON.stringify(Array.from(vector))}'),
+				${memoryId},
+				0,
+				'${contentHash}',
+				'test-model'
+			)
+		`);
+	}
+
 	it("stores vectors with integer metadata columns via sqlite-vec workaround", async () => {
 		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
 
@@ -414,6 +461,91 @@ describe("vectors", () => {
 			{ model: "old-model", c: 1 },
 			{ model: "test-model", c: 1 },
 		]);
+	});
+
+	it("filters semantic search candidates by local scope authorization", async () => {
+		const deviceId = "device-authorized";
+		grantScopeToDevice("authorized-team", deviceId);
+		insertCoordinatorScope("unauthorized-team");
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Visible semantic note",
+			"semantic scope detail",
+		);
+		const hiddenId = insertScopedMemory(
+			"unauthorized-team",
+			"Hidden semantic note",
+			"semantic scope secret",
+		);
+		insertTestVector(visibleId, 0, "visible-hash");
+		insertTestVector(hiddenId, 0, "hidden-hash");
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+
+		const results = await semanticSearch(db, "semantic scope", 10, null, {
+			actorId: "local:device-authorized",
+			deviceId,
+		});
+
+		const resultIds = results.map((item) => item.id);
+		expect(resultIds).toContain(visibleId);
+		expect(resultIds).not.toContain(hiddenId);
+	});
+
+	it("intersects semantic search scope filters with local authorization", async () => {
+		const deviceId = "device-authorized";
+		grantScopeToDevice("authorized-team", deviceId);
+		insertCoordinatorScope("unauthorized-team");
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Visible semantic note",
+			"semantic scope detail",
+		);
+		const hiddenId = insertScopedMemory(
+			"unauthorized-team",
+			"Hidden semantic note",
+			"semantic scope secret",
+		);
+		insertTestVector(visibleId, 0, "visible-hash");
+		insertTestVector(hiddenId, 0, "hidden-hash");
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+		const context = { actorId: "local:device-authorized", deviceId };
+
+		expect(
+			await semanticSearch(db, "semantic scope", 10, { scope_id: "unauthorized-team" }, context),
+		).toEqual([]);
+		expect(
+			(
+				await semanticSearch(db, "semantic scope", 10, { scope_id: "authorized-team" }, context)
+			).map((item) => item.id),
+		).toContain(visibleId);
+	});
+
+	it("widens KNN candidates before scope filtering", async () => {
+		const deviceId = "device-authorized";
+		grantScopeToDevice("authorized-team", deviceId);
+		insertCoordinatorScope("unauthorized-team");
+		for (let i = 0; i < 12; i += 1) {
+			const hiddenId = insertScopedMemory(
+				"unauthorized-team",
+				`Closest hidden semantic note ${i}`,
+				"semantic scope secret",
+			);
+			insertTestVector(hiddenId, 0, `hidden-hash-${i}`);
+		}
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Visible semantic fallback note",
+			"semantic scope detail",
+		);
+		insertTestVector(visibleId, 0.5, "visible-hash");
+		vi.mocked(embeddings.embedTexts).mockResolvedValue([new Float32Array(384)]);
+
+		const results = await semanticSearch(db, "semantic scope", 1, null, {
+			actorId: "local:device-authorized",
+			deviceId,
+		});
+
+		expect(results.map((item) => item.id)).toEqual([visibleId]);
 	});
 
 	it("skips query embedding when vector search is disabled during migration", async () => {

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -19,15 +19,38 @@ import {
 	resolveEmbeddingModel,
 	serializeFloat32,
 } from "./embeddings.js";
+import { buildFilterClausesWithContext, type OwnershipFilterContext } from "./filters.js";
 import { getMaintenanceJob } from "./maintenance-jobs.js";
 import { projectClause } from "./project.js";
 import type { ReplicationVectorWork } from "./sync-replication.js";
+import type { MemoryFilters } from "./types.js";
 
 const VECTOR_MODEL_MIGRATION_JOB = "vector_model_migration";
 
 type VectorModelCount = { model: string; rows: number };
 
 type MemoryTextRow = { id: number; title: string | null; body_text: string | null };
+
+export interface SemanticSearchScopeContext {
+	actorId: string;
+	deviceId: string;
+}
+
+function scopeVisibleFilterContext(
+	context: SemanticSearchScopeContext | null | undefined,
+): OwnershipFilterContext {
+	return {
+		actorId: context?.actorId ?? "",
+		deviceId: context?.deviceId ?? "",
+		enforceScopeVisibility: true,
+	};
+}
+
+function clampSemanticLimit(limit: number): number {
+	if (limit === Number.POSITIVE_INFINITY) return 200;
+	if (!Number.isFinite(limit)) return 1;
+	return Math.min(Math.max(1, Math.trunc(limit)), 200);
+}
 
 function listVectorModelCounts(db: Database): VectorModelCount[] {
 	if (!tableExists(db, "memory_vectors")) {
@@ -671,7 +694,8 @@ export async function semanticSearch(
 	db: Database,
 	query: string,
 	limit = 10,
-	filters?: { project?: string | null } | null,
+	filters?: MemoryFilters | null,
+	context?: SemanticSearchScopeContext | null,
 ): Promise<SemanticSearchResult[]> {
 	if (query.trim().length < 3) return [];
 	const searchModel = resolveSemanticSearchModel(db, resolveEmbeddingModel());
@@ -683,21 +707,16 @@ export async function semanticSearch(
 	const firstEmbedding = embeddings[0];
 	if (!firstEmbedding) return [];
 	const queryEmbedding = serializeFloat32(firstEmbedding);
-	const params: unknown[] = [queryEmbedding, limit, searchModel];
+	const effectiveLimit = clampSemanticLimit(limit);
+	let knnLimit = Math.min(Math.max(effectiveLimit * 4, effectiveLimit + 8), 200);
 	const whereClauses: string[] = ["memory_items.active = 1"];
-	let joinSessions = false;
-
-	if (filters?.project) {
-		const pc = projectClause(filters.project);
-		if (pc.clause) {
-			whereClauses.push(pc.clause);
-			params.push(...pc.params);
-			joinSessions = true;
-		}
-	}
+	const filterResult = buildFilterClausesWithContext(filters, scopeVisibleFilterContext(context));
+	whereClauses.push(...filterResult.clauses);
 
 	const where = whereClauses.join(" AND ");
-	const joinClause = joinSessions ? "JOIN sessions ON sessions.id = memory_items.session_id" : "";
+	const joinClause = filterResult.joinSessions
+		? "JOIN sessions ON sessions.id = memory_items.session_id"
+		: "";
 
 	const sql = `
 		SELECT memory_items.*, memory_vectors.distance
@@ -711,22 +730,34 @@ export async function semanticSearch(
 		ORDER BY memory_vectors.distance ASC
 	`;
 
-	const rows = db.prepare(sql).all(...params) as Array<Record<string, unknown>>;
+	const statement = db.prepare(sql);
+	let rows: Array<Record<string, unknown>> = [];
+	while (true) {
+		rows = statement.all(queryEmbedding, knnLimit, searchModel, ...filterResult.params) as Array<
+			Record<string, unknown>
+		>;
+		if (rows.length >= effectiveLimit || knnLimit >= 200) break;
+		const nextLimit = Math.min(knnLimit * 2, 200);
+		if (nextLimit === knnLimit) break;
+		knnLimit = nextLimit;
+	}
 
-	return rows.map((row) => ({
-		id: Number(row.id),
-		kind: String(row.kind ?? "observation"),
-		title: String(row.title ?? ""),
-		body_text: String(row.body_text ?? ""),
-		confidence: Number(row.confidence ?? 0),
-		tags_text: String(row.tags_text ?? ""),
-		metadata_json: row.metadata_json == null ? null : String(row.metadata_json),
-		created_at: String(row.created_at ?? ""),
-		updated_at: String(row.updated_at ?? ""),
-		session_id: Number(row.session_id),
-		score: 1.0 / (1.0 + Number(row.distance ?? 0)),
-		distance: Number(row.distance ?? 0),
-		narrative: row.narrative == null ? null : String(row.narrative),
-		facts: row.facts == null ? null : String(row.facts),
-	}));
+	return rows
+		.map((row) => ({
+			id: Number(row.id),
+			kind: String(row.kind ?? "observation"),
+			title: String(row.title ?? ""),
+			body_text: String(row.body_text ?? ""),
+			confidence: Number(row.confidence ?? 0),
+			tags_text: String(row.tags_text ?? ""),
+			metadata_json: row.metadata_json == null ? null : String(row.metadata_json),
+			created_at: String(row.created_at ?? ""),
+			updated_at: String(row.updated_at ?? ""),
+			session_id: Number(row.session_id),
+			score: 1.0 / (1.0 + Number(row.distance ?? 0)),
+			distance: Number(row.distance ?? 0),
+			narrative: row.narrative == null ? null : String(row.narrative),
+			facts: row.facts == null ? null : String(row.facts),
+		}))
+		.slice(0, effectiveLimit);
 }


### PR DESCRIPTION
## Description

Applies the central scope-visibility gate to the sqlite-vec semantic search path so KNN candidates outside locally authorized sharing domains can never reach the hybrid merge. Vectors inherit memory scope; explicit scope filters intersect with authorization. KNN candidate widening goes up to a cap of 200 so authorized candidates are not crowded out by hidden neighbors.

Decomposed from codemem-ov4g.5.3 → ov4g.5.7.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Coverage: \`semanticSearch\` filters by local scope auth, intersects with explicit scope filters, ranks only authorized candidates when unauthorized candidates dominate the K nearest, and requires explicit context.

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced