### PR TITLE
feat(ui): add Projects project correction

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -382,6 +382,7 @@ export type {
 	ProjectScopeInventoryStatus,
 	ProjectScopeMappingChangeGuardrailAnalysis,
 	ProjectScopeSettingsMapping,
+	ReassignProjectScopeInventoryProjectResult,
 	SharingDomainSettingsScope,
 	UpsertProjectScopeMappingInput,
 } from "./project-scope-settings.js";
@@ -392,6 +393,7 @@ export {
 	listProjectScopeInventory,
 	listProjectScopeSettingsMappings,
 	listSharingDomainSettingsScopes,
+	reassignProjectScopeInventoryProject,
 	upsertProjectScopeSettingsMapping,
 } from "./project-scope-settings.js";
 export type { FlushRawEventsOptions } from "./raw-event-flush.js";

--- a/packages/core/src/project-scope-settings.test.ts
+++ b/packages/core/src/project-scope-settings.test.ts
@@ -7,6 +7,7 @@ import {
 	listProjectScopeInventory,
 	listProjectScopeSettingsMappings,
 	listSharingDomainSettingsScopes,
+	reassignProjectScopeInventoryProject,
 	upsertProjectScopeSettingsMapping,
 } from "./project-scope-settings.js";
 import { LOCAL_DEFAULT_SCOPE_ID } from "./scope-resolution.js";
@@ -247,6 +248,40 @@ describe("project scope settings", () => {
 					code: "basename_collision_review",
 					requires_confirmation: true,
 					related_workspace_identities: ["https://git.example.invalid/oss/api.git"],
+				}),
+			]),
+		);
+	});
+
+	it("reassigns sessions for a stable workspace identity to the corrected project", () => {
+		const sessionId = insertSession(db, {
+			cwd: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
+			gitBranch: null,
+			gitRemote: null,
+			project: "injection",
+		});
+		insertMemory(db, sessionId);
+
+		const result = reassignProjectScopeInventoryProject(db, {
+			project: "codemem",
+			workspaceIdentity: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
+		});
+
+		expect(result).toMatchObject({
+			moved_memory_count: 1,
+			moved_session_count: 1,
+			previous_projects: ["injection"],
+			project: "codemem",
+		});
+		const row = db.prepare("SELECT project FROM sessions WHERE id = ?").get(sessionId) as {
+			project: string;
+		};
+		expect(row.project).toBe("codemem");
+		expect(listProjectScopeInventory(db, { query: "codemem" }).projects).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					project: "codemem",
+					workspace_identity: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
 				}),
 			]),
 		);

--- a/packages/core/src/project-scope-settings.ts
+++ b/packages/core/src/project-scope-settings.ts
@@ -131,6 +131,14 @@ export interface ProjectScopeMappingChangeGuardrailAnalysis {
 	warnings: ProjectScopeGuardrailWarning[];
 }
 
+export interface ReassignProjectScopeInventoryProjectResult {
+	workspace_identity: string;
+	project: string;
+	previous_projects: string[];
+	moved_session_count: number;
+	moved_memory_count: number;
+}
+
 interface ProjectScopeCandidateRow {
 	id: number;
 	started_at: string | null;
@@ -873,6 +881,72 @@ export function listProjectScopeInventory(
 		limit,
 		offset,
 		has_more: offset + limit < filtered.length,
+	};
+}
+
+export function reassignProjectScopeInventoryProject(
+	db: Database,
+	input: { workspaceIdentity: string; project: string },
+): ReassignProjectScopeInventoryProjectResult {
+	ensureScopeBackfillScopes(db);
+	const workspaceIdentity = normalizeWorkspaceIdentity(input.workspaceIdentity);
+	if (!workspaceIdentity) throw new Error("workspace_identity must be a non-empty string");
+	if (workspaceIdentity.startsWith("unmapped:")) {
+		throw new Error("unmapped projects cannot be reassigned until they have a stable identity");
+	}
+	const project = clean(input.project);
+	if (!project) throw new Error("project must be a non-empty string");
+	const rows = db
+		.prepare(
+			`SELECT
+				s.id,
+				s.started_at,
+				s.cwd,
+				s.project,
+				s.git_remote,
+				s.git_branch,
+				(
+					SELECT mi.workspace_id
+					FROM memory_items mi
+					WHERE mi.session_id = s.id
+					  AND mi.workspace_id IS NOT NULL
+					  AND TRIM(mi.workspace_id) <> ''
+					ORDER BY mi.id DESC
+					LIMIT 1
+				) AS workspace_id,
+				COUNT(mi_count.id) AS memory_count
+			 FROM sessions s
+			 LEFT JOIN memory_items mi_count ON mi_count.session_id = s.id
+			 WHERE COALESCE(TRIM(s.git_remote), TRIM(s.cwd), TRIM(s.project), '') <> ''
+			    OR mi_count.id IS NOT NULL
+			 GROUP BY s.id`,
+		)
+		.all() as ProjectScopeCandidateRow[];
+	const matched = rows.filter((row) => {
+		const identity = canonicalWorkspaceIdentity({
+			gitRemote: row.git_remote,
+			gitBranch: row.git_branch,
+			cwd: row.cwd,
+			project: row.project,
+			workspaceId: row.workspace_id,
+		});
+		return identity.value === workspaceIdentity;
+	});
+	if (matched.length === 0) throw new Error("project identity not found");
+	const previousProjects = [
+		...new Set(matched.map((row) => clean(row.project) ?? "").filter(Boolean)),
+	].sort();
+	const movedMemoryCount = matched.reduce((total, row) => total + Number(row.memory_count ?? 0), 0);
+	const update = db.prepare("UPDATE sessions SET project = ? WHERE id = ?");
+	db.transaction(() => {
+		for (const row of matched) update.run(project, row.id);
+	})();
+	return {
+		moved_memory_count: movedMemoryCount,
+		moved_session_count: matched.length,
+		previous_projects: previousProjects,
+		project,
+		workspace_identity: workspaceIdentity,
 	};
 }
 

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -58,6 +58,7 @@ export {
 	loadSyncActors,
 	loadSyncStatus,
 	mergeActor,
+	reassignProjectInventoryProject,
 	renameActor,
 	renamePeer,
 	SharingDomainGuardrailConfirmationError,

--- a/packages/ui/src/lib/api/sync.ts
+++ b/packages/ui/src/lib/api/sync.ts
@@ -237,6 +237,14 @@ export interface ProjectScopeInventoryResult {
 	has_more: boolean;
 }
 
+export interface ProjectReassignmentResult {
+	workspace_identity: string;
+	project: string;
+	previous_projects: string[];
+	moved_session_count: number;
+	moved_memory_count: number;
+}
+
 export interface SharingDomainSettings {
 	scopes: SharingDomainScope[];
 	mappings: ProjectScopeMapping[];
@@ -326,6 +334,23 @@ export async function deleteSharingDomainProjectMapping(id: number): Promise<boo
 	const { text, payload } = await readJsonPayload<{ deleted?: boolean }>(resp);
 	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
 	return Boolean(payload?.deleted);
+}
+
+export async function reassignProjectInventoryProject(input: {
+	workspace_identity: string;
+	project: string;
+}): Promise<ProjectReassignmentResult> {
+	const resp = await fetch("/api/sync/projects/reassign-project", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(input),
+	});
+	const { text, payload } = await readJsonPayload<ProjectReassignmentResult & { error?: string }>(
+		resp,
+	);
+	if (!resp.ok) throw new Error(payloadError(payload) || text || "request failed");
+	if (!payload?.workspace_identity) throw new Error("response missing project reassignment");
+	return payload;
 }
 
 export async function loadCoordinatorGroupPreferences(

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../lib/api", () => ({
 	deleteSharingDomainProjectMapping: vi.fn(),
+	loadProjects: vi.fn(),
 	loadProjectScopeInventory: vi.fn(),
 	loadSharingDomainSettings: vi.fn(),
+	reassignProjectInventoryProject: vi.fn(),
 	saveSharingDomainProjectMapping: vi.fn(),
 	SharingDomainGuardrailConfirmationError: class SharingDomainGuardrailConfirmationError extends Error {
 		requiredGuardrailTokens: string[];
@@ -21,10 +23,12 @@ vi.mock("../lib/api", () => ({
 }));
 
 vi.mock("../lib/notice", () => ({ showGlobalNotice: vi.fn() }));
+vi.mock("./sync/sync-dialogs", () => ({ openSyncInputDialog: vi.fn() }));
 
 import * as api from "../lib/api";
 import type { ProjectScopeInventoryProject } from "../lib/api/sync";
 import { initProjectsTab, loadProjectsData } from "./projects";
+import { openSyncInputDialog } from "./sync/sync-dialogs";
 
 function project(
 	overrides: Partial<ProjectScopeInventoryProject> = {},
@@ -94,6 +98,14 @@ describe("Projects tab", () => {
 					status: "active",
 				},
 			],
+		});
+		vi.mocked(api.loadProjects).mockResolvedValue(["api", "codemem"]);
+		vi.mocked(api.reassignProjectInventoryProject).mockResolvedValue({
+			moved_memory_count: 1,
+			moved_session_count: 1,
+			previous_projects: ["api"],
+			project: "codemem",
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
 		});
 	});
 
@@ -234,5 +246,64 @@ describe("Projects tab", () => {
 		expect(document.body.textContent).toContain(
 			"Needs attention: Another project is also named api.",
 		);
+	});
+
+	it("lets project rows reassign their stored project", async () => {
+		const refresh = vi.fn();
+		vi.mocked(openSyncInputDialog).mockResolvedValue("codemem");
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 25,
+			offset: 0,
+			projects: [project({ memory_count: 11, project: "injection", session_count: 1 })],
+			total: 1,
+		});
+
+		initProjectsTab(refresh);
+		await loadProjectsData();
+		const changeProject = Array.from(document.querySelectorAll("button")).find(
+			(button) => button.textContent === "Change project…",
+		) as HTMLButtonElement | undefined;
+		expect(changeProject).not.toBeUndefined();
+
+		changeProject?.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(openSyncInputDialog).toHaveBeenCalledWith(
+			expect.objectContaining({
+				description: expect.stringContaining("1 session and 11 memories"),
+				initialValue: "injection",
+				title: "Change project",
+			}),
+		);
+		expect(api.reassignProjectInventoryProject).toHaveBeenCalledWith({
+			project: "codemem",
+			workspace_identity: "https://git.example.invalid/exampleco/api.git",
+		});
+		expect(refresh).toHaveBeenCalled();
+	});
+
+	it("disables project reassignment for saved mappings with no sessions", async () => {
+		vi.mocked(api.loadProjectScopeInventory).mockResolvedValue({
+			has_more: false,
+			limit: 25,
+			offset: 0,
+			projects: [
+				project({
+					memory_count: 0,
+					resolution_reason: "exact_mapping",
+					session_count: 0,
+				}),
+			],
+			total: 1,
+		});
+
+		await loadProjectsData();
+
+		const changeProject = Array.from(document.querySelectorAll("button")).find(
+			(button) => button.textContent === "Change project…",
+		) as HTMLButtonElement | undefined;
+		expect(changeProject?.disabled).toBe(true);
+		expect(changeProject?.title).toContain("No sessions");
 	});
 });

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -5,6 +5,7 @@ import type {
 	SharingDomainScope,
 } from "../lib/api/sync";
 import { showGlobalNotice } from "../lib/notice";
+import { openSyncInputDialog } from "./sync/sync-dialogs";
 
 type RefreshFn = () => void;
 
@@ -127,6 +128,48 @@ async function removeProjectMapping(project: ProjectScopeInventoryProject) {
 	}
 }
 
+async function reassignProject(project: ProjectScopeInventoryProject) {
+	if (project.identity_source === "unmapped") return;
+	const currentProject = String(project.project || project.display_project || "").trim();
+	let suggestions: string[] = [];
+	try {
+		suggestions = (await api.loadProjects()).filter((name) => name && name !== currentProject);
+	} catch {
+		// Non-fatal — free-text correction still works.
+	}
+	const nextProject = await openSyncInputDialog({
+		cancelLabel: "Cancel",
+		confirmLabel: "Change project",
+		description: `This will update ${project.session_count} session${project.session_count === 1 ? "" : "s"} and ${project.memory_count ?? 0} memor${project.memory_count === 1 ? "y" : "ies"} by changing the stored project. Sharing-domain assignment stays unchanged.`,
+		initialValue: currentProject,
+		placeholder: "Project name",
+		suggestions,
+		title: "Change project",
+		validate: (value) => {
+			const trimmed = value.trim();
+			if (!trimmed) return "Enter a project name.";
+			if (trimmed === currentProject) return "Already assigned to this project.";
+			return null;
+		},
+	});
+	if (nextProject == null) return;
+	try {
+		const result = await api.reassignProjectInventoryProject({
+			project: nextProject.trim(),
+			workspace_identity: project.workspace_identity,
+		});
+		showGlobalNotice(
+			`Changed project to ${result.project} for ${result.moved_session_count} session${result.moved_session_count === 1 ? "" : "s"}.`,
+		);
+		refreshProjects?.();
+	} catch (error) {
+		showGlobalNotice(
+			error instanceof Error ? error.message : "Unable to change project.",
+			"warning",
+		);
+	}
+}
+
 function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElement {
 	const actions = document.createElement("div");
 	actions.className = "project-inventory-actions";
@@ -195,7 +238,17 @@ function renderProjectActions(project: ProjectScopeInventoryProject): HTMLElemen
 	remove.disabled = project.mapping_id == null || project.resolution_reason !== "exact_mapping";
 	remove.addEventListener("click", () => void removeProjectMapping(project));
 
-	actions.append(label, select, save, keepLocal, remove);
+	const changeProject = document.createElement("button");
+	changeProject.className = "settings-button";
+	changeProject.type = "button";
+	changeProject.textContent = "Change project…";
+	changeProject.disabled = project.session_count === 0;
+	if (changeProject.disabled) {
+		changeProject.title = "No sessions are available to reassign for this saved mapping.";
+	}
+	changeProject.addEventListener("click", () => void reassignProject(project));
+
+	actions.append(label, select, save, keepLocal, remove, changeProject);
 	const pending = pendingConfirmations.get(project.workspace_identity);
 	if (pending) {
 		const warningBox = document.createElement("div");

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -6087,6 +6087,50 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("reassigns a project inventory row to the corrected project", async () => {
+			const { app, getStore, cleanup } = createTestApp();
+			try {
+				await app.request("/api/stats");
+				const store = getStore();
+				if (!store) throw new Error("store not initialized");
+				const sessionId = insertTestSession(store.db);
+				store.db
+					.prepare(
+						"UPDATE sessions SET cwd = ?, git_remote = NULL, git_branch = NULL, project = ? WHERE id = ?",
+					)
+					.run("/Users/adam/workspace/codemem/.claude/worktrees/injection", "injection", sessionId);
+				insertTestMemory(store, {
+					sessionId,
+					kind: "discovery",
+					title: "project correction candidate",
+				});
+
+				const res = await app.request("/api/sync/projects/reassign-project", {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({
+						project: "codemem",
+						workspace_identity: "/Users/adam/workspace/codemem/.claude/worktrees/injection",
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				expect(await res.json()).toMatchObject({
+					moved_memory_count: 1,
+					moved_session_count: 1,
+					previous_projects: ["injection"],
+					project: "codemem",
+				});
+				const inventoryRes = await app.request("/api/sync/projects?q=codemem");
+				const inventory = (await inventoryRes.json()) as { projects: Array<{ project: string }> };
+				expect(inventory.projects).toEqual(
+					expect.arrayContaining([expect.objectContaining({ project: "codemem" })]),
+				);
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("requires confirmation before saving risky Sharing domain mappings", async () => {
 			const { app, getStore, cleanup } = createTestApp();
 			try {

--- a/packages/viewer-server/src/routes/sync.ts
+++ b/packages/viewer-server/src/routes/sync.ts
@@ -74,6 +74,7 @@ import {
 	parseSyncScopeRequest,
 	personalScopeGrantStatusForPeer,
 	readCoordinatorSyncConfig,
+	reassignProjectScopeInventoryProject,
 	recordNonce,
 	rejectInboundScopeFailures,
 	requestJson,
@@ -2389,6 +2390,24 @@ export function syncRoutes(
 				status: c.req.query("status"),
 			}),
 		);
+	});
+
+	app.post("/api/sync/projects/reassign-project", async (c) => {
+		const store = getStore();
+		const body = await parseViewerJsonBody(c);
+		if (!body) return c.json({ error: "invalid json" }, 400);
+		try {
+			const workspaceIdentity = optionalViewerStrictString(body, "workspace_identity") ?? "";
+			const project = optionalViewerStrictString(body, "project") ?? "";
+			const result = reassignProjectScopeInventoryProject(store.db, {
+				project,
+				workspaceIdentity,
+			});
+			return c.json({ ok: true, ...result });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return c.json({ error: message }, message.includes("not found") ? 404 : 400);
+		}
 	});
 
 	app.put("/api/sync/sharing-domains/project-mappings", async (c) => {


### PR DESCRIPTION
## Description
Add a Projects-row correction workflow for cases where the workspace identity is right but `sessions.project` is wrong. Users can change the stored project directly from the Projects row with session/memory counts in the prompt; Sharing-domain mappings remain separate and unchanged.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, targeted Vitest)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Targeted checks run in stack:
- `pnpm exec vitest run packages/core/src/project-scope-settings.test.ts packages/viewer-server/src/index.test.ts packages/ui/src/tabs/projects.test.ts packages/ui/src/lib/state.test.ts`
- `pnpm run tsc`
- `pnpm run lint` (only pre-existing FeedItemCard info warnings)
- `pnpm --filter @codemem/ui build`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced