### PR TITLE
feat(sync): suggest project sharing-domain mappings

### DIFF
--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -28,9 +28,11 @@ function insertSession(
 		)
 		.run(
 			now,
-			input.cwd === undefined ? "/Users/adam/work/acme/api" : input.cwd,
+			input.cwd === undefined ? "/workspace/work/exampleco/api" : input.cwd,
 			input.project === undefined ? "api" : input.project,
-			input.gitRemote === undefined ? "https://example.test/acme/api.git" : input.gitRemote,
+			input.gitRemote === undefined
+				? "https://git.example.invalid/exampleco/api.git"
+				: input.gitRemote,
 			input.gitBranch === undefined ? "main" : input.gitBranch,
 			"test-user",
 			"test",
@@ -119,14 +121,14 @@ describe("project scope settings", () => {
 
 	it("warns when same-basename projects need review before assignment", () => {
 		const workSession = insertSession(db, {
-			cwd: "/Users/adam/work/acme/api",
-			gitRemote: "https://example.test/acme/api.git",
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
 			project: "api",
 		});
 		insertMemory(db, workSession);
 		const ossSession = insertSession(db, {
-			cwd: "/Users/adam/oss/api",
-			gitRemote: "https://example.test/oss/api.git",
+			cwd: "/workspace/oss/api",
+			gitRemote: "https://git.example.invalid/oss/api.git",
 			project: "api",
 		});
 		insertMemory(db, ossSession, { workspaceId: "shared:oss-api" });
@@ -137,22 +139,22 @@ describe("project scope settings", () => {
 		expect(projects).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
-					workspace_identity: "https://example.test/acme/api.git",
+					workspace_identity: "https://git.example.invalid/exampleco/api.git",
 					guardrail_warnings: expect.arrayContaining([
 						expect.objectContaining({
 							code: "basename_collision_review",
 							requires_confirmation: true,
-							related_workspace_identities: ["https://example.test/oss/api.git"],
+							related_workspace_identities: ["https://git.example.invalid/oss/api.git"],
 						}),
 					]),
 				}),
 				expect.objectContaining({
-					workspace_identity: "https://example.test/oss/api.git",
+					workspace_identity: "https://git.example.invalid/oss/api.git",
 					guardrail_warnings: expect.arrayContaining([
 						expect.objectContaining({
 							code: "basename_collision_review",
 							requires_confirmation: true,
-							related_workspace_identities: ["https://example.test/acme/api.git"],
+							related_workspace_identities: ["https://git.example.invalid/exampleco/api.git"],
 						}),
 					]),
 				}),
@@ -160,16 +162,136 @@ describe("project scope settings", () => {
 		);
 	});
 
+	it("suggests mappings from canonical signals without saving them", () => {
+		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
+		insertScope(db, {
+			scopeId: "personal-devices",
+			label: "Personal Devices",
+			kind: "personal",
+			authorityType: "local",
+		});
+		const workSession = insertSession(db, {
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
+			project: "api",
+		});
+		insertMemory(db, workSession);
+		const personalSession = insertSession(db, {
+			cwd: "/workspace/personal/api",
+			gitRemote: null,
+			project: "api",
+		});
+		insertMemory(db, personalSession, { workspaceId: "personal:api" });
+
+		const projects = listProjectScopeCandidates(db);
+		const work = projects.find(
+			(project) => project.workspace_identity === "https://git.example.invalid/exampleco/api.git",
+		);
+		const personal = projects.find(
+			(project) => project.workspace_identity === "/workspace/personal/api",
+		);
+		const mappingCount = db.prepare("SELECT COUNT(*) AS n FROM project_scope_mappings").get() as {
+			n: number;
+		};
+
+		expect(work).toMatchObject({
+			identity_source: "git_remote",
+			resolved_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			resolution_reason: "local_default",
+			suggested_scope_id: "exampleco-work",
+			suggestion_signal: "git_remote",
+		});
+		expect(work?.suggestion_reason).toContain("git remote");
+		expect(personal).toMatchObject({
+			identity_source: "cwd",
+			resolved_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			suggested_scope_id: "personal-devices",
+			suggestion_signal: "cwd",
+		});
+		expect(projects).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					workspace_identity: "https://git.example.invalid/exampleco/api.git",
+					guardrail_warnings: expect.arrayContaining([
+						expect.objectContaining({ code: "basename_collision_review" }),
+					]),
+				}),
+				expect.objectContaining({
+					workspace_identity: "/workspace/personal/api",
+					guardrail_warnings: expect.arrayContaining([
+						expect.objectContaining({ code: "basename_collision_review" }),
+					]),
+				}),
+			]),
+		);
+		expect(mappingCount.n).toBe(0);
+	});
+
+	it("does not guess when multiple scopes match a project signal equally", () => {
+		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
+		insertScope(db, { scopeId: "exampleco-client", label: "ExampleCo Client", kind: "client" });
+		const sessionId = insertSession(db, {
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
+			project: "api",
+		});
+		insertMemory(db, sessionId);
+
+		const [project] = listProjectScopeCandidates(db);
+
+		expect(project).toMatchObject({
+			resolved_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			suggested_scope_id: null,
+			suggestion_reason: null,
+		});
+	});
+
+	it("falls back from git remote to cwd when suggesting mappings", () => {
+		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
+		const sessionId = insertSession(db, {
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/vendor/api.git",
+			project: "api",
+		});
+		insertMemory(db, sessionId);
+
+		const [project] = listProjectScopeCandidates(db);
+
+		expect(project).toMatchObject({
+			resolved_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			suggested_scope_id: "exampleco-work",
+			suggestion_signal: "cwd",
+		});
+	});
+
+	it("does not suggest org domains from generic category tokens only", () => {
+		insertScope(db, { scopeId: "exampleco-client", label: "ExampleCo Client", kind: "client" });
+		const sessionId = insertSession(db, {
+			cwd: "/workspace/client/api",
+			gitRemote: null,
+			project: "api",
+		});
+		insertMemory(db, sessionId);
+
+		const [project] = listProjectScopeCandidates(db);
+
+		expect(project).toMatchObject({
+			resolved_scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			suggested_scope_id: null,
+			suggestion_reason: null,
+		});
+	});
+
 	it("does not require basename collision confirmation for local-only assignments", () => {
 		const workSession = insertSession(db, {
-			cwd: "/Users/adam/work/acme/api",
-			gitRemote: "https://example.test/acme/api.git",
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
 			project: "api",
 		});
 		insertMemory(db, workSession);
 		const ossSession = insertSession(db, {
-			cwd: "/Users/adam/oss/api",
-			gitRemote: "https://example.test/oss/api.git",
+			cwd: "/workspace/oss/api",
+			gitRemote: "https://git.example.invalid/oss/api.git",
 			project: "api",
 		});
 		insertMemory(db, ossSession, { workspaceId: "shared:oss-api" });
@@ -257,12 +379,12 @@ describe("project scope settings", () => {
 		insertScope(db, { scopeId: "acme-oss", label: "Acme OSS" });
 
 		const first = upsertProjectScopeSettingsMapping(db, {
-			workspace_identity: "C:\\Users\\adam\\work\\acme\\api\\",
+			workspace_identity: "C:\\workspace\\work\\exampleco\\api\\",
 			project_pattern: "api",
 			scope_id: "acme-work",
 		});
 		const second = upsertProjectScopeSettingsMapping(db, {
-			workspace_identity: "C:/Users/adam/work/acme/api",
+			workspace_identity: "C:/workspace/work/exampleco/api",
 			project_pattern: "api",
 			scope_id: "acme-oss",
 		});
@@ -273,7 +395,7 @@ describe("project scope settings", () => {
 		expect(second.id).toBe(first.id);
 		expect(second).toMatchObject({
 			scope_id: "acme-oss",
-			workspace_identity: "C:/Users/adam/work/acme/api",
+			workspace_identity: "C:/workspace/work/exampleco/api",
 		});
 		expect(rows.n).toBe(1);
 	});
@@ -282,11 +404,11 @@ describe("project scope settings", () => {
 		insertScope(db, { scopeId: "acme-work", label: "Acme Work" });
 
 		const analysis = analyzeProjectScopeMappingChangeGuardrails(db, {
-			project_pattern: "/Users/adam/*",
+			project_pattern: "/home/fixture-user/*",
 			scope_id: "acme-work",
 		});
 		const mapping = upsertProjectScopeSettingsMapping(db, {
-			project_pattern: "/Users/adam/*",
+			project_pattern: "/home/fixture-user/*",
 			scope_id: "acme-work",
 		});
 		const [listed] = listProjectScopeSettingsMappings(db);
@@ -357,14 +479,14 @@ describe("project scope settings", () => {
 
 		expect(() =>
 			upsertProjectScopeSettingsMapping(db, {
-				workspace_identity: "https://example.test/acme/api.git",
+				workspace_identity: "https://git.example.invalid/exampleco/api.git",
 				project_pattern: "api",
 				scope_id: "missing-domain",
 			}),
 		).toThrow(/not an active Sharing domain/);
 		expect(() =>
 			upsertProjectScopeSettingsMapping(db, {
-				workspace_identity: "https://example.test/acme/api.git",
+				workspace_identity: "https://git.example.invalid/exampleco/api.git",
 				project_pattern: "api",
 				scope_id: "inactive-work",
 			}),

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Database } from "./db.js";
-import { ensureScopeBackfillScopes } from "./scope-backfill.js";
+import { ensureScopeBackfillScopes, LEGACY_SHARED_REVIEW_SCOPE_ID } from "./scope-backfill.js";
 import {
 	canonicalWorkspaceIdentity,
 	LOCAL_DEFAULT_SCOPE_ID,
@@ -71,7 +71,16 @@ export interface ProjectScopeCandidate {
 	resolution_reason: ScopeResolutionReason;
 	mapping_id: number | null;
 	matched_pattern: string | null;
+	suggested_scope_id: string | null;
+	suggestion_reason: string | null;
+	suggestion_signal: WorkspaceIdentitySource | null;
 	guardrail_warnings: ProjectScopeGuardrailWarning[];
+}
+
+interface ProjectScopeSuggestion {
+	scopeId: string;
+	reason: string;
+	signal: WorkspaceIdentitySource;
 }
 
 export interface UpsertProjectScopeMappingInput {
@@ -127,6 +136,86 @@ function isOrgLikeScope(scope: SharingDomainSettingsScope | undefined): boolean 
 	if (!scope || scope.scope_id === LOCAL_DEFAULT_SCOPE_ID) return false;
 	if (scope.authority_type !== "local") return true;
 	return scope.kind === "team" || scope.kind === "org" || scope.kind === "client";
+}
+
+function tokenSet(value: string | null | undefined): Set<string> {
+	const normalized = clean(value)?.toLowerCase() ?? "";
+	return new Set(normalized.match(/[a-z0-9][a-z0-9-]{1,}/g) ?? []);
+}
+
+function scopeSuggestionTokens(scope: SharingDomainSettingsScope): {
+	generic: string[];
+	specific: string[];
+} {
+	const ignored = new Set(["domain", "sharing", "devices", "scope", "team", "org", "local"]);
+	const generic = new Set(["client", "dev", "oss", "personal", "work"]);
+	const tokens = [...tokenSet(`${scope.scope_id} ${scope.label}`)].filter(
+		(token) => !ignored.has(token),
+	);
+	return {
+		generic: tokens.filter((token) => generic.has(token)),
+		specific: tokens.filter((token) => !generic.has(token)),
+	};
+}
+
+function signalTexts(
+	project: Pick<ProjectScopeCandidate, "git_remote" | "cwd" | "workspace_identity">,
+): Array<{ signal: WorkspaceIdentitySource; text: string }> {
+	const signals: Array<{ signal: WorkspaceIdentitySource; text: string }> = [];
+	if (project.git_remote) signals.push({ signal: "git_remote", text: project.git_remote });
+	if (project.cwd) signals.push({ signal: "cwd", text: project.cwd });
+	signals.push({ signal: "workspace_id", text: project.workspace_identity });
+	return signals;
+}
+
+function suggestProjectScope(
+	project: Pick<
+		ProjectScopeCandidate,
+		"git_remote" | "cwd" | "workspace_identity" | "resolved_scope_id" | "resolution_reason"
+	>,
+	scopes: SharingDomainSettingsScope[],
+): ProjectScopeSuggestion | null {
+	if (project.resolution_reason !== "local_default") return null;
+	if (project.workspace_identity.startsWith("unmapped:")) return null;
+	for (const signal of signalTexts(project)) {
+		const signalTokens = tokenSet(signal.text);
+		const candidates = scopes
+			.filter(
+				(scope) =>
+					scope.scope_id !== LOCAL_DEFAULT_SCOPE_ID &&
+					scope.scope_id !== LEGACY_SHARED_REVIEW_SCOPE_ID &&
+					scope.status === "active",
+			)
+			.flatMap((scope) => {
+				const tokens = scopeSuggestionTokens(scope);
+				const specificMatches = tokens.specific.filter((token) => signalTokens.has(token));
+				const genericMatches = tokens.generic.filter(
+					(token) => token === "personal" && signalTokens.has(token) && scope.kind === token,
+				);
+				if (specificMatches.length === 0 && genericMatches.length === 0) return [];
+				return [
+					{
+						scope,
+						matches: [...specificMatches, ...genericMatches],
+						score: specificMatches.length * 10 + genericMatches.length,
+					},
+				];
+			})
+			.toSorted((left, right) => right.score - left.score);
+		const [best, second] = candidates;
+		if (!best) continue;
+		if (second && second.score === best.score) continue;
+		const scopeName = scopeDisplayName(best.scope, best.scope.scope_id);
+		const signalName = signal.signal === "git_remote" ? "git remote" : signal.signal;
+		return {
+			scopeId: best.scope.scope_id,
+			reason: `${scopeName} is suggested because the ${signalName} contains ${best.matches.join(
+				", ",
+			)}. Confirm before mapping; this does not grant peer access.`,
+			signal: signal.signal,
+		};
+	}
+	return null;
 }
 
 function hasWildcard(value: string): boolean {
@@ -498,6 +587,7 @@ export function listProjectScopeCandidates(
 	ensureScopeBackfillScopes(db);
 	const limit = Math.max(1, Math.min(options.limit ?? 250, 1000));
 	const mappings = listProjectScopeSettingsMappings(db);
+	const scopes = listSharingDomainSettingsScopes(db);
 	const rows = db
 		.prepare(
 			`SELECT
@@ -544,7 +634,7 @@ export function listProjectScopeCandidates(
 			workspaceId: row.workspace_id,
 			mappings,
 		});
-		candidates.push({
+		const baseCandidate = {
 			workspace_identity: identity.value,
 			identity_source: identity.source,
 			display_project:
@@ -558,7 +648,17 @@ export function listProjectScopeCandidates(
 			resolution_reason: resolution.reason,
 			mapping_id: resolution.mapping?.id ?? null,
 			matched_pattern: resolution.matchedPattern,
+			suggested_scope_id: null,
+			suggestion_reason: null,
+			suggestion_signal: null,
 			guardrail_warnings: [],
+		} satisfies ProjectScopeCandidate;
+		const suggestion = suggestProjectScope(baseCandidate, scopes);
+		candidates.push({
+			...baseCandidate,
+			suggested_scope_id: suggestion?.scopeId ?? null,
+			suggestion_reason: suggestion?.reason ?? null,
+			suggestion_signal: suggestion?.signal ?? null,
 		});
 	}
 

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -209,6 +209,9 @@ export interface ProjectScopeCandidate {
 	resolution_reason: string;
 	mapping_id: number | null;
 	matched_pattern: string | null;
+	suggested_scope_id?: string | null;
+	suggestion_reason?: string | null;
+	suggestion_signal?: string | null;
 	guardrail_warnings?: ProjectScopeGuardrailWarning[];
 }
 

--- a/packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx
+++ b/packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx
@@ -111,10 +111,10 @@ describe("SharingDomainsPanel", () => {
 				mappings: [],
 				projects: [
 					{
-						cwd: "/work/acme/api",
+						cwd: "/workspace/work/exampleco/api",
 						display_project: "api",
 						git_branch: "main",
-						git_remote: "https://example.test/acme/api.git",
+						git_remote: "https://git.example.invalid/exampleco/api.git",
 						identity_source: "git_remote",
 						latest_session_at: "2026-05-06T00:00:00Z",
 						mapping_id: null,
@@ -122,7 +122,7 @@ describe("SharingDomainsPanel", () => {
 						project: "api",
 						resolution_reason: "local_default",
 						resolved_scope_id: "local-default",
-						workspace_identity: "https://example.test/acme/api.git",
+						workspace_identity: "https://git.example.invalid/exampleco/api.git",
 					},
 				],
 				scopes: [
@@ -147,10 +147,10 @@ describe("SharingDomainsPanel", () => {
 				mappings: [],
 				projects: [
 					{
-						cwd: "/work/acme/api",
+						cwd: "/workspace/work/exampleco/api",
 						display_project: "api",
 						git_branch: "main",
-						git_remote: "https://example.test/acme/api.git",
+						git_remote: "https://git.example.invalid/exampleco/api.git",
 						identity_source: "git_remote",
 						latest_session_at: "2026-05-06T00:00:00Z",
 						mapping_id: 42,
@@ -158,7 +158,7 @@ describe("SharingDomainsPanel", () => {
 						project: "api",
 						resolution_reason: "exact_mapping",
 						resolved_scope_id: "acme-work",
-						workspace_identity: "https://example.test/acme/api.git",
+						workspace_identity: "https://git.example.invalid/exampleco/api.git",
 					},
 				],
 				scopes: [
@@ -184,7 +184,7 @@ describe("SharingDomainsPanel", () => {
 			project_pattern: "api",
 			scope_id: "acme-work",
 			source: "user",
-			workspace_identity: "https://example.test/acme/api.git",
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
 		});
 
 		const root = renderIntoDocument(<SharingDomainsPanel />);
@@ -212,9 +212,82 @@ describe("SharingDomainsPanel", () => {
 		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledWith({
 			project_pattern: "api",
 			scope_id: "acme-work",
-			workspace_identity: "https://example.test/acme/api.git",
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
 		});
 		expect(root.textContent).toContain("Current default: Acme Work · explicit project mapping");
+	});
+
+	it("preselects suggested mappings but requires explicit confirmation to save", async () => {
+		vi.mocked(api.loadSharingDomainSettings).mockResolvedValue({
+			local_default_scope_id: "local-default",
+			mappings: [],
+			projects: [
+				{
+					cwd: "/workspace/work/exampleco/api",
+					display_project: "api",
+					git_branch: "main",
+					git_remote: "https://git.example.invalid/exampleco/api.git",
+					identity_source: "git_remote",
+					latest_session_at: "2026-05-06T00:00:00Z",
+					mapping_id: null,
+					matched_pattern: null,
+					project: "api",
+					resolution_reason: "local_default",
+					resolved_scope_id: "local-default",
+					suggested_scope_id: "exampleco-work",
+					suggestion_reason:
+						"ExampleCo Work is suggested because the git remote contains exampleco. Confirm before mapping; this does not grant peer access.",
+					suggestion_signal: "git_remote",
+					workspace_identity: "https://git.example.invalid/exampleco/api.git",
+				},
+			],
+			scopes: [
+				{
+					authority_type: "local",
+					kind: "system",
+					label: "Local only",
+					scope_id: "local-default",
+					status: "active",
+				},
+				{
+					authority_type: "coordinator",
+					kind: "team",
+					label: "ExampleCo Work",
+					scope_id: "exampleco-work",
+					status: "active",
+				},
+			],
+		});
+		vi.mocked(api.saveSharingDomainProjectMapping).mockResolvedValue({
+			id: 42,
+			priority: 0,
+			project_pattern: "api",
+			scope_id: "exampleco-work",
+			source: "user",
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
+		});
+
+		const root = renderIntoDocument(<SharingDomainsPanel />);
+		await flushEffects();
+
+		expect(root.textContent).toContain("Suggested mapping: ExampleCo Work");
+		expect(root.textContent).toContain("Folders, paths, and git remotes are hints only");
+		expect(root.querySelector("select")?.value).toBe("exampleco-work");
+		expect(api.saveSharingDomainProjectMapping).not.toHaveBeenCalled();
+
+		const saveButton = Array.from(root.querySelectorAll("button")).find(
+			(button) => button.textContent === "Confirm suggested mapping",
+		);
+		await act(async () => {
+			saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+			await Promise.resolve();
+		});
+
+		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledWith({
+			project_pattern: "api",
+			scope_id: "exampleco-work",
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
+		});
 	});
 
 	it("shows guardrail confirmation and retries save with confirmed codes", async () => {
@@ -224,10 +297,10 @@ describe("SharingDomainsPanel", () => {
 				mappings: [],
 				projects: [
 					{
-						cwd: "/work/acme/api",
+						cwd: "/workspace/work/exampleco/api",
 						display_project: "api",
 						git_branch: "main",
-						git_remote: "https://example.test/acme/api.git",
+						git_remote: "https://git.example.invalid/exampleco/api.git",
 						guardrail_warnings: [],
 						identity_source: "git_remote",
 						latest_session_at: "2026-05-06T00:00:00Z",
@@ -236,7 +309,7 @@ describe("SharingDomainsPanel", () => {
 						project: "api",
 						resolution_reason: "exact_mapping",
 						resolved_scope_id: "acme-work",
-						workspace_identity: "https://example.test/acme/api.git",
+						workspace_identity: "https://git.example.invalid/exampleco/api.git",
 					},
 				],
 				scopes: [
@@ -261,10 +334,10 @@ describe("SharingDomainsPanel", () => {
 				mappings: [],
 				projects: [
 					{
-						cwd: "/work/acme/api",
+						cwd: "/workspace/work/exampleco/api",
 						display_project: "api",
 						git_branch: "main",
-						git_remote: "https://example.test/acme/api.git",
+						git_remote: "https://git.example.invalid/exampleco/api.git",
 						guardrail_warnings: [],
 						identity_source: "git_remote",
 						latest_session_at: "2026-05-06T00:00:00Z",
@@ -273,7 +346,7 @@ describe("SharingDomainsPanel", () => {
 						project: "api",
 						resolution_reason: "exact_mapping",
 						resolved_scope_id: "personal-devices",
-						workspace_identity: "https://example.test/acme/api.git",
+						workspace_identity: "https://git.example.invalid/exampleco/api.git",
 					},
 				],
 				scopes: [
@@ -316,7 +389,7 @@ describe("SharingDomainsPanel", () => {
 				project_pattern: "api",
 				scope_id: "personal-devices",
 				source: "user",
-				workspace_identity: "https://example.test/acme/api.git",
+				workspace_identity: "https://git.example.invalid/exampleco/api.git",
 			});
 
 		const root = renderIntoDocument(<SharingDomainsPanel />);
@@ -354,7 +427,7 @@ describe("SharingDomainsPanel", () => {
 			id: 42,
 			project_pattern: "api",
 			scope_id: "personal-devices",
-			workspace_identity: "https://example.test/acme/api.git",
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
 		});
 		expect(root.textContent).toContain(
 			"Current default: Personal Devices · explicit project mapping",
@@ -376,7 +449,7 @@ describe("SharingDomainsPanel", () => {
 			],
 			projects: [
 				{
-					cwd: "/work/acme/api",
+					cwd: "/workspace/work/exampleco/api",
 					display_project: "api",
 					git_branch: null,
 					git_remote: null,
@@ -388,7 +461,7 @@ describe("SharingDomainsPanel", () => {
 					project: "api",
 					resolution_reason: "pattern_mapping",
 					resolved_scope_id: "acme-work",
-					workspace_identity: "/work/acme/api",
+					workspace_identity: "/workspace/work/exampleco/api",
 				},
 			],
 			scopes: [
@@ -414,7 +487,7 @@ describe("SharingDomainsPanel", () => {
 			project_pattern: "api",
 			scope_id: "personal-devices",
 			source: "user",
-			workspace_identity: "/work/acme/api",
+			workspace_identity: "/workspace/work/exampleco/api",
 		});
 
 		const root = renderIntoDocument(<SharingDomainsPanel />);
@@ -437,7 +510,7 @@ describe("SharingDomainsPanel", () => {
 		expect(api.saveSharingDomainProjectMapping).toHaveBeenCalledWith({
 			project_pattern: "api",
 			scope_id: "personal-devices",
-			workspace_identity: "/work/acme/api",
+			workspace_identity: "/workspace/work/exampleco/api",
 		});
 	});
 

--- a/packages/ui/src/tabs/settings/components/SharingDomainsPanel.tsx
+++ b/packages/ui/src/tabs/settings/components/SharingDomainsPanel.tsx
@@ -47,7 +47,10 @@ function scopeName(scopes: SharingDomainScope[], scopeId: string): string {
 
 function resetDrafts(settings: SharingDomainSettings): Drafts {
 	return Object.fromEntries(
-		settings.projects.map((project) => [project.workspace_identity, project.resolved_scope_id]),
+		settings.projects.map((project) => [
+			project.workspace_identity,
+			project.suggested_scope_id ?? project.resolved_scope_id,
+		]),
 	);
 }
 
@@ -62,6 +65,14 @@ function warningKey(warning: ProjectScopeGuardrailWarning, index: number): strin
 function visibleProjectWarnings(project: ProjectScopeCandidate): ProjectScopeGuardrailWarning[] {
 	return (project.guardrail_warnings ?? []).filter(
 		(warning) => warning.severity === "warning" || warning.code === "unknown_project_local_only",
+	);
+}
+
+function isUsingSuggestion(project: ProjectScopeCandidate, currentValue: string): boolean {
+	return Boolean(
+		project.suggested_scope_id &&
+			currentValue === project.suggested_scope_id &&
+			project.suggested_scope_id !== project.resolved_scope_id,
 	);
 }
 
@@ -218,6 +229,10 @@ export function SharingDomainsPanel() {
 				const unchanged = currentValue === project.resolved_scope_id;
 				const assignable = canAssignProject(project);
 				const currentScopeName = scopeName(settings.scopes, project.resolved_scope_id);
+				const usingSuggestion = isUsingSuggestion(project, currentValue);
+				const suggestedScopeName = project.suggested_scope_id
+					? scopeName(settings.scopes, project.suggested_scope_id)
+					: null;
 				const pendingConfirmation =
 					confirmation?.workspaceIdentity === project.workspace_identity ? confirmation : null;
 				const canRemoveProjectMapping =
@@ -247,6 +262,16 @@ export function SharingDomainsPanel() {
 						<div className="small">
 							Current default: {currentScopeName} · {resolutionLabel(project.resolution_reason)}
 						</div>
+						{project.suggested_scope_id && project.suggestion_reason ? (
+							<div className="settings-note" role="status">
+								<strong>Suggested mapping: {suggestedScopeName}</strong>
+								<div>{project.suggestion_reason}</div>
+								<div>
+									Folders, paths, and git remotes are hints only. Saving this mapping requires your
+									confirmation and does not grant any peer access.
+								</div>
+							</div>
+						) : null}
 						<GuardrailMessages warnings={visibleProjectWarnings(project)} />
 						{!assignable ? (
 							<div className="settings-note">
@@ -294,7 +319,11 @@ export function SharingDomainsPanel() {
 								onClick={() => void saveProject(project)}
 								type="button"
 							>
-								{saving ? "Saving…" : "Save Sharing domain"}
+								{saving
+									? "Saving…"
+									: usingSuggestion
+										? "Confirm suggested mapping"
+										: "Save Sharing domain"}
 							</button>
 							<button
 								className="settings-button"

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5916,6 +5916,59 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("returns confirmed setup suggestion fields in Sharing domain settings", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				store.db
+					.prepare("UPDATE sessions SET cwd = ?, git_remote = ?, project = ? WHERE id = ?")
+					.run(
+						"/workspace/work/exampleco/api",
+						"https://git.example.invalid/exampleco/api.git",
+						"api",
+						sessionId,
+					);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "suggested project domain candidate",
+					metadata: {},
+				});
+				const now = new Date().toISOString();
+				store.db
+					.prepare(
+						`INSERT INTO replication_scopes(
+							scope_id, label, kind, authority_type, membership_epoch, status, created_at, updated_at
+						 ) VALUES ('exampleco-work', 'ExampleCo Work', 'team', 'coordinator', 1, 'active', ?, ?)`,
+					)
+					.run(now, now);
+
+				const settingsRes = await app.request("/api/sync/sharing-domains/settings");
+				expect(settingsRes.status).toBe(200);
+				const settings = (await settingsRes.json()) as {
+					projects: Array<{
+						display_project: string;
+						resolved_scope_id: string;
+						suggested_scope_id: string | null;
+						suggestion_reason: string | null;
+						suggestion_signal: string | null;
+					}>;
+				};
+
+				expect(settings.projects.find((item) => item.display_project === "api")).toMatchObject({
+					resolved_scope_id: "local-default",
+					suggested_scope_id: "exampleco-work",
+					suggestion_reason: expect.stringContaining("git remote"),
+					suggestion_signal: "git_remote",
+				});
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("requires confirmation before saving risky Sharing domain mappings", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {
@@ -5935,7 +5988,7 @@ describe("viewer-server", () => {
 					method: "PUT",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
-						project_pattern: "/Users/adam/*",
+						project_pattern: "/home/fixture-user/*",
 						scope_id: "acme-work",
 					}),
 				});
@@ -5971,7 +6024,7 @@ describe("viewer-server", () => {
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
 						confirmed_guardrails: ["broad_org_domain_pattern", "home_directory_org_domain_pattern"],
-						project_pattern: "/Users/adam/*",
+						project_pattern: "/home/fixture-user/*",
 						scope_id: "acme-work",
 					}),
 				});
@@ -5992,7 +6045,7 @@ describe("viewer-server", () => {
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
 						confirmed_guardrail_tokens: unconfirmed.required_guardrail_tokens,
-						project_pattern: "/Users/adam/*",
+						project_pattern: "/home/fixture-user/*",
 						scope_id: "acme-work",
 					}),
 				});
@@ -6420,19 +6473,19 @@ describe("viewer-server", () => {
 				const createRes = await app.request("/api/sync/actors", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ display_name: "Adam shadow" }),
+					body: JSON.stringify({ display_name: "Fixture shadow" }),
 				});
 				expect(createRes.status).toBe(200);
 				const created = (await createRes.json()) as { actor_id: string; display_name: string };
-				expect(created.display_name).toBe("Adam shadow");
+				expect(created.display_name).toBe("Fixture shadow");
 
 				const renameRes = await app.request("/api/sync/actors/rename", {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ actor_id: created.actor_id, display_name: "Adam remote" }),
+					body: JSON.stringify({ actor_id: created.actor_id, display_name: "Fixture remote" }),
 				});
 				expect(renameRes.status).toBe(200);
-				expect((await renameRes.json()).display_name).toBe("Adam remote");
+				expect((await renameRes.json()).display_name).toBe("Fixture remote");
 
 				const localActor = store.db
 					.prepare("SELECT actor_id FROM actors WHERE is_local = 1 LIMIT 1")
@@ -7303,7 +7356,7 @@ describe("viewer-server", () => {
 			globalThis.fetch = fetchMock as typeof fetch;
 			process.env.CODEMEM_CONFIG = configPath;
 			process.env.CODEMEM_KEYS_DIR = keysDir;
-			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Adam" }));
+			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Fixture User" }));
 			const { app, getStore, cleanup } = createTestApp();
 			try {
 				await app.request("/api/stats");
@@ -7360,7 +7413,7 @@ describe("viewer-server", () => {
 			globalThis.fetch = fetchMock as typeof fetch;
 			process.env.CODEMEM_CONFIG = configPath;
 			process.env.CODEMEM_KEYS_DIR = keysDir;
-			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Adam" }));
+			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Fixture User" }));
 			const { app, getStore, cleanup } = createTestApp();
 			try {
 				await app.request("/api/stats");
@@ -7411,7 +7464,7 @@ describe("viewer-server", () => {
 			globalThis.fetch = fetchMock as typeof fetch;
 			process.env.CODEMEM_CONFIG = configPath;
 			process.env.CODEMEM_KEYS_DIR = keysDir;
-			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Adam" }));
+			writeFileSync(configPath, JSON.stringify({ actor_display_name: "Fixture User" }));
 			const { app, getStore, cleanup } = createTestApp();
 			try {
 				await app.request("/api/stats");


### PR DESCRIPTION
## Description
Adds confirmed project-to-Sharing-domain suggestions from canonical project signals so unknown projects can surface likely domains without silently creating mappings. Suggestions remain confirmation-only and preserve the rule that paths/remotes are hints, not access grants.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted tests)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx packages/ui/src/tabs/projects.test.ts packages/ui/src/lib/state.test.ts`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "searchable project inventory|confirmed setup suggestion|updates local Sharing domain project mappings|risky Sharing domain"`
- `pnpm run tsc`
- `pnpm run lint` (passes; reports pre-existing FeedItemCard noExtraBooleanCast infos)
- `pnpm --filter @codemem/ui build`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced