### PR TITLE
fix(ui): refine Projects sharing-domain review

### DIFF
--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -145,6 +145,7 @@ describe("project scope settings", () => {
 						expect.objectContaining({
 							code: "basename_collision_review",
 							requires_confirmation: true,
+							severity: "info",
 							related_workspace_identities: ["https://git.example.invalid/oss/api.git"],
 						}),
 					]),
@@ -155,9 +156,97 @@ describe("project scope settings", () => {
 						expect.objectContaining({
 							code: "basename_collision_review",
 							requires_confirmation: true,
+							severity: "info",
 							related_workspace_identities: ["https://git.example.invalid/exampleco/api.git"],
 						}),
 					]),
+				}),
+			]),
+		);
+	});
+
+	it("does not mark same-basename worktrees as persistent needs-attention inventory", () => {
+		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
+		const workSession = insertSession(db, {
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
+			project: "api",
+		});
+		insertMemory(db, workSession);
+		const ossSession = insertSession(db, {
+			cwd: "/workspace/oss/api",
+			gitRemote: "https://git.example.invalid/oss/api.git",
+			project: "api",
+		});
+		insertMemory(db, ossSession, { workspaceId: "shared:oss-api" });
+
+		const inventory = listProjectScopeInventory(db);
+		const work = inventory.projects.find(
+			(project) => project.workspace_identity === "https://git.example.invalid/exampleco/api.git",
+		);
+		if (!work) throw new Error("work project missing");
+
+		expect(work.statuses).not.toContain("needs_attention");
+		expect(work.guardrail_warnings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "basename_collision_review",
+					requires_confirmation: true,
+					severity: "info",
+				}),
+			]),
+		);
+
+		const analysis = analyzeProjectScopeMappingChangeGuardrails(db, {
+			workspace_identity: work.workspace_identity,
+			project_pattern: work.display_project,
+			scope_id: "exampleco-work",
+		});
+		expect(analysis.warnings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "basename_collision_review",
+					requires_confirmation: true,
+				}),
+			]),
+		);
+	});
+
+	it("checks basename collisions beyond the default candidate list when confirming assignments", () => {
+		insertScope(db, { scopeId: "exampleco-work", label: "ExampleCo Work" });
+		const targetSession = insertSession(db, {
+			cwd: "/workspace/work/exampleco/api",
+			gitRemote: "https://git.example.invalid/exampleco/api.git",
+			project: "api",
+		});
+		insertMemory(db, targetSession);
+		const siblingSession = insertSession(db, {
+			cwd: "/workspace/oss/api",
+			gitRemote: "https://git.example.invalid/oss/api.git",
+			project: "api",
+		});
+		insertMemory(db, siblingSession, { workspaceId: "shared:oss-api" });
+		for (let i = 0; i < 260; i++) {
+			const sessionId = insertSession(db, {
+				cwd: `/workspace/noise/project-${i}`,
+				gitRemote: `https://git.example.invalid/noise/project-${i}.git`,
+				project: `project-${i}`,
+			});
+			insertMemory(db, sessionId, { workspaceId: `shared:noise-${i}` });
+		}
+
+		const analysis = analyzeProjectScopeMappingChangeGuardrails(db, {
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
+			project_pattern: "api",
+			scope_id: "exampleco-work",
+		});
+
+		expect(analysis.warnings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "basename_collision_review",
+					requires_confirmation: true,
+					related_workspace_identities: ["https://git.example.invalid/oss/api.git"],
 				}),
 			]),
 		);

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -370,8 +370,8 @@ function projectScopeCandidateGuardrailWarnings(
 	if (related.length > 0) {
 		warnings.push({
 			code: "basename_collision_review",
-			severity: "warning",
-			message: `Another project is also named ${project.display_project}. Review the git remote or path before assigning a non-local Sharing domain.`,
+			severity: "info",
+			message: `Another workspace is also named ${project.display_project}. Review the git remote or path before assigning a non-local Sharing domain.`,
 			requires_confirmation: true,
 			workspace_identity: project.workspace_identity,
 			related_workspace_identities: related.map((candidate) => candidate.workspace_identity),
@@ -660,7 +660,7 @@ export function analyzeProjectScopeMappingChangeGuardrails(
 		);
 	}
 	const candidate = draft.workspaceIdentity
-		? listProjectScopeCandidates(db).find(
+		? listProjectScopeCandidates(db, { limit: null }).find(
 				(project) => project.workspace_identity === draft.workspaceIdentity,
 			)
 		: null;
@@ -701,15 +701,13 @@ export function analyzeProjectScopeMappingChangeGuardrails(
 
 export function listProjectScopeCandidates(
 	db: Database,
-	options: { limit?: number } = {},
+	options: { limit?: number | null } = {},
 ): ProjectScopeCandidate[] {
 	ensureScopeBackfillScopes(db);
-	const limit = Math.max(1, Math.min(options.limit ?? 250, 1000));
+	const limit = options.limit === null ? null : Math.max(1, Math.min(options.limit ?? 250, 1000));
 	const mappings = listProjectScopeSettingsMappings(db);
 	const scopes = listSharingDomainSettingsScopes(db);
-	const rows = db
-		.prepare(
-			`SELECT
+	const sql = `SELECT
 				s.id,
 				s.started_at,
 				s.cwd,
@@ -728,10 +726,10 @@ export function listProjectScopeCandidates(
 			 FROM sessions s
 			 WHERE COALESCE(TRIM(s.git_remote), TRIM(s.cwd), TRIM(s.project), '') <> ''
 			    OR EXISTS (SELECT 1 FROM memory_items mi_candidate WHERE mi_candidate.session_id = s.id)
-			 ORDER BY s.started_at DESC, s.id DESC
-			 LIMIT ?`,
-		)
-		.all(limit) as ProjectScopeCandidateRow[];
+			 ORDER BY s.started_at DESC, s.id DESC${limit == null ? "" : "\n\t\t\t LIMIT ?"}`;
+	const rows = (
+		limit == null ? db.prepare(sql).all() : db.prepare(sql).all(limit)
+	) as ProjectScopeCandidateRow[];
 
 	const seen = new Set<string>();
 	const candidates: ProjectScopeCandidate[] = [];

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -105,7 +105,7 @@ describe("Projects tab", () => {
 	it("shows empty inventory without bogus pagination range", async () => {
 		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
 			has_more: false,
-			limit: 50,
+			limit: 25,
 			offset: 0,
 			projects: [],
 			total: 0,
@@ -116,6 +116,9 @@ describe("Projects tab", () => {
 
 		expect(document.getElementById("projectsInventoryMeta")?.textContent).toBe("0 projects found");
 		expect(document.body.textContent).not.toContain("showing 1-0");
+		expect(api.loadProjectScopeInventory).toHaveBeenCalledWith(
+			expect.objectContaining({ limit: 25 }),
+		);
 	});
 
 	it("does not render assignment controls for unmapped projects", async () => {
@@ -156,5 +159,80 @@ describe("Projects tab", () => {
 		expect(values).toContain("local-default");
 		expect(values).toContain("exampleco-work");
 		expect(values).not.toContain("legacy-shared-review");
+	});
+
+	it("keeps expanded project details open after refresh", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 50,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+
+		await loadProjectsData();
+		const details = document.querySelector("details");
+		expect(details).not.toBeNull();
+		details?.setAttribute("open", "");
+		details?.dispatchEvent(new Event("toggle"));
+
+		await loadProjectsData();
+
+		expect(document.querySelector("details")?.open).toBe(true);
+	});
+
+	it("keeps draft domain selection after refresh", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 25,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		});
+
+		await loadProjectsData();
+		const select = document.querySelector(".project-domain-select") as HTMLSelectElement | null;
+		expect(select).not.toBeNull();
+		if (!select) throw new Error("select missing");
+		select.value = "exampleco-work";
+		select.dispatchEvent(new Event("change"));
+
+		await loadProjectsData();
+
+		expect(
+			(document.querySelector(".project-domain-select") as HTMLSelectElement | null)?.value,
+		).toBe("exampleco-work");
+	});
+
+	it("surfaces suggestions and attention warnings on the collapsed card", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 50,
+			offset: 0,
+			projects: [
+				project({
+					guardrail_warnings: [
+						{
+							code: "basename_collision_review",
+							message: "Another project is also named api.",
+							requires_confirmation: true,
+							severity: "warning",
+						},
+					],
+					statuses: ["suggested", "needs_attention"],
+					suggested_scope_id: "exampleco-work",
+					suggestion_reason:
+						"ExampleCo Work is suggested because the git remote contains exampleco.",
+				}),
+			],
+			total: 1,
+		});
+
+		await loadProjectsData();
+
+		expect(document.body.textContent).toContain("Suggestion: ExampleCo Work is suggested");
+		expect(document.body.textContent).toContain(
+			"Needs attention: Another project is also named api.",
+		);
 	});
 });

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -12,16 +12,18 @@ const STATUS_OPTIONS = [
 	["", "All statuses"],
 	["local_only", "Local only"],
 	["unmapped", "Unmapped"],
-	["suggested", "Suggested"],
+	["suggested", "Suggested assignment"],
 	["explicitly_mapped", "Explicitly mapped"],
 	["legacy_review", "Legacy review"],
-	["needs_attention", "Needs attention"],
+	["needs_attention", "Review before mapping"],
 ] as const;
 
 let refreshProjects: RefreshFn | null = null;
 let currentOffset = 0;
-const lastLimit = 50;
+const lastLimit = 25;
 let scopes: SharingDomainScope[] = [];
+const openProjectDetails = new Set<string>();
+const draftDomainSelections = new Map<string, string>();
 const pendingConfirmations = new Map<
 	string,
 	{ requiredGuardrailTokens: string[]; scopeId: string; warnings: ProjectScopeGuardrailWarning[] }
@@ -89,6 +91,7 @@ async function saveProjectMapping(
 			workspace_identity: project.workspace_identity,
 		});
 		pendingConfirmations.delete(project.workspace_identity);
+		draftDomainSelections.delete(project.workspace_identity);
 		showGlobalNotice("Project Sharing domain updated. Device access grants are unchanged.");
 		refreshProjects?.();
 	} catch (error) {
@@ -113,6 +116,7 @@ async function removeProjectMapping(project: ProjectScopeInventoryProject) {
 	try {
 		await api.deleteSharingDomainProjectMapping(project.mapping_id);
 		pendingConfirmations.delete(project.workspace_identity);
+		draftDomainSelections.delete(project.workspace_identity);
 		showGlobalNotice("Project Sharing domain mapping removed. The next fallback now applies.");
 		refreshProjects?.();
 	} catch (error) {
@@ -158,7 +162,10 @@ function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElemen
 		option.textContent = scope.label ? `${scope.label} · ${scope.scope_id}` : scope.scope_id;
 		select.appendChild(option);
 	}
-	select.value = project.suggested_scope_id ?? project.resolved_scope_id;
+	select.value =
+		draftDomainSelections.get(project.workspace_identity) ??
+		project.suggested_scope_id ??
+		project.resolved_scope_id;
 
 	const save = document.createElement("button");
 	save.className = "settings-button";
@@ -170,6 +177,7 @@ function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElemen
 	save.disabled = select.value === project.resolved_scope_id && !currentAssignable;
 	save.addEventListener("click", () => void saveProjectMapping(project, select.value));
 	select.addEventListener("change", () => {
+		draftDomainSelections.set(project.workspace_identity, select.value);
 		save.textContent = "Save domain";
 		save.disabled = false;
 	});
@@ -250,6 +258,23 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 	signal.textContent = strongestSignal(project);
 	row.appendChild(signal);
 
+	if (project.suggested_scope_id && project.suggested_scope_id !== project.resolved_scope_id) {
+		const suggestion = document.createElement("div");
+		suggestion.className = "settings-note project-suggestion-note";
+		suggestion.textContent = project.suggestion_reason
+			? `Suggestion: ${project.suggestion_reason}`
+			: `Suggestion: map this project to ${scopeLabel(project.suggested_scope_id)}.`;
+		row.appendChild(suggestion);
+	}
+
+	const warnings = project.guardrail_warnings.filter((warning) => warning.severity === "warning");
+	if (warnings.length > 0) {
+		const warningBox = document.createElement("div");
+		warningBox.className = "settings-note project-attention-note";
+		warningBox.textContent = `Needs attention: ${warnings.map((warning) => warning.message).join(" ")}`;
+		row.appendChild(warningBox);
+	}
+
 	if (project.statuses.length > 0) {
 		const badges = document.createElement("div");
 		badges.className = "project-inventory-badges";
@@ -264,6 +289,11 @@ function renderProjectRow(project: ProjectScopeInventoryProject): HTMLElement {
 
 	const detail = document.createElement("details");
 	detail.className = "project-inventory-details";
+	detail.open = openProjectDetails.has(project.workspace_identity);
+	detail.addEventListener("toggle", () => {
+		if (detail.open) openProjectDetails.add(project.workspace_identity);
+		else openProjectDetails.delete(project.workspace_identity);
+	});
 	const summary = document.createElement("summary");
 	summary.textContent = "Identity and mapping details";
 	detail.appendChild(summary);

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3658,8 +3658,8 @@
       <div class="card" style="animation-delay: 0s">
         <div class="section-header">
           <div>
-            <h2>Projects</h2>
-            <div class="section-meta">Review known projects and worktrees, then verify which Sharing domain future memories use.</div>
+            <h2>Projects & Sharing domains</h2>
+            <div class="section-meta">Review project/worktree identities and choose the Sharing domain future memories use. Metadata correction stays in the Feed for now.</div>
           </div>
         </div>
         <div class="projects-toolbar">


### PR DESCRIPTION
## Description
Refine the Projects screen around its primary job: Sharing-domain assignment review. Duplicate display-name collisions are now informational inventory guardrails instead of permanent scary attention states, while non-local assignment still requires confirmation. The screen also preserves expanded rows during refresh, lowers card pagination to 25, and surfaces suggestion/actionable warning copy more clearly.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted Vitest)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run in stack:
- `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/projects.test.ts packages/ui/src/lib/state.test.ts`
- `pnpm run tsc`
- `pnpm run lint` (only pre-existing FeedItemCard info warnings)
- `pnpm --filter @codemem/ui build`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced