### PR TITLE
fix(viewer): prevent stale Projects tab assets

### DIFF
--- a/packages/ui/src/lib/state.test.ts
+++ b/packages/ui/src/lib/state.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	ALL_TAB_IDS,
 	type CachedCoordinatorAdminStatus,
 	getVisibleTabs,
+	parseTabFromHash,
 	resolveAccessibleTab,
 	shouldShowCoordinatorAdminTab,
 } from "./state";
+
+describe("Viewer tab routing", () => {
+	it("recognizes Projects as a routable top-level tab", () => {
+		expect(ALL_TAB_IDS).toContain("projects");
+		expect(parseTabFromHash("#projects")).toBe("projects");
+	});
+});
 
 describe("Coordinator Admin tab gating", () => {
 	it("keeps the tab visible while admin status is still unknown", () => {

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -222,6 +222,33 @@ function grantSyncScopeToDevices(store: MemoryStore, scopeId: string, deviceIds:
 // ---------------------------------------------------------------------------
 
 describe("viewer-server", () => {
+	it("serves viewer shell and app bundle with cache-safe headers", async () => {
+		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-viewer-static-cache-"));
+		const previousStaticDir = process.env.CODEMEM_VIEWER_STATIC_DIR;
+		process.env.CODEMEM_VIEWER_STATIC_DIR = tmpDir;
+		try {
+			writeFileSync(
+				join(tmpDir, "index.html"),
+				'<!doctype html><script src="/assets/app.js"></script>',
+			);
+			writeFileSync(join(tmpDir, "app.js"), "globalThis.__codememTestApp = true;");
+			const app = createApp({
+				storeFactory: () => createTestStore().store,
+			});
+
+			const index = await app.request("/");
+			expect(index.headers.get("cache-control")).toBe("no-store");
+
+			const bundle = await app.request("/assets/app.js");
+			expect(bundle.status).toBe(200);
+			expect(bundle.headers.get("cache-control")).toBe("no-cache");
+		} finally {
+			if (previousStaticDir == null) delete process.env.CODEMEM_VIEWER_STATIC_DIR;
+			else process.env.CODEMEM_VIEWER_STATIC_DIR = previousStaticDir;
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
 	it("createApp fails with a clear build hint when viewer assets are missing", () => {
 		const tmpDir = mkdtempSync(join(tmpdir(), "codemem-viewer-static-missing-"));
 		const previousStaticDir = process.env.CODEMEM_VIEWER_STATIC_DIR;

--- a/packages/viewer-server/src/index.ts
+++ b/packages/viewer-server/src/index.ts
@@ -105,6 +105,11 @@ export function createApp(opts?: AppOptions) {
 	const staticRoot =
 		process.env.CODEMEM_VIEWER_STATIC_DIR ?? join(import.meta.dirname ?? ".", "../static");
 
+	app.use("/assets/*", async (c, next) => {
+		c.header("Cache-Control", "no-cache");
+		await next();
+	});
+
 	app.use(
 		"/assets/*",
 		serveStatic({
@@ -125,6 +130,7 @@ export function createApp(opts?: AppOptions) {
 		if (c.req.path.startsWith("/api/")) {
 			return c.json({ error: "not found" }, 404);
 		}
+		c.header("Cache-Control", "no-store");
 		return c.html(indexHtml);
 	});
 


### PR DESCRIPTION
## Description
Prevent the Projects tab from showing fresh HTML with stale JavaScript by adding cache-safe headers for the viewer shell and app bundle. Also covers Projects hash routing so the tab is recognized as a routable top-level view.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted Vitest)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run in stack:
- `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/projects.test.ts packages/ui/src/lib/state.test.ts`
- `pnpm run tsc`
- `pnpm run lint` (only pre-existing FeedItemCard info warnings)
- `pnpm --filter @codemem/ui build`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced