### PR TITLE
fix(core): harden memory pack scope assembly

### DIFF
--- a/packages/core/src/filters.ts
+++ b/packages/core/src/filters.ts
@@ -110,7 +110,7 @@ function addScopeVisibilityFilter(
 	// but until that completes those rows must remain visible to their owning
 	// device exactly the way local-default rows are.
 	clauses.push(`(
-		COALESCE(TRIM(memory_items.scope_id), '') IN ('', ?, ?)
+		COALESCE(TRIM(memory_items.scope_id), '') IN (?, ?, ?)
 		OR EXISTS (
 			SELECT 1
 			FROM replication_scopes rs
@@ -129,7 +129,7 @@ function addScopeVisibilityFilter(
 			  AND sm.membership_epoch >= rs.membership_epoch
 		)
 	)`);
-	params.push(LOCAL_DEFAULT_SCOPE_ID, LEGACY_SHARED_REVIEW_SCOPE_ID, deviceId);
+	params.push("", LOCAL_DEFAULT_SCOPE_ID, LEGACY_SHARED_REVIEW_SCOPE_ID, deviceId);
 }
 
 /**

--- a/packages/core/src/maintenance.test.ts
+++ b/packages/core/src/maintenance.test.ts
@@ -379,16 +379,16 @@ describe("maintenance", { timeout: 15_000 }, () => {
 		try {
 			initTestSchema(db);
 			db.exec(`
-				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version) VALUES
-				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
-				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
-				  ('opencode', 'ses-1', 'ses-1', 1, '2026-03-01T10:00:00Z');
-				INSERT INTO memory_items(
-					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
-				) VALUES
-				  (1, 1, 'session_summary', 'Session recap', 'Summary body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1'),
-				  (2, 1, 'decision', 'OAuth callback fix', 'Patched callback validation', 1, '2026-03-01T10:10:01Z', '2026-03-01T10:10:01Z', '{}', 'k2');
-			`);
+					INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version) VALUES
+					  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
+					INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+					  ('opencode', 'ses-1', 'ses-1', 1, '2026-03-01T10:00:00Z');
+					INSERT INTO memory_items(
+						id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key, scope_id
+					) VALUES
+					  (1, 1, 'session_summary', 'Session recap', 'Summary body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1', 'local-default'),
+					  (2, 1, 'decision', 'OAuth callback fix', 'Patched callback validation', 1, '2026-03-01T10:10:01Z', '2026-03-01T10:10:01Z', '{}', 'k2', 'local-default');
+				`);
 		} finally {
 			db.close();
 		}
@@ -493,18 +493,18 @@ describe("maintenance", { timeout: 15_000 }, () => {
 		const baselineDb = new Database(baselinePath);
 		try {
 			baselineDb.exec(`
-				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version) VALUES
-				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test'),
-				  (2, '2026-03-01T10:20:00Z', '2026-03-01T10:20:20Z', '/tmp/repo', 'codemem', 'adam', 'test');
-				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
-				  ('opencode', 'ses-1', 'ses-1', 1, '2026-03-01T10:00:00Z');
-				INSERT INTO memory_items(
-					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
-				) VALUES
-				  (1, 1, 'session_summary', 'Session recap', 'Summary body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1'),
-				  (2, 2, 'change', 'Legacy recap', '## Request\nfoo\n\n## Completed\nbar', 1, '2026-03-01T10:20:20Z', '2026-03-01T10:20:20Z', '{"is_summary":true}', 'k2'),
-				  (3, 2, 'decision', 'OAuth callback fix', 'Patched callback validation', 1, '2026-03-01T10:20:21Z', '2026-03-01T10:20:21Z', '{}', 'k3');
-			`);
+					INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version) VALUES
+					  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test'),
+					  (2, '2026-03-01T10:20:00Z', '2026-03-01T10:20:20Z', '/tmp/repo', 'codemem', 'adam', 'test');
+					INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+					  ('opencode', 'ses-1', 'ses-1', 1, '2026-03-01T10:00:00Z');
+					INSERT INTO memory_items(
+						id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key, scope_id
+					) VALUES
+					  (1, 1, 'session_summary', 'Session recap', 'Summary body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1', 'local-default'),
+					  (2, 2, 'change', 'Legacy recap', '## Request\nfoo\n\n## Completed\nbar', 1, '2026-03-01T10:20:20Z', '2026-03-01T10:20:20Z', '{"is_summary":true}', 'k2', 'local-default'),
+					  (3, 2, 'decision', 'OAuth callback fix', 'Patched callback validation', 1, '2026-03-01T10:20:21Z', '2026-03-01T10:20:21Z', '{}', 'k3', 'local-default');
+				`);
 		} finally {
 			baselineDb.close();
 		}
@@ -512,16 +512,16 @@ describe("maintenance", { timeout: 15_000 }, () => {
 		const candidateDb = new Database(candidatePath);
 		try {
 			candidateDb.exec(`
-				INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version) VALUES
-				  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
-				INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
-				  ('opencode', 'ses-1', 'ses-1', 1, '2026-03-01T10:00:00Z');
-				INSERT INTO memory_items(
-					id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key
-				) VALUES
-				  (20, 1, 'decision', 'OAuth callback fix', 'Patched callback validation', 1, '2026-03-01T10:20:21Z', '2026-03-01T10:20:21Z', '{}', 'k3'),
-				  (21, 1, 'session_summary', 'Session recap', 'Summary body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1');
-			`);
+					INSERT INTO sessions(id, started_at, ended_at, cwd, project, user, tool_version) VALUES
+					  (1, '2026-03-01T10:00:00Z', '2026-03-01T10:10:00Z', '/tmp/repo', 'codemem', 'adam', 'test');
+					INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES
+					  ('opencode', 'ses-1', 'ses-1', 1, '2026-03-01T10:00:00Z');
+					INSERT INTO memory_items(
+						id, session_id, kind, title, body_text, active, created_at, updated_at, metadata_json, import_key, scope_id
+					) VALUES
+					  (20, 1, 'decision', 'OAuth callback fix', 'Patched callback validation', 1, '2026-03-01T10:20:21Z', '2026-03-01T10:20:21Z', '{}', 'k3', 'local-default'),
+					  (21, 1, 'session_summary', 'Session recap', 'Summary body', 1, '2026-03-01T10:10:00Z', '2026-03-01T10:10:00Z', '{}', 'k1', 'local-default');
+				`);
 		} finally {
 			candidateDb.close();
 		}

--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -217,6 +217,152 @@ describe("buildMemoryPack", () => {
 		expect(typeof second.metrics.pack_token_delta).toBe("number");
 	});
 
+	it("does not use out-of-scope pack delta baselines", () => {
+		grantScopeToLocalDevice("authorized-team");
+		insertCoordinatorScope("unauthorized-team");
+		const hiddenId = insertScopedMemory(
+			"unauthorized-team",
+			"Hidden delta memory",
+			"delta scope body",
+		);
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Visible delta memory",
+			"delta scope body",
+		);
+		store.db
+			.prepare(
+				`INSERT INTO usage_events(
+					session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json
+				) VALUES (NULL, 'pack', 999, 0, 0, ?, ?)`,
+			)
+			.run(
+				"2026-01-01T00:00:00.000Z",
+				JSON.stringify({ pack_item_ids: [hiddenId], pack_tokens: 999 }),
+			);
+
+		const pack = buildMemoryPack(store, "delta", 10);
+
+		expect(pack.item_ids).toContain(visibleId);
+		expect(pack.item_ids).not.toContain(hiddenId);
+		expect(pack.metrics.pack_delta_available).toBe(false);
+		expect(pack.metrics.removed_ids).not.toContain(hiddenId);
+		expect(pack.metrics.retained_ids).not.toContain(hiddenId);
+		expect(pack.metrics.added_ids).not.toContain(hiddenId);
+	});
+
+	it("does not use itemless pack delta token baselines", () => {
+		grantScopeToLocalDevice("authorized-team");
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Visible empty-baseline memory",
+			"empty baseline body",
+		);
+		store.db
+			.prepare(
+				`INSERT INTO usage_events(
+					session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json
+				) VALUES (NULL, 'pack', 999, 0, 0, ?, ?)`,
+			)
+			.run("2026-01-01T00:00:00.000Z", JSON.stringify({ pack_item_ids: [], pack_tokens: 999 }));
+
+		const pack = buildMemoryPack(store, "empty baseline", 10);
+
+		expect(pack.item_ids).toContain(visibleId);
+		expect(pack.metrics.pack_delta_available).toBe(false);
+		expect(pack.metrics.pack_token_delta).toBe(0);
+	});
+
+	it("does not use pack delta baselines outside current scope filters", () => {
+		grantScopeToLocalDevice("scope-a");
+		grantScopeToLocalDevice("scope-b");
+		const scopeBId = insertScopedMemory("scope-b", "Scope B delta memory", "delta filter body");
+		const scopeAId = insertScopedMemory("scope-a", "Scope A delta memory", "delta filter body");
+		store.db
+			.prepare(
+				`INSERT INTO usage_events(
+					session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json
+				) VALUES (NULL, 'pack', 999, 0, 0, ?, ?)`,
+			)
+			.run(
+				"2026-01-01T00:00:00.000Z",
+				JSON.stringify({ pack_item_ids: [scopeBId], pack_tokens: 999 }),
+			);
+
+		const pack = buildMemoryPack(store, "delta filter", 10, null, { scope_id: "scope-a" });
+
+		expect(pack.item_ids).toContain(scopeAId);
+		expect(pack.item_ids).not.toContain(scopeBId);
+		expect(pack.metrics.pack_delta_available).toBe(false);
+		expect(pack.metrics.removed_ids).not.toContain(scopeBId);
+		expect(pack.metrics.retained_ids).not.toContain(scopeBId);
+	});
+
+	it("finds current-scope pack delta baselines beyond out-of-scope history", () => {
+		grantScopeToLocalDevice("scope-a");
+		grantScopeToLocalDevice("scope-b");
+		const scopeAId = insertScopedMemory("scope-a", "Scope A retained memory", "retained body");
+		const scopeBId = insertScopedMemory("scope-b", "Scope B noisy memory", "retained body");
+		const insertUsage = (ids: number[], createdAt: string, packTokens: number) => {
+			store.db
+				.prepare(
+					`INSERT INTO usage_events(
+						session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json
+					) VALUES (NULL, 'pack', ?, 0, 0, ?, ?)`,
+				)
+				.run(
+					packTokens,
+					createdAt,
+					JSON.stringify({ pack_item_ids: ids, pack_tokens: packTokens }),
+				);
+		};
+		insertUsage([scopeAId], "2026-01-01T00:00:00.000Z", 10);
+		for (let i = 0; i < 26; i += 1) {
+			insertUsage([scopeBId], `2026-01-02T00:${String(i).padStart(2, "0")}:00.000Z`, 999);
+		}
+
+		const pack = buildMemoryPack(store, "retained", 10, null, { scope_id: "scope-a" });
+
+		expect(pack.item_ids).toContain(scopeAId);
+		expect(pack.item_ids).not.toContain(scopeBId);
+		expect(pack.metrics.pack_delta_available).toBe(true);
+		expect(pack.metrics.retained_ids).toContain(scopeAId);
+		expect(pack.metrics.removed_ids).not.toContain(scopeBId);
+	});
+
+	it("bounds pack delta baseline scans when no current-scope baseline is recent", () => {
+		grantScopeToLocalDevice("scope-a");
+		grantScopeToLocalDevice("scope-b");
+		const scopeAId = insertScopedMemory("scope-a", "Scope A old retained memory", "retained body");
+		const scopeBId = insertScopedMemory("scope-b", "Scope B noisy old memory", "retained body");
+		const insertUsage = (ids: number[], createdAt: string, packTokens: number) => {
+			store.db
+				.prepare(
+					`INSERT INTO usage_events(
+						session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json
+					) VALUES (NULL, 'pack', ?, 0, 0, ?, ?)`,
+				)
+				.run(
+					packTokens,
+					createdAt,
+					JSON.stringify({ pack_item_ids: ids, pack_tokens: packTokens }),
+				);
+		};
+		insertUsage([scopeAId], "2026-01-01T00:00:00.000Z", 10);
+		for (let i = 0; i < 260; i += 1) {
+			insertUsage(
+				[scopeBId],
+				`2026-01-02T00:${String(Math.floor(i / 60)).padStart(2, "0")}:${String(i % 60).padStart(2, "0")}.000Z`,
+				999,
+			);
+		}
+
+		const pack = buildMemoryPack(store, "retained", 10, null, { scope_id: "scope-a" });
+
+		expect(pack.item_ids).toContain(scopeAId);
+		expect(pack.metrics.pack_delta_available).toBe(false);
+	});
+
 	it("keeps project delta baseline after many packs in other projects", () => {
 		store.remember(sessionId, "feature", "Project A item", "Body A", 0.7);
 
@@ -848,6 +994,154 @@ describe("buildMemoryPack", () => {
 
 		expect(pack.item_ids).toContain(visibleId);
 		expect(pack.metrics.sources.semantic).toBe(1);
+	});
+
+	it("uses database content when revalidating semantic pack candidates", () => {
+		grantScopeToLocalDevice("authorized-team");
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Database semantic pack note",
+			"database semantic body",
+		);
+		const semanticResults = [
+			semanticCandidate(visibleId, "Forged semantic pack note", "forged semantic body", 0.9),
+		];
+
+		const pack = buildMemoryPack(store, "zzz_nomatch_zzz", 10, null, undefined, semanticResults);
+
+		expect(pack.pack_text).toContain("Database semantic pack note");
+		expect(pack.pack_text).not.toContain("Forged semantic pack note");
+	});
+
+	it("uses database content when revalidating semantic trace candidates", () => {
+		grantScopeToLocalDevice("authorized-team");
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Database semantic trace note",
+			"database semantic trace body",
+		);
+		const semanticResults = [
+			semanticCandidate(visibleId, "Forged semantic trace note", "forged semantic trace body", 0.9),
+		];
+
+		const trace = buildMemoryPackTrace(
+			store,
+			"zzz_nomatch_zzz",
+			10,
+			null,
+			undefined,
+			semanticResults,
+		);
+		const candidate = trace.retrieval.candidates.find((item) => item.id === visibleId);
+
+		expect(trace.output.pack_text).toContain("Database semantic trace note");
+		expect(trace.output.pack_text).not.toContain("Forged semantic trace note");
+		expect(candidate?.title).toBe("Database semantic trace note");
+		expect(candidate?.preview).toContain("database semantic trace body");
+		expect(candidate?.preview).not.toContain("forged semantic trace body");
+	});
+
+	it("excludes hidden semantic candidates from pack trace output", () => {
+		grantScopeToLocalDevice("authorized-team");
+		insertCoordinatorScope("unauthorized-team");
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Visible semantic trace note",
+			"visible semantic trace body",
+		);
+		const hiddenId = insertScopedMemory(
+			"unauthorized-team",
+			"Hidden semantic trace note",
+			"hidden semantic trace body",
+		);
+		const semanticResults = [
+			semanticCandidate(hiddenId, "Hidden semantic trace note", "hidden semantic trace body", 0.99),
+			semanticCandidate(
+				visibleId,
+				"Visible semantic trace note",
+				"visible semantic trace body",
+				0.5,
+			),
+		];
+
+		const trace = buildMemoryPackTrace(
+			store,
+			"zzz_nomatch_zzz",
+			10,
+			null,
+			undefined,
+			semanticResults,
+		);
+		const selectedIds = Object.values(trace.assembly.sections).flat();
+
+		expect(selectedIds).toContain(visibleId);
+		expect(selectedIds).not.toContain(hiddenId);
+		expect(trace.output.pack_text).toContain("Visible semantic trace note");
+		expect(trace.output.pack_text).not.toContain("Hidden semantic trace note");
+		expect(trace.retrieval.candidates.map((candidate) => candidate.id)).not.toContain(hiddenId);
+	});
+
+	it("keeps token-budget trimming behind the pack scope gate", () => {
+		grantScopeToLocalDevice("authorized-team");
+		insertCoordinatorScope("unauthorized-team");
+		const visibleId = insertScopedMemory(
+			"authorized-team",
+			"Visible budget semantic note",
+			"visible budget semantic body",
+		);
+		const hiddenId = insertScopedMemory(
+			"unauthorized-team",
+			"Hidden budget semantic note",
+			"hidden budget semantic body ".repeat(20),
+		);
+		const semanticResults = [
+			semanticCandidate(
+				hiddenId,
+				"Hidden budget semantic note",
+				"hidden budget semantic body",
+				0.99,
+			),
+			semanticCandidate(
+				visibleId,
+				"Visible budget semantic note",
+				"visible budget semantic body",
+				0.5,
+			),
+		];
+
+		const pack = buildMemoryPack(store, "zzz_nomatch_zzz", 10, 20, undefined, semanticResults);
+
+		expect(pack.item_ids).toContain(visibleId);
+		expect(pack.item_ids).not.toContain(hiddenId);
+		expect(pack.pack_text).toContain("Visible budget semantic note");
+		expect(pack.pack_text).not.toContain("Hidden budget semantic note");
+	});
+
+	it("applies scope filters to working-set file-ref candidates", () => {
+		grantScopeToLocalDevice("scope-a");
+		grantScopeToLocalDevice("scope-b");
+		const scopeAId = insertScopedMemory("scope-a", "Scope A working-set note", "working set body");
+		const scopeBId = insertScopedMemory("scope-b", "Scope B working-set note", "working set body");
+		for (const id of [scopeAId, scopeBId]) {
+			store.db
+				.prepare(
+					"INSERT OR IGNORE INTO memory_file_refs(memory_id, file_path, relation) VALUES (?, ?, 'modified')",
+				)
+				.run(id, "src/shared.ts");
+		}
+
+		const filters = { scope_id: "scope-a", working_set_paths: ["src/shared.ts"] };
+		const pack = buildMemoryPack(store, "zzz_nomatch_zzz", 10, null, filters);
+		const trace = buildMemoryPackTrace(store, "zzz_nomatch_zzz", 10, null, filters);
+		const traceIds = Object.values(trace.assembly.sections).flat();
+
+		expect(pack.item_ids).toContain(scopeAId);
+		expect(pack.item_ids).not.toContain(scopeBId);
+		expect(pack.pack_text).toContain("Scope A working-set note");
+		expect(pack.pack_text).not.toContain("Scope B working-set note");
+		expect(traceIds).toContain(scopeAId);
+		expect(traceIds).not.toContain(scopeBId);
+		expect(trace.retrieval.candidates.map((candidate) => candidate.id)).not.toContain(scopeBId);
 	});
 
 	it("scopes latest summary fallback during pack assembly", () => {

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -68,6 +68,8 @@ const TASK_HINT_QUERY =
 
 const RECALL_HINT_QUERY = "session summary recap remember last time previous work";
 
+const PACK_BASELINE_BATCH_SIZE = 25;
+const MAX_PACK_BASELINE_SCAN_ROWS = 250;
 const MAX_SEMANTIC_REVALIDATION_IDS = 200;
 const TRACE_CANDIDATE_LIMIT = 20;
 const TRACE_PREVIEW_LIMIT = 160;
@@ -534,6 +536,8 @@ type PackArtifacts = {
 	trace: PackTrace;
 };
 
+type PackUsageBaselineRow = { metadata_json: string | null; tokens_read: number | null };
+
 type RawSemanticResult = Awaited<ReturnType<typeof semanticSearch>>[number];
 
 function semanticMemoryResults(results: RawSemanticResult[]): MemoryResult[] {
@@ -888,6 +892,34 @@ function parseMetadataObject(value: unknown): Record<string, unknown> {
 	return getSummaryMetadata(value);
 }
 
+function validatePackDeltaBaselineIds(
+	store: StoreHandle,
+	ids: number[],
+	filters: MemoryFilters | null,
+): number[] | null {
+	if (ids.length === 0) return null;
+	const filterResult = buildFilterClausesWithContext(filters, {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+		enforceScopeVisibility: true,
+	});
+	const placeholders = ids.map(() => "?").join(", ");
+	const joinClause = filterResult.joinSessions
+		? "JOIN sessions ON sessions.id = memory_items.session_id"
+		: "";
+	const rows = store.db
+		.prepare(
+			`SELECT memory_items.id
+			 FROM memory_items
+			 ${joinClause}
+			 WHERE ${["memory_items.active = 1", `memory_items.id IN (${placeholders})`, ...filterResult.clauses].join(" AND ")}`,
+		)
+		.all(...ids, ...filterResult.params) as Array<{ id: number }>;
+	const visibleIds = new Set(rows.map((row) => row.id));
+	if (visibleIds.size !== ids.length) return null;
+	return ids.filter((id) => visibleIds.has(id));
+}
+
 function isSummaryLike(item: Pick<MemoryResult, "kind" | "metadata">): boolean {
 	return isSummaryLikeMemory(item);
 }
@@ -921,51 +953,58 @@ function findLatestSummaryLike(store: StoreHandle, filters?: MemoryFilters): Mem
 
 function getPackDeltaBaseline(
 	store: StoreHandle,
-	project: string | null,
+	filters: MemoryFilters | null,
 ): { previousPackIds: number[] | null; previousPackTokens: number | null } {
+	const project = filters?.project ?? null;
 	const projectBase = project ? projectBasename(project) : null;
 	const metaProjectExpr =
 		"CASE WHEN json_valid(metadata_json) = 1 THEN json_extract(metadata_json, '$.project') ELSE NULL END";
-	const rows = project
-		? (store.db
-				.prepare(
-					`SELECT metadata_json, tokens_read
-					 FROM usage_events
-					 WHERE event = 'pack'
-					   AND (${metaProjectExpr} = ? OR ${metaProjectExpr} = ?)
-					 ORDER BY created_at DESC
-					 LIMIT 25`,
-				)
-				.all(project, projectBase ?? project) as Array<{
-				metadata_json: string | null;
-				tokens_read: number | null;
-			}>)
-		: (store.db
-				.prepare(
-					`SELECT metadata_json, tokens_read
-					 FROM usage_events
-					 WHERE event = 'pack'
-					 ORDER BY created_at DESC
-					 LIMIT 25`,
-				)
-				.all() as Array<{ metadata_json: string | null; tokens_read: number | null }>);
+	let offset = 0;
+	while (offset < MAX_PACK_BASELINE_SCAN_ROWS) {
+		const batchLimit = Math.min(PACK_BASELINE_BATCH_SIZE, MAX_PACK_BASELINE_SCAN_ROWS - offset);
+		const rows = project
+			? (store.db
+					.prepare(
+						`SELECT metadata_json, tokens_read
+						 FROM usage_events
+						 WHERE event = 'pack'
+						   AND (${metaProjectExpr} = ? OR ${metaProjectExpr} = ?)
+						 ORDER BY created_at DESC
+						 LIMIT ? OFFSET ?`,
+					)
+					.all(project, projectBase ?? project, batchLimit, offset) as PackUsageBaselineRow[])
+			: (store.db
+					.prepare(
+						`SELECT metadata_json, tokens_read
+						 FROM usage_events
+						 WHERE event = 'pack'
+						 ORDER BY created_at DESC
+						 LIMIT ? OFFSET ?`,
+					)
+					.all(batchLimit, offset) as PackUsageBaselineRow[]);
+		if (rows.length === 0) break;
 
-	for (const row of rows) {
-		const metadata = parseMetadataObject(row.metadata_json);
-		if (project != null) {
-			const rowProject = typeof metadata.project === "string" ? metadata.project : null;
-			if (rowProject !== project && rowProject !== projectBase) continue;
+		for (const row of rows) {
+			const metadata = parseMetadataObject(row.metadata_json);
+			if (project != null) {
+				const rowProject = typeof metadata.project === "string" ? metadata.project : null;
+				if (rowProject !== project && rowProject !== projectBase) continue;
+			}
+			if (!("pack_item_ids" in metadata)) continue;
+
+			const { ids, valid } = coercePackItemIds(metadata.pack_item_ids);
+			if (!valid) continue;
+			const scopedIds = validatePackDeltaBaselineIds(store, ids, filters);
+			if (scopedIds == null) continue;
+
+			const previousTokens =
+				parseNonNegativeInt(metadata.pack_tokens) ?? parseNonNegativeInt(row.tokens_read);
+			if (previousTokens == null) continue;
+
+			return { previousPackIds: scopedIds, previousPackTokens: previousTokens };
 		}
-		if (!("pack_item_ids" in metadata)) continue;
 
-		const { ids, valid } = coercePackItemIds(metadata.pack_item_ids);
-		if (!valid) continue;
-
-		const previousTokens =
-			parseNonNegativeInt(metadata.pack_tokens) ?? parseNonNegativeInt(row.tokens_read);
-		if (previousTokens == null) continue;
-
-		return { previousPackIds: ids, previousPackTokens: previousTokens };
+		offset += rows.length;
 	}
 
 	return { previousPackIds: null, previousPackTokens: null };
@@ -1067,7 +1106,7 @@ function mergeResults(
 		const existing = seen.get(r.id);
 		if (!existing || r.score > existing.score) seen.set(r.id, r);
 	}
-	const scopedSemanticResults = scopeSemanticResults(store, semanticResults, filters);
+	const scopedSemanticResults = rehydrateScopedCandidateResults(store, semanticResults, filters);
 	let semanticCount = 0;
 	for (const r of scopedSemanticResults) {
 		if (!seen.has(r.id)) semanticCount++;
@@ -1078,14 +1117,14 @@ function mergeResults(
 	return { merged, ftsCount: ftsResults.length, semanticCount };
 }
 
-function scopeSemanticResults(
+function rehydrateScopedCandidateResults(
 	store: StoreHandle,
-	semanticResults: MemoryResult[],
+	candidates: MemoryResult[],
 	filters?: MemoryFilters,
 ): MemoryResult[] {
-	if (semanticResults.length === 0) return [];
+	if (candidates.length === 0) return [];
 	const originalById = new Map<number, MemoryResult>();
-	for (const item of semanticResults) {
+	for (const item of candidates) {
 		if (!Number.isSafeInteger(item.id) || item.id <= 0) continue;
 		if (!originalById.has(item.id)) originalById.set(item.id, item);
 	}
@@ -1168,10 +1207,25 @@ function mergeFileRefCandidates(
 	);
 	const newIds = refCandidateIds.filter((id) => !existingIds.has(id));
 	if (newIds.length === 0) return results;
-	const refMemories = newIds
-		.map((id) => store.get(id))
-		.filter((m): m is NonNullable<typeof m> => m != null)
-		.map(toMemoryResult);
+	const refMemories = rehydrateScopedCandidateResults(
+		store,
+		newIds.map((id) => ({
+			id,
+			kind: "discovery",
+			title: "",
+			body_text: "",
+			confidence: 0,
+			created_at: "",
+			updated_at: "",
+			tags_text: "",
+			score: 0,
+			session_id: 0,
+			metadata: {},
+			narrative: null,
+			facts: null,
+		})),
+		filters,
+	);
 	return [...results, ...refMemories];
 }
 
@@ -1625,10 +1679,7 @@ function buildPackArtifacts(
 		}
 	}
 
-	const { previousPackIds, previousPackTokens } = getPackDeltaBaseline(
-		store,
-		filters?.project ?? null,
-	);
+	const { previousPackIds, previousPackTokens } = getPackDeltaBaseline(store, filters ?? null);
 	const packDeltaAvailable = previousPackIds != null && previousPackTokens != null;
 	const previousSet = new Set(previousPackIds ?? []);
 	const currentSet = new Set(allItemIds);
@@ -1885,7 +1936,7 @@ export async function buildMemoryPackAsync(
 	let semResults: MemoryResult[] = [];
 	const semanticQuery = sanitizeSearchQuery(context).clean_query;
 	try {
-		const raw = await semanticSearch(store.db, semanticQuery, limit, filters, {
+		const raw = await semanticSearch(store.db, semanticQuery, limit, filters ?? null, {
 			actorId: store.actorId,
 			deviceId: store.deviceId,
 		});
@@ -1912,7 +1963,7 @@ export async function buildMemoryPackTraceAsync(
 	let semResults: MemoryResult[] = [];
 	const semanticQuery = sanitizeSearchQuery(context).clean_query;
 	try {
-		const raw = await semanticSearch(store.db, semanticQuery, limit, filters, {
+		const raw = await semanticSearch(store.db, semanticQuery, limit, filters ?? null, {
 			actorId: store.actorId,
 			deviceId: store.deviceId,
 		});

--- a/packages/core/src/vectors.test.ts
+++ b/packages/core/src/vectors.test.ts
@@ -520,11 +520,11 @@ describe("vectors", () => {
 		).toContain(visibleId);
 	});
 
-	it("widens KNN candidates before scope filtering", async () => {
+	it("ranks only authorized semantic candidates even when unauthorized candidates dominate", async () => {
 		const deviceId = "device-authorized";
 		grantScopeToDevice("authorized-team", deviceId);
 		insertCoordinatorScope("unauthorized-team");
-		for (let i = 0; i < 12; i += 1) {
+		for (let i = 0; i < 220; i += 1) {
 			const hiddenId = insertScopedMemory(
 				"unauthorized-team",
 				`Closest hidden semantic note ${i}`,
@@ -548,6 +548,26 @@ describe("vectors", () => {
 		expect(results.map((item) => item.id)).toEqual([visibleId]);
 	});
 
+	it("requires explicit scope context when vector search has candidates", async () => {
+		const memoryId = insertScopedMemory(
+			"local-default",
+			"Legacy local semantic note",
+			"semantic scope detail",
+		);
+		insertTestVector(memoryId, 0, "legacy-local-hash");
+
+		await expect(
+			semanticSearch(
+				db,
+				"semantic scope",
+				10,
+				null,
+				undefined as unknown as Parameters<typeof semanticSearch>[4],
+			),
+		).rejects.toThrow("semantic_search_scope_context_required");
+		expect(embeddings.embedTexts).not.toHaveBeenCalled();
+	});
+
 	it("skips query embedding when vector search is disabled during migration", async () => {
 		startMaintenanceJob(db, {
 			kind: "vector_model_migration",
@@ -555,7 +575,10 @@ describe("vectors", () => {
 			metadata: { source_model: "old-model", target_model: "test-model" },
 		});
 
-		const results = await semanticSearch(db, "query text");
+		const results = await semanticSearch(db, "query text", 10, null, {
+			actorId: "local:disabled-device",
+			deviceId: "disabled-device",
+		});
 
 		expect(results).toEqual([]);
 		expect(embeddings.embedTexts).not.toHaveBeenCalled();
@@ -566,7 +589,10 @@ describe("vectors", () => {
 		try {
 			initTestSchema(freshDb);
 
-			const results = await semanticSearch(freshDb, "query text");
+			const results = await semanticSearch(freshDb, "query text", 10, null, {
+				actorId: "local:fresh-device",
+				deviceId: "fresh-device",
+			});
 
 			expect(results).toEqual([]);
 			expect(embeddings.embedTexts).not.toHaveBeenCalled();

--- a/packages/core/src/vectors.ts
+++ b/packages/core/src/vectors.ts
@@ -36,9 +36,7 @@ export interface SemanticSearchScopeContext {
 	deviceId: string;
 }
 
-function scopeVisibleFilterContext(
-	context: SemanticSearchScopeContext | null | undefined,
-): OwnershipFilterContext {
+function scopeVisibleFilterContext(context: SemanticSearchScopeContext): OwnershipFilterContext {
 	return {
 		actorId: context?.actorId ?? "",
 		deviceId: context?.deviceId ?? "",
@@ -685,7 +683,7 @@ export interface SemanticSearchResult {
 }
 
 /**
- * Search for memories by vector similarity (KNN via sqlite-vec MATCH).
+ * Search for memories by vector similarity using exact sqlite-vec distance.
  * Returns an empty array when embeddings are disabled or unavailable.
  *
  * Matches Python's `_semantic_search()` in store/search.py.
@@ -693,13 +691,16 @@ export interface SemanticSearchResult {
 export async function semanticSearch(
 	db: Database,
 	query: string,
-	limit = 10,
-	filters?: MemoryFilters | null,
-	context?: SemanticSearchScopeContext | null,
+	limit: number,
+	filters: MemoryFilters | null,
+	context: SemanticSearchScopeContext,
 ): Promise<SemanticSearchResult[]> {
 	if (query.trim().length < 3) return [];
 	const searchModel = resolveSemanticSearchModel(db, resolveEmbeddingModel());
 	if (!searchModel) return [];
+	if (!context?.deviceId?.trim()) {
+		throw new Error("semantic_search_scope_context_required");
+	}
 
 	const embeddings = await embedTexts([query]);
 	if (embeddings.length === 0) return [];
@@ -708,7 +709,6 @@ export async function semanticSearch(
 	if (!firstEmbedding) return [];
 	const queryEmbedding = serializeFloat32(firstEmbedding);
 	const effectiveLimit = clampSemanticLimit(limit);
-	let knnLimit = Math.min(Math.max(effectiveLimit * 4, effectiveLimit + 8), 200);
 	const whereClauses: string[] = ["memory_items.active = 1"];
 	const filterResult = buildFilterClausesWithContext(filters, scopeVisibleFilterContext(context));
 	whereClauses.push(...filterResult.clauses);
@@ -718,29 +718,37 @@ export async function semanticSearch(
 		? "JOIN sessions ON sessions.id = memory_items.session_id"
 		: "";
 
+	// Scope predicates must apply before vector ranking. sqlite-vec's MATCH/k
+	// query ranks inside the virtual table before joined memory_items filters can
+	// reliably constrain the candidate set, so use an exact distance scan over the
+	// already-authorized memory rows instead of widening post-KNN candidates.
 	const sql = `
-		SELECT memory_items.*, memory_vectors.distance
-		FROM memory_vectors
-		JOIN memory_items ON memory_items.id = memory_vectors.memory_id
-		${joinClause}
-		WHERE memory_vectors.embedding MATCH ?
-		  AND k = ?
-		  AND memory_vectors.model = ?
-		  AND ${where}
-		ORDER BY memory_vectors.distance ASC
+		WITH scoped_vectors AS (
+			SELECT
+				memory_vectors.memory_id,
+				MIN(vec_distance_l2(memory_vectors.embedding, ?)) AS distance
+			FROM memory_vectors
+			JOIN memory_items ON memory_items.id = memory_vectors.memory_id
+			${joinClause}
+			WHERE memory_vectors.model = ?
+			  AND ${where}
+			GROUP BY memory_vectors.memory_id
+			ORDER BY distance ASC
+			LIMIT ?
+		)
+		SELECT memory_items.*, scoped_vectors.distance
+		FROM scoped_vectors
+		JOIN memory_items ON memory_items.id = scoped_vectors.memory_id
+		ORDER BY scoped_vectors.distance ASC
 	`;
 
 	const statement = db.prepare(sql);
-	let rows: Array<Record<string, unknown>> = [];
-	while (true) {
-		rows = statement.all(queryEmbedding, knnLimit, searchModel, ...filterResult.params) as Array<
-			Record<string, unknown>
-		>;
-		if (rows.length >= effectiveLimit || knnLimit >= 200) break;
-		const nextLimit = Math.min(knnLimit * 2, 200);
-		if (nextLimit === knnLimit) break;
-		knnLimit = nextLimit;
-	}
+	const rows = statement.all(
+		queryEmbedding,
+		searchModel,
+		...filterResult.params,
+		effectiveLimit,
+	) as Array<Record<string, unknown>>;
 
 	return rows
 		.map((row) => ({


### PR DESCRIPTION
## Description

Hardens \`buildMemoryPack\` so every section of the assembled pack respects the central scope-visibility gate:

- Caller-supplied semantic candidates are DB-rehydrated through scope+filter and chunked through the rehydration path (no 200-id pre-filter cap that could drop authorized candidates).
- Pack delta baselines are re-validated against the current scope/filter set; rows with any unauthorized id, or empty baselines, are skipped. Baseline scan is bounded to a fixed window so a long pack history with no in-scope baseline does not turn into an unbounded scan.
- File-ref / working-set candidates are rehydrated through the scoped path before merge.
- \`findLatestSummaryLike\` enforces scope visibility for fallback summary lookups.

Decomposed from codemem-ov4g.5.3 → ov4g.5.8.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Coverage: pack/trace exclude unauthorized scopes, delta baselines reject out-of-scope history, working-set file-ref candidates respect scope, semantic revalidation keeps authorized candidates after hidden chunks fill the first window, baseline scan stays bounded under noisy out-of-scope history.

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced