### PR TITLE
fix: handle sync auth store contention

### DIFF
--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -2809,6 +2809,77 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("returns retryable busy when sync auth cannot record a nonce", async () => {
+			const { syncApp, getStore, cleanup } = createTestApp();
+			const peers: ReturnType<typeof createAuthenticatedSyncPeer>[] = [];
+			let blocker: Database | null = null;
+			let lockReleased = false;
+			try {
+				await syncApp.request("/v1/status");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const scenarios: Array<{
+					url: string;
+					method?: "GET" | "POST";
+					bodyBytes?: Buffer;
+				}> = [
+					{ url: "http://localhost/v1/status" },
+					{ url: "http://localhost/v1/ops?since=&limit=1" },
+					{
+						url: "http://localhost/v1/snapshot?generation=1&snapshot_id=snapshot-1&limit=1",
+					},
+					{
+						url: "http://localhost/v1/ops",
+						method: "POST",
+						bodyBytes: Buffer.from(JSON.stringify({ ops: [] })),
+					},
+				];
+				const signedRequests = scenarios.map((scenario) => {
+					const peer = createAuthenticatedSyncPeer(store, scenario);
+					peers.push(peer);
+					return { ...scenario, headers: peer.headers };
+				});
+				store.db.pragma("busy_timeout = 1");
+				blocker = connect(store.dbPath);
+				blocker.pragma("busy_timeout = 1");
+				blocker.exec("BEGIN IMMEDIATE");
+
+				for (const request of signedRequests) {
+					const res = await syncApp.request(request.url, {
+						method: request.method,
+						headers: request.headers,
+						body: request.bodyBytes,
+					});
+
+					expect(res.status).toBe(503);
+					expect(res.headers.get("retry-after")).toBe("1");
+					expect(await res.json()).toEqual({ error: "sync_auth_store_busy" });
+				}
+
+				blocker.exec("ROLLBACK");
+				lockReleased = true;
+				const retry = await syncApp.request(signedRequests[0].url, {
+					headers: signedRequests[0].headers,
+				});
+				expect(retry.status).toBe(200);
+				const replay = await syncApp.request(signedRequests[0].url, {
+					headers: signedRequests[0].headers,
+				});
+				expect(replay.status).toBe(401);
+			} finally {
+				if (!lockReleased) {
+					try {
+						blocker?.exec("ROLLBACK");
+					} catch {
+						// Ignore rollback errors when the lock was not acquired.
+					}
+				}
+				blocker?.close();
+				for (const peer of peers) peer.cleanup();
+				cleanup();
+			}
+		});
+
 		it("rate limits repeated sync listener requests", async () => {
 			const { syncApp, cleanup } = createTestApp({
 				syncRequestRateLimit: { unauthenticatedReadLimit: 1 },

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -503,11 +503,59 @@ function unauthorizedPayload(reason: string, exposeReason = false): Record<strin
 	return { error: "unauthorized" };
 }
 
+const SYNC_AUTH_STORE_BUSY_REASON = "sync_auth_store_busy";
+
+type SyncAuthResult = { ok: boolean; reason: string; deviceId: string };
+
+function isSqliteBusy(err: unknown): boolean {
+	if (!err || typeof err !== "object") return false;
+	const code = "code" in err ? String((err as { code?: unknown }).code ?? "") : "";
+	const message = err instanceof Error ? err.message : "";
+	return code === "SQLITE_BUSY" || message.includes("database is locked");
+}
+
+function recordSyncAuthNonce(
+	store: MemoryStore,
+	deviceId: string,
+	nonce: string,
+	createdAt: string,
+): SyncAuthResult | null {
+	try {
+		if (!recordNonce(store.db, deviceId, nonce, createdAt)) {
+			return { ok: false, reason: "nonce_replay", deviceId };
+		}
+	} catch (err) {
+		if (isSqliteBusy(err)) {
+			return { ok: false, reason: SYNC_AUTH_STORE_BUSY_REASON, deviceId };
+		}
+		throw err;
+	}
+
+	const cutoff = new Date(Date.now() - DEFAULT_TIME_WINDOW_S * 2 * 1000).toISOString();
+	try {
+		cleanupNonces(store.db, cutoff);
+	} catch (err) {
+		if (!isSqliteBusy(err)) throw err;
+		// Nonce cleanup is best-effort. A lock here should not fail a request
+		// after its nonce was already recorded; the next request can prune.
+	}
+	return null;
+}
+
+function isSyncAuthStoreBusy(auth: SyncAuthResult): boolean {
+	return !auth.ok && auth.reason === SYNC_AUTH_STORE_BUSY_REASON;
+}
+
+function syncAuthStoreBusyResponse(c: Context) {
+	c.header("Retry-After", "1");
+	return c.json({ error: SYNC_AUTH_STORE_BUSY_REASON }, 503);
+}
+
 function authorizeSyncRequest(
 	store: MemoryStore,
 	request: { method: string; url: string; header(name: string): string | undefined },
 	body: Buffer,
-): { ok: boolean; reason: string; deviceId: string } {
+): SyncAuthResult {
 	const deviceId = (request.header("X-Opencode-Device") ?? "").trim();
 	const signature = request.header("X-Opencode-Signature") ?? "";
 	const timestamp = request.header("X-Opencode-Timestamp") ?? "";
@@ -555,12 +603,8 @@ function authorizeSyncRequest(
 	}
 
 	const createdAt = new Date().toISOString();
-	if (!recordNonce(store.db, deviceId, nonce, createdAt)) {
-		return { ok: false, reason: "nonce_replay", deviceId };
-	}
-
-	const cutoff = new Date(Date.now() - DEFAULT_TIME_WINDOW_S * 2 * 1000).toISOString();
-	cleanupNonces(store.db, cutoff);
+	const nonceResult = recordSyncAuthNonce(store, deviceId, nonce, createdAt);
+	if (nonceResult) return nonceResult;
 	return { ok: true, reason: "ok", deviceId };
 }
 
@@ -568,7 +612,7 @@ async function authorizeBootstrapGrantRequest(
 	store: MemoryStore,
 	request: { method: string; url: string; header(name: string): string | undefined },
 	body: Buffer,
-): Promise<{ ok: boolean; reason: string; deviceId: string }> {
+): Promise<SyncAuthResult> {
 	const grantId = (request.header("X-Codemem-Bootstrap-Grant") ?? "").trim();
 	const deviceId = (request.header("X-Opencode-Device") ?? "").trim();
 	const signature = request.header("X-Opencode-Signature") ?? "";
@@ -647,11 +691,8 @@ async function authorizeBootstrapGrantRequest(
 	}
 
 	const createdAt = new Date().toISOString();
-	if (!recordNonce(store.db, deviceId, nonce, createdAt)) {
-		return { ok: false, reason: "nonce_replay", deviceId };
-	}
-	const cutoff = new Date(Date.now() - DEFAULT_TIME_WINDOW_S * 2 * 1000).toISOString();
-	cleanupNonces(store.db, cutoff);
+	const nonceResult = recordSyncAuthNonce(store, deviceId, nonce, createdAt);
+	if (nonceResult) return nonceResult;
 	return { ok: true, reason: "ok", deviceId };
 }
 
@@ -1362,6 +1403,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		const store = getStore();
 		return (async () => {
 			let auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
+			if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 			let preauthChecked = false;
 			let bootstrapAttempted = false;
 			if (!auth.ok) {
@@ -1380,6 +1422,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				auth = await authorizeBootstrapGrantRequest(store, c.req, Buffer.alloc(0));
 				bootstrapAttempted = true;
 			}
+			if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 			if (!auth.ok) {
 				// Specific reasons are logged server-side; wire responses use a generic
 				// reason to prevent info-disclosure.
@@ -1419,6 +1462,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 	app.get("/v1/ops", (c) => {
 		const store = getStore();
 		const auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
+		if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 		if (!auth.ok)
 			return (
 				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)
@@ -1494,6 +1538,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		const store = getStore();
 		return (async () => {
 			let auth = authorizeSyncRequest(store, c.req, Buffer.alloc(0));
+			if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 			let preauthChecked = false;
 			let bootstrapAttempted = false;
 			if (!auth.ok) {
@@ -1512,6 +1557,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 				auth = await authorizeBootstrapGrantRequest(store, c.req, Buffer.alloc(0));
 				bootstrapAttempted = true;
 			}
+			if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 			if (!auth.ok) {
 				// Specific reasons are logged server-side; wire responses use a generic
 				// reason to prevent info-disclosure.
@@ -1600,6 +1646,7 @@ export function syncProtocolRoutes(getStore: StoreFactory, opts: SyncProtocolRou
 		}
 
 		const auth = authorizeSyncRequest(store, c.req, raw);
+		if (isSyncAuthStoreBusy(auth)) return syncAuthStoreBusyResponse(c);
 		if (!auth.ok)
 			return (
 				rateLimitedResponse(c, c.req.path, false) ?? c.json(unauthorizedPayload(auth.reason), 401)


### PR DESCRIPTION
## Description
Handle sync auth nonce-store contention when maintenance temporarily owns SQLite's writer lock. Authenticated sync requests now fail closed with a retryable `503 sync_auth_store_busy` instead of throwing `SQLITE_BUSY` through the sync listener.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run:

- `pnpm exec vitest run packages/viewer-server/src/index.test.ts packages/cli/src/commands/serve.test.ts`
- `pnpm exec tsc --build packages/core/tsconfig.json packages/cli/tsconfig.json packages/viewer-server/tsconfig.json`
- `pnpm exec biome check packages/viewer-server/src/routes/sync.ts packages/viewer-server/src/index.test.ts`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced