### PR TITLE
fix(core): refresh coordinator peer addresses

### DIFF
--- a/packages/core/src/coordinator-runtime.test.ts
+++ b/packages/core/src/coordinator-runtime.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { readCoordinatorSyncConfig } from "./coordinator-runtime.js";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	readCoordinatorSyncConfig,
+	refreshStoredCoordinatorPeerAddresses,
+} from "./coordinator-runtime.js";
+import { initTestSchema } from "./test-utils.js";
 
 describe("readCoordinatorSyncConfig.syncOpsLimit", () => {
 	afterEach(() => {
@@ -35,5 +40,119 @@ describe("readCoordinatorSyncConfig.syncOpsLimit", () => {
 	it("falls back to the default when the config value is not an integer", () => {
 		const config = readCoordinatorSyncConfig({ sync_ops_limit: "not-a-number" });
 		expect(config.syncOpsLimit).toBe(500);
+	});
+});
+
+describe("refreshStoredCoordinatorPeerAddresses", () => {
+	let db: InstanceType<typeof Database>;
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		initTestSchema(db);
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("merges fresh multi-group coordinator addresses into an existing pinned peer", () => {
+		db.prepare(
+			"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, public_key, addresses_json, projects_include_json, projects_exclude_json, last_error, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		).run(
+			"peer-1",
+			"Peer One",
+			"fp-1",
+			"peer-public-key",
+			JSON.stringify(["http://old.example:7337"]),
+			JSON.stringify(["work/*"]),
+			JSON.stringify(["personal/*"]),
+			"offline",
+			new Date().toISOString(),
+		);
+
+		const updated = refreshStoredCoordinatorPeerAddresses(db, [
+			{
+				device_id: "peer-1",
+				fingerprint: "fp-1",
+				addresses: ["http://10.0.0.5:7337"],
+				groups: ["team-a"],
+			},
+			{
+				device_id: "peer-1",
+				fingerprint: "fp-1",
+				addresses: ["10.0.0.6:7337"],
+				groups: ["team-b"],
+			},
+		]);
+
+		expect(updated).toBe(1);
+		const row = db
+			.prepare(
+				"SELECT name, pinned_fingerprint, public_key, addresses_json, projects_include_json, projects_exclude_json, last_error FROM sync_peers WHERE peer_device_id = ?",
+			)
+			.get("peer-1") as {
+			name: string | null;
+			pinned_fingerprint: string | null;
+			public_key: string | null;
+			addresses_json: string;
+			projects_include_json: string | null;
+			projects_exclude_json: string | null;
+			last_error: string | null;
+		};
+		expect(row.name).toBe("Peer One");
+		expect(row.pinned_fingerprint).toBe("fp-1");
+		expect(row.public_key).toBe("peer-public-key");
+		expect(JSON.parse(row.projects_include_json ?? "[]")).toEqual(["work/*"]);
+		expect(JSON.parse(row.projects_exclude_json ?? "[]")).toEqual(["personal/*"]);
+		expect(JSON.parse(row.addresses_json)).toEqual([
+			"http://old.example:7337",
+			"http://10.0.0.5:7337",
+			"http://10.0.0.6:7337",
+		]);
+		expect(row.last_error).toBe("offline");
+	});
+
+	it("does not refresh when the discovered fingerprint differs from the pinned peer", () => {
+		db.prepare(
+			"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, addresses_json, created_at) VALUES (?, ?, ?, ?, ?)",
+		).run(
+			"peer-1",
+			"Peer One",
+			"fp-pinned",
+			JSON.stringify(["http://old.example:7337"]),
+			new Date().toISOString(),
+		);
+
+		const updated = refreshStoredCoordinatorPeerAddresses(db, [
+			{
+				device_id: "peer-1",
+				fingerprint: "fp-other",
+				addresses: ["http://10.0.0.5:7337"],
+				groups: ["team-a"],
+			},
+		]);
+
+		expect(updated).toBe(0);
+		const row = db
+			.prepare("SELECT addresses_json FROM sync_peers WHERE peer_device_id = ?")
+			.get("peer-1") as { addresses_json: string };
+		expect(JSON.parse(row.addresses_json)).toEqual(["http://old.example:7337"]);
+	});
+
+	it("does not create peers for coordinator-only discovered devices", () => {
+		const updated = refreshStoredCoordinatorPeerAddresses(db, [
+			{
+				device_id: "peer-new",
+				fingerprint: "fp-new",
+				addresses: ["http://10.0.0.5:7337"],
+				groups: ["team-a"],
+			},
+		]);
+
+		expect(updated).toBe(0);
+		const count = db.prepare("SELECT COUNT(1) AS total FROM sync_peers").get() as {
+			total: number;
+		};
+		expect(count.total).toBe(0);
 	});
 });

--- a/packages/core/src/coordinator-runtime.ts
+++ b/packages/core/src/coordinator-runtime.ts
@@ -272,6 +272,78 @@ export async function lookupCoordinatorPeers(
 	return [...merged.values()];
 }
 
+function stringList(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function parseAddressCache(value: unknown): string[] {
+	if (typeof value !== "string" || value.trim().length === 0) return [];
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return stringList(parsed);
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Refresh cached transport addresses for existing, already-trusted peers from
+ * coordinator discovery results.
+ *
+ * This intentionally does not create peers or change trust/scope metadata. A
+ * discovered device can refresh a local peer only when both the device id and
+ * the pinned fingerprint match the existing row.
+ */
+export function refreshStoredCoordinatorPeerAddresses(
+	db: Database,
+	peers: Record<string, unknown>[],
+): number {
+	const discoveredAddressesByPinnedPeer = new Map<string, string[]>();
+	for (const peer of peers) {
+		const deviceId = clean(peer.device_id);
+		const fingerprint = clean(peer.fingerprint);
+		if (!deviceId || !fingerprint) continue;
+		const addresses = stringList(peer.addresses);
+		if (addresses.length === 0) continue;
+		const key = `${deviceId}:${fingerprint}`;
+		discoveredAddressesByPinnedPeer.set(
+			key,
+			mergeAddresses(discoveredAddressesByPinnedPeer.get(key) ?? [], addresses),
+		);
+	}
+	if (discoveredAddressesByPinnedPeer.size === 0) return 0;
+
+	const rows = db
+		.prepare("SELECT peer_device_id, pinned_fingerprint, addresses_json FROM sync_peers")
+		.all() as Array<{
+		peer_device_id: string | null;
+		pinned_fingerprint: string | null;
+		addresses_json: string | null;
+	}>;
+	const update = db.prepare(
+		"UPDATE sync_peers SET addresses_json = ? WHERE peer_device_id = ? AND pinned_fingerprint = ?",
+	);
+	let updated = 0;
+	const refresh = db.transaction(() => {
+		for (const row of rows) {
+			const deviceId = clean(row.peer_device_id);
+			const fingerprint = clean(row.pinned_fingerprint);
+			if (!deviceId || !fingerprint) continue;
+			const discoveredAddresses = discoveredAddressesByPinnedPeer.get(`${deviceId}:${fingerprint}`);
+			if (!discoveredAddresses?.length) continue;
+
+			const existingAddresses = mergeAddresses(parseAddressCache(row.addresses_json), []);
+			const mergedAddresses = mergeAddresses(existingAddresses, discoveredAddresses);
+			if (JSON.stringify(mergedAddresses) === JSON.stringify(existingAddresses)) continue;
+			update.run(JSON.stringify(mergedAddresses), deviceId, fingerprint);
+			updated += 1;
+		}
+	});
+	refresh.immediate();
+	return updated;
+}
+
 /**
  * Fetch the set of coordinator peer device IDs whose presence has expired.
  *
@@ -288,6 +360,7 @@ export async function fetchCoordinatorStalePeers(
 	if (!coordinatorEnabled(config)) return new Set();
 	try {
 		const peers = await lookupCoordinatorPeers({ db, dbPath }, config, { keysDir });
+		refreshStoredCoordinatorPeerAddresses(db, peers);
 		// A device may appear under multiple fingerprints (key rotation, multi-group).
 		// Only mark a device stale if ALL its entries are stale.
 		const freshDevices = new Set<string>();
@@ -472,6 +545,7 @@ export async function coordinatorStatusSnapshot(
 	}
 	try {
 		const peers = await lookupCoordinatorPeers(store, config);
+		refreshStoredCoordinatorPeerAddresses(store.db, peers);
 		let incomingApprovals: CoordinatorReciprocalApproval[] = [];
 		let outgoingApprovals: CoordinatorReciprocalApproval[] = [];
 		try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,7 @@ export {
 	listCoordinatorReciprocalApprovals,
 	lookupCoordinatorPeers,
 	readCoordinatorSyncConfig,
+	refreshStoredCoordinatorPeerAddresses,
 	registerCoordinatorPresence,
 } from "./coordinator-runtime.js";
 export type {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -6187,6 +6187,127 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("refreshes an existing multi-group peer address cache from sync status without re-pairing", async () => {
+			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
+			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));
+			const prevConfig = process.env.CODEMEM_CONFIG;
+			const prevKeysDir = process.env.CODEMEM_KEYS_DIR;
+			const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url.endsWith("/v1/presence")) {
+					return new Response(JSON.stringify({ ok: true, addresses: ["http://local:7337"] }), {
+						status: 200,
+					});
+				}
+				if (url.includes("/v1/peers?group_id=team-a")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Fresh Device",
+									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
+									addresses: ["http://10.0.0.5:7337"],
+									last_seen_at: new Date().toISOString(),
+									expires_at: new Date(Date.now() + 60_000).toISOString(),
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (url.includes("/v1/peers?group_id=team-b")) {
+					return new Response(
+						JSON.stringify({
+							items: [
+								{
+									device_id: "peer-fresh",
+									display_name: "Fresh Device",
+									fingerprint: "fp-fresh",
+									public_key: "peer-public-key",
+									addresses: ["10.0.0.6:7337"],
+									last_seen_at: new Date().toISOString(),
+									expires_at: new Date(Date.now() + 60_000).toISOString(),
+									stale: false,
+								},
+							],
+						}),
+						{ status: 200 },
+					);
+				}
+				if (url.includes("/v1/reciprocal-approvals")) {
+					return new Response(JSON.stringify({ items: [] }), { status: 200 });
+				}
+				return new Response(JSON.stringify({ error: "unexpected" }), { status: 500 });
+			});
+			const prevFetch = globalThis.fetch;
+			globalThis.fetch = fetchMock as typeof fetch;
+			process.env.CODEMEM_CONFIG = configPath;
+			process.env.CODEMEM_KEYS_DIR = keysDir;
+			writeFileSync(
+				configPath,
+				JSON.stringify({
+					sync_enabled: true,
+					sync_coordinator_url: "https://coord-refresh.example.test",
+					sync_coordinator_groups: ["team-a", "team-b"],
+				}),
+			);
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				ensureDeviceIdentity(store.db, { keysDir });
+				store.db
+					.prepare(
+						"INSERT INTO sync_peers(peer_device_id, name, pinned_fingerprint, addresses_json, last_error, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+					)
+					.run(
+						"peer-fresh",
+						"Old Name",
+						"fp-fresh",
+						JSON.stringify(["http://old.example:7337"]),
+						"all addresses failed",
+						new Date().toISOString(),
+					);
+
+				const res = await app.request("/api/sync/status?includeDiagnostics=1");
+
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as { peers?: Array<Record<string, unknown>> };
+				const peerPayload = body.peers?.find((peer) => peer.peer_device_id === "peer-fresh");
+				expect(peerPayload?.addresses).toEqual([
+					"http://old.example:7337",
+					"http://10.0.0.5:7337",
+					"http://10.0.0.6:7337",
+				]);
+				const peerRow = store.db
+					.prepare("SELECT addresses_json, last_error FROM sync_peers WHERE peer_device_id = ?")
+					.get("peer-fresh") as Record<string, unknown> | undefined;
+				expect(JSON.parse(String(peerRow?.addresses_json ?? "[]"))).toEqual([
+					"http://old.example:7337",
+					"http://10.0.0.5:7337",
+					"http://10.0.0.6:7337",
+				]);
+				expect(peerRow?.last_error).toBe("all addresses failed");
+				expect(
+					fetchMock.mock.calls.some(
+						([input, init]) =>
+							String(input).endsWith("/v1/reciprocal-approvals") && init?.method === "POST",
+					),
+				).toBe(false);
+			} finally {
+				cleanup();
+				globalThis.fetch = prevFetch;
+				if (prevConfig == null) delete process.env.CODEMEM_CONFIG;
+				else process.env.CODEMEM_CONFIG = prevConfig;
+				if (prevKeysDir == null) delete process.env.CODEMEM_KEYS_DIR;
+				else process.env.CODEMEM_KEYS_DIR = prevKeysDir;
+			}
+		});
+
 		it("rejects accepting a discovered device when an existing peer is pinned to another fingerprint", async () => {
 			const configPath = join(mkdtempSync(join(tmpdir(), "codemem-config-test-")), "config.json");
 			const keysDir = mkdtempSync(join(tmpdir(), "codemem-keys-test-"));

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -1805,6 +1805,11 @@ export function syncRoutes(
 				statusPayload.daemon_detail = runtimeStatus.detail ?? daemonDetail;
 			}
 
+			const coordinatorSnapshot = await coordinatorStatusSnapshot(store, config);
+			const coordinator = traceSync("coordinator", () =>
+				redactCoordinatorStatus(coordinatorSnapshot, showDiag),
+			);
+
 			// Build peers list using deduplicated mapPeerRow
 			const peerRows = traceSync(
 				"peerRows",
@@ -1878,10 +1883,6 @@ export function syncRoutes(
 			};
 			const legacyDevices = traceSync("legacyDevices", () => store.claimableLegacyDeviceIds());
 			const sharingReview = traceSync("sharingReview", () => store.sharingReviewSummary(project));
-			const coordinatorSnapshot = await coordinatorStatusSnapshot(store, config);
-			const coordinator = traceSync("coordinator", () =>
-				redactCoordinatorStatus(coordinatorSnapshot, showDiag),
-			);
 			let joinRequests: Record<string, unknown>[] = [];
 			if (includeJoinRequests && showDiag && config.syncCoordinatorAdminSecret) {
 				try {


### PR DESCRIPTION
## Description
Fixes `codemem-rmze` by refreshing existing sync peer address caches from coordinator discovery. Status refreshes and daemon coordinator preflight now merge fresh normalized addresses into already-trusted peers matched by `peer_device_id` + pinned fingerprint, without creating peers or changing trust/scope metadata.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Ran:
- `pnpm exec vitest run packages/core/src/coordinator-runtime.test.ts packages/core/src/sync-daemon.test.ts packages/viewer-server/src/index.test.ts`
- `pnpm run tsc`
- `pnpm run lint` (passes; reports existing FeedItemCard Boolean infos)
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced