### PR TITLE
feat(sync): surface filtered op diagnostics

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -553,6 +553,7 @@ export {
 export type {
 	ApplyReplicationOpsOptions,
 	ApplyResult,
+	FilterReplicationSkipped,
 	InboundScopeRejection,
 	InboundScopeRejectionPeerSummary,
 	InboundScopeRejectionReason,

--- a/packages/core/src/sync-pass.ts
+++ b/packages/core/src/sync-pass.ts
@@ -29,7 +29,8 @@ import {
 	backfillReplicationOps,
 	chunkOpsBySize,
 	extractReplicationOps,
-	filterReplicationOpsForSync,
+	type FilterReplicationSkipped,
+	filterReplicationOpsForSyncWithStatus,
 	getReplicationCursor,
 	hasUnsyncedSharedMemoryChanges,
 	migrateLegacyImportKeys,
@@ -78,6 +79,8 @@ export interface SyncResult {
 	address?: string;
 	opsIn: number;
 	opsOut: number;
+	opsSkipped?: number;
+	skippedOut?: FilterReplicationSkipped | null;
 	addressErrors: Array<{ address: string; error: string }>;
 	resetRequired?: SyncResetRequired;
 }
@@ -744,12 +747,11 @@ export async function syncOnce(
 
 			// -- 5. Push local ops to peer --
 			const [outboundWindow, outboundCursor] = loadLocalOpsSince(db, lastAcked, deviceId, limit);
-			const [outboundOps, filteredOutboundCursor] = filterReplicationOpsForSync(
-				db,
-				outboundWindow,
-				peerDeviceId,
-				{ localDeviceId: deviceId },
-			);
+			const [outboundOps, filteredOutboundCursor, skippedOutbound] =
+				filterReplicationOpsForSyncWithStatus(db, outboundWindow, peerDeviceId, {
+					localDeviceId: deviceId,
+				});
+			const opsSkipped = skippedOutbound?.skipped_count ?? 0;
 			const postUrl = `${baseUrl}/v1/ops`;
 			if (outboundOps.length > 0) {
 				const batches = chunkOpsBySize(outboundOps, MAX_SYNC_BODY_BYTES);
@@ -776,6 +778,8 @@ export async function syncOnce(
 				address: baseUrl,
 				opsIn: applied.applied,
 				opsOut: outboundOps.length,
+				opsSkipped,
+				skippedOut: skippedOutbound ?? null,
 				addressErrors: [],
 			};
 		} catch (err: unknown) {

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -34,7 +34,17 @@ export interface SyncRunItem {
 	address?: string;
 	opsIn: number;
 	opsOut: number;
+	opsSkipped?: number;
+	skipped_out?: SyncSkippedOutDetail | null;
 	addressErrors: Array<{ address: string; error: string }>;
+}
+
+export interface SyncSkippedOutDetail {
+	reason?: "scope_filter" | "visibility_filter" | "project_filter" | string;
+	skipped_count?: number;
+	project?: string | null;
+	scope_id?: string | null;
+	visibility?: string | null;
 }
 
 export interface SyncRunResponse {

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -305,6 +305,61 @@ describe("summarizeSyncRunResult", () => {
 			warning: true,
 		});
 	});
+
+	it("surfaces outbound filter diagnostics without treating them as failed sync", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: true,
+						opsIn: 0,
+						opsOut: 0,
+						opsSkipped: 3,
+						skipped_out: { reason: "project_filter", skipped_count: 3, project: "private" },
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: true,
+			message:
+				"3 outbound ops were filtered: 3 by project filter. No payload was sent for filtered data.",
+			warning: true,
+		});
+	});
+
+	it("splits outbound filter diagnostics by reason", () => {
+		expect(
+			summarizeSyncRunResult({
+				items: [
+					{
+						peer_device_id: "peer-a",
+						ok: true,
+						opsIn: 0,
+						opsOut: 0,
+						opsSkipped: 2,
+						skipped_out: { reason: "project_filter", skipped_count: 2, project: "private" },
+						addressErrors: [],
+					},
+					{
+						peer_device_id: "peer-b",
+						ok: true,
+						opsIn: 0,
+						opsOut: 0,
+						opsSkipped: 1,
+						skipped_out: { reason: "visibility_filter", skipped_count: 1, visibility: "private" },
+						addressErrors: [],
+					},
+				],
+			}),
+		).toEqual({
+			ok: true,
+			message:
+				"3 outbound ops were filtered: 2 by project filter, 1 by visibility. No payload was sent for filtered data.",
+			warning: true,
+		});
+	});
 });
 
 describe("deriveDuplicatePeople", () => {

--- a/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
+++ b/packages/ui/src/tabs/sync/view-model/coordinator-approval.ts
@@ -10,7 +10,14 @@ import type {
 	DiscoveredDeviceLike,
 	UiCoordinatorApprovalSummary,
 	UiSyncRunResponse,
+	UiSyncSkippedOutDetail,
 } from "./types";
+
+const OUTBOUND_FILTER_LABELS: Record<string, string> = {
+	scope_filter: "sharing-domain membership",
+	visibility_filter: "visibility",
+	project_filter: "project filter",
+};
 
 export function deriveCoordinatorApprovalSummary(input: {
 	device: DiscoveredDeviceLike;
@@ -51,7 +58,7 @@ export function shouldShowCoordinatorReviewAction(input: {
 	const deviceId = cleanText(input.device?.device_id);
 	const fingerprint = cleanText(input.device?.fingerprint);
 	if (!deviceId || !fingerprint) return false;
-	if (Boolean(input.device?.stale) || Boolean(input.hasAmbiguousCoordinatorGroup)) return false;
+	if (input.device?.stale || input.hasAmbiguousCoordinatorGroup) return false;
 	if (!input.pairedLocally) return true;
 	return approvalSummary.state === "needs-your-approval";
 }
@@ -66,7 +73,22 @@ export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
 		return { ok: true, message: "Sync pass completed with no eligible devices.", warning: false };
 	}
 	const failedItems = items.filter((item) => item && item.ok === false);
+	const skippedItems = items.filter((item) => Math.max(0, Number(item.opsSkipped ?? 0)) > 0);
 	if (!failedItems.length) {
+		if (skippedItems.length) {
+			const skipped = skippedItems.reduce(
+				(total, item) => total + Math.max(0, Number(item.opsSkipped ?? 0)),
+				0,
+			);
+			const reasonSummary = skippedReasonSummary(
+				skippedItems.map((item) => item.skipped_out ?? null),
+			);
+			return {
+				ok: true,
+				message: `${skipped.toLocaleString()} outbound op${skipped === 1 ? " was" : "s were"} filtered: ${reasonSummary}. No payload was sent for filtered data.`,
+				warning: true,
+			};
+		}
 		return {
 			ok: true,
 			message: `Sync pass finished for ${items.length} device${items.length === 1 ? "" : "s"}.`,
@@ -99,4 +121,24 @@ export function summarizeSyncRunResult(payload: UiSyncRunResponse): {
 		message: error || "Sync failed for at least one device.",
 		warning: true,
 	};
+}
+
+function outboundFilterLabel(detail: UiSyncSkippedOutDetail | null): string {
+	const reason = cleanText(detail?.reason);
+	return OUTBOUND_FILTER_LABELS[reason] ?? (reason.replaceAll("_", " ") || "sync filters");
+}
+
+function skippedReasonSummary(details: Array<UiSyncSkippedOutDetail | null>): string {
+	const counts = new Map<string, number>();
+	for (const detail of details) {
+		const label = outboundFilterLabel(detail);
+		const count = Math.max(0, Number(detail?.skipped_count ?? 0));
+		if (count === 0) continue;
+		counts.set(label, (counts.get(label) ?? 0) + count);
+	}
+	if (!counts.size) return "sync filters";
+	return Array.from(counts.entries())
+		.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+		.map(([label, count]) => `${count.toLocaleString()} by ${label}`)
+		.join(", ");
 }

--- a/packages/ui/src/tabs/sync/view-model/peer-status.ts
+++ b/packages/ui/src/tabs/sync/view-model/peer-status.ts
@@ -107,6 +107,8 @@ const SCOPE_REJECTION_REASON_LABELS: Record<PeerScopeRejectionReason, string> = 
 	receiver_not_member: "Receiver not a scope member",
 	stale_epoch: "Stale or revoked membership",
 	scope_mismatch: "Scope mismatch",
+	visibility_filter: "Visibility filter",
+	project_filter: "Project filter",
 };
 
 export interface PeerScopeRejectionsView {

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -41,7 +41,19 @@ export interface UiSyncRunItem {
 	address?: string;
 	opsIn: number;
 	opsOut: number;
+	opsSkipped?: number;
+	skipped_out?: UiSyncSkippedOutDetail | null;
 	addressErrors: Array<{ address: string; error: string }>;
+}
+
+export type UiSyncSkippedOutReason = "scope_filter" | "visibility_filter" | "project_filter";
+
+export interface UiSyncSkippedOutDetail {
+	reason?: UiSyncSkippedOutReason | string;
+	skipped_count?: number;
+	project?: string | null;
+	scope_id?: string | null;
+	visibility?: string | null;
 }
 
 export interface UiSyncRunResponse {
@@ -105,7 +117,9 @@ export type PeerScopeRejectionReason =
 	| "sender_not_member"
 	| "receiver_not_member"
 	| "stale_epoch"
-	| "scope_mismatch";
+	| "scope_mismatch"
+	| "visibility_filter"
+	| "project_filter";
 
 export interface PeerScopeRejectionsSummary {
 	total?: number;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -3676,6 +3676,15 @@ describe("viewer-server", () => {
 				expect(res.status).toBe(200);
 				const body = (await res.json()) as Record<string, unknown>;
 				expect(body).toMatchObject({ applied: 1, skipped: 1, rejected: 0 });
+				expect(body.skipped_detail).toMatchObject({
+					reason: "project_filter",
+					skipped_count: 1,
+					project: "blocked-project",
+				});
+				expect(body.skipped_detail).not.toHaveProperty("op_id");
+				expect(body.skipped_detail).not.toHaveProperty("entity_id");
+				expect(body.skipped_detail).not.toHaveProperty("entity_type");
+				expect(body.skipped_detail).not.toHaveProperty("created_at");
 				expect(
 					store.db
 						.prepare("SELECT title FROM memory_items WHERE import_key = ?")

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -45,6 +45,7 @@ import {
 	DEFAULT_TIME_WINDOW_S,
 	ensureDeviceIdentity,
 	extractReplicationOps,
+	type FilterReplicationSkipped,
 	filterReplicationOpsForSyncWithStatus,
 	fingerprintPublicKey,
 	getCoordinatorGroupPreference,
@@ -95,6 +96,24 @@ type SyncRuntimeStatus = {
 		| null;
 	detail?: string | null;
 };
+
+type SafeSkippedSyncDetail = Pick<
+	FilterReplicationSkipped,
+	"reason" | "skipped_count" | "scope_id" | "project" | "visibility"
+>;
+
+function safeSkippedSyncDetail(
+	detail: FilterReplicationSkipped | null | undefined,
+): SafeSkippedSyncDetail | null {
+	if (!detail) return null;
+	return {
+		reason: detail.reason,
+		skipped_count: detail.skipped_count,
+		scope_id: detail.scope_id ?? null,
+		project: detail.project ?? null,
+		visibility: detail.visibility ?? null,
+	};
+}
 
 interface SyncProtocolRouteOptions {
 	routeRateLimit?: {
@@ -988,12 +1007,16 @@ function filterOpsForPeer(
 	localDeviceId: string | null,
 	ops: ReplicationOp[],
 	options: { applyScopeFilter?: boolean } = {},
-): { allowed: ReplicationOp[]; skipped: number } {
+): { allowed: ReplicationOp[]; skipped: number; skippedDetail: SafeSkippedSyncDetail | null } {
 	const [allowed, , skipped] = filterReplicationOpsForSyncWithStatus(store.db, ops, peerDeviceId, {
 		localDeviceId,
 		applyScopeFilter: options.applyScopeFilter,
 	});
-	return { allowed, skipped: skipped?.skipped_count ?? 0 };
+	return {
+		allowed,
+		skipped: skipped?.skipped_count ?? 0,
+		skippedDetail: skipped ? safeSkippedSyncDetail(skipped) : null,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -1340,6 +1363,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				ops: filtered.allowed,
 				next_cursor: nextCursor,
 				skipped: filtered.skipped,
+				skipped_detail: filtered.skippedDetail,
 			});
 		} catch {
 			return c.json({ error: "internal_error" }, 500);
@@ -1542,6 +1566,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		return c.json({
 			...result,
 			skipped,
+			skipped_detail: filtered.skippedDetail,
 			sync_capability: LOCAL_SYNC_CAPABILITY,
 			scope_id: scopeRequest.scope_id,
 		});
@@ -2107,7 +2132,12 @@ export function syncRoutes(
 		const items = [] as Array<Record<string, unknown>>;
 		for (const peerId of peerIds) {
 			const result = await runSyncPass(store.db, peerId, { scanner: store.scanner });
-			items.push({ peer_device_id: peerId, ...result });
+			items.push({
+				peer_device_id: peerId,
+				...result,
+				skippedOut: undefined,
+				skipped_out: safeSkippedSyncDetail(result.skippedOut),
+			});
 		}
 		return c.json({ items });
 	});


### PR DESCRIPTION
## Description
Surfaces filtered outbound sync diagnostics so operators can tell when data was not sent to a peer because of sharing-domain membership, visibility, or project filters.

The API/UI only expose bounded metadata (`reason`, `skipped_count`, `scope_id`, `project`, `visibility`) and explicitly avoid payload-adjacent identifiers such as op/entity ids.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation run:
- `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts packages/viewer-server/src/index.test.ts`
- `pnpm run tsc`
- `pnpm run lint` (only existing unrelated FeedItemCard info findings)
- `pnpm run test`
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced