### PR TITLE
docs: explain sharing-domain backfill maintenance

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -171,6 +171,24 @@ Do not treat coordinator group membership as data access. A coordinator group ca
 help discover and administer peers, but a peer still needs an explicit Sharing
 domain grant before it can receive that domain's memories.
 
+### Upgrade maintenance / Sharing-domain backfill
+
+When upgrading an existing database to 0.30, codemem may run a one-time
+Sharing-domain backfill. This stamps historical memories and sync bookkeeping
+rows with `scope_id` so future sync and retrieval can enforce the new hard
+boundary.
+
+The progress total can be larger than the visible memory count because it
+includes both `memory_items` and historical `replication_ops`. Large databases
+can be CPU-bound while this runs. That is expected upgrade work; successful
+completion should make later startups quieter.
+
+Inspect current and completed maintenance jobs with:
+
+```fish
+codemem maintenance status
+```
+
 ### Claim your own devices
 
 - In the Sync panel, use `Assigned actor` to map a peer to your local actor when that machine should count as part of your identity.

--- a/packages/core/src/scope-backfill.test.ts
+++ b/packages/core/src/scope-backfill.test.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { toJson } from "./db.js";
+import { getMaintenanceJob } from "./maintenance-jobs.js";
 import {
 	backfillScopeIds,
 	classifyLegacyMemoryScope,
@@ -287,7 +288,13 @@ describe("scope backfill", () => {
 		// between ticks is what protects against the concurrent-writer
 		// race surfaced in the #1025 review.
 		await expect(runScopeBackfillPass(db, { batchSize: 10 })).resolves.toBe(true);
+		let job = getMaintenanceJob(db, "scope_id_backfill");
+		expect(job?.title).toBe("Backfilling Sharing domains");
+		expect(job?.message).toContain("memories and replication ops");
+
 		await expect(runScopeBackfillPass(db, { batchSize: 10 })).resolves.toBe(false);
+		job = getMaintenanceJob(db, "scope_id_backfill");
+		expect(job?.message).toContain("future startup should be quieter");
 
 		const memory = db.prepare("SELECT scope_id FROM memory_items").get() as { scope_id: string };
 		expect(memory.scope_id).toBe(LOCAL_DEFAULT_SCOPE_ID);

--- a/packages/core/src/scope-backfill.ts
+++ b/packages/core/src/scope-backfill.ts
@@ -510,7 +510,7 @@ export async function runScopeBackfillPass(
 		if (existingJob && existingJob.status !== "completed") {
 			if (previouslyExhausted) {
 				completeMaintenanceJob(db, SCOPE_BACKFILL_JOB, {
-					message: "Scope backfill complete",
+					message: "Sharing-domain backfill complete; future startup should be quieter",
 					progressCurrent: Number(existingMetadata.processed_memories ?? 0),
 					progressTotal: Number(existingMetadata.processed_memories ?? 0),
 					metadata: {
@@ -524,7 +524,7 @@ export async function runScopeBackfillPass(
 				return false;
 			}
 			updateMaintenanceJob(db, SCOPE_BACKFILL_JOB, {
-				message: "Scope backfill quiescent — confirming on next tick",
+				message: "Sharing-domain backfill quiescent — confirming on next tick",
 				progressCurrent: Number(existingMetadata.processed_memories ?? 0),
 				progressTotal: Number(existingMetadata.processed_memories ?? 0),
 				metadata: {
@@ -542,8 +542,8 @@ export async function runScopeBackfillPass(
 	if (startingFresh) {
 		startMaintenanceJob(db, {
 			kind: SCOPE_BACKFILL_JOB,
-			title: "Backfilling sharing domains",
-			message: `Backfilling ${totalBefore} legacy scope item(s)`,
+			title: "Backfilling Sharing domains",
+			message: `Backfilling ${totalBefore} legacy Sharing-domain item(s), including memories and replication ops`,
 			progressTotal: totalBefore,
 			metadata: {
 				seeded_scopes: 0,
@@ -615,7 +615,7 @@ export async function runScopeBackfillPass(
 
 	if (isComplete) {
 		completeMaintenanceJob(db, SCOPE_BACKFILL_JOB, {
-			message: "Scope backfill complete",
+			message: "Sharing-domain backfill complete; future startup should be quieter",
 			progressCurrent: totalBefore,
 			progressTotal: totalBefore,
 			metadata: {
@@ -628,7 +628,7 @@ export async function runScopeBackfillPass(
 	}
 
 	updateMaintenanceJob(db, SCOPE_BACKFILL_JOB, {
-		message: `Backfilled sharing domains for ${progressCurrent} of ${totalBefore} item(s)`,
+		message: `Backfilled Sharing domains for ${progressCurrent} of ${totalBefore} item(s), including memories and replication ops`,
 		progressCurrent,
 		progressTotal: totalBefore,
 		metadata,

--- a/packages/ui/src/tabs/health/render/health-overview.ts
+++ b/packages/ui/src/tabs/health/render/health-overview.ts
@@ -16,6 +16,8 @@ import { state } from "../../../lib/state";
 import { buildHealthCard, renderActionList, renderHealthCards, renderIcons } from "../components";
 import type { HealthAction, HealthCardInput } from "../types";
 
+const SCOPE_BACKFILL_JOB = "scope_id_backfill";
+
 export function renderHealthOverview() {
 	const healthGrid = document.getElementById("healthGrid");
 	const healthMeta = document.getElementById("healthMeta");
@@ -38,6 +40,7 @@ export function renderHealthOverview() {
 		error?: string | null;
 		progress?: { current?: number; total?: number | null; unit?: string };
 	}> = Array.isArray(stats.maintenance_jobs) ? stats.maintenance_jobs : [];
+	const scopeBackfillJob = maintenanceJobs.find((job) => job.kind === SCOPE_BACKFILL_JOB);
 	const reliability = stats.reliability || {};
 	const counts = reliability.counts || {};
 	const rates = reliability.rates || {};
@@ -193,12 +196,17 @@ export function renderHealthOverview() {
 				: `${current.toLocaleString()} ${unit}`;
 		const isFailed = job.status === "failed";
 		const isCompleted = job.status === "completed";
+		const isScopeBackfill = job.kind === SCOPE_BACKFILL_JOB;
 		const value = isFailed ? "Failed" : isCompleted ? "Complete" : progress;
 		const detail = isFailed
 			? String(job.error || "unknown error").trim()
 			: isCompleted
-				? progress
-				: undefined;
+				? isScopeBackfill
+					? `${progress} · one-time Sharing-domain upgrade finished`
+					: progress
+				: isScopeBackfill
+					? "One-time upgrade backfill; totals include memories and replication ops"
+					: undefined;
 		return buildHealthCard({
 			key: String(job.kind || job.title || "background-maintenance"),
 			label: String(job.title || job.kind || "Background maintenance"),
@@ -210,7 +218,9 @@ export function renderHealthOverview() {
 				? `Error: ${job.error || "unknown"}`
 				: isCompleted
 					? `${String(job.title || "Maintenance")} finished`
-					: `${String(job.title || "Maintenance")} in progress`,
+					: isScopeBackfill
+						? `${String(job.title || "Maintenance")} in progress; inspect with codemem maintenance status`
+						: `${String(job.title || "Maintenance")} in progress`,
 		});
 	});
 
@@ -309,6 +319,13 @@ export function renderHealthOverview() {
 		recommendations.push({
 			label: "Tag coverage is low. Preview backfill impact.",
 			command: "codemem db backfill-tags --dry-run",
+		});
+	}
+	if (scopeBackfillJob && scopeBackfillJob.status !== "completed" && recommendations.length < 3) {
+		recommendations.push({
+			label:
+				"Sharing-domain upgrade backfill is expected one-time work. Inspect progress if startup feels busy.",
+			command: "codemem maintenance status",
 		});
 	}
 	renderActionList(healthActions, recommendations);


### PR DESCRIPTION
## Description
Clarifies Sharing-domain backfill expectations for large upgraded databases, including that progress totals include memories and replication ops and that `codemem maintenance status` is the inspection path.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Targeted validation:
- `pnpm exec vitest run packages/core/src/scope-backfill.test.ts`
- `pnpm --filter @codemem/ui typecheck`
- `pnpm exec biome check packages/core/src/scope-backfill.ts packages/core/src/scope-backfill.test.ts packages/ui/src/tabs/health/render/health-overview.ts`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced