### PR TITLE
fix: isolate viewer maintenance runners

### DIFF
--- a/docs/plans/2026-05-06-maintenance-worker-isolation-design.md
+++ b/docs/plans/2026-05-06-maintenance-worker-isolation-design.md
@@ -1,0 +1,43 @@
+# Maintenance Worker Isolation Design
+
+**Status:** Approved for 0.30 release-readiness  
+**Date:** 2026-05-06
+
+## Context
+
+Large upgrade maintenance can run expensive synchronous SQLite statements. Because
+codemem uses `better-sqlite3`, those statements block the Node event loop in the
+process that runs them. When the viewer owns heavy maintenance, HTTP responses
+and signal handlers can stall until SQLite returns.
+
+Restart escalation helps recover a wedged viewer, but it does not keep the live
+viewer responsive while maintenance is active.
+
+## Decision
+
+Run heavy maintenance in a managed child process started by `codemem serve`.
+The viewer remains responsible for HTTP, sync routes, sync daemon scheduling,
+and raw-event sweeping. The worker owns vector migration, scope/backfill
+runners, summary/ref/session/dedup backfills, and sync retention.
+
+The worker uses its own SQLite connection. WAL mode and the existing busy
+timeout coordinate cross-process access. The viewer never shares a
+`better-sqlite3` connection with the worker.
+
+## Lifecycle
+
+- The viewer spawns hidden plumbing command `codemem maintenance worker`.
+- The worker records progress through the existing `maintenance_jobs` table.
+- `codemem maintenance status` and viewer health surfaces continue to read the
+  same status records.
+- The worker PID is stored as `maintenance-worker.pid` beside `viewer.pid`.
+- Viewer start/restart removes stale trusted workers for the same database.
+- Viewer shutdown sends `SIGTERM` to the worker and escalates to `SIGKILL` if
+  the worker is blocked in synchronous SQLite work.
+
+## Consequences
+
+This adds one child process while `codemem serve` is running. In exchange, heavy
+maintenance can no longer monopolize the viewer event loop. A blocked worker may
+still need forceful termination, but that no longer prevents the viewer from
+serving HTTP or handling lifecycle signals.

--- a/packages/cli/src/commands/maintenance.ts
+++ b/packages/cli/src/commands/maintenance.ts
@@ -15,9 +15,12 @@ import {
 } from "@codemem/core";
 import { Command } from "commander";
 import { helpStyle } from "../help-style.js";
+import { startMaintenanceWorkerRuntime } from "../maintenance-worker-runtime.js";
 import {
+	addConfigOption,
 	addDbOption,
 	addJsonOption,
+	type ConfigOpts,
 	type DbOpts,
 	type JsonOpts,
 	resolveDbOpt,
@@ -34,6 +37,13 @@ const statusCmd = new Command("status")
 addDbOption(statusCmd);
 addJsonOption(statusCmd);
 
+const workerCmd = new Command("worker")
+	.configureHelp(helpStyle)
+	.description("Run maintenance worker plumbing");
+
+addDbOption(workerCmd);
+addConfigOption(workerCmd);
+
 statusCmd.action((opts: DbOpts & JsonOpts) => {
 	const store = new MemoryStore(resolveDbPath(resolveDbOpt(opts)));
 	try {
@@ -48,7 +58,53 @@ statusCmd.action((opts: DbOpts & JsonOpts) => {
 	}
 });
 
+export async function runMaintenanceWorkerCommand(opts: DbOpts & ConfigOpts): Promise<void> {
+	const dbPath = resolveDbPath(resolveDbOpt(opts));
+	if (opts.config) process.env.CODEMEM_CONFIG = opts.config;
+	process.env.CODEMEM_DB = dbPath;
+
+	const abort = new AbortController();
+	const runtime = startMaintenanceWorkerRuntime({
+		dbPath,
+		configPath: opts.config ?? null,
+		signal: abort.signal,
+	});
+	const keepAlive = setInterval(() => undefined, 60_000);
+	let stopping = false;
+
+	const shutdown = async () => {
+		if (stopping) return;
+		stopping = true;
+		abort.abort();
+		clearInterval(keepAlive);
+		const forceExit = setTimeout(() => {
+			process.exit(1);
+		}, 30_000);
+		try {
+			await runtime.stop();
+			process.exit(0);
+		} finally {
+			clearTimeout(forceExit);
+		}
+	};
+
+	await new Promise<void>((resolve, reject) => {
+		process.once("SIGINT", () => void shutdown().then(resolve, reject));
+		process.once("SIGTERM", () => void shutdown().then(resolve, reject));
+	});
+}
+
+workerCmd.action(async (opts: DbOpts & ConfigOpts) => {
+	try {
+		await runMaintenanceWorkerCommand(opts);
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	}
+});
+
 maintenanceCmd.addCommand(statusCmd);
+maintenanceCmd.addCommand(workerCmd, { hidden: true });
 
 export const maintenanceCommand = maintenanceCmd;
 

--- a/packages/cli/src/commands/serve.test.ts
+++ b/packages/cli/src/commands/serve.test.ts
@@ -1,18 +1,23 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MemoryStore } from "@codemem/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	buildForegroundRunnerArgs,
+	buildMaintenanceWorkerArgs,
+	commandHasExactDbPath,
 	extractViewerPid,
+	isLikelyMaintenanceWorkerCommand,
 	isLikelyViewerCommand,
 	isLocalHost,
 	isLoopbackOnlyHost,
 	isSqliteVecLoadFailure,
+	maintenanceWorkerPidFilePath,
 	pickViewerPidCandidate,
 	prepareViewerDatabase,
 	sqliteVecFailureDiagnostics,
+	terminateTrustedMaintenanceWorker,
 	terminateTrustedViewerPid,
 } from "./serve.js";
 import {
@@ -155,6 +160,32 @@ describe("serve command option resolution", () => {
 		]);
 	});
 
+	it("builds maintenance worker args from the current runner", () => {
+		const args = buildMaintenanceWorkerArgs(
+			"/repo/packages/cli/src/index.ts",
+			{
+				mode: "start",
+				dbPath: "/tmp/test.sqlite",
+				configPath: "/tmp/codemem.jsonc",
+				host: "127.0.0.1",
+				port: 38991,
+				background: false,
+			},
+			["--conditions", "source"],
+		);
+		expect(args).toEqual([
+			"--conditions",
+			"source",
+			"/repo/packages/cli/src/index.ts",
+			"maintenance",
+			"worker",
+			"--db-path",
+			"/tmp/test.sqlite",
+			"--config",
+			"/tmp/codemem.jsonc",
+		]);
+	});
+
 	it("detects sqlite-vec load errors for viewer startup fallback", () => {
 		expect(isSqliteVecLoadFailure(new Error("sqlite-vec loaded but version check failed"))).toBe(
 			true,
@@ -234,7 +265,95 @@ describe("serve command option resolution", () => {
 		expect(
 			isLikelyViewerCommand("node /repo/packages/cli/dist/index.js serve start --foreground"),
 		).toBe(true);
+		expect(isLikelyViewerCommand("node /repo/packages/cli/src/index.ts serve start")).toBe(true);
 		expect(isLikelyViewerCommand("node /usr/bin/python -m http.server 38888")).toBe(false);
+	});
+
+	it("matches likely codemem maintenance worker command lines", () => {
+		expect(
+			isLikelyMaintenanceWorkerCommand(
+				"node /repo/packages/cli/src/index.ts maintenance worker --db-path /tmp/test.sqlite",
+			),
+		).toBe(true);
+		expect(
+			isLikelyMaintenanceWorkerCommand(
+				"node /repo/packages/cli/dist/index.js maintenance worker --db-path /tmp/test.sqlite",
+			),
+		).toBe(true);
+		expect(isLikelyMaintenanceWorkerCommand("node /tmp/other.js maintenance worker")).toBe(false);
+	});
+
+	it("requires exact maintenance worker db-path command ownership", () => {
+		expect(
+			commandHasExactDbPath(
+				"node /repo/packages/cli/src/index.ts maintenance worker --db-path /tmp/mem.sqlite",
+				"/tmp/mem.sqlite",
+			),
+		).toBe(true);
+		expect(
+			commandHasExactDbPath(
+				"node /repo/packages/cli/src/index.ts maintenance worker --db-path=/tmp/mem.sqlite",
+				"/tmp/mem.sqlite",
+			),
+		).toBe(true);
+		expect(
+			commandHasExactDbPath(
+				"node /repo/packages/cli/src/index.ts maintenance worker --db-path /tmp/mem.sqlite.bak",
+				"/tmp/mem.sqlite",
+			),
+		).toBe(false);
+	});
+
+	it("cleans stale maintenance worker pidfiles", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-worker-pid-"));
+		const dbPath = join(dir, "viewer.sqlite");
+		const pidPath = maintenanceWorkerPidFilePath(dbPath);
+		writeFileSync(pidPath, JSON.stringify({ pid: 999_999_999 }), "utf-8");
+		try {
+			await expect(terminateTrustedMaintenanceWorker(dbPath)).resolves.toBe(true);
+			expect(existsSync(pidPath)).toBe(false);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not stop a maintenance worker pidfile for another database", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-worker-pid-"));
+		const dbPath = join(dir, "viewer.sqlite");
+		const pidPath = maintenanceWorkerPidFilePath(dbPath);
+		writeFileSync(
+			pidPath,
+			JSON.stringify({ pid: 999_999_999, dbPath: join(dir, "other.sqlite") }),
+			"utf-8",
+		);
+		try {
+			await expect(terminateTrustedMaintenanceWorker(dbPath)).resolves.toBe(false);
+			expect(existsSync(pidPath)).toBe(true);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses running legacy maintenance worker pidfiles without database ownership", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "codemem-worker-pid-"));
+		const dbPath = join(dir, "viewer.sqlite");
+		const pidPath = maintenanceWorkerPidFilePath(dbPath);
+		writeFileSync(pidPath, JSON.stringify({ pid: 12345 }), "utf-8");
+		const signals: string[] = [];
+		const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+			expect(pid).toBe(12345);
+			if (signal === 0) return true;
+			signals.push(String(signal));
+			return true;
+		});
+		try {
+			await expect(terminateTrustedMaintenanceWorker(dbPath)).resolves.toBe(false);
+			expect(signals).toEqual([]);
+			expect(existsSync(pidPath)).toBe(true);
+			expect(killSpy).toHaveBeenCalled();
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("escalates trusted viewer shutdown when graceful SIGTERM stalls", async () => {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,37 +1,19 @@
-import { spawn, spawnSync } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import net from "node:net";
 import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import {
-	DEDUP_KEY_BACKFILL_JOB,
-	DedupKeyBackfillRunner,
-	getMaintenanceJob,
-	hasPendingDedupKeyBackfill,
-	hasPendingRefBackfill,
-	hasPendingScopeBackfill,
-	hasPendingSessionContextBackfill,
-	hasPendingSummaryDedupBackfill,
 	initDatabase,
 	isEmbeddingDisabled,
 	type MemoryStore,
 	ObserverClient,
 	RawEventSweeper,
-	REF_BACKFILL_JOB,
-	RefBackfillRunner,
 	readCodememConfigFile,
 	readCodememConfigFileAtPath,
 	readCoordinatorSyncConfig,
 	resolveDbPath,
 	runSyncDaemon,
-	SCOPE_BACKFILL_JOB,
-	ScopeBackfillRunner,
-	SESSION_CONTEXT_BACKFILL_JOB,
-	SessionContextBackfillRunner,
-	SUMMARY_DEDUP_BACKFILL_JOB,
-	SummaryDedupBackfillRunner,
-	SyncRetentionRunner,
-	VectorModelMigrationRunner,
 } from "@codemem/core";
 import { Command, Option } from "commander";
 import { helpStyle } from "../help-style.js";
@@ -95,7 +77,8 @@ export function isLikelyViewerCommand(command: string): boolean {
 	return (
 		lowered.includes("codemem") ||
 		lowered.includes("packages/cli/dist/index.js") ||
-		lowered.includes("/cli/dist/index.js")
+		lowered.includes("/cli/dist/index.js") ||
+		lowered.includes("packages/cli/src/index.ts")
 	);
 }
 
@@ -151,6 +134,60 @@ function isTrustedViewerPid(
 
 function pidFilePath(dbPath: string): string {
 	return join(dirname(dbPath), "viewer.pid");
+}
+
+export function maintenanceWorkerPidFilePath(dbPath: string): string {
+	return join(dirname(dbPath), "maintenance-worker.pid");
+}
+
+function readMaintenanceWorkerPidRecord(
+	dbPath: string,
+): { pid: number; dbPath: string | null } | null {
+	const pidPath = maintenanceWorkerPidFilePath(dbPath);
+	if (!existsSync(pidPath)) return null;
+	const raw = readFileSync(pidPath, "utf-8").trim();
+	try {
+		const parsed = JSON.parse(raw) as { pid?: unknown; dbPath?: unknown } | number;
+		if (typeof parsed === "number" && Number.isFinite(parsed) && parsed > 0) {
+			return { pid: Math.trunc(parsed), dbPath: null };
+		}
+		if (
+			typeof parsed === "object" &&
+			parsed !== null &&
+			typeof parsed.pid === "number" &&
+			Number.isFinite(parsed.pid) &&
+			parsed.pid > 0
+		) {
+			return {
+				pid: Math.trunc(parsed.pid),
+				dbPath: typeof parsed.dbPath === "string" ? resolveDbPath(parsed.dbPath) : null,
+			};
+		}
+	} catch {
+		const parsed = Number.parseInt(raw, 10);
+		if (Number.isFinite(parsed) && parsed > 0) return { pid: parsed, dbPath: null };
+	}
+	return null;
+}
+
+export function isLikelyMaintenanceWorkerCommand(command: string): boolean {
+	const lowered = command.toLowerCase();
+	if (!/\bmaintenance\s+worker\b/.test(lowered)) return false;
+	return (
+		lowered.includes("codemem") ||
+		lowered.includes("packages/cli/dist/index.js") ||
+		lowered.includes("/cli/dist/index.js") ||
+		lowered.includes("packages/cli/src/index.ts")
+	);
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function commandHasExactDbPath(command: string, dbPath: string): boolean {
+	const escapedPath = escapeRegExp(resolveDbPath(dbPath));
+	return new RegExp(`(?:^|\\s)--db-path(?:=|\\s+)${escapedPath}(?:\\s|$)`).test(command);
 }
 
 function readViewerPidRecord(dbPath: string): ViewerPidRecord | null {
@@ -266,7 +303,7 @@ async function waitForProcessExit(pid: number, timeoutMs = 30000): Promise<boole
 	return !isProcessRunning(pid);
 }
 
-export async function terminateTrustedViewerPid(
+async function terminateProcessPid(
 	pid: number,
 	timeouts: { gracefulMs?: number; forceMs?: number } = {},
 ): Promise<boolean> {
@@ -277,16 +314,56 @@ export async function terminateTrustedViewerPid(
 	}
 	if (await waitForProcessExit(pid, timeouts.gracefulMs ?? 30000)) return true;
 
-	// A stuck better-sqlite3 maintenance query blocks the viewer's JS signal
-	// handler, so graceful shutdown can never run. At this point the PID has
-	// already passed the localhost + command-line trust checks; escalate so
-	// `codemem serve restart` does not require a manual kill -9.
+	// A stuck better-sqlite3 maintenance query blocks the target process's JS
+	// signal handler, so graceful shutdown can never run. Callers only reach
+	// this helper after command-line/pidfile trust checks; escalate so lifecycle
+	// commands do not require a manual kill -9.
 	try {
 		process.kill(pid, "SIGKILL");
 	} catch {
 		return true;
 	}
 	return waitForProcessExit(pid, timeouts.forceMs ?? 5000);
+}
+
+export async function terminateTrustedViewerPid(
+	pid: number,
+	timeouts: { gracefulMs?: number; forceMs?: number } = {},
+): Promise<boolean> {
+	return terminateProcessPid(pid, timeouts);
+}
+
+export async function terminateTrustedMaintenanceWorker(
+	dbPath: string,
+	timeouts: { gracefulMs?: number; forceMs?: number } = {},
+): Promise<boolean> {
+	const pidPath = maintenanceWorkerPidFilePath(dbPath);
+	const record = readMaintenanceWorkerPidRecord(dbPath);
+	if (!record) return true;
+	const expectedDbPath = resolveDbPath(dbPath);
+	if (record.dbPath && record.dbPath !== expectedDbPath) return false;
+	if (!isProcessRunning(record.pid)) {
+		try {
+			rmSync(pidPath);
+		} catch {
+			// ignore
+		}
+		return true;
+	}
+	const command = readProcessCommand(record.pid);
+	if (!command || !isLikelyMaintenanceWorkerCommand(command)) return false;
+	if (record.dbPath !== expectedDbPath || !commandHasExactDbPath(command, expectedDbPath)) {
+		return false;
+	}
+	const stopped = await terminateProcessPid(record.pid, timeouts);
+	if (stopped) {
+		try {
+			rmSync(pidPath);
+		} catch {
+			// ignore
+		}
+	}
+	return stopped;
 }
 
 async function waitForPortRelease(host: string, port: number, timeoutMs = 10000): Promise<boolean> {
@@ -320,9 +397,15 @@ async function stopExistingViewer(
 
 	if (!record) return { stopped: false, pid: null };
 
-	if (await respondsLikeCodememViewer(record)) {
+	const recordListenerPid = lookupListeningPid(record.host, record.port);
+	if (
+		(await respondsLikeCodememViewer(record)) &&
+		isTrustedViewerPid(record.pid, { host: record.host, port: record.port }, recordListenerPid)
+	) {
 		const stopped = await terminateTrustedViewerPid(record.pid);
 		if (!stopped) return { stopped: false, pid: record.pid };
+	} else {
+		return { stopped: false, pid: null };
 	}
 	try {
 		rmSync(pidPath);
@@ -352,6 +435,61 @@ export function buildForegroundRunnerArgs(
 		args.push("--db-path", invocation.dbPath);
 	}
 	return args;
+}
+
+export function buildMaintenanceWorkerArgs(
+	scriptPath: string,
+	invocation: ResolvedServeInvocation,
+	execArgv: string[] = process.execArgv,
+): string[] {
+	const args = [...execArgv, scriptPath, "maintenance", "worker"];
+	if (invocation.dbPath) args.push("--db-path", invocation.dbPath);
+	if (invocation.configPath) args.push("--config", invocation.configPath);
+	return args;
+}
+
+function startMaintenanceWorkerProcess(invocation: ResolvedServeInvocation): ChildProcess | null {
+	const scriptPath = process.argv[1];
+	if (!scriptPath) {
+		p.log.warn("Unable to resolve CLI entrypoint for maintenance worker launch");
+		return null;
+	}
+	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
+	const child = spawn(process.execPath, buildMaintenanceWorkerArgs(scriptPath, invocation), {
+		cwd: process.cwd(),
+		stdio: "ignore",
+		env: {
+			...process.env,
+			CODEMEM_DB: dbPath,
+			...(invocation.configPath ? { CODEMEM_CONFIG: invocation.configPath } : {}),
+		},
+	});
+	child.unref();
+	if (child.pid) {
+		writeFileSync(
+			maintenanceWorkerPidFilePath(dbPath),
+			JSON.stringify({ pid: child.pid, dbPath }),
+			"utf-8",
+		);
+		p.log.step(`Maintenance worker started (pid ${child.pid})`);
+	}
+	return child;
+}
+
+async function stopMaintenanceWorkerProcess(
+	child: ChildProcess | null,
+	dbPath: string,
+): Promise<void> {
+	if (child?.pid && isProcessRunning(child.pid)) {
+		await terminateProcessPid(child.pid, { gracefulMs: 5000, forceMs: 5000 });
+	} else {
+		await terminateTrustedMaintenanceWorker(dbPath, { gracefulMs: 5000, forceMs: 5000 });
+	}
+	try {
+		rmSync(maintenanceWorkerPidFilePath(dbPath));
+	} catch {
+		// ignore
+	}
 }
 
 export function isSqliteVecLoadFailure(error: unknown): boolean {
@@ -413,112 +551,6 @@ async function startBackgroundViewer(invocation: ResolvedServeInvocation): Promi
 	);
 }
 
-type ManagedBackfillRunner = {
-	start(): void;
-	stop(): Promise<void>;
-};
-
-type BackfillJobPlan = {
-	name: string;
-	kind: string;
-	isPending: (db: MemoryStore["db"]) => boolean;
-	createRunner: () => ManagedBackfillRunner;
-};
-
-function createSequentialBackfillCoordinator(
-	store: MemoryStore,
-	jobPlans: BackfillJobPlan[],
-	signal?: AbortSignal,
-): { start: () => void; stop: () => Promise<void> } {
-	const pollIntervalMs = 1000;
-	let activeRunner: ManagedBackfillRunner | null = null;
-	let activePlan: BackfillJobPlan | null = null;
-	let activePollTimer: ReturnType<typeof setTimeout> | null = null;
-	let nextJobIndex = 0;
-	let stopped = false;
-
-	const clearPollTimer = () => {
-		if (!activePollTimer) return;
-		clearTimeout(activePollTimer);
-		activePollTimer = null;
-	};
-
-	const schedulePoll = (fn: () => void) => {
-		clearPollTimer();
-		activePollTimer = setTimeout(fn, pollIntervalMs);
-		if (typeof activePollTimer === "object" && "unref" in activePollTimer) {
-			activePollTimer.unref();
-		}
-	};
-
-	const waitForCurrentJob = () => {
-		if (stopped || signal?.aborted || !activePlan || !activeRunner) return;
-		const job = getMaintenanceJob(store.db, activePlan.kind);
-		if (!activePlan.isPending(store.db)) {
-			const finishedPlan = activePlan;
-			const finishedRunner = activeRunner;
-			activePlan = null;
-			activeRunner = null;
-			void finishedRunner.stop().finally(() => {
-				if (!stopped && !signal?.aborted) {
-					p.log.step(`${finishedPlan.name} backfill complete`);
-					startNextJob();
-				}
-			});
-			return;
-		}
-		if (job?.status === "failed") {
-			const failedPlan = activePlan;
-			const failedRunner = activeRunner;
-			activePlan = null;
-			activeRunner = null;
-			void failedRunner.stop().finally(() => {
-				if (!stopped && !signal?.aborted) {
-					p.log.warn(`${failedPlan.name} backfill failed and will be retried on a later startup`);
-					startNextJob();
-				}
-			});
-			return;
-		}
-		schedulePoll(waitForCurrentJob);
-	};
-
-	const startNextJob = () => {
-		clearPollTimer();
-		if (stopped || signal?.aborted) return;
-		while (nextJobIndex < jobPlans.length) {
-			const plan = jobPlans[nextJobIndex++];
-			if (!plan) continue;
-			if (!plan.isPending(store.db)) continue;
-			activePlan = plan;
-			activeRunner = plan.createRunner();
-			p.log.step(`${plan.name} backfill started`);
-			activeRunner.start();
-			schedulePoll(waitForCurrentJob);
-			return;
-		}
-		p.log.step("All backfill jobs complete");
-	};
-
-	return {
-		start: () => {
-			if (stopped || signal?.aborted) return;
-			const pendingCount = jobPlans.filter((plan) => plan.isPending(store.db)).length;
-			if (pendingCount === 0) return;
-			p.log.step(`${pendingCount} backfill job(s) pending — starting sequential runners`);
-			startNextJob();
-		},
-		stop: async () => {
-			stopped = true;
-			clearPollTimer();
-			const runner = activeRunner;
-			activeRunner = null;
-			activePlan = null;
-			if (runner) await runner.stop();
-		},
-	};
-}
-
 async function startForegroundViewer(invocation: ResolvedServeInvocation): Promise<void> {
 	const { createApp, createSyncApp, closeStore, getStore } = await import("@codemem/server");
 	const { serve } = await import("@hono/node-server");
@@ -559,84 +591,17 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	sweeper.start();
 
 	const syncAbort = new AbortController();
-	const retentionAbort = new AbortController();
-	const backfillAbort = new AbortController();
 	const config = invocation.configPath
 		? readCodememConfigFileAtPath(invocation.configPath)
 		: readCodememConfigFile();
 	const syncConfig = readCoordinatorSyncConfig(config);
 	const syncEnabled = syncConfig.syncEnabled;
 	const dbPath = resolveDbPath(invocation.dbPath ?? undefined);
-	const retentionRunner = new SyncRetentionRunner({
-		dbPath,
-		signal: retentionAbort.signal,
-	});
-	// Reuses backfillAbort intentionally: "abort all backfill-style work"
-	// is the shutdown signal callers care about. If a future use case
-	// needs to stop only the vector-migration runner (e.g. embeddings
-	// disabled mid-run) without touching the backfill coordinator, split
-	// this into its own controller.
-	const vectorMigrationRunner = new VectorModelMigrationRunner({
-		dbPath,
-		signal: backfillAbort.signal,
-	});
-	const backfillCoordinator = createSequentialBackfillCoordinator(
-		store,
-		[
-			{
-				name: "Sharing-domain",
-				kind: SCOPE_BACKFILL_JOB,
-				isPending: hasPendingScopeBackfill,
-				createRunner: () =>
-					new ScopeBackfillRunner({
-						dbPath,
-						signal: backfillAbort.signal,
-					}),
-			},
-			{
-				name: "Dedup-key",
-				kind: DEDUP_KEY_BACKFILL_JOB,
-				isPending: hasPendingDedupKeyBackfill,
-				createRunner: () =>
-					new DedupKeyBackfillRunner({
-						dbPath,
-						signal: backfillAbort.signal,
-					}),
-			},
-			{
-				name: "Session-context",
-				kind: SESSION_CONTEXT_BACKFILL_JOB,
-				isPending: hasPendingSessionContextBackfill,
-				createRunner: () =>
-					new SessionContextBackfillRunner({
-						dbPath,
-						signal: backfillAbort.signal,
-					}),
-			},
-			{
-				name: "Ref",
-				kind: REF_BACKFILL_JOB,
-				isPending: hasPendingRefBackfill,
-				createRunner: () =>
-					new RefBackfillRunner({
-						dbPath,
-						signal: backfillAbort.signal,
-					}),
-			},
-			{
-				name: "Session-summary dedup",
-				kind: SUMMARY_DEDUP_BACKFILL_JOB,
-				isPending: hasPendingSummaryDedupBackfill,
-				createRunner: () =>
-					new SummaryDedupBackfillRunner({
-						dbPath,
-						deviceId: store.deviceId,
-						signal: backfillAbort.signal,
-					}),
-			},
-		],
-		backfillAbort.signal,
-	);
+	if (!(await terminateTrustedMaintenanceWorker(dbPath, { gracefulMs: 1000, forceMs: 5000 }))) {
+		p.log.warn(
+			"Existing maintenance worker is not trusted or did not stop; starting viewer anyway",
+		);
+	}
 	const syncRuntimeStatus: {
 		phase: "starting" | "running" | "stopping" | "error" | "disabled" | null;
 		detail: string | null;
@@ -653,6 +618,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	};
 	const app = createApp(appOpts);
 	const pidPath = pidFilePath(dbPath);
+	let maintenanceWorker: ChildProcess | null = null;
 
 	// Sync protocol listener — separate port, network-accessible for peers.
 	// syncServerRef is never nulled after creation so shutdown always drains it.
@@ -691,15 +657,7 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 			p.log.success(`Listening on http://${info.address}:${info.port}`);
 			p.log.info(`Database: ${preparedDb}`);
 			p.log.step("Raw event sweeper started");
-			if (!isEmbeddingDisabled()) {
-				vectorMigrationRunner.start();
-				p.log.step("Vector maintenance runner started");
-			}
-			backfillCoordinator.start();
-			if (syncConfig.syncRetentionEnabled) {
-				retentionRunner.start();
-				p.log.step("Retention maintenance runner started");
-			}
+			maintenanceWorker = startMaintenanceWorkerProcess(invocation);
 			if (syncEnabled) {
 				const syncStartDelayMs = 3000;
 				p.log.step(`Sync daemon will start in background (${syncStartDelayMs / 1000}s delay)`);
@@ -756,29 +714,11 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 		process.exit(1);
 	});
 
-	// Periodic WAL checkpoint — keeps the WAL file bounded.
-	// Without this, long-running viewer processes accumulate a WAL that can
-	// grow to match the main DB size when concurrent readers hold it open.
-	const WAL_CHECKPOINT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
-	const walCheckpointTimer = setInterval(() => {
-		try {
-			store.db.pragma("wal_checkpoint(TRUNCATE)");
-		} catch (err) {
-			p.log.warn(`WAL checkpoint failed: ${err instanceof Error ? err.message : String(err)}`);
-		}
-	}, WAL_CHECKPOINT_INTERVAL_MS);
-	walCheckpointTimer.unref();
-
 	const shutdown = async () => {
 		p.outro("shutting down");
-		clearInterval(walCheckpointTimer);
 		syncAbort.abort();
-		retentionAbort.abort();
-		backfillAbort.abort();
+		await stopMaintenanceWorkerProcess(maintenanceWorker, dbPath);
 		await sweeper.stop();
-		await vectorMigrationRunner.stop();
-		await retentionRunner.stop();
-		await backfillCoordinator.stop();
 
 		// Drain both listeners before closing the shared store.
 		await new Promise<void>((resolve) => {
@@ -804,8 +744,20 @@ async function startForegroundViewer(invocation: ResolvedServeInvocation): Promi
 	// Force-exit safety net if graceful shutdown stalls for an unusually long time.
 	const forceShutdown = () => {
 		setTimeout(() => {
+			if (maintenanceWorker?.pid && isProcessRunning(maintenanceWorker.pid)) {
+				try {
+					process.kill(maintenanceWorker.pid, "SIGKILL");
+				} catch {
+					// ignore
+				}
+			}
 			try {
 				rmSync(pidPath);
+			} catch {
+				// ignore
+			}
+			try {
+				rmSync(maintenanceWorkerPidFilePath(dbPath));
 			} catch {
 				// ignore
 			}
@@ -846,8 +798,15 @@ async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<
 			port: invocation.port,
 		});
 		if (result.stopped) {
+			const workerStopped = await terminateTrustedMaintenanceWorker(dbPath, {
+				gracefulMs: 5000,
+				forceMs: 5000,
+			});
 			p.intro("codemem viewer");
 			p.log.success(`Stopped viewer${result.pid ? ` (pid ${result.pid})` : ""}`);
+			if (!workerStopped) {
+				p.log.warn("Maintenance worker pidfile exists but did not match trusted worker command");
+			}
 			if (invocation.mode === "stop") {
 				p.outro("done");
 				return;
@@ -863,7 +822,14 @@ async function runServeInvocation(invocation: ResolvedServeInvocation): Promise<
 			process.exitCode = 1;
 			return;
 		} else if (invocation.mode === "stop") {
+			const workerStopped = await terminateTrustedMaintenanceWorker(dbPath, {
+				gracefulMs: 5000,
+				forceMs: 5000,
+			});
 			p.intro("codemem viewer");
+			if (!workerStopped) {
+				p.log.warn("Maintenance worker pidfile exists but did not match trusted worker command");
+			}
 			p.outro("No background viewer found");
 			return;
 		}

--- a/packages/cli/src/maintenance-worker-runtime.ts
+++ b/packages/cli/src/maintenance-worker-runtime.ts
@@ -1,0 +1,256 @@
+import {
+	DEDUP_KEY_BACKFILL_JOB,
+	DedupKeyBackfillRunner,
+	getMaintenanceJob,
+	hasPendingDedupKeyBackfill,
+	hasPendingRefBackfill,
+	hasPendingScopeBackfill,
+	hasPendingSessionContextBackfill,
+	hasPendingSummaryDedupBackfill,
+	isEmbeddingDisabled,
+	type MemoryStore,
+	MemoryStore as MemoryStoreCtor,
+	REF_BACKFILL_JOB,
+	RefBackfillRunner,
+	readCodememConfigFile,
+	readCodememConfigFileAtPath,
+	readCoordinatorSyncConfig,
+	resolveDbPath,
+	SCOPE_BACKFILL_JOB,
+	ScopeBackfillRunner,
+	SESSION_CONTEXT_BACKFILL_JOB,
+	SessionContextBackfillRunner,
+	SUMMARY_DEDUP_BACKFILL_JOB,
+	SummaryDedupBackfillRunner,
+	SyncRetentionRunner,
+	VectorModelMigrationRunner,
+} from "@codemem/core";
+
+export interface MaintenanceWorkerLogger {
+	step(message: string): void;
+	warn(message: string): void;
+	error(message: string): void;
+}
+
+export interface MaintenanceWorkerRuntimeOptions {
+	dbPath?: string | null;
+	configPath?: string | null;
+	signal?: AbortSignal;
+	logger?: MaintenanceWorkerLogger;
+}
+
+type ManagedMaintenanceRunner = {
+	start(): void;
+	stop(): Promise<void>;
+};
+
+type BackfillJobPlan = {
+	name: string;
+	kind: string;
+	isPending: (db: MemoryStore["db"]) => boolean;
+	createRunner: () => ManagedMaintenanceRunner;
+};
+
+const defaultLogger: MaintenanceWorkerLogger = {
+	step: (message) => console.error(message),
+	warn: (message) => console.error(`Warning: ${message}`),
+	error: (message) => console.error(`Error: ${message}`),
+};
+
+function readWorkerSyncConfig(configPath?: string | null) {
+	const config = configPath ? readCodememConfigFileAtPath(configPath) : readCodememConfigFile();
+	return readCoordinatorSyncConfig(config);
+}
+
+function createSequentialBackfillCoordinator(
+	store: MemoryStore,
+	jobPlans: BackfillJobPlan[],
+	options: { signal?: AbortSignal; logger: MaintenanceWorkerLogger },
+): ManagedMaintenanceRunner {
+	const pollIntervalMs = 1000;
+	let activeRunner: ManagedMaintenanceRunner | null = null;
+	let activePlan: BackfillJobPlan | null = null;
+	let activePollTimer: ReturnType<typeof setTimeout> | null = null;
+	let nextJobIndex = 0;
+	let stopped = false;
+
+	const clearPollTimer = () => {
+		if (!activePollTimer) return;
+		clearTimeout(activePollTimer);
+		activePollTimer = null;
+	};
+
+	const schedulePoll = (fn: () => void) => {
+		clearPollTimer();
+		activePollTimer = setTimeout(fn, pollIntervalMs);
+		if (typeof activePollTimer === "object" && "unref" in activePollTimer) {
+			activePollTimer.unref();
+		}
+	};
+
+	const startNextJob = () => {
+		clearPollTimer();
+		if (stopped || options.signal?.aborted) return;
+		while (nextJobIndex < jobPlans.length) {
+			const plan = jobPlans[nextJobIndex++];
+			if (!plan) continue;
+			if (!plan.isPending(store.db)) continue;
+			activePlan = plan;
+			activeRunner = plan.createRunner();
+			options.logger.step(`${plan.name} backfill started`);
+			activeRunner.start();
+			schedulePoll(waitForCurrentJob);
+			return;
+		}
+		options.logger.step("All backfill jobs complete");
+	};
+
+	const waitForCurrentJob = () => {
+		if (stopped || options.signal?.aborted || !activePlan || !activeRunner) return;
+		const job = getMaintenanceJob(store.db, activePlan.kind);
+		if (!activePlan.isPending(store.db)) {
+			const finishedPlan = activePlan;
+			const finishedRunner = activeRunner;
+			activePlan = null;
+			activeRunner = null;
+			void finishedRunner.stop().finally(() => {
+				if (!stopped && !options.signal?.aborted) {
+					options.logger.step(`${finishedPlan.name} backfill complete`);
+					startNextJob();
+				}
+			});
+			return;
+		}
+		if (job?.status === "failed") {
+			const failedPlan = activePlan;
+			const failedRunner = activeRunner;
+			activePlan = null;
+			activeRunner = null;
+			void failedRunner.stop().finally(() => {
+				if (!stopped && !options.signal?.aborted) {
+					options.logger.warn(
+						`${failedPlan.name} backfill failed and will be retried on a later startup`,
+					);
+					startNextJob();
+				}
+			});
+			return;
+		}
+		schedulePoll(waitForCurrentJob);
+	};
+
+	return {
+		start: () => {
+			if (stopped || options.signal?.aborted) return;
+			const pendingCount = jobPlans.filter((plan) => plan.isPending(store.db)).length;
+			if (pendingCount === 0) return;
+			options.logger.step(`${pendingCount} backfill job(s) pending — starting sequential runners`);
+			startNextJob();
+		},
+		stop: async () => {
+			stopped = true;
+			clearPollTimer();
+			const runner = activeRunner;
+			activeRunner = null;
+			activePlan = null;
+			if (runner) await runner.stop();
+		},
+	};
+}
+
+export function startMaintenanceWorkerRuntime(
+	options: MaintenanceWorkerRuntimeOptions = {},
+): ManagedMaintenanceRunner {
+	const logger = options.logger ?? defaultLogger;
+	const dbPath = resolveDbPath(options.dbPath ?? undefined);
+	const store = new MemoryStoreCtor(dbPath);
+	const syncConfig = readWorkerSyncConfig(options.configPath);
+	const runners: ManagedMaintenanceRunner[] = [];
+	const walCheckpointTimer = setInterval(
+		() => {
+			try {
+				store.db.pragma("wal_checkpoint(TRUNCATE)");
+			} catch (error) {
+				logger.warn(
+					`WAL checkpoint failed: ${error instanceof Error ? error.message : String(error)}`,
+				);
+			}
+		},
+		5 * 60 * 1000,
+	);
+	walCheckpointTimer.unref();
+
+	if (!isEmbeddingDisabled()) {
+		runners.push(
+			new VectorModelMigrationRunner({
+				dbPath,
+				signal: options.signal,
+				idleIntervalMs: 5000,
+			}),
+		);
+	}
+
+	runners.push(
+		createSequentialBackfillCoordinator(
+			store,
+			[
+				{
+					name: "Sharing-domain",
+					kind: SCOPE_BACKFILL_JOB,
+					isPending: hasPendingScopeBackfill,
+					createRunner: () => new ScopeBackfillRunner({ dbPath, signal: options.signal }),
+				},
+				{
+					name: "Dedup-key",
+					kind: DEDUP_KEY_BACKFILL_JOB,
+					isPending: hasPendingDedupKeyBackfill,
+					createRunner: () => new DedupKeyBackfillRunner({ dbPath, signal: options.signal }),
+				},
+				{
+					name: "Session-context",
+					kind: SESSION_CONTEXT_BACKFILL_JOB,
+					isPending: hasPendingSessionContextBackfill,
+					createRunner: () => new SessionContextBackfillRunner({ dbPath, signal: options.signal }),
+				},
+				{
+					name: "Ref",
+					kind: REF_BACKFILL_JOB,
+					isPending: hasPendingRefBackfill,
+					createRunner: () => new RefBackfillRunner({ dbPath, signal: options.signal }),
+				},
+				{
+					name: "Session-summary dedup",
+					kind: SUMMARY_DEDUP_BACKFILL_JOB,
+					isPending: hasPendingSummaryDedupBackfill,
+					createRunner: () =>
+						new SummaryDedupBackfillRunner({
+							dbPath,
+							deviceId: store.deviceId,
+							signal: options.signal,
+						}),
+				},
+			],
+			{ signal: options.signal, logger },
+		),
+	);
+
+	if (syncConfig.syncRetentionEnabled) {
+		runners.push(new SyncRetentionRunner({ dbPath, signal: options.signal }));
+	}
+
+	for (const runner of runners) runner.start();
+	logger.step("Maintenance worker started");
+
+	return {
+		start: () => {
+			for (const runner of runners) runner.start();
+		},
+		stop: async () => {
+			clearInterval(walCheckpointTimer);
+			for (const runner of [...runners].reverse()) {
+				await runner.stop();
+			}
+			store.close();
+		},
+	};
+}

--- a/packages/core/src/vector-migration.ts
+++ b/packages/core/src/vector-migration.ts
@@ -18,6 +18,7 @@ const SYNC_INCREMENTAL_TRIGGER = "sync_incremental";
 export interface VectorModelMigrationOptions {
 	batchSize?: number;
 	intervalMs?: number;
+	idleIntervalMs?: number;
 	dbPath?: string;
 	signal?: AbortSignal;
 }
@@ -572,6 +573,7 @@ export class VectorModelMigrationRunner {
 	private readonly signal?: AbortSignal;
 	private readonly batchSize: number;
 	private readonly intervalMs: number;
+	private readonly idleIntervalMs: number;
 	private active = false;
 	private timer: ReturnType<typeof setTimeout> | null = null;
 	private currentRun: Promise<void> | null = null;
@@ -582,6 +584,7 @@ export class VectorModelMigrationRunner {
 		this.signal = options.signal;
 		this.batchSize = Math.max(1, options.batchSize ?? 50);
 		this.intervalMs = Math.max(1000, options.intervalMs ?? 5000);
+		this.idleIntervalMs = Math.max(1000, options.idleIntervalMs ?? IDLE_INTERVAL_MS);
 	}
 
 	start(): void {
@@ -628,7 +631,7 @@ export class VectorModelMigrationRunner {
 				})
 				.finally(() => {
 					this.currentRun = null;
-					const next = this.lastTickWasIdle ? IDLE_INTERVAL_MS : this.intervalMs;
+					const next = this.lastTickWasIdle ? this.idleIntervalMs : this.intervalMs;
 					this.schedule(next);
 				});
 		}, delayMs);

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -429,6 +429,13 @@ describe("viewer-server", () => {
 					title: "Hidden pack item",
 					scopeId: "unauthorized-team",
 				});
+				const inactiveId = insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "Forgotten pack item",
+					scopeId: "authorized-team",
+					active: false,
+				});
 				store.db
 					.prepare(
 						`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
@@ -438,10 +445,10 @@ describe("viewer-server", () => {
 						sessionId,
 						"2026-03-26T23:30:00Z",
 						JSON.stringify({
-							pack_item_ids: [visibleId, hiddenId],
-							added_ids: [visibleId, hiddenId],
-							removed_ids: [hiddenId],
-							retained_ids: [String(visibleId), String(hiddenId)],
+							pack_item_ids: [visibleId, hiddenId, inactiveId],
+							added_ids: [visibleId, hiddenId, inactiveId],
+							removed_ids: [hiddenId, inactiveId],
+							retained_ids: [String(visibleId), String(hiddenId), String(inactiveId)],
 						}),
 					);
 				const hiddenSessionId = insertTestSession(store.db);
@@ -475,6 +482,92 @@ describe("viewer-server", () => {
 					added_ids: [visibleId],
 					removed_ids: [],
 					retained_ids: [visibleId],
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("does not expose hidden usage rows that reference visible pack ids", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				grantSyncScopeToDevices(store, "authorized-team", [store.deviceId]);
+				grantSyncScopeToDevices(store, "unauthorized-team", []);
+				const visibleSessionId = insertTestSession(store.db);
+				const visibleId = insertTestMemory(store, {
+					sessionId: visibleSessionId,
+					kind: "discovery",
+					title: "Visible pack item from another session",
+					scopeId: "authorized-team",
+				});
+				const hiddenSessionId = insertTestSession(store.db);
+				insertTestMemory(store, {
+					sessionId: hiddenSessionId,
+					kind: "discovery",
+					title: "Hidden session item",
+					scopeId: "unauthorized-team",
+				});
+				store.db
+					.prepare(
+						`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+						 VALUES (?, 'pack', 999, 0, 999, ?, ?)`,
+					)
+					.run(
+						hiddenSessionId,
+						"2026-03-29T23:30:00Z",
+						JSON.stringify({ pack_item_ids: [visibleId], project: "secret-project" }),
+					);
+
+				const res = await app.request("/api/usage");
+				expect(res.status).toBe(200);
+				const body = (await res.json()) as {
+					recent_packs: unknown[];
+					totals: { count: number; tokens_read: number; tokens_saved: number };
+				};
+				expect(body.recent_packs).toHaveLength(0);
+				expect(body.totals).toMatchObject({ count: 0, tokens_read: 0, tokens_saved: 0 });
+			} finally {
+				cleanup();
+			}
+		});
+
+		it("batches usage memory visibility instead of fetching each pack item", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				const visibleIds = Array.from({ length: 25 }, (_, idx) =>
+					insertTestMemory(store, {
+						sessionId,
+						kind: "discovery",
+						title: `Visible usage item ${idx}`,
+					}),
+				);
+				store.db
+					.prepare(
+						`INSERT INTO usage_events(session_id, event, tokens_read, tokens_written, tokens_saved, created_at, metadata_json)
+						 VALUES (?, 'pack', 123, 0, 456, ?, ?)`,
+					)
+					.run(
+						sessionId,
+						"2026-03-28T23:30:00Z",
+						JSON.stringify({ pack_item_ids: visibleIds, added_ids: visibleIds }),
+					);
+				const getSpy = vi.spyOn(store, "get");
+
+				const res = await app.request("/api/usage");
+
+				expect(res.status).toBe(200);
+				expect(getSpy).not.toHaveBeenCalled();
+				const body = (await res.json()) as { recent_packs: Array<{ metadata_json: unknown }> };
+				expect(body.recent_packs[0]?.metadata_json).toMatchObject({
+					pack_item_ids: visibleIds,
+					added_ids: visibleIds,
 				});
 			} finally {
 				cleanup();

--- a/packages/viewer-server/src/routes/stats.ts
+++ b/packages/viewer-server/src/routes/stats.ts
@@ -44,6 +44,11 @@ type UsageRow = {
 	metadata_json: Record<string, unknown> | null;
 };
 
+type UsageVisibility = {
+	visibleMemoryIds: Set<number>;
+	visibleSessionIds: Set<number>;
+};
+
 function toUsageRow(
 	row: Record<string, unknown>,
 	metadata: Record<string, unknown> | null,
@@ -60,49 +65,117 @@ function toUsageRow(
 	};
 }
 
-function visibleMemoryIds(store: MemoryStore, value: unknown): number[] {
+function metadataMemoryIds(value: unknown): number[] {
 	if (!Array.isArray(value)) return [];
 	return value
 		.map((item) => (typeof item === "number" ? item : Number(item)))
-		.filter((item) => Number.isInteger(item) && store.get(item) != null);
+		.filter((item) => Number.isInteger(item) && item > 0);
 }
 
-function sessionHasVisibleMemory(store: MemoryStore, sessionId: number): boolean {
-	const filterResult = buildFilterClausesWithContext(
-		{ session_id: sessionId },
-		{
-			actorId: store.actorId,
-			deviceId: store.deviceId,
-			enforceScopeVisibility: true,
-		},
-	);
-	const clauses = ["memory_items.active = 1", ...filterResult.clauses];
-	const row = store.db
-		.prepare(`SELECT 1 AS found FROM memory_items WHERE ${clauses.join(" AND ")} LIMIT 1`)
-		.get(...filterResult.params) as Record<string, unknown> | undefined;
-	return row != null;
+function chunkNumbers(values: number[], chunkSize = 500): number[][] {
+	const chunks: number[][] = [];
+	for (let start = 0; start < values.length; start += chunkSize) {
+		chunks.push(values.slice(start, start + chunkSize));
+	}
+	return chunks;
 }
 
-function usageRowVisible(store: MemoryStore, row: UsageRow): boolean {
+function visibleMemoryIdSet(store: MemoryStore, memoryIds: Set<number>): Set<number> {
+	if (memoryIds.size === 0) return new Set();
+	const filterResult = buildFilterClausesWithContext(null, {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+		enforceScopeVisibility: true,
+	});
+	const visibleIds = new Set<number>();
+	for (const chunk of chunkNumbers([...memoryIds])) {
+		const placeholders = chunk.map(() => "?").join(", ");
+		const clauses = [
+			"memory_items.active = 1",
+			`memory_items.id IN (${placeholders})`,
+			...filterResult.clauses,
+		];
+		const rows = store.db
+			.prepare(`SELECT memory_items.id FROM memory_items WHERE ${clauses.join(" AND ")}`)
+			.all(...chunk, ...filterResult.params) as Array<{ id: number }>;
+		for (const row of rows) visibleIds.add(Number(row.id));
+	}
+	return visibleIds;
+}
+
+function visibleSessionIdSet(store: MemoryStore, sessionIds: Set<number>): Set<number> {
+	if (sessionIds.size === 0) return new Set();
+	const filterResult = buildFilterClausesWithContext(null, {
+		actorId: store.actorId,
+		deviceId: store.deviceId,
+		enforceScopeVisibility: true,
+	});
+	const visibleIds = new Set<number>();
+	for (const chunk of chunkNumbers([...sessionIds])) {
+		const placeholders = chunk.map(() => "?").join(", ");
+		const clauses = [
+			"memory_items.active = 1",
+			`memory_items.session_id IN (${placeholders})`,
+			...filterResult.clauses,
+		];
+		const rows = store.db
+			.prepare(
+				`SELECT DISTINCT memory_items.session_id AS session_id
+				 FROM memory_items
+				 WHERE ${clauses.join(" AND ")}`,
+			)
+			.all(...chunk, ...filterResult.params) as Array<{ session_id: number | null }>;
+		for (const row of rows) {
+			if (typeof row.session_id === "number") visibleIds.add(row.session_id);
+		}
+	}
+	return visibleIds;
+}
+
+function buildUsageVisibility(store: MemoryStore, rows: UsageRow[]): UsageVisibility {
+	const memoryIds = new Set<number>();
+	const sessionIds = new Set<number>();
+	for (const row of rows) {
+		if (typeof row.session_id === "number") sessionIds.add(row.session_id);
+		for (const key of MEMORY_ID_METADATA_KEYS) {
+			for (const memoryId of metadataMemoryIds(row.metadata_json?.[key])) {
+				memoryIds.add(memoryId);
+			}
+		}
+	}
+	return {
+		visibleMemoryIds: visibleMemoryIdSet(store, memoryIds),
+		visibleSessionIds: visibleSessionIdSet(store, sessionIds),
+	};
+}
+
+function usageRowVisible(row: UsageRow, visibility: UsageVisibility): boolean {
+	const rowSessionVisible =
+		row.session_id == null || visibility.visibleSessionIds.has(row.session_id);
 	const packItemIds = row.metadata_json?.pack_item_ids;
 	if (Array.isArray(packItemIds)) {
 		if (packItemIds.length === 0) {
-			return row.session_id != null && sessionHasVisibleMemory(store, row.session_id);
+			return row.session_id != null && visibility.visibleSessionIds.has(row.session_id);
 		}
-		return visibleMemoryIds(store, packItemIds).length > 0;
+		return (
+			rowSessionVisible &&
+			metadataMemoryIds(packItemIds).some((memoryId) => visibility.visibleMemoryIds.has(memoryId))
+		);
 	}
-	return row.session_id != null && sessionHasVisibleMemory(store, row.session_id);
+	return row.session_id != null && visibility.visibleSessionIds.has(row.session_id);
 }
 
 function sanitizePackUsageMetadata(
-	store: MemoryStore,
 	metadata: Record<string, unknown> | null,
+	visibility: UsageVisibility,
 ): Record<string, unknown> | null {
 	if (!metadata) return null;
 	const sanitized = { ...metadata };
 	for (const key of MEMORY_ID_METADATA_KEYS) {
 		if (Array.isArray(sanitized[key])) {
-			sanitized[key] = visibleMemoryIds(store, sanitized[key]);
+			sanitized[key] = metadataMemoryIds(sanitized[key]).filter((memoryId) =>
+				visibility.visibleMemoryIds.has(memoryId),
+			);
 		}
 	}
 	return sanitized;
@@ -233,22 +306,31 @@ export function statsRoutes(getStore: () => MemoryStore) {
 								 ORDER BY created_at DESC`,
 							)
 							.all() as Record<string, unknown>[]);
-				return rows
-					.map((row) => toUsageRow(row, parseMetadataJson(row.metadata_json)))
-					.filter((row) => usageRowVisible(store, row));
+				return rows.map((row) => toUsageRow(row, parseMetadataJson(row.metadata_json)));
 			};
-			const globalRows = loadUsageRows();
-			const filteredRows = projectFilter ? loadUsageRows(projectFilter) : null;
+			const loadedGlobalRows = loadUsageRows();
+			const globalVisibility = buildUsageVisibility(store, loadedGlobalRows);
+			const globalRows = loadedGlobalRows.filter((row) => usageRowVisible(row, globalVisibility));
+			const loadedFilteredRows = projectFilter ? loadUsageRows(projectFilter) : null;
+			const filteredVisibility = loadedFilteredRows
+				? buildUsageVisibility(store, loadedFilteredRows)
+				: null;
+			const filteredRows = loadedFilteredRows
+				? loadedFilteredRows.filter((row) =>
+						usageRowVisible(row, filteredVisibility ?? globalVisibility),
+					)
+				: null;
 			const eventsGlobal = summarizeUsageEvents(globalRows);
 			const totalsGlobal = totalUsageEvents(globalRows);
 			const eventsFiltered = filteredRows ? summarizeUsageEvents(filteredRows) : null;
 			const totalsFiltered = filteredRows ? totalUsageEvents(filteredRows) : null;
+			const recentVisibility = filteredVisibility ?? globalVisibility;
 			const recentPacks = (filteredRows ?? globalRows)
 				.filter((row) => row.event === "pack")
 				.slice(0, 10)
 				.map((row) => ({
 					...row,
-					metadata_json: sanitizePackUsageMetadata(store, row.metadata_json),
+					metadata_json: sanitizePackUsageMetadata(row.metadata_json, recentVisibility),
 				}));
 
 			return c.json({


### PR DESCRIPTION
## Description
Moves heavy maintenance/backfill work out of the viewer event loop into a managed child process so synchronous `better-sqlite3` work cannot freeze HTTP responses or signal handling. The viewer now starts/stops a hidden `codemem maintenance worker`, records a DB-bound worker pidfile, and only terminates trusted workers whose live command line exactly matches the target `--db-path`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Targeted validation:
- `pnpm exec vitest run packages/cli/src/commands/serve.test.ts`
- `pnpm exec vitest run packages/core/src/vector-migration.test.ts packages/core/src/vectors.test.ts`
- `pnpm exec tsc --build packages/core/tsconfig.json packages/cli/tsconfig.json`
- `pnpm exec biome check packages/cli/src/commands/serve.ts packages/cli/src/commands/serve.test.ts packages/cli/src/commands/maintenance.ts packages/cli/src/maintenance-worker-runtime.ts packages/core/src/vector-migration.ts`
- `pnpm run codemem maintenance --help`
- `pnpm run codemem maintenance worker --help`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
