### PR TITLE
feat(ui): clarify sharing-domain review state

### DIFF
--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -117,6 +117,13 @@ export interface SyncSharingReviewRow {
 	shareable_count?: number;
 }
 
+export interface CachedLegacySharedReview {
+	scope_id?: string;
+	memory_count?: number;
+	has_data?: boolean;
+	last_updated_at?: string | null;
+}
+
 export interface DiscoveredDevice {
 	device_id?: string;
 	display_name?: string;
@@ -231,6 +238,7 @@ export const state = {
 	lastSyncPeers: [] as SyncPeer[],
 	pendingAcceptedSyncPeers: [] as SyncPeer[],
 	lastSyncSharingReview: [] as SyncSharingReviewRow[],
+	lastSyncLegacySharedReview: null as CachedLegacySharedReview | null,
 	lastSyncCoordinator: null as CachedSyncCoordinator | null,
 	lastCoordinatorAdminStatus: null as CachedCoordinatorAdminStatus | null,
 	coordinatorAdminTargetGroup: "",

--- a/packages/ui/src/tabs/sync/components/sync-peers.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-peers.tsx
@@ -209,6 +209,11 @@ function SyncPeerCard({
 		: "This device is not assigned to anyone yet.";
 	const lastSyncAt = String(peerStatus.last_sync_at || peerStatus.last_sync_at_utc || "");
 	const lastPingAt = String(peerStatus.last_ping_at || peerStatus.last_ping_at_utc || "");
+	const discoverySummary = peer.discovered_via_group_id
+		? `Discovery: seen through coordinator group ${peer.discovered_via_group_id}. Discovery helps find devices; Sharing-domain grants above decide data access.`
+		: peer.discovered_via_coordinator_id
+			? `Discovery: seen through coordinator ${peer.discovered_via_coordinator_id}. Discovery helps find devices; Sharing-domain grants above decide data access.`
+			: null;
 	const scopeEditorOpen = openPeerScopeEditors.has(peerId);
 	const scopeReviewRequested = consumePeerScopeReviewRequest(peerId);
 	const cardRef = useRef<HTMLDivElement | null>(null);
@@ -567,6 +572,7 @@ function SyncPeerCard({
 
 						<div className="peer-scope-summary">Device details</div>
 						<div className="peer-addresses">{addressLine}</div>
+						{discoverySummary ? <div className="peer-meta">{discoverySummary}</div> : null}
 						<div className="peer-meta">
 							{[
 								lastSyncAt ? `Sync: ${formatTimestamp(lastSyncAt)}` : "Sync: never",

--- a/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-sharing-review.tsx
@@ -7,8 +7,14 @@ export interface SyncSharingReviewItem {
 	shareableCount: number;
 }
 
+export interface SyncLegacySharedReviewItem {
+	memoryCount: number;
+	scopeId: string;
+}
+
 type SyncSharingReviewProps = {
 	items: SyncSharingReviewItem[];
+	legacyReview?: SyncLegacySharedReviewItem | null;
 	onReview: () => void;
 };
 
@@ -40,9 +46,28 @@ function SharingReviewRow({
 	);
 }
 
-export function SyncSharingReview({ items, onReview }: SyncSharingReviewProps) {
+function LegacySharedReviewRow({ item }: { item: SyncLegacySharedReviewItem }) {
+	return (
+		<div className="actor-row">
+			<div className="actor-details">
+				<div className="actor-title">
+					<strong>Legacy shared review</strong>
+					<span className="badge badge-offline">Needs review</span>
+				</div>
+				<div className="peer-meta">
+					{item.memoryCount.toLocaleString()} historical shared memories are in {item.scopeId}. 0.30
+					placed ambiguous older shared data there conservatively; review mappings before promoting
+					it. Remapping or revocation does not erase data already copied to peers.
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function SyncSharingReview({ items, legacyReview, onReview }: SyncSharingReviewProps) {
 	return (
 		<>
+			{legacyReview ? <LegacySharedReviewRow item={legacyReview} /> : null}
 			{items.map((item) => (
 				<SharingReviewRow
 					key={`${item.peerName}:${item.actorId}:${item.scopeLabel}`}

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -47,6 +47,7 @@ type SyncStatusResponseLike = {
 	coordinator?: Record<string, unknown> | null;
 	join_requests?: unknown[];
 	sharing_review?: unknown[];
+	legacy_shared_review?: Record<string, unknown> | null;
 	attempts?: unknown[];
 	legacy_devices?: unknown[];
 };
@@ -187,6 +188,10 @@ export async function loadSyncData() {
 		state.pendingAcceptedSyncPeers = pendingPeers;
 		state.lastSyncPeers = [...payloadPeers, ...pendingPeers];
 		state.lastSyncSharingReview = payload.sharing_review || [];
+		state.lastSyncLegacySharedReview =
+			payload.legacy_shared_review && typeof payload.legacy_shared_review === "object"
+				? payload.legacy_shared_review
+				: null;
 		state.lastSyncCoordinator = payload.coordinator || null;
 		state.lastCoordinatorAdminStatus =
 			coordinatorAdminStatus && typeof coordinatorAdminStatus === "object"

--- a/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
+++ b/packages/ui/src/tabs/sync/team-sync/render/sharing-review.ts
@@ -21,17 +21,26 @@ export function renderSyncSharingReview() {
 	const meta = document.getElementById("syncSharingReviewMeta");
 	const list = document.getElementById("syncSharingReviewList") as HTMLElement | null;
 	if (!panel || !meta || !list) return;
+	const title = panel.querySelector<HTMLElement>(".settings-group-title");
 	const items = Array.isArray(state.lastSyncSharingReview) ? state.lastSyncSharingReview : [];
-	if (!items.length) {
+	const legacyRaw = state.lastSyncLegacySharedReview;
+	const legacyCount = Math.max(0, Number(legacyRaw?.memory_count ?? 0));
+	const legacyReview = legacyRaw?.has_data
+		? { memoryCount: legacyCount, scopeId: String(legacyRaw.scope_id || "legacy-shared-review") }
+		: null;
+	if (!items.length && !legacyReview) {
 		clearSyncMount(list);
 		panel.hidden = true;
 		return;
 	}
 	panel.hidden = false;
+	if (title) title.textContent = legacyReview ? "Sharing review" : "What teammates will receive";
 	const scopeLabel = state.currentProject
 		? `current project (${state.currentProject})`
 		: "all allowed projects";
-	meta.textContent = `Teammates receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
+	meta.textContent = legacyReview
+		? `Review conservative upgrade state before promoting historical shared data. Teammates receive memories from ${scopeLabel} by default once Sharing-domain grants allow it.`
+		: `Teammates receive memories from ${scopeLabel} by default. Use Only me on a memory when it should stay local.`;
 	const reviewItems: SyncSharingReviewItem[] = items.map((item) => ({
 		actorDisplayName: String(item.actor_display_name || item.actor_id || "unknown"),
 		actorId: String(item.actor_id || "unknown"),
@@ -42,6 +51,6 @@ export function renderSyncSharingReview() {
 	}));
 	renderIntoSyncMount(
 		list,
-		h(SyncSharingReview, { items: reviewItems, onReview: openFeedSharingReview }),
+		h(SyncSharingReview, { items: reviewItems, legacyReview, onReview: openFeedSharingReview }),
 	);
 }

--- a/packages/ui/src/tabs/sync/view-model.test.ts
+++ b/packages/ui/src/tabs/sync/view-model.test.ts
@@ -186,6 +186,7 @@ describe("derivePeerAuthorizedDomainsView", () => {
 		expect(view.total).toBe(0);
 		expect(view.badgeLabel).toBe("No Sharing domains");
 		expect(view.isWarning).toBe(true);
+		expect(view.emptyMessage).toContain("No Sharing-domain grants exist");
 		expect(view.emptyMessage).toContain("Project filters below cannot send data by themselves");
 	});
 

--- a/packages/ui/src/tabs/sync/view-model/peer-status.ts
+++ b/packages/ui/src/tabs/sync/view-model/peer-status.ts
@@ -211,7 +211,7 @@ export function derivePeerAuthorizedDomainsView(peer: PeerLike): PeerAuthorizedD
 		isWarning: total === 0,
 		domains,
 		emptyMessage:
-			"No authorized Sharing domains are cached for this device. Project filters below cannot send data by themselves.",
+			"No Sharing-domain grants exist for this device yet. Project filters below cannot send data by themselves.",
 	};
 }
 

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2179,10 +2179,19 @@ describe("viewer-server", () => {
 					.prepare(
 						`INSERT INTO sync_peers (
 							peer_device_id, name, claimed_local_actor, projects_include_json,
-							projects_exclude_json, created_at
-						) VALUES (?, ?, 0, ?, ?, ?)`,
+							projects_exclude_json, discovered_via_coordinator_id,
+							discovered_via_group_id, created_at
+						) VALUES (?, ?, 0, ?, ?, ?, ?, ?)`,
 					)
-					.run("peer-scope", "Peer Scope", JSON.stringify(["*"]), JSON.stringify(["private"]), now);
+					.run(
+						"peer-scope",
+						"Peer Scope",
+						JSON.stringify(["*"]),
+						JSON.stringify(["private"]),
+						"coord",
+						"team-a",
+						now,
+					);
 				const insertScope = store.db.prepare(
 					`INSERT INTO replication_scopes(
 						scope_id, label, kind, authority_type, coordinator_id, group_id,
@@ -2298,6 +2307,8 @@ describe("viewer-server", () => {
 				const body = (await res.json()) as {
 					items: Array<{
 						authorized_scopes: Array<Record<string, unknown>>;
+						discovered_via_coordinator_id: string | null;
+						discovered_via_group_id: string | null;
 						peer_device_id: string;
 						project_scope: Record<string, unknown>;
 					}>;
@@ -2323,12 +2334,18 @@ describe("viewer-server", () => {
 					membership_epoch: 2,
 					role: "member",
 				});
+				expect(peer).toMatchObject({
+					discovered_via_coordinator_id: "coord",
+					discovered_via_group_id: "team-a",
+				});
 
 				const statusRes = await app.request("/api/sync/status");
 				expect(statusRes.status).toBe(200);
 				const statusBody = (await statusRes.json()) as {
 					peers: Array<{
 						authorized_scopes: Array<Record<string, unknown>>;
+						discovered_via_coordinator_id: string | null;
+						discovered_via_group_id: string | null;
 						peer_device_id: string;
 						project_scope: Record<string, unknown>;
 					}>;
@@ -2341,6 +2358,58 @@ describe("viewer-server", () => {
 				expect(statusPeer?.project_scope).toMatchObject({
 					effective_exclude: ["private"],
 					effective_include: ["*"],
+				});
+				expect(statusPeer).toMatchObject({
+					discovered_via_coordinator_id: "coord",
+					discovered_via_group_id: "team-a",
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("surfaces legacy shared review summary in sync status", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				const _warmup = await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const now = new Date().toISOString();
+				const session = store.db
+					.prepare(
+						`INSERT INTO sessions(started_at, cwd, project, user, tool_version)
+						 VALUES (?, ?, ?, ?, ?)`,
+					)
+					.run(now, "/tmp/codemem-test", "codemem-test", "test", "test");
+				store.db
+					.prepare(
+						`INSERT INTO memory_items(
+							session_id, kind, title, body_text, created_at, updated_at,
+							visibility, workspace_id, workspace_kind, active, scope_id, metadata_json
+						 ) VALUES (?, 'discovery', ?, ?, ?, ?, 'shared', 'shared:default', 'shared', 1, ?, '{}')`,
+					)
+					.run(
+						Number(session.lastInsertRowid),
+						"Legacy shared",
+						"Legacy shared body",
+						now,
+						now,
+						"legacy-shared-review",
+					);
+
+				const res = await app.request("/api/sync/status");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					legacy_shared_review: {
+						has_data: boolean;
+						memory_count: number;
+						scope_id: string;
+					};
+				};
+				expect(body.legacy_shared_review).toMatchObject({
+					has_data: true,
+					memory_count: 1,
+					scope_id: "legacy-shared-review",
 				});
 			} finally {
 				cleanup();

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -55,6 +55,7 @@ import {
 	getSemanticIndexDiagnostics,
 	getSyncResetState,
 	type InboundScopeRejectionPeerSummary,
+	LEGACY_SHARED_REVIEW_SCOPE_ID,
 	LOCAL_DEFAULT_SCOPE_ID,
 	LOCAL_SYNC_CAPABILITY,
 	listCoordinatorJoinRequests,
@@ -1197,6 +1198,28 @@ function recentScopeRejectionsByPeer(
 	return map;
 }
 
+function legacySharedReviewSummary(store: MemoryStore): Record<string, unknown> {
+	const row = store.db
+		.prepare(
+			`SELECT COUNT(*) AS memory_count,
+			        MAX(updated_at) AS last_updated_at
+			 FROM memory_items
+			 WHERE scope_id = ?
+			   AND active = 1
+			   AND deleted_at IS NULL`,
+		)
+		.get(LEGACY_SHARED_REVIEW_SCOPE_ID) as
+		| { memory_count: number | null; last_updated_at: string | null }
+		| undefined;
+	const memoryCount = Number(row?.memory_count ?? 0);
+	return {
+		scope_id: LEGACY_SHARED_REVIEW_SCOPE_ID,
+		memory_count: memoryCount,
+		has_data: memoryCount > 0,
+		last_updated_at: row?.last_updated_at ?? null,
+	};
+}
+
 // Aggregate ops_in / ops_out across recent successful sync_attempts per peer.
 // Window: last 24 hours. Feeds the per-peer direction glyph on the Sync tab
 // (↕ bidirectional, ↑ publishing, ↓ subscribed) off real traffic instead of
@@ -1294,7 +1317,8 @@ const PEERS_QUERY = `
 	SELECT p.peer_device_id, p.name, p.pinned_fingerprint, p.addresses_json,
 	       p.last_seen_at, p.last_sync_at, p.last_error,
 	       p.projects_include_json, p.projects_exclude_json, p.claimed_local_actor,
-	       p.actor_id, a.display_name AS actor_display_name
+	       p.actor_id, p.discovered_via_coordinator_id, p.discovered_via_group_id,
+	       a.display_name AS actor_display_name
 	FROM sync_peers AS p
 	LEFT JOIN actors AS a ON a.actor_id = p.actor_id
 	ORDER BY name, peer_device_id
@@ -1927,6 +1951,7 @@ export function syncRoutes(
 				ping: {},
 			};
 			const legacyDevices = traceSync("legacyDevices", () => store.claimableLegacyDeviceIds());
+			const legacyReview = traceSync("legacySharedReview", () => legacySharedReviewSummary(store));
 			const sharingReview = traceSync("sharingReview", () => store.sharingReviewSummary(project));
 			let joinRequests: Record<string, unknown>[] = [];
 			if (includeJoinRequests && showDiag && config.syncCoordinatorAdminSecret) {
@@ -1984,6 +2009,7 @@ export function syncRoutes(
 				peers: peersItems,
 				attempts: attemptsItems.slice(0, 5),
 				legacy_devices: legacyDevices,
+				legacy_shared_review: legacyReview,
 				sharing_review: sharingReview,
 				coordinator,
 			};


### PR DESCRIPTION
## Description
Improves Sync peer Sharing-domain visibility and surfaces conservative `legacy-shared-review` upgrade state. Peer details now separate coordinator discovery context from actual Sharing-domain grants, and Sync status exposes a lightweight legacy review summary for the existing review panel.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Targeted validation:
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts -t "legacy shared review summary|authorized Sharing domains"`
- `pnpm exec vitest run packages/ui/src/tabs/sync/view-model.test.ts packages/ui/src/tabs/sync/index.test.ts`
- `pnpm exec tsc --build packages/viewer-server/tsconfig.json packages/ui/tsconfig.json`
- `pnpm exec biome check` on touched viewer-server/UI files

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced