### PR TITLE
fix(release): accept prerelease versions

### DIFF
--- a/packages/cli/.opencode/tests/plugin-adapter.test.js
+++ b/packages/cli/.opencode/tests/plugin-adapter.test.js
@@ -312,7 +312,11 @@ describe("opencode adapter event mapping", () => {
     expect(args).toEqual(["-y", `codemem@${__testUtils.PINNED_BACKEND_VERSION}`]);
   });
 
-  test("pinned backend version remains on the latest stable backend during alpha releases", () => {
+  test("CLI-bundled plugin pin stays in lockstep with the CLI package version", () => {
+    // The CLI's bundled OpenCode plugin spawns `npx codemem@${PINNED}` when
+    // no local backend is configured. Because that backend ships inside the
+    // same package as this plugin, the pin must match the package version
+    // exactly — including alpha/beta/rc prereleases.
     const packageJsonPath = resolve(
       fileURLToPath(new URL(".", import.meta.url)),
       "..",
@@ -322,6 +326,8 @@ describe("opencode adapter event mapping", () => {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 
     expect(packageJson.version).toBe(__testUtils.PINNED_BACKEND_VERSION);
-    expect(__testUtils.PINNED_BACKEND_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(__testUtils.PINNED_BACKEND_VERSION).toMatch(
+      /^\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.\d+)?$/,
+    );
   });
 });

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -3,7 +3,10 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 
-const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+// Plain X.Y.Z plus the prerelease tags the Release workflow already
+// recognizes for npm dist-tag routing (alpha/beta/rc; see .github/workflows/release.yml).
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.\d+)?$/;
+const SEMVER_FORMAT = "X.Y.Z or X.Y.Z-{alpha,beta,rc}.N";
 const CORE_VERSION_RE = /^(export\s+const\s+VERSION\s*=\s*")([^"]+)(";\s*)$/m;
 const CORE_TEST_VERSION_RE = /^(\s*expect\(VERSION\)\.toBe\(")([^"]+)("\);\s*)$/m;
 const PLUGIN_PIN_RE = /^(const\s+PINNED_BACKEND_VERSION\s*=\s*")([^"]+)(";\s*)$/m;
@@ -23,7 +26,7 @@ const REQUIRED_REPO_MARKERS = [
 
 function validateSemver(version) {
 	if (!SEMVER_RE.test(version)) {
-		throw new Error(`Invalid version '${version}'. Expected format: X.Y.Z`);
+		throw new Error(`Invalid version '${version}'. Expected format: ${SEMVER_FORMAT}`);
 	}
 }
 

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -150,6 +150,22 @@ describe("release-version script", () => {
 		assert.throws(() => setVersion(root, "v1.0.1"), /Expected format: X.Y.Z/);
 	});
 
+	it("accepts alpha/beta/rc prerelease tags routed by the Release workflow", () => {
+		const root = makeRepo("1.0.0");
+		setVersion(root, "1.0.1-alpha.0");
+		assert.deepEqual(new Set(Object.values(readVersions(root))), new Set(["1.0.1-alpha.0"]));
+		setVersion(root, "1.0.1-beta.2");
+		assert.deepEqual(new Set(Object.values(readVersions(root))), new Set(["1.0.1-beta.2"]));
+		setVersion(root, "1.0.1-rc.1");
+		assert.deepEqual(new Set(Object.values(readVersions(root))), new Set(["1.0.1-rc.1"]));
+	});
+
+	it("rejects unknown prerelease identifiers", () => {
+		const root = makeRepo("1.0.0");
+		assert.throws(() => setVersion(root, "1.0.1-canary.0"), /Expected format: X.Y.Z/);
+		assert.throws(() => setVersion(root, "1.0.1-alpha"), /Expected format: X.Y.Z/);
+	});
+
 	it("does not write partial changes before validation failure", () => {
 		const root = makeRepo("1.0.0");
 		writeFileSync(join(root, ".claude-plugin/marketplace.json"), '{"metadata": {"version": "1.0.0"}, "plugins": []}\n');


### PR DESCRIPTION
## Description
Ports the release/0.30 prerelease version gate back to main so `scripts/release-version.mjs` accepts the prerelease channels already routed by the release workflow: `alpha`, `beta`, and `rc` with numeric suffixes.

Also updates release-version coverage and the CLI-bundled OpenCode plugin pin assertion so prerelease prep commits do not fail CI while pins track the package version.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation run:
- `pnpm exec node --test scripts/release-version.test.mjs`
- `pnpm --filter codemem test:plugin -- --runInBand`
- `pnpm run tsc`
- `pnpm run lint` (only existing unrelated FeedItemCard info findings)
- `pnpm run test`
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced