### PR TITLE
feat(ui): allow Projects domain corrections

### DIFF
--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -286,6 +286,23 @@ describe("project scope settings", () => {
 		]);
 	});
 
+	it("rejects inert unmapped and legacy-review assignments", () => {
+		expect(() =>
+			upsertProjectScopeSettingsMapping(db, {
+				workspace_identity: "unmapped:abc123",
+				project_pattern: "unknown",
+				scope_id: LOCAL_DEFAULT_SCOPE_ID,
+			}),
+		).toThrow(/unmapped projects cannot be assigned/);
+		expect(() =>
+			upsertProjectScopeSettingsMapping(db, {
+				workspace_identity: "workspace:legacy-target",
+				project_pattern: "legacy-target",
+				scope_id: "legacy-shared-review",
+			}),
+		).toThrow(/not an assignable Sharing domain/);
+	});
+
 	it("does not guess when multiple scopes match a project signal equally", () => {
 		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
 		insertScope(db, { scopeId: "exampleco-client", label: "ExampleCo Client", kind: "client" });

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -594,6 +594,9 @@ function getProjectScopeSettingsMappingByWorkspaceIdentity(
 }
 
 function assertActiveScope(db: Database, scopeId: string): void {
+	if (scopeId === LEGACY_SHARED_REVIEW_SCOPE_ID) {
+		throw new Error("legacy-shared-review is a review bucket, not an assignable Sharing domain");
+	}
 	const row = db
 		.prepare("SELECT 1 FROM replication_scopes WHERE scope_id = ? AND status = 'active' LIMIT 1")
 		.get(scopeId);
@@ -886,6 +889,9 @@ export function upsertProjectScopeSettingsMapping(
 	assertActiveScope(db, scopeId);
 
 	const { existing, workspaceIdentity } = draft;
+	if (workspaceIdentity?.startsWith("unmapped:")) {
+		throw new Error("unmapped projects cannot be assigned to a Sharing domain");
+	}
 	const projectPattern = draft.projectPattern;
 	if (!projectPattern) throw new Error("project_pattern or workspace_identity is required");
 	assertCanonicalPattern(workspaceIdentity, projectPattern);

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/api", () => ({
+	deleteSharingDomainProjectMapping: vi.fn(),
+	loadProjectScopeInventory: vi.fn(),
+	loadSharingDomainSettings: vi.fn(),
+	saveSharingDomainProjectMapping: vi.fn(),
+	SharingDomainGuardrailConfirmationError: class SharingDomainGuardrailConfirmationError extends Error {
+		requiredGuardrailTokens: string[];
+		guardrailWarnings: Array<{ message: string }>;
+
+		constructor(input: {
+			required_guardrail_tokens?: string[];
+			guardrail_warnings?: Array<{ message: string }>;
+		}) {
+			super("Sharing domain guardrail confirmation required");
+			this.requiredGuardrailTokens = input.required_guardrail_tokens ?? [];
+			this.guardrailWarnings = input.guardrail_warnings ?? [];
+		}
+	},
+}));
+
+vi.mock("../lib/notice", () => ({ showGlobalNotice: vi.fn() }));
+
+import * as api from "../lib/api";
+import type { ProjectScopeInventoryProject } from "../lib/api/sync";
+import { initProjectsTab, loadProjectsData } from "./projects";
+
+function project(
+	overrides: Partial<ProjectScopeInventoryProject> = {},
+): ProjectScopeInventoryProject {
+	return {
+		cwd: "/workspace/work/exampleco/api",
+		display_project: "api",
+		git_branch: "main",
+		git_remote: "https://git.example.invalid/exampleco/api.git",
+		guardrail_warnings: [],
+		identity_source: "git_remote",
+		latest_session_at: "2026-05-06T00:00:00Z",
+		mapping_id: null,
+		matched_pattern: null,
+		memory_count: 1,
+		project: "api",
+		resolution_reason: "local_default",
+		resolved_scope_id: "local-default",
+		session_count: 1,
+		statuses: ["local_only"],
+		suggested_scope_id: null,
+		suggestion_reason: null,
+		suggestion_signal: null,
+		workspace_identity: "https://git.example.invalid/exampleco/api.git",
+		...overrides,
+	};
+}
+
+function mountProjectsDom() {
+	document.body.innerHTML = `
+		<input id="projectsSearch" />
+		<select id="projectsStatusFilter"></select>
+		<div id="projectsInventoryMeta"></div>
+		<div id="projectsInventoryList"></div>
+		<button id="projectsPrevPage"></button>
+		<button id="projectsNextPage"></button>
+	`;
+}
+
+describe("Projects tab", () => {
+	beforeEach(() => {
+		mountProjectsDom();
+		vi.mocked(api.loadSharingDomainSettings).mockResolvedValue({
+			local_default_scope_id: "local-default",
+			mappings: [],
+			projects: [],
+			scopes: [
+				{
+					authority_type: "local",
+					kind: "system",
+					label: "Local only",
+					scope_id: "local-default",
+					status: "active",
+				},
+				{
+					authority_type: "local",
+					kind: "system",
+					label: "Legacy shared review",
+					scope_id: "legacy-shared-review",
+					status: "active",
+				},
+				{
+					authority_type: "coordinator",
+					kind: "team",
+					label: "ExampleCo Work",
+					scope_id: "exampleco-work",
+					status: "active",
+				},
+			],
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		document.body.innerHTML = "";
+	});
+
+	it("shows empty inventory without bogus pagination range", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 50,
+			offset: 0,
+			projects: [],
+			total: 0,
+		});
+
+		initProjectsTab(() => {});
+		await loadProjectsData();
+
+		expect(document.getElementById("projectsInventoryMeta")?.textContent).toBe("0 projects found");
+		expect(document.body.textContent).not.toContain("showing 1-0");
+	});
+
+	it("does not render assignment controls for unmapped projects", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 50,
+			offset: 0,
+			projects: [
+				project({
+					identity_source: "unmapped",
+					statuses: ["local_only", "unmapped"],
+					workspace_identity: "unmapped:abc123",
+				}),
+			],
+			total: 1,
+		});
+
+		await loadProjectsData();
+
+		expect(document.body.textContent).toContain("missing a stable path");
+		expect(document.querySelector(".project-domain-select")).toBeNull();
+	});
+
+	it("excludes legacy review from assignment options", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 50,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+
+		await loadProjectsData();
+
+		const values = Array.from(document.querySelectorAll("option")).map(
+			(option) => (option as HTMLOptionElement).value,
+		);
+		expect(values).toContain("local-default");
+		expect(values).toContain("exampleco-work");
+		expect(values).not.toContain("legacy-shared-review");
+	});
+});

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -1,5 +1,10 @@
 import * as api from "../lib/api";
-import type { ProjectScopeInventoryProject } from "../lib/api/sync";
+import type {
+	ProjectScopeGuardrailWarning,
+	ProjectScopeInventoryProject,
+	SharingDomainScope,
+} from "../lib/api/sync";
+import { showGlobalNotice } from "../lib/notice";
 
 type RefreshFn = () => void;
 
@@ -16,6 +21,11 @@ const STATUS_OPTIONS = [
 let refreshProjects: RefreshFn | null = null;
 let currentOffset = 0;
 const lastLimit = 50;
+let scopes: SharingDomainScope[] = [];
+const pendingConfirmations = new Map<
+	string,
+	{ requiredGuardrailTokens: string[]; scopeId: string; warnings: ProjectScopeGuardrailWarning[] }
+>();
 
 function el<T extends HTMLElement>(id: string): T | null {
 	return document.getElementById(id) as T | null;
@@ -51,6 +61,168 @@ function strongestSignal(project: ProjectScopeInventoryProject): string {
 	return project.workspace_identity;
 }
 
+function scopeLabel(scopeId: string | null | undefined): string {
+	if (!scopeId) return "—";
+	const scope = scopes.find((item) => item.scope_id === scopeId);
+	return scope?.label ? `${scope.label} (${scope.scope_id})` : scopeId;
+}
+
+function assignableScopes(): SharingDomainScope[] {
+	return scopes.filter((scope) => scope.scope_id !== "legacy-shared-review");
+}
+
+async function saveProjectMapping(
+	project: ProjectScopeInventoryProject,
+	scopeId: string,
+	confirmedGuardrailTokens: string[] = [],
+) {
+	try {
+		await api.saveSharingDomainProjectMapping({
+			...(project.mapping_id && project.resolution_reason === "exact_mapping"
+				? { id: project.mapping_id }
+				: {}),
+			...(confirmedGuardrailTokens.length > 0
+				? { confirmed_guardrail_tokens: confirmedGuardrailTokens }
+				: {}),
+			project_pattern: project.display_project,
+			scope_id: scopeId,
+			workspace_identity: project.workspace_identity,
+		});
+		pendingConfirmations.delete(project.workspace_identity);
+		showGlobalNotice("Project Sharing domain updated. Device access grants are unchanged.");
+		refreshProjects?.();
+	} catch (error) {
+		if (error instanceof api.SharingDomainGuardrailConfirmationError) {
+			pendingConfirmations.set(project.workspace_identity, {
+				requiredGuardrailTokens: error.requiredGuardrailTokens,
+				scopeId,
+				warnings: error.guardrailWarnings,
+			});
+			refreshProjects?.();
+			return;
+		}
+		showGlobalNotice(
+			error instanceof Error ? error.message : "Unable to update project Sharing domain.",
+			"warning",
+		);
+	}
+}
+
+async function removeProjectMapping(project: ProjectScopeInventoryProject) {
+	if (project.mapping_id == null) return;
+	try {
+		await api.deleteSharingDomainProjectMapping(project.mapping_id);
+		pendingConfirmations.delete(project.workspace_identity);
+		showGlobalNotice("Project Sharing domain mapping removed. The next fallback now applies.");
+		refreshProjects?.();
+	} catch (error) {
+		showGlobalNotice(
+			error instanceof Error ? error.message : "Unable to remove project Sharing domain mapping.",
+			"warning",
+		);
+	}
+}
+
+function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElement {
+	const actions = document.createElement("div");
+	actions.className = "project-inventory-actions";
+	if (project.identity_source === "unmapped") {
+		const note = document.createElement("div");
+		note.className = "settings-note";
+		note.textContent =
+			"This project is missing a stable path, git remote, or workspace id. It stays Local only until it has a stable identity.";
+		actions.appendChild(note);
+		return actions;
+	}
+	const label = document.createElement("label");
+	label.className = "sr-only";
+	const selectId = `project-domain-${project.workspace_identity.replace(/[^a-z0-9_-]/gi, "-")}`;
+	label.htmlFor = selectId;
+	label.textContent = `Sharing domain for ${project.display_project}`;
+	const select = document.createElement("select");
+	select.id = selectId;
+	select.className = "project-domain-select";
+	const currentAssignable = assignableScopes().some(
+		(scope) => scope.scope_id === project.resolved_scope_id,
+	);
+	if (!currentAssignable && project.resolved_scope_id) {
+		const current = document.createElement("option");
+		current.value = project.resolved_scope_id;
+		current.textContent = `${scopeLabel(project.resolved_scope_id)} — not assignable`;
+		current.disabled = true;
+		select.appendChild(current);
+	}
+	for (const scope of assignableScopes()) {
+		const option = document.createElement("option");
+		option.value = scope.scope_id;
+		option.textContent = scope.label ? `${scope.label} · ${scope.scope_id}` : scope.scope_id;
+		select.appendChild(option);
+	}
+	select.value = project.suggested_scope_id ?? project.resolved_scope_id;
+
+	const save = document.createElement("button");
+	save.className = "settings-button";
+	save.type = "button";
+	save.textContent =
+		project.suggested_scope_id && select.value === project.suggested_scope_id
+			? "Confirm suggestion"
+			: "Save domain";
+	save.disabled = select.value === project.resolved_scope_id && !currentAssignable;
+	save.addEventListener("click", () => void saveProjectMapping(project, select.value));
+	select.addEventListener("change", () => {
+		save.textContent = "Save domain";
+		save.disabled = false;
+	});
+
+	const keepLocal = document.createElement("button");
+	keepLocal.className = "settings-button";
+	keepLocal.type = "button";
+	keepLocal.textContent = "Keep local-only";
+	keepLocal.addEventListener("click", () => void saveProjectMapping(project, "local-default"));
+
+	const remove = document.createElement("button");
+	remove.className = "settings-button";
+	remove.type = "button";
+	remove.textContent = "Remove mapping";
+	remove.disabled = project.mapping_id == null || project.resolution_reason !== "exact_mapping";
+	remove.addEventListener("click", () => void removeProjectMapping(project));
+
+	actions.append(label, select, save, keepLocal, remove);
+	const pending = pendingConfirmations.get(project.workspace_identity);
+	if (pending) {
+		const warningBox = document.createElement("div");
+		warningBox.className = "settings-note project-guardrail-confirmation";
+		warningBox.setAttribute("role", "alert");
+		const title = document.createElement("strong");
+		title.textContent = "Review before saving this Sharing domain.";
+		const list = document.createElement("ul");
+		for (const warning of pending.warnings) {
+			const item = document.createElement("li");
+			item.textContent = warning.message;
+			list.appendChild(item);
+		}
+		const confirm = document.createElement("button");
+		confirm.className = "settings-button";
+		confirm.type = "button";
+		confirm.textContent = "Confirm and save";
+		confirm.addEventListener(
+			"click",
+			() => void saveProjectMapping(project, pending.scopeId, pending.requiredGuardrailTokens),
+		);
+		const cancel = document.createElement("button");
+		cancel.className = "settings-button";
+		cancel.type = "button";
+		cancel.textContent = "Cancel";
+		cancel.addEventListener("click", () => {
+			pendingConfirmations.delete(project.workspace_identity);
+			refreshProjects?.();
+		});
+		warningBox.append(title, list, confirm, cancel);
+		actions.appendChild(warningBox);
+	}
+	return actions;
+}
+
 function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 	const row = document.createElement("article");
 	row.className = "project-inventory-row";
@@ -64,7 +236,7 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 
 	const domain = document.createElement("div");
 	domain.className = "project-inventory-domain";
-	domain.textContent = project.resolved_scope_id;
+	domain.textContent = scopeLabel(project.resolved_scope_id);
 	header.appendChild(domain);
 	row.appendChild(header);
 
@@ -116,6 +288,7 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 		list.append(dt, dd);
 	}
 	detail.appendChild(list);
+	detail.appendChild(renderProjectActions(project));
 	row.appendChild(detail);
 	return row;
 }
@@ -136,19 +309,26 @@ export async function loadProjectsData() {
 	if (!meta || !list) return;
 	meta.textContent = "Loading project inventory…";
 	try {
-		const result = await api.loadProjectScopeInventory({
-			limit: lastLimit,
-			offset: currentOffset,
-			q: el<HTMLInputElement>("projectsSearch")?.value.trim() || undefined,
-			status: el<HTMLSelectElement>("projectsStatusFilter")?.value || undefined,
-		});
+		const [result, settings] = await Promise.all([
+			api.loadProjectScopeInventory({
+				limit: lastLimit,
+				offset: currentOffset,
+				q: el<HTMLInputElement>("projectsSearch")?.value.trim() || undefined,
+				status: el<HTMLSelectElement>("projectsStatusFilter")?.value || undefined,
+			}),
+			api.loadSharingDomainSettings(),
+		]);
+		scopes = settings.scopes;
 		list.textContent = "";
 		if (result.projects.length === 0) {
 			renderEmpty("No projects match those filters.");
 		} else {
 			for (const project of result.projects) list.appendChild(renderProjectRow(project));
 		}
-		meta.textContent = `${result.total} project${result.total === 1 ? "" : "s"} found · showing ${result.offset + 1}-${Math.min(result.offset + result.projects.length, result.total)}`;
+		meta.textContent =
+			result.total === 0
+				? "0 projects found"
+				: `${result.total} project${result.total === 1 ? "" : "s"} found · showing ${result.offset + 1}-${Math.min(result.offset + result.projects.length, result.total)}`;
 		const prev = el<HTMLButtonElement>("projectsPrevPage");
 		const next = el<HTMLButtonElement>("projectsNextPage");
 		if (prev) prev.disabled = result.offset === 0;

--- a/packages/ui/src/tabs/settings/components/SharingDomainsPanel.tsx
+++ b/packages/ui/src/tabs/settings/components/SharingDomainsPanel.tsx
@@ -127,10 +127,12 @@ export function SharingDomainsPanel() {
 
 	const scopeOptions = useMemo(
 		() =>
-			(settings?.scopes ?? []).map((scope) => ({
-				value: scope.scope_id,
-				label: domainLabel(scope),
-			})),
+			(settings?.scopes ?? [])
+				.filter((scope) => scope.scope_id !== "legacy-shared-review")
+				.map((scope) => ({
+					value: scope.scope_id,
+					label: domainLabel(scope),
+				})),
 		[settings?.scopes],
 	);
 

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -1307,6 +1307,27 @@
       }
       .project-detail-grid dt { color: var(--text-tertiary); }
       .project-detail-grid dd { margin: 0; overflow-wrap: anywhere; color: var(--text-primary); }
+      .project-inventory-actions {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: var(--sp-2);
+        margin-top: var(--sp-4);
+      }
+      .project-domain-select {
+        min-width: min(100%, 260px);
+        padding: var(--sp-2) var(--sp-3);
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--input-bg);
+        color: var(--text-primary);
+        font-family: var(--font-sans);
+        font-size: 13px;
+      }
+      .project-guardrail-confirmation {
+        flex-basis: 100%;
+        margin-top: var(--sp-2);
+      }
       .projects-pagination { margin-top: var(--sp-4); }
 
       /* 36×36 square icon buttons — theme toggle, settings gear. */

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5860,6 +5860,28 @@ describe("viewer-server", () => {
 				});
 				expect(invalidScopeRes.status).toBe(400);
 
+				const unmappedLocalRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						workspace_identity: "unmapped:abc123",
+						project_pattern: "unknown",
+						scope_id: "local-default",
+					}),
+				});
+				expect(unmappedLocalRes.status).toBe(400);
+
+				const legacyScopeRes = await app.request("/api/sync/sharing-domains/project-mappings", {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						workspace_identity: project?.workspace_identity,
+						project_pattern: project?.display_project,
+						scope_id: "legacy-shared-review",
+					}),
+				});
+				expect(legacyScopeRes.status).toBe(400);
+
 				const fractionalIdRes = await app.request("/api/sync/sharing-domains/project-mappings", {
 					method: "PUT",
 					headers: { "Content-Type": "application/json" },

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -2414,15 +2414,12 @@ export function syncRoutes(
 				source,
 			};
 			const analysis = analyzeProjectScopeMappingChangeGuardrails(store.db, mappingInput);
-			if (
-				analysis.requested_workspace_identity?.startsWith("unmapped:") &&
-				scopeId !== LOCAL_DEFAULT_SCOPE_ID
-			) {
+			if (analysis.requested_workspace_identity?.startsWith("unmapped:")) {
 				return c.json(
 					{
 						error: "unmapped_project_local_only",
 						message:
-							"Unmapped projects need a stable path, git remote, or workspace id before assigning a non-local Sharing domain.",
+							"Unmapped projects need a stable path, git remote, or workspace id before assigning a Sharing domain.",
 						guardrail_warnings: analysis.warnings,
 					},
 					400,


### PR DESCRIPTION
## Description
Adds correction actions to the Projects tab for confirming suggestions, changing Sharing domains, keeping a project local-only, and removing exact mappings. The action flow preserves guardrail confirmation, blocks unmapped projects from inert assignments, and prevents legacy review from being selected as a normal destination.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted tests)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted validation:
- `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts packages/ui/src/tabs/settings/components/SharingDomainsPanel.test.tsx packages/ui/src/tabs/projects.test.ts packages/ui/src/lib/state.test.ts`
- `pnpm exec vitest run packages/viewer-server/src/index.test.ts --testNamePattern "searchable project inventory|confirmed setup suggestion|updates local Sharing domain project mappings|risky Sharing domain"`
- `pnpm run tsc`
- `pnpm run lint` (passes; reports pre-existing FeedItemCard noExtraBooleanCast infos)
- `pnpm --filter @codemem/ui build`

Review:
- Gordon Ramsay review found two submit-blocking issues; both were fixed and re-reviewed with no remaining blockers.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced