### PR TITLE
feat(ui): add read-only Projects inventory screen

### DIFF
--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -27,6 +27,7 @@ import { getTheme, initThemeToggle, setTheme } from "./lib/theme";
 import { initCoordinatorAdminTab, loadCoordinatorAdminData } from "./tabs/coordinator-admin";
 import { initFeedTab, loadFeedData, updateFeedView } from "./tabs/feed";
 import { initHealthTab, loadHealthData } from "./tabs/health";
+import { initProjectsTab, loadProjectsData } from "./tabs/projects";
 import { initSettings, isSettingsOpen, loadConfigData } from "./tabs/settings";
 import {
 	initSyncTab,
@@ -341,6 +342,9 @@ async function doRefresh() {
 		if (refreshTab === "feed") {
 			promises.push(loadFeedData());
 		}
+		if (refreshTab === "projects") {
+			promises.push(loadProjectsData());
+		}
 		// Sync data is needed by both Sync tab and Health tab (health cards derive sync state)
 		if (refreshTab === "sync" || refreshTab === "health") {
 			promises.push(loadSyncData());
@@ -395,6 +399,7 @@ initTabs();
 // Tab modules
 initFeedTab();
 initHealthTab();
+initProjectsTab(() => refresh());
 initSyncTab(() => refresh());
 initCoordinatorAdminTab();
 initSettings(stopPolling, startPolling, () => refresh());

--- a/packages/ui/src/lib/state.ts
+++ b/packages/ui/src/lib/state.ts
@@ -3,8 +3,8 @@
 import type { UiSyncViewModel } from "../tabs/sync/view-model";
 
 export type RefreshState = "idle" | "refreshing" | "paused" | "error";
-export type TabId = "feed" | "health" | "sync" | "coordinator-admin";
-export const ALL_TAB_IDS: TabId[] = ["feed", "health", "sync", "coordinator-admin"];
+export type TabId = "feed" | "health" | "projects" | "sync" | "coordinator-admin";
+export const ALL_TAB_IDS: TabId[] = ["feed", "health", "projects", "sync", "coordinator-admin"];
 
 /* ── Cached server payload shapes ─────────────────────────── */
 

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -1,0 +1,187 @@
+import * as api from "../lib/api";
+import type { ProjectScopeInventoryProject } from "../lib/api/sync";
+
+type RefreshFn = () => void;
+
+const STATUS_OPTIONS = [
+	["", "All statuses"],
+	["local_only", "Local only"],
+	["unmapped", "Unmapped"],
+	["suggested", "Suggested"],
+	["explicitly_mapped", "Explicitly mapped"],
+	["legacy_review", "Legacy review"],
+	["needs_attention", "Needs attention"],
+] as const;
+
+let refreshProjects: RefreshFn | null = null;
+let currentOffset = 0;
+const lastLimit = 50;
+
+function el<T extends HTMLElement>(id: string): T | null {
+	return document.getElementById(id) as T | null;
+}
+
+function formatStatus(status: string): string {
+	return STATUS_OPTIONS.find(([value]) => value === status)?.[1] ?? status.replaceAll("_", " ");
+}
+
+function formatResolution(reason: string): string {
+	switch (reason) {
+		case "exact_mapping":
+			return "explicit project mapping";
+		case "pattern_mapping":
+			return "pattern mapping";
+		case "explicit_override":
+			return "explicit override";
+		default:
+			return "local-only fallback";
+	}
+}
+
+function formatLatest(value: string | null): string {
+	if (!value) return "No recent sessions";
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return value;
+	return date.toLocaleString();
+}
+
+function strongestSignal(project: ProjectScopeInventoryProject): string {
+	if (project.git_remote) return project.git_remote;
+	if (project.cwd) return project.cwd;
+	return project.workspace_identity;
+}
+
+function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
+	const row = document.createElement("article");
+	row.className = "project-inventory-row";
+	const header = document.createElement("div");
+	header.className = "project-inventory-row-header";
+
+	const title = document.createElement("div");
+	title.className = "project-inventory-title";
+	title.textContent = project.display_project;
+	header.appendChild(title);
+
+	const domain = document.createElement("div");
+	domain.className = "project-inventory-domain";
+	domain.textContent = project.resolved_scope_id;
+	header.appendChild(domain);
+	row.appendChild(header);
+
+	const meta = document.createElement("div");
+	meta.className = "project-inventory-meta";
+	meta.textContent = `${formatResolution(project.resolution_reason)} · ${project.identity_source} · ${formatLatest(project.latest_session_at)}`;
+	row.appendChild(meta);
+
+	const signal = document.createElement("div");
+	signal.className = "project-inventory-signal mono";
+	signal.textContent = strongestSignal(project);
+	row.appendChild(signal);
+
+	if (project.statuses.length > 0) {
+		const badges = document.createElement("div");
+		badges.className = "project-inventory-badges";
+		for (const status of project.statuses) {
+			const badge = document.createElement("span");
+			badge.className = `project-status-badge ${status}`;
+			badge.textContent = formatStatus(status);
+			badges.appendChild(badge);
+		}
+		row.appendChild(badges);
+	}
+
+	const detail = document.createElement("details");
+	detail.className = "project-inventory-details";
+	const summary = document.createElement("summary");
+	summary.textContent = "Identity and mapping details";
+	detail.appendChild(summary);
+	const list = document.createElement("dl");
+	list.className = "project-detail-grid";
+	const fields: Array<[string, string | number | null | undefined]> = [
+		["Workspace identity", project.workspace_identity],
+		["Project", project.project],
+		["CWD", project.cwd],
+		["Git remote", project.git_remote],
+		["Git branch", project.git_branch],
+		["Suggested domain", project.suggested_scope_id],
+		["Suggestion reason", project.suggestion_reason],
+		["Sessions", project.session_count],
+		["Memories", project.memory_count ?? "count unavailable"],
+	];
+	for (const [label, value] of fields) {
+		const dt = document.createElement("dt");
+		dt.textContent = label;
+		const dd = document.createElement("dd");
+		dd.textContent = value == null || value === "" ? "—" : String(value);
+		list.append(dt, dd);
+	}
+	detail.appendChild(list);
+	row.appendChild(detail);
+	return row;
+}
+
+function renderEmpty(message: string) {
+	const list = el<HTMLDivElement>("projectsInventoryList");
+	if (!list) return;
+	list.textContent = "";
+	const empty = document.createElement("div");
+	empty.className = "settings-note";
+	empty.textContent = message;
+	list.appendChild(empty);
+}
+
+export async function loadProjectsData() {
+	const meta = el<HTMLDivElement>("projectsInventoryMeta");
+	const list = el<HTMLDivElement>("projectsInventoryList");
+	if (!meta || !list) return;
+	meta.textContent = "Loading project inventory…";
+	try {
+		const result = await api.loadProjectScopeInventory({
+			limit: lastLimit,
+			offset: currentOffset,
+			q: el<HTMLInputElement>("projectsSearch")?.value.trim() || undefined,
+			status: el<HTMLSelectElement>("projectsStatusFilter")?.value || undefined,
+		});
+		list.textContent = "";
+		if (result.projects.length === 0) {
+			renderEmpty("No projects match those filters.");
+		} else {
+			for (const project of result.projects) list.appendChild(renderProjectRow(project));
+		}
+		meta.textContent = `${result.total} project${result.total === 1 ? "" : "s"} found · showing ${result.offset + 1}-${Math.min(result.offset + result.projects.length, result.total)}`;
+		const prev = el<HTMLButtonElement>("projectsPrevPage");
+		const next = el<HTMLButtonElement>("projectsNextPage");
+		if (prev) prev.disabled = result.offset === 0;
+		if (next) next.disabled = !result.has_more;
+	} catch (error) {
+		meta.textContent = "Project inventory failed to load.";
+		renderEmpty(error instanceof Error ? error.message : "Unable to load project inventory.");
+	}
+}
+
+export function initProjectsTab(refresh: RefreshFn) {
+	refreshProjects = refresh;
+	const status = el<HTMLSelectElement>("projectsStatusFilter");
+	if (status && status.options.length === 0) {
+		for (const [value, label] of STATUS_OPTIONS) {
+			const option = document.createElement("option");
+			option.value = value;
+			option.textContent = label;
+			status.appendChild(option);
+		}
+	}
+	const requestRefresh = () => {
+		currentOffset = 0;
+		refreshProjects?.();
+	};
+	el<HTMLInputElement>("projectsSearch")?.addEventListener("input", requestRefresh);
+	status?.addEventListener("change", requestRefresh);
+	el<HTMLButtonElement>("projectsPrevPage")?.addEventListener("click", () => {
+		currentOffset = Math.max(0, currentOffset - lastLimit);
+		refreshProjects?.();
+	});
+	el<HTMLButtonElement>("projectsNextPage")?.addEventListener("click", () => {
+		currentOffset += lastLimit;
+		refreshProjects?.();
+	});
+}

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1237,6 +1237,78 @@
         box-shadow: 0 0 0 3px var(--focus-ring);
       }
 
+      .projects-toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sp-3);
+        align-items: center;
+        margin: var(--sp-4) 0 var(--sp-3);
+      }
+      .projects-toolbar .feed-search { flex: 1 1 320px; }
+      .projects-toolbar select {
+        padding: var(--sp-2) var(--sp-3);
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--input-bg);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 13px;
+      }
+      .project-inventory-list {
+        display: grid;
+        gap: var(--sp-3);
+        margin-top: var(--sp-4);
+      }
+      .project-inventory-row {
+        padding: var(--sp-4);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        background: var(--surface-1);
+      }
+      .project-inventory-row-header {
+        display: flex;
+        justify-content: space-between;
+        gap: var(--sp-3);
+        align-items: flex-start;
+      }
+      .project-inventory-title { font-size: 15px; font-weight: 650; color: var(--text-primary); }
+      .project-inventory-domain { font-family: var(--font-mono); font-size: 12px; color: var(--accent); }
+      .project-inventory-meta, .project-inventory-signal {
+        margin-top: var(--sp-2);
+        color: var(--text-secondary);
+        font-size: 12px;
+      }
+      .project-inventory-signal { overflow-wrap: anywhere; }
+      .project-inventory-badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--sp-2);
+        margin-top: var(--sp-3);
+      }
+      .project-status-badge {
+        padding: 2px 8px;
+        border-radius: var(--radius-pill);
+        background: var(--surface-2);
+        color: var(--text-secondary);
+        font-size: 11px;
+        border: 1px solid var(--border);
+      }
+      .project-status-badge.needs_attention,
+      .project-status-badge.legacy_review { color: var(--accent-warm); background: var(--accent-warm-subtle); }
+      .project-status-badge.suggested { color: var(--accent); background: var(--accent-subtle); }
+      .project-inventory-details { margin-top: var(--sp-3); }
+      .project-inventory-details summary { cursor: pointer; color: var(--text-secondary); font-size: 12px; }
+      .project-detail-grid {
+        display: grid;
+        grid-template-columns: minmax(130px, max-content) 1fr;
+        gap: var(--sp-2) var(--sp-3);
+        margin-top: var(--sp-3);
+        font-size: 12px;
+      }
+      .project-detail-grid dt { color: var(--text-tertiary); }
+      .project-detail-grid dd { margin: 0; overflow-wrap: anywhere; color: var(--text-primary); }
+      .projects-pagination { margin-top: var(--sp-4); }
+
       /* 36×36 square icon buttons — theme toggle, settings gear. */
       .icon-button {
         width: 36px;
@@ -3307,6 +3379,7 @@
     <nav class="tab-bar" aria-label="Main navigation">
       <button class="tab-btn active" id="tabBtn-feed">Feed</button>
       <button class="tab-btn" id="tabBtn-health">Health</button>
+      <button class="tab-btn" id="tabBtn-projects">Projects</button>
       <button class="tab-btn" id="tabBtn-sync">Sync</button>
       <button class="tab-btn" id="tabBtn-coordinator-admin">Coordinator Admin</button>
     </nav>
@@ -3555,6 +3628,28 @@
           <h2>Current session</h2>
           <div class="section-meta" id="sessionMeta">No injections yet</div>
           <div class="grid-2" id="sessionGrid"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Tab: Projects ───────────────────────────────────── -->
+    <div class="tab-panel" id="tab-projects" hidden>
+      <div class="card" style="animation-delay: 0s">
+        <div class="section-header">
+          <div>
+            <h2>Projects</h2>
+            <div class="section-meta">Review known projects and worktrees, then verify which Sharing domain future memories use.</div>
+          </div>
+        </div>
+        <div class="projects-toolbar">
+          <input class="feed-search" id="projectsSearch" placeholder="Search project, path, git remote, or workspace id…" />
+          <select id="projectsStatusFilter" aria-label="Project status filter"></select>
+        </div>
+        <div class="section-meta" id="projectsInventoryMeta">Loading project inventory…</div>
+        <div class="project-inventory-list" id="projectsInventoryList" aria-live="polite"></div>
+        <div class="section-actions projects-pagination">
+          <button class="settings-button" id="projectsPrevPage" type="button">Previous</button>
+          <button class="settings-button" id="projectsNextPage" type="button">Next</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description
Adds a first-class Projects tab that shows a searchable, filterable read-only project/worktree inventory with Sharing-domain resolution, status badges, identity details, suggestions, and counts. This gives users a visible home for project/domain diagnosis outside the Settings modal.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted tests)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx packages/ui/src/tabs/projects.test.ts packages/ui/src/lib/state.test.ts`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "searchable project inventory|confirmed setup suggestion|updates local Sharing domain project mappings|risky Sharing domain"`
- `pnpm run tsc`
- `pnpm run lint` (passes; reports pre-existing FeedItemCard noExtraBooleanCast infos)
- `pnpm --filter @codemem/ui build`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced