### PR TITLE
feat(ui): show peer Sharing domains in sync

### DIFF
--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -18,12 +18,16 @@ import {
 import { PeerScopeCollapsible } from "../peer-scope-collapsible";
 import { openSyncConfirmDialog } from "../sync-dialogs";
 import {
+	derivePeerAuthorizedDomainsView,
 	derivePeerDirection,
+	derivePeerProjectNarrowingView,
 	derivePeerScopeRejectionsView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
+	type PeerClaimedLocalActorScopeLike,
 	type PeerDirection,
 	type PeerLike,
+	type PeerProjectScopeLike,
 	type PeerScopeRejectionsSummary,
 } from "../view-model";
 import { renderIntoSyncMount } from "./render-root";
@@ -99,19 +103,12 @@ const DIRECTION_GLYPH: Record<PeerDirection, { glyph: string; label: string } | 
 	none: null,
 };
 
-type PeerScopeLike = {
-	include?: string[];
-	exclude?: string[];
-	effective_include?: string[];
-	effective_exclude?: string[];
-	inherits_global?: boolean;
-};
-
 type SyncPeer = PeerLike & {
 	actor_display_name?: string;
 	addresses?: unknown[];
 	claimed_local_actor?: boolean;
-	project_scope?: PeerScopeLike;
+	claimed_local_actor_scope?: PeerClaimedLocalActorScopeLike | null;
+	project_scope?: PeerProjectScopeLike;
 	scope_rejections?: PeerScopeRejectionsSummary;
 	discovered_via_coordinator_id?: string | null;
 	discovered_via_group_id?: string | null;
@@ -144,6 +141,19 @@ type SyncPeersListProps = Omit<SyncPeerCardProps, "peer"> & {
 
 function listText(value: unknown): string[] {
 	return Array.isArray(value) ? value.map((item) => String(item || "").trim()).filter(Boolean) : [];
+}
+
+function claimedLocalActorScopeMessage(
+	scope: PeerClaimedLocalActorScopeLike | null | undefined,
+): string {
+	const scopeId = String(scope?.scope_id || "").trim();
+	if (!scope) {
+		return "Private same-person sync is limited to an allowed personal Sharing domain; team or org domains do not carry your private memories.";
+	}
+	if (scope.authorized) {
+		return `Private same-person sync is limited to personal Sharing domain ${scopeId || "this device's personal domain"}. Team and org domains do not carry your private memories.`;
+	}
+	return `Private same-person sync is blocked until this device is granted ${scopeId || "its personal Sharing domain"}.`;
 }
 
 function ExistingElementSlot({ element }: { element: HTMLElement }) {
@@ -179,8 +189,10 @@ function SyncPeerCard({
 	const trustSummary = derivePeerTrustSummary(peer);
 	const directionHint = DIRECTION_GLYPH[derivePeerDirection(peer)];
 	const peerStatus: SyncPeerStatus = peer.status || {};
+	const authorizedDomains = derivePeerAuthorizedDomainsView(peer);
 	const scopeRejections = derivePeerScopeRejectionsView(peer);
 	const scope = peer.project_scope || {};
+	const projectNarrowing = derivePeerProjectNarrowingView(scope);
 	const includeList = listText(scope.include);
 	const excludeList = listText(scope.exclude);
 	const primaryAddress = pickPrimaryAddress(peer.addresses);
@@ -461,6 +473,12 @@ function SyncPeerCard({
 							{pendingScopeReview ? (
 								<span className="badge actor-badge">Needs scope review</span>
 							) : null}
+							<span
+								className={`badge ${authorizedDomains.isWarning ? "badge-offline" : "actor-badge"}`}
+								title="Sharing domains are the hard access boundary; project filters only narrow inside them."
+							>
+								{authorizedDomains.badgeLabel}
+							</span>
 							{scopeRejections.badgeLabel ? (
 								<span
 									className="badge badge-offline"
@@ -556,6 +574,23 @@ function SyncPeerCard({
 							].join(" · ")}
 						</div>
 
+						<div className="peer-scope-summary">Authorized Sharing domains</div>
+						<div className="peer-meta">
+							{authorizedDomains.total > 0
+								? "These Sharing domains are the hard access boundary for this device."
+								: authorizedDomains.emptyMessage}
+						</div>
+						{authorizedDomains.domains.length > 0 ? (
+							<ul className="peer-scope-chips" aria-label="Authorized Sharing domains">
+								{authorizedDomains.domains.map((domain) => (
+									<li className="peer-scope-chip" key={domain.scopeId} title={domain.detail}>
+										{domain.label}
+									</li>
+								))}
+							</ul>
+						) : null}
+						<div className="peer-meta">{projectNarrowing.note}</div>
+
 						{scopeRejections.total > 0 ? (
 							<div
 								className="peer-scope-rejections"
@@ -586,6 +621,11 @@ function SyncPeerCard({
 
 						<div className="peer-scope-summary">Who this device belongs to</div>
 						<div className="peer-meta">{assignmentSummary}</div>
+						{peer.claimed_local_actor ? (
+							<div className="peer-meta">
+								{claimedLocalActorScopeMessage(peer.claimed_local_actor_scope)}
+							</div>
+						) : null}
 						<div className="peer-actor-row">
 							<div className="sync-radix-select-host sync-actor-select-host">
 								<RadixSelect
@@ -611,10 +651,10 @@ function SyncPeerCard({
 							</button>
 						</div>
 
-						<div className="peer-scope-summary">Advanced sharing scope</div>
+						<div className="peer-scope-summary">Project filters (narrowing only)</div>
 						<div className="peer-meta">
-							Review or tighten what this device can share when you need more than the global
-							defaults.
+							{projectNarrowing.summary} Review or tighten these filters when this device should
+							receive fewer projects from its authorized Sharing domains.
 						</div>
 						<PeerScopeCollapsible
 							contentHost={scopeHost}

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
 	deriveCoordinatorApprovalSummary,
 	deriveDuplicatePeople,
+	derivePeerAuthorizedDomainsView,
+	derivePeerProjectNarrowingView,
 	derivePeerScopeRejectionsView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
@@ -174,6 +176,57 @@ describe("derivePeerScopeRejectionsView", () => {
 			scope_rejections: { total: 1, by_reason: { missing_scope: 1 } },
 		});
 		expect(view.badgeLabel).toBe("1 sync rejection");
+	});
+});
+
+describe("derivePeerAuthorizedDomainsView", () => {
+	it("labels peers with no cached Sharing domain authorization", () => {
+		const view = derivePeerAuthorizedDomainsView({ authorized_scopes: [] });
+
+		expect(view.total).toBe(0);
+		expect(view.badgeLabel).toBe("No Sharing domains");
+		expect(view.isWarning).toBe(true);
+		expect(view.emptyMessage).toContain("Project filters below cannot send data by themselves");
+	});
+
+	it("formats authorized Sharing domains without exposing membership internals", () => {
+		const view = derivePeerAuthorizedDomainsView({
+			authorized_scopes: [
+				{
+					authority_type: "coordinator",
+					kind: "team",
+					label: "Acme Work",
+					role: "member",
+					scope_id: "acme-work",
+				},
+				{
+					authority_type: "local",
+					kind: "personal",
+					label: "Personal Devices",
+					role: "member",
+					scope_id: "personal-devices",
+				},
+			],
+		});
+
+		expect(view.badgeLabel).toBe("2 Sharing domains");
+		expect(view.isWarning).toBe(false);
+		expect(view.domains.map((domain) => domain.label)).toEqual(["Acme Work", "Personal Devices"]);
+		expect(view.domains[0]?.detail).toBe("team · coordinator · member role");
+	});
+});
+
+describe("derivePeerProjectNarrowingView", () => {
+	it("explains project filters as narrowing instead of grants", () => {
+		const view = derivePeerProjectNarrowingView({
+			effective_exclude: ["personal"],
+			effective_include: ["*"],
+			inherits_global: true,
+		});
+
+		expect(view.summary).toBe("Global defaults. Include filter: *; Exclude filter: personal.");
+		expect(view.note).toContain("only narrow data after Sharing domain authorization");
+		expect(view.note).toContain("never grant access to another domain");
 	});
 });
 

--- a/packages/ui/src/tabs/sync/view-model.ts
+++ b/packages/ui/src/tabs/sync/view-model.ts
@@ -13,10 +13,15 @@ export {
 } from "./view-model/coordinator-approval";
 export { deviceNeedsFriendlyName, resolveFriendlyDeviceName } from "./view-model/device-names";
 export {
+	derivePeerAuthorizedDomainsView,
 	derivePeerDirection,
+	derivePeerProjectNarrowingView,
 	derivePeerScopeRejectionsView,
 	derivePeerTrustSummary,
 	derivePeerUiStatus,
+	type PeerAuthorizedDomainsView,
+	type PeerAuthorizedDomainViewItem,
+	type PeerProjectNarrowingView,
 	type PeerScopeRejectionsView,
 } from "./view-model/peer-status";
 export {
@@ -27,8 +32,11 @@ export { deriveSyncViewModel } from "./view-model/sync-view-model";
 export {
 	type ActorLike,
 	type DiscoveredDeviceLike,
+	type PeerAuthorizedScopeLike,
+	type PeerClaimedLocalActorScopeLike,
 	type PeerDirection,
 	type PeerLike,
+	type PeerProjectScopeLike,
 	type PeerRecentOps,
 	type PeerScopeRejectionReason,
 	type PeerScopeRejectionsSummary,

--- a/packages/ui/src/tabs/sync/view-model/peer-status.ts
+++ b/packages/ui/src/tabs/sync/view-model/peer-status.ts
@@ -10,8 +10,10 @@ import {
 	peerErrorText,
 } from "./internal";
 import type {
+	PeerAuthorizedScopeLike,
 	PeerDirection,
 	PeerLike,
+	PeerProjectScopeLike,
 	PeerScopeRejectionReason,
 	UiPeerTrustSummary,
 	UiSyncStatus,
@@ -147,5 +149,93 @@ export function derivePeerScopeRejectionsView(peer: PeerLike): PeerScopeRejectio
 		badgeLabel,
 		reasons,
 		lastAt: summary.last_at ?? null,
+	};
+}
+
+function cleanList(values: unknown): string[] {
+	return Array.isArray(values)
+		? values.map((item) => cleanText(item)).filter((item): item is string => Boolean(item))
+		: [];
+}
+
+function shortList(values: string[], emptyLabel: string): string {
+	if (values.length === 0) return emptyLabel;
+	const visible = values.slice(0, 3).join(", ");
+	const remaining = values.length - 3;
+	return remaining > 0 ? `${visible} +${remaining.toLocaleString()} more` : visible;
+}
+
+function labelPart(value: string | null, fallback: string): string {
+	return value ? value.replaceAll("_", " ") : fallback;
+}
+
+export interface PeerAuthorizedDomainViewItem {
+	scopeId: string;
+	label: string;
+	detail: string;
+}
+
+export interface PeerAuthorizedDomainsView {
+	total: number;
+	badgeLabel: string;
+	isWarning: boolean;
+	domains: PeerAuthorizedDomainViewItem[];
+	emptyMessage: string;
+}
+
+export function derivePeerAuthorizedDomainsView(peer: PeerLike): PeerAuthorizedDomainsView {
+	const domains = (Array.isArray(peer.authorized_scopes) ? peer.authorized_scopes : [])
+		.map((scope: PeerAuthorizedScopeLike): PeerAuthorizedDomainViewItem | null => {
+			const scopeId = cleanText(scope.scope_id);
+			const label = cleanText(scope.label) ?? scopeId;
+			if (!scopeId && !label) return null;
+			const detail = [
+				labelPart(cleanText(scope.kind), "user"),
+				labelPart(cleanText(scope.authority_type), "local"),
+				`${labelPart(cleanText(scope.role), "member")} role`,
+			]
+				.filter(Boolean)
+				.join(" · ");
+			return { scopeId: scopeId || label, label: label || scopeId, detail };
+		})
+		.filter((item): item is PeerAuthorizedDomainViewItem => item != null);
+	const total = domains.length;
+	return {
+		total,
+		badgeLabel:
+			total === 1
+				? "1 Sharing domain"
+				: total > 1
+					? `${total} Sharing domains`
+					: "No Sharing domains",
+		isWarning: total === 0,
+		domains,
+		emptyMessage:
+			"No authorized Sharing domains are cached for this device. Project filters below cannot send data by themselves.",
+	};
+}
+
+export interface PeerProjectNarrowingView {
+	summary: string;
+	note: string;
+	sourceLabel: string;
+	includeLabel: string;
+	excludeLabel: string;
+}
+
+export function derivePeerProjectNarrowingView(
+	scope: PeerProjectScopeLike | null | undefined,
+): PeerProjectNarrowingView {
+	const effectiveInclude = cleanList(scope?.effective_include);
+	const effectiveExclude = cleanList(scope?.effective_exclude);
+	const sourceLabel = scope?.inherits_global ? "Global defaults" : "Device override";
+	const includeLabel = `Include filter: ${shortList(effectiveInclude, "all projects")}`;
+	const excludeLabel = `Exclude filter: ${shortList(effectiveExclude, "no exclusions")}`;
+	return {
+		sourceLabel,
+		includeLabel,
+		excludeLabel,
+		summary: `${sourceLabel}. ${includeLabel}; ${excludeLabel}.`,
+		note: "Project filters only narrow data after Sharing domain authorization; they never grant access to another domain.",
 	};
 }

--- a/packages/ui/src/tabs/sync/view-model/types.ts
+++ b/packages/ui/src/tabs/sync/view-model/types.ts
@@ -127,6 +127,33 @@ export interface PeerScopeRejectionsSummary {
 	last_at?: string | null;
 }
 
+export interface PeerProjectScopeLike {
+	include?: string[];
+	exclude?: string[];
+	effective_include?: string[];
+	effective_exclude?: string[];
+	inherits_global?: boolean;
+}
+
+export interface PeerAuthorizedScopeLike {
+	scope_id?: string | null;
+	label?: string | null;
+	kind?: string | null;
+	authority_type?: string | null;
+	coordinator_id?: string | null;
+	group_id?: string | null;
+	role?: string | null;
+	membership_epoch?: number | null;
+	updated_at?: string | null;
+}
+
+export interface PeerClaimedLocalActorScopeLike {
+	scope_id?: string | null;
+	authorized?: boolean;
+	state?: string | null;
+	action_required?: boolean;
+}
+
 export interface PeerLike {
 	peer_device_id?: string;
 	name?: string;
@@ -137,6 +164,10 @@ export interface PeerLike {
 	status?: SyncPeerStatusLike;
 	recent_ops?: PeerRecentOps;
 	scope_rejections?: PeerScopeRejectionsSummary;
+	project_scope?: PeerProjectScopeLike;
+	authorized_scopes?: PeerAuthorizedScopeLike[];
+	claimed_local_actor?: boolean;
+	claimed_local_actor_scope?: PeerClaimedLocalActorScopeLike | null;
 }
 
 export interface DiscoveredDeviceLike {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2168,6 +2168,185 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("surfaces authorized Sharing domains separately from project narrowing", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				const _warmup = await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						`INSERT INTO sync_peers (
+							peer_device_id, name, claimed_local_actor, projects_include_json,
+							projects_exclude_json, created_at
+						) VALUES (?, ?, 0, ?, ?, ?)`,
+					)
+					.run("peer-scope", "Peer Scope", JSON.stringify(["*"]), JSON.stringify(["private"]), now);
+				const insertScope = store.db.prepare(
+					`INSERT INTO replication_scopes(
+						scope_id, label, kind, authority_type, coordinator_id, group_id,
+						membership_epoch, status, created_at, updated_at
+					 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				);
+				insertScope.run(
+					"acme-work",
+					"Acme Work",
+					"team",
+					"coordinator",
+					"coord",
+					"team-a",
+					2,
+					"active",
+					now,
+					now,
+				);
+				insertScope.run(
+					"personal-devices",
+					"Personal Devices",
+					"personal",
+					"local",
+					null,
+					null,
+					1,
+					"active",
+					now,
+					now,
+				);
+				insertScope.run(
+					"stale-team",
+					"Stale Team",
+					"team",
+					"coordinator",
+					"coord",
+					"team-a",
+					5,
+					"active",
+					now,
+					now,
+				);
+				insertScope.run(
+					"archived-team",
+					"Archived Team",
+					"team",
+					"coordinator",
+					"coord",
+					"team-a",
+					1,
+					"archived",
+					now,
+					now,
+				);
+				const insertMembership = store.db.prepare(
+					`INSERT INTO scope_memberships(
+						scope_id, device_id, role, status, membership_epoch, coordinator_id, group_id, updated_at
+					 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				);
+				insertMembership.run(
+					"acme-work",
+					"peer-scope",
+					"member",
+					"active",
+					2,
+					"coord",
+					"team-a",
+					now,
+				);
+				insertMembership.run(
+					"personal-devices",
+					"peer-scope",
+					"member",
+					"active",
+					1,
+					null,
+					null,
+					now,
+				);
+				insertMembership.run(
+					"stale-team",
+					"peer-scope",
+					"member",
+					"active",
+					4,
+					"coord",
+					"team-a",
+					now,
+				);
+				insertMembership.run(
+					"archived-team",
+					"peer-scope",
+					"member",
+					"active",
+					1,
+					"coord",
+					"team-a",
+					now,
+				);
+				insertMembership.run(
+					"acme-work",
+					"peer-revoked",
+					"member",
+					"active",
+					2,
+					"coord",
+					"team-a",
+					now,
+				);
+
+				const res = await app.request("/api/sync/peers");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					items: Array<{
+						authorized_scopes: Array<Record<string, unknown>>;
+						peer_device_id: string;
+						project_scope: Record<string, unknown>;
+					}>;
+				};
+				const peer = body.items.find((item) => item.peer_device_id === "peer-scope");
+				expect(peer?.project_scope).toMatchObject({
+					effective_exclude: ["private"],
+					effective_include: ["*"],
+					exclude: ["private"],
+					include: ["*"],
+					inherits_global: false,
+				});
+				expect(peer?.authorized_scopes.map((scope) => scope.scope_id)).toEqual([
+					"acme-work",
+					"personal-devices",
+				]);
+				expect(peer?.authorized_scopes[0]).toMatchObject({
+					authority_type: "coordinator",
+					coordinator_id: "coord",
+					group_id: "team-a",
+					kind: "team",
+					label: "Acme Work",
+					membership_epoch: 2,
+					role: "member",
+				});
+
+				const statusRes = await app.request("/api/sync/status");
+				expect(statusRes.status).toBe(200);
+				const statusBody = (await statusRes.json()) as {
+					peers: Array<{
+						authorized_scopes: Array<Record<string, unknown>>;
+						peer_device_id: string;
+						project_scope: Record<string, unknown>;
+					}>;
+				};
+				const statusPeer = statusBody.peers.find((item) => item.peer_device_id === "peer-scope");
+				expect(statusPeer?.authorized_scopes.map((scope) => scope.scope_id)).toEqual([
+					"acme-work",
+					"personal-devices",
+				]);
+				expect(statusPeer?.project_scope).toMatchObject({
+					effective_exclude: ["private"],
+					effective_include: ["*"],
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("surfaces inbound scope-rejection summary per peer", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {
@@ -5901,10 +6080,58 @@ describe("viewer-server", () => {
 				const now = new Date().toISOString();
 				store.db
 					.prepare(
-						`INSERT INTO sync_peers(peer_device_id, name, actor_id, claimed_local_actor, created_at)
-						 VALUES (?, ?, ?, 1, ?)`,
+						`INSERT INTO sync_peers(
+							peer_device_id, name, actor_id, claimed_local_actor, pinned_fingerprint,
+							addresses_json, last_error, created_at
+						) VALUES (?, ?, ?, 1, ?, ?, ?, ?)`,
 					)
-					.run("peer-claim", "Peer Claim", store.actorId, now);
+					.run(
+						"peer-claim",
+						"Peer Claim",
+						store.actorId,
+						"fp-claim",
+						JSON.stringify(["10.0.0.5:38899"]),
+						"raw sync error",
+						now,
+					);
+
+				const redactedRes = await app.request("/api/sync/peers");
+				expect(redactedRes.status).toBe(200);
+				const redactedBody = (await redactedRes.json()) as {
+					items: Array<{
+						addresses: unknown[];
+						claimed_local_actor_scope: Record<string, unknown> | null;
+						fingerprint: unknown;
+						last_error: unknown;
+					}>;
+					redacted: boolean;
+				};
+				expect(redactedBody.redacted).toBe(true);
+				expect(redactedBody.items[0]?.fingerprint).toBeNull();
+				expect(redactedBody.items[0]?.addresses).toEqual([]);
+				expect(redactedBody.items[0]?.last_error).toBeNull();
+				expect(redactedBody.items[0]?.claimed_local_actor_scope).toMatchObject({
+					action_required: true,
+					authorized: false,
+					scope_id: `personal:${store.actorId}`,
+					state: "not_authorized",
+				});
+
+				const statusRes = await app.request("/api/sync/status");
+				expect(statusRes.status).toBe(200);
+				const statusBody = (await statusRes.json()) as {
+					peers: Array<{
+						claimed_local_actor_scope: Record<string, unknown> | null;
+						peer_device_id: string;
+					}>;
+				};
+				const statusPeer = statusBody.peers.find((item) => item.peer_device_id === "peer-claim");
+				expect(statusPeer?.claimed_local_actor_scope).toMatchObject({
+					action_required: true,
+					authorized: false,
+					scope_id: `personal:${store.actorId}`,
+					state: "not_authorized",
+				});
 
 				const missingRes = await app.request("/api/sync/peers?includeDiagnostics=1");
 				expect(missingRes.status).toBe(200);

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -715,6 +715,50 @@ function currentProjectScope(
 	};
 }
 
+function cleanPeerScopeText(value: unknown): string | null {
+	const text = String(value ?? "").trim();
+	return text || null;
+}
+
+function peerAuthorizedScopes(store: MemoryStore, peerDeviceId: string): Record<string, unknown>[] {
+	const deviceId = peerDeviceId.trim();
+	if (!deviceId) return [];
+	const rows = store.db
+		.prepare(
+			`SELECT
+				rs.scope_id,
+				rs.label,
+				rs.kind,
+				rs.authority_type,
+				rs.coordinator_id,
+				rs.group_id,
+				sm.role,
+				sm.membership_epoch,
+				sm.updated_at
+			 FROM scope_memberships sm
+			 JOIN replication_scopes rs ON rs.scope_id = sm.scope_id
+			 WHERE sm.device_id = ?
+			   AND sm.status = 'active'
+			   AND rs.status = 'active'
+			   AND sm.membership_epoch >= rs.membership_epoch
+			 ORDER BY CASE WHEN rs.authority_type = 'local' THEN 1 ELSE 0 END,
+			          rs.label COLLATE NOCASE,
+			          rs.scope_id`,
+		)
+		.all(deviceId) as Array<Record<string, unknown>>;
+	return rows.map((row) => ({
+		scope_id: String(row.scope_id ?? ""),
+		label: String(row.label ?? row.scope_id ?? ""),
+		kind: String(row.kind ?? "user"),
+		authority_type: String(row.authority_type ?? "local"),
+		coordinator_id: cleanPeerScopeText(row.coordinator_id),
+		group_id: cleanPeerScopeText(row.group_id),
+		role: String(row.role ?? "member"),
+		membership_epoch: Number(row.membership_epoch ?? 0),
+		updated_at: cleanPeerScopeText(row.updated_at),
+	}));
+}
+
 function ensureLocalActorRecord(store: MemoryStore): void {
 	const d = drizzle(store.db, { schema });
 	const existing = d
@@ -1115,9 +1159,10 @@ function mapPeerRow(
 		last_error: showDiag ? row.last_error : null,
 		has_error: Boolean(row.last_error),
 		claimed_local_actor: Boolean(row.claimed_local_actor),
-		claimed_local_actor_scope: showDiag ? claimedLocalActorScopeStatus(store, row) : null,
+		claimed_local_actor_scope: claimedLocalActorScopeStatus(store, row),
 		actor_id: row.actor_id ?? null,
 		actor_display_name: row.actor_display_name ?? null,
+		authorized_scopes: peerAuthorizedScopes(store, peerId),
 		project_scope: {
 			...currentProjectScope(row, readPeerProjectFilters(store, String(row.peer_device_id ?? ""))),
 		},


### PR DESCRIPTION
## Description
Shows each Sync peer's authorized Sharing domains separately from project include/exclude filters so broad project filters no longer look like data grants. The peer payload now includes active authorized scopes, preserves personal-domain status under redaction, and the Sync UI explains that project filters only narrow within Sharing domains.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Local checks run:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/ui/src/tabs/sync/view-model.test.ts`
- `pnpm run tsc`
- `pnpm run lint` (passes with pre-existing FeedItemCard noExtraBooleanCast infos)
- `git diff --check`
- CodeReviewer final pass: clean

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced