### PR TITLE
fix(core): finalize scope backfill completion state

### DIFF
--- a/packages/cli/src/maintenance-worker-runtime.test.ts
+++ b/packages/cli/src/maintenance-worker-runtime.test.ts
@@ -1,0 +1,62 @@
+import { connect, type Database, startMaintenanceJob, updateMaintenanceJob } from "@codemem/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createSequentialBackfillCoordinator,
+	type MaintenanceWorkerLogger,
+} from "./maintenance-worker-runtime.js";
+
+describe("maintenance worker runtime", () => {
+	let db: Database;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		db = connect(":memory:");
+	});
+
+	afterEach(() => {
+		db.close();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("stops a failed active backfill even when its pending predicate remains true", async () => {
+		const logger: MaintenanceWorkerLogger = {
+			step: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		};
+		const runner = {
+			start: vi.fn(() => {
+				updateMaintenanceJob(db, "test_backfill", { status: "failed" });
+			}),
+			stop: vi.fn(async () => {}),
+		};
+		startMaintenanceJob(db, {
+			kind: "test_backfill",
+			title: "Test backfill",
+			status: "running",
+		});
+
+		const coordinator = createSequentialBackfillCoordinator(
+			{ db } as never,
+			[
+				{
+					name: "Test",
+					kind: "test_backfill",
+					isPending: () => true,
+					createRunner: () => runner,
+				},
+			],
+			{ logger },
+		);
+
+		coordinator.start();
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(runner.start).toHaveBeenCalledTimes(1);
+		expect(runner.stop).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(
+			"Test backfill failed and will be retried on a later startup",
+		);
+	});
+});

--- a/packages/cli/src/maintenance-worker-runtime.ts
+++ b/packages/cli/src/maintenance-worker-runtime.ts
@@ -39,12 +39,12 @@ export interface MaintenanceWorkerRuntimeOptions {
 	logger?: MaintenanceWorkerLogger;
 }
 
-type ManagedMaintenanceRunner = {
+export type ManagedMaintenanceRunner = {
 	start(): void;
 	stop(): Promise<void>;
 };
 
-type BackfillJobPlan = {
+export type BackfillJobPlan = {
 	name: string;
 	kind: string;
 	isPending: (db: MemoryStore["db"]) => boolean;
@@ -62,7 +62,7 @@ function readWorkerSyncConfig(configPath?: string | null) {
 	return readCoordinatorSyncConfig(config);
 }
 
-function createSequentialBackfillCoordinator(
+export function createSequentialBackfillCoordinator(
 	store: MemoryStore,
 	jobPlans: BackfillJobPlan[],
 	options: { signal?: AbortSignal; logger: MaintenanceWorkerLogger },
@@ -108,19 +108,6 @@ function createSequentialBackfillCoordinator(
 	const waitForCurrentJob = () => {
 		if (stopped || options.signal?.aborted || !activePlan || !activeRunner) return;
 		const job = getMaintenanceJob(store.db, activePlan.kind);
-		if (!activePlan.isPending(store.db)) {
-			const finishedPlan = activePlan;
-			const finishedRunner = activeRunner;
-			activePlan = null;
-			activeRunner = null;
-			void finishedRunner.stop().finally(() => {
-				if (!stopped && !options.signal?.aborted) {
-					options.logger.step(`${finishedPlan.name} backfill complete`);
-					startNextJob();
-				}
-			});
-			return;
-		}
 		if (job?.status === "failed") {
 			const failedPlan = activePlan;
 			const failedRunner = activeRunner;
@@ -131,6 +118,19 @@ function createSequentialBackfillCoordinator(
 					options.logger.warn(
 						`${failedPlan.name} backfill failed and will be retried on a later startup`,
 					);
+					startNextJob();
+				}
+			});
+			return;
+		}
+		if (!activePlan.isPending(store.db)) {
+			const finishedPlan = activePlan;
+			const finishedRunner = activeRunner;
+			activePlan = null;
+			activeRunner = null;
+			void finishedRunner.stop().finally(() => {
+				if (!stopped && !options.signal?.aborted) {
+					options.logger.step(`${finishedPlan.name} backfill complete`);
 					startNextJob();
 				}
 			});

--- a/packages/core/src/scope-backfill.test.ts
+++ b/packages/core/src/scope-backfill.test.ts
@@ -387,6 +387,44 @@ describe("scope backfill", () => {
 		expect(hasPendingScopeBackfill(db)).toBe(false);
 	});
 
+	it("keeps running progress below 100% while completion confirmation is pending", async () => {
+		const sessionId = insertSession(db, { project: "personal", cwd: "/home/me/personal" });
+		insertMemory(db, {
+			sessionId,
+			title: "Already scoped",
+			workspaceId: "personal:actor-1",
+			workspaceKind: "personal",
+			importKey: "key:stamped",
+			scopeId: LOCAL_DEFAULT_SCOPE_ID,
+		});
+		insertReplicationOp(db, "op-stamped", "key:stamped");
+
+		await expect(runScopeBackfillPass(db, { batchSize: 10 })).resolves.toBe(true);
+		let job = getMaintenanceJob(db, "scope_id_backfill");
+		expect(job?.status).toBe("running");
+		expect(job?.progress.current).toBeLessThan(job?.progress.total ?? 0);
+		expect(hasPendingScopeBackfill(db)).toBe(true);
+		expect(job?.metadata).toMatchObject({
+			processed_replication_ops: 1,
+			remaining_memories: 0,
+			remaining_replication_ops: 0,
+			exhausted_in_previous_pass: false,
+		});
+
+		await expect(runScopeBackfillPass(db, { batchSize: 10 })).resolves.toBe(true);
+		job = getMaintenanceJob(db, "scope_id_backfill");
+		expect(job?.status).toBe("running");
+		expect(job?.progress.current).toBeLessThan(job?.progress.total ?? 0);
+		expect(hasPendingScopeBackfill(db)).toBe(true);
+		expect(job?.metadata).toMatchObject({ exhausted_in_previous_pass: true });
+
+		await expect(runScopeBackfillPass(db, { batchSize: 10 })).resolves.toBe(false);
+		job = getMaintenanceJob(db, "scope_id_backfill");
+		expect(job?.status).toBe("completed");
+		expect(job?.progress.current).toBe(job?.progress.total);
+		expect(hasPendingScopeBackfill(db)).toBe(false);
+	});
+
 	it("hasPendingScopeBackfill returns quickly without joining replication_ops to memory_items", () => {
 		// Reproduces the slow-startup case: a database where the legacy
 		// pendingWorkCount path's correlated EXISTS join (replication_ops

--- a/packages/core/src/scope-backfill.ts
+++ b/packages/core/src/scope-backfill.ts
@@ -279,9 +279,9 @@ export function hasPendingScopeBackfill(db: SqliteDatabase): boolean {
 	// runner should sweep again. Both queries hit
 	// idx_replication_ops_scope_created.
 	const unstampedCount = countAllUnstampedReplicationOps(db);
-	if (unstampedCount === 0) return false;
-
 	const job = getMaintenanceJob(db, SCOPE_BACKFILL_JOB);
+	if (job?.status === "running") return true;
+	if (unstampedCount === 0) return false;
 	if (!job || job.status !== "completed") return true;
 	const metadata = (job.metadata ?? {}) as ScopeBackfillMetadata;
 	const opWatermark = metadata.unstamped_replication_ops_at_completion;
@@ -480,6 +480,14 @@ function getExistingMetadata(db: SqliteDatabase): ScopeBackfillMetadata {
 	return (getMaintenanceJob(db, SCOPE_BACKFILL_JOB)?.metadata ?? {}) as ScopeBackfillMetadata;
 }
 
+function processedScopeBackfillItems(metadata: ScopeBackfillMetadata): number {
+	return (
+		Number(metadata.seeded_scopes ?? 0) +
+		Number(metadata.processed_memories ?? 0) +
+		Number(metadata.processed_replication_ops ?? 0)
+	);
+}
+
 export async function runScopeBackfillPass(
 	db: SqliteDatabase,
 	options: { batchSize?: number } = {},
@@ -514,11 +522,12 @@ export async function runScopeBackfillPass(
 		// commit the watermarks and finish.
 		const previouslyExhausted = Boolean(existingMetadata.exhausted_in_previous_pass);
 		if (existingJob && existingJob.status !== "completed") {
+			const processedItems = processedScopeBackfillItems(existingMetadata);
 			if (previouslyExhausted) {
 				completeMaintenanceJob(db, SCOPE_BACKFILL_JOB, {
 					message: "Sharing-domain backfill complete; future startup should be quieter",
-					progressCurrent: Number(existingMetadata.processed_memories ?? 0),
-					progressTotal: Number(existingMetadata.processed_memories ?? 0),
+					progressCurrent: processedItems,
+					progressTotal: processedItems,
 					metadata: {
 						...existingMetadata,
 						remaining_memories: 0,
@@ -531,8 +540,8 @@ export async function runScopeBackfillPass(
 			}
 			updateMaintenanceJob(db, SCOPE_BACKFILL_JOB, {
 				message: "Sharing-domain backfill quiescent — confirming on next tick",
-				progressCurrent: Number(existingMetadata.processed_memories ?? 0),
-				progressTotal: Number(existingMetadata.processed_memories ?? 0),
+				progressCurrent: processedItems,
+				progressTotal: processedItems + 1,
 				metadata: {
 					...existingMetadata,
 					remaining_memories: 0,
@@ -610,8 +619,17 @@ export async function runScopeBackfillPass(
 	// counts we already computed in this pass, so the UI gets honest progress
 	// without paying for another stampable-op scan.
 	const progressCurrent = seededScopes + processedMemories + processedReplicationOps;
+	const confirmationPending =
+		!isComplete &&
+		remainingMemory === 0 &&
+		result.remainingReplicationOps === 0 &&
+		remainingMissingScopes === 0;
 	const progressTotal = Math.max(
-		progressCurrent + remainingMemory + result.remainingReplicationOps + remainingMissingScopes,
+		progressCurrent +
+			remainingMemory +
+			result.remainingReplicationOps +
+			remainingMissingScopes +
+			(confirmationPending ? 1 : 0),
 		progressCurrent,
 	);
 	const metadata: ScopeBackfillMetadata = {


### PR DESCRIPTION
## Description
Fixes maintenance job lifecycle edge cases discovered after the scope backfill performance patch merged:

- Prevents `scope_id_backfill` from showing `running` at 100% while the two-pass completion confirmation is still pending.
- Keeps `hasPendingScopeBackfill()` true for an in-flight running job so the maintenance worker does not stop before finalizing completion.
- Ensures the sequential maintenance coordinator handles failed jobs before checking pending work, so failed jobs with remaining work do not poll forever.

## Type of Change
<!-- Mark the relevant option(s) with an "x" -->

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing
<!-- Describe how you tested these changes -->

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Targeted local checks:

- `pnpm exec vitest run packages/core/src/scope-backfill.test.ts packages/cli/src/maintenance-worker-runtime.test.ts`
- `pnpm exec biome check packages/core/src/scope-backfill.ts packages/core/src/scope-backfill.test.ts packages/cli/src/maintenance-worker-runtime.ts packages/cli/src/maintenance-worker-runtime.test.ts`

## Checklist
<!-- Mark completed items with an "x" -->

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced