### PR TITLE
release: prepare 0.30.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.30.0-alpha.5"
+    "version": "0.30.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.30.0-alpha.5",
+      "version": "0.30.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/docs/plans/2026-05-06-sharing-domain-030-release-readiness-checklist.md
+++ b/docs/plans/2026-05-06-sharing-domain-030-release-readiness-checklist.md
@@ -1,7 +1,7 @@
 # Sharing-domain 0.30 release-readiness checklist
 
 **Date:** 2026-05-06  
-**Status:** open  
+**Status:** satisfied for alpha dogfood; final release still requires dogfood sign-off  
 **Related:** `2026-05-06-sharing-domain-release-readiness-ux-design.md`, `2026-05-06-sharing-domain-boundary-checkpoint.md`, `2026-04-30-sharing-domain-scope-design.md`
 
 This checklist gates the remaining 0.30 Sharing-domain UX polish. OV4G enforcement is complete; this gate verifies that dogfooders can understand the new model without weakening it.
@@ -22,40 +22,42 @@ Every 0.30 release-readiness change must preserve these statements:
 
 ### Anchor-peer setup clarity (`codemem-p6kx.1`)
 
-- [ ] Sync or Settings includes a compact explanation/checklist for always-on peers.
-- [ ] Copy says an anchor peer is a normal high-uptime peer.
-- [ ] Copy says explicit Sharing-domain grants decide what the peer receives.
-- [ ] Copy says coordinator discovery is not data access.
-- [ ] Copy says project filters only narrow.
-- [ ] Surface links to `docs/anchor-peer-deployment.md`.
+- [x] Sync or Settings includes a compact explanation/checklist for always-on peers.
+- [x] Copy says an anchor peer is a normal high-uptime peer.
+- [x] Copy says explicit Sharing-domain grants decide what the peer receives.
+- [x] Copy says coordinator discovery is not data access.
+- [x] Copy says project filters only narrow.
+- [x] Surface links to `docs/anchor-peer-deployment.md`.
 
 ### Peer Sharing-domain grant visibility (`codemem-p6kx.2`)
 
-- [ ] Peer rows/details show authorized Sharing domains clearly.
-- [ ] The empty state says no Sharing-domain grants exist yet.
-- [ ] Project include/exclude filters are labeled as narrowing only.
-- [ ] Coordinator group/discovery indicators are visually or textually separate from domain grants.
-- [ ] No copy implies coordinator group membership or project filters grant data access.
+- [x] Peer rows/details show authorized Sharing domains clearly.
+- [x] The empty state says no Sharing-domain grants exist yet.
+- [x] Project include/exclude filters are labeled as narrowing only.
+- [x] Coordinator group/discovery indicators are visually or textually separate from domain grants.
+- [x] No copy implies coordinator group membership or project filters grant data access.
 
 ### Legacy review upgrade state (`codemem-p6kx.3`)
 
-- [ ] Users can see when `legacy-shared-review` data exists.
-- [ ] Copy explains that 0.30 placed ambiguous historical shared data there conservatively.
-- [ ] Users are pointed to Sharing-domain mappings or docs for review.
-- [ ] No automatic reassignment or promotion is performed.
-- [ ] Copy warns that already-copied historical data is not erased by remapping or revocation.
+- [x] Users can see when `legacy-shared-review` data exists.
+- [x] Copy explains that 0.30 placed ambiguous historical shared data there conservatively.
+- [x] Users are pointed to Sharing-domain mappings or docs for review.
+- [x] No automatic reassignment or promotion is performed.
+- [x] Copy warns that already-copied historical data is not erased by remapping or revocation.
 
 ### Scope backfill and maintenance expectations (`codemem-p6kx.4`)
 
-- [ ] Upgrade/maintenance copy explains that scope backfill may process memories and replication ops.
-- [ ] Copy explains that progress totals can exceed the visible memory count.
-- [ ] Copy sets expectation that large databases can be CPU-bound during one-time work.
-- [ ] `codemem maintenance status` is documented as the inspection command.
-- [ ] Completed jobs remain understandable after fast or long runs.
+- [x] Upgrade/maintenance copy explains that scope backfill may process memories and replication ops.
+- [x] Copy explains that progress totals can exceed the visible memory count.
+- [x] Copy sets expectation that large databases can be CPU-bound during one-time work.
+- [x] `codemem maintenance status` is documented as the inspection command.
+- [x] Completed jobs remain understandable after fast or long runs.
 
 ## Validation path
 
 Before cutting the final 0.30 release:
+
+Tracked by `codemem-p6kx.6` for the `v0.30.0-alpha.5` dogfood pass.
 
 1. Run targeted tests for each changed surface.
 2. Run the normal TypeScript gate:

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.30.0-alpha.5";
+const PINNED_BACKEND_VERSION = "0.30.0";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.30.0-alpha.5",
+	"version": "0.30.0",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.30.0-alpha.5",
+	"version": "0.30.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.30.0-alpha.5");
+		expect(VERSION).toBe("0.30.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.30.0-alpha.5";
+export const VERSION = "0.30.0";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.30.0-alpha.5",
+	"version": "0.30.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -15,7 +15,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.30.0-alpha.5";
+const PINNED_BACKEND_VERSION = "0.30.0";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.30.0-alpha.5",
+	"version": "0.30.0",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.30.0-alpha.5",
+	"version": "0.30.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.30.0-alpha.5",
+  "version": "0.30.0",
   "author": {
     "name": "Adam Kunicki"
   },


### PR DESCRIPTION
## Description
Prepare the stable `0.30.0` release after the `v0.30.0-alpha.5` dogfood candidate.

This bumps the shared codemem version stream from `0.30.0-alpha.5` to `0.30.0` across package metadata, runtime version exports, plugin pins, and Claude plugin metadata. It also marks the 0.30 release-readiness checklist items satisfied for alpha dogfood while keeping the final dogfood sign-off tracked separately in `codemem-p6kx.6`.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [ ] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validation run:
- `CI=true pnpm install`
- `pnpm build`
- `node scripts/release-version.mjs check`
- `pnpm run tsc`
- `pnpm run lint`
- `env -u CODEMEM_EMBEDDING_DISABLED pnpm exec vitest run --testTimeout=30000`

Dogfood gate:
- `codemem-p6kx.6` remains open until the alpha.5 upgraded-database dogfood pass is explicitly signed off.
- Do not tag `v0.30.0` until that sign-off is complete.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced