### PR TITLE
fix(mcp): enforce scope-safe memory tools

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -20,12 +20,17 @@ import {
 	projectMatchesFilter,
 	resolveDbPath,
 	storeVectors,
-	toJson,
 	VERSION,
 } from "@codemem/core";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import {
+	forgetMemoryForMcp,
+	getManyForMcp,
+	getMemoryForMcp,
+	rememberMemoryForMcp,
+} from "./memory-access.js";
 import { buildFilters, resolveDefaultProject } from "./project-scope.js";
 
 // ---------------------------------------------------------------------------
@@ -46,9 +51,16 @@ const MEMORY_KINDS: Record<string, string> = {
 // Shared zod filter schema (spread into each tool that accepts filters)
 // ---------------------------------------------------------------------------
 
+const scopeFilterSchema = {
+	scope_id: z.string().optional().describe("Filter by a single sharing domain scope_id"),
+	include_scope_ids: z.array(z.string()).optional().describe("Sharing domain scope_ids to include"),
+	exclude_scope_ids: z.array(z.string()).optional().describe("Sharing domain scope_ids to exclude"),
+};
+
 const filterSchema = {
 	kind: z.string().optional().describe("Filter by memory kind"),
 	project: z.string().optional().describe("Filter by project scope (matches sessions.project)"),
+	...scopeFilterSchema,
 	visibility: z.array(z.string()).optional(),
 	include_visibility: z.array(z.string()).optional(),
 	exclude_visibility: z.array(z.string()).optional(),
@@ -82,25 +94,6 @@ function jsonContent(data: unknown) {
 /** Wrap an error message into the MCP text content envelope. */
 function errorContent(message: string) {
 	return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }] };
-}
-
-/** ISO timestamp. */
-function nowIso(): string {
-	return new Date().toISOString();
-}
-
-/**
- * Fetch multiple memory items by ID. Returns items in ID order, skipping
- * missing IDs. Implemented directly since MemoryStore doesn't have getMany.
- */
-function getMany(store: MemoryStore, ids: number[]): MemoryItemResponse[] {
-	if (ids.length === 0) return [];
-	const results: MemoryItemResponse[] = [];
-	for (const id of ids) {
-		const item = store.get(id);
-		if (item) results.push(item);
-	}
-	return results;
 }
 
 // ---------------------------------------------------------------------------
@@ -329,15 +322,16 @@ async function main() {
 			depth_before: z.number().int().min(0).default(3).describe("Timeline items before"),
 			depth_after: z.number().int().min(0).default(3).describe("Timeline items after"),
 			include_observations: z.boolean().default(false).describe("Include full observation details"),
-			project: z.string().optional().describe("Project scope filter"),
+			...filterSchema,
 		},
 		async (args) => {
 			try {
 				// Python: project if project is not None else default_project
 				// Explicit "" clears project scoping; only fall back to default when undefined.
-				const resolvedProject =
-					args.project !== undefined ? args.project.trim() || null : defaultProject || null;
-				const filters = resolvedProject ? { project: resolvedProject } : undefined;
+				const filterDefaultProject =
+					args.project !== undefined && !args.project.trim() ? null : defaultProject;
+				const filters = buildFilters(args, filterDefaultProject);
+				const resolvedProject = filters?.project ?? null;
 				const { ordered: orderedIds, invalid: invalidIds } = dedupeOrderedIds(args.ids);
 				const errors: Array<Record<string, unknown>> = [];
 
@@ -352,6 +346,7 @@ async function main() {
 
 				const missingNotFound: number[] = [];
 				const missingProjectMismatch: number[] = [];
+				const missingFilterMismatch: number[] = [];
 				const anchors: MemoryItemResponse[] = [];
 				const timelineItems: MemoryItemResponse[] = [];
 				const timelineSeen = new Set<number>();
@@ -381,8 +376,6 @@ async function main() {
 						continue;
 					}
 
-					anchors.push(item);
-
 					const expanded = store.timeline(
 						null,
 						memoryId,
@@ -390,6 +383,13 @@ async function main() {
 						args.depth_after,
 						filters,
 					);
+					const anchor = expanded.find((expandedItem) => expandedItem.id === memoryId);
+					if (!anchor) {
+						missingFilterMismatch.push(memoryId);
+						continue;
+					}
+
+					anchors.push(anchor);
 					for (const expandedItem of expanded) {
 						const expandedId = expandedItem.id;
 						if (expandedId <= 0 || timelineSeen.has(expandedId)) continue;
@@ -414,6 +414,14 @@ async function main() {
 						ids: missingProjectMismatch,
 					});
 				}
+				if (missingFilterMismatch.length > 0) {
+					errors.push({
+						code: "FILTER_MISMATCH",
+						field: "filters",
+						message: "some requested ids are outside the requested filters",
+						ids: missingFilterMismatch,
+					});
+				}
 
 				// Collect full observations if requested
 				let observations: MemoryItemResponse[] = [];
@@ -426,7 +434,7 @@ async function main() {
 							observationIds.push(item.id);
 						}
 					}
-					observations = getMany(store, observationIds);
+					observations = getManyForMcp(store, observationIds, filters);
 				}
 
 				return jsonContent({
@@ -435,7 +443,9 @@ async function main() {
 					observations,
 					missing_ids: orderedIds.filter(
 						(memoryId: number) =>
-							missingNotFound.includes(memoryId) || missingProjectMismatch.includes(memoryId),
+							missingNotFound.includes(memoryId) ||
+							missingProjectMismatch.includes(memoryId) ||
+							missingFilterMismatch.includes(memoryId),
 					),
 					errors,
 					metadata: {
@@ -460,10 +470,11 @@ async function main() {
 		"Fetch a single memory item by ID.",
 		{
 			memory_id: z.number().int().describe("Memory ID"),
+			...filterSchema,
 		},
 		async (args) => {
 			try {
-				const item = store.get(args.memory_id);
+				const item = getMemoryForMcp(store, args.memory_id, buildFilters(args, null));
 				if (!item) return errorContent("not_found");
 				return jsonContent(item);
 			} catch (err) {
@@ -480,10 +491,11 @@ async function main() {
 		"Fetch multiple memory items by their IDs.",
 		{
 			ids: z.array(z.number().int()).max(200).describe("Memory IDs to fetch"),
+			...filterSchema,
 		},
 		async (args) => {
 			try {
-				const items = getMany(store, args.ids);
+				const items = getManyForMcp(store, args.ids, buildFilters(args, null));
 				return jsonContent({ items });
 			} catch (err) {
 				return errorContent(err instanceof Error ? err.message : String(err));
@@ -574,39 +586,9 @@ async function main() {
 		},
 		async (args) => {
 			try {
-				// Create a transient session + memory in a transaction for atomicity.
-				// TS store doesn't have startSession/endSession yet, so
-				// we insert the session row directly. Wrapped in transaction to
-				// prevent orphaned sessions if remember() fails.
-				const result = store.db.transaction(() => {
-					const now = nowIso();
-					const user = process.env.USER ?? "unknown";
-					const cwd = process.cwd();
-					const project = args.project ?? process.env.CODEMEM_PROJECT ?? null;
-
-					const sessionInfo = store.db
-						.prepare(
-							`INSERT INTO sessions(started_at, ended_at, cwd, project, user, tool_version, metadata_json)
-							 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-						)
-						.run(now, now, cwd, project, user, "mcp-ts", toJson({ mcp: true }));
-					const sessionId = Number(sessionInfo.lastInsertRowid);
-
-					const memId = store.remember(
-						sessionId,
-						args.kind,
-						args.title,
-						args.body,
-						args.confidence,
-					);
-
-					// End the session
-					store.db
-						.prepare("UPDATE sessions SET ended_at = ?, metadata_json = ? WHERE id = ?")
-						.run(nowIso(), toJson({ mcp: true }), sessionId);
-
-					return { memId, title: args.title, body: args.body };
-				})();
+				const result = rememberMemoryForMcp(store, args, {
+					envProject: process.env.CODEMEM_PROJECT ?? null,
+				});
 
 				try {
 					await storeVectors(store.db, result.memId, result.title, result.body);
@@ -629,10 +611,13 @@ async function main() {
 		"Soft-delete a memory item. Use for incorrect or sensitive data.",
 		{
 			memory_id: z.number().int().describe("Memory ID to forget"),
+			...filterSchema,
 		},
 		async (args) => {
 			try {
-				store.forget(args.memory_id);
+				if (!forgetMemoryForMcp(store, args.memory_id, buildFilters(args, null))) {
+					return errorContent("not_found");
+				}
 				return jsonContent({ status: "ok" });
 			} catch (err) {
 				return errorContent(err instanceof Error ? err.message : String(err));
@@ -667,6 +652,9 @@ async function main() {
 					"session_id",
 					"since",
 					"project",
+					"scope_id",
+					"include_scope_ids",
+					"exclude_scope_ids",
 					"include_actor_ids",
 					"exclude_actor_ids",
 					"include_visibility",

--- a/packages/mcp-server/src/memory-access.test.ts
+++ b/packages/mcp-server/src/memory-access.test.ts
@@ -1,0 +1,220 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemoryStore } from "@codemem/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connect } from "../../core/src/db.js";
+import { initTestSchema } from "../../core/src/test-utils.js";
+import {
+	forgetMemoryForMcp,
+	getManyForMcp,
+	getMemoryForMcp,
+	rememberMemoryForMcp,
+} from "./memory-access.js";
+
+describe("MCP memory access scope guards", () => {
+	const originalDeviceId = process.env.CODEMEM_DEVICE_ID;
+	let tmpDir: string;
+	let dbPath: string;
+	let store: MemoryStore;
+	let sessionId: number;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-mcp-scope-"));
+		dbPath = join(tmpDir, "mem.sqlite");
+		process.env.CODEMEM_DEVICE_ID = "mcp-scope-device";
+		const db = connect(dbPath);
+		initTestSchema(db);
+		sessionId = insertSession(db, { cwd: join(tmpDir, "greenroom"), project: "greenroom" });
+		grantScopeToDevice(db, "scope-a", "mcp-scope-device");
+		insertCoordinatorScope(db, "scope-b");
+		db.close();
+		store = new MemoryStore(dbPath);
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+		if (originalDeviceId === undefined) {
+			delete process.env.CODEMEM_DEVICE_ID;
+		} else {
+			process.env.CODEMEM_DEVICE_ID = originalDeviceId;
+		}
+	});
+
+	it("hides unauthorized scoped IDs and intersects explicit scope filters", () => {
+		const authorizedId = insertScopedMemory(store, {
+			sessionId,
+			scopeId: "scope-a",
+			title: "Authorized MCP note",
+		});
+		const hiddenId = insertScopedMemory(store, {
+			sessionId,
+			scopeId: "scope-b",
+			title: "Hidden MCP note",
+		});
+
+		expect(getMemoryForMcp(store, authorizedId)?.title).toBe("Authorized MCP note");
+		expect(getMemoryForMcp(store, hiddenId)).toBe(null);
+		expect(getManyForMcp(store, [hiddenId, authorizedId]).map((item) => item.id)).toEqual([
+			authorizedId,
+		]);
+		expect(getMemoryForMcp(store, authorizedId, { scope_id: "scope-b" })).toBe(null);
+	});
+
+	it("refuses to forget unauthorized or explicitly filtered-out memories", () => {
+		const authorizedId = insertScopedMemory(store, {
+			sessionId,
+			scopeId: "scope-a",
+			title: "Forgettable MCP note",
+		});
+		const hiddenId = insertScopedMemory(store, {
+			sessionId,
+			scopeId: "scope-b",
+			title: "Hidden forget target",
+		});
+
+		expect(forgetMemoryForMcp(store, hiddenId)).toBe(false);
+		expect(readActive(store, hiddenId)).toBe(1);
+		expect(forgetMemoryForMcp(store, authorizedId, { scope_id: "scope-b" })).toBe(false);
+		expect(readActive(store, authorizedId)).toBe(1);
+
+		expect(forgetMemoryForMcp(store, authorizedId)).toBe(true);
+		expect(readActive(store, authorizedId)).toBe(0);
+	});
+
+	it("stamps remembered MCP memories with the resolved project scope", () => {
+		insertProjectScopeMapping(store, {
+			projectPattern: join(tmpDir, "greenroom"),
+			scopeId: "scope-a",
+		});
+
+		const result = rememberMemoryForMcp(
+			store,
+			{
+				kind: "decision",
+				title: "MCP scoped remember",
+				body: "Remembered through MCP with a mapped project scope.",
+				confidence: 0.8,
+				project: "greenroom",
+			},
+			{
+				cwd: join(tmpDir, "greenroom"),
+				user: "mcp-test",
+				now: () => "2026-01-01T00:00:00.000Z",
+			},
+		);
+
+		const row = store.db
+			.prepare("SELECT scope_id FROM memory_items WHERE id = ?")
+			.get(result.memId) as { scope_id: string };
+		expect(row.scope_id).toBe("scope-a");
+		expect(getMemoryForMcp(store, result.memId)?.title).toBe("MCP scoped remember");
+	});
+
+	it("rolls back remembered MCP memories that resolve to unauthorized scopes", () => {
+		insertProjectScopeMapping(store, {
+			projectPattern: join(tmpDir, "greenroom"),
+			scopeId: "scope-b",
+		});
+
+		expect(() =>
+			rememberMemoryForMcp(
+				store,
+				{
+					kind: "decision",
+					title: "Unauthorized MCP scoped remember",
+					body: "This should not be persisted into an unauthorized scope.",
+					confidence: 0.8,
+					project: "greenroom",
+				},
+				{
+					cwd: join(tmpDir, "greenroom"),
+					user: "mcp-test",
+					now: () => "2026-01-01T00:00:00.000Z",
+				},
+			),
+		).toThrow("unauthorized_scope");
+		expect(countMemoriesByTitle(store, "Unauthorized MCP scoped remember")).toBe(0);
+	});
+});
+
+function insertSession(
+	db: ReturnType<typeof connect>,
+	input: { cwd: string; project: string },
+): number {
+	const now = new Date().toISOString();
+	const info = db
+		.prepare(
+			"INSERT INTO sessions(started_at, cwd, project, user, tool_version) VALUES (?, ?, ?, ?, ?)",
+		)
+		.run(now, input.cwd, input.project, "mcp-test", "test");
+	return Number(info.lastInsertRowid);
+}
+
+function insertCoordinatorScope(db: ReturnType<typeof connect>, scopeId: string): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT OR REPLACE INTO replication_scopes(
+			scope_id, label, kind, authority_type, coordinator_id, group_id,
+			membership_epoch, status, created_at, updated_at
+		 ) VALUES (?, ?, 'team', 'coordinator', 'coord-test', 'group-test', 0, 'active', ?, ?)`,
+	).run(scopeId, scopeId, now, now);
+}
+
+function grantScopeToDevice(
+	db: ReturnType<typeof connect>,
+	scopeId: string,
+	deviceId: string,
+): void {
+	insertCoordinatorScope(db, scopeId);
+	db.prepare(
+		`INSERT OR REPLACE INTO scope_memberships(
+			scope_id, device_id, role, status, membership_epoch,
+			coordinator_id, group_id, updated_at
+		 ) VALUES (?, ?, 'member', 'active', 0, 'coord-test', 'group-test', ?)`,
+	).run(scopeId, deviceId, new Date().toISOString());
+}
+
+function insertScopedMemory(
+	store: MemoryStore,
+	input: { sessionId: number; scopeId: string; title: string },
+): number {
+	const now = new Date().toISOString();
+	const info = store.db
+		.prepare(
+			`INSERT INTO memory_items(session_id, kind, title, body_text, confidence,
+				tags_text, active, created_at, updated_at, metadata_json, rev, visibility, scope_id)
+			 VALUES (?, 'discovery', ?, ?, 0.9, '', 1, ?, ?, '{}', 1, 'shared', ?)`,
+		)
+		.run(input.sessionId, input.title, `${input.title} body`, now, now, input.scopeId);
+	return Number(info.lastInsertRowid);
+}
+
+function insertProjectScopeMapping(
+	store: MemoryStore,
+	input: { projectPattern: string; scopeId: string },
+): void {
+	const now = new Date().toISOString();
+	store.db
+		.prepare(
+			`INSERT INTO project_scope_mappings(
+				project_pattern, scope_id, priority, source, created_at, updated_at
+			 ) VALUES (?, ?, 10, 'user', ?, ?)`,
+		)
+		.run(input.projectPattern, input.scopeId, now, now);
+}
+
+function readActive(store: MemoryStore, memoryId: number): number | null {
+	const row = store.db.prepare("SELECT active FROM memory_items WHERE id = ?").get(memoryId) as
+		| { active: number }
+		| undefined;
+	return row?.active ?? null;
+}
+
+function countMemoriesByTitle(store: MemoryStore, title: string): number {
+	const row = store.db
+		.prepare("SELECT COUNT(*) AS count FROM memory_items WHERE title = ?")
+		.get(title) as { count: number };
+	return row.count;
+}

--- a/packages/mcp-server/src/memory-access.ts
+++ b/packages/mcp-server/src/memory-access.ts
@@ -1,0 +1,87 @@
+import {
+	type MemoryFilters,
+	type MemoryItemResponse,
+	type MemoryStore,
+	toJson,
+} from "@codemem/core";
+
+export function getMemoryForMcp(
+	store: MemoryStore,
+	memoryId: number,
+	filters?: MemoryFilters,
+): MemoryItemResponse | null {
+	const rows = store.timeline(null, memoryId, 0, 0, filters ?? null);
+	return rows.find((row) => row.id === memoryId) ?? null;
+}
+
+export function getManyForMcp(
+	store: MemoryStore,
+	ids: number[],
+	filters?: MemoryFilters,
+): MemoryItemResponse[] {
+	if (ids.length === 0) return [];
+	const results: MemoryItemResponse[] = [];
+	for (const id of ids) {
+		const item = getMemoryForMcp(store, id, filters);
+		if (item) results.push(item);
+	}
+	return results;
+}
+
+export function forgetMemoryForMcp(
+	store: MemoryStore,
+	memoryId: number,
+	filters?: MemoryFilters,
+): boolean {
+	const item = getMemoryForMcp(store, memoryId, filters);
+	if (!item) return false;
+	store.forget(memoryId);
+	return true;
+}
+
+export interface RememberMemoryForMcpInput {
+	kind: string;
+	title: string;
+	body: string;
+	confidence: number;
+	project?: string | null;
+}
+
+export interface RememberMemoryForMcpContext {
+	cwd?: string;
+	user?: string;
+	envProject?: string | null;
+	now?: () => string;
+}
+
+export function rememberMemoryForMcp(
+	store: MemoryStore,
+	input: RememberMemoryForMcpInput,
+	context: RememberMemoryForMcpContext = {},
+): { memId: number; title: string; body: string } {
+	return store.db.transaction(() => {
+		const now = context.now?.() ?? new Date().toISOString();
+		const user = context.user ?? process.env.USER ?? "unknown";
+		const cwd = context.cwd ?? process.cwd();
+		const project = input.project ?? context.envProject ?? null;
+
+		const sessionInfo = store.db
+			.prepare(
+				`INSERT INTO sessions(started_at, ended_at, cwd, project, user, tool_version, metadata_json)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.run(now, now, cwd, project, user, "mcp-ts", toJson({ mcp: true }));
+		const sessionId = Number(sessionInfo.lastInsertRowid);
+
+		const memId = store.remember(sessionId, input.kind, input.title, input.body, input.confidence);
+		if (!getMemoryForMcp(store, memId)) {
+			throw new Error("unauthorized_scope");
+		}
+
+		store.db
+			.prepare("UPDATE sessions SET ended_at = ?, metadata_json = ? WHERE id = ?")
+			.run(context.now?.() ?? new Date().toISOString(), toJson({ mcp: true }), sessionId);
+
+		return { memId, title: input.title, body: input.body };
+	})();
+}

--- a/packages/mcp-server/src/project-scope.test.ts
+++ b/packages/mcp-server/src/project-scope.test.ts
@@ -54,6 +54,32 @@ describe("project-scope helpers", () => {
 		});
 	});
 
+	it("passes through scope filters while preserving default project narrowing", async () => {
+		const { buildFilters } = await import("./project-scope.js");
+		expect(
+			buildFilters(
+				{
+					scope_id: "scope-a",
+					include_scope_ids: ["scope-a", "scope-b"],
+					exclude_scope_ids: ["scope-c"],
+				},
+				"repo-name",
+			),
+		).toEqual({
+			project: "repo-name",
+			scope_id: "scope-a",
+			include_scope_ids: ["scope-a", "scope-b"],
+			exclude_scope_ids: ["scope-c"],
+		});
+	});
+
+	it("supports scope-only filters for direct ID tools without default project widening", async () => {
+		const { buildFilters } = await import("./project-scope.js");
+		expect(buildFilters({ scope_id: "scope-a" }, null)).toEqual({
+			scope_id: "scope-a",
+		});
+	});
+
 	it("falls back to default project when env or request project is blank", async () => {
 		process.env.CODEMEM_PROJECT = "   ";
 		const { buildFilters, resolveDefaultProject } = await import("./project-scope.js");

--- a/packages/mcp-server/src/project-scope.ts
+++ b/packages/mcp-server/src/project-scope.ts
@@ -22,6 +22,9 @@ export function buildFilters(
 	for (const key of [
 		"kind",
 		"visibility",
+		"scope_id",
+		"include_scope_ids",
+		"exclude_scope_ids",
 		"include_visibility",
 		"exclude_visibility",
 		"include_workspace_ids",


### PR DESCRIPTION
## Description

Updates the MCP memory tools so every read and write surface (\`memory_search\`, \`memory_search_index\`, \`memory_timeline\`, \`memory_explain\`, \`memory_expand\`, \`memory_get\`, \`memory_get_observations\`, \`memory_recent\`, \`memory_pack\`, \`memory_remember\`, \`memory_forget\`) respects the device's authorized sharing domains by default:

- New \`memory-access.ts\` helpers route direct-id, getMany, forget, and remember through scope-filtered store paths.
- Filter schema accepts optional \`scope_id\` / \`include_scope_ids\` / \`exclude_scope_ids\` that intersect with authorization.
- \`rememberMemoryForMcp\` rolls back inside the transaction with \`unauthorized_scope\` if the resolved scope is not locally visible.

Implements codemem-ov4g.5.4.

## Type of Change

- [x] 🐛 Bug fix (fixes an issue)

## Testing

- [x] Relevant checks pass locally (\`pnpm run tsc\`, \`pnpm run lint\`, \`pnpm run test\`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Coverage: MCP direct reads, getMany filtering, forget refusal on unauthorized scope, remember rollback when scope is hidden.

## Checklist

- [x] Code follows project style (\`pnpm run lint\` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced