### PR TITLE
feat(viewer): expose Sharing domain settings API

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5377,6 +5377,133 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("updates local Sharing domain project mappings without granting membership", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "project domain candidate",
+					metadata: {},
+				});
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						`INSERT INTO replication_scopes(
+							scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+						 ) VALUES ('acme-work', 'Acme Work', 'team', 'coordinator', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+
+				const settingsRes = await app.request("/api/sync/sharing-domains/settings");
+				expect(settingsRes.status).toBe(200);
+				const settings = (await settingsRes.json()) as {
+					scopes: Array<{ scope_id: string }>;
+					projects: Array<{
+						workspace_identity: string;
+						display_project: string;
+						resolved_scope_id: string;
+					}>;
+				};
+				expect(settings.scopes.map((scope) => scope.scope_id)).toEqual(
+					expect.arrayContaining(["local-default", "acme-work"]),
+				);
+				const project = settings.projects.find((item) => item.display_project === "test-project");
+				expect(project).toMatchObject({ resolved_scope_id: "local-default" });
+
+				const malformedRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						workspace_identity: project?.workspace_identity,
+						project_pattern: project?.display_project,
+						scope_id: ["acme-work"],
+					}),
+				});
+				expect(malformedRes.status).toBe(400);
+
+				const emptyScopeRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						workspace_identity: project?.workspace_identity,
+						project_pattern: project?.display_project,
+						scope_id: "",
+					}),
+				});
+				expect(emptyScopeRes.status).toBe(400);
+
+				const invalidScopeRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						workspace_identity: project?.workspace_identity,
+						project_pattern: project?.display_project,
+						scope_id: "missing-work-domain",
+					}),
+				});
+				expect(invalidScopeRes.status).toBe(400);
+
+				const fractionalIdRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						id: 1.9,
+						workspace_identity: project?.workspace_identity,
+						project_pattern: project?.display_project,
+						scope_id: "acme-work",
+					}),
+				});
+				expect(fractionalIdRes.status).toBe(400);
+
+				const saveRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						workspace_identity: project?.workspace_identity,
+						project_pattern: project?.display_project,
+						scope_id: "acme-work",
+					}),
+				});
+				expect(saveRes.status).toBe(200);
+				const saveBody = (await saveRes.json()) as { mapping: { id: number; scope_id: string } };
+				expect(saveBody.mapping.scope_id).toBe("acme-work");
+
+				const updatedRes = await app.request("/api/sync/sharing-domains/settings");
+				const updated = (await updatedRes.json()) as {
+					projects: Array<{
+						display_project: string;
+						resolved_scope_id: string;
+						mapping_id: number;
+					}>;
+				};
+				expect(
+					updated.projects.find((item) => item.display_project === "test-project"),
+				).toMatchObject({
+					resolved_scope_id: "acme-work",
+					mapping_id: saveBody.mapping.id,
+				});
+				const memberships = store.db
+					.prepare("SELECT COUNT(*) AS n FROM scope_memberships")
+					.get() as {
+					n: number;
+				};
+				expect(memberships.n).toBe(0);
+
+				const deleteRes = await app.request(
+					`/api/sync/sharing-domains/project-mappings/${saveBody.mapping.id}`,
+					{ method: "DELETE" },
+				);
+				expect(deleteRes.status).toBe(200);
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("runs sync for all peers through the compatibility sync route", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -43,6 +43,7 @@ import {
 	coordinatorUpdateScopeAction,
 	createCoordinatorReciprocalApproval,
 	DEFAULT_TIME_WINDOW_S,
+	deleteProjectScopeSettingsMapping,
 	ensureDeviceIdentity,
 	extractReplicationOps,
 	type FilterReplicationSkipped,
@@ -52,10 +53,14 @@ import {
 	getSemanticIndexDiagnostics,
 	getSyncResetState,
 	type InboundScopeRejectionPeerSummary,
+	LOCAL_DEFAULT_SCOPE_ID,
 	LOCAL_SYNC_CAPABILITY,
 	listCoordinatorJoinRequests,
 	listInboundScopeRejections,
 	listMaintenanceJobs,
+	listProjectScopeCandidates,
+	listProjectScopeSettingsMappings,
+	listSharingDomainSettingsScopes,
 	loadMemorySnapshotPageForPeer,
 	loadReplicationOpsForPeer,
 	lookupCoordinatorPeers,
@@ -75,6 +80,7 @@ import {
 	syncScopeResetRequiredPayload,
 	updatePeerAddresses,
 	upsertCoordinatorGroupPreference,
+	upsertProjectScopeSettingsMapping,
 	verifySignature,
 } from "@codemem/core";
 import { and, count, desc, eq, max, ne } from "drizzle-orm";
@@ -260,11 +266,25 @@ function optionalViewerString(body: Record<string, unknown>, key: string): strin
 	return String(value).trim() || null;
 }
 
+function optionalViewerStrictString(body: Record<string, unknown>, key: string): string | null {
+	const value = body[key];
+	if (value == null) return null;
+	if (typeof value !== "string") throw new Error(`${key} must be string`);
+	return value.trim() || null;
+}
+
 function optionalViewerNumber(body: Record<string, unknown>, key: string): number | null {
 	const value = body[key];
 	if (value == null || value === "") return null;
 	const number = typeof value === "number" ? value : Number(value);
 	return Number.isFinite(number) ? Math.trunc(number) : Number.NaN;
+}
+
+function optionalViewerInteger(body: Record<string, unknown>, key: string): number | null {
+	const value = body[key];
+	if (value == null || value === "") return null;
+	const number = typeof value === "number" ? value : Number(value);
+	return Number.isInteger(number) ? number : Number.NaN;
 }
 
 function coordinatorAdminMutationStatus(message: string): 400 | 404 | 409 | 502 {
@@ -2192,6 +2212,51 @@ export function syncRoutes(
 			ok: true,
 			project_scope: currentProjectScope(row, readPeerProjectFilters(store, peerDeviceId)),
 		});
+	});
+
+	app.get("/api/sync/sharing-domains/settings", (c) => {
+		const store = getStore();
+		const limit = Math.max(1, queryInt(c.req.query("limit"), 250));
+		return c.json({
+			scopes: listSharingDomainSettingsScopes(store.db),
+			mappings: listProjectScopeSettingsMappings(store.db),
+			projects: listProjectScopeCandidates(store.db, { limit }),
+			local_default_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+		});
+	});
+
+	app.put("/api/sync/sharing-domains/project-mappings", async (c) => {
+		const store = getStore();
+		const body = await parseViewerJsonBody(c);
+		if (!body) return c.json({ error: "invalid json" }, 400);
+		const id = optionalViewerInteger(body, "id");
+		const priority = optionalViewerInteger(body, "priority");
+		if (Number.isNaN(id)) return c.json({ error: "id must be an integer" }, 400);
+		if (Number.isNaN(priority)) return c.json({ error: "priority must be an integer" }, 400);
+		try {
+			const mapping = upsertProjectScopeSettingsMapping(store.db, {
+				id,
+				workspace_identity: optionalViewerStrictString(body, "workspace_identity"),
+				project_pattern: optionalViewerStrictString(body, "project_pattern"),
+				scope_id: optionalViewerStrictString(body, "scope_id") ?? "",
+				priority,
+				source: optionalViewerStrictString(body, "source") ?? "user",
+			});
+			return c.json({ ok: true, mapping });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		}
+	});
+
+	app.delete("/api/sync/sharing-domains/project-mappings/:id", (c) => {
+		const store = getStore();
+		const id = Number(c.req.param("id"));
+		try {
+			const deleted = deleteProjectScopeSettingsMapping(store.db, id);
+			return c.json({ ok: true, deleted });
+		} catch (error) {
+			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
+		}
 	});
 
 	app.post("/api/sync/peers/identity", async (c) => {


### PR DESCRIPTION
## Description
Adds viewer-server settings endpoints for Sharing-domain project mappings on top of the core helpers. The API lists domains/projects/mappings, saves mappings with strict field validation, rejects inactive or unknown `scope_id` values, and does not mutate `scope_memberships`.

Stack slice: viewer API for codemem-ov4g.6.1. Depends on #1044.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Validation run:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts -t "updates local Sharing domain project mappings without granting membership"`
- `pnpm run tsc`
- touched-file Biome check

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced