### PR TITLE
feat(ui): add Sharing domain guardrail confirmations

### DIFF
--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -59,6 +59,7 @@ export {
 	mergeActor,
 	renameActor,
 	renamePeer,
+	SharingDomainGuardrailConfirmationError,
 	saveCoordinatorGroupPreferences,
 	saveSharingDomainProjectMapping,
 	triggerSync,

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -176,6 +176,24 @@ export interface ProjectScopeMapping {
 	source: string;
 	created_at?: string | null;
 	updated_at?: string | null;
+	guardrail_warnings?: ProjectScopeGuardrailWarning[];
+}
+
+export type ProjectScopeGuardrailSeverity = "info" | "warning";
+
+export interface ProjectScopeGuardrailWarning {
+	code: string;
+	severity: ProjectScopeGuardrailSeverity;
+	message: string;
+	requires_confirmation: boolean;
+	scope_id?: string | null;
+	previous_scope_id?: string | null;
+	mapping_id?: number | null;
+	workspace_identity?: string | null;
+	project_pattern?: string | null;
+	related_workspace_identities?: string[];
+	related_projects?: string[];
+	confirmation_token?: string;
 }
 
 export interface ProjectScopeCandidate {
@@ -191,6 +209,7 @@ export interface ProjectScopeCandidate {
 	resolution_reason: string;
 	mapping_id: number | null;
 	matched_pattern: string | null;
+	guardrail_warnings?: ProjectScopeGuardrailWarning[];
 }
 
 export interface SharingDomainSettings {
@@ -198,6 +217,24 @@ export interface SharingDomainSettings {
 	mappings: ProjectScopeMapping[];
 	projects: ProjectScopeCandidate[];
 	local_default_scope_id: string;
+}
+
+export class SharingDomainGuardrailConfirmationError extends Error {
+	requiredGuardrails: string[];
+	requiredGuardrailTokens: string[];
+	guardrailWarnings: ProjectScopeGuardrailWarning[];
+
+	constructor(input: {
+		required_guardrails?: string[];
+		required_guardrail_tokens?: string[];
+		guardrail_warnings?: ProjectScopeGuardrailWarning[];
+	}) {
+		super("Sharing domain guardrail confirmation required");
+		this.name = "SharingDomainGuardrailConfirmationError";
+		this.requiredGuardrails = input.required_guardrails ?? [];
+		this.requiredGuardrailTokens = input.required_guardrail_tokens ?? [];
+		this.guardrailWarnings = input.guardrail_warnings ?? [];
+	}
 }
 
 export async function loadSharingDomainSettings(): Promise<SharingDomainSettings> {
@@ -210,17 +247,32 @@ export async function saveSharingDomainProjectMapping(input: {
 	project_pattern?: string | null;
 	scope_id: string;
 	priority?: number | null;
+	confirmed_guardrail_tokens?: string[];
 }): Promise<ProjectScopeMapping> {
 	const resp = await fetch("/api/sync/sharing-domains/project-mappings", {
 		method: "PUT",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify(input),
 	});
-	const { text, payload } = await readJsonPayload<{ mapping?: ProjectScopeMapping }>(resp);
-	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	const { text, payload } = await readJsonPayload<{
+		error?: string;
+		mapping?: ProjectScopeMapping;
+		required_guardrails?: string[];
+		required_guardrail_tokens?: string[];
+		guardrail_warnings?: ProjectScopeGuardrailWarning[];
+	}>(resp);
+	if (!resp.ok) {
+		if (payload?.error === "guardrail_confirmation_required") {
+			throw new SharingDomainGuardrailConfirmationError(payload);
+		}
+		throw new Error(payloadError(payload) || text || "request failed");
+	}
 	const mapping = payload?.mapping;
 	if (!mapping) throw new Error("response missing mapping");
-	return mapping;
+	return {
+		...mapping,
+		guardrail_warnings: payload.guardrail_warnings ?? mapping.guardrail_warnings,
+	};
 }
 
 export async function deleteSharingDomainProjectMapping(id: number): Promise<boolean> {

--- a/packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx
+++ b/packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx
@@ -38,6 +38,34 @@ vi.mock("../../../lib/api", () => ({
 	deleteSharingDomainProjectMapping: vi.fn(),
 	loadSharingDomainSettings: vi.fn(),
 	saveSharingDomainProjectMapping: vi.fn(),
+	SharingDomainGuardrailConfirmationError: class SharingDomainGuardrailConfirmationError extends Error {
+		requiredGuardrails: string[];
+		requiredGuardrailTokens: string[];
+		guardrailWarnings: Array<{
+			code: string;
+			confirmation_token?: string;
+			message: string;
+			requires_confirmation: boolean;
+			severity: "info" | "warning";
+		}>;
+
+		constructor(input: {
+			required_guardrails?: string[];
+			required_guardrail_tokens?: string[];
+			guardrail_warnings?: Array<{
+				code: string;
+				confirmation_token?: string;
+				message: string;
+				requires_confirmation: boolean;
+				severity: "info" | "warning";
+			}>;
+		}) {
+			super("Sharing domain guardrail confirmation required");
+			this.requiredGuardrails = input.required_guardrails ?? [];
+			this.requiredGuardrailTokens = input.required_guardrail_tokens ?? [];
+			this.guardrailWarnings = input.guardrail_warnings ?? [];
+		}
+	},
 }));
 
 vi.mock("../../../lib/notice", () => ({ showGlobalNotice: vi.fn() }));
@@ -187,6 +215,230 @@ describe("SharingDomainsPanel", () => {
 			workspace_identity: "https://example.test/acme/api.git",
 		});
 		expect(root.textContent).toContain("Current default: Acme Work · explicit project mapping");
+	});
+
+	it("shows guardrail confirmation and retries save with confirmed codes", async () => {
+		vi.mocked(api.loadSharingDomainSettings)
+			.mockResolvedValueOnce({
+				local_default_scope_id: "local-default",
+				mappings: [],
+				projects: [
+					{
+						cwd: "/work/acme/api",
+						display_project: "api",
+						git_branch: "main",
+						git_remote: "https://example.test/acme/api.git",
+						guardrail_warnings: [],
+						identity_source: "git_remote",
+						latest_session_at: "2026-05-06T00:00:00Z",
+						mapping_id: 42,
+						matched_pattern: null,
+						project: "api",
+						resolution_reason: "exact_mapping",
+						resolved_scope_id: "acme-work",
+						workspace_identity: "https://example.test/acme/api.git",
+					},
+				],
+				scopes: [
+					{
+						authority_type: "coordinator",
+						kind: "team",
+						label: "Acme Work",
+						scope_id: "acme-work",
+						status: "active",
+					},
+					{
+						authority_type: "local",
+						kind: "personal",
+						label: "Personal Devices",
+						scope_id: "personal-devices",
+						status: "active",
+					},
+				],
+			})
+			.mockResolvedValueOnce({
+				local_default_scope_id: "local-default",
+				mappings: [],
+				projects: [
+					{
+						cwd: "/work/acme/api",
+						display_project: "api",
+						git_branch: "main",
+						git_remote: "https://example.test/acme/api.git",
+						guardrail_warnings: [],
+						identity_source: "git_remote",
+						latest_session_at: "2026-05-06T00:00:00Z",
+						mapping_id: 42,
+						matched_pattern: null,
+						project: "api",
+						resolution_reason: "exact_mapping",
+						resolved_scope_id: "personal-devices",
+						workspace_identity: "https://example.test/acme/api.git",
+					},
+				],
+				scopes: [
+					{
+						authority_type: "coordinator",
+						kind: "team",
+						label: "Acme Work",
+						scope_id: "acme-work",
+						status: "active",
+					},
+					{
+						authority_type: "local",
+						kind: "personal",
+						label: "Personal Devices",
+						scope_id: "personal-devices",
+						status: "active",
+					},
+				],
+			});
+		vi.mocked(api.saveSharingDomainProjectMapping)
+			.mockRejectedValueOnce(
+				new api.SharingDomainGuardrailConfirmationError({
+					guardrail_warnings: [
+						{
+							code: "scope_reassignment_old_copies",
+							confirmation_token: "psg_reassign_api",
+							message:
+								"Changing this project may leave old Sharing domain copies on previous recipients.",
+							requires_confirmation: true,
+							severity: "warning",
+						},
+					],
+					required_guardrail_tokens: ["psg_reassign_api"],
+					required_guardrails: ["scope_reassignment_old_copies"],
+				}),
+			)
+			.mockResolvedValueOnce({
+				id: 42,
+				priority: 0,
+				project_pattern: "api",
+				scope_id: "personal-devices",
+				source: "user",
+				workspace_identity: "https://example.test/acme/api.git",
+			});
+
+		const root = renderIntoDocument(<SharingDomainsPanel />);
+		await flushEffects();
+
+		const select = root.querySelector("select");
+		act(() => {
+			if (!select) throw new Error("select missing");
+			select.value = "personal-devices";
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		const saveButton = Array.from(root.querySelectorAll("button")).find(
+			(button) => button.textContent === "Save Sharing domain",
+		);
+		await act(async () => {
+			saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			await Promise.resolve();
+		});
+		await flushEffects();
+
+		expect(root.textContent).toContain("Review before saving this Sharing domain.");
+		expect(root.textContent).toContain("may leave old Sharing domain copies");
+
+		const confirmButton = Array.from(root.querySelectorAll("button")).find(
+			(button) => button.textContent === "Confirm and save",
+		);
+		await act(async () => {
+			confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			await Promise.resolve();
+		});
+		await flushEffects();
+
+		expect(api.saveSharingDomainProjectMapping).toHaveBeenLastCalledWith({
+			confirmed_guardrail_tokens: ["psg_reassign_api"],
+			id: 42,
+			project_pattern: "api",
+			scope_id: "personal-devices",
+			workspace_identity: "https://example.test/acme/api.git",
+		});
+		expect(root.textContent).toContain(
+			"Current default: Personal Devices · explicit project mapping",
+		);
+	});
+
+	it("creates a project override instead of rewriting a matched pattern mapping", async () => {
+		vi.mocked(api.loadSharingDomainSettings).mockResolvedValue({
+			local_default_scope_id: "local-default",
+			mappings: [
+				{
+					id: 7,
+					priority: 0,
+					project_pattern: "/work/acme/*",
+					scope_id: "acme-work",
+					source: "user",
+					workspace_identity: null,
+				},
+			],
+			projects: [
+				{
+					cwd: "/work/acme/api",
+					display_project: "api",
+					git_branch: null,
+					git_remote: null,
+					guardrail_warnings: [],
+					identity_source: "cwd",
+					latest_session_at: "2026-05-06T00:00:00Z",
+					mapping_id: 7,
+					matched_pattern: "/work/acme/*",
+					project: "api",
+					resolution_reason: "pattern_mapping",
+					resolved_scope_id: "acme-work",
+					workspace_identity: "/work/acme/api",
+				},
+			],
+			scopes: [
+				{
+					authority_type: "coordinator",
+					kind: "team",
+					label: "Acme Work",
+					scope_id: "acme-work",
+					status: "active",
+				},
+				{
+					authority_type: "local",
+					kind: "personal",
+					label: "Personal Devices",
+					scope_id: "personal-devices",
+					status: "active",
+				},
+			],
+		});
+		vi.mocked(api.saveSharingDomainProjectMapping).mockResolvedValue({
+			id: 42,
+			priority: 0,
+			project_pattern: "api",
+			scope_id: "personal-devices",
+			source: "user",
+			workspace_identity: "/work/acme/api",
+		});
+
+		const root = renderIntoDocument(<SharingDomainsPanel />);
+		await flushEffects();
+
+		const select = root.querySelector("select");
+		act(() => {
+			if (!select) throw new Error("select missing");
+			select.value = "personal-devices";
+			select.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		const saveButton = Array.from(root.querySelectorAll("button")).find(
+			(button) => button.textContent === "Save Sharing domain",
+		);
+		await act(async () => {
+			saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			await Promise.resolve();
+		});
+
+		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledWith({
+			project_pattern: "api",
+			scope_id: "personal-devices",
+			workspace_identity: "/work/acme/api",
+		});
 	});
 
 	it("keeps unmapped project assignment controls disabled", async () => {

--- a/packages/ui/src/tabs/settings/components/SharingDomainsPanel.tsx
+++ b/packages/ui/src/tabs/settings/components/SharingDomainsPanel.tsx
@@ -3,12 +3,19 @@ import { RadixSelect } from "../../../components/primitives/radix-select";
 import * as api from "../../../lib/api";
 import type {
 	ProjectScopeCandidate,
+	ProjectScopeGuardrailWarning,
 	SharingDomainScope,
 	SharingDomainSettings,
 } from "../../../lib/api/sync";
 import { showGlobalNotice } from "../../../lib/notice";
 
 type Drafts = Record<string, string>;
+
+interface PendingGuardrailConfirmation {
+	workspaceIdentity: string;
+	requiredGuardrailTokens: string[];
+	warnings: ProjectScopeGuardrailWarning[];
+}
 
 function domainLabel(scope: SharingDomainScope): string {
 	const qualifier = scope.authority_type === "local" ? "local" : scope.authority_type;
@@ -48,12 +55,46 @@ function canAssignProject(project: ProjectScopeCandidate): boolean {
 	return project.identity_source !== "unmapped";
 }
 
+function warningKey(warning: ProjectScopeGuardrailWarning, index: number): string {
+	return [warning.code, warning.workspace_identity, warning.project_pattern, index].join(":");
+}
+
+function visibleProjectWarnings(project: ProjectScopeCandidate): ProjectScopeGuardrailWarning[] {
+	return (project.guardrail_warnings ?? []).filter(
+		(warning) => warning.severity === "warning" || warning.code === "unknown_project_local_only",
+	);
+}
+
+function settingsMappingWarnings(settings: SharingDomainSettings): ProjectScopeGuardrailWarning[] {
+	return settings.mappings.flatMap((mapping) => mapping.guardrail_warnings ?? []);
+}
+
+function GuardrailMessages({
+	label = "Sharing domain guardrail",
+	warnings,
+}: {
+	label?: string;
+	warnings: ProjectScopeGuardrailWarning[];
+}) {
+	if (warnings.length === 0) return null;
+	return (
+		<div aria-label={label} className="settings-note" role="status">
+			<ul>
+				{warnings.map((warning, index) => (
+					<li key={warningKey(warning, index)}>{warning.message}</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
 export function SharingDomainsPanel() {
 	const [settings, setSettings] = useState<SharingDomainSettings | null>(null);
 	const [drafts, setDrafts] = useState<Drafts>({});
 	const [loading, setLoading] = useState(false);
 	const [savingKey, setSavingKey] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
+	const [confirmation, setConfirmation] = useState<PendingGuardrailConfirmation | null>(null);
 
 	const reload = async () => {
 		setLoading(true);
@@ -83,6 +124,13 @@ export function SharingDomainsPanel() {
 	);
 
 	const saveProject = async (project: ProjectScopeCandidate) => {
+		await saveProjectWithGuardrails(project);
+	};
+
+	const saveProjectWithGuardrails = async (
+		project: ProjectScopeCandidate,
+		confirmedGuardrailTokens: string[] = [],
+	) => {
 		if (!canAssignProject(project)) {
 			setError(
 				"Unmapped projects need a stable path, git remote, or workspace id before assignment.",
@@ -94,13 +142,28 @@ export function SharingDomainsPanel() {
 		setError(null);
 		try {
 			await api.saveSharingDomainProjectMapping({
+				...(project.mapping_id && project.resolution_reason === "exact_mapping"
+					? { id: project.mapping_id }
+					: {}),
+				...(confirmedGuardrailTokens.length > 0
+					? { confirmed_guardrail_tokens: confirmedGuardrailTokens }
+					: {}),
 				workspace_identity: project.workspace_identity,
 				project_pattern: project.display_project,
 				scope_id: scopeId,
 			});
+			setConfirmation(null);
 			showGlobalNotice("Project Sharing domain updated. Device access grants are unchanged.");
 			await reload();
 		} catch (err) {
+			if (err instanceof api.SharingDomainGuardrailConfirmationError) {
+				setConfirmation({
+					workspaceIdentity: project.workspace_identity,
+					requiredGuardrailTokens: err.requiredGuardrailTokens,
+					warnings: err.guardrailWarnings,
+				});
+				return;
+			}
 			setError(err instanceof Error ? err.message : "Unable to save Sharing domain mapping");
 		} finally {
 			setSavingKey(null);
@@ -113,6 +176,7 @@ export function SharingDomainsPanel() {
 		setError(null);
 		try {
 			await api.deleteSharingDomainProjectMapping(project.mapping_id);
+			setConfirmation(null);
 			showGlobalNotice("Project Sharing domain mapping removed. The next fallback now applies.");
 			await reload();
 		} catch (err) {
@@ -132,8 +196,18 @@ export function SharingDomainsPanel() {
 			<div className="small">
 				Unmapped and unknown projects stay on Local only until you assign a domain.
 			</div>
+			{settings ? (
+				<GuardrailMessages
+					label="Sharing domain mapping warnings"
+					warnings={settingsMappingWarnings(settings)}
+				/>
+			) : null}
 			{loading && !settings ? <div className="small">Loading Sharing domains…</div> : null}
-			{error ? <div className="settings-note">{error}</div> : null}
+			{error ? (
+				<div className="settings-note" role="alert">
+					{error}
+				</div>
+			) : null}
 			{settings && settings.projects.length === 0 ? (
 				<div className="small">No projects with memories are available yet.</div>
 			) : null}
@@ -144,6 +218,8 @@ export function SharingDomainsPanel() {
 				const unchanged = currentValue === project.resolved_scope_id;
 				const assignable = canAssignProject(project);
 				const currentScopeName = scopeName(settings.scopes, project.resolved_scope_id);
+				const pendingConfirmation =
+					confirmation?.workspaceIdentity === project.workspace_identity ? confirmation : null;
 				const canRemoveProjectMapping =
 					assignable && project.mapping_id != null && project.resolution_reason === "exact_mapping";
 				return (
@@ -156,9 +232,12 @@ export function SharingDomainsPanel() {
 							disabled={!assignable || saving || scopeOptions.length === 0}
 							id={fieldId}
 							itemClassName="settings-select-item"
-							onValueChange={(value) =>
-								setDrafts((prev) => ({ ...prev, [project.workspace_identity]: value }))
-							}
+							onValueChange={(value) => {
+								setDrafts((prev) => ({ ...prev, [project.workspace_identity]: value }));
+								if (confirmation?.workspaceIdentity === project.workspace_identity) {
+									setConfirmation(null);
+								}
+							}}
 							options={scopeOptions}
 							placeholder="Choose Sharing domain"
 							triggerClassName="settings-select-trigger"
@@ -168,10 +247,44 @@ export function SharingDomainsPanel() {
 						<div className="small">
 							Current default: {currentScopeName} · {resolutionLabel(project.resolution_reason)}
 						</div>
+						<GuardrailMessages warnings={visibleProjectWarnings(project)} />
 						{!assignable ? (
 							<div className="settings-note">
 								This project is missing a stable identity, so Sharing domain assignment is disabled.
 								Add a path, git remote, or workspace id first; until then it remains Local only.
+							</div>
+						) : null}
+						{pendingConfirmation ? (
+							<div className="settings-note" role="alert">
+								<strong>Review before saving this Sharing domain.</strong>
+								<ul>
+									{pendingConfirmation.warnings.map((warning, warningIndex) => (
+										<li key={warningKey(warning, warningIndex)}>{warning.message}</li>
+									))}
+								</ul>
+								<div className="section-actions">
+									<button
+										className="settings-button"
+										disabled={saving}
+										onClick={() =>
+											void saveProjectWithGuardrails(
+												project,
+												pendingConfirmation.requiredGuardrailTokens,
+											)
+										}
+										type="button"
+									>
+										Confirm and save
+									</button>
+									<button
+										className="settings-button"
+										disabled={saving}
+										onClick={() => setConfirmation(null)}
+										type="button"
+									>
+										Cancel
+									</button>
+								</div>
 							</div>
 						) : null}
 						<div className="section-actions">


### PR DESCRIPTION
## Description
Adds Settings UI treatment for Sharing-domain guardrails: inline warnings, accessible confirmation prompts, and retry with API-issued confirmation tokens before risky saves.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant targeted checks pass locally: `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx`, `pnpm run tsc`, touched-file Biome, `pnpm --filter @codemem/ui build`
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced