### PR TITLE
feat(viewer): enforce Sharing domain guardrail confirmations

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5504,6 +5504,284 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("requires confirmation before saving risky Sharing domain mappings", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						`INSERT INTO replication_scopes(
+							scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+						 ) VALUES ('acme-work', 'Acme Work', 'team', 'coordinator', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+
+				const unconfirmedRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						project_pattern: "/Users/adam/*",
+						scope_id: "acme-work",
+					}),
+				});
+				expect(unconfirmedRes.status).toBe(409);
+				const unconfirmed = (await unconfirmedRes.json()) as {
+					error: string;
+					required_guardrails: string[];
+					required_guardrail_tokens: string[];
+					guardrail_warnings: Array<{
+						code: string;
+						confirmation_token: string;
+						requires_confirmation: boolean;
+					}>;
+				};
+				expect(unconfirmed).toMatchObject({
+					error: "guardrail_confirmation_required",
+					required_guardrails: ["broad_org_domain_pattern", "home_directory_org_domain_pattern"],
+				});
+				expect(unconfirmed.guardrail_warnings).toEqual(
+					expect.arrayContaining([
+						expect.objectContaining({
+							code: "broad_org_domain_pattern",
+							confirmation_token: expect.stringMatching(/^psg_/),
+						}),
+						expect.objectContaining({
+							code: "home_directory_org_domain_pattern",
+							confirmation_token: expect.stringMatching(/^psg_/),
+						}),
+					]),
+				);
+				const codeOnlyRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						confirmed_guardrails: ["broad_org_domain_pattern", "home_directory_org_domain_pattern"],
+						project_pattern: "/Users/adam/*",
+						scope_id: "acme-work",
+					}),
+				});
+				expect(codeOnlyRes.status).toBe(409);
+				const staleTokenRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						confirmed_guardrail_tokens: unconfirmed.required_guardrail_tokens,
+						project_pattern: "/Users/bob/*",
+						scope_id: "acme-work",
+					}),
+				});
+				expect(staleTokenRes.status).toBe(409);
+
+				const confirmedRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						confirmed_guardrail_tokens: unconfirmed.required_guardrail_tokens,
+						project_pattern: "/Users/adam/*",
+						scope_id: "acme-work",
+					}),
+				});
+				expect(confirmedRes.status).toBe(200);
+				const confirmed = (await confirmedRes.json()) as {
+					mapping: { scope_id: string };
+					guardrail_warnings: Array<{ code: string }>;
+				};
+				expect(confirmed.mapping.scope_id).toBe("acme-work");
+				expect(confirmed.guardrail_warnings.map((warning) => warning.code)).toEqual([
+					"broad_org_domain_pattern",
+					"home_directory_org_domain_pattern",
+				]);
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("blocks unmapped projects from non-local Sharing domain assignment", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = new Date().toISOString();
+				const sessionResult = store.db
+					.prepare(
+						`INSERT INTO sessions(started_at, cwd, project, git_remote, git_branch, user, tool_version)
+						 VALUES (?, NULL, NULL, NULL, NULL, ?, ?)`,
+					)
+					.run(now, "test-user", "test");
+				insertTestMemory(store, {
+					sessionId: Number(sessionResult.lastInsertRowid),
+					kind: "discovery",
+					title: "unmapped project candidate",
+					metadata: {},
+				});
+				store.db
+					.prepare("UPDATE memory_items SET workspace_id = NULL WHERE title = ?")
+					.run("unmapped project candidate");
+				store.db
+					.prepare(
+						`INSERT INTO replication_scopes(
+							scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+						 ) VALUES ('acme-work', 'Acme Work', 'team', 'coordinator', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+
+				const settingsRes = await app.request("/api/sync/sharing-domains/settings");
+				const settings = (await settingsRes.json()) as {
+					projects: Array<{
+						display_project: string;
+						identity_source: string;
+						workspace_identity: string;
+					}>;
+				};
+				const project = settings.projects.find((item) => item.identity_source === "unmapped");
+				expect(project?.workspace_identity).toMatch(/^unmapped:/);
+
+				const res = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						workspace_identity: project?.workspace_identity,
+						project_pattern: project?.display_project,
+						scope_id: "acme-work",
+					}),
+				});
+				expect(res.status).toBe(400);
+				expect(await res.json()).toMatchObject({ error: "unmapped_project_local_only" });
+				const mappingResult = store.db
+					.prepare(
+						`INSERT INTO project_scope_mappings(
+							workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+						 ) VALUES (?, ?, ?, 0, 'user', ?, ?)`,
+					)
+					.run(project?.workspace_identity, project?.display_project, "local-default", now, now);
+				const byIdRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						id: Number(mappingResult.lastInsertRowid),
+						scope_id: "acme-work",
+					}),
+				});
+				expect(byIdRes.status).toBe(400);
+				expect(await byIdRes.json()).toMatchObject({ error: "unmapped_project_local_only" });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("requires confirmation before reassigning an existing project mapping", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "reassignment candidate",
+					metadata: {},
+				});
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						`INSERT INTO replication_scopes(
+							scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+						 ) VALUES ('acme-work', 'Acme Work', 'team', 'coordinator', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+				store.db
+					.prepare(
+						`INSERT INTO replication_scopes(
+							scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+						 ) VALUES ('personal-devices', 'Personal Devices', 'personal', 'local', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+				store.db
+					.prepare(
+						`INSERT INTO replication_scopes(
+							scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+						 ) VALUES ('oss-codemem', 'OSS codemem', 'team', 'coordinator', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+				const settingsRes = await app.request("/api/sync/sharing-domains/settings");
+				const settings = (await settingsRes.json()) as {
+					projects: Array<{ display_project: string; workspace_identity: string }>;
+				};
+				const project = settings.projects.find((item) => item.display_project === "test-project");
+				if (!project) throw new Error("project missing");
+				const createRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						workspace_identity: project.workspace_identity,
+						project_pattern: project.display_project,
+						scope_id: "acme-work",
+					}),
+				});
+				expect(createRes.status).toBe(200);
+				const created = (await createRes.json()) as { mapping: { id: number } };
+
+				const unconfirmedRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						id: created.mapping.id,
+						scope_id: "personal-devices",
+					}),
+				});
+				expect(unconfirmedRes.status).toBe(409);
+				const unconfirmed = (await unconfirmedRes.json()) as {
+					required_guardrails: string[];
+					required_guardrail_tokens: string[];
+				};
+				expect(unconfirmed).toMatchObject({
+					error: "guardrail_confirmation_required",
+					required_guardrails: ["scope_reassignment_old_copies"],
+				});
+				expect(unconfirmed.required_guardrail_tokens).toEqual([expect.stringMatching(/^psg_/)]);
+				store.db
+					.prepare("UPDATE project_scope_mappings SET scope_id = ? WHERE id = ?")
+					.run("oss-codemem", created.mapping.id);
+				const staleTokenRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						confirmed_guardrail_tokens: unconfirmed.required_guardrail_tokens,
+						id: created.mapping.id,
+						scope_id: "personal-devices",
+					}),
+				});
+				expect(staleTokenRes.status).toBe(409);
+				const staleTokenBody = (await staleTokenRes.json()) as {
+					required_guardrail_tokens: string[];
+				};
+				expect(staleTokenBody.required_guardrail_tokens).not.toEqual(
+					unconfirmed.required_guardrail_tokens,
+				);
+
+				const confirmedRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						confirmed_guardrail_tokens: staleTokenBody.required_guardrail_tokens,
+						id: created.mapping.id,
+						scope_id: "personal-devices",
+					}),
+				});
+				expect(confirmedRes.status).toBe(200);
+				expect(await confirmedRes.json()).toMatchObject({
+					mapping: { id: created.mapping.id, scope_id: "personal-devices" },
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("runs sync for all peers through the compatibility sync route", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const prevConfig = process.env.CODEMEM_CONFIG;

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -10,11 +10,13 @@ import type {
 	CoordinatorBootstrapGrantVerification,
 	MaintenanceJobSnapshot,
 	MemoryStore,
+	ProjectScopeGuardrailWarning,
 	ReplicationOp,
 	SemanticIndexDiagnostics,
 } from "@codemem/core";
 import {
 	addSyncScopeToBoundary,
+	analyzeProjectScopeMappingChangeGuardrails,
 	applyReplicationOps,
 	buildBaseUrl,
 	cleanupNonces,
@@ -273,6 +275,22 @@ function optionalViewerStrictString(body: Record<string, unknown>, key: string):
 	return value.trim() || null;
 }
 
+function optionalViewerStringList(body: Record<string, unknown>, key: string): string[] {
+	const value = body[key];
+	if (value == null) return [];
+	if (!Array.isArray(value)) throw new Error(`${key} must be an array of strings`);
+	return [
+		...new Set(
+			value
+				.map((item) => {
+					if (typeof item !== "string") throw new Error(`${key} must be an array of strings`);
+					return item.trim();
+				})
+				.filter(Boolean),
+		),
+	];
+}
+
 function optionalViewerNumber(body: Record<string, unknown>, key: string): number | null {
 	const value = body[key];
 	if (value == null || value === "") return null;
@@ -285,6 +303,18 @@ function optionalViewerInteger(body: Record<string, unknown>, key: string): numb
 	if (value == null || value === "") return null;
 	const number = typeof value === "number" ? value : Number(value);
 	return Number.isInteger(number) ? number : Number.NaN;
+}
+
+function missingGuardrailConfirmations(
+	warnings: ProjectScopeGuardrailWarning[],
+	confirmedTokens: string[],
+): ProjectScopeGuardrailWarning[] {
+	const confirmed = new Set(confirmedTokens);
+	return warnings.filter(
+		(warning) =>
+			warning.requires_confirmation &&
+			(!warning.confirmation_token || !confirmed.has(warning.confirmation_token)),
+	);
 }
 
 function coordinatorAdminMutationStatus(message: string): 400 | 404 | 409 | 502 {
@@ -2229,20 +2259,62 @@ export function syncRoutes(
 		const store = getStore();
 		const body = await parseViewerJsonBody(c);
 		if (!body) return c.json({ error: "invalid json" }, 400);
-		const id = optionalViewerInteger(body, "id");
-		const priority = optionalViewerInteger(body, "priority");
-		if (Number.isNaN(id)) return c.json({ error: "id must be an integer" }, 400);
-		if (Number.isNaN(priority)) return c.json({ error: "priority must be an integer" }, 400);
 		try {
-			const mapping = upsertProjectScopeSettingsMapping(store.db, {
+			const id = optionalViewerInteger(body, "id");
+			const priority = optionalViewerInteger(body, "priority");
+			if (Number.isNaN(id)) return c.json({ error: "id must be an integer" }, 400);
+			if (Number.isNaN(priority)) return c.json({ error: "priority must be an integer" }, 400);
+			const workspaceIdentity = optionalViewerStrictString(body, "workspace_identity");
+			const projectPattern = optionalViewerStrictString(body, "project_pattern");
+			const scopeId = optionalViewerStrictString(body, "scope_id") ?? "";
+			const source = optionalViewerStrictString(body, "source") ?? "user";
+			const confirmedGuardrailTokens = optionalViewerStringList(body, "confirmed_guardrail_tokens");
+			const mappingInput = {
 				id,
-				workspace_identity: optionalViewerStrictString(body, "workspace_identity"),
-				project_pattern: optionalViewerStrictString(body, "project_pattern"),
-				scope_id: optionalViewerStrictString(body, "scope_id") ?? "",
+				workspace_identity: workspaceIdentity,
+				project_pattern: projectPattern,
+				scope_id: scopeId,
 				priority,
-				source: optionalViewerStrictString(body, "source") ?? "user",
+				source,
+			};
+			const analysis = analyzeProjectScopeMappingChangeGuardrails(store.db, mappingInput);
+			if (
+				analysis.requested_workspace_identity?.startsWith("unmapped:") &&
+				scopeId !== LOCAL_DEFAULT_SCOPE_ID
+			) {
+				return c.json(
+					{
+						error: "unmapped_project_local_only",
+						message:
+							"Unmapped projects need a stable path, git remote, or workspace id before assigning a non-local Sharing domain.",
+						guardrail_warnings: analysis.warnings,
+					},
+					400,
+				);
+			}
+			const missingConfirmations = missingGuardrailConfirmations(
+				analysis.warnings,
+				confirmedGuardrailTokens,
+			);
+			if (missingConfirmations.length > 0) {
+				const missingCodes = [...new Set(missingConfirmations.map((warning) => warning.code))];
+				const missingTokens = [
+					...new Set(missingConfirmations.map((warning) => warning.confirmation_token)),
+				].filter((token): token is string => typeof token === "string" && token.length > 0);
+				return c.json(
+					{
+						error: "guardrail_confirmation_required",
+						required_guardrails: missingCodes,
+						required_guardrail_tokens: missingTokens,
+						guardrail_warnings: analysis.warnings,
+					},
+					409,
+				);
+			}
+			const mapping = upsertProjectScopeSettingsMapping(store.db, {
+				...mappingInput,
 			});
-			return c.json({ ok: true, mapping });
+			return c.json({ ok: true, mapping, guardrail_warnings: analysis.warnings });
 		} catch (error) {
 			return c.json({ error: error instanceof Error ? error.message : String(error) }, 400);
 		}


### PR DESCRIPTION
## Description
Wires guardrail analysis into the viewer Sharing-domain settings API. Risky mappings now return `409 guardrail_confirmation_required` with warning tokens, reject code-only/stale confirmations, and keep unmapped projects local-only unless they gain a stable identity.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant targeted checks pass locally: `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx`, `pnpm run tsc`, touched-file Biome, `pnpm --filter @codemem/ui build`
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced